### PR TITLE
agent: exclude .git from glob, grep and find-symbol walkers

### DIFF
--- a/maki-agent/src/tools/glob.rs
+++ b/maki-agent/src/tools/glob.rs
@@ -1,10 +1,8 @@
 use crate::ToolOutput;
-use ignore::WalkBuilder;
-use ignore::overrides::OverrideBuilder;
 use maki_tool_macro::Tool;
 use tracing::debug;
 
-use super::{mtime, relative_path, resolve_search_path};
+use super::{mtime, relative_path, resolve_search_path, walk_builder};
 
 #[derive(Tool, Debug, Clone)]
 pub struct Glob {
@@ -33,17 +31,7 @@ impl Glob {
                 "glob executing"
             );
 
-            let mut overrides = OverrideBuilder::new(&search_path);
-            overrides
-                .add(&pattern)
-                .map_err(|e| format!("invalid glob pattern: {e}"))?;
-            let overrides = overrides
-                .build()
-                .map_err(|e| format!("glob build error: {e}"))?;
-
-            let mut entries: Vec<_> = WalkBuilder::new(&search_path)
-                .hidden(false)
-                .overrides(overrides)
+            let mut entries: Vec<_> = walk_builder(&search_path, &[&pattern])?
                 .build()
                 .flatten()
                 .filter(|e| e.file_type().is_some_and(|ft| ft.is_file()))

--- a/maki-agent/src/tools/grep.rs
+++ b/maki-agent/src/tools/grep.rs
@@ -1,18 +1,17 @@
 use std::io;
 use std::path::Path;
 
+use crate::{GrepFileEntry, GrepLine, GrepMatchGroup, ToolOutput};
 use grep_regex::RegexMatcher;
 use grep_searcher::Searcher;
 use grep_searcher::SearcherBuilder;
 use grep_searcher::{Sink, SinkContext, SinkFinish, SinkMatch};
-use ignore::WalkBuilder;
-use ignore::overrides::OverrideBuilder;
-
-use crate::{GrepFileEntry, GrepLine, GrepMatchGroup, ToolOutput};
 use maki_tool_macro::Tool;
 use tracing::debug;
 
-use super::{NO_FILES_FOUND, mtime, relative_path, resolve_search_path, truncate_bytes};
+use super::{
+    NO_FILES_FOUND, mtime, relative_path, resolve_search_path, truncate_bytes, walk_builder,
+};
 
 pub(super) const INVALID_REGEX: &str = "invalid regex pattern";
 const MAX_PER_CALL_LIMIT: usize = 1000;
@@ -79,20 +78,8 @@ impl Grep {
                     .map_err(|e| format!("{INVALID_REGEX}: {e}"))?
             };
 
-            let mut walker = WalkBuilder::new(&search_path);
-            walker.hidden(false);
-
-            if let Some(glob) = &include {
-                let mut overrides = OverrideBuilder::new(&search_path);
-                overrides
-                    .add(glob)
-                    .map_err(|e| format!("invalid glob pattern: {e}"))?;
-                walker.overrides(
-                    overrides
-                        .build()
-                        .map_err(|e| format!("invalid glob pattern: {e}"))?,
-                );
-            }
+            let patterns: Vec<&str> = include.as_deref().into_iter().collect();
+            let walker = walk_builder(&search_path, &patterns)?;
 
             let mut builder = SearcherBuilder::new();
             builder

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -35,6 +35,7 @@ use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant, SystemTime};
 
 use humantime::format_duration;
+use ignore::WalkBuilder;
 use serde_json::{Value, json};
 use std::future::Future;
 use tracing::{error, info, warn};
@@ -308,6 +309,33 @@ fn format_rel(prefix: &str, fallback: &str, rel: &Path) -> String {
     } else {
         format!("{prefix}{s}")
     }
+}
+
+/// Returns a `WalkBuilder` with `.hidden(false)` and `!.git` exclusion enforced.
+///
+/// Every tool that walks the file tree should use this instead of constructing
+/// a `WalkBuilder` directly. Extra override patterns (user globs, file-type
+/// filters) can be passed in.
+pub(crate) fn walk_builder(root: &str, patterns: &[&str]) -> Result<WalkBuilder, String> {
+    let mut ob = ignore::overrides::OverrideBuilder::new(root);
+    ob.add("!.git").expect("!.git is a valid glob");
+
+    for p in patterns {
+        ob.add(p)
+            .map_err(|e| format!("invalid glob pattern: {e}"))?;
+    }
+
+    let overrides = ob
+        .build()
+        .map_err(|e| format!("invalid glob pattern: {e}"))?;
+
+    // NOTE: .hidden(false) makes all dotfiles visible, including the .git/ dir.
+    // The .gitignore file never lists .git/ (git handles that implicitly), so
+    // git_ignore(true) does not help. The override is the same mechanism
+    // ripgrep uses for -g '!.git/'
+    let mut wb = WalkBuilder::new(root);
+    wb.hidden(false).overrides(overrides);
+    Ok(wb)
 }
 
 pub(crate) fn mtime(path: &Path) -> SystemTime {
@@ -1213,6 +1241,90 @@ mod tests {
     #[test_case(Value::String("".into()),                         "integer", None               ; "empty_string")]
     fn coerce_value_cases(val: Value, json_type: &str, expected: Option<Value>) {
         assert_eq!(coerce_value(&val, "test_field", json_type), expected);
+    }
+
+    #[test]
+    fn walk_builder_excludes_dot_git_but_shows_dotfiles() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        // create a fake .git dir with an object inside
+        fs::create_dir_all(root.join(".git/objects")).unwrap();
+        fs::write(root.join(".git/config"), "repositoryformatversion = 0").unwrap();
+        fs::write(root.join(".git/objects/abc123"), "blob").unwrap();
+
+        // create a regular dotfile and a normal file
+        fs::write(root.join(".env"), "SECRET=42").unwrap();
+        fs::write(root.join("main.rs"), "fn main() {}").unwrap();
+
+        let root_str = root.to_string_lossy();
+        let paths: Vec<String> = walk_builder(&root_str, &[])
+            .unwrap()
+            .build()
+            .flatten()
+            .filter(|e| e.file_type().is_some_and(|ft| ft.is_file()))
+            .map(|e| {
+                e.path()
+                    .strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+
+        assert!(
+            paths.contains(&"main.rs".to_string()),
+            "normal files should appear"
+        );
+        assert!(
+            paths.contains(&".env".to_string()),
+            "dotfiles should appear"
+        );
+        assert!(
+            !paths.iter().any(|p| p.starts_with(".git")),
+            ".git/ contents should be excluded, got: {paths:?}"
+        );
+    }
+
+    #[test]
+    fn walk_builder_excludes_dot_git_with_extra_patterns() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join(".git/config"), "stuff").unwrap();
+        fs::write(root.join("lib.rs"), "pub fn foo() {}").unwrap();
+        fs::write(root.join("main.py"), "print('hi')").unwrap();
+        fs::write(root.join(".hidden.rs"), "// hidden").unwrap();
+
+        let root_str = root.to_string_lossy();
+        let paths: Vec<String> = walk_builder(&root_str, &["*.rs"])
+            .unwrap()
+            .build()
+            .flatten()
+            .filter(|e| e.file_type().is_some_and(|ft| ft.is_file()))
+            .map(|e| {
+                e.path()
+                    .strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+
+        assert!(paths.contains(&"lib.rs".to_string()), "*.rs should match");
+        assert!(
+            paths.contains(&".hidden.rs".to_string()),
+            "hidden *.rs should match"
+        );
+        assert!(
+            !paths.contains(&"main.py".to_string()),
+            "*.py should be filtered"
+        );
+        assert!(
+            !paths.iter().any(|p| p.starts_with(".git")),
+            ".git/ should still be excluded, got: {paths:?}"
+        );
     }
 
     #[test]

--- a/maki-code-index/src/find_symbol/search.rs
+++ b/maki-code-index/src/find_symbol/search.rs
@@ -269,6 +269,7 @@ fn search_project(
     walker.max_filesize(Some(MAX_FILE_SIZE));
 
     let mut overrides = OverrideBuilder::new(dir);
+    let _ = overrides.add("!.git");
     for ext in lang.extensions() {
         let _ = overrides.add(&format!("*.{ext}"));
     }


### PR DESCRIPTION
All file walkers (glob, grep, find-symbol) use the `ignore` crate with `.hidden(false)` so dotfiles like `.env` show up. But `.git/` is also just a hidden directory, and since `.gitignore` never lists `.git/` (git handles that internally), the walker walks right into it and silently scans all the git objects.

`BurntSushi` has explicitly said this is working-as-designed ([#3099](https://github.com/BurntSushi/ripgrep/issues/3099), [#1509](https://github.com/BurntSushi/ripgrep/issues/1509)): `.hidden()` controls all dotfiles, `.git` is not special-cased.

## Fix

Added `!.git` via `OverrideBuilder`, which is the same mechanism ripgrep itself uses for `-g '!.git/'`. This was chosen over `filter_entry` because the override approach is composable (doesn't consume the single `filter_entry` slot) and the tools already use `OverrideBuilder` for user-provided globs.

The exclusion is centralized in a `walk_builder(root, patterns)` helper in `maki-agent` that creates the walker with `.hidden(false)` and an `OverrideBuilder` that always enforces `!.git` before any caller patterns. `glob` and `grep` go through it, so new callers get the exclusion for free. `maki-code-index` (`find-symbol`) keeps its own inline `!.git` since it's a separate crate with a single call site.

Two regression tests verify that `.git/` is excluded while dotfiles still show up, and that the exclusion survives when extra glob patterns are layered on top.

## Repro

```sh
➜ git init /tmp/empty_repo && cd /tmp/empty_repo
Initialized empty Git repository in /tmp/empty_repo/.git/
```

### Before

```sh
➜ maki --print --yolo 'use grep to search for "repositoryformatversion"'
Found:

- `.git/config:2` — `repositoryformatversion = 0`%
```

### After
```sh
➜ maki-gitfix --print --yolo 'use grep to search for "repositoryformatversion"'
No matches for `repositoryformatversion` under `/tmp/empty_repo`.%
```