### PR TITLE
lua: fix bash timeout hanging on `Waiting for output...`

### DIFF
--- a/maki-lua/src/api/ctx.rs
+++ b/maki-lua/src/api/ctx.rs
@@ -1,10 +1,14 @@
+use std::time::{Duration, Instant};
+
 use maki_agent::AgentEvent;
 use maki_agent::cancel::CancelToken;
 use maki_config::{AgentConfig, ToolOutputLines};
 use mlua::{LuaSerdeExt, UserData, UserDataMethods, Value as LuaValue};
 
 use crate::api::tool::ToolCallReply;
-use crate::runtime::LiveCtx;
+use crate::runtime::{LiveCtx, active_task};
+
+const DEADLINE_ALREADY_SET_MSG: &str = "ctx:set_deadline() already called";
 
 pub(crate) struct RestoreCtx {
     pub(crate) tool_output_lines: ToolOutputLines,
@@ -43,6 +47,18 @@ impl UserData for LuaCtx {
                     content,
                 });
             }
+            Ok(())
+        });
+
+        methods.add_method("set_deadline", |lua, _this, secs: u64| {
+            let handle = active_task(lua);
+            let cell = handle.lock().unwrap_or_else(|e| e.into_inner());
+            if cell.deadline_secs.get().is_some() {
+                return Err(mlua::Error::runtime(DEADLINE_ALREADY_SET_MSG));
+            }
+            cell.deadline_secs.set(Some(secs));
+            cell.deadline
+                .set(Some(Instant::now() + Duration::from_secs(secs)));
             Ok(())
         });
 

--- a/maki-lua/src/api/fn_api.rs
+++ b/maki-lua/src/api/fn_api.rs
@@ -17,13 +17,8 @@ pub(crate) enum JobEvent {
     Exit(i32),
 }
 
-enum JobKind {
-    Process { pid: u32 },
-    Timer,
-}
-
 struct JobMeta {
-    kind: JobKind,
+    pid: u32,
     alive: bool,
     on_stdout: Option<RegistryKey>,
     on_stderr: Option<RegistryKey>,
@@ -132,43 +127,10 @@ impl JobStore {
         self.jobs.insert(
             id,
             JobMeta {
-                kind: JobKind::Process { pid },
+                pid,
                 alive: true,
                 on_stdout,
                 on_stderr,
-                on_exit,
-                event_rx: Some(event_rx),
-            },
-        );
-
-        Ok(id)
-    }
-
-    pub fn start_timer(
-        &mut self,
-        timeout_ms: u64,
-        on_exit: Option<RegistryKey>,
-    ) -> Result<u32, String> {
-        let id = self.next_id;
-        self.next_id += 1;
-
-        let (event_tx, event_rx) = flume::unbounded();
-
-        thread::Builder::new()
-            .name("timer".into())
-            .spawn(move || {
-                thread::sleep(Duration::from_millis(timeout_ms));
-                let _ = event_tx.send(JobEvent::Exit(0));
-            })
-            .map_err(|e| e.to_string())?;
-
-        self.jobs.insert(
-            id,
-            JobMeta {
-                kind: JobKind::Timer,
-                alive: true,
-                on_stdout: None,
-                on_stderr: None,
                 on_exit,
                 event_rx: Some(event_rx),
             },
@@ -260,30 +222,24 @@ fn shell_command(cmd: &str) -> Command {
 }
 
 fn kill_job(meta: &mut JobMeta) {
-    match meta.kind {
-        JobKind::Timer => {
-            meta.alive = false;
+    let pid = meta.pid;
+    #[cfg(unix)]
+    unsafe {
+        libc::killpg(pid as libc::pid_t, libc::SIGKILL);
+    }
+    #[cfg(windows)]
+    {
+        const PROCESS_TERMINATE: u32 = 0x0001;
+        unsafe extern "system" {
+            fn OpenProcess(access: u32, inherit: i32, pid: u32) -> *mut std::ffi::c_void;
+            fn TerminateProcess(handle: *mut std::ffi::c_void, exit_code: u32) -> i32;
+            fn CloseHandle(handle: *mut std::ffi::c_void) -> i32;
         }
-        JobKind::Process { pid } => {
-            #[cfg(unix)]
-            unsafe {
-                libc::killpg(pid as libc::pid_t, libc::SIGKILL);
-            }
-            #[cfg(windows)]
-            {
-                const PROCESS_TERMINATE: u32 = 0x0001;
-                unsafe extern "system" {
-                    fn OpenProcess(access: u32, inherit: i32, pid: u32) -> *mut std::ffi::c_void;
-                    fn TerminateProcess(handle: *mut std::ffi::c_void, exit_code: u32) -> i32;
-                    fn CloseHandle(handle: *mut std::ffi::c_void) -> i32;
-                }
-                unsafe {
-                    let handle = OpenProcess(PROCESS_TERMINATE, 0, pid);
-                    if !handle.is_null() {
-                        TerminateProcess(handle, 1);
-                        CloseHandle(handle);
-                    }
-                }
+        unsafe {
+            let handle = OpenProcess(PROCESS_TERMINATE, 0, pid);
+            if !handle.is_null() {
+                TerminateProcess(handle, 1);
+                CloseHandle(handle);
             }
         }
     }
@@ -325,7 +281,6 @@ pub(crate) fn create_fn_table(lua: &Lua) -> LuaResult<Table> {
             with_task_jobs(lua, |store| {
                 store.start(&cmd, cwd, env, on_stdout, on_stderr, on_exit)
             })
-            .ok_or_else(|| mlua::Error::runtime("job store not initialized"))?
             .map_err(mlua::Error::runtime)
         })?,
     )?;
@@ -333,8 +288,7 @@ pub(crate) fn create_fn_table(lua: &Lua) -> LuaResult<Table> {
     t.set(
         "jobstop",
         lua.create_function(|lua, job_id: u32| {
-            with_task_jobs(lua, |store| store.kill(job_id))
-                .ok_or_else(|| mlua::Error::runtime("job store not initialized"))?;
+            with_task_jobs(lua, |store| store.kill(job_id));
             Ok(())
         })?,
     )?;
@@ -343,7 +297,6 @@ pub(crate) fn create_fn_table(lua: &Lua) -> LuaResult<Table> {
         "jobwait",
         lua.create_async_function(|lua, (job_id, timeout_ms): (u32, Option<u64>)| async move {
             let rx = with_task_jobs(&lua, |store| store.take_receiver(job_id))
-                .ok_or_else(|| mlua::Error::runtime("job store not initialized"))?
                 .ok_or_else(|| mlua::Error::runtime("unknown job id or already waited"))?;
 
             let timeout = Duration::from_millis(timeout_ms.unwrap_or(30_000));
@@ -520,26 +473,5 @@ mod tests {
             buf.is_empty(),
             "drained receiver yields no events via drain_events"
         );
-    }
-
-    #[test]
-    fn start_timer_fires_exit_event() {
-        let mut store = make_store();
-        let id = store.start_timer(50, None).unwrap();
-        assert!(store.has_alive_jobs());
-
-        let rx = store.take_receiver(id).unwrap();
-        let event = rx.recv_timeout(Duration::from_secs(2));
-        assert!(matches!(event, Ok(JobEvent::Exit(0))));
-    }
-
-    #[test]
-    fn kill_timer_marks_dead() {
-        let mut store = make_store();
-        let id = store.start_timer(10_000, None).unwrap();
-        assert!(store.has_alive_jobs());
-
-        store.kill(id);
-        assert!(!store.has_alive_jobs());
     }
 }

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -19,11 +19,10 @@ pub(crate) mod yaml;
 
 use std::sync::Arc;
 
-use mlua::{Function, Lua, Result as LuaResult, Table, Value};
+use mlua::{Lua, Result as LuaResult, Table, Value};
 
 use crate::api::command::UiAction;
 use crate::api::tool::PendingTools;
-use crate::runtime::with_task_jobs;
 
 pub(crate) fn create_maki_global(
     lua: &Lua,
@@ -48,15 +47,6 @@ pub(crate) fn create_maki_global(
     maki.set("text", text::create_text_table(lua)?)?;
     maki.set("ui", ui::create_ui_table(lua, ui_action_tx)?)?;
     maki.set("fn", fn_api::create_fn_table(lua)?)?;
-    maki.set(
-        "defer_fn",
-        lua.create_function(|lua, (func, timeout_ms): (Function, u64)| {
-            let on_exit = lua.create_registry_value(func)?;
-            with_task_jobs(lua, |store| store.start_timer(timeout_ms, Some(on_exit)))
-                .ok_or_else(|| mlua::Error::runtime("job store not initialized"))?
-                .map_err(mlua::Error::runtime)
-        })?,
-    )?;
     maki.set("async", async_api::create_async_table(lua)?)?;
 
     Ok(maki)

--- a/maki-lua/src/api/ui.rs
+++ b/maki-lua/src/api/ui.rs
@@ -31,10 +31,7 @@ pub(crate) fn create_ui_table(
     let t = lua.create_table()?;
     t.set(
         "buf",
-        lua.create_function(|lua, ()| {
-            with_task_bufs(lua, |store| store.create_live())
-                .ok_or_else(|| mlua::Error::runtime("buffer store not initialized"))
-        })?,
+        lua.create_function(|lua, ()| Ok(with_task_bufs(lua, |store| store.create_live())))?,
     )?;
     t.set(
         "highlight",

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -14,7 +14,7 @@ use maki_agent::cancel::CancelToken;
 use maki_agent::tools::{
     HeaderResult, PermissionScopes, RegistryError, Tool, ToolRegistry, ToolSource,
 };
-use maki_agent::{BufferSnapshot, SharedBuf};
+use maki_agent::{BufferSnapshot, SharedBuf, SnapshotLine, SnapshotSpan, SpanStyle};
 use mlua::{Function, Lua, LuaSerdeExt, RegistryKey, Value as LuaValue, VmState};
 use serde_json::Value;
 
@@ -27,13 +27,14 @@ use crate::api::create_maki_global;
 use crate::api::ctx::LuaCtx;
 use crate::api::fn_api::{JobEvent, JobStore};
 use crate::api::setup::ConfigStore;
-use crate::api::tool::{LuaTool, PendingTool, PendingTools, ToolCallReply};
+use crate::api::tool::{LuaOutputFormat, LuaTool, PendingTool, PendingTools, ToolCallReply};
 use crate::error::PluginError;
 
 const INTERRUPT_MSG: &str = "plugin interrupted: cancelled, deadline exceeded, or shutting down";
 const DISPATCH_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const NIL_WITHOUT_FINISH_MSG: &str =
     "handler returned nil without calling ctx:finish() or starting jobs";
+pub(crate) const CANCELLED_MSG: &str = "cancelled";
 const MAX_INFLIGHT_TOOLS: usize = 64;
 const GC_STEP_INTERVAL: usize = 4;
 const INTERRUPT_CANCEL_CHECK_INTERVAL: u32 = 128;
@@ -123,19 +124,23 @@ pub struct LiveCtx {
     pub tool_use_id: String,
 }
 
-struct TaskCtx {
-    cancel: CancelToken,
-    deadline: Option<Instant>,
-    jobs: JobStore,
-    bufs: BufferStore,
-    live: Option<LiveCtx>,
+/// The `Mutex` is never contended (Lua is single-threaded) but
+/// `Lua::app_data` requires `Send + Sync` with the `send` feature.
+pub(crate) struct TaskCell {
+    pub(crate) cancel: CancelToken,
+    pub(crate) deadline: Cell<Option<Instant>>,
+    pub(crate) deadline_secs: Cell<Option<u64>>,
+    pub(crate) jobs: JobStore,
+    pub(crate) bufs: BufferStore,
+    pub(crate) live: Option<LiveCtx>,
 }
 
-impl TaskCtx {
+impl TaskCell {
     fn new(cancel: CancelToken, deadline: Option<Instant>, live: Option<LiveCtx>) -> Self {
         Self {
             cancel,
-            deadline,
+            deadline: Cell::new(deadline),
+            deadline_secs: Cell::new(None),
             jobs: JobStore::new(),
             bufs: BufferStore::new(),
             live,
@@ -143,32 +148,112 @@ impl TaskCtx {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-struct ThreadKey(usize);
-
-impl ThreadKey {
-    fn current(lua: &Lua) -> Self {
-        Self(lua.current_thread().to_pointer() as usize)
-    }
-}
-
-/// Keyed by coroutine pointer. Single-threaded, so no locking needed.
-type TaskMap = HashMap<ThreadKey, TaskCtx>;
+pub(crate) type TaskHandle = Arc<Mutex<TaskCell>>;
 
 type ClickHandlerMap = HashMap<String, (RegistryKey, Arc<SharedBuf>)>;
 
-pub(crate) fn with_task_jobs<R>(lua: &Lua, f: impl FnOnce(&mut JobStore) -> R) -> Option<R> {
-    let key = ThreadKey::current(lua);
-    let mut tasks = lua.app_data_mut::<TaskMap>()?;
-    let ctx = tasks.get_mut(&key)?;
-    Some(f(&mut ctx.jobs))
+pub(crate) fn lock_cell(handle: &TaskHandle) -> std::sync::MutexGuard<'_, TaskCell> {
+    handle.lock().unwrap_or_else(|e| e.into_inner())
 }
 
-pub(crate) fn with_task_bufs<R>(lua: &Lua, f: impl FnOnce(&mut BufferStore) -> R) -> Option<R> {
-    let key = ThreadKey::current(lua);
-    let mut tasks = lua.app_data_mut::<TaskMap>()?;
-    let ctx = tasks.get_mut(&key)?;
-    Some(f(&mut ctx.bufs))
+/// Publishes a `TaskCell` into `Lua::app_data` for the duration of a
+/// task, and restores the previous one on drop. Async work must go
+/// through `scope_future` because concurrent tasks on the same executor
+/// overwrite `app_data` between yields.
+pub(crate) struct TaskScope {
+    lua: Lua,
+    handle: TaskHandle,
+    prev: Option<TaskHandle>,
+}
+
+impl TaskScope {
+    pub(crate) fn new(lua: &Lua, cell: TaskCell) -> Self {
+        let handle: TaskHandle = Arc::new(Mutex::new(cell));
+        let prev = lua.set_app_data::<TaskHandle>(Arc::clone(&handle));
+        Self {
+            lua: lua.clone(),
+            handle,
+            prev,
+        }
+    }
+
+    pub(crate) fn handle(&self) -> &TaskHandle {
+        &self.handle
+    }
+
+    pub(crate) fn scope_future<F>(&self, inner: F) -> ScopedFuture<F> {
+        ScopedFuture {
+            lua: self.lua.clone(),
+            handle: Arc::clone(&self.handle),
+            inner,
+        }
+    }
+}
+
+impl Drop for TaskScope {
+    fn drop(&mut self) {
+        {
+            let mut cell = lock_cell(&self.handle);
+            cell.jobs.kill_all();
+            cell.jobs.clear(&self.lua);
+            cell.bufs.clear();
+        }
+        match self.prev.take() {
+            Some(p) => {
+                self.lua.set_app_data(p);
+            }
+            None => {
+                self.lua.remove_app_data::<TaskHandle>();
+            }
+        }
+    }
+}
+
+/// Re-publishes the task handle around every `poll` so each concurrent
+/// task on the shared Lua instance sees its own `TaskCell`.
+pub(crate) struct ScopedFuture<F> {
+    lua: Lua,
+    handle: TaskHandle,
+    inner: F,
+}
+
+impl<F: std::future::Future> std::future::Future for ScopedFuture<F> {
+    type Output = F::Output;
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        // SAFETY: `inner` is structurally pinned; `lua`/`handle` are
+        // never moved out.
+        let this = unsafe { self.get_unchecked_mut() };
+        let prev = this
+            .lua
+            .set_app_data::<TaskHandle>(Arc::clone(&this.handle));
+        let result = unsafe { std::pin::Pin::new_unchecked(&mut this.inner) }.poll(cx);
+        match prev {
+            Some(p) => {
+                this.lua.set_app_data(p);
+            }
+            None => {
+                this.lua.remove_app_data::<TaskHandle>();
+            }
+        }
+        result
+    }
+}
+
+pub(crate) fn active_task(lua: &Lua) -> TaskHandle {
+    lua.app_data_ref::<TaskHandle>()
+        .map(|r| Arc::clone(&*r))
+        .expect("task accessor called outside a task scope")
+}
+
+pub(crate) fn with_task_jobs<R>(lua: &Lua, f: impl FnOnce(&mut JobStore) -> R) -> R {
+    f(&mut lock_cell(&active_task(lua)).jobs)
+}
+
+pub(crate) fn with_task_bufs<R>(lua: &Lua, f: impl FnOnce(&mut BufferStore) -> R) -> R {
+    f(&mut lock_cell(&active_task(lua)).bufs)
 }
 
 pub(crate) fn with_click_handlers<R>(
@@ -179,24 +264,22 @@ pub(crate) fn with_click_handlers<R>(
 }
 
 pub(crate) fn with_live_ctx<R>(lua: &Lua, f: impl FnOnce(&LiveCtx) -> R) -> Option<R> {
-    let key = ThreadKey::current(lua);
-    lua.app_data_ref::<TaskMap>()
-        .and_then(|tasks| tasks.get(&key)?.live.as_ref().map(f))
+    let handle = lua.app_data_ref::<TaskHandle>()?;
+    lock_cell(&handle).live.as_ref().map(f)
 }
 
 pub(crate) fn enqueue_async_task(lua: &Lua, work_fn: RegistryKey) -> Result<(), mlua::Error> {
-    let key = ThreadKey::current(lua);
-    let (cancel, live_ctx, live_buf) = lua
-        .app_data_ref::<TaskMap>()
-        .and_then(|m| {
-            let ctx = m.get(&key)?;
-            Some((
-                ctx.cancel.clone(),
-                ctx.live.clone(),
-                ctx.bufs.live_buf().cloned(),
-            ))
-        })
-        .unwrap_or((CancelToken::none(), None, None));
+    let (cancel, live_ctx, live_buf) = match lua.app_data_ref::<TaskHandle>() {
+        Some(h) => {
+            let cell = lock_cell(&h);
+            (
+                cell.cancel.clone(),
+                cell.live.clone(),
+                cell.bufs.live_buf().cloned(),
+            )
+        }
+        None => (CancelToken::none(), None, None),
+    };
 
     let task = PendingAsyncTask {
         work_fn,
@@ -211,35 +294,6 @@ pub(crate) fn enqueue_async_task(lua: &Lua, work_fn: RegistryKey) -> Result<(), 
         .ok_or_else(|| mlua::Error::runtime("spawn queue not initialized"))?;
     queue.borrow_mut().push(task);
     Ok(())
-}
-
-struct TaskCleanupGuard {
-    lua: Lua,
-    key: ThreadKey,
-}
-
-impl Drop for TaskCleanupGuard {
-    fn drop(&mut self) {
-        if let Some(mut task) = self
-            .lua
-            .app_data_mut::<TaskMap>()
-            .and_then(|mut m| m.remove(&self.key))
-        {
-            task.jobs.kill_all();
-            task.jobs.clear(&self.lua);
-            task.bufs.clear();
-        }
-    }
-}
-
-fn register_task(lua: &Lua, thread_key: ThreadKey, ctx: TaskCtx) -> TaskCleanupGuard {
-    if let Some(mut tasks) = lua.app_data_mut::<TaskMap>() {
-        tasks.insert(thread_key, ctx);
-    }
-    TaskCleanupGuard {
-        lua: lua.clone(),
-        key: thread_key,
-    }
 }
 
 /// Caps concurrent coroutines so they don't blow the Lua stack or starve
@@ -347,15 +401,13 @@ fn drain_spawn_queue(lua: &Lua, ex: &Rc<smol::LocalExecutor<'_>>, gate: &Rc<Infl
         ex.spawn(async move {
             let _gate_guard = GateGuard::new(&g);
 
-            let run = async {
+            let scope = TaskScope::new(
+                &lua,
+                TaskCell::new(task.cancel.clone(), task.deadline, task.live_ctx.clone()),
+            );
+            let run = scope.scope_future(async {
                 let work_fn: Function = lua.registry_value(&task.work_fn)?;
                 let thread = lua.create_thread(work_fn)?;
-                let thread_key = ThreadKey(thread.to_pointer() as usize);
-                let _cleanup = register_task(
-                    &lua,
-                    thread_key,
-                    TaskCtx::new(task.cancel.clone(), task.deadline, task.live_ctx.clone()),
-                );
                 let async_thread = thread.into_async::<LuaValue>(())?;
                 match task.deadline {
                     Some(dl) => {
@@ -367,7 +419,7 @@ fn drain_spawn_queue(lua: &Lua, ex: &Rc<smol::LocalExecutor<'_>>, gate: &Rc<Infl
                     }
                     None => async_thread.await,
                 }
-            };
+            });
 
             let result = run.await;
             if let Err(e) = &result {
@@ -383,6 +435,7 @@ fn drain_spawn_queue(lua: &Lua, ex: &Rc<smol::LocalExecutor<'_>>, gate: &Rc<Infl
                 }
             }
 
+            drop(scope);
             lua.remove_registry_value(task.work_fn).ok();
             drain_spawn_queue(&lua, &ex2, &g);
         })
@@ -436,23 +489,12 @@ impl LuaRuntime {
             if tick % INTERRUPT_CANCEL_CHECK_INTERVAL != 0 {
                 return Ok(VmState::Continue);
             }
-            // current_thread() pushes onto the Lua stack which is unsafe in
-            // interrupts (luau-lang/luau#446). Rate-limit this check to avoid
-            // exhausting the auxiliary stack in long-running coroutines.
-            let thread = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                interrupt_lua.current_thread()
-            }));
-            let Ok(thread) = thread else {
-                return Ok(VmState::Continue);
-            };
-            let key = ThreadKey(thread.to_pointer() as usize);
             let cancelled = interrupt_lua
-                .app_data_ref::<TaskMap>()
-                .and_then(|m| {
-                    let ctx = m.get(&key)?;
-                    let cancel = ctx.cancel.is_cancelled();
-                    let expired = ctx.deadline.is_some_and(|d| Instant::now() > d);
-                    Some(cancel || expired)
+                .app_data_ref::<TaskHandle>()
+                .map(|h| {
+                    let cell = lock_cell(&h);
+                    cell.cancel.is_cancelled()
+                        || cell.deadline.get().is_some_and(|d| Instant::now() > d)
                 })
                 .unwrap_or(false);
             if cancelled {
@@ -476,7 +518,6 @@ impl LuaRuntime {
             source: e,
         })?;
 
-        lua.set_app_data(TaskMap::new());
         lua.set_app_data(ClickHandlerMap::new());
         lua.set_app_data(CommandHandlerMap::new());
         lua.set_app_data(SpawnQueue::default());
@@ -552,11 +593,14 @@ impl LuaRuntime {
         };
         let mut extras = Vec::new();
         for (plugin, func) in &callbacks {
-            let result: mlua::Result<LuaValue> = async {
-                let thread = self.lua.create_thread(func.clone())?;
-                thread.into_async::<LuaValue>(())?.await
-            }
-            .await;
+            let scope = TaskScope::new(&self.lua, TaskCell::new(CancelToken::none(), None, None));
+            let result: mlua::Result<LuaValue> = scope
+                .scope_future(async {
+                    let thread = self.lua.create_thread(func.clone())?;
+                    thread.into_async::<LuaValue>(())?.await
+                })
+                .await;
+            drop(scope);
             match result {
                 Ok(LuaValue::String(s)) => extras.push(s.to_string_lossy()),
                 Ok(LuaValue::Nil) => {}
@@ -849,20 +893,11 @@ impl LuaRuntime {
             }
         };
 
-        let key = ThreadKey::current(&self.lua);
-        let task_ctx = TaskCtx::new(CancelToken::none(), None, None);
-        let Some(mut tasks) = self.lua.app_data_mut::<TaskMap>() else {
-            return HeaderResult::plain(tool.to_string());
-        };
-        tasks.insert(key, task_ctx);
-        drop(tasks);
+        let scope = TaskScope::new(&self.lua, TaskCell::new(CancelToken::none(), None, None));
+        let result = func.call::<LuaValue>(input_lua);
+        drop(scope);
 
-        let _cleanup = TaskCleanupGuard {
-            lua: self.lua.clone(),
-            key,
-        };
-
-        match func.call::<LuaValue>(input_lua) {
+        match result {
             Ok(LuaValue::String(s)) => match s.to_str() {
                 Ok(s) => HeaderResult::plain(s.to_owned()),
                 Err(_) => HeaderResult::plain(tool.to_string()),
@@ -896,29 +931,33 @@ impl LuaRuntime {
         };
         let input_lua = self.lua.to_value(&input).ok()?;
         let thread = self.lua.create_thread(func).ok()?;
-        let thread_key = ThreadKey(thread.to_pointer() as usize);
 
         let (dummy_tx, _) = flume::unbounded();
-        let task_ctx = TaskCtx::new(
-            CancelToken::none(),
-            None,
-            Some(LiveCtx {
-                event_tx: maki_agent::EventSender::new(dummy_tx, 0),
-                tool_use_id: tool_use_id.to_owned(),
-            }),
+        let scope = TaskScope::new(
+            &self.lua,
+            TaskCell::new(
+                CancelToken::none(),
+                None,
+                Some(LiveCtx {
+                    event_tx: maki_agent::EventSender::new(dummy_tx, 0),
+                    tool_use_id: tool_use_id.to_owned(),
+                }),
+            ),
         );
-        let _cleanup = register_task(&self.lua, thread_key, task_ctx);
 
         let ctx_ud = self
             .lua
             .create_userdata(crate::api::ctx::RestoreCtx { tool_output_lines })
             .ok()?;
-        let ret = thread
+        let inner = thread
             .into_async::<LuaValue>((input_lua, output, is_error, ctx_ud))
-            .ok()?
+            .ok()?;
+        let ret = scope
+            .scope_future(inner)
             .await
             .inspect_err(|e| tracing::warn!(tool, error = %e, "restore callback failed"))
             .ok()?;
+        drop(scope);
 
         extract_restore_reply(&ret)
     }
@@ -1044,20 +1083,19 @@ fn extract_restore_reply(ret: &LuaValue) -> Option<RestoreReply> {
     Some(RestoreReply { body, header })
 }
 
-/// A handler returning nil means "I went async". This loop polls job
-/// events until the plugin calls `ctx:finish()` or every job dies.
+/// Nil from the handler means "I went async". Polls job events until
+/// `ctx:finish()`, all jobs die, or the deadline (possibly set
+/// mid-flight via `ctx:set_deadline`) expires.
 async fn dispatch_async(
     lua: &Lua,
-    key: ThreadKey,
+    handle: TaskHandle,
+    plugin: &str,
+    tool: &str,
     finish_rx: flume::Receiver<ToolCallReply>,
 ) -> ToolCallReply {
-    let task_state = lua.app_data_ref::<TaskMap>().and_then(|m| {
-        let ctx = m.get(&key)?;
-        Some((ctx.cancel.clone(), ctx.deadline, !ctx.jobs.is_empty()))
-    });
-
-    let Some((cancel, deadline, has_jobs)) = task_state else {
-        return ToolCallReply::err(NIL_WITHOUT_FINISH_MSG);
+    let (cancel, has_jobs) = {
+        let cell = lock_cell(&handle);
+        (cell.cancel.clone(), !cell.jobs.is_empty())
     };
 
     if !has_jobs {
@@ -1069,12 +1107,20 @@ async fn dispatch_async(
         };
     }
 
-    let is_cancelled = || cancel.is_cancelled() || deadline.is_some_and(|d| Instant::now() > d);
+    let timed_out = || {
+        lock_cell(&handle)
+            .deadline
+            .get()
+            .is_some_and(|d| Instant::now() > d)
+    };
     let mut event_buf = Vec::new();
 
     loop {
-        if is_cancelled() {
-            return ToolCallReply::err("cancelled");
+        if cancel.is_cancelled() {
+            return ToolCallReply::err(CANCELLED_MSG);
+        }
+        if timed_out() {
+            return timeout_reply(&handle, plugin, tool);
         }
 
         match finish_rx.try_recv() {
@@ -1085,18 +1131,10 @@ async fn dispatch_async(
             Err(flume::TryRecvError::Empty) => {}
         }
 
-        if let Some(m) = lua.app_data_ref::<TaskMap>() {
-            if let Some(ctx) = m.get(&key) {
-                ctx.jobs.drain_events(&mut event_buf);
-            }
-        }
+        lock_cell(&handle).jobs.drain_events(&mut event_buf);
 
         if event_buf.is_empty() {
-            let has_alive = lua
-                .app_data_ref::<TaskMap>()
-                .and_then(|m| Some(m.get(&key)?.jobs.has_alive_jobs()))
-                .unwrap_or(false);
-
+            let has_alive = lock_cell(&handle).jobs.has_alive_jobs();
             if !has_alive {
                 smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
                 return match finish_rx.try_recv() {
@@ -1111,12 +1149,10 @@ async fn dispatch_async(
         for (job_id, event) in event_buf.drain(..) {
             let is_exit = matches!(event, JobEvent::Exit(_));
 
-            let callback = lua.app_data_ref::<TaskMap>().and_then(|m| {
-                let ctx = m.get(&key)?;
-                ctx.jobs
-                    .callback_key(job_id, &event)
-                    .and_then(|k| lua.registry_value::<Function>(k).ok())
-            });
+            let callback = lock_cell(&handle)
+                .jobs
+                .callback_key(job_id, &event)
+                .and_then(|k| lua.registry_value::<Function>(k).ok());
 
             if let Some(func) = callback {
                 let arg: LuaValue = match &event {
@@ -1132,19 +1168,48 @@ async fn dispatch_async(
             }
 
             if is_exit {
-                if let Some(mut tasks) = lua.app_data_mut::<TaskMap>() {
-                    if let Some(ctx) = tasks.get_mut(&key) {
-                        ctx.jobs.mark_dead(job_id);
-                    }
-                }
+                lock_cell(&handle).jobs.mark_dead(job_id);
             }
         }
     }
 }
 
-/// Coroutines interleave at yield points on a single `smol::LocalExecutor`.
-/// Deadlines work in three layers: `set_interrupt` catches tight CPU loops,
-/// `smol::Timer` races catch I/O waits, and the dispatch loop covers jobs.
+/// The error message format is load-bearing: the bash plugin's `restore`
+/// parses it to re-render the timeout sentinel on session reload.
+fn timeout_reply(handle: &TaskHandle, plugin: &str, tool: &str) -> ToolCallReply {
+    let (secs, live_buf) = {
+        let cell = lock_cell(handle);
+        (
+            cell.deadline_secs.get().unwrap_or(0),
+            cell.bufs.live_buf().cloned(),
+        )
+    };
+    let qualified = if plugin == tool || plugin.is_empty() {
+        tool.to_owned()
+    } else {
+        format!("{plugin}.{tool}")
+    };
+
+    if let Some(ref buf) = live_buf {
+        buf.append(SnapshotLine {
+            spans: vec![SnapshotSpan {
+                text: format!("Timed out after {secs}s"),
+                style: SpanStyle::Named("dim".into()),
+            }],
+        });
+    }
+
+    ToolCallReply {
+        result: Err(format!("tool {qualified} timed out after {secs}s")),
+        snapshot: None,
+        header: None,
+        live_buf,
+        format: LuaOutputFormat::default(),
+    }
+}
+
+/// Deadlines work in two layers: the interrupt hook catches tight CPU
+/// loops, and the dispatch loop catches I/O waits between job events.
 #[allow(clippy::too_many_arguments)]
 async fn run_tool_call(
     lua: Lua,
@@ -1191,52 +1256,60 @@ async fn run_tool_call(
         Ok(t) => t,
         Err(e) => return ToolCallReply::err(e.to_string()),
     };
-    let thread_key = ThreadKey(thread.to_pointer() as usize);
-
-    let task_ctx = TaskCtx::new(cancel, deadline, live);
-    let _cleanup = register_task(&lua, thread_key, task_ctx);
+    let scope = TaskScope::new(&lua, TaskCell::new(cancel, deadline, live));
+    let handle = Arc::clone(scope.handle());
 
     let async_thread = match thread.into_async::<LuaValue>((input_lua, ctx_ud)) {
         Ok(at) => at,
         Err(e) => return ToolCallReply::err(e.to_string()),
     };
 
-    let call_future = async {
-        match async_thread.await {
+    let call_future = scope.scope_future(async {
+        let handler_result = {
+            let deadline = lock_cell(&handle).deadline.get();
+            match deadline {
+                Some(dl) => {
+                    futures_lite::future::race(async_thread, async {
+                        smol::Timer::at(dl).await;
+                        Err(mlua::Error::runtime("timeout"))
+                    })
+                    .await
+                }
+                None => async_thread.await,
+            }
+        };
+        match handler_result {
             Ok(LuaValue::Nil) => {
-                let live_shared = lua.app_data_ref::<TaskMap>().and_then(|m| {
-                    let ctx = m.get(&thread_key)?;
-                    let live = ctx.live.as_ref()?;
-                    let shared = ctx.bufs.live_buf()?;
-                    Some((
-                        live.event_tx.clone(),
-                        live.tool_use_id.clone(),
-                        Arc::clone(shared),
-                    ))
-                });
+                let live_shared = {
+                    let cell = lock_cell(&handle);
+                    cell.live.as_ref().and_then(|live| {
+                        let shared = cell.bufs.live_buf()?;
+                        Some((
+                            live.event_tx.clone(),
+                            live.tool_use_id.clone(),
+                            Arc::clone(shared),
+                        ))
+                    })
+                };
                 if let Some((event_tx, tool_use_id, shared)) = live_shared {
                     let _ = event_tx.send(maki_agent::AgentEvent::LiveToolBuf {
                         id: tool_use_id,
                         body: shared,
                     });
                 }
-                dispatch_async(&lua, thread_key, finish_rx).await
+                dispatch_async(&lua, Arc::clone(&handle), &plugin, &tool, finish_rx).await
             }
             Ok(val) => ToolCallReply::from_lua_value(&val),
             Err(e) => ToolCallReply::err(e.to_string()),
         }
-    };
+    });
 
-    match deadline {
-        Some(dl) => {
-            futures_lite::future::race(call_future, async {
-                smol::Timer::at(dl).await;
-                ToolCallReply::err("timeout")
-            })
-            .await
-        }
-        None => call_future.await,
-    }
+    // Both the dispatch loop and the interrupt hook read the live
+    // deadline from TaskCell. The outer `tool.rs` timeout is the
+    // absolute backstop.
+    let reply = call_future.await;
+    drop(scope);
+    reply
 }
 
 pub(crate) struct LuaThread {
@@ -1360,9 +1433,15 @@ pub fn spawn(
                                         return;
                                     };
                                     let _ = data.set("row", row);
-                                    if let Err(e) = func.call_async::<()>(data).await {
+                                    let scope = TaskScope::new(
+                                        &lua,
+                                        TaskCell::new(CancelToken::none(), None, None),
+                                    );
+                                    let scoped = scope.scope_future(func.call_async::<()>(data));
+                                    if let Err(e) = scoped.await {
                                         tracing::warn!(tool_id, error = %e, "click handler failed");
                                     }
+                                    drop(scope);
                                     drain_spawn_queue(&lua, &ex_ref, &g);
                                     let _ = reply.send(Some(ClickReply {
                                         snapshot: buf.take(),
@@ -1389,19 +1468,19 @@ pub fn spawn(
                                 let ex_ref = Rc::clone(&ex);
                                 let g = Rc::clone(&gate);
                                 ex.spawn(async move {
+                                    let scope = TaskScope::new(
+                                        &lua,
+                                        TaskCell::new(CancelToken::none(), None, None),
+                                    );
                                     let run = async {
                                         let thread = lua.create_thread(func)?;
-                                        let thread_key = ThreadKey(thread.to_pointer() as usize);
-                                        let _cleanup = register_task(&lua, thread_key, TaskCtx::new(
-                                            CancelToken::none(),
-                                            None,
-                                            None,
-                                        ));
                                         thread.into_async::<()>(args)?.await
                                     };
-                                    if let Err(e) = run.await {
+                                    let scoped = scope.scope_future(run);
+                                    if let Err(e) = scoped.await {
                                         tracing::warn!(plugin = %plugin, command = %command, error = %e, "command handler failed");
                                     }
+                                    drop(scope);
                                     drain_spawn_queue(&lua, &ex_ref, &g);
                                 })
                                 .detach();
@@ -1477,12 +1556,8 @@ pub fn spawn(
 
 #[cfg(test)]
 pub(crate) fn install_live_ctx(lua: &Lua, tool_use_id: &str) {
-    let key = ThreadKey::current(lua);
-    if lua.app_data_ref::<TaskMap>().is_none() {
-        lua.set_app_data(TaskMap::new());
-    }
     let (tx, _rx) = flume::unbounded();
-    let ctx = TaskCtx::new(
+    let cell = TaskCell::new(
         CancelToken::none(),
         None,
         Some(LiveCtx {
@@ -1490,14 +1565,14 @@ pub(crate) fn install_live_ctx(lua: &Lua, tool_use_id: &str) {
             tool_use_id: tool_use_id.to_owned(),
         }),
     );
-    lua.app_data_mut::<TaskMap>().unwrap().insert(key, ctx);
+    let handle: TaskHandle = Arc::new(Mutex::new(cell));
+    lua.set_app_data::<TaskHandle>(handle);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::api::tool::ToolCallReply;
-    use maki_agent::{SnapshotLine, SnapshotSpan, SpanStyle};
 
     fn make_buf_handle(text: &str) -> BufHandle {
         let buf = Arc::new(maki_agent::SharedBuf::new());
@@ -1553,47 +1628,35 @@ mod tests {
     }
 
     #[test]
-    fn task_cleanup_guard_removes_entry() {
+    fn task_scope_clears_jobs_and_bufs_on_drop() {
         let lua = Lua::new();
-        lua.set_app_data(TaskMap::new());
-        let key = ThreadKey::current(&lua);
-        {
-            lua.app_data_mut::<TaskMap>()
-                .unwrap()
-                .insert(key, task_ctx(None));
-        }
-        drop(TaskCleanupGuard {
-            lua: lua.clone(),
-            key,
-        });
-        let tasks = lua.app_data_ref::<TaskMap>().unwrap();
-        assert!(!tasks.contains_key(&key));
+        let scope = TaskScope::new(&lua, task_cell(None));
+        let handle = Arc::clone(scope.handle());
+        lock_cell(&handle).bufs.create_live();
+        assert!(lock_cell(&handle).bufs.live_buf().is_some());
+        drop(scope);
+        assert!(lock_cell(&handle).bufs.live_buf().is_none());
     }
 
-    fn task_ctx(live: Option<LiveCtx>) -> TaskCtx {
-        TaskCtx::new(CancelToken::none(), None, live)
+    fn task_cell(live: Option<LiveCtx>) -> TaskCell {
+        TaskCell::new(CancelToken::none(), None, live)
     }
 
     #[test]
     fn with_live_ctx_follows_task_live_field() {
         let lua = Lua::new();
-        lua.set_app_data(TaskMap::new());
-        let key = ThreadKey::current(&lua);
-
-        lua.app_data_mut::<TaskMap>()
-            .unwrap()
-            .insert(key, task_ctx(None));
-        assert!(with_live_ctx(&lua, |_| ()).is_none());
 
         let (tx, _rx) = flume::unbounded();
-        lua.app_data_mut::<TaskMap>()
-            .unwrap()
-            .get_mut(&key)
-            .unwrap()
-            .live = Some(LiveCtx {
+        let with_live = task_cell(Some(LiveCtx {
             event_tx: maki_agent::EventSender::new(tx, 0),
             tool_use_id: "tool_abc".into(),
-        });
+        }));
+
+        let scope = TaskScope::new(&lua, task_cell(None));
+        assert!(with_live_ctx(&lua, |_| ()).is_none());
+        drop(scope);
+
+        let _scope = TaskScope::new(&lua, with_live);
         assert_eq!(
             with_live_ctx(&lua, |ctx| ctx.tool_use_id.clone()).unwrap(),
             "tool_abc"
@@ -1669,7 +1732,6 @@ mod tests {
 
     fn enqueue_test_lua() -> Lua {
         let lua = Lua::new();
-        lua.set_app_data(TaskMap::new());
         lua.set_app_data(SpawnQueue::new(Vec::new()));
         lua
     }
@@ -1679,9 +1741,8 @@ mod tests {
         lua.create_registry_value(func).unwrap()
     }
 
-    fn enqueue_with_ctx(lua: &Lua, ctx: TaskCtx) {
-        let key = ThreadKey::current(lua);
-        lua.app_data_mut::<TaskMap>().unwrap().insert(key, ctx);
+    fn set_active(lua: &Lua, cell: TaskCell) -> TaskScope {
+        TaskScope::new(lua, cell)
     }
 
     #[test]
@@ -1721,7 +1782,7 @@ mod tests {
     fn enqueue_async_task_inherits_cancel_token() {
         let lua = enqueue_test_lua();
         let (trigger, token) = CancelToken::new();
-        enqueue_with_ctx(&lua, TaskCtx::new(token, None, None));
+        let _h = set_active(&lua, TaskCell::new(token, None, None));
         enqueue_async_task(&lua, enqueue_dummy(&lua)).unwrap();
 
         let queue = lua.app_data_ref::<SpawnQueue>().unwrap();
@@ -1738,9 +1799,9 @@ mod tests {
     fn enqueue_async_task_uses_fresh_deadline_regardless_of_parent() {
         let lua = enqueue_test_lua();
         let parent_deadline = Instant::now() - Duration::from_secs(10);
-        enqueue_with_ctx(
+        let _h = set_active(
             &lua,
-            TaskCtx::new(CancelToken::none(), Some(parent_deadline), None),
+            TaskCell::new(CancelToken::none(), Some(parent_deadline), None),
         );
 
         let before = Instant::now();

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use maki_agent::tools::{ToolRegistry, ToolSource};
+use maki_config::{PluginsConfig, ToolOutputLines};
 use maki_lua::{PluginError, PluginHost};
 
 fn fresh_registry() -> Arc<ToolRegistry> {
@@ -56,6 +58,10 @@ const NON_STRING_FIELD_SCHEMA: &str = r#"{
 const NIL_WITHOUT_JOBS_ERR: &str =
     "handler returned nil without calling ctx:finish() or starting jobs";
 const FINISH_CALLED_TWICE_ERR: &str = "ctx:finish() already called";
+const DEADLINE_ALREADY_SET_ERR: &str = "ctx:set_deadline() already called";
+const DEADLINE_TIMEOUT_MSG: &str = "tool deadline_test timed out after 1s";
+const BASH_TIMEOUT_MSG: &str = "tool bash timed out after 1s";
+const BASH_TIMEOUT_MARKER: &str = "Timed out after 1s";
 
 #[test]
 fn stdlib_globals_accessible() {
@@ -992,4 +998,105 @@ fn unload_clears_commands() {
 
     host.unload("cmd_only").unwrap();
     assert_eq!(host.command_reader().load().commands.len(), 0);
+}
+
+#[test]
+fn job_callback_finishes_after_handler_returns_nil() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "job_after_return",
+            description = "on_exit finishes after handler returns nil",
+            schema = {MINIMAL_SCHEMA},
+            audiences = {{ "main" }},
+            handler = function(input, ctx)
+                maki.fn.jobstart("true", {{
+                    on_exit = function(_, code)
+                        ctx:finish("exit=" .. tostring(code))
+                    end,
+                }})
+                return nil
+            end
+        }})"#,
+    );
+    host.load_source("job_after_return", &src).unwrap();
+    let out = exec_tool(&reg, "job_after_return", serde_json::json!({})).unwrap();
+    assert_eq!(out, "exit=0");
+}
+
+#[test]
+fn ctx_set_deadline_times_out() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "deadline_test",
+            description = "uses ctx:set_deadline",
+            schema = {MINIMAL_SCHEMA},
+            audiences = {{ "main" }},
+            handler = function(input, ctx)
+                ctx:set_deadline(1)
+                maki.fn.jobstart("sleep 30", {{
+                    on_exit = function(_, _) ctx:finish("should-not-reach") end,
+                }})
+                return nil
+            end
+        }})"#,
+    );
+    host.load_source("deadline_test", &src).unwrap();
+    let err = exec_tool(&reg, "deadline_test", serde_json::json!({})).unwrap_err();
+    assert_eq!(err, DEADLINE_TIMEOUT_MSG);
+}
+
+#[test]
+fn ctx_set_deadline_twice_errors() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "deadline_twice",
+            description = "calls set_deadline twice",
+            schema = {MINIMAL_SCHEMA},
+            audiences = {{ "main" }},
+            handler = function(input, ctx)
+                ctx:set_deadline(5)
+                ctx:set_deadline(5)
+            end
+        }})"#,
+    );
+    host.load_source("deadline_twice", &src).unwrap();
+    let err = exec_tool(&reg, "deadline_twice", serde_json::json!({})).unwrap_err();
+    assert!(err.contains(DEADLINE_ALREADY_SET_ERR), "got: {err}");
+}
+
+#[test]
+fn bash_timeout_round_trip() {
+    let reg = fresh_registry();
+    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_builtins(&PluginsConfig::from_tools(HashMap::new()))
+        .unwrap();
+
+    let input = serde_json::json!({"command": "sleep 30", "timeout": 1});
+    let err = exec_tool(&reg, "bash", input.clone()).unwrap_err();
+    assert_eq!(err, BASH_TIMEOUT_MSG);
+
+    let handle = host.event_handle().expect("event handle available");
+    let reply = handle
+        .restore_tool(
+            "bash",
+            "test_id",
+            BASH_TIMEOUT_MSG,
+            &input,
+            true,
+            &ToolOutputLines::default(),
+        )
+        .expect("restore should return a reply");
+    let body = reply.body.expect("restore body present");
+    let last = body.lines.last().expect("at least one line");
+    let text: String = last.spans.iter().map(|s| s.text.as_str()).collect();
+    assert!(
+        text.contains(BASH_TIMEOUT_MARKER),
+        "restored body missing timeout marker; got: {text:?}"
+    );
 }

--- a/plugins/bash/init.lua
+++ b/plugins/bash/init.lua
@@ -275,7 +275,10 @@ maki.api.register_tool({
   restore = function(input, output, is_error, ctx)
     local command = resolve_command(input)
     local buf, view = create_bash_view(command, ctx)
-    if is_error then
+    local timeout_secs = output:match("^tool bash timed out after (%d+)s$")
+    if timeout_secs then
+      view:append({ { "Timed out after " .. timeout_secs .. "s", "dim" } })
+    elseif is_error then
       local body, code = output:match("^(.-)\nExit code: (%d+)$")
       if body then
         for line in (body .. "\n"):gmatch("([^\n]*)\n") do
@@ -312,6 +315,8 @@ maki.api.register_tool({
     local max_lines = (config and config.max_output_lines) or 2000
     local max_bytes = (config and config.max_output_bytes) or (50 * 1024)
 
+    ctx:set_deadline(timeout_secs)
+
     local rewritten = rtk_rewrite(command, ctx)
     if rewritten then
       command = rewritten
@@ -321,14 +326,8 @@ maki.api.register_tool({
 
     local output_parts = {}
     local has_output = false
-    local finished = false
 
     local function finish(exit_code)
-      if finished then
-        return
-      end
-      finished = true
-
       local output = table.concat(output_parts)
       output = truncate(output, max_lines, max_bytes)
 
@@ -359,7 +358,7 @@ maki.api.register_tool({
 
     view:append({ { "Waiting for output...", "dim" } })
 
-    local id = maki.fn.jobstart(command, {
+    maki.fn.jobstart(command, {
       cwd = workdir,
       env = { GIT_TERMINAL_PROMPT = "0" },
       on_stdout = function(_, line)
@@ -382,26 +381,6 @@ maki.api.register_tool({
         finish(code)
       end,
     })
-
-    maki.defer_fn(function()
-      if not finished then
-        maki.fn.jobstop(id)
-        finished = true
-        local output = table.concat(output_parts)
-        output = truncate(output, max_lines, max_bytes)
-        local msg = "command timed out after " .. timeout_secs .. "s"
-        if output ~= "" then
-          msg = msg .. "\n" .. output
-        end
-        view:append({ { "Timed out after " .. timeout_secs .. "s", "dim" } })
-        view:finish()
-        ctx:finish({
-          llm_output = msg,
-          is_error = true,
-          body = buf,
-        })
-      end
-    end, timeout_secs * 1000)
 
     return nil
   end,


### PR DESCRIPTION
`bash command="sleep 5" timeout=1` hung the view on `Waiting for output...` and the LLM got `job callback error: runtime error: job store not initialized`, because per-task state was keyed by the active Lua coroutine pointer via `ThreadKey::current(lua)`, and the `defer_fn` timer fired on the main thread where the lookup missed.

Replaced the ambient lookup with an explicit task scope: `TaskHandle = Arc<Mutex<TaskCell>>` stored in `Lua::app_data`, wrapped around every site that runs Lua for a task (handler coroutine, job callbacks, header, restore, click and command runners) via a sync `with_active_task` guard and an async `ScopedFuture` that re-sets app_data on each `poll`. Accessors now panic outside a scope so missed wraps fail loudly instead of silently returning `None`.

While there, killed the duplicate timeout system: added `ctx:set_deadline(secs)` (one-shot) that writes to the active `TaskCell`, made `dispatch_async` honor the deadline and reply with `tool {name} timed out after {N}s` plus a dim `Timed out after Ns` sentinel in the live buffer, dropped `maki.defer_fn` and `JobStore::start_timer`, and taught the bash `restore` to recognize the sentinel so reloaded sessions render the same dim marker.