### PR TITLE
providers: support `reasoning_effort` for OpenAI thinking models

### DIFF
--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -93,7 +93,12 @@ impl ProviderKind {
     pub const fn supports_thinking(self) -> bool {
         matches!(
             self,
-            Self::Anthropic | Self::Google | Self::Mistral | Self::DeepSeek | Self::Synthetic
+            Self::Anthropic
+                | Self::Google
+                | Self::Mistral
+                | Self::DeepSeek
+                | Self::Synthetic
+                | Self::OpenAi
         )
     }
 

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -142,7 +142,7 @@ impl Provider for OpenAi {
         system: &'a str,
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
-        _opts: RequestOptions,
+        opts: RequestOptions,
         _session_id: Option<&str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
@@ -168,7 +168,8 @@ impl Provider for OpenAi {
                     .await;
             }
 
-            let body = self.compat.build_body(model, messages, system, tools);
+            let mut body = self.compat.build_body(model, messages, system, tools);
+            opts.thinking.apply_reasoning_effort(&mut body);
             self.with_oauth_retry(|| async {
                 let auth = self.current_auth();
                 self.compat

--- a/maki-providers/src/providers/synthetic.rs
+++ b/maki-providers/src/providers/synthetic.rs
@@ -1,11 +1,11 @@
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
-use serde_json::{Value, json};
+use serde_json::Value;
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
@@ -117,22 +117,7 @@ impl Provider for Synthetic {
             let mut buf = String::new();
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
-            match opts.thinking {
-                ThinkingConfig::Off => {}
-                ThinkingConfig::Adaptive => {
-                    body["reasoning_effort"] = json!("medium");
-                }
-                ThinkingConfig::Budget(n) => {
-                    let effort = if n < 2048 {
-                        "low"
-                    } else if n < 8192 {
-                        "medium"
-                    } else {
-                        "high"
-                    };
-                    body["reasoning_effort"] = json!(effort);
-                }
-            };
+            opts.thinking.apply_reasoning_effort(&mut body);
             self.compat
                 .do_stream(model, &[], &body, event_tx, &auth)
                 .await

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -264,6 +264,17 @@ impl ThinkingConfig {
         }
     }
 
+    pub fn apply_reasoning_effort(self, body: &mut Value) {
+        let effort = match self {
+            Self::Off => return,
+            Self::Adaptive => "medium",
+            Self::Budget(n) if n < 2048 => "low",
+            Self::Budget(n) if n < 8192 => "medium",
+            Self::Budget(_) => "high",
+        };
+        body["reasoning_effort"] = json!(effort);
+    }
+
     pub fn parse(input: &str, current: Self) -> Result<Self, &'static str> {
         if input.is_empty() {
             return Ok(if current.is_enabled() {
@@ -393,20 +404,30 @@ mod tests {
         assert_eq!(&*deserialized.data, "abc123");
     }
 
-    #[test]
-    fn thinking_apply_to_body() {
-        let mut off = json!({"model": "test"});
-        ThinkingConfig::Off.apply_to_body(&mut off);
-        assert!(off.get("thinking").is_none());
+    #[test_case(ThinkingConfig::Off,          None                                                ; "off")]
+    #[test_case(ThinkingConfig::Adaptive,     Some(json!({"type": "adaptive"}))                    ; "adaptive")]
+    #[test_case(ThinkingConfig::Budget(10000), Some(json!({"type": "enabled", "budget_tokens": 10000})) ; "budget")]
+    fn thinking_apply_to_body(config: ThinkingConfig, expected: Option<Value>) {
+        let mut body = json!({"model": "test"});
+        config.apply_to_body(&mut body);
+        match expected {
+            Some(e) => assert_eq!(body["thinking"], e),
+            None => assert!(body.get("thinking").is_none()),
+        }
+    }
 
-        let mut adaptive = json!({"model": "test"});
-        ThinkingConfig::Adaptive.apply_to_body(&mut adaptive);
-        assert_eq!(adaptive["thinking"]["type"], "adaptive");
-
-        let mut budget = json!({"model": "test"});
-        ThinkingConfig::Budget(10000).apply_to_body(&mut budget);
-        assert_eq!(budget["thinking"]["type"], "enabled");
-        assert_eq!(budget["thinking"]["budget_tokens"], 10000);
+    #[test_case(ThinkingConfig::Off,          None            ; "off")]
+    #[test_case(ThinkingConfig::Adaptive,     Some("medium")  ; "adaptive")]
+    #[test_case(ThinkingConfig::Budget(1024), Some("low")     ; "budget_low")]
+    #[test_case(ThinkingConfig::Budget(4096), Some("medium")  ; "budget_medium")]
+    #[test_case(ThinkingConfig::Budget(8192), Some("high")    ; "budget_high")]
+    fn thinking_apply_reasoning_effort(config: ThinkingConfig, expected: Option<&str>) {
+        let mut body = json!({"model": "test"});
+        config.apply_reasoning_effort(&mut body);
+        match expected {
+            Some(e) => assert_eq!(body["reasoning_effort"], e),
+            None => assert!(body.get("reasoning_effort").is_none()),
+        }
     }
 
     #[test_case("",         ThinkingConfig::Off,      Ok(ThinkingConfig::Adaptive)  ; "toggle_on")]

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -2336,7 +2336,7 @@ fn thinking_explicit_args() {
 #[test]
 fn thinking_non_anthropic_flashes_error() {
     let mut app = test_app();
-    app.state.model.provider = maki_providers::provider::ProviderKind::OpenAi;
+    app.state.model.provider = maki_providers::provider::ProviderKind::Ollama;
 
     app.execute_command(cmd("/thinking"));
     assert_eq!(app.state.thinking, ThinkingConfig::Off);


### PR DESCRIPTION
The OpenAI provider silently ignored the `/think` toggle because `stream_message` discarded `RequestOptions` and `supports_thinking` did not list `OpenAi`.

Now the provider maps `ThinkingConfig` to `reasoning_effort` on the request body, same as Synthetic and Mistral already do: `Adaptive` sends `"medium"`, `Budget` picks `"low"` / `"medium"` / `"high"` by token threshold, and `Off` leaves the field absent.

Closes #165.