### PR TITLE
agent: structured prompt slot system for Lua plugins

### DIFF
--- a/maki-agent/src/agent/instructions.rs
+++ b/maki-agent/src/agent/instructions.rs
@@ -52,19 +52,13 @@ pub fn build_system_prompt(
     vars: &Vars,
     mode: &AgentMode,
     instructions: &str,
-    prompt_extras: &[String],
+    slots: &crate::prompt::ResolvedSlots,
 ) -> String {
-    let mut out = crate::prompt::SYSTEM_PROMPT.to_string();
-
-    out.push_str(&vars.apply(
+    let env = vars.apply(
         "\n\nEnvironment:\n- Working directory: {cwd}\n- Platform: {platform}\n- Date: {date}",
-    ));
-
-    out.push_str(instructions);
-
-    for extra in prompt_extras {
-        out.push_str(extra);
-    }
+    );
+    let instructions = format!("{env}{instructions}");
+    let mut out = crate::prompt::assemble(crate::prompt::PromptId::System, slots, &instructions);
 
     if let AgentMode::Plan(plan_path) = mode {
         let plan_vars = Vars::new().set("{plan_path}", plan_path.display().to_string());
@@ -186,7 +180,8 @@ mod tests {
     #[test_case(&AgentMode::Plan(PathBuf::from(PLAN_PATH)), true ; "plan_includes_plan")]
     fn plan_section_presence(mode: &AgentMode, expect_plan: bool) {
         let vars = Vars::new().set("{cwd}", "/tmp").set("{platform}", "linux");
-        let prompt = build_system_prompt(&vars, mode, "", &[]);
+        let slots = crate::prompt::ResolvedSlots::default();
+        let prompt = build_system_prompt(&vars, mode, "", &slots);
         assert_eq!(prompt.contains("Plan Mode"), expect_plan);
         if expect_plan {
             assert!(prompt.contains(PLAN_PATH));
@@ -194,22 +189,31 @@ mod tests {
     }
 
     #[test]
-    fn prompt_extras_ordered_after_instructions_before_plan() {
+    fn after_instructions_slot_lands_between_instructions_and_plan() {
+        use std::sync::Arc;
+        const INSTR: &str = "Project instructions here";
+        const EXTRA: &str = "MEMORY_EXTRA";
         let vars = Vars::new().set("{cwd}", "/tmp").set("{platform}", "linux");
-        let extras = vec!["EXTRA_A".to_string(), "EXTRA_B".to_string()];
+        let mut slots = crate::prompt::ResolvedSlots::default();
+        slots.insert(
+            crate::prompt::PromptId::System,
+            crate::prompt::Slot::AfterInstructions,
+            crate::prompt::SlotEntry {
+                plugin: Arc::from("memory"),
+                content: EXTRA.into(),
+            },
+        );
         let prompt = build_system_prompt(
             &vars,
             &AgentMode::Plan(PathBuf::from("plan.md")),
-            "\nProject instructions here",
-            &extras,
+            &format!("\n{INSTR}"),
+            &slots,
         );
-        let pos_instr = prompt.find("Project instructions here").unwrap();
-        let pos_a = prompt.find("EXTRA_A").expect("EXTRA_A missing");
-        let pos_b = prompt.find("EXTRA_B").expect("EXTRA_B missing");
-        let pos_plan = prompt.find("Plan Mode").unwrap();
-        assert!(pos_instr < pos_a, "extras after instructions");
-        assert!(pos_a < pos_b, "extras preserve insertion order");
-        assert!(pos_b < pos_plan, "extras before plan section");
+        let positions = [INSTR, EXTRA, "Plan Mode"].map(|n| prompt.find(n).unwrap());
+        assert!(
+            positions.is_sorted(),
+            "expected order instructions < slot extra < plan section, got {positions:?}"
+        );
     }
 
     #[test_case("AGENTS.md",                true  ; "direct_match")]

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -42,6 +42,7 @@ pub struct AgentParams {
     pub session_id: Option<String>,
     pub timeouts: maki_providers::Timeouts,
     pub file_tracker: Arc<FileReadTracker>,
+    pub prompt_slots: Arc<crate::prompt::ResolvedSlots>,
 }
 
 pub struct AgentRunParams {
@@ -77,6 +78,7 @@ pub struct Agent {
     session_id: Option<String>,
     timeouts: maki_providers::Timeouts,
     file_tracker: Arc<FileReadTracker>,
+    prompt_slots: Arc<crate::prompt::ResolvedSlots>,
 }
 
 impl Agent {
@@ -107,6 +109,7 @@ impl Agent {
             opts: RequestOptions::default(),
             session_id: params.session_id,
             file_tracker: params.file_tracker,
+            prompt_slots: params.prompt_slots,
         }
     }
 
@@ -336,6 +339,7 @@ impl Agent {
             permissions: Arc::clone(&self.permissions),
             timeouts: self.timeouts,
             file_tracker: Arc::clone(&self.file_tracker),
+            prompt_slots: Arc::clone(&self.prompt_slots),
         }
     }
 
@@ -503,6 +507,7 @@ mod tests {
                 session_id: None,
                 timeouts: maki_providers::Timeouts::default(),
                 file_tracker: FileReadTracker::fresh(),
+                prompt_slots: Arc::new(crate::prompt::ResolvedSlots::default()),
             },
             AgentRunParams {
                 history,
@@ -757,6 +762,7 @@ mod tests {
                     session_id: None,
                     timeouts: maki_providers::Timeouts::default(),
                     file_tracker: FileReadTracker::fresh(),
+                    prompt_slots: Arc::new(crate::prompt::ResolvedSlots::default()),
                 },
                 AgentRunParams {
                     history: History::new(Vec::new()),

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -7,6 +7,7 @@ use tracing::error;
 
 use crate::agent::{self, History};
 use crate::permissions::PermissionManager;
+use crate::prompt::ResolvedSlots;
 use crate::template;
 use crate::tools::{DescriptionContext, FileReadTracker, ToolFilter, ToolRegistry};
 use crate::{
@@ -23,7 +24,7 @@ pub struct HeadlessParams {
     pub permissions_config: PermissionsConfig,
     pub timeouts: Timeouts,
     pub prompt: String,
-    pub prompt_extras: Vec<String>,
+    pub prompt_slots: ResolvedSlots,
     pub excluded_tools: Vec<&'static str>,
     pub mcp_handle: Option<McpHandle>,
     pub initial_wd: PathBuf,
@@ -48,8 +49,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
     let tools =
         ToolRegistry::native().definitions(&vars, &ctx, params.model.supports_tool_examples());
 
-    let system =
-        agent::build_system_prompt(&vars, &mode, &instructions.text, &params.prompt_extras);
+    let system = agent::build_system_prompt(&vars, &mode, &instructions.text, &params.prompt_slots);
 
     let tool_names = extract_tool_names(&tools);
 
@@ -88,6 +88,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
                     session_id: Some(session_id),
                     timeouts: params.timeouts,
                     file_tracker: FileReadTracker::fresh(),
+                    prompt_slots: Arc::new(params.prompt_slots),
                 },
                 AgentRunParams {
                     history: History::new(Vec::new()),

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -18,7 +18,7 @@ pub use maki_config::{AgentConfig, PermissionsConfig, ToolOutputLines};
 pub mod command;
 pub mod diff;
 pub mod permissions;
-pub(crate) mod prompt;
+pub mod prompt;
 pub mod template;
 pub mod tools;
 pub use tools::ToolFilter;

--- a/maki-agent/src/prompt.rs
+++ b/maki-agent/src/prompt.rs
@@ -1,6 +1,297 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use strum::EnumString;
+
 pub const SYSTEM_PROMPT: &str = include_str!("prompts/system.md");
 pub const PLAN_PROMPT: &str = include_str!("prompts/plan.md");
 pub const RESEARCH_PROMPT: &str = include_str!("prompts/research.md");
 pub const GENERAL_PROMPT: &str = include_str!("prompts/general.md");
 pub const COMPACTION_SYSTEM: &str = include_str!("prompts/compaction.md");
 pub const COMPACTION_USER: &str = include_str!("prompts/compaction_user.md");
+
+const NATIVE_EFFICIENT_TOOLS: &[&str] = &["batch", "code_execution", "task"];
+const INSTRUCTIONS_MARKER: &str = "{{instructions}}";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumString)]
+#[strum(serialize_all = "snake_case")]
+pub enum Slot {
+    ToolUsage,
+    EfficientTools,
+    Conventions,
+    AfterInstructions,
+}
+
+impl Slot {
+    fn marker(self) -> &'static str {
+        match self {
+            Slot::ToolUsage => "{{tool_usage}}",
+            Slot::EfficientTools => "{{efficient_tools}}",
+            Slot::Conventions => "{{conventions}}",
+            Slot::AfterInstructions => "{{after_instructions}}",
+        }
+    }
+
+    const ALL: &[Slot] = &[
+        Slot::ToolUsage,
+        Slot::EfficientTools,
+        Slot::Conventions,
+        Slot::AfterInstructions,
+    ];
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumString)]
+#[strum(serialize_all = "snake_case")]
+pub enum PromptId {
+    System,
+    Research,
+    General,
+}
+
+impl PromptId {
+    pub const ALL: &[PromptId] = &[PromptId::System, PromptId::Research, PromptId::General];
+}
+
+pub struct SlotEntry {
+    pub plugin: Arc<str>,
+    pub content: String,
+}
+
+#[derive(Default)]
+pub struct ResolvedSlots {
+    entries: HashMap<(PromptId, Slot), Vec<SlotEntry>>,
+}
+
+impl ResolvedSlots {
+    pub fn get(&self, prompt: PromptId, slot: Slot) -> &[SlotEntry] {
+        self.entries
+            .get(&(prompt, slot))
+            .map(|v| v.as_slice())
+            .unwrap_or_default()
+    }
+
+    pub fn insert(&mut self, prompt: PromptId, slot: Slot, entry: SlotEntry) {
+        self.entries.entry((prompt, slot)).or_default().push(entry);
+    }
+}
+
+impl PromptId {
+    fn template(self) -> &'static str {
+        match self {
+            PromptId::System => SYSTEM_PROMPT,
+            PromptId::Research => RESEARCH_PROMPT,
+            PromptId::General => GENERAL_PROMPT,
+        }
+    }
+
+    /// A slot exists for this prompt iff its marker is present in the template.
+    /// Markers that are absent get no content (and we warn at collection time
+    /// when a plugin targets them explicitly).
+    pub fn has_slot(self, slot: Slot) -> bool {
+        self.template().contains(slot.marker())
+    }
+}
+
+fn render_slot(slots: &ResolvedSlots, prompt: PromptId, slot: Slot) -> String {
+    if slot == Slot::EfficientTools {
+        return render_efficient_tools(slots, prompt);
+    }
+    slots
+        .get(prompt, slot)
+        .iter()
+        .map(|e| e.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn render_efficient_tools(slots: &ResolvedSlots, prompt: PromptId) -> String {
+    let extras = slots.get(prompt, Slot::EfficientTools);
+    let names = NATIVE_EFFICIENT_TOOLS
+        .iter()
+        .copied()
+        .chain(extras.iter().map(|e| e.content.as_str()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("Most efficient tools: {names}.")
+}
+
+/// Fill each `{{slot}}` marker in the template with its rendered content and
+/// drop the project instructions (AGENTS.md and friends) into `{{instructions}}`.
+pub fn assemble(id: PromptId, slots: &ResolvedSlots, instructions: &str) -> String {
+    let mut out = id.template().to_string();
+    for &slot in Slot::ALL {
+        out = fill_marker(&out, slot.marker(), &render_slot(slots, id, slot));
+    }
+    out.replace(INSTRUCTIONS_MARKER, instructions)
+}
+
+/// Replace a slot marker with its content. When the content is empty, also drop
+/// the marker's own line (the trailing newline) so empty slots leave no blank
+/// gap, without touching any other whitespace in the prompt.
+fn fill_marker(template: &str, marker: &str, content: &str) -> String {
+    if content.is_empty() {
+        return template
+            .replace(&format!("{marker}\n"), "")
+            .replace(marker, "");
+    }
+    template.replace(marker, content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    const NATIVE_EFFICIENT_LINE: &str = "Most efficient tools: batch, code_execution, task";
+
+    fn slots(prompt: PromptId, entries: &[(Slot, &str)]) -> ResolvedSlots {
+        let mut slots = ResolvedSlots::default();
+        for &(slot, content) in entries {
+            slots.insert(
+                prompt,
+                slot,
+                SlotEntry {
+                    plugin: Arc::from("p"),
+                    content: content.into(),
+                },
+            );
+        }
+        slots
+    }
+
+    fn at(out: &str, needle: &str) -> usize {
+        out.find(needle)
+            .unwrap_or_else(|| panic!("missing: {needle}"))
+    }
+
+    #[test]
+    fn empty_slots_emit_template_and_native_efficient_line() {
+        let out = assemble(PromptId::System, &ResolvedSlots::default(), "");
+        assert!(out.starts_with("You are Maki"));
+        assert!(
+            !out.contains("{{"),
+            "unfilled marker left in output:\n{out}"
+        );
+        assert!(out.contains(&format!("{NATIVE_EFFICIENT_LINE}.")));
+    }
+
+    /// One test to pin the whole System layout: every slot shows up, in order,
+    /// around the instructions. Covers presence and ordering for all of them.
+    #[test]
+    fn system_sections_land_in_layout_order() {
+        let s = slots(
+            PromptId::System,
+            &[
+                (Slot::ToolUsage, "TOOL_USAGE"),
+                (Slot::EfficientTools, "EXTRA_TOOL"),
+                (Slot::Conventions, "CONVENTIONS"),
+                (Slot::AfterInstructions, "AFTER"),
+            ],
+        );
+        let out = assemble(PromptId::System, &s, "INSTR");
+        let positions = ["TOOL_USAGE", "EXTRA_TOOL", "CONVENTIONS", "INSTR", "AFTER"]
+            .map(|needle| at(&out, needle));
+        assert!(
+            positions.is_sorted(),
+            "sections out of layout order ({positions:?}):\n{out}"
+        );
+    }
+
+    /// Regression: a `tool_usage` hint must land inside the `# Tool usage`
+    /// section, not be appended after the rest of the prompt.
+    #[test]
+    fn tool_usage_hint_lands_inside_tool_usage_section() {
+        const HINT: &str = "- HINT_LINE";
+        let s = slots(PromptId::System, &[(Slot::ToolUsage, HINT)]);
+        let out = assemble(PromptId::System, &s, "");
+        let hint = at(&out, HINT);
+        assert!(
+            at(&out, "# Tool usage") < hint,
+            "hint before its section:\n{out}"
+        );
+        assert!(
+            hint < at(&out, "# Conventions"),
+            "hint leaked past section:\n{out}"
+        );
+    }
+
+    #[test]
+    fn efficient_tools_extras_join_native_list() {
+        let s = slots(
+            PromptId::System,
+            &[
+                (Slot::EfficientTools, "index"),
+                (Slot::EfficientTools, "foo"),
+            ],
+        );
+        let out = assemble(PromptId::System, &s, "");
+        assert!(out.contains(&format!("{NATIVE_EFFICIENT_LINE}, index, foo.")));
+    }
+
+    #[test]
+    fn same_slot_preserves_insertion_order() {
+        let s = slots(
+            PromptId::System,
+            &[(Slot::ToolUsage, "FIRST"), (Slot::ToolUsage, "SECOND")],
+        );
+        let out = assemble(PromptId::System, &s, "");
+        assert!(at(&out, "FIRST") < at(&out, "SECOND"));
+    }
+
+    /// Only System carries AfterInstructions, so the same content shows up there
+    /// but never leaks into the subagent prompts.
+    #[test]
+    fn after_instructions_only_reaches_system() {
+        let mut s = ResolvedSlots::default();
+        for &pid in PromptId::ALL {
+            s.insert(
+                pid,
+                Slot::AfterInstructions,
+                SlotEntry {
+                    plugin: Arc::from("p"),
+                    content: "AFTER".into(),
+                },
+            );
+        }
+        assert!(assemble(PromptId::System, &s, "").contains("AFTER"));
+        assert!(!assemble(PromptId::Research, &s, "").contains("AFTER"));
+        assert!(!assemble(PromptId::General, &s, "").contains("AFTER"));
+    }
+
+    #[test]
+    fn research_drops_conventions_but_keeps_efficient_extras() {
+        let s = slots(
+            PromptId::Research,
+            &[
+                (Slot::Conventions, "DROPPED"),
+                (Slot::EfficientTools, "EXTRA"),
+            ],
+        );
+        let out = assemble(PromptId::Research, &s, "");
+        assert!(!out.contains("DROPPED"));
+        assert!(out.contains(&format!("{NATIVE_EFFICIENT_LINE}, EXTRA.")));
+    }
+
+    #[test_case(PromptId::System, Slot::ToolUsage, true ; "system_tool_usage")]
+    #[test_case(PromptId::System, Slot::EfficientTools, true ; "system_efficient")]
+    #[test_case(PromptId::System, Slot::Conventions, true ; "system_conventions")]
+    #[test_case(PromptId::System, Slot::AfterInstructions, true ; "system_after")]
+    #[test_case(PromptId::Research, Slot::Conventions, false ; "research_no_conventions")]
+    #[test_case(PromptId::Research, Slot::AfterInstructions, false ; "research_no_after")]
+    #[test_case(PromptId::General, Slot::AfterInstructions, false ; "general_no_after")]
+    fn has_slot(prompt: PromptId, slot: Slot, expected: bool) {
+        assert_eq!(prompt.has_slot(slot), expected);
+    }
+
+    #[test_case("after_instructions", Some(Slot::AfterInstructions) ; "valid_slot")]
+    #[test_case("tool_usagee", None ; "typo_slot")]
+    fn slot_parse_is_plugin_contract(input: &str, expected: Option<Slot>) {
+        assert_eq!(input.parse::<Slot>().ok(), expected);
+    }
+
+    #[test_case("system", Some(PromptId::System) ; "valid_prompt")]
+    #[test_case("systm", None ; "typo_prompt")]
+    fn prompt_parse_is_plugin_contract(input: &str, expected: Option<PromptId>) {
+        assert_eq!(input.parse::<PromptId>().ok(), expected);
+    }
+}

--- a/maki-agent/src/prompts/general.md
+++ b/maki-agent/src/prompts/general.md
@@ -15,14 +15,13 @@ You must NEVER generate or guess URLs unless they are for helping the user with 
 # Tool usage
 - Every tool result grows your context. Minimize use of verbose tool calls, prefer compact results.
 - **Use batch** for 2+ independent parallel calls, **code_execution** for dependent/chained calls or filtering/processing results.
-- **Use index** before read to understand file structure. Then read with offset/limit for specific sections.
-- Reserve bash for system commands (git, builds, tests). Do NOT use bash for file operations.
 - Read files before editing them. Look at surrounding context and imports to match conventions.
 - Prefer edit/multiedit over write; targeted edits use far fewer tokens.
 - NEVER create files unless absolutely necessary. Prefer editing existing files.
 - Use todo_write to plan and track multi-step tasks (must be 3+ steps). Update after EACH step.
+{{tool_usage}}
 
-Most efficient tools: batch, code_execution, index.
+{{efficient_tools}}
 
 # Conventions
 - Never assume a library is available. Check the project's dependency files first.
@@ -30,7 +29,9 @@ Most efficient tools: batch, code_execution, index.
 - Follow security best practices. Never expose secrets or keys.
 - Do NOT commit or push changes.
 - When referencing code, use `file_path:line_number` format.
+{{conventions}}
 
 # When done
 - Return a concise summary of what you did and any findings.
 - If you cannot complete what was asked for, say so clearly and explain why.
+{{instructions}}

--- a/maki-agent/src/prompts/research.md
+++ b/maki-agent/src/prompts/research.md
@@ -19,14 +19,14 @@ You must NEVER generate or guess URLs unless they are for helping the user with 
 - Every tool result grows your context. Minimize use of verbose tool calls, prefer compact results.
 - **Use batch** for 2+ independent reads, greps, or globs. Never call them one at a time sequentially.
 - **Use code_execution** for dependent/chained calls (e.g. glob then read matches) or filtering large tool outputs.
-- **Use index** before read to understand file structure. Then read with offset/limit for specific sections.
-- Reserve bash for system commands only. Do NOT use bash for file operations.
 - Use todo_write to plan and track multi-step research tasks (must be 3+ steps). Update after EACH step.
+{{tool_usage}}
 
-Most efficient tools: batch, code_execution, index.
+{{efficient_tools}}
 
 # Guidelines
 - Search broadly first (glob, grep), then drill into relevant files.
 - Include specific file paths and line numbers when referencing code.
 - If you cannot find what was asked for, say so clearly.
 - Do not speculate beyond what the code shows.
+{{instructions}}

--- a/maki-agent/src/prompts/system.md
+++ b/maki-agent/src/prompts/system.md
@@ -13,17 +13,15 @@ You must NEVER generate or guess URLs unless they are for helping the user with 
 Prioritize technical accuracy over validating the user's beliefs. Provide direct, objective technical info without unnecessary praise or emotional validation. Disagree when necessary. Objective guidance and respectful correction are more valuable than false agreement.
 
 # Tool usage
-- Reserve bash for system commands (git, builds, tests). Do NOT use bash for file operations, including on files outside the working dir.
 - Every tool result grows your context. Minimize use of verbose tool calls, prefer compact results.
-- Use **index** before **read**.
 - Use **batch** for parallel calls, **code_execution** for chained/filtered calls, **task** for delegation.
 - Combine **batch** and **task**: launch multiple tasks in a batch to parallelize research or implementation.
 - Read files before editing them. Match surrounding context, conventions, and imports.
 - Use todo_write to plan and track multi-step tasks (must be 3+ steps). Update after EACH step, not only all at once.
 - Prefer edits over full file writes.
-- Proactively save non-obvious project gotchas and architecture decisions to **memory**.
+{{tool_usage}}
 
-Most efficient tools: batch, code_execution, task, index.
+{{efficient_tools}}
 
 # Conventions
 - Never assume a library is available. Check the project's dependency files first.
@@ -33,6 +31,8 @@ Most efficient tools: batch, code_execution, task, index.
 - Never force push, skip hooks, or amend commits you didn't create.
 - Never commit secrets (.env, credentials, keys).
 - When referencing code, use `file_path:line_number` format.
+{{conventions}}
 
 # When done
 - Summarize what you did concisely.
+{{instructions}}{{after_instructions}}

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -195,6 +195,7 @@ pub struct ToolContext {
     pub permissions: Arc<PermissionManager>,
     pub timeouts: maki_providers::Timeouts,
     pub file_tracker: Arc<FileReadTracker>,
+    pub prompt_slots: Arc<crate::prompt::ResolvedSlots>,
 }
 
 pub(crate) fn resolve_path(path: &str) -> Result<String, String> {
@@ -608,6 +609,7 @@ pub(crate) fn interpreter_ctx(
         permissions,
         timeouts: maki_providers::Timeouts::default(),
         file_tracker,
+        prompt_slots: Arc::new(crate::prompt::ResolvedSlots::default()),
     }
 }
 

--- a/maki-agent/src/tools/task.rs
+++ b/maki-agent/src/tools/task.rs
@@ -49,9 +49,12 @@ impl Task {
     pub async fn execute(&self, ctx: &ToolContext) -> Result<ToolOutput, String> {
         let vars = template::env_vars();
         let agent_type = self.subagent_type.as_deref().unwrap_or("research");
-        let (prompt, audience) = match agent_type {
-            "research" => (crate::prompt::RESEARCH_PROMPT, ToolAudience::RESEARCH_SUB),
-            "general" => (crate::prompt::GENERAL_PROMPT, ToolAudience::GENERAL_SUB),
+        let (prompt_id, audience) = match agent_type {
+            "research" => (
+                crate::prompt::PromptId::Research,
+                ToolAudience::RESEARCH_SUB,
+            ),
+            "general" => (crate::prompt::PromptId::General, ToolAudience::GENERAL_SUB),
             other => return Err(format!("unknown subagent type: {other}")),
         };
 
@@ -85,10 +88,15 @@ impl Task {
             "subagent spawning",
         );
 
-        let mut system = vars.apply(prompt).into_owned();
         let cwd_owned = vars.apply("{cwd}").into_owned();
-        let text = smol::unblock(move || agent::load_instruction_text(&cwd_owned)).await;
-        system.push_str(&text);
+        let instructions = smol::unblock(move || agent::load_instruction_text(&cwd_owned)).await;
+        let system = vars
+            .apply(&crate::prompt::assemble(
+                prompt_id,
+                &ctx.prompt_slots,
+                &instructions,
+            ))
+            .into_owned();
         let snapshot = ToolRegistry::native().iter();
         let tool_names: Vec<String> = snapshot
             .iter()
@@ -154,6 +162,7 @@ impl Task {
                 session_id: Some(session_id),
                 timeouts: ctx.timeouts,
                 file_tracker: FileReadTracker::fresh(),
+                prompt_slots: Arc::clone(&ctx.prompt_slots),
             },
             AgentRunParams {
                 history: crate::History::new(Vec::new()),

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use flume::Sender;
+use maki_agent::prompt::{PromptId, Slot};
 use maki_agent::tools::Tool;
 use maki_agent::tools::schema::{ParamSchema, to_json_schema, try_from_json, validate};
 use maki_agent::tools::{
@@ -20,7 +21,7 @@ use crate::api::command::{
     CommandEntry, CommandHandlerMap, LuaCommandWriter, publish_command_snapshot,
 };
 use crate::api::ctx::LuaCtx;
-use crate::runtime::{LiveCtx, PromptExtraCallbacks, Request};
+use crate::runtime::{HintContent, LiveCtx, PromptHintCallbacks, PromptHintRegistration, Request};
 
 const TOOL_NAME_MAX: usize = 64;
 const TOOL_HANDLER_RETURN_ERR: &str =
@@ -296,15 +297,62 @@ pub(crate) fn create_api_table(
     {
         let plugin = Arc::clone(&plugin);
         t.set(
-            "register_system_prompt_extra",
-            lua.create_function(move |lua, callback: Function| {
-                let key = lua.create_registry_value(callback)?;
+            "register_prompt_hint",
+            lua.create_function(move |lua, spec: Table| {
+                let slot: Slot = spec
+                    .get::<String>("slot")
+                    .map_err(|_| mlua::Error::runtime("'slot' is required"))?
+                    .parse()
+                    .map_err(|_| {
+                        mlua::Error::runtime(
+                            "unknown 'slot'. Valid: tool_usage, efficient_tools, conventions, after_instructions",
+                        )
+                    })?;
+
+                let parse_prompt = |s: &str| -> mlua::Result<PromptId> {
+                    s.parse().map_err(|_| {
+                        mlua::Error::runtime("unknown 'prompt'. Valid: system, research, general")
+                    })
+                };
+                let prompts: Option<Vec<PromptId>> = match spec.get::<LuaValue>("prompt") {
+                    Ok(LuaValue::String(s)) => Some(vec![parse_prompt(&s.to_str()?)?]),
+                    Ok(LuaValue::Table(t)) => {
+                        let mut ids = Vec::new();
+                        for pair in t.sequence_values::<mlua::String>() {
+                            ids.push(parse_prompt(&pair?.to_str()?)?);
+                        }
+                        Some(ids)
+                    }
+                    Ok(LuaValue::Nil) | Err(_) => None,
+                    Ok(_) => {
+                        return Err(mlua::Error::runtime(
+                            "'prompt' must be a string or list of strings",
+                        ));
+                    }
+                };
+
+                let content = match spec
+                    .get("content")
+                    .map_err(|_| mlua::Error::runtime("'content' is required"))?
+                {
+                    LuaValue::String(s) => HintContent::Static(s.to_string_lossy()),
+                    LuaValue::Function(f) => HintContent::Callback(lua.create_registry_value(f)?),
+                    _ => {
+                        return Err(mlua::Error::runtime(
+                            "'content' must be a string or function",
+                        ));
+                    }
+                };
+
+                let reg = PromptHintRegistration {
+                    prompts,
+                    slot,
+                    content,
+                };
                 let mut map = lua
-                    .app_data_mut::<PromptExtraCallbacks>()
+                    .app_data_mut::<PromptHintCallbacks>()
                     .ok_or_else(|| mlua::Error::runtime("not initialized"))?;
-                if let Some(old) = map.insert(Arc::clone(&plugin), key) {
-                    lua.remove_registry_value(old)?;
-                }
+                map.entry(Arc::clone(&plugin)).or_default().push(reg);
                 Ok(())
             })?,
         )?;

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -11,6 +11,7 @@ use maki_config::{PluginsConfig, RawConfig};
 use crate::api::command::{LuaCommandReader, UiAction};
 use crate::error::PluginError;
 use crate::runtime::{self, ClickReply, LuaThread, Request, RestoreReply};
+use maki_agent::prompt::ResolvedSlots;
 use serde_json::Value;
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
@@ -283,15 +284,15 @@ impl EventHandle {
         });
     }
 
-    pub fn collect_prompt_extras(&self) -> Vec<String> {
+    pub fn collect_prompt_slots(&self) -> ResolvedSlots {
         let (tx, rx) = flume::bounded(1);
-        let _ = self.tx.send(Request::CollectPromptExtras { reply: tx });
+        let _ = self.tx.send(Request::CollectPromptSlots { reply: tx });
         rx.recv().unwrap_or_default()
     }
 
-    pub async fn collect_prompt_extras_async(&self) -> Vec<String> {
+    pub async fn collect_prompt_slots_async(&self) -> ResolvedSlots {
         let (tx, rx) = flume::bounded(1);
-        let _ = self.tx.send(Request::CollectPromptExtras { reply: tx });
+        let _ = self.tx.send(Request::CollectPromptSlots { reply: tx });
         rx.recv_async().await.unwrap_or_default()
     }
 
@@ -322,7 +323,26 @@ impl EventHandle {
 mod tests {
     use super::*;
     use crate::api::command::{LuaCommandInfo, LuaCommandWriter};
+    use maki_agent::prompt::{PromptId, ResolvedSlots, Slot};
     use maki_agent::tools::ToolRegistry;
+    use test_case::test_case;
+
+    /// Load `src` as a single plugin and collect the resolved slots. Panics on
+    /// load failure; reach for `load_err` when you want to inspect the error.
+    fn slots_from(plugin: &str, src: &str) -> (PluginHost, ResolvedSlots) {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        host.load_source(plugin, src).unwrap();
+        let slots = host.event_handle().unwrap().collect_prompt_slots();
+        (host, slots)
+    }
+
+    fn contents(slots: &ResolvedSlots, prompt: PromptId, slot: Slot) -> Vec<&str> {
+        slots
+            .get(prompt, slot)
+            .iter()
+            .map(|e| e.content.as_str())
+            .collect()
+    }
 
     #[test]
     fn command_writer_reader_pair_works() {
@@ -431,117 +451,179 @@ mod tests {
     }
 
     #[test]
-    fn prompt_extra_callback_string_is_collected() {
-        let reg = Arc::new(ToolRegistry::new());
-        let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-        host.load_source(
-            "test_extra",
+    fn callback_string_lands_in_targeted_prompt_only() {
+        let (_host, slots) = slots_from(
+            "cb",
             r#"
-            maki.api.register_system_prompt_extra(function()
-                return "\n\nfrom test_extra"
-            end)
+            maki.api.register_prompt_hint({
+                slot = "tool_usage",
+                prompt = "general",
+                content = function() return "from_cb" end,
+            })
             "#,
-        )
-        .unwrap();
-        let handle = host.event_handle().unwrap();
-        let extras = handle.collect_prompt_extras();
-        assert_eq!(extras.len(), 1);
-        assert_eq!(extras[0], "\n\nfrom test_extra");
+        );
+        assert_eq!(
+            contents(&slots, PromptId::General, Slot::ToolUsage),
+            ["from_cb"]
+        );
+        assert!(contents(&slots, PromptId::System, Slot::ToolUsage).is_empty());
     }
 
     #[test]
-    fn prompt_extra_non_string_returns_are_skipped() {
-        let reg = Arc::new(ToolRegistry::new());
-        let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-        host.load_source(
-            "nil_extra",
+    fn callback_returning_nil_contributes_nothing() {
+        let (_host, slots) = slots_from(
+            "nil_cb",
             r#"
-            maki.api.register_system_prompt_extra(function()
-                return nil
-            end)
+            maki.api.register_prompt_hint({
+                slot = "tool_usage",
+                content = function() return nil end,
+            })
             "#,
-        )
-        .unwrap();
-        let handle = host.event_handle().unwrap();
-        assert!(handle.collect_prompt_extras().is_empty());
+        );
+        assert!(contents(&slots, PromptId::System, Slot::ToolUsage).is_empty());
+    }
+
+    /// A hint with no `prompt` is a default: it lands on every prompt that has the slot.
+    #[test]
+    fn static_no_prompt_lands_on_all_prompts_with_slot() {
+        let (_host, slots) = slots_from(
+            "static_hint",
+            r#"
+            maki.api.register_prompt_hint({
+                slot = "efficient_tools",
+                content = "index",
+            })
+            "#,
+        );
+        for &pid in PromptId::ALL {
+            assert_eq!(contents(&slots, pid, Slot::EfficientTools), ["index"]);
+        }
+    }
+
+    /// `conventions` lives on system and general but not research, so a default
+    /// hint follows the slot and skips research.
+    #[test]
+    fn default_hint_skips_prompts_lacking_the_slot() {
+        let (_host, slots) = slots_from(
+            "conv",
+            r#"
+            maki.api.register_prompt_hint({
+                slot = "conventions",
+                content = "follow conventions",
+            })
+            "#,
+        );
+        for pid in [PromptId::System, PromptId::General] {
+            assert_eq!(
+                contents(&slots, pid, Slot::Conventions),
+                ["follow conventions"]
+            );
+        }
+        assert!(contents(&slots, PromptId::Research, Slot::Conventions).is_empty());
+    }
+
+    /// Targeting a prompt that does not have the slot quietly drops the hint.
+    #[test]
+    fn explicit_prompt_without_slot_is_dropped() {
+        let (_host, slots) = slots_from(
+            "drop",
+            r#"
+            maki.api.register_prompt_hint({
+                slot = "after_instructions",
+                prompt = "research",
+                content = "never lands",
+            })
+            "#,
+        );
+        assert!(contents(&slots, PromptId::Research, Slot::AfterInstructions).is_empty());
     }
 
     #[test]
-    fn prompt_extra_multiple_plugins_ordered_by_name() {
-        let reg = Arc::new(ToolRegistry::new());
-        let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-        host.load_source(
-            "zzz_plugin",
+    fn prompt_list_targets_each_listed_prompt() {
+        const CONTENT: &str = "shared";
+        let (_host, slots) = slots_from(
+            "list",
             r#"
-            maki.api.register_system_prompt_extra(function()
-                return "from_zzz"
-            end)
+            maki.api.register_prompt_hint({
+                slot = "tool_usage",
+                prompt = { "system", "research" },
+                content = "shared",
+            })
             "#,
-        )
-        .unwrap();
-        host.load_source(
-            "aaa_plugin",
-            r#"
-            maki.api.register_system_prompt_extra(function()
-                return "from_aaa"
-            end)
-            "#,
-        )
-        .unwrap();
-        let handle = host.event_handle().unwrap();
-        let extras = handle.collect_prompt_extras();
-        assert_eq!(extras.len(), 2);
-        assert_eq!(extras[0], "from_aaa", "BTreeMap should sort by plugin name");
-        assert_eq!(extras[1], "from_zzz");
+        );
+        assert_eq!(
+            contents(&slots, PromptId::System, Slot::ToolUsage),
+            [CONTENT]
+        );
+        assert_eq!(
+            contents(&slots, PromptId::Research, Slot::ToolUsage),
+            [CONTENT]
+        );
+        assert!(contents(&slots, PromptId::General, Slot::ToolUsage).is_empty());
     }
 
     #[test]
-    fn prompt_extra_unload_cleans_up_callback() {
-        let reg = Arc::new(ToolRegistry::new());
-        let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-        host.load_source(
-            "temp_plugin",
-            r#"
-            maki.api.register_system_prompt_extra(function()
-                return "temporary"
-            end)
-            "#,
-        )
-        .unwrap();
-        let handle = host.event_handle().unwrap();
-        assert_eq!(handle.collect_prompt_extras().len(), 1);
-
-        host.unload("temp_plugin").unwrap();
-        assert!(handle.collect_prompt_extras().is_empty());
+    fn multiple_plugins_sorted_by_plugin_name() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        for plugin in ["zzz", "aaa"] {
+            host.load_source(
+                plugin,
+                r#"
+                maki.api.register_prompt_hint({ slot = "tool_usage", content = "from_PLUGIN" })
+                "#
+                .replace("PLUGIN", plugin)
+                .as_str(),
+            )
+            .unwrap();
+        }
+        let slots = host.event_handle().unwrap().collect_prompt_slots();
+        assert_eq!(
+            contents(&slots, PromptId::System, Slot::ToolUsage),
+            ["from_aaa", "from_zzz"],
+            "entries must be ordered by plugin name"
+        );
     }
 
+    /// One plugin can register several hints; unloading it clears all of them.
     #[test]
-    fn prompt_extra_re_register_replaces_old_callback() {
-        let reg = Arc::new(ToolRegistry::new());
-        let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    fn unload_clears_all_hints_from_plugin() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
         host.load_source(
-            "evolving",
+            "multi",
             r#"
-            maki.api.register_system_prompt_extra(function()
-                return "v1"
-            end)
+            maki.api.register_prompt_hint({ slot = "tool_usage", prompt = "system", content = "usage" })
+            maki.api.register_prompt_hint({ slot = "conventions", prompt = "system", content = "conv" })
             "#,
         )
         .unwrap();
         let handle = host.event_handle().unwrap();
-        assert_eq!(handle.collect_prompt_extras(), vec!["v1"]);
 
-        host.load_source(
-            "evolving",
-            r#"
-            maki.api.register_system_prompt_extra(function()
-                return "v2"
-            end)
-            "#,
-        )
-        .unwrap();
-        let extras = handle.collect_prompt_extras();
-        assert_eq!(extras.len(), 1, "should have exactly one, not two");
-        assert_eq!(extras[0], "v2");
+        let slots = handle.collect_prompt_slots();
+        assert_eq!(
+            contents(&slots, PromptId::System, Slot::ToolUsage),
+            ["usage"]
+        );
+        assert_eq!(
+            contents(&slots, PromptId::System, Slot::Conventions),
+            ["conv"]
+        );
+
+        host.unload("multi").unwrap();
+        let slots = handle.collect_prompt_slots();
+        assert!(contents(&slots, PromptId::System, Slot::ToolUsage).is_empty());
+        assert!(contents(&slots, PromptId::System, Slot::Conventions).is_empty());
+    }
+
+    #[test_case(r#"{ slot = "nonexistent", content = "x" }"# ; "invalid_slot")]
+    #[test_case(r#"{ slot = "tool_usage", content = "x", prompt = "nope" }"# ; "invalid_prompt")]
+    #[test_case(r#"{ slot = "tool_usage", content = "x", prompt = { "system", "bogus" } }"# ; "invalid_prompt_in_list")]
+    #[test_case(r#"{ slot = "tool_usage" }"# ; "missing_content")]
+    #[test_case(r#"{ content = "x" }"# ; "missing_slot")]
+    #[test_case(r#"{ slot = "tool_usage", content = 42 }"# ; "content_wrong_type")]
+    #[test_case(r#"{ slot = "tool_usage", content = "x", prompt = 42 }"# ; "prompt_wrong_type")]
+    fn invalid_hint_spec_is_rejected(spec: &str) {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        let src = format!("maki.api.register_prompt_hint({spec})");
+        assert!(host.load_source("bad", &src).is_err());
     }
 }

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -11,6 +11,7 @@ use event_listener::Event;
 
 use include_dir::Dir;
 use maki_agent::cancel::CancelToken;
+use maki_agent::prompt::{PromptId, ResolvedSlots, Slot, SlotEntry};
 use maki_agent::tools::{
     HeaderResult, PermissionScopes, RegistryError, Tool, ToolRegistry, ToolSource,
 };
@@ -42,7 +43,18 @@ const INTERRUPT_CANCEL_CHECK_INTERVAL: u32 = 128;
 const ASYNC_RUN_DEFAULT_DEADLINE: Duration = Duration::from_secs(60);
 
 pub type LoadResult = Result<(), PluginError>;
-pub(crate) type PromptExtraCallbacks = BTreeMap<Arc<str>, RegistryKey>;
+pub(crate) enum HintContent {
+    Static(String),
+    Callback(RegistryKey),
+}
+
+pub(crate) struct PromptHintRegistration {
+    pub(crate) prompts: Option<Vec<PromptId>>,
+    pub(crate) slot: Slot,
+    pub(crate) content: HintContent,
+}
+
+pub(crate) type PromptHintCallbacks = BTreeMap<Arc<str>, Vec<PromptHintRegistration>>;
 
 /// Load and clear requests drain in-flight tools first so we never
 /// mutate a plugin environment while a tool call is still running.
@@ -94,8 +106,8 @@ pub enum Request {
         command: Arc<str>,
         args: String,
     },
-    CollectPromptExtras {
-        reply: flume::Sender<Vec<String>>,
+    CollectPromptSlots {
+        reply: flume::Sender<ResolvedSlots>,
     },
     Shutdown,
     RestoreTool {
@@ -523,7 +535,7 @@ impl LuaRuntime {
         lua.set_app_data(CommandHandlerMap::new());
         lua.set_app_data(SpawnQueue::default());
         lua.set_app_data(command_writer);
-        lua.set_app_data(PromptExtraCallbacks::default());
+        lua.set_app_data(PromptHintCallbacks::default());
 
         Ok(Self {
             lua,
@@ -571,49 +583,113 @@ impl LuaRuntime {
                 }
             }
         }
-        if let Some(mut extras) = self.lua.app_data_mut::<PromptExtraCallbacks>() {
-            if let Some(key) = extras.remove(name) {
-                if let Err(e) = self.lua.remove_registry_value(key) {
-                    tracing::warn!(plugin = name, error = %e, "failed to drop prompt extra key");
+        if let Some(mut hints) = self.lua.app_data_mut::<PromptHintCallbacks>() {
+            if let Some(regs) = hints.remove(name) {
+                for reg in regs {
+                    if let HintContent::Callback(key) = reg.content {
+                        if let Err(e) = self.lua.remove_registry_value(key) {
+                            tracing::warn!(plugin = name, error = %e, "failed to drop prompt hint key");
+                        }
+                    }
                 }
             }
         }
     }
 
-    async fn collect_prompt_extras(&self) -> Vec<String> {
-        let callbacks: Vec<(Arc<str>, Function)> = {
-            let Some(map) = self.lua.app_data_ref::<PromptExtraCallbacks>() else {
-                return Vec::new();
+    async fn run_hint_callback(&self, plugin: &str, func: Function) -> Option<String> {
+        let scope = TaskScope::new(&self.lua, TaskCell::new(CancelToken::none(), None, None));
+        let result: mlua::Result<LuaValue> = scope
+            .scope_future(async {
+                let thread = self.lua.create_thread(func)?;
+                thread.into_async::<LuaValue>(())?.await
+            })
+            .await;
+        drop(scope);
+        match result {
+            Ok(LuaValue::String(s)) => Some(s.to_string_lossy()),
+            Ok(LuaValue::Nil) => None,
+            Ok(_) => {
+                tracing::warn!(plugin, "prompt hint callback returned non-string");
+                None
+            }
+            Err(e) => {
+                tracing::warn!(plugin, error = %e, "prompt hint callback failed");
+                None
+            }
+        }
+    }
+
+    async fn collect_prompt_slots(&self) -> ResolvedSlots {
+        struct Pending {
+            plugin: Arc<str>,
+            prompts: Option<Vec<PromptId>>,
+            slot: Slot,
+            content: PendingContent,
+        }
+        enum PendingContent {
+            Static(String),
+            Callback(Function),
+        }
+
+        let pending: Vec<Pending> = {
+            let Some(map) = self.lua.app_data_ref::<PromptHintCallbacks>() else {
+                return ResolvedSlots::default();
             };
             map.iter()
-                .filter_map(|(plugin, key)| {
-                    let func = self.lua.registry_value::<Function>(key).ok()?;
-                    Some((Arc::clone(plugin), func))
+                .flat_map(|(plugin, regs)| {
+                    regs.iter().filter_map(move |r| {
+                        let content = match &r.content {
+                            HintContent::Static(s) => PendingContent::Static(s.clone()),
+                            HintContent::Callback(key) => match self.lua.registry_value(key) {
+                                Ok(func) => PendingContent::Callback(func),
+                                Err(e) => {
+                                    tracing::warn!(plugin = %plugin, error = %e, "failed to read prompt hint callback");
+                                    return None;
+                                }
+                            },
+                        };
+                        Some(Pending {
+                            plugin: Arc::clone(plugin),
+                            prompts: r.prompts.clone(),
+                            slot: r.slot,
+                            content,
+                        })
+                    })
                 })
                 .collect()
         };
-        let mut extras = Vec::new();
-        for (plugin, func) in &callbacks {
-            let scope = TaskScope::new(&self.lua, TaskCell::new(CancelToken::none(), None, None));
-            let result: mlua::Result<LuaValue> = scope
-                .scope_future(async {
-                    let thread = self.lua.create_thread(func.clone())?;
-                    thread.into_async::<LuaValue>(())?.await
-                })
-                .await;
-            drop(scope);
-            match result {
-                Ok(LuaValue::String(s)) => extras.push(s.to_string_lossy()),
-                Ok(LuaValue::Nil) => {}
-                Ok(_) => {
-                    tracing::warn!(plugin = %plugin, "prompt extra callback returned non-string")
+
+        let mut slots = ResolvedSlots::default();
+        for item in pending {
+            let content = match item.content {
+                PendingContent::Static(s) => Some(s),
+                PendingContent::Callback(func) => self.run_hint_callback(&item.plugin, func).await,
+            };
+            let Some(content) = content else { continue };
+            let explicit = item.prompts.is_some();
+            for &pid in item.prompts.as_deref().unwrap_or(PromptId::ALL) {
+                if !pid.has_slot(item.slot) {
+                    if explicit {
+                        tracing::warn!(
+                            plugin = %item.plugin,
+                            slot = ?item.slot,
+                            prompt = ?pid,
+                            "prompt hint targets a prompt that has no such slot; ignoring"
+                        );
+                    }
+                    continue;
                 }
-                Err(e) => {
-                    tracing::warn!(plugin = %plugin, error = %e, "prompt extra callback failed")
-                }
+                slots.insert(
+                    pid,
+                    item.slot,
+                    SlotEntry {
+                        plugin: Arc::clone(&item.plugin),
+                        content: content.clone(),
+                    },
+                );
             }
         }
-        extras
+        slots
     }
 
     fn drain_pending(&self) -> Vec<PendingTool> {
@@ -1515,9 +1591,9 @@ pub fn spawn(
                             let res = rt.run_init_lua(&source, &source_name, plugin_dir);
                             let _ = reply.send(res);
                         }
-                        Request::CollectPromptExtras { reply } => {
-                            let extras = rt.collect_prompt_extras().await;
-                            let _ = reply.send(extras);
+                        Request::CollectPromptSlots { reply } => {
+                            let slots = rt.collect_prompt_slots().await;
+                            let _ = reply.send(slots);
                         }
                     Request::RestoreTool {
                         tool,

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -138,7 +138,7 @@ impl AgentLoop {
         if self.init_cancel.is_cancelled() {
             return false;
         }
-        self.publish_btw_system(&[]);
+        self.publish_btw_system(&maki_agent::prompt::ResolvedSlots::default());
 
         let slot = self.model_slot.load();
         self.tools = self.build_tools(&slot.model);
@@ -206,17 +206,17 @@ impl AgentLoop {
 
         self.sync_shared_history_with_pending(&input);
 
-        let prompt_extras = match self.lua_handle.as_ref() {
-            Some(h) => h.collect_prompt_extras_async().await,
-            None => Vec::new(),
+        let prompt_slots = match self.lua_handle.as_ref() {
+            Some(h) => h.collect_prompt_slots_async().await,
+            None => maki_agent::prompt::ResolvedSlots::default(),
         };
         let system = agent::build_system_prompt(
             &self.vars,
             &input.mode,
             &self.instructions.text,
-            &prompt_extras,
+            &prompt_slots,
         );
-        self.publish_btw_system(&prompt_extras);
+        self.publish_btw_system(&prompt_slots);
         let (trigger, cancel) = CancelToken::new();
         self.set_cancel_trigger(run_id, trigger);
 
@@ -232,6 +232,7 @@ impl AgentLoop {
                 session_id: self.session_id.clone(),
                 timeouts: self.timeouts,
                 file_tracker: Arc::clone(&self.file_tracker),
+                prompt_slots: Arc::new(prompt_slots),
             },
             AgentRunParams {
                 history: mem::replace(&mut self.history, History::new(Vec::new())),
@@ -281,12 +282,12 @@ impl AgentLoop {
 
     /// Always pins `Build` mode: btw runs no tools, so Plan-mode constraints would only confuse
     /// the model. Everything else matches the live prompt.
-    fn publish_btw_system(&self, prompt_extras: &[String]) {
+    fn publish_btw_system(&self, prompt_slots: &maki_agent::prompt::ResolvedSlots) {
         let system = agent::build_system_prompt(
             &self.vars,
             &maki_agent::AgentMode::Build,
             &self.instructions.text,
-            prompt_extras,
+            prompt_slots,
         );
         self.btw_system.store(Arc::new(system));
     }

--- a/plugins/bash/init.lua
+++ b/plugins/bash/init.lua
@@ -223,6 +223,11 @@ Commands run in ]] .. cwd .. [[ by default.
 - Output truncated beyond 2000 lines or 50KB.
 - Interactive commands (sudo, ssh prompts) fail immediately.]]
 
+maki.api.register_prompt_hint({
+  slot = "tool_usage",
+  content = "- Reserve bash for system commands (git, builds, tests). Do NOT use bash for file operations, including on files outside the working dir.",
+})
+
 maki.api.register_tool({
   name = "bash",
   description = description,

--- a/plugins/index/init.lua
+++ b/plugins/index/init.lua
@@ -110,6 +110,16 @@ local function render_index(skeleton, path, ctx)
   return buf, render_header(path, line_count)
 end
 
+maki.api.register_prompt_hint({
+  slot = "tool_usage",
+  content = "- Use **index** before **read**.",
+})
+
+maki.api.register_prompt_hint({
+  slot = "efficient_tools",
+  content = "index",
+})
+
 maki.api.register_tool({
   name = "index",
   description = [[

--- a/plugins/memory/init.lua
+++ b/plugins/memory/init.lua
@@ -26,24 +26,33 @@ local function resolve_dir(check_legacy)
   return maki.fs.joinpath(state, memories_path_suffix())
 end
 
-maki.api.register_system_prompt_extra(function()
-  local dir = resolve_dir(true)
-  if not dir then
-    return nil
-  end
-  local entries = helpers.collect_file_entries(dir)
-  if #entries == 0 then
-    return nil
-  end
-  table.sort(entries, function(a, b)
-    return a[1] < b[1]
-  end)
-  local out = "\n\nMemory files (use the memory tool to view/update):\n"
-  for _, e in ipairs(entries) do
-    out = out .. "- " .. e[1] .. " (" .. e[2] .. " bytes)\n"
-  end
-  return out
-end)
+maki.api.register_prompt_hint({
+  prompt = "system",
+  slot = "after_instructions",
+  content = function()
+    local dir = resolve_dir(true)
+    if not dir then
+      return nil
+    end
+    local entries = helpers.collect_file_entries(dir)
+    if #entries == 0 then
+      return nil
+    end
+    table.sort(entries, function(a, b)
+      return a[1] < b[1]
+    end)
+    local out = "\n\nMemory files (use the memory tool to view/update):\n"
+    for _, e in ipairs(entries) do
+      out = out .. "- " .. e[1] .. " (" .. e[2] .. " bytes)\n"
+    end
+    return out
+  end,
+})
+
+maki.api.register_prompt_hint({
+  slot = "tool_usage",
+  content = "- Proactively save non-obvious project gotchas and architecture decisions to **memory**.",
+})
 
 local function render_content(content, path, ctx)
   local buf = maki.ui.buf()

--- a/src/print.rs
+++ b/src/print.rs
@@ -137,9 +137,9 @@ pub fn run(
         }
     };
 
-    let prompt_extras = lua_handle
+    let prompt_slots = lua_handle
         .as_ref()
-        .map(|h| h.collect_prompt_extras())
+        .map(|h| h.collect_prompt_slots())
         .unwrap_or_default();
 
     let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
@@ -154,7 +154,7 @@ pub fn run(
         permissions_config,
         timeouts,
         prompt,
-        prompt_extras,
+        prompt_slots,
         excluded_tools: vec![QUESTION_TOOL_NAME],
         mcp_handle,
         initial_wd: cwd,


### PR DESCRIPTION
The system, research, and general prompts hardcoded tool lines like `Use **index** before **read**`, which only make sense when that plugin is loaded.

Now a Rust function assembles each prompt from a static `.md` template plus named slots, and plugins drop lines into a slot with `register_prompt_hint`, optionally targeting a specific subagent prompt.

The `Slot` and `PromptId` enums validate the strings at registration time, so a typo becomes an instant Lua error.

`ResolvedSlots` rides along through `AgentParams` and `ToolContext`, so subagent prompts spawned by the `task` tool pick up the same hints, while `index`, `bash`, and `memory` register their own.