### PR TITLE
agent: track file reads, require read before edit

### DIFF
--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -15,7 +15,7 @@ use crate::cancel::CancelToken;
 use crate::mcp::McpHandle;
 use crate::permissions::PermissionManager;
 use crate::skill::Skill;
-use crate::tools::{Deadline, ToolContext};
+use crate::tools::{Deadline, FileReadTracker, ToolContext};
 use crate::{
     AgentConfig, AgentError, AgentEvent, AgentInput, AgentMode, EventSender, ExtractedCommand,
     InterruptSource, TurnCompleteEvent,
@@ -75,6 +75,7 @@ pub struct Agent {
     thinking: ThinkingConfig,
     session_id: Option<String>,
     timeouts: maki_providers::Timeouts,
+    file_tracker: Arc<FileReadTracker>,
 }
 
 impl Agent {
@@ -104,6 +105,7 @@ impl Agent {
             reauth_attempts: 0,
             thinking: ThinkingConfig::Off,
             session_id: params.session_id,
+            file_tracker: Arc::new(FileReadTracker::new()),
         }
     }
 
@@ -329,6 +331,7 @@ impl Agent {
             config: self.config.clone(),
             permissions: Arc::clone(&self.permissions),
             timeouts: self.timeouts,
+            file_tracker: Arc::clone(&self.file_tracker),
         }
     }
 

--- a/maki-agent/src/tools/code_execution.rs
+++ b/maki-agent/src/tools/code_execution.rs
@@ -23,7 +23,7 @@ use crate::{AgentConfig, AgentEvent, AgentMode, EventSender, ToolInput, ToolOutp
 use smol::future::block_on;
 
 use super::truncate_output;
-use super::{Deadline, INTERPRETER_TOOLS};
+use super::{Deadline, FileReadTracker, INTERPRETER_TOOLS};
 
 const STREAM_FLUSH_INTERVAL: Duration = Duration::from_millis(100);
 const PREAMBLE: &str = "import re\nimport asyncio\nimport sys\nimport os\nimport json\n";
@@ -61,6 +61,7 @@ impl CodeExecution {
         let cancel = ctx.cancel.clone();
         let config = ctx.config.clone();
         let permissions = ctx.permissions.clone();
+        let file_tracker = ctx.file_tracker.clone();
         let deadline = Deadline::after(timeout);
         let limits = runner::limits(timeout, config.interpreter_max_memory_mb * 1024 * 1024);
 
@@ -76,6 +77,7 @@ impl CodeExecution {
                     deadline,
                     config.clone(),
                     &permissions,
+                    &file_tracker,
                 );
                 let resolver = build_async_resolver(
                     &event_tx,
@@ -84,6 +86,7 @@ impl CodeExecution {
                     deadline,
                     config.clone(),
                     &permissions,
+                    &file_tracker,
                 );
                 let code = format!("{PREAMBLE}{code}");
 
@@ -164,6 +167,7 @@ fn build_tool_fns(
     deadline: Deadline,
     config: AgentConfig,
     permissions: &Arc<PermissionManager>,
+    file_tracker: &Arc<FileReadTracker>,
 ) -> HashMap<String, ToolFn> {
     let mut tools: HashMap<String, ToolFn> = HashMap::new();
 
@@ -177,6 +181,7 @@ fn build_tool_fns(
         let cancel = cancel.clone();
         let permissions = Arc::clone(permissions);
         let config = config.clone();
+        let file_tracker = Arc::clone(file_tracker);
 
         tools.insert(
             name.clone(),
@@ -193,6 +198,7 @@ fn build_tool_fns(
                         &tx,
                         cancel.clone(),
                         Arc::clone(&permissions),
+                        Arc::clone(&file_tracker),
                     );
                     inner_ctx.deadline = deadline;
                     inner_ctx.config = config.clone();
@@ -217,14 +223,17 @@ fn build_async_resolver(
     deadline: Deadline,
     config: AgentConfig,
     permissions: &Arc<PermissionManager>,
+    file_tracker: &Arc<FileReadTracker>,
 ) -> AsyncResolver {
     let tx = event_tx.clone();
     let mode = mode.clone();
     let cancel = cancel.clone();
     let permissions = Arc::clone(permissions);
+    let file_tracker = Arc::clone(file_tracker);
 
     Box::new(move |pending_calls: Vec<PendingCall>| {
         let config = config.clone();
+        let file_tracker = Arc::clone(&file_tracker);
         smol::future::block_on(async {
             let call_ids: Vec<u32> = pending_calls.iter().map(|pc| pc.call_id).collect();
             let mut set = TaskSet::new();
@@ -234,6 +243,7 @@ fn build_async_resolver(
                 let cancel = cancel.clone();
                 let permissions = Arc::clone(&permissions);
                 let config = config.clone();
+                let file_tracker = Arc::clone(&file_tracker);
 
                 set.spawn(async move {
                     if let Err(e) = deadline.check() {
@@ -249,8 +259,13 @@ fn build_async_resolver(
                         Err(e) => return (pc.call_id, Err(format!("tool parse error: {e}"))),
                     };
 
-                    let mut inner_ctx =
-                        super::interpreter_ctx(&mode, &tx, cancel, Arc::clone(&permissions));
+                    let mut inner_ctx = super::interpreter_ctx(
+                        &mode,
+                        &tx,
+                        cancel,
+                        Arc::clone(&permissions),
+                        file_tracker,
+                    );
                     inner_ctx.deadline = deadline;
                     inner_ctx.config = config;
                     let done = call.execute(&inner_ctx, String::new()).await;

--- a/maki-agent/src/tools/edit.rs
+++ b/maki-agent/src/tools/edit.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::Path;
 
 use crate::ToolOutput;
 use maki_tool_macro::Tool;
@@ -29,15 +30,22 @@ impl Edit {
 ]"#,
     );
 
-    pub async fn execute(&self, _ctx: &super::ToolContext) -> Result<ToolOutput, String> {
+    pub async fn execute(&self, ctx: &super::ToolContext) -> Result<ToolOutput, String> {
         let path = super::resolve_path(&self.path)?;
         let old_string = self.old_string.clone();
         let new_string = self.new_string.clone();
         let replace_all = self.replace_all.unwrap_or(false);
+        let file_tracker = ctx.file_tracker.clone();
         smol::unblock(move || {
-            let before = fs::read_to_string(&path).map_err(|e| format!("read error: {e}"))?;
+            let p = Path::new(&path);
+            file_tracker.check_before_edit(p)?;
+
+            let before = fs::read_to_string(p).map_err(|e| format!("read error: {e}"))?;
             let after = fuzzy_replace::replace(&before, &old_string, &new_string, replace_all)?;
-            fs::write(&path, &after).map_err(|e| format!("write error: {e}"))?;
+            fs::write(p, &after).map_err(|e| format!("write error: {e}"))?;
+
+            file_tracker.record_read(p);
+
             Ok(ToolOutput::Diff {
                 summary: format!("edited {}", relative_path(&path)),
                 path,
@@ -66,6 +74,7 @@ impl super::ToolDefaults for Edit {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::path::Path;
 
     use tempfile::TempDir;
 
@@ -80,6 +89,10 @@ mod tests {
         path.to_string_lossy().to_string()
     }
 
+    fn pre_read(ctx: &super::super::ToolContext, path: &str) {
+        ctx.file_tracker.record_read(Path::new(path));
+    }
+
     #[test]
     fn edit_reads_replaces_writes() {
         smol::block_on(async {
@@ -87,6 +100,7 @@ mod tests {
             let ctx = stub_ctx(&AgentMode::Build);
 
             let path = temp_file(&dir, "f.rs", "fn old() {}\nfn keep() {}");
+            pre_read(&ctx, &path);
             Edit {
                 path: path.clone(),
                 old_string: "fn old() {}".into(),
@@ -102,6 +116,7 @@ mod tests {
             );
 
             let path = temp_file(&dir, "g.rs", "let x = 1;\nlet x = 1;\nlet y = 2;");
+            pre_read(&ctx, &path);
             Edit {
                 path: path.clone(),
                 old_string: "let x = 1;".into(),
@@ -130,6 +145,7 @@ mod tests {
             let original = "const A: u8 = 1;\nconst B: u8 = 2;\n";
             let updated = "const A: u8 = 9;\nconst B: u8 = 2;\n";
             let path = temp_file(&dir, "f.rs", original);
+            pre_read(&ctx, &path);
             let output = Edit {
                 path: path.clone(),
                 old_string: "const A: u8 = 1;\\nconst B: u8 = 2;".into(),

--- a/maki-agent/src/tools/file_tracker.rs
+++ b/maki-agent/src/tools/file_tracker.rs
@@ -1,0 +1,129 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::SystemTime;
+
+pub struct FileReadTracker(Mutex<HashMap<PathBuf, SystemTime>>);
+
+fn get_mtime(path: &Path) -> SystemTime {
+    fs::metadata(path)
+        .and_then(|m| m.modified())
+        .unwrap_or(SystemTime::UNIX_EPOCH)
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+impl FileReadTracker {
+    pub fn new() -> Self {
+        Self(Mutex::new(HashMap::new()))
+    }
+
+    pub fn record_read(&self, path: &Path) {
+        let normalized = normalize_path(path);
+        let mtime = get_mtime(&normalized);
+        self.0.lock().unwrap().insert(normalized, mtime);
+    }
+
+    pub fn check_before_edit(&self, path: &Path) -> Result<(), String> {
+        let normalized = normalize_path(path);
+        let current_mtime = get_mtime(&normalized);
+
+        let guard = self.0.lock().unwrap();
+        match guard.get(&normalized) {
+            None => Err(format!(
+                "file must be read before editing: {}",
+                path.display()
+            )),
+            Some(&recorded) if recorded != current_mtime => Err(format!(
+                "file changed since last read: {} - re-read before editing",
+                path.display()
+            )),
+            Some(_) => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ERR_NOT_READ: &str = "file must be read before editing";
+    const ERR_FILE_CHANGED: &str = "file changed since last read";
+
+    #[test]
+    fn edit_without_read_fails() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("untracked.rs");
+        fs::write(&path, "content").unwrap();
+
+        let tracker = FileReadTracker::new();
+        let err = tracker.check_before_edit(&path).unwrap_err();
+        assert!(err.contains(ERR_NOT_READ));
+    }
+
+    #[test]
+    fn edit_after_read_succeeds() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.rs");
+        fs::write(&path, "content").unwrap();
+
+        let tracker = FileReadTracker::new();
+        tracker.record_read(&path);
+        tracker.check_before_edit(&path).unwrap();
+    }
+
+    #[test]
+    fn stale_mtime_fails() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.rs");
+        fs::write(&path, "original").unwrap();
+
+        let tracker = FileReadTracker::new();
+        tracker.record_read(&path);
+
+        let normalized = normalize_path(&path);
+        let stale = SystemTime::UNIX_EPOCH;
+        tracker.0.lock().unwrap().insert(normalized, stale);
+
+        let err = tracker.check_before_edit(&path).unwrap_err();
+        assert!(err.contains(ERR_FILE_CHANGED));
+    }
+
+    #[test]
+    fn re_record_updates_mtime() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.rs");
+        fs::write(&path, "content").unwrap();
+
+        let tracker = FileReadTracker::new();
+        tracker.record_read(&path);
+
+        let normalized = normalize_path(&path);
+        tracker
+            .0
+            .lock()
+            .unwrap()
+            .insert(normalized.clone(), SystemTime::UNIX_EPOCH);
+        assert!(tracker.check_before_edit(&path).is_err());
+
+        tracker.record_read(&path);
+        tracker.check_before_edit(&path).unwrap();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn symlink_resolves_to_same_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let real_path = dir.path().join("real.rs");
+        let link_path = dir.path().join("link.rs");
+        fs::write(&real_path, "content").unwrap();
+        std::os::unix::fs::symlink(&real_path, &link_path).unwrap();
+
+        let tracker = FileReadTracker::new();
+        tracker.record_read(&real_path);
+        tracker.check_before_edit(&link_path).unwrap();
+    }
+}

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -10,6 +10,7 @@ mod bash;
 mod batch;
 mod code_execution;
 mod edit;
+mod file_tracker;
 mod find_symbol;
 mod fuzzy_replace;
 mod glob;
@@ -26,6 +27,8 @@ mod todowrite;
 mod webfetch;
 mod websearch;
 mod write;
+
+pub(crate) use file_tracker::FileReadTracker;
 
 use std::collections::HashSet;
 use std::env;
@@ -252,6 +255,7 @@ pub struct ToolContext {
     pub config: AgentConfig,
     pub permissions: Arc<PermissionManager>,
     pub timeouts: maki_providers::Timeouts,
+    pub file_tracker: Arc<FileReadTracker>,
 }
 
 pub(crate) fn resolve_path(path: &str) -> Result<String, String> {
@@ -774,6 +778,7 @@ pub(crate) fn interpreter_ctx(
     event_tx: &EventSender,
     cancel: CancelToken,
     permissions: Arc<PermissionManager>,
+    file_tracker: Arc<FileReadTracker>,
 ) -> ToolContext {
     static PROVIDER: LazyLock<Arc<dyn Provider>> = LazyLock::new(|| Arc::new(NullProvider));
     static MODEL: LazyLock<Arc<Model>> =
@@ -794,6 +799,7 @@ pub(crate) fn interpreter_ctx(
         config: AgentConfig::default(),
         permissions,
         timeouts: maki_providers::Timeouts::default(),
+        file_tracker,
     }
 }
 
@@ -831,6 +837,7 @@ pub(crate) mod test_support {
             event_tx,
             CancelToken::none(),
             Arc::clone(&TEST_PERMISSIONS),
+            Arc::new(FileReadTracker::new()),
         );
         ctx.tool_use_id = tool_use_id.map(String::from);
         ctx
@@ -844,6 +851,7 @@ pub(crate) mod test_support {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::path::Path;
 
     use serde_json::json;
     use tempfile::TempDir;
@@ -1155,6 +1163,10 @@ mod tests {
 
             let plan_str = plan_path.to_str().unwrap();
             let other_str = other.to_str().unwrap();
+
+            // Pre-read both files for edit/multiedit tests
+            ctx.file_tracker.record_read(Path::new(plan_str));
+            ctx.file_tracker.record_read(Path::new(other_str));
 
             let blocked = ToolCall::from_api(tool, &other_input(plan_str, other_str)).unwrap();
             let result = blocked.execute(&ctx, "t1".into()).await;

--- a/maki-agent/src/tools/multiedit.rs
+++ b/maki-agent/src/tools/multiedit.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::Path;
 
 use crate::ToolOutput;
 use serde::Deserialize;
@@ -59,13 +60,20 @@ impl MultiEdit {
         Ok(content)
     }
 
-    pub async fn execute(&self, _ctx: &super::ToolContext) -> Result<ToolOutput, String> {
+    pub async fn execute(&self, ctx: &super::ToolContext) -> Result<ToolOutput, String> {
         let path = super::resolve_path(&self.path)?;
         let this = self.clone();
+        let file_tracker = ctx.file_tracker.clone();
         smol::unblock(move || {
-            let before = fs::read_to_string(&path).map_err(|e| format!("read error: {e}"))?;
+            let p = Path::new(&path);
+            file_tracker.check_before_edit(p)?;
+
+            let before = fs::read_to_string(p).map_err(|e| format!("read error: {e}"))?;
             let after = this.apply_edits(&before)?;
-            fs::write(&path, &after).map_err(|e| format!("write error: {e}"))?;
+            fs::write(p, &after).map_err(|e| format!("write error: {e}"))?;
+
+            file_tracker.record_read(p);
+
             Ok(ToolOutput::Diff {
                 summary: format!(
                     "applied {} to {}",
@@ -102,6 +110,7 @@ impl super::ToolDefaults for MultiEdit {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::path::Path;
 
     use serde_json::json;
     use tempfile::TempDir;
@@ -121,12 +130,17 @@ mod tests {
         path.to_string_lossy().to_string()
     }
 
+    fn pre_read(ctx: &super::super::ToolContext, path: &str) {
+        ctx.file_tracker.record_read(Path::new(path));
+    }
+
     #[test]
     fn sequential_edits_compose() {
         smol::block_on(async {
             let dir = TempDir::new().unwrap();
             let ctx = stub_ctx(&AgentMode::Build);
             let path = temp_file(&dir, "f.rs", "fn alpha() {}\nfn beta() {}");
+            pre_read(&ctx, &path);
             let tool = MultiEdit::parse_input(&json!({
                 "path": path,
                 "edits": [
@@ -151,6 +165,7 @@ mod tests {
             let ctx = stub_ctx(&AgentMode::Build);
             let original = "let a = 1;\nlet b = 2;";
             let path = temp_file(&dir, "f.rs", original);
+            pre_read(&ctx, &path);
             let tool = MultiEdit::parse_input(&json!({
                 "path": path,
                 "edits": [
@@ -172,25 +187,10 @@ mod tests {
             let dir = TempDir::new().unwrap();
             let ctx = stub_ctx(&AgentMode::Build);
             let path = temp_file(&dir, "f.rs", "content");
+            pre_read(&ctx, &path);
             let tool = MultiEdit::parse_input(&json!({ "path": path, "edits": [] })).unwrap();
             assert_eq!(tool.execute(&ctx).await.unwrap_err(), EMPTY_ERR);
         });
-    }
-
-    #[test]
-    fn start_summary_is_path_only() {
-        let tool = MultiEdit {
-            path: "/x.rs".into(),
-            edits: vec![
-                EditEntry {
-                    old_string: "a".into(),
-                    new_string: "b".into(),
-                    replace_all: None,
-                };
-                2
-            ],
-        };
-        assert_eq!(tool.start_summary(), "/x.rs");
     }
 
     #[test_case(1, "1 edit"  ; "singular")]

--- a/maki-agent/src/tools/read.rs
+++ b/maki-agent/src/tools/read.rs
@@ -44,13 +44,15 @@ impl Read {
         let loaded = ctx.loaded_instructions.clone();
         let max_output_lines = ctx.config.max_output_lines;
         let max_line_bytes = ctx.config.max_line_bytes;
+        let file_tracker = ctx.file_tracker.clone();
         smol::unblock(move || {
             let cwd = std::env::current_dir().ok();
-            if Path::new(&path).is_dir() {
+            let p = Path::new(&path);
+            if p.is_dir() {
                 return Self::list_dir(&path, cwd.as_deref(), &loaded);
             }
 
-            let raw = fs::read_to_string(&path).map_err(|e| format!("read error: {e}"))?;
+            let raw = fs::read_to_string(p).map_err(|e| format!("read error: {e}"))?;
             let total_lines = raw.lines().count();
 
             let start = offset.unwrap_or(1).saturating_sub(1);
@@ -64,7 +66,6 @@ impl Read {
                 .collect();
 
             let instructions = cwd.as_deref().and_then(|cwd| {
-                let p = Path::new(&path);
                 if agent::is_instruction_file(p.file_name()?.to_str()?) {
                     return None;
                 }
@@ -74,6 +75,8 @@ impl Read {
                     &loaded,
                 ))
             });
+
+            file_tracker.record_read(p);
 
             Ok(ToolOutput::ReadCode {
                 path,

--- a/maki-agent/src/tools/write.rs
+++ b/maki-agent/src/tools/write.rs
@@ -38,11 +38,17 @@ impl Write {
         let path = super::resolve_path(&self.path)?;
         let content = self.content.clone();
         let output = self.write_output(&path, ctx.config.max_output_lines);
+        let file_tracker = ctx.file_tracker.clone();
         smol::unblock(move || {
-            if let Some(parent) = Path::new(&path).parent() {
+            let p = Path::new(&path);
+            if p.exists() {
+                file_tracker.check_before_edit(p)?;
+            }
+            if let Some(parent) = p.parent() {
                 fs::create_dir_all(parent).map_err(|e| format!("mkdir error: {e}"))?;
             }
             fs::write(&path, &content).map_err(|e| format!("write error: {e}"))?;
+            file_tracker.record_read(p);
             Ok(output)
         })
         .await


### PR DESCRIPTION
Edit and multiedit now check that you read a file before editing it. If the file changed externally since the last read, the edit fails with a clear error asking to re-read. This prevents silent overwrites when files drift out of sync.

The tracker lives in ToolContext and is shared across code_execution tool calls. Each agent run gets a fresh tracker.

https://github.com/tontinton/maki/issues/70