### PR TITLE
agent: batch: suppress ToolStart for batch children

### DIFF
--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -333,6 +333,7 @@ impl Agent {
             permissions: Arc::clone(&self.permissions),
             timeouts: self.timeouts,
             file_tracker: Arc::clone(&self.file_tracker),
+            batch_child: false,
         }
     }
 

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -115,7 +115,7 @@ pub(crate) async fn run(
             input: invocation.start_input(),
             output: invocation.start_output(),
         };
-        let _ = ctx.event_tx.send(AgentEvent::ToolStart(Box::new(start)));
+        ctx.emit_tool_start(start);
 
         if let Some(scope) = invocation.permission_scope()
             && let Err(e) = ctx
@@ -171,7 +171,7 @@ pub(crate) async fn run(
             input: None,
             output: None,
         };
-        let _ = ctx.event_tx.send(AgentEvent::ToolStart(Box::new(start)));
+        ctx.emit_tool_start(start);
         execute_mcp_tool(ctx, &id, tool_static, name, input).await
     } else {
         let msg = format!("{UNKNOWN_TOOL_PREFIX}: {name}");

--- a/maki-agent/src/tools/batch.rs
+++ b/maki-agent/src/tools/batch.rs
@@ -186,6 +186,7 @@ impl Batch {
 
                 let inner_ctx = ToolContext {
                     tool_use_id: Some(id.clone()),
+                    batch_child: true,
                     ..ctx.clone()
                 };
                 let done = tool_dispatch::run(

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -53,7 +53,7 @@ use crate::cancel::CancelToken;
 use crate::mcp::McpHandle;
 use crate::permissions::PermissionManager;
 use crate::skill::Skill;
-use crate::{AgentConfig, AgentMode, EventSender};
+use crate::{AgentConfig, AgentEvent, AgentMode, EventSender, ToolStartEvent};
 use maki_providers::Model;
 use maki_providers::provider::Provider;
 
@@ -219,6 +219,15 @@ pub struct ToolContext {
     pub permissions: Arc<PermissionManager>,
     pub timeouts: maki_providers::Timeouts,
     pub file_tracker: Arc<FileReadTracker>,
+    pub(crate) batch_child: bool,
+}
+
+impl ToolContext {
+    pub(crate) fn emit_tool_start(&self, start: ToolStartEvent) {
+        if !self.batch_child {
+            let _ = self.event_tx.send(AgentEvent::ToolStart(Box::new(start)));
+        }
+    }
 }
 
 pub(crate) fn resolve_path(path: &str) -> Result<String, String> {
@@ -621,6 +630,7 @@ pub(crate) fn interpreter_ctx(
         permissions,
         timeouts: maki_providers::Timeouts::default(),
         file_tracker,
+        batch_child: false,
     }
 }
 


### PR DESCRIPTION
The registry refactor (ce70c28) routed batch children through dispatch::run which sends ToolStart for every tool. The UI only knows about batch entries inside the parent's ToolOutput, so those stray ToolStart events created duplicate top-level messages with wrong background and missing separators.

Added a batch_child flag on ToolContext so dispatch::run skips the ToolStart event when running inside a batch. ToolDone is still sent because the app needs it to mark subagent chats as finished.