### PR TITLE
providers: openai_compat: include reasoning_content in assistant messages

### DIFF
--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -195,11 +195,15 @@ pub fn convert_messages(messages: &[Message], system: &str) -> Vec<Value> {
             }
             Role::Assistant => {
                 let mut text = String::new();
+                let mut reasoning_text = String::new();
                 let mut tool_calls = Vec::new();
 
                 for block in &msg.content {
                     match block {
                         ContentBlock::Text { text: t } => text.push_str(t),
+                        ContentBlock::Thinking { thinking, .. } => {
+                            reasoning_text.push_str(thinking);
+                        }
                         ContentBlock::ToolUse { id, name, input } => {
                             tool_calls.push(json!({
                                 "id": id,
@@ -212,15 +216,19 @@ pub fn convert_messages(messages: &[Message], system: &str) -> Vec<Value> {
                         }
                         ContentBlock::ToolResult { .. }
                         | ContentBlock::Image { .. }
-                        | ContentBlock::Thinking { .. }
                         | ContentBlock::RedactedThinking { .. } => {}
                     }
                 }
 
-                if !text.is_empty() || !tool_calls.is_empty() {
+                if !text.is_empty() || !tool_calls.is_empty() || !reasoning_text.is_empty() {
                     let mut msg_obj = json!({"role": "assistant"});
                     if !text.is_empty() {
                         msg_obj["content"] = Value::String(text);
+                    } else if !reasoning_text.is_empty() {
+                        msg_obj["content"] = Value::String(String::new());
+                    }
+                    if !reasoning_text.is_empty() {
+                        msg_obj["reasoning_content"] = Value::String(reasoning_text);
                     }
                     if !tool_calls.is_empty() {
                         msg_obj["tool_calls"] = Value::Array(tool_calls);
@@ -841,6 +849,45 @@ data: [DONE]\n";
         let msgs = vec![Message::user("hello".into())];
         let result = convert_messages(&msgs, "system");
         assert!(result[1]["content"].is_string());
+    }
+
+    #[test]
+    fn convert_messages_assistant_with_reasoning() {
+        let messages = vec![Message {
+            role: Role::Assistant,
+            content: vec![
+                ContentBlock::Thinking {
+                    thinking: "Let me think...".into(),
+                    signature: None,
+                },
+                ContentBlock::Text {
+                    text: "Hello".into(),
+                },
+            ],
+            ..Default::default()
+        }];
+        let wire = convert_messages(&messages, "");
+        let asst = &wire[1];
+        assert_eq!(asst["role"], "assistant");
+        assert_eq!(asst["content"], "Hello");
+        assert_eq!(asst["reasoning_content"], "Let me think...");
+    }
+
+    #[test]
+    fn convert_messages_assistant_reasoning_only() {
+        let messages = vec![Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::Thinking {
+                thinking: "Just thinking...".into(),
+                signature: None,
+            }],
+            ..Default::default()
+        }];
+        let wire = convert_messages(&messages, "");
+        let asst = &wire[1];
+        assert_eq!(asst["role"], "assistant");
+        assert_eq!(asst["reasoning_content"], "Just thinking...");
+        assert_eq!(asst["content"], "");
     }
 
     #[test]


### PR DESCRIPTION
DeepSeeks API requires `reasoning_content` from the assistants thinking mode to be passed back in subsequent conversation turns. Previously, `ContentBlock::Thinking` blocks were being ignored during message conversion, causing the API to return a 400 error: "The `reasoning_content` in the thinking mode must be passed back to the API." This broke multi-turn conversations with DeepSeek models.

Added two test cases for convert_messages verifying that ContentBlock::Thinking blocks in assistant messages are serialized as reasoning_content in the OpenAI-compatible wire format.

Modified the `Role::Assistant` branch in `convert_messages` to:

1. Extract `ContentBlock::Thinking` content into a `reasoning_text` accumulator
2. Update the message creation condition to also check for non-empty reasoning text
3. When there's `reasoning_text` but no `content`, an empty string is assigned to `content`. This is needed by DeepSeek's API.
4. Include the `reasoning_content` field in the message object when non-empty
5. Tests added:
   - convert_messages_assistant_with_reasoning: verifies both text content and reasoning_content are present when an assistant message has both Thinking and Text blocks
   - convert_messages_assistant_reasoning_only: verifies the edge case where an assistant message contains only a Thinking block with no text content

Ought these changes were needed only for DeepSeek, I have tested the changes with Synthetic's models, and they work fine.