### PR TITLE
ui: add user guidance when denying permission

### DIFF
--- a/maki-agent/src/permissions.rs
+++ b/maki-agent/src/permissions.rs
@@ -54,12 +54,21 @@ pub enum PermissionCheck {
 }
 
 #[derive(Debug, Error)]
-#[error(
-    "Permission denied for `{tool}` ({scope}). Do not retry. Try a different approach or ask the user for guidance."
-)]
 pub struct PermissionError {
     tool: String,
     scope: String,
+    guidance: Option<String>,
+}
+
+impl std::fmt::Display for PermissionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Permission denied for `{}` ({}).", self.tool, self.scope)?;
+        if let Some(g) = &self.guidance {
+            write!(f, " User guidance: {}", g)
+        } else {
+            write!(f, " {}", DEFAULT_DENY_GUIDANCE)
+        }
+    }
 }
 
 impl PermissionError {
@@ -67,50 +76,79 @@ impl PermissionError {
         Self {
             tool: tool.to_string(),
             scope: scope.to_string(),
+            guidance: None,
+        }
+    }
+
+    fn with_guidance(tool: &str, scope: &str, guidance: String) -> Self {
+        Self {
+            tool: tool.to_string(),
+            scope: scope.to_string(),
+            guidance: Some(guidance),
         }
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PermissionDecision {
+pub const DEFAULT_DENY_GUIDANCE: &str =
+    "Do not retry. Try a different approach or ask the user for guidance.";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PermissionAnswer {
     AllowOnce,
     AllowSession,
     AllowAlwaysLocal,
     AllowAlwaysGlobal,
-    DenyOnce,
+    Deny,
+    DenyWithGuidance(String),
     DenyAlwaysLocal,
     DenyAlwaysGlobal,
 }
 
-impl PermissionDecision {
-    pub fn is_allow(self) -> bool {
+impl PermissionAnswer {
+    pub fn is_allow(&self) -> bool {
         matches!(
             self,
             Self::AllowOnce | Self::AllowSession | Self::AllowAlwaysLocal | Self::AllowAlwaysGlobal
         )
     }
 
-    pub fn to_answer_str(self) -> &'static str {
+    pub fn encode(&self) -> String {
         match self {
-            Self::AllowOnce => "allow",
-            Self::AllowSession => "allow_session",
-            Self::AllowAlwaysLocal => "allow_always_local",
-            Self::AllowAlwaysGlobal => "allow_always_global",
-            Self::DenyOnce => "deny",
-            Self::DenyAlwaysLocal => "deny_always_local",
-            Self::DenyAlwaysGlobal => "deny_always_global",
+            Self::AllowOnce => "allow".to_string(),
+            Self::AllowSession => "allow_session".to_string(),
+            Self::AllowAlwaysLocal => "allow_always_local".to_string(),
+            Self::AllowAlwaysGlobal => "allow_always_global".to_string(),
+            Self::Deny => "deny".to_string(),
+            Self::DenyWithGuidance(g) => format!("deny:{g}"),
+            Self::DenyAlwaysLocal => "deny_always_local".to_string(),
+            Self::DenyAlwaysGlobal => "deny_always_global".to_string(),
         }
     }
 
-    pub fn from_answer_str(s: &str) -> Option<Self> {
+    pub fn decode(s: &str) -> Option<Self> {
         match s {
             "allow" => Some(Self::AllowOnce),
             "allow_session" => Some(Self::AllowSession),
             "allow_always_local" => Some(Self::AllowAlwaysLocal),
             "allow_always_global" => Some(Self::AllowAlwaysGlobal),
-            "deny" => Some(Self::DenyOnce),
+            "deny" => Some(Self::Deny),
             "deny_always_local" => Some(Self::DenyAlwaysLocal),
             "deny_always_global" => Some(Self::DenyAlwaysGlobal),
+            _ if s.starts_with("deny:") => {
+                let guidance = s.strip_prefix("deny:").unwrap();
+                if guidance.is_empty() {
+                    Some(Self::Deny)
+                } else {
+                    Some(Self::DenyWithGuidance(guidance.to_string()))
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn guidance(&self) -> Option<&str> {
+        match self {
+            Self::DenyWithGuidance(g) => Some(g),
             _ => None,
         }
     }
@@ -233,16 +271,18 @@ impl PermissionManager {
         *self.session_rules() = rules;
     }
 
-    pub fn apply_decision(&self, tool: &str, scopes: &[String], decision: PermissionDecision) {
-        let resolved = if decision.is_allow() {
+    pub fn apply_decision(&self, tool: &str, scopes: &[String], answer: &PermissionAnswer) {
+        let resolved = if answer.is_allow() {
             generalized_scopes(tool, scopes)
         } else {
             scopes.to_vec()
         };
 
-        match decision {
-            PermissionDecision::AllowOnce | PermissionDecision::DenyOnce => {}
-            PermissionDecision::AllowSession => {
+        match answer {
+            PermissionAnswer::AllowOnce
+            | PermissionAnswer::Deny
+            | PermissionAnswer::DenyWithGuidance(_) => {}
+            PermissionAnswer::AllowSession => {
                 for s in &resolved {
                     self.add_session_rule(PermissionRule {
                         tool: tool.to_string(),
@@ -251,17 +291,17 @@ impl PermissionManager {
                     });
                 }
             }
-            PermissionDecision::AllowAlwaysLocal
-            | PermissionDecision::AllowAlwaysGlobal
-            | PermissionDecision::DenyAlwaysLocal
-            | PermissionDecision::DenyAlwaysGlobal => {
-                let effect = if decision.is_allow() {
+            PermissionAnswer::AllowAlwaysLocal
+            | PermissionAnswer::AllowAlwaysGlobal
+            | PermissionAnswer::DenyAlwaysLocal
+            | PermissionAnswer::DenyAlwaysGlobal => {
+                let effect = if answer.is_allow() {
                     Effect::Allow
                 } else {
                     Effect::Deny
                 };
-                let target = match decision {
-                    PermissionDecision::AllowAlwaysLocal | PermissionDecision::DenyAlwaysLocal => {
+                let target = match answer {
+                    PermissionAnswer::AllowAlwaysLocal | PermissionAnswer::DenyAlwaysLocal => {
                         PermissionTarget::Project(self.cwd.clone())
                     }
                     _ => PermissionTarget::Global,
@@ -332,11 +372,17 @@ impl PermissionManager {
                             }
                             Err(_) => return Err(PermissionError::new(tool, scope)),
                         };
-                        match PermissionDecision::from_answer_str(&answer) {
-                            Some(d) => {
-                                self.apply_decision(&t2, &s2, d);
-                                if d.is_allow() {
+                        match PermissionAnswer::decode(&answer) {
+                            Some(a) => {
+                                self.apply_decision(&t2, &s2, &a);
+                                if a.is_allow() {
                                     Ok(())
+                                } else if let Some(guidance) = a.guidance() {
+                                    Err(PermissionError::with_guidance(
+                                        tool,
+                                        scope,
+                                        guidance.to_string(),
+                                    ))
                                 } else {
                                     Err(PermissionError::new(tool, scope))
                                 }
@@ -747,7 +793,7 @@ mod tests {
         mgr.apply_decision(
             "bash",
             &["cd /tmp".into(), "cargo test --all".into()],
-            PermissionDecision::AllowAlwaysLocal,
+            &PermissionAnswer::AllowAlwaysLocal,
         );
         assert!(matches!(
             mgr.check("bash", "cd /other && cargo build"),
@@ -761,7 +807,7 @@ mod tests {
         mgr.apply_decision(
             "bash",
             &["cd /tmp".into(), "cargo test".into()],
-            PermissionDecision::DenyAlwaysLocal,
+            &PermissionAnswer::DenyAlwaysLocal,
         );
         assert!(matches!(
             mgr.check("bash", "cd /tmp"),
@@ -898,15 +944,15 @@ mod tests {
 
     #[test]
     fn allow_decisions_use_generalized_scope() {
-        for decision in [
-            PermissionDecision::AllowSession,
-            PermissionDecision::AllowAlwaysLocal,
+        for answer in [
+            PermissionAnswer::AllowSession,
+            PermissionAnswer::AllowAlwaysLocal,
         ] {
             let mgr = PermissionManager::new(PermissionsConfig::default(), PathBuf::from("/tmp"));
-            mgr.apply_decision("bash", &["cargo test --all".into()], decision);
+            mgr.apply_decision("bash", &["cargo test --all".into()], &answer);
             assert!(
                 matches!(mgr.check("bash", "cargo build"), PermissionCheck::Allowed),
-                "{decision:?} should generalize scope"
+                "{answer:?} should generalize scope"
             );
         }
     }
@@ -932,28 +978,28 @@ mod tests {
     }
 
     #[test]
-    fn permission_decision_roundtrip() {
-        let decisions = [
-            PermissionDecision::AllowOnce,
-            PermissionDecision::AllowSession,
-            PermissionDecision::AllowAlwaysLocal,
-            PermissionDecision::AllowAlwaysGlobal,
-            PermissionDecision::DenyOnce,
-            PermissionDecision::DenyAlwaysLocal,
-            PermissionDecision::DenyAlwaysGlobal,
+    fn permission_answer_roundtrip() {
+        let answers = [
+            PermissionAnswer::AllowOnce,
+            PermissionAnswer::AllowSession,
+            PermissionAnswer::AllowAlwaysLocal,
+            PermissionAnswer::AllowAlwaysGlobal,
+            PermissionAnswer::Deny,
+            PermissionAnswer::DenyAlwaysLocal,
+            PermissionAnswer::DenyAlwaysGlobal,
         ];
-        for d in decisions {
-            let s = d.to_answer_str();
-            let parsed = PermissionDecision::from_answer_str(s).unwrap();
-            assert_eq!(parsed, d);
+        for a in answers {
+            let s = a.encode();
+            let parsed = PermissionAnswer::decode(&s).unwrap();
+            assert_eq!(parsed, a);
         }
     }
 
     #[test]
     fn once_decisions_do_not_add_rules() {
         let mgr = PermissionManager::new(PermissionsConfig::default(), PathBuf::from("/tmp"));
-        for decision in [PermissionDecision::AllowOnce, PermissionDecision::DenyOnce] {
-            mgr.apply_decision("bash", &["cargo test".into()], decision);
+        for answer in [PermissionAnswer::AllowOnce, PermissionAnswer::Deny] {
+            mgr.apply_decision("bash", &["cargo test".into()], &answer);
             assert!(matches!(
                 mgr.check("bash", "cargo test"),
                 PermissionCheck::NeedsPrompt { .. }
@@ -969,5 +1015,36 @@ mod tests {
         assert!(pm.is_yolo());
         assert!(!pm.toggle_yolo());
         assert!(!pm.is_yolo());
+    }
+
+    #[test]
+    fn permission_error_without_guidance() {
+        let err = PermissionError::new("bash", "rm -rf /");
+        let msg = err.to_string();
+        assert!(msg.contains(DEFAULT_DENY_GUIDANCE));
+        assert!(!msg.contains("User guidance"));
+    }
+
+    #[test]
+    fn permission_error_with_guidance() {
+        let guidance = "Use cat instead";
+        let err = PermissionError::with_guidance("bash", "rm -rf /", guidance.into());
+        let msg = err.to_string();
+        assert!(msg.contains(&format!("User guidance: {}", guidance)));
+        assert!(!msg.contains(DEFAULT_DENY_GUIDANCE));
+    }
+
+    #[test_case("deny" => Some(PermissionAnswer::Deny) ; "plain_deny")]
+    #[test_case("deny:" => Some(PermissionAnswer::Deny) ; "deny_colon_empty")]
+    #[test_case("deny:Use cat" => Some(PermissionAnswer::DenyWithGuidance("Use cat".into())) ; "deny_with_guidance")]
+    fn decode_deny_variants(input: &str) -> Option<PermissionAnswer> {
+        PermissionAnswer::decode(input)
+    }
+
+    #[test]
+    fn deny_with_guidance_roundtrip() {
+        let answer = PermissionAnswer::DenyWithGuidance("Use cat".into());
+        let encoded = answer.encode();
+        assert_eq!(PermissionAnswer::decode(&encoded), Some(answer));
     }
 }

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -31,7 +31,7 @@ use crate::components::list_picker::{ListPicker, PickerAction};
 use crate::components::mcp_picker::{McpPicker, McpPickerAction};
 use crate::components::memory_modal::{MemoryEntry, MemoryModal, MemoryModalAction};
 use crate::components::model_picker::{ModelPicker, ModelPickerAction};
-use crate::components::permission_prompt::{PermissionAction, PermissionPrompt};
+use crate::components::permission_prompt::PermissionPrompt;
 use crate::components::plan_form::{PlanForm, PlanFormAction};
 use crate::components::question_form::{QuestionForm, QuestionFormAction};
 use crate::components::rewind_picker::{RewindPicker, RewindPickerAction};
@@ -49,7 +49,7 @@ use arc_swap::{ArcSwap, ArcSwapOption};
 use crossterm::event::{KeyCode, KeyEvent, MouseEvent};
 #[cfg(feature = "demo")]
 use maki_agent::QuestionInfo;
-use maki_agent::permissions::{PermissionDecision, PermissionManager};
+use maki_agent::permissions::PermissionManager;
 use maki_agent::{
     AgentEvent, Envelope, ImageSource, McpPromptInfo, McpSnapshotReader, SubagentInfo, ToolOutput,
 };
@@ -400,23 +400,14 @@ impl App {
         }
 
         if self.permission_prompt.is_open() {
-            if let Some(action) = self.permission_prompt.handle_key(key) {
+            if let Some(answer) = self.permission_prompt.handle_key(key) {
                 let subagent_id = self.permission_prompt.subagent_id().map(str::to_owned);
-                let decision = match action {
-                    PermissionAction::AllowOnce => PermissionDecision::AllowOnce,
-                    PermissionAction::AllowSession => PermissionDecision::AllowSession,
-                    PermissionAction::AllowAlwaysLocal => PermissionDecision::AllowAlwaysLocal,
-                    PermissionAction::AllowAlwaysGlobal => PermissionDecision::AllowAlwaysGlobal,
-                    PermissionAction::Deny => PermissionDecision::DenyOnce,
-                    PermissionAction::DenyAlwaysLocal => PermissionDecision::DenyAlwaysLocal,
-                    PermissionAction::DenyAlwaysGlobal => PermissionDecision::DenyAlwaysGlobal,
-                };
-                let answer = decision.to_answer_str().to_string();
+                let encoded = answer.encode();
                 self.permission_prompt.close();
                 if let Some(tx) = subagent_id.and_then(|id| self.subagent_answers.get(&id)) {
-                    let _ = tx.try_send(answer);
+                    let _ = tx.try_send(encoded);
                 } else {
-                    self.send_answer(answer);
+                    self.send_answer(encoded);
                 }
             }
             return vec![];
@@ -1259,6 +1250,9 @@ impl App {
 
     fn route_text_paste(&mut self, text: &str) {
         if self.plan_form.is_visible() {
+            return;
+        }
+        if self.permission_prompt.handle_paste(text) {
             return;
         }
         if self.question_form.handle_paste(text) {

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -49,9 +49,16 @@ use ratatui::text::{Line, Span};
 
 pub(crate) fn hint_line(pairs: &[(&str, &str)]) -> Line<'static> {
     let t = crate::theme::current();
-    let mut spans = Vec::with_capacity(pairs.len() * 2);
+    let mut spans = Vec::with_capacity(pairs.len() * 3);
     for (key, desc) in pairs {
-        spans.push(Span::styled(format!("  {key}"), t.keybind_key));
+        spans.push(Span::raw("  "));
+        let parts: Vec<&str> = key.split('/').collect();
+        for (i, part) in parts.iter().enumerate() {
+            if i > 0 {
+                spans.push(Span::raw("/"));
+            }
+            spans.push(Span::styled((*part).to_string(), t.keybind_key));
+        }
         spans.push(Span::styled(format!(" {desc}"), t.form_hint));
     }
     Line::from(spans)

--- a/maki-ui/src/components/permission_prompt.rs
+++ b/maki-ui/src/components/permission_prompt.rs
@@ -5,12 +5,13 @@ use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Wrap};
 
-use maki_agent::permissions::generalized_scopes;
+use maki_agent::permissions::{DEFAULT_DENY_GUIDANCE, PermissionAnswer, generalized_scopes};
 
 use crate::components::Overlay;
 use crate::components::form::render_form;
 use crate::components::hint_line;
 use crate::components::is_ctrl;
+use crate::text_buffer::TextBuffer;
 use crate::theme;
 
 const HINT_ALLOW_ROW: &[(&str, &str)] = &[
@@ -25,20 +26,26 @@ const HINT_DENY_ROW: &[(&str, &str)] = &[
     ("D", "Deny-always (all)"),
 ];
 
-const CONFIRM_ALLOW_PROJECT_HINTS: &[(&str, &str)] =
-    &[("y", "Confirm allow-always (project)"), ("any", "Cancel")];
+const CONFIRM_ALLOW_PROJECT_HINTS: &[(&str, &str)] = &[
+    ("Enter / y", "Confirm allow-always (project)"),
+    ("any", "Cancel"),
+];
 const CONFIRM_ALLOW_ALL_HINTS: &[(&str, &str)] = &[
-    ("y", "Confirm allow-always (all projects)"),
+    ("Enter / y", "Confirm allow-always (all projects)"),
     ("any", "Cancel"),
 ];
 const CONFIRM_SESSION_HINTS: &[(&str, &str)] =
-    &[("y", "Confirm allow (session)"), ("any", "Cancel")];
-const CONFIRM_DENY_PROJECT_HINTS: &[(&str, &str)] =
-    &[("y", "Confirm deny-always (project)"), ("any", "Cancel")];
-const CONFIRM_DENY_ALL_HINTS: &[(&str, &str)] = &[
-    ("y", "Confirm deny-always (all projects)"),
+    &[("Enter / y", "Confirm allow (session)"), ("any", "Cancel")];
+const CONFIRM_DENY_PROJECT_HINTS: &[(&str, &str)] = &[
+    ("Enter / y", "Confirm deny-always (project)"),
     ("any", "Cancel"),
 ];
+const CONFIRM_DENY_ALL_HINTS: &[(&str, &str)] = &[
+    ("Enter / y", "Confirm deny-always (all projects)"),
+    ("any", "Cancel"),
+];
+
+const DENY_GUIDANCE_HINTS: &[(&str, &str)] = &[("Enter", "Deny"), ("Esc", "Cancel")];
 
 fn aligned_hint_rows(rows: &[&[(&str, &str)]]) -> Vec<Line<'static>> {
     let t = theme::current();
@@ -71,17 +78,6 @@ fn aligned_hint_rows(rows: &[&[(&str, &str)]]) -> Vec<Line<'static>> {
         .collect()
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PermissionAction {
-    AllowOnce,
-    Deny,
-    AllowAlwaysLocal,
-    AllowAlwaysGlobal,
-    DenyAlwaysLocal,
-    DenyAlwaysGlobal,
-    AllowSession,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) enum PromptState {
     #[default]
@@ -91,6 +87,7 @@ pub(crate) enum PromptState {
     ConfirmAllowSession,
     ConfirmDenyAlwaysLocal,
     ConfirmDenyAlwaysGlobal,
+    DenyEditing,
 }
 
 pub enum PermissionPrompt {
@@ -103,6 +100,7 @@ pub enum PermissionPrompt {
         subagent_id: Option<String>,
         allow_scopes: Vec<String>,
         state: PromptState,
+        buffer: TextBuffer,
     },
 }
 
@@ -145,6 +143,7 @@ impl PermissionPrompt {
             subagent_id,
             allow_scopes,
             state: PromptState::Normal,
+            buffer: TextBuffer::new(String::new()),
         };
     }
 
@@ -155,12 +154,33 @@ impl PermissionPrompt {
         }
     }
 
-    pub fn handle_key(&mut self, key: KeyEvent) -> Option<PermissionAction> {
-        let Self::Open { state, .. } = self else {
+    pub fn handle_key(&mut self, key: KeyEvent) -> Option<PermissionAnswer> {
+        let Self::Open { state, buffer, .. } = self else {
             return None;
         };
         if is_ctrl(&key) && key.code == KeyCode::Char('c') {
-            return Some(PermissionAction::Deny);
+            return Some(PermissionAnswer::Deny);
+        }
+        if *state == PromptState::DenyEditing {
+            return match key.code {
+                KeyCode::Enter => {
+                    let text = buffer.value().trim().to_string();
+                    if text.is_empty() {
+                        Some(PermissionAnswer::Deny)
+                    } else {
+                        Some(PermissionAnswer::DenyWithGuidance(text))
+                    }
+                }
+                KeyCode::Esc => {
+                    *buffer = TextBuffer::new(String::new());
+                    *state = PromptState::Normal;
+                    None
+                }
+                _ => {
+                    buffer.handle_key(key);
+                    None
+                }
+            };
         }
         if key
             .modifiers
@@ -168,68 +188,62 @@ impl PermissionPrompt {
         {
             return None;
         }
-        match *state {
-            PromptState::Normal => match key.code {
-                KeyCode::Char('y') => Some(PermissionAction::AllowOnce),
-                KeyCode::Char('n') => Some(PermissionAction::Deny),
-                KeyCode::Char('a') => {
-                    *state = PromptState::ConfirmAllowAlwaysLocal;
-                    None
-                }
-                KeyCode::Char('A') => {
-                    *state = PromptState::ConfirmAllowAlwaysGlobal;
-                    None
-                }
-                KeyCode::Char('d') => {
-                    *state = PromptState::ConfirmDenyAlwaysLocal;
-                    None
-                }
-                KeyCode::Char('D') => {
-                    *state = PromptState::ConfirmDenyAlwaysGlobal;
-                    None
-                }
-                KeyCode::Char('s') => {
-                    *state = PromptState::ConfirmAllowSession;
-                    None
-                }
-                _ => None,
-            },
-            PromptState::ConfirmAllowAlwaysLocal => match key.code {
-                KeyCode::Char('y') => Some(PermissionAction::AllowAlwaysLocal),
+        let confirm_answer = match *state {
+            PromptState::ConfirmAllowAlwaysLocal => Some(PermissionAnswer::AllowAlwaysLocal),
+            PromptState::ConfirmAllowAlwaysGlobal => Some(PermissionAnswer::AllowAlwaysGlobal),
+            PromptState::ConfirmAllowSession => Some(PermissionAnswer::AllowSession),
+            PromptState::ConfirmDenyAlwaysLocal => Some(PermissionAnswer::DenyAlwaysLocal),
+            PromptState::ConfirmDenyAlwaysGlobal => Some(PermissionAnswer::DenyAlwaysGlobal),
+            _ => None,
+        };
+        if let Some(answer) = confirm_answer {
+            return match key.code {
+                KeyCode::Char('y') | KeyCode::Enter => Some(answer),
                 _ => {
                     *state = PromptState::Normal;
                     None
                 }
-            },
-            PromptState::ConfirmAllowAlwaysGlobal => match key.code {
-                KeyCode::Char('y') => Some(PermissionAction::AllowAlwaysGlobal),
-                _ => {
-                    *state = PromptState::Normal;
-                    None
-                }
-            },
-            PromptState::ConfirmAllowSession => match key.code {
-                KeyCode::Char('y') => Some(PermissionAction::AllowSession),
-                _ => {
-                    *state = PromptState::Normal;
-                    None
-                }
-            },
-            PromptState::ConfirmDenyAlwaysLocal => match key.code {
-                KeyCode::Char('y') => Some(PermissionAction::DenyAlwaysLocal),
-                _ => {
-                    *state = PromptState::Normal;
-                    None
-                }
-            },
-            PromptState::ConfirmDenyAlwaysGlobal => match key.code {
-                KeyCode::Char('y') => Some(PermissionAction::DenyAlwaysGlobal),
-                _ => {
-                    *state = PromptState::Normal;
-                    None
-                }
-            },
+            };
         }
+        match key.code {
+            KeyCode::Char('y') => Some(PermissionAnswer::AllowOnce),
+            KeyCode::Char('n') => {
+                *state = PromptState::DenyEditing;
+                None
+            }
+            KeyCode::Char('a') => {
+                *state = PromptState::ConfirmAllowAlwaysLocal;
+                None
+            }
+            KeyCode::Char('A') => {
+                *state = PromptState::ConfirmAllowAlwaysGlobal;
+                None
+            }
+            KeyCode::Char('d') => {
+                *state = PromptState::ConfirmDenyAlwaysLocal;
+                None
+            }
+            KeyCode::Char('D') => {
+                *state = PromptState::ConfirmDenyAlwaysGlobal;
+                None
+            }
+            KeyCode::Char('s') => {
+                *state = PromptState::ConfirmAllowSession;
+                None
+            }
+            _ => None,
+        }
+    }
+
+    pub fn handle_paste(&mut self, text: &str) -> bool {
+        let Self::Open { state, buffer, .. } = self else {
+            return false;
+        };
+        if *state == PromptState::DenyEditing {
+            buffer.insert_text(text);
+            return true;
+        }
+        false
     }
 
     fn build_lines(&self) -> Vec<Line<'static>> {
@@ -239,6 +253,7 @@ impl PermissionPrompt {
             subagent_id,
             allow_scopes,
             state,
+            buffer,
             ..
         } = self
         else {
@@ -275,6 +290,32 @@ impl PermissionPrompt {
             }
         }
 
+        if *state == PromptState::DenyEditing {
+            let text = buffer.value();
+            let (display_text, cursor_pos) = if text.is_empty() {
+                (DEFAULT_DENY_GUIDANCE, 0)
+            } else {
+                (text.as_str(), TextBuffer::char_to_byte(&text, buffer.x()))
+            };
+            let (before, after) = display_text.split_at(cursor_pos);
+            let mut chars = after.chars();
+            let cursor_ch = chars.next().map_or(' ', |c| c);
+            let rest: String = chars.collect();
+
+            let mut spans = vec![Span::raw("  "), Span::styled("guide ", label_style)];
+            if text.is_empty() {
+                spans.push(Span::styled(cursor_ch.to_string(), Style::new().reversed()));
+                spans.push(Span::styled(rest, t.form_hint));
+            } else {
+                spans.push(Span::raw(before.to_string()));
+                spans.push(Span::styled(cursor_ch.to_string(), Style::new().reversed()));
+                if !rest.is_empty() {
+                    spans.push(Span::raw(rest));
+                }
+            }
+            lines.push(Line::from(spans));
+        }
+
         lines.push(Line::raw(""));
         match *state {
             PromptState::ConfirmAllowAlwaysLocal => {
@@ -291,6 +332,9 @@ impl PermissionPrompt {
             }
             PromptState::ConfirmDenyAlwaysGlobal => {
                 lines.push(hint_line(CONFIRM_DENY_ALL_HINTS));
+            }
+            PromptState::DenyEditing => {
+                lines.push(hint_line(DENY_GUIDANCE_HINTS));
             }
             PromptState::Normal => {
                 lines.extend(aligned_hint_rows(&[HINT_ALLOW_ROW, HINT_DENY_ROW]));
@@ -320,8 +364,9 @@ impl PermissionPrompt {
 #[cfg(test)]
 mod tests {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use maki_agent::permissions::PermissionAnswer;
 
-    use super::{PermissionAction, PermissionPrompt};
+    use super::{PermissionPrompt, PromptState};
 
     fn open_prompt() -> PermissionPrompt {
         let mut prompt = PermissionPrompt::new();
@@ -333,9 +378,77 @@ mod tests {
         KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)
     }
 
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
     #[test]
     fn ctrl_c_denies() {
         let mut prompt = open_prompt();
-        assert_eq!(prompt.handle_key(ctrl_c()), Some(PermissionAction::Deny));
+        assert_eq!(prompt.handle_key(ctrl_c()), Some(PermissionAnswer::Deny));
+        // Also test from editing state
+        let mut prompt2 = open_prompt();
+        prompt2.handle_key(key(KeyCode::Char('n')));
+        prompt2.handle_key(key(KeyCode::Char('t')));
+        assert_eq!(prompt2.handle_key(ctrl_c()), Some(PermissionAnswer::Deny));
+    }
+
+    #[test]
+    fn n_goes_to_deny_editing() {
+        let mut prompt = open_prompt();
+        assert_eq!(prompt.handle_key(key(KeyCode::Char('n'))), None);
+        if let PermissionPrompt::Open { state, .. } = &prompt {
+            assert_eq!(*state, PromptState::DenyEditing);
+        } else {
+            panic!("expected Open");
+        }
+    }
+
+    #[test]
+    fn deny_editing_esc_returns_to_normal() {
+        let mut prompt = open_prompt();
+        prompt.handle_key(key(KeyCode::Char('n')));
+        prompt.handle_key(key(KeyCode::Char('t')));
+        assert_eq!(prompt.handle_key(key(KeyCode::Esc)), None);
+        if let PermissionPrompt::Open { state, buffer, .. } = &prompt {
+            assert_eq!(*state, PromptState::Normal);
+            assert!(buffer.value().is_empty());
+        } else {
+            panic!("expected Open");
+        }
+    }
+
+    #[test]
+    fn deny_editing_enter_empty_sends_deny() {
+        let mut prompt = open_prompt();
+        prompt.handle_key(key(KeyCode::Char('n')));
+        assert_eq!(
+            prompt.handle_key(key(KeyCode::Enter)),
+            Some(PermissionAnswer::Deny)
+        );
+    }
+
+    #[test]
+    fn deny_editing_with_text_sends_guidance() {
+        let mut prompt = open_prompt();
+        prompt.handle_key(key(KeyCode::Char('n')));
+        prompt.handle_paste("Use cat");
+        assert_eq!(
+            prompt.handle_key(key(KeyCode::Enter)),
+            Some(PermissionAnswer::DenyWithGuidance("Use cat".into()))
+        );
+    }
+
+    #[test]
+    fn handle_paste_requires_editing_mode() {
+        let mut prompt = open_prompt();
+        assert!(!prompt.handle_paste("ignored"));
+        prompt.handle_key(key(KeyCode::Char('n')));
+        assert!(prompt.handle_paste("accepted"));
+        if let PermissionPrompt::Open { buffer, .. } = &prompt {
+            assert_eq!(buffer.value(), "accepted");
+        } else {
+            panic!("expected Open");
+        }
     }
 }


### PR DESCRIPTION
When you press 'n' to deny a tool call, you now see a preview of the message going to the AI. Press y to send it as is, or Enter to type your own guidance. The AI gets something like 'Permission denied for bash. User guidance: try cat instead' so it can make a smarter retry.

Also made Enter behave like y in other forms to make the UX more uniform.

https://github.com/tontinton/maki/issues/60