### PR TITLE
plugins: index: add Bazel indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,6 +2359,7 @@ dependencies = [
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-scala",
+ "tree-sitter-starlark",
  "tree-sitter-swift",
  "tree-sitter-typescript",
 ]
@@ -4776,6 +4777,16 @@ name = "tree-sitter-scala"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83079f50ea7d03e0faf6be6260ed97538e6df7349ec3cbcbf5771f7b38e3c8b7"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-starlark"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8934f282d085cc4b9ee28aa688aa3fbe8aa3766201c2a6252f411d45b4c3a721"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ tree-sitter-python = "0.23"
 tree-sitter-ruby = "0.23"
 tree-sitter-rust = "0.24"
 tree-sitter-scala = "0.25"
+tree-sitter-starlark = "1.3"
 tree-sitter-swift = "0.7"
 tree-sitter-typescript = "0.23"
 monty = { git = "https://github.com/pydantic/monty.git", rev = "2e9df4b", package = "monty" }

--- a/maki-lua/Cargo.toml
+++ b/maki-lua/Cargo.toml
@@ -43,6 +43,7 @@ tree-sitter-python = { workspace = true }
 tree-sitter-ruby = { workspace = true }
 tree-sitter-rust = { workspace = true }
 tree-sitter-scala = { workspace = true }
+tree-sitter-starlark = { workspace = true }
 tree-sitter-swift = { workspace = true }
 tree-sitter-typescript = { workspace = true }
 [target.'cfg(unix)'.dependencies]

--- a/maki-lua/src/language.rs
+++ b/maki-lua/src/language.rs
@@ -20,6 +20,7 @@ pub enum Language {
     Lua,
     Elixir,
     Markdown,
+    Starlark,
 }
 
 impl Language {
@@ -43,6 +44,7 @@ impl Language {
             "lua" => Some(Self::Lua),
             "elixir" => Some(Self::Elixir),
             "markdown" => Some(Self::Markdown),
+            "starlark" => Some(Self::Starlark),
             _ => None,
         }
     }
@@ -67,6 +69,7 @@ impl Language {
             "lua" => Some(Self::Lua),
             "ex" | "exs" => Some(Self::Elixir),
             "md" | "markdown" => Some(Self::Markdown),
+            "bzl" => Some(Self::Starlark),
             _ => None,
         }
     }
@@ -91,6 +94,7 @@ impl Language {
             Self::Lua => tree_sitter_lua::LANGUAGE.into(),
             Self::Elixir => tree_sitter_elixir::LANGUAGE.into(),
             Self::Markdown => tree_sitter_md::LANGUAGE.into(),
+            Self::Starlark => tree_sitter_starlark::LANGUAGE.into(),
         }
     }
 }

--- a/plugins/index/indexer.lua
+++ b/plugins/index/indexer.lua
@@ -40,11 +40,21 @@ local EXT_TO_LANG = {
   exs = "elixir",
   md = "markdown",
   markdown = "markdown",
+  bzl = "bazel_bzl",
+}
+
+local FILENAME_TO_LANG = {
+  ["MODULE.bazel"] = "bazel_module",
+  ["BUILD"] = "bazel_build",
+  ["BUILD.bazel"] = "bazel_build",
 }
 
 local LANG_TO_PARSER = {
   lua_lang = "lua",
   javascript = "typescript",
+  bazel_build = "starlark",
+  bazel_module = "starlark",
+  bazel_bzl = "starlark",
 }
 
 local function parser_name(lang)
@@ -736,16 +746,30 @@ local function unique_langs()
 end
 
 local EXTRACTORS = {}
-for _, name in ipairs(unique_langs()) do
-  local factory = require("lang." .. name)
-  local lang = factory(U)
-  validate_lang(name, lang)
 
-  if lang.extract then
-    EXTRACTORS[name] = lang.extract
-  else
-    EXTRACTORS[name] = function(source, root)
-      return default_extract(lang, source, root)
+-- Bazel file-kind extractors live in lang/bazel/ and are pre-registered
+-- because BUILD.bazel and MODULE.bazel are detected by filename (not by
+-- extension), and all three share the "starlark" tree-sitter parser.
+for _, sub in ipairs({ "build", "module", "bzl" }) do
+  local lang_name = "bazel_" .. sub
+  local factory = require("lang.bazel." .. sub)
+  local lang = factory(U)
+  validate_lang(lang_name, lang)
+  EXTRACTORS[lang_name] = lang.extract
+end
+
+for _, name in ipairs(unique_langs()) do
+  if not EXTRACTORS[name] then
+    local factory = require("lang." .. name)
+    local lang = factory(U)
+    validate_lang(name, lang)
+
+    if lang.extract then
+      EXTRACTORS[name] = lang.extract
+    else
+      EXTRACTORS[name] = function(source, root)
+        return default_extract(lang, source, root)
+      end
     end
   end
 end
@@ -768,4 +792,5 @@ end
 return {
   index_source = index_source,
   EXT_TO_LANG = EXT_TO_LANG,
+  FILENAME_TO_LANG = FILENAME_TO_LANG,
 }

--- a/plugins/index/init.lua
+++ b/plugins/index/init.lua
@@ -125,14 +125,19 @@ Return a compact overview of a source file: imports, type definitions, function 
       }
     end
 
-    local ext = path:match("%.([^%.]+)$")
-    if not ext then
-      return { llm_output = "Unsupported file type: (no extension). Use the read tool instead.", is_error = true }
-    end
+    local filename = path:match("([^/]+)$")
+    local lang = indexer.FILENAME_TO_LANG[filename]
 
-    local lang = indexer.EXT_TO_LANG[ext]
     if not lang then
-      return { llm_output = "Unsupported file type: ." .. ext .. ". Use the read tool instead.", is_error = true }
+      local ext = path:match("%.([^%.]+)$")
+      if not ext then
+        return { llm_output = "Unsupported file type: (no extension). Use the read tool instead.", is_error = true }
+      end
+
+      lang = indexer.EXT_TO_LANG[ext]
+      if not lang then
+        return { llm_output = "Unsupported file type: ." .. ext .. ". Use the read tool instead.", is_error = true }
+      end
     end
 
     local config = ctx:config()

--- a/plugins/index/lang/bazel/README.md
+++ b/plugins/index/lang/bazel/README.md
@@ -1,0 +1,60 @@
+# Bazel indexer
+
+Bazel files are written in [Starlark], but they come in three distinct kinds
+with different semantic models. Even though we parse them with the same
+`starlark` tree-sitter grammar, they need their own extractors:
+
+- [`MODULE.bazel`]: a [Bzlmod] manifest.
+- [`BUILD`] / `BUILD.bazel`: package files that declare build targets.
+- [`.bzl`]: Starlark module files.
+
+## Architecture
+
+The plugin is layered. Each extractor is file-kind specific and depends only on
+the internal API: `analyze.lua` (records) and `render.lua` (output), plus the
+layer-agnostic `util.lua`. Tree-sitter primitives live in `ast.lua`, private to
+`analyze.lua`, so the AST shape never leaks into the rest of the plugin.
+
+```
+                     +----------------------------------------------+
+                     |        Extractors (file-kind specific)       |
+                     |  +-----------+  +------------+  +---------+  |
+                     |  | build.lua |  | module.lua |  | bzl.lua |  |
+                     |  +-----------+  +------------+  +---------+  |
+                     +----------------------------------------------+
+ +----------+                               |
+ | util.lua | ← reachable from any layer    |
+ +----------+                               |
+                        +---------------------------------------+
+                        |    Internal API (records + output)    |
+                        |  +-------------+     +------------+   |
+                        |  | analyze.lua |     | render.lua |   |
+                        |  +-------------+     +------------+   |
+                        |       |                               |
+                        |  +---------+                          |
+                        |  | ast.lua | ← tree-sitter primitives |
+                        |  +---------+                          |
+                        +---------------------------------------+
+```
+
+## Where to make changes
+
+- **Recognise a new `MODULE.bazel` builtin call**: add it to `call_handlers`
+  in `module.lua`.
+- **Recognise a new BUILD rule shape**: add it to `call_handlers` in
+  `build.lua`.
+- **Skip a noisy call kind**: add it to `IGNORED_CALLS` in the relevant
+  extractor.
+- **Add a new top-level statement kind**: add a classifier to
+  `classify_steps` in `analyze.lua`, plus a new record builder.
+- **Change how a section renders**: edit the relevant `render_*` function in
+  the extractor (or in `render.lua` if the change is shared).
+- **Add a tree-sitter helper**: put it in `ast.lua` and surface it through
+  an `analyze.lua` record field or method. Do not require `ast.lua` from an
+  extractor.
+
+[Starlark]: https://github.com/bazelbuild/starlark/blob/master/spec.md
+[Bzlmod]: https://bazel.build/external/overview
+[`MODULE.bazel`]: https://bazel.build/external/module
+[`BUILD`]: https://bazel.build/concepts/build-files
+[`.bzl`]: https://bazel.build/extending/concepts

--- a/plugins/index/lang/bazel/analyze.lua
+++ b/plugins/index/lang/bazel/analyze.lua
@@ -1,0 +1,309 @@
+-- Statement classification for the Bazel indexer.
+--
+-- Top-level AST nodes are classified into records keyed by `kind`:
+--   load        { module, module_quoted, names[], line_start, line_end }
+--   assignment  { name, value_text_raw, value_text_compact,
+--                 value_call?, line_start, line_end }
+--   function    { name, params, line_start, line_end }
+--   call        CallRecord (with metatable; methods cover kwarg/positional access)
+--
+-- Each call's arguments are walked once at classify time. Positional and
+-- keyword args become "value records" stored on the record, so extractors
+-- never have to revisit the tree-sitter AST.
+--
+-- Extractors require this module (and render.lua / util.lua); they do not
+-- require ast.lua. That keeps tree-sitter primitives behind a single
+-- boundary owned by analyze.lua.
+
+return function(U)
+  local ast = require("lang.bazel.ast")(U)
+
+  local A = {}
+
+  ----------------------------------------------------------------------
+  -- value records & call args (shared by classifiers below)
+  ----------------------------------------------------------------------
+
+  -- A value record represents one argument's value. `text` is always
+  -- populated so callers don't special-case node kinds:
+  --   "foo"     -> { kind = "string",     text = "foo",       quoted = true }
+  --   FOO       -> { kind = "identifier", text = "FOO",       quoted = false }
+  --   any expr  -> { kind = "other",      text = "<compact>", quoted = false }
+  local function new_value_record(node, source)
+    local t = node:type()
+
+    if t == "identifier" then
+      return { kind = "identifier", text = ast.get_text(node, source), quoted = false }
+    elseif t == "string" then
+      local content = ast.raw_string_contents(node, source)
+      if content then
+        return { kind = "string", text = content, quoted = true }
+      end
+    elseif t == "list" then
+      return { kind = "other", text = ast.compact_list(node, source), quoted = false }
+    end
+
+    -- Default: anything else (and malformed string literals that fail to
+    -- parse) renders as compact source text.
+    return { kind = "other", text = ast.compact_ws_node(node, source), quoted = false }
+  end
+
+  -- Walk a call's args once. Returns three views:
+  --   positional[]  value records by 1-based positional index
+  --   kwargs        table by name, value records
+  --   args[]        all args in source order, each
+  --                 { kind = "positional", value = vrec } or
+  --                 { kind = "keyword", name = "...", value = vrec }
+  local function extract_call_args(call, source)
+    local positional = {}
+    local kwargs = {}
+    local args = {}
+
+    for _, arg in ipairs(ast.call_args(call)) do
+      local entry
+
+      if arg:type() == "keyword_argument" then
+        local name = ast.keyword_name(arg, source)
+        local value_node = ast.keyword_value(arg)
+
+        if name and value_node then
+          entry = { kind = "keyword", name = name, value = new_value_record(value_node, source) }
+          kwargs[name] = entry.value
+        end
+
+        -- Malformed keyword arg (no name or no value) is silently dropped.
+      elseif arg:type() == "dictionary_splat" then
+        entry = { kind = "dictionary_splat", keys = ast.dictionary_splat_keys(arg, source) }
+      else
+        entry = { kind = "positional", value = new_value_record(arg, source) }
+        positional[#positional + 1] = entry.value
+      end
+
+      if entry then
+        args[#args + 1] = entry
+      end
+    end
+
+    return positional, kwargs, args
+  end
+
+  ----------------------------------------------------------------------
+  -- CallRecord
+  --
+  -- Methods (kwarg, kwarg_string, kwarg_bool, ...) return value records or
+  -- nil; the value record schema is documented above.
+  ----------------------------------------------------------------------
+
+  local CallRecord = {}
+  CallRecord.__index = CallRecord
+
+  function CallRecord:kwarg(name)
+    return self.kwargs[name]
+  end
+
+  function CallRecord:kwarg_present(name)
+    return self.kwargs[name] ~= nil
+  end
+
+  function CallRecord:kwarg_string(name)
+    local v = self.kwargs[name]
+    if v and v.kind == "string" then
+      return v.text
+    end
+    return nil
+  end
+
+  function CallRecord:kwarg_bool(name)
+    local v = self.kwargs[name]
+    if not v then
+      return nil
+    end
+    if v.text == "True" then
+      return true
+    end
+    if v.text == "False" then
+      return false
+    end
+    return nil
+  end
+
+  function CallRecord:positional_at(i)
+    return self.positional[i]
+  end
+
+  function CallRecord:positional_or_kwarg(i, name)
+    return self.positional[i] or self.kwargs[name]
+  end
+
+  function CallRecord.new(call, source)
+    local positional, kwargs, args = extract_call_args(call, source)
+    local s, e = ast.node_lines(call)
+
+    return setmetatable({
+      kind = "call",
+      target = ast.call_target(call, source),
+      positional = positional,
+      kwargs = kwargs,
+      args = args,
+      line_start = s,
+      line_end = e,
+    }, CallRecord)
+  end
+
+  ----------------------------------------------------------------------
+  -- per-kind classifiers
+  ----------------------------------------------------------------------
+
+  local function call_record(node, source)
+    local call = ast.unwrap_to(node, "call")
+    if not call then
+      return nil
+    end
+    return CallRecord.new(call, source)
+  end
+
+  -- The first arg is the module path; subsequent args are imported names.
+  -- `module_quoted` is true iff the module came from a string literal, so
+  -- extractors can render accordingly: BUILD keeps both shapes, .bzl drops
+  -- non-quoted modules. For a keyword-form import (`alias = "real"`) the
+  -- displayed name is the alias.
+  local function load_record(node, source)
+    local call = ast.unwrap_to(node, "call")
+    if not call then
+      return nil
+    end
+
+    if ast.call_target(call, source) ~= "load" then
+      return nil
+    end
+
+    local _, _, args = extract_call_args(call, source)
+    if #args == 0 then
+      return nil
+    end
+
+    local module_vrec = args[1].value
+    local names = {}
+
+    for i = 2, #args do
+      local entry = args[i]
+      if entry.kind == "keyword" then
+        names[#names + 1] = entry.name
+      else
+        names[#names + 1] = entry.value.text
+      end
+    end
+
+    local s, e = ast.node_lines(call)
+
+    return {
+      kind = "load",
+      module = module_vrec.text,
+      module_quoted = module_vrec.quoted,
+      names = names,
+      line_start = s,
+      line_end = e,
+    }
+  end
+
+  local function assignment_record(node, source)
+    local assignment = ast.unwrap_to(node, "assignment")
+    if not assignment then
+      return nil
+    end
+
+    local value_node = ast.assignment_value(assignment)
+    if not value_node then
+      return nil
+    end
+
+    local s, e = ast.node_lines(assignment)
+
+    -- Two text forms are precomputed because the extractors render bindings
+    -- differently: .bzl keeps the source layout (multi-line dicts/lists stay
+    -- as-written), BUILD collapses everything onto one line. module.lua uses
+    -- neither form -- it asks `value_call` for structured access.
+    local rec = {
+      kind = "assignment",
+      name = ast.assignment_name(assignment, source),
+      value_text_raw = ast.get_text(value_node, source),
+      value_text_compact = ast.compact_ws_node(value_node, source),
+      line_start = s,
+      line_end = e,
+    }
+
+    -- value_call is a full CallRecord (metatabled) so module.lua's
+    -- handle_extension_assignment can ask :positional_or_kwarg / :kwarg_bool
+    -- on the RHS call directly.
+    if value_node:type() == "call" then
+      rec.value_call = CallRecord.new(value_node, source)
+    end
+
+    return rec
+  end
+
+  local function function_record(node, source)
+    -- function_definition is a top-level statement form, so it may appear
+    -- directly (unwrapped) as well as inside an expression_statement.
+    local inner = ast.unwrap_to(node, "function_definition")
+
+    if not inner then
+      return nil
+    end
+
+    local name_node = inner:field("name")[1]
+    if not name_node then
+      return nil
+    end
+
+    local params_node = inner:field("parameters")[1]
+    local s, e = ast.node_lines(inner)
+
+    return {
+      kind = "function",
+      name = ast.get_text(name_node, source),
+      params = params_node and ast.compact_params(params_node, source) or "()",
+      line_start = s,
+      line_end = e,
+    }
+  end
+
+  ----------------------------------------------------------------------
+  -- top-level dispatch
+  ----------------------------------------------------------------------
+
+  -- load_record runs before call_record because load() is also a call.
+  local classify_steps = {
+    load_record,
+    assignment_record,
+    function_record,
+    call_record,
+  }
+
+  function A.classify(node, source)
+    for _, step in ipairs(classify_steps) do
+      local stmt = step(node, source)
+      if stmt then
+        return stmt
+      end
+    end
+
+    return nil
+  end
+
+  function A.collect(root, source)
+    local doc, nodes = ast.split_preamble(root, source)
+    local statements = {}
+
+    for _, node in ipairs(nodes) do
+      local stmt = A.classify(node, source)
+      if stmt then
+        statements[#statements + 1] = stmt
+      end
+    end
+
+    return { doc = doc, statements = statements }
+  end
+
+  return A
+end

--- a/plugins/index/lang/bazel/ast.lua
+++ b/plugins/index/lang/bazel/ast.lua
@@ -1,0 +1,321 @@
+-- Tree-sitter / Starlark AST primitives for the Bazel indexer.
+--
+-- This module is private to analyze.lua: extractors (build, module, bzl) must
+-- not require it. Anything an extractor needs is exposed through analyze.lua's
+-- record API instead, so the AST/tree-sitter shape stays a single-layer concern.
+--
+-- The helpers mirror the shapes from tree-sitter-starlark's grammar:
+--   expression_statement  wraps most top-level nodes (calls, assignments)
+--   call                  rule invocations, load(), use_extension(), etc.
+--   assignment            variable bindings (plain or inside expression_statement)
+--   keyword_argument      named arguments in calls (name = value)
+--   string                literals that may be single/double/triple-quoted
+
+return function(U)
+  local get_text = U.get_text
+  local compact_ws = U.compact_ws
+  local line_start = U.line_start
+  local line_end = U.line_end
+
+  local STRING_PREFIX = {
+    B = true,
+    F = true,
+    R = true,
+    U = true,
+    b = true,
+    f = true,
+    r = true,
+    u = true,
+  }
+
+  local M = {}
+
+  -- Unwrap expression_statement -> its inner value node.
+  -- Many Starlark top-level statements arrive wrapped this way.
+  function M.expression_value(node)
+    if node:type() ~= "expression_statement" then
+      return nil
+    end
+
+    local children = node:named_children()
+
+    return children[1]
+  end
+
+  -- Return `node` if it is `target_type`, or its inner value if it's an
+  -- expression_statement wrapping a `target_type`. Returns nil otherwise.
+  function M.unwrap_to(node, target_type)
+    if node:type() == target_type then
+      return node
+    end
+
+    local child = M.expression_value(node)
+
+    if child and child:type() == target_type then
+      return child
+    end
+
+    return nil
+  end
+
+  function M.assignment_name(node, source)
+    local left = node:field("left")[1]
+
+    if not left then
+      return nil
+    end
+
+    return M.compact_ws_node(left, source)
+  end
+
+  function M.assignment_value(node)
+    return node:field("right")[1]
+  end
+
+  -- Strip whitespace and backslash line-continuation so multi-line attribute
+  -- access (`pip.\\\n  parse`) collapses to its single-line form (`pip.parse`).
+  -- Identifiers and dotted attribute paths cannot contain whitespace or
+  -- backslashes, so this is safe.
+  --
+  -- Note: tree-sitter-starlark only parses line continuation when it sits
+  -- AFTER the dot (`pip.\\\n  parse`). Continuation between the identifier
+  -- and the dot (`pip\\\n  .parse`) is not parsed as an attribute call at
+  -- all, so no fix here can recover it.
+  function M.call_target(call, source)
+    local fn_node = call:field("function")[1]
+
+    if not fn_node then
+      return nil
+    end
+
+    return (get_text(fn_node, source):gsub("[%s\\]+", ""))
+  end
+
+  function M.call_args(call)
+    local args_node = call:field("arguments")[1]
+
+    if not args_node then
+      return {}
+    end
+
+    local args = {}
+
+    for _, child in ipairs(args_node:named_children()) do
+      if child:type() ~= "comment" then
+        args[#args + 1] = child
+      end
+    end
+
+    return args
+  end
+
+  -- Caller is responsible for verifying that `node` is a keyword_argument.
+  function M.keyword_name(node, source)
+    local name_node = node:field("name")[1]
+
+    if not name_node then
+      return nil
+    end
+
+    return get_text(name_node, source)
+  end
+
+  -- Caller is responsible for verifying that `node` is a keyword_argument.
+  function M.keyword_value(node)
+    return node:field("value")[1]
+  end
+
+  function M.dictionary_splat_keys(node, source)
+    if node:type() ~= "dictionary_splat" then
+      return {}
+    end
+
+    local dict = node:named_children()[1]
+    if not dict or dict:type() ~= "dictionary" then
+      return {}
+    end
+
+    local keys = {}
+    for _, child in ipairs(dict:named_children()) do
+      if child:type() == "pair" then
+        local key = child:field("key")[1]
+        local key_text = key and M.raw_string_contents(key, source)
+        if key_text then
+          keys[#keys + 1] = key_text
+        end
+      end
+    end
+
+    return keys
+  end
+
+  -- Source text of `node` with whitespace runs collapsed to single spaces.
+  -- For label/name extraction and tightly-rendered call args; do not use for
+  -- doc strings or binding values where indentation matters.
+  function M.compact_ws_node(node, source)
+    return compact_ws(get_text(node, source))
+  end
+
+  -- Return content bounds for a Starlark string literal, excluding prefixes
+  -- and quote delimiters. Also reports whether the literal is triple-quoted.
+  local function string_content_bounds(text)
+    local quote_start = 1
+
+    while quote_start <= #text and STRING_PREFIX[text:sub(quote_start, quote_start)] do
+      quote_start = quote_start + 1
+    end
+
+    local quote = text:sub(quote_start, quote_start)
+
+    if quote ~= '"' and quote ~= "'" then
+      return nil
+    end
+
+    local triple_quote = quote:rep(3)
+    local is_triple_quoted = text:sub(quote_start, quote_start + 2) == triple_quote
+
+    if is_triple_quoted then
+      if #text < quote_start + 5 or text:sub(-3) ~= triple_quote then
+        return nil
+      end
+
+      return quote_start + 3, #text - 3, true
+    end
+
+    if #text < quote_start + 1 or text:sub(-1) ~= quote then
+      return nil
+    end
+
+    return quote_start + 1, #text - 1, false
+  end
+
+  -- Strip quotes from a string literal node. Handles single, double, and
+  -- triple-quoted strings. Returns nil for non-string nodes.
+  -- Note: uses compact_ws_node (collapses whitespace), which is intentional
+  -- for names, labels, and module paths. Do NOT use this for doc string bodies
+  -- where whitespace matters.
+  function M.raw_string_contents(node, source)
+    if node:type() ~= "string" then
+      return nil
+    end
+
+    local text = M.compact_ws_node(node, source)
+    local content_start, content_end = string_content_bounds(text)
+
+    if not content_start then
+      return nil
+    end
+
+    return text:sub(content_start, content_end)
+  end
+
+  -- Render a `list` node tightly for the index. Walks the list's elements
+  -- directly so multi-line / trailing-comma forms render the same as their
+  -- single-line equivalents, and recurses into nested lists.
+  function M.compact_list(node, source)
+    local items = {}
+
+    for _, child in ipairs(node:named_children()) do
+      local kind = child:type()
+      if kind ~= "comment" then
+        if kind == "list" then
+          items[#items + 1] = M.compact_list(child, source)
+        else
+          items[#items + 1] = M.compact_ws_node(child, source)
+        end
+      end
+    end
+
+    return "[" .. table.concat(items, ", ") .. "]"
+  end
+
+  local function compact_default_parameter(node, source)
+    local name = node:field("name")[1]
+    local value = node:field("value")[1]
+
+    if not name or not value then
+      return nil
+    end
+
+    local type_node = node:field("type")[1]
+    local type_text = type_node and ": " .. M.compact_ws_node(type_node, source) or ""
+
+    return M.compact_ws_node(name, source) .. type_text .. "=" .. M.compact_ws_node(value, source)
+  end
+
+  local function compact_parameter(node, source)
+    local kind = node:type()
+
+    if kind == "default_parameter" or kind == "typed_default_parameter" then
+      local rendered = compact_default_parameter(node, source)
+      if rendered then
+        return rendered
+      end
+    end
+
+    return M.compact_ws_node(node, source)
+  end
+
+  -- Render a function's `parameters` node tightly for the index.
+  function M.compact_params(node, source)
+    local params = {}
+
+    for _, child in ipairs(node:named_children()) do
+      if child:type() ~= "comment" then
+        params[#params + 1] = compact_parameter(child, source)
+      end
+    end
+
+    return "(" .. table.concat(params, ", ") .. ")"
+  end
+
+  function M.node_lines(node)
+    return line_start(node), line_end(node)
+  end
+
+  function M.is_doc_string(node, source)
+    local child = M.expression_value(node)
+
+    if not child or child:type() ~= "string" then
+      return false
+    end
+
+    local text = get_text(child, source)
+    local _, _, is_triple_quoted = string_content_bounds(text)
+
+    return is_triple_quoted == true
+  end
+
+  -- Pull a leading module doc string out of the top-level nodes. Returns:
+  --   doc   {start, end} line range of the doc string, or nil
+  --   rest  remaining nodes
+  function M.split_preamble(root, source)
+    local nodes = root:named_children()
+    local doc = nil
+    local index = 1
+
+    -- Walk past file-level comments first
+    while index <= #nodes and nodes[index]:type() == "comment" do
+      index = index + 1
+    end
+
+    -- Then capture the next node if it is a triple-quoted string
+    if index <= #nodes and M.is_doc_string(nodes[index], source) then
+      local s, e = M.node_lines(nodes[index])
+      doc = { s, e }
+      index = index + 1
+    end
+
+    -- Remaining nodes for classify() to handle as statements
+    local rest = {}
+    for i = index, #nodes do
+      rest[#rest + 1] = nodes[i]
+    end
+
+    return doc, rest
+  end
+
+  M.get_text = get_text
+
+  return M
+end

--- a/plugins/index/lang/bazel/build.lua
+++ b/plugins/index/lang/bazel/build.lua
@@ -1,0 +1,161 @@
+-- BUILD / BUILD.bazel indexer.
+--
+-- BUILD files are target-heavy. Keep the declarations that help navigation:
+-- loads, package_groups, exports_files, top-level bindings, and named rule
+-- calls. package() is valid but usually too broad to be useful in the index.
+
+return function(U)
+  local A = require("lang.bazel.analyze")(U)
+  local R = require("lang.bazel.render")(U)
+  local util = require("lang.bazel.util")
+
+  local function push_binding(stmt, state)
+    if not stmt.name then
+      return
+    end
+
+    stmt.value = U.truncate(stmt.value_text_compact, util.BINDING_TRUNCATE)
+    state.bindings[#state.bindings + 1] = stmt
+  end
+
+  local function push_package_group(stmt, state)
+    local name = stmt:kwarg("name")
+
+    if not name then
+      return
+    end
+
+    state.package_groups[#state.package_groups + 1] = {
+      name = name.text,
+      line_start = stmt.line_start,
+      line_end = stmt.line_end,
+    }
+  end
+
+  local function push_exports_files(stmt, state)
+    local files = stmt:positional_or_kwarg(1, "srcs")
+
+    if not files then
+      return
+    end
+
+    state.exports_files[#state.exports_files + 1] = {
+      files = files.text,
+      line_start = stmt.line_start,
+      line_end = stmt.line_end,
+    }
+  end
+
+  local function push_target(stmt, state)
+    local name = stmt:kwarg("name")
+
+    if not name then
+      return
+    end
+
+    state.targets[#state.targets + 1] = {
+      name = name.text,
+      rule = stmt.target,
+      deprecated = stmt:kwarg_present("deprecation"),
+      line_start = stmt.line_start,
+      line_end = stmt.line_end,
+    }
+  end
+
+  local call_handlers = {
+    package_group = push_package_group,
+    exports_files = push_exports_files,
+  }
+
+  -- BUILD calls we skip from the index. Currently just package(); its
+  -- visibility/default args are too broad to surface as navigable structure.
+  local IGNORED_CALLS = {
+    package = true,
+  }
+
+  local function handle_call(stmt, state)
+    if IGNORED_CALLS[stmt.target] then
+      return
+    end
+
+    local handler = call_handlers[stmt.target]
+
+    if handler then
+      handler(stmt, state)
+      return
+    end
+
+    push_target(stmt, state)
+  end
+
+  local function render_loads(state)
+    return R.render_items("loads", state.loads, function(load)
+      local module = load.module_quoted and util.quote(load.module) or load.module
+      return R.label_line(module, table.concat(load.names, ", "), R.item_range(load))
+    end)
+  end
+
+  local function render_package_groups(state)
+    return R.render_items("package_groups", state.package_groups, function(group)
+      return R.label_line(group.name, nil, R.item_range(group), { indent = 2 })
+    end)
+  end
+
+  local function render_exports_files(state)
+    return R.render_items("exports_files", state.exports_files, function(export)
+      return R.item_line(export.files, R.item_range(export), { indent = 2 })
+    end)
+  end
+
+  local function render_bindings(state)
+    return R.render_items("variable bindings", state.bindings, function(binding)
+      return R.label_line(binding.name, binding.value, R.item_range(binding), { indent = 2 })
+    end)
+  end
+
+  local function render_targets(state)
+    return R.render_items("targets", state.targets, function(target)
+      local deprecated = target.deprecated and ", deprecated=True" or ""
+
+      return R.label_line(target.name, target.rule .. deprecated, R.item_range(target), { indent = 2 })
+    end)
+  end
+
+  local function render(state, collected)
+    local sections = {}
+
+    R.append_section_if_present(sections, R.render_doc("build", collected))
+    R.append_section_if_present(sections, render_loads(state))
+    R.append_section_if_present(sections, render_package_groups(state))
+    R.append_section_if_present(sections, render_exports_files(state))
+    R.append_section_if_present(sections, render_bindings(state))
+    R.append_section_if_present(sections, render_targets(state))
+
+    return table.concat(sections, "\n")
+  end
+
+  return {
+    extract = function(source, root)
+      local state = {
+        loads = {},
+        package_groups = {},
+        exports_files = {},
+        bindings = {},
+        targets = {},
+      }
+      local collected = A.collect(root, source)
+
+      for _, stmt in ipairs(collected.statements) do
+        if stmt.kind == "load" then
+          state.loads[#state.loads + 1] = stmt
+        elseif stmt.kind == "assignment" then
+          push_binding(stmt, state)
+        elseif stmt.kind == "call" and stmt.target then
+          handle_call(stmt, state)
+        end
+      end
+
+      return render(state, collected)
+    end,
+  }
+end

--- a/plugins/index/lang/bazel/bzl.lua
+++ b/plugins/index/lang/bazel/bzl.lua
@@ -1,0 +1,90 @@
+-- .bzl file indexer.
+--
+-- .bzl files are closest to Python modules: module docs, loads, top-level
+-- bindings, and function signatures. Binding values keep raw whitespace before
+-- truncation so multi-line structures retain their shape.
+
+return function(U)
+  local A = require("lang.bazel.analyze")(U)
+  local R = require("lang.bazel.render")(U)
+  local util = require("lang.bazel.util")
+
+  local function handle_assignment(stmt, state)
+    if not stmt.name then
+      return
+    end
+
+    stmt.value = U.truncate(stmt.value_text_raw, util.BINDING_TRUNCATE)
+    state.bindings[#state.bindings + 1] = stmt
+  end
+
+  local function handle_function(stmt, state)
+    state.functions[#state.functions + 1] = stmt
+  end
+
+  -- .bzl skips loads whose module is not a string literal. They are valid
+  -- Starlark but rare and ambiguous to render, so dropping them keeps the
+  -- index focused.
+  local function handle_load(stmt, state)
+    if not stmt.module_quoted then
+      return
+    end
+
+    state.loads[#state.loads + 1] = stmt
+  end
+
+  local stmt_handlers = {
+    load = handle_load,
+    assignment = handle_assignment,
+    ["function"] = handle_function,
+  }
+
+  local function render_loads(state)
+    return R.render_items("loads", state.loads, function(load)
+      return R.label_line(util.quote(load.module), table.concat(load.names, ", "), R.item_range(load))
+    end)
+  end
+
+  local function render_bindings(state)
+    return R.render_items("variable bindings", state.bindings, function(binding)
+      return R.item_line(binding.name .. " = " .. binding.value, R.item_range(binding))
+    end)
+  end
+
+  local function render_functions(state)
+    return R.render_items("functions", state.functions, function(func)
+      return R.item_line(func.name .. func.params, R.item_range(func))
+    end)
+  end
+
+  local function render(state, collected)
+    local sections = {}
+
+    R.append_section_if_present(sections, R.render_doc("module", collected))
+    R.append_section_if_present(sections, render_loads(state))
+    R.append_section_if_present(sections, render_bindings(state))
+    R.append_section_if_present(sections, render_functions(state))
+
+    return table.concat(sections, "\n")
+  end
+
+  return {
+    extract = function(source, root)
+      local state = {
+        loads = {},
+        bindings = {},
+        functions = {},
+      }
+      local collected = A.collect(root, source)
+
+      for _, stmt in ipairs(collected.statements) do
+        local handler = stmt_handlers[stmt.kind]
+        if handler then
+          handler(stmt, state)
+        end
+      end
+
+      return render(state, collected)
+    end,
+  }
+end

--- a/plugins/index/lang/bazel/module.lua
+++ b/plugins/index/lang/bazel/module.lua
@@ -1,0 +1,385 @@
+-- MODULE.bazel indexer.
+--
+-- Bzlmod uses aliases heavily. use_extension() and use_repo_rule()
+-- assignments seed alias entries; later calls such as llvm.toolchain(...) and
+-- http_file(...) are indexed only when their aliases were declared earlier.
+
+return function(U)
+  local A = require("lang.bazel.analyze")(U)
+  local R = require("lang.bazel.render")(U)
+  local util = require("lang.bazel.util")
+
+  local function dev_dependency(call)
+    return call:kwarg_bool("dev_dependency") or false
+  end
+
+  local function dev_text(item, text)
+    return item.dev_dependency and text or ""
+  end
+
+  local function is_alias_of(state, name, kind)
+    return state.aliases[name] == kind
+  end
+
+  local function push_repo(state, rule, names, line_start, line_end, dev_dependency)
+    state.repos[#state.repos + 1] = {
+      rule = rule,
+      names = names,
+      dev_dependency = dev_dependency or false,
+      line_start = line_start,
+      line_end = line_end,
+    }
+  end
+
+  local function handle_extension_assignment(stmt, state)
+    local call = stmt.value_call
+    local path = call:positional_or_kwarg(1, "extension_bzl_file")
+    local extension_name = call:positional_or_kwarg(2, "extension_name")
+
+    if not path or not extension_name then
+      return
+    end
+
+    state.aliases[stmt.name] = "extension"
+    state.extensions[#state.extensions + 1] = {
+      alias = stmt.name,
+      path = util.render_value(path),
+      name = util.render_value(extension_name),
+      dev_dependency = dev_dependency(call),
+      line_start = stmt.line_start,
+      line_end = stmt.line_end,
+    }
+  end
+
+  local function has_repo_rule_args(stmt)
+    local call = stmt.value_call
+
+    return call:positional_or_kwarg(1, "repo_rule_bzl_file") ~= nil
+      and call:positional_or_kwarg(2, "repo_rule_name") ~= nil
+  end
+
+  local function handle_assignment(stmt, state)
+    if not stmt.name then
+      return
+    end
+
+    state.aliases[stmt.name] = nil
+
+    if stmt.value_call then
+      local target = stmt.value_call.target
+
+      if target == "use_extension" then
+        handle_extension_assignment(stmt, state)
+        return
+      end
+
+      if target == "use_repo_rule" then
+        if has_repo_rule_args(stmt) then
+          state.aliases[stmt.name] = "repo_rule"
+        end
+        return
+      end
+    end
+
+    if util.is_constant_name(stmt.name) then
+      state.vars[#state.vars + 1] = {
+        name = stmt.name,
+        line_start = stmt.line_start,
+        line_end = stmt.line_end,
+      }
+    end
+  end
+
+  local function handle_module_call(stmt, state)
+    local name = stmt:positional_or_kwarg(1, "name")
+
+    if not name or not name.quoted then
+      return
+    end
+
+    state.module_decl = {
+      name = name.text,
+      line_start = stmt.line_start,
+      line_end = stmt.line_end,
+    }
+  end
+
+  local function handle_bazel_dep(stmt, state)
+    local name = stmt:positional_or_kwarg(1, "name")
+    local version = stmt:positional_or_kwarg(2, "version")
+    local repo_name = stmt:kwarg("repo_name")
+
+    if not name or not name.quoted then
+      return
+    end
+
+    local apparent_repo_name = name.text
+
+    if repo_name and repo_name.kind == "string" and repo_name.text ~= "" then
+      apparent_repo_name = repo_name.text
+    elseif repo_name and not repo_name.quoted and repo_name.text == "None" then
+      apparent_repo_name = nil
+    end
+
+    state.deps[#state.deps + 1] = {
+      module_name = name.text,
+      apparent_repo_name = apparent_repo_name,
+      version = version and util.render_value(version) or '""',
+      dev_dependency = dev_dependency(stmt),
+      line_start = stmt.line_start,
+      line_end = stmt.line_end,
+    }
+  end
+
+  local function handle_use_repo(stmt, state)
+    local first = stmt.args[1]
+    if not first or first.kind ~= "positional" then
+      return
+    end
+
+    local proxy = first.value
+    if proxy.kind ~= "identifier" or not is_alias_of(state, proxy.text, "extension") then
+      return
+    end
+
+    local names = {}
+
+    for i = 2, #stmt.args do
+      local entry = stmt.args[i]
+
+      if entry.kind == "dictionary_splat" then
+        for _, key in ipairs(entry.keys) do
+          names[#names + 1] = util.quote("@" .. key)
+        end
+      else
+        names[#names + 1] = util.arg_repo_label(entry)
+      end
+    end
+
+    if #names == 0 then
+      return
+    end
+
+    push_repo(state, proxy.text, names, stmt.line_start, stmt.line_end)
+  end
+
+  -- track_dev=false skips reading dev_dependency: include() doesn't accept it
+  -- and we don't want a stale field on its records.
+  local function push_targets(items, stmt, track_dev)
+    local is_dev = track_dev and dev_dependency(stmt) or false
+
+    for _, entry in ipairs(stmt.args) do
+      if entry.kind == "positional" then
+        items[#items + 1] = {
+          target = util.render_value(entry.value),
+          dev_dependency = is_dev,
+          line_start = stmt.line_start,
+          line_end = stmt.line_end,
+        }
+      end
+    end
+  end
+
+  local function handle_extension_tag(stmt, state)
+    local alias, tag = stmt.target:match("^(.+)%.(.+)$")
+
+    if not is_alias_of(state, alias, "extension") then
+      return false
+    end
+
+    state.tags[#state.tags + 1] = {
+      alias = alias,
+      tag = tag,
+      name = stmt:kwarg("name"),
+      line_start = stmt.line_start,
+      line_end = stmt.line_end,
+    }
+    return true
+  end
+
+  local function handle_repo_rule_alias(stmt, state)
+    if not is_alias_of(state, stmt.target, "repo_rule") then
+      return
+    end
+
+    local name = stmt:kwarg("name")
+
+    if not name then
+      return
+    end
+
+    local repo_name = name.quoted and util.quote("@" .. name.text) or name.text
+
+    push_repo(state, stmt.target, { repo_name }, stmt.line_start, stmt.line_end, dev_dependency(stmt))
+  end
+
+  -- Default for calls whose target isn't a known builtin. Tag form
+  -- `<alias>.<tag>` resolves via state.aliases as "extension"; a bare
+  -- `<alias>` resolves as "repo_rule". Calls that match neither are
+  -- silently dropped.
+  local function handle_alias(stmt, state)
+    if handle_extension_tag(stmt, state) then
+      return
+    end
+
+    handle_repo_rule_alias(stmt, state)
+  end
+
+  local call_handlers = {
+    module = handle_module_call,
+    bazel_dep = handle_bazel_dep,
+    use_repo = handle_use_repo,
+    register_toolchains = function(stmt, state)
+      push_targets(state.toolchains, stmt, true)
+    end,
+    register_execution_platforms = function(stmt, state)
+      push_targets(state.exec_platforms, stmt, true)
+    end,
+    include = function(stmt, state)
+      push_targets(state.includes, stmt, false)
+    end,
+  }
+
+  -- Bzlmod calls we skip from the index. Overrides, injected repos, and flag
+  -- aliases are valid but add noise rather than navigable structure.
+  local IGNORED_CALLS = {
+    single_version_override = true,
+    multiple_version_override = true,
+    archive_override = true,
+    git_override = true,
+    local_path_override = true,
+    override_repo = true,
+    flag_alias = true,
+    inject_repo = true,
+  }
+
+  local function handle_call(stmt, state)
+    if IGNORED_CALLS[stmt.target] then
+      return
+    end
+
+    local handler = call_handlers[stmt.target]
+
+    if handler then
+      handler(stmt, state)
+      return
+    end
+
+    handle_alias(stmt, state)
+  end
+
+  local function render_module(state)
+    if not state.module_decl then
+      return nil
+    end
+
+    -- Alternative without R.render_items (single-item section):
+    --   local decl = state.module_decl
+    --   return "module:\n" .. R.item_line(util.quote("@" .. decl.name), R.item_range(decl)) .. "\n"
+    return R.render_items("module", { state.module_decl }, function(decl)
+      return R.item_line(util.quote("@" .. decl.name), R.item_range(decl))
+    end)
+  end
+
+  local function render_deps(state)
+    return R.render_items("bazel_deps", state.deps, function(dep)
+      local label = dep.apparent_repo_name and util.quote("@" .. dep.apparent_repo_name) or util.quote(dep.module_name)
+      local no_repo_text = dep.apparent_repo_name and "" or ", repo_name=None"
+      local value = dep.version .. no_repo_text .. dev_text(dep, ", dev=True")
+
+      return R.label_line(label, value, R.item_range(dep))
+    end)
+  end
+
+  local function render_extensions(state)
+    return R.render_items("module_extensions", state.extensions, function(ext)
+      local value = ext.path .. ", " .. ext.name .. dev_text(ext, ", dev=True")
+
+      return R.label_line(ext.alias, value, R.item_range(ext))
+    end)
+  end
+
+  local function render_tags(state)
+    return R.render_items("module_extensions.tags", state.tags, function(tag)
+      local prefix = tag.alias .. "." .. tag.tag
+      local value = tag.name and util.render_value(tag.name) or nil
+
+      return R.label_line(prefix, value, R.item_range(tag))
+    end)
+  end
+
+  local function render_repos(state)
+    return R.render_items("repos", state.repos, function(repo)
+      local value = table.concat(repo.names, ", ") .. dev_text(repo, ", dev=True")
+
+      return R.label_line(repo.rule, value, R.item_range(repo))
+    end)
+  end
+
+  -- For toolchains and exec_platforms dev_dependency may be true; for includes
+  -- it is always false (push_targets is called with track_dev=false), so
+  -- dev_text returns "" and the dev marker is omitted.
+  local function render_target_section(header, items)
+    return R.render_items(header, items, function(item)
+      return R.label_line(item.target, dev_text(item, "dev=True"), R.item_range(item))
+    end)
+  end
+
+  local function render_vars(state)
+    return R.render_items("vars", state.vars, function(var)
+      return R.label_line(var.name, nil, R.item_range(var))
+    end)
+  end
+
+  local function new_state()
+    return {
+      module_decl = nil,
+      deps = {},
+      extensions = {},
+      tags = {},
+      repos = {},
+      toolchains = {},
+      exec_platforms = {},
+      vars = {},
+      includes = {},
+      -- alias name -> "extension" or "repo_rule". Seeded by handle_assignment
+      -- when it sees `name = use_extension(...)` / `name = use_repo_rule(...)`,
+      -- and consulted later to recognize tag/repo-rule call shapes.
+      aliases = {},
+    }
+  end
+
+  local function render(state, collected)
+    local sections = {}
+
+    R.append_section_if_present(sections, R.render_doc("module", collected))
+    R.append_section_if_present(sections, render_module(state))
+    R.append_section_if_present(sections, render_deps(state))
+    R.append_section_if_present(sections, render_extensions(state))
+    R.append_section_if_present(sections, render_tags(state))
+    R.append_section_if_present(sections, render_repos(state))
+    R.append_section_if_present(sections, render_target_section("register_toolchains", state.toolchains))
+    R.append_section_if_present(sections, render_target_section("register_execution_platforms", state.exec_platforms))
+    R.append_section_if_present(sections, render_vars(state))
+    R.append_section_if_present(sections, render_target_section("includes", state.includes))
+
+    return table.concat(sections, "\n")
+  end
+
+  return {
+    extract = function(source, root)
+      local state = new_state()
+      local collected = A.collect(root, source)
+
+      for _, stmt in ipairs(collected.statements) do
+        if stmt.kind == "assignment" then
+          handle_assignment(stmt, state)
+        elseif stmt.kind == "call" and stmt.target then
+          handle_call(stmt, state)
+        end
+      end
+
+      return render(state, collected)
+    end,
+  }
+end

--- a/plugins/index/lang/bazel/render.lua
+++ b/plugins/index/lang/bazel/render.lua
@@ -1,0 +1,82 @@
+-- Output formatting for the Bazel indexer.
+--
+-- Knows nothing about Starlark, tree-sitter, or the AST layer. Operates only
+-- on the record shapes produced by analyze.lua and on plain strings, so it can
+-- be unit-tested or repurposed without dragging in tree-sitter.
+
+local DEFAULT_INDENT_LEVEL = 1
+local INDENT_WIDTH = 2
+
+return function(U)
+  local format_range = U.format_range
+
+  local R = {}
+
+  local function render_lines(header_line, items, render_fn)
+    local lines = { header_line }
+
+    for _, item in ipairs(items) do
+      lines[#lines + 1] = render_fn(item)
+    end
+
+    return table.concat(lines, "\n") .. "\n"
+  end
+
+  local function indent(level)
+    return (" "):rep(INDENT_WIDTH * level)
+  end
+
+  local function join_line(...)
+    local fields = {}
+
+    for i = 1, select("#", ...) do
+      local part = select(i, ...)
+
+      if part and part ~= "" then
+        fields[#fields + 1] = part
+      end
+    end
+
+    return table.concat(fields, " ")
+  end
+
+  function R.append_section_if_present(sections, section)
+    if section then
+      sections[#sections + 1] = section
+    end
+  end
+
+  function R.render_items(header, items, render_fn)
+    if #items == 0 then
+      return nil
+    end
+
+    return render_lines(header .. ":", items, render_fn)
+  end
+
+  function R.item_range(item)
+    return format_range(item.line_start, item.line_end)
+  end
+
+  function R.item_line(value, line_range, opts)
+    local indent_level = opts and opts.indent or DEFAULT_INDENT_LEVEL
+
+    return join_line(indent(indent_level) .. value, line_range)
+  end
+
+  function R.label_line(label, value, line_range, opts)
+    local indent_level = opts and opts.indent or DEFAULT_INDENT_LEVEL
+
+    return join_line(indent(indent_level) .. label .. ":", value, line_range)
+  end
+
+  function R.render_doc(kind, collected)
+    if not collected.doc then
+      return nil
+    end
+
+    return kind .. " doc: " .. format_range(collected.doc[1], collected.doc[2]) .. "\n"
+  end
+
+  return R
+end

--- a/plugins/index/lang/bazel/util.lua
+++ b/plugins/index/lang/bazel/util.lua
@@ -1,0 +1,50 @@
+-- Layer-agnostic helpers for the Bazel indexer.
+--
+-- Imported by both extractors and analyze.lua. Has no dependencies on
+-- ast.lua or render.lua, so it can be required from any layer.
+
+local M = {}
+
+-- Max length of a rendered assignment value before "[truncated]" is appended.
+-- Shared by the .bzl and BUILD extractors so binding lines stay scannable.
+M.BINDING_TRUNCATE = 60
+
+function M.quote(text)
+  return '"' .. text .. '"'
+end
+
+-- Render an analyze value record as it would appear in the index: quoted if
+-- the source was a string literal, raw otherwise.
+function M.render_value(v)
+  return v.quoted and M.quote(v.text) or v.text
+end
+
+-- Match all-uppercase identifiers (with optional leading underscores) such
+-- as MY_CONST or _PRIVATE. Used by module.lua to recognize Bzlmod constants.
+function M.is_constant_name(name)
+  return name and name:match("^_*[A-Z][A-Z0-9_]*$") ~= nil
+end
+
+-- Render a use_repo() argument as a repo label. The argument here is an
+-- entry from a CallRecord's `args` list (not a value record), because the
+-- keyword-argument case must read the keyword *name* as the alias.
+--   keyword arg `alias = "real"` -> '"@alias"'
+--   positional string "foo"     -> '"@foo"'
+--   positional anything else    -> the argument's compacted text (e.g. a bare
+--                                  identifier FOO renders as 'FOO', since it
+--                                  cannot be resolved at index time)
+function M.arg_repo_label(entry)
+  if entry.kind == "keyword" then
+    return M.quote("@" .. entry.name)
+  end
+
+  local v = entry.value
+
+  if v.kind == "string" then
+    return M.quote("@" .. v.text)
+  end
+
+  return v.text
+end
+
+return M

--- a/plugins/index/tests/lang/bazel.lua
+++ b/plugins/index/tests/lang/bazel.lua
@@ -1,0 +1,930 @@
+local helpers = require("tests.helpers")
+local case = helpers.case
+local idx = helpers.idx
+local has = helpers.has
+local lacks = helpers.lacks
+
+case("bazel_build_fixture", function()
+  local src = [==["""
+# BUILD docs
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur.
+"""
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+package(default_visibility = ["//visibility:public"])
+
+package_group(
+    name = "tropical",
+    packages = [
+        "//fruits/mango",
+        "//fruits/orange",
+        "//fruits/papaya/...",
+    ],
+)
+
+exports_files([
+    "arch.bzl",
+    "declare_outputs.bzl",
+])
+
+FOOBAR = 42
+
+bzl_library(
+    name = "arch",
+    srcs = ["arch.bzl"],
+)
+
+bzl_library(
+    name = "foo_%s" % FOOBAR,
+    srcs = ["declare_outputs.bzl"],
+    deps = [
+        "@bazel_skylib//lib:paths",
+    ],
+)
+
+cc_library(
+    name = "foo_lib",
+    srcs = ["foo_lib.cc"],
+    hdrs = ["foo_lib.h"],
+    deprecation = "Use //:new_foo_lib instead",
+)
+
+# Some test
+
+cc_test(
+    name = "foo_lib_test",
+    srcs = ["foo_lib_test.cc"],
+    deps = [":foo_lib"],
+)]==]
+  local expected = [==[build doc: [1-10]
+
+loads:
+  "@bazel_skylib//:bzl_library.bzl": bzl_library [12]
+
+package_groups:
+    tropical: [16-23]
+
+exports_files:
+    ["arch.bzl", "declare_outputs.bzl"] [25-28]
+
+variable bindings:
+    FOOBAR: 42 [30]
+
+targets:
+    arch: bzl_library [32-35]
+    "foo_%s" % FOOBAR: bzl_library [37-43]
+    foo_lib: cc_library, deprecated=True [45-50]
+    foo_lib_test: cc_test [54-58]
+]==]
+  local out = idx(src, "bazel_build")
+  assert(out == expected, "BUILD fixture mismatch:\n--- expected ---\n" .. expected .. "\n--- got ---\n" .. out)
+end)
+
+case("bazel_module_fixture", function()
+  local src = [==[module(
+    name = "monogres",
+    # https://bazel.build/external/faq#module-versioning-best-practices
+    version = "",
+    bazel_compatibility = [">=8.4.2"],
+    # https://bazel.build/external/faq#incrementing-compatibility-level
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "bazel_lib", version = "3.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "download_archives", version = "0.1.0")
+bazel_dep(name = "gawk", version = "5.3.2.bcr.3")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+# see https://bazelbuild.slack.com/archives/CA31HN1T3/p1753021278448849
+bazel_dep(name = "protobuf", version = "31.1")
+bazel_dep(name = "rules_bison", version = "0.4")
+bazel_dep(name = "rules_distroless", version = "0.6.1")
+bazel_dep(name = "rules_flex", version = "0.4")
+bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
+bazel_dep(name = "rules_m4", version = "0.3")
+bazel_dep(name = "rules_pkg", version = "1.2.0")
+bazel_dep(name = "rules_python", version = "1.6.3")
+bazel_dep(name = "starlark_utils", version = "0.0.1")
+bazel_dep(name = "tar.bzl", version = "0.6.0")
+bazel_dep(name = "version_utils", version = "0.1.0")
+
+bazel_dep(name = "toolchains_llvm", version = "1.5.0", dev_dependency = True)
+
+local_path_override(
+    module_name = "starlark_utils",
+    path = "starlark_utils",
+)
+
+local_path_override(
+    module_name = "download_archives",
+    path = "/src/bazel_download_archives",
+)
+
+RFCC_COMMIT = "2eca712c15301c1f4e71ceec21e6271f373501e2"
+
+archive_override(
+    module_name = "rules_foreign_cc",
+    patch_strip = 1,
+    patches = [
+        "//patches/rules_foreign_cc:0001-workaround-rfcc-0.15.1-ninja-version-breaks-with-gli.patch",
+    ],
+    sha256 = "62cf2de93583a40413cbf7ebca380a0c0d2421db7b3614eb1d8389bcba21723e",
+    strip_prefix = "rules_foreign_cc-{}".format(RFCC_COMMIT),
+    url = "https://github.com/bazel-contrib/rules_foreign_cc/archive/{}.tar.gz".format(RFCC_COMMIT),
+)
+
+# toolchains/
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
+
+# NOTE:
+# We use a system LLVM toolchain, so it will use the LLVM installed in the
+# Docker image. This requires llvm-14, clang-14, lld-14, and libc6-dev to be
+# installed. Also, absolute_paths=True is needed because the system toolchain
+# uses absolute paths for builtin headers:
+# /usr/lib/llvm-14/lib/clang/14.0.6/include/
+llvm.toolchain(
+    name = "llvm_toolchain_system_linux_amd64",
+    absolute_paths = True,
+    exec_arch = "amd64",
+    exec_os = "linux",
+    llvm_version = "14.0.6",
+)
+llvm.toolchain_root(
+    name = "llvm_toolchain_system_linux_amd64",
+    path = "/usr/lib/llvm-14",
+)
+llvm.toolchain(
+    name = "llvm_toolchain_system_linux_arm64",
+    absolute_paths = True,
+    exec_arch = "arm64",
+    exec_os = "linux",
+    llvm_version = "14.0.6",
+)
+llvm.toolchain_root(
+    name = "llvm_toolchain_system_linux_arm64",
+    path = "/usr/lib/llvm-14",
+)
+use_repo(llvm, "llvm_toolchain_system_linux_amd64", "llvm_toolchain_system_linux_arm64")
+
+register_toolchains(
+    "@llvm_toolchain_system_linux_arm64//:all",
+    dev_dependency = True,
+)
+
+register_toolchains(
+    "@llvm_toolchain_system_linux_amd64//:all",
+    dev_dependency = True,
+)
+
+bison = use_extension(
+    "@rules_bison//bison/extensions:bison_repository_ext.bzl",
+    "bison_repository_ext",
+)
+bison.repository(
+    name = "bison",
+    version = "3.3.2",
+)
+use_repo(bison, "bison")
+
+flex = use_extension("@rules_flex//flex/extensions:flex_repository_ext.bzl", "flex_repository_ext")
+flex.repository(
+    name = "flex",
+    version = "2.6.4",
+)
+use_repo(flex, "flex")
+
+m4 = use_extension("@rules_m4//m4/extensions:m4_repository_ext.bzl", "m4_repository_ext")
+m4.repository(
+    name = "m4",
+    version = "1.4.18",
+)
+use_repo(m4, "m4")
+
+tar_toolchains = use_extension("@tar.bzl//tar:extensions.bzl", "toolchains")
+use_repo(tar_toolchains, "bsd_tar_toolchains")
+
+register_toolchains("@bsd_tar_toolchains//:all")
+
+zstd_toolchains = use_extension("@bazel_lib//lib:extensions.bzl", "toolchains")
+use_repo(zstd_toolchains, "zstd_toolchains")
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    python_version = "3.11",
+)
+use_repo(python, "python_3_11")
+
+override_repo(
+  python,
+  python_3_11 = "otherrepo",
+)
+
+monoext = use_extension("//monoext:monoext.bzl", "monoext")
+monoext.monogres(
+    name = "pg",
+    pg = "//postgres:repo.json",
+    extensions = "//extensions/catalog:index.json",
+)
+use_repo(monoext, "pg", "pg_ext", "pg_pkgs")
+
+http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+http_file(
+    name = "somefile",
+    sha256 = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    url = "https://example.com/somefile",
+)
+
+SOMEREPO = "somerepo"
+
+local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
+local_repository(name = SOMEREPO, path = "../%s" % SOMEREPO)
+
+foo = use_extension("//foo:extensions.bzl", "foobar")
+inject_repo(foo, SOMEREPO)
+
+register_execution_platforms("@platforms//amd64")
+
+include("//foo:foo.MODULE.bazel")]==]
+  local expected = [==[module:
+  "@monogres" [1-8]
+
+bazel_deps:
+  "@bazel_lib": "3.0.0" [10]
+  "@bazel_skylib": "1.8.2" [11]
+  "@download_archives": "0.1.0" [12]
+  "@gawk": "5.3.2.bcr.3" [13]
+  "@platforms": "1.0.0" [14]
+  "@protobuf": "31.1" [17]
+  "@rules_bison": "0.4" [18]
+  "@rules_distroless": "0.6.1" [19]
+  "@rules_flex": "0.4" [20]
+  "@rules_foreign_cc": "0.15.1" [21]
+  "@rules_m4": "0.3" [22]
+  "@rules_pkg": "1.2.0" [23]
+  "@rules_python": "1.6.3" [24]
+  "@starlark_utils": "0.0.1" [25]
+  "@tar.bzl": "0.6.0" [26]
+  "@version_utils": "0.1.0" [27]
+  "@toolchains_llvm": "1.5.0", dev=True [29]
+
+module_extensions:
+  llvm: "@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev=True [55]
+  bison: "@rules_bison//bison/extensions:bison_repository_ext.bzl", "bison_repository_ext" [97-100]
+  flex: "@rules_flex//flex/extensions:flex_repository_ext.bzl", "flex_repository_ext" [107]
+  m4: "@rules_m4//m4/extensions:m4_repository_ext.bzl", "m4_repository_ext" [114]
+  tar_toolchains: "@tar.bzl//tar:extensions.bzl", "toolchains" [121]
+  zstd_toolchains: "@bazel_lib//lib:extensions.bzl", "toolchains" [126]
+  python: "@rules_python//python/extensions:python.bzl", "python" [129]
+  monoext: "//monoext:monoext.bzl", "monoext" [140]
+  foo: "//foo:extensions.bzl", "foobar" [160]
+
+module_extensions.tags:
+  llvm.toolchain: "llvm_toolchain_system_linux_amd64" [63-69]
+  llvm.toolchain_root: "llvm_toolchain_system_linux_amd64" [70-73]
+  llvm.toolchain: "llvm_toolchain_system_linux_arm64" [74-80]
+  llvm.toolchain_root: "llvm_toolchain_system_linux_arm64" [81-84]
+  bison.repository: "bison" [101-104]
+  flex.repository: "flex" [108-111]
+  m4.repository: "m4" [115-118]
+  python.toolchain: [130-132]
+  monoext.monogres: "pg" [141-145]
+
+repos:
+  llvm: "@llvm_toolchain_system_linux_amd64", "@llvm_toolchain_system_linux_arm64" [85]
+  bison: "@bison" [105]
+  flex: "@flex" [112]
+  m4: "@m4" [119]
+  tar_toolchains: "@bsd_tar_toolchains" [122]
+  zstd_toolchains: "@zstd_toolchains" [127]
+  python: "@python_3_11" [133]
+  monoext: "@pg", "@pg_ext", "@pg_pkgs" [146]
+  http_file: "@somefile" [149-153]
+  local_repository: SOMEREPO [158]
+
+register_toolchains:
+  "@llvm_toolchain_system_linux_arm64//:all": dev=True [87-90]
+  "@llvm_toolchain_system_linux_amd64//:all": dev=True [92-95]
+  "@bsd_tar_toolchains//:all": [124]
+
+register_execution_platforms:
+  "@platforms//amd64": [163]
+
+vars:
+  RFCC_COMMIT: [41]
+  SOMEREPO: [155]
+
+includes:
+  "//foo:foo.MODULE.bazel": [165]
+]==]
+  local out = idx(src, "bazel_module")
+  assert(out == expected, "MODULE fixture mismatch:\n--- expected ---\n" .. expected .. "\n--- got ---\n" .. out)
+end)
+
+case("bazel_bzl_fixture", function()
+  local src = [==["""
+# Starlark module
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur.
+"""
+
+load("@version_utils//spec:spec.bzl", "spec")
+load("@version_utils//version:version.bzl", Version = "version")
+load(
+  "@foo//bar:foobar.bzl",
+  "import1",
+  "import2",
+  Import3 = "import3",
+  Import4 = "import4",
+)
+
+__MAX_ITERATIONS__ = 2 << 31 - 2
+
+_BRACKETS = {
+    "close": {
+        "dict": "}",
+        "list": "]",
+        "tuple": ")",
+    },
+    "open": {
+        "dict": "{",
+        "list": "[",
+        "tuple": "(",
+    },
+}
+
+_FN_SENTINEL = "__starlark_fn__"
+_FN_ARGS = "__starlark_fn_args__"
+
+def _foo(s):
+    pass
+
+def _bar(*args, **kwargs):
+    """Lorem ipsum dolor sit amet."""
+    pass
+
+def _foobar(
+        arg1,
+        arg2,
+        arg3,
+        arg4,
+        arg5,
+        kv1 = 42,
+        kv2 = True,
+        kv3 = ("a", "b", "c", "d"),
+        kv4 = [1, 2, 3, 4]):
+    '''Excepteur sint "occaecat cupidatat" non proident.
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+    veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+    commodo consequat.
+    '''
+    pass
+
+foobar = struct(
+    bar = _bar,
+    lbar = lambda arg, **kwargs: _bar(arg, kv1 = True, **kwargs),
+    foobar = _foobar,
+    __test__ = struct(
+        _foo = _foo,
+    ),
+)]==]
+  local expected = [==[module doc: [1-10]
+
+loads:
+  "@version_utils//spec:spec.bzl": spec [12]
+  "@version_utils//version:version.bzl": Version [13]
+  "@foo//bar:foobar.bzl": import1, import2, Import3, Import4 [14-20]
+
+variable bindings:
+  __MAX_ITERATIONS__ = 2 << 31 - 2 [22]
+  _BRACKETS = {
+    "close": {
+        "dict": "}",
+        "li[truncated] [24-35]
+  _FN_SENTINEL = "__starlark_fn__" [37]
+  _FN_ARGS = "__starlark_fn_args__" [38]
+  foobar = struct(
+    bar = _bar,
+    lbar = lambda arg, **[truncated] [66-73]
+
+functions:
+  _foo(s) [40-41]
+  _bar(*args, **kwargs) [43-45]
+  _foobar(arg1, arg2, arg3, arg4, arg5, kv1=42, kv2=True, kv3=("a", "b", "c", "d"), kv4=[1, 2, 3, 4]) [47-64]
+]==]
+  local out = idx(src, "bazel_bzl")
+  assert(out == expected, "BZL fixture mismatch:\n--- expected ---\n" .. expected .. "\n--- got ---\n" .. out)
+end)
+
+case("bazel_build_sections", function()
+  local src = [==[load("@rules_cc//cc:defs.bzl", "cc_library")
+
+TIMEOUT = 300
+
+cc_library(
+    name = "mylib",
+    srcs = ["mylib.cc"],
+)]==]
+  local out = idx(src, "bazel_build")
+  has(out, {
+    "loads:",
+    '"@rules_cc//cc:defs.bzl": cc_library',
+    "variable bindings:",
+    "TIMEOUT: 300",
+    "targets:",
+    "mylib: cc_library",
+  })
+end)
+
+case("bazel_build_deprecated_target", function()
+  local src = [==[cc_library(
+    name = "old_lib",
+    deprecation = "Use new_lib instead",
+)]==]
+  local out = idx(src, "bazel_build")
+  has(out, { "old_lib: cc_library, deprecated=True" })
+end)
+
+case("bazel_build_multiple_exports_files", function()
+  local src = [==[exports_files(["one.txt"])
+exports_files(["two.txt", "three.txt"])]==]
+  local out = idx(src, "bazel_build")
+  has(out, {
+    "exports_files:",
+    '["one.txt"] [1]',
+    '["two.txt", "three.txt"] [2]',
+  })
+end)
+
+case("bazel_build_exports_files_keyword_srcs", function()
+  local src = [==[exports_files(srcs = ["one.txt"])]==]
+  local out = idx(src, "bazel_build")
+  has(out, {
+    "exports_files:",
+    '["one.txt"] [1]',
+  })
+  lacks(out, { "srcs =" })
+end)
+
+case("bazel_build_exports_files_multiline_without_trailing_comma", function()
+  local src = [==[exports_files([
+    "one.txt",
+    "two.txt"
+])]==]
+  local out = idx(src, "bazel_build")
+  has(out, { '["one.txt", "two.txt"] [1-4]' })
+  lacks(out, { '"two.txt" ]' })
+end)
+
+case("bazel_build_binding_truncation", function()
+  local src = [==[LONG_VALUE = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]==]
+  local out = idx(src, "bazel_build")
+  has(out, { "[truncated]" })
+end)
+
+case("bazel_build_package_group_constant_name", function()
+  local src = [==[GROUP_NAME = "tropical"
+package_group(name = GROUP_NAME)]==]
+  local out = idx(src, "bazel_build")
+  has(out, {
+    "package_groups:",
+    "GROUP_NAME: [2]",
+  })
+end)
+
+case("bazel_module_alias_tracking", function()
+  local src = [==[pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip.parse(
+    name = "pip_deps",
+    python_version = "3.11",
+    requirements_lock = "//requirements:lock.txt",
+)
+use_repo(pip, "pip_deps")]==]
+  local out = idx(src, "bazel_module")
+  has(out, {
+    "module_extensions:",
+    'pip: "@rules_python//python/extensions:pip.bzl", "pip"',
+    "module_extensions.tags:",
+    'pip.parse: "pip_deps"',
+    "repos:",
+    'pip: "@pip_deps"',
+  })
+end)
+
+case("bazel_module_keyword_alias_assignments", function()
+  local src = [==[ext = use_extension(extension_bzl_file = "//:ext.bzl", extension_name = "ext")
+ext.tag(name = "repo")
+
+repo_rule = use_repo_rule(repo_rule_bzl_file = "//:repo.bzl", repo_rule_name = "repo")
+repo_rule(name = "generated")]==]
+  local out = idx(src, "bazel_module")
+  has(out, {
+    'ext: "//:ext.bzl", "ext" [1]',
+    'ext.tag: "repo" [2]',
+    'repo_rule: "@generated" [5]',
+  })
+end)
+
+case("bazel_module_tag_name_variable", function()
+  local src = [==[PIP_NAME = "pip_deps"
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip.parse(name = PIP_NAME)]==]
+  local out = idx(src, "bazel_module")
+  has(out, {
+    "vars:",
+    "PIP_NAME: [1]",
+    'pip: "@rules_python//python/extensions:pip.bzl", "pip" [2]',
+    "module_extensions.tags:",
+    "pip.parse: PIP_NAME [3]",
+  })
+  lacks(out, { 'pip.parse: "PIP_NAME"' })
+end)
+
+case("bazel_module_ignored_calls", function()
+  local src = [==[bazel_dep(name = "foo", version = "1.0")
+
+archive_override(
+    module_name = "foo",
+    sha256 = "abc123",
+    url = "https://example.com/foo.tar.gz",
+)
+
+local_path_override(
+    module_name = "bar",
+    path = "/local/bar",
+)]==]
+  local out = idx(src, "bazel_module")
+  has(out, { "bazel_deps:" })
+  lacks(out, { "archive_override", "local_path_override" })
+end)
+
+case("bazel_module_dev_dependency", function()
+  local src = [==[bazel_dep(name = "rules_testing", version = "0.6.0", dev_dependency = True)]==]
+  local out = idx(src, "bazel_module")
+  has(out, { '@rules_testing": "0.6.0", dev=True' })
+end)
+
+case("bazel_module_positional_module_and_dep_args", function()
+  local src = [==[module("app")
+bazel_dep("rules_cc", "0.1.1")
+bazel_dep("rules_go", version = "0.53.0")
+bazel_dep(name = "rules_java", version = "8.12.0")
+bazel_dep("versionless")]==]
+  local out = idx(src, "bazel_module")
+  has(out, {
+    '"@app" [1]',
+    '"@rules_cc": "0.1.1" [2]',
+    '"@rules_go": "0.53.0" [3]',
+    '"@rules_java": "8.12.0" [4]',
+    '"@versionless": "" [5]',
+  })
+end)
+
+case("bazel_module_bazel_dep_repo_name", function()
+  local src = [==[bazel_dep(name = "rules_foo", version = "1.0", repo_name = "foo")
+bazel_dep(name = "default_name", version = "1.1", repo_name = "")
+bazel_dep(name = "nodep", version = "2.0", repo_name = None)]==]
+  local out = idx(src, "bazel_module")
+  has(out, {
+    '"@foo": "1.0" [1]',
+    '"@default_name": "1.1" [2]',
+    '"nodep": "2.0", repo_name=None [3]',
+  })
+  lacks(out, {
+    '"@"',
+    '"@nodep"',
+    '"@rules_foo"',
+  })
+end)
+
+case("bazel_module_use_repo_keyword_alias", function()
+  local src = [==[ext = use_extension("//:ext.bzl", "ext")
+use_repo(ext, visible_repo = "generated_repo")]==]
+  local out = idx(src, "bazel_module")
+  has(out, {
+    'ext: "//:ext.bzl", "ext" [1]',
+    'ext: "@visible_repo" [2]',
+  })
+  lacks(out, { '"@generated_repo"' })
+end)
+
+case("bazel_module_use_repo_dict_splat_alias", function()
+  local src = [==[ext = use_extension("//:ext.bzl", "ext")
+use_repo(ext, **{"foo.2": "generated_repo", "bar": "generated_bar"})]==]
+  local out = idx(src, "bazel_module")
+  has(out, {
+    'ext: "@foo.2", "@bar" [2]',
+  })
+  lacks(out, {
+    '**{"foo.2": "generated_repo", "bar": "generated_bar"}',
+    '"@generated_repo"',
+  })
+end)
+
+case("bazel_module_use_repo_proxy_must_be_positional", function()
+  local src = [==[ext = use_extension("//:ext.bzl", "ext")
+use_repo(extension_proxy = ext, "name")]==]
+  local out = idx(src, "bazel_module")
+  lacks(out, { "repos:", '"@name"' })
+end)
+
+case("bazel_module_invalid_alias_assignments", function()
+  local src = [==[ext = use_extension()
+ext.tag(name = "bad")
+use_repo(ext, "bad")
+
+repo_rule = use_repo_rule()
+repo_rule(name = "bad")]==]
+  local out = idx(src, "bazel_module")
+  lacks(out, {
+    "module_extensions.tags:",
+    "repos:",
+    'ext.tag: "bad"',
+    'ext: "@bad"',
+    'repo_rule: "@bad"',
+  })
+end)
+
+case("bazel_module_reassigned_aliases_are_cleared", function()
+  local src = [==[ext = use_extension("//:ext.bzl", "ext")
+ext = "not_extension"
+ext.tag(name = "bad")
+use_repo(ext, "bad")
+
+repo_rule = use_repo_rule("//:repo.bzl", "repo")
+repo_rule = "not_repo_rule"
+repo_rule(name = "bad")]==]
+  local out = idx(src, "bazel_module")
+  has(out, {
+    "module_extensions:",
+    'ext: "//:ext.bzl", "ext" [1]',
+  })
+  lacks(out, {
+    "module_extensions.tags:",
+    "repos:",
+    'ext.tag: "bad"',
+    'ext: "@bad"',
+    'repo_rule: "@bad"',
+  })
+end)
+
+case("bazel_module_invalid_reassignment_clears_stale_alias", function()
+  local src = [==[ext = use_extension("//:ext.bzl", "ext")
+ext = use_extension()
+ext.tag(name = "bad")
+use_repo(ext, "bad")
+
+repo_rule = use_repo_rule("//:repo.bzl", "repo")
+repo_rule = use_repo_rule()
+repo_rule(name = "bad")]==]
+  local out = idx(src, "bazel_module")
+  lacks(out, {
+    "module_extensions.tags:",
+    "repos:",
+    'ext.tag: "bad"',
+    'ext: "@bad"',
+    'repo_rule: "@bad"',
+  })
+end)
+
+case("bazel_module_multiple_target_args", function()
+  local src = [==[register_toolchains(
+    "@a//:all",
+    "@b//:all",
+    dev_dependency = True,
+)
+register_execution_platforms("@p1", "@p2")
+include("//a:MODULE.bazel", "//b:MODULE.bazel")]==]
+  local out = idx(src, "bazel_module")
+  has(out, {
+    "register_toolchains:",
+    '"@a//:all": dev=True [1-5]',
+    '"@b//:all": dev=True [1-5]',
+    "register_execution_platforms:",
+    '"@p1": [6]',
+    '"@p2": [6]',
+    "includes:",
+    '"//a:MODULE.bazel": [7]',
+    '"//b:MODULE.bazel": [7]',
+  })
+end)
+
+case("bazel_module_register_execution_platforms_dev_dependency", function()
+  local src = [==[register_execution_platforms(
+    "@p1",
+    "@p2",
+    dev_dependency = True,
+)
+register_execution_platforms("@p3")]==]
+  local out = idx(src, "bazel_module")
+  has(out, {
+    "register_execution_platforms:",
+    '"@p1": dev=True [1-5]',
+    '"@p2": dev=True [1-5]',
+    '"@p3": [6]',
+  })
+end)
+
+case("bazel_module_include_never_renders_dev", function()
+  local src = [==[include("//a:MODULE.bazel", dev_dependency = True)]==]
+  local out = idx(src, "bazel_module")
+  has(out, { '"//a:MODULE.bazel": [1]' })
+  lacks(out, { "dev=True" })
+end)
+
+-- analyze.lua's value records expose `text` as the unquoted contents of a
+-- string literal. Callers that render targets must use util.render_value
+-- to re-add quotes; otherwise "@a//:all" leaks as @a//:all.
+case("bazel_module_string_positional_args_keep_quotes", function()
+  local src = [==[ext = use_extension("//:ext.bzl", "ext")
+register_toolchains("@a//:all")
+register_execution_platforms("@p1")
+include("//a:MODULE.bazel")
+use_repo(ext, "alias")]==]
+  local out = idx(src, "bazel_module")
+  has(out, {
+    '"@a//:all": [2]',
+    '"@p1": [3]',
+    '"//a:MODULE.bazel": [4]',
+    'ext: "@alias" [5]',
+  })
+  lacks(out, {
+    "@a//:all: ",
+    "@p1: ",
+    "//a:MODULE.bazel: ",
+  })
+end)
+
+case("bazel_module_repo_rule_dev_dependency", function()
+  local src = [==[http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+http_file(name = "fixture", dev_dependency = True)]==]
+  local out = idx(src, "bazel_module")
+  has(out, {
+    'http_file: "@fixture", dev=True [2]',
+  })
+end)
+
+case("bazel_module_uppercase_alias_no_var_dup", function()
+  local src = [==[EXT = use_extension("//:ext.bzl", "ext")
+RULE = use_repo_rule("//:repo.bzl", "rule")]==]
+  local out = idx(src, "bazel_module")
+  has(out, {
+    "module_extensions:",
+    'EXT: "//:ext.bzl", "ext"',
+  })
+  lacks(out, {
+    "vars:",
+    "EXT: [",
+    "RULE: [",
+  })
+end)
+
+case("bazel_module_private_and_numbered_vars", function()
+  local src = [==[_PRIVATE_VERSION = "1.0"
+VERSION2 = "2.0"]==]
+  local out = idx(src, "bazel_module")
+  has(out, {
+    "vars:",
+    "_PRIVATE_VERSION: [1]",
+    "VERSION2: [2]",
+  })
+end)
+
+case("bazel_module_module_doc", function()
+  local src = [==["""Bzlmod manifest for foo."""
+
+module(name = "foo")]==]
+  local out = idx(src, "bazel_module")
+  has(out, { "module doc: [1]" })
+end)
+
+case("bazel_bzl_module_doc", function()
+  local src = [==["""Module-level docstring."""
+
+def helper():
+    pass]==]
+  local out = idx(src, "bazel_bzl")
+  has(out, { "module doc:" })
+end)
+
+case("bazel_bzl_single_quote_module_doc", function()
+  local src = [==['''Module-level docstring.'''
+
+def helper():
+    pass]==]
+  local out = idx(src, "bazel_bzl")
+  has(out, { "module doc: [1]" })
+end)
+
+case("bazel_bzl_raw_string_load", function()
+  local src = [==[load(r"//foo:defs.bzl", "rule")]==]
+  local out = idx(src, "bazel_bzl")
+  has(out, {
+    "loads:",
+    '"//foo:defs.bzl": rule [1]',
+  })
+end)
+
+case("bazel_bzl_function_params", function()
+  local src = [==[def my_rule(name, srcs = [], deps = [], visibility = None):
+    pass]==]
+  local out = idx(src, "bazel_bzl")
+  has(out, { "my_rule(name, srcs=[], deps=[], visibility=None)" })
+end)
+
+case("bazel_bzl_function_params_keep_string_default_equals", function()
+  local src = [==[def my_rule(
+    message = "a = b",
+    raw = r"c = d",
+    single = 'e = f',
+    same = x == y,
+    min_ok = x >= y,
+):
+    pass]==]
+  local out = idx(src, "bazel_bzl")
+  has(out, { [[my_rule(message="a = b", raw=r"c = d", single='e = f', same=x == y, min_ok=x >= y)]] })
+end)
+
+case("bazel_bzl_binding_truncation", function()
+  local src = [==[LONG_VALUE = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]==]
+  local out = idx(src, "bazel_bzl")
+  has(out, { "[truncated]" })
+end)
+
+case("bazel_module_inline_comment_in_register_toolchains", function()
+  local src = [==[register_toolchains(
+    "@a//:all",
+    # this is a comment
+    "@b//:all",
+)]==]
+  local out = idx(src, "bazel_module")
+  has(out, {
+    '"@a//:all":',
+    '"@b//:all":',
+  })
+  lacks(out, { "this is a comment" })
+end)
+
+case("bazel_module_attr_call_with_line_continuation", function()
+  local src = [==[pip = use_extension("//:ext.bzl", "ext")
+pip.\
+parse(name = "foo")]==]
+  local out = idx(src, "bazel_module")
+  has(out, {
+    "module_extensions.tags:",
+    'pip.parse: "foo"',
+  })
+end)
+
+case("bazel_module_inline_comment_in_use_repo", function()
+  local src = [==[ext = use_extension("//:ext.bzl", "ext")
+use_repo(
+    ext,
+    # comment between args
+    "first_repo",
+    "second_repo",
+)]==]
+  local out = idx(src, "bazel_module")
+  has(out, {
+    'ext: "@first_repo", "@second_repo"',
+  })
+  lacks(out, { "comment between args" })
+end)
+
+case("bazel_build_inline_comment_in_load", function()
+  local src = [==[load(
+    # the bzl file
+    "@foo//bar.bzl",
+    "rule",
+)]==]
+  local out = idx(src, "bazel_build")
+  has(out, {
+    '"@foo//bar.bzl": rule',
+  })
+  lacks(out, { "the bzl file" })
+end)
+
+case("bazel_module_inline_comment_in_bazel_dep", function()
+  local src = [==[bazel_dep(
+    # use latest version
+    name = "protobuf",
+    version = "31.1",
+)]==]
+  local out = idx(src, "bazel_module")
+  has(out, { '"@protobuf": "31.1"' })
+  lacks(out, { "use latest version" })
+end)

--- a/plugins/index/tests/spec.lua
+++ b/plugins/index/tests/spec.lua
@@ -6,6 +6,7 @@
 -- alphabetized. Each spec uses the shared `case` helper from tests/helpers.lua,
 -- which collects failures so a single broken case does not abort the suite.
 require("tests.lang.bash")
+require("tests.lang.bazel")
 require("tests.lang.c")
 require("tests.lang.c_sharp")
 require("tests.lang.cpp")


### PR DESCRIPTION
Bazel files are all Starlark, so they share one tree-sitter parser, but the three file kinds (MODULE.bazel, BUILD, *.bzl) have different enough semantics that each gets its own extractor. They sit on top of a shared internal API: analyze.lua classifies top-level statements into records, render.lua formats output, and ast.lua keeps all tree-sitter primitives behind a single wall so extractors never touch the AST directly.

Fixes: #122