### PR TITLE
ui: show spinner for running tasks in /tasks picker

### DIFF
--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -28,7 +28,7 @@ use crate::components::file_picker::{FilePickerModal, FilePickerModalAction};
 use crate::components::help_modal::HelpModal;
 use crate::components::input::{InputAction, InputBox, Submission};
 use crate::components::keybindings::key;
-use crate::components::list_picker::{ListPicker, PickerAction};
+use crate::components::list_picker::{ListPicker, PickerAction, PickerItem};
 use crate::components::mcp_picker::{McpPicker, McpPickerAction};
 use crate::components::memory_modal::{MemoryEntry, MemoryModal, MemoryModalAction};
 use crate::components::model_picker::{ModelPicker, ModelPickerAction};
@@ -80,6 +80,28 @@ const AUTH_EXPIRED_MSG: &str =
 const FLASH_NO_PLAN: &str = "No plan file";
 const IMPLEMENT_MSG_PREFIX: &str = "Implement the plan";
 
+const TASK_DONE_DETAIL: &str = "✓ ";
+
+/// `Option<bool>` lets us distinguish the main chat (None, no status indicator)
+/// from subagents (Some, with spinner or checkmark).
+#[derive(Clone)]
+pub(super) struct TaskEntry {
+    name: String,
+    finished: Option<bool>,
+}
+
+impl PickerItem for TaskEntry {
+    fn label(&self) -> &str {
+        &self.name
+    }
+    fn detail(&self) -> Option<&str> {
+        matches!(self.finished, Some(true)).then_some(TASK_DONE_DETAIL)
+    }
+    fn is_spinning(&self) -> bool {
+        matches!(self.finished, Some(false))
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(super) enum PendingInput {
     #[default]
@@ -102,7 +124,7 @@ pub struct App {
     pub(super) chat_index: HashMap<String, usize>,
     pub(crate) input_box: InputBox,
     pub(super) command_palette: CommandPalette,
-    pub(super) task_picker: ListPicker<String>,
+    pub(super) task_picker: ListPicker<TaskEntry>,
     pub(super) task_picker_original: Option<usize>,
     pub(super) theme_picker: ThemePicker,
     pub(super) model_picker: ModelPicker,
@@ -324,9 +346,17 @@ impl App {
     }
 
     fn open_tasks(&mut self) {
-        let names: Vec<String> = self.chats.iter().map(|c| c.name.clone()).collect();
+        let entries: Vec<TaskEntry> = self
+            .chats
+            .iter()
+            .enumerate()
+            .map(|(i, c)| TaskEntry {
+                name: c.name.clone(),
+                finished: (i > 0).then_some(c.is_finished()),
+            })
+            .collect();
         self.task_picker_original = Some(self.active_chat);
-        self.task_picker.open(names, " Tasks ");
+        self.task_picker.open(entries, " Tasks ");
         self.task_picker.select(self.active_chat);
     }
 

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -233,6 +233,10 @@ impl Chat {
             .push(DisplayMessage::new(role, text.into()));
     }
 
+    pub fn is_finished(&self) -> bool {
+        self.finished
+    }
+
     pub fn update_tool_summary(&mut self, tool_id: &str, summary: &str) {
         self.messages_panel.update_tool_summary(tool_id, summary);
     }

--- a/maki-ui/src/components/list_picker.rs
+++ b/maki-ui/src/components/list_picker.rs
@@ -1,9 +1,10 @@
 //! Modal list picker with search. Supports immediate (`open`) or lazy loading
 //! (`open_loading` → `resolve`) where a spinner is shown until items arrive.
 
+use std::sync::OnceLock;
 use std::time::Instant;
 
-use crate::animation::spinner_frame;
+use crate::animation::{spinner_frame, spinner_str};
 use crate::components::Overlay;
 use crate::components::hint_line;
 use crate::components::is_ctrl;
@@ -28,6 +29,13 @@ const MAX_HEIGHT_PERCENT: u16 = 80;
 const SEARCH_ROW: u16 = 1;
 const DETAIL_RIGHT_PAD: u16 = 1;
 
+/// Spinners need a consistent time reference. Using a static epoch avoids
+/// passing Instant through every render call.
+fn animation_elapsed_ms() -> u128 {
+    static EPOCH: OnceLock<Instant> = OnceLock::new();
+    EPOCH.get_or_init(Instant::now).elapsed().as_millis()
+}
+
 pub trait PickerItem {
     fn label(&self) -> &str;
     fn detail(&self) -> Option<&str> {
@@ -35,6 +43,10 @@ pub trait PickerItem {
     }
     fn section(&self) -> Option<&str> {
         None
+    }
+    /// Shows a spinner in the detail slot when true.
+    fn is_spinning(&self) -> bool {
+        false
     }
 }
 
@@ -52,7 +64,7 @@ pub enum PickerAction<T> {
 }
 
 enum PickerState<T> {
-    Loading(Instant),
+    Loading,
     Ready(State<T>),
 }
 
@@ -60,14 +72,14 @@ impl<T> PickerState<T> {
     fn ready(&self) -> Option<&State<T>> {
         match self {
             Self::Ready(s) => Some(s),
-            Self::Loading(_) => None,
+            Self::Loading => None,
         }
     }
 
     fn ready_mut(&mut self) -> Option<&mut State<T>> {
         match self {
             Self::Ready(s) => Some(s),
-            Self::Loading(_) => None,
+            Self::Loading => None,
         }
     }
 }
@@ -262,7 +274,7 @@ impl<T: PickerItem> ListPicker<T> {
     pub fn open_loading(&mut self, title: &'static str) {
         self.generation += 1;
         self.title = title;
-        self.state = Some(PickerState::Loading(Instant::now()));
+        self.state = Some(PickerState::Loading);
     }
 
     pub fn resolve(&mut self, items: Vec<T>) {
@@ -338,7 +350,7 @@ impl<T: PickerItem> ListPicker<T> {
     }
 
     pub fn is_loading(&self) -> bool {
-        matches!(self.state, Some(PickerState::Loading(_)))
+        matches!(self.state, Some(PickerState::Loading))
     }
 
     pub fn contains(&self, pos: Position) -> bool {
@@ -351,7 +363,7 @@ impl<T: PickerItem> ListPicker<T> {
     pub fn handle_key(&mut self, key: KeyEvent) -> PickerAction<T> {
         match &self.state {
             None => return PickerAction::Close,
-            Some(PickerState::Loading(_)) => {
+            Some(PickerState::Loading) => {
                 if key::QUIT.matches(key) || key.code == KeyCode::Esc {
                     self.generation += 1;
                     self.state = None;
@@ -506,7 +518,7 @@ impl<T: PickerItem> ListPicker<T> {
         let footer_rows = if footer.is_some() { 1u16 } else { 0 };
         match self.state.as_mut() {
             None => Rect::default(),
-            Some(PickerState::Loading(started_at)) => {
+            Some(PickerState::Loading) => {
                 let modal = Modal {
                     title: self.title,
                     width_percent: MIN_WIDTH_PERCENT,
@@ -525,7 +537,7 @@ impl<T: PickerItem> ListPicker<T> {
                 let areas = Layout::vertical(constraints).split(inner);
                 let list_area = areas[0];
                 let search_area = areas[1];
-                let ch = spinner_frame(started_at.elapsed().as_millis());
+                let ch = spinner_frame(animation_elapsed_ms());
                 let line = Line::from(Span::styled(
                     format!("  {ch} {LOADING_LABEL}"),
                     theme::current().cmd_desc,
@@ -772,7 +784,12 @@ fn render_list<T: PickerItem>(
             Span::styled(sym, sty)
         });
         let label = format!("  {}", item.label());
-        let line = match item.detail() {
+        let detail: Option<&str> = if item.is_spinning() {
+            Some(spinner_str(animation_elapsed_ms()))
+        } else {
+            item.detail()
+        };
+        let line = match detail {
             Some(detail) => {
                 let label = truncate_label(&label, max_label_width(detail, area.width));
                 let pad = detail_padding(&label, detail, area.width);


### PR DESCRIPTION
The task picker now shows an animated spinner next to running subagents and a checkmark for completed ones. Added is_spinning() to the PickerItem trait so items can request spinner rendering. The picker owns the timing via an Instant stored in the Ready state.

Fixes #104 .