### PR TITLE
agent: tools: read: Try improving offset/limit usage of the read tool

### DIFF
--- a/maki-agent/src/tools/read.md
+++ b/maki-agent/src/tools/read.md
@@ -1,9 +1,11 @@
 Read a file or directory. Returns contents with line numbers (1-indexed).
 
 - Supports absolute, relative, and ~/ paths.
-- Use index tool first to see file structure and find the right line numbers.
-- Up to 2000 lines by default.
-- Always use offset/limit if you know them or for large files (>500 lines).
-- Use grep to find specific content instead of reading entire large files.
+- Use the index tool first to locate relevant line ranges.
+- **Always include offset and limit**. Defaults: no offset = start at 1; no limit = up to 2000 lines.
+- Use truncation hints (e.g. "truncated lines X-Y") to continue with the correct offset.
+- For files >500 lines, always **read** with offset/limit (only what you need).
+- Do not reread the same range (same file and same offset).
+- Prefer grep to locate content instead of scanning full files.
 - Call in parallel when reading multiple files.
 - Avoid tiny repeated slices - read a larger window if you need more context.

--- a/maki-agent/src/tools/read.rs
+++ b/maki-agent/src/tools/read.rs
@@ -15,7 +15,9 @@ pub struct Read {
     path: String,
     #[param(description = "Line number to start from (1-indexed)")]
     offset: Option<usize>,
-    #[param(description = "Max number of lines to read")]
+    #[param(
+        description = "Max number of lines to read. Omitting the limit reads up to 2000 lines."
+    )]
     limit: Option<usize>,
 }
 

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -317,7 +317,10 @@ impl ToolOutput {
                 let remaining = lines_remaining_after(*total_lines, *start_line, lines.len());
                 if remaining > 0 {
                     out.push_str(&format!(
-                        "\n\n... truncated {remaining} more lines. Use offset/limit to read further.",
+                        "\n\n...\n\nTruncated lines: {}-{}. Use offset={} to read further.",
+                        start_line + lines.len(),
+                        total_lines,
+                        start_line + lines.len(),
                     ));
                 }
                 out
@@ -875,14 +878,14 @@ mod tests {
         10,
         vec!["fn foo()".into(), "fn bar()".into()],
         Some(vec![InstructionBlock { path: "AGENTS.md".into(), content: "do stuff".into() }]),
-        "10: fn foo()\n11: fn bar()\n\n... truncated 89 more lines. Use offset/limit to read further."
+        "10: fn foo()\n11: fn bar()\n\n...\n\nTruncated lines: 12-100. Use offset=12 to read further."
         ; "with_instructions"
     )]
     #[test_case(
         1,
         vec!["line1".into()],
         None,
-        "1: line1\n\n... truncated 99 more lines. Use offset/limit to read further."
+        "1: line1\n\n...\n\nTruncated lines: 2-100. Use offset=2 to read further."
         ; "without_instructions"
     )]
     fn read_code_display_text(

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -29,7 +29,7 @@ Read a file or directory. Returns contents with line numbers (1-indexed).
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `limit` | integer | no | Max number of lines to read |
+| `limit` | integer | no | Max number of lines to read. Omitting the limit reads up to 2000 lines. |
 | `offset` | integer | no | Line number to start from (1-indexed) |
 | `path` | string | yes | Absolute path to the file or directory |
 


### PR DESCRIPTION
Various smaller models regular fail to follow the instructions and repeatadly read the whole file (i.e. 2000 lines) instead of properly using offset/limit to only read a part.

More examples and more explicit tool prompt help here.