### PR TITLE
ui: add --exit-on-done flag for automation workflows

### DIFF
--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -41,7 +41,9 @@ use crate::components::status_bar::StatusBar;
 use crate::components::theme_picker::{ThemePicker, ThemePickerAction};
 use crate::components::todo_panel::TodoPanel;
 use crate::components::tool_display::format_turn_usage;
-use crate::components::{Action, DisplayMessage, DisplayRole, Overlay, RetryInfo, Status, is_ctrl};
+use crate::components::{
+    Action, DisplayMessage, DisplayRole, ExitRequest, Overlay, RetryInfo, Status, is_ctrl,
+};
 use crate::image;
 use crate::selection::{SelectionState, SelectionZone, ZoneRegistry};
 use arboard::Clipboard;
@@ -117,7 +119,8 @@ pub struct App {
     pub(super) status_bar: StatusBar,
     pub status: Status,
     pub(crate) state: session_state::SessionState,
-    pub should_quit: bool,
+    pub exit_request: ExitRequest,
+    pub(crate) exit_on_done: bool,
     pub(crate) queue: MessageQueue,
     pub answer_tx: Option<flume::Sender<String>>,
     pub(crate) cmd_tx: Option<flume::Sender<super::AgentCommand>>,
@@ -181,7 +184,8 @@ impl App {
             status_bar: StatusBar::new(ui_config.flash_duration()),
             status: Status::Idle,
             state,
-            should_quit: false,
+            exit_request: ExitRequest::None,
+            exit_on_done: false,
             queue: MessageQueue::default(),
             answer_tx: None,
             cmd_tx: None,
@@ -696,11 +700,11 @@ impl App {
     fn quit(&mut self) -> Vec<Action> {
         self.save_session();
         self.save_input_history();
-        self.should_quit = true;
+        self.exit_request = ExitRequest::Success;
         vec![Action::Quit]
     }
 
-    fn handle_submit(&mut self, sub: Submission) -> Vec<Action> {
+    pub(crate) fn handle_submit(&mut self, sub: Submission) -> Vec<Action> {
         if self.pending_input == PendingInput::AuthRetry {
             self.pending_input = PendingInput::None;
             self.send_answer(String::new());
@@ -891,6 +895,9 @@ impl App {
                     if self.state.mode == Mode::Plan && self.state.plan.is_written() {
                         self.plan_form.open();
                     }
+                    if self.exit_on_done {
+                        self.exit_request = ExitRequest::Success;
+                    }
                 }
                 ChatEventResult::Error(message) => {
                     self.status = Status::error(message.clone());
@@ -901,6 +908,9 @@ impl App {
                     self.finish_subagents(DisplayRole::Error, ERROR_TEXT);
                     for chat in &mut self.chats {
                         chat.fail_in_progress_with_message(message.clone());
+                    }
+                    if self.exit_on_done {
+                        self.exit_request = ExitRequest::Error;
                     }
                 }
                 ChatEventResult::QuestionPrompt { questions } => {

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -3,7 +3,7 @@ use crate::agent::shared_queue;
 use crate::chat::{CANCELLED_TEXT, DONE_TEXT, ERROR_TEXT};
 use crate::components::command::ParsedCommand;
 use crate::components::keybindings::{KeybindContext, key as kb};
-use crate::components::{key, test_model};
+use crate::components::{ExitRequest, key, test_model};
 use crate::selection::{EdgeScroll, SelectableZone, SelectionZone};
 use arc_swap::ArcSwap;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEventKind};
@@ -158,7 +158,7 @@ fn ctrl_c_clears_nonempty_input(setup: fn(&mut App)) {
     setup(&mut app);
     let actions = app.update(Msg::Key(kb::QUIT.to_key_event()));
     assert!(actions.is_empty());
-    assert!(!app.should_quit);
+    assert_eq!(app.exit_request, ExitRequest::None);
     assert!(app.input_box.is_empty());
 }
 
@@ -168,19 +168,19 @@ fn ctrl_c_quits_when_input_empty(status: Status) {
     let mut app = test_app();
     app.status = status;
     let actions = app.update(Msg::Key(kb::QUIT.to_key_event()));
-    assert!(app.should_quit);
+    assert_eq!(app.exit_request, ExitRequest::Success);
     assert!(matches!(&actions[0], Action::Quit));
 }
 
-#[test]
-fn error_event_sets_status() {
+#[test_case(AgentEvent::Done { usage: TokenUsage::default(), num_turns: 1, stop_reason: None }, ExitRequest::Success ; "done_exits_success")]
+#[test_case(AgentEvent::Error { message: "boom".into() }, ExitRequest::Error ; "error_exits_error")]
+fn exit_on_done_flag_triggers_exit(event: AgentEvent, expected: ExitRequest) {
     let mut app = test_app();
+    app.exit_on_done = true;
     app.status = Status::Streaming;
     app.run_id = 1;
-    app.update(agent_msg(AgentEvent::Error {
-        message: "boom".into(),
-    }));
-    assert!(matches!(app.status, Status::Error { ref message, .. } if message == "boom"));
+    app.update(agent_msg(event));
+    assert_eq!(app.exit_request, expected);
 }
 
 #[test]
@@ -1391,7 +1391,7 @@ fn submit_exit_quits(input: &str) {
         text: input.into(),
         images: vec![],
     });
-    assert!(app.should_quit);
+    assert_eq!(app.exit_request, ExitRequest::Success);
     assert!(matches!(&actions[0], Action::Quit));
 }
 
@@ -1956,7 +1956,7 @@ fn ctrl_c_closes_overlay_instead_of_quitting() {
     assert!(app.help_modal.is_open());
 
     let actions = app.update(Msg::Key(kb::QUIT.to_key_event()));
-    assert!(!app.should_quit);
+    assert_eq!(app.exit_request, ExitRequest::None);
     assert!(!app.help_modal.is_open());
     assert!(actions.is_empty());
 }
@@ -2060,7 +2060,7 @@ fn ctrl_c_denies_permission_prompt() {
     assert!(app.permission_prompt.is_open());
 
     let actions = app.update(Msg::Key(kb::QUIT.to_key_event()));
-    assert!(!app.should_quit);
+    assert_eq!(app.exit_request, ExitRequest::None);
     assert!(!app.permission_prompt.is_open());
     assert!(actions.is_empty());
 }

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -199,6 +199,23 @@ pub enum Action {
 
 const ERROR_DISPLAY: Duration = Duration::from_secs(5);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ExitRequest {
+    #[default]
+    None,
+    Success,
+    Error,
+}
+
+impl ExitRequest {
+    pub fn code(&self) -> i32 {
+        match self {
+            Self::None | Self::Success => 0,
+            Self::Error => 1,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum Status {
     Idle,

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -24,7 +24,8 @@ use crate::app::shell::{ShellEvent, spawn_shell};
 use crate::app::{App, Msg};
 #[cfg(feature = "demo")]
 use crate::components;
-use crate::components::{Action, Status};
+use crate::components::input::Submission;
+use crate::components::{Action, ExitRequest, Status};
 
 #[cfg(feature = "demo")]
 use crate::mock;
@@ -45,6 +46,7 @@ pub struct EventLoopParams {
     pub input_history_size: usize,
     pub permissions: Arc<PermissionManager>,
     pub timeouts: Timeouts,
+    pub exit_on_done: bool,
     #[cfg(feature = "demo")]
     pub demo: bool,
 }
@@ -154,6 +156,7 @@ impl<'t> EventLoop<'t> {
             input_history_size,
             permissions,
             timeouts,
+            exit_on_done,
             #[cfg(feature = "demo")]
             demo,
         } = params;
@@ -200,6 +203,7 @@ impl<'t> EventLoop<'t> {
             Arc::clone(&permissions),
             custom_commands,
         );
+        app.exit_on_done = exit_on_done;
 
         #[cfg(feature = "demo")]
         if demo {
@@ -229,13 +233,21 @@ impl<'t> EventLoop<'t> {
         })
     }
 
-    pub(crate) fn run(mut self) -> Result<Option<String>> {
+    pub(crate) fn run(mut self, initial_prompt: Option<String>) -> Result<(Option<String>, i32)> {
+        if let Some(prompt) = initial_prompt {
+            let sub = Submission {
+                text: prompt,
+                images: Vec::new(),
+            };
+            let actions = self.app.handle_submit(sub);
+            self.dispatch(actions);
+        }
         loop {
             self.tick();
             self.terminal.draw(|f| self.app.view(f))?;
             let had_agent_msg = self.drain_channels();
 
-            if self.app.should_quit {
+            if self.app.exit_request != ExitRequest::None {
                 return Ok(self.shutdown());
             }
 
@@ -465,7 +477,8 @@ impl<'t> EventLoop<'t> {
         }
     }
 
-    fn shutdown(mut self) -> Option<String> {
+    fn shutdown(mut self) -> (Option<String>, i32) {
+        let exit_code = self.app.exit_request.code();
         let session_id = self
             .app
             .has_content()
@@ -481,7 +494,7 @@ impl<'t> EventLoop<'t> {
                 warn!("storage writer has outstanding references, skipping graceful shutdown")
             }
         }
-        session_id
+        (session_id, exit_code)
     }
 }
 

--- a/maki-ui/src/lib.rs
+++ b/maki-ui/src/lib.rs
@@ -36,8 +36,11 @@ pub type AppSession = maki_storage::sessions::Session<Message, TokenUsage, ToolO
 pub(crate) use agent::AgentCommand;
 pub use event_loop::EventLoopParams;
 
-pub fn run(params: EventLoopParams) -> Result<Option<String>> {
+pub fn run(
+    params: EventLoopParams,
+    initial_prompt: Option<String>,
+) -> Result<(Option<String>, i32)> {
     let (_guard, mut terminal) = terminal::TerminalGuard::init()?;
     let el = event_loop::EventLoop::new(&mut terminal, params)?;
-    el.run()
+    el.run(initial_prompt)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod print;
 
 use std::env;
+use std::io::{self, IsTerminal, Read};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
@@ -73,11 +74,15 @@ struct Cli {
     #[arg(long)]
     yolo: bool,
 
+    /// Exit after the agent completes (for automation workflows)
+    #[arg(long)]
+    exit_on_done: bool,
+
     /// Pre-approve tools (comma-separated). Accepts PascalCase (Claude Code) or snake_case.
     #[arg(long, value_delimiter = ',')]
     allowed_tools: Vec<String>,
 
-    /// Initial prompt (reads stdin if omitted in --print mode)
+    /// Initial prompt (reads stdin if piped)
     prompt: Option<String>,
 }
 
@@ -339,26 +344,42 @@ fn run() -> Result<()> {
                 } else {
                     Model::from_spec(&session.model).unwrap_or(model)
                 };
-                let session_id = maki_ui::run(maki_ui::EventLoopParams {
-                    model,
-                    skills,
-                    commands,
-                    session,
-                    storage,
-                    config: config.agent,
-                    ui_config: config.ui,
-                    input_history_size: config.storage.input_history_size,
-                    permissions: Arc::new(maki_agent::permissions::PermissionManager::new(
-                        config.permissions,
-                        cwd.clone(),
-                    )),
-                    timeouts,
-                    #[cfg(feature = "demo")]
-                    demo: cli.demo,
-                })
+                let initial_prompt = match cli.prompt {
+                    Some(p) => Some(p),
+                    None if !io::stdin().is_terminal() => {
+                        let mut buf = String::new();
+                        io::stdin().read_to_string(&mut buf).context("read stdin")?;
+                        Some(buf)
+                    }
+                    None => None,
+                };
+                let (session_id, exit_code) = maki_ui::run(
+                    maki_ui::EventLoopParams {
+                        model,
+                        skills,
+                        commands,
+                        session,
+                        storage,
+                        config: config.agent,
+                        ui_config: config.ui,
+                        input_history_size: config.storage.input_history_size,
+                        permissions: Arc::new(maki_agent::permissions::PermissionManager::new(
+                            config.permissions,
+                            cwd.clone(),
+                        )),
+                        timeouts,
+                        exit_on_done: cli.exit_on_done,
+                        #[cfg(feature = "demo")]
+                        demo: cli.demo,
+                    },
+                    initial_prompt,
+                )
                 .context("run UI")?;
                 if let Some(session_id) = session_id {
                     eprintln!("session: {session_id}");
+                }
+                if exit_code != 0 {
+                    std::process::exit(exit_code);
                 }
             }
         }


### PR DESCRIPTION
When running maki in scripts or pipelines, you want it to exit when the agent finishes. The new --exit-on-done flag does that, exiting 0 on success and 1 on errors.

You can now pass a prompt as argument or pipe from stdin. Combined with --exit-on-done, this enables full automation: echo 'fix typo' | maki --exit-on-done --yolo

Replaced the old should_quit bool with an ExitRequest enum that tracks both whether to exit and why.

https://github.com/tontinton/maki/issues/39