### PR TITLE
provider: auto-detect context window from llama.cpp/Ollama

### DIFF
--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -214,6 +214,19 @@ pub trait Provider: Send + Sync {
 
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>>;
 
+    /// Probe the backend for the actual context window of `model_id`. Used to
+    /// correct the static fallback (128k for arbitrary Ollama/OpenAI models)
+    /// when pointed at a local server with its own configured window -- see
+    /// llama.cpp's `meta.n_ctx` or Ollama's `model_info.*.context_length`.
+    /// Default returns `Ok(None)` so providers with reliable static metadata
+    /// don't have to implement it.
+    fn discover_context_window<'a>(
+        &'a self,
+        _model_id: &'a str,
+    ) -> BoxFuture<'a, Result<Option<u32>, AgentError>> {
+        Box::pin(async { Ok(None) })
+    }
+
     fn refresh_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
         Box::pin(async { Ok(()) })
     }

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -500,6 +500,13 @@ impl Provider for DynamicProvider {
         self.inner.list_models()
     }
 
+    fn discover_context_window<'a>(
+        &'a self,
+        model_id: &'a str,
+    ) -> BoxFuture<'a, Result<Option<u32>, AgentError>> {
+        self.inner.discover_context_window(model_id)
+    }
+
     fn refresh_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
         self.run_auth_script("refresh")
     }

--- a/maki-providers/src/providers/llama_cpp.rs
+++ b/maki-providers/src/providers/llama_cpp.rs
@@ -120,6 +120,18 @@ impl Provider for LlamaCpp {
             }))
         })
     }
+
+    fn discover_context_window<'a>(
+        &'a self,
+        model_id: &'a str,
+    ) -> BoxFuture<'a, Result<Option<u32>, AgentError>> {
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            self.compat
+                .do_discover_context_window(model_id, &auth)
+                .await
+        })
+    }
 }
 
 #[cfg(test)]

--- a/maki-providers/src/providers/ollama.rs
+++ b/maki-providers/src/providers/ollama.rs
@@ -1,7 +1,8 @@
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
-use serde_json::Value;
+use isahc::{AsyncReadResponseExt, Request};
+use serde_json::{Value, json};
 
 use crate::model::{Model, ModelEntry};
 use crate::provider::{BoxFuture, Provider};
@@ -124,6 +125,42 @@ impl Provider for Ollama {
             }))
         })
     }
+
+    fn discover_context_window<'a>(
+        &'a self,
+        model_id: &'a str,
+    ) -> BoxFuture<'a, Result<Option<u32>, AgentError>> {
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            let base = auth.base_url.as_deref().unwrap_or(CONFIG.base_url);
+            let host = base.strip_suffix("/v1").unwrap_or(base);
+            let body = serde_json::to_vec(&json!({"name": model_id}))?;
+            let mut builder = Request::builder()
+                .method("POST")
+                .uri(format!("{host}/api/show"))
+                .header("content-type", "application/json");
+            for (key, value) in &auth.headers {
+                builder = builder.header(key.as_str(), value.as_str());
+            }
+            let request = builder.body(body)?;
+            let mut response = self.compat.client().send_async(request).await?;
+            if response.status().as_u16() != 200 {
+                return Err(AgentError::from_response(response).await);
+            }
+            let body: Value = serde_json::from_str(&response.text().await?)?;
+            Ok(extract_context_length(&body))
+        })
+    }
+}
+
+/// Ollama's `/api/show` response carries arch-prefixed metadata in
+/// `model_info`, e.g. `{"llama.context_length": 131072, ...}`. We scan for the
+/// first `*.context_length` entry rather than hard-coding architecture names.
+fn extract_context_length(body: &Value) -> Option<u32> {
+    let info = body.get("model_info")?.as_object()?;
+    info.iter()
+        .find_map(|(k, v)| k.ends_with(".context_length").then(|| v.as_u64()).flatten())
+        .and_then(|n| u32::try_from(n).ok())
 }
 
 #[cfg(test)]
@@ -173,5 +210,24 @@ mod tests {
         assert_eq!(auth.base_url.as_deref(), Some("http://local:1234/v1"));
         assert_eq!(auth.headers.len(), 1);
         assert_eq!(auth.headers[0].1, "Bearer test-key");
+    }
+
+    #[test]
+    fn extract_context_length_finds_arch_prefixed_field() {
+        let body = json!({
+            "model_info": {
+                "general.architecture": "llama",
+                "llama.context_length": 131072_u64,
+                "tokenizer.ggml.bos_token_id": 1,
+            }
+        });
+        assert_eq!(extract_context_length(&body), Some(131072));
+    }
+
+    #[test]
+    fn extract_context_length_missing_returns_none() {
+        let body = json!({"model_info": {"general.architecture": "llama"}});
+        assert_eq!(extract_context_length(&body), None);
+        assert_eq!(extract_context_length(&json!({})), None);
     }
 }

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -198,6 +198,24 @@ impl Provider for OpenAi {
         })
     }
 
+    fn discover_context_window<'a>(
+        &'a self,
+        model_id: &'a str,
+    ) -> BoxFuture<'a, Result<Option<u32>, AgentError>> {
+        Box::pin(async move {
+            if self.is_oauth() {
+                return Ok(None);
+            }
+            self.with_oauth_retry(|| async {
+                let auth = self.current_auth();
+                self.compat
+                    .do_discover_context_window(model_id, &auth)
+                    .await
+            })
+            .await
+        })
+    }
+
     fn refresh_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
         Box::pin(async {
             if self.is_oauth() {

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -144,6 +144,36 @@ impl OpenAiCompatProvider {
         models.sort();
         Ok(models)
     }
+
+    /// llama.cpp's llama-server reports the server-side context size as
+    /// `meta.n_ctx` on each `/v1/models` entry. Real OpenAI omits it, in which
+    /// case we return `None` and the caller keeps the static fallback.
+    pub async fn do_discover_context_window(
+        &self,
+        model_id: &str,
+        auth: &ResolvedAuth,
+    ) -> Result<Option<u32>, AgentError> {
+        let request = self.build_request("GET", "/models", auth).body(())?;
+        let mut response = self.client.send_async(request).await?;
+        if response.status().as_u16() != 200 {
+            return Err(AgentError::from_response(response).await);
+        }
+        let body: Value = serde_json::from_str(&response.text().await?)?;
+        Ok(extract_n_ctx(&body, model_id))
+    }
+}
+
+fn extract_n_ctx(body: &Value, model_id: &str) -> Option<u32> {
+    let entries = body["data"].as_array()?;
+    let entry = entries.iter().find(|m| {
+        m["id"].as_str() == Some(model_id)
+            || m["aliases"]
+                .as_array()
+                .is_some_and(|a| a.iter().any(|v| v.as_str() == Some(model_id)))
+    })?;
+    entry["meta"]["n_ctx"]
+        .as_u64()
+        .and_then(|n| u32::try_from(n).ok())
 }
 
 pub fn convert_messages(messages: &[Message], system: &str) -> Vec<Value> {
@@ -944,5 +974,42 @@ data: [DONE]\n";
             assert_eq!(text_deltas, vec!["Hello"]);
             assert_eq!(thinking_deltas, vec!["Let me think", "..."]);
         })
+    }
+
+    /// llama.cpp's /v1/models response includes a non-standard `meta.n_ctx`
+    /// field that reports the actual server-side context window. Match either
+    /// the canonical id or an alias (llama-server exposes both).
+    #[test]
+    fn extract_n_ctx_from_llamacpp_payload() {
+        let body = json!({
+            "object": "list",
+            "data": [{
+                "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
+                "aliases": ["qwen3-coder"],
+                "meta": {"n_ctx": 32768, "n_ctx_train": 262144},
+            }],
+        });
+        assert_eq!(
+            extract_n_ctx(&body, "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF"),
+            Some(32768)
+        );
+        assert_eq!(extract_n_ctx(&body, "qwen3-coder"), Some(32768));
+    }
+
+    #[test]
+    fn extract_n_ctx_absent_for_real_openai_payload() {
+        let body = json!({
+            "object": "list",
+            "data": [{"id": "gpt-4.1", "object": "model", "owned_by": "openai"}],
+        });
+        assert_eq!(extract_n_ctx(&body, "gpt-4.1"), None);
+    }
+
+    #[test]
+    fn extract_n_ctx_unknown_model_is_none() {
+        let body = json!({
+            "data": [{"id": "other", "meta": {"n_ctx": 8192}}],
+        });
+        assert_eq!(extract_n_ctx(&body, "missing"), None);
     }
 }

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -17,7 +17,7 @@ use maki_providers::Timeouts;
 use maki_providers::provider::{Provider, fetch_all_models, from_model};
 use maki_providers::{Message, Model};
 use maki_storage::StateDir;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::AppSession;
 use crate::agent::{AgentCommand, AgentHandles, ModelSlot, shared_queue::QueueItem};
@@ -67,16 +67,56 @@ pub(crate) struct EventLoop<'t> {
     shell_tx: flume::Sender<ShellEvent>,
     shell_rx: flume::Receiver<ShellEvent>,
     warn_rx: flume::Receiver<String>,
+    ctx_window_tx: flume::Sender<ContextWindowUpdate>,
+    ctx_window_rx: flume::Receiver<ContextWindowUpdate>,
     storage_writer: Arc<StorageWriter>,
     timeouts: Timeouts,
     ui_action_rx: Option<flume::Receiver<UiAction>>,
     _model_fetch_task: smol::Task<()>,
 }
 
+/// Result of `Provider::discover_context_window` flowing back to the UI thread.
+/// Carries the spec so a stale discovery (model switched while we were probing)
+/// can be discarded.
+struct ContextWindowUpdate {
+    spec: String,
+    context_window: u32,
+}
+
 struct BackgroundModels {
     available: Arc<ArcSwapOption<Vec<String>>>,
     warn_rx: flume::Receiver<String>,
     task: smol::Task<()>,
+}
+
+/// Probe the current provider for its real context window in the background.
+/// Discovery is best-effort: any error is logged but does not surface to the
+/// user, since the static fallback in `Model::context_window` still works.
+fn spawn_context_discovery(
+    model_slot: &Arc<ArcSwap<ModelSlot>>,
+    tx: &flume::Sender<ContextWindowUpdate>,
+) {
+    let slot = model_slot.load();
+    let spec = slot.model.spec();
+    let model_id = slot.model.id.clone();
+    let provider = Arc::clone(&slot.provider);
+    let tx = tx.clone();
+    smol::spawn(async move {
+        match provider.discover_context_window(&model_id).await {
+            Ok(Some(context_window)) => {
+                debug!(model = %model_id, context_window, "context window discovered");
+                let _ = tx
+                    .send_async(ContextWindowUpdate {
+                        spec,
+                        context_window,
+                    })
+                    .await;
+            }
+            Ok(None) => debug!(model = %model_id, "context window discovery returned None"),
+            Err(e) => warn!(model = %model_id, error = %e, "context window discovery failed"),
+        }
+    })
+    .detach();
 }
 
 fn spawn_model_fetch() -> BackgroundModels {
@@ -187,6 +227,8 @@ impl<'t> EventLoop<'t> {
             model: model.clone(),
             provider,
         }));
+        let (ctx_window_tx, ctx_window_rx) = flume::unbounded::<ContextWindowUpdate>();
+        spawn_context_discovery(&model_slot, &ctx_window_tx);
         let handles = AgentHandles::spawn(
             &model_slot,
             initial_history,
@@ -238,6 +280,8 @@ impl<'t> EventLoop<'t> {
             shell_tx,
             shell_rx,
             warn_rx: bg.warn_rx,
+            ctx_window_tx,
+            ctx_window_rx,
             storage_writer,
             timeouts,
             ui_action_rx,
@@ -280,6 +324,10 @@ impl<'t> EventLoop<'t> {
     fn drain_channels(&mut self) -> bool {
         while let Ok(event) = self.shell_rx.try_recv() {
             self.app.handle_shell_event(event);
+        }
+
+        while let Ok(update) = self.ctx_window_rx.try_recv() {
+            self.apply_context_window_update(update);
         }
 
         let mut had_agent_msg = false;
@@ -446,6 +494,7 @@ impl<'t> EventLoop<'t> {
                         model: new_model,
                         provider: Arc::from(new_provider),
                     }));
+                    spawn_context_discovery(&self.model_slot, &self.ctx_window_tx);
                 }
                 self.respawn_agent(loaded.messages);
                 *self
@@ -507,6 +556,20 @@ impl<'t> EventLoop<'t> {
         }
     }
 
+    fn apply_context_window_update(&mut self, update: ContextWindowUpdate) {
+        let slot = self.model_slot.load_full();
+        if slot.model.spec() != update.spec || slot.model.context_window == update.context_window {
+            return;
+        }
+        let mut new_model = slot.model.clone();
+        new_model.context_window = update.context_window;
+        self.app.update_model(&new_model);
+        self.model_slot.store(Arc::new(ModelSlot {
+            model: new_model,
+            provider: Arc::clone(&slot.provider),
+        }));
+    }
+
     fn change_model(&mut self, spec: String) {
         match Model::from_spec(&spec) {
             Ok(new_model) => match from_model(&new_model, self.timeouts) {
@@ -516,6 +579,7 @@ impl<'t> EventLoop<'t> {
                         model: new_model,
                         provider: Arc::from(new_provider),
                     }));
+                    spawn_context_discovery(&self.model_slot, &self.ctx_window_tx);
                 }
                 Err(e) => self.app.flash(format!("Failed to create provider: {e}")),
             },


### PR DESCRIPTION
provider: auto-detect context window from llama.cpp/Ollama
Add Provider::discover_context_window(model_id) -> Option<u32> with a
default Ok(None), so providers with reliable static metadata can opt in.
Static fallback in Model::context_window still applies when discovery
returns None or errors.

- OpenAiCompatProvider::do_discover_context_window queries /v1/models
  and extracts meta.n_ctx (llama-server reports the server-side context
  size there). Used by LlamaCpp and the OpenAI platform provider.
- Ollama POSTs /api/show on the host root (not /v1) and scans
  model_info.*.context_length for the first arch-prefixed field.
- Dynamic forwards to the inner provider.
- event_loop spawns discovery in the background on agent start and on
  model change, then applies the result via a flume channel; results
  for a stale spec (model switched mid-probe) are dropped.