### PR TITLE
agent: tools: bash: Handle exit codes of rtk explicitly

### DIFF
--- a/maki-agent/src/tools/bash.rs
+++ b/maki-agent/src/tools/bash.rs
@@ -40,7 +40,13 @@ fn rtk_rewrite(command: &str, no_rtk: bool) -> Option<String> {
         .arg(command)
         .output()
         .ok()?;
-    if !output.status.success() {
+    // rtk exits with code 0 or 3 if rewriting was successful
+    if !output.status.success()
+        && output
+            .status
+            .code()
+            .is_none_or(|code| code != 0 && code != 3)
+    {
         return None;
     }
     let rewritten = String::from_utf8(output.stdout).ok()?;


### PR DESCRIPTION
Specifically, 3 is also a successful exit code according to the documentation and means that the "ask" rule matched.

For maki's purposes that is treated the same as a normal success.