### PR TITLE
Add native GitHub Copilot provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,6 +2396,7 @@ dependencies = [
  "maki-storage",
  "serde",
  "serde_json",
+ "serde_yaml",
  "smol",
  "strum",
  "tempfile",

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ User experience:
 Supported providers:
 * Anthropic - `ANTHROPIC_API_KEY` only (using OAuth is against TOS).
 * OpenAI - `OPENAI_API_KEY` and OAuth via `maki auth login openai`.
+* Copilot - `GH_COPILOT_TOKEN` or an existing GitHub Copilot sign-in at `~/.config/github-copilot/`.
 * Ollama - `OLLAMA_HOST` for local (e.g. `http://localhost:11434`), or `OLLAMA_API_KEY` for cloud.
 * Mistral - `MISTRAL_API_KEY`.
 * Z.AI - `ZHIPU_API_KEY`.

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -141,6 +141,18 @@ fn build_sections() -> Vec<ProviderSection> {
                     entries: models_for_provider(kind),
                 });
             }
+            ProviderKind::Copilot => {
+                sections.push(ProviderSection {
+                    name: kind.display_name(),
+                    auth_line: format!(
+                        "{} or `~/.config/github-copilot/{{hosts.json,apps.json}}`",
+                        format_auth(kind)
+                    ),
+                    urls: vec![kind.base_url()],
+                    features: kind.features(),
+                    entries: models_for_provider(kind),
+                });
+            }
             _ => {
                 sections.push(ProviderSection {
                     name: kind.display_name(),

--- a/maki-providers/Cargo.toml
+++ b/maki-providers/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 maki-storage = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -12,6 +12,7 @@ pub use model::{
     models_for_provider,
 };
 pub use providers::Timeouts;
+pub use providers::copilot::auth as copilot_auth;
 pub use providers::dynamic;
 pub use providers::openai::auth as openai_auth;
 pub use types::{

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -10,7 +10,9 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 use crate::provider::ProviderKind;
-use crate::providers::{anthropic, dynamic, google, mistral, ollama, openai, synthetic, zai};
+use crate::providers::{
+    anthropic, copilot, dynamic, google, mistral, ollama, openai, synthetic, zai,
+};
 
 const PER_MILLION: f64 = 1_000_000.0;
 
@@ -110,6 +112,7 @@ pub fn models_for_provider(provider: ProviderKind) -> &'static [ModelEntry] {
     match provider {
         ProviderKind::Anthropic => anthropic::models(),
         ProviderKind::OpenAi => openai::models(),
+        ProviderKind::Copilot => copilot::models(),
         ProviderKind::Ollama => ollama::models(),
         ProviderKind::Mistral => mistral::models(),
         ProviderKind::Google => google::models(),

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -9,6 +9,7 @@ use tracing::{debug, warn};
 use crate::model::{Model, ModelFamily, models_for_provider};
 use crate::providers::Timeouts;
 use crate::providers::anthropic::Anthropic;
+use crate::providers::copilot::Copilot;
 use crate::providers::dynamic;
 use crate::providers::google::Google;
 use crate::providers::mistral::Mistral;
@@ -25,6 +26,7 @@ pub enum ProviderKind {
     #[strum(serialize = "openai")]
     OpenAi,
     Google,
+    Copilot,
     Ollama,
     Mistral,
     Zai,
@@ -38,6 +40,7 @@ impl ProviderKind {
             Self::Anthropic => "Anthropic",
             Self::OpenAi => "OpenAI",
             Self::Google => "Google",
+            Self::Copilot => "Copilot",
             Self::Ollama => "Ollama",
             Self::Mistral => "Mistral",
             Self::Zai => "Z.AI",
@@ -51,6 +54,7 @@ impl ProviderKind {
             Self::Anthropic => "ANTHROPIC_API_KEY",
             Self::OpenAi => "OPENAI_API_KEY",
             Self::Google => "GEMINI_API_KEY",
+            Self::Copilot => "GH_COPILOT_TOKEN",
             Self::Ollama => "OLLAMA_API_KEY",
             Self::Mistral => "MISTRAL_API_KEY",
             Self::Zai | Self::ZaiCodingPlan => "ZHIPU_API_KEY",
@@ -63,6 +67,9 @@ impl ProviderKind {
             Self::Anthropic => "https://api.anthropic.com/v1/messages",
             Self::OpenAi => "https://api.openai.com/v1",
             Self::Google => "https://generativelanguage.googleapis.com/v1beta",
+            Self::Copilot => {
+                "https://api.githubcopilot.com (or GraphQL-discovered Copilot API endpoint)"
+            }
             Self::Ollama => "http://localhost:11434/v1",
             Self::Mistral => "https://api.mistral.ai/v1",
             Self::Zai => "https://api.z.ai/api/paas/v4",
@@ -84,6 +91,7 @@ impl ProviderKind {
                 Some("Prompt caching, thinking mode (adaptive/budgeted), advanced tool use")
             }
             Self::Google => Some("Native Gemini API with thinking support"),
+            Self::Copilot => Some("Native Copilot Chat HTTP API with model endpoint discovery"),
             Self::Ollama => {
                 Some("Local or remote inference via OLLAMA_HOST, cloud fallback via OLLAMA_API_KEY")
             }
@@ -99,6 +107,7 @@ impl ProviderKind {
             Self::Anthropic => ModelFamily::Claude,
             Self::OpenAi => ModelFamily::Gpt,
             Self::Google => ModelFamily::Gemini,
+            Self::Copilot => ModelFamily::Generic,
             Self::Ollama => ModelFamily::Generic,
             Self::Mistral => ModelFamily::Generic,
             Self::Zai | Self::ZaiCodingPlan => ModelFamily::Glm,
@@ -107,7 +116,7 @@ impl ProviderKind {
     }
 
     pub const fn accepts_arbitrary_models(self) -> bool {
-        matches!(self, Self::Ollama | Self::Google)
+        matches!(self, Self::Ollama | Self::Google | Self::Copilot)
     }
 
     pub const fn fallback_max_output(self) -> u32 {
@@ -115,6 +124,7 @@ impl ProviderKind {
             Self::Anthropic => 128_000,
             Self::OpenAi => 100_000,
             Self::Google => 65_536,
+            Self::Copilot => 100_000,
             Self::Ollama => 16_384,
             Self::Mistral => 32_000,
             Self::Zai | Self::ZaiCodingPlan => 16_000,
@@ -127,6 +137,7 @@ impl ProviderKind {
             Self::Anthropic => 200_000,
             Self::OpenAi => 200_000,
             Self::Google => 1_000_000,
+            Self::Copilot => 200_000,
             Self::Ollama => 128_000,
             Self::Mistral => 128_000,
             Self::Zai | Self::ZaiCodingPlan => 128_000,
@@ -139,6 +150,7 @@ impl ProviderKind {
             Self::Anthropic => Ok(Box::new(Anthropic::new(timeouts)?)),
             Self::OpenAi => Ok(Box::new(OpenAi::new(timeouts)?)),
             Self::Google => Ok(Box::new(Google::new(timeouts)?)),
+            Self::Copilot => Ok(Box::new(Copilot::new(timeouts)?)),
             Self::Ollama => Ok(Box::new(Ollama::new(timeouts)?)),
             Self::Mistral => Ok(Box::new(Mistral::new(timeouts)?)),
             Self::Zai => Ok(Box::new(Zai::new(ZaiPlan::Standard, timeouts)?)),

--- a/maki-providers/src/providers/anthropic.rs
+++ b/maki-providers/src/providers/anthropic.rs
@@ -590,7 +590,7 @@ fn build_wire_tools(tools: &Value) -> Value {
     Value::Array(out)
 }
 
-async fn parse_sse(
+pub(crate) async fn parse_sse(
     response: isahc::Response<isahc::AsyncBody>,
     event_tx: &Sender<ProviderEvent>,
     stream_timeout: Duration,

--- a/maki-providers/src/providers/copilot/auth.rs
+++ b/maki-providers/src/providers/copilot/auth.rs
@@ -1,0 +1,143 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use serde_json::Value as JsonValue;
+use serde_yaml::Value as YamlValue;
+
+use crate::AgentError;
+
+const TOKEN_ENV_VARS: &[&str] = &["GH_COPILOT_TOKEN", "COPILOT_GITHUB_TOKEN"];
+const COPILOT_DOMAIN: &str = "github.com";
+
+pub(crate) fn load_token() -> Result<String, AgentError> {
+    for key in TOKEN_ENV_VARS {
+        if let Ok(token) = env::var(key)
+            && !token.trim().is_empty()
+        {
+            return Ok(token);
+        }
+    }
+
+    for path in copilot_config_paths() {
+        if let Ok(contents) = fs::read_to_string(path)
+            && let Some(token) = extract_json_oauth_token(&contents, COPILOT_DOMAIN)
+        {
+            return Ok(token);
+        }
+    }
+
+    for path in gh_config_paths() {
+        if let Ok(contents) = fs::read_to_string(path)
+            && let Some(token) = extract_yaml_oauth_token(&contents, COPILOT_DOMAIN)
+        {
+            return Ok(token);
+        }
+    }
+
+    Err(AgentError::Config {
+        message: "Copilot token not found. Run `gh auth login --web`, sign in with GitHub Copilot, or set GH_COPILOT_TOKEN.".into(),
+    })
+}
+
+pub fn login() -> Result<(), AgentError> {
+    let _ = load_token()?;
+    println!("Copilot token found.");
+    Ok(())
+}
+
+pub fn logout() -> Result<(), AgentError> {
+    Err(AgentError::Config {
+        message: "Copilot auth is managed by GitHub Copilot. Sign out from your Copilot client or remove GH_COPILOT_TOKEN.".into(),
+    })
+}
+
+fn copilot_config_paths() -> Vec<PathBuf> {
+    let base = config_dir().map(|config| config.join("github-copilot"));
+    base.map(|base| vec![base.join("hosts.json"), base.join("apps.json")])
+        .unwrap_or_default()
+}
+
+fn gh_config_paths() -> Vec<PathBuf> {
+    config_dir()
+        .map(|config| vec![config.join("gh").join("hosts.yml")])
+        .unwrap_or_default()
+}
+
+fn config_dir() -> Option<PathBuf> {
+    env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".config")))
+}
+
+fn extract_json_oauth_token(contents: &str, domain: &str) -> Option<String> {
+    let value: JsonValue = serde_json::from_str(contents).ok()?;
+    value.as_object()?.iter().find_map(|(key, value)| {
+        if key.starts_with(domain) {
+            value["oauth_token"].as_str().map(ToOwned::to_owned)
+        } else {
+            None
+        }
+    })
+}
+
+fn extract_yaml_oauth_token(contents: &str, domain: &str) -> Option<String> {
+    let value: YamlValue = serde_yaml::from_str(contents).ok()?;
+    value.as_mapping()?.iter().find_map(|(key, value)| {
+        if key.as_str().is_some_and(|key| key.starts_with(domain)) {
+            value["oauth_token"].as_str().map(ToOwned::to_owned)
+        } else {
+            None
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_matching_oauth_token() {
+        let contents = r#"{
+            "github.com": {
+                "oauth_token": "token-1"
+            }
+        }"#;
+        assert_eq!(
+            extract_json_oauth_token(contents, "github.com").as_deref(),
+            Some("token-1")
+        );
+    }
+
+    #[test]
+    fn ignores_other_domains() {
+        let contents = r#"{
+            "enterprise.example.com": {
+                "oauth_token": "token-1"
+            }
+        }"#;
+        assert_eq!(extract_json_oauth_token(contents, "github.com"), None);
+    }
+
+    #[test]
+    fn extracts_matching_gh_oauth_token() {
+        let contents = r#"
+github.com:
+  oauth_token: token-1
+  user: octocat
+"#;
+        assert_eq!(
+            extract_yaml_oauth_token(contents, "github.com").as_deref(),
+            Some("token-1")
+        );
+    }
+
+    #[test]
+    fn ignores_other_gh_domains() {
+        let contents = r#"
+enterprise.example.com:
+  oauth_token: token-1
+"#;
+        assert_eq!(extract_yaml_oauth_token(contents, "github.com"), None);
+    }
+}

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -1,0 +1,614 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use flume::Sender;
+use futures_lite::io::BufReader;
+use isahc::{AsyncReadResponseExt, HttpClient, Request};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tracing::{debug, warn};
+
+use super::openai::responses;
+use super::openai_compat;
+use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
+use crate::provider::{BoxFuture, Provider};
+use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
+
+pub mod auth;
+
+const DEFAULT_API_ENDPOINT: &str = "https://api.githubcopilot.com";
+const GRAPHQL_QUERY: &str = "query { viewer { copilotEndpoints { api } } }";
+const API_VERSION_HEADER: &str = "2025-10-01";
+const EDITOR_VERSION_HEADER: &str = concat!("Maki/", env!("CARGO_PKG_VERSION"));
+const CHAT_COMPLETIONS_PATH: &str = "/chat/completions";
+const RESPONSES_PATH: &str = "/responses";
+const MESSAGES_PATH: &str = "/v1/messages";
+const MODELS_PATH: &str = "/models";
+
+pub(crate) fn models() -> &'static [ModelEntry] {
+    &[
+        ModelEntry {
+            prefixes: &["gpt-5-mini", "gpt-5 mini", "claude-haiku-4.5"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Generic,
+            default: true,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 100_000,
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.2", "gpt-4.1", "claude-sonnet-4.5"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            default: true,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 100_000,
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &[
+                "gpt-5.4",
+                "gpt-5.3-codex",
+                "claude-opus-4.6",
+                "grok-code-fast-1",
+            ],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Generic,
+            default: true,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 100_000,
+            context_window: 200_000,
+        },
+    ]
+}
+
+pub struct Copilot {
+    client: HttpClient,
+    stream_timeout: Duration,
+    auth: Arc<Mutex<Option<CopilotAuth>>>,
+    resolved_auth: Option<Arc<Mutex<super::ResolvedAuth>>>,
+    system_prefix: Option<String>,
+    models: Arc<Mutex<HashMap<String, CopilotModel>>>,
+}
+
+impl Copilot {
+    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
+        Ok(Self {
+            client: super::http_client(timeouts),
+            stream_timeout: timeouts.stream,
+            auth: Arc::default(),
+            resolved_auth: None,
+            system_prefix: None,
+            models: Arc::default(),
+        })
+    }
+
+    pub(crate) fn with_auth(
+        auth: Arc<Mutex<super::ResolvedAuth>>,
+        timeouts: super::Timeouts,
+    ) -> Self {
+        Self {
+            client: super::http_client(timeouts),
+            stream_timeout: timeouts.stream,
+            auth: Arc::default(),
+            resolved_auth: Some(auth),
+            system_prefix: None,
+            models: Arc::default(),
+        }
+    }
+
+    pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
+        self.system_prefix = prefix;
+        self
+    }
+
+    async fn auth(&self) -> Result<CopilotAuth, AgentError> {
+        if let Some(auth) = &self.resolved_auth {
+            return copilot_auth_from_resolved(&auth.lock().unwrap());
+        }
+
+        if let Some(auth) = self.auth.lock().unwrap().clone() {
+            return Ok(auth);
+        }
+
+        let token = auth::load_token()?;
+        let endpoint = discover_api_endpoint(&self.client, &token).await;
+        let auth = CopilotAuth { token, endpoint };
+        *self.auth.lock().unwrap() = Some(auth.clone());
+        Ok(auth)
+    }
+
+    async fn model_endpoint(&self, model_id: &str) -> Result<Endpoint, AgentError> {
+        if let Some(model) = self.models.lock().unwrap().get(model_id).cloned() {
+            return Ok(model.endpoint());
+        }
+
+        let models = self.fetch_models().await?;
+        let mut guard = self.models.lock().unwrap();
+        guard.clear();
+        guard.extend(models.into_iter().map(|model| (model.id.clone(), model)));
+        Ok(guard
+            .get(model_id)
+            .map(CopilotModel::endpoint)
+            .unwrap_or_else(|| guess_endpoint(model_id)))
+    }
+
+    async fn fetch_models(&self) -> Result<Vec<CopilotModel>, AgentError> {
+        let auth = self.auth().await?;
+        let request = copilot_request(
+            Request::builder()
+                .method("GET")
+                .uri(format!("{}{MODELS_PATH}", auth.endpoint)),
+            &auth,
+            None,
+        )
+        .body(())?;
+
+        let mut response = self.client.send_async(request).await?;
+        if !response.status().is_success() {
+            return Err(AgentError::from_response(response).await);
+        }
+
+        let body: CopilotModelsResponse = serde_json::from_str(&response.text().await?)?;
+        let mut models = body
+            .data
+            .into_iter()
+            .filter_map(
+                |value| match serde_json::from_value::<CopilotModel>(value) {
+                    Ok(model) => Some(model),
+                    Err(err) => {
+                        warn!(error = %err, "skipping malformed Copilot model metadata");
+                        None
+                    }
+                },
+            )
+            .filter(CopilotModel::is_enabled_chat_model)
+            .collect::<Vec<_>>();
+
+        if let Some(default_pos) = models.iter().position(|model| model.is_chat_default) {
+            let default_model = models.remove(default_pos);
+            models.insert(0, default_model);
+        }
+
+        Ok(models)
+    }
+
+    async fn stream_chat_completions(
+        &self,
+        model: &Model,
+        messages: &[Message],
+        system: &str,
+        tools: &Value,
+        event_tx: &Sender<ProviderEvent>,
+    ) -> Result<StreamResponse, AgentError> {
+        let auth = self.auth().await?;
+        let wire_tools = openai_compat::convert_tools(tools);
+        let mut body = json!({
+            "model": model.id,
+            "messages": openai_compat::convert_messages(messages, system),
+            "n": 1,
+            "stream": true,
+            "temperature": 0.1,
+        });
+        if wire_tools.as_array().is_some_and(|tools| !tools.is_empty()) {
+            body["tools"] = wire_tools;
+        }
+
+        let request = self
+            .build_post(
+                &auth,
+                CHAT_COMPLETIONS_PATH,
+                Some("conversation-agent"),
+                &body,
+            )?
+            .body(serde_json::to_vec(&body)?)?;
+        let response = self.client.send_async(request).await?;
+        if response.status().is_success() {
+            openai_compat::parse_sse(
+                BufReader::new(response.into_body()),
+                event_tx,
+                self.stream_timeout,
+            )
+            .await
+        } else {
+            Err(AgentError::from_response(response).await)
+        }
+    }
+
+    async fn stream_responses(
+        &self,
+        model: &Model,
+        messages: &[Message],
+        system: &str,
+        tools: &Value,
+        event_tx: &Sender<ProviderEvent>,
+    ) -> Result<StreamResponse, AgentError> {
+        let auth = self.auth().await?;
+        let body = responses::build_body(model, messages, system, tools);
+        let resolved = super::ResolvedAuth {
+            base_url: Some(auth.endpoint.clone()),
+            headers: copilot_headers(&auth, Some("conversation-agent")),
+        };
+        responses::do_stream(
+            &self.client,
+            model,
+            &body,
+            event_tx,
+            &resolved,
+            self.stream_timeout,
+        )
+        .await
+    }
+
+    async fn stream_messages(
+        &self,
+        model: &Model,
+        messages: &[Message],
+        system: &str,
+        tools: &Value,
+        event_tx: &Sender<ProviderEvent>,
+        thinking: ThinkingConfig,
+    ) -> Result<StreamResponse, AgentError> {
+        let auth = self.auth().await?;
+        let mut body = json!({
+            "model": model.id,
+            "max_tokens": model.max_output_tokens,
+            "system": [{"type": "text", "text": system}],
+            "messages": anthropic_messages(messages),
+            "tools": tools,
+            "stream": true,
+        });
+        thinking.apply_to_body(&mut body);
+
+        let request = self
+            .build_post(&auth, MESSAGES_PATH, Some("conversation-agent"), &body)?
+            .header("anthropic-version", "2023-06-01")
+            .body(serde_json::to_vec(&body)?)?;
+        let response = self.client.send_async(request).await?;
+        if response.status().is_success() {
+            super::anthropic::parse_sse(response, event_tx, self.stream_timeout).await
+        } else {
+            Err(AgentError::from_response(response).await)
+        }
+    }
+
+    fn build_post(
+        &self,
+        auth: &CopilotAuth,
+        path: &str,
+        interaction_type: Option<&str>,
+        body: &Value,
+    ) -> Result<isahc::http::request::Builder, AgentError> {
+        debug!(
+            path,
+            body_bytes = serde_json::to_vec(body)?.len(),
+            "sending Copilot API request"
+        );
+        Ok(copilot_request(
+            Request::builder()
+                .method("POST")
+                .uri(format!("{}{path}", auth.endpoint)),
+            auth,
+            interaction_type,
+        ))
+    }
+}
+
+#[derive(Clone)]
+struct CopilotAuth {
+    token: String,
+    endpoint: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Endpoint {
+    ChatCompletions,
+    Responses,
+    Messages,
+}
+
+#[derive(Clone, Deserialize)]
+struct CopilotModel {
+    id: String,
+    #[serde(default)]
+    policy: Option<CopilotModelPolicy>,
+    #[serde(default)]
+    capabilities: CopilotModelCapabilities,
+    #[serde(default)]
+    is_chat_default: bool,
+    #[serde(default)]
+    model_picker_enabled: bool,
+    #[serde(default)]
+    supported_endpoints: Vec<String>,
+}
+
+impl CopilotModel {
+    fn is_enabled_chat_model(&self) -> bool {
+        self.model_picker_enabled
+            && self.capabilities.model_type == "chat"
+            && self
+                .policy
+                .as_ref()
+                .is_none_or(|policy| policy.state == "enabled")
+    }
+
+    fn endpoint(&self) -> Endpoint {
+        if self
+            .supported_endpoints
+            .iter()
+            .any(|endpoint| endpoint == MESSAGES_PATH)
+        {
+            Endpoint::Messages
+        } else if self
+            .supported_endpoints
+            .iter()
+            .any(|endpoint| endpoint == RESPONSES_PATH)
+        {
+            Endpoint::Responses
+        } else {
+            Endpoint::ChatCompletions
+        }
+    }
+}
+
+#[derive(Clone, Default, Deserialize)]
+struct CopilotModelPolicy {
+    #[serde(default)]
+    state: String,
+}
+
+#[derive(Clone, Default, Deserialize)]
+struct CopilotModelCapabilities {
+    #[serde(default, rename = "type")]
+    model_type: String,
+}
+
+#[derive(Deserialize)]
+struct CopilotModelsResponse {
+    #[serde(default)]
+    data: Vec<Value>,
+}
+
+#[derive(Deserialize)]
+struct GraphQlResponse {
+    data: Option<GraphQlData>,
+}
+
+#[derive(Deserialize)]
+struct GraphQlData {
+    viewer: GraphQlViewer,
+}
+
+#[derive(Deserialize)]
+struct GraphQlViewer {
+    #[serde(rename = "copilotEndpoints")]
+    copilot_endpoints: GraphQlCopilotEndpoints,
+}
+
+#[derive(Deserialize)]
+struct GraphQlCopilotEndpoints {
+    api: String,
+}
+
+async fn discover_api_endpoint(client: &HttpClient, token: &str) -> String {
+    match try_discover_api_endpoint(client, token).await {
+        Ok(endpoint) => endpoint,
+        Err(err) => {
+            warn!(error = %err, fallback = DEFAULT_API_ENDPOINT, "Copilot endpoint discovery failed");
+            DEFAULT_API_ENDPOINT.to_owned()
+        }
+    }
+}
+
+async fn try_discover_api_endpoint(client: &HttpClient, token: &str) -> Result<String, AgentError> {
+    let body = json!({ "query": GRAPHQL_QUERY });
+    let request = Request::builder()
+        .method("POST")
+        .uri("https://api.github.com/graphql")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(serde_json::to_vec(&body)?)?;
+
+    let mut response = client.send_async(request).await?;
+    if !response.status().is_success() {
+        return Err(AgentError::from_response(response).await);
+    }
+
+    let parsed: GraphQlResponse = serde_json::from_str(&response.text().await?)?;
+    parsed
+        .data
+        .map(|data| data.viewer.copilot_endpoints.api)
+        .ok_or_else(|| AgentError::Config {
+            message: "Copilot endpoint discovery response contained no data".into(),
+        })
+}
+
+fn copilot_request(
+    builder: isahc::http::request::Builder,
+    auth: &CopilotAuth,
+    interaction_type: Option<&str>,
+) -> isahc::http::request::Builder {
+    let builder = builder
+        .header("authorization", format!("Bearer {}", auth.token))
+        .header("content-type", "application/json")
+        .header("editor-version", EDITOR_VERSION_HEADER)
+        .header("x-github-api-version", API_VERSION_HEADER);
+
+    if let Some(interaction_type) = interaction_type {
+        builder
+            .header("x-initiator", "agent")
+            .header("x-interaction-type", interaction_type)
+            .header("openai-intent", interaction_type)
+    } else {
+        builder
+    }
+}
+
+fn copilot_headers(auth: &CopilotAuth, interaction_type: Option<&str>) -> Vec<(String, String)> {
+    let mut headers = vec![
+        ("authorization".into(), format!("Bearer {}", auth.token)),
+        ("content-type".into(), "application/json".into()),
+        ("editor-version".into(), EDITOR_VERSION_HEADER.into()),
+        ("x-github-api-version".into(), API_VERSION_HEADER.into()),
+    ];
+    if let Some(interaction_type) = interaction_type {
+        headers.extend([
+            ("x-initiator".into(), "agent".into()),
+            ("x-interaction-type".into(), interaction_type.into()),
+            ("openai-intent".into(), interaction_type.into()),
+        ]);
+    }
+    headers
+}
+
+fn copilot_auth_from_resolved(auth: &super::ResolvedAuth) -> Result<CopilotAuth, AgentError> {
+    let token = auth
+        .headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("authorization"))
+        .and_then(|(_, value)| value.strip_prefix("Bearer "))
+        .map(str::to_owned)
+        .ok_or_else(|| AgentError::Config {
+            message: "dynamic Copilot provider missing Bearer authorization header".into(),
+        })?;
+
+    Ok(CopilotAuth {
+        token,
+        endpoint: auth
+            .base_url
+            .clone()
+            .unwrap_or_else(|| DEFAULT_API_ENDPOINT.into()),
+    })
+}
+
+fn anthropic_messages(messages: &[Message]) -> Value {
+    Value::Array(
+        messages
+            .iter()
+            .map(|message| {
+                json!({
+                    "role": message.role,
+                    "content": message.content,
+                })
+            })
+            .collect(),
+    )
+}
+
+fn guess_endpoint(model_id: &str) -> Endpoint {
+    if model_id.starts_with("claude-") {
+        Endpoint::Messages
+    } else if model_id.contains("gpt-5") || model_id.contains("codex") {
+        Endpoint::Responses
+    } else {
+        Endpoint::ChatCompletions
+    }
+}
+
+impl Provider for Copilot {
+    fn stream_message<'a>(
+        &'a self,
+        model: &'a Model,
+        messages: &'a [Message],
+        system: &'a str,
+        tools: &'a Value,
+        event_tx: &'a Sender<ProviderEvent>,
+        thinking: ThinkingConfig,
+        _session_id: Option<&'a str>,
+    ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
+        Box::pin(async move {
+            let mut prefixed_system = String::new();
+            let system = super::with_prefix(&self.system_prefix, system, &mut prefixed_system);
+            let endpoint = self.model_endpoint(&model.id).await?;
+            debug!(model = %model.id, ?endpoint, "running Copilot request");
+            match endpoint {
+                Endpoint::ChatCompletions => {
+                    self.stream_chat_completions(model, messages, system, tools, event_tx)
+                        .await
+                }
+                Endpoint::Responses => {
+                    self.stream_responses(model, messages, system, tools, event_tx)
+                        .await
+                }
+                Endpoint::Messages => {
+                    self.stream_messages(model, messages, system, tools, event_tx, thinking)
+                        .await
+                }
+            }
+        })
+    }
+
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+        Box::pin(async move {
+            let models = self.fetch_models().await?;
+            let ids = models
+                .iter()
+                .map(|model| model.id.clone())
+                .collect::<Vec<_>>();
+            let mut guard = self.models.lock().unwrap();
+            guard.clear();
+            guard.extend(models.into_iter().map(|model| (model.id.clone(), model)));
+            Ok(ids)
+        })
+    }
+
+    fn reload_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
+        Box::pin(async {
+            *self.auth.lock().unwrap() = None;
+            self.models.lock().unwrap().clear();
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_prefers_messages_then_responses_then_chat() {
+        let mut model = CopilotModel {
+            id: "claude-sonnet-4.5".into(),
+            policy: None,
+            capabilities: CopilotModelCapabilities {
+                model_type: "chat".into(),
+            },
+            is_chat_default: false,
+            model_picker_enabled: true,
+            supported_endpoints: vec![CHAT_COMPLETIONS_PATH.into(), MESSAGES_PATH.into()],
+        };
+        assert_eq!(model.endpoint(), Endpoint::Messages);
+
+        model.supported_endpoints = vec![RESPONSES_PATH.into()];
+        assert_eq!(model.endpoint(), Endpoint::Responses);
+
+        model.supported_endpoints.clear();
+        assert_eq!(model.endpoint(), Endpoint::ChatCompletions);
+    }
+
+    #[test]
+    fn filters_enabled_chat_models() {
+        let enabled = CopilotModel {
+            id: "gpt-5.4".into(),
+            policy: Some(CopilotModelPolicy {
+                state: "enabled".into(),
+            }),
+            capabilities: CopilotModelCapabilities {
+                model_type: "chat".into(),
+            },
+            is_chat_default: false,
+            model_picker_enabled: true,
+            supported_endpoints: vec![],
+        };
+        assert!(enabled.is_enabled_chat_model());
+
+        let disabled = CopilotModel {
+            policy: Some(CopilotModelPolicy {
+                state: "pending".into(),
+            }),
+            ..enabled
+        };
+        assert!(!disabled.is_enabled_chat_model());
+    }
+}

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -17,6 +17,7 @@ use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
 
 use super::ResolvedAuth;
 use super::anthropic::Anthropic;
+use super::copilot::Copilot;
 use super::google::Google;
 use super::mistral::Mistral;
 use super::ollama::Ollama;
@@ -348,6 +349,10 @@ pub fn create(slug: &str, timeouts: super::Timeouts) -> Result<Box<dyn Provider>
                 .with_system_prefix(meta.system_prefix.clone()),
         ),
         ProviderKind::Google => Box::new(Google::with_auth(auth.clone(), timeouts)),
+        ProviderKind::Copilot => Box::new(
+            Copilot::with_auth(auth.clone(), timeouts)
+                .with_system_prefix(meta.system_prefix.clone()),
+        ),
         ProviderKind::Ollama => Box::new(
             Ollama::with_auth(auth.clone(), timeouts)
                 .with_system_prefix(meta.system_prefix.clone()),

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use crate::AgentError;
 
 pub(crate) mod anthropic;
+pub(crate) mod copilot;
 pub mod dynamic;
 pub(crate) mod google;
 pub(crate) mod mistral;

--- a/maki-providers/src/providers/openai/mod.rs
+++ b/maki-providers/src/providers/openai/mod.rs
@@ -1,6 +1,6 @@
 pub mod auth;
 mod platform;
-mod responses;
+pub(crate) mod responses;
 
 pub use platform::OpenAi;
 

--- a/maki-providers/src/providers/openai/responses.rs
+++ b/maki-providers/src/providers/openai/responses.rs
@@ -230,7 +230,16 @@ pub(crate) async fn parse_sse(
             });
         }
 
-        match current_event.as_str() {
+        let parsed_event = if current_event.is_empty() {
+            serde_json::from_str::<Value>(data)
+                .ok()
+                .and_then(|value| value["type"].as_str().map(ToOwned::to_owned))
+                .unwrap_or_default()
+        } else {
+            current_event.clone()
+        };
+
+        match parsed_event.as_str() {
             "response.output_text.delta" => {
                 let parsed: Value = match serde_json::from_str(data) {
                     Ok(v) => v,
@@ -293,6 +302,58 @@ pub(crate) async fn parse_sse(
                         .find(|a| a.output_index == output_index)
                     {
                         acc.arguments.push_str(delta);
+                    }
+                }
+            }
+
+            "response.output_item.done" => {
+                let parsed: Value = match serde_json::from_str(data) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                let item = &parsed["item"];
+                if item["type"].as_str() == Some("function_call") {
+                    let output_index = parsed["output_index"].as_u64().unwrap_or(0);
+                    let call_id = item["call_id"].as_str().unwrap_or_default().to_string();
+                    let name = item["name"].as_str().unwrap_or_default().to_string();
+                    let arguments = item["arguments"].as_str().unwrap_or_default().to_string();
+                    if let Some(acc) = tool_accumulators
+                        .iter_mut()
+                        .find(|acc| acc.output_index == output_index)
+                    {
+                        let should_emit_start = acc.name.is_empty() && !name.is_empty();
+                        if acc.call_id.is_empty() {
+                            acc.call_id = call_id.clone();
+                        }
+                        if acc.name.is_empty() {
+                            acc.name = name.clone();
+                        }
+                        if !arguments.is_empty() {
+                            acc.arguments = arguments;
+                        }
+                        if should_emit_start {
+                            event_tx
+                                .send_async(ProviderEvent::ToolUseStart {
+                                    id: acc.call_id.clone(),
+                                    name: acc.name.clone(),
+                                })
+                                .await?;
+                        }
+                    } else {
+                        if !name.is_empty() {
+                            event_tx
+                                .send_async(ProviderEvent::ToolUseStart {
+                                    id: call_id.clone(),
+                                    name: name.clone(),
+                                })
+                                .await?;
+                        }
+                        tool_accumulators.push(ToolAccumulator {
+                            output_index,
+                            call_id,
+                            name,
+                            arguments,
+                        });
                     }
                 }
             }

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -58,6 +58,20 @@ Defaults: gpt-5.4-nano (weak), gpt-4.1 (medium), gpt-5.5 (strong)
 
 Defaults: gemini-2.5-pro (strong), gemini-2.5-flash (medium), gemini-2.0-flash-lite (weak)
 
+### Copilot
+
+- **Env var**: `GH_COPILOT_TOKEN` or `~/.config/github-copilot/{hosts.json,apps.json}`
+- **API**: `https://api.githubcopilot.com (or GraphQL-discovered Copilot API endpoint)`
+- **Features**: Native Copilot Chat HTTP API with model endpoint discovery
+
+| Tier | Models | Pricing (in/out per 1M tokens) | Context |
+|------|--------|-------------------------------|---------|
+| Weak | **gpt-5-mini, gpt-5 mini, claude-haiku-4.5** (default) | $0.00 / $0.00 | 200K ctx / 100K out |
+| Medium | **gpt-5.2, gpt-4.1, claude-sonnet-4.5** (default) | $0.00 / $0.00 | 200K ctx / 100K out |
+| Strong | **gpt-5.4, gpt-5.3-codex, claude-opus-4.6, grok-code-fast-1** (default) | $0.00 / $0.00 | 200K ctx / 100K out |
+
+Defaults: gpt-5-mini (weak), gpt-5.2 (medium), gpt-5.4 (strong)
+
 ### Ollama
 
 - **Env var**: `OLLAMA_HOST` for local/remote (e.g. `http://localhost:11434`), `OLLAMA_API_KEY` for auth
@@ -135,7 +149,7 @@ To add a custom provider or proxy, drop an executable script into `~/.maki/provi
 
 `resolve` is called each time a new agent spawns, so scripts should read tokens from disk instead of caching them in memory. That way auth changes from other processes get picked up.
 
-The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `ollama`, `mistral`, `zai`, `zai-coding-plan`, `synthetic`.
+The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `copilot`, `ollama`, `mistral`, `zai`, `zai-coding-plan`, `synthetic`.
 
 If your provider serves models not in the base catalog, add a `models` subcommand returning:
 

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -10,12 +10,13 @@ use maki_agent::tools::ToolRegistry;
 use maki_config::load_config;
 use maki_lua::PluginHost;
 use maki_providers::provider::fetch_all_models;
-use maki_providers::{dynamic, openai_auth};
+use maki_providers::{copilot_auth, dynamic, openai_auth};
 use maki_storage::DataDir;
 
 pub fn auth_login(provider: &str, storage: &DataDir) -> Result<()> {
     match provider {
         "openai" => openai_auth::login(storage)?,
+        "copilot" => copilot_auth::login()?,
         slug => dynamic::login(slug)?,
     }
     Ok(())
@@ -24,6 +25,7 @@ pub fn auth_login(provider: &str, storage: &DataDir) -> Result<()> {
 pub fn auth_logout(provider: &str, storage: &DataDir) -> Result<()> {
     match provider {
         "openai" => openai_auth::logout(storage)?,
+        "copilot" => copilot_auth::logout()?,
         slug => dynamic::logout(slug)?,
     }
     Ok(())


### PR DESCRIPTION
## Summary
- Add a native GitHub Copilot provider with endpoint discovery, model listing, and streaming chat support.
- Support Copilot auth from GH_COPILOT_TOKEN, COPILOT_GITHUB_TOKEN, existing github-copilot config files, or gh auth token.
- Wire Copilot into provider/model discovery, auth commands, and generated provider docs.

## Validation
- cargo run -p maki-docgen
- cargo test -p maki-providers copilot
- cargo test --all-features --workspace
- cargo clippy --all-features --all --tests -- -D warnings