### PR TITLE
ui: support multiple concurrent image pastes

### DIFF
--- a/maki-ui/src/app/image_paste.rs
+++ b/maki-ui/src/app/image_paste.rs
@@ -25,24 +25,25 @@ impl App {
         thread::spawn(move || {
             let _ = tx.send(f());
         });
-        self.image_paste_rx = Some(rx);
+        self.image_paste_rx.push(rx);
         self.status_bar.flash(flash);
     }
 
     pub fn poll_image_paste(&mut self) {
-        let Some(ref rx) = self.image_paste_rx else {
-            return;
-        };
-        let Ok(result) = rx.try_recv() else {
-            return;
-        };
-        self.image_paste_rx = None;
-        match result {
-            Ok(source) => {
-                self.input_box.attach_image(source);
-                self.status_bar.flash("Image attached".into());
+        let mut i = 0;
+        while i < self.image_paste_rx.len() {
+            let Ok(result) = self.image_paste_rx[i].try_recv() else {
+                i += 1;
+                continue;
+            };
+            self.image_paste_rx.swap_remove(i);
+            match result {
+                Ok(source) => {
+                    self.input_box.attach_image(source);
+                    self.status_bar.flash("Image attached".into());
+                }
+                Err(e) => self.status_bar.flash(format!("Image paste failed: {e}")),
             }
-            Err(e) => self.status_bar.flash(format!("Image paste failed: {e}")),
         }
     }
 }

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -164,7 +164,7 @@ pub struct App {
     pub(crate) storage: StateDir,
     pub(crate) shared_history: Option<Arc<ArcSwap<Vec<Message>>>>,
     pub(crate) shared_tool_outputs: Option<Arc<Mutex<HashMap<String, ToolOutput>>>>,
-    pub(crate) image_paste_rx: Option<flume::Receiver<Result<ImageSource, String>>>,
+    pub(crate) image_paste_rx: Vec<flume::Receiver<Result<ImageSource, String>>>,
     storage_writer: Arc<StorageWriter>,
     pub(crate) shell: shell::ShellState,
     pub(crate) ui_config: UiConfig,
@@ -235,7 +235,7 @@ impl App {
             storage,
             shared_history: None,
             shared_tool_outputs: None,
-            image_paste_rx: None,
+            image_paste_rx: vec![],
             storage_writer,
             shell: shell::ShellState::default(),
             ui_config,
@@ -289,15 +289,22 @@ impl App {
             Msg::Paste(text) => {
                 let text = text.replace("\r\n", "\n").replace('\r', "\n");
                 if text.is_empty() {
-                    if self.is_main_chat() && self.image_paste_rx.is_none() {
+                    if self.is_main_chat() && self.image_paste_rx.is_empty() {
                         self.start_image_paste();
                     }
-                } else if let Some((path, media_type)) = image::try_parse_image_path(&text) {
-                    if self.is_main_chat() && self.image_paste_rx.is_none() {
-                        self.start_file_image_paste(path, media_type);
-                    }
                 } else {
-                    self.route_text_paste(&text);
+                    let mut any_image = false;
+                    if self.is_main_chat() {
+                        for line in text.lines() {
+                            if let Some((path, mt)) = image::try_parse_image_path(line) {
+                                self.start_file_image_paste(path, mt);
+                                any_image = true;
+                            }
+                        }
+                    }
+                    if !any_image {
+                        self.route_text_paste(&text);
+                    }
                 }
                 vec![]
             }
@@ -693,7 +700,7 @@ impl App {
                 self.search_modal.open(top, auto);
             } else if key::FILE_PICKER.matches(key) {
                 self.file_picker.open(&self.state.session.cwd);
-            } else if key.code == KeyCode::Char('v') && self.image_paste_rx.is_none() {
+            } else if key.code == KeyCode::Char('v') && self.image_paste_rx.is_empty() {
                 self.start_image_paste();
             } else if let InputAction::PaletteSync(val) = self.input_box.handle_key(key) {
                 self.command_palette.sync(&val);
@@ -1302,7 +1309,7 @@ impl App {
     }
 
     pub fn is_animating(&self) -> bool {
-        self.image_paste_rx.is_some()
+        !self.image_paste_rx.is_empty()
             || self.btw_modal.is_animating()
             || self.session_picker.is_loading()
             || self.file_picker.is_loading()

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -302,7 +302,7 @@ fn paste_routed_to_question_form_in_custom_mode() {
 fn paste_file_path_triggers_image_load() {
     let mut app = test_app();
     app.update(Msg::Paste("file:///tmp/nonexistent.png".into()));
-    assert!(app.image_paste_rx.is_some());
+    assert!(!app.image_paste_rx.is_empty());
     assert_eq!(app.input_box.buffer.value(), "");
 }
 


### PR DESCRIPTION
Dragging several images at once would silently drop all but the first because `image_paste_rx` was a single `Option<Receiver>`.

Changed it to a `Vec`, added `try_parse_image_paths` that splits multi-line pastes into individual paths, and `poll_image_paste` now drains all receivers with `swap_remove`.

Closes #237