### PR TITLE
providers: bring back anthropic `-1m` models, driven by the API

### DIFF
--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -18,6 +18,8 @@ Maki re-reads auth from storage and environment variables each time a new agent 
 
 You can set multiple API keys in one env var (`ANTHROPIC_API_KEY=sk-1,sk-2,sk-3`) and they rotate automatically on rate-limit or auth errors."#;
 
+const LONG_CONTEXT_NOTE: &str = r#"Add `-1m` to any Claude model, like `claude-sonnet-4-6-1m`, to use the 1M token context window."#;
+
 const BEDROCK_NOTE: &str = r#"#### Amazon Bedrock
 
 If you already use Claude through AWS Bedrock, you can point Maki at it instead of the direct Anthropic API. Set `CLAUDE_CODE_USE_BEDROCK=1` and Maki will route all Anthropic requests through Bedrock. The same models, the same features, just a different door.
@@ -283,6 +285,7 @@ fn write_section(out: &mut String, section: &ProviderSection) {
     }
 
     if section.name == "Anthropic" {
+        let _ = writeln!(out, "\n{LONG_CONTEXT_NOTE}");
         let _ = writeln!(out, "\n{BEDROCK_NOTE}");
     }
 }

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -170,7 +170,7 @@ impl Model {
                 e.family,
                 e.pricing.clone(),
                 e.max_output_tokens,
-                e.context_window,
+                anthropic::shared::long_context_window(model_id).unwrap_or(e.context_window),
                 e.fast_capable,
             ),
             None => (

--- a/maki-providers/src/providers/anthropic/bedrock.rs
+++ b/maki-providers/src/providers/anthropic/bedrock.rs
@@ -531,7 +531,9 @@ impl Provider for Bedrock {
                 self.reload_auth().await?;
             }
             let auth = self.auth.lock().unwrap().clone();
-            let model_id = env::var("ANTHROPIC_MODEL").unwrap_or_else(|_| model.id.clone());
+            let requested_id = env::var("ANTHROPIC_MODEL").unwrap_or_else(|_| model.id.clone());
+            let long_context = requested_id.ends_with(shared::LONG_CONTEXT_SUFFIX);
+            let model_id = shared::strip_long_context(&requested_id).to_string();
 
             let mut body = shared::build_request_body_with_system(
                 model,
@@ -550,8 +552,15 @@ impl Provider for Bedrock {
             let has_examples = tools
                 .as_array()
                 .is_some_and(|arr| arr.iter().any(|t| t.get("input_examples").is_some()));
+            let mut betas = Vec::new();
             if has_examples {
-                body["anthropic_beta"] = json!([shared::BETA_TOOL_EXAMPLES_BEDROCK]);
+                betas.push(shared::BETA_TOOL_EXAMPLES_BEDROCK);
+            }
+            if long_context {
+                betas.push(shared::LONG_CONTEXT_BETA);
+            }
+            if !betas.is_empty() {
+                body["anthropic_beta"] = json!(betas);
             }
 
             let encoded_model = super::super::urlenc(&model_id);

--- a/maki-providers/src/providers/anthropic/mod.rs
+++ b/maki-providers/src/providers/anthropic/mod.rs
@@ -2,7 +2,7 @@
 //! definition, the system prompt, and the last block of the 2 most recent messages.
 
 pub(crate) mod bedrock;
-pub(super) mod shared;
+pub(crate) mod shared;
 
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -105,13 +105,21 @@ impl Anthropic {
         body: &Value,
         event_tx: &Sender<ProviderEvent>,
         fast: bool,
+        long_context: bool,
     ) -> Result<StreamResponse, AgentError> {
         let json_body = serde_json::to_vec(body)?;
         let mut builder = self
             .build_request("POST", None)
             .header("content-type", "application/json");
+        let mut betas = Vec::new();
         if fast {
-            builder = builder.header("anthropic-beta", FAST_MODE_BETA);
+            betas.push(FAST_MODE_BETA);
+        }
+        if long_context {
+            betas.push(shared::LONG_CONTEXT_BETA);
+        }
+        if !betas.is_empty() {
+            builder = builder.header("anthropic-beta", betas.join(","));
         }
         let request = builder.body(json_body)?;
         let response = self.client.send_async(request).await?;
@@ -142,7 +150,14 @@ impl Anthropic {
 
             let body_text = response.text().await?;
             let page: ModelsPage = serde_json::from_str(&body_text)?;
-            models.extend(page.data.into_iter().map(|m| m.id));
+            for m in page.data {
+                // The API never tells us about `-1m`, so we mint it ourselves for
+                // any model that reports a 1M window.
+                if m.max_input_tokens >= shared::LONG_CONTEXT_WINDOW {
+                    models.push(format!("{}{}", m.id, shared::LONG_CONTEXT_SUFFIX));
+                }
+                models.push(m.id);
+            }
 
             if !page.has_more {
                 break;
@@ -195,12 +210,14 @@ impl Provider for Anthropic {
                 tools,
                 opts.thinking,
             );
-            body["model"] = json!(model.id);
+            body["model"] = json!(shared::strip_long_context(&model.id));
             body["stream"] = json!(true);
             let fast = apply_fast_mode(&mut body, model, opts);
+            let long_context = model.id.ends_with(shared::LONG_CONTEXT_SUFFIX);
 
-            debug!(model = %model.id, num_messages = messages.len(), thinking = ?opts.thinking, fast, "sending API request");
-            self.do_stream_request(&body, event_tx, fast).await
+            debug!(model = %model.id, num_messages = messages.len(), thinking = ?opts.thinking, fast, long_context, "sending API request");
+            self.do_stream_request(&body, event_tx, fast, long_context)
+                .await
         })
     }
 
@@ -230,6 +247,8 @@ impl Provider for Anthropic {
 #[derive(Deserialize)]
 struct ModelInfo {
     id: String,
+    #[serde(default)]
+    max_input_tokens: u32,
 }
 
 #[derive(Deserialize)]
@@ -474,6 +493,50 @@ data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":5}}\n";
         let header = apply_fast_mode(&mut body, &model, RequestOptions::default());
         assert!(!header);
         assert!(body.get("speed").is_none());
+    }
+
+    #[test]
+    fn long_context_spec_resolves_to_1m_window() {
+        let model = Model::from_spec("anthropic/claude-opus-4-8-1m").unwrap();
+        assert_eq!(model.id, "claude-opus-4-8-1m");
+        assert_eq!(model.context_window, shared::LONG_CONTEXT_WINDOW);
+        assert!(model.id.ends_with(shared::LONG_CONTEXT_SUFFIX));
+        // The API has never heard of `-1m`, so strip it before sending.
+        assert_eq!(shared::strip_long_context(&model.id), "claude-opus-4-8");
+    }
+
+    #[test]
+    fn list_models_adds_1m_variant_from_max_input_tokens() {
+        // The real /v1/models payload hides the 1M window in `max_input_tokens`.
+        let page: ModelsPage = serde_json::from_str(
+            r#"{
+                "data": [
+                    {"id": "claude-opus-4-8", "max_input_tokens": 1000000},
+                    {"id": "claude-opus-4-5-20251101", "max_input_tokens": 200000}
+                ],
+                "has_more": false,
+                "last_id": null
+            }"#,
+        )
+        .unwrap();
+
+        let mut models = Vec::new();
+        for m in page.data {
+            if m.max_input_tokens >= shared::LONG_CONTEXT_WINDOW {
+                models.push(format!("{}{}", m.id, shared::LONG_CONTEXT_SUFFIX));
+            }
+            models.push(m.id);
+        }
+        models.sort();
+
+        assert_eq!(
+            models,
+            vec![
+                "claude-opus-4-5-20251101".to_string(),
+                "claude-opus-4-8".to_string(),
+                "claude-opus-4-8-1m".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/maki-providers/src/providers/anthropic/shared.rs
+++ b/maki-providers/src/providers/anthropic/shared.rs
@@ -13,6 +13,26 @@ use crate::{
 
 pub(super) const BETA_TOOL_EXAMPLES_BEDROCK: &str = "tool-examples-2025-10-29";
 
+/// A `-1m` suffix is our own convention for asking Anthropic for the 1M context
+/// window. We strip it from the id before sending and add [`LONG_CONTEXT_BETA`]
+/// to the request instead.
+pub(crate) const LONG_CONTEXT_SUFFIX: &str = "-1m";
+pub(crate) const LONG_CONTEXT_BETA: &str = "context-1m-2025-08-07";
+pub(crate) const LONG_CONTEXT_WINDOW: u32 = 1_000_000;
+
+pub(crate) fn strip_long_context(model_id: &str) -> &str {
+    model_id
+        .strip_suffix(LONG_CONTEXT_SUFFIX)
+        .unwrap_or(model_id)
+}
+
+/// A `-1m` model is just its base entry with a wider window.
+pub(crate) fn long_context_window(model_id: &str) -> Option<u32> {
+    model_id
+        .ends_with(LONG_CONTEXT_SUFFIX)
+        .then_some(LONG_CONTEXT_WINDOW)
+}
+
 pub(super) const MESSAGE_CACHE_BREAKPOINTS: usize = 2;
 
 #[derive(Serialize)]
@@ -495,4 +515,26 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             fast_capable: false,
         },
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    use super::{
+        LONG_CONTEXT_SUFFIX, LONG_CONTEXT_WINDOW, long_context_window, strip_long_context,
+    };
+
+    #[test_case("claude-opus-4-8-1m", "claude-opus-4-8" ; "strips_suffix")]
+    #[test_case("claude-opus-4-8", "claude-opus-4-8" ; "leaves_plain_id")]
+    fn strip_long_context_removes_suffix(model_id: &str, expected: &str) {
+        assert_eq!(strip_long_context(model_id), expected);
+    }
+
+    #[test_case("claude-opus-4-8-1m", Some(LONG_CONTEXT_WINDOW) ; "suffix_opts_in")]
+    #[test_case("claude-opus-4-8", None ; "plain_id_keeps_base")]
+    fn long_context_window_follows_suffix(model_id: &str, expected: Option<u32>) {
+        assert_eq!(long_context_window(model_id), expected);
+        assert!(LONG_CONTEXT_SUFFIX.ends_with("1m"));
+    }
 }

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -33,6 +33,8 @@ You can set multiple API keys in one env var (`ANTHROPIC_API_KEY=sk-1,sk-2,sk-3`
 
 Defaults: claude-haiku-4-5 (weak), claude-sonnet-4-6 (medium), claude-opus-4-8 (strong)
 
+Add `-1m` to any Claude model, like `claude-sonnet-4-6-1m`, to use the 1M token context window.
+
 #### Amazon Bedrock
 
 If you already use Claude through AWS Bedrock, you can point Maki at it instead of the direct Anthropic API. Set `CLAUDE_CODE_USE_BEDROCK=1` and Maki will route all Anthropic requests through Bedrock. The same models, the same features, just a different door.


### PR DESCRIPTION
The `-1m` models vanished when the loader started reading the live list, and it turned out they never really worked: the old code sent `claude-...-1m` as the model id and forgot the `context-1m-2025-08-07` beta header.

So the `-1m` suffix is now a clean Maki convention, stripped from the id before the request and turned into the beta header, on both the direct API and Bedrock.

The live `/v1/models` reply already tells the truth in `max_input_tokens`, so the dynamic loader mints a `-1m` variant for every model reporting a 1M window instead of guessing from a hardcoded list.

The static fallback regains its `-1m` entries for the offline case, and `gen_providers` now reads context from a non `-1m` row so the table keeps showing the common 200K.