### PR TITLE
providers: API key rotation via comma-separated key pools

### DIFF
--- a/maki-agent/src/agent/streaming.rs
+++ b/maki-agent/src/agent/streaming.rs
@@ -53,6 +53,11 @@ pub(crate) async fn stream_with_retry(
             Ok(r) => return Ok(r),
             Err(AgentError::Cancelled) => return Err(AgentError::Cancelled),
             Err(e) if e.is_retryable() => {
+                if e.should_rotate_key()
+                    && let Ok(true) = provider.rotate_key().await
+                {
+                    warn!("rotated API key after error: {e}");
+                }
                 let (attempt, delay) = retry.next_delay();
                 if matches!(e, AgentError::Timeout { .. }) && attempt > MAX_TIMEOUT_RETRIES {
                     return Err(e);

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -14,7 +14,9 @@ const TIER_PICKER_NOTE: &str = r#"Open the model picker with `/model` and press 
 
 const AUTH_RELOADING: &str = r#"## Auth Reloading
 
-Maki re-reads auth from storage and environment variables each time a new agent spawns (`/new`, retry, session load). If you run `maki auth login` in another terminal or change an env var, the next session picks it up without a restart."#;
+Maki re-reads auth from storage and environment variables each time a new agent spawns (`/new`, retry, session load). If you run `maki auth login` in another terminal or change an env var, the next session picks it up without a restart.
+
+You can set multiple API keys in one env var (`ANTHROPIC_API_KEY=sk-1,sk-2,sk-3`) and they rotate automatically on rate-limit or auth errors."#;
 
 const BEDROCK_NOTE: &str = r#"#### Amazon Bedrock
 

--- a/maki-providers/src/error.rs
+++ b/maki-providers/src/error.rs
@@ -46,6 +46,10 @@ impl AgentError {
         matches!(self, Self::Api { status: 401, .. })
     }
 
+    pub fn should_rotate_key(&self) -> bool {
+        matches!(self, Self::Api { status, .. } if *status == 429 || *status == 401 || *status == 403)
+    }
+
     pub fn user_message(&self) -> String {
         match self {
             Self::Config { message } => message.clone(),

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -221,6 +221,10 @@ pub trait Provider: Send + Sync {
     fn reload_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
         Box::pin(async { Ok(()) })
     }
+
+    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
+        Box::pin(async { Ok(false) })
+    }
 }
 
 pub fn from_model(model: &Model, timeouts: Timeouts) -> Result<Box<dyn Provider>, AgentError> {

--- a/maki-providers/src/providers/anthropic/mod.rs
+++ b/maki-providers/src/providers/anthropic/mod.rs
@@ -4,7 +4,6 @@
 pub(crate) mod bedrock;
 pub(super) mod shared;
 
-use std::env;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -19,39 +18,40 @@ use crate::model::Model;
 use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
 
+use super::KeyPool;
+
 const API_VERSION: &str = "2023-06-01";
 const MESSAGES_URL: &str = "https://api.anthropic.com/v1/messages";
 const MODELS_URL: &str = "https://api.anthropic.com/v1/models?limit=1000";
 
+const ENV_VAR: &str = "ANTHROPIC_API_KEY";
+
 pub(crate) use shared::models;
 
-fn resolve_auth() -> Result<super::ResolvedAuth, AgentError> {
-    if let Ok(key) = env::var("ANTHROPIC_API_KEY") {
-        debug!("using API key authentication");
-        return Ok(super::ResolvedAuth {
-            base_url: Some("https://api.anthropic.com/v1/messages".into()),
-            headers: vec![("x-api-key".into(), key)],
-        });
+fn resolve_auth_from_key(key: &str) -> super::ResolvedAuth {
+    super::ResolvedAuth {
+        base_url: Some("https://api.anthropic.com/v1/messages".into()),
+        headers: vec![("x-api-key".into(), key.to_string())],
     }
-
-    Err(AgentError::Config {
-        message: "set ANTHROPIC_API_KEY environment variable".into(),
-    })
 }
 
 pub struct Anthropic {
     client: HttpClient,
     auth: Arc<Mutex<super::ResolvedAuth>>,
+    key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
     stream_timeout: Duration,
 }
 
 impl Anthropic {
     pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
-        let resolved = resolve_auth()?;
+        let pool = KeyPool::from_env(ENV_VAR)?;
+        let resolved = resolve_auth_from_key(pool.current());
+        debug!(keys = pool.len(), "using API key authentication");
         Ok(Self {
             client: super::http_client(timeouts),
             auth: Arc::new(Mutex::new(resolved)),
+            key_pool: Some(pool),
             system_prefix: None,
             stream_timeout: timeouts.stream,
         })
@@ -64,6 +64,7 @@ impl Anthropic {
         Self {
             client: super::http_client(timeouts),
             auth,
+            key_pool: None,
             system_prefix: None,
             stream_timeout: timeouts.stream,
         }
@@ -192,10 +193,19 @@ impl Provider for Anthropic {
 
     fn reload_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
         Box::pin(async {
-            let resolved = resolve_auth()?;
-            *self.auth.lock().unwrap() = resolved;
+            let pool = KeyPool::from_env(ENV_VAR)?;
+            *self.auth.lock().unwrap() = resolve_auth_from_key(pool.current());
             debug!("reloaded Anthropic auth from env");
             Ok(())
+        })
+    }
+
+    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
+        Box::pin(async {
+            Ok(self
+                .key_pool
+                .as_ref()
+                .is_some_and(|p| p.rotate_auth(&self.auth, resolve_auth_from_key)))
         })
     }
 }

--- a/maki-providers/src/providers/deepseek.rs
+++ b/maki-providers/src/providers/deepseek.rs
@@ -8,8 +8,8 @@ use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
 
-use super::ResolvedAuth;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+use super::{KeyPool, ResolvedAuth};
 
 static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     api_key_env: "DEEPSEEK_API_KEY",
@@ -55,17 +55,17 @@ pub(crate) fn models() -> &'static [ModelEntry] {
 pub struct DeepSeek {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
+    key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
 }
 
 impl DeepSeek {
     pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
-        let api_key = std::env::var(CONFIG.api_key_env).map_err(|_| AgentError::Config {
-            message: format!("{} not set", CONFIG.api_key_env),
-        })?;
+        let pool = KeyPool::from_env(CONFIG.api_key_env)?;
         Ok(Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
-            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(&api_key))),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(pool.current()))),
+            key_pool: Some(pool),
             system_prefix: None,
         })
     }
@@ -74,6 +74,7 @@ impl DeepSeek {
         Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
             auth,
+            key_pool: None,
             system_prefix: None,
         }
     }
@@ -127,6 +128,15 @@ impl Provider for DeepSeek {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
             self.compat.do_list_models(&auth).await
+        })
+    }
+
+    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
+        Box::pin(async {
+            Ok(self
+                .key_pool
+                .as_ref()
+                .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
         })
     }
 }

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -16,9 +15,10 @@ use crate::{
     ThinkingConfig, TokenUsage,
 };
 
-use super::{ResolvedAuth, http_client, next_sse_line};
+use super::{KeyPool, ResolvedAuth, http_client, next_sse_line};
 
 const BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
+const ENV_VAR: &str = "GEMINI_API_KEY";
 
 pub(crate) fn models() -> &'static [ModelEntry] {
     &[
@@ -67,30 +67,28 @@ pub(crate) fn models() -> &'static [ModelEntry] {
     ]
 }
 
-fn resolve_auth() -> Result<ResolvedAuth, AgentError> {
-    if let Ok(key) = env::var("GEMINI_API_KEY") {
-        return Ok(ResolvedAuth {
-            base_url: None,
-            headers: vec![("x-goog-api-key".into(), key)],
-        });
+fn resolve_auth_from_key(key: &str) -> ResolvedAuth {
+    ResolvedAuth {
+        base_url: None,
+        headers: vec![("x-goog-api-key".into(), key.to_string())],
     }
-    Err(AgentError::Config {
-        message: "set GEMINI_API_KEY environment variable".into(),
-    })
 }
 
 pub struct Google {
     client: HttpClient,
     auth: Arc<Mutex<ResolvedAuth>>,
+    key_pool: Option<KeyPool>,
     stream_timeout: Duration,
 }
 
 impl Google {
     pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
-        let resolved = resolve_auth()?;
+        let pool = KeyPool::from_env(ENV_VAR)?;
+        let resolved = resolve_auth_from_key(pool.current());
         Ok(Self {
             client: http_client(timeouts),
             auth: Arc::new(Mutex::new(resolved)),
+            key_pool: Some(pool),
             stream_timeout: timeouts.stream,
         })
     }
@@ -102,6 +100,7 @@ impl Google {
         Self {
             client: http_client(timeouts),
             auth,
+            key_pool: None,
             stream_timeout: timeouts.stream,
         }
     }
@@ -255,9 +254,18 @@ impl Provider for Google {
 
     fn reload_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
         Box::pin(async {
-            let resolved = resolve_auth()?;
-            *self.auth.lock().unwrap() = resolved;
+            let pool = KeyPool::from_env(ENV_VAR)?;
+            *self.auth.lock().unwrap() = resolve_auth_from_key(pool.current());
             Ok(())
+        })
+    }
+
+    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
+        Box::pin(async {
+            Ok(self
+                .key_pool
+                .as_ref()
+                .is_some_and(|p| p.rotate_auth(&self.auth, resolve_auth_from_key)))
         })
     }
 }

--- a/maki-providers/src/providers/llama_cpp.rs
+++ b/maki-providers/src/providers/llama_cpp.rs
@@ -7,8 +7,8 @@ use crate::model::{Model, ModelEntry};
 use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
 
-use super::ResolvedAuth;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+use super::{KeyPool, ResolvedAuth};
 
 const HOST_ENV: &str = "LLAMA_CPP_HOST";
 const API_KEY_ENV: &str = "LLAMA_CPP_API_KEY";
@@ -29,22 +29,21 @@ pub(crate) fn models() -> &'static [ModelEntry] {
 pub struct LlamaCpp {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
+    key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
 }
 
 impl LlamaCpp {
     pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
-        Self::from_env(
-            timeouts,
-            std::env::var(API_KEY_ENV).ok(),
-            std::env::var(HOST_ENV).ok(),
-        )
+        let key_pool = KeyPool::from_env(API_KEY_ENV).ok();
+        Self::from_env(timeouts, key_pool, std::env::var(HOST_ENV).ok())
     }
 
     pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
         Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
             auth,
+            key_pool: None,
             system_prefix: None,
         }
     }
@@ -56,7 +55,7 @@ impl LlamaCpp {
 
     fn from_env(
         timeouts: super::Timeouts,
-        api_key: Option<String>,
+        key_pool: Option<KeyPool>,
         host: Option<String>,
     ) -> Result<Self, AgentError> {
         let base_url = match host {
@@ -67,7 +66,7 @@ impl LlamaCpp {
                 });
             }
         };
-        let headers = match api_key {
+        let headers = match key_pool.as_ref().map(|p| p.current().to_string()) {
             Some(key) => vec![("authorization".into(), format!("Bearer {key}"))],
             None => Vec::new(),
         };
@@ -77,6 +76,7 @@ impl LlamaCpp {
                 base_url: Some(base_url),
                 headers,
             })),
+            key_pool,
             system_prefix: None,
         })
     }
@@ -110,6 +110,16 @@ impl Provider for LlamaCpp {
             self.compat.do_list_models(&auth).await
         })
     }
+
+    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
+        Box::pin(async {
+            Ok(self.key_pool.as_ref().is_some_and(|p| {
+                p.rotate_headers(&self.auth, |key| {
+                    vec![("authorization".into(), format!("Bearer {key}"))]
+                })
+            }))
+        })
+    }
 }
 
 #[cfg(test)]
@@ -141,12 +151,9 @@ mod tests {
 
     #[test]
     fn from_env_with_api_key_uses_host_with_auth() {
-        let llama = LlamaCpp::from_env(
-            TEST_TIMEOUTS,
-            Some("test-key".into()),
-            Some("http://local:1234".into()),
-        )
-        .unwrap();
+        let pool = KeyPool::from_keys(vec!["test-key".into()]);
+        let llama = LlamaCpp::from_env(TEST_TIMEOUTS, Some(pool), Some("http://local:1234".into()))
+            .unwrap();
         let auth = llama.auth.lock().unwrap();
         assert_eq!(auth.base_url.as_deref(), Some("http://local:1234/v1"));
         assert_eq!(auth.headers.len(), 1);

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -7,8 +7,8 @@ use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
 
-use super::ResolvedAuth;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+use super::{KeyPool, ResolvedAuth};
 
 static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     api_key_env: "MISTRAL_API_KEY",
@@ -68,17 +68,17 @@ pub(crate) fn models() -> &'static [ModelEntry] {
 pub struct Mistral {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
+    key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
 }
 
 impl Mistral {
     pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
-        let api_key = std::env::var(CONFIG.api_key_env).map_err(|_| AgentError::Config {
-            message: format!("{} not set", CONFIG.api_key_env),
-        })?;
+        let pool = KeyPool::from_env(CONFIG.api_key_env)?;
         Ok(Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
-            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(&api_key))),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(pool.current()))),
+            key_pool: Some(pool),
             system_prefix: None,
         })
     }
@@ -87,6 +87,7 @@ impl Mistral {
         Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
             auth,
+            key_pool: None,
             system_prefix: None,
         }
     }
@@ -132,6 +133,15 @@ impl Provider for Mistral {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
             self.compat.do_list_models(&auth).await
+        })
+    }
+
+    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
+        Box::pin(async {
+            Ok(self
+                .key_pool
+                .as_ref()
+                .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
         })
     }
 }

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use futures_lite::StreamExt;
@@ -146,6 +148,82 @@ pub(crate) fn http_client(timeouts: Timeouts) -> isahc::HttpClient {
         .expect("failed to build HTTP client")
 }
 
+#[derive(Clone)]
+pub struct KeyPool {
+    keys: Arc<Vec<String>>,
+    index: Arc<AtomicUsize>,
+}
+
+impl KeyPool {
+    pub fn from_env(env_var: &str) -> Result<Self, AgentError> {
+        let raw = std::env::var(env_var).map_err(|_| AgentError::Config {
+            message: format!("{env_var} not set"),
+        })?;
+        let keys: Vec<String> = raw
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if keys.is_empty() {
+            return Err(AgentError::Config {
+                message: format!("{env_var} is empty"),
+            });
+        }
+        Ok(Self {
+            keys: Arc::new(keys),
+            index: Arc::new(AtomicUsize::new(0)),
+        })
+    }
+
+    #[cfg(test)]
+    pub fn from_keys(keys: Vec<String>) -> Self {
+        Self {
+            keys: Arc::new(keys),
+            index: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    pub fn current(&self) -> &str {
+        &self.keys[self.index.load(Ordering::Relaxed) % self.keys.len()]
+    }
+
+    pub fn rotate(&self) -> bool {
+        if self.keys.len() <= 1 {
+            return false;
+        }
+        self.index.fetch_add(1, Ordering::Relaxed);
+        true
+    }
+
+    pub fn rotate_auth(
+        &self,
+        auth: &Mutex<ResolvedAuth>,
+        build: impl FnOnce(&str) -> ResolvedAuth,
+    ) -> bool {
+        if !self.rotate() {
+            return false;
+        }
+        *auth.lock().unwrap() = build(self.current());
+        true
+    }
+
+    pub fn rotate_headers(
+        &self,
+        auth: &Mutex<ResolvedAuth>,
+        build: impl FnOnce(&str) -> Vec<(String, String)>,
+    ) -> bool {
+        if !self.rotate() {
+            return false;
+        }
+        auth.lock().unwrap().headers = build(self.current());
+        true
+    }
+
+    pub fn len(&self) -> usize {
+        self.keys.len()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -193,5 +271,37 @@ mod tests {
                 .unwrap_err();
             assert!(matches!(err, AgentError::Timeout { .. }));
         })
+    }
+
+    #[test]
+    fn key_pool_single_key_current() {
+        let pool = KeyPool::from_keys(vec!["sk-1".into()]);
+        assert_eq!(pool.current(), "sk-1");
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn key_pool_single_key_rotate_returns_false() {
+        let pool = KeyPool::from_keys(vec!["sk-1".into()]);
+        assert!(!pool.rotate());
+        assert_eq!(pool.current(), "sk-1");
+    }
+
+    #[test]
+    fn key_pool_multi_key_rotates() {
+        let pool = KeyPool::from_keys(vec!["sk-1".into(), "sk-2".into(), "sk-3".into()]);
+        assert_eq!(pool.current(), "sk-1");
+        assert!(pool.rotate());
+        assert_eq!(pool.current(), "sk-2");
+        assert!(pool.rotate());
+        assert_eq!(pool.current(), "sk-3");
+    }
+
+    #[test]
+    fn key_pool_wraps_around() {
+        let pool = KeyPool::from_keys(vec!["a".into(), "b".into()]);
+        pool.rotate();
+        pool.rotate();
+        assert_eq!(pool.current(), "a");
     }
 }

--- a/maki-providers/src/providers/ollama.rs
+++ b/maki-providers/src/providers/ollama.rs
@@ -7,6 +7,7 @@ use crate::model::{Model, ModelEntry};
 use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
 
+use super::KeyPool;
 use super::ResolvedAuth;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 
@@ -30,22 +31,21 @@ pub(crate) fn models() -> &'static [ModelEntry] {
 pub struct Ollama {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
+    key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
 }
 
 impl Ollama {
     pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
-        Self::from_env(
-            timeouts,
-            std::env::var(API_KEY_ENV).ok(),
-            std::env::var(HOST_ENV).ok(),
-        )
+        let key_pool = KeyPool::from_env(API_KEY_ENV).ok();
+        Self::from_env(timeouts, key_pool, std::env::var(HOST_ENV).ok())
     }
 
     pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
         Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
             auth,
+            key_pool: None,
             system_prefix: None,
         }
     }
@@ -57,9 +57,10 @@ impl Ollama {
 
     fn from_env(
         timeouts: super::Timeouts,
-        api_key: Option<String>,
+        key_pool: Option<KeyPool>,
         host: Option<String>,
     ) -> Result<Self, AgentError> {
+        let api_key = key_pool.as_ref().map(|p| p.current().to_string());
         let base_url = match host {
             Some(h) => format!("{h}/v1"),
             None if api_key.is_some() => CLOUD_BASE_URL.into(),
@@ -79,6 +80,7 @@ impl Ollama {
                 base_url: Some(base_url),
                 headers,
             })),
+            key_pool,
             system_prefix: None,
         })
     }
@@ -112,6 +114,16 @@ impl Provider for Ollama {
             self.compat.do_list_models(&auth).await
         })
     }
+
+    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
+        Box::pin(async {
+            Ok(self.key_pool.as_ref().is_some_and(|p| {
+                p.rotate_headers(&self.auth, |key| {
+                    vec![("authorization".into(), format!("Bearer {key}"))]
+                })
+            }))
+        })
+    }
 }
 
 #[cfg(test)]
@@ -143,7 +155,8 @@ mod tests {
 
     #[test]
     fn from_env_with_api_key_uses_cloud() {
-        let ollama = Ollama::from_env(TEST_TIMEOUTS, Some("test-key".into()), None).unwrap();
+        let pool = KeyPool::from_keys(vec!["test-key".into()]);
+        let ollama = Ollama::from_env(TEST_TIMEOUTS, Some(pool), None).unwrap();
         let auth = ollama.auth.lock().unwrap();
         assert_eq!(auth.base_url.as_deref(), Some(CLOUD_BASE_URL));
         assert_eq!(auth.headers.len(), 1);
@@ -153,12 +166,9 @@ mod tests {
 
     #[test]
     fn from_env_both_host_and_api_key_uses_host_with_auth() {
-        let ollama = Ollama::from_env(
-            TEST_TIMEOUTS,
-            Some("test-key".into()),
-            Some("http://local:1234".into()),
-        )
-        .unwrap();
+        let pool = KeyPool::from_keys(vec!["test-key".into()]);
+        let ollama =
+            Ollama::from_env(TEST_TIMEOUTS, Some(pool), Some("http://local:1234".into())).unwrap();
         let auth = ollama.auth.lock().unwrap();
         assert_eq!(auth.base_url.as_deref(), Some("http://local:1234/v1"));
         assert_eq!(auth.headers.len(), 1);

--- a/maki-providers/src/providers/synthetic.rs
+++ b/maki-providers/src/providers/synthetic.rs
@@ -7,8 +7,8 @@ use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
 
-use super::ResolvedAuth;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+use super::{KeyPool, ResolvedAuth};
 
 static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     api_key_env: "SYNTHETIC_API_KEY",
@@ -68,17 +68,17 @@ pub(crate) fn models() -> &'static [ModelEntry] {
 pub struct Synthetic {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
+    key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
 }
 
 impl Synthetic {
     pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
-        let api_key = std::env::var(CONFIG.api_key_env).map_err(|_| AgentError::Config {
-            message: format!("{} not set", CONFIG.api_key_env),
-        })?;
+        let pool = KeyPool::from_env(CONFIG.api_key_env)?;
         Ok(Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
-            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(&api_key))),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(pool.current()))),
+            key_pool: Some(pool),
             system_prefix: None,
         })
     }
@@ -87,6 +87,7 @@ impl Synthetic {
         Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
             auth,
+            key_pool: None,
             system_prefix: None,
         }
     }
@@ -139,6 +140,15 @@ impl Provider for Synthetic {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
             self.compat.do_list_models(&auth).await
+        })
+    }
+
+    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
+        Box::pin(async {
+            Ok(self
+                .key_pool
+                .as_ref()
+                .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
         })
     }
 }

--- a/maki-providers/src/providers/zai.rs
+++ b/maki-providers/src/providers/zai.rs
@@ -9,8 +9,8 @@ use crate::model::{ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
 
-use super::ResolvedAuth;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+use super::{KeyPool, ResolvedAuth};
 
 static CONFIG_STANDARD: OpenAiCompatConfig = OpenAiCompatConfig {
     api_key_env: "ZHIPU_API_KEY",
@@ -140,6 +140,7 @@ pub enum ZaiPlan {
 pub struct Zai {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
+    key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
 }
 
@@ -149,12 +150,11 @@ impl Zai {
             ZaiPlan::Standard => &CONFIG_STANDARD,
             ZaiPlan::Coding => &CONFIG_CODING,
         };
-        let api_key = std::env::var(config.api_key_env).map_err(|_| AgentError::Config {
-            message: format!("{} not set", config.api_key_env),
-        })?;
+        let pool = KeyPool::from_env(config.api_key_env)?;
         Ok(Self {
             compat: OpenAiCompatProvider::new(config, timeouts),
-            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(&api_key))),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(pool.current()))),
+            key_pool: Some(pool),
             system_prefix: None,
         })
     }
@@ -171,6 +171,7 @@ impl Zai {
         Self {
             compat: OpenAiCompatProvider::new(config, timeouts),
             auth,
+            key_pool: None,
             system_prefix: None,
         }
     }
@@ -221,6 +222,15 @@ impl Provider for Zai {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
             self.compat.do_list_models(&auth).await
+        })
+    }
+
+    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
+        Box::pin(async {
+            Ok(self
+                .key_pool
+                .as_ref()
+                .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
         })
     }
 }

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -15,6 +15,8 @@ Open the model picker with `/model` and press `Alt+1`, `Alt+2`, or `Alt+3` on an
 
 Maki re-reads auth from storage and environment variables each time a new agent spawns (`/new`, retry, session load). If you run `maki auth login` in another terminal or change an env var, the next session picks it up without a restart.
 
+You can set multiple API keys in one env var (`ANTHROPIC_API_KEY=sk-1,sk-2,sk-3`) and they rotate automatically on rate-limit or auth errors.
+
 ## Built-in Providers
 
 ### Anthropic


### PR DESCRIPTION
Set multiple keys in one env var (`ANTHROPIC_API_KEY=sk-1,sk-2,sk-3`) and they rotate automatically on 429/401/403 errors.

A lock-free `KeyPool` wraps the keys with an `AtomicUsize` round-robin index, and each provider rebuilds its `ResolvedAuth` on rotation.

Single-key setups are unchanged since `KeyPool` with one entry never rotates.

#190