### PR TITLE
fix: don't print session IDs for empty sessions

### DIFF
--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -12,6 +12,21 @@ use super::{App, Mode, PendingInput, PlanState};
 use crate::agent::QueuedMessage;
 
 impl App {
+    pub(crate) fn has_messages(&self) -> bool {
+        !self.state.session.messages.is_empty()
+    }
+
+    pub(crate) fn has_ephemeral(&self) -> bool {
+        self.state.session.meta.input_draft.is_some()
+            || self.state.session.meta.todo_dismissed
+            || !self.state.session.meta.queued_messages.is_empty()
+            || self.state.session.meta.mode != Some(maki_storage::sessions::StoredMode::Build)
+    }
+
+    pub(crate) fn has_content(&self) -> bool {
+        self.has_messages() || self.has_ephemeral()
+    }
+
     pub(crate) fn save_session(&mut self) {
         self.state.sync_session(
             &self.shared_history,
@@ -19,12 +34,7 @@ impl App {
             &self.permissions,
         );
         self.sync_ephemeral_state();
-        let has_messages = !self.state.session.messages.is_empty();
-        let has_ephemeral = self.state.session.meta.input_draft.is_some()
-            || self.state.session.meta.todo_dismissed
-            || !self.state.session.meta.queued_messages.is_empty()
-            || self.state.session.meta.mode != Some(maki_storage::sessions::StoredMode::Build);
-        if !has_messages && !has_ephemeral {
+        if !self.has_content() {
             return;
         }
         self.enqueue_save();

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -2052,3 +2052,21 @@ fn ctrl_c_denies_permission_prompt() {
     assert!(!app.permission_prompt.is_open());
     assert!(actions.is_empty());
 }
+
+#[test_case(false, false => false ; "neither")]
+#[test_case(true,  false => true  ; "messages only")]
+#[test_case(false, true  => true  ; "ephemeral only")]
+#[test_case(true,  true  => true  ; "both")]
+fn has_content(messages: bool, ephemeral: bool) -> bool {
+    let mut app = test_app();
+    if messages {
+        app.state
+            .session
+            .messages
+            .push(maki_providers::Message::user("hello".into()));
+    }
+    if ephemeral {
+        app.state.session.meta.todo_dismissed = true;
+    }
+    app.has_content()
+}

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -221,7 +221,7 @@ impl<'t> EventLoop<'t> {
         })
     }
 
-    pub(crate) fn run(mut self) -> Result<String> {
+    pub(crate) fn run(mut self) -> Result<Option<String>> {
         loop {
             self.tick();
             self.terminal.draw(|f| self.app.view(f))?;
@@ -447,8 +447,11 @@ impl<'t> EventLoop<'t> {
         }
     }
 
-    fn shutdown(mut self) -> String {
-        let session_id = self.app.state.session.id.clone();
+    fn shutdown(mut self) -> Option<String> {
+        let session_id = self
+            .app
+            .has_content()
+            .then(|| self.app.state.session.id.clone());
         maki_agent::mcp::kill_process_groups(
             &self
                 .handles

--- a/maki-ui/src/lib.rs
+++ b/maki-ui/src/lib.rs
@@ -36,7 +36,7 @@ pub type AppSession = maki_storage::sessions::Session<Message, TokenUsage, ToolO
 pub(crate) use agent::AgentCommand;
 pub use event_loop::EventLoopParams;
 
-pub fn run(params: EventLoopParams) -> Result<String> {
+pub fn run(params: EventLoopParams) -> Result<Option<String>> {
     let (_guard, mut terminal) = terminal::TerminalGuard::init()?;
     let el = event_loop::EventLoop::new(&mut terminal, params)?;
     el.run()

--- a/src/main.rs
+++ b/src/main.rs
@@ -350,7 +350,9 @@ fn run() -> Result<()> {
                     demo: cli.demo,
                 })
                 .context("run UI")?;
-                eprintln!("session: {session_id}");
+                if let Some(session_id) = session_id {
+                    eprintln!("session: {session_id}");
+                }
             }
         }
     }


### PR DESCRIPTION
Maki always printed a session ID on exit, even when the session was empty and no session file is saved to the ~/.maki/sessions directory. Now shutdown() checks has_content() before returning the id.