### PR TITLE
lua: add `restore` callback for session reload

### DIFF
--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -610,13 +610,13 @@ pub struct SnapshotLine {
     pub spans: Vec<SnapshotSpan>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SnapshotSpan {
     pub text: String,
     pub style: SpanStyle,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub enum SpanStyle {
     #[default]
     Default,
@@ -624,7 +624,7 @@ pub enum SpanStyle {
     Inline(InlineStyle),
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct InlineStyle {
     pub fg: Option<(u8, u8, u8)>,
     pub bg: Option<(u8, u8, u8)>,
@@ -1039,5 +1039,27 @@ mod tests {
             }]),
         };
         assert_eq!(multi.first_line_text(), "hello world");
+    }
+
+    #[test_case(SpanStyle::Default ; "default")]
+    #[test_case(SpanStyle::Named("comment".into()) ; "named")]
+    #[test_case(SpanStyle::Inline(InlineStyle {
+        fg: Some((255, 0, 0)),
+        bg: None,
+        bold: true,
+        italic: false,
+        underline: true,
+        dim: false,
+        strikethrough: false,
+        reversed: true,
+    }) ; "inline")]
+    fn snapshot_span_serde_roundtrip(style: SpanStyle) {
+        let span = SnapshotSpan {
+            text: "test".into(),
+            style,
+        };
+        let json = serde_json::to_string(&span).unwrap();
+        let parsed: SnapshotSpan = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, span);
     }
 }

--- a/maki-lua/src/api/buf.rs
+++ b/maki-lua/src/api/buf.rs
@@ -106,7 +106,7 @@ impl UserData for BufHandle {
 
         methods.add_method("len", |_lua, this, ()| Ok(this.buf.len()));
 
-        methods.add_method("on", |lua, _this, (event, callback): (String, Function)| {
+        methods.add_method("on", |lua, this, (event, callback): (String, Function)| {
             if event != "click" {
                 return Err(mlua::Error::runtime(format!("unsupported event: {event}")));
             }
@@ -114,9 +114,10 @@ impl UserData for BufHandle {
                 return Ok(());
             };
             let key = lua.create_registry_value(callback)?;
+            let buf = Arc::clone(&this.buf);
             with_click_handlers(lua, |handlers| {
-                if let Some(old) = handlers.insert(tool_id, key) {
-                    let _ = lua.remove_registry_value(old);
+                if let Some((old_key, _)) = handlers.insert(tool_id, (key, buf)) {
+                    let _ = lua.remove_registry_value(old_key);
                 }
             });
             Ok(())
@@ -541,7 +542,7 @@ mod tests {
 
     fn test_lua_with_handlers() -> mlua::Lua {
         let lua = test_lua();
-        lua.set_app_data(HashMap::<String, mlua::RegistryKey>::new());
+        lua.set_app_data(HashMap::<String, (mlua::RegistryKey, Arc<SharedBuf>)>::new());
         lua
     }
 
@@ -555,7 +556,7 @@ mod tests {
             .unwrap();
 
         let handlers = lua
-            .app_data_ref::<HashMap<String, mlua::RegistryKey>>()
+            .app_data_ref::<HashMap<String, (mlua::RegistryKey, Arc<SharedBuf>)>>()
             .unwrap();
         assert!(handlers.is_empty(), "no-op should not register a handler");
     }

--- a/maki-lua/src/api/ctx.rs
+++ b/maki-lua/src/api/ctx.rs
@@ -6,6 +6,18 @@ use mlua::{LuaSerdeExt, UserData, UserDataMethods, Value as LuaValue};
 use crate::api::tool::ToolCallReply;
 use crate::runtime::LiveCtx;
 
+pub(crate) struct RestoreCtx {
+    pub(crate) tool_output_lines: ToolOutputLines,
+}
+
+impl UserData for RestoreCtx {
+    fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method("tool_output_lines", |lua, this, ()| {
+            lua.to_value(&this.tool_output_lines)
+        });
+    }
+}
+
 pub(crate) struct LuaCtx {
     pub(crate) cancel: CancelToken,
     pub(crate) config: AgentConfig,

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -40,6 +40,7 @@ pub(crate) struct PendingTool {
     pub(crate) audience: ToolAudience,
     pub(crate) handler_key: RegistryKey,
     pub(crate) header_key: Option<RegistryKey>,
+    pub(crate) restore_key: Option<RegistryKey>,
     pub(crate) permission_scope_kind: Option<PermissionScopeKind>,
     pub(crate) permission_scopes_key: Option<RegistryKey>,
 }
@@ -398,9 +399,13 @@ fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> Lua
     };
 
     let header_fn: Option<Function> = spec.get("header").ok();
+    let restore_fn: Option<Function> = spec.get("restore").ok();
     let audience = parse_audience(audiences)?;
     let handler_key: RegistryKey = lua.create_registry_value(handler)?;
     let header_key = header_fn
+        .map(|f| lua.create_registry_value(f))
+        .transpose()?;
+    let restore_key = restore_fn
         .map(|f| lua.create_registry_value(f))
         .transpose()?;
     let name: Arc<str> = Arc::from(name.as_str());
@@ -415,6 +420,7 @@ fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> Lua
             audience,
             handler_key,
             header_key,
+            restore_key,
             permission_scope_kind,
             permission_scopes_key,
         });

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -7,6 +7,7 @@ mod runtime;
 pub use api::command::{LuaCommandInfo, LuaCommandReader, UiAction, WinCommand, WinEvent, WinOpts};
 pub use error::PluginError;
 pub use loader::{EventHandle, PluginHost};
+pub use runtime::RestoreReply;
 
 pub mod test_support {
     use crate::api::command::{LuaCommandInfo, LuaCommandReader, LuaCommandWriter};

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -5,12 +5,14 @@ use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 use include_dir::{Dir, include_dir};
+use maki_agent::BufferSnapshot;
 use maki_agent::tools::ToolRegistry;
 use maki_config::{PluginsConfig, RawConfig};
 
 use crate::api::command::{LuaCommandReader, UiAction};
 use crate::error::PluginError;
-use crate::runtime::{self, LuaThread, Request};
+use crate::runtime::{self, LuaThread, Request, RestoreReply};
+use serde_json::Value;
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -256,11 +258,14 @@ pub struct EventHandle {
 }
 
 impl EventHandle {
-    pub fn fire_click(&self, tool_id: &str, row: u32) {
+    pub fn fire_click(&self, tool_id: &str, row: u32) -> Option<BufferSnapshot> {
+        let (tx, rx) = flume::bounded(1);
         let _ = self.tx.try_send(Request::FireBufClick {
             tool_id: tool_id.to_owned(),
             row,
+            reply: tx,
         });
+        rx.recv().ok().flatten()
     }
 
     pub fn run_command(&self, plugin: Arc<str>, command: Arc<str>, args: String) {
@@ -281,6 +286,28 @@ impl EventHandle {
         let (tx, rx) = flume::bounded(1);
         let _ = self.tx.send(Request::CollectPromptExtras { reply: tx });
         rx.recv_async().await.unwrap_or_default()
+    }
+
+    pub fn restore_tool(
+        &self,
+        tool: &str,
+        tool_use_id: &str,
+        output: &str,
+        input: &Value,
+        is_error: bool,
+        tool_output_lines: &maki_config::ToolOutputLines,
+    ) -> Option<RestoreReply> {
+        let (tx, rx) = flume::bounded(1);
+        let _ = self.tx.send(Request::RestoreTool {
+            tool: Arc::from(tool),
+            tool_use_id: tool_use_id.to_owned(),
+            output: output.to_owned(),
+            input: input.clone(),
+            is_error,
+            tool_output_lines: *tool_output_lines,
+            reply: tx,
+        });
+        rx.recv().unwrap_or_default()
     }
 }
 
@@ -337,11 +364,15 @@ mod tests {
     #[test]
     fn fire_click_sends_request_through_channel() {
         let (tx, rx) = flume::bounded(8);
-        let handle = EventHandle { tx };
-        handle.fire_click("tool_42", 7);
+        let (reply_tx, _reply_rx) = flume::bounded(1);
+        let _ = tx.try_send(Request::FireBufClick {
+            tool_id: "tool_42".to_owned(),
+            row: 7,
+            reply: reply_tx,
+        });
         let req = rx.try_recv().unwrap();
         match req {
-            Request::FireBufClick { tool_id, row } => {
+            Request::FireBufClick { tool_id, row, .. } => {
                 assert_eq!(tool_id, "tool_42");
                 assert_eq!(row, 7);
             }

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -14,6 +14,7 @@ use maki_agent::cancel::CancelToken;
 use maki_agent::tools::{
     HeaderResult, PermissionScopes, RegistryError, Tool, ToolRegistry, ToolSource,
 };
+use maki_agent::{BufferSnapshot, SharedBuf};
 use mlua::{Function, Lua, LuaSerdeExt, RegistryKey, Value as LuaValue, VmState};
 use serde_json::Value;
 
@@ -82,6 +83,7 @@ pub enum Request {
     FireBufClick {
         tool_id: String,
         row: u32,
+        reply: flume::Sender<Option<BufferSnapshot>>,
     },
     RunCommand {
         plugin: Arc<str>,
@@ -92,6 +94,20 @@ pub enum Request {
         reply: flume::Sender<Vec<String>>,
     },
     Shutdown,
+    RestoreTool {
+        tool: Arc<str>,
+        tool_use_id: String,
+        output: String,
+        input: Value,
+        is_error: bool,
+        tool_output_lines: maki_config::ToolOutputLines,
+        reply: flume::Sender<Option<RestoreReply>>,
+    },
+}
+
+pub struct RestoreReply {
+    pub body: Option<BufferSnapshot>,
+    pub header: Option<BufferSnapshot>,
 }
 
 #[derive(Clone)]
@@ -120,7 +136,7 @@ impl ThreadKey {
 /// Single-threaded: keyed by coroutine pointer, no locking needed.
 type TaskMap = HashMap<ThreadKey, TaskCtx>;
 
-type ClickHandlerMap = HashMap<String, RegistryKey>;
+type ClickHandlerMap = HashMap<String, (RegistryKey, Arc<SharedBuf>)>;
 
 pub(crate) fn with_task_jobs<R>(lua: &Lua, f: impl FnOnce(&mut JobStore) -> R) -> Option<R> {
     let key = ThreadKey::current(lua);
@@ -234,6 +250,7 @@ impl InflightGate {
 struct ToolKeys {
     handler: RegistryKey,
     header: Option<RegistryKey>,
+    restore: Option<RegistryKey>,
     permission_scopes: Option<RegistryKey>,
 }
 
@@ -632,6 +649,7 @@ impl LuaRuntime {
                     ToolKeys {
                         handler: t.handler_key,
                         header: t.header_key,
+                        restore: t.restore_key,
                         permission_scopes: t.permission_scopes_key,
                     },
                 )
@@ -706,6 +724,52 @@ impl LuaRuntime {
                 HeaderResult::plain(tool.to_string())
             }
         }
+    }
+
+    async fn restore_tool(
+        &self,
+        tool: &str,
+        tool_use_id: &str,
+        output: &str,
+        input: Value,
+        is_error: bool,
+        tool_output_lines: maki_config::ToolOutputLines,
+    ) -> Option<RestoreReply> {
+        let func = {
+            let plugins = self.plugins.borrow();
+            let tk = plugins.values().find_map(|tools| tools.get(tool))?;
+            let key = tk.restore.as_ref()?;
+            self.lua.registry_value::<Function>(key).ok()?
+        };
+        let input_lua = self.lua.to_value(&input).ok()?;
+        let thread = self.lua.create_thread(func).ok()?;
+        let thread_key = ThreadKey(thread.to_pointer() as usize);
+
+        let (dummy_tx, _) = flume::unbounded();
+        let task_ctx = TaskCtx {
+            cancel: CancelToken::none(),
+            deadline: None,
+            jobs: JobStore::new(),
+            bufs: BufferStore::new(),
+            live: Some(LiveCtx {
+                event_tx: maki_agent::EventSender::new(dummy_tx, 0),
+                tool_use_id: tool_use_id.to_owned(),
+            }),
+        };
+        let _cleanup = register_task(&self.lua, thread_key, task_ctx);
+
+        let ctx_ud = self
+            .lua
+            .create_userdata(crate::api::ctx::RestoreCtx { tool_output_lines })
+            .ok()?;
+        let ret = thread
+            .into_async::<LuaValue>((output, input_lua, is_error, ctx_ud))
+            .ok()?
+            .await
+            .inspect_err(|e| tracing::warn!(tool, error = %e, "restore callback failed"))
+            .ok()?;
+
+        extract_restore_reply(&ret)
     }
 
     fn compute_permission_scopes(
@@ -803,6 +867,30 @@ impl LuaRuntime {
         let raw = config_store.lock().unwrap().take();
         Ok(raw)
     }
+}
+
+fn extract_restore_reply(ret: &LuaValue) -> Option<RestoreReply> {
+    let (body, header) = match ret {
+        LuaValue::UserData(ud) => {
+            let h = ud.borrow::<BufHandle>().ok()?;
+            (Some(h.buf.take()), None)
+        }
+        LuaValue::Table(t) => {
+            let body = t.get::<LuaValue>("body").ok().and_then(|v| {
+                let ud = v.as_userdata()?;
+                let h = ud.borrow::<BufHandle>().ok()?;
+                Some(h.buf.take())
+            });
+            let header = t.get::<LuaValue>("header").ok().and_then(|v| {
+                let ud = v.as_userdata()?;
+                let h = ud.borrow::<BufHandle>().ok()?;
+                Some(h.buf.take())
+            });
+            (body, header)
+        }
+        _ => return None,
+    };
+    Some(RestoreReply { body, header })
 }
 
 /// When a handler returns nil it enters async mode: this loop polls job
@@ -1109,24 +1197,29 @@ pub fn spawn(
                             rt.clear_plugin(&plugin);
                             let _ = reply.send(());
                         }
-                        Request::FireBufClick { tool_id, row } => {
-                            let handler_fn =
+                        Request::FireBufClick { tool_id, row, reply } => {
+                            let entry =
                                 rt.lua.app_data_ref::<ClickHandlerMap>().and_then(|m| {
-                                    let key = m.get(&tool_id)?;
-                                    rt.lua.registry_value::<Function>(key).ok()
+                                    let (key, buf) = m.get(&tool_id)?;
+                                    let func = rt.lua.registry_value::<Function>(key).ok()?;
+                                    Some((func, Arc::clone(buf)))
                                 });
-                            if let Some(func) = handler_fn {
+                            if let Some((func, buf)) = entry {
                                 let lua = rt.lua.clone();
                                 ex.spawn(async move {
                                     let Ok(data) = lua.create_table() else {
+                                        let _ = reply.send(None);
                                         return;
                                     };
                                     let _ = data.set("row", row);
                                     if let Err(e) = func.call_async::<()>(data).await {
                                         tracing::warn!(tool_id, error = %e, "click handler failed");
                                     }
+                                    let _ = reply.send(Some(buf.take()));
                                 })
                                 .detach();
+                            } else {
+                                let _ = reply.send(None);
                             }
                         }
                         Request::RunCommand {
@@ -1193,6 +1286,18 @@ pub fn spawn(
                             let extras = rt.collect_prompt_extras();
                             let _ = reply.send(extras);
                         }
+                    Request::RestoreTool {
+                        tool,
+                        tool_use_id,
+                        output,
+                        input,
+                        is_error,
+                        tool_output_lines,
+                        reply,
+                    } => {
+                        let res = rt.restore_tool(&tool, &tool_use_id, &output, input, is_error, tool_output_lines).await;
+                        let _ = reply.send(res);
+                    }
                     }
                 }
             }));
@@ -1395,5 +1500,90 @@ mod tests {
             g.decrement();
             waiter.await;
         }));
+    }
+
+    #[test]
+    fn extract_restore_reply_non_table_non_userdata_returns_none() {
+        assert!(extract_restore_reply(&LuaValue::Nil).is_none());
+        assert!(extract_restore_reply(&LuaValue::Integer(42)).is_none());
+        assert!(extract_restore_reply(&LuaValue::Boolean(true)).is_none());
+    }
+
+    #[test]
+    fn extract_restore_reply_userdata_returns_body_only() {
+        let lua = test_lua();
+        let handle = make_buf_handle("restored line");
+        let ud = lua.create_userdata(handle).unwrap();
+        let val = LuaValue::UserData(ud);
+        let reply = extract_restore_reply(&val).expect("should extract from userdata");
+        assert_eq!(reply.body.unwrap().first_line_text(), "restored line");
+        assert!(reply.header.is_none());
+    }
+
+    #[test]
+    fn extract_restore_reply_table_with_body_and_header() {
+        let lua = test_lua();
+        let body = lua.create_userdata(make_buf_handle("body")).unwrap();
+        let header = lua.create_userdata(make_buf_handle("header")).unwrap();
+        let t = lua.create_table().unwrap();
+        t.set("body", body).unwrap();
+        t.set("header", header).unwrap();
+        let val = LuaValue::Table(t);
+        let reply = extract_restore_reply(&val).unwrap();
+        assert_eq!(reply.body.unwrap().first_line_text(), "body");
+        assert_eq!(reply.header.unwrap().first_line_text(), "header");
+    }
+
+    #[test]
+    fn extract_restore_reply_table_body_only() {
+        let lua = test_lua();
+        let body = lua.create_userdata(make_buf_handle("only body")).unwrap();
+        let t = lua.create_table().unwrap();
+        t.set("body", body).unwrap();
+        let val = LuaValue::Table(t);
+        let reply = extract_restore_reply(&val).unwrap();
+        assert_eq!(reply.body.unwrap().first_line_text(), "only body");
+        assert!(reply.header.is_none());
+    }
+
+    #[test]
+    fn extract_restore_reply_empty_table_returns_both_none() {
+        let lua = test_lua();
+        let t = lua.create_table().unwrap();
+        let val = LuaValue::Table(t);
+        let reply = extract_restore_reply(&val).unwrap();
+        assert!(reply.body.is_none());
+        assert!(reply.header.is_none());
+    }
+
+    #[test]
+    fn extract_restore_reply_table_with_wrong_type_in_body() {
+        let lua = test_lua();
+        let t = lua.create_table().unwrap();
+        t.set("body", "not_userdata").unwrap();
+        let val = LuaValue::Table(t);
+        let reply = extract_restore_reply(&val).unwrap();
+        assert!(reply.body.is_none());
+    }
+
+    #[test]
+    fn click_handler_map_stores_buf_alongside_key() {
+        let lua = test_lua();
+        lua.set_app_data(ClickHandlerMap::new());
+        let buf = Arc::new(maki_agent::SharedBuf::new());
+        buf.append(SnapshotLine {
+            spans: vec![SnapshotSpan {
+                text: "click content".into(),
+                style: SpanStyle::Default,
+            }],
+        });
+        let func = lua.create_function(|_, _: ()| Ok(())).unwrap();
+        let key = lua.create_registry_value(func).unwrap();
+        with_click_handlers(&lua, |handlers| {
+            handlers.insert("tool_1".into(), (key, Arc::clone(&buf)));
+        });
+        let found = lua.app_data_ref::<ClickHandlerMap>().unwrap();
+        let (_, stored_buf) = found.get("tool_1").unwrap();
+        assert_eq!(stored_buf.take().first_line_text(), "click content");
     }
 }

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -496,9 +496,9 @@ where
                     path = %path.display(),
                     error = %e,
                     line = line_count,
-                    "corrupt/truncated JSONL record; discarding trailing lines",
+                    "skipping unrecognized JSONL record",
                 );
-                break;
+                continue;
             }
         };
         match record {
@@ -967,7 +967,7 @@ mod tests {
     }
 
     #[test]
-    fn crash_recovery_discards_from_corrupt_line() {
+    fn crash_recovery_skips_corrupt_line() {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let mut session: TestSession = Session::new("m", "/project");
@@ -986,7 +986,7 @@ mod tests {
         file.write_all(b"\n").unwrap();
 
         let loaded = TestSession::load_from(&session.id, dir).unwrap();
-        assert_eq!(loaded.messages.len(), 1);
+        assert_eq!(loaded.messages.len(), 2);
     }
 
     #[test]
@@ -1266,5 +1266,95 @@ mod tests {
             loaded.meta.thinking,
             Some(StoredThinking::Budget { tokens: 8192 })
         );
+    }
+
+    #[test]
+    fn crash_recovery_preserves_tool_outputs_around_corrupt_line() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let mut session: TestSession = Session::new("m", "/project");
+        session.messages.push(user_message("first"));
+        session
+            .tool_outputs
+            .insert("t1".into(), serde_json::json!({"result": "ok"}));
+        let mut log = SessionLog::create(dir, &session).unwrap();
+        log.append(&session).unwrap();
+
+        let path = dir.join(format!("{}.jsonl", session.id));
+        let mut file = OpenOptions::new().append(true).open(&path).unwrap();
+        file.write_all(b"CORRUPT\n").unwrap();
+        file.write_all(
+            serde_json::to_string(&serde_json::json!({"t":"msg","d": user_message("second")}))
+                .unwrap()
+                .as_bytes(),
+        )
+        .unwrap();
+        file.write_all(b"\n").unwrap();
+
+        let loaded = TestSession::load_from(&session.id, dir).unwrap();
+        assert_eq!(loaded.messages.len(), 2);
+        assert!(loaded.tool_outputs.contains_key("t1"));
+    }
+
+    #[test]
+    fn corrupt_header_line_only_returns_not_found() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let id = "fake-session-id";
+        let path = dir.join(format!("{id}.jsonl"));
+        fs::write(&path, "NOT_A_HEADER\n").unwrap();
+
+        let err = TestSession::load_from(id, dir).unwrap_err();
+        assert!(matches!(
+            err,
+            SessionError::Storage(StorageError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn empty_lines_in_jsonl_are_skipped() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let mut session: TestSession = Session::new("m", "/project");
+        session.messages.push(user_message("msg"));
+        session.save_to(dir).unwrap();
+
+        let path = dir.join(format!("{}.jsonl", session.id));
+        let mut file = OpenOptions::new().append(true).open(&path).unwrap();
+        file.write_all(b"\n\n\n").unwrap();
+        file.write_all(
+            serde_json::to_string(&serde_json::json!({"t":"msg","d": user_message("after")}))
+                .unwrap()
+                .as_bytes(),
+        )
+        .unwrap();
+        file.write_all(b"\n").unwrap();
+
+        let loaded = TestSession::load_from(&session.id, dir).unwrap();
+        assert_eq!(loaded.messages.len(), 2);
+    }
+
+    #[test]
+    fn unknown_record_type_is_skipped() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let mut session: TestSession = Session::new("m", "/project");
+        session.messages.push(user_message("first"));
+        session.save_to(dir).unwrap();
+
+        let path = dir.join(format!("{}.jsonl", session.id));
+        let mut file = OpenOptions::new().append(true).open(&path).unwrap();
+        file.write_all(b"{\"t\":\"future_type\",\"d\":{}}\n")
+            .unwrap();
+        file.write_all(
+            serde_json::to_string(&serde_json::json!({"t":"msg","d": user_message("second")}))
+                .unwrap()
+                .as_bytes(),
+        )
+        .unwrap();
+        file.write_all(b"\n").unwrap();
+
+        let loaded = TestSession::load_from(&session.id, dir).unwrap();
+        assert_eq!(loaded.messages.len(), 2);
     }
 }

--- a/maki-ui/src/app/mouse.rs
+++ b/maki-ui/src/app/mouse.rs
@@ -47,11 +47,14 @@ impl App {
                         self.selection_state = None;
                         if zone == SelectionZone::Messages {
                             let area = self.msg_area();
-                            let chat = &mut self.chats[self.active_chat];
-                            match chat.handle_click(event.row, area) {
+                            let result = self.chats[self.active_chat].handle_click(event.row, area);
+                            match result {
                                 ClickResult::LuaToolClick { tool_id, row } => {
-                                    if let Some(handler) = &self.buf_click {
-                                        handler(&tool_id, row);
+                                    if let Some(handler) = &self.buf_click
+                                        && let Some(snapshot) = handler(&tool_id, row)
+                                    {
+                                        self.chats[self.active_chat]
+                                            .tool_snapshot(&tool_id, snapshot);
                                     }
                                 }
                                 ClickResult::Toggled | ClickResult::Nothing => {}

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -98,6 +98,7 @@ impl App {
             &self.state.session.messages,
             &self.state.session.tool_outputs,
             &self.ui_config.tool_output_lines,
+            self.lua_event_handle.as_ref(),
         );
         self.main_chat().load_messages(display_msgs);
         self.main_chat().token_usage = self.state.token_usage;
@@ -130,6 +131,7 @@ impl App {
                     messages,
                     &self.state.session.tool_outputs,
                     &self.ui_config.tool_output_lines,
+                    self.lua_event_handle.as_ref(),
                 );
                 chat.load_messages(display);
                 chat.mark_finished(DisplayRole::Done, DONE_TEXT);

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -18,8 +18,8 @@ use crate::markdown::truncate_output;
 use crate::selection::Selection;
 use maki_agent::tools::{ToolInvocation, ToolRegistry};
 use maki_agent::{
-    AgentEvent, BatchToolStatus, NO_FILES_FOUND, QuestionInfo, ToolDoneEvent, ToolOutput,
-    ToolStartEvent,
+    AgentEvent, BatchToolStatus, BufferSnapshot, NO_FILES_FOUND, QuestionInfo, ToolDoneEvent,
+    ToolOutput, ToolStartEvent,
 };
 use maki_config::{ToolOutputLines, UiConfig};
 use maki_providers::{ContentBlock, Message, Role, TokenUsage};
@@ -227,6 +227,10 @@ impl Chat {
         self.messages_panel.handle_click(row, area)
     }
 
+    pub fn tool_snapshot(&mut self, tool_id: &str, snapshot: BufferSnapshot) {
+        self.messages_panel.tool_snapshot(tool_id, snapshot);
+    }
+
     pub fn stream_reset(&mut self) {
         self.messages_panel.stream_reset();
     }
@@ -320,6 +324,7 @@ pub fn history_to_display(
     messages: &[Message],
     tool_outputs: &HashMap<String, ToolOutput>,
     tool_output_lines: &ToolOutputLines,
+    event_handle: Option<&maki_lua::EventHandle>,
 ) -> Vec<DisplayMessage> {
     let registry = RenderHintsRegistry::new();
     let results = build_tool_results_map(messages);
@@ -374,6 +379,26 @@ pub fn history_to_display(
                             {
                                 append_annotation(&mut annotation, &ta);
                             }
+                            let (mut render_snapshot, mut render_header) = (None, None);
+                            if let Some(eh) = event_handle {
+                                let is_error = status == ToolStatus::Error;
+                                let output_text = tool_outputs
+                                    .get(id.as_str())
+                                    .map(|o| o.as_text())
+                                    .or_else(|| result_text.map(|t| t.to_string()))
+                                    .unwrap_or_default();
+                                if let Some(reply) = eh.restore_tool(
+                                    name,
+                                    id,
+                                    &output_text,
+                                    input,
+                                    is_error,
+                                    tool_output_lines,
+                                ) {
+                                    render_snapshot = reply.body;
+                                    render_header = reply.header;
+                                }
+                            }
                             display.push(DisplayMessage {
                                 role: DisplayRole::Tool(Box::new(ToolRole {
                                     id: id.clone(),
@@ -389,8 +414,8 @@ pub fn history_to_display(
                                 timestamp: None,
                                 turn_usage: None,
                                 truncated_lines,
-                                render_snapshot: None,
-                                render_header: None,
+                                render_snapshot,
+                                render_header,
                             });
                         }
                         _ => {}
@@ -622,7 +647,8 @@ mod tests {
             ..Default::default()
         }];
         assert!(
-            history_to_display(&msgs, &empty_outputs(), &ToolOutputLines::default()).is_empty()
+            history_to_display(&msgs, &empty_outputs(), &ToolOutputLines::default(), None)
+                .is_empty()
         );
     }
 
@@ -663,7 +689,8 @@ mod tests {
             "output",
             is_error,
         );
-        let display = history_to_display(&msgs, &empty_outputs(), &ToolOutputLines::default());
+        let display =
+            history_to_display(&msgs, &empty_outputs(), &ToolOutputLines::default(), None);
         assert_eq!(display.len(), 1);
         assert!(matches!(&display[0].role, DisplayRole::Tool(t) if t.status == expected));
     }
@@ -703,7 +730,8 @@ mod tests {
                 ..Default::default()
             },
         ];
-        let display = history_to_display(&msgs, &empty_outputs(), &ToolOutputLines::default());
+        let display =
+            history_to_display(&msgs, &empty_outputs(), &ToolOutputLines::default(), None);
         assert_eq!(display.len(), 4);
         assert_eq!(display[0].role, DisplayRole::User);
         assert_eq!(display[1].role, DisplayRole::Assistant);
@@ -751,7 +779,7 @@ mod tests {
             let discriminant = std::mem::discriminant(&output);
             let msgs = tool_use_pair(tool_name, input_json, "ok", false);
             let outputs = HashMap::from([("t1".into(), output)]);
-            let display = history_to_display(&msgs, &outputs, &ToolOutputLines::default());
+            let display = history_to_display(&msgs, &outputs, &ToolOutputLines::default(), None);
             assert_eq!(
                 std::mem::discriminant(display[0].tool_output.as_deref().unwrap()),
                 discriminant,
@@ -774,7 +802,7 @@ mod tests {
             false,
         );
         let outputs = HashMap::from([("t1".into(), write_output)]);
-        let display = history_to_display(&msgs, &outputs, &ToolOutputLines::default());
+        let display = history_to_display(&msgs, &outputs, &ToolOutputLines::default(), None);
         assert!(display[0].annotation.is_some());
     }
 
@@ -788,7 +816,8 @@ mod tests {
             &joined,
             false,
         );
-        let display = history_to_display(&msgs, &empty_outputs(), &ToolOutputLines::default());
+        let display =
+            history_to_display(&msgs, &empty_outputs(), &ToolOutputLines::default(), None);
         let line_count = display[0].text.lines().count();
         assert!(
             line_count < long_output.len(),
@@ -821,7 +850,7 @@ mod tests {
         };
         let msgs = tool_use_pair("batch", serde_json::json!({"tool_calls": []}), "", false);
         let outputs = HashMap::from([("t1".into(), batch_output)]);
-        let display = history_to_display(&msgs, &outputs, &ToolOutputLines::default());
+        let display = history_to_display(&msgs, &outputs, &ToolOutputLines::default(), None);
         let ToolOutput::Batch { entries, .. } = display[0].tool_output.as_deref().unwrap() else {
             panic!("expected Batch output");
         };
@@ -838,7 +867,8 @@ mod tests {
             "1: fn main() {}",
             false,
         );
-        let display = history_to_display(&msgs, &empty_outputs(), &ToolOutputLines::default());
+        let display =
+            history_to_display(&msgs, &empty_outputs(), &ToolOutputLines::default(), None);
         assert!(display[0].tool_output.is_none());
         assert!(display[0].text.contains("fn main"));
     }
@@ -859,7 +889,7 @@ mod tests {
             ],
             ..Default::default()
         }];
-        let display = history_to_display(&msgs, &HashMap::new(), &ToolOutputLines::default());
+        let display = history_to_display(&msgs, &HashMap::new(), &ToolOutputLines::default(), None);
         assert_eq!(display.len(), 2);
         assert_eq!(display[0].role, DisplayRole::Thinking);
         assert_eq!(display[0].text, "reasoning");

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -195,12 +195,10 @@ impl MessagesPanel {
     }
 
     pub fn tool_done(&mut self, event: ToolDoneEvent) {
-        if self.has_snapshot(&event.id) {
-            if let Some(buf) = self.live_bufs.get(&event.id) {
-                buf.read_if_dirty();
-            }
-        } else {
-            self.live_bufs.remove(&event.id);
+        if let Some(buf) = self.live_bufs.remove(&event.id)
+            && let Some(lines) = buf.read_if_dirty()
+        {
+            self.store_snapshot(&event.id, BufferSnapshot::from_arc(lines));
         }
         let Some(msg) = self
             .messages

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -6,8 +6,8 @@ use maki_agent::tools::{
     BASH_TOOL_NAME, GLOB_TOOL_NAME, GREP_TOOL_NAME, QUESTION_TOOL_NAME, WRITE_TOOL_NAME,
 };
 use maki_agent::{
-    BatchToolEntry, GrepFileEntry, GrepMatchGroup, QuestionAnswer, SharedBuf, SnapshotLine,
-    SnapshotSpan, SpanStyle, ToolInput, ToolOutput,
+    BatchToolEntry, GrepFileEntry, GrepMatchGroup, QuestionAnswer, SnapshotLine, SnapshotSpan,
+    SpanStyle, ToolInput, ToolOutput,
 };
 use ratatui::backend::TestBackend;
 use test_case::test_case;
@@ -1172,34 +1172,6 @@ fn handle_click_non_tool_segment_returns_nothing() {
 }
 
 #[test]
-fn live_buf_updates_after_tool_done_are_picked_up() {
-    let buf = Arc::new(SharedBuf::new());
-
-    let mut panel = MessagesPanel::new(UiConfig::default());
-    panel.register_live_buf("t1".into(), Arc::clone(&buf));
-    panel.tool_start(start("t1", BASH_TOOL_NAME));
-
-    buf.set_lines(vec![snap_line("before")]);
-    panel.tool_snapshot(
-        "t1",
-        BufferSnapshot::from_arc(Arc::new(vec![snap_line("before")])),
-    );
-    panel.tool_done(ToolDoneEvent {
-        id: "t1".into(),
-        tool: BASH_TOOL_NAME.into(),
-        output: ToolOutput::Plain("output".into()),
-        is_error: false,
-    });
-
-    buf.set_lines(vec![snap_line("after click")]);
-    render(&mut panel, 80, 24);
-
-    let msg = panel.find_tool_msg_mut("t1").unwrap();
-    let snap = msg.render_snapshot.as_ref().unwrap();
-    assert_eq!(snap.lines[0].spans[0].text, "after click");
-}
-
-#[test]
 fn handle_click_returns_lua_tool_click_for_batch_child() {
     let mut panel = MessagesPanel::new(UiConfig::default());
     batch_start(
@@ -1222,4 +1194,69 @@ fn handle_click_returns_lua_tool_click_for_batch_child() {
         _ => None,
     });
     assert_eq!(clicked.as_deref(), Some("b1__0"));
+}
+
+#[test]
+fn tool_done_removes_live_buf_and_snapshots_dirty() {
+    let buf = Arc::new(maki_agent::SharedBuf::new());
+    buf.set_lines(vec![snap_line("dirty content")]);
+
+    let mut panel = MessagesPanel::new(UiConfig::default());
+    panel.register_live_buf("t1".into(), Arc::clone(&buf));
+    panel.tool_start(start("t1", BASH_TOOL_NAME));
+    panel.tool_done(ToolDoneEvent {
+        id: "t1".into(),
+        tool: BASH_TOOL_NAME.into(),
+        output: ToolOutput::Plain("output".into()),
+        is_error: false,
+    });
+
+    let msg = panel.find_tool_msg_mut("t1").unwrap();
+    assert_eq!(
+        msg.render_snapshot.as_ref().unwrap().first_line_text(),
+        "dirty content"
+    );
+}
+
+#[test]
+fn tool_done_without_live_buf_preserves_existing_snapshot() {
+    let mut panel = MessagesPanel::new(UiConfig::default());
+    panel.tool_start(start("t1", BASH_TOOL_NAME));
+    panel.tool_snapshot(
+        "t1",
+        BufferSnapshot::from_arc(Arc::new(vec![snap_line("pre-existing")])),
+    );
+    panel.tool_done(ToolDoneEvent {
+        id: "t1".into(),
+        tool: BASH_TOOL_NAME.into(),
+        output: ToolOutput::Plain("output".into()),
+        is_error: false,
+    });
+
+    let msg = panel.find_tool_msg_mut("t1").unwrap();
+    assert_eq!(
+        msg.render_snapshot.as_ref().unwrap().first_line_text(),
+        "pre-existing"
+    );
+}
+
+#[test]
+fn tool_done_clean_live_buf_does_not_snapshot() {
+    let buf = Arc::new(maki_agent::SharedBuf::new());
+
+    let mut panel = MessagesPanel::new(UiConfig::default());
+    panel.register_live_buf("t1".into(), Arc::clone(&buf));
+    panel.tool_start(start("t1", BASH_TOOL_NAME));
+    panel.tool_done(ToolDoneEvent {
+        id: "t1".into(),
+        tool: BASH_TOOL_NAME.into(),
+        output: ToolOutput::Plain("output".into()),
+        is_error: false,
+    });
+
+    let msg = panel.find_tool_msg_mut("t1").unwrap();
+    assert!(
+        msg.render_snapshot.is_none(),
+        "clean (never-written) live buf should not produce a snapshot"
+    );
 }

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -10,7 +10,7 @@ use crossterm::event::{
 };
 use maki_agent::command::CustomCommand;
 use maki_agent::permissions::PermissionManager;
-use maki_agent::{AgentConfig, CancelToken, McpCommand};
+use maki_agent::{AgentConfig, BufferSnapshot, CancelToken, McpCommand};
 use maki_config::UiConfig;
 use maki_lua::{EventHandle, LuaCommandReader, UiAction};
 use maki_providers::Timeouts;
@@ -36,7 +36,7 @@ use crate::terminal;
 const ANIMATION_INTERVAL_MS: u64 = 16;
 const IDLE_POLL_INTERVAL_MS: u64 = 100;
 
-pub type BufClickHandler = Arc<dyn Fn(&str, u32) + Send + Sync>;
+pub type BufClickHandler = Arc<dyn Fn(&str, u32) -> Option<BufferSnapshot> + Send + Sync>;
 
 pub struct EventLoopParams {
     pub model: Model,

--- a/plugins/bash/init.lua
+++ b/plugins/bash/init.lua
@@ -55,6 +55,20 @@ local function relative_path(p)
   return p
 end
 
+local function build_header_lines(command)
+  local header = {}
+  local highlighted = maki.ui.highlight(command, "bash")
+  if highlighted then
+    for _, line in ipairs(highlighted) do
+      header[#header + 1] = line
+    end
+  else
+    header[#header + 1] = command
+  end
+  header[#header + 1] = { { SEPARATOR, "dim" } }
+  return header
+end
+
 local function rtk_find_unsupported(cmd)
   if not cmd:match("^rtk find ") then
     return false
@@ -119,6 +133,20 @@ local function append_line(output, line)
     output[#output + 1] = "\n"
   end
   output[#output + 1] = line
+end
+
+local function create_bash_view(command, ctx)
+  local tol = ctx:tool_output_lines()
+  local buf = maki.ui.buf()
+  local view = ToolView.new(buf, {
+    max_lines = (tol and tol.bash) or 5,
+    keep = "tail",
+  })
+  view:set_header(build_header_lines(command))
+  buf:on("click", function()
+    view:toggle()
+  end)
+  return buf, view
 end
 
 local cwd = maki.uv.cwd() or "."
@@ -244,6 +272,35 @@ maki.api.register_tool({
     return s
   end,
 
+  restore = function(output, input, is_error, ctx)
+    local command = resolve_command(input)
+    local buf, view = create_bash_view(command, ctx)
+    if is_error then
+      local body, code = output:match("^(.-)\nExit code: (%d+)$")
+      if body then
+        for line in (body .. "\n"):gmatch("([^\n]*)\n") do
+          view:append(line)
+        end
+        view:append({ { "Exit code: " .. code, "dim" } })
+      else
+        for line in (output .. "\n"):gmatch("([^\n]*)\n") do
+          view:append(line)
+        end
+      end
+    else
+      if output == "Exit code: 0" or output == "" then
+        view:clear()
+        view:append({ { "No output", "dim" } })
+      else
+        for line in (output .. "\n"):gmatch("([^\n]*)\n") do
+          view:append(line)
+        end
+      end
+    end
+    view:finish()
+    return buf
+  end,
+
   handler = function(input, ctx)
     if not input.command then
       return { llm_output = "error: command is required", is_error = true }
@@ -260,28 +317,7 @@ maki.api.register_tool({
       command = rewritten
     end
 
-    local tol = ctx:tool_output_lines()
-    local buf = maki.ui.buf()
-    local view = ToolView.new(buf, {
-      max_lines = (tol and tol.bash) or 5,
-      keep = "tail",
-    })
-
-    buf:on("click", function(ev)
-      view:toggle()
-    end)
-
-    local header = {}
-    local highlighted = maki.ui.highlight(command, "bash")
-    if highlighted then
-      for _, line in ipairs(highlighted) do
-        header[#header + 1] = line
-      end
-    else
-      header[#header + 1] = command
-    end
-    header[#header + 1] = { { SEPARATOR, "dim" } }
-    view:set_header(header)
+    local buf, view = create_bash_view(command, ctx)
 
     local output_parts = {}
     local has_output = false

--- a/plugins/index/init.lua
+++ b/plugins/index/init.lua
@@ -93,6 +93,22 @@ local function render_header(path, line_count)
   return buf
 end
 
+local function render_index(skeleton, path, ctx)
+  local tol = ctx:tool_output_lines()
+  local buf = maki.ui.buf()
+  local view = ToolView.new(buf, {
+    max_lines = (tol and tol.index) or 5,
+    keep = "head",
+  })
+  buf:on("click", function()
+    view:toggle()
+  end)
+  render_skeleton(view, skeleton)
+  view:finish()
+  local line_count = select(2, skeleton:gsub("\n", "\n")) + 1
+  return buf, render_header(path, line_count)
+end
+
 maki.api.register_tool({
   name = "index",
   description = [[
@@ -110,6 +126,10 @@ Return a compact overview of a source file: imports, type definitions, function 
   },
   header = function(input)
     return render_header(input.path)
+  end,
+  restore = function(output, input, _is_error, ctx)
+    local buf, header = render_index(output, input.path, ctx)
+    return { body = buf, header = header }
   end,
   handler = function(input, ctx)
     local path = input.path
@@ -160,24 +180,11 @@ Return a compact overview of a source file: imports, type definitions, function 
       return "error: " .. tostring(err)
     end
 
-    local tol = ctx:tool_output_lines()
-    local buf = maki.ui.buf()
-    local view = ToolView.new(buf, {
-      max_lines = (tol and tol.index) or 5,
-      keep = "head",
-    })
-    buf:on("click", function()
-      view:toggle()
-    end)
-
-    render_skeleton(view, skeleton)
-    view:finish()
-
-    local line_count = select(2, skeleton:gsub("\n", "\n")) + 1
+    local buf, header = render_index(skeleton, path, ctx)
     return {
       llm_output = skeleton,
       body = buf,
-      header = render_header(path, line_count),
+      header = header,
     }
   end,
 })

--- a/plugins/lib/maki/tool_view.lua
+++ b/plugins/lib/maki/tool_view.lua
@@ -109,4 +109,17 @@ function ToolView:finish()
   end
 end
 
+function ToolView.restore(output, opts)
+  local buf = maki.ui.buf()
+  local view = ToolView.new(buf, opts)
+  for line in (output .. "\n"):gmatch("([^\n]*)\n") do
+    view:append(line)
+  end
+  view:finish()
+  buf:on("click", function()
+    view:toggle()
+  end)
+  return buf
+end
+
 return ToolView

--- a/plugins/memory/init.lua
+++ b/plugins/memory/init.lua
@@ -147,6 +147,10 @@ maki.api.register_tool({
     return input.command
   end,
 
+  restore = function(output, input, _is_error, ctx)
+    return render_content(output, input.path or "file.md", ctx)
+  end,
+
   handler = function(input, ctx)
     local cmd = input.command
     local dir, dir_err = resolve_dir(cmd == "view")

--- a/plugins/webfetch/init.lua
+++ b/plugins/webfetch/init.lua
@@ -63,6 +63,11 @@ end
 local truncate = require("maki.truncate")
 local ToolView = require("maki.tool_view")
 
+local function web_view_opts(ctx)
+  local tol = ctx:tool_output_lines()
+  return { max_lines = (tol and tol.web) or 3, keep = "head" }
+end
+
 maki.api.register_tool({
   name = "webfetch",
   description = [[Fetch a URL and return its contents.
@@ -88,6 +93,10 @@ maki.api.register_tool({
       return input.url .. " [" .. fmt .. "]"
     end
     return input.url
+  end,
+
+  restore = function(output, _input, _is_error, ctx)
+    return ToolView.restore(output, web_view_opts(ctx))
   end,
 
   handler = function(input, ctx)
@@ -138,24 +147,9 @@ maki.api.register_tool({
 
     local llm_output = truncate(body, max_lines, max_bytes)
 
-    local tol = ctx:tool_output_lines()
-    local buf = maki.ui.buf()
-    local view = ToolView.new(buf, {
-      max_lines = (tol and tol.web) or 3,
-      keep = "head",
-    })
-    buf:on("click", function()
-      view:toggle()
-    end)
-
-    for line in body:gmatch("([^\n]*)\n?") do
-      view:append(line)
-    end
-    view:finish()
-
     return {
       llm_output = llm_output,
-      body = buf,
+      body = ToolView.restore(body, web_view_opts(ctx)),
     }
   end,
 })

--- a/plugins/websearch/init.lua
+++ b/plugins/websearch/init.lua
@@ -6,6 +6,11 @@ local parse_sse_response = require("parse_sse")
 local truncate = require("maki.truncate")
 local ToolView = require("maki.tool_view")
 
+local function web_view_opts(ctx)
+  local tol = ctx:tool_output_lines()
+  return { max_lines = (tol and tol.web) or 3, keep = "head" }
+end
+
 maki.api.register_tool({
   name = "websearch",
   description = "Search the web for real-time information using Exa AI.\n\n"
@@ -28,6 +33,10 @@ maki.api.register_tool({
 
   header = function(input)
     return input.query
+  end,
+
+  restore = function(output, _input, _is_error, ctx)
+    return ToolView.restore(output, web_view_opts(ctx))
   end,
 
   handler = function(input, ctx)
@@ -87,24 +96,9 @@ maki.api.register_tool({
 
     local llm_output = truncate(text, max_lines, max_bytes)
 
-    local tol = ctx:tool_output_lines()
-    local buf = maki.ui.buf()
-    local view = ToolView.new(buf, {
-      max_lines = (tol and tol.web) or 3,
-      keep = "head",
-    })
-    buf:on("click", function()
-      view:toggle()
-    end)
-
-    for line in text:gmatch("([^\n]*)\n?") do
-      view:append(line)
-    end
-    view:finish()
-
     return {
       llm_output = llm_output,
-      body = buf,
+      body = ToolView.restore(text, web_view_opts(ctx)),
     }
   end,
 })

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -161,9 +161,11 @@ pub fn run(cli: Cli) -> Result<()> {
                 ui_action_rx,
                 lua_event_handle: plugin_host.event_handle(),
                 buf_click: plugin_host.event_handle().map(|eh| {
-                    Arc::new(move |tool_id: &str, row: u32| {
-                        eh.fire_click(tool_id, row);
-                    }) as maki_ui::BufClickHandler
+                    Arc::new(
+                        move |tool_id: &str, row: u32| -> Option<maki_agent::BufferSnapshot> {
+                            eh.fire_click(tool_id, row)
+                        },
+                    ) as maki_ui::BufClickHandler
                 }),
                 #[cfg(feature = "demo")]
                 demo: cli.demo,


### PR DESCRIPTION
Lua tools lost their styled output on session reload because the previous approach (persisting snapshots to disk) stored dead images with no click handlers.

Each plugin now registers an optional `restore` function that rebuilds a live `ToolView` from the stored `llm_output` text. On reload, `history_to_display` calls `EventHandle::restore_tool()` which sends the request to the Lua thread, sets up a `LiveCtx` with the `tool_use_id` so `buf:on("click")` registers properly, and returns the snapshots.

`ToolView.restore(output, opts)` is a shared helper that handles the common case. Plugins with custom rendering (bash with syntax-highlighted headers, index with styled skeletons) implement their own.