### PR TITLE
markdown: unify rendering on a width-aware semantic renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,7 +2381,9 @@ name = "maki-markdown"
 version = "0.3.7"
 dependencies = [
  "fastrand",
+ "maki-highlight",
  "test-case",
+ "unicode-width",
 ]
 
 [[package]]

--- a/maki-lua/src/api/ui.rs
+++ b/maki-lua/src/api/ui.rs
@@ -41,16 +41,22 @@ pub(crate) fn create_ui_table(
             segments_to_lua_lines(&lua, &segments)
         })?,
     )?;
-    // maki.ui.markdown(text) -> lines, each line is `{ {text, style}, ... }`.
-    // Styles: "", "bold", "italic", "bold_italic", "inline_code",
-    // "strikethrough", "list_marker", "heading", "horizontal_rule".
-    // Block roles win over inline emphasis (so `**bold**` inside `#` reads as
-    // "heading"), and code wins over emphasis on content spans.
+    // maki.ui.markdown(text, width) -> lines.
+    // Each line is `{ {text, style}, ... }`. Async because highlighting
+    // code blocks is expensive.
+    //
+    // Style is either a named string (resolved at paint time via
+    // `theme::style_by_name`) or a `{fg, bold, italic, underline}` table
+    // for syntax-highlighted tokens.
+    //
+    // Named styles: "", "bold", "italic", "bold_italic",
+    // "strikethrough", "inline_code", "code_bar", "heading",
+    // "list_marker", "table_border", "horizontal_rule".
     t.set(
         "markdown",
-        lua.create_function(|lua, text: String| {
-            let lines = maki_markdown::render_lines(&text);
-            markdown_lines_to_lua(lua, &lines)
+        lua.create_async_function(|lua, (text, width): (String, u16)| async move {
+            let lines = smol::unblock(move || maki_markdown::render::render(&text, width)).await;
+            markdown_lines_to_lua(&lua, &lines)
         })?,
     )?;
     t.set(
@@ -247,15 +253,73 @@ fn segments_to_lua_lines(
     Ok(result)
 }
 
-fn markdown_lines_to_lua(lua: &Lua, lines: &[maki_markdown::RenderedLine]) -> LuaResult<Table> {
+/// Most spans become a named style string. `Highlight` tokens carry their
+/// own rgb, so they become an inline `{fg, bold, italic, underline}` table.
+///
+/// No wildcard arm on `StyleToken`: adding a variant is a compile error
+/// here, so we can't forget to map it.
+fn span_style_to_lua(lua: &Lua, span: &maki_markdown::render::Span) -> LuaResult<mlua::Value> {
+    use maki_markdown::render::StyleToken;
+
+    let v = match &span.style {
+        StyleToken::Text => {
+            let name = emphasis_style_name(span.emphasis);
+            mlua::Value::String(lua.create_string(name)?)
+        }
+        StyleToken::InlineCode => mlua::Value::String(lua.create_string("inline_code")?),
+        StyleToken::Highlight {
+            fg,
+            bold,
+            italic,
+            underline,
+        } => {
+            let tbl = lua.create_table()?;
+            tbl.set("fg", format!("#{:02x}{:02x}{:02x}", fg.0, fg.1, fg.2))?;
+            if *bold {
+                tbl.set("bold", true)?;
+            }
+            if *italic {
+                tbl.set("italic", true)?;
+            }
+            if *underline {
+                tbl.set("underline", true)?;
+            }
+            mlua::Value::Table(tbl)
+        }
+        StyleToken::CodeBar => mlua::Value::String(lua.create_string("code_bar")?),
+        StyleToken::Heading => mlua::Value::String(lua.create_string("heading")?),
+        StyleToken::ListMarker => mlua::Value::String(lua.create_string("list_marker")?),
+        StyleToken::TableBorder => mlua::Value::String(lua.create_string("table_border")?),
+        StyleToken::HorizontalRule => mlua::Value::String(lua.create_string("horizontal_rule")?),
+    };
+    Ok(v)
+}
+
+/// Flatten `Emphasis` to a single named style. Strike wins over bold/italic
+/// (the Lua theme has no combined slot). Underline only appears in
+/// `Highlight` tokens, not here.
+fn emphasis_style_name(e: maki_markdown::Emphasis) -> &'static str {
+    if e.strike {
+        "strikethrough"
+    } else if e.bold && e.italic {
+        "bold_italic"
+    } else if e.bold {
+        "bold"
+    } else if e.italic {
+        "italic"
+    } else {
+        ""
+    }
+}
+
+fn markdown_lines_to_lua(lua: &Lua, lines: &[maki_markdown::render::Line]) -> LuaResult<Table> {
     let result = lua.create_table_with_capacity(lines.len(), 0)?;
     for (i, rendered) in lines.iter().enumerate() {
         let line_tbl = lua.create_table_with_capacity(rendered.spans.len(), 0)?;
         for (j, sp) in rendered.spans.iter().enumerate() {
-            let style = maki_markdown::span_style_name(&rendered.kind, sp);
             let span_tbl = lua.create_table_with_capacity(2, 0)?;
             span_tbl.raw_set(1, sp.text.as_str())?;
-            span_tbl.raw_set(2, style)?;
+            span_tbl.raw_set(2, span_style_to_lua(lua, sp)?)?;
             line_tbl.raw_set(i32::try_from(j + 1).unwrap(), span_tbl)?;
         }
         result.raw_set(i32::try_from(i + 1).unwrap(), line_tbl)?;
@@ -514,17 +578,23 @@ mod tests {
     const STYLE_HR: &str = "horizontal_rule";
     const STYLE_PLAIN: &str = "";
     const STYLE_CODE: &str = "inline_code";
+    const STYLE_CODE_BAR: &str = "code_bar";
     const STYLE_ITALIC: &str = "italic";
     const STYLE_STRIKE: &str = "strikethrough";
+    const STYLE_TABLE_BORDER: &str = "table_border";
+    const MD_WIDTH: u16 = 80;
 
     fn render_markdown(lua: &Lua, input: &str) -> Table {
-        let lines = maki_markdown::render_lines(input);
+        let lines = maki_markdown::render::render(input, MD_WIDTH);
         markdown_lines_to_lua(lua, &lines).unwrap()
     }
 
     fn span_style(line: &Table, idx: usize) -> String {
         let span: Table = line.get(idx).unwrap();
-        span.get::<String>(2).unwrap()
+        match span.get::<mlua::Value>(2).unwrap() {
+            mlua::Value::String(s) => s.to_str().unwrap().to_string(),
+            other => panic!("expected string style, got {other:?}"),
+        }
     }
 
     fn span_text(line: &Table, idx: usize) -> String {
@@ -549,21 +619,6 @@ mod tests {
         let result = render_markdown(&lua, "***x***");
         let line: Table = result.get(1).unwrap();
         assert_eq!(span_style(&line, 1), STYLE_BOLD_ITALIC);
-    }
-
-    #[test]
-    fn markdown_empty_input_returns_empty_table() {
-        let lua = Lua::new();
-        let result = render_markdown(&lua, "");
-        assert_eq!(result.len().unwrap(), 0);
-    }
-
-    #[test]
-    fn markdown_preserves_utf8() {
-        let lua = Lua::new();
-        let result = render_markdown(&lua, "héllo 🦀");
-        let line: Table = result.get(1).unwrap();
-        assert_eq!(span_text(&line, 1), "héllo 🦀");
     }
 
     #[test]
@@ -610,12 +665,15 @@ mod tests {
     }
 
     #[test]
-    fn markdown_horizontal_rule_emits_single_styled_span() {
+    fn markdown_horizontal_rule_emits_hr_span_filled_to_width() {
         let lua = Lua::new();
         let result = render_markdown(&lua, "---");
         let line: Table = result.get(1).unwrap();
         assert_eq!(line.len().unwrap(), 1);
         assert_eq!(span_style(&line, 1), STYLE_HR);
+        let text = span_text(&line, 1);
+        assert_eq!(text.chars().count(), MD_WIDTH as usize);
+        assert!(text.chars().all(|c| c == '─'));
     }
 
     #[test]
@@ -681,16 +739,29 @@ mod tests {
     }
 
     #[test]
-    fn markdown_code_fence_emits_one_line_per_code_line_with_inline_code_style() {
+    fn markdown_code_fence_emits_code_bar_prefix_with_highlight_span_tables() {
         let lua = Lua::new();
-        let result = render_markdown(&lua, "```rust\nfn x() {}\nlet y;\n```");
-        assert_eq!(result.len().unwrap(), 2);
-        let l1: Table = result.get(1).unwrap();
-        let l2: Table = result.get(2).unwrap();
-        assert_eq!(span_text(&l1, 1), "fn x() {}");
-        assert_eq!(span_style(&l1, 1), STYLE_CODE);
-        assert_eq!(span_text(&l2, 1), "let y;");
-        assert_eq!(span_style(&l2, 1), STYLE_CODE);
+        let result = render_markdown(&lua, "```rust\nfn x() {}\n```");
+        let lines = result.len().unwrap();
+        let code_line: Table = (1..=lines)
+            .find_map(|i| {
+                let line: Table = result.get(i).ok()?;
+                (line.len().ok()? > 0
+                    && line
+                        .get::<Table>(1)
+                        .and_then(|s| s.get::<String>(2))
+                        .ok()
+                        .is_some_and(|s| s == STYLE_CODE_BAR))
+                .then_some(line)
+            })
+            .expect("code bar line");
+        assert_eq!(span_style(&code_line, 1), STYLE_CODE_BAR);
+        let content_span: Table = code_line.get(2).unwrap();
+        let style = content_span.get::<mlua::Value>(2).unwrap();
+        assert!(
+            matches!(style, mlua::Value::Table(_)),
+            "highlight span style must be an inline table"
+        );
     }
 
     #[test_case("# a" ; "h1")]
@@ -715,10 +786,10 @@ mod tests {
     }
 
     #[test]
-    fn segments_to_lua_lines_italic_flag_only_present_when_true() {
+    fn segments_to_lua_lines_modifier_flags_only_present_when_true() {
         let lua = Lua::new();
         let lines = vec![vec![
-            seg_full("a", false, true, false),
+            seg_full("a", false, true, true),
             seg_full("b", false, false, false),
         ]];
         let result = segments_to_lua_lines(&lua, &lines).unwrap();
@@ -726,25 +797,10 @@ mod tests {
         let s1: Table = line.get(1).unwrap();
         let st1: Table = s1.get(2).unwrap();
         assert!(st1.get::<bool>("italic").unwrap());
-        let s2: Table = line.get(2).unwrap();
-        let st2: Table = s2.get(2).unwrap();
-        assert!(st2.get::<Option<bool>>("italic").unwrap().is_none());
-    }
-
-    #[test]
-    fn segments_to_lua_lines_underline_flag_only_present_when_true() {
-        let lua = Lua::new();
-        let lines = vec![vec![
-            seg_full("a", false, false, true),
-            seg_full("b", false, false, false),
-        ]];
-        let result = segments_to_lua_lines(&lua, &lines).unwrap();
-        let line: Table = result.get(1).unwrap();
-        let s1: Table = line.get(1).unwrap();
-        let st1: Table = s1.get(2).unwrap();
         assert!(st1.get::<bool>("underline").unwrap());
         let s2: Table = line.get(2).unwrap();
         let st2: Table = s2.get(2).unwrap();
+        assert!(st2.get::<Option<bool>>("italic").unwrap().is_none());
         assert!(st2.get::<Option<bool>>("underline").unwrap().is_none());
     }
 
@@ -763,13 +819,27 @@ mod tests {
     }
 
     #[test]
-    fn markdown_horizontal_rule_synthetic_span_text_is_empty_string() {
+    fn markdown_table_has_border_and_data_spans() {
         let lua = Lua::new();
-        let result = render_markdown(&lua, "---");
-        let line: Table = result.get(1).unwrap();
-        assert_eq!(line.len().unwrap(), 1);
-        assert_eq!(span_text(&line, 1), "");
-        assert_eq!(span_style(&line, 1), STYLE_HR);
+        let result = render_markdown(&lua, "| col1 | col2 |\n|------|------|\n| a    | b    |");
+        let mut saw_border = false;
+        let mut saw_plain = false;
+        for i in 1..=result.len().unwrap() {
+            let line: Table = result.get(i).unwrap();
+            for j in 1..=line.len().unwrap() {
+                let span: Table = line.get(j).unwrap();
+                if let mlua::Value::String(s) = span.get::<mlua::Value>(2).unwrap() {
+                    let s = s.to_str().unwrap();
+                    if s == STYLE_TABLE_BORDER {
+                        saw_border = true;
+                    } else if s == STYLE_PLAIN {
+                        saw_plain = true;
+                    }
+                }
+            }
+        }
+        assert!(saw_border, "table must have border spans");
+        assert!(saw_plain, "table must have data/content spans");
     }
 
     #[test]
@@ -786,34 +856,76 @@ mod tests {
         assert!(result.len().unwrap() > 0);
     }
 
-    #[test_case(STYLE_BOLD ; "bold")]
-    #[test_case(STYLE_BOLD_ITALIC ; "bold_italic")]
-    #[test_case(STYLE_HEADING ; "heading")]
-    #[test_case(STYLE_LIST_MARKER ; "list_marker")]
-    #[test_case(STYLE_HR ; "horizontal_rule")]
-    #[test_case(STYLE_CODE ; "inline_code")]
-    #[test_case(STYLE_ITALIC ; "italic")]
-    #[test_case(STYLE_STRIKE ; "strikethrough")]
-    fn markdown_style_names_are_lower_snake_case(name: &str) {
-        assert!(!name.is_empty());
-        assert!(
-            name.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
-            "style name {name:?} must match [a-z_]+"
-        );
-    }
-
     #[test]
-    fn markdown_code_inside_heading_all_spans_surface_as_heading() {
+    fn markdown_code_inside_heading_keeps_inline_code_style() {
         let lua = Lua::new();
         let result = render_markdown(&lua, "# foo `bar`");
         let line: Table = result.get(1).unwrap();
-        let n = line.len().unwrap();
-        assert!(n >= 2);
-        for i in 1..=n {
+        let bar_idx = (1..=line.len().unwrap())
+            .find(|&i| span_text(&line, i as usize) == "bar")
+            .expect("bar span");
+        assert_eq!(span_style(&line, bar_idx as usize), STYLE_CODE);
+        let foo_idx = (1..=line.len().unwrap())
+            .find(|&i| span_text(&line, i as usize).contains("foo"))
+            .expect("foo span");
+        assert_eq!(span_style(&line, foo_idx as usize), STYLE_HEADING);
+    }
+
+    #[test_case(false, false, false, false, "" ; "default_emphasis_is_empty")]
+    #[test_case(true, false, false, false, "bold" ; "bold_only")]
+    #[test_case(false, true, false, false, "italic" ; "italic_only")]
+    #[test_case(true, true, false, false, "bold_italic" ; "bold_and_italic")]
+    #[test_case(false, false, true, false, "strikethrough" ; "strike_only")]
+    #[test_case(true, false, true, false, "strikethrough" ; "strike_wins_over_bold")]
+    #[test_case(false, true, true, false, "strikethrough" ; "strike_wins_over_italic")]
+    #[test_case(false, false, false, true, "" ; "underline_alone_not_surfaced")]
+    #[test_case(true, false, false, true, "bold" ; "underline_ignored_with_bold")]
+    fn emphasis_style_name_combos(
+        bold: bool,
+        italic: bool,
+        strike: bool,
+        underline: bool,
+        expected: &str,
+    ) {
+        let e = maki_markdown::Emphasis {
+            bold,
+            italic,
+            strike,
+            underline,
+        };
+        assert_eq!(emphasis_style_name(e), expected);
+    }
+
+    #[test]
+    fn span_style_to_lua_highlight() {
+        let lua = Lua::new();
+        for (bold, italic, underline) in [(true, false, false), (true, true, true)] {
+            let span = maki_markdown::render::Span {
+                text: "tok".into(),
+                style: maki_markdown::render::StyleToken::Highlight {
+                    fg: (255, 128, 0),
+                    bold,
+                    italic,
+                    underline,
+                },
+                emphasis: maki_markdown::Emphasis::default(),
+            };
+            let val = span_style_to_lua(&lua, &span).unwrap();
+            let tbl = match val {
+                mlua::Value::Table(t) => t,
+                other => panic!("expected table, got {other:?}"),
+            };
+            assert_eq!(tbl.get::<String>("fg").unwrap(), ORANGE_HEX);
+            assert_eq!(tbl.get::<bool>("bold").unwrap(), bold);
             assert_eq!(
-                span_style(&line, i as usize),
-                STYLE_HEADING,
-                "span {i} should collapse to heading at Lua boundary"
+                tbl.get::<Option<bool>>("italic").unwrap().unwrap_or(false),
+                italic
+            );
+            assert_eq!(
+                tbl.get::<Option<bool>>("underline")
+                    .unwrap()
+                    .unwrap_or(false),
+                underline
             );
         }
     }

--- a/maki-markdown/Cargo.toml
+++ b/maki-markdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maki-markdown"
-description = "Theme-free markdown parser shared by maki-ui's renderer and the maki-lua bridge."
+description = "Theme-free markdown parser and width-aware renderer shared by maki-ui and the maki-lua bridge."
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -9,6 +9,8 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+maki-highlight = { workspace = true }
+unicode-width = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/maki-markdown/src/lib.rs
+++ b/maki-markdown/src/lib.rs
@@ -1,11 +1,10 @@
-//! Leaf markdown parser shared by `maki-ui` (ratatui rendering) and
-//! `maki-lua` (flat per-line view for plugins). No styling, no widths.
+//! Markdown parser and width-aware renderer.
 //!
-//! The model has two orthogonal axes so we don't lose information at the
-//! boundary: `SpanKind` says what an inline span is (text or code), and
-//! `Emphasis` carries the modifiers (bold, italic, strike). Emphasis
-//! composes (`***x***` is bold and italic), code does not, and code nested
-//! inside bold keeps both.
+//! The parser separates two orthogonal axes: `SpanKind` (text vs code) and
+//! `Emphasis` (bold, italic, strike). They compose freely, so `***x***` is
+//! bold+italic, and code inside bold keeps both.
+
+pub mod render;
 
 const BULLET: &str = "• ";
 const LIST_INDENT_STEP: usize = 2;
@@ -17,6 +16,7 @@ pub struct Emphasis {
     pub bold: bool,
     pub italic: bool,
     pub strike: bool,
+    pub underline: bool,
 }
 
 impl Emphasis {
@@ -24,21 +24,31 @@ impl Emphasis {
         bold: true,
         italic: false,
         strike: false,
+        underline: false,
     };
     pub const ITALIC: Self = Self {
         bold: false,
         italic: true,
         strike: false,
+        underline: false,
     };
     pub const BOLD_ITALIC: Self = Self {
         bold: true,
         italic: true,
         strike: false,
+        underline: false,
     };
     pub const STRIKE: Self = Self {
         bold: false,
         italic: false,
         strike: true,
+        underline: false,
+    };
+    pub const UNDERLINE: Self = Self {
+        bold: false,
+        italic: false,
+        strike: false,
+        underline: true,
     };
 
     pub fn merge(self, other: Self) -> Self {
@@ -46,11 +56,12 @@ impl Emphasis {
             bold: self.bold || other.bold,
             italic: self.italic || other.italic,
             strike: self.strike || other.strike,
+            underline: self.underline || other.underline,
         }
     }
 
     pub fn is_empty(self) -> bool {
-        !self.bold && !self.italic && !self.strike
+        !self.bold && !self.italic && !self.strike && !self.underline
     }
 }
 
@@ -274,137 +285,6 @@ pub fn block_prefix(kind: &BlockKind) -> Option<String> {
             Some(format!("{}{marker} ", " ".repeat(depth * LIST_INDENT_STEP)))
         }
         BlockKind::Paragraph | BlockKind::Heading(_) | BlockKind::HorizontalRule => None,
-    }
-}
-
-/// Carried as data so consumers don't need positional rules like "the first
-/// span is the bullet".
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum SpanRole {
-    Marker,
-    Content,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct RenderedSpan {
-    pub text: String,
-    pub kind: SpanKind,
-    pub emphasis: Emphasis,
-    pub role: SpanRole,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct RenderedLine {
-    pub kind: BlockKind,
-    pub spans: Vec<RenderedSpan>,
-}
-
-/// Flattens everything into one `RenderedLine` per output row, with inline
-/// emphasis and code fully resolved. This is what the Lua bridge consumes;
-/// width-aware Rust renderers should use `parse` directly instead.
-pub fn render_lines(text: &str) -> Vec<RenderedLine> {
-    let mut out = Vec::new();
-    for block in parse(text) {
-        match block {
-            Block::Lines(lines) => {
-                for lb in lines {
-                    out.push(render_line_block(&lb));
-                }
-            }
-            Block::Code { code, .. } => {
-                for line in code.split('\n') {
-                    out.push(RenderedLine {
-                        kind: BlockKind::Paragraph,
-                        spans: vec![RenderedSpan {
-                            text: line.to_owned(),
-                            kind: SpanKind::Code,
-                            emphasis: Emphasis::default(),
-                            role: SpanRole::Content,
-                        }],
-                    });
-                }
-            }
-            Block::Table { rows, .. } => {
-                for row in rows {
-                    let joined = row.join(" | ");
-                    out.push(RenderedLine {
-                        kind: BlockKind::Paragraph,
-                        spans: parse_inline(&joined)
-                            .into_iter()
-                            .map(content_span)
-                            .collect(),
-                    });
-                }
-            }
-        }
-    }
-    out
-}
-
-fn content_span(s: InlineSpan) -> RenderedSpan {
-    RenderedSpan {
-        text: s.text,
-        kind: s.kind,
-        emphasis: s.emphasis,
-        role: SpanRole::Content,
-    }
-}
-
-fn render_line_block(lb: &LineBlock) -> RenderedLine {
-    let mut spans = Vec::new();
-    if let Some(p) = block_prefix(&lb.kind) {
-        spans.push(RenderedSpan {
-            text: p,
-            kind: SpanKind::Text,
-            emphasis: Emphasis::default(),
-            role: SpanRole::Marker,
-        });
-    }
-    if matches!(lb.kind, BlockKind::HorizontalRule) {
-        // Empty span keeps the block visible to consumers that iterate spans.
-        spans.push(RenderedSpan {
-            text: String::new(),
-            kind: SpanKind::Text,
-            emphasis: Emphasis::default(),
-            role: SpanRole::Content,
-        });
-    } else {
-        spans.extend(parse_inline(&lb.inline).into_iter().map(content_span));
-    }
-    RenderedLine {
-        kind: lb.kind.clone(),
-        spans,
-    }
-}
-
-/// One flat style name per span, for consumers that can't carry the typed
-/// (kind, emphasis, role) tuple (the Lua bridge, mainly).
-///
-/// Precedence runs top down: markers, then block roles (heading, HR), then
-/// code, then emphasis. Strike only surfaces when bold and italic are both
-/// off, because the theme has no `bold_strikethrough` slot.
-pub fn span_style_name(line_kind: &BlockKind, span: &RenderedSpan) -> &'static str {
-    if span.role == SpanRole::Marker {
-        return "list_marker";
-    }
-    match line_kind {
-        BlockKind::Heading(_) => return "heading",
-        BlockKind::HorizontalRule => return "horizontal_rule",
-        _ => {}
-    }
-    if matches!(span.kind, SpanKind::Code) {
-        return "inline_code";
-    }
-    match (
-        span.emphasis.bold,
-        span.emphasis.italic,
-        span.emphasis.strike,
-    ) {
-        (true, true, _) => "bold_italic",
-        (true, false, _) => "bold",
-        (false, true, _) => "italic",
-        (false, false, true) => "strikethrough",
-        (false, false, false) => "",
     }
 }
 
@@ -1103,12 +983,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_inline_utf8_preserved() {
-        let spans = parse_inline("héllo 🦀");
-        assert_eq!(span_text(&spans), "héllo 🦀");
-    }
-
-    #[test]
     fn parse_inline_unmatched_star_passes_through_as_plain() {
         let spans = parse_inline("a*b");
         assert!(
@@ -1117,85 +991,6 @@ mod tests {
                 .all(|s| s.kind == SpanKind::Text && s.emphasis.is_empty())
         );
         assert_eq!(span_text(&spans), "a*b");
-    }
-
-    #[test]
-    fn render_lines_includes_bullet_for_unordered_lists() {
-        let lines = render_lines("- item");
-        assert_eq!(lines.len(), 1);
-        assert_eq!(lines[0].spans[0].text, "• ");
-        assert_eq!(lines[0].spans[0].role, SpanRole::Marker);
-        assert_eq!(lines[0].spans[1].text, "item");
-        assert_eq!(lines[0].spans[1].role, SpanRole::Content);
-        assert!(matches!(
-            lines[0].kind,
-            BlockKind::UnorderedListItem { depth: 0 }
-        ));
-    }
-
-    #[test]
-    fn render_lines_heading_does_not_bake_bold_into_emphasis() {
-        // Heading boldness comes from `BlockKind`, not span emphasis, so the
-        // `world` span here stays italic-only.
-        let lines = render_lines("# hello *world*");
-        assert!(matches!(lines[0].kind, BlockKind::Heading(1)));
-        let world = lines[0]
-            .spans
-            .iter()
-            .find(|s| s.text == "world")
-            .expect("world span");
-        assert_eq!(world.emphasis, Emphasis::ITALIC);
-    }
-
-    #[test]
-    fn render_lines_code_fence_emits_one_line_per_code_line() {
-        let lines = render_lines("```\nfn x() {}\nlet y;\n```");
-        assert_eq!(lines.len(), 2);
-        assert_eq!(lines[0].spans[0].kind, SpanKind::Code);
-        assert_eq!(lines[0].spans[0].text, "fn x() {}");
-    }
-
-    #[test]
-    fn render_lines_horizontal_rule_emits_single_empty_content_span() {
-        let lines = render_lines("---");
-        assert_eq!(lines.len(), 1);
-        assert!(matches!(lines[0].kind, BlockKind::HorizontalRule));
-        assert_eq!(lines[0].spans.len(), 1);
-        assert!(lines[0].spans[0].text.is_empty());
-        assert_eq!(lines[0].spans[0].role, SpanRole::Content);
-    }
-
-    fn rendered_span(kind: SpanKind, emphasis: Emphasis, role: SpanRole) -> RenderedSpan {
-        RenderedSpan {
-            text: String::new(),
-            kind,
-            emphasis,
-            role,
-        }
-    }
-
-    #[test_case(BlockKind::Paragraph, SpanKind::Text, Emphasis::default(), SpanRole::Content, "" ; "plain_text")]
-    #[test_case(BlockKind::Paragraph, SpanKind::Text, Emphasis::BOLD, SpanRole::Content, "bold" ; "bold")]
-    #[test_case(BlockKind::Paragraph, SpanKind::Text, Emphasis::ITALIC, SpanRole::Content, "italic" ; "italic")]
-    #[test_case(BlockKind::Paragraph, SpanKind::Text, Emphasis::BOLD_ITALIC, SpanRole::Content, "bold_italic" ; "bold_italic")]
-    #[test_case(BlockKind::Paragraph, SpanKind::Text, Emphasis::STRIKE, SpanRole::Content, "strikethrough" ; "strike_only")]
-    #[test_case(BlockKind::Paragraph, SpanKind::Text, Emphasis { bold: true, italic: false, strike: true }, SpanRole::Content, "bold" ; "bold_plus_strike_collapses_to_bold")]
-    #[test_case(BlockKind::Paragraph, SpanKind::Code, Emphasis::default(), SpanRole::Content, "inline_code" ; "code")]
-    #[test_case(BlockKind::Paragraph, SpanKind::Code, Emphasis::BOLD, SpanRole::Content, "inline_code" ; "code_inside_bold_wins")]
-    #[test_case(BlockKind::Heading(1), SpanKind::Text, Emphasis::BOLD, SpanRole::Content, "heading" ; "heading_wins_over_bold")]
-    #[test_case(BlockKind::Heading(1), SpanKind::Code, Emphasis::default(), SpanRole::Content, "heading" ; "heading_wins_over_code")]
-    #[test_case(BlockKind::HorizontalRule, SpanKind::Text, Emphasis::default(), SpanRole::Content, "horizontal_rule" ; "hr")]
-    #[test_case(BlockKind::UnorderedListItem { depth: 0 }, SpanKind::Text, Emphasis::default(), SpanRole::Marker, "list_marker" ; "marker_wins")]
-    #[test_case(BlockKind::UnorderedListItem { depth: 0 }, SpanKind::Code, Emphasis::BOLD, SpanRole::Marker, "list_marker" ; "marker_wins_even_over_code_and_emphasis")]
-    fn span_style_name_projection(
-        line_kind: BlockKind,
-        span_kind: SpanKind,
-        emphasis: Emphasis,
-        role: SpanRole,
-        expected: &'static str,
-    ) {
-        let span = rendered_span(span_kind, emphasis, role);
-        assert_eq!(span_style_name(&line_kind, &span), expected);
     }
 
     #[test_case("- item", Some("• "); "unordered_depth_zero")]
@@ -1218,35 +1013,15 @@ mod tests {
     }
 
     #[test]
-    fn emphasis_merge_bold_and_italic_yields_bold_italic() {
+    fn emphasis_merge_ors_fields_and_default_is_identity() {
         assert_eq!(
             Emphasis::BOLD.merge(Emphasis::ITALIC),
             Emphasis::BOLD_ITALIC
         );
-    }
-
-    #[test]
-    fn emphasis_merge_is_commutative_over_or_fields() {
-        let a = Emphasis::BOLD;
-        let b = Emphasis::STRIKE;
-        assert_eq!(a.merge(b), b.merge(a));
-        let merged = a.merge(b);
-        assert!(merged.bold && merged.strike && !merged.italic);
-    }
-
-    #[test]
-    fn emphasis_merge_with_default_is_identity() {
         let e = Emphasis::BOLD_ITALIC;
         assert_eq!(e.merge(Emphasis::default()), e);
-        assert_eq!(Emphasis::default().merge(e), e);
-    }
-
-    #[test_case(Emphasis::default(), true; "default_is_empty")]
-    #[test_case(Emphasis::BOLD, false; "bold_not_empty")]
-    #[test_case(Emphasis::ITALIC, false; "italic_not_empty")]
-    #[test_case(Emphasis::STRIKE, false; "strike_not_empty")]
-    fn emphasis_is_empty_only_when_all_fields_false(e: Emphasis, expected: bool) {
-        assert_eq!(e.is_empty(), expected);
+        assert!(Emphasis::default().is_empty());
+        assert!(!Emphasis::BOLD.is_empty());
     }
 
     #[test]
@@ -1395,14 +1170,6 @@ mod tests {
     }
 
     #[test]
-    fn strikethrough_requires_double_tilde() {
-        let spans = parse_inline("~~yes~~");
-        assert_eq!(spans.len(), 1);
-        assert_eq!(spans[0].text, "yes");
-        assert_eq!(spans[0].emphasis, Emphasis::STRIKE);
-    }
-
-    #[test]
     fn code_span_with_pipes_and_emphasis_chars_is_atomic() {
         let spans = parse_inline("a `x|y*z` b");
         assert_eq!(spans.len(), 3);
@@ -1431,58 +1198,6 @@ mod tests {
     }
 
     #[test]
-    fn render_lines_table_cell_with_code_span_preserves_pipe() {
-        let lines = render_lines("| `cmd|filter` | z |\n|---|---|");
-        assert_eq!(lines.len(), 1);
-        let code = lines[0]
-            .spans
-            .iter()
-            .find(|s| s.kind == SpanKind::Code)
-            .expect("code span");
-        assert_eq!(code.text, "cmd|filter");
-    }
-
-    #[test]
-    fn render_lines_ordered_list_emits_marker_then_content() {
-        let lines = render_lines("1. item");
-        assert_eq!(lines.len(), 1);
-        assert!(matches!(
-            lines[0].kind,
-            BlockKind::OrderedListItem { depth: 0, ref marker } if marker == "1."
-        ));
-        assert_eq!(lines[0].spans[0].text, "1. ");
-        assert_eq!(lines[0].spans[0].role, SpanRole::Marker);
-        assert_eq!(lines[0].spans[1].text, "item");
-        assert_eq!(lines[0].spans[1].role, SpanRole::Content);
-    }
-
-    #[test]
-    fn render_lines_heading_with_code_span_preserves_code_kind_on_span() {
-        // Heading wins at the style projection layer, but the span itself
-        // still carries `SpanKind::Code` so renderers can layer on top.
-        let lines = render_lines("# foo `bar`");
-        assert!(matches!(lines[0].kind, BlockKind::Heading(1)));
-        let bar = lines[0]
-            .spans
-            .iter()
-            .find(|s| s.text == "bar")
-            .expect("bar span");
-        assert_eq!(bar.kind, SpanKind::Code);
-        assert!(bar.emphasis.is_empty());
-        assert_eq!(bar.role, SpanRole::Content);
-    }
-
-    #[test]
-    fn span_style_name_ordered_list_content_code_returns_inline_code() {
-        let kind = BlockKind::OrderedListItem {
-            depth: 0,
-            marker: "1.".to_owned(),
-        };
-        let span = rendered_span(SpanKind::Code, Emphasis::default(), SpanRole::Content);
-        assert_eq!(span_style_name(&kind, &span), "inline_code");
-    }
-
-    #[test]
     fn underscore_italic_with_nested_bold_becomes_bold_italic() {
         let spans = parse_inline("_a **b** c_");
         assert_eq!(spans.len(), 3);
@@ -1490,13 +1205,6 @@ mod tests {
         assert_eq!(spans[1].emphasis, Emphasis::BOLD_ITALIC);
         assert_eq!(spans[1].text, "b");
         assert_eq!(spans[2].emphasis, Emphasis::ITALIC);
-    }
-
-    #[test]
-    fn render_lines_empty_input_returns_no_lines() {
-        // Empty input means no lines. Callers that want a placeholder blank
-        // line must add it themselves.
-        assert!(render_lines("").is_empty());
     }
 
     #[test]

--- a/maki-markdown/src/render.rs
+++ b/maki-markdown/src/render.rs
@@ -1,0 +1,1299 @@
+//! Width-aware markdown renderer. Theme-free: outputs semantic style
+//! tokens that consumers (`maki-ui`, `maki-lua`) map to their own colours.
+//!
+//! Single source of truth for layout: tables, code bars, wrapping, blank
+//! lines. Everyone consumes `Line` values from here.
+
+use std::borrow::Cow;
+use std::iter;
+use std::mem;
+
+use maki_highlight::CodeHighlighter;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use crate::{
+    Block, BlockKind, Emphasis, InlineSpan, LineBlock, SpanKind, block_prefix, parse, parse_inline,
+};
+
+pub const CODE_BAR: &str = "│ ";
+pub const CODE_BAR_WRAP: &str = "│";
+/// Lines longer than this get truncated with `...` to protect the parser
+/// and terminal from runaway output.
+pub const MAX_LINE_BYTES: usize = 500;
+const HR_CHAR: char = '─';
+const MIN_COL_WIDTH: usize = 5;
+const LONG_LINE_SUFFIX: &str = "...";
+
+/// Semantic style token. Emphasis (bold/italic/strike/underline) lives on
+/// the `Span`, not here, so they compose independently.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StyleToken {
+    Text,
+    InlineCode,
+    /// Syntax-highlighted token. Carries resolved rgb + modifiers so the
+    /// consumer doesn't need to know the language.
+    Highlight {
+        fg: (u8, u8, u8),
+        bold: bool,
+        italic: bool,
+        underline: bool,
+    },
+    CodeBar,
+    Heading,
+    ListMarker,
+    TableBorder,
+    HorizontalRule,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Span {
+    pub text: String,
+    pub style: StyleToken,
+    pub emphasis: Emphasis,
+}
+
+impl Span {
+    pub fn new(text: impl Into<String>, style: StyleToken) -> Self {
+        Self {
+            text: text.into(),
+            style,
+            emphasis: Emphasis::default(),
+        }
+    }
+
+    pub fn with_emphasis(text: impl Into<String>, style: StyleToken, emphasis: Emphasis) -> Self {
+        Self {
+            text: text.into(),
+            style,
+            emphasis,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LineKind {
+    Paragraph,
+    Heading,
+    ListItem,
+    Code,
+    TableBorder,
+    TableRow,
+    HorizontalRule,
+    Blank,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Line {
+    pub kind: LineKind,
+    pub spans: Vec<Span>,
+}
+
+impl Line {
+    pub fn blank() -> Self {
+        Self {
+            kind: LineKind::Blank,
+            spans: Vec::new(),
+        }
+    }
+
+    pub fn width(&self) -> usize {
+        self.spans.iter().map(|s| s.text.width()).sum()
+    }
+
+    pub fn is_blank(&self) -> bool {
+        self.spans.is_empty() || self.spans.iter().all(|s| s.text.is_empty())
+    }
+}
+
+pub fn render(text: &str, width: u16) -> Vec<Line> {
+    Renderer::new().render(text, width, 0)
+}
+
+/// Reuses highlighter and table-width caches across calls so streaming
+/// (successive prefixes of a growing message) doesn't re-highlight completed
+/// code lines. Bump `theme_gen` to flush caches after a theme change.
+pub struct Renderer {
+    highlighters: Vec<CodeHighlighter>,
+    table_col_widths: Vec<Vec<usize>>,
+    theme_gen: u64,
+    wrap_paragraphs: bool,
+}
+
+impl Default for Renderer {
+    fn default() -> Self {
+        Self {
+            highlighters: Vec::new(),
+            table_col_widths: Vec::new(),
+            theme_gen: 0,
+            wrap_paragraphs: true,
+        }
+    }
+}
+
+impl Renderer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Skip paragraph/heading/list wrapping (ratatui re-wraps those at
+    /// paint time). Code blocks and tables still wrap.
+    pub fn unwrapped() -> Self {
+        Self {
+            wrap_paragraphs: false,
+            ..Self::default()
+        }
+    }
+
+    pub fn render(&mut self, text: &str, width: u16, theme_gen: u64) -> Vec<Line> {
+        if theme_gen != self.theme_gen {
+            self.highlighters.clear();
+            self.theme_gen = theme_gen;
+        }
+        let text = text.trim_start_matches('\n');
+        let blocks = parse(text);
+        let mut lines: Vec<Line> = Vec::new();
+        let mut state = RenderState {
+            code_idx: 0,
+            table_idx: 0,
+            highlighters: &mut self.highlighters,
+            table_col_widths: &mut self.table_col_widths,
+        };
+        let ctx = RenderCtx {
+            width,
+            wrap_paragraphs: self.wrap_paragraphs,
+        };
+
+        for block in &blocks {
+            render_block(block, &mut lines, &mut state, &ctx);
+        }
+
+        state.highlighters.truncate(state.code_idx);
+        state.table_col_widths.truncate(state.table_idx);
+        finalize_lines(&mut lines);
+        lines
+    }
+}
+
+struct RenderCtx {
+    width: u16,
+    wrap_paragraphs: bool,
+}
+
+struct RenderState<'a> {
+    code_idx: usize,
+    table_idx: usize,
+    highlighters: &'a mut Vec<CodeHighlighter>,
+    table_col_widths: &'a mut Vec<Vec<usize>>,
+}
+
+/// Streaming can split tokens differently than a oneshot render because the
+/// highlighter sees partial input. Merging identical neighbours keeps the
+/// span shape stable.
+fn coalesce_adjacent_spans(spans: &mut Vec<Span>) {
+    if spans.len() < 2 {
+        return;
+    }
+    let mut write = 0;
+    for read in 1..spans.len() {
+        if spans[write].style == spans[read].style && spans[write].emphasis == spans[read].emphasis
+        {
+            let tail = mem::take(&mut spans[read].text);
+            spans[write].text.push_str(&tail);
+        } else {
+            write += 1;
+            if write != read {
+                spans.swap(write, read);
+            }
+        }
+    }
+    spans.truncate(write + 1);
+}
+
+fn render_block(
+    block: &Block,
+    lines: &mut Vec<Line>,
+    state: &mut RenderState<'_>,
+    ctx: &RenderCtx,
+) {
+    match block {
+        Block::Lines(line_blocks) => {
+            for lb in line_blocks {
+                render_line_block(lb, lines, ctx);
+            }
+        }
+        Block::Code { lang, code } => {
+            ensure_blank_line(lines);
+            if state.code_idx >= state.highlighters.len() {
+                state.highlighters.push(CodeHighlighter::new(lang));
+            }
+            let segments: Vec<_> = state.highlighters[state.code_idx].update(code).to_vec();
+            let start = lines.len();
+            for segs in segments {
+                let mut spans = vec![Span::new(CODE_BAR, StyleToken::CodeBar)];
+                for seg in segs {
+                    spans.push(Span::new(
+                        seg.text,
+                        StyleToken::Highlight {
+                            fg: seg.fg,
+                            bold: seg.bold,
+                            italic: seg.italic,
+                            underline: seg.underline,
+                        },
+                    ));
+                }
+                coalesce_adjacent_spans(&mut spans);
+                lines.push(Line {
+                    kind: LineKind::Code,
+                    spans,
+                });
+            }
+            wrap_code_lines(lines, start, ctx.width);
+            ensure_blank_line(lines);
+            state.code_idx += 1;
+        }
+        Block::Table { rows, header_end } => {
+            ensure_blank_line(lines);
+            if state.table_idx >= state.table_col_widths.len() {
+                state
+                    .table_col_widths
+                    .resize_with(state.table_idx + 1, Vec::new);
+            }
+            let pw = &mut state.table_col_widths[state.table_idx];
+            lines.extend(render_table(rows, *header_end, ctx.width, pw));
+            ensure_blank_line(lines);
+            state.table_idx += 1;
+        }
+    }
+}
+
+fn render_line_block(lb: &LineBlock, lines: &mut Vec<Line>, ctx: &RenderCtx) {
+    if matches!(lb.kind, BlockKind::HorizontalRule) {
+        lines.push(Line {
+            kind: LineKind::HorizontalRule,
+            spans: vec![Span::new(hr_text(ctx.width), StyleToken::HorizontalRule)],
+        });
+        return;
+    }
+
+    let marker = block_prefix(&lb.kind).map(|p| Span::new(p, StyleToken::ListMarker));
+
+    let is_heading = matches!(lb.kind, BlockKind::Heading(_));
+    let kind = match &lb.kind {
+        BlockKind::Heading(_) => LineKind::Heading,
+        BlockKind::UnorderedListItem { .. } | BlockKind::OrderedListItem { .. } => {
+            LineKind::ListItem
+        }
+        _ => LineKind::Paragraph,
+    };
+
+    let mut content_spans: Vec<Span> = Vec::new();
+    for InlineSpan {
+        text,
+        kind: sk,
+        emphasis,
+    } in parse_inline(&lb.inline)
+    {
+        // Code keeps its own token inside headings so consumers can layer
+        // code colours on top. The Lua bridge collapses to one name per span.
+        let style = if sk == SpanKind::Code {
+            StyleToken::InlineCode
+        } else if is_heading {
+            StyleToken::Heading
+        } else {
+            StyleToken::Text
+        };
+        content_spans.push(Span::with_emphasis(text, style, emphasis));
+    }
+
+    let marker_width = marker.as_ref().map_or(0, |m| m.text.width());
+    let width = ctx.width as usize;
+
+    if width == 0 || !ctx.wrap_paragraphs {
+        let mut spans = Vec::new();
+        if let Some(m) = marker {
+            spans.push(m);
+        }
+        spans.extend(content_spans);
+        lines.push(Line { kind, spans });
+        return;
+    }
+
+    // If the marker is wider than the line, it gets its own row.
+    // Otherwise it shares row 1 and continuations indent to align.
+    let (first_row_marker, cont_indent, content_width) = if marker_width >= width {
+        if let Some(mut mk) = marker {
+            mk.text = mk.text.trim_start_matches(' ').to_owned();
+            lines.push(Line {
+                kind: kind.clone(),
+                spans: vec![mk],
+            });
+        }
+        (None, None, width)
+    } else {
+        let indent = marker
+            .as_ref()
+            .map(|_| Span::new(" ".repeat(marker_width), StyleToken::ListMarker));
+        (marker, indent, width - marker_width)
+    };
+
+    let wrapped = wrap_spans(content_spans, content_width);
+
+    if wrapped.is_empty() {
+        if let Some(m) = first_row_marker {
+            lines.push(Line {
+                kind,
+                spans: vec![m],
+            });
+        }
+        return;
+    }
+
+    let mut first_row_marker = first_row_marker;
+    for (i, row) in wrapped.into_iter().enumerate() {
+        let mut spans = Vec::new();
+        if i == 0 {
+            if let Some(m) = first_row_marker.take() {
+                spans.push(m);
+            }
+        } else if let Some(ref ind) = cont_indent {
+            spans.push(ind.clone());
+        }
+        spans.extend(row);
+        lines.push(Line {
+            kind: kind.clone(),
+            spans,
+        });
+    }
+}
+
+fn finalize_lines(lines: &mut Vec<Line>) {
+    let mut write = 0;
+    let mut prev_blank = false;
+    for read in 0..lines.len() {
+        let blank = lines[read].is_blank();
+        if blank && prev_blank {
+            continue;
+        }
+        if write != read {
+            lines.swap(write, read);
+        }
+        write += 1;
+        prev_blank = blank;
+    }
+    lines.truncate(write);
+    while lines.last().is_some_and(Line::is_blank) {
+        lines.pop();
+    }
+}
+
+fn ensure_blank_line(lines: &mut Vec<Line>) {
+    if !lines.last().is_some_and(Line::is_blank) {
+        lines.push(Line::blank());
+    }
+}
+
+fn fit_width(text: &str, max_width: usize) -> usize {
+    let mut width = 0;
+    for (i, ch) in text.char_indices() {
+        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if width + cw > max_width {
+            return i;
+        }
+        width += cw;
+    }
+    text.len()
+}
+
+fn wrap_code_lines(lines: &mut Vec<Line>, start: usize, width: u16) {
+    let width = width as usize;
+    if width == 0 {
+        return;
+    }
+    let tail = lines.split_off(start);
+    for line in tail {
+        if line.width() <= width {
+            lines.push(line);
+        } else {
+            lines.extend(split_line_with_bar(line, width));
+        }
+    }
+}
+
+fn split_line_with_bar(line: Line, width: usize) -> Vec<Line> {
+    if line.spans.is_empty() {
+        return vec![line];
+    }
+
+    let bar_span = line.spans[0].clone();
+    let content_spans = &line.spans[1..];
+    let first_avail = width.saturating_sub(CODE_BAR.width());
+    let cont_avail = width.saturating_sub(CODE_BAR_WRAP.width());
+
+    let mut result: Vec<Line> = Vec::new();
+    let mut current_spans: Vec<Span> = vec![bar_span];
+    let mut remaining = first_avail;
+
+    for span in content_spans {
+        let mut text = span.text.as_str();
+        let style = span.style.clone();
+        let emphasis = span.emphasis;
+
+        while !text.is_empty() {
+            let fits = fit_width(text, remaining);
+            if fits == 0 {
+                if current_spans.len() > 1 {
+                    result.push(Line {
+                        kind: LineKind::Code,
+                        spans: mem::take(&mut current_spans),
+                    });
+                    current_spans = vec![Span::new(CODE_BAR_WRAP, StyleToken::CodeBar)];
+                    remaining = cont_avail;
+                    continue;
+                }
+                let ch_len = text.chars().next().map_or(1, char::len_utf8);
+                current_spans.push(Span::with_emphasis(
+                    text[..ch_len].to_owned(),
+                    style.clone(),
+                    emphasis,
+                ));
+                text = &text[ch_len..];
+                result.push(Line {
+                    kind: LineKind::Code,
+                    spans: mem::take(&mut current_spans),
+                });
+                current_spans = vec![Span::new(CODE_BAR_WRAP, StyleToken::CodeBar)];
+                remaining = cont_avail;
+                continue;
+            }
+            current_spans.push(Span::with_emphasis(
+                text[..fits].to_owned(),
+                style.clone(),
+                emphasis,
+            ));
+            remaining -= text[..fits].width();
+            text = &text[fits..];
+            if !text.is_empty() {
+                result.push(Line {
+                    kind: LineKind::Code,
+                    spans: mem::take(&mut current_spans),
+                });
+                current_spans = vec![Span::new(CODE_BAR_WRAP, StyleToken::CodeBar)];
+                remaining = cont_avail;
+            }
+        }
+    }
+
+    if current_spans.len() > 1 || result.is_empty() {
+        result.push(Line {
+            kind: LineKind::Code,
+            spans: current_spans,
+        });
+    }
+
+    result
+}
+
+fn cell_display_width(cell: &str) -> usize {
+    parse_inline(cell).iter().map(|s| s.text.width()).sum()
+}
+
+fn constrain_col_widths(col_widths: &mut [usize], available: usize) {
+    let total: usize = col_widths.iter().sum();
+    if total <= available {
+        return;
+    }
+    for w in col_widths.iter_mut() {
+        *w = (*w * available / total).max(MIN_COL_WIDTH).min(*w);
+    }
+    let mut excess = col_widths.iter().sum::<usize>().saturating_sub(available);
+    while excess > 0 {
+        let max_w = col_widths.iter().copied().max().unwrap_or(0);
+        if max_w <= MIN_COL_WIDTH {
+            break;
+        }
+        for w in col_widths.iter_mut() {
+            if excess == 0 {
+                break;
+            }
+            if *w == max_w && *w > MIN_COL_WIDTH {
+                *w -= 1;
+                excess -= 1;
+            }
+        }
+    }
+}
+
+/// Soft-break on spaces, hard-break on char boundaries for long runs.
+fn wrap_spans(spans: Vec<Span>, max_width: usize) -> Vec<Vec<Span>> {
+    if max_width == 0 {
+        return vec![spans];
+    }
+    let mut result: Vec<Vec<Span>> = Vec::new();
+    let mut current: Vec<Span> = Vec::new();
+    let mut remaining = max_width;
+
+    for span in spans {
+        let mut text = span.text.as_str();
+        let style = span.style.clone();
+        let emphasis = span.emphasis;
+
+        while !text.is_empty() {
+            let fits = fit_width(text, remaining);
+            if fits == 0 {
+                if current.is_empty() {
+                    let ch_len = text.chars().next().map_or(1, char::len_utf8);
+                    current.push(Span::with_emphasis(
+                        text[..ch_len].to_owned(),
+                        style.clone(),
+                        emphasis,
+                    ));
+                    text = &text[ch_len..];
+                }
+                result.push(mem::take(&mut current));
+                remaining = max_width;
+                text = text.strip_prefix(' ').unwrap_or(text);
+                continue;
+            }
+            let (take, skip) = if fits < text.len() {
+                match text[..fits].rfind(' ') {
+                    Some(sp) if sp > 0 => (sp, sp + 1),
+                    _ => (fits, fits),
+                }
+            } else {
+                (fits, fits)
+            };
+            current.push(Span::with_emphasis(
+                text[..take].to_owned(),
+                style.clone(),
+                emphasis,
+            ));
+            remaining -= text[..take].width();
+            text = &text[skip..];
+            if take < fits && !text.is_empty() {
+                result.push(mem::take(&mut current));
+                remaining = max_width;
+            }
+        }
+    }
+    if !current.is_empty() || result.is_empty() {
+        result.push(current);
+    }
+    result
+}
+
+fn spans_width(spans: &[Span]) -> usize {
+    spans.iter().map(|s| s.text.width()).sum()
+}
+
+fn cell_spans(cell: &str, header: bool) -> Vec<Span> {
+    parse_inline(cell)
+        .into_iter()
+        .map(
+            |InlineSpan {
+                 text,
+                 kind,
+                 emphasis,
+             }| {
+                let mut emphasis = emphasis;
+                if header {
+                    emphasis.bold = true;
+                }
+                let style = if kind == SpanKind::Code {
+                    StyleToken::InlineCode
+                } else {
+                    StyleToken::Text
+                };
+                Span::with_emphasis(text, style, emphasis)
+            },
+        )
+        .collect()
+}
+
+fn render_table(
+    rows: &[Vec<String>],
+    header_end: usize,
+    width: u16,
+    persistent_widths: &mut Vec<usize>,
+) -> Vec<Line> {
+    let col_count = rows.iter().map(|r| r.len()).max().unwrap_or(0);
+    if col_count == 0 {
+        return Vec::new();
+    }
+
+    let overhead = col_count * 3 + 1;
+    let min_box_width = overhead + col_count * MIN_COL_WIDTH;
+    if (width as usize) < min_box_width {
+        return render_table_compact(rows, header_end, width);
+    }
+
+    let mut col_widths = vec![0usize; col_count];
+    for row in rows {
+        for (c, cell) in row.iter().enumerate() {
+            col_widths[c] = col_widths[c].max(cell_display_width(cell));
+        }
+    }
+
+    let available = (width as usize) - overhead;
+
+    persistent_widths.resize(persistent_widths.len().max(col_count), 0);
+    for (i, w) in col_widths.iter_mut().enumerate() {
+        persistent_widths[i] = persistent_widths[i].max(*w);
+        *w = persistent_widths[i];
+    }
+
+    constrain_col_widths(&mut col_widths, available);
+
+    let mut lines = Vec::new();
+
+    let border = |left: &str, mid: &str, right: &str, fill: &str| -> Line {
+        let mut spans = vec![Span::new(left, StyleToken::TableBorder)];
+        for (i, &w) in col_widths.iter().enumerate() {
+            spans.push(Span::new(fill.repeat(w + 2), StyleToken::TableBorder));
+            if i < col_count - 1 {
+                spans.push(Span::new(mid, StyleToken::TableBorder));
+            }
+        }
+        spans.push(Span::new(right, StyleToken::TableBorder));
+        Line {
+            kind: LineKind::TableBorder,
+            spans,
+        }
+    };
+
+    lines.push(border("╭", "┬", "╮", "─"));
+
+    for (ri, row) in rows.iter().enumerate() {
+        let header = ri < header_end;
+
+        let wrapped_cells: Vec<Vec<Vec<Span>>> = (0..col_count)
+            .map(|c| {
+                let cell = row.get(c).map(String::as_str).unwrap_or("");
+                wrap_spans(cell_spans(cell, header), col_widths[c])
+            })
+            .collect();
+
+        let row_height = wrapped_cells.iter().map(|c| c.len()).max().unwrap_or(1);
+        let row_emphasis = if header {
+            Emphasis::BOLD
+        } else {
+            Emphasis::default()
+        };
+
+        for line_idx in 0..row_height {
+            let mut spans = vec![Span::new("│ ", StyleToken::TableBorder)];
+            for (c, &w) in col_widths.iter().enumerate() {
+                let sub_line = wrapped_cells[c].get(line_idx);
+                let content_width = sub_line.map_or(0, |sl| spans_width(sl));
+
+                let pad = w.saturating_sub(content_width);
+
+                if let Some(sl) = sub_line {
+                    spans.extend(sl.iter().cloned());
+                }
+                spans.push(Span::with_emphasis(
+                    " ".repeat(pad + 1),
+                    StyleToken::Text,
+                    row_emphasis,
+                ));
+                if c < col_count - 1 {
+                    spans.push(Span::new("│ ", StyleToken::TableBorder));
+                } else {
+                    spans.push(Span::new("│", StyleToken::TableBorder));
+                }
+            }
+            lines.push(Line {
+                kind: LineKind::TableRow,
+                spans,
+            });
+        }
+
+        if ri + 1 < rows.len() {
+            lines.push(border("├", "┼", "┤", "─"));
+        }
+    }
+
+    lines.push(border("╰", "┴", "╯", "─"));
+
+    lines
+}
+
+pub fn hr_text(width: u16) -> String {
+    iter::repeat_n(HR_CHAR, width as usize).collect()
+}
+
+/// Truncate lines longer than [`MAX_LINE_BYTES`]. Returns borrowed when
+/// nothing needs truncating (common path, zero alloc).
+pub fn truncate_long_lines(text: &str) -> Cow<'_, str> {
+    if !text.lines().any(|l| l.len() > MAX_LINE_BYTES) {
+        return Cow::Borrowed(text);
+    }
+    let mut result = String::with_capacity(text.len());
+    for (i, line) in text.lines().enumerate() {
+        if i > 0 {
+            result.push('\n');
+        }
+        if line.len() > MAX_LINE_BYTES {
+            let mut boundary = MAX_LINE_BYTES;
+            while !line.is_char_boundary(boundary) {
+                boundary -= 1;
+            }
+            result.push_str(&line[..boundary]);
+            result.push_str(LONG_LINE_SUFFIX);
+        } else {
+            result.push_str(line);
+        }
+    }
+    if text.ends_with('\n') {
+        result.push('\n');
+    }
+    Cow::Owned(result)
+}
+
+/// Fallback when the terminal is too narrow for box-drawing borders.
+fn render_table_compact(rows: &[Vec<String>], header_end: usize, width: u16) -> Vec<Line> {
+    const CELL_SEP: &str = " | ";
+    let mut lines = Vec::new();
+    for (ri, row) in rows.iter().enumerate() {
+        let header = ri < header_end;
+        let mut spans: Vec<Span> = Vec::new();
+        for (c, cell) in row.iter().enumerate() {
+            if c > 0 {
+                spans.push(Span::new(CELL_SEP, StyleToken::TableBorder));
+            }
+            spans.extend(cell_spans(cell, header));
+        }
+        for row_spans in wrap_spans(spans, width as usize) {
+            lines.push(Line {
+                kind: LineKind::TableRow,
+                spans: row_spans,
+            });
+        }
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    const TEST_WIDTH: u16 = 80;
+
+    fn lines_text(lines: &[Line]) -> Vec<String> {
+        lines
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.text.as_str()).collect())
+            .collect()
+    }
+
+    #[test]
+    fn render_paragraph_emits_text_token() {
+        let lines = render("hello world", TEST_WIDTH);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].kind, LineKind::Paragraph);
+        assert_eq!(lines[0].spans.len(), 1);
+        assert_eq!(lines[0].spans[0].text, "hello world");
+        assert_eq!(lines[0].spans[0].style, StyleToken::Text);
+        assert!(lines[0].spans[0].emphasis.is_empty());
+    }
+
+    #[test]
+    fn render_bold_emits_text_with_bold_emphasis() {
+        let lines = render("**bold**", TEST_WIDTH);
+        let span = &lines[0].spans[0];
+        assert_eq!(span.text, "bold");
+        assert_eq!(span.style, StyleToken::Text);
+        assert_eq!(span.emphasis, Emphasis::BOLD);
+    }
+
+    #[test]
+    fn render_inline_code_emits_inline_code_token() {
+        let lines = render("a `b` c", TEST_WIDTH);
+        let code = lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "b")
+            .expect("code span");
+        assert_eq!(code.style, StyleToken::InlineCode);
+        assert!(code.emphasis.is_empty());
+    }
+
+    #[test_case(1; "h1")]
+    #[test_case(3; "h3")]
+    #[test_case(6; "h6")]
+    fn render_heading_emits_heading_kind_and_token(level: u8) {
+        let input = format!("{} hello", "#".repeat(level as usize));
+        let lines = render(&input, TEST_WIDTH);
+        assert_eq!(lines[0].kind, LineKind::Heading);
+        let hello = lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "hello")
+            .expect("hello span");
+        assert_eq!(hello.style, StyleToken::Heading);
+    }
+
+    #[test]
+    fn render_heading_preserves_inline_code_token() {
+        let lines = render("## **bold** and `code`", TEST_WIDTH);
+        let code_span = lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "code")
+            .expect("code span");
+        assert_eq!(code_span.style, StyleToken::InlineCode);
+        let bold_span = lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "bold")
+            .expect("bold span");
+        assert_eq!(bold_span.style, StyleToken::Heading);
+    }
+
+    #[test]
+    fn render_horizontal_rule_emits_hr_token() {
+        let lines = render("---", TEST_WIDTH);
+        assert_eq!(lines[0].kind, LineKind::HorizontalRule);
+        assert_eq!(lines[0].spans[0].style, StyleToken::HorizontalRule);
+    }
+
+    #[test]
+    fn render_unordered_list_marker_then_content() {
+        let lines = render("- item", TEST_WIDTH);
+        assert_eq!(lines[0].kind, LineKind::ListItem);
+        assert_eq!(lines[0].spans[0].text, "• ");
+        assert_eq!(lines[0].spans[0].style, StyleToken::ListMarker);
+        assert_eq!(lines[0].spans[1].text, "item");
+    }
+
+    #[test]
+    fn render_code_block_emits_code_bar_then_highlight_tokens() {
+        let lines = render("```rust\nfn x() {}\n```", TEST_WIDTH);
+        let code_lines: Vec<_> = lines.iter().filter(|l| l.kind == LineKind::Code).collect();
+        assert!(!code_lines.is_empty());
+        assert_eq!(code_lines[0].spans[0].style, StyleToken::CodeBar);
+        assert!(
+            code_lines[0]
+                .spans
+                .iter()
+                .skip(1)
+                .all(|s| matches!(s.style, StyleToken::Highlight { .. })),
+            "code line content spans must be highlight tokens"
+        );
+    }
+
+    #[test]
+    fn render_code_block_wraps_long_lines_with_continuation_bar() {
+        let code = "a".repeat(40);
+        let input = format!("```\n{code}\n```");
+        let lines = render(&input, 15);
+        let code_lines: Vec<_> = lines.iter().filter(|l| l.kind == LineKind::Code).collect();
+        assert!(code_lines.len() > 1, "long code line should wrap");
+        for line in &code_lines {
+            assert!(line.width() <= 15);
+            assert_eq!(line.spans[0].style, StyleToken::CodeBar);
+        }
+        let bar_text: Vec<_> = code_lines
+            .iter()
+            .map(|l| l.spans[0].text.as_str())
+            .collect();
+        assert_eq!(bar_text[0], CODE_BAR);
+        assert_eq!(bar_text[1], CODE_BAR_WRAP);
+    }
+
+    #[test]
+    fn render_code_block_narrow_width_does_not_loop() {
+        let input = "```\n\u{4e16}\u{754c}\n```";
+        for w in 1..=3 {
+            let lines = render(input, w);
+            let code_lines: Vec<_> = lines.iter().filter(|l| l.kind == LineKind::Code).collect();
+            assert!(
+                !code_lines.is_empty(),
+                "width={w} should produce code lines"
+            );
+        }
+    }
+
+    #[test]
+    fn render_table_emits_borders_and_rows_with_table_border_tokens() {
+        let lines = render("| H |\n| --- |\n| d |", TEST_WIDTH);
+        let borders: Vec<_> = lines
+            .iter()
+            .filter(|l| l.kind == LineKind::TableBorder)
+            .collect();
+        assert!(borders.len() >= 2, "top + bottom borders expected");
+        for border in &borders {
+            assert!(
+                border
+                    .spans
+                    .iter()
+                    .all(|s| s.style == StyleToken::TableBorder)
+            );
+        }
+        let rows: Vec<_> = lines
+            .iter()
+            .filter(|l| l.kind == LineKind::TableRow)
+            .collect();
+        assert!(!rows.is_empty(), "data row expected");
+    }
+
+    #[test]
+    fn render_table_wraps_overflowing_cells_within_width() {
+        let long = "x".repeat(60);
+        let input = format!("| Col1 | Col2 |\n| --- | --- |\n| short | {long} |");
+        let width: u16 = 40;
+        let lines = render(&input, width);
+        for line in &lines {
+            assert!(line.width() <= width as usize, "line overflow: {line:?}");
+        }
+        let rendered: String = lines_text(&lines).join("");
+        let x_count = rendered.chars().filter(|c| *c == 'x').count();
+        assert_eq!(x_count, 60, "wrap must preserve content");
+    }
+
+    #[test]
+    fn render_consecutive_blocks_separated_by_blank_line() {
+        let lines = render("before\n```\ncode\n```\nafter", TEST_WIDTH);
+        let texts = lines_text(&lines);
+        let blanks: Vec<usize> = texts
+            .iter()
+            .enumerate()
+            .filter(|(_, t)| t.is_empty())
+            .map(|(i, _)| i)
+            .collect();
+        assert!(!blanks.is_empty(), "expected blank lines between blocks");
+        let consecutive = texts.windows(2).any(|w| w[0].is_empty() && w[1].is_empty());
+        assert!(!consecutive, "should never have two consecutive blanks");
+    }
+
+    #[test]
+    fn renderer_caches_table_column_widths_across_calls() {
+        let mut r = Renderer::new();
+        let width = 120;
+        r.render("| A | B |\n| --- | --- |\n| hi | there |", width, 0);
+        let widths_after_first = r.table_col_widths[0].clone();
+        r.render(
+            "| A | B |\n| --- | --- |\n| hi | there |\n| longer | x |",
+            width,
+            0,
+        );
+        for (i, (&old, &new)) in widths_after_first
+            .iter()
+            .zip(&r.table_col_widths[0])
+            .enumerate()
+        {
+            assert!(new >= old, "table width shrank at col {i}: {old} -> {new}");
+        }
+    }
+
+    #[test]
+    fn renderer_caches_highlighter_state_across_streaming_updates() {
+        let mut r = Renderer::new();
+        let text = "```rust\nfn main() {}\n```";
+        let a = r.render(text, TEST_WIDTH, 0);
+        let b = r.render(text, TEST_WIDTH, 0);
+        assert_eq!(a, b, "stable input must produce stable output");
+        assert_eq!(r.highlighters.len(), 1);
+    }
+
+    #[test]
+    fn render_empty_input_yields_no_lines() {
+        assert!(render("", TEST_WIDTH).is_empty());
+    }
+
+    #[test]
+    fn render_width_zero_does_not_panic() {
+        let _ = render("```\nhello\n```", 0);
+    }
+
+    #[test]
+    fn render_table_header_row_cells_are_bold() {
+        let lines = render("| Header |\n| --- |\n| Data |", TEST_WIDTH);
+        let header_span = lines
+            .iter()
+            .flat_map(|l| &l.spans)
+            .find(|s| s.text.trim() == "Header")
+            .expect("header span");
+        match &header_span.style {
+            StyleToken::Text | StyleToken::InlineCode => assert!(header_span.emphasis.bold),
+            other => panic!("expected text/inline-code with bold, got {other:?}"),
+        }
+    }
+
+    #[test_case("short\nlines\n", "short\nlines\n" ; "short_text_unchanged")]
+    #[test_case(&"a".repeat(MAX_LINE_BYTES), &"a".repeat(MAX_LINE_BYTES) ; "exactly_at_limit_unchanged")]
+    #[test_case(&"a".repeat(MAX_LINE_BYTES + 1), &format!("{}...", "a".repeat(MAX_LINE_BYTES)) ; "one_over_limit_truncated")]
+    fn truncate_long_lines_cases(input: &str, expected: &str) {
+        assert_eq!(&*truncate_long_lines(input), expected);
+    }
+
+    #[test]
+    fn truncate_long_lines_multibyte_boundary() {
+        let mut line = "a".repeat(MAX_LINE_BYTES - 1);
+        line.push('\u{00e9}');
+        let result = truncate_long_lines(&line);
+        assert!(result.ends_with("..."));
+        assert!(!result.contains('\u{00e9}'));
+    }
+
+    #[test_case(&format!("{}\n", "z".repeat(MAX_LINE_BYTES + 10)), true ; "preserves_trailing_newline")]
+    #[test_case(&"z".repeat(MAX_LINE_BYTES + 10), false ; "no_trailing_newline_when_absent")]
+    fn truncate_long_lines_trailing_newline(input: &str, expect_trailing: bool) {
+        assert_eq!(truncate_long_lines(input).ends_with('\n'), expect_trailing);
+    }
+
+    #[test]
+    fn streaming_matches_oneshot() {
+        const CORPUS: &[&str] = &[
+            "hello world\n# heading\n\npara",
+            "```rust\nfn main() {}\n```",
+            "| H1 | H2 |\n| --- | --- |\n| a | b |\n| c | d |",
+            "## title with `code`\n\n- one\n- two\n- three\n\n```py\nx=1\ny=2\n```\nend",
+        ];
+        const WIDTHS: &[u16] = &[20, 40, 80];
+        for text in CORPUS {
+            for &w in WIDTHS {
+                let oneshot = Renderer::new().render(text, w, 0);
+                let mut streamer = Renderer::new();
+                for end in 1..text.len() {
+                    if !text.is_char_boundary(end) {
+                        continue;
+                    }
+                    let _ = streamer.render(&text[..end], w, 0);
+                }
+                let final_streamed = streamer.render(text, w, 0);
+                assert_eq!(final_streamed, oneshot, "mismatch text={text:?} width={w}");
+            }
+        }
+    }
+
+    #[test]
+    fn finalize_lines_collapses_internal_consecutive_blanks() {
+        let mut lines = vec![
+            Line {
+                kind: LineKind::Paragraph,
+                spans: vec![Span::new("a", StyleToken::Text)],
+            },
+            Line::blank(),
+            Line::blank(),
+            Line::blank(),
+            Line {
+                kind: LineKind::Paragraph,
+                spans: vec![Span::new("b", StyleToken::Text)],
+            },
+            Line::blank(),
+            Line {
+                kind: LineKind::Paragraph,
+                spans: vec![Span::new("c", StyleToken::Text)],
+            },
+            Line::blank(),
+            Line::blank(),
+        ];
+        finalize_lines(&mut lines);
+        assert!(!lines.last().is_some_and(Line::is_blank));
+        for w in lines.windows(2) {
+            assert!(
+                !(w[0].is_blank() && w[1].is_blank()),
+                "two consecutive blanks: {lines:?}"
+            );
+        }
+        let texts: Vec<_> = lines
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.text.as_str()).collect::<String>())
+            .collect();
+        assert_eq!(texts, vec!["a", "", "b", "", "c"]);
+    }
+
+    #[test]
+    fn theme_gen_change_clears_highlighter_cache() {
+        let mut r = Renderer::new();
+        let code = "```rust\nlet x = 42;\n```";
+        r.render(code, TEST_WIDTH, 0);
+        assert_eq!(
+            r.highlighters.len(),
+            1,
+            "one highlighter after first render"
+        );
+        let gen0_output = r.render(code, TEST_WIDTH, 0);
+        assert_eq!(r.highlighters.len(), 1);
+        let gen1_output = r.render(code, TEST_WIDTH, 1);
+        assert_eq!(r.highlighters.len(), 1, "highlighter rebuilt at new gen");
+        assert_eq!(r.theme_gen, 1, "theme_gen updated");
+        assert_eq!(gen0_output, gen1_output, "same theme produces same output");
+    }
+
+    #[test]
+    fn unwrapped_mode_does_not_wrap_paragraphs() {
+        let long_para = "word ".repeat(50);
+        let mut r = Renderer::unwrapped();
+        let lines = r.render(long_para.trim(), 30, 0);
+        let para_lines: Vec<_> = lines
+            .iter()
+            .filter(|l| l.kind == LineKind::Paragraph)
+            .collect();
+        assert_eq!(
+            para_lines.len(),
+            1,
+            "unwrapped paragraph must stay on one line"
+        );
+    }
+
+    #[test]
+    fn unwrapped_mode_still_wraps_code_blocks() {
+        let long_code = "a".repeat(60);
+        let input = format!("```\n{long_code}\n```");
+        let mut r = Renderer::unwrapped();
+        let lines = r.render(&input, 20, 0);
+        let code_lines: Vec<_> = lines.iter().filter(|l| l.kind == LineKind::Code).collect();
+        assert!(
+            code_lines.len() > 1,
+            "unwrapped mode must still wrap code lines"
+        );
+    }
+
+    #[test]
+    fn table_compact_fallback_at_small_width() {
+        let input = "| aa | bb |\n| --- | --- |\n| cc | dd |";
+        let narrow_width: u16 = 10;
+        let lines = render(input, narrow_width);
+        let has_box_border = lines.iter().any(|l| l.kind == LineKind::TableBorder);
+        assert!(
+            !has_box_border,
+            "compact mode should have no TableBorder lines"
+        );
+        let row_lines: Vec<_> = lines
+            .iter()
+            .filter(|l| l.kind == LineKind::TableRow)
+            .collect();
+        assert!(
+            !row_lines.is_empty(),
+            "compact mode should produce TableRow lines"
+        );
+    }
+
+    #[test]
+    fn multiple_code_blocks_get_separate_highlighters() {
+        let mut r = Renderer::new();
+        let two_blocks = "```rust\nfn a() {}\n```\n\n```python\nx = 1\n```";
+        r.render(two_blocks, TEST_WIDTH, 0);
+        assert_eq!(
+            r.highlighters.len(),
+            2,
+            "each code block gets its own highlighter"
+        );
+        let one_block = "```rust\nfn a() {}\n```";
+        r.render(one_block, TEST_WIDTH, 0);
+        assert_eq!(
+            r.highlighters.len(),
+            1,
+            "highlighters truncated to match block count"
+        );
+    }
+
+    #[test]
+    fn paragraph_wrapping_preserves_all_content() {
+        const INPUT: &str = "The **quick** brown _fox_ jumps over the `lazy` dog repeatedly";
+        let lines = render(INPUT, 20);
+        let rendered: String = lines
+            .iter()
+            .flat_map(|l| &l.spans)
+            .map(|s| s.text.as_str())
+            .collect();
+        let expected = INPUT.replace("**", "").replace(['_', '`'], "");
+        assert_eq!(
+            rendered, expected,
+            "wrapped output must preserve all visible text"
+        );
+    }
+
+    #[test]
+    fn coalesce_merges_same_style_and_splits_different() {
+        let mut spans = vec![
+            Span::new("aa", StyleToken::Text),
+            Span::new("bb", StyleToken::Text),
+            Span::new("cc", StyleToken::InlineCode),
+            Span::new("dd", StyleToken::InlineCode),
+            Span::new("ee", StyleToken::Text),
+        ];
+        coalesce_adjacent_spans(&mut spans);
+        assert_eq!(spans.len(), 3, "three groups after coalesce");
+        assert_eq!(spans[0].text, "aabb");
+        assert_eq!(spans[0].style, StyleToken::Text);
+        assert_eq!(spans[1].text, "ccdd");
+        assert_eq!(spans[1].style, StyleToken::InlineCode);
+        assert_eq!(spans[2].text, "ee");
+        assert_eq!(spans[2].style, StyleToken::Text);
+    }
+
+    #[test]
+    fn coalesce_does_not_merge_different_emphasis() {
+        let mut spans = vec![
+            Span::new("plain", StyleToken::Text),
+            Span::with_emphasis("bold", StyleToken::Text, Emphasis::BOLD),
+        ];
+        coalesce_adjacent_spans(&mut spans);
+        assert_eq!(spans.len(), 2, "different emphasis must not merge");
+    }
+
+    #[test_case(10 ; "narrow")]
+    #[test_case(40 ; "medium")]
+    #[test_case(120 ; "wide")]
+    fn table_with_empty_cell_does_not_panic(width: u16) {
+        let input = "| a | | c |\n| --- | --- | --- |\n| d | | f |";
+        let lines = render(input, width);
+        let rows: Vec<_> = lines
+            .iter()
+            .filter(|l| l.kind == LineKind::TableRow)
+            .collect();
+        assert!(rows.len() >= 2, "two data rows expected at width={width}");
+    }
+
+    #[test]
+    fn ordered_list_emits_correct_marker() {
+        let lines = render("1. first", TEST_WIDTH);
+        assert_eq!(lines[0].kind, LineKind::ListItem);
+        let marker = &lines[0].spans[0];
+        assert_eq!(marker.text, "1. ", "ordered list marker text");
+        assert_eq!(
+            marker.style,
+            StyleToken::ListMarker,
+            "ordered list marker style"
+        );
+        let content = &lines[0].spans[1];
+        assert_eq!(content.text, "first");
+    }
+
+    #[test]
+    fn wrap_spans_hard_breaks_unbreakable_run() {
+        let long_word = "x".repeat(30);
+        let spans = vec![Span::new(long_word.clone(), StyleToken::Text)];
+        let max_width: usize = 10;
+        let wrapped = wrap_spans(spans, max_width);
+        assert!(
+            wrapped.len() >= 3,
+            "30 chars at width 10 must produce at least 3 rows, got {}",
+            wrapped.len()
+        );
+        let reassembled: String = wrapped
+            .iter()
+            .flat_map(|row| row.iter())
+            .map(|s| s.text.as_str())
+            .collect();
+        assert_eq!(
+            reassembled, long_word,
+            "hard-break must preserve all characters"
+        );
+        for row in &wrapped {
+            let w: usize = row.iter().map(|s| s.text.width()).sum();
+            assert!(w <= max_width, "row exceeded max_width: {w}");
+        }
+    }
+
+    #[test]
+    fn render_leading_newlines_are_stripped() {
+        let lines = render("\n\n\nhello", TEST_WIDTH);
+        assert!(!lines.is_empty());
+        let first_text: String = lines[0].spans.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(first_text, "hello");
+    }
+}

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -1129,7 +1129,6 @@ impl MessagesPanel {
                         prefix,
                         style.text_style,
                         style.prefix_style,
-                        None,
                         self.viewport_width,
                     )
                 } else {

--- a/maki-ui/src/components/streaming_content.rs
+++ b/maki-ui/src/components/streaming_content.rs
@@ -1,75 +1,75 @@
 use crate::animation::Typewriter;
-use crate::highlight::CodeHighlighter;
-use crate::markdown::{RenderCtx, RenderState, finalize_lines, render_block};
-use maki_markdown::parse;
+use crate::markdown::paint_semantic;
+use crate::theme;
 
+use maki_markdown::render::Renderer;
 use ratatui::style::Style;
 use ratatui::text::Line;
+use std::hash::{DefaultHasher, Hash, Hasher};
 
 /// Block-level streaming markdown cache.
 ///
-/// Incremental renderer for a streaming markdown message.
-///
-/// Re-parses all blocks each frame (parsing is cheap string scanning).
-/// Code blocks use `CodeHighlighter` which caches completed lines internally,
-/// so repeated `render_block` calls only re-highlight the last (incomplete) line.
-///
-/// Table column widths are monotonically grown per table (`table_col_widths`)
-/// so that adding a wider row never causes earlier rows to shift. Each table
-/// in a message gets its own independent width vec to prevent cross-table
-/// interference.
+/// Memoizes the rendered line tree under a content-addressed key so
+/// repaints during streaming are free when nothing changed. The key
+/// combines a 64-bit hash of the visible text, its byte length, the
+/// render width, and the theme generation. Length is part of the key
+/// alongside the hash because hashing alone could in principle collide;
+/// requiring both makes accidental reuse on different buffers
+/// astronomically unlikely.
 #[derive(Default)]
 struct StreamingCache {
-    byte_len: usize,
+    key: Option<CacheKey>,
     lines: Vec<Line<'static>>,
-    highlighters: Vec<CodeHighlighter>,
-    table_col_widths: Vec<Vec<usize>>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct CacheKey {
+    hash: u64,
+    byte_len: usize,
+    width: u16,
+    theme_gen: u64,
+}
+
+impl CacheKey {
+    fn for_text(text: &str, width: u16, theme_gen: u64) -> Self {
+        let mut hasher = DefaultHasher::new();
+        text.hash(&mut hasher);
+        Self {
+            hash: hasher.finish(),
+            byte_len: text.len(),
+            width,
+            theme_gen,
+        }
+    }
 }
 
 impl StreamingCache {
     fn invalidate(&mut self) {
-        *self = Self::default();
+        self.key = None;
+        self.lines.clear();
     }
 
+    /// Returns `true` when the cache was repopulated. The caller passes a
+    /// renderer so the highlighter/table-width state persists across calls
+    /// for a stable streamed view.
     fn get_or_update(
         &mut self,
+        renderer: &mut Renderer,
         visible: &str,
         prefix: &str,
         text_style: Style,
         prefix_style: Style,
         width: u16,
     ) -> bool {
-        let len = visible.len();
-        if len == self.byte_len && !self.lines.is_empty() {
+        let theme_gen = theme::generation();
+        let key = CacheKey::for_text(visible, width, theme_gen);
+        if self.key == Some(key) {
             return false;
         }
-        self.byte_len = len;
-
-        let text = visible.trim_start_matches('\n');
-        let blocks = parse(text);
-
-        self.lines.clear();
-        let (code_idx, table_idx) = {
-            let mut state = RenderState {
-                highlighters: Some(&mut self.highlighters),
-                table_col_widths: Some(&mut self.table_col_widths),
-                ..RenderState::new()
-            };
-            let ctx = RenderCtx {
-                prefix,
-                text_style,
-                prefix_style,
-                width,
-            };
-            for block in &blocks {
-                render_block(block, &mut self.lines, &mut state, &ctx);
-            }
-            (state.code_idx, state.table_idx)
-        };
-        self.highlighters.truncate(code_idx);
-        self.table_col_widths.truncate(table_idx);
-
-        finalize_lines(&mut self.lines, prefix, prefix_style);
+        let text = maki_markdown::render::truncate_long_lines(visible);
+        let semantic = renderer.render(text.as_ref(), width, theme_gen);
+        self.lines = paint_semantic(&semantic, prefix, text_style, prefix_style);
+        self.key = Some(key);
         true
     }
 }
@@ -77,6 +77,7 @@ impl StreamingCache {
 pub(crate) struct StreamingContent {
     typewriter: Typewriter,
     cache: StreamingCache,
+    renderer: Renderer,
     prefix: &'static str,
     text_style: Style,
     prefix_style: Style,
@@ -92,6 +93,7 @@ impl StreamingContent {
         Self {
             typewriter: Typewriter::with_speed(ms_per_char),
             cache: StreamingCache::default(),
+            renderer: Renderer::unwrapped(),
             prefix,
             text_style,
             prefix_style,
@@ -105,10 +107,12 @@ impl StreamingContent {
     pub fn clear(&mut self) {
         self.typewriter.clear();
         self.cache.invalidate();
+        self.renderer = Renderer::unwrapped();
     }
 
     pub fn take_all(&mut self) -> String {
         self.cache.invalidate();
+        self.renderer = Renderer::unwrapped();
         self.typewriter.take_all()
     }
 
@@ -130,6 +134,7 @@ impl StreamingContent {
     pub fn render_lines(&mut self, width: u16) -> &[Line<'static>] {
         self.typewriter.tick();
         self.cache.get_or_update(
+            &mut self.renderer,
             self.typewriter.visible(),
             self.prefix,
             self.text_style,
@@ -181,11 +186,14 @@ mod tests {
 
     fn full_render_lines(text: &str, prefix: &str, width: u16) -> Vec<String> {
         let style = Style::default();
-        let mut hl = Vec::new();
-        text_to_lines(text, prefix, style, style, Some(&mut hl), width)
+        text_to_lines(text, prefix, style, style, width)
             .iter()
             .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
             .collect()
+    }
+
+    fn fresh_renderer() -> Renderer {
+        Renderer::unwrapped()
     }
 
     #[test_case(
@@ -222,6 +230,7 @@ mod tests {
         let style = Style::default();
         let width = 80;
         let mut cache = StreamingCache::default();
+        let mut renderer = fresh_renderer();
 
         let step = 7;
         let mut end = step;
@@ -230,11 +239,18 @@ mod tests {
                 end += 1;
                 continue;
             }
-            cache.get_or_update(&full_text[..end], prefix, style, style, width);
+            cache.get_or_update(
+                &mut renderer,
+                &full_text[..end],
+                prefix,
+                style,
+                style,
+                width,
+            );
             end += step;
         }
 
-        cache.get_or_update(full_text, prefix, style, style, width);
+        cache.get_or_update(&mut renderer, full_text, prefix, style, style, width);
         let incremental = cache_lines_text(&cache);
         let expected = full_render_lines(full_text, prefix, width);
         assert_eq!(
@@ -248,11 +264,12 @@ mod tests {
         let style = Style::default();
         let width = 80;
         let mut cache = StreamingCache::default();
+        let mut renderer = fresh_renderer();
 
-        cache.get_or_update("partial text", "", style, style, width);
+        cache.get_or_update(&mut renderer, "partial text", "", style, style, width);
 
         let text = "block1\n```py\nx=1\n```\nblock2\n```js\ny=2\n```\ntail";
-        cache.get_or_update(text, "", style, style, width);
+        cache.get_or_update(&mut renderer, text, "", style, style, width);
 
         let expected = full_render_lines(text, "", width);
         assert_eq!(cache_lines_text(&cache), expected);
@@ -263,11 +280,53 @@ mod tests {
         let style = Style::default();
         let width = 80;
         let mut cache = StreamingCache::default();
+        let mut renderer = fresh_renderer();
         let text = "hello\n```rust\nfn x(){}\n```\nafter";
-        cache.get_or_update(text, "", style, style, width);
+        cache.get_or_update(&mut renderer, text, "", style, style, width);
         cache.invalidate();
-        cache.get_or_update(text, "", style, style, width);
+        cache.get_or_update(&mut renderer, text, "", style, style, width);
         assert_eq!(cache_lines_text(&cache), full_render_lines(text, "", width));
+    }
+
+    #[test]
+    fn cache_invalidates_on_equal_length_content_change() {
+        let style = Style::default();
+        let width = 80;
+        let mut cache = StreamingCache::default();
+        let mut renderer = fresh_renderer();
+
+        let first = "**bold text**";
+        let second = "*italic txt*!";
+        assert_eq!(first.len(), second.len());
+
+        cache.get_or_update(&mut renderer, first, "", style, style, width);
+        let first_lines = cache_lines_text(&cache);
+        assert_eq!(first_lines, full_render_lines(first, "", width));
+
+        cache.get_or_update(&mut renderer, second, "", style, style, width);
+        let second_lines = cache_lines_text(&cache);
+        assert_eq!(second_lines, full_render_lines(second, "", width));
+        assert_ne!(
+            first_lines, second_lines,
+            "cache must re-render when bytes change at equal length"
+        );
+    }
+
+    #[test]
+    fn cache_invalidates_on_width_change() {
+        let style = Style::default();
+        let mut cache = StreamingCache::default();
+        let mut renderer = fresh_renderer();
+        let text = "```rust\nfn extremely_long_function_name_that_definitely_will_not_fit(arg_one: &str, arg_two: usize) {}\n```";
+
+        cache.get_or_update(&mut renderer, text, "", style, style, 200);
+        let wide = cache.lines.len();
+        cache.get_or_update(&mut renderer, text, "", style, style, 30);
+        let narrow = cache.lines.len();
+        assert!(
+            narrow > wide,
+            "narrower width must produce more wrapped lines (wide={wide}, narrow={narrow})"
+        );
     }
 
     #[test_case(
@@ -284,15 +343,16 @@ mod tests {
         let style = Style::default();
         let width = 80;
         let mut cache = StreamingCache::default();
+        let mut renderer = fresh_renderer();
 
-        cache.get_or_update(base, "", style, style, width);
+        cache.get_or_update(&mut renderer, base, "", style, style, width);
         let mut prev_count = cache.lines.len();
 
         let chars: Vec<char> = suffix.chars().collect();
         for i in 1..=chars.len() {
             let partial: String = chars[..i].iter().collect();
             let text = format!("{base}{partial}");
-            cache.get_or_update(&text, "", style, style, width);
+            cache.get_or_update(&mut renderer, &text, "", style, style, width);
             assert!(
                 cache.lines.len() >= prev_count.saturating_sub(1),
                 "line count dropped from {prev_count} to {} at partial {partial:?}",
@@ -307,13 +367,14 @@ mod tests {
         let style = Style::default();
         let width = 80;
         let mut cache = StreamingCache::default();
+        let mut renderer = fresh_renderer();
 
         let base = "| A | B |\n| --- | --- |\n| 1 | 2 |";
-        cache.get_or_update(base, "", style, style, width);
+        cache.get_or_update(&mut renderer, base, "", style, style, width);
         let base_lines = cache_lines_text(&cache);
 
         let partial = format!("{base}\n| 3 | in pro");
-        cache.get_or_update(&partial, "", style, style, width);
+        cache.get_or_update(&mut renderer, &partial, "", style, style, width);
         let partial_lines = cache_lines_text(&cache);
         assert!(
             partial_lines.len() > base_lines.len(),
@@ -326,7 +387,7 @@ mod tests {
         );
 
         let complete = format!("{base}\n| 3 | in progress |");
-        cache.get_or_update(&complete, "", style, style, width);
+        cache.get_or_update(&mut renderer, &complete, "", style, style, width);
         let complete_lines = cache_lines_text(&cache);
         let has_complete_content = complete_lines.iter().any(|l| l.contains("in progress"));
         assert!(
@@ -344,7 +405,7 @@ mod tests {
         sc.render_lines(80);
         sc.clear();
         assert!(sc.is_empty());
-        assert_eq!(sc.cache.byte_len, 0);
+        assert!(sc.cache.key.is_none());
         assert!(sc.cache.lines.is_empty());
 
         sc.set_buffer("hello");
@@ -352,7 +413,7 @@ mod tests {
         let text = sc.take_all();
         assert_eq!(text, "hello");
         assert!(sc.is_empty());
-        assert_eq!(sc.cache.byte_len, 0);
+        assert!(sc.cache.key.is_none());
 
         let mut sc = StreamingContent::new("old> ", style, style, 4);
         sc.set_buffer("text");
@@ -360,5 +421,89 @@ mod tests {
         let new_style = Style::default().fg(ratatui::style::Color::Red);
         sc.set_style("new> ", new_style, new_style);
         assert!(sc.cache.lines.is_empty());
+    }
+
+    #[test]
+    fn cache_miss_on_first_call_returns_true() {
+        let style = Style::default();
+        let mut cache = StreamingCache::default();
+        let mut renderer = fresh_renderer();
+        let repopulated = cache.get_or_update(&mut renderer, "hello", "", style, style, 80);
+        assert!(repopulated, "first call must repopulate (return true)");
+    }
+
+    #[test]
+    fn cache_hit_returns_false() {
+        let style = Style::default();
+        let mut cache = StreamingCache::default();
+        let mut renderer = fresh_renderer();
+        cache.get_or_update(&mut renderer, "hello", "", style, style, 80);
+        let hit = cache.get_or_update(&mut renderer, "hello", "", style, style, 80);
+        assert!(
+            !hit,
+            "second identical call must be a cache hit (return false)"
+        );
+    }
+
+    #[test]
+    fn set_style_invalidates_visual_output() {
+        let style = Style::default();
+        let red = Style::default().fg(ratatui::style::Color::Red);
+
+        let mut sc = StreamingContent::new("old> ", style, style, 4);
+        sc.set_buffer("hello");
+        let before: Vec<String> = sc
+            .render_lines(80)
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
+        assert!(before.iter().any(|l| l.contains("old> ")));
+
+        sc.set_style("new> ", red, red);
+        let after: Vec<String> = sc
+            .render_lines(80)
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
+        assert!(after.iter().any(|l| l.contains("new> ")));
+        assert!(!after.iter().any(|l| l.contains("old> ")));
+    }
+
+    #[test]
+    fn empty_content_produces_output() {
+        let style = Style::default();
+        let mut cache = StreamingCache::default();
+        let mut renderer = fresh_renderer();
+        let repopulated = cache.get_or_update(&mut renderer, "", "", style, style, 80);
+        assert!(repopulated);
+        assert!(
+            !cache.lines.is_empty(),
+            "empty content should still produce lines"
+        );
+    }
+
+    #[test]
+    fn renderer_persists_across_cache_updates() {
+        let style = Style::default();
+        let mut cache = StreamingCache::default();
+        let mut renderer = fresh_renderer();
+
+        let first_block = "```rust\nfn a() {}\n```";
+        cache.get_or_update(&mut renderer, first_block, "", style, style, 80);
+        let after_first = cache_lines_text(&cache);
+
+        let both_blocks = "```rust\nfn a() {}\n```\ntext\n```python\ndef b(): pass\n```";
+        cache.get_or_update(&mut renderer, both_blocks, "", style, style, 80);
+        let after_both = cache_lines_text(&cache);
+
+        assert!(
+            after_both.len() > after_first.len(),
+            "second code block should add lines"
+        );
+        let expected = full_render_lines(both_blocks, "", 80);
+        assert_eq!(
+            after_both, expected,
+            "renderer state must produce correct output across updates"
+        );
     }
 }

--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -584,14 +584,7 @@ impl ToolLineBuilder {
     fn push_markdown_body(&mut self, text: &str) {
         let style = theme::current().assistant;
         let indent = TOOL_BODY_INDENT.len() as u16;
-        let md_lines = text_to_lines(
-            text,
-            "",
-            style,
-            style,
-            None,
-            self.width.saturating_sub(indent),
-        );
+        let md_lines = text_to_lines(text, "", style, style, self.width.saturating_sub(indent));
         for mut line in md_lines {
             line.spans.insert(0, Span::raw(TOOL_BODY_INDENT));
             self.lines.push(line);

--- a/maki-ui/src/highlight.rs
+++ b/maki-ui/src/highlight.rs
@@ -2,7 +2,7 @@ use crate::theme;
 
 use maki_highlight::StyledSegment;
 use ratatui::style::{Color, Modifier, Style};
-use ratatui::text::{Line, Span};
+use ratatui::text::Span;
 
 pub use maki_highlight::TAB_SPACES;
 
@@ -28,55 +28,6 @@ pub fn highlight_line(hl: &mut maki_highlight::Highlighter, text: &str) -> Vec<S
             Span::styled(seg.text, style)
         })
         .collect()
-}
-
-pub fn highlight_code_plain(lang: &str, code: &str) -> Vec<Line<'static>> {
-    maki_highlight::highlight_code(lang, code)
-        .into_iter()
-        .map(|segs| segments_to_line(&segs))
-        .collect()
-}
-
-pub struct CodeHighlighter {
-    inner: maki_highlight::CodeHighlighter,
-    lines: Vec<Line<'static>>,
-    completed: usize,
-}
-
-impl CodeHighlighter {
-    pub fn new(lang: &str) -> Self {
-        Self {
-            inner: maki_highlight::CodeHighlighter::new(lang),
-            lines: Vec::new(),
-            completed: 0,
-        }
-    }
-
-    pub fn update(&mut self, code: &str) -> &[Line<'static>] {
-        let segments = self.inner.update(code);
-        let n = segments.len();
-        self.lines.truncate(n);
-        let stable = n.saturating_sub(1).min(self.completed);
-        for (i, segs) in segments[stable..].iter().enumerate() {
-            let idx = stable + i;
-            let line = segments_to_line(segs);
-            if idx < self.lines.len() {
-                self.lines[idx] = line;
-            } else {
-                self.lines.push(line);
-            }
-        }
-        self.completed = n.saturating_sub(1);
-        &self.lines
-    }
-}
-
-fn segments_to_line(segs: &[StyledSegment]) -> Line<'static> {
-    Line::from(
-        segs.iter()
-            .map(|s| Span::styled(s.text.clone(), convert_segment(s)))
-            .collect::<Vec<_>>(),
-    )
 }
 
 pub fn highlight_regex_inline(pattern: &str) -> Vec<Span<'static>> {

--- a/maki-ui/src/markdown.rs
+++ b/maki-ui/src/markdown.rs
@@ -1,34 +1,22 @@
 use std::borrow::Cow;
-use std::iter;
-use std::mem;
 
-use crate::highlight;
-use crate::highlight::CodeHighlighter;
 use crate::theme;
-use maki_markdown::{Block, BlockKind, Emphasis, InlineSpan, LineBlock, SpanKind, parse};
+use crate::theme::Theme;
+use maki_markdown::Emphasis;
+use maki_markdown::render::{self, Line as RLine, LineKind, Span as RSpan, StyleToken};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use unicode_width::UnicodeWidthStr;
 
-pub(crate) const CODE_BAR: &str = "│ ";
-pub(crate) const CODE_BAR_WRAP: &str = "│";
 pub const TRUNCATION_PREFIX: &str = "...";
 const MIN_TRUNCATABLE_LINES: usize = 2;
-const HR_CHAR: char = '─';
-const MIN_COL_WIDTH: usize = 5;
-const MAX_LINE_CHARS: usize = 500;
 
 /// Add `over`'s modifiers on top of `base`, keeping `base`'s colors.
-/// Used for emphasis (bold, italic, strike): so `## **bold**` keeps the
-/// heading color and just picks up the bold flag.
 fn apply_modifiers(base: Style, over: Style) -> Style {
     base.add_modifier(over.add_modifier)
         .remove_modifier(over.sub_modifier)
 }
 
-/// Recolor `base` with `over`'s colors and OR the modifiers. Used for code
-/// spans, where the color carries meaning, and for body text where emphasis
-/// supplies its own theme color.
+/// Recolor `base` with `over`'s colors and OR the modifiers.
 fn overlay_style(base: Style, over: Style) -> Style {
     let mut out = base;
     if let Some(fg) = over.fg {
@@ -40,12 +28,9 @@ fn overlay_style(base: Style, over: Style) -> Style {
     apply_modifiers(out, over)
 }
 
-/// Emphasis normally recolors with its theme style so `**bold**` stands out
-/// in body text. When `preserve_base_color` is set (headings), emphasis
-/// only adds modifiers so the heading color survives. Code always overlays
-/// its color, because "this is code" is semantic and beats context.
-fn style_for(kind: SpanKind, emphasis: Emphasis, base: Style, preserve_base_color: bool) -> Style {
-    let t = theme::current();
+/// When `preserve_base_color` is set (headings), emphasis only adds modifiers
+/// so the heading colour survives. Otherwise it recolors from the theme.
+fn apply_emphasis(base: Style, emphasis: Emphasis, preserve_base_color: bool, t: &Theme) -> Style {
     let emph_style = match (emphasis.bold, emphasis.italic) {
         (true, true) => Some(t.bold_italic),
         (true, false) => Some(t.bold),
@@ -66,121 +51,73 @@ fn style_for(kind: SpanKind, emphasis: Emphasis, base: Style, preserve_base_colo
     if emphasis.strike {
         style = combine(style, t.strikethrough);
     }
-    if kind == SpanKind::Code {
-        style = overlay_style(style, t.inline_code);
-    }
     style
 }
 
-pub fn parse_inline_markdown(text: &str, base_style: Style) -> Vec<Span<'static>> {
-    parse_inline_with_base(text, base_style, false)
+fn style_for_token(
+    token: &StyleToken,
+    emphasis: Emphasis,
+    base: Style,
+    preserve_base_color: bool,
+    t: &Theme,
+) -> Style {
+    match token {
+        StyleToken::Text => apply_emphasis(base, emphasis, preserve_base_color, t),
+        StyleToken::InlineCode => {
+            let style = apply_emphasis(base, emphasis, preserve_base_color, t);
+            overlay_style(style, t.inline_code)
+        }
+        StyleToken::Heading => apply_emphasis(t.heading, emphasis, true, t),
+        StyleToken::Highlight {
+            fg,
+            bold,
+            italic,
+            underline,
+        } => {
+            let mut s = Style::default().fg(ratatui::style::Color::Rgb(fg.0, fg.1, fg.2));
+            if *bold {
+                s = s.add_modifier(Modifier::BOLD);
+            }
+            if *italic {
+                s = s.add_modifier(Modifier::ITALIC);
+            }
+            if *underline {
+                s = s.add_modifier(Modifier::UNDERLINED);
+            }
+            s
+        }
+        StyleToken::CodeBar => t.code_bar,
+        StyleToken::ListMarker => t.list_marker,
+        StyleToken::TableBorder => t.table_border,
+        StyleToken::HorizontalRule => t.horizontal_rule,
+    }
 }
 
-fn parse_inline_with_base(
-    text: &str,
-    base_style: Style,
-    preserve_base_color: bool,
-) -> Vec<Span<'static>> {
-    maki_markdown::parse_inline(text)
-        .into_iter()
+/// Heading lines preserve heading colour through emphasis. Code lines start
+/// from `Style::default()` so highlighter colours stand alone.
+fn paint_line(line: &RLine, text_style: Style, t: &Theme) -> Line<'static> {
+    let (base, preserve_color) = match line.kind {
+        LineKind::Heading => (t.heading, true),
+        LineKind::Code => (Style::default(), false),
+        _ => (text_style, false),
+    };
+    let spans = line
+        .spans
+        .iter()
         .map(
-            |InlineSpan {
+            |RSpan {
                  text,
-                 kind,
+                 style,
                  emphasis,
              }| {
                 Span::styled(
-                    text,
-                    style_for(kind, emphasis, base_style, preserve_base_color),
+                    text.clone(),
+                    style_for_token(style, *emphasis, base, preserve_color, t),
                 )
             },
         )
-        .collect()
-}
-
-fn fit_width(text: &str, max_width: usize) -> usize {
-    let mut width = 0;
-    for (i, ch) in text.char_indices() {
-        let cw = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
-        if width + cw > max_width {
-            return i;
-        }
-        width += cw;
-    }
-    text.len()
-}
-
-fn prepend_code_bar(line: &mut Line<'static>) {
-    line.spans
-        .insert(0, Span::styled(CODE_BAR, theme::current().code_bar));
-}
-
-pub(crate) fn wrap_code_lines(lines: &mut Vec<Line<'static>>, start: usize, width: u16) {
-    let width = width as usize;
-    if width == 0 {
-        return;
-    }
-    let tail = lines.split_off(start);
-    for line in tail {
-        let line_width: usize = line.spans.iter().map(|s| s.content.width()).sum();
-        if line_width <= width {
-            lines.push(line);
-        } else {
-            lines.extend(split_line_with_bar(line, width));
-        }
-    }
-}
-
-fn split_line_with_bar(line: Line<'static>, width: usize) -> Vec<Line<'static>> {
-    if line.spans.is_empty() {
-        return vec![line];
-    }
-
-    let bar_span = line.spans[0].clone();
-    let content_spans = &line.spans[1..];
-    let first_avail = width.saturating_sub(CODE_BAR.width());
-    let cont_avail = width.saturating_sub(CODE_BAR_WRAP.width());
-
-    let mut result: Vec<Line<'static>> = Vec::new();
-    let mut current_spans: Vec<Span<'static>> = vec![bar_span];
-    let mut remaining = first_avail;
-
-    for span in content_spans {
-        let mut text = span.content.as_ref();
-        let style = span.style;
-
-        while !text.is_empty() {
-            let fits = fit_width(text, remaining);
-            if fits == 0 && remaining == 0 {
-                break;
-            }
-            if fits > 0 {
-                current_spans.push(Span::styled(text[..fits].to_owned(), style));
-                remaining -= text[..fits].width();
-                text = &text[fits..];
-            }
-            if !text.is_empty() {
-                result.push(Line::from(current_spans));
-                current_spans = vec![Span::styled(CODE_BAR_WRAP, theme::current().code_bar)];
-                remaining = cont_avail;
-            }
-        }
-    }
-
-    if current_spans.len() > 1 || result.is_empty() {
-        result.push(Line::from(current_spans));
-    }
-
-    result
-}
-
-fn highlight_code(lang: &str, code: &str, width: u16) -> Vec<Line<'static>> {
-    let mut lines = highlight::highlight_code_plain(lang, code);
-    for line in &mut lines {
-        prepend_code_bar(line);
-    }
-    wrap_code_lines(&mut lines, 0, width);
-    lines
+        .collect::<Vec<_>>();
+    Line::from(spans)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -204,242 +141,17 @@ pub fn truncation_notice(count: usize) -> String {
 pub struct Truncated<'a> {
     pub kept: &'a str,
     pub skipped: usize,
-    keep: Keep,
-}
-
-impl Truncated<'_> {
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub fn notice_line(&self) -> Option<Line<'static>> {
-        if should_truncate(self.skipped) {
-            let text = truncation_notice(self.skipped);
-            Some(Line::from(Span::styled(text, theme::current().tool_dim)))
-        } else {
-            None
-        }
-    }
-
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub fn into_string(self) -> String {
-        if !should_truncate(self.skipped) {
-            return self.kept.to_owned();
-        }
-        let notice = truncation_notice(self.skipped);
-        match self.keep {
-            Keep::Head => format!("{}\n{notice}", self.kept),
-            Keep::Tail => format!("{notice}\n{}", self.kept),
-        }
-    }
 }
 
 pub(crate) fn hr_line(width: u16, style: Style) -> Line<'static> {
-    let hr: String = iter::repeat_n(HR_CHAR, width as usize).collect();
-    Line::from(Span::styled(hr, style))
-}
-
-fn cell_display_width(cell: &str) -> usize {
-    parse_inline_markdown(cell, Style::default())
-        .iter()
-        .map(|s| s.content.width())
-        .sum()
-}
-
-fn constrain_col_widths(col_widths: &mut [usize], available: usize) {
-    let total: usize = col_widths.iter().sum();
-    if total <= available {
-        return;
-    }
-    for w in col_widths.iter_mut() {
-        *w = (*w * available / total).max(MIN_COL_WIDTH).min(*w);
-    }
-    let mut excess = col_widths.iter().sum::<usize>().saturating_sub(available);
-    while excess > 0 {
-        let max_w = col_widths.iter().copied().max().unwrap_or(0);
-        if max_w <= MIN_COL_WIDTH {
-            break;
-        }
-        for w in col_widths.iter_mut() {
-            if excess == 0 {
-                break;
-            }
-            if *w == max_w && *w > MIN_COL_WIDTH {
-                *w -= 1;
-                excess -= 1;
-            }
-        }
-    }
-}
-
-fn wrap_cell_spans(spans: Vec<Span<'static>>, max_width: usize) -> Vec<Vec<Span<'static>>> {
-    if max_width == 0 {
-        return vec![spans];
-    }
-    let mut result: Vec<Vec<Span<'static>>> = Vec::new();
-    let mut current: Vec<Span<'static>> = Vec::new();
-    let mut remaining = max_width;
-
-    for span in spans {
-        let mut text = span.content.as_ref();
-        let style = span.style;
-
-        while !text.is_empty() {
-            let fits = fit_width(text, remaining);
-            if fits == 0 {
-                if current.is_empty() {
-                    let ch_len = text.chars().next().map_or(1, char::len_utf8);
-                    current.push(Span::styled(text[..ch_len].to_owned(), style));
-                    text = &text[ch_len..];
-                }
-                result.push(mem::take(&mut current));
-                remaining = max_width;
-                text = text.strip_prefix(' ').unwrap_or(text);
-                continue;
-            }
-            let (take, skip) = if fits < text.len() {
-                match text[..fits].rfind(' ') {
-                    Some(sp) if sp > 0 => (sp, sp + 1),
-                    _ => (fits, fits),
-                }
-            } else {
-                (fits, fits)
-            };
-            current.push(Span::styled(text[..take].to_owned(), style));
-            remaining -= text[..take].width();
-            text = &text[skip..];
-            if take < fits && !text.is_empty() {
-                result.push(mem::take(&mut current));
-                remaining = max_width;
-            }
-        }
-    }
-    if !current.is_empty() || result.is_empty() {
-        result.push(current);
-    }
-    result
-}
-
-fn spans_width(spans: &[Span<'_>]) -> usize {
-    spans.iter().map(|s| s.content.width()).sum()
-}
-
-fn render_table(
-    rows: &[Vec<String>],
-    header_end: usize,
-    text_style: Style,
-    width: u16,
-    persistent_widths: Option<&mut Vec<usize>>,
-) -> Vec<Line<'static>> {
-    let col_count = rows.iter().map(|r| r.len()).max().unwrap_or(0);
-    if col_count == 0 {
-        return Vec::new();
-    }
-
-    let mut col_widths = vec![0usize; col_count];
-    for row in rows {
-        for (c, cell) in row.iter().enumerate() {
-            col_widths[c] = col_widths[c].max(cell_display_width(cell));
-        }
-    }
-
-    let overhead = col_count * 3 + 1;
-    let available = (width as usize).saturating_sub(overhead);
-
-    if let Some(pw) = persistent_widths {
-        pw.resize(pw.len().max(col_count), 0);
-        for (i, w) in col_widths.iter_mut().enumerate() {
-            pw[i] = pw[i].max(*w);
-            *w = pw[i];
-        }
-    }
-
-    constrain_col_widths(&mut col_widths, available);
-
-    let mut lines = Vec::new();
-
-    let border = |left: &str, mid: &str, right: &str, fill: &str| -> Line<'static> {
-        let tbs = theme::current().table_border;
-        let mut spans = vec![Span::styled(left.to_owned(), tbs)];
-        for (i, &w) in col_widths.iter().enumerate() {
-            spans.push(Span::styled(fill.repeat(w + 2), tbs));
-            if i < col_count - 1 {
-                spans.push(Span::styled(mid.to_owned(), tbs));
-            }
-        }
-        spans.push(Span::styled(right.to_owned(), tbs));
-        Line::from(spans)
-    };
-
-    lines.push(border("╭", "┬", "╮", "─"));
-
-    for (ri, row) in rows.iter().enumerate() {
-        let base = if ri < header_end {
-            overlay_style(text_style, theme::current().bold)
-        } else {
-            text_style
-        };
-
-        let wrapped_cells: Vec<Vec<Vec<Span<'static>>>> = (0..col_count)
-            .map(|c| {
-                let cell = row.get(c).map(String::as_str).unwrap_or("");
-                let cell_spans = parse_inline_markdown(cell, base);
-                wrap_cell_spans(cell_spans, col_widths[c])
-            })
-            .collect();
-
-        let row_height = wrapped_cells.iter().map(|c| c.len()).max().unwrap_or(1);
-
-        for line_idx in 0..row_height {
-            let mut spans = vec![Span::styled("│ ".to_owned(), theme::current().table_border)];
-            for (c, &w) in col_widths.iter().enumerate() {
-                let sub_line = wrapped_cells[c].get(line_idx);
-                let content_width = sub_line.map_or(0, |sl| spans_width(sl));
-                let pad = w.saturating_sub(content_width);
-
-                if let Some(sl) = sub_line {
-                    spans.extend(sl.iter().cloned());
-                }
-                spans.push(Span::styled(" ".repeat(pad + 1), base));
-                if c < col_count - 1 {
-                    spans.push(Span::styled("│ ".to_owned(), theme::current().table_border));
-                } else {
-                    spans.push(Span::styled("│".to_owned(), theme::current().table_border));
-                }
-            }
-            lines.push(Line::from(spans));
-        }
-
-        if ri + 1 < rows.len() {
-            lines.push(border("├", "┼", "┤", "─"));
-        }
-    }
-
-    lines.push(border("╰", "┴", "╯", "─"));
-
-    lines
-}
-
-fn is_blank_line(line: &Line<'_>) -> bool {
-    line.spans.is_empty() || line.spans.iter().all(|s| s.content.is_empty())
-}
-
-fn ensure_blank_line(lines: &mut Vec<Line<'static>>) {
-    if !lines.last().is_some_and(is_blank_line) {
-        lines.push(Line::default());
-    }
+    Line::from(Span::styled(render::hr_text(width), style))
 }
 
 fn prefix_span(prefix: &str, style: Style) -> Span<'static> {
     Span::styled(prefix.to_owned(), style.add_modifier(Modifier::BOLD))
 }
 
-/// Skip the prefix when it's empty, otherwise we'd push a styled empty span
-/// that shows up as a phantom bold marker on every first line.
-fn push_prefix(spans: &mut Vec<Span<'static>>, prefix: &str, style: Style) {
-    if !prefix.is_empty() {
-        spans.push(prefix_span(prefix, style));
-    }
-}
-
-/// Returns `Line::default()` when the prefix is empty, so callers can use it
+/// Returns `Line::default()` when the prefix is empty so callers can use it
 /// as a blank first line without an empty styled span sneaking in.
 fn prefix_line(prefix: &str, style: Style) -> Line<'static> {
     if prefix.is_empty() {
@@ -447,6 +159,15 @@ fn prefix_line(prefix: &str, style: Style) -> Line<'static> {
     } else {
         Line::from(prefix_span(prefix, style))
     }
+}
+
+/// Inline block kinds (paragraph, heading, list) share line 1 with their
+/// prefix. Standalone kinds (code, table, hr) need a separate leader line.
+fn shares_line_with_prefix(kind: &LineKind) -> bool {
+    matches!(
+        kind,
+        LineKind::Paragraph | LineKind::Heading | LineKind::ListItem | LineKind::Blank
+    )
 }
 
 pub fn plain_lines(
@@ -462,7 +183,9 @@ pub fn plain_lines(
     for line in text.split('\n') {
         let mut spans: Vec<Span<'static>> = Vec::new();
         if first_line {
-            push_prefix(&mut spans, prefix, prefix_style);
+            if !prefix.is_empty() {
+                spans.push(prefix_span(prefix, prefix_style));
+            }
             first_line = false;
         }
         spans.push(Span::styled(line.to_owned(), text_style));
@@ -476,199 +199,46 @@ pub fn plain_lines(
     lines
 }
 
-pub(crate) struct RenderState<'a> {
-    pub code_idx: usize,
-    pub table_idx: usize,
-    pub highlighters: Option<&'a mut Vec<CodeHighlighter>>,
-    pub table_col_widths: Option<&'a mut Vec<Vec<usize>>>,
-}
-
-impl<'a> RenderState<'a> {
-    pub fn new() -> Self {
-        Self {
-            code_idx: 0,
-            table_idx: 0,
-            highlighters: None,
-            table_col_widths: None,
-        }
-    }
-}
-
-pub(crate) struct RenderCtx<'a> {
-    pub prefix: &'a str,
-    pub text_style: Style,
-    pub prefix_style: Style,
-    pub width: u16,
-}
-
-fn emit_first_line_prefix(lines: &mut Vec<Line<'static>>, ctx: &RenderCtx<'_>, standalone: bool) {
-    if !lines.is_empty() {
-        return;
-    }
-    if !standalone || !ctx.prefix.is_empty() {
-        lines.push(prefix_line(ctx.prefix, ctx.prefix_style));
-    }
-}
-
-fn render_line_block(lb: &LineBlock, lines: &mut Vec<Line<'static>>, ctx: &RenderCtx<'_>) {
-    if matches!(lb.kind, BlockKind::HorizontalRule) {
-        emit_first_line_prefix(lines, ctx, true);
-        lines.push(hr_line(ctx.width, theme::current().horizontal_rule));
-        return;
-    }
-
-    let mut spans: Vec<Span<'static>> = Vec::new();
-    if lines.is_empty() {
-        push_prefix(&mut spans, ctx.prefix, ctx.prefix_style);
-    }
-
-    if let Some(p) = maki_markdown::block_prefix(&lb.kind) {
-        spans.push(Span::styled(p, theme::current().list_marker));
-    }
-
-    let is_heading = matches!(lb.kind, BlockKind::Heading(_));
-    let base = if is_heading {
-        theme::current().heading
-    } else {
-        ctx.text_style
-    };
-
-    for InlineSpan {
-        text,
-        kind,
-        emphasis,
-    } in maki_markdown::parse_inline(&lb.inline)
-    {
-        spans.push(Span::styled(
-            text,
-            style_for(kind, emphasis, base, is_heading),
-        ));
-    }
-
-    lines.push(Line::from(spans));
-}
-
-pub(crate) fn render_block(
-    block: &Block,
-    lines: &mut Vec<Line<'static>>,
-    state: &mut RenderState<'_>,
-    ctx: &RenderCtx<'_>,
-) {
-    match block {
-        Block::Lines(line_blocks) => {
-            for lb in line_blocks {
-                render_line_block(lb, lines, ctx);
-            }
-        }
-        Block::Code { lang, code } => {
-            if lines.is_empty() {
-                lines.push(prefix_line(ctx.prefix, ctx.prefix_style));
-            }
-            ensure_blank_line(lines);
-            if let Some(hl) = state.highlighters.as_deref_mut() {
-                if state.code_idx >= hl.len() {
-                    hl.push(CodeHighlighter::new(lang));
-                }
-                let unwrapped = hl[state.code_idx].update(code);
-                let start = lines.len();
-                for src_line in unwrapped {
-                    let mut line = src_line.clone();
-                    prepend_code_bar(&mut line);
-                    lines.push(line);
-                }
-                wrap_code_lines(lines, start, ctx.width);
-            } else {
-                lines.extend(highlight_code(lang, code, ctx.width));
-            }
-            ensure_blank_line(lines);
-            state.code_idx += 1;
-        }
-        Block::Table { rows, header_end } => {
-            emit_first_line_prefix(lines, ctx, true);
-            ensure_blank_line(lines);
-            let pw = state.table_col_widths.as_deref_mut().map(|all| {
-                if state.table_idx >= all.len() {
-                    all.resize_with(state.table_idx + 1, Vec::new);
-                }
-                &mut all[state.table_idx]
-            });
-            lines.extend(render_table(
-                rows,
-                *header_end,
-                ctx.text_style,
-                ctx.width,
-                pw,
-            ));
-            ensure_blank_line(lines);
-            state.table_idx += 1;
-        }
-    }
-}
-
-pub(crate) fn finalize_lines(lines: &mut Vec<Line<'static>>, prefix: &str, prefix_style: Style) {
-    while lines.last().is_some_and(is_blank_line) {
-        lines.pop();
-    }
-    if lines.is_empty() {
-        lines.push(prefix_line(prefix, prefix_style));
-    }
-}
-
-pub fn text_to_lines<'a>(
-    text: &str,
-    prefix: &'a str,
+/// Paint semantic lines into ratatui lines, splicing the prefix onto
+/// the first line (or as a standalone leader for non-inline blocks).
+pub(crate) fn paint_semantic(
+    semantic: &[RLine],
+    prefix: &str,
     text_style: Style,
     prefix_style: Style,
-    highlighters: Option<&'a mut Vec<CodeHighlighter>>,
-    width: u16,
 ) -> Vec<Line<'static>> {
-    let text = text.trim_start_matches('\n');
-    let blocks = parse(text);
-    let mut lines: Vec<Line<'static>> = Vec::new();
-    let mut state = RenderState {
-        highlighters,
-        ..RenderState::new()
-    };
-    let ctx = RenderCtx {
-        prefix,
-        text_style,
-        prefix_style,
-        width,
-    };
+    let t = theme::current();
+    let mut lines: Vec<Line<'static>> = semantic
+        .iter()
+        .map(|l| paint_line(l, text_style, &t))
+        .collect();
 
-    for block in &blocks {
-        render_block(block, &mut lines, &mut state, &ctx);
+    if lines.is_empty() {
+        lines.push(prefix_line(prefix, prefix_style));
+        return lines;
     }
 
-    if let Some(hl) = state.highlighters.as_deref_mut() {
-        hl.truncate(state.code_idx);
+    if shares_line_with_prefix(&semantic[0].kind) {
+        if !prefix.is_empty() {
+            lines[0].spans.insert(0, prefix_span(prefix, prefix_style));
+        }
+    } else if !prefix.is_empty() {
+        lines.insert(0, prefix_line(prefix, prefix_style));
     }
 
-    finalize_lines(&mut lines, prefix, prefix_style);
     lines
 }
 
-fn truncate_long_lines(text: &str) -> Cow<'_, str> {
-    if !text.lines().any(|l| l.len() > MAX_LINE_CHARS) {
-        return Cow::Borrowed(text);
-    }
-    let mut result = String::with_capacity(text.len());
-    for (i, line) in text.lines().enumerate() {
-        if i > 0 {
-            result.push('\n');
-        }
-        if line.len() > MAX_LINE_CHARS {
-            let boundary = line.floor_char_boundary(MAX_LINE_CHARS);
-            result.push_str(&line[..boundary]);
-            result.push_str("...");
-        } else {
-            result.push_str(line);
-        }
-    }
-    if text.ends_with('\n') {
-        result.push('\n');
-    }
-    Cow::Owned(result)
+pub fn text_to_lines(
+    text: &str,
+    prefix: &str,
+    text_style: Style,
+    prefix_style: Style,
+    width: u16,
+) -> Vec<Line<'static>> {
+    let text = render::truncate_long_lines(text);
+    let semantic = render::Renderer::unwrapped().render(text.as_ref(), width, 0);
+    paint_semantic(&semantic, prefix, text_style, prefix_style)
 }
 
 pub struct TruncatedOutput<'a> {
@@ -679,7 +249,7 @@ pub struct TruncatedOutput<'a> {
 pub fn truncate_output(text: &str, max: usize, keep: Keep) -> TruncatedOutput<'_> {
     let tr = truncate_lines(text, max, keep);
     TruncatedOutput {
-        kept: truncate_long_lines(tr.kept),
+        kept: render::truncate_long_lines(tr.kept),
         skipped: tr.skipped,
     }
 }
@@ -693,7 +263,6 @@ pub fn truncate_lines(s: &str, max: usize, keep: Keep) -> Truncated<'_> {
         return Truncated {
             kept: s,
             skipped: 0,
-            keep,
         };
     };
     let result = match keep {
@@ -704,7 +273,6 @@ pub fn truncate_lines(s: &str, max: usize, keep: Keep) -> Truncated<'_> {
             Truncated {
                 kept: &s[..i],
                 skipped: if has_content { newlines } else { 0 },
-                keep,
             }
         }
         Keep::Tail => {
@@ -714,7 +282,6 @@ pub fn truncate_lines(s: &str, max: usize, keep: Keep) -> Truncated<'_> {
             Truncated {
                 kept: &s[i + 1..],
                 skipped: if has_content { newlines } else { 0 },
-                keep,
             }
         }
     };
@@ -722,7 +289,6 @@ pub fn truncate_lines(s: &str, max: usize, keep: Keep) -> Truncated<'_> {
         return Truncated {
             kept: s,
             skipped: 0,
-            keep,
         };
     }
     result
@@ -731,262 +297,10 @@ pub fn truncate_lines(s: &str, max: usize, keep: Keep) -> Truncated<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use maki_markdown::render::CODE_BAR;
     use test_case::test_case;
 
-    fn bs() -> Style {
-        theme::current().bold
-    }
-    fn cs() -> Style {
-        theme::current().inline_code
-    }
-    fn ss() -> Style {
-        theme::current().strikethrough
-    }
-    fn bcs() -> Style {
-        overlay_style(bs(), cs())
-    }
-    fn bis() -> Style {
-        theme::current().bold_italic
-    }
-    fn heading_code() -> Style {
-        overlay_style(theme::current().heading, cs())
-    }
-    const IS: Style = Style::new().add_modifier(Modifier::ITALIC);
     const TEST_WIDTH: u16 = 80;
-
-    fn assert_inline(input: &str, expected: &[(&str, Option<Style>)]) {
-        let base = Style::default();
-        let spans = parse_inline_markdown(input, base);
-        assert_eq!(
-            spans.len(),
-            expected.len(),
-            "span count mismatch for {input:?}: got {spans:?}"
-        );
-        for (span, (text, style)) in spans.iter().zip(expected) {
-            assert_eq!(span.content, *text);
-            assert_eq!(span.style, style.unwrap_or(base));
-        }
-    }
-
-    macro_rules! inline_test {
-        ($name:ident, $input:expr, $expected:expr) => {
-            #[test]
-            fn $name() {
-                assert_inline($input, $expected);
-            }
-        };
-    }
-
-    inline_test!(
-        inline_bold,
-        "a **bold** b",
-        &[("a ", None), ("bold", Some(bs())), (" b", None)]
-    );
-    inline_test!(
-        inline_code,
-        "use `foo` here",
-        &[("use ", None), ("foo", Some(cs())), (" here", None)]
-    );
-    inline_test!(
-        italic_star,
-        "some *emphasized* word",
-        &[("some ", None), ("emphasized", Some(IS)), (" word", None)]
-    );
-    inline_test!(italic_underscore, "_italic_", &[("italic", Some(IS))]);
-    inline_test!(
-        strikethrough,
-        "a ~~struck~~ b",
-        &[("a ", None), ("struck", Some(ss())), (" b", None)]
-    );
-    inline_test!(
-        triple_star,
-        "***bold italic***",
-        &[("bold italic", Some(bis()))]
-    );
-
-    inline_test!(
-        code_inside_bold,
-        "**bold `code` bold**",
-        &[
-            ("bold ", Some(bs())),
-            ("code", Some(bcs())),
-            (" bold", Some(bs()))
-        ]
-    );
-    inline_test!(
-        bold_inside_code,
-        "`code **bold** code`",
-        &[("code **bold** code", Some(cs()))]
-    );
-    inline_test!(
-        italic_inside_bold,
-        "**bold *italic* bold**",
-        &[
-            ("bold ", Some(bs())),
-            ("italic", Some(bis())),
-            (" bold", Some(bs()))
-        ]
-    );
-    inline_test!(entire_bold_is_code, "**`all`**", &[("all", Some(bcs()))]);
-    inline_test!(entire_code_is_bold, "`**all**`", &[("**all**", Some(cs()))]);
-
-    #[test_case("here is `/home/tony/file.rs` path" ; "path_in_backticks")]
-    #[test_case("use `fn main()` and **important**" ; "code_and_bold_real_content")]
-    #[test_case("**`/home/tony/c/maki/src/tools/read.rs:23-38`**" ; "bold_code_path")]
-    #[test_case("### 1. Data ` Types` — How Output" ; "heading_with_stray_backtick")]
-    #[test_case("**/ Diffs Are Structured" ; "unclosed_bold_with_slash")]
-    #[test_case("text `code` more **bold** end `code2` fin" ; "mixed_inline")]
-    fn inline_parse_invariants(input: &str) {
-        let base = Style::default();
-        let spans = parse_inline_markdown(input, base);
-        let reconstructed: String = spans.iter().map(|s| s.content.as_ref()).collect();
-
-        let strip = |s: &str| -> String {
-            s.chars()
-                .filter(|c| !matches!(c, '`' | '*' | '~' | '_'))
-                .collect()
-        };
-        assert_eq!(
-            strip(&reconstructed),
-            strip(input),
-            "non-delimiter content lost or reordered\n  input: {input:?}\n  output: {reconstructed:?}"
-        );
-    }
-
-    #[test_case("line1\nline2\nline3", 3, "p> line1" ; "splits_newlines")]
-    #[test_case("\n\nfirst line\nsecond", 2, "p> first line" ; "strips_leading_newlines")]
-    fn text_to_lines_cases(input: &str, expected_lines: usize, first_line: &str) {
-        let style = Style::default();
-        let lines = text_to_lines(input, "p> ", style, style, None, TEST_WIDTH);
-        assert_eq!(lines.len(), expected_lines);
-        assert_eq!(lines_text(&lines)[0], first_line);
-    }
-
-    #[test_case("a\nb\nc", 5, Keep::Head, "a\nb\nc", 0 ; "under_limit_returns_input")]
-    #[test_case("a\nb\nc\nd", 2, Keep::Head, "a\nb", 2 ; "head_over_limit")]
-    #[test_case("a\nb\nc", 2, Keep::Head, "a\nb\nc", 0 ; "head_singular_no_truncation")]
-    #[test_case("a\nb\nc\nd", 2, Keep::Tail, "c\nd", 2 ; "tail_over_limit")]
-    #[test_case("a\nb\nc\nd\ne", 3, Keep::Tail, "c\nd\ne", 2 ; "tail_keeps_last_n")]
-    #[test_case("a\nb\nc", 2, Keep::Tail, "a\nb\nc", 0 ; "tail_singular_no_truncation")]
-    #[test_case("a\nb\nc\n", 3, Keep::Head, "a\nb\nc", 0 ; "head_trailing_newline_no_phantom")]
-    #[test_case("\na\nb\nc", 3, Keep::Tail, "a\nb\nc", 0 ; "tail_leading_newline_no_phantom")]
-    fn truncate_lines_cases(
-        input: &str,
-        max: usize,
-        keep: Keep,
-        expected_kept: &str,
-        expected_skipped: usize,
-    ) {
-        let tr = truncate_lines(input, max, keep);
-        assert_eq!(tr.kept, expected_kept);
-        assert_eq!(tr.skipped, expected_skipped);
-    }
-
-    #[test_case("a\nb\nc\nd", 2, Keep::Head, "a\nb\n... (2 lines) click to expand" ; "head_with_notice")]
-    #[test_case("a\nb\nc\nd", 2, Keep::Tail, "... (2 lines) click to expand\nc\nd" ; "tail_with_notice")]
-    #[test_case("a\nb\nc",    5, Keep::Head, "a\nb\nc"             ; "no_truncation")]
-    fn truncated_into_string(input: &str, max: usize, keep: Keep, expected: &str) {
-        assert_eq!(truncate_lines(input, max, keep).into_string(), expected);
-    }
-
-    #[test_case(5,  "click to expand"   ; "collapsed_shows_expand")]
-    #[test_case(2,  "(2 lines)"          ; "collapsed_plural")]
-    fn truncation_notice_text(count: usize, expected_substr: &str) {
-        let notice = truncation_notice(count);
-        assert!(
-            notice.contains(expected_substr),
-            "expected {expected_substr:?} in {notice:?}"
-        );
-    }
-
-    #[test]
-    fn truncated_inside_code_block_notice_not_in_code() {
-        let style = Style::default();
-        let input = "```rust\nfn a() {}\nfn b() {}\nfn c() {}\nfn d() {}";
-        let tr = truncate_lines(input, 3, Keep::Head);
-        let lines = text_to_lines(tr.kept, "", style, style, None, TEST_WIDTH);
-        for line in &lines {
-            let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-            assert!(
-                !text.contains(TRUNCATION_PREFIX),
-                "kept text should not contain truncation notice"
-            );
-        }
-        assert!(tr.notice_line().is_some());
-    }
-
-    fn block_summary(blocks: &[Block]) -> Vec<(String, Option<String>)> {
-        blocks
-            .iter()
-            .filter_map(|b| match b {
-                Block::Lines(lbs) => {
-                    let joined = lbs
-                        .iter()
-                        .map(reconstruct_line)
-                        .collect::<Vec<_>>()
-                        .join("\n");
-                    Some((joined, None))
-                }
-                Block::Code { lang, code } => Some((code.clone(), Some(lang.clone()))),
-                Block::Table { .. } => None,
-            })
-            .collect()
-    }
-
-    fn reconstruct_line(lb: &LineBlock) -> String {
-        let prefix = maki_markdown::block_prefix(&lb.kind).unwrap_or_default();
-        match lb.kind {
-            BlockKind::Heading(n) => format!("{} {}", "#".repeat(n as usize), lb.inline),
-            BlockKind::HorizontalRule => "---".to_owned(),
-            _ => format!("{prefix}{}", lb.inline),
-        }
-    }
-
-    /// Only asserts the top-level block boundaries (paragraph vs code fence
-    /// vs table). Inline contents of normal blocks live in `maki-markdown`'s
-    /// own tests.
-    #[test_case(
-        "before\n```rust\nfn main() {}\n```\nafter",
-        &[(false, None), (true, Some("rust")), (false, None)]
-        ; "single_code_block"
-    )]
-    #[test_case(
-        "a\n```py\nx=1\n```\nb\n```js\ny=2\n```\nc",
-        &[(false, None), (true, Some("py")), (false, None), (true, Some("js")), (false, None)]
-        ; "multiple_code_blocks"
-    )]
-    #[test_case(
-        "before\n```rust\nfn main() {}",
-        &[(false, None), (true, Some("rust"))]
-        ; "unclosed_fence"
-    )]
-    #[test_case(
-        "a\n```rs\n```\nb",
-        &[(false, None), (true, Some("rs")), (false, None)]
-        ; "empty_code_block"
-    )]
-    #[test_case(
-        "inline ```code``` here\ntext with ``` inside\nand more",
-        &[(false, None)]
-        ; "mid_line_backticks_not_a_fence"
-    )]
-    #[test_case(
-        "before\n````markdown\n```rust\nfn main() {}\n```\n````\nafter",
-        &[(false, None), (true, Some("markdown")), (false, None)]
-        ; "four_backtick_fence_nests_three"
-    )]
-    fn parse_blocks_structure(input: &str, expected: &[(bool, Option<&str>)]) {
-        let blocks = parse(input);
-        let shape: Vec<(bool, Option<&str>)> = blocks
-            .iter()
-            .map(|b| match b {
-                Block::Lines(_) => (false, None),
-                Block::Code { lang, .. } => (true, Some(lang.as_str())),
-                Block::Table { .. } => (true, Some("<table>")),
-            })
-            .collect();
-        assert_eq!(shape, expected.to_vec());
-    }
 
     fn lines_text(lines: &[Line<'_>]) -> Vec<String> {
         lines
@@ -1000,244 +314,135 @@ mod tests {
             .collect()
     }
 
-    fn strip_md(s: &str) -> String {
-        s.chars()
-            .filter(|c| {
-                !matches!(
-                    c,
-                    '`' | '*'
-                        | '#'
-                        | '•'
-                        | '-'
-                        | '+'
-                        | '~'
-                        | '_'
-                        | '─'
-                        | '│'
-                        | '╭'
-                        | '╮'
-                        | '├'
-                        | '┤'
-                        | '╰'
-                        | '╯'
-                        | '┬'
-                        | '┴'
-                        | '┼'
-                        | '|'
-                )
-            })
-            .collect()
-    }
-
-    fn normalize_ws(s: &str) -> String {
-        s.split_whitespace().collect::<Vec<_>>().join(" ")
+    fn find_span<'a>(lines: &'a [Line<'_>], needle: &str) -> &'a Span<'a> {
+        lines
+            .iter()
+            .flat_map(|l| &l.spans)
+            .find(|s| s.content == needle)
+            .unwrap_or_else(|| panic!("span {needle:?} not found in {:?}", lines_text(lines)))
     }
 
     #[test]
-    fn highlighter_reuse_matches_fresh_render() {
+    fn heading_uses_theme_heading_style() {
         let style = Style::default();
-        let text = "hello\n```rust\nfn main() {}\n```\nbye";
-        let full = text_to_lines(text, "p> ", style, style, None, TEST_WIDTH);
-        let mut hl = Vec::new();
-        let inc = text_to_lines(text, "p> ", style, style, Some(&mut hl), TEST_WIDTH);
-        assert_eq!(lines_text(&full), lines_text(&inc));
-    }
-
-    #[test_case(
-        "Here is **bold** and `code` text.\nLine2 has `more` stuff."
-        ; "streaming_mixed_markdown"
-    )]
-    #[test_case(
-        "### 1. Data Types\n\nHere is `/home/file.rs` path\n**bold** end"
-        ; "streaming_heading_with_code"
-    )]
-    #[test_case(
-        "**`/home/tony/c/maki/src/tools/read.rs:23-38`**\n\nSome text after"
-        ; "streaming_bold_code_path"
-    )]
-    #[test_case(
-        "Before\n```rust\nfn main() {}\n```\nAfter with **bold**"
-        ; "streaming_code_block_then_inline"
-    )]
-    #[test_case(
-        "a `b` c **d** e\n`f` **g**\nh"
-        ; "streaming_multiline_inline"
-    )]
-    #[test_case(
-        "- **bold item**\n- `code item`\n  - nested"
-        ; "streaming_list_with_inline"
-    )]
-    #[test_case(
-        "Here is *italic* and ~~struck~~ text with _underscores_"
-        ; "streaming_italic_strike_underscore"
-    )]
-    #[test_case(
-        "Before table\n\n| Name | Value |\n| --- | --- |\n| foo | 42 |\n| bar | 99 |\n\nAfter table"
-        ; "streaming_table_between_paragraphs"
-    )]
-    fn streaming_never_garbles(input: &str) {
-        let style = Style::default();
-        let step = if input.len() > 200 { 31 } else { 1 };
-        let mut end = step;
-        while end <= input.len() {
-            if !input.is_char_boundary(end) {
-                end += 1;
-                continue;
-            }
-            let prefix = &input[..end];
-            let lines = text_to_lines(prefix, "", style, style, None, TEST_WIDTH);
-            let rendered: String = lines
-                .iter()
-                .map(|l| {
-                    l.spans
-                        .iter()
-                        .map(|s| s.content.as_ref())
-                        .collect::<String>()
-                })
-                .collect::<Vec<_>>()
-                .join("\n");
-
-            for line in rendered.split('\n') {
-                if line.is_empty() {
-                    continue;
-                }
-                let trimmed = line.trim_end();
-                let without_bar = trimmed
-                    .strip_prefix(CODE_BAR)
-                    .or_else(|| trimmed.strip_prefix(CODE_BAR.trim_end()))
-                    .unwrap_or(trimmed);
-                let line_stripped = normalize_ws(&strip_md(without_bar));
-                if line_stripped.is_empty() {
-                    continue;
-                }
-                let input_stripped = normalize_ws(&strip_md(prefix));
-                assert!(
-                    input_stripped.contains(&line_stripped),
-                    "rendered line not found in input at prefix len={end}\n  prefix: {prefix:?}\n  rendered line: {line:?}\n  full rendered: {rendered:?}"
-                );
-            }
-            end += step;
-        }
-    }
-
-    fn hr_text() -> String {
-        iter::repeat_n(HR_CHAR, TEST_WIDTH as usize).collect()
-    }
-
-    #[test_case(
-        "before\n---\nafter",
-        vec!["before".to_owned(), hr_text(), "after".to_owned()]
-        ; "hr_between_paragraphs"
-    )]
-    #[test_case(
-        "---",
-        vec![hr_text()]
-        ; "hr_only"
-    )]
-    fn horizontal_rule_rendering(input: &str, expected: Vec<String>) {
-        let style = Style::default();
-        let lines = text_to_lines(input, "", style, style, None, TEST_WIDTH);
-        assert_eq!(lines_text(&lines), expected);
-    }
-
-    fn prefixed(code: &str) -> String {
-        format!("{}{code}", CODE_BAR)
-    }
-
-    #[test_case(
-        "before\n```rust\nfn main() {}\n```\nafter",
-        vec!["before".into(), "".into(), prefixed("fn main() {}"), "".into(), "after".into()]
-        ; "margin_around_code_block"
-    )]
-    #[test_case(
-        "before\n\n```rust\ncode\n```\n\nafter",
-        vec!["before".into(), "".into(), prefixed("code"), "".into(), "after".into()]
-        ; "extra_blanks_collapsed"
-    )]
-    #[test_case(
-        "hello\n```rust\ncode\n```",
-        vec!["hello".into(), "".into(), prefixed("code")]
-        ; "no_trailing_blank_after_final_code_block"
-    )]
-    fn code_block_margins(input: &str, expected: Vec<String>) {
-        let style = Style::default();
-        let lines = text_to_lines(input, "", style, style, None, TEST_WIDTH);
-        assert_eq!(lines_text(&lines), expected);
-    }
-
-    #[test]
-    fn heading_with_inline_markdown() {
-        let style = Style::default();
-        let lines = text_to_lines("## **bold** and `code`", "", style, style, None, TEST_WIDTH);
+        let lines = text_to_lines("# hello", "", style, style, TEST_WIDTH);
         assert_eq!(lines.len(), 1);
-        let text: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
-        assert_eq!(text, "bold and code");
-        let styles: Vec<_> = lines[0].spans.iter().map(|s| s.style).collect();
-        let heading = theme::current().heading;
-        assert!(styles.contains(&heading), "plain heading span missing");
+        let heading_fg = theme::current().heading.fg;
+        assert_eq!(lines[0].spans[0].style.fg, heading_fg);
+    }
+
+    #[test]
+    fn code_block_emits_code_bar_with_theme_color() {
+        let style = Style::default();
+        let lines = text_to_lines("```\nhello\n```", "", style, style, TEST_WIDTH);
+        let bar = lines
+            .iter()
+            .flat_map(|l| &l.spans)
+            .find(|s| s.content.as_ref() == CODE_BAR)
+            .expect("code bar span");
+        assert_eq!(bar.style, theme::current().code_bar);
+    }
+
+    #[test]
+    fn bold_uses_theme_bold_fg_and_modifier() {
+        let style = Style::default();
+        let lines = text_to_lines("**bold**", "", style, style, TEST_WIDTH);
+        let bold = find_span(&lines, "bold");
+        assert_eq!(bold.style.fg, theme::current().bold.fg);
+        assert!(bold.style.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn heading_emphasis_preserves_heading_color() {
+        let style = Style::default();
+        let lines = text_to_lines("## ***hi***", "", style, style, TEST_WIDTH);
+        let hi = find_span(&lines, "hi");
+        assert_eq!(hi.style.fg, theme::current().heading.fg);
         assert!(
-            styles
-                .iter()
-                .any(|s| s.fg == heading.fg && s.add_modifier.contains(Modifier::BOLD)),
-            "bolded word should retain heading color, got {styles:?}"
+            hi.style
+                .add_modifier
+                .contains(Modifier::BOLD | Modifier::ITALIC)
         );
-        assert!(styles.contains(&heading_code()));
     }
 
-    #[test_case(
-        "- first\n- second\n- third",
-        &["• first", "• second", "• third"]
-        ; "simple_unordered_list"
-    )]
-    #[test_case(
-        "- item\n  - nested\n    - deep",
-        &["• item", "  • nested", "    • deep"]
-        ; "nested_unordered_list"
-    )]
-    #[test_case(
-        "* star item\n+ plus item",
-        &["• star item", "• plus item"]
-        ; "star_and_plus_markers"
-    )]
-    #[test_case(
-        "1. first\n2. second\n3. third",
-        &["1. first", "2. second", "3. third"]
-        ; "simple_ordered_list"
-    )]
-    #[test_case(
-        "1. item\n   - nested bullet",
-        &["1. item", "  • nested bullet"]
-        ; "ordered_then_nested_unordered"
-    )]
-    #[test_case(
-        "10. double digits\n100. triple digits",
-        &["10. double digits", "100. triple digits"]
-        ; "multi_digit_numbers"
-    )]
-    fn list_rendering(input: &str, expected: &[&str]) {
+    #[test]
+    fn heading_inline_code_recolors_to_code_fg() {
         let style = Style::default();
-        let lines = text_to_lines(input, "", style, style, None, TEST_WIDTH);
-        assert_eq!(lines_text(&lines), expected);
+        let lines = text_to_lines("## foo `bar`", "", style, style, TEST_WIDTH);
+        let bar = find_span(&lines, "bar");
+        assert_eq!(bar.style.fg, theme::current().inline_code.fg);
     }
 
-    #[test_case("- item", "• " ; "unordered_bullet")]
-    #[test_case("1. item", "1. " ; "ordered_number")]
-    fn list_marker_styled(input: &str, expected_marker: &str) {
+    #[test]
+    fn list_marker_uses_list_marker_style() {
         let style = Style::default();
-        let lines = text_to_lines(input, "", style, style, None, TEST_WIDTH);
+        let lines = text_to_lines("- item", "", style, style, TEST_WIDTH);
         let marker = lines[0]
             .spans
             .iter()
-            .find(|s| s.style == theme::current().list_marker);
-        assert_eq!(marker.unwrap().content, expected_marker);
+            .find(|s| s.style == theme::current().list_marker)
+            .expect("list marker span");
+        assert_eq!(marker.content, "• ");
+    }
+
+    #[test_case("hello", "p> hello"           ; "paragraph_inline")]
+    #[test_case("# title", "p> title"         ; "heading_inline")]
+    #[test_case("- item", "p> • item"         ; "list_inline")]
+    fn prefix_inlined_on_first_line_blocks(input: &str, expected: &str) {
+        let style = Style::default();
+        let lines = text_to_lines(input, "p> ", style, style, TEST_WIDTH);
+        assert_eq!(lines_text(&lines)[0], expected);
     }
 
     #[test]
-    fn list_item_with_inline_markdown() {
+    fn prefix_emits_standalone_line_for_code_block() {
         let style = Style::default();
-        let lines = text_to_lines("- **bold** and `code`", "", style, style, None, TEST_WIDTH);
-        let text: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
-        assert_eq!(text, "• bold and code");
+        let lines = text_to_lines("```\ncode\n```", "p> ", style, style, TEST_WIDTH);
+        assert_eq!(lines[0].spans[0].content, "p> ");
+    }
+
+    #[test]
+    fn prefix_emits_standalone_line_for_table() {
+        let style = Style::default();
+        let input = "| a | b |\n| --- | --- |\n| 1 | 2 |";
+        let lines = text_to_lines(input, "p> ", style, style, TEST_WIDTH);
+        assert_eq!(lines[0].spans[0].content, "p> ");
+    }
+
+    #[test]
+    fn empty_input_yields_single_prefix_line() {
+        let style = Style::default();
+        let lines = text_to_lines("", "p> ", style, style, TEST_WIDTH);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].spans[0].content, "p> ");
+    }
+
+    #[test]
+    fn no_phantom_empty_bold_span_when_prefix_empty() {
+        let style = Style::default();
+        let lines = text_to_lines("hello", "", style, style, TEST_WIDTH);
+        for span in &lines[0].spans {
+            assert!(
+                !(span.content.is_empty() && span.style.add_modifier.contains(Modifier::BOLD)),
+                "phantom empty bold span: {:?}",
+                lines[0].spans
+            );
+        }
+    }
+
+    #[test_case("a\nb\nc", 5, Keep::Head, "a\nb\nc", 0     ; "under_limit")]
+    #[test_case("a\nb\nc\nd", 2, Keep::Head, "a\nb", 2     ; "head_over_limit")]
+    #[test_case("a\nb\nc\nd", 2, Keep::Tail, "c\nd", 2     ; "tail_over_limit")]
+    fn truncate_lines_cases(
+        input: &str,
+        max: usize,
+        keep: Keep,
+        expected_kept: &str,
+        expected_skipped: usize,
+    ) {
+        let tr = truncate_lines(input, max, keep);
+        assert_eq!(tr.kept, expected_kept);
+        assert_eq!(tr.skipped, expected_skipped);
     }
 
     #[test_case(
@@ -1250,619 +455,113 @@ mod tests {
         &["p> before", "```rust", "fn main() {}", "```", "after"]
         ; "plain_preserves_code_fences_literally"
     )]
-    #[test_case(
-        "line1\nline2",
-        &["p> line1", "line2"]
-        ; "plain_splits_lines"
-    )]
     fn plain_content(input: &str, expected: &[&str]) {
         let base = Style::new().fg(ratatui::style::Color::Cyan);
         let lines = plain_lines(input, "p> ", base, base);
         assert_eq!(lines_text(&lines), expected);
-        for line in &lines {
-            for span in &line.spans {
-                assert!(
-                    span.style == base || span.style == base.add_modifier(Modifier::BOLD),
-                    "unexpected style on {:?}",
-                    span.content
-                );
-            }
-        }
     }
 
-    #[test]
-    fn render_table_structure() {
-        let style = Style::default();
-        let input = "| Name | Value |\n| --- | --- |\n| foo | 42 |";
-        let lines = text_to_lines(input, "", style, style, None, TEST_WIDTH);
-        let joined = lines_text(&lines).join("\n");
-        for expected in ["Name", "foo", "42"] {
-            assert!(joined.contains(expected), "missing {expected:?} in table");
-        }
+    #[test_case(5,  "click to expand"   ; "collapsed_shows_expand")]
+    #[test_case(2,  "(2 lines)"         ; "collapsed_plural")]
+    fn truncation_notice_text(count: usize, expected_substr: &str) {
+        let notice = truncation_notice(count);
         assert!(
-            lines.len() >= 5,
-            "table should have border+header+sep+data+border"
+            notice.contains(expected_substr),
+            "expected {expected_substr:?} in {notice:?}"
         );
-        let sep_lines: Vec<_> = lines
-            .iter()
-            .filter(|l| l.spans.iter().any(|s| s.content.contains('├')))
-            .collect();
-        for sep in &sep_lines {
-            assert_eq!(
-                sep.spans.first().unwrap().style,
-                theme::current().table_border,
-                "all separators should use table_border_style"
-            );
-        }
-    }
-
-    #[test_case("| H |\n| --- |\n| a |\n| b |\n| c |", 3 ; "multi_row_separators")]
-    #[test_case("| H |\n| --- |\n| only |", 1 ; "single_row_header_only")]
-    fn table_separator_count(input: &str, expected: usize) {
-        let style = Style::default();
-        let lines = text_to_lines(input, "", style, style, None, TEST_WIDTH);
-        let sep_count = lines
-            .iter()
-            .filter(|l| l.spans.iter().any(|s| s.content.contains('├')))
-            .count();
-        assert_eq!(sep_count, expected);
     }
 
     #[test]
-    fn render_table_escaped_pipe_stays_in_cell() {
+    fn strikethrough_uses_theme_strikethrough_style() {
         let style = Style::default();
-        let input = "| Query | Result |\n| --- | --- |\n| `cmd \\| filter` | ok |";
-        let lines = text_to_lines(input, "", style, style, None, 80);
-        let joined = lines_text(&lines).join("\n");
-        assert!(
-            joined.contains("cmd \\| filter"),
-            "escaped pipe content missing"
-        );
-        assert!(joined.contains("ok"), "adjacent cell missing");
+        let lines = text_to_lines("~~struck~~", "", style, style, TEST_WIDTH);
+        let struck = find_span(&lines, "struck");
+        assert!(struck.style.add_modifier.contains(Modifier::CROSSED_OUT));
+        assert_eq!(struck.style.fg, theme::current().strikethrough.fg);
     }
 
     #[test]
-    fn table_with_prefix() {
+    fn italic_uses_italic_modifier() {
+        let style = Style::default();
+        let lines = text_to_lines("*italic*", "", style, style, TEST_WIDTH);
+        let it = find_span(&lines, "italic");
+        assert!(it.style.add_modifier.contains(Modifier::ITALIC));
+    }
+
+    #[test]
+    fn table_border_uses_theme_table_border_style() {
         let style = Style::default();
         let input = "| a | b |\n| --- | --- |\n| 1 | 2 |";
-        let lines = text_to_lines(input, "p> ", style, style, None, TEST_WIDTH);
+        let lines = text_to_lines(input, "", style, style, TEST_WIDTH);
+        let border_span = lines
+            .iter()
+            .flat_map(|l| &l.spans)
+            .find(|s| {
+                let c = s.content.as_ref();
+                c.contains('╭') || c.contains('│')
+            })
+            .expect("box-drawing border span");
+        assert_eq!(border_span.style, theme::current().table_border);
+    }
+
+    #[test]
+    fn horizontal_rule_uses_theme_style_and_fill_char() {
+        let style = Style::default();
+        let lines = text_to_lines("---", "", style, style, TEST_WIDTH);
+        assert_eq!(lines.len(), 1);
+        let hr = &lines[0].spans[0];
+        assert_eq!(hr.style, theme::current().horizontal_rule);
+        assert!(
+            hr.content.chars().all(|c| c == '─'),
+            "HR should be filled with ─ chars, got {:?}",
+            hr.content
+        );
+    }
+
+    #[test]
+    fn prefix_on_hr_gets_standalone_leader_line() {
+        let style = Style::default();
+        let lines = text_to_lines("---", "p> ", style, style, TEST_WIDTH);
         assert_eq!(lines[0].spans[0].content, "p> ");
-    }
-
-    #[test]
-    fn table_no_double_blank_before_hr() {
-        let style = Style::default();
-        let input = "| a | b |\n| --- | --- |\n| 1 | 2 |\n\n---\n\nafter";
-        let lines = text_to_lines(input, "", style, style, None, TEST_WIDTH);
-        let text = lines_text(&lines);
-        let consecutive_blanks = text
-            .windows(2)
-            .filter(|w| w[0].is_empty() && w[1].is_empty())
-            .count();
-        assert_eq!(
-            consecutive_blanks, 0,
-            "should never have two consecutive blank lines"
-        );
-    }
-
-    #[test]
-    fn mismatched_cell_counts_does_not_panic() {
-        let style = Style::default();
-        let input = "| a | b | c |\n| --- | --- | --- |\n| 1 | 2 |";
-        let _ = text_to_lines(input, "", style, style, None, TEST_WIDTH);
-    }
-
-    #[test]
-    fn header_row_is_bold() {
-        let style = Style::default();
-        let input = "| Header |\n| --- |\n| Data |";
-        let lines = text_to_lines(input, "", style, style, None, TEST_WIDTH);
-        let header_span = lines
-            .iter()
-            .flat_map(|l| &l.spans)
-            .find(|s| s.content.trim() == "Header")
-            .expect("Header span");
-        assert!(header_span.style.add_modifier.contains(Modifier::BOLD));
-    }
-
-    fn assert_table_within_width(input: &str, width: u16) {
-        let style = Style::default();
-        let lines = text_to_lines(input, "", style, style, None, width);
-        for line in lines_text(&lines) {
-            assert!(
-                line.width() <= width as usize,
-                "line exceeds width {width}: ({}) {line:?}",
-                line.width()
-            );
-        }
-    }
-
-    #[test]
-    fn table_wraps_and_preserves_content() {
-        let style = Style::default();
-        let long = "x".repeat(60);
-        let input = format!("| Col1 | Col2 |\n| --- | --- |\n| short | {long} |");
-        let width: u16 = 40;
-        let lines = text_to_lines(&input, "", style, style, None, width);
-        let rendered: String = lines_text(&lines).join("");
-        let x_count = rendered.chars().filter(|c| *c == 'x').count();
-        assert_eq!(x_count, 60, "wrapped table must preserve all content");
-        assert_table_within_width(&input, width);
-    }
-
-    #[test]
-    fn table_narrow_prose_within_width() {
-        let input = "| Test | Rationale |\n| --- | --- |\n| name | This is a very long rationale that should definitely be wrapped when the terminal width is narrow enough to require it |";
-        assert_table_within_width(input, 50);
-    }
-
-    fn wrap_texts(spans: Vec<Span<'static>>, width: usize) -> Vec<String> {
-        wrap_cell_spans(spans, width)
-            .iter()
-            .map(|l| l.iter().map(|s| s.content.as_ref()).collect())
-            .collect()
-    }
-
-    #[test_case("hello world foo bar", 10, &["hello", "world foo", "bar"] ; "word_boundary")]
-    #[test_case("abcdefghij", 6, &["abcdef", "ghij"] ; "char_boundary_fallback")]
-    fn wrap_cell_spans_cases(input: &str, width: usize, expected: &[&str]) {
-        assert_eq!(
-            wrap_texts(vec![Span::raw(input.to_owned())], width),
-            expected
-        );
-    }
-
-    #[test_case(&[10, 90], 50, true  ; "shrinks_proportionally")]
-    #[test_case(&[10, 20], 50, false ; "noop_when_fits")]
-    fn constrain_col_widths_cases(input: &[usize], available: usize, should_shrink: bool) {
-        let mut widths = input.to_vec();
-        let original = widths.clone();
-        constrain_col_widths(&mut widths, available);
-        assert!(widths.iter().sum::<usize>() <= available);
-        for w in &widths {
-            assert!(*w >= MIN_COL_WIDTH);
-        }
-        if !should_shrink {
-            assert_eq!(widths, original);
-        }
-    }
-
-    fn content_text(lines: &[Line<'_>]) -> String {
-        lines
-            .iter()
-            .flat_map(|l| &l.spans)
-            .filter(|s| s.content.as_ref() != CODE_BAR && s.content.as_ref() != CODE_BAR_WRAP)
-            .map(|s| s.content.as_ref())
-            .collect()
-    }
-
-    #[test]
-    fn wrap_preserves_content() {
-        let code = "a".repeat(20);
-        let lines = highlight_code("txt", &code, 12);
-        assert!(lines.len() >= 2);
-        assert_eq!(content_text(&lines), code);
-    }
-
-    #[test]
-    fn wrap_zero_width_does_not_panic() {
-        let lines = highlight_code("txt", "hello", 0);
-        assert!(!lines.is_empty());
-    }
-
-    #[test]
-    fn wrap_code_lines_preserves_prefix() {
-        let style = Style::default();
-        let input = format!("```\n{}\n```", "a".repeat(30));
-        let lines = text_to_lines(&input, "", style, style, None, 15);
-        for line in &lines {
-            if is_blank_line(line) {
-                continue;
-            }
-            let first = &line.spans[0].content;
-            assert!(
-                first.as_ref() == CODE_BAR || first.as_ref() == CODE_BAR_WRAP,
-                "code line missing bar prefix: {first:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn wrap_code_lines_preserves_lines_before_start() {
-        let mut lines = vec![
-            Line::from("header"),
-            Line::from(vec![
-                Span::styled(CODE_BAR, theme::current().code_bar),
-                Span::raw("short"),
-            ]),
-        ];
-        wrap_code_lines(&mut lines, 1, 80);
-        assert_eq!(lines[0].spans[0].content, "header");
-    }
-
-    #[test]
-    fn persistent_widths_constrained_to_available() {
-        let style = Style::default();
-        let width: u16 = 40;
-        let mut pw = Vec::new();
-
-        let rows1 = vec![
-            vec!["Name".into(), "Description".into()],
-            vec!["a".into(), "short".into()],
-        ];
-        let lines1 = render_table(&rows1, 1, style, width, Some(&mut pw));
-        for line in lines_text(&lines1) {
-            assert!(
-                line.width() <= width as usize,
-                "frame 1 overflows ({} > {width}): {line:?}",
-                line.width()
-            );
-        }
-
-        let rows2 = vec![
-            vec!["Name".into(), "Description".into()],
-            vec!["a".into(), "short".into()],
-            vec![
-                "b".into(),
-                "a very long description that exceeds the available width".into(),
-            ],
-        ];
-        let lines2 = render_table(&rows2, 1, style, width, Some(&mut pw));
-        for line in lines_text(&lines2) {
-            assert!(
-                line.width() <= width as usize,
-                "frame 2 overflows ({} > {width}): {line:?}",
-                line.width()
-            );
-        }
-    }
-
-    #[test]
-    fn persistent_widths_grow_monotonically() {
-        let style = Style::default();
-        let width: u16 = 120;
-        let mut pw = Vec::new();
-
-        let rows1 = vec![
-            vec!["A".into(), "B".into()],
-            vec!["hi".into(), "there".into()],
-        ];
-        render_table(&rows1, 1, style, width, Some(&mut pw));
-        let pw_after1 = pw.clone();
-
-        let rows2 = vec![
-            vec!["A".into(), "B".into()],
-            vec!["hi".into(), "there".into()],
-            vec!["longer".into(), "x".into()],
-        ];
-        render_table(&rows2, 1, style, width, Some(&mut pw));
-        for (i, (&old, &new)) in pw_after1.iter().zip(pw.iter()).enumerate() {
-            assert!(
-                new >= old,
-                "persistent width shrank at col {i}: {old} -> {new}"
-            );
-        }
-    }
-
-    #[test]
-    fn second_table_does_not_widen_first_table() {
-        let style = Style::default();
-        let width: u16 = 120;
-        let mut all_widths: Vec<Vec<usize>> = Vec::new();
-        let table1 = "| A | B |\n| --- | --- |\n| x | y |";
-        let table2_wide = "\n\nsome text\n\n| Very Wide Column | Another Wide Col |\n| --- | --- |\n| long content here | more long content |";
-
-        let render = |input: &str, widths: &mut Vec<Vec<usize>>| {
-            let blocks = parse(input);
-            let mut lines = Vec::new();
-            let mut state = RenderState {
-                table_col_widths: Some(widths),
-                ..RenderState::new()
-            };
-            let ctx = RenderCtx {
-                prefix: "",
-                text_style: style,
-                prefix_style: style,
-                width,
-            };
-            for block in &blocks {
-                render_block(block, &mut lines, &mut state, &ctx);
-            }
-        };
-
-        render(table1, &mut all_widths);
-        let table1_widths_before = all_widths[0].clone();
-
-        let both = format!("{table1}{table2_wide}");
-        render(&both, &mut all_widths);
-        assert_eq!(
-            all_widths[0], table1_widths_before,
-            "table 1 widths changed after table 2 appeared"
-        );
-    }
-
-    #[test_case("short\nlines\n", "short\nlines\n" ; "short_text_unchanged")]
-    #[test_case(&"a".repeat(MAX_LINE_CHARS), &"a".repeat(MAX_LINE_CHARS) ; "exactly_at_limit_unchanged")]
-    #[test_case(&"a".repeat(MAX_LINE_CHARS + 1), &format!("{}...", "a".repeat(MAX_LINE_CHARS)) ; "one_over_limit_truncated")]
-    fn truncate_long_lines_cases(input: &str, expected: &str) {
-        assert_eq!(&*truncate_long_lines(input), expected);
-    }
-
-    #[test]
-    fn truncate_long_lines_multibyte_boundary() {
-        let mut line = "a".repeat(MAX_LINE_CHARS - 1);
-        line.push('\u{00e9}');
-        let result = truncate_long_lines(&line);
-        assert!(result.ends_with("..."));
-        assert!(!result.contains('\u{00e9}'));
-    }
-
-    #[test]
-    fn truncate_long_lines_mixed_only_long_truncated() {
-        let long = "x".repeat(MAX_LINE_CHARS + 50);
-        let input = format!("short\n{long}\nshort");
-        let result = truncate_long_lines(&input);
-        let lines: Vec<&str> = result.lines().collect();
-        assert_eq!(lines.len(), 3);
-        assert_eq!(lines[0], "short");
-        assert!(lines[1].len() <= MAX_LINE_CHARS + 3);
-        assert!(lines[1].ends_with("..."));
-        assert_eq!(lines[2], "short");
-    }
-
-    #[test_case(&format!("{}\n", "z".repeat(MAX_LINE_CHARS + 10)), true ; "preserves_trailing_newline")]
-    #[test_case(&"z".repeat(MAX_LINE_CHARS + 10), false ; "no_trailing_newline_when_absent")]
-    fn truncate_long_lines_trailing_newline(input: &str, expect_trailing: bool) {
-        assert_eq!(truncate_long_lines(input).ends_with('\n'), expect_trailing);
-    }
-
-    #[test]
-    fn truncate_output_line_count_and_long_lines() {
-        let long = "y".repeat(MAX_LINE_CHARS + 50);
-        let input = format!("a\n{long}\nc\nd\ne");
-        let result = truncate_output(&input, 3, Keep::Head);
-        assert_eq!(result.skipped, 2);
-        let kept_lines: Vec<&str> = result.kept.lines().collect();
-        assert_eq!(kept_lines.len(), 3);
-        assert!(kept_lines[1].ends_with("..."));
-        assert!(kept_lines[1].len() <= MAX_LINE_CHARS + 3);
-    }
-
-    #[test]
-    fn streaming_table_no_flicker_during_separator() {
-        let full = "| Name | Value |\n| --- | --- |\n| foo | 42 |";
-        let mut ever_table = false;
-        for i in 1..=full.len() {
-            let partial = &full[..i];
-            let blocks = parse(partial);
-            let is_table = blocks.iter().any(|b| matches!(b, Block::Table { .. }));
-            if is_table {
-                ever_table = true;
-            }
-            assert!(
-                !ever_table || is_table,
-                "once recognized as table, must stay table at byte {i}: {partial:?}"
-            );
-        }
-        assert!(ever_table, "table should be recognized at some point");
-    }
-
-    /// The summary helper isn't used by the renderer, so this test is the
-    /// only thing keeping it honest.
-    #[test]
-    fn block_summary_round_trips_code() {
-        let blocks = parse("```rust\nfn x() {}\n```");
-        let summary = block_summary(&blocks);
-        assert_eq!(
-            summary,
-            vec![("fn x() {}".to_owned(), Some("rust".to_owned()))]
-        );
-    }
-
-    // Regression tests for heading-color preservation under emphasis: when
-    // base has a foreground, emphasis only adds modifiers; code still
-    // recolors because it's semantic.
-
-    fn find_span<'a>(lines: &'a [Line<'_>], needle: &str) -> &'a Span<'a> {
-        lines
-            .iter()
-            .flat_map(|l| &l.spans)
-            .find(|s| s.content == needle)
-            .unwrap_or_else(|| panic!("span {needle:?} not found in {:?}", lines_text(lines)))
-    }
-
-    #[test_case(
-        "## ***hi***", "hi",
-        Modifier::BOLD | Modifier::ITALIC
-        ; "bold_italic_on_heading")]
-    #[test_case(
-        "## *x*", "x",
-        Modifier::ITALIC
-        ; "italic_on_heading")]
-    #[test_case(
-        "## ~~x~~", "x",
-        Modifier::CROSSED_OUT
-        ; "strikethrough_on_heading")]
-    fn heading_emphasis_preserves_color(input: &str, needle: &str, expected_mods: Modifier) {
-        let style = Style::default();
-        let lines = text_to_lines(input, "", style, style, None, TEST_WIDTH);
-        let span = find_span(&lines, needle);
-        let heading_fg = theme::current().heading.fg;
-        assert_eq!(
-            span.style.fg, heading_fg,
-            "emphasis on heading must keep heading fg, got {:?}",
-            span.style
-        );
         assert!(
-            span.style.add_modifier.contains(expected_mods),
-            "missing modifiers {expected_mods:?} on {needle:?}: {:?}",
-            span.style
-        );
-    }
-
-    /// Inline code overrides heading color (semantic), while emphasis only
-    /// modifies appearance.
-    #[test]
-    fn heading_inline_code_recolors() {
-        let style = Style::default();
-        let lines = text_to_lines("## foo `bar`", "", style, style, None, TEST_WIDTH);
-        let bar = find_span(&lines, "bar");
-        let code_fg = theme::current().inline_code.fg;
-        assert!(code_fg.is_some(), "test assumes theme inline_code has fg");
-        assert_eq!(
-            bar.style.fg, code_fg,
-            "inline code on heading must use code fg, got {:?}",
-            bar.style
-        );
-    }
-
-    // Regression tests: no phantom empty bold span on the first line when
-    // the prefix is empty.
-
-    #[test]
-    fn no_phantom_empty_span_when_prefix_empty() {
-        let style = Style::default();
-        let lines = text_to_lines("hello", "", style, style, None, TEST_WIDTH);
-        for span in &lines[0].spans {
-            assert!(
-                !(span.content.is_empty() && span.style.add_modifier.contains(Modifier::BOLD)),
-                "phantom empty bold span present: {:?}",
-                lines[0].spans
-            );
-        }
-    }
-
-    #[test]
-    fn non_empty_prefix_has_no_spurious_empty_span_before_it() {
-        let style = Style::default();
-        let lines = text_to_lines("hello", "p> ", style, style, None, TEST_WIDTH);
-        let first = &lines[0].spans[0];
-        assert_eq!(first.content, "p> ", "first span must be the prefix");
-        for span in &lines[0].spans {
-            assert!(
-                !span.content.is_empty(),
-                "no span should be empty: {:?}",
-                lines[0].spans
-            );
-        }
-    }
-
-    #[test]
-    fn paragraph_bold_italic_carries_both_modifiers() {
-        let style = Style::default();
-        let lines = text_to_lines("***hello***", "", style, style, None, TEST_WIDTH);
-        let hello = find_span(&lines, "hello");
-        assert!(
-            hello
-                .style
-                .add_modifier
-                .contains(Modifier::BOLD | Modifier::ITALIC),
-            "***hello*** must have BOLD|ITALIC, got {:?}",
-            hello.style
+            lines[1].spans[0].content.chars().all(|c| c == '─'),
+            "second line should be the HR"
         );
     }
 
     #[test]
-    fn paragraph_strikethrough_carries_modifier() {
+    fn code_block_highlight_spans_have_rgb_color() {
         let style = Style::default();
-        let lines = text_to_lines("a ~~gone~~ b", "", style, style, None, TEST_WIDTH);
-        let gone = find_span(&lines, "gone");
-        assert!(
-            gone.style.add_modifier.contains(Modifier::CROSSED_OUT),
-            "~~gone~~ must have CROSSED_OUT, got {:?}",
-            gone.style
-        );
-    }
-
-    /// `parse_inline_markdown` always recolors emphasis with the theme
-    /// style, even when the base already has a foreground. Heading color
-    /// preservation is handled by the heading render path, not here.
-    #[test]
-    fn parse_inline_with_colored_base_recolors_bold() {
-        let base = Style::default().fg(ratatui::style::Color::Cyan);
-        let spans = parse_inline_markdown("a **b**", base);
-        let b = spans.iter().find(|s| s.content == "b").expect("b span");
-        assert_eq!(b.style.fg, theme::current().bold.fg);
-        assert!(b.style.add_modifier.contains(Modifier::BOLD));
-    }
-
-    #[test]
-    fn parse_inline_with_default_base_recolors_bold() {
-        let spans = parse_inline_markdown("a **b**", Style::default());
-        let b = spans.iter().find(|s| s.content == "b").expect("b span");
-        assert_eq!(b.style.fg, theme::current().bold.fg);
-        assert!(b.style.add_modifier.contains(Modifier::BOLD));
-    }
-
-    #[test]
-    fn render_is_idempotent() {
-        let style = Style::default();
-        let input = "## title\n\n- a `code` item\n- **bold** item\n\n```rust\nfn x() {}\n```";
-        let a = text_to_lines(input, "", style, style, None, TEST_WIDTH);
-        let b = text_to_lines(input, "", style, style, None, TEST_WIDTH);
-        assert_eq!(lines_text(&a), lines_text(&b));
-        assert_eq!(a.len(), b.len());
-        for (la, lb) in a.iter().zip(&b) {
-            assert_eq!(la.spans.len(), lb.spans.len());
-            for (sa, sb) in la.spans.iter().zip(&lb.spans) {
-                assert_eq!(sa.content, sb.content);
-                assert_eq!(sa.style, sb.style);
-            }
-        }
-    }
-
-    #[test_case("```unknownlang\nfn x() {}\n```" ; "unknown_language")]
-    #[test_case("```\nplain code\n```" ; "no_language")]
-    fn code_block_renders_with_bar(input: &str) {
-        let style = Style::default();
-        let lines = text_to_lines(input, "", style, style, None, TEST_WIDTH);
-        assert!(!lines.is_empty());
-        let has_bar = lines
+        let lines = text_to_lines("```rust\nfn x() {}\n```", "", style, style, TEST_WIDTH);
+        let code_spans: Vec<_> = lines
             .iter()
             .flat_map(|l| &l.spans)
-            .any(|s| s.content.as_ref() == CODE_BAR || s.content.as_ref() == CODE_BAR_WRAP);
-        assert!(
-            has_bar,
-            "code block missing bar prefix: {:?}",
-            lines_text(&lines)
-        );
-    }
-
-    #[test]
-    fn nested_list_markers_share_style() {
-        let style = Style::default();
-        let lines = text_to_lines("- a\n  - b", "", style, style, None, TEST_WIDTH);
-        let marker_style = theme::current().list_marker;
-        let markers: Vec<&Span<'_>> = lines
-            .iter()
-            .flat_map(|l| &l.spans)
-            .filter(|s| s.content.trim() == "•")
+            .filter(|s| {
+                s.content.as_ref() != CODE_BAR && !s.content.is_empty() && s.content.as_ref() != "│"
+            })
             .collect();
-        assert_eq!(markers.len(), 2, "expected two bullet markers");
-        for m in markers {
-            assert_eq!(m.style, marker_style);
-        }
+        let has_rgb = code_spans
+            .iter()
+            .any(|s| matches!(s.style.fg, Some(ratatui::style::Color::Rgb(_, _, _))));
+        assert!(
+            has_rgb,
+            "expected at least one Rgb-colored span in code block, got: {:?}",
+            code_spans
+                .iter()
+                .map(|s| (&s.content, s.style.fg))
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]
-    fn strikethrough_inside_bold_keeps_both_modifiers() {
+    fn inline_code_inside_bold_gets_overlay() {
         let style = Style::default();
-        let lines = text_to_lines(
-            "**bold ~~struck~~ bold**",
-            "",
-            style,
-            style,
-            None,
-            TEST_WIDTH,
-        );
-        let struck = find_span(&lines, "struck");
+        let lines = text_to_lines("**a `code` b**", "", style, style, TEST_WIDTH);
+        let code = find_span(&lines, "code");
+        assert_eq!(code.style.fg, theme::current().inline_code.fg);
         assert!(
-            struck
-                .style
-                .add_modifier
-                .contains(Modifier::BOLD | Modifier::CROSSED_OUT),
-            "struck word must have BOLD|CROSSED_OUT, got {:?}",
-            struck.style
+            code.style.add_modifier.contains(Modifier::BOLD),
+            "inline code inside bold should inherit BOLD modifier"
         );
     }
 }

--- a/maki-ui/src/selection.rs
+++ b/maki-ui/src/selection.rs
@@ -37,8 +37,8 @@ use ratatui::text::Line;
 
 use unicode_width::UnicodeWidthChar;
 
-use crate::markdown::{CODE_BAR, CODE_BAR_WRAP};
 use crate::theme;
+use maki_markdown::render::{CODE_BAR, CODE_BAR_WRAP};
 
 /// Position in doc space (full logical document, not just visible window).
 /// Stored as (row, col) where col is a screen x coordinate.

--- a/maki-ui/src/theme.rs
+++ b/maki-ui/src/theme.rs
@@ -287,6 +287,8 @@ pub fn style_by_name(name: &str) -> Style {
         "heading" => t.heading,
         "list_marker" => t.list_marker,
         "horizontal_rule" => t.horizontal_rule,
+        "code_bar" => t.code_bar,
+        "table_border" => t.table_border,
         "keyword" | "index_keyword" => t.index_keyword,
         "section" | "index_section" => t.index_section,
         "line_nr" | "index_line_nr" => t.index_line_nr,

--- a/plugins/question/question_form.lua
+++ b/plugins/question/question_form.lua
@@ -133,26 +133,27 @@ local function initial_state(questions)
     cursor = 1,
     answers = {},
     custom_input = TextInput.new(),
-    rendered_questions = {},
+    rendered_questions = { width = nil, by_idx = {} },
   }
 end
 
-local function question_md(state, idx)
-  local cached = state.rendered_questions[idx]
-  if cached then
-    return cached
+local function question_md(state, idx, width)
+  local cache = state.rendered_questions
+  if cache.width ~= width then
+    cache.width = width
+    cache.by_idx = {}
+  end
+  local hit = cache.by_idx[idx]
+  if hit then
+    return hit
   end
   local text = state.questions[idx].question
-  local ok, lines = pcall(maki.ui.markdown, text)
+  local ok, lines = pcall(maki.ui.markdown, text, width)
   if not ok or type(lines) ~= "table" or #lines == 0 then
     lines = { { { text, "" } } }
   end
-  state.rendered_questions[idx] = lines
+  cache.by_idx[idx] = lines
   return lines
-end
-
-local function inline_md(state, idx)
-  return question_md(state, idx)[1] or { { state.questions[idx].question, "" } }
 end
 
 local function is_selected(state, label)
@@ -371,7 +372,7 @@ local function render_selecting(state, width)
     reserved_top = 2
   end
 
-  for _, md_line in ipairs(question_md(state, state.tab)) do
+  for _, md_line in ipairs(question_md(state, state.tab, width - 1)) do
     append_wrapped(lines, md_line, width - 1, " ", "", " ")
   end
   lines[#lines + 1] = {}
@@ -477,7 +478,9 @@ local function render_confirming(state, width)
     local q_prefix_w = display_width(q_prefix)
     local q_pad = string.rep(" ", q_prefix_w)
 
-    append_wrapped(lines, inline_md(state, i), width - q_prefix_w, q_prefix, "", q_pad)
+    for j, md_line in ipairs(question_md(state, i, width - q_prefix_w)) do
+      append_wrapped(lines, md_line, width - q_prefix_w, j == 1 and q_prefix or q_pad, "", q_pad)
+    end
     append_wrapped(
       lines,
       { { ans_text, "form_answer" } },

--- a/plugins/question/tests/spec.lua
+++ b/plugins/question/tests/spec.lua
@@ -260,19 +260,19 @@ case("question_md_falls_back_to_plain_text_on_invalid_markdown_return", function
   local mocks = {
     {
       name = "error",
-      fn = function()
+      fn = function(_text, _width)
         error("boom")
       end,
     },
     {
       name = "non-table",
-      fn = function()
+      fn = function(_text, _width)
         return "not a table"
       end,
     },
     {
       name = "empty-table",
-      fn = function()
+      fn = function(_text, _width)
         return {}
       end,
     },
@@ -288,9 +288,9 @@ case("question_md_falls_back_to_plain_text_on_invalid_markdown_return", function
   end
 end)
 
-case("inline_md_returns_only_first_markdown_line_in_confirming", function()
+case("confirming_view_renders_all_question_lines_at_inline_width", function()
   local original = maki.ui.markdown
-  maki.ui.markdown = function()
+  maki.ui.markdown = function(_text, _width)
     return { { { "first", "" } }, { { "second", "" } } }
   end
   local s = confirming_multi()
@@ -298,7 +298,24 @@ case("inline_md_returns_only_first_markdown_line_in_confirming", function()
   maki.ui.markdown = original
   eq(s.mode, MODE.CONFIRMING)
   assert(find_span_with_text(r.lines, "first"), "confirming row must include first markdown line")
-  assert(not find_span_with_text(r.lines, "second"), "confirming row must NOT include subsequent markdown lines")
+  assert(find_span_with_text(r.lines, "second"), "confirming row must also include subsequent markdown lines")
+end)
+
+case("question_md_cache_invalidates_on_width_change", function()
+  local original = maki.ui.markdown
+  local calls = 0
+  maki.ui.markdown = function(_text, width)
+    calls = calls + 1
+    return { { { "w=" .. tostring(width), "" } } }
+  end
+  local s = selecting_single()
+  QuestionForm._render(s, 80)
+  local calls_after_80 = calls
+  QuestionForm._render(s, 80)
+  eq(calls, calls_after_80, "same width must reuse cache")
+  QuestionForm._render(s, 60)
+  maki.ui.markdown = original
+  assert(calls > calls_after_80, "width change must invalidate cache and re-render")
 end)
 
 local function multi_with_custom()


### PR DESCRIPTION
The form prompt went through `maki.ui.markdown(text)`, a flat width-agnostic projection that joined table cells with `" | "` and rendered fenced code as plain `inline_code` lines, so any prompt with a table or a code block lost its layout.

`maki-markdown::render` is now the single source of truth for markdown layout.  It emits theme-free `Line` values carrying `StyleToken` spans (`Heading`, `InlineCode`, `Highlight`, `CodeBar`, `TableBorder`), with tables getting real box-drawing borders, code fences getting `│ ` bars plus syntect highlight tokens, and everything wrapping to the given width.

`StreamingContent` owns a persistent `Renderer` whose highlighter and table-width caches survive across typewriter ticks, so completed code lines are never re-highlighted and table columns never shrink mid-stream.  Before this the streaming path constructed a fresh renderer on every cache miss, throwing away all checkpoint state.

`Emphasis` is lifted out of `StyleToken` onto `Span` so heading colours survive bold or italic, and both the ratatui adapter and the Lua bridge (`maki.ui.markdown(text, width)`) consume the same `Line` tree with no divergence.  Previously `InlineCode` inside a heading collapsed to the heading style in Lua but recoloured to code style in the UI, so the same markdown looked different in the question form vs the assistant bubble.

Locked in with a `streaming_matches_oneshot` test that feeds byte-prefixes through a persistent `Renderer` and asserts the final output equals a one-shot render across several widths.