### PR TITLE
agent & ui: edit: store (before, after) snapshots, derive everything

### DIFF
--- a/maki-agent/src/diff.rs
+++ b/maki-agent/src/diff.rs
@@ -1,0 +1,157 @@
+//! Single source of truth for turning `(before, after)` file snapshots into
+//! structured hunks and unified text. `ToolOutput::Diff` only stores the two
+//! snapshots; display text, hunks, and syntax-aware rendering are all derived
+//! from them, so they cannot drift out of sync with what was written to disk.
+
+use std::fmt::Write;
+
+use serde::{Deserialize, Serialize};
+use similar::{ChangeTag, TextDiff};
+
+const CONTEXT_LINES: usize = 3;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DiffSpan {
+    pub text: String,
+    pub emphasized: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum DiffLine {
+    Unchanged(String),
+    Added(Vec<DiffSpan>),
+    Removed(Vec<DiffSpan>),
+}
+
+/// A contiguous group of changes plus surrounding context. `before_start` and
+/// `after_start` are 1-indexed and let the renderer position two highlighters
+/// (one walking `before`, one walking `after`) so removed lines are highlighted
+/// in the old file's parser state and added lines in the new file's.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DiffHunk {
+    pub before_start: usize,
+    pub after_start: usize,
+    pub lines: Vec<DiffLine>,
+}
+
+pub fn compute_hunks(before: &str, after: &str) -> Vec<DiffHunk> {
+    let diff = TextDiff::from_lines(before, after);
+    let mut hunks = Vec::new();
+
+    for group in diff.grouped_ops(CONTEXT_LINES) {
+        let Some(first) = group.first() else { continue };
+        let before_start = first.old_range().start + 1;
+        let after_start = first.new_range().start + 1;
+        let mut lines = Vec::new();
+
+        for op in &group {
+            for change in diff.iter_inline_changes(op) {
+                let spans: Vec<DiffSpan> = change
+                    .iter_strings_lossy()
+                    .map(|(emphasized, text)| DiffSpan {
+                        text: text.trim_end_matches('\n').to_owned(),
+                        emphasized,
+                    })
+                    .collect();
+                lines.push(match change.tag() {
+                    ChangeTag::Equal => {
+                        DiffLine::Unchanged(spans.into_iter().map(|s| s.text).collect())
+                    }
+                    ChangeTag::Delete => DiffLine::Removed(spans),
+                    ChangeTag::Insert => DiffLine::Added(spans),
+                });
+            }
+        }
+
+        hunks.push(DiffHunk {
+            before_start,
+            after_start,
+            lines,
+        });
+    }
+
+    hunks
+}
+
+pub fn unified_text(before: &str, after: &str, summary: &str, display_path: &str) -> String {
+    let mut out = format!("{summary}\n--- {display_path}\n+++ {display_path}");
+    let write_change = |out: &mut String, prefix: &str, spans: &[DiffSpan]| {
+        let _ = write!(out, "\n{prefix}");
+        for s in spans {
+            out.push_str(&s.text);
+        }
+    };
+    for hunk in compute_hunks(before, after) {
+        out.push('\n');
+        for dl in &hunk.lines {
+            match dl {
+                DiffLine::Unchanged(t) => {
+                    let _ = write!(out, "\n  {t}");
+                }
+                DiffLine::Removed(spans) => write_change(&mut out, "- ", spans),
+                DiffLine::Added(spans) => write_change(&mut out, "+ ", spans),
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn line_text(line: &DiffLine) -> String {
+        match line {
+            DiffLine::Unchanged(s) => s.clone(),
+            DiffLine::Added(spans) | DiffLine::Removed(spans) => {
+                spans.iter().map(|s| s.text.as_str()).collect()
+            }
+        }
+    }
+
+    #[test]
+    fn hunk_starts_are_one_indexed_and_lines_have_no_trailing_newline() {
+        let before = "a\nb\nc\nd\nOLD\nf\ng\nh\ni\n";
+        let after = "a\nb\nc\nd\nNEW\nf\ng\nh\ni\n";
+        let hunks = compute_hunks(before, after);
+        assert_eq!(hunks.len(), 1);
+        assert_eq!((hunks[0].before_start, hunks[0].after_start), (2, 2));
+        assert!(hunks[0].lines.iter().all(|l| !line_text(l).contains('\n')));
+    }
+
+    #[test]
+    fn no_change_returns_empty() {
+        let s = "a\nb\nc\n";
+        assert!(compute_hunks(s, s).is_empty());
+    }
+
+    /// When an earlier insertion shifts subsequent line numbers, a later
+    /// hunk's `after_start` must reflect the post-insertion line, not the
+    /// original. The renderer relies on this to keep its AFTER walker aligned
+    /// with the actual file coordinates. The two changes are placed far apart
+    /// so they always land in distinct grouped hunks.
+    #[test]
+    fn after_start_tracks_post_insertion_line_numbers() {
+        let mut before: Vec<String> = (1..=40).map(|i| i.to_string()).collect();
+        let mut after = before.clone();
+        after.insert(1, "INS".into());
+        before[35] = "OLD".into();
+        after[36] = "NEW".into();
+        let hunks = compute_hunks(&before.join("\n"), &after.join("\n"));
+        let last = hunks.last().expect("at least one hunk");
+        assert_eq!(last.after_start, last.before_start + 1);
+    }
+
+    #[test]
+    fn unified_text_renders_summary_header_and_all_line_kinds() {
+        let before = "keep\nold\n";
+        let after = "keep\nnew\n";
+        let text = unified_text(before, after, "Edited foo", "src/main.rs");
+        assert!(text.starts_with("Edited foo"));
+        assert!(text.contains("--- src/main.rs"));
+        assert!(text.contains("+++ src/main.rs"));
+        assert!(text.contains("  keep"));
+        assert!(text.contains("- old"));
+        assert!(text.contains("+ new"));
+    }
+}

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -19,6 +19,7 @@ pub use agent::{
 pub use cancel::{CancelToken, CancelTrigger};
 pub use maki_config::{AgentConfig, PermissionsConfig, UiConfig};
 pub mod command;
+pub mod diff;
 pub mod permissions;
 pub(crate) mod prompt;
 pub mod skill;
@@ -34,11 +35,10 @@ pub use maki_providers::AgentError;
 use maki_providers::Message;
 pub use maki_providers::{ImageMediaType, ImageSource, ThinkingConfig};
 pub use types::{
-    AgentEvent, BatchProgressEvent, BatchToolEntry, BatchToolStatus, DiffHunk, DiffLine, DiffSpan,
-    Envelope, EventSender, GrepFileEntry, GrepLine, GrepMatchGroup, InstructionBlock,
-    NO_FILES_FOUND, QuestionAnswer, QuestionInfo, QuestionOption, SubagentInfo, TodoItem,
-    TodoPriority, TodoStatus, ToolDoneEvent, ToolInput, ToolOutput, ToolStartEvent,
-    TurnCompleteEvent,
+    AgentEvent, BatchProgressEvent, BatchToolEntry, BatchToolStatus, Envelope, EventSender,
+    GrepFileEntry, GrepLine, GrepMatchGroup, InstructionBlock, NO_FILES_FOUND, QuestionAnswer,
+    QuestionInfo, QuestionOption, SubagentInfo, TodoItem, TodoPriority, TodoStatus, ToolDoneEvent,
+    ToolInput, ToolOutput, ToolStartEvent, TurnCompleteEvent,
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]

--- a/maki-agent/src/tools/edit.rs
+++ b/maki-agent/src/tools/edit.rs
@@ -4,8 +4,7 @@ use crate::ToolOutput;
 use maki_tool_macro::Tool;
 
 use super::fuzzy_replace;
-use super::multiedit::build_hunk;
-use super::{line_at_offset, relative_path};
+use super::relative_path;
 
 #[derive(Tool, Debug, Clone)]
 pub struct Edit {
@@ -29,35 +28,21 @@ impl Edit {
 ]"#,
     );
 
-    fn diff_output(&self, resolved_path: &str, lines: &[usize]) -> ToolOutput {
-        let rel = relative_path(resolved_path);
-        let hunks = lines
-            .iter()
-            .map(|&line| build_hunk(line, &self.old_string, &self.new_string))
-            .collect();
-        ToolOutput::Diff {
-            hunks,
-            summary: format!("edited {rel}"),
-            path: resolved_path.to_owned(),
-        }
-    }
-
     pub async fn execute(&self, _ctx: &super::ToolContext) -> Result<ToolOutput, String> {
         let path = super::resolve_path(&self.path)?;
         let old_string = self.old_string.clone();
         let new_string = self.new_string.clone();
         let replace_all = self.replace_all.unwrap_or(false);
-        let diff_self = self.clone();
         smol::unblock(move || {
-            let content = fs::read_to_string(&path).map_err(|e| format!("read error: {e}"))?;
-            let result = fuzzy_replace::replace(&content, &old_string, &new_string, replace_all)?;
-            fs::write(&path, &result.content).map_err(|e| format!("write error: {e}"))?;
-            let lines: Vec<usize> = result
-                .match_offsets
-                .iter()
-                .map(|&off| line_at_offset(&content, off))
-                .collect();
-            Ok(diff_self.diff_output(&path, &lines))
+            let before = fs::read_to_string(&path).map_err(|e| format!("read error: {e}"))?;
+            let after = fuzzy_replace::replace(&before, &old_string, &new_string, replace_all)?;
+            fs::write(&path, &after).map_err(|e| format!("write error: {e}"))?;
+            Ok(ToolOutput::Diff {
+                summary: format!("edited {}", relative_path(&path)),
+                path,
+                before,
+                after,
+            })
         })
         .await
     }
@@ -68,11 +53,6 @@ impl Edit {
 }
 
 impl super::ToolDefaults for Edit {
-    fn start_output(&self) -> Option<ToolOutput> {
-        let path = super::resolve_path(&self.path).ok()?;
-        Some(self.diff_output(&path, &[1]))
-    }
-
     fn mutable_path(&self) -> Option<&str> {
         Some(&self.path)
     }
@@ -84,6 +64,8 @@ impl super::ToolDefaults for Edit {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use tempfile::TempDir;
 
     use crate::AgentMode;
@@ -132,6 +114,37 @@ mod tests {
                 fs::read_to_string(&path).unwrap(),
                 "let x = 9;\nlet x = 9;\nlet y = 2;"
             );
+        });
+    }
+
+    /// Regression: when `old_string` contains a literal `\n` it is unescaped
+    /// before writing, so the Diff snapshots must be the post-unescape file
+    /// content, not the raw single-line input. This is the structural
+    /// guarantee that prevents the old "diff full of `\n` escapes" bug.
+    #[test]
+    fn diff_snapshots_are_real_file_content_not_raw_input() {
+        smol::block_on(async {
+            let dir = TempDir::new().unwrap();
+            let ctx = stub_ctx(&AgentMode::Build);
+            let original = "const A: u8 = 1;\nconst B: u8 = 2;\n";
+            let updated = "const A: u8 = 9;\nconst B: u8 = 2;\n";
+            let path = temp_file(&dir, "f.rs", original);
+            let output = Edit {
+                path: path.clone(),
+                old_string: "const A: u8 = 1;\\nconst B: u8 = 2;".into(),
+                new_string: "const A: u8 = 9;\\nconst B: u8 = 2;".into(),
+                replace_all: None,
+            }
+            .execute(&ctx)
+            .await
+            .unwrap();
+
+            let ToolOutput::Diff { before, after, .. } = output else {
+                panic!("expected Diff output");
+            };
+            assert_eq!(before, original);
+            assert_eq!(after, updated);
+            assert_eq!(fs::read_to_string(&path).unwrap(), updated);
         });
     }
 }

--- a/maki-agent/src/tools/fuzzy_replace.rs
+++ b/maki-agent/src/tools/fuzzy_replace.rs
@@ -11,18 +11,12 @@ const CONTEXT_AWARE_MATCH_RATIO: f64 = 0.5;
 
 type Replacer = fn(&str, &str) -> Vec<String>;
 
-#[derive(Debug)]
-pub(super) struct ReplaceResult {
-    pub content: String,
-    pub match_offsets: Vec<usize>,
-}
-
 pub(super) fn replace(
     content: &str,
     old_string: &str,
     new_string: &str,
     replace_all: bool,
-) -> Result<ReplaceResult, String> {
+) -> Result<String, String> {
     const REPLACERS: &[Replacer] = &[
         exact,
         line_trimmed,
@@ -34,7 +28,7 @@ pub(super) fn replace(
 
     let mut any_found = false;
 
-    let mut try_match = |candidates: Vec<String>, replacement: &str| -> Option<ReplaceResult> {
+    let mut try_match = |candidates: Vec<String>, replacement: &str| -> Option<String> {
         for matched in candidates {
             let Some(first) = content.find(&*matched) else {
                 continue;
@@ -42,11 +36,7 @@ pub(super) fn replace(
             any_found = true;
 
             if replace_all {
-                let offsets = all_offsets(content, &matched);
-                return Some(ReplaceResult {
-                    content: content.replace(&*matched, replacement),
-                    match_offsets: offsets,
-                });
+                return Some(content.replace(&*matched, replacement));
             }
 
             if content[first + matched.len()..].contains(&*matched) {
@@ -57,10 +47,7 @@ pub(super) fn replace(
             result.push_str(&content[..first]);
             result.push_str(replacement);
             result.push_str(&content[first + matched.len()..]);
-            return Some(ReplaceResult {
-                content: result,
-                match_offsets: vec![first],
-            });
+            return Some(result);
         }
         None
     };
@@ -424,16 +411,6 @@ fn substring_whitespace_match(line: &str, normalized_find: &str) -> Option<Strin
     re.find(line).map(|m| m.as_str().to_string())
 }
 
-fn all_offsets(content: &str, needle: &str) -> Vec<usize> {
-    let mut offsets = Vec::new();
-    let mut start = 0;
-    while let Some(pos) = content[start..].find(needle) {
-        offsets.push(start + pos);
-        start += pos + needle.len();
-    }
-    offsets
-}
-
 fn unescape(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
     let mut chars = s.chars();
@@ -483,7 +460,6 @@ mod tests {
         assert!(
             replace(content, search, replacement, false)
                 .unwrap()
-                .content
                 .contains(R)
         );
     }
@@ -501,15 +477,15 @@ mod tests {
     fn block_anchor_picks_best_among_multiple() {
         let content = "fn a() {\n    unrelated();\n}\nfn a() {\n    target();\n}";
         let result = replace(content, "fn a() {\n    target();\n}", R, false).unwrap();
-        assert!(result.content.contains(R));
-        assert!(result.content.contains("unrelated()"));
+        assert!(result.contains(R));
+        assert!(result.contains("unrelated()"));
     }
 
     #[test]
     fn leading_whitespace_disambiguates() {
         let result = replace("fn foo() {}\n  fn foo() {}", "  fn foo() {}", R, false).unwrap();
-        assert!(result.content.starts_with("fn foo() {}"));
-        assert!(result.content.ends_with(R));
+        assert!(result.starts_with("fn foo() {}"));
+        assert!(result.ends_with(R));
     }
 
     #[test]
@@ -546,7 +522,7 @@ mod tests {
         let old = r#"print(\"hello\")"#;
         let new = r#"print(\"world\")"#;
         let result = replace(content, old, new, false).unwrap();
-        assert_eq!(result.content, r#"print("world")"#);
+        assert_eq!(result, r#"print("world")"#);
     }
 
     #[test]
@@ -555,16 +531,12 @@ mod tests {
         let old = r#"say(\"a\")"#;
         let new = r#"say(\"x\")"#;
         let result = replace(content, old, new, true).unwrap();
-        assert_eq!(result.content, "say(\"x\")\nsay(\"b\")");
+        assert_eq!(result, "say(\"x\")\nsay(\"b\")");
     }
 
     #[test]
-    fn replace_returns_match_offsets() {
-        let exact = replace("let x = 1;", "let x = 1;", "let x = 2;", false).unwrap();
-        assert_eq!(exact.match_offsets, vec![0]);
-
+    fn replace_all_replaces_every_occurrence() {
         let all = replace("aXbXc", "X", "Y", true).unwrap();
-        assert_eq!(all.content, "aYbYc");
-        assert_eq!(all.match_offsets, vec![1, 3]);
+        assert_eq!(all, "aYbYc");
     }
 }

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -280,10 +280,6 @@ pub(crate) fn resolve_search_path(path: Option<&str>) -> Result<String, String> 
     }
 }
 
-pub(crate) fn line_at_offset(content: &str, offset: usize) -> usize {
-    content[..offset].matches('\n').count() + 1
-}
-
 static CWD: LazyLock<Option<PathBuf>> = LazyLock::new(|| env::current_dir().ok());
 static HOME: LazyLock<Option<PathBuf>> = LazyLock::new(dirs::home_dir);
 

--- a/maki-agent/src/tools/multiedit.rs
+++ b/maki-agent/src/tools/multiedit.rs
@@ -1,13 +1,12 @@
 use std::fs;
 
-use crate::{DiffHunk, DiffLine, DiffSpan, ToolOutput};
+use crate::ToolOutput;
 use serde::Deserialize;
-use similar::ChangeTag;
 
 use maki_tool_macro::{Args, Tool};
 
 use super::fuzzy_replace;
-use super::{line_at_offset, relative_path};
+use super::relative_path;
 
 #[derive(Args, Debug, Clone, Deserialize)]
 struct EditEntry {
@@ -43,39 +42,39 @@ impl MultiEdit {
         format!("{n} edit{s}")
     }
 
+    fn apply_edits(&self, before: &str) -> Result<String, String> {
+        if self.edits.is_empty() {
+            return Err("provide at least one edit".into());
+        }
+        let mut content = before.to_owned();
+        for (i, edit) in self.edits.iter().enumerate() {
+            content = fuzzy_replace::replace(
+                &content,
+                &edit.old_string,
+                &edit.new_string,
+                edit.replace_all.unwrap_or(false),
+            )
+            .map_err(|e| format!("edit {i}: {e}"))?;
+        }
+        Ok(content)
+    }
+
     pub async fn execute(&self, _ctx: &super::ToolContext) -> Result<ToolOutput, String> {
         let path = super::resolve_path(&self.path)?;
-        let edits = self.edits.clone();
-        let edit_count_label = self.edit_count_label();
+        let this = self.clone();
         smol::unblock(move || {
-            if edits.is_empty() {
-                return Err("provide at least one edit".into());
-            }
-            let mut content = fs::read_to_string(&path).map_err(|e| format!("read error: {e}"))?;
-
-            let mut hunks = Vec::with_capacity(edits.len());
-            for (i, edit) in edits.iter().enumerate() {
-                let replace_all = edit.replace_all.unwrap_or(false);
-                let result = fuzzy_replace::replace(
-                    &content,
-                    &edit.old_string,
-                    &edit.new_string,
-                    replace_all,
-                )
-                .map_err(|e| format!("edit {i}: {e}"))?;
-                for &off in &result.match_offsets {
-                    let line = line_at_offset(&content, off);
-                    hunks.push(build_hunk(line, &edit.old_string, &edit.new_string));
-                }
-                content = result.content;
-            }
-
-            fs::write(&path, &content).map_err(|e| format!("write error: {e}"))?;
-            let rel = relative_path(&path);
+            let before = fs::read_to_string(&path).map_err(|e| format!("read error: {e}"))?;
+            let after = this.apply_edits(&before)?;
+            fs::write(&path, &after).map_err(|e| format!("write error: {e}"))?;
             Ok(ToolOutput::Diff {
-                hunks,
-                summary: format!("applied {edit_count_label} to {rel}"),
+                summary: format!(
+                    "applied {} to {}",
+                    this.edit_count_label(),
+                    relative_path(&path)
+                ),
                 path,
+                before,
+                after,
             })
         })
         .await
@@ -87,21 +86,6 @@ impl MultiEdit {
 }
 
 impl super::ToolDefaults for MultiEdit {
-    fn start_output(&self) -> Option<ToolOutput> {
-        let hunks: Vec<DiffHunk> = self
-            .edits
-            .iter()
-            .map(|e| build_hunk(1, &e.old_string, &e.new_string))
-            .collect();
-        let path = super::resolve_path(&self.path).ok()?;
-        let rel = relative_path(&path);
-        Some(ToolOutput::Diff {
-            hunks,
-            summary: format!("applied {} to {rel}", self.edit_count_label()),
-            path,
-        })
-    }
-
     fn start_annotation(&self) -> Option<String> {
         Some(self.edit_count_label())
     }
@@ -113,38 +97,6 @@ impl super::ToolDefaults for MultiEdit {
     fn permission(&self) -> Option<String> {
         Some(crate::permissions::canonicalize_scope_path(&self.path))
     }
-}
-pub(super) fn build_hunk(start_line: usize, old: &str, new: &str) -> DiffHunk {
-    let diff = similar::TextDiff::from_lines(old, new);
-    let mut lines = Vec::new();
-    for op in diff.ops() {
-        for change in diff.iter_inline_changes(op) {
-            match change.tag() {
-                ChangeTag::Equal => {
-                    let text: String = change
-                        .iter_strings_lossy()
-                        .map(|(_, t)| t.trim_end_matches('\n').to_owned())
-                        .collect();
-                    lines.push(DiffLine::Unchanged(text));
-                }
-                tag => {
-                    let spans: Vec<DiffSpan> = change
-                        .iter_strings_lossy()
-                        .map(|(emphasized, text)| DiffSpan {
-                            text: text.trim_end_matches('\n').to_owned(),
-                            emphasized,
-                        })
-                        .collect();
-                    if tag == ChangeTag::Delete {
-                        lines.push(DiffLine::Removed(spans));
-                    } else {
-                        lines.push(DiffLine::Added(spans));
-                    }
-                }
-            }
-        }
-    }
-    DiffHunk { start_line, lines }
 }
 
 #[cfg(test)]
@@ -223,25 +175,6 @@ mod tests {
             let tool = MultiEdit::parse_input(&json!({ "path": path, "edits": [] })).unwrap();
             assert_eq!(tool.execute(&ctx).await.unwrap_err(), EMPTY_ERR);
         });
-    }
-
-    fn tags(hunk: &DiffHunk) -> Vec<char> {
-        hunk.lines
-            .iter()
-            .map(|l| match l {
-                DiffLine::Unchanged(_) => '=',
-                DiffLine::Removed(_) => '-',
-                DiffLine::Added(_) => '+',
-            })
-            .collect()
-    }
-
-    #[test_case(1, "keep\n",  "keep\nadded", &['=', '+']           ; "append")]
-    #[test_case(5, "a\nb\nc", "a\nB\nc",     &['=', '-', '+', '='] ; "middle_change")]
-    fn build_hunk_tags(line: usize, old: &str, new: &str, expected: &[char]) {
-        let hunk = build_hunk(line, old, new);
-        assert_eq!(hunk.start_line, line);
-        assert_eq!(tags(&hunk), expected);
     }
 
     #[test]

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -8,34 +8,6 @@ use serde::{Deserialize, Serialize};
 
 pub const NO_FILES_FOUND: &str = "No files found";
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct DiffSpan {
-    pub text: String,
-    pub emphasized: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum DiffLine {
-    Unchanged(String),
-    Added(Vec<DiffSpan>),
-    Removed(Vec<DiffSpan>),
-}
-
-impl DiffSpan {
-    pub fn plain(text: String) -> Self {
-        Self {
-            text,
-            emphasized: false,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DiffHunk {
-    pub start_line: usize,
-    pub lines: Vec<DiffLine>,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GrepFileEntry {
     pub path: String,
@@ -216,7 +188,8 @@ pub enum ToolOutput {
     },
     Diff {
         path: String,
-        hunks: Vec<DiffHunk>,
+        before: String,
+        after: String,
         summary: String,
     },
     TodoList(Vec<TodoItem>),
@@ -347,35 +320,15 @@ impl ToolOutput {
             }
             Self::Diff {
                 path,
-                hunks,
+                before,
+                after,
                 summary,
-            } => {
-                let display = crate::tools::relative_path(path);
-                let mut out = format!("{summary}\n--- {display}\n+++ {display}");
-                for hunk in hunks {
-                    out.push('\n');
-                    for dl in &hunk.lines {
-                        match dl {
-                            DiffLine::Unchanged(t) => {
-                                let _ = write!(out, "\n  {t}");
-                            }
-                            DiffLine::Removed(spans) | DiffLine::Added(spans) => {
-                                let prefix = if matches!(dl, DiffLine::Removed(_)) {
-                                    "- "
-                                } else {
-                                    "+ "
-                                };
-
-                                let _ = write!(out, "\n{prefix}");
-                                for s in spans {
-                                    out.push_str(&s.text);
-                                }
-                            }
-                        }
-                    }
-                }
-                out
-            }
+            } => crate::diff::unified_text(
+                before,
+                after,
+                summary,
+                &crate::tools::relative_path(path),
+            ),
             Self::TodoList(items) => {
                 if items.is_empty() {
                     return "No todos.".into();
@@ -638,26 +591,11 @@ mod tests {
     use test_case::test_case;
 
     #[test]
-    fn as_display_text_diff_covers_all_line_types_and_multiple_hunks() {
+    fn as_display_text_diff_renders_unified_text() {
         let output = ToolOutput::Diff {
             path: "src/main.rs".into(),
-            hunks: vec![
-                DiffHunk {
-                    start_line: 1,
-                    lines: vec![
-                        DiffLine::Unchanged("keep".into()),
-                        DiffLine::Removed(vec![DiffSpan::plain("old".into())]),
-                        DiffLine::Added(vec![DiffSpan::plain("new".into())]),
-                    ],
-                },
-                DiffHunk {
-                    start_line: 10,
-                    lines: vec![
-                        DiffLine::Removed(vec![DiffSpan::plain("c".into())]),
-                        DiffLine::Added(vec![DiffSpan::plain("d".into())]),
-                    ],
-                },
-            ],
+            before: "keep\nold\n".into(),
+            after: "keep\nnew\n".into(),
             summary: "Updated value".into(),
         };
         let display = output.as_display_text();
@@ -667,8 +605,6 @@ mod tests {
         assert!(display.contains("  keep"));
         assert!(display.contains("- old"));
         assert!(display.contains("+ new"));
-        assert!(display.contains("- c"));
-        assert!(display.contains("+ d"));
         assert_eq!(output.as_text(), "Updated value");
     }
 
@@ -762,7 +698,7 @@ mod tests {
     }
 
     #[test_case(ToolOutput::WriteCode { path: "src/lib.rs".into(), byte_count: 10, lines: vec![] }, Some("src/lib.rs") ; "write_code")]
-    #[test_case(ToolOutput::Diff { path: "src/lib.rs".into(), hunks: vec![], summary: String::new() }, Some("src/lib.rs") ; "diff")]
+    #[test_case(ToolOutput::Diff { path: "src/lib.rs".into(), before: String::new(), after: String::new(), summary: String::new() }, Some("src/lib.rs") ; "diff")]
     #[test_case(ToolOutput::Plain("ok".into()), None ; "non_write_variant")]
     fn output_written_path(output: ToolOutput, expected: Option<&str>) {
         assert_eq!(output.written_path(), expected);

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -219,7 +219,7 @@ fn toggle_mode_state_machine() {
 }
 
 #[test_case(ToolOutput::WriteCode { path: "/tmp/plans/test.md".into(), byte_count: 100, lines: vec![] }, true  ; "write_matching")]
-#[test_case(ToolOutput::Diff { path: "/tmp/plans/test.md".into(), hunks: vec![], summary: String::new() }, true  ; "edit_matching")]
+#[test_case(ToolOutput::Diff { path: "/tmp/plans/test.md".into(), before: String::new(), after: String::new(), summary: String::new() }, true  ; "edit_matching")]
 #[test_case(ToolOutput::WriteCode { path: "/tmp/other.rs".into(), byte_count: 100, lines: vec![] }, false ; "write_non_matching")]
 fn tool_done_sets_plan_written_flag(output: ToolOutput, expect_written: bool) {
     let mut app = test_app();

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -472,8 +472,8 @@ fn build_tool_results_map(messages: &[Message]) -> HashMap<&str, (bool, &str)> {
 mod tests {
     use super::*;
     use maki_agent::{
-        AgentEvent, BatchToolEntry, BatchToolStatus, DiffHunk, DiffLine, DiffSpan, ToolDoneEvent,
-        ToolInput, ToolOutput, ToolStartEvent,
+        AgentEvent, BatchToolEntry, BatchToolStatus, ToolDoneEvent, ToolInput, ToolOutput,
+        ToolStartEvent,
     };
     use maki_config::UiConfig;
     use test_case::test_case;
@@ -509,7 +509,8 @@ mod tests {
     fn edit_output(path: &str) -> ToolOutput {
         ToolOutput::Diff {
             path: path.into(),
-            hunks: vec![],
+            before: String::new(),
+            after: String::new(),
             summary: String::new(),
         }
     }
@@ -688,13 +689,8 @@ mod tests {
                 serde_json::json!({"path": "a", "old_string": "x", "new_string": "y"}),
                 ToolOutput::Diff {
                     path: "a".into(),
-                    hunks: vec![DiffHunk {
-                        start_line: 1,
-                        lines: vec![
-                            DiffLine::Removed(vec![DiffSpan::plain("x".into())]),
-                            DiffLine::Added(vec![DiffSpan::plain("y".into())]),
-                        ],
-                    }],
+                    before: "x\n".into(),
+                    after: "y\n".into(),
                     summary: "edited a".into(),
                 },
             ),

--- a/maki-ui/src/components/code_view.rs
+++ b/maki-ui/src/components/code_view.rs
@@ -5,11 +5,11 @@ use crate::highlight::{
 use crate::markdown::{should_truncate, truncation_notice};
 use crate::theme;
 
-use maki_agent::{
-    DiffHunk, DiffLine, DiffSpan, GrepFileEntry, InstructionBlock, ToolInput, ToolOutput,
-};
+use maki_agent::diff::{DiffLine, DiffSpan, compute_hunks};
+use maki_agent::{GrepFileEntry, InstructionBlock, ToolInput, ToolOutput};
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
+use std::str::Lines;
 use syntect::easy::HighlightLines;
 
 const MAX_CODE_EXECUTION_LINES: usize = 100;
@@ -99,28 +99,70 @@ fn render_code(
     (lines, has_truncation)
 }
 
-fn render_diff(path: Option<&str>, hunks: &[DiffHunk]) -> Vec<Line<'static>> {
-    let max_line_nr = hunks
+/// Walks one file with a syntect highlighter so the parser state at each line
+/// reflects everything seen since the start. Two walkers (one over BEFORE, one
+/// over AFTER) let removed lines be styled in the old file's parser state and
+/// added lines in the new file's.
+struct FileWalker<'a> {
+    lines: Lines<'a>,
+    pos: usize,
+    hl: Option<HighlightLines<'static>>,
+    buf: String,
+}
+
+impl<'a> FileWalker<'a> {
+    fn new(content: &'a str, hl: Option<HighlightLines<'static>>) -> Self {
+        Self {
+            lines: content.lines(),
+            pos: 1,
+            hl,
+            buf: String::new(),
+        }
+    }
+
+    fn skip_to(&mut self, target: usize) {
+        while self.pos < target {
+            let _ = self.step();
+        }
+    }
+
+    fn step(&mut self) -> Option<Vec<(Style, String)>> {
+        let line = self.lines.next().unwrap_or("");
+        let result = self.hl.as_mut().map(|hl| {
+            self.buf.clear();
+            self.buf.push_str(line);
+            self.buf.push('\n');
+            highlight_line(hl, &self.buf)
+        });
+        self.pos += 1;
+        result
+    }
+}
+
+fn render_diff(path: Option<&str>, before: &str, after: &str) -> Vec<Line<'static>> {
+    let hunks = compute_hunks(before, after);
+    let Some(last) = hunks.last() else {
+        return Vec::new();
+    };
+    let numbered = last
+        .lines
         .iter()
-        .map(|h| {
-            let numbered = h
-                .lines
-                .iter()
-                .filter(|l| !matches!(l, DiffLine::Added(_)))
-                .count();
-            h.start_line + numbered.saturating_sub(1)
-        })
-        .max()
-        .unwrap_or(1);
-    let w = nr_width(max_line_nr);
+        .filter(|l| !matches!(l, DiffLine::Added(_)))
+        .count();
+    let w = nr_width(last.before_start + numbered.saturating_sub(1));
+
+    let mut before_walker = FileWalker::new(before, path.map(highlighter_for_path));
+    let mut after_walker = FileWalker::new(after, path.map(highlighter_for_path));
 
     let mut lines = Vec::new();
     for (i, hunk) in hunks.iter().enumerate() {
         if i > 0 {
             lines.push(gap_ellipsis());
         }
-        let mut hl = path.map(highlighter_for_path);
-        let mut line_nr = hunk.start_line;
+        before_walker.skip_to(hunk.before_start);
+        after_walker.skip_to(hunk.after_start);
+
+        let mut line_nr = hunk.before_start;
         for dl in &hunk.lines {
             let show_nr = !matches!(dl, DiffLine::Added(_));
             let nr_str = if show_nr {
@@ -133,45 +175,63 @@ fn render_diff(path: Option<&str>, hunks: &[DiffHunk]) -> Vec<Line<'static>> {
             let mut spans = vec![gutter(&nr_str)];
             match dl {
                 DiffLine::Unchanged(t) => {
+                    let _ = before_walker.step();
                     spans.push(Span::raw("  ".to_owned()));
-                    spans.extend(code_spans(&mut hl, t));
+                    spans.extend(syntax_to_spans(after_walker.step(), t));
                 }
-                DiffLine::Removed(ds) | DiffLine::Added(ds) => {
-                    let is_add = matches!(dl, DiffLine::Added(_));
-                    let (prefix, base, emph) = if is_add {
-                        (
-                            "+ ",
-                            theme::current().diff_new,
-                            theme::current().diff_new_emphasis,
-                        )
-                    } else {
-                        (
-                            "- ",
-                            theme::current().diff_old,
-                            theme::current().diff_old_emphasis,
-                        )
-                    };
-                    spans.push(Span::styled(
-                        prefix,
-                        base.patch(theme::current().code_fallback),
-                    ));
-                    let full: String = ds.iter().map(|s| s.text.as_str()).collect();
-                    if let Some(ref mut h) = hl {
-                        let with_nl = format!("{full}\n");
-                        let syn = highlight_line(h, &with_nl);
-                        spans.extend(merge_syntax_with_diff(&syn, ds, base, emph));
-                    } else {
-                        spans.push(Span::styled(
-                            crate::highlight::normalize_text(&full),
-                            base.patch(theme::current().code_fallback),
-                        ));
-                    }
-                }
+                DiffLine::Removed(ds) => spans.extend(diff_change_spans(
+                    "- ",
+                    ds,
+                    before_walker.step(),
+                    theme::current().diff_old,
+                    theme::current().diff_old_emphasis,
+                )),
+                DiffLine::Added(ds) => spans.extend(diff_change_spans(
+                    "+ ",
+                    ds,
+                    after_walker.step(),
+                    theme::current().diff_new,
+                    theme::current().diff_new_emphasis,
+                )),
             }
             lines.push(Line::from(spans));
         }
     }
     lines
+}
+
+fn syntax_to_spans(syntax: Option<Vec<(Style, String)>>, text: &str) -> Vec<Span<'static>> {
+    match syntax {
+        Some(s) => s
+            .into_iter()
+            .map(|(style, chunk)| Span::styled(chunk, style))
+            .collect(),
+        None => vec![fallback_span(text)],
+    }
+}
+
+fn diff_change_spans(
+    prefix: &'static str,
+    ds: &[DiffSpan],
+    syntax: Option<Vec<(Style, String)>>,
+    base: Style,
+    emph: Style,
+) -> Vec<Span<'static>> {
+    let mut spans = vec![Span::styled(
+        prefix,
+        base.patch(theme::current().code_fallback),
+    )];
+    match syntax {
+        Some(syn) => spans.extend(merge_syntax_with_diff(&syn, ds, base, emph)),
+        None => {
+            let full: String = ds.iter().map(|s| s.text.as_str()).collect();
+            spans.push(Span::styled(
+                crate::highlight::normalize_text(&full),
+                base.patch(theme::current().code_fallback),
+            ));
+        }
+    }
+    spans
 }
 
 fn render_grep_results(
@@ -375,8 +435,13 @@ pub fn render_tool_content(
             code_lines.len(),
             max_lines,
         ),
-        Some(ToolOutput::Diff { path, hunks, .. }) => (
-            render_diff(highlight.then_some(path.as_str()), hunks),
+        Some(ToolOutput::Diff {
+            path,
+            before,
+            after,
+            ..
+        }) => (
+            render_diff(highlight.then_some(path.as_str()), before, after),
             false,
         ),
         Some(ToolOutput::GrepResult { entries }) => {
@@ -462,8 +527,15 @@ fn merge_syntax_with_diff(
 mod tests {
     use super::*;
     use crate::markdown::TRUNCATION_PREFIX;
-    use maki_agent::{DiffSpan, GrepLine, GrepMatchGroup};
+    use maki_agent::{GrepLine, GrepMatchGroup};
     use test_case::test_case;
+
+    fn plain(text: &str) -> DiffSpan {
+        DiffSpan {
+            text: text.into(),
+            emphasized: false,
+        }
+    }
 
     use ratatui::style::Color;
 
@@ -485,13 +557,70 @@ mod tests {
         assert_eq!(result.len(), expected);
     }
 
+    fn diff_fg(lines: &[Line<'static>], substr: &str) -> ratatui::style::Color {
+        lines
+            .iter()
+            .find_map(|l| {
+                l.spans
+                    .iter()
+                    .find(|s| s.content.contains(substr))
+                    .and_then(|s| s.style.fg)
+            })
+            .unwrap_or_else(|| panic!("no fg-styled span containing {substr:?}"))
+    }
+
+    /// Reference color: highlight `text` as part of `prefix` and return the fg
+    /// for the substring `find`. This is the "ground truth" — what the
+    /// highlighter produces when it walks the file from the start.
+    fn fg_in_context(path: &str, prefix: &str, text: &str, find: &str) -> ratatui::style::Color {
+        let mut hl = highlighter_for_path(path);
+        for line in prefix.lines() {
+            let with_nl = format!("{line}\n");
+            let _ = highlight_line(&mut hl, &with_nl);
+        }
+        let with_nl = format!("{text}\n");
+        highlight_line(&mut hl, &with_nl)
+            .into_iter()
+            .find_map(|(s, t)| if t.contains(find) { s.fg } else { None })
+            .unwrap_or_else(|| panic!("ref fg for {find:?} missing"))
+    }
+
+    /// Regression: an unchanged context line inside a multi-line block comment
+    /// must be highlighted with the parser state from walking the full file —
+    /// not from a fresh state at the hunk's start_line. We assert this by
+    /// comparing against an independent reference highlighter.
+    #[test]
+    fn diff_context_line_inside_block_comment_matches_full_file_state() {
+        let before = "/*\nalpha\nbravo\ncharlie\ndelta\necho\nfoxtrot\nOLD\ngolf\n*/\n";
+        let after = "/*\nalpha\nbravo\ncharlie\ndelta\necho\nfoxtrot\nNEW\ngolf\n*/\n";
+
+        let lines = render_diff(Some("test.rs"), before, after);
+
+        let expected = fg_in_context("test.rs", "/*\nalpha\nbravo\ncharlie\n", "delta", "delta");
+        assert_eq!(diff_fg(&lines, "delta"), expected);
+    }
+
+    /// Regression: when an edit removes a closing `*/`, lines that were code
+    /// in BEFORE are now comment in AFTER. Unchanged context lines must be
+    /// highlighted using the AFTER state (their post-edit truth).
+    #[test]
+    fn diff_unchanged_line_uses_after_state_when_close_tag_removed() {
+        let before = "/*\ndoc\n*/\nfn x() {}\n";
+        let after = "/*\ndoc\nfn x() {}\n";
+
+        let lines = render_diff(Some("test.rs"), before, after);
+
+        let expected = fg_in_context("test.rs", "/*\ndoc\n", "fn x() {}", "fn");
+        assert_eq!(diff_fg(&lines, "fn x() {}"), expected);
+    }
+
     #[test]
     fn merge_syntax_with_diff_emphasis_split() {
         let base = Style::new().bg(Color::Red);
         let emph = Style::new().bg(Color::Green);
         let syn = vec![(Style::new().fg(Color::White), "abcde".to_owned())];
         let diff = vec![
-            DiffSpan::plain("abc".into()),
+            plain("abc"),
             DiffSpan {
                 text: "de".into(),
                 emphasized: true,
@@ -513,7 +642,7 @@ mod tests {
             (Style::new().fg(Color::Blue), "ab".to_owned()),
             (Style::new().fg(Color::Cyan), "cd".to_owned()),
         ];
-        let diff = vec![DiffSpan::plain("ab".into())];
+        let diff = vec![plain("ab")];
         let result = merge_syntax_with_diff(&syn, &diff, base, Style::default());
         let text: String = result.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(text, "abcd");
@@ -576,7 +705,7 @@ mod tests {
             (Style::new().fg(Color::Blue), "cd".to_owned()),
         ];
         let diff = vec![
-            DiffSpan::plain("a".into()),
+            plain("a"),
             DiffSpan {
                 text: "bcd".into(),
                 emphasized: true,

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -6,8 +6,7 @@ use maki_agent::tools::{
     BASH_TOOL_NAME, GLOB_TOOL_NAME, GREP_TOOL_NAME, QUESTION_TOOL_NAME, WRITE_TOOL_NAME,
 };
 use maki_agent::{
-    BatchToolEntry, DiffHunk, DiffLine, DiffSpan, GrepFileEntry, GrepMatchGroup, QuestionAnswer,
-    ToolInput, ToolOutput,
+    BatchToolEntry, GrepFileEntry, GrepMatchGroup, QuestionAnswer, ToolInput, ToolOutput,
 };
 use ratatui::backend::TestBackend;
 use test_case::test_case;
@@ -519,13 +518,8 @@ fn search_text_diff_output_includes_hunks() {
         tool: "edit",
         output: ToolOutput::Diff {
             path: "src/main.rs".into(),
-            hunks: vec![DiffHunk {
-                start_line: 1,
-                lines: vec![
-                    DiffLine::Removed(vec![DiffSpan::plain("old".into())]),
-                    DiffLine::Added(vec![DiffSpan::plain("new".into())]),
-                ],
-            }],
+            before: "old\n".into(),
+            after: "new\n".into(),
             summary: "1 edit".into(),
         },
         is_error: false,

--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -1185,7 +1185,7 @@ mod tests {
     #[test_case("grep",  ToolOutput::GrepResult { entries: vec![GrepFileEntry { path: "a.rs".into(), groups: vec![GrepMatchGroup::single(1, "hit")] }] }, Some("1 matches in 1 file") ; "grep_file_count")]
     #[test_case("glob",  ToolOutput::GlobResult { files: vec!["a".into(), "b".into()] }, Some("2 files") ; "glob_file_count")]
     #[test_case("glob",  ToolOutput::GlobResult { files: vec![] },            None                ; "glob_empty_no_annotation")]
-    #[test_case("edit",  ToolOutput::Diff { path: "a.rs".into(), hunks: vec![], summary: "ok".into() }, None ; "diff_no_annotation")]
+    #[test_case("edit",  ToolOutput::Diff { path: "a.rs".into(), before: String::new(), after: String::new(), summary: "ok".into() }, None ; "diff_no_annotation")]
     fn annotation_cases(tool: &str, output: ToolOutput, expected: Option<&str>) {
         assert_eq!(
             tool_output_annotation(&output, ToolKind::from_name(tool)).as_deref(),

--- a/maki-ui/src/mock.rs
+++ b/maki-ui/src/mock.rs
@@ -4,10 +4,9 @@ use maki_agent::tools::{
     TASK_TOOL_NAME, TODOWRITE_TOOL_NAME, WEBFETCH_TOOL_NAME, WRITE_TOOL_NAME,
 };
 use maki_agent::{
-    AgentEvent, BatchToolEntry, BatchToolStatus, DiffHunk, DiffLine, DiffSpan, Envelope,
-    GrepFileEntry, GrepMatchGroup, QuestionInfo, QuestionOption, SubagentInfo, TodoItem,
-    TodoPriority, TodoStatus, ToolDoneEvent, ToolInput, ToolOutput, ToolStartEvent,
-    TurnCompleteEvent,
+    AgentEvent, BatchToolEntry, BatchToolStatus, Envelope, GrepFileEntry, GrepMatchGroup,
+    QuestionInfo, QuestionOption, SubagentInfo, TodoItem, TodoPriority, TodoStatus, ToolDoneEvent,
+    ToolInput, ToolOutput, ToolStartEvent, TurnCompleteEvent,
 };
 use maki_providers::{Message, TokenUsage};
 
@@ -264,15 +263,8 @@ pub fn mock_events() -> Vec<MockEvent> {
         EDIT_TOOL_NAME,
         ToolOutput::Diff {
             path: "src/config/mod.rs".into(),
-            hunks: vec![DiffHunk {
-                start_line: 3,
-                lines: vec![
-                    DiffLine::Removed(vec![DiffSpan::plain("pub struct Config {".into())]),
-                    DiffLine::Added(vec![DiffSpan::plain("pub struct ConfigBuilder {".into())]),
-                    DiffLine::Unchanged("    pub port: u16,".into()),
-                    DiffLine::Added(vec![DiffSpan::plain("    pub host: String,".into())]),
-                ],
-            }],
+            before: "use std::net::IpAddr;\n\npub struct Config {\n    pub port: u16,\n}\n".into(),
+            after: "use std::net::IpAddr;\n\npub struct ConfigBuilder {\n    pub port: u16,\n    pub host: String,\n}\n".into(),
             summary: "Renamed Config to ConfigBuilder, added host field".into(),
         },
         false,
@@ -578,13 +570,8 @@ print(f'Total lines across config: {total}')"
         MULTIEDIT_TOOL_NAME,
         ToolOutput::Diff {
             path: "src/main.rs".into(),
-            hunks: vec![DiffHunk {
-                start_line: 1,
-                lines: vec![
-                    DiffLine::Removed(vec![DiffSpan::plain("use config::Config;".into())]),
-                    DiffLine::Added(vec![DiffSpan::plain("use config::ConfigBuilder;".into())]),
-                ],
-            }],
+            before: "use config::Config;\n\nfn main() {}\n".into(),
+            after: "use config::ConfigBuilder;\n\nfn main() {}\n".into(),
             summary: "Updated import to use ConfigBuilder".into(),
         },
         false,


### PR DESCRIPTION
Hunks were precomputed at edit time and re-interpreted later by display and the renderer, so anything those layers did not know about made the diff drift from the file. A normalizer in fuzzy_replace once turned literal \n into a one-line diff full of escapes, and a hunk that began inside a multi-line string was highlighted as if it were the start of the file.

ToolOutput::Diff now stores only the two file snapshots. compute_hunks and unified_text derive from them, and the renderer walks both files with two syntect highlighters, so removed lines keep the old parser state and added lines the new one.