### PR TITLE
Fix skills behaviour

### DIFF
--- a/maki-agent/src/skill.rs
+++ b/maki-agent/src/skill.rs
@@ -77,15 +77,16 @@ impl Skill {
 }
 
 pub fn build_skill_list_description(skills: &[Skill]) -> String {
-    if skills.is_empty() {
-        return String::new();
-    }
-    let mut desc = String::from("\n\n<available_skills>\n");
-    for skill in skills {
-        desc.push_str(&format!("- {}: {}\n", skill.name, skill.description));
-    }
-    desc.push_str("</available_skills>");
-    desc
+    let body = if skills.is_empty() {
+        "No skills available.\n".to_string()
+    } else {
+        skills
+            .iter()
+            .map(|s| format!("- {}: {}\n", s.name, s.description))
+            .collect()
+    };
+
+    format!("\n\n<available_skills>\n{body}</available_skills>")
 }
 
 pub(crate) fn find_project_ancestor_dirs(cwd: &Path) -> Vec<PathBuf> {
@@ -297,7 +298,10 @@ mod tests {
 
     #[test]
     fn build_skill_list_description_empty() {
-        assert_eq!(build_skill_list_description(&[]), "");
+        assert_eq!(
+            build_skill_list_description(&[]),
+            "\n\n<available_skills>\nNo skills available.\n</available_skills>"
+        );
     }
 
     #[test]

--- a/maki-agent/src/skill.rs
+++ b/maki-agent/src/skill.rs
@@ -15,10 +15,15 @@ const PROJECT_SKILL_DIRS: &[&str] = &[
     ".maki/skills",
     ".claude/skills",
     ".opencode/skills",
-    ".opencode/skill",
+    ".agents/skills",
 ];
 
-const GLOBAL_SKILL_DIRS: &[&str] = &[".maki/skills", ".claude/skills", ".opencode/skills"];
+const GLOBAL_SKILL_DIRS: &[&str] = &[
+    ".maki/skills",
+    ".claude/skills",
+    ".config/opencode/skills",
+    ".agents/skills",
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Skill {
@@ -270,7 +275,7 @@ mod tests {
             (".maki/skills/a-skill", "a-skill"),
             (".claude/skills/b-skill", "b-skill"),
             (".opencode/skills/c-skill", "c-skill"),
-            (".opencode/skill/d-skill", "d-skill"),
+            (".agents/skills/d-skill", "d-skill"),
         ] {
             let path = dir.path().join(skill_dir);
             fs::create_dir_all(&path).unwrap();

--- a/maki-agent/src/tools/skill.rs
+++ b/maki-agent/src/tools/skill.rs
@@ -16,7 +16,8 @@ pub struct SkillTool {
 
 impl SkillTool {
     pub const NAME: &str = "skill";
-    pub const DESCRIPTION: &str = "Load a skill by name to get detailed instructions.";
+    pub const DESCRIPTION: &str =
+        "Load a skill that provides instructions and workflows for specific tasks.";
     pub const EXAMPLES: Option<&str> = Some(r#"[{"name": "rust-patterns"}]"#);
 
     pub async fn execute(&self, ctx: &ToolContext) -> Result<ToolOutput, String> {

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -192,7 +192,7 @@ Persistent, project-scoped scratchpad for learnings, patterns, decisions, and go
 
 ### `skill`
 
-Load a skill by name to get detailed instructions.
+Load a skill that provides instructions and workflows for specific tasks.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|


### PR DESCRIPTION
# Skill discovery
AFAIK global `~/.opencode` isn't used since v1 and project-local `.opencode/skill` doesn't even exist...?
This PR fixes the opencode global skill path to use `~/.config/opencode/skills` and adds support for project-agnostic .agents folder

# Skill tool description 
First of all, now maki lets the agent know if there are no loadable skills.
Besides that, now the `skill` tool description explains what the skills are. I've yoinked the tool description from opencode and condensed it into a small sentence