### PR TITLE
question: label each answer block with `**A{n}.**`

### DIFF
--- a/plugins/question/question_helpers.lua
+++ b/plugins/question/question_helpers.lua
@@ -4,6 +4,7 @@ function QuestionHelpers.format_answer_list(questions, answers)
   local blocks = {}
   for i, q in ipairs(questions) do
     local lines = { "**Q" .. i .. ".** " .. q.question }
+    lines[#lines + 1] = "**A" .. i .. ".**"
     local ans = answers[i]
     if ans and #ans > 0 then
       for _, v in ipairs(ans) do

--- a/plugins/question/tests/spec.lua
+++ b/plugins/question/tests/spec.lua
@@ -171,15 +171,15 @@ case("format_answer_list_renders_questions_answers_pipes_newlines_and_missing", 
   }
   local out = QuestionHelpers.format_answer_list(questions, { { "a", "ans|with|pipes" } })
   assert(out:find("**Q1.** Has | pipe\nand newline", 1, true), "Q1 header + verbatim pipes/newlines")
+  assert(out:find("**A1.**\n- a\n", 1, true), "A1 label before answer bullets")
   assert(out:find("**Q2.** Q2", 1, true), "Q2 header present")
-  assert(out:find("\n- a\n", 1, true), "answer a on its own bullet")
+  assert(out:find("**A2.**\n- (no answer)", 1, true), "A2 label before no-answer bullet")
   assert(out:find("\n- ans|with|pipes", 1, true), "answer pipes preserved verbatim on bullet")
-  assert(out:find("- (no answer)", 1, true), "missing answer renders as (no answer)")
 end)
 
 case("format_answer_list_indents_multiline_answer_continuation", function()
   local out = QuestionHelpers.format_answer_list({ { question = "Q" } }, { { "a\nb" } })
-  assert(out:find("- a\n  b", 1, true), "multi-line answer continuation indented with two spaces")
+  assert(out:find("**A1.**\n- a\n  b", 1, true), "A1 label before multi-line answer continuation")
 end)
 
 case("format_answer_list_with_no_questions_returns_empty_string", function()


### PR DESCRIPTION
Questions already printed `**Q1.**`, `**Q2.**` headers, but the answers that followed had no matching label, so a long multi-question response was hard to scan.

Now `format_answer_list` inserts an `**A{n}.**` line right after each question header, giving every answer block a visual anchor that pairs with its question.