### PR TITLE
ui: add file picker (Ctrl+S)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2325,6 +2325,7 @@ dependencies = [
  "flume 0.11.1",
  "futures-lite",
  "getrandom 0.3.4",
+ "ignore",
  "image",
  "isahc",
  "jiff",
@@ -2334,6 +2335,7 @@ dependencies = [
  "maki-providers",
  "maki-storage",
  "notify",
+ "nucleo",
  "nucleo-matcher",
  "ratatui",
  "serde",
@@ -2563,6 +2565,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "nucleo"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5262af4c94921c2646c5ac6ff7900c2af9cbb08dc26a797e18130a7019c039d4"
+dependencies = [
+ "nucleo-matcher",
+ "parking_lot",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ event-listener = "5"
 futures-lite = "2"
 isahc = { version = "1.7", default-features = false, features = ["text-decoding", "static-curl", "static-ssl"] }
 libc = "0.2"
+nucleo = "0.5"
 nucleo-matcher = "0.3"
 open = "5"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/maki-ui/Cargo.toml
+++ b/maki-ui/Cargo.toml
@@ -29,7 +29,9 @@ getrandom = { workspace = true }
 futures-lite = { workspace = true }
 image = { workspace = true }
 base64 = { workspace = true }
+nucleo = { workspace = true }
 nucleo-matcher = { workspace = true }
+ignore = { workspace = true }
 async-process = { workspace = true }
 libc = { workspace = true }
 dirs = { workspace = true }

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -24,6 +24,7 @@ use crate::chat::Chat;
 use crate::chat::{CANCELLED_TEXT, ChatEventResult, DONE_TEXT, ERROR_TEXT};
 use crate::components::btw_modal::BtwModal;
 use crate::components::command::{CommandAction, CommandPalette, ParsedCommand};
+use crate::components::file_picker::{FilePickerModal, FilePickerModalAction};
 use crate::components::help_modal::HelpModal;
 use crate::components::input::{InputAction, InputBox, Submission};
 use crate::components::keybindings::key;
@@ -110,6 +111,7 @@ pub struct App {
     pub(super) btw_modal: BtwModal,
     pub(super) memory_modal: MemoryModal,
     pub(super) search_modal: SearchModal,
+    pub(super) file_picker: FilePickerModal,
     pub(super) todo_panel: TodoPanel,
     pub(super) permission_prompt: PermissionPrompt,
     pub(super) question_form: QuestionForm,
@@ -175,6 +177,7 @@ impl App {
             btw_modal: BtwModal::new(ui_config.typewriter_ms_per_char),
             memory_modal: MemoryModal::new(),
             search_modal: SearchModal::new(),
+            file_picker: FilePickerModal::new(),
             todo_panel: TodoPanel::new(),
             permission_prompt: PermissionPrompt::new(),
             question_form: QuestionForm::new(),
@@ -310,6 +313,7 @@ impl App {
         try_picker!(self.rewind_picker);
         try_picker!(self.task_picker);
         try_picker!(self.model_picker);
+        try_picker!(self.file_picker);
         if let Some(zone) = self.zone_at(row, column) {
             self.scroll_zone(zone.zone, delta);
         }
@@ -503,6 +507,25 @@ impl App {
             return vec![];
         }
 
+        if self.file_picker.is_open() {
+            return match self.file_picker.handle_key(key) {
+                FilePickerModalAction::Consumed => vec![],
+                FilePickerModalAction::Select(path) => {
+                    self.file_picker.close();
+                    if let InputAction::PaletteSync(val) =
+                        self.input_box.handle_paste_with_spaces(&path)
+                    {
+                        self.command_palette.sync(&val);
+                    }
+                    vec![]
+                }
+                FilePickerModalAction::Close => {
+                    self.file_picker.close();
+                    vec![]
+                }
+            };
+        }
+
         if self.queue.focus().is_some() {
             match key.code {
                 KeyCode::Up => {
@@ -628,6 +651,8 @@ impl App {
                 let top = self.chats[self.active_chat].scroll_top();
                 let auto = self.chats[self.active_chat].auto_scroll();
                 self.search_modal.open(top, auto);
+            } else if key::FILE_PICKER.matches(key) {
+                self.file_picker.open(&self.state.session.cwd);
             } else if key.code == KeyCode::Char('v') && self.image_paste_rx.is_none() {
                 self.start_image_paste();
             } else if let InputAction::PaletteSync(val) = self.input_box.handle_key(key) {
@@ -1159,12 +1184,13 @@ impl App {
         vec![]
     }
 
-    fn overlays(&self) -> [&dyn Overlay; 13] {
+    fn overlays(&self) -> [&dyn Overlay; 14] {
         [
             &self.help_modal,
             &self.btw_modal,
             &self.memory_modal,
             &self.search_modal,
+            &self.file_picker,
             &self.task_picker,
             &self.session_picker,
             &self.rewind_picker,
@@ -1177,12 +1203,13 @@ impl App {
         ]
     }
 
-    fn overlays_mut(&mut self) -> [&mut dyn Overlay; 13] {
+    fn overlays_mut(&mut self) -> [&mut dyn Overlay; 14] {
         [
             &mut self.help_modal,
             &mut self.btw_modal,
             &mut self.memory_modal,
             &mut self.search_modal,
+            &mut self.file_picker,
             &mut self.task_picker,
             &mut self.session_picker,
             &mut self.rewind_picker,
@@ -1211,6 +1238,7 @@ impl App {
         self.image_paste_rx.is_some()
             || self.btw_modal.is_animating()
             || self.session_picker.is_loading()
+            || self.file_picker.is_loading()
             || self
                 .selection_state
                 .as_ref()
@@ -1274,6 +1302,7 @@ impl App {
             };
         }
         try_picker!(self.memory_modal);
+        try_picker!(self.file_picker);
         try_picker!(self.task_picker);
         try_picker!(self.session_picker);
         try_picker!(self.rewind_picker);

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -162,6 +162,15 @@ impl App {
             overlay_rect = self.task_picker.view(frame, full);
         }
 
+        if self.file_picker.is_open() {
+            self.file_picker.tick();
+            overlay_rect = self.file_picker.view(frame, full);
+        }
+
+        if let Some(flash) = self.file_picker.take_flash() {
+            self.status_bar.flash(flash);
+        }
+
         if self.session_picker.is_open() {
             self.session_picker.tick();
             overlay_rect = self.session_picker.view(frame, full);
@@ -319,6 +328,8 @@ impl App {
             contexts.push(KeybindContext::CommandPalette);
         } else if self.search_modal.is_open() {
             contexts.push(KeybindContext::Search);
+        } else if self.file_picker.is_open() {
+            contexts.push(KeybindContext::FilePicker);
         } else {
             if self.status == Status::Streaming {
                 contexts.push(KeybindContext::Streaming);

--- a/maki-ui/src/components/file_picker.rs
+++ b/maki-ui/src/components/file_picker.rs
@@ -1,0 +1,885 @@
+use std::mem;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Instant;
+
+use crate::animation::spinner_frame;
+use crate::components::Overlay;
+use crate::components::keybindings::key;
+use crate::components::modal::Modal;
+use crate::components::scrollbar::render_vertical_scrollbar;
+use crate::text_buffer::TextBuffer;
+use crate::theme;
+
+use tracing::warn;
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ignore::WalkBuilder;
+use ignore::overrides::OverrideBuilder;
+use nucleo::pattern::{CaseMatching, Normalization};
+use nucleo::{Config, Matcher, Nucleo, Utf32String};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Position, Rect};
+use ratatui::style::Modifier;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use unicode_width::UnicodeWidthChar;
+
+const TITLE: &str = " Files ";
+// Memory/perf cap: materializing matches builds a Vec of styled strings for
+// rendering. 640 keeps the allocation bounded while being far more than the
+// viewport can display, so scrolling stays smooth without unbounded growth.
+// Plus, as everybody knows, 640 "ought to be enough for anybody" ;)
+const MAX_MATERIALIZED: u32 = 640;
+const TITLE_WALKING: &str = " Files (scanning…) ";
+const WIDTH_PERCENT: u16 = 60;
+const MAX_HEIGHT_PERCENT: u16 = 80;
+const SEARCH_ROW: u16 = 1;
+const NO_MATCHES: &str = "  No matches";
+const LABEL_INDENT: &str = "  ";
+const EMPTY_DIR_MSG: &str = "Current directory is empty";
+const PENDING_DEBOUNCE_MS: u128 = 100;
+const WALKER_CRASHED_MSG: &str = "File scanner crashed";
+
+pub enum FilePickerModalAction {
+    Consumed,
+    Select(String),
+    Close,
+}
+
+struct FilePickerModalMatch {
+    path: String,
+    indices: Vec<u32>,
+}
+
+/// The active walker + matcher session. Created on open(), dropped on close().
+/// `visible` tracks the pending→open transition: false while waiting for the
+/// first file or the debounce timeout, true once the modal should be rendered.
+struct FileWalkerSession {
+    nucleo: Nucleo<()>,
+    matcher: Matcher,
+    matches: Vec<FilePickerModalMatch>,
+    total_matches: u32,
+    cancel: Arc<AtomicBool>,
+    done_rx: flume::Receiver<()>,
+    started_at: Instant,
+    walking: bool,
+    matching: bool,
+    visible: bool,
+}
+
+impl Drop for FileWalkerSession {
+    fn drop(&mut self) {
+        self.cancel.store(true, Ordering::Relaxed);
+    }
+}
+
+impl FileWalkerSession {
+    fn reparse_pattern(&mut self, query: &str) {
+        self.nucleo
+            .pattern
+            .reparse(0, query, CaseMatching::Smart, Normalization::Smart, false);
+    }
+
+    fn refresh_matches(&mut self) {
+        let snapshot = self.nucleo.snapshot();
+        self.total_matches = snapshot.matched_item_count();
+        let count = self.total_matches.min(MAX_MATERIALIZED);
+
+        self.matches.clear();
+
+        let pattern = snapshot.pattern();
+        let has_pattern = !pattern.column_pattern(0).atoms.is_empty();
+        let mut indices_buf = Vec::new();
+
+        for item in snapshot.matched_items(0..count) {
+            let col = &item.matcher_columns[0];
+            let path = col.to_string();
+
+            let indices = if has_pattern {
+                indices_buf.clear();
+                pattern.column_pattern(0).indices(
+                    col.slice(..),
+                    &mut self.matcher,
+                    &mut indices_buf,
+                );
+                mem::take(&mut indices_buf)
+            } else {
+                Vec::new()
+            };
+
+            self.matches.push(FilePickerModalMatch { path, indices });
+        }
+    }
+}
+
+pub struct FilePickerModal {
+    search: TextBuffer,
+    selected: usize,
+    scroll_offset: usize,
+    viewport_height: usize,
+    inner_area: Rect,
+
+    session: Option<FileWalkerSession>,
+    flash: Option<String>,
+}
+
+impl FilePickerModal {
+    pub fn new() -> Self {
+        Self {
+            search: TextBuffer::new(String::new()),
+            selected: 0,
+            scroll_offset: 0,
+            viewport_height: 0,
+            inner_area: Rect::default(),
+
+            session: None,
+            flash: None,
+        }
+    }
+
+    pub fn open(&mut self, cwd: &str) {
+        self.close();
+
+        // NOTE: tick() is called continuously while is_loading() is true
+        // (which tracks both walking and matching), so we don't need nucleo
+        // to wake the event loop.
+        let notify = Arc::new(|| {});
+        let nucleo = Nucleo::new(Config::DEFAULT.match_paths(), notify, None, 1);
+        let injector = nucleo.injector();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let cancel_clone = cancel.clone();
+
+        // oneshot: walker sends () on completion
+        let (done_tx, done_rx) = flume::bounded(1);
+
+        let root = PathBuf::from(cwd);
+        if let Err(e) = thread::Builder::new()
+            .name("file-walker".into())
+            .spawn(move || {
+                let overrides = OverrideBuilder::new(&root)
+                    .add("!.git")
+                    .unwrap()
+                    .build()
+                    .unwrap();
+                WalkBuilder::new(&root)
+                    .hidden(false) // include dotfiles
+                    .overrides(overrides)
+                    .build_parallel()
+                    .run(|| {
+                        let injector = injector.clone();
+                        let cancel = cancel.clone();
+                        let root = root.clone();
+                        Box::new(move |entry| {
+                            if cancel.load(Ordering::Relaxed) {
+                                return ignore::WalkState::Quit;
+                            }
+                            let Ok(entry) = entry else {
+                                return ignore::WalkState::Continue;
+                            };
+                            if !entry
+                                .file_type()
+                                .is_some_and(|ft| ft.is_file() || ft.is_symlink())
+                            {
+                                return ignore::WalkState::Continue;
+                            }
+                            let path = entry.path().strip_prefix(&root).unwrap_or(entry.path());
+                            let path_str = path.to_string_lossy();
+                            injector.push((), |_, cols| {
+                                cols[0] = Utf32String::from(path_str.as_ref());
+                            });
+                            ignore::WalkState::Continue
+                        })
+                    });
+                let _ = done_tx.send(());
+            })
+        {
+            warn!("{}: failed to spawn thread: {e}", WALKER_CRASHED_MSG);
+            self.flash = Some(WALKER_CRASHED_MSG.into());
+            return;
+        }
+
+        self.session = Some(FileWalkerSession {
+            nucleo,
+            matcher: Matcher::new(Config::DEFAULT.match_paths()),
+            matches: Vec::new(),
+            total_matches: 0,
+            cancel: cancel_clone,
+            done_rx,
+            started_at: Instant::now(),
+            walking: true,
+            matching: false,
+            visible: false,
+        });
+    }
+
+    pub fn close(&mut self) {
+        self.session = None; // Drop cancels the walker
+        self.search.clear();
+        self.selected = 0;
+        self.scroll_offset = 0;
+    }
+
+    /// Returns true while a session exists, including during the Pending state
+    /// when the modal is not yet visible. This lets us intercept keystrokes
+    /// before the modal is rendered. Use `is_visible()` when the rendered
+    /// on-screen distinction matters.
+    pub fn is_open(&self) -> bool {
+        self.session.is_some()
+    }
+
+    pub fn is_visible(&self) -> bool {
+        self.session.as_ref().is_some_and(|s| s.visible)
+    }
+
+    pub fn is_loading(&self) -> bool {
+        self.session
+            .as_ref()
+            .is_some_and(|s| s.walking || s.matching)
+    }
+
+    pub fn take_flash(&mut self) -> Option<String> {
+        self.flash.take()
+    }
+
+    pub fn contains(&self, pos: Position) -> bool {
+        self.is_visible() && self.inner_area.contains(pos)
+    }
+
+    pub fn scroll(&mut self, delta: i32) {
+        if delta > 0 {
+            self.move_up_by(delta as usize);
+        } else {
+            self.move_down_by(delta.unsigned_abs() as usize);
+        }
+    }
+
+    pub fn handle_paste(&mut self, text: &str) -> bool {
+        if self.session.is_none() {
+            return false;
+        }
+        self.search.insert_text(text);
+        self.reparse_pattern();
+        true
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> FilePickerModalAction {
+        let visible = self.is_visible();
+
+        match key.code {
+            KeyCode::Esc => FilePickerModalAction::Close,
+            KeyCode::Enter => {
+                if !visible {
+                    return FilePickerModalAction::Consumed;
+                }
+                if let Some(s) = &self.session
+                    && let Some(m) = s.matches.get(self.selected)
+                {
+                    return FilePickerModalAction::Select(m.path.clone());
+                }
+                FilePickerModalAction::Close
+            }
+            KeyCode::Up => {
+                self.move_up_by(1);
+                FilePickerModalAction::Consumed
+            }
+            KeyCode::Down => {
+                self.move_down_by(1);
+                FilePickerModalAction::Consumed
+            }
+            KeyCode::Backspace => {
+                self.search.remove_char();
+                self.reparse_pattern();
+                FilePickerModalAction::Consumed
+            }
+            KeyCode::Left => {
+                self.search.move_left();
+                FilePickerModalAction::Consumed
+            }
+            KeyCode::Right => {
+                self.search.move_right();
+                FilePickerModalAction::Consumed
+            }
+            KeyCode::Home => {
+                self.search.move_home();
+                FilePickerModalAction::Consumed
+            }
+            KeyCode::End => {
+                self.search.move_end();
+                FilePickerModalAction::Consumed
+            }
+            _ if key::DELETE_WORD.matches(key) => {
+                self.search.remove_word_before_cursor();
+                self.reparse_pattern();
+                FilePickerModalAction::Consumed
+            }
+            _ if key::SCROLL_HALF_UP.matches(key) => {
+                self.move_up_by((self.viewport_height / 2).max(1));
+                FilePickerModalAction::Consumed
+            }
+            _ if key::SCROLL_HALF_DOWN.matches(key) => {
+                self.move_down_by((self.viewport_height / 2).max(1));
+                FilePickerModalAction::Consumed
+            }
+            _ if key::SCROLL_LINE_UP.matches(key) => {
+                self.move_up_by(1);
+                FilePickerModalAction::Consumed
+            }
+            _ if key::SCROLL_LINE_DOWN.matches(key) => {
+                self.move_down_by(1);
+                FilePickerModalAction::Consumed
+            }
+            _ if super::is_ctrl(&key) => FilePickerModalAction::Consumed,
+            KeyCode::Char(c) => {
+                self.search.push_char(c);
+                self.reparse_pattern();
+                FilePickerModalAction::Consumed
+            }
+            _ => FilePickerModalAction::Consumed,
+        }
+    }
+
+    fn reparse_pattern(&mut self) {
+        let query = self.search.value();
+        if let Some(session) = &mut self.session {
+            session.reparse_pattern(&query);
+        }
+        self.selected = 0;
+        self.scroll_offset = 0;
+    }
+
+    fn matches(&self) -> &[FilePickerModalMatch] {
+        self.session.as_ref().map_or(&[], |s| s.matches.as_slice())
+    }
+
+    fn move_up_by(&mut self, n: usize) {
+        if self.matches().is_empty() {
+            return;
+        }
+        self.selected = self.selected.saturating_sub(n);
+        self.ensure_visible();
+    }
+
+    fn move_down_by(&mut self, n: usize) {
+        if self.matches().is_empty() {
+            return;
+        }
+        self.selected = (self.selected + n).min(self.matches().len() - 1);
+        self.ensure_visible();
+    }
+
+    fn ensure_visible(&mut self) {
+        // clamp scroll so content fills the viewport to prevent gap after resizing
+        let len = self.matches().len();
+        if len > self.viewport_height {
+            self.scroll_offset = self.scroll_offset.min(len - self.viewport_height);
+        } else {
+            self.scroll_offset = 0;
+        }
+
+        if self.selected < self.scroll_offset {
+            self.scroll_offset = self.selected;
+        } else if self.selected >= self.scroll_offset + self.viewport_height {
+            self.scroll_offset = self.selected + 1 - self.viewport_height;
+        }
+    }
+
+    fn clamp_selection(&mut self) {
+        let len = self.matches().len();
+        if len == 0 {
+            self.selected = 0;
+            self.scroll_offset = 0;
+        } else {
+            self.selected = self.selected.min(len - 1);
+            self.ensure_visible();
+        }
+    }
+
+    pub fn tick(&mut self) {
+        let Some(session) = &mut self.session else {
+            return;
+        };
+
+        // tick() is called from the render path so forcing nucleo to not block
+        let status = session.nucleo.tick(0);
+        session.matching = status.running;
+
+        // walking: check if walker finished (or panicked)
+        if session.walking {
+            match session.done_rx.try_recv() {
+                Ok(()) => {
+                    session.walking = false;
+                }
+                Err(flume::TryRecvError::Disconnected) => {
+                    warn!("{}: walker thread panicked", WALKER_CRASHED_MSG);
+                    self.flash = Some(WALKER_CRASHED_MSG.into());
+                    self.close();
+                    return;
+                }
+                Err(flume::TryRecvError::Empty) => {}
+            }
+        }
+
+        // NOTE: to avoid screen flicker with an empty modal we stay invisible
+        // until files arrive or the debounce expires, so the user never sees a
+        // blank picker flash on screen.
+        if !session.visible {
+            let has_files = session.nucleo.injector().injected_items() > 0;
+            let debounce_elapsed = session.started_at.elapsed().as_millis() >= PENDING_DEBOUNCE_MS;
+
+            if has_files || (session.walking && debounce_elapsed) {
+                session.visible = true;
+            } else if !session.walking {
+                self.flash = Some(EMPTY_DIR_MSG.into());
+                self.close();
+                return;
+            } else {
+                return;
+            }
+        }
+
+        if !status.changed {
+            return;
+        }
+
+        session.refresh_matches();
+        self.clamp_selection();
+    }
+
+    pub fn view(&mut self, frame: &mut Frame, area: Rect) -> Rect {
+        let session = match &self.session {
+            Some(s) if s.visible => s,
+            _ => return Rect::default(),
+        };
+
+        let match_count = session.matches.len() as u16; // bounded by MAX_MATERIALIZED
+        let walking = session.walking;
+        let started_at = session.started_at;
+        let title = if walking { TITLE_WALKING } else { TITLE };
+
+        let has_query_without_matches =
+            session.matches.is_empty() && !self.search.value().is_empty();
+        // cap so the modal never grows taller than the screen can show
+        // Modal::render will further cap at MAX_HEIGHT_PERCENT.
+        let max_visible = area.height.saturating_sub(SEARCH_ROW + 2); // 2 = border chrome
+        let content_rows = if has_query_without_matches {
+            1
+        } else {
+            match_count.min(max_visible)
+        };
+
+        let modal = Modal {
+            title,
+            width_percent: WIDTH_PERCENT,
+            max_height_percent: MAX_HEIGHT_PERCENT,
+        };
+        let (popup, inner) = modal.render(frame, area, content_rows + SEARCH_ROW);
+        self.inner_area = inner;
+
+        let viewport_h = inner.height.saturating_sub(SEARCH_ROW) as usize;
+        self.viewport_height = viewport_h;
+        self.ensure_visible();
+
+        let [list_area, search_area] =
+            Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(inner);
+
+        self.render_list(frame, list_area, viewport_h);
+        self.render_search(frame, search_area, walking, started_at);
+
+        if match_count > viewport_h as u16 {
+            render_vertical_scrollbar(frame, list_area, match_count, self.scroll_offset as u16);
+        }
+
+        popup
+    }
+
+    fn render_list(&self, frame: &mut Frame, area: Rect, viewport_height: usize) {
+        let t = theme::current();
+        let matches = self.matches();
+
+        if matches.is_empty() {
+            if !self.search.value().is_empty() {
+                let line = Line::from(Span::styled(NO_MATCHES, t.cmd_desc));
+                frame.render_widget(Paragraph::new(vec![line]), area);
+            }
+            return;
+        }
+
+        let more_results_available = self
+            .session
+            .as_ref()
+            .is_some_and(|s| s.total_matches > MAX_MATERIALIZED);
+
+        // when at the bottom of a truncated list, reserve the last row for the hint
+        let at_bottom = self.scroll_offset + viewport_height >= matches.len();
+        let hint_row = if more_results_available && at_bottom {
+            1
+        } else {
+            0
+        };
+        let visible_rows = viewport_height - hint_row;
+
+        let max_label_width = area.width.saturating_sub(LABEL_INDENT.len() as u16) as usize;
+        let mut lines: Vec<Line> = Vec::new();
+        let end = (self.scroll_offset + visible_rows).min(matches.len());
+
+        for (i, m) in matches[self.scroll_offset..end].iter().enumerate() {
+            let is_selected = self.scroll_offset + i == self.selected;
+            let line =
+                build_highlighted_line(&m.path, &m.indices, max_label_width, is_selected, &t);
+            lines.push(line);
+        }
+
+        if hint_row > 0 {
+            let total = self.session.as_ref().unwrap().total_matches;
+            let truncated_count = total - MAX_MATERIALIZED;
+            let hint = format!("{LABEL_INDENT}+{truncated_count} more files (not shown)");
+            lines.push(Line::from(Span::styled(hint, t.cmd_desc)));
+        }
+
+        frame.render_widget(Paragraph::new(lines), area);
+    }
+
+    fn render_search(&self, frame: &mut Frame, area: Rect, walking: bool, started_at: Instant) {
+        let t = theme::current();
+        let query = self.search.value();
+        let cursor_byte = TextBuffer::char_to_byte(&query, self.search.x());
+        let (before, rest) = query.split_at(cursor_byte);
+        let mut chars = rest.chars();
+        let cursor_char = chars.next().unwrap_or(' ');
+        let after = chars.as_str();
+
+        let mut spans = vec![Span::styled(super::CHEVRON, t.picker_search_prefix)];
+
+        if walking {
+            let ch = spinner_frame(started_at.elapsed().as_millis());
+            spans.push(Span::styled(format!("{ch} "), t.cmd_desc));
+        }
+
+        spans.extend([
+            Span::styled(before.to_owned(), t.picker_search_text),
+            Span::styled(cursor_char.to_string(), t.cursor),
+            Span::styled(after.to_owned(), t.picker_search_text),
+        ]);
+
+        frame.render_widget(Paragraph::new(vec![Line::from(spans)]), area);
+    }
+}
+
+impl Overlay for FilePickerModal {
+    fn is_open(&self) -> bool {
+        self.is_open()
+    }
+
+    fn close(&mut self) {
+        self.close();
+    }
+}
+
+fn build_highlighted_line<'a>(
+    text: &str,
+    indices: &[u32],
+    max_width: usize,
+    is_selected: bool,
+    t: &'a theme::Theme,
+) -> Line<'a> {
+    let base_style = if is_selected {
+        t.cmd_selected
+    } else {
+        t.cmd_name
+    };
+    let match_style = base_style
+        .fg(t.highlight_text.fg.unwrap_or_default())
+        .add_modifier(Modifier::BOLD);
+
+    let mut spans = vec![Span::styled(LABEL_INDENT, base_style)];
+    let mut current_highlighted = false;
+    let mut run = String::new();
+    let mut cell_width = 0usize;
+
+    for (char_pos, ch) in text.chars().enumerate() {
+        let cw = ch.width().unwrap_or(0);
+        if cell_width + cw > max_width {
+            break;
+        }
+        cell_width += cw;
+        let is_match = indices.binary_search(&(char_pos as u32)).is_ok();
+
+        if is_match != current_highlighted && !run.is_empty() {
+            let style = if current_highlighted {
+                match_style
+            } else {
+                base_style
+            };
+            spans.push(Span::styled(mem::take(&mut run), style));
+        }
+        current_highlighted = is_match;
+        run.push(ch);
+    }
+
+    if !run.is_empty() {
+        let style = if current_highlighted {
+            match_style
+        } else {
+            base_style
+        };
+        spans.push(Span::styled(run, style));
+    }
+
+    Line::from(spans)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyEventKind, KeyEventState, KeyModifiers};
+    use test_case::test_case;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    /// Sets up a picker in Pending state with a controllable nucleo + done
+    /// channel without spawning a real walker thread.
+    fn pending_picker() -> (FilePickerModal, flume::Sender<()>) {
+        let mut picker = FilePickerModal::new();
+        let notify = Arc::new(|| {});
+        let nucleo = Nucleo::new(Config::DEFAULT.match_paths(), notify, None, 1);
+        let (done_tx, done_rx) = flume::bounded(1);
+        picker.session = Some(FileWalkerSession {
+            nucleo,
+            matcher: Matcher::new(Config::DEFAULT.match_paths()),
+            matches: Vec::new(),
+            total_matches: 0,
+            cancel: Arc::new(AtomicBool::new(false)),
+            done_rx,
+            started_at: Instant::now(),
+            walking: true,
+            matching: false,
+            visible: false,
+        });
+        (picker, done_tx)
+    }
+
+    fn inject_file(picker: &FilePickerModal, path: &str) {
+        let session = picker.session.as_ref().unwrap();
+        let injector = session.nucleo.injector();
+        injector.push((), |_, cols| {
+            cols[0] = Utf32String::from(path);
+        });
+    }
+
+    #[test]
+    fn pending_transitions_to_visible_when_files_arrive() {
+        let (mut picker, _done_tx) = pending_picker();
+        inject_file(&picker, "src/main.rs");
+
+        picker.tick();
+        assert!(picker.session.as_ref().unwrap().visible);
+    }
+
+    #[test]
+    fn pending_closes_on_empty_walk() {
+        let (mut picker, done_tx) = pending_picker();
+        let _ = done_tx.send(()); // walker finishes normally with no files
+
+        picker.tick(); // walking = false
+        picker.tick(); // pending sees !walking + 0 files → close
+
+        assert!(picker.session.is_none());
+        assert_eq!(picker.flash.as_deref(), Some(EMPTY_DIR_MSG));
+    }
+
+    #[test]
+    fn pending_transitions_to_visible_after_debounce() {
+        let (mut picker, _done_tx) = pending_picker();
+        picker.session.as_mut().unwrap().started_at =
+            Instant::now() - std::time::Duration::from_millis(200);
+
+        picker.tick();
+        assert!(picker.session.as_ref().unwrap().visible);
+    }
+
+    #[test]
+    fn pending_stays_pending_before_debounce() {
+        let (mut picker, _done_tx) = pending_picker();
+
+        picker.tick();
+        assert!(!picker.session.as_ref().unwrap().visible);
+    }
+
+    #[test]
+    fn walker_crash_flashes_and_closes() {
+        let (mut picker, done_tx) = pending_picker();
+        drop(done_tx); // simulate thread panic (Disconnected)
+
+        picker.tick();
+        assert!(picker.session.is_none());
+        assert_eq!(picker.flash.as_deref(), Some(WALKER_CRASHED_MSG));
+    }
+
+    #[test]
+    fn close_resets_all_state() {
+        let (mut picker, _done_tx) = pending_picker();
+        inject_file(&picker, "a.rs");
+        picker.tick();
+        assert!(picker.session.as_ref().unwrap().visible);
+
+        picker.close();
+        assert!(picker.session.is_none());
+        assert_eq!(picker.selected, 0);
+        assert_eq!(picker.scroll_offset, 0);
+    }
+
+    #[test]
+    fn open_while_already_open_resets() {
+        let (mut picker, _done_tx) = pending_picker();
+        inject_file(&picker, "a.rs");
+        picker.tick();
+        assert!(picker.session.as_ref().unwrap().visible);
+
+        picker.open("/tmp");
+        assert!(!picker.session.as_ref().unwrap().visible);
+        assert!(picker.session.as_ref().unwrap().matches.is_empty());
+    }
+
+    #[test]
+    fn esc_returns_close() {
+        let (mut picker, _done_tx) = pending_picker();
+        assert!(matches!(
+            picker.handle_key(key(KeyCode::Esc)),
+            FilePickerModalAction::Close
+        ));
+    }
+
+    #[test]
+    fn typing_during_pending_buffers_query() {
+        let (mut picker, _done_tx) = pending_picker();
+        picker.handle_key(key(KeyCode::Char('m')));
+        picker.handle_key(key(KeyCode::Char('a')));
+        assert_eq!(picker.search.value(), "ma");
+    }
+
+    #[test]
+    fn enter_during_pending_is_consumed() {
+        let (mut picker, _done_tx) = pending_picker();
+        assert!(matches!(
+            picker.handle_key(key(KeyCode::Enter)),
+            FilePickerModalAction::Consumed
+        ));
+    }
+
+    #[test]
+    fn clamp_selection_after_match_list_shrinks() {
+        let (mut picker, _done_tx) = pending_picker();
+        inject_file(&picker, "a.rs");
+        inject_file(&picker, "b.rs");
+        inject_file(&picker, "c.rs");
+        picker.tick();
+        picker.tick();
+
+        picker.selected = 2;
+        picker.session.as_mut().unwrap().matches.truncate(1);
+        picker.clamp_selection();
+        assert_eq!(picker.selected, 0);
+    }
+
+    #[test]
+    fn matches_capped_at_max_materialized() {
+        let (mut picker, _done_tx) = pending_picker();
+        let count = MAX_MATERIALIZED + 50;
+        for i in 0..count {
+            inject_file(&picker, &format!("file_{i:05}.rs"));
+        }
+        // tick until nucleo has processed all items
+        for _ in 0..20 {
+            picker.tick();
+        }
+
+        let session = picker.session.as_ref().unwrap();
+        assert_eq!(session.total_matches, count);
+        assert_eq!(session.matches.len(), MAX_MATERIALIZED as usize);
+    }
+
+    /// Returns a visible picker with `n` synthetic matches (no nucleo timing).
+    fn picker_with_matches(n: usize) -> FilePickerModal {
+        let (mut picker, _done_tx) = pending_picker();
+        let session = picker.session.as_mut().unwrap();
+        session.visible = true;
+        session.matches = (0..n)
+            .map(|i| FilePickerModalMatch {
+                path: format!("file_{i:03}.rs"),
+                indices: Vec::new(),
+            })
+            .collect();
+        session.total_matches = n as u32;
+        picker
+    }
+
+    #[test]
+    fn resize_taller_clamps_scroll_offset() {
+        let mut picker = picker_with_matches(20);
+
+        // simulate: small viewport, scrolled to the bottom
+        picker.viewport_height = 5;
+        picker.selected = 19;
+        picker.scroll_offset = 15; // shows entries 15..20
+        picker.ensure_visible();
+        assert_eq!(picker.scroll_offset, 15);
+
+        // simulate: terminal resize makes viewport much taller
+        picker.viewport_height = 20;
+        picker.ensure_visible();
+        // scroll_offset must drop to 0 so 20 entries fill 20 rows (no gap)
+        assert_eq!(picker.scroll_offset, 0);
+    }
+
+    #[test]
+    fn resize_taller_keeps_selected_visible() {
+        let mut picker = picker_with_matches(30);
+
+        // small viewport, selected near the end, scrolled to show it
+        picker.viewport_height = 5;
+        picker.selected = 28;
+        picker.scroll_offset = 25;
+        picker.ensure_visible();
+        assert_eq!(picker.scroll_offset, 25);
+
+        // grow viewport to 15 rows — clamp reduces scroll but selected stays visible
+        picker.viewport_height = 15;
+        picker.ensure_visible();
+        assert_eq!(picker.scroll_offset, 15); // 30 - 15
+        assert!(picker.selected >= picker.scroll_offset);
+        assert!(picker.selected < picker.scroll_offset + picker.viewport_height);
+    }
+
+    #[test]
+    fn resize_viewport_larger_than_matches_resets_scroll() {
+        let mut picker = picker_with_matches(5);
+
+        picker.viewport_height = 3;
+        picker.selected = 4;
+        picker.scroll_offset = 2;
+        picker.ensure_visible();
+        assert_eq!(picker.scroll_offset, 2);
+
+        // viewport grows larger than the total number of matches
+        picker.viewport_height = 10;
+        picker.ensure_visible();
+        assert_eq!(picker.scroll_offset, 0);
+    }
+
+    #[test_case(&[], 3 ; "empty_indices")]
+    #[test_case(&[0, 2], 5 ; "sparse_match")]
+    fn build_highlighted_line_does_not_panic(indices: &[u32], max_width: usize) {
+        let t = theme::current();
+        let _ = build_highlighted_line("hello", indices, max_width, false, &t);
+    }
+}

--- a/maki-ui/src/components/input.rs
+++ b/maki-ui/src/components/input.rs
@@ -120,6 +120,46 @@ impl InputBox {
         InputAction::PaletteSync(self.buffer.value())
     }
 
+    /// Like `handle_paste`, but adds a space before/after the pasted text when
+    /// the character(s) adjacent to the cursor (|) aren't already a space to
+    /// prevent the inserted text merging into surrounding words.
+    ///
+    /// Examples:
+    /// - `read|foo`  + `src/main.rs` -> `read src/main.rs foo`
+    /// - `read |foo` + `src/main.rs` -> `read src/main.rs foo`
+    /// - `read| foo` + `src/main.rs` -> `read src/main.rs foo`
+    pub fn handle_paste_with_spaces(&mut self, text: &str) -> InputAction {
+        let line = &self.buffer.lines()[self.buffer.y()];
+        let bx = TextBuffer::char_to_byte(line, self.buffer.x());
+
+        let char_before = line[..bx].chars().next_back();
+        let char_after = line[bx..].chars().next();
+
+        let is_word_boundary =
+            |c: char| -> bool { c.is_alphanumeric() || c == '_' || ")]}>".contains(c) };
+
+        let needs_leading = char_before.is_some_and(&is_word_boundary) && !text.starts_with(' ');
+        let needs_trailing = char_after.is_some_and(&is_word_boundary) && !text.ends_with(' ');
+
+        if !needs_leading && !needs_trailing {
+            return self.handle_paste(text);
+        }
+
+        let mut spaced = String::with_capacity(
+            text.len() + usize::from(needs_leading) + usize::from(needs_trailing),
+        );
+
+        if needs_leading {
+            spaced.push(' ');
+        }
+        spaced.push_str(text);
+        if needs_trailing {
+            spaced.push(' ');
+        }
+
+        self.handle_paste(&spaced)
+    }
+
     pub fn new(history: InputHistory) -> Self {
         Self {
             buffer: TextBuffer::new(String::new()),
@@ -929,5 +969,54 @@ mod tests {
         let base_height = input.height(TEST_WIDTH);
         input.attach_image(test_image());
         assert_eq!(input.height(TEST_WIDTH), base_height + 1);
+    }
+
+    #[test_case("read", "src/main.rs", " src/main.rs" ; "leading_after_ascii")]
+    #[test_case("打开", "src/main.rs", " src/main.rs" ; "leading_after_unicode")]
+    #[test_case("", "src/main.rs", "src/main.rs" ; "no_leading_at_start")]
+    #[test_case("read ", "src/main.rs", "src/main.rs" ; "no_leading_after_space")]
+    #[test_case("--file=", "src/main.rs", "src/main.rs" ; "no_leading_after_equals")]
+    #[test_case("/", "src/main.rs", "src/main.rs" ; "no_leading_after_slash")]
+    #[test_case("\"", "src/main.rs", "src/main.rs" ; "no_leading_after_quote")]
+    #[test_case("'", "src/main.rs", "src/main.rs" ; "no_leading_after_squote")]
+    #[test_case("foo_", "src/main.rs", " src/main.rs" ; "leading_after_underscore")]
+    #[test_case("$(cmd)", "src/main.rs", " src/main.rs" ; "leading_after_closing_paren")]
+    #[test_case("arr[0]", "src/main.rs", " src/main.rs" ; "leading_after_closing_bracket")]
+    fn paste_with_spaces_leading(before: &str, paste: &str, expected_suffix: &str) {
+        let mut input = InputBox::new(InputHistory::default());
+        type_text(&mut input, before);
+        input.handle_paste_with_spaces(paste);
+        assert_eq!(input.buffer.value(), format!("{before}{expected_suffix}"));
+    }
+
+    #[test_case("file", 0, "/tmp/foo", "/tmp/foo file" ; "trailing_before_ascii")]
+    #[test_case("を読む", 0, "/tmp/foo", "/tmp/foo を読む" ; "trailing_before_unicode")]
+    #[test_case("foobar", 3, "src/main.rs", "foo src/main.rs bar" ; "both_sides_mid_word")]
+    #[test_case("in  between", 3, "file.rs", "in file.rs between" ; "neither_side_between_spaces")]
+    #[test_case("read ''", 6, "src/main.rs", "read 'src/main.rs'" ; "neither_side_between_quotes")]
+    fn paste_with_spaces_at_cursor(before: &str, cursor_at: usize, paste: &str, expected: &str) {
+        let mut input = InputBox::new(InputHistory::default());
+        type_text(&mut input, before);
+        let back = before.chars().count() - cursor_at;
+        for _ in 0..back {
+            input.buffer.move_left();
+        }
+        input.handle_paste_with_spaces(paste);
+        assert_eq!(input.buffer.value(), expected);
+    }
+
+    #[test]
+    fn paste_with_spaces_empty_line() {
+        let mut input = InputBox::new(InputHistory::default());
+        input.handle_paste_with_spaces("file.rs");
+        assert_eq!(input.buffer.value(), "file.rs");
+    }
+
+    #[test]
+    fn paste_with_spaces_text_has_leading_space() {
+        let mut input = InputBox::new(InputHistory::default());
+        type_text(&mut input, "read");
+        input.handle_paste_with_spaces(" file.rs");
+        assert_eq!(input.buffer.value(), "read file.rs");
     }
 }

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -143,6 +143,7 @@ pub mod key {
     pub const POP_QUEUE: Bind = ctrl_bind!('q');
     pub const DELETE_WORD: Bind = ctrl_bind!('w');
     pub const SEARCH: Bind = ctrl_bind!('f');
+    pub const FILE_PICKER: Bind = ctrl_bind!('s');
     pub const OPEN_EDITOR: Bind = ctrl_bind!('o');
     pub const TODO_PANEL: Bind = ctrl_bind!('t');
     pub const TASKS: Bind = ctrl_bind!('x');
@@ -166,6 +167,7 @@ pub enum KeybindContext {
     QueueFocus,
     CommandPalette,
     Search,
+    FilePicker,
 }
 
 impl KeybindContext {
@@ -184,6 +186,7 @@ impl KeybindContext {
             Self::QueueFocus => "Queue",
             Self::CommandPalette => "Commands",
             Self::Search => "Search",
+            Self::FilePicker => "File Picker",
         }
     }
 
@@ -196,7 +199,8 @@ impl KeybindContext {
             | Self::ModelPicker
             | Self::QueueFocus
             | Self::CommandPalette
-            | Self::Search => Some(Self::Picker),
+            | Self::Search
+            | Self::FilePicker => Some(Self::Picker),
             _ => None,
         }
     }
@@ -316,6 +320,12 @@ pub const KEYBINDS: &[Keybind] = &[
     Keybind {
         label: KeyLabel::Single(key::SEARCH.label),
         description: "Search messages",
+        context: KeybindContext::General,
+        platform: Platform::All,
+    },
+    Keybind {
+        label: KeyLabel::Single(key::FILE_PICKER.label),
+        description: "File picker",
         context: KeybindContext::General,
         platform: Platform::All,
     },

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod btw_modal;
 pub(crate) mod code_view;
 pub mod command;
+pub(crate) mod file_picker;
 pub(crate) mod form;
 pub(crate) mod help_modal;
 pub(crate) mod index_highlight;

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -17,6 +17,7 @@ On macOS, `Ctrl` maps to `Cmd` where it makes sense (run `/help` for exact keybi
 | `Ctrl+H` | Show keybindings |
 | `Ctrl+N` / `Ctrl+P` | Next / previous task chat |
 | `Ctrl+F` | Search messages |
+| `Ctrl+S` | File picker |
 | `Ctrl+O` | Open plan in editor |
 | `Ctrl+T` | Toggle todo panel |
 | `Ctrl+X` | Open tasks |
@@ -85,4 +86,4 @@ Some pickers add extra bindings on top of the defaults:
 
 Child contexts inherit their parent's bindings and add their own.
 
-- **Pickers** is the base for: Task Picker, Session Picker, Rewind Picker, Theme Picker, Model Picker, Queue, Commands, Search
+- **Pickers** is the base for: Task Picker, Session Picker, Rewind Picker, Theme Picker, Model Picker, Queue, Commands, Search, File Picker


### PR DESCRIPTION
Pressing Ctrl+S opens a fuzzy file picker that lists repo files via git ls-files in a background thread. Selecting a file inserts the path at the cursor with smart spacing so it won't merge into adjacent words. Built on top of ListPicker, same pattern as SessionPicker.