### PR TITLE
ui: push the chat up for the question form instead of floating over it

### DIFF
--- a/maki-lua/src/api/command.rs
+++ b/maki-lua/src/api/command.rs
@@ -145,6 +145,22 @@ impl Border {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Split {
+    #[default]
+    None,
+    Below,
+}
+
+impl Split {
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "below" => Self::Below,
+            _ => Self::None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TitlePos {
     #[default]
     Left,
@@ -177,6 +193,7 @@ pub struct FloatConfig {
     pub cursor_line: bool,
     pub reserved_bottom: usize,
     pub reserved_top: usize,
+    pub split: Split,
 }
 
 impl Default for FloatConfig {
@@ -195,6 +212,7 @@ impl Default for FloatConfig {
             cursor_line: false,
             reserved_bottom: 0,
             reserved_top: 0,
+            split: Split::None,
         }
     }
 }
@@ -222,7 +240,8 @@ impl FloatConfig {
             zindex,
             cursor_line,
             reserved_bottom,
-            reserved_top
+            reserved_top,
+            split
         );
     }
 }
@@ -242,6 +261,7 @@ pub struct FloatConfigPatch {
     pub cursor_line: Option<bool>,
     pub reserved_bottom: Option<usize>,
     pub reserved_top: Option<usize>,
+    pub split: Option<Split>,
 }
 
 pub enum WinEvent {
@@ -366,6 +386,15 @@ mod tests {
         TitlePos::parse(s)
     }
 
+    #[test_case("below" => Split::Below ; "below")]
+    #[test_case("none" => Split::None ; "none")]
+    #[test_case("" => Split::None ; "empty_defaults_none")]
+    #[test_case("Below" => Split::None ; "exact_match_is_case_sensitive")]
+    #[test_case("garbage" => Split::None ; "unknown_defaults_none")]
+    fn split_parse(s: &str) -> Split {
+        Split::parse(s)
+    }
+
     #[test]
     fn apply_patch_selective_fields() {
         let mut cfg = FloatConfig::default();
@@ -398,6 +427,19 @@ mod tests {
         cfg.apply_patch(patch);
         assert_eq!(cfg.row, None, "Some(None) clears the value");
         assert_eq!(cfg.col, Some(5), "Some(Some(5)) overwrites it");
+    }
+
+    #[test]
+    fn apply_patch_sets_split() {
+        let mut cfg = FloatConfig::default();
+        assert_eq!(cfg.split, Split::None);
+        let patch = FloatConfigPatch {
+            split: Some(Split::Below),
+            ..FloatConfigPatch::default()
+        };
+        cfg.apply_patch(patch);
+        assert_eq!(cfg.split, Split::Below);
+        assert_eq!(cfg.border, Border::Rounded, "untouched fields stay");
     }
 
     #[test]

--- a/maki-lua/src/api/ui.rs
+++ b/maki-lua/src/api/ui.rs
@@ -5,7 +5,7 @@ use humantime::format_duration;
 use mlua::{Lua, Result as LuaResult, Table};
 
 use crate::api::command::{
-    Anchor, Border, Dimension, FloatConfig, TitlePos, UiAction, WinCommand, WinEvent,
+    Anchor, Border, Dimension, FloatConfig, Split, TitlePos, UiAction, WinCommand, WinEvent,
 };
 use crate::api::win::WinHandle;
 use crate::runtime::with_task_bufs;
@@ -135,6 +135,7 @@ pub(crate) fn create_ui_table(
                     let anchor = parse_anchor(&opts_tbl);
                     let border = parse_border(&opts_tbl);
                     let title_pos = parse_title_pos(&opts_tbl);
+                    let split = parse_split(&opts_tbl);
 
                     let config = FloatConfig {
                         width,
@@ -150,6 +151,7 @@ pub(crate) fn create_ui_table(
                         cursor_line,
                         reserved_bottom,
                         reserved_top,
+                        split,
                     };
 
                     let (term_cols, term_rows) = crossterm::terminal::size().unwrap_or((80, 24));
@@ -208,6 +210,12 @@ pub(crate) fn parse_dimension(tbl: &Table, key: &str, default: Dimension) -> Dim
 fn parse_anchor(tbl: &Table) -> Anchor {
     tbl.get::<String>("anchor")
         .map(|s| Anchor::parse(&s))
+        .unwrap_or_default()
+}
+
+fn parse_split(tbl: &Table) -> Split {
+    tbl.get::<String>("split")
+        .map(|s| Split::parse(&s))
         .unwrap_or_default()
 }
 

--- a/maki-lua/src/api/win.rs
+++ b/maki-lua/src/api/win.rs
@@ -1,6 +1,8 @@
 use mlua::{Table, UserData, UserDataMethods};
 
-use crate::api::command::{Anchor, Border, FloatConfigPatch, TitlePos, WinCommand, WinEvent};
+use crate::api::command::{
+    Anchor, Border, FloatConfigPatch, Split, TitlePos, WinCommand, WinEvent,
+};
 use crate::api::ui::{parse_footer, try_parse_dimension};
 
 pub(crate) struct WinHandle {
@@ -116,6 +118,9 @@ impl UserData for WinHandle {
             }
             if let Ok(rt) = opts.get::<usize>("reserved_top") {
                 patch.reserved_top = Some(rt);
+            }
+            if let Ok(s) = opts.get::<String>("split") {
+                patch.split = Some(Split::parse(&s));
             }
             patch.width = try_parse_dimension(&opts, "width");
             patch.height = try_parse_dimension(&opts, "height");

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -6,7 +6,7 @@ mod runtime;
 
 pub use api::command::{
     Anchor, Border, Dimension, FloatConfig, FloatConfigPatch, LuaCommandInfo, LuaCommandReader,
-    TitlePos, UiAction, WinCommand, WinEvent,
+    Split, TitlePos, UiAction, WinCommand, WinEvent,
 };
 pub use error::PluginError;
 pub use loader::{EventHandle, PluginHost};

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -2476,3 +2476,75 @@ fn has_content(messages: bool, ephemeral: bool) -> bool {
     }
     app.has_content()
 }
+
+const TEST_AREA: Rect = Rect {
+    x: 0,
+    y: 0,
+    width: 80,
+    height: 40,
+};
+const SPLIT_HEIGHT: u16 = 8;
+
+fn open_split_window(app: &mut App) {
+    let buf = Arc::new(maki_agent::SharedBuf::new());
+    let config = maki_lua::FloatConfig {
+        height: maki_lua::Dimension::Abs(SPLIT_HEIGHT),
+        border: maki_lua::Border::None,
+        split: maki_lua::Split::Below,
+        ..maki_lua::FloatConfig::default()
+    };
+    let (event_tx, _event_rx) = flume::bounded::<maki_lua::WinEvent>(8);
+    let (_cmd_tx, cmd_rx) = flume::bounded::<maki_lua::WinCommand>(8);
+    app.float_mgr.open(buf, config, true, event_tx, cmd_rx);
+}
+
+#[test]
+fn push_window_reserves_bottom_and_suppresses_input() {
+    let mut app = test_app();
+    let (msg_before, _b, _s, input_before, push_before) = app.layout_geometry(TEST_AREA);
+    assert!(!push_before, "no push window open yet");
+    assert!(input_before.height > 0, "input box visible before push");
+
+    open_split_window(&mut app);
+    let (msg_after, bottom_after, _s, input_after, push_after) = app.layout_geometry(TEST_AREA);
+
+    assert!(push_after, "push window should reserve the bottom area");
+    assert_eq!(
+        bottom_after.height, SPLIT_HEIGHT,
+        "bottom area routes through bottom_split_height",
+    );
+    assert!(
+        msg_after.height < msg_before.height,
+        "chat must shrink to make room for the push window",
+    );
+    assert_eq!(
+        input_after.height, 0,
+        "input box is suppressed under a push"
+    );
+}
+
+#[test]
+fn closing_push_window_restores_input_layout() {
+    let mut app = test_app();
+    let before = app.layout_geometry(TEST_AREA);
+
+    open_split_window(&mut app);
+    app.float_mgr.close_all();
+
+    let after = app.layout_geometry(TEST_AREA);
+    assert_eq!(after, before, "closing the push window restores the layout");
+}
+
+#[test]
+fn permission_prompt_takes_bottom_precedence_over_push() {
+    let mut app = test_app();
+    open_split_window(&mut app);
+    app.permission_prompt
+        .open("perm-1".into(), "bash".into(), vec!["ls".into()], None);
+
+    let (_msg, _bottom, _status, _input, push) = app.layout_geometry(TEST_AREA);
+    assert!(
+        !push,
+        "push must yield the bottom area to an open permission prompt"
+    );
+}

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -1,6 +1,7 @@
 use crate::components::Overlay;
 #[cfg(test)]
 use crate::components::keybindings::KeybindContext;
+use crate::components::lua_float::MIN_CHAT_AND_STATUS_ROWS;
 use crate::components::queue_panel;
 use crate::components::status_bar::{StatusBarContext, UsageStats};
 use crate::selection::{self, SelectableZone, SelectionZone};
@@ -18,6 +19,7 @@ struct ViewLayout {
     queue_area: Rect,
     todo_area: Rect,
     input_area: Rect,
+    push_active: bool,
 }
 
 impl App {
@@ -27,7 +29,7 @@ impl App {
         let in_plan = self.state.mode == Mode::Plan;
         let form_visible =
             self.permission_prompt.is_open() || (in_plan && self.plan_form.is_visible());
-        let layout = self.compute_layout(frame, form_visible);
+        let layout = self.compute_layout(frame.area(), form_visible);
         let render_chat = self.resolve_render_chat();
 
         self.render_background(frame);
@@ -40,15 +42,23 @@ impl App {
         self.apply_selection(frame, render_chat);
     }
 
-    fn compute_layout(&self, frame: &Frame, form_visible: bool) -> ViewLayout {
-        let area = frame.area();
-        let bottom_height = if form_visible {
-            let max = area.height.saturating_sub(3);
-            if self.permission_prompt.is_open() {
-                self.permission_prompt.height(area.width).min(max)
-            } else {
-                self.plan_form.height().min(max)
-            }
+    fn compute_layout(&self, area: Rect, form_visible: bool) -> ViewLayout {
+        let max_bottom = area.height.saturating_sub(MIN_CHAT_AND_STATUS_ROWS);
+        let permission_open = self.permission_prompt.is_open();
+        // The permission prompt wins the bottom area, so a push window only gets
+        // it when no prompt is open.
+        let push_height = if permission_open {
+            None
+        } else {
+            self.float_mgr.bottom_split_height(area)
+        };
+        let bottom_takeover = form_visible || push_height.is_some();
+        let bottom_height = if permission_open {
+            self.permission_prompt.height(area.width).min(max_bottom)
+        } else if let Some(h) = push_height {
+            h
+        } else if form_visible {
+            self.plan_form.height().min(max_bottom)
         } else if self.is_main_chat() {
             queue_panel::height(self.queue.panel_len())
                 + self.chats[self.active_chat].todo_panel.height()
@@ -65,13 +75,14 @@ impl App {
         ])
         .areas(area);
 
-        let queue_height = queue_panel::height(self.queue.panel_len());
-        let todo_h = if form_visible {
-            0
+        let (queue_height, todo_h, input_height) = if bottom_takeover {
+            (0, 0, 0)
         } else {
-            self.chats[self.active_chat].todo_panel.height()
+            let queue_height = queue_panel::height(self.queue.panel_len());
+            let todo_h = self.chats[self.active_chat].todo_panel.height();
+            let input_height = bottom_area.height.saturating_sub(queue_height + todo_h);
+            (queue_height, todo_h, input_height)
         };
-        let input_height = bottom_area.height.saturating_sub(queue_height + todo_h);
 
         let [queue_area, todo_area, input_area] = Layout::vertical([
             Constraint::Length(queue_height),
@@ -87,6 +98,7 @@ impl App {
             queue_area,
             todo_area,
             input_area,
+            push_active: push_height.is_some(),
         }
     }
 
@@ -116,6 +128,8 @@ impl App {
         let in_plan = self.state.mode == Mode::Plan;
         if self.permission_prompt.is_open() {
             self.permission_prompt.view(frame, layout.bottom_area);
+        } else if layout.push_active {
+            self.float_mgr.view_bottom_split(frame, layout.bottom_area);
         } else if !self.is_main_chat() {
             let todo_h = self.chats[self.active_chat].todo_panel.height();
             let (todo_area, sep_area) = if todo_h > 0 {
@@ -323,6 +337,23 @@ impl App {
             let sel = *sel;
             self.copy_selection(frame.buffer_mut(), &sel, render_chat);
         }
+    }
+
+    /// Layout geometry for tests: `(msg_area, bottom_area, status_area,
+    /// input_area, push_present)`.
+    #[cfg(test)]
+    pub(super) fn layout_geometry(&self, area: Rect) -> (Rect, Rect, Rect, Rect, bool) {
+        let in_plan = self.state.mode == Mode::Plan;
+        let form_visible =
+            self.permission_prompt.is_open() || (in_plan && self.plan_form.is_visible());
+        let layout = self.compute_layout(area, form_visible);
+        (
+            layout.msg_area,
+            layout.bottom_area,
+            layout.status_area,
+            layout.input_area,
+            layout.push_active,
+        )
     }
 
     #[cfg(test)]

--- a/maki-ui/src/components/lua_float.rs
+++ b/maki-ui/src/components/lua_float.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crossterm::event::KeyEvent;
 use maki_agent::{SharedBuf, SnapshotLine};
-use maki_lua::{Anchor, Border, FloatConfig, TitlePos, WinCommand, WinEvent};
+use maki_lua::{Anchor, Border, FloatConfig, Split, TitlePos, WinCommand, WinEvent};
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::text::{Line, Span};
@@ -14,9 +14,13 @@ use crate::components::{
 };
 use crate::theme;
 
-/// Splits the lines into a top band, a bottom band, and the scrollable middle.
-/// When the window is too short to fit both bands, the bottom wins so footers
-/// like keybind hints stay on screen even if the header gets squeezed out.
+/// Rows a bottom split always leaves behind so the chat and status bar never
+/// get pushed off screen.
+pub(crate) const MIN_CHAT_AND_STATUS_ROWS: u16 = 3;
+
+/// A top band, a bottom band, and the scrollable middle. When the window is too
+/// short for both bands the bottom wins, so footers like keybind hints survive
+/// even when the header gets squeezed out.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 struct Layout {
     reserved_top: usize,
@@ -140,6 +144,35 @@ impl FloatManager {
         }
     }
 
+    fn split_window_idx(&self) -> Option<usize> {
+        self.windows
+            .iter()
+            .position(|w| w.config.split == Split::Below)
+    }
+
+    /// The one path windows take to leave the manager. Routing every removal
+    /// here is what keeps the close event, the window list, and `focused_id`
+    /// from ever drifting apart.
+    fn remove_windows(&mut self, should_remove: impl Fn(&FloatWindow) -> bool) {
+        let focus_lost = self
+            .focused_id
+            .and_then(|fid| self.windows.iter().find(|w| w.id == fid))
+            .is_some_and(&should_remove);
+
+        self.windows.retain(|w| {
+            let remove = should_remove(w);
+            if remove {
+                let _ = w.event_tx.try_send(WinEvent::Close);
+            }
+            !remove
+        });
+
+        if focus_lost {
+            self.focused_id = self.windows.last().map(|w| w.id);
+            self.focused_rect = None;
+        }
+    }
+
     pub fn open(
         &mut self,
         buf: Arc<SharedBuf>,
@@ -151,6 +184,12 @@ impl FloatManager {
         let cached_lines = buf.read_if_dirty().unwrap_or_default();
         let id = self.next_id;
         self.next_id += 1;
+
+        // Only one bottom split at a time, so evict the old one through the same
+        // removal path that guarantees it hears about its close.
+        if config.split == Split::Below {
+            self.remove_windows(|w| w.config.split == Split::Below);
+        }
 
         let win = FloatWindow {
             id,
@@ -190,28 +229,17 @@ impl FloatManager {
                     Ok(WinCommand::SetCursor(row)) => {
                         win.set_cursor(row);
                     }
-                    Ok(WinCommand::Close) => {
-                        let _ = win.event_tx.try_send(WinEvent::Close);
+                    Ok(WinCommand::Close) | Err(flume::TryRecvError::Disconnected) => {
                         closed_ids.push(win.id);
                         break;
                     }
                     Err(flume::TryRecvError::Empty) => break,
-                    Err(flume::TryRecvError::Disconnected) => {
-                        closed_ids.push(win.id);
-                        break;
-                    }
                 }
             }
         }
 
         if !closed_ids.is_empty() {
-            self.windows.retain(|w| !closed_ids.contains(&w.id));
-            if let Some(fid) = self.focused_id
-                && !self.windows.iter().any(|w| w.id == fid)
-            {
-                self.focused_id = self.windows.last().map(|w| w.id);
-                self.focused_rect = None;
-            }
+            self.remove_windows(|w| closed_ids.contains(&w.id));
         }
     }
 
@@ -245,160 +273,190 @@ impl FloatManager {
 
     pub fn view(&mut self, frame: &mut Frame, area: Rect) -> Rect {
         let mut union = Rect::default();
-        let t = theme::current();
 
-        for win in &mut self.windows {
-            let popup = resolve_rect(&win.config, area);
+        for idx in 0..self.windows.len() {
+            if self.windows[idx].config.split != Split::None {
+                continue;
+            }
+            let popup = resolve_rect(&self.windows[idx].config, area);
             if popup.width == 0 || popup.height == 0 {
                 continue;
             }
-
-            frame.render_widget(Clear, popup);
-
-            let border_type = match win.config.border {
-                Border::None => None,
-                Border::Single => Some(BorderType::Plain),
-                Border::Double => Some(BorderType::Double),
-                Border::Rounded => Some(BorderType::Rounded),
-            };
-
-            let block = if let Some(bt) = border_type {
-                let mut b = Block::default()
-                    .borders(Borders::ALL)
-                    .border_type(bt)
-                    .border_style(t.panel_border)
-                    .style(ratatui::style::Style::new().bg(t.background));
-
-                if !win.config.title.is_empty() {
-                    let alignment = match win.config.title_pos {
-                        TitlePos::Left => ratatui::layout::Alignment::Left,
-                        TitlePos::Center => ratatui::layout::Alignment::Center,
-                        TitlePos::Right => ratatui::layout::Alignment::Right,
-                    };
-                    b = b
-                        .title(win.config.title.as_str())
-                        .title_alignment(alignment)
-                        .title_style(t.panel_title);
-                }
-                b
-            } else {
-                Block::default().style(ratatui::style::Style::new().bg(t.background))
-            };
-
-            let inner = block.inner(popup);
-            frame.render_widget(block, popup);
-
-            let footer_h = u16::from(!win.config.footer.is_empty());
-            let content_area = if footer_h > 0 && inner.height > footer_h {
-                let footer_rect = Rect {
-                    x: inner.x,
-                    y: inner.y + inner.height - footer_h,
-                    width: inner.width,
-                    height: footer_h,
-                };
-                frame.render_widget(hint_line(&win.config.footer), footer_rect);
-                Rect {
-                    x: inner.x,
-                    y: inner.y,
-                    width: inner.width,
-                    height: inner.height - footer_h,
-                }
-            } else {
-                inner
-            };
-
-            if win.last_content != content_area {
-                let _ = win.event_tx.try_send(WinEvent::Resize {
-                    width: content_area.width,
-                    height: content_area.height,
-                });
-                win.last_content = content_area;
-            }
-
-            let layout = win.layout();
-            let reserved_top_h = layout.reserved_top as u16;
-            let reserved_bot_h = layout.reserved_bot as u16;
-            let chrome_h = reserved_top_h + reserved_bot_h;
-
-            let (pinned_top_area, scroll_area, pinned_bot_area) =
-                if chrome_h > 0 && content_area.height > chrome_h {
-                    let top_area = (layout.reserved_top > 0).then_some(Rect {
-                        x: content_area.x,
-                        y: content_area.y,
-                        width: content_area.width,
-                        height: reserved_top_h,
-                    });
-                    let sa = Rect {
-                        x: content_area.x,
-                        y: content_area.y + reserved_top_h,
-                        width: content_area.width,
-                        height: content_area.height - chrome_h,
-                    };
-                    let bot_area = (layout.reserved_bot > 0).then_some(Rect {
-                        x: content_area.x,
-                        y: sa.y + sa.height,
-                        width: content_area.width,
-                        height: reserved_bot_h,
-                    });
-                    (top_area, sa, bot_area)
-                } else {
-                    (None, content_area, None)
-                };
-
-            win.refresh_layout(scroll_area.height);
-            let top = layout.reserved_top;
-            let scrollable = layout.scrollable;
-
-            let vh = win.viewport_h as usize;
-            let end = (top + win.scroll_offset + vh).min(top + scrollable);
-            let visible = &win.cached_lines[top + win.scroll_offset..end];
-
-            let lines: Vec<Line<'_>> = visible
-                .iter()
-                .enumerate()
-                .map(|(i, sline)| {
-                    let mut line = snapshot_to_line(sline);
-                    if win.config.cursor_line && top + win.scroll_offset + i == win.cursor {
-                        line = line.style(t.cmd_selected);
-                    }
-                    line
-                })
-                .collect();
-
-            frame.render_widget(Paragraph::new(lines), scroll_area);
-
-            if let Some(pa) = pinned_top_area {
-                let pinned: Vec<Line<'_>> = win.cached_lines[..top]
-                    .iter()
-                    .map(snapshot_to_line)
-                    .collect();
-                frame.render_widget(Paragraph::new(pinned), pa);
-            }
-
-            if let Some(pa) = pinned_bot_area {
-                let pinned: Vec<Line<'_>> = win.cached_lines[top + scrollable..]
-                    .iter()
-                    .map(snapshot_to_line)
-                    .collect();
-                frame.render_widget(Paragraph::new(pinned), pa);
-            }
-
-            if scrollable as u16 > win.viewport_h {
-                render_vertical_scrollbar(
-                    frame,
-                    scroll_area,
-                    scrollable as u16,
-                    win.scroll_offset as u16,
-                );
-            }
-
-            if Some(win.id) == self.focused_id {
-                self.focused_rect = Some(popup);
-            }
+            self.render_window(frame, idx, popup);
             union = union_rect(union, popup);
         }
 
         union
+    }
+
+    /// The single source of truth for push height. The app layout asks here so
+    /// the rows it reserves and the rows we draw into can never disagree.
+    pub fn bottom_split_height(&self, area: Rect) -> Option<u16> {
+        let win = &self.windows[self.split_window_idx()?];
+        let max = area.height.saturating_sub(MIN_CHAT_AND_STATUS_ROWS);
+        Some(win.config.height.resolve(area.height).min(max))
+    }
+
+    /// Draws into the rect the layout hands us, untouched. The layout owns the
+    /// geometry; we only fill it.
+    pub fn view_bottom_split(&mut self, frame: &mut Frame, rect: Rect) {
+        let Some(idx) = self.split_window_idx() else {
+            return;
+        };
+        if rect.width == 0 || rect.height == 0 {
+            return;
+        }
+        // render_window only records focused_rect for the focused window, which
+        // keeps mouse hit-testing from ever landing on an unfocused split.
+        self.render_window(frame, idx, rect);
+    }
+
+    fn render_window(&mut self, frame: &mut Frame, idx: usize, popup: Rect) {
+        let t = theme::current();
+        let win = &mut self.windows[idx];
+
+        frame.render_widget(Clear, popup);
+
+        let border_type = match win.config.border {
+            Border::None => None,
+            Border::Single => Some(BorderType::Plain),
+            Border::Double => Some(BorderType::Double),
+            Border::Rounded => Some(BorderType::Rounded),
+        };
+
+        let block = if let Some(bt) = border_type {
+            let mut b = Block::default()
+                .borders(Borders::ALL)
+                .border_type(bt)
+                .border_style(t.panel_border)
+                .style(ratatui::style::Style::new().bg(t.background));
+
+            if !win.config.title.is_empty() {
+                let alignment = match win.config.title_pos {
+                    TitlePos::Left => ratatui::layout::Alignment::Left,
+                    TitlePos::Center => ratatui::layout::Alignment::Center,
+                    TitlePos::Right => ratatui::layout::Alignment::Right,
+                };
+                b = b
+                    .title(win.config.title.as_str())
+                    .title_alignment(alignment)
+                    .title_style(t.panel_title);
+            }
+            b
+        } else {
+            Block::default().style(ratatui::style::Style::new().bg(t.background))
+        };
+
+        let inner = block.inner(popup);
+        frame.render_widget(block, popup);
+
+        let footer_h = u16::from(!win.config.footer.is_empty());
+        let content_area = if footer_h > 0 && inner.height > footer_h {
+            let footer_rect = Rect {
+                x: inner.x,
+                y: inner.y + inner.height - footer_h,
+                width: inner.width,
+                height: footer_h,
+            };
+            frame.render_widget(hint_line(&win.config.footer), footer_rect);
+            Rect {
+                x: inner.x,
+                y: inner.y,
+                width: inner.width,
+                height: inner.height - footer_h,
+            }
+        } else {
+            inner
+        };
+
+        if win.last_content != content_area {
+            let _ = win.event_tx.try_send(WinEvent::Resize {
+                width: content_area.width,
+                height: content_area.height,
+            });
+            win.last_content = content_area;
+        }
+
+        let layout = win.layout();
+        let reserved_top_h = layout.reserved_top as u16;
+        let reserved_bot_h = layout.reserved_bot as u16;
+        let chrome_h = reserved_top_h + reserved_bot_h;
+
+        let (pinned_top_area, scroll_area, pinned_bot_area) =
+            if chrome_h > 0 && content_area.height > chrome_h {
+                let top_area = (layout.reserved_top > 0).then_some(Rect {
+                    x: content_area.x,
+                    y: content_area.y,
+                    width: content_area.width,
+                    height: reserved_top_h,
+                });
+                let sa = Rect {
+                    x: content_area.x,
+                    y: content_area.y + reserved_top_h,
+                    width: content_area.width,
+                    height: content_area.height - chrome_h,
+                };
+                let bot_area = (layout.reserved_bot > 0).then_some(Rect {
+                    x: content_area.x,
+                    y: sa.y + sa.height,
+                    width: content_area.width,
+                    height: reserved_bot_h,
+                });
+                (top_area, sa, bot_area)
+            } else {
+                (None, content_area, None)
+            };
+
+        win.refresh_layout(scroll_area.height);
+        let top = layout.reserved_top;
+        let scrollable = layout.scrollable;
+
+        let vh = win.viewport_h as usize;
+        let end = (top + win.scroll_offset + vh).min(top + scrollable);
+        let visible = &win.cached_lines[top + win.scroll_offset..end];
+
+        let lines: Vec<Line<'_>> = visible
+            .iter()
+            .enumerate()
+            .map(|(i, sline)| {
+                let mut line = snapshot_to_line(sline);
+                if win.config.cursor_line && top + win.scroll_offset + i == win.cursor {
+                    line = line.style(t.cmd_selected);
+                }
+                line
+            })
+            .collect();
+
+        frame.render_widget(Paragraph::new(lines), scroll_area);
+
+        if let Some(pa) = pinned_top_area {
+            let pinned: Vec<Line<'_>> = win.cached_lines[..top]
+                .iter()
+                .map(snapshot_to_line)
+                .collect();
+            frame.render_widget(Paragraph::new(pinned), pa);
+        }
+
+        if let Some(pa) = pinned_bot_area {
+            let pinned: Vec<Line<'_>> = win.cached_lines[top + scrollable..]
+                .iter()
+                .map(snapshot_to_line)
+                .collect();
+            frame.render_widget(Paragraph::new(pinned), pa);
+        }
+
+        if scrollable as u16 > win.viewport_h {
+            render_vertical_scrollbar(
+                frame,
+                scroll_area,
+                scrollable as u16,
+                win.scroll_offset as u16,
+            );
+        }
+
+        if Some(win.id) == self.focused_id {
+            self.focused_rect = Some(popup);
+        }
     }
 
     pub fn contains(&self, pos: ratatui::layout::Position) -> bool {
@@ -420,12 +478,7 @@ impl FloatManager {
     }
 
     pub fn close_all(&mut self) {
-        for win in &self.windows {
-            let _ = win.event_tx.try_send(WinEvent::Close);
-        }
-        self.windows.clear();
-        self.focused_id = None;
-        self.focused_rect = None;
+        self.remove_windows(|_| true);
     }
 }
 
@@ -1503,5 +1556,304 @@ mod tests {
             op(&mut win);
             assert_invariants(&win);
         }
+    }
+
+    const EXPECT_NO_SPLIT: &str = "expected no bottom split height without a Below window";
+    const EXPECT_SINGLE_SPLIT: &str = "expected exactly one Below window after re-open";
+    const EXPECT_SPLIT_DRAWN: &str = "expected the split window to receive its layout rect";
+
+    fn split_config(height: Dimension) -> FloatConfig {
+        FloatConfig {
+            height,
+            border: Border::None,
+            split: Split::Below,
+            ..FloatConfig::default()
+        }
+    }
+
+    fn render_into(
+        mgr: &mut FloatManager,
+        area: Rect,
+        f: impl FnOnce(&mut FloatManager, &mut Frame),
+    ) {
+        let backend = ratatui::backend::TestBackend::new(area.width, area.height);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal.draw(|frame| f(mgr, frame)).unwrap();
+    }
+
+    #[test]
+    fn bottom_split_height_none_without_split_window() {
+        let mut mgr = FloatManager::new();
+        open_with_lines(&mut mgr, &["a"]);
+        let area = Rect::new(0, 0, 80, 40);
+        assert!(mgr.bottom_split_height(area).is_none(), "{EXPECT_NO_SPLIT}");
+    }
+
+    #[test]
+    fn bottom_split_height_resolves_and_clamps() {
+        let mut mgr = FloatManager::new();
+        let (event_tx, cmd_rx, _erx, _ctx) = make_channels();
+        mgr.open(
+            make_buf(&["a"]),
+            split_config(Dimension::Abs(10)),
+            true,
+            event_tx,
+            cmd_rx,
+        );
+        let area = Rect::new(0, 0, 80, 40);
+        assert_eq!(mgr.bottom_split_height(area), Some(10));
+
+        let area_tight = Rect::new(0, 0, 80, 8);
+        assert_eq!(
+            mgr.bottom_split_height(area_tight),
+            Some(8 - MIN_CHAT_AND_STATUS_ROWS),
+            "height clamps to area.height - MIN_CHAT_AND_STATUS_ROWS",
+        );
+    }
+
+    #[test]
+    fn view_skips_split_window() {
+        let mut mgr = FloatManager::new();
+        let (event_tx, cmd_rx, event_rx, _ctx) = make_channels();
+        mgr.open(
+            make_buf(&["hello"]),
+            split_config(Dimension::Abs(10)),
+            true,
+            event_tx,
+            cmd_rx,
+        );
+        let area = Rect::new(0, 0, 80, 40);
+        render_into(&mut mgr, area, |m, f| {
+            let u = m.view(f, area);
+            assert_eq!(u, Rect::default(), "overlay pass must not draw the split");
+        });
+        assert!(
+            !event_rx
+                .drain()
+                .any(|e| matches!(e, WinEvent::Resize { .. })),
+            "{EXPECT_SPLIT_DRAWN}: overlay pass must leave it undrawn",
+        );
+    }
+
+    #[test]
+    fn view_bottom_split_draws_into_given_rect() {
+        let mut mgr = FloatManager::new();
+        let (event_tx, cmd_rx, event_rx, _ctx) = make_channels();
+        mgr.open(
+            make_buf(&["hello"]),
+            split_config(Dimension::Abs(10)),
+            true,
+            event_tx,
+            cmd_rx,
+        );
+        let area = Rect::new(0, 0, 80, 40);
+        let rect = Rect::new(0, 30, 80, 10);
+        render_into(&mut mgr, area, |m, f| m.view_bottom_split(f, rect));
+
+        let resize = event_rx
+            .drain()
+            .find_map(|e| match e {
+                WinEvent::Resize { width, height } => Some((width, height)),
+                _ => None,
+            })
+            .expect(EXPECT_SPLIT_DRAWN);
+        assert_eq!(resize, (rect.width, rect.height), "{EXPECT_SPLIT_DRAWN}");
+        assert!(
+            mgr.contains(ratatui::layout::Position::new(rect.x + 1, rect.y + 1)),
+            "scroll/contains must target the pushed area",
+        );
+    }
+
+    #[test]
+    fn second_split_replaces_first() {
+        let mut mgr = FloatManager::new();
+        let (tx1, rx1, erx1, _ctx1) = make_channels();
+        mgr.open(
+            make_buf(&["a"]),
+            split_config(Dimension::Abs(5)),
+            true,
+            tx1,
+            rx1,
+        );
+
+        let (tx2, rx2, _erx2, _ctx2) = make_channels();
+        mgr.open(
+            make_buf(&["b"]),
+            split_config(Dimension::Abs(5)),
+            true,
+            tx2,
+            rx2,
+        );
+
+        let split_count = mgr
+            .windows
+            .iter()
+            .filter(|w| w.config.split == Split::Below)
+            .count();
+        assert_eq!(split_count, 1, "{EXPECT_SINGLE_SPLIT}");
+        assert!(
+            erx1.drain().any(|e| matches!(e, WinEvent::Close)),
+            "the replaced split must receive a Close event",
+        );
+    }
+
+    const EXPECT_UNFOCUSED_NO_RECT: &str =
+        "an unfocused split must not claim focused_rect (mouse hit-testing target)";
+    const EXPECT_FOCUS_RECOVERS: &str =
+        "removing the focused window must hand focus to a surviving window";
+
+    #[test]
+    fn unfocused_split_does_not_claim_focused_rect() {
+        let mut mgr = FloatManager::new();
+        let (event_tx, cmd_rx, _erx, _ctx) = make_channels();
+        mgr.open(
+            make_buf(&["hello"]),
+            split_config(Dimension::Abs(10)),
+            false,
+            event_tx,
+            cmd_rx,
+        );
+        let area = Rect::new(0, 0, 80, 40);
+        let rect = Rect::new(0, 30, 80, 10);
+        render_into(&mut mgr, area, |m, f| m.view_bottom_split(f, rect));
+        assert!(
+            !mgr.contains(ratatui::layout::Position::new(rect.x + 1, rect.y + 1)),
+            "{EXPECT_UNFOCUSED_NO_RECT}",
+        );
+    }
+
+    #[test]
+    fn removing_focused_window_recovers_focus_to_survivor() {
+        let mut mgr = FloatManager::new();
+        let (tx1, rx1, _erx1, _ctx1) = make_channels();
+        mgr.open(make_buf(&["a"]), FloatConfig::default(), false, tx1, rx1);
+        let survivor = mgr.windows[0].id;
+
+        let (tx2, rx2, _erx2, _ctx2) = make_channels();
+        mgr.open(
+            make_buf(&["b"]),
+            split_config(Dimension::Abs(5)),
+            true,
+            tx2,
+            rx2,
+        );
+
+        mgr.remove_windows(|w| w.config.split == Split::Below);
+        assert_eq!(mgr.focused_id, Some(survivor), "{EXPECT_FOCUS_RECOVERS}");
+    }
+
+    const EXPECT_ZERO_RECT_NOOP: &str =
+        "a zero-size rect must skip drawing: no Resize, no focused_rect";
+    const EXPECT_HAS_SPLIT: &str = "a Below window exists regardless of its resolved height";
+    const EXPECT_CLOSE_TO_SPLIT: &str = "close_all must send Close to the Below split window";
+
+    #[test_case(Rect::new(0, 30, 80, 0) ; "zero_height")]
+    #[test_case(Rect::new(0, 30, 0, 10) ; "zero_width")]
+    fn view_bottom_split_zero_size_rect_is_noop(rect: Rect) {
+        let mut mgr = FloatManager::new();
+        let (event_tx, cmd_rx, event_rx, _ctx) = make_channels();
+        mgr.open(
+            make_buf(&["hello"]),
+            split_config(Dimension::Abs(10)),
+            true,
+            event_tx,
+            cmd_rx,
+        );
+        let area = Rect::new(0, 0, 80, 40);
+        render_into(&mut mgr, area, |m, f| m.view_bottom_split(f, rect));
+
+        assert!(
+            !event_rx
+                .drain()
+                .any(|e| matches!(e, WinEvent::Resize { .. })),
+            "{EXPECT_ZERO_RECT_NOOP}",
+        );
+        assert!(
+            !mgr.contains(ratatui::layout::Position::new(rect.x, rect.y)),
+            "{EXPECT_ZERO_RECT_NOOP}",
+        );
+    }
+
+    #[test]
+    fn view_overlays_float_and_skips_coexisting_split() {
+        let mut mgr = FloatManager::new();
+        let (ftx, frx, ferx, _fctx) = make_channels();
+        mgr.open(
+            make_buf(&["float"]),
+            FloatConfig {
+                width: Dimension::Abs(20),
+                height: Dimension::Abs(10),
+                ..FloatConfig::default()
+            },
+            true,
+            ftx,
+            frx,
+        );
+
+        let (stx, srx, serx, _sctx) = make_channels();
+        mgr.open(
+            make_buf(&["split"]),
+            split_config(Dimension::Abs(10)),
+            false,
+            stx,
+            srx,
+        );
+
+        let area = Rect::new(0, 0, 80, 40);
+        render_into(&mut mgr, area, |m, f| {
+            let u = m.view(f, area);
+            assert_ne!(u, Rect::default(), "overlay pass must draw the float");
+        });
+
+        assert!(
+            ferx.drain().any(|e| matches!(e, WinEvent::Resize { .. })),
+            "the float must be drawn by the overlay pass",
+        );
+        assert!(
+            !serx.drain().any(|e| matches!(e, WinEvent::Resize { .. })),
+            "{EXPECT_SPLIT_DRAWN}: overlay pass must skip the split",
+        );
+
+        let rect = Rect::new(0, 30, 80, 10);
+        render_into(&mut mgr, area, |m, f| m.view_bottom_split(f, rect));
+        assert!(
+            serx.drain().any(|e| matches!(e, WinEvent::Resize { .. })),
+            "{EXPECT_SPLIT_DRAWN}: split joins layout via view_bottom_split",
+        );
+    }
+
+    #[test]
+    fn bottom_split_height_zero_config_is_some() {
+        let mut mgr = FloatManager::new();
+        let (event_tx, cmd_rx, _erx, _ctx) = make_channels();
+        mgr.open(
+            make_buf(&["a"]),
+            split_config(Dimension::Abs(0)),
+            true,
+            event_tx,
+            cmd_rx,
+        );
+        let area = Rect::new(0, 0, 80, 40);
+        assert_eq!(mgr.bottom_split_height(area), Some(0), "{EXPECT_HAS_SPLIT}");
+    }
+
+    #[test]
+    fn close_all_notifies_split_window() {
+        let mut mgr = FloatManager::new();
+        let (event_tx, cmd_rx, event_rx, _ctx) = make_channels();
+        mgr.open(
+            make_buf(&["a"]),
+            split_config(Dimension::Abs(10)),
+            true,
+            event_tx,
+            cmd_rx,
+        );
+
+        mgr.close_all();
+        assert!(!mgr.is_open(), "{EXPECT_CLOSED}");
+        assert!(
+            event_rx.drain().any(|e| matches!(e, WinEvent::Close)),
+            "{EXPECT_CLOSE_TO_SPLIT}",
+        );
     }
 }

--- a/plugins/question/question_form.lua
+++ b/plugins/question/question_form.lua
@@ -597,8 +597,7 @@ function QuestionForm.open(questions)
     border = "rounded",
     reserved_bottom = 1,
     focus = true,
-    anchor = "SW",
-    row = -1,
+    split = "below",
   })
 
   local width = win.width

--- a/plugins/question/tests/spec.lua
+++ b/plugins/question/tests/spec.lua
@@ -522,6 +522,37 @@ case("render_selecting_long_label_and_desc_wrap_within_width", function()
   end
 end)
 
+case("open_requests_bottom_split", function()
+  local original_open = maki.ui.open_win
+  local original_buf = maki.ui.buf
+  local original_size = maki.ui.terminal_size
+  local captured
+  maki.ui.open_win = function(_buf, opts)
+    captured = opts
+    return {
+      width = 80,
+      set_config = function() end,
+      set_cursor = function() end,
+      recv = function()
+        return { type = "close" }
+      end,
+    }
+  end
+  maki.ui.buf = function()
+    return { set_lines = function() end }
+  end
+  maki.ui.terminal_size = function()
+    return { rows = 40, cols = 100 }
+  end
+  local ok, err = pcall(QuestionForm.open, single_question())
+  maki.ui.open_win = original_open
+  maki.ui.buf = original_buf
+  maki.ui.terminal_size = original_size
+  assert(ok, "open must not error: " .. tostring(err))
+  assert(captured, "open_win must be called")
+  eq(captured.split, "below", "form must request a bottom split")
+end)
+
 if #failures > 0 then
   error(#failures .. " case(s) failed:\n\n" .. table.concat(failures, "\n\n"))
 end


### PR DESCRIPTION
The question popup used to float on top of the chat as an overlay.  Now it joins the layout like the permission prompt: it reserves rows at the bottom, sits right above the status bar in place of the input box, and the chat shrinks to end exactly where the form begins.

We expose this through `maki.ui.open_win` with a neovim style `split = "below"` option, so any window can opt in. Layout is the single owner of the rect, `FloatManager` only renders into what it is handed and computes height in one place, so the reserved space and the drawn space can never drift.

Only one bottom split may exist at a time, enforced on open, and a real float still overlays on top because the overlay pass now skips split windows.