### PR TITLE
config: add always_fast and always_thinking for new sessions

### DIFF
--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use maki_config_macro::ConfigSection;
 use maki_storage::paths;
+use maki_storage::sessions::{StoredThinking, ThinkingParseError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::warn;
@@ -98,13 +99,29 @@ pub struct ConfigField {
     pub description: &'static str,
 }
 
-pub const TOP_LEVEL_FIELDS: &[ConfigField] = &[ConfigField {
-    name: "always_yolo",
-    ty: "bool",
-    default: ConfigValue::Bool(false),
-    min: None,
-    description: "Start every session with YOLO mode (skip permission prompts, deny rules still apply)",
-}];
+pub const TOP_LEVEL_FIELDS: &[ConfigField] = &[
+    ConfigField {
+        name: "always_yolo",
+        ty: "bool",
+        default: ConfigValue::Bool(false),
+        min: None,
+        description: "Start every session with YOLO mode (skip permission prompts, deny rules still apply)",
+    },
+    ConfigField {
+        name: "always_fast",
+        ty: "bool",
+        default: ConfigValue::Bool(false),
+        min: None,
+        description: "Start every session with Anthropic fast mode (Opus only; ignored otherwise)",
+    },
+    ConfigField {
+        name: "always_thinking",
+        ty: "bool | string",
+        default: ConfigValue::Bool(false),
+        min: None,
+        description: "Start every session with extended thinking (true/\"adaptive\", \"off\", or a token budget)",
+    },
+];
 
 pub const INDEX_FIELDS: &[ConfigField] = &[ConfigField {
     name: "max_file_size_mb",
@@ -115,12 +132,16 @@ pub const INDEX_FIELDS: &[ConfigField] = &[ConfigField {
 }];
 
 #[derive(Debug, Error)]
-#[error("invalid config: {section}.{field} = {value} is below minimum ({min})")]
-pub struct ConfigError {
-    section: &'static str,
-    field: &'static str,
-    value: u64,
-    min: u64,
+pub enum ConfigError {
+    #[error("invalid config: {section}.{field} = {value} is below minimum ({min})")]
+    BelowMinimum {
+        section: &'static str,
+        field: &'static str,
+        value: u64,
+        min: u64,
+    },
+    #[error("invalid config: always_thinking: {0}")]
+    Thinking(#[from] ThinkingParseError),
 }
 
 fn check(
@@ -130,7 +151,7 @@ fn check(
     min: u64,
 ) -> Result<(), ConfigError> {
     if value < min {
-        return Err(ConfigError {
+        return Err(ConfigError::BelowMinimum {
             section,
             field,
             value,
@@ -146,10 +167,29 @@ macro_rules! merge_option {
     };
 }
 
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum AlwaysThinking {
+    Toggle(bool),
+    Mode(String),
+}
+
+impl AlwaysThinking {
+    fn resolve(self) -> Result<StoredThinking, ThinkingParseError> {
+        match self {
+            Self::Toggle(true) => Ok(StoredThinking::Adaptive),
+            Self::Toggle(false) => Ok(StoredThinking::Off),
+            Self::Mode(s) => StoredThinking::parse_setting(&s),
+        }
+    }
+}
+
 #[derive(Deserialize, Default, Debug)]
 #[serde(default, deny_unknown_fields)]
 pub struct RawConfig {
     pub always_yolo: Option<bool>,
+    pub always_fast: Option<bool>,
+    pub always_thinking: Option<AlwaysThinking>,
     #[serde(default)]
     pub ui: UiFileConfig,
     pub agent: AgentFileConfig,
@@ -161,7 +201,7 @@ pub struct RawConfig {
 
 impl RawConfig {
     pub fn merge(&mut self, overlay: RawConfig) {
-        merge_option!(self, overlay, always_yolo);
+        merge_option!(self, overlay, always_yolo, always_fast, always_thinking);
         self.ui.merge(overlay.ui);
         self.agent.merge(overlay.agent);
         self.provider.merge(overlay.provider);
@@ -170,22 +210,27 @@ impl RawConfig {
         self.tools.extend(overlay.tools);
     }
 
-    pub fn into_config(self, no_rtk: bool) -> Config {
+    pub fn into_config(self, no_rtk: bool) -> Result<Config, ConfigError> {
         let disabled_tools: Vec<String> = self
             .tools
             .iter()
             .filter(|(_, cfg)| cfg.enabled == Some(false))
             .map(|(name, _)| name.clone())
             .collect();
-        Config {
+        Ok(Config {
             always_yolo: self.always_yolo.unwrap_or(false),
+            always_fast: self.always_fast.unwrap_or(false),
+            always_thinking: self
+                .always_thinking
+                .map(AlwaysThinking::resolve)
+                .transpose()?,
             ui: UiConfig::from_file(self.ui),
             agent: AgentConfig::from_file(self.agent, no_rtk, &self.index, disabled_tools),
             provider: ProviderConfig::from_file(self.provider),
             storage: StorageConfig::from_file(self.storage),
             permissions: PermissionsConfig::default(),
             plugins: PluginsConfig::from_tools(self.tools),
-        }
+        })
     }
 }
 
@@ -408,6 +453,8 @@ pub struct PermissionsConfig {
 
 pub struct Config {
     pub always_yolo: bool,
+    pub always_fast: bool,
+    pub always_thinking: Option<StoredThinking>,
     pub ui: UiConfig,
     pub agent: AgentConfig,
     pub provider: ProviderConfig,
@@ -1057,7 +1104,7 @@ mod tests {
 
     #[test]
     fn empty_config_returns_defaults() {
-        let config = RawConfig::default().into_config(false);
+        let config = RawConfig::default().into_config(false).unwrap();
         assert!(config.ui.splash_animation);
         assert_eq!(config.agent.max_output_bytes, DEFAULT_MAX_OUTPUT_BYTES);
         assert_eq!(
@@ -1080,7 +1127,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let config = raw.into_config(false);
+        let config = raw.into_config(false).unwrap();
         assert_eq!(config.agent.max_output_lines, 5000);
         assert_eq!(config.agent.bash_timeout_secs, 60);
         assert_eq!(config.agent.max_output_bytes, DEFAULT_MAX_OUTPUT_BYTES);
@@ -1119,6 +1166,57 @@ mod tests {
         assert_eq!(base.ui.flash_duration_ms, Some(2000), "base preserved");
     }
 
+    #[test]
+    fn merge_always_fast_and_thinking_overlay_wins() {
+        let mut base = RawConfig {
+            always_fast: Some(false),
+            always_thinking: Some(AlwaysThinking::Mode("off".into())),
+            ..Default::default()
+        };
+        let overlay = RawConfig {
+            always_fast: Some(true),
+            always_thinking: Some(AlwaysThinking::Toggle(true)),
+            ..Default::default()
+        };
+        base.merge(overlay);
+
+        assert_eq!(base.always_fast, Some(true), "overlay wins");
+        assert_eq!(
+            base.always_thinking,
+            Some(AlwaysThinking::Toggle(true)),
+            "overlay wins"
+        );
+    }
+
+    #[test_case(AlwaysThinking::Toggle(true), StoredThinking::Adaptive ; "toggle_true")]
+    #[test_case(AlwaysThinking::Toggle(false), StoredThinking::Off ; "toggle_false")]
+    fn always_thinking_toggle_resolve(input: AlwaysThinking, expected: StoredThinking) {
+        assert_eq!(input.resolve(), Ok(expected));
+    }
+
+    #[test]
+    fn into_config_resolves_always_thinking() {
+        let defaults = RawConfig::default().into_config(false).unwrap();
+        assert!(defaults.always_thinking.is_none());
+
+        let raw = RawConfig {
+            always_thinking: Some(AlwaysThinking::Mode("8192".into())),
+            ..Default::default()
+        };
+        let config = raw.into_config(false).unwrap();
+        assert_eq!(
+            config.always_thinking,
+            Some(StoredThinking::Budget { tokens: 8192 })
+        );
+
+        let raw = RawConfig {
+            always_thinking: Some(AlwaysThinking::Mode("fast".into())),
+            ..Default::default()
+        };
+        let err = raw.into_config(false).err().expect("expected config error");
+        assert!(matches!(err, ConfigError::Thinking(_)));
+    }
+
     #[test_case("max_output_bytes",  0 ; "zero_output_bytes")]
     #[test_case("max_output_lines",  0 ; "zero_output_lines")]
     #[test_case("max_response_bytes", 0 ; "zero_response_bytes")]
@@ -1135,7 +1233,7 @@ mod tests {
             _ => unreachable!(),
         }
         let err = config.validate().unwrap_err();
-        assert_eq!(err.field, field);
+        assert!(matches!(err, ConfigError::BelowMinimum { field: f, .. } if f == field));
     }
 
     #[test]
@@ -1151,7 +1249,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let config = raw.into_config(false);
+        let config = raw.into_config(false).unwrap();
         assert_eq!(config.ui.tool_output_lines.bash, 20);
         assert_eq!(config.ui.tool_output_lines.read, 20);
         assert_eq!(
@@ -1168,6 +1266,8 @@ mod tests {
     fn validate_rejects_invalid_sections(section: &str, field: &str, value: u64) {
         let mut config = Config {
             always_yolo: false,
+            always_fast: false,
+            always_thinking: None,
             ui: UiConfig::default(),
             agent: AgentConfig::default(),
             provider: ProviderConfig::default(),
@@ -1186,8 +1286,10 @@ mod tests {
             _ => unreachable!(),
         }
         let err = config.validate().unwrap_err();
-        assert_eq!(err.section, section);
-        assert_eq!(err.field, field);
+        assert!(matches!(
+            err,
+            ConfigError::BelowMinimum { section: s, field: f, .. } if s == section && f == field
+        ));
     }
 
     #[test]
@@ -1396,7 +1498,7 @@ mod tests {
 
     #[test]
     fn plugins_default_builtins_populated_when_enabled() {
-        let config = RawConfig::default().into_config(false);
+        let config = RawConfig::default().into_config(false).unwrap();
         assert!(
             !config.plugins.tools.is_empty(),
             "enabled plugins should have default builtins"
@@ -1601,7 +1703,7 @@ mod tests {
             tools,
             ..Default::default()
         };
-        let config = raw.into_config(false);
+        let config = raw.into_config(false).unwrap();
 
         assert!(config.plugins.tools.contains(&"bash".to_string()));
         assert!(!config.plugins.tools.contains(&"websearch".to_string()));

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use maki_agent::tools::{ToolRegistry, ToolSource};
-use maki_config::{PluginsConfig, ToolOutputLines};
+use maki_config::{AlwaysThinking, PluginsConfig, ToolOutputLines};
 use maki_lua::{PluginError, PluginHost};
 
 fn fresh_registry() -> Arc<ToolRegistry> {
@@ -873,6 +873,8 @@ fn setup_all_sections_at_once() {
         .send_run_init_lua(
             r#"maki.setup({
                 always_yolo = true,
+                always_fast = true,
+                always_thinking = "adaptive",
                 ui = { splash_animation = false, mouse_scroll_lines = 5 },
                 agent = { bash_timeout_secs = 120, max_output_lines = 9000 },
                 provider = { default_model = "anthropic/claude-opus-4-6" },
@@ -887,6 +889,11 @@ fn setup_all_sections_at_once() {
         .unwrap()
         .expect("expected Some(RawConfig)");
     assert_eq!(raw.always_yolo, Some(true));
+    assert_eq!(raw.always_fast, Some(true));
+    assert_eq!(
+        raw.always_thinking,
+        Some(AlwaysThinking::Mode("adaptive".into()))
+    );
     assert_eq!(raw.ui.splash_animation, Some(false));
     assert_eq!(raw.ui.mouse_scroll_lines, Some(5));
     assert_eq!(raw.agent.bash_timeout_secs, Some(120));
@@ -898,6 +905,21 @@ fn setup_all_sections_at_once() {
     assert_eq!(raw.storage.max_log_files, Some(3));
     assert_eq!(raw.index.max_file_size_mb, Some(8));
     assert_eq!(raw.tools["bash"].enabled, Some(true));
+}
+
+#[test]
+fn setup_always_thinking_accepts_bool() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let raw = host
+        .send_run_init_lua(
+            "maki.setup({ always_thinking = true })".to_owned(),
+            "test_init.lua".to_owned(),
+            None,
+        )
+        .unwrap()
+        .expect("expected Some(RawConfig)");
+    assert_eq!(raw.always_thinking, Some(AlwaysThinking::Toggle(true)));
 }
 
 #[test]

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -237,7 +237,7 @@ impl StopReason {
     }
 }
 
-const MIN_THINKING_BUDGET: u32 = 1024;
+const THINKING_USAGE: &str = "Usage: /thinking [off|adaptive|<budget\u{2265}1024>]";
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum ThinkingConfig {
@@ -265,19 +265,16 @@ impl ThinkingConfig {
     }
 
     pub fn parse(input: &str, current: Self) -> Result<Self, &'static str> {
-        match input {
-            "" => Ok(if current.is_enabled() {
+        if input.is_empty() {
+            return Ok(if current.is_enabled() {
                 Self::Off
             } else {
                 Self::Adaptive
-            }),
-            "off" => Ok(Self::Off),
-            "adaptive" => Ok(Self::Adaptive),
-            n => match n.parse::<u32>() {
-                Ok(budget) if budget >= MIN_THINKING_BUDGET => Ok(Self::Budget(budget)),
-                _ => Err("Usage: /thinking [off|adaptive|<budget\u{2265}1024>]"),
-            },
+            });
         }
+        StoredThinking::parse_setting(input)
+            .map(Into::into)
+            .map_err(|_| THINKING_USAGE)
     }
 
     pub fn status_label(self) -> Option<Cow<'static, str>> {

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -112,12 +112,36 @@ pub struct StoredRule {
     pub effect: StoredEffect,
 }
 
+pub const MIN_THINKING_BUDGET: u32 = 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ThinkingParseError {
+    #[error("unknown thinking value {0:?} (use off, adaptive, or a token budget)")]
+    Unknown(String),
+    #[error("thinking budget {0} is below the minimum of {MIN_THINKING_BUDGET}")]
+    BudgetTooSmall(u32),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase", tag = "kind")]
 pub enum StoredThinking {
     Off,
     Adaptive,
     Budget { tokens: u32 },
+}
+
+impl StoredThinking {
+    pub fn parse_setting(input: &str) -> Result<Self, ThinkingParseError> {
+        match input.trim() {
+            "off" => Ok(Self::Off),
+            "adaptive" => Ok(Self::Adaptive),
+            other => match other.parse::<u32>() {
+                Ok(n) if n >= MIN_THINKING_BUDGET => Ok(Self::Budget { tokens: n }),
+                Ok(n) => Err(ThinkingParseError::BudgetTooSmall(n)),
+                Err(_) => Err(ThinkingParseError::Unknown(other.to_string())),
+            },
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -836,6 +860,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::StoredThinking;
+    use super::ThinkingParseError;
     use super::{
         CWD_INDEX_FILE, DEFAULT_TITLE, MAX_TITLE_LEN, SESSION_VERSION, generate_title,
         load_cwd_index, update_cwd_index,
@@ -1246,6 +1271,17 @@ mod tests {
         let json = serde_json::to_string(&variant).unwrap();
         let parsed: StoredThinking = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, variant);
+    }
+
+    #[test_case("off", Ok(StoredThinking::Off) ; "off")]
+    #[test_case("adaptive", Ok(StoredThinking::Adaptive) ; "adaptive")]
+    #[test_case(" adaptive ", Ok(StoredThinking::Adaptive) ; "trims_whitespace")]
+    #[test_case("4096", Ok(StoredThinking::Budget { tokens: 4096 }) ; "valid_budget")]
+    #[test_case("1024", Ok(StoredThinking::Budget { tokens: 1024 }) ; "minimum_budget")]
+    #[test_case("512", Err(ThinkingParseError::BudgetTooSmall(512)) ; "budget_too_small")]
+    #[test_case("fast", Err(ThinkingParseError::Unknown("fast".into())) ; "garbage")]
+    fn parse_setting(input: &str, expected: Result<StoredThinking, ThinkingParseError>) {
+        assert_eq!(StoredThinking::parse_setting(input), expected);
     }
 
     #[test]

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -55,6 +55,8 @@ All fields are optional. Typos in field names cause an error right away.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `always_yolo` | bool | `false` | Start every session with YOLO mode (skip permission prompts, deny rules still apply) |
+| `always_fast` | bool | `false` | Start every session with Anthropic fast mode (Opus only; ignored otherwise) |
+| `always_thinking` | bool | string | `false` | Start every session with extended thinking (true/"adaptive", "off", or a token budget) |
 
 ### `ui`
 

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -55,7 +55,10 @@ pub fn index(path: &str, no_plugins: bool) -> Result<()> {
 
     let raw_config = host.load_init_files(&cwd).context("load init.lua files")?;
 
-    let mut config = raw_config.unwrap_or_default().into_config(false);
+    let mut config = raw_config
+        .unwrap_or_default()
+        .into_config(false)
+        .context("invalid config")?;
     config.permissions = load_permissions(&cwd);
 
     host.load_builtins(&config.plugins)

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -80,7 +80,10 @@ pub fn run(cli: Cli) -> Result<()> {
         .load_init_files(&cwd)
         .context("load init.lua files")?;
 
-    let mut config = raw_config.unwrap_or_default().into_config(cli.no_rtk);
+    let mut config = raw_config
+        .unwrap_or_default()
+        .into_config(cli.no_rtk)
+        .context("invalid config")?;
     config.permissions = load_permissions(&cwd);
 
     if cli.yolo || config.always_yolo {
@@ -129,13 +132,19 @@ pub fn run(cli: Cli) -> Result<()> {
         .context("run print mode")?;
     } else {
         let cwd_str = cwd.to_string_lossy().into_owned();
-        let session = resolve_session(
+        let mut session = resolve_session(
             cli.continue_session,
             cli.session,
             &model.spec(),
             &cwd_str,
             &storage,
         )?;
+        if session.messages.is_empty() {
+            session.meta.fast |= config.always_fast;
+            if let Some(thinking) = config.always_thinking {
+                session.meta.thinking = Some(thinking);
+            }
+        }
         let model = if session.messages.is_empty() {
             model
         } else {


### PR DESCRIPTION
People who always run `/fast` or `/thinking` had to toggle them on every start, so `init.lua` now takes `always_fast` and `always_thinking`, applied only to fresh sessions while resumed ones keep their own value.

The trap was that thinking parsing and the `1024` minimum already lived in `maki-providers`, so a copy in `maki-config` would quietly drift. Instead both rules move down to `maki-storage` as `StoredThinking::parse_setting`, and providers, config, and the `/thinking` command all lean on that one parser.

A bogus value like `always_thinking = "fast"` now fails loud at startup through `ConfigError` instead of silently turning thinking off.