### PR TITLE
agent: Improve wording around `index` and `read` tools

### DIFF
--- a/maki-agent/src/prompts/system.md
+++ b/maki-agent/src/prompts/system.md
@@ -15,7 +15,7 @@ Prioritize technical accuracy over validating the user's beliefs. Provide direct
 # Tool usage
 - Reserve bash for system commands (git, builds, tests). Do NOT use bash for file operations, including on files outside the working dir.
 - Every tool result grows your context. Minimize use of verbose tool calls, prefer compact results.
-- Use **index** before **read**.
+- Always use **index** before **read**.
 - Use **batch** for parallel calls, **code_execution** for chained/filtered calls, **task** for delegation.
 - Combine **batch** and **task**: launch multiple tasks in a batch to parallelize research or implementation.
 - Read files before editing them. Match surrounding context, conventions, and imports.

--- a/maki-agent/src/tools/index.md
+++ b/maki-agent/src/tools/index.md
@@ -1,4 +1,4 @@
-Return a compact skeleton of a source file: imports, type definitions, function signatures, and structure with their line numbers sorrounded by []. ~70-90% fewer tokens than reading the full file.
+Return a compact overview of a source file: imports, type definitions, function signatures, and structure with their line numbers surrounded by []. ~70-90% fewer tokens than reading the full file.
 
 - Use this FIRST to understand file structure before using read with offset/limit.
 - Falls back with an error on unsupported languages. Use read instead.

--- a/maki-agent/src/tools/read.md
+++ b/maki-agent/src/tools/read.md
@@ -3,7 +3,7 @@ Read a file or directory. Returns contents with line numbers (1-indexed).
 - Supports absolute, relative, and ~/ paths.
 - Use index tool first to see file structure and find the right line numbers.
 - Up to 2000 lines by default.
-- Use offset/limit for large files.
+- Always use offset/limit if you know them or for large files (>500 lines).
 - Use grep to find specific content instead of reading entire large files.
 - Call in parallel when reading multiple files.
 - Avoid tiny repeated slices - read a larger window if you need more context.

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -87,7 +87,7 @@ Search file contents using regex.
 
 ### `index`
 
-Return a compact skeleton of a source file: imports, type definitions, function signatures, and structure with their line numbers sorrounded by []. ~70-90% fewer tokens than reading the full file.
+Return a compact overview of a source file: imports, type definitions, function signatures, and structure with their line numbers surrounded by []. ~70-90% fewer tokens than reading the full file.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|


### PR DESCRIPTION
This makes it more likely that the `index` tool is actually used and that only subsets of a file are `read` if the line numbers are known.

Fixes https://github.com/tontinton/maki/issues/74