### PR TITLE
ui: fix `/btw` to keep the full session context

### DIFF
--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -33,6 +33,7 @@ pub(super) struct AgentLoop {
     mcp_handle: Option<McpHandle>,
     history: History,
     shared_history: Arc<ArcSwap<Vec<Message>>>,
+    btw_system: Arc<ArcSwap<String>>,
     cancel_map: Arc<Mutex<CancelMap>>,
     init_cancel: CancelToken,
     permissions: Arc<PermissionManager>,
@@ -54,6 +55,7 @@ impl AgentLoop {
         tool_output_lines: ToolOutputLines,
         initial_history: Vec<Message>,
         shared_history: Arc<ArcSwap<Vec<Message>>>,
+        btw_system: Arc<ArcSwap<String>>,
         mcp_handle: Option<McpHandle>,
         permissions: Arc<PermissionManager>,
         agent_tx: flume::Sender<Envelope>,
@@ -75,6 +77,7 @@ impl AgentLoop {
             mcp_handle,
             history: History::new(initial_history),
             shared_history,
+            btw_system,
             cancel_map,
             init_cancel,
             permissions,
@@ -135,6 +138,7 @@ impl AgentLoop {
         if self.init_cancel.is_cancelled() {
             return false;
         }
+        self.publish_btw_system(&[]);
 
         let slot = self.model_slot.load();
         self.tools = self.build_tools(&slot.model);
@@ -212,6 +216,7 @@ impl AgentLoop {
             &self.instructions.text,
             &prompt_extras,
         );
+        self.publish_btw_system(&prompt_extras);
         let (trigger, cancel) = CancelToken::new();
         self.set_cancel_trigger(run_id, trigger);
 
@@ -272,6 +277,18 @@ impl AgentLoop {
     async fn reload_instructions(&mut self) {
         let cwd = self.vars.apply("{cwd}").into_owned();
         self.instructions = smol::unblock(move || agent::load_instructions(&cwd)).await;
+    }
+
+    /// Always pins `Build` mode: btw runs no tools, so Plan-mode constraints would only confuse
+    /// the model. Everything else matches the live prompt.
+    fn publish_btw_system(&self, prompt_extras: &[String]) {
+        let system = agent::build_system_prompt(
+            &self.vars,
+            &maki_agent::AgentMode::Build,
+            &self.instructions.text,
+            prompt_extras,
+        );
+        self.btw_system.store(Arc::new(system));
     }
 
     fn sync_shared_history(&self) {

--- a/maki-ui/src/agent/mod.rs
+++ b/maki-ui/src/agent/mod.rs
@@ -44,6 +44,7 @@ pub(crate) struct AgentHandles {
     pub(crate) agent_rx: flume::Receiver<Envelope>,
     pub(crate) answer_tx: flume::Sender<String>,
     pub(crate) history: Arc<ArcSwap<Vec<Message>>>,
+    pub(crate) btw_system: Arc<ArcSwap<String>>,
     pub(crate) tool_outputs: Arc<Mutex<HashMap<String, ToolOutput>>>,
     pub(crate) mcp_handle: Option<McpHandle>,
     pub(crate) mcp_config_errors: McpConfigErrors,
@@ -93,6 +94,7 @@ impl AgentHandles {
         app.answer_tx = Some(self.answer_tx.clone());
         app.cmd_tx = Some(self.cmd_tx.clone());
         app.shared_history = Some(Arc::clone(&self.history));
+        app.btw_system = Some(Arc::clone(&self.btw_system));
         app.shared_tool_outputs = Some(Arc::clone(&self.tool_outputs));
         app.queue.set_shared(self.queue.clone());
     }
@@ -190,6 +192,7 @@ fn spawn_agent_internal(
     let queue_rx = Arc::new(queue_rx);
     let shared_history: Arc<ArcSwap<Vec<Message>>> =
         Arc::new(ArcSwap::from_pointee(initial_history.clone()));
+    let btw_system: Arc<ArcSwap<String>> = Arc::new(ArcSwap::from_pointee(String::new()));
     let shared_tool_outputs: Arc<Mutex<HashMap<String, ToolOutput>>> =
         Arc::new(Mutex::new(HashMap::new()));
     let (init_trigger, init_cancel) = CancelToken::new();
@@ -203,6 +206,7 @@ fn spawn_agent_internal(
         tool_output_lines,
         initial_history,
         Arc::clone(&shared_history),
+        Arc::clone(&btw_system),
         mcp_handle.clone(),
         Arc::clone(permissions),
         agent_tx,
@@ -222,6 +226,7 @@ fn spawn_agent_internal(
         agent_rx,
         answer_tx,
         history: shared_history,
+        btw_system,
         tool_outputs: shared_tool_outputs,
         mcp_handle,
         mcp_config_errors,

--- a/maki-ui/src/app/btw.rs
+++ b/maki-ui/src/app/btw.rs
@@ -10,7 +10,19 @@ use crate::components::btw_modal::BtwEvent;
 
 use super::App;
 
-const BTW_SYSTEM: &str = "Answer the user's question concisely. No tools available.";
+const BTW_REMINDER: &str = "<system-reminder>\nThis is a side question. Answer it directly in a \
+single response.\n- You have NO tools: you cannot read files, run commands, or take any action.\n\
+- One-off response: there are no follow-up turns.\n- Answer ONLY from the existing conversation \
+context.\n- Never say \"Let me...\", \"I'll now...\", or promise any action.\n- If you don't know, \
+say so; do not offer to look it up.\n</system-reminder>";
+
+const BTW_FALLBACK_SYSTEM: &str = "You are a helpful coding assistant. Answer concisely \
+from the conversation context.";
+
+/// The reminder leads so the model treats the question as a quick aside, not a task to act on.
+pub(crate) fn btw_question(question: &str) -> Message {
+    Message::user(format!("{BTW_REMINDER}\n\n{question}"))
+}
 
 impl App {
     pub(crate) fn start_btw(
@@ -24,19 +36,34 @@ impl App {
             .as_ref()
             .map(|h| Vec::clone(&h.load()))
             .unwrap_or_default();
+        let system = self
+            .btw_system
+            .as_ref()
+            .map(|s| String::clone(&s.load()))
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| BTW_FALLBACK_SYSTEM.to_string());
+        messages.push(btw_question(&question));
 
         let (tx, rx) = flume::bounded(64);
         self.btw_modal.open(&question, rx);
-        messages.push(Message::user(question));
 
         let session_id = self.state.session.id.clone();
-        smol::spawn(run_btw(provider, model, messages, tx, Some(session_id))).detach();
+        smol::spawn(run_btw(
+            provider,
+            model,
+            system,
+            messages,
+            tx,
+            Some(session_id),
+        ))
+        .detach();
     }
 }
 
 async fn run_btw(
     provider: Arc<dyn Provider>,
     model: Model,
+    system: String,
     messages: Vec<Message>,
     btw_tx: Sender<BtwEvent>,
     session_id: Option<String>,
@@ -47,7 +74,7 @@ async fn run_btw(
     let stream_fut = provider.stream_message(
         &model,
         &messages,
-        BTW_SYSTEM,
+        &system,
         &tools,
         &event_tx,
         RequestOptions::default(),
@@ -75,5 +102,29 @@ async fn run_btw(
         Err(e) => {
             let _ = btw_tx.send(BtwEvent::Error(e.to_string()));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const Q: &str = "why sqlite?";
+
+    fn user_text(msg: &Message) -> String {
+        msg.content
+            .iter()
+            .filter_map(|b| match b {
+                maki_providers::ContentBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn injects_reminder_before_question() {
+        let text = user_text(&btw_question(Q));
+        assert!(text.starts_with(BTW_REMINDER), "reminder leads the message");
+        assert!(text.ends_with(Q), "question trails the message");
     }
 }

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -161,6 +161,7 @@ pub struct App {
 
     pub(crate) storage: StateDir,
     pub(crate) shared_history: Option<Arc<ArcSwap<Vec<Message>>>>,
+    pub(crate) btw_system: Option<Arc<ArcSwap<String>>>,
     pub(crate) shared_tool_outputs: Option<Arc<Mutex<HashMap<String, ToolOutput>>>>,
     pub(crate) image_paste_rx: Vec<flume::Receiver<Result<ImageSource, String>>>,
     storage_writer: Arc<StorageWriter>,
@@ -231,6 +232,7 @@ impl App {
             last_esc: None,
             storage,
             shared_history: None,
+            btw_system: None,
             shared_tool_outputs: None,
             image_paste_rx: vec![],
             storage_writer,


### PR DESCRIPTION
The side question used to throw away the real system prompt, so it lost AGENTS.md rules, environment info, and the agent persona.

Now the `AgentLoop` publishes a mode-independent build of the live prompt into a shared `btw_system`, mirroring how `shared_history` already flows to the UI.

A single `build_btw_request` assembles the request, prepending a constraint block that tells the model it has no tools and only one turn, so it stops drifting into "Let me check..." answers.