### PR TITLE
build: fix flake dep hashes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
               # NOTE: these are cargo git dependencies; set hash to "" and
               # rebuild to get the correct value.
               outputHashes = {
-                "monty-0.0.9" = "sha256-lIuPWXuovY4TB5M7JUCDAIN97bo1X8B6MhL3UjFTnqA=";
+                "monty-0.0.11" = "sha256-PRP8XcgeNVnc+2dWHxpizjvAtSjfqtkEXckXjPCRoJI=";
                 "ruff_python_ast-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
                 "ruff_python_parser-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
                 "ruff_python_trivia-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";


### PR DESCRIPTION
This change fixes the flake build after you updated `monty`.

---

A github action could be added to make sure the flake build succeeds with something like this:
```yaml
  build-flake
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: DeterminateSystems/nix-installer-action@main
      - uses: DeterminateSystems/magic-nix-cache-action@main
      - run: nix build
```

I'll leave it up to you whether or not to use it.