### PR TITLE
Extend Mistral support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,6 +2372,7 @@ dependencies = [
  "futures-lite",
  "isahc",
  "maki-storage",
+ "open",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/maki-providers/Cargo.toml
+++ b/maki-providers/Cargo.toml
@@ -18,6 +18,7 @@ isahc = { workspace = true }
 base64 = { workspace = true }
 wait-timeout = { workspace = true }
 fastrand = { workspace = true }
+open = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -14,6 +14,7 @@ pub use model::{
 pub use providers::Timeouts;
 pub use providers::copilot::auth as copilot_auth;
 pub use providers::dynamic;
+pub use providers::mistral::auth as mistral_auth;
 pub use providers::openai::auth as openai_auth;
 pub use types::{
     ContentBlock, ImageMediaType, ImageSource, Message, ProviderEvent, Role, StopReason,

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -115,6 +115,7 @@ pub fn models_for_provider(provider: ProviderKind) -> &'static [ModelEntry] {
         ProviderKind::Copilot => copilot::models(),
         ProviderKind::Ollama => ollama::models(),
         ProviderKind::Mistral => mistral::models(),
+        ProviderKind::MistralCoding => mistral::models_coding(),
         ProviderKind::Google => google::models(),
         ProviderKind::Zai | ProviderKind::ZaiCodingPlan => zai::models(),
         ProviderKind::Synthetic => synthetic::models(),

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -12,7 +12,7 @@ use crate::providers::anthropic::Anthropic;
 use crate::providers::copilot::Copilot;
 use crate::providers::dynamic;
 use crate::providers::google::Google;
-use crate::providers::mistral::Mistral;
+use crate::providers::mistral::{Mistral, MistralPlan};
 use crate::providers::ollama::Ollama;
 use crate::providers::openai::OpenAi;
 use crate::providers::synthetic::Synthetic;
@@ -29,6 +29,7 @@ pub enum ProviderKind {
     Copilot,
     Ollama,
     Mistral,
+    MistralCoding,
     Zai,
     ZaiCodingPlan,
     Synthetic,
@@ -43,6 +44,7 @@ impl ProviderKind {
             Self::Copilot => "Copilot",
             Self::Ollama => "Ollama",
             Self::Mistral => "Mistral",
+            Self::MistralCoding => "Mistral Coding",
             Self::Zai => "Z.AI",
             Self::ZaiCodingPlan => "Z.AI Coding",
             Self::Synthetic => "Synthetic",
@@ -56,7 +58,7 @@ impl ProviderKind {
             Self::Google => "GEMINI_API_KEY",
             Self::Copilot => "GH_COPILOT_TOKEN",
             Self::Ollama => "OLLAMA_API_KEY",
-            Self::Mistral => "MISTRAL_API_KEY",
+            Self::Mistral | Self::MistralCoding => "MISTRAL_API_KEY",
             Self::Zai | Self::ZaiCodingPlan => "ZHIPU_API_KEY",
             Self::Synthetic => "SYNTHETIC_API_KEY",
         }
@@ -71,7 +73,7 @@ impl ProviderKind {
                 "https://api.githubcopilot.com (or GraphQL-discovered Copilot API endpoint)"
             }
             Self::Ollama => "http://localhost:11434/v1",
-            Self::Mistral => "https://api.mistral.ai/v1",
+            Self::Mistral | Self::MistralCoding => "https://api.mistral.ai/v1",
             Self::Zai => "https://api.z.ai/api/paas/v4",
             Self::ZaiCodingPlan => "https://api.z.ai/api/coding/paas/v4",
             Self::Synthetic => "https://api.synthetic.new/openai/v1",
@@ -81,7 +83,7 @@ impl ProviderKind {
     pub const fn supports_thinking(self) -> bool {
         matches!(
             self,
-            Self::Anthropic | Self::Google | Self::Mistral | Self::Synthetic
+            Self::Anthropic | Self::Google | Self::Mistral | Self::MistralCoding | Self::Synthetic
         )
     }
 
@@ -109,7 +111,7 @@ impl ProviderKind {
             Self::Google => ModelFamily::Gemini,
             Self::Copilot => ModelFamily::Generic,
             Self::Ollama => ModelFamily::Generic,
-            Self::Mistral => ModelFamily::Generic,
+            Self::Mistral | Self::MistralCoding => ModelFamily::Generic,
             Self::Zai | Self::ZaiCodingPlan => ModelFamily::Glm,
             Self::Synthetic => ModelFamily::Synthetic,
         }
@@ -126,7 +128,7 @@ impl ProviderKind {
             Self::Google => 65_536,
             Self::Copilot => 100_000,
             Self::Ollama => 16_384,
-            Self::Mistral => 32_000,
+            Self::Mistral | Self::MistralCoding => 32_000,
             Self::Zai | Self::ZaiCodingPlan => 16_000,
             Self::Synthetic => 32_000,
         }
@@ -139,7 +141,7 @@ impl ProviderKind {
             Self::Google => 1_000_000,
             Self::Copilot => 200_000,
             Self::Ollama => 128_000,
-            Self::Mistral => 128_000,
+            Self::Mistral | Self::MistralCoding => 128_000,
             Self::Zai | Self::ZaiCodingPlan => 128_000,
             Self::Synthetic => 128_000,
         }
@@ -152,7 +154,8 @@ impl ProviderKind {
             Self::Google => Ok(Box::new(Google::new(timeouts)?)),
             Self::Copilot => Ok(Box::new(Copilot::new(timeouts)?)),
             Self::Ollama => Ok(Box::new(Ollama::new(timeouts)?)),
-            Self::Mistral => Ok(Box::new(Mistral::new(timeouts)?)),
+            Self::Mistral => Ok(Box::new(Mistral::new(MistralPlan::Standard, timeouts)?)),
+            Self::MistralCoding => Ok(Box::new(Mistral::new(MistralPlan::Coding, timeouts)?)),
             Self::Zai => Ok(Box::new(Zai::new(ZaiPlan::Standard, timeouts)?)),
             Self::ZaiCodingPlan => Ok(Box::new(Zai::new(ZaiPlan::Coding, timeouts)?)),
             Self::Synthetic => Ok(Box::new(Synthetic::new(timeouts)?)),

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -363,6 +363,10 @@ pub fn create(slug: &str, timeouts: super::Timeouts) -> Result<Box<dyn Provider>
             Mistral::with_auth(auth.clone(), timeouts)
                 .with_system_prefix(meta.system_prefix.clone()),
         ),
+        ProviderKind::MistralCoding => Box::new(
+            Mistral::with_auth(auth.clone(), timeouts)
+                .with_system_prefix(meta.system_prefix.clone()),
+        ),
         ProviderKind::Zai => Box::new(
             Zai::with_auth(ZaiPlan::Standard, auth.clone(), timeouts)
                 .with_system_prefix(meta.system_prefix.clone()),

--- a/maki-providers/src/providers/mistral/auth.rs
+++ b/maki-providers/src/providers/mistral/auth.rs
@@ -1,0 +1,13 @@
+use crate::AgentError;
+use crate::providers::prompt_api_key;
+
+const API_KEYS_URL: &str = "https://console.mistral.ai/codestral/cli?profile_dialog=api-keys";
+const CODING_PLAN_URL: &str = "https://console.mistral.ai/codestral/cli";
+
+pub fn login() -> Result<String, AgentError> {
+    prompt_api_key(API_KEYS_URL, "MISTRAL_API_KEY")
+}
+
+pub fn login_coding() -> Result<String, AgentError> {
+    prompt_api_key(CODING_PLAN_URL, "MISTRAL_API_KEY")
+}

--- a/maki-providers/src/providers/mistral/mod.rs
+++ b/maki-providers/src/providers/mistral/mod.rs
@@ -10,6 +10,14 @@ use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
 use super::ResolvedAuth;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 
+pub mod auth;
+
+#[derive(Debug, Clone, Copy)]
+pub enum MistralPlan {
+    Standard,
+    Coding,
+}
+
 static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     api_key_env: "MISTRAL_API_KEY",
     base_url: "https://api.mistral.ai/v1",
@@ -18,22 +26,29 @@ static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     provider_name: "Mistral",
 };
 
+const DEVSTRAL_STRONG: ModelEntry = ModelEntry {
+    prefixes: &[
+        "devstral-2",
+        "devstral-latest",
+        "devstral-medium-latest",
+        "devstral-2512",
+    ],
+    tier: ModelTier::Strong,
+    family: ModelFamily::Generic,
+    default: true,
+    pricing: ModelPricing {
+        input: 0.4,
+        output: 2.0,
+        cache_write: 0.0,
+        cache_read: 0.0,
+    },
+    max_output_tokens: 262_144,
+    context_window: 262_144,
+};
+
 pub(crate) fn models() -> &'static [ModelEntry] {
     &[
-        ModelEntry {
-            prefixes: &["devstral-latest", "devstral-medium-latest", "devstral-2512"],
-            tier: ModelTier::Strong,
-            family: ModelFamily::Generic,
-            default: true,
-            pricing: ModelPricing {
-                input: 0.4,
-                output: 2.0,
-                cache_write: 0.00,
-                cache_read: 0.00,
-            },
-            max_output_tokens: 262_144,
-            context_window: 262_144,
-        },
+        DEVSTRAL_STRONG,
         ModelEntry {
             prefixes: &["mistral-large-latest", "mistral-large-2512"],
             tier: ModelTier::Medium,
@@ -42,8 +57,8 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             pricing: ModelPricing {
                 input: 0.5,
                 output: 1.5,
-                cache_write: 0.00,
-                cache_read: 0.00,
+                cache_write: 0.0,
+                cache_read: 0.0,
             },
             max_output_tokens: 262_144,
             context_window: 262_144,
@@ -56,8 +71,68 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             pricing: ModelPricing {
                 input: 0.15,
                 output: 0.60,
-                cache_write: 0.00,
-                cache_read: 0.00,
+                cache_write: 0.0,
+                cache_read: 0.0,
+            },
+            max_output_tokens: 262_144,
+            context_window: 262_144,
+        },
+    ]
+}
+
+pub(crate) fn models_coding() -> &'static [ModelEntry] {
+    &[
+        ModelEntry {
+            prefixes: &[
+                "mistral-vibe-cli-latest",
+                "devstral-2",
+                "devstral-latest",
+                "devstral-2512",
+            ],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Generic,
+            default: true,
+            pricing: ModelPricing {
+                input: 0.4,
+                output: 2.0,
+                cache_write: 0.0,
+                cache_read: 0.0,
+            },
+            max_output_tokens: 262_144,
+            context_window: 262_144,
+        },
+        ModelEntry {
+            prefixes: &[
+                "mistral-vibe-cli-with-tools",
+                "mistral-medium-latest",
+                "mistral-medium-2508",
+            ],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            default: true,
+            pricing: ModelPricing {
+                input: 0.4,
+                output: 2.0,
+                cache_write: 0.0,
+                cache_read: 0.0,
+            },
+            max_output_tokens: 131_072,
+            context_window: 131_072,
+        },
+        ModelEntry {
+            prefixes: &[
+                "mistral-vibe-cli-fast",
+                "mistral-small-latest",
+                "mistral-small-2603",
+            ],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Generic,
+            default: true,
+            pricing: ModelPricing {
+                input: 0.15,
+                output: 0.60,
+                cache_write: 0.0,
+                cache_read: 0.0,
             },
             max_output_tokens: 262_144,
             context_window: 262_144,
@@ -72,7 +147,7 @@ pub struct Mistral {
 }
 
 impl Mistral {
-    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
+    pub fn new(_plan: MistralPlan, timeouts: super::Timeouts) -> Result<Self, AgentError> {
         let api_key = std::env::var(CONFIG.api_key_env).map_err(|_| AgentError::Config {
             message: format!("{} not set", CONFIG.api_key_env),
         })?;

--- a/maki-providers/src/providers/mistral/mod.rs
+++ b/maki-providers/src/providers/mistral/mod.rs
@@ -26,14 +26,39 @@ static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     provider_name: "Mistral",
 };
 
-const DEVSTRAL_STRONG: ModelEntry = ModelEntry {
-    prefixes: &[
-        "devstral-2",
-        "devstral-latest",
-        "devstral-medium-latest",
-        "devstral-2512",
-    ],
+const MISTRAL_MEDIUM_3_5: ModelEntry = ModelEntry {
+    prefixes: &["mistral-vibe-cli-latest", "mistral-medium-3.5"],
     tier: ModelTier::Strong,
+    family: ModelFamily::Generic,
+    default: true,
+    pricing: ModelPricing {
+        input: 1.5,
+        output: 7.5,
+        cache_write: 0.0,
+        cache_read: 0.0,
+    },
+    max_output_tokens: 262_144,
+    context_window: 262_144,
+};
+
+const DEVSTRAL_SMALL: ModelEntry = ModelEntry {
+    prefixes: &["devstral-small-latest", "devstral-small"],
+    tier: ModelTier::Weak,
+    family: ModelFamily::Generic,
+    default: true,
+    pricing: ModelPricing {
+        input: 0.1,
+        output: 0.3,
+        cache_write: 0.0,
+        cache_read: 0.0,
+    },
+    max_output_tokens: 262_144,
+    context_window: 262_144,
+};
+
+const MISTRAL_MEDIUM: ModelEntry = ModelEntry {
+    prefixes: &["mistral-medium-latest", "mistral-medium-2508"],
+    tier: ModelTier::Medium,
     family: ModelFamily::Generic,
     default: true,
     pricing: ModelPricing {
@@ -42,102 +67,16 @@ const DEVSTRAL_STRONG: ModelEntry = ModelEntry {
         cache_write: 0.0,
         cache_read: 0.0,
     },
-    max_output_tokens: 262_144,
-    context_window: 262_144,
+    max_output_tokens: 131_072,
+    context_window: 131_072,
 };
 
 pub(crate) fn models() -> &'static [ModelEntry] {
-    &[
-        DEVSTRAL_STRONG,
-        ModelEntry {
-            prefixes: &["mistral-large-latest", "mistral-large-2512"],
-            tier: ModelTier::Medium,
-            family: ModelFamily::Generic,
-            default: true,
-            pricing: ModelPricing {
-                input: 0.5,
-                output: 1.5,
-                cache_write: 0.0,
-                cache_read: 0.0,
-            },
-            max_output_tokens: 262_144,
-            context_window: 262_144,
-        },
-        ModelEntry {
-            prefixes: &["mistral-small-latest", "mistral-small-2603"],
-            tier: ModelTier::Weak,
-            family: ModelFamily::Generic,
-            default: true,
-            pricing: ModelPricing {
-                input: 0.15,
-                output: 0.60,
-                cache_write: 0.0,
-                cache_read: 0.0,
-            },
-            max_output_tokens: 262_144,
-            context_window: 262_144,
-        },
-    ]
+    &[MISTRAL_MEDIUM_3_5, MISTRAL_MEDIUM, DEVSTRAL_SMALL]
 }
 
 pub(crate) fn models_coding() -> &'static [ModelEntry] {
-    &[
-        ModelEntry {
-            prefixes: &[
-                "mistral-vibe-cli-latest",
-                "devstral-2",
-                "devstral-latest",
-                "devstral-2512",
-            ],
-            tier: ModelTier::Strong,
-            family: ModelFamily::Generic,
-            default: true,
-            pricing: ModelPricing {
-                input: 0.4,
-                output: 2.0,
-                cache_write: 0.0,
-                cache_read: 0.0,
-            },
-            max_output_tokens: 262_144,
-            context_window: 262_144,
-        },
-        ModelEntry {
-            prefixes: &[
-                "mistral-vibe-cli-with-tools",
-                "mistral-medium-latest",
-                "mistral-medium-2508",
-            ],
-            tier: ModelTier::Medium,
-            family: ModelFamily::Generic,
-            default: true,
-            pricing: ModelPricing {
-                input: 0.4,
-                output: 2.0,
-                cache_write: 0.0,
-                cache_read: 0.0,
-            },
-            max_output_tokens: 131_072,
-            context_window: 131_072,
-        },
-        ModelEntry {
-            prefixes: &[
-                "mistral-vibe-cli-fast",
-                "mistral-small-latest",
-                "mistral-small-2603",
-            ],
-            tier: ModelTier::Weak,
-            family: ModelFamily::Generic,
-            default: true,
-            pricing: ModelPricing {
-                input: 0.15,
-                output: 0.60,
-                cache_write: 0.0,
-                cache_read: 0.0,
-            },
-            max_output_tokens: 262_144,
-            context_window: 262_144,
-        },
-    ]
+    &[MISTRAL_MEDIUM_3_5, MISTRAL_MEDIUM, DEVSTRAL_SMALL]
 }
 
 pub struct Mistral {

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -1,3 +1,4 @@
+use std::io::{self, Write};
 use std::time::{Duration, Instant};
 
 use futures_lite::StreamExt;
@@ -142,6 +143,34 @@ pub(crate) fn http_client(timeouts: Timeouts) -> isahc::HttpClient {
         .low_speed_timeout(LOW_SPEED_BYTES_PER_SEC, timeouts.low_speed)
         .build()
         .expect("failed to build HTTP client")
+}
+
+pub(crate) fn prompt_api_key(url: &str, prompt: &str) -> Result<String, AgentError> {
+    if let Err(e) = open::that(url) {
+        tracing::warn!(error = %e, "failed to open browser");
+    }
+    println!("Opened {} in your browser.", url);
+    println!("Create an API key and paste it below.");
+    print!("{prompt}: ");
+    io::stdout().flush().map_err(|e| AgentError::Config {
+        message: format!("flush stdout: {e}"),
+    })?;
+
+    let mut api_key = String::new();
+    io::stdin()
+        .read_line(&mut api_key)
+        .map_err(|e| AgentError::Config {
+            message: format!("read input: {e}"),
+        })?;
+    let api_key = api_key.trim().to_string();
+
+    if api_key.is_empty() {
+        return Err(AgentError::Config {
+            message: "no API key provided".to_string(),
+        });
+    }
+
+    Ok(api_key)
 }
 
 #[cfg(test)]

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -87,11 +87,24 @@ Maki asks Ollama for the list of installed models, so there's no built-in catalo
 
 | Tier | Models | Pricing (in/out per 1M tokens) | Context |
 |------|--------|-------------------------------|---------|
-| Weak | **mistral-small-latest, mistral-small-2603** (default) | $0.15 / $0.60 | 262K ctx / 262K out |
-| Medium | **mistral-large-latest, mistral-large-2512** (default) | $0.50 / $1.50 | 262K ctx / 262K out |
-| Strong | **devstral-latest, devstral-medium-latest, devstral-2512** (default) | $0.40 / $2.00 | 262K ctx / 262K out |
+| Weak | **devstral-small-latest, devstral-small** (default) | $0.10 / $0.30 | 262K ctx / 262K out |
+| Medium | **mistral-medium-latest, mistral-medium-2508** (default) | $0.40 / $2.00 | 131K ctx / 131K out |
+| Strong | **mistral-vibe-cli-latest, mistral-medium-3.5** (default) | $1.50 / $7.50 | 262K ctx / 262K out |
 
-Defaults: devstral-latest (strong), mistral-large-latest (medium), mistral-small-latest (weak)
+Defaults: mistral-vibe-cli-latest (strong), mistral-medium-latest (medium), devstral-small-latest (weak)
+
+### Mistral Coding
+
+- **Env var**: `MISTRAL_API_KEY`
+- **API**: `https://api.mistral.ai/v1`
+
+| Tier | Models | Pricing (in/out per 1M tokens) | Context |
+|------|--------|-------------------------------|---------|
+| Weak | **devstral-small-latest, devstral-small** (default) | $0.10 / $0.30 | 262K ctx / 262K out |
+| Medium | **mistral-medium-latest, mistral-medium-2508** (default) | $0.40 / $2.00 | 131K ctx / 131K out |
+| Strong | **mistral-vibe-cli-latest, mistral-medium-3.5** (default) | $1.50 / $7.50 | 262K ctx / 262K out |
+
+Defaults: mistral-vibe-cli-latest (strong), mistral-medium-latest (medium), devstral-small-latest (weak)
 
 ### Z.AI
 
@@ -149,7 +162,7 @@ To add a custom provider or proxy, drop an executable script into `~/.maki/provi
 
 `resolve` is called each time a new agent spawns, so scripts should read tokens from disk instead of caching them in memory. That way auth changes from other processes get picked up.
 
-The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `copilot`, `ollama`, `mistral`, `zai`, `zai-coding-plan`, `synthetic`.
+The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `copilot`, `ollama`, `mistral`, `mistral-coding`, `zai`, `zai-coding-plan`, `synthetic`.
 
 If your provider serves models not in the base catalog, add a `models` subcommand returning:
 

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -10,13 +10,24 @@ use maki_agent::tools::ToolRegistry;
 use maki_config::load_config;
 use maki_lua::PluginHost;
 use maki_providers::provider::fetch_all_models;
-use maki_providers::{copilot_auth, dynamic, openai_auth};
+use maki_providers::{copilot_auth, dynamic, mistral_auth, openai_auth};
 use maki_storage::StateDir;
+use maki_storage::model::persist_model;
 
 pub fn auth_login(provider: &str, storage: &StateDir) -> Result<()> {
     match provider {
         "openai" => openai_auth::login(storage)?,
         "copilot" => copilot_auth::login()?,
+        "mistral" => {
+            let api_key = mistral_auth::login()?;
+            persist_env_key("MISTRAL_API_KEY", &api_key)?;
+            persist_model(storage, "mistral/devstral-latest");
+        }
+        "mistral-coding" => {
+            let api_key = mistral_auth::login_coding()?;
+            persist_env_key("MISTRAL_API_KEY", &api_key)?;
+            persist_model(storage, "mistral-coding/mistral-vibe-cli-latest");
+        }
         slug => dynamic::login(slug)?,
     }
     Ok(())
@@ -97,5 +108,30 @@ pub fn mcp_logout(server: &str, storage: &StateDir) -> Result<()> {
     } else {
         eprintln!("No stored credentials for MCP server '{server}'");
     }
+    Ok(())
+}
+
+fn persist_env_key(key: &str, value: &str) -> Result<()> {
+    let env_path = maki_storage::paths::config_dir()?.join(".env");
+    let content = if env_path.exists() {
+        std::fs::read_to_string(&env_path)?
+    } else {
+        String::new()
+    };
+    let key_line = format!("{key}={value}");
+    let prefix = format!("{key}=");
+    let updated = if content.lines().any(|l| l.starts_with(&prefix)) {
+        content
+            .lines()
+            .map(|l| if l.starts_with(&prefix) { &key_line } else { l })
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else if content.ends_with('\n') || content.is_empty() {
+        format!("{content}{key_line}")
+    } else {
+        format!("{content}\n{key_line}")
+    };
+    std::fs::write(&env_path, updated)?;
+    println!("Saved {key} to {}", env_path.display());
     Ok(())
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -13,6 +13,8 @@ use tracing_subscriber::EnvFilter;
 const PROVIDER_PRIORITY: &[ProviderKind] = &[
     ProviderKind::Anthropic,
     ProviderKind::OpenAi,
+    ProviderKind::Mistral,
+    ProviderKind::MistralCoding,
     ProviderKind::Zai,
     ProviderKind::ZaiCodingPlan,
     ProviderKind::Synthetic,


### PR DESCRIPTION
- Add login instructions (paving the way for its automation once mistral makes it generally available)
- Make so the API key is picked up like the others
- Include the logic to use the vibe key (restricts the models to the devstral family)