### PR TITLE
lua: fix memory plugin system prompt via `collect_prompt_extras` async

### DIFF
--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -389,16 +389,26 @@ impl LuaRuntime {
         }
     }
 
-    fn collect_prompt_extras(&self) -> Vec<String> {
-        let Some(map) = self.lua.app_data_ref::<PromptExtraCallbacks>() else {
-            return Vec::new();
+    async fn collect_prompt_extras(&self) -> Vec<String> {
+        let callbacks: Vec<(Arc<str>, Function)> = {
+            let Some(map) = self.lua.app_data_ref::<PromptExtraCallbacks>() else {
+                return Vec::new();
+            };
+            map.iter()
+                .filter_map(|(plugin, key)| {
+                    let func = self.lua.registry_value::<Function>(key).ok()?;
+                    Some((Arc::clone(plugin), func))
+                })
+                .collect()
         };
         let mut extras = Vec::new();
-        for (plugin, key) in map.iter() {
-            let Ok(func) = self.lua.registry_value::<Function>(key) else {
-                continue;
-            };
-            match func.call::<LuaValue>(()) {
+        for (plugin, func) in &callbacks {
+            let result: mlua::Result<LuaValue> = async {
+                let thread = self.lua.create_thread(func.clone())?;
+                thread.into_async::<LuaValue>(())?.await
+            }
+            .await;
+            match result {
                 Ok(LuaValue::String(s)) => extras.push(s.to_string_lossy()),
                 Ok(LuaValue::Nil) => {}
                 Ok(_) => {
@@ -1283,7 +1293,7 @@ pub fn spawn(
                             let _ = reply.send(res);
                         }
                         Request::CollectPromptExtras { reply } => {
-                            let extras = rt.collect_prompt_extras();
+                            let extras = rt.collect_prompt_extras().await;
                             let _ = reply.send(extras);
                         }
                     Request::RestoreTool {


### PR DESCRIPTION
The memory plugin's `register_system_prompt_extra` callback calls async fs functions (`maki.fs.root`, `maki.fs.dir`), but
`collect_prompt_extras` was calling them synchronously via `func.call()`. Lua can't yield across a C-call boundary, so the callback silently failed and the system prompt never included memory listings.

Switched to the coroutine pattern (`create_thread` + `into_async` + `.await`) that `run_tool_call` and `restore_tool` already use.