### PR TITLE
ui: add `ui.scrollbar` config to hide the scrollbar

### DIFF
--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -199,6 +199,7 @@ pub struct ToolFileConfig {
 #[serde(default, deny_unknown_fields)]
 pub struct UiFileConfig {
     pub splash_animation: Option<bool>,
+    pub scrollbar: Option<bool>,
     pub flash_duration_ms: Option<u64>,
     pub typewriter_ms_per_char: Option<u64>,
     pub mouse_scroll_lines: Option<u32>,
@@ -211,6 +212,7 @@ impl UiFileConfig {
             self,
             overlay,
             splash_animation,
+            scrollbar,
             flash_duration_ms,
             typewriter_ms_per_char,
             mouse_scroll_lines
@@ -420,6 +422,9 @@ pub struct UiConfig {
     #[config(default = true, desc = "Show splash animation on startup")]
     pub splash_animation: bool,
 
+    #[config(default = true, desc = "Show vertical scrollbar in scrollable areas")]
+    pub scrollbar: bool,
+
     #[config(default = DEFAULT_FLASH_DURATION_MS, desc = "Duration of flash messages (ms)")]
     pub flash_duration_ms: u64,
 
@@ -441,6 +446,7 @@ impl UiConfig {
     fn from_file(f: UiFileConfig) -> Self {
         Self {
             splash_animation: f.splash_animation.unwrap_or(true),
+            scrollbar: f.scrollbar.unwrap_or(true),
             flash_duration_ms: f.flash_duration_ms.unwrap_or(DEFAULT_FLASH_DURATION_MS),
             typewriter_ms_per_char: f
                 .typewriter_ms_per_char

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -36,6 +36,7 @@ use crate::components::model_picker::{ModelPicker, ModelPickerAction};
 use crate::components::permission_prompt::PermissionPrompt;
 use crate::components::plan_form::{PlanForm, PlanFormAction};
 use crate::components::rewind_picker::{RewindPicker, RewindPickerAction};
+use crate::components::scrollbar;
 use crate::components::search_modal::{SearchAction, SearchModal};
 use crate::components::session_picker::{SessionPicker, SessionPickerAction};
 use crate::components::status_bar::StatusBar;
@@ -184,6 +185,7 @@ impl App {
         permissions: Arc<PermissionManager>,
         custom_commands: Arc<[maki_agent::command::CustomCommand]>,
     ) -> Self {
+        scrollbar::set_enabled(ui_config.scrollbar);
         let state = SessionState::from_session(session, model, &storage);
         Self {
             chats: vec![Chat::new("Main".into(), ui_config)],

--- a/maki-ui/src/components/scrollbar.rs
+++ b/maki-ui/src/components/scrollbar.rs
@@ -1,10 +1,21 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState};
 
 pub const SCROLLBAR_THUMB: &str = "\u{2590}";
 
+static ENABLED: AtomicBool = AtomicBool::new(true);
+
+pub fn set_enabled(enabled: bool) {
+    ENABLED.store(enabled, Ordering::Relaxed);
+}
+
 pub fn render_vertical_scrollbar(frame: &mut Frame, area: Rect, content_len: u16, position: u16) {
+    if !ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
     let max_scroll = content_len.saturating_sub(area.height);
     let mut state = ScrollbarState::default()
         .content_length(max_scroll as usize + 1)

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -61,6 +61,7 @@ All fields are optional. Typos in field names cause an error right away.
 | Field | Type | Default | Min | Description |
 |-------|------|---------|-----|-------------|
 | `splash_animation` | bool | `true` | - | Show splash animation on startup |
+| `scrollbar` | bool | `true` | - | Show vertical scrollbar in scrollable areas |
 | `flash_duration_ms` | u64 | `1500` | - | Duration of flash messages (ms) |
 | `typewriter_ms_per_char` | u64 | `4` | - | Typewriter effect speed (ms/char) |
 | `mouse_scroll_lines` | u32 | `3` | 1 | Lines per mouse wheel scroll |


### PR DESCRIPTION
The scrollbar was always rendered but not interactive, so it just took up space for people who did not want it.

`UiConfig` now has a `scrollbar` bool (default `true`). `App::new` writes it once into a static `AtomicBool` in `scrollbar.rs`, and `render_vertical_scrollbar` early-returns when disabled. One flag gates all 8 call sites without threading config through every component.

Fixes #248.