### PR TITLE
ui: extend window `split` to all four neovim directions

### DIFF
--- a/maki-lua/src/api/command.rs
+++ b/maki-lua/src/api/command.rs
@@ -148,16 +148,68 @@ impl Border {
 pub enum Split {
     #[default]
     None,
+    Above,
     Below,
+    Left,
+    Right,
+}
+
+/// The renderer and layout read `Axis` rather than matching on `Split`, so a
+/// new direction never needs a new match arm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Axis {
+    /// Reserves rows: a band on the top or bottom edge.
+    Vertical,
+    /// Reserves columns: a band on the left or right edge.
+    Horizontal,
+}
+
+/// `at_start` means the top or left edge, otherwise the bottom or right.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Edge {
+    pub axis: Axis,
+    pub at_start: bool,
 }
 
 impl Split {
     pub fn parse(s: &str) -> Self {
         match s {
+            "above" => Self::Above,
             "below" => Self::Below,
+            "left" => Self::Left,
+            "right" => Self::Right,
             _ => Self::None,
         }
     }
+
+    /// The one place a direction turns into geometry, so the mapping lives in a
+    /// single spot. `None` means the split is off.
+    pub fn edge(self) -> Option<Edge> {
+        Some(match self {
+            Self::None => return None,
+            Self::Above => Edge {
+                axis: Axis::Vertical,
+                at_start: true,
+            },
+            Self::Below => Edge {
+                axis: Axis::Vertical,
+                at_start: false,
+            },
+            Self::Left => Edge {
+                axis: Axis::Horizontal,
+                at_start: true,
+            },
+            Self::Right => Edge {
+                axis: Axis::Horizontal,
+                at_start: false,
+            },
+        })
+    }
+
+    /// Every real direction, in carve order: columns before rows. Callers loop
+    /// over this so they stay exhaustive without a match. It is hand-written, so
+    /// `all_lists_exactly_the_edge_bearing_variants` keeps it honest.
+    pub const ALL: [Split; 4] = [Split::Left, Split::Right, Split::Above, Split::Below];
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -386,13 +438,41 @@ mod tests {
         TitlePos::parse(s)
     }
 
+    #[test_case("above" => Split::Above ; "above")]
     #[test_case("below" => Split::Below ; "below")]
+    #[test_case("left" => Split::Left ; "left")]
+    #[test_case("right" => Split::Right ; "right")]
     #[test_case("none" => Split::None ; "none")]
     #[test_case("" => Split::None ; "empty_defaults_none")]
     #[test_case("Below" => Split::None ; "exact_match_is_case_sensitive")]
     #[test_case("garbage" => Split::None ; "unknown_defaults_none")]
     fn split_parse(s: &str) -> Split {
         Split::parse(s)
+    }
+
+    #[test_case(Split::None => None ; "none_has_no_edge")]
+    #[test_case(Split::Above => Some(Edge { axis: Axis::Vertical, at_start: true }) ; "above_is_vertical_start")]
+    #[test_case(Split::Below => Some(Edge { axis: Axis::Vertical, at_start: false }) ; "below_is_vertical_end")]
+    #[test_case(Split::Left => Some(Edge { axis: Axis::Horizontal, at_start: true }) ; "left_is_horizontal_start")]
+    #[test_case(Split::Right => Some(Edge { axis: Axis::Horizontal, at_start: false }) ; "right_is_horizontal_end")]
+    fn split_edge(split: Split) -> Option<Edge> {
+        split.edge()
+    }
+
+    /// A variant belongs in `ALL` exactly when it carries an edge, so a dropped
+    /// direction can never ship. The case list is exhaustive: add a variant and
+    /// this fails until `ALL` agrees.
+    #[test_case(Split::None)]
+    #[test_case(Split::Above)]
+    #[test_case(Split::Below)]
+    #[test_case(Split::Left)]
+    #[test_case(Split::Right)]
+    fn all_lists_exactly_the_edge_bearing_variants(variant: Split) {
+        assert_eq!(
+            variant.edge().is_some(),
+            Split::ALL.contains(&variant),
+            "{variant:?}: edge-bearing variants belong in ALL, others must not",
+        );
     }
 
     #[test]

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -5,8 +5,8 @@ mod loader;
 mod runtime;
 
 pub use api::command::{
-    Anchor, Border, Dimension, FloatConfig, FloatConfigPatch, LuaCommandInfo, LuaCommandReader,
-    Split, TitlePos, UiAction, WinCommand, WinEvent,
+    Anchor, Axis, Border, Dimension, Edge, FloatConfig, FloatConfigPatch, LuaCommandInfo,
+    LuaCommandReader, Split, TitlePos, UiAction, WinCommand, WinEvent,
 };
 pub use error::PluginError;
 pub use loader::{EventHandle, PluginHost};

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -2483,14 +2483,15 @@ const TEST_AREA: Rect = Rect {
     width: 80,
     height: 40,
 };
-const SPLIT_HEIGHT: u16 = 8;
+const SPLIT_EXTENT: u16 = 8;
 
-fn open_split_window(app: &mut App) {
+fn open_split_window(app: &mut App, dir: maki_lua::Split) {
     let buf = Arc::new(maki_agent::SharedBuf::new());
     let config = maki_lua::FloatConfig {
-        height: maki_lua::Dimension::Abs(SPLIT_HEIGHT),
+        width: maki_lua::Dimension::Abs(SPLIT_EXTENT),
+        height: maki_lua::Dimension::Abs(SPLIT_EXTENT),
         border: maki_lua::Border::None,
-        split: maki_lua::Split::Below,
+        split: dir,
         ..maki_lua::FloatConfig::default()
     };
     let (event_tx, _event_rx) = flume::bounded::<maki_lua::WinEvent>(8);
@@ -2499,52 +2500,91 @@ fn open_split_window(app: &mut App) {
 }
 
 #[test]
-fn push_window_reserves_bottom_and_suppresses_input() {
+fn below_split_reserves_bottom_and_suppresses_input() {
     let mut app = test_app();
-    let (msg_before, _b, _s, input_before, push_before) = app.layout_geometry(TEST_AREA);
-    assert!(!push_before, "no push window open yet");
-    assert!(input_before.height > 0, "input box visible before push");
+    let (msg_before, _b, _s, input_before, splits_before) = app.layout_geometry(TEST_AREA);
+    assert!(
+        splits_before.rect(maki_lua::Split::Below).is_none(),
+        "no split open yet"
+    );
+    assert!(input_before.height > 0, "input box visible before split");
 
-    open_split_window(&mut app);
-    let (msg_after, bottom_after, _s, input_after, push_after) = app.layout_geometry(TEST_AREA);
+    open_split_window(&mut app, maki_lua::Split::Below);
+    let (msg_after, _bottom, _s, input_after, splits_after) = app.layout_geometry(TEST_AREA);
 
-    assert!(push_after, "push window should reserve the bottom area");
+    let band = splits_after
+        .rect(maki_lua::Split::Below)
+        .expect("below split should reserve a bottom band");
     assert_eq!(
-        bottom_after.height, SPLIT_HEIGHT,
-        "bottom area routes through bottom_split_height",
+        band.height, SPLIT_EXTENT,
+        "below band reserves the requested rows",
     );
     assert!(
         msg_after.height < msg_before.height,
-        "chat must shrink to make room for the push window",
+        "chat must shrink to make room for the below split",
     );
     assert_eq!(
         input_after.height, 0,
-        "input box is suppressed under a push"
+        "input box is suppressed under a below split"
+    );
+}
+
+/// `carve` already tests the per-direction geometry; this pins the app wiring:
+/// a split shrinks the chat while the full-width status bar stays put. Below is
+/// tested separately since it also hides the input box.
+#[test_case(maki_lua::Split::Above ; "above")]
+#[test_case(maki_lua::Split::Left ; "left")]
+#[test_case(maki_lua::Split::Right ; "right")]
+fn non_below_split_reserves_band_and_keeps_status_full_width(dir: maki_lua::Split) {
+    let mut app = test_app();
+    let (msg_before, _b, _s, _i, _sp) = app.layout_geometry(TEST_AREA);
+
+    open_split_window(&mut app, dir);
+    let (msg_after, _bottom, status_after, _input, splits) = app.layout_geometry(TEST_AREA);
+
+    assert!(splits.rect(dir).is_some(), "split must reserve a band");
+    assert!(
+        msg_after.area() < msg_before.area(),
+        "chat must shrink to make room for the split",
+    );
+    assert_eq!(
+        status_after.width, TEST_AREA.width,
+        "status bar stays full width regardless of the split",
     );
 }
 
 #[test]
-fn closing_push_window_restores_input_layout() {
+fn closing_split_restores_layout() {
     let mut app = test_app();
     let before = app.layout_geometry(TEST_AREA);
 
-    open_split_window(&mut app);
+    open_split_window(&mut app, maki_lua::Split::Below);
     app.float_mgr.close_all();
 
     let after = app.layout_geometry(TEST_AREA);
-    assert_eq!(after, before, "closing the push window restores the layout");
+    assert_eq!(after, before, "closing the split restores the layout");
 }
 
 #[test]
-fn permission_prompt_takes_bottom_precedence_over_push() {
+fn permission_prompt_takes_bottom_precedence_over_below_split() {
     let mut app = test_app();
-    open_split_window(&mut app);
+    open_split_window(&mut app, maki_lua::Split::Below);
+    open_split_window(&mut app, maki_lua::Split::Left);
+    open_split_window(&mut app, maki_lua::Split::Above);
     app.permission_prompt
         .open("perm-1".into(), "bash".into(), vec!["ls".into()], None);
 
-    let (_msg, _bottom, _status, _input, push) = app.layout_geometry(TEST_AREA);
+    let (_msg, _bottom, _status, _input, splits) = app.layout_geometry(TEST_AREA);
     assert!(
-        !push,
-        "push must yield the bottom area to an open permission prompt"
+        splits.rect(maki_lua::Split::Below).is_none(),
+        "below split must yield the bottom area to an open permission prompt",
+    );
+    assert!(
+        splits.rect(maki_lua::Split::Left).is_some(),
+        "the prompt must leave a left split untouched",
+    );
+    assert!(
+        splits.rect(maki_lua::Split::Above).is_some(),
+        "the prompt must leave an above split untouched",
     );
 }

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -1,11 +1,12 @@
 use crate::components::Overlay;
 #[cfg(test)]
 use crate::components::keybindings::KeybindContext;
-use crate::components::lua_float::MIN_CHAT_AND_STATUS_ROWS;
 use crate::components::queue_panel;
+use crate::components::split_layout::{MIN_CHAT_ROWS, SplitLayout, carve};
 use crate::components::status_bar::{StatusBarContext, UsageStats};
 use crate::selection::{self, SelectableZone, SelectionZone};
 use crate::theme;
+use maki_lua::Split;
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::widgets::{Block, Borders, Widget};
@@ -19,7 +20,7 @@ struct ViewLayout {
     queue_area: Rect,
     todo_area: Rect,
     input_area: Rect,
-    push_active: bool,
+    splits: SplitLayout,
 }
 
 impl App {
@@ -35,6 +36,7 @@ impl App {
         self.render_background(frame);
         self.render_messages(frame, &layout, render_chat);
         self.render_bottom_panel(frame, &layout);
+        self.render_splits(frame, &layout);
         let mut overlay_rect = self.render_picker_overlays(frame, &layout);
         self.render_status_bar(frame, layout.status_area, render_chat);
         overlay_rect = self.render_top_modals(frame, overlay_rect);
@@ -43,37 +45,47 @@ impl App {
     }
 
     fn compute_layout(&self, area: Rect, form_visible: bool) -> ViewLayout {
-        let max_bottom = area.height.saturating_sub(MIN_CHAT_AND_STATUS_ROWS);
         let permission_open = self.permission_prompt.is_open();
-        // The permission prompt wins the bottom area, so a push window only gets
-        // it when no prompt is open.
-        let push_height = if permission_open {
-            None
-        } else {
-            self.float_mgr.bottom_split_height(area)
-        };
-        let bottom_takeover = form_visible || push_height.is_some();
+
+        // Carve the full-width status bar first so the split carving below only
+        // ever deals with the content region above it.
+        let [content, status_area] =
+            Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(area);
+
+        // The permission prompt owns the bottom area, so drop any `below` split
+        // here at the source. That keeps "prompt wins bottom" in one filter
+        // instead of needing a fix-up further down.
+        let reqs: Vec<_> = self
+            .float_mgr
+            .split_reqs(content)
+            .into_iter()
+            .filter(|r| !(permission_open && r.split == Split::Below))
+            .collect();
+        let splits = carve(content, &reqs);
+        let inner = splits.inner;
+
+        let below_active = splits.rect(Split::Below).is_some();
+        let bottom_takeover = form_visible || below_active;
+        let max_bottom = inner.height.saturating_sub(MIN_CHAT_ROWS);
         let bottom_height = if permission_open {
-            self.permission_prompt.height(area.width).min(max_bottom)
-        } else if let Some(h) = push_height {
-            h
+            self.permission_prompt.height(inner.width).min(max_bottom)
+        } else if below_active {
+            0
         } else if form_visible {
             self.plan_form.height().min(max_bottom)
         } else if self.is_main_chat() {
             queue_panel::height(self.queue.panel_len())
                 + self.chats[self.active_chat].todo_panel.height()
-                + self.input_box.height(area.width)
+                + self.input_box.height(inner.width)
         } else {
             let todo_h = self.chats[self.active_chat].todo_panel.height();
             if todo_h > 0 { todo_h + 1 } else { 1 }
         };
 
-        let [msg_area, bottom_area, status_area] = Layout::vertical([
-            Constraint::Min(1),
-            Constraint::Length(bottom_height),
-            Constraint::Length(1),
-        ])
-        .areas(area);
+        // The `below` split lives outside `inner` (drawn by render_splits), so
+        // the bottom panel only ever splits the chat region.
+        let [msg_area, bottom_area] =
+            Layout::vertical([Constraint::Min(1), Constraint::Length(bottom_height)]).areas(inner);
 
         let (queue_height, todo_h, input_height) = if bottom_takeover {
             (0, 0, 0)
@@ -98,7 +110,7 @@ impl App {
             queue_area,
             todo_area,
             input_area,
-            push_active: push_height.is_some(),
+            splits,
         }
     }
 
@@ -128,8 +140,6 @@ impl App {
         let in_plan = self.state.mode == Mode::Plan;
         if self.permission_prompt.is_open() {
             self.permission_prompt.view(frame, layout.bottom_area);
-        } else if layout.push_active {
-            self.float_mgr.view_bottom_split(frame, layout.bottom_area);
         } else if !self.is_main_chat() {
             let todo_h = self.chats[self.active_chat].todo_panel.height();
             let (todo_area, sep_area) = if todo_h > 0 {
@@ -174,6 +184,14 @@ impl App {
                 panel_hint,
             );
             self.command_palette.view(frame, layout.input_area);
+        }
+    }
+
+    fn render_splits(&mut self, frame: &mut Frame, layout: &ViewLayout) {
+        for dir in Split::ALL {
+            if let Some(rect) = layout.splits.rect(dir) {
+                self.float_mgr.view_split(frame, dir, rect);
+            }
         }
     }
 
@@ -340,9 +358,9 @@ impl App {
     }
 
     /// Layout geometry for tests: `(msg_area, bottom_area, status_area,
-    /// input_area, push_present)`.
+    /// input_area, splits)`.
     #[cfg(test)]
-    pub(super) fn layout_geometry(&self, area: Rect) -> (Rect, Rect, Rect, Rect, bool) {
+    pub(super) fn layout_geometry(&self, area: Rect) -> (Rect, Rect, Rect, Rect, SplitLayout) {
         let in_plan = self.state.mode == Mode::Plan;
         let form_visible =
             self.permission_prompt.is_open() || (in_plan && self.plan_form.is_visible());
@@ -352,7 +370,7 @@ impl App {
             layout.bottom_area,
             layout.status_area,
             layout.input_area,
-            layout.push_active,
+            layout.splits,
         )
     }
 

--- a/maki-ui/src/components/lua_float.rs
+++ b/maki-ui/src/components/lua_float.rs
@@ -2,21 +2,18 @@ use std::sync::Arc;
 
 use crossterm::event::KeyEvent;
 use maki_agent::{SharedBuf, SnapshotLine};
-use maki_lua::{Anchor, Border, FloatConfig, Split, TitlePos, WinCommand, WinEvent};
+use maki_lua::{Anchor, Axis, Border, FloatConfig, Split, TitlePos, WinCommand, WinEvent};
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph};
 
+use crate::components::split_layout::SplitReq;
 use crate::components::{
     Overlay, hint_line, keybindings::key_event_to_string, scrollbar::render_vertical_scrollbar,
     tool_display::resolve_span_style,
 };
 use crate::theme;
-
-/// Rows a bottom split always leaves behind so the chat and status bar never
-/// get pushed off screen.
-pub(crate) const MIN_CHAT_AND_STATUS_ROWS: u16 = 3;
 
 /// A top band, a bottom band, and the scrollable middle. When the window is too
 /// short for both bands the bottom wins, so footers like keybind hints survive
@@ -144,10 +141,8 @@ impl FloatManager {
         }
     }
 
-    fn split_window_idx(&self) -> Option<usize> {
-        self.windows
-            .iter()
-            .position(|w| w.config.split == Split::Below)
+    fn split_window_idx(&self, dir: Split) -> Option<usize> {
+        self.windows.iter().position(|w| w.config.split == dir)
     }
 
     /// The one path windows take to leave the manager. Routing every removal
@@ -185,10 +180,11 @@ impl FloatManager {
         let id = self.next_id;
         self.next_id += 1;
 
-        // Only one bottom split at a time, so evict the old one through the same
-        // removal path that guarantees it hears about its close.
-        if config.split == Split::Below {
-            self.remove_windows(|w| w.config.split == Split::Below);
+        // One split per direction, so evicting the old same-direction window
+        // goes through the same removal path that guarantees it hears its close.
+        if config.split != Split::None {
+            let dir = config.split;
+            self.remove_windows(|w| w.config.split == dir);
         }
 
         let win = FloatWindow {
@@ -289,25 +285,33 @@ impl FloatManager {
         union
     }
 
-    /// The single source of truth for push height. The app layout asks here so
-    /// the rows it reserves and the rows we draw into can never disagree.
-    pub fn bottom_split_height(&self, area: Rect) -> Option<u16> {
-        let win = &self.windows[self.split_window_idx()?];
-        let max = area.height.saturating_sub(MIN_CHAT_AND_STATUS_ROWS);
-        Some(win.config.height.resolve(area.height).min(max))
+    /// Turns each open split's requested Dimension into a cell count. `carve`
+    /// then clamps that against the chat minimum.
+    pub fn split_reqs(&self, area: Rect) -> Vec<SplitReq> {
+        self.windows
+            .iter()
+            .filter_map(|w| {
+                let split = w.config.split;
+                let edge = split.edge()?;
+                let extent = match edge.axis {
+                    Axis::Vertical => w.config.height.resolve(area.height),
+                    Axis::Horizontal => w.config.width.resolve(area.width),
+                };
+                Some(SplitReq { split, extent })
+            })
+            .collect()
     }
 
-    /// Draws into the rect the layout hands us, untouched. The layout owns the
-    /// geometry; we only fill it.
-    pub fn view_bottom_split(&mut self, frame: &mut Frame, rect: Rect) {
-        let Some(idx) = self.split_window_idx() else {
+    /// The layout owns the geometry; we only fill the rect it carved.
+    /// render_window records focused_rect for the focused window alone, so a
+    /// mouse click never lands on an unfocused split.
+    pub fn view_split(&mut self, frame: &mut Frame, dir: Split, rect: Rect) {
+        let Some(idx) = self.split_window_idx(dir) else {
             return;
         };
         if rect.width == 0 || rect.height == 0 {
             return;
         }
-        // render_window only records focused_rect for the focused window, which
-        // keeps mouse hit-testing from ever landing on an unfocused split.
         self.render_window(frame, idx, rect);
     }
 
@@ -1558,18 +1562,33 @@ mod tests {
         }
     }
 
-    const EXPECT_NO_SPLIT: &str = "expected no bottom split height without a Below window";
-    const EXPECT_SINGLE_SPLIT: &str = "expected exactly one Below window after re-open";
+    const EXPECT_NO_REQS: &str = "expected no split reqs without a split window";
+    const EXPECT_SINGLE_SPLIT: &str = "expected exactly one same-direction window after re-open";
     const EXPECT_SPLIT_DRAWN: &str = "expected the split window to receive its layout rect";
 
-    fn split_config(height: Dimension) -> FloatConfig {
+    fn split_config(dir: Split, extent: Dimension) -> FloatConfig {
         FloatConfig {
-            height,
+            width: extent,
+            height: extent,
             border: Border::None,
-            split: Split::Below,
+            split: dir,
             ..FloatConfig::default()
         }
     }
+
+    fn open_split(mgr: &mut FloatManager, dir: Split, extent: u16, focus: bool) -> SplitChannels {
+        let (event_tx, cmd_rx, event_rx, cmd_tx) = make_channels();
+        mgr.open(
+            make_buf(&["split"]),
+            split_config(dir, Dimension::Abs(extent)),
+            focus,
+            event_tx,
+            cmd_rx,
+        );
+        (event_rx, cmd_tx)
+    }
+
+    type SplitChannels = (flume::Receiver<WinEvent>, flume::Sender<WinCommand>);
 
     fn render_into(
         mgr: &mut FloatManager,
@@ -1582,46 +1601,27 @@ mod tests {
     }
 
     #[test]
-    fn bottom_split_height_none_without_split_window() {
+    fn split_reqs_empty_without_split_window() {
         let mut mgr = FloatManager::new();
         open_with_lines(&mut mgr, &["a"]);
         let area = Rect::new(0, 0, 80, 40);
-        assert!(mgr.bottom_split_height(area).is_none(), "{EXPECT_NO_SPLIT}");
+        assert!(mgr.split_reqs(area).is_empty(), "{EXPECT_NO_REQS}");
     }
 
-    #[test]
-    fn bottom_split_height_resolves_and_clamps() {
+    #[test_case(Split::Below, 10 ; "vertical_uses_height")]
+    #[test_case(Split::Left, 30 ; "horizontal_uses_width")]
+    fn split_reqs_resolves_extent_per_axis(dir: Split, extent: u16) {
         let mut mgr = FloatManager::new();
-        let (event_tx, cmd_rx, _erx, _ctx) = make_channels();
-        mgr.open(
-            make_buf(&["a"]),
-            split_config(Dimension::Abs(10)),
-            true,
-            event_tx,
-            cmd_rx,
-        );
+        let _ = open_split(&mut mgr, dir, extent, true);
         let area = Rect::new(0, 0, 80, 40);
-        assert_eq!(mgr.bottom_split_height(area), Some(10));
-
-        let area_tight = Rect::new(0, 0, 80, 8);
-        assert_eq!(
-            mgr.bottom_split_height(area_tight),
-            Some(8 - MIN_CHAT_AND_STATUS_ROWS),
-            "height clamps to area.height - MIN_CHAT_AND_STATUS_ROWS",
-        );
+        let reqs = mgr.split_reqs(area);
+        assert_eq!(reqs, vec![SplitReq { split: dir, extent }]);
     }
 
     #[test]
     fn view_skips_split_window() {
         let mut mgr = FloatManager::new();
-        let (event_tx, cmd_rx, event_rx, _ctx) = make_channels();
-        mgr.open(
-            make_buf(&["hello"]),
-            split_config(Dimension::Abs(10)),
-            true,
-            event_tx,
-            cmd_rx,
-        );
+        let (event_rx, _ctx) = open_split(&mut mgr, Split::Below, 10, true);
         let area = Rect::new(0, 0, 80, 40);
         render_into(&mut mgr, area, |m, f| {
             let u = m.view(f, area);
@@ -1636,19 +1636,13 @@ mod tests {
     }
 
     #[test]
-    fn view_bottom_split_draws_into_given_rect() {
+    fn view_split_draws_into_given_rect() {
         let mut mgr = FloatManager::new();
-        let (event_tx, cmd_rx, event_rx, _ctx) = make_channels();
-        mgr.open(
-            make_buf(&["hello"]),
-            split_config(Dimension::Abs(10)),
-            true,
-            event_tx,
-            cmd_rx,
-        );
-        let area = Rect::new(0, 0, 80, 40);
+        let dir = Split::Below;
         let rect = Rect::new(0, 30, 80, 10);
-        render_into(&mut mgr, area, |m, f| m.view_bottom_split(f, rect));
+        let (event_rx, _ctx) = open_split(&mut mgr, dir, 10, true);
+        let area = Rect::new(0, 0, 80, 40);
+        render_into(&mut mgr, area, |m, f| m.view_split(f, dir, rect));
 
         let resize = event_rx
             .drain()
@@ -1660,41 +1654,41 @@ mod tests {
         assert_eq!(resize, (rect.width, rect.height), "{EXPECT_SPLIT_DRAWN}");
         assert!(
             mgr.contains(ratatui::layout::Position::new(rect.x + 1, rect.y + 1)),
-            "scroll/contains must target the pushed area",
+            "scroll/contains must target the carved area",
         );
     }
 
     #[test]
-    fn second_split_replaces_first() {
+    fn second_split_of_same_direction_replaces_first() {
         let mut mgr = FloatManager::new();
-        let (tx1, rx1, erx1, _ctx1) = make_channels();
-        mgr.open(
-            make_buf(&["a"]),
-            split_config(Dimension::Abs(5)),
-            true,
-            tx1,
-            rx1,
-        );
+        let dir = Split::Below;
+        let (erx1, _ctx1) = open_split(&mut mgr, dir, 5, true);
+        let _ = open_split(&mut mgr, dir, 5, true);
 
-        let (tx2, rx2, _erx2, _ctx2) = make_channels();
-        mgr.open(
-            make_buf(&["b"]),
-            split_config(Dimension::Abs(5)),
-            true,
-            tx2,
-            rx2,
-        );
-
-        let split_count = mgr
-            .windows
-            .iter()
-            .filter(|w| w.config.split == Split::Below)
-            .count();
+        let split_count = mgr.windows.iter().filter(|w| w.config.split == dir).count();
         assert_eq!(split_count, 1, "{EXPECT_SINGLE_SPLIT}");
         assert!(
             erx1.drain().any(|e| matches!(e, WinEvent::Close)),
             "the replaced split must receive a Close event",
         );
+    }
+
+    #[test]
+    fn splits_of_different_directions_coexist() {
+        let mut mgr = FloatManager::new();
+        let (erx_left, _) = open_split(&mut mgr, Split::Left, 20, true);
+        let (erx_below, _) = open_split(&mut mgr, Split::Below, 10, true);
+
+        assert!(
+            mgr.split_window_idx(Split::Left).is_some(),
+            "left split must survive opening a below split",
+        );
+        assert!(mgr.split_window_idx(Split::Below).is_some());
+        assert!(
+            !erx_left.drain().any(|e| matches!(e, WinEvent::Close)),
+            "a different-direction split must not evict the left split",
+        );
+        let _ = erx_below;
     }
 
     const EXPECT_UNFOCUSED_NO_RECT: &str =
@@ -1705,17 +1699,10 @@ mod tests {
     #[test]
     fn unfocused_split_does_not_claim_focused_rect() {
         let mut mgr = FloatManager::new();
-        let (event_tx, cmd_rx, _erx, _ctx) = make_channels();
-        mgr.open(
-            make_buf(&["hello"]),
-            split_config(Dimension::Abs(10)),
-            false,
-            event_tx,
-            cmd_rx,
-        );
+        let _ = open_split(&mut mgr, Split::Below, 10, false);
         let area = Rect::new(0, 0, 80, 40);
         let rect = Rect::new(0, 30, 80, 10);
-        render_into(&mut mgr, area, |m, f| m.view_bottom_split(f, rect));
+        render_into(&mut mgr, area, |m, f| m.view_split(f, Split::Below, rect));
         assert!(
             !mgr.contains(ratatui::layout::Position::new(rect.x + 1, rect.y + 1)),
             "{EXPECT_UNFOCUSED_NO_RECT}",
@@ -1729,14 +1716,7 @@ mod tests {
         mgr.open(make_buf(&["a"]), FloatConfig::default(), false, tx1, rx1);
         let survivor = mgr.windows[0].id;
 
-        let (tx2, rx2, _erx2, _ctx2) = make_channels();
-        mgr.open(
-            make_buf(&["b"]),
-            split_config(Dimension::Abs(5)),
-            true,
-            tx2,
-            rx2,
-        );
+        let _ = open_split(&mut mgr, Split::Below, 5, true);
 
         mgr.remove_windows(|w| w.config.split == Split::Below);
         assert_eq!(mgr.focused_id, Some(survivor), "{EXPECT_FOCUS_RECOVERS}");
@@ -1744,23 +1724,15 @@ mod tests {
 
     const EXPECT_ZERO_RECT_NOOP: &str =
         "a zero-size rect must skip drawing: no Resize, no focused_rect";
-    const EXPECT_HAS_SPLIT: &str = "a Below window exists regardless of its resolved height";
-    const EXPECT_CLOSE_TO_SPLIT: &str = "close_all must send Close to the Below split window";
+    const EXPECT_CLOSE_TO_SPLIT: &str = "close_all must send Close to the split window";
 
     #[test_case(Rect::new(0, 30, 80, 0) ; "zero_height")]
     #[test_case(Rect::new(0, 30, 0, 10) ; "zero_width")]
-    fn view_bottom_split_zero_size_rect_is_noop(rect: Rect) {
+    fn view_split_zero_size_rect_is_noop(rect: Rect) {
         let mut mgr = FloatManager::new();
-        let (event_tx, cmd_rx, event_rx, _ctx) = make_channels();
-        mgr.open(
-            make_buf(&["hello"]),
-            split_config(Dimension::Abs(10)),
-            true,
-            event_tx,
-            cmd_rx,
-        );
+        let (event_rx, _ctx) = open_split(&mut mgr, Split::Below, 10, true);
         let area = Rect::new(0, 0, 80, 40);
-        render_into(&mut mgr, area, |m, f| m.view_bottom_split(f, rect));
+        render_into(&mut mgr, area, |m, f| m.view_split(f, Split::Below, rect));
 
         assert!(
             !event_rx
@@ -1790,14 +1762,7 @@ mod tests {
             frx,
         );
 
-        let (stx, srx, serx, _sctx) = make_channels();
-        mgr.open(
-            make_buf(&["split"]),
-            split_config(Dimension::Abs(10)),
-            false,
-            stx,
-            srx,
-        );
+        let (serx, _sctx) = open_split(&mut mgr, Split::Below, 10, false);
 
         let area = Rect::new(0, 0, 80, 40);
         render_into(&mut mgr, area, |m, f| {
@@ -1815,39 +1780,17 @@ mod tests {
         );
 
         let rect = Rect::new(0, 30, 80, 10);
-        render_into(&mut mgr, area, |m, f| m.view_bottom_split(f, rect));
+        render_into(&mut mgr, area, |m, f| m.view_split(f, Split::Below, rect));
         assert!(
             serx.drain().any(|e| matches!(e, WinEvent::Resize { .. })),
-            "{EXPECT_SPLIT_DRAWN}: split joins layout via view_bottom_split",
+            "{EXPECT_SPLIT_DRAWN}: split joins layout via view_split",
         );
-    }
-
-    #[test]
-    fn bottom_split_height_zero_config_is_some() {
-        let mut mgr = FloatManager::new();
-        let (event_tx, cmd_rx, _erx, _ctx) = make_channels();
-        mgr.open(
-            make_buf(&["a"]),
-            split_config(Dimension::Abs(0)),
-            true,
-            event_tx,
-            cmd_rx,
-        );
-        let area = Rect::new(0, 0, 80, 40);
-        assert_eq!(mgr.bottom_split_height(area), Some(0), "{EXPECT_HAS_SPLIT}");
     }
 
     #[test]
     fn close_all_notifies_split_window() {
         let mut mgr = FloatManager::new();
-        let (event_tx, cmd_rx, event_rx, _ctx) = make_channels();
-        mgr.open(
-            make_buf(&["a"]),
-            split_config(Dimension::Abs(10)),
-            true,
-            event_tx,
-            cmd_rx,
-        );
+        let (event_rx, _ctx) = open_split(&mut mgr, Split::Below, 10, true);
 
         mgr.close_all();
         assert!(!mgr.is_open(), "{EXPECT_CLOSED}");

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod rewind_picker;
 pub(crate) mod scrollbar;
 pub(crate) mod search_modal;
 pub(crate) mod session_picker;
+pub(crate) mod split_layout;
 pub mod status_bar;
 pub(crate) mod streaming_content;
 pub(crate) mod theme_picker;

--- a/maki-ui/src/components/split_layout.rs
+++ b/maki-ui/src/components/split_layout.rs
@@ -1,0 +1,217 @@
+use maki_lua::{Axis, Split};
+use ratatui::layout::Rect;
+
+/// Minimum interior columns the chat keeps after every column split is carved.
+const MIN_CHAT_COLS: u16 = 20;
+/// The one floor that protects the chat from vanishing: `carve` clamps row
+/// splits against it, and the app clamps the bottom panel against it too, so no
+/// feature can shrink the chat below this no matter how it grows.
+pub const MIN_CHAT_ROWS: u16 = 2;
+
+/// A split that wants `extent` cells along its edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SplitReq {
+    pub split: Split,
+    pub extent: u16,
+}
+
+/// The inner rect left for the chat, plus the rect granted to each carved
+/// split. A split that clamped out to nothing simply does not appear, so
+/// callers never have to handle an invalid rect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SplitLayout {
+    pub inner: Rect,
+    rects: [Option<Rect>; 4],
+}
+
+impl SplitLayout {
+    pub fn rect(&self, split: Split) -> Option<Rect> {
+        Split::ALL
+            .iter()
+            .position(|s| *s == split)
+            .and_then(|i| self.rects[i])
+    }
+}
+
+/// Carve every requested split off `area`, clamped so the interior keeps at
+/// least [`MIN_CHAT_COLS`] x [`MIN_CHAT_ROWS`]. [`Split::ALL`] fixes the order
+/// (columns before rows) so geometry stays the same no matter what opened first.
+pub fn carve(area: Rect, reqs: &[SplitReq]) -> SplitLayout {
+    let mut inner = area;
+    let mut rects = [None; 4];
+
+    for (i, dir) in Split::ALL.iter().enumerate() {
+        let Some(req) = reqs.iter().find(|r| r.split == *dir) else {
+            continue;
+        };
+        let Some(edge) = dir.edge() else {
+            continue;
+        };
+
+        let (available, min) = match edge.axis {
+            Axis::Vertical => (inner.height, MIN_CHAT_ROWS),
+            Axis::Horizontal => (inner.width, MIN_CHAT_COLS),
+        };
+        let band = req.extent.min(available.saturating_sub(min));
+        if band == 0 {
+            continue;
+        }
+
+        let (granted, rest) = split_edge(inner, edge.axis, edge.at_start, band);
+        rects[i] = Some(granted);
+        inner = rest;
+    }
+
+    SplitLayout { inner, rects }
+}
+
+/// Split `area` into `(band, rest)`. The band takes `extent` cells from the
+/// start (top/left) or end (bottom/right) edge along `axis`; `rest` keeps the
+/// remainder.
+fn split_edge(area: Rect, axis: Axis, at_start: bool, extent: u16) -> (Rect, Rect) {
+    match axis {
+        Axis::Vertical => {
+            if at_start {
+                let band = Rect::new(area.x, area.y, area.width, extent);
+                let rest = Rect::new(area.x, area.y + extent, area.width, area.height - extent);
+                (band, rest)
+            } else {
+                let rest = Rect::new(area.x, area.y, area.width, area.height - extent);
+                let band = Rect::new(area.x, area.y + area.height - extent, area.width, extent);
+                (band, rest)
+            }
+        }
+        Axis::Horizontal => {
+            if at_start {
+                let band = Rect::new(area.x, area.y, extent, area.height);
+                let rest = Rect::new(area.x + extent, area.y, area.width - extent, area.height);
+                (band, rest)
+            } else {
+                let rest = Rect::new(area.x, area.y, area.width - extent, area.height);
+                let band = Rect::new(area.x + area.width - extent, area.y, extent, area.height);
+                (band, rest)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    const AREA: Rect = Rect {
+        x: 0,
+        y: 0,
+        width: 80,
+        height: 40,
+    };
+
+    const EXPECT_INNER: &str = "inner must equal area when nothing is carved";
+    const EXPECT_NO_RECT: &str = "a direction with no request must have no rect";
+    const EXPECT_CONSERVED: &str = "band + inner must conserve the carved axis";
+    const EXPECT_DISJOINT: &str = "carved bands must not overlap the inner rect";
+
+    fn req(split: Split, extent: u16) -> SplitReq {
+        SplitReq { split, extent }
+    }
+
+    #[test]
+    fn empty_reqs_leave_inner_equal_to_area() {
+        let layout = carve(AREA, &[]);
+        assert_eq!(layout.inner, AREA, "{EXPECT_INNER}");
+        for dir in Split::ALL {
+            assert!(layout.rect(dir).is_none(), "{EXPECT_NO_RECT}");
+        }
+    }
+
+    #[test_case(Split::Above ; "above_reserves_top_rows")]
+    #[test_case(Split::Below ; "below_reserves_bottom_rows")]
+    fn vertical_split_reserves_rows(dir: Split) {
+        let layout = carve(AREA, &[req(dir, 10)]);
+        let band = layout.rect(dir).expect("band must exist");
+        assert_eq!(band.height, 10);
+        assert_eq!(band.width, AREA.width);
+        assert_eq!(layout.inner.height, AREA.height - 10);
+        assert_eq!(
+            band.height + layout.inner.height,
+            AREA.height,
+            "{EXPECT_CONSERVED}"
+        );
+        let at_top = band.y == AREA.y;
+        assert_eq!(at_top, dir == Split::Above, "{EXPECT_DISJOINT}");
+    }
+
+    #[test_case(Split::Left ; "left_reserves_columns")]
+    #[test_case(Split::Right ; "right_reserves_columns")]
+    fn horizontal_split_reserves_columns(dir: Split) {
+        let layout = carve(AREA, &[req(dir, 30)]);
+        let band = layout.rect(dir).expect("band must exist");
+        assert_eq!(band.width, 30);
+        assert_eq!(band.height, AREA.height);
+        assert_eq!(layout.inner.width, AREA.width - 30);
+        assert_eq!(
+            band.width + layout.inner.width,
+            AREA.width,
+            "{EXPECT_CONSERVED}"
+        );
+        let at_left = band.x == AREA.x;
+        assert_eq!(at_left, dir == Split::Left, "{EXPECT_DISJOINT}");
+    }
+
+    #[test]
+    fn oversize_row_request_clamps_to_chat_minimum() {
+        let layout = carve(AREA, &[req(Split::Below, 1000)]);
+        let band = layout.rect(Split::Below).expect("band must exist");
+        assert_eq!(layout.inner.height, MIN_CHAT_ROWS);
+        assert_eq!(band.height, AREA.height - MIN_CHAT_ROWS);
+    }
+
+    #[test]
+    fn oversize_column_request_clamps_to_chat_minimum() {
+        let layout = carve(AREA, &[req(Split::Left, 1000)]);
+        let band = layout.rect(Split::Left).expect("band must exist");
+        assert_eq!(layout.inner.width, MIN_CHAT_COLS);
+        assert_eq!(band.width, AREA.width - MIN_CHAT_COLS);
+    }
+
+    #[test]
+    fn zero_extent_request_yields_no_rect() {
+        let layout = carve(AREA, &[req(Split::Below, 0)]);
+        assert!(layout.rect(Split::Below).is_none(), "{EXPECT_NO_RECT}");
+        assert_eq!(layout.inner, AREA, "{EXPECT_INNER}");
+    }
+
+    #[test]
+    fn request_with_no_room_clamps_to_none() {
+        let tight = Rect::new(0, 0, MIN_CHAT_COLS, 40);
+        let layout = carve(tight, &[req(Split::Left, 10)]);
+        assert!(layout.rect(Split::Left).is_none(), "{EXPECT_NO_RECT}");
+        assert_eq!(layout.inner, tight, "{EXPECT_INNER}");
+    }
+
+    #[test]
+    fn coexisting_left_and_below_shrink_both_axes() {
+        let left = carve(AREA, &[req(Split::Left, 20), req(Split::Below, 10)]);
+        assert_eq!(left.inner.width, AREA.width - 20);
+        assert_eq!(left.inner.height, AREA.height - 10);
+        let l = left.rect(Split::Left).expect("left band");
+        let b = left.rect(Split::Below).expect("below band");
+        assert_eq!(l.width, 20);
+        assert_eq!(b.height, 10);
+        assert!(
+            l.x + l.width <= left.inner.x || b.y >= left.inner.y + left.inner.height,
+            "{EXPECT_DISJOINT}",
+        );
+    }
+
+    #[test]
+    fn open_order_does_not_change_geometry() {
+        let a = carve(AREA, &[req(Split::Left, 20), req(Split::Below, 10)]);
+        let b = carve(AREA, &[req(Split::Below, 10), req(Split::Left, 20)]);
+        assert_eq!(
+            a, b,
+            "carve order is fixed by Split::ALL, not request order"
+        );
+    }
+}


### PR DESCRIPTION
The `split` option on `maki.ui.open_win` only knew `"below"`.

Now it speaks the full neovim set, `"above"`, `"below"`, `"left"` and `"right"`, where rows or columns get reserved on one edge and the chat shrinks in.

Three single sources of truth keep it honest: `Split::edge()` maps a direction to its axis, a pure `carve()` turns the screen plus the open splits into disjoint rects, and `FloatManager` just fills what the layout hands it, so reserved space and drawn space can never drift.

One split per direction may live at once, opening the same direction again evicts the old one, and the chat always keeps a minimum so it never gets pushed off screen.

Adding a future edge is one `Split` variant plus one `edge()` arm, since every caller iterates `Split::ALL` instead of matching by hand.