### PR TITLE
ui: restore `code_execution` separator between script and output

### DIFF
--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -77,6 +77,7 @@ pub const TOOL_INDICATOR: &str = "● ";
 pub const TOOL_BODY_INDENT: &str = "  ";
 
 const TOOL_SEPARATOR: &str = "──────────────────";
+const CODE_OUTPUT_DIVIDER: &str = "  ────────────";
 const BATCH_INDENT: &str = "  ";
 const BATCH_CONTENT_INDENT: &str = "    ";
 
@@ -562,7 +563,7 @@ impl ToolLineBuilder {
             self.lines.push(line);
         }
         self.content_range = (start, self.lines.len());
-        if let Some(ToolInput::Code { code, .. }) = input {
+        if let Some(ToolInput::Code { code, .. } | ToolInput::Script { code, .. }) = input {
             self.push_search_text(code.trim_end());
         }
         if let Some(text) = output.and_then(|o| o.structured_display_text()) {
@@ -573,6 +574,13 @@ impl ToolLineBuilder {
     fn push_resolved_output(&mut self, resolved: &ResolvedOutput<'_>) {
         if resolved.text.is_none() {
             return;
+        }
+
+        if self.content_range.1 > self.content_range.0 {
+            self.lines.push(Line::from(Span::styled(
+                CODE_OUTPUT_DIVIDER,
+                theme::current().tool_dim,
+            )));
         }
 
         if let Some(text) = &resolved.text {


### PR DESCRIPTION
The `SeparatorStyle` cleanup in `04539a2` targeted bash (moved to Lua), but also removed the dim `────────────` rule that sat between a `code_execution` python script and its output.

Bring it back with a `CODE_EXECUTION_OUTPUT_SEPARATOR` const in `push_resolved_output`, inserted when `content_range` shows code lines above. Also fix `push_code_content` search text to match both `ToolInput::Code` and `ToolInput::Script` so scripts are searchable too.