### PR TITLE
ui: require Ctrl for model picker tier shortcuts

### DIFF
--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -10,7 +10,7 @@ weight = 5
 group = "Reference"
 +++"#;
 
-const TIER_PICKER_NOTE: &str = r#"Open the model picker with `/model` and press `1`, `2`, or `3` on any row to reassign it to strong, medium, or weak. Your overrides are saved to `~/.maki/model-tiers` and apply across sessions."#;
+const TIER_PICKER_NOTE: &str = r#"Open the model picker with `/model` and press `Ctrl+1`, `Ctrl+2`, or `Ctrl+3` on any row to reassign it to strong, medium, or weak. Your overrides are saved to `~/.maki/model-tiers` and apply across sessions."#;
 
 const AUTH_RELOADING: &str = r#"## Auth Reloading
 

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -526,6 +526,12 @@ pub const KEYBINDS: &[Keybind] = &[
         context: KeybindContext::CommandPalette,
         platform: Platform::All,
     },
+    Keybind {
+        label: KeyLabel::MacMulti(&["Ctrl+1/2/3"], &["⌘1/2/3"]),
+        description: "Set tier (strong/medium/weak)",
+        context: KeybindContext::ModelPicker,
+        platform: Platform::All,
+    },
 ];
 
 pub fn all_contexts() -> impl Iterator<Item = KeybindContext> {

--- a/maki-ui/src/components/list_picker.rs
+++ b/maki-ui/src/components/list_picker.rs
@@ -23,7 +23,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 const NO_MATCHES: &str = "No matches";
 const LOADING_LABEL: &str = "Loading...";
 const SEARCH_PREFIX: &str = super::CHEVRON;
-const MIN_WIDTH_PERCENT: u16 = 60;
+const MIN_WIDTH_PERCENT: u16 = 65;
 const MAX_HEIGHT_PERCENT: u16 = 80;
 const SEARCH_ROW: u16 = 1;
 const DETAIL_RIGHT_PAD: u16 = 1;

--- a/maki-ui/src/components/model_picker.rs
+++ b/maki-ui/src/components/model_picker.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use arc_swap::ArcSwapOption;
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::Frame;
 use ratatui::layout::{Position, Rect};
 use ratatui::text::{Line, Span};
@@ -21,19 +21,22 @@ fn footer_line() -> Line<'static> {
     Line::from(vec![
         Span::styled("  Enter", t.keybind_key),
         Span::styled(" select", t.form_hint),
-        Span::styled("  1 ", t.keybind_key),
+        Span::styled("  Ctrl+1 ", t.keybind_key),
         Span::styled("(set strong)", t.form_hint),
         Span::styled(" / ", t.form_hint),
-        Span::styled("2 ", t.keybind_key),
+        Span::styled("Ctrl+2 ", t.keybind_key),
         Span::styled("(set medium)", t.form_hint),
         Span::styled(" / ", t.form_hint),
-        Span::styled("3 ", t.keybind_key),
+        Span::styled("Ctrl+3 ", t.keybind_key),
         Span::styled("(set weak)", t.form_hint),
     ])
 }
 
-fn tier_for_shortcut(code: KeyCode) -> Option<ModelTier> {
-    match code {
+fn tier_for_shortcut(key: KeyEvent) -> Option<ModelTier> {
+    if !key.modifiers.contains(KeyModifiers::CONTROL) {
+        return None;
+    }
+    match key.code {
         KeyCode::Char('1') => Some(ModelTier::Strong),
         KeyCode::Char('2') => Some(ModelTier::Medium),
         KeyCode::Char('3') => Some(ModelTier::Weak),
@@ -139,7 +142,7 @@ impl ModelPicker {
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> ModelPickerAction {
-        if let Some(tier) = tier_for_shortcut(key.code)
+        if let Some(tier) = tier_for_shortcut(key)
             && let Some(entry) = self.picker.selected_item()
         {
             let spec = entry.spec.clone();
@@ -198,8 +201,12 @@ mod tests {
     use super::*;
     use crate::components::key;
     use crate::components::keybindings::key as kb;
-    use crossterm::event::{KeyCode, KeyEvent};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use test_case::test_case;
+
+    fn ctrl_key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::CONTROL)
+    }
 
     fn test_models() -> Arc<ArcSwapOption<Vec<String>>> {
         let models = Arc::new(ArcSwapOption::empty());
@@ -302,19 +309,30 @@ mod tests {
         assert!(parse_model_entry("no-slash").is_none());
     }
 
-    // Regression: 1/2/3 must work on every provider, not just Ollama.
-    #[test_case(KeyCode::Char('1'), ModelTier::Strong ; "1_strong")]
-    #[test_case(KeyCode::Char('2'), ModelTier::Medium ; "2_medium")]
-    #[test_case(KeyCode::Char('3'), ModelTier::Weak   ; "3_weak")]
+    // Regression: Ctrl+1/2/3 must work on every provider, not just Ollama.
+    #[test_case(KeyCode::Char('1'), ModelTier::Strong ; "ctrl_1_strong")]
+    #[test_case(KeyCode::Char('2'), ModelTier::Medium ; "ctrl_2_medium")]
+    #[test_case(KeyCode::Char('3'), ModelTier::Weak   ; "ctrl_3_weak")]
     fn tier_shortcut_assigns_and_keeps_picker_open(code: KeyCode, want: ModelTier) {
         let mut p = ModelPicker::new(test_models());
         p.open("");
-        let action = p.handle_key(key(code));
+        let action = p.handle_key(ctrl_key(code));
         assert!(
             matches!(&action, ModelPickerAction::AssignTier(s, t)
                 if s == "anthropic/claude-sonnet-4-20250514" && *t == want),
             "expected AssignTier(claude-sonnet, {want:?}), got something else",
         );
         assert!(p.is_open());
+    }
+
+    #[test]
+    fn plain_number_keys_go_to_filter() {
+        let mut p = ModelPicker::new(test_models());
+        p.open("");
+        let action = p.handle_key(key(KeyCode::Char('1')));
+        assert!(
+            matches!(action, ModelPickerAction::Consumed),
+            "plain '1' should be consumed by filter, not trigger tier assignment"
+        );
     }
 }

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -82,6 +82,7 @@ Some pickers add extra bindings on top of the defaults:
 | Session Picker | `Ctrl+D` | Delete session |
 | Queue | `Enter` | Remove item |
 | Commands | `Tab` | Toggle mode |
+| Model Picker | `Ctrl+1/2/3` | Set tier (strong/medium/weak) |
 
 ## Context Inheritance
 

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -9,7 +9,7 @@ group = "Reference"
 
 Maki talks to LLM providers over their HTTP APIs. Models are split into three tiers: **weak** (cheap and fast), **medium** (balanced), and **strong** (highest capability, highest cost).
 
-Open the model picker with `/model` and press `1`, `2`, or `3` on any row to reassign it to strong, medium, or weak. Your overrides are saved to `~/.maki/model-tiers` and apply across sessions.
+Open the model picker with `/model` and press `Ctrl+1`, `Ctrl+2`, or `Ctrl+3` on any row to reassign it to strong, medium, or weak. Your overrides are saved to `~/.maki/model-tiers` and apply across sessions.
 
 ## Auth Reloading
 


### PR DESCRIPTION
Number keys 1/2/3 were swallowed by the tier assignment shortcuts, so you couldn't type version numbers like "5.1" in the filter. Now they need Ctrl+1/2/3 instead. Also bumped the picker width from 60% to 65% to fit the longer keybind hints.

Fixes #96.