### PR TITLE
agent: fix MCP tools not loaded in headless mode

### DIFF
--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -22,6 +22,7 @@ pub mod transport;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
 
 use arc_swap::{ArcSwap, Guard};
 use serde_json::{Value, json};
@@ -38,6 +39,7 @@ use self::transport::McpTransport;
 
 const SEPARATOR: &str = "__";
 pub const UNKNOWN_MCP: &str = "unknown_mcp";
+const MCP_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
 struct McpToolDef {
     qualified_name: Arc<str>,
@@ -275,6 +277,25 @@ impl McpHandle {
             arr.extend(self.index.load().descriptors.iter().cloned());
         }
     }
+
+    pub async fn shutdown(&self) {
+        let (ack_tx, ack_rx) = flume::bounded(1);
+        self.send(McpCommand::Shutdown { ack: ack_tx });
+        let finished = futures_lite::future::or(
+            async {
+                let _ = ack_rx.recv_async().await;
+                true
+            },
+            async {
+                smol::Timer::after(MCP_SHUTDOWN_TIMEOUT).await;
+                false
+            },
+        )
+        .await;
+        if !finished {
+            warn!("MCP shutdown timed out after {MCP_SHUTDOWN_TIMEOUT:?}");
+        }
+    }
 }
 
 pub async fn start(cwd: &Path) -> Option<McpHandle> {
@@ -288,10 +309,13 @@ pub async fn start_with_config(config: McpConfig) -> Option<McpHandle> {
         return None;
     }
 
-    let inner = parse_entries(config);
+    let mut inner = parse_entries(config);
+
+    start_enabled(&mut inner).await;
+    inner.generation += 1;
+
     let snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot::default()));
     let index: Arc<ArcSwap<ToolIndex>> = Arc::new(ArcSwap::from_pointee(ToolIndex::default()));
-
     publish(&inner, &index, &snapshot);
 
     let (cmd_tx, cmd_rx) = flume::unbounded();
@@ -300,20 +324,6 @@ pub async fn start_with_config(config: McpConfig) -> Option<McpHandle> {
         index: Arc::clone(&index),
         snapshot: Arc::clone(&snapshot),
     };
-
-    smol::spawn(run_with_init(inner, index, snapshot, cmd_rx)).detach();
-    Some(handle)
-}
-
-async fn run_with_init(
-    mut inner: McpManagerInner,
-    index: Arc<ArcSwap<ToolIndex>>,
-    snapshot: Arc<ArcSwap<McpSnapshot>>,
-    cmd_rx: flume::Receiver<McpCommand>,
-) {
-    start_enabled(&mut inner).await;
-    inner.generation += 1;
-    publish(&inner, &index, &snapshot);
 
     info!(
         running = inner
@@ -325,7 +335,8 @@ async fn run_with_init(
         "MCP servers initialized"
     );
 
-    run(inner, index, snapshot, cmd_rx).await;
+    smol::spawn(run(inner, index, snapshot, cmd_rx)).detach();
+    Some(handle)
 }
 
 async fn run(
@@ -334,6 +345,7 @@ async fn run(
     snapshot: Arc<ArcSwap<McpSnapshot>>,
     cmd_rx: flume::Receiver<McpCommand>,
 ) {
+    let mut ack: Option<flume::Sender<()>> = None;
     while let Ok(cmd) = cmd_rx.recv_async().await {
         match cmd {
             McpCommand::Toggle { server, enabled } => {
@@ -342,16 +354,19 @@ async fn run(
             McpCommand::Reconnect { server, url, token } => {
                 handle_reconnect(&mut inner, &server, &url, &token).await;
             }
-            McpCommand::Shutdown { ack } => {
-                shutdown_all(&mut inner).await;
-                inner.generation += 1;
-                publish(&inner, &index, &snapshot);
-                let _ = ack.try_send(());
-                return;
+            McpCommand::Shutdown { ack: tx } => {
+                ack = Some(tx);
+                break;
             }
         }
         inner.generation += 1;
         publish(&inner, &index, &snapshot);
+    }
+    shutdown_all(&mut inner).await;
+    inner.generation += 1;
+    publish(&inner, &index, &snapshot);
+    if let Some(tx) = ack {
+        let _ = tx.try_send(());
     }
 }
 

--- a/maki-ui/src/agent/mod.rs
+++ b/maki-ui/src/agent/mod.rs
@@ -28,8 +28,6 @@ use self::agent_loop::AgentLoop;
 use self::command_router::spawn_command_router;
 pub(crate) use self::shared_queue::{QueueSender, QueuedMessage};
 
-const MCP_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
-
 pub(crate) struct ModelSlot {
     pub(crate) model: Model,
     pub(crate) provider: Arc<dyn Provider>,
@@ -157,29 +155,10 @@ impl AgentHandles {
                 warn!("agent did not finish within {timeout:?}, forcing shutdown");
             }
 
-            if let Some(handle) = mcp_handle {
-                shutdown_mcp(&handle).await;
+            if let Some(ref handle) = mcp_handle {
+                handle.shutdown().await;
             }
         });
-    }
-}
-
-async fn shutdown_mcp(handle: &McpHandle) {
-    let (ack_tx, ack_rx) = flume::bounded(1);
-    handle.send(McpCommand::Shutdown { ack: ack_tx });
-    let finished = futures_lite::future::or(
-        async {
-            let _ = ack_rx.recv_async().await;
-            true
-        },
-        async {
-            smol::Timer::after(MCP_SHUTDOWN_TIMEOUT).await;
-            false
-        },
-    )
-    .await;
-    if !finished {
-        warn!("MCP shutdown timed out after {MCP_SHUTDOWN_TIMEOUT:?}");
     }
 }
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -160,6 +160,7 @@ pub fn run(
     if let Some(ref handle) = mcp_handle {
         handle.extend_tools(&mut tools);
     }
+    let mcp_for_agent = mcp_handle.clone();
 
     let system = agent::build_system_prompt(&vars, &mode, &instructions.text);
 
@@ -220,7 +221,7 @@ pub fn run(
             },
         )
         .with_loaded_instructions(instructions.loaded)
-        .with_mcp(mcp_handle);
+        .with_mcp(mcp_for_agent);
         let outcome = agent.run(input).await;
         if let Err(e) = outcome.result {
             error!(error = %e, "agent error");
@@ -346,15 +347,13 @@ pub fn run(
         }
     }
     smol::block_on(async {
-        futures_lite::future::or(
-            async {
-                agent_task.await;
-            },
-            async {
-                smol::Timer::after(AGENT_SHUTDOWN_TIMEOUT).await;
-            },
-        )
+        futures_lite::future::or(agent_task, async {
+            smol::Timer::after(AGENT_SHUTDOWN_TIMEOUT).await;
+        })
         .await;
+        if let Some(ref handle) = mcp_handle {
+            handle.shutdown().await;
+        }
     });
 
     let duration_ms = start.elapsed().as_millis();


### PR DESCRIPTION
`mcp::start()` returned the handle before servers finished connecting. The actual init ran on a detached task, so every caller that read tools right after `start()` got an empty `ToolIndex`. Print mode always hit this race.

Inlined the init into `start_with_config()` so it awaits `start_enabled()` before returning. If you have a handle, it is ready. Also moved `shutdown_mcp` into `mcp::shutdown()` so print mode can clean up child processes too (it never did before).