### PR TITLE
Add DeepSeek provider

### DIFF
--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::provider::ProviderKind;
 use crate::providers::{
-    anthropic, copilot, dynamic, google, mistral, ollama, openai, synthetic, zai,
+    anthropic, copilot, deepseek, dynamic, google, mistral, ollama, openai, synthetic, zai,
 };
 
 const PER_MILLION: f64 = 1_000_000.0;
@@ -118,6 +118,7 @@ pub fn models_for_provider(provider: ProviderKind) -> &'static [ModelEntry] {
         ProviderKind::Google => google::models(),
         ProviderKind::Zai | ProviderKind::ZaiCodingPlan => zai::models(),
         ProviderKind::Synthetic => synthetic::models(),
+        ProviderKind::DeepSeek => deepseek::models(),
     }
 }
 
@@ -358,6 +359,10 @@ mod tests {
                 continue;
             }
             for &tier in &TIERS {
+                // DeepSeek has no Weak tier model
+                if provider == ProviderKind::DeepSeek && tier == ModelTier::Weak {
+                    continue;
+                }
                 let model = Model::from_tier(provider, tier).unwrap();
                 assert_eq!(model.provider, provider);
                 assert_eq!(model.tier, tier);
@@ -387,6 +392,9 @@ mod tests {
             }
             let entries = models_for_provider(provider);
             for &tier in &TIERS {
+                if provider == ProviderKind::DeepSeek && tier == ModelTier::Weak {
+                    continue;
+                }
                 let count = entries
                     .iter()
                     .filter(|e| e.tier == tier && e.default)
@@ -404,6 +412,7 @@ mod tests {
     #[test_case("openai/gpt-99", ProviderKind::OpenAi, "gpt-99" ; "unknown_openai_model_accepted")]
     #[test_case("synthetic/hf:nonexistent", ProviderKind::Synthetic, "hf:nonexistent" ; "unknown_synthetic_model_accepted")]
     #[test_case("ollama/my-custom-model", ProviderKind::Ollama, "my-custom-model" ; "unknown_ollama_model_accepted")]
+    #[test_case("deepseek/my-custom-model", ProviderKind::DeepSeek, "my-custom-model" ; "unknown_deepseek_model_accepted")]
     fn unknown_model_accepted(spec: &str, expected_provider: ProviderKind, expected_id: &str) {
         let model = Model::from_spec(spec).unwrap();
         assert_eq!(model.provider, expected_provider);

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -10,6 +10,7 @@ use crate::model::{Model, ModelFamily, models_for_provider};
 use crate::providers::Timeouts;
 use crate::providers::anthropic::Anthropic;
 use crate::providers::copilot::Copilot;
+use crate::providers::deepseek::DeepSeek;
 use crate::providers::dynamic;
 use crate::providers::google::Google;
 use crate::providers::mistral::Mistral;
@@ -31,6 +32,8 @@ pub enum ProviderKind {
     Mistral,
     Zai,
     ZaiCodingPlan,
+    #[strum(serialize = "deepseek")]
+    DeepSeek,
     Synthetic,
 }
 
@@ -45,6 +48,7 @@ impl ProviderKind {
             Self::Mistral => "Mistral",
             Self::Zai => "Z.AI",
             Self::ZaiCodingPlan => "Z.AI Coding",
+            Self::DeepSeek => "DeepSeek",
             Self::Synthetic => "Synthetic",
         }
     }
@@ -58,6 +62,7 @@ impl ProviderKind {
             Self::Ollama => "OLLAMA_API_KEY",
             Self::Mistral => "MISTRAL_API_KEY",
             Self::Zai | Self::ZaiCodingPlan => "ZHIPU_API_KEY",
+            Self::DeepSeek => "DEEPSEEK_API_KEY",
             Self::Synthetic => "SYNTHETIC_API_KEY",
         }
     }
@@ -74,6 +79,7 @@ impl ProviderKind {
             Self::Mistral => "https://api.mistral.ai/v1",
             Self::Zai => "https://api.z.ai/api/paas/v4",
             Self::ZaiCodingPlan => "https://api.z.ai/api/coding/paas/v4",
+            Self::DeepSeek => "https://api.deepseek.com",
             Self::Synthetic => "https://api.synthetic.new/openai/v1",
         }
     }
@@ -81,7 +87,7 @@ impl ProviderKind {
     pub const fn supports_thinking(self) -> bool {
         matches!(
             self,
-            Self::Anthropic | Self::Google | Self::Mistral | Self::Synthetic
+            Self::Anthropic | Self::Google | Self::Mistral | Self::DeepSeek | Self::Synthetic
         )
     }
 
@@ -98,6 +104,7 @@ impl ProviderKind {
             Self::Synthetic => {
                 Some("Reasoning effort support (low/medium/high), open-weight models")
             }
+            Self::DeepSeek => Some("Thinking mode toggle (on/off), open-weight models"),
             _ => None,
         }
     }
@@ -111,6 +118,7 @@ impl ProviderKind {
             Self::Ollama => ModelFamily::Generic,
             Self::Mistral => ModelFamily::Generic,
             Self::Zai | Self::ZaiCodingPlan => ModelFamily::Glm,
+            Self::DeepSeek => ModelFamily::Generic,
             Self::Synthetic => ModelFamily::Synthetic,
         }
     }
@@ -128,6 +136,7 @@ impl ProviderKind {
             Self::Ollama => 16_384,
             Self::Mistral => 32_000,
             Self::Zai | Self::ZaiCodingPlan => 16_000,
+            Self::DeepSeek => 384_000,
             Self::Synthetic => 32_000,
         }
     }
@@ -141,6 +150,7 @@ impl ProviderKind {
             Self::Ollama => 128_000,
             Self::Mistral => 128_000,
             Self::Zai | Self::ZaiCodingPlan => 128_000,
+            Self::DeepSeek => 1_000_000,
             Self::Synthetic => 128_000,
         }
     }
@@ -155,6 +165,7 @@ impl ProviderKind {
             Self::Mistral => Ok(Box::new(Mistral::new(timeouts)?)),
             Self::Zai => Ok(Box::new(Zai::new(ZaiPlan::Standard, timeouts)?)),
             Self::ZaiCodingPlan => Ok(Box::new(Zai::new(ZaiPlan::Coding, timeouts)?)),
+            Self::DeepSeek => Ok(Box::new(DeepSeek::new(timeouts)?)),
             Self::Synthetic => Ok(Box::new(Synthetic::new(timeouts)?)),
         }
     }

--- a/maki-providers/src/providers/deepseek.rs
+++ b/maki-providers/src/providers/deepseek.rs
@@ -1,0 +1,132 @@
+use std::sync::{Arc, Mutex};
+
+use flume::Sender;
+use serde_json::Value;
+use tracing::warn;
+
+use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
+use crate::provider::{BoxFuture, Provider};
+use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
+
+use super::ResolvedAuth;
+use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+
+static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
+    api_key_env: "DEEPSEEK_API_KEY",
+    base_url: "https://api.deepseek.com",
+    max_tokens_field: "max_tokens",
+    include_stream_usage: true,
+    provider_name: "DeepSeek",
+};
+
+pub(crate) fn models() -> &'static [ModelEntry] {
+    &[
+        ModelEntry {
+            prefixes: &["deepseek-v4-flash"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            default: true,
+            pricing: ModelPricing {
+                input: 0.14,
+                output: 0.28,
+                cache_write: 0.00,
+                cache_read: 0.00,
+            },
+            max_output_tokens: 384_000,
+            context_window: 1_000_000,
+        },
+        ModelEntry {
+            prefixes: &["deepseek-v4-pro"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Generic,
+            default: true,
+            pricing: ModelPricing {
+                input: 0.435,
+                output: 0.87,
+                cache_write: 0.00,
+                cache_read: 0.00,
+            },
+            max_output_tokens: 384_000,
+            context_window: 1_000_000,
+        },
+    ]
+}
+
+pub struct DeepSeek {
+    compat: OpenAiCompatProvider,
+    auth: Arc<Mutex<ResolvedAuth>>,
+    system_prefix: Option<String>,
+}
+
+impl DeepSeek {
+    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
+        let api_key = std::env::var(CONFIG.api_key_env).map_err(|_| AgentError::Config {
+            message: format!("{} not set", CONFIG.api_key_env),
+        })?;
+        Ok(Self {
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(&api_key))),
+            system_prefix: None,
+        })
+    }
+
+    pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
+        Self {
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
+            auth,
+            system_prefix: None,
+        }
+    }
+
+    pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
+        self.system_prefix = prefix;
+        self
+    }
+}
+
+impl Provider for DeepSeek {
+    fn stream_message<'a>(
+        &'a self,
+        model: &'a Model,
+        messages: &'a [Message],
+        system: &'a str,
+        tools: &'a Value,
+        event_tx: &'a Sender<ProviderEvent>,
+        thinking: ThinkingConfig,
+        _session_id: Option<&'a str>,
+    ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            let mut buf = String::new();
+            let system = super::with_prefix(&self.system_prefix, system, &mut buf);
+            let mut body = self.compat.build_body(model, messages, system, tools);
+
+            // DeepSeek enables reasoning by default; Adaptive and Budget
+            // use the model's default reasoning behavior.
+            match thinking {
+                ThinkingConfig::Off => {
+                    body["thinking"] = serde_json::json!({"type": "disabled"});
+                }
+                ThinkingConfig::Adaptive => {
+                    body["thinking"] = serde_json::json!({"type": "enabled"});
+                }
+                ThinkingConfig::Budget(_n) => {
+                    body["thinking"] = serde_json::json!({"type": "enabled"});
+                    body["reasoning_effort"] = serde_json::json!("max");
+                    warn!("DeepSeek reasoning does not support token budgets");
+                }
+            }
+
+            self.compat
+                .do_stream(model, &[], &body, event_tx, &auth)
+                .await
+        })
+    }
+
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            self.compat.do_list_models(&auth).await
+        })
+    }
+}

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -18,6 +18,7 @@ use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
 use super::ResolvedAuth;
 use super::anthropic::Anthropic;
 use super::copilot::Copilot;
+use super::deepseek::DeepSeek;
 use super::google::Google;
 use super::mistral::Mistral;
 use super::ollama::Ollama;
@@ -375,6 +376,10 @@ pub fn create(slug: &str, timeouts: super::Timeouts) -> Result<Box<dyn Provider>
             Synthetic::with_auth(auth.clone(), timeouts)
                 .with_system_prefix(meta.system_prefix.clone()),
         ),
+        ProviderKind::DeepSeek => Box::new(
+            DeepSeek::with_auth(auth.clone(), timeouts)
+                .with_system_prefix(meta.system_prefix.clone()),
+        ),
     };
 
     Ok(Box::new(DynamicProvider {
@@ -653,6 +658,7 @@ esac
     #[test_case("zai", ProviderKind::Zai ; "base_zai")]
     #[test_case("zai-coding-plan", ProviderKind::ZaiCodingPlan ; "base_zai_coding_plan")]
     #[test_case("synthetic", ProviderKind::Synthetic ; "base_synthetic")]
+    #[test_case("deepseek", ProviderKind::DeepSeek ; "base_deepseek")]
     fn discover_accepts_all_bases(base: &str, expected: ProviderKind) {
         let tmp = TempDir::new().unwrap();
         let info = format!(r#"{{"display_name": "Test", "base": "{base}", "has_auth": false}}"#);

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -9,6 +9,7 @@ use crate::AgentError;
 
 pub(crate) mod anthropic;
 pub(crate) mod copilot;
+pub(crate) mod deepseek;
 pub mod dynamic;
 pub(crate) mod google;
 pub(crate) mod mistral;

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -1089,7 +1089,10 @@ impl App {
             }
             "/thinking" => {
                 if !self.state.model.provider.supports_thinking() {
-                    self.flash("Thinking requires Anthropic, Mistral or Synthetic provider".into());
+                    self.flash(
+                        "Thinking requires Anthropic, Mistral, DeepSeek or Synthetic provider"
+                            .into(),
+                    );
                     return vec![];
                 }
                 match ThinkingConfig::parse(cmd.args.trim(), self.state.thinking) {

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -110,6 +110,19 @@ Defaults: devstral-latest (strong), mistral-large-latest (medium), mistral-small
 
 Defaults: glm-5-code (strong), glm-4.7-flash (weak), glm-4.7 (medium)
 
+### DeepSeek
+
+- **Env var**: `DEEPSEEK_API_KEY`
+- **API**: `https://api.deepseek.com`
+- **Features**: Thinking mode toggle (on/off), open-weight models
+
+| Tier | Models | Pricing (in/out per 1M tokens) | Context |
+|------|--------|-------------------------------|---------|
+| Medium | **deepseek-v4-flash** (default) | $0.14 / $0.28 | 1000K ctx / 384K out |
+| Strong | **deepseek-v4-pro** (default) | $0.43 / $0.87 | 1000K ctx / 384K out |
+
+Defaults: deepseek-v4-flash (medium), deepseek-v4-pro (strong)
+
 ### Synthetic
 
 - **Env var**: `SYNTHETIC_API_KEY`
@@ -151,7 +164,7 @@ To add a custom provider or proxy, drop an executable script into `~/.maki/provi
 
 `resolve` is called each time a new agent spawns, so scripts should read tokens from disk instead of caching them in memory. That way auth changes from other processes get picked up.
 
-The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `copilot`, `ollama`, `mistral`, `zai`, `zai-coding-plan`, `synthetic`.
+The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `copilot`, `ollama`, `mistral`, `zai`, `zai-coding-plan`, `deepseek`, `synthetic`.
 
 If your provider serves models not in the base catalog, add a `models` subcommand returning:
 

--- a/site/index.html
+++ b/site/index.html
@@ -1481,6 +1481,7 @@ imports = <span class="fn">set</span>()
         <a href="/docs/providers/#ollama" class="provider-chip">Ollama / llama.cpp</a>
         <a href="/docs/providers/#mistral" class="provider-chip">Mistral</a>
         <a href="/docs/providers/#z-ai" class="provider-chip">Z.AI</a>
+        <a href="/docs/providers/#deepseek" class="provider-chip">DeepSeek</a>
         <a href="/docs/providers/#synthetic" class="provider-chip">Synthetic</a>
       </div>
       <p class="provider-plus reveal reveal-d3">Anything that speaks the OpenAI or Anthropic API works too. Write a short <a href="https://github.com/tontinton/maki/tree/main/scripts/providers" target="_blank" rel="noopener">provider script</a>. OpenAI oauth example included.</p>

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -16,6 +16,7 @@ const PROVIDER_PRIORITY: &[ProviderKind] = &[
     ProviderKind::Zai,
     ProviderKind::ZaiCodingPlan,
     ProviderKind::Synthetic,
+    ProviderKind::DeepSeek,
 ];
 
 pub fn resolve_model(


### PR DESCRIPTION
I have been playing with DeepSeek for a while, and in order to understand a bit better maki's code base, I adventured to write the provider. I hope it would  be considered to merge.

The first commit (providers: openai_compat: include reasoning_content...) would be the tricky one, since it impacts all the openai-based providers. But I tested with Synthetic's models and it looks to work just fine.