### PR TITLE
agent: stop the tool schema and the parser from drifting apart

### DIFF
--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -109,7 +109,12 @@ fn parse_tool_calls<'a>(
     let mut errors = Vec::new();
 
     for (id, name, input) in tool_uses {
-        debug!(tool = %name, id = %id, raw_input = %input, "parsing tool call");
+        debug!(
+            tool = %name,
+            id = %id,
+            input_preview = %crate::tools::schema::preview(&input.to_string()),
+            "parsing tool call"
+        );
         if recent.is_doom_loop(name, input) {
             warn!(tool = %name, "doom loop detected, skipping execution");
             errors.push(ToolDoneEvent::error(id.to_owned(), DOOM_LOOP_MESSAGE));
@@ -120,11 +125,21 @@ fn parse_tool_calls<'a>(
                     call,
                 }),
                 Err(AgentError::Tool { message, .. }) => {
-                    warn!(tool = %name, input = %input, error = %message, "failed to parse tool call");
+                    warn!(
+                        tool = %name,
+                        input_preview = %crate::tools::schema::preview(&input.to_string()),
+                        error = %message,
+                        "failed to parse tool call"
+                    );
                     errors.push(ToolDoneEvent::error(id.to_owned(), message));
                 }
                 Err(e) => {
-                    warn!(tool = %name, input = %input, error = %e, "failed to parse tool call");
+                    warn!(
+                        tool = %name,
+                        input_preview = %crate::tools::schema::preview(&input.to_string()),
+                        error = %e,
+                        "failed to parse tool call"
+                    );
                     errors.push(ToolDoneEvent::error(id.to_owned(), e.to_string()));
                 }
             }

--- a/maki-agent/src/tools/bash.rs
+++ b/maki-agent/src/tools/bash.rs
@@ -9,6 +9,7 @@ use async_process::Command;
 use futures_lite::StreamExt;
 use futures_lite::io::{AsyncBufReadExt, BufReader};
 use maki_tool_macro::Tool;
+use serde::Deserialize;
 
 use crate::{AgentEvent, EventSender, ToolInput, ToolOutput};
 
@@ -103,7 +104,7 @@ fn timeout_or_cancel_msg(
     msg
 }
 
-#[derive(Tool, Debug, Clone)]
+#[derive(Tool, Debug, Clone, Deserialize)]
 pub struct Bash {
     #[param(description = "The bash command to execute")]
     command: String,

--- a/maki-agent/src/tools/batch.rs
+++ b/maki-agent/src/tools/batch.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Deserializer};
 use serde_json::Value;
 
 use crate::task_set::TaskSet;
-use maki_tool_macro::{Args, Tool};
+use maki_tool_macro::Tool;
 use tracing::{error, info};
 
 use std::time::Instant;
@@ -21,12 +21,17 @@ use super::{ToolCall, ToolContext};
 
 const MAX_BATCH_SIZE: usize = 25;
 
-#[derive(Args, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub(super) struct BatchEntry {
-    #[param(description = "The name of the tool to execute")]
     tool: String,
-    #[param(description = "Parameters for the tool")]
     parameters: Value,
+}
+
+impl BatchEntry {
+    pub(crate) const ITEM_SCHEMA: &'static crate::tools::schema::ParamSchema =
+        &crate::tools::schema::ParamSchema::Any {
+            description: "Tool invocation: { tool: string, parameters: object } or flat { tool: string, ...params }",
+        };
 }
 
 /// Models sometimes send batch entries with flat fields:
@@ -117,7 +122,7 @@ impl BatchEntry {
     }
 }
 
-#[derive(Tool, Debug, Clone)]
+#[derive(Tool, Debug, Clone, Deserialize)]
 pub struct Batch {
     #[param(description = "Array of tool calls to execute in parallel")]
     tool_calls: Vec<BatchEntry>,

--- a/maki-agent/src/tools/code_execution.rs
+++ b/maki-agent/src/tools/code_execution.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use maki_interpreter::runner::{self, ToolFn};
 use maki_interpreter::{AsyncResolver, PendingCall};
 use maki_tool_macro::Tool;
+use serde::Deserialize;
 use serde_json::Value;
 
 use std::sync::Arc;
@@ -27,7 +28,7 @@ use super::{Deadline, INTERPRETER_TOOLS};
 const STREAM_FLUSH_INTERVAL: Duration = Duration::from_millis(100);
 const PREAMBLE: &str = "import re\nimport asyncio\nimport sys\nimport os\nimport json\n";
 
-#[derive(Tool, Debug, Clone)]
+#[derive(Tool, Debug, Clone, Deserialize)]
 pub struct CodeExecution {
     #[param(
         description = "Python code to execute. Tools are async functions that return strings (not objects). You MUST await every call: `result = await read(path='/file')`. Use `await asyncio.gather(...)` for concurrency."

--- a/maki-agent/src/tools/edit.rs
+++ b/maki-agent/src/tools/edit.rs
@@ -2,11 +2,12 @@ use std::fs;
 
 use crate::ToolOutput;
 use maki_tool_macro::Tool;
+use serde::Deserialize;
 
 use super::fuzzy_replace;
 use super::relative_path;
 
-#[derive(Tool, Debug, Clone)]
+#[derive(Tool, Debug, Clone, Deserialize)]
 pub struct Edit {
     #[param(description = "Absolute path to the file")]
     path: String,

--- a/maki-agent/src/tools/find_symbol.rs
+++ b/maki-agent/src/tools/find_symbol.rs
@@ -2,13 +2,14 @@ use std::path::Path;
 
 use maki_code_index::find_symbol::{FindSymbolError, find_symbol as do_find_symbol};
 use maki_tool_macro::Tool;
+use serde::Deserialize;
 
 use super::relative_path;
 use crate::ToolOutput;
 
 const DEFAULT_MAX_RESULTS: usize = 50;
 
-#[derive(Tool, Debug, Clone)]
+#[derive(Tool, Debug, Clone, Deserialize)]
 pub struct FindSymbol {
     #[param(description = "Symbol name")]
     symbol: String,

--- a/maki-agent/src/tools/glob.rs
+++ b/maki-agent/src/tools/glob.rs
@@ -1,10 +1,11 @@
 use crate::ToolOutput;
 use maki_tool_macro::Tool;
+use serde::Deserialize;
 use tracing::debug;
 
 use super::{mtime, relative_path, resolve_search_path, walk_builder};
 
-#[derive(Tool, Debug, Clone)]
+#[derive(Tool, Debug, Clone, Deserialize)]
 pub struct Glob {
     #[param(description = "Glob pattern (e.g. **/*.rs, src/**/*.ts)")]
     pattern: String,

--- a/maki-agent/src/tools/grep.rs
+++ b/maki-agent/src/tools/grep.rs
@@ -7,6 +7,7 @@ use grep_searcher::Searcher;
 use grep_searcher::SearcherBuilder;
 use grep_searcher::{Sink, SinkContext, SinkFinish, SinkMatch};
 use maki_tool_macro::Tool;
+use serde::Deserialize;
 use tracing::debug;
 
 use super::{
@@ -21,7 +22,7 @@ fn needs_multiline(pattern: &str) -> bool {
     pattern.contains("\\n") || pattern.contains("(?s)") || pattern.contains("(?m)")
 }
 
-#[derive(Tool, Debug, Clone, Default)]
+#[derive(Tool, Debug, Clone, Default, Deserialize)]
 pub struct Grep {
     #[param(description = "Regex pattern")]
     pattern: String,

--- a/maki-agent/src/tools/index.rs
+++ b/maki-agent/src/tools/index.rs
@@ -3,10 +3,11 @@ use std::path::Path;
 use crate::ToolOutput;
 use maki_code_index::{IndexError, index_file};
 use maki_tool_macro::Tool;
+use serde::Deserialize;
 
 use super::relative_path;
 
-#[derive(Tool, Debug, Clone)]
+#[derive(Tool, Debug, Clone, Deserialize)]
 pub struct Index {
     #[param(description = "Absolute path to the file")]
     path: String,

--- a/maki-agent/src/tools/memory.rs
+++ b/maki-agent/src/tools/memory.rs
@@ -5,12 +5,13 @@ use std::path::{Path, PathBuf};
 use crate::ToolOutput;
 use futures_lite::StreamExt;
 use maki_tool_macro::Tool;
+use serde::Deserialize;
 
 const MAX_LINES_PER_FILE: usize = 200;
 const MAX_DIR_BYTES: u64 = 50 * 1024;
 const VALID_COMMANDS: &[&str] = &["view", "write", "delete"];
 
-#[derive(Tool, Debug, Clone)]
+#[derive(Tool, Debug, Clone, Deserialize)]
 pub struct Memory {
     #[param(description = "Command: view, write, delete")]
     command: String,

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -19,6 +19,7 @@ pub mod memory;
 mod multiedit;
 mod question;
 mod read;
+pub(crate) mod schema;
 mod skill;
 mod task;
 mod todowrite;
@@ -486,10 +487,10 @@ pub(crate) fn sanitize_tool_input(input: &Value) -> Value {
     let mut out = serde_json::Map::new();
     for (key, val) in obj {
         let norm_key = to_snake_case(key);
-        let new_val = val
-            .as_str()
-            .map(|s| strip_stray_quotes(key, s))
-            .unwrap_or_else(|| val.clone());
+        let new_val = match val.as_str() {
+            Some(s) => Value::String(strip_stray_quotes(key, s)),
+            None => val.clone(),
+        };
         if norm_key != *key {
             warn!(original = %key, normalized = %norm_key, "normalized camelCase key to snake_case");
         }
@@ -498,15 +499,15 @@ pub(crate) fn sanitize_tool_input(input: &Value) -> Value {
     Value::Object(out)
 }
 
-fn strip_stray_quotes(field: &str, s: &str) -> Value {
+fn strip_stray_quotes(field: &str, s: &str) -> String {
     let t = s.trim();
     if let Some(inner) = t.strip_prefix('"').and_then(|s| s.strip_suffix('"'))
         && !inner.contains('"')
     {
         warn!(field = %field, original = %s, fixed = %inner, "stripped stray quotes from tool param");
-        return Value::String(inner.to_string());
+        return inner.to_string();
     }
-    Value::String(s.to_string())
+    s.to_string()
 }
 
 fn to_snake_case(s: &str) -> String {
@@ -522,43 +523,6 @@ fn to_snake_case(s: &str) -> String {
         }
     }
     result
-}
-
-fn coerce_value(val: &Value, field: &str, json_type: &str) -> Option<Value> {
-    let coerced = match (val, json_type) {
-        (Value::String(s), "integer") => parse_number::<i64>(s).map(Value::from),
-        (Value::String(s), "number") => parse_number::<f64>(s).map(Value::from),
-        (Value::String(s), "boolean") => match s.trim() {
-            "true" => Some(Value::Bool(true)),
-            "false" => Some(Value::Bool(false)),
-            _ => None,
-        },
-        _ => None,
-    }?;
-    warn!(field = %field, original = %val, fixed = %coerced, "coerced tool param type");
-    Some(coerced)
-}
-
-pub(crate) fn deserialize_with_coercion<T: serde::de::DeserializeOwned>(
-    raw: &Value,
-    field: &str,
-    json_type: &str,
-) -> Result<T, String> {
-    serde_json::from_value::<T>(raw.clone()).or_else(|serde_err| {
-        coerce_value(raw, field, json_type)
-            .and_then(|c| serde_json::from_value(c).ok())
-            .ok_or_else(|| {
-                let msg = format!(
-                    "Invalid value for parameter '{}' (expected {}): {}",
-                    field, json_type, serde_err
-                );
-                msg
-            })
-    })
-}
-
-fn parse_number<T: std::str::FromStr>(s: &str) -> Option<T> {
-    s.trim().parse().ok()
 }
 
 macro_rules! register_tools {
@@ -605,7 +569,7 @@ macro_rules! register_tools {
                     $(<$inner>::NAME => {
                         <$inner>::parse_input(input)
                             .map(|v| ToolCall::$Variant(Box::new(v)))
-                            .map_err(|msg| AgentError::Tool { tool: name.to_string(), message: msg })
+                            .map_err(|e| AgentError::Tool { tool: name.to_string(), message: e.to_string() })
                     })+
                     _ => Err(AgentError::Tool {
                         tool: name.to_string(),
@@ -1084,6 +1048,37 @@ mod tests {
         assert_eq!(tool, "nonexistent_tool");
     }
 
+    /// Every registered tool, poked with four shapes of garbage, should come
+    /// back with a plain validator error the LLM can read (Missing,
+    /// TypeMismatch, NotInEnum). If any of them trips the `InternalBug`
+    /// path, the schema no longer matches the Rust type and serde exploded
+    /// after validation said it was fine. That's ours to fix, not the
+    /// model's, so this test fails loudly when it happens.
+    #[test]
+    fn every_tool_rejects_bogus_input_without_internal_bug() {
+        const BOGUS_INPUTS: &[&str] = &[
+            "{}",
+            "\"raw string\"",
+            "{\"unknown_field\": 42}",
+            "{\"path\": 123, \"pattern\": []}",
+        ];
+        for name in ToolCall::all_names() {
+            for raw in BOGUS_INPUTS {
+                let input: Value = serde_json::from_str(raw).unwrap();
+                match ToolCall::from_api(name, &input) {
+                    Ok(_) => {}
+                    Err(AgentError::Tool { message, .. }) => {
+                        assert!(
+                            !message.contains("internal validator bug"),
+                            "tool `{name}` with input `{raw}` produced InternalBug: {message}",
+                        );
+                    }
+                    Err(e) => panic!("unexpected error kind for `{name}`: {e:?}"),
+                }
+            }
+        }
+    }
+
     #[test]
     fn tool_definitions_schema_requires_additional_properties_false() {
         fn check_object_schemas(schema: &Value, path: &str) {
@@ -1218,21 +1213,6 @@ mod tests {
         assert_eq!(sanitize_tool_input(&input), expected);
     }
 
-    #[test_case(Value::String("30".into()),                       "integer", Some(json!(30))    ; "string_to_integer")]
-    #[test_case(Value::String("-5".into()),                       "integer", Some(json!(-5))    ; "negative_string_to_integer")]
-    #[test_case(Value::String(" 42".into()),                      "integer", Some(json!(42))    ; "leading_whitespace")]
-    #[test_case(Value::String("30, \"offset\": 2075".into()),     "integer", None               ; "embedded_trailing_fields_rejected")]
-    #[test_case(Value::String("-3-5".into()),                     "integer", None               ; "malformed_number_rejected")]
-    #[test_case(Value::String("true".into()),                     "boolean", Some(json!(true))  ; "string_true_to_bool")]
-    #[test_case(Value::String("false".into()),                    "boolean", Some(json!(false)) ; "string_false_to_bool")]
-    #[test_case(Value::String("1.25".into()),                      "number",  Some(json!(1.25))  ; "string_to_float")]
-    #[test_case(Value::String("hello".into()),                    "integer", None               ; "non_numeric_string")]
-    #[test_case(json!(30),                                        "integer", None               ; "already_correct_type")]
-    #[test_case(Value::String("".into()),                         "integer", None               ; "empty_string")]
-    fn coerce_value_cases(val: Value, json_type: &str, expected: Option<Value>) {
-        assert_eq!(coerce_value(&val, "test_field", json_type), expected);
-    }
-
     #[test]
     fn walk_builder_excludes_dot_git_but_shows_dotfiles() {
         let tmp = TempDir::new().unwrap();
@@ -1357,23 +1337,31 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_error_includes_serde_message() {
-        // array with correct top-level type but bad items
-        let bad_array = json!([{"not_a_valid_field": 1}]);
-        let err =
-            deserialize_with_coercion::<Vec<batch::BatchEntry>>(&bad_array, "tool_calls", "array")
-                .unwrap_err();
-        assert!(
-            err.contains("missing field"),
-            "expected serde detail, got: {err}"
-        );
+    fn multiedit_reports_inner_shape_with_path() {
+        let input = json!({
+            "path": "/x",
+            "edits": [{"old_string": "a"}]
+        });
+        let err = ToolCall::from_api("multiedit", &input).unwrap_err();
+        let AgentError::Tool { message, .. } = err else {
+            panic!("expected Tool error");
+        };
+        assert!(message.contains("edits[0].new_string"), "got: {message}");
+        assert!(message.contains("missing"), "got: {message}");
+    }
 
-        // wrong type entirely (string instead of integer)
-        let bad_type = json!("not_a_number");
-        let err = deserialize_with_coercion::<i64>(&bad_type, "count", "integer").unwrap_err();
+    #[test]
+    fn multiedit_huge_string_error_is_bounded() {
+        let huge: String = "x".repeat(50 * 1024);
+        let input = json!({"path": "/x", "edits": huge});
+        let err = ToolCall::from_api("multiedit", &input).unwrap_err();
+        let AgentError::Tool { message, .. } = err else {
+            panic!("expected Tool error");
+        };
         assert!(
-            err.contains("invalid type"),
-            "expected serde detail, got: {err}"
+            message.len() < schema::BOUNDED_ERR_MAX,
+            "error message too long: {} bytes",
+            message.len()
         );
     }
 }

--- a/maki-agent/src/tools/multiedit.rs
+++ b/maki-agent/src/tools/multiedit.rs
@@ -18,7 +18,7 @@ struct EditEntry {
     replace_all: Option<bool>,
 }
 
-#[derive(Tool, Debug, Clone)]
+#[derive(Tool, Debug, Clone, Deserialize)]
 pub struct MultiEdit {
     #[param(description = "Absolute path to the file")]
     path: String,

--- a/maki-agent/src/tools/question.rs
+++ b/maki-agent/src/tools/question.rs
@@ -1,10 +1,11 @@
 use crate::{AgentEvent, QuestionAnswer, QuestionInfo, ToolOutput};
 use maki_tool_macro::Tool;
+use serde::Deserialize;
 
 const EMPTY_QUESTIONS: &str = "at least one question is required";
 const CHANNEL_CLOSED: &str = "question cancelled: response channel closed";
 
-#[derive(Tool, Debug, Clone)]
+#[derive(Tool, Debug, Clone, Deserialize)]
 pub struct Question {
     #[param(description = "List of questions to ask the user")]
     questions: Vec<QuestionInfo>,

--- a/maki-agent/src/tools/read.rs
+++ b/maki-agent/src/tools/read.rs
@@ -5,10 +5,11 @@ use std::path::Path;
 use crate::agent::{self, LoadedInstructions};
 use crate::{InstructionBlock, ToolOutput};
 use maki_tool_macro::Tool;
+use serde::Deserialize;
 
 use super::{relative_path, truncate_bytes};
 
-#[derive(Tool, Debug, Clone)]
+#[derive(Tool, Debug, Clone, Deserialize)]
 pub struct Read {
     #[param(description = "Absolute path to the file or directory")]
     path: String,
@@ -204,21 +205,13 @@ mod tests {
         }
     }
 
+    const EXPECTED_INTEGER: &str = "expected integer";
+
     #[test]
     fn parse_input_bad_coercion_returns_error() {
         let err = Read::parse_input(&json!({"path": "x", "limit": "not_a_number"})).unwrap_err();
-        assert!(
-            err.contains("limit"),
-            "error should mention field name: {err}"
-        );
-    }
-
-    #[test]
-    fn parse_input_error_includes_schema_hint() {
-        let err = Read::parse_input(&json!({})).unwrap_err();
-        assert!(
-            err.contains("path") && err.contains("Expected:"),
-            "error should mention missing field and schema: {err}"
-        );
+        let msg = err.to_string();
+        assert!(msg.contains("limit"), "should mention field: {msg}");
+        assert!(msg.contains(EXPECTED_INTEGER), "should mention type: {msg}");
     }
 }

--- a/maki-agent/src/tools/schema.rs
+++ b/maki-agent/src/tools/schema.rs
@@ -1,0 +1,670 @@
+//! One `ParamSchema` per tool, declared at compile time, feeds both the
+//! JSON Schema we send the LLM and the validator that checks what comes
+//! back. Keeping them in one place is the whole point: if the two ever
+//! disagree, the model gets a schema that lies about what we accept.
+//!
+//! Validation errors are our own typed values, rendered through a single
+//! `Display` impl, so the model never sees a stray serde or serde_json
+//! message we didn't write ourselves.
+
+use std::fmt::{self, Display, Formatter, Write};
+
+use serde::de::DeserializeOwned;
+use serde_json::{Value, json};
+use tracing::warn;
+
+pub(crate) const PARAM_PREVIEW_MAX: usize = 120;
+
+const PREVIEW_SUFFIX: &str = "...";
+const JSON_ENCODED_ARRAY_HINT: &str = "Pass a JSON array, not a JSON-encoded string.";
+const JSON_ENCODED_OBJECT_HINT: &str = "Pass a JSON object, not a JSON-encoded string.";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ParamKind {
+    Null,
+    Bool,
+    Integer,
+    Number,
+    String,
+    Array,
+    Object,
+}
+
+impl ParamKind {
+    pub(crate) fn of(v: &Value) -> Self {
+        match v {
+            Value::Null => Self::Null,
+            Value::Bool(_) => Self::Bool,
+            Value::Number(n) if n.is_i64() || n.is_u64() => Self::Integer,
+            Value::Number(_) => Self::Number,
+            Value::String(_) => Self::String,
+            Value::Array(_) => Self::Array,
+            Value::Object(_) => Self::Object,
+        }
+    }
+}
+
+impl Display for ParamKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Null => "null",
+            Self::Bool => "boolean",
+            Self::Integer => "integer",
+            Self::Number => "number",
+            Self::String => "string",
+            Self::Array => "array",
+            Self::Object => "object",
+        })
+    }
+}
+
+pub(crate) type Property = (&'static str, &'static ParamSchema, bool);
+
+#[derive(Debug)]
+pub(crate) enum ParamSchema {
+    Primitive {
+        kind: ParamKind,
+        description: &'static str,
+    },
+    Enum {
+        variants: &'static [&'static str],
+        description: &'static str,
+    },
+    Array {
+        items: &'static ParamSchema,
+        description: &'static str,
+    },
+    Object {
+        properties: &'static [Property],
+        description: &'static str,
+    },
+    /// Used for `serde_json::Value` fields where we genuinely want to let
+    /// anything through, like batch entry parameters.
+    Any { description: &'static str },
+}
+
+pub(crate) fn to_json_schema(s: &ParamSchema) -> Value {
+    match s {
+        ParamSchema::Primitive { kind, description } => {
+            json!({ "type": kind.to_string(), "description": description })
+        }
+        ParamSchema::Enum {
+            variants,
+            description,
+        } => {
+            let mut v = json!({ "type": "string", "enum": variants });
+            if !description.is_empty() {
+                v["description"] = json!(description);
+            }
+            v
+        }
+        ParamSchema::Array { items, description } => json!({
+            "type": "array",
+            "description": description,
+            "items": to_json_schema(items),
+        }),
+        ParamSchema::Object {
+            properties,
+            description,
+        } => {
+            let props: serde_json::Map<String, Value> = properties
+                .iter()
+                .map(|(name, sub, _)| ((*name).into(), to_json_schema(sub)))
+                .collect();
+            let required: Vec<&&str> = properties
+                .iter()
+                .filter_map(|(name, _, req)| req.then_some(name))
+                .collect();
+            let mut v = json!({
+                "type": "object",
+                "required": required,
+                "properties": props,
+                "additionalProperties": false,
+            });
+            if !description.is_empty() {
+                v["description"] = json!(description);
+            }
+            v
+        }
+        ParamSchema::Any { description } => {
+            if description.is_empty() {
+                json!({})
+            } else {
+                json!({ "description": description })
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum PathSeg {
+    Field(&'static str),
+    Index(usize),
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct JsonPath(Vec<PathSeg>);
+
+impl JsonPath {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn with_field<R>(&mut self, name: &'static str, f: impl FnOnce(&mut Self) -> R) -> R {
+        self.0.push(PathSeg::Field(name));
+        let out = f(self);
+        self.0.pop();
+        out
+    }
+
+    fn with_index<R>(&mut self, i: usize, f: impl FnOnce(&mut Self) -> R) -> R {
+        self.0.push(PathSeg::Index(i));
+        let out = f(self);
+        self.0.pop();
+        out
+    }
+}
+
+impl Display for JsonPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        for seg in &self.0 {
+            match seg {
+                PathSeg::Field(name) => {
+                    if !first {
+                        f.write_char('.')?;
+                    }
+                    f.write_str(name)?;
+                }
+                PathSeg::Index(i) => write!(f, "[{i}]")?,
+            }
+            first = false;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ToolInputError {
+    pub path: JsonPath,
+    pub kind: ToolInputErrorKind,
+}
+
+#[derive(Debug)]
+pub(crate) enum ToolInputErrorKind {
+    Missing,
+    TypeMismatch {
+        expected: ParamKind,
+        got: ParamKind,
+        preview: Option<String>,
+    },
+    NotInEnum {
+        expected: &'static [&'static str],
+        got: String,
+    },
+    InternalBug {
+        detail: String,
+    },
+}
+
+impl ToolInputError {
+    fn at(path: &JsonPath, kind: ToolInputErrorKind) -> Self {
+        Self {
+            path: path.clone(),
+            kind,
+        }
+    }
+}
+
+impl Display for ToolInputError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if self.path.is_empty() {
+            f.write_str("invalid tool input: ")?;
+        } else {
+            write!(f, "invalid parameter '{}': ", self.path)?;
+        }
+        match &self.kind {
+            ToolInputErrorKind::Missing => f.write_str("missing"),
+            ToolInputErrorKind::TypeMismatch {
+                expected,
+                got,
+                preview,
+            } => {
+                write!(f, "expected {expected}, got {got}")?;
+                if let Some(p) = preview {
+                    let hint = match expected {
+                        ParamKind::Array => Some(JSON_ENCODED_ARRAY_HINT),
+                        ParamKind::Object => Some(JSON_ENCODED_OBJECT_HINT),
+                        _ => None,
+                    };
+                    if let Some(hint) = hint {
+                        write!(f, ". {hint}")?;
+                    }
+                    write!(f, " Preview: {p}")?;
+                }
+                Ok(())
+            }
+            ToolInputErrorKind::NotInEnum { expected, got } => {
+                f.write_str("expected one of [")?;
+                for (i, v) in expected.iter().enumerate() {
+                    if i > 0 {
+                        f.write_str(", ")?;
+                    }
+                    f.write_str(v)?;
+                }
+                write!(f, "], got \"{got}\"")
+            }
+            ToolInputErrorKind::InternalBug { detail } => {
+                write!(f, "internal validator bug: {detail}")
+            }
+        }
+    }
+}
+
+pub(crate) fn preview(s: &str) -> String {
+    let mut out = String::with_capacity(s.len().min(PARAM_PREVIEW_MAX) + 4);
+    out.push('"');
+    let mut written = 0usize;
+    for ch in s.chars() {
+        let escaped = match ch {
+            '\n' => Some("\\n"),
+            '\t' => Some("\\t"),
+            '\r' => Some("\\r"),
+            '\\' => Some("\\\\"),
+            '"' => Some("\\\""),
+            _ => None,
+        };
+        let chunk_len = escaped.map_or(ch.len_utf8(), str::len);
+        if written + chunk_len > PARAM_PREVIEW_MAX {
+            out.push_str(PREVIEW_SUFFIX);
+            break;
+        }
+        match escaped {
+            Some(s) => out.push_str(s),
+            None => out.push(ch),
+        }
+        written += chunk_len;
+    }
+    out.push('"');
+    out
+}
+
+pub(crate) fn validate(schema: &ParamSchema, input: Value) -> Result<Value, ToolInputError> {
+    walk(schema, input, &mut JsonPath::default())
+}
+
+fn walk(schema: &ParamSchema, value: Value, path: &mut JsonPath) -> Result<Value, ToolInputError> {
+    match schema {
+        ParamSchema::Any { .. } => Ok(value),
+        ParamSchema::Primitive { kind, .. } => validate_primitive(*kind, value, path),
+        ParamSchema::Enum { variants, .. } => validate_enum(variants, value, path),
+        ParamSchema::Array { items, .. } => validate_array(items, value, path),
+        ParamSchema::Object { properties, .. } => validate_object(properties, value, path),
+    }
+}
+
+fn validate_primitive(
+    expected: ParamKind,
+    value: Value,
+    path: &mut JsonPath,
+) -> Result<Value, ToolInputError> {
+    let got = ParamKind::of(&value);
+    if got == expected || (expected == ParamKind::Number && got == ParamKind::Integer) {
+        return Ok(value);
+    }
+    if let Some(coerced) = coerce_primitive(&value, expected) {
+        log_coercion(path, got, expected, &value, &coerced);
+        return Ok(coerced);
+    }
+    Err(ToolInputError::at(
+        path,
+        ToolInputErrorKind::TypeMismatch {
+            expected,
+            got,
+            preview: None,
+        },
+    ))
+}
+
+fn validate_enum(
+    variants: &'static [&'static str],
+    value: Value,
+    path: &mut JsonPath,
+) -> Result<Value, ToolInputError> {
+    match &value {
+        Value::String(s) if variants.contains(&s.as_str()) => Ok(value),
+        Value::String(s) => Err(ToolInputError::at(
+            path,
+            ToolInputErrorKind::NotInEnum {
+                expected: variants,
+                got: preview(s),
+            },
+        )),
+        other => Err(ToolInputError::at(
+            path,
+            ToolInputErrorKind::TypeMismatch {
+                expected: ParamKind::String,
+                got: ParamKind::of(other),
+                preview: None,
+            },
+        )),
+    }
+}
+
+fn validate_array(
+    item_schema: &ParamSchema,
+    value: Value,
+    path: &mut JsonPath,
+) -> Result<Value, ToolInputError> {
+    let Value::Array(arr) = coerce_container(value, ParamKind::Array, path)? else {
+        unreachable!("coerce_container(_, Array) returns an Array")
+    };
+    arr.into_iter()
+        .enumerate()
+        .map(|(i, item)| path.with_index(i, |p| walk(item_schema, item, p)))
+        .collect::<Result<Vec<_>, _>>()
+        .map(Value::Array)
+}
+
+fn validate_object(
+    properties: &'static [Property],
+    value: Value,
+    path: &mut JsonPath,
+) -> Result<Value, ToolInputError> {
+    let Value::Object(mut map) = coerce_container(value, ParamKind::Object, path)? else {
+        unreachable!("coerce_container(_, Object) returns an Object")
+    };
+    let mut out = serde_json::Map::new();
+    for (name, sub_schema, required) in properties {
+        match map.remove(*name) {
+            Some(v) if v.is_null() && !required => {}
+            Some(v) => {
+                let validated = path.with_field(name, |p| walk(sub_schema, v, p))?;
+                out.insert((*name).into(), validated);
+            }
+            None if *required => {
+                return Err(
+                    path.with_field(name, |p| ToolInputError::at(p, ToolInputErrorKind::Missing))
+                );
+            }
+            None => {}
+        }
+    }
+    for (extra_key, _) in map {
+        warn!(path = %path, key = %extra_key, "dropped unknown tool parameter");
+    }
+    Ok(Value::Object(out))
+}
+
+/// Always returns a `Value` of the requested kind, so callers can safely
+/// destructure with `unreachable!` in the else arm. Models sometimes
+/// stringify the whole array or object, so we try parsing the string
+/// before giving up.
+fn coerce_container(
+    value: Value,
+    expected: ParamKind,
+    path: &mut JsonPath,
+) -> Result<Value, ToolInputError> {
+    if ParamKind::of(&value) == expected {
+        return Ok(value);
+    }
+    if let Value::String(s) = &value
+        && let Some(parsed) = coerce_str_to(s, expected)
+    {
+        log_coercion(path, ParamKind::String, expected, &value, &parsed);
+        return Ok(parsed);
+    }
+    let got = ParamKind::of(&value);
+    let preview = if let Value::String(s) = &value {
+        Some(preview(s))
+    } else {
+        None
+    };
+    Err(ToolInputError::at(
+        path,
+        ToolInputErrorKind::TypeMismatch {
+            expected,
+            got,
+            preview,
+        },
+    ))
+}
+
+fn coerce_primitive(v: &Value, expected: ParamKind) -> Option<Value> {
+    let s = v.as_str()?.trim();
+    match expected {
+        ParamKind::Integer => s.parse::<i64>().ok().map(Value::from),
+        ParamKind::Number => s.parse::<f64>().ok().map(Value::from),
+        ParamKind::Bool => match s {
+            "true" => Some(Value::Bool(true)),
+            "false" => Some(Value::Bool(false)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn coerce_str_to(s: &str, expected: ParamKind) -> Option<Value> {
+    let parsed: Value = serde_json::from_str(s).ok()?;
+    (ParamKind::of(&parsed) == expected).then_some(parsed)
+}
+
+fn log_coercion(
+    path: &JsonPath,
+    from: ParamKind,
+    to: ParamKind,
+    original: &Value,
+    coerced: &Value,
+) {
+    warn!(
+        path = %path,
+        from = %from,
+        to = %to,
+        original = %preview(&original.to_string()),
+        coerced = %preview(&coerced.to_string()),
+        "coerced tool param type"
+    );
+}
+
+/// The one path every `Tool` derive takes: validate first so the LLM gets
+/// our nice structured errors, then let serde handle defaults, renames,
+/// and tagged enums. If serde still fails after validation passed, the
+/// schema is out of sync with the Rust type. That's on us, not the model,
+/// hence the `InternalBug` error kind.
+pub(crate) fn validate_and_deserialize<T: DeserializeOwned>(
+    schema: &ParamSchema,
+    input: Value,
+) -> Result<T, ToolInputError> {
+    let validated = validate(schema, input)?;
+    serde_json::from_value(validated).map_err(|e| ToolInputError {
+        path: JsonPath::default(),
+        kind: ToolInputErrorKind::InternalBug {
+            detail: e.to_string(),
+        },
+    })
+}
+
+/// Ceiling on a rendered validator error, shared so unit and integration
+/// tests agree on the same budget.
+#[cfg(test)]
+pub(crate) const BOUNDED_ERR_MAX: usize = 400;
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use test_case::test_case;
+
+    use super::*;
+
+    const MSG_MISSING: &str = "missing";
+    const MSG_EXPECTED_ARRAY: &str = "expected array";
+    const MSG_JSON_ENCODED_HINT: &str = "Pass a JSON array";
+    const MSG_EXPECTED_ONE_OF: &str = "expected one of";
+
+    const STR_PRIM: ParamSchema = ParamSchema::Primitive {
+        kind: ParamKind::String,
+        description: "",
+    };
+    const BOOL_PRIM: ParamSchema = ParamSchema::Primitive {
+        kind: ParamKind::Bool,
+        description: "",
+    };
+
+    const EDIT_ENTRY: ParamSchema = ParamSchema::Object {
+        properties: &[
+            ("old_string", &STR_PRIM, true),
+            ("new_string", &STR_PRIM, true),
+            ("replace_all", &BOOL_PRIM, false),
+        ],
+        description: "",
+    };
+
+    const EDITS_ARRAY: ParamSchema = ParamSchema::Array {
+        items: &EDIT_ENTRY,
+        description: "",
+    };
+
+    const MULTIEDIT_LIKE: ParamSchema = ParamSchema::Object {
+        properties: &[("path", &STR_PRIM, true), ("edits", &EDITS_ARRAY, true)],
+        description: "",
+    };
+
+    const MODE_ENUM: ParamSchema = ParamSchema::Enum {
+        variants: &["research", "general"],
+        description: "",
+    };
+
+    #[test]
+    fn param_kind_distinguishes_integer_from_number() {
+        assert_eq!(ParamKind::of(&json!(3)), ParamKind::Integer);
+        assert_eq!(ParamKind::of(&json!(1.5)), ParamKind::Number);
+    }
+
+    #[test]
+    fn to_json_schema_object_is_closed_with_required_and_nested_items() {
+        let v = to_json_schema(&MULTIEDIT_LIKE);
+        assert_eq!(v["type"], "object");
+        assert_eq!(v["additionalProperties"], false);
+        let req: Vec<&str> = v["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x.as_str().unwrap())
+            .collect();
+        assert_eq!(req, vec!["path", "edits"]);
+        assert_eq!(v["properties"]["edits"]["type"], "array");
+        assert_eq!(v["properties"]["edits"]["items"]["type"], "object");
+        assert_eq!(
+            v["properties"]["edits"]["items"]["additionalProperties"],
+            false
+        );
+    }
+
+    #[test]
+    fn validate_missing_required_nested_has_dotted_path_and_display() {
+        let err = validate(
+            &MULTIEDIT_LIKE,
+            json!({"path": "/x", "edits": [{"old_string": "a"}]}),
+        )
+        .unwrap_err();
+        assert!(matches!(err.kind, ToolInputErrorKind::Missing));
+        assert_eq!(err.path.to_string(), "edits[0].new_string");
+        let rendered = err.to_string();
+        assert!(rendered.contains(MSG_MISSING), "render: {rendered}");
+    }
+
+    #[test]
+    fn coerce_stringified_json_array_is_accepted() {
+        let input = json!({
+            "path": "/x",
+            "edits": r#"[{"old_string": "a", "new_string": "b"}]"#
+        });
+        let out = validate(&MULTIEDIT_LIKE, input).unwrap();
+        assert_eq!(out["edits"][0]["old_string"], "a");
+    }
+
+    #[test]
+    fn coerce_stringified_array_with_bad_inner_item_reports_nested_path() {
+        let input = json!({
+            "path": "/x",
+            "edits": r#"[{"old_string": "a"}]"#
+        });
+        let err = validate(&MULTIEDIT_LIKE, input).unwrap_err();
+        assert_eq!(err.path.to_string(), "edits[0].new_string");
+        assert!(matches!(err.kind, ToolInputErrorKind::Missing));
+    }
+
+    #[test]
+    fn huge_string_for_array_has_bounded_error_with_hint() {
+        let huge: String = "x".repeat(50 * 1024);
+        let input = json!({"path": "/x", "edits": huge});
+        let err = validate(&MULTIEDIT_LIKE, input).unwrap_err();
+        let rendered = err.to_string();
+        assert!(rendered.len() < BOUNDED_ERR_MAX, "too long: {rendered}");
+        assert!(rendered.contains(MSG_EXPECTED_ARRAY));
+        assert!(rendered.contains(MSG_JSON_ENCODED_HINT));
+    }
+
+    #[test_case(json!("30"),                     ParamKind::Integer, Some(json!(30))   ; "string_to_integer")]
+    #[test_case(json!(" 42"),                    ParamKind::Integer, Some(json!(42))   ; "whitespace_trimmed")]
+    #[test_case(json!("-5"),                     ParamKind::Integer, Some(json!(-5))   ; "negative")]
+    #[test_case(json!(""),                       ParamKind::Integer, None              ; "empty_string")]
+    #[test_case(json!("30, \"offset\": 2075"),   ParamKind::Integer, None              ; "embedded_trailing_fields_rejected")]
+    #[test_case(json!("-3-5"),                   ParamKind::Integer, None              ; "malformed_number_rejected")]
+    #[test_case(json!("1.25"),                   ParamKind::Number,  Some(json!(1.25)) ; "string_to_float")]
+    #[test_case(json!("true"),                   ParamKind::Bool,    Some(json!(true)) ; "string_to_bool")]
+    #[test_case(json!(30),                       ParamKind::Integer, None              ; "already_correct_type_no_coercion")]
+    fn coerce_primitive_cases(value: Value, expected: ParamKind, wanted: Option<Value>) {
+        assert_eq!(coerce_primitive(&value, expected), wanted);
+    }
+
+    #[test]
+    fn preview_escapes_and_truncates_on_char_boundary() {
+        assert_eq!(preview("a\nb\"c"), "\"a\\nb\\\"c\"");
+
+        let long: String = "\u{1F600}".repeat(PARAM_PREVIEW_MAX);
+        let out = preview(&long);
+        assert!(out.ends_with(&format!("{PREVIEW_SUFFIX}\"")));
+        assert!(out.len() <= PARAM_PREVIEW_MAX + PREVIEW_SUFFIX.len() + 2);
+    }
+
+    #[test]
+    fn enum_errors_report_type_mismatch_and_render_variants() {
+        let type_err = validate(&MODE_ENUM, json!(42)).unwrap_err();
+        assert!(matches!(
+            type_err.kind,
+            ToolInputErrorKind::TypeMismatch {
+                expected: ParamKind::String,
+                got: ParamKind::Integer,
+                ..
+            }
+        ));
+
+        let value_err = validate(&MODE_ENUM, json!("human")).unwrap_err();
+        let rendered = value_err.to_string();
+        assert!(rendered.contains(MSG_EXPECTED_ONE_OF));
+        assert!(rendered.contains("research"));
+        assert!(rendered.contains("human"));
+    }
+
+    #[test]
+    fn optional_null_treated_as_absent() {
+        const SCHEMA: ParamSchema = ParamSchema::Object {
+            properties: &[("name", &STR_PRIM, true), ("hint", &STR_PRIM, false)],
+            description: "",
+        };
+        let out = validate(&SCHEMA, json!({"name": "x", "hint": null})).unwrap();
+        assert_eq!(out["name"], "x");
+        assert!(out.get("hint").is_none());
+    }
+
+    #[test]
+    fn extra_keys_dropped() {
+        const SCHEMA: ParamSchema = ParamSchema::Object {
+            properties: &[("name", &STR_PRIM, true)],
+            description: "",
+        };
+        let out = validate(&SCHEMA, json!({"name": "x", "extra": 42})).unwrap();
+        assert!(out.get("extra").is_none());
+    }
+}

--- a/maki-agent/src/tools/task.rs
+++ b/maki-agent/src/tools/task.rs
@@ -12,6 +12,7 @@ use maki_providers::model::ModelTier;
 use maki_providers::provider;
 use maki_providers::{ContentBlock, Model, ModelError, Role};
 use maki_tool_macro::Tool;
+use serde::Deserialize;
 use tracing::info;
 use uuid::Uuid;
 
@@ -23,7 +24,7 @@ use crate::template;
 use crate::tools::ToolCall;
 use crate::{Agent, AgentInput, AgentMode, AgentParams, AgentRunParams};
 
-#[derive(Tool, Debug, Clone)]
+#[derive(Tool, Debug, Clone, Deserialize)]
 pub struct Task {
     #[param(description = "Short (3-5 words) description of the task")]
     description: String,

--- a/maki-agent/src/tools/todowrite.rs
+++ b/maki-agent/src/tools/todowrite.rs
@@ -1,7 +1,8 @@
 use crate::{TodoItem, ToolOutput};
 use maki_tool_macro::Tool;
+use serde::Deserialize;
 
-#[derive(Tool, Debug, Clone)]
+#[derive(Tool, Debug, Clone, Deserialize)]
 pub struct TodoWrite {
     #[param(description = "The updated todo list")]
     todos: Vec<TodoItem>,

--- a/maki-agent/src/tools/webfetch.rs
+++ b/maki-agent/src/tools/webfetch.rs
@@ -5,6 +5,7 @@ use isahc::config::Configurable;
 use isahc::{AsyncReadResponseExt, HttpClient, Request};
 
 use maki_tool_macro::Tool;
+use serde::Deserialize;
 
 use crate::ToolOutput;
 
@@ -18,7 +19,7 @@ const CF_MITIGATED: &str = "cf-mitigated";
 const CF_CHALLENGE: &str = "challenge";
 const FALLBACK_USER_AGENT: &str = "maki";
 
-#[derive(Tool, Debug, Clone)]
+#[derive(Tool, Debug, Clone, Deserialize)]
 pub struct WebFetch {
     #[param(description = "URL to fetch (http:// or https://)")]
     url: String,

--- a/maki-agent/src/tools/websearch.rs
+++ b/maki-agent/src/tools/websearch.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use isahc::config::Configurable;
 use isahc::{AsyncReadResponseExt, HttpClient, Request};
 use maki_tool_macro::Tool;
+use serde::Deserialize;
 use serde_json::{Value, json};
 
 use crate::ToolOutput;
@@ -15,7 +16,7 @@ const REQUEST_TIMEOUT_SECS: u64 = 25;
 const DEFAULT_NUM_RESULTS: u64 = 8;
 const NO_RESULTS_MSG: &str = "No search results found";
 
-#[derive(Tool, Debug, Clone)]
+#[derive(Tool, Debug, Clone, Deserialize)]
 pub struct WebSearch {
     #[param(description = "Search query")]
     query: String,

--- a/maki-agent/src/tools/write.rs
+++ b/maki-agent/src/tools/write.rs
@@ -3,10 +3,11 @@ use std::path::Path;
 
 use crate::ToolOutput;
 use maki_tool_macro::Tool;
+use serde::Deserialize;
 
 use super::relative_path;
 
-#[derive(Tool, Debug, Clone)]
+#[derive(Tool, Debug, Clone, Deserialize)]
 pub struct Write {
     #[param(description = "Absolute path to the file")]
     path: String,

--- a/maki-tool-macro/src/lib.rs
+++ b/maki-tool-macro/src/lib.rs
@@ -1,15 +1,22 @@
 //! Derive macros for tool schemas.
 //!
-//! - `Tool`: generates `schema()`, `parse_input()`, `schema_hint()` for top-level tool structs.
-//! - `Args`: generates `item_schema()` for structs used as `Vec<T>` items in tool schemas.
-//! - `ArgEnum`: generates `item_schema()` for `#[serde(rename_all = "snake_case")]` enums.
+//! - `Tool`: generates `SCHEMA`, `schema()`, and `parse_input()` for top-level tool structs.
+//! - `Args`: generates `ITEM_SCHEMA` for structs used as nested objects.
+//! - `ArgEnum`: generates `ITEM_SCHEMA` for `#[serde(rename_all = "snake_case")]` enums.
+//!
+//! The actual shape of every parameter lives in one `ParamSchema` value
+//! over in `maki_agent::tools::schema`. We require `Deserialize` on the
+//! tool struct because once validation has cleaned the JSON up, we hand
+//! the result to `serde_json::from_value` and let serde do the last mile.
+//! That way defaults, renames, and tagged enums stay with serde instead
+//! of a hand-rolled field loop in here that would drift out of sync.
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{
-    Attribute, Data, DeriveInput, Expr, Fields, GenericArgument, Ident, Lit, Meta, PathArguments,
-    Type, parse_macro_input,
+    Attribute, Data, DeriveInput, Expr, Fields, GenericArgument, Lit, Meta, PathArguments, Type,
+    parse_macro_input,
 };
 
 fn param_description(attrs: &[Attribute]) -> Option<String> {
@@ -49,36 +56,6 @@ fn unwrapped_type(ty: &Type) -> &Type {
     inner_type(ty, "Option").unwrap_or(ty)
 }
 
-fn json_type_str(ty: &Type) -> &'static str {
-    let ty = unwrapped_type(ty);
-    if let Type::Path(tp) = ty
-        && let Some(seg) = tp.path.segments.last()
-    {
-        return match seg.ident.to_string().as_str() {
-            "String" | "str" => "string",
-            "bool" => "boolean",
-            "u8" | "u16" | "u32" | "u64" | "u128" | "usize" | "i8" | "i16" | "i32" | "i64"
-            | "i128" | "isize" => "integer",
-            "f32" | "f64" => "number",
-            "Vec" => "array",
-            _ => "object",
-        };
-    }
-    "object"
-}
-
-fn vec_item_schema(ty: &Type) -> TokenStream2 {
-    let inner = unwrapped_type(ty);
-    if let Some(item_ty) = inner_type(inner, "Vec") {
-        let item_json_type = json_type_str(item_ty);
-        if item_json_type == "object" {
-            return quote! { #item_ty::item_schema() };
-        }
-        return quote! { serde_json::json!({ "type": #item_json_type }) };
-    }
-    quote! { serde_json::json!({}) }
-}
-
 fn has_serde_default(attrs: &[Attribute]) -> bool {
     attrs.iter().any(|attr| {
         if !attr.path().is_ident("serde") {
@@ -106,7 +83,31 @@ fn to_snake_case(s: &str) -> String {
     out
 }
 
-fn is_plain_object(ty: &Type) -> bool {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Primitive {
+    String,
+    Bool,
+    Integer,
+    Number,
+}
+
+fn primitive_of(ty: &Type) -> Option<Primitive> {
+    if let Type::Path(tp) = ty
+        && let Some(seg) = tp.path.segments.last()
+    {
+        return match seg.ident.to_string().as_str() {
+            "String" | "str" => Some(Primitive::String),
+            "bool" => Some(Primitive::Bool),
+            "u8" | "u16" | "u32" | "u64" | "u128" | "usize" | "i8" | "i16" | "i32" | "i64"
+            | "i128" | "isize" => Some(Primitive::Integer),
+            "f32" | "f64" => Some(Primitive::Number),
+            _ => None,
+        };
+    }
+    None
+}
+
+fn is_value_type(ty: &Type) -> bool {
     if let Type::Path(tp) = ty
         && let Some(seg) = tp.path.segments.last()
     {
@@ -115,22 +116,73 @@ fn is_plain_object(ty: &Type) -> bool {
     false
 }
 
-fn field_schema_token(field_ty: &Type) -> TokenStream2 {
-    let json_type = json_type_str(field_ty);
-    let unwrapped = unwrapped_type(field_ty);
-    if json_type == "array" {
-        let item_schema = vec_item_schema(unwrapped);
-        quote! {
-            serde_json::json!({
-                "type": "array",
-                "items": #item_schema
-            })
-        }
-    } else if json_type == "object" && !is_plain_object(unwrapped) {
-        quote! { #unwrapped::item_schema() }
+/// `Option<T>` only gets peeled at the top level of a field. Inside a
+/// `Vec`, we keep whatever the user wrote so optional items still round
+/// trip through serde.
+fn schema_ref(ty: &Type, description: &str, unwrap_option: bool) -> TokenStream2 {
+    let inner = if unwrap_option {
+        unwrapped_type(ty)
     } else {
-        quote! { serde_json::json!({ "type": #json_type }) }
+        ty
+    };
+
+    if is_value_type(inner) {
+        return quote! {
+            &crate::tools::schema::ParamSchema::Any { description: #description }
+        };
     }
+
+    if let Some(prim) = primitive_of(inner) {
+        let kind = primitive_kind_token(prim);
+        return quote! {
+            &crate::tools::schema::ParamSchema::Primitive {
+                kind: #kind,
+                description: #description,
+            }
+        };
+    }
+
+    if let Some(item_ty) = inner_type(inner, "Vec") {
+        let item_schema = schema_ref(item_ty, "", false);
+        return quote! {
+            &crate::tools::schema::ParamSchema::Array {
+                items: #item_schema,
+                description: #description,
+            }
+        };
+    }
+
+    quote! { #inner::ITEM_SCHEMA }
+}
+
+fn primitive_kind_token(prim: Primitive) -> TokenStream2 {
+    match prim {
+        Primitive::String => quote! { crate::tools::schema::ParamKind::String },
+        Primitive::Bool => quote! { crate::tools::schema::ParamKind::Bool },
+        Primitive::Integer => quote! { crate::tools::schema::ParamKind::Integer },
+        Primitive::Number => quote! { crate::tools::schema::ParamKind::Number },
+    }
+}
+
+fn object_property_tokens(fields: &syn::FieldsNamed) -> Vec<TokenStream2> {
+    fields
+        .named
+        .iter()
+        .map(|field| {
+            let field_name = field.ident.as_ref().unwrap();
+            let field_str = field_name.to_string();
+            let desc = param_description(&field.attrs).unwrap_or_default();
+            let schema = schema_ref(&field.ty, &desc, true);
+            let required = !(is_option(&field.ty) || has_serde_default(&field.attrs));
+            quote! {
+                (
+                    #field_str,
+                    #schema,
+                    #required,
+                )
+            }
+        })
+        .collect()
 }
 
 #[proc_macro_derive(ArgEnum)]
@@ -152,12 +204,11 @@ pub fn derive_arg_enum(input: TokenStream) -> TokenStream {
 
     let expanded = quote! {
         impl #name {
-            pub fn item_schema() -> serde_json::Value {
-                serde_json::json!({
-                    "type": "string",
-                    "enum": [#(#variants),*]
-                })
-            }
+            pub(crate) const ITEM_SCHEMA: &'static crate::tools::schema::ParamSchema =
+                &crate::tools::schema::ParamSchema::Enum {
+                    variants: &[#(#variants),*],
+                    description: "",
+                };
         }
     };
     expanded.into()
@@ -179,46 +230,15 @@ pub fn derive_args(input: TokenStream) -> TokenStream {
             .into();
     };
 
-    let mut prop_entries = Vec::new();
-    let mut required_entries = Vec::new();
-
-    for field in &fields.named {
-        let field_name = field.ident.as_ref().unwrap();
-        let field_ty = &field.ty;
-        let field_str = field_name.to_string();
-        let desc = param_description(&field.attrs).unwrap_or_default();
-        let optional = is_option(field_ty) || has_serde_default(&field.attrs);
-        let base = field_schema_token(field_ty);
-
-        prop_entries.push(quote! {
-            let mut entry = #base;
-            if let serde_json::Value::Object(ref mut m) = entry {
-                if !#desc.is_empty() {
-                    m.insert("description".to_string(), serde_json::Value::String(#desc.to_string()));
-                }
-            }
-            props.insert(#field_str.to_string(), entry);
-        });
-
-        if !optional {
-            required_entries.push(quote! { required.push(#field_str.to_string()); });
-        }
-    }
+    let props = object_property_tokens(fields);
 
     let expanded = quote! {
         impl #name {
-            pub fn item_schema() -> serde_json::Value {
-                let mut props = serde_json::Map::new();
-                #(#prop_entries)*
-                let mut required = Vec::<String>::new();
-                #(#required_entries)*
-                serde_json::json!({
-                    "type": "object",
-                    "required": required,
-                    "properties": serde_json::Value::Object(props),
-                    "additionalProperties": false
-                })
-            }
+            pub(crate) const ITEM_SCHEMA: &'static crate::tools::schema::ParamSchema =
+                &crate::tools::schema::ParamSchema::Object {
+                    properties: &[#(#props),*],
+                    description: "",
+                };
         }
     };
     expanded.into()
@@ -240,101 +260,25 @@ pub fn derive_tool(input: TokenStream) -> TokenStream {
             .into();
     };
 
-    let mut prop_entries = Vec::new();
-    let mut required_entries = Vec::new();
-    let mut field_extractions = Vec::new();
-    let mut schema_hint_parts = Vec::new();
-
-    for field in &fields.named {
-        let field_name = field.ident.as_ref().unwrap();
-        let field_ty = &field.ty;
-        let field_str = field_name.to_string();
-        let desc = param_description(&field.attrs).unwrap_or_default();
-        let json_type = json_type_str(field_ty);
-        let optional = is_option(field_ty) || has_serde_default(&field.attrs);
-
-        if json_type == "array" {
-            let item_schema = vec_item_schema(field_ty);
-            prop_entries.push(quote! {
-                props.insert(#field_str.to_string(), serde_json::json!({
-                    "type": "array",
-                    "description": #desc,
-                    "items": #item_schema
-                }));
-            });
-        } else {
-            prop_entries.push(quote! {
-                props.insert(#field_str.to_string(), serde_json::json!({
-                    "type": #json_type,
-                    "description": #desc
-                }));
-            });
-        }
-
-        if !optional {
-            required_entries.push(quote! { required.push(#field_str.to_string()); });
-        }
-
-        let hint_suffix = if optional { "?" } else { "" };
-        let type_hint = match json_type {
-            "string" => "str",
-            "integer" => "int",
-            "boolean" => "bool",
-            "number" => "num",
-            "array" => "[...]",
-            _ => "obj",
-        };
-        schema_hint_parts.push(format!("{}{}: {}", field_str, hint_suffix, type_hint));
-
-        if optional {
-            field_extractions.push(quote! {
-                let #field_name: #field_ty = input
-                    .get(#field_str)
-                    .filter(|v| !v.is_null())
-                    .map(|v| crate::tools::deserialize_with_coercion(v, #field_str, #json_type))
-                    .transpose()?;
-            });
-        } else {
-            field_extractions.push(quote! {
-                let #field_name: #field_ty = {
-                    let raw = input.get(#field_str).filter(|v| !v.is_null()).ok_or_else(|| format!("The required parameter '{}' is missing. Expected: {}", #field_str, Self::schema_hint()))?;
-                    crate::tools::deserialize_with_coercion(raw, #field_str, #json_type)?
-                };
-            });
-        }
-    }
-
-    let field_names: Vec<&Ident> = fields
-        .named
-        .iter()
-        .map(|f| f.ident.as_ref().unwrap())
-        .collect();
-
-    let schema_hint_str = format!("{{ {} }}", schema_hint_parts.join(", "));
+    let props = object_property_tokens(fields);
 
     let expanded = quote! {
         impl #name {
+            pub(crate) const SCHEMA: &'static crate::tools::schema::ParamSchema =
+                &crate::tools::schema::ParamSchema::Object {
+                    properties: &[#(#props),*],
+                    description: "",
+                };
+
             pub(crate) fn schema() -> serde_json::Value {
-                let mut props = serde_json::Map::new();
-                #(#prop_entries)*
-                let mut required = Vec::<String>::new();
-                #(#required_entries)*
-                serde_json::json!({
-                    "type": "object",
-                    "required": required,
-                    "properties": serde_json::Value::Object(props),
-                    "additionalProperties": false
-                })
+                crate::tools::schema::to_json_schema(Self::SCHEMA)
             }
 
-            pub(crate) fn schema_hint() -> &'static str {
-                #schema_hint_str
-            }
-
-            pub(crate) fn parse_input(input: &serde_json::Value) -> Result<Self, String> {
-                let input = &crate::tools::sanitize_tool_input(input);
-                #(#field_extractions)*
-                Ok(Self { #(#field_names),* })
+            pub(crate) fn parse_input(
+                input: &serde_json::Value,
+            ) -> Result<Self, crate::tools::schema::ToolInputError> {
+                let sanitized = crate::tools::sanitize_tool_input(input);
+                crate::tools::schema::validate_and_deserialize(Self::SCHEMA, sanitized)
             }
         }
     };


### PR DESCRIPTION
The old Tool derive kept two pictures of each tool in its head. One was the JSON schema we sent the LLM. The other was a hand rolled field loop that pulled parameters out of the incoming JSON one by one. When the two drifted, the model got a schema that lied about what we accept, and we got surprise parse errors that the model had no way to fix.

Now there is one ParamSchema value per tool. We turn it into JSON for the LLM, and we walk the same value to check what comes back. Once validation is happy, we hand the cleaned JSON to serde, so things like #[serde(default)] and tagged enums keep working without a second implementation.

Errors the model sees are now our own typed values with dotted paths like edits[0].new_string, so when it messes up a nested field it knows exactly where to look. A small sentinel test feeds four shapes of garbage to every registered tool, so the next person who adds a tool gets the same coverage for free.