### PR TITLE
feat: refresh MCP server tools and prompts on enable toggle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,6 +2123,7 @@ dependencies = [
 name = "maki"
 version = "0.1.12"
 dependencies = [
+ "arc-swap",
  "clap",
  "color-eyre",
  "flume 0.11.1",
@@ -2146,6 +2147,7 @@ dependencies = [
 name = "maki-agent"
 version = "0.1.12"
 dependencies = [
+ "arc-swap",
  "async-io",
  "async-lock",
  "async-process",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tracing-subscriber = { workspace = true }
 smol = { workspace = true }
 futures-lite = { workspace = true }
 flume = { workspace = true }
+arc-swap = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/maki-agent/Cargo.toml
+++ b/maki-agent/Cargo.toml
@@ -26,6 +26,7 @@ humantime = { workspace = true }
 smol = { workspace = true }
 async-process = { workspace = true }
 flume = { workspace = true }
+arc-swap = { workspace = true }
 event-listener = { workspace = true }
 async-lock = { workspace = true }
 async-io = { workspace = true }

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -12,7 +12,7 @@ use super::instructions::LoadedInstructions;
 use super::streaming::stream_with_retry;
 use super::tool_dispatch::{self, RecentCalls};
 use crate::cancel::CancelToken;
-use crate::mcp::McpManager;
+use crate::mcp::McpHandle;
 use crate::permissions::PermissionManager;
 use crate::skill::Skill;
 use crate::tools::{Deadline, ToolContext};
@@ -66,7 +66,7 @@ pub struct Agent {
     auto_compact: bool,
     loaded_instructions: LoadedInstructions,
     rollback_len: usize,
-    mcp: Option<Arc<McpManager>>,
+    mcp: Option<McpHandle>,
     config: AgentConfig,
     reauth_attempts: u32,
     permissions: Arc<PermissionManager>,
@@ -101,7 +101,7 @@ impl Agent {
         }
     }
 
-    pub fn with_mcp(mut self, mcp: Option<Arc<McpManager>>) -> Self {
+    pub fn with_mcp(mut self, mcp: Option<McpHandle>) -> Self {
         self.mcp = mcp;
         self
     }

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -1,12 +1,11 @@
 use std::collections::VecDeque;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::sync::Arc;
 
 use serde_json::Value;
 use tracing::{debug, error, warn};
 
-use crate::mcp::McpManager;
+use crate::mcp::McpHandle;
 use crate::task_set::TaskSet;
 use crate::tools::{ToolCall, ToolContext};
 use crate::{AgentError, AgentEvent, AgentMode, ToolDoneEvent, ToolOutput, ToolStartEvent};
@@ -22,7 +21,7 @@ pub(crate) enum ResolvedCall {
 }
 
 impl ResolvedCall {
-    pub(crate) fn start_event(&self, id: String, mcp: Option<&McpManager>) -> ToolStartEvent {
+    pub(crate) fn start_event(&self, id: String, mcp: Option<&McpHandle>) -> ToolStartEvent {
         match self {
             Self::Native(call) => call.start_event(id),
             Self::Mcp { tool_name, .. } => {
@@ -52,7 +51,7 @@ impl ResolvedCall {
 pub(crate) fn resolve_tool(
     name: &str,
     input: &Value,
-    mcp: Option<&McpManager>,
+    mcp: Option<&McpHandle>,
 ) -> Result<ResolvedCall, AgentError> {
     match ToolCall::from_api(name, input) {
         Ok(call) => Ok(ResolvedCall::Native(call)),
@@ -104,7 +103,7 @@ impl RecentCalls {
 fn parse_tool_calls<'a>(
     tool_uses: impl Iterator<Item = (&'a str, &'a str, &'a Value)>,
     recent: &mut RecentCalls,
-    mcp: Option<&McpManager>,
+    mcp: Option<&McpHandle>,
 ) -> (Vec<ParsedToolCall>, Vec<ToolDoneEvent>) {
     let mut parsed = Vec::new();
     let mut errors = Vec::new();
@@ -228,22 +227,18 @@ pub(crate) async fn execute_mcp_tool(
 pub(super) async fn process_tool_calls(
     response: maki_providers::StreamResponse,
     recent_calls: &mut RecentCalls,
-    mcp: Option<&Arc<McpManager>>,
+    mcp: Option<&McpHandle>,
     history: &mut super::history::History,
     event_tx: &crate::EventSender,
     ctx: &ToolContext,
 ) -> Result<(), AgentError> {
-    let (parsed, errors) = parse_tool_calls(
-        response.message.tool_uses(),
-        recent_calls,
-        mcp.map(|m| m.as_ref()),
-    );
+    let (parsed, errors) = parse_tool_calls(response.message.tool_uses(), recent_calls, mcp);
 
     history.push(response.message);
 
     for p in &parsed {
         event_tx.send(AgentEvent::ToolStart(Box::new(
-            p.call.start_event(p.id.clone(), mcp.map(|m| m.as_ref())),
+            p.call.start_event(p.id.clone(), mcp),
         )))?;
     }
 

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -11,7 +11,7 @@ pub mod mcp;
 pub use mcp::config::McpServerInfo;
 pub use mcp::config::McpServerStatus;
 pub use mcp::protocol::PromptRole;
-pub use mcp::{McpPromptArg, McpPromptInfo};
+pub use mcp::{McpCommand, McpHandle, McpPromptArg, McpPromptInfo, McpSnapshot};
 pub(crate) mod task_set;
 pub use agent::{
     Agent, AgentParams, AgentRunParams, History, Instructions, LoadedInstructions, RunOutcome,

--- a/maki-agent/src/mcp/config.rs
+++ b/maki-agent/src/mcp/config.rs
@@ -109,14 +109,14 @@ pub struct RawHttpFields {
     pub headers: HashMap<String, String>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ServerConfig {
     pub name: String,
     pub timeout: Duration,
     pub transport: Transport,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Transport {
     Stdio {
         program: String,

--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -2,6 +2,10 @@
 //!
 //! Tool names are namespaced as `server__tool` (double underscore) to avoid collisions across servers.
 //! Names are leaked into `&'static str` so they can be used in tool descriptors without lifetime friction.
+//!
+//! State is managed through a single command loop (`McpManager::run`). External callers interact
+//! via `McpHandle`, which exposes read-only access through `ArcSwap<McpSnapshot>` and mutations
+//! through a command channel. Tool calls bypass the command loop for performance.
 
 pub mod config;
 pub mod error;
@@ -14,8 +18,8 @@ pub mod transport;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
 
+use arc_swap::ArcSwap;
 use async_lock::RwLock;
 use serde_json::{Value, json};
 use tracing::{info, warn};
@@ -83,11 +87,10 @@ impl McpPromptDef {
 
 struct ServerEntry {
     name: String,
+    config: Option<ServerConfig>,
     transport_kind: &'static str,
     origin: PathBuf,
     status: McpServerStatus,
-    url: Option<String>,
-    timeout: Duration,
 }
 
 struct McpManagerInner {
@@ -96,10 +99,8 @@ struct McpManagerInner {
     tool_index: HashMap<&'static str, usize>,
     prompts: Vec<McpPromptDef>,
     entries: Vec<ServerEntry>,
-}
-
-pub struct McpManager {
-    inner: RwLock<McpManagerInner>,
+    disabled: Vec<String>,
+    generation: u64,
 }
 
 #[derive(Clone)]
@@ -117,6 +118,91 @@ pub struct McpPromptArg {
     pub required: bool,
 }
 
+#[derive(Clone)]
+pub struct McpSnapshot {
+    pub infos: Vec<McpServerInfo>,
+    pub prompts: Vec<McpPromptInfo>,
+    pub pids: Vec<u32>,
+    pub generation: u64,
+}
+
+pub enum McpCommand {
+    Toggle {
+        server: String,
+        enabled: bool,
+    },
+    Reconnect {
+        server: String,
+        url: String,
+        token: String,
+    },
+    Shutdown,
+}
+
+pub struct McpHandle {
+    cmd_tx: flume::Sender<McpCommand>,
+    manager: Arc<McpManager>,
+    pub snapshot: Arc<ArcSwap<McpSnapshot>>,
+}
+
+impl McpHandle {
+    pub fn send(&self, cmd: McpCommand) {
+        if let Err(e) = self.cmd_tx.try_send(cmd) {
+            tracing::warn!(error = %e, "MCP command dropped — manager shut down");
+        }
+    }
+
+    pub fn has_tool(&self, name: &str) -> bool {
+        self.manager.has_tool(name)
+    }
+
+    pub fn interned_name(&self, name: &str) -> &'static str {
+        self.manager.interned_name(name)
+    }
+
+    pub async fn call_tool(&self, qualified_name: &str, args: &Value) -> Result<String, McpError> {
+        self.manager.call_tool(qualified_name, args).await
+    }
+
+    pub async fn get_prompt(
+        &self,
+        qualified_name: &str,
+        arguments: &HashMap<String, String>,
+    ) -> Result<Vec<protocol::PromptMessage>, McpError> {
+        self.manager.get_prompt(qualified_name, arguments).await
+    }
+
+    pub fn extend_tools(&self, tools: &mut Value) {
+        self.manager.extend_tools(tools)
+    }
+}
+
+impl Clone for McpHandle {
+    fn clone(&self) -> Self {
+        Self {
+            cmd_tx: self.cmd_tx.clone(),
+            manager: Arc::clone(&self.manager),
+            snapshot: Arc::clone(&self.snapshot),
+        }
+    }
+}
+
+pub async fn start(
+    cwd: &Path,
+    disabled: Vec<String>,
+    snapshot: Arc<ArcSwap<McpSnapshot>>,
+) -> Option<McpHandle> {
+    McpManager::start(cwd, disabled, snapshot).await
+}
+
+pub async fn start_with_config(
+    config: McpConfig,
+    disabled: Vec<String>,
+    snapshot: Arc<ArcSwap<McpSnapshot>>,
+) -> Option<McpHandle> {
+    McpManager::start_with_config(config, disabled, snapshot).await
+}
+
 fn transport_url(transport: &Transport) -> Option<String> {
     match transport {
         Transport::Http { url, .. } => Some(url.clone()),
@@ -124,14 +210,26 @@ fn transport_url(transport: &Transport) -> Option<String> {
     }
 }
 
+struct McpManager {
+    inner: RwLock<McpManagerInner>,
+}
+
 impl McpManager {
-    pub async fn start(cwd: &Path) -> Option<Arc<Self>> {
+    pub async fn start(
+        cwd: &Path,
+        disabled: Vec<String>,
+        snapshot: Arc<ArcSwap<McpSnapshot>>,
+    ) -> Option<McpHandle> {
         let cwd = cwd.to_owned();
         let config = smol::unblock(move || load_config(&cwd)).await;
-        Self::start_with_config(config).await
+        Self::start_with_config(config, disabled, snapshot).await
     }
 
-    pub async fn start_with_config(config: McpConfig) -> Option<Arc<Self>> {
+    pub async fn start_with_config(
+        config: McpConfig,
+        disabled: Vec<String>,
+        snapshot: Arc<ArcSwap<McpSnapshot>>,
+    ) -> Option<McpHandle> {
         if config.is_empty() {
             return None;
         }
@@ -154,34 +252,34 @@ impl McpManager {
         for (name, raw) in config.mcp {
             let kind = transport_kind(&raw.transport);
             let origin = origins.get(&name).cloned().unwrap_or_default();
-
-            if !raw.enabled {
-                entries.push(ServerEntry {
-                    name,
-                    transport_kind: kind,
-                    origin,
-                    status: McpServerStatus::Disabled,
-                    url: None,
-                    timeout: Duration::default(),
-                });
-                continue;
-            }
+            let enabled = raw.enabled;
 
             match parse_server(name.clone(), raw) {
-                Ok(sc) => pending.push(Pending {
-                    config: sc,
-                    kind,
-                    origin,
-                }),
+                Ok(sc) => {
+                    if enabled {
+                        pending.push(Pending {
+                            config: sc,
+                            kind,
+                            origin,
+                        });
+                    } else {
+                        entries.push(ServerEntry {
+                            name: sc.name.clone(),
+                            config: Some(sc),
+                            transport_kind: kind,
+                            origin,
+                            status: McpServerStatus::Disabled,
+                        });
+                    }
+                }
                 Err(e) => {
                     warn!(server = %name, error = %e, "invalid MCP server config");
                     entries.push(ServerEntry {
                         name,
+                        config: None,
                         transport_kind: kind,
                         origin,
                         status: McpServerStatus::Failed(e.to_string()),
-                        url: None,
-                        timeout: Duration::default(),
                     });
                 }
             }
@@ -199,8 +297,6 @@ impl McpManager {
 
         for handle in handles {
             let (p, result) = handle.await;
-            let url = transport_url(&p.config.transport);
-            let timeout = p.config.timeout;
             match result {
                 Ok((t, server_tools, server_prompts)) => {
                     let server_name: Arc<str> = Arc::from(p.config.name.as_str());
@@ -222,12 +318,11 @@ impl McpManager {
                     }
                     transports.insert(Arc::clone(&server_name), t);
                     entries.push(ServerEntry {
-                        name: p.config.name,
+                        name: p.config.name.clone(),
+                        config: Some(p.config),
                         transport_kind: p.kind,
                         origin: p.origin,
                         status: McpServerStatus::Running,
-                        url,
-                        timeout,
                     });
                 }
                 Err(e) => {
@@ -245,12 +340,11 @@ impl McpManager {
                         McpServerStatus::Failed(e.to_string())
                     };
                     entries.push(ServerEntry {
-                        name: p.config.name,
+                        name: p.config.name.clone(),
+                        config: Some(p.config),
                         transport_kind: p.kind,
                         origin: p.origin,
                         status,
-                        url,
-                        timeout,
                     });
                 }
             }
@@ -264,15 +358,166 @@ impl McpManager {
             "MCP servers initialized"
         );
 
-        Some(Arc::new(Self {
+        let manager = Arc::new(Self {
             inner: RwLock::new(McpManagerInner {
                 transports,
                 tools,
                 tool_index,
                 prompts,
                 entries,
+                disabled,
+                generation: 0,
             }),
-        }))
+        });
+
+        snapshot.store(Arc::new(manager.build_snapshot()));
+
+        let (cmd_tx, cmd_rx) = flume::bounded(8);
+        let handle = McpHandle {
+            cmd_tx,
+            manager: Arc::clone(&manager),
+            snapshot: Arc::clone(&snapshot),
+        };
+
+        smol::spawn(Self::run(manager, cmd_rx, snapshot)).detach();
+
+        Some(handle)
+    }
+
+    async fn run(
+        self: Arc<Self>,
+        cmd_rx: flume::Receiver<McpCommand>,
+        snapshot: Arc<ArcSwap<McpSnapshot>>,
+    ) {
+        while let Ok(cmd) = cmd_rx.recv_async().await {
+            match cmd {
+                McpCommand::Toggle { server, enabled } => {
+                    self.handle_toggle(&server, enabled, &snapshot).await;
+                }
+                McpCommand::Reconnect { server, url, token } => {
+                    self.handle_reconnect(&server, &url, &token, &snapshot)
+                        .await;
+                }
+                McpCommand::Shutdown => {
+                    self.do_shutdown().await;
+                    break;
+                }
+            }
+        }
+    }
+
+    async fn handle_toggle(
+        &self,
+        server_name: &str,
+        enabled: bool,
+        snapshot: &ArcSwap<McpSnapshot>,
+    ) {
+        let config_path = {
+            let mut inner = self.inner.write().await;
+            toggle_disabled(&mut inner.disabled, server_name, enabled);
+            if let Some(entry) = inner.entries.iter_mut().find(|e| e.name == server_name)
+                && !enabled
+            {
+                entry.status = McpServerStatus::Disabled;
+            }
+            inner.generation += 1;
+            inner
+                .entries
+                .iter()
+                .find(|e| e.name == server_name)
+                .map(|e| e.origin.clone())
+        };
+
+        if let Some(path) = config_path {
+            let name = server_name.to_owned();
+            let server_for_log = server_name.to_owned();
+            smol::spawn(async move {
+                if let Err(e) =
+                    smol::unblock(move || config::persist_enabled(&path, &name, enabled)).await
+                {
+                    tracing::warn!(error = %e, server = %server_for_log, "failed to persist MCP toggle");
+                }
+            })
+            .detach();
+        }
+
+        if enabled && let Err(e) = self.refresh_server(server_name).await {
+            tracing::warn!(
+                server = %server_name,
+                error = %e,
+                "MCP server refresh failed"
+            );
+        }
+
+        snapshot.store(Arc::new(self.build_snapshot()));
+        info!(server = server_name, enabled, "MCP toggle complete");
+    }
+
+    async fn handle_reconnect(
+        &self,
+        server_name: &str,
+        server_url: &str,
+        access_token: &str,
+        snapshot: &ArcSwap<McpSnapshot>,
+    ) {
+        let timeout = {
+            let inner = self.inner.read().await;
+            if inner.disabled.iter().any(|d| d == server_name) {
+                info!(
+                    server = server_name,
+                    "ignoring reconnect for disabled server"
+                );
+                return;
+            }
+            inner
+                .entries
+                .iter()
+                .find(|e| e.name == server_name)
+                .and_then(|e| e.config.as_ref().map(|c| c.timeout))
+                .unwrap_or_default()
+        };
+        let mut headers = HashMap::new();
+        headers.insert(
+            "Authorization".to_string(),
+            format!("Bearer {access_token}"),
+        );
+        let config = ServerConfig {
+            name: server_name.to_string(),
+            timeout,
+            transport: Transport::Http {
+                url: server_url.to_string(),
+                headers,
+            },
+        };
+        if let Err(e) = self.refresh_server_with(server_name, Some(config)).await {
+            tracing::warn!(server = %server_name, error = %e, "reconnect failed");
+        }
+        let snap = {
+            let mut inner = self.inner.write().await;
+            inner.generation += 1;
+            Self::snapshot_from(&inner)
+        };
+        snapshot.store(Arc::new(snap));
+        info!(server = server_name, "MCP reconnect complete");
+    }
+
+    async fn do_shutdown(&self) {
+        let transports = {
+            let mut inner = self.inner.write().await;
+            std::mem::take(&mut inner.transports)
+        };
+        let handles: Vec<_> = transports
+            .into_iter()
+            .map(|(name, t)| {
+                smol::spawn(async move {
+                    info!(server = &*name, "shutting down MCP server");
+                    t.shutdown().await;
+                })
+            })
+            .collect();
+        for h in handles {
+            h.await;
+        }
     }
 
     async fn start_server(
@@ -316,11 +561,11 @@ impl McpManager {
         Ok((t, tools, prompts))
     }
 
-    pub fn has_tool(&self, name: &str) -> bool {
+    fn has_tool(&self, name: &str) -> bool {
         self.inner.read_blocking().tool_index.contains_key(name)
     }
 
-    pub fn interned_name(&self, name: &str) -> &'static str {
+    fn interned_name(&self, name: &str) -> &'static str {
         self.inner
             .read_blocking()
             .tool_index
@@ -329,7 +574,7 @@ impl McpManager {
             .unwrap_or("unknown_mcp")
     }
 
-    pub async fn call_tool(&self, qualified_name: &str, args: &Value) -> Result<String, McpError> {
+    async fn call_tool(&self, qualified_name: &str, args: &Value) -> Result<String, McpError> {
         let inner = self.inner.read().await;
         let idx = inner
             .tool_index
@@ -347,8 +592,9 @@ impl McpManager {
         transport::call_tool(t.as_ref(), &def.raw_name, args).await
     }
 
-    pub fn extend_tools(&self, tools: &mut Value, disabled: &[String]) {
+    fn extend_tools(&self, tools: &mut Value) {
         let inner = self.inner.read_blocking();
+        let disabled = &inner.disabled;
         for t in inner
             .tools
             .iter()
@@ -364,53 +610,73 @@ impl McpManager {
         }
     }
 
-    pub fn server_infos(&self, disabled: &[String]) -> Vec<McpServerInfo> {
-        let inner = self.inner.read_blocking();
-        let mut counts: HashMap<&str, (usize, usize)> = HashMap::new();
+    fn build_snapshot(&self) -> McpSnapshot {
+        Self::snapshot_from(&self.inner.read_blocking())
+    }
+
+    fn snapshot_from(inner: &McpManagerInner) -> McpSnapshot {
+        let disabled = &inner.disabled;
+
+        let mut tool_counts: HashMap<&str, (usize, usize)> = HashMap::new();
         for tool in &inner.tools {
-            counts.entry(&tool.server_name).or_default().0 += 1;
+            tool_counts.entry(&tool.server_name).or_default().0 += 1;
         }
         for prompt in &inner.prompts {
-            counts.entry(&prompt.server_name).or_default().1 += 1;
+            tool_counts.entry(&prompt.server_name).or_default().1 += 1;
         }
-        inner
+
+        let infos = inner
             .entries
             .iter()
             .map(|entry| {
-                let status = if disabled.contains(&entry.name) {
+                let name = &entry.name;
+                let status = if disabled.contains(name) {
                     McpServerStatus::Disabled
                 } else {
                     entry.status.clone()
                 };
                 let (tool_count, prompt_count) = if matches!(status, McpServerStatus::Running) {
-                    counts.get(entry.name.as_str()).copied().unwrap_or((0, 0))
+                    tool_counts.get(name.as_str()).copied().unwrap_or((0, 0))
                 } else {
                     (0, 0)
                 };
                 McpServerInfo {
-                    name: entry.name.clone(),
+                    name: name.clone(),
                     transport_kind: entry.transport_kind,
                     tool_count,
                     prompt_count,
                     status,
                     config_path: entry.origin.clone(),
-                    url: entry.url.clone(),
+                    url: entry
+                        .config
+                        .as_ref()
+                        .and_then(|c| transport_url(&c.transport)),
                 }
             })
-            .collect()
-    }
+            .collect();
 
-    pub fn prompt_infos(&self, disabled: &[String]) -> Vec<McpPromptInfo> {
-        let inner = self.inner.read_blocking();
-        inner
+        let prompts = inner
             .prompts
             .iter()
             .filter(|p| !disabled.iter().any(|d| **d == *p.server_name))
             .map(|p| p.to_info())
-            .collect()
+            .collect();
+
+        let pids = inner
+            .transports
+            .values()
+            .flat_map(|t| t.child_pids())
+            .collect();
+
+        McpSnapshot {
+            infos,
+            prompts,
+            pids,
+            generation: inner.generation,
+        }
     }
 
-    pub async fn get_prompt(
+    async fn get_prompt(
         &self,
         qualified_name: &str,
         arguments: &HashMap<String, String>,
@@ -432,112 +698,125 @@ impl McpManager {
         transport::get_prompt(t.as_ref(), &def.raw_name, arguments).await
     }
 
-    pub async fn shutdown(self) {
-        let inner = self.inner.into_inner();
-        let handles: Vec<_> = inner
-            .transports
-            .into_iter()
-            .map(|(name, t)| {
-                smol::spawn(async move {
-                    info!(server = &*name, "shutting down MCP server");
-                    t.shutdown().await;
-                })
-            })
-            .collect();
-        for h in handles {
-            h.await;
-        }
+    async fn refresh_server(&self, server_name: &str) -> Result<(), McpError> {
+        self.refresh_server_with(server_name, None).await
     }
 
-    pub fn child_pids(&self) -> Vec<u32> {
-        self.inner
-            .read_blocking()
-            .transports
-            .values()
-            .flat_map(|t| t.child_pids())
-            .collect()
-    }
-
-    pub async fn reconnect_server(
+    async fn refresh_server_with(
         &self,
         server_name: &str,
-        server_url: &str,
-        access_token: &str,
+        config_override: Option<ServerConfig>,
     ) -> Result<(), McpError> {
-        let timeout = {
-            let inner = self.inner.read().await;
-            inner
-                .entries
-                .iter()
-                .find(|e| e.name == server_name)
-                .map(|e| e.timeout)
-                .unwrap_or_default()
+        let (config, is_override) = match config_override {
+            Some(c) => (c, true),
+            None => {
+                let inner = self.inner.read().await;
+                let cfg = inner
+                    .entries
+                    .iter()
+                    .find(|e| e.name == server_name)
+                    .and_then(|e| e.config.clone())
+                    .ok_or_else(|| McpError::Config(format!("unknown server '{server_name}'")))?;
+                (cfg, false)
+            }
         };
-        let mut headers = HashMap::new();
-        headers.insert(
-            "Authorization".to_string(),
-            format!("Bearer {access_token}"),
-        );
-        let transport: Box<dyn McpTransport> = Box::new(HttpTransport::new(
-            server_name,
-            server_url,
-            &headers,
-            timeout,
-        )?);
-        transport::initialize(transport.as_ref()).await?;
-        let new_tools = transport::list_tools(transport.as_ref()).await?;
-        let new_prompts = transport::list_prompts(transport.as_ref()).await?;
+
+        let old_transport = {
+            let mut inner = self.inner.write().await;
+            if let Some(entry) = inner.entries.iter_mut().find(|e| e.name == server_name) {
+                entry.status = McpServerStatus::Connecting;
+            }
+            inner.transports.remove(server_name)
+        };
+
+        if let Some(old) = old_transport {
+            old.shutdown().await;
+        }
+
+        let result = Self::start_server(&config).await;
 
         let mut inner = self.inner.write().await;
-        let server_key: Arc<str> = Arc::from(server_name);
 
-        inner.tools.retain(|t| *t.server_name != *server_name);
-        inner.prompts.retain(|p| *p.server_name != *server_name);
-        inner.tool_index.clear();
-        let rebind: Vec<_> = inner
-            .tools
-            .iter()
-            .enumerate()
-            .map(|(i, t)| (t.qualified_name, i))
-            .collect();
-        for (name, i) in rebind {
-            inner.tool_index.insert(name, i);
+        if is_override && let Some(entry) = inner.entries.iter_mut().find(|e| e.name == server_name)
+        {
+            entry.config = Some(config.clone());
         }
 
-        for tool_info in new_tools {
-            let qualified = format!("{server_name}{SEPARATOR}{}", tool_info.name);
-            let interned = intern(qualified);
-            let idx = inner.tools.len();
-            inner.tools.push(McpToolDef {
-                qualified_name: interned,
-                server_name: Arc::clone(&server_key),
-                raw_name: tool_info.name,
-                description: tool_info.description,
-                input_schema: tool_info.input_schema,
-            });
-            inner.tool_index.insert(interned, idx);
-        }
+        let status = match result {
+            Ok((transport, new_tools, new_prompts)) => {
+                let server_key: Arc<str> = Arc::from(server_name);
 
-        for info in new_prompts {
-            inner
-                .prompts
-                .push(McpPromptDef::from_info(&server_key, info));
-        }
+                inner.tools.retain(|t| *t.server_name != *server_name);
+                inner.prompts.retain(|p| *p.server_name != *server_name);
+                inner.tool_index = inner
+                    .tools
+                    .iter()
+                    .enumerate()
+                    .map(|(i, t)| (t.qualified_name, i))
+                    .collect();
 
-        inner.transports.insert(Arc::clone(&server_key), transport);
+                for tool_info in new_tools {
+                    let qualified = format!("{server_name}{SEPARATOR}{}", tool_info.name);
+                    let interned = intern(qualified);
+                    let idx = inner.tools.len();
+                    inner.tools.push(McpToolDef {
+                        qualified_name: interned,
+                        server_name: Arc::clone(&server_key),
+                        raw_name: tool_info.name,
+                        description: tool_info.description,
+                        input_schema: tool_info.input_schema,
+                    });
+                    inner.tool_index.insert(interned, idx);
+                }
 
-        for entry in &mut inner.entries {
-            if entry.name == server_name {
-                entry.status = McpServerStatus::Running;
+                for info in new_prompts {
+                    inner
+                        .prompts
+                        .push(McpPromptDef::from_info(&server_key, info));
+                }
+
+                inner.transports.insert(Arc::clone(&server_key), transport);
+
+                info!(
+                    server = server_name,
+                    tools = inner.tools.len(),
+                    "MCP server refreshed"
+                );
+                Ok(McpServerStatus::Running)
+            }
+            Err(e) => {
+                let s = if let McpError::HttpError {
+                    status: 401,
+                    ref reason,
+                    ..
+                } = e
+                {
+                    McpServerStatus::NeedsAuth {
+                        url: Some(reason.clone()),
+                    }
+                } else {
+                    warn!(server = server_name, error = %e, "failed to refresh MCP server");
+                    McpServerStatus::Failed(e.to_string())
+                };
+                Err((s, e))
+            }
+        };
+
+        if let Some(entry) = inner.entries.iter_mut().find(|e| e.name == server_name) {
+            match &status {
+                Ok(s) | Err((s, _)) => entry.status = s.clone(),
             }
         }
 
-        info!(
-            server = server_name,
-            tools = inner.tools.len(),
-            "MCP server reconnected after OAuth"
-        );
-        Ok(())
+        status.map(|_| ()).map_err(|(_, e)| e)
+    }
+}
+
+fn toggle_disabled(disabled: &mut Vec<String>, name: &str, enabled: bool) {
+    if enabled {
+        disabled.retain(|s| s != name);
+    } else if !disabled.contains(&name.to_owned()) {
+        disabled.push(name.to_owned());
     }
 }
 
@@ -601,7 +880,13 @@ mod tests {
     fn empty_config_returns_none() {
         smol::block_on(async {
             let config = McpConfig::default();
-            let result = McpManager::start_with_config(config).await;
+            let snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot {
+                infos: vec![],
+                prompts: vec![],
+                pids: vec![],
+                generation: 0,
+            }));
+            let result = McpManager::start_with_config(config, vec![], snapshot).await;
             assert!(result.is_none());
         });
     }
@@ -616,8 +901,17 @@ mod tests {
                 ("bad-srv", stdio_raw(&[])),
                 ("also-bad", stdio_raw(&[])),
             ]);
-            let mgr = McpManager::start_with_config(config).await.unwrap();
-            let mut infos = mgr.server_infos(&[]);
+            let snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot {
+                infos: vec![],
+                prompts: vec![],
+                pids: vec![],
+                generation: 0,
+            }));
+            let handle = McpManager::start_with_config(config, vec![], snapshot)
+                .await
+                .unwrap();
+            let snap = handle.snapshot.load();
+            let mut infos = snap.infos.clone();
             infos.sort_by(|a, b| a.name.cmp(&b.name));
             assert_eq!(infos.len(), 3);
             assert!(matches!(infos[0].status, McpServerStatus::Failed(_)));
@@ -625,6 +919,7 @@ mod tests {
             assert!(matches!(infos[1].status, McpServerStatus::Failed(_)));
             assert_eq!(infos[2].status, McpServerStatus::Disabled);
             assert_eq!(infos[2].config_path, PathBuf::from("/test/config.toml"));
+            drop(handle);
         });
     }
 }

--- a/maki-agent/src/tools/batch.rs
+++ b/maki-agent/src/tools/batch.rs
@@ -144,7 +144,7 @@ impl Batch {
         let active = &self.tool_calls[..self.tool_calls.len().min(MAX_BATCH_SIZE)];
         let discarded = &self.tool_calls[active.len()..];
 
-        let mcp = ctx.mcp.as_deref();
+        let mcp = ctx.mcp.as_ref();
 
         let parsed: Vec<Result<ResolvedCall, String>> = active
             .iter()

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -42,7 +42,7 @@ use tracing::{error, info, warn};
 
 use crate::agent::LoadedInstructions;
 use crate::cancel::CancelToken;
-use crate::mcp::McpManager;
+use crate::mcp::McpHandle;
 use crate::permissions::PermissionManager;
 use crate::skill::Skill;
 use crate::template::Vars;
@@ -246,7 +246,7 @@ pub struct ToolContext {
     pub skills: Arc<[Skill]>,
     pub loaded_instructions: LoadedInstructions,
     pub cancel: CancelToken,
-    pub mcp: Option<Arc<McpManager>>,
+    pub mcp: Option<McpHandle>,
     pub deadline: Deadline,
     pub config: AgentConfig,
     pub permissions: Arc<PermissionManager>,

--- a/maki-agent/src/tools/task.rs
+++ b/maki-agent/src/tools/task.rs
@@ -100,7 +100,7 @@ impl Task {
         };
         let mut tools = ToolCall::definitions(&vars, &ctx_desc, model.supports_tool_examples());
         if let Some(ref mcp) = ctx.mcp {
-            mcp.extend_tools(&mut tools, &[]);
+            mcp.extend_tools(&mut tools);
         }
 
         let (sub_tx, sub_rx) = flume::unbounded::<crate::Envelope>();

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -1,11 +1,12 @@
 use std::mem;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use maki_agent::agent;
-use maki_agent::mcp::McpManager;
-use maki_agent::mcp::config::{McpServerInfo, persist_enabled};
+use maki_agent::mcp;
+use maki_agent::mcp::McpHandle;
+use maki_agent::mcp::config::{McpServerInfo, McpServerStatus};
 use maki_agent::permissions::PermissionManager;
 use maki_agent::skill::Skill;
 use maki_agent::template;
@@ -13,7 +14,8 @@ use maki_agent::template::Vars;
 use maki_agent::tools::{DescriptionContext, ToolCall, ToolFilter};
 use maki_agent::{
     Agent, AgentConfig, AgentEvent, AgentInput, AgentParams, AgentRunParams, CancelToken,
-    CancelTrigger, Envelope, EventSender, History, Instructions, McpPromptInfo, PromptRole,
+    CancelTrigger, Envelope, EventSender, History, Instructions, McpCommand, McpSnapshot,
+    PromptRole,
 };
 use maki_providers::{AgentError, Message, Model, TokenUsage};
 use serde_json::Value;
@@ -22,7 +24,6 @@ use tracing::error;
 use super::ModelSlot;
 use super::cancel_map::CancelMap;
 use super::shared_queue::{QueueItem, SharedQueue};
-use super::toggle_disabled;
 
 pub(super) struct AgentLoop {
     model_slot: Arc<ArcSwap<ModelSlot>>,
@@ -31,14 +32,12 @@ pub(super) struct AgentLoop {
     vars: Vars,
     instructions: Instructions,
     tools: Value,
-    disabled: Vec<String>,
-    mcp_manager: Option<Arc<McpManager>>,
-    mcp_infos: Arc<ArcSwap<Vec<McpServerInfo>>>,
-    mcp_prompts: Arc<ArcSwap<Vec<McpPromptInfo>>>,
-    mcp_pids: Arc<Mutex<Vec<u32>>>,
+    initial_disabled: Vec<String>,
+    mcp_handle: Option<McpHandle>,
+    mcp_snapshot: Arc<ArcSwap<McpSnapshot>>,
     history: History,
     shared_history: Arc<ArcSwap<Vec<Message>>>,
-    cancel_map: Arc<Mutex<CancelMap>>,
+    cancel_map: Arc<std::sync::Mutex<CancelMap>>,
     cancel: CancelToken,
     permissions: Arc<PermissionManager>,
     min_run_id: u64,
@@ -62,9 +61,7 @@ impl AgentLoop {
         config: AgentConfig,
         initial_history: Vec<Message>,
         shared_history: Arc<ArcSwap<Vec<Message>>>,
-        mcp_infos: Arc<ArcSwap<Vec<McpServerInfo>>>,
-        mcp_prompts: Arc<ArcSwap<Vec<McpPromptInfo>>>,
-        mcp_pids: Arc<Mutex<Vec<u32>>>,
+        mcp_snapshot: Arc<ArcSwap<McpSnapshot>>,
         initial_disabled: Vec<String>,
         permissions: Arc<PermissionManager>,
         agent_tx: flume::Sender<Envelope>,
@@ -72,7 +69,7 @@ impl AgentLoop {
         notify_rx: flume::Receiver<()>,
         queue: Arc<SharedQueue>,
         toggle_rx: flume::Receiver<(String, bool)>,
-        cancel_map: Arc<Mutex<CancelMap>>,
+        cancel_map: Arc<std::sync::Mutex<CancelMap>>,
         cancel: CancelToken,
     ) -> Self {
         Self {
@@ -82,11 +79,9 @@ impl AgentLoop {
             vars: Vars::default(),
             instructions: Instructions::default(),
             tools: Value::Null,
-            disabled: initial_disabled,
-            mcp_manager: None,
-            mcp_infos,
-            mcp_prompts,
-            mcp_pids,
+            initial_disabled,
+            mcp_handle: None,
+            mcp_snapshot,
             history: History::new(initial_history),
             shared_history,
             cancel_map,
@@ -110,7 +105,7 @@ impl AgentLoop {
             let event = {
                 let notify_rx = &self.notify_rx;
                 let toggle_rx = &self.toggle_rx;
-                futures_lite::future::race(
+                futures_lite::future::or(
                     async { notify_rx.recv_async().await.ok().map(|_| LoopEvent::Queue) },
                     async {
                         toggle_rx
@@ -177,32 +172,41 @@ impl AgentLoop {
     }
 
     async fn init_mcp(&mut self, cwd: &Path) {
-        let mcp_config = maki_agent::mcp::config::load_config(cwd);
-        self.disabled.sort_unstable();
-        self.disabled.dedup();
+        let mcp_config = mcp::config::load_config(cwd);
+        let disabled = {
+            let mut d = self.initial_disabled.clone();
+            d.sort_unstable();
+            d.dedup();
+            d
+        };
 
         if !mcp_config.is_empty() {
-            self.mcp_infos
-                .store(Arc::new(mcp_config.preliminary_infos(&self.disabled)));
+            let preliminary = mcp_config.preliminary_infos(&disabled);
+            self.mcp_snapshot.store(Arc::new(McpSnapshot {
+                infos: preliminary,
+                prompts: vec![],
+                pids: vec![],
+                generation: 0,
+            }));
         }
 
-        let mcp_manager = self
+        let handle = self
             .cancel
-            .race(McpManager::start_with_config(mcp_config))
+            .race(mcp::start_with_config(
+                mcp_config,
+                disabled,
+                self.mcp_snapshot.clone(),
+            ))
             .await
             .unwrap_or(None);
 
-        if let Some(ref mgr) = mcp_manager {
-            mgr.extend_tools(&mut self.tools, &self.disabled);
-            let infos = mgr.server_infos(&self.disabled);
-            spawn_oauth_for_needs_auth(&infos, mgr, &self.mcp_infos, &self.disabled);
-            self.mcp_infos.store(Arc::new(infos));
-            self.mcp_prompts
-                .store(Arc::new(mgr.prompt_infos(&self.disabled)));
-            *self.mcp_pids.lock().unwrap_or_else(|e| e.into_inner()) = mgr.child_pids();
+        if let Some(ref h) = handle {
+            h.extend_tools(&mut self.tools);
+            let snap = h.snapshot.load();
+            spawn_oauth_for_needs_auth(&snap.infos, h);
         }
 
-        self.mcp_manager = mcp_manager;
+        self.mcp_handle = handle;
     }
 
     async fn do_compact(&mut self, event_tx: &EventSender) -> Result<(), AgentError> {
@@ -232,10 +236,14 @@ impl AgentLoop {
             self.history.push(msg);
         }
 
-        if let Some(ref prompt_ref) = input.prompt
-            && let Some(ref mgr) = self.mcp_manager
-        {
-            let messages = mgr
+        if let Some(ref prompt_ref) = input.prompt {
+            let Some(ref mcp) = self.mcp_handle else {
+                return Err(AgentError::Tool {
+                    tool: "mcp_prompt".into(),
+                    message: "MCP not available".into(),
+                });
+            };
+            let messages = mcp
                 .get_prompt(&prompt_ref.qualified_name, &prompt_ref.arguments)
                 .await
                 .map_err(|e| AgentError::Tool {
@@ -283,7 +291,7 @@ impl AgentLoop {
         .with_user_response_rx(Arc::clone(&self.answer_rx))
         .with_interrupt_source(Arc::clone(&self.queue) as Arc<dyn maki_agent::InterruptSource>)
         .with_cancel(cancel)
-        .with_mcp(self.mcp_manager.clone());
+        .with_mcp(self.mcp_handle.clone());
 
         let outcome = agent.run(input).await;
 
@@ -299,23 +307,18 @@ impl AgentLoop {
     }
 
     fn handle_mcp_toggle(&mut self, server_name: String, enabled: bool) {
-        toggle_disabled(&mut self.disabled, &server_name, enabled);
-        let slot = self.model_slot.load();
-        self.rebuild_tools(&slot.model);
-
-        if let Some(ref mcp) = self.mcp_manager {
-            let infos = mcp.server_infos(&self.disabled);
-            self.persist_mcp_toggle(&infos, &server_name, enabled);
-            self.mcp_infos.store(Arc::new(infos));
-            self.mcp_prompts
-                .store(Arc::new(mcp.prompt_infos(&self.disabled)));
+        if let Some(ref mcp) = self.mcp_handle {
+            mcp.send(McpCommand::Toggle {
+                server: server_name,
+                enabled,
+            });
         }
     }
 
     fn rebuild_tools(&mut self, model: &Model) {
         let mut tools = self.build_tools(model);
-        if let Some(ref mcp) = self.mcp_manager {
-            mcp.extend_tools(&mut tools, &self.disabled);
+        if let Some(ref mcp) = self.mcp_handle {
+            mcp.extend_tools(&mut tools);
         }
         self.tools = tools;
     }
@@ -333,22 +336,6 @@ impl AgentLoop {
     async fn reload_instructions(&mut self) {
         let cwd = self.vars.apply("{cwd}").into_owned();
         self.instructions = smol::unblock(move || agent::load_instructions(&cwd)).await;
-    }
-
-    fn persist_mcp_toggle(&self, infos: &[McpServerInfo], server_name: &str, enabled: bool) {
-        if let Some(info) = infos.iter().find(|i| i.name == server_name) {
-            let path = info.config_path.clone();
-            let name = server_name.to_owned();
-            let server_for_log = server_name.to_owned();
-            smol::spawn(async move {
-                if let Err(e) =
-                    smol::unblock(move || persist_enabled(&path, &name, enabled)).await
-                {
-                    tracing::warn!(error = %e, server = %server_for_log, "failed to persist MCP toggle");
-                }
-            })
-            .detach();
-        }
     }
 
     fn sync_shared_history(&self) {
@@ -396,14 +383,7 @@ impl AgentLoop {
     }
 }
 
-fn spawn_oauth_for_needs_auth(
-    infos: &[McpServerInfo],
-    mgr: &Arc<McpManager>,
-    mcp_infos: &Arc<ArcSwap<Vec<McpServerInfo>>>,
-    disabled: &[String],
-) {
-    use maki_agent::mcp::config::McpServerStatus;
-
+fn spawn_oauth_for_needs_auth(infos: &[McpServerInfo], handle: &McpHandle) {
     for info in infos {
         let McpServerStatus::NeedsAuth { ref url } = info.status else {
             continue;
@@ -411,12 +391,10 @@ fn spawn_oauth_for_needs_auth(
         let Some(ref server_url) = info.url else {
             continue;
         };
-        let mgr = Arc::clone(mgr);
+        let handle = handle.clone();
         let server_name = info.name.clone();
         let server_url = server_url.clone();
         let www_auth = url.clone();
-        let mcp_infos = Arc::clone(mcp_infos);
-        let disabled = disabled.to_vec();
         smol::spawn(async move {
             let storage = match maki_storage::DataDir::resolve() {
                 Ok(s) => s,
@@ -442,14 +420,11 @@ fn spawn_oauth_for_needs_auth(
             let Some(ref tokens) = auth_data.tokens else {
                 return;
             };
-            if let Err(e) = mgr
-                .reconnect_server(&server_name, &server_url, &tokens.access)
-                .await
-            {
-                tracing::warn!(server = %server_name, error = %e, "OAuth reconnect failed");
-                return;
-            }
-            mcp_infos.store(Arc::new(mgr.server_infos(&disabled)));
+            handle.send(McpCommand::Reconnect {
+                server: server_name.clone(),
+                url: server_url,
+                token: tokens.access.clone(),
+            });
             tracing::info!(server = %server_name, "MCP server authenticated via OAuth");
         })
         .detach();

--- a/maki-ui/src/agent/mod.rs
+++ b/maki-ui/src/agent/mod.rs
@@ -9,10 +9,9 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use arc_swap::ArcSwap;
-use maki_agent::mcp::config::McpServerInfo;
 use maki_agent::permissions::PermissionManager;
 use maki_agent::skill::Skill;
-use maki_agent::{AgentConfig, CancelToken, Envelope, McpPromptInfo, ToolOutput};
+use maki_agent::{AgentConfig, CancelToken, Envelope, McpSnapshot, ToolOutput};
 
 use self::cancel_map::CancelMap;
 use maki_providers::provider::Provider;
@@ -36,12 +35,24 @@ pub(crate) enum AgentCommand {
     ToggleMcp(String, bool),
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub(crate) struct McpState {
     pub(crate) disabled: Vec<String>,
-    pub(crate) infos: Arc<ArcSwap<Vec<McpServerInfo>>>,
-    pub(crate) prompts: Arc<ArcSwap<Vec<McpPromptInfo>>>,
-    pub(crate) pids: Arc<Mutex<Vec<u32>>>,
+    pub(crate) snapshot: Arc<ArcSwap<McpSnapshot>>,
+}
+
+impl Default for McpState {
+    fn default() -> Self {
+        Self {
+            disabled: Vec::new(),
+            snapshot: Arc::new(ArcSwap::from_pointee(McpSnapshot {
+                infos: vec![],
+                prompts: vec![],
+                pids: vec![],
+                generation: 0,
+            })),
+        }
+    }
 }
 
 pub(crate) struct AgentHandles {
@@ -151,9 +162,7 @@ pub(crate) fn spawn_agent(
         config,
         initial_history,
         Arc::clone(&shared_history),
-        Arc::clone(&mcp_state.infos),
-        Arc::clone(&mcp_state.prompts),
-        Arc::clone(&mcp_state.pids),
+        Arc::clone(&mcp_state.snapshot),
         mcp_state.disabled.clone(),
         Arc::clone(permissions),
         agent_tx,

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -51,7 +51,7 @@ use crossterm::event::{KeyCode, KeyEvent, MouseEvent};
 use maki_agent::QuestionInfo;
 use maki_agent::permissions::{PermissionDecision, PermissionManager};
 use maki_agent::{
-    AgentEvent, Envelope, ImageSource, McpPromptInfo, McpServerInfo, SubagentInfo, ToolOutput,
+    AgentEvent, Envelope, ImageSource, McpPromptInfo, McpSnapshot, SubagentInfo, ToolOutput,
 };
 use maki_config::UiConfig;
 use maki_providers::{Message, Model, ThinkingConfig};
@@ -149,8 +149,7 @@ impl App {
         session: AppSession,
         storage: DataDir,
         available_models: Arc<ArcSwapOption<Vec<String>>>,
-        mcp_infos: Arc<ArcSwap<Vec<McpServerInfo>>>,
-        mcp_prompts: Arc<ArcSwap<Vec<McpPromptInfo>>>,
+        mcp_snapshot: Arc<ArcSwap<McpSnapshot>>,
         storage_writer: Arc<StorageWriter>,
         ui_config: UiConfig,
         input_history_size: usize,
@@ -163,12 +162,12 @@ impl App {
             active_chat: 0,
             chat_index: HashMap::new(),
             input_box: InputBox::new(InputHistory::load(&storage, input_history_size)),
-            command_palette: CommandPalette::new(custom_commands, mcp_prompts),
+            command_palette: CommandPalette::new(custom_commands, Arc::clone(&mcp_snapshot)),
             task_picker: ListPicker::new(),
             task_picker_original: None,
             theme_picker: ThemePicker::new(),
             model_picker: ModelPicker::new(available_models),
-            mcp_picker: McpPicker::new(mcp_infos),
+            mcp_picker: McpPicker::new(Arc::clone(&mcp_snapshot)),
             session_picker: SessionPicker::new(),
             rewind_picker: RewindPicker::new(),
             help_modal: HelpModal::new(),

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -9,7 +9,8 @@ use arc_swap::ArcSwap;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEventKind};
 use maki_agent::permissions::PermissionManager;
 use maki_agent::{
-    QuestionInfo, QuestionOption, ToolDoneEvent, ToolOutput, ToolStartEvent, TurnCompleteEvent,
+    McpSnapshot, QuestionInfo, QuestionOption, ToolDoneEvent, ToolOutput, ToolStartEvent,
+    TurnCompleteEvent,
 };
 use maki_config::{PermissionsConfig, UiConfig};
 use maki_providers::TokenUsage;
@@ -29,7 +30,12 @@ fn set_zone(app: &mut App, zone: SelectionZone, area: Rect) {
 
 fn test_app() -> App {
     let writer = Arc::new(StorageWriter::new(DataDir::from_path(env::temp_dir())));
-    let mcp_infos = Arc::new(ArcSwap::from_pointee(Vec::new()));
+    let mcp_snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot {
+        infos: vec![],
+        prompts: vec![],
+        pids: vec![],
+        generation: 0,
+    }));
     let permissions = Arc::new(PermissionManager::new(
         PermissionsConfig {
             allow_all: false,
@@ -43,8 +49,7 @@ fn test_app() -> App {
         AppSession::new("test-model", "/tmp/test"),
         DataDir::from_path(env::temp_dir()),
         Arc::new(ArcSwapOption::empty()),
-        mcp_infos,
-        Arc::new(ArcSwap::from_pointee(Vec::new())),
+        mcp_snapshot,
         writer,
         UiConfig::default(),
         100,
@@ -443,15 +448,19 @@ fn load_session_clears_plan() {
     let writer = Arc::new(StorageWriter::new(DataDir::from_path(
         tmp.path().to_path_buf(),
     )));
-    let mcp_infos = Arc::new(ArcSwap::from_pointee(Vec::new()));
+    let mcp_snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot {
+        infos: vec![],
+        prompts: vec![],
+        pids: vec![],
+        generation: 0,
+    }));
     let model = test_model();
     let mut app = App::new(
         &model,
         AppSession::new("test-model", "/tmp/test"),
         dir,
         Arc::new(ArcSwapOption::empty()),
-        mcp_infos,
-        Arc::new(ArcSwap::from_pointee(Vec::new())),
+        mcp_snapshot,
         writer,
         UiConfig::default(),
         100,
@@ -1649,15 +1658,20 @@ fn mcp_toggle_dispatches_action() {
     use std::path::PathBuf;
 
     let mut app = test_app();
-    app.mcp_picker = McpPicker::new(Arc::new(ArcSwap::from_pointee(vec![McpServerInfo {
-        name: "test-srv".into(),
-        transport_kind: "stdio",
-        tool_count: 2,
-        prompt_count: 0,
-        status: McpServerStatus::Running,
-        config_path: PathBuf::from("/tmp/config.toml"),
-        url: None,
-    }])));
+    app.mcp_picker = McpPicker::new(Arc::new(ArcSwap::from_pointee(McpSnapshot {
+        infos: vec![McpServerInfo {
+            name: "test-srv".into(),
+            transport_kind: "stdio",
+            tool_count: 2,
+            prompt_count: 0,
+            status: McpServerStatus::Running,
+            config_path: PathBuf::from("/tmp/config.toml"),
+            url: None,
+        }],
+        prompts: vec![],
+        pids: vec![],
+        generation: 0,
+    })));
     app.execute_command(cmd("/mcp"));
 
     let actions = app.update(Msg::Key(key(KeyCode::Enter)));

--- a/maki-ui/src/components/command.rs
+++ b/maki-ui/src/components/command.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use crossterm::event::{KeyCode, KeyEvent};
-use maki_agent::McpPromptInfo;
 use maki_agent::command::CustomCommand;
+use maki_agent::{McpPromptInfo, McpSnapshot};
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
@@ -119,22 +119,22 @@ pub struct CommandPalette {
     selected: usize,
     filtered: Vec<FilteredItem>,
     custom: Arc<[CustomCommand]>,
-    mcp_prompts_source: Arc<ArcSwap<Vec<McpPromptInfo>>>,
-    mcp_prompts: Arc<Vec<McpPromptInfo>>,
+    mcp_snapshot_source: Arc<ArcSwap<McpSnapshot>>,
+    mcp_prompts: Vec<McpPromptInfo>,
 }
 
 impl CommandPalette {
     pub fn new(
         custom_commands: Arc<[CustomCommand]>,
-        mcp_prompts: Arc<ArcSwap<Vec<McpPromptInfo>>>,
+        mcp_snapshot: Arc<ArcSwap<McpSnapshot>>,
     ) -> Self {
-        let snapshot = mcp_prompts.load_full();
+        let prompts = mcp_snapshot.load().prompts.clone();
         Self {
             selected: 0,
             filtered: Vec::new(),
             custom: custom_commands,
-            mcp_prompts_source: mcp_prompts,
-            mcp_prompts: snapshot,
+            mcp_snapshot_source: mcp_snapshot,
+            mcp_prompts: prompts,
         }
     }
 
@@ -175,7 +175,7 @@ impl CommandPalette {
     }
 
     pub fn sync(&mut self, input: &str) {
-        self.mcp_prompts = self.mcp_prompts_source.load_full();
+        self.mcp_prompts = self.mcp_snapshot_source.load().prompts.clone();
         let Some(stripped) = input.strip_prefix('/') else {
             self.filtered.clear();
             return;
@@ -374,18 +374,23 @@ mod tests {
     use maki_agent::McpPromptArg;
     use test_case::test_case;
 
-    fn empty_prompts() -> Arc<ArcSwap<Vec<McpPromptInfo>>> {
-        Arc::new(ArcSwap::from_pointee(Vec::new()))
+    fn empty_snapshot() -> Arc<ArcSwap<McpSnapshot>> {
+        Arc::new(ArcSwap::from_pointee(McpSnapshot {
+            infos: vec![],
+            prompts: vec![],
+            pids: vec![],
+            generation: 0,
+        }))
     }
 
     fn synced(input: &str) -> CommandPalette {
-        let mut p = CommandPalette::new(Arc::from([]), empty_prompts());
+        let mut p = CommandPalette::new(Arc::from([]), empty_snapshot());
         p.sync(input);
         p
     }
 
     fn synced_with_custom(input: &str, custom: Arc<[CustomCommand]>) -> CommandPalette {
-        let mut p = CommandPalette::new(custom, empty_prompts());
+        let mut p = CommandPalette::new(custom, empty_snapshot());
         p.sync(input);
         p
     }
@@ -456,7 +461,7 @@ mod tests {
 
     #[test]
     fn confirm_when_inactive_returns_none() {
-        let p = CommandPalette::new(Arc::from([]), empty_prompts());
+        let p = CommandPalette::new(Arc::from([]), empty_snapshot());
         assert!(p.confirm("").is_none());
     }
 
@@ -507,7 +512,7 @@ mod tests {
     #[test_case("/compact", "/compact", ""    ; "other_command")]
     #[test_case("/btw hello world", "/btw", "hello world" ; "btw_multi_word")]
     fn confirm_parses_args(input: &str, expected_name: &str, expected_args: &str) {
-        let mut p = CommandPalette::new(Arc::from([]), empty_prompts());
+        let mut p = CommandPalette::new(Arc::from([]), empty_snapshot());
         p.sync(input);
         let cmd = p.confirm(input).unwrap();
         assert_eq!(cmd.name, expected_name);
@@ -517,7 +522,7 @@ mod tests {
     #[test]
     fn confirm_custom_command() {
         let custom = sample_custom();
-        let mut p = CommandPalette::new(custom, empty_prompts());
+        let mut p = CommandPalette::new(custom, empty_snapshot());
         p.sync("/project:review");
         assert!(p.is_active());
         let cmd = p.confirm("/project:review some-file.rs").unwrap();
@@ -528,32 +533,37 @@ mod tests {
     #[test]
     fn find_custom_command_lookup() {
         let custom = sample_custom();
-        let p = CommandPalette::new(custom, empty_prompts());
+        let p = CommandPalette::new(custom, empty_snapshot());
         let found = p.find_custom_command("/project:review");
         assert!(found.is_some());
         assert_eq!(found.unwrap().content, "Review $ARGUMENTS");
         assert!(p.find_custom_command("/nonexistent").is_none());
     }
 
-    fn sample_prompts() -> Arc<ArcSwap<Vec<McpPromptInfo>>> {
-        Arc::new(ArcSwap::from_pointee(vec![
-            McpPromptInfo {
-                display_name: "myserver:code-review".into(),
-                qualified_name: "myserver/code-review".into(),
-                description: "Review code changes".into(),
-                arguments: vec![McpPromptArg {
-                    name: "diff".into(),
-                    description: "The diff".into(),
-                    required: true,
-                }],
-            },
-            McpPromptInfo {
-                display_name: "myserver:summarize".into(),
-                qualified_name: "myserver/summarize".into(),
-                description: "Summarize text".into(),
-                arguments: vec![],
-            },
-        ]))
+    fn sample_prompts() -> Arc<ArcSwap<McpSnapshot>> {
+        Arc::new(ArcSwap::from_pointee(McpSnapshot {
+            infos: vec![],
+            prompts: vec![
+                McpPromptInfo {
+                    display_name: "myserver:code-review".into(),
+                    qualified_name: "myserver/code-review".into(),
+                    description: "Review code changes".into(),
+                    arguments: vec![McpPromptArg {
+                        name: "diff".into(),
+                        description: "The diff".into(),
+                        required: true,
+                    }],
+                },
+                McpPromptInfo {
+                    display_name: "myserver:summarize".into(),
+                    qualified_name: "myserver/summarize".into(),
+                    description: "Summarize text".into(),
+                    arguments: vec![],
+                },
+            ],
+            pids: vec![],
+            generation: 0,
+        }))
     }
 
     fn synced_with_prompts(input: &str) -> CommandPalette {

--- a/maki-ui/src/components/list_picker.rs
+++ b/maki-ui/src/components/list_picker.rs
@@ -288,6 +288,14 @@ impl<T: PickerItem> ListPicker<T> {
         }
     }
 
+    pub fn replace_toggleable(&mut self, items: Vec<T>, enabled: Vec<bool>) {
+        if let Some(s) = self.state.as_mut().and_then(PickerState::ready_mut) {
+            self.generation += 1;
+            s.enabled = Some(enabled);
+            s.replace_items(items);
+        }
+    }
+
     pub fn retain(&mut self, f: impl Fn(&T) -> bool) {
         let Some(s) = self.state.as_mut().and_then(PickerState::ready_mut) else {
             return;

--- a/maki-ui/src/components/mcp_picker.rs
+++ b/maki-ui/src/components/mcp_picker.rs
@@ -5,12 +5,50 @@ use crossterm::event::KeyEvent;
 use ratatui::Frame;
 use ratatui::layout::Rect;
 
-use maki_agent::{McpServerInfo, McpServerStatus};
+use maki_agent::{McpServerInfo, McpServerStatus, McpSnapshot};
 
 use crate::components::Overlay;
 use crate::components::list_picker::{ListPicker, PickerAction, PickerItem};
 
 const TITLE: &str = " MCP Servers ";
+
+fn build_entries(infos: &[McpServerInfo]) -> (Vec<McpEntry>, Vec<bool>) {
+    let entries = infos
+        .iter()
+        .map(|info| McpEntry {
+            name: info.name.clone(),
+            detail_text: match &info.status {
+                McpServerStatus::Connecting => {
+                    format!("{} \u{00b7} connecting\u{2026}", info.transport_kind)
+                }
+                McpServerStatus::Running => {
+                    let mut parts = vec![info.transport_kind.to_string()];
+                    if info.tool_count > 0 {
+                        parts.push(format!("{} tools", info.tool_count));
+                    }
+                    if info.prompt_count > 0 {
+                        parts.push(format!("{} prompts", info.prompt_count));
+                    }
+                    if info.tool_count == 0 && info.prompt_count == 0 {
+                        parts.push("no capabilities".into());
+                    }
+                    parts.join(" \u{00b7} ")
+                }
+                McpServerStatus::Disabled => {
+                    format!("{} \u{00b7} disabled", info.transport_kind)
+                }
+                McpServerStatus::Failed(e) => {
+                    format!("{} \u{00b7} error: {}", info.transport_kind, e)
+                }
+                McpServerStatus::NeedsAuth { .. } => {
+                    format!("{} \u{00b7} needs auth", info.transport_kind)
+                }
+            },
+        })
+        .collect();
+    let enabled = infos.iter().map(|info| info.status.is_active()).collect();
+    (entries, enabled)
+}
 
 pub enum McpPickerAction {
     Consumed,
@@ -35,56 +73,37 @@ impl PickerItem for McpEntry {
 
 pub struct McpPicker {
     picker: ListPicker<McpEntry>,
-    infos: Arc<ArcSwap<Vec<McpServerInfo>>>,
+    snapshot: Arc<ArcSwap<McpSnapshot>>,
+    last_generation: u64,
 }
 
 impl McpPicker {
-    pub fn new(infos: Arc<ArcSwap<Vec<McpServerInfo>>>) -> Self {
+    pub fn new(snapshot: Arc<ArcSwap<McpSnapshot>>) -> Self {
         Self {
             picker: ListPicker::new(),
-            infos,
+            snapshot,
+            last_generation: 0,
         }
     }
 
     pub fn open(&mut self) {
-        let guard = self.infos.load();
-        let infos: &[McpServerInfo] = &guard;
-
-        let entries: Vec<McpEntry> = infos
-            .iter()
-            .map(|info| McpEntry {
-                name: info.name.clone(),
-                detail_text: match &info.status {
-                    McpServerStatus::Connecting => {
-                        format!("{} \u{00b7} connecting\u{2026}", info.transport_kind)
-                    }
-                    McpServerStatus::Running => {
-                        let mut parts = vec![info.transport_kind.to_string()];
-                        if info.tool_count > 0 {
-                            parts.push(format!("{} tools", info.tool_count));
-                        }
-                        if info.prompt_count > 0 {
-                            parts.push(format!("{} prompts", info.prompt_count));
-                        }
-                        if info.tool_count == 0 && info.prompt_count == 0 {
-                            parts.push("no capabilities".into());
-                        }
-                        parts.join(" \u{00b7} ")
-                    }
-                    McpServerStatus::Disabled => {
-                        format!("{} \u{00b7} disabled", info.transport_kind)
-                    }
-                    McpServerStatus::Failed(e) => {
-                        format!("{} \u{00b7} error: {}", info.transport_kind, e)
-                    }
-                    McpServerStatus::NeedsAuth { .. } => {
-                        format!("{} \u{00b7} needs auth", info.transport_kind)
-                    }
-                },
-            })
-            .collect();
-        let enabled: Vec<bool> = infos.iter().map(|info| info.status.is_active()).collect();
+        let guard = self.snapshot.load();
+        self.last_generation = guard.generation;
+        let (entries, enabled) = build_entries(&guard.infos);
         self.picker.open_toggleable(entries, enabled, TITLE);
+    }
+
+    pub fn refresh(&mut self) {
+        if !self.picker.is_open() {
+            return;
+        }
+        let guard = self.snapshot.load();
+        if guard.generation == self.last_generation {
+            return;
+        }
+        self.last_generation = guard.generation;
+        let (entries, enabled) = build_entries(&guard.infos);
+        self.picker.replace_toggleable(entries, enabled);
     }
 
     pub fn is_open(&self) -> bool {
@@ -138,32 +157,37 @@ mod tests {
     use std::path::PathBuf;
     use test_case::test_case;
 
-    fn test_infos() -> Arc<ArcSwap<Vec<McpServerInfo>>> {
-        Arc::new(ArcSwap::from_pointee(vec![
-            McpServerInfo {
-                name: "fs".into(),
-                transport_kind: "stdio",
-                tool_count: 5,
-                prompt_count: 0,
-                status: McpServerStatus::Running,
-                config_path: PathBuf::from("/home/.config/maki/config.toml"),
-                url: None,
-            },
-            McpServerInfo {
-                name: "github".into(),
-                transport_kind: "stdio",
-                tool_count: 3,
-                prompt_count: 0,
-                status: McpServerStatus::Disabled,
-                config_path: PathBuf::from("/project/.maki/config.toml"),
-                url: None,
-            },
-        ]))
+    fn test_snapshot() -> Arc<ArcSwap<McpSnapshot>> {
+        Arc::new(ArcSwap::from_pointee(McpSnapshot {
+            infos: vec![
+                McpServerInfo {
+                    name: "fs".into(),
+                    transport_kind: "stdio",
+                    tool_count: 5,
+                    prompt_count: 0,
+                    status: McpServerStatus::Running,
+                    config_path: PathBuf::from("/home/.config/maki/config.toml"),
+                    url: None,
+                },
+                McpServerInfo {
+                    name: "github".into(),
+                    transport_kind: "stdio",
+                    tool_count: 3,
+                    prompt_count: 0,
+                    status: McpServerStatus::Disabled,
+                    config_path: PathBuf::from("/project/.maki/config.toml"),
+                    url: None,
+                },
+            ],
+            prompts: vec![],
+            pids: vec![],
+            generation: 0,
+        }))
     }
 
     #[test]
     fn toggle_returns_server_name_and_new_state() {
-        let mut p = McpPicker::new(test_infos());
+        let mut p = McpPicker::new(test_snapshot());
         p.open();
         let action = p.handle_key(key(KeyCode::Enter));
         assert!(matches!(
@@ -175,7 +199,7 @@ mod tests {
     #[test_case(key(KeyCode::Esc)       ; "esc_closes")]
     #[test_case(kb::QUIT.to_key_event() ; "ctrl_c_closes")]
     fn close_keys(cancel_key: KeyEvent) {
-        let mut p = McpPicker::new(test_infos());
+        let mut p = McpPicker::new(test_snapshot());
         p.open();
         let action = p.handle_key(cancel_key);
         assert!(matches!(action, McpPickerAction::Close));
@@ -184,8 +208,13 @@ mod tests {
 
     #[test]
     fn open_with_empty_infos() {
-        let infos = Arc::new(ArcSwap::from_pointee(vec![]));
-        let mut p = McpPicker::new(infos);
+        let snap = Arc::new(ArcSwap::from_pointee(McpSnapshot {
+            infos: vec![],
+            prompts: vec![],
+            pids: vec![],
+            generation: 0,
+        }));
+        let mut p = McpPicker::new(snap);
         p.open();
         assert!(p.is_open());
     }

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -174,8 +174,7 @@ impl<'t> EventLoop<'t> {
             session,
             storage,
             bg.available,
-            Arc::clone(&mcp_state.infos),
-            Arc::clone(&mcp_state.prompts),
+            Arc::clone(&mcp_state.snapshot),
             Arc::clone(&storage_writer),
             ui_config,
             input_history_size,
@@ -241,6 +240,7 @@ impl<'t> EventLoop<'t> {
         self.app.poll_image_paste();
         self.app.btw_modal.poll();
         self.app.status_bar.poll_branch_update();
+        self.app.mcp_picker.refresh();
     }
 
     fn drain_channels(&mut self) -> bool {
@@ -455,14 +455,7 @@ impl<'t> EventLoop<'t> {
             .app
             .has_content()
             .then(|| self.app.state.session.id.clone());
-        maki_agent::mcp::kill_process_groups(
-            &self
-                .handles
-                .mcp
-                .pids
-                .lock()
-                .unwrap_or_else(|e| e.into_inner()),
-        );
+        maki_agent::mcp::kill_process_groups(&self.handles.mcp.snapshot.load().pids);
         self.app.cmd_tx = None;
         self.app.answer_tx = None;
         drop(self.app);

--- a/src/print.rs
+++ b/src/print.rs
@@ -20,10 +20,12 @@ use std::io::{self, Read};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use arc_swap::ArcSwap;
 use clap::ValueEnum;
 use color_eyre::Result;
 use color_eyre::eyre::Context;
-use maki_agent::mcp::McpManager;
+use maki_agent::mcp;
+use maki_agent::mcp::McpSnapshot;
 use maki_agent::skill::Skill;
 use maki_agent::tools::{DescriptionContext, QUESTION_TOOL_NAME, ToolCall, ToolFilter};
 use maki_agent::{
@@ -153,10 +155,16 @@ pub fn run(
     };
     let mut tools = ToolCall::definitions(&vars, &ctx, model.supports_tool_examples());
 
-    let mcp_manager = smol::block_on(McpManager::start(&cwd_path));
+    let mcp_snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot {
+        infos: vec![],
+        prompts: vec![],
+        pids: vec![],
+        generation: 0,
+    }));
+    let mcp_handle = smol::block_on(mcp::start(&cwd_path, vec![], mcp_snapshot));
 
-    if let Some(ref mcp) = mcp_manager {
-        mcp.extend_tools(&mut tools, &[]);
+    if let Some(ref handle) = mcp_handle {
+        handle.extend_tools(&mut tools);
     }
 
     let system = agent::build_system_prompt(&vars, &mode, &instructions.text);
@@ -214,7 +222,7 @@ pub fn run(
             },
         )
         .with_loaded_instructions(instructions.loaded)
-        .with_mcp(mcp_manager);
+        .with_mcp(mcp_handle);
         let outcome = agent.run(input).await;
         if let Err(e) = outcome.result {
             error!(error = %e, "agent error");


### PR DESCRIPTION
Enabling an MCP server from /mcp now connects to it and fetches fresh tools and prompts instead of unfiltering the stale in-memory cache. Disable + enable is now a reliable manual refresh flow.

Store ServerConfig in ServerEntry so any server can be reconnected. Add refresh_server() that tears down the old transport and calls start_server() for a fresh one. On enable the UI shows Connecting immediately while a background task does the actual work, then signals the agent loop to rebuild the tool list.