### PR TITLE
agent: tools: grep: update mtime cache for matched files

### DIFF
--- a/maki-agent/src/tools/grep.rs
+++ b/maki-agent/src/tools/grep.rs
@@ -57,6 +57,7 @@ impl Grep {
             .limit
             .map(|l| l.min(MAX_PER_CALL_LIMIT))
             .unwrap_or(search_limit);
+        let file_tracker = ctx.file_tracker.clone();
 
         smol::unblock(move || {
             let search_path = resolve_search_path(path.as_deref())?;
@@ -121,6 +122,7 @@ impl Grep {
                 let _ = searcher.search_path(&matcher, &path, &mut sink);
 
                 if !groups.is_empty() {
+                    file_tracker.record_read(&path);
                     let rel = path
                         .strip_prefix(base)
                         .unwrap_or(&path)


### PR DESCRIPTION
Files found by grep can now be edited without a separate read call. Previously only the read tool recorded file mtimes, so grep results required re-reading before edit/multiedit would work.

Fixes #101.