### PR TITLE
agent & lua: plugins with Luau runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1046,6 +1048,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,6 +1319,24 @@ name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -1936,6 +1967,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2110,6 +2151,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "luau0-src"
+version = "0.18.3+luau709"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e73f7d752fe2ef0a41f132b83d0be154c6ae0ed84967b4df80a16901866be075"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,6 +2188,7 @@ dependencies = [
  "maki-agent",
  "maki-code-index",
  "maki-config",
+ "maki-lua",
  "maki-providers",
  "maki-storage",
  "maki-ui",
@@ -2273,6 +2324,23 @@ version = "0.2.5"
 dependencies = [
  "monty",
  "serde_json",
+ "test-case",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "maki-lua"
+version = "0.2.5"
+dependencies = [
+ "flume 0.11.1",
+ "futures-lite",
+ "maki-agent",
+ "maki-config",
+ "mlua",
+ "serde_json",
+ "smol",
+ "tempfile",
  "test-case",
  "thiserror 2.0.18",
  "tracing",
@@ -2485,6 +2553,55 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mlua"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd36acfa49ce6ee56d1307a061dd302c564eee757e6e4cd67eb4f7204846fab"
+dependencies = [
+ "bstr",
+ "either",
+ "erased-serde",
+ "futures-util",
+ "libc",
+ "mlua-sys",
+ "mlua_derive",
+ "num-traits",
+ "parking_lot",
+ "rustc-hash",
+ "rustversion",
+ "serde",
+ "serde-value",
+]
+
+[[package]]
+name = "mlua-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1c3a7fc7580227ece249fd90aa2fa3b39eb2b49d3aec5e103b3e85f2c3dfc8"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "luau0-src",
+ "pkg-config",
+]
+
+[[package]]
+name = "mlua_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465bddde514c4eb3b50b543250e97c1d4b284fa3ef7dc0ba2992c77545dbceb2"
+dependencies = [
+ "itertools 0.14.0",
+ "once_cell",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2814,6 +2931,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-float"
@@ -3204,6 +3330,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -3694,6 +3842,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4095,7 +4253,7 @@ dependencies = [
  "nix",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 4.6.0",
  "pest",
  "pest_derive",
  "phf 0.11.3",
@@ -4604,6 +4762,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4948,7 +5112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float",
+ "ordered-float 4.6.0",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ maki-code-index = { workspace = true }
 maki-config = { workspace = true }
 maki-providers = { workspace = true }
 maki-storage = { workspace = true }
+maki-lua = { workspace = true }
 clap = { workspace = true }
 color-eyre = { workspace = true }
 serde = { workspace = true }
@@ -51,6 +52,7 @@ members = [
   "maki-config",
   "maki-docgen",
   "maki-interpreter",
+  "maki-lua",
   "maki-providers",
   "maki-storage",
   "maki-tool-macro",
@@ -75,6 +77,7 @@ maki-interpreter = { path = "maki-interpreter" }
 maki-providers = { path = "maki-providers" }
 maki-storage = { path = "maki-storage" }
 maki-ui = { path = "maki-ui" }
+maki-lua = { path = "maki-lua" }
 maki-tool-macro = { path = "maki-tool-macro" }
 maki-config-macro = { path = "maki-config-macro" }
 serde = { version = "1", features = ["derive", "rc"] }
@@ -128,6 +131,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 dirs = "6"
 dotenvy = "0.15"
 tree-sitter = "0.26"
+mlua = { version = "0.11", features = ["luau", "async", "send", "serde", "macros"] }
 tree-sitter-bash = "0.25"
 tree-sitter-elixir = "0.3"
 tree-sitter-md = "0.5"

--- a/maki-agent/Cargo.toml
+++ b/maki-agent/Cargo.toml
@@ -49,3 +49,6 @@ uuid = { workspace = true }
 [dev-dependencies]
 test-case = { workspace = true }
 tempfile = { workspace = true }
+
+[features]
+test-support = []

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use std::sync::Arc;
 use std::time::Instant;
 
 use serde_json::Value;
@@ -8,8 +9,8 @@ use tracing::{debug, error, warn};
 
 use crate::mcp::{McpHandle, UNKNOWN_MCP};
 use crate::task_set::TaskSet;
+use crate::tools::ToolContext;
 use crate::tools::registry::ToolRegistry;
-use crate::tools::{ToolContext, native_static_name};
 use crate::{AgentError, AgentEvent, AgentMode, ToolDoneEvent, ToolOutput, ToolStartEvent};
 
 const DOOM_LOOP_THRESHOLD: usize = 3;
@@ -49,18 +50,9 @@ impl RecentCalls {
     }
 }
 
-/// Events need `&'static str` names, but MCP names only appear at runtime. We intern
-/// them through `McpHandle` and fall back to a shared placeholder for unknowns.
-fn static_tool_name(name: &str, mcp: Option<&McpHandle>) -> &'static str {
-    if let Some(n) = native_static_name(name) {
-        return n;
-    }
-    mcp.map(|m| m.interned_name(name)).unwrap_or(UNKNOWN_MCP)
-}
-
-/// `ToolStart` goes out from here so every source (native, MCP) looks the same to the UI.
-/// On parse error or unknown tool we skip the start event, matching the old code and
-/// keeping the UI from showing a phantom running tool.
+/// Unified dispatch: every tool source (native, MCP, Lua) flows through here.
+/// Parse errors and unknown tools skip the start event so the UI never shows a
+/// phantom running tool.
 pub(crate) async fn run(
     registry: &ToolRegistry,
     mcp: Option<&McpHandle>,
@@ -69,17 +61,22 @@ pub(crate) async fn run(
     input: &Value,
     ctx: &ToolContext,
 ) -> ToolDoneEvent {
-    let tool_static = static_tool_name(name, mcp);
+    let entry = registry.get(name);
+    let tool_id: Arc<str> = entry
+        .as_ref()
+        .map(|e| Arc::from(e.tool.name()))
+        .or_else(|| mcp.map(|m| m.interned_name(name)))
+        .unwrap_or_else(|| Arc::from(UNKNOWN_MCP));
     let started = Instant::now();
 
     let done_error = |msg: String| ToolDoneEvent {
         id: id.clone(),
-        tool: tool_static,
+        tool: Arc::clone(&tool_id),
         output: ToolOutput::Plain(msg),
         is_error: true,
     };
 
-    if let Some(entry) = registry.get(name) {
+    if let Some(entry) = entry {
         let invocation = match entry.tool.parse(input) {
             Ok(inv) => inv,
             Err(e) => {
@@ -109,7 +106,7 @@ pub(crate) async fn run(
 
         let start = ToolStartEvent {
             id: id.clone(),
-            tool: tool_static,
+            tool: Arc::clone(&tool_id),
             summary: invocation.start_summary(),
             annotation: invocation.start_annotation(),
             input: invocation.start_input(),
@@ -145,7 +142,7 @@ pub(crate) async fn run(
                 );
                 ToolDoneEvent {
                     id,
-                    tool: tool_static,
+                    tool: tool_id,
                     output,
                     is_error: false,
                 }
@@ -165,14 +162,14 @@ pub(crate) async fn run(
         // MCP tools have no `ToolInvocation`, so we build the start event by hand.
         let start = ToolStartEvent {
             id: id.clone(),
-            tool: tool_static,
+            tool: Arc::clone(&tool_id),
             summary: format!("mcp: {name}"),
             annotation: None,
             input: None,
             output: None,
         };
         ctx.emit_tool_start(start);
-        execute_mcp_tool(ctx, &id, tool_static, name, input).await
+        execute_mcp_tool(ctx, &id, tool_id, name, input).await
     } else {
         let msg = format!("{UNKNOWN_TOOL_PREFIX}: {name}");
         warn!(tool = %name, "unknown tool");
@@ -183,13 +180,13 @@ pub(crate) async fn run(
 async fn execute_mcp_tool(
     ctx: &ToolContext,
     id: &str,
-    tool_static: &'static str,
+    tool_id: Arc<str>,
     tool_name: &str,
     input: &Value,
 ) -> ToolDoneEvent {
     let done = |output: String, is_error: bool| ToolDoneEvent {
         id: id.to_owned(),
-        tool: tool_static,
+        tool: Arc::clone(&tool_id),
         output: ToolOutput::Plain(output),
         is_error,
     };
@@ -329,12 +326,12 @@ async fn dispatch_mcp(
     tool_name: &str,
     input: &Value,
 ) -> ToolDoneEvent {
-    let tool_static = ctx
+    let tool_id = ctx
         .mcp
         .as_ref()
         .map(|m| m.interned_name(tool_name))
-        .unwrap_or(UNKNOWN_MCP);
-    execute_mcp_tool(ctx, id, tool_static, tool_name, input).await
+        .unwrap_or_else(|| Arc::from(UNKNOWN_MCP));
+    execute_mcp_tool(ctx, id, tool_id, tool_name, input).await
 }
 
 #[cfg(test)]
@@ -381,7 +378,7 @@ mod tests {
             )
             .await;
             assert!(done.is_error);
-            assert_eq!(done.tool, UNKNOWN_MCP);
+            assert_eq!(done.tool.as_ref(), UNKNOWN_MCP);
             let text = done.output.as_text();
             assert!(text.starts_with(UNKNOWN_TOOL_PREFIX));
             assert!(text.contains("nonexistent__tool"));

--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -1,26 +1,15 @@
 //! MCP client: manages transports and routes tool calls to servers.
 //!
-//! Tool names are namespaced as `server__tool` (double underscore) so two servers can both
-//! expose a tool called `search` without stepping on each other. The qualified names are leaked
-//! into `&'static str` so tool descriptors can hold them without dragging a lifetime everywhere.
+//! Tool names are namespaced as `server__tool` so two servers can both expose `search`
+//! without colliding. Names are deduped via `Arc<str>` in a small cache.
 //!
-//! # Architecture
+//! All mutable state lives in the `run` task, which owns `McpManagerInner` exclusively.
+//! Commands come in through a channel (one at a time, no interleaving). Reads go through
+//! two lock-free `ArcSwap`s: a `ToolIndex` for tool calls and an `McpSnapshot` for the UI.
+//! This way a slow tool call never blocks a toggle and vice versa.
 //!
-//! All mutable state lives inside one task, `run`, which owns `McpManagerInner` outright. Nobody
-//! else gets to touch it. Two doors lead in and out:
-//!
-//! * Writes come in as `McpCommand`s over a channel. `run` handles them one at a time, so a
-//!   toggle, a reconnect and a shutdown can never interleave.
-//! * Reads go through two `ArcSwap`s that `run` republishes after every change: a `ToolIndex`
-//!   for the hot tool-call path and an `McpSnapshot` for the UI. Both sides are lock-free, so a
-//!   slow tool call can't stall a toggle and a toggle can't stall an in-flight call.
-//!
-//! `McpSnapshotReader` is a read-only newtype around the snapshot `ArcSwap`. Handing that out
-//! instead of the raw `ArcSwap` means outside code physically cannot publish a snapshot, which
-//! keeps the "only `run` publishes" rule enforced by the type system.
-//!
-//! The snapshot is the single source of truth for every per-server fact, including whether a
-//! server is disabled. There is no second list to keep in sync.
+//! `McpSnapshotReader` is a read-only handle. Outside code physically cannot publish a
+//! snapshot, so the "only `run` publishes" invariant is enforced by the type system.
 
 pub mod config;
 pub mod error;
@@ -30,7 +19,7 @@ pub mod protocol;
 pub mod stdio;
 pub mod transport;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -51,7 +40,7 @@ const SEPARATOR: &str = "__";
 pub const UNKNOWN_MCP: &str = "unknown_mcp";
 
 struct McpToolDef {
-    qualified_name: &'static str,
+    qualified_name: Arc<str>,
     raw_name: String,
     description: String,
     input_schema: Value,
@@ -146,7 +135,7 @@ struct McpManagerInner {
 
 #[derive(Default)]
 struct ToolIndex {
-    tools: HashMap<&'static str, ToolRef>,
+    tools: HashMap<Arc<str>, ToolRef>,
     prompts: HashMap<String, PromptRef>,
     descriptors: Arc<[Value]>,
 }
@@ -242,13 +231,13 @@ impl McpHandle {
         self.index.load().tools.contains_key(name)
     }
 
-    pub fn interned_name(&self, name: &str) -> &'static str {
+    pub fn interned_name(&self, name: &str) -> Arc<str> {
         self.index
             .load()
             .tools
             .get_key_value(name)
-            .map(|(&k, _)| k)
-            .unwrap_or(UNKNOWN_MCP)
+            .map(|(k, _)| Arc::clone(k))
+            .unwrap_or_else(|| Arc::from(UNKNOWN_MCP))
     }
 
     pub async fn call_tool(&self, qualified_name: &str, args: &Value) -> Result<String, McpError> {
@@ -621,14 +610,14 @@ fn publish(inner: &McpManagerInner, index: &ArcSwap<ToolIndex>, snapshot: &ArcSw
         {
             for t in &entry.tools {
                 tools.insert(
-                    t.qualified_name,
+                    Arc::clone(&t.qualified_name),
                     ToolRef {
                         raw_name: t.raw_name.clone(),
                         transport: Arc::clone(transport),
                     },
                 );
                 descriptors.push(json!({
-                    "name": t.qualified_name,
+                    "name": t.qualified_name.as_ref(),
                     "description": t.description,
                     "input_schema": t.input_schema,
                 }));
@@ -698,20 +687,20 @@ pub fn kill_process_groups(pids: &[u32]) {
 #[cfg(not(unix))]
 pub fn kill_process_groups(_pids: &[u32]) {}
 
-/// Leak the name into a `&'static str` so tool descriptors can use it without a lifetime. Names
-/// come from config, so the set is small and fixed per session, and the leak stays bounded.
-fn intern(name: String) -> &'static str {
-    static CACHE: OnceLock<Mutex<HashSet<&'static str>>> = OnceLock::new();
-    let mut set = CACHE
-        .get_or_init(|| Mutex::new(HashSet::new()))
+/// Dedup cache for qualified MCP tool names. The set is bounded (finite per session)
+/// and `Arc<str>` means entries get freed when the cache drops, unlike the old `Box::leak`.
+fn intern(name: String) -> Arc<str> {
+    static CACHE: OnceLock<Mutex<HashMap<String, Arc<str>>>> = OnceLock::new();
+    let mut map = CACHE
+        .get_or_init(|| Mutex::new(HashMap::new()))
         .lock()
         .unwrap_or_else(|e| e.into_inner());
-    if let Some(&existing) = set.get(name.as_str()) {
-        return existing;
+    if let Some(existing) = map.get(&name) {
+        return Arc::clone(existing);
     }
-    let leaked: &'static str = Box::leak(name.into_boxed_str());
-    set.insert(leaked);
-    leaked
+    let arc: Arc<str> = Arc::from(name.as_str());
+    map.insert(name, Arc::clone(&arc));
+    arc
 }
 
 #[cfg(test)]

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -21,7 +21,7 @@ mod multiedit;
 mod question;
 mod read;
 pub mod registry;
-pub(crate) mod schema;
+pub mod schema;
 mod skill;
 mod task;
 mod todowrite;
@@ -634,8 +634,8 @@ pub(crate) fn interpreter_ctx(
     }
 }
 
-#[cfg(test)]
-pub(crate) mod test_support {
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support {
     use crate::{Envelope, EventSender};
 
     use super::*;
@@ -650,7 +650,7 @@ pub(crate) mod test_support {
         ))
     });
 
-    pub(crate) fn stub_ctx_with(
+    pub fn stub_ctx_with(
         mode: &AgentMode,
         event_tx: Option<&EventSender>,
         tool_use_id: Option<&str>,
@@ -675,10 +675,11 @@ pub(crate) mod test_support {
         ctx
     }
 
-    pub(crate) fn stub_ctx(mode: &AgentMode) -> ToolContext {
+    pub fn stub_ctx(mode: &AgentMode) -> ToolContext {
         stub_ctx_with(mode, None, None)
     }
 
+    #[cfg(test)]
     pub(crate) fn stub_ctx_with_permissions(
         mode: &AgentMode,
         permissions: Arc<PermissionManager>,
@@ -697,6 +698,7 @@ pub(crate) mod test_support {
         ctx
     }
 
+    #[cfg(test)]
     pub(crate) fn pre_read(ctx: &ToolContext, path: &str) {
         ctx.file_tracker.record_read(Path::new(path));
     }

--- a/maki-agent/src/tools/registry.rs
+++ b/maki-agent/src/tools/registry.rs
@@ -1,8 +1,5 @@
-//! The one place that knows about tools. Built-in, MCP, and future plugins all land here,
-//! so there is no second list to forget and no parallel `match name { ... }` table to drift.
-//!
-//! Tool identity is an `Arc<str>` owned by the entry, so MCP tools don't need leaked
-//! strings to look like natives at call sites.
+//! Single source of truth for all tools (native, MCP, Lua). One registry, one lookup
+//! path, no parallel lists that can drift.
 
 use std::borrow::Cow;
 use std::future::Future;
@@ -20,8 +17,6 @@ use crate::{ToolInput as ToolInputEvent, ToolOutput};
 use super::{DescriptionContext, ToolContext};
 
 bitflags! {
-    /// Subagents and `code_execution` filter on this instead of each keeping their own
-    /// allow-list of tool names.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct ToolAudience: u8 {
         const MAIN         = 0b0001;
@@ -37,12 +32,11 @@ impl Default for ToolAudience {
     }
 }
 
-/// Carried on every entry so log lines can say `tool_source=mcp:github` and the "why is
-/// this one behaving differently" question answers itself.
 #[derive(Clone, Debug)]
 pub enum ToolSource {
     Native,
     Mcp { server: Arc<str> },
+    Lua { plugin: Arc<str> },
 }
 
 impl ToolSource {
@@ -50,6 +44,7 @@ impl ToolSource {
         match self {
             Self::Native => Cow::Borrowed("native"),
             Self::Mcp { server } => Cow::Owned(format!("mcp:{server}")),
+            Self::Lua { plugin } => Cow::Owned(format!("lua:{plugin}")),
         }
     }
 }
@@ -138,7 +133,12 @@ impl ToolRegistry {
     }
 
     pub fn native() -> &'static Self {
-        static NATIVE: LazyLock<ToolRegistry> = LazyLock::new(ToolRegistry::build_native);
+        Self::native_arc()
+    }
+
+    pub fn native_arc() -> &'static Arc<Self> {
+        static NATIVE: LazyLock<Arc<ToolRegistry>> =
+            LazyLock::new(|| Arc::new(ToolRegistry::build_native()));
         &NATIVE
     }
 
@@ -175,6 +175,7 @@ impl ToolRegistry {
         let name = tool.name().to_owned();
         let mut conflict = None;
         self.tools.rcu(|current| {
+            conflict = None;
             if let Some(existing) = current.iter().find(|t| t.name() == name) {
                 conflict = Some(existing.source.as_log_field().into_owned());
                 return Vec::clone(current);
@@ -202,6 +203,7 @@ impl ToolRegistry {
         let entries: Vec<_> = entries.into_iter().collect();
         let mut conflict = None;
         self.tools.rcu(|current| {
+            conflict = None;
             let mut next = Vec::clone(current);
             for (tool, source) in &entries {
                 let name = tool.name();
@@ -225,14 +227,62 @@ impl ToolRegistry {
         Ok(())
     }
 
-    /// Called on MCP server disconnect or reconnect so stale entries cannot outlive
-    /// their transport.
     pub fn clear_mcp_server(&self, server: &str) {
         self.tools.rcu(|current| {
             current
                 .iter()
                 .filter(
                     |t| !matches!(&t.source, ToolSource::Mcp { server: s } if s.as_ref() == server),
+                )
+                .cloned()
+                .collect::<Vec<_>>()
+        });
+    }
+
+    /// Swap a plugin's tools atomically. On name conflict with another source, rolls back.
+    pub fn replace_plugin(
+        &self,
+        plugin: &str,
+        new_entries: Vec<(Arc<dyn Tool>, ToolSource)>,
+    ) -> Result<(), RegistryError> {
+        let mut conflict = None;
+        self.tools.rcu(|current| {
+            conflict = None;
+            let mut next: Vec<RegisteredTool> = current
+                .iter()
+                .filter(
+                    |t| !matches!(&t.source, ToolSource::Lua { plugin: p } if p.as_ref() == plugin),
+                )
+                .cloned()
+                .collect();
+            for (tool, source) in &new_entries {
+                let name = tool.name();
+                if let Some(existing) = next.iter().find(|t| t.name() == name) {
+                    conflict = Some(RegistryError::NameConflict {
+                        name: name.to_owned(),
+                        existing: existing.source.as_log_field().into_owned(),
+                    });
+                    return Vec::clone(current);
+                }
+                next.push(RegisteredTool {
+                    tool: Arc::clone(tool),
+                    source: source.clone(),
+                });
+            }
+            next
+        });
+        if let Some(e) = conflict {
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    pub fn clear_plugin(&self, plugin: &str) {
+        self.tools.rcu(|current| {
+            current
+                .iter()
+                .filter(
+                    |t| !matches!(&t.source, ToolSource::Lua { plugin: p } if p.as_ref() == plugin),
                 )
                 .cloned()
                 .collect::<Vec<_>>()
@@ -437,5 +487,32 @@ mod tests {
         assert!(!reg.has("serverA__one"));
         assert!(reg.has("serverB__one"));
         assert!(reg.has("native_tool"));
+    }
+
+    #[test]
+    fn clear_plugin_removes_only_that_plugin() {
+        let reg = ToolRegistry::new();
+        reg.register(
+            mock("pluginA__foo"),
+            ToolSource::Lua {
+                plugin: "pluginA".into(),
+            },
+        )
+        .unwrap();
+        reg.register(
+            mock("pluginB__bar"),
+            ToolSource::Lua {
+                plugin: "pluginB".into(),
+            },
+        )
+        .unwrap();
+        reg.register(mock("native_tool2"), ToolSource::Native)
+            .unwrap();
+
+        reg.clear_plugin("pluginA");
+
+        assert!(!reg.has("pluginA__foo"));
+        assert!(reg.has("pluginB__bar"));
+        assert!(reg.has("native_tool2"));
     }
 }

--- a/maki-agent/src/tools/schema.rs
+++ b/maki-agent/src/tools/schema.rs
@@ -83,7 +83,7 @@ pub enum ParamSchema {
     Any { description: &'static str },
 }
 
-pub(crate) fn to_json_schema(s: &ParamSchema) -> Value {
+pub fn to_json_schema(s: &ParamSchema) -> Value {
     match s {
         ParamSchema::Primitive { kind, description } => {
             json!({ "type": kind.to_string(), "description": description })
@@ -134,6 +134,91 @@ pub(crate) fn to_json_schema(s: &ParamSchema) -> Value {
             }
         }
     }
+}
+
+/// `Box::leak` everything so the result is `&'static`, matching native tool schemas
+/// which are `const`. Leaks are proportional to schema size, so reloading a plugin
+/// leaks the old schemas. Acceptable because the set is small and fixed per session.
+pub fn try_from_json(v: &Value) -> Result<&'static ParamSchema, String> {
+    let description: &'static str = v
+        .get("description")
+        .and_then(|d| d.as_str())
+        .map(|s| -> &'static str { Box::leak(s.to_owned().into_boxed_str()) })
+        .unwrap_or("");
+
+    let type_str = v.get("type").and_then(|t| t.as_str());
+
+    let schema = match type_str {
+        Some("string") if v.get("enum").is_some() => {
+            let variants: &'static [&'static str] = Box::leak(
+                v["enum"]
+                    .as_array()
+                    .ok_or("enum must be an array")?
+                    .iter()
+                    .map(|e| -> Result<&'static str, String> {
+                        let s = e.as_str().ok_or("enum variant must be a string")?;
+                        Ok(Box::leak(s.to_owned().into_boxed_str()))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_boxed_slice(),
+            );
+            ParamSchema::Enum {
+                variants,
+                description,
+            }
+        }
+        Some("string") => ParamSchema::Primitive {
+            kind: ParamKind::String,
+            description,
+        },
+        Some("integer") => ParamSchema::Primitive {
+            kind: ParamKind::Integer,
+            description,
+        },
+        Some("number") => ParamSchema::Primitive {
+            kind: ParamKind::Number,
+            description,
+        },
+        Some("boolean") => ParamSchema::Primitive {
+            kind: ParamKind::Bool,
+            description,
+        },
+        Some("array") => {
+            let items_val = v.get("items").ok_or("array schema missing items")?;
+            let items: &'static ParamSchema = try_from_json(items_val)?;
+            ParamSchema::Array { items, description }
+        }
+        Some("object") => {
+            let props_map = v
+                .get("properties")
+                .and_then(|p| p.as_object())
+                .ok_or("object schema missing properties")?;
+            let required: Vec<&str> = v
+                .get("required")
+                .and_then(|r| r.as_array())
+                .map(|arr| arr.iter().filter_map(|x| x.as_str()).collect())
+                .unwrap_or_default();
+            let properties: &'static [Property] = Box::leak(
+                props_map
+                    .iter()
+                    .map(|(name, sub)| -> Result<Property, String> {
+                        let static_name: &'static str = Box::leak(name.clone().into_boxed_str());
+                        let static_schema: &'static ParamSchema = try_from_json(sub)?;
+                        let is_required = required.contains(&name.as_str());
+                        Ok((static_name, static_schema, is_required))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_boxed_slice(),
+            );
+            ParamSchema::Object {
+                properties,
+                description,
+            }
+        }
+        _ => ParamSchema::Any { description },
+    };
+
+    Ok(Box::leak(Box::new(schema)))
 }
 
 #[derive(Debug, Clone)]
@@ -289,7 +374,7 @@ pub(crate) fn preview(s: &str) -> String {
     out
 }
 
-pub(crate) fn validate(schema: &ParamSchema, input: Value) -> Result<Value, ToolInputError> {
+pub fn validate(schema: &ParamSchema, input: Value) -> Result<Value, ToolInputError> {
     walk(schema, input, &mut JsonPath::default())
 }
 
@@ -666,5 +751,36 @@ mod tests {
         };
         let out = validate(&SCHEMA, json!({"name": "x", "extra": 42})).unwrap();
         assert!(out.get("extra").is_none());
+    }
+
+    #[test_case(ParamKind::String,  json!("hello"), json!(42)    ; "string_accepts_string_rejects_int")]
+    #[test_case(ParamKind::Integer, json!(7),        json!("no") ; "integer_accepts_int_rejects_string")]
+    #[test_case(ParamKind::Bool,    json!(true),     json!(1)    ; "bool_accepts_bool_rejects_int")]
+    fn roundtrip_primitive(kind: ParamKind, good: Value, bad: Value) {
+        let schema = ParamSchema::Primitive {
+            kind,
+            description: "",
+        };
+        let json_schema = to_json_schema(&schema);
+        let recovered = try_from_json(&json_schema).expect("try_from_json failed");
+        assert!(validate(recovered, good).is_ok());
+        assert!(validate(recovered, bad).is_err());
+    }
+
+    #[test]
+    fn roundtrip_object() {
+        const INT_PRIM: ParamSchema = ParamSchema::Primitive {
+            kind: ParamKind::Integer,
+            description: "",
+        };
+        const SCHEMA: ParamSchema = ParamSchema::Object {
+            properties: &[("name", &STR_PRIM, true), ("count", &INT_PRIM, false)],
+            description: "",
+        };
+        let json_schema = to_json_schema(&SCHEMA);
+        let recovered = try_from_json(&json_schema).expect("try_from_json failed");
+        assert!(validate(recovered, json!({"name": "x", "count": 3})).is_ok());
+        assert!(validate(recovered, json!({"name": "x"})).is_ok());
+        assert!(validate(recovered, json!({"count": 3})).is_err());
     }
 }

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -1,5 +1,6 @@
 use std::fmt::Write;
 use std::path::Path;
+use std::sync::Arc;
 
 use flume::Sender;
 use maki_providers::{AgentError, ContentBlock, Message, Role, StopReason, TokenUsage};
@@ -393,7 +394,7 @@ impl ToolOutput {
 #[derive(Debug, Clone, Serialize)]
 pub struct ToolStartEvent {
     pub id: String,
-    pub tool: &'static str,
+    pub tool: Arc<str>,
     pub summary: String,
     pub annotation: Option<String>,
     pub input: Option<ToolInput>,
@@ -403,16 +404,18 @@ pub struct ToolStartEvent {
 #[derive(Debug, Clone, Serialize)]
 pub struct ToolDoneEvent {
     pub id: String,
-    pub tool: &'static str,
+    pub tool: Arc<str>,
     pub output: ToolOutput,
     pub is_error: bool,
 }
+
+const UNKNOWN_TOOL: &str = "unknown";
 
 impl ToolDoneEvent {
     pub fn error(id: String, message: impl Into<String>) -> Self {
         Self {
             id,
-            tool: "unknown",
+            tool: Arc::from(UNKNOWN_TOOL),
             output: ToolOutput::Plain(message.into()),
             is_error: true,
         }
@@ -708,7 +711,7 @@ mod tests {
     fn event_written_path_none_on_error() {
         let event = ToolDoneEvent {
             id: "id".into(),
-            tool: "write",
+            tool: Arc::from("write"),
             output: ToolOutput::WriteCode {
                 path: "src/lib.rs".into(),
                 byte_count: 10,
@@ -724,13 +727,13 @@ mod tests {
         let msg = tool_results(vec![
             ToolDoneEvent {
                 id: "t1".into(),
-                tool: "bash",
+                tool: Arc::from("bash"),
                 output: ToolOutput::Plain("ok".into()),
                 is_error: false,
             },
             ToolDoneEvent {
                 id: "t2".into(),
-                tool: "read",
+                tool: Arc::from("read"),
                 output: ToolOutput::Plain("fail".into()),
                 is_error: true,
             },
@@ -797,7 +800,7 @@ mod tests {
     fn wrote_to_matches_absolute_path() {
         let event = ToolDoneEvent {
             id: "id".into(),
-            tool: "write",
+            tool: Arc::from("write"),
             output: ToolOutput::WriteCode {
                 path: "/home/user/.maki/plans/slug.md".into(),
                 byte_count: 10,
@@ -813,7 +816,7 @@ mod tests {
     fn wrote_to_false_on_error() {
         let event = ToolDoneEvent {
             id: "id".into(),
-            tool: "write",
+            tool: Arc::from("write"),
             output: ToolOutput::WriteCode {
                 path: "/plans/slug.md".into(),
                 byte_count: 10,

--- a/maki-config-macro/src/lib.rs
+++ b/maki-config-macro/src/lib.rs
@@ -13,7 +13,7 @@ struct ConfigAttr {
 enum ConfigAttrValue {
     Flag,
     Str(LitStr),
-    Expr(Expr),
+    Expr(Box<Expr>),
 }
 
 impl Parse for ConfigAttr {
@@ -36,7 +36,7 @@ impl Parse for ConfigAttr {
             let expr: Expr = input.parse()?;
             Ok(Self {
                 key,
-                value: ConfigAttrValue::Expr(expr),
+                value: ConfigAttrValue::Expr(Box::new(expr)),
             })
         }
     }
@@ -117,14 +117,14 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
                     ConfigAttrValue::Str(lit) => {
                         attrs.default = Some(parse_str(&lit.value())?);
                     }
-                    ConfigAttrValue::Expr(expr) => attrs.default = Some(expr),
+                    ConfigAttrValue::Expr(expr) => attrs.default = Some(*expr),
                     ConfigAttrValue::Flag => {
                         return Err(syn::Error::new(item.key.span(), "default requires a value"));
                     }
                 },
                 "min" => {
                     if let ConfigAttrValue::Expr(expr) = item.value {
-                        attrs.min = Some(expr);
+                        attrs.min = Some(*expr);
                     }
                 }
                 "desc" => {

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use dirs::home_dir;
 
 use maki_config_macro::ConfigSection;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::warn;
 
@@ -157,6 +157,7 @@ struct RawConfig {
     provider: ProviderFileConfig,
     storage: StorageFileConfig,
     index: IndexFileConfig,
+    lua_plugins: LuaPluginsFileConfig,
 }
 
 #[derive(Deserialize, Default)]
@@ -291,6 +292,7 @@ pub struct Config {
     pub provider: ProviderConfig,
     pub storage: StorageConfig,
     pub permissions: PermissionsConfig,
+    pub lua_plugins: LuaPluginsConfig,
 }
 
 #[derive(Debug, Clone, Copy, ConfigSection)]
@@ -423,7 +425,7 @@ impl Default for ToolOutputLines {
     }
 }
 
-#[derive(Debug, Clone, ConfigSection)]
+#[derive(Debug, Clone, ConfigSection, Serialize)]
 #[config(section = "agent")]
 pub struct AgentConfig {
     #[config(default = DEFAULT_MAX_OUTPUT_BYTES, min = MIN_OUTPUT_BYTES, desc = "Max tool output size (bytes)")]
@@ -612,6 +614,28 @@ impl StorageConfig {
     }
 }
 
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct LuaPluginsFileConfig {
+    enabled: Option<bool>,
+    user_dirs: Option<Vec<PathBuf>>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct LuaPluginsConfig {
+    pub enabled: bool,
+    pub user_dirs: Vec<PathBuf>,
+}
+
+impl LuaPluginsConfig {
+    fn from_file(f: LuaPluginsFileConfig) -> Self {
+        Self {
+            enabled: f.enabled.unwrap_or(false),
+            user_dirs: f.user_dirs.unwrap_or_default(),
+        }
+    }
+}
+
 impl Config {
     pub fn validate(&self) -> Result<(), ConfigError> {
         self.ui.validate_all()?;
@@ -740,6 +764,7 @@ fn load_config_with_global(cwd: &Path, no_rtk: bool, global: Option<PathBuf>) ->
         provider: ProviderConfig::from_file(raw.provider),
         storage: StorageConfig::from_file(raw.storage),
         permissions: load_permissions_with_global(cwd, global.as_deref()),
+        lua_plugins: LuaPluginsConfig::from_file(raw.lua_plugins),
     }
 }
 
@@ -1102,6 +1127,7 @@ mod tests {
             provider: ProviderConfig::default(),
             storage: StorageConfig::default(),
             permissions: PermissionsConfig::default(),
+            lua_plugins: LuaPluginsConfig::default(),
         };
         match (section, field) {
             ("provider", "connect_timeout_secs") => {
@@ -1320,5 +1346,31 @@ mod tests {
             std::env::remove_var(PROJECT_SHADOWS);
             std::env::remove_var(PROCESS_WINS);
         }
+    }
+
+    #[test]
+    fn lua_plugins_config_parses_fields() {
+        let dir = TempDir::new().unwrap();
+        let maki_dir = dir.path().join(".maki");
+        fs::create_dir_all(&maki_dir).unwrap();
+        fs::write(
+            maki_dir.join("config.toml"),
+            "[lua_plugins]\nenabled = true\nuser_dirs = [\"/tmp/plugins\"]\n",
+        )
+        .unwrap();
+        let config = load_config(dir.path(), false);
+        assert!(config.lua_plugins.enabled);
+        assert_eq!(
+            config.lua_plugins.user_dirs,
+            vec![PathBuf::from("/tmp/plugins")]
+        );
+    }
+
+    #[test]
+    fn lua_plugins_config_empty_returns_defaults() {
+        let dir = TempDir::new().unwrap();
+        let config = load_config(dir.path(), false);
+        assert!(!config.lua_plugins.enabled);
+        assert!(config.lua_plugins.user_dirs.is_empty());
     }
 }

--- a/maki-lua/Cargo.toml
+++ b/maki-lua/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "maki-lua"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+maki-agent = { workspace = true }
+maki-config = { workspace = true }
+mlua = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+smol = { workspace = true }
+flume = { workspace = true }
+futures-lite = { workspace = true }
+
+[dev-dependencies]
+maki-agent = { workspace = true, features = ["test-support"] }
+tempfile = { workspace = true }
+test-case = { workspace = true }

--- a/maki-lua/src/api/ctx.rs
+++ b/maki-lua/src/api/ctx.rs
@@ -1,0 +1,16 @@
+use maki_agent::cancel::CancelToken;
+use maki_config::AgentConfig;
+use mlua::{LuaSerdeExt, UserData, UserDataMethods};
+
+pub(crate) struct LuaCtx {
+    pub(crate) cancel: CancelToken,
+    pub(crate) config: AgentConfig,
+}
+
+impl UserData for LuaCtx {
+    fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method("cancelled", |_, this, ()| Ok(this.cancel.is_cancelled()));
+
+        methods.add_method("config", |lua, this, ()| lua.to_value(&this.config));
+    }
+}

--- a/maki-lua/src/api/fs.rs
+++ b/maki-lua/src/api/fs.rs
@@ -1,0 +1,217 @@
+use std::ffi::OsStr;
+use std::io::ErrorKind;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use mlua::{Buffer, Lua, Result as LuaResult, Table};
+
+const SANDBOX_ERR: &str = "path outside sandbox";
+
+/// Resolve `path` for sandbox checking: canonicalize the deepest ancestor that exists
+/// (catching symlink escapes), then re-append remaining components lexically.
+/// This lets plugins write to paths that don't exist yet while still blocking
+/// symlink escapes through any component that does exist.
+fn resolve_for_sandbox(path: &str) -> LuaResult<PathBuf> {
+    let p = Path::new(path);
+    let abs = if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|e| mlua::Error::runtime(format!("fs: cannot resolve cwd: {e}")))?
+            .join(p)
+    };
+
+    let mut existing = abs.as_path();
+    let mut trailing: Vec<&OsStr> = Vec::new();
+    let canon = loop {
+        match existing.canonicalize() {
+            Ok(c) => break c,
+            Err(_) => match existing.parent() {
+                Some(parent) => {
+                    if let Some(name) = existing.file_name() {
+                        trailing.push(name);
+                    }
+                    existing = parent;
+                }
+                None => {
+                    return Err(mlua::Error::runtime(format!(
+                        "fs: cannot resolve path '{path}'"
+                    )));
+                }
+            },
+        }
+    };
+
+    let mut result = canon;
+    for name in trailing.iter().rev() {
+        let comp = Path::new(name);
+        match comp.components().next() {
+            Some(Component::ParentDir) => {
+                result.pop();
+            }
+            Some(Component::CurDir) | None => {}
+            _ => result.push(name),
+        }
+    }
+    Ok(result)
+}
+
+fn check_sandbox(path: &str, roots: &[PathBuf]) -> LuaResult<PathBuf> {
+    let resolved = resolve_for_sandbox(path)?;
+    if roots.iter().any(|r| resolved.starts_with(r)) {
+        Ok(resolved)
+    } else {
+        Err(mlua::Error::runtime(format!("{SANDBOX_ERR}: {path}")))
+    }
+}
+
+pub(crate) fn create_fs_table(lua: &Lua, roots: Arc<[PathBuf]>) -> LuaResult<Table> {
+    let t = lua.create_table()?;
+
+    let roots_read = Arc::clone(&roots);
+    t.set(
+        "read",
+        lua.create_function(move |_, path: String| {
+            let canonical = check_sandbox(&path, &roots_read)?;
+            std::fs::read_to_string(&canonical).map_err(|e| {
+                if e.kind() == ErrorKind::InvalidData {
+                    mlua::Error::runtime("non-utf8 content; use read_bytes")
+                } else {
+                    mlua::Error::runtime(format!("fs.read({path}): {e}"))
+                }
+            })
+        })?,
+    )?;
+
+    let roots_bytes = Arc::clone(&roots);
+    t.set(
+        "read_bytes",
+        lua.create_function(move |lua, path: String| -> LuaResult<Buffer> {
+            let canonical = check_sandbox(&path, &roots_bytes)?;
+            let bytes = std::fs::read(&canonical)
+                .map_err(|e| mlua::Error::runtime(format!("fs.read_bytes({path}): {e}")))?;
+            lua.create_buffer(bytes)
+        })?,
+    )?;
+
+    let roots_meta = Arc::clone(&roots);
+    t.set(
+        "metadata",
+        lua.create_function(move |lua, path: String| -> LuaResult<Table> {
+            let canonical = check_sandbox(&path, &roots_meta)?;
+            let meta = std::fs::metadata(&canonical)
+                .map_err(|e| mlua::Error::runtime(format!("fs.metadata({path}): {e}")))?;
+            let tbl = lua.create_table()?;
+            tbl.set("size", meta.len())?;
+            tbl.set("is_file", meta.is_file())?;
+            tbl.set("is_dir", meta.is_dir())?;
+            Ok(tbl)
+        })?,
+    )?;
+
+    Ok(t)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mlua::Lua;
+    use tempfile::TempDir;
+
+    fn roots(dirs: &[&Path]) -> Arc<[PathBuf]> {
+        dirs.iter()
+            .map(|p| p.canonicalize().unwrap_or_else(|_| p.to_path_buf()))
+            .collect::<Vec<_>>()
+            .into()
+    }
+
+    #[test]
+    fn fs_read_within_cwd_ok() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("hello.txt");
+        std::fs::write(&file, "world").unwrap();
+
+        let lua = Lua::new();
+        let allowed = roots(&[tmp.path()]);
+        let tbl = create_fs_table(&lua, allowed).unwrap();
+        let read: mlua::Function = tbl.get("read").unwrap();
+        let result: String = read.call(file.to_str().unwrap()).unwrap();
+        assert_eq!(result, "world");
+    }
+
+    #[test]
+    fn fs_read_outside_cwd_denied() {
+        let tmp = TempDir::new().unwrap();
+
+        let lua = Lua::new();
+        let allowed = roots(&[tmp.path()]);
+        let tbl = create_fs_table(&lua, allowed).unwrap();
+        let read: mlua::Function = tbl.get("read").unwrap();
+        let err = read
+            .call::<String>("/etc/hostname")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains(SANDBOX_ERR),
+            "expected sandbox error, got: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fs_read_symlink_escape_denied() {
+        let tmp = TempDir::new().unwrap();
+        let link = tmp.path().join("escape");
+        std::os::unix::fs::symlink("/etc/hostname", &link).unwrap();
+
+        let lua = Lua::new();
+        let allowed = roots(&[tmp.path()]);
+        let tbl = create_fs_table(&lua, allowed).unwrap();
+
+        let read: mlua::Function = tbl.get("read").unwrap();
+        let err = read
+            .call::<String>(link.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains(SANDBOX_ERR),
+            "expected sandbox error for symlink escape, got: {err}"
+        );
+    }
+
+    #[test]
+    fn fs_read_bytes_sandbox_check() {
+        let tmp = TempDir::new().unwrap();
+
+        let lua = Lua::new();
+        let allowed = roots(&[tmp.path()]);
+        let tbl = create_fs_table(&lua, allowed).unwrap();
+        let read_bytes: mlua::Function = tbl.get("read_bytes").unwrap();
+        let err = read_bytes
+            .call::<Buffer>("/etc/hostname")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains(SANDBOX_ERR),
+            "expected sandbox error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn fs_metadata_sandbox_check() {
+        let tmp = TempDir::new().unwrap();
+
+        let lua = Lua::new();
+        let allowed = roots(&[tmp.path()]);
+        let tbl = create_fs_table(&lua, allowed).unwrap();
+        let metadata: mlua::Function = tbl.get("metadata").unwrap();
+        let err = metadata
+            .call::<Table>("/etc/hostname")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains(SANDBOX_ERR),
+            "expected sandbox error, got: {err}"
+        );
+    }
+}

--- a/maki-lua/src/api/log.rs
+++ b/maki-lua/src/api/log.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+
+use mlua::{Lua, Result as LuaResult, Table};
+
+pub(crate) fn create_log_table(lua: &Lua, plugin: Arc<str>) -> LuaResult<Table> {
+    let t = lua.create_table()?;
+
+    let mk = |lua: &Lua, plugin: Arc<str>, level: &'static str| {
+        lua.create_function(move |_, msg: String| {
+            let plugin = &plugin;
+            match level {
+                "debug" => tracing::debug!(plugin = %plugin, "{}", msg),
+                "info" => tracing::info!(plugin = %plugin, "{}", msg),
+                "warn" => tracing::warn!(plugin = %plugin, "{}", msg),
+                "error" => tracing::error!(plugin = %plugin, "{}", msg),
+                _ => unreachable!(),
+            }
+            Ok(())
+        })
+    };
+
+    t.set("debug", mk(lua, Arc::clone(&plugin), "debug")?)?;
+    t.set("info", mk(lua, Arc::clone(&plugin), "info")?)?;
+    t.set("warn", mk(lua, Arc::clone(&plugin), "warn")?)?;
+    t.set("error", mk(lua, plugin, "error")?)?;
+
+    Ok(t)
+}

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -1,0 +1,26 @@
+pub(crate) mod ctx;
+pub(crate) mod fs;
+pub(crate) mod log;
+pub(crate) mod tool;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use mlua::{Lua, Result as LuaResult, Table};
+
+use crate::api::tool::PendingTools;
+
+pub(crate) fn create_maki_global(
+    lua: &Lua,
+    pending: PendingTools,
+    fs_roots: Arc<[PathBuf]>,
+    plugin: Arc<str>,
+) -> LuaResult<Table> {
+    let maki = lua.create_table()?;
+
+    maki.set("api", tool::create_api_table(lua, pending)?)?;
+    maki.set("fs", fs::create_fs_table(lua, fs_roots)?)?;
+    maki.set("log", log::create_log_table(lua, plugin)?)?;
+
+    Ok(maki)
+}

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -1,0 +1,272 @@
+use std::borrow::Cow;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use flume::Sender;
+use maki_agent::ToolOutput;
+use maki_agent::tools::Tool;
+use maki_agent::tools::schema::{ParamSchema, to_json_schema, try_from_json, validate};
+use maki_agent::tools::{
+    Deadline, DescriptionContext, ExecFuture, ParseError, ToolAudience, ToolContext, ToolInvocation,
+};
+use mlua::{
+    Function, Lua, LuaSerdeExt, RegistryKey, Result as LuaResult, Table, Value as LuaValue,
+};
+use serde_json::Value;
+
+use crate::api::ctx::LuaCtx;
+use crate::runtime::Request;
+
+const TOOL_NAME_MAX: usize = 64;
+const TOOL_HANDLER_RETURN_ERR: &str =
+    "tool handler must return string or {output=string, is_error?=bool}";
+const TOOL_CALL_MAX_TIME: Duration = Duration::from_secs(30);
+
+pub(crate) struct PendingTool {
+    pub(crate) name: Arc<str>,
+    pub(crate) description: String,
+    pub(crate) schema: &'static ParamSchema,
+    pub(crate) audience: ToolAudience,
+    pub(crate) handler_key: RegistryKey,
+}
+
+pub(crate) type PendingTools = Arc<Mutex<Vec<PendingTool>>>;
+
+pub(crate) struct LuaTool {
+    pub(crate) name: Arc<str>,
+    pub(crate) description: String,
+    pub(crate) schema: &'static ParamSchema,
+    pub(crate) audience: ToolAudience,
+    pub(crate) tx: Sender<Request>,
+    pub(crate) plugin: Arc<str>,
+}
+
+impl Tool for LuaTool {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn description(&self, _ctx: &DescriptionContext) -> Cow<'_, str> {
+        Cow::Borrowed(&self.description)
+    }
+
+    fn schema(&self) -> Value {
+        to_json_schema(self.schema)
+    }
+
+    fn audience(&self) -> ToolAudience {
+        self.audience
+    }
+
+    fn parse(&self, input: &Value) -> Result<Box<dyn ToolInvocation>, ParseError> {
+        let validated = validate(self.schema, input.clone())?;
+        Ok(Box::new(LuaToolInvocation {
+            tool: Arc::clone(&self.name),
+            plugin: Arc::clone(&self.plugin),
+            input: validated,
+            tx: self.tx.clone(),
+        }))
+    }
+}
+
+struct LuaToolInvocation {
+    tool: Arc<str>,
+    plugin: Arc<str>,
+    input: Value,
+    tx: Sender<Request>,
+}
+
+impl ToolInvocation for LuaToolInvocation {
+    fn start_summary(&self) -> String {
+        format!("{}({})", self.tool, self.plugin)
+    }
+
+    fn execute<'a>(self: Box<Self>, ctx: &'a ToolContext) -> ExecFuture<'a> {
+        let deadline = ctx.deadline;
+        let plugin = self.plugin;
+        let tool = self.tool;
+        let input = self.input;
+        let tx = self.tx;
+
+        Box::pin(async move {
+            let timeout_secs = deadline.cap_timeout(TOOL_CALL_MAX_TIME.as_secs())?;
+
+            let (reply_tx, reply_rx) = flume::bounded(1);
+            let lua_ctx = LuaCtx {
+                cancel: ctx.cancel.clone(),
+                config: ctx.config.clone(),
+            };
+
+            tx.send_async(Request::CallTool {
+                plugin: Arc::clone(&plugin),
+                tool: Arc::clone(&tool),
+                input,
+                ctx: lua_ctx,
+                deadline: match deadline {
+                    Deadline::At(t) => Some(t),
+                    Deadline::None => None,
+                },
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "lua thread disconnected".to_string())?;
+
+            let timeout = smol::Timer::after(Duration::from_secs(timeout_secs));
+            let result =
+                futures_lite::future::race(async { Some(reply_rx.recv_async().await) }, async {
+                    timeout.await;
+                    None
+                })
+                .await;
+
+            match result {
+                None => Err(format!(
+                    "plugin {} tool {} exceeded timeout ({timeout_secs}s)",
+                    plugin, tool
+                )),
+                Some(Err(_)) => Err("lua thread disconnected".to_string()),
+                Some(Ok(result)) => result.map(ToolOutput::Plain),
+            }
+        })
+    }
+}
+
+pub(crate) fn create_api_table(lua: &Lua, pending: PendingTools) -> LuaResult<Table> {
+    let t = lua.create_table()?;
+
+    t.set(
+        "register_tool",
+        lua.create_function(move |lua, spec: Table| {
+            register_tool_from_lua(lua, &spec, pending.clone())
+        })?,
+    )?;
+
+    Ok(t)
+}
+
+fn is_valid_tool_name(name: &str) -> bool {
+    if name.is_empty() || name.len() > TOOL_NAME_MAX {
+        return false;
+    }
+    let mut chars = name.chars();
+    let first = chars.next().unwrap();
+    if !first.is_ascii_alphabetic() && first != '_' {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn parse_audience(audiences: Option<mlua::Table>) -> LuaResult<ToolAudience> {
+    let Some(arr) = audiences else {
+        return Ok(ToolAudience::default());
+    };
+    let mut flags = ToolAudience::empty();
+    let mut count = 0;
+    for item in arr.sequence_values::<String>() {
+        let s = item?;
+        count += 1;
+        flags |= match s.as_str() {
+            "all" => ToolAudience::all(),
+            "main" => ToolAudience::MAIN,
+            "research_sub" => ToolAudience::RESEARCH_SUB,
+            "general_sub" => ToolAudience::GENERAL_SUB,
+            "interpreter" => ToolAudience::INTERPRETER,
+            _ => {
+                return Err(mlua::Error::runtime(format!("unknown audience: {s}")));
+            }
+        };
+    }
+    if count == 0 {
+        return Err(mlua::Error::runtime(
+            "register_tool: 'audiences' must be omitted or non-empty",
+        ));
+    }
+    Ok(flags)
+}
+
+fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> LuaResult<()> {
+    let name: String = spec
+        .get("name")
+        .map_err(|_| mlua::Error::runtime("register_tool: missing 'name'"))?;
+    if !is_valid_tool_name(&name) {
+        return Err(mlua::Error::runtime(format!(
+            "register_tool: invalid name '{name}'"
+        )));
+    }
+    let description: String = spec.get("description").unwrap_or_default();
+    if description.trim().is_empty() {
+        return Err(mlua::Error::runtime(
+            "register_tool: description must be non-empty",
+        ));
+    }
+    let handler: Function = spec
+        .get("handler")
+        .map_err(|_| mlua::Error::runtime("register_tool: missing 'handler'"))?;
+    let schema_table: LuaValue = spec
+        .get("schema")
+        .map_err(|_| mlua::Error::runtime("register_tool: missing 'schema'"))?;
+    let audiences: Option<mlua::Table> = spec.get("audiences").ok();
+
+    let schema_val: Value = lua.from_value(schema_table)?;
+    let param_schema = try_from_json(&schema_val).map_err(mlua::Error::runtime)?;
+    let audience = parse_audience(audiences)?;
+    let handler_key: RegistryKey = lua.create_registry_value(handler)?;
+    let name: Arc<str> = Arc::from(name.as_str());
+
+    pending
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .push(PendingTool {
+            name,
+            description,
+            schema: param_schema,
+            audience,
+            handler_key,
+        });
+
+    Ok(())
+}
+
+pub(crate) type ToolCallResult = Result<String, String>;
+pub(crate) fn coerce_tool_result(result: &LuaValue) -> ToolCallResult {
+    match result {
+        LuaValue::String(s) => s.to_str().map(|s| s.to_owned()).map_err(|e| e.to_string()),
+        LuaValue::Table(t) => {
+            let output = t.get::<LuaValue>("output").ok().and_then(|v| {
+                if let LuaValue::String(s) = v {
+                    s.to_str().ok().map(|s| s.to_owned())
+                } else {
+                    None
+                }
+            });
+            match output {
+                Some(s) if matches!(t.get::<LuaValue>("is_error"), Ok(LuaValue::Boolean(true))) => {
+                    Err(s)
+                }
+                Some(s) => Ok(s),
+                None => Err(TOOL_HANDLER_RETURN_ERR.to_string()),
+            }
+        }
+        _ => Err(TOOL_HANDLER_RETURN_ERR.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test_case::test_case("echo", true ; "simple_name")]
+    #[test_case::test_case("echo_tool", true ; "with_underscore")]
+    #[test_case::test_case("_private", true ; "leading_underscore")]
+    #[test_case::test_case("tool123", true ; "trailing_digits")]
+    #[test_case::test_case("a", true ; "single_char")]
+    #[test_case::test_case("", false ; "empty")]
+    #[test_case::test_case("../../bash", false ; "path_traversal")]
+    #[test_case::test_case("foo bar", false ; "space")]
+    #[test_case::test_case("foo.bar", false ; "dot")]
+    #[test_case::test_case("foo/bar", false ; "slash")]
+    #[test_case::test_case("1foo", false ; "leading_digit")]
+    fn tool_name_validation(name: &str, expected: bool) {
+        assert_eq!(is_valid_tool_name(name), expected);
+    }
+}

--- a/maki-lua/src/error.rs
+++ b/maki-lua/src/error.rs
@@ -1,0 +1,24 @@
+use std::io;
+use std::path::PathBuf;
+
+#[derive(Debug, thiserror::Error)]
+pub enum PluginError {
+    #[error("lua error in {plugin}: {source}")]
+    Lua {
+        plugin: String,
+        #[source]
+        source: mlua::Error,
+    },
+    #[error("plugin {plugin} attempted to shadow existing tool '{tool}'")]
+    NameConflict { plugin: String, tool: String },
+    #[error("duplicate plugin name '{plugin}' across dirs")]
+    DuplicatePlugin { plugin: String },
+    #[error("io error loading plugin {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("plugin host is not running")]
+    HostDead,
+}

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -1,0 +1,7 @@
+mod api;
+mod error;
+mod loader;
+mod runtime;
+
+pub use error::PluginError;
+pub use loader::PluginHost;

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -1,0 +1,199 @@
+use std::collections::HashSet;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use maki_agent::tools::ToolRegistry;
+use maki_config::LuaPluginsConfig;
+
+use crate::error::PluginError;
+use crate::runtime::{self, LuaThread, Request};
+
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+
+pub struct PluginHost {
+    inner: Option<LuaThread>,
+}
+
+impl Drop for PluginHost {
+    fn drop(&mut self) {
+        let Some(ref mut inner) = self.inner else {
+            return;
+        };
+        let Some(handle) = inner.join.take() else {
+            return;
+        };
+        inner.shutdown.store(true, Ordering::Release);
+        let _ = inner.tx.send(Request::Shutdown);
+        let (done_tx, done_rx) = flume::bounded(1);
+        std::thread::spawn(move || {
+            let _ = done_tx.send(handle.join().is_err());
+        });
+        match done_rx.recv_timeout(SHUTDOWN_TIMEOUT) {
+            Ok(true) => tracing::warn!("lua thread panicked on shutdown"),
+            Err(_) => tracing::warn!("lua thread did not stop within timeout, detaching"),
+            Ok(false) => {}
+        }
+    }
+}
+
+impl PluginHost {
+    pub fn new(
+        config: &LuaPluginsConfig,
+        registry: Arc<ToolRegistry>,
+    ) -> Result<Self, PluginError> {
+        if !config.enabled {
+            return Ok(Self { inner: None });
+        }
+
+        let lua = runtime::spawn(registry)?;
+        let host = Self { inner: Some(lua) };
+
+        let mut seen: HashSet<Arc<str>> = HashSet::new();
+        for dir in &config.user_dirs {
+            host.load_dir(dir, &mut seen)?;
+        }
+
+        Ok(host)
+    }
+
+    fn tx(&self) -> Result<&flume::Sender<Request>, PluginError> {
+        self.inner
+            .as_ref()
+            .map(|r| &r.tx)
+            .ok_or(PluginError::HostDead)
+    }
+
+    fn load_dir(&self, dir: &Path, seen: &mut HashSet<Arc<str>>) -> Result<(), PluginError> {
+        let entries = match fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(e) if e.kind() == ErrorKind::NotFound => {
+                tracing::debug!(path = %dir.display(), "plugin dir not found, skipping");
+                return Ok(());
+            }
+            Err(e) => {
+                return Err(PluginError::Io {
+                    path: dir.to_owned(),
+                    source: e,
+                });
+            }
+        };
+
+        let mut paths: Vec<PathBuf> = entries
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("lua"))
+            .collect();
+        paths.sort();
+
+        for path in paths {
+            let stem = match path.file_stem().and_then(|s| s.to_str()) {
+                Some(s) => Arc::from(s),
+                None => {
+                    tracing::warn!(path = %path.display(), "plugin file has non-UTF8 name, skipping");
+                    continue;
+                }
+            };
+            if seen.contains(&stem) {
+                return Err(PluginError::DuplicatePlugin {
+                    plugin: stem.to_string(),
+                });
+            }
+            seen.insert(Arc::clone(&stem));
+            self.load_file(&path, stem)?;
+        }
+        Ok(())
+    }
+
+    fn load_file(&self, path: &Path, name: Arc<str>) -> Result<(), PluginError> {
+        let plugin_dir = path.parent().map(Path::to_path_buf);
+        let source = fs::read_to_string(path).map_err(|e| PluginError::Io {
+            path: path.to_owned(),
+            source: e,
+        })?;
+        self.load_source_named(name, source, plugin_dir)
+    }
+
+    fn load_source_named(
+        &self,
+        name: Arc<str>,
+        source: String,
+        plugin_dir: Option<PathBuf>,
+    ) -> Result<(), PluginError> {
+        let tx = self.tx()?;
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        tx.send(Request::LoadSource {
+            name,
+            source,
+            plugin_dir,
+            reply: reply_tx,
+        })
+        .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)?
+    }
+
+    pub fn unload(&self, plugin: &str) -> Result<(), PluginError> {
+        let tx = self.tx()?;
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        tx.send(Request::ClearPlugin {
+            plugin: Arc::from(plugin),
+            reply: reply_tx,
+        })
+        .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)?;
+        Ok(())
+    }
+
+    pub fn load_source(&self, name: &str, source: &str) -> Result<(), PluginError> {
+        self.load_source_named(Arc::from(name), source.to_owned(), None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use maki_agent::tools::ToolRegistry;
+    use maki_config::LuaPluginsConfig;
+
+    use super::*;
+
+    fn enabled_config() -> LuaPluginsConfig {
+        LuaPluginsConfig {
+            enabled: true,
+            user_dirs: vec![],
+        }
+    }
+
+    fn disabled_config() -> LuaPluginsConfig {
+        LuaPluginsConfig {
+            enabled: false,
+            user_dirs: vec![],
+        }
+    }
+
+    fn fresh_registry() -> Arc<ToolRegistry> {
+        Arc::new(ToolRegistry::new())
+    }
+
+    #[test]
+    fn dropping_host_stops_thread() {
+        let reg = fresh_registry();
+        let host = PluginHost::new(&enabled_config(), Arc::clone(&reg)).unwrap();
+        host.load_source("noop", "").unwrap();
+        let start = std::time::Instant::now();
+        drop(host);
+        assert!(
+            start.elapsed() < Duration::from_secs(10),
+            "drop took too long: {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[test]
+    fn dropping_disabled_host_is_noop() {
+        let reg = fresh_registry();
+        let host = PluginHost::new(&disabled_config(), Arc::clone(&reg)).unwrap();
+        drop(host);
+    }
+}

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -1,0 +1,385 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Instant;
+
+use maki_agent::cancel::CancelToken;
+use maki_agent::tools::{RegistryError, Tool, ToolRegistry, ToolSource};
+use mlua::{Function, Lua, LuaSerdeExt, RegistryKey, Value as LuaValue, VmState};
+use serde_json::Value;
+
+use crate::api::create_maki_global;
+use crate::api::ctx::LuaCtx;
+use crate::api::tool::{LuaTool, PendingTool, PendingTools, ToolCallResult, coerce_tool_result};
+use crate::error::PluginError;
+
+const INTERRUPT_MSG: &str = "plugin interrupted: cancelled, deadline exceeded, or shutting down";
+
+pub enum Request {
+    LoadSource {
+        name: Arc<str>,
+        source: String,
+        plugin_dir: Option<PathBuf>,
+        reply: flume::Sender<Result<(), PluginError>>,
+    },
+    CallTool {
+        plugin: Arc<str>,
+        tool: Arc<str>,
+        input: Value,
+        ctx: LuaCtx,
+        deadline: Option<Instant>,
+        reply: flume::Sender<ToolCallResult>,
+    },
+    ClearPlugin {
+        plugin: Arc<str>,
+        reply: flume::Sender<()>,
+    },
+    Shutdown,
+}
+
+struct CallState {
+    cancel: CancelToken,
+    deadline: Option<Instant>,
+}
+
+struct CallStateGuard<'a>(&'a Mutex<Option<CallState>>);
+
+impl Drop for CallStateGuard<'_> {
+    fn drop(&mut self) {
+        let mut guard = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = None;
+    }
+}
+
+struct LuaRuntime {
+    lua: Lua,
+    pending: PendingTools,
+    plugins: HashMap<Arc<str>, HashMap<Arc<str>, RegistryKey>>,
+    registry: Arc<ToolRegistry>,
+    tx: flume::Sender<Request>,
+    cwd: PathBuf,
+    call_state: Arc<Mutex<Option<CallState>>>,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl LuaRuntime {
+    fn new(
+        registry: Arc<ToolRegistry>,
+        tx: flume::Sender<Request>,
+        shutdown: Arc<AtomicBool>,
+    ) -> Result<Self, PluginError> {
+        let lua = Lua::new();
+        let pending: PendingTools = Arc::new(Mutex::new(Vec::new()));
+        let cwd = std::env::current_dir().unwrap_or_default();
+        let call_state: Arc<Mutex<Option<CallState>>> = Arc::new(Mutex::new(None));
+
+        let interrupt_state = Arc::clone(&call_state);
+        let interrupt_shutdown = Arc::clone(&shutdown);
+        lua.set_interrupt(move |_| {
+            if interrupt_shutdown.load(Ordering::Acquire) {
+                return Err(mlua::Error::runtime(INTERRUPT_MSG));
+            }
+            let guard = interrupt_state.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(state) = guard.as_ref() {
+                let cancelled = state.cancel.is_cancelled();
+                let expired = state.deadline.is_some_and(|d| Instant::now() > d);
+                if cancelled || expired {
+                    return Err(mlua::Error::runtime(INTERRUPT_MSG));
+                }
+            }
+            Ok(VmState::Continue)
+        });
+
+        let globals = lua.globals();
+        for dangerous in &["os", "io", "debug", "package", "require"] {
+            globals
+                .set(*dangerous, LuaValue::Nil)
+                .map_err(|e| PluginError::Lua {
+                    plugin: "<init>".to_owned(),
+                    source: e,
+                })?;
+        }
+        drop(globals);
+        lua.sandbox(true).map_err(|e| PluginError::Lua {
+            plugin: "<init>".to_owned(),
+            source: e,
+        })?;
+
+        Ok(Self {
+            lua,
+            pending,
+            plugins: HashMap::new(),
+            registry,
+            tx,
+            cwd,
+            call_state,
+            shutdown,
+        })
+    }
+
+    fn fs_roots(&self, plugin_dir: Option<&Path>) -> Arc<[PathBuf]> {
+        let cwd_canon = self.cwd.canonicalize().unwrap_or_else(|_| self.cwd.clone());
+        let mut roots = vec![cwd_canon];
+        if let Some(dir) = plugin_dir {
+            let canon = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
+            if !roots.contains(&canon) {
+                roots.push(canon);
+            }
+        }
+        roots.into()
+    }
+
+    /// Log and continue on individual failures since partial removal still helps.
+    fn drop_plugin_keys(&mut self, name: &str) {
+        if let Some(keys) = self.plugins.remove(name) {
+            for (_, key) in keys {
+                if let Err(e) = self.lua.remove_registry_value(key) {
+                    tracing::warn!(plugin = name, error = %e, "failed to drop lua handler key");
+                }
+            }
+        }
+    }
+
+    fn drain_pending(&self) -> Vec<PendingTool> {
+        self.pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .drain(..)
+            .collect()
+    }
+
+    fn discard_pending(&mut self, tools: Vec<PendingTool>) {
+        for t in tools {
+            if let Err(e) = self.lua.remove_registry_value(t.handler_key) {
+                tracing::warn!(error = %e, "failed to drop lua handler key on rollback");
+            }
+        }
+    }
+
+    fn build_plugin_env(
+        &self,
+        fs_roots: Arc<[PathBuf]>,
+        plugin: Arc<str>,
+    ) -> Result<mlua::Table, mlua::Error> {
+        let maki = create_maki_global(&self.lua, Arc::clone(&self.pending), fs_roots, plugin)?;
+        let env = self.lua.create_table()?;
+        env.set("maki", maki)?;
+        let meta = self.lua.create_table()?;
+        meta.set("__index", self.lua.globals())?;
+        env.set_metatable(Some(meta))?;
+        Ok(env)
+    }
+
+    fn load_source(
+        &mut self,
+        name: Arc<str>,
+        source: &str,
+        plugin_dir: Option<PathBuf>,
+    ) -> Result<(), PluginError> {
+        let stale = self.drain_pending();
+        debug_assert!(
+            stale.is_empty(),
+            "leftover pending tools from previous load"
+        );
+        self.discard_pending(stale);
+
+        let roots = self.fs_roots(plugin_dir.as_deref());
+
+        let env = self
+            .build_plugin_env(roots, Arc::clone(&name))
+            .map_err(|e| PluginError::Lua {
+                plugin: name.to_string(),
+                source: e,
+            })?;
+
+        let exec_result = self
+            .lua
+            .load(source)
+            .set_name(name.as_ref())
+            .set_environment(env)
+            .exec();
+
+        if let Err(e) = exec_result {
+            let stale = self.drain_pending();
+            self.discard_pending(stale);
+            return Err(PluginError::Lua {
+                plugin: name.to_string(),
+                source: e,
+            });
+        }
+
+        let pending = self.drain_pending();
+
+        let registry_entries: Vec<(Arc<dyn Tool>, ToolSource)> = pending
+            .iter()
+            .map(|t| {
+                let tool: Arc<dyn Tool> = Arc::new(LuaTool {
+                    name: Arc::clone(&t.name),
+                    description: t.description.clone(),
+                    schema: t.schema,
+                    audience: t.audience,
+                    tx: self.tx.clone(),
+                    plugin: Arc::clone(&name),
+                });
+                (
+                    tool,
+                    ToolSource::Lua {
+                        plugin: Arc::clone(&name),
+                    },
+                )
+            })
+            .collect();
+
+        if let Err(e) = self.registry.replace_plugin(&name, registry_entries) {
+            self.discard_pending(pending);
+            return Err(match e {
+                RegistryError::NameConflict { name: n, .. } => PluginError::NameConflict {
+                    plugin: name.to_string(),
+                    tool: n,
+                },
+            });
+        }
+
+        self.drop_plugin_keys(&name);
+
+        let keys: HashMap<Arc<str>, RegistryKey> = pending
+            .into_iter()
+            .map(|t| (t.name, t.handler_key))
+            .collect();
+        self.plugins.insert(name, keys);
+
+        Ok(())
+    }
+
+    fn clear_plugin(&mut self, plugin: &str) {
+        self.registry.clear_plugin(plugin);
+        self.drop_plugin_keys(plugin);
+    }
+
+    fn call_tool(
+        &self,
+        plugin: &str,
+        tool: &str,
+        input: Value,
+        ctx: LuaCtx,
+        deadline: Option<Instant>,
+    ) -> ToolCallResult {
+        let keys = self
+            .plugins
+            .get(plugin)
+            .ok_or_else(|| format!("plugin not loaded: {plugin}"))?;
+
+        let handler_key = keys
+            .get(tool)
+            .ok_or_else(|| format!("tool not found: {tool}"))?;
+
+        let handler: Function = self
+            .lua
+            .registry_value(handler_key)
+            .map_err(|e| e.to_string())?;
+
+        if self.shutdown.load(Ordering::Acquire) {
+            return Err("plugin host shutting down".into());
+        }
+
+        {
+            let mut guard = self.call_state.lock().unwrap_or_else(|e| e.into_inner());
+            *guard = Some(CallState {
+                cancel: ctx.cancel.clone(),
+                deadline,
+            });
+        }
+
+        let _clear_on_drop = CallStateGuard(&self.call_state);
+
+        let input_lua = self.lua.to_value(&input).map_err(|e| e.to_string())?;
+        let ctx_ud = self.lua.create_userdata(ctx).map_err(|e| e.to_string())?;
+
+        let result = handler.call::<LuaValue>((input_lua, ctx_ud));
+
+        match result {
+            Ok(val) => coerce_tool_result(&val),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+}
+
+pub(crate) struct LuaThread {
+    pub tx: flume::Sender<Request>,
+    pub join: Option<JoinHandle<()>>,
+    pub shutdown: Arc<AtomicBool>,
+}
+
+pub fn spawn(registry: Arc<ToolRegistry>) -> Result<LuaThread, PluginError> {
+    let (tx, rx) = flume::unbounded::<Request>();
+    let tx_clone = tx.clone();
+    let shutdown: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+    let shutdown_thread = Arc::clone(&shutdown);
+    let (init_tx, init_rx) = flume::bounded::<Result<(), PluginError>>(1);
+
+    let handle = thread::Builder::new()
+        .name("maki-lua".to_owned())
+        .spawn(move || {
+            let mut rt = match LuaRuntime::new(registry, tx_clone, shutdown_thread) {
+                Ok(r) => {
+                    let _ = init_tx.send(Ok(()));
+                    r
+                }
+                Err(e) => {
+                    let _ = init_tx.send(Err(e));
+                    return;
+                }
+            };
+
+            loop {
+                let msg = match rx.recv() {
+                    Ok(m) => m,
+                    Err(_) => break,
+                };
+                match msg {
+                    Request::Shutdown => break,
+                    Request::LoadSource {
+                        name,
+                        source,
+                        plugin_dir,
+                        reply,
+                    } => {
+                        let res = rt.load_source(Arc::clone(&name), &source, plugin_dir);
+                        let _ = reply.send(res);
+                    }
+                    Request::CallTool {
+                        plugin,
+                        tool,
+                        input,
+                        ctx,
+                        deadline,
+                        reply,
+                    } => {
+                        let res = rt.call_tool(&plugin, &tool, input, ctx, deadline);
+                        let _ = reply.send(res);
+                    }
+                    Request::ClearPlugin { plugin, reply } => {
+                        rt.clear_plugin(&plugin);
+                        let _ = reply.send(());
+                    }
+                }
+            }
+        })
+        .map_err(|e| PluginError::Io {
+            path: PathBuf::from("lua-thread"),
+            source: e,
+        })?;
+
+    init_rx.recv().map_err(|_| PluginError::Lua {
+        plugin: "<init>".to_owned(),
+        source: mlua::Error::runtime("lua thread exited before init completed"),
+    })??;
+
+    Ok(LuaThread {
+        tx,
+        join: Some(handle),
+        shutdown,
+    })
+}

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -1,0 +1,449 @@
+use std::sync::Arc;
+
+use maki_agent::tools::{ToolRegistry, ToolSource};
+use maki_config::LuaPluginsConfig;
+use maki_lua::{PluginError, PluginHost};
+
+fn enabled_config() -> LuaPluginsConfig {
+    LuaPluginsConfig {
+        enabled: true,
+        user_dirs: vec![],
+    }
+}
+
+fn fresh_registry() -> Arc<ToolRegistry> {
+    Arc::new(ToolRegistry::new())
+}
+
+fn exec_tool(reg: &ToolRegistry, name: &str, input: serde_json::Value) -> Result<String, String> {
+    let entry = reg
+        .get(name)
+        .unwrap_or_else(|| panic!("tool {name} not registered"));
+    let inv = entry.tool.parse(&input).expect("parse failed");
+    let ctx = maki_agent::tools::test_support::stub_ctx(&maki_agent::AgentMode::Build);
+    smol::block_on(async { inv.execute(&ctx).await }).map(|out| match out {
+        maki_agent::ToolOutput::Plain(s) => s,
+        other => panic!("unexpected output: {other:?}"),
+    })
+}
+
+const ECHO_PLUGIN: &str = r#"
+maki.api.register_tool({
+    name = "echo_",
+    description = "echo",
+    schema = {
+        type = "object",
+        properties = { msg = { type = "string" } },
+        required = { "msg" }
+    },
+    audiences = { "main" },
+    handler = function(input, ctx)
+        return input.msg
+    end
+})
+"#;
+
+const MINIMAL_SCHEMA: &str =
+    r#"{ type = "object", properties = {}, additionalProperties = false }"#;
+
+#[test]
+fn sandbox_strips_dangerous_globals() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(&enabled_config(), Arc::clone(&reg)).unwrap();
+
+    for global in &["os", "io", "debug", "package"] {
+        let source =
+            format!(r#"if {global} ~= nil then error("sandbox leak: {global} is not nil") end"#);
+        host.load_source(&format!("sandbox_check_{global}"), &source)
+            .unwrap_or_else(|e| panic!("sandbox check for {global} failed: {e}"));
+    }
+}
+
+#[test]
+fn register_echo_tool() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(&enabled_config(), Arc::clone(&reg)).unwrap();
+    host.load_source("echo_plugin", ECHO_PLUGIN).unwrap();
+
+    let entry = reg.get("echo_").expect("echo_ tool not registered");
+    assert_eq!(entry.tool.name(), "echo_");
+    assert!(
+        matches!(entry.source, ToolSource::Lua { ref plugin } if plugin.as_ref() == "echo_plugin"),
+    );
+
+    let out = exec_tool(&reg, "echo_", serde_json::json!({"msg": "hello"})).unwrap();
+    assert_eq!(out, "hello");
+}
+
+#[test]
+fn definitions_unchanged_when_disabled() {
+    let reg = fresh_registry();
+    let names_before = reg.names();
+
+    let config = LuaPluginsConfig {
+        enabled: false,
+        user_dirs: vec![],
+    };
+    let _host = PluginHost::new(&config, Arc::clone(&reg)).unwrap();
+
+    assert_eq!(reg.names(), names_before, "disabled host mutated registry");
+}
+
+#[test]
+fn unload_round_trip() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(&enabled_config(), Arc::clone(&reg)).unwrap();
+
+    host.load_source("unload_test", ECHO_PLUGIN).unwrap();
+    assert!(reg.has("echo_"));
+
+    host.unload("unload_test").unwrap();
+    assert!(!reg.has("echo_"));
+
+    host.load_source("unload_test", "").unwrap();
+    assert!(!reg.has("echo_"));
+}
+
+#[test]
+fn invalid_tool_name_rejected() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(&enabled_config(), Arc::clone(&reg)).unwrap();
+
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "bad name!",
+            description = "test",
+            schema = {MINIMAL_SCHEMA},
+            handler = function(input, ctx) return "" end
+        }})"#,
+    );
+    let err = host
+        .load_source("bad_name_plugin", &src)
+        .expect_err("expected error for invalid tool name");
+
+    assert!(matches!(err, PluginError::Lua { .. }));
+    assert!(err.to_string().contains("invalid name"));
+}
+
+#[test]
+fn empty_description_rejected() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(&enabled_config(), Arc::clone(&reg)).unwrap();
+
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "valid_name",
+            description = "",
+            schema = {MINIMAL_SCHEMA},
+            handler = function(input, ctx) return "" end
+        }})"#,
+    );
+    let err = host
+        .load_source("empty_desc_plugin", &src)
+        .expect_err("expected error for empty description");
+
+    assert!(matches!(err, PluginError::Lua { .. }));
+    assert!(err.to_string().contains("description must be non-empty"));
+}
+
+#[test]
+fn empty_audiences_rejected() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(&enabled_config(), Arc::clone(&reg)).unwrap();
+
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "no_aud",
+            description = "test",
+            schema = {MINIMAL_SCHEMA},
+            audiences = {{}},
+            handler = function() return "" end
+        }})"#,
+    );
+    let err = host
+        .load_source("empty_aud", &src)
+        .expect_err("expected error for empty audiences list");
+
+    assert!(matches!(err, PluginError::Lua { .. }));
+    assert!(err.to_string().contains("audiences"));
+}
+
+#[test]
+fn interrupt_kills_infinite_loop_and_vm_recovers() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(&enabled_config(), Arc::clone(&reg)).unwrap();
+
+    let src = format!(
+        r#"
+maki.api.register_tool({{
+    name = "infinite_loop_",
+    description = "loops forever",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function(input, ctx) while true do end end
+}})
+maki.api.register_tool({{
+    name = "noop_after_loop",
+    description = "returns ok",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function(input, ctx) return "ok" end
+}})
+"#,
+    );
+    host.load_source("loop_plugin", &src).unwrap();
+
+    let entry = reg.get("infinite_loop_").expect("loop tool not registered");
+    let inv = entry.tool.parse(&serde_json::json!({})).unwrap();
+    let mut ctx = maki_agent::tools::test_support::stub_ctx(&maki_agent::AgentMode::Build);
+    ctx.deadline = maki_agent::tools::Deadline::after(std::time::Duration::from_millis(500));
+
+    let start = std::time::Instant::now();
+    let result = smol::block_on(async { inv.execute(&ctx).await });
+    let elapsed = start.elapsed();
+
+    assert!(result.is_err(), "expected error from timed-out loop");
+    assert!(
+        elapsed < std::time::Duration::from_secs(5),
+        "loop took too long to interrupt: {elapsed:?}"
+    );
+
+    let ok = exec_tool(&reg, "noop_after_loop", serde_json::json!({}));
+    assert!(ok.is_ok(), "VM poisoned after interrupt: {ok:?}");
+}
+
+#[test]
+fn reload_same_plugin_replaces_tools() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(&enabled_config(), Arc::clone(&reg)).unwrap();
+
+    host.load_source("p1", ECHO_PLUGIN).unwrap();
+    assert!(reg.has("echo_"));
+
+    host.load_source("p1", ECHO_PLUGIN)
+        .expect("reload with same plugin name should succeed");
+    assert!(reg.has("echo_"));
+
+    host.load_source("p1", "").unwrap();
+    assert!(!reg.has("echo_"));
+}
+
+#[test]
+fn failed_load_leaves_no_tools() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(&enabled_config(), Arc::clone(&reg)).unwrap();
+
+    let src = format!(
+        r#"
+maki.api.register_tool({{
+    name = "doomed",
+    description = "never registered",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function() return "" end
+}})
+error("plugin blew up after register")
+"#,
+    );
+    let err = host
+        .load_source("broken", &src)
+        .expect_err("expected lua error");
+    assert!(matches!(err, PluginError::Lua { .. }));
+    assert!(!reg.has("doomed"));
+
+    host.load_source("broken", ECHO_PLUGIN)
+        .expect("retry with good source should succeed");
+    assert!(reg.has("echo_"));
+}
+
+#[test]
+fn is_error_propagated_as_error() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(&enabled_config(), Arc::clone(&reg)).unwrap();
+
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "returns_error",
+            description = "returns is_error=true",
+            schema = {MINIMAL_SCHEMA},
+            audiences = {{ "main" }},
+            handler = function(input, ctx)
+                return {{ output = "boom", is_error = true }}
+            end
+        }})"#,
+    );
+    host.load_source("err_plugin", &src).unwrap();
+
+    let err = exec_tool(&reg, "returns_error", serde_json::json!({})).unwrap_err();
+    assert_eq!(err, "boom");
+}
+
+const BAD_RETURN_NUMBER: &str = r#"
+maki.api.register_tool({
+    name = "bad_ret_num",
+    description = "returns a number",
+    schema = { type = "object", properties = {}, additionalProperties = false },
+    audiences = { "main" },
+    handler = function() return 42 end
+})
+"#;
+
+const BAD_RETURN_NIL: &str = r#"
+maki.api.register_tool({
+    name = "bad_ret_nil",
+    description = "returns nil",
+    schema = { type = "object", properties = {}, additionalProperties = false },
+    audiences = { "main" },
+    handler = function() return nil end
+})
+"#;
+
+#[test_case::test_case(BAD_RETURN_NUMBER, "bad_ret_num" ; "number_return")]
+#[test_case::test_case(BAD_RETURN_NIL,    "bad_ret_nil" ; "nil_return")]
+fn handler_bad_return_type_is_error(plugin_src: &str, tool_name: &str) {
+    let reg = fresh_registry();
+    let host = PluginHost::new(&enabled_config(), Arc::clone(&reg)).unwrap();
+    host.load_source("bad_ret", plugin_src).unwrap();
+
+    let err = exec_tool(&reg, tool_name, serde_json::json!({})).unwrap_err();
+    assert!(err.contains("must return string"), "got: {err}");
+}
+
+#[test]
+fn handler_lua_error_surfaces_as_tool_error() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(&enabled_config(), Arc::clone(&reg)).unwrap();
+
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "thrower",
+            description = "throws on call",
+            schema = {MINIMAL_SCHEMA},
+            audiences = {{ "main" }},
+            handler = function() error("intentional kaboom") end
+        }})"#,
+    );
+    host.load_source("thrower_plugin", &src).unwrap();
+
+    let err = exec_tool(&reg, "thrower", serde_json::json!({})).unwrap_err();
+    assert!(err.contains("intentional kaboom"), "got: {err}");
+}
+
+#[test]
+fn lua_tool_schema_rejects_bad_input() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(&enabled_config(), Arc::clone(&reg)).unwrap();
+
+    let src = r#"
+maki.api.register_tool({
+    name = "needs_name",
+    description = "requires a name field",
+    schema = {
+        type = "object",
+        properties = { name = { type = "string" } },
+        required = { "name" }
+    },
+    handler = function(input) return input.name end
+})
+"#;
+    host.load_source("schema_test", src).unwrap();
+
+    let entry = reg.get("needs_name").unwrap();
+    let err = entry
+        .tool
+        .parse(&serde_json::json!({"count": 1}))
+        .err()
+        .expect("missing required field should fail");
+    assert!(err.to_string().contains("name"));
+
+    assert!(
+        entry
+            .tool
+            .parse(&serde_json::json!({"name": "alice"}))
+            .is_ok()
+    );
+}
+
+#[test]
+fn load_dir_discovers_lua_files() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        tmp.path().join("greet.lua"),
+        r#"
+maki.api.register_tool({
+    name = "greet",
+    description = "says hi",
+    schema = { type = "object", properties = {}, additionalProperties = false },
+    handler = function() return "hi" end
+})
+"#,
+    )
+    .unwrap();
+    std::fs::write(tmp.path().join("readme.txt"), "not a plugin").unwrap();
+
+    let config = LuaPluginsConfig {
+        enabled: true,
+        user_dirs: vec![tmp.path().to_path_buf()],
+    };
+    let reg = fresh_registry();
+    let _host = PluginHost::new(&config, Arc::clone(&reg)).unwrap();
+
+    assert!(reg.has("greet"));
+    assert_eq!(reg.names().len(), 1);
+}
+
+#[test]
+fn multi_tool_plugin_registers_and_unloads_all() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(&enabled_config(), Arc::clone(&reg)).unwrap();
+
+    let src = format!(
+        r#"
+maki.api.register_tool({{
+    name = "multi_alpha",
+    description = "first tool",
+    schema = {MINIMAL_SCHEMA},
+    handler = function() return "alpha" end
+}})
+maki.api.register_tool({{
+    name = "multi_beta",
+    description = "second tool",
+    schema = {MINIMAL_SCHEMA},
+    handler = function() return "beta" end
+}})
+"#,
+    );
+    host.load_source("multi", &src).unwrap();
+
+    assert!(reg.has("multi_alpha"));
+    assert!(reg.has("multi_beta"));
+
+    host.unload("multi").unwrap();
+    assert!(!reg.has("multi_alpha"));
+    assert!(!reg.has("multi_beta"));
+}
+
+#[test]
+fn conflict_from_different_plugin_preserves_original() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(&enabled_config(), Arc::clone(&reg)).unwrap();
+
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "evolving",
+            description = "version 1",
+            schema = {MINIMAL_SCHEMA},
+            handler = function() return "v1" end
+        }})"#,
+    );
+    host.load_source("keeper", &src).unwrap();
+    assert!(reg.has("evolving"));
+
+    let err = host
+        .load_source("intruder", &src)
+        .expect_err("expected conflict");
+    assert!(matches!(err, PluginError::NameConflict { .. }));
+
+    let entry = reg.get("evolving").unwrap();
+    assert!(matches!(entry.source, ToolSource::Lua { ref plugin } if plugin.as_ref() == "keeper"),);
+}

--- a/maki-ui/src/app/shell.rs
+++ b/maki-ui/src/app/shell.rs
@@ -105,7 +105,7 @@ impl App {
             ShellEvent::Start { id, command } => {
                 self.main_chat().shell_tool_start(ToolStartEvent {
                     id,
-                    tool: "bash",
+                    tool: "bash".into(),
                     summary: command.clone(),
                     annotation: None,
                     input: Some(ToolInput::Code {
@@ -135,7 +135,7 @@ impl App {
                 };
                 self.main_chat().shell_tool_done(ToolDoneEvent {
                     id,
-                    tool: "bash",
+                    tool: "bash".into(),
                     output: ToolOutput::Plain(output),
                     is_error,
                 });

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -229,7 +229,7 @@ fn tool_done_sets_plan_written_flag(output: ToolOutput, expect_written: bool) {
 
     app.update(agent_msg(AgentEvent::ToolDone(Box::new(ToolDoneEvent {
         id: "t1".into(),
-        tool: "write",
+        tool: "write".into(),
         output,
         is_error: false,
     }))));
@@ -612,7 +612,7 @@ fn cancel_resets_all_chats_and_indices() {
     app.update(subagent_msg(
         AgentEvent::ToolStart(Box::new(ToolStartEvent {
             id: "sub_t1".into(),
-            tool: "bash",
+            tool: "bash".into(),
             summary: "running".into(),
             annotation: None,
             input: None,
@@ -631,7 +631,7 @@ fn cancel_resets_all_chats_and_indices() {
 fn finish_subagent(app: &mut App, id: &str, is_error: bool) {
     app.update(agent_msg(AgentEvent::ToolDone(Box::new(ToolDoneEvent {
         id: id.into(),
-        tool: "task",
+        tool: "task".into(),
         output: ToolOutput::Plain("result".into()),
         is_error,
     }))));
@@ -974,7 +974,7 @@ fn double_esc_cancels_flushes_and_fails_tools() {
     }));
     app.update(agent_msg(AgentEvent::ToolStart(Box::new(ToolStartEvent {
         id: "t1".into(),
-        tool: "bash",
+        tool: "bash".into(),
         summary: "running".into(),
         annotation: None,
         input: None,
@@ -1288,7 +1288,7 @@ fn resolve_or_create_chat_sets_model_id_and_annotation() {
     app.run_id = 1;
     app.update(agent_msg(AgentEvent::ToolStart(Box::new(ToolStartEvent {
         id: "task1".into(),
-        tool: "task",
+        tool: "task".into(),
         summary: "research".into(),
         annotation: None,
         input: None,
@@ -2031,7 +2031,7 @@ fn agent_error_creates_synthetic_tool_done_with_message() {
 
     app.update(agent_msg(AgentEvent::ToolStart(Box::new(ToolStartEvent {
         id: "t1".into(),
-        tool: "bash",
+        tool: "bash".into(),
         summary: "echo hello".into(),
         annotation: None,
         input: None,

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -355,7 +355,7 @@ pub fn history_to_display(
                                 role: DisplayRole::Tool(Box::new(ToolRole {
                                     id: id.clone(),
                                     status,
-                                    name: static_name,
+                                    name: static_name.into(),
                                 })),
                                 text,
                                 tool_input: tool_input.map(Arc::new),
@@ -484,10 +484,10 @@ mod tests {
     use maki_config::UiConfig;
     use test_case::test_case;
 
-    fn tool_start(id: &str, tool: &'static str) -> AgentEvent {
+    fn tool_start(id: &str, tool: &str) -> AgentEvent {
         AgentEvent::ToolStart(Box::new(ToolStartEvent {
             id: id.into(),
-            tool,
+            tool: tool.into(),
             summary: String::new(),
             annotation: None,
             input: None,
@@ -495,10 +495,10 @@ mod tests {
         }))
     }
 
-    fn tool_done(id: &str, tool: &'static str, output: ToolOutput) -> AgentEvent {
+    fn tool_done(id: &str, tool: &str, output: ToolOutput) -> AgentEvent {
         AgentEvent::ToolDone(Box::new(ToolDoneEvent {
             id: id.into(),
-            tool,
+            tool: tool.into(),
             output,
             is_error: false,
         }))

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -124,7 +124,7 @@ impl MessagesPanel {
         let role = DisplayRole::Tool(Box::new(ToolRole {
             id,
             status: ToolStatus::InProgress,
-            name,
+            name: Arc::from(name),
         }));
         let mut msg = DisplayMessage::new(role, String::new());
         msg.timestamp = Some(format_timestamp_now());
@@ -134,7 +134,7 @@ impl MessagesPanel {
     pub fn tool_start(&mut self, event: ToolStartEvent) {
         if let Some(msg) = self.find_tool_msg_mut(&event.id) {
             if let DisplayRole::Tool(t) = &mut msg.role {
-                t.name = event.tool;
+                t.name = Arc::clone(&event.tool);
             }
             msg.text = event.summary;
             msg.tool_input = event.input.map(Arc::new);
@@ -148,7 +148,7 @@ impl MessagesPanel {
             DisplayRole::Tool(Box::new(ToolRole {
                 id: event.id,
                 status: ToolStatus::InProgress,
-                name: event.tool,
+                name: Arc::clone(&event.tool),
             })),
             event.summary,
         );
@@ -195,16 +195,16 @@ impl MessagesPanel {
         }
         truncate_to_header(&mut msg.text);
         let done_annotation =
-            tool_output_annotation(&event.output, ToolKind::from_name(event.tool));
+            tool_output_annotation(&event.output, ToolKind::from_name(&event.tool));
         if let Some(suffix) = &done_annotation {
             append_annotation(&mut msg.annotation, suffix);
         }
 
         match &event.output {
             ToolOutput::Plain(text) | ToolOutput::ReadDir { text, .. } => {
-                if !matches!(event.tool, WEBFETCH_TOOL_NAME) {
+                if event.tool.as_ref() != WEBFETCH_TOOL_NAME {
                     let limits =
-                        ToolKind::from_name(event.tool).output_limits(&self.tool_output_lines);
+                        ToolKind::from_name(&event.tool).output_limits(&self.tool_output_lines);
                     let tr = truncate_output(text, limits.max_lines, limits.keep);
                     msg.truncated_lines = tr.skipped;
                     if !tr.kept.is_empty() {
@@ -222,7 +222,7 @@ impl MessagesPanel {
                 } else {
                     let display = output.as_display_text();
                     let limits =
-                        ToolKind::from_name(event.tool).output_limits(&self.tool_output_lines);
+                        ToolKind::from_name(&event.tool).output_limits(&self.tool_output_lines);
                     let tr = truncate_output(&display, limits.max_lines, limits.keep);
                     msg.truncated_lines = tr.skipped;
                     msg.text = format!("{}\n{}", msg.text, tr.kept);
@@ -392,14 +392,14 @@ impl MessagesPanel {
     }
 
     pub fn fail_in_progress_with_message(&mut self, message: String) {
-        let ids: Vec<(String, &'static str)> = self
+        let ids: Vec<(String, Arc<str>)> = self
             .messages
             .iter()
             .filter_map(|m| {
                 if let DisplayRole::Tool(t) = &m.role
                     && t.status == ToolStatus::InProgress
                 {
-                    Some((t.id.clone(), t.name))
+                    Some((t.id.clone(), Arc::clone(&t.name)))
                 } else {
                     None
                 }

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -11,10 +11,10 @@ use maki_agent::{
 use ratatui::backend::TestBackend;
 use test_case::test_case;
 
-fn start(id: &str, tool: &'static str) -> ToolStartEvent {
+fn start(id: &str, tool: &str) -> ToolStartEvent {
     ToolStartEvent {
         id: id.into(),
-        tool,
+        tool: tool.into(),
         summary: id.into(),
         annotation: None,
         input: None,
@@ -37,7 +37,7 @@ fn tool_done_updates_start_status(is_error: bool, expected: ToolStatus) {
     panel.tool_start(start("t1", "bash"));
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
-        tool: "bash",
+        tool: "bash".into(),
         output: ToolOutput::Plain("output".into()),
         is_error,
     });
@@ -64,7 +64,7 @@ fn tool_done_sets_annotation(tool: &'static str, output: ToolOutput, expected: O
     panel.tool_start(start("t1", tool));
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
-        tool,
+        tool: tool.into(),
         output,
         is_error: false,
     });
@@ -80,7 +80,7 @@ fn tool_done_annotation_merge(output: &str, expected: Option<&str>) {
     panel.tool_start(event);
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
-        tool: BASH_TOOL_NAME,
+        tool: BASH_TOOL_NAME.into(),
         output: ToolOutput::Plain(output.into()),
         is_error: false,
     });
@@ -113,7 +113,7 @@ fn tool_done_glob_result(output: ToolOutput, has_file_count: bool, has_no_files_
     panel.tool_start(start("t1", GLOB_TOOL_NAME));
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
-        tool: GLOB_TOOL_NAME,
+        tool: GLOB_TOOL_NAME.into(),
         output,
         is_error: false,
     });
@@ -131,7 +131,7 @@ fn tool_done_grep_shows_matches() {
     panel.tool_start(start("t1", GREP_TOOL_NAME));
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
-        tool: GREP_TOOL_NAME,
+        tool: GREP_TOOL_NAME.into(),
         output: grep_output(2),
         is_error: false,
     });
@@ -231,7 +231,7 @@ fn unknown_tool_id_is_noop() {
     panel.tool_output("ghost", "data");
     panel.tool_done(ToolDoneEvent {
         id: "orphan".into(),
-        tool: "bash",
+        tool: "bash".into(),
         output: ToolOutput::Plain("output".into()),
         is_error: false,
     });
@@ -245,7 +245,7 @@ fn in_progress_tracking() {
 
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
-        tool: "bash",
+        tool: "bash".into(),
         output: ToolOutput::Plain("ok".into()),
         is_error: false,
     });
@@ -253,7 +253,7 @@ fn in_progress_tracking() {
 
     panel.tool_done(ToolDoneEvent {
         id: "t2".into(),
-        tool: "read",
+        tool: "read".into(),
         output: ToolOutput::Plain("ok".into()),
         is_error: false,
     });
@@ -318,7 +318,7 @@ fn events_before_cache_built_render_correctly() {
     panel.tool_output("t1", "early output");
     panel.tool_done(ToolDoneEvent {
         id: "t2".into(),
-        tool: "bash",
+        tool: "bash".into(),
         output: ToolOutput::Plain("result".into()),
         is_error: false,
     });
@@ -331,7 +331,7 @@ fn events_before_cache_built_render_correctly() {
 fn bash_code_start(panel: &mut MessagesPanel, id: &str, code: &str) {
     panel.tool_start(ToolStartEvent {
         id: id.into(),
-        tool: BASH_TOOL_NAME,
+        tool: BASH_TOOL_NAME.into(),
         summary: code.into(),
         annotation: None,
         input: Some(ToolInput::Code {
@@ -353,7 +353,7 @@ fn bash_live_output_with_code_input() {
 
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
-        tool: BASH_TOOL_NAME,
+        tool: BASH_TOOL_NAME.into(),
         output: ToolOutput::Plain("done".into()),
         is_error: false,
     });
@@ -368,7 +368,7 @@ fn cancel_in_progress_marks_pending_as_error(cache_built: bool) {
     let mut panel = panel_with_tools(&[("t1", "bash"), ("t2", "read")]);
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
-        tool: "bash",
+        tool: "bash".into(),
         output: ToolOutput::Plain("ok".into()),
         is_error: false,
     });
@@ -405,7 +405,7 @@ fn tool_done_after_cancel_in_progress_does_not_underflow() {
 
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
-        tool: "bash",
+        tool: "bash".into(),
         output: ToolOutput::Plain("late".into()),
         is_error: false,
     });
@@ -413,12 +413,12 @@ fn tool_done_after_cancel_in_progress_does_not_underflow() {
     assert_eq!(msg_status(&panel, "t1"), ToolStatus::Success);
 }
 
-fn tool_msg(id: &str, name: &'static str, status: ToolStatus) -> DisplayMessage {
+fn tool_msg(id: &str, name: &str, status: ToolStatus) -> DisplayMessage {
     DisplayMessage::new(
         DisplayRole::Tool(Box::new(ToolRole {
             id: id.into(),
             status,
-            name,
+            name: name.into(),
         })),
         id.into(),
     )
@@ -447,7 +447,7 @@ fn question_tool_renders_summary() {
     panel.tool_start(start("q1", QUESTION_TOOL_NAME));
     panel.tool_done(ToolDoneEvent {
         id: "q1".into(),
-        tool: QUESTION_TOOL_NAME,
+        tool: QUESTION_TOOL_NAME.into(),
         output: ToolOutput::QuestionAnswers(vec![
             QuestionAnswer {
                 question: "Q1".into(),
@@ -500,7 +500,7 @@ fn search_text_grep_result_includes_structured_output() {
     panel.tool_start(start("t1", "grep"));
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
-        tool: "grep",
+        tool: "grep".into(),
         output: grep_output(2),
         is_error: false,
     });
@@ -515,7 +515,7 @@ fn search_text_diff_output_includes_hunks() {
     panel.tool_start(start("t1", "edit"));
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
-        tool: "edit",
+        tool: "edit".into(),
         output: ToolOutput::Diff {
             path: "src/main.rs".into(),
             before: "old\n".into(),
@@ -535,7 +535,7 @@ fn search_text_bash_with_code_input() {
     bash_code_start(&mut panel, "t1", "echo hello");
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
-        tool: BASH_TOOL_NAME,
+        tool: BASH_TOOL_NAME.into(),
         output: ToolOutput::Plain("hello".into()),
         is_error: false,
     });
@@ -601,7 +601,7 @@ fn batch_entry(tool: &str, summary: &str, status: BatchToolStatus) -> BatchToolE
 fn batch_start(panel: &mut MessagesPanel, entries: Vec<BatchToolEntry>) {
     panel.tool_start(ToolStartEvent {
         id: "b1".into(),
-        tool: "batch",
+        tool: "batch".into(),
         summary: format!("{} tools", entries.len()),
         annotation: None,
         input: None,
@@ -615,7 +615,7 @@ fn batch_start(panel: &mut MessagesPanel, entries: Vec<BatchToolEntry>) {
 fn batch_done(panel: &mut MessagesPanel, entries: Vec<BatchToolEntry>) {
     panel.tool_done(ToolDoneEvent {
         id: "b1".into(),
-        tool: "batch",
+        tool: "batch".into(),
         output: ToolOutput::Batch {
             entries,
             text: String::new(),
@@ -877,7 +877,7 @@ fn panel_with_long_tool(line_count: usize) -> MessagesPanel {
     let mut panel = MessagesPanel::new(UiConfig::default());
     panel.tool_start(ToolStartEvent {
         id: "t1".into(),
-        tool: BASH_TOOL_NAME,
+        tool: BASH_TOOL_NAME.into(),
         summary: "cmd".into(),
         annotation: None,
         input: None,
@@ -885,7 +885,7 @@ fn panel_with_long_tool(line_count: usize) -> MessagesPanel {
     });
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
-        tool: BASH_TOOL_NAME,
+        tool: BASH_TOOL_NAME.into(),
         output: ToolOutput::Plain(body),
         is_error: false,
     });
@@ -938,7 +938,7 @@ fn panel_with_grep_tool(match_count: usize) -> MessagesPanel {
     let mut panel = MessagesPanel::new(UiConfig::default());
     panel.tool_start(ToolStartEvent {
         id: "t1".into(),
-        tool: GREP_TOOL_NAME,
+        tool: GREP_TOOL_NAME.into(),
         summary: "grep pattern".into(),
         annotation: None,
         input: None,
@@ -946,7 +946,7 @@ fn panel_with_grep_tool(match_count: usize) -> MessagesPanel {
     });
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
-        tool: GREP_TOOL_NAME,
+        tool: GREP_TOOL_NAME.into(),
         output: ToolOutput::GrepResult { entries },
         is_error: false,
     });
@@ -1030,7 +1030,7 @@ fn search_text_includes_truncated_bash_output() {
     bash_code_start(&mut panel, "t1", "echo lines");
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
-        tool: BASH_TOOL_NAME,
+        tool: BASH_TOOL_NAME.into(),
         output: ToolOutput::Plain(full_output.clone()),
         is_error: false,
     });
@@ -1066,7 +1066,7 @@ fn instruction_segment_has_spacer_before_it() {
     panel.tool_start(start("t1", "read"));
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
-        tool: "read",
+        tool: "read".into(),
         output: read_code_with_instructions(instruction_blocks()),
         is_error: false,
     });
@@ -1111,7 +1111,7 @@ fn toggle_instruction_segment_expands_and_collapses() {
     panel.tool_start(start("t1", "read"));
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
-        tool: "read",
+        tool: "read".into(),
         output: read_code_with_instructions(blocks),
         is_error: false,
     });

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -311,7 +311,7 @@ impl DisplayMessage {
 pub struct ToolRole {
     pub id: String,
     pub status: ToolStatus,
-    pub name: &'static str,
+    pub name: Arc<str>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -325,9 +325,9 @@ pub enum DisplayRole {
 }
 
 impl DisplayRole {
-    pub fn tool_name(&self) -> Option<&'static str> {
+    pub fn tool_name(&self) -> Option<&str> {
         match self {
-            DisplayRole::Tool(t) => Some(t.name),
+            DisplayRole::Tool(t) => Some(&t.name),
             _ => None,
         }
     }

--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -925,7 +925,7 @@ mod tests {
             role: DisplayRole::Tool(Box::new(ToolRole {
                 id: "t1".into(),
                 status,
-                name: BASH_TOOL_NAME,
+                name: BASH_TOOL_NAME.into(),
             })),
             text: text.into(),
             tool_input: input.map(Arc::new),
@@ -1277,7 +1277,7 @@ mod tests {
             role: DisplayRole::Tool(Box::new(ToolRole {
                 id: "t1".into(),
                 status: ToolStatus::Success,
-                name: TASK_TOOL_NAME,
+                name: TASK_TOOL_NAME.into(),
             })),
             text: "Find auth".into(),
             tool_input: None,
@@ -1391,7 +1391,7 @@ mod tests {
             role: DisplayRole::Tool(Box::new(ToolRole {
                 id: "t1".into(),
                 status: ToolStatus::Success,
-                name: INDEX_TOOL_NAME,
+                name: INDEX_TOOL_NAME.into(),
             })),
             text: format!("src/lib.rs\n{body}"),
             tool_input: None,
@@ -1529,7 +1529,7 @@ mod tests {
             role: DisplayRole::Tool(Box::new(ToolRole {
                 id: "t1".into(),
                 status,
-                name: BASH_TOOL_NAME,
+                name: BASH_TOOL_NAME.into(),
             })),
             text,
             tool_input: None,
@@ -1646,7 +1646,7 @@ mod tests {
             role: DisplayRole::Tool(Box::new(ToolRole {
                 id: "t1".into(),
                 status: ToolStatus::Success,
-                name: READ_TOOL_NAME,
+                name: READ_TOOL_NAME.into(),
             })),
             text: "read /src/main.rs".into(),
             tool_input: None,

--- a/maki-ui/src/mock.rs
+++ b/maki-ui/src/mock.rs
@@ -57,20 +57,20 @@ fn sub_evt_with(
     }))
 }
 
-fn tool_start(id: &str, tool: &'static str, summary: &str, input: Option<ToolInput>) -> AgentEvent {
+fn tool_start(id: &str, tool: &str, summary: &str, input: Option<ToolInput>) -> AgentEvent {
     tool_start_with(id, tool, summary, input, None)
 }
 
 fn tool_start_with(
     id: &str,
-    tool: &'static str,
+    tool: &str,
     summary: &str,
     input: Option<ToolInput>,
     annotation: Option<&str>,
 ) -> AgentEvent {
     AgentEvent::ToolStart(Box::new(ToolStartEvent {
         id: id.into(),
-        tool,
+        tool: tool.into(),
         summary: summary.into(),
         annotation: annotation.map(Into::into),
         input,
@@ -78,10 +78,10 @@ fn tool_start_with(
     }))
 }
 
-fn tool_done(id: &str, tool: &'static str, output: ToolOutput, is_error: bool) -> AgentEvent {
+fn tool_done(id: &str, tool: &str, output: ToolOutput, is_error: bool) -> AgentEvent {
     AgentEvent::ToolDone(Box::new(ToolDoneEvent {
         id: id.into(),
-        tool,
+        tool: tool.into(),
         output,
         is_error,
     }))

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,9 @@ use color_eyre::eyre::{Context, bail};
 use maki_agent::command::{self, CustomCommand};
 use maki_agent::mcp::{config as mcp_config, oauth as mcp_oauth};
 use maki_agent::skill::{self, Skill};
+use maki_agent::tools::ToolRegistry;
 use maki_config::load_config;
+use maki_lua::PluginHost;
 use maki_storage::DataDir;
 use maki_ui::AppSession;
 use tracing_subscriber::EnvFilter;
@@ -336,6 +338,9 @@ fn run() -> Result<()> {
             install_panic_log_hook();
             let skills = discover(cli.no_skills);
             let commands = discover_cmds(cli.no_commands);
+            let _plugin_host =
+                PluginHost::new(&config.lua_plugins, Arc::clone(ToolRegistry::native_arc()))
+                    .context("initialize lua plugin host")?;
             if cli.print {
                 print::run(
                     &model,


### PR DESCRIPTION
New maki-lua crate.

Add a .lua file in ~/.config/maki/plugins/ and it can register tools the agent calls.

Once Luau VM on a dedicated thread, talked to over flume. Sandbox strips os/io/debug/package, the maki global is frozen per plugin so plugins can't contaminate each other. Tools land in the same ToolRegistry as native and MCP, so permissions and plan mode work for free.

Off by default under [lua_plugins].

https://luau.org/