### PR TITLE
Fix `nix run` on macOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,13 +60,7 @@
                                  '#![doc = "Monty Python bridge."]'
               done
             '';
-            buildInputs =
-              with pkgs;
-              [ openssl ]
-              ++ lib.optionals stdenv.isDarwin [
-                darwin.apple_sdk.frameworks.AppKit
-                darwin.apple_sdk.frameworks.ApplicationServices
-              ];
+            buildInputs = with pkgs; [ openssl ];
             doCheck = false;
           };
         in


### PR DESCRIPTION
Closes https://github.com/tontinton/maki/issues/35

I did some further testing using a dynamic provider and it looks like everything works without the dependencies that are causing the evaluation failure