### PR TITLE
lua: shield permission_scopes callback from a stale cancelled task

### DIFF
--- a/maki-agent/src/permissions.rs
+++ b/maki-agent/src/permissions.rs
@@ -385,12 +385,19 @@ fn matches_rule(rule: &PermissionRule, tool: &str, scope: &str) -> bool {
     }
 }
 
+/// Glob matcher for permission scopes. The boundary suffixes (`/**`, `" *"`)
+/// must be tried before the bare `*`, otherwise a plain prefix would swallow
+/// them. `" *"` is the bash form `<command> *`: it has to match the bare
+/// command too (`pwd *` covers `pwd` and `pwd -L`, but not `pwdx`).
 pub fn scope_matches(pattern: &str, value: &str) -> bool {
     if pattern == "*" || pattern == "**" {
         return true;
     }
     if let Some(prefix) = pattern.strip_suffix("/**") {
         return value == prefix || value.starts_with(&format!("{prefix}/"));
+    }
+    if let Some(prefix) = pattern.strip_suffix(" *") {
+        return value == prefix || value.starts_with(&format!("{prefix} "));
     }
     if let Some(prefix) = pattern.strip_suffix('*') {
         return value.starts_with(prefix);
@@ -484,6 +491,9 @@ mod tests {
     #[test_case("*", "anything" => true ; "star")]
     #[test_case("cargo *", "cargo test" => true ; "prefix")]
     #[test_case("cargo *", "git push" => false ; "prefix_no_match")]
+    #[test_case("pwd *", "pwd" => true ; "space_star_matches_bare_command")]
+    #[test_case("pwd *", "pwd -L" => true ; "space_star_matches_with_args")]
+    #[test_case("pwd *", "pwdx" => false ; "space_star_no_partial_token")]
     #[test_case("src/**", "src/main.rs" => true ; "glob")]
     #[test_case("src/**", "src/deep/nested/file.rs" => true ; "glob_deep_nested")]
     #[test_case("src/**", "src" => true ; "glob_exact_prefix")]
@@ -710,18 +720,20 @@ mod tests {
             .unwrap()
     }
 
-    #[test]
-    fn generalize_edit_scope_root_file() {
-        let scopes = vec!["/Cargo.toml".into()];
-        let result = generalized_scopes("edit", &scopes);
-        assert_eq!(result, vec!["//**"]);
-    }
-
-    #[test]
-    fn generalize_unknown_tool_preserves_exact() {
-        let scopes = vec!["some:scope".into()];
-        let result = generalized_scopes("webfetch", &scopes);
-        assert_eq!(result, vec!["some:scope"]);
+    /// "Allow always" stores a command's generalized scope as a rule, so the
+    /// command must match the very rule it would create. When this broke, the
+    /// bare `pwd` never matched its own `pwd *` rule and we reprompted forever.
+    #[test_case("bash", "pwd" ; "bash_bare_command")]
+    #[test_case("bash", "cargo test" ; "bash_command_with_args")]
+    #[test_case("bash", "git status --short" ; "bash_command_with_flags")]
+    #[test_case("edit", "/home/user/project/src/main.rs" ; "edit_path")]
+    #[test_case("webfetch", "https://example.com" ; "unknown_tool_exact")]
+    fn command_matches_its_own_generalized_rule(tool: &str, scope: &str) {
+        let rule = &generalized_scopes(tool, &[scope.into()])[0];
+        assert!(
+            scope_matches(rule, scope),
+            "{scope:?} does not match its generalized rule {rule:?}"
+        );
     }
 
     #[test]

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -32,7 +32,9 @@ use crate::api::setup::ConfigStore;
 use crate::api::tool::{LuaOutputFormat, LuaTool, PendingTool, PendingTools, ToolCallReply};
 use crate::error::PluginError;
 
-const INTERRUPT_MSG: &str = "plugin interrupted: cancelled, deadline exceeded, or shutting down";
+const INTERRUPT_SHUTDOWN_MSG: &str = "plugin interrupted: host shutting down";
+const INTERRUPT_CANCELLED_MSG: &str = "plugin interrupted: task cancelled";
+const INTERRUPT_DEADLINE_MSG: &str = "plugin interrupted: deadline exceeded";
 const DISPATCH_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const NIL_WITHOUT_FINISH_MSG: &str =
     "handler returned nil without calling ctx:finish() or starting jobs";
@@ -169,6 +171,39 @@ pub(crate) fn lock_cell(handle: &TaskHandle) -> std::sync::MutexGuard<'_, TaskCe
     handle.lock().unwrap_or_else(|e| e.into_inner())
 }
 
+/// Bails out of a plugin call once its `TaskHandle` is cancelled, its deadline
+/// passed, or the host is shutting down. Cancel and deadline sit behind a mutex,
+/// so we only peek every `INTERRUPT_CANCEL_CHECK_INTERVAL` ticks to keep this
+/// hot path cheap.
+fn install_interrupt(lua: &Lua, shutdown: Arc<AtomicBool>) {
+    let interrupt_lua = lua.clone();
+    let interrupt_tick = Cell::new(0u32);
+    lua.set_interrupt(move |_| {
+        if shutdown.load(Ordering::Acquire) {
+            return Err(mlua::Error::runtime(INTERRUPT_SHUTDOWN_MSG));
+        }
+        let tick = interrupt_tick.get().wrapping_add(1);
+        interrupt_tick.set(tick);
+        if tick % INTERRUPT_CANCEL_CHECK_INTERVAL != 0 {
+            return Ok(VmState::Continue);
+        }
+        let stop = interrupt_lua.app_data_ref::<TaskHandle>().and_then(|h| {
+            let cell = lock_cell(&h);
+            if cell.cancel.is_cancelled() {
+                Some(INTERRUPT_CANCELLED_MSG)
+            } else if cell.deadline.get().is_some_and(|d| Instant::now() > d) {
+                Some(INTERRUPT_DEADLINE_MSG)
+            } else {
+                None
+            }
+        });
+        if let Some(msg) = stop {
+            return Err(mlua::Error::runtime(msg));
+        }
+        Ok(VmState::Continue)
+    });
+}
+
 /// Publishes a `TaskCell` into `Lua::app_data` for the duration of a
 /// task, and restores the previous one on drop. Async work must go
 /// through `scope_future` because concurrent tasks on the same executor
@@ -190,6 +225,16 @@ impl TaskScope {
         }
     }
 
+    /// A fresh non-cancelled scope. The shared Lua keeps the last task's
+    /// `TaskHandle` around, so a system callback must run under one of these or
+    /// the interrupt checker aborts it the moment that stale handle looks
+    /// cancelled. Prefer [`run_detached`] (async) or
+    /// [`LuaRuntime::call_sync_detached`] (sync): a raw scope is easy to leak by
+    /// forgetting `drop`.
+    pub(crate) fn detached(lua: &Lua) -> Self {
+        Self::new(lua, TaskCell::new(CancelToken::none(), None, None))
+    }
+
     pub(crate) fn handle(&self) -> &TaskHandle {
         &self.handle
     }
@@ -201,6 +246,18 @@ impl TaskScope {
             inner,
         }
     }
+}
+
+/// The one safe way to run an async system callback (hints, click/command
+/// handlers) on the shared Lua. It owns the [detached] scope for the whole
+/// call, so no caller can forget to set it up or `drop` it.
+///
+/// [detached]: TaskScope::detached
+pub(crate) async fn run_detached<F: std::future::Future>(lua: &Lua, fut: F) -> F::Output {
+    let scope = TaskScope::detached(lua);
+    let out = scope.scope_future(fut).await;
+    drop(scope);
+    out
 }
 
 impl Drop for TaskScope {
@@ -490,31 +547,7 @@ impl LuaRuntime {
         let lua = Lua::new();
         let pending: PendingTools = Arc::new(Mutex::new(Vec::new()));
 
-        let interrupt_shutdown = Arc::clone(&shutdown);
-        let interrupt_lua = lua.clone();
-        let interrupt_tick = Cell::new(0u32);
-        lua.set_interrupt(move |_| {
-            if interrupt_shutdown.load(Ordering::Acquire) {
-                return Err(mlua::Error::runtime(INTERRUPT_MSG));
-            }
-            let tick = interrupt_tick.get().wrapping_add(1);
-            interrupt_tick.set(tick);
-            if tick % INTERRUPT_CANCEL_CHECK_INTERVAL != 0 {
-                return Ok(VmState::Continue);
-            }
-            let cancelled = interrupt_lua
-                .app_data_ref::<TaskHandle>()
-                .map(|h| {
-                    let cell = lock_cell(&h);
-                    cell.cancel.is_cancelled()
-                        || cell.deadline.get().is_some_and(|d| Instant::now() > d)
-                })
-                .unwrap_or(false);
-            if cancelled {
-                return Err(mlua::Error::runtime(INTERRUPT_MSG));
-            }
-            Ok(VmState::Continue)
-        });
+        install_interrupt(&lua, Arc::clone(&shutdown));
 
         let globals = lua.globals();
         for name in &["require", "io", "package"] {
@@ -597,14 +630,11 @@ impl LuaRuntime {
     }
 
     async fn run_hint_callback(&self, plugin: &str, func: Function) -> Option<String> {
-        let scope = TaskScope::new(&self.lua, TaskCell::new(CancelToken::none(), None, None));
-        let result: mlua::Result<LuaValue> = scope
-            .scope_future(async {
-                let thread = self.lua.create_thread(func)?;
-                thread.into_async::<LuaValue>(())?.await
-            })
-            .await;
-        drop(scope);
+        let result: mlua::Result<LuaValue> = run_detached(&self.lua, async {
+            let thread = self.lua.create_thread(func)?;
+            thread.into_async::<LuaValue>(())?.await
+        })
+        .await;
         match result {
             Ok(LuaValue::String(s)) => Some(s.to_string_lossy()),
             Ok(LuaValue::Nil) => None,
@@ -946,6 +976,17 @@ impl LuaRuntime {
         self.drop_plugin_keys(plugin);
     }
 
+    /// The sync sibling of [`run_detached`]: runs a synchronous system callback
+    /// on the shared Lua under a [`TaskScope::detached`] guard.
+    fn call_sync_detached<R: mlua::FromLuaMulti>(
+        &self,
+        func: &Function,
+        args: impl mlua::IntoLuaMulti,
+    ) -> mlua::Result<R> {
+        let _scope = TaskScope::detached(&self.lua);
+        func.call::<R>(args)
+    }
+
     /// Registers a TaskCtx so `maki.ui.buf()` works inside the handler.
     fn compute_header(&self, plugin: &str, tool: &str, input: Value) -> HeaderResult {
         let plugins = self.plugins.borrow();
@@ -970,9 +1011,7 @@ impl LuaRuntime {
             }
         };
 
-        let scope = TaskScope::new(&self.lua, TaskCell::new(CancelToken::none(), None, None));
-        let result = func.call::<LuaValue>(input_lua);
-        drop(scope);
+        let result = self.call_sync_detached::<LuaValue>(&func, input_lua);
 
         match result {
             Ok(LuaValue::String(s)) => match s.to_str() {
@@ -1010,16 +1049,13 @@ impl LuaRuntime {
         let thread = self.lua.create_thread(func).ok()?;
 
         let (dummy_tx, _) = flume::unbounded();
-        let scope = TaskScope::new(
-            &self.lua,
-            TaskCell::new(
-                CancelToken::none(),
-                None,
-                Some(LiveCtx {
-                    event_tx: maki_agent::EventSender::new(dummy_tx, 0),
-                    tool_use_id: tool_use_id.to_owned(),
-                }),
-            ),
+        let cell = TaskCell::new(
+            CancelToken::none(),
+            None,
+            Some(LiveCtx {
+                event_tx: maki_agent::EventSender::new(dummy_tx, 0),
+                tool_use_id: tool_use_id.to_owned(),
+            }),
         );
 
         let ctx_ud = self
@@ -1029,6 +1065,7 @@ impl LuaRuntime {
         let inner = thread
             .into_async::<LuaValue>((input_lua, output, is_error, ctx_ud))
             .ok()?;
+        let scope = TaskScope::new(&self.lua, cell);
         let ret = scope
             .scope_future(inner)
             .await
@@ -1062,7 +1099,7 @@ impl LuaRuntime {
                 return None;
             }
         };
-        let result: LuaValue = match func.call(lua_input) {
+        let result: LuaValue = match self.call_sync_detached(&func, lua_input) {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!(plugin, tool, error = %e, "permission_scopes callback failed");
@@ -1510,15 +1547,9 @@ pub fn spawn(
                                         return;
                                     };
                                     let _ = data.set("row", row);
-                                    let scope = TaskScope::new(
-                                        &lua,
-                                        TaskCell::new(CancelToken::none(), None, None),
-                                    );
-                                    let scoped = scope.scope_future(func.call_async::<()>(data));
-                                    if let Err(e) = scoped.await {
+                                    if let Err(e) = run_detached(&lua, func.call_async::<()>(data)).await {
                                         tracing::warn!(tool_id, error = %e, "click handler failed");
                                     }
-                                    drop(scope);
                                     drain_spawn_queue(&lua, &ex_ref, &g);
                                     let _ = reply.send(Some(ClickReply {
                                         snapshot: buf.take(),
@@ -1545,19 +1576,13 @@ pub fn spawn(
                                 let ex_ref = Rc::clone(&ex);
                                 let g = Rc::clone(&gate);
                                 ex.spawn(async move {
-                                    let scope = TaskScope::new(
-                                        &lua,
-                                        TaskCell::new(CancelToken::none(), None, None),
-                                    );
                                     let run = async {
                                         let thread = lua.create_thread(func)?;
                                         thread.into_async::<()>(args)?.await
                                     };
-                                    let scoped = scope.scope_future(run);
-                                    if let Err(e) = scoped.await {
+                                    if let Err(e) = run_detached(&lua, run).await {
                                         tracing::warn!(plugin = %plugin, command = %command, error = %e, "command handler failed");
                                     }
-                                    drop(scope);
                                     drain_spawn_queue(&lua, &ex_ref, &g);
                                 })
                                 .detach();
@@ -1920,6 +1945,55 @@ mod tests {
             smol::future::yield_now().await;
             assert_eq!(g.count.get(), 0);
         }));
+    }
+
+    /// Loops far past `INTERRUPT_CANCEL_CHECK_INTERVAL` so the interrupt handler
+    /// is guaranteed to run the cancel check at least once mid-call.
+    fn looping_callback(lua: &Lua) -> Function {
+        lua.load("for _ = 1, 100000 do end return true")
+            .into_function()
+            .unwrap()
+    }
+
+    fn cancelled_handle() -> TaskHandle {
+        let (trigger, token) = CancelToken::new();
+        trigger.cancel();
+        Arc::new(Mutex::new(TaskCell::new(token, None, None)))
+    }
+
+    #[test]
+    fn stale_cancelled_handle_aborts_callback_without_fresh_scope() {
+        let lua = Lua::new();
+        install_interrupt(&lua, Arc::new(AtomicBool::new(false)));
+        lua.set_app_data::<TaskHandle>(cancelled_handle());
+        let err = looping_callback(&lua).call::<bool>(()).unwrap_err();
+        assert!(err.to_string().contains(INTERRUPT_CANCELLED_MSG));
+    }
+
+    #[test]
+    fn fresh_task_scope_shields_callback_from_stale_cancelled_handle() {
+        let lua = Lua::new();
+        install_interrupt(&lua, Arc::new(AtomicBool::new(false)));
+        lua.set_app_data::<TaskHandle>(cancelled_handle());
+
+        let scope = TaskScope::detached(&lua);
+        let result = looping_callback(&lua).call::<bool>(());
+        drop(scope);
+
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn shutdown_flag_aborts_callback_even_with_fresh_scope() {
+        let lua = Lua::new();
+        let shutdown = Arc::new(AtomicBool::new(true));
+        install_interrupt(&lua, shutdown);
+
+        let scope = TaskScope::detached(&lua);
+        let err = looping_callback(&lua).call::<bool>(()).unwrap_err();
+        drop(scope);
+
+        assert!(err.to_string().contains(INTERRUPT_SHUTDOWN_MSG));
     }
 
     #[test]

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -1122,3 +1122,28 @@ fn bash_timeout_round_trip() {
         "restored body missing timeout marker; got: {text:?}"
     );
 }
+
+/// Guards the stale-cancelled-handle bug: `permission_scopes` must run the
+/// plugin callback and return its parsed result, never fall back to the raw
+/// input JSON. A leaked `{"command":...}` scope breaks allow rules, so we
+/// reprompt on every call. Covers both a parseable and an unparseable command.
+#[test_case::test_case("git status" ; "parseable command")]
+#[test_case::test_case("echo 'unterminated" ; "unparseable command")]
+fn bash_permission_scopes_never_falls_back_to_json(command: &str) {
+    let reg = fresh_registry();
+    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_builtins(&PluginsConfig::from_tools(HashMap::new()))
+        .unwrap();
+
+    let input = serde_json::json!({ "command": command });
+    let entry = reg.get("bash").expect("bash registered");
+    let inv = entry.tool.parse(&input).expect("parse failed");
+    let scopes = smol::block_on(inv.permission_scopes())
+        .expect("permission_scopes returned None (would fall back to raw JSON)");
+
+    assert!(
+        !scopes.scopes.iter().any(|s| s.contains("\"command\"")),
+        "fell back to raw JSON scope: {:?}",
+        scopes.scopes
+    );
+}


### PR DESCRIPTION
The shared Lua runs every plugin call against one `app_data` task handle, and the interrupt checker aborts a call the moment that handle looks cancelled. `compute_permission_scopes` called the plugin without a fresh `TaskScope`, so a cancelled bash run left its handle behind and killed the next scope lookup mid-call.

The fallout was nasty: the failed callback returned `None`, so the tool fell back to `force_prompt` with the raw input JSON, which both showed `{"command":...}` as the scope and bypassed allow rules, so the prompt asked again every single time.

So it now wraps the call in a fresh `TaskScope` with `CancelToken::none()`, the same guard `compute_header` already uses, and tests pin down both the abort and the fix.