### PR TITLE
feat/github-copilot-provider

### DIFF
--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -24,6 +24,7 @@ Models are referenced as `provider/model_id`:
 anthropic/claude-sonnet-4-6
 openai/gpt-4.1
 zai/glm-4.7
+github-copilot/gpt-5.4
 ```
 
 If the model name is unique across providers, the prefix can be omitted."#;
@@ -141,6 +142,15 @@ fn build_sections() -> Vec<ProviderSection> {
                     entries: models_for_provider(kind),
                 });
             }
+            ProviderKind::GitHubCopilot => {
+                sections.push(ProviderSection {
+                    name: kind.display_name(),
+                    auth_line: "Device login flow (see below)".to_string(),
+                    urls: vec![],
+                    features: Some("Device OAuth flow, static model catalog"),
+                    entries: models_for_provider(kind),
+                });
+            }
             _ => {
                 sections.push(ProviderSection {
                     name: kind.display_name(),
@@ -223,11 +233,48 @@ fn write_model_table(out: &mut String, entries: &[ModelEntry]) {
 
 fn write_section(out: &mut String, section: &ProviderSection) {
     let _ = writeln!(out, "### {}\n", section.name);
+
+    // Special handling for GitHub Copilot device login
+    if section.name == "GitHub Copilot" {
+        let _ = writeln!(out, "- **Auth**: Device login flow");
+        let _ = writeln!(out);
+        let _ = writeln!(
+            out,
+            "Run `maki auth login github-copilot` to start the device flow. This opens a browser window where you authorize Maki to access your GitHub Copilot subscription. The process takes about 30 seconds. Once done, your tokens are stored securely and refreshed automatically."
+        );
+        let _ = writeln!(out);
+        let _ = writeln!(out, "#### V1 Limits");
+        let _ = writeln!(out);
+        let _ = writeln!(
+            out,
+            "This is a V1 implementation with the following limits:"
+        );
+        let _ = writeln!(
+            out,
+            "- Static model listing. New models must be added to Maki via code updates."
+        );
+        let _ = writeln!(
+            out,
+            "- No enterprise support. Only individual GitHub Copilot subscriptions work."
+        );
+        let _ = writeln!(
+            out,
+            "- No PAT or API key authentication. Only device login is supported."
+        );
+        let _ = writeln!(out);
+        if let Some(features) = section.features {
+            let _ = writeln!(out, "- **Features**: {features}");
+        }
+        let _ = writeln!(out);
+        write_model_table(out, section.entries);
+        return;
+    }
+
     let _ = writeln!(out, "- **Env var**: {}", section.auth_line);
 
     if section.urls.len() == 1 {
         let _ = writeln!(out, "- **API**: `{}`", section.urls[0]);
-    } else {
+    } else if !section.urls.is_empty() {
         let _ = writeln!(out, "- **API endpoints**:");
         for url in &section.urls {
             let _ = writeln!(out, "  - `{url}`");

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -13,6 +13,7 @@ pub use model::{
 };
 pub use providers::Timeouts;
 pub use providers::dynamic;
+pub use providers::github_copilot::auth as github_copilot_auth;
 pub use providers::openai::auth as openai_auth;
 pub use types::{
     ContentBlock, ImageMediaType, ImageSource, Message, ProviderEvent, Role, StopReason,

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -10,7 +10,9 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 use crate::provider::ProviderKind;
-use crate::providers::{anthropic, dynamic, google, mistral, ollama, openai, synthetic, zai};
+use crate::providers::{
+    anthropic, dynamic, github_copilot, google, mistral, ollama, openai, synthetic, zai,
+};
 
 const PER_MILLION: f64 = 1_000_000.0;
 
@@ -96,7 +98,7 @@ pub struct ModelEntry {
     pub context_window: u32,
 }
 
-fn lookup_entry<'a>(
+pub(crate) fn lookup_entry<'a>(
     entries: &'a [ModelEntry],
     model_id: &str,
 ) -> Result<&'a ModelEntry, ModelError> {
@@ -115,6 +117,7 @@ pub fn models_for_provider(provider: ProviderKind) -> &'static [ModelEntry] {
         ProviderKind::Google => google::models(),
         ProviderKind::Zai | ProviderKind::ZaiCodingPlan => zai::models(),
         ProviderKind::Synthetic => synthetic::models(),
+        ProviderKind::GitHubCopilot => github_copilot::models(),
     }
 }
 
@@ -134,16 +137,21 @@ pub struct Model {
     pub dynamic_slug: Option<String>,
     pub tier: ModelTier,
     pub family: ModelFamily,
-    pub supports_tool_examples_override: Option<bool>,
     pub pricing: ModelPricing,
     pub max_output_tokens: u32,
     pub context_window: u32,
+    pub supports_tool_examples_override: Option<bool>,
 }
 
 impl Model {
     pub fn supports_tool_examples(&self) -> bool {
-        self.supports_tool_examples_override
-            .unwrap_or_else(|| self.family.supports_tool_examples())
+        if let Some(override_value) = self.supports_tool_examples_override {
+            return override_value;
+        }
+        match (self.provider, self.family) {
+            (ProviderKind::GitHubCopilot, ModelFamily::Claude) => false,
+            _ => self.family.supports_tool_examples(),
+        }
     }
 
     pub fn spec(&self) -> String {
@@ -217,10 +225,10 @@ impl Model {
                 dynamic_slug: None,
                 tier,
                 family,
-                supports_tool_examples_override: None,
                 pricing,
                 max_output_tokens,
                 context_window,
+                supports_tool_examples_override: None,
             });
         }
 
@@ -236,10 +244,10 @@ impl Model {
                 dynamic_slug: Some(provider_str.to_string()),
                 tier: entry.tier,
                 family: entry.family,
-                supports_tool_examples_override: None,
                 pricing: entry.pricing.clone(),
                 max_output_tokens: entry.max_output_tokens,
                 context_window: entry.context_window,
+                supports_tool_examples_override: None,
             });
         }
 
@@ -406,5 +414,16 @@ mod tests {
         assert_eq!(model.provider, expected_provider);
         assert_eq!(model.id, expected_id);
         assert_eq!(model.family, expected_provider.family());
+    }
+
+    #[test]
+    fn tool_example_support_respects_provider_overrides() {
+        let anthropic = Model::from_spec("anthropic/claude-sonnet-4").unwrap();
+        let github_copilot_claude = Model::from_spec("github-copilot/claude-sonnet-4").unwrap();
+        let github_copilot_gpt = Model::from_spec("github-copilot/gpt-4o").unwrap();
+
+        assert!(anthropic.supports_tool_examples());
+        assert!(!github_copilot_claude.supports_tool_examples());
+        assert!(github_copilot_gpt.supports_tool_examples());
     }
 }

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -10,6 +10,7 @@ use crate::model::{Model, ModelFamily, models_for_provider};
 use crate::providers::Timeouts;
 use crate::providers::anthropic::Anthropic;
 use crate::providers::dynamic;
+use crate::providers::github_copilot;
 use crate::providers::google::Google;
 use crate::providers::mistral::Mistral;
 use crate::providers::ollama::Ollama;
@@ -30,6 +31,8 @@ pub enum ProviderKind {
     Zai,
     ZaiCodingPlan,
     Synthetic,
+    #[strum(serialize = "github-copilot")]
+    GitHubCopilot,
 }
 
 impl ProviderKind {
@@ -43,6 +46,7 @@ impl ProviderKind {
             Self::Zai => "Z.AI",
             Self::ZaiCodingPlan => "Z.AI Coding",
             Self::Synthetic => "Synthetic",
+            Self::GitHubCopilot => "GitHub Copilot",
         }
     }
 
@@ -55,6 +59,7 @@ impl ProviderKind {
             Self::Mistral => "MISTRAL_API_KEY",
             Self::Zai | Self::ZaiCodingPlan => "ZHIPU_API_KEY",
             Self::Synthetic => "SYNTHETIC_API_KEY",
+            Self::GitHubCopilot => "",
         }
     }
 
@@ -68,13 +73,14 @@ impl ProviderKind {
             Self::Zai => "https://api.z.ai/api/paas/v4",
             Self::ZaiCodingPlan => "https://api.z.ai/api/coding/paas/v4",
             Self::Synthetic => "https://api.synthetic.new/openai/v1",
+            Self::GitHubCopilot => "",
         }
     }
 
     pub const fn supports_thinking(self) -> bool {
         matches!(
             self,
-            Self::Anthropic | Self::Google | Self::Mistral | Self::Synthetic
+            Self::Anthropic | Self::Google | Self::Mistral | Self::Synthetic | Self::GitHubCopilot
         )
     }
 
@@ -101,6 +107,7 @@ impl ProviderKind {
             Self::Mistral => ModelFamily::Generic,
             Self::Zai | Self::ZaiCodingPlan => ModelFamily::Glm,
             Self::Synthetic => ModelFamily::Synthetic,
+            Self::GitHubCopilot => ModelFamily::Gpt,
         }
     }
 
@@ -117,6 +124,7 @@ impl ProviderKind {
             Self::Mistral => 32_000,
             Self::Zai | Self::ZaiCodingPlan => 16_000,
             Self::Synthetic => 32_000,
+            Self::GitHubCopilot => 100_000,
         }
     }
 
@@ -129,6 +137,7 @@ impl ProviderKind {
             Self::Mistral => 128_000,
             Self::Zai | Self::ZaiCodingPlan => 128_000,
             Self::Synthetic => 128_000,
+            Self::GitHubCopilot => 200_000,
         }
     }
 
@@ -142,6 +151,7 @@ impl ProviderKind {
             Self::Zai => Ok(Box::new(Zai::new(ZaiPlan::Standard, timeouts)?)),
             Self::ZaiCodingPlan => Ok(Box::new(Zai::new(ZaiPlan::Coding, timeouts)?)),
             Self::Synthetic => Ok(Box::new(Synthetic::new(timeouts)?)),
+            Self::GitHubCopilot => Ok(Box::new(github_copilot::GitHubCopilot::new()?)),
         }
     }
 
@@ -268,5 +278,26 @@ pub async fn fetch_all_models(mut on_ready: impl FnMut(ModelBatch)) {
 
     while let Ok(batch) = rx.recv_async().await {
         on_ready(batch);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProviderKind;
+
+    #[test]
+    fn supports_thinking_includes_expected_providers() {
+        assert!(ProviderKind::Anthropic.supports_thinking());
+        assert!(ProviderKind::Mistral.supports_thinking());
+        assert!(ProviderKind::Synthetic.supports_thinking());
+        assert!(ProviderKind::GitHubCopilot.supports_thinking());
+    }
+
+    #[test]
+    fn supports_thinking_excludes_expected_providers() {
+        assert!(!ProviderKind::OpenAi.supports_thinking());
+        assert!(!ProviderKind::Ollama.supports_thinking());
+        assert!(!ProviderKind::Zai.supports_thinking());
+        assert!(!ProviderKind::ZaiCodingPlan.supports_thinking());
     }
 }

--- a/maki-providers/src/providers/anthropic.rs
+++ b/maki-providers/src/providers/anthropic.rs
@@ -1,6 +1,4 @@
 //! Anthropic API provider with prompt caching.
-//! Cache breakpoints: 1 on tools (last element), 1 on system prompt, 2 on the last two messages
-//! (last content block each). This consumes all 4 of Anthropic's allowed breakpoints.
 
 use std::env;
 use std::sync::{Arc, Mutex};
@@ -26,11 +24,7 @@ const MESSAGES_URL: &str = "https://api.anthropic.com/v1/messages";
 const MODELS_URL: &str = "https://api.anthropic.com/v1/models?limit=1000";
 const BETA_ADVANCED_TOOL_USE: &str = "advanced-tool-use-2025-11-20";
 
-/// Anthropic caches conversation by blocks (tools -> system -> messages).
-/// We use 1 cache breakpoint for the last tool block, and 1 for the system prompt.
-/// We're allowed to set up to 4 breakpoints. So we're left with 2 to use for messages.
-///
-/// See https://platform.claude.com/docs/en/build-with-claude/prompt-caching.
+/// Reserve the last two cache breakpoints for the latest messages.
 const MESSAGE_CACHE_BREAKPOINTS: usize = 2;
 
 #[derive(Serialize)]
@@ -275,7 +269,7 @@ fn resolve_auth() -> Result<super::ResolvedAuth, AgentError> {
 }
 
 #[derive(Deserialize)]
-struct Usage {
+pub(crate) struct Usage {
     #[serde(default)]
     input_tokens: u32,
     #[serde(default)]
@@ -298,19 +292,19 @@ impl From<Usage> for TokenUsage {
 }
 
 #[derive(Deserialize)]
-struct MessagePayload {
+pub(crate) struct MessagePayload {
     #[serde(default)]
     usage: Option<Usage>,
 }
 
 #[derive(Deserialize)]
-struct MessageStartEvent {
+pub(crate) struct MessageStartEvent {
     message: MessagePayload,
 }
 
 #[derive(Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-enum SseContentBlock {
+pub(crate) enum SseContentBlock {
     Text,
     Thinking,
     RedactedThinking { data: String },
@@ -318,14 +312,14 @@ enum SseContentBlock {
 }
 
 #[derive(Deserialize)]
-struct ContentBlockStartEvent {
+pub(crate) struct ContentBlockStartEvent {
     index: usize,
     content_block: SseContentBlock,
 }
 
 #[derive(Deserialize)]
 #[serde(tag = "type")]
-enum Delta {
+pub(crate) enum Delta {
     #[serde(rename = "text_delta")]
     Text { text: String },
     #[serde(rename = "thinking_delta")]
@@ -337,19 +331,19 @@ enum Delta {
 }
 
 #[derive(Deserialize)]
-struct ContentBlockDeltaEvent {
+pub(crate) struct ContentBlockDeltaEvent {
     index: usize,
     delta: Delta,
 }
 
 #[derive(Deserialize)]
-struct MessageDeltaPayload {
+pub(crate) struct MessageDeltaPayload {
     #[serde(default)]
     stop_reason: Option<String>,
 }
 
 #[derive(Deserialize)]
-struct MessageDeltaEvent {
+pub(crate) struct MessageDeltaEvent {
     #[serde(default)]
     delta: Option<MessageDeltaPayload>,
     #[serde(default)]
@@ -391,8 +385,12 @@ impl Anthropic {
         self
     }
 
-    fn build_request(&self, method: &str, url: Option<&str>) -> isahc::http::request::Builder {
-        let auth = self.auth.lock().unwrap();
+    fn build_request(
+        &self,
+        method: &str,
+        url: Option<&str>,
+        auth: &super::ResolvedAuth,
+    ) -> isahc::http::request::Builder {
         let url = url.unwrap_or_else(|| auth.base_url.as_deref().unwrap_or(MESSAGES_URL));
         let mut builder = Request::builder()
             .method(method)
@@ -408,10 +406,23 @@ impl Anthropic {
         &self,
         body: &Value,
         event_tx: &Sender<ProviderEvent>,
+        auth: &super::ResolvedAuth,
+    ) -> Result<StreamResponse, AgentError> {
+        self.do_stream_request_with_url(body, event_tx, None, auth)
+            .await
+    }
+
+    /// Stream a pre-built body, optionally to a custom URL with explicit auth.
+    pub(crate) async fn do_stream_request_with_url(
+        &self,
+        body: &Value,
+        event_tx: &Sender<ProviderEvent>,
+        url: Option<&str>,
+        auth: &super::ResolvedAuth,
     ) -> Result<StreamResponse, AgentError> {
         let json_body = serde_json::to_vec(body)?;
         let request = self
-            .build_request("POST", None)
+            .build_request("POST", url, auth)
             .header("content-type", "application/json")
             .body(json_body)?;
         let response = self.client.send_async(request).await?;
@@ -434,7 +445,8 @@ impl Anthropic {
                 url.push_str(&format!("&after_id={cursor}"));
             }
 
-            let request = self.build_request("GET", Some(&url)).body(())?;
+            let auth = (*self.auth.lock().unwrap()).clone();
+            let request = self.build_request("GET", Some(&url), &auth).body(())?;
             let mut response = self.client.send_async(request).await?;
             if response.status().as_u16() != 200 {
                 return Err(AgentError::from_response(response).await);
@@ -467,38 +479,18 @@ impl Provider for Anthropic {
         _session_id: Option<&str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
-            let wire_messages = build_wire_messages(messages);
-            let wire_tools = build_wire_tools(tools);
-            let system_block = SystemBlock {
-                r#type: "text",
-                text: system,
-                cache_control: Some(EPHEMERAL),
-            };
-
-            let system_blocks = if let Some(prefix) = &self.system_prefix {
-                let prefix_block = SystemBlock {
-                    r#type: "text",
-                    text: prefix,
-                    cache_control: None,
-                };
-                json!([prefix_block, system_block])
-            } else {
-                json!([system_block])
-            };
-
-            let mut body = json!({
-                "model": model.id,
-                "max_tokens": model.max_output_tokens,
-                "system": system_blocks,
-                "messages": wire_messages,
-                "tools": wire_tools,
-                "stream": true,
-            });
-
+            let mut body = build_body(
+                model,
+                messages,
+                tools,
+                system,
+                self.system_prefix.as_deref(),
+            );
             thinking.apply_to_body(&mut body);
 
             debug!(model = %model.id, num_messages = messages.len(), ?thinking, "sending API request");
-            self.do_stream_request(&body, event_tx).await
+            let auth = (*self.auth.lock().unwrap()).clone();
+            self.do_stream_request(&body, event_tx, &auth).await
         })
     }
 
@@ -590,7 +582,45 @@ fn build_wire_tools(tools: &Value) -> Value {
     Value::Array(out)
 }
 
-async fn parse_sse(
+/// Build an Anthropic request body with prompt caching.
+pub(crate) fn build_body(
+    model: &Model,
+    messages: &[Message],
+    tools: &Value,
+    system: &str,
+    system_prefix: Option<&str>,
+) -> Value {
+    let wire_messages = build_wire_messages(messages);
+    let wire_tools = build_wire_tools(tools);
+    let system_block = SystemBlock {
+        r#type: "text",
+        text: system,
+        cache_control: Some(EPHEMERAL),
+    };
+
+    let system_blocks = match system_prefix {
+        Some("") | None => json!([system_block]),
+        Some(prefix) => json!([
+            SystemBlock {
+                r#type: "text",
+                text: prefix,
+                cache_control: None,
+            },
+            system_block
+        ]),
+    };
+
+    json!({
+        "model": model.id,
+        "max_tokens": model.max_output_tokens,
+        "system": system_blocks,
+        "messages": wire_messages,
+        "tools": wire_tools,
+        "stream": true,
+    })
+}
+
+pub(crate) async fn parse_sse(
     response: isahc::Response<isahc::AsyncBody>,
     event_tx: &Sender<ProviderEvent>,
     stream_timeout: Duration,
@@ -1074,5 +1104,52 @@ data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usa
                 matches!(&resp.message.content[1], ContentBlock::Text { text } if text == "Hi")
             );
         })
+    }
+
+    fn test_model() -> Model {
+        Model::from_spec("anthropic/claude-sonnet-4-5").unwrap()
+    }
+
+    #[test]
+    fn build_body_empty_system_prefix_yields_single_block() {
+        let model = test_model();
+        let messages = vec![Message::user("hello".into())];
+        let tools = json!([]);
+
+        let body_none = build_body(&model, &messages, &tools, "sys", None);
+        let body_empty = build_body(&model, &messages, &tools, "sys", Some(""));
+
+        let sys_none = body_none["system"].as_array().unwrap();
+        let sys_empty = body_empty["system"].as_array().unwrap();
+
+        assert_eq!(
+            sys_none.len(),
+            1,
+            "None prefix should yield one system block"
+        );
+        assert_eq!(
+            sys_empty.len(),
+            1,
+            "empty string prefix should yield one system block"
+        );
+
+        assert_eq!(sys_none[0]["text"], "sys");
+        assert_eq!(sys_empty[0]["text"], "sys");
+    }
+
+    #[test]
+    fn build_body_nonempty_prefix_yields_two_blocks() {
+        let model = test_model();
+        let messages = vec![Message::user("hello".into())];
+        let tools = json!([]);
+
+        let body = build_body(&model, &messages, &tools, "sys", Some("prefix"));
+
+        let sys = body["system"].as_array().unwrap();
+        assert_eq!(sys.len(), 2);
+        assert_eq!(sys[0]["text"], "prefix");
+        assert!(sys[0].get("cache_control").is_none());
+        assert_eq!(sys[1]["text"], "sys");
+        assert_eq!(sys[1]["cache_control"]["type"], "ephemeral");
     }
 }

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -48,14 +48,14 @@ struct ScriptModel {
     id: String,
     #[serde(default = "default_tier")]
     tier: ModelTier,
-    #[serde(default)]
-    supports_tool_examples: Option<bool>,
     #[serde(default = "default_max_output_tokens")]
     max_output_tokens: u32,
     #[serde(default = "default_context_window")]
     context_window: u32,
     #[serde(default)]
     pricing: Option<ModelPricing>,
+    #[serde(default)]
+    supports_tool_examples: Option<bool>,
 }
 
 fn default_tier() -> ModelTier {
@@ -396,10 +396,10 @@ pub fn lookup_model(slug: &str, model_id: &str) -> Option<Model> {
         dynamic_slug: Some(slug.to_string()),
         tier: script_model.tier,
         family: meta.base.family(),
-        supports_tool_examples_override: script_model.supports_tool_examples,
         pricing: script_model.pricing.clone().unwrap_or_default(),
         max_output_tokens: script_model.max_output_tokens,
         context_window: script_model.context_window,
+        supports_tool_examples_override: script_model.supports_tool_examples,
     })
 }
 
@@ -412,10 +412,10 @@ pub fn find_model_for_tier(slug: &str, tier: ModelTier) -> Option<Model> {
         dynamic_slug: Some(slug.to_string()),
         tier,
         family: meta.base.family(),
-        supports_tool_examples_override: script_model.supports_tool_examples,
         pricing: script_model.pricing.clone().unwrap_or_default(),
         max_output_tokens: script_model.max_output_tokens,
         context_window: script_model.context_window,
+        supports_tool_examples_override: script_model.supports_tool_examples,
     })
 }
 
@@ -533,16 +533,14 @@ mod tests {
 
     #[test]
     fn script_model_deserialization() {
-        let full = r#"{"id": "my-model", "tier": "strong", "supports_tool_examples": true, "max_output_tokens": 32000, "context_window": 200000, "pricing": {"input": 3.0, "output": 15.0, "cache_write": 3.75, "cache_read": 0.30}}"#;
+        let full = r#"{"id": "my-model", "tier": "strong", "max_output_tokens": 32000, "context_window": 200000, "pricing": {"input": 3.0, "output": 15.0, "cache_write": 3.75, "cache_read": 0.30}}"#;
         let model: ScriptModel = serde_json::from_str(full).unwrap();
         assert_eq!(model.id, "my-model");
         assert_eq!(model.tier, ModelTier::Strong);
-        assert_eq!(model.supports_tool_examples, Some(true));
         assert!(model.pricing.is_some());
 
         let minimal: ScriptModel = serde_json::from_str(r#"{"id": "custom-v1"}"#).unwrap();
         assert_eq!(minimal.tier, ModelTier::Medium);
-        assert_eq!(minimal.supports_tool_examples, None);
         assert_eq!(minimal.max_output_tokens, 16384);
         assert_eq!(minimal.context_window, 128_000);
         assert!(minimal.pricing.is_none());
@@ -607,6 +605,8 @@ esac
         assert_eq!(providers[0].models.len(), 1);
         assert_eq!(providers[0].models[0].id, "custom-v1");
         assert_eq!(providers[0].models[0].tier, ModelTier::Strong);
+        assert_eq!(providers[0].models[0].max_output_tokens, 32000);
+        assert_eq!(providers[0].models[0].context_window, 200000);
     }
 
     #[cfg(unix)]

--- a/maki-providers/src/providers/github_copilot/anthropic.rs
+++ b/maki-providers/src/providers/github_copilot/anthropic.rs
@@ -1,0 +1,810 @@
+//! Anthropic Messages support for GitHub Copilot `/v1/messages`.
+
+use serde_json::{Value, json};
+
+use crate::model::Model;
+use crate::providers::anthropic::build_body;
+use crate::{ContentBlock, Message, ThinkingConfig};
+
+#[cfg(test)]
+use crate::Role;
+
+const HIGH_EFFORT: &str = "high";
+const MEDIUM_EFFORT: &str = "medium";
+const DEFAULT_THINKING_BUDGET: u32 = 1600;
+const INTERLEAVED_THINKING_BETA: &str = "interleaved-thinking-2025-05-14";
+const ADVANCED_TOOL_USE_BETA: &str = "advanced-tool-use-2025-11-20";
+const PLACEHOLDER_THINKING: &str = "Thinking...";
+
+/// Thinking mode for the `/v1/messages` endpoint (Anthropic Messages API).
+///
+/// Controls how reasoning/thinking is configured for Claude-family models.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessagesThinkingMode {
+    Off,
+    Adaptive,
+    Manual(u32),
+}
+
+impl MessagesThinkingMode {
+    pub(crate) fn from_thinking_config(thinking: ThinkingConfig, model_id: &str) -> Self {
+        match thinking {
+            ThinkingConfig::Off => Self::Off,
+            ThinkingConfig::Adaptive => {
+                // Only 4.6+ models support adaptive. Older models fall back to
+                // the Anthropic SDK's default manual budget.
+                // See: https://github.com/anthropics/anthropic-sdk-python/blob/78de297e71bacbe6acf4d3b420edcaad90ce1045/examples/thinking_stream.py#L8
+                if model_supports_adaptive(model_id) {
+                    Self::Adaptive
+                } else {
+                    Self::Manual(DEFAULT_THINKING_BUDGET)
+                }
+            }
+            ThinkingConfig::Budget(budget) => Self::Manual(budget),
+        }
+    }
+
+    pub(crate) fn apply_to_body(self, body: &mut Value, model_id: &str) {
+        match self {
+            Self::Off => {}
+            Self::Adaptive => {
+                body["thinking"] = json!({"type": "adaptive"});
+                let effort = if model_supports_high_effort(model_id) {
+                    HIGH_EFFORT
+                } else {
+                    MEDIUM_EFFORT
+                };
+                body["output_config"] = json!({"effort": effort});
+            }
+            Self::Manual(budget_tokens) => {
+                body["thinking"] = json!({"type": "enabled", "budget_tokens": budget_tokens});
+            }
+        }
+    }
+}
+
+/// Parse a model version like `claude-4.6` into `(major, minor)`.
+fn parse_model_version(model_id: &str) -> Option<(u32, u32)> {
+    let version = &model_id[model_id.find(|c: char| c.is_ascii_digit())?..];
+    let (major, rest) = parse_leading_u32(version)?;
+
+    let minor = rest
+        .strip_prefix('.')
+        .and_then(|rest| parse_leading_u32(rest).map(|(minor, _)| minor))
+        .unwrap_or(0);
+
+    Some((major, minor))
+}
+
+fn parse_leading_u32(input: &str) -> Option<(u32, &str)> {
+    let end = input
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(input.len());
+
+    input[..end]
+        .parse()
+        .ok()
+        .map(|value| (value, &input[end..]))
+}
+
+/// Check if a model supports adaptive thinking (Claude 4.6 or higher).
+fn model_supports_adaptive(model_id: &str) -> bool {
+    parse_model_version(model_id)
+        .is_some_and(|(major, minor)| major > 4 || (major == 4 && minor >= 6))
+}
+
+/// Check if a model requires the advanced-tool-use beta (Claude 4.5 or higher).
+fn model_requires_advanced_tool_use(model_id: &str) -> bool {
+    parse_model_version(model_id)
+        .is_some_and(|(major, minor)| major > 4 || (major == 4 && minor >= 5))
+}
+
+/// Check if a model supports high effort (Claude Opus 4.7+ does not support high).
+fn model_supports_high_effort(model_id: &str) -> bool {
+    parse_model_version(model_id).is_some_and(|(major, minor)| !(major == 4 && minor == 7))
+}
+
+// Managed beta tokens. Keep this in sync with the logic below.
+const MANAGED_BETAS: &[&str] = &[INTERLEAVED_THINKING_BETA, ADVANCED_TOOL_USE_BETA];
+
+/// Rebuild `anthropic-beta` with the managed betas this request needs.
+pub(crate) fn adjust_anthropic_beta_header(
+    headers: &mut Vec<(String, String)>,
+    mode: MessagesThinkingMode,
+    model_id: &str,
+) {
+    // Preserve caller-managed betas and replace the ones we own.
+    let existing: Vec<String> = headers
+        .iter()
+        .position(|(k, _)| k.eq_ignore_ascii_case("anthropic-beta"))
+        .map(|idx| {
+            let (_, value) = headers.remove(idx);
+            value
+                .split(',')
+                .map(|s| s.trim())
+                .filter(|s| {
+                    !MANAGED_BETAS
+                        .iter()
+                        .any(|managed| managed.eq_ignore_ascii_case(s))
+                })
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut betas = existing;
+
+    if matches!(mode, MessagesThinkingMode::Manual(_)) {
+        betas.push(INTERLEAVED_THINKING_BETA.into());
+    }
+    if model_requires_advanced_tool_use(model_id) {
+        betas.push(ADVANCED_TOOL_USE_BETA.into());
+    }
+
+    if !betas.is_empty() {
+        headers.push(("anthropic-beta".into(), betas.join(", ")));
+    }
+}
+
+/// Signatures containing `@` are Copilot placeholders.
+fn is_invalid_thinking(thinking: &str, signature: Option<&str>) -> bool {
+    thinking.is_empty()
+        || thinking == PLACEHOLDER_THINKING
+        || signature.is_some_and(|s| s.contains('@'))
+}
+
+fn normalize_for_claude(blocks: &[ContentBlock]) -> Vec<ContentBlock> {
+    blocks
+        .iter()
+        .filter(|block| {
+            let ContentBlock::Thinking {
+                thinking,
+                signature,
+            } = block
+            else {
+                return true;
+            };
+            !is_invalid_thinking(thinking, signature.as_deref())
+        })
+        .map(|block| match block {
+            ContentBlock::Thinking {
+                thinking,
+                signature: None,
+            } => ContentBlock::Text {
+                text: thinking.clone(),
+            },
+            _ => block.clone(),
+        })
+        .collect()
+}
+
+fn sanitize_tools(tools: &Value) -> Value {
+    let Some(arr) = tools.as_array() else {
+        return tools.clone();
+    };
+    Value::Array(
+        arr.iter()
+            .map(|t| {
+                let mut tool = t.clone();
+                tool.as_object_mut().map(|o| o.remove("input_examples"));
+                tool
+            })
+            .collect(),
+    )
+}
+
+pub fn build_anthropic_messages_body(
+    model: &Model,
+    messages: &[Message],
+    system: &str,
+    tools: &Value,
+    thinking: ThinkingConfig,
+) -> (Value, MessagesThinkingMode) {
+    let normalized_messages: Vec<Message> = messages
+        .iter()
+        .map(|m| Message {
+            role: m.role,
+            content: normalize_for_claude(&m.content),
+            display_text: None,
+        })
+        .collect();
+
+    let sanitized_tools = sanitize_tools(tools);
+
+    // Apply thinking after the shared builder. Copilot rejects explicit effort
+    // when the shared body already set one.
+    let mut body = build_body(model, &normalized_messages, &sanitized_tools, system, None);
+    let mode = MessagesThinkingMode::from_thinking_config(thinking, &model.id);
+    mode.apply_to_body(&mut body, &model.id);
+
+    (body, mode)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use test_case::test_case;
+
+    const TEST_PLACEHOLDER_THINKING: &str = PLACEHOLDER_THINKING;
+
+    fn user_messages() -> Vec<Message> {
+        vec![Message::user("hello".into())]
+    }
+
+    fn sample_tools() -> Value {
+        serde_json::json!([{
+            "name": "bash",
+            "description": "Run a command",
+            "input_schema": {"type": "object", "properties": {"cmd": {"type": "string"}}, "required": ["cmd"]},
+            "input_examples": [{"cmd": "pwd"}]
+        }])
+    }
+
+    fn find_beta_header(headers: &[(String, String)]) -> Option<&str> {
+        headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("anthropic-beta"))
+            .map(|(_, v)| v.as_str())
+    }
+
+    #[test_case(MessagesThinkingMode::Manual(1024), "claude-sonnet-4",
+        Some(INTERLEAVED_THINKING_BETA); "manual adds interleaved")]
+    #[test_case(MessagesThinkingMode::Adaptive, "claude-sonnet-4",
+        None; "adaptive no betas")]
+    #[test_case(MessagesThinkingMode::Off, "claude-sonnet-4",
+        None; "off no betas")]
+    #[test_case(MessagesThinkingMode::Off, "claude-sonnet-4.5",
+        Some(ADVANCED_TOOL_USE_BETA); "45 gets advanced-tool")]
+    #[test_case(MessagesThinkingMode::Off, "claude-opus-4.6",
+        Some(ADVANCED_TOOL_USE_BETA); "46 gets advanced-tool")]
+    fn beta_header_added_when_missing(
+        mode: MessagesThinkingMode,
+        model_id: &str,
+        expected: Option<&str>,
+    ) {
+        let mut headers = vec![];
+        adjust_anthropic_beta_header(&mut headers, mode, model_id);
+        assert_eq!(find_beta_header(&headers), expected);
+    }
+
+    #[test]
+    fn manual_appends_to_existing() {
+        let mut headers = vec![(
+            "anthropic-beta".into(),
+            "context-management-2025-06-27".into(),
+        )];
+        adjust_anthropic_beta_header(&mut headers, MessagesThinkingMode::Manual(1024), "claude-4");
+
+        let beta = find_beta_header(&headers).unwrap();
+        assert!(
+            beta.contains("context-management-2025-06-27"),
+            "preserves unmanaged"
+        );
+        assert!(beta.contains(INTERLEAVED_THINKING_BETA), "adds managed");
+    }
+
+    #[test]
+    fn adaptive_removes_interleaved() {
+        let mut headers = vec![(
+            "anthropic-beta".into(),
+            format!("{INTERLEAVED_THINKING_BETA},other-beta"),
+        )];
+        adjust_anthropic_beta_header(&mut headers, MessagesThinkingMode::Adaptive, "claude-4");
+
+        let beta = find_beta_header(&headers).unwrap();
+        assert!(!beta.contains(INTERLEAVED_THINKING_BETA), "removes managed");
+        assert!(beta.contains("other-beta"), "preserves unmanaged");
+    }
+
+    #[test]
+    fn managed_betas_deduplicated() {
+        let mut headers = vec![(
+            "anthropic-beta".into(),
+            format!("{ADVANCED_TOOL_USE_BETA},custom-beta"),
+        )];
+        adjust_anthropic_beta_header(&mut headers, MessagesThinkingMode::Off, "claude-4.5");
+
+        let beta = find_beta_header(&headers).unwrap();
+        assert_eq!(beta.matches(ADVANCED_TOOL_USE_BETA).count(), 1);
+    }
+
+    #[test]
+    fn case_insensitive_header_handling() {
+        let mut headers = vec![("Anthropic-Beta".into(), "custom".into())];
+        adjust_anthropic_beta_header(&mut headers, MessagesThinkingMode::Manual(1024), "claude-4");
+
+        assert!(find_beta_header(&headers).unwrap().contains("custom"));
+    }
+
+    #[test]
+    fn manual_thinking_on_45_plus_has_both_betas() {
+        let mut headers = vec![];
+        adjust_anthropic_beta_header(
+            &mut headers,
+            MessagesThinkingMode::Manual(1024),
+            "claude-4.5",
+        );
+
+        let beta = find_beta_header(&headers).unwrap();
+        assert!(beta.contains(INTERLEAVED_THINKING_BETA));
+        assert!(beta.contains(ADVANCED_TOOL_USE_BETA));
+    }
+
+    #[test]
+    fn messages_thinking_mode_off_does_not_modify_body() {
+        let mut body = serde_json::json!({"model": "claude-sonnet-4"});
+        MessagesThinkingMode::Off.apply_to_body(&mut body, "claude-sonnet-4");
+
+        assert!(body.get("thinking").is_none());
+        assert!(body.get("output_config").is_none());
+    }
+
+    #[test]
+    fn messages_thinking_mode_adaptive_adds_thinking_and_output_config() {
+        let mut body = serde_json::json!({"model": "claude-sonnet-4.6"});
+        MessagesThinkingMode::Adaptive.apply_to_body(&mut body, "claude-sonnet-4.6");
+
+        assert_eq!(body["thinking"]["type"], "adaptive");
+        assert_eq!(body["output_config"]["effort"], "high");
+    }
+
+    #[test]
+    fn messages_thinking_mode_adaptive_uses_medium_for_opus_47() {
+        let mut body = serde_json::json!({"model": "claude-opus-4.7"});
+        MessagesThinkingMode::Adaptive.apply_to_body(&mut body, "claude-opus-4.7");
+
+        assert_eq!(body["thinking"]["type"], "adaptive");
+        assert_eq!(body["output_config"]["effort"], "medium");
+    }
+
+    #[test]
+    fn messages_thinking_mode_manual_adds_enabled_thinking_with_budget() {
+        let mut body = serde_json::json!({"model": "claude-sonnet-4"});
+        MessagesThinkingMode::Manual(4096).apply_to_body(&mut body, "claude-sonnet-4");
+
+        assert_eq!(body["thinking"]["type"], "enabled");
+        assert_eq!(body["thinking"]["budget_tokens"], 4096);
+        assert!(body.get("output_config").is_none());
+    }
+
+    #[test]
+    fn claude_body_format() {
+        let model = Model::from_spec("github-copilot/claude-sonnet-4").unwrap();
+        let (body, _) = build_anthropic_messages_body(
+            &model,
+            &user_messages(),
+            "system",
+            &serde_json::json!([]),
+            ThinkingConfig::Off,
+        );
+        assert!(body.get("messages").is_some());
+        assert!(body.get("input").is_none());
+        assert!(body.get("system").is_some());
+        assert!(body.get("max_tokens").is_some());
+        assert!(body.get("max_completion_tokens").is_none());
+    }
+
+    #[test]
+    fn top_level_system_field() {
+        let model = Model::from_spec("github-copilot/claude-sonnet-4").unwrap();
+        let (body, _) = build_anthropic_messages_body(
+            &model,
+            &user_messages(),
+            "You are helpful",
+            &serde_json::json!([]),
+            ThinkingConfig::Off,
+        );
+        let system = body["system"].as_array().unwrap();
+        assert_eq!(system[0]["text"], "You are helpful");
+        assert!(
+            !body["messages"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|m| m["role"] == "system")
+        );
+    }
+
+    #[test]
+    fn thinking_adaptive_for_46_plus() {
+        let model = Model::from_spec("github-copilot/claude-sonnet-4.6").unwrap();
+        let (body, _) = build_anthropic_messages_body(
+            &model,
+            &user_messages(),
+            "system",
+            &serde_json::json!([]),
+            ThinkingConfig::Adaptive,
+        );
+        assert_eq!(body["thinking"]["type"], "adaptive");
+        assert_eq!(body["output_config"]["effort"], "high");
+    }
+
+    #[test]
+    fn thinking_fallback_for_pre_46() {
+        let model = Model::from_spec("github-copilot/claude-sonnet-4").unwrap();
+        let (body, _) = build_anthropic_messages_body(
+            &model,
+            &user_messages(),
+            "system",
+            &serde_json::json!([]),
+            ThinkingConfig::Adaptive,
+        );
+        assert_eq!(body["thinking"]["type"], "enabled");
+        assert!(body.get("output_config").is_none());
+    }
+
+    #[test]
+    fn thinking_manual_budget() {
+        let model = Model::from_spec("github-copilot/claude-opus-4.6").unwrap();
+        let (body, _) = build_anthropic_messages_body(
+            &model,
+            &user_messages(),
+            "system",
+            &serde_json::json!([]),
+            ThinkingConfig::Budget(8192),
+        );
+        assert_eq!(body["thinking"]["budget_tokens"], 8192);
+    }
+
+    #[test]
+    fn unsigned_thinking_normalized() {
+        let model = Model::from_spec("github-copilot/claude-sonnet-4").unwrap();
+        let messages = vec![Message {
+            role: Role::Assistant,
+            content: vec![
+                ContentBlock::Thinking {
+                    thinking: "reasoning".into(),
+                    signature: None,
+                },
+                ContentBlock::Text {
+                    text: "answer".into(),
+                },
+            ],
+            ..Default::default()
+        }];
+        let (body, _) = build_anthropic_messages_body(
+            &model,
+            &messages,
+            "system",
+            &serde_json::json!([]),
+            ThinkingConfig::Off,
+        );
+        let content = body["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "reasoning");
+    }
+
+    #[test]
+    fn signed_thinking_preserved() {
+        let model = Model::from_spec("github-copilot/claude-sonnet-4").unwrap();
+        let messages = vec![Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::Thinking {
+                thinking: "reasoning".into(),
+                signature: Some("sig".into()),
+            }],
+            ..Default::default()
+        }];
+        let (body, _) = build_anthropic_messages_body(
+            &model,
+            &messages,
+            "system",
+            &serde_json::json!([]),
+            ThinkingConfig::Off,
+        );
+        let content = body["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(content[0]["type"], "thinking");
+        assert_eq!(content[0]["signature"], "sig");
+    }
+
+    #[test]
+    fn tools_included() {
+        let model = Model::from_spec("github-copilot/claude-sonnet-4").unwrap();
+        let (body, _) = build_anthropic_messages_body(
+            &model,
+            &user_messages(),
+            "system",
+            &sample_tools(),
+            ThinkingConfig::Off,
+        );
+        let tools = body["tools"].as_array().unwrap();
+        assert_eq!(tools[0]["name"], "bash");
+        assert!(tools[0].get("function").is_none());
+    }
+
+    #[test]
+    fn tools_sanitized() {
+        let sanitized = sanitize_tools(&sample_tools());
+        let tools = sanitized.as_array().unwrap();
+        assert!(tools[0].get("input_examples").is_none());
+    }
+
+    #[test]
+    fn tools_non_array_passthrough() {
+        let tools = serde_json::json!({"not": "an array"});
+        let sanitized = sanitize_tools(&tools);
+        assert_eq!(sanitized, tools);
+    }
+
+    #[test]
+    fn cache_breakpoint_single_user_message() {
+        let model = Model::from_spec("github-copilot/claude-sonnet-4").unwrap();
+        let messages = vec![Message::user("hello".into())];
+        let (body, _) = build_anthropic_messages_body(
+            &model,
+            &messages,
+            "system",
+            &serde_json::json!([]),
+            ThinkingConfig::Off,
+        );
+
+        let wire_messages = body["messages"].as_array().unwrap();
+        assert_eq!(wire_messages.len(), 1);
+        let content = wire_messages[0]["content"].as_array().unwrap();
+        assert_eq!(content[0]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn cache_breakpoints_last_two_messages_only() {
+        let model = Model::from_spec("github-copilot/claude-sonnet-4").unwrap();
+        let messages = vec![
+            Message::user("first".into()),
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::Text {
+                    text: "reply".into(),
+                }],
+                ..Default::default()
+            },
+            Message {
+                role: Role::User,
+                content: vec![
+                    ContentBlock::ToolResult {
+                        tool_use_id: "t1".into(),
+                        content: "ok".into(),
+                        is_error: false,
+                    },
+                    ContentBlock::Text {
+                        text: "second".into(),
+                    },
+                ],
+                ..Default::default()
+            },
+        ];
+        let (body, _) = build_anthropic_messages_body(
+            &model,
+            &messages,
+            "system",
+            &serde_json::json!([]),
+            ThinkingConfig::Off,
+        );
+
+        let wire_messages = body["messages"].as_array().unwrap();
+        assert_eq!(wire_messages.len(), 3);
+
+        assert!(
+            wire_messages[0]["content"][0]
+                .get("cache_control")
+                .is_none()
+        );
+
+        assert_eq!(
+            wire_messages[1]["content"][0]["cache_control"]["type"],
+            "ephemeral"
+        );
+
+        assert!(
+            wire_messages[2]["content"][0]
+                .get("cache_control")
+                .is_none()
+        );
+        assert_eq!(
+            wire_messages[2]["content"][1]["cache_control"]["type"],
+            "ephemeral"
+        );
+    }
+
+    #[test]
+    fn cache_breakpoint_last_tool_only() {
+        let model = Model::from_spec("github-copilot/claude-sonnet-4").unwrap();
+        let tools = serde_json::json!([
+            {"name": "tool1", "description": "first"},
+            {"name": "tool2", "description": "second"},
+            {"name": "tool3", "description": "third"}
+        ]);
+        let (body, _) = build_anthropic_messages_body(
+            &model,
+            &[Message::user("hello".into())],
+            "system",
+            &tools,
+            ThinkingConfig::Off,
+        );
+
+        let wire_tools = body["tools"].as_array().unwrap();
+        assert_eq!(wire_tools.len(), 3);
+
+        assert!(wire_tools[0].get("cache_control").is_none());
+        assert!(wire_tools[1].get("cache_control").is_none());
+
+        assert_eq!(wire_tools[2]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn cache_breakpoint_system_block() {
+        let model = Model::from_spec("github-copilot/claude-sonnet-4").unwrap();
+        let (body, _) = build_anthropic_messages_body(
+            &model,
+            &[Message::user("hello".into())],
+            "You are helpful",
+            &serde_json::json!([]),
+            ThinkingConfig::Off,
+        );
+
+        let system = body["system"].as_array().unwrap();
+        assert_eq!(system.len(), 1);
+        assert_eq!(system[0]["cache_control"]["type"], "ephemeral");
+        assert_eq!(system[0]["text"], "You are helpful");
+    }
+
+    #[test]
+    fn thinking_applied_after_shared_body_construction() {
+        let model = Model::from_spec("github-copilot/claude-sonnet-4.6").unwrap();
+        let messages = vec![
+            Message::user("first".into()),
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::Text {
+                    text: "reply".into(),
+                }],
+                ..Default::default()
+            },
+        ];
+        let (body, mode) = build_anthropic_messages_body(
+            &model,
+            &messages,
+            "system",
+            &serde_json::json!([]),
+            ThinkingConfig::Adaptive,
+        );
+
+        assert_eq!(body["thinking"]["type"], "adaptive");
+        assert_eq!(body["output_config"]["effort"], "high");
+        assert_eq!(mode, MessagesThinkingMode::Adaptive);
+
+        let wire_messages = body["messages"].as_array().unwrap();
+        assert_eq!(
+            wire_messages[1]["content"][0]["cache_control"]["type"],
+            "ephemeral"
+        );
+
+        let system = body["system"].as_array().unwrap();
+        assert_eq!(system[0]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn tool_sanitization_removes_input_examples() {
+        let model = Model::from_spec("github-copilot/claude-sonnet-4").unwrap();
+        let tools = serde_json::json!([{
+            "name": "bash",
+            "description": "Run a command",
+            "input_schema": {"type": "object"},
+            "input_examples": [{"cmd": "pwd"}]
+        }]);
+        let (body, _) = build_anthropic_messages_body(
+            &model,
+            &[Message::user("hello".into())],
+            "system",
+            &tools,
+            ThinkingConfig::Off,
+        );
+
+        let wire_tools = body["tools"].as_array().unwrap();
+        assert!(wire_tools[0].get("input_examples").is_none());
+        assert_eq!(wire_tools[0]["name"], "bash");
+    }
+
+    #[test]
+    fn unsigned_thinking_normalized_before_body_construction() {
+        let model = Model::from_spec("github-copilot/claude-sonnet-4").unwrap();
+        let messages = vec![Message {
+            role: Role::Assistant,
+            content: vec![
+                ContentBlock::Thinking {
+                    thinking: "my reasoning".into(),
+                    signature: None,
+                },
+                ContentBlock::Text {
+                    text: "answer".into(),
+                },
+            ],
+            ..Default::default()
+        }];
+        let (body, _) = build_anthropic_messages_body(
+            &model,
+            &messages,
+            "system",
+            &serde_json::json!([]),
+            ThinkingConfig::Off,
+        );
+
+        let content = body["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "my reasoning");
+        assert_eq!(content[1]["type"], "text");
+        assert_eq!(content[1]["text"], "answer");
+    }
+
+    #[test_case(TEST_PLACEHOLDER_THINKING, None; "placeholder text")]
+    #[test_case("", Some("sig"); "empty thinking text")]
+    #[test_case("valid", Some("sig@bad"); "signature with @")]
+    #[test_case(TEST_PLACEHOLDER_THINKING, Some(""); "placeholder with empty sig")]
+    fn drops_invalid_thinking_blocks(thinking: &str, signature: Option<&str>) {
+        let blocks = vec![ContentBlock::Thinking {
+            thinking: thinking.into(),
+            signature: signature.map(|s| s.into()),
+        }];
+        assert!(normalize_for_claude(&blocks).is_empty());
+    }
+
+    #[test]
+    fn keeps_valid_signed_thinking() {
+        let blocks = vec![ContentBlock::Thinking {
+            thinking: "actual reasoning".into(),
+            signature: Some("clean-sig".into()),
+        }];
+        let result = normalize_for_claude(&blocks);
+
+        assert_eq!(result.len(), 1);
+        assert!(
+            matches!(&result[0], ContentBlock::Thinking { thinking, signature }
+                if thinking == "actual reasoning" && signature.as_deref() == Some("clean-sig"))
+        );
+    }
+
+    #[test]
+    fn converts_unsigned_thinking_to_text() {
+        let blocks = vec![ContentBlock::Thinking {
+            thinking: "valid reasoning".into(),
+            signature: None,
+        }];
+        let result = normalize_for_claude(&blocks);
+
+        assert_eq!(result.len(), 1);
+        assert!(matches!(&result[0], ContentBlock::Text { text } if text == "valid reasoning"));
+    }
+
+    #[test]
+    fn filters_mixed_blocks() {
+        let blocks = vec![
+            ContentBlock::Thinking {
+                thinking: TEST_PLACEHOLDER_THINKING.into(),
+                signature: None,
+            },
+            ContentBlock::Text {
+                text: "actual text".into(),
+            },
+            ContentBlock::Thinking {
+                thinking: "unsigned".into(),
+                signature: None,
+            },
+            ContentBlock::Thinking {
+                thinking: "signed".into(),
+                signature: Some("good".into()),
+            },
+            ContentBlock::Thinking {
+                thinking: "bad".into(),
+                signature: Some("sig@bad".into()),
+            },
+        ];
+        let result = normalize_for_claude(&blocks);
+
+        assert_eq!(result.len(), 3);
+        assert!(matches!(&result[0], ContentBlock::Text { text } if text == "actual text"));
+        assert!(matches!(&result[1], ContentBlock::Text { text } if text == "unsigned"));
+        assert!(
+            matches!(&result[2], ContentBlock::Thinking { thinking, signature }
+                if thinking == "signed" && signature.as_deref() == Some("good"))
+        );
+    }
+}

--- a/maki-providers/src/providers/github_copilot/auth.rs
+++ b/maki-providers/src/providers/github_copilot/auth.rs
@@ -1,0 +1,815 @@
+use std::time::Duration;
+
+use isahc::ReadResponseExt;
+use maki_storage::DataDir;
+use maki_storage::auth::{OAuthTokens, delete_tokens, load_tokens, save_tokens};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, warn};
+
+use super::platform::{COPILOT_INTEGRATION_ID, EDITOR_PLUGIN_VERSION, EDITOR_VERSION};
+use crate::AgentError;
+use crate::providers::{ResolvedAuth, urlenc};
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const TOKEN_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub(crate) const PROVIDER: &str = "github_copilot";
+const CLIENT_ID: &str = "Iv1.b507a08c87ecfe98";
+const DEVICE_CODE_URL: &str = "https://github.com/login/device/code";
+const DEVICE_TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
+const COPILOT_TOKEN_URL: &str = "https://api.github.com/copilot_internal/v2/token";
+const DEVICE_AUTH_URL: &str = "https://github.com/login/device";
+const POLL_SAFETY_MARGIN: Duration = Duration::from_secs(3);
+const POLL_TIMEOUT: Duration = Duration::from_secs(600);
+const COPILOT_EXPIRY_BUFFER_MS: u64 = 300_000;
+pub const FALLBACK_COPILOT_BASE_URL: &str = "https://api.githubcopilot.com";
+const GH_COPILOT_TOKEN_ENV: &str = "GH_COPILOT_TOKEN";
+
+#[derive(Debug, Deserialize)]
+pub struct DeviceCodeResponse {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    pub expires_in: u64,
+    pub interval: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TokenPollResponse {
+    pub access_token: Option<String>,
+    pub token_type: Option<String>,
+    pub scope: Option<String>,
+    pub error: Option<String>,
+    pub error_description: Option<String>,
+    pub interval: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CopilotTokenResponse {
+    pub token: String,
+    pub expires_at: u64,
+    #[serde(rename = "proxy-ep")]
+    pub proxy_ep: Option<String>,
+}
+
+fn build_device_code_body() -> String {
+    format!(
+        "client_id={}&scope={}",
+        urlenc(CLIENT_ID),
+        urlenc("read:user,copilot")
+    )
+}
+
+fn http_client(timeout: Duration) -> Result<isahc::HttpClient, AgentError> {
+    use isahc::config::Configurable;
+    isahc::HttpClient::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(timeout)
+        .build()
+        .map_err(|e| AgentError::Config {
+            message: format!("http client: {e}"),
+        })
+}
+
+pub fn request_device_code() -> Result<DeviceCodeResponse, AgentError> {
+    let client = http_client(TOKEN_EXCHANGE_TIMEOUT)?;
+    let form_body = build_device_code_body();
+
+    let request = isahc::Request::builder()
+        .method("POST")
+        .uri(DEVICE_CODE_URL)
+        .header("content-type", "application/x-www-form-urlencoded")
+        .header("accept", "application/json")
+        .body(form_body.into_bytes())?;
+
+    let mut resp = client.send(request).map_err(|e| AgentError::Config {
+        message: format!("device code request: {e}"),
+    })?;
+
+    if resp.status().as_u16() != 200 {
+        let body_text = resp.text().unwrap_or_else(|_| "unknown error".into());
+        return Err(AgentError::Config {
+            message: format!("device code request failed: {body_text}"),
+        });
+    }
+
+    let body_text = resp.text()?;
+    serde_json::from_str(&body_text).map_err(Into::into)
+}
+
+fn build_device_token_body(device_code: &str) -> String {
+    format!(
+        "client_id={}&device_code={}&grant_type={}",
+        urlenc(CLIENT_ID),
+        urlenc(device_code),
+        urlenc("urn:ietf:params:oauth:grant-type:device_code")
+    )
+}
+
+pub fn poll_device_token(device: &DeviceCodeResponse) -> Result<TokenPollResponse, AgentError> {
+    let client = http_client(TOKEN_EXCHANGE_TIMEOUT)?;
+    let poll_interval =
+        Duration::from_secs(device.interval).max(Duration::from_secs(1)) + POLL_SAFETY_MARGIN;
+
+    smol::block_on(poll_device_token_with(device, poll_interval, |request| {
+        client.send(request).map_err(|e| AgentError::Config {
+            message: format!("device token poll: {e}"),
+        })
+    }))
+}
+
+async fn poll_device_token_with<FSend>(
+    device: &DeviceCodeResponse,
+    poll_interval: Duration,
+    mut send: FSend,
+) -> Result<TokenPollResponse, AgentError>
+where
+    FSend: FnMut(isahc::Request<Vec<u8>>) -> Result<isahc::Response<isahc::Body>, AgentError>,
+{
+    let deadline = std::time::Instant::now() + POLL_TIMEOUT;
+    let form_body = build_device_token_body(&device.device_code);
+    let mut current_interval = poll_interval;
+
+    loop {
+        if std::time::Instant::now() > deadline {
+            return Err(AgentError::Config {
+                message: "device authorization timed out".into(),
+            });
+        }
+
+        smol::Timer::after(current_interval).await;
+
+        let request = isahc::Request::builder()
+            .method("POST")
+            .uri(DEVICE_TOKEN_URL)
+            .header("content-type", "application/x-www-form-urlencoded")
+            .header("accept", "application/json")
+            .body(form_body.clone().into_bytes())?;
+
+        let mut resp = send(request)?;
+        let body_text = resp.text()?;
+        let poll_result: TokenPollResponse = serde_json::from_str(&body_text)?;
+
+        match classify_poll_response(&poll_result) {
+            PollStatus::Success => return Ok(poll_result),
+            PollStatus::Pending => {
+                debug!("authorization pending, continuing poll");
+            }
+            PollStatus::SlowDown(new_interval) => {
+                warn!("polling too fast, slowing down");
+                current_interval = new_interval;
+            }
+            PollStatus::Error(msg) => {
+                return Err(AgentError::Config {
+                    message: format!("device authorization failed: {msg}"),
+                });
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum PollStatus {
+    Success,
+    Pending,
+    SlowDown(Duration),
+    Error(String),
+}
+
+fn classify_poll_response(response: &TokenPollResponse) -> PollStatus {
+    if response.access_token.is_some() {
+        return PollStatus::Success;
+    }
+
+    if let Some(error) = &response.error {
+        match error.as_str() {
+            "authorization_pending" => PollStatus::Pending,
+            "slow_down" => {
+                let interval = response
+                    .interval
+                    .map(Duration::from_secs)
+                    .unwrap_or_else(|| Duration::from_secs(10));
+                PollStatus::SlowDown(interval + POLL_SAFETY_MARGIN)
+            }
+            _ => PollStatus::Error(format!(
+                "{} - {}",
+                error,
+                response
+                    .error_description
+                    .as_deref()
+                    .unwrap_or("unknown error")
+            )),
+        }
+    } else {
+        PollStatus::Error("no access token received".into())
+    }
+}
+
+pub fn exchange_copilot_token(github_token: &str) -> Result<CopilotTokenResponse, AgentError> {
+    let client = http_client(TOKEN_EXCHANGE_TIMEOUT)?;
+
+    let request = isahc::Request::builder()
+        .method("GET")
+        .uri(COPILOT_TOKEN_URL)
+        .header("authorization", format!("token {github_token}"))
+        .header("accept", "application/json")
+        .header("Editor-Version", EDITOR_VERSION)
+        .header("Editor-Plugin-Version", EDITOR_PLUGIN_VERSION)
+        .header("Copilot-Integration-Id", COPILOT_INTEGRATION_ID)
+        .body(())?;
+
+    let mut resp = client.send(request).map_err(|e| AgentError::Config {
+        message: format!("copilot token exchange: {e}"),
+    })?;
+
+    if resp.status().as_u16() != 200 {
+        let body_text = resp.text().unwrap_or_else(|_| "unknown error".into());
+        return Err(AgentError::Config {
+            message: format!("copilot token exchange failed: {body_text}"),
+        });
+    }
+
+    let body_text = resp.text()?;
+    serde_json::from_str(&body_text).map_err(Into::into)
+}
+
+pub fn refresh_tokens(tokens: &OAuthTokens) -> Result<OAuthTokens, AgentError> {
+    let expired = tokens.is_expired();
+    debug!(expired, "refreshing GitHub Copilot tokens");
+
+    let github_token = &tokens.refresh;
+    let copilot = exchange_copilot_token(github_token)?;
+    Ok(into_oauth_tokens(github_token, copilot))
+}
+
+pub fn resolve(dir: &DataDir) -> Result<ResolvedAuth, AgentError> {
+    if let Ok(env_token) = std::env::var(GH_COPILOT_TOKEN_ENV)
+        && !env_token.is_empty()
+    {
+        debug!("using GitHub Copilot authentication from GH_COPILOT_TOKEN");
+        return Ok(build_resolved_auth_from_token(&env_token));
+    }
+
+    if let Some(tokens) = load_tokens(dir, PROVIDER) {
+        if !tokens.is_expired() {
+            debug!("using GitHub Copilot authentication");
+            return Ok(build_resolved_auth(&tokens));
+        }
+        match refresh_tokens(&tokens) {
+            Ok(fresh) => {
+                save_tokens(dir, PROVIDER, &fresh)?;
+                debug!("using GitHub Copilot authentication (refreshed)");
+                return Ok(build_resolved_auth(&fresh));
+            }
+            Err(e) => {
+                warn!(error = %e, "GitHub Copilot token refresh failed, clearing stale tokens");
+                delete_tokens(dir, PROVIDER).ok();
+            }
+        }
+    }
+
+    Err(AgentError::Config {
+        message: "not authenticated, run `maki auth login github-copilot`".into(),
+    })
+}
+
+pub fn login(dir: &DataDir) -> Result<(), AgentError> {
+    let device = request_device_code()?;
+
+    println!("Open this URL in your browser:\n\n  {DEVICE_AUTH_URL}\n");
+    println!("Enter code: {}\n", device.user_code);
+    println!("Waiting for authorization...");
+
+    let token_resp = poll_device_token(&device).map_err(|e| {
+        error!(error = %e, "GitHub device authorization failed");
+        e
+    })?;
+
+    let github_token = token_resp.access_token.ok_or_else(|| AgentError::Config {
+        message: "no access token received from GitHub".into(),
+    })?;
+
+    let copilot = exchange_copilot_token(&github_token).map_err(|e| {
+        error!(error = %e, "GitHub Copilot token exchange failed");
+        e
+    })?;
+
+    let tokens = into_oauth_tokens(&github_token, copilot);
+    save_tokens(dir, PROVIDER, &tokens)?;
+    println!("Authenticated successfully.");
+    Ok(())
+}
+
+pub fn logout(dir: &DataDir) -> Result<(), AgentError> {
+    if delete_tokens(dir, PROVIDER)? {
+        println!("Logged out of GitHub Copilot.");
+    } else {
+        println!("Not currently logged in to GitHub Copilot.");
+    }
+    Ok(())
+}
+
+fn build_resolved_auth(tokens: &OAuthTokens) -> ResolvedAuth {
+    let base_url = extract_proxy_ep(&tokens.access)
+        .and_then(normalize_proxy_ep)
+        .unwrap_or_else(|| FALLBACK_COPILOT_BASE_URL.into());
+
+    ResolvedAuth {
+        base_url: Some(base_url),
+        headers: vec![("authorization".into(), format!("Bearer {}", tokens.access))],
+    }
+}
+
+fn build_resolved_auth_from_token(token: &str) -> ResolvedAuth {
+    let base_url = extract_proxy_ep(token)
+        .and_then(normalize_proxy_ep)
+        .unwrap_or_else(|| FALLBACK_COPILOT_BASE_URL.into());
+
+    ResolvedAuth {
+        base_url: Some(base_url),
+        headers: vec![("authorization".into(), format!("Bearer {token}"))],
+    }
+}
+
+const DISALLOWED_AUTH_HEADERS: &[&str] = &[
+    "cookie",
+    "x-auth-token",
+    "x-api-key",
+    "x-csrf-token",
+    "set-cookie",
+];
+
+pub fn sanitize_headers(headers: &mut Vec<(String, String)>) {
+    headers.retain(|(key, _)| {
+        let key_lower = key.to_lowercase();
+        !DISALLOWED_AUTH_HEADERS
+            .iter()
+            .any(|disallowed| key_lower == *disallowed)
+    });
+}
+
+fn extract_proxy_ep(token: &str) -> Option<String> {
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    let parts: Vec<&str> = token.split('.').take(4).collect();
+    if parts.len() != 3 || parts.iter().any(|p| p.is_empty()) {
+        return None;
+    }
+
+    let payload = URL_SAFE_NO_PAD.decode(parts[1]).ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&payload).ok()?;
+
+    json.get("proxy-ep")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+}
+
+fn normalize_proxy_ep(proxy_ep: String) -> Option<String> {
+    let trimmed = proxy_ep.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let url = if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        trimmed.to_string()
+    } else {
+        format!("https://{}", trimmed)
+    };
+
+    let scheme_end = url.find("://")?;
+    let scheme = &url[..scheme_end];
+    let rest = &url[scheme_end + 3..];
+
+    let host_port = rest.split('/').next()?;
+    if host_port.is_empty() {
+        return None;
+    }
+
+    Some(format!("{scheme}://{host_port}"))
+}
+
+fn into_oauth_tokens(github_token: &str, copilot: CopilotTokenResponse) -> OAuthTokens {
+    OAuthTokens {
+        access: copilot.token,
+        refresh: github_token.into(),
+        expires: copilot
+            .expires_at
+            .saturating_mul(1000)
+            .saturating_sub(COPILOT_EXPIRY_BUFFER_MS),
+        account_id: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use maki_storage::DataDir;
+    use maki_storage::auth::{load_tokens, now_millis, save_tokens};
+    use test_case::test_case;
+
+    use super::*;
+
+    pub(crate) const TEST_PROVIDER: &str = "github_copilot";
+
+    pub(crate) fn sample_oauth_tokens() -> OAuthTokens {
+        OAuthTokens {
+            access: "copilot_xyz789".into(),
+            refresh: "gho_abc123xyz".into(),
+            expires: now_millis() + 3_600_000,
+            account_id: None,
+        }
+    }
+
+    #[test]
+    fn device_code_response_parses() {
+        let json = r#"{
+            "device_code": "device-code-abc",
+            "user_code": "ABCD-1234",
+            "verification_uri": "https://github.com/login/device",
+            "expires_in": 900,
+            "interval": 5
+        }"#;
+        let parsed: DeviceCodeResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.device_code, "device-code-abc");
+        assert_eq!(parsed.user_code, "ABCD-1234");
+        assert_eq!(parsed.expires_in, 900);
+    }
+
+    #[test]
+    fn token_poll_success_parses() {
+        let json = r#"{
+            "access_token": "gho_abc123xyz",
+            "token_type": "bearer",
+            "scope": "read:user,copilot"
+        }"#;
+        let parsed: TokenPollResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.access_token.unwrap(), "gho_abc123xyz");
+        assert_eq!(parsed.error, None);
+    }
+
+    #[test]
+    fn token_poll_error_parses() {
+        let json = r#"{
+            "error": "authorization_pending",
+            "error_description": "The authorization request is still pending.",
+            "interval": 5
+        }"#;
+        let parsed: TokenPollResponse = serde_json::from_str(json).unwrap();
+        assert!(parsed.access_token.is_none());
+        assert_eq!(parsed.error.as_deref(), Some("authorization_pending"));
+    }
+
+    #[test]
+    fn copilot_token_response_parses() {
+        let json = r#"{"token": "copilot_xyz789", "expires_at": 9999999999}"#;
+        let parsed: CopilotTokenResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.token, "copilot_xyz789");
+        assert_eq!(parsed.expires_at, 9999999999);
+    }
+
+    #[test]
+    fn resolve_fails_without_auth() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = DataDir::from_path(tmp.path().to_path_buf());
+        unsafe {
+            std::env::remove_var(GH_COPILOT_TOKEN_ENV);
+        }
+        assert!(resolve(&dir).is_err());
+    }
+
+    #[test_case(vec![("authorization", "Bearer token"), ("content-type", "application/json")], 2)]
+    #[test_case(vec![("authorization", "Bearer token"), ("cookie", "session=abc")], 1)]
+    fn sanitize_headers_filters_disallowed(headers: Vec<(&str, &str)>, expected: usize) {
+        let mut headers: Vec<(String, String)> = headers
+            .into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect();
+        sanitize_headers(&mut headers);
+        assert_eq!(headers.len(), expected);
+    }
+
+    #[test]
+    fn extract_proxy_ep_from_valid_jwt() {
+        use base64::Engine;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        let payload = r#"{"proxy-ep":"https://proxy.example.com/v1/chat"}"#;
+        let encoded = URL_SAFE_NO_PAD.encode(payload);
+        let token = format!("header.{}.{}", encoded, "sig");
+        assert_eq!(
+            extract_proxy_ep(&token),
+            Some("https://proxy.example.com/v1/chat".into())
+        );
+    }
+
+    #[test_case("not.valid", None)]
+    #[test_case("invalid", None)]
+    #[test_case(".b.c", None)]
+    #[test_case("a..c", None)]
+    #[test_case("a.b.", None)]
+    #[test_case("a.b.c.d", None)]
+    fn extract_proxy_ep_error_cases(token: &str, expected: Option<String>) {
+        assert_eq!(extract_proxy_ep(token), expected);
+    }
+
+    #[test_case("https://proxy.example.com/v1/chat", Some("https://proxy.example.com"))]
+    #[test_case("proxy.example.com", Some("https://proxy.example.com"))]
+    #[test_case("", None)]
+    fn normalize_proxy_ep_cases(input: &str, expected: Option<&str>) {
+        assert_eq!(normalize_proxy_ep(input.into()), expected.map(String::from));
+    }
+
+    #[test]
+    fn into_oauth_tokens_saturates_on_small_expires() {
+        let gh_token = "gho_test";
+        let copilot = CopilotTokenResponse {
+            token: "cop".into(),
+            expires_at: 301,
+            proxy_ep: None,
+        };
+        let tokens = into_oauth_tokens(gh_token, copilot);
+        assert_eq!(tokens.expires, 1000);
+    }
+
+    #[test]
+    fn resolved_auth_fallback_for_invalid_token() {
+        let tokens = OAuthTokens {
+            access: "not_a_valid_jwt".into(),
+            refresh: "gho_test".into(),
+            expires: now_millis() + 3_600_000,
+            account_id: None,
+        };
+        let auth = build_resolved_auth(&tokens);
+        assert_eq!(auth.base_url, Some(FALLBACK_COPILOT_BASE_URL.into()));
+    }
+
+    #[test]
+    fn resolved_auth_uses_proxy_ep_from_token() {
+        use base64::Engine;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        let payload = r#"{"proxy-ep":"https://proxy.example.com/v1/chat"}"#;
+        let encoded = URL_SAFE_NO_PAD.encode(payload);
+        let token = format!("header.{}.{}", encoded, "sig");
+        let tokens = OAuthTokens {
+            access: token,
+            refresh: "gho_test".into(),
+            expires: now_millis() + 3_600_000,
+            account_id: None,
+        };
+        let auth = build_resolved_auth(&tokens);
+        assert_eq!(auth.base_url, Some("https://proxy.example.com".into()));
+    }
+
+    #[test]
+    fn resolve_prefers_env_token() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = DataDir::from_path(tmp.path().to_path_buf());
+        unsafe {
+            std::env::set_var(GH_COPILOT_TOKEN_ENV, "env_token");
+        }
+        let auth = resolve(&dir).unwrap();
+        unsafe {
+            std::env::remove_var(GH_COPILOT_TOKEN_ENV);
+        }
+        assert_eq!(auth.base_url, Some(FALLBACK_COPILOT_BASE_URL.into()));
+    }
+
+    #[test]
+    fn resolve_uses_stored_tokens() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = DataDir::from_path(tmp.path().to_path_buf());
+        save_tokens(&dir, TEST_PROVIDER, &sample_oauth_tokens()).unwrap();
+        unsafe {
+            std::env::remove_var(GH_COPILOT_TOKEN_ENV);
+        }
+        let auth = resolve(&dir).unwrap();
+        assert!(auth.headers.iter().any(|(k, _)| k == "authorization"));
+        let header = auth
+            .headers
+            .iter()
+            .find(|(k, _)| k == "authorization")
+            .map(|(_, v)| v.as_str());
+        assert!(header.unwrap().starts_with("Bearer "));
+    }
+
+    #[test]
+    fn logout_clears_tokens() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = DataDir::from_path(tmp.path().to_path_buf());
+        save_tokens(&dir, TEST_PROVIDER, &sample_oauth_tokens()).unwrap();
+        assert!(load_tokens(&dir, TEST_PROVIDER).is_some());
+        logout(&dir).unwrap();
+        assert!(load_tokens(&dir, TEST_PROVIDER).is_none());
+    }
+
+    #[test]
+    fn logout_ok_when_not_logged_in() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = DataDir::from_path(tmp.path().to_path_buf());
+        assert!(logout(&dir).is_ok());
+    }
+
+    #[test]
+    fn resolve_clears_stale_tokens_on_refresh_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = DataDir::from_path(tmp.path().to_path_buf());
+        let expired = OAuthTokens {
+            access: "expired".into(),
+            refresh: "invalid".into(),
+            expires: now_millis() - 1000,
+            account_id: None,
+        };
+        save_tokens(&dir, TEST_PROVIDER, &expired).unwrap();
+        unsafe {
+            std::env::remove_var(GH_COPILOT_TOKEN_ENV);
+        }
+        assert!(resolve(&dir).is_err());
+        assert!(load_tokens(&dir, TEST_PROVIDER).is_none());
+    }
+
+    #[test]
+    fn extract_proxy_ep_handles_invalid_json() {
+        use base64::Engine;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        let encoded = URL_SAFE_NO_PAD.encode("not json");
+        let token = format!("header.{}.{}", encoded, "sig");
+        assert_eq!(extract_proxy_ep(&token), None);
+    }
+
+    #[test]
+    fn extract_proxy_ep_handles_missing_proxy_ep() {
+        use base64::Engine;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        let encoded = URL_SAFE_NO_PAD.encode(r#"{"other":"value"}"#);
+        let token = format!("header.{}.{}", encoded, "sig");
+        assert_eq!(extract_proxy_ep(&token), None);
+    }
+
+    #[test]
+    fn extract_proxy_ep_handles_null_proxy_ep() {
+        use base64::Engine;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        let encoded_payload = URL_SAFE_NO_PAD.encode(r#"{"proxy-ep":null}"#);
+        let token = format!("header.{}.{}", encoded_payload, "signature");
+
+        assert_eq!(extract_proxy_ep(&token), None);
+    }
+
+    #[test_case("https://", None)]
+    #[test_case("http:/bad", Some("https://http:"))]
+    fn normalize_proxy_ep_edge_cases(input: &str, expected: Option<&str>) {
+        assert_eq!(normalize_proxy_ep(input.into()), expected.map(String::from));
+    }
+
+    #[test]
+    fn device_code_body_contains_required_params() {
+        let body = build_device_code_body();
+        assert!(body.contains("client_id="));
+        assert!(body.contains("scope="));
+    }
+
+    #[test]
+    fn device_token_body_url_encodes_params() {
+        let body = build_device_token_body("code with spaces");
+        assert!(body.contains("device_code=code%20with%20spaces"));
+    }
+
+    #[test]
+    fn classify_poll_response_success() {
+        let response = TokenPollResponse {
+            access_token: Some("token123".into()),
+            token_type: Some("bearer".into()),
+            scope: Some("read".into()),
+            error: None,
+            error_description: None,
+            interval: None,
+        };
+        assert_eq!(classify_poll_response(&response), PollStatus::Success);
+    }
+
+    #[test]
+    fn classify_poll_response_pending() {
+        let response = TokenPollResponse {
+            access_token: None,
+            token_type: None,
+            scope: None,
+            error: Some("authorization_pending".into()),
+            error_description: None,
+            interval: None,
+        };
+        assert_eq!(classify_poll_response(&response), PollStatus::Pending);
+    }
+
+    #[test_case(Some(5), Duration::from_secs(8))]
+    #[test_case(None, Duration::from_secs(13))]
+    fn classify_poll_response_slow_down(interval: Option<u64>, expected: Duration) {
+        let response = TokenPollResponse {
+            access_token: None,
+            token_type: None,
+            scope: None,
+            error: Some("slow_down".into()),
+            error_description: None,
+            interval,
+        };
+        assert!(
+            matches!(classify_poll_response(&response), PollStatus::SlowDown(d) if d == expected)
+        );
+    }
+
+    #[test]
+    fn classify_poll_response_error_cases() {
+        let unknown = TokenPollResponse {
+            access_token: None,
+            token_type: None,
+            scope: None,
+            error: Some("expired_token".into()),
+            error_description: Some("token expired".into()),
+            interval: None,
+        };
+        assert!(
+            matches!(classify_poll_response(&unknown), PollStatus::Error(ref m) if m.contains("expired"))
+        );
+
+        let no_token = TokenPollResponse {
+            access_token: None,
+            token_type: None,
+            scope: None,
+            error: None,
+            error_description: None,
+            interval: None,
+        };
+        assert!(
+            matches!(classify_poll_response(&no_token), PollStatus::Error(ref m) if m == "no access token received")
+        );
+    }
+
+    #[test]
+    fn poll_device_token_retries_pending() {
+        use std::cell::RefCell;
+        let device = DeviceCodeResponse {
+            device_code: "d123".into(),
+            user_code: "C123".into(),
+            verification_uri: "https://github.com/login/device".into(),
+            expires_in: 900,
+            interval: 1,
+        };
+        let pending = r#"{"error":"authorization_pending"}"#;
+        let success = r#"{"access_token":"gho_abc"}"#;
+
+        let calls = RefCell::new(0);
+        let mock_send = |_req: isahc::Request<Vec<u8>>| {
+            let c = *calls.borrow();
+            *calls.borrow_mut() = c + 1;
+            let body = if c == 0 {
+                isahc::Body::from(pending)
+            } else {
+                isahc::Body::from(success)
+            };
+            Ok::<_, AgentError>(isahc::Response::builder().status(200).body(body).unwrap())
+        };
+
+        let result = smol::block_on(poll_device_token_with(
+            &device,
+            Duration::from_millis(1),
+            mock_send,
+        ));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().access_token, Some("gho_abc".into()));
+    }
+
+    #[test]
+    fn poll_device_token_propagates_errors_from_send() {
+        use std::cell::RefCell;
+        let device = DeviceCodeResponse {
+            device_code: "d789".into(),
+            user_code: "C789".into(),
+            verification_uri: "https://github.com/login/device".into(),
+            expires_in: 900,
+            interval: 1,
+        };
+
+        let call_count = RefCell::new(0);
+        let mock_send = move |_req: isahc::Request<Vec<u8>>| {
+            let count = *call_count.borrow();
+            *call_count.borrow_mut() = count + 1;
+            if count >= 1 {
+                return Err(AgentError::Config {
+                    message: "network error".into(),
+                });
+            }
+            Ok::<_, AgentError>(
+                isahc::Response::builder()
+                    .status(200)
+                    .body(isahc::Body::from(r#"{"error":"authorization_pending"}"#))
+                    .unwrap(),
+            )
+        };
+
+        let result = smol::block_on(poll_device_token_with(
+            &device,
+            Duration::from_millis(1),
+            mock_send,
+        ));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("network error"));
+    }
+}

--- a/maki-providers/src/providers/github_copilot/mod.rs
+++ b/maki-providers/src/providers/github_copilot/mod.rs
@@ -1,0 +1,510 @@
+//! GitHub Copilot API provider.
+//! Uses the GitHub Copilot Chat API with OpenAI-compatible models.
+
+pub(crate) mod anthropic;
+pub mod auth;
+mod models;
+pub(crate) mod openai;
+pub mod platform;
+
+pub(crate) use models::{endpoint_path_for_model, models};
+
+use flume::Sender;
+use maki_storage::DataDir;
+use serde_json::Value;
+
+use crate::model::Model;
+use crate::provider::{BoxFuture, Provider};
+use crate::providers::ResolvedAuth;
+use crate::providers::anthropic::Anthropic;
+use crate::providers::github_copilot::anthropic::MessagesThinkingMode;
+use crate::providers::openai::OpenAi;
+use crate::providers::openai_compat::OpenAiCompatProvider;
+use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig, Timeouts};
+
+use platform::GitHubCopilotPlatform;
+
+#[derive(Debug)]
+struct StreamMetadata {
+    endpoint: platform::EndpointPath,
+    body: Value,
+    anthropic_mode: Option<MessagesThinkingMode>,
+}
+
+static CONFIG: crate::providers::openai_compat::OpenAiCompatConfig =
+    crate::providers::openai_compat::OpenAiCompatConfig {
+        api_key_env: "",
+        base_url: auth::FALLBACK_COPILOT_BASE_URL,
+        max_tokens_field: "max_completion_tokens",
+        include_stream_usage: false,
+        provider_name: "GitHub Copilot",
+    };
+
+pub struct GitHubCopilot {
+    platform: GitHubCopilotPlatform,
+    compat: OpenAiCompatProvider,
+    anthropic: Anthropic,
+    openai: OpenAi,
+}
+
+impl GitHubCopilot {
+    pub fn new() -> Result<Self, AgentError> {
+        let storage = DataDir::resolve()?;
+        let platform = GitHubCopilotPlatform::new(&storage)?;
+        let compat = OpenAiCompatProvider::new(&CONFIG, Timeouts::default());
+        let anthropic = Anthropic::with_auth(platform.share_auth_for_child(), Timeouts::default());
+        let openai = OpenAi::with_auth(platform.share_auth_for_child(), Timeouts::default());
+        Ok(Self {
+            platform,
+            compat,
+            anthropic,
+            openai,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn from_parts(platform: GitHubCopilotPlatform, compat: OpenAiCompatProvider) -> Self {
+        let anthropic = Anthropic::with_auth(platform.share_auth_for_child(), Timeouts::default());
+        let openai = OpenAi::with_auth(platform.share_auth_for_child(), Timeouts::default());
+        Self {
+            platform,
+            compat,
+            anthropic,
+            openai,
+        }
+    }
+
+    fn build_stream_metadata(
+        &self,
+        model: &Model,
+        messages: &[Message],
+        system: &str,
+        tools: &Value,
+        thinking: ThinkingConfig,
+        session_id: Option<&str>,
+    ) -> StreamMetadata {
+        use crate::providers::github_copilot::platform::EndpointPath;
+
+        let endpoint = self.platform.select_endpoint_path(&model.id);
+        let (body, anthropic_mode) = match endpoint {
+            EndpointPath::Responses => {
+                let mut body =
+                    openai::build_responses_body(model, messages, system, tools, false, thinking);
+                openai::apply_responses_extensions(&mut body, session_id);
+                (body, None)
+            }
+            EndpointPath::V1Messages => {
+                let (body, mode) = anthropic::build_anthropic_messages_body(
+                    model, messages, system, tools, thinking,
+                );
+                (body, Some(mode))
+            }
+            EndpointPath::ChatCompletions => {
+                let body = self.compat.build_body(model, messages, system, tools);
+                (body, None)
+            }
+        };
+
+        StreamMetadata {
+            endpoint,
+            body,
+            anthropic_mode,
+        }
+    }
+
+    fn current_auth(&self) -> ResolvedAuth {
+        let mut auth = self.platform.current_auth();
+        auth.base_url.get_or_insert_with(|| {
+            crate::providers::github_copilot::auth::FALLBACK_COPILOT_BASE_URL.into()
+        });
+        auth
+    }
+
+    /// Use one auth snapshot per request to avoid auth/header races.
+    fn current_auth_with_headers(&self, messages: &[Message]) -> ResolvedAuth {
+        let mut auth = self.current_auth();
+        auth.headers = GitHubCopilotPlatform::build_headers_from_auth(&auth, messages);
+        auth
+    }
+}
+
+impl Provider for GitHubCopilot {
+    fn stream_message<'a>(
+        &'a self,
+        model: &'a Model,
+        messages: &'a [Message],
+        system: &'a str,
+        tools: &'a Value,
+        event_tx: &'a Sender<ProviderEvent>,
+        thinking: ThinkingConfig,
+        session_id: Option<&'a str>,
+    ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
+        Box::pin(async move {
+            use crate::providers::github_copilot::platform::EndpointPath;
+
+            let meta =
+                self.build_stream_metadata(model, messages, system, tools, thinking, session_id);
+
+            match meta.endpoint {
+                EndpointPath::Responses => {
+                    self.platform
+                        .with_auth_retry(|| async {
+                            let auth = self.current_auth_with_headers(messages);
+                            self.openai
+                                .do_responses_with_parse(
+                                    model,
+                                    &meta.body,
+                                    event_tx,
+                                    &auth,
+                                    openai::parse_usage,
+                                )
+                                .await
+                        })
+                        .await
+                }
+                EndpointPath::V1Messages => {
+                    let Some(mode) = meta.anthropic_mode else {
+                        return Err(crate::AgentError::Config {
+                            message: "V1Messages endpoint requires thinking mode configuration"
+                                .into(),
+                        });
+                    };
+                    self.platform
+                        .with_auth_retry(|| async {
+                            let mut auth = self.current_auth_with_headers(messages);
+                            anthropic::adjust_anthropic_beta_header(
+                                &mut auth.headers,
+                                mode,
+                                &model.id,
+                            );
+                            let url = auth
+                                .base_url
+                                .as_ref()
+                                .map(|base| format!("{}/v1/messages", base.trim_end_matches('/')));
+                            self.anthropic
+                                .do_stream_request_with_url(
+                                    &meta.body,
+                                    event_tx,
+                                    url.as_deref(),
+                                    &auth,
+                                )
+                                .await
+                        })
+                        .await
+                }
+                EndpointPath::ChatCompletions => {
+                    self.platform
+                        .with_auth_retry(|| async {
+                            let auth = self.current_auth_with_headers(messages);
+                            self.compat
+                                .do_stream_with_path(
+                                    model,
+                                    &[] as &[(String, String)],
+                                    &meta.body,
+                                    event_tx,
+                                    &auth,
+                                    meta.endpoint.as_str(),
+                                )
+                                .await
+                        })
+                        .await
+                }
+            }
+        })
+    }
+
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+        Box::pin(async {
+            Ok(models()
+                .iter()
+                .flat_map(|e| e.prefixes.iter())
+                .map(|p| p.to_string())
+                .collect())
+        })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_constants {
+    pub(crate) const GPT5_MODEL: &str = "gpt-5.4";
+    pub(crate) const GPT5_SPEC: &str = "github-copilot/gpt-5.4";
+    pub(crate) const CLAUDE_SPEC: &str = "github-copilot/claude-sonnet-4";
+    pub(crate) const GPT4_SPEC: &str = "github-copilot/gpt-4o";
+
+    pub(crate) const GEMINI_25_PRO_SPEC: &str = "github-copilot/gemini-2.5-pro";
+    pub(crate) const GEMINI_3_PRO_SPEC: &str = "github-copilot/gemini-3-pro-preview";
+    pub(crate) const GROK_CODE_FAST_SPEC: &str = "github-copilot/grok-code-fast-1";
+
+    pub(crate) const FALLBACK_CHAT_MODEL_SPECS: &[&str] =
+        &[GEMINI_25_PRO_SPEC, GEMINI_3_PRO_SPEC, GROK_CODE_FAST_SPEC];
+}
+
+#[cfg(test)]
+mod wrapper_tests {
+    use std::sync::{Arc, Mutex};
+
+    use crate::Message;
+    use crate::providers::ResolvedAuth;
+    use crate::providers::github_copilot::auth::FALLBACK_COPILOT_BASE_URL;
+    use crate::providers::github_copilot::platform::GitHubCopilotPlatform;
+    use crate::providers::openai_compat::OpenAiCompatProvider;
+
+    use super::test_constants::{CLAUDE_SPEC, FALLBACK_CHAT_MODEL_SPECS, GPT4_SPEC, GPT5_SPEC};
+    use super::*;
+
+    pub(crate) const TEST_TOKEN: &str = "test_copilot_token_abc123";
+    pub(crate) const TEST_BASE_URL: &str = "https://proxy.individual.githubcopilot.com";
+
+    pub(crate) fn make_auth(
+        base_url: Option<&str>,
+        auth_header: Option<&str>,
+    ) -> Arc<Mutex<ResolvedAuth>> {
+        let headers = auth_header.map(|h| ("authorization".into(), format!("Bearer {h}")));
+        Arc::new(Mutex::new(ResolvedAuth {
+            base_url: base_url.map(String::from),
+            headers: headers.into_iter().collect(),
+        }))
+    }
+
+    pub(crate) fn make_copilot(auth: Arc<Mutex<ResolvedAuth>>) -> GitHubCopilot {
+        let platform = GitHubCopilotPlatform::with_auth(auth);
+        let compat = OpenAiCompatProvider::new(&CONFIG, Timeouts::default());
+        GitHubCopilot::from_parts(platform, compat)
+    }
+
+    pub(crate) fn user_message() -> Vec<Message> {
+        vec![Message::user("hello".into())]
+    }
+
+    #[test]
+    fn current_auth_falls_back_to_default_base_url() {
+        let auth = make_auth(None, Some(TEST_TOKEN));
+        let copilot = make_copilot(auth);
+        let resolved = copilot.current_auth();
+        assert_eq!(resolved.base_url, Some(FALLBACK_COPILOT_BASE_URL.into()));
+    }
+
+    #[test]
+    fn auth_headers_include_required_copilot_headers() {
+        let auth = make_auth(Some(TEST_BASE_URL), Some(TEST_TOKEN));
+        let copilot = make_copilot(auth);
+        let resolved = copilot.current_auth_with_headers(&user_message());
+
+        let has_authorization = resolved
+            .headers
+            .iter()
+            .any(|(k, _)| k.to_lowercase() == "authorization");
+        assert!(has_authorization, "authorization header should be present");
+
+        let has_editor_version = resolved
+            .headers
+            .iter()
+            .any(|(k, _)| k.to_lowercase() == "editor-version");
+        assert!(
+            has_editor_version,
+            "editor-version header should be present"
+        );
+
+        let has_copilot_integration_id = resolved
+            .headers
+            .iter()
+            .any(|(k, _)| k.to_lowercase() == "copilot-integration-id");
+        assert!(
+            has_copilot_integration_id,
+            "copilot-integration-id header should be present"
+        );
+    }
+
+    #[test]
+    fn gpt5_routes_to_responses() {
+        let auth = make_auth(Some(TEST_BASE_URL), Some(TEST_TOKEN));
+        let copilot = make_copilot(auth);
+        let model = Model::from_spec(GPT5_SPEC).unwrap();
+
+        let meta = copilot.build_stream_metadata(
+            &model,
+            &user_message(),
+            "system",
+            &serde_json::json!([]),
+            ThinkingConfig::Off,
+            None,
+        );
+        let (path, body) = (meta.endpoint, meta.body);
+
+        assert_eq!(path.as_str(), "/responses");
+        assert!(body.get("input").is_some());
+        assert_eq!(body["model"], super::test_constants::GPT5_MODEL);
+    }
+
+    #[test]
+    fn claude_routes_to_v1_messages() {
+        let auth = make_auth(Some(TEST_BASE_URL), Some(TEST_TOKEN));
+        let copilot = make_copilot(auth);
+        let model = Model::from_spec(CLAUDE_SPEC).unwrap();
+
+        let meta = copilot.build_stream_metadata(
+            &model,
+            &user_message(),
+            "system",
+            &serde_json::json!([]),
+            ThinkingConfig::Off,
+            None,
+        );
+        let (path, body) = (meta.endpoint, meta.body);
+
+        assert_eq!(path.as_str(), "/v1/messages");
+        assert!(body.get("messages").is_some());
+        assert!(body.get("system").is_some());
+    }
+
+    #[test]
+    fn gpt4_routes_to_chat_completions() {
+        let auth = make_auth(Some(TEST_BASE_URL), Some(TEST_TOKEN));
+        let copilot = make_copilot(auth);
+        let model = Model::from_spec(GPT4_SPEC).unwrap();
+
+        let meta = copilot.build_stream_metadata(
+            &model,
+            &user_message(),
+            "system",
+            &serde_json::json!([]),
+            ThinkingConfig::Off,
+            None,
+        );
+        let (path, body) = (meta.endpoint, meta.body);
+
+        assert_eq!(path.as_str(), "/chat/completions");
+        assert!(body.get("messages").is_some());
+        assert!(body.get("system").is_none());
+    }
+
+    #[test]
+    fn fallback_models_route_to_chat_completions() {
+        let auth = make_auth(Some(TEST_BASE_URL), Some(TEST_TOKEN));
+        let copilot = make_copilot(auth);
+
+        for spec in FALLBACK_CHAT_MODEL_SPECS {
+            let model = Model::from_spec(spec).unwrap();
+            let meta = copilot.build_stream_metadata(
+                &model,
+                &user_message(),
+                "system",
+                &serde_json::json!([]),
+                ThinkingConfig::Off,
+                None,
+            );
+            let (path, body) = (meta.endpoint, meta.body);
+            assert_eq!(path.as_str(), "/chat/completions", "{spec}");
+            assert!(body.get("messages").is_some());
+        }
+    }
+
+    #[test]
+    fn responses_cache_key_behavior() {
+        let auth = make_auth(Some(TEST_BASE_URL), Some(TEST_TOKEN));
+        let copilot = make_copilot(auth);
+        let model = Model::from_spec(GPT5_SPEC).unwrap();
+
+        let cases = [(Some("session-abc"), true), (None, false)];
+
+        for (session_id, expect_key) in cases {
+            let meta = copilot.build_stream_metadata(
+                &model,
+                &user_message(),
+                "system",
+                &serde_json::json!([]),
+                ThinkingConfig::Off,
+                session_id,
+            );
+            let body = meta.body;
+
+            if expect_key {
+                let key = body["prompt_cache_key"].as_str().unwrap();
+                assert!(key.starts_with("maki-"));
+            } else {
+                assert!(body.get("prompt_cache_key").is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn thinking_config_for_responses_path() {
+        let auth = make_auth(Some(TEST_BASE_URL), Some(TEST_TOKEN));
+        let copilot = make_copilot(auth);
+        let model = Model::from_spec(GPT5_SPEC).unwrap();
+
+        let cases = [
+            (ThinkingConfig::Adaptive, true),
+            (ThinkingConfig::Off, false),
+        ];
+
+        for (config, expect_reasoning) in cases {
+            let meta = copilot.build_stream_metadata(
+                &model,
+                &user_message(),
+                "system",
+                &serde_json::json!([]),
+                config,
+                None,
+            );
+            let body = meta.body;
+
+            if expect_reasoning {
+                assert_eq!(body["reasoning"]["effort"], "high");
+            } else {
+                assert!(body.get("reasoning").is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn thinking_budget_uses_manual_mode() {
+        let auth = make_auth(Some(TEST_BASE_URL), Some(TEST_TOKEN));
+        let copilot = make_copilot(auth);
+        let model = Model::from_spec(CLAUDE_SPEC).unwrap();
+
+        let meta = copilot.build_stream_metadata(
+            &model,
+            &user_message(),
+            "system",
+            &serde_json::json!([]),
+            ThinkingConfig::Budget(8192),
+            None,
+        );
+        let body = meta.body;
+
+        assert_eq!(body["thinking"]["type"], "enabled");
+        assert_eq!(body["thinking"]["budget_tokens"], 8192);
+    }
+
+    #[test]
+    fn v1_messages_uses_auth_with_headers() {
+        let auth = make_auth(Some(TEST_BASE_URL), Some(TEST_TOKEN));
+        let copilot = make_copilot(auth);
+
+        let resolved = copilot.current_auth_with_headers(&user_message());
+
+        let has_editor_version = resolved
+            .headers
+            .iter()
+            .any(|(k, _)| k.to_lowercase() == "editor-version");
+        let has_copilot_integration_id = resolved
+            .headers
+            .iter()
+            .any(|(k, _)| k.to_lowercase() == "copilot-integration-id");
+        let has_x_initiator = resolved
+            .headers
+            .iter()
+            .any(|(k, _)| k.to_lowercase() == "x-initiator");
+
+        assert!(
+            has_editor_version,
+            "Editor-Version header should be present"
+        );
+        assert!(
+            has_copilot_integration_id,
+            "Copilot-Integration-Id header should be present"
+        );
+        assert!(has_x_initiator, "X-Initiator header should be present");
+    }
+}

--- a/maki-providers/src/providers/github_copilot/models.rs
+++ b/maki-providers/src/providers/github_copilot/models.rs
@@ -1,0 +1,323 @@
+use crate::model::{ModelEntry, ModelFamily, ModelPricing, ModelTier};
+use crate::providers::github_copilot::platform::EndpointPath;
+
+const GPT_PREFIX: &str = "gpt-";
+
+/// Extracts the major version number from a lowercase GPT model ID.
+/// Returns Some(version) for strings like "gpt-5", "gpt-5.2", "gpt-6-alpha".
+/// Returns None if the model doesn't start with "gpt-" or has no valid version.
+fn extract_gpt_version(model_id: &str) -> Option<u32> {
+    let after_prefix = model_id.strip_prefix(GPT_PREFIX)?;
+    let version_digits: String = after_prefix
+        .split('.')
+        .next()?
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    if version_digits.is_empty() {
+        return None;
+    }
+    version_digits.parse::<u32>().ok()
+}
+
+/// Routes a model to its appropriate API endpoint based on family classification.
+/// - Claude models use Anthropic's /v1/messages endpoint
+/// - GPT-5+ models use OpenAI's /responses endpoint
+/// - All other models (GPT-4 family, unknown, generic) use /chat/completions
+pub(crate) fn endpoint_path_for_model(model_id: &str, family: ModelFamily) -> EndpointPath {
+    // Normalize to lowercase for case-insensitive version detection
+    let model_lower = model_id.to_ascii_lowercase();
+    match family {
+        ModelFamily::Claude => EndpointPath::V1Messages,
+        ModelFamily::Gpt => {
+            // Within the GPT family, only version 5+ uses the Responses API
+            if extract_gpt_version(&model_lower).is_some_and(|v| v >= 5) {
+                EndpointPath::Responses
+            } else {
+                EndpointPath::ChatCompletions
+            }
+        }
+        // All other families (Generic, Gemini, Glm, Synthetic, unknown) default to chat completions
+        _ => EndpointPath::ChatCompletions,
+    }
+}
+
+pub(crate) fn models() -> &'static [ModelEntry] {
+    &[
+        // Weak tier: prefix name → family → number (low→high)
+        ModelEntry {
+            prefixes: &["claude-haiku-4.5"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Claude,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 32_000,
+            context_window: 144_000,
+        },
+        ModelEntry {
+            prefixes: &["gemini-3-flash-preview"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Generic,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 64_000,
+            context_window: 128_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-4o"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Gpt,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 4_096,
+            context_window: 128_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5-mini"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Gpt,
+            default: true,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 64_000,
+            context_window: 264_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.4-mini"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Gpt,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 128_000,
+            context_window: 400_000,
+        },
+        // Medium tier
+        ModelEntry {
+            prefixes: &["claude-sonnet-4"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Claude,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 16_000,
+            context_window: 216_000,
+        },
+        ModelEntry {
+            prefixes: &["claude-sonnet-4.5"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Claude,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 32_000,
+            context_window: 144_000,
+        },
+        ModelEntry {
+            prefixes: &["claude-sonnet-4.6"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Claude,
+            default: true,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 32_000,
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["gemini-2.5-pro"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 64_000,
+            context_window: 128_000,
+        },
+        ModelEntry {
+            prefixes: &["grok-code-fast-1"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 64_000,
+            context_window: 128_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.2-codex"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Gpt,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 128_000,
+            context_window: 400_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.3-codex"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Gpt,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 128_000,
+            context_window: 400_000,
+        },
+        // Strong tier
+        ModelEntry {
+            prefixes: &["claude-opus-4.5"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Claude,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 32_000,
+            context_window: 160_000,
+        },
+        ModelEntry {
+            prefixes: &["claude-opus-4.6"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Claude,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 64_000,
+            context_window: 144_000,
+        },
+        ModelEntry {
+            prefixes: &["claude-opus-4.7"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Claude,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 64_000,
+            context_window: 144_000,
+        },
+        ModelEntry {
+            prefixes: &["gemini-3.1-pro-preview"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Generic,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 64_000,
+            context_window: 128_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-4.1"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Gpt,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 16_384,
+            context_window: 128_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.2"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Gpt,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 64_000,
+            context_window: 264_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.4"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Gpt,
+            default: true,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 128_000,
+            context_window: 400_000,
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::ModelTier;
+    use std::collections::HashSet;
+
+    const AUTHORIZED_MODELS: &[&str] = &[
+        "claude-haiku-4.5",
+        "gemini-3-flash-preview",
+        "gpt-4o",
+        "gpt-4.1",
+        "gpt-5-mini",
+        "gpt-5.4-mini",
+        "claude-sonnet-4",
+        "claude-sonnet-4.5",
+        "claude-sonnet-4.6",
+        "gemini-2.5-pro",
+        "grok-code-fast-1",
+        "gpt-5.2",
+        "gpt-5.2-codex",
+        "gpt-5.3-codex",
+        "claude-opus-4.5",
+        "claude-opus-4.6",
+        "claude-opus-4.7",
+        "gemini-3.1-pro-preview",
+        "gpt-5.4",
+    ];
+
+    #[test]
+    fn model_set_matches_authorized() {
+        let actual: HashSet<String> = models()
+            .iter()
+            .flat_map(|e| e.prefixes.iter().map(|p| p.to_string()))
+            .collect();
+        let expected: HashSet<String> = AUTHORIZED_MODELS.iter().map(|s| s.to_string()).collect();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn tier_defaults_exist() {
+        assert!(
+            models()
+                .iter()
+                .any(|e| e.tier == ModelTier::Weak && e.default)
+        );
+        assert!(
+            models()
+                .iter()
+                .any(|e| e.tier == ModelTier::Medium && e.default)
+        );
+        assert!(
+            models()
+                .iter()
+                .any(|e| e.tier == ModelTier::Strong && e.default)
+        );
+    }
+
+    #[test]
+    fn gpt_5_mini_is_weak() {
+        let entry = models()
+            .iter()
+            .find(|e| e.prefixes.contains(&"gpt-5-mini"))
+            .unwrap();
+        assert_eq!(entry.tier, ModelTier::Weak);
+    }
+
+    #[test]
+    fn claude_opus_is_strong() {
+        for entry in models()
+            .iter()
+            .filter(|e| e.prefixes.iter().any(|p| p.starts_with("claude-opus")))
+        {
+            assert_eq!(entry.tier, ModelTier::Strong);
+        }
+    }
+
+    #[test]
+    fn specific_prefixes_resolve_correctly() {
+        use crate::model::lookup_entry;
+        let entries = models();
+        assert!(
+            lookup_entry(entries, "gpt-5.2-codex")
+                .unwrap()
+                .prefixes
+                .contains(&"gpt-5.2-codex")
+        );
+        assert!(
+            lookup_entry(entries, "gpt-5.4-mini")
+                .unwrap()
+                .prefixes
+                .contains(&"gpt-5.4-mini")
+        );
+        assert!(
+            lookup_entry(entries, "gpt-5.4")
+                .unwrap()
+                .prefixes
+                .contains(&"gpt-5.4")
+        );
+    }
+}

--- a/maki-providers/src/providers/github_copilot/openai.rs
+++ b/maki-providers/src/providers/github_copilot/openai.rs
@@ -1,0 +1,317 @@
+use serde_json::{Value, json};
+
+use crate::model::Model;
+use crate::providers::openai::responses::{convert_input, convert_tools_for_responses};
+use crate::{ThinkingConfig, TokenUsage};
+
+/// Thinking mode for GitHub Copilot's `/responses` endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponsesThinkingMode {
+    Off,
+    Enabled,
+}
+
+impl ResponsesThinkingMode {
+    /// Map shared thinking config to the Responses wire format.
+    pub(crate) fn from_thinking(thinking: ThinkingConfig) -> Self {
+        match thinking {
+            ThinkingConfig::Off => Self::Off,
+            ThinkingConfig::Adaptive | ThinkingConfig::Budget(_) => Self::Enabled,
+        }
+    }
+
+    pub(crate) fn apply_to_body(self, body: &mut Value) {
+        match self {
+            Self::Off => {}
+            Self::Enabled => {
+                body["reasoning"] = json!({"effort": "high", "summary": "detailed"});
+                body["include"] = json!(["reasoning.encrypted_content"]);
+            }
+        }
+    }
+}
+
+/// Copilot uses prompt_tokens/completion_tokens instead of OpenAI's input_tokens/output_tokens.
+pub(crate) fn parse_usage(u: &Value) -> TokenUsage {
+    let input = u["prompt_tokens"]
+        .as_u64()
+        .or_else(|| u["input_tokens"].as_u64())
+        .unwrap_or(0) as u32;
+    let output = u["completion_tokens"]
+        .as_u64()
+        .or_else(|| u["output_tokens"].as_u64())
+        .unwrap_or(0) as u32;
+    let cached = u["prompt_tokens_details"]["cached_tokens"]
+        .as_u64()
+        .or_else(|| u["input_tokens_details"]["cached_tokens"].as_u64())
+        .unwrap_or(0) as u32;
+    TokenUsage {
+        input: input.saturating_sub(cached),
+        output,
+        cache_read: cached,
+        cache_creation: 0,
+    }
+}
+
+fn derive_cache_key(session_id: &str) -> String {
+    format!("maki-{}", session_id)
+}
+
+/// Copilot rejects cache_control.scope on /responses but accepts other cache_control fields.
+pub(crate) fn apply_responses_extensions(body: &mut Value, session_id: Option<&str>) {
+    if let Some(id) = session_id {
+        body["prompt_cache_key"] = json!(derive_cache_key(id));
+    }
+    strip_unsupported_cache_scope(body);
+}
+
+/// Copilot rejects `cache_control.scope` on `/responses`, but accepts the rest.
+fn strip_unsupported_cache_scope(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            if let Some(Value::Object(cache_map)) = map.get_mut("cache_control") {
+                cache_map.remove("scope");
+                if cache_map.is_empty() {
+                    map.remove("cache_control");
+                }
+            }
+            for v in map.values_mut() {
+                strip_unsupported_cache_scope(v);
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                strip_unsupported_cache_scope(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Build a `/responses` request body.
+pub fn build_responses_body(
+    model: &Model,
+    messages: &[crate::Message],
+    system: &str,
+    tools: &Value,
+    strict_tools: bool,
+    thinking: ThinkingConfig,
+) -> Value {
+    let input = convert_input(messages);
+    let wire_tools = convert_tools_for_responses(tools, strict_tools);
+
+    let mut body = json!({
+        "model": model.id,
+        "instructions": system,
+        "input": input,
+        "stream": true,
+        "store": false,
+    });
+
+    if wire_tools.as_array().is_some_and(|a| !a.is_empty()) {
+        body["tools"] = wire_tools;
+    }
+
+    let mode = ResponsesThinkingMode::from_thinking(thinking);
+    mode.apply_to_body(&mut body);
+
+    body
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::github_copilot::test_constants::{GPT5_MODEL, GPT5_SPEC};
+    use crate::{Message, ThinkingConfig};
+
+    fn user_messages() -> Vec<Message> {
+        vec![Message::user("hello".into())]
+    }
+
+    fn sample_tools() -> Value {
+        serde_json::json!([{
+            "name": "bash",
+            "description": "Run a shell command",
+            "input_schema": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"]
+            }
+        }])
+    }
+
+    #[test]
+    fn gpt_5_family_models_use_responses_body_format() {
+        let model = Model::from_spec(GPT5_SPEC).unwrap();
+
+        let body = build_responses_body(
+            &model,
+            &user_messages(),
+            "system",
+            &serde_json::json!([]),
+            false,
+            ThinkingConfig::Off,
+        );
+
+        assert!(body.get("input").is_some(), "/responses uses input array");
+        assert!(
+            body.get("messages").is_none(),
+            "/responses does not use messages array"
+        );
+        assert_eq!(body["model"], GPT5_MODEL);
+        assert_eq!(body["instructions"], "system");
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["store"], false);
+        assert!(body.get("tools").is_none());
+
+        let input = body["input"].as_array().expect("input should be an array");
+        assert!(!input.is_empty());
+        assert_eq!(input[0]["type"], "message");
+        assert_eq!(input[0]["role"], "user");
+    }
+
+    #[test]
+    fn responses_body_includes_tools_when_provided() {
+        let model = Model::from_spec(GPT5_SPEC).unwrap();
+        let tools = sample_tools();
+
+        let body = build_responses_body(
+            &model,
+            &user_messages(),
+            "system",
+            &tools,
+            false,
+            ThinkingConfig::Off,
+        );
+
+        let tools_array = body["tools"].as_array().expect("tools should be an array");
+        assert_eq!(tools_array.len(), 1);
+        assert_eq!(tools_array[0]["type"], "function");
+        assert_eq!(tools_array[0]["name"], "bash");
+        assert_eq!(tools_array[0]["description"], "Run a shell command");
+        assert!(
+            tools_array[0].get("function").is_none(),
+            "responses endpoint tools must not have nested 'function' object"
+        );
+    }
+
+    #[test]
+    fn responses_body_with_thinking_adaptive_includes_reasoning() {
+        let model = Model::from_spec(GPT5_SPEC).unwrap();
+
+        let body = build_responses_body(
+            &model,
+            &user_messages(),
+            "system",
+            &serde_json::json!([]),
+            false,
+            ThinkingConfig::Adaptive,
+        );
+
+        assert_eq!(body["reasoning"]["effort"], "high");
+        assert_eq!(body["reasoning"]["summary"], "detailed");
+        assert_eq!(
+            body["include"],
+            serde_json::json!(["reasoning.encrypted_content"])
+        );
+    }
+
+    #[test]
+    fn responses_body_with_thinking_off_omits_reasoning() {
+        let model = Model::from_spec(GPT5_SPEC).unwrap();
+
+        let body = build_responses_body(
+            &model,
+            &user_messages(),
+            "system",
+            &serde_json::json!([]),
+            false,
+            ThinkingConfig::Off,
+        );
+
+        assert!(body.get("reasoning").is_none());
+        assert!(body.get("include").is_none());
+    }
+
+    #[test]
+    fn parse_usage_cached_tokens_accounting() {
+        let u = serde_json::json!({
+            "prompt_tokens": 500,
+            "completion_tokens": 100,
+            "prompt_tokens_details": { "cached_tokens": 300 },
+        });
+        let usage = parse_usage(&u);
+        assert_eq!(usage.input, 200);
+        assert_eq!(usage.output, 100);
+        assert_eq!(usage.cache_read, 300);
+    }
+
+    #[test]
+    fn parse_usage_cached_tokens_saturating() {
+        let u = serde_json::json!({
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "prompt_tokens_details": { "cached_tokens": 150 },
+        });
+        let usage = parse_usage(&u);
+        assert_eq!(usage.input, 0);
+        assert_eq!(usage.cache_read, 150);
+    }
+
+    #[test]
+    fn parse_usage_input_tokens_details_cached_tokens() {
+        let u = serde_json::json!({
+            "input_tokens": 400,
+            "output_tokens": 80,
+            "input_tokens_details": { "cached_tokens": 250 },
+        });
+        let usage = parse_usage(&u);
+        assert_eq!(usage.input, 150);
+        assert_eq!(usage.output, 80);
+        assert_eq!(usage.cache_read, 250);
+    }
+
+    #[test]
+    fn apply_responses_extensions_injects_prompt_cache_key() {
+        let mut body = serde_json::json!({"model": "gpt-5"});
+        apply_responses_extensions(&mut body, Some("session-xyz"));
+        assert_eq!(body["prompt_cache_key"], "maki-session-xyz");
+    }
+
+    #[test]
+    fn apply_responses_extensions_strips_nested_cache_control_scope() {
+        let mut body = serde_json::json!({
+            "model": "gpt-5",
+            "input": [
+                {
+                    "type": "message",
+                    "content": [{ "type": "output_text", "text": "hello" }],
+                    "cache_control": { "scope": "some_scope", "type": "some_type" }
+                }
+            ]
+        });
+        apply_responses_extensions(&mut body, None);
+
+        let inner_cache = &body["input"][0]["cache_control"];
+        assert!(inner_cache.get("scope").is_none());
+        assert_eq!(inner_cache.get("type").unwrap(), "some_type");
+    }
+
+    #[test]
+    fn apply_responses_extensions_removes_empty_cache_control_objects() {
+        let mut body = serde_json::json!({
+            "model": "gpt-5",
+            "cache_control": { "scope": "only_scope" }
+        });
+        apply_responses_extensions(&mut body, None);
+
+        assert!(body.get("cache_control").is_none());
+    }
+
+    #[test]
+    fn derive_cache_key_prefixes_session_id() {
+        assert_eq!(derive_cache_key("session-abc"), "maki-session-abc");
+        assert_eq!(derive_cache_key("uuid-123e-4567"), "maki-uuid-123e-4567");
+        assert_ne!(derive_cache_key("session-a"), derive_cache_key("session-b"));
+    }
+}

--- a/maki-providers/src/providers/github_copilot/platform.rs
+++ b/maki-providers/src/providers/github_copilot/platform.rs
@@ -1,0 +1,523 @@
+use std::sync::{Arc, Mutex};
+
+use maki_storage::DataDir;
+
+use crate::providers::ResolvedAuth;
+use crate::{ContentBlock, Message, Role};
+
+const RESPONSES_PATH: &str = "/responses";
+const V1_MESSAGES_PATH: &str = "/v1/messages";
+
+const HEADER_INITIATOR: &str = "X-Initiator";
+const HEADER_EDITOR_VERSION: &str = "Editor-Version";
+const HEADER_EDITOR_PLUGIN_VERSION: &str = "Editor-Plugin-Version";
+const HEADER_COPILOT_INTEGRATION_ID: &str = "Copilot-Integration-Id";
+const HEADER_USER_AGENT: &str = "User-Agent";
+const HEADER_OPENAI_INTENT: &str = "Openai-Intent";
+const HEADER_COPILOT_VISION: &str = "Copilot-Vision-Request";
+const HEADER_INTERACTION_TYPE: &str = "X-Interaction-Type";
+const HEADER_AUTHORIZATION: &str = "authorization";
+const HEADER_CONTENT_TYPE: &str = "content-type";
+
+// VS Code-style headers required by the Copilot proxy.
+pub const EDITOR_VERSION: &str = "vscode/1.96.2";
+pub const EDITOR_PLUGIN_VERSION: &str = "copilot-chat/0.23.2";
+pub const COPILOT_INTEGRATION_ID: &str = "vscode-chat";
+const USER_AGENT: &str = "GitHubCopilotChat/0.23.2";
+const INTERACTION_TYPE: &str = "chat";
+
+const CONVERSATION_EDITS_INTENT: &str = "conversation-edits";
+const CHAT_COMPLETIONS_PATH: &str = "/chat/completions";
+const INITIATOR_USER: &str = "user";
+const INITIATOR_AGENT: &str = "agent";
+
+#[derive(Clone, Debug)]
+pub enum EndpointPath {
+    Responses,
+    V1Messages,
+    ChatCompletions,
+}
+
+impl EndpointPath {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Responses => RESPONSES_PATH,
+            Self::V1Messages => V1_MESSAGES_PATH,
+            Self::ChatCompletions => CHAT_COMPLETIONS_PATH,
+        }
+    }
+}
+
+/// Shared GitHub Copilot transport and auth state.
+pub struct GitHubCopilotPlatform {
+    auth: Arc<Mutex<ResolvedAuth>>,
+    storage: Option<DataDir>,
+    /// Test-only refresh hook.
+    #[cfg(test)]
+    test_refresh: Option<Box<dyn Fn() -> Result<(), crate::AgentError> + Send + Sync>>,
+}
+
+impl GitHubCopilotPlatform {
+    /// Create a platform backed by stored OAuth state.
+    pub fn new(dir: &DataDir) -> Result<Self, crate::AgentError> {
+        let auth = super::auth::resolve(dir)?;
+        Ok(Self {
+            auth: Arc::new(Mutex::new(auth)),
+            storage: Some(dir.clone()),
+            #[cfg(test)]
+            test_refresh: None,
+        })
+    }
+
+    /// Create a platform with fixed auth for tests.
+    #[cfg(test)]
+    pub fn with_auth(auth: Arc<Mutex<ResolvedAuth>>) -> Self {
+        Self {
+            auth,
+            storage: None,
+            test_refresh: None,
+        }
+    }
+
+    /// Create a platform with a custom refresh hook for tests.
+    #[cfg(test)]
+    pub fn with_auth_and_refresh<F>(auth: Arc<Mutex<ResolvedAuth>>, refresh: F) -> Self
+    where
+        F: Fn() -> Result<(), crate::AgentError> + Send + Sync + 'static,
+    {
+        Self {
+            auth,
+            storage: None,
+            test_refresh: Some(Box::new(refresh)),
+        }
+    }
+
+    /// Return whether auth headers are present.
+    #[cfg(test)]
+    pub fn has_auth(&self) -> bool {
+        self.auth
+            .lock()
+            .map(|auth| !auth.headers.is_empty())
+            .unwrap_or(false)
+    }
+
+    /// Return whether auth is storage-backed.
+    #[cfg(test)]
+    pub fn is_oauth(&self) -> bool {
+        self.storage.is_some()
+    }
+
+    /// Return the current auth state, even from a poisoned lock.
+    ///
+    /// Keep stored credentials when a lock is poisoned. The caller still fills
+    /// in the fallback base URL if needed.
+    fn recover_auth(&self) -> ResolvedAuth {
+        match self.auth.lock() {
+            Ok(guard) => guard.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
+    }
+
+    /// Return the current auth state.
+    pub fn current_auth(&self) -> ResolvedAuth {
+        self.recover_auth()
+    }
+
+    /// Share auth state with child providers.
+    pub(crate) fn share_auth_for_child(&self) -> Arc<Mutex<ResolvedAuth>> {
+        self.auth.clone()
+    }
+
+    /// Build request headers from one auth snapshot.
+    pub fn build_headers_from_auth(
+        auth: &ResolvedAuth,
+        messages: &[Message],
+    ) -> Vec<(String, String)> {
+        let auth_headers = &auth.headers;
+
+        let mut headers = Vec::new();
+
+        headers.push((HEADER_CONTENT_TYPE.into(), "application/json".into()));
+
+        if let Some((_, auth_value)) = auth_headers.iter().find(|(k, _)| k == HEADER_AUTHORIZATION)
+        {
+            headers.push((HEADER_AUTHORIZATION.into(), auth_value.clone()));
+        }
+
+        headers.push((HEADER_USER_AGENT.into(), USER_AGENT.into()));
+        headers.push((HEADER_EDITOR_VERSION.into(), EDITOR_VERSION.into()));
+        headers.push((
+            HEADER_EDITOR_PLUGIN_VERSION.into(),
+            EDITOR_PLUGIN_VERSION.into(),
+        ));
+        headers.push((
+            HEADER_COPILOT_INTEGRATION_ID.into(),
+            COPILOT_INTEGRATION_ID.into(),
+        ));
+        headers.push((HEADER_INITIATOR.into(), infer_initiator(messages).into()));
+        headers.push((
+            HEADER_OPENAI_INTENT.into(),
+            CONVERSATION_EDITS_INTENT.into(),
+        ));
+
+        headers.push((HEADER_INTERACTION_TYPE.into(), INTERACTION_TYPE.into()));
+
+        if has_image_content(messages) {
+            headers.push((HEADER_COPILOT_VISION.into(), "true".into()));
+        }
+
+        super::auth::sanitize_headers(&mut headers);
+        headers
+    }
+
+    /// Choose the API path for a model.
+    pub fn select_endpoint_path(&self, model_id: &str) -> EndpointPath {
+        let entries = super::models();
+        let family = crate::model::lookup_entry(entries, model_id)
+            .map(|e| e.family)
+            .unwrap_or(crate::model::ModelFamily::Generic);
+        super::endpoint_path_for_model(model_id, family)
+    }
+
+    /// Retry once after refreshing auth on 401.
+    pub async fn with_auth_retry<T, F, Fut>(&self, f: F) -> Result<T, crate::AgentError>
+    where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = Result<T, crate::AgentError>>,
+    {
+        match f().await {
+            Err(crate::AgentError::Api { status: 401, .. }) => {
+                self.refresh_auth().await?;
+                f().await
+            }
+            result => result,
+        }
+    }
+
+    async fn refresh_auth(&self) -> Result<(), crate::AgentError> {
+        #[cfg(test)]
+        if let Some(ref test_refresh) = self.test_refresh {
+            return test_refresh();
+        }
+
+        let storage = self
+            .storage
+            .clone()
+            .ok_or_else(|| crate::AgentError::Config {
+                message: "cannot refresh auth without storage".into(),
+            })?;
+
+        let auth_arc = self.auth.clone();
+
+        smol::unblock(move || {
+            let tokens = maki_storage::auth::load_tokens(&storage, super::auth::PROVIDER)
+                .ok_or_else(|| crate::AgentError::Config {
+                    message: "no tokens found for refresh".into(),
+                })?;
+
+            let fresh = super::auth::refresh_tokens(&tokens)?;
+            maki_storage::auth::save_tokens(&storage, super::auth::PROVIDER, &fresh)?;
+
+            let resolved = super::auth::resolve(&storage)?;
+            match auth_arc.lock() {
+                Ok(mut guard) => *guard = resolved,
+                Err(poisoned) => *poisoned.into_inner() = resolved,
+            }
+
+            Ok::<(), crate::AgentError>(())
+        })
+        .await
+    }
+}
+
+fn has_image_content(messages: &[Message]) -> bool {
+    messages.iter().any(|m| {
+        m.content
+            .iter()
+            .any(|b| matches!(b, ContentBlock::Image { .. }))
+    })
+}
+
+fn infer_initiator(messages: &[Message]) -> &'static str {
+    match messages.last() {
+        Some(msg) if matches!(msg.role, Role::User) => INITIATOR_USER,
+        _ => INITIATOR_AGENT,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use maki_storage::DataDir;
+
+    use crate::providers::ResolvedAuth;
+    use crate::providers::github_copilot::auth;
+    use crate::providers::github_copilot::platform::GitHubCopilotPlatform;
+
+    use crate::{AgentError, Message, Role};
+
+    use super::{
+        CHAT_COMPLETIONS_PATH, HEADER_AUTHORIZATION, HEADER_COPILOT_VISION, HEADER_INITIATOR,
+        INITIATOR_AGENT, INITIATOR_USER, RESPONSES_PATH, V1_MESSAGES_PATH,
+    };
+
+    const TEST_COPILOT_TOKEN: &str = "copilot_test_token_abc123";
+    const TEST_BASE_URL: &str = auth::FALLBACK_COPILOT_BASE_URL;
+
+    fn sample_resolved_auth() -> ResolvedAuth {
+        ResolvedAuth {
+            base_url: Some(TEST_BASE_URL.into()),
+            headers: vec![(
+                HEADER_AUTHORIZATION.into(),
+                format!("Bearer {TEST_COPILOT_TOKEN}"),
+            )],
+        }
+    }
+
+    fn user_messages() -> Vec<Message> {
+        vec![Message::user("hello".into())]
+    }
+
+    fn agent_messages() -> Vec<Message> {
+        vec![
+            Message::user("hello".into()),
+            Message {
+                role: Role::Assistant,
+                content: vec![],
+                ..Default::default()
+            },
+        ]
+    }
+
+    #[test]
+    fn initiator_user_when_last_message_is_user() {
+        let auth = sample_resolved_auth();
+        let headers = GitHubCopilotPlatform::build_headers_from_auth(&auth, &user_messages());
+        let initiator = headers
+            .iter()
+            .find(|(k, _)| k == HEADER_INITIATOR)
+            .map(|(_, v): &(_, _)| v.as_str());
+        assert_eq!(initiator, Some(INITIATOR_USER));
+    }
+
+    #[test]
+    fn initiator_agent_when_last_message_is_assistant() {
+        let auth = sample_resolved_auth();
+        let headers = GitHubCopilotPlatform::build_headers_from_auth(&auth, &agent_messages());
+        let initiator = headers
+            .iter()
+            .find(|(k, _)| k == HEADER_INITIATOR)
+            .map(|(_, v): &(_, _)| v.as_str());
+        assert_eq!(initiator, Some(INITIATOR_AGENT));
+    }
+
+    #[test]
+    fn auth_retry_triggers_on_401() {
+        let auth = sample_resolved_auth();
+        let platform = GitHubCopilotPlatform::with_auth(Arc::new(Mutex::new(auth)));
+        let result: Result<String, AgentError> = smol::block_on(async {
+            platform
+                .with_auth_retry(|| async {
+                    Err(AgentError::Api {
+                        status: 401,
+                        message: "Unauthorized".into(),
+                    })
+                })
+                .await
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn auth_retry_rereads_fresh_auth_after_401() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let auth = Arc::new(Mutex::new(ResolvedAuth {
+            base_url: Some(TEST_BASE_URL.into()),
+            headers: vec![("authorization".into(), "Bearer token_v1_initial".into())],
+        }));
+
+        let calls = Arc::new(Mutex::new(Vec::<String>::new()));
+        let call_count = Arc::new(AtomicUsize::new(0));
+
+        let auth_for_refresh = auth.clone();
+        let platform = GitHubCopilotPlatform::with_auth_and_refresh(auth.clone(), move || {
+            auth_for_refresh.lock().unwrap().headers =
+                vec![("authorization".into(), "Bearer token_v2_refreshed".into())];
+            Ok(())
+        });
+
+        let calls_for_closure = calls.clone();
+        let count_for_closure = call_count.clone();
+
+        let result: Result<String, AgentError> = smol::block_on(async {
+            platform
+                .with_auth_retry(|| {
+                    let captured = calls_for_closure.clone();
+                    let count = count_for_closure.clone();
+                    let auth_ref = auth.clone();
+
+                    async move {
+                        let n = count.fetch_add(1, Ordering::SeqCst);
+
+                        let header = {
+                            let auth = auth_ref.lock().unwrap();
+                            auth.headers
+                                .iter()
+                                .find(|(k, _)| k.eq_ignore_ascii_case("authorization"))
+                                .map(|(_, v)| v.clone())
+                                .unwrap_or_default()
+                        };
+
+                        captured.lock().unwrap().push(header);
+
+                        if n == 0 {
+                            Err(AgentError::Api {
+                                status: 401,
+                                message: "Unauthorized".into(),
+                            })
+                        } else {
+                            Ok("success".into())
+                        }
+                    }
+                })
+                .await
+        });
+
+        assert_eq!(call_count.load(Ordering::SeqCst), 2);
+        assert!(result.is_ok());
+
+        let seen = calls.lock().unwrap();
+        assert_eq!(seen.len(), 2);
+        assert_eq!(seen[0], "Bearer token_v1_initial");
+        assert_eq!(seen[1], "Bearer token_v2_refreshed");
+    }
+
+    #[test]
+    fn auth_retry_skips_on_non_401() {
+        let auth = sample_resolved_auth();
+        let platform = GitHubCopilotPlatform::with_auth(Arc::new(Mutex::new(auth)));
+        let result: Result<String, AgentError> = smol::block_on(async {
+            platform
+                .with_auth_retry(|| async {
+                    Err(AgentError::Api {
+                        status: 400,
+                        message: "Bad Request".into(),
+                    })
+                })
+                .await
+        });
+        assert!(result.unwrap_err().user_message().contains("Bad Request"));
+    }
+
+    #[test]
+    fn oauth_detection() {
+        let auth = sample_resolved_auth();
+        let platform_no_storage =
+            GitHubCopilotPlatform::with_auth(Arc::new(Mutex::new(auth.clone())));
+        assert!(!platform_no_storage.is_oauth());
+
+        let platform_with_storage = GitHubCopilotPlatform {
+            auth: Arc::new(Mutex::new(auth)),
+            storage: Some(DataDir::resolve().unwrap()),
+            test_refresh: None,
+        };
+        assert!(platform_with_storage.is_oauth());
+    }
+
+    #[test]
+    fn has_auth_checks() {
+        let auth = sample_resolved_auth();
+        let platform = GitHubCopilotPlatform::with_auth(Arc::new(Mutex::new(auth)));
+        assert!(platform.has_auth());
+
+        let no_auth = ResolvedAuth {
+            base_url: Some(TEST_BASE_URL.into()),
+            headers: vec![],
+        };
+        let platform_no_auth = GitHubCopilotPlatform::with_auth(Arc::new(Mutex::new(no_auth)));
+        assert!(!platform_no_auth.has_auth());
+    }
+
+    #[test]
+    fn headers_contain_auth() {
+        let auth = sample_resolved_auth();
+        let headers = GitHubCopilotPlatform::build_headers_from_auth(&auth, &user_messages());
+        let auth_header = headers
+            .iter()
+            .find(|(k, _)| k == HEADER_AUTHORIZATION)
+            .map(|(_, v): &(_, _)| v.as_str());
+        assert_eq!(auth_header.unwrap(), format!("Bearer {TEST_COPILOT_TOKEN}"));
+    }
+
+    #[test]
+    fn headers_include_vision_for_images() {
+        use crate::{ImageMediaType, ImageSource};
+        let auth = sample_resolved_auth();
+        let source = ImageSource::new(ImageMediaType::Png, std::sync::Arc::from("abc"));
+        let headers = GitHubCopilotPlatform::build_headers_from_auth(
+            &auth,
+            &[Message::user_with_images("hi".into(), vec![source])],
+        );
+        assert!(
+            headers
+                .iter()
+                .any(|(k, v)| k == HEADER_COPILOT_VISION && v == "true")
+        );
+    }
+
+    #[test]
+    fn headers_without_auth_skips_bearer() {
+        let auth = ResolvedAuth {
+            base_url: Some(TEST_BASE_URL.into()),
+            headers: vec![],
+        };
+        let headers = GitHubCopilotPlatform::build_headers_from_auth(&auth, &user_messages());
+        assert!(!headers.iter().any(|(k, _)| k == HEADER_AUTHORIZATION));
+    }
+
+    #[test]
+    fn routing_claude_to_v1_messages() {
+        use crate::model::ModelFamily;
+        use crate::providers::github_copilot::endpoint_path_for_model;
+
+        assert_eq!(
+            endpoint_path_for_model("claude-sonnet-4", ModelFamily::Claude).as_str(),
+            V1_MESSAGES_PATH
+        );
+    }
+
+    #[test]
+    fn routing_gpt5_to_responses() {
+        use crate::model::ModelFamily;
+        use crate::providers::github_copilot::endpoint_path_for_model;
+
+        assert_eq!(
+            endpoint_path_for_model("gpt-5.4", ModelFamily::Gpt).as_str(),
+            RESPONSES_PATH
+        );
+    }
+
+    #[test]
+    fn routing_gpt4_to_chat_completions() {
+        use crate::model::ModelFamily;
+        use crate::providers::github_copilot::endpoint_path_for_model;
+
+        assert_eq!(
+            endpoint_path_for_model("gpt-4o", ModelFamily::Gpt).as_str(),
+            CHAT_COMPLETIONS_PATH
+        );
+    }
+
+    #[test]
+    fn routing_generic_to_chat_completions() {
+        use crate::model::ModelFamily;
+        use crate::providers::github_copilot::endpoint_path_for_model;
+
+        assert_eq!(
+            endpoint_path_for_model("gemini-2.5-pro", ModelFamily::Generic).as_str(),
+            CHAT_COMPLETIONS_PATH
+        );
+    }
+}

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -9,6 +9,7 @@ use crate::AgentError;
 
 pub(crate) mod anthropic;
 pub mod dynamic;
+pub(crate) mod github_copilot;
 pub(crate) mod google;
 pub(crate) mod mistral;
 pub(crate) mod ollama;

--- a/maki-providers/src/providers/openai/mod.rs
+++ b/maki-providers/src/providers/openai/mod.rs
@@ -1,6 +1,6 @@
 pub mod auth;
 mod platform;
-mod responses;
+pub(crate) mod responses;
 
 pub use platform::OpenAi;
 

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -7,7 +7,7 @@ use tracing::{debug, warn};
 
 use crate::model::Model;
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
+use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig, TokenUsage};
 
 use super::auth;
 use crate::providers::ResolvedAuth;
@@ -119,18 +119,39 @@ impl OpenAi {
     }
 
     fn codex_auth(&self) -> Result<ResolvedAuth, AgentError> {
-        // Prefer OAuth tokens for the ChatGPT Coding Plan backend.
+        // Prefer Coding Plan OAuth tokens when available.
         if let Some(storage) = self.storage.as_ref()
             && let Some(tokens) = maki_storage::auth::load_tokens(storage, auth::PROVIDER)
         {
             return Ok(auth::build_coding_plan_resolved(&tokens));
         }
-        // Fall back to standard API key via the Responses API.
+        // Otherwise use the standard API key.
         let mut auth = self.current_auth();
         if auth.base_url.is_none() {
             auth.base_url = Some(CONFIG.base_url.into());
         }
         Ok(auth)
+    }
+
+    /// Stream to `/responses` with a custom usage parser.
+    pub(crate) async fn do_responses_with_parse(
+        &self,
+        model: &Model,
+        body: &serde_json::Value,
+        event_tx: &Sender<ProviderEvent>,
+        auth: &ResolvedAuth,
+        parse_usage: fn(&serde_json::Value) -> TokenUsage,
+    ) -> Result<StreamResponse, AgentError> {
+        super::responses::do_stream_with_parse(
+            self.compat.client(),
+            model,
+            body,
+            event_tx,
+            auth,
+            self.compat.stream_timeout(),
+            parse_usage,
+        )
+        .await
     }
 }
 

--- a/maki-providers/src/providers/openai/responses.rs
+++ b/maki-providers/src/providers/openai/responses.rs
@@ -1,8 +1,9 @@
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use flume::Sender;
-use futures_lite::io::{AsyncBufRead, AsyncBufReadExt, BufReader};
-use isahc::{HttpClient, Request};
+use futures_lite::io::{AsyncBufRead, BufReader};
+use isahc::{AsyncBody, Request};
 use serde_json::{Value, json};
 use tracing::{debug, warn};
 
@@ -20,7 +21,8 @@ pub(crate) fn build_body(
     tools: &Value,
 ) -> Value {
     let input = convert_input(messages);
-    let wire_tools = convert_tools(tools);
+    // OpenAI requires `strict: false` in tool definitions.
+    let wire_tools = convert_tools_for_responses(tools, true);
 
     let mut body = json!({
         "model": model.id,
@@ -35,6 +37,115 @@ pub(crate) fn build_body(
     body
 }
 
+pub(crate) async fn do_stream(
+    client: &isahc::HttpClient,
+    model: &crate::model::Model,
+    body: &Value,
+    event_tx: &Sender<ProviderEvent>,
+    auth: &ResolvedAuth,
+    stream_timeout: Duration,
+) -> Result<StreamResponse, AgentError> {
+    do_stream_with_parse(
+        client,
+        model,
+        body,
+        event_tx,
+        auth,
+        stream_timeout,
+        parse_usage,
+    )
+    .await
+}
+
+pub(crate) async fn do_stream_with_parse(
+    client: &isahc::HttpClient,
+    model: &crate::model::Model,
+    body: &Value,
+    event_tx: &Sender<ProviderEvent>,
+    auth: &ResolvedAuth,
+    stream_timeout: Duration,
+    usage_parser: fn(&Value) -> TokenUsage,
+) -> Result<StreamResponse, AgentError> {
+    let base = auth.base_url.as_deref().ok_or_else(|| AgentError::Config {
+        message: "Responses API requires a base_url in auth".into(),
+    })?;
+    let json_body = serde_json::to_vec(body)?;
+
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(format!("{base}{RESPONSES_PATH}"))
+        .header("content-type", "application/json");
+    for (key, value) in &auth.headers {
+        builder = builder.header(key.as_str(), value.as_str());
+    }
+    let request = builder.body(json_body)?;
+
+    debug!(
+        model = %model.id,
+        provider = "OpenAI Coding Plan",
+        "sending Responses API request"
+    );
+
+    let (parts, body_vec) = request.into_parts();
+    let body = AsyncBody::from(body_vec);
+    let request = Request::from_parts(parts, body);
+    let response = client.send_async(request).await?;
+    let status = response.status().as_u16();
+
+    if status == 200 {
+        parse_sse(
+            BufReader::new(response.into_body()),
+            event_tx,
+            stream_timeout,
+            usage_parser,
+        )
+        .await
+    } else {
+        Err(AgentError::from_response(response).await)
+    }
+}
+
+pub(crate) fn parse_usage(u: &Value) -> TokenUsage {
+    let input = u["input_tokens"].as_u64().unwrap_or(0) as u32;
+    let output = u["output_tokens"].as_u64().unwrap_or(0) as u32;
+    let cached = u["input_tokens_details"]["cached_tokens"]
+        .as_u64()
+        .unwrap_or(0) as u32;
+    TokenUsage {
+        input: input.saturating_sub(cached),
+        output,
+        cache_read: cached,
+        cache_creation: 0,
+    }
+}
+
+/// OpenAI requires a flat tool structure without the nested 'function' wrapper that Anthropic uses.
+/// `strict` adds `strict: false` for OpenAI's native endpoint validation.
+pub(crate) fn convert_tools_for_responses(anthropic_tools: &Value, strict: bool) -> Value {
+    let Some(tools) = anthropic_tools.as_array() else {
+        return json!([]);
+    };
+
+    Value::Array(
+        tools
+            .iter()
+            .filter_map(|t| {
+                let mut tool = json!({
+                    "type": "function",
+                    "name": t.get("name")?,
+                    "description": t.get("description")?,
+                    "parameters": t.get("input_schema")?,
+                });
+                if strict {
+                    tool["strict"] = json!(false);
+                }
+                Some(tool)
+            })
+            .collect(),
+    )
+}
+
+/// The Responses API uses an 'input' array with typed entries instead of a 'messages' array.
 pub(crate) fn convert_input(messages: &[Message]) -> Value {
     let mut input = Vec::new();
 
@@ -77,6 +188,7 @@ pub(crate) fn convert_input(messages: &[Message]) -> Value {
             Role::Assistant => {
                 let mut text_parts = Vec::new();
                 let mut tool_calls = Vec::new();
+                let mut has_thinking = false;
 
                 for block in &msg.content {
                     match block {
@@ -84,10 +196,10 @@ pub(crate) fn convert_input(messages: &[Message]) -> Value {
                         ContentBlock::ToolUse { id, name, input } => {
                             tool_calls.push((id, name, input));
                         }
-                        ContentBlock::ToolResult { .. }
-                        | ContentBlock::Image { .. }
-                        | ContentBlock::Thinking { .. }
-                        | ContentBlock::RedactedThinking { .. } => {}
+                        ContentBlock::Thinking { .. } | ContentBlock::RedactedThinking { .. } => {
+                            has_thinking = true;
+                        }
+                        ContentBlock::ToolResult { .. } | ContentBlock::Image { .. } => {}
                     }
                 }
 
@@ -97,6 +209,12 @@ pub(crate) fn convert_input(messages: &[Message]) -> Value {
                         "type": "message",
                         "role": "assistant",
                         "content": [{"type": "output_text", "text": joined}]
+                    }));
+                } else if has_thinking && tool_calls.is_empty() {
+                    input.push(json!({
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": ""}]
                     }));
                 }
 
@@ -115,86 +233,31 @@ pub(crate) fn convert_input(messages: &[Message]) -> Value {
     Value::Array(input)
 }
 
-pub(crate) fn convert_tools(anthropic_tools: &Value) -> Value {
-    let Some(tools) = anthropic_tools.as_array() else {
-        return json!([]);
-    };
-
-    Value::Array(
-        tools
-            .iter()
-            .filter_map(|t| {
-                Some(json!({
-                    "type": "function",
-                    "name": t.get("name")?,
-                    "description": t.get("description")?,
-                    "parameters": t.get("input_schema")?,
-                    "strict": false,
-                }))
-            })
-            .collect(),
-    )
-}
-
-pub(crate) async fn do_stream(
-    client: &HttpClient,
-    model: &crate::model::Model,
-    body: &Value,
-    event_tx: &Sender<ProviderEvent>,
-    auth: &ResolvedAuth,
-    stream_timeout: Duration,
-) -> Result<StreamResponse, AgentError> {
-    let base = auth.base_url.as_deref().ok_or_else(|| AgentError::Config {
-        message: "Responses API requires a base_url in auth".into(),
-    })?;
-    let json_body = serde_json::to_vec(body)?;
-
-    let mut builder = Request::builder()
-        .method("POST")
-        .uri(format!("{base}{RESPONSES_PATH}"))
-        .header("content-type", "application/json");
-    for (key, value) in &auth.headers {
-        builder = builder.header(key.as_str(), value.as_str());
-    }
-    let request = builder.body(json_body)?;
-
-    debug!(
-        model = %model.id,
-        provider = "OpenAI Coding Plan",
-        "sending Responses API request"
-    );
-
-    let response = client.send_async(request).await?;
-    let status = response.status().as_u16();
-
-    if status == 200 {
-        parse_sse(
-            BufReader::new(response.into_body()),
-            event_tx,
-            stream_timeout,
-        )
-        .await
-    } else {
-        Err(AgentError::from_response(response).await)
-    }
-}
-
-struct ToolAccumulator {
+struct ResponseToolAccumulator {
     output_index: u64,
     call_id: String,
     name: String,
     arguments: String,
 }
 
-pub(crate) async fn parse_sse(
+/// Parse a Responses API SSE stream.
+async fn parse_sse<F>(
     reader: impl AsyncBufRead + Unpin,
     event_tx: &Sender<ProviderEvent>,
     stream_timeout: Duration,
-) -> Result<StreamResponse, AgentError> {
+    usage_parser: F,
+) -> Result<StreamResponse, AgentError>
+where
+    F: Fn(&Value) -> TokenUsage,
+{
+    use futures_lite::io::AsyncBufReadExt;
+
     let mut lines = reader.lines();
 
     let mut text = String::new();
-    let mut tool_accumulators: Vec<ToolAccumulator> = Vec::new();
+    let mut reasoning_text = String::new();
+    let mut tool_accumulators: Vec<ResponseToolAccumulator> = Vec::new();
+    let mut pending_deltas: HashMap<u64, String> = HashMap::new();
     let mut usage = TokenUsage::default();
     let mut stop_reason: Option<StopReason> = None;
     let mut is_first_content = true;
@@ -254,6 +317,25 @@ pub(crate) async fn parse_sse(
                 }
             }
 
+            "response.reasoning_summary_text.delta" => {
+                let parsed: Value = match serde_json::from_str(data) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                if let Some(delta) = parsed["delta"].as_str()
+                    && !delta.is_empty()
+                {
+                    reasoning_text.push_str(delta);
+                    event_tx
+                        .send_async(ProviderEvent::ThinkingDelta {
+                            text: delta.to_string(),
+                        })
+                        .await?;
+                }
+            }
+
+            "response.reasoning_summary_text.done" => {}
+
             "response.output_item.added" => {
                 let parsed: Value = match serde_json::from_str(data) {
                     Ok(v) => v,
@@ -272,11 +354,12 @@ pub(crate) async fn parse_sse(
                             })
                             .await?;
                     }
-                    tool_accumulators.push(ToolAccumulator {
+                    let initial_args = pending_deltas.remove(&output_index).unwrap_or_default();
+                    tool_accumulators.push(ResponseToolAccumulator {
                         output_index,
                         call_id,
                         name,
-                        arguments: String::new(),
+                        arguments: initial_args,
                     });
                 }
             }
@@ -293,6 +376,11 @@ pub(crate) async fn parse_sse(
                         .find(|a| a.output_index == output_index)
                     {
                         acc.arguments.push_str(delta);
+                    } else {
+                        pending_deltas
+                            .entry(output_index)
+                            .or_default()
+                            .push_str(delta);
                     }
                 }
             }
@@ -305,7 +393,7 @@ pub(crate) async fn parse_sse(
                 let resp = &parsed["response"];
 
                 if let Some(u) = resp.get("usage") {
-                    usage = parse_usage(u);
+                    usage = usage_parser(u);
                 }
 
                 let status = resp["status"].as_str().unwrap_or("completed");
@@ -329,7 +417,7 @@ pub(crate) async fn parse_sse(
                 };
                 let resp = &parsed["response"];
                 if let Some(u) = resp.get("usage") {
-                    usage = parse_usage(u);
+                    usage = usage_parser(u);
                 }
                 stop_reason = Some(StopReason::MaxTokens);
             }
@@ -360,9 +448,18 @@ pub(crate) async fn parse_sse(
 
     let mut content_blocks: Vec<ContentBlock> = Vec::new();
 
+    if !reasoning_text.is_empty() {
+        content_blocks.push(ContentBlock::Thinking {
+            thinking: reasoning_text,
+            signature: None,
+        });
+    }
+
     if !text.is_empty() {
         content_blocks.push(ContentBlock::Text { text });
     }
+
+    tool_accumulators.sort_by_key(|a| a.output_index);
 
     for acc in tool_accumulators {
         let input: Value = match serde_json::from_str(&acc.arguments) {
@@ -393,170 +490,92 @@ pub(crate) async fn parse_sse(
     })
 }
 
-fn parse_usage(u: &Value) -> TokenUsage {
-    let input_tokens = u["input_tokens"].as_u64().unwrap_or(0) as u32;
-    let output_tokens = u["output_tokens"].as_u64().unwrap_or(0) as u32;
-
-    let cached = u["input_tokens_details"]["cached_tokens"]
-        .as_u64()
-        .unwrap_or(0) as u32;
-
-    TokenUsage {
-        input: input_tokens.saturating_sub(cached),
-        output: output_tokens,
-        cache_read: cached,
-        cache_creation: 0,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use futures_lite::io::Cursor;
-    use serde_json::json;
 
     const TEST_STREAM_TIMEOUT: Duration = Duration::from_secs(300);
 
-    async fn run_sse(sse: &str) -> (Result<StreamResponse, AgentError>, Vec<ProviderEvent>) {
-        let (tx, rx) = flume::unbounded();
-        let result = parse_sse(Cursor::new(sse.as_bytes()), &tx, TEST_STREAM_TIMEOUT).await;
-        (result, rx.drain().collect())
-    }
-
     #[test]
-    fn parse_sse_text_and_usage() {
-        smol::block_on(async {
-            let sse = "\
-event: response.output_text.delta\n\
-data: {\"delta\":\"Hello\"}\n\
-\n\
-event: response.output_text.delta\n\
-data: {\"delta\":\" world\"}\n\
-\n\
-event: response.completed\n\
-data: {\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":100,\"output_tokens\":10,\"input_tokens_details\":{\"cached_tokens\":40}}}}\n\
-\n";
-
-            let (resp, events) = run_sse(sse).await;
-            let resp = resp.unwrap();
-
-            assert_eq!(resp.usage.input, 60);
-            assert_eq!(resp.usage.output, 10);
-            assert_eq!(resp.usage.cache_read, 40);
-            assert_eq!(resp.stop_reason, Some(StopReason::EndTurn));
-            assert!(
-                matches!(&resp.message.content[0], ContentBlock::Text { text } if text == "Hello world")
-            );
-
-            let deltas: Vec<_> = events
-                .iter()
-                .filter_map(|e| match e {
-                    ProviderEvent::TextDelta { text } => Some(text.as_str()),
-                    _ => None,
-                })
-                .collect();
-            assert_eq!(deltas, vec!["Hello", " world"]);
-        })
-    }
-
-    #[test]
-    fn parse_sse_tool_calls() {
-        smol::block_on(async {
-            let sse = "\
-event: response.output_item.added\n\
-data: {\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"c1\",\"name\":\"bash\"}}\n\
-\n\
-event: response.output_item.added\n\
-data: {\"output_index\":1,\"item\":{\"type\":\"function_call\",\"call_id\":\"c2\",\"name\":\"read\"}}\n\
-\n\
-event: response.function_call_arguments.delta\n\
-data: {\"output_index\":0,\"delta\":\"{\\\"command\\\": \\\"ls\\\"}\"}\n\
-\n\
-event: response.function_call_arguments.delta\n\
-data: {\"output_index\":1,\"delta\":\"{\\\"path\\\": \\\"/tmp\\\"}\"}\n\
-\n\
-event: response.completed\n\
-data: {\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":5,\"output_tokens\":3}}}\n\
-\n";
-
-            let (resp, events) = run_sse(sse).await;
-            let resp = resp.unwrap();
-
-            let tools: Vec<_> = resp.message.tool_uses().collect();
-            assert_eq!(tools.len(), 2);
-            assert_eq!((tools[0].0, tools[0].1), ("c1", "bash"));
-            assert_eq!(tools[0].2["command"], "ls");
-            assert_eq!((tools[1].0, tools[1].1), ("c2", "read"));
-            assert_eq!(tools[1].2["path"], "/tmp");
-            assert_eq!(resp.stop_reason, Some(StopReason::ToolUse));
-
-            let starts: Vec<_> = events
-                .iter()
-                .filter_map(|e| match e {
-                    ProviderEvent::ToolUseStart { id, name } => Some((id.as_str(), name.as_str())),
-                    _ => None,
-                })
-                .collect();
-            assert_eq!(starts, vec![("c1", "bash"), ("c2", "read")]);
-        })
-    }
-
-    #[test]
-    fn parse_sse_error_event() {
-        smol::block_on(async {
-            let sse = "\
-event: error\n\
-data: {\"error\":{\"message\":\"Server overloaded\",\"type\":\"overloaded_error\"}}\n\
-\n";
-
-            let (err, _) = run_sse(sse).await;
-            match err.unwrap_err() {
-                AgentError::Api { status, message } => {
-                    assert_eq!(status, 529);
-                    assert_eq!(message, "Server overloaded");
-                }
-                other => panic!("expected Api error, got: {other:?}"),
+    fn convert_tools_for_responses_structure() {
+        let anthropic = json!([{
+            "name": "bash",
+            "description": "Run a shell command",
+            "input_schema": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"]
             }
-        })
+        }]);
+
+        let tools = convert_tools_for_responses(&anthropic, false);
+        let tool = &tools[0];
+
+        assert_eq!(tool["type"], "function");
+        assert_eq!(tool["name"], "bash");
+        assert_eq!(tool["description"], "Run a shell command");
+        assert_eq!(tool["parameters"]["type"], "object");
+
+        assert!(tool.get("function").is_none());
+
+        assert!(tool.get("strict").is_none());
     }
 
     #[test]
-    fn parse_sse_response_failed() {
-        smol::block_on(async {
-            let sse = "\
-event: response.failed\n\
-data: {\"response\":{\"error\":{\"code\":\"rate_limit_exceeded\",\"message\":\"Rate limit hit\"}}}\n\
-\n";
-
-            let (err, _) = run_sse(sse).await;
-            match err.unwrap_err() {
-                AgentError::Api { status, message } => {
-                    assert_eq!(status, 429);
-                    assert_eq!(message, "Rate limit hit");
-                }
-                other => panic!("expected Api error, got: {other:?}"),
+    fn convert_tools_for_responses_strict_includes_strict_field() {
+        let anthropic = json!([{
+            "name": "bash",
+            "description": "Run a shell command",
+            "input_schema": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"]
             }
-        })
+        }]);
+
+        let tools = convert_tools_for_responses(&anthropic, true);
+        let tool = &tools[0];
+
+        assert_eq!(tool["type"], "function");
+        assert_eq!(tool["name"], "bash");
+        assert_eq!(tool["strict"], false);
     }
 
     #[test]
-    fn parse_sse_incomplete_response() {
-        smol::block_on(async {
-            let sse = "\
-event: response.output_text.delta\n\
-data: {\"delta\":\"partial\"}\n\
-\n\
-event: response.incomplete\n\
-data: {\"response\":{\"status\":\"incomplete\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}\n\
-\n";
+    fn convert_tools_for_responses_multiple_tools() {
+        let anthropic = json!([
+            {
+                "name": "bash",
+                "description": "Run a command",
+                "input_schema": {"type": "object"}
+            },
+            {
+                "name": "read",
+                "description": "Read a file",
+                "input_schema": {"type": "object"}
+            }
+        ]);
 
-            let (resp, _) = run_sse(sse).await;
-            let resp = resp.unwrap();
-            assert_eq!(resp.stop_reason, Some(StopReason::MaxTokens));
-            assert!(
-                matches!(&resp.message.content[0], ContentBlock::Text { text } if text == "partial")
-            );
-        })
+        let tools = convert_tools_for_responses(&anthropic, false);
+
+        assert_eq!(tools.as_array().unwrap().len(), 2);
+        assert_eq!(tools[0]["name"], "bash");
+        assert_eq!(tools[1]["name"], "read");
+        assert!(tools[0].get("function").is_none());
+        assert!(tools[1].get("function").is_none());
+    }
+
+    #[test]
+    fn convert_tools_for_responses_empty_array() {
+        let tools = convert_tools_for_responses(&json!([]), false);
+        assert!(tools.as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn convert_tools_for_responses_non_array_returns_empty() {
+        let tools = convert_tools_for_responses(&json!({"not": "an array"}), false);
+        assert!(tools.as_array().unwrap().is_empty());
     }
 
     #[test]
@@ -611,25 +630,346 @@ data: {\"response\":{\"status\":\"incomplete\",\"usage\":{\"input_tokens\":10,\"
     }
 
     #[test]
-    fn parse_sse_malformed_tool_json_yields_empty_object() {
+    fn convert_input_empty_messages() {
+        let messages: Vec<Message> = vec![];
+        let input = convert_input(&messages);
+        let items = input.as_array().unwrap();
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn convert_input_user_with_multiple_text_blocks() {
+        let messages = vec![Message {
+            role: Role::User,
+            content: vec![
+                ContentBlock::Text {
+                    text: "first".to_string(),
+                },
+                ContentBlock::Text {
+                    text: "second".to_string(),
+                },
+            ],
+            ..Default::default()
+        }];
+
+        let input = convert_input(&messages);
+        let items = input.as_array().unwrap();
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0]["content"][0]["text"], "first");
+        assert_eq!(items[1]["content"][0]["text"], "second");
+    }
+
+    #[test]
+    fn convert_input_assistant_with_text_and_tools() {
+        let messages = vec![Message {
+            role: Role::Assistant,
+            content: vec![
+                ContentBlock::Text {
+                    text: "Let me help".to_string(),
+                },
+                ContentBlock::ToolUse {
+                    id: "call_1".to_string(),
+                    name: "read".to_string(),
+                    input: json!({"path": "/tmp/test"}),
+                },
+                ContentBlock::ToolUse {
+                    id: "call_2".to_string(),
+                    name: "bash".to_string(),
+                    input: json!({"command": "ls -la"}),
+                },
+            ],
+            ..Default::default()
+        }];
+
+        let input = convert_input(&messages);
+        let items = input.as_array().unwrap();
+
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0]["type"], "message");
+        assert_eq!(items[0]["role"], "assistant");
+        assert_eq!(items[0]["content"][0]["text"], "Let me help");
+
+        assert_eq!(items[1]["type"], "function_call");
+        assert_eq!(items[1]["call_id"], "call_1");
+        assert_eq!(items[1]["name"], "read");
+
+        assert_eq!(items[2]["type"], "function_call");
+        assert_eq!(items[2]["call_id"], "call_2");
+        assert_eq!(items[2]["name"], "bash");
+    }
+
+    #[test]
+    fn convert_input_ignores_thinking_and_redacted_blocks() {
+        let messages = vec![Message {
+            role: Role::Assistant,
+            content: vec![
+                ContentBlock::Thinking {
+                    thinking: "secret thought".to_string(),
+                    signature: None,
+                },
+                ContentBlock::Text {
+                    text: "visible text".to_string(),
+                },
+                ContentBlock::RedactedThinking {
+                    data: "redacted".to_string(),
+                },
+            ],
+            ..Default::default()
+        }];
+
+        let input = convert_input(&messages);
+        let items = input.as_array().unwrap();
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0]["content"][0]["text"], "visible text");
+    }
+
+    async fn run_response_sse<F>(
+        sse: &str,
+        usage_parser: F,
+    ) -> (Result<StreamResponse, AgentError>, Vec<ProviderEvent>)
+    where
+        F: Fn(&Value) -> TokenUsage,
+    {
+        let (tx, rx) = flume::unbounded();
+        let result = parse_sse(
+            Cursor::new(sse.as_bytes()),
+            &tx,
+            TEST_STREAM_TIMEOUT,
+            usage_parser,
+        )
+        .await;
+        (result, rx.drain().collect())
+    }
+
+    fn test_parse_usage(u: &Value) -> TokenUsage {
+        let input = u["input_tokens"].as_u64().unwrap_or(0) as u32;
+        let output = u["output_tokens"].as_u64().unwrap_or(0) as u32;
+        let cached = u["input_tokens_details"]["cached_tokens"]
+            .as_u64()
+            .unwrap_or(0) as u32;
+        TokenUsage {
+            input: input.saturating_sub(cached),
+            output,
+            cache_read: cached,
+            cache_creation: 0,
+        }
+    }
+
+    #[test]
+    fn parse_sse_response_text_and_usage() {
         smol::block_on(async {
             let sse = "\
-event: response.output_item.added\n\
-data: {\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"c1\",\"name\":\"bash\"}}\n\
-\n\
-event: response.function_call_arguments.delta\n\
-data: {\"delta\":\"{broken\"}\n\
-\n\
-event: response.completed\n\
-data: {\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\
-\n";
+event: response.output_text.delta\ndata: {\"delta\":\"Hello\"}\n\nevent: response.output_text.delta\ndata: {\"delta\":\" world\"}\n\nevent: response.completed\ndata: {\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":100,\"output_tokens\":10,\"input_tokens_details\":{\"cached_tokens\":40}}}}\n\n";
 
-            let (resp, _) = run_sse(sse).await;
+            let (resp, events) = run_response_sse(sse, test_parse_usage).await;
+            let resp = resp.unwrap();
+
+            assert_eq!(resp.usage.input, 60);
+            assert_eq!(resp.usage.output, 10);
+            assert_eq!(resp.usage.cache_read, 40);
+            assert_eq!(resp.stop_reason, Some(StopReason::EndTurn));
+            assert!(
+                matches!(&resp.message.content[0], ContentBlock::Text { text } if text == "Hello world")
+            );
+
+            let deltas: Vec<_> = events
+                .iter()
+                .filter_map(|e| match e {
+                    ProviderEvent::TextDelta { text } => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(deltas, vec!["Hello", " world"]);
+        })
+    }
+
+    #[test]
+    fn parse_sse_response_tool_calls() {
+        smol::block_on(async {
+            let sse = "\
+event: response.output_item.added\ndata: {\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"c1\",\"name\":\"bash\"}}\n\nevent: response.output_item.added\ndata: {\"output_index\":1,\"item\":{\"type\":\"function_call\",\"call_id\":\"c2\",\"name\":\"read\"}}\n\nevent: response.function_call_arguments.delta\ndata: {\"output_index\":0,\"delta\":\"{\\\"command\\\": \\\"ls\\\"}\"}\n\nevent: response.function_call_arguments.delta\ndata: {\"output_index\":1,\"delta\":\"{\\\"path\\\": \\\"/tmp\\\"}\"}\n\nevent: response.completed\ndata: {\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":5,\"output_tokens\":3}}}\n\n";
+
+            let (resp, events) = run_response_sse(sse, test_parse_usage).await;
+            let resp = resp.unwrap();
+
+            let tools: Vec<_> = resp.message.tool_uses().collect();
+            assert_eq!(tools.len(), 2);
+            assert_eq!((tools[0].0, tools[0].1), ("c1", "bash"));
+            assert_eq!(tools[0].2["command"], "ls");
+            assert_eq!((tools[1].0, tools[1].1), ("c2", "read"));
+            assert_eq!(tools[1].2["path"], "/tmp");
+            assert_eq!(resp.stop_reason, Some(StopReason::ToolUse));
+
+            let starts: Vec<_> = events
+                .iter()
+                .filter_map(|e| match e {
+                    ProviderEvent::ToolUseStart { id, name } => Some((id.as_str(), name.as_str())),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(starts, vec![("c1", "bash"), ("c2", "read")]);
+        })
+    }
+
+    #[test]
+    fn parse_sse_response_error_event() {
+        smol::block_on(async {
+            let sse = "\
+event: error\ndata: {\"error\":{\"message\":\"Server overloaded\",\"type\":\"overloaded_error\"}}\n\n";
+
+            let (err, _) = run_response_sse(sse, test_parse_usage).await;
+            match err.unwrap_err() {
+                AgentError::Api { status, message } => {
+                    assert_eq!(status, 529);
+                    assert_eq!(message, "Server overloaded");
+                }
+                other => panic!("expected Api error, got: {other:?}"),
+            }
+        })
+    }
+
+    #[test]
+    fn parse_sse_response_failed() {
+        smol::block_on(async {
+            let sse = "\
+event: response.failed\ndata: {\"response\":{\"error\":{\"code\":\"rate_limit_exceeded\",\"message\":\"Rate limit hit\"}}}\n\n";
+
+            let (err, _) = run_response_sse(sse, test_parse_usage).await;
+            match err.unwrap_err() {
+                AgentError::Api { status, message } => {
+                    assert_eq!(status, 429);
+                    assert_eq!(message, "Rate limit hit");
+                }
+                other => panic!("expected Api error, got: {other:?}"),
+            }
+        })
+    }
+
+    #[test]
+    fn parse_sse_response_malformed_tool_json_yields_empty_object() {
+        smol::block_on(async {
+            let sse = "\
+event: response.output_item.added\ndata: {\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"c1\",\"name\":\"bash\"}}\n\nevent: response.function_call_arguments.delta\ndata: {\"delta\":\"{broken\"}\n\nevent: response.completed\ndata: {\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n";
+
+            let (resp, _) = run_response_sse(sse, test_parse_usage).await;
             let resp = resp.unwrap();
             let tools: Vec<_> = resp.message.tool_uses().collect();
             assert_eq!(tools.len(), 1);
             assert_eq!(tools[0].1, "bash");
             assert_eq!(*tools[0].2, Value::Object(Default::default()));
+        })
+    }
+
+    #[test]
+    fn parse_sse_response_reasoning_summary_text() {
+        smol::block_on(async {
+            let sse = "\
+event: response.reasoning_summary_text.delta\ndata: {\"delta\":\"Let me analyze\"}\n\nevent: response.reasoning_summary_text.delta\ndata: {\"delta\":\" this step by step\"}\n\nevent: response.reasoning_summary_text.done\ndata: {}\n\nevent: response.output_text.delta\ndata: {\"delta\":\"The answer is\"}\n\nevent: response.output_text.delta\ndata: {\"delta\":\" 42\"}\n\nevent: response.completed\ndata: {\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}\n\n";
+
+            let (resp, events) = run_response_sse(sse, test_parse_usage).await;
+            let resp = resp.unwrap();
+
+            assert_eq!(resp.message.content.len(), 2);
+            assert!(
+                matches!(&resp.message.content[0], ContentBlock::Thinking { thinking, .. } if thinking == "Let me analyze this step by step"),
+                "expected Thinking block, got: {:?}",
+                resp.message.content[0]
+            );
+            assert!(
+                matches!(&resp.message.content[1], ContentBlock::Text { text } if text == "The answer is 42")
+            );
+
+            let thinking_deltas: Vec<_> = events
+                .iter()
+                .filter_map(|e| match e {
+                    ProviderEvent::ThinkingDelta { text } => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                thinking_deltas,
+                vec!["Let me analyze", " this step by step"]
+            );
+
+            let text_deltas: Vec<_> = events
+                .iter()
+                .filter_map(|e| match e {
+                    ProviderEvent::TextDelta { text } => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(text_deltas, vec!["The answer is", " 42"]);
+        })
+    }
+
+    #[test]
+    fn parse_sse_response_reasoning_only_no_text() {
+        smol::block_on(async {
+            let sse = "\
+event: response.reasoning_summary_text.delta\ndata: {\"delta\":\"Processing...\"}\n\nevent: response.completed\ndata: {\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}\n\n";
+
+            let (resp, events) = run_response_sse(sse, test_parse_usage).await;
+            let resp = resp.unwrap();
+
+            assert_eq!(resp.message.content.len(), 1);
+            assert!(
+                matches!(&resp.message.content[0], ContentBlock::Thinking { thinking, .. } if thinking == "Processing...")
+            );
+
+            let thinking_deltas: Vec<_> = events
+                .iter()
+                .filter_map(|e| match e {
+                    ProviderEvent::ThinkingDelta { text } => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(thinking_deltas, vec!["Processing..."]);
+        })
+    }
+
+    #[test]
+    fn convert_input_assistant_reasoning_only_preserves_turn() {
+        let messages = vec![Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::Thinking {
+                thinking: "Deep reasoning".to_string(),
+                signature: None,
+            }],
+            ..Default::default()
+        }];
+
+        let input = convert_input(&messages);
+        let items = input.as_array().unwrap();
+
+        assert!(!items.is_empty());
+        assert_eq!(items[0]["type"], "message");
+        assert_eq!(items[0]["role"], "assistant");
+    }
+
+    #[test]
+    fn parse_sse_response_out_of_order_function_call_delta() {
+        smol::block_on(async {
+            let sse = "\
+event: response.function_call_arguments.delta\ndata: {\"output_index\":0,\"delta\":\"{\\\"command\\\": \\\"ls\"}\n\nevent: response.output_item.added\ndata: {\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"c1\",\"name\":\"bash\"}}\n\nevent: response.function_call_arguments.delta\ndata: {\"output_index\":0,\"delta\":\"\\\"}\"}\n\nevent: response.completed\ndata: {\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":5,\"output_tokens\":3}}}\n\n";
+
+            let (resp, events) = run_response_sse(sse, test_parse_usage).await;
+            let resp = resp.unwrap();
+
+            let tools: Vec<_> = resp.message.tool_uses().collect();
+            assert_eq!(tools.len(), 1);
+            assert_eq!((tools[0].0, tools[0].1), ("c1", "bash"));
+            assert_eq!(tools[0].2["command"], "ls");
+
+            let starts: Vec<_> = events
+                .iter()
+                .filter_map(|e| match e {
+                    ProviderEvent::ToolUseStart { id, name } => Some((id.as_str(), name.as_str())),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(starts, vec![("c1", "bash")]);
         })
     }
 }

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use flume::Sender;
 use futures_lite::io::{AsyncBufRead, AsyncBufReadExt, BufReader};
 use isahc::{AsyncReadResponseExt, HttpClient, Request};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tracing::{debug, warn};
 
@@ -94,9 +94,29 @@ impl OpenAiCompatProvider {
         event_tx: &Sender<ProviderEvent>,
         auth: &ResolvedAuth,
     ) -> Result<StreamResponse, AgentError> {
+        self.do_stream_with_path(
+            model,
+            extra_headers,
+            body,
+            event_tx,
+            auth,
+            "/chat/completions",
+        )
+        .await
+    }
+
+    pub async fn do_stream_with_path(
+        &self,
+        model: &crate::model::Model,
+        extra_headers: &[(String, String)],
+        body: &Value,
+        event_tx: &Sender<ProviderEvent>,
+        auth: &ResolvedAuth,
+        path: &str,
+    ) -> Result<StreamResponse, AgentError> {
         let json_body = serde_json::to_vec(body)?;
         let mut request = self
-            .build_request("POST", "/chat/completions", auth)
+            .build_request("POST", path, auth)
             .header("content-type", "application/json");
         for (key, value) in extra_headers {
             request = request.header(key.as_str(), value.as_str());
@@ -107,6 +127,7 @@ impl OpenAiCompatProvider {
         debug!(
             model = %model.id,
             provider = self.config.provider_name,
+            path = %path,
             "sending API request"
         );
 
@@ -310,13 +331,13 @@ struct ChunkChoice {
     finish_reason: Option<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct PromptTokensDetails {
     #[serde(default)]
     cached_tokens: u32,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct ChunkUsage {
     #[serde(default)]
     prompt_tokens: u32,
@@ -343,6 +364,46 @@ pub async fn parse_sse(
     event_tx: &Sender<ProviderEvent>,
     stream_timeout: Duration,
 ) -> Result<StreamResponse, AgentError> {
+    parse_sse_with_usage(reader, event_tx, stream_timeout, default_usage_parser).await
+}
+
+fn default_usage_parser(u: &Value) -> TokenUsage {
+    let cached = u
+        .get("prompt_tokens_details")
+        .and_then(|d| d.get("cached_tokens"))
+        .or_else(|| {
+            u.get("input_tokens_details")
+                .and_then(|d| d.get("cached_tokens"))
+        })
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    let input = u
+        .get("prompt_tokens")
+        .or_else(|| u.get("input_tokens"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    let output = u
+        .get("completion_tokens")
+        .or_else(|| u.get("output_tokens"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    TokenUsage {
+        input: input.saturating_sub(cached),
+        output,
+        cache_read: cached,
+        cache_creation: 0,
+    }
+}
+
+pub async fn parse_sse_with_usage<F>(
+    reader: impl AsyncBufRead + Unpin,
+    event_tx: &Sender<ProviderEvent>,
+    stream_timeout: Duration,
+    usage_parser: F,
+) -> Result<StreamResponse, AgentError>
+where
+    F: Fn(&Value) -> TokenUsage,
+{
     let mut lines = reader.lines();
 
     let mut text = String::new();
@@ -379,16 +440,8 @@ pub async fn parse_sse(
         };
 
         if let Some(u) = chunk.usage {
-            let cached = u
-                .prompt_tokens_details
-                .map(|d| d.cached_tokens)
-                .unwrap_or(0);
-            usage = TokenUsage {
-                input: u.prompt_tokens.saturating_sub(cached),
-                output: u.completion_tokens,
-                cache_read: cached,
-                cache_creation: 0,
-            };
+            let usage_value = serde_json::to_value(u).unwrap_or_default();
+            usage = usage_parser(&usage_value);
         }
 
         let Some(choice) = chunk.choices.into_iter().next() else {

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -59,7 +59,7 @@ impl ImageSource {
     }
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Role {
     #[default]

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -363,10 +363,10 @@ pub(crate) fn test_model() -> maki_providers::Model {
         dynamic_slug: None,
         tier: maki_providers::ModelTier::Medium,
         family: maki_providers::ModelFamily::Claude,
-        supports_tool_examples_override: None,
         pricing: test_pricing(),
         max_output_tokens: 8192,
         context_window: TEST_CONTEXT_WINDOW,
+        supports_tool_examples_override: None,
     }
 }
 

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -108,6 +108,29 @@ Defaults: glm-5-code (strong), glm-4.7-flash (weak), glm-4.7 (medium)
 
 Defaults: hf:moonshotai/Kimi-K2.5 (strong), hf:deepseek-ai/DeepSeek-V3.2 (medium), hf:zai-org/GLM-4.7-Flash (weak)
 
+### GitHub Copilot
+
+- **Auth**: Device login flow
+
+Run `maki auth login github-copilot` to start the device flow. This opens a browser window where you authorize Maki to access your GitHub Copilot subscription. The process takes about 30 seconds. Once done, your tokens are stored securely and refreshed automatically.
+
+#### V1 Limits
+
+This is a V1 implementation with the following limits:
+- Static model listing. New models must be added to Maki via code updates.
+- No enterprise support. Only individual GitHub Copilot subscriptions work.
+- No PAT or API key authentication. Only device login is supported.
+
+- **Features**: Device OAuth flow, static model catalog
+
+| Tier | Models | Pricing (in/out per 1M tokens) | Context |
+|------|--------|-------------------------------|---------|
+| Weak | claude-haiku-4.5, gemini-3-flash-preview, gpt-4o, **gpt-5-mini** (default), gpt-5.4-mini | $0.00 / $0.00 | 144K ctx / 32K out |
+| Medium | claude-sonnet-4, claude-sonnet-4.5, **claude-sonnet-4.6** (default), gemini-2.5-pro, grok-code-fast-1, gpt-5.2-codex, gpt-5.3-codex | $0.00 / $0.00 | 216K ctx / 16K out |
+| Strong | claude-opus-4.5, claude-opus-4.6, claude-opus-4.7, gemini-3.1-pro-preview, gpt-4.1, gpt-5.2, **gpt-5.4** (default) | $0.00 / $0.00 | 160K ctx / 32K out |
+
+Defaults: gpt-5-mini (weak), claude-sonnet-4.6 (medium), gpt-5.4 (strong)
+
 ## Model Identifiers
 
 Models are referenced as `provider/model_id`:
@@ -116,6 +139,7 @@ Models are referenced as `provider/model_id`:
 anthropic/claude-sonnet-4-6
 openai/gpt-4.1
 zai/glm-4.7
+github-copilot/gpt-5.4
 ```
 
 If the model name is unique across providers, the prefix can be omitted.
@@ -135,7 +159,7 @@ To add a custom provider or proxy, drop an executable script into `~/.maki/provi
 
 `resolve` is called each time a new agent spawns, so scripts should read tokens from disk instead of caching them in memory. That way auth changes from other processes get picked up.
 
-The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `ollama`, `mistral`, `zai`, `zai-coding-plan`, `synthetic`.
+The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `ollama`, `mistral`, `zai`, `zai-coding-plan`, `synthetic`, `github-copilot`.
 
 If your provider serves models not in the base catalog, add a `models` subcommand returning:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use tracing_subscriber::EnvFilter;
 
 use maki_providers::model::{Model, ModelTier};
 use maki_providers::provider::{ProviderKind, fetch_all_models};
-use maki_providers::{dynamic, openai_auth};
+use maki_providers::{dynamic, github_copilot_auth, openai_auth};
 use maki_storage::log::RotatingFileWriter;
 use maki_storage::model::{persist_model, read_model};
 use print::OutputFormat;
@@ -223,10 +223,12 @@ fn run() -> Result<()> {
             match action {
                 AuthAction::Login { provider } => match provider.as_str() {
                     "openai" => openai_auth::login(&storage)?,
+                    "github-copilot" => github_copilot_auth::login(&storage)?,
                     slug => dynamic::login(slug)?,
                 },
                 AuthAction::Logout { provider } => match provider.as_str() {
                     "openai" => openai_auth::logout(&storage)?,
+                    "github-copilot" => github_copilot_auth::logout(&storage)?,
                     slug => dynamic::logout(slug)?,
                 },
             }


### PR DESCRIPTION
### Closes #75

Add GitHub Copilot provider based on copilot-api (https://github.com/caozhiyuan/copilot-api).

### What

Add GitHub Copilot as a new LLM provider supporting both Claude and OpenAI models through the Copilot API.

### Implementation

- New provider with auth, models, and platform detection
- Shared response handling refactored from OpenAI module
- Integration into existing provider system
- Documentation and test coverage

### AI Usage

 Implementation written with AI assistance following existing codebase patterns.