### PR TITLE
agent & ui: split queue into sender/receiver so shutdown is drop driven

### DIFF
--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -106,6 +106,9 @@ struct ServerEntry {
 impl ServerEntry {
     async fn clear_connection(&mut self) {
         if let Some(old) = self.transport.take() {
+            // A live tool call can still be holding an `Arc` to this transport via the
+            // `ToolIndex`, so we cannot rely on `Drop` to reap the child in time.
+            kill_process_groups(&old.child_pids());
             old.shutdown().await;
         }
         self.tools.clear();

--- a/maki-agent/src/mcp/stdio.rs
+++ b/maki-agent/src/mcp/stdio.rs
@@ -314,14 +314,11 @@ impl McpTransport for StdioTransport {
 
     fn shutdown<'a>(&'a self) -> BoxFuture<'a, ()> {
         Box::pin(async move {
+            // Flip `alive` so any in-flight reader or writer gives up with a clean error.
+            // We deliberately do not signal the child here: the transport lives behind an
+            // Arc, and once the last clone goes away `ChildGuard::drop` takes care of
+            // killing the whole process group. Doing it twice just raced with itself.
             self.alive.store(false, Ordering::Release);
-            #[cfg(unix)]
-            unsafe {
-                libc::killpg(self._child.id() as i32, libc::SIGTERM);
-            }
-            smol::Timer::after(Duration::from_millis(200)).await;
-            // SIGTERM above gives the child a brief window to exit on its own. When the last
-            // Arc drops, `ChildGuard::drop` follows up with SIGKILL on the process group.
         })
     }
 

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -20,7 +20,7 @@ use tracing::error;
 
 use super::ModelSlot;
 use super::cancel_map::CancelMap;
-use super::shared_queue::{QueueItem, SharedQueue};
+use super::shared_queue::{QueueItem, QueueReceiver};
 
 pub(super) struct AgentLoop {
     model_slot: Arc<ArcSwap<ModelSlot>>,
@@ -33,13 +33,12 @@ pub(super) struct AgentLoop {
     history: History,
     shared_history: Arc<ArcSwap<Vec<Message>>>,
     cancel_map: Arc<Mutex<CancelMap>>,
-    cancel: CancelToken,
+    init_cancel: CancelToken,
     permissions: Arc<PermissionManager>,
     min_run_id: u64,
     agent_tx: flume::Sender<Envelope>,
     answer_rx: Arc<async_lock::Mutex<flume::Receiver<String>>>,
-    notify_rx: flume::Receiver<()>,
-    queue: Arc<SharedQueue>,
+    queue: Arc<QueueReceiver>,
     session_id: Option<String>,
 }
 
@@ -55,10 +54,9 @@ impl AgentLoop {
         permissions: Arc<PermissionManager>,
         agent_tx: flume::Sender<Envelope>,
         answer_rx: flume::Receiver<String>,
-        notify_rx: flume::Receiver<()>,
-        queue: Arc<SharedQueue>,
+        queue: Arc<QueueReceiver>,
         cancel_map: Arc<Mutex<CancelMap>>,
-        cancel: CancelToken,
+        init_cancel: CancelToken,
         session_id: Option<String>,
     ) -> Self {
         Self {
@@ -72,12 +70,11 @@ impl AgentLoop {
             history: History::new(initial_history),
             shared_history,
             cancel_map,
-            cancel,
+            init_cancel,
             permissions,
             min_run_id: 0,
             agent_tx,
             answer_rx: Arc::new(async_lock::Mutex::new(answer_rx)),
-            notify_rx,
             queue,
             session_id,
         }
@@ -88,7 +85,7 @@ impl AgentLoop {
             return;
         }
 
-        while let Ok(()) = self.notify_rx.recv_async().await {
+        while let Ok(()) = self.queue.recv_notify().await {
             while let Some(entry) = self.queue.pop() {
                 if entry.run_id() < self.min_run_id {
                     continue;
@@ -123,7 +120,7 @@ impl AgentLoop {
     async fn initialize(&mut self) -> bool {
         self.vars = template::env_vars();
         self.reload_instructions().await;
-        if self.cancel.is_cancelled() {
+        if self.init_cancel.is_cancelled() {
             return false;
         }
 
@@ -133,7 +130,7 @@ impl AgentLoop {
             mcp.extend_tools(&mut self.tools);
             spawn_oauth_for_needs_auth(mcp);
         }
-        !self.cancel.is_cancelled()
+        !self.init_cancel.is_cancelled()
     }
 
     async fn do_compact(&mut self, event_tx: &EventSender) -> Result<(), AgentError> {

--- a/maki-ui/src/agent/mod.rs
+++ b/maki-ui/src/agent/mod.rs
@@ -26,7 +26,7 @@ use crate::app::App;
 
 use self::agent_loop::AgentLoop;
 use self::command_router::spawn_command_router;
-pub(crate) use self::shared_queue::{QueuedMessage, SharedQueue};
+pub(crate) use self::shared_queue::{QueueSender, QueuedMessage};
 
 const MCP_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -47,7 +47,7 @@ pub(crate) struct AgentHandles {
     pub(crate) history: Arc<ArcSwap<Vec<Message>>>,
     pub(crate) tool_outputs: Arc<Mutex<HashMap<String, ToolOutput>>>,
     pub(crate) mcp_handle: Option<McpHandle>,
-    pub(crate) queue: Arc<SharedQueue>,
+    pub(crate) queue: QueueSender,
     task: smol::Task<()>,
 }
 
@@ -87,7 +87,7 @@ impl AgentHandles {
         app.cmd_tx = Some(self.cmd_tx.clone());
         app.shared_history = Some(Arc::clone(&self.history));
         app.shared_tool_outputs = Some(Arc::clone(&self.tool_outputs));
-        app.queue.set_shared(Arc::clone(&self.queue));
+        app.queue.set_shared(self.queue.clone());
     }
 
     pub(crate) fn cancel(self) {
@@ -123,15 +123,17 @@ impl AgentHandles {
             Some(app.state.session.id.clone()),
         );
         let old = mem::replace(self, new);
-        old.cancel();
+        // Repoint the app at the new queue before dropping `old`, otherwise the app keeps
+        // the last old `QueueSender` alive and the old loop parks in `recv_notify` forever.
         self.apply_to_app(app);
+        old.cancel();
     }
 
     pub(crate) fn shutdown(self, timeout: Duration) {
         let _ = self.cmd_tx.try_send(AgentCommand::CancelAll);
         let mcp_handle = self.mcp_handle;
         let task = self.task;
-        drop((self.cmd_tx, self.agent_rx, self.answer_tx));
+        drop((self.cmd_tx, self.agent_rx, self.answer_tx, self.queue));
         info!("waiting for agent to finish (timeout {timeout:?})");
         smol::block_on(async {
             let finished = futures_lite::future::or(
@@ -187,7 +189,8 @@ fn spawn_agent_internal(
     let (agent_tx, agent_rx) = flume::unbounded::<Envelope>();
     let (cmd_tx, cmd_rx) = flume::unbounded::<AgentCommand>();
     let (answer_tx, answer_rx) = flume::unbounded::<String>();
-    let (queue, notify_rx) = SharedQueue::new();
+    let (queue_tx, queue_rx) = shared_queue::queue();
+    let queue_rx = Arc::new(queue_rx);
     let shared_history: Arc<ArcSwap<Vec<Message>>> =
         Arc::new(ArcSwap::from_pointee(initial_history.clone()));
     let shared_tool_outputs: Arc<Mutex<HashMap<String, ToolOutput>>> =
@@ -207,8 +210,7 @@ fn spawn_agent_internal(
         Arc::clone(permissions),
         agent_tx,
         answer_rx,
-        notify_rx,
-        Arc::clone(&queue),
+        queue_rx,
         cancel_map,
         init_cancel,
         session_id,
@@ -223,7 +225,7 @@ fn spawn_agent_internal(
         history: shared_history,
         tool_outputs: shared_tool_outputs,
         mcp_handle,
-        queue,
+        queue: queue_tx,
         task,
     }
 }

--- a/maki-ui/src/agent/shared_queue.rs
+++ b/maki-ui/src/agent/shared_queue.rs
@@ -1,3 +1,11 @@
+//! Queue of work handed from the UI to the agent loop.
+//!
+//! Shutdown rides on `Drop`: when the last [`QueueSender`] goes away, flume
+//! closes the notify channel, so the receiver's `recv_notify` wakes with an
+//! `Err` and the agent loop falls out of its main loop on its own. That way
+//! nobody needs a separate "please stop" flag, and callers can't forget to
+//! set it.
+
 use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
@@ -9,6 +17,8 @@ use crate::components::queue_panel::QueueEntry;
 use crate::theme;
 
 const COMPACT_LABEL: &str = "/compact";
+
+type Items = Arc<Mutex<VecDeque<QueueItem>>>;
 
 pub(crate) struct QueuedMessage {
     pub(crate) text: String,
@@ -67,47 +77,46 @@ impl QueueItem {
     }
 }
 
-pub(crate) struct SharedQueue {
-    inner: Mutex<VecDeque<QueueItem>>,
-    notify_tx: flume::Sender<()>,
-}
-
 fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
     mutex.lock().unwrap_or_else(PoisonError::into_inner)
 }
 
-impl SharedQueue {
-    pub(crate) fn new() -> (Arc<Self>, flume::Receiver<()>) {
-        let (tx, rx) = flume::bounded(1);
-        (
-            Arc::new(Self {
-                inner: Mutex::new(VecDeque::new()),
-                notify_tx: tx,
-            }),
-            rx,
-        )
-    }
+#[derive(Clone)]
+pub(crate) struct QueueSender {
+    items: Items,
+    notify_tx: flume::Sender<()>,
+}
 
+pub(crate) struct QueueReceiver {
+    items: Items,
+    notify_rx: flume::Receiver<()>,
+}
+
+pub(crate) fn queue() -> (QueueSender, QueueReceiver) {
+    let (notify_tx, notify_rx) = flume::bounded(1);
+    let items: Items = Arc::new(Mutex::new(VecDeque::new()));
+    (
+        QueueSender {
+            items: Arc::clone(&items),
+            notify_tx,
+        },
+        QueueReceiver { items, notify_rx },
+    )
+}
+
+impl QueueSender {
     pub(crate) fn push(&self, entry: QueueItem) {
-        lock(&self.inner).push_back(entry);
+        lock(&self.items).push_back(entry);
         let _ = self.notify_tx.try_send(());
     }
 
-    pub(crate) fn pop(&self) -> Option<QueueItem> {
-        lock(&self.inner).pop_front()
-    }
-
     pub(crate) fn remove(&self, index: usize) -> Option<QueueItem> {
-        let mut inner = lock(&self.inner);
-        if index < inner.len() {
-            inner.remove(index)
-        } else {
-            None
-        }
+        let mut items = lock(&self.items);
+        (index < items.len()).then(|| items.remove(index)).flatten()
     }
 
     pub(crate) fn len(&self) -> usize {
-        lock(&self.inner).len()
+        lock(&self.items).len()
     }
 
     #[cfg(test)]
@@ -116,11 +125,11 @@ impl SharedQueue {
     }
 
     pub(crate) fn clear(&self) {
-        lock(&self.inner).clear();
+        lock(&self.items).clear();
     }
 
     pub(crate) fn text_messages(&self) -> Vec<String> {
-        lock(&self.inner)
+        lock(&self.items)
             .iter()
             .filter_map(|item| match item {
                 QueueItem::Message { text, .. } => Some(text.clone()),
@@ -130,15 +139,45 @@ impl SharedQueue {
     }
 
     pub(crate) fn entries(&self) -> Vec<QueueEntry<'static>> {
-        lock(&self.inner)
+        lock(&self.items)
             .iter()
             .map(QueueItem::as_queue_entry)
             .collect()
     }
 }
 
-impl InterruptSource for SharedQueue {
+impl QueueReceiver {
+    pub(crate) fn pop(&self) -> Option<QueueItem> {
+        lock(&self.items).pop_front()
+    }
+
+    pub(crate) async fn recv_notify(&self) -> Result<(), flume::RecvError> {
+        self.notify_rx.recv_async().await
+    }
+}
+
+impl InterruptSource for QueueReceiver {
     fn poll(&self) -> Option<ExtractedCommand> {
         self.pop().map(QueueItem::into_extracted_command)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn last_sender_drop_closes_notify_channel() {
+        let (tx, rx) = queue();
+        let tx2 = tx.clone();
+
+        drop(tx);
+        assert_eq!(rx.notify_rx.try_recv(), Err(flume::TryRecvError::Empty));
+
+        drop(tx2);
+        assert_eq!(
+            rx.notify_rx.try_recv(),
+            Err(flume::TryRecvError::Disconnected)
+        );
     }
 }

--- a/maki-ui/src/app/queue.rs
+++ b/maki-ui/src/app/queue.rs
@@ -1,24 +1,20 @@
 //! Queue for messages typed while the agent is busy.
 //!
-//! MessageQueue wraps SharedQueue and manages UI-only state (focus).
-
-use std::sync::Arc;
-
 use super::{App, format_with_images};
 
-use crate::agent::shared_queue::{QueueItem, SharedQueue};
+use crate::agent::shared_queue::{QueueItem, QueueSender};
 use crate::components::queue_panel::QueueEntry;
 
 pub(crate) use crate::agent::shared_queue::QueuedMessage;
 
 #[derive(Default)]
 pub(crate) struct MessageQueue {
-    shared: Option<Arc<SharedQueue>>,
+    shared: Option<QueueSender>,
     focus: Option<usize>,
 }
 
 impl MessageQueue {
-    pub(crate) fn set_shared(&mut self, shared: Arc<SharedQueue>) {
+    pub(crate) fn set_shared(&mut self, shared: QueueSender) {
         self.shared = Some(shared);
     }
 

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::agent::shared_queue::SharedQueue;
+use crate::agent::shared_queue;
 use crate::chat::{CANCELLED_TEXT, DONE_TEXT, ERROR_TEXT};
 use crate::components::command::ParsedCommand;
 use crate::components::keybindings::{KeybindContext, key as kb};
@@ -51,7 +51,7 @@ fn test_app() -> App {
         permissions,
         Arc::from([]),
     );
-    let (shared_queue, _rx) = SharedQueue::new();
+    let (shared_queue, _rx) = shared_queue::queue();
     app.queue.set_shared(shared_queue);
     app
 }


### PR DESCRIPTION
Quitting the UI blocked for 3 seconds after the MCP command loop refactor. The agent loop held its own Arc<SharedQueue> alongside every producer, so dropping the outside senders never closed the notify channel and recv_async parked forever until the shutdown timeout kicked in.

shared_queue now exposes QueueSender (clonable producer) and a non-clone QueueReceiver owned by the agent loop. AgentHandles::shutdown drops the last sender in one tuple and the outer loop wakes with Err on the next recv_notify. While touching shutdown, the 200ms SIGTERM sleep in stdio transport is gone too: kill_process_groups already sent SIGKILL before this path runs.