### PR TITLE
ui: terminal: Handle EDITOR environment variable with multiple arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2340,6 +2340,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "shell-words",
  "smol",
  "strum",
  "syntect",
@@ -3727,6 +3728,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ tree-sitter = "0.26"
 tree-sitter-bash = "0.25"
 monty = { git = "https://github.com/pydantic/monty.git", rev = "2e9df4b", package = "monty" }
 notify = { version = "9.0.0-rc.2", default-features = false, features = ["flume", "macos_fsevent"] }
+shell-words = "1"
 
 wait-timeout = "0.2"
 

--- a/maki-ui/Cargo.toml
+++ b/maki-ui/Cargo.toml
@@ -36,6 +36,7 @@ dirs = { workspace = true }
 strum = { workspace = true }
 notify = { workspace = true }
 tempfile = { workspace = true }
+shell-words = { workspace = true }
 
 [features]
 demo = []

--- a/maki-ui/src/terminal.rs
+++ b/maki-ui/src/terminal.rs
@@ -1,3 +1,4 @@
+use shell_words::split;
 use std::io::stdout;
 use std::path::Path;
 
@@ -82,9 +83,16 @@ pub(crate) fn open_in_editor(
         .or_else(|_| std::env::var("EDITOR"))
         .map_err(|_| "Set $VISUAL or $EDITOR to open files".to_string())?;
 
+    let args = split(&editor).map_err(|e| format!("Failed to parse $VISUAL or $EDITOR: {e}"))?;
+
+    if args.is_empty() {
+        return Err("Empty $VISUAL or $EDITOR".to_string());
+    }
+
     suspend();
 
-    let result = std::process::Command::new(&editor)
+    let result = std::process::Command::new(&args[0])
+        .args(&args[1..])
         .arg(path)
         .stdin(std::process::Stdio::inherit())
         .stdout(std::process::Stdio::inherit())


### PR DESCRIPTION
The EDITOR environment variable is not necessarily just an executable but might include additional arguments, which need parsing.

Use shell-words to split it into separate arguments.

----

I have no idea if this is correct for Windows.