### PR TITLE
agent: read: Don't allow two consecutive reads on the same file with …

### DIFF
--- a/maki-agent/src/tools/edit.rs
+++ b/maki-agent/src/tools/edit.rs
@@ -41,10 +41,13 @@ impl Edit {
             file_tracker.check_before_edit(p)?;
 
             let before = fs::read_to_string(p).map_err(|e| format!("read error: {e}"))?;
-            let after = fuzzy_replace::replace(&before, &old_string, &new_string, replace_all)?;
+            let after = fuzzy_replace::replace(&before, &old_string, &new_string, replace_all)
+                .inspect_err(|_| {
+                    file_tracker.clear_read(p);
+                })?;
             fs::write(p, &after).map_err(|e| format!("write error: {e}"))?;
 
-            file_tracker.record_read(p);
+            file_tracker.record_read(p, 1, usize::MAX);
 
             Ok(ToolOutput::Diff {
                 summary: format!("edited {}", relative_path(&path)),
@@ -90,6 +93,8 @@ mod tests {
     use tempfile::TempDir;
 
     use crate::AgentMode;
+    use crate::ToolOutput;
+    use crate::tools::read::Read;
     use crate::tools::test_support::{pre_read, stub_ctx};
 
     use super::*;
@@ -169,6 +174,70 @@ mod tests {
             assert_eq!(before, original);
             assert_eq!(after, updated);
             assert_eq!(fs::read_to_string(&path).unwrap(), updated);
+        });
+    }
+
+    #[test]
+    fn failed_edit_allows_re_read() {
+        smol::block_on(async {
+            let dir = TempDir::new().unwrap();
+            let ctx = stub_ctx(&AgentMode::Build);
+            let path = temp_file(&dir, "f.rs", "fn alpha() {}\nfn beta() {}");
+            pre_read(&ctx, &path);
+
+            // Failed edit - old_string not found
+            let err = Edit {
+                path: path.clone(),
+                old_string: "MISSING".into(),
+                new_string: "replaced".into(),
+                replace_all: None,
+            }
+            .execute(&ctx)
+            .await
+            .unwrap_err();
+            assert!(err.contains("not found"));
+
+            // Re-reading with same params should now succeed
+            let read = Read::parse_input(&serde_json::json!({ "path": path })).unwrap();
+            let output = read.execute(&ctx).await.unwrap();
+            assert!(matches!(output, ToolOutput::ReadCode { .. }));
+        });
+    }
+
+    #[test]
+    fn sequential_edits_on_same_file_succeed() {
+        smol::block_on(async {
+            let dir = TempDir::new().unwrap();
+            let ctx = stub_ctx(&AgentMode::Build);
+            let path = temp_file(&dir, "f.rs", "fn one() {}\nfn two() {}\nfn three() {}");
+            pre_read(&ctx, &path);
+
+            // First edit
+            Edit {
+                path: path.clone(),
+                old_string: "fn one() {}".into(),
+                new_string: "fn alpha() {}".into(),
+                replace_all: None,
+            }
+            .execute(&ctx)
+            .await
+            .unwrap();
+
+            // Second edit on same file without re-reading
+            Edit {
+                path: path.clone(),
+                old_string: "fn two() {}".into(),
+                new_string: "fn beta() {}".into(),
+                replace_all: None,
+            }
+            .execute(&ctx)
+            .await
+            .unwrap();
+
+            assert_eq!(
+                fs::read_to_string(&path).unwrap(),
+                "fn alpha() {}\nfn beta() {}\nfn three() {}"
+            );
         });
     }
 }

--- a/maki-agent/src/tools/file_tracker.rs
+++ b/maki-agent/src/tools/file_tracker.rs
@@ -4,7 +4,14 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
-pub struct FileReadTracker(Mutex<HashMap<PathBuf, SystemTime>>);
+pub struct FileReadTracker(Mutex<HashMap<PathBuf, FileReadInfo>>);
+
+#[derive(Clone, Copy)]
+struct FileReadInfo {
+    mtime: SystemTime,
+    offset: usize,
+    limit: usize,
+}
 
 fn get_mtime(path: &Path) -> SystemTime {
     fs::metadata(path)
@@ -31,10 +38,17 @@ impl FileReadTracker {
         Arc::new(Self::new())
     }
 
-    pub fn record_read(&self, path: &Path) {
+    pub fn record_read(&self, path: &Path, offset: usize, limit: usize) {
         let normalized = normalize_path(path);
         let mtime = get_mtime(&normalized);
-        self.0.lock().unwrap().insert(normalized, mtime);
+        self.0.lock().unwrap().insert(
+            normalized,
+            FileReadInfo {
+                mtime,
+                offset,
+                limit,
+            },
+        );
     }
 
     pub fn check_before_edit(&self, path: &Path) -> Result<(), String> {
@@ -47,11 +61,52 @@ impl FileReadTracker {
                 "file must be read before editing with read tool: {}",
                 path.display()
             )),
-            Some(&recorded) if recorded != current_mtime => Err(format!(
+            Some(&recorded) if recorded.mtime != current_mtime => Err(format!(
                 "file changed since last read: {} - re-read using read tool before editing",
                 path.display()
             )),
             Some(_) => Ok(()),
+        }
+    }
+
+    /// Remove the read record for a file, allowing it to be re-read.
+    pub fn clear_read(&self, path: &Path) {
+        let normalized = normalize_path(path);
+        self.0.lock().unwrap().remove(&normalized);
+    }
+
+    /// Check whether a read with the given parameters is allowed.
+    /// Returns `Ok(())` if the file has changed since the last read
+    /// or if the parameters differ. Returns an error if the read would
+    /// be a duplicate of the previous read on an unchanged file.
+    pub fn check_before_read(
+        &self,
+        path: &Path,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(), String> {
+        let normalized = normalize_path(path);
+        let current_mtime = get_mtime(&normalized);
+
+        let guard = self.0.lock().unwrap();
+        match guard.get(&normalized) {
+            None => Ok(()),
+            Some(&info) => {
+                // File changed since last read - always allow.
+                if info.mtime != current_mtime {
+                    return Ok(());
+                }
+                // Same file, same content - allow only if parameters differ.
+                if info.offset != offset || info.limit != limit {
+                    return Ok(());
+                }
+                Err(format!(
+                    "file {} was already read with the same parameters (offset={}, limit={}) - no need to read again",
+                    path.display(),
+                    offset,
+                    limit
+                ))
+            }
         }
     }
 }
@@ -74,17 +129,6 @@ mod tests {
     }
 
     #[test]
-    fn edit_after_read_succeeds() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("test.rs");
-        fs::write(&path, "content").unwrap();
-
-        let tracker = FileReadTracker::new();
-        tracker.record_read(&path);
-        tracker.check_before_edit(&path).unwrap();
-    }
-
-    #[test]
     #[cfg(unix)]
     fn symlink_resolves_to_same_file() {
         let dir = tempfile::TempDir::new().unwrap();
@@ -94,7 +138,70 @@ mod tests {
         std::os::unix::fs::symlink(&real_path, &link_path).unwrap();
 
         let tracker = FileReadTracker::new();
-        tracker.record_read(&real_path);
+        tracker.record_read(&real_path, 1, 2000);
         tracker.check_before_edit(&link_path).unwrap();
+    }
+
+    const DUP_READ_ERR: &str = "already read with the same parameters";
+
+    #[test]
+    fn duplicate_read_with_same_params_fails() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.rs");
+        fs::write(&path, "content").unwrap();
+
+        let tracker = FileReadTracker::new();
+        tracker.record_read(&path, 1, 2000);
+        let err = tracker.check_before_read(&path, 1, 2000).unwrap_err();
+        assert!(err.contains(DUP_READ_ERR));
+    }
+
+    #[test]
+    fn different_offset_allows_read() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.rs");
+        fs::write(&path, "content").unwrap();
+
+        let tracker = FileReadTracker::new();
+        tracker.record_read(&path, 1, 2000);
+        tracker.check_before_read(&path, 5, 2000).unwrap();
+    }
+
+    #[test]
+    fn different_limit_allows_read() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.rs");
+        fs::write(&path, "content").unwrap();
+
+        let tracker = FileReadTracker::new();
+        tracker.record_read(&path, 1, 2000);
+        tracker.check_before_read(&path, 1, 500).unwrap();
+    }
+
+    #[test]
+    fn file_changed_since_last_read_allows_read() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.rs");
+        fs::write(&path, "content").unwrap();
+
+        let tracker = FileReadTracker::new();
+        tracker.record_read(&path, 1, 2000);
+
+        // Modify the file to change its mtime
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        fs::write(&path, "modified content").unwrap();
+
+        // Same params but file changed - should allow
+        tracker.check_before_read(&path, 1, 2000).unwrap();
+    }
+
+    #[test]
+    fn never_read_allows_read() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.rs");
+        fs::write(&path, "content").unwrap();
+
+        let tracker = FileReadTracker::new();
+        tracker.check_before_read(&path, 1, 2000).unwrap();
     }
 }

--- a/maki-agent/src/tools/grep.rs
+++ b/maki-agent/src/tools/grep.rs
@@ -124,7 +124,7 @@ impl Grep {
                 let _ = searcher.search_path(&matcher, &path, &mut sink);
 
                 if !groups.is_empty() {
-                    file_tracker.record_read(&path);
+                    file_tracker.record_read(&path, 1, usize::MAX);
                     let rel = path
                         .strip_prefix(base)
                         .unwrap_or(&path)

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -699,7 +699,7 @@ pub mod test_support {
 
     #[cfg(test)]
     pub(crate) fn pre_read(ctx: &ToolContext, path: &str) {
-        ctx.file_tracker.record_read(Path::new(path));
+        ctx.file_tracker.record_read(Path::new(path), 1, usize::MAX);
     }
 }
 
@@ -1015,8 +1015,10 @@ mod tests {
             let plan_str = plan_path.to_str().unwrap();
             let other_str = other.to_str().unwrap();
 
-            ctx.file_tracker.record_read(Path::new(plan_str));
-            ctx.file_tracker.record_read(Path::new(other_str));
+            ctx.file_tracker
+                .record_read(Path::new(plan_str), 1, usize::MAX);
+            ctx.file_tracker
+                .record_read(Path::new(other_str), 1, usize::MAX);
 
             let registry = ToolRegistry::native();
             let blocked = tool_dispatch::run(

--- a/maki-agent/src/tools/multiedit.rs
+++ b/maki-agent/src/tools/multiedit.rs
@@ -69,10 +69,11 @@ impl MultiEdit {
             file_tracker.check_before_edit(p)?;
 
             let before = fs::read_to_string(p).map_err(|e| format!("read error: {e}"))?;
-            let after = this.apply_edits(&before)?;
+            let after = this.apply_edits(&before).inspect_err(|_| {
+                file_tracker.clear_read(p);
+            })?;
             fs::write(p, &after).map_err(|e| format!("write error: {e}"))?;
-
-            file_tracker.record_read(p);
+            file_tracker.record_read(p, 1, usize::MAX);
 
             Ok(ToolOutput::Diff {
                 summary: format!(

--- a/maki-agent/src/tools/read.rs
+++ b/maki-agent/src/tools/read.rs
@@ -52,11 +52,16 @@ impl Read {
                 return Self::list_dir(&path, cwd.as_deref(), &loaded);
             }
 
+            let offset_val = offset.unwrap_or(1);
+            let limit_val = limit.unwrap_or(max_output_lines);
+
+            file_tracker.check_before_read(p, offset_val, limit_val)?;
+
             let raw = fs::read_to_string(p).map_err(|e| format!("read error: {e}"))?;
             let total_lines = raw.lines().count();
 
-            let start = offset.unwrap_or(1).saturating_sub(1);
-            let limit = limit.unwrap_or(max_output_lines);
+            let start = offset_val.saturating_sub(1);
+            let limit = limit_val;
 
             let lines: Vec<String> = raw
                 .lines()
@@ -76,7 +81,7 @@ impl Read {
                 ))
             });
 
-            file_tracker.record_read(p);
+            file_tracker.record_read(p, offset_val, limit_val);
 
             Ok(ToolOutput::ReadCode {
                 path,

--- a/maki-agent/src/tools/write.rs
+++ b/maki-agent/src/tools/write.rs
@@ -48,7 +48,7 @@ impl Write {
                 fs::create_dir_all(parent).map_err(|e| format!("mkdir error: {e}"))?;
             }
             fs::write(&path, &content).map_err(|e| format!("write error: {e}"))?;
-            file_tracker.record_read(p);
+            file_tracker.record_read(p, 1, usize::MAX);
             Ok(output)
         })
         .await


### PR DESCRIPTION
…the same offset/limit

Unless the mtime changes or an edit happens in between.