### PR TITLE
Plan Mode Implement screen should not override question screen

### DIFF
--- a/maki-agent/src/prompts/plan.md
+++ b/maki-agent/src/prompts/plan.md
@@ -13,6 +13,6 @@ Your responsibility is to think, read, search, and construct a well-formed plan 
 
 Use the Question tool freely to ask clarifying questions or get the user's opinion when weighing tradeoffs. Don't make large assumptions about user intent. The goal is to present a well-researched plan and tie up loose ends before implementation begins.
 
-Write your plan to: {plan_path} only when you have no more open questions and the plan is finalized. This signals to the system that the plan is ready for implementation.
+Write your plan to: {plan_path} only after all questions are resolved and the plan is finalized.
 When complete, tell the user.
 </system-reminder>

--- a/maki-agent/src/prompts/plan.md
+++ b/maki-agent/src/prompts/plan.md
@@ -13,6 +13,6 @@ Your responsibility is to think, read, search, and construct a well-formed plan 
 
 Use the Question tool freely to ask clarifying questions or get the user's opinion when weighing tradeoffs. Don't make large assumptions about user intent. The goal is to present a well-researched plan and tie up loose ends before implementation begins.
 
-Write your plan to: {plan_path}
+Write your plan to: {plan_path} only when you have no more open questions and the plan is finalized. This signals to the system that the plan is ready for implementation.
 When complete, tell the user.
 </system-reminder>

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -866,7 +866,13 @@ impl App {
             if self.state.mode == Mode::Plan
                 && self.state.plan.path().is_some_and(|pp| e.wrote_to(pp))
             {
-                self.state.plan.mark_written();
+                if !self.state.plan.is_ready() {
+                    self.state.plan.mark_ready();
+                    self.plan_form.open();
+                } else {
+                    self.state.plan.mark_drafting();
+                    self.plan_form.close();
+                }
             }
             if let Some(ref outputs) = self.shared_tool_outputs {
                 outputs
@@ -947,9 +953,6 @@ impl App {
                     self.chat_index.clear();
                     self.subagent_answers.clear();
                     self.status = Status::Idle;
-                    if self.state.mode == Mode::Plan && self.state.plan.is_written() {
-                        self.plan_form.open();
-                    }
                     if self.exit_on_done {
                         self.exit_request = ExitRequest::Success;
                     }
@@ -969,6 +972,10 @@ impl App {
                     }
                 }
                 ChatEventResult::QuestionPrompt { questions } => {
+                    if self.state.plan.is_ready() {
+                        self.state.plan.mark_drafting();
+                        self.plan_form.close();
+                    }
                     if QuestionForm::is_form_suitable(&questions) {
                         self.question_form.open(questions);
                     } else {
@@ -1407,7 +1414,7 @@ impl App {
 
     fn implement_plan(&mut self, clear_context: bool) -> Vec<Action> {
         let plan_snapshot = match std::mem::take(&mut self.state.plan) {
-            PlanState::Written(p) => Some((
+            PlanState::Ready(p) | PlanState::Drafting(p) => Some((
                 std::fs::read_to_string(&p).unwrap_or_default(),
                 p.display().to_string(),
             )),

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -66,7 +66,7 @@ use crate::storage_writer::StorageWriter;
 use ratatui::layout::Position;
 
 pub(crate) use crate::agent::QueuedMessage;
-pub(crate) use mode::{Mode, PlanState};
+pub(crate) use mode::{Mode, PlanState, PlanTrigger};
 #[cfg(test)]
 use mouse::EDGE_SCROLL_LINES;
 pub(crate) use queue::MessageQueue;
@@ -866,13 +866,7 @@ impl App {
             if self.state.mode == Mode::Plan
                 && self.state.plan.path().is_some_and(|pp| e.wrote_to(pp))
             {
-                if !self.state.plan.is_ready() {
-                    self.state.plan.mark_ready();
-                    self.plan_form.open();
-                } else {
-                    self.state.plan.mark_drafting();
-                    self.plan_form.close();
-                }
+                self.transition_plan(PlanTrigger::WriteDone);
             }
             if let Some(ref outputs) = self.shared_tool_outputs {
                 outputs
@@ -972,10 +966,7 @@ impl App {
                     }
                 }
                 ChatEventResult::QuestionPrompt { questions } => {
-                    if self.state.plan.is_ready() {
-                        self.state.plan.mark_drafting();
-                        self.plan_form.close();
-                    }
+                    self.transition_plan(PlanTrigger::QuestionAsked);
                     if QuestionForm::is_form_suitable(&questions) {
                         self.question_form.open(questions);
                     } else {
@@ -1414,7 +1405,7 @@ impl App {
 
     fn implement_plan(&mut self, clear_context: bool) -> Vec<Action> {
         let plan_snapshot = match std::mem::take(&mut self.state.plan) {
-            PlanState::Ready(p) | PlanState::Drafting(p) => Some((
+            PlanState::Ready(p) => Some((
                 std::fs::read_to_string(&p).unwrap_or_default(),
                 p.display().to_string(),
             )),

--- a/maki-ui/src/app/mode.rs
+++ b/maki-ui/src/app/mode.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
+use crate::agent::QueuedMessage;
 use crate::components::Status;
 use crate::theme;
 use maki_agent::{AgentInput, AgentMode};
@@ -9,12 +10,16 @@ use maki_storage::plans;
 use ratatui::style::{Color, Modifier, Style};
 
 use super::App;
-use crate::agent::QueuedMessage;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Mode {
     Build,
     Plan,
+}
+
+pub(crate) enum PlanTrigger {
+    WriteDone,
+    QuestionAsked,
 }
 
 impl Mode {
@@ -68,6 +73,27 @@ impl PlanState {
 }
 
 impl App {
+    pub(super) fn transition_plan(&mut self, trigger: PlanTrigger) {
+        if self.state.mode != Mode::Plan {
+            return;
+        }
+        match trigger {
+            PlanTrigger::WriteDone => {
+                if self.state.plan.is_ready() {
+                    return;
+                }
+                self.state.plan.mark_ready();
+                self.plan_form.open();
+            }
+            PlanTrigger::QuestionAsked => {
+                if self.state.plan.is_ready() {
+                    self.state.plan.mark_drafting();
+                    self.plan_form.close();
+                }
+            }
+        }
+    }
+
     pub(super) fn enter_plan(&mut self) {
         self.state.plan.allocate_path(&self.storage);
         self.state.mode = Mode::Plan;

--- a/maki-ui/src/app/mode.rs
+++ b/maki-ui/src/app/mode.rs
@@ -31,25 +31,31 @@ pub(crate) enum PlanState {
     #[default]
     None,
     Drafting(PathBuf),
-    Written(PathBuf),
+    Ready(PathBuf),
 }
 
 impl PlanState {
     pub(crate) fn path(&self) -> Option<&Path> {
         match self {
             Self::None => Option::None,
-            Self::Drafting(p) | Self::Written(p) => Some(p),
+            Self::Drafting(p) | Self::Ready(p) => Some(p),
         }
     }
 
-    pub(crate) fn mark_written(&mut self) {
+    pub(crate) fn mark_ready(&mut self) {
         if let Self::Drafting(p) = self {
-            *self = Self::Written(std::mem::take(p));
+            *self = Self::Ready(std::mem::take(p));
         }
     }
 
-    pub(crate) fn is_written(&self) -> bool {
-        matches!(self, Self::Written(_))
+    pub(crate) fn mark_drafting(&mut self) {
+        if let Self::Ready(p) = self {
+            *self = Self::Drafting(std::mem::take(p));
+        }
+    }
+
+    pub(crate) fn is_ready(&self) -> bool {
+        matches!(self, Self::Ready(_))
     }
 
     pub(crate) fn allocate_path(&mut self, storage: &DataDir) {

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -48,7 +48,7 @@ impl SessionState {
         let mut plan = match &session.meta.plan_path {
             Some(p) if Path::new(p).exists() => {
                 if session.meta.plan_written {
-                    PlanState::Written(PathBuf::from(p))
+                    PlanState::Ready(PathBuf::from(p))
                 } else {
                     PlanState::Drafting(PathBuf::from(p))
                 }
@@ -95,7 +95,7 @@ impl SessionState {
         self.session.meta.context_size = self.context_size;
         self.session.meta.mode = Some(self.mode.into());
         self.session.meta.plan_path = self.plan.path().map(|p| p.to_string_lossy().into_owned());
-        self.session.meta.plan_written = self.plan.is_written();
+        self.session.meta.plan_written = self.plan.is_ready();
         self.session.meta.session_rules = rules_to_stored(&permissions.session_rules_snapshot());
         self.session.meta.thinking = Some(self.thinking.into());
         self.session.updated_at = maki_storage::now_epoch();

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -1941,7 +1941,7 @@ fn re_edit_closes_plan_form() {
     assert!(app.state.plan.is_ready());
     assert!(app.plan_form.is_visible());
 
-    // Agent edits the plan again (second write to same path)
+    // Agent edits the plan again (second write to same path) — idempotent, stays Ready
     app.update(agent_msg(AgentEvent::ToolDone(Box::new(ToolDoneEvent {
         id: "t2".into(),
         tool: "write".into(),
@@ -1952,8 +1952,8 @@ fn re_edit_closes_plan_form() {
         },
         is_error: false,
     }))));
-    assert!(matches!(app.state.plan, PlanState::Drafting(_)));
-    assert!(!app.plan_form.is_visible());
+    assert!(matches!(app.state.plan, PlanState::Ready(_)));
+    assert!(app.plan_form.is_visible());
 }
 
 #[test_case(0, Mode::Build, true,  true  ; "clear_and_implement")]

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -197,16 +197,16 @@ fn toggle_mode_state_machine() {
 
     tab(&mut app);
     assert_eq!(app.state.mode, Mode::Build);
-    assert!(!app.state.plan.is_written());
+    assert!(!app.state.plan.is_ready());
 
     tab(&mut app);
     assert_eq!(app.state.mode, Mode::Plan);
     assert_eq!(app.state.plan.path().unwrap(), first_path);
 
-    app.state.plan.mark_written();
+    app.state.plan.mark_ready();
     tab(&mut app);
     assert_eq!(app.state.mode, Mode::Build);
-    assert!(app.state.plan.is_written());
+    assert!(app.state.plan.is_ready());
     assert_eq!(app.state.plan.path().unwrap(), first_path);
 
     app.state.mode = Mode::Build;
@@ -220,7 +220,7 @@ fn toggle_mode_state_machine() {
 #[test_case(ToolOutput::WriteCode { path: "/tmp/plans/test.md".into(), byte_count: 100, lines: vec![] }, true  ; "write_matching")]
 #[test_case(ToolOutput::Diff { path: "/tmp/plans/test.md".into(), before: String::new(), after: String::new(), summary: String::new() }, true  ; "edit_matching")]
 #[test_case(ToolOutput::WriteCode { path: "/tmp/other.rs".into(), byte_count: 100, lines: vec![] }, false ; "write_non_matching")]
-fn tool_done_sets_plan_written_flag(output: ToolOutput, expect_written: bool) {
+fn tool_done_transitions_plan_to_ready(output: ToolOutput, expect_ready: bool) {
     let mut app = test_app();
     app.state.mode = Mode::Plan;
     app.state.plan = PlanState::Drafting(PathBuf::from("/tmp/plans/test.md"));
@@ -234,7 +234,7 @@ fn tool_done_sets_plan_written_flag(output: ToolOutput, expect_written: bool) {
         is_error: false,
     }))));
 
-    assert_eq!(app.state.plan.is_written(), expect_written);
+    assert_eq!(app.state.plan.is_ready(), expect_ready);
 }
 
 #[test]
@@ -400,7 +400,7 @@ fn reset_session_clears_plan() {
     app.state.token_usage.input = 500;
     app.chats[0].context_size = 1000;
     app.state.mode = Mode::Build;
-    app.state.plan = PlanState::Written(PathBuf::from("plan.md"));
+    app.state.plan = PlanState::Ready(PathBuf::from("plan.md"));
     app.queue_and_notify(queued_msg("q"));
     app.queue.set_focus_at(0);
     app.update(Msg::Key(kb::HELP.to_key_event()));
@@ -477,7 +477,7 @@ fn load_session_clears_plan() {
     app.state.session.save(&app.storage).unwrap();
     let id = app.state.session.id.clone();
     app.state.mode = Mode::Build;
-    app.state.plan = PlanState::Written(PathBuf::from("old-plan.md"));
+    app.state.plan = PlanState::Ready(PathBuf::from("old-plan.md"));
     app.load_session(id);
     assert_eq!(app.state.mode, Mode::Build);
     assert_eq!(app.state.plan.path(), None);
@@ -1703,7 +1703,7 @@ fn paste_routing(setup: fn(&mut App), expected_input: &str) {
 
 #[test_case(PlanState::None,                                       true  ; "no_plan")]
 #[test_case(PlanState::Drafting(PathBuf::from("/tmp/plan.md")),     false ; "plan_drafting")]
-#[test_case(PlanState::Written(PathBuf::from("/tmp/plan.md")),      false ; "plan_written")]
+#[test_case(PlanState::Ready(PathBuf::from("/tmp/plan.md")),       false ; "plan_ready")]
 fn open_editor(plan: PlanState, expect_flash: bool) {
     let mut app = test_app();
     let plan_path = plan.path().map(Path::to_path_buf);
@@ -1863,21 +1863,97 @@ fn plan_app() -> App {
     app.status = Status::Streaming;
     app.run_id = 1;
     app.state.mode = Mode::Plan;
-    app.state.plan = PlanState::Written(PathBuf::from("test-plan.md"));
+    app.state.plan = PlanState::Drafting(PathBuf::from("test-plan.md"));
+    app.update(agent_msg(AgentEvent::ToolDone(Box::new(ToolDoneEvent {
+        id: "t1".into(),
+        tool: "write".into(),
+        output: ToolOutput::WriteCode {
+            path: "test-plan.md".into(),
+            byte_count: 42,
+            lines: vec![],
+        },
+        is_error: false,
+    }))));
     app
 }
 
-#[test_case(Mode::Plan,  PlanState::Written(PathBuf::from("test-plan.md")),  true  ; "plan_mode_written_opens_form")]
-#[test_case(Mode::Plan,  PlanState::Drafting(PathBuf::from("test-plan.md")), false ; "plan_mode_unwritten_no_form")]
-#[test_case(Mode::Build, PlanState::None,                                    false ; "build_mode_no_form")]
-fn done_plan_form_visibility(mode: Mode, plan: PlanState, expect_form: bool) {
+#[test_case(Mode::Plan,  true  ; "plan_mode_tooldone_opens_form")]
+#[test_case(Mode::Build, false ; "build_mode_tooldone_no_form")]
+fn tool_done_write_opens_plan_form(mode: Mode, expect_form: bool) {
     let mut app = test_app();
     app.status = Status::Streaming;
     app.run_id = 1;
     app.state.mode = mode;
-    app.state.plan = plan;
-    app.update(done_event());
+    app.state.plan = PlanState::Drafting(PathBuf::from("/tmp/plans/test.md"));
+    app.update(agent_msg(AgentEvent::ToolDone(Box::new(ToolDoneEvent {
+        id: "t1".into(),
+        tool: "write".into(),
+        output: ToolOutput::WriteCode {
+            path: "/tmp/plans/test.md".into(),
+            byte_count: 42,
+            lines: vec![],
+        },
+        is_error: false,
+    }))));
     assert_eq!(app.plan_form.is_visible(), expect_form);
+    if expect_form {
+        assert!(app.state.plan.is_ready());
+    }
+}
+
+#[test]
+fn done_event_does_not_open_plan_form() {
+    let mut app = test_app();
+    app.status = Status::Streaming;
+    app.run_id = 1;
+    app.state.mode = Mode::Plan;
+    app.state.plan = PlanState::Ready(PathBuf::from("test-plan.md"));
+    app.update(done_event());
+    assert!(!app.plan_form.is_visible());
+}
+
+#[test]
+fn question_demotes_ready_to_drafting() {
+    let mut app = plan_app();
+    assert!(app.state.plan.is_ready());
+    assert!(app.plan_form.is_visible());
+
+    app.update(agent_msg(AgentEvent::QuestionPrompt {
+        id: "q1".into(),
+        questions: vec![QuestionInfo {
+            question: "Pick one".into(),
+            header: "Choice".into(),
+            options: vec![QuestionOption {
+                label: "A".into(),
+                description: String::new(),
+            }],
+            multiple: false,
+        }],
+    }));
+    assert!(matches!(app.state.plan, PlanState::Drafting(_)));
+    assert!(!app.plan_form.is_visible());
+    assert!(app.question_form.is_visible());
+}
+
+#[test]
+fn re_edit_closes_plan_form() {
+    let mut app = plan_app();
+    assert!(app.state.plan.is_ready());
+    assert!(app.plan_form.is_visible());
+
+    // Agent edits the plan again (second write to same path)
+    app.update(agent_msg(AgentEvent::ToolDone(Box::new(ToolDoneEvent {
+        id: "t2".into(),
+        tool: "write".into(),
+        output: ToolOutput::WriteCode {
+            path: "test-plan.md".into(),
+            byte_count: 50,
+            lines: vec![],
+        },
+        is_error: false,
+    }))));
+    assert!(matches!(app.state.plan, PlanState::Drafting(_)));
+    assert!(!app.plan_form.is_visible());
 }
 
 #[test_case(0, Mode::Build, true,  true  ; "clear_and_implement")]
@@ -1890,7 +1966,6 @@ fn plan_form_menu_options(
     has_send_message: bool,
 ) {
     let mut app = plan_app();
-    app.update(done_event());
     assert!(app.plan_form.is_visible());
 
     for _ in 0..downs {
@@ -1912,7 +1987,6 @@ fn plan_form_menu_options(
 #[test]
 fn implement_plan_clear_context_does_not_leak_plan_state() {
     let mut app = plan_app();
-    app.update(done_event());
     assert!(app.plan_form.is_visible());
     app.update(Msg::Key(key(KeyCode::Enter)));
     assert_eq!(app.state.mode, Mode::Build);
@@ -1922,7 +1996,6 @@ fn implement_plan_clear_context_does_not_leak_plan_state() {
 #[test]
 fn plan_form_open_editor() {
     let mut app = plan_app();
-    app.update(done_event());
 
     let actions = app.update(Msg::Key(kb::OPEN_EDITOR.to_key_event()));
     assert!(app.plan_form.is_visible());
@@ -1932,7 +2005,6 @@ fn plan_form_open_editor() {
 #[test]
 fn plan_form_dismiss_on_esc() {
     let mut app = plan_app();
-    app.update(done_event());
 
     let actions = app.update(Msg::Key(key(KeyCode::Esc)));
     assert!(!app.plan_form.is_visible());
@@ -1942,7 +2014,6 @@ fn plan_form_dismiss_on_esc() {
 #[test]
 fn reset_session_closes_plan_form() {
     let mut app = plan_app();
-    app.update(done_event());
     assert!(app.plan_form.is_visible());
 
     app.reset_session();


### PR DESCRIPTION
In pursuit of #109 here is a PR.

I looked at just prompt modification and realized that clarifying to the agent to only write the file when it was definitely done, but sometimes agents are overeager or do things slightly out of order even with improved instruction. This was particularly true of agents in thinking mode, doing a "but wait" after they had already engaged in plan writing, shockingly common on some models. 

I updated Written to Ready for planning mostly to just indicate semantically what the expectation around it is. 

Now if the agent during its reasoning writes a file but has questions, calling the questions tool will put the status back into drafting. And if the agent calls the question tool but then writes to the plan file before the end of its turn, the ready state will not be reached, as the question tool will have precedence. In the case where the agent has no questions and is just ready, this works as usual, the agent writes to the plan file and you get your option to implement.

This was me and GLP-5.1 at work. 