### PR TITLE
dev: add flake-based Nix workflow

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+# shellcheck shell=bash
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 __pycache__/
 runs.csv
+/.direnv/

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Living on the edge (main branch):
 cargo install --locked --git https://github.com/tontinton/maki.git maki
 ```
 
+With Nix:
+
+```sh
+nix run github:tontinton/maki
+```
+
 Or download a pre-built binary from [GitHub Releases](https://github.com/tontinton/maki/releases/latest).
 
 More info at the [official docs](http://maki.sh/docs).

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,110 @@
+{
+  description = "Maki - AI coding agent";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      lib = nixpkgs.lib;
+      cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+      packageName = cargoToml.package.name;
+      version = cargoToml.workspace.package.version;
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forEachSystem = f: lib.genAttrs systems (system: f system (import nixpkgs { inherit system; }));
+    in
+    {
+      packages = forEachSystem (
+        system: pkgs:
+        let
+          maki = pkgs.rustPlatform.buildRustPackage {
+            pname = packageName;
+            inherit version;
+            src = ./.;
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+              # NOTE: these are cargo git dependencies; set hash to "" and
+              # rebuild to get the correct value.
+              outputHashes = {
+                "monty-0.0.9" = "sha256-lIuPWXuovY4TB5M7JUCDAIN97bo1X8B6MhL3UjFTnqA=";
+                "ruff_python_ast-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
+                "ruff_python_parser-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
+                "ruff_python_trivia-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
+                "ruff_source_file-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
+                "ruff_text_size-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
+              };
+            };
+            cargoBuildFlags = [
+              "--package"
+              packageName
+            ];
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+              perl
+              python3
+            ];
+            # TODO: Upstream monty includes a relative README path that doesn't
+            # survive nix vendoring. Remove this once `monty` stops including
+            # the relative path
+            postPatch = ''
+              for f in "$cargoDepsCopy"/monty-*/src/lib.rs; do
+                substituteInPlace "$f" \
+                  --replace-fail '#![doc = include_str!("../../../README.md")]' \
+                                 '#![doc = "Monty Python bridge."]'
+              done
+            '';
+            buildInputs =
+              with pkgs;
+              [ openssl ]
+              ++ lib.optionals stdenv.isDarwin [
+                darwin.apple_sdk.frameworks.AppKit
+                darwin.apple_sdk.frameworks.ApplicationServices
+              ];
+            doCheck = false;
+          };
+        in
+        {
+          default = maki;
+        }
+      );
+
+      devShells = forEachSystem (
+        _: pkgs:
+        let
+          certs = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              cargo
+              cargo-nextest
+              clippy
+              git
+              just
+              openssl
+              perl
+              pkg-config
+              python3
+              ripgrep
+              ruff
+              rustc
+              rustfmt
+              ty
+            ];
+
+            SSL_CERT_FILE = certs;
+            NIX_SSL_CERT_FILE = certs;
+          };
+        }
+      );
+
+      formatter = forEachSystem (_: pkgs: pkgs.nixfmt-rfc-style);
+    };
+}

--- a/site/docs/content/quick-start/_index.md
+++ b/site/docs/content/quick-start/_index.md
@@ -32,6 +32,12 @@ Living on the edge (main branch):
 cargo install --locked --git https://github.com/tontinton/maki.git maki
 ```
 
+With Nix:
+
+```sh
+nix run github:tontinton/maki
+```
+
 Or download a pre-built binary from [GitHub Releases](https://github.com/tontinton/maki/releases/latest).
 
 ## API Keys


### PR DESCRIPTION
## Summary

This PR adds a first-class Nix entrypoint for the repo without changing the existing development workflow. The project can continue to be used as-is with `just`, `cargo`, and the current commands. The flake simply standardizes and packages the environment around the development tools, ensuring a consistent and reproducible environment across different systems.

That brings a few practical benefits:

- `nix run .` provides a zero-install entrypoint to try the project immediately, without requiring a preinstalled Rust toolchain or managing dependencies on the host system.
- `nix develop` provides a ready-to-use dev shell with the project tooling already available.
- `direnv` can enter that shell automatically on `cd`, making the repository effectively zero-setup after the initial trust step.

## What changes

- add `flake.nix` and `flake.lock`
- expose a dev shell with the tools needed for the existing workflows
- expose `nix run` for the application
- wire `.envrc` to the flake so `direnv` works naturally
- document the Nix path in the README, contributor docs, and agent instructions