### PR TITLE
ui: fix code_execution script not expanding on click

### DIFF
--- a/maki-ui/src/components/code_view.rs
+++ b/maki-ui/src/components/code_view.rs
@@ -1,5 +1,5 @@
 use crate::highlight::{
-    advance_highlighter, fallback_span, highlight_code_plain, highlight_line, highlighter_for_path,
+    advance_highlighter, fallback_span, highlight_line, highlighter_for_path,
     highlighter_for_syntax, highlighter_for_token, syntax_for_path,
 };
 use crate::markdown::{should_truncate, truncation_notice};
@@ -13,7 +13,7 @@ use syntect::easy::HighlightLines;
 use syntect::parsing::SyntaxReference;
 use syntect::util::LinesWithEndings;
 
-const MAX_CODE_EXECUTION_LINES: usize = 100;
+pub(crate) const MAX_CODE_EXECUTION_LINES: usize = 100;
 pub(crate) const MAX_INSTRUCTION_LINES: usize = 15;
 
 pub(crate) fn instruction_limit(expanded: bool) -> usize {
@@ -412,45 +412,74 @@ pub(crate) fn render_instructions(
     truncated
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SectionFlags {
+    pub script: bool,
+    pub output: bool,
+}
+
+impl SectionFlags {
+    pub fn any(self) -> bool {
+        self.script || self.output
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct RenderLimits {
+    pub script: usize,
+    pub output: usize,
+}
+
+impl RenderLimits {
+    pub fn new(expanded: SectionFlags, output_limit: usize) -> Self {
+        Self {
+            script: if expanded.script {
+                usize::MAX
+            } else {
+                MAX_CODE_EXECUTION_LINES
+            },
+            output: if expanded.output {
+                usize::MAX
+            } else {
+                output_limit
+            },
+        }
+    }
+
+    pub fn is_output_expanded(self) -> bool {
+        self.output == usize::MAX
+    }
+}
+
 pub struct ToolContent {
     pub lines: Vec<Line<'static>>,
-    pub has_truncation: bool,
+    pub truncation: SectionFlags,
+    pub separator_line: Option<usize>,
 }
 
 pub fn render_tool_content(
     input: Option<&ToolInput>,
     output: Option<&ToolOutput>,
     highlight: bool,
-    max_lines: usize,
+    limits: RenderLimits,
 ) -> ToolContent {
     let mut lines = Vec::new();
-    let mut has_truncation = false;
-    match input {
-        Some(ToolInput::Script { language, code }) => {
-            let code_lines: Vec<String> = code
-                .trim_end_matches('\n')
-                .lines()
-                .map(String::from)
-                .collect();
-            let total = code_lines.len();
-            let hl = highlight.then(|| highlighter_for_token(language));
-            let (code_result, trunc) =
-                render_code(hl, 1, &code_lines, total, MAX_CODE_EXECUTION_LINES);
-            has_truncation |= trunc;
-            lines.extend(code_result);
+    let mut truncation = SectionFlags::default();
+    if let Some((language, code)) = input.map(|i| match i {
+        ToolInput::Script { language, code } | ToolInput::Code { language, code } => {
+            (language, code)
         }
-        Some(ToolInput::Code { language, code }) => {
-            if highlight {
-                for line in highlight_code_plain(language, code) {
-                    lines.push(line);
-                }
-            } else {
-                for text in code.trim_end_matches('\n').lines() {
-                    lines.push(Line::from(fallback_span(text)));
-                }
-            }
-        }
-        None => {}
+    }) {
+        let code_lines: Vec<String> = code
+            .trim_end_matches('\n')
+            .lines()
+            .map(String::from)
+            .collect();
+        let total = code_lines.len();
+        let hl = highlight.then(|| highlighter_for_token(language));
+        let (code_result, trunc) = render_code(hl, 1, &code_lines, total, limits.script);
+        truncation.script = trunc;
+        lines.extend(code_result);
     }
     let (output_lines, output_trunc) = match output {
         Some(ToolOutput::ReadCode {
@@ -463,7 +492,7 @@ pub fn render_tool_content(
             *start_line,
             code_lines,
             code_lines.len(),
-            max_lines,
+            limits.output,
         ),
         Some(
             ToolOutput::WriteCode {
@@ -484,7 +513,7 @@ pub fn render_tool_content(
             1,
             code_lines,
             code_lines.len(),
-            max_lines,
+            limits.output,
         ),
         Some(ToolOutput::Diff {
             path,
@@ -496,24 +525,30 @@ pub fn render_tool_content(
             false,
         ),
         Some(ToolOutput::GrepResult { entries }) => {
-            render_grep_results(entries, max_lines, highlight)
+            render_grep_results(entries, limits.output, highlight)
         }
         Some(ToolOutput::Instructions { blocks }) => {
             let mut instruction_lines = Vec::new();
-            let trunc = render_instructions(blocks, &mut instruction_lines, max_lines, highlight);
+            let trunc =
+                render_instructions(blocks, &mut instruction_lines, limits.output, highlight);
             (instruction_lines, trunc)
         }
         Some(ToolOutput::ReadDir { .. }) => (Vec::new(), false),
         _ => (Vec::new(), false),
     };
-    has_truncation |= output_trunc;
-    if !lines.is_empty() && !output_lines.is_empty() {
+    truncation.output = output_trunc;
+    let separator_line = if !lines.is_empty() && !output_lines.is_empty() {
+        let sep = lines.len();
         lines.push(Line::default());
-    }
+        Some(sep)
+    } else {
+        None
+    };
     lines.extend(output_lines);
     ToolContent {
         lines,
-        has_truncation,
+        truncation,
+        separator_line,
     }
 }
 

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -8,13 +8,14 @@ use self::render::RenderCursor;
 use self::segment::{Segment, SegmentCache, wrapped_line_count};
 use self::selection::parse_batch_inner_id;
 
-use super::streaming_content::StreamingContent;
 use super::tool_display::{
-    ToolLines, append_annotation, append_right_info, assistant_style, build_batch_entry_lines,
-    build_instructions_lines, build_tool_lines, done_style, error_style, format_timestamp_now,
-    thinking_style, tool_output_annotation, truncate_to_header, user_style,
+    ToolKind, ToolLines, append_annotation, append_right_info, assistant_style,
+    build_batch_entry_lines, build_instructions_lines, build_tool_lines, done_style, error_style,
+    format_timestamp_now, thinking_style, tool_output_annotation, truncate_to_header, user_style,
 };
-use super::{DisplayMessage, DisplayRole, ToolRole, ToolStatus, apply_scroll_delta};
+use super::{
+    DisplayMessage, DisplayRole, ToolRole, ToolStatus, apply_scroll_delta, code_view::SectionFlags,
+};
 use crate::animation::spinner_str;
 use crate::components::keybindings::key;
 use crate::markdown::{hr_line, plain_lines, text_to_lines, truncate_output};
@@ -24,12 +25,12 @@ use crate::splash::{ColorTransition, Splash};
 use crate::theme;
 use maki_config::{ToolOutputLines, UiConfig};
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
 use super::scrollbar::render_vertical_scrollbar;
-use super::tool_display::ToolKind;
+use super::streaming_content::StreamingContent;
 use maki_agent::tools::{ToolCall, WEBFETCH_TOOL_NAME};
 use maki_agent::{
     BatchToolEntry, BatchToolStatus, InstructionBlock, NO_FILES_FOUND, ToolDoneEvent, ToolOutput,
@@ -55,7 +56,7 @@ pub struct MessagesPanel {
     highlight_segment: Option<usize>,
     idle_splash: Splash,
     accent: ColorTransition,
-    expanded_tools: HashSet<String>,
+    expanded_tools: HashMap<String, SectionFlags>,
     tool_output_lines: ToolOutputLines,
 }
 
@@ -90,7 +91,7 @@ impl MessagesPanel {
             highlight_segment: None,
             idle_splash: Splash::new(ui_config.splash_animation),
             accent: ColorTransition::new(theme::current().mode_build),
-            expanded_tools: HashSet::new(),
+            expanded_tools: HashMap::new(),
             tool_output_lines: ui_config.tool_output_lines,
         }
     }
@@ -332,8 +333,12 @@ impl MessagesPanel {
         }
         let inst_id = segment::instruction_id(parent_id);
         let batch_index = parse_batch_inner_id(parent_id).map(|(_, idx)| idx + 1);
-        let expanded = self.expanded_tools.contains(&inst_id);
-        let tl = build_instructions_lines(blocks, self.viewport_width, expanded, batch_index);
+        let exp = self
+            .expanded_tools
+            .get(&inst_id)
+            .copied()
+            .unwrap_or_default();
+        let tl = build_instructions_lines(blocks, self.viewport_width, exp.output, batch_index);
 
         if let Some(seg_idx) = self.cache.find_by_tool_id(&inst_id) {
             let seg = self.cache.get_mut(seg_idx).unwrap();
@@ -461,14 +466,18 @@ impl MessagesPanel {
         else {
             return false;
         };
-        let is_expanded = self.expanded_tools.contains(tool_id);
-        if !seg.has_truncation && !is_expanded {
+        let exp = self
+            .expanded_tools
+            .get(tool_id)
+            .copied()
+            .unwrap_or_default();
+        if !seg.truncation.any() && !exp.any() {
             return false;
         }
         let tool_id = tool_id.to_owned();
-        if !self.expanded_tools.remove(&tool_id) {
-            self.expanded_tools.insert(tool_id.clone());
-        }
+        let entry = self.expanded_tools.entry(tool_id.clone()).or_default();
+        entry.script = !entry.script;
+        entry.output = !entry.output;
         self.rebuild_expanded_tool(&tool_id);
         true
     }
@@ -558,19 +567,37 @@ impl MessagesPanel {
         }
         let doc_row = (row.saturating_sub(area.y)) as u32 + self.scroll_top as u32;
         let width = self.viewport_width;
-        let Some((_, seg)) = self.cache.segment_at_row(doc_row, width) else {
+        let Some((_, seg, seg_start)) = self.cache.segment_at_row(doc_row, width) else {
             return false;
         };
         let Some(tool_id) = seg.tool_id.as_deref() else {
             return false;
         };
-        let is_expanded = self.expanded_tools.contains(tool_id);
-        if !seg.has_truncation && !is_expanded {
+        let exp = self
+            .expanded_tools
+            .get(tool_id)
+            .copied()
+            .unwrap_or_default();
+        if !seg.truncation.any() && !exp.any() {
             return false;
         }
+        let click_line = (doc_row - seg_start) as usize;
         let tool_id = tool_id.to_owned();
-        if !self.expanded_tools.remove(&tool_id) {
-            self.expanded_tools.insert(tool_id.clone());
+        let truncation = seg.truncation;
+        let separator_line = seg.separator_line;
+
+        let entry = self.expanded_tools.entry(tool_id.clone()).or_default();
+        match separator_line {
+            Some(sep) if click_line < sep => {
+                if truncation.script || entry.script {
+                    entry.script = !entry.script;
+                }
+            }
+            _ => {
+                if truncation.output || entry.output {
+                    entry.output = !entry.output;
+                }
+            }
         }
         self.rebuild_expanded_tool(&tool_id);
         true
@@ -759,10 +786,10 @@ impl MessagesPanel {
         status: ToolStatus,
         started_at: Instant,
         width: u16,
-        expanded: bool,
+        exp: SectionFlags,
         tool_output_lines: &ToolOutputLines,
     ) -> ToolLines {
-        let mut tl = build_tool_lines(msg, status, started_at, width, expanded, tool_output_lines);
+        let mut tl = build_tool_lines(msg, status, started_at, width, exp, tool_output_lines);
         if let Some(ts) = &msg.timestamp
             && !tl.lines.is_empty()
         {
@@ -826,13 +853,17 @@ impl MessagesPanel {
             return;
         };
 
-        let expanded = self.expanded_tools.contains(tool_id);
+        let exp = self
+            .expanded_tools
+            .get(tool_id)
+            .copied()
+            .unwrap_or_default();
         let tl = Self::build_tool_segment_lines(
             msg,
             status,
             self.started_at,
             self.viewport_width,
-            expanded,
+            exp,
             &self.tool_output_lines,
         );
 
@@ -868,13 +899,17 @@ impl MessagesPanel {
             .enumerate()
             .map(|(j, entry)| {
                 let child_id = format!("{tool_id}__{j}");
-                let child_expanded = self.expanded_tools.contains(&child_id);
+                let child_exp = self
+                    .expanded_tools
+                    .get(&child_id)
+                    .copied()
+                    .unwrap_or_default();
                 let tl = build_batch_entry_lines(
                     entry,
                     j,
                     self.started_at,
                     self.viewport_width,
-                    child_expanded,
+                    child_exp,
                     &self.tool_output_lines,
                 );
                 let search = tl.search_text.clone();
@@ -921,14 +956,14 @@ impl MessagesPanel {
             let msg = &self.messages[i];
 
             if let DisplayRole::Tool(t) = &msg.role {
-                let expanded = self.expanded_tools.contains(&t.id);
+                let exp = self.expanded_tools.get(&t.id).copied().unwrap_or_default();
                 let status = t.status;
                 let tl = Self::build_tool_segment_lines(
                     msg,
                     status,
                     self.started_at,
                     self.viewport_width,
-                    expanded,
+                    exp,
                     &self.tool_output_lines,
                 );
                 let id = t.id.clone();
@@ -945,13 +980,17 @@ impl MessagesPanel {
                         .enumerate()
                         .map(|(j, entry)| {
                             let child_id = format!("{id}__{j}");
-                            let child_expanded = self.expanded_tools.contains(&child_id);
+                            let child_exp = self
+                                .expanded_tools
+                                .get(&child_id)
+                                .copied()
+                                .unwrap_or_default();
                             let tl = build_batch_entry_lines(
                                 entry,
                                 j,
                                 self.started_at,
                                 self.viewport_width,
-                                child_expanded,
+                                child_exp,
                                 &self.tool_output_lines,
                             );
                             let blocks = entry.output.as_ref().and_then(|o| o.owned_instructions());

--- a/maki-ui/src/components/messages/segment.rs
+++ b/maki-ui/src/components/messages/segment.rs
@@ -1,5 +1,6 @@
 use crate::render_worker::RenderWorker;
 
+use super::super::code_view::SectionFlags;
 use super::super::tool_display::{HighlightRequest, ToolLines};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Wrap};
@@ -48,7 +49,8 @@ pub(super) struct Segment {
     pub search_text: String,
     pub tool_id: Option<String>,
     pub msg_index: Option<usize>,
-    pub has_truncation: bool,
+    pub truncation: SectionFlags,
+    pub separator_line: Option<usize>,
     cached_height: Cell<Option<CachedHeight>>,
     pending_highlight: Option<u64>,
     highlight_range: Option<(usize, usize)>,
@@ -145,7 +147,8 @@ impl Segment {
         self.highlight_key = HighlightKey::from_request(tl.highlight.as_ref());
         self.spinner_lines = tl.spinner_lines;
         self.content_indent = tl.content_indent;
-        self.has_truncation = tl.has_truncation;
+        self.truncation = tl.truncation;
+        self.separator_line = tl.separator_line;
         self.set_lines(tl.lines);
     }
 
@@ -158,7 +161,8 @@ impl Segment {
             tl.lines.splice(s..req.range.1, hl_lines);
             Some((s, new_end))
         });
-        self.has_truncation = tl.has_truncation;
+        self.truncation = tl.truncation;
+        self.separator_line = tl.separator_line;
         if let Some((s, e)) = reused {
             self.set_lines(tl.lines);
             self.highlight_range = Some((s, e));
@@ -237,12 +241,13 @@ impl SegmentCache {
         self.segments.iter().map(|s| s.height(width) as u32).sum()
     }
 
-    pub fn segment_at_row(&self, doc_row: u32, width: u16) -> Option<(usize, &Segment)> {
+    pub fn segment_at_row(&self, doc_row: u32, width: u16) -> Option<(usize, &Segment, u32)> {
         let mut cumulative: u32 = 0;
         for (i, seg) in self.segments.iter().enumerate() {
+            let seg_start = cumulative;
             cumulative += seg.height(width) as u32;
             if doc_row < cumulative {
-                return Some((i, seg));
+                return Some((i, seg, seg_start));
             }
         }
         None

--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -4,6 +4,8 @@ use super::{DisplayMessage, ToolStatus};
 use super::{code_view, index_highlight};
 use crate::animation::spinner_frame;
 use crate::theme;
+use code_view::RenderLimits;
+use code_view::SectionFlags;
 use maki_config::ToolOutputLines;
 
 use std::borrow::Cow;
@@ -260,19 +262,19 @@ pub fn done_style() -> RoleStyle {
 
 pub struct ToolLines {
     pub lines: Vec<Line<'static>>,
-    /// Plain-text for search. Built in parallel with `lines` by ToolLineBuilder.
     pub search_text: String,
     pub highlight: Option<HighlightRequest>,
     pub spinner_lines: Vec<usize>,
     pub content_indent: &'static str,
-    pub has_truncation: bool,
+    pub truncation: SectionFlags,
+    pub separator_line: Option<usize>,
 }
 
 pub struct HighlightRequest {
     pub range: (usize, usize),
     pub input: Option<Arc<ToolInput>>,
     pub output: Option<Arc<ToolOutput>>,
-    pub max_lines: usize,
+    pub limits: RenderLimits,
 }
 
 impl HighlightRequest {
@@ -280,7 +282,7 @@ impl HighlightRequest {
         range: (usize, usize),
         input: Option<Arc<ToolInput>>,
         output: Option<Arc<ToolOutput>>,
-        max_lines: usize,
+        limits: RenderLimits,
     ) -> Option<Self> {
         if range.0 == range.1 {
             return None;
@@ -307,7 +309,7 @@ impl HighlightRequest {
             range,
             input,
             output,
-            max_lines,
+            limits,
         })
     }
 }
@@ -315,7 +317,7 @@ impl HighlightRequest {
 impl ToolLines {
     pub fn send_highlight(&self, worker: &RenderWorker) -> Option<u64> {
         let hl = self.highlight.as_ref()?;
-        Some(worker.send(hl.input.clone(), hl.output.clone(), hl.max_lines))
+        Some(worker.send(hl.input.clone(), hl.output.clone(), hl.limits))
     }
 }
 
@@ -408,9 +410,8 @@ fn resolve_output<'a>(
     body: Option<&'a str>,
     live_output: Option<&'a str>,
     pre_truncated: usize,
-    max_lines: usize,
+    limits: RenderLimits,
     keep: Keep,
-    expanded: bool,
 ) -> ResolvedOutput<'a> {
     if let Some(ToolOutput::Batch { .. } | ToolOutput::QuestionAnswers(_)) = output {
         return ResolvedOutput {
@@ -427,6 +428,7 @@ fn resolve_output<'a>(
         _ => None,
     };
 
+    let expanded = limits.is_output_expanded();
     let (raw_text, already_truncated): (Option<Cow<'a, str>>, usize) = if expanded {
         match &full_text {
             Some(t) => (Some(t.clone()), 0),
@@ -462,7 +464,7 @@ fn resolve_output<'a>(
 
     let (text, skipped) = match raw_text {
         Some(t) if !t.is_empty() => {
-            let tr = truncate_output(&t, max_lines, keep);
+            let tr = truncate_output(&t, limits.output, keep);
             let s = if tr.skipped > 0 {
                 tr.skipped
             } else {
@@ -487,18 +489,20 @@ struct ToolLineBuilder {
     content_range: (usize, usize),
     width: u16,
     outer_indent: &'static str,
-    has_truncation: bool,
-    max_lines: usize,
+    truncation: SectionFlags,
+    separator_line: Option<usize>,
+    limits: RenderLimits,
     keep: Keep,
 }
 
 impl ToolLineBuilder {
-    fn new(width: u16, outer_indent: &'static str, expanded: bool, limits: OutputLimits) -> Self {
-        let max_lines = if expanded {
-            usize::MAX
-        } else {
-            limits.max_lines
-        };
+    fn new(
+        width: u16,
+        outer_indent: &'static str,
+        expanded: SectionFlags,
+        output_limits: OutputLimits,
+    ) -> Self {
+        let limits = RenderLimits::new(expanded, output_limits.max_lines);
         Self {
             lines: Vec::new(),
             search_text: String::new(),
@@ -506,9 +510,10 @@ impl ToolLineBuilder {
             content_range: (0, 0),
             width: width.saturating_sub(outer_indent.len() as u16),
             outer_indent,
-            has_truncation: false,
-            max_lines,
-            keep: limits.keep,
+            truncation: SectionFlags::default(),
+            separator_line: None,
+            limits,
+            keep: output_limits.keep,
         }
     }
 
@@ -555,9 +560,11 @@ impl ToolLineBuilder {
     }
 
     fn push_code_content(&mut self, input: Option<&ToolInput>, output: Option<&ToolOutput>) {
-        let content = code_view::render_tool_content(input, output, false, self.max_lines);
-        self.has_truncation |= content.has_truncation;
+        let content = code_view::render_tool_content(input, output, false, self.limits);
+        self.truncation.script |= content.truncation.script;
+        self.truncation.output |= content.truncation.output;
         let start = self.lines.len();
+        self.separator_line = content.separator_line.map(|l| start + l);
         for mut line in content.lines {
             line.spans.insert(0, Span::raw(TOOL_BODY_INDENT));
             self.lines.push(line);
@@ -633,7 +640,7 @@ impl ToolLineBuilder {
 
     fn push_truncation_count(&mut self, skipped: usize) {
         if should_truncate(skipped) {
-            self.has_truncation = true;
+            self.truncation.output = true;
             let text = truncation_notice(skipped);
             let mut line = Line::from(Span::styled(text, theme::current().tool_dim));
             line.spans.insert(0, Span::raw(TOOL_BODY_INDENT));
@@ -642,6 +649,7 @@ impl ToolLineBuilder {
     }
 
     fn push_bash_output_label(&mut self, indent: &str, is_done: bool, has_output: bool) {
+        self.separator_line = Some(self.lines.len());
         self.lines.push(Line::from(Span::styled(
             format!("{indent}{BASH_OUTPUT_SEPARATOR}"),
             theme::current().tool_dim,
@@ -663,6 +671,7 @@ impl ToolLineBuilder {
 
     fn push_code_output_separator(&mut self, kind: ToolKind, indent: &str) {
         if kind == ToolKind::CodeExecution {
+            self.separator_line = Some(self.lines.len());
             self.lines.push(Line::from(Span::styled(
                 format!("{indent}{}", CODE_EXECUTION_OUTPUT_SEPARATOR),
                 theme::current().tool_dim,
@@ -697,14 +706,15 @@ impl ToolLineBuilder {
                 line.spans.insert(0, Span::raw(self.outer_indent));
             }
         }
-        let highlight = HighlightRequest::new(self.content_range, input, output, self.max_lines);
+        let highlight = HighlightRequest::new(self.content_range, input, output, self.limits);
         ToolLines {
             lines: self.lines,
             search_text: self.search_text,
             highlight,
             spinner_lines: self.spinner_lines,
             content_indent,
-            has_truncation: self.has_truncation,
+            truncation: self.truncation,
+            separator_line: self.separator_line,
         }
     }
 }
@@ -724,7 +734,7 @@ pub fn build_tool_lines(
     status: ToolStatus,
     started_at: Instant,
     width: u16,
-    expanded: bool,
+    expanded: SectionFlags,
     tool_output_lines: &ToolOutputLines,
 ) -> ToolLines {
     let tool_name = msg.role.tool_name().unwrap_or("?");
@@ -745,9 +755,8 @@ pub fn build_tool_lines(
         body,
         msg.live_output.as_deref(),
         msg.truncated_lines,
-        b.max_lines,
+        b.limits,
         b.keep,
-        expanded,
     );
     b.push_resolved_output(&resolved, kind, is_done);
     b.finish(
@@ -767,7 +776,7 @@ pub fn build_batch_entry_lines(
     index: usize,
     started_at: Instant,
     width: u16,
-    expanded: bool,
+    expanded: SectionFlags,
     tool_output_lines: &ToolOutputLines,
 ) -> ToolLines {
     let kind = ToolKind::from_name(&entry.tool);
@@ -789,15 +798,7 @@ pub fn build_batch_entry_lines(
         entry.status,
         BatchToolStatus::Success | BatchToolStatus::Error
     );
-    let resolved = resolve_output(
-        entry.output.as_ref(),
-        None,
-        None,
-        0,
-        b.max_lines,
-        b.keep,
-        expanded,
-    );
+    let resolved = resolve_output(entry.output.as_ref(), None, None, 0, b.limits, b.keep);
     b.push_resolved_output(&resolved, kind, is_done);
     b.prepend_separator(index);
     b.finish(
@@ -838,13 +839,18 @@ pub fn build_instructions_lines(
         max_lines: code_view::instruction_limit(expanded),
         keep: Keep::Tail,
     };
-    let mut b = ToolLineBuilder::new(width, outer_indent, expanded, limits);
+    let exp = SectionFlags {
+        script: false,
+        output: expanded,
+    };
+    let mut b = ToolLineBuilder::new(width, outer_indent, exp, limits);
     b.push_header("load", header, annotation.as_deref());
     b.prepend_indicator(Indicator::Success, Instant::now());
 
     let start = b.lines.len();
-    let has_truncation = code_view::render_instructions(blocks, &mut b.lines, b.max_lines, false);
-    b.has_truncation |= has_truncation;
+    let has_truncation =
+        code_view::render_instructions(blocks, &mut b.lines, b.limits.output, false);
+    b.truncation.output |= has_truncation;
     let inner_indent = &content_indent[outer_indent.len()..];
     for line in &mut b.lines[start..] {
         line.spans.insert(0, Span::raw(inner_indent));
@@ -880,6 +886,13 @@ mod tests {
         BatchToolEntry, BatchToolStatus, GrepFileEntry, GrepMatchGroup, ToolInput, ToolOutput,
     };
     use test_case::test_case;
+
+    fn exp(both: bool) -> SectionFlags {
+        SectionFlags {
+            script: both,
+            output: both,
+        }
+    }
 
     fn code_input() -> Option<ToolInput> {
         Some(ToolInput::Code {
@@ -936,7 +949,14 @@ mod tests {
         expect_output: bool,
     ) {
         let msg = bash_msg("header\nbody", ToolStatus::Success, input, output);
-        let tl = build_tool_lines(&msg, ToolStatus::Success, Instant::now(), 80, false, &TOL);
+        let tl = build_tool_lines(
+            &msg,
+            ToolStatus::Success,
+            Instant::now(),
+            80,
+            SectionFlags::default(),
+            &TOL,
+        );
         assert_eq!(tl.highlight.is_some(), expect_highlight);
         if let Some(hl) = &tl.highlight {
             assert_eq!(hl.output.is_some(), expect_output);
@@ -1011,7 +1031,14 @@ mod tests {
     #[test_case(ToolStatus::Success,    plain_output() ; "done_with_plain_output_shows_body")]
     fn bash_body_visible(status: ToolStatus, output: Option<ToolOutput>) {
         let msg = bash_msg("echo hi\nline1\nline2", status, code_input(), output);
-        let tl = build_tool_lines(&msg, status, Instant::now(), 80, false, &TOL);
+        let tl = build_tool_lines(
+            &msg,
+            status,
+            Instant::now(),
+            80,
+            SectionFlags::default(),
+            &TOL,
+        );
         let text = lines_text(&tl);
         assert!(text.contains("line1"));
         assert!(text.contains("line2"));
@@ -1027,7 +1054,14 @@ mod tests {
     #[test_case(None,         false ; "hidden_without_code_input")]
     fn bash_separator(input: Option<ToolInput>, expected: bool) {
         let msg = bash_msg("echo hi\nhello", ToolStatus::Success, input, plain_output());
-        let tl = build_tool_lines(&msg, ToolStatus::Success, Instant::now(), 80, false, &TOL);
+        let tl = build_tool_lines(
+            &msg,
+            ToolStatus::Success,
+            Instant::now(),
+            80,
+            SectionFlags::default(),
+            &TOL,
+        );
         assert_eq!(
             line_has_styled(&tl, BASH_OUTPUT_SEPARATOR, theme::current().tool_dim),
             expected,
@@ -1038,7 +1072,14 @@ mod tests {
     #[test_case(ToolStatus::Success,    Some(ToolOutput::Plain(String::new())),    BASH_NO_OUTPUT_LABEL ; "no_output_when_done_empty")]
     fn bash_status_label(status: ToolStatus, output: Option<ToolOutput>, label: &str) {
         let msg = bash_msg("echo hi", status, code_input(), output);
-        let tl = build_tool_lines(&msg, status, Instant::now(), 80, false, &TOL);
+        let tl = build_tool_lines(
+            &msg,
+            status,
+            Instant::now(),
+            80,
+            SectionFlags::default(),
+            &TOL,
+        );
         assert!(line_has_styled(&tl, label, theme::current().tool_dim));
     }
 
@@ -1050,7 +1091,8 @@ mod tests {
             code_input(),
             Some(ToolOutput::Plain("hello".into())),
         );
-        let tl = build_batch_entry_lines(&entry, 0, Instant::now(), 80, false, &TOL);
+        let tl =
+            build_batch_entry_lines(&entry, 0, Instant::now(), 80, SectionFlags::default(), &TOL);
         assert!(line_has_styled(
             &tl,
             BASH_OUTPUT_SEPARATOR,
@@ -1090,7 +1132,14 @@ mod tests {
     #[test_case(10, false ; "hidden_when_too_narrow")]
     fn append_right_info_timestamp_visibility(width: u16, expect_timestamp: bool) {
         let msg = tool_msg();
-        let mut tl = build_tool_lines(&msg, ToolStatus::Success, Instant::now(), 80, false, &TOL);
+        let mut tl = build_tool_lines(
+            &msg,
+            ToolStatus::Success,
+            Instant::now(),
+            80,
+            SectionFlags::default(),
+            &TOL,
+        );
         let span_count_before = tl.lines[0].spans.len();
         append_right_info(&mut tl.lines[0], None, Some("12:34:56"), width);
         if expect_timestamp {
@@ -1117,14 +1166,16 @@ mod tests {
             }),
         );
         entry.summary = "src/main.rs".into();
-        let tl = build_batch_entry_lines(&entry, 0, Instant::now(), 80, false, &TOL);
+        let tl =
+            build_batch_entry_lines(&entry, 0, Instant::now(), 80, SectionFlags::default(), &TOL);
         assert!(lines_text(&tl).contains("(42 lines)"));
     }
 
     #[test]
     fn batch_entry_code_input_rendered() {
         let entry = batch_entry("bash", BatchToolStatus::Success, code_input(), None);
-        let tl = build_batch_entry_lines(&entry, 0, Instant::now(), 80, false, &TOL);
+        let tl =
+            build_batch_entry_lines(&entry, 0, Instant::now(), 80, SectionFlags::default(), &TOL);
         assert!(lines_text(&tl).contains("echo hi"));
     }
 
@@ -1133,15 +1184,18 @@ mod tests {
     #[test_case(BatchToolStatus::Success,    &[]     ; "success_no_spinner")]
     fn batch_entry_spinner(status: BatchToolStatus, expected: &[usize]) {
         let entry = batch_entry("bash", status, None, None);
-        let tl = build_batch_entry_lines(&entry, 0, Instant::now(), 80, false, &TOL);
+        let tl =
+            build_batch_entry_lines(&entry, 0, Instant::now(), 80, SectionFlags::default(), &TOL);
         assert_eq!(tl.spinner_lines, expected);
     }
 
     #[test]
     fn batch_entry_separator_on_nonzero_index() {
         let entry = batch_entry("bash", BatchToolStatus::Success, None, None);
-        let first = build_batch_entry_lines(&entry, 0, Instant::now(), 80, false, &TOL);
-        let second = build_batch_entry_lines(&entry, 1, Instant::now(), 80, false, &TOL);
+        let first =
+            build_batch_entry_lines(&entry, 0, Instant::now(), 80, SectionFlags::default(), &TOL);
+        let second =
+            build_batch_entry_lines(&entry, 1, Instant::now(), 80, SectionFlags::default(), &TOL);
         assert!(second.lines.len() > first.lines.len());
         assert!(spans_text(&second.lines[1].spans).contains(TOOL_SEPARATOR));
     }
@@ -1154,7 +1208,8 @@ mod tests {
             None,
             Some(ToolOutput::Plain("hello world".into())),
         );
-        let tl = build_batch_entry_lines(&entry, 0, Instant::now(), 80, false, &TOL);
+        let tl =
+            build_batch_entry_lines(&entry, 0, Instant::now(), 80, SectionFlags::default(), &TOL);
         assert!(lines_text(&tl).contains("hello world"));
     }
 
@@ -1162,7 +1217,14 @@ mod tests {
     fn annotation_rendered_on_header() {
         let mut msg = tool_msg();
         msg.annotation = Some("2m timeout".into());
-        let tl = build_tool_lines(&msg, ToolStatus::Success, Instant::now(), 80, false, &TOL);
+        let tl = build_tool_lines(
+            &msg,
+            ToolStatus::Success,
+            Instant::now(),
+            80,
+            SectionFlags::default(),
+            &TOL,
+        );
         let text = lines_text(&tl);
         assert!(text.contains("(2m timeout)"));
     }
@@ -1171,7 +1233,8 @@ mod tests {
     fn batch_entry_stored_annotation_rendered() {
         let mut entry = batch_entry("task", BatchToolStatus::Success, None, None);
         entry.annotation = Some("anthropic/claude-haiku-4-20250414".into());
-        let tl = build_batch_entry_lines(&entry, 0, Instant::now(), 80, false, &TOL);
+        let tl =
+            build_batch_entry_lines(&entry, 0, Instant::now(), 80, SectionFlags::default(), &TOL);
         assert!(lines_text(&tl).contains("(anthropic/claude-haiku-4-20250414)"));
     }
 
@@ -1196,7 +1259,14 @@ mod tests {
     #[test]
     fn task_output_body_visible() {
         let msg = task_msg("**bold** and `code`".into());
-        let tl = build_tool_lines(&msg, ToolStatus::Success, Instant::now(), 80, false, &TOL);
+        let tl = build_tool_lines(
+            &msg,
+            ToolStatus::Success,
+            Instant::now(),
+            80,
+            SectionFlags::default(),
+            &TOL,
+        );
         let text = lines_text(&tl);
         assert!(text.contains("bold"));
         assert!(text.contains("code"));
@@ -1240,7 +1310,14 @@ mod tests {
 
     fn task_truncation_tl(output: String) -> ToolLines {
         let msg = task_msg(output);
-        build_tool_lines(&msg, ToolStatus::Success, Instant::now(), 80, false, &TOL)
+        build_tool_lines(
+            &msg,
+            ToolStatus::Success,
+            Instant::now(),
+            80,
+            SectionFlags::default(),
+            &TOL,
+        )
     }
 
     #[test]
@@ -1283,7 +1360,7 @@ mod tests {
             ToolStatus::Success,
             Instant::now(),
             width,
-            false,
+            SectionFlags::default(),
             &TOL,
         );
         assert_hr_fits(&tl, width);
@@ -1298,7 +1375,14 @@ mod tests {
             None,
             Some(ToolOutput::Plain("before\n\n---\n\nafter".into())),
         );
-        let tl = build_batch_entry_lines(&entry, 0, Instant::now(), width, false, &TOL);
+        let tl = build_batch_entry_lines(
+            &entry,
+            0,
+            Instant::now(),
+            width,
+            SectionFlags::default(),
+            &TOL,
+        );
         assert_hr_fits(&tl, width);
     }
 
@@ -1325,7 +1409,14 @@ mod tests {
     fn index_output_truncated_at_max_lines() {
         let body: String = (0..150).map(|i| format!("  line_{i}\n")).collect();
         let msg = index_msg(&body);
-        let tl = build_tool_lines(&msg, ToolStatus::Success, Instant::now(), 80, false, &TOL);
+        let tl = build_tool_lines(
+            &msg,
+            ToolStatus::Success,
+            Instant::now(),
+            80,
+            SectionFlags::default(),
+            &TOL,
+        );
         let text = lines_text(&tl);
         assert!(text.contains("line_0"));
         assert!(!text.contains("line_149"));
@@ -1336,7 +1427,14 @@ mod tests {
     fn index_output_styles_all_elements() {
         let body = "imports: [1-5]\n  pub fn main() [10-20]\nfns:";
         let msg = index_msg(body);
-        let tl = build_tool_lines(&msg, ToolStatus::Success, Instant::now(), 80, false, &TOL);
+        let tl = build_tool_lines(
+            &msg,
+            ToolStatus::Success,
+            Instant::now(),
+            80,
+            SectionFlags::default(),
+            &TOL,
+        );
         let t = theme::current();
         assert!(line_has_styled(&tl, "imports:", t.index_section));
         assert!(line_has_styled(&tl, "fns:", t.index_section));
@@ -1385,47 +1483,26 @@ mod tests {
         expect_text: bool,
     ) {
         let kind = ToolKind::from_name(tool);
-        let limits = kind.output_limits(&TOL);
-        let resolved = resolve_output(
-            output.as_ref(),
-            body,
-            None,
-            0,
-            limits.max_lines,
-            limits.keep,
-            false,
-        );
+        let output_limits = kind.output_limits(&TOL);
+        let limits = RenderLimits::new(SectionFlags::default(), output_limits.max_lines);
+        let resolved = resolve_output(output.as_ref(), body, None, 0, limits, output_limits.keep);
         assert_eq!(resolved.text.is_some(), expect_text);
     }
 
     #[test]
     fn resolve_output_pre_truncated_forwarded() {
-        let limits = ToolKind::Bash.output_limits(&TOL);
-        let resolved = resolve_output(
-            None,
-            Some("short"),
-            None,
-            42,
-            limits.max_lines,
-            limits.keep,
-            false,
-        );
+        let output_limits = ToolKind::Bash.output_limits(&TOL);
+        let limits = RenderLimits::new(SectionFlags::default(), output_limits.max_lines);
+        let resolved = resolve_output(None, Some("short"), None, 42, limits, output_limits.keep);
         assert_eq!(resolved.skipped, 42);
     }
 
     #[test]
     fn resolve_output_truncation_overrides_pre_truncated() {
         let long = n_lines(200);
-        let limits = ToolKind::Bash.output_limits(&TOL);
-        let resolved = resolve_output(
-            None,
-            Some(&long),
-            None,
-            5,
-            limits.max_lines,
-            limits.keep,
-            false,
-        );
+        let output_limits = ToolKind::Bash.output_limits(&TOL);
+        let limits = RenderLimits::new(SectionFlags::default(), output_limits.max_lines);
+        let resolved = resolve_output(None, Some(&long), None, 5, limits, output_limits.keep);
         assert!(resolved.skipped > 5);
     }
 
@@ -1474,15 +1551,21 @@ mod tests {
             ToolStatus::InProgress,
             Instant::now(),
             80,
-            false,
+            exp(false),
             &TOL,
         );
-        let expanded =
-            build_tool_lines(&msg, ToolStatus::InProgress, Instant::now(), 80, true, &TOL);
+        let expanded = build_tool_lines(
+            &msg,
+            ToolStatus::InProgress,
+            Instant::now(),
+            80,
+            exp(true),
+            &TOL,
+        );
         let collapsed_text = lines_text(&collapsed);
         let expanded_text = lines_text(&expanded);
-        assert!(collapsed.has_truncation);
-        assert!(!expanded.has_truncation);
+        assert!(collapsed.truncation.any());
+        assert!(!expanded.truncation.any());
         assert!(!expanded_text.contains(BASH_WAITING_LABEL));
         assert!(expanded_text.contains("line 0"));
         assert!(!collapsed_text.contains("line 0"));
@@ -1503,11 +1586,11 @@ mod tests {
             ToolStatus::Success,
             Instant::now(),
             80,
-            expanded,
+            exp(expanded),
             &TOL,
         );
         let text = lines_text(&tl);
-        assert_eq!(tl.has_truncation, expect_truncation);
+        assert_eq!(tl.truncation.any(), expect_truncation);
         assert_eq!(text.contains("click to expand"), expect_expand_notice);
     }
 
@@ -1530,10 +1613,10 @@ mod tests {
             ToolStatus::Success,
             Instant::now(),
             80,
-            expanded,
+            exp(expanded),
             &TOL,
         );
-        assert_eq!(tl.has_truncation, expect_truncation);
+        assert_eq!(tl.truncation.any(), expect_truncation);
         let text = lines_text(&tl);
         assert_eq!(text.contains("click to expand"), expect_expand_notice);
     }
@@ -1590,7 +1673,7 @@ mod tests {
         let output = msg.tool_output.as_deref().unwrap();
         let blocks = output.instructions().unwrap();
         let tl = build_instructions_lines(blocks, 80, expanded, None);
-        assert_eq!(tl.has_truncation, expect_truncation);
+        assert_eq!(tl.truncation.any(), expect_truncation);
         let text = lines_text(&tl);
         assert_eq!(text.contains("inst 29"), expect_all_visible);
     }
@@ -1598,7 +1681,14 @@ mod tests {
     #[test]
     fn read_code_tool_lines_exclude_instructions() {
         let msg = read_msg_with_instructions(3, 30);
-        let tl = build_tool_lines(&msg, ToolStatus::Success, Instant::now(), 80, false, &TOL);
+        let tl = build_tool_lines(
+            &msg,
+            ToolStatus::Success,
+            Instant::now(),
+            80,
+            SectionFlags::default(),
+            &TOL,
+        );
         let text = lines_text(&tl);
         assert!(
             !text.contains("inst 0"),

--- a/maki-ui/src/render_worker.rs
+++ b/maki-ui/src/render_worker.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use tracing::error;
 
-use crate::components::code_view;
+use crate::components::code_view::{self, RenderLimits};
 use maki_agent::{ToolInput, ToolOutput};
 use ratatui::text::Line;
 
@@ -20,7 +20,7 @@ struct RenderJob {
     id: u64,
     tool_input: Option<Arc<ToolInput>>,
     tool_output: Option<Arc<ToolOutput>>,
-    max_lines: usize,
+    limits: RenderLimits,
 }
 
 pub struct RenderResult {
@@ -67,14 +67,14 @@ impl RenderWorker {
         &self,
         tool_input: Option<Arc<ToolInput>>,
         tool_output: Option<Arc<ToolOutput>>,
-        max_lines: usize,
+        limits: RenderLimits,
     ) -> u64 {
         let id = NEXT_JOB_ID.fetch_add(1, Ordering::Relaxed);
         let _ = self.job_tx.send(RenderJob {
             id,
             tool_input,
             tool_output,
-            max_lines,
+            limits,
         });
         self.maybe_spawn_thread();
         id
@@ -115,7 +115,7 @@ fn worker_loop(inner: &PoolInner) {
             job.tool_input.as_deref(),
             job.tool_output.as_deref(),
             true,
-            job.max_lines,
+            job.limits,
         );
         if inner
             .result_tx


### PR DESCRIPTION
Clicking a truncated code_execution only expanded output, not script. Script rendering ignored expanded state and always used MAX_CODE_EXECUTION_LINES.

Now tracks script and output expansion separately via RenderLimits. Click position relative to separator_line determines which section to toggle. Also merged duplicate Script/Code input handling in render_tool_content.