### PR TITLE
agent: recover panicked tools instead of dropping them

### DIFF
--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -298,7 +298,9 @@ pub(super) async fn process_tool_calls(
     }
 
     let mut set = TaskSet::new();
+    let mut spawned_ids: Vec<String> = Vec::new();
     for (id, name, input) in runnable {
+        spawned_ids.push(id.clone());
         let event_tx_clone = ctx.event_tx.clone();
         let tool_ctx = ToolContext {
             tool_use_id: Some(id.clone()),
@@ -325,11 +327,12 @@ pub(super) async fn process_tool_calls(
         .join_all()
         .await
         .into_iter()
-        .filter_map(|r| match r {
-            Ok(out) => Some(out),
+        .zip(spawned_ids)
+        .map(|(r, id)| match r {
+            Ok(out) => out,
             Err(e) => {
                 error!(error = %e, "tool task panicked");
-                None
+                ToolDoneEvent::error(id, format!("internal error: tool panicked: {e}"))
             }
         })
         .collect();


### PR DESCRIPTION
When a tool panicked (e.g. monty `ForIter` crash during `code_execution`), `process_tool_calls` silently dropped the result via `filter_map` + `None`. The assistant message still had a `tool_use` block for that ID, but the follow-up user message was missing its `tool_result`, so the API returned a 400 `"user messages must have non-empty content"`.

Track `spawned_ids` alongside the `TaskSet` and zip them with results, so panics become `ToolDoneEvent::error` with the right ID instead of vanishing. The model now sees the panic message as a tool error and can retry or move on.