### PR TITLE
Add tree-sitter-elixir support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2202,6 +2202,7 @@ dependencies = [
  "tree-sitter-c",
  "tree-sitter-c-sharp",
  "tree-sitter-cpp",
+ "tree-sitter-elixir",
  "tree-sitter-go",
  "tree-sitter-java",
  "tree-sitter-javascript",
@@ -4414,6 +4415,16 @@ name = "tree-sitter-cpp"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-elixir"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66dd064a762ed95bfc29857fa3cb7403bb1e5cb88112de0f6341b7e47284ba40"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 dirs = "6"
 tree-sitter = "0.26"
 tree-sitter-bash = "0.25"
+tree-sitter-elixir = "0.3"
 monty = { git = "https://github.com/pydantic/monty.git", rev = "2e9df4b", package = "monty" }
 notify = { version = "9.0.0-rc.2", default-features = false, features = ["flume", "macos_fsevent"] }
 shell-words = "1"

--- a/maki-code-index/Cargo.toml
+++ b/maki-code-index/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 [features]
 default = ["lang-rust", "lang-python", "lang-typescript", "lang-go", "lang-java",
            "lang-c", "lang-cpp", "lang-c-sharp", "lang-ruby", "lang-php",
-           "lang-swift", "lang-kotlin", "lang-scala", "lang-bash", "lang-lua"]
+           "lang-swift", "lang-kotlin", "lang-scala", "lang-bash", "lang-lua", "lang-elixir"]
 lang-rust = ["dep:tree-sitter-rust"]
 lang-python = ["dep:tree-sitter-python"]
 lang-typescript = ["dep:tree-sitter-typescript", "dep:tree-sitter-javascript"]
@@ -22,6 +22,7 @@ lang-kotlin = ["dep:tree-sitter-kotlin-ng"]
 lang-scala = ["dep:tree-sitter-scala"]
 lang-bash = ["dep:tree-sitter-bash"]
 lang-lua = ["dep:tree-sitter-lua"]
+lang-elixir = ["dep:tree-sitter-elixir"]
 
 [dependencies]
 thiserror = { workspace = true }
@@ -44,6 +45,7 @@ tree-sitter-kotlin-ng = { version = "1.1", optional = true }
 tree-sitter-scala = { version = "0.25", optional = true }
 tree-sitter-bash = { version = "0.25", optional = true }
 tree-sitter-lua = { version = "0.5", optional = true }
+tree-sitter-elixir = { version = "0.3.5", optional = true }
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/maki-code-index/src/index/common.rs
+++ b/maki-code-index/src/index/common.rs
@@ -338,6 +338,7 @@ pub(crate) enum ChildKind {
 #[derive(Debug, Clone)]
 pub(crate) enum EntryData {
     Import {
+        keyword: Option<String>,
         paths: Vec<Vec<String>>,
     },
     Item {
@@ -371,11 +372,19 @@ impl SkeletonEntry {
     }
 
     pub(crate) fn new_import(node: Node, paths: Vec<Vec<String>>) -> Self {
+        Self::new_import_with_keyword(node, None, paths)
+    }
+
+    pub(crate) fn new_import_with_keyword(
+        node: Node,
+        keyword: Option<String>,
+        paths: Vec<Vec<String>>,
+    ) -> Self {
         Self {
             section: Section::Import,
             line_start: node.start_position().row + 1,
             line_end: node.end_position().row + 1,
-            data: EntryData::Import { paths },
+            data: EntryData::Import { keyword, paths },
         }
     }
 
@@ -564,17 +573,29 @@ fn format_imports(out: &mut String, entries: &[&SkeletonEntry], import_sep: &str
     let prefix = if out.is_empty() { "" } else { "\n" };
     let _ = writeln!(out, "{prefix}imports: {}", line_range(min_line, max_line));
 
-    let mut trie = ImportTrie::default();
+    let mut keyword_tries: BTreeMap<&str, ImportTrie> = BTreeMap::new();
     for entry in entries {
-        if let EntryData::Import { paths } = &entry.data {
+        if let EntryData::Import { keyword, paths } = &entry.data {
+            let trie = keyword_tries
+                .entry(keyword.as_deref().unwrap_or("import"))
+                .or_default();
             for path in paths {
                 trie.insert(path);
             }
         }
     }
-    let lines = trie.render(import_sep);
-    for line in lines {
-        let _ = writeln!(out, "  {line}");
+
+    for (keyword, trie) in keyword_tries {
+        let lines = trie.render(import_sep);
+        if keyword == "import" {
+            for line in lines {
+                let _ = writeln!(out, "  {line}");
+            }
+        } else {
+            for line in lines {
+                let _ = writeln!(out, "  {keyword}: {line}");
+            }
+        }
     }
 }
 

--- a/maki-code-index/src/index/elixir.rs
+++ b/maki-code-index/src/index/elixir.rs
@@ -1,0 +1,169 @@
+use tree_sitter::Node;
+
+use super::common::{
+    LanguageExtractor, Section, SkeletonEntry, compact_ws, find_child, line_range, node_text,
+};
+
+pub(crate) struct ElixirExtractor;
+
+const DEF: &str = "def";
+const DEFP: &str = "defp";
+const DEFMODULE: &str = "defmodule";
+
+const IMPORT_KEYWORDS: &[&str] = &["alias", "import", "require", "use"];
+
+const DOC_ATTRS: &[&str] = &["doc", "moduledoc", "typedoc", "spec"];
+
+impl ElixirExtractor {
+    fn call_target<'a>(&self, node: Node, source: &'a [u8]) -> Option<&'a str> {
+        if node.kind() != "call" {
+            return None;
+        }
+        let target = node.child_by_field_name("target")?;
+        Some(node_text(target, source))
+    }
+
+    fn extract_import(&self, node: Node, source: &[u8]) -> Option<SkeletonEntry> {
+        let target_name = self.call_target(node, source)?;
+        if !IMPORT_KEYWORDS.contains(&target_name) {
+            return None;
+        }
+        let args = find_child(node, "arguments")?;
+        let first_arg = args.child(0)?;
+        let module_path = node_text(first_arg, source);
+        let segments: Vec<String> = module_path.split('.').map(String::from).collect();
+        Some(SkeletonEntry::new_import_with_keyword(
+            node,
+            Some(target_name.to_string()),
+            vec![segments],
+        ))
+    }
+
+    fn extract_module(&self, node: Node, source: &[u8]) -> Vec<SkeletonEntry> {
+        match self.call_target(node, source) {
+            Some(DEFMODULE) => {}
+            _ => return Vec::new(),
+        };
+        let args = match find_child(node, "arguments") {
+            Some(a) => a,
+            None => return Vec::new(),
+        };
+        let name = match args.child(0) {
+            Some(c) => node_text(c, source),
+            None => return Vec::new(),
+        };
+        let mut imports = Vec::new();
+        let mut methods = Vec::new();
+        if let Some(block) = find_child(node, "do_block") {
+            let mut cursor = block.walk();
+            for child in block.children(&mut cursor) {
+                if let Some(imp) = self.extract_import(child, source) {
+                    imports.push(imp);
+                    continue;
+                }
+                if self.is_def_call(child, source).is_some()
+                    && let Some(sig) = self.def_sig(child, source)
+                {
+                    let lr =
+                        line_range(child.start_position().row + 1, child.end_position().row + 1);
+                    methods.push(compact_ws(&format!("{sig} {lr}")).into_owned());
+                }
+            }
+        }
+        imports.push(
+            SkeletonEntry::new(Section::Class, node, format!("defmodule {name}"))
+                .with_children(methods),
+        );
+        imports
+    }
+    fn def_sig(&self, node: Node, source: &[u8]) -> Option<String> {
+        let args = find_child(node, "arguments")?;
+        let first = args.child(0)?;
+        match first.kind() {
+            "call" | "identifier" | "binary_operator" => Some(node_text(first, source).to_string()),
+            _ => None,
+        }
+    }
+
+    fn is_def_call<'a>(&self, node: Node, source: &'a [u8]) -> Option<&'a str> {
+        let target_name = self.call_target(node, source)?;
+        (target_name == DEF || target_name == DEFP).then_some(target_name)
+    }
+
+    fn extract_standalone_fn(&self, node: Node, source: &[u8]) -> Option<SkeletonEntry> {
+        self.is_def_call(node, source)?;
+        let sig = self.def_sig(node, source)?;
+        Some(SkeletonEntry::new(
+            Section::Function,
+            node,
+            compact_ws(&sig).into_owned(),
+        ))
+    }
+
+    fn extract_module_attr(&self, node: Node, source: &[u8]) -> Option<SkeletonEntry> {
+        let name = self.attr_name(node, source)?;
+        if DOC_ATTRS.contains(&name.as_str()) {
+            return None;
+        }
+        if !name.starts_with(|c: char| c.is_ascii_uppercase()) {
+            return None;
+        }
+        Some(SkeletonEntry::new(
+            Section::Constant,
+            node,
+            format!("@{name}"),
+        ))
+    }
+
+    fn attr_name(&self, node: Node, source: &[u8]) -> Option<String> {
+        if node.kind() != "unary_operator" {
+            return None;
+        }
+        let op = node.child_by_field_name("operator")?;
+        if node_text(op, source) != "@" {
+            return None;
+        }
+        let operand = node.child_by_field_name("operand")?;
+        match operand.kind() {
+            "identifier" | "alias" => Some(node_text(operand, source).to_string()),
+            "call" => {
+                let target = operand.child_by_field_name("target")?;
+                Some(node_text(target, source).to_string())
+            }
+            _ => None,
+        }
+    }
+}
+
+impl LanguageExtractor for ElixirExtractor {
+    fn extract_nodes(&self, node: Node, source: &[u8], _attrs: &[Node]) -> Vec<SkeletonEntry> {
+        if node.kind() == "call" {
+            if let Some(entry) = self.extract_import(node, source) {
+                return vec![entry];
+            }
+            let module_entries = self.extract_module(node, source);
+            if !module_entries.is_empty() {
+                return module_entries;
+            }
+            if let Some(entry) = self.extract_standalone_fn(node, source) {
+                return vec![entry];
+            }
+        }
+        if let Some(entry) = self.extract_module_attr(node, source) {
+            return vec![entry];
+        }
+        Vec::new()
+    }
+
+    fn is_doc_comment(&self, node: Node, source: &[u8]) -> bool {
+        if node.kind() == "comment" {
+            return true;
+        }
+        self.attr_name(node, source)
+            .is_some_and(|name| DOC_ATTRS.contains(&name.as_str()))
+    }
+
+    fn import_separator(&self) -> &'static str {
+        "."
+    }
+}

--- a/maki-code-index/src/index/mod.rs
+++ b/maki-code-index/src/index/mod.rs
@@ -17,6 +17,8 @@ pub(crate) mod common;
 pub(crate) mod cpp;
 #[cfg(feature = "lang-c-sharp")]
 pub(crate) mod csharp;
+#[cfg(feature = "lang-elixir")]
+pub(crate) mod elixir;
 #[cfg(feature = "lang-go")]
 pub(crate) mod go;
 #[cfg(feature = "lang-java")]

--- a/maki-code-index/src/index/tests.rs
+++ b/maki-code-index/src/index/tests.rs
@@ -980,3 +980,59 @@ enum class Color {
         ],
     );
 }
+
+#[test]
+#[cfg(feature = "lang-elixir")]
+fn elixir_all_sections() {
+    let src = r#"
+defmodule MyApp.Web do
+  alias Phoenix.Controller
+  import Plug.Conn
+  use MyApp.Web, :controller
+  require Logger
+
+  @doc "Process data"
+  def process(conn, params) do
+    :ok
+  end
+
+  defp validate(data) do
+    true
+  end
+end
+
+defmodule MyApp.Helpers do
+  def format_name(name) do
+    name
+  end
+end
+
+@MAX_RETRIES 3
+
+def handle_event(event, state) do
+  {:ok, state}
+end
+"#;
+    let out = idx(src, Language::Elixir);
+    has(
+        &out,
+        &[
+            "imports:",
+            "Phoenix.Controller",
+            "Plug.Conn",
+            "use: MyApp.Web",
+            "require: Logger",
+            "classes:",
+            "defmodule MyApp.Web",
+            "process(conn, params)",
+            "validate(data)",
+            "defmodule MyApp.Helpers",
+            "format_name(name)",
+            "consts:",
+            "@MAX_RETRIES",
+            "fns:",
+            "handle_event(event, state)",
+        ],
+    );
+    lacks(&out, &[":ok", "true", "{:ok, state}"]);
+}

--- a/maki-code-index/src/lib.rs
+++ b/maki-code-index/src/lib.rs
@@ -46,6 +46,8 @@ pub enum Language {
     Bash,
     #[cfg(feature = "lang-lua")]
     Lua,
+    #[cfg(feature = "lang-elixir")]
+    Elixir,
 }
 
 impl Language {
@@ -87,6 +89,8 @@ impl Language {
             "sh" | "bash" | "zsh" => Some(Self::Bash),
             #[cfg(feature = "lang-lua")]
             "lua" => Some(Self::Lua),
+            #[cfg(feature = "lang-elixir")]
+            "ex" | "exs" => Some(Self::Elixir),
             _ => None,
         }
     }
@@ -125,6 +129,8 @@ impl Language {
             Self::Bash => tree_sitter_bash::LANGUAGE.into(),
             #[cfg(feature = "lang-lua")]
             Self::Lua => tree_sitter_lua::LANGUAGE.into(),
+            #[cfg(feature = "lang-elixir")]
+            Self::Elixir => tree_sitter_elixir::LANGUAGE.into(),
         }
     }
 
@@ -162,6 +168,8 @@ impl Language {
             Self::Bash => &index::bash::BashExtractor,
             #[cfg(feature = "lang-lua")]
             Self::Lua => &index::lua::LuaExtractor,
+            #[cfg(feature = "lang-elixir")]
+            Self::Elixir => &index::elixir::ElixirExtractor,
         }
     }
 }


### PR DESCRIPTION
My workflow consists mostly of writing Elixir, and not having a tree-sitter made a lot of failing `index` calls and the token consumption went up pretty fast.

The [tree-sitter-elixir](https://crates.io/crates/tree-sitter-elixir) uses the [official grammar definition](https://github.com/elixir-lang/tree-sitter-elixir) from the Elixir team.

I have already tried using this indexer for several hours on two different projects and it works really well. I also updated the `monty` dep in `flake.nix` so I could test it easily on my setup.

I had to modify the `import` pipeline a little bit so it would differentiate between `use`, `require`, `alias` and `import` since each of those carry a different meaning and use in elixir (`use` expands a macro, `alias` just aliases a name, ...) and they would be useful for the indexer to see.


This PR was made using `maki`, and reviewed manually by me before submitting. Some parts were manually edited.