### PR TITLE
ui: paint plain lua plugin text in the theme foreground

### DIFF
--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -686,7 +686,7 @@ fn snapshot_to_lines_range(
 
 pub(crate) fn resolve_span_style(style: &SpanStyle) -> Style {
     match style {
-        SpanStyle::Default => Style::default(),
+        SpanStyle::Default => theme::current().tool,
         SpanStyle::Named(name) => theme::style_by_name(name),
         SpanStyle::Inline(inline) => {
             let mut s = Style::default();
@@ -1901,6 +1901,15 @@ mod tests {
         assert_eq!(resolved.fg, None);
         assert_eq!(resolved.bg, None);
         assert_eq!(resolved, Style::default());
+    }
+
+    #[test]
+    fn default_span_resolves_to_theme_tool() {
+        theme::set(theme::load_by_name("dracula").expect("dracula theme"));
+        assert_eq!(
+            resolve_span_style(&SpanStyle::Default),
+            theme::current().tool
+        );
     }
 
     #[test]


### PR DESCRIPTION
Lua plugins emit plain lines as default spans, and `resolve_span_style` mapped those to `Style::default()`, which sets no foreground and falls back to the terminal default.

On a light theme that default is often white, so plugin output like `bash` or `glob` turned into white on light and vanished.

So default spans now resolve to the theme's `tool` style, which is `fg = foreground` in every bundled theme, fixing both the tool output and float window paths at once.