### PR TITLE
providers: ollama: add cloud API key support

### DIFF
--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -97,8 +97,8 @@ struct ProviderSection {
 
 fn format_auth(kind: ProviderKind) -> String {
     let env = kind.api_key_env();
-    if env.is_empty() {
-        "`OLLAMA_HOST` (required, e.g. `http://localhost:11434`)".to_string()
+    if kind == ProviderKind::Ollama {
+        format!("`{env}` for cloud, or `OLLAMA_HOST` for local (e.g. `http://localhost:11434`)")
     } else {
         format!("`{env}`")
     }

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -46,7 +46,7 @@ impl ProviderKind {
         match self {
             Self::Anthropic => "ANTHROPIC_API_KEY",
             Self::OpenAi => "OPENAI_API_KEY",
-            Self::Ollama => "",
+            Self::Ollama => "OLLAMA_API_KEY",
             Self::Mistral => "MISTRAL_API_KEY",
             Self::Zai | Self::ZaiCodingPlan => "ZHIPU_API_KEY",
             Self::Synthetic => "SYNTHETIC_API_KEY",
@@ -74,7 +74,7 @@ impl ProviderKind {
             Self::Anthropic => {
                 Some("Prompt caching, thinking mode (adaptive/budgeted), advanced tool use")
             }
-            Self::Ollama => Some("Local inference, no API key required, any model via ollama pull"),
+            Self::Ollama => Some("Local inference via OLLAMA_HOST, or cloud via OLLAMA_API_KEY"),
             Self::Synthetic => {
                 Some("Reasoning effort support (low/medium/high), open-weight models")
             }

--- a/maki-providers/src/providers/ollama.rs
+++ b/maki-providers/src/providers/ollama.rs
@@ -11,7 +11,9 @@ use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 pub(crate) const DEFAULT_MAX_OUTPUT: u32 = 16384;
 pub(crate) const DEFAULT_CONTEXT: u32 = 128_000;
 const HOST_ENV: &str = "OLLAMA_HOST";
-const HOST_NOT_SET: &str = "OLLAMA_HOST not set";
+const API_KEY_ENV: &str = "OLLAMA_API_KEY";
+const CLOUD_BASE_URL: &str = "https://ollama.com/v1";
+const HOST_NOT_SET: &str = "OLLAMA_HOST not set (or set OLLAMA_API_KEY for cloud)";
 
 static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     api_key_env: "",
@@ -32,6 +34,16 @@ pub struct Ollama {
 
 impl Ollama {
     pub fn new() -> Result<Self, AgentError> {
+        if let Ok(api_key) = std::env::var(API_KEY_ENV) {
+            return Ok(Self {
+                compat: OpenAiCompatProvider::new(&CONFIG),
+                auth: ResolvedAuth {
+                    base_url: Some(CLOUD_BASE_URL.into()),
+                    headers: vec![("authorization".into(), format!("Bearer {api_key}"))],
+                },
+            });
+        }
+
         let host = std::env::var(HOST_ENV).map_err(|_| AgentError::Config {
             message: HOST_NOT_SET.into(),
         })?;
@@ -77,14 +89,17 @@ mod tests {
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
-    fn new_without_host_errors() {
+    fn new_without_host_or_api_key_errors() {
         let _guard = ENV_LOCK.lock().unwrap();
         // SAFETY: single-threaded test section guarded by ENV_LOCK.
-        unsafe { std::env::remove_var(HOST_ENV) };
+        unsafe {
+            std::env::remove_var(HOST_ENV);
+            std::env::remove_var(API_KEY_ENV);
+        }
         match Ollama::new() {
             Err(AgentError::Config { message }) => assert_eq!(message, HOST_NOT_SET),
             Err(other) => panic!("expected Config error, got {other:?}"),
-            Ok(_) => panic!("expected error when {HOST_ENV} is unset"),
+            Ok(_) => panic!("expected error when {HOST_ENV} and {API_KEY_ENV} are unset"),
         }
     }
 
@@ -92,10 +107,49 @@ mod tests {
     fn new_with_host_builds_auth() {
         let _guard = ENV_LOCK.lock().unwrap();
         // SAFETY: single-threaded test section guarded by ENV_LOCK.
-        unsafe { std::env::set_var(HOST_ENV, "http://x:1234") };
+        unsafe {
+            std::env::remove_var(API_KEY_ENV);
+            std::env::set_var(HOST_ENV, "http://x:1234");
+        }
         let ollama = Ollama::new().expect("should build when host set");
         assert_eq!(ollama.auth.base_url.as_deref(), Some("http://x:1234/v1"));
+        assert!(ollama.auth.headers.is_empty());
         // SAFETY: single-threaded test section guarded by ENV_LOCK.
         unsafe { std::env::remove_var(HOST_ENV) };
+    }
+
+    #[test]
+    fn new_with_api_key_uses_cloud() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: single-threaded test section guarded by ENV_LOCK.
+        unsafe {
+            std::env::remove_var(HOST_ENV);
+            std::env::set_var(API_KEY_ENV, "test-key");
+        }
+        let ollama = Ollama::new().expect("should build with API key");
+        assert_eq!(ollama.auth.base_url.as_deref(), Some(CLOUD_BASE_URL));
+        assert_eq!(ollama.auth.headers.len(), 1);
+        assert_eq!(ollama.auth.headers[0].0, "authorization");
+        assert_eq!(ollama.auth.headers[0].1, "Bearer test-key");
+        // SAFETY: single-threaded test section guarded by ENV_LOCK.
+        unsafe { std::env::remove_var(API_KEY_ENV) };
+    }
+
+    #[test]
+    fn new_api_key_takes_precedence_over_host() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: single-threaded test section guarded by ENV_LOCK.
+        unsafe {
+            std::env::set_var(HOST_ENV, "http://local:1234");
+            std::env::set_var(API_KEY_ENV, "test-key");
+        }
+        let ollama = Ollama::new().expect("should build");
+        assert_eq!(ollama.auth.base_url.as_deref(), Some(CLOUD_BASE_URL));
+        assert_eq!(ollama.auth.headers[0].1, "Bearer test-key");
+        // SAFETY: single-threaded test section guarded by ENV_LOCK.
+        unsafe {
+            std::env::remove_var(HOST_ENV);
+            std::env::remove_var(API_KEY_ENV);
+        }
     }
 }

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -46,9 +46,9 @@ Defaults: gpt-5.4-nano (weak), gpt-4.1 (medium), gpt-5.4 (strong)
 
 ### Ollama
 
-- **Env var**: `OLLAMA_HOST` (required, e.g. `http://localhost:11434`)
+- **Env var**: `OLLAMA_API_KEY` for cloud, or `OLLAMA_HOST` for local (e.g. `http://localhost:11434`)
 - **API**: `http://localhost:11434/v1`
-- **Features**: Local inference, no API key required, any model via ollama pull
+- **Features**: Local inference via OLLAMA_HOST, or cloud via OLLAMA_API_KEY
 
 Maki asks your local Ollama for the list of installed models, so there's no built-in catalog. Tiers are guessed from list order: the first model becomes strong, the second medium, and the rest weak. If that guess is wrong, open `/model` and press `1`, `2`, or `3` on any row to reassign it. Your choices are saved to `~/.maki/model-tiers`.
 


### PR DESCRIPTION
Ollama now checks OLLAMA_API_KEY first. When set, it talks to https://ollama.com/v1 with Bearer auth. When not set, falls back to OLLAMA_HOST for local inference. API key wins if both are set.

https://github.com/tontinton/maki/issues/34