### PR TITLE
feat: supports deepseek-v4 models natively

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ An AI coding agent optimized for minimal use of context tokens, while providing 
 * Mistral - `MISTRAL_API_KEY`.
 * Z.AI - `ZHIPU_API_KEY`.
 * Synthetic - `SYNTHETIC_API_KEY`.
+* DeepSeek - `DEEPSEEK_API_KEY`.
 
 **Dynamic providers** - drop an executable script into `~/.maki/providers/` to add custom providers or proxies. See [docs](https://maki.sh/docs/providers/#dynamic-providers) for details.
 

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -153,6 +153,18 @@ fn build_sections() -> Vec<ProviderSection> {
                     entries: models_for_provider(kind),
                 });
             }
+            ProviderKind::Deepseek => {
+                sections.push(ProviderSection {
+                    name: kind.display_name(),
+                    auth_line: format!(
+                        "{} (shared across both endpoints)",
+                        format_auth(ProviderKind::Zai)
+                    ),
+                    urls: vec![kind.base_url()],
+                    features: kind.features(),
+                    entries: models_for_provider(kind),
+                });
+            }
             _ => {
                 sections.push(ProviderSection {
                     name: kind.display_name(),

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -153,18 +153,6 @@ fn build_sections() -> Vec<ProviderSection> {
                     entries: models_for_provider(kind),
                 });
             }
-            ProviderKind::Deepseek => {
-                sections.push(ProviderSection {
-                    name: kind.display_name(),
-                    auth_line: format!(
-                        "{} (shared across both endpoints)",
-                        format_auth(ProviderKind::Zai)
-                    ),
-                    urls: vec![kind.base_url()],
-                    features: kind.features(),
-                    entries: models_for_provider(kind),
-                });
-            }
             _ => {
                 sections.push(ProviderSection {
                     name: kind.display_name(),

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::provider::ProviderKind;
 use crate::providers::{
-    anthropic, copilot, dynamic, google, mistral, ollama, openai, synthetic, zai,
+    anthropic, copilot, deepseek, dynamic, google, mistral, ollama, openai, synthetic, zai,
 };
 
 const PER_MILLION: f64 = 1_000_000.0;
@@ -113,6 +113,7 @@ pub fn models_for_provider(provider: ProviderKind) -> &'static [ModelEntry] {
         ProviderKind::Anthropic => anthropic::models(),
         ProviderKind::OpenAi => openai::models(),
         ProviderKind::Copilot => copilot::models(),
+        ProviderKind::Deepseek => deepseek::models(),
         ProviderKind::Ollama => ollama::models(),
         ProviderKind::Mistral => mistral::models(),
         ProviderKind::Google => google::models(),

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -299,6 +299,15 @@ mod tests {
 
     const TIERS: [ModelTier; 3] = [ModelTier::Weak, ModelTier::Medium, ModelTier::Strong];
 
+    impl ModelTier {
+        fn supports_provider(&self, kind: ProviderKind) -> bool {
+            match *self {
+                Self::Weak if kind == ProviderKind::Deepseek => false,
+                _ => true,
+            }
+        }
+    }
+
     #[test_case("no-slash-here", ModelError::InvalidFormat ; "invalid_format")]
     #[test_case("foobar/gpt-4", ModelError::UnsupportedProvider("foobar".into()) ; "unsupported_provider")]
     fn from_spec_errors(spec: &str, expected: ModelError) {
@@ -359,6 +368,9 @@ mod tests {
                 continue;
             }
             for &tier in &TIERS {
+                if !tier.supports_provider(provider) {
+                    continue;
+                }
                 let model = Model::from_tier(provider, tier).unwrap();
                 assert_eq!(model.provider, provider);
                 assert_eq!(model.tier, tier);
@@ -392,6 +404,14 @@ mod tests {
                     .iter()
                     .filter(|e| e.tier == tier && e.default)
                     .count();
+                if !tier.supports_provider(provider) {
+                    assert_eq!(
+                        count, 0,
+                        "{provider}/{tier}: expected exactly 0 default for weak tier, found {count}"
+                    );
+                    continue;
+                }
+
                 assert_eq!(
                     count, 1,
                     "{provider}/{tier}: expected exactly 1 default, found {count}"

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -10,6 +10,7 @@ use crate::model::{Model, ModelFamily, models_for_provider};
 use crate::providers::Timeouts;
 use crate::providers::anthropic::Anthropic;
 use crate::providers::copilot::Copilot;
+use crate::providers::deepseek::DeepSeek;
 use crate::providers::dynamic;
 use crate::providers::google::Google;
 use crate::providers::mistral::Mistral;
@@ -27,6 +28,7 @@ pub enum ProviderKind {
     OpenAi,
     Google,
     Copilot,
+    Deepseek,
     Ollama,
     Mistral,
     Zai,
@@ -41,6 +43,7 @@ impl ProviderKind {
             Self::OpenAi => "OpenAI",
             Self::Google => "Google",
             Self::Copilot => "Copilot",
+            Self::Deepseek => "DeepSeek",
             Self::Ollama => "Ollama",
             Self::Mistral => "Mistral",
             Self::Zai => "Z.AI",
@@ -55,6 +58,7 @@ impl ProviderKind {
             Self::OpenAi => "OPENAI_API_KEY",
             Self::Google => "GEMINI_API_KEY",
             Self::Copilot => "GH_COPILOT_TOKEN",
+            Self::Deepseek => "DEEPSEEK_API_KEY",
             Self::Ollama => "OLLAMA_API_KEY",
             Self::Mistral => "MISTRAL_API_KEY",
             Self::Zai | Self::ZaiCodingPlan => "ZHIPU_API_KEY",
@@ -70,6 +74,7 @@ impl ProviderKind {
             Self::Copilot => {
                 "https://api.githubcopilot.com (or GraphQL-discovered Copilot API endpoint)"
             }
+            Self::Deepseek => "https://api.deepseek.com",
             Self::Ollama => "http://localhost:11434/v1",
             Self::Mistral => "https://api.mistral.ai/v1",
             Self::Zai => "https://api.z.ai/api/paas/v4",
@@ -108,6 +113,7 @@ impl ProviderKind {
             Self::OpenAi => ModelFamily::Gpt,
             Self::Google => ModelFamily::Gemini,
             Self::Copilot => ModelFamily::Generic,
+            Self::Deepseek => ModelFamily::Gpt, // API format compatible with OpenAI
             Self::Ollama => ModelFamily::Generic,
             Self::Mistral => ModelFamily::Generic,
             Self::Zai | Self::ZaiCodingPlan => ModelFamily::Glm,
@@ -125,6 +131,7 @@ impl ProviderKind {
             Self::OpenAi => 100_000,
             Self::Google => 65_536,
             Self::Copilot => 100_000,
+            Self::Deepseek => 8_192,
             Self::Ollama => 16_384,
             Self::Mistral => 32_000,
             Self::Zai | Self::ZaiCodingPlan => 16_000,
@@ -138,6 +145,7 @@ impl ProviderKind {
             Self::OpenAi => 200_000,
             Self::Google => 1_000_000,
             Self::Copilot => 200_000,
+            Self::Deepseek => 128_000,
             Self::Ollama => 128_000,
             Self::Mistral => 128_000,
             Self::Zai | Self::ZaiCodingPlan => 128_000,
@@ -151,6 +159,7 @@ impl ProviderKind {
             Self::OpenAi => Ok(Box::new(OpenAi::new(timeouts)?)),
             Self::Google => Ok(Box::new(Google::new(timeouts)?)),
             Self::Copilot => Ok(Box::new(Copilot::new(timeouts)?)),
+            Self::Deepseek => Ok(Box::new(DeepSeek::new(timeouts)?)),
             Self::Ollama => Ok(Box::new(Ollama::new(timeouts)?)),
             Self::Mistral => Ok(Box::new(Mistral::new(timeouts)?)),
             Self::Zai => Ok(Box::new(Zai::new(ZaiPlan::Standard, timeouts)?)),

--- a/maki-providers/src/providers/deepseek.rs
+++ b/maki-providers/src/providers/deepseek.rs
@@ -1,0 +1,401 @@
+use std::sync::{Arc, Mutex};
+
+use flume::Sender;
+use serde_json::{Value, json};
+
+use crate::model::Model;
+use crate::model::{ModelEntry, ModelFamily, ModelPricing, ModelTier};
+use crate::provider::{BoxFuture, Provider};
+use crate::{
+    AgentError, ContentBlock, Message, ProviderEvent, Role, StreamResponse, ThinkingConfig,
+};
+
+use super::ResolvedAuth;
+use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider, convert_tools};
+
+static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
+    api_key_env: "DEEPSEEK_API_KEY",
+    base_url: "https://api.deepseek.com",
+    max_tokens_field: "max_tokens",
+    include_stream_usage: false,
+    provider_name: "DeepSeek",
+};
+
+pub(crate) fn models() -> &'static [ModelEntry] {
+    &[
+        ModelEntry {
+            prefixes: &["deepseek-v4-flash"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Gpt,
+            default: true,
+            pricing: ModelPricing {
+                input: 0.14,
+                output: 0.28,
+                cache_write: 0.00,
+                cache_read: 0.0028,
+            },
+            max_output_tokens: 384_000,
+            context_window: 1_000_000,
+        },
+        ModelEntry {
+            prefixes: &["deepseek-v4-pro"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Gpt,
+            default: true,
+            pricing: ModelPricing {
+                input: 1.74,
+                output: 3.48,
+                cache_write: 0.00,
+                cache_read: 0.0145,
+            },
+            max_output_tokens: 384_000,
+            context_window: 1_000_000,
+        },
+    ]
+}
+
+pub struct DeepSeek {
+    compat: OpenAiCompatProvider,
+    auth: Arc<Mutex<ResolvedAuth>>,
+    system_prefix: Option<String>,
+}
+
+impl DeepSeek {
+    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
+        let api_key = std::env::var(CONFIG.api_key_env).map_err(|_| AgentError::Config {
+            message: format!("{} not set", CONFIG.api_key_env),
+        })?;
+        Ok(Self {
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(&api_key))),
+            system_prefix: None,
+        })
+    }
+
+    pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
+        Self {
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
+            auth,
+            system_prefix: None,
+        }
+    }
+
+    pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
+        self.system_prefix = prefix;
+        self
+    }
+
+    pub fn build_body(
+        &self,
+        model: &crate::model::Model,
+        messages: &[Message],
+        system: &str,
+        tools: &Value,
+    ) -> Value {
+        let wire_messages = convert_messages(messages, system);
+        let wire_tools = convert_tools(tools);
+
+        let mut body = json!({
+            "model": model.id,
+            "messages": wire_messages,
+            "stream": true,
+            CONFIG.max_tokens_field: model.max_output_tokens,
+        });
+        if CONFIG.include_stream_usage {
+            body["stream_options"] = json!({"include_usage": true});
+        }
+        if wire_tools.as_array().is_some_and(|a| !a.is_empty()) {
+            body["tools"] = wire_tools;
+        }
+        body
+    }
+}
+
+pub fn convert_messages(messages: &[Message], system: &str) -> Vec<Value> {
+    let mut out = vec![json!({"role": "system", "content": system})];
+    let mut used_tool = false;
+
+    for msg in messages {
+        match msg.role {
+            Role::User => {
+                let mut tool_results = Vec::new();
+                let mut text_parts: Vec<&str> = Vec::new();
+                let mut image_parts = Vec::new();
+
+                for block in &msg.content {
+                    match block {
+                        ContentBlock::Text { text } => text_parts.push(text.as_str()),
+                        ContentBlock::Image { source } => {
+                            image_parts.push(json!({
+                                "type": "image_url",
+                                "image_url": { "url": source.to_data_url() }
+                            }));
+                        }
+                        ContentBlock::ToolResult {
+                            tool_use_id,
+                            content,
+                            ..
+                        } => {
+                            tool_results.push(json!({
+                                "role": "tool",
+                                "tool_call_id": tool_use_id,
+                                "content": content,
+                            }));
+                        }
+                        ContentBlock::ToolUse { .. }
+                        | ContentBlock::Thinking { .. }
+                        | ContentBlock::RedactedThinking { .. } => {}
+                    }
+                }
+
+                if !image_parts.is_empty() {
+                    let mut parts = image_parts;
+                    if !text_parts.is_empty() {
+                        parts.push(json!({"type": "text", "text": text_parts.join("\n")}));
+                    }
+                    out.push(json!({"role": "user", "content": parts}));
+                } else if !text_parts.is_empty() {
+                    out.push(json!({"role": "user", "content": text_parts.join("\n")}));
+                }
+                out.extend(tool_results);
+            }
+            Role::Assistant => {
+                let mut text = String::new();
+                let mut tool_calls = Vec::new();
+                let mut reasoning_content = String::new();
+
+                for block in &msg.content {
+                    match block {
+                        ContentBlock::Text { text: t } => text.push_str(t),
+                        ContentBlock::ToolUse { id, name, input } => {
+                            used_tool = true;
+                            tool_calls.push(json!({
+                                "id": id,
+                                "type": "function",
+                                "function": {
+                                    "name": name,
+                                    "arguments": input.to_string(),
+                                }
+                            }));
+                        }
+                        ContentBlock::Thinking { thinking, .. } => {
+                            reasoning_content.push_str(thinking);
+                        }
+                        ContentBlock::ToolResult { .. }
+                        | ContentBlock::Image { .. }
+                        | ContentBlock::RedactedThinking { .. } => {}
+                    }
+                }
+
+                if !text.is_empty() || !tool_calls.is_empty() || !reasoning_content.is_empty() {
+                    let mut msg_obj = json!({"role": "assistant"});
+                    if !text.is_empty() {
+                        msg_obj["content"] = Value::String(text);
+                    }
+                    if !tool_calls.is_empty() {
+                        msg_obj["tool_calls"] = Value::Array(tool_calls);
+                    }
+                    // for turns that do perform tool calls, the reasoning_content must be fully passed back to the API in all subsequent requests
+                    if used_tool && !reasoning_content.is_empty() {
+                        msg_obj["reasoning_content"] = Value::String(reasoning_content);
+                    }
+                    out.push(msg_obj);
+                }
+            }
+        }
+    }
+
+    out
+}
+
+impl Provider for DeepSeek {
+    fn stream_message<'a>(
+        &'a self,
+        model: &'a Model,
+        messages: &'a [Message],
+        system: &'a str,
+        tools: &'a Value,
+        event_tx: &'a Sender<ProviderEvent>,
+        _thinking: ThinkingConfig,
+        _session_id: Option<&str>,
+    ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            let mut buf = String::new();
+            let system = super::with_prefix(&self.system_prefix, system, &mut buf);
+            let body = self.build_body(model, messages, system, tools);
+            self.compat
+                .do_stream(model, &[], &body, event_tx, &auth)
+                .await
+        })
+    }
+
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            self.compat.do_list_models(&auth).await
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Model, ModelFamily, ModelPricing, ModelTier};
+    use crate::provider::ProviderKind;
+    use crate::{ContentBlock, Message, Role};
+
+    fn create_test_model() -> Model {
+        Model {
+            id: "deepseek-v4-pro".to_string(),
+            provider: ProviderKind::Deepseek,
+            dynamic_slug: None,
+            tier: ModelTier::Strong,
+            family: ModelFamily::Gpt,
+            supports_tool_examples_override: None,
+            pricing: ModelPricing {
+                input: 1.74,
+                output: 3.48,
+                cache_write: 0.00,
+                cache_read: 0.0145,
+            },
+            max_output_tokens: 384_000,
+            context_window: 1_000_000,
+        }
+    }
+
+    #[test]
+    fn test_build_body_basic_conversation() {
+        let auth = Arc::new(Mutex::new(ResolvedAuth::bearer("test_key")));
+        let provider = DeepSeek::with_auth(auth, crate::providers::Timeouts::default());
+        let model = create_test_model();
+        let messages = vec![
+            Message {
+                role: Role::User,
+                content: vec![ContentBlock::Text {
+                    text: "Hello, how are you?".to_string(),
+                }],
+                display_text: None,
+            },
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::Text {
+                    text: "I'm doing well, thank you!".to_string(),
+                }],
+                display_text: None,
+            },
+        ];
+        let system = "You are a helpful assistant.";
+        let tools = json!({});
+
+        let body = provider.build_body(&model, &messages, system, &tools);
+
+        assert_eq!(body["model"], "deepseek-v4-pro");
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["max_tokens"], 384_000);
+
+        let messages_out = body["messages"].as_array().unwrap();
+        assert_eq!(messages_out.len(), 3); // system + user + assistant
+        assert_eq!(messages_out[0]["role"], "system");
+        assert_eq!(messages_out[0]["content"], "You are a helpful assistant.");
+        assert_eq!(messages_out[1]["role"], "user");
+        assert_eq!(messages_out[1]["content"], "Hello, how are you?");
+        assert_eq!(messages_out[2]["role"], "assistant");
+        assert_eq!(messages_out[2]["content"], "I'm doing well, thank you!");
+    }
+
+    #[test]
+    fn test_build_body_reasoning_content_included_with_tool_calls() {
+        let auth = Arc::new(Mutex::new(ResolvedAuth::bearer("test_key")));
+        let provider = DeepSeek::with_auth(auth, crate::providers::Timeouts::default());
+        let model = create_test_model();
+
+        let messages = vec![
+            Message {
+                role: Role::User,
+                content: vec![ContentBlock::Text {
+                    text: "Solve this problem".to_string(),
+                }],
+                display_text: None,
+            },
+            Message {
+                role: Role::Assistant,
+                content: vec![
+                    ContentBlock::Thinking {
+                        thinking: "Let me think about this...".to_string(),
+                        signature: None,
+                    },
+                    ContentBlock::ToolUse {
+                        id: "call_456".to_string(),
+                        name: "calculate".to_string(),
+                        input: json!({"expression": "2+2"}),
+                    },
+                ],
+                display_text: None,
+            },
+        ];
+        let system = "You are a helpful assistant.";
+        let tools = json!({});
+
+        let body = provider.build_body(&model, &messages, system, &tools);
+        let messages_out = body["messages"].as_array().unwrap();
+        let assistant_msg = &messages_out[2];
+
+        // After a tool call, reasoning_content SHOULD be included
+        assert!(
+            assistant_msg.get("reasoning_content").is_some(),
+            "reasoning_content should be present when there's a tool call"
+        );
+        assert_eq!(
+            assistant_msg["reasoning_content"],
+            "Let me think about this..."
+        );
+    }
+
+    #[test]
+    fn test_build_body_reasoning_content_excluded_without_tool_calls() {
+        let auth = Arc::new(Mutex::new(ResolvedAuth::bearer("test_key")));
+        let provider = DeepSeek::with_auth(auth, crate::providers::Timeouts::default());
+        let model = create_test_model();
+
+        let messages = vec![
+            Message {
+                role: Role::User,
+                content: vec![ContentBlock::Text {
+                    text: "Tell me a joke".to_string(),
+                }],
+                display_text: None,
+            },
+            Message {
+                role: Role::Assistant,
+                content: vec![
+                    ContentBlock::Thinking {
+                        thinking: "Thinking of a funny joke...".to_string(),
+                        signature: None,
+                    },
+                    ContentBlock::Text {
+                        text: "Why did the chicken cross the road?".to_string(),
+                    },
+                ],
+                display_text: None,
+            },
+        ];
+
+        let system = "You are a helpful assistant.";
+        let tools = json!({});
+
+        let body = provider.build_body(&model, &messages, system, &tools);
+        let messages_out = body["messages"].as_array().unwrap();
+        let assistant_msg = &messages_out[2];
+
+        // Without tool calls, reasoning_content should NOT be included
+        assert!(
+            assistant_msg.get("reasoning_content").is_none(),
+            "reasoning_content should NOT be present when there's no tool call"
+        );
+        assert_eq!(
+            assistant_msg["content"],
+            "Why did the chicken cross the road?"
+        );
+    }
+}

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -18,6 +18,7 @@ use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
 use super::ResolvedAuth;
 use super::anthropic::Anthropic;
 use super::copilot::Copilot;
+use super::deepseek::DeepSeek;
 use super::google::Google;
 use super::mistral::Mistral;
 use super::ollama::Ollama;
@@ -353,6 +354,10 @@ pub fn create(slug: &str, timeouts: super::Timeouts) -> Result<Box<dyn Provider>
         ProviderKind::Google => Box::new(Google::with_auth(auth.clone(), timeouts)),
         ProviderKind::Copilot => Box::new(
             Copilot::with_auth(auth.clone(), timeouts)
+                .with_system_prefix(meta.system_prefix.clone()),
+        ),
+        ProviderKind::Deepseek => Box::new(
+            DeepSeek::with_auth(auth.clone(), timeouts)
                 .with_system_prefix(meta.system_prefix.clone()),
         ),
         ProviderKind::Ollama => Box::new(

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -9,6 +9,7 @@ use crate::AgentError;
 
 pub(crate) mod anthropic;
 pub(crate) mod copilot;
+pub(crate) mod deepseek;
 pub mod dynamic;
 pub(crate) mod google;
 pub(crate) mod mistral;

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -108,6 +108,18 @@ Defaults: devstral-latest (strong), mistral-large-latest (medium), mistral-small
 
 Defaults: glm-5-code (strong), glm-4.7-flash (weak), glm-4.7 (medium)
 
+### DeepSeek
+
+- **Env var**: `DEEPSEEK_API_KEY`
+- **API**: `https://api.deepseek.com`
+
+| Tier | Models | Pricing (in/out per 1M tokens) | Context |
+|------|--------|-------------------------------|---------|
+| Medium | **deepseek-v4-flash** (default) | $0.14 / $0.28 | 1M ctx / 384K out |
+| Strong | **deepseek-v4-pro** (default) | ~~$1.74~~ / ~~$3.48~~ <br> $0.435 / $0.87 (75% off until 2026/05/31 15:59 UTC) | 1M ctx / 384K out |
+
+Defaults: deepseek-v4-flash (medium), deepseek-v4-pro (strong)
+
 ### Synthetic
 
 - **Env var**: `SYNTHETIC_API_KEY`

--- a/site/index.html
+++ b/site/index.html
@@ -1482,6 +1482,7 @@ imports = <span class="fn">set</span>()
         <a href="/docs/providers/#mistral" class="provider-chip">Mistral</a>
         <a href="/docs/providers/#z-ai" class="provider-chip">Z.AI</a>
         <a href="/docs/providers/#synthetic" class="provider-chip">Synthetic</a>
+        <a href="/docs/providers/#deepseek" class="provider-chip">Deepseek</a>
       </div>
       <p class="provider-plus reveal reveal-d3">Anything that speaks the OpenAI or Anthropic API works too. Write a short <a href="https://github.com/tontinton/maki/tree/main/scripts/providers" target="_blank" rel="noopener">provider script</a>. OpenAI oauth example included.</p>
     </div>

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -16,6 +16,7 @@ const PROVIDER_PRIORITY: &[ProviderKind] = &[
     ProviderKind::Zai,
     ProviderKind::ZaiCodingPlan,
     ProviderKind::Synthetic,
+    ProviderKind::Deepseek,
 ];
 
 pub fn resolve_model(


### PR DESCRIPTION
There are two failed tests:

1. from_tier_covers_all_providers
2. exactly_one_default_per_provider_tier

DeepSeek only has two models and we have three provider tiers. How can I make sure each provider tier has exactly one default model?

UPDATE:
I skip the weak tier for deepseek in these two tests.