### PR TITLE
feat(llama.cpp): Read n_ctx from /props and specify id slot

### DIFF
--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -187,12 +187,19 @@ impl Model {
                 e.max_output_tokens,
                 anthropic::shared::long_context_window(model_id).unwrap_or(e.context_window),
             ),
-            None => (
-                provider.family(),
-                ModelPricing::ZERO,
-                provider.fallback_max_output(),
-                provider.fallback_context_window(),
-            ),
+            None => {
+                let context_window = match provider {
+                    ProviderKind::LlamaCpp => llama_cpp::fetch_context_window()
+                        .unwrap_or_else(|| provider.fallback_context_window()),
+                    _ => provider.fallback_context_window(),
+                };
+                (
+                    provider.family(),
+                    ModelPricing::ZERO,
+                    provider.fallback_max_output(),
+                    context_window,
+                )
+            }
         };
         Self {
             id: model_id.to_string(),

--- a/maki-providers/src/providers/llama_cpp.rs
+++ b/maki-providers/src/providers/llama_cpp.rs
@@ -103,7 +103,7 @@ fn parse_props_n_ctx(body: &str) -> Option<u32> {
         .and_then(|s| s.get("n_ctx"))
         .or_else(|| parsed.get("n_ctx"))
         .and_then(Value::as_u64)
-        .map(|n| n as u32)
+        .and_then(|n| u32::try_from(n).ok())
 }
 
 fn parse_slot_n_ctx(body: &str, slot_id: i32) -> Option<u32> {
@@ -112,7 +112,7 @@ fn parse_slot_n_ctx(body: &str, slot_id: i32) -> Option<u32> {
     let slot = slots
         .iter()
         .find(|s| s.get("id").and_then(Value::as_i64) == Some(slot_id as i64))?;
-    slot.get("n_ctx").and_then(Value::as_u64).map(|n| n as u32)
+    slot.get("n_ctx").and_then(Value::as_u64).and_then(|n| u32::try_from(n).ok())
 }
 
 fn first_api_key() -> Option<String> {

--- a/maki-providers/src/providers/llama_cpp.rs
+++ b/maki-providers/src/providers/llama_cpp.rs
@@ -16,6 +16,7 @@ use super::{KeyPool, ResolvedAuth};
 
 const HOST_ENV: &str = "LLAMA_CPP_HOST";
 const API_KEY_ENV: &str = "LLAMA_CPP_API_KEY";
+const ID_SLOT_ENV: &str = "LLAMA_CPP_ID_SLOT";
 const HOST_NOT_SET: &str = "LLAMA_CPP_HOST not set";
 const PROBE_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 const PROBE_TOTAL_TIMEOUT: Duration = Duration::from_secs(5);
@@ -34,10 +35,12 @@ pub(crate) fn models() -> &'static [ModelEntry] {
 
 static CACHED_CONTEXT_WINDOW: OnceLock<Option<u32>> = OnceLock::new();
 
-/// Probe the running llama.cpp server for its actual context size by reading
-/// `default_generation_settings.n_ctx` from `/props`. Cached for the life of
-/// the process; returns `None` on any failure so callers fall back to a static
-/// default.
+/// Probe the running llama.cpp server for its actual context size. By default
+/// reads `default_generation_settings.n_ctx` from `/props` (always enabled).
+/// If `LLAMA_CPP_ID_SLOT` is set, reads `n_ctx` for that slot from `/slots`
+/// instead (requires the server to be started with `--slots`). Cached for the
+/// life of the process; returns `None` on any failure so callers fall back to
+/// a static default.
 pub(crate) fn fetch_context_window() -> Option<u32> {
     *CACHED_CONTEXT_WINDOW.get_or_init(probe_context_window)
 }
@@ -51,7 +54,10 @@ fn probe_context_window() -> Option<u32> {
         .build()
         .ok()?;
 
-    let n_ctx = probe_props_n_ctx(&client, host)?;
+    let n_ctx = match id_slot() {
+        Some(id) => probe_slot_n_ctx(&client, host, id)?,
+        None => probe_props_n_ctx(&client, host)?,
+    };
     debug!(n_ctx, "llama.cpp context window detected");
     Some(n_ctx)
 }
@@ -59,6 +65,11 @@ fn probe_context_window() -> Option<u32> {
 fn probe_props_n_ctx(client: &isahc::HttpClient, host: &str) -> Option<u32> {
     let body = http_get(client, &format!("{host}/props"))?;
     parse_props_n_ctx(&body)
+}
+
+fn probe_slot_n_ctx(client: &isahc::HttpClient, host: &str, slot_id: i32) -> Option<u32> {
+    let body = http_get(client, &format!("{host}/slots"))?;
+    parse_slot_n_ctx(&body, slot_id)
 }
 
 fn http_get(client: &isahc::HttpClient, url: &str) -> Option<String> {
@@ -95,8 +106,21 @@ fn parse_props_n_ctx(body: &str) -> Option<u32> {
         .map(|n| n as u32)
 }
 
+fn parse_slot_n_ctx(body: &str, slot_id: i32) -> Option<u32> {
+    let parsed: Value = serde_json::from_str(body).ok()?;
+    let slots = parsed.as_array()?;
+    let slot = slots
+        .iter()
+        .find(|s| s.get("id").and_then(Value::as_i64) == Some(slot_id as i64))?;
+    slot.get("n_ctx").and_then(Value::as_u64).map(|n| n as u32)
+}
+
 fn first_api_key() -> Option<String> {
     KeyPool::from_env(API_KEY_ENV).ok().map(|p| p.current().to_string())
+}
+
+fn id_slot() -> Option<i32> {
+    std::env::var(ID_SLOT_ENV).ok()?.trim().parse().ok()
 }
 
 pub struct LlamaCpp {
@@ -104,6 +128,7 @@ pub struct LlamaCpp {
     auth: Arc<Mutex<ResolvedAuth>>,
     key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
+    id_slot: Option<i32>,
 }
 
 impl LlamaCpp {
@@ -118,6 +143,7 @@ impl LlamaCpp {
             auth,
             key_pool: None,
             system_prefix: None,
+            id_slot: id_slot(),
         }
     }
 
@@ -151,6 +177,7 @@ impl LlamaCpp {
             })),
             key_pool,
             system_prefix: None,
+            id_slot: id_slot(),
         })
     }
 }
@@ -170,7 +197,10 @@ impl Provider for LlamaCpp {
             let auth = self.auth.lock().unwrap().clone();
             let mut buf = String::new();
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
-            let body = self.compat.build_body(model, messages, system, tools);
+            let mut body = self.compat.build_body(model, messages, system, tools);
+            if let Some(id) = self.id_slot {
+                body["id_slot"] = Value::from(id);
+            }
             self.compat
                 .do_stream(model, &[], &body, event_tx, &auth)
                 .await
@@ -238,6 +268,30 @@ mod tests {
     fn parse_props_n_ctx_handles_garbage() {
         assert_eq!(parse_props_n_ctx("not json"), None);
         assert_eq!(parse_props_n_ctx("{}"), None);
+    }
+
+    #[test]
+    fn parse_slot_n_ctx_finds_matching_slot() {
+        let body = r#"[
+            {"id":0,"n_ctx":4096},
+            {"id":1,"n_ctx":2048},
+            {"id":2,"n_ctx":8192}
+        ]"#;
+        assert_eq!(parse_slot_n_ctx(body, 0), Some(4096));
+        assert_eq!(parse_slot_n_ctx(body, 1), Some(2048));
+        assert_eq!(parse_slot_n_ctx(body, 2), Some(8192));
+    }
+
+    #[test]
+    fn parse_slot_n_ctx_missing_slot_returns_none() {
+        let body = r#"[{"id":0,"n_ctx":4096}]"#;
+        assert_eq!(parse_slot_n_ctx(body, 7), None);
+    }
+
+    #[test]
+    fn parse_slot_n_ctx_handles_garbage() {
+        assert_eq!(parse_slot_n_ctx("not json", 0), None);
+        assert_eq!(parse_slot_n_ctx(r#"{"error":"slots disabled"}"#, 0), None);
     }
 
     #[test]

--- a/maki-providers/src/providers/llama_cpp.rs
+++ b/maki-providers/src/providers/llama_cpp.rs
@@ -112,11 +112,15 @@ fn parse_slot_n_ctx(body: &str, slot_id: i32) -> Option<u32> {
     let slot = slots
         .iter()
         .find(|s| s.get("id").and_then(Value::as_i64) == Some(slot_id as i64))?;
-    slot.get("n_ctx").and_then(Value::as_u64).and_then(|n| u32::try_from(n).ok())
+    slot.get("n_ctx")
+        .and_then(Value::as_u64)
+        .and_then(|n| u32::try_from(n).ok())
 }
 
 fn first_api_key() -> Option<String> {
-    KeyPool::from_env(API_KEY_ENV).ok().map(|p| p.current().to_string())
+    KeyPool::from_env(API_KEY_ENV)
+        .ok()
+        .map(|p| p.current().to_string())
 }
 
 fn id_slot() -> Option<i32> {
@@ -254,7 +258,8 @@ mod tests {
 
     #[test]
     fn parse_props_n_ctx_reads_nested() {
-        let body = r#"{"default_generation_settings":{"n_ctx":8192,"temperature":0.8},"total_slots":1}"#;
+        let body =
+            r#"{"default_generation_settings":{"n_ctx":8192,"temperature":0.8},"total_slots":1}"#;
         assert_eq!(parse_props_n_ctx(body), Some(8192));
     }
 

--- a/maki-providers/src/providers/llama_cpp.rs
+++ b/maki-providers/src/providers/llama_cpp.rs
@@ -1,7 +1,11 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
 
 use flume::Sender;
+use isahc::ReadResponseExt;
+use isahc::config::Configurable;
 use serde_json::Value;
+use tracing::{debug, warn};
 
 use crate::model::{Model, ModelEntry};
 use crate::provider::{BoxFuture, Provider};
@@ -13,6 +17,8 @@ use super::{KeyPool, ResolvedAuth};
 const HOST_ENV: &str = "LLAMA_CPP_HOST";
 const API_KEY_ENV: &str = "LLAMA_CPP_API_KEY";
 const HOST_NOT_SET: &str = "LLAMA_CPP_HOST not set";
+const PROBE_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+const PROBE_TOTAL_TIMEOUT: Duration = Duration::from_secs(5);
 
 static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     api_key_env: "",
@@ -24,6 +30,73 @@ static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
 
 pub(crate) fn models() -> &'static [ModelEntry] {
     &[]
+}
+
+static CACHED_CONTEXT_WINDOW: OnceLock<Option<u32>> = OnceLock::new();
+
+/// Probe the running llama.cpp server for its actual context size by reading
+/// `default_generation_settings.n_ctx` from `/props`. Cached for the life of
+/// the process; returns `None` on any failure so callers fall back to a static
+/// default.
+pub(crate) fn fetch_context_window() -> Option<u32> {
+    *CACHED_CONTEXT_WINDOW.get_or_init(probe_context_window)
+}
+
+fn probe_context_window() -> Option<u32> {
+    let host = std::env::var(HOST_ENV).ok()?;
+    let host = host.trim_end_matches('/');
+    let client = isahc::HttpClient::builder()
+        .connect_timeout(PROBE_CONNECT_TIMEOUT)
+        .timeout(PROBE_TOTAL_TIMEOUT)
+        .build()
+        .ok()?;
+
+    let n_ctx = probe_props_n_ctx(&client, host)?;
+    debug!(n_ctx, "llama.cpp context window detected");
+    Some(n_ctx)
+}
+
+fn probe_props_n_ctx(client: &isahc::HttpClient, host: &str) -> Option<u32> {
+    let body = http_get(client, &format!("{host}/props"))?;
+    parse_props_n_ctx(&body)
+}
+
+fn http_get(client: &isahc::HttpClient, url: &str) -> Option<String> {
+    let mut builder = isahc::Request::get(url);
+    if let Some(key) = first_api_key() {
+        builder = builder.header("authorization", format!("Bearer {key}"));
+    }
+    let request = builder.body(()).ok()?;
+
+    let mut resp = match client.send(request) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(error = %e, %url, "failed to probe llama.cpp; using fallback context window");
+            return None;
+        }
+    };
+
+    let status = resp.status().as_u16();
+    if status != 200 {
+        warn!(status, %url, "llama.cpp probe returned non-200; using fallback context window");
+        return None;
+    }
+
+    resp.text().ok()
+}
+
+fn parse_props_n_ctx(body: &str) -> Option<u32> {
+    let parsed: Value = serde_json::from_str(body).ok()?;
+    parsed
+        .get("default_generation_settings")
+        .and_then(|s| s.get("n_ctx"))
+        .or_else(|| parsed.get("n_ctx"))
+        .and_then(Value::as_u64)
+        .map(|n| n as u32)
+}
+
+fn first_api_key() -> Option<String> {
+    KeyPool::from_env(API_KEY_ENV).ok().map(|p| p.current().to_string())
 }
 
 pub struct LlamaCpp {
@@ -147,6 +220,24 @@ mod tests {
         let auth = llama.auth.lock().unwrap();
         assert_eq!(auth.base_url.as_deref(), Some("http://x:1234/v1"));
         assert!(auth.headers.is_empty());
+    }
+
+    #[test]
+    fn parse_props_n_ctx_reads_nested() {
+        let body = r#"{"default_generation_settings":{"n_ctx":8192,"temperature":0.8},"total_slots":1}"#;
+        assert_eq!(parse_props_n_ctx(body), Some(8192));
+    }
+
+    #[test]
+    fn parse_props_n_ctx_falls_back_to_top_level() {
+        let body = r#"{"n_ctx":4096,"total_slots":1}"#;
+        assert_eq!(parse_props_n_ctx(body), Some(4096));
+    }
+
+    #[test]
+    fn parse_props_n_ctx_handles_garbage() {
+        assert_eq!(parse_props_n_ctx("not json"), None);
+        assert_eq!(parse_props_n_ctx("{}"), None);
     }
 
     #[test]


### PR DESCRIPTION
This adds two features for interacting with a llama.cpp service:

- Read the context size directly from llama.cpp `/props` endpoint instead of the general fallback
- Add env var `LLAMA_CPP_ID_SLOT` for picking a dedicated llama.cpp slot (when the llama server is running with `--slots`) for people running parallel queries