### PR TITLE
agent: fix code_execution live output replacing instead of appending

### DIFF
--- a/maki-agent/src/tools/code_execution.rs
+++ b/maki-agent/src/tools/code_execution.rs
@@ -94,16 +94,15 @@ impl CodeExecution {
                 let code = format!("{PREAMBLE}{code}");
 
                 let result = if let Some(ref id) = tool_use_id {
-                    let mut pending = String::new();
+                    let mut accumulated = String::new();
                     let mut last_flush = Instant::now();
                     runner::run_streaming(&code, &tools, Some(&resolver), limits, &mut |line| {
-                        pending.push_str(line);
-                        if last_flush.elapsed() >= STREAM_FLUSH_INTERVAL && !pending.is_empty() {
+                        accumulated.push_str(line);
+                        if last_flush.elapsed() >= STREAM_FLUSH_INTERVAL {
                             env.event_tx.try_send(AgentEvent::ToolOutput {
                                 id: id.to_string(),
-                                content: pending.clone(),
+                                content: accumulated.clone(),
                             });
-                            pending.clear();
                             last_flush = Instant::now();
                         }
                     })

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -418,6 +418,8 @@ pub enum AgentEvent {
         name: String,
     },
     ToolStart(Box<ToolStartEvent>),
+    /// `content` is the **full accumulated output** so far, not a delta.
+    /// Producers must accumulate into a growing buffer and send the whole thing each flush.
     ToolOutput {
         id: String,
         content: String,

--- a/maki-lua/src/api/ctx.rs
+++ b/maki-lua/src/api/ctx.rs
@@ -1,12 +1,11 @@
 use std::time::{Duration, Instant};
 
-use maki_agent::AgentEvent;
 use maki_agent::cancel::CancelToken;
 use maki_config::{AgentConfig, ToolOutputLines};
 use mlua::{LuaSerdeExt, UserData, UserDataMethods, Value as LuaValue};
 
 use crate::api::tool::ToolCallReply;
-use crate::runtime::{LiveCtx, active_task};
+use crate::runtime::active_task;
 
 const DEADLINE_ALREADY_SET_MSG: &str = "ctx:set_deadline() already called";
 
@@ -27,7 +26,6 @@ pub(crate) struct LuaCtx {
     pub(crate) config: AgentConfig,
     pub(crate) tool_output_lines: ToolOutputLines,
     pub(crate) finish_tx: Option<flume::Sender<ToolCallReply>>,
-    pub(crate) live: Option<LiveCtx>,
 }
 
 impl UserData for LuaCtx {
@@ -38,16 +36,6 @@ impl UserData for LuaCtx {
 
         methods.add_method("tool_output_lines", |lua, this, ()| {
             lua.to_value(&this.tool_output_lines)
-        });
-
-        methods.add_method("emit_output", |_, this, content: String| {
-            if let Some(live) = &this.live {
-                live.event_tx.try_send(AgentEvent::ToolOutput {
-                    id: live.tool_use_id.clone(),
-                    content,
-                });
-            }
-            Ok(())
         });
 
         methods.add_method("set_deadline", |lua, _this, secs: u64| {

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -210,7 +210,6 @@ impl ToolInvocation for LuaToolInvocation {
                 config: ctx.config.clone(),
                 tool_output_lines: ctx.tool_output_lines,
                 finish_tx: None,
-                live: live.clone(),
             };
 
             tx.send_async(Request::CallTool {


### PR DESCRIPTION
`code_execution` flushed output every 100ms but called `pending.clear()` after each send, so the UI only ever saw the latest fragment instead of the full log.

The shell tool never had this bug because it accumulates into a growing buffer and sends the whole thing each flush.

Now `code_execution` does the same: one `accumulated` buffer that grows and never clears, and a doc comment on `AgentEvent::ToolOutput` pins the contract that `content` is always the full output.

Also removed the dead `ctx:emit_output` method from `LuaCtx` since no Lua plugin ever called it.