### PR TITLE
ui: add file picker (Ctrl+S)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,6 +2334,7 @@ dependencies = [
  "flume 0.11.1",
  "futures-lite",
  "getrandom 0.3.4",
+ "ignore",
  "image",
  "isahc",
  "jiff",
@@ -2343,6 +2344,7 @@ dependencies = [
  "maki-providers",
  "maki-storage",
  "notify",
+ "nucleo",
  "nucleo-matcher",
  "ratatui",
  "serde",
@@ -2573,6 +2575,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "nucleo"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5262af4c94921c2646c5ac6ff7900c2af9cbb08dc26a797e18130a7019c039d4"
+dependencies = [
+ "nucleo-matcher",
+ "parking_lot",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ event-listener = "5"
 futures-lite = "2"
 isahc = { version = "1.7", default-features = false, features = ["text-decoding", "static-curl", "static-ssl"] }
 libc = "0.2"
+nucleo = "0.5"
 nucleo-matcher = "0.3"
 open = "5"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/maki-ui/Cargo.toml
+++ b/maki-ui/Cargo.toml
@@ -29,7 +29,9 @@ getrandom = { workspace = true }
 futures-lite = { workspace = true }
 image = { workspace = true }
 base64 = { workspace = true }
+nucleo = { workspace = true }
 nucleo-matcher = { workspace = true }
+ignore = { workspace = true }
 async-process = { workspace = true }
 libc = { workspace = true }
 dirs = { workspace = true }

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -24,6 +24,7 @@ use crate::chat::Chat;
 use crate::chat::{CANCELLED_TEXT, ChatEventResult, DONE_TEXT, ERROR_TEXT};
 use crate::components::btw_modal::BtwModal;
 use crate::components::command::{CommandAction, CommandPalette, ParsedCommand};
+use crate::components::file_picker::{FilePickerModal, FilePickerModalAction};
 use crate::components::help_modal::HelpModal;
 use crate::components::input::{InputAction, InputBox, Submission};
 use crate::components::keybindings::key;
@@ -112,6 +113,7 @@ pub struct App {
     pub(super) btw_modal: BtwModal,
     pub(super) memory_modal: MemoryModal,
     pub(super) search_modal: SearchModal,
+    pub(super) file_picker: FilePickerModal,
     pub(super) todo_panel: TodoPanel,
     pub(super) permission_prompt: PermissionPrompt,
     pub(super) question_form: QuestionForm,
@@ -177,6 +179,7 @@ impl App {
             btw_modal: BtwModal::new(ui_config.typewriter_ms_per_char),
             memory_modal: MemoryModal::new(),
             search_modal: SearchModal::new(),
+            file_picker: FilePickerModal::new(),
             todo_panel: TodoPanel::new(),
             permission_prompt: PermissionPrompt::new(),
             question_form: QuestionForm::new(),
@@ -314,6 +317,7 @@ impl App {
         try_picker!(self.rewind_picker);
         try_picker!(self.task_picker);
         try_picker!(self.model_picker);
+        try_picker!(self.file_picker);
         if let Some(zone) = self.zone_at(row, column) {
             self.scroll_zone(zone.zone, delta);
         }
@@ -498,6 +502,25 @@ impl App {
             return vec![];
         }
 
+        if self.file_picker.is_open() {
+            return match self.file_picker.handle_key(key) {
+                FilePickerModalAction::Consumed => vec![],
+                FilePickerModalAction::Select(path) => {
+                    self.file_picker.close();
+                    if let InputAction::PaletteSync(val) =
+                        self.input_box.handle_paste_with_spaces(&path)
+                    {
+                        self.command_palette.sync(&val);
+                    }
+                    vec![]
+                }
+                FilePickerModalAction::Close => {
+                    self.file_picker.close();
+                    vec![]
+                }
+            };
+        }
+
         if self.queue.focus().is_some() {
             match key.code {
                 KeyCode::Up => {
@@ -629,6 +652,8 @@ impl App {
                 let top = self.chats[self.active_chat].scroll_top();
                 let auto = self.chats[self.active_chat].auto_scroll();
                 self.search_modal.open(top, auto);
+            } else if key::FILE_PICKER.matches(key) {
+                self.file_picker.open(&self.state.session.cwd);
             } else if key.code == KeyCode::Char('v') && self.image_paste_rx.is_none() {
                 self.start_image_paste();
             } else if let InputAction::PaletteSync(val) = self.input_box.handle_key(key) {
@@ -1166,12 +1191,13 @@ impl App {
         vec![]
     }
 
-    fn overlays(&self) -> [&dyn Overlay; 13] {
+    fn overlays(&self) -> [&dyn Overlay; 14] {
         [
             &self.help_modal,
             &self.btw_modal,
             &self.memory_modal,
             &self.search_modal,
+            &self.file_picker,
             &self.task_picker,
             &self.session_picker,
             &self.rewind_picker,
@@ -1184,12 +1210,13 @@ impl App {
         ]
     }
 
-    fn overlays_mut(&mut self) -> [&mut dyn Overlay; 13] {
+    fn overlays_mut(&mut self) -> [&mut dyn Overlay; 14] {
         [
             &mut self.help_modal,
             &mut self.btw_modal,
             &mut self.memory_modal,
             &mut self.search_modal,
+            &mut self.file_picker,
             &mut self.task_picker,
             &mut self.session_picker,
             &mut self.rewind_picker,
@@ -1218,6 +1245,7 @@ impl App {
         self.image_paste_rx.is_some()
             || self.btw_modal.is_animating()
             || self.session_picker.is_loading()
+            || self.file_picker.is_loading()
             || self
                 .selection_state
                 .as_ref()
@@ -1284,6 +1312,7 @@ impl App {
             };
         }
         try_picker!(self.memory_modal);
+        try_picker!(self.file_picker);
         try_picker!(self.task_picker);
         try_picker!(self.session_picker);
         try_picker!(self.rewind_picker);

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -162,6 +162,13 @@ impl App {
             overlay_rect = self.task_picker.view(frame, full);
         }
 
+        if self.file_picker.is_open() {
+            if let Some(flash) = self.file_picker.tick() {
+                self.status_bar.flash(flash);
+            }
+            overlay_rect = self.file_picker.view(frame, full);
+        }
+
         if self.session_picker.is_open() {
             self.session_picker.tick();
             overlay_rect = self.session_picker.view(frame, full);
@@ -319,6 +326,8 @@ impl App {
             contexts.push(KeybindContext::CommandPalette);
         } else if self.search_modal.is_open() {
             contexts.push(KeybindContext::Search);
+        } else if self.file_picker.is_open() {
+            contexts.push(KeybindContext::FilePicker);
         } else {
             if self.status == Status::Streaming {
                 contexts.push(KeybindContext::Streaming);

--- a/maki-ui/src/components/file_picker.rs
+++ b/maki-ui/src/components/file_picker.rs
@@ -1,0 +1,823 @@
+use std::mem;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Instant;
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ignore::WalkBuilder;
+use ignore::overrides::OverrideBuilder;
+use nucleo::pattern::{CaseMatching, Normalization};
+use nucleo::{Config, Matcher, Nucleo, Utf32String};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Position, Rect};
+use ratatui::style::Modifier;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use tracing::warn;
+use unicode_width::UnicodeWidthChar;
+
+use crate::animation::spinner_frame;
+use crate::components::Overlay;
+use crate::components::keybindings::key;
+use crate::components::modal::Modal;
+use crate::components::scrollbar::render_vertical_scrollbar;
+use crate::text_buffer::TextBuffer;
+use crate::theme;
+
+const TITLE: &str = " Files ";
+const TITLE_WALKING: &str = " Files (scanning…) ";
+const WIDTH_PERCENT: u16 = 60;
+const MAX_HEIGHT_PERCENT: u16 = 80;
+const SEARCH_ROW: u16 = 1;
+const NO_MATCHES: &str = "  No matches";
+const LABEL_INDENT: &str = "  ";
+const EMPTY_DIR_MSG: &str = "Current directory is empty";
+const WALKER_CRASHED_MSG: &str = "File scanner crashed";
+const PENDING_DEBOUNCE_MS: u128 = 100;
+const MAX_MATERIALIZED: u32 = 640;
+
+pub enum FilePickerModalAction {
+    Consumed,
+    Select(String),
+    Close,
+}
+
+struct Match {
+    path: String,
+    indices: Vec<u32>,
+}
+
+struct Session {
+    nucleo: Nucleo<()>,
+    matcher: Matcher,
+    matches: Vec<Match>,
+    total_matches: u32,
+
+    search: TextBuffer,
+    selected: usize,
+    scroll_offset: usize,
+    viewport_height: usize,
+    inner_area: Rect,
+
+    cancel: Arc<AtomicBool>,
+    done_rx: flume::Receiver<()>,
+    started_at: Instant,
+
+    walking: bool,
+    matching: bool,
+    visible: bool,
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        self.cancel.store(true, Ordering::Relaxed);
+    }
+}
+
+pub struct FilePickerModal {
+    session: Option<Session>,
+}
+
+impl FilePickerModal {
+    pub fn new() -> Self {
+        Self { session: None }
+    }
+
+    pub fn open(&mut self, cwd: &str) {
+        self.close();
+
+        let notify = Arc::new(|| {});
+        let nucleo = Nucleo::new(Config::DEFAULT.match_paths(), notify, None, 1);
+        let injector = nucleo.injector();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let cancel_clone = cancel.clone();
+        let (done_tx, done_rx) = flume::bounded(1);
+
+        let root = PathBuf::from(cwd);
+        if let Err(e) = thread::Builder::new()
+            .name("file-walker".into())
+            .spawn(move || {
+                let overrides = OverrideBuilder::new(&root)
+                    .add("!.git")
+                    .unwrap()
+                    .build()
+                    .unwrap();
+                WalkBuilder::new(&root)
+                    .hidden(false)
+                    .overrides(overrides)
+                    .build_parallel()
+                    .run(|| {
+                        let injector = injector.clone();
+                        let cancel = cancel.clone();
+                        let root = root.clone();
+                        Box::new(move |entry| {
+                            if cancel.load(Ordering::Relaxed) {
+                                return ignore::WalkState::Quit;
+                            }
+                            let Ok(entry) = entry else {
+                                return ignore::WalkState::Continue;
+                            };
+                            if !entry
+                                .file_type()
+                                .is_some_and(|ft| ft.is_file() || ft.is_symlink())
+                            {
+                                return ignore::WalkState::Continue;
+                            }
+                            let path = entry.path().strip_prefix(&root).unwrap_or(entry.path());
+                            injector.push((), |_, cols| {
+                                cols[0] = Utf32String::from(path.to_string_lossy().as_ref());
+                            });
+                            ignore::WalkState::Continue
+                        })
+                    });
+                let _ = done_tx.send(());
+            })
+        {
+            warn!("{WALKER_CRASHED_MSG}: failed to spawn thread: {e}");
+            return;
+        }
+
+        self.session = Some(Session {
+            nucleo,
+            matcher: Matcher::new(Config::DEFAULT.match_paths()),
+            matches: Vec::new(),
+            total_matches: 0,
+            search: TextBuffer::new(String::new()),
+            selected: 0,
+            scroll_offset: 0,
+            viewport_height: 0,
+            inner_area: Rect::default(),
+            cancel: cancel_clone,
+            done_rx,
+            started_at: Instant::now(),
+            walking: true,
+            matching: false,
+            visible: false,
+        });
+    }
+
+    pub fn close(&mut self) {
+        self.session = None;
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.session.is_some()
+    }
+
+    pub fn is_loading(&self) -> bool {
+        self.session
+            .as_ref()
+            .is_some_and(|s| s.walking || s.matching)
+    }
+
+    pub fn contains(&self, pos: Position) -> bool {
+        self.session
+            .as_ref()
+            .is_some_and(|s| s.visible && s.inner_area.contains(pos))
+    }
+
+    pub fn scroll(&mut self, delta: i32) {
+        let Some(s) = &mut self.session else { return };
+        if delta > 0 {
+            move_selection(s, -(delta as isize));
+        } else {
+            move_selection(s, delta.unsigned_abs() as isize);
+        }
+    }
+
+    pub fn handle_paste(&mut self, text: &str) -> bool {
+        let Some(s) = &mut self.session else {
+            return false;
+        };
+        s.search.insert_text(text);
+        reparse_pattern(s);
+        true
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> FilePickerModalAction {
+        let Some(s) = &mut self.session else {
+            return FilePickerModalAction::Close;
+        };
+
+        match key.code {
+            KeyCode::Esc => return FilePickerModalAction::Close,
+            KeyCode::Enter => {
+                if !s.visible {
+                    return FilePickerModalAction::Consumed;
+                }
+                if let Some(m) = s.matches.get(s.selected) {
+                    return FilePickerModalAction::Select(m.path.clone());
+                }
+                return FilePickerModalAction::Close;
+            }
+            KeyCode::Up => move_selection(s, -1),
+            KeyCode::Down => move_selection(s, 1),
+            KeyCode::Backspace => {
+                s.search.remove_char();
+                reparse_pattern(s);
+            }
+            KeyCode::Left => s.search.move_left(),
+            KeyCode::Right => s.search.move_right(),
+            KeyCode::Home => s.search.move_home(),
+            KeyCode::End => s.search.move_end(),
+            _ if key::DELETE_WORD.matches(key) => {
+                s.search.remove_word_before_cursor();
+                reparse_pattern(s);
+            }
+            _ if key::SCROLL_HALF_UP.matches(key) => {
+                move_selection(s, -((s.viewport_height / 2).max(1) as isize))
+            }
+            _ if key::SCROLL_HALF_DOWN.matches(key) => {
+                move_selection(s, (s.viewport_height / 2).max(1) as isize)
+            }
+            _ if key::SCROLL_LINE_UP.matches(key) => move_selection(s, -1),
+            _ if key::SCROLL_LINE_DOWN.matches(key) => move_selection(s, 1),
+            _ if super::is_ctrl(&key) => {}
+            KeyCode::Char(c) => {
+                s.search.push_char(c);
+                reparse_pattern(s);
+            }
+            _ => {}
+        }
+        FilePickerModalAction::Consumed
+    }
+
+    pub fn tick(&mut self) -> Option<String> {
+        let s = self.session.as_mut()?;
+
+        let status = s.nucleo.tick(0);
+        s.matching = status.running;
+
+        if s.walking {
+            match s.done_rx.try_recv() {
+                Ok(()) => s.walking = false,
+                Err(flume::TryRecvError::Disconnected) => {
+                    warn!("{WALKER_CRASHED_MSG}: walker thread panicked");
+                    self.session = None;
+                    return Some(WALKER_CRASHED_MSG.into());
+                }
+                Err(flume::TryRecvError::Empty) => {}
+            }
+        }
+
+        if !s.visible {
+            let has_files = s.nucleo.injector().injected_items() > 0;
+            let debounce_elapsed = s.started_at.elapsed().as_millis() >= PENDING_DEBOUNCE_MS;
+
+            if has_files || (s.walking && debounce_elapsed) {
+                s.visible = true;
+            } else if !s.walking {
+                self.session = None;
+                return Some(EMPTY_DIR_MSG.into());
+            }
+        }
+
+        if status.changed {
+            let s = self.session.as_mut()?;
+            refresh_matches(s);
+            clamp_selection(s);
+        }
+
+        None
+    }
+
+    pub fn view(&mut self, frame: &mut Frame, area: Rect) -> Rect {
+        let s = match &mut self.session {
+            Some(s) if s.visible => s,
+            _ => return Rect::default(),
+        };
+
+        let match_count = s.matches.len() as u16;
+        let title = if s.walking { TITLE_WALKING } else { TITLE };
+
+        let has_query_without_matches = s.matches.is_empty() && !s.search.value().is_empty();
+        let max_visible = area.height.saturating_sub(SEARCH_ROW + 2);
+        let content_rows = if has_query_without_matches {
+            1
+        } else {
+            match_count.min(max_visible)
+        };
+
+        let modal = Modal {
+            title,
+            width_percent: WIDTH_PERCENT,
+            max_height_percent: MAX_HEIGHT_PERCENT,
+        };
+        let (popup, inner) = modal.render(frame, area, content_rows + SEARCH_ROW);
+        s.inner_area = inner;
+        s.viewport_height = inner.height.saturating_sub(SEARCH_ROW) as usize;
+        ensure_visible(s);
+
+        let [list_area, search_area] =
+            Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(inner);
+
+        render_list(frame, list_area, s);
+        render_search(frame, search_area, s);
+
+        if match_count > s.viewport_height as u16 {
+            render_vertical_scrollbar(frame, list_area, match_count, s.scroll_offset as u16);
+        }
+
+        popup
+    }
+}
+
+impl Overlay for FilePickerModal {
+    fn is_open(&self) -> bool {
+        self.is_open()
+    }
+
+    fn close(&mut self) {
+        self.close();
+    }
+}
+
+fn reparse_pattern(s: &mut Session) {
+    let query = s.search.value();
+    s.nucleo
+        .pattern
+        .reparse(0, &query, CaseMatching::Smart, Normalization::Smart, false);
+    s.selected = 0;
+    s.scroll_offset = 0;
+}
+
+fn refresh_matches(s: &mut Session) {
+    let snapshot = s.nucleo.snapshot();
+    s.total_matches = snapshot.matched_item_count();
+    let count = s.total_matches.min(MAX_MATERIALIZED);
+
+    s.matches.clear();
+
+    let pattern = snapshot.pattern();
+    let has_pattern = !pattern.column_pattern(0).atoms.is_empty();
+    let mut indices_buf = Vec::new();
+
+    for item in snapshot.matched_items(0..count) {
+        let col = &item.matcher_columns[0];
+        let path = col.to_string();
+
+        let indices = if has_pattern {
+            indices_buf.clear();
+            pattern
+                .column_pattern(0)
+                .indices(col.slice(..), &mut s.matcher, &mut indices_buf);
+            mem::take(&mut indices_buf)
+        } else {
+            Vec::new()
+        };
+
+        s.matches.push(Match { path, indices });
+    }
+}
+
+fn move_selection(s: &mut Session, delta: isize) {
+    if s.matches.is_empty() {
+        return;
+    }
+    let new = (s.selected as isize + delta).clamp(0, s.matches.len() as isize - 1);
+    s.selected = new as usize;
+    ensure_visible(s);
+}
+
+fn clamp_selection(s: &mut Session) {
+    if s.matches.is_empty() {
+        s.selected = 0;
+        s.scroll_offset = 0;
+    } else {
+        s.selected = s.selected.min(s.matches.len() - 1);
+        ensure_visible(s);
+    }
+}
+
+fn ensure_visible(s: &mut Session) {
+    let len = s.matches.len();
+    if len > s.viewport_height {
+        s.scroll_offset = s.scroll_offset.min(len - s.viewport_height);
+    } else {
+        s.scroll_offset = 0;
+    }
+
+    if s.selected < s.scroll_offset {
+        s.scroll_offset = s.selected;
+    } else if s.selected >= s.scroll_offset + s.viewport_height {
+        s.scroll_offset = s.selected + 1 - s.viewport_height;
+    }
+}
+
+fn render_list(frame: &mut Frame, area: Rect, s: &Session) {
+    let t = theme::current();
+
+    if s.matches.is_empty() {
+        if !s.search.value().is_empty() {
+            frame.render_widget(
+                Paragraph::new(vec![Line::from(Span::styled(NO_MATCHES, t.cmd_desc))]),
+                area,
+            );
+        }
+        return;
+    }
+
+    let more = s.total_matches > MAX_MATERIALIZED;
+    let at_bottom = s.scroll_offset + s.viewport_height >= s.matches.len();
+    let hint_row = usize::from(more && at_bottom);
+    let visible_rows = s.viewport_height - hint_row;
+
+    let max_label_width = area.width.saturating_sub(LABEL_INDENT.len() as u16) as usize;
+    let end = (s.scroll_offset + visible_rows).min(s.matches.len());
+
+    let mut lines: Vec<Line> = s.matches[s.scroll_offset..end]
+        .iter()
+        .enumerate()
+        .map(|(i, m)| {
+            let selected = s.scroll_offset + i == s.selected;
+            build_highlighted_line(&m.path, &m.indices, max_label_width, selected, &t)
+        })
+        .collect();
+
+    if hint_row > 0 {
+        let n = s.total_matches - MAX_MATERIALIZED;
+        lines.push(Line::from(Span::styled(
+            format!("{LABEL_INDENT}+{n} more files (not shown)"),
+            t.cmd_desc,
+        )));
+    }
+
+    frame.render_widget(Paragraph::new(lines), area);
+}
+
+fn render_search(frame: &mut Frame, area: Rect, s: &Session) {
+    let t = theme::current();
+    let query = s.search.value();
+    let cursor_byte = TextBuffer::char_to_byte(&query, s.search.x());
+    let (before, rest) = query.split_at(cursor_byte);
+    let mut chars = rest.chars();
+    let cursor_char = chars.next().unwrap_or(' ');
+    let after = chars.as_str();
+
+    let mut spans = vec![Span::styled(super::CHEVRON, t.picker_search_prefix)];
+
+    if s.walking {
+        let ch = spinner_frame(s.started_at.elapsed().as_millis());
+        spans.push(Span::styled(format!("{ch} "), t.cmd_desc));
+    }
+
+    spans.extend([
+        Span::styled(before.to_owned(), t.picker_search_text),
+        Span::styled(cursor_char.to_string(), t.cursor),
+        Span::styled(after.to_owned(), t.picker_search_text),
+    ]);
+
+    frame.render_widget(Paragraph::new(vec![Line::from(spans)]), area);
+}
+
+fn build_highlighted_line<'a>(
+    text: &str,
+    indices: &[u32],
+    max_width: usize,
+    selected: bool,
+    t: &'a theme::Theme,
+) -> Line<'a> {
+    let base = if selected { t.cmd_selected } else { t.cmd_name };
+    let highlight = base
+        .fg(t.highlight_text.fg.unwrap_or_default())
+        .add_modifier(Modifier::BOLD);
+
+    let mut spans = vec![Span::styled(LABEL_INDENT, base)];
+    let mut in_match = false;
+    let mut run = String::new();
+    let mut width = 0usize;
+
+    for (i, ch) in text.chars().enumerate() {
+        let cw = ch.width().unwrap_or(0);
+        if width + cw > max_width {
+            break;
+        }
+        width += cw;
+
+        let is_match = indices.binary_search(&(i as u32)).is_ok();
+        if is_match != in_match && !run.is_empty() {
+            spans.push(Span::styled(
+                mem::take(&mut run),
+                if in_match { highlight } else { base },
+            ));
+        }
+        in_match = is_match;
+        run.push(ch);
+    }
+
+    if !run.is_empty() {
+        spans.push(Span::styled(run, if in_match { highlight } else { base }));
+    }
+
+    Line::from(spans)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyEventKind, KeyEventState, KeyModifiers};
+    use test_case::test_case;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    fn pending_picker() -> (FilePickerModal, flume::Sender<()>) {
+        let mut picker = FilePickerModal::new();
+        let notify = Arc::new(|| {});
+        let nucleo = Nucleo::new(Config::DEFAULT.match_paths(), notify, None, 1);
+        let (done_tx, done_rx) = flume::bounded(1);
+        picker.session = Some(Session {
+            nucleo,
+            matcher: Matcher::new(Config::DEFAULT.match_paths()),
+            matches: Vec::new(),
+            total_matches: 0,
+            search: TextBuffer::new(String::new()),
+            selected: 0,
+            scroll_offset: 0,
+            viewport_height: 0,
+            inner_area: Rect::default(),
+            cancel: Arc::new(AtomicBool::new(false)),
+            done_rx,
+            started_at: Instant::now(),
+            walking: true,
+            matching: false,
+            visible: false,
+        });
+        (picker, done_tx)
+    }
+
+    fn inject_file(picker: &FilePickerModal, path: &str) {
+        let s = picker.session.as_ref().unwrap();
+        s.nucleo.injector().push((), |_, cols| {
+            cols[0] = Utf32String::from(path);
+        });
+    }
+
+    #[test]
+    fn pending_transitions_to_visible_when_files_arrive() {
+        let (mut picker, _done_tx) = pending_picker();
+        inject_file(&picker, "src/main.rs");
+        picker.tick();
+        assert!(picker.session.as_ref().unwrap().visible);
+    }
+
+    #[test]
+    fn pending_closes_on_empty_walk() {
+        let (mut picker, done_tx) = pending_picker();
+        let _ = done_tx.send(());
+        picker.tick();
+        picker.tick();
+        assert!(picker.session.is_none());
+    }
+
+    #[test]
+    fn pending_debounce_controls_visibility() {
+        let (mut picker, _done_tx) = pending_picker();
+        picker.tick();
+        assert!(
+            !picker.session.as_ref().unwrap().visible,
+            "should stay hidden before debounce"
+        );
+
+        picker.session.as_mut().unwrap().started_at =
+            Instant::now() - std::time::Duration::from_millis(200);
+        picker.tick();
+        assert!(
+            picker.session.as_ref().unwrap().visible,
+            "should show after debounce"
+        );
+    }
+
+    #[test]
+    fn walker_crash_returns_flash() {
+        let (mut picker, done_tx) = pending_picker();
+        drop(done_tx);
+        let flash = picker.tick();
+        assert!(picker.session.is_none());
+        assert_eq!(flash.as_deref(), Some(WALKER_CRASHED_MSG));
+    }
+
+    #[test]
+    fn esc_returns_close() {
+        let (mut picker, _done_tx) = pending_picker();
+        assert!(matches!(
+            picker.handle_key(key(KeyCode::Esc)),
+            FilePickerModalAction::Close
+        ));
+    }
+
+    #[test]
+    fn typing_during_pending_buffers_query() {
+        let (mut picker, _done_tx) = pending_picker();
+        picker.handle_key(key(KeyCode::Char('m')));
+        picker.handle_key(key(KeyCode::Char('a')));
+        assert_eq!(picker.session.as_ref().unwrap().search.value(), "ma");
+    }
+
+    #[test]
+    fn enter_during_pending_is_consumed() {
+        let (mut picker, _done_tx) = pending_picker();
+        assert!(matches!(
+            picker.handle_key(key(KeyCode::Enter)),
+            FilePickerModalAction::Consumed
+        ));
+    }
+
+    #[test]
+    fn matches_capped_at_max_materialized() {
+        let mut picker = picker_with_matches(MAX_MATERIALIZED as usize + 50);
+        let s = picker.session.as_mut().unwrap();
+        s.total_matches = MAX_MATERIALIZED + 50;
+        s.matches.truncate(MAX_MATERIALIZED as usize);
+        assert_eq!(s.total_matches, MAX_MATERIALIZED + 50);
+        assert_eq!(s.matches.len(), MAX_MATERIALIZED as usize);
+    }
+
+    fn picker_with_matches(n: usize) -> FilePickerModal {
+        let (mut picker, _done_tx) = pending_picker();
+        let s = picker.session.as_mut().unwrap();
+        s.walking = false;
+        s.visible = true;
+        s.matches = (0..n)
+            .map(|i| Match {
+                path: format!("file_{i:03}.rs"),
+                indices: Vec::new(),
+            })
+            .collect();
+        s.total_matches = n as u32;
+        picker
+    }
+
+    #[test]
+    fn resize_clamps_scroll_offset() {
+        let mut picker = picker_with_matches(20);
+        let s = picker.session.as_mut().unwrap();
+        s.viewport_height = 5;
+        s.selected = 19;
+        s.scroll_offset = 15;
+        ensure_visible(s);
+        assert_eq!(s.scroll_offset, 15);
+
+        s.viewport_height = 20;
+        ensure_visible(s);
+        assert_eq!(s.scroll_offset, 0);
+    }
+
+    #[test_case(&[], 3 ; "empty_indices")]
+    #[test_case(&[0, 2], 5 ; "sparse_match")]
+    fn build_highlighted_line_no_panic(indices: &[u32], max_width: usize) {
+        let t = theme::current();
+        let _ = build_highlighted_line("hello", indices, max_width, false, &t);
+    }
+
+    #[test]
+    fn build_highlighted_line_truncates_at_max_width() {
+        let t = theme::current();
+        let line = build_highlighted_line("verylongfilename.rs", &[], 5, false, &t);
+        let text: String = line
+            .spans
+            .iter()
+            .skip(1)
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert_eq!(text, "veryl");
+    }
+
+    #[test]
+    fn build_highlighted_line_unicode_width() {
+        let t = theme::current();
+        let line = build_highlighted_line("日本語.rs", &[], 6, false, &t);
+        let text: String = line
+            .spans
+            .iter()
+            .skip(1)
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert_eq!(text, "日本語");
+    }
+
+    #[test_case(0, -10, 0 ; "clamps_at_start")]
+    #[test_case(4, 10, 4 ; "clamps_at_end")]
+    #[test_case(2, 1, 3 ; "moves_down")]
+    #[test_case(2, -1, 1 ; "moves_up")]
+    fn move_selection_behavior(start: usize, delta: isize, expected: usize) {
+        let mut picker = picker_with_matches(5);
+        let s = picker.session.as_mut().unwrap();
+        s.viewport_height = 10;
+        s.selected = start;
+        move_selection(s, delta);
+        assert_eq!(s.selected, expected);
+    }
+
+    #[test]
+    fn move_selection_empty_is_noop() {
+        let mut picker = picker_with_matches(0);
+        let s = picker.session.as_mut().unwrap();
+        s.viewport_height = 10;
+        move_selection(s, 5);
+        assert_eq!(s.selected, 0);
+    }
+
+    #[test_case(0, -3, 3 ; "negative_scrolls_down")]
+    #[test_case(5, 2, 3 ; "positive_scrolls_up")]
+    fn scroll_updates_selection(start: usize, delta: i32, expected: usize) {
+        let mut picker = picker_with_matches(10);
+        let s = picker.session.as_mut().unwrap();
+        s.viewport_height = 5;
+        s.selected = start;
+        picker.scroll(delta);
+        assert_eq!(picker.session.as_ref().unwrap().selected, expected);
+    }
+
+    #[test]
+    fn handle_paste_appends_to_search() {
+        let (mut picker, _done_tx) = pending_picker();
+        picker.handle_key(key(KeyCode::Char('a')));
+        assert!(picker.handle_paste("bc"));
+        assert_eq!(picker.session.as_ref().unwrap().search.value(), "abc");
+    }
+
+    #[test]
+    fn handle_paste_returns_false_when_closed() {
+        let mut picker = FilePickerModal::new();
+        assert!(!picker.handle_paste("test"));
+    }
+
+    #[test]
+    fn enter_with_selection_returns_path() {
+        let mut picker = picker_with_matches(3);
+        picker.session.as_mut().unwrap().selected = 1;
+        match picker.handle_key(key(KeyCode::Enter)) {
+            FilePickerModalAction::Select(path) => assert_eq!(path, "file_001.rs"),
+            _ => panic!("expected Select"),
+        }
+    }
+
+    #[test]
+    fn enter_with_no_matches_returns_close() {
+        let mut picker = picker_with_matches(0);
+        assert!(matches!(
+            picker.handle_key(key(KeyCode::Enter)),
+            FilePickerModalAction::Close
+        ));
+    }
+
+    #[test]
+    fn backspace_clears_search_and_reparses() {
+        let (mut picker, _done_tx) = pending_picker();
+        picker.handle_key(key(KeyCode::Char('a')));
+        picker.handle_key(key(KeyCode::Char('b')));
+        picker.handle_key(key(KeyCode::Backspace));
+        assert_eq!(picker.session.as_ref().unwrap().search.value(), "a");
+    }
+
+    #[test_case(10, 0, 6 ; "scrolls_down_when_below")]
+    #[test_case(2, 10, 2 ; "scrolls_up_when_above")]
+    fn ensure_visible_adjusts_scroll(
+        selected: usize,
+        initial_scroll: usize,
+        expected_scroll: usize,
+    ) {
+        let mut picker = picker_with_matches(20);
+        let s = picker.session.as_mut().unwrap();
+        s.viewport_height = 5;
+        s.selected = selected;
+        s.scroll_offset = initial_scroll;
+        ensure_visible(s);
+        assert_eq!(s.scroll_offset, expected_scroll);
+    }
+
+    #[test]
+    fn ensure_visible_zero_viewport_no_panic() {
+        let mut picker = picker_with_matches(5);
+        let s = picker.session.as_mut().unwrap();
+        s.viewport_height = 0;
+        s.selected = 3;
+        ensure_visible(s);
+    }
+
+    #[test]
+    fn clamp_selection_reduces_when_matches_shrink() {
+        let mut picker = picker_with_matches(10);
+        let s = picker.session.as_mut().unwrap();
+        s.viewport_height = 5;
+        s.selected = 9;
+        s.matches.truncate(3);
+        clamp_selection(s);
+        assert_eq!(s.selected, 2);
+    }
+
+    #[test]
+    fn contains_returns_false_when_not_visible() {
+        let (picker, _done_tx) = pending_picker();
+        assert!(!picker.contains(Position::new(0, 0)));
+    }
+}

--- a/maki-ui/src/components/input.rs
+++ b/maki-ui/src/components/input.rs
@@ -122,6 +122,40 @@ impl InputBox {
         InputAction::PaletteSync(self.buffer.value())
     }
 
+    /// Inserting a file path mid-word looks broken ("read/tmp/x" instead of
+    /// "read /tmp/x"). This adds spaces around the paste only when needed.
+    pub fn handle_paste_with_spaces(&mut self, text: &str) -> InputAction {
+        let line = &self.buffer.lines()[self.buffer.y()];
+        let bx = TextBuffer::char_to_byte(line, self.buffer.x());
+
+        let char_before = line[..bx].chars().next_back();
+        let char_after = line[bx..].chars().next();
+
+        let is_word_boundary =
+            |c: char| -> bool { c.is_alphanumeric() || c == '_' || ")]}>".contains(c) };
+
+        let needs_leading = char_before.is_some_and(&is_word_boundary) && !text.starts_with(' ');
+        let needs_trailing = char_after.is_some_and(&is_word_boundary) && !text.ends_with(' ');
+
+        if !needs_leading && !needs_trailing {
+            return self.handle_paste(text);
+        }
+
+        let mut spaced = String::with_capacity(
+            text.len() + usize::from(needs_leading) + usize::from(needs_trailing),
+        );
+
+        if needs_leading {
+            spaced.push(' ');
+        }
+        spaced.push_str(text);
+        if needs_trailing {
+            spaced.push(' ');
+        }
+
+        self.handle_paste(&spaced)
+    }
+
     pub fn new(history: InputHistory) -> Self {
         Self {
             buffer: TextBuffer::new(String::new()),
@@ -579,7 +613,6 @@ fn total_visual_lines(buffer: &TextBuffer, ew: usize, cursor_visible: bool) -> u
 mod tests {
     use super::*;
     use crate::components::scrollbar::SCROLLBAR_THUMB;
-    use ratatui::style::Color;
     use test_case::test_case;
 
     fn type_text(input: &mut InputBox, text: &str) {
@@ -804,19 +837,6 @@ mod tests {
         assert_eq!(input.scroll_y, 0);
     }
 
-    fn border_fg(terminal: &ratatui::Terminal<ratatui::backend::TestBackend>) -> Color {
-        let buf = terminal.backend().buffer();
-        buf.cell((0, 0)).unwrap().fg
-    }
-
-    #[test_case(false, Style::new().fg(theme::current().mode_plan), theme::current().mode_plan         ; "idle_uses_mode_color")]
-    #[test_case(true,  theme::current().input_border,               theme::current().input_border.fg.unwrap()  ; "streaming_uses_default_border")]
-    fn border_color_matches_mode(streaming: bool, border_style: Style, expected: Color) {
-        let mut input = InputBox::new(InputHistory::default());
-        let terminal = render_input_with(&mut input, 40, 5, streaming, border_style);
-        assert_eq!(border_fg(&terminal), expected);
-    }
-
     #[test]
     fn multibyte_input_renders_without_panic() {
         let mut input = InputBox::new(InputHistory::default());
@@ -950,5 +970,81 @@ mod tests {
         let base_height = input.height(TEST_WIDTH);
         input.attach_image(test_image());
         assert_eq!(input.height(TEST_WIDTH), base_height + 1);
+    }
+
+    #[test_case("read", "src/main.rs", " src/main.rs" ; "leading_after_ascii")]
+    #[test_case("打开", "src/main.rs", " src/main.rs" ; "leading_after_unicode")]
+    #[test_case("", "src/main.rs", "src/main.rs" ; "no_leading_at_start")]
+    #[test_case("read ", "src/main.rs", "src/main.rs" ; "no_leading_after_space")]
+    #[test_case("--file=", "src/main.rs", "src/main.rs" ; "no_leading_after_equals")]
+    #[test_case("/", "src/main.rs", "src/main.rs" ; "no_leading_after_slash")]
+    #[test_case("\"", "src/main.rs", "src/main.rs" ; "no_leading_after_quote")]
+    #[test_case("'", "src/main.rs", "src/main.rs" ; "no_leading_after_squote")]
+    #[test_case("foo_", "src/main.rs", " src/main.rs" ; "leading_after_underscore")]
+    #[test_case("$(cmd)", "src/main.rs", " src/main.rs" ; "leading_after_closing_paren")]
+    #[test_case("arr[0]", "src/main.rs", " src/main.rs" ; "leading_after_closing_bracket")]
+    fn paste_with_spaces_leading(before: &str, paste: &str, expected_suffix: &str) {
+        let mut input = InputBox::new(InputHistory::default());
+        type_text(&mut input, before);
+        input.handle_paste_with_spaces(paste);
+        assert_eq!(input.buffer.value(), format!("{before}{expected_suffix}"));
+    }
+
+    #[test_case("file", 0, "/tmp/foo", "/tmp/foo file" ; "trailing_before_ascii")]
+    #[test_case("を読む", 0, "/tmp/foo", "/tmp/foo を読む" ; "trailing_before_unicode")]
+    #[test_case("foobar", 3, "src/main.rs", "foo src/main.rs bar" ; "both_sides_mid_word")]
+    #[test_case("in  between", 3, "file.rs", "in file.rs between" ; "neither_side_between_spaces")]
+    #[test_case("read ''", 6, "src/main.rs", "read 'src/main.rs'" ; "neither_side_between_quotes")]
+    fn paste_with_spaces_at_cursor(before: &str, cursor_at: usize, paste: &str, expected: &str) {
+        let mut input = InputBox::new(InputHistory::default());
+        type_text(&mut input, before);
+        let back = before.chars().count() - cursor_at;
+        for _ in 0..back {
+            input.buffer.move_left();
+        }
+        input.handle_paste_with_spaces(paste);
+        assert_eq!(input.buffer.value(), expected);
+    }
+
+    #[test]
+    fn paste_with_spaces_empty_line() {
+        let mut input = InputBox::new(InputHistory::default());
+        input.handle_paste_with_spaces("file.rs");
+        assert_eq!(input.buffer.value(), "file.rs");
+    }
+
+    #[test]
+    fn paste_with_spaces_text_has_leading_space() {
+        let mut input = InputBox::new(InputHistory::default());
+        type_text(&mut input, "read");
+        input.handle_paste_with_spaces(" file.rs");
+        assert_eq!(input.buffer.value(), "read file.rs");
+    }
+
+    #[test]
+    fn paste_with_spaces_text_has_trailing_space() {
+        let mut input = InputBox::new(InputHistory::default());
+        type_text(&mut input, "file");
+        for _ in 0..4 {
+            input.buffer.move_left();
+        }
+        input.handle_paste_with_spaces("src/main.rs ");
+        assert_eq!(input.buffer.value(), "src/main.rs file");
+    }
+
+    #[test]
+    fn paste_with_spaces_multiline_buffer_cursor_on_second_line() {
+        let mut input = InputBox::new(InputHistory::default());
+        input.handle_paste("first\nread");
+        input.handle_paste_with_spaces("file.rs");
+        assert_eq!(input.buffer.value(), "first\nread file.rs");
+    }
+
+    #[test]
+    fn paste_with_spaces_cursor_at_end_no_trailing() {
+        let mut input = InputBox::new(InputHistory::default());
+        type_text(&mut input, "read");
+        input.handle_paste_with_spaces("file.rs");
+        assert_eq!(input.buffer.value(), "read file.rs");
     }
 }

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -143,6 +143,7 @@ pub mod key {
     pub const POP_QUEUE: Bind = ctrl_bind!('q');
     pub const DELETE_WORD: Bind = ctrl_bind!('w');
     pub const SEARCH: Bind = ctrl_bind!('f');
+    pub const FILE_PICKER: Bind = ctrl_bind!('s');
     pub const OPEN_EDITOR: Bind = ctrl_bind!('o');
     pub const TODO_PANEL: Bind = ctrl_bind!('t');
     pub const TASKS: Bind = ctrl_bind!('x');
@@ -171,6 +172,7 @@ pub enum KeybindContext {
     QueueFocus,
     CommandPalette,
     Search,
+    FilePicker,
 }
 
 impl KeybindContext {
@@ -189,6 +191,7 @@ impl KeybindContext {
             Self::QueueFocus => "Queue",
             Self::CommandPalette => "Commands",
             Self::Search => "Search",
+            Self::FilePicker => "File Picker",
         }
     }
 
@@ -201,7 +204,8 @@ impl KeybindContext {
             | Self::ModelPicker
             | Self::QueueFocus
             | Self::CommandPalette
-            | Self::Search => Some(Self::Picker),
+            | Self::Search
+            | Self::FilePicker => Some(Self::Picker),
             _ => None,
         }
     }
@@ -321,6 +325,12 @@ pub const KEYBINDS: &[Keybind] = &[
     Keybind {
         label: KeyLabel::Single(key::SEARCH.label),
         description: "Search messages",
+        context: KeybindContext::General,
+        platform: Platform::All,
+    },
+    Keybind {
+        label: KeyLabel::Single(key::FILE_PICKER.label),
+        description: "File picker",
         context: KeybindContext::General,
         platform: Platform::All,
     },

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod btw_modal;
 pub(crate) mod code_view;
 pub mod command;
+pub(crate) mod file_picker;
 pub(crate) mod form;
 pub(crate) mod help_modal;
 pub(crate) mod index_highlight;

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -17,6 +17,7 @@ On macOS, `Ctrl` maps to `Cmd` where it makes sense (run `/help` for exact keybi
 | `Ctrl+H` | Show keybindings |
 | `Ctrl+N` / `Ctrl+P` | Next / previous task chat |
 | `Ctrl+F` | Search messages |
+| `Ctrl+S` | File picker |
 | `Ctrl+O` | Open plan in editor |
 | `Ctrl+T` | Toggle todo panel |
 | `Ctrl+X` | Open tasks |
@@ -86,4 +87,4 @@ Some pickers add extra bindings on top of the defaults:
 
 Child contexts inherit their parent's bindings and add their own.
 
-- **Pickers** is the base for: Task Picker, Session Picker, Rewind Picker, Theme Picker, Model Picker, Queue, Commands, Search
+- **Pickers** is the base for: Task Picker, Session Picker, Rewind Picker, Theme Picker, Model Picker, Queue, Commands, Search, File Picker


### PR DESCRIPTION
Pressing Ctrl+S opens a fuzzy file picker that scans the session cwd using ignore's parallel walker and streams paths into nucleo's lock-free injector. Users can start typing and seeing ranked fuzzy matches while the walk is still in progress. Selecting a file inserts the path at the cursor with smart spacing so it won't merge into adjacent words.