### PR TITLE
agent: follow redirects in MCP HTTP transport

### DIFF
--- a/maki-agent/src/mcp/http.rs
+++ b/maki-agent/src/mcp/http.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use async_lock::Mutex;
 use isahc::HttpClient;
-use isahc::config::Configurable;
+use isahc::config::{Configurable, RedirectPolicy};
 use isahc::http::header::{ACCEPT, CONTENT_TYPE};
 use isahc::http::{Method, Request, StatusCode, header::HeaderMap};
 use serde_json::Value;
@@ -16,6 +16,7 @@ use super::protocol::{JsonRpcNotification, JsonRpcRequest, JsonRpcResponse};
 use super::transport::{BoxFuture, McpTransport};
 use tracing::info;
 
+pub(super) const MAX_REDIRECTS: u32 = 10;
 const SESSION_HEADER: &str = "mcp-session-id";
 const CT_JSON: &str = "application/json";
 const CT_SSE: &str = "text/event-stream";
@@ -37,14 +38,14 @@ impl HttpTransport {
         headers: &HashMap<String, String>,
         timeout: Duration,
     ) -> Result<Self, McpError> {
-        let client =
-            HttpClient::builder()
-                .timeout(timeout)
-                .build()
-                .map_err(|e: isahc::Error| McpError::StartFailed {
-                    server: name.into(),
-                    reason: e.to_string(),
-                })?;
+        let client = HttpClient::builder()
+            .redirect_policy(RedirectPolicy::Limit(MAX_REDIRECTS))
+            .timeout(timeout)
+            .build()
+            .map_err(|e: isahc::Error| McpError::StartFailed {
+                server: name.into(),
+                reason: e.to_string(),
+            })?;
 
         Ok(Self {
             name: Arc::from(name),

--- a/maki-agent/src/mcp/oauth/mod.rs
+++ b/maki-agent/src/mcp/oauth/mod.rs
@@ -19,7 +19,7 @@ pub enum OAuthError {
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use isahc::HttpClient;
-use isahc::config::Configurable;
+use isahc::config::{Configurable, RedirectPolicy};
 use maki_storage::StateDir;
 use maki_storage::auth::{McpAuthData, load_mcp_auth, save_mcp_auth};
 use tracing::{info, warn};
@@ -203,6 +203,7 @@ async fn discover_auth_server_for(
 
 fn build_http_client() -> Result<HttpClient, isahc::Error> {
     HttpClient::builder()
+        .redirect_policy(RedirectPolicy::Limit(super::http::MAX_REDIRECTS))
         .timeout(std::time::Duration::from_secs(30))
         .build()
 }


### PR DESCRIPTION
`isahc` defaults to `RedirectPolicy::None`, so any 3xx from an MCP server or OAuth discovery endpoint just failed instead of following the hop.

Both `HttpTransport` and the OAuth `build_http_client` now set `RedirectPolicy::Limit(10)` to follow redirects while guarding against infinite loops.