### PR TITLE
agent: fix MCP tools not loaded in headless mode 🤖🤖🤖

### DIFF
--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -47,8 +47,12 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
 
     let filter = ToolFilter::from_config(&params.config, &params.excluded_tools);
     let ctx = DescriptionContext { filter: &filter };
-    let tools =
+    let mut tools =
         ToolRegistry::native().definitions(&vars, &ctx, params.model.supports_tool_examples());
+
+    if let Some(handle) = &params.mcp_handle {
+        handle.extend_tools(&mut tools);
+    }
 
     let system = agent::build_system_prompt(&vars, &mode, &instructions.text, &params.prompt_slots);
 


### PR DESCRIPTION
## Problem

In headless / print mode (`maki -p`), MCP servers start and connect, but **none of their tools are ever exposed to the model**. The `system/init` event lists only the 16 native tools, and the model cannot call any `mcp__*` tool.

This is a regression. #201 originally fixed "MCP tools not loaded in headless mode". Later, #240 ("add `headless` module for embedding maki as a library") moved the print-mode logic into `maki-agent/src/headless.rs` and, while doing so, built the tool list from `ToolRegistry::native()` only — it dropped the `extend_tools` call that the interactive UI path performs.

So in `headless::spawn`:
- `mcp::start(cwd)` runs and `mcp_handle` is passed via `.with_mcp(...)` (execution wiring is fine), **but**
- the `tools` Value sent to the model and used for `tool_names` is native-only, so MCP descriptors never reach the model nor the init event.

## Fix

Merge the MCP tool descriptors into the tool list before spawning the agent, exactly like the interactive path does:

```rust
if let Some(handle) = &params.mcp_handle {
    handle.extend_tools(&mut tools);
}
```

One-line behavioral change, in the same spirit as the existing `extend_tools` usage already covered by tests in `mcp/mod.rs`.

## Verification

Built `v0.3.13` with and without the patch and ran `maki -p --output-format stream-json --verbose` in a cwd with a `.maki/mcp.toml` pointing at `@modelcontextprotocol/server-everything` (stdio):

- **Unpatched:** `init.tools` = 16 native tools, **0** `everything__*` tools.
- **Patched:** `init.tools` = 16 native + all 13 `everything__*` MCP tools.

Also reproduced the original bug against a real remote HTTP MCP server before fixing.

## AI use

Diagnosed and written with an AI coding agent. The root cause was found by reading `headless.rs` / `print.rs` / `mcp/mod.rs` and comparing the headless tool-list construction against the interactive path, then confirmed with the before/after `server-everything` test above. Prompt intent: "trace why MCP tools are missing in `-p` mode and apply the minimal fix matching the interactive path".