### PR TITLE
main.rs & providers: auto-detect synthetic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -466,6 +466,7 @@ const PROVIDER_PRIORITY: &[ProviderKind] = &[
     ProviderKind::OpenAi,
     ProviderKind::Zai,
     ProviderKind::ZaiCodingPlan,
+    ProviderKind::Synthetic,
 ];
 
 fn auto_detect_model() -> Option<Model> {


### PR DESCRIPTION
This a naive patch because I couldn't figure out how to start maki with my Synthetic's API key.