### PR TITLE
providers: ollama: respect host URL when API key is set

### DIFF
--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -98,7 +98,7 @@ struct ProviderSection {
 fn format_auth(kind: ProviderKind) -> String {
     let env = kind.api_key_env();
     if kind == ProviderKind::Ollama {
-        format!("`{env}` for cloud, or `OLLAMA_HOST` for local (e.g. `http://localhost:11434`)")
+        format!("`OLLAMA_HOST` for local/remote (e.g. `http://localhost:11434`), `{env}` for auth")
     } else {
         format!("`{env}`")
     }
@@ -243,7 +243,7 @@ fn write_section(out: &mut String, section: &ProviderSection) {
     if section.entries.is_empty() {
         let _ = writeln!(
             out,
-            "Maki asks your local Ollama for the list of installed models, so there's no built-in catalog. Tiers are guessed from list order: the first model becomes strong, the second medium, and the rest weak. If that guess is wrong, open `/model` and press `Alt+1`, `Alt+2`, or `Alt+3` on any row to reassign it. Your choices are saved to `~/.maki/model-tiers`."
+            "Maki asks Ollama for the list of installed models, so there's no built-in catalog. Tiers are guessed from list order: the first model becomes strong, the second medium, and the rest weak. If that guess is wrong, open `/model` and press `Alt+1`, `Alt+2`, or `Alt+3` on any row to reassign it. Your choices are saved to `~/.maki/model-tiers`."
         );
     } else {
         write_model_table(out, section.entries);

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -84,7 +84,9 @@ impl ProviderKind {
                 Some("Prompt caching, thinking mode (adaptive/budgeted), advanced tool use")
             }
             Self::Google => Some("Native Gemini API with thinking support"),
-            Self::Ollama => Some("Local inference via OLLAMA_HOST, or cloud via OLLAMA_API_KEY"),
+            Self::Ollama => {
+                Some("Local or remote inference via OLLAMA_HOST, cloud fallback via OLLAMA_API_KEY")
+            }
             Self::Synthetic => {
                 Some("Reasoning effort support (low/medium/high), open-weight models")
             }

--- a/maki-providers/src/providers/ollama.rs
+++ b/maki-providers/src/providers/ollama.rs
@@ -44,24 +44,24 @@ impl Ollama {
         api_key: Option<String>,
         host: Option<String>,
     ) -> Result<Self, AgentError> {
-        if let Some(api_key) = api_key {
-            return Ok(Self {
-                compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
-                auth: ResolvedAuth {
-                    base_url: Some(CLOUD_BASE_URL.into()),
-                    headers: vec![("authorization".into(), format!("Bearer {api_key}"))],
-                },
-            });
-        }
-
-        let host = host.ok_or(AgentError::Config {
-            message: HOST_NOT_SET.into(),
-        })?;
+        let base_url = match host {
+            Some(h) => format!("{h}/v1"),
+            None if api_key.is_some() => CLOUD_BASE_URL.into(),
+            None => {
+                return Err(AgentError::Config {
+                    message: HOST_NOT_SET.into(),
+                });
+            }
+        };
+        let headers = match api_key {
+            Some(key) => vec![("authorization".into(), format!("Bearer {key}"))],
+            None => Vec::new(),
+        };
         Ok(Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
             auth: ResolvedAuth {
-                base_url: Some(format!("{host}/v1")),
-                headers: Vec::new(),
+                base_url: Some(base_url),
+                headers,
             },
         })
     }
@@ -127,14 +127,18 @@ mod tests {
     }
 
     #[test]
-    fn from_env_api_key_takes_precedence_over_host() {
+    fn from_env_both_host_and_api_key_uses_host_with_auth() {
         let ollama = Ollama::from_env(
             TEST_TIMEOUTS,
             Some("test-key".into()),
             Some("http://local:1234".into()),
         )
         .unwrap();
-        assert_eq!(ollama.auth.base_url.as_deref(), Some(CLOUD_BASE_URL));
+        assert_eq!(
+            ollama.auth.base_url.as_deref(),
+            Some("http://local:1234/v1")
+        );
+        assert_eq!(ollama.auth.headers.len(), 1);
         assert_eq!(ollama.auth.headers[0].1, "Bearer test-key");
     }
 }

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -60,11 +60,11 @@ Defaults: gemini-2.5-pro (strong), gemini-2.5-flash (medium), gemini-2.0-flash-l
 
 ### Ollama
 
-- **Env var**: `OLLAMA_API_KEY` for cloud, or `OLLAMA_HOST` for local (e.g. `http://localhost:11434`)
+- **Env var**: `OLLAMA_HOST` for local/remote (e.g. `http://localhost:11434`), `OLLAMA_API_KEY` for auth
 - **API**: `http://localhost:11434/v1`
-- **Features**: Local inference via OLLAMA_HOST, or cloud via OLLAMA_API_KEY
+- **Features**: Local or remote inference via OLLAMA_HOST, cloud fallback via OLLAMA_API_KEY
 
-Maki asks your local Ollama for the list of installed models, so there's no built-in catalog. Tiers are guessed from list order: the first model becomes strong, the second medium, and the rest weak. If that guess is wrong, open `/model` and press `Alt+1`, `Alt+2`, or `Alt+3` on any row to reassign it. Your choices are saved to `~/.maki/model-tiers`.
+Maki asks Ollama for the list of installed models, so there's no built-in catalog. Tiers are guessed from list order: the first model becomes strong, the second medium, and the rest weak. If that guess is wrong, open `/model` and press `Alt+1`, `Alt+2`, or `Alt+3` on any row to reassign it. Your choices are saved to `~/.maki/model-tiers`.
 
 ### Mistral
 


### PR DESCRIPTION
When both OLLAMA_HOST and OLLAMA_API_KEY were set, the provider always used the cloud URL, ignoring the host entirely. Now the host takes priority and the API key is attached as a Bearer header alongside it. Cloud URL is only used as fallback when no host is provided.

Fixes #150.