### PR TITLE
providers: add OpenRouter as a builtin provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,16 @@ An AI coding agent optimized for minimal use of context tokens, while providing 
 
 ## Supported providers
 
-* Anthropic - `ANTHROPIC_API_KEY` only (using OAuth is against TOS).
+* Anthropic - `ANTHROPIC_API_KEY` only (using OAuth is against TOS). Bedrock supported via `CLAUDE_CODE_USE_BEDROCK=1`.
 * OpenAI - `OPENAI_API_KEY` and OAuth via `maki auth login openai`.
+* Google - `GEMINI_API_KEY`.
 * Copilot - `GH_COPILOT_TOKEN` or an existing GitHub Copilot sign-in at `~/.config/github-copilot/`.
 * Ollama - `OLLAMA_HOST` for local (e.g. `http://localhost:11434`), or `OLLAMA_API_KEY` for cloud.
+* llama.cpp - `LLAMA_CPP_HOST` (e.g. `http://localhost:8080`), optionally `LLAMA_CPP_API_KEY`.
 * Mistral - `MISTRAL_API_KEY`.
 * Z.AI - `ZHIPU_API_KEY`.
+* DeepSeek - `DEEPSEEK_API_KEY`.
+* OpenRouter - `OPENROUTER_API_KEY`.
 * Synthetic - `SYNTHETIC_API_KEY`.
 
 **Dynamic providers** - drop an executable script into `~/.maki/providers/` to add custom providers or proxies. See [docs](https://maki.sh/docs/providers/#dynamic-providers) for details.

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -11,8 +11,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::provider::ProviderKind;
 use crate::providers::{
-    anthropic, copilot, deepseek, dynamic, google, llama_cpp, mistral, ollama, openai, synthetic,
-    zai,
+    anthropic, copilot, deepseek, dynamic, google, llama_cpp, mistral, ollama, openai, openrouter,
+    synthetic, zai,
 };
 
 const PER_MILLION: f64 = 1_000_000.0;
@@ -140,6 +140,7 @@ pub fn models_for_provider(provider: ProviderKind) -> &'static [ModelEntry] {
         ProviderKind::Zai | ProviderKind::ZaiCodingPlan => zai::models(),
         ProviderKind::Synthetic => synthetic::models(),
         ProviderKind::DeepSeek => deepseek::models(),
+        ProviderKind::OpenRouter => openrouter::models(),
     }
 }
 

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -18,6 +18,7 @@ use crate::providers::llama_cpp::LlamaCpp;
 use crate::providers::mistral::Mistral;
 use crate::providers::ollama::Ollama;
 use crate::providers::openai::OpenAi;
+use crate::providers::openrouter::OpenRouter;
 use crate::providers::synthetic::Synthetic;
 use crate::providers::zai::{Zai, ZaiPlan};
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
@@ -37,6 +38,8 @@ pub enum ProviderKind {
     ZaiCodingPlan,
     #[strum(serialize = "deepseek")]
     DeepSeek,
+    #[strum(serialize = "openrouter")]
+    OpenRouter,
     Synthetic,
 }
 
@@ -53,6 +56,7 @@ impl ProviderKind {
             Self::Zai => "Z.AI",
             Self::ZaiCodingPlan => "Z.AI Coding",
             Self::DeepSeek => "DeepSeek",
+            Self::OpenRouter => "OpenRouter",
             Self::Synthetic => "Synthetic",
         }
     }
@@ -68,6 +72,7 @@ impl ProviderKind {
             Self::Mistral => "MISTRAL_API_KEY",
             Self::Zai | Self::ZaiCodingPlan => "ZHIPU_API_KEY",
             Self::DeepSeek => "DEEPSEEK_API_KEY",
+            Self::OpenRouter => "OPENROUTER_API_KEY",
             Self::Synthetic => "SYNTHETIC_API_KEY",
         }
     }
@@ -86,6 +91,7 @@ impl ProviderKind {
             Self::Zai => "https://api.z.ai/api/paas/v4",
             Self::ZaiCodingPlan => "https://api.z.ai/api/coding/paas/v4",
             Self::DeepSeek => "https://api.deepseek.com",
+            Self::OpenRouter => "https://openrouter.ai/api/v1",
             Self::Synthetic => "https://api.synthetic.new/openai/v1",
         }
     }
@@ -99,6 +105,7 @@ impl ProviderKind {
                 | Self::DeepSeek
                 | Self::Synthetic
                 | Self::OpenAi
+                | Self::OpenRouter
         )
     }
 
@@ -119,6 +126,9 @@ impl ProviderKind {
                 Some("Reasoning effort support (low/medium/high), open-weight models")
             }
             Self::DeepSeek => Some("Thinking mode toggle (on/off), open-weight models"),
+            Self::OpenRouter => {
+                Some("300+ models from all providers, prompt caching, provider routing")
+            }
             _ => None,
         }
     }
@@ -134,6 +144,7 @@ impl ProviderKind {
             Self::Mistral => ModelFamily::Generic,
             Self::Zai | Self::ZaiCodingPlan => ModelFamily::Glm,
             Self::DeepSeek => ModelFamily::Generic,
+            Self::OpenRouter => ModelFamily::Generic,
             Self::Synthetic => ModelFamily::Synthetic,
         }
     }
@@ -141,7 +152,7 @@ impl ProviderKind {
     pub const fn accepts_arbitrary_models(self) -> bool {
         matches!(
             self,
-            Self::Ollama | Self::LlamaCpp | Self::Google | Self::Copilot
+            Self::Ollama | Self::LlamaCpp | Self::Google | Self::Copilot | Self::OpenRouter
         )
     }
 
@@ -156,6 +167,7 @@ impl ProviderKind {
             Self::Mistral => 32_000,
             Self::Zai | Self::ZaiCodingPlan => 16_000,
             Self::DeepSeek => 384_000,
+            Self::OpenRouter => 128_000,
             Self::Synthetic => 32_000,
         }
     }
@@ -171,6 +183,7 @@ impl ProviderKind {
             Self::Mistral => 128_000,
             Self::Zai | Self::ZaiCodingPlan => 128_000,
             Self::DeepSeek => 1_000_000,
+            Self::OpenRouter => 200_000,
             Self::Synthetic => 128_000,
         }
     }
@@ -193,6 +206,7 @@ impl ProviderKind {
             Self::Zai => Ok(Box::new(Zai::new(ZaiPlan::Standard, timeouts)?)),
             Self::ZaiCodingPlan => Ok(Box::new(Zai::new(ZaiPlan::Coding, timeouts)?)),
             Self::DeepSeek => Ok(Box::new(DeepSeek::new(timeouts)?)),
+            Self::OpenRouter => Ok(Box::new(OpenRouter::new(timeouts)?)),
             Self::Synthetic => Ok(Box::new(Synthetic::new(timeouts)?)),
         }
     }

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -24,6 +24,7 @@ use super::llama_cpp::LlamaCpp;
 use super::mistral::Mistral;
 use super::ollama::Ollama;
 use super::openai::OpenAi;
+use super::openrouter::OpenRouter;
 use super::synthetic::Synthetic;
 use super::zai::{Zai, ZaiPlan};
 
@@ -383,6 +384,10 @@ pub fn create(slug: &str, timeouts: super::Timeouts) -> Result<Box<dyn Provider>
         ),
         ProviderKind::DeepSeek => Box::new(
             DeepSeek::with_auth(auth.clone(), timeouts)
+                .with_system_prefix(meta.system_prefix.clone()),
+        ),
+        ProviderKind::OpenRouter => Box::new(
+            OpenRouter::with_auth(auth.clone(), timeouts)
                 .with_system_prefix(meta.system_prefix.clone()),
         ),
     };

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod mistral;
 pub(crate) mod ollama;
 pub(crate) mod openai;
 pub(crate) mod openai_compat;
+pub(crate) mod openrouter;
 pub(crate) mod synthetic;
 pub(crate) mod zai;
 

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -89,7 +89,7 @@ impl OpenAiCompatProvider {
     pub async fn do_stream(
         &self,
         model: &crate::model::Model,
-        extra_headers: &[(String, String)],
+        extra_headers: &[(&str, &str)],
         body: &Value,
         event_tx: &Sender<ProviderEvent>,
         auth: &ResolvedAuth,
@@ -98,8 +98,8 @@ impl OpenAiCompatProvider {
         let mut request = self
             .build_request("POST", "/chat/completions", auth)
             .header("content-type", "application/json");
-        for (key, value) in extra_headers {
-            request = request.header(key.as_str(), value.as_str());
+        for &(key, value) in extra_headers {
+            request = request.header(key, value);
         }
 
         let request = request.body(json_body)?;

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -3,79 +3,36 @@ use std::sync::{Arc, Mutex};
 use flume::Sender;
 use serde_json::{Value, json};
 
-use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
+use crate::model::{Model, ModelEntry};
 use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
 
+const REFERER: &str = "https://maki.sh";
+const APP_TITLE: &str = "maki";
+
 static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
-    api_key_env: "MISTRAL_API_KEY",
-    base_url: "https://api.mistral.ai/v1",
+    api_key_env: "OPENROUTER_API_KEY",
+    base_url: "https://openrouter.ai/api/v1",
     max_tokens_field: "max_tokens",
     include_stream_usage: true,
-    provider_name: "Mistral",
+    provider_name: "OpenRouter",
 };
 
 pub(crate) fn models() -> &'static [ModelEntry] {
-    &[
-        ModelEntry {
-            prefixes: &["devstral-latest", "devstral-medium-latest", "devstral-2512"],
-            tier: ModelTier::Strong,
-            family: ModelFamily::Generic,
-            default: true,
-            pricing: ModelPricing {
-                input: 0.4,
-                output: 2.0,
-                cache_write: 0.00,
-                cache_read: 0.00,
-                fast: None,
-            },
-            max_output_tokens: 262_144,
-            context_window: 262_144,
-        },
-        ModelEntry {
-            prefixes: &["mistral-large-latest", "mistral-large-2512"],
-            tier: ModelTier::Medium,
-            family: ModelFamily::Generic,
-            default: true,
-            pricing: ModelPricing {
-                input: 0.5,
-                output: 1.5,
-                cache_write: 0.00,
-                cache_read: 0.00,
-                fast: None,
-            },
-            max_output_tokens: 262_144,
-            context_window: 262_144,
-        },
-        ModelEntry {
-            prefixes: &["mistral-small-latest", "mistral-small-2603"],
-            tier: ModelTier::Weak,
-            family: ModelFamily::Generic,
-            default: true,
-            pricing: ModelPricing {
-                input: 0.15,
-                output: 0.60,
-                cache_write: 0.00,
-                cache_read: 0.00,
-                fast: None,
-            },
-            max_output_tokens: 262_144,
-            context_window: 262_144,
-        },
-    ]
+    &[]
 }
 
-pub struct Mistral {
+pub struct OpenRouter {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
     key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
 }
 
-impl Mistral {
+impl OpenRouter {
     pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
         let pool = KeyPool::from_env(CONFIG.api_key_env)?;
         Ok(Self {
@@ -101,7 +58,7 @@ impl Mistral {
     }
 }
 
-impl Provider for Mistral {
+impl Provider for OpenRouter {
     fn stream_message<'a>(
         &'a self,
         model: &'a Model,
@@ -118,14 +75,23 @@ impl Provider for Mistral {
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
 
-            if !matches!(opts.thinking, ThinkingConfig::Off) {
-                body["reasoning_effort"] = json!("high");
+            body["cache_control"] = json!({"type": "ephemeral"});
+
+            match opts.thinking {
+                ThinkingConfig::Off => {}
+                ThinkingConfig::Adaptive => {
+                    body["reasoning_effort"] = json!("high");
+                }
+                ThinkingConfig::Budget(n) => {
+                    body["reasoning_effort"] = json!(ThinkingConfig::budget_to_effort(n));
+                }
             }
 
-            let mut extra_headers = vec![];
-            if let Some(session_id) = session_id {
-                extra_headers.push(("x-affinity", session_id));
+            if let Some(sid) = session_id {
+                body["session_id"] = json!(sid);
             }
+
+            let extra_headers = [("HTTP-Referer", REFERER), ("X-OpenRouter-Title", APP_TITLE)];
             self.compat
                 .do_stream(model, &extra_headers, &body, event_tx, &auth)
                 .await

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -252,6 +252,16 @@ impl ThinkingConfig {
         !matches!(self, Self::Off)
     }
 
+    pub fn budget_to_effort(n: u32) -> &'static str {
+        if n < 2048 {
+            "low"
+        } else if n < 8192 {
+            "medium"
+        } else {
+            "high"
+        }
+    }
+
     pub fn apply_to_body(self, body: &mut Value) {
         match self {
             Self::Off => {}
@@ -268,9 +278,7 @@ impl ThinkingConfig {
         let effort = match self {
             Self::Off => return,
             Self::Adaptive => "medium",
-            Self::Budget(n) if n < 2048 => "low",
-            Self::Budget(n) if n < 8192 => "medium",
-            Self::Budget(_) => "high",
+            Self::Budget(n) => Self::budget_to_effort(n),
         };
         body["reasoning_effort"] = json!(effort);
     }

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -152,6 +152,16 @@ Defaults: glm-5-code (strong), glm-4.7-flash (weak), glm-4.7 (medium)
 
 Defaults: deepseek-v4-flash (medium), deepseek-v4-pro (strong)
 
+### OpenRouter
+
+- **Env var**: `OPENROUTER_API_KEY`
+- **API**: `https://openrouter.ai/api/v1`
+- **Features**: 300+ models from all providers, prompt caching, provider routing
+
+This provider talks the OpenAI-compatible `/v1` API, so it also works with llama.cpp's server, LocalAI, or anything else that speaks the same protocol. Just point `OLLAMA_HOST` to the right address (e.g. `http://localhost:8080` for llama.cpp).
+
+Maki asks the server for the list of installed models, so there's no built-in catalog. Tiers are guessed from list order: the first model becomes strong, the second medium, and the rest weak. If that guess is wrong, open `/model` and press `Alt+1`, `Alt+2`, or `Alt+3` on any row to reassign it. Your choices are saved to `~/.maki/model-tiers`.
+
 ### Synthetic
 
 - **Env var**: `SYNTHETIC_API_KEY`
@@ -193,7 +203,7 @@ To add a custom provider or proxy, drop an executable script into `~/.maki/provi
 
 `resolve` is called each time a new agent spawns, so scripts should read tokens from disk instead of caching them in memory. That way auth changes from other processes get picked up.
 
-The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `copilot`, `ollama`, `llama-cpp`, `mistral`, `zai`, `zai-coding-plan`, `deepseek`, `synthetic`.
+The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `copilot`, `ollama`, `llama-cpp`, `mistral`, `zai`, `zai-coding-plan`, `deepseek`, `openrouter`, `synthetic`.
 
 If your provider serves models not in the base catalog, add a `models` subcommand returning:
 


### PR DESCRIPTION
OpenRouter gives access to 300+ models behind one API key, so instead of hardcoding a model table it uses `accepts_arbitrary_models` and discovers everything through `/v1/models`.

Every request carries `cache_control: {"type": "ephemeral"}` in the body for Anthropic auto-caching (other providers ignore it) and a `session_id` for sticky routing to maximize cache hits.

Attribution headers (`HTTP-Referer`, `X-OpenRouter-Title`) go out on every request per their docs.

Closes #90.