### PR TITLE
fix: is_codex_model for OpenAI subscription models

### DIFF
--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -21,8 +21,11 @@ static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     provider_name: "OpenAI",
 };
 
+// NOTE: OpenAI also offers these models for subscription usage via the Coding Plan
+const PLAN_MODELS: &[&str] = &["gpt-5.4", "gpt-5.4-mini", "gpt-5.2"];
+
 fn is_codex_model(model_id: &str) -> bool {
-    model_id.contains("codex")
+    model_id.contains("-codex") || PLAN_MODELS.contains(&model_id)
 }
 
 pub struct OpenAi {

--- a/maki-providers/src/providers/openai/responses.rs
+++ b/maki-providers/src/providers/openai/responses.rs
@@ -27,7 +27,7 @@ pub(crate) fn build_body(
         "instructions": system,
         "input": input,
         "stream": true,
-        "max_output_tokens": model.max_output_tokens,
+        "store": false,
     });
     if wire_tools.as_array().is_some_and(|a| !a.is_empty()) {
         body["tools"] = wire_tools;


### PR DESCRIPTION
Fixes: #9

OpenAI has these "non-Codex family" models available as "Codex models" for subscription plans.

See [my comment in #9](https://github.com/tontinton/maki/issues/9#issuecomment-4187107299) for more details.