### PR TITLE
providers: anthropic: add `claude-fable-5`

### DIFF
--- a/maki-providers/src/providers/anthropic/shared.rs
+++ b/maki-providers/src/providers/anthropic/shared.rs
@@ -509,6 +509,21 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             context_window: 200_000,
         },
         ModelEntry {
+            prefixes: &["claude-fable-5"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Claude,
+            default: false,
+            pricing: ModelPricing {
+                input: 10.00,
+                output: 50.00,
+                cache_write: 12.50,
+                cache_read: 1.00,
+                fast: None,
+            },
+            max_output_tokens: 128000,
+            context_window: 200_000,
+        },
+        ModelEntry {
             prefixes: &["claude-opus-4-0", "claude-opus-4-1"],
             tier: ModelTier::Strong,
             family: ModelFamily::Claude,

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -29,7 +29,7 @@ You can set multiple API keys in one env var (`ANTHROPIC_API_KEY=sk-1,sk-2,sk-3`
 |------|--------|-------------------------------|---------|
 | Weak | **claude-haiku-4-5** (default) | $1.00 / $5.00 | 200K ctx / 64K out |
 | Medium | claude-sonnet-4-5, **claude-sonnet-4-6** (default), claude-sonnet-4 | $3.00 / $15.00 | 200K ctx / 64K out |
-| Strong | claude-opus-4-5, claude-opus-4-6, claude-opus-4-7, **claude-opus-4-8** (default), claude-opus-4-0, claude-opus-4-1 | $5.00 / $25.00 | 200K ctx / 64K out |
+| Strong | claude-opus-4-5, claude-opus-4-6, claude-opus-4-7, **claude-opus-4-8** (default), claude-fable-5, claude-opus-4-0, claude-opus-4-1 | $5.00 / $25.00 | 200K ctx / 64K out |
 
 Defaults: claude-haiku-4-5 (weak), claude-sonnet-4-6 (medium), claude-opus-4-8 (strong)
 


### PR DESCRIPTION
The Anthropic `/models` endpoint does not list `claude-fable-5` yet, so
the model is completely absent from the picker.

Adding the static `ModelEntry` makes it available as a fallback, with
Strong tier, $10/$50 pricing, and 128k output / 200k context to match
the other top-tier Claude models.