### PR TITLE
ui: fix user message jumping up for one frame after submit

### DIFF
--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -113,9 +113,12 @@ impl AgentLoop {
                 text,
                 image_count,
                 input,
+                displayed,
                 ..
             } => {
-                let _ = event_tx.send(AgentEvent::QueueItemConsumed { text, image_count });
+                if !displayed {
+                    let _ = event_tx.send(AgentEvent::QueueItemConsumed { text, image_count });
+                }
                 self.do_agent_run(input, event_tx, run_id).await
             }
             QueueItem::Compact { .. } => self.do_compact(&event_tx).await,

--- a/maki-ui/src/agent/shared_queue.rs
+++ b/maki-ui/src/agent/shared_queue.rs
@@ -40,6 +40,11 @@ pub(crate) enum QueueItem {
         image_count: usize,
         input: AgentInput,
         run_id: u64,
+        /// `true` when the UI already drew the bubble (immediate dispatch).
+        /// The agent then skips `QueueItemConsumed` so we don't draw it twice.
+        /// `false` when the user typed while the agent was busy: the UI waits
+        /// for `QueueItemConsumed` before drawing.
+        displayed: bool,
     },
     Compact {
         run_id: u64,
@@ -73,6 +78,16 @@ impl QueueItem {
         match self {
             Self::Message { input, run_id, .. } => ExtractedCommand::Interrupt(input, run_id),
             Self::Compact { run_id } => ExtractedCommand::Compact(run_id),
+        }
+    }
+
+    /// Immediate-dispatch messages already sit in the chat, so hiding them
+    /// here stops the panel from reserving a row the agent is about to free,
+    /// which used to make the bubble hop up by one frame.
+    fn visible_in_panel(&self) -> bool {
+        match self {
+            Self::Message { displayed, .. } => !displayed,
+            Self::Compact { .. } => true,
         }
     }
 }
@@ -131,6 +146,7 @@ impl QueueSender {
     pub(crate) fn text_messages(&self) -> Vec<String> {
         lock(&self.items)
             .iter()
+            .filter(|item| item.visible_in_panel())
             .filter_map(|item| match item {
                 QueueItem::Message { text, .. } => Some(text.clone()),
                 QueueItem::Compact { .. } => None,
@@ -138,9 +154,17 @@ impl QueueSender {
             .collect()
     }
 
-    pub(crate) fn entries(&self) -> Vec<QueueEntry<'static>> {
+    pub(crate) fn panel_len(&self) -> usize {
         lock(&self.items)
             .iter()
+            .filter(|item| item.visible_in_panel())
+            .count()
+    }
+
+    pub(crate) fn panel_entries(&self) -> Vec<QueueEntry<'static>> {
+        lock(&self.items)
+            .iter()
+            .filter(|item| item.visible_in_panel())
             .map(QueueItem::as_queue_entry)
             .collect()
     }
@@ -165,19 +189,26 @@ impl InterruptSource for QueueReceiver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_case::test_case;
 
-    #[test]
-    fn last_sender_drop_closes_notify_channel() {
-        let (tx, rx) = queue();
-        let tx2 = tx.clone();
+    fn msg(displayed: bool) -> QueueItem {
+        QueueItem::Message {
+            text: "t".into(),
+            image_count: 0,
+            input: AgentInput::default(),
+            run_id: 0,
+            displayed,
+        }
+    }
 
-        drop(tx);
-        assert_eq!(rx.notify_rx.try_recv(), Err(flume::TryRecvError::Empty));
-
-        drop(tx2);
-        assert_eq!(
-            rx.notify_rx.try_recv(),
-            Err(flume::TryRecvError::Disconnected)
-        );
+    #[test_case(msg(false),                       true  ; "deferred_message_visible")]
+    #[test_case(msg(true),                        false ; "displayed_message_hidden")]
+    #[test_case(QueueItem::Compact { run_id: 0 }, true  ; "compact_visible")]
+    fn panel_visibility(item: QueueItem, visible: bool) {
+        let (tx, _rx) = queue();
+        tx.push(item);
+        let expected = usize::from(visible);
+        assert_eq!(tx.panel_len(), expected);
+        assert_eq!(tx.panel_entries().len(), expected);
     }
 }

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod session_state;
 pub(crate) mod shell;
 #[cfg(test)]
 mod tests;
-mod view;
+pub(crate) mod view;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -781,9 +781,7 @@ impl App {
             let id = self.shell.next_id();
             let sigil = if prefix.visible { "!" } else { "!!" };
             let display = format!("{sigil} {}", prefix.command);
-            self.main_chat().flush();
-            self.main_chat().push_user_message(display);
-            self.main_chat().enable_auto_scroll();
+            self.main_chat().show_user_message(display);
             return vec![Action::ShellCommand {
                 id,
                 command: prefix.command,
@@ -1131,7 +1129,7 @@ impl App {
             format!("{name} {args}")
         };
         let mut input = self.build_agent_input(&QueuedMessage {
-            text: display_text,
+            text: display_text.clone(),
             images: Vec::new(),
         });
         input.prompt = Some(Box::new(prompt_ref));
@@ -1142,6 +1140,7 @@ impl App {
         } else {
             self.run_id += 1;
             self.status = Status::Streaming;
+            self.main_chat().show_user_message(display_text);
             vec![Action::SendMessage(Box::new(input))]
         }
     }

--- a/maki-ui/src/app/queue.rs
+++ b/maki-ui/src/app/queue.rs
@@ -77,8 +77,12 @@ impl MessageQueue {
         }
     }
 
-    pub(crate) fn entries(&self) -> Vec<QueueEntry<'static>> {
-        self.shared.as_ref().map_or(vec![], |s| s.entries())
+    pub(crate) fn panel_len(&self) -> usize {
+        self.shared.as_ref().map_or(0, |s| s.panel_len())
+    }
+
+    pub(crate) fn panel_entries(&self) -> Vec<QueueEntry<'static>> {
+        self.shared.as_ref().map_or(vec![], |s| s.panel_entries())
     }
 
     pub(crate) fn text_messages(&self) -> Vec<String> {
@@ -102,6 +106,8 @@ impl MessageQueue {
 }
 
 impl App {
+    /// Deferred path: the agent is busy, so park the message and let
+    /// `QueueItemConsumed` draw it once the agent picks it up.
     pub(super) fn queue_and_notify(&mut self, msg: QueuedMessage) {
         let Some(ref shared) = self.queue.shared else {
             return;
@@ -112,6 +118,7 @@ impl App {
             image_count: msg.images.len(),
             input,
             run_id: self.run_id,
+            displayed: false,
         });
     }
 
@@ -124,15 +131,19 @@ impl App {
         });
     }
 
+    /// Agent reached a deferred message: time to draw the bubble.
+    /// Immediate-dispatch items skip this event, so no dedup needed.
     pub(super) fn on_queue_item_consumed(&mut self, text: &str, image_count: usize) {
-        self.main_chat().flush();
         self.main_chat()
-            .push_user_message(format_with_images(text, image_count));
-        self.main_chat().enable_auto_scroll();
+            .show_user_message(format_with_images(text, image_count));
     }
 
+    /// Immediate path: kick off the agent and draw the bubble in the same
+    /// frame, so the user sees their message land where it will stay.
     pub(super) fn start_from_queue(&mut self, msg: &QueuedMessage) -> Vec<super::Action> {
         self.status = super::Status::Streaming;
+        self.main_chat()
+            .show_user_message(format_with_images(&msg.text, msg.images.len()));
         vec![super::Action::SendMessage(Box::new(
             self.build_agent_input(msg),
         ))]

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -150,6 +150,13 @@ fn typing_and_submit() {
     let actions = app.update(Msg::Key(key(KeyCode::Enter)));
     assert!(matches!(&actions[0], Action::SendMessage(s) if s.message == "hi"));
     assert_eq!(app.status, Status::Streaming);
+    // Regression check: the bubble has to be on screen the same frame we
+    // submit, otherwise it briefly sits one row too high before snapping down.
+    assert_eq!(
+        app.main_chat().last_message_role(),
+        Some(&DisplayRole::User),
+    );
+    assert_eq!(app.main_chat().last_message_text(), "hi");
 }
 
 fn with_text(app: &mut App) {
@@ -300,6 +307,35 @@ fn submit_during_streaming_queues_message() {
     let actions = app.update(Msg::Key(key(KeyCode::Enter)));
     assert!(actions.is_empty());
     assert_eq!(app.queue.len(), 1);
+}
+
+#[test]
+fn queue_item_consumed_pushes_deferred_user_message() {
+    let mut app = test_app();
+    type_and_submit(&mut app, "first");
+    assert_eq!(app.main_chat().message_count(), 1);
+
+    app.queue_and_notify(queued_msg("queued"));
+    assert_eq!(
+        app.main_chat().message_count(),
+        1,
+        "queueing while streaming must not render the bubble yet",
+    );
+
+    app.update(agent_msg_with_run_id(
+        AgentEvent::QueueItemConsumed {
+            text: "queued".into(),
+            image_count: 0,
+        },
+        app.run_id,
+    ));
+
+    assert_eq!(app.main_chat().message_count(), 2);
+    assert_eq!(app.main_chat().last_message_text(), "queued");
+    assert_eq!(
+        app.main_chat().last_message_role(),
+        Some(&DisplayRole::User),
+    );
 }
 
 #[test_case(error_app as fn(&mut App) ; "error")]
@@ -799,7 +835,7 @@ fn compact_during_streaming_queues_item() {
     let actions = app.execute_command(cmd("/compact"));
     assert!(actions.is_empty());
     assert_eq!(app.queue.len(), 1);
-    assert_eq!(app.queue.entries()[0].text, "/compact");
+    assert_eq!(app.queue.panel_entries()[0].text, "/compact");
 }
 
 #[test]
@@ -1206,7 +1242,7 @@ fn queue_enter_removes_selected() {
 
     app.update(Msg::Key(key(KeyCode::Enter)));
     assert_eq!(app.queue.len(), 1);
-    assert_eq!(app.queue.entries()[0].text, "second");
+    assert_eq!(app.queue.panel_entries()[0].text, "second");
     assert_eq!(app.queue.focus(), Some(0));
 }
 
@@ -1236,7 +1272,7 @@ fn ctrl_q_pops_front() {
     app.queue_and_notify(queued_msg("second"));
     app.update(Msg::Key(kb::POP_QUEUE.to_key_event()));
     assert_eq!(app.queue.len(), 1);
-    assert_eq!(app.queue.entries()[0].text, "second");
+    assert_eq!(app.queue.panel_entries()[0].text, "second");
     assert!(app.queue.focus().is_none(), "unfocused stays unfocused");
 
     app.queue_and_notify(queued_msg("third"));
@@ -1269,14 +1305,6 @@ fn stale_events_ignored_after_run_id_increment() {
     let actions = type_and_submit(&mut app, "new prompt");
     assert!(matches!(&actions[0], Action::SendMessage(i) if i.message == "new prompt"));
     let active_run = app.run_id;
-
-    app.update(agent_msg_with_run_id(
-        AgentEvent::QueueItemConsumed {
-            text: "new prompt".into(),
-            image_count: 0,
-        },
-        active_run,
-    ));
 
     app.update(agent_msg_with_run_id(
         AgentEvent::TextDelta {

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -50,7 +50,7 @@ impl App {
                 self.plan_form.height().min(max)
             }
         } else if self.is_main_chat() {
-            queue_panel::height(self.queue.len())
+            queue_panel::height(self.queue.panel_len())
                 + self.chats[self.active_chat].todo_panel.height()
                 + self.input_box.height(area.width)
         } else {
@@ -65,7 +65,7 @@ impl App {
         ])
         .areas(area);
 
-        let queue_height = queue_panel::height(self.queue.len());
+        let queue_height = queue_panel::height(self.queue.panel_len());
         let todo_h = if form_visible {
             0
         } else {
@@ -135,7 +135,7 @@ impl App {
         } else if in_plan && self.plan_form.is_visible() {
             self.plan_form.view(frame, layout.bottom_area);
         } else if layout.bottom_area.height > 0 {
-            let queue_entries = self.queue.entries();
+            let queue_entries = self.queue.panel_entries();
             queue_panel::view(frame, layout.queue_area, &queue_entries, self.queue.focus());
             if layout.todo_area.height > 0 {
                 self.chats[self.active_chat]

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -280,6 +280,15 @@ impl Chat {
             .push(DisplayMessage::new(DisplayRole::User, text.into()));
     }
 
+    /// Flush any in-flight stream, push the bubble, then re-pin auto-scroll.
+    /// Doing all three together keeps the bubble from briefly landing in the
+    /// wrong row, which is what caused the one-frame hop after submit.
+    pub fn show_user_message(&mut self, text: impl Into<String>) {
+        self.flush();
+        self.push_user_message(text);
+        self.enable_auto_scroll();
+    }
+
     pub fn shell_tool_start(&mut self, event: ToolStartEvent) {
         self.messages_panel.tool_start(event);
     }

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -431,6 +431,7 @@ impl<'t> EventLoop<'t> {
                     image_count: input.images.len(),
                     input,
                     run_id,
+                    displayed: true,
                 });
             }
             Action::CancelAgent { run_id } => {


### PR DESCRIPTION
`Action::SendMessage` pushes the user's input onto the shared queue (read by the agent loop) but the queue panel was also observing that same queue to size itself. Between `compute_layout` reading `queue.len() == 1` and the actual render, the agent task popped the item, so the queue panel rendered into an empty 3-row reserved area and the user message sat 3 rows above its final position. The next frame saw `queue.len() == 0` and reclaimed the space, producing the hop.

Made the panel observe only items that haven't been displayed in chat: the `displayed` flag (true for immediate dispatch, false for deferred) now gates both `panel_len()` and `panel_entries()`. The raw `len()` and `entries()` remain for internal index-based ops and tests.

Also replaces the previous string-match dedup in `on_queue_item_consumed` with the structural `displayed` flag on `QueueItem::Message`: the agent loop suppresses `QueueItemConsumed` for items already shown by the UI, so the consumer always pushes unconditionally.