### PR TITLE
Github Copilot Provider

### DIFF
--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -13,6 +13,7 @@ pub use model::{
 };
 pub use providers::Timeouts;
 pub use providers::dynamic;
+pub use providers::github_copilot::auth as github_copilot_auth;
 pub use providers::openai::auth as openai_auth;
 pub use types::{
     ContentBlock, ImageMediaType, ImageSource, Message, ProviderEvent, Role, StopReason,

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -10,7 +10,9 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 use crate::provider::ProviderKind;
-use crate::providers::{anthropic, dynamic, google, mistral, ollama, openai, synthetic, zai};
+use crate::providers::{
+    anthropic, dynamic, github_copilot, google, mistral, ollama, openai, synthetic, zai,
+};
 
 const PER_MILLION: f64 = 1_000_000.0;
 
@@ -114,6 +116,7 @@ pub fn models_for_provider(provider: ProviderKind) -> &'static [ModelEntry] {
         ProviderKind::Mistral => mistral::models(),
         ProviderKind::Google => google::models(),
         ProviderKind::Zai | ProviderKind::ZaiCodingPlan => zai::models(),
+        ProviderKind::GithubCopilot => github_copilot::models(),
         ProviderKind::Synthetic => synthetic::models(),
     }
 }
@@ -407,6 +410,15 @@ mod tests {
         let model = Model::from_spec("ollama/my-custom-model").unwrap();
         assert_eq!(model.provider, ProviderKind::Ollama);
         assert_eq!(model.id, "my-custom-model");
+        assert_eq!(model.tier, ModelTier::Medium);
+        assert_eq!(model.family, ModelFamily::Generic);
+    }
+
+    #[test]
+    fn copilot_arbitrary_model_accepted() {
+        let model = Model::from_spec("github-copilot/my-future-model").unwrap();
+        assert_eq!(model.provider, ProviderKind::GithubCopilot);
+        assert_eq!(model.id, "my-future-model");
         assert_eq!(model.tier, ModelTier::Medium);
         assert_eq!(model.family, ModelFamily::Generic);
     }

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -10,6 +10,7 @@ use crate::model::{Model, ModelFamily, models_for_provider};
 use crate::providers::Timeouts;
 use crate::providers::anthropic::Anthropic;
 use crate::providers::dynamic;
+use crate::providers::github_copilot::GithubCopilot;
 use crate::providers::google::Google;
 use crate::providers::mistral::Mistral;
 use crate::providers::ollama::Ollama;
@@ -24,6 +25,8 @@ pub enum ProviderKind {
     Anthropic,
     #[strum(serialize = "openai")]
     OpenAi,
+    #[strum(serialize = "github-copilot")]
+    GithubCopilot,
     Google,
     Ollama,
     Mistral,
@@ -37,6 +40,7 @@ impl ProviderKind {
         match self {
             Self::Anthropic => "Anthropic",
             Self::OpenAi => "OpenAI",
+            Self::GithubCopilot => "GitHub Copilot",
             Self::Google => "Google",
             Self::Ollama => "Ollama",
             Self::Mistral => "Mistral",
@@ -50,6 +54,7 @@ impl ProviderKind {
         match self {
             Self::Anthropic => "ANTHROPIC_API_KEY",
             Self::OpenAi => "OPENAI_API_KEY",
+            Self::GithubCopilot => "COPILOT_GITHUB_TOKEN",
             Self::Google => "GEMINI_API_KEY",
             Self::Ollama => "OLLAMA_API_KEY",
             Self::Mistral => "MISTRAL_API_KEY",
@@ -62,6 +67,7 @@ impl ProviderKind {
         match self {
             Self::Anthropic => "https://api.anthropic.com/v1/messages",
             Self::OpenAi => "https://api.openai.com/v1",
+            Self::GithubCopilot => "https://api.individual.githubcopilot.com",
             Self::Google => "https://generativelanguage.googleapis.com/v1beta",
             Self::Ollama => "http://localhost:11434/v1",
             Self::Mistral => "https://api.mistral.ai/v1",
@@ -74,7 +80,7 @@ impl ProviderKind {
     pub const fn supports_thinking(self) -> bool {
         matches!(
             self,
-            Self::Anthropic | Self::Google | Self::Mistral | Self::Synthetic
+            Self::Anthropic | Self::Google | Self::Mistral | Self::Synthetic | Self::GithubCopilot
         )
     }
 
@@ -88,6 +94,9 @@ impl ProviderKind {
             Self::Synthetic => {
                 Some("Reasoning effort support (low/medium/high), open-weight models")
             }
+            Self::GithubCopilot => {
+                Some("GitHub Copilot proxy — Claude, GPT, Gemini models via OAuth")
+            }
             _ => None,
         }
     }
@@ -97,7 +106,7 @@ impl ProviderKind {
             Self::Anthropic => ModelFamily::Claude,
             Self::OpenAi => ModelFamily::Gpt,
             Self::Google => ModelFamily::Gemini,
-            Self::Ollama => ModelFamily::Generic,
+            Self::Ollama | Self::GithubCopilot => ModelFamily::Generic,
             Self::Mistral => ModelFamily::Generic,
             Self::Zai | Self::ZaiCodingPlan => ModelFamily::Glm,
             Self::Synthetic => ModelFamily::Synthetic,
@@ -105,13 +114,14 @@ impl ProviderKind {
     }
 
     pub const fn accepts_arbitrary_models(self) -> bool {
-        matches!(self, Self::Ollama | Self::Google)
+        matches!(self, Self::Ollama | Self::Google | Self::GithubCopilot)
     }
 
     pub fn create(self, timeouts: Timeouts) -> Result<Box<dyn Provider>, AgentError> {
         match self {
             Self::Anthropic => Ok(Box::new(Anthropic::new(timeouts)?)),
             Self::OpenAi => Ok(Box::new(OpenAi::new(timeouts)?)),
+            Self::GithubCopilot => Ok(Box::new(GithubCopilot::new(timeouts)?)),
             Self::Google => Ok(Box::new(Google::new(timeouts)?)),
             Self::Ollama => Ok(Box::new(Ollama::new(timeouts)?)),
             Self::Mistral => Ok(Box::new(Mistral::new(timeouts)?)),

--- a/maki-providers/src/providers/github_copilot/auth.rs
+++ b/maki-providers/src/providers/github_copilot/auth.rs
@@ -1,0 +1,407 @@
+use std::env;
+use std::time::Duration;
+use std::{io, thread};
+
+use isahc::ReadResponseExt;
+use isahc::config::Configurable;
+use maki_storage::DataDir;
+use maki_storage::auth::{OAuthTokens, delete_tokens, load_tokens, save_tokens};
+use serde::Deserialize;
+use tracing::{debug, error, warn};
+
+use crate::AgentError;
+use crate::providers::ResolvedAuth;
+
+pub(crate) const PROVIDER: &str = "github-copilot";
+const CLIENT_ID: &str = "Iv1.b507a08c87ecfe98";
+const DEFAULT_DOMAIN: &str = "github.com";
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const POLL_SAFETY_MARGIN: Duration = Duration::from_secs(5);
+const POLL_TIMEOUT: Duration = Duration::from_secs(300);
+const TOKEN_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(30);
+
+const COPILOT_HEADERS: [(&str, &str); 4] = [
+    ("User-Agent", "GitHubCopilotChat/0.35.0"),
+    ("Editor-Version", "vscode/1.107.0"),
+    ("Editor-Plugin-Version", "copilot-chat/0.35.0"),
+    ("Copilot-Integration-Id", "vscode-chat"),
+];
+
+fn http_client(timeout: Duration) -> Result<isahc::HttpClient, AgentError> {
+    isahc::HttpClient::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(timeout)
+        .build()
+        .map_err(|e| AgentError::Config {
+            message: format!("http client: {e}"),
+        })
+}
+
+#[derive(Deserialize)]
+struct DeviceCodeResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    interval: u64,
+    #[serde(default)]
+    #[allow(dead_code)]
+    expires_in: Option<u64>,
+}
+
+#[derive(Deserialize)]
+struct CopilotTokenResponse {
+    token: String,
+    expires_at: u64,
+}
+
+fn request_device_code(domain: &str) -> Result<DeviceCodeResponse, AgentError> {
+    let client = http_client(TOKEN_EXCHANGE_TIMEOUT)?;
+    let body = format!(
+        "client_id={}&scope=read:user",
+        crate::providers::urlenc(CLIENT_ID),
+    );
+
+    let request = isahc::Request::builder()
+        .method("POST")
+        .uri(format!("https://{domain}/login/device/code"))
+        .header("content-type", "application/x-www-form-urlencoded")
+        .header("accept", "application/json")
+        .body(body.into_bytes())?;
+
+    let mut resp = client.send(request).map_err(|e| AgentError::Config {
+        message: format!("device code request: {e}"),
+    })?;
+
+    if resp.status().as_u16() != 200 {
+        let body_text = resp.text().unwrap_or_else(|_| "unknown error".into());
+        return Err(AgentError::Config {
+            message: format!(
+                "device code request failed ({}): {body_text}",
+                resp.status()
+            ),
+        });
+    }
+
+    let body_text = resp.text()?;
+    serde_json::from_str(&body_text).map_err(Into::into)
+}
+
+fn poll_for_access_token(
+    domain: &str,
+    device_code: &DeviceCodeResponse,
+) -> Result<String, AgentError> {
+    let client = http_client(POLL_TIMEOUT)?;
+    let interval = Duration::from_secs(device_code.interval.max(5)) + POLL_SAFETY_MARGIN;
+    let deadline = std::time::Instant::now() + POLL_TIMEOUT;
+
+    let body = format!(
+        "client_id={}&device_code={}&grant_type=urn:ietf:params:oauth:grant-type:device_code",
+        crate::providers::urlenc(CLIENT_ID),
+        crate::providers::urlenc(&device_code.device_code),
+    );
+
+    loop {
+        if std::time::Instant::now() > deadline {
+            return Err(AgentError::Config {
+                message: "device authorization timed out".into(),
+            });
+        }
+
+        thread::sleep(interval);
+
+        let request = isahc::Request::builder()
+            .method("POST")
+            .uri(format!("https://{domain}/login/oauth/access_token"))
+            .header("content-type", "application/x-www-form-urlencoded")
+            .header("accept", "application/json")
+            .body(body.as_bytes().to_vec())?;
+
+        let mut resp = client.send(request).map_err(|e| AgentError::Config {
+            message: format!("access token poll: {e}"),
+        })?;
+
+        let status = resp.status().as_u16();
+        let body_text = resp.text().unwrap_or_else(|_| String::new());
+
+        let parsed: serde_json::Value = match serde_json::from_str(&body_text) {
+            Ok(v) => v,
+            Err(e) => {
+                if status != 200 {
+                    return Err(AgentError::Config {
+                        message: format!("access token poll failed ({status}): {body_text}"),
+                    });
+                }
+                return Err(AgentError::Config {
+                    message: format!("failed to parse access token response: {e}"),
+                });
+            }
+        };
+
+        if let Some(error_type) = parsed.get("error").and_then(|v| v.as_str()) {
+            match error_type {
+                "authorization_pending" => continue,
+                "slow_down" => {
+                    thread::sleep(Duration::from_secs(5));
+                    continue;
+                }
+                _ => {
+                    return Err(AgentError::Config {
+                        message: format!("access token poll failed: {body_text}"),
+                    });
+                }
+            }
+        }
+
+        let access_token = parsed["access_token"]
+            .as_str()
+            .ok_or_else(|| AgentError::Config {
+                message: format!("access token response missing access_token: {body_text}"),
+            })?;
+        return Ok(access_token.to_string());
+    }
+}
+
+fn exchange_copilot_token(
+    github_access_token: &str,
+    domain: &str,
+) -> Result<CopilotTokenResponse, AgentError> {
+    let client = http_client(TOKEN_EXCHANGE_TIMEOUT)?;
+    let url = format!("https://api.{domain}/copilot_internal/v2/token");
+
+    let mut builder = isahc::Request::builder()
+        .method("GET")
+        .uri(&url)
+        .header("authorization", format!("token {github_access_token}"));
+    for (key, value) in &COPILOT_HEADERS {
+        builder = builder.header(*key, *value);
+    }
+    let request = builder.body(())?;
+
+    let mut resp = client.send(request).map_err(|e| AgentError::Config {
+        message: format!("copilot token exchange: {e}"),
+    })?;
+
+    if resp.status().as_u16() != 200 {
+        let body_text = resp.text().unwrap_or_else(|_| "unknown error".into());
+        return Err(AgentError::Config {
+            message: format!(
+                "copilot token exchange failed ({}): {body_text}",
+                resp.status()
+            ),
+        });
+    }
+
+    let body_text = resp.text()?;
+    serde_json::from_str(&body_text).map_err(|e| AgentError::Config {
+        message: format!("failed to parse copilot token: {e}"),
+    })
+}
+
+pub(crate) fn parse_base_url_from_token(token: &str) -> Option<String> {
+    for part in token.split(';') {
+        if let Some(proxy_ep) = part.strip_prefix("proxy-ep=") {
+            let host = proxy_ep.trim();
+            let api_host = if host.starts_with("proxy.") {
+                host.replacen("proxy.", "api.", 1)
+            } else {
+                format!("api.{host}")
+            };
+            return Some(format!("https://{api_host}"));
+        }
+    }
+    None
+}
+
+fn enable_model(copilot_token: &str, model_id: &str, base_url: &str) -> Result<(), AgentError> {
+    let client = http_client(TOKEN_EXCHANGE_TIMEOUT)?;
+    let url = format!("{base_url}/models/{model_id}/policy");
+    let body = serde_json::json!({"state": "enabled"});
+    let json_body = serde_json::to_vec(&body)?;
+
+    let mut builder = isahc::Request::builder()
+        .method("POST")
+        .uri(&url)
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {copilot_token}"));
+    for (key, value) in &COPILOT_HEADERS {
+        builder = builder.header(*key, *value);
+    }
+    let request = builder.body(json_body)?;
+
+    let mut resp = client.send(request).map_err(|e| {
+        warn!(model = model_id, error = %e, "failed to enable model");
+        e
+    })?;
+    let status = resp.status().as_u16();
+    if status != 200 {
+        let body_text = resp.text().unwrap_or_default();
+        warn!(model = model_id, status, body = %body_text, "model policy enable failed");
+    }
+    Ok(())
+}
+
+pub(crate) fn build_resolved_auth(copilot_token: &str, base_url: Option<String>) -> ResolvedAuth {
+    let mut headers = vec![("authorization".into(), format!("Bearer {copilot_token}"))];
+    for (key, value) in &COPILOT_HEADERS {
+        headers.push(((*key).into(), (*value).into()));
+    }
+    ResolvedAuth { base_url, headers }
+}
+
+pub fn resolve(dir: &DataDir) -> Result<ResolvedAuth, AgentError> {
+    if let Some(tokens) = load_tokens(dir, PROVIDER) {
+        if !tokens.is_expired() {
+            debug!("using Copilot OAuth authentication");
+            let base_url = parse_base_url_from_token(&tokens.access).or_else(|| {
+                tokens
+                    .account_id
+                    .as_ref()
+                    .map(|d| format!("https://api.{d}"))
+            });
+            return Ok(build_resolved_auth(&tokens.access, base_url));
+        }
+        match refresh_tokens(&tokens) {
+            Ok(fresh) => {
+                save_tokens(dir, PROVIDER, &fresh)?;
+                debug!("using Copilot OAuth authentication (refreshed)");
+                let base_url = parse_base_url_from_token(&fresh.access).or_else(|| {
+                    fresh
+                        .account_id
+                        .as_ref()
+                        .map(|d| format!("https://api.{d}"))
+                });
+                return Ok(build_resolved_auth(&fresh.access, base_url));
+            }
+            Err(e) => {
+                warn!(error = %e, "Copilot token refresh failed, clearing stale tokens");
+                delete_tokens(dir, PROVIDER).ok();
+            }
+        }
+    }
+
+    for env_var in ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"] {
+        if let Ok(token) = env::var(env_var) {
+            debug!(
+                env = env_var,
+                "using GitHub token for Copilot authentication"
+            );
+            let exchange = exchange_copilot_token(&token, DEFAULT_DOMAIN)?;
+            let base_url = parse_base_url_from_token(&exchange.token);
+            return Ok(build_resolved_auth(&exchange.token, base_url));
+        }
+    }
+
+    Err(AgentError::Config {
+        message:
+            "not authenticated, run `maki auth login github-copilot` or set COPILOT_GITHUB_TOKEN"
+                .into(),
+    })
+}
+
+pub fn login(dir: &DataDir) -> Result<(), AgentError> {
+    println!("Authenticate with GitHub for Copilot access.\n");
+    println!("For enterprise GitHub, enter your domain (e.g. github.example.com).");
+    println!("Press Enter for github.com:");
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    let domain = input.trim();
+    let domain = if domain.is_empty() {
+        DEFAULT_DOMAIN
+    } else {
+        domain
+    };
+
+    let device = request_device_code(domain)?;
+
+    println!(
+        "\nOpen this URL in your browser:\n\n  {}\n",
+        device.verification_uri
+    );
+    println!("Enter code: {}\n", device.user_code);
+    println!("Waiting for authorization...");
+
+    let github_token = poll_for_access_token(domain, &device).map_err(|e| {
+        error!(error = %e, "GitHub device authorization failed");
+        e
+    })?;
+
+    let copilot = exchange_copilot_token(&github_token, domain).map_err(|e| {
+        error!(error = %e, "Copilot token exchange failed");
+        e
+    })?;
+
+    let base_url = parse_base_url_from_token(&copilot.token)
+        .unwrap_or_else(|| format!("https://api.{domain}"));
+
+    let all_models = crate::providers::github_copilot::models();
+    for entry in all_models {
+        for &model_id in entry.prefixes {
+            enable_model(&copilot.token, model_id, &base_url).ok();
+        }
+    }
+
+    let expires = copilot.expires_at.saturating_sub(300) * 1000;
+    let tokens = OAuthTokens {
+        access: copilot.token,
+        refresh: github_token,
+        expires,
+        account_id: Some(domain.to_string()),
+    };
+    save_tokens(dir, PROVIDER, &tokens)?;
+    println!("Authenticated successfully as GitHub Copilot.");
+    Ok(())
+}
+
+pub fn logout(dir: &DataDir) -> Result<(), AgentError> {
+    if delete_tokens(dir, PROVIDER)? {
+        println!("Logged out of GitHub Copilot.");
+    } else {
+        println!("Not currently logged in to GitHub Copilot.");
+    }
+    Ok(())
+}
+
+pub(crate) fn refresh_tokens(tokens: &OAuthTokens) -> Result<OAuthTokens, AgentError> {
+    let domain = tokens.account_id.as_deref().unwrap_or(DEFAULT_DOMAIN);
+    let copilot = exchange_copilot_token(&tokens.refresh, domain)?;
+    let expires = copilot.expires_at.saturating_sub(300) * 1000;
+    Ok(OAuthTokens {
+        access: copilot.token,
+        refresh: tokens.refresh.clone(),
+        expires,
+        account_id: tokens.account_id.clone(),
+    })
+}
+
+pub(crate) fn is_oauth(dir: &DataDir) -> bool {
+    load_tokens(dir, PROVIDER).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_base_url_from_proxy_ep() {
+        let token = "tid=abc;exp=123;proxy-ep=proxy.individual.githubcopilot.com;sku=monthly";
+        assert_eq!(
+            parse_base_url_from_token(token),
+            Some("https://api.individual.githubcopilot.com".into())
+        );
+    }
+
+    #[test]
+    fn parse_base_url_no_proxy_ep() {
+        let token = "tid=abc;exp=123;sku=monthly";
+        assert_eq!(parse_base_url_from_token(token), None);
+    }
+
+    #[test]
+    fn parse_base_url_enterprise_proxy() {
+        let token = "tid=abc;exp=123;proxy-ep=proxy.github.myenterprise.com;sku=enterprise";
+        assert_eq!(
+            parse_base_url_from_token(token),
+            Some("https://api.github.myenterprise.com".into())
+        );
+    }
+}

--- a/maki-providers/src/providers/github_copilot/mod.rs
+++ b/maki-providers/src/providers/github_copilot/mod.rs
@@ -1,0 +1,777 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use flume::Sender;
+use futures_lite::io::{AsyncBufReadExt, BufReader};
+use isahc::{AsyncReadResponseExt, Request};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tracing::{debug, warn};
+
+use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
+use crate::provider::{BoxFuture, Provider};
+use crate::providers::openai_compat::OpenAiCompatProvider;
+use crate::{
+    AgentError, ContentBlock, Message, ProviderEvent, Role, StopReason, StreamResponse,
+    ThinkingConfig, TokenUsage,
+};
+
+use super::ResolvedAuth;
+pub mod auth;
+
+const DEFAULT_BASE_URL: &str = "https://api.individual.githubcopilot.com";
+const API_VERSION: &str = "2023-06-01";
+const BETA_ADVANCED_TOOL_USE: &str = "advanced-tool-use-2025-11-20";
+
+static COMPAT_CONFIG: super::openai_compat::OpenAiCompatConfig =
+    super::openai_compat::OpenAiCompatConfig {
+        api_key_env: "COPILOT_GITHUB_TOKEN",
+        base_url: DEFAULT_BASE_URL,
+        max_tokens_field: "max_completion_tokens",
+        include_stream_usage: true,
+        provider_name: "GitHub Copilot",
+    };
+
+fn is_claude_model(model_id: &str) -> bool {
+    model_id.starts_with("claude-")
+}
+
+fn is_codex_model(model_id: &str) -> bool {
+    model_id.contains("-codex") || model_id.starts_with("gpt-5.4")
+}
+
+pub(crate) fn models() -> &'static [ModelEntry] {
+    &[
+        ModelEntry {
+            prefixes: &["claude-haiku-4.5", "claude-haiku-4-5"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Claude,
+            default: true,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 64000,
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &[
+                "claude-sonnet-4",
+                "claude-sonnet-4.5",
+                "claude-sonnet-4-5",
+                "claude-sonnet-4-6",
+            ],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Claude,
+            default: true,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 64000,
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["claude-opus-4.5", "claude-opus-4-5", "claude-opus-4-6"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Claude,
+            default: true,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 64000,
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-4o"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Gpt,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 16384,
+            context_window: 128_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-4.1-mini"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Gpt,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 65536,
+            context_window: 1_047_576,
+        },
+        ModelEntry {
+            prefixes: &["gpt-4.1"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Gpt,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 32768,
+            context_window: 1_047_576,
+        },
+        ModelEntry {
+            prefixes: &["o4-mini"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Gpt,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 100_000,
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["o3"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Gpt,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 100_000,
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.1-codex-mini"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Gpt,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 128_000,
+            context_window: 400_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.1-codex"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Gpt,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 128_000,
+            context_window: 400_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.2-codex", "gpt-5.3-codex"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Gpt,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 128_000,
+            context_window: 400_000,
+        },
+        ModelEntry {
+            prefixes: &["gemini-2.5-pro"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Gemini,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 65536,
+            context_window: 1_048_576,
+        },
+        ModelEntry {
+            prefixes: &["gemini-3-flash-preview"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Gemini,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 65536,
+            context_window: 1_048_576,
+        },
+    ]
+}
+
+pub struct GithubCopilot {
+    compat: OpenAiCompatProvider,
+    auth: Arc<Mutex<ResolvedAuth>>,
+    storage: Option<maki_storage::DataDir>,
+    stream_timeout: Duration,
+}
+
+impl GithubCopilot {
+    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
+        let storage = maki_storage::DataDir::resolve()?;
+        let resolved = auth::resolve(&storage)?;
+        let compat = OpenAiCompatProvider::new(&COMPAT_CONFIG, timeouts);
+        Ok(Self {
+            compat,
+            auth: Arc::new(Mutex::new(resolved)),
+            storage: Some(storage),
+            stream_timeout: timeouts.stream,
+        })
+    }
+
+    fn current_auth(&self) -> ResolvedAuth {
+        self.auth.lock().unwrap().clone()
+    }
+
+    fn is_oauth(&self) -> bool {
+        self.storage.as_ref().is_some_and(auth::is_oauth)
+    }
+
+    async fn refresh_oauth(&self) -> Result<(), AgentError> {
+        let storage = self.storage.clone().ok_or_else(|| AgentError::Config {
+            message: "OAuth refresh not available for externally-managed auth".into(),
+        })?;
+        let resolved = smol::unblock(move || {
+            let tokens =
+                maki_storage::auth::load_tokens(&storage, auth::PROVIDER).ok_or_else(|| {
+                    AgentError::Api {
+                        status: 401,
+                        message: "Copilot OAuth tokens not found on disk".into(),
+                    }
+                })?;
+            match auth::refresh_tokens(&tokens) {
+                Ok(fresh) => {
+                    let base_url = auth::parse_base_url_from_token(&fresh.access).or_else(|| {
+                        fresh
+                            .account_id
+                            .as_ref()
+                            .map(|d| format!("https://api.{d}"))
+                    });
+                    maki_storage::auth::save_tokens(&storage, auth::PROVIDER, &fresh)?;
+                    Ok(auth::build_resolved_auth(&fresh.access, base_url))
+                }
+                Err(e) => {
+                    warn!(error = %e, "Copilot token refresh failed, clearing stale tokens");
+                    let _ = maki_storage::auth::delete_tokens(&storage, auth::PROVIDER);
+                    Err(e)
+                }
+            }
+        })
+        .await?;
+        *self.auth.lock().unwrap() = resolved;
+        debug!("refreshed Copilot OAuth token");
+        Ok(())
+    }
+
+    async fn with_oauth_retry<T, F, Fut>(&self, f: F) -> Result<T, AgentError>
+    where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = Result<T, AgentError>>,
+    {
+        let result = f().await;
+        if self.is_oauth()
+            && matches!(&result, Err(e) if e.is_auth_error())
+            && self.refresh_oauth().await.is_ok()
+        {
+            return f().await;
+        }
+        result
+    }
+
+    fn dynamic_headers(&self, messages: &[Message]) -> Vec<(String, String)> {
+        let mut headers = Vec::new();
+        let initiator = if matches!(messages.last(), Some(m) if matches!(m.role, Role::User)) {
+            "user"
+        } else {
+            "agent"
+        };
+        headers.push(("X-Initiator".into(), initiator.into()));
+        headers.push(("Openai-Intent".into(), "conversation-edits".into()));
+        let has_images = messages.iter().any(|m| {
+            m.content
+                .iter()
+                .any(|b| matches!(b, ContentBlock::Image { .. }))
+        });
+        if has_images {
+            headers.push(("Copilot-Vision-Request".into(), "true".into()));
+        }
+        headers
+    }
+
+    async fn stream_claude(
+        &self,
+        model: &Model,
+        messages: &[Message],
+        system: &str,
+        tools: &Value,
+        event_tx: &Sender<ProviderEvent>,
+        thinking: ThinkingConfig,
+    ) -> Result<StreamResponse, AgentError> {
+        let auth = self.current_auth();
+        let base_url = auth.base_url.as_deref().unwrap_or(DEFAULT_BASE_URL);
+
+        let wire_messages = build_anthropic_wire_messages(messages);
+        let wire_tools = build_anthropic_wire_tools(tools);
+        let system_block =
+            json!({"type": "text", "text": system, "cache_control": {"type": "ephemeral"}});
+        let mut body = json!({
+            "model": model.id,
+            "max_tokens": model.max_output_tokens,
+            "system": [system_block],
+            "messages": wire_messages,
+            "tools": wire_tools,
+            "stream": true,
+        });
+        thinking.apply_to_body(&mut body);
+
+        let json_body = serde_json::to_vec(&body)?;
+        let url = format!("{base_url}/v1/messages");
+        let mut builder = Request::builder()
+            .method("POST")
+            .uri(&url)
+            .header("content-type", "application/json")
+            .header("anthropic-version", API_VERSION)
+            .header("anthropic-beta", BETA_ADVANCED_TOOL_USE);
+        for (key, value) in &auth.headers {
+            builder = builder.header(key.as_str(), value.as_str());
+        }
+        for (key, value) in self.dynamic_headers(messages) {
+            builder = builder.header(key.as_str(), value.as_str());
+        }
+        let request = builder.body(json_body)?;
+
+        debug!(model = %model.id, provider = "Copilot/Anthropic", "sending API request");
+        let response = self.compat.client().send_async(request).await?;
+        let status = response.status().as_u16();
+        if status == 200 {
+            parse_anthropic_sse(response, event_tx, self.stream_timeout).await
+        } else {
+            Err(AgentError::from_response(response).await)
+        }
+    }
+
+    async fn stream_responses(
+        &self,
+        model: &Model,
+        messages: &[Message],
+        system: &str,
+        tools: &Value,
+        event_tx: &Sender<ProviderEvent>,
+    ) -> Result<StreamResponse, AgentError> {
+        let auth = self.current_auth();
+        let base_url = auth.base_url.as_deref().unwrap_or(DEFAULT_BASE_URL);
+        let auth_with_base = ResolvedAuth {
+            base_url: Some(base_url.into()),
+            headers: auth.headers.clone(),
+        };
+        let body = super::openai::responses::build_body(model, messages, system, tools);
+        super::openai::responses::do_stream(
+            self.compat.client(),
+            model,
+            &body,
+            event_tx,
+            &auth_with_base,
+            self.stream_timeout,
+        )
+        .await
+    }
+
+    async fn stream_completions(
+        &self,
+        model: &Model,
+        messages: &[Message],
+        system: &str,
+        tools: &Value,
+        event_tx: &Sender<ProviderEvent>,
+    ) -> Result<StreamResponse, AgentError> {
+        let body = self.compat.build_body(model, messages, system, tools);
+        let mut auth = self.current_auth();
+        if auth.base_url.is_none() {
+            auth.base_url = Some(DEFAULT_BASE_URL.into());
+        }
+        let extra_headers = self.dynamic_headers(messages);
+        self.compat
+            .do_stream(model, &extra_headers, &body, event_tx, &auth)
+            .await
+    }
+
+    async fn do_list_models(&self) -> Result<Vec<String>, AgentError> {
+        let auth = self.current_auth();
+        let base_url = auth.base_url.as_deref().unwrap_or(DEFAULT_BASE_URL);
+        let url = format!("{base_url}/models");
+
+        let mut builder = Request::builder().method("GET").uri(&url);
+        for (key, value) in &auth.headers {
+            builder = builder.header(key.as_str(), value.as_str());
+        }
+        let request = builder.body(())?;
+
+        let mut response = self.compat.client().send_async(request).await?;
+        if response.status().as_u16() != 200 {
+            return Err(AgentError::from_response(response).await);
+        }
+
+        let body: Value = serde_json::from_str(&response.text().await?)?;
+        let mut model_ids: Vec<String> = body["data"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|m| {
+                        let policy_state = m
+                            .get("policy")
+                            .and_then(|p| p.get("state"))
+                            .and_then(|s| s.as_str())
+                            .unwrap_or("enabled");
+                        if policy_state != "enabled" {
+                            return None;
+                        }
+                        m["id"].as_str().map(String::from)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        model_ids.sort();
+        Ok(model_ids)
+    }
+}
+
+impl Provider for GithubCopilot {
+    fn stream_message<'a>(
+        &'a self,
+        model: &'a Model,
+        messages: &'a [Message],
+        system: &'a str,
+        tools: &'a Value,
+        event_tx: &'a Sender<ProviderEvent>,
+        thinking: ThinkingConfig,
+        _session_id: Option<&str>,
+    ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
+        Box::pin(async move {
+            if is_claude_model(&model.id) {
+                self.with_oauth_retry(|| {
+                    self.stream_claude(model, messages, system, tools, event_tx, thinking)
+                })
+                .await
+            } else if is_codex_model(&model.id) {
+                self.with_oauth_retry(|| {
+                    self.stream_responses(model, messages, system, tools, event_tx)
+                })
+                .await
+            } else {
+                self.with_oauth_retry(|| {
+                    self.stream_completions(model, messages, system, tools, event_tx)
+                })
+                .await
+            }
+        })
+    }
+
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+        Box::pin(async {
+            match self.do_list_models().await {
+                Ok(models) => Ok(models),
+                Err(e) => {
+                    warn!(error = %e, "Copilot list models failed, using static fallback");
+                    Ok(models()
+                        .iter()
+                        .flat_map(|e| e.prefixes.iter())
+                        .map(|&s| s.to_string())
+                        .collect())
+                }
+            }
+        })
+    }
+
+    fn refresh_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
+        Box::pin(async {
+            if self.is_oauth() {
+                self.refresh_oauth().await
+            } else {
+                Ok(())
+            }
+        })
+    }
+
+    fn reload_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
+        Box::pin(async {
+            let Some(storage) = self.storage.clone() else {
+                return Ok(());
+            };
+            let resolved = smol::unblock(move || auth::resolve(&storage)).await?;
+            *self.auth.lock().unwrap() = resolved;
+            debug!("reloaded Copilot auth from storage");
+            Ok(())
+        })
+    }
+}
+
+// Anthropic wire format helpers for Copilot's Claude proxy
+
+#[derive(serde::Serialize)]
+#[allow(dead_code)]
+struct AnthropicSystemBlock<'a> {
+    r#type: &'static str,
+    text: &'a str,
+    cache_control: serde_json::Value,
+}
+
+#[derive(serde::Serialize)]
+struct AnthropicWireContentBlock<'a> {
+    #[serde(flatten)]
+    inner: &'a ContentBlock,
+}
+
+#[derive(serde::Serialize)]
+struct AnthropicWireMessage<'a> {
+    role: &'a Role,
+    content: Vec<AnthropicWireContentBlock<'a>>,
+}
+
+fn build_anthropic_wire_messages(messages: &[Message]) -> Vec<AnthropicWireMessage<'_>> {
+    messages
+        .iter()
+        .map(|msg| AnthropicWireMessage {
+            role: &msg.role,
+            content: msg
+                .content
+                .iter()
+                .map(|block| AnthropicWireContentBlock { inner: block })
+                .collect(),
+        })
+        .collect()
+}
+
+fn build_anthropic_wire_tools(tools: &Value) -> Value {
+    let Some(arr) = tools.as_array() else {
+        return tools.clone();
+    };
+    let mut out: Vec<Value> = arr
+        .iter()
+        .map(|tool| {
+            let mut tool = tool.clone();
+            tool.as_object_mut().map(|t| t.remove("input_examples"));
+            tool
+        })
+        .collect();
+    if let Some(last) = out.last_mut() {
+        last["cache_control"] = json!({"type": "ephemeral"});
+    }
+    Value::Array(out)
+}
+
+#[derive(Deserialize)]
+struct Usage {
+    #[serde(default)]
+    input_tokens: u32,
+    #[serde(default)]
+    output_tokens: u32,
+    #[serde(default)]
+    cache_creation_input_tokens: u32,
+    #[serde(default)]
+    cache_read_input_tokens: u32,
+}
+
+impl From<Usage> for TokenUsage {
+    fn from(u: Usage) -> Self {
+        Self {
+            input: u.input_tokens,
+            output: u.output_tokens,
+            cache_creation: u.cache_creation_input_tokens,
+            cache_read: u.cache_read_input_tokens,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct MessagePayload {
+    #[serde(default)]
+    usage: Option<Usage>,
+}
+
+#[derive(Deserialize)]
+struct MessageStartEvent {
+    message: MessagePayload,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum SseContentBlock {
+    Text,
+    Thinking,
+    RedactedThinking { data: String },
+    ToolUse { id: String, name: String },
+}
+
+#[derive(Deserialize)]
+struct ContentBlockStartEvent {
+    index: usize,
+    content_block: SseContentBlock,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+enum Delta {
+    #[serde(rename = "text_delta")]
+    Text { text: String },
+    #[serde(rename = "thinking_delta")]
+    Thinking { thinking: String },
+    #[serde(rename = "signature_delta")]
+    Signature { signature: String },
+    #[serde(rename = "input_json_delta")]
+    InputJson { partial_json: String },
+}
+
+#[derive(Deserialize)]
+struct ContentBlockDeltaEvent {
+    index: usize,
+    delta: Delta,
+}
+
+#[derive(Deserialize)]
+struct MessageDeltaPayload {
+    #[serde(default)]
+    stop_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct MessageDeltaEvent {
+    #[serde(default)]
+    delta: Option<MessageDeltaPayload>,
+    #[serde(default)]
+    usage: Option<Usage>,
+}
+
+async fn parse_anthropic_sse(
+    response: isahc::Response<isahc::AsyncBody>,
+    event_tx: &Sender<ProviderEvent>,
+    stream_timeout: Duration,
+) -> Result<StreamResponse, AgentError> {
+    use std::time::Instant;
+
+    let reader = BufReader::new(response.into_body());
+    let mut lines = reader.lines();
+
+    let mut content_blocks: Vec<ContentBlock> = Vec::new();
+    let mut current_tool_json = String::new();
+    let mut current_event = String::new();
+    let mut current_block_idx: usize = 0;
+    let mut usage = TokenUsage::default();
+    let mut stop_reason: Option<StopReason> = None;
+    let mut deadline = Instant::now() + stream_timeout;
+
+    while let Some(line) = super::next_sse_line(&mut lines, &mut deadline, stream_timeout).await? {
+        if let Some(event_type) = line.strip_prefix("event: ") {
+            current_event = event_type.to_string();
+            continue;
+        }
+
+        let data = match line.strip_prefix("data: ") {
+            Some(d) => d,
+            None => continue,
+        };
+
+        match current_event.as_str() {
+            "message_start" => {
+                if let Ok(ev) = serde_json::from_str::<MessageStartEvent>(data)
+                    && let Some(u) = ev.message.usage
+                {
+                    usage = TokenUsage::from(u);
+                }
+            }
+            "content_block_start" => match serde_json::from_str::<ContentBlockStartEvent>(data) {
+                Ok(ev) => {
+                    current_block_idx = ev.index;
+                    match ev.content_block {
+                        SseContentBlock::Text => {
+                            content_blocks.push(ContentBlock::Text {
+                                text: String::new(),
+                            });
+                        }
+                        SseContentBlock::Thinking => {
+                            content_blocks.push(ContentBlock::Thinking {
+                                thinking: String::new(),
+                                signature: None,
+                            });
+                        }
+                        SseContentBlock::RedactedThinking { data } => {
+                            content_blocks.push(ContentBlock::RedactedThinking { data });
+                        }
+                        SseContentBlock::ToolUse { id, name } => {
+                            current_tool_json.clear();
+                            event_tx
+                                .send_async(ProviderEvent::ToolUseStart {
+                                    id: id.clone(),
+                                    name: name.clone(),
+                                })
+                                .await?;
+                            content_blocks.push(ContentBlock::ToolUse {
+                                id,
+                                name,
+                                input: Value::Null,
+                            });
+                        }
+                    }
+                }
+                Err(e) => warn!(error = %e, "failed to parse content_block_start"),
+            },
+            "content_block_delta" => match serde_json::from_str::<ContentBlockDeltaEvent>(data) {
+                Ok(ev) => {
+                    current_block_idx = ev.index;
+                    let block = content_blocks.get_mut(current_block_idx);
+                    match ev.delta {
+                        Delta::Text { text } => {
+                            if !text.is_empty() {
+                                if let Some(ContentBlock::Text { text: t }) = block {
+                                    t.push_str(&text);
+                                }
+                                event_tx
+                                    .send_async(ProviderEvent::TextDelta { text })
+                                    .await?;
+                            }
+                        }
+                        Delta::Thinking { thinking } => {
+                            if !thinking.is_empty() {
+                                if let Some(ContentBlock::Thinking { thinking: t, .. }) = block {
+                                    t.push_str(&thinking);
+                                }
+                                event_tx
+                                    .send_async(ProviderEvent::ThinkingDelta { text: thinking })
+                                    .await?;
+                            }
+                        }
+                        Delta::Signature { signature } => {
+                            if let Some(ContentBlock::Thinking { signature: sig, .. }) = block {
+                                *sig = Some(signature);
+                            }
+                        }
+                        Delta::InputJson { partial_json } => {
+                            current_tool_json.push_str(&partial_json);
+                        }
+                    }
+                }
+                Err(e) => warn!(error = %e, "failed to parse content_block_delta"),
+            },
+            "content_block_stop" => {
+                if let Some(ContentBlock::ToolUse { name, input, .. }) =
+                    content_blocks.get_mut(current_block_idx)
+                {
+                    *input = match serde_json::from_str(&current_tool_json) {
+                        Ok(v) => {
+                            debug!(tool = %name, json = %current_tool_json, "tool input JSON");
+                            v
+                        }
+                        Err(e) => {
+                            warn!(error = %e, json = %current_tool_json, "malformed tool JSON, falling back to {{}}");
+                            Value::Object(Default::default())
+                        }
+                    };
+                    current_tool_json.clear();
+                }
+            }
+            "message_delta" => {
+                if let Ok(ev) = serde_json::from_str::<MessageDeltaEvent>(data) {
+                    if let Some(u) = ev.usage {
+                        usage.output = u.output_tokens;
+                    }
+                    if let Some(d) = ev.delta {
+                        stop_reason = d
+                            .stop_reason
+                            .map(|s| StopReason::from_anthropic(&s))
+                            .or(stop_reason);
+                    }
+                }
+            }
+            "error" => {
+                if let Ok(ev) = serde_json::from_str::<super::SseErrorPayload>(data) {
+                    warn!(error_type = %ev.error.r#type, message = %ev.error.message, "SSE error event");
+                    return Err(ev.into_agent_error());
+                }
+                warn!(raw = %data, "unparseable SSE error event");
+                return Err(AgentError::Api {
+                    status: 400,
+                    message: data.to_string(),
+                });
+            }
+            "message_stop" => break,
+            _ => {}
+        }
+    }
+
+    Ok(StreamResponse {
+        message: Message {
+            role: Role::Assistant,
+            content: content_blocks,
+            ..Default::default()
+        },
+        usage,
+        stop_reason,
+    })
+}

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -9,6 +9,7 @@ use crate::AgentError;
 
 pub(crate) mod anthropic;
 pub mod dynamic;
+pub(crate) mod github_copilot;
 pub(crate) mod google;
 pub(crate) mod mistral;
 pub(crate) mod ollama;

--- a/maki-providers/src/providers/openai/mod.rs
+++ b/maki-providers/src/providers/openai/mod.rs
@@ -1,6 +1,6 @@
 pub mod auth;
 mod platform;
-mod responses;
+pub(crate) mod responses;
 
 pub use platform::OpenAi;
 

--- a/maki-providers/src/providers/openai/responses.rs
+++ b/maki-providers/src/providers/openai/responses.rs
@@ -13,7 +13,7 @@ use crate::{
 
 const RESPONSES_PATH: &str = "/responses";
 
-pub(crate) fn build_body(
+pub fn build_body(
     model: &crate::model::Model,
     messages: &[Message],
     system: &str,
@@ -35,7 +35,7 @@ pub(crate) fn build_body(
     body
 }
 
-pub(crate) fn convert_input(messages: &[Message]) -> Value {
+pub fn convert_input(messages: &[Message]) -> Value {
     let mut input = Vec::new();
 
     for msg in messages {
@@ -115,7 +115,7 @@ pub(crate) fn convert_input(messages: &[Message]) -> Value {
     Value::Array(input)
 }
 
-pub(crate) fn convert_tools(anthropic_tools: &Value) -> Value {
+pub fn convert_tools(anthropic_tools: &Value) -> Value {
     let Some(tools) = anthropic_tools.as_array() else {
         return json!([]);
     };
@@ -136,7 +136,7 @@ pub(crate) fn convert_tools(anthropic_tools: &Value) -> Value {
     )
 }
 
-pub(crate) async fn do_stream(
+pub async fn do_stream(
     client: &HttpClient,
     model: &crate::model::Model,
     body: &Value,
@@ -186,7 +186,7 @@ struct ToolAccumulator {
     arguments: String,
 }
 
-pub(crate) async fn parse_sse(
+pub async fn parse_sse(
     reader: impl AsyncBufRead + Unpin,
     event_tx: &Sender<ProviderEvent>,
     stream_timeout: Duration,

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -44,6 +44,20 @@ Defaults: claude-haiku-4-5 (weak), claude-sonnet-4-6 (medium), claude-opus-4-6 (
 
 Defaults: gpt-5.4-nano (weak), gpt-4.1 (medium), gpt-5.4 (strong)
 
+### GitHub Copilot
+
+- **Env var**: `COPILOT_GITHUB_TOKEN`
+- **API**: `https://api.individual.githubcopilot.com`
+- **Features**: GitHub Copilot proxy — Claude, GPT, Gemini models via OAuth
+
+| Tier | Models | Pricing (in/out per 1M tokens) | Context |
+|------|--------|-------------------------------|---------|
+| Weak | **claude-haiku-4.5, claude-haiku-4-5** (default), gpt-4o | $0.00 / $0.00 | 200K ctx / 64K out |
+| Medium | **claude-sonnet-4, claude-sonnet-4.5, claude-sonnet-4-5, claude-sonnet-4-6** (default), gpt-4.1-mini, gpt-4.1, o4-mini, gpt-5.1-codex-mini, gemini-2.5-pro, gemini-3-flash-preview | $0.00 / $0.00 | 200K ctx / 64K out |
+| Strong | **claude-opus-4.5, claude-opus-4-5, claude-opus-4-6** (default), o3, gpt-5.1-codex, gpt-5.2-codex, gpt-5.3-codex | $0.00 / $0.00 | 200K ctx / 64K out |
+
+Defaults: claude-haiku-4.5 (weak), claude-sonnet-4 (medium), claude-opus-4.5 (strong)
+
 ### Google
 
 - **Env var**: `GEMINI_API_KEY`
@@ -135,7 +149,7 @@ To add a custom provider or proxy, drop an executable script into `~/.maki/provi
 
 `resolve` is called each time a new agent spawns, so scripts should read tokens from disk instead of caching them in memory. That way auth changes from other processes get picked up.
 
-The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `ollama`, `mistral`, `zai`, `zai-coding-plan`, `synthetic`.
+The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `github-copilot`, `google`, `ollama`, `mistral`, `zai`, `zai-coding-plan`, `synthetic`.
 
 If your provider serves models not in the base catalog, add a `models` subcommand returning:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use tracing_subscriber::EnvFilter;
 
 use maki_providers::model::{Model, ModelTier};
 use maki_providers::provider::{ProviderKind, fetch_all_models};
-use maki_providers::{dynamic, openai_auth};
+use maki_providers::{dynamic, github_copilot_auth, openai_auth};
 use maki_storage::log::RotatingFileWriter;
 use maki_storage::model::{persist_model, read_model};
 use print::OutputFormat;
@@ -224,10 +224,12 @@ fn run() -> Result<()> {
             match action {
                 AuthAction::Login { provider } => match provider.as_str() {
                     "openai" => openai_auth::login(&storage)?,
+                    "github-copilot" => github_copilot_auth::login(&storage)?,
                     slug => dynamic::login(slug)?,
                 },
                 AuthAction::Logout { provider } => match provider.as_str() {
                     "openai" => openai_auth::logout(&storage)?,
+                    "github-copilot" => github_copilot_auth::logout(&storage)?,
                     slug => dynamic::logout(slug)?,
                 },
             }


### PR DESCRIPTION
So I was able to test this against(the free options):
- gpt-4
- gpt-5-mini
- claude-haiku-4.5

### Methodology for my tests

- Planning Mode Prompt: Please write a web scraper using a python uv script that calls duck duck go search and returns the first result.
- Let it plan, do a forced iteration where I ask it for more information or change something (this was done at random I'll clean that up in the future)
- New Context and implement after the forced iteration step
- Ask it to make a trivial modification in build mode once its complete
- Ask it to check prior art for uv (on gpt-4 I did this earlier cause it didn't know what uv was) to confirm our approach was sensible

### Notes 
1. It wasn't always clear to me on how to get every copilot option forwarded to whatever background provider was selected. 

     - I marked the provider as thinking-capable. But it wasn't super clear how to do that for every background model so right now its Anthropic only as that's the only one I could verify 100%.

2. Had a question around openai/mods. If you prefer instead of the method I used I could do a shared internal module for passing those response functions around.

3. Through the Anthropic Provider Claude has supportes_examples(inputs_examples at the anthropic call level) but Copilot yeets the request back, but examples-as-text fallback still works, so I just decided to rip this out right before it passes to copilot, didn't want to modify the existing functions for anthropic with branching code unnecessarily. 

5. I used a blocking method for the oauth waiting for login flow. This is probably fine but figured I'd note it.

6. Do we want to title it `github-copilot` in full like I did, or is `github` or `copilot` preferred?

7. The return from github's /models endpoint is ugly and might have some red herrings, it might be better to build a static list.


### Additional Things
Work was done by me and glp-5.1 in maki itself using OpenCode's go model set.

I looked at how pi was doing this as a primary reference. 

### Follow on work
- Both Gemini and Copilot operate on a request model over a token model. Something to add support for probably.