### PR TITLE
providers: Add explicit llama.cpp provider

### DIFF
--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -11,7 +11,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::provider::ProviderKind;
 use crate::providers::{
-    anthropic, copilot, deepseek, dynamic, google, mistral, ollama, openai, synthetic, zai,
+    anthropic, copilot, deepseek, dynamic, google, llama_cpp, mistral, ollama, openai, synthetic,
+    zai,
 };
 
 const PER_MILLION: f64 = 1_000_000.0;
@@ -114,6 +115,7 @@ pub fn models_for_provider(provider: ProviderKind) -> &'static [ModelEntry] {
         ProviderKind::OpenAi => openai::models(),
         ProviderKind::Copilot => copilot::models(),
         ProviderKind::Ollama => ollama::models(),
+        ProviderKind::LlamaCpp => llama_cpp::models(),
         ProviderKind::Mistral => mistral::models(),
         ProviderKind::Google => google::models(),
         ProviderKind::Zai | ProviderKind::ZaiCodingPlan => zai::models(),

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -14,6 +14,7 @@ use crate::providers::copilot::Copilot;
 use crate::providers::deepseek::DeepSeek;
 use crate::providers::dynamic;
 use crate::providers::google::Google;
+use crate::providers::llama_cpp::LlamaCpp;
 use crate::providers::mistral::Mistral;
 use crate::providers::ollama::Ollama;
 use crate::providers::openai::OpenAi;
@@ -30,6 +31,7 @@ pub enum ProviderKind {
     Google,
     Copilot,
     Ollama,
+    LlamaCpp,
     Mistral,
     Zai,
     ZaiCodingPlan,
@@ -46,6 +48,7 @@ impl ProviderKind {
             Self::Google => "Google",
             Self::Copilot => "Copilot",
             Self::Ollama => "Ollama",
+            Self::LlamaCpp => "LlamaCpp",
             Self::Mistral => "Mistral",
             Self::Zai => "Z.AI",
             Self::ZaiCodingPlan => "Z.AI Coding",
@@ -61,6 +64,7 @@ impl ProviderKind {
             Self::Google => "GEMINI_API_KEY",
             Self::Copilot => "GH_COPILOT_TOKEN",
             Self::Ollama => "OLLAMA_API_KEY",
+            Self::LlamaCpp => "LLAMA_CPP_API_KEY",
             Self::Mistral => "MISTRAL_API_KEY",
             Self::Zai | Self::ZaiCodingPlan => "ZHIPU_API_KEY",
             Self::DeepSeek => "DEEPSEEK_API_KEY",
@@ -77,6 +81,7 @@ impl ProviderKind {
                 "https://api.githubcopilot.com (or GraphQL-discovered Copilot API endpoint)"
             }
             Self::Ollama => "http://localhost:11434/v1",
+            Self::LlamaCpp => "http://localhost:8080/v1",
             Self::Mistral => "https://api.mistral.ai/v1",
             Self::Zai => "https://api.z.ai/api/paas/v4",
             Self::ZaiCodingPlan => "https://api.z.ai/api/coding/paas/v4",
@@ -102,6 +107,9 @@ impl ProviderKind {
             Self::Ollama => {
                 Some("Local or remote inference via OLLAMA_HOST, cloud fallback via OLLAMA_API_KEY")
             }
+            Self::LlamaCpp => Some(
+                "Local or remote inference via LLAMA_CPP_HOST, set optional key via LLAMA_CPP_API_KEY",
+            ),
             Self::Synthetic => {
                 Some("Reasoning effort support (low/medium/high), open-weight models")
             }
@@ -117,6 +125,7 @@ impl ProviderKind {
             Self::Google => ModelFamily::Gemini,
             Self::Copilot => ModelFamily::Generic,
             Self::Ollama => ModelFamily::Generic,
+            Self::LlamaCpp => ModelFamily::Generic,
             Self::Mistral => ModelFamily::Generic,
             Self::Zai | Self::ZaiCodingPlan => ModelFamily::Glm,
             Self::DeepSeek => ModelFamily::Generic,
@@ -125,7 +134,10 @@ impl ProviderKind {
     }
 
     pub const fn accepts_arbitrary_models(self) -> bool {
-        matches!(self, Self::Ollama | Self::Google | Self::Copilot)
+        matches!(
+            self,
+            Self::Ollama | Self::LlamaCpp | Self::Google | Self::Copilot
+        )
     }
 
     pub const fn fallback_max_output(self) -> u32 {
@@ -135,6 +147,7 @@ impl ProviderKind {
             Self::Google => 65_536,
             Self::Copilot => 100_000,
             Self::Ollama => 16_384,
+            Self::LlamaCpp => 16_384,
             Self::Mistral => 32_000,
             Self::Zai | Self::ZaiCodingPlan => 16_000,
             Self::DeepSeek => 384_000,
@@ -149,6 +162,7 @@ impl ProviderKind {
             Self::Google => 1_000_000,
             Self::Copilot => 200_000,
             Self::Ollama => 128_000,
+            Self::LlamaCpp => 128_000,
             Self::Mistral => 128_000,
             Self::Zai | Self::ZaiCodingPlan => 128_000,
             Self::DeepSeek => 1_000_000,
@@ -169,6 +183,7 @@ impl ProviderKind {
             Self::Google => Ok(Box::new(Google::new(timeouts)?)),
             Self::Copilot => Ok(Box::new(Copilot::new(timeouts)?)),
             Self::Ollama => Ok(Box::new(Ollama::new(timeouts)?)),
+            Self::LlamaCpp => Ok(Box::new(LlamaCpp::new(timeouts)?)),
             Self::Mistral => Ok(Box::new(Mistral::new(timeouts)?)),
             Self::Zai => Ok(Box::new(Zai::new(ZaiPlan::Standard, timeouts)?)),
             Self::ZaiCodingPlan => Ok(Box::new(Zai::new(ZaiPlan::Coding, timeouts)?)),

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -20,6 +20,7 @@ use super::anthropic::Anthropic;
 use super::copilot::Copilot;
 use super::deepseek::DeepSeek;
 use super::google::Google;
+use super::llama_cpp::LlamaCpp;
 use super::mistral::Mistral;
 use super::ollama::Ollama;
 use super::openai::OpenAi;
@@ -360,6 +361,10 @@ pub fn create(slug: &str, timeouts: super::Timeouts) -> Result<Box<dyn Provider>
             Ollama::with_auth(auth.clone(), timeouts)
                 .with_system_prefix(meta.system_prefix.clone()),
         ),
+        ProviderKind::LlamaCpp => Box::new(
+            LlamaCpp::with_auth(auth.clone(), timeouts)
+                .with_system_prefix(meta.system_prefix.clone()),
+        ),
         ProviderKind::Mistral => Box::new(
             Mistral::with_auth(auth.clone(), timeouts)
                 .with_system_prefix(meta.system_prefix.clone()),
@@ -654,6 +659,7 @@ esac
 
     #[cfg(unix)]
     #[test_case("ollama", ProviderKind::Ollama ; "base_ollama")]
+    #[test_case("llama-cpp", ProviderKind::LlamaCpp ; "base_llama_cpp")]
     #[test_case("mistral", ProviderKind::Mistral ; "base_mistral")]
     #[test_case("zai", ProviderKind::Zai ; "base_zai")]
     #[test_case("zai-coding-plan", ProviderKind::ZaiCodingPlan ; "base_zai_coding_plan")]

--- a/maki-providers/src/providers/llama_cpp.rs
+++ b/maki-providers/src/providers/llama_cpp.rs
@@ -1,0 +1,155 @@
+use std::sync::{Arc, Mutex};
+
+use flume::Sender;
+use serde_json::Value;
+
+use crate::model::{Model, ModelEntry};
+use crate::provider::{BoxFuture, Provider};
+use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
+
+use super::ResolvedAuth;
+use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+
+const HOST_ENV: &str = "LLAMA_CPP_HOST";
+const API_KEY_ENV: &str = "LLAMA_CPP_API_KEY";
+const HOST_NOT_SET: &str = "LLAMA_CPP_HOST not set";
+
+static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
+    api_key_env: "",
+    base_url: "http://localhost:8080/v1",
+    max_tokens_field: "max_tokens",
+    include_stream_usage: true,
+    provider_name: "LlamaCpp",
+};
+
+pub(crate) fn models() -> &'static [ModelEntry] {
+    &[]
+}
+
+pub struct LlamaCpp {
+    compat: OpenAiCompatProvider,
+    auth: Arc<Mutex<ResolvedAuth>>,
+    system_prefix: Option<String>,
+}
+
+impl LlamaCpp {
+    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
+        Self::from_env(
+            timeouts,
+            std::env::var(API_KEY_ENV).ok(),
+            std::env::var(HOST_ENV).ok(),
+        )
+    }
+
+    pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
+        Self {
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
+            auth,
+            system_prefix: None,
+        }
+    }
+
+    pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
+        self.system_prefix = prefix;
+        self
+    }
+
+    fn from_env(
+        timeouts: super::Timeouts,
+        api_key: Option<String>,
+        host: Option<String>,
+    ) -> Result<Self, AgentError> {
+        let base_url = match host {
+            Some(h) => format!("{h}/v1"),
+            None => {
+                return Err(AgentError::Config {
+                    message: HOST_NOT_SET.into(),
+                });
+            }
+        };
+        let headers = match api_key {
+            Some(key) => vec![("authorization".into(), format!("Bearer {key}"))],
+            None => Vec::new(),
+        };
+        Ok(Self {
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
+            auth: Arc::new(Mutex::new(ResolvedAuth {
+                base_url: Some(base_url),
+                headers,
+            })),
+            system_prefix: None,
+        })
+    }
+}
+
+impl Provider for LlamaCpp {
+    fn stream_message<'a>(
+        &'a self,
+        model: &'a Model,
+        messages: &'a [Message],
+        system: &'a str,
+        tools: &'a Value,
+        event_tx: &'a Sender<ProviderEvent>,
+        _thinking: ThinkingConfig,
+        _session_id: Option<&str>,
+    ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            let mut buf = String::new();
+            let system = super::with_prefix(&self.system_prefix, system, &mut buf);
+            let body = self.compat.build_body(model, messages, system, tools);
+            self.compat
+                .do_stream(model, &[], &body, event_tx, &auth)
+                .await
+        })
+    }
+
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            self.compat.do_list_models(&auth).await
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_TIMEOUTS: super::super::Timeouts = super::super::Timeouts {
+        connect: std::time::Duration::from_secs(10),
+        low_speed: std::time::Duration::from_secs(30),
+        stream: std::time::Duration::from_secs(300),
+    };
+
+    #[test]
+    fn from_env_without_host_or_api_key_errors() {
+        match LlamaCpp::from_env(TEST_TIMEOUTS, None, None) {
+            Err(AgentError::Config { message }) => assert_eq!(message, HOST_NOT_SET),
+            Err(other) => panic!("expected Config error, got {other:?}"),
+            Ok(_) => panic!("expected error when host and api_key are None"),
+        }
+    }
+
+    #[test]
+    fn from_env_with_host_builds_auth() {
+        let llama = LlamaCpp::from_env(TEST_TIMEOUTS, None, Some("http://x:1234".into())).unwrap();
+        let auth = llama.auth.lock().unwrap();
+        assert_eq!(auth.base_url.as_deref(), Some("http://x:1234/v1"));
+        assert!(auth.headers.is_empty());
+    }
+
+    #[test]
+    fn from_env_with_api_key_uses_host_with_auth() {
+        let llama = LlamaCpp::from_env(
+            TEST_TIMEOUTS,
+            Some("test-key".into()),
+            Some("http://local:1234".into()),
+        )
+        .unwrap();
+        let auth = llama.auth.lock().unwrap();
+        assert_eq!(auth.base_url.as_deref(), Some("http://local:1234/v1"));
+        assert_eq!(auth.headers.len(), 1);
+        assert_eq!(auth.headers[0].1, "Bearer test-key");
+    }
+}

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod copilot;
 pub(crate) mod deepseek;
 pub mod dynamic;
 pub(crate) mod google;
+pub(crate) mod llama_cpp;
 pub(crate) mod mistral;
 pub(crate) mod ollama;
 pub(crate) mod openai;

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -97,6 +97,16 @@ This provider talks the OpenAI-compatible `/v1` API, so it also works with llama
 
 Maki asks the server for the list of installed models, so there's no built-in catalog. Tiers are guessed from list order: the first model becomes strong, the second medium, and the rest weak. If that guess is wrong, open `/model` and press `Alt+1`, `Alt+2`, or `Alt+3` on any row to reassign it. Your choices are saved to `~/.maki/model-tiers`.
 
+### LlamaCpp
+
+- **Env var**: `LLAMA_CPP_API_KEY`
+- **API**: `http://localhost:8080/v1`
+- **Features**: Local or remote inference via LLAMA_CPP_HOST, set optional key via LLAMA_CPP_API_KEY
+
+This provider talks the OpenAI-compatible `/v1` API, so it also works with llama.cpp's server, LocalAI, or anything else that speaks the same protocol. Just point `OLLAMA_HOST` to the right address (e.g. `http://localhost:8080` for llama.cpp).
+
+Maki asks the server for the list of installed models, so there's no built-in catalog. Tiers are guessed from list order: the first model becomes strong, the second medium, and the rest weak. If that guess is wrong, open `/model` and press `Alt+1`, `Alt+2`, or `Alt+3` on any row to reassign it. Your choices are saved to `~/.maki/model-tiers`.
+
 ### Mistral
 
 - **Env var**: `MISTRAL_API_KEY`
@@ -179,7 +189,7 @@ To add a custom provider or proxy, drop an executable script into `~/.maki/provi
 
 `resolve` is called each time a new agent spawns, so scripts should read tokens from disk instead of caching them in memory. That way auth changes from other processes get picked up.
 
-The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `copilot`, `ollama`, `mistral`, `zai`, `zai-coding-plan`, `deepseek`, `synthetic`.
+The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `copilot`, `ollama`, `llama-cpp`, `mistral`, `zai`, `zai-coding-plan`, `deepseek`, `synthetic`.
 
 If your provider serves models not in the base catalog, add a `models` subcommand returning:
 


### PR DESCRIPTION
Mostly to help unblock https://github.com/tontinton/maki/pull/197 . For now it's more or less a copy, but there's a bit that can be implemented now that we have this (getting context window automatically, calculating how many tokens a request is ahead of time to avoid going over the limits, ...).