### PR TITLE
providers: use provider timeout configs

### DIFF
--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -40,6 +40,7 @@ pub struct AgentParams {
     pub config: AgentConfig,
     pub permissions: Arc<PermissionManager>,
     pub session_id: Option<String>,
+    pub timeouts: maki_providers::Timeouts,
 }
 
 pub struct AgentRunParams {
@@ -73,6 +74,7 @@ pub struct Agent {
     permissions: Arc<PermissionManager>,
     thinking: ThinkingConfig,
     session_id: Option<String>,
+    timeouts: maki_providers::Timeouts,
 }
 
 impl Agent {
@@ -83,6 +85,7 @@ impl Agent {
             skills: params.skills,
             config: params.config,
             permissions: params.permissions,
+            timeouts: params.timeouts,
             history: run.history,
             system: run.system,
             event_tx: run.event_tx,
@@ -325,6 +328,7 @@ impl Agent {
             deadline: Deadline::None,
             config: self.config.clone(),
             permissions: Arc::clone(&self.permissions),
+            timeouts: self.timeouts,
         }
     }
 
@@ -491,6 +495,7 @@ mod tests {
                     std::path::PathBuf::from("/tmp"),
                 )),
                 session_id: None,
+                timeouts: maki_providers::Timeouts::default(),
             },
             AgentRunParams {
                 history,
@@ -743,6 +748,7 @@ mod tests {
                         std::path::PathBuf::from("/tmp"),
                     )),
                     session_id: None,
+                    timeouts: maki_providers::Timeouts::default(),
                 },
                 AgentRunParams {
                     history: History::new(Vec::new()),

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -251,6 +251,7 @@ pub struct ToolContext {
     pub deadline: Deadline,
     pub config: AgentConfig,
     pub permissions: Arc<PermissionManager>,
+    pub timeouts: maki_providers::Timeouts,
 }
 
 pub(crate) fn resolve_path(path: &str) -> Result<String, String> {
@@ -792,6 +793,7 @@ pub(crate) fn interpreter_ctx(
         deadline: Deadline::None,
         config: AgentConfig::default(),
         permissions,
+        timeouts: maki_providers::Timeouts::default(),
     }
 }
 

--- a/maki-agent/src/tools/task.rs
+++ b/maki-agent/src/tools/task.rs
@@ -70,7 +70,7 @@ impl Task {
                     ctx.model.dynamic_slug.as_deref(),
                 )
                 .map_err(|e| e.to_string())?;
-                let resolved_provider = provider::from_model_async(&resolved_model)
+                let resolved_provider = provider::from_model_async(&resolved_model, ctx.timeouts)
                     .await
                     .map_err(|e| e.to_string())?;
                 (resolved_model, Arc::from(resolved_provider))
@@ -151,6 +151,7 @@ impl Task {
                 config: ctx.config.clone(),
                 permissions: Arc::clone(&ctx.permissions),
                 session_id: Some(session_id),
+                timeouts: ctx.timeouts,
             },
             AgentRunParams {
                 history: crate::History::new(Vec::new()),

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -11,6 +11,7 @@ pub use model::{
     Model, ModelEntry, ModelError, ModelFamily, ModelPricing, ModelTier, TokenUsage,
     models_for_provider,
 };
+pub use providers::Timeouts;
 pub use providers::dynamic;
 pub use providers::openai::auth as openai_auth;
 pub use types::{

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -7,6 +7,7 @@ use strum::{Display, EnumIter, EnumString, IntoEnumIterator};
 use tracing::{debug, warn};
 
 use crate::model::{Model, ModelFamily, models_for_provider};
+use crate::providers::Timeouts;
 use crate::providers::anthropic::Anthropic;
 use crate::providers::dynamic;
 use crate::providers::mistral::Mistral;
@@ -97,20 +98,20 @@ impl ProviderKind {
         matches!(self, Self::Ollama)
     }
 
-    pub fn create(self) -> Result<Box<dyn Provider>, AgentError> {
+    pub fn create(self, timeouts: Timeouts) -> Result<Box<dyn Provider>, AgentError> {
         match self {
-            Self::Anthropic => Ok(Box::new(Anthropic::new()?)),
-            Self::OpenAi => Ok(Box::new(OpenAi::new()?)),
-            Self::Ollama => Ok(Box::new(Ollama::new()?)),
-            Self::Mistral => Ok(Box::new(Mistral::new()?)),
-            Self::Zai => Ok(Box::new(Zai::new(ZaiPlan::Standard)?)),
-            Self::ZaiCodingPlan => Ok(Box::new(Zai::new(ZaiPlan::Coding)?)),
-            Self::Synthetic => Ok(Box::new(Synthetic::new()?)),
+            Self::Anthropic => Ok(Box::new(Anthropic::new(timeouts)?)),
+            Self::OpenAi => Ok(Box::new(OpenAi::new(timeouts)?)),
+            Self::Ollama => Ok(Box::new(Ollama::new(timeouts)?)),
+            Self::Mistral => Ok(Box::new(Mistral::new(timeouts)?)),
+            Self::Zai => Ok(Box::new(Zai::new(ZaiPlan::Standard, timeouts)?)),
+            Self::ZaiCodingPlan => Ok(Box::new(Zai::new(ZaiPlan::Coding, timeouts)?)),
+            Self::Synthetic => Ok(Box::new(Synthetic::new(timeouts)?)),
         }
     }
 
     pub fn is_available(self) -> bool {
-        self.create().is_ok()
+        self.create(Timeouts::default()).is_ok()
     }
 }
 
@@ -140,26 +141,29 @@ pub trait Provider: Send + Sync {
     }
 }
 
-pub fn from_model(model: &Model) -> Result<Box<dyn Provider>, AgentError> {
+pub fn from_model(model: &Model, timeouts: Timeouts) -> Result<Box<dyn Provider>, AgentError> {
     if let Some(slug) = &model.dynamic_slug {
-        let provider = dynamic::create(slug)?;
+        let provider = dynamic::create(slug, timeouts)?;
         debug!(slug, model = %model.id, "dynamic provider created");
         return Ok(provider);
     }
-    let provider = model.provider.create()?;
+    let provider = model.provider.create(timeouts)?;
     debug!(provider = %model.provider, model = %model.id, "provider created");
     Ok(provider)
 }
 
-pub async fn from_model_async(model: &Model) -> Result<Box<dyn Provider>, AgentError> {
+pub async fn from_model_async(
+    model: &Model,
+    timeouts: Timeouts,
+) -> Result<Box<dyn Provider>, AgentError> {
     let slug = model.dynamic_slug.clone();
     let kind = model.provider;
     let id = model.id.clone();
     let provider = smol::unblock(move || {
         if let Some(slug) = &slug {
-            dynamic::create(slug)
+            dynamic::create(slug, timeouts)
         } else {
-            kind.create()
+            kind.create(timeouts)
         }
     })
     .await?;
@@ -174,9 +178,10 @@ pub struct ModelBatch {
 
 pub async fn fetch_all_models(mut on_ready: impl FnMut(ModelBatch)) {
     let (tx, rx) = flume::unbounded();
+    let timeouts = Timeouts::default();
 
     for kind in ProviderKind::iter() {
-        let Ok(provider) = smol::unblock(move || kind.create()).await else {
+        let Ok(provider) = smol::unblock(move || kind.create(timeouts)).await else {
             warn!(provider = %kind, "failed to create provider, skipping");
             continue;
         };

--- a/maki-providers/src/providers/anthropic.rs
+++ b/maki-providers/src/providers/anthropic.rs
@@ -4,7 +4,7 @@
 
 use std::env;
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use flume::Sender;
 use futures_lite::io::{AsyncBufReadExt, BufReader};
@@ -304,23 +304,29 @@ pub struct Anthropic {
     client: HttpClient,
     auth: Arc<Mutex<super::ResolvedAuth>>,
     system_prefix: Option<String>,
+    stream_timeout: Duration,
 }
 
 impl Anthropic {
-    pub fn new() -> Result<Self, AgentError> {
+    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
         let resolved = resolve_auth()?;
         Ok(Self {
-            client: super::http_client(),
+            client: super::http_client(timeouts.connect),
             auth: Arc::new(Mutex::new(resolved)),
             system_prefix: None,
+            stream_timeout: timeouts.stream,
         })
     }
 
-    pub(crate) fn with_auth(auth: Arc<Mutex<super::ResolvedAuth>>) -> Self {
+    pub(crate) fn with_auth(
+        auth: Arc<Mutex<super::ResolvedAuth>>,
+        timeouts: super::Timeouts,
+    ) -> Self {
         Self {
-            client: super::http_client(),
+            client: super::http_client(timeouts.connect),
             auth,
             system_prefix: None,
+            stream_timeout: timeouts.stream,
         }
     }
 
@@ -356,7 +362,7 @@ impl Anthropic {
         let status = response.status().as_u16();
 
         if status == 200 {
-            parse_sse(response, event_tx).await
+            parse_sse(response, event_tx, self.stream_timeout).await
         } else {
             Err(AgentError::from_response(response).await)
         }
@@ -531,6 +537,7 @@ fn build_wire_tools(tools: &Value) -> Value {
 async fn parse_sse(
     response: isahc::Response<isahc::AsyncBody>,
     event_tx: &Sender<ProviderEvent>,
+    stream_timeout: Duration,
 ) -> Result<StreamResponse, AgentError> {
     let reader = BufReader::new(response.into_body());
     let mut lines = reader.lines();
@@ -541,9 +548,9 @@ async fn parse_sse(
     let mut current_block_idx: usize = 0;
     let mut usage = TokenUsage::default();
     let mut stop_reason: Option<StopReason> = None;
-    let mut deadline = Instant::now() + super::SSE_TIMEOUT;
+    let mut deadline = Instant::now() + stream_timeout;
 
-    while let Some(line) = super::next_sse_line(&mut lines, &mut deadline).await? {
+    while let Some(line) = super::next_sse_line(&mut lines, &mut deadline, stream_timeout).await? {
         if let Some(event_type) = line.strip_prefix("event: ") {
             current_event = event_type.to_string();
             continue;
@@ -696,6 +703,8 @@ async fn parse_sse(
 mod tests {
     use super::*;
 
+    const TEST_STREAM_TIMEOUT: Duration = Duration::from_secs(300);
+
     fn mock_response(data: &'static [u8]) -> isahc::Response<isahc::AsyncBody> {
         let body = isahc::AsyncBody::from_bytes_static(data);
         isahc::Response::builder().status(200).body(body).unwrap()
@@ -727,7 +736,9 @@ event: message_stop\n\
 data: {\"type\":\"message_stop\"}\n";
 
             let (tx, rx) = flume::unbounded();
-            let resp = parse_sse(mock_response(sse_data), &tx).await.unwrap();
+            let resp = parse_sse(mock_response(sse_data), &tx, TEST_STREAM_TIMEOUT)
+                .await
+                .unwrap();
 
             assert_eq!(
                 resp.usage,
@@ -776,7 +787,7 @@ event: message_delta\n\
 data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":5}}\n";
 
             let (tx, rx) = flume::unbounded();
-            let resp = parse_sse(mock_response(sse_data.as_bytes()), &tx)
+            let resp = parse_sse(mock_response(sse_data.as_bytes()), &tx, TEST_STREAM_TIMEOUT)
                 .await
                 .unwrap();
 
@@ -850,7 +861,9 @@ data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":5}}\n";
         smol::block_on(async {
             let input = b"event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}\n";
             let (tx, _rx) = flume::unbounded();
-            let err = parse_sse(mock_response(input), &tx).await.unwrap_err();
+            let err = parse_sse(mock_response(input), &tx, TEST_STREAM_TIMEOUT)
+                .await
+                .unwrap_err();
             match err {
                 AgentError::Api { status, message } => {
                     assert_eq!(status, 529);
@@ -866,7 +879,9 @@ data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":5}}\n";
         smol::block_on(async {
             let input = b"event: error\ndata: not-json\n";
             let (tx, _rx) = flume::unbounded();
-            let err = parse_sse(mock_response(input), &tx).await.unwrap_err();
+            let err = parse_sse(mock_response(input), &tx, TEST_STREAM_TIMEOUT)
+                .await
+                .unwrap_err();
             match err {
                 AgentError::Api { status, message } => {
                     assert_eq!(status, 400);
@@ -897,7 +912,7 @@ event: message_delta\n\
 data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":1}}\n";
 
             let (tx, _rx) = flume::unbounded();
-            let resp = parse_sse(mock_response(sse_data.as_bytes()), &tx)
+            let resp = parse_sse(mock_response(sse_data.as_bytes()), &tx, TEST_STREAM_TIMEOUT)
                 .await
                 .unwrap();
 
@@ -943,7 +958,9 @@ event: message_delta\n\
 data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":3}}\n";
 
             let (tx, rx) = flume::unbounded();
-            let resp = parse_sse(mock_response(sse_data), &tx).await.unwrap();
+            let resp = parse_sse(mock_response(sse_data), &tx, TEST_STREAM_TIMEOUT)
+                .await
+                .unwrap();
 
             assert!(
                 matches!(&resp.message.content[0], ContentBlock::Thinking { thinking, signature }
@@ -990,7 +1007,9 @@ event: message_delta\n\
 data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":1}}\n";
 
             let (tx, _rx) = flume::unbounded();
-            let resp = parse_sse(mock_response(sse_data), &tx).await.unwrap();
+            let resp = parse_sse(mock_response(sse_data), &tx, TEST_STREAM_TIMEOUT)
+                .await
+                .unwrap();
 
             assert!(
                 matches!(&resp.message.content[0], ContentBlock::RedactedThinking { data } if data == "opaque_data")

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -326,7 +326,7 @@ pub fn auth_providers() -> Vec<(&'static str, &'static str)> {
         .collect()
 }
 
-pub fn create(slug: &str) -> Result<Box<dyn Provider>, AgentError> {
+pub fn create(slug: &str, timeouts: super::Timeouts) -> Result<Box<dyn Provider>, AgentError> {
     let meta = find_meta(slug).ok_or_else(|| AgentError::Config {
         message: format!("unknown dynamic provider '{slug}'"),
     })?;
@@ -335,11 +335,13 @@ pub fn create(slug: &str) -> Result<Box<dyn Provider>, AgentError> {
 
     let inner: Box<dyn Provider> = match meta.base {
         ProviderKind::Anthropic => Box::new(
-            Anthropic::with_auth(auth.clone()).with_system_prefix(meta.system_prefix.clone()),
+            Anthropic::with_auth(auth.clone(), timeouts)
+                .with_system_prefix(meta.system_prefix.clone()),
         ),
-        ProviderKind::OpenAi => {
-            Box::new(OpenAi::with_auth(auth.clone()).with_system_prefix(meta.system_prefix.clone()))
-        }
+        ProviderKind::OpenAi => Box::new(
+            OpenAi::with_auth(auth.clone(), timeouts)
+                .with_system_prefix(meta.system_prefix.clone()),
+        ),
         other => {
             return Err(AgentError::Config {
                 message: format!(

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -69,12 +69,12 @@ pub struct Mistral {
 }
 
 impl Mistral {
-    pub fn new() -> Result<Self, AgentError> {
+    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
         let api_key = std::env::var(CONFIG.api_key_env).map_err(|_| AgentError::Config {
             message: format!("{} not set", CONFIG.api_key_env),
         })?;
         Ok(Self {
-            compat: OpenAiCompatProvider::new(&CONFIG),
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
             auth: ResolvedAuth::bearer(&api_key),
         })
     }

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -16,10 +16,23 @@ pub(crate) mod openai_compat;
 pub(crate) mod synthetic;
 pub(crate) mod zai;
 
-pub(crate) const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
-pub(crate) const SSE_TIMEOUT: Duration = Duration::from_secs(120);
 const LOW_SPEED_BYTES_PER_SEC: u32 = 1;
 const LOW_SPEED_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Copy)]
+pub struct Timeouts {
+    pub connect: Duration,
+    pub stream: Duration,
+}
+
+impl Default for Timeouts {
+    fn default() -> Self {
+        Self {
+            connect: Duration::from_secs(10),
+            stream: Duration::from_secs(300),
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct ResolvedAuth {
@@ -84,12 +97,10 @@ impl SseErrorPayload {
     }
 }
 
-/// Read the next SSE line, resetting the deadline on every received line.
-/// Any received line (including pings, blank separators) proves the connection
-/// is alive. Dead connections are caught by the HTTP-layer LOW_SPEED_TIMEOUT.
 pub(crate) async fn next_sse_line<R: AsyncBufRead + Unpin>(
     lines: &mut futures_lite::io::Lines<R>,
     deadline: &mut Instant,
+    stream_timeout: Duration,
 ) -> Result<Option<String>, AgentError> {
     let remaining = deadline.saturating_duration_since(Instant::now());
     let result = futures_lite::future::or(
@@ -97,20 +108,20 @@ pub(crate) async fn next_sse_line<R: AsyncBufRead + Unpin>(
         async {
             smol::Timer::after(remaining).await;
             Err(AgentError::Timeout {
-                secs: SSE_TIMEOUT.as_secs(),
+                secs: stream_timeout.as_secs(),
             })
         },
     )
     .await;
     if let Ok(Some(_)) = &result {
-        *deadline = Instant::now() + SSE_TIMEOUT;
+        *deadline = Instant::now() + stream_timeout;
     }
     result
 }
 
-pub(crate) fn http_client() -> isahc::HttpClient {
+pub(crate) fn http_client(connect_timeout: Duration) -> isahc::HttpClient {
     isahc::HttpClient::builder()
-        .connect_timeout(CONNECT_TIMEOUT)
+        .connect_timeout(connect_timeout)
         .low_speed_timeout(LOW_SPEED_BYTES_PER_SEC, LOW_SPEED_TIMEOUT)
         .build()
         .expect("failed to build HTTP client")
@@ -157,7 +168,10 @@ mod tests {
         smol::block_on(async {
             let mut lines = NeverReader.lines();
             let mut past = Instant::now() - Duration::from_secs(1);
-            let err = next_sse_line(&mut lines, &mut past).await.unwrap_err();
+            let stream_timeout = Duration::from_secs(300);
+            let err = next_sse_line(&mut lines, &mut past, stream_timeout)
+                .await
+                .unwrap_err();
             assert!(matches!(err, AgentError::Timeout { .. }));
         })
     }

--- a/maki-providers/src/providers/ollama.rs
+++ b/maki-providers/src/providers/ollama.rs
@@ -33,10 +33,10 @@ pub struct Ollama {
 }
 
 impl Ollama {
-    pub fn new() -> Result<Self, AgentError> {
+    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
         if let Ok(api_key) = std::env::var(API_KEY_ENV) {
             return Ok(Self {
-                compat: OpenAiCompatProvider::new(&CONFIG),
+                compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
                 auth: ResolvedAuth {
                     base_url: Some(CLOUD_BASE_URL.into()),
                     headers: vec![("authorization".into(), format!("Bearer {api_key}"))],
@@ -48,7 +48,7 @@ impl Ollama {
             message: HOST_NOT_SET.into(),
         })?;
         Ok(Self {
-            compat: OpenAiCompatProvider::new(&CONFIG),
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
             auth: ResolvedAuth {
                 base_url: Some(format!("{host}/v1")),
                 headers: Vec::new(),
@@ -88,6 +88,11 @@ mod tests {
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+    const TEST_TIMEOUTS: super::super::Timeouts = super::super::Timeouts {
+        connect: std::time::Duration::from_secs(10),
+        stream: std::time::Duration::from_secs(300),
+    };
+
     #[test]
     fn new_without_host_or_api_key_errors() {
         let _guard = ENV_LOCK.lock().unwrap();
@@ -96,7 +101,7 @@ mod tests {
             std::env::remove_var(HOST_ENV);
             std::env::remove_var(API_KEY_ENV);
         }
-        match Ollama::new() {
+        match Ollama::new(TEST_TIMEOUTS) {
             Err(AgentError::Config { message }) => assert_eq!(message, HOST_NOT_SET),
             Err(other) => panic!("expected Config error, got {other:?}"),
             Ok(_) => panic!("expected error when {HOST_ENV} and {API_KEY_ENV} are unset"),
@@ -111,7 +116,7 @@ mod tests {
             std::env::remove_var(API_KEY_ENV);
             std::env::set_var(HOST_ENV, "http://x:1234");
         }
-        let ollama = Ollama::new().expect("should build when host set");
+        let ollama = Ollama::new(TEST_TIMEOUTS).expect("should build when host set");
         assert_eq!(ollama.auth.base_url.as_deref(), Some("http://x:1234/v1"));
         assert!(ollama.auth.headers.is_empty());
         // SAFETY: single-threaded test section guarded by ENV_LOCK.
@@ -126,7 +131,7 @@ mod tests {
             std::env::remove_var(HOST_ENV);
             std::env::set_var(API_KEY_ENV, "test-key");
         }
-        let ollama = Ollama::new().expect("should build with API key");
+        let ollama = Ollama::new(TEST_TIMEOUTS).expect("should build with API key");
         assert_eq!(ollama.auth.base_url.as_deref(), Some(CLOUD_BASE_URL));
         assert_eq!(ollama.auth.headers.len(), 1);
         assert_eq!(ollama.auth.headers[0].0, "authorization");
@@ -143,7 +148,7 @@ mod tests {
             std::env::set_var(HOST_ENV, "http://local:1234");
             std::env::set_var(API_KEY_ENV, "test-key");
         }
-        let ollama = Ollama::new().expect("should build");
+        let ollama = Ollama::new(TEST_TIMEOUTS).expect("should build");
         assert_eq!(ollama.auth.base_url.as_deref(), Some(CLOUD_BASE_URL));
         assert_eq!(ollama.auth.headers[0].1, "Bearer test-key");
         // SAFETY: single-threaded test section guarded by ENV_LOCK.

--- a/maki-providers/src/providers/openai/auth.rs
+++ b/maki-providers/src/providers/openai/auth.rs
@@ -9,8 +9,9 @@ use serde::Deserialize;
 use tracing::{debug, error, warn};
 
 use crate::AgentError;
-use crate::providers::{CONNECT_TIMEOUT, ResolvedAuth, urlenc};
+use crate::providers::{ResolvedAuth, urlenc};
 
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 pub(crate) const PROVIDER: &str = "openai";
 const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const DEVICE_CODE_URL: &str = "https://auth.openai.com/api/accounts/deviceauth/usercode";

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -36,10 +36,10 @@ pub struct OpenAi {
 }
 
 impl OpenAi {
-    pub fn new() -> Result<Self, AgentError> {
+    pub fn new(timeouts: crate::providers::Timeouts) -> Result<Self, AgentError> {
         let storage = DataDir::resolve()?;
         let resolved = auth::resolve(&storage)?;
-        let compat = OpenAiCompatProvider::new(&CONFIG);
+        let compat = OpenAiCompatProvider::new(&CONFIG, timeouts);
         Ok(Self {
             compat,
             auth: Arc::new(Mutex::new(resolved)),
@@ -48,9 +48,12 @@ impl OpenAi {
         })
     }
 
-    pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>) -> Self {
+    pub(crate) fn with_auth(
+        auth: Arc<Mutex<ResolvedAuth>>,
+        timeouts: crate::providers::Timeouts,
+    ) -> Self {
         Self {
-            compat: OpenAiCompatProvider::new(&CONFIG),
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
             auth,
             storage: None,
             system_prefix: None,
@@ -153,6 +156,7 @@ impl Provider for OpenAi {
 
             if is_codex_model(&model.id) {
                 let body = super::responses::build_body(model, messages, system, tools);
+                let stream_timeout = self.compat.stream_timeout();
                 return self
                     .with_oauth_retry(|| async {
                         let codex_auth = self.codex_auth()?;
@@ -162,6 +166,7 @@ impl Provider for OpenAi {
                             &body,
                             event_tx,
                             &codex_auth,
+                            stream_timeout,
                         )
                         .await
                     })

--- a/maki-providers/src/providers/openai/responses.rs
+++ b/maki-providers/src/providers/openai/responses.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use flume::Sender;
 use futures_lite::io::{AsyncBufRead, AsyncBufReadExt, BufReader};
@@ -142,6 +142,7 @@ pub(crate) async fn do_stream(
     body: &Value,
     event_tx: &Sender<ProviderEvent>,
     auth: &ResolvedAuth,
+    stream_timeout: Duration,
 ) -> Result<StreamResponse, AgentError> {
     let base = auth.base_url.as_deref().ok_or_else(|| AgentError::Config {
         message: "Responses API requires a base_url in auth".into(),
@@ -167,7 +168,12 @@ pub(crate) async fn do_stream(
     let status = response.status().as_u16();
 
     if status == 200 {
-        parse_sse(BufReader::new(response.into_body()), event_tx).await
+        parse_sse(
+            BufReader::new(response.into_body()),
+            event_tx,
+            stream_timeout,
+        )
+        .await
     } else {
         Err(AgentError::from_response(response).await)
     }
@@ -183,6 +189,7 @@ struct ToolAccumulator {
 pub(crate) async fn parse_sse(
     reader: impl AsyncBufRead + Unpin,
     event_tx: &Sender<ProviderEvent>,
+    stream_timeout: Duration,
 ) -> Result<StreamResponse, AgentError> {
     let mut lines = reader.lines();
 
@@ -191,10 +198,12 @@ pub(crate) async fn parse_sse(
     let mut usage = TokenUsage::default();
     let mut stop_reason: Option<StopReason> = None;
     let mut is_first_content = true;
-    let mut deadline = Instant::now() + crate::providers::SSE_TIMEOUT;
+    let mut deadline = Instant::now() + stream_timeout;
     let mut current_event = String::new();
 
-    while let Some(line) = crate::providers::next_sse_line(&mut lines, &mut deadline).await? {
+    while let Some(line) =
+        crate::providers::next_sse_line(&mut lines, &mut deadline, stream_timeout).await?
+    {
         if let Some(event_type) = line.strip_prefix("event: ") {
             current_event = event_type.trim().to_string();
             continue;
@@ -406,9 +415,11 @@ mod tests {
     use futures_lite::io::Cursor;
     use serde_json::json;
 
+    const TEST_STREAM_TIMEOUT: Duration = Duration::from_secs(300);
+
     async fn run_sse(sse: &str) -> (Result<StreamResponse, AgentError>, Vec<ProviderEvent>) {
         let (tx, rx) = flume::unbounded();
-        let result = parse_sse(Cursor::new(sse.as_bytes()), &tx).await;
+        let result = parse_sse(Cursor::new(sse.as_bytes()), &tx, TEST_STREAM_TIMEOUT).await;
         (result, rx.drain().collect())
     }
 

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use flume::Sender;
 use futures_lite::io::{AsyncBufRead, AsyncBufReadExt, BufReader};
@@ -25,18 +25,24 @@ pub(crate) struct OpenAiCompatConfig {
 pub(crate) struct OpenAiCompatProvider {
     client: HttpClient,
     config: &'static OpenAiCompatConfig,
+    stream_timeout: Duration,
 }
 
 impl OpenAiCompatProvider {
-    pub fn new(config: &'static OpenAiCompatConfig) -> Self {
+    pub fn new(config: &'static OpenAiCompatConfig, timeouts: super::Timeouts) -> Self {
         Self {
-            client: super::http_client(),
+            client: super::http_client(timeouts.connect),
             config,
+            stream_timeout: timeouts.stream,
         }
     }
 
     pub(crate) fn client(&self) -> &HttpClient {
         &self.client
+    }
+
+    pub(crate) fn stream_timeout(&self) -> Duration {
+        self.stream_timeout
     }
 
     pub fn build_body(
@@ -108,7 +114,12 @@ impl OpenAiCompatProvider {
         let status = response.status().as_u16();
 
         if status == 200 {
-            parse_sse(BufReader::new(response.into_body()), event_tx).await
+            parse_sse(
+                BufReader::new(response.into_body()),
+                event_tx,
+                self.stream_timeout,
+            )
+            .await
         } else {
             Err(AgentError::from_response(response).await)
         }
@@ -321,6 +332,7 @@ struct ToolAccumulator {
 pub async fn parse_sse(
     reader: impl AsyncBufRead + Unpin,
     event_tx: &Sender<ProviderEvent>,
+    stream_timeout: Duration,
 ) -> Result<StreamResponse, AgentError> {
     let mut lines = reader.lines();
 
@@ -330,9 +342,9 @@ pub async fn parse_sse(
     let mut usage = TokenUsage::default();
     let mut stop_reason: Option<StopReason> = None;
     let mut is_first_content = true;
-    let mut deadline = Instant::now() + super::SSE_TIMEOUT;
+    let mut deadline = Instant::now() + stream_timeout;
 
-    while let Some(line) = super::next_sse_line(&mut lines, &mut deadline).await? {
+    while let Some(line) = super::next_sse_line(&mut lines, &mut deadline, stream_timeout).await? {
         let data = match line.strip_prefix("data: ") {
             Some(d) => d.trim(),
             None => continue,
@@ -515,6 +527,8 @@ mod tests {
     use super::*;
     use futures_lite::io::Cursor;
 
+    const TEST_STREAM_TIMEOUT: Duration = Duration::from_secs(300);
+
     #[test]
     fn parse_sse_text_and_usage() {
         smol::block_on(async {
@@ -528,7 +542,9 @@ data: {\"choices\":[{\"finish_reason\":\"stop\",\"delta\":{}}],\"usage\":{\"prom
 data: [DONE]\n";
 
             let (tx, rx) = flume::unbounded();
-            let resp = parse_sse(Cursor::new(sse.as_bytes()), &tx).await.unwrap();
+            let resp = parse_sse(Cursor::new(sse.as_bytes()), &tx, TEST_STREAM_TIMEOUT)
+                .await
+                .unwrap();
 
             assert_eq!(resp.usage.input, 60);
             assert_eq!(resp.usage.output, 10);
@@ -564,7 +580,9 @@ data: {\"choices\":[{\"finish_reason\":\"stop\",\"delta\":{}}],\"usage\":{\"prom
 data: [DONE]\n";
 
             let (tx, rx) = flume::unbounded();
-            let resp = parse_sse(Cursor::new(sse.as_bytes()), &tx).await.unwrap();
+            let resp = parse_sse(Cursor::new(sse.as_bytes()), &tx, TEST_STREAM_TIMEOUT)
+                .await
+                .unwrap();
 
             assert!(
                 matches!(&resp.message.content[0], ContentBlock::Thinking { thinking, .. } if thinking == "Let me think...")
@@ -669,7 +687,9 @@ data: {\"choices\":[{\"finish_reason\":\"tool_calls\",\"delta\":{}}],\"usage\":{
 data: [DONE]\n";
 
             let (tx, rx) = flume::unbounded();
-            let resp = parse_sse(Cursor::new(sse.as_bytes()), &tx).await.unwrap();
+            let resp = parse_sse(Cursor::new(sse.as_bytes()), &tx, TEST_STREAM_TIMEOUT)
+                .await
+                .unwrap();
 
             let tools: Vec<_> = resp.message.tool_uses().collect();
             assert_eq!(tools.len(), 2);
@@ -702,7 +722,7 @@ data: [DONE]\n";
 data: {\"error\":{\"message\":\"Server overloaded\",\"type\":\"overloaded_error\"}}\n";
 
             let (tx, _rx) = flume::unbounded();
-            let err = parse_sse(Cursor::new(sse.as_bytes()), &tx)
+            let err = parse_sse(Cursor::new(sse.as_bytes()), &tx, TEST_STREAM_TIMEOUT)
                 .await
                 .unwrap_err();
 
@@ -727,7 +747,9 @@ data: {\"choices\":[{\"finish_reason\":\"tool_calls\",\"delta\":{}}],\"usage\":{
 data: [DONE]\n";
 
             let (tx, _rx) = flume::unbounded();
-            let resp = parse_sse(Cursor::new(sse.as_bytes()), &tx).await.unwrap();
+            let resp = parse_sse(Cursor::new(sse.as_bytes()), &tx, TEST_STREAM_TIMEOUT)
+                .await
+                .unwrap();
 
             let tools: Vec<_> = resp.message.tool_uses().collect();
             assert_eq!(tools.len(), 1);
@@ -749,7 +771,9 @@ data: {\"choices\":[{\"finish_reason\":\"tool_calls\",\"delta\":{}}],\"usage\":{
 data: [DONE]\n";
 
             let (tx, _rx) = flume::unbounded();
-            let resp = parse_sse(Cursor::new(sse.as_bytes()), &tx).await.unwrap();
+            let resp = parse_sse(Cursor::new(sse.as_bytes()), &tx, TEST_STREAM_TIMEOUT)
+                .await
+                .unwrap();
 
             let tools: Vec<_> = resp.message.tool_uses().collect();
             assert_eq!(tools.len(), 1);
@@ -791,7 +815,9 @@ data: [DONE]\n";
         smol::block_on(async {
             let sse = "data: [DONE]\n";
             let (tx, _rx) = flume::unbounded();
-            let resp = parse_sse(Cursor::new(sse.as_bytes()), &tx).await.unwrap();
+            let resp = parse_sse(Cursor::new(sse.as_bytes()), &tx, TEST_STREAM_TIMEOUT)
+                .await
+                .unwrap();
             assert!(resp.message.content.is_empty());
             assert_eq!(resp.usage, TokenUsage::default());
             assert_eq!(resp.stop_reason, None);
@@ -812,7 +838,9 @@ data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\
 data: [DONE]\n";
 
             let (tx, rx) = flume::unbounded();
-            let resp = parse_sse(Cursor::new(sse.as_bytes()), &tx).await.unwrap();
+            let resp = parse_sse(Cursor::new(sse.as_bytes()), &tx, TEST_STREAM_TIMEOUT)
+                .await
+                .unwrap();
 
             assert!(
                 matches!(&resp.message.content[0], ContentBlock::Thinking { thinking, .. } if thinking == "Let me think..."),

--- a/maki-providers/src/providers/synthetic.rs
+++ b/maki-providers/src/providers/synthetic.rs
@@ -69,12 +69,12 @@ pub struct Synthetic {
 }
 
 impl Synthetic {
-    pub fn new() -> Result<Self, AgentError> {
+    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
         let api_key = std::env::var(CONFIG.api_key_env).map_err(|_| AgentError::Config {
             message: format!("{} not set", CONFIG.api_key_env),
         })?;
         Ok(Self {
-            compat: OpenAiCompatProvider::new(&CONFIG),
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
             auth: ResolvedAuth::bearer(&api_key),
         })
     }

--- a/maki-providers/src/providers/zai.rs
+++ b/maki-providers/src/providers/zai.rs
@@ -141,7 +141,7 @@ pub struct Zai {
 }
 
 impl Zai {
-    pub fn new(plan: ZaiPlan) -> Result<Self, AgentError> {
+    pub fn new(plan: ZaiPlan, timeouts: super::Timeouts) -> Result<Self, AgentError> {
         let config = match plan {
             ZaiPlan::Standard => &CONFIG_STANDARD,
             ZaiPlan::Coding => &CONFIG_CODING,
@@ -150,7 +150,7 @@ impl Zai {
             message: format!("{} not set", config.api_key_env),
         })?;
         Ok(Self {
-            compat: OpenAiCompatProvider::new(config),
+            compat: OpenAiCompatProvider::new(config, timeouts),
             auth: ResolvedAuth::bearer(&api_key),
         })
     }

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -40,6 +40,7 @@ pub(super) struct AgentLoop {
     answer_rx: Arc<async_lock::Mutex<flume::Receiver<String>>>,
     queue: Arc<QueueReceiver>,
     session_id: Option<String>,
+    timeouts: maki_providers::Timeouts,
 }
 
 impl AgentLoop {
@@ -58,6 +59,7 @@ impl AgentLoop {
         cancel_map: Arc<Mutex<CancelMap>>,
         init_cancel: CancelToken,
         session_id: Option<String>,
+        timeouts: maki_providers::Timeouts,
     ) -> Self {
         Self {
             model_slot,
@@ -77,6 +79,7 @@ impl AgentLoop {
             answer_rx: Arc::new(async_lock::Mutex::new(answer_rx)),
             queue,
             session_id,
+            timeouts,
         }
     }
 
@@ -204,6 +207,7 @@ impl AgentLoop {
                 config: self.config.clone(),
                 permissions: Arc::clone(&self.permissions),
                 session_id: self.session_id.clone(),
+                timeouts: self.timeouts,
             },
             AgentRunParams {
                 history: mem::replace(&mut self.history, History::new(Vec::new())),

--- a/maki-ui/src/agent/mod.rs
+++ b/maki-ui/src/agent/mod.rs
@@ -48,12 +48,14 @@ pub(crate) struct AgentHandles {
     pub(crate) tool_outputs: Arc<Mutex<HashMap<String, ToolOutput>>>,
     pub(crate) mcp_handle: Option<McpHandle>,
     pub(crate) queue: QueueSender,
+    pub(crate) timeouts: maki_providers::Timeouts,
     task: smol::Task<()>,
 }
 
 impl AgentHandles {
     /// MCP is started once up front. The handle lives across agent respawns, only the agent
     /// loop task gets replaced.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn spawn(
         model_slot: &Arc<ArcSwap<ModelSlot>>,
         initial_history: Vec<Message>,
@@ -62,6 +64,7 @@ impl AgentHandles {
         permissions: &Arc<PermissionManager>,
         cwd: PathBuf,
         session_id: Option<String>,
+        timeouts: maki_providers::Timeouts,
     ) -> Self {
         let mcp_handle = smol::block_on(mcp::start(&cwd));
         spawn_agent_internal(
@@ -72,6 +75,7 @@ impl AgentHandles {
             permissions,
             mcp_handle,
             session_id,
+            timeouts,
         )
     }
 
@@ -121,6 +125,7 @@ impl AgentHandles {
             permissions,
             self.mcp_handle.clone(),
             Some(app.state.session.id.clone()),
+            self.timeouts,
         );
         let old = mem::replace(self, new);
         // Repoint the app at the new queue before dropping `old`, otherwise the app keeps
@@ -177,6 +182,7 @@ async fn shutdown_mcp(handle: &McpHandle) {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn spawn_agent_internal(
     model_slot: &Arc<ArcSwap<ModelSlot>>,
     initial_history: Vec<Message>,
@@ -185,6 +191,7 @@ fn spawn_agent_internal(
     permissions: &Arc<PermissionManager>,
     mcp_handle: Option<McpHandle>,
     session_id: Option<String>,
+    timeouts: maki_providers::Timeouts,
 ) -> AgentHandles {
     let (agent_tx, agent_rx) = flume::unbounded::<Envelope>();
     let (cmd_tx, cmd_rx) = flume::unbounded::<AgentCommand>();
@@ -214,6 +221,7 @@ fn spawn_agent_internal(
         cancel_map,
         init_cancel,
         session_id,
+        timeouts,
     );
 
     let task = smol::spawn(agent_loop.run());
@@ -226,6 +234,7 @@ fn spawn_agent_internal(
         tool_outputs: shared_tool_outputs,
         mcp_handle,
         queue: queue_tx,
+        timeouts,
         task,
     }
 }

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -12,6 +12,7 @@ use maki_agent::permissions::PermissionManager;
 use maki_agent::skill::Skill;
 use maki_agent::{AgentConfig, CancelToken, McpCommand};
 use maki_config::UiConfig;
+use maki_providers::Timeouts;
 use maki_providers::provider::{Provider, fetch_all_models, from_model};
 use maki_providers::{Message, Model};
 use maki_storage::DataDir;
@@ -43,6 +44,7 @@ pub struct EventLoopParams {
     pub ui_config: UiConfig,
     pub input_history_size: usize,
     pub permissions: Arc<PermissionManager>,
+    pub timeouts: Timeouts,
     #[cfg(feature = "demo")]
     pub demo: bool,
 }
@@ -59,6 +61,7 @@ pub(crate) struct EventLoop<'t> {
     shell_rx: flume::Receiver<ShellEvent>,
     warn_rx: flume::Receiver<String>,
     storage_writer: Arc<StorageWriter>,
+    timeouts: Timeouts,
     _model_fetch_task: smol::Task<()>,
 }
 
@@ -150,6 +153,7 @@ impl<'t> EventLoop<'t> {
             ui_config,
             input_history_size,
             permissions,
+            timeouts,
             #[cfg(feature = "demo")]
             demo,
         } = params;
@@ -165,7 +169,8 @@ impl<'t> EventLoop<'t> {
         let initial_history = session.messages.clone();
         let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
 
-        let provider: Arc<dyn Provider> = Arc::from(from_model(&model).context("create provider")?);
+        let provider: Arc<dyn Provider> =
+            Arc::from(from_model(&model, timeouts).context("create provider")?);
         let skills: Arc<[Skill]> = Arc::from(skills);
         let model_slot = Arc::new(ArcSwap::from_pointee(ModelSlot {
             model: model.clone(),
@@ -179,6 +184,7 @@ impl<'t> EventLoop<'t> {
             &permissions,
             cwd,
             Some(session.id.clone()),
+            timeouts,
         );
 
         let custom_commands: Arc<[CustomCommand]> = Arc::from(commands);
@@ -218,6 +224,7 @@ impl<'t> EventLoop<'t> {
             shell_rx,
             warn_rx: bg.warn_rx,
             storage_writer,
+            timeouts,
             _model_fetch_task: bg.task,
         })
     }
@@ -374,7 +381,7 @@ impl<'t> EventLoop<'t> {
                 let loaded = *loaded;
                 if loaded.model_spec != self.model_slot.load().model.spec()
                     && let Ok(new_model) = Model::from_spec(&loaded.model_spec)
-                    && let Ok(new_provider) = from_model(&new_model)
+                    && let Ok(new_provider) = from_model(&new_model, self.timeouts)
                 {
                     self.model_slot.store(Arc::new(ModelSlot {
                         model: new_model,
@@ -437,7 +444,7 @@ impl<'t> EventLoop<'t> {
 
     fn change_model(&mut self, spec: String) {
         match Model::from_spec(&spec) {
-            Ok(new_model) => match from_model(&new_model) {
+            Ok(new_model) => match from_model(&new_model, self.timeouts) {
                 Ok(new_provider) => {
                     self.app.update_model(&new_model);
                     self.model_slot.store(Arc::new(ModelSlot {

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,6 +293,10 @@ fn run() -> Result<()> {
             maki_providers::tier_map::load_from_storage(&storage);
             let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
             let mut config = load_config(&cwd, cli.no_rtk);
+            let timeouts = maki_providers::Timeouts {
+                connect: config.provider.connect_timeout,
+                stream: config.provider.stream_timeout,
+            };
             if cli.yolo || config.always_yolo {
                 config.permissions.allow_all = true;
             }
@@ -318,6 +322,7 @@ fn run() -> Result<()> {
                     skills,
                     config.agent,
                     config.permissions,
+                    timeouts,
                 )
                 .context("run print mode")?;
             } else {
@@ -347,6 +352,7 @@ fn run() -> Result<()> {
                         config.permissions,
                         cwd.clone(),
                     )),
+                    timeouts,
                     #[cfg(feature = "demo")]
                     demo: cli.demo,
                 })

--- a/src/print.rs
+++ b/src/print.rs
@@ -123,6 +123,7 @@ impl VerboseOutput {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     model: &Model,
     prompt_arg: Option<String>,
@@ -131,6 +132,7 @@ pub fn run(
     skills: Vec<Skill>,
     config: AgentConfig,
     permissions_config: PermissionsConfig,
+    timeouts: maki_providers::Timeouts,
 ) -> Result<()> {
     let prompt = match prompt_arg {
         Some(p) => p,
@@ -184,16 +186,17 @@ pub fn run(
     let session_id_clone = session_id.clone();
     let agent_task = smol::spawn(async move {
         let event_tx = EventSender::new(raw_tx, 0);
-        let provider: Arc<dyn Provider> = match provider::from_model_async(&model_clone).await {
-            Ok(p) => Arc::from(p),
-            Err(e) => {
-                error!(error = %e, "provider error");
-                let _ = event_tx.send(AgentEvent::Error {
-                    message: e.user_message(),
-                });
-                return;
-            }
-        };
+        let provider: Arc<dyn Provider> =
+            match provider::from_model_async(&model_clone, timeouts).await {
+                Ok(p) => Arc::from(p),
+                Err(e) => {
+                    error!(error = %e, "provider error");
+                    let _ = event_tx.send(AgentEvent::Error {
+                        message: e.user_message(),
+                    });
+                    return;
+                }
+            };
         let skills: Arc<[Skill]> = Arc::from(skills);
         let error_tx = event_tx.clone();
         let agent = Agent::new(
@@ -207,6 +210,7 @@ pub fn run(
                     cwd_path.clone(),
                 )),
                 session_id: Some(session_id_clone),
+                timeouts,
             },
             AgentRunParams {
                 history: History::new(Vec::new()),


### PR DESCRIPTION
The connect_timeout and stream_timeout config options were defined but never used. Providers had hardcoded constants instead (and stream timeout was 120s vs config default of 300s).

https://github.com/tontinton/maki/issues/57