### PR TITLE
ui: smarter line truncation per context

### DIFF
--- a/maki-markdown/src/render.rs
+++ b/maki-markdown/src/render.rs
@@ -19,7 +19,7 @@ pub const CODE_BAR: &str = "│ ";
 pub const CODE_BAR_WRAP: &str = "│";
 /// Lines longer than this get truncated with `...` to protect the parser
 /// and terminal from runaway output.
-pub const MAX_LINE_BYTES: usize = 500;
+pub const TOOL_OUTPUT_MAX_LINE_BYTES: usize = 500;
 const HR_CHAR: char = '─';
 const MIN_COL_WIDTH: usize = 5;
 const LONG_LINE_SUFFIX: &str = "...";
@@ -721,10 +721,12 @@ pub fn hr_text(width: u16) -> String {
     iter::repeat_n(HR_CHAR, width as usize).collect()
 }
 
-/// Truncate lines longer than [`MAX_LINE_BYTES`]. Returns borrowed when
-/// nothing needs truncating (common path, zero alloc).
 pub fn truncate_long_lines(text: &str) -> Cow<'_, str> {
-    if !text.lines().any(|l| l.len() > MAX_LINE_BYTES) {
+    truncate_long_lines_at(text, TOOL_OUTPUT_MAX_LINE_BYTES)
+}
+
+pub fn truncate_long_lines_at(text: &str, max_bytes: usize) -> Cow<'_, str> {
+    if !text.lines().any(|l| l.len() > max_bytes) {
         return Cow::Borrowed(text);
     }
     let mut result = String::with_capacity(text.len());
@@ -732,8 +734,8 @@ pub fn truncate_long_lines(text: &str) -> Cow<'_, str> {
         if i > 0 {
             result.push('\n');
         }
-        if line.len() > MAX_LINE_BYTES {
-            let mut boundary = MAX_LINE_BYTES;
+        if line.len() > max_bytes {
+            let mut boundary = max_bytes;
             while !line.is_char_boundary(boundary) {
                 boundary -= 1;
             }
@@ -1021,23 +1023,23 @@ mod tests {
     }
 
     #[test_case("short\nlines\n", "short\nlines\n" ; "short_text_unchanged")]
-    #[test_case(&"a".repeat(MAX_LINE_BYTES), &"a".repeat(MAX_LINE_BYTES) ; "exactly_at_limit_unchanged")]
-    #[test_case(&"a".repeat(MAX_LINE_BYTES + 1), &format!("{}...", "a".repeat(MAX_LINE_BYTES)) ; "one_over_limit_truncated")]
+    #[test_case(&"a".repeat(TOOL_OUTPUT_MAX_LINE_BYTES), &"a".repeat(TOOL_OUTPUT_MAX_LINE_BYTES) ; "exactly_at_limit_unchanged")]
+    #[test_case(&"a".repeat(TOOL_OUTPUT_MAX_LINE_BYTES + 1), &format!("{}...", "a".repeat(TOOL_OUTPUT_MAX_LINE_BYTES)) ; "one_over_limit_truncated")]
     fn truncate_long_lines_cases(input: &str, expected: &str) {
         assert_eq!(&*truncate_long_lines(input), expected);
     }
 
     #[test]
     fn truncate_long_lines_multibyte_boundary() {
-        let mut line = "a".repeat(MAX_LINE_BYTES - 1);
+        let mut line = "a".repeat(TOOL_OUTPUT_MAX_LINE_BYTES - 1);
         line.push('\u{00e9}');
         let result = truncate_long_lines(&line);
         assert!(result.ends_with("..."));
         assert!(!result.contains('\u{00e9}'));
     }
 
-    #[test_case(&format!("{}\n", "z".repeat(MAX_LINE_BYTES + 10)), true ; "preserves_trailing_newline")]
-    #[test_case(&"z".repeat(MAX_LINE_BYTES + 10), false ; "no_trailing_newline_when_absent")]
+    #[test_case(&format!("{}\n", "z".repeat(TOOL_OUTPUT_MAX_LINE_BYTES + 10)), true ; "preserves_trailing_newline")]
+    #[test_case(&"z".repeat(TOOL_OUTPUT_MAX_LINE_BYTES + 10), false ; "no_trailing_newline_when_absent")]
     fn truncate_long_lines_trailing_newline(input: &str, expect_trailing: bool) {
         assert_eq!(truncate_long_lines(input).ends_with('\n'), expect_trailing);
     }

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -1292,6 +1292,7 @@ impl MessagesPanel {
                         style.text_style,
                         style.prefix_style,
                         self.viewport_width,
+                        style.max_line_bytes,
                     )
                 } else {
                     plain_lines(&msg.text, prefix, style.text_style, style.prefix_style)

--- a/maki-ui/src/components/streaming_content.rs
+++ b/maki-ui/src/components/streaming_content.rs
@@ -7,6 +7,8 @@ use ratatui::style::Style;
 use ratatui::text::Line;
 use std::hash::{DefaultHasher, Hash, Hasher};
 
+const STREAMING_MAX_LINE_BYTES: usize = 5_000;
+
 /// Block-level streaming markdown cache.
 ///
 /// Memoizes the rendered line tree under a content-addressed key so
@@ -66,7 +68,7 @@ impl StreamingCache {
         if self.key == Some(key) {
             return false;
         }
-        let text = maki_markdown::render::truncate_long_lines(visible);
+        let text = maki_markdown::render::truncate_long_lines_at(visible, STREAMING_MAX_LINE_BYTES);
         let semantic = renderer.render(text.as_ref(), width, theme_gen);
         self.lines = paint_semantic(&semantic, prefix, text_style, prefix_style);
         self.key = Some(key);
@@ -186,7 +188,7 @@ mod tests {
 
     fn full_render_lines(text: &str, prefix: &str, width: u16) -> Vec<String> {
         let style = Style::default();
-        text_to_lines(text, prefix, style, style, width)
+        text_to_lines(text, prefix, style, style, width, None)
             .iter()
             .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
             .collect()

--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -173,6 +173,7 @@ pub struct RoleStyle {
     pub text_style: Style,
     pub prefix_style: Style,
     pub use_markdown: bool,
+    pub max_line_bytes: Option<usize>,
 }
 
 pub fn assistant_style() -> RoleStyle {
@@ -181,6 +182,7 @@ pub fn assistant_style() -> RoleStyle {
         text_style: theme::current().assistant,
         prefix_style: theme::current().assistant_prefix,
         use_markdown: true,
+        max_line_bytes: Some(maki_markdown::render::TOOL_OUTPUT_MAX_LINE_BYTES),
     }
 }
 
@@ -190,6 +192,7 @@ pub fn user_style() -> RoleStyle {
         text_style: theme::current().assistant,
         prefix_style: theme::current().user,
         use_markdown: true,
+        max_line_bytes: None,
     }
 }
 
@@ -199,6 +202,7 @@ pub fn thinking_style() -> RoleStyle {
         text_style: theme::current().thinking,
         prefix_style: theme::current().thinking,
         use_markdown: true,
+        max_line_bytes: Some(maki_markdown::render::TOOL_OUTPUT_MAX_LINE_BYTES),
     }
 }
 
@@ -208,6 +212,7 @@ pub fn error_style() -> RoleStyle {
         text_style: theme::current().error,
         prefix_style: theme::current().tool_error,
         use_markdown: false,
+        max_line_bytes: None,
     }
 }
 
@@ -219,6 +224,7 @@ pub fn done_style() -> RoleStyle {
             .add_modifier(ratatui::style::Modifier::BOLD),
         prefix_style: theme::current().tool_success,
         use_markdown: false,
+        max_line_bytes: None,
     }
 }
 
@@ -591,7 +597,14 @@ impl ToolLineBuilder {
     fn push_markdown_body(&mut self, text: &str) {
         let style = theme::current().assistant;
         let indent = TOOL_BODY_INDENT.len() as u16;
-        let md_lines = text_to_lines(text, "", style, style, self.width.saturating_sub(indent));
+        let md_lines = text_to_lines(
+            text,
+            "",
+            style,
+            style,
+            self.width.saturating_sub(indent),
+            Some(maki_markdown::render::TOOL_OUTPUT_MAX_LINE_BYTES),
+        );
         for mut line in md_lines {
             line.spans.insert(0, Span::raw(TOOL_BODY_INDENT));
             self.lines.push(line);

--- a/maki-ui/src/markdown.rs
+++ b/maki-ui/src/markdown.rs
@@ -235,9 +235,17 @@ pub fn text_to_lines(
     text_style: Style,
     prefix_style: Style,
     width: u16,
+    max_line_bytes: Option<usize>,
 ) -> Vec<Line<'static>> {
-    let text = render::truncate_long_lines(text);
-    let semantic = render::Renderer::unwrapped().render(text.as_ref(), width, 0);
+    let truncated;
+    let text = match max_line_bytes {
+        Some(limit) => {
+            truncated = render::truncate_long_lines_at(text, limit);
+            truncated.as_ref()
+        }
+        None => text,
+    };
+    let semantic = render::Renderer::unwrapped().render(text, width, 0);
     paint_semantic(&semantic, prefix, text_style, prefix_style)
 }
 
@@ -301,6 +309,16 @@ mod tests {
     use test_case::test_case;
 
     const TEST_WIDTH: u16 = 80;
+
+    fn text_to_lines(
+        text: &str,
+        prefix: &str,
+        text_style: Style,
+        prefix_style: Style,
+        width: u16,
+    ) -> Vec<Line<'static>> {
+        super::text_to_lines(text, prefix, text_style, prefix_style, width, None)
+    }
 
     fn lines_text(lines: &[Line<'_>]) -> Vec<String> {
         lines


### PR DESCRIPTION
`truncate_long_lines` used a flat 500-byte cap everywhere, which cut off long lines mid-stream while you were reading, and also silently chopped your own prompts.

Now there are three paths: tool output still truncates at 500 bytes (`TOOL_OUTPUT_MAX_LINE_BYTES`), the streaming renderer gets 5,000 bytes (`STREAMING_MAX_LINE_BYTES`) so lines stay intact while text is flowing in, and user messages (`text_to_lines_raw`) skip truncation entirely so your input is never mangled.

The old `truncate_long_lines` delegates to a new `truncate_long_lines_at(text, max_bytes)` that takes a configurable limit, keeping the zero-alloc fast path when nothing needs cutting.