### PR TITLE
feat: Extract context windows from llama.cpp router mode

### DIFF
--- a/maki-providers/src/context_windows.rs
+++ b/maki-providers/src/context_windows.rs
@@ -1,0 +1,22 @@
+//! Discovered context windows per provider/model, populated at runtime by
+//! `list_models()`. Not persisted. Used to override the fallback for providers
+//! that accept arbitrary models (e.g. llama-cpp router mode, ollama).
+
+use std::collections::HashMap;
+use std::sync::{OnceLock, RwLock};
+
+use crate::provider::ProviderKind;
+
+static CONTEXT_WINDOWS: OnceLock<RwLock<HashMap<(ProviderKind, String), u32>>> = OnceLock::new();
+
+fn map() -> &'static RwLock<HashMap<(ProviderKind, String), u32>> {
+    CONTEXT_WINDOWS.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+pub fn set_context_window(provider: ProviderKind, model_id: String, window: u32) {
+    map().write().unwrap().insert((provider, model_id), window);
+}
+
+pub fn get_context_window(provider: ProviderKind, model_id: &str) -> Option<u32> {
+    map().read().unwrap().get(&(provider, model_id.to_string())).copied()
+}

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -1,4 +1,5 @@
 pub(crate) mod error;
+pub mod context_windows;
 pub mod model;
 pub mod provider;
 pub(crate) mod providers;

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -210,12 +210,15 @@ impl Model {
                     e.max_output_tokens,
                     e.context_window,
                 ),
-                None => (
-                    provider.family(),
-                    ModelPricing::ZERO,
-                    provider.fallback_max_output(),
-                    provider.fallback_context_window(),
-                ),
+                None => {
+                    let ctx = crate::context_windows::get_context_window(provider, model_id);
+                    (
+                        provider.family(),
+                        ModelPricing::ZERO,
+                        provider.fallback_max_output(),
+                        ctx.unwrap_or_else(|| provider.fallback_context_window()),
+                    )
+                }
             };
             return Ok(Self {
                 id: model_id.to_string(),

--- a/maki-providers/src/providers/llama_cpp.rs
+++ b/maki-providers/src/providers/llama_cpp.rs
@@ -14,6 +14,22 @@ const HOST_ENV: &str = "LLAMA_CPP_HOST";
 const API_KEY_ENV: &str = "LLAMA_CPP_API_KEY";
 const HOST_NOT_SET: &str = "LLAMA_CPP_HOST not set";
 
+fn extract_context_window(model: &Value) -> Option<u32> {
+    if let Some(n_ctx) = model.get("meta").and_then(|m| m.get("n_ctx")).and_then(|v| v.as_u64()) {
+        return Some(n_ctx as u32);
+    }
+    if let Some(args) = model.get("status").and_then(|s| s.get("args")).and_then(|a| a.as_array()) {
+        for i in 0..args.len().saturating_sub(1) {
+            if args[i].as_str() == Some("--ctx-size")
+                && let Some(val) = args[i + 1].as_str().and_then(|s| s.parse::<u32>().ok())
+            {
+                return Some(val);
+            }
+        }
+    }
+    None
+}
+
 static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     api_key_env: "",
     base_url: "http://localhost:8080/v1",
@@ -107,7 +123,27 @@ impl Provider for LlamaCpp {
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
-            self.compat.do_list_models(&auth).await
+            let body = self.compat.do_list_models_raw(&auth).await?;
+            let mut models: Vec<String> = body["data"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|m| {
+                            let id = m["id"].as_str().map(String::from)?;
+                            if let Some(ctx) = extract_context_window(m) {
+                                crate::context_windows::set_context_window(
+                                    crate::provider::ProviderKind::LlamaCpp,
+                                    id.clone(),
+                                    ctx,
+                                );
+                            }
+                            Some(id)
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            models.sort();
+            Ok(models)
         })
     }
 

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -125,14 +125,8 @@ impl OpenAiCompatProvider {
         }
     }
 
-    pub async fn do_list_models(&self, auth: &ResolvedAuth) -> Result<Vec<String>, AgentError> {
-        let request = self.build_request("GET", "/models", auth).body(())?;
-        let mut response = self.client.send_async(request).await?;
-        if response.status().as_u16() != 200 {
-            return Err(AgentError::from_response(response).await);
-        }
-
-        let body: Value = serde_json::from_str(&response.text().await?)?;
+   pub async fn do_list_models(&self, auth: &ResolvedAuth) -> Result<Vec<String>, AgentError> {
+        let body = self.do_list_models_raw(auth).await?;
         let mut models: Vec<String> = body["data"]
             .as_array()
             .map(|arr| {
@@ -143,6 +137,16 @@ impl OpenAiCompatProvider {
             .unwrap_or_default();
         models.sort();
         Ok(models)
+    }
+
+    pub async fn do_list_models_raw(&self, auth: &ResolvedAuth) -> Result<Value, AgentError> {
+        let request = self.build_request("GET", "/models", auth).body(())?;
+        let mut response = self.client.send_async(request).await?;
+        if response.status().as_u16() != 200 {
+            return Err(AgentError::from_response(response).await);
+        }
+        let body: Value = serde_json::from_str(&response.text().await?)?;
+        Ok(body)
     }
 }
 

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -67,6 +67,7 @@ pub(crate) struct EventLoop<'t> {
     shell_tx: flume::Sender<ShellEvent>,
     shell_rx: flume::Receiver<ShellEvent>,
     warn_rx: flume::Receiver<String>,
+    model_ready_rx: flume::Receiver<Model>,
     storage_writer: Arc<StorageWriter>,
     timeouts: Timeouts,
     ui_action_rx: Option<flume::Receiver<UiAction>>,
@@ -76,13 +77,17 @@ pub(crate) struct EventLoop<'t> {
 struct BackgroundModels {
     available: Arc<ArcSwapOption<Vec<String>>>,
     warn_rx: flume::Receiver<String>,
+    model_ready_rx: flume::Receiver<Model>,
     task: smol::Task<()>,
 }
 
-fn spawn_model_fetch() -> BackgroundModels {
+fn spawn_model_fetch(model_slot: &Arc<ArcSwap<ModelSlot>>) -> BackgroundModels {
     let available: Arc<ArcSwapOption<Vec<String>>> = Arc::new(ArcSwapOption::empty());
     let bg = Arc::clone(&available);
     let (warn_tx, warn_rx) = flume::unbounded::<String>();
+    let (model_ready_tx, model_ready_rx) = flume::unbounded::<Model>();
+    let model_slot = Arc::clone(model_slot);
+    let tx = model_ready_tx.clone();
     let task = smol::spawn(async move {
         let warn_tx = warn_tx;
         fetch_all_models(|batch| {
@@ -97,10 +102,19 @@ fn spawn_model_fetch() -> BackgroundModels {
             bg.store(Some(Arc::new(merged)));
         })
         .await;
+
+        // Re-resolve the current model now that context_windows are populated
+        let current = model_slot.load();
+        if let Ok(updated) = Model::from_spec(&current.model.spec())
+            && updated.context_window != current.model.context_window
+        {
+            let _ = tx.try_send(updated);
+        }
     });
     BackgroundModels {
         available,
         warn_rx,
+        model_ready_rx,
         task,
     }
 }
@@ -173,7 +187,13 @@ impl<'t> EventLoop<'t> {
         std::thread::spawn(crate::highlight::warmup);
         crate::update::spawn_check();
 
-        let bg = spawn_model_fetch();
+        let provider: Arc<dyn Provider> =
+            Arc::from(from_model(&model, timeouts).context("create provider")?);
+        let model_slot = Arc::new(ArcSwap::from_pointee(ModelSlot {
+            model: model.clone(),
+            provider,
+        }));
+        let bg = spawn_model_fetch(&model_slot);
         let storage_writer = Arc::new(StorageWriter::new(storage.clone()));
         let (shell_tx, shell_rx) = flume::unbounded::<ShellEvent>();
 
@@ -181,12 +201,6 @@ impl<'t> EventLoop<'t> {
         let initial_history = session.messages.clone();
         let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
 
-        let provider: Arc<dyn Provider> =
-            Arc::from(from_model(&model, timeouts).context("create provider")?);
-        let model_slot = Arc::new(ArcSwap::from_pointee(ModelSlot {
-            model: model.clone(),
-            provider,
-        }));
         let handles = AgentHandles::spawn(
             &model_slot,
             initial_history,
@@ -238,6 +252,7 @@ impl<'t> EventLoop<'t> {
             shell_tx,
             shell_rx,
             warn_rx: bg.warn_rx,
+            model_ready_rx: bg.model_ready_rx,
             storage_writer,
             timeouts,
             ui_action_rx,
@@ -300,6 +315,10 @@ impl<'t> EventLoop<'t> {
 
         while let Ok(warning) = self.warn_rx.try_recv() {
             self.app.flash(warning);
+        }
+
+        while let Ok(updated_model) = self.model_ready_rx.try_recv() {
+            self.app.update_model(&updated_model);
         }
 
         if let Some(rx) = &self.ui_action_rx {


### PR DESCRIPTION
Add context_windows module for runtime context window storage. llama_cpp fetches raw /v1/models response and extracts context lengths (preferring meta.n_ctx, falling back to --ctx-size in status.args). Model::from_spec checks this store for unknown models.

Made with llama.cpp + Qwen3.6-27B + maki (prompt: "the llama.cpp provider in this repository doesn't correctly detect the model's context length when llama-server is running in router mode. try to find a solution about this issue")