### PR TITLE
add anthropic fast mode (`/fast`)

### DIFF
--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use maki_providers::{ContentBlock, Message, Model, ThinkingConfig, TokenUsage};
+use maki_providers::{ContentBlock, Message, Model, RequestOptions, TokenUsage};
 use tracing::info;
 
 use super::history::History;
@@ -33,7 +33,7 @@ pub(super) async fn compact_history(
         &empty_tools,
         event_tx,
         cancel,
-        ThinkingConfig::Off,
+        RequestOptions::default(),
         None,
     )
     .await?;
@@ -118,8 +118,8 @@ mod tests {
 
     use maki_providers::provider::{BoxFuture, Provider};
     use maki_providers::{
-        ContentBlock, Message, Model, ProviderEvent, Role, StopReason, StreamResponse,
-        ThinkingConfig, TokenUsage,
+        ContentBlock, Message, Model, ProviderEvent, RequestOptions, Role, StopReason,
+        StreamResponse, TokenUsage,
     };
     use serde_json::Value;
     use test_case::test_case;
@@ -147,7 +147,7 @@ mod tests {
             _: &'a str,
             _: &'a Value,
             _: &'a flume::Sender<ProviderEvent>,
-            _: ThinkingConfig,
+            _: RequestOptions,
             _: Option<&str>,
         ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
             Box::pin(async {

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use tracing::{error, info, warn};
 
 use maki_providers::provider::Provider;
-use maki_providers::{Message, Model, StopReason, StreamResponse, ThinkingConfig, TokenUsage};
+use maki_providers::{Message, Model, RequestOptions, StopReason, StreamResponse, TokenUsage};
 
 use super::compaction::{self, CONTINUE_AFTER_COMPACT};
 use super::history::{History, sanitize_cancelled_history};
@@ -73,7 +73,7 @@ pub struct Agent {
     tool_output_lines: ToolOutputLines,
     reauth_attempts: u32,
     permissions: Arc<PermissionManager>,
-    thinking: ThinkingConfig,
+    opts: RequestOptions,
     session_id: Option<String>,
     timeouts: maki_providers::Timeouts,
     file_tracker: Arc<FileReadTracker>,
@@ -104,7 +104,7 @@ impl Agent {
             rollback_len: 0,
             mcp: None,
             reauth_attempts: 0,
-            thinking: ThinkingConfig::Off,
+            opts: RequestOptions::default(),
             session_id: params.session_id,
             file_tracker: params.file_tracker,
         }
@@ -143,7 +143,10 @@ impl Agent {
         let msg = Message::user_with_images(input.message.clone(), input.images);
         self.history.push(msg);
         self.mode = input.mode;
-        self.thinking = input.thinking;
+        self.opts = RequestOptions {
+            thinking: input.thinking,
+            fast: input.fast,
+        };
 
         info!(
             model = %self.model.id,
@@ -188,7 +191,7 @@ impl Agent {
             &self.tools,
             &self.event_tx,
             &self.cancel,
-            self.thinking,
+            self.opts,
             self.session_id.as_deref(),
         )
         .await
@@ -401,8 +404,8 @@ mod tests {
 
     use maki_providers::provider::{BoxFuture, Provider};
     use maki_providers::{
-        ContentBlock, Message, Model, ProviderEvent, Role, StopReason, StreamResponse,
-        ThinkingConfig, TokenUsage,
+        ContentBlock, Message, Model, ProviderEvent, RequestOptions, Role, StopReason,
+        StreamResponse, TokenUsage,
     };
     use serde_json::Value;
     use test_case::test_case;
@@ -449,7 +452,7 @@ mod tests {
             _: &'a str,
             _: &'a Value,
             _: &'a flume::Sender<ProviderEvent>,
-            _: ThinkingConfig,
+            _: RequestOptions,
             _: Option<&str>,
         ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
             Box::pin(async {
@@ -721,7 +724,7 @@ mod tests {
                     _: &'a str,
                     _: &'a Value,
                     _: &'a flume::Sender<ProviderEvent>,
-                    _: ThinkingConfig,
+                    _: RequestOptions,
                     _: Option<&'a str>,
                 ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
                     Box::pin(async {

--- a/maki-agent/src/agent/streaming.rs
+++ b/maki-agent/src/agent/streaming.rs
@@ -1,6 +1,6 @@
 use maki_providers::provider::Provider;
 use maki_providers::retry::{MAX_TIMEOUT_RETRIES, RetryState};
-use maki_providers::{Message, Model, ProviderEvent, StreamResponse, ThinkingConfig};
+use maki_providers::{Message, Model, ProviderEvent, RequestOptions, StreamResponse};
 use serde_json::Value;
 use tracing::warn;
 
@@ -29,7 +29,7 @@ pub(crate) async fn stream_with_retry(
     tools: &Value,
     event_tx: &EventSender,
     cancel: &CancelToken,
-    thinking: ThinkingConfig,
+    opts: RequestOptions,
     session_id: Option<&str>,
 ) -> Result<StreamResponse, AgentError> {
     let mut retry = RetryState::new();
@@ -40,7 +40,7 @@ pub(crate) async fn stream_with_retry(
             async move { forward_provider_events(prx, &event_tx).await }
         });
         let result = futures_lite::future::race(
-            provider.stream_message(model, messages, system, tools, &ptx, thinking, session_id),
+            provider.stream_message(model, messages, system, tools, &ptx, opts, session_id),
             async {
                 cancel.cancelled().await;
                 Err(AgentError::Cancelled)

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -66,5 +66,6 @@ pub struct AgentInput {
     pub images: Vec<ImageSource>,
     pub preamble: Vec<Message>,
     pub thinking: ThinkingConfig,
+    pub fast: bool,
     pub prompt: Option<Box<McpPromptRef>>,
 }

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -558,7 +558,7 @@ pub fn all_builtin_tool_names() -> Vec<&'static str> {
         .collect()
 }
 
-use maki_providers::{Message, ProviderEvent, StreamResponse, ThinkingConfig};
+use maki_providers::{Message, ProviderEvent, RequestOptions, StreamResponse};
 
 struct NullProvider;
 
@@ -570,7 +570,7 @@ impl Provider for NullProvider {
         _: &'a str,
         _: &'a Value,
         _: &'a flume::Sender<ProviderEvent>,
-        _: ThinkingConfig,
+        _: RequestOptions,
         _: Option<&str>,
     ) -> BoxFuture<'a, Result<StreamResponse, crate::AgentError>> {
         Box::pin(async { unimplemented!() })

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -16,6 +16,6 @@ pub use providers::copilot::auth as copilot_auth;
 pub use providers::dynamic;
 pub use providers::openai::auth as openai_auth;
 pub use types::{
-    ContentBlock, ImageMediaType, ImageSource, Message, ProviderEvent, Role, StopReason,
-    StreamResponse, ThinkingConfig,
+    ContentBlock, ImageMediaType, ImageSource, Message, ProviderEvent, RequestOptions, Role,
+    StopReason, StreamResponse, ThinkingConfig,
 };

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -97,6 +97,9 @@ pub struct ModelEntry {
     pub pricing: ModelPricing,
     pub max_output_tokens: u32,
     pub context_window: u32,
+    /// Read this through `Model::supports_fast()`, never directly: it also
+    /// checks the provider, since only the Anthropic direct API serves fast mode.
+    pub fast_capable: bool,
 }
 
 fn lookup_entry<'a>(
@@ -144,6 +147,7 @@ pub struct Model {
     pub pricing: ModelPricing,
     pub max_output_tokens: u32,
     pub context_window: u32,
+    pub fast_capable: bool,
 }
 
 impl Model {
@@ -160,18 +164,21 @@ impl Model {
             provider,
             static_entry.map(|e| e.tier),
         );
-        let (family, pricing, max_output_tokens, context_window) = match static_entry {
+        let (family, pricing, max_output_tokens, context_window, fast_capable) = match static_entry
+        {
             Some(e) => (
                 e.family,
                 e.pricing.clone(),
                 e.max_output_tokens,
                 e.context_window,
+                e.fast_capable,
             ),
             None => (
                 provider.family(),
                 ModelPricing::ZERO,
                 provider.fallback_max_output(),
                 provider.fallback_context_window(),
+                false,
             ),
         };
         Self {
@@ -184,12 +191,19 @@ impl Model {
             pricing,
             max_output_tokens,
             context_window,
+            fast_capable,
         }
     }
 
     pub fn supports_tool_examples(&self) -> bool {
         self.supports_tool_examples_override
             .unwrap_or_else(|| self.family.supports_tool_examples())
+    }
+
+    /// Bedrock reuses `ProviderKind::Anthropic` and the same model table, so we
+    /// also check the provider here: fast mode only exists on the direct API.
+    pub fn supports_fast(&self) -> bool {
+        self.fast_capable && self.provider == ProviderKind::Anthropic
     }
 
     pub fn spec(&self) -> String {
@@ -437,5 +451,34 @@ mod tests {
             (p.input, p.output, p.cache_write, p.cache_read),
             (0.0, 0.0, 0.0, 0.0)
         );
+    }
+
+    #[test_case("claude-opus-4-6" ; "opus_4_6")]
+    #[test_case("claude-opus-4-7" ; "opus_4_7")]
+    #[test_case("claude-opus-4-8" ; "opus_4_8")]
+    fn supports_fast_true_for_anthropic_opus(model_id: &str) {
+        let model = Model::from_base(ProviderKind::Anthropic, model_id, None);
+        assert!(model.supports_fast());
+    }
+
+    #[test_case("claude-sonnet-4-5" ; "sonnet")]
+    #[test_case("claude-haiku-4-5" ; "haiku")]
+    #[test_case("claude-opus-4-5" ; "opus_4_5")]
+    fn supports_fast_false_for_other_anthropic_models(model_id: &str) {
+        let model = Model::from_base(ProviderKind::Anthropic, model_id, None);
+        assert!(!model.supports_fast());
+    }
+
+    #[test]
+    fn supports_fast_false_for_unknown_anthropic_model() {
+        let model = Model::from_base(ProviderKind::Anthropic, "claude-opus-99", None);
+        assert!(!model.supports_fast());
+    }
+
+    #[test]
+    fn supports_fast_false_for_non_anthropic_even_if_fast_capable() {
+        let mut model = Model::from_base(ProviderKind::Google, "gemini-2.5-pro", None);
+        model.fast_capable = true;
+        assert!(!model.supports_fast());
     }
 }

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -20,7 +20,7 @@ use crate::providers::ollama::Ollama;
 use crate::providers::openai::OpenAi;
 use crate::providers::synthetic::Synthetic;
 use crate::providers::zai::{Zai, ZaiPlan};
-use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumString, EnumIter)]
 #[strum(serialize_all = "kebab-case")]
@@ -208,7 +208,7 @@ pub trait Provider: Send + Sync {
         system: &'a str,
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
-        thinking: ThinkingConfig,
+        opts: RequestOptions,
         session_id: Option<&'a str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>>;
 

--- a/maki-providers/src/providers/anthropic/bedrock.rs
+++ b/maki-providers/src/providers/anthropic/bedrock.rs
@@ -14,7 +14,7 @@ use tracing::{debug, warn};
 
 use crate::model::Model;
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 use super::shared;
 
@@ -522,7 +522,7 @@ impl Provider for Bedrock {
         system: &'a str,
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
-        thinking: ThinkingConfig,
+        opts: RequestOptions,
         _session_id: Option<&'a str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
@@ -542,8 +542,10 @@ impl Provider for Bedrock {
                     cache_control: Some(shared::EPHEMERAL),
                 }],
                 tools,
-                thinking,
+                opts.thinking,
             );
+            // Fast mode lives only on the direct API, so Bedrock skips `opts.fast`
+            // and never sends the `speed` param.
             body["anthropic_version"] = json!(BEDROCK_API_VERSION);
             let has_examples = tools
                 .as_array()

--- a/maki-providers/src/providers/anthropic/mod.rs
+++ b/maki-providers/src/providers/anthropic/mod.rs
@@ -16,17 +16,29 @@ use tracing::debug;
 
 use crate::model::Model;
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 use super::KeyPool;
 
 const API_VERSION: &str = "2023-06-01";
 const MESSAGES_URL: &str = "https://api.anthropic.com/v1/messages";
 const MODELS_URL: &str = "https://api.anthropic.com/v1/models?limit=1000";
+const FAST_MODE_BETA: &str = "fast-mode-2026-02-01";
 
 const ENV_VAR: &str = "ANTHROPIC_API_KEY";
 
 pub(crate) use shared::models;
+
+/// Returns whether the fast-mode beta header must be attached. We re-check
+/// `supports_fast()` here rather than trusting `opts.fast` alone, so a stale UI
+/// flag can never bill an ineligible model at the premium fast-mode rate.
+fn apply_fast_mode(body: &mut Value, model: &Model, opts: RequestOptions) -> bool {
+    let on = opts.fast && model.supports_fast();
+    if on {
+        body["speed"] = json!("fast");
+    }
+    on
+}
 
 fn resolve_auth_from_key(key: &str) -> super::ResolvedAuth {
     super::ResolvedAuth {
@@ -92,12 +104,16 @@ impl Anthropic {
         &self,
         body: &Value,
         event_tx: &Sender<ProviderEvent>,
+        fast: bool,
     ) -> Result<StreamResponse, AgentError> {
         let json_body = serde_json::to_vec(body)?;
-        let request = self
+        let mut builder = self
             .build_request("POST", None)
-            .header("content-type", "application/json")
-            .body(json_body)?;
+            .header("content-type", "application/json");
+        if fast {
+            builder = builder.header("anthropic-beta", FAST_MODE_BETA);
+        }
+        let request = builder.body(json_body)?;
         let response = self.client.send_async(request).await?;
         let status = response.status().as_u16();
 
@@ -147,7 +163,7 @@ impl Provider for Anthropic {
         system: &'a str,
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
-        thinking: ThinkingConfig,
+        opts: RequestOptions,
         _session_id: Option<&str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
@@ -177,13 +193,14 @@ impl Provider for Anthropic {
                 messages,
                 &system_blocks,
                 tools,
-                thinking,
+                opts.thinking,
             );
             body["model"] = json!(model.id);
             body["stream"] = json!(true);
+            let fast = apply_fast_mode(&mut body, model, opts);
 
-            debug!(model = %model.id, num_messages = messages.len(), ?thinking, "sending API request");
-            self.do_stream_request(&body, event_tx).await
+            debug!(model = %model.id, num_messages = messages.len(), thinking = ?opts.thinking, fast, "sending API request");
+            self.do_stream_request(&body, event_tx, fast).await
         })
     }
 
@@ -415,6 +432,48 @@ data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":5}}\n";
             json[2]["content"][1]["cache_control"],
             json!({"type": "ephemeral"})
         );
+    }
+
+    #[test]
+    fn apply_fast_mode_sets_speed_on_capable_model() {
+        let model = Model::from_spec("anthropic/claude-opus-4-8").unwrap();
+        let mut body = json!({});
+        let header = apply_fast_mode(
+            &mut body,
+            &model,
+            RequestOptions {
+                fast: true,
+                ..Default::default()
+            },
+        );
+        assert!(header);
+        assert_eq!(body["speed"], json!("fast"));
+    }
+
+    #[test]
+    fn apply_fast_mode_ignores_stale_flag_on_ineligible_model() {
+        // Sonnet is not fast-capable, so opts.fast=true must still skip `speed`.
+        let model = Model::from_spec("anthropic/claude-sonnet-4-5").unwrap();
+        let mut body = json!({});
+        let header = apply_fast_mode(
+            &mut body,
+            &model,
+            RequestOptions {
+                fast: true,
+                ..Default::default()
+            },
+        );
+        assert!(!header);
+        assert!(body.get("speed").is_none());
+    }
+
+    #[test]
+    fn apply_fast_mode_off_when_not_requested() {
+        let model = Model::from_spec("anthropic/claude-opus-4-8").unwrap();
+        let mut body = json!({});
+        let header = apply_fast_mode(&mut body, &model, RequestOptions::default());
+        assert!(!header);
+        assert!(body.get("speed").is_none());
     }
 
     #[test]

--- a/maki-providers/src/providers/anthropic/shared.rs
+++ b/maki-providers/src/providers/anthropic/shared.rs
@@ -372,6 +372,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 64000,
             context_window: 200_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["claude-sonnet-4-5"],
@@ -386,6 +387,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 64000,
             context_window: 200_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["claude-sonnet-4-6"],
@@ -400,6 +402,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 64000,
             context_window: 200_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["claude-sonnet-4"],
@@ -414,6 +417,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 64000,
             context_window: 200_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["claude-opus-4-5"],
@@ -428,6 +432,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 64000,
             context_window: 200_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["claude-opus-4-6"],
@@ -442,6 +447,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 128000,
             context_window: 200_000,
+            fast_capable: true,
         },
         ModelEntry {
             prefixes: &["claude-opus-4-7"],
@@ -456,6 +462,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 128000,
             context_window: 200_000,
+            fast_capable: true,
         },
         ModelEntry {
             prefixes: &["claude-opus-4-8"],
@@ -470,6 +477,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 128000,
             context_window: 200_000,
+            fast_capable: true,
         },
         ModelEntry {
             prefixes: &["claude-opus-4-0", "claude-opus-4-1"],
@@ -484,6 +492,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 32000,
             context_window: 200_000,
+            fast_capable: false,
         },
     ]
 }

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -13,7 +13,7 @@ use super::openai::responses;
 use super::openai_compat;
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig};
 
 pub mod auth;
 
@@ -36,6 +36,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             pricing: ModelPricing::ZERO,
             max_output_tokens: 100_000,
             context_window: 200_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["gpt-5.2", "gpt-4.1", "claude-sonnet-4.5"],
@@ -45,6 +46,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             pricing: ModelPricing::ZERO,
             max_output_tokens: 100_000,
             context_window: 200_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &[
@@ -59,6 +61,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             pricing: ModelPricing::ZERO,
             max_output_tokens: 100_000,
             context_window: 200_000,
+            fast_capable: false,
         },
     ]
 }
@@ -515,7 +518,7 @@ impl Provider for Copilot {
         system: &'a str,
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
-        thinking: ThinkingConfig,
+        opts: RequestOptions,
         _session_id: Option<&'a str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
@@ -533,7 +536,7 @@ impl Provider for Copilot {
                         .await
                 }
                 Endpoint::Messages => {
-                    self.stream_messages(model, messages, system, tools, event_tx, thinking)
+                    self.stream_messages(model, messages, system, tools, event_tx, opts.thinking)
                         .await
                 }
             }

--- a/maki-providers/src/providers/deepseek.rs
+++ b/maki-providers/src/providers/deepseek.rs
@@ -6,7 +6,7 @@ use tracing::warn;
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
@@ -37,6 +37,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 384_000,
             context_window: 1_000_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["deepseek-v4-pro"],
@@ -51,6 +52,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 384_000,
             context_window: 1_000_000,
+            fast_capable: false,
         },
     ]
 }
@@ -96,7 +98,7 @@ impl Provider for DeepSeek {
         system: &'a str,
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
-        thinking: ThinkingConfig,
+        opts: RequestOptions,
         _session_id: Option<&'a str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
@@ -107,7 +109,7 @@ impl Provider for DeepSeek {
 
             // DeepSeek enables reasoning by default; Adaptive and Budget
             // use the model's default reasoning behavior.
-            match thinking {
+            match opts.thinking {
                 ThinkingConfig::Off => {
                     body["thinking"] = serde_json::json!({"type": "disabled"});
                 }

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -13,7 +13,7 @@ use tracing::{debug, warn};
 
 use crate::model::{Model, ModelPricing, ModelTier, models_for_provider};
 use crate::provider::{BoxFuture, Provider, ProviderKind};
-use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 use super::ResolvedAuth;
 use super::anthropic::Anthropic;
@@ -437,6 +437,7 @@ pub fn lookup_model(slug: &str, model_id: &str) -> Option<Model> {
         pricing: script_model.pricing.clone().unwrap_or_default(),
         max_output_tokens: script_model.max_output_tokens,
         context_window: script_model.context_window,
+        fast_capable: false,
     })
 }
 
@@ -453,6 +454,7 @@ pub fn find_model_for_tier(slug: &str, tier: ModelTier) -> Option<Model> {
         pricing: script_model.pricing.clone().unwrap_or_default(),
         max_output_tokens: script_model.max_output_tokens,
         context_window: script_model.context_window,
+        fast_capable: false,
     })
 }
 
@@ -492,12 +494,11 @@ impl Provider for DynamicProvider {
         system: &'a str,
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
-        thinking: ThinkingConfig,
+        opts: RequestOptions,
         session_id: Option<&'a str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
-        self.inner.stream_message(
-            model, messages, system, tools, event_tx, thinking, session_id,
-        )
+        self.inner
+            .stream_message(model, messages, system, tools, event_tx, opts, session_id)
     }
 
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -11,8 +11,8 @@ use tracing::warn;
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
 use crate::{
-    AgentError, ContentBlock, Message, ProviderEvent, Role, StopReason, StreamResponse,
-    ThinkingConfig, TokenUsage,
+    AgentError, ContentBlock, Message, ProviderEvent, RequestOptions, Role, StopReason,
+    StreamResponse, ThinkingConfig, TokenUsage,
 };
 
 use super::{KeyPool, ResolvedAuth, http_client, next_sse_line};
@@ -35,6 +35,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 65_536,
             context_window: 1_048_576,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["gemini-2.5-flash"],
@@ -49,6 +50,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 65_536,
             context_window: 1_048_576,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["gemini-2.0-flash-lite"],
@@ -63,6 +65,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 65_536,
             context_window: 1_048_576,
+            fast_capable: false,
         },
     ]
 }
@@ -215,10 +218,10 @@ impl Provider for Google {
         system: &'a str,
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
-        thinking: ThinkingConfig,
+        opts: RequestOptions,
         _session_id: Option<&'a str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
-        Box::pin(self.do_stream(model, messages, system, tools, event_tx, thinking))
+        Box::pin(self.do_stream(model, messages, system, tools, event_tx, opts.thinking))
     }
 
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
@@ -600,6 +603,7 @@ mod tests {
             pricing: ModelPricing::default(),
             max_output_tokens: 8192,
             context_window: 1_048_576,
+            fast_capable: false,
         };
         let messages = vec![Message::user("hello".into())];
         let body = google.build_body(
@@ -629,6 +633,7 @@ mod tests {
             pricing: ModelPricing::default(),
             max_output_tokens: 8192,
             context_window: 1_048_576,
+            fast_capable: false,
         };
         let messages = vec![Message::user("think about this".into())];
         let body = google.build_body(&model, &messages, "", &json!([]), ThinkingConfig::Adaptive);
@@ -652,6 +657,7 @@ mod tests {
             pricing: ModelPricing::default(),
             max_output_tokens: 8192,
             context_window: 1_048_576,
+            fast_capable: false,
         };
         let messages = vec![Message::user("think hard".into())];
         let body = google.build_body(

--- a/maki-providers/src/providers/llama_cpp.rs
+++ b/maki-providers/src/providers/llama_cpp.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 use crate::model::{Model, ModelEntry};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
@@ -90,7 +90,7 @@ impl Provider for LlamaCpp {
         system: &'a str,
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
-        _thinking: ThinkingConfig,
+        _opts: RequestOptions,
         _session_id: Option<&str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -5,7 +5,7 @@ use serde_json::{Value, json};
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
@@ -33,6 +33,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 262_144,
             context_window: 262_144,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["mistral-large-latest", "mistral-large-2512"],
@@ -47,6 +48,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 262_144,
             context_window: 262_144,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["mistral-small-latest", "mistral-small-2603"],
@@ -61,6 +63,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 262_144,
             context_window: 262_144,
+            fast_capable: false,
         },
     ]
 }
@@ -106,7 +109,7 @@ impl Provider for Mistral {
         system: &'a str,
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
-        thinking: ThinkingConfig,
+        opts: RequestOptions,
         session_id: Option<&'a str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
@@ -115,7 +118,7 @@ impl Provider for Mistral {
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
 
-            if !matches!(thinking, ThinkingConfig::Off) {
+            if !matches!(opts.thinking, ThinkingConfig::Off) {
                 body["reasoning_effort"] = json!("high");
             }
 

--- a/maki-providers/src/providers/ollama.rs
+++ b/maki-providers/src/providers/ollama.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 use crate::model::{Model, ModelEntry};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 use super::KeyPool;
 use super::ResolvedAuth;
@@ -94,7 +94,7 @@ impl Provider for Ollama {
         system: &'a str,
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
-        _thinking: ThinkingConfig,
+        _opts: RequestOptions,
         _session_id: Option<&str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {

--- a/maki-providers/src/providers/openai/mod.rs
+++ b/maki-providers/src/providers/openai/mod.rs
@@ -21,6 +21,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 128_000,
             context_window: 400_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["gpt-5.4-mini"],
@@ -35,6 +36,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 128_000,
             context_window: 400_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["gpt-4.1-nano"],
@@ -49,6 +51,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 32_768,
             context_window: 1_047_576,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["gpt-4.1-mini"],
@@ -63,6 +66,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 32_768,
             context_window: 1_047_576,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["gpt-4.1"],
@@ -77,6 +81,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 32_768,
             context_window: 1_047_576,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["o4-mini"],
@@ -91,6 +96,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 100_000,
             context_window: 200_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["gpt-5.5"],
@@ -105,6 +111,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 128_000,
             context_window: 1_050_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["gpt-5.4"],
@@ -119,6 +126,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 128_000,
             context_window: 1_050_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["o3"],
@@ -133,6 +141,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 100_000,
             context_window: 200_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["gpt-5.3-codex"],
@@ -147,6 +156,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 128_000,
             context_window: 400_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["gpt-5.2-codex"],
@@ -161,6 +171,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 128_000,
             context_window: 400_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["gpt-5.1-codex-mini"],
@@ -175,6 +186,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 128_000,
             context_window: 400_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["gpt-5.1-codex-max"],
@@ -189,6 +201,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 128_000,
             context_window: 400_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["gpt-5.1-codex"],
@@ -203,6 +216,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 128_000,
             context_window: 400_000,
+            fast_capable: false,
         },
     ]
 }

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -7,7 +7,7 @@ use tracing::{debug, warn};
 
 use crate::model::Model;
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 use super::auth;
 use crate::providers::ResolvedAuth;
@@ -142,7 +142,7 @@ impl Provider for OpenAi {
         system: &'a str,
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
-        _thinking: ThinkingConfig,
+        _opts: RequestOptions,
         _session_id: Option<&str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {

--- a/maki-providers/src/providers/synthetic.rs
+++ b/maki-providers/src/providers/synthetic.rs
@@ -5,7 +5,7 @@ use serde_json::{Value, json};
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
@@ -33,6 +33,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 131072,
             context_window: 200_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["hf:deepseek-ai/DeepSeek-V3.2"],
@@ -47,6 +48,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 131072,
             context_window: 200_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["hf:zai-org/GLM-4.7-Flash"],
@@ -61,6 +63,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 131072,
             context_window: 200_000,
+            fast_capable: false,
         },
     ]
 }
@@ -106,7 +109,7 @@ impl Provider for Synthetic {
         system: &'a str,
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
-        thinking: ThinkingConfig,
+        opts: RequestOptions,
         _session_id: Option<&str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
@@ -114,7 +117,7 @@ impl Provider for Synthetic {
             let mut buf = String::new();
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
-            match thinking {
+            match opts.thinking {
                 ThinkingConfig::Off => {}
                 ThinkingConfig::Adaptive => {
                     body["reasoning_effort"] = json!("medium");

--- a/maki-providers/src/providers/zai.rs
+++ b/maki-providers/src/providers/zai.rs
@@ -7,7 +7,7 @@ use tracing::warn;
 use crate::model::Model;
 use crate::model::{ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, StreamResponse, ThinkingConfig};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
@@ -43,6 +43,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 131072,
             context_window: 200_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["glm-5"],
@@ -57,6 +58,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 131072,
             context_window: 200_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["glm-4.7-flash"],
@@ -71,6 +73,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 131072,
             context_window: 200_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["glm-4.7", "glm-4.6"],
@@ -85,6 +88,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 131072,
             context_window: 200_000,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["glm-4.5-flash"],
@@ -99,6 +103,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 98304,
             context_window: 131_072,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["glm-4.5-air"],
@@ -113,6 +118,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 98304,
             context_window: 131_072,
+            fast_capable: false,
         },
         ModelEntry {
             prefixes: &["glm-4.5"],
@@ -127,6 +133,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             },
             max_output_tokens: 98304,
             context_window: 131_072,
+            fast_capable: false,
         },
     ]
 }
@@ -190,7 +197,7 @@ impl Provider for Zai {
         system: &'a str,
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
-        _thinking: ThinkingConfig,
+        _opts: RequestOptions,
         _session_id: Option<&str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -319,6 +319,14 @@ impl From<ThinkingConfig> for StoredThinking {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RequestOptions {
+    pub thinking: ThinkingConfig,
+    /// Just what the user asked for. The provider re-checks `supports_fast()`
+    /// before sending it, so a stale flag never bills an ineligible model.
+    pub fast: bool,
+}
+
 #[derive(Debug)]
 pub struct StreamResponse {
     pub message: Message,

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -61,6 +61,8 @@ pub struct SessionMeta {
     pub subagents: Vec<StoredSubagent>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thinking: Option<StoredThinking>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub fast: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1266,6 +1268,25 @@ mod tests {
             loaded.meta.thinking,
             Some(StoredThinking::Budget { tokens: 8192 })
         );
+    }
+
+    #[test]
+    fn session_meta_fast_backward_compat() {
+        let json = r#"{"mode":"build"}"#;
+        let meta: super::SessionMeta = serde_json::from_str(json).unwrap();
+        assert!(!meta.fast);
+    }
+
+    #[test]
+    fn session_fast_persists_through_save_load() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let mut session: TestSession = Session::new("m", "/project");
+        session.meta.fast = true;
+        session.save_to(dir).unwrap();
+
+        let loaded = TestSession::load_from(&session.id, dir).unwrap();
+        assert!(loaded.meta.fast);
     }
 
     #[test]

--- a/maki-ui/src/app/btw.rs
+++ b/maki-ui/src/app/btw.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use flume::Sender;
 use futures_lite::future;
 use maki_providers::provider::Provider;
-use maki_providers::{Message, Model, ProviderEvent, ThinkingConfig};
+use maki_providers::{Message, Model, ProviderEvent, RequestOptions};
 use serde_json::Value;
 
 use crate::components::btw_modal::BtwEvent;
@@ -50,7 +50,7 @@ async fn run_btw(
         BTW_SYSTEM,
         &tools,
         &event_tx,
-        ThinkingConfig::Off,
+        RequestOptions::default(),
         session_id.as_deref(),
     );
 

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -78,6 +78,9 @@ const FLASH_REWIND: &str = "Press esc again to rewind...";
 const AUTH_EXPIRED_MSG: &str =
     "Token expired. Run `maki auth login` in another terminal, then press Enter to retry.";
 const FLASH_NO_PLAN: &str = "No plan file";
+const FAST_UNSUPPORTED_MSG: &str = "Fast mode requires an Anthropic Opus 4.6+ model (API only)";
+const FAST_ON_MSG: &str = "Fast mode: on";
+const FAST_OFF_MSG: &str = "Fast mode: off";
 const IMPLEMENT_MSG_PREFIX: &str = "Implement the plan";
 const IMPLEMENT_PARALLEL_HINT: &str = "Use batch+task to parallelize, assign each subagent a separate module and restrict its tests to that module to avoid interference.";
 
@@ -1079,6 +1082,22 @@ impl App {
                     }
                     Err(msg) => self.flash(msg.into()),
                 }
+                vec![]
+            }
+            "/fast" => {
+                if !self.state.model.supports_fast() {
+                    self.flash(FAST_UNSUPPORTED_MSG.into());
+                    return vec![];
+                }
+                self.state.fast = !self.state.fast;
+                self.flash(
+                    if self.state.fast {
+                        FAST_ON_MSG
+                    } else {
+                        FAST_OFF_MSG
+                    }
+                    .into(),
+                );
                 vec![]
             }
             "/exit" => self.quit(),

--- a/maki-ui/src/app/mode.rs
+++ b/maki-ui/src/app/mode.rs
@@ -126,6 +126,7 @@ impl App {
             mode: self.agent_mode(),
             images: msg.images.clone(),
             thinking: self.state.thinking,
+            fast: self.state.fast,
             ..Default::default()
         }
     }

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -23,6 +23,7 @@ pub(crate) struct SessionState {
     pub plan: PlanState,
     pub warnings: Vec<String>,
     pub thinking: ThinkingConfig,
+    pub fast: bool,
 }
 
 const PLAN_FILE_MISSING_WARNING: &str = "Plan file was deleted \u{2014} started a new plan";
@@ -69,6 +70,10 @@ impl SessionState {
 
         Self {
             thinking: session.meta.thinking.map(Into::into).unwrap_or_default(),
+            // The saved model may have changed or fallen back to a parse failure
+            // since, so reconcile against the live model. This keeps the flag
+            // honest for everyone who reads it (the UI badge, the agent).
+            fast: session.meta.fast && model.supports_fast(),
             session,
             model,
             token_usage,
@@ -98,6 +103,7 @@ impl SessionState {
         self.session.meta.plan_written = self.plan.is_ready();
         self.session.meta.session_rules = rules_to_stored(&permissions.session_rules_snapshot());
         self.session.meta.thinking = Some(self.thinking.into());
+        self.session.meta.fast = self.fast;
         self.session.updated_at = maki_storage::now_epoch();
         self.session.update_title_if_default();
     }
@@ -105,6 +111,9 @@ impl SessionState {
     pub fn update_model(&mut self, model: &Model) {
         if !model.provider.supports_thinking() {
             self.thinking = ThinkingConfig::Off;
+        }
+        if !model.supports_fast() {
+            self.fast = false;
         }
         self.session.model = model.spec();
         self.model = model.clone();

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -2351,6 +2351,71 @@ fn thinking_restored_from_session_meta() {
     assert_eq!(state.thinking, ThinkingConfig::Budget(4096));
 }
 
+fn set_opus_model(app: &mut App) {
+    app.state.model = maki_providers::Model::from_spec("anthropic/claude-opus-4-8").unwrap();
+}
+
+#[test]
+fn fast_toggle_on_off_on_opus() {
+    let mut app = test_app();
+    set_opus_model(&mut app);
+    assert!(!app.state.fast);
+
+    app.execute_command(cmd("/fast"));
+    assert!(app.state.fast);
+    assert_eq!(app.status_bar.flash_text(), Some(FAST_ON_MSG));
+
+    app.execute_command(cmd("/fast"));
+    assert!(!app.state.fast);
+    assert_eq!(app.status_bar.flash_text(), Some(FAST_OFF_MSG));
+}
+
+#[test_case("anthropic/claude-sonnet-4-5" ; "non_opus_anthropic")]
+#[test_case("openai/gpt-5.5" ; "non_anthropic")]
+fn fast_flashes_error_on_ineligible_model(spec: &str) {
+    let mut app = test_app();
+    app.state.model = maki_providers::Model::from_spec(spec).unwrap();
+
+    app.execute_command(cmd("/fast"));
+    assert!(!app.state.fast);
+    assert_eq!(app.status_bar.flash_text(), Some(FAST_UNSUPPORTED_MSG));
+}
+
+#[test]
+fn fast_restored_from_session_meta() {
+    let tmp = TempDir::new().unwrap();
+    let storage = StateDir::from_path(tmp.path().to_path_buf());
+    let mut session = AppSession::new("anthropic/claude-opus-4-8", "/tmp/test");
+    session.meta.fast = true;
+
+    let state = SessionState::from_session(session, &test_model(), &storage);
+    assert!(state.fast);
+}
+
+#[test]
+fn fast_normalized_off_when_restored_onto_ineligible_model() {
+    let tmp = TempDir::new().unwrap();
+    let storage = StateDir::from_path(tmp.path().to_path_buf());
+    // Saved as fast=true, but sonnet cannot do fast mode, so restoring must drop
+    // it to false or the UI would show a phantom [fast] badge.
+    let mut session = AppSession::new("anthropic/claude-sonnet-4-5", "/tmp/test");
+    session.meta.fast = true;
+
+    let state = SessionState::from_session(session, &test_model(), &storage);
+    assert!(!state.fast);
+}
+
+#[test]
+fn update_model_to_ineligible_resets_fast() {
+    let mut app = test_app();
+    set_opus_model(&mut app);
+    app.state.fast = true;
+
+    let sonnet = maki_providers::Model::from_spec("anthropic/claude-sonnet-4-5").unwrap();
+    app.state.update_model(&sonnet);
+    assert!(!app.state.fast);
+}
+
 #[test]
 fn agent_error_creates_synthetic_tool_done_with_message() {
     let mut app = test_app();

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -247,6 +247,7 @@ impl App {
             chat_name,
             retry_info: self.retry_info.as_ref(),
             thinking_label: self.state.thinking.status_label(),
+            fast: self.state.fast,
         };
         self.status_bar.view(frame, status_area, &ctx);
     }

--- a/maki-ui/src/components/command.rs
+++ b/maki-ui/src/components/command.rs
@@ -88,6 +88,11 @@ pub const BUILTIN_COMMANDS: &[BuiltinCommand] = &[
         max_args: 1,
     },
     BuiltinCommand {
+        name: "/fast",
+        description: "Toggle Anthropic fast mode (Opus only)",
+        max_args: 0,
+    },
+    BuiltinCommand {
         name: "/exit",
         description: "Exit the application",
         max_args: 0,

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -366,6 +366,7 @@ pub(crate) fn test_model() -> maki_providers::Model {
         pricing: test_pricing(),
         max_output_tokens: 8192,
         context_window: TEST_CONTEXT_WINDOW,
+        fast_capable: false,
     }
 }
 

--- a/maki-ui/src/components/status_bar.rs
+++ b/maki-ui/src/components/status_bar.rs
@@ -15,6 +15,8 @@ use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
+const FAST_LABEL: &str = " [fast]";
+
 pub(crate) fn format_tokens(n: u32) -> String {
     match n {
         0..1_000 => n.to_string(),
@@ -42,6 +44,7 @@ pub struct StatusBarContext<'a> {
     pub chat_name: Option<&'a str>,
     pub retry_info: Option<&'a RetryInfo>,
     pub thinking_label: Option<Cow<'static, str>>,
+    pub fast: bool,
 }
 
 pub struct StatusBar {
@@ -166,6 +169,10 @@ impl StatusBar {
                         format!(" [{label}]"),
                         theme::current().status_context,
                     ));
+                }
+
+                if ctx.fast {
+                    right_spans.push(Span::styled(FAST_LABEL, theme::current().status_context));
                 }
 
                 let rest_text = format!(

--- a/site/docs/content/commands/_index.md
+++ b/site/docs/content/commands/_index.md
@@ -26,6 +26,7 @@ Type `/` in the input box to open the command palette.
 | `/btw` | Ask a quick question (no tools, no history pollution) |
 | `/yolo` | Toggle YOLO mode (skip all permission prompts) |
 | `/thinking` | Toggle extended thinking (off, adaptive, or budget) |
+| `/fast` | Toggle Anthropic fast mode (Opus only) |
 | `/exit` | Exit the application |
 | `/memory` | View, edit, and delete memory files |
 


### PR DESCRIPTION
Anthropic now runs Opus at a faster inference speed for a premium price, but only on the direct API and only on Opus `4.6`/`4.7`/`4.8`.

So we add a `/fast` toggle that mirrors `/thinking`, gated behind one method `Model::supports_fast()` that reads a single `fast_capable` column on the model table.

User intent lives as one bool in session state, but the provider always re-derives the real decision from the model, so a stale flag can never trigger premium billing on a model that cannot do it.

To carry both flags cleanly, `thinking` and `fast` now travel together inside a new `RequestOptions` struct through every provider.