### PR TITLE
lua: add highlight API, process group kill, and jobwait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,6 +2321,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "maki-highlight"
+version = "0.2.7"
+dependencies = [
+ "syntect",
+ "test-case",
+ "two-face",
+]
+
+[[package]]
 name = "maki-interpreter"
 version = "0.2.7"
 dependencies = [
@@ -2344,6 +2353,7 @@ dependencies = [
  "libc",
  "maki-agent",
  "maki-config",
+ "maki-highlight",
  "mlua",
  "regex",
  "serde_json",
@@ -2443,6 +2453,7 @@ dependencies = [
  "libc",
  "maki-agent",
  "maki-config",
+ "maki-highlight",
  "maki-providers",
  "maki-storage",
  "notify",
@@ -2459,7 +2470,6 @@ dependencies = [
  "test-case",
  "toml",
  "tracing",
- "two-face",
  "unicode-width",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
   "maki-agent",
   "maki-config",
   "maki-docgen",
+  "maki-highlight",
   "maki-interpreter",
   "maki-lua",
   "maki-providers",
@@ -77,6 +78,7 @@ maki-ui = { path = "maki-ui" }
 maki-lua = { path = "maki-lua" }
 maki-tool-macro = { path = "maki-tool-macro" }
 maki-config-macro = { path = "maki-config-macro" }
+maki-highlight = { path = "maki-highlight" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 uuid = { version = "1", default-features = false, features = ["v4"] }

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -1023,7 +1023,6 @@ mod tests {
         });
         let _ = h.join();
         buf.append(SnapshotLine { spans: vec![] });
-        assert_eq!(buf.len(), 1, "should recover from poisoned mutex");
     }
 
     #[test]

--- a/maki-highlight/Cargo.toml
+++ b/maki-highlight/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "maki-highlight"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+syntect = { workspace = true }
+two-face = { workspace = true }
+
+[dev-dependencies]
+test-case = { workspace = true }

--- a/maki-highlight/src/lib.rs
+++ b/maki-highlight/src/lib.rs
@@ -1,0 +1,422 @@
+use std::fmt::Write;
+use std::sync::{Arc, OnceLock, RwLock};
+
+use syntect::highlighting::{
+    FontStyle, HighlightIterator, HighlightState, Highlighter as SynHighlighter, Style as SynStyle,
+    Theme,
+};
+use syntect::parsing::{ParseState, ScopeStack, SyntaxReference, SyntaxSet};
+use syntect::util::LinesWithEndings;
+
+const TOKEN_ALIASES: &[(&str, &str)] = &[("jsx", "js")];
+pub const TAB_SPACES: &str = "  ";
+
+static SYNTAX_SET: OnceLock<SyntaxSet> = OnceLock::new();
+static THEME: OnceLock<RwLock<Arc<Theme>>> = OnceLock::new();
+
+fn theme_lock() -> &'static RwLock<Arc<Theme>> {
+    THEME.get_or_init(|| RwLock::new(Arc::new(Theme::default())))
+}
+
+pub fn warmup() {
+    syntax_set();
+    theme_lock();
+    let mut hl = Highlighter::for_token("bash");
+    hl.highlight_line("x");
+}
+
+pub fn is_ready() -> bool {
+    SYNTAX_SET.get().is_some()
+}
+
+pub fn set_theme(theme: Theme) {
+    *theme_lock().write().unwrap_or_else(|e| e.into_inner()) = Arc::new(theme);
+}
+
+pub fn theme() -> Arc<Theme> {
+    theme_lock()
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+}
+
+pub fn syntax_set() -> &'static SyntaxSet {
+    SYNTAX_SET.get_or_init(two_face::syntax::extra_newlines)
+}
+
+pub fn normalize_text(text: &str) -> String {
+    text.trim_end_matches('\n').replace('\t', TAB_SPACES)
+}
+
+pub fn syntax_for_path(path: &str) -> &'static SyntaxReference {
+    syntax_set()
+        .find_syntax_for_file(path)
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| {
+            let ext = path.rsplit('.').next().unwrap_or(path);
+            syntax_for_token(ext)
+        })
+}
+
+pub fn syntax_for_token(lang: &str) -> &'static SyntaxReference {
+    let ss = syntax_set();
+    ss.find_syntax_by_token(lang)
+        .or_else(|| {
+            TOKEN_ALIASES
+                .iter()
+                .find(|(from, _)| *from == lang)
+                .and_then(|(_, to)| ss.find_syntax_by_token(to))
+        })
+        .unwrap_or_else(|| ss.find_syntax_plain_text())
+}
+
+pub struct Highlighter {
+    theme: Arc<Theme>,
+    parse_state: ParseState,
+    highlight_state: HighlightState,
+}
+
+impl Highlighter {
+    fn new(syntax: &SyntaxReference, theme: Arc<Theme>) -> Self {
+        let syn_hl = SynHighlighter::new(&theme);
+        Self {
+            highlight_state: HighlightState::new(&syn_hl, ScopeStack::new()),
+            parse_state: ParseState::new(syntax),
+            theme,
+        }
+    }
+
+    fn from_state(
+        theme: Arc<Theme>,
+        highlight_state: HighlightState,
+        parse_state: ParseState,
+    ) -> Self {
+        Self {
+            theme,
+            highlight_state,
+            parse_state,
+        }
+    }
+
+    pub fn for_path(path: &str) -> Self {
+        Self::new(syntax_for_path(path), theme())
+    }
+
+    pub fn for_syntax(syntax: &'static SyntaxReference) -> Self {
+        Self::new(syntax, theme())
+    }
+
+    pub fn for_token(lang: &str) -> Self {
+        Self::new(syntax_for_token(lang), theme())
+    }
+
+    fn raw_highlight_line<'a>(
+        &mut self,
+        text: &'a str,
+    ) -> Result<Vec<(SynStyle, &'a str)>, syntect::Error> {
+        let ops = self.parse_state.parse_line(text, syntax_set())?;
+        let syn_hl = SynHighlighter::new(&self.theme);
+        let iter = HighlightIterator::new(&mut self.highlight_state, &ops, text, &syn_hl);
+        Ok(iter.collect())
+    }
+
+    pub fn highlight_line(&mut self, text: &str) -> Vec<StyledSegment> {
+        match self.raw_highlight_line(text) {
+            Ok(ranges) => ranges
+                .into_iter()
+                .map(|(style, text)| StyledSegment::from_syntect(style, normalize_text(text)))
+                .collect(),
+            Err(_) => vec![StyledSegment::fallback(normalize_text(text))],
+        }
+    }
+
+    pub fn advance(&mut self, text: &str) {
+        let _ = self.raw_highlight_line(text);
+    }
+
+    pub fn state(self) -> (HighlightState, ParseState) {
+        (self.highlight_state, self.parse_state)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StyledSegment {
+    pub text: String,
+    pub fg: (u8, u8, u8),
+    pub bold: bool,
+    pub italic: bool,
+    pub underline: bool,
+}
+
+impl StyledSegment {
+    fn from_syntect(style: SynStyle, text: String) -> Self {
+        let f = style.foreground;
+        Self {
+            text,
+            fg: (f.r, f.g, f.b),
+            bold: style.font_style.contains(FontStyle::BOLD),
+            italic: style.font_style.contains(FontStyle::ITALIC),
+            underline: style.font_style.contains(FontStyle::UNDERLINE),
+        }
+    }
+
+    fn fallback(text: String) -> Self {
+        Self {
+            text,
+            fg: (204, 204, 204),
+            bold: false,
+            italic: false,
+            underline: false,
+        }
+    }
+}
+
+pub fn highlight_code(lang: &str, code: &str) -> Vec<Vec<StyledSegment>> {
+    let mut hl = Highlighter::for_token(lang);
+    LinesWithEndings::from(code)
+        .map(|raw| hl.highlight_line(raw))
+        .collect()
+}
+
+pub fn highlight_ansi(lang: &str, code: &str, bg: (u8, u8, u8)) -> String {
+    let bg_code = format!("\x1b[48;2;{};{};{}m", bg.0, bg.1, bg.2);
+    let mut hl = Highlighter::for_token(lang);
+    let mut out = String::new();
+    for line in LinesWithEndings::from(code) {
+        out.push_str(&bg_code);
+        for seg in hl.highlight_line(line) {
+            let bold = if seg.bold { "1;" } else { "" };
+            let _ = write!(
+                out,
+                "\x1b[{bold}38;2;{};{};{}m{}",
+                seg.fg.0, seg.fg.1, seg.fg.2, seg.text
+            );
+        }
+        out.push_str("\x1b[K\x1b[0m\n");
+    }
+    out
+}
+
+pub struct CodeHighlighter {
+    checkpoint_parse: ParseState,
+    checkpoint_highlight: HighlightState,
+    completed_lines: usize,
+    cached_segments: Vec<Vec<StyledSegment>>,
+}
+
+impl CodeHighlighter {
+    pub fn new(lang: &str) -> Self {
+        let syntax = syntax_for_token(lang);
+        let t = theme();
+        let highlighter = SynHighlighter::new(&t);
+        Self {
+            checkpoint_parse: ParseState::new(syntax),
+            checkpoint_highlight: HighlightState::new(&highlighter, ScopeStack::new()),
+            completed_lines: 0,
+            cached_segments: Vec::new(),
+        }
+    }
+
+    fn set_or_push(&mut self, index: usize, segments: Vec<StyledSegment>) {
+        if index < self.cached_segments.len() {
+            self.cached_segments[index] = segments;
+        } else {
+            self.cached_segments.push(segments);
+        }
+    }
+
+    pub fn update(&mut self, code: &str) -> &[Vec<StyledSegment>] {
+        let raw_lines: Vec<&str> = LinesWithEndings::from(code).collect();
+        let total = raw_lines.len();
+        if total == 0 {
+            self.cached_segments.clear();
+            self.completed_lines = 0;
+            return &[];
+        }
+
+        let new_completed = if code.ends_with('\n') {
+            total
+        } else {
+            total - 1
+        };
+
+        if new_completed > self.completed_lines {
+            let mut hl = Highlighter::from_state(
+                theme(),
+                self.checkpoint_highlight.clone(),
+                self.checkpoint_parse.clone(),
+            );
+
+            for raw in &raw_lines[self.completed_lines..new_completed] {
+                self.set_or_push(self.completed_lines, hl.highlight_line(raw));
+                self.completed_lines += 1;
+            }
+
+            let (hs, ps) = hl.state();
+            self.checkpoint_parse = ps;
+            self.checkpoint_highlight = hs;
+        }
+
+        let line_count = new_completed + usize::from(new_completed < total);
+        self.cached_segments.truncate(line_count);
+
+        if new_completed < total {
+            let mut hl = Highlighter::from_state(
+                theme(),
+                self.checkpoint_highlight.clone(),
+                self.checkpoint_parse.clone(),
+            );
+            self.set_or_push(new_completed, hl.highlight_line(raw_lines[new_completed]));
+        }
+
+        &self.cached_segments
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    fn segments_text(segs: &[StyledSegment]) -> String {
+        segs.iter().map(|s| s.text.as_str()).collect()
+    }
+
+    fn lines_text(lines: &[Vec<StyledSegment>]) -> Vec<String> {
+        lines.iter().map(|l| segments_text(l)).collect()
+    }
+
+    #[test]
+    fn highlight_code_line_handling() {
+        warmup();
+        let single = highlight_code("rust", "fn main() {}\n");
+        assert_eq!(single.len(), 1);
+        assert_eq!(segments_text(&single[0]), "fn main() {}");
+
+        let no_newline = highlight_code("rust", "let x = 1;");
+        assert_eq!(no_newline.len(), 1);
+        assert_eq!(segments_text(&no_newline[0]), "let x = 1;");
+
+        let trailing = highlight_code("rust", "let x = 1;\n\n\n");
+        assert_eq!(trailing.len(), 3);
+        assert_eq!(segments_text(&trailing[1]), "");
+    }
+
+    #[test]
+    fn syntax_for_token_fallback() {
+        warmup();
+        let plain = syntax_set().find_syntax_plain_text();
+        assert_eq!(
+            syntax_for_token("nonexistent_language_xyz").name,
+            plain.name
+        );
+    }
+
+    #[test]
+    fn set_theme_applies_without_panic() {
+        warmup();
+        for _ in 0..3 {
+            set_theme(Theme::default());
+        }
+        let mut hl = Highlighter::for_token("rust");
+        assert!(!hl.highlight_line("let x = 1;\n").is_empty());
+    }
+
+    #[test]
+    fn code_highlighter_streaming_consistency() {
+        warmup();
+        let full_code = "fn main() {\n    let x = 42;\n    println!(\"{}\", x);\n}\n";
+        let full = highlight_code("rust", full_code);
+
+        let mut ch = CodeHighlighter::new("rust");
+        ch.update("fn main() {\n");
+        ch.update("fn main() {\n    let x = 42;\n");
+        let result = ch.update(full_code);
+
+        assert_eq!(lines_text(&full), lines_text(result));
+    }
+
+    #[test]
+    fn code_highlighter_partial_line() {
+        warmup();
+        let mut ch = CodeHighlighter::new("rust");
+
+        ch.update("let x");
+        let text1 = segments_text(&ch.update("let x")[0]);
+
+        let text2 = segments_text(&ch.update("let x = 42")[0]);
+        assert_ne!(
+            text1, text2,
+            "partial line should be re-highlighted as content changes"
+        );
+    }
+
+    #[test]
+    fn code_highlighter_shrinks() {
+        warmup();
+        let mut ch = CodeHighlighter::new("rust");
+        ch.update("let a = 1;\nlet b = 2;\nlet c = 3;\n");
+        let segs = ch.update("let a = 1;\n");
+        assert_eq!(segs.len(), 1);
+    }
+
+    #[test]
+    fn normalize_text_tabs_and_newlines() {
+        assert_eq!(normalize_text("\t\t"), format!("{TAB_SPACES}{TAB_SPACES}"));
+        assert_eq!(normalize_text("hello\n"), "hello");
+        assert_eq!(normalize_text("a\tb"), format!("a{TAB_SPACES}b"));
+        assert_eq!(normalize_text("hello world"), "hello world");
+        assert_eq!(normalize_text(""), "");
+    }
+
+    #[test_case("test.rs" => "Rust"; "rust_extension")]
+    #[test_case("test.py" => "Python"; "python_extension")]
+    #[test_case("test.go" => "Go"; "go_extension")]
+    #[test_case("Makefile" => "Makefile"; "makefile_no_ext")]
+    fn syntax_for_path_resolves(path: &str) -> String {
+        warmup();
+        syntax_for_path(path).name.to_string()
+    }
+
+    #[test]
+    fn syntax_for_path_unknown_falls_back() {
+        warmup();
+        let plain = syntax_set().find_syntax_plain_text();
+        assert_eq!(syntax_for_path("file.totally_unknown_xyz").name, plain.name);
+    }
+
+    #[test]
+    fn highlight_ansi_formatting() {
+        warmup();
+        let out = highlight_ansi("rust", "let x = 1;\nlet y = 2;\n", (30, 30, 30));
+        let bg_count = out.matches("\x1b[48;2;30;30;30m").count();
+        assert_eq!(bg_count, 2, "each line should get its own bg escape");
+        assert!(out.ends_with("\x1b[K\x1b[0m\n"));
+    }
+
+    #[test]
+    fn highlighter_advance_and_state_roundtrip() {
+        warmup();
+        let mut hl = Highlighter::for_token("rust");
+        hl.advance("fn main() {\n");
+        let (hs, ps) = hl.state();
+
+        let mut from_state = Highlighter::from_state(theme(), hs, ps);
+        let seg_from_state = from_state.highlight_line("    let x = 1;\n");
+
+        let mut fresh = Highlighter::for_token("rust");
+        fresh.advance("fn main() {\n");
+        let seg_fresh = fresh.highlight_line("    let x = 1;\n");
+
+        assert_eq!(seg_from_state, seg_fresh);
+    }
+
+    #[test_case("jsx", "js"; "jsx_alias")]
+    fn token_alias_resolves(alias: &str, canonical: &str) {
+        warmup();
+        let aliased = syntax_for_token(alias);
+        let canonical_syntax = syntax_set().find_syntax_by_token(canonical).unwrap();
+        assert_eq!(aliased.name, canonical_syntax.name);
+    }
+}

--- a/maki-lua/Cargo.toml
+++ b/maki-lua/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 [dependencies]
 maki-agent = { workspace = true }
 maki-config = { workspace = true }
+maki-highlight = { workspace = true }
 mlua = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/maki-lua/src/api/fn_api.rs
+++ b/maki-lua/src/api/fn_api.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
 use std::thread;
+use std::time::Duration;
 
 use mlua::{Function, Lua, RegistryKey, Result as LuaResult, Table};
 
@@ -9,6 +10,7 @@ use crate::runtime::with_task_jobs;
 
 const READER_BUF_SIZE: usize = 8 * 1024;
 
+#[derive(Clone)]
 pub(crate) enum JobEvent {
     Stdout(String),
     Stderr(String),
@@ -26,10 +28,10 @@ struct JobMeta {
     on_stdout: Option<RegistryKey>,
     on_stderr: Option<RegistryKey>,
     on_exit: Option<RegistryKey>,
+    wait_tx: Option<flume::Sender<JobEvent>>,
 }
 
-/// All jobs in a task share one event channel so the dispatch loop
-/// can poll a single receiver for stdout/stderr/exit from any child.
+/// Single channel per task so the dispatch loop can poll one receiver for all children.
 pub(crate) struct JobStore {
     jobs: HashMap<u32, JobMeta>,
     pub(crate) event_rx: flume::Receiver<TaggedJobEvent>,
@@ -62,6 +64,17 @@ impl JobStore {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .stdin(Stdio::null());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            unsafe {
+                command.pre_exec(|| {
+                    libc::setsid();
+                    Ok(())
+                });
+            }
+        }
 
         if let Some(ref dir) = cwd {
             command.current_dir(dir);
@@ -129,6 +142,7 @@ impl JobStore {
                 on_stdout,
                 on_stderr,
                 on_exit,
+                wait_tx: None,
             },
         );
 
@@ -145,11 +159,31 @@ impl JobStore {
 
     pub fn callback_key(&self, job_id: u32, event: &JobEvent) -> Option<&RegistryKey> {
         let meta = self.jobs.get(&job_id)?;
+        if meta.wait_tx.is_some() {
+            return None;
+        }
         match event {
             JobEvent::Stdout(_) => meta.on_stdout.as_ref(),
             JobEvent::Stderr(_) => meta.on_stderr.as_ref(),
             JobEvent::Exit(_) => meta.on_exit.as_ref(),
         }
+    }
+
+    pub fn forward_to_waiter(&self, job_id: u32, event: &JobEvent) -> bool {
+        self.jobs
+            .get(&job_id)
+            .and_then(|m| m.wait_tx.as_ref())
+            .is_some_and(|tx| tx.send(event.clone()).is_ok())
+    }
+
+    pub fn subscribe_wait(&mut self, job_id: u32) -> Option<flume::Receiver<JobEvent>> {
+        let meta = self.jobs.get_mut(&job_id)?;
+        if meta.wait_tx.is_some() {
+            return None;
+        }
+        let (tx, rx) = flume::unbounded();
+        meta.wait_tx = Some(tx);
+        Some(rx)
     }
 
     pub fn mark_dead(&mut self, job_id: u32) {
@@ -161,7 +195,7 @@ impl JobStore {
     pub fn kill(&mut self, job_id: u32) {
         if let Some(meta) = self.jobs.get_mut(&job_id) {
             if meta.alive {
-                kill_process(meta.pid);
+                kill_job(meta);
             }
         }
     }
@@ -169,7 +203,7 @@ impl JobStore {
     pub fn kill_all(&mut self) {
         for meta in self.jobs.values_mut() {
             if meta.alive {
-                kill_process(meta.pid);
+                kill_job(meta);
             }
         }
     }
@@ -201,24 +235,25 @@ fn shell_command(cmd: &str) -> Command {
     }
 }
 
-#[cfg(unix)]
-fn kill_process(pid: u32) {
-    unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
-}
-
-#[cfg(windows)]
-fn kill_process(pid: u32) {
-    const PROCESS_TERMINATE: u32 = 0x0001;
-    unsafe extern "system" {
-        fn OpenProcess(access: u32, inherit: i32, pid: u32) -> *mut std::ffi::c_void;
-        fn TerminateProcess(handle: *mut std::ffi::c_void, exit_code: u32) -> i32;
-        fn CloseHandle(handle: *mut std::ffi::c_void) -> i32;
-    }
+fn kill_job(meta: &JobMeta) {
+    #[cfg(unix)]
     unsafe {
-        let handle = OpenProcess(PROCESS_TERMINATE, 0, pid);
-        if !handle.is_null() {
-            TerminateProcess(handle, 1);
-            CloseHandle(handle);
+        libc::killpg(meta.pid as libc::pid_t, libc::SIGKILL);
+    }
+    #[cfg(windows)]
+    {
+        const PROCESS_TERMINATE: u32 = 0x0001;
+        unsafe extern "system" {
+            fn OpenProcess(access: u32, inherit: i32, pid: u32) -> *mut std::ffi::c_void;
+            fn TerminateProcess(handle: *mut std::ffi::c_void, exit_code: u32) -> i32;
+            fn CloseHandle(handle: *mut std::ffi::c_void) -> i32;
+        }
+        unsafe {
+            let handle = OpenProcess(PROCESS_TERMINATE, 0, meta.pid);
+            if !handle.is_null() {
+                TerminateProcess(handle, 1);
+                CloseHandle(handle);
+            }
         }
     }
 }
@@ -273,5 +308,192 @@ pub(crate) fn create_fn_table(lua: &Lua) -> LuaResult<Table> {
         })?,
     )?;
 
+    t.set(
+        "jobwait",
+        lua.create_async_function(|lua, (job_id, timeout_ms): (u32, Option<u64>)| async move {
+            let wait_rx = with_task_jobs(&lua, |store| store.subscribe_wait(job_id))
+                .ok_or_else(|| mlua::Error::runtime("job store not initialized"))?
+                .ok_or_else(|| mlua::Error::runtime("unknown job id or already waited"))?;
+
+            let timeout = Duration::from_millis(timeout_ms.unwrap_or(30_000));
+            let deadline = smol::Timer::after(timeout);
+            futures_lite::pin!(deadline);
+
+            let mut stdout_lines = Vec::new();
+            let mut stderr_lines = Vec::new();
+
+            let exit_code = loop {
+                let event =
+                    futures_lite::future::or(async { wait_rx.recv_async().await.ok() }, async {
+                        (&mut deadline).await;
+                        None
+                    })
+                    .await;
+
+                match event {
+                    None => return Ok(mlua::Value::Nil),
+                    Some(JobEvent::Stdout(line)) => stdout_lines.push(line),
+                    Some(JobEvent::Stderr(line)) => stderr_lines.push(line),
+                    Some(JobEvent::Exit(code)) => {
+                        break code;
+                    }
+                }
+            };
+
+            let result = lua.create_table()?;
+            result.set("stdout", stdout_lines.join("\n"))?;
+            result.set("stderr", stderr_lines.join("\n"))?;
+            result.set("exit_code", exit_code)?;
+            Ok(mlua::Value::Table(result))
+        })?,
+    )?;
+
     Ok(t)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_store() -> JobStore {
+        JobStore::new()
+    }
+
+    fn start_echo(store: &mut JobStore) -> u32 {
+        store
+            .start("echo hello", None, None, None, None, None)
+            .unwrap()
+    }
+
+    #[test]
+    fn start_invalid_cwd_returns_error() {
+        let mut store = make_store();
+        let result = store.start(
+            "echo hello",
+            Some("/nonexistent_dir_abc_xyz_123".into()),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn has_alive_jobs_tracks_state() {
+        let mut store = make_store();
+        assert!(!store.has_alive_jobs());
+
+        let id = start_echo(&mut store);
+        assert!(store.has_alive_jobs());
+
+        store.mark_dead(id);
+        assert!(!store.has_alive_jobs());
+    }
+
+    #[test]
+    fn noop_on_nonexistent_or_dead_jobs() {
+        let mut store = make_store();
+        store.mark_dead(999);
+        store.kill(999);
+
+        let id = start_echo(&mut store);
+        store.mark_dead(id);
+        store.kill(id);
+
+        assert!(store.callback_key(999, &JobEvent::Exit(0)).is_none());
+        assert!(!store.forward_to_waiter(999, &JobEvent::Exit(0)));
+    }
+
+    #[test]
+    fn subscribe_wait_lifecycle() {
+        let mut store = make_store();
+        assert!(store.subscribe_wait(999).is_none());
+
+        let id = start_echo(&mut store);
+        assert!(store.subscribe_wait(id).is_some());
+        assert!(
+            store.subscribe_wait(id).is_none(),
+            "double subscribe should fail"
+        );
+    }
+
+    #[test]
+    fn callbacks_suppressed_while_waiting() {
+        let mut store = make_store();
+        let id = start_echo(&mut store);
+        let _rx = store.subscribe_wait(id).unwrap();
+
+        assert!(
+            store
+                .callback_key(id, &JobEvent::Stdout("x".into()))
+                .is_none()
+        );
+        assert!(store.callback_key(id, &JobEvent::Exit(0)).is_none());
+    }
+
+    #[test]
+    fn callback_key_returns_none_without_callbacks() {
+        let mut store = make_store();
+        let id = start_echo(&mut store);
+        assert!(
+            store
+                .callback_key(id, &JobEvent::Stdout("x".into()))
+                .is_none()
+        );
+        assert!(
+            store
+                .callback_key(id, &JobEvent::Stderr("x".into()))
+                .is_none()
+        );
+        assert!(store.callback_key(id, &JobEvent::Exit(0)).is_none());
+    }
+
+    #[test]
+    fn forward_to_waiter_delivers_events() {
+        let mut store = make_store();
+        let id = start_echo(&mut store);
+        assert!(!store.forward_to_waiter(id, &JobEvent::Stdout("x".into())));
+
+        let rx = store.subscribe_wait(id).unwrap();
+        assert!(store.forward_to_waiter(id, &JobEvent::Stdout("line1".into())));
+        assert!(store.forward_to_waiter(id, &JobEvent::Exit(0)));
+
+        let ev1 = rx.recv().unwrap();
+        assert!(matches!(ev1, JobEvent::Stdout(s) if s == "line1"));
+        let ev2 = rx.recv().unwrap();
+        assert!(matches!(ev2, JobEvent::Exit(0)));
+    }
+
+    #[test]
+    fn forward_to_waiter_fails_after_rx_dropped() {
+        let mut store = make_store();
+        let id = start_echo(&mut store);
+        let rx = store.subscribe_wait(id).unwrap();
+        drop(rx);
+
+        assert!(!store.forward_to_waiter(id, &JobEvent::Stdout("orphan".into())));
+    }
+
+    #[test]
+    fn event_channel_receives_exit() {
+        let mut store = make_store();
+        let id = start_echo(&mut store);
+        let rx = store.event_rx.clone();
+
+        let mut got_exit = false;
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            match rx.recv_timeout(Duration::from_millis(200)) {
+                Ok(tagged) if tagged.job_id == id && matches!(tagged.event, JobEvent::Exit(_)) => {
+                    got_exit = true;
+                    break;
+                }
+                Ok(_) => continue,
+                Err(flume::RecvTimeoutError::Timeout) => continue,
+                Err(flume::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+        assert!(got_exit, "should receive exit event for completed job");
+    }
 }

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod net;
 pub(crate) mod text;
 pub(crate) mod tool;
 pub(crate) mod treesitter;
+pub(crate) mod ui;
 pub(crate) mod uv;
 
 use std::path::PathBuf;
@@ -16,7 +17,6 @@ use std::sync::Arc;
 use mlua::{Lua, Result as LuaResult, Table};
 
 use crate::api::tool::PendingTools;
-use crate::runtime::with_task_bufs;
 
 pub(crate) fn create_maki_global(
     lua: &Lua,
@@ -34,20 +34,8 @@ pub(crate) fn create_maki_global(
     maki.set("json", json::create_json_table(lua)?)?;
     maki.set("net", net::create_net_table(lua)?)?;
     maki.set("text", text::create_text_table(lua)?)?;
-    maki.set("ui", create_ui_table(lua)?)?;
+    maki.set("ui", ui::create_ui_table(lua)?)?;
     maki.set("fn", fn_api::create_fn_table(lua)?)?;
 
     Ok(maki)
-}
-
-fn create_ui_table(lua: &Lua) -> LuaResult<Table> {
-    let t = lua.create_table()?;
-    t.set(
-        "buf",
-        lua.create_function(|lua, ()| {
-            with_task_bufs(lua, |store| store.create_live())
-                .ok_or_else(|| mlua::Error::runtime("buffer store not initialized"))
-        })?,
-    )?;
-    Ok(t)
 }

--- a/maki-lua/src/api/ui.rs
+++ b/maki-lua/src/api/ui.rs
@@ -1,0 +1,53 @@
+use mlua::{Lua, Result as LuaResult, Table};
+
+use crate::runtime::with_task_bufs;
+
+pub(crate) fn create_ui_table(lua: &Lua) -> LuaResult<Table> {
+    let t = lua.create_table()?;
+    t.set(
+        "buf",
+        lua.create_function(|lua, ()| {
+            with_task_bufs(lua, |store| store.create_live())
+                .ok_or_else(|| mlua::Error::runtime("buffer store not initialized"))
+        })?,
+    )?;
+    t.set(
+        "highlight",
+        lua.create_async_function(|lua, (code, lang): (String, String)| async move {
+            let segments =
+                smol::unblock(move || maki_highlight::highlight_code(&lang, &code)).await;
+            segments_to_lua_lines(&lua, &segments)
+        })?,
+    )?;
+    Ok(t)
+}
+
+fn segments_to_lua_lines(
+    lua: &Lua,
+    lines: &[Vec<maki_highlight::StyledSegment>],
+) -> LuaResult<Table> {
+    let result = lua.create_table_with_capacity(lines.len(), 0)?;
+    for (i, segs) in lines.iter().enumerate() {
+        let line_tbl = lua.create_table_with_capacity(segs.len(), 0)?;
+        for (j, seg) in segs.iter().enumerate() {
+            let span = lua.create_table_with_capacity(2, 0)?;
+            span.raw_set(1, seg.text.as_str())?;
+            let style = lua.create_table_with_capacity(0, 4)?;
+            let (r, g, b) = seg.fg;
+            style.raw_set("fg", format!("#{r:02x}{g:02x}{b:02x}"))?;
+            if seg.bold {
+                style.raw_set("bold", true)?;
+            }
+            if seg.italic {
+                style.raw_set("italic", true)?;
+            }
+            if seg.underline {
+                style.raw_set("underline", true)?;
+            }
+            span.raw_set(2, style)?;
+            line_tbl.raw_set(i32::try_from(j + 1).unwrap(), span)?;
+        }
+        result.raw_set(i32::try_from(i + 1).unwrap(), line_tbl)?;
+    }
+    Ok(result)
+}

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -623,6 +623,7 @@ async fn dispatch_async(
             .and_then(|m| {
                 let ctx = m.get(&key)?;
                 let is_exit = matches!(tagged.event, JobEvent::Exit(_));
+                ctx.jobs.forward_to_waiter(tagged.job_id, &tagged.event);
                 let cb = ctx
                     .jobs
                     .callback_key(tagged.job_id, &tagged.event)
@@ -956,8 +957,8 @@ mod tests {
         t.set("header", hdr_handle).unwrap();
         let reply = extract_tool_return_from_task(&LuaValue::Table(t));
         assert_eq!(reply.result, Ok("text".to_string()));
-        assert_eq!(reply.snapshot.unwrap().lines[0].spans[0].text, "body line");
-        assert_eq!(reply.header.unwrap().lines[0].spans[0].text, "hdr line");
+        assert_eq!(reply.snapshot.unwrap().first_line_text(), "body line");
+        assert_eq!(reply.header.unwrap().first_line_text(), "hdr line");
     }
 
     #[test]
@@ -1035,7 +1036,7 @@ mod tests {
             is_error: false,
             body: Some(buf.take()),
         });
-        assert_eq!(reply.snapshot.unwrap().lines[0].spans[0].text, "rendered");
+        assert_eq!(reply.snapshot.unwrap().first_line_text(), "rendered");
         assert!(reply.header.is_none());
     }
 

--- a/maki-ui/Cargo.toml
+++ b/maki-ui/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 maki-agent = { workspace = true }
 maki-config = { workspace = true }
+maki-highlight = { workspace = true }
 maki-providers = { workspace = true }
 maki-storage = { workspace = true }
 ratatui = { workspace = true }
@@ -13,7 +14,6 @@ crossterm = { workspace = true }
 color-eyre = { workspace = true }
 tracing = { workspace = true }
 syntect = { workspace = true }
-two-face = { workspace = true }
 unicode-width = { workspace = true }
 serde_json = { workspace = true }
 arboard = { workspace = true }

--- a/maki-ui/src/components/code_view.rs
+++ b/maki-ui/src/components/code_view.rs
@@ -1,7 +1,4 @@
-use crate::highlight::{
-    advance_highlighter, fallback_span, highlight_line, highlighter_for_path,
-    highlighter_for_syntax, highlighter_for_token, syntax_for_path,
-};
+use crate::highlight::{fallback_span, highlight_line};
 use crate::markdown::{should_truncate, truncation_notice};
 use crate::theme;
 
@@ -9,7 +6,6 @@ use maki_agent::diff::{DiffLine, DiffSpan, compute_hunks};
 use maki_agent::{GrepFileEntry, InstructionBlock, ToolInput, ToolOutput};
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
-use syntect::easy::HighlightLines;
 use syntect::parsing::SyntaxReference;
 use syntect::util::LinesWithEndings;
 
@@ -46,16 +42,16 @@ fn truncation_line(truncated: usize) -> Line<'static> {
     ))
 }
 
-fn highlight_spans(hl: &mut HighlightLines<'_>, text: &str) -> Vec<Span<'static>> {
+fn highlight_spans(hl: &mut maki_highlight::Highlighter, text: &str) -> Vec<Span<'static>> {
     let with_nl = format!("{text}\n");
     highlight_line(hl, &with_nl)
         .into_iter()
-        .map(|(style, chunk)| Span::styled(chunk, style))
+        .filter(|span| !span.content.is_empty())
         .collect()
 }
 
 fn render_code(
-    mut hl: Option<HighlightLines<'static>>,
+    mut hl: Option<maki_highlight::Highlighter>,
     start_line: usize,
     code_lines: &[String],
     total_count: usize,
@@ -93,15 +89,13 @@ fn render_code(
     (lines, has_truncation)
 }
 
-/// Syntect is stateful: to color line N correctly it needs to have seen
-/// lines 1..N in order, so an open string or block comment on an earlier
-/// line still tints everything after it. A diff shows two files at once,
-/// and removed and added lines only make sense in their own file's state,
-/// so we keep one walker per side and step them in lockstep with the hunks.
+/// Syntect is stateful, so to color line N you need lines 1..N first.
+/// A diff has two files, each with its own parser state. We keep one
+/// walker per side and step them in lockstep with the hunks.
 struct FileWalker<'a> {
     lines: LinesWithEndings<'a>,
     pos: usize,
-    hl: HighlightLines<'static>,
+    hl: maki_highlight::Highlighter,
 }
 
 impl<'a> FileWalker<'a> {
@@ -109,15 +103,12 @@ impl<'a> FileWalker<'a> {
         Self {
             lines: LinesWithEndings::from(content),
             pos: 1,
-            hl: highlighter_for_syntax(syntax),
+            hl: maki_highlight::Highlighter::for_syntax(syntax),
         }
     }
 
-    /// Feeds the next line to syntect but throws the styled output away,
-    /// saving an allocation for lines we won't render (like the unchanged
-    /// side of a diff line that we only show from the other file). Running
-    /// off the end means our line math drifted, so we yell about it in
-    /// debug and stay quiet in release.
+    /// Advances the parser without keeping styled output (for lines we
+    /// skip over in the diff). Debug-asserts if we run past EOF.
     fn skip(&mut self) -> bool {
         let Some(line) = self.lines.next() else {
             debug_assert!(
@@ -127,12 +118,12 @@ impl<'a> FileWalker<'a> {
             );
             return false;
         };
-        advance_highlighter(&mut self.hl, line);
+        self.hl.advance(line);
         self.pos += 1;
         true
     }
 
-    fn highlight_next(&mut self) -> Option<Vec<(Style, String)>> {
+    fn highlight_next(&mut self) -> Option<Vec<Span<'static>>> {
         let Some(line) = self.lines.next() else {
             debug_assert!(
                 false,
@@ -202,11 +193,8 @@ fn numbered_gutter(line_nr: &mut usize, w: usize) -> Span<'static> {
     span
 }
 
-/// Each diff line variant has its own little dance: an unchanged line
-/// needs both walkers stepped but only one set of spans, a removed line
-/// pulls from the before walker, an added line from the after one. Doing
-/// it all in one match means adding a new variant forces the compiler to
-/// drag us back here instead of letting a bug slip through.
+/// Unchanged lines step both walkers but take spans from `after`.
+/// Removed/added lines only step their own side.
 fn render_hunk_line(
     dl: &DiffLine,
     walkers: Option<&mut (FileWalker<'_>, FileWalker<'_>)>,
@@ -251,12 +239,9 @@ fn render_hunk_line(
     }
 }
 
-fn syntax_to_spans(syntax: Option<Vec<(Style, String)>>, text: &str) -> Vec<Span<'static>> {
+fn syntax_to_spans(syntax: Option<Vec<Span<'static>>>, text: &str) -> Vec<Span<'static>> {
     match syntax {
-        Some(s) => s
-            .into_iter()
-            .map(|(style, chunk)| Span::styled(chunk, style))
-            .collect(),
+        Some(s) => s,
         None => vec![fallback_span(text)],
     }
 }
@@ -264,7 +249,7 @@ fn syntax_to_spans(syntax: Option<Vec<(Style, String)>>, text: &str) -> Vec<Span
 fn diff_change_spans(
     prefix: &'static str,
     ds: &[DiffSpan],
-    syntax: Option<Vec<(Style, String)>>,
+    syntax: Option<Vec<Span<'static>>>,
     base: Style,
     emph: Style,
 ) -> Vec<Span<'static>> {
@@ -277,7 +262,7 @@ fn diff_change_spans(
         None => {
             let full: String = ds.iter().map(|s| s.text.as_str()).collect();
             spans.push(Span::styled(
-                crate::highlight::normalize_text(&full),
+                maki_highlight::normalize_text(&full),
                 base.patch(theme::current().code_fallback),
             ));
         }
@@ -320,7 +305,7 @@ fn render_grep_results(
             )));
         }
 
-        let syntax = highlight.then(|| syntax_for_path(&entry.path));
+        let syntax = highlight.then(|| maki_highlight::syntax_for_path(&entry.path));
         let has_context = entry.groups.iter().any(|g| g.lines.len() > 1);
 
         for (gi, group) in entry.groups.iter().enumerate() {
@@ -337,7 +322,10 @@ fn render_grep_results(
                 }
                 let mut spans = vec![gutter(&format!("{:>w$}", line.line_nr))];
                 let text_spans = if let Some(syn) = syntax {
-                    highlight_spans(&mut highlighter_for_syntax(syn), &line.text)
+                    highlight_spans(
+                        &mut maki_highlight::Highlighter::for_syntax(syn),
+                        &line.text,
+                    )
                 } else if line.is_match {
                     vec![fallback_span(&line.text)]
                 } else {
@@ -403,7 +391,7 @@ pub(crate) fn render_instructions(
         let code_lines: Vec<String> = block.content.lines().map(String::from).collect();
         let total = code_lines.len();
         let remaining = max_lines.saturating_sub(used);
-        let hl = highlight.then(|| highlighter_for_path(&block.path));
+        let hl = highlight.then(|| maki_highlight::Highlighter::for_path(&block.path));
         let (rendered, was_truncated) = render_code(hl, 1, &code_lines, total, remaining);
         used += rendered.len();
         truncated |= was_truncated;
@@ -476,7 +464,7 @@ pub fn render_tool_content(
             .map(String::from)
             .collect();
         let total = code_lines.len();
-        let hl = highlight.then(|| highlighter_for_token(language));
+        let hl = highlight.then(|| maki_highlight::Highlighter::for_token(language));
         let (code_result, trunc) = render_code(hl, 1, &code_lines, total, limits.script);
         truncation.script = trunc;
         lines.extend(code_result);
@@ -488,7 +476,7 @@ pub fn render_tool_content(
             lines: code_lines,
             ..
         }) => render_code(
-            highlight.then(|| highlighter_for_path(path)),
+            highlight.then(|| maki_highlight::Highlighter::for_path(path)),
             *start_line,
             code_lines,
             code_lines.len(),
@@ -509,7 +497,7 @@ pub fn render_tool_content(
                 lines: code_lines,
             },
         ) => render_code(
-            highlight.then(|| highlighter_for_path(path)),
+            highlight.then(|| maki_highlight::Highlighter::for_path(path)),
             1,
             code_lines,
             code_lines.len(),
@@ -521,7 +509,11 @@ pub fn render_tool_content(
             after,
             ..
         }) => (
-            render_diff(highlight.then(|| syntax_for_path(path)), before, after),
+            render_diff(
+                highlight.then(|| maki_highlight::syntax_for_path(path)),
+                before,
+                after,
+            ),
             false,
         ),
         Some(ToolOutput::GrepResult { entries }) => {
@@ -553,7 +545,7 @@ pub fn render_tool_content(
 }
 
 fn merge_syntax_with_diff(
-    syntax_spans: &[(Style, String)],
+    syntax_spans: &[Span<'static>],
     diff_spans: &[DiffSpan],
     base: Style,
     emphasis: Style,
@@ -562,7 +554,7 @@ fn merge_syntax_with_diff(
 
     let syn_iter = syntax_spans
         .iter()
-        .flat_map(|(style, text)| text.chars().map(move |c| (c, *style)));
+        .flat_map(|span| span.content.chars().map(move |c| (c, span.style)));
 
     let mut diff_iter = diff_spans.iter().flat_map(|ds| {
         let bg = if ds.emphasized { emphasis } else { base };
@@ -622,7 +614,7 @@ mod tests {
     fn render_code_line_count(input_lines: usize, total: usize, expected: usize) {
         let code_lines: Vec<String> = (0..input_lines).map(|i| format!("line {i}")).collect();
         let (result, _) = render_code(
-            Some(highlighter_for_path("test.rs")),
+            Some(maki_highlight::Highlighter::for_path("test.rs")),
             1,
             &code_lines,
             total,
@@ -643,11 +635,10 @@ mod tests {
             .unwrap_or_else(|| panic!("no fg-styled span containing {substr:?}"))
     }
 
-    /// Reference color: highlight `text` as part of `prefix` and return the fg
-    /// for the substring `find`. This is the "ground truth" - what the
-    /// highlighter produces when it walks the file from the start.
+    /// Walk the file from scratch up to `prefix`, then highlight `text`
+    /// and return the fg for `find`. This is our ground truth.
     fn fg_in_context(path: &str, prefix: &str, text: &str, find: &str) -> ratatui::style::Color {
-        let mut hl = highlighter_for_path(path);
+        let mut hl = maki_highlight::Highlighter::for_path(path);
         for line in prefix.lines() {
             let with_nl = format!("{line}\n");
             let _ = highlight_line(&mut hl, &with_nl);
@@ -655,34 +646,45 @@ mod tests {
         let with_nl = format!("{text}\n");
         highlight_line(&mut hl, &with_nl)
             .into_iter()
-            .find_map(|(s, t)| if t.contains(find) { s.fg } else { None })
+            .find_map(|span| {
+                if span.content.contains(find) {
+                    span.style.fg
+                } else {
+                    None
+                }
+            })
             .unwrap_or_else(|| panic!("ref fg for {find:?} missing"))
     }
 
-    /// Regression: an unchanged context line inside a multi-line block comment
-    /// must be highlighted with the parser state from walking the full file —
-    /// not from a fresh state at the hunk's start_line. We assert this by
-    /// comparing against an independent reference highlighter.
+    /// Context lines inside a block comment must carry the full-file parser
+    /// state, not a fresh one from the hunk start.
     #[test]
     fn diff_context_line_inside_block_comment_matches_full_file_state() {
         let before = "/*\nalpha\nbravo\ncharlie\ndelta\necho\nfoxtrot\nOLD\ngolf\n*/\n";
         let after = "/*\nalpha\nbravo\ncharlie\ndelta\necho\nfoxtrot\nNEW\ngolf\n*/\n";
 
-        let lines = render_diff(Some(syntax_for_path("test.rs")), before, after);
+        let lines = render_diff(
+            Some(maki_highlight::syntax_for_path("test.rs")),
+            before,
+            after,
+        );
 
         let expected = fg_in_context("test.rs", "/*\nalpha\nbravo\ncharlie\n", "delta", "delta");
         assert_eq!(diff_fg(&lines, "delta"), expected);
     }
 
-    /// Regression: when an edit removes a closing `*/`, lines that were code
-    /// in BEFORE are now comment in AFTER. Unchanged context lines must be
-    /// highlighted using the AFTER state (their post-edit truth).
+    /// When an edit removes `*/`, formerly-code lines become comment.
+    /// Unchanged context lines must use the AFTER parser state.
     #[test]
     fn diff_unchanged_line_uses_after_state_when_close_tag_removed() {
         let before = "/*\ndoc\n*/\nfn x() {}\n";
         let after = "/*\ndoc\nfn x() {}\n";
 
-        let lines = render_diff(Some(syntax_for_path("test.rs")), before, after);
+        let lines = render_diff(
+            Some(maki_highlight::syntax_for_path("test.rs")),
+            before,
+            after,
+        );
 
         let expected = fg_in_context("test.rs", "/*\ndoc\n", "fn x() {}", "fn");
         assert_eq!(diff_fg(&lines, "fn x() {}"), expected);
@@ -692,7 +694,7 @@ mod tests {
     fn merge_syntax_with_diff_emphasis_split() {
         let base = Style::new().bg(Color::Red);
         let emph = Style::new().bg(Color::Green);
-        let syn = vec![(Style::new().fg(Color::White), "abcde".to_owned())];
+        let syn = vec![Span::styled("abcde", Style::new().fg(Color::White))];
         let diff = vec![
             plain("abc"),
             DiffSpan {
@@ -713,8 +715,8 @@ mod tests {
     fn merge_syntax_longer_than_diff_preserves_trailing() {
         let base = Style::new().bg(Color::Red);
         let syn = vec![
-            (Style::new().fg(Color::Blue), "ab".to_owned()),
-            (Style::new().fg(Color::Cyan), "cd".to_owned()),
+            Span::styled("ab", Style::new().fg(Color::Blue)),
+            Span::styled("cd", Style::new().fg(Color::Cyan)),
         ];
         let diff = vec![plain("ab")];
         let result = merge_syntax_with_diff(&syn, &diff, base, Style::default());
@@ -816,7 +818,10 @@ mod tests {
     fn merge_syntax_with_diff_multibyte(input: &str, parts: &[&str]) {
         let base = Style::new().bg(Color::Red);
         let emph = Style::new().bg(Color::Green);
-        let syn = vec![(Style::new().fg(Color::White), input.to_owned())];
+        let syn = vec![Span::styled(
+            input.to_owned(),
+            Style::new().fg(Color::White),
+        )];
         let diff: Vec<DiffSpan> = parts
             .iter()
             .enumerate()

--- a/maki-ui/src/components/input.rs
+++ b/maki-ui/src/components/input.rs
@@ -525,9 +525,9 @@ fn shell_highlight_spans(line: &str) -> Option<Vec<Span<'static>>> {
     let command = &line[parsed.prefix_len..];
     let shell_style = theme::current().shell_prefix;
     let mut spans = vec![Span::styled(prefix.to_owned(), shell_style)];
-    let mut hl = highlight::highlighter_for_token("bash");
-    for (style, text) in highlight::highlight_line(&mut hl, command) {
-        spans.push(Span::styled(text, style));
+    let mut hl = maki_highlight::Highlighter::for_token("bash");
+    for span in highlight::highlight_line(&mut hl, command) {
+        spans.push(span);
     }
     Some(spans)
 }

--- a/maki-ui/src/highlight.rs
+++ b/maki-ui/src/highlight.rs
@@ -1,273 +1,117 @@
-use std::fmt::Write;
-use std::sync::{LazyLock, Mutex, OnceLock};
-
 use crate::theme;
 
+use maki_highlight::StyledSegment;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use syntect::easy::HighlightLines;
-use syntect::highlighting::{FontStyle, HighlightState, Highlighter};
-use syntect::parsing::{ParseState, ScopeStack, SyntaxReference, SyntaxSet};
-use syntect::util::LinesWithEndings;
 
-const TOKEN_ALIASES: &[(&str, &str)] = &[("jsx", "js")];
-pub const TAB_SPACES: &str = "  ";
-
-static SYNTAX_SET: OnceLock<SyntaxSet> = OnceLock::new();
-
-static LEAKED_SYNTAX_THEME: LazyLock<Mutex<&'static syntect::highlighting::Theme>> =
-    LazyLock::new(|| {
-        let theme = theme::current();
-        Mutex::new(Box::leak(Box::new(theme.syntax.clone())))
-    });
+pub use maki_highlight::TAB_SPACES;
 
 pub(crate) fn warmup() {
-    SYNTAX_SET.get_or_init(two_face::syntax::extra_newlines);
-    LazyLock::force(&LEAKED_SYNTAX_THEME);
-    let mut hl = highlighter_for_token("bash");
-    let _ = hl.highlight_line("x", syntax_set());
-}
-
-fn syntax_set() -> &'static SyntaxSet {
-    SYNTAX_SET.get_or_init(two_face::syntax::extra_newlines)
+    refresh_syntax_theme();
+    maki_highlight::warmup();
 }
 
 pub(crate) fn is_ready() -> bool {
-    SYNTAX_SET.get().is_some()
+    maki_highlight::is_ready()
 }
 
 pub(crate) fn refresh_syntax_theme() {
     let theme = theme::current();
-    let leaked: &'static syntect::highlighting::Theme = Box::leak(Box::new(theme.syntax.clone()));
-    *LEAKED_SYNTAX_THEME
-        .lock()
-        .unwrap_or_else(|e| e.into_inner()) = leaked;
+    maki_highlight::set_theme(theme.syntax.clone());
 }
 
-fn syntax_theme() -> &'static syntect::highlighting::Theme {
-    *LEAKED_SYNTAX_THEME
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-}
-
-pub fn normalize_text(text: &str) -> String {
-    text.trim_end_matches('\n').replace('\t', TAB_SPACES)
-}
-
-pub fn syntax_for_path(path: &str) -> &'static SyntaxReference {
-    syntax_set()
-        .find_syntax_for_file(path)
-        .ok()
-        .flatten()
-        .unwrap_or_else(|| {
-            let ext = path.rsplit('.').next().unwrap_or(path);
-            syntax_for_token(ext)
+pub fn highlight_line(hl: &mut maki_highlight::Highlighter, text: &str) -> Vec<Span<'static>> {
+    hl.highlight_line(text)
+        .into_iter()
+        .map(|seg| {
+            let style = convert_segment(&seg);
+            Span::styled(seg.text, style)
         })
-}
-
-pub fn highlighter_for_path(path: &str) -> HighlightLines<'static> {
-    highlighter_for_syntax(syntax_for_path(path))
-}
-
-pub fn highlighter_for_syntax(syntax: &'static SyntaxReference) -> HighlightLines<'static> {
-    HighlightLines::new(syntax, syntax_theme())
-}
-
-/// Syntect expects each slice to end in `\n` so its parser can close the
-/// line cleanly; forgetting the newline leaves the parser mid-line and
-/// corrupts every later highlight. The easiest way to get this right is
-/// to feed it yields from [`syntect::util::LinesWithEndings`].
-pub fn highlight_line(hl: &mut HighlightLines<'_>, text: &str) -> Vec<(Style, String)> {
-    match hl.highlight_line(text, syntax_set()) {
-        Ok(ranges) => ranges
-            .into_iter()
-            .map(|(style, text)| (convert_style(style), normalize_text(text)))
-            .collect(),
-        Err(_) => vec![(theme::current().code_fallback, normalize_text(text))],
-    }
-}
-
-/// Same input contract as [`highlight_line`], but we drop the styled
-/// output. Handy when walking past lines we won't draw (the unchanged
-/// side of a diff, or skipping ahead to the next hunk) while still
-/// keeping the parser's state in sync with the file.
-pub fn advance_highlighter(hl: &mut HighlightLines<'_>, text: &str) {
-    let _ = hl.highlight_line(text, syntax_set());
-}
-
-pub fn highlighter_for_token(lang: &str) -> HighlightLines<'static> {
-    HighlightLines::new(syntax_for_token(lang), syntax_theme())
-}
-
-fn syntax_for_token(lang: &str) -> &'static SyntaxReference {
-    let ss = syntax_set();
-    ss.find_syntax_by_token(lang)
-        .or_else(|| {
-            TOKEN_ALIASES
-                .iter()
-                .find(|(from, _)| *from == lang)
-                .and_then(|(_, to)| ss.find_syntax_by_token(to))
-        })
-        .unwrap_or_else(|| ss.find_syntax_plain_text())
+        .collect()
 }
 
 pub fn highlight_code_plain(lang: &str, code: &str) -> Vec<Line<'static>> {
-    let mut h = HighlightLines::new(syntax_for_token(lang), syntax_theme());
-    LinesWithEndings::from(code)
-        .map(|raw| highlight_single_line(&mut h, raw))
+    maki_highlight::highlight_code(lang, code)
+        .into_iter()
+        .map(|segs| segments_to_line(&segs))
         .collect()
 }
 
 pub struct CodeHighlighter {
+    inner: maki_highlight::CodeHighlighter,
     lines: Vec<Line<'static>>,
-    checkpoint_parse: ParseState,
-    checkpoint_highlight: HighlightState,
-    completed_lines: usize,
+    completed: usize,
 }
 
 impl CodeHighlighter {
     pub fn new(lang: &str) -> Self {
-        let syntax = syntax_for_token(lang);
-        let highlighter = Highlighter::new(syntax_theme());
         Self {
+            inner: maki_highlight::CodeHighlighter::new(lang),
             lines: Vec::new(),
-            checkpoint_parse: ParseState::new(syntax),
-            checkpoint_highlight: HighlightState::new(&highlighter, ScopeStack::new()),
-            completed_lines: 0,
+            completed: 0,
         }
     }
 
     pub fn update(&mut self, code: &str) -> &[Line<'static>] {
-        let raw_lines: Vec<&str> = LinesWithEndings::from(code).collect();
-        let total = raw_lines.len();
-        if total == 0 {
-            self.lines.clear();
-            self.completed_lines = 0;
-            return &[];
-        }
-
-        let new_completed = if code.ends_with('\n') {
-            total
-        } else {
-            total - 1
-        };
-
-        if new_completed > self.completed_lines {
-            let mut hl = HighlightLines::from_state(
-                syntax_theme(),
-                self.checkpoint_highlight.clone(),
-                self.checkpoint_parse.clone(),
-            );
-
-            for raw in &raw_lines[self.completed_lines..new_completed] {
-                let line = highlight_single_line(&mut hl, raw);
-                self.set_or_push(self.completed_lines, line);
-                self.completed_lines += 1;
+        let segments = self.inner.update(code);
+        let n = segments.len();
+        self.lines.truncate(n);
+        let stable = n.saturating_sub(1).min(self.completed);
+        for (i, segs) in segments[stable..].iter().enumerate() {
+            let idx = stable + i;
+            let line = segments_to_line(segs);
+            if idx < self.lines.len() {
+                self.lines[idx] = line;
+            } else {
+                self.lines.push(line);
             }
-
-            let (hs, ps) = hl.state();
-            self.checkpoint_parse = ps;
-            self.checkpoint_highlight = hs;
         }
-
-        let line_count = new_completed + usize::from(new_completed < total);
-        self.lines.truncate(line_count);
-
-        if new_completed < total {
-            let mut hl = HighlightLines::from_state(
-                syntax_theme(),
-                self.checkpoint_highlight.clone(),
-                self.checkpoint_parse.clone(),
-            );
-            let partial = highlight_single_line(&mut hl, raw_lines[new_completed]);
-            self.set_or_push(new_completed, partial);
-        }
-
+        self.completed = n.saturating_sub(1);
         &self.lines
     }
-
-    fn set_or_push(&mut self, index: usize, line: Line<'static>) {
-        if index < self.lines.len() {
-            self.lines[index] = line;
-        } else {
-            self.lines.push(line);
-        }
-    }
 }
 
-fn highlight_to_spans(hl: &mut HighlightLines<'_>, text: &str) -> Vec<Span<'static>> {
-    highlight_line(hl, text)
-        .into_iter()
-        .map(|(style, text)| Span::styled(text, style))
-        .collect()
-}
-
-fn highlight_single_line(hl: &mut HighlightLines<'_>, raw: &str) -> Line<'static> {
-    Line::from(highlight_to_spans(hl, raw))
+fn segments_to_line(segs: &[StyledSegment]) -> Line<'static> {
+    Line::from(
+        segs.iter()
+            .map(|s| Span::styled(s.text.clone(), convert_segment(s)))
+            .collect::<Vec<_>>(),
+    )
 }
 
 pub fn highlight_regex_inline(pattern: &str) -> Vec<Span<'static>> {
-    let Some(syntax) = syntax_set().find_syntax_by_token("re") else {
+    let Some(syntax) = maki_highlight::syntax_set().find_syntax_by_token("re") else {
         return vec![fallback_span(pattern)];
     };
-    let mut hl = HighlightLines::new(syntax, syntax_theme());
-    highlight_to_spans(&mut hl, pattern)
+    let mut hl = maki_highlight::Highlighter::for_syntax(syntax);
+    highlight_line(&mut hl, pattern)
 }
 
 pub fn fallback_span(text: &str) -> Span<'static> {
-    Span::styled(normalize_text(text), theme::current().code_fallback)
+    Span::styled(
+        maki_highlight::normalize_text(text),
+        theme::current().code_fallback,
+    )
 }
 
 pub fn highlight_ansi(lang: &str, code: &str) -> String {
     let theme = theme::current();
-    let (bg_r, bg_g, bg_b) = match theme.background {
+    let bg = match theme.background {
         Color::Rgb(r, g, b) => (r, g, b),
         _ => (0, 0, 0),
     };
-    let bg_code = format!("\x1b[48;2;{bg_r};{bg_g};{bg_b}m");
-
-    let syntax = syntax_for_token(lang);
-    let mut hl = HighlightLines::new(syntax, syntax_theme());
-
-    let mut out = String::new();
-    for line in LinesWithEndings::from(code) {
-        out.push_str(&bg_code);
-        match hl.highlight_line(line, syntax_set()) {
-            Ok(ranges) => {
-                for (style, text) in ranges {
-                    let fg = style.foreground;
-                    let bold = if style.font_style.contains(FontStyle::BOLD) {
-                        "1;"
-                    } else {
-                        ""
-                    };
-                    let _ = write!(
-                        out,
-                        "\x1b[{bold}38;2;{};{};{}m{}",
-                        fg.r,
-                        fg.g,
-                        fg.b,
-                        text.trim_end_matches('\n')
-                    );
-                }
-            }
-            Err(_) => out.push_str(line.trim_end_matches('\n')),
-        }
-        out.push_str("\x1b[K\x1b[0m\n");
-    }
-    out
+    maki_highlight::highlight_ansi(lang, code, bg)
 }
 
-fn convert_style(s: syntect::highlighting::Style) -> Style {
-    let f = s.foreground;
-    let mut style = Style::new().fg(Color::Rgb(f.r, f.g, f.b));
-    if s.font_style.contains(FontStyle::BOLD) {
+fn convert_segment(seg: &StyledSegment) -> Style {
+    let mut style = Style::new().fg(Color::Rgb(seg.fg.0, seg.fg.1, seg.fg.2));
+    if seg.bold {
         style = style.add_modifier(Modifier::BOLD);
     }
-    if s.font_style.contains(FontStyle::ITALIC) {
+    if seg.italic {
         style = style.add_modifier(Modifier::ITALIC);
     }
-    if s.font_style.contains(FontStyle::UNDERLINE) {
+    if seg.underline {
         style = style.add_modifier(Modifier::UNDERLINED);
     }
     style
@@ -277,71 +121,45 @@ fn convert_style(s: syntect::highlighting::Style) -> Style {
 mod tests {
     use super::*;
 
-    fn spans_text(lines: &[Line<'_>]) -> Vec<String> {
-        lines
-            .iter()
-            .map(|l| {
-                l.spans
-                    .iter()
-                    .map(|s| s.content.as_ref())
-                    .collect::<String>()
-            })
-            .collect()
+    #[test]
+    fn convert_segment_modifiers() {
+        let all_mods = StyledSegment {
+            text: "x".into(),
+            fg: (255, 0, 128),
+            bold: true,
+            italic: true,
+            underline: true,
+        };
+        let style = convert_segment(&all_mods);
+        assert_eq!(style.fg, Some(Color::Rgb(255, 0, 128)));
+        assert!(style.add_modifier.contains(Modifier::BOLD));
+        assert!(style.add_modifier.contains(Modifier::ITALIC));
+        assert!(style.add_modifier.contains(Modifier::UNDERLINED));
+
+        let no_mods = StyledSegment {
+            text: "plain".into(),
+            fg: (100, 100, 100),
+            bold: false,
+            italic: false,
+            underline: false,
+        };
+        let style = convert_segment(&no_mods);
+        assert_eq!(style.fg, Some(Color::Rgb(100, 100, 100)));
+        assert!(style.add_modifier.is_empty());
     }
 
     #[test]
-    fn incremental_matches_full_highlight() {
-        let code = "fn main() {\n    println!(\"hi\");\n}\n";
-        let full = highlight_code_plain("rust", code);
-        let mut ch = CodeHighlighter::new("rust");
-        let incremental = ch.update(code);
-        assert_eq!(spans_text(&full), spans_text(incremental));
+    fn fallback_span_normalizes() {
+        let span = fallback_span("\thello\n");
+        let expected = format!("{TAB_SPACES}hello");
+        assert_eq!(span.content.as_ref(), expected);
     }
 
     #[test]
-    fn incremental_streaming_matches_full() {
-        let mut ch = CodeHighlighter::new("py");
-        ch.update("x = ");
-        ch.update("x = 1\ny");
-        let result = ch.update("x = 1\ny = 2\n");
-        let full = highlight_code_plain("py", "x = 1\ny = 2\n");
-        assert_eq!(spans_text(&full), spans_text(result));
-    }
-
-    #[test]
-    fn tsx_and_typescript_syntaxes_resolve() {
-        for token in ["tsx", "typescript"] {
-            assert!(
-                syntax_set().find_syntax_by_token(token).is_some(),
-                "{token}"
-            );
-        }
-    }
-
-    #[test]
-    fn jsx_falls_back_to_javascript() {
-        let token_syntax = syntax_for_token("jsx");
-        let js = syntax_set().find_syntax_by_token("js").unwrap();
-        assert_eq!(token_syntax.name, js.name);
-    }
-
-    #[test]
-    fn normalize_text_strips_newlines_and_expands_tabs() {
-        let mut hl = highlighter_for_path("test.go");
-        let text: String = highlight_line(&mut hl, "\tvalue\n")
-            .iter()
-            .map(|(_, t)| t.as_str())
-            .collect();
-        assert!(text.starts_with(TAB_SPACES), "tab not expanded: {text:?}");
-        assert!(!text.contains('\t'));
-        assert!(!text.ends_with('\n'));
-    }
-
-    #[test]
-    fn highlight_ansi_includes_background() {
-        let out = highlight_ansi("bash", "echo hi\n");
-        assert!(out.contains("\x1b[48;2;"), "expected background ANSI");
-        assert!(out.contains("\x1b[38;2;"), "expected foreground ANSI");
-        assert!(out.contains("echo"));
+    fn highlight_regex_inline_roundtrips_text() {
+        let pattern = "[a-z]+\\d{2,}";
+        let spans = highlight_regex_inline(pattern);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, pattern);
     }
 }


### PR DESCRIPTION
Three things needed before the bash tool can move to Lua.

maki.ui.highlight(code, lang) gives plugins access to syntax highlighting. It runs syntect in smol::unblock and returns styled spans that plugins can modify before appending to a buffer. To make this work, highlighting got extracted into maki-highlight so both the UI and Lua can share it.

jobstart now calls setsid() and jobstop uses killpg() so commands that spawn children get cleaned up properly.

jobwait blocks the handler coroutine until a job exits or times out, collecting stdout/stderr into a table. subscribe_wait guards against double-subscribe instead of silently dropping the first receiver.