### PR TITLE
agent: allow writes when no prior read is recorded

### DIFF
--- a/maki-agent/src/tools/file_tracker.rs
+++ b/maki-agent/src/tools/file_tracker.rs
@@ -43,15 +43,11 @@ impl FileReadTracker {
 
         let guard = self.0.lock().unwrap();
         match guard.get(&normalized) {
-            None => Err(format!(
-                "file must be read before editing with read tool: {}",
-                path.display()
-            )),
             Some(&recorded) if recorded != current_mtime => Err(format!(
                 "file changed since last read: {} - re-read using read tool before editing",
                 path.display()
             )),
-            Some(_) => Ok(()),
+            _ => Ok(()),
         }
     }
 }
@@ -60,17 +56,14 @@ impl FileReadTracker {
 mod tests {
     use super::*;
 
-    const ERR_NOT_READ: &str = "file must be read before editing";
-
     #[test]
-    fn edit_without_read_fails() {
+    fn edit_without_read_allowed() {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("untracked.rs");
         fs::write(&path, "content").unwrap();
 
         let tracker = FileReadTracker::new();
-        let err = tracker.check_before_edit(&path).unwrap_err();
-        assert!(err.contains(ERR_NOT_READ));
+        tracker.check_before_edit(&path).unwrap();
     }
 
     #[test]

--- a/maki-agent/src/tools/write.rs
+++ b/maki-agent/src/tools/write.rs
@@ -41,9 +41,7 @@ impl Write {
         let file_tracker = ctx.file_tracker.clone();
         smol::unblock(move || {
             let p = Path::new(&path);
-            if p.exists() {
-                file_tracker.check_before_edit(p)?;
-            }
+            file_tracker.check_before_edit(p)?;
             if let Some(parent) = p.parent() {
                 fs::create_dir_all(parent).map_err(|e| format!("mkdir error: {e}"))?;
             }
@@ -98,8 +96,6 @@ mod tests {
 
     use super::*;
 
-    const ERR_NOT_READ: &str = "file must be read before editing";
-
     #[test]
     fn write_new_file_succeeds() {
         smol::block_on(async {
@@ -120,23 +116,22 @@ mod tests {
     }
 
     #[test]
-    fn write_existing_without_read_fails() {
+    fn write_existing_without_read_allowed() {
         smol::block_on(async {
             let dir = TempDir::new().unwrap();
             let ctx = stub_ctx(&AgentMode::Build);
             let path = dir.path().join("existing.txt");
             fs::write(&path, "original").unwrap();
 
-            let err = Write {
+            Write {
                 path: path.to_string_lossy().to_string(),
                 content: "overwrite".into(),
             }
             .execute(&ctx)
             .await
-            .unwrap_err();
+            .unwrap();
 
-            assert!(err.contains(ERR_NOT_READ));
-            assert_eq!(fs::read_to_string(&path).unwrap(), "original");
+            assert_eq!(fs::read_to_string(&path).unwrap(), "overwrite");
         });
     }
 


### PR DESCRIPTION
`FileReadTracker::check_before_edit` used to reject any write to a file that was never read in the current session. This meant a fresh session could not `write` to an existing file without a pointless `read` first.

Now the `None` case (no mtime on record) falls through to `Ok(())`, so writes are only blocked when we actually have a stale mtime to compare against.