### PR TITLE
storage: replace dirs with etcetera for XDG-aware path resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,27 +951,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,6 +1060,16 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "euclid"
@@ -2106,15 +2095,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libredox"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,7 +2225,6 @@ dependencies = [
  "async-process",
  "base64",
  "bitflags 2.11.0",
- "dirs",
  "event-listener",
  "flume 0.11.1",
  "futures-lite",
@@ -2286,9 +2265,9 @@ dependencies = [
 name = "maki-config"
 version = "0.2.8"
 dependencies = [
- "dirs",
  "dotenvy",
  "maki-config-macro",
+ "maki-storage",
  "serde",
  "tempfile",
  "test-case",
@@ -2344,7 +2323,6 @@ dependencies = [
 name = "maki-lua"
 version = "0.2.8"
 dependencies = [
- "dirs",
  "flume 0.11.1",
  "futures-lite",
  "htmd",
@@ -2354,6 +2332,7 @@ dependencies = [
  "maki-agent",
  "maki-config",
  "maki-highlight",
+ "maki-storage",
  "mlua",
  "regex",
  "serde_json",
@@ -2388,7 +2367,6 @@ name = "maki-providers"
 version = "0.2.8"
 dependencies = [
  "base64",
- "dirs",
  "fastrand",
  "flume 0.11.1",
  "futures-lite",
@@ -2410,7 +2388,7 @@ dependencies = [
 name = "maki-storage"
 version = "0.2.8"
 dependencies = [
- "dirs",
+ "etcetera",
  "getrandom 0.3.4",
  "isahc",
  "libc",
@@ -2444,7 +2422,6 @@ dependencies = [
  "color-eyre",
  "criterion",
  "crossterm",
- "dirs",
  "flume 0.11.1",
  "futures-lite",
  "getrandom 0.3.4",
@@ -2974,12 +2951,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,7 +2984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3724,17 +3695,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ nucleo = "0.5"
 nucleo-matcher = "0.3"
 open = "5"
 criterion = { version = "0.5", features = ["html_reports"] }
-dirs = "6"
+etcetera = "0.11"
 dotenvy = "0.15"
 tree-sitter = "0.26"
 include_dir = "0.7"

--- a/maki-agent/Cargo.toml
+++ b/maki-agent/Cargo.toml
@@ -35,7 +35,6 @@ toml_edit = { workspace = true }
 isahc = { workspace = true }
 libc = { workspace = true }
 open = { workspace = true }
-dirs = { workspace = true }
 tree-sitter = { workspace = true }
 tree-sitter-bash = { workspace = true }
 sha2 = { workspace = true }

--- a/maki-agent/src/agent/instructions.rs
+++ b/maki-agent/src/agent/instructions.rs
@@ -97,7 +97,7 @@ fn append_instruction_files(out: &mut String, cwd: &str, home: Option<&Path>) {
 }
 
 pub fn load_instruction_text(cwd: &str) -> String {
-    load_instruction_text_with_home(cwd, dirs::home_dir().as_deref())
+    load_instruction_text_with_home(cwd, maki_storage::paths::home().as_deref())
 }
 
 fn load_instruction_text_with_home(cwd: &str, home: Option<&Path>) -> String {
@@ -107,7 +107,7 @@ fn load_instruction_text_with_home(cwd: &str, home: Option<&Path>) -> String {
 }
 
 pub fn load_instructions(cwd: &str) -> Instructions {
-    load_instructions_with_home(cwd, dirs::home_dir().as_deref())
+    load_instructions_with_home(cwd, maki_storage::paths::home().as_deref())
 }
 
 fn load_instructions_with_home(cwd: &str, home: Option<&Path>) -> Instructions {

--- a/maki-agent/src/command.rs
+++ b/maki-agent/src/command.rs
@@ -46,7 +46,7 @@ impl CustomCommand {
 }
 
 pub fn discover_commands(cwd: &Path) -> Vec<CustomCommand> {
-    let home = dirs::home_dir();
+    let home = maki_storage::paths::home();
     discover_commands_inner(cwd, home.as_deref())
 }
 

--- a/maki-agent/src/mcp/oauth/mod.rs
+++ b/maki-agent/src/mcp/oauth/mod.rs
@@ -20,7 +20,7 @@ use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use isahc::HttpClient;
 use isahc::config::Configurable;
-use maki_storage::DataDir;
+use maki_storage::StateDir;
 use maki_storage::auth::{McpAuthData, load_mcp_auth, save_mcp_auth};
 use tracing::{info, warn};
 
@@ -32,7 +32,7 @@ pub async fn authenticate(
     server_name: &str,
     server_url: &str,
     www_authenticate: Option<&str>,
-    storage: &DataDir,
+    storage: &StateDir,
 ) -> Result<McpAuthData, McpError> {
     let wrap = |e: OAuthError| McpError::OAuthFailed {
         server: server_name.into(),

--- a/maki-agent/src/skill.rs
+++ b/maki-agent/src/skill.rs
@@ -34,7 +34,7 @@ pub struct Skill {
 }
 
 pub fn discover_skills(cwd: &Path) -> Vec<Skill> {
-    let home = dirs::home_dir();
+    let home = maki_storage::paths::home();
     discover_skills_inner(cwd, home.as_deref())
 }
 

--- a/maki-agent/src/tools/bash.rs
+++ b/maki-agent/src/tools/bash.rs
@@ -574,7 +574,7 @@ mod tests {
     #[test_case("ls",              Some("~/projects"), "projects" ; "explicit_workdir_tilde")]
     #[test_case("cd ~/foo && ls",   None,               "foo"      ; "cd_prefix_tilde")]
     fn resolved_workdir_expands_tilde(cmd: &str, workdir: Option<&str>, suffix: &str) {
-        let home = dirs::home_dir().unwrap();
+        let home = maki_storage::paths::home().unwrap();
         let b = Bash {
             command: cmd.into(),
             timeout: None,

--- a/maki-agent/src/tools/memory.rs
+++ b/maki-agent/src/tools/memory.rs
@@ -234,7 +234,7 @@ pub fn resolve_memories_dir() -> Result<PathBuf, String> {
     let cwd = std::env::current_dir().map_err(|e| format!("cannot get cwd: {e}"))?;
     let root = find_git_root(&cwd);
     let project_id = project_id(&root);
-    let home = dirs::home_dir().ok_or("home directory not found")?;
+    let home = maki_storage::paths::home().ok_or("home directory not found")?;
     Ok(home
         .join(".maki")
         .join("projects")

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -247,7 +247,7 @@ pub(crate) fn resolve_search_path(path: Option<&str>) -> Result<String, String> 
 }
 
 static CWD: LazyLock<Option<PathBuf>> = LazyLock::new(|| env::current_dir().ok());
-static HOME: LazyLock<Option<PathBuf>> = LazyLock::new(dirs::home_dir);
+static HOME: LazyLock<Option<PathBuf>> = LazyLock::new(maki_storage::paths::home);
 
 pub(crate) fn relative_path(path: &str) -> String {
     let p = Path::new(path);
@@ -1162,7 +1162,7 @@ mod tests {
     #[test]
     fn relative_path_cases() {
         let cwd = env::current_dir().unwrap();
-        let home = dirs::home_dir().unwrap();
+        let home = maki_storage::paths::home().unwrap();
 
         let cases: &[(&str, &str)] = &[
             (&format!("{}/src/main.rs", cwd.display()), "src/main.rs"),
@@ -1184,7 +1184,7 @@ mod tests {
     #[test]
     fn resolve_path_cases() {
         let cwd = env::current_dir().unwrap();
-        let home = dirs::home_dir().unwrap();
+        let home = maki_storage::paths::home().unwrap();
 
         assert_eq!(
             resolve_path("~/foo/bar").unwrap(),

--- a/maki-config/Cargo.toml
+++ b/maki-config/Cargo.toml
@@ -5,12 +5,12 @@ edition.workspace = true
 
 [dependencies]
 maki-config-macro = { workspace = true }
+maki-storage = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
 tracing = { workspace = true }
-dirs = { workspace = true }
 dotenvy = { workspace = true }
 
 [dev-dependencies]

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -3,16 +3,12 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-#[cfg(unix)]
-use dirs::home_dir;
-
 use maki_config_macro::ConfigSection;
+use maki_storage::paths;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::warn;
 
-#[cfg(unix)]
-const GLOBAL_CONFIG_DIR: &str = ".config/maki";
 const PROJECT_DIR: &str = ".maki";
 pub const PROJECT_CONFIG_FILE: &str = ".maki/config.toml";
 const CONFIG_FILE: &str = "config.toml";
@@ -698,14 +694,7 @@ fn build_permissions(
 }
 
 fn global_dir() -> Option<PathBuf> {
-    #[cfg(unix)]
-    {
-        home_dir().map(|h| h.join(GLOBAL_CONFIG_DIR))
-    }
-    #[cfg(not(unix))]
-    {
-        dirs::config_dir().map(|c| c.join("maki"))
-    }
+    paths::config_dir().ok()
 }
 
 fn load_env_files_with_global(cwd: &Path, global: Option<&Path>) {

--- a/maki-lua/Cargo.toml
+++ b/maki-lua/Cargo.toml
@@ -21,7 +21,7 @@ futures-lite = { workspace = true }
 tree-sitter = { workspace = true }
 regex = { workspace = true }
 include_dir = { workspace = true }
-dirs = { workspace = true }
+maki-storage = { workspace = true }
 isahc = { workspace = true }
 htmd = { workspace = true }
 tree-sitter-bash = { workspace = true }

--- a/maki-lua/src/api/fs.rs
+++ b/maki-lua/src/api/fs.rs
@@ -5,11 +5,11 @@ use mlua::{Lua, Result as LuaResult, Table};
 
 fn expand_tilde(path: &str) -> PathBuf {
     if let Some(rest) = path.strip_prefix("~/") {
-        if let Some(home) = dirs::home_dir() {
+        if let Some(home) = maki_storage::paths::home() {
             return home.join(rest);
         }
     } else if path == "~" {
-        if let Some(home) = dirs::home_dir() {
+        if let Some(home) = maki_storage::paths::home() {
             return home;
         }
     }

--- a/maki-lua/src/api/uv.rs
+++ b/maki-lua/src/api/uv.rs
@@ -15,7 +15,7 @@ pub(crate) fn create_uv_table(lua: &Lua) -> LuaResult<Table> {
     t.set(
         "os_homedir",
         lua.create_function(|_, ()| {
-            Ok(dirs::home_dir().and_then(|p| p.to_str().map(String::from)))
+            Ok(maki_storage::paths::home().and_then(|p| p.to_str().map(String::from)))
         })?,
     )?;
 

--- a/maki-providers/Cargo.toml
+++ b/maki-providers/Cargo.toml
@@ -10,7 +10,6 @@ serde_yaml = { workspace = true }
 maki-storage = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-dirs = { workspace = true }
 strum = { workspace = true }
 smol = { workspace = true }
 flume = { workspace = true }

--- a/maki-providers/src/providers/copilot/auth.rs
+++ b/maki-providers/src/providers/copilot/auth.rs
@@ -67,7 +67,7 @@ fn gh_config_paths() -> Vec<PathBuf> {
 fn config_dir() -> Option<PathBuf> {
     env::var_os("XDG_CONFIG_HOME")
         .map(PathBuf::from)
-        .or_else(|| dirs::home_dir().map(|home| home.join(".config")))
+        .or_else(|| maki_storage::paths::home().map(|home| home.join(".config")))
 }
 
 fn extract_json_oauth_token(contents: &str, domain: &str) -> Option<String> {

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -102,7 +102,9 @@ fn builtin_slugs() -> Vec<String> {
 }
 
 fn providers_dir() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".maki").join(PROVIDERS_DIR))
+    maki_storage::paths::config_dir()
+        .ok()
+        .map(|d| d.join(PROVIDERS_DIR))
 }
 
 fn run_script(path: &Path, subcommand: &str, timeout: Duration) -> Result<String, AgentError> {

--- a/maki-providers/src/providers/openai/auth.rs
+++ b/maki-providers/src/providers/openai/auth.rs
@@ -3,7 +3,7 @@ use std::{env, thread};
 
 use isahc::ReadResponseExt;
 use isahc::config::Configurable;
-use maki_storage::DataDir;
+use maki_storage::StateDir;
 use maki_storage::auth::{OAuthTokens, delete_tokens, load_tokens, now_millis, save_tokens};
 use serde::Deserialize;
 use tracing::{debug, error, warn};
@@ -265,11 +265,11 @@ pub(crate) fn build_coding_plan_resolved(tokens: &OAuthTokens) -> ResolvedAuth {
     }
 }
 
-pub(crate) fn is_oauth(dir: &DataDir) -> bool {
+pub(crate) fn is_oauth(dir: &StateDir) -> bool {
     load_tokens(dir, PROVIDER).is_some()
 }
 
-pub fn resolve(dir: &DataDir) -> Result<ResolvedAuth, AgentError> {
+pub fn resolve(dir: &StateDir) -> Result<ResolvedAuth, AgentError> {
     if let Some(tokens) = load_tokens(dir, PROVIDER) {
         if !tokens.is_expired() {
             debug!("using OpenAI OAuth authentication");
@@ -301,7 +301,7 @@ pub fn resolve(dir: &DataDir) -> Result<ResolvedAuth, AgentError> {
     })
 }
 
-pub fn login(dir: &DataDir) -> Result<(), AgentError> {
+pub fn login(dir: &StateDir) -> Result<(), AgentError> {
     let device = request_device_code()?;
 
     println!("Open this URL in your browser:\n\n  {DEVICE_AUTH_URL}\n");
@@ -324,7 +324,7 @@ pub fn login(dir: &DataDir) -> Result<(), AgentError> {
     Ok(())
 }
 
-pub fn logout(dir: &DataDir) -> Result<(), AgentError> {
+pub fn logout(dir: &StateDir) -> Result<(), AgentError> {
     if delete_tokens(dir, PROVIDER)? {
         println!("Logged out of OpenAI.");
     } else {

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
-use maki_storage::DataDir;
+use maki_storage::StateDir;
 use serde_json::Value;
 use tracing::{debug, warn};
 
@@ -31,13 +31,13 @@ fn is_codex_model(model_id: &str) -> bool {
 pub struct OpenAi {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
-    storage: Option<DataDir>,
+    storage: Option<StateDir>,
     system_prefix: Option<String>,
 }
 
 impl OpenAi {
     pub fn new(timeouts: crate::providers::Timeouts) -> Result<Self, AgentError> {
-        let storage = DataDir::resolve()?;
+        let storage = StateDir::resolve()?;
         let resolved = auth::resolve(&storage)?;
         let compat = OpenAiCompatProvider::new(&CONFIG, timeouts);
         Ok(Self {

--- a/maki-providers/src/tier_map.rs
+++ b/maki-providers/src/tier_map.rs
@@ -18,7 +18,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 use std::sync::{OnceLock, RwLock};
 
-use maki_storage::{DataDir, atomic_write};
+use maki_storage::{StateDir, atomic_write};
 use tracing::warn;
 
 use crate::model::ModelTier;
@@ -37,7 +37,7 @@ pub fn tier_map() -> &'static RwLock<TierMap> {
 
 /// Load persisted overrides from `~/.maki/model-tiers` into the global map.
 /// Replaces any previously-loaded overrides but preserves `known_models`.
-pub fn load_from_storage(dir: &DataDir) {
+pub fn load_from_storage(dir: &StateDir) {
     let overrides = read_overrides(dir.path().join(TIERS_FILE).as_path());
     tier_map().write().unwrap().set_overrides(overrides);
 }
@@ -45,7 +45,7 @@ pub fn load_from_storage(dir: &DataDir) {
 /// Atomically set an override and write the new state to disk.
 /// Releases the write lock before touching the filesystem, so I/O latency
 /// does not block other tier reads.
-pub fn set_and_persist(spec: String, tier: ModelTier, dir: &DataDir) {
+pub fn set_and_persist(spec: String, tier: ModelTier, dir: &StateDir) {
     let snapshot = {
         let mut map = tier_map().write().unwrap();
         map.set(spec, tier);

--- a/maki-storage/Cargo.toml
+++ b/maki-storage/Cargo.toml
@@ -11,7 +11,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-dirs = { workspace = true }
+etcetera = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/maki-storage/src/auth.rs
+++ b/maki-storage/src/auth.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
-use crate::{DataDir, StorageError, atomic_write_permissions};
+use crate::{StateDir, StorageError, atomic_write_permissions};
 
 const AUTH_DIR: &str = "auth";
 const AUTH_FILE_MODE: u32 = 0o600;
@@ -49,7 +49,7 @@ pub fn now_millis() -> u64 {
         .as_millis() as u64
 }
 
-fn auth_path(dir: &DataDir, filename: &str) -> PathBuf {
+fn auth_path(dir: &StateDir, filename: &str) -> PathBuf {
     dir.path().join(AUTH_DIR).join(format!("{filename}.json"))
 }
 
@@ -77,23 +77,23 @@ fn delete_auth(path: &Path) -> Result<bool, StorageError> {
     Ok(false)
 }
 
-pub fn load_tokens(dir: &DataDir, provider: &str) -> Option<OAuthTokens> {
+pub fn load_tokens(dir: &StateDir, provider: &str) -> Option<OAuthTokens> {
     load_auth(&auth_path(dir, provider))
 }
 
 pub fn save_tokens(
-    dir: &DataDir,
+    dir: &StateDir,
     provider: &str,
     tokens: &OAuthTokens,
 ) -> Result<(), StorageError> {
     save_auth(&auth_path(dir, provider), tokens)
 }
 
-pub fn delete_tokens(dir: &DataDir, provider: &str) -> Result<bool, StorageError> {
+pub fn delete_tokens(dir: &StateDir, provider: &str) -> Result<bool, StorageError> {
     delete_auth(&auth_path(dir, provider))
 }
 
-pub fn load_mcp_auth(dir: &DataDir, server_name: &str, expected_url: &str) -> Option<McpAuthData> {
+pub fn load_mcp_auth(dir: &StateDir, server_name: &str, expected_url: &str) -> Option<McpAuthData> {
     let data: McpAuthData = load_auth(&auth_path(dir, &format!("mcp-{server_name}")))?;
     if data.server_url != expected_url {
         return None;
@@ -107,14 +107,14 @@ pub fn load_mcp_auth(dir: &DataDir, server_name: &str, expected_url: &str) -> Op
 }
 
 pub fn save_mcp_auth(
-    dir: &DataDir,
+    dir: &StateDir,
     server_name: &str,
     data: &McpAuthData,
 ) -> Result<(), StorageError> {
     save_auth(&auth_path(dir, &format!("mcp-{server_name}")), data)
 }
 
-pub fn delete_mcp_auth(dir: &DataDir, server_name: &str) -> Result<bool, StorageError> {
+pub fn delete_mcp_auth(dir: &StateDir, server_name: &str) -> Result<bool, StorageError> {
     delete_auth(&auth_path(dir, &format!("mcp-{server_name}")))
 }
 
@@ -154,7 +154,7 @@ mod tests {
     #[test]
     fn save_load_delete_round_trip() {
         let tmp = TempDir::new().unwrap();
-        let dir = DataDir::from_path(tmp.path().to_path_buf());
+        let dir = StateDir::from_path(tmp.path().to_path_buf());
         let tokens = OAuthTokens {
             access: "access_tok".into(),
             refresh: "refresh_tok".into(),
@@ -182,7 +182,7 @@ mod tests {
     #[test]
     fn mcp_auth_round_trip() {
         let tmp = TempDir::new().unwrap();
-        let dir = DataDir::from_path(tmp.path().to_path_buf());
+        let dir = StateDir::from_path(tmp.path().to_path_buf());
         let data = McpAuthData {
             tokens: Some(OAuthTokens {
                 access: "acc".into(),
@@ -214,7 +214,7 @@ mod tests {
     )]
     fn mcp_auth_load_returns_none(data: McpAuthData, lookup_url: &str) {
         let tmp = TempDir::new().unwrap();
-        let dir = DataDir::from_path(tmp.path().to_path_buf());
+        let dir = StateDir::from_path(tmp.path().to_path_buf());
         save_mcp_auth(&dir, "srv", &data).unwrap();
         assert!(load_mcp_auth(&dir, "srv", lookup_url).is_none());
     }

--- a/maki-storage/src/input_history.rs
+++ b/maki-storage/src/input_history.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 use std::fs;
 
-use crate::{DataDir, StorageError, atomic_write};
+use crate::{StateDir, StorageError, atomic_write};
 
 const HISTORY_FILE: &str = "input_history.json";
 pub const MAX_ENTRIES: usize = 100;
@@ -22,7 +22,7 @@ impl Default for InputHistory {
 }
 
 impl InputHistory {
-    pub fn load(dir: &DataDir, max_entries: usize) -> Self {
+    pub fn load(dir: &StateDir, max_entries: usize) -> Self {
         let path = dir.path().join(HISTORY_FILE);
         let data = match fs::read(&path) {
             Ok(d) => d,
@@ -44,7 +44,7 @@ impl InputHistory {
         history
     }
 
-    pub fn save(&self, dir: &DataDir) -> Result<(), StorageError> {
+    pub fn save(&self, dir: &StateDir) -> Result<(), StorageError> {
         let data = serde_json::to_vec(&self.entries)?;
         atomic_write(&dir.path().join(HISTORY_FILE), &data)
     }
@@ -85,9 +85,9 @@ mod tests {
     use super::*;
     use test_case::test_case;
 
-    fn tmp_dir() -> (tempfile::TempDir, DataDir) {
+    fn tmp_dir() -> (tempfile::TempDir, StateDir) {
         let tmp = tempfile::tempdir().unwrap();
-        let dir = DataDir::from_path(tmp.path().to_path_buf());
+        let dir = StateDir::from_path(tmp.path().to_path_buf());
         (tmp, dir)
     }
 

--- a/maki-storage/src/lib.rs
+++ b/maki-storage/src/lib.rs
@@ -1,10 +1,11 @@
-//! Persistent storage under `~/.maki`. `atomic_write` writes to `.tmp` then renames for crash
+//! Persistent storage. `atomic_write` writes to `.tmp` then renames for crash
 //! safety. `atomic_write_permissions` sets file mode before rename (for auth keys at 0600).
 
 pub mod auth;
 pub mod input_history;
 pub mod log;
 pub mod model;
+pub mod paths;
 pub mod plans;
 pub mod sessions;
 pub mod theme;
@@ -17,17 +18,14 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const DATA_DIR_NAME: &str = ".maki";
+use paths::state_dir;
 
 #[derive(Debug, Clone)]
-pub struct DataDir(PathBuf);
+pub struct StateDir(PathBuf);
 
-impl DataDir {
+impl StateDir {
     pub fn resolve() -> Result<Self, StorageError> {
-        let dir = dirs::home_dir()
-            .ok_or(StorageError::HomeNotSet)?
-            .join(DATA_DIR_NAME);
-        fs::create_dir_all(&dir)?;
+        let dir = state_dir()?;
         Ok(Self(dir))
     }
 

--- a/maki-storage/src/log.rs
+++ b/maki-storage/src/log.rs
@@ -4,7 +4,7 @@ use std::io::{self, Write};
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
-use crate::DataDir;
+use crate::StateDir;
 
 const LOG_FILE_NAME: &str = "maki.log";
 const LOCK_FILE_NAME: &str = "maki.log.lock";
@@ -43,7 +43,7 @@ pub struct RotatingFileWriter {
 }
 
 impl RotatingFileWriter {
-    pub fn new(data_dir: &DataDir, max_bytes: u64, max_files: u32) -> io::Result<Self> {
+    pub fn new(data_dir: &StateDir, max_bytes: u64, max_files: u32) -> io::Result<Self> {
         Self::with_limits(data_dir.path(), max_bytes, max_files)
     }
 

--- a/maki-storage/src/model.rs
+++ b/maki-storage/src/model.rs
@@ -1,14 +1,14 @@
 use std::fs;
 
-use crate::{DataDir, atomic_write};
+use crate::{StateDir, atomic_write};
 
 const MODEL_FILE: &str = "model";
 
-pub fn persist_model(dir: &DataDir, spec: &str) {
+pub fn persist_model(dir: &StateDir, spec: &str) {
     let _ = atomic_write(&dir.path().join(MODEL_FILE), spec.as_bytes());
 }
 
-pub fn read_model(dir: &DataDir) -> Option<String> {
+pub fn read_model(dir: &StateDir) -> Option<String> {
     let raw = fs::read_to_string(dir.path().join(MODEL_FILE)).ok()?;
     let spec = raw.trim();
     (!spec.is_empty()).then(|| spec.to_owned())
@@ -22,7 +22,7 @@ mod tests {
     #[test]
     fn round_trip() {
         let tmp = TempDir::new().unwrap();
-        let dir = DataDir::from_path(tmp.path().to_path_buf());
+        let dir = StateDir::from_path(tmp.path().to_path_buf());
 
         assert!(read_model(&dir).is_none());
 
@@ -39,7 +39,7 @@ mod tests {
     #[test]
     fn whitespace_and_empty_treated_as_none() {
         let tmp = TempDir::new().unwrap();
-        let dir = DataDir::from_path(tmp.path().to_path_buf());
+        let dir = StateDir::from_path(tmp.path().to_path_buf());
 
         fs::write(dir.path().join(MODEL_FILE), "  \n").unwrap();
         assert!(read_model(&dir).is_none());

--- a/maki-storage/src/paths.rs
+++ b/maki-storage/src/paths.rs
@@ -1,0 +1,92 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use etcetera::base_strategy::BaseStrategy;
+
+const FALLBACK_DIR: &str = ".maki";
+const APP_NAME: &str = "maki";
+
+static STRATEGY: OnceLock<Option<Paths>> = OnceLock::new();
+
+struct Paths {
+    config: PathBuf,
+    data: PathBuf,
+    cache: PathBuf,
+}
+
+fn resolve() -> Option<&'static Paths> {
+    STRATEGY
+        .get_or_init(|| {
+            let home = etcetera::home_dir().ok()?;
+            if home.join(FALLBACK_DIR).is_dir() {
+                let fallback = home.join(FALLBACK_DIR);
+                return Some(Paths {
+                    config: fallback.clone(),
+                    data: fallback.clone(),
+                    cache: fallback,
+                });
+            }
+            let s = etcetera::choose_base_strategy().ok()?;
+            Some(Paths {
+                config: s.config_dir().join(APP_NAME),
+                data: s.data_dir().join(APP_NAME),
+                cache: s.cache_dir().join(APP_NAME),
+            })
+        })
+        .as_ref()
+}
+
+fn err() -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        "cannot determine base directories",
+    )
+}
+
+fn ensure(path: &Path) -> Result<PathBuf, std::io::Error> {
+    fs::create_dir_all(path)?;
+    Ok(path.to_path_buf())
+}
+
+fn xdg_sibling(data: &Path, name: &str) -> PathBuf {
+    data.parent()
+        .and_then(|p| p.parent())
+        .map(|base| base.join(name).join(APP_NAME))
+        .unwrap_or_else(|| data.join(name))
+}
+
+pub fn config_dir() -> Result<PathBuf, std::io::Error> {
+    let p = resolve().ok_or_else(err)?;
+    ensure(&p.config)
+}
+
+pub fn data_dir() -> Result<PathBuf, std::io::Error> {
+    let p = resolve().ok_or_else(err)?;
+    ensure(&p.data)
+}
+
+pub fn state_dir() -> Result<PathBuf, std::io::Error> {
+    let p = resolve().ok_or_else(err)?;
+    if p.config == p.data {
+        return ensure(&p.data);
+    }
+    ensure(&xdg_sibling(&p.data, "state"))
+}
+
+pub fn logs_dir() -> Result<PathBuf, std::io::Error> {
+    let p = resolve().ok_or_else(err)?;
+    if p.config == p.data {
+        return ensure(&p.data);
+    }
+    ensure(&xdg_sibling(&p.data, "logs"))
+}
+
+pub fn cache_dir() -> Result<PathBuf, std::io::Error> {
+    let p = resolve().ok_or_else(err)?;
+    ensure(&p.cache)
+}
+
+pub fn home() -> Option<PathBuf> {
+    etcetera::home_dir().ok()
+}

--- a/maki-storage/src/plans.rs
+++ b/maki-storage/src/plans.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
-use crate::{DataDir, StorageError};
+use crate::{StateDir, StorageError};
 
 const PLANS_DIR: &str = "plans";
 const SLUG_RETRIES: usize = 10;
@@ -16,7 +16,7 @@ fn load_words(text: &'static str) -> Vec<&'static str> {
     words
 }
 
-pub fn new_plan_path(dir: &DataDir) -> Result<PathBuf, StorageError> {
+pub fn new_plan_path(dir: &StateDir) -> Result<PathBuf, StorageError> {
     let plans_dir = dir.ensure_subdir(PLANS_DIR)?;
     for _ in 0..SLUG_RETRIES {
         let path = plans_dir.join(format!("{}.md", generate_slug()));
@@ -46,7 +46,7 @@ fn generate_slug() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::DataDir;
+    use crate::StateDir;
 
     #[test]
     fn slug_format_invariants() {
@@ -65,7 +65,7 @@ mod tests {
     #[test]
     fn new_plan_path_under_plans_dir() {
         let tmp = tempfile::tempdir().unwrap();
-        let dir = DataDir::from_path(tmp.path().to_path_buf());
+        let dir = StateDir::from_path(tmp.path().to_path_buf());
         let path = new_plan_path(&dir).unwrap();
         assert!(path.starts_with(tmp.path().join("plans")));
         assert_eq!(path.extension().and_then(|e| e.to_str()), Some("md"));

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -18,7 +18,7 @@ use tracing::warn;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use crate::{DataDir, StorageError, atomic_write, now_epoch};
+use crate::{StateDir, StorageError, atomic_write, now_epoch};
 
 const SESSION_VERSION: u32 = 1;
 const LOG_FORMAT_VERSION: u32 = 2;
@@ -733,7 +733,7 @@ where
         }
     }
 
-    pub fn save(&mut self, dir: &DataDir) -> Result<(), SessionError> {
+    pub fn save(&mut self, dir: &StateDir) -> Result<(), SessionError> {
         let sessions_dir = dir.ensure_subdir(SESSIONS_DIR)?;
         self.save_to(&sessions_dir)
     }
@@ -744,7 +744,7 @@ where
         Ok(())
     }
 
-    pub fn load(id: &str, dir: &DataDir) -> Result<Self, SessionError> {
+    pub fn load(id: &str, dir: &StateDir) -> Result<Self, SessionError> {
         let sessions_dir = dir.ensure_subdir(SESSIONS_DIR)?;
         Self::load_from(id, &sessions_dir)
     }
@@ -770,7 +770,7 @@ where
         Ok(session)
     }
 
-    pub fn list(cwd: &str, dir: &DataDir) -> Result<Vec<SessionSummary>, SessionError> {
+    pub fn list(cwd: &str, dir: &StateDir) -> Result<Vec<SessionSummary>, SessionError> {
         let sessions_dir = dir.ensure_subdir(SESSIONS_DIR)?;
         Self::list_in(cwd, &sessions_dir)
     }
@@ -781,7 +781,7 @@ where
         Ok(summaries)
     }
 
-    pub fn latest(cwd: &str, dir: &DataDir) -> Result<Option<Self>, SessionError> {
+    pub fn latest(cwd: &str, dir: &StateDir) -> Result<Option<Self>, SessionError> {
         let sessions_dir = dir.ensure_subdir(SESSIONS_DIR)?;
         Self::latest_in(cwd, &sessions_dir)
     }
@@ -807,7 +807,7 @@ where
         }
     }
 
-    pub fn delete(id: &str, dir: &DataDir) -> Result<(), SessionError> {
+    pub fn delete(id: &str, dir: &StateDir) -> Result<(), SessionError> {
         let sessions_dir = dir.ensure_subdir(SESSIONS_DIR)?;
         Self::delete_from(id, &sessions_dir)
     }

--- a/maki-storage/src/theme.rs
+++ b/maki-storage/src/theme.rs
@@ -1,14 +1,14 @@
 use std::fs;
 
-use crate::DataDir;
+use crate::StateDir;
 
 const THEME_FILE: &str = "theme";
 
-pub fn persist_theme_name(dir: &DataDir, name: &str) {
+pub fn persist_theme_name(dir: &StateDir, name: &str) {
     let _ = fs::write(dir.path().join(THEME_FILE), name);
 }
 
-pub fn read_theme_name(dir: &DataDir) -> Option<String> {
+pub fn read_theme_name(dir: &StateDir) -> Option<String> {
     let name = fs::read_to_string(dir.path().join(THEME_FILE)).ok()?;
     let name = name.trim();
     (!name.is_empty()).then(|| name.to_owned())
@@ -22,7 +22,7 @@ mod tests {
     #[test]
     fn theme_persistence_round_trip() {
         let tmp = TempDir::new().unwrap();
-        let dir = DataDir::from_path(tmp.path().to_path_buf());
+        let dir = StateDir::from_path(tmp.path().to_path_buf());
 
         assert!(read_theme_name(&dir).is_none());
 

--- a/maki-ui/Cargo.toml
+++ b/maki-ui/Cargo.toml
@@ -33,7 +33,6 @@ nucleo-matcher = { workspace = true }
 ignore = { workspace = true }
 async-process = { workspace = true }
 libc = { workspace = true }
-dirs = { workspace = true }
 strum = { workspace = true }
 notify = { workspace = true }
 tempfile = { workspace = true }

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -320,7 +320,7 @@ fn spawn_oauth_for_needs_auth(handle: &McpHandle) {
         let server_url = server_url.clone();
         let www_auth = url.clone();
         smol::spawn(async move {
-            let storage = match maki_storage::DataDir::resolve() {
+            let storage = match maki_storage::StateDir::resolve() {
                 Ok(s) => s,
                 Err(e) => {
                     tracing::warn!(server = %server_name, error = %e, "cannot resolve storage for OAuth");

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -58,7 +58,7 @@ use maki_agent::{
 };
 use maki_config::UiConfig;
 use maki_providers::{Message, Model, ThinkingConfig};
-use maki_storage::DataDir;
+use maki_storage::StateDir;
 use maki_storage::input_history::InputHistory;
 use maki_storage::model::persist_model;
 
@@ -158,7 +158,7 @@ pub struct App {
     pub(super) clipboard: ClipboardState,
     pub(super) last_esc: Option<Instant>,
 
-    pub(crate) storage: DataDir,
+    pub(crate) storage: StateDir,
     pub(crate) shared_history: Option<Arc<ArcSwap<Vec<Message>>>>,
     pub(crate) shared_tool_outputs: Option<Arc<Mutex<HashMap<String, ToolOutput>>>>,
     pub(crate) image_paste_rx: Option<flume::Receiver<Result<ImageSource, String>>>,
@@ -174,7 +174,7 @@ impl App {
     pub fn new(
         model: &Model,
         session: AppSession,
-        storage: DataDir,
+        storage: StateDir,
         available_models: Arc<ArcSwapOption<Vec<String>>>,
         mcp_reader: McpSnapshotReader,
         storage_writer: Arc<StorageWriter>,
@@ -1194,11 +1194,11 @@ impl App {
 
     fn cmd_cd(&mut self, args: &str) -> Vec<Action> {
         let path = if args.is_empty() {
-            dirs::home_dir().unwrap_or_default()
+            maki_storage::paths::home().unwrap_or_default()
         } else {
             match args.strip_prefix('~') {
                 Some(rest) => {
-                    let home = dirs::home_dir().unwrap_or_default();
+                    let home = maki_storage::paths::home().unwrap_or_default();
                     if rest.is_empty() {
                         home
                     } else {

--- a/maki-ui/src/app/mode.rs
+++ b/maki-ui/src/app/mode.rs
@@ -5,7 +5,7 @@ use crate::agent::QueuedMessage;
 use crate::components::Status;
 use crate::theme;
 use maki_agent::{AgentInput, AgentMode};
-use maki_storage::DataDir;
+use maki_storage::StateDir;
 use maki_storage::plans;
 use ratatui::style::{Color, Modifier, Style};
 
@@ -63,7 +63,7 @@ impl PlanState {
         matches!(self, Self::Ready(_))
     }
 
-    pub(crate) fn allocate_path(&mut self, storage: &DataDir) {
+    pub(crate) fn allocate_path(&mut self, storage: &StateDir) {
         if matches!(self, Self::None) {
             *self = Self::Drafting(
                 plans::new_plan_path(storage).unwrap_or_else(|_| PathBuf::from("plans/plan.md")),

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -7,7 +7,7 @@ use maki_agent::ToolOutput;
 use maki_agent::permissions::PermissionManager;
 use maki_config::Effect;
 use maki_providers::{Message, Model, ThinkingConfig, TokenUsage};
-use maki_storage::DataDir;
+use maki_storage::StateDir;
 use maki_storage::sessions::{StoredEffect, StoredMode, StoredRule};
 
 use crate::AppSession;
@@ -31,7 +31,7 @@ impl SessionState {
     pub fn from_session(
         mut session: AppSession,
         fallback_model: &Model,
-        storage: &DataDir,
+        storage: &StateDir,
     ) -> Self {
         let model = Model::from_spec(&session.model).unwrap_or_else(|_| {
             session.model = fallback_model.spec();
@@ -163,7 +163,7 @@ mod tests {
     #[test]
     fn plan_mode_without_path_allocates_path() {
         let tmp = tempfile::tempdir().unwrap();
-        let storage = DataDir::from_path(tmp.path().to_path_buf());
+        let storage = StateDir::from_path(tmp.path().to_path_buf());
         let session = make_plan_session(Some(StoredMode::Plan), None);
         let state = SessionState::from_session(session, &test_model(), &storage);
         assert_eq!(state.mode, Mode::Plan);
@@ -173,7 +173,7 @@ mod tests {
     #[test]
     fn plan_mode_with_missing_file_allocates_new_path_and_warns() {
         let tmp = tempfile::tempdir().unwrap();
-        let storage = DataDir::from_path(tmp.path().to_path_buf());
+        let storage = StateDir::from_path(tmp.path().to_path_buf());
         let session =
             make_plan_session(Some(StoredMode::Plan), Some("/nonexistent/plan.md".into()));
         let state = SessionState::from_session(session, &test_model(), &storage);
@@ -187,7 +187,7 @@ mod tests {
     #[test]
     fn plan_mode_with_existing_file_preserves_path() {
         let tmp = tempfile::tempdir().unwrap();
-        let storage = DataDir::from_path(tmp.path().to_path_buf());
+        let storage = StateDir::from_path(tmp.path().to_path_buf());
         let plan_file = tmp.path().join("existing-plan.md");
         std::fs::write(&plan_file, "# Plan").unwrap();
         let session = make_plan_session(
@@ -202,7 +202,7 @@ mod tests {
     #[test]
     fn build_mode_does_not_allocate_path() {
         let tmp = tempfile::tempdir().unwrap();
-        let storage = DataDir::from_path(tmp.path().to_path_buf());
+        let storage = StateDir::from_path(tmp.path().to_path_buf());
         let session = make_plan_session(Some(StoredMode::Build), None);
         let state = SessionState::from_session(session, &test_model(), &storage);
         assert_eq!(state.mode, Mode::Build);

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -30,7 +30,7 @@ fn set_zone(app: &mut App, zone: SelectionZone, area: Rect) {
 }
 
 fn test_app() -> App {
-    let writer = Arc::new(StorageWriter::new(DataDir::from_path(env::temp_dir())));
+    let writer = Arc::new(StorageWriter::new(StateDir::from_path(env::temp_dir())));
     let permissions = Arc::new(PermissionManager::new(
         PermissionsConfig {
             allow_all: false,
@@ -42,7 +42,7 @@ fn test_app() -> App {
     let mut app = App::new(
         &model,
         AppSession::new("test-model", "/tmp/test"),
-        DataDir::from_path(env::temp_dir()),
+        StateDir::from_path(env::temp_dir()),
         Arc::new(ArcSwapOption::empty()),
         McpSnapshotReader::empty(),
         writer,
@@ -447,8 +447,8 @@ fn reset_session_clears_drafting_plan_in_build_mode() {
 #[test]
 fn load_session_clears_plan() {
     let tmp = TempDir::new().unwrap();
-    let dir = DataDir::from_path(tmp.path().to_path_buf());
-    let writer = Arc::new(StorageWriter::new(DataDir::from_path(
+    let dir = StateDir::from_path(tmp.path().to_path_buf());
+    let writer = Arc::new(StorageWriter::new(StateDir::from_path(
         tmp.path().to_path_buf(),
     )));
     let model = test_model();
@@ -2153,7 +2153,7 @@ fn thinking_non_anthropic_flashes_error() {
 #[test]
 fn thinking_restored_from_session_meta() {
     let tmp = TempDir::new().unwrap();
-    let storage = DataDir::from_path(tmp.path().to_path_buf());
+    let storage = StateDir::from_path(tmp.path().to_path_buf());
     let mut session = AppSession::new("test-model", "/tmp/test");
     session.meta.thinking = Some(StoredThinking::Budget { tokens: 4096 });
 

--- a/maki-ui/src/components/session_picker.rs
+++ b/maki-ui/src/components/session_picker.rs
@@ -7,7 +7,7 @@ use crate::components::list_picker::{ListPicker, PickerAction, PickerItem};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use jiff::Timestamp;
-use maki_storage::DataDir;
+use maki_storage::StateDir;
 use ratatui::Frame;
 use ratatui::layout::{Position, Rect};
 
@@ -55,7 +55,7 @@ impl SessionPicker {
         }
     }
 
-    pub fn open(&mut self, cwd: &str, current_session_id: &str, dir: &DataDir) {
+    pub fn open(&mut self, cwd: &str, current_session_id: &str, dir: &StateDir) {
         self.picker.open_loading(TITLE);
         let cwd = cwd.to_owned();
         let current_session_id = current_session_id.to_owned();

--- a/maki-ui/src/components/status_bar.rs
+++ b/maki-ui/src/components/status_bar.rs
@@ -214,7 +214,7 @@ impl StatusBar {
 }
 
 fn collapse_home(path: &str) -> String {
-    let Some(home) = dirs::home_dir() else {
+    let Some(home) = maki_storage::paths::home() else {
         return path.to_string();
     };
     collapse_home_with(path, &home.to_string_lossy())

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -16,7 +16,7 @@ use maki_config::UiConfig;
 use maki_providers::Timeouts;
 use maki_providers::provider::{Provider, fetch_all_models, from_model};
 use maki_providers::{Message, Model};
-use maki_storage::DataDir;
+use maki_storage::StateDir;
 use tracing::warn;
 
 use crate::AppSession;
@@ -41,7 +41,7 @@ pub struct EventLoopParams {
     pub skills: Vec<Skill>,
     pub commands: Vec<CustomCommand>,
     pub session: AppSession,
-    pub storage: DataDir,
+    pub storage: StateDir,
     pub config: AgentConfig,
     pub ui_config: UiConfig,
     pub input_history_size: usize,

--- a/maki-ui/src/image.rs
+++ b/maki-ui/src/image.rs
@@ -33,7 +33,7 @@ pub(crate) fn try_parse_image_path(text: &str) -> Option<(PathBuf, ImageMediaTyp
         return None;
     }
     let path = if let Some(rest) = path_str.strip_prefix("~/") {
-        dirs::home_dir()?.join(rest)
+        maki_storage::paths::home()?.join(rest)
     } else {
         PathBuf::from(&path_str)
     };
@@ -111,7 +111,7 @@ mod tests {
     #[test]
     fn try_parse_image_path_tilde() {
         let (path, media) = try_parse_image_path("~/Pictures/photo.jpg").expect("should parse");
-        let home = dirs::home_dir().unwrap();
+        let home = maki_storage::paths::home().unwrap();
         assert_eq!(path, home.join("Pictures/photo.jpg"));
         assert_eq!(media, ImageMediaType::Jpeg);
     }

--- a/maki-ui/src/storage_writer.rs
+++ b/maki-ui/src/storage_writer.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use maki_storage::DataDir;
+use maki_storage::StateDir;
 use maki_storage::sessions::{SESSIONS_DIR, SessionError, SessionLog};
 use tracing::warn;
 
@@ -21,7 +21,7 @@ pub struct StorageWriter {
 }
 
 impl StorageWriter {
-    pub fn new(dir: DataDir) -> Self {
+    pub fn new(dir: StateDir) -> Self {
         let latest: Arc<Mutex<Option<Box<AppSession>>>> = Arc::new(Mutex::new(None));
         let writer_latest = Arc::clone(&latest);
         let (notify, notify_rx) = flume::bounded::<()>(1);
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn shutdown_drains_pending_session() {
-        let dir = DataDir::from_path(env::temp_dir().join("maki-test-sw"));
+        let dir = StateDir::from_path(env::temp_dir().join("maki-test-sw"));
         let writer = StorageWriter::new(dir);
         writer.send(Box::new(AppSession::new("test-model", "/tmp")));
         writer.shutdown(Duration::from_secs(2));

--- a/maki-ui/src/theme.rs
+++ b/maki-ui/src/theme.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock};
 
 use arc_swap::{ArcSwap, Guard};
-use maki_storage::DataDir;
+use maki_storage::StateDir;
 use ratatui::style::{Color, Modifier, Style};
 use serde::Deserialize;
 use syntect::highlighting::{
@@ -258,13 +258,13 @@ pub fn load_by_name(name: &str) -> Result<Theme, String> {
 }
 
 pub fn persist_theme(name: &str) {
-    if let Ok(dir) = DataDir::resolve() {
+    if let Ok(dir) = StateDir::resolve() {
         maki_storage::theme::persist_theme_name(&dir, name);
     }
 }
 
 fn read_theme_name() -> Option<String> {
-    let dir = DataDir::resolve().ok()?;
+    let dir = StateDir::resolve().ok()?;
     maki_storage::theme::read_theme_name(&dir)
 }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -4,7 +4,7 @@ mod tui;
 use color_eyre::Result;
 use color_eyre::eyre::Context;
 
-use maki_storage::DataDir;
+use maki_storage::StateDir;
 
 use crate::cli::{AuthAction, Cli, Command, McpAction};
 use crate::update;
@@ -12,7 +12,7 @@ use crate::update;
 pub fn dispatch(cli: Cli) -> Result<()> {
     match cli.command {
         Some(Command::Auth { action }) => {
-            let storage = DataDir::resolve().context("resolve data directory")?;
+            let storage = StateDir::resolve().context("resolve data directory")?;
             match action {
                 AuthAction::Login { provider } => subcmd::auth_login(&provider, &storage)?,
                 AuthAction::Logout { provider } => subcmd::auth_logout(&provider, &storage)?,
@@ -25,7 +25,7 @@ pub fn dispatch(cli: Cli) -> Result<()> {
             subcmd::models();
         }
         Some(Command::Mcp { action }) => {
-            let storage = DataDir::resolve().context("resolve data directory")?;
+            let storage = StateDir::resolve().context("resolve data directory")?;
             match action {
                 McpAction::Auth { server } => subcmd::mcp_auth(&server, &storage)?,
                 McpAction::Logout { server } => subcmd::mcp_logout(&server, &storage)?,

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -11,9 +11,9 @@ use maki_config::load_config;
 use maki_lua::PluginHost;
 use maki_providers::provider::fetch_all_models;
 use maki_providers::{copilot_auth, dynamic, openai_auth};
-use maki_storage::DataDir;
+use maki_storage::StateDir;
 
-pub fn auth_login(provider: &str, storage: &DataDir) -> Result<()> {
+pub fn auth_login(provider: &str, storage: &StateDir) -> Result<()> {
     match provider {
         "openai" => openai_auth::login(storage)?,
         "copilot" => copilot_auth::login()?,
@@ -22,7 +22,7 @@ pub fn auth_login(provider: &str, storage: &DataDir) -> Result<()> {
     Ok(())
 }
 
-pub fn auth_logout(provider: &str, storage: &DataDir) -> Result<()> {
+pub fn auth_logout(provider: &str, storage: &StateDir) -> Result<()> {
     match provider {
         "openai" => openai_auth::logout(storage)?,
         "copilot" => copilot_auth::logout()?,
@@ -72,7 +72,7 @@ pub fn index(path: &str, no_plugins: bool) -> Result<()> {
     Ok(())
 }
 
-pub fn mcp_auth(server: &str, storage: &DataDir) -> Result<()> {
+pub fn mcp_auth(server: &str, storage: &StateDir) -> Result<()> {
     smol::block_on(async {
         let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
         let config = mcp_config::load_config(&cwd);
@@ -90,7 +90,7 @@ pub fn mcp_auth(server: &str, storage: &DataDir) -> Result<()> {
     })
 }
 
-pub fn mcp_logout(server: &str, storage: &DataDir) -> Result<()> {
+pub fn mcp_logout(server: &str, storage: &StateDir) -> Result<()> {
     let deleted = maki_storage::auth::delete_mcp_auth(storage, server)?;
     if deleted {
         eprintln!("Removed OAuth credentials for MCP server '{server}'");

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -11,7 +11,7 @@ use maki_agent::tools::ToolRegistry;
 use maki_config::load_config;
 use maki_lua::PluginHost;
 use maki_providers::model::Model;
-use maki_storage::DataDir;
+use maki_storage::StateDir;
 use maki_ui::AppSession;
 
 use crate::cli::{Cli, normalize_tool_name};
@@ -38,7 +38,7 @@ fn resolve_session(
     session_id: Option<String>,
     model: &str,
     cwd: &str,
-    storage: &DataDir,
+    storage: &StateDir,
 ) -> Result<AppSession> {
     if let Some(id) = session_id {
         return AppSession::load(&id, storage).map_err(|e| color_eyre::eyre::eyre!("{e}"));
@@ -70,7 +70,7 @@ fn read_initial_prompt(cli_prompt: Option<String>) -> Result<Option<String>> {
 }
 
 pub fn run(cli: Cli) -> Result<()> {
-    let storage = DataDir::resolve().context("resolve data directory")?;
+    let storage = StateDir::resolve().context("resolve data directory")?;
     maki_providers::tier_map::load_from_storage(&storage);
 
     let cwd = env::current_dir().unwrap_or_else(|_| ".".into());

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -5,7 +5,7 @@ use color_eyre::eyre::Context;
 
 use maki_providers::model::{Model, ModelTier};
 use maki_providers::provider::ProviderKind;
-use maki_storage::DataDir;
+use maki_storage::StateDir;
 use maki_storage::log::RotatingFileWriter;
 use maki_storage::model::{persist_model, read_model};
 use tracing_subscriber::EnvFilter;
@@ -21,7 +21,7 @@ const PROVIDER_PRIORITY: &[ProviderKind] = &[
 pub fn resolve_model(
     explicit: Option<&str>,
     provider_config: &maki_config::ProviderConfig,
-    storage: &DataDir,
+    storage: &StateDir,
 ) -> Result<Model> {
     if let Some(spec) = explicit {
         let model = Model::from_spec(spec).context("invalid --model spec")?;
@@ -77,7 +77,7 @@ pub fn install_panic_log_hook() {
     }));
 }
 
-pub fn init_logging(storage: &DataDir, storage_config: &maki_config::StorageConfig) {
+pub fn init_logging(storage: &StateDir, storage_config: &maki_config::StorageConfig) {
     let Ok(writer) = RotatingFileWriter::new(
         storage,
         storage_config.max_log_bytes,

--- a/src/update.rs
+++ b/src/update.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use maki_storage::version::{self, VersionError};
-use maki_storage::{DataDir, StorageError};
+use maki_storage::{StateDir, StorageError};
 
 const INSTALL_SCRIPT_URL: &str = "https://maki.sh/install.sh";
 const BACKUP_FILENAME: &str = "maki_backup";
@@ -66,7 +66,7 @@ fn fetch_script() -> Result<String, UpdateError> {
     })
 }
 
-fn backup_binary(exe_path: &Path, storage: &DataDir) -> Result<PathBuf, UpdateError> {
+fn backup_binary(exe_path: &Path, storage: &StateDir) -> Result<PathBuf, UpdateError> {
     let backup_path = storage.path().join(BACKUP_FILENAME);
     std::fs::copy(exe_path, &backup_path).map_err(|e| UpdateError::Backup {
         path: backup_path.clone(),
@@ -161,7 +161,7 @@ pub fn update(skip_confirm: bool, no_color: bool) -> Result<(), UpdateError> {
     println!();
 
     let exe_path = std::env::current_exe().map_err(UpdateError::CurrentExe)?;
-    let storage = DataDir::resolve()?;
+    let storage = StateDir::resolve()?;
 
     let script = fetch_script()?;
 
@@ -190,7 +190,7 @@ pub fn update(skip_confirm: bool, no_color: bool) -> Result<(), UpdateError> {
 
 pub fn rollback() -> Result<(), UpdateError> {
     let exe_path = std::env::current_exe().map_err(UpdateError::CurrentExe)?;
-    let storage = DataDir::resolve()?;
+    let storage = StateDir::resolve()?;
     let backup_path = storage.path().join(BACKUP_FILENAME);
 
     if !backup_path.exists() {


### PR DESCRIPTION
## Summary

- Replace `dirs` crate with `etcetera` across the entire workspace
- Add `maki-storage/src/paths.rs` with typed resolvers: `config_dir()`, `data_dir()`, `state_dir()`, `logs_dir()`, `cache_dir()`, `home()`
- XDG layout: config in `~/.config/maki/`, data in `~/.local/lib/maki/`, state in `~/.local/state/maki/`, logs in `~/.local/logs/maki/`, cache in `~/.cache/maki/`
- Backward compat: falls back to `~/.maki/` when it already exists
- Also fixes pre-existing clippy lints in storage, agent, and ui