### PR TITLE
skill: load skills from XDG config dir instead of ~/.maki

### DIFF
--- a/maki-lua/src/api/env.rs
+++ b/maki-lua/src/api/env.rs
@@ -13,6 +13,15 @@ pub(crate) fn create_env_table(lua: &Lua) -> LuaResult<Table> {
     )?;
 
     t.set(
+        "config_dir",
+        lua.create_function(|_, ()| {
+            Ok(maki_storage::paths::config_dir()
+                .ok()
+                .and_then(|p| p.to_str().map(String::from)))
+        })?,
+    )?;
+
+    t.set(
         "legacy_dir",
         lua.create_function(|_, ()| {
             Ok(maki_storage::paths::legacy_home_dir().and_then(|p| p.to_str().map(String::from)))

--- a/plugins/skill/init.lua
+++ b/plugins/skill/init.lua
@@ -13,7 +13,6 @@ local PROJECT_SKILL_DIRS = {
   ".agents/skills",
 }
 local GLOBAL_SKILL_DIRS = {
-  ".maki/skills",
   ".claude/skills",
   ".config/opencode/skills",
   ".agents/skills",
@@ -59,8 +58,13 @@ end
 
 local function discover_skills()
   local skills = {}
-  local home = maki.uv.os_homedir()
 
+  local config = maki.env.config_dir()
+  if config then
+    scan_skill_dir(maki.fs.joinpath(config, "skills"), skills)
+  end
+
+  local home = maki.uv.os_homedir()
   if home then
     for _, rel in ipairs(GLOBAL_SKILL_DIRS) do
       scan_skill_dir(maki.fs.joinpath(home, rel), skills)


### PR DESCRIPTION
The skill plugin looked for global skills in `~/.maki/skills`, but the rest of maki already moved to `~/.config/maki` (XDG) with `~/.maki` as a legacy fallback.

Now `discover_skills()` checks `maki.env.config_dir() .. "/skills"` first, then falls back to `maki.env.legacy_dir() .. "/skills"`, keeping the third-party compat dirs (`~/.claude/skills`, etc.) unchanged.

Added `config_dir` to the `maki.env` Lua API so plugins can reach `maki_storage::paths::config_dir()` the same way they already use `state_dir` and `legacy_dir`.

Closes #275.