### PR TITLE
chore: index plugins

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,7 @@
               ruff
               rustc
               rustfmt
+              stylua
               ty
             ];
 

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -634,6 +634,27 @@ pub(crate) fn interpreter_ctx(
     }
 }
 
+/// Minimal ToolContext for CLI one-shot tool execution (e.g. `maki index`).
+/// Allows everything, sends events to a dummy channel, uses no model.
+pub fn cli_tool_ctx() -> ToolContext {
+    let (tx, _rx) = flume::unbounded::<crate::Envelope>();
+    let event_tx = crate::EventSender::new(tx, 0);
+    interpreter_ctx(
+        &AgentMode::Build,
+        &event_tx,
+        CancelToken::none(),
+        Arc::new(PermissionManager::new(
+            maki_config::PermissionsConfig {
+                allow_all: true,
+                rules: vec![],
+            },
+            std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+        )),
+        Arc::new(FileReadTracker::new()),
+        None,
+    )
+}
+
 pub mod test_support {
     use crate::{Envelope, EventSender};
 

--- a/maki-code-index/Cargo.toml
+++ b/maki-code-index/Cargo.toml
@@ -4,50 +4,66 @@ version.workspace = true
 edition.workspace = true
 
 [features]
-default = ["lang-rust", "lang-python", "lang-typescript", "lang-go", "lang-java",
-           "lang-c", "lang-cpp", "lang-c-sharp", "lang-ruby", "lang-php",
-           "lang-swift", "lang-kotlin", "lang-scala", "lang-bash", "lang-lua", "lang-elixir", "lang-markdown"]
-lang-rust = ["dep:tree-sitter-rust"]
-lang-python = ["dep:tree-sitter-python"]
-lang-typescript = ["dep:tree-sitter-typescript", "dep:tree-sitter-javascript"]
+default = [
+    "lang-bash",
+    "lang-c",
+    "lang-c-sharp",
+    "lang-cpp",
+    "lang-elixir",
+    "lang-go",
+    "lang-java",
+    "lang-kotlin",
+    "lang-lua",
+    "lang-markdown",
+    "lang-php",
+    "lang-python",
+    "lang-ruby",
+    "lang-rust",
+    "lang-scala",
+    "lang-swift",
+    "lang-typescript",
+]
+lang-bash = ["dep:tree-sitter-bash"]
+lang-c = ["dep:tree-sitter-c"]
+lang-c-sharp = ["dep:tree-sitter-c-sharp"]
+lang-cpp = ["dep:tree-sitter-cpp", "dep:tree-sitter-c"]
+lang-elixir = ["dep:tree-sitter-elixir"]
 lang-go = ["dep:tree-sitter-go"]
 lang-java = ["dep:tree-sitter-java"]
-lang-c = ["dep:tree-sitter-c"]
-lang-cpp = ["dep:tree-sitter-cpp", "dep:tree-sitter-c"]
-lang-c-sharp = ["dep:tree-sitter-c-sharp"]
-lang-ruby = ["dep:tree-sitter-ruby"]
-lang-php = ["dep:tree-sitter-php"]
-lang-swift = ["dep:tree-sitter-swift"]
 lang-kotlin = ["dep:tree-sitter-kotlin-ng"]
-lang-scala = ["dep:tree-sitter-scala"]
-lang-bash = ["dep:tree-sitter-bash"]
 lang-lua = ["dep:tree-sitter-lua"]
-lang-elixir = ["dep:tree-sitter-elixir"]
 lang-markdown = ["dep:tree-sitter-md"]
+lang-php = ["dep:tree-sitter-php"]
+lang-python = ["dep:tree-sitter-python"]
+lang-ruby = ["dep:tree-sitter-ruby"]
+lang-rust = ["dep:tree-sitter-rust"]
+lang-scala = ["dep:tree-sitter-scala"]
+lang-swift = ["dep:tree-sitter-swift"]
+lang-typescript = ["dep:tree-sitter-typescript", "dep:tree-sitter-javascript"]
 
 [dependencies]
-thiserror = { workspace = true }
 ignore = { workspace = true }
 memchr = { workspace = true }
+thiserror = { workspace = true }
 tree-sitter = "0.26"
-tree-sitter-rust = { version = "0.24", optional = true }
-tree-sitter-python = { version = "0.23", optional = true }
-tree-sitter-typescript = { version = "0.23", optional = true }
-tree-sitter-javascript = { version = "0.23", optional = true }
+tree-sitter-bash = { version = "0.25", optional = true }
+tree-sitter-c = { version = "0.24", optional = true }
+tree-sitter-c-sharp = { version = "0.23", optional = true }
+tree-sitter-cpp = { version = "0.23", optional = true }
+tree-sitter-elixir = { version = "0.3.5", optional = true }
 tree-sitter-go = { version = "0.23", optional = true }
 tree-sitter-java = { version = "0.23", optional = true }
-tree-sitter-c = { version = "0.24", optional = true }
-tree-sitter-cpp = { version = "0.23", optional = true }
-tree-sitter-c-sharp = { version = "0.23", optional = true }
-tree-sitter-ruby = { version = "0.23", optional = true }
-tree-sitter-php = { version = "0.24", optional = true }
-tree-sitter-swift = { version = "0.7", optional = true }
+tree-sitter-javascript = { version = "0.23", optional = true }
 tree-sitter-kotlin-ng = { version = "1.1", optional = true }
-tree-sitter-scala = { version = "0.25", optional = true }
-tree-sitter-bash = { version = "0.25", optional = true }
 tree-sitter-lua = { version = "0.5", optional = true }
-tree-sitter-elixir = { version = "0.3.5", optional = true }
 tree-sitter-md = { version = "0.5.3", optional = true }
+tree-sitter-php = { version = "0.24", optional = true }
+tree-sitter-python = { version = "0.23", optional = true }
+tree-sitter-ruby = { version = "0.23", optional = true }
+tree-sitter-rust = { version = "0.24", optional = true }
+tree-sitter-scala = { version = "0.25", optional = true }
+tree-sitter-swift = { version = "0.7", optional = true }
+tree-sitter-typescript = { version = "0.23", optional = true }
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,10 @@ struct Cli {
     #[arg(long)]
     no_rtk: bool,
 
+    /// Enable the Lua plugin system
+    #[arg(long)]
+    plugins: bool,
+
     /// Skip all permission prompts (allow everything)
     #[arg(long)]
     yolo: bool,
@@ -235,7 +239,10 @@ fn run() -> Result<()> {
         }
         Some(Command::Index { path }) => {
             let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
-            let config = load_config(&cwd, false);
+            let mut config = load_config(&cwd, false);
+            if cli.plugins {
+                config.plugins.enabled = true;
+            }
             let abs_path = Path::new(&path)
                 .canonicalize()
                 .unwrap_or_else(|_| Path::new(&path).to_path_buf());
@@ -352,6 +359,9 @@ fn run() -> Result<()> {
                 low_speed: config.provider.low_speed_timeout,
                 stream: config.provider.stream_timeout,
             };
+            if cli.plugins {
+                config.plugins.enabled = true;
+            }
             if cli.yolo || config.always_yolo {
                 config.permissions.allow_all = true;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,10 +236,40 @@ fn run() -> Result<()> {
         Some(Command::Index { path }) => {
             let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
             let config = load_config(&cwd, false);
-            let output =
-                maki_code_index::index_file(Path::new(&path), config.agent.index_max_file_size)
-                    .context("index file")?;
-            print!("{output}");
+            let abs_path = Path::new(&path)
+                .canonicalize()
+                .unwrap_or_else(|_| Path::new(&path).to_path_buf());
+            let _plugin_host =
+                PluginHost::new(&config.plugins, Arc::clone(ToolRegistry::native_arc()))
+                    .context("initialize lua plugin host")?;
+            let input = serde_json::json!({"path": abs_path.to_str().unwrap_or(&path)});
+            let reg = ToolRegistry::native_arc();
+            let entry = reg
+                .get("index")
+                .ok_or_else(|| color_eyre::eyre::eyre!("index tool not registered"))?;
+            let inv = entry
+                .tool
+                .parse(&input)
+                .map_err(|e| color_eyre::eyre::eyre!("parse index input: {e}"))?;
+            let ctx = maki_agent::tools::cli_tool_ctx();
+            let result: Result<maki_agent::ToolOutput, String> =
+                smol::block_on(async { inv.execute(&ctx).await });
+            match result {
+                Ok(output) => {
+                    let text = output.as_text();
+                    if text == "DELEGATE_NATIVE" {
+                        let output = maki_code_index::index_file(
+                            &abs_path,
+                            config.agent.index_max_file_size,
+                        )
+                        .context("index file")?;
+                        print!("{output}");
+                    } else {
+                        print!("{text}");
+                    }
+                }
+                Err(e) => bail!("index failed: {e}"),
+            }
         }
         Some(Command::FindSymbol { symbol, file, line }) => {
             let cwd = env::current_dir().unwrap_or_else(|_| ".".into());


### PR DESCRIPTION
Here are some "chore commits" related to the `plugins/index`:

- Add `stylua` to the Nix dev shell.
- Sort `maki-code-index/Cargo.toml` feature and dependency lists alphabetically.
- Route `maki index` through the Lua plugin system so plugins can intercept/override file indexing. Falls back to the native `maki_code_index::index_file` when the plugin returns `DELEGATE_NATIVE`.
- Add `--plugins` CLI flag to enable the Lua plugin host for both `index` and agent modes.
