### PR TITLE
lua: support setting custom summary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2353,6 +2353,7 @@ dependencies = [
 name = "maki-lua"
 version = "0.2.5"
 dependencies = [
+ "dirs",
  "flume 0.11.1",
  "futures-lite",
  "include_dir",

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -106,7 +106,7 @@ pub async fn run(
         let start = ToolStartEvent {
             id: id.clone(),
             tool: Arc::clone(&tool_id),
-            summary: invocation.start_summary(),
+            summary: invocation.start_summary().await,
             annotation: invocation.start_annotation(),
             input: invocation.start_input(),
             output: invocation.start_output(),

--- a/maki-agent/src/tools/bash.rs
+++ b/maki-agent/src/tools/bash.rs
@@ -311,8 +311,8 @@ impl Bash {
 super::impl_tool!(Bash);
 
 impl super::ToolInvocation for Bash {
-    fn start_summary(&self) -> String {
-        Bash::start_summary(self)
+    fn start_summary(&self) -> super::SummaryFuture {
+        super::SummaryFuture::Ready(Bash::start_summary(self))
     }
     fn start_input(&self) -> Option<ToolInput> {
         let (command, _) = self.resolved();

--- a/maki-agent/src/tools/batch.rs
+++ b/maki-agent/src/tools/batch.rs
@@ -116,7 +116,10 @@ impl BatchEntry {
             .and_then(|e| e.tool.parse(&self.parameters).ok());
         BatchToolEntry {
             tool: self.tool.clone(),
-            summary: call.as_ref().map(|c| c.start_summary()).unwrap_or_default(),
+            summary: call
+                .as_ref()
+                .map(|c| c.start_summary().into_ready())
+                .unwrap_or_default(),
             status,
             input: call.and_then(|c| c.start_input()),
             output,
@@ -309,8 +312,8 @@ super::impl_tool!(
 );
 
 impl super::ToolInvocation for Batch {
-    fn start_summary(&self) -> String {
-        Batch::start_summary(self)
+    fn start_summary(&self) -> super::SummaryFuture {
+        super::SummaryFuture::Ready(Batch::start_summary(self))
     }
     fn start_output(&self) -> Option<ToolOutput> {
         let entries = self

--- a/maki-agent/src/tools/code_execution.rs
+++ b/maki-agent/src/tools/code_execution.rs
@@ -152,8 +152,8 @@ super::impl_tool!(
 );
 
 impl super::ToolInvocation for CodeExecution {
-    fn start_summary(&self) -> String {
-        CodeExecution::start_summary(self)
+    fn start_summary(&self) -> super::SummaryFuture {
+        super::SummaryFuture::Ready(CodeExecution::start_summary(self))
     }
     fn start_input(&self) -> Option<ToolInput> {
         Some(ToolInput::Script {

--- a/maki-agent/src/tools/edit.rs
+++ b/maki-agent/src/tools/edit.rs
@@ -69,8 +69,8 @@ super::impl_tool!(
 );
 
 impl super::ToolInvocation for Edit {
-    fn start_summary(&self) -> String {
-        Edit::start_summary(self)
+    fn start_summary(&self) -> super::SummaryFuture {
+        super::SummaryFuture::Ready(Edit::start_summary(self))
     }
     fn mutable_path(&self) -> Option<&Path> {
         Some(Path::new(&self.path))

--- a/maki-agent/src/tools/find_symbol.rs
+++ b/maki-agent/src/tools/find_symbol.rs
@@ -91,8 +91,8 @@ impl FindSymbol {
 super::impl_tool!(FindSymbol);
 
 impl super::ToolInvocation for FindSymbol {
-    fn start_summary(&self) -> String {
-        FindSymbol::start_summary(self)
+    fn start_summary(&self) -> super::SummaryFuture {
+        super::SummaryFuture::Ready(FindSymbol::start_summary(self))
     }
     fn execute<'a>(self: Box<Self>, ctx: &'a super::ToolContext) -> super::ExecFuture<'a> {
         Box::pin(async move { FindSymbol::execute(&self, ctx).await })

--- a/maki-agent/src/tools/glob.rs
+++ b/maki-agent/src/tools/glob.rs
@@ -58,13 +58,13 @@ impl Glob {
 super::impl_tool!(Glob);
 
 impl super::ToolInvocation for Glob {
-    fn start_summary(&self) -> String {
+    fn start_summary(&self) -> super::SummaryFuture {
         let mut s = self.pattern.clone();
         if let Some(dir) = &self.path {
             s.push_str(" in ");
             s.push_str(&relative_path(dir));
         }
-        s
+        super::SummaryFuture::Ready(s)
     }
     fn execute<'a>(self: Box<Self>, ctx: &'a super::ToolContext) -> super::ExecFuture<'a> {
         Box::pin(async move { Glob::execute(&self, ctx).await })
@@ -84,6 +84,6 @@ mod tests {
             pattern: pattern.into(),
             path: path.map(Into::into),
         };
-        assert_eq!(g.start_summary(), expected);
+        assert_eq!(g.start_summary().into_ready(), expected);
     }
 }

--- a/maki-agent/src/tools/grep.rs
+++ b/maki-agent/src/tools/grep.rs
@@ -173,8 +173,8 @@ impl Grep {
 super::impl_tool!(Grep);
 
 impl super::ToolInvocation for Grep {
-    fn start_summary(&self) -> String {
-        Grep::start_summary(self)
+    fn start_summary(&self) -> super::SummaryFuture {
+        super::SummaryFuture::Ready(Grep::start_summary(self))
     }
     fn execute<'a>(self: Box<Self>, ctx: &'a super::ToolContext) -> super::ExecFuture<'a> {
         Box::pin(async move { Grep::execute(&self, ctx).await })

--- a/maki-agent/src/tools/index.rs
+++ b/maki-agent/src/tools/index.rs
@@ -53,8 +53,8 @@ super::impl_tool!(
 );
 
 impl super::ToolInvocation for Index {
-    fn start_summary(&self) -> String {
-        Index::start_summary(self)
+    fn start_summary(&self) -> super::SummaryFuture {
+        super::SummaryFuture::Ready(Index::start_summary(self))
     }
     fn execute<'a>(self: Box<Self>, ctx: &'a super::ToolContext) -> super::ExecFuture<'a> {
         Box::pin(async move { Index::execute(&self, ctx).await })

--- a/maki-agent/src/tools/memory.rs
+++ b/maki-agent/src/tools/memory.rs
@@ -53,8 +53,8 @@ super::impl_tool!(
 );
 
 impl super::ToolInvocation for Memory {
-    fn start_summary(&self) -> String {
-        Memory::start_summary(self)
+    fn start_summary(&self) -> super::SummaryFuture {
+        super::SummaryFuture::Ready(Memory::start_summary(self))
     }
     fn execute<'a>(self: Box<Self>, ctx: &'a super::ToolContext) -> super::ExecFuture<'a> {
         Box::pin(async move { Memory::execute(&self, ctx).await })

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -31,8 +31,8 @@ mod write;
 
 pub use file_tracker::FileReadTracker;
 pub use registry::{
-    ExecFuture, Native, ParseError, RegisteredTool, RegistryError, Tool, ToolAudience,
-    ToolInvocation, ToolRegistry, ToolSource,
+    ExecFuture, Native, ParseError, RegisteredTool, RegistryError, SummaryFuture, Tool,
+    ToolAudience, ToolInvocation, ToolRegistry, ToolSource,
 };
 
 use std::collections::HashSet;

--- a/maki-agent/src/tools/multiedit.rs
+++ b/maki-agent/src/tools/multiedit.rs
@@ -101,8 +101,8 @@ super::impl_tool!(
 );
 
 impl super::ToolInvocation for MultiEdit {
-    fn start_summary(&self) -> String {
-        MultiEdit::start_summary(self)
+    fn start_summary(&self) -> super::SummaryFuture {
+        super::SummaryFuture::Ready(MultiEdit::start_summary(self))
     }
     fn start_annotation(&self) -> Option<String> {
         Some(self.edit_count_label())

--- a/maki-agent/src/tools/question.rs
+++ b/maki-agent/src/tools/question.rs
@@ -53,8 +53,8 @@ impl Question {
 super::impl_tool!(Question, audience = super::ToolAudience::MAIN);
 
 impl super::ToolInvocation for Question {
-    fn start_summary(&self) -> String {
-        Question::start_summary(self)
+    fn start_summary(&self) -> super::SummaryFuture {
+        super::SummaryFuture::Ready(Question::start_summary(self))
     }
     fn execute<'a>(self: Box<Self>, ctx: &'a super::ToolContext) -> super::ExecFuture<'a> {
         Box::pin(async move { Question::execute(&self, ctx).await })

--- a/maki-agent/src/tools/read.rs
+++ b/maki-agent/src/tools/read.rs
@@ -144,8 +144,8 @@ impl Read {
 super::impl_tool!(Read);
 
 impl super::ToolInvocation for Read {
-    fn start_summary(&self) -> String {
-        Read::start_summary(self)
+    fn start_summary(&self) -> super::SummaryFuture {
+        super::SummaryFuture::Ready(Read::start_summary(self))
     }
     fn execute<'a>(self: Box<Self>, ctx: &'a super::ToolContext) -> super::ExecFuture<'a> {
         Box::pin(async move { Read::execute(&self, ctx).await })

--- a/maki-agent/src/tools/registry.rs
+++ b/maki-agent/src/tools/registry.rs
@@ -6,6 +6,7 @@ use std::future::Future;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::{Arc, LazyLock};
+use std::task::{Context, Poll};
 
 use arc_swap::ArcSwap;
 use bitflags::bitflags;
@@ -55,11 +56,39 @@ pub type ParseError = super::schema::ToolInputError;
 
 pub type ExecFuture<'a> = Pin<Box<dyn Future<Output = Result<ToolOutput, String>> + Send + 'a>>;
 
+pub enum SummaryFuture {
+    Ready(String),
+    Pending(Pin<Box<dyn Future<Output = String> + Send>>),
+}
+
+impl SummaryFuture {
+    pub fn into_ready(self) -> String {
+        match self {
+            Self::Ready(s) => s,
+            Self::Pending(_) => {
+                debug_assert!(false, "into_ready() on Pending SummaryFuture");
+                String::new()
+            }
+        }
+    }
+}
+
+impl Future for SummaryFuture {
+    type Output = String;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<String> {
+        match self.get_mut() {
+            Self::Ready(s) => Poll::Ready(std::mem::take(s)),
+            Self::Pending(fut) => fut.as_mut().poll(cx),
+        }
+    }
+}
+
 /// Holds the parsed input so start-event and `execute` share one parse pass.
 /// `permission_scope` and `mutable_path` belong here because only the parsed
 /// call knows which file it will touch.
 pub trait ToolInvocation: Send + Sync {
-    fn start_summary(&self) -> String;
+    fn start_summary(&self) -> SummaryFuture;
     fn start_annotation(&self) -> Option<String> {
         None
     }
@@ -453,8 +482,8 @@ mod tests {
     struct MockInvocation;
 
     impl ToolInvocation for MockInvocation {
-        fn start_summary(&self) -> String {
-            "mock".into()
+        fn start_summary(&self) -> SummaryFuture {
+            SummaryFuture::Ready("mock".into())
         }
         fn execute<'a>(self: Box<Self>, _ctx: &'a super::ToolContext) -> ExecFuture<'a> {
             Box::pin(async { Ok(ToolOutput::Plain(String::new())) })

--- a/maki-agent/src/tools/schema.rs
+++ b/maki-agent/src/tools/schema.rs
@@ -219,23 +219,6 @@ pub fn try_from_json(v: &Value) -> Result<&'static ParamSchema, String> {
     Ok(Box::leak(Box::new(schema)))
 }
 
-/// Pulls property names marked `"summary": true` out of a JSON schema.
-/// Leaks like `try_from_json` so the result is `&'static`.
-pub fn extract_summary_keys(v: &Value) -> &'static [&'static str] {
-    let Some(props) = v.get("properties").and_then(|p| p.as_object()) else {
-        return &[];
-    };
-    let keys: Vec<&'static str> = props
-        .iter()
-        .filter(|(_, sub)| sub.get("summary").and_then(|v| v.as_bool()) == Some(true))
-        .map(|(name, _)| -> &'static str { Box::leak(name.clone().into_boxed_str()) })
-        .collect();
-    if keys.is_empty() {
-        return &[];
-    }
-    Box::leak(keys.into_boxed_slice())
-}
-
 #[derive(Debug, Clone)]
 enum PathSeg {
     Field(&'static str),

--- a/maki-agent/src/tools/skill.rs
+++ b/maki-agent/src/tools/skill.rs
@@ -43,8 +43,8 @@ super::impl_tool!(
 );
 
 impl super::ToolInvocation for SkillTool {
-    fn start_summary(&self) -> String {
-        SkillTool::start_summary(self)
+    fn start_summary(&self) -> super::SummaryFuture {
+        super::SummaryFuture::Ready(SkillTool::start_summary(self))
     }
     fn execute<'a>(self: Box<Self>, ctx: &'a super::ToolContext) -> super::ExecFuture<'a> {
         Box::pin(async move { SkillTool::execute(&self, ctx).await })

--- a/maki-agent/src/tools/task.rs
+++ b/maki-agent/src/tools/task.rs
@@ -209,8 +209,8 @@ impl Task {
 super::impl_tool!(Task, audience = super::ToolAudience::MAIN);
 
 impl super::ToolInvocation for Task {
-    fn start_summary(&self) -> String {
-        Task::start_summary(self)
+    fn start_summary(&self) -> super::SummaryFuture {
+        super::SummaryFuture::Ready(Task::start_summary(self))
     }
     fn permission_scope(&self) -> Option<String> {
         Some(format!("task:{}", self.description))

--- a/maki-agent/src/tools/todowrite.rs
+++ b/maki-agent/src/tools/todowrite.rs
@@ -23,8 +23,8 @@ impl TodoWrite {
 super::impl_tool!(TodoWrite, audience = super::ToolAudience::MAIN);
 
 impl super::ToolInvocation for TodoWrite {
-    fn start_summary(&self) -> String {
-        format!("{} todos", self.todos.len())
+    fn start_summary(&self) -> super::SummaryFuture {
+        super::SummaryFuture::Ready(format!("{} todos", self.todos.len()))
     }
     fn execute<'a>(self: Box<Self>, ctx: &'a super::ToolContext) -> super::ExecFuture<'a> {
         Box::pin(async move { TodoWrite::execute(&self, ctx).await })

--- a/maki-agent/src/tools/webfetch.rs
+++ b/maki-agent/src/tools/webfetch.rs
@@ -162,8 +162,8 @@ impl WebFetch {
 super::impl_tool!(WebFetch);
 
 impl super::ToolInvocation for WebFetch {
-    fn start_summary(&self) -> String {
-        WebFetch::start_summary(self)
+    fn start_summary(&self) -> super::SummaryFuture {
+        super::SummaryFuture::Ready(WebFetch::start_summary(self))
     }
     fn permission_scope(&self) -> Option<String> {
         Some(self.url.clone())

--- a/maki-agent/src/tools/websearch.rs
+++ b/maki-agent/src/tools/websearch.rs
@@ -112,8 +112,8 @@ super::impl_tool!(
 );
 
 impl super::ToolInvocation for WebSearch {
-    fn start_summary(&self) -> String {
-        WebSearch::start_summary(self)
+    fn start_summary(&self) -> super::SummaryFuture {
+        super::SummaryFuture::Ready(WebSearch::start_summary(self))
     }
     fn permission_scope(&self) -> Option<String> {
         Some(self.query.clone())

--- a/maki-agent/src/tools/write.rs
+++ b/maki-agent/src/tools/write.rs
@@ -67,8 +67,8 @@ super::impl_tool!(
 );
 
 impl super::ToolInvocation for Write {
-    fn start_summary(&self) -> String {
-        Write::start_summary(self)
+    fn start_summary(&self) -> super::SummaryFuture {
+        super::SummaryFuture::Ready(Write::start_summary(self))
     }
     fn start_output(&self) -> Option<ToolOutput> {
         let path = super::resolve_path(&self.path).ok()?;

--- a/maki-lua/Cargo.toml
+++ b/maki-lua/Cargo.toml
@@ -21,6 +21,7 @@ tree-sitter = { workspace = true }
 regex = { workspace = true }
 maki-code-index = { workspace = true }
 include_dir = { workspace = true }
+dirs = { workspace = true }
 
 [dev-dependencies]
 maki-agent = { workspace = true }

--- a/maki-lua/src/api/AGENTS.md
+++ b/maki-lua/src/api/AGENTS.md
@@ -1,0 +1,2 @@
+Mirror Neovim's Lua API namespaces (maki.uv = vim.uv, maki.fs = vim.fs, maki.treesitter = vim.treesitter).
+Keep function signatures identical so plugins can be copy-pasted between Neovim and maki.

--- a/maki-lua/src/api/fs.rs
+++ b/maki-lua/src/api/fs.rs
@@ -6,6 +6,37 @@ use std::sync::Arc;
 use mlua::{Buffer, Lua, Result as LuaResult, Table};
 
 const SANDBOX_ERR: &str = "path outside sandbox";
+const NON_UTF8: &str = "non-utf8 path";
+
+fn expand_tilde(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    } else if path == "~" {
+        if let Some(home) = dirs::home_dir() {
+            return home;
+        }
+    }
+    PathBuf::from(path)
+}
+
+fn make_absolute(path: &str) -> LuaResult<PathBuf> {
+    let p = expand_tilde(path);
+    if p.is_absolute() {
+        Ok(p)
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(&p))
+            .map_err(|e| mlua::Error::runtime(format!("cannot resolve cwd: {e}")))
+    }
+}
+
+fn path_to_string(p: &Path) -> LuaResult<String> {
+    p.to_str()
+        .map(|s| s.to_owned())
+        .ok_or_else(|| mlua::Error::runtime(NON_UTF8))
+}
 
 /// Canonicalize the deepest existing ancestor, then re-append the rest lexically.
 /// This way plugins can write to paths that don't exist yet, but symlink escapes
@@ -108,6 +139,155 @@ pub(crate) fn create_fs_table(lua: &Lua, roots: Arc<[PathBuf]>) -> LuaResult<Tab
         })?,
     )?;
 
+    // vim.fs-compatible path utilities
+
+    t.set(
+        "dirname",
+        lua.create_function(|_, file: String| {
+            Ok(Path::new(&file)
+                .parent()
+                .and_then(|p| p.to_str())
+                .map(|s| s.to_owned()))
+        })?,
+    )?;
+
+    t.set(
+        "basename",
+        lua.create_function(|_, file: String| {
+            Ok(Path::new(&file)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(|s| s.to_owned()))
+        })?,
+    )?;
+
+    t.set(
+        "joinpath",
+        lua.create_function(|_, parts: mlua::Variadic<String>| {
+            let mut buf = PathBuf::new();
+            for part in parts.iter() {
+                buf.push(part);
+            }
+            path_to_string(&buf)
+        })?,
+    )?;
+
+    t.set(
+        "normalize",
+        lua.create_function(|_, path: String| {
+            let abs = make_absolute(&path)?;
+            let mut components = Vec::new();
+            for comp in abs.components() {
+                match comp {
+                    Component::ParentDir => {
+                        components.pop();
+                    }
+                    Component::CurDir => {}
+                    _ => components.push(comp),
+                }
+            }
+            let result: PathBuf = components.iter().collect();
+            path_to_string(&result)
+        })?,
+    )?;
+
+    t.set(
+        "abspath",
+        lua.create_function(|_, path: String| path_to_string(&make_absolute(&path)?))?,
+    )?;
+
+    t.set(
+        "parents",
+        lua.create_function(|lua, start: String| {
+            let p = Path::new(&start);
+            let tbl = lua.create_table()?;
+            let mut i = 1;
+            let mut current = p.parent();
+            while let Some(parent) = current {
+                if let Some(s) = parent.to_str() {
+                    tbl.set(i, s)?;
+                    i += 1;
+                }
+                current = parent.parent();
+            }
+            Ok(tbl)
+        })?,
+    )?;
+
+    t.set(
+        "root",
+        lua.create_function(|_, (source, marker): (String, mlua::Value)| {
+            let markers: Vec<String> = match marker {
+                mlua::Value::String(s) => vec![s.to_str()?.to_owned()],
+                mlua::Value::Table(t) => {
+                    let mut v = Vec::new();
+                    for pair in t.sequence_values::<String>() {
+                        v.push(pair?);
+                    }
+                    v
+                }
+                _ => {
+                    return Err(mlua::Error::runtime(
+                        "fs.root: marker must be a string or list of strings",
+                    ));
+                }
+            };
+
+            let start = Path::new(&source);
+            let start = if start.is_file() || !start.exists() {
+                start.parent().unwrap_or(start)
+            } else {
+                start
+            };
+
+            let mut dir = make_absolute(start.to_str().unwrap_or_default())?;
+
+            loop {
+                for m in &markers {
+                    if dir.join(m).exists() {
+                        return Ok(Some(path_to_string(&dir)?));
+                    }
+                }
+                if !dir.pop() {
+                    return Ok(None);
+                }
+            }
+        })?,
+    )?;
+
+    t.set(
+        "relpath",
+        lua.create_function(|_, (base, target): (String, String)| {
+            let base_comps: Vec<_> = Path::new(&base).components().collect();
+            let target_comps: Vec<_> = Path::new(&target).components().collect();
+
+            let common = base_comps
+                .iter()
+                .zip(target_comps.iter())
+                .take_while(|(a, b)| a == b)
+                .count();
+
+            let mut result = PathBuf::new();
+            for _ in common..base_comps.len() {
+                result.push("..");
+            }
+            for comp in &target_comps[common..] {
+                result.push(comp);
+            }
+            path_to_string(&result)
+        })?,
+    )?;
+
+    t.set(
+        "ext",
+        lua.create_function(|_, file: String| {
+            Ok(Path::new(&file)
+                .extension()
+                .and_then(|e| e.to_str())
+                .map(|s| s.to_owned()))
+        })?,
+    )?;
+
     Ok(t)
 }
 
@@ -116,6 +296,7 @@ mod tests {
     use super::*;
     use mlua::Lua;
     use tempfile::TempDir;
+    use test_case::test_case;
 
     fn roots(dirs: &[&Path]) -> Arc<[PathBuf]> {
         dirs.iter()
@@ -125,48 +306,45 @@ mod tests {
     }
 
     #[test]
-    fn fs_read_within_cwd_ok() {
+    fn read_within_sandbox_ok() {
         let tmp = TempDir::new().unwrap();
         let file = tmp.path().join("hello.txt");
         std::fs::write(&file, "world").unwrap();
 
         let lua = Lua::new();
-        let allowed = roots(&[tmp.path()]);
-        let tbl = create_fs_table(&lua, allowed).unwrap();
+        let tbl = create_fs_table(&lua, roots(&[tmp.path()])).unwrap();
         let read: mlua::Function = tbl.get("read").unwrap();
         let result: String = read.call(file.to_str().unwrap()).unwrap();
         assert_eq!(result, "world");
     }
 
-    #[test]
-    fn fs_read_outside_cwd_denied() {
+    #[test_case("read"     ; "read")]
+    #[test_case("read_bytes" ; "read_bytes")]
+    #[test_case("metadata" ; "metadata")]
+    fn sandbox_denies_outside_path(fn_name: &str) {
         let tmp = TempDir::new().unwrap();
-
         let lua = Lua::new();
-        let allowed = roots(&[tmp.path()]);
-        let tbl = create_fs_table(&lua, allowed).unwrap();
-        let read: mlua::Function = tbl.get("read").unwrap();
-        let err = read
-            .call::<String>("/etc/hostname")
+        let tbl = create_fs_table(&lua, roots(&[tmp.path()])).unwrap();
+        let f: mlua::Function = tbl.get(fn_name).unwrap();
+        let err = f
+            .call::<mlua::Value>("/etc/hostname")
             .unwrap_err()
             .to_string();
         assert!(
             err.contains(SANDBOX_ERR),
-            "expected sandbox error, got: {err}"
+            "{fn_name}: expected sandbox error, got: {err}"
         );
     }
 
     #[cfg(unix)]
     #[test]
-    fn fs_read_symlink_escape_denied() {
+    fn symlink_escape_denied() {
         let tmp = TempDir::new().unwrap();
         let link = tmp.path().join("escape");
         std::os::unix::fs::symlink("/etc/hostname", &link).unwrap();
 
         let lua = Lua::new();
-        let allowed = roots(&[tmp.path()]);
-        let tbl = create_fs_table(&lua, allowed).unwrap();
-
+        let tbl = create_fs_table(&lua, roots(&[tmp.path()])).unwrap();
         let read: mlua::Function = tbl.get("read").unwrap();
         let err = read
             .call::<String>(link.to_str().unwrap())
@@ -175,42 +353,6 @@ mod tests {
         assert!(
             err.contains(SANDBOX_ERR),
             "expected sandbox error for symlink escape, got: {err}"
-        );
-    }
-
-    #[test]
-    fn fs_read_bytes_sandbox_check() {
-        let tmp = TempDir::new().unwrap();
-
-        let lua = Lua::new();
-        let allowed = roots(&[tmp.path()]);
-        let tbl = create_fs_table(&lua, allowed).unwrap();
-        let read_bytes: mlua::Function = tbl.get("read_bytes").unwrap();
-        let err = read_bytes
-            .call::<Buffer>("/etc/hostname")
-            .unwrap_err()
-            .to_string();
-        assert!(
-            err.contains(SANDBOX_ERR),
-            "expected sandbox error, got: {err}"
-        );
-    }
-
-    #[test]
-    fn fs_metadata_sandbox_check() {
-        let tmp = TempDir::new().unwrap();
-
-        let lua = Lua::new();
-        let allowed = roots(&[tmp.path()]);
-        let tbl = create_fs_table(&lua, allowed).unwrap();
-        let metadata: mlua::Function = tbl.get("metadata").unwrap();
-        let err = metadata
-            .call::<Table>("/etc/hostname")
-            .unwrap_err()
-            .to_string();
-        assert!(
-            err.contains(SANDBOX_ERR),
-            "expected sandbox error, got: {err}"
         );
     }
 }

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod fs;
 pub(crate) mod log;
 pub(crate) mod tool;
 pub(crate) mod treesitter;
+pub(crate) mod uv;
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -23,6 +24,7 @@ pub(crate) fn create_maki_global(
     maki.set("fs", fs::create_fs_table(lua, fs_roots)?)?;
     maki.set("log", log::create_log_table(lua, plugin)?)?;
     maki.set("treesitter", treesitter::create_treesitter_table(lua)?)?;
+    maki.set("uv", uv::create_uv_table(lua)?)?;
 
     Ok(maki)
 }

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -5,11 +5,10 @@ use std::time::Duration;
 use flume::Sender;
 use maki_agent::ToolOutput;
 use maki_agent::tools::Tool;
-use maki_agent::tools::schema::{
-    ParamSchema, extract_summary_keys, to_json_schema, try_from_json, validate,
-};
+use maki_agent::tools::schema::{ParamSchema, to_json_schema, try_from_json, validate};
 use maki_agent::tools::{
-    Deadline, DescriptionContext, ExecFuture, ParseError, ToolAudience, ToolContext, ToolInvocation,
+    Deadline, DescriptionContext, ExecFuture, ParseError, SummaryFuture, ToolAudience, ToolContext,
+    ToolInvocation,
 };
 use mlua::{
     Function, Lua, LuaSerdeExt, RegistryKey, Result as LuaResult, Table, Value as LuaValue,
@@ -30,7 +29,7 @@ pub(crate) struct PendingTool {
     pub(crate) schema: &'static ParamSchema,
     pub(crate) audience: ToolAudience,
     pub(crate) handler_key: RegistryKey,
-    pub(crate) summary_keys: &'static [&'static str],
+    pub(crate) summary_key: Option<RegistryKey>,
 }
 
 pub(crate) type PendingTools = Arc<Mutex<Vec<PendingTool>>>;
@@ -42,7 +41,7 @@ pub(crate) struct LuaTool {
     pub(crate) audience: ToolAudience,
     pub(crate) tx: Sender<Request>,
     pub(crate) plugin: Arc<str>,
-    pub(crate) summary_keys: &'static [&'static str],
+    pub(crate) has_summary_fn: bool,
 }
 
 impl Tool for LuaTool {
@@ -67,7 +66,7 @@ impl Tool for LuaTool {
         Ok(Box::new(LuaToolInvocation {
             tool: Arc::clone(&self.name),
             plugin: Arc::clone(&self.plugin),
-            summary_keys: self.summary_keys,
+            has_summary_fn: self.has_summary_fn,
             input: validated,
             tx: self.tx.clone(),
         }))
@@ -77,23 +76,38 @@ impl Tool for LuaTool {
 struct LuaToolInvocation {
     tool: Arc<str>,
     plugin: Arc<str>,
-    summary_keys: &'static [&'static str],
+    has_summary_fn: bool,
     input: Value,
     tx: Sender<Request>,
 }
 
 impl ToolInvocation for LuaToolInvocation {
-    fn start_summary(&self) -> String {
-        let parts: Vec<&str> = self
-            .summary_keys
-            .iter()
-            .filter_map(|k| self.input.get(*k).and_then(Value::as_str))
-            .collect();
-        if parts.is_empty() {
-            self.tool.to_string()
-        } else {
-            parts.join(" ")
+    fn start_summary(&self) -> SummaryFuture {
+        if !self.has_summary_fn {
+            return SummaryFuture::Ready(self.tool.to_string());
         }
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        let tool = Arc::clone(&self.tool);
+        let plugin = Arc::clone(&self.plugin);
+        let input = self.input.clone();
+        let tx = self.tx.clone();
+        SummaryFuture::Pending(Box::pin(async move {
+            let sent = tx
+                .send_async(Request::ComputeSummary {
+                    plugin: Arc::clone(&plugin),
+                    tool: Arc::clone(&tool),
+                    input,
+                    reply: reply_tx,
+                })
+                .await;
+            if sent.is_err() {
+                return tool.to_string();
+            }
+            reply_rx
+                .recv_async()
+                .await
+                .unwrap_or_else(|_| tool.to_string())
+        }))
     }
 
     fn execute<'a>(self: Box<Self>, ctx: &'a ToolContext) -> ExecFuture<'a> {
@@ -224,9 +238,12 @@ fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> Lua
 
     let schema_val: Value = lua.from_value(schema_table)?;
     let param_schema = try_from_json(&schema_val).map_err(mlua::Error::runtime)?;
-    let summary_keys = extract_summary_keys(&schema_val);
+    let summary_fn: Option<Function> = spec.get("summary").ok();
     let audience = parse_audience(audiences)?;
     let handler_key: RegistryKey = lua.create_registry_value(handler)?;
+    let summary_key = summary_fn
+        .map(|f| lua.create_registry_value(f))
+        .transpose()?;
     let name: Arc<str> = Arc::from(name.as_str());
 
     pending
@@ -238,7 +255,7 @@ fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> Lua
             schema: param_schema,
             audience,
             handler_key,
-            summary_keys,
+            summary_key,
         });
 
     Ok(())
@@ -287,65 +304,20 @@ mod tests {
         assert_eq!(is_valid_tool_name(name), expected);
     }
 
-    fn invocation(summary_keys: &'static [&'static str], input: Value) -> LuaToolInvocation {
+    fn invocation(input: Value) -> LuaToolInvocation {
         let (tx, _rx) = flume::unbounded();
         LuaToolInvocation {
             tool: Arc::from("test_tool"),
             plugin: Arc::from("test"),
-            summary_keys,
+            has_summary_fn: false,
             input,
             tx,
         }
     }
 
-    #[test_case::test_case(&["path"], serde_json::json!({"path": "/home/x/foo.rs"}), "/home/x/foo.rs" ; "extracts_declared_key")]
-    #[test_case::test_case(&["path"], serde_json::json!({"count": 5}), "test_tool" ; "key_missing_falls_back_to_tool_name")]
-    #[test_case::test_case(&["path"], serde_json::json!({"path": 42}), "test_tool" ; "non_string_value_falls_back_to_tool_name")]
-    #[test_case::test_case(&[], serde_json::json!({"path": "/home/x/foo.rs"}), "test_tool" ; "no_keys_declared")]
-    #[test_case::test_case(&["pattern", "path"], serde_json::json!({"pattern": "foo", "path": "/src"}), "foo /src" ; "multiple_keys_joined")]
-    #[test_case::test_case(&["pattern", "path"], serde_json::json!({"pattern": "foo"}), "foo" ; "multiple_keys_partial")]
-    fn start_summary_cases(summary_keys: &'static [&'static str], input: Value, expected: &str) {
-        let inv = invocation(summary_keys, input);
-        assert_eq!(inv.start_summary(), expected);
-    }
-
     #[test]
-    fn summary_extracted_from_schema() {
-        let json = serde_json::json!({
-            "type": "object",
-            "properties": {
-                "path": { "type": "string", "summary": true },
-                "count": { "type": "integer" }
-            },
-            "required": ["path"]
-        });
-        assert_eq!(extract_summary_keys(&json), &["path"]);
-    }
-
-    #[test]
-    fn summary_multiple_from_schema() {
-        let json = serde_json::json!({
-            "type": "object",
-            "properties": {
-                "pattern": { "type": "string", "summary": true },
-                "path": { "type": "string", "summary": true },
-                "limit": { "type": "integer" }
-            },
-            "required": ["pattern"]
-        });
-        let keys = extract_summary_keys(&json);
-        assert!(keys.contains(&"pattern"));
-        assert!(keys.contains(&"path"));
-        assert_eq!(keys.len(), 2);
-    }
-
-    #[test]
-    fn no_summary_in_schema() {
-        let json = serde_json::json!({
-            "type": "object",
-            "properties": { "path": { "type": "string" } },
-            "required": ["path"]
-        });
-        assert!(extract_summary_keys(&json).is_empty());
+    fn no_summary_fn_returns_tool_name() {
+        let inv = invocation(serde_json::json!({"path": "/home/x/foo.rs"}));
+        assert_eq!(inv.start_summary().into_ready(), "test_tool");
     }
 }

--- a/maki-lua/src/api/uv.rs
+++ b/maki-lua/src/api/uv.rs
@@ -1,0 +1,23 @@
+use mlua::{Lua, Result as LuaResult, Table};
+
+pub(crate) fn create_uv_table(lua: &Lua) -> LuaResult<Table> {
+    let t = lua.create_table()?;
+
+    t.set(
+        "cwd",
+        lua.create_function(|_, ()| {
+            Ok(std::env::current_dir()
+                .ok()
+                .and_then(|p| p.to_str().map(String::from)))
+        })?,
+    )?;
+
+    t.set(
+        "os_homedir",
+        lua.create_function(|_, ()| {
+            Ok(dirs::home_dir().and_then(|p| p.to_str().map(String::from)))
+        })?,
+    )?;
+
+    Ok(t)
+}

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -34,6 +34,12 @@ pub enum Request {
         deadline: Option<Instant>,
         reply: flume::Sender<ToolCallResult>,
     },
+    ComputeSummary {
+        plugin: Arc<str>,
+        tool: Arc<str>,
+        input: Value,
+        reply: flume::Sender<String>,
+    },
     ClearPlugin {
         plugin: Arc<str>,
         reply: flume::Sender<()>,
@@ -55,10 +61,15 @@ impl Drop for CallStateGuard<'_> {
     }
 }
 
+struct ToolKeys {
+    handler: RegistryKey,
+    summary: Option<RegistryKey>,
+}
+
 struct LuaRuntime {
     lua: Lua,
     pending: PendingTools,
-    plugins: HashMap<Arc<str>, HashMap<Arc<str>, RegistryKey>>,
+    plugins: HashMap<Arc<str>, HashMap<Arc<str>, ToolKeys>>,
     registry: Arc<ToolRegistry>,
     tx: flume::Sender<Request>,
     cwd: PathBuf,
@@ -138,9 +149,14 @@ impl LuaRuntime {
 
     fn drop_plugin_keys(&mut self, name: &str) {
         if let Some(keys) = self.plugins.remove(name) {
-            for (_, key) in keys {
-                if let Err(e) = self.lua.remove_registry_value(key) {
+            for (_, tk) in keys {
+                if let Err(e) = self.lua.remove_registry_value(tk.handler) {
                     tracing::warn!(plugin = name, error = %e, "failed to drop lua handler key");
+                }
+                if let Some(sk) = tk.summary {
+                    if let Err(e) = self.lua.remove_registry_value(sk) {
+                        tracing::warn!(plugin = name, error = %e, "failed to drop lua summary key");
+                    }
                 }
             }
         }
@@ -158,6 +174,11 @@ impl LuaRuntime {
         for t in tools {
             if let Err(e) = self.lua.remove_registry_value(t.handler_key) {
                 tracing::warn!(error = %e, "failed to drop lua handler key on rollback");
+            }
+            if let Some(sk) = t.summary_key {
+                if let Err(e) = self.lua.remove_registry_value(sk) {
+                    tracing::warn!(error = %e, "failed to drop lua summary key on rollback");
+                }
             }
         }
     }
@@ -318,7 +339,7 @@ impl LuaRuntime {
                     audience: t.audience,
                     tx: self.tx.clone(),
                     plugin: Arc::clone(&name),
-                    summary_keys: t.summary_keys,
+                    has_summary_fn: t.summary_key.is_some(),
                 });
                 (
                     tool,
@@ -341,9 +362,17 @@ impl LuaRuntime {
 
         self.drop_plugin_keys(&name);
 
-        let keys: HashMap<Arc<str>, RegistryKey> = pending
+        let keys: HashMap<Arc<str>, ToolKeys> = pending
             .into_iter()
-            .map(|t| (t.name, t.handler_key))
+            .map(|t| {
+                (
+                    t.name,
+                    ToolKeys {
+                        handler: t.handler_key,
+                        summary: t.summary_key,
+                    },
+                )
+            })
             .collect();
         self.plugins.insert(name, keys);
 
@@ -368,13 +397,13 @@ impl LuaRuntime {
             .get(plugin)
             .ok_or_else(|| format!("plugin not loaded: {plugin}"))?;
 
-        let handler_key = keys
+        let tool_keys = keys
             .get(tool)
             .ok_or_else(|| format!("tool not found: {tool}"))?;
 
         let handler: Function = self
             .lua
-            .registry_value(handler_key)
+            .registry_value(&tool_keys.handler)
             .map_err(|e| e.to_string())?;
 
         if self.shutdown.load(Ordering::Acquire) {
@@ -400,6 +429,20 @@ impl LuaRuntime {
             Ok(val) => coerce_tool_result(&val),
             Err(e) => Err(e.to_string()),
         }
+    }
+
+    fn compute_summary(&self, plugin: &str, tool: &str, input: Value) -> String {
+        let result = (|| {
+            let tk = self.plugins.get(plugin)?.get(tool)?;
+            let key = tk.summary.as_ref()?;
+            let func = self.lua.registry_value::<Function>(key).ok()?;
+            let input_lua = self.lua.to_value(&input).ok()?;
+            match func.call::<LuaValue>(input_lua).ok()? {
+                LuaValue::String(s) => s.to_str().ok().map(|s| s.to_owned()),
+                _ => None,
+            }
+        })();
+        result.unwrap_or_else(|| tool.to_string())
     }
 }
 
@@ -463,6 +506,15 @@ pub fn spawn(
                     Request::ClearPlugin { plugin, reply } => {
                         rt.clear_plugin(&plugin);
                         let _ = reply.send(());
+                    }
+                    Request::ComputeSummary {
+                        plugin,
+                        tool,
+                        input,
+                        reply,
+                    } => {
+                        let res = rt.compute_summary(&plugin, &tool, input);
+                        let _ = reply.send(res);
                     }
                 }
             }

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -323,7 +323,7 @@ pub fn history_to_display(
                                 .and_then(|entry| entry.try_parse(input));
                             let summary = tool_call
                                 .as_deref()
-                                .map(|tc| tc.start_summary())
+                                .map(|tc| tc.start_summary().into_ready())
                                 .unwrap_or_else(|| name.clone());
                             let tool_input = tool_call.as_deref().and_then(|tc| tc.start_input());
                             let (status, result_text) = results

--- a/plugins/index/init.lua
+++ b/plugins/index/init.lua
@@ -1,5 +1,19 @@
 local indexer = require("indexer")
 
+local function normalize(p)
+  local cwd = maki.uv.cwd()
+  if cwd and p:sub(1, #cwd + 1) == cwd .. "/" then
+    local rel = p:sub(#cwd + 2)
+    return rel == "" and "." or rel
+  end
+  local home = maki.uv.os_homedir()
+  if home and p:sub(1, #home + 1) == home .. "/" then
+    local rel = p:sub(#home + 2)
+    return rel == "" and "~" or "~/" .. rel
+  end
+  return p
+end
+
 maki.api.register_tool({
   name = "index",
   description = [[
@@ -12,10 +26,13 @@ Return a compact overview of a source file: imports, type definitions, function 
   schema = {
     type = "object",
     properties = {
-      path = { type = "string", description = "Absolute path to the file", summary = true },
+      path = { type = "string", description = "Absolute path to the file" },
     },
     required = { "path" },
   },
+  summary = function(input)
+    return normalize(input.path)
+  end,
   handler = function(input, _)
     local path = input.path
     if not path then


### PR DESCRIPTION
Tool summaries used to be a 'summary=true' marker on schema properties that got string-joined at display time. Now plugins provide an actual summary function that runs on the Lua thread via a new ComputeSummary request. start_summary() returns a SummaryFuture that can be either ready (native tools) or pending (Lua tools that need the runtime). The index plugin uses this to show shortened paths (~/foo instead of /home/user/foo).

Added maki.uv (cwd, os_homedir) and vim.fs path helpers to maki.fs (dirname, basename, joinpath, normalize, abspath, parents, root, relpath, ext) so the Lua API matches neovim namespaces.