### PR TITLE
providers: openai: Drop `<think>` and `</think>` around reasoning blocks

### DIFF
--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -419,14 +419,31 @@ pub async fn parse_sse(
     let mut content_blocks: Vec<ContentBlock> = Vec::new();
 
     if !reasoning_text.is_empty() {
-        content_blocks.push(ContentBlock::Thinking {
-            thinking: reasoning_text,
-            signature: None,
-        });
+        // Some models like Qwen3.5 are putting the reasoning content into
+        // <think>...</think>, sometimes omitting the closing </think>
+        if let Some(stripped) = reasoning_text.strip_prefix("<think>") {
+            reasoning_text = stripped
+                .strip_suffix("</think>")
+                .unwrap_or(stripped)
+                .trim()
+                .to_owned();
+        } else {
+            reasoning_text = reasoning_text.trim().to_owned();
+        }
+
+        if !reasoning_text.is_empty() {
+            content_blocks.push(ContentBlock::Thinking {
+                thinking: reasoning_text,
+                signature: None,
+            });
+        }
     }
 
     if !text.is_empty() {
-        content_blocks.push(ContentBlock::Text { text });
+        text = text.trim().to_owned();
+        if !text.is_empty() {
+            content_blocks.push(ContentBlock::Text { text });
+        }
     }
 
     for (idx, acc) in tool_accumulators.into_iter().enumerate() {

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -496,10 +496,11 @@ impl MessagesPanel {
     pub fn flush(&mut self) {
         self.flush_thinking();
         if !self.streaming_text.is_empty() {
-            self.messages.push(DisplayMessage::new(
-                DisplayRole::Assistant,
-                self.streaming_text.take_all(),
-            ));
+            let text = self.streaming_text.take_all().trim().to_owned();
+            if !text.is_empty() {
+                self.messages
+                    .push(DisplayMessage::new(DisplayRole::Assistant, text));
+            }
         }
     }
 
@@ -773,10 +774,24 @@ impl MessagesPanel {
 
     fn flush_thinking(&mut self) {
         if !self.streaming_thinking.is_empty() {
-            self.messages.push(DisplayMessage::new(
-                DisplayRole::Thinking,
-                self.streaming_thinking.take_all(),
-            ));
+            let mut text = self.streaming_thinking.take_all();
+
+            // Some models like Qwen3.5 are putting the reasoning content into
+            // <think>...</think>, sometimes omitting the closing </think>
+            if let Some(stripped) = text.strip_prefix("<think>") {
+                text = stripped
+                    .strip_suffix("</think>")
+                    .unwrap_or(stripped)
+                    .trim()
+                    .to_owned();
+            } else {
+                text = text.trim().to_owned();
+            }
+
+            if !text.trim().is_empty() {
+                self.messages
+                    .push(DisplayMessage::new(DisplayRole::Thinking, text));
+            }
         }
     }
 


### PR DESCRIPTION
    Some models like Qwen3.5 are putting the reasoning content into such
    blocks, and sometimes only output an empty reasoning block with just
    those tags.
    
    This strips them from the OpenAI compat provider when creating the
    content blocks for the history as well as from the UI messages when
    handling streaming responses.
    
    In addition, also trim complete reasoning and text responsens so that
    leading and trailing whitespace are removed and don't output them if
    there was only whitespace.

----

The check is now done in two places, which is not very nice. How would you prefer this to be factored out?