### PR TITLE
agent: replace batch_child with Emit parameter on tool_dispatch::run

### DIFF
--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -333,7 +333,6 @@ impl Agent {
             permissions: Arc::clone(&self.permissions),
             timeouts: self.timeouts,
             file_tracker: Arc::clone(&self.file_tracker),
-            batch_child: false,
         }
     }
 

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -13,6 +13,12 @@ use crate::tools::ToolContext;
 use crate::tools::registry::{ToolInvocation, ToolRegistry};
 use crate::{AgentError, AgentEvent, AgentMode, ToolDoneEvent, ToolOutput, ToolStartEvent};
 
+#[derive(Clone, Copy)]
+pub enum Emit {
+    Notify,
+    Silent,
+}
+
 const DOOM_LOOP_THRESHOLD: usize = 3;
 const DOOM_LOOP_MESSAGE: &str = "You have called this tool with identical input 3 times in a row. You are stuck in a loop. Break out and try a different approach.";
 const MCP_BLOCKED_IN_PLAN: &str = "MCP tools are not available in plan mode";
@@ -59,6 +65,7 @@ pub async fn run(
     name: &str,
     input: &Value,
     ctx: &ToolContext,
+    emit: Emit,
 ) -> ToolDoneEvent {
     let entry = registry.get(name);
     let tool_id: Arc<str> = entry
@@ -113,7 +120,9 @@ pub async fn run(
             input: invocation.start_input(),
             output: invocation.start_output(),
         };
-        ctx.emit_tool_start(start);
+        if matches!(emit, Emit::Notify) {
+            let _ = ctx.event_tx.send(AgentEvent::ToolStart(Box::new(start)));
+        }
 
         if let Err(e) = enforce_permission(invocation.as_ref(), name, ctx, &id).await {
             return done_error(e);
@@ -159,7 +168,9 @@ pub async fn run(
             input: None,
             output: None,
         };
-        ctx.emit_tool_start(start);
+        if matches!(emit, Emit::Notify) {
+            let _ = ctx.event_tx.send(AgentEvent::ToolStart(Box::new(start)));
+        }
         execute_mcp_tool(ctx, &id, tool_id, name, input).await
     } else {
         let msg = format!("{UNKNOWN_TOOL_PREFIX}: {name}");
@@ -299,6 +310,7 @@ pub(super) async fn process_tool_calls(
                 &name,
                 &input,
                 &tool_ctx,
+                Emit::Notify,
             )
             .await;
             event_tx_clone.try_send(AgentEvent::ToolDone(Box::new(done.clone())));
@@ -387,6 +399,7 @@ mod tests {
                 "nonexistent__tool",
                 &serde_json::json!({}),
                 &ctx,
+                Emit::Silent,
             )
             .await;
             assert!(done.is_error);
@@ -468,6 +481,7 @@ mod tests {
                 crate::tools::BASH_TOOL_NAME,
                 &serde_json::json!({ "command": format!("touch {marker_str}") }),
                 &ctx,
+                Emit::Silent,
             )
             .await;
 

--- a/maki-agent/src/tools/batch.rs
+++ b/maki-agent/src/tools/batch.rs
@@ -5,7 +5,7 @@
 
 use std::fmt::Write;
 
-use crate::agent::tool_dispatch;
+use crate::agent::tool_dispatch::{self, Emit};
 use crate::tools::ToolRegistry;
 use crate::{AgentEvent, BatchProgressEvent, BatchToolEntry, BatchToolStatus, ToolOutput};
 use serde::de::{self, MapAccess, Visitor};
@@ -206,7 +206,6 @@ impl Batch {
 
                 let inner_ctx = ToolContext {
                     tool_use_id: Some(id.clone()),
-                    batch_child: true,
                     ..ctx.clone()
                 };
                 let done = tool_dispatch::run(
@@ -216,6 +215,7 @@ impl Batch {
                     &name,
                     &params,
                     &inner_ctx,
+                    Emit::Silent,
                 )
                 .await;
                 ctx.event_tx

--- a/maki-agent/src/tools/code_execution.rs
+++ b/maki-agent/src/tools/code_execution.rs
@@ -16,6 +16,7 @@ use serde_json::Value;
 
 use std::sync::Arc;
 
+use crate::agent::tool_dispatch::Emit;
 use crate::cancel::CancelToken;
 use crate::permissions::PermissionManager;
 use crate::task_set::TaskSet;
@@ -220,6 +221,7 @@ fn build_tool_fns(env: &InterpreterEnv) -> HashMap<String, ToolFn> {
                         fn_name,
                         &input,
                         &inner_ctx,
+                        Emit::Silent,
                     ));
                     if done.is_error {
                         Err(done.output.as_text())
@@ -287,6 +289,7 @@ fn build_async_resolver(env: &InterpreterEnv) -> AsyncResolver {
                         &pc.name,
                         &input,
                         &inner_ctx,
+                        Emit::Silent,
                     )
                     .await;
 

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -49,7 +49,7 @@ use crate::cancel::CancelToken;
 use crate::mcp::McpHandle;
 use crate::permissions::PermissionManager;
 use crate::skill::Skill;
-use crate::{AgentConfig, AgentEvent, AgentMode, EventSender, ToolStartEvent};
+use crate::{AgentConfig, AgentMode, EventSender};
 use maki_providers::Model;
 use maki_providers::provider::Provider;
 
@@ -207,15 +207,6 @@ pub struct ToolContext {
     pub permissions: Arc<PermissionManager>,
     pub timeouts: maki_providers::Timeouts,
     pub file_tracker: Arc<FileReadTracker>,
-    pub(crate) batch_child: bool,
-}
-
-impl ToolContext {
-    pub(crate) fn emit_tool_start(&self, start: ToolStartEvent) {
-        if !self.batch_child {
-            let _ = self.event_tx.send(AgentEvent::ToolStart(Box::new(start)));
-        }
-    }
 }
 
 pub(crate) fn resolve_path(path: &str) -> Result<String, String> {
@@ -609,7 +600,6 @@ pub(crate) fn interpreter_ctx(
         permissions,
         timeouts: maki_providers::Timeouts::default(),
         file_tracker,
-        batch_child: false,
     }
 }
 
@@ -1026,6 +1016,7 @@ mod tests {
                 tool,
                 &other_input(plan_str, other_str),
                 &ctx,
+                tool_dispatch::Emit::Silent,
             )
             .await;
             assert!(
@@ -1040,6 +1031,7 @@ mod tests {
                 tool,
                 &plan_input(plan_str, other_str),
                 &ctx,
+                tool_dispatch::Emit::Silent,
             )
             .await;
             assert!(!allowed.is_error, "{tool} should be allowed on plan file");


### PR DESCRIPTION
code_execution inner tools were emitting ToolStart events that showed up as phantom spinners in the UI. batch worked around this with a batch_child bool on ToolContext, but every new context constructor had to remember to set it. Moved the decision to the call site: run() now takes an Emit::Notify or Emit::Silent parameter, so the compiler forces you to pick one. Removed batch_child and emit_tool_start from ToolContext.