### PR TITLE
ui: better model picker

### DIFF
--- a/maki-agent/src/tools/task.rs
+++ b/maki-agent/src/tools/task.rs
@@ -66,12 +66,20 @@ impl Task {
             if effective == ctx.model.tier {
                 (Model::clone(&ctx.model), Arc::clone(&ctx.provider))
             } else {
-                let resolved_model = Model::from_tier_dynamic(
-                    ctx.model.provider,
-                    effective,
-                    ctx.model.dynamic_slug.as_deref(),
-                )
-                .map_err(|e| e.to_string())?;
+                let resolved_model = {
+                    let map = maki_providers::tier_map::tier_map().read().unwrap();
+                    map.spec_for_tier(ctx.model.provider, effective)
+                        .or_else(|| map.spec_for_tier_any(effective))
+                        .and_then(|spec| Model::from_spec(&spec).ok())
+                }
+                .unwrap_or(
+                    Model::from_tier_dynamic(
+                        ctx.model.provider,
+                        effective,
+                        ctx.model.dynamic_slug.as_deref(),
+                    )
+                    .map_err(|e| e.to_string())?,
+                );
                 let resolved_provider = provider::from_model_async(&resolved_model, ctx.timeouts)
                     .await
                     .map_err(|e| e.to_string())?;

--- a/maki-docgen/src/gen_commands.rs
+++ b/maki-docgen/src/gen_commands.rs
@@ -55,7 +55,7 @@ pub fn generate() -> String {
 
     writeln!(out, "### User commands").unwrap();
     writeln!(out).unwrap();
-    writeln!(out, "Place `.md` files in `~/.maki/commands/`.").unwrap();
+    writeln!(out, "Place `.md` files in `~/.config/maki/commands/`.").unwrap();
     writeln!(out, "They appear in the palette as `/user:<filename>`.").unwrap();
     writeln!(out).unwrap();
     writeln!(

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -10,7 +10,7 @@ weight = 5
 group = "Reference"
 +++"#;
 
-const TIER_PICKER_NOTE: &str = r#"Open the model picker with `/model` and press `Alt+1`, `Alt+2`, or `Alt+3` on any row to reassign it to strong, medium, or weak. Your overrides are saved to `~/.maki/model-tiers` and apply across sessions."#;
+const TIER_PICKER_NOTE: &str = r#"Open the model picker with `/model` and press `1`, `2`, or `3` on any row to reassign it to strong, medium, or weak. Your overrides are saved to `~/.local/state/maki/model-tiers` and apply across sessions."#;
 
 const AUTH_RELOADING: &str = r#"## Auth Reloading
 
@@ -274,11 +274,7 @@ fn write_section(out: &mut String, section: &ProviderSection) {
     if section.entries.is_empty() {
         let _ = writeln!(
             out,
-            "This provider talks the OpenAI-compatible `/v1` API, so it also works with llama.cpp's server, LocalAI, or anything else that speaks the same protocol. Just point `OLLAMA_HOST` to the right address (e.g. `http://localhost:8080` for llama.cpp).\n"
-        );
-        let _ = writeln!(
-            out,
-            "Maki asks the server for the list of installed models, so there's no built-in catalog. Tiers are guessed from list order: the first model becomes strong, the second medium, and the rest weak. If that guess is wrong, open `/model` and press `Alt+1`, `Alt+2`, or `Alt+3` on any row to reassign it. Your choices are saved to `~/.maki/model-tiers`."
+            "This provider talks the OpenAI-compatible `/v1` API, so it also works with llama.cpp's server, LocalAI, or anything else that speaks the same protocol. Just point `OLLAMA_HOST` to the right address (e.g. `http://localhost:8080` for llama.cpp)."
         );
     } else {
         write_model_table(out, section.entries);

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -53,7 +53,7 @@ fn dynamic_providers_section() -> String {
     format!(
         r#"## Dynamic Providers
 
-To add a custom provider or proxy, drop an executable script into `~/.maki/providers/`. The script must handle these subcommands:
+To add a custom provider or proxy, drop an executable script into `~/.config/maki/providers/`. The script must handle these subcommands:
 
 | Subcommand | Timeout | What it does |
 |------------|---------|--------|

--- a/maki-providers/src/tier_map.rs
+++ b/maki-providers/src/tier_map.rs
@@ -133,6 +133,24 @@ impl TierMap {
             _ => Some(spec),
         }
     }
+
+    pub fn spec_for_tier_any(&self, tier: ModelTier) -> Option<String> {
+        for (spec, &t) in &self.overrides {
+            if t == tier {
+                return Some(spec.clone());
+            }
+        }
+        for &provider in self.known_models.keys() {
+            if let Some(spec) = self.spec_for_tier(provider, tier) {
+                return Some(spec);
+            }
+        }
+        None
+    }
+
+    pub fn is_override(&self, spec: &str) -> bool {
+        self.overrides.contains_key(spec)
+    }
 }
 
 /// Pure function: map a list position to a tier. Position 0 is Strong, 1 is
@@ -275,8 +293,9 @@ mod tests {
     }
 
     #[test]
-    fn spec_for_tier_no_models_returns_none() {
-        let map = make_map(&[], &[]);
+    fn spec_for_tier_skips_model_overridden_elsewhere() {
+        // "big" is at the Strong slot but overridden to Weak; don't return it for Strong.
+        let map = make_map(&[("ollama/big", ModelTier::Weak)], &["big", "mid", "small"]);
         assert_eq!(
             map.spec_for_tier(ProviderKind::Ollama, ModelTier::Strong),
             None
@@ -284,12 +303,26 @@ mod tests {
     }
 
     #[test]
-    fn spec_for_tier_skips_model_overridden_elsewhere() {
-        // "big" is at the Strong slot but overridden to Weak; don't return it for Strong.
-        let map = make_map(&[("ollama/big", ModelTier::Weak)], &["big", "mid", "small"]);
+    fn spec_for_tier_any_cross_provider_and_sorted() {
+        let map = make_map(
+            &[
+                ("zai/glm-5", ModelTier::Weak),
+                ("anthropic/opus", ModelTier::Weak),
+                ("openai/gpt-foo", ModelTier::Strong),
+            ],
+            &["big", "mid", "small"],
+        );
         assert_eq!(
-            map.spec_for_tier(ProviderKind::Ollama, ModelTier::Strong),
-            None
+            map.spec_for_tier_any(ModelTier::Strong),
+            Some("openai/gpt-foo".into()),
+        );
+        assert_eq!(
+            map.spec_for_tier_any(ModelTier::Weak),
+            Some("anthropic/opus".into()),
+        );
+        assert_eq!(
+            map.spec_for_tier_any(ModelTier::Medium),
+            Some("ollama/mid".into()),
         );
     }
 

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -533,7 +533,7 @@ pub const KEYBINDS: &[Keybind] = &[
         platform: Platform::All,
     },
     Keybind {
-        label: KeyLabel::Single("Alt+1/2/3"),
+        label: KeyLabel::Single("1/2/3"),
         description: "Set tier (strong/medium/weak)",
         context: KeybindContext::ModelPicker,
         platform: Platform::All,

--- a/maki-ui/src/components/list_picker.rs
+++ b/maki-ui/src/components/list_picker.rs
@@ -45,8 +45,10 @@ pub trait PickerItem {
     fn section(&self) -> Option<&str> {
         None
     }
-    /// Shows a spinner in the detail slot when true.
     fn is_spinning(&self) -> bool {
+        false
+    }
+    fn is_highlighted(&self) -> bool {
         false
     }
 }
@@ -484,14 +486,6 @@ impl<T: PickerItem> ListPicker<T> {
             .and_then(|s| s.items.get(idx))
     }
 
-    pub fn with_item_mut(&mut self, label: &str, f: impl FnOnce(&mut T)) {
-        if let Some(s) = self.state.as_mut().and_then(PickerState::ready_mut)
-            && let Some(item) = s.items.iter_mut().find(|i| i.label() == label)
-        {
-            f(item);
-        }
-    }
-
     pub fn handle_paste(&mut self, text: &str) -> bool {
         let Some(Some(s)) = self.state.as_mut().map(PickerState::ready_mut) else {
             return self.is_open();
@@ -532,15 +526,10 @@ impl<T: PickerItem> ListPicker<T> {
                     max_height_percent: MAX_HEIGHT_PERCENT,
                 };
                 let (popup, inner) = modal.render(frame, area, 1 + SEARCH_ROW + footer_rows);
-                let constraints: Vec<Constraint> = if footer.is_some() {
-                    vec![
-                        Constraint::Min(1),
-                        Constraint::Length(1),
-                        Constraint::Length(1),
-                    ]
-                } else {
-                    vec![Constraint::Min(1), Constraint::Length(1)]
-                };
+                let mut constraints = vec![Constraint::Min(1), Constraint::Length(1)];
+                if footer.is_some() {
+                    constraints.push(Constraint::Length(1));
+                }
                 let areas = Layout::vertical(constraints).split(inner);
                 let list_area = areas[0];
                 let search_area = areas[1];
@@ -623,7 +612,7 @@ fn render_ready<T: PickerItem>(
     constraints.push(Constraint::Min(1)); // list
     constraints.push(Constraint::Length(1)); // search
     if footer.is_some() {
-        constraints.push(Constraint::Length(1)); // footer
+        constraints.push(Constraint::Length(1));
     }
 
     let areas = Layout::vertical(constraints).split(inner);
@@ -804,10 +793,16 @@ fn render_list<T: PickerItem>(
             break;
         }
 
-        let style = if i == selected {
-            theme::current().item_selected
-        } else {
-            theme::current().item
+        let highlighted = item.is_highlighted();
+        let t = theme::current();
+        let (style, detail_style) = match (i == selected, highlighted) {
+            (true, true) => {
+                let s = t.item_selected.fg(t.accent.fg.unwrap_or_default());
+                (s, theme::dim_style(s, 0.4))
+            }
+            (true, false) => (t.item_selected, t.item_selected),
+            (false, true) => (t.accent, theme::dim_style(t.accent, 0.4)),
+            (false, false) => (t.item, t.item_desc),
         };
         let checkbox = enabled.map(|en| {
             let sym = if en[item_idx] { "✓ " } else { "✗ " };
@@ -830,11 +825,6 @@ fn render_list<T: PickerItem>(
             Some(detail) => {
                 let label = truncate_label(&label, max_label_width(detail, area.width));
                 let pad = detail_padding(&label, detail, area.width);
-                let detail_style = if i == selected {
-                    style
-                } else {
-                    theme::current().item_desc
-                };
                 let mut spans = Vec::with_capacity(5);
                 if let Some(cb) = checkbox {
                     spans.push(cb);
@@ -879,7 +869,7 @@ fn render_search(frame: &mut Frame, area: Rect, search: &TextBuffer) {
 }
 
 fn render_footer(frame: &mut Frame, area: Rect, spec: &FooterSpec) {
-    frame.render_widget(Paragraph::new(vec![spec.build()]), area);
+    frame.render_widget(Paragraph::new(spec.build()), area);
 }
 
 #[cfg(test)]

--- a/maki-ui/src/components/model_picker.rs
+++ b/maki-ui/src/components/model_picker.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use arc_swap::ArcSwapOption;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::Frame;
 use ratatui::layout::{Position, Rect};
 use ratatui::text::{Line, Span};
@@ -9,6 +9,7 @@ use ratatui::text::{Line, Span};
 use maki_providers::ModelTier;
 use maki_providers::dynamic;
 use maki_providers::provider::ProviderKind;
+use maki_providers::tier_map;
 
 use crate::components::Overlay;
 use crate::components::list_picker::{ListPicker, PickerAction, PickerItem};
@@ -21,20 +22,18 @@ fn footer_line() -> Line<'static> {
     Line::from(vec![
         Span::styled("  Enter", t.keybind_key),
         Span::styled(" select", t.tool_dim),
-        Span::styled("  Alt+1 ", t.keybind_key),
-        Span::styled("(set strong)", t.tool_dim),
-        Span::styled(" / ", t.tool_dim),
-        Span::styled("Alt+2 ", t.keybind_key),
-        Span::styled("(set medium)", t.tool_dim),
-        Span::styled(" / ", t.tool_dim),
-        Span::styled("Alt+3 ", t.keybind_key),
-        Span::styled("(set weak)", t.tool_dim),
+        Span::styled("  1", t.keybind_key),
+        Span::styled(" strong", t.tool_dim),
+        Span::styled("  2", t.keybind_key),
+        Span::styled(" medium", t.tool_dim),
+        Span::styled("  3", t.keybind_key),
+        Span::styled(" weak", t.tool_dim),
     ])
 }
 
 fn tier_for_shortcut(key: KeyEvent) -> Option<ModelTier> {
     let digit = match key.code {
-        KeyCode::Char(c @ '1'..='3') if key.modifiers.contains(KeyModifiers::ALT) => c,
+        KeyCode::Char(c @ '1'..='3') => c,
         KeyCode::Char('¡') => '1',
         KeyCode::Char('™') => '2',
         KeyCode::Char('£') => '3',
@@ -60,6 +59,7 @@ struct ModelEntry {
     id: String,
     provider_display: &'static str,
     tier: String,
+    tier_override: bool,
 }
 
 impl PickerItem for ModelEntry {
@@ -74,12 +74,17 @@ impl PickerItem for ModelEntry {
     fn section(&self) -> Option<&str> {
         Some(self.provider_display)
     }
+
+    fn is_highlighted(&self) -> bool {
+        self.tier_override
+    }
 }
 
 pub struct ModelPicker {
     picker: ListPicker<ModelEntry>,
     models: Arc<ArcSwapOption<Vec<String>>>,
     last_spec_count: usize,
+    dirty: bool,
 }
 
 impl ModelPicker {
@@ -88,6 +93,7 @@ impl ModelPicker {
             picker: ListPicker::new().with_footer_builder(footer_line),
             models,
             last_spec_count: 0,
+            dirty: false,
         }
     }
 
@@ -112,16 +118,16 @@ impl ModelPicker {
         }
         let guard = self.models.load();
         let spec_count = guard.as_deref().map_or(0, Vec::len);
-        if spec_count == self.last_spec_count {
+        let count_changed = spec_count != self.last_spec_count;
+        if !count_changed && !self.dirty {
             return;
         }
         self.last_spec_count = spec_count;
+        self.dirty = false;
         let entries: Vec<ModelEntry> = guard
             .as_deref()
-            .unwrap()
-            .iter()
-            .filter_map(|s| parse_model_entry(s))
-            .collect();
+            .map(|s| s.iter().filter_map(|s| parse_model_entry(s)).collect())
+            .unwrap_or_default();
         self.picker.replace_items(entries);
     }
 
@@ -150,9 +156,7 @@ impl ModelPicker {
             && let Some(entry) = self.picker.selected_item()
         {
             let spec = entry.spec.clone();
-            let id = entry.id.clone();
-            self.picker
-                .with_item_mut(&id, |e| e.tier = tier.to_string());
+            self.dirty = true;
             return ModelPickerAction::AssignTier(spec, tier);
         }
         match self.picker.handle_key(key) {
@@ -192,11 +196,13 @@ fn parse_model_entry(spec: &str) -> Option<ModelEntry> {
         Ok(m) => m.tier.to_string(),
         Err(_) => String::new(),
     };
+    let tier_override = tier_map::tier_map().read().unwrap().is_override(spec);
     Some(ModelEntry {
         spec: spec.to_string(),
         id: model_id.to_string(),
         provider_display,
         tier,
+        tier_override,
     })
 }
 
@@ -255,13 +261,17 @@ mod tests {
         let models = Arc::new(ArcSwapOption::empty());
         let mut p = ModelPicker::new(models.clone());
         p.open("");
-        assert_eq!(p.last_spec_count, 0);
+        assert!(matches!(
+            p.handle_key(key(KeyCode::Enter)),
+            ModelPickerAction::Consumed
+        ));
 
         models.store(Some(Arc::new(vec![
             "anthropic/claude-sonnet-4-20250514".into(),
         ])));
         p.try_refresh();
-        assert_eq!(p.last_spec_count, 1);
+        let action = p.handle_key(key(KeyCode::Enter));
+        assert!(matches!(action, ModelPickerAction::Select(ref s) if s.contains("sonnet")));
     }
 
     #[test]
@@ -313,6 +323,9 @@ mod tests {
         assert!(parse_model_entry("no-slash").is_none());
     }
 
+    #[test_case(key(KeyCode::Char('1')),           ModelTier::Strong ; "bare_1_strong")]
+    #[test_case(key(KeyCode::Char('2')),           ModelTier::Medium ; "bare_2_medium")]
+    #[test_case(key(KeyCode::Char('3')),           ModelTier::Weak   ; "bare_3_weak")]
     #[test_case(alt_key(KeyCode::Char('1')),       ModelTier::Strong ; "alt_1_strong")]
     #[test_case(alt_key(KeyCode::Char('2')),       ModelTier::Medium ; "alt_2_medium")]
     #[test_case(alt_key(KeyCode::Char('3')),       ModelTier::Weak   ; "alt_3_weak")]
@@ -329,16 +342,5 @@ mod tests {
             "expected AssignTier(claude-sonnet, {want:?}), got something else",
         );
         assert!(p.is_open());
-    }
-
-    #[test]
-    fn plain_number_keys_go_to_filter() {
-        let mut p = ModelPicker::new(test_models());
-        p.open("");
-        let action = p.handle_key(key(KeyCode::Char('1')));
-        assert!(
-            matches!(action, ModelPickerAction::Consumed),
-            "plain '1' should be consumed by filter, not trigger tier assignment"
-        );
     }
 }

--- a/site/docs/content/commands/_index.md
+++ b/site/docs/content/commands/_index.md
@@ -41,7 +41,7 @@ They appear in the palette as `/project:<filename>`.
 
 ### User commands
 
-Place `.md` files in `~/.maki/commands/`.
+Place `.md` files in `~/.config/maki/commands/`.
 They appear in the palette as `/user:<filename>`.
 
 Project commands override user commands with the same name.

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -82,7 +82,7 @@ Some pickers add extra bindings on top of the defaults:
 | Session Picker | `Ctrl+D` | Delete session |
 | Queue | `Enter` | Remove item |
 | Commands | `Tab` | Complete command |
-| Model Picker | `Alt+1/2/3` | Set tier (strong/medium/weak) |
+| Model Picker | `1/2/3` | Set tier (strong/medium/weak) |
 
 ## Context Inheritance
 

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -9,7 +9,7 @@ group = "Reference"
 
 Maki talks to LLM providers over their HTTP APIs. Models are split into three tiers: **weak** (cheap and fast), **medium** (balanced), and **strong** (highest capability, highest cost).
 
-Open the model picker with `/model` and press `Alt+1`, `Alt+2`, or `Alt+3` on any row to reassign it to strong, medium, or weak. Your overrides are saved to `~/.maki/model-tiers` and apply across sessions.
+Open the model picker with `/model` and press `1`, `2`, or `3` on any row to reassign it to strong, medium, or weak. Your overrides are saved to `~/.local/state/maki/model-tiers` and apply across sessions.
 
 ## Auth Reloading
 
@@ -99,8 +99,6 @@ Defaults: gpt-5-mini (weak), gpt-5.2 (medium), gpt-5.4 (strong)
 
 This provider talks the OpenAI-compatible `/v1` API, so it also works with llama.cpp's server, LocalAI, or anything else that speaks the same protocol. Just point `OLLAMA_HOST` to the right address (e.g. `http://localhost:8080` for llama.cpp).
 
-Maki asks the server for the list of installed models, so there's no built-in catalog. Tiers are guessed from list order: the first model becomes strong, the second medium, and the rest weak. If that guess is wrong, open `/model` and press `Alt+1`, `Alt+2`, or `Alt+3` on any row to reassign it. Your choices are saved to `~/.maki/model-tiers`.
-
 ### LlamaCpp
 
 - **Env var**: `LLAMA_CPP_API_KEY`
@@ -108,8 +106,6 @@ Maki asks the server for the list of installed models, so there's no built-in ca
 - **Features**: Local or remote inference via LLAMA_CPP_HOST, set optional key via LLAMA_CPP_API_KEY
 
 This provider talks the OpenAI-compatible `/v1` API, so it also works with llama.cpp's server, LocalAI, or anything else that speaks the same protocol. Just point `OLLAMA_HOST` to the right address (e.g. `http://localhost:8080` for llama.cpp).
-
-Maki asks the server for the list of installed models, so there's no built-in catalog. Tiers are guessed from list order: the first model becomes strong, the second medium, and the rest weak. If that guess is wrong, open `/model` and press `Alt+1`, `Alt+2`, or `Alt+3` on any row to reassign it. Your choices are saved to `~/.maki/model-tiers`.
 
 ### Mistral
 
@@ -159,8 +155,6 @@ Defaults: deepseek-v4-flash (medium), deepseek-v4-pro (strong)
 - **Features**: 300+ models from all providers, prompt caching, provider routing
 
 This provider talks the OpenAI-compatible `/v1` API, so it also works with llama.cpp's server, LocalAI, or anything else that speaks the same protocol. Just point `OLLAMA_HOST` to the right address (e.g. `http://localhost:8080` for llama.cpp).
-
-Maki asks the server for the list of installed models, so there's no built-in catalog. Tiers are guessed from list order: the first model becomes strong, the second medium, and the rest weak. If that guess is wrong, open `/model` and press `Alt+1`, `Alt+2`, or `Alt+3` on any row to reassign it. Your choices are saved to `~/.maki/model-tiers`.
 
 ### Synthetic
 

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -184,7 +184,7 @@ If the model name is unique across providers, the prefix can be omitted.
 
 ## Dynamic Providers
 
-To add a custom provider or proxy, drop an executable script into `~/.maki/providers/`. The script must handle these subcommands:
+To add a custom provider or proxy, drop an executable script into `~/.config/maki/providers/`. The script must handle these subcommands:
 
 | Subcommand | Timeout | What it does |
 |------------|---------|--------|

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>maki</title>
-  <meta name="description" content="An efficient AI coding agent. Native Rust TUI. Immediate startup, 60 FPS, low memory. Indexes files instead of reading them, chains tools in a sandbox interpreter. Anthropic, OpenAI, Google, Z.AI, Synthetic, or any OpenAI / Anthropic compatible API.">
+  <meta name="description" content="An efficient AI coding agent. Native Rust TUI. Immediate startup, 60 FPS, low memory. Indexes files instead of reading them, chains tools in a sandbox interpreter. Anthropic, OpenAI, Google, Z.AI, OpenRouter, Synthetic, or any OpenAI / Anthropic compatible API.">
   <meta name="theme-color" content="#f0ede2">
   <link rel="dns-prefetch" href="https://api.github.com">
   <link rel="preload" href="demo.cast" as="fetch" crossorigin fetchpriority="high">
@@ -1483,6 +1483,7 @@ imports = <span class="fn">set</span>()
         <a href="/docs/providers/#mistral" class="provider-chip">Mistral</a>
         <a href="/docs/providers/#z-ai" class="provider-chip">Z.AI</a>
         <a href="/docs/providers/#deepseek" class="provider-chip">DeepSeek</a>
+        <a href="/docs/providers/#openrouter" class="provider-chip">OpenRouter</a>
         <a href="/docs/providers/#synthetic" class="provider-chip">Synthetic</a>
       </div>
       <p class="provider-plus reveal reveal-d3">Anything that speaks the OpenAI or Anthropic API works too. Write a short <a href="https://github.com/tontinton/maki/tree/main/scripts/providers" target="_blank" rel="noopener">provider script</a>. OpenAI oauth example included.</p>


### PR DESCRIPTION
Tier shortcut keys changed from `Alt+1/2/3` to bare `1/2/3`. Models with a user-assigned tier override now get highlighted in accent color so you can see which model is active for each tier at a glance.

`TierMap::set` now evicts stale overrides for the same provider and tier, so only one model per provider per tier stays highlighted. `is_override` checks the spec is the first match in sorted order, not just present in the map.