### PR TITLE
Unbreak macos keybindings

### DIFF
--- a/maki-docgen/src/gen_keybindings.rs
+++ b/maki-docgen/src/gen_keybindings.rs
@@ -121,7 +121,7 @@ fn write_inheritance(out: &mut String) {
 pub fn generate() -> String {
     let mut out = String::from(FRONTMATTER);
     out.push_str("\n\n# Keybindings\n\n");
-    out.push_str("On macOS, `Ctrl` maps to `Cmd` where it makes sense (run `/help` for exact keybindings).\n");
+    out.push_str("On macOS, some bindings use Option or Fn keys instead (run `/help` for exact keybindings).\n");
 
     for &ctx in MAIN_CONTEXTS {
         write_section(&mut out, ctx);

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -523,7 +523,7 @@ pub const KEYBINDS: &[Keybind] = &[
         platform: Platform::All,
     },
     Keybind {
-        label: KeyLabel::MacMulti(&["Ctrl+1/2/3"], &["Ctrl+1/2/3"]),
+        label: KeyLabel::Single("Alt+1/2/3"),
         description: "Set tier (strong/medium/weak)",
         context: KeybindContext::ModelPicker,
         platform: Platform::All,

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -4,11 +4,7 @@ use unicode_width::UnicodeWidthStr;
 
 macro_rules! mod_key {
     ($suffix:expr) => {
-        if cfg!(target_os = "macos") {
-            concat!("⌘", $suffix)
-        } else {
-            concat!("Ctrl+", $suffix)
-        }
+        concat!("Ctrl+", $suffix)
     };
 }
 
@@ -383,7 +379,7 @@ pub const KEYBINDS: &[Keybind] = &[
         platform: Platform::All,
     },
     Keybind {
-        label: KeyLabel::Alt(mod_key!("←"), mod_key!("→")),
+        label: KeyLabel::Alt("⌥←", "⌥→"),
         description: "Move word left / right",
         context: KeybindContext::Editing,
         platform: Platform::MacOnly,
@@ -407,7 +403,7 @@ pub const KEYBINDS: &[Keybind] = &[
         platform: Platform::MacOnly,
     },
     Keybind {
-        label: KeyLabel::Alt("⌘←", "⌘→"),
+        label: KeyLabel::Alt("Home", "End"),
         description: "Jump to start/end of line",
         context: KeybindContext::Editing,
         platform: Platform::MacOnly,
@@ -527,7 +523,7 @@ pub const KEYBINDS: &[Keybind] = &[
         platform: Platform::All,
     },
     Keybind {
-        label: KeyLabel::MacMulti(&["Ctrl+1/2/3"], &["⌘1/2/3"]),
+        label: KeyLabel::MacMulti(&["Ctrl+1/2/3"], &["Ctrl+1/2/3"]),
         description: "Set tier (strong/medium/weak)",
         context: KeybindContext::ModelPicker,
         platform: Platform::All,

--- a/maki-ui/src/components/model_picker.rs
+++ b/maki-ui/src/components/model_picker.rs
@@ -21,19 +21,19 @@ fn footer_line() -> Line<'static> {
     Line::from(vec![
         Span::styled("  Enter", t.keybind_key),
         Span::styled(" select", t.form_hint),
-        Span::styled("  Ctrl+1 ", t.keybind_key),
+        Span::styled("  Alt+1 ", t.keybind_key),
         Span::styled("(set strong)", t.form_hint),
         Span::styled(" / ", t.form_hint),
-        Span::styled("Ctrl+2 ", t.keybind_key),
+        Span::styled("Alt+2 ", t.keybind_key),
         Span::styled("(set medium)", t.form_hint),
         Span::styled(" / ", t.form_hint),
-        Span::styled("Ctrl+3 ", t.keybind_key),
+        Span::styled("Alt+3 ", t.keybind_key),
         Span::styled("(set weak)", t.form_hint),
     ])
 }
 
 fn tier_for_shortcut(key: KeyEvent) -> Option<ModelTier> {
-    if !key.modifiers.contains(KeyModifiers::CONTROL) {
+    if !key.modifiers.contains(KeyModifiers::ALT) {
         return None;
     }
     match key.code {
@@ -204,8 +204,8 @@ mod tests {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use test_case::test_case;
 
-    fn ctrl_key(code: KeyCode) -> KeyEvent {
-        KeyEvent::new(code, KeyModifiers::CONTROL)
+    fn alt_key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::ALT)
     }
 
     fn test_models() -> Arc<ArcSwapOption<Vec<String>>> {
@@ -309,14 +309,14 @@ mod tests {
         assert!(parse_model_entry("no-slash").is_none());
     }
 
-    // Regression: Ctrl+1/2/3 must work on every provider, not just Ollama.
-    #[test_case(KeyCode::Char('1'), ModelTier::Strong ; "ctrl_1_strong")]
-    #[test_case(KeyCode::Char('2'), ModelTier::Medium ; "ctrl_2_medium")]
-    #[test_case(KeyCode::Char('3'), ModelTier::Weak   ; "ctrl_3_weak")]
+    // Regression: Alt+1/2/3 must work on every provider, not just Ollama.
+    #[test_case(KeyCode::Char('1'), ModelTier::Strong ; "alt_1_strong")]
+    #[test_case(KeyCode::Char('2'), ModelTier::Medium ; "alt_2_medium")]
+    #[test_case(KeyCode::Char('3'), ModelTier::Weak   ; "alt_3_weak")]
     fn tier_shortcut_assigns_and_keeps_picker_open(code: KeyCode, want: ModelTier) {
         let mut p = ModelPicker::new(test_models());
         p.open("");
-        let action = p.handle_key(ctrl_key(code));
+        let action = p.handle_key(alt_key(code));
         assert!(
             matches!(&action, ModelPickerAction::AssignTier(s, t)
                 if s == "anthropic/claude-sonnet-4-20250514" && *t == want),

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -7,7 +7,7 @@ group = "Reference"
 
 # Keybindings
 
-On macOS, `Ctrl` maps to `Cmd` where it makes sense (run `/help` for exact keybindings).
+On macOS, some bindings use Option or Fn keys instead (run `/help` for exact keybindings).
 
 ## General
 
@@ -43,11 +43,11 @@ On macOS, `Ctrl` maps to `Cmd` where it makes sense (run `/help` for exact keybi
 
 | Key | Action |
 |-----|--------|
-| `Ctrl+←` / `Ctrl+→` | Move word left / right |
+| `⌥←` / `⌥→` | Move word left / right |
 | `Ctrl+Del` / `⌥Del` | Delete word forward |
 | `Ctrl+K` | Delete to end of line |
 | `Ctrl+A` | Jump to start of line |
-| `⌘←` / `⌘→` | Jump to start/end of line |
+| `Home` / `End` | Jump to start/end of line |
 
 ## While Streaming
 
@@ -82,7 +82,7 @@ Some pickers add extra bindings on top of the defaults:
 | Session Picker | `Ctrl+D` | Delete session |
 | Queue | `Enter` | Remove item |
 | Commands | `Tab` | Toggle mode |
-| Model Picker | `Ctrl+1/2/3` | Set tier (strong/medium/weak) |
+| Model Picker | `Alt+1/2/3` | Set tier (strong/medium/weak) |
 
 ## Context Inheritance
 


### PR DESCRIPTION
This morning I decided to go and test the keybindings on macos:
- cmd is not mapped, KeyModifiers::CONTROL is always used in the code. The documentation and help were wrong.
- some of the macos-only keybindings cannot work since the are os-intercepted by default.

As side-effect this makes generating the documentation work the same no matter the host os.