### PR TITLE
providers: dynamic: support all provider kinds as base

### DIFF
--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -18,7 +18,11 @@ use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
 use super::ResolvedAuth;
 use super::anthropic::Anthropic;
 use super::google::Google;
+use super::mistral::Mistral;
+use super::ollama::Ollama;
 use super::openai::OpenAi;
+use super::synthetic::Synthetic;
+use super::zai::{Zai, ZaiPlan};
 
 const INFO_TIMEOUT: Duration = Duration::from_secs(5);
 const SCRIPT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -344,14 +348,26 @@ pub fn create(slug: &str, timeouts: super::Timeouts) -> Result<Box<dyn Provider>
                 .with_system_prefix(meta.system_prefix.clone()),
         ),
         ProviderKind::Google => Box::new(Google::with_auth(auth.clone(), timeouts)),
-        other => {
-            return Err(AgentError::Config {
-                message: format!(
-                    "dynamic provider '{}' uses unsupported base '{other}'",
-                    meta.slug
-                ),
-            });
-        }
+        ProviderKind::Ollama => Box::new(
+            Ollama::with_auth(auth.clone(), timeouts)
+                .with_system_prefix(meta.system_prefix.clone()),
+        ),
+        ProviderKind::Mistral => Box::new(
+            Mistral::with_auth(auth.clone(), timeouts)
+                .with_system_prefix(meta.system_prefix.clone()),
+        ),
+        ProviderKind::Zai => Box::new(
+            Zai::with_auth(ZaiPlan::Standard, auth.clone(), timeouts)
+                .with_system_prefix(meta.system_prefix.clone()),
+        ),
+        ProviderKind::ZaiCodingPlan => Box::new(
+            Zai::with_auth(ZaiPlan::Coding, auth.clone(), timeouts)
+                .with_system_prefix(meta.system_prefix.clone()),
+        ),
+        ProviderKind::Synthetic => Box::new(
+            Synthetic::with_auth(auth.clone(), timeouts)
+                .with_system_prefix(meta.system_prefix.clone()),
+        ),
     };
 
     Ok(Box::new(DynamicProvider {
@@ -622,5 +638,20 @@ esac
             run_script(&path, "nonexistent", SCRIPT_TIMEOUT).unwrap_err(),
             AgentError::Config { .. }
         ));
+    }
+
+    #[cfg(unix)]
+    #[test_case("ollama", ProviderKind::Ollama ; "base_ollama")]
+    #[test_case("mistral", ProviderKind::Mistral ; "base_mistral")]
+    #[test_case("zai", ProviderKind::Zai ; "base_zai")]
+    #[test_case("zai-coding-plan", ProviderKind::ZaiCodingPlan ; "base_zai_coding_plan")]
+    #[test_case("synthetic", ProviderKind::Synthetic ; "base_synthetic")]
+    fn discover_accepts_all_bases(base: &str, expected: ProviderKind) {
+        let tmp = TempDir::new().unwrap();
+        let info = format!(r#"{{"display_name": "Test", "base": "{base}", "has_auth": false}}"#);
+        write_script(tmp.path(), "custom-test", &info);
+        let providers = discover_in(tmp.path());
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].base, expected);
     }
 }

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use flume::Sender;
 use serde_json::{Value, json};
 
@@ -65,7 +67,8 @@ pub(crate) fn models() -> &'static [ModelEntry] {
 
 pub struct Mistral {
     compat: OpenAiCompatProvider,
-    auth: ResolvedAuth,
+    auth: Arc<Mutex<ResolvedAuth>>,
+    system_prefix: Option<String>,
 }
 
 impl Mistral {
@@ -75,8 +78,22 @@ impl Mistral {
         })?;
         Ok(Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
-            auth: ResolvedAuth::bearer(&api_key),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(&api_key))),
+            system_prefix: None,
         })
+    }
+
+    pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
+        Self {
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
+            auth,
+            system_prefix: None,
+        }
+    }
+
+    pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
+        self.system_prefix = prefix;
+        self
     }
 }
 
@@ -92,6 +109,9 @@ impl Provider for Mistral {
         session_id: Option<&'a str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            let mut buf = String::new();
+            let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
 
             if !matches!(thinking, ThinkingConfig::Off) {
@@ -103,12 +123,15 @@ impl Provider for Mistral {
                 extra_headers.push(("x-affinity".to_string(), session_id.to_string()));
             }
             self.compat
-                .do_stream(model, &extra_headers, &body, event_tx, &self.auth)
+                .do_stream(model, &extra_headers, &body, event_tx, &auth)
                 .await
         })
     }
 
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
-        Box::pin(self.compat.do_list_models(&self.auth))
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            self.compat.do_list_models(&auth).await
+        })
     }
 }

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -51,6 +51,20 @@ impl ResolvedAuth {
     }
 }
 
+pub(crate) fn with_prefix<'a>(
+    prefix: &Option<String>,
+    system: &'a str,
+    buf: &'a mut String,
+) -> &'a str {
+    match prefix {
+        Some(p) => {
+            *buf = format!("{p}\n\n{system}");
+            buf
+        }
+        None => system,
+    }
+}
+
 pub(crate) fn urlenc(s: &str) -> String {
     let mut out = String::with_capacity(s.len() * 2);
     for b in s.bytes() {

--- a/maki-providers/src/providers/ollama.rs
+++ b/maki-providers/src/providers/ollama.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use flume::Sender;
 use serde_json::Value;
 
@@ -27,7 +29,8 @@ pub(crate) fn models() -> &'static [ModelEntry] {
 
 pub struct Ollama {
     compat: OpenAiCompatProvider,
-    auth: ResolvedAuth,
+    auth: Arc<Mutex<ResolvedAuth>>,
+    system_prefix: Option<String>,
 }
 
 impl Ollama {
@@ -37,6 +40,19 @@ impl Ollama {
             std::env::var(API_KEY_ENV).ok(),
             std::env::var(HOST_ENV).ok(),
         )
+    }
+
+    pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
+        Self {
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
+            auth,
+            system_prefix: None,
+        }
+    }
+
+    pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
+        self.system_prefix = prefix;
+        self
     }
 
     fn from_env(
@@ -59,10 +75,11 @@ impl Ollama {
         };
         Ok(Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
-            auth: ResolvedAuth {
+            auth: Arc::new(Mutex::new(ResolvedAuth {
                 base_url: Some(base_url),
                 headers,
-            },
+            })),
+            system_prefix: None,
         })
     }
 }
@@ -79,15 +96,21 @@ impl Provider for Ollama {
         _session_id: Option<&str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            let mut buf = String::new();
+            let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let body = self.compat.build_body(model, messages, system, tools);
             self.compat
-                .do_stream(model, &[], &body, event_tx, &self.auth)
+                .do_stream(model, &[], &body, event_tx, &auth)
                 .await
         })
     }
 
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
-        Box::pin(self.compat.do_list_models(&self.auth))
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            self.compat.do_list_models(&auth).await
+        })
     }
 }
 
@@ -113,17 +136,19 @@ mod tests {
     #[test]
     fn from_env_with_host_builds_auth() {
         let ollama = Ollama::from_env(TEST_TIMEOUTS, None, Some("http://x:1234".into())).unwrap();
-        assert_eq!(ollama.auth.base_url.as_deref(), Some("http://x:1234/v1"));
-        assert!(ollama.auth.headers.is_empty());
+        let auth = ollama.auth.lock().unwrap();
+        assert_eq!(auth.base_url.as_deref(), Some("http://x:1234/v1"));
+        assert!(auth.headers.is_empty());
     }
 
     #[test]
     fn from_env_with_api_key_uses_cloud() {
         let ollama = Ollama::from_env(TEST_TIMEOUTS, Some("test-key".into()), None).unwrap();
-        assert_eq!(ollama.auth.base_url.as_deref(), Some(CLOUD_BASE_URL));
-        assert_eq!(ollama.auth.headers.len(), 1);
-        assert_eq!(ollama.auth.headers[0].0, "authorization");
-        assert_eq!(ollama.auth.headers[0].1, "Bearer test-key");
+        let auth = ollama.auth.lock().unwrap();
+        assert_eq!(auth.base_url.as_deref(), Some(CLOUD_BASE_URL));
+        assert_eq!(auth.headers.len(), 1);
+        assert_eq!(auth.headers[0].0, "authorization");
+        assert_eq!(auth.headers[0].1, "Bearer test-key");
     }
 
     #[test]
@@ -134,11 +159,9 @@ mod tests {
             Some("http://local:1234".into()),
         )
         .unwrap();
-        assert_eq!(
-            ollama.auth.base_url.as_deref(),
-            Some("http://local:1234/v1")
-        );
-        assert_eq!(ollama.auth.headers.len(), 1);
-        assert_eq!(ollama.auth.headers[0].1, "Bearer test-key");
+        let auth = ollama.auth.lock().unwrap();
+        assert_eq!(auth.base_url.as_deref(), Some("http://local:1234/v1"));
+        assert_eq!(auth.headers.len(), 1);
+        assert_eq!(auth.headers[0].1, "Bearer test-key");
     }
 }

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -146,13 +146,8 @@ impl Provider for OpenAi {
         _session_id: Option<&str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
-            let effective_system;
-            let system = if let Some(prefix) = &self.system_prefix {
-                effective_system = format!("{prefix}\n\n{system}");
-                &effective_system
-            } else {
-                system
-            };
+            let mut buf = String::new();
+            let system = super::super::with_prefix(&self.system_prefix, system, &mut buf);
 
             if is_codex_model(&model.id) {
                 let body = super::responses::build_body(model, messages, system, tools);

--- a/maki-providers/src/providers/synthetic.rs
+++ b/maki-providers/src/providers/synthetic.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use flume::Sender;
 use serde_json::{Value, json};
 
@@ -65,7 +67,8 @@ pub(crate) fn models() -> &'static [ModelEntry] {
 
 pub struct Synthetic {
     compat: OpenAiCompatProvider,
-    auth: ResolvedAuth,
+    auth: Arc<Mutex<ResolvedAuth>>,
+    system_prefix: Option<String>,
 }
 
 impl Synthetic {
@@ -75,8 +78,22 @@ impl Synthetic {
         })?;
         Ok(Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
-            auth: ResolvedAuth::bearer(&api_key),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(&api_key))),
+            system_prefix: None,
         })
+    }
+
+    pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
+        Self {
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
+            auth,
+            system_prefix: None,
+        }
+    }
+
+    pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
+        self.system_prefix = prefix;
+        self
     }
 }
 
@@ -92,6 +109,9 @@ impl Provider for Synthetic {
         _session_id: Option<&str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            let mut buf = String::new();
+            let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
             match thinking {
                 ThinkingConfig::Off => {}
@@ -110,12 +130,15 @@ impl Provider for Synthetic {
                 }
             };
             self.compat
-                .do_stream(model, &[], &body, event_tx, &self.auth)
+                .do_stream(model, &[], &body, event_tx, &auth)
                 .await
         })
     }
 
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
-        Box::pin(self.compat.do_list_models(&self.auth))
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            self.compat.do_list_models(&auth).await
+        })
     }
 }

--- a/maki-providers/src/providers/zai.rs
+++ b/maki-providers/src/providers/zai.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use flume::Sender;
 use serde_json::Value;
 use tracing::warn;
@@ -137,7 +139,8 @@ pub enum ZaiPlan {
 
 pub struct Zai {
     compat: OpenAiCompatProvider,
-    auth: ResolvedAuth,
+    auth: Arc<Mutex<ResolvedAuth>>,
+    system_prefix: Option<String>,
 }
 
 impl Zai {
@@ -151,8 +154,30 @@ impl Zai {
         })?;
         Ok(Self {
             compat: OpenAiCompatProvider::new(config, timeouts),
-            auth: ResolvedAuth::bearer(&api_key),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(&api_key))),
+            system_prefix: None,
         })
+    }
+
+    pub(crate) fn with_auth(
+        plan: ZaiPlan,
+        auth: Arc<Mutex<ResolvedAuth>>,
+        timeouts: super::Timeouts,
+    ) -> Self {
+        let config = match plan {
+            ZaiPlan::Standard => &CONFIG_STANDARD,
+            ZaiPlan::Coding => &CONFIG_CODING,
+        };
+        Self {
+            compat: OpenAiCompatProvider::new(config, timeouts),
+            auth,
+            system_prefix: None,
+        }
+    }
+
+    pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
+        self.system_prefix = prefix;
+        self
     }
 }
 
@@ -168,10 +193,13 @@ impl Provider for Zai {
         _session_id: Option<&str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            let mut buf = String::new();
+            let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let body = self.compat.build_body(model, messages, system, tools);
             match self
                 .compat
-                .do_stream(model, &[], &body, event_tx, &self.auth)
+                .do_stream(model, &[], &body, event_tx, &auth)
                 .await
             {
                 Err(AgentError::Api { status, message })
@@ -190,6 +218,9 @@ impl Provider for Zai {
     }
 
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
-        Box::pin(self.compat.do_list_models(&self.auth))
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            self.compat.do_list_models(&auth).await
+        })
     }
 }


### PR DESCRIPTION
Dynamic provider scripts could only use anthropic, openai, and google as their base. The other four (ollama, mistral, zai, synthetic) hit an "unsupported base" error at runtime even though the docs listed them as valid. Moved all compat-based providers from ResolvedAuth to Arc<Mutex<ResolvedAuth>> so auth refresh propagates from the dynamic layer, added with_auth/with_system_prefix to each, and wired them into the create() match. The match is now exhaustive so a new ProviderKind variant will be a compile error instead of a silent runtime failure.