### PR TITLE
lua: bash: expand `~` in jobstart cwd and name it in errors

### DIFF
--- a/maki-lua/src/api/fn_api.rs
+++ b/maki-lua/src/api/fn_api.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use mlua::{Function, Lua, RegistryKey, Result as LuaResult, Table};
 
+use crate::api::fs::expand_tilde;
 use crate::runtime::with_task_jobs;
 
 use crate::plugin_permissions::{
@@ -72,7 +73,10 @@ impl JobStore {
             }
         }
 
-        if let Some(ref dir) = cwd {
+        if let Some(dir) = cwd.as_deref().map(expand_tilde) {
+            if !dir.is_dir() {
+                return Err(format!("cwd is not a directory: {}", dir.display()));
+            }
             command.current_dir(dir);
         }
         if let Some(ref env_map) = env {

--- a/maki-lua/src/api/fs.rs
+++ b/maki-lua/src/api/fs.rs
@@ -11,7 +11,7 @@ use crate::plugin_permissions::{
     PluginPermissions,
 };
 
-fn expand_tilde(path: &str) -> PathBuf {
+pub(crate) fn expand_tilde(path: &str) -> PathBuf {
     if let Some(rest) = path.strip_prefix("~/") {
         if let Some(home) = maki_storage::paths::home() {
             return home.join(rest);

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -55,6 +55,8 @@ const NON_STRING_FIELD_SCHEMA: &str = r#"{
     properties = { count = { type = "integer" } },
     required = { "count" },
 }"#;
+const JOB_BAD_CWD: &str = "~/definitely/not/a/dir";
+const JOB_BAD_CWD_ERR_PREFIX: &str = "cwd is not a directory: ";
 const NIL_WITHOUT_JOBS_ERR: &str =
     "handler returned nil without calling ctx:finish() or starting jobs";
 const FINISH_CALLED_TWICE_ERR: &str = "ctx:finish() already called";
@@ -678,6 +680,31 @@ fn async_job_on_exit_receives_exit_code() {
     host.load_source("job_exit_code", &src).unwrap();
     let out = exec_tool(&reg, "job_exit_code", serde_json::json!({})).unwrap();
     assert_eq!(out, "code=42");
+}
+
+#[test]
+fn jobstart_invalid_cwd_errors_with_expanded_path() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "job_bad_cwd",
+            description = "jobstart with missing tilde cwd",
+            schema = {MINIMAL_SCHEMA},
+            audiences = {{ "main" }},
+            handler = function(input, ctx)
+                local _, err = pcall(maki.fn.jobstart, "pwd", {{ cwd = "{JOB_BAD_CWD}" }})
+                return tostring(err)
+            end
+        }})"#,
+    );
+    host.load_source("job_bad_cwd", &src).unwrap();
+    let out = exec_tool(&reg, "job_bad_cwd", serde_json::json!({})).unwrap();
+    let expanded = maki_storage::paths::home()
+        .expect("home dir")
+        .join(JOB_BAD_CWD.strip_prefix("~/").unwrap());
+    let expected = format!("{JOB_BAD_CWD_ERR_PREFIX}{}", expanded.display());
+    assert!(out.contains(&expected), "got: {out}");
 }
 
 #[test]


### PR DESCRIPTION
The bash tool passes `workdir` straight to `Command::current_dir`, so a path like `~/c/trino` failed with a bare `No such file or directory (os error 2)` that never mentioned the cwd.

After seeing that once, the model decided `workdir` was broken and went back to running everything from the repo root.

Reuse `expand_tilde` from the fs API and validate the directory upfront, so a bad cwd now fails with `cwd is not a directory: <path>`.