### PR TITLE
ui: fix flaky selection copy on Linux

### DIFF
--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -272,6 +272,16 @@ impl App {
         &mut self.chats[self.active_chat]
     }
 
+    fn clear_selection_unless_pending_copy(&mut self) {
+        if !self
+            .selection_state
+            .as_ref()
+            .is_some_and(|s| s.is_pending_copy())
+        {
+            self.selection_state = None;
+        }
+    }
+
     pub fn update(&mut self, msg: Msg) -> Vec<Action> {
         match msg {
             Msg::Key(key) => self.handle_key(key),
@@ -295,7 +305,7 @@ impl App {
                 vec![]
             }
             Msg::Scroll { column, row, delta } => {
-                self.selection_state = None;
+                self.clear_selection_unless_pending_copy();
                 self.handle_scroll(column, row, delta);
                 vec![]
             }
@@ -478,7 +488,7 @@ impl App {
             }
         }
 
-        self.selection_state = None;
+        self.clear_selection_unless_pending_copy();
 
         if self.help_modal.is_open() {
             self.help_modal.handle_key(key);
@@ -1295,7 +1305,7 @@ impl App {
             || self
                 .selection_state
                 .as_ref()
-                .is_some_and(|s| s.edge_scroll.is_some())
+                .is_some_and(|s| s.is_edge_scrolling())
             || self.chats.iter().any(|c| c.is_animating())
     }
 

--- a/maki-ui/src/app/mouse.rs
+++ b/maki-ui/src/app/mouse.rs
@@ -2,7 +2,9 @@ use std::time::{Duration, Instant};
 
 use crate::clipboard::CopyResult;
 use crate::components::messages::ClickResult;
-use crate::selection::{self, ContentRegion, EdgeScroll, SelectableZone, Selection, SelectionZone};
+use crate::selection::{
+    self, ContentRegion, EdgeScroll, SelectableZone, Selection, SelectionState, SelectionZone,
+};
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;
 
@@ -20,7 +22,7 @@ impl App {
                         return;
                     }
                     let scroll = self.scroll_offset(zone.zone);
-                    self.selection_state = Some(crate::selection::SelectionState {
+                    self.selection_state = Some(SelectionState::Dragging {
                         sel: Selection::start(
                             event.row,
                             event.column,
@@ -28,7 +30,6 @@ impl App {
                             zone.zone,
                             scroll,
                         ),
-                        copy_on_release: false,
                         edge_scroll: None,
                         last_drag_col: event.column,
                     });
@@ -38,12 +39,11 @@ impl App {
                 self.handle_drag(event.row, event.column);
             }
             MouseEventKind::Up(MouseButton::Left) => {
-                if let Some(ref mut state) = self.selection_state {
-                    state.edge_scroll = None;
-                    if !state.sel.is_empty() {
-                        state.copy_on_release = true;
+                if let Some(SelectionState::Dragging { sel, .. }) = self.selection_state {
+                    if !sel.is_empty() {
+                        self.selection_state = Some(SelectionState::PendingCopy { sel });
                     } else {
-                        let zone = state.sel.zone;
+                        let zone = sel.zone;
                         self.selection_state = None;
                         if zone == SelectionZone::Messages {
                             let area = self.msg_area();
@@ -65,12 +65,17 @@ impl App {
     }
 
     fn handle_drag(&mut self, row: u16, col: u16) {
-        let Some(ref mut state) = self.selection_state else {
-            return;
+        let (zone, area) = match self.selection_state {
+            Some(SelectionState::Dragging {
+                ref sel,
+                ref mut last_drag_col,
+                ..
+            }) => {
+                *last_drag_col = col;
+                (sel.zone, sel.area)
+            }
+            _ => return,
         };
-        let zone = state.sel.zone;
-        let area = state.sel.area;
-        state.last_drag_col = col;
 
         let at_top = row <= area.y;
         let at_bottom = row + 1 >= area.bottom();
@@ -81,56 +86,78 @@ impl App {
             } else {
                 -EDGE_SCROLL_LINES
             };
-            let first_edge_hit = state.edge_scroll.is_none();
-            if let Some(ref mut es) = state.edge_scroll {
-                es.dir = dir;
+            let first_edge_hit = if let Some(SelectionState::Dragging { edge_scroll, .. }) =
+                &mut self.selection_state
+            {
+                let first = edge_scroll.is_none();
+                match edge_scroll {
+                    Some(es) => es.dir = dir,
+                    None => {
+                        *edge_scroll = Some(EdgeScroll {
+                            dir,
+                            last_tick: Instant::now(),
+                        });
+                    }
+                }
+                first
             } else {
-                state.edge_scroll = Some(EdgeScroll {
-                    dir,
-                    last_tick: Instant::now(),
-                });
-            }
+                false
+            };
             if first_edge_hit {
                 self.scroll_zone(zone, dir);
             }
             self.update_selection_to_edge(zone, col);
         } else {
-            let state = self.selection_state.as_mut().expect("checked above");
-            state.edge_scroll = None;
+            if let Some(SelectionState::Dragging { edge_scroll, .. }) = &mut self.selection_state {
+                *edge_scroll = None;
+            }
             let scroll = self.scroll_offset(zone);
-            let state = self.selection_state.as_mut().expect("checked above");
-            state.sel.update(row, col, scroll);
+            if let Some(SelectionState::Dragging { sel, .. }) = &mut self.selection_state {
+                sel.update(row, col, scroll);
+            }
         }
     }
 
     fn update_selection_to_edge(&mut self, zone: SelectionZone, col: u16) {
         let scroll = self.scroll_offset(zone);
-        let state = self.selection_state.as_mut().expect("caller ensures Some");
-        let edge_row = if state.edge_scroll.as_ref().is_some_and(|es| es.dir > 0) {
-            state.sel.area.y
-        } else {
-            state.sel.area.bottom().saturating_sub(1)
+        let Some(SelectionState::Dragging {
+            ref mut sel,
+            ref edge_scroll,
+            ..
+        }) = self.selection_state
+        else {
+            return;
         };
-        state.sel.update(edge_row, col, scroll);
+        let edge_row = if edge_scroll.as_ref().is_some_and(|es| es.dir > 0) {
+            sel.area.y
+        } else {
+            sel.area.bottom().saturating_sub(1)
+        };
+        sel.update(edge_row, col, scroll);
     }
 
     pub fn tick_edge_scroll(&mut self) {
-        let Some(ref mut state) = self.selection_state else {
-            return;
+        let (dir, zone, col) = match self.selection_state {
+            Some(SelectionState::Dragging {
+                ref sel,
+                ref mut edge_scroll,
+                last_drag_col,
+            }) => {
+                let Some(es) = edge_scroll else {
+                    return;
+                };
+                if es.last_tick.elapsed() < EDGE_SCROLL_INTERVAL {
+                    return;
+                }
+                let dir = es.dir;
+                es.last_tick = Instant::now();
+                (dir, sel.zone, last_drag_col)
+            }
+            _ => return,
         };
-        let Some(ref mut es) = state.edge_scroll else {
-            return;
-        };
-        if es.last_tick.elapsed() < EDGE_SCROLL_INTERVAL {
-            return;
-        }
-        let dir = es.dir;
-        let zone = state.sel.zone;
-        let last_drag_col = state.last_drag_col;
-        es.last_tick = Instant::now();
 
         self.scroll_zone(zone, dir);
-        self.update_selection_to_edge(zone, last_drag_col);
+        self.update_selection_to_edge(zone, col);
     }
 
     pub(super) fn copy_selection(

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -4,7 +4,7 @@ use crate::chat::{CANCELLED_TEXT, DONE_TEXT, ERROR_TEXT};
 use crate::components::command::ParsedCommand;
 use crate::components::keybindings::{KeybindContext, key as kb};
 use crate::components::{ExitRequest, key, test_model};
-use crate::selection::{EdgeScroll, SelectableZone, SelectionZone};
+use crate::selection::{EdgeScroll, SelectableZone, SelectionState, SelectionZone};
 use arc_swap::ArcSwap;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEventKind};
 use maki_agent::permissions::PermissionManager;
@@ -900,7 +900,7 @@ fn mouse_drag_updates_selection() {
     app.update(mouse_event(MouseEventKind::Drag(MouseButton::Left), 20, 10));
 
     let state = app.selection_state.as_ref().unwrap();
-    let (_, end) = state.sel.normalized();
+    let (_, end) = state.sel().normalized();
     assert_eq!(end.row, 10);
     assert_eq!(end.col, 20);
 }
@@ -919,11 +919,11 @@ fn mouse_drag_clamps_to_area() {
     ));
 
     let state = app.selection_state.as_ref().unwrap();
-    let (_, end) = state.sel.normalized();
+    let (_, end) = state.sel().normalized();
     assert_eq!(end.col, 79);
     assert_eq!(end.row, 19, "clamped to area bottom");
     assert!(
-        state.edge_scroll.is_some(),
+        app.selection_state.as_ref().unwrap().is_edge_scrolling(),
         "outside area triggers edge scroll"
     );
 }
@@ -948,7 +948,11 @@ fn edge_scroll_direction(zone: Rect, down: (u16, u16), drag: (u16, u16), expecte
     ));
 
     let state = app.selection_state.as_ref().unwrap();
-    assert_eq!(state.edge_scroll.as_ref().map(|es| es.dir), expected);
+    let edge_dir = match state {
+        SelectionState::Dragging { edge_scroll, .. } => edge_scroll.as_ref().map(|es| es.dir),
+        _ => None,
+    };
+    assert_eq!(edge_dir, expected);
 }
 
 #[test]
@@ -959,11 +963,11 @@ fn mouse_up_clears_edge_scroll() {
 
     app.update(mouse_event(MouseEventKind::Down(MouseButton::Left), 10, 10));
     app.update(mouse_event(MouseEventKind::Drag(MouseButton::Left), 10, 1));
-    assert!(app.selection_state.as_ref().unwrap().edge_scroll.is_some());
+    assert!(app.selection_state.as_ref().unwrap().is_edge_scrolling());
 
     app.update(mouse_event(MouseEventKind::Up(MouseButton::Left), 10, 1));
     let state = app.selection_state.as_ref().unwrap();
-    assert!(state.edge_scroll.is_none());
+    assert!(state.is_pending_copy());
 }
 
 #[test]
@@ -1031,11 +1035,12 @@ fn edge_scroll_makes_app_animating() {
     assert!(!app.is_animating());
     set_zone(&mut app, SelectionZone::Messages, Rect::new(0, 0, 80, 20));
     app.update(mouse_event(MouseEventKind::Down(MouseButton::Left), 5, 5));
-    let state = app.selection_state.as_mut().unwrap();
-    state.edge_scroll = Some(EdgeScroll {
-        dir: 1,
-        last_tick: Instant::now(),
-    });
+    if let Some(SelectionState::Dragging { edge_scroll, .. }) = app.selection_state.as_mut() {
+        *edge_scroll = Some(EdgeScroll {
+            dir: 1,
+            last_tick: Instant::now(),
+        });
+    }
     assert!(app.is_animating());
 }
 
@@ -1048,11 +1053,10 @@ fn mouse_up_behavior() {
     app.update(mouse_event(MouseEventKind::Drag(MouseButton::Left), 10, 10));
     app.update(mouse_event(MouseEventKind::Up(MouseButton::Left), 10, 10));
     assert!(
-        app.selection_state.as_ref().unwrap().copy_on_release,
-        "non-empty selection sets copy flag"
+        app.selection_state.as_ref().unwrap().is_pending_copy(),
+        "non-empty selection transitions to PendingCopy"
     );
 
-    app.selection_state.as_mut().unwrap().copy_on_release = false;
     app.selection_state = None;
     app.update(mouse_event(MouseEventKind::Down(MouseButton::Left), 5, 5));
     app.update(mouse_event(MouseEventKind::Up(MouseButton::Left), 5, 5));
@@ -1075,6 +1079,170 @@ fn key_and_scroll_clear_selection() {
         delta: 3,
     });
     assert!(app.selection_state.is_none(), "scroll clears selection");
+}
+
+#[test]
+fn key_and_scroll_preserve_pending_copy() {
+    let mut app = test_app();
+    set_zone(&mut app, SelectionZone::Messages, Rect::new(0, 0, 80, 20));
+
+    app.update(mouse_event(MouseEventKind::Down(MouseButton::Left), 5, 5));
+    app.update(mouse_event(MouseEventKind::Drag(MouseButton::Left), 10, 10));
+    app.update(mouse_event(MouseEventKind::Up(MouseButton::Left), 10, 10));
+    assert!(app.selection_state.as_ref().unwrap().is_pending_copy());
+
+    app.update(Msg::Key(key(KeyCode::Char('a'))));
+    assert!(
+        app.selection_state.as_ref().unwrap().is_pending_copy(),
+        "key press must not clear pending copy"
+    );
+
+    app.update(Msg::Scroll {
+        column: 10,
+        row: 10,
+        delta: 3,
+    });
+    assert!(
+        app.selection_state.as_ref().unwrap().is_pending_copy(),
+        "scroll must not clear pending copy"
+    );
+}
+
+#[test]
+fn new_mouse_down_replaces_pending_copy_with_dragging() {
+    let mut app = test_app();
+    set_zone(&mut app, SelectionZone::Messages, Rect::new(0, 0, 80, 20));
+
+    app.update(mouse_event(MouseEventKind::Down(MouseButton::Left), 5, 5));
+    app.update(mouse_event(MouseEventKind::Drag(MouseButton::Left), 10, 10));
+    app.update(mouse_event(MouseEventKind::Up(MouseButton::Left), 10, 10));
+    assert!(app.selection_state.as_ref().unwrap().is_pending_copy());
+
+    app.update(mouse_event(MouseEventKind::Down(MouseButton::Left), 15, 15));
+    let state = app.selection_state.as_ref().unwrap();
+    assert!(
+        matches!(state, SelectionState::Dragging { .. }),
+        "new mouse-down must transition PendingCopy back to Dragging"
+    );
+}
+
+#[test]
+fn drag_on_pending_copy_is_noop() {
+    let mut app = test_app();
+    set_zone(&mut app, SelectionZone::Messages, Rect::new(0, 0, 80, 20));
+
+    app.update(mouse_event(MouseEventKind::Down(MouseButton::Left), 5, 5));
+    app.update(mouse_event(MouseEventKind::Drag(MouseButton::Left), 10, 10));
+    app.update(mouse_event(MouseEventKind::Up(MouseButton::Left), 10, 10));
+    assert!(app.selection_state.as_ref().unwrap().is_pending_copy());
+
+    let sel_before = *app.selection_state.as_ref().unwrap().sel();
+    app.update(mouse_event(MouseEventKind::Drag(MouseButton::Left), 50, 50));
+    assert!(
+        app.selection_state.as_ref().unwrap().is_pending_copy(),
+        "drag event must not change PendingCopy state"
+    );
+    let sel_after = *app.selection_state.as_ref().unwrap().sel();
+    assert_eq!(sel_before.normalized(), sel_after.normalized());
+}
+
+#[test]
+fn tick_edge_scroll_noop_on_pending_copy() {
+    let mut app = test_app();
+    set_zone(&mut app, SelectionZone::Messages, Rect::new(0, 0, 80, 20));
+
+    app.update(mouse_event(MouseEventKind::Down(MouseButton::Left), 5, 5));
+    app.update(mouse_event(MouseEventKind::Drag(MouseButton::Left), 10, 10));
+    app.update(mouse_event(MouseEventKind::Up(MouseButton::Left), 10, 10));
+    assert!(app.selection_state.as_ref().unwrap().is_pending_copy());
+
+    app.tick_edge_scroll();
+    assert!(
+        app.selection_state.as_ref().unwrap().is_pending_copy(),
+        "tick_edge_scroll must not alter PendingCopy"
+    );
+}
+
+#[test]
+fn pending_copy_not_animating() {
+    let mut app = test_app();
+    set_zone(&mut app, SelectionZone::Messages, Rect::new(0, 0, 80, 20));
+    app.run_id = 1;
+    app.update(agent_msg(AgentEvent::TextDelta { text: "x".into() }));
+    app.update(agent_msg(AgentEvent::Done {
+        usage: TokenUsage::default(),
+        num_turns: 1,
+        stop_reason: None,
+    }));
+
+    app.update(mouse_event(MouseEventKind::Down(MouseButton::Left), 5, 5));
+    app.update(mouse_event(MouseEventKind::Drag(MouseButton::Left), 10, 10));
+    app.update(mouse_event(MouseEventKind::Up(MouseButton::Left), 10, 10));
+    assert!(app.selection_state.as_ref().unwrap().is_pending_copy());
+    assert!(
+        !app.is_animating(),
+        "PendingCopy should not keep the app animating"
+    );
+}
+
+#[test]
+fn edge_scroll_direction_switches_on_drag_reversal() {
+    let mut app = test_app();
+    let zone = Rect::new(0, 5, 80, 10);
+    set_zone(&mut app, SelectionZone::Messages, zone);
+    app.active_chat().scroll_to_top();
+
+    app.update(mouse_event(MouseEventKind::Down(MouseButton::Left), 10, 8));
+    app.update(mouse_event(MouseEventKind::Drag(MouseButton::Left), 10, 4));
+
+    if let Some(SelectionState::Dragging { edge_scroll, .. }) = &app.selection_state {
+        assert!(
+            edge_scroll.as_ref().unwrap().dir > 0,
+            "scrolling up (positive dir)"
+        );
+    } else {
+        panic!("expected Dragging");
+    }
+
+    app.update(mouse_event(MouseEventKind::Drag(MouseButton::Left), 10, 16));
+    if let Some(SelectionState::Dragging { edge_scroll, .. }) = &app.selection_state {
+        assert!(
+            edge_scroll.as_ref().unwrap().dir < 0,
+            "scrolling down after reversal"
+        );
+    } else {
+        panic!("expected Dragging");
+    }
+}
+
+#[test]
+fn drag_back_into_area_clears_edge_scroll() {
+    let mut app = test_app();
+    let zone = Rect::new(0, 5, 80, 10);
+    set_zone(&mut app, SelectionZone::Messages, zone);
+    app.active_chat().scroll_to_top();
+
+    app.update(mouse_event(MouseEventKind::Down(MouseButton::Left), 10, 8));
+    app.update(mouse_event(MouseEventKind::Drag(MouseButton::Left), 10, 4));
+    assert!(app.selection_state.as_ref().unwrap().is_edge_scrolling());
+
+    app.update(mouse_event(MouseEventKind::Drag(MouseButton::Left), 10, 10));
+    assert!(
+        !app.selection_state.as_ref().unwrap().is_edge_scrolling(),
+        "dragging back into area must stop edge scroll"
+    );
+}
+
+#[test]
+fn mouse_down_outside_all_zones_ignored() {
+    let mut app = test_app();
+    set_zone(&mut app, SelectionZone::Messages, Rect::new(0, 0, 40, 10));
+
+    app.update(mouse_event(MouseEventKind::Down(MouseButton::Left), 50, 15));
+    assert!(
+        app.selection_state.is_none(),
+        "click outside zones must not create selection"
+    );
 }
 
 #[test]
@@ -1280,8 +1448,8 @@ fn mouse_down_in_input_creates_input_zone_selection() {
 
     app.update(mouse_event(MouseEventKind::Down(MouseButton::Left), 10, 16));
     let state = app.selection_state.as_ref().unwrap();
-    assert_eq!(state.sel.zone, SelectionZone::Input);
-    assert_eq!(state.sel.area, input);
+    assert_eq!(state.sel().zone, SelectionZone::Input);
+    assert_eq!(state.sel().area, input);
 }
 
 #[test]
@@ -1789,7 +1957,7 @@ fn overlay_zone_click_gating() {
 
     app.update(mouse_event(MouseEventKind::Down(MouseButton::Left), 20, 5));
     let state = app.selection_state.as_ref().unwrap();
-    assert_eq!(state.sel.zone, SelectionZone::Overlay);
+    assert_eq!(state.sel().zone, SelectionZone::Overlay);
 }
 
 fn streaming_app_with_history() -> App {

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -297,7 +297,7 @@ impl App {
             if self
                 .selection_state
                 .as_ref()
-                .is_some_and(|s| s.sel.zone == SelectionZone::Overlay)
+                .is_some_and(|s| s.sel().zone == SelectionZone::Overlay)
             {
                 self.selection_state = None;
             }
@@ -309,16 +309,17 @@ impl App {
             return;
         };
 
-        let zone = state.sel.zone;
+        let sel = state.sel();
+        let zone = sel.zone;
         let scroll = self.scroll_offset(zone);
-        if let Some(screen_sel) = state.sel.to_screen(scroll) {
+        if let Some(screen_sel) = sel.to_screen(scroll) {
             let highlight_area = self.zones[zone.idx()]
                 .map(|z| z.highlight_area)
                 .unwrap_or_default();
             selection::apply_highlight(frame.buffer_mut(), highlight_area, &screen_sel);
         }
-        if state.copy_on_release {
-            let sel = state.sel;
+        if state.is_pending_copy() {
+            let sel = *sel;
             self.copy_selection(frame.buffer_mut(), &sel, render_chat);
         }
     }

--- a/maki-ui/src/clipboard.rs
+++ b/maki-ui/src/clipboard.rs
@@ -48,17 +48,18 @@ impl ClipboardState {
 
         #[cfg(target_os = "linux")]
         {
-            clipboard
+            let primary = clipboard
                 .set()
                 .clipboard(LinuxClipboardKind::Primary)
-                .text(text)
-                .and_then(|()| {
-                    clipboard
-                        .set()
-                        .clipboard(LinuxClipboardKind::Clipboard)
-                        .text(text)
-                })
-                .map_err(|e| e.to_string())
+                .text(text);
+            let system = clipboard
+                .set()
+                .clipboard(LinuxClipboardKind::Clipboard)
+                .text(text);
+            match (primary, system) {
+                (_, Ok(())) | (Ok(()), _) => Ok(()),
+                (Err(p), Err(s)) => Err(format!("primary: {p}; clipboard: {s}")),
+            }
         }
 
         #[cfg(not(target_os = "linux"))]
@@ -132,22 +133,20 @@ mod tests {
     }
 
     #[test]
-    fn each_backend_receives_the_input_text_verbatim() {
-        // Force native to fail so osc52 also runs; capture what each got.
-        let native_input = Cell::new(String::new());
-        let osc52_input = Cell::new(String::new());
-        let _ = ClipboardState::copy_text_impl(
-            "the payload",
-            |t| {
-                native_input.set(t.to_string());
-                Err("fail".into())
-            },
-            |t| {
-                osc52_input.set(t.to_string());
+    fn whitespace_only_text_is_not_noop() {
+        let native_called = Cell::new(false);
+        let result = ClipboardState::copy_text_impl(
+            "   \n\t",
+            |_| {
+                native_called.set(true);
                 Ok(())
             },
+            |_| Ok(()),
         );
-        assert_eq!(native_input.take(), "the payload");
-        assert_eq!(osc52_input.take(), "the payload");
+        assert!(matches!(result, Ok(CopyResult::Copied)));
+        assert!(
+            native_called.get(),
+            "whitespace-only text must still be copied"
+        );
     }
 }

--- a/maki-ui/src/selection.rs
+++ b/maki-ui/src/selection.rs
@@ -1,26 +1,23 @@
 //! Mouse selection + clipboard copy.
 //!
-//! We call `EnableMouseCapture` for scroll events, which kills the terminal's
-//! native text selection. This module reimplements it.
+//! Enabling mouse capture (for scroll) kills the terminal's native text
+//! selection, so we reimplement it here. A few things that are easy to get
+//! wrong:
 //!
-//! Key design decisions:
+//! Positions are stored in doc space (`DocPos`), not screen space, because
+//! screen coords go stale the moment the user scrolls.
 //!
-//! - Selection stores positions in doc space (`DocPos`), not screen space.
-//!   Screen positions go stale on scroll; doc positions don't.
+//! Copy runs inside `view()`, not on mouse-up. The terminal buffer only
+//! holds valid cell data during rendering, so that is the only moment we
+//! can scrape the text. Code bar prefixes (`│ `) are stripped during
+//! scraping so you get clean source.
 //!
-//! - Copy happens inside `view()`, not on mouse-up. The terminal buffer only
-//!   has valid cell data during rendering.
+//! While a selection is active, `has_selection` freezes auto-scroll in the
+//! messages panel so the viewport stays put while the user drags.
 //!
-//! - All selections extract from the rendered buffer via cell scraping.
-//!   Code block `| ` prefixes are stripped. Truncated content stays truncated.
-//!
-//! - `has_selection` freezes auto-scroll in `MessagesPanel::view()` so the
-//!   viewport doesn't jump while the user is dragging.
-//!
-//! - Content is rendered 1 column narrower than the area to reserve space for
-//!   the scrollbar. `highlight_area` and `msg_area()` reflect this content
-//!   width. `apply_highlight` and `append_rows` use `area.width - 1` for the
-//!   rightmost content column index.
+//! The rightmost column of each area is reserved for the scrollbar, so
+//! `highlight_area` / `msg_area()` are 1 column narrower than the full
+//! area and all column math uses `width - 1`.
 
 use std::cmp::Ordering;
 use std::time::Instant;
@@ -208,14 +205,39 @@ pub struct EdgeScroll {
     pub last_tick: Instant,
 }
 
-/// `copy_on_release`: set on mouse-up, consumed in next `view()`. We can't
-/// copy on mouse-up because the terminal buffer is only valid during rendering.
-/// `last_drag_col`: remembered for edge-scroll ticks that lack mouse coords.
-pub struct SelectionState {
-    pub sel: Selection,
-    pub copy_on_release: bool,
-    pub edge_scroll: Option<EdgeScroll>,
-    pub last_drag_col: u16,
+/// Two-phase lifecycle: `Dragging` while the mouse is held, then
+/// `PendingCopy` on release so the next `view()` can scrape the buffer.
+pub enum SelectionState {
+    Dragging {
+        sel: Selection,
+        edge_scroll: Option<EdgeScroll>,
+        last_drag_col: u16,
+    },
+    PendingCopy {
+        sel: Selection,
+    },
+}
+
+impl SelectionState {
+    pub fn sel(&self) -> &Selection {
+        match self {
+            Self::Dragging { sel, .. } | Self::PendingCopy { sel } => sel,
+        }
+    }
+
+    pub fn is_pending_copy(&self) -> bool {
+        matches!(self, Self::PendingCopy { .. })
+    }
+
+    pub fn is_edge_scrolling(&self) -> bool {
+        matches!(
+            self,
+            Self::Dragging {
+                edge_scroll: Some(_),
+                ..
+            }
+        )
+    }
 }
 
 #[derive(Clone, Debug, Default)]
@@ -279,8 +301,8 @@ fn is_code_wrap_continuation(line: &Line<'_>) -> bool {
         .is_some_and(|s| s.content.as_ref() == CODE_BAR_WRAP)
 }
 
-/// Screen region + optional raw source text for copy. If `raw_text` is
-/// non-empty and the region is fully selected, raw text is used as-is.
+/// When `raw_text` is set and the region is fully selected we use the
+/// source text verbatim instead of scraping cells.
 #[derive(Default)]
 pub struct ContentRegion<'a> {
     pub area: Rect,
@@ -342,7 +364,7 @@ pub(crate) fn col_range(ss: &ScreenSelection, left: u16, right: u16, row: u16) -
     (col_start, col_end)
 }
 
-/// Flips `REVERSED` on selected cells. Skips last column (scrollbar).
+/// Last column is the scrollbar, so we skip it.
 pub fn apply_highlight(buf: &mut Buffer, area: Rect, ss: &ScreenSelection) {
     if area.width == 0 || area.height == 0 {
         return;
@@ -382,8 +404,8 @@ pub(crate) fn strip_code_bar_prefix(
     prefix_len
 }
 
-/// Trailing whitespace trimmed per line; consecutive trailing blank lines
-/// collapsed via `pending_newlines`.
+/// Trailing whitespace is trimmed per line. Consecutive blank lines are
+/// collapsed so we don't emit a wall of empty newlines.
 pub(crate) fn append_rows(
     buf: &Buffer,
     area: Rect,
@@ -443,7 +465,7 @@ pub(crate) fn append_rows(
     }
 }
 
-/// Regions searched in reverse (overlays win). Uncovered rows skipped.
+/// Searched in reverse so overlays win over what is behind them.
 pub fn extract_selected_text(
     buf: &Buffer,
     ss: &ScreenSelection,
@@ -675,6 +697,11 @@ mod tests {
     #[test_case(doc(5,3),  doc(12,8),  Rect::new(0,0,80,10),  0, Some(ss(5,3,9,79))     ; "cursor_below_area")]
     #[test_case(doc(12,5), doc(3,2),   Rect::new(0,0,80,10),  0, Some(ss(3,2,9,79))     ; "backward_from_below")]
     #[test_case(doc(58,5), doc(55,3),  Rect::new(0,2,80,20), 50, Some(ss(7,3,10,5))     ; "edge_scroll_reversal")]
+    #[test_case(doc(9,0),  doc(9,5),   Rect::new(0,0,80,10),  0, Some(ss(9,0,9,5))      ; "at_viewport_bottom")]
+    #[test_case(doc(9,0),  doc(9,5),   Rect::new(0,0,80,10), 10, None                   ; "scrolled_past_bottom")]
+    #[test_case(doc(3,10), doc(12,50), Rect::new(0,0,80,10),  5, Some(ss(0,0,7,50))     ; "start_above_viewport")]
+    #[test_case(doc(2,5),  doc(25,70), Rect::new(0,0,80,10),  5, Some(ss(0,0,9,79))     ; "both_ends_outside")]
+    #[test_case(doc(0,8),  doc(5,20),  Rect::new(5,3,40,10),  0, Some(ss(3,8,8,20))     ; "nonzero_area_offset")]
     fn to_screen_cases(
         anchor: DocPos,
         cursor: DocPos,
@@ -873,5 +900,109 @@ mod tests {
         };
         let text = extract_selected_text(&buf, &ss(0, 0, 1, 19), &[region]);
         assert_eq!(text, "long_variable_name_here");
+    }
+
+    #[test]
+    fn selection_empty_until_updated() {
+        let area = Rect::new(0, 0, 80, 20);
+        let mut sel = Selection::start(5, 10, area, SelectionZone::Messages, 0);
+        assert!(sel.is_empty());
+        sel.update(6, 10, 0);
+        assert!(!sel.is_empty());
+    }
+
+    #[test]
+    fn selection_start_col_clamped() {
+        let area = Rect::new(10, 5, 40, 20);
+        let right = Selection::start(8, 200, area, SelectionZone::Messages, 0);
+        assert_eq!(right.normalized().0.col, 49, "clamped to area right edge");
+        let left = Selection::start(8, 0, area, SelectionZone::Messages, 0);
+        assert_eq!(left.normalized().0.col, 10, "clamped to area left edge");
+    }
+
+    #[test]
+    fn covers_rect_empty_area() {
+        let sel = ss(0, 0, 10, 10);
+        assert!(!sel.covers_rect(Rect::new(0, 0, 0, 5)));
+        assert!(!sel.covers_rect(Rect::new(0, 0, 5, 0)));
+        assert!(!sel.covers_rect(Rect::ZERO));
+    }
+
+    #[test]
+    fn line_breaks_bitmap_zero_height_ignored() {
+        let lb = LineBreaks::from_heights([1, 0, 0, 1].iter().copied());
+        assert!(lb.is_line_start(0));
+        assert!(lb.is_line_start(1));
+        assert!(!lb.is_line_start(2));
+    }
+
+    #[test]
+    fn line_breaks_empty_iterator() {
+        let lb = LineBreaks::from_heights(std::iter::empty());
+        assert!(matches!(lb, LineBreaks::Bitmap(ref v) if v.is_empty()));
+    }
+
+    #[test]
+    fn line_breaks_bitmap_query_beyond_stored_bits() {
+        let lb = LineBreaks::from_heights([1].iter().copied());
+        assert!(!lb.is_line_start(100));
+    }
+
+    #[test]
+    fn extract_trailing_blank_lines_collapsed() {
+        let area = Rect::new(0, 0, 10, 4);
+        let mut buf = Buffer::empty(area);
+        buf.set_string(0, 0, "Line A    ", Style::default());
+        buf.set_string(0, 1, "          ", Style::default());
+        buf.set_string(0, 2, "          ", Style::default());
+        buf.set_string(0, 3, "Line D    ", Style::default());
+        let region = ContentRegion {
+            area,
+            ..Default::default()
+        };
+        let text = extract_selected_text(&buf, &ss(0, 0, 3, 9), &[region]);
+        assert_eq!(
+            text, "Line A\n\n\nLine D",
+            "two blank rows produce two pending newlines"
+        );
+    }
+
+    #[test]
+    fn extract_single_cell_selection() {
+        let (buf, area) = test_buffer();
+        let region = ContentRegion {
+            area,
+            ..Default::default()
+        };
+        let text = extract_selected_text(&buf, &ss(0, 0, 0, 0), &[region]);
+        assert_eq!(text, "H");
+    }
+
+    #[test]
+    fn col_range_single_row_selection() {
+        let sel = ss(5, 10, 5, 20);
+        let (start, end) = col_range(&sel, 0, 79, 5);
+        assert_eq!(start, 10);
+        assert_eq!(end, 20);
+    }
+
+    #[test]
+    fn col_range_mid_row_full_width() {
+        let sel = ss(3, 10, 7, 50);
+        let (start, end) = col_range(&sel, 0, 79, 5);
+        assert_eq!(start, 0, "mid row gets full left");
+        assert_eq!(end, 79, "mid row gets full right");
+    }
+
+    #[test]
+    fn zone_at_returns_none_when_outside() {
+        let mut zones: ZoneRegistry = [None; SelectionZone::COUNT];
+        assert!(zone_at(&zones, 10, 10).is_none(), "no zones registered");
+        zones[SelectionZone::Messages.idx()] = Some(SelectableZone {
+            area: Rect::new(0, 0, 80, 20),
+            highlight_area: Rect::new(0, 0, 80, 20),
+            zone: SelectionZone::Messages,
+        });
+        assert!(zone_at(&zones, 25, 10).is_none(), "outside all zones");
     }
 }


### PR DESCRIPTION
Copy is deferred from mouse-up to the next `view()` call because text extraction needs the terminal buffer. `handle_key` and `Msg::Scroll` were clearing `selection_state` before `view()` ran, so any input event between mouse-up and render killed the pending copy.

Replaced the `copy_on_release` bool with a proper `SelectionState` enum (`Dragging` / `PendingCopy`) so the pending state is protected from stray clears. Linux clipboard writes are now independent: `PRIMARY` and `CLIPBOARD` are attempted separately instead of chained, so one failing no longer blocks the other.