### PR TITLE
agent & ui: MCP server refresh on toggle via command loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2146,6 +2146,7 @@ dependencies = [
 name = "maki-agent"
 version = "0.1.12"
 dependencies = [
+ "arc-swap",
  "async-io",
  "async-lock",
  "async-process",

--- a/maki-agent/Cargo.toml
+++ b/maki-agent/Cargo.toml
@@ -26,6 +26,7 @@ humantime = { workspace = true }
 smol = { workspace = true }
 async-process = { workspace = true }
 flume = { workspace = true }
+arc-swap = { workspace = true }
 event-listener = { workspace = true }
 async-lock = { workspace = true }
 async-io = { workspace = true }

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -12,7 +12,7 @@ use super::instructions::LoadedInstructions;
 use super::streaming::stream_with_retry;
 use super::tool_dispatch::{self, RecentCalls};
 use crate::cancel::CancelToken;
-use crate::mcp::McpManager;
+use crate::mcp::McpHandle;
 use crate::permissions::PermissionManager;
 use crate::skill::Skill;
 use crate::tools::{Deadline, ToolContext};
@@ -66,7 +66,7 @@ pub struct Agent {
     auto_compact: bool,
     loaded_instructions: LoadedInstructions,
     rollback_len: usize,
-    mcp: Option<Arc<McpManager>>,
+    mcp: Option<McpHandle>,
     config: AgentConfig,
     reauth_attempts: u32,
     permissions: Arc<PermissionManager>,
@@ -101,7 +101,7 @@ impl Agent {
         }
     }
 
-    pub fn with_mcp(mut self, mcp: Option<Arc<McpManager>>) -> Self {
+    pub fn with_mcp(mut self, mcp: Option<McpHandle>) -> Self {
         self.mcp = mcp;
         self
     }

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -1,12 +1,11 @@
 use std::collections::VecDeque;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::sync::Arc;
 
 use serde_json::Value;
 use tracing::{debug, error, warn};
 
-use crate::mcp::McpManager;
+use crate::mcp::{McpHandle, UNKNOWN_MCP};
 use crate::task_set::TaskSet;
 use crate::tools::{ToolCall, ToolContext};
 use crate::{AgentError, AgentEvent, AgentMode, ToolDoneEvent, ToolOutput, ToolStartEvent};
@@ -22,13 +21,13 @@ pub(crate) enum ResolvedCall {
 }
 
 impl ResolvedCall {
-    pub(crate) fn start_event(&self, id: String, mcp: Option<&McpManager>) -> ToolStartEvent {
+    pub(crate) fn start_event(&self, id: String, mcp: Option<&McpHandle>) -> ToolStartEvent {
         match self {
             Self::Native(call) => call.start_event(id),
             Self::Mcp { tool_name, .. } => {
                 let interned = mcp
                     .map(|m| m.interned_name(tool_name))
-                    .unwrap_or("unknown_mcp");
+                    .unwrap_or(UNKNOWN_MCP);
                 ToolStartEvent {
                     id,
                     tool: interned,
@@ -52,7 +51,7 @@ impl ResolvedCall {
 pub(crate) fn resolve_tool(
     name: &str,
     input: &Value,
-    mcp: Option<&McpManager>,
+    mcp: Option<&McpHandle>,
 ) -> Result<ResolvedCall, AgentError> {
     match ToolCall::from_api(name, input) {
         Ok(call) => Ok(ResolvedCall::Native(call)),
@@ -104,7 +103,7 @@ impl RecentCalls {
 fn parse_tool_calls<'a>(
     tool_uses: impl Iterator<Item = (&'a str, &'a str, &'a Value)>,
     recent: &mut RecentCalls,
-    mcp: Option<&McpManager>,
+    mcp: Option<&McpHandle>,
 ) -> (Vec<ParsedToolCall>, Vec<ToolDoneEvent>) {
     let mut parsed = Vec::new();
     let mut errors = Vec::new();
@@ -177,7 +176,7 @@ pub(crate) async fn execute_mcp_tool(
         .mcp
         .as_ref()
         .map(|m| m.interned_name(tool_name))
-        .unwrap_or("unknown_mcp");
+        .unwrap_or(UNKNOWN_MCP);
 
     let done = |output: String, is_error: bool| ToolDoneEvent {
         id: id.to_owned(),
@@ -228,22 +227,18 @@ pub(crate) async fn execute_mcp_tool(
 pub(super) async fn process_tool_calls(
     response: maki_providers::StreamResponse,
     recent_calls: &mut RecentCalls,
-    mcp: Option<&Arc<McpManager>>,
+    mcp: Option<&McpHandle>,
     history: &mut super::history::History,
     event_tx: &crate::EventSender,
     ctx: &ToolContext,
 ) -> Result<(), AgentError> {
-    let (parsed, errors) = parse_tool_calls(
-        response.message.tool_uses(),
-        recent_calls,
-        mcp.map(|m| m.as_ref()),
-    );
+    let (parsed, errors) = parse_tool_calls(response.message.tool_uses(), recent_calls, mcp);
 
     history.push(response.message);
 
     for p in &parsed {
         event_tx.send(AgentEvent::ToolStart(Box::new(
-            p.call.start_event(p.id.clone(), mcp.map(|m| m.as_ref())),
+            p.call.start_event(p.id.clone(), mcp),
         )))?;
     }
 

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -11,7 +11,7 @@ pub mod mcp;
 pub use mcp::config::McpServerInfo;
 pub use mcp::config::McpServerStatus;
 pub use mcp::protocol::PromptRole;
-pub use mcp::{McpPromptArg, McpPromptInfo};
+pub use mcp::{McpCommand, McpHandle, McpPromptArg, McpPromptInfo, McpSnapshot, McpSnapshotReader};
 pub(crate) mod task_set;
 pub use agent::{
     Agent, AgentParams, AgentRunParams, History, Instructions, LoadedInstructions, RunOutcome,

--- a/maki-agent/src/mcp/config.rs
+++ b/maki-agent/src/mcp/config.rs
@@ -109,14 +109,14 @@ pub struct RawHttpFields {
     pub headers: HashMap<String, String>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ServerConfig {
     pub name: String,
     pub timeout: Duration,
     pub transport: Transport,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Transport {
     Stdio {
         program: String,

--- a/maki-agent/src/mcp/http.rs
+++ b/maki-agent/src/mcp/http.rs
@@ -235,7 +235,7 @@ impl McpTransport for HttpTransport {
         })
     }
 
-    fn shutdown(self: Box<Self>) -> BoxFuture<'static, ()> {
+    fn shutdown<'a>(&'a self) -> BoxFuture<'a, ()> {
         Box::pin(async move {
             let session_id = self.session_id.lock().await.clone();
             let Some(sid) = session_id else { return };

--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -1,7 +1,26 @@
 //! MCP client: manages transports and routes tool calls to servers.
 //!
-//! Tool names are namespaced as `server__tool` (double underscore) to avoid collisions across servers.
-//! Names are leaked into `&'static str` so they can be used in tool descriptors without lifetime friction.
+//! Tool names are namespaced as `server__tool` (double underscore) so two servers can both
+//! expose a tool called `search` without stepping on each other. The qualified names are leaked
+//! into `&'static str` so tool descriptors can hold them without dragging a lifetime everywhere.
+//!
+//! # Architecture
+//!
+//! All mutable state lives inside one task, `run`, which owns `McpManagerInner` outright. Nobody
+//! else gets to touch it. Two doors lead in and out:
+//!
+//! * Writes come in as `McpCommand`s over a channel. `run` handles them one at a time, so a
+//!   toggle, a reconnect and a shutdown can never interleave.
+//! * Reads go through two `ArcSwap`s that `run` republishes after every change: a `ToolIndex`
+//!   for the hot tool-call path and an `McpSnapshot` for the UI. Both sides are lock-free, so a
+//!   slow tool call can't stall a toggle and a toggle can't stall an in-flight call.
+//!
+//! `McpSnapshotReader` is a read-only newtype around the snapshot `ArcSwap`. Handing that out
+//! instead of the raw `ArcSwap` means outside code physically cannot publish a snapshot, which
+//! keeps the "only `run` publishes" rule enforced by the type system.
+//!
+//! The snapshot is the single source of truth for every per-server fact, including whether a
+//! server is disabled. There is no second list to keep in sync.
 
 pub mod config;
 pub mod error;
@@ -11,12 +30,11 @@ pub mod protocol;
 pub mod stdio;
 pub mod transport;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::{Arc, Mutex, OnceLock};
 
-use async_lock::RwLock;
+use arc_swap::{ArcSwap, Guard};
 use serde_json::{Value, json};
 use tracing::{info, warn};
 
@@ -30,10 +48,10 @@ use self::stdio::StdioTransport;
 use self::transport::McpTransport;
 
 const SEPARATOR: &str = "__";
+pub const UNKNOWN_MCP: &str = "unknown_mcp";
 
 struct McpToolDef {
     qualified_name: &'static str,
-    server_name: Arc<str>,
     raw_name: String,
     description: String,
     input_schema: Value,
@@ -41,31 +59,24 @@ struct McpToolDef {
 
 struct McpPromptDef {
     qualified_name: String,
-    server_name: Arc<str>,
     raw_name: String,
     description: String,
     arguments: Vec<protocol::PromptArgument>,
 }
 
 impl McpPromptDef {
-    fn from_info(server_name: &Arc<str>, info: protocol::PromptInfo) -> Self {
-        let qualified_name = format!("{server_name}{SEPARATOR}{}", info.name);
+    fn from_info(server_name: &str, info: protocol::PromptInfo) -> Self {
         Self {
-            qualified_name,
-            server_name: Arc::clone(server_name),
+            qualified_name: format!("{server_name}{SEPARATOR}{}", info.name),
             raw_name: info.name,
             description: info.description.unwrap_or_default(),
             arguments: info.arguments,
         }
     }
 
-    fn display_name(&self) -> String {
-        format!("{}:{}", self.server_name, self.raw_name)
-    }
-
-    fn to_info(&self) -> McpPromptInfo {
+    fn to_info(&self, server_name: &str) -> McpPromptInfo {
         McpPromptInfo {
-            display_name: self.display_name(),
+            display_name: format!("{server_name}:{}", self.raw_name),
             qualified_name: self.qualified_name.clone(),
             description: self.description.clone(),
             arguments: self
@@ -83,23 +94,68 @@ impl McpPromptDef {
 
 struct ServerEntry {
     name: String,
+    config: Option<ServerConfig>,
     transport_kind: &'static str,
     origin: PathBuf,
     status: McpServerStatus,
-    url: Option<String>,
-    timeout: Duration,
+    transport: Option<Arc<dyn McpTransport>>,
+    tools: Vec<McpToolDef>,
+    prompts: Vec<McpPromptDef>,
+}
+
+impl ServerEntry {
+    async fn clear_connection(&mut self) {
+        if let Some(old) = self.transport.take() {
+            old.shutdown().await;
+        }
+        self.tools.clear();
+        self.prompts.clear();
+    }
+
+    fn populate(&mut self, result: StartResult) {
+        let StartResult {
+            transport,
+            tool_infos,
+            prompt_infos,
+        } = result;
+        self.tools = tool_infos
+            .into_iter()
+            .map(|info| McpToolDef {
+                qualified_name: intern(format!("{}{SEPARATOR}{}", self.name, info.name)),
+                raw_name: info.name,
+                description: info.description,
+                input_schema: info.input_schema,
+            })
+            .collect();
+        self.prompts = prompt_infos
+            .into_iter()
+            .map(|info| McpPromptDef::from_info(&self.name, info))
+            .collect();
+        self.transport = Some(transport);
+        self.status = McpServerStatus::Running;
+    }
 }
 
 struct McpManagerInner {
-    transports: HashMap<Arc<str>, Box<dyn McpTransport>>,
-    tools: Vec<McpToolDef>,
-    tool_index: HashMap<&'static str, usize>,
-    prompts: Vec<McpPromptDef>,
     entries: Vec<ServerEntry>,
+    generation: u64,
 }
 
-pub struct McpManager {
-    inner: RwLock<McpManagerInner>,
+#[derive(Default)]
+struct ToolIndex {
+    tools: HashMap<&'static str, ToolRef>,
+    prompts: HashMap<String, PromptRef>,
+    descriptors: Arc<[Value]>,
+}
+
+struct ToolRef {
+    raw_name: String,
+    transport: Arc<dyn McpTransport>,
+}
+
+struct PromptRef {
+    raw_name: String,
+    transport: Arc<dyn McpTransport>,
 }
 
 #[derive(Clone)]
@@ -117,297 +173,92 @@ pub struct McpPromptArg {
     pub required: bool,
 }
 
-fn transport_url(transport: &Transport) -> Option<String> {
-    match transport {
-        Transport::Http { url, .. } => Some(url.clone()),
-        Transport::Stdio { .. } => None,
+#[derive(Clone, Default)]
+pub struct McpSnapshot {
+    pub infos: Vec<McpServerInfo>,
+    pub prompts: Vec<McpPromptInfo>,
+    pub pids: Vec<u32>,
+    pub generation: u64,
+}
+
+/// Read-only view of the latest published `McpSnapshot`. Handing this out instead of the
+/// raw `ArcSwap` keeps outside code from publishing snapshots of its own.
+#[derive(Clone)]
+pub struct McpSnapshotReader(Arc<ArcSwap<McpSnapshot>>);
+
+impl McpSnapshotReader {
+    pub fn empty() -> Self {
+        Self::from_snapshot(McpSnapshot::default())
+    }
+
+    pub fn from_snapshot(snapshot: McpSnapshot) -> Self {
+        Self(Arc::new(ArcSwap::from_pointee(snapshot)))
+    }
+
+    pub fn load(&self) -> Guard<Arc<McpSnapshot>> {
+        self.0.load()
     }
 }
 
-impl McpManager {
-    pub async fn start(cwd: &Path) -> Option<Arc<Self>> {
-        let cwd = cwd.to_owned();
-        let config = smol::unblock(move || load_config(&cwd)).await;
-        Self::start_with_config(config).await
+pub enum McpCommand {
+    Toggle {
+        server: String,
+        enabled: bool,
+    },
+    Reconnect {
+        server: String,
+        url: String,
+        token: String,
+    },
+    /// Drain every running transport and stop the loop. The loop sends `()` on `ack` once
+    /// every shutdown has finished, so callers can wait with a timeout.
+    Shutdown {
+        ack: flume::Sender<()>,
+    },
+}
+
+#[derive(Clone)]
+pub struct McpHandle {
+    cmd_tx: flume::Sender<McpCommand>,
+    index: Arc<ArcSwap<ToolIndex>>,
+    snapshot: Arc<ArcSwap<McpSnapshot>>,
+}
+
+impl McpHandle {
+    pub fn send(&self, cmd: McpCommand) {
+        if let Err(e) = self.cmd_tx.try_send(cmd) {
+            warn!(error = %e, "MCP command loop is gone");
+        }
     }
 
-    pub async fn start_with_config(config: McpConfig) -> Option<Arc<Self>> {
-        if config.is_empty() {
-            return None;
-        }
-
-        let origins = config.origins;
-        let mut transports: HashMap<Arc<str>, Box<dyn McpTransport>> = HashMap::new();
-        let mut tools = Vec::new();
-        let mut tool_index = HashMap::new();
-        let mut prompts = Vec::new();
-        let mut entries = Vec::new();
-
-        struct Pending {
-            config: ServerConfig,
-            kind: &'static str,
-            origin: PathBuf,
-        }
-
-        let mut pending = Vec::new();
-
-        for (name, raw) in config.mcp {
-            let kind = transport_kind(&raw.transport);
-            let origin = origins.get(&name).cloned().unwrap_or_default();
-
-            if !raw.enabled {
-                entries.push(ServerEntry {
-                    name,
-                    transport_kind: kind,
-                    origin,
-                    status: McpServerStatus::Disabled,
-                    url: None,
-                    timeout: Duration::default(),
-                });
-                continue;
-            }
-
-            match parse_server(name.clone(), raw) {
-                Ok(sc) => pending.push(Pending {
-                    config: sc,
-                    kind,
-                    origin,
-                }),
-                Err(e) => {
-                    warn!(server = %name, error = %e, "invalid MCP server config");
-                    entries.push(ServerEntry {
-                        name,
-                        transport_kind: kind,
-                        origin,
-                        status: McpServerStatus::Failed(e.to_string()),
-                        url: None,
-                        timeout: Duration::default(),
-                    });
-                }
-            }
-        }
-
-        let handles: Vec<_> = pending
-            .into_iter()
-            .map(|p| {
-                smol::spawn(async move {
-                    let result = Self::start_server(&p.config).await;
-                    (p, result)
-                })
-            })
-            .collect();
-
-        for handle in handles {
-            let (p, result) = handle.await;
-            let url = transport_url(&p.config.transport);
-            let timeout = p.config.timeout;
-            match result {
-                Ok((t, server_tools, server_prompts)) => {
-                    let server_name: Arc<str> = Arc::from(p.config.name.as_str());
-                    for tool_info in server_tools {
-                        let qualified = format!("{}{SEPARATOR}{}", p.config.name, tool_info.name);
-                        let interned = intern(qualified);
-                        let idx = tools.len();
-                        tools.push(McpToolDef {
-                            qualified_name: interned,
-                            server_name: Arc::clone(&server_name),
-                            raw_name: tool_info.name,
-                            description: tool_info.description,
-                            input_schema: tool_info.input_schema,
-                        });
-                        tool_index.insert(interned, idx);
-                    }
-                    for info in server_prompts {
-                        prompts.push(McpPromptDef::from_info(&server_name, info));
-                    }
-                    transports.insert(Arc::clone(&server_name), t);
-                    entries.push(ServerEntry {
-                        name: p.config.name,
-                        transport_kind: p.kind,
-                        origin: p.origin,
-                        status: McpServerStatus::Running,
-                        url,
-                        timeout,
-                    });
-                }
-                Err(e) => {
-                    let status = if let McpError::HttpError {
-                        status: 401,
-                        ref reason,
-                        ..
-                    } = e
-                    {
-                        McpServerStatus::NeedsAuth {
-                            url: Some(reason.clone()),
-                        }
-                    } else {
-                        warn!(server = %p.config.name, error = %e, "failed to start MCP server");
-                        McpServerStatus::Failed(e.to_string())
-                    };
-                    entries.push(ServerEntry {
-                        name: p.config.name,
-                        transport_kind: p.kind,
-                        origin: p.origin,
-                        status,
-                        url,
-                        timeout,
-                    });
-                }
-            }
-        }
-
-        info!(
-            running = transports.len(),
-            tools = tools.len(),
-            prompts = prompts.len(),
-            total = entries.len(),
-            "MCP servers initialized"
-        );
-
-        Some(Arc::new(Self {
-            inner: RwLock::new(McpManagerInner {
-                transports,
-                tools,
-                tool_index,
-                prompts,
-                entries,
-            }),
-        }))
-    }
-
-    async fn start_server(
-        config: &ServerConfig,
-    ) -> Result<
-        (
-            Box<dyn McpTransport>,
-            Vec<protocol::ToolInfo>,
-            Vec<protocol::PromptInfo>,
-        ),
-        McpError,
-    > {
-        let t: Box<dyn McpTransport> = match &config.transport {
-            Transport::Stdio {
-                program,
-                args,
-                environment,
-            } => Box::new(StdioTransport::spawn(
-                &config.name,
-                program,
-                args,
-                environment,
-                config.timeout,
-            )?),
-            Transport::Http { url, headers } => Box::new(HttpTransport::new(
-                &config.name,
-                url,
-                headers,
-                config.timeout,
-            )?),
-        };
-        transport::initialize(t.as_ref()).await?;
-        let tools = transport::list_tools(t.as_ref()).await?;
-        let prompts = transport::list_prompts(t.as_ref()).await?;
-        info!(
-            server = config.name,
-            tool_count = tools.len(),
-            prompt_count = prompts.len(),
-            "MCP server initialized"
-        );
-        Ok((t, tools, prompts))
+    pub fn reader(&self) -> McpSnapshotReader {
+        McpSnapshotReader(Arc::clone(&self.snapshot))
     }
 
     pub fn has_tool(&self, name: &str) -> bool {
-        self.inner.read_blocking().tool_index.contains_key(name)
+        self.index.load().tools.contains_key(name)
     }
 
     pub fn interned_name(&self, name: &str) -> &'static str {
-        self.inner
-            .read_blocking()
-            .tool_index
+        self.index
+            .load()
+            .tools
             .get_key_value(name)
             .map(|(&k, _)| k)
-            .unwrap_or("unknown_mcp")
+            .unwrap_or(UNKNOWN_MCP)
     }
 
     pub async fn call_tool(&self, qualified_name: &str, args: &Value) -> Result<String, McpError> {
-        let inner = self.inner.read().await;
-        let idx = inner
-            .tool_index
-            .get(qualified_name)
-            .ok_or_else(|| McpError::UnknownTool {
-                name: qualified_name.into(),
-            })?;
-        let def = &inner.tools[*idx];
-        let t = inner
-            .transports
-            .get(&def.server_name)
-            .ok_or_else(|| McpError::ServerDied {
-                server: (*def.server_name).into(),
-            })?;
-        transport::call_tool(t.as_ref(), &def.raw_name, args).await
-    }
-
-    pub fn extend_tools(&self, tools: &mut Value, disabled: &[String]) {
-        let inner = self.inner.read_blocking();
-        for t in inner
-            .tools
-            .iter()
-            .filter(|t| !disabled.contains(&t.server_name.to_string()))
-        {
-            if let Some(arr) = tools.as_array_mut() {
-                arr.push(json!({
-                    "name": t.qualified_name,
-                    "description": t.description,
-                    "input_schema": t.input_schema,
-                }));
-            }
-        }
-    }
-
-    pub fn server_infos(&self, disabled: &[String]) -> Vec<McpServerInfo> {
-        let inner = self.inner.read_blocking();
-        let mut counts: HashMap<&str, (usize, usize)> = HashMap::new();
-        for tool in &inner.tools {
-            counts.entry(&tool.server_name).or_default().0 += 1;
-        }
-        for prompt in &inner.prompts {
-            counts.entry(&prompt.server_name).or_default().1 += 1;
-        }
-        inner
-            .entries
-            .iter()
-            .map(|entry| {
-                let status = if disabled.contains(&entry.name) {
-                    McpServerStatus::Disabled
-                } else {
-                    entry.status.clone()
-                };
-                let (tool_count, prompt_count) = if matches!(status, McpServerStatus::Running) {
-                    counts.get(entry.name.as_str()).copied().unwrap_or((0, 0))
-                } else {
-                    (0, 0)
-                };
-                McpServerInfo {
-                    name: entry.name.clone(),
-                    transport_kind: entry.transport_kind,
-                    tool_count,
-                    prompt_count,
-                    status,
-                    config_path: entry.origin.clone(),
-                    url: entry.url.clone(),
-                }
-            })
-            .collect()
-    }
-
-    pub fn prompt_infos(&self, disabled: &[String]) -> Vec<McpPromptInfo> {
-        let inner = self.inner.read_blocking();
-        inner
-            .prompts
-            .iter()
-            .filter(|p| !disabled.iter().any(|d| **d == *p.server_name))
-            .map(|p| p.to_info())
-            .collect()
+        let (raw_name, transport) = {
+            let idx = self.index.load();
+            let Some(t) = idx.tools.get(qualified_name) else {
+                return Err(McpError::UnknownTool {
+                    name: qualified_name.into(),
+                });
+            };
+            (t.raw_name.clone(), Arc::clone(&t.transport))
+        };
+        transport::call_tool(transport.as_ref(), &raw_name, args).await
     }
 
     pub async fn get_prompt(
@@ -415,130 +266,414 @@ impl McpManager {
         qualified_name: &str,
         arguments: &HashMap<String, String>,
     ) -> Result<Vec<protocol::PromptMessage>, McpError> {
-        let inner = self.inner.read().await;
-        let def = inner
-            .prompts
-            .iter()
-            .find(|p| p.qualified_name == qualified_name)
-            .ok_or_else(|| McpError::UnknownPrompt {
-                name: qualified_name.into(),
-            })?;
-        let t = inner
-            .transports
-            .get(&def.server_name)
-            .ok_or_else(|| McpError::ServerDied {
-                server: (*def.server_name).into(),
-            })?;
-        transport::get_prompt(t.as_ref(), &def.raw_name, arguments).await
-    }
-
-    pub async fn shutdown(self) {
-        let inner = self.inner.into_inner();
-        let handles: Vec<_> = inner
-            .transports
-            .into_iter()
-            .map(|(name, t)| {
-                smol::spawn(async move {
-                    info!(server = &*name, "shutting down MCP server");
-                    t.shutdown().await;
-                })
-            })
-            .collect();
-        for h in handles {
-            h.await;
-        }
-    }
-
-    pub fn child_pids(&self) -> Vec<u32> {
-        self.inner
-            .read_blocking()
-            .transports
-            .values()
-            .flat_map(|t| t.child_pids())
-            .collect()
-    }
-
-    pub async fn reconnect_server(
-        &self,
-        server_name: &str,
-        server_url: &str,
-        access_token: &str,
-    ) -> Result<(), McpError> {
-        let timeout = {
-            let inner = self.inner.read().await;
-            inner
-                .entries
-                .iter()
-                .find(|e| e.name == server_name)
-                .map(|e| e.timeout)
-                .unwrap_or_default()
+        let (raw_name, transport) = {
+            let idx = self.index.load();
+            let Some(p) = idx.prompts.get(qualified_name) else {
+                return Err(McpError::UnknownPrompt {
+                    name: qualified_name.into(),
+                });
+            };
+            (p.raw_name.clone(), Arc::clone(&p.transport))
         };
-        let mut headers = HashMap::new();
-        headers.insert(
-            "Authorization".to_string(),
-            format!("Bearer {access_token}"),
-        );
-        let transport: Box<dyn McpTransport> = Box::new(HttpTransport::new(
-            server_name,
-            server_url,
-            &headers,
-            timeout,
-        )?);
-        transport::initialize(transport.as_ref()).await?;
-        let new_tools = transport::list_tools(transport.as_ref()).await?;
-        let new_prompts = transport::list_prompts(transport.as_ref()).await?;
+        transport::get_prompt(transport.as_ref(), &raw_name, arguments).await
+    }
 
-        let mut inner = self.inner.write().await;
-        let server_key: Arc<str> = Arc::from(server_name);
+    pub fn extend_tools(&self, tools: &mut Value) {
+        if let Some(arr) = tools.as_array_mut() {
+            arr.extend(self.index.load().descriptors.iter().cloned());
+        }
+    }
+}
 
-        inner.tools.retain(|t| *t.server_name != *server_name);
-        inner.prompts.retain(|p| *p.server_name != *server_name);
-        inner.tool_index.clear();
-        let rebind: Vec<_> = inner
-            .tools
+pub async fn start(cwd: &Path) -> Option<McpHandle> {
+    let cwd = cwd.to_owned();
+    let config = smol::unblock(move || load_config(&cwd)).await;
+    start_with_config(config).await
+}
+
+pub async fn start_with_config(config: McpConfig) -> Option<McpHandle> {
+    if config.is_empty() {
+        return None;
+    }
+
+    // Publish placeholder entries first so the UI shows every server as Connecting, Disabled
+    // or Failed while transports are still being brought up in the background.
+    let mut inner = parse_entries(config);
+    let snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot::default()));
+    let index: Arc<ArcSwap<ToolIndex>> = Arc::new(ArcSwap::from_pointee(ToolIndex::default()));
+    publish(&inner, &index, &snapshot);
+
+    start_enabled(&mut inner).await;
+    inner.generation += 1;
+    publish(&inner, &index, &snapshot);
+
+    info!(
+        running = inner
+            .entries
             .iter()
-            .enumerate()
-            .map(|(i, t)| (t.qualified_name, i))
-            .collect();
-        for (name, i) in rebind {
-            inner.tool_index.insert(name, i);
-        }
+            .filter(|e| e.transport.is_some())
+            .count(),
+        total = inner.entries.len(),
+        "MCP servers initialized"
+    );
 
-        for tool_info in new_tools {
-            let qualified = format!("{server_name}{SEPARATOR}{}", tool_info.name);
-            let interned = intern(qualified);
-            let idx = inner.tools.len();
-            inner.tools.push(McpToolDef {
-                qualified_name: interned,
-                server_name: Arc::clone(&server_key),
-                raw_name: tool_info.name,
-                description: tool_info.description,
-                input_schema: tool_info.input_schema,
-            });
-            inner.tool_index.insert(interned, idx);
-        }
+    let (cmd_tx, cmd_rx) = flume::unbounded();
+    let handle = McpHandle {
+        cmd_tx,
+        index: Arc::clone(&index),
+        snapshot: Arc::clone(&snapshot),
+    };
+    smol::spawn(run(inner, index, snapshot, cmd_rx)).detach();
+    Some(handle)
+}
 
-        for info in new_prompts {
-            inner
-                .prompts
-                .push(McpPromptDef::from_info(&server_key, info));
-        }
-
-        inner.transports.insert(Arc::clone(&server_key), transport);
-
-        for entry in &mut inner.entries {
-            if entry.name == server_name {
-                entry.status = McpServerStatus::Running;
+async fn run(
+    mut inner: McpManagerInner,
+    index: Arc<ArcSwap<ToolIndex>>,
+    snapshot: Arc<ArcSwap<McpSnapshot>>,
+    cmd_rx: flume::Receiver<McpCommand>,
+) {
+    while let Ok(cmd) = cmd_rx.recv_async().await {
+        match cmd {
+            McpCommand::Toggle { server, enabled } => {
+                handle_toggle(&mut inner, &server, enabled).await;
+            }
+            McpCommand::Reconnect { server, url, token } => {
+                handle_reconnect(&mut inner, &server, &url, &token).await;
+            }
+            McpCommand::Shutdown { ack } => {
+                shutdown_all(&mut inner).await;
+                inner.generation += 1;
+                publish(&inner, &index, &snapshot);
+                let _ = ack.try_send(());
+                return;
             }
         }
+        inner.generation += 1;
+        publish(&inner, &index, &snapshot);
+    }
+}
 
+async fn handle_toggle(inner: &mut McpManagerInner, server_name: &str, enabled: bool) {
+    if let Some(path) = inner
+        .entries
+        .iter()
+        .find(|e| e.name == server_name)
+        .map(|e| e.origin.clone())
+    {
+        spawn_persist_enabled(path, server_name.to_owned(), enabled);
+    }
+
+    if enabled {
+        if let Err(e) = refresh_server(inner, server_name, None).await {
+            warn!(server = %server_name, error = %e, "MCP server refresh failed");
+        }
+    } else if let Some(entry) = inner.entries.iter_mut().find(|e| e.name == server_name) {
+        entry.clear_connection().await;
+        entry.status = McpServerStatus::Disabled;
+    }
+
+    info!(server = server_name, enabled, "MCP toggle complete");
+}
+
+async fn handle_reconnect(
+    inner: &mut McpManagerInner,
+    server_name: &str,
+    server_url: &str,
+    access_token: &str,
+) {
+    let Some(entry) = inner.entries.iter().find(|e| e.name == server_name) else {
+        warn!(server = server_name, "reconnect for unknown server");
+        return;
+    };
+    if entry.status == McpServerStatus::Disabled {
         info!(
             server = server_name,
-            tools = inner.tools.len(),
-            "MCP server reconnected after OAuth"
+            "ignoring reconnect for disabled server"
         );
-        Ok(())
+        return;
     }
+    let timeout = entry.config.as_ref().map(|c| c.timeout).unwrap_or_default();
+    let mut headers = HashMap::new();
+    headers.insert(
+        "Authorization".to_string(),
+        format!("Bearer {access_token}"),
+    );
+    let cfg = ServerConfig {
+        name: server_name.to_string(),
+        timeout,
+        transport: Transport::Http {
+            url: server_url.to_string(),
+            headers,
+        },
+    };
+    if let Err(e) = refresh_server(inner, server_name, Some(cfg)).await {
+        warn!(server = %server_name, error = %e, "reconnect failed");
+    }
+    info!(server = server_name, "MCP reconnect complete");
+}
+
+async fn shutdown_all(inner: &mut McpManagerInner) {
+    for entry in &mut inner.entries {
+        entry.clear_connection().await;
+        if entry.status != McpServerStatus::Disabled {
+            entry.status = McpServerStatus::Failed("shutdown".into());
+        }
+    }
+    info!("MCP command loop shutting down");
+}
+
+/// Tear the old transport down and wipe tools/prompts *before* starting the new one. That way
+/// a failed start leaves the entry empty instead of holding zombie tool references into a dead
+/// transport.
+async fn refresh_server(
+    inner: &mut McpManagerInner,
+    server_name: &str,
+    config_override: Option<ServerConfig>,
+) -> Result<(), McpError> {
+    let Some(idx) = inner.entries.iter().position(|e| e.name == server_name) else {
+        return Err(McpError::Config(format!("unknown server '{server_name}'")));
+    };
+
+    let config = match config_override {
+        Some(c) => {
+            inner.entries[idx].config = Some(c.clone());
+            c
+        }
+        None => inner.entries[idx]
+            .config
+            .clone()
+            .ok_or_else(|| McpError::Config(format!("server '{server_name}' has no config")))?,
+    };
+
+    {
+        let entry = &mut inner.entries[idx];
+        entry.status = McpServerStatus::Connecting;
+        entry.clear_connection().await;
+    }
+
+    let result = start_server(&config).await;
+    apply_start_result(&mut inner.entries[idx], result, "refresh")?;
+    info!(
+        server = server_name,
+        tools = inner.entries[idx].tools.len(),
+        "MCP server refreshed"
+    );
+    Ok(())
+}
+
+fn status_from_err(e: &McpError) -> McpServerStatus {
+    if let McpError::HttpError {
+        status: 401,
+        reason,
+        ..
+    } = e
+    {
+        McpServerStatus::NeedsAuth {
+            url: Some(reason.clone()),
+        }
+    } else {
+        McpServerStatus::Failed(e.to_string())
+    }
+}
+
+struct StartResult {
+    transport: Arc<dyn McpTransport>,
+    tool_infos: Vec<protocol::ToolInfo>,
+    prompt_infos: Vec<protocol::PromptInfo>,
+}
+
+async fn start_server(config: &ServerConfig) -> Result<StartResult, McpError> {
+    let transport: Arc<dyn McpTransport> = match &config.transport {
+        Transport::Stdio {
+            program,
+            args,
+            environment,
+        } => Arc::new(StdioTransport::spawn(
+            &config.name,
+            program,
+            args,
+            environment,
+            config.timeout,
+        )?),
+        Transport::Http { url, headers } => Arc::new(HttpTransport::new(
+            &config.name,
+            url,
+            headers,
+            config.timeout,
+        )?),
+    };
+    transport::initialize(transport.as_ref()).await?;
+    let tool_infos = transport::list_tools(transport.as_ref()).await?;
+    let prompt_infos = transport::list_prompts(transport.as_ref()).await?;
+    info!(
+        server = config.name,
+        tool_count = tool_infos.len(),
+        prompt_count = prompt_infos.len(),
+        "MCP server initialized"
+    );
+    Ok(StartResult {
+        transport,
+        tool_infos,
+        prompt_infos,
+    })
+}
+
+fn parse_entries(config: McpConfig) -> McpManagerInner {
+    let origins = config.origins;
+    let mut entries = Vec::with_capacity(config.mcp.len());
+
+    for (name, raw) in config.mcp {
+        let transport_kind = transport_kind(&raw.transport);
+        let origin = origins.get(&name).cloned().unwrap_or_default();
+        let disabled = !raw.enabled;
+        let (config, status) = match parse_server(name.clone(), raw) {
+            Ok(sc) if disabled => (Some(sc), McpServerStatus::Disabled),
+            Ok(sc) => (Some(sc), McpServerStatus::Connecting),
+            Err(e) => {
+                warn!(server = %name, error = %e, "invalid MCP server config");
+                (None, McpServerStatus::Failed(e.to_string()))
+            }
+        };
+        entries.push(ServerEntry {
+            name,
+            config,
+            transport_kind,
+            origin,
+            status,
+            transport: None,
+            tools: Vec::new(),
+            prompts: Vec::new(),
+        });
+    }
+
+    McpManagerInner {
+        entries,
+        generation: 0,
+    }
+}
+
+async fn start_enabled(inner: &mut McpManagerInner) {
+    let tasks: Vec<_> = inner
+        .entries
+        .iter()
+        .enumerate()
+        .filter(|(_, e)| e.status == McpServerStatus::Connecting)
+        .filter_map(|(i, e)| e.config.clone().map(|c| (i, c)))
+        .map(|(i, cfg)| smol::spawn(async move { (i, start_server(&cfg).await) }))
+        .collect();
+
+    for task in tasks {
+        let (i, result) = task.await;
+        let _ = apply_start_result(&mut inner.entries[i], result, "start");
+    }
+}
+
+fn apply_start_result(
+    entry: &mut ServerEntry,
+    result: Result<StartResult, McpError>,
+    action: &'static str,
+) -> Result<(), McpError> {
+    match result {
+        Ok(start) => {
+            entry.populate(start);
+            Ok(())
+        }
+        Err(e) => {
+            entry.status = status_from_err(&e);
+            if !matches!(entry.status, McpServerStatus::NeedsAuth { .. }) {
+                warn!(server = %entry.name, action, error = %e, "MCP server start failed");
+            }
+            Err(e)
+        }
+    }
+}
+
+/// The only place read-side state is updated. Every mutation in the command loop ends here.
+fn publish(inner: &McpManagerInner, index: &ArcSwap<ToolIndex>, snapshot: &ArcSwap<McpSnapshot>) {
+    let mut tools = HashMap::new();
+    let mut prompts = HashMap::new();
+    let mut descriptors: Vec<Value> = Vec::new();
+    let mut server_infos = Vec::with_capacity(inner.entries.len());
+    let mut prompt_infos = Vec::new();
+    let mut pids = Vec::new();
+
+    for entry in &inner.entries {
+        let url = entry
+            .config
+            .as_ref()
+            .and_then(|c| transport_url(&c.transport));
+
+        if let Some(ref transport) = entry.transport
+            && entry.status != McpServerStatus::Disabled
+        {
+            for t in &entry.tools {
+                tools.insert(
+                    t.qualified_name,
+                    ToolRef {
+                        raw_name: t.raw_name.clone(),
+                        transport: Arc::clone(transport),
+                    },
+                );
+                descriptors.push(json!({
+                    "name": t.qualified_name,
+                    "description": t.description,
+                    "input_schema": t.input_schema,
+                }));
+            }
+            for p in &entry.prompts {
+                prompts.insert(
+                    p.qualified_name.clone(),
+                    PromptRef {
+                        raw_name: p.raw_name.clone(),
+                        transport: Arc::clone(transport),
+                    },
+                );
+                prompt_infos.push(p.to_info(&entry.name));
+            }
+            pids.extend(transport.child_pids());
+        }
+
+        server_infos.push(McpServerInfo {
+            name: entry.name.clone(),
+            transport_kind: entry.transport_kind,
+            tool_count: entry.tools.len(),
+            prompt_count: entry.prompts.len(),
+            status: entry.status.clone(),
+            config_path: entry.origin.clone(),
+            url,
+        });
+    }
+
+    index.store(Arc::new(ToolIndex {
+        tools,
+        prompts,
+        descriptors: descriptors.into(),
+    }));
+    snapshot.store(Arc::new(McpSnapshot {
+        infos: server_infos,
+        prompts: prompt_infos,
+        pids,
+        generation: inner.generation,
+    }));
+}
+
+fn transport_url(transport: &Transport) -> Option<String> {
+    match transport {
+        Transport::Http { url, .. } => Some(url.clone()),
+        Transport::Stdio { .. } => None,
+    }
+}
+
+fn spawn_persist_enabled(path: PathBuf, name: String, enabled: bool) {
+    let log_name = name.clone();
+    smol::spawn(async move {
+        if let Err(e) = smol::unblock(move || config::persist_enabled(&path, &name, enabled)).await
+        {
+            warn!(error = %e, server = %log_name, "failed to persist MCP toggle");
+        }
+    })
+    .detach();
 }
 
 #[cfg(unix)]
@@ -551,9 +686,9 @@ pub fn kill_process_groups(pids: &[u32]) {
 #[cfg(not(unix))]
 pub fn kill_process_groups(_pids: &[u32]) {}
 
+/// Leak the name into a `&'static str` so tool descriptors can use it without a lifetime. Names
+/// come from config, so the set is small and fixed per session, and the leak stays bounded.
 fn intern(name: String) -> &'static str {
-    use std::collections::HashSet;
-    use std::sync::{Mutex, OnceLock};
     static CACHE: OnceLock<Mutex<HashSet<&'static str>>> = OnceLock::new();
     let mut set = CACHE
         .get_or_init(|| Mutex::new(HashSet::new()))
@@ -570,9 +705,9 @@ fn intern(name: String) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use config::{McpServerStatus, RawServerConfig, RawStdioFields, RawTransport};
-    use std::collections::HashMap;
-    use std::path::PathBuf;
+    use async_lock::Mutex as AsyncMutex;
+    use config::{RawServerConfig, RawStdioFields, RawTransport};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 
@@ -597,34 +732,243 @@ mod tests {
         McpConfig { mcp, origins }
     }
 
-    #[test]
-    fn empty_config_returns_none() {
-        smol::block_on(async {
-            let config = McpConfig::default();
-            let result = McpManager::start_with_config(config).await;
-            assert!(result.is_none());
-        });
+    const TOOL_NAME: &str = "srv__tool";
+
+    /// Counts shutdowns, signals on `call_entered` the moment a `tools/call` begins, and holds
+    /// the call inside `call_gate` until tests release it. That way tests can meet an in-flight
+    /// RPC at a known point without polling.
+    struct FakeTransport {
+        name: Arc<str>,
+        shutdowns: AtomicUsize,
+        call_entered: flume::Sender<()>,
+        call_entered_rx: flume::Receiver<()>,
+        call_gate: AsyncMutex<()>,
+    }
+
+    impl FakeTransport {
+        fn new() -> Arc<Self> {
+            let (call_entered, call_entered_rx) = flume::bounded(1);
+            Arc::new(Self {
+                name: Arc::from("fake"),
+                shutdowns: AtomicUsize::new(0),
+                call_entered,
+                call_entered_rx,
+                call_gate: AsyncMutex::new(()),
+            })
+        }
+
+        fn shutdowns(&self) -> usize {
+            self.shutdowns.load(Ordering::SeqCst)
+        }
+    }
+
+    impl McpTransport for FakeTransport {
+        fn send_request<'a>(
+            &'a self,
+            method: &'a str,
+            _params: Option<Value>,
+        ) -> transport::BoxFuture<'a, Result<Value, McpError>> {
+            Box::pin(async move {
+                if method == "tools/call" {
+                    let _ = self.call_entered.try_send(());
+                    let _g = self.call_gate.lock().await;
+                    Ok(json!({ "content": [{ "type": "text", "text": "ok" }] }))
+                } else {
+                    Ok(Value::Null)
+                }
+            })
+        }
+        fn send_notification<'a>(
+            &'a self,
+            _method: &'a str,
+            _params: Option<Value>,
+        ) -> transport::BoxFuture<'a, Result<(), McpError>> {
+            Box::pin(async move { Ok(()) })
+        }
+        fn shutdown<'a>(&'a self) -> transport::BoxFuture<'a, ()> {
+            self.shutdowns.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async {})
+        }
+        fn server_name(&self) -> &Arc<str> {
+            &self.name
+        }
+        fn transport_kind(&self) -> &'static str {
+            "fake"
+        }
+    }
+
+    fn fake_entry(name: &str, transport: Arc<dyn McpTransport>) -> ServerEntry {
+        let qualified = intern(format!("{name}{SEPARATOR}tool"));
+        ServerEntry {
+            name: name.into(),
+            config: None,
+            transport_kind: "fake",
+            origin: PathBuf::new(),
+            status: McpServerStatus::Running,
+            transport: Some(transport),
+            tools: vec![McpToolDef {
+                qualified_name: qualified,
+                raw_name: "tool".into(),
+                description: String::new(),
+                input_schema: json!({}),
+            }],
+            prompts: Vec::new(),
+        }
+    }
+
+    fn bad_stdio_config(name: &str) -> ServerConfig {
+        ServerConfig {
+            name: name.into(),
+            timeout: std::time::Duration::from_secs(1),
+            transport: Transport::Stdio {
+                program: "/nonexistent/definitely-not-here".into(),
+                args: vec![],
+                environment: HashMap::new(),
+            },
+        }
+    }
+
+    /// Build `inner`, publish it into fresh `ArcSwap`s, and return a live `McpHandle` pointing
+    /// at the same state so tests can hit both the mutation and the read path.
+    fn setup(entries: Vec<ServerEntry>) -> (McpManagerInner, McpHandle) {
+        let inner = McpManagerInner {
+            entries,
+            generation: 0,
+        };
+        let index = Arc::new(ArcSwap::from_pointee(ToolIndex::default()));
+        let snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot::default()));
+        publish(&inner, &index, &snapshot);
+        let handle = McpHandle {
+            cmd_tx: flume::unbounded().0,
+            index,
+            snapshot,
+        };
+        (inner, handle)
     }
 
     #[test]
-    fn mixed_config_produces_correct_entries() {
+    fn start_with_config_produces_terminal_statuses() {
         smol::block_on(async {
-            let mut disabled = stdio_raw(&["echo"]);
+            assert!(start_with_config(McpConfig::default()).await.is_none());
+
+            let mut disabled = stdio_raw(&["unused-disabled-cmd"]);
             disabled.enabled = false;
             let config = make_config(vec![
                 ("disabled-srv", disabled),
                 ("bad-srv", stdio_raw(&[])),
-                ("also-bad", stdio_raw(&[])),
             ]);
-            let mgr = McpManager::start_with_config(config).await.unwrap();
-            let mut infos = mgr.server_infos(&[]);
+            let handle = start_with_config(config).await.unwrap();
+            let mut infos = handle.reader().load().infos.clone();
             infos.sort_by(|a, b| a.name.cmp(&b.name));
-            assert_eq!(infos.len(), 3);
+
             assert!(matches!(infos[0].status, McpServerStatus::Failed(_)));
             assert_eq!(infos[0].tool_count, 0);
-            assert!(matches!(infos[1].status, McpServerStatus::Failed(_)));
-            assert_eq!(infos[2].status, McpServerStatus::Disabled);
-            assert_eq!(infos[2].config_path, PathBuf::from("/test/config.toml"));
+            assert_eq!(infos[1].status, McpServerStatus::Disabled);
+        });
+    }
+
+    /// If a refresh fails, the entry must end up empty. A zombie tool left behind would be
+    /// handed to the model on the next turn and then try to call into a dead transport.
+    #[test]
+    fn failed_refresh_clears_entry() {
+        smol::block_on(async {
+            let t = FakeTransport::new();
+            let (mut inner, _) = setup(vec![fake_entry("srv", Arc::clone(&t) as _)]);
+            inner.entries[0].config = Some(bad_stdio_config("srv"));
+
+            assert!(refresh_server(&mut inner, "srv", None).await.is_err());
+
+            let entry = &inner.entries[0];
+            assert_eq!(t.shutdowns(), 1);
+            assert!(entry.tools.is_empty());
+            assert!(entry.prompts.is_empty());
+            assert!(entry.transport.is_none());
+            assert!(matches!(entry.status, McpServerStatus::Failed(_)));
+        });
+    }
+
+    #[test]
+    fn disable_purges_entry_and_published_view() {
+        smol::block_on(async {
+            let t = FakeTransport::new();
+            let (mut inner, handle) = setup(vec![fake_entry("srv", Arc::clone(&t) as _)]);
+
+            assert!(handle.has_tool(TOOL_NAME));
+            let mut tools = json!([]);
+            handle.extend_tools(&mut tools);
+            assert_eq!(tools[0]["name"], TOOL_NAME);
+
+            handle_toggle(&mut inner, "srv", false).await;
+            publish(&inner, &handle.index, &handle.snapshot);
+
+            let entry = &inner.entries[0];
+            assert_eq!(t.shutdowns(), 1);
+            assert!(entry.tools.is_empty());
+            assert!(entry.transport.is_none());
+            assert_eq!(entry.status, McpServerStatus::Disabled);
+            assert!(!handle.has_tool(TOOL_NAME));
+            let mut tools = json!([]);
+            handle.extend_tools(&mut tools);
+            assert!(tools.as_array().unwrap().is_empty());
+        });
+    }
+
+    /// Regression: the lock-free refactor fixed a case where `call_tool` held the inner read
+    /// lock across the transport await, so any in-flight call blocked every publish behind it.
+    /// The rendezvous here stays deterministic: the call signals on `call_entered`, the test
+    /// waits for that signal, then calls `publish` while the call is still parked on `call_gate`.
+    #[test]
+    fn slow_tool_call_does_not_block_publish() {
+        smol::block_on(async {
+            let t = FakeTransport::new();
+            let (mut inner, handle) = setup(vec![fake_entry("srv", Arc::clone(&t) as _)]);
+
+            let held = t.call_gate.lock().await;
+            let entered = t.call_entered_rx.clone();
+            let call_handle = {
+                let handle = handle.clone();
+                smol::spawn(async move { handle.call_tool(TOOL_NAME, &json!({})).await.unwrap() })
+            };
+
+            entered.recv_async().await.unwrap();
+            inner.generation += 1;
+            publish(&inner, &handle.index, &handle.snapshot);
+            assert_eq!(handle.snapshot.load().generation, 1);
+
+            drop(held);
+            call_handle.await;
+        });
+    }
+
+    #[test]
+    fn shutdown_command_drains_and_acks() {
+        smol::block_on(async {
+            let (t1, t2) = (FakeTransport::new(), FakeTransport::new());
+            let inner = McpManagerInner {
+                entries: vec![
+                    fake_entry("a", Arc::clone(&t1) as _),
+                    fake_entry("b", Arc::clone(&t2) as _),
+                ],
+                generation: 0,
+            };
+            let index = Arc::new(ArcSwap::from_pointee(ToolIndex::default()));
+            let snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot::default()));
+            let (cmd_tx, cmd_rx) = flume::unbounded();
+            let loop_task = smol::spawn(run(
+                inner,
+                Arc::clone(&index),
+                Arc::clone(&snapshot),
+                cmd_rx,
+            ));
+
+            let (ack_tx, ack_rx) = flume::bounded(1);
+            cmd_tx.send(McpCommand::Shutdown { ack: ack_tx }).unwrap();
+            ack_rx.recv_async().await.unwrap();
+            loop_task.await;
+
+            assert_eq!(t1.shutdowns(), 1);
+            assert_eq!(t2.shutdowns(), 1);
+            assert!(snapshot.load().infos.iter().all(|i| i.tool_count == 0));
         });
     }
 }

--- a/maki-agent/src/mcp/stdio.rs
+++ b/maki-agent/src/mcp/stdio.rs
@@ -312,7 +312,7 @@ impl McpTransport for StdioTransport {
         })
     }
 
-    fn shutdown(self: Box<Self>) -> BoxFuture<'static, ()> {
+    fn shutdown<'a>(&'a self) -> BoxFuture<'a, ()> {
         Box::pin(async move {
             self.alive.store(false, Ordering::Release);
             #[cfg(unix)]
@@ -320,7 +320,8 @@ impl McpTransport for StdioTransport {
                 libc::killpg(self._child.id() as i32, libc::SIGTERM);
             }
             smol::Timer::after(Duration::from_millis(200)).await;
-            // Drop of self._child (ChildGuard) sends SIGKILL to process group
+            // SIGTERM above gives the child a brief window to exit on its own. When the last
+            // Arc drops, `ChildGuard::drop` follows up with SIGKILL on the process group.
         })
     }
 

--- a/maki-agent/src/mcp/transport.rs
+++ b/maki-agent/src/mcp/transport.rs
@@ -27,7 +27,7 @@ pub trait McpTransport: Send + Sync {
         method: &'a str,
         params: Option<Value>,
     ) -> BoxFuture<'a, Result<(), McpError>>;
-    fn shutdown(self: Box<Self>) -> BoxFuture<'static, ()>;
+    fn shutdown<'a>(&'a self) -> BoxFuture<'a, ()>;
     fn server_name(&self) -> &Arc<str>;
     fn transport_kind(&self) -> &'static str;
     fn child_pids(&self) -> Vec<u32> {

--- a/maki-agent/src/tools/batch.rs
+++ b/maki-agent/src/tools/batch.rs
@@ -144,7 +144,7 @@ impl Batch {
         let active = &self.tool_calls[..self.tool_calls.len().min(MAX_BATCH_SIZE)];
         let discarded = &self.tool_calls[active.len()..];
 
-        let mcp = ctx.mcp.as_deref();
+        let mcp = ctx.mcp.as_ref();
 
         let parsed: Vec<Result<ResolvedCall, String>> = active
             .iter()

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -42,7 +42,7 @@ use tracing::{error, info, warn};
 
 use crate::agent::LoadedInstructions;
 use crate::cancel::CancelToken;
-use crate::mcp::McpManager;
+use crate::mcp::McpHandle;
 use crate::permissions::PermissionManager;
 use crate::skill::Skill;
 use crate::template::Vars;
@@ -246,7 +246,7 @@ pub struct ToolContext {
     pub skills: Arc<[Skill]>,
     pub loaded_instructions: LoadedInstructions,
     pub cancel: CancelToken,
-    pub mcp: Option<Arc<McpManager>>,
+    pub mcp: Option<McpHandle>,
     pub deadline: Deadline,
     pub config: AgentConfig,
     pub permissions: Arc<PermissionManager>,

--- a/maki-agent/src/tools/task.rs
+++ b/maki-agent/src/tools/task.rs
@@ -100,7 +100,7 @@ impl Task {
         };
         let mut tools = ToolCall::definitions(&vars, &ctx_desc, model.supports_tool_examples());
         if let Some(ref mcp) = ctx.mcp {
-            mcp.extend_tools(&mut tools, &[]);
+            mcp.extend_tools(&mut tools);
         }
 
         let (sub_tx, sub_rx) = flume::unbounded::<crate::Envelope>();

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -1,11 +1,10 @@
 use std::mem;
-use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use arc_swap::ArcSwap;
 use maki_agent::agent;
-use maki_agent::mcp::McpManager;
-use maki_agent::mcp::config::{McpServerInfo, persist_enabled};
+use maki_agent::mcp::McpHandle;
+use maki_agent::mcp::config::McpServerStatus;
 use maki_agent::permissions::PermissionManager;
 use maki_agent::skill::Skill;
 use maki_agent::template;
@@ -13,7 +12,7 @@ use maki_agent::template::Vars;
 use maki_agent::tools::{DescriptionContext, ToolCall, ToolFilter};
 use maki_agent::{
     Agent, AgentConfig, AgentEvent, AgentInput, AgentParams, AgentRunParams, CancelToken,
-    CancelTrigger, Envelope, EventSender, History, Instructions, McpPromptInfo, PromptRole,
+    CancelTrigger, Envelope, EventSender, History, Instructions, McpCommand, PromptRole,
 };
 use maki_providers::{AgentError, Message, Model, TokenUsage};
 use serde_json::Value;
@@ -22,7 +21,6 @@ use tracing::error;
 use super::ModelSlot;
 use super::cancel_map::CancelMap;
 use super::shared_queue::{QueueItem, SharedQueue};
-use super::toggle_disabled;
 
 pub(super) struct AgentLoop {
     model_slot: Arc<ArcSwap<ModelSlot>>,
@@ -31,11 +29,7 @@ pub(super) struct AgentLoop {
     vars: Vars,
     instructions: Instructions,
     tools: Value,
-    disabled: Vec<String>,
-    mcp_manager: Option<Arc<McpManager>>,
-    mcp_infos: Arc<ArcSwap<Vec<McpServerInfo>>>,
-    mcp_prompts: Arc<ArcSwap<Vec<McpPromptInfo>>>,
-    mcp_pids: Arc<Mutex<Vec<u32>>>,
+    mcp_handle: Option<McpHandle>,
     history: History,
     shared_history: Arc<ArcSwap<Vec<Message>>>,
     cancel_map: Arc<Mutex<CancelMap>>,
@@ -46,12 +40,6 @@ pub(super) struct AgentLoop {
     answer_rx: Arc<async_lock::Mutex<flume::Receiver<String>>>,
     notify_rx: flume::Receiver<()>,
     queue: Arc<SharedQueue>,
-    toggle_rx: flume::Receiver<(String, bool)>,
-}
-
-enum LoopEvent {
-    Queue,
-    Toggle(String, bool),
 }
 
 impl AgentLoop {
@@ -62,16 +50,12 @@ impl AgentLoop {
         config: AgentConfig,
         initial_history: Vec<Message>,
         shared_history: Arc<ArcSwap<Vec<Message>>>,
-        mcp_infos: Arc<ArcSwap<Vec<McpServerInfo>>>,
-        mcp_prompts: Arc<ArcSwap<Vec<McpPromptInfo>>>,
-        mcp_pids: Arc<Mutex<Vec<u32>>>,
-        initial_disabled: Vec<String>,
+        mcp_handle: Option<McpHandle>,
         permissions: Arc<PermissionManager>,
         agent_tx: flume::Sender<Envelope>,
         answer_rx: flume::Receiver<String>,
         notify_rx: flume::Receiver<()>,
         queue: Arc<SharedQueue>,
-        toggle_rx: flume::Receiver<(String, bool)>,
         cancel_map: Arc<Mutex<CancelMap>>,
         cancel: CancelToken,
     ) -> Self {
@@ -82,11 +66,7 @@ impl AgentLoop {
             vars: Vars::default(),
             instructions: Instructions::default(),
             tools: Value::Null,
-            disabled: initial_disabled,
-            mcp_manager: None,
-            mcp_infos,
-            mcp_prompts,
-            mcp_pids,
+            mcp_handle,
             history: History::new(initial_history),
             shared_history,
             cancel_map,
@@ -97,7 +77,6 @@ impl AgentLoop {
             answer_rx: Arc::new(async_lock::Mutex::new(answer_rx)),
             notify_rx,
             queue,
-            toggle_rx,
         }
     }
 
@@ -106,35 +85,12 @@ impl AgentLoop {
             return;
         }
 
-        loop {
-            let event = {
-                let notify_rx = &self.notify_rx;
-                let toggle_rx = &self.toggle_rx;
-                futures_lite::future::race(
-                    async { notify_rx.recv_async().await.ok().map(|_| LoopEvent::Queue) },
-                    async {
-                        toggle_rx
-                            .recv_async()
-                            .await
-                            .ok()
-                            .map(|(s, e)| LoopEvent::Toggle(s, e))
-                    },
-                )
-                .await
-            };
-
-            let Some(event) = event else { break };
-
-            match event {
-                LoopEvent::Toggle(name, enabled) => self.handle_mcp_toggle(name, enabled),
-                LoopEvent::Queue => {
-                    while let Some(entry) = self.queue.pop() {
-                        if entry.run_id() < self.min_run_id {
-                            continue;
-                        }
-                        self.process_entry(entry).await;
-                    }
+        while let Ok(()) = self.notify_rx.recv_async().await {
+            while let Some(entry) = self.queue.pop() {
+                if entry.run_id() < self.min_run_id {
+                    continue;
                 }
+                self.process_entry(entry).await;
             }
         }
     }
@@ -170,39 +126,11 @@ impl AgentLoop {
 
         let slot = self.model_slot.load();
         self.tools = self.build_tools(&slot.model);
-
-        let cwd = PathBuf::from(self.vars.apply("{cwd}").into_owned());
-        self.init_mcp(&cwd).await;
+        if let Some(ref mcp) = self.mcp_handle {
+            mcp.extend_tools(&mut self.tools);
+            spawn_oauth_for_needs_auth(mcp);
+        }
         !self.cancel.is_cancelled()
-    }
-
-    async fn init_mcp(&mut self, cwd: &Path) {
-        let mcp_config = maki_agent::mcp::config::load_config(cwd);
-        self.disabled.sort_unstable();
-        self.disabled.dedup();
-
-        if !mcp_config.is_empty() {
-            self.mcp_infos
-                .store(Arc::new(mcp_config.preliminary_infos(&self.disabled)));
-        }
-
-        let mcp_manager = self
-            .cancel
-            .race(McpManager::start_with_config(mcp_config))
-            .await
-            .unwrap_or(None);
-
-        if let Some(ref mgr) = mcp_manager {
-            mgr.extend_tools(&mut self.tools, &self.disabled);
-            let infos = mgr.server_infos(&self.disabled);
-            spawn_oauth_for_needs_auth(&infos, mgr, &self.mcp_infos, &self.disabled);
-            self.mcp_infos.store(Arc::new(infos));
-            self.mcp_prompts
-                .store(Arc::new(mgr.prompt_infos(&self.disabled)));
-            *self.mcp_pids.lock().unwrap_or_else(|e| e.into_inner()) = mgr.child_pids();
-        }
-
-        self.mcp_manager = mcp_manager;
     }
 
     async fn do_compact(&mut self, event_tx: &EventSender) -> Result<(), AgentError> {
@@ -232,10 +160,14 @@ impl AgentLoop {
             self.history.push(msg);
         }
 
-        if let Some(ref prompt_ref) = input.prompt
-            && let Some(ref mgr) = self.mcp_manager
-        {
-            let messages = mgr
+        if let Some(ref prompt_ref) = input.prompt {
+            let Some(ref mcp) = self.mcp_handle else {
+                return Err(AgentError::Tool {
+                    tool: "mcp_prompt".into(),
+                    message: "MCP not available".into(),
+                });
+            };
+            let messages = mcp
                 .get_prompt(&prompt_ref.qualified_name, &prompt_ref.arguments)
                 .await
                 .map_err(|e| AgentError::Tool {
@@ -283,7 +215,7 @@ impl AgentLoop {
         .with_user_response_rx(Arc::clone(&self.answer_rx))
         .with_interrupt_source(Arc::clone(&self.queue) as Arc<dyn maki_agent::InterruptSource>)
         .with_cancel(cancel)
-        .with_mcp(self.mcp_manager.clone());
+        .with_mcp(self.mcp_handle.clone());
 
         let outcome = agent.run(input).await;
 
@@ -298,24 +230,10 @@ impl AgentLoop {
         outcome.result
     }
 
-    fn handle_mcp_toggle(&mut self, server_name: String, enabled: bool) {
-        toggle_disabled(&mut self.disabled, &server_name, enabled);
-        let slot = self.model_slot.load();
-        self.rebuild_tools(&slot.model);
-
-        if let Some(ref mcp) = self.mcp_manager {
-            let infos = mcp.server_infos(&self.disabled);
-            self.persist_mcp_toggle(&infos, &server_name, enabled);
-            self.mcp_infos.store(Arc::new(infos));
-            self.mcp_prompts
-                .store(Arc::new(mcp.prompt_infos(&self.disabled)));
-        }
-    }
-
     fn rebuild_tools(&mut self, model: &Model) {
         let mut tools = self.build_tools(model);
-        if let Some(ref mcp) = self.mcp_manager {
-            mcp.extend_tools(&mut tools, &self.disabled);
+        if let Some(ref mcp) = self.mcp_handle {
+            mcp.extend_tools(&mut tools);
         }
         self.tools = tools;
     }
@@ -333,22 +251,6 @@ impl AgentLoop {
     async fn reload_instructions(&mut self) {
         let cwd = self.vars.apply("{cwd}").into_owned();
         self.instructions = smol::unblock(move || agent::load_instructions(&cwd)).await;
-    }
-
-    fn persist_mcp_toggle(&self, infos: &[McpServerInfo], server_name: &str, enabled: bool) {
-        if let Some(info) = infos.iter().find(|i| i.name == server_name) {
-            let path = info.config_path.clone();
-            let name = server_name.to_owned();
-            let server_for_log = server_name.to_owned();
-            smol::spawn(async move {
-                if let Err(e) =
-                    smol::unblock(move || persist_enabled(&path, &name, enabled)).await
-                {
-                    tracing::warn!(error = %e, server = %server_for_log, "failed to persist MCP toggle");
-                }
-            })
-            .detach();
-        }
     }
 
     fn sync_shared_history(&self) {
@@ -396,27 +298,19 @@ impl AgentLoop {
     }
 }
 
-fn spawn_oauth_for_needs_auth(
-    infos: &[McpServerInfo],
-    mgr: &Arc<McpManager>,
-    mcp_infos: &Arc<ArcSwap<Vec<McpServerInfo>>>,
-    disabled: &[String],
-) {
-    use maki_agent::mcp::config::McpServerStatus;
-
-    for info in infos {
+fn spawn_oauth_for_needs_auth(handle: &McpHandle) {
+    let snapshot = handle.reader().load().clone();
+    for info in snapshot.infos.iter() {
         let McpServerStatus::NeedsAuth { ref url } = info.status else {
             continue;
         };
         let Some(ref server_url) = info.url else {
             continue;
         };
-        let mgr = Arc::clone(mgr);
+        let handle = handle.clone();
         let server_name = info.name.clone();
         let server_url = server_url.clone();
         let www_auth = url.clone();
-        let mcp_infos = Arc::clone(mcp_infos);
-        let disabled = disabled.to_vec();
         smol::spawn(async move {
             let storage = match maki_storage::DataDir::resolve() {
                 Ok(s) => s,
@@ -442,14 +336,11 @@ fn spawn_oauth_for_needs_auth(
             let Some(ref tokens) = auth_data.tokens else {
                 return;
             };
-            if let Err(e) = mgr
-                .reconnect_server(&server_name, &server_url, &tokens.access)
-                .await
-            {
-                tracing::warn!(server = %server_name, error = %e, "OAuth reconnect failed");
-                return;
-            }
-            mcp_infos.store(Arc::new(mgr.server_infos(&disabled)));
+            handle.send(McpCommand::Reconnect {
+                server: server_name.clone(),
+                url: server_url,
+                token: tokens.access.clone(),
+            });
             tracing::info!(server = %server_name, "MCP server authenticated via OAuth");
         })
         .detach();

--- a/maki-ui/src/agent/command_router.rs
+++ b/maki-ui/src/agent/command_router.rs
@@ -5,27 +5,14 @@ use super::cancel_map::CancelMap;
 
 pub(super) fn spawn_command_router(
     cmd_rx: flume::Receiver<AgentCommand>,
-    toggle_tx: flume::Sender<(String, bool)>,
     cancel_map: Arc<Mutex<CancelMap>>,
 ) {
     smol::spawn(async move {
         while let Ok(cmd) = cmd_rx.recv_async().await {
+            let mut map = cancel_map.lock().unwrap_or_else(|e| e.into_inner());
             match cmd {
-                AgentCommand::Cancel { run_id } => {
-                    cancel_map
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .cancel(run_id);
-                }
-                AgentCommand::CancelAll => {
-                    cancel_map
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .cancel_all();
-                }
-                AgentCommand::ToggleMcp(name, enabled) => {
-                    let _ = toggle_tx.try_send((name, enabled));
-                }
+                AgentCommand::Cancel { run_id } => map.cancel(run_id),
+                AgentCommand::CancelAll => map.cancel_all(),
             }
         }
     })

--- a/maki-ui/src/agent/mod.rs
+++ b/maki-ui/src/agent/mod.rs
@@ -5,14 +5,17 @@ pub(crate) mod shared_queue;
 
 use std::collections::HashMap;
 use std::mem;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use arc_swap::ArcSwap;
-use maki_agent::mcp::config::McpServerInfo;
+use maki_agent::mcp;
 use maki_agent::permissions::PermissionManager;
 use maki_agent::skill::Skill;
-use maki_agent::{AgentConfig, CancelToken, Envelope, McpPromptInfo, ToolOutput};
+use maki_agent::{
+    AgentConfig, CancelToken, Envelope, McpCommand, McpHandle, McpSnapshotReader, ToolOutput,
+};
 
 use self::cancel_map::CancelMap;
 use maki_providers::provider::Provider;
@@ -25,6 +28,8 @@ use self::agent_loop::AgentLoop;
 use self::command_router::spawn_command_router;
 pub(crate) use self::shared_queue::{QueuedMessage, SharedQueue};
 
+const MCP_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+
 pub(crate) struct ModelSlot {
     pub(crate) model: Model,
     pub(crate) provider: Arc<dyn Provider>,
@@ -33,15 +38,6 @@ pub(crate) struct ModelSlot {
 pub(crate) enum AgentCommand {
     Cancel { run_id: u64 },
     CancelAll,
-    ToggleMcp(String, bool),
-}
-
-#[derive(Clone, Default)]
-pub(crate) struct McpState {
-    pub(crate) disabled: Vec<String>,
-    pub(crate) infos: Arc<ArcSwap<Vec<McpServerInfo>>>,
-    pub(crate) prompts: Arc<ArcSwap<Vec<McpPromptInfo>>>,
-    pub(crate) pids: Arc<Mutex<Vec<u32>>>,
 }
 
 pub(crate) struct AgentHandles {
@@ -50,12 +46,40 @@ pub(crate) struct AgentHandles {
     pub(crate) answer_tx: flume::Sender<String>,
     pub(crate) history: Arc<ArcSwap<Vec<Message>>>,
     pub(crate) tool_outputs: Arc<Mutex<HashMap<String, ToolOutput>>>,
-    pub(crate) mcp: McpState,
+    pub(crate) mcp_handle: Option<McpHandle>,
     pub(crate) queue: Arc<SharedQueue>,
     task: smol::Task<()>,
 }
 
 impl AgentHandles {
+    /// MCP is started once up front. The handle lives across agent respawns, only the agent
+    /// loop task gets replaced.
+    pub(crate) fn spawn(
+        model_slot: &Arc<ArcSwap<ModelSlot>>,
+        initial_history: Vec<Message>,
+        skills: &Arc<[Skill]>,
+        config: AgentConfig,
+        permissions: &Arc<PermissionManager>,
+        cwd: PathBuf,
+    ) -> Self {
+        let mcp_handle = smol::block_on(mcp::start(&cwd));
+        spawn_agent_internal(
+            model_slot,
+            initial_history,
+            skills,
+            config,
+            permissions,
+            mcp_handle,
+        )
+    }
+
+    pub(crate) fn mcp_reader(&self) -> McpSnapshotReader {
+        self.mcp_handle
+            .as_ref()
+            .map(McpHandle::reader)
+            .unwrap_or_else(McpSnapshotReader::empty)
+    }
+
     pub(crate) fn apply_to_app(&self, app: &mut App) {
         app.answer_tx = Some(self.answer_tx.clone());
         app.cmd_tx = Some(self.cmd_tx.clone());
@@ -68,7 +92,12 @@ impl AgentHandles {
         let _ = self.cmd_tx.try_send(AgentCommand::CancelAll);
     }
 
-    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn send_mcp(&self, cmd: McpCommand) {
+        if let Some(ref h) = self.mcp_handle {
+            h.send(cmd);
+        }
+    }
+
     pub(crate) fn respawn(
         &mut self,
         history: Vec<Message>,
@@ -82,17 +111,22 @@ impl AgentHandles {
         if let Err(e) = smol::block_on(slot.provider.reload_auth()) {
             warn!(error = %e, "failed to reload auth, continuing with existing credentials");
         }
-        let mcp = self.mcp.clone();
-        let old = mem::replace(
-            self,
-            spawn_agent(model_slot, history, skills, config, permissions, mcp),
+        let new = spawn_agent_internal(
+            model_slot,
+            history,
+            skills,
+            config,
+            permissions,
+            self.mcp_handle.clone(),
         );
+        let old = mem::replace(self, new);
         old.cancel();
         self.apply_to_app(app);
     }
 
     pub(crate) fn shutdown(self, timeout: Duration) {
         let _ = self.cmd_tx.try_send(AgentCommand::CancelAll);
+        let mcp_handle = self.mcp_handle;
         let task = self.task;
         drop((self.cmd_tx, self.agent_rx, self.answer_tx));
         info!("waiting for agent to finish (timeout {timeout:?})");
@@ -111,30 +145,44 @@ impl AgentHandles {
             if !finished {
                 warn!("agent did not finish within {timeout:?}, forcing shutdown");
             }
+
+            if let Some(handle) = mcp_handle {
+                shutdown_mcp(&handle).await;
+            }
         });
     }
 }
 
-pub(crate) fn toggle_disabled(disabled: &mut Vec<String>, name: &str, enabled: bool) {
-    if enabled {
-        disabled.retain(|s| s != name);
-    } else if !disabled.contains(&name.to_owned()) {
-        disabled.push(name.to_owned());
+async fn shutdown_mcp(handle: &McpHandle) {
+    let (ack_tx, ack_rx) = flume::bounded(1);
+    handle.send(McpCommand::Shutdown { ack: ack_tx });
+    let finished = futures_lite::future::or(
+        async {
+            let _ = ack_rx.recv_async().await;
+            true
+        },
+        async {
+            smol::Timer::after(MCP_SHUTDOWN_TIMEOUT).await;
+            false
+        },
+    )
+    .await;
+    if !finished {
+        warn!("MCP shutdown timed out after {MCP_SHUTDOWN_TIMEOUT:?}");
     }
 }
 
-pub(crate) fn spawn_agent(
+fn spawn_agent_internal(
     model_slot: &Arc<ArcSwap<ModelSlot>>,
     initial_history: Vec<Message>,
     skills: &Arc<[Skill]>,
     config: AgentConfig,
     permissions: &Arc<PermissionManager>,
-    mcp_state: McpState,
+    mcp_handle: Option<McpHandle>,
 ) -> AgentHandles {
     let (agent_tx, agent_rx) = flume::unbounded::<Envelope>();
     let (cmd_tx, cmd_rx) = flume::unbounded::<AgentCommand>();
     let (answer_tx, answer_rx) = flume::unbounded::<String>();
-    let (toggle_tx, toggle_rx) = flume::unbounded::<(String, bool)>();
     let (queue, notify_rx) = SharedQueue::new();
     let shared_history: Arc<ArcSwap<Vec<Message>>> =
         Arc::new(ArcSwap::from_pointee(initial_history.clone()));
@@ -143,7 +191,7 @@ pub(crate) fn spawn_agent(
     let (init_trigger, init_cancel) = CancelToken::new();
     let cancel_map = Arc::new(Mutex::new(CancelMap::new(0, init_trigger)));
 
-    spawn_command_router(cmd_rx, toggle_tx, Arc::clone(&cancel_map));
+    spawn_command_router(cmd_rx, Arc::clone(&cancel_map));
 
     let agent_loop = AgentLoop::new(
         Arc::clone(model_slot),
@@ -151,16 +199,12 @@ pub(crate) fn spawn_agent(
         config,
         initial_history,
         Arc::clone(&shared_history),
-        Arc::clone(&mcp_state.infos),
-        Arc::clone(&mcp_state.prompts),
-        Arc::clone(&mcp_state.pids),
-        mcp_state.disabled.clone(),
+        mcp_handle.clone(),
         Arc::clone(permissions),
         agent_tx,
         answer_rx,
         notify_rx,
         Arc::clone(&queue),
-        toggle_rx,
         cancel_map,
         init_cancel,
     );
@@ -173,7 +217,7 @@ pub(crate) fn spawn_agent(
         answer_tx,
         history: shared_history,
         tool_outputs: shared_tool_outputs,
-        mcp: mcp_state,
+        mcp_handle,
         queue,
         task,
     }

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -51,7 +51,7 @@ use crossterm::event::{KeyCode, KeyEvent, MouseEvent};
 use maki_agent::QuestionInfo;
 use maki_agent::permissions::{PermissionDecision, PermissionManager};
 use maki_agent::{
-    AgentEvent, Envelope, ImageSource, McpPromptInfo, McpServerInfo, SubagentInfo, ToolOutput,
+    AgentEvent, Envelope, ImageSource, McpPromptInfo, McpSnapshotReader, SubagentInfo, ToolOutput,
 };
 use maki_config::UiConfig;
 use maki_providers::{Message, Model, ThinkingConfig};
@@ -149,8 +149,7 @@ impl App {
         session: AppSession,
         storage: DataDir,
         available_models: Arc<ArcSwapOption<Vec<String>>>,
-        mcp_infos: Arc<ArcSwap<Vec<McpServerInfo>>>,
-        mcp_prompts: Arc<ArcSwap<Vec<McpPromptInfo>>>,
+        mcp_reader: McpSnapshotReader,
         storage_writer: Arc<StorageWriter>,
         ui_config: UiConfig,
         input_history_size: usize,
@@ -163,12 +162,12 @@ impl App {
             active_chat: 0,
             chat_index: HashMap::new(),
             input_box: InputBox::new(InputHistory::load(&storage, input_history_size)),
-            command_palette: CommandPalette::new(custom_commands, mcp_prompts),
+            command_palette: CommandPalette::new(custom_commands, mcp_reader.clone()),
             task_picker: ListPicker::new(),
             task_picker_original: None,
             theme_picker: ThemePicker::new(),
             model_picker: ModelPicker::new(available_models),
-            mcp_picker: McpPicker::new(mcp_infos),
+            mcp_picker: McpPicker::new(mcp_reader),
             session_picker: SessionPicker::new(),
             rewind_picker: RewindPicker::new(),
             help_modal: HelpModal::new(),

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -9,10 +9,12 @@ use arc_swap::ArcSwap;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEventKind};
 use maki_agent::permissions::PermissionManager;
 use maki_agent::{
-    QuestionInfo, QuestionOption, ToolDoneEvent, ToolOutput, ToolStartEvent, TurnCompleteEvent,
+    ImageMediaType, McpServerInfo, McpServerStatus, McpSnapshot, McpSnapshotReader, QuestionInfo,
+    QuestionOption, ToolDoneEvent, ToolOutput, ToolStartEvent, TurnCompleteEvent,
 };
 use maki_config::{PermissionsConfig, UiConfig};
-use maki_providers::TokenUsage;
+use maki_providers::{ContentBlock, Role, TokenUsage};
+use maki_storage::sessions::StoredThinking;
 use ratatui::layout::Rect;
 use std::env;
 use std::path::{Path, PathBuf};
@@ -29,7 +31,6 @@ fn set_zone(app: &mut App, zone: SelectionZone, area: Rect) {
 
 fn test_app() -> App {
     let writer = Arc::new(StorageWriter::new(DataDir::from_path(env::temp_dir())));
-    let mcp_infos = Arc::new(ArcSwap::from_pointee(Vec::new()));
     let permissions = Arc::new(PermissionManager::new(
         PermissionsConfig {
             allow_all: false,
@@ -43,8 +44,7 @@ fn test_app() -> App {
         AppSession::new("test-model", "/tmp/test"),
         DataDir::from_path(env::temp_dir()),
         Arc::new(ArcSwapOption::empty()),
-        mcp_infos,
-        Arc::new(ArcSwap::from_pointee(Vec::new())),
+        McpSnapshotReader::empty(),
         writer,
         UiConfig::default(),
         100,
@@ -147,7 +147,6 @@ fn with_text(app: &mut App) {
 }
 
 fn with_image(app: &mut App) {
-    use maki_agent::ImageMediaType;
     let img = ImageSource::new(ImageMediaType::Png, Arc::from("dGVzdA=="));
     app.input_box.attach_image(img);
 }
@@ -443,15 +442,13 @@ fn load_session_clears_plan() {
     let writer = Arc::new(StorageWriter::new(DataDir::from_path(
         tmp.path().to_path_buf(),
     )));
-    let mcp_infos = Arc::new(ArcSwap::from_pointee(Vec::new()));
     let model = test_model();
     let mut app = App::new(
         &model,
         AppSession::new("test-model", "/tmp/test"),
         dir,
         Arc::new(ArcSwapOption::empty()),
-        mcp_infos,
-        Arc::new(ArcSwap::from_pointee(Vec::new())),
+        McpSnapshotReader::empty(),
         writer,
         UiConfig::default(),
         100,
@@ -1448,7 +1445,6 @@ fn slash_noncommand_sends_as_prompt() {
 
 fn build_rewind_app() -> App {
     let mut app = test_app();
-    use maki_providers::{ContentBlock, Message, Role};
 
     app.state.session.messages = vec![
         Message::user("first prompt".into()),
@@ -1645,19 +1641,21 @@ fn mcp_command_opens_picker() {
 
 #[test]
 fn mcp_toggle_dispatches_action() {
-    use maki_agent::{McpServerInfo, McpServerStatus};
-    use std::path::PathBuf;
-
     let mut app = test_app();
-    app.mcp_picker = McpPicker::new(Arc::new(ArcSwap::from_pointee(vec![McpServerInfo {
-        name: "test-srv".into(),
-        transport_kind: "stdio",
-        tool_count: 2,
-        prompt_count: 0,
-        status: McpServerStatus::Running,
-        config_path: PathBuf::from("/tmp/config.toml"),
-        url: None,
-    }])));
+    app.mcp_picker = McpPicker::new(McpSnapshotReader::from_snapshot(McpSnapshot {
+        infos: vec![McpServerInfo {
+            name: "test-srv".into(),
+            transport_kind: "stdio",
+            tool_count: 2,
+            prompt_count: 0,
+            status: McpServerStatus::Running,
+            config_path: PathBuf::from("/tmp/config.toml"),
+            url: None,
+        }],
+        prompts: vec![],
+        pids: vec![],
+        generation: 0,
+    }));
     app.execute_command(cmd("/mcp"));
 
     let actions = app.update(Msg::Key(key(KeyCode::Enter)));
@@ -1772,7 +1770,6 @@ fn overlay_zone_click_gating() {
 }
 
 fn streaming_app_with_history() -> App {
-    use maki_providers::{ContentBlock, Message, Role};
     let mut app = test_app();
     app.status = Status::Streaming;
     app.run_id = 1;
@@ -2000,8 +1997,6 @@ fn thinking_non_anthropic_flashes_error() {
 
 #[test]
 fn thinking_restored_from_session_meta() {
-    use maki_storage::sessions::StoredThinking;
-
     let tmp = TempDir::new().unwrap();
     let storage = DataDir::from_path(tmp.path().to_path_buf());
     let mut session = AppSession::new("test-model", "/tmp/test");

--- a/maki-ui/src/components/command.rs
+++ b/maki-ui/src/components/command.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 
-use arc_swap::ArcSwap;
 use crossterm::event::{KeyCode, KeyEvent};
-use maki_agent::McpPromptInfo;
 use maki_agent::command::CustomCommand;
+use maki_agent::{McpPromptInfo, McpSnapshotReader};
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
@@ -119,22 +118,24 @@ pub struct CommandPalette {
     selected: usize,
     filtered: Vec<FilteredItem>,
     custom: Arc<[CustomCommand]>,
-    mcp_prompts_source: Arc<ArcSwap<Vec<McpPromptInfo>>>,
-    mcp_prompts: Arc<Vec<McpPromptInfo>>,
+    mcp_reader: McpSnapshotReader,
+    mcp_prompts: Vec<McpPromptInfo>,
+    mcp_generation: u64,
 }
 
 impl CommandPalette {
-    pub fn new(
-        custom_commands: Arc<[CustomCommand]>,
-        mcp_prompts: Arc<ArcSwap<Vec<McpPromptInfo>>>,
-    ) -> Self {
-        let snapshot = mcp_prompts.load_full();
+    pub fn new(custom_commands: Arc<[CustomCommand]>, mcp_reader: McpSnapshotReader) -> Self {
+        let snap = mcp_reader.load();
+        let mcp_generation = snap.generation;
+        let prompts = snap.prompts.clone();
+        drop(snap);
         Self {
             selected: 0,
             filtered: Vec::new(),
             custom: custom_commands,
-            mcp_prompts_source: mcp_prompts,
-            mcp_prompts: snapshot,
+            mcp_reader,
+            mcp_prompts: prompts,
+            mcp_generation,
         }
     }
 
@@ -175,7 +176,12 @@ impl CommandPalette {
     }
 
     pub fn sync(&mut self, input: &str) {
-        self.mcp_prompts = self.mcp_prompts_source.load_full();
+        let snap = self.mcp_reader.load();
+        if snap.generation != self.mcp_generation {
+            self.mcp_generation = snap.generation;
+            self.mcp_prompts = snap.prompts.clone();
+        }
+        drop(snap);
         let Some(stripped) = input.strip_prefix('/') else {
             self.filtered.clear();
             return;
@@ -370,21 +376,21 @@ impl CommandPalette {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use maki_agent::McpPromptArg;
+    use maki_agent::{McpPromptArg, McpSnapshot};
     use test_case::test_case;
 
-    fn empty_prompts() -> Arc<ArcSwap<Vec<McpPromptInfo>>> {
-        Arc::new(ArcSwap::from_pointee(Vec::new()))
+    fn empty_snapshot() -> McpSnapshotReader {
+        McpSnapshotReader::empty()
     }
 
     fn synced(input: &str) -> CommandPalette {
-        let mut p = CommandPalette::new(Arc::from([]), empty_prompts());
+        let mut p = CommandPalette::new(Arc::from([]), empty_snapshot());
         p.sync(input);
         p
     }
 
     fn synced_with_custom(input: &str, custom: Arc<[CustomCommand]>) -> CommandPalette {
-        let mut p = CommandPalette::new(custom, empty_prompts());
+        let mut p = CommandPalette::new(custom, empty_snapshot());
         p.sync(input);
         p
     }
@@ -455,7 +461,7 @@ mod tests {
 
     #[test]
     fn confirm_when_inactive_returns_none() {
-        let p = CommandPalette::new(Arc::from([]), empty_prompts());
+        let p = CommandPalette::new(Arc::from([]), empty_snapshot());
         assert!(p.confirm("").is_none());
     }
 
@@ -506,7 +512,7 @@ mod tests {
     #[test_case("/compact", "/compact", ""    ; "other_command")]
     #[test_case("/btw hello world", "/btw", "hello world" ; "btw_multi_word")]
     fn confirm_parses_args(input: &str, expected_name: &str, expected_args: &str) {
-        let mut p = CommandPalette::new(Arc::from([]), empty_prompts());
+        let mut p = CommandPalette::new(Arc::from([]), empty_snapshot());
         p.sync(input);
         let cmd = p.confirm(input).unwrap();
         assert_eq!(cmd.name, expected_name);
@@ -516,7 +522,7 @@ mod tests {
     #[test]
     fn confirm_custom_command() {
         let custom = sample_custom();
-        let mut p = CommandPalette::new(custom, empty_prompts());
+        let mut p = CommandPalette::new(custom, empty_snapshot());
         p.sync("/project:review");
         assert!(p.is_active());
         let cmd = p.confirm("/project:review some-file.rs").unwrap();
@@ -527,32 +533,37 @@ mod tests {
     #[test]
     fn find_custom_command_lookup() {
         let custom = sample_custom();
-        let p = CommandPalette::new(custom, empty_prompts());
+        let p = CommandPalette::new(custom, empty_snapshot());
         let found = p.find_custom_command("/project:review");
         assert!(found.is_some());
         assert_eq!(found.unwrap().content, "Review $ARGUMENTS");
         assert!(p.find_custom_command("/nonexistent").is_none());
     }
 
-    fn sample_prompts() -> Arc<ArcSwap<Vec<McpPromptInfo>>> {
-        Arc::new(ArcSwap::from_pointee(vec![
-            McpPromptInfo {
-                display_name: "myserver:code-review".into(),
-                qualified_name: "myserver/code-review".into(),
-                description: "Review code changes".into(),
-                arguments: vec![McpPromptArg {
-                    name: "diff".into(),
-                    description: "The diff".into(),
-                    required: true,
-                }],
-            },
-            McpPromptInfo {
-                display_name: "myserver:summarize".into(),
-                qualified_name: "myserver/summarize".into(),
-                description: "Summarize text".into(),
-                arguments: vec![],
-            },
-        ]))
+    fn sample_prompts() -> McpSnapshotReader {
+        McpSnapshotReader::from_snapshot(McpSnapshot {
+            infos: vec![],
+            prompts: vec![
+                McpPromptInfo {
+                    display_name: "myserver:code-review".into(),
+                    qualified_name: "myserver/code-review".into(),
+                    description: "Review code changes".into(),
+                    arguments: vec![McpPromptArg {
+                        name: "diff".into(),
+                        description: "The diff".into(),
+                        required: true,
+                    }],
+                },
+                McpPromptInfo {
+                    display_name: "myserver:summarize".into(),
+                    qualified_name: "myserver/summarize".into(),
+                    description: "Summarize text".into(),
+                    arguments: vec![],
+                },
+            ],
+            pids: vec![],
+            generation: 0,
+        })
     }
 
     fn synced_with_prompts(input: &str) -> CommandPalette {

--- a/maki-ui/src/components/list_picker.rs
+++ b/maki-ui/src/components/list_picker.rs
@@ -288,6 +288,14 @@ impl<T: PickerItem> ListPicker<T> {
         }
     }
 
+    pub fn replace_toggleable(&mut self, items: Vec<T>, enabled: Vec<bool>) {
+        if let Some(s) = self.state.as_mut().and_then(PickerState::ready_mut) {
+            self.generation += 1;
+            s.enabled = Some(enabled);
+            s.replace_items(items);
+        }
+    }
+
     pub fn retain(&mut self, f: impl Fn(&T) -> bool) {
         let Some(s) = self.state.as_mut().and_then(PickerState::ready_mut) else {
             return;

--- a/maki-ui/src/components/mcp_picker.rs
+++ b/maki-ui/src/components/mcp_picker.rs
@@ -1,16 +1,51 @@
-use std::sync::Arc;
-
-use arc_swap::ArcSwap;
 use crossterm::event::KeyEvent;
 use ratatui::Frame;
 use ratatui::layout::Rect;
 
-use maki_agent::{McpServerInfo, McpServerStatus};
+use maki_agent::{McpServerInfo, McpServerStatus, McpSnapshotReader};
 
 use crate::components::Overlay;
 use crate::components::list_picker::{ListPicker, PickerAction, PickerItem};
 
 const TITLE: &str = " MCP Servers ";
+
+fn build_entries(infos: &[McpServerInfo]) -> (Vec<McpEntry>, Vec<bool>) {
+    let entries = infos
+        .iter()
+        .map(|info| McpEntry {
+            name: info.name.clone(),
+            detail_text: match &info.status {
+                McpServerStatus::Connecting => {
+                    format!("{} \u{00b7} connecting\u{2026}", info.transport_kind)
+                }
+                McpServerStatus::Running => {
+                    let mut parts = vec![info.transport_kind.to_string()];
+                    if info.tool_count > 0 {
+                        parts.push(format!("{} tools", info.tool_count));
+                    }
+                    if info.prompt_count > 0 {
+                        parts.push(format!("{} prompts", info.prompt_count));
+                    }
+                    if info.tool_count == 0 && info.prompt_count == 0 {
+                        parts.push("no capabilities".into());
+                    }
+                    parts.join(" \u{00b7} ")
+                }
+                McpServerStatus::Disabled => {
+                    format!("{} \u{00b7} disabled", info.transport_kind)
+                }
+                McpServerStatus::Failed(e) => {
+                    format!("{} \u{00b7} error: {}", info.transport_kind, e)
+                }
+                McpServerStatus::NeedsAuth { .. } => {
+                    format!("{} \u{00b7} needs auth", info.transport_kind)
+                }
+            },
+        })
+        .collect();
+    let enabled = infos.iter().map(|info| info.status.is_active()).collect();
+    (entries, enabled)
+}
 
 pub enum McpPickerAction {
     Consumed,
@@ -35,56 +70,37 @@ impl PickerItem for McpEntry {
 
 pub struct McpPicker {
     picker: ListPicker<McpEntry>,
-    infos: Arc<ArcSwap<Vec<McpServerInfo>>>,
+    snapshot: McpSnapshotReader,
+    last_generation: u64,
 }
 
 impl McpPicker {
-    pub fn new(infos: Arc<ArcSwap<Vec<McpServerInfo>>>) -> Self {
+    pub fn new(snapshot: McpSnapshotReader) -> Self {
         Self {
             picker: ListPicker::new(),
-            infos,
+            snapshot,
+            last_generation: 0,
         }
     }
 
     pub fn open(&mut self) {
-        let guard = self.infos.load();
-        let infos: &[McpServerInfo] = &guard;
-
-        let entries: Vec<McpEntry> = infos
-            .iter()
-            .map(|info| McpEntry {
-                name: info.name.clone(),
-                detail_text: match &info.status {
-                    McpServerStatus::Connecting => {
-                        format!("{} \u{00b7} connecting\u{2026}", info.transport_kind)
-                    }
-                    McpServerStatus::Running => {
-                        let mut parts = vec![info.transport_kind.to_string()];
-                        if info.tool_count > 0 {
-                            parts.push(format!("{} tools", info.tool_count));
-                        }
-                        if info.prompt_count > 0 {
-                            parts.push(format!("{} prompts", info.prompt_count));
-                        }
-                        if info.tool_count == 0 && info.prompt_count == 0 {
-                            parts.push("no capabilities".into());
-                        }
-                        parts.join(" \u{00b7} ")
-                    }
-                    McpServerStatus::Disabled => {
-                        format!("{} \u{00b7} disabled", info.transport_kind)
-                    }
-                    McpServerStatus::Failed(e) => {
-                        format!("{} \u{00b7} error: {}", info.transport_kind, e)
-                    }
-                    McpServerStatus::NeedsAuth { .. } => {
-                        format!("{} \u{00b7} needs auth", info.transport_kind)
-                    }
-                },
-            })
-            .collect();
-        let enabled: Vec<bool> = infos.iter().map(|info| info.status.is_active()).collect();
+        let guard = self.snapshot.load();
+        self.last_generation = guard.generation;
+        let (entries, enabled) = build_entries(&guard.infos);
         self.picker.open_toggleable(entries, enabled, TITLE);
+    }
+
+    pub fn refresh(&mut self) {
+        if !self.picker.is_open() {
+            return;
+        }
+        let guard = self.snapshot.load();
+        if guard.generation == self.last_generation {
+            return;
+        }
+        self.last_generation = guard.generation;
+        let (entries, enabled) = build_entries(&guard.infos);
+        self.picker.replace_toggleable(entries, enabled);
     }
 
     pub fn is_open(&self) -> bool {
@@ -135,35 +151,41 @@ mod tests {
     use crate::components::key;
     use crate::components::keybindings::key as kb;
     use crossterm::event::{KeyCode, KeyEvent};
+    use maki_agent::McpSnapshot;
     use std::path::PathBuf;
     use test_case::test_case;
 
-    fn test_infos() -> Arc<ArcSwap<Vec<McpServerInfo>>> {
-        Arc::new(ArcSwap::from_pointee(vec![
-            McpServerInfo {
-                name: "fs".into(),
-                transport_kind: "stdio",
-                tool_count: 5,
-                prompt_count: 0,
-                status: McpServerStatus::Running,
-                config_path: PathBuf::from("/home/.config/maki/config.toml"),
-                url: None,
-            },
-            McpServerInfo {
-                name: "github".into(),
-                transport_kind: "stdio",
-                tool_count: 3,
-                prompt_count: 0,
-                status: McpServerStatus::Disabled,
-                config_path: PathBuf::from("/project/.maki/config.toml"),
-                url: None,
-            },
-        ]))
+    fn test_snapshot() -> McpSnapshotReader {
+        McpSnapshotReader::from_snapshot(McpSnapshot {
+            infos: vec![
+                McpServerInfo {
+                    name: "fs".into(),
+                    transport_kind: "stdio",
+                    tool_count: 5,
+                    prompt_count: 0,
+                    status: McpServerStatus::Running,
+                    config_path: PathBuf::from("/home/.config/maki/config.toml"),
+                    url: None,
+                },
+                McpServerInfo {
+                    name: "github".into(),
+                    transport_kind: "stdio",
+                    tool_count: 3,
+                    prompt_count: 0,
+                    status: McpServerStatus::Disabled,
+                    config_path: PathBuf::from("/project/.maki/config.toml"),
+                    url: None,
+                },
+            ],
+            prompts: vec![],
+            pids: vec![],
+            generation: 0,
+        })
     }
 
     #[test]
     fn toggle_returns_server_name_and_new_state() {
-        let mut p = McpPicker::new(test_infos());
+        let mut p = McpPicker::new(test_snapshot());
         p.open();
         let action = p.handle_key(key(KeyCode::Enter));
         assert!(matches!(
@@ -175,7 +197,7 @@ mod tests {
     #[test_case(key(KeyCode::Esc)       ; "esc_closes")]
     #[test_case(kb::QUIT.to_key_event() ; "ctrl_c_closes")]
     fn close_keys(cancel_key: KeyEvent) {
-        let mut p = McpPicker::new(test_infos());
+        let mut p = McpPicker::new(test_snapshot());
         p.open();
         let action = p.handle_key(cancel_key);
         assert!(matches!(action, McpPickerAction::Close));
@@ -184,8 +206,7 @@ mod tests {
 
     #[test]
     fn open_with_empty_infos() {
-        let infos = Arc::new(ArcSwap::from_pointee(vec![]));
-        let mut p = McpPicker::new(infos);
+        let mut p = McpPicker::new(McpSnapshotReader::empty());
         p.open();
         assert!(p.is_open());
     }

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -10,7 +10,7 @@ use crossterm::event::{
 use maki_agent::command::CustomCommand;
 use maki_agent::permissions::PermissionManager;
 use maki_agent::skill::Skill;
-use maki_agent::{AgentConfig, CancelToken};
+use maki_agent::{AgentConfig, CancelToken, McpCommand};
 use maki_config::UiConfig;
 use maki_providers::provider::{Provider, fetch_all_models, from_model};
 use maki_providers::{Message, Model};
@@ -18,10 +18,7 @@ use maki_storage::DataDir;
 use tracing::warn;
 
 use crate::AppSession;
-use crate::agent::{
-    AgentCommand, AgentHandles, McpState, ModelSlot, shared_queue::QueueItem, spawn_agent,
-    toggle_disabled,
-};
+use crate::agent::{AgentCommand, AgentHandles, ModelSlot, shared_queue::QueueItem};
 use crate::app::shell::{ShellEvent, spawn_shell};
 use crate::app::{App, Msg};
 #[cfg(feature = "demo")]
@@ -162,11 +159,26 @@ impl<'t> EventLoop<'t> {
 
         let bg = spawn_model_fetch();
         let storage_writer = Arc::new(StorageWriter::new(storage.clone()));
-        let mcp_state = McpState::default();
         let (shell_tx, shell_rx) = flume::unbounded::<ShellEvent>();
 
         let resumed = !session.messages.is_empty();
         let initial_history = session.messages.clone();
+        let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
+
+        let provider: Arc<dyn Provider> = Arc::from(from_model(&model).context("create provider")?);
+        let skills: Arc<[Skill]> = Arc::from(skills);
+        let model_slot = Arc::new(ArcSwap::from_pointee(ModelSlot {
+            model: model.clone(),
+            provider,
+        }));
+        let handles = AgentHandles::spawn(
+            &model_slot,
+            initial_history,
+            &skills,
+            config.clone(),
+            &permissions,
+            cwd,
+        );
 
         let custom_commands: Arc<[CustomCommand]> = Arc::from(commands);
         let mut app = App::new(
@@ -174,8 +186,7 @@ impl<'t> EventLoop<'t> {
             session,
             storage,
             bg.available,
-            Arc::clone(&mcp_state.infos),
-            Arc::clone(&mcp_state.prompts),
+            handles.mcp_reader(),
             Arc::clone(&storage_writer),
             ui_config,
             input_history_size,
@@ -188,17 +199,6 @@ impl<'t> EventLoop<'t> {
             apply_demo(&mut app);
         }
 
-        let provider: Arc<dyn Provider> = Arc::from(from_model(&model).context("create provider")?);
-        let skills: Arc<[Skill]> = Arc::from(skills);
-        let model_slot = Arc::new(ArcSwap::from_pointee(ModelSlot { model, provider }));
-        let handles = spawn_agent(
-            &model_slot,
-            initial_history,
-            &skills,
-            config.clone(),
-            &permissions,
-            mcp_state,
-        );
         handles.apply_to_app(&mut app);
 
         if resumed {
@@ -241,6 +241,7 @@ impl<'t> EventLoop<'t> {
         self.app.poll_image_paste();
         self.app.btw_modal.poll();
         self.app.status_bar.poll_branch_update();
+        self.app.mcp_picker.refresh();
     }
 
     fn drain_channels(&mut self) -> bool {
@@ -396,11 +397,10 @@ impl<'t> EventLoop<'t> {
                 });
             }
             Action::ToggleMcp(server_name, enabled) => {
-                toggle_disabled(&mut self.handles.mcp.disabled, &server_name, enabled);
-                let _ = self
-                    .handles
-                    .cmd_tx
-                    .try_send(AgentCommand::ToggleMcp(server_name, enabled));
+                self.handles.send_mcp(McpCommand::Toggle {
+                    server: server_name,
+                    enabled,
+                });
             }
             Action::ShellCommand {
                 id,
@@ -455,14 +455,7 @@ impl<'t> EventLoop<'t> {
             .app
             .has_content()
             .then(|| self.app.state.session.id.clone());
-        maki_agent::mcp::kill_process_groups(
-            &self
-                .handles
-                .mcp
-                .pids
-                .lock()
-                .unwrap_or_else(|e| e.into_inner()),
-        );
+        maki_agent::mcp::kill_process_groups(&self.handles.mcp_reader().load().pids);
         self.app.cmd_tx = None;
         self.app.answer_tx = None;
         drop(self.app);

--- a/src/print.rs
+++ b/src/print.rs
@@ -23,7 +23,7 @@ use std::time::{Duration, Instant};
 use clap::ValueEnum;
 use color_eyre::Result;
 use color_eyre::eyre::Context;
-use maki_agent::mcp::McpManager;
+use maki_agent::mcp;
 use maki_agent::skill::Skill;
 use maki_agent::tools::{DescriptionContext, QUESTION_TOOL_NAME, ToolCall, ToolFilter};
 use maki_agent::{
@@ -153,10 +153,10 @@ pub fn run(
     };
     let mut tools = ToolCall::definitions(&vars, &ctx, model.supports_tool_examples());
 
-    let mcp_manager = smol::block_on(McpManager::start(&cwd_path));
+    let mcp_handle = smol::block_on(mcp::start(&cwd_path));
 
-    if let Some(ref mcp) = mcp_manager {
-        mcp.extend_tools(&mut tools, &[]);
+    if let Some(ref handle) = mcp_handle {
+        handle.extend_tools(&mut tools);
     }
 
     let system = agent::build_system_prompt(&vars, &mode, &instructions.text);
@@ -214,7 +214,7 @@ pub fn run(
             },
         )
         .with_loaded_instructions(instructions.loaded)
-        .with_mcp(mcp_manager);
+        .with_mcp(mcp_handle);
         let outcome = agent.run(input).await;
         if let Err(e) = outcome.result {
             error!(error = %e, "agent error");


### PR DESCRIPTION
Enabling an MCP server from /mcp now connects to it and fetches fresh tools and prompts instead of unfiltering the stale in-memory cache. Disable + enable is a reliable manual refresh flow.

State is managed through a single McpManager::run() command loop that processes Toggle, Reconnect and Shutdown sequentially. External callers use McpHandle: read-only ArcSwap<McpSnapshot> for UI, a command channel for mutations, and direct access for tool calls. This eliminates concurrent refresh races, stale tool windows between toggle and refresh completion, and redundant picker rebuilds. OAuth reconnect routes through McpCommand::Reconnect with a disabled-server guard.

A generation counter replaces pointer-based change detection in the MCP picker, providing reliable UI updates when snapshot content changes but Arc is reused.

https://github.com/tontinton/maki/pull/31