### PR TITLE
interpreter: update monty to v0.0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2650,8 +2650,8 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.11"
-source = "git+https://github.com/pydantic/monty.git?rev=2e9df4b#2e9df4b508e8a9ac80f3a6a26ed680242d1f460d"
+version = "0.0.17"
+source = "git+https://github.com/pydantic/monty.git?tag=v0.0.17#5c7cf2b62be8e4421a4828072d41ebe69328bbf2"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2666,11 +2666,12 @@ dependencies = [
  "num-integer",
  "num-traits",
  "postcard",
- "pyo3-build-config",
  "ruff_python_ast",
  "ruff_python_parser",
+ "ruff_python_stdlib",
  "ruff_text_size",
  "serde",
+ "serde_json",
  "smallvec",
  "speedate",
  "strum",
@@ -3791,6 +3792,15 @@ dependencies = [
  "unicode-ident",
  "unicode-normalization",
  "unicode_names2",
+]
+
+[[package]]
+name = "ruff_python_stdlib"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#6ded4bed1651e30b34dd04cdaa50c763036abb0d"
+dependencies = [
+ "bitflags 2.11.0",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ tree-sitter-starlark = "1.3"
 tree-sitter-swift = "0.7"
 tree-sitter-typescript = "0.23"
 tree-sitter-zig = "1.1"
-monty = { git = "https://github.com/pydantic/monty.git", rev = "2e9df4b", package = "monty" }
+monty = { git = "https://github.com/pydantic/monty.git", tag = "v0.0.17", package = "monty" }
 notify = { version = "9.0.0-rc.2", default-features = false, features = ["flume", "macos_fsevent"] }
 serde_yaml = "0.9"
 shell-words = "1"

--- a/flake.nix
+++ b/flake.nix
@@ -33,9 +33,10 @@
               # NOTE: these are cargo git dependencies; set hash to "" and
               # rebuild to get the correct value.
               outputHashes = {
-                "monty-0.0.11" = "sha256-PRP8XcgeNVnc+2dWHxpizjvAtSjfqtkEXckXjPCRoJI=";
+                "monty-0.0.17" = "sha256-f+WcznnOMSc0ahgfvgVec4U0nH9j022NLnWQLdISv3M=";
                 "ruff_python_ast-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
                 "ruff_python_parser-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
+                "ruff_python_stdlib-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
                 "ruff_python_trivia-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
                 "ruff_source_file-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
                 "ruff_text_size-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";

--- a/maki-interpreter/src/runner.rs
+++ b/maki-interpreter/src/runner.rs
@@ -69,7 +69,7 @@ pub fn run(
     limits: ResourceLimits,
 ) -> Result<InterpreterResult, InterpreterError> {
     let mut stdout = String::new();
-    let mut print_writer = PrintWriter::Collect(&mut stdout);
+    let mut print_writer = PrintWriter::CollectString(&mut stdout);
     let output = run_inner(code, tools, resolver, limits, &mut print_writer)?;
     Ok(InterpreterResult { output, stdout })
 }

--- a/maki-lua/src/api/json.rs
+++ b/maki-lua/src/api/json.rs
@@ -1,6 +1,6 @@
 use mlua::{Lua, LuaSerdeExt, Result as LuaResult, Table, Value};
 
-use super::err_pair;
+use super::{err_pair, json_to_lua};
 
 pub(crate) fn create_json_table(lua: &Lua) -> LuaResult<Table> {
     let json = lua.create_table()?;
@@ -23,7 +23,7 @@ pub(crate) fn create_json_table(lua: &Lua) -> LuaResult<Table> {
         "decode",
         lua.create_function(|lua, s: String| {
             match serde_json::from_str::<serde_json::Value>(&s) {
-                Ok(v) => Ok((lua.to_value(&v)?, Value::Nil)),
+                Ok(v) => Ok((json_to_lua(lua, &v)?, Value::Nil)),
                 Err(e) => err_pair(lua, e),
             }
         })?,

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod yaml;
 use std::sync::Arc;
 
 use mlua::{Lua, Result as LuaResult, Table, Value};
+use serde_json::Value as JsonValue;
 
 use crate::api::command::UiAction;
 use crate::api::tool::PendingTools;
@@ -54,4 +55,38 @@ pub(crate) fn create_maki_global(
 
 pub(crate) fn err_pair(lua: &Lua, e: impl std::fmt::Display) -> LuaResult<(Value, Value)> {
     Ok((Value::Nil, Value::String(lua.create_string(e.to_string())?)))
+}
+
+/// Convert a [`serde_json::Value`] into a Lua value by hand.
+///
+/// mlua's `to_value` looks like the easy path, but monty turns on serde_json's
+/// `arbitrary_precision` feature for the whole workspace. With it, a number
+/// serializes as a little tagged struct instead of a plain scalar, so plugins
+/// end up with a Lua table where they asked for a number. We walk the tree
+/// ourselves to keep numbers as numbers.
+pub(crate) fn json_to_lua(lua: &Lua, value: &JsonValue) -> LuaResult<Value> {
+    Ok(match value {
+        JsonValue::Null => Value::Nil,
+        JsonValue::Bool(b) => Value::Boolean(*b),
+        JsonValue::Number(n) => match (n.as_i64(), n.as_f64()) {
+            (Some(i), _) => Value::Integer(i),
+            (_, Some(f)) => Value::Number(f),
+            _ => Value::Nil,
+        },
+        JsonValue::String(s) => Value::String(lua.create_string(s)?),
+        JsonValue::Array(items) => {
+            let table = lua.create_table_with_capacity(items.len(), 0)?;
+            for (idx, item) in items.iter().enumerate() {
+                table.set(idx + 1, json_to_lua(lua, item)?)?;
+            }
+            Value::Table(table)
+        }
+        JsonValue::Object(map) => {
+            let table = lua.create_table_with_capacity(0, map.len())?;
+            for (key, val) in map {
+                table.set(key.as_str(), json_to_lua(lua, val)?)?;
+            }
+            Value::Table(table)
+        }
+    })
 }

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -15,7 +15,7 @@ use maki_agent::tools::{
     HeaderResult, PermissionScopes, RegistryError, Tool, ToolRegistry, ToolSource,
 };
 use maki_agent::{BufferSnapshot, SharedBuf, SnapshotLine, SnapshotSpan, SpanStyle};
-use mlua::{Function, Lua, LuaSerdeExt, RegistryKey, Value as LuaValue, VmState};
+use mlua::{Function, Lua, RegistryKey, Value as LuaValue, VmState};
 use serde_json::Value;
 
 use maki_config::RawConfig;
@@ -26,6 +26,7 @@ use crate::api::command::{LuaCommandReader, LuaCommandWriter, UiAction};
 use crate::api::create_maki_global;
 use crate::api::ctx::LuaCtx;
 use crate::api::fn_api::{JobEvent, JobStore};
+use crate::api::json_to_lua;
 use crate::api::setup::ConfigStore;
 use crate::api::tool::{LuaOutputFormat, LuaTool, PendingTool, PendingTools, ToolCallReply};
 use crate::error::PluginError;
@@ -885,7 +886,7 @@ impl LuaRuntime {
                 return HeaderResult::plain(tool.to_string());
             }
         };
-        let input_lua = match self.lua.to_value(&input) {
+        let input_lua = match json_to_lua(&self.lua, &input) {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!(plugin, tool, error = %e, "header fn input serialization failed");
@@ -929,7 +930,7 @@ impl LuaRuntime {
             let key = tk.restore.as_ref()?;
             self.lua.registry_value::<Function>(key).ok()?
         };
-        let input_lua = self.lua.to_value(&input).ok()?;
+        let input_lua = json_to_lua(&self.lua, &input).ok()?;
         let thread = self.lua.create_thread(func).ok()?;
 
         let (dummy_tx, _) = flume::unbounded();
@@ -978,7 +979,7 @@ impl LuaRuntime {
                 return None;
             }
         };
-        let lua_input = match self.lua.to_value(&input) {
+        let lua_input = match json_to_lua(&self.lua, &input) {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!(plugin, tool, error = %e, "failed to convert input for permission_scopes");
@@ -1243,7 +1244,7 @@ async fn run_tool_call(
     ctx.finish_tx = Some(finish_tx);
     let cancel = ctx.cancel.clone();
 
-    let input_lua = match lua.to_value(&input) {
+    let input_lua = match json_to_lua(&lua, &input) {
         Ok(v) => v,
         Err(e) => return ToolCallReply::err(e.to_string()),
     };


### PR DESCRIPTION
Monty has no real crate on crates.io, only a `0.0.0` placeholder, so we stay on the git dependency.

We pin a `tag` now instead of a bare commit, which reads as a version and makes bumps obvious.

The `0.0.17` release renamed `PrintWriter::Collect` to `CollectString` and pulled in a new `ruff_python_stdlib` git crate, so the `flake.nix` `outputHashes` gained an entry.

All git hashes were verified with a real `nix build` in a container, since `nix` is not installed here.