### PR TITLE
fix: accept flat batch entries and improve deserialization errors

### DIFF
--- a/maki-agent/src/tools/batch.rs
+++ b/maki-agent/src/tools/batch.rs
@@ -7,7 +7,8 @@ use std::fmt::Write;
 
 use crate::agent::{ResolvedCall, resolve_tool};
 use crate::{AgentEvent, BatchProgressEvent, BatchToolEntry, BatchToolStatus, ToolOutput};
-use serde::Deserialize;
+use serde::de::{self, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer};
 use serde_json::Value;
 
 use crate::task_set::TaskSet;
@@ -20,12 +21,82 @@ use super::{ToolCall, ToolContext};
 
 const MAX_BATCH_SIZE: usize = 25;
 
-#[derive(Args, Debug, Clone, Deserialize)]
+#[derive(Args, Debug, Clone)]
 pub(super) struct BatchEntry {
     #[param(description = "The name of the tool to execute")]
     tool: String,
     #[param(description = "Parameters for the tool")]
     parameters: Value,
+}
+
+/// Models sometimes send batch entries with flat fields:
+///   `{"tool": "glob", "path": "/tmp", "pattern": "*.rs"}`
+/// instead of the expected nested format:
+///   `{"tool": "glob", "parameters": {"path": "/tmp", "pattern": "*.rs"}}`
+///
+/// This custom deserializer accepts both. When `parameters` is missing,
+/// every field that isn't `tool` is collected into a `parameters` object.
+/// When both `parameters` and flat fields are present, they are merged
+/// (duplicate keys are rejected).
+impl<'de> Deserialize<'de> for BatchEntry {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct BatchEntryVisitor;
+
+        impl<'de> Visitor<'de> for BatchEntryVisitor {
+            type Value = BatchEntry;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a batch entry with 'tool' and either 'parameters' or flat tool params")
+            }
+
+            fn visit_map<M: MapAccess<'de>>(self, mut map: M) -> Result<BatchEntry, M::Error> {
+                let mut tool: Option<String> = None;
+                let mut parameters: Option<Value> = None;
+                let mut rest = serde_json::Map::new();
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "tool" => {
+                            tool = Some(map.next_value()?);
+                        }
+                        "parameters" => {
+                            parameters = Some(map.next_value()?);
+                        }
+                        _ => {
+                            rest.insert(key, map.next_value()?);
+                        }
+                    }
+                }
+
+                let tool = tool.ok_or_else(|| de::Error::missing_field("tool"))?;
+                let parameters = match parameters {
+                    Some(p) if rest.is_empty() => p,
+                    Some(Value::Object(mut obj)) => {
+                        for (k, v) in rest {
+                            if obj.contains_key(&k) {
+                                return Err(de::Error::custom(format_args!(
+                                    "duplicate parameter '{k}' in both 'parameters' and flat fields"
+                                )));
+                            }
+                            obj.insert(k, v);
+                        }
+                        Value::Object(obj)
+                    }
+                    Some(_) => {
+                        return Err(de::Error::custom(
+                            "'parameters' must be an object when flat fields are also present",
+                        ));
+                    }
+                    None if !rest.is_empty() => Value::Object(rest),
+                    None => return Err(de::Error::missing_field("parameters")),
+                };
+
+                Ok(BatchEntry { tool, parameters })
+            }
+        }
+
+        deserializer.deserialize_map(BatchEntryVisitor)
+    }
 }
 
 impl BatchEntry {
@@ -348,6 +419,89 @@ mod tests {
                     .any(|env| matches!(&env.event, AgentEvent::ToolDone(done) if !done.is_error)),
                 "batch inner tool must emit ToolDone"
             );
+        });
+    }
+
+    #[test]
+    fn flat_batch_entry_deserialized_as_nested() {
+        let flat = json!({
+            "tool_calls": [
+                {"tool": "glob", "path": "/tmp", "pattern": "*.rs"},
+                {"tool": "read", "path": "/tmp/foo.txt"}
+            ]
+        });
+        let batch = Batch::parse_input(&flat).unwrap();
+        assert_eq!(batch.tool_calls.len(), 2);
+        assert_eq!(batch.tool_calls[0].tool, "glob");
+        assert_eq!(batch.tool_calls[0].parameters["path"], "/tmp");
+        assert_eq!(batch.tool_calls[0].parameters["pattern"], "*.rs");
+        assert_eq!(batch.tool_calls[1].tool, "read");
+        assert_eq!(batch.tool_calls[1].parameters["path"], "/tmp/foo.txt");
+    }
+
+    #[test]
+    fn nested_batch_entry_still_works() {
+        let nested = json!({
+            "tool_calls": [
+                {"tool": "glob", "parameters": {"path": "/tmp", "pattern": "*.rs"}}
+            ]
+        });
+        let batch = Batch::parse_input(&nested).unwrap();
+        assert_eq!(batch.tool_calls[0].tool, "glob");
+        assert_eq!(batch.tool_calls[0].parameters["path"], "/tmp");
+    }
+
+    #[test]
+    fn mixed_nested_and_flat_fields_merged() {
+        let mixed = json!({
+            "tool_calls": [
+                {"tool": "glob", "parameters": {"path": "/tmp"}, "pattern": "*.rs"}
+            ]
+        });
+        let batch = Batch::parse_input(&mixed).unwrap();
+        assert_eq!(batch.tool_calls[0].tool, "glob");
+        assert_eq!(batch.tool_calls[0].parameters["path"], "/tmp");
+        assert_eq!(batch.tool_calls[0].parameters["pattern"], "*.rs");
+    }
+
+    #[test]
+    fn mixed_with_duplicate_key_is_error() {
+        let dup = json!({
+            "tool_calls": [
+                {"tool": "glob", "parameters": {"pattern": "*.rs"}, "pattern": "*.txt"}
+            ]
+        });
+        assert!(Batch::parse_input(&dup).is_err());
+    }
+
+    #[test]
+    fn batch_entry_missing_tool_is_error() {
+        let no_tool = json!({"tool_calls": [{"parameters": {"path": "/tmp"}}]});
+        assert!(Batch::parse_input(&no_tool).is_err());
+    }
+
+    #[test]
+    fn batch_entry_missing_tool_and_params_is_error() {
+        let empty = json!({"tool_calls": [{}]});
+        assert!(Batch::parse_input(&empty).is_err());
+    }
+
+    #[test]
+    fn flat_batch_entries_actually_execute() {
+        smol::block_on(async {
+            let dir = tempfile::TempDir::new().unwrap();
+            std::fs::write(dir.path().join("a.txt"), "hello").unwrap();
+            let dir_str = dir.path().to_string_lossy().to_string();
+
+            let (entries, text) = run_batch(json!({
+                "tool_calls": [
+                    {"tool": "glob", "path": dir_str, "pattern": "*.txt"}
+                ]
+            }))
+            .await;
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].status, BatchToolStatus::Success);
+            assert!(text.contains("a.txt"));
         });
     }
 }

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -520,22 +520,15 @@ pub(crate) fn deserialize_with_coercion<T: serde::de::DeserializeOwned>(
     field: &str,
     json_type: &str,
 ) -> Result<T, String> {
-    serde_json::from_value::<T>(raw.clone()).or_else(|_| {
+    serde_json::from_value::<T>(raw.clone()).or_else(|serde_err| {
         coerce_value(raw, field, json_type)
             .and_then(|c| serde_json::from_value(c).ok())
             .ok_or_else(|| {
-                let got_type = match raw {
-                    Value::String(_) => "string",
-                    Value::Number(_) => "number",
-                    Value::Bool(_) => "boolean",
-                    Value::Array(_) => "array",
-                    Value::Object(_) => "object",
-                    Value::Null => "null",
-                };
-                format!(
-                    "The parameter '{}' type is expected as '{}' but provided as '{}'",
-                    field, json_type, got_type
-                )
+                let msg = format!(
+                    "Invalid value for parameter '{}' (expected {}): {}",
+                    field, json_type, serde_err
+                );
+                msg
             })
     })
 }
@@ -1251,6 +1244,27 @@ mod tests {
         assert_eq!(
             resolve_path("src/main.rs").unwrap(),
             cwd.join("src/main.rs").to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn deserialize_error_includes_serde_message() {
+        // array with correct top-level type but bad items
+        let bad_array = json!([{"not_a_valid_field": 1}]);
+        let err =
+            deserialize_with_coercion::<Vec<batch::BatchEntry>>(&bad_array, "tool_calls", "array")
+                .unwrap_err();
+        assert!(
+            err.contains("missing field"),
+            "expected serde detail, got: {err}"
+        );
+
+        // wrong type entirely (string instead of integer)
+        let bad_type = json!("not_a_number");
+        let err = deserialize_with_coercion::<i64>(&bad_type, "count", "integer").unwrap_err();
+        assert!(
+            err.contains("invalid type"),
+            "expected serde detail, got: {err}"
         );
     }
 }


### PR DESCRIPTION
The batch tool was failing with an not-so-helpful `expected 'array' but provided 'array'` error:

<img width="791" height="635" alt="maki-tool_calls-array_error" src="https://github.com/user-attachments/assets/0c213fdc-4a83-483b-a8b4-6f1348063c65" />

Two issues stacked on top of each other:

1. `deserialize_with_coercion` error message only reported the JSON type mismatch, discarding the actual serde error. For same-type failures (e.g., an array with the wrong item shape), this produced unactionable messages like "expected 'array' but provided 'array'".
2. Batch entries are "a tool call inside a tool call" and some models (seen with `gpt-5.4` in non-API "plan" mode) sometimes reply with batch entries in the wrong shape, falling back to their "native protocol" by placing tool parameters flat alongside the tool name (`{"tool": "glob", "path": "/tmp", "pattern": "*.rs"}`) instead of the expected nested format (`{"tool": "glob", "parameters": {"path": "/tmp", "pattern": "*.rs"}}`. 

Now the full serde error is always surfaced, and a custom deserializer now accepts both formats, matching the defensive normalization already done by `sanitize_tool_input` for other model quirks (camelCase keys, stray quotes, spurious wrappers, etc).

---

## Repro

```sh
cargo run -- --print --yolo <<'EOF'
use batch to glob for all Cargo.toml files AND \
all README.md files under this repo in parallel
EOF

Found in parallel:

`Cargo.toml` files:
- `Cargo.toml`
- `maki-agent/Cargo.toml`
- `maki-code-index/Cargo.toml`
- `maki-config/Cargo.toml`
- `maki-config-macro/Cargo.toml`
- `maki-docgen/Cargo.toml`
- `maki-interpreter/Cargo.toml`
- `maki-providers/Cargo.toml`
- `maki-storage/Cargo.toml`
- `maki-tool-macro/Cargo.toml`
- `maki-ui/Cargo.toml`

`README.md` files:
- `README.md`%
```

### `main`

full log: [maki_log-0-main.json](https://github.com/user-attachments/files/26506339/maki_log-0-main.json)

```json
{
  "timestamp": "2026-04-05T22:44:04.488312Z",
  "level": "WARN",
  "fields": {
    "message": "failed to parse tool call",
    "tool": "batch",
    "input": "{\"tool_calls\":[{\"path\":\"/tmp/maki\",\"pattern\":\"**/Cargo.toml\",\"tool\":\"glob\"},{\"path\":\"/tmp/maki\",\"pattern\":\"**/README.md\",\"tool\":\"glob\"}]}",
    "error": "The parameter 'tool_calls' type is expected as 'array' but provided as 'array'"
  },
  "target": "maki_agent::agent::tool_dispatch"
}
(...)
{
  "timestamp": "2026-04-05T22:44:10.371196Z",
  "level": "INFO",
  "fields": {
    "message": "agent run completed",
    "self.num_turns": 3,
    "total_input": 11860,
    "total_output": 306
  },
  "target": "maki_agent::agent::run"
}
```

### After logging the serde error

full log: [maki_log-1-serde_err.json](https://github.com/user-attachments/files/26506350/maki_log-1-serde_err.json)

```json
{
  "timestamp": "2026-04-05T22:45:29.987466Z",
  "level": "WARN",
  "fields": {
    "message": "failed to parse tool call",
    "tool": "batch",
    "input": "{\"tool_calls\":[{\"path\":\"/tmp/maki\",\"pattern\":\"**/Cargo.toml\",\"tool\":\"glob\"},{\"path\":\"/tmp/maki\",\"pattern\":\"**/README.md\",\"tool\":\"glob\"}]}",
    "error": "Invalid value for parameter 'tool_calls' (expected array): missing field `parameters`"
  },
  "target": "maki_agent::agent::tool_dispatch"
}
(...)
{
  "timestamp": "2026-04-05T22:45:37.981235Z",
  "level": "INFO",
  "fields": {
    "message": "agent run completed",
    "self.num_turns": 3,
    "total_input": 11857,
    "total_output": 299
  },
  "target": "maki_agent::agent::run"
}
```

### After the custom deserializer

full log: [maki_log-2-after_deserialize.json](https://github.com/user-attachments/files/26506353/maki_log-2-after_deserialize.json)

```json
{
  "timestamp": "2026-04-05T22:56:52.685935Z",
  "level": "INFO",
  "fields": {
    "message": "agent run completed",
    "self.num_turns": 2,
    "total_input": 7825,
    "total_output": 217
  },
  "target": "maki_agent::agent::run"
}
```