### PR TITLE
ui: copy_selection OSC52 fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
+ "wl-clipboard-rs",
  "x11rb",
 ]
 
@@ -778,6 +779,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
+ "base64",
  "bitflags 2.11.0",
  "crossterm_winapi",
  "derive_more",
@@ -1006,6 +1008,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1220,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -2695,6 +2709,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "notify"
 version = "9.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2983,6 +3006,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3070,6 +3103,17 @@ checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
+ "indexmap",
 ]
 
 [[package]]
@@ -3228,7 +3272,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64",
  "indexmap",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -3475,6 +3519,15 @@ name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]
@@ -4241,7 +4294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf 0.11.3",
  "phf_codegen 0.11.3",
 ]
@@ -4267,7 +4320,7 @@ dependencies = [
  "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "hex",
  "lazy_static",
  "libc",
@@ -4774,6 +4827,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "two-face"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5063,6 +5127,76 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.2",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -5512,6 +5646,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 uuid = { version = "1", default-features = false, features = ["v4"] }
 ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
-crossterm = "0.29"
+crossterm = { version = "0.29", features = ["osc52"] }
 color-eyre = { version = "0.6", default-features = false, features = ["track-caller"] }
 thiserror = "2"
 tracing = "0.1"
@@ -108,7 +108,7 @@ two-face = { version = "0.5", default-features = false, features = ["syntect-def
 unicode-width = "0.2"
 similar = { version = "2", features = ["inline", "unicode"] }
 jiff = { version = "0.2", default-features = false, features = ["std"] }
-arboard = { version = "3", default-features = false, features = ["image-data"] }
+arboard = { version = "3", default-features = false, features = ["image-data", "wayland-data-control"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 flume = { version = "0.11", default-features = false, features = ["async"] }
 humantime = "2"

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -22,6 +22,7 @@ use std::time::{Duration, Instant};
 use crate::AppSession;
 use crate::chat::Chat;
 use crate::chat::{CANCELLED_TEXT, ChatEventResult, DONE_TEXT, ERROR_TEXT};
+use crate::clipboard::ClipboardState;
 use crate::components::btw_modal::BtwModal;
 use crate::components::command::{CommandAction, CommandPalette, ParsedCommand};
 use crate::components::file_picker::{FilePickerModal, FilePickerModalAction};
@@ -47,7 +48,6 @@ use crate::components::{
 };
 use crate::image;
 use crate::selection::{SelectionState, SelectionZone, ZoneRegistry};
-use arboard::Clipboard;
 use arc_swap::{ArcSwap, ArcSwapOption};
 use crossterm::event::{KeyCode, KeyEvent, MouseEvent};
 #[cfg(feature = "demo")]
@@ -155,7 +155,7 @@ pub struct App {
     demo_questions: Option<(usize, Vec<QuestionInfo>)>,
     pub(super) zones: ZoneRegistry,
     pub(super) selection_state: Option<SelectionState>,
-    pub(super) clipboard: Option<Clipboard>,
+    pub(super) clipboard: ClipboardState,
     pub(super) last_esc: Option<Instant>,
 
     pub(crate) storage: DataDir,
@@ -221,7 +221,7 @@ impl App {
             demo_questions: None,
             zones: [None; SelectionZone::COUNT],
             selection_state: None,
-            clipboard: Clipboard::new().ok(),
+            clipboard: ClipboardState::new(),
             last_esc: None,
             storage,
             shared_history: None,

--- a/maki-ui/src/app/mouse.rs
+++ b/maki-ui/src/app/mouse.rs
@@ -1,8 +1,7 @@
 use std::time::{Duration, Instant};
 
+use crate::clipboard::CopyResult;
 use crate::selection::{self, ContentRegion, EdgeScroll, SelectableZone, Selection, SelectionZone};
-#[cfg(target_os = "linux")]
-use arboard::{LinuxClipboardKind, SetExtLinux};
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;
 
@@ -166,28 +165,10 @@ impl App {
             }
         };
 
-        if !text.is_empty() {
-            match &mut self.clipboard {
-                Some(cb) => {
-                    #[cfg(target_os = "linux")]
-                    let result = cb
-                        .set()
-                        .clipboard(LinuxClipboardKind::Primary)
-                        .text(&text)
-                        .and_then(|()| {
-                            cb.set().clipboard(LinuxClipboardKind::Clipboard).text(text)
-                        });
-
-                    #[cfg(not(target_os = "linux"))]
-                    let result = cb.set_text(&text);
-
-                    match result {
-                        Ok(()) => self.status_bar.flash("Copied selection".into()),
-                        Err(e) => self.status_bar.flash(format!("Copy failed: {e}")),
-                    }
-                }
-                None => self.status_bar.flash("Copy failed: no clipboard".into()),
-            }
+        match self.clipboard.copy_text(&text) {
+            Ok(CopyResult::Noop) => {}
+            Ok(CopyResult::Copied) => self.status_bar.flash("Copied selection".into()),
+            Err(e) => self.status_bar.flash(format!("Copy failed: {e}")),
         }
         self.selection_state = None;
     }

--- a/maki-ui/src/clipboard.rs
+++ b/maki-ui/src/clipboard.rs
@@ -1,0 +1,153 @@
+use crate::terminal;
+use arboard::Clipboard;
+#[cfg(target_os = "linux")]
+use arboard::{LinuxClipboardKind, SetExtLinux};
+
+pub(crate) enum CopyResult {
+    Copied,
+    Noop,
+}
+
+pub(crate) struct ClipboardState {
+    native: Option<Clipboard>,
+}
+
+impl ClipboardState {
+    pub(crate) fn new() -> Self {
+        Self {
+            native: Clipboard::new().ok(),
+        }
+    }
+
+    pub(crate) fn copy_text(&mut self, text: &str) -> Result<CopyResult, String> {
+        Self::copy_text_impl(text, |t| self.copy_native(t), terminal::copy_to_clipboard)
+    }
+
+    fn copy_text_impl<F, G>(text: &str, native: F, osc52: G) -> Result<CopyResult, String>
+    where
+        F: FnOnce(&str) -> Result<(), String>,
+        G: FnOnce(&str) -> Result<(), String>,
+    {
+        if text.is_empty() {
+            return Ok(CopyResult::Noop);
+        }
+        let native_err = match native(text) {
+            Ok(()) => return Ok(CopyResult::Copied),
+            Err(e) => e,
+        };
+        match osc52(text) {
+            Ok(()) => Ok(CopyResult::Copied),
+            Err(osc52_err) => Err(format!("native ({native_err}); osc52 ({osc52_err})")),
+        }
+    }
+
+    fn copy_native(&mut self, text: &str) -> Result<(), String> {
+        let Some(clipboard) = &mut self.native else {
+            return Err("native clipboard unavailable".into());
+        };
+
+        #[cfg(target_os = "linux")]
+        {
+            clipboard
+                .set()
+                .clipboard(LinuxClipboardKind::Primary)
+                .text(text)
+                .and_then(|()| {
+                    clipboard
+                        .set()
+                        .clipboard(LinuxClipboardKind::Clipboard)
+                        .text(text)
+                })
+                .map_err(|e| e.to_string())
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            clipboard.set_text(text).map_err(|e| e.to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn empty_text_is_noop_and_skips_both_backends() {
+        let native_called = Cell::new(false);
+        let osc52_called = Cell::new(false);
+        let result = ClipboardState::copy_text_impl(
+            "",
+            |_| {
+                native_called.set(true);
+                Ok(())
+            },
+            |_| {
+                osc52_called.set(true);
+                Ok(())
+            },
+        );
+        assert!(matches!(result, Ok(CopyResult::Noop)));
+        assert!(!native_called.get(), "empty text must not reach native");
+        assert!(!osc52_called.get(), "empty text must not reach osc52");
+    }
+
+    #[test]
+    fn native_success_skips_osc52() {
+        let osc52_called = Cell::new(false);
+        let result = ClipboardState::copy_text_impl(
+            "hello",
+            |_| Ok(()),
+            |_| {
+                osc52_called.set(true);
+                Ok(())
+            },
+        );
+        assert!(matches!(result, Ok(CopyResult::Copied)));
+        assert!(
+            !osc52_called.get(),
+            "osc52 must not fire after native succeeds"
+        );
+    }
+
+    #[test]
+    fn native_failure_is_recovered_by_osc52() {
+        let result =
+            ClipboardState::copy_text_impl("hello", |_| Err("unavailable".into()), |_| Ok(()));
+        assert!(matches!(result, Ok(CopyResult::Copied)));
+    }
+
+    #[test]
+    fn both_failing_composes_errors_with_native_first() {
+        let result = ClipboardState::copy_text_impl(
+            "hello",
+            |_| Err("no display".into()),
+            |_| Err("stdout closed".into()),
+        );
+        let Err(msg) = result else {
+            panic!("expected Err when both backends fail");
+        };
+        assert_eq!(msg, "native (no display); osc52 (stdout closed)");
+    }
+
+    #[test]
+    fn each_backend_receives_the_input_text_verbatim() {
+        // Force native to fail so osc52 also runs; capture what each got.
+        let native_input = Cell::new(String::new());
+        let osc52_input = Cell::new(String::new());
+        let _ = ClipboardState::copy_text_impl(
+            "the payload",
+            |t| {
+                native_input.set(t.to_string());
+                Err("fail".into())
+            },
+            |t| {
+                osc52_input.set(t.to_string());
+                Ok(())
+            },
+        );
+        assert_eq!(native_input.take(), "the payload");
+        assert_eq!(osc52_input.take(), "the payload");
+    }
+}

--- a/maki-ui/src/lib.rs
+++ b/maki-ui/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod animation;
 pub mod app;
 pub mod chat;
+mod clipboard;
 mod components;
 pub use components::command::{BUILTIN_COMMANDS, BuiltinCommand};
 pub use components::keybindings;

--- a/maki-ui/src/terminal.rs
+++ b/maki-ui/src/terminal.rs
@@ -1,9 +1,11 @@
 use shell_words::split;
-use std::io::stdout;
+use std::io::{Write, stdout};
 use std::path::Path;
 
 use color_eyre::Result;
+use crossterm::Command;
 use crossterm::ExecutableCommand;
+use crossterm::clipboard::CopyToClipboard;
 use crossterm::event::{
     DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
     KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
@@ -11,6 +13,48 @@ use crossterm::event::{
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 
 pub(crate) struct TerminalGuard;
+
+enum TerminalMux {
+    Zellij,
+    Tmux,
+    Screen,
+    None,
+}
+
+impl TerminalMux {
+    fn detect() -> Self {
+        if std::env::var_os("ZELLIJ").is_some() {
+            Self::Zellij
+        } else if std::env::var_os("TMUX").is_some() {
+            Self::Tmux
+        } else if std::env::var_os("STY").is_some() {
+            Self::Screen
+        } else {
+            Self::None
+        }
+    }
+
+    // Wrap a control sequence so terminal multiplexers pass it through to the
+    // outer terminal. tmux and screen take a DCS-wrapped payload with every
+    // internal ESC byte doubled. Otherwise the ESC in the OSC52 `ESC \`
+    // terminator ends the DCS early and truncates the payload. Zellij has no
+    // passthrough protocol but intercepts OSC52 itself, so we emit the raw
+    // sequence and let zellij forward or honor it per its `copy_command`
+    // config.
+    fn wrap_for_mux(&self, sequence: String) -> String {
+        match self {
+            Self::Zellij | Self::None => sequence,
+            Self::Tmux => {
+                let escaped = sequence.replace('\u{1b}', "\u{1b}\u{1b}");
+                format!("\u{1b}Ptmux;{escaped}\u{1b}\\")
+            }
+            Self::Screen => {
+                let escaped = sequence.replace('\u{1b}', "\u{1b}\u{1b}");
+                format!("\u{1b}P{escaped}\u{1b}\\")
+            }
+        }
+    }
+}
 
 impl TerminalGuard {
     pub(crate) fn init() -> Result<(Self, ratatui::DefaultTerminal)> {
@@ -109,5 +153,122 @@ pub(crate) fn open_in_editor(
             "Failed to open {editor}: {e} - set $VISUAL or $EDITOR"
         )),
         Ok(_) => Ok(()),
+    }
+}
+
+pub(crate) fn copy_to_clipboard(text: &str) -> Result<(), String> {
+    let mut sequence = String::new();
+    CopyToClipboard::to_clipboard_from(text)
+        .write_ansi(&mut sequence)
+        .map_err(|e| e.to_string())?;
+    let sequence = TerminalMux::detect().wrap_for_mux(sequence);
+    let mut stdout = stdout().lock();
+    stdout
+        .write_all(sequence.as_bytes())
+        .and_then(|()| stdout.flush())
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Faithfully simulates how a DCS-passthrough mux (tmux/screen) parses the
+    // body between its opener and ST terminator: `ESC ESC` collapses to a
+    // single ESC, `ESC \` ends the DCS, and any other byte is emitted verbatim.
+    // Panics on malformed input so tests fail loudly on unexpected bytes.
+    fn parse_dcs_passthrough(wrapped: &str, prefix: &str) -> String {
+        let body = wrapped
+            .strip_prefix(prefix)
+            .unwrap_or_else(|| panic!("missing DCS prefix {prefix:?} in {wrapped:?}"));
+        let bytes = body.as_bytes();
+        let mut out = Vec::with_capacity(bytes.len());
+        let mut i = 0;
+        loop {
+            match bytes.get(i) {
+                None => panic!("DCS body missing ST terminator: {body:?}"),
+                Some(&0x1B) => match bytes.get(i + 1) {
+                    Some(&0x1B) => {
+                        out.push(0x1B);
+                        i += 2;
+                    }
+                    Some(&b'\\') => {
+                        assert_eq!(
+                            i + 2,
+                            bytes.len(),
+                            "unexpected trailing bytes after DCS ST: {:?}",
+                            &bytes[i + 2..]
+                        );
+                        return String::from_utf8(out).expect("utf-8 body");
+                    }
+                    Some(b) => panic!("unexpected byte 0x{b:02x} after ESC inside DCS"),
+                    None => panic!("lone trailing ESC in DCS body"),
+                },
+                Some(&b) => {
+                    out.push(b);
+                    i += 1;
+                }
+            }
+        }
+    }
+
+    // OSC52 payload using ST terminator — matches what crossterm emits, and
+    // exercises the case where the DCS body contains an ESC both at the
+    // start (opening the OSC) and mid-body (opening the ST terminator).
+    const OSC52_WITH_ST: &str = "\u{1b}]52;c;SGVsbG8=\u{1b}\\";
+
+    #[test]
+    fn none_is_identity() {
+        assert_eq!(
+            TerminalMux::None.wrap_for_mux(OSC52_WITH_ST.to_string()),
+            OSC52_WITH_ST
+        );
+    }
+
+    #[test]
+    fn zellij_is_identity_because_it_intercepts_osc52() {
+        // Zellij consumes OSC52 itself rather than forwarding; wrapping in a
+        // DCS it doesn't understand would eat the whole sequence.
+        assert_eq!(
+            TerminalMux::Zellij.wrap_for_mux(OSC52_WITH_ST.to_string()),
+            OSC52_WITH_ST
+        );
+    }
+
+    #[test]
+    fn tmux_wrap_survives_tmux_passthrough_parser() {
+        let wrapped = TerminalMux::Tmux.wrap_for_mux(OSC52_WITH_ST.to_string());
+        assert_eq!(
+            parse_dcs_passthrough(&wrapped, "\u{1b}Ptmux;"),
+            OSC52_WITH_ST
+        );
+    }
+
+    #[test]
+    fn screen_wrap_survives_screen_passthrough_parser() {
+        let wrapped = TerminalMux::Screen.wrap_for_mux(OSC52_WITH_ST.to_string());
+        assert_eq!(parse_dcs_passthrough(&wrapped, "\u{1b}P"), OSC52_WITH_ST);
+    }
+
+    // A payload with ESC bytes at multiple positions: if any of them gets left
+    // undoubled, the first undoubled `ESC \` would close the DCS early and
+    // truncate the payload, and this round-trip would fail.
+    #[test]
+    fn tmux_preserves_payload_with_multiple_interior_esc_bytes() {
+        let payload = "\u{1b}A\u{1b}B\u{1b}C\u{1b}\\";
+        let wrapped = TerminalMux::Tmux.wrap_for_mux(payload.to_string());
+        assert_eq!(parse_dcs_passthrough(&wrapped, "\u{1b}Ptmux;"), payload);
+    }
+
+    // End-to-end: feed the actual crossterm OSC52 output through the wrapper,
+    // confirming the full real pipeline isn't lossy.
+    #[test]
+    fn tmux_wrap_roundtrips_crossterm_osc52_output() {
+        let mut sequence = String::new();
+        CopyToClipboard::to_clipboard_from("hello, world!")
+            .write_ansi(&mut sequence)
+            .expect("crossterm write_ansi");
+        let wrapped = TerminalMux::Tmux.wrap_for_mux(sequence.clone());
+        assert_eq!(parse_dcs_passthrough(&wrapped, "\u{1b}Ptmux;"), sequence);
     }
 }


### PR DESCRIPTION
Before, copying a selection needed a reachable system clipboard. SSH sessions and shells without a display could only flash an error.

Now when that path fails we fall back to OSC52, so the terminal itself carries the copy to the host clipboard. Also, OSC52 is wrapped as needed so it works from inside tmux, screen and zellij.

Finally, arboard now uses the wayland-data-control feature so Wayland sessions work without XWayland.

Fixes: #135