### PR TITLE
acp: add `maki acp` subcommand for ACP over stdio

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ Rust workspace, key crates in root dir:
 - maki-storage: Persistent state across runs (e.g. sessions, auth)
 - maki-config: User config
 - maki-lua: Lua plugin system (API mirrored from neovim for plugin compatibility), built-in plugins in ./plugins dir
+- maki-acp: ACP ndjson stdio server
 
 Built-in lua plugins in ./plugins: index (return a compact skeleton of a source file using tree-sitter), bash, glob, question, skill, memory, webfetch, websearch.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "agent-client-protocol-schema"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c290bfa00c6b52339db66f8e9cf711d5f08530800529f7d619ff24d6cba253d0"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum 0.28.0",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +445,15 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -863,8 +887,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -882,12 +916,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -905,6 +963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -938,6 +997,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -992,6 +1052,12 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -1511,6 +1577,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1803,6 +1875,17 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
@@ -1848,7 +1931,7 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "indoc",
  "proc-macro2",
  "quote",
@@ -2219,6 +2302,7 @@ dependencies = [
  "futures-lite",
  "isahc",
  "libc",
+ "maki-acp",
  "maki-agent",
  "maki-config",
  "maki-lua",
@@ -2233,6 +2317,24 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "maki-acp"
+version = "0.3.16"
+dependencies = [
+ "agent-client-protocol-schema",
+ "color-eyre",
+ "flume 0.11.1",
+ "maki-agent",
+ "maki-providers",
+ "maki-storage",
+ "serde",
+ "serde_json",
+ "smol",
+ "tempfile",
+ "test-case",
+ "tracing",
 ]
 
 [[package]]
@@ -2270,7 +2372,7 @@ dependencies = [
  "sha2",
  "similar",
  "smol",
- "strum",
+ "strum 0.27.2",
  "tempfile",
  "test-case",
  "thiserror 2.0.18",
@@ -2315,7 +2417,7 @@ dependencies = [
  "maki-ui",
  "serde_json",
  "smol",
- "strum",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -2417,7 +2519,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "smol",
- "strum",
+ "strum 0.27.2",
  "tempfile",
  "test-case",
  "thiserror 2.0.18",
@@ -2485,7 +2587,7 @@ dependencies = [
  "serde_json",
  "shell-words",
  "smol",
- "strum",
+ "strum 0.27.2",
  "syntect",
  "tempfile",
  "test-case",
@@ -2672,7 +2774,7 @@ dependencies = [
  "chrono",
  "fancy-regex 0.17.0",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.13.0",
  "itertools 0.14.0",
  "jiter",
  "libm",
@@ -2688,7 +2790,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "speedate",
- "strum",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -2803,9 +2905,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -3018,7 +3120,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfa78c92071bbd3628c22b1a964f7e0eb201dc1456555db072beb1662ecd6715"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
 ]
 
 [[package]]
@@ -3129,7 +3231,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
 ]
 
 [[package]]
@@ -3287,7 +3389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64",
- "indexmap",
+ "indexmap 2.13.0",
  "quick-xml 0.38.4",
  "serde",
  "time",
@@ -3654,7 +3756,7 @@ dependencies = [
  "itertools 0.14.0",
  "kasuari",
  "lru",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -3706,7 +3808,7 @@ dependencies = [
  "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "strum",
+ "strum 0.27.2",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -3739,6 +3841,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3910,6 +4032,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3962,12 +4121,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -3985,12 +4155,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -4142,8 +4344,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aba069c070b5e213f2a094deb7e5ed50ecb092be36102a4f4042e8d2056d060e"
 dependencies = [
  "lexical-parse-float",
- "strum",
- "strum_macros",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -4209,7 +4411,16 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -4217,6 +4428,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4481,9 +4704,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -4498,15 +4721,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4574,7 +4797,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5181,7 +5404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -5194,7 +5417,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
@@ -5657,7 +5880,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -5688,7 +5911,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -5707,7 +5930,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://maki.sh"
 readme = "README.md"
 keywords = ["ai", "agent", "cli", "tui", "coding"]
 categories = ["command-line-utilities", "development-tools"]
-rust-version = "1.85"
+rust-version = "1.88"
 
 [[bin]]
 name = "maki"
@@ -22,6 +22,7 @@ demo = ["maki-ui/demo"]
 [dependencies]
 maki-ui = { workspace = true }
 maki-agent = { workspace = true }
+maki-acp = { workspace = true }
 maki-config = { workspace = true }
 maki-providers = { workspace = true }
 maki-storage = { workspace = true }
@@ -44,6 +45,7 @@ test-case = { workspace = true }
 
 [workspace]
 members = [
+  "maki-acp",
   "maki-agent",
   "maki-config",
   "maki-docgen",
@@ -65,10 +67,11 @@ edition = "2024"
 authors = ["Tony Solomonik <tony.solomonik@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/tontinton/maki"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [workspace.dependencies]
 maki-agent = { path = "maki-agent" }
+maki-acp = { path = "maki-acp" }
 maki-config = { path = "maki-config" }
 maki-interpreter = { path = "maki-interpreter" }
 maki-providers = { path = "maki-providers" }
@@ -159,6 +162,7 @@ monty = { git = "https://github.com/pydantic/monty.git", tag = "v0.0.17", packag
 notify = { version = "9.0.0-rc.2", default-features = false, features = ["flume", "macos_fsevent"] }
 serde_yaml = "0.9"
 shell-words = "1"
+agent-client-protocol-schema = "0.13"
 
 wait-timeout = "0.2"
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ nix run github:tontinton/maki
 
 Or download a pre-built binary from [GitHub Releases](https://github.com/tontinton/maki/releases/latest).
 
+## ACP
+
+Run `maki acp` or configure your ACP supporting editor to use maki, e.g. in [Zed](https://zed.dev/)'s `settings.json`:
+
+```json
+"agent_servers": {
+  "Maki": {
+    "default_config_options": {
+      "model": "deepseek/deepseek-v4-flash"
+    },
+    "type": "custom",
+    "command": "maki",
+    "args": ["acp"],
+    "env": {}
+  }
+}
+```
+
 ## Documentation
 
 More info at the [official docs](http://maki.sh/docs).

--- a/maki-acp/Cargo.toml
+++ b/maki-acp/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "maki-acp"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+maki-agent = { workspace = true }
+maki-providers = { workspace = true }
+maki-storage = { workspace = true }
+agent-client-protocol-schema = { workspace = true }
+smol = { workspace = true }
+flume = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+color-eyre = { workspace = true }
+
+[dev-dependencies]
+test-case = { workspace = true }
+tempfile = { workspace = true }

--- a/maki-acp/src/lib.rs
+++ b/maki-acp/src/lib.rs
@@ -1,0 +1,27 @@
+pub mod methods;
+pub mod permissions;
+pub mod server;
+pub mod translate;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use maki_agent::prompt::ResolvedSlots;
+use maki_agent::{AgentConfig, PermissionsConfig};
+use maki_providers::Timeouts;
+use maki_providers::model::Model;
+
+pub struct AcpParams {
+    pub model: Model,
+    pub config: AgentConfig,
+    pub permissions_config: PermissionsConfig,
+    pub timeouts: Timeouts,
+    pub initial_wd: PathBuf,
+    pub mcp_handle: Option<maki_agent::McpHandle>,
+    pub prompt_slots: Arc<ResolvedSlots>,
+    pub yolo: bool,
+}
+
+pub fn run(params: AcpParams) -> color_eyre::Result<()> {
+    smol::block_on(server::serve(params))
+}

--- a/maki-acp/src/methods.rs
+++ b/maki-acp/src/methods.rs
@@ -1,0 +1,70 @@
+use agent_client_protocol_schema::{
+    AgentCapabilities, Implementation, InitializeResponse, LoadSessionResponse, McpCapabilities,
+    NewSessionResponse, PromptCapabilities, ProtocolVersion, SessionConfigOption,
+    SessionConfigOptionCategory, SessionConfigSelectOption, SessionMode, SessionModeId,
+    SessionModeState,
+};
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+const MODE_BUILD: &str = "build";
+const MODE_PLAN: &str = "plan";
+
+pub const MODEL_CONFIG_ID: &str = "model";
+
+pub fn initialize_response() -> InitializeResponse {
+    InitializeResponse::new(ProtocolVersion::V1)
+        .agent_capabilities(
+            AgentCapabilities::new()
+                .load_session(true)
+                .prompt_capabilities(PromptCapabilities::new().image(true).embedded_context(true))
+                .mcp_capabilities(McpCapabilities::default()),
+        )
+        .auth_methods(vec![])
+        .agent_info(Implementation::new("maki", VERSION))
+}
+
+pub fn mode_state(current: &str) -> SessionModeState {
+    SessionModeState::new(
+        SessionModeId::from(current.to_string()),
+        vec![
+            SessionMode::new(SessionModeId::from(MODE_BUILD.to_string()), "Build"),
+            SessionMode::new(SessionModeId::from(MODE_PLAN.to_string()), "Plan"),
+        ],
+    )
+}
+
+pub fn new_session_response(session_id: &str) -> NewSessionResponse {
+    NewSessionResponse::new(session_id.to_string()).modes(mode_state(MODE_BUILD))
+}
+
+pub fn load_session_response() -> LoadSessionResponse {
+    LoadSessionResponse::new().modes(mode_state(MODE_BUILD))
+}
+
+pub fn model_config_option(current: &str, specs: &[String]) -> SessionConfigOption {
+    let mut options: Vec<SessionConfigSelectOption> = specs
+        .iter()
+        .map(|spec| SessionConfigSelectOption::new(spec.clone(), spec.clone()))
+        .collect();
+    if !specs.iter().any(|spec| spec == current) {
+        options.insert(
+            0,
+            SessionConfigSelectOption::new(current.to_string(), current.to_string()),
+        );
+    }
+    SessionConfigOption::select(MODEL_CONFIG_ID, "Model", current.to_string(), options)
+        .category(SessionConfigOptionCategory::Model)
+}
+
+pub fn mode_id_to_agent_mode(mode_id: &str) -> Option<maki_agent::AgentMode> {
+    match mode_id {
+        MODE_BUILD => Some(maki_agent::AgentMode::Build),
+        MODE_PLAN => {
+            let storage = maki_storage::StateDir::resolve().ok()?;
+            let plan_path = maki_storage::plans::new_plan_path(&storage).ok()?;
+            Some(maki_agent::AgentMode::Plan(plan_path))
+        }
+        _ => None,
+    }
+}

--- a/maki-acp/src/permissions.rs
+++ b/maki-acp/src/permissions.rs
@@ -1,0 +1,48 @@
+use agent_client_protocol_schema::{
+    PermissionOption, PermissionOptionId, PermissionOptionKind, RequestPermissionOutcome,
+};
+use maki_agent::permissions::PermissionAnswer;
+
+const ALLOW_ONCE_ID: &str = "allow_once";
+const ALLOW_ALWAYS_ID: &str = "allow_always";
+const REJECT_ONCE_ID: &str = "reject_once";
+const REJECT_ALWAYS_ID: &str = "reject_always";
+
+pub fn permission_options() -> Vec<PermissionOption> {
+    vec![
+        PermissionOption::new(
+            PermissionOptionId::from(ALLOW_ONCE_ID),
+            "Allow once",
+            PermissionOptionKind::AllowOnce,
+        ),
+        PermissionOption::new(
+            PermissionOptionId::from(ALLOW_ALWAYS_ID),
+            "Allow always",
+            PermissionOptionKind::AllowAlways,
+        ),
+        PermissionOption::new(
+            PermissionOptionId::from(REJECT_ONCE_ID),
+            "Reject once",
+            PermissionOptionKind::RejectOnce,
+        ),
+        PermissionOption::new(
+            PermissionOptionId::from(REJECT_ALWAYS_ID),
+            "Reject always",
+            PermissionOptionKind::RejectAlways,
+        ),
+    ]
+}
+
+pub fn outcome_to_answer(outcome: &RequestPermissionOutcome) -> PermissionAnswer {
+    match outcome {
+        RequestPermissionOutcome::Cancelled => PermissionAnswer::Deny,
+        RequestPermissionOutcome::Selected(selected) => match selected.option_id.0.as_ref() {
+            ALLOW_ONCE_ID => PermissionAnswer::AllowOnce,
+            ALLOW_ALWAYS_ID => PermissionAnswer::AllowSession,
+            REJECT_ONCE_ID => PermissionAnswer::Deny,
+            REJECT_ALWAYS_ID => PermissionAnswer::DenyAlwaysLocal,
+            _ => PermissionAnswer::Deny,
+        },
+        _ => PermissionAnswer::Deny,
+    }
+}

--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -1,0 +1,501 @@
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use agent_client_protocol_schema::{
+    AgentNotification, AgentRequest, AgentResponse, ContentBlock, CurrentModeUpdate,
+    EmbeddedResourceResource, Error as AcpError, ImageContent, JsonRpcMessage, LoadSessionRequest,
+    NewSessionRequest, Notification, PromptRequest, PromptResponse, Request, RequestId,
+    RequestPermissionRequest, RequestPermissionResponse, Response, SessionId, SessionModeId,
+    SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
+    SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModeResponse, TextContent,
+    ToolCallId, ToolCallUpdate, ToolCallUpdateFields,
+};
+use color_eyre::eyre::Context;
+use flume::{Receiver, Sender};
+use maki_agent::headless::{self, InteractiveHandle, InteractiveParams};
+use maki_agent::types::{AgentEvent, BatchToolStatus, ToolOutput};
+use maki_agent::{AgentInput, AgentMode, Envelope, ImageMediaType, ImageSource};
+use maki_providers::Message;
+use maki_providers::model::Model;
+use maki_providers::provider::available_model_specs;
+use serde::Serialize;
+use serde_json::Value;
+use smol::io::AsyncBufReadExt;
+use tracing::{debug, warn};
+
+use crate::{AcpParams, methods, permissions, translate};
+
+const FIRST_OUTGOING_REQUEST_ID: i64 = 1000;
+
+type PendingPrompt = Arc<Mutex<Option<RequestId>>>;
+
+struct SessionState {
+    handle: InteractiveHandle,
+    current_mode: AgentMode,
+    current_model: String,
+    pending_prompt: PendingPrompt,
+}
+
+struct Server {
+    out_tx: Sender<Value>,
+    model_specs: Vec<String>,
+    session: Option<SessionState>,
+}
+
+impl Server {
+    fn respond(&self, id: RequestId, result: Result<AgentResponse, AcpError>) {
+        send(&self.out_tx, Response::new(id, result));
+    }
+}
+
+pub async fn serve(params: AcpParams) -> color_eyre::Result<()> {
+    let (out_tx, out_rx) = flume::unbounded::<Value>();
+
+    let writer_task = smol::spawn(async move {
+        let stdout = std::io::stdout();
+        while let Ok(msg) = out_rx.recv_async().await {
+            let mut handle = stdout.lock();
+            if serde_json::to_writer(&mut handle, &msg).is_ok() {
+                let _ = handle.write_all(b"\n");
+                let _ = handle.flush();
+            }
+        }
+    });
+
+    let mut server = Server {
+        out_tx,
+        model_specs: available_model_specs(),
+        session: None,
+    };
+
+    let stdin = smol::Unblock::new(std::io::stdin());
+    let mut reader = smol::io::BufReader::new(stdin);
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        if reader.read_line(&mut line).await.context("read stdin")? == 0 {
+            break;
+        }
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let raw: Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(error = %e, "invalid JSON on stdin");
+                server.respond(RequestId::Null, Err(AcpError::parse_error()));
+                continue;
+            }
+        };
+
+        let id = raw.get("id").map(request_id);
+
+        if raw.get("result").is_some() || raw.get("error").is_some() {
+            handle_incoming_response(&server, &raw);
+        } else if let Some(method) = raw.get("method").and_then(Value::as_str) {
+            match id {
+                Some(id) => handle_request(&mut server, method, id, &raw, &params),
+                None => handle_notification(&server, method),
+            }
+        } else if let Some(id) = id {
+            server.respond(id, Err(AcpError::invalid_request()));
+        }
+    }
+
+    drop(server);
+    writer_task.await;
+
+    Ok(())
+}
+
+fn request_id(v: &Value) -> RequestId {
+    serde_json::from_value(v.clone()).unwrap_or(RequestId::Null)
+}
+
+fn handle_request(srv: &mut Server, method: &str, id: RequestId, raw: &Value, params: &AcpParams) {
+    let result = match method {
+        "initialize" => Ok(AgentResponse::InitializeResponse(
+            methods::initialize_response(),
+        )),
+        "session/new" => parse_params::<NewSessionRequest>(raw).map(|req| {
+            let handle = spawn_session(params, req.cwd, None, Vec::new());
+            let spec = params.model.spec();
+            let resp = methods::new_session_response(&handle.session_id)
+                .config_options(vec![methods::model_config_option(&spec, &srv.model_specs)]);
+            install_session(srv, handle, spec);
+            AgentResponse::NewSessionResponse(resp)
+        }),
+        "session/load" => parse_params::<LoadSessionRequest>(raw).and_then(|req| {
+            let session_id = req.session_id.0.to_string();
+            let history = load_history(&session_id)?;
+            let sid = SessionId::from(session_id.clone());
+            for update in translate::replay_history(&history) {
+                session_update(&srv.out_tx, &sid, update);
+            }
+            let handle = spawn_session(params, req.cwd, Some(session_id), history);
+            let spec = params.model.spec();
+            let resp = methods::load_session_response()
+                .config_options(vec![methods::model_config_option(&spec, &srv.model_specs)]);
+            install_session(srv, handle, spec);
+            Ok(AgentResponse::LoadSessionResponse(resp))
+        }),
+        "session/prompt" => match handle_prompt(srv, raw, &id) {
+            Ok(()) => return,
+            Err(e) => Err(e),
+        },
+        "session/set_mode" => handle_set_mode(srv, raw),
+        "session/set_config_option" => handle_set_config(srv, raw),
+        _ => Err(AcpError::method_not_found()),
+    };
+    srv.respond(id, result);
+}
+
+fn spawn_session(
+    params: &AcpParams,
+    cwd: PathBuf,
+    session_id: Option<String>,
+    history: Vec<Message>,
+) -> InteractiveHandle {
+    headless::spawn_interactive(InteractiveParams {
+        model: params.model.clone(),
+        config: params.config.clone(),
+        permissions_config: params.permissions_config.clone(),
+        timeouts: params.timeouts,
+        prompt_slots: Arc::clone(&params.prompt_slots),
+        excluded_tools: Vec::new(),
+        mcp_handle: params.mcp_handle.clone(),
+        initial_wd: cwd,
+        session_id,
+        initial_history: history,
+        yolo: params.yolo,
+    })
+}
+
+fn install_session(srv: &mut Server, handle: InteractiveHandle, current_model: String) {
+    let pending = PendingPrompt::default();
+    start_event_pump(
+        handle.event_rx.clone(),
+        handle.session_id.clone(),
+        srv.out_tx.clone(),
+        Arc::clone(&pending),
+    );
+    srv.session = Some(SessionState {
+        handle,
+        current_mode: AgentMode::Build,
+        current_model,
+        pending_prompt: pending,
+    });
+}
+
+fn load_history(session_id: &str) -> Result<Vec<Message>, AcpError> {
+    let storage = maki_storage::StateDir::resolve()
+        .map_err(|e| AcpError::internal_error().data(json_str(&e)))?;
+    load_history_from(&storage, session_id)
+}
+
+fn load_history_from(
+    storage: &maki_storage::StateDir,
+    session_id: &str,
+) -> Result<Vec<Message>, AcpError> {
+    let session: maki_storage::sessions::Session<
+        Message,
+        maki_providers::TokenUsage,
+        maki_agent::ToolOutput,
+    > = maki_storage::sessions::Session::load(session_id, storage).map_err(|e| {
+        AcpError::resource_not_found(Some(format!("session/{session_id}"))).data(json_str(&e))
+    })?;
+    Ok(session.messages)
+}
+
+fn handle_prompt(srv: &mut Server, raw: &Value, id: &RequestId) -> Result<(), AcpError> {
+    let req: PromptRequest = parse_params(raw)?;
+    let session = srv.session.as_ref().ok_or_else(no_session)?;
+
+    let (message, images) = extract_prompt_content(&req.prompt);
+    let input = AgentInput {
+        message,
+        mode: session.current_mode.clone(),
+        images,
+        ..Default::default()
+    };
+
+    session
+        .handle
+        .input_tx
+        .send(input)
+        .map_err(|_| AcpError::new(-32603, "session ended"))?;
+    *session.pending_prompt.lock().unwrap() = Some(id.clone());
+    Ok(())
+}
+
+fn handle_set_mode(srv: &mut Server, raw: &Value) -> Result<AgentResponse, AcpError> {
+    let req: SetSessionModeRequest = parse_params(raw)?;
+    let mode_str = req.mode_id.0.to_string();
+    let new_mode = methods::mode_id_to_agent_mode(&mode_str)
+        .ok_or_else(|| AcpError::new(-32602, format!("unknown mode: {mode_str}")))?;
+
+    let session = srv.session.as_mut().ok_or_else(no_session)?;
+    session.current_mode = new_mode;
+
+    let sid = SessionId::from(session.handle.session_id.clone());
+    session_update(
+        &srv.out_tx,
+        &sid,
+        SessionUpdate::CurrentModeUpdate(CurrentModeUpdate::new(SessionModeId::from(mode_str))),
+    );
+    Ok(AgentResponse::SetSessionModeResponse(
+        SetSessionModeResponse::new(),
+    ))
+}
+
+fn handle_set_config(srv: &mut Server, raw: &Value) -> Result<AgentResponse, AcpError> {
+    let req: SetSessionConfigOptionRequest = parse_params(raw)?;
+    if req.config_id.0.as_ref() != methods::MODEL_CONFIG_ID {
+        let detail = format!("unknown config option: {}", req.config_id);
+        return Err(AcpError::invalid_params().data(json_str(&detail)));
+    }
+
+    let spec = req.value.0.to_string();
+    let model =
+        Model::from_spec(&spec).map_err(|e| AcpError::invalid_params().data(json_str(&e)))?;
+
+    let session = srv.session.as_mut().ok_or_else(no_session)?;
+    session
+        .handle
+        .model_tx
+        .send(model)
+        .map_err(|_| AcpError::new(-32603, "session ended"))?;
+    session.current_model = spec.clone();
+
+    Ok(AgentResponse::SetSessionConfigOptionResponse(
+        SetSessionConfigOptionResponse::new(vec![methods::model_config_option(
+            &spec,
+            &srv.model_specs,
+        )]),
+    ))
+}
+
+fn handle_notification(srv: &Server, method: &str) {
+    match method {
+        "session/cancel" => {
+            if let Some(session) = &srv.session {
+                let _ = session.handle.cancel_tx.try_send(());
+            }
+        }
+        _ => debug!(method, "unknown notification"),
+    }
+}
+
+fn handle_incoming_response(srv: &Server, raw: &Value) {
+    let Some(session) = &srv.session else { return };
+
+    if let Some(result) = raw.get("result")
+        && let Ok(resp) = serde_json::from_value::<RequestPermissionResponse>(result.clone())
+    {
+        let answer = permissions::outcome_to_answer(&resp.outcome);
+        let _ = session.handle.answer_tx.send(answer.encode());
+    }
+}
+
+fn extract_prompt_content(blocks: &[ContentBlock]) -> (String, Vec<ImageSource>) {
+    let mut text = String::new();
+    let mut images = Vec::new();
+
+    for block in blocks {
+        match block {
+            ContentBlock::Text(TextContent { text: t, .. }) => append(&mut text, t),
+            ContentBlock::Image(ImageContent {
+                data, mime_type, ..
+            }) => images.push(ImageSource {
+                media_type: image_media_type(mime_type),
+                data: Arc::from(data.as_str()),
+            }),
+            ContentBlock::Resource(res) => {
+                if let EmbeddedResourceResource::TextResourceContents(trc) = &res.resource {
+                    append(&mut text, &format!("--- {} ---\n{}", trc.uri, trc.text));
+                }
+            }
+            ContentBlock::ResourceLink(rl) => append(&mut text, &format!("[Resource: {}]", rl.uri)),
+            _ => {}
+        }
+    }
+
+    (text, images)
+}
+
+fn append(text: &mut String, part: &str) {
+    if !text.is_empty() {
+        text.push('\n');
+    }
+    text.push_str(part);
+}
+
+fn image_media_type(mime: &str) -> ImageMediaType {
+    match mime {
+        "image/png" => ImageMediaType::Png,
+        "image/gif" => ImageMediaType::Gif,
+        "image/webp" => ImageMediaType::Webp,
+        _ => ImageMediaType::Jpeg,
+    }
+}
+
+fn start_event_pump(
+    event_rx: Receiver<Envelope>,
+    session_id: String,
+    out_tx: Sender<Value>,
+    pending: PendingPrompt,
+) {
+    smol::spawn(async move {
+        let sid = SessionId::from(session_id);
+        let mut next_request_id = FIRST_OUTGOING_REQUEST_ID;
+
+        while let Ok(Envelope {
+            event, subagent, ..
+        }) = event_rx.recv_async().await
+        {
+            if subagent.is_some() {
+                continue;
+            }
+
+            let update = match event {
+                AgentEvent::TextDelta { text } => translate::text_delta(&text),
+                AgentEvent::ThinkingDelta { text } => translate::thinking_delta(&text),
+                AgentEvent::ToolPending { id, name } => translate::tool_pending(&id, &name),
+                AgentEvent::ToolStart(event) => translate::tool_start(&event),
+                AgentEvent::ToolOutput { id, content } => translate::tool_output(&id, &content),
+                AgentEvent::ToolDone(event) => {
+                    if let ToolOutput::TodoList(items) = &event.output {
+                        session_update(&out_tx, &sid, translate::todo_list_to_plan(items));
+                    }
+                    translate::tool_done(&event)
+                }
+                AgentEvent::BatchProgress(event) => {
+                    if event.status != BatchToolStatus::InProgress {
+                        continue;
+                    }
+                    translate::batch_inner_start(&event)
+                }
+                AgentEvent::PermissionRequest { id, tool, scopes } => {
+                    let fields =
+                        ToolCallUpdateFields::new().title(format!("{tool}: {}", scopes.join(", ")));
+                    let request =
+                        AgentRequest::RequestPermissionRequest(RequestPermissionRequest::new(
+                            sid.clone(),
+                            ToolCallUpdate::new(ToolCallId::from(id), fields),
+                            permissions::permission_options(),
+                        ));
+                    next_request_id += 1;
+                    send(
+                        &out_tx,
+                        Request {
+                            id: RequestId::Number(next_request_id),
+                            method: Arc::from(request.method()),
+                            params: Some(request),
+                        },
+                    );
+                    continue;
+                }
+                AgentEvent::Done { stop_reason, .. } => {
+                    if let Some(id) = pending.lock().unwrap().take() {
+                        let resp = PromptResponse::new(translate::map_stop_reason(stop_reason));
+                        send(
+                            &out_tx,
+                            Response::new(id, Ok(AgentResponse::PromptResponse(resp))),
+                        );
+                    }
+                    continue;
+                }
+                AgentEvent::Error { message } => {
+                    if let Some(id) = pending.lock().unwrap().take() {
+                        let error = AcpError::internal_error().data(Value::String(message));
+                        send(&out_tx, Response::<AgentResponse>::new(id, Err(error)));
+                    }
+                    continue;
+                }
+                _ => continue,
+            };
+            session_update(&out_tx, &sid, update);
+        }
+    })
+    .detach();
+}
+
+fn send(out_tx: &Sender<Value>, msg: impl Serialize) {
+    if let Ok(json) = serde_json::to_value(JsonRpcMessage::wrap(msg)) {
+        let _ = out_tx.send(json);
+    }
+}
+
+fn session_update(out_tx: &Sender<Value>, sid: &SessionId, update: SessionUpdate) {
+    let notification =
+        AgentNotification::SessionNotification(SessionNotification::new(sid.clone(), update));
+    send(
+        out_tx,
+        Notification {
+            method: Arc::from("session/update"),
+            params: Some(notification),
+        },
+    );
+}
+
+fn no_session() -> AcpError {
+    AcpError::new(-32600, "no active session")
+}
+
+fn parse_params<T: serde::de::DeserializeOwned>(raw: &Value) -> Result<T, AcpError> {
+    serde_json::from_value(raw.get("params").cloned().unwrap_or(Value::Null))
+        .map_err(|e| AcpError::invalid_params().data(json_str(&e)))
+}
+
+fn json_str(e: &impl std::fmt::Display) -> Value {
+    Value::String(e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use maki_providers::{ContentBlock as MsgBlock, Role, TokenUsage};
+    use maki_storage::StateDir;
+    use maki_storage::sessions::Session;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn load_history_round_trips_stored_messages() {
+        let tmp = TempDir::new().unwrap();
+        let dir = StateDir::from_path(tmp.path().to_path_buf());
+        let messages = vec![
+            Message::user("rename foo to bar".into()),
+            Message {
+                role: Role::Assistant,
+                content: vec![MsgBlock::Text {
+                    text: "done".into(),
+                }],
+                display_text: None,
+            },
+        ];
+        let mut session: Session<Message, TokenUsage, ToolOutput> =
+            Session::new("anthropic/test-model", "/project");
+        session.messages = messages.clone();
+        session.save(&dir).unwrap();
+
+        let history = load_history_from(&dir, &session.id).unwrap();
+        assert_eq!(
+            serde_json::to_value(&history).unwrap(),
+            serde_json::to_value(&messages).unwrap()
+        );
+    }
+
+    #[test]
+    fn load_missing_session_is_resource_not_found() {
+        let tmp = TempDir::new().unwrap();
+        let dir = StateDir::from_path(tmp.path().to_path_buf());
+        let err = load_history_from(&dir, "missing-id").unwrap_err();
+        assert_eq!(err.code, AcpError::resource_not_found(None).code);
+    }
+}

--- a/maki-acp/src/translate.rs
+++ b/maki-acp/src/translate.rs
@@ -1,0 +1,498 @@
+use agent_client_protocol_schema::{
+    Content, ContentBlock, ContentChunk, Diff, ImageContent, Plan, PlanEntry, PlanEntryPriority,
+    PlanEntryStatus, SessionUpdate, TextContent, ToolCall, ToolCallContent, ToolCallId,
+    ToolCallLocation, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind,
+};
+use maki_agent::tools::ToolRegistry;
+use maki_agent::types::{BatchProgressEvent, ToolDoneEvent, ToolOutput, ToolStartEvent};
+use maki_agent::{TodoItem, TodoPriority, TodoStatus};
+use maki_providers::{ContentBlock as MsgBlock, ImageMediaType, Message, Role as MsgRole};
+
+const MIN_FENCE_LEN: usize = 3;
+
+/// Zed renders tool output as markdown, so bare text loses its newlines.
+/// We wrap it in a backtick fence (longer than any run inside the text)
+/// to keep the original formatting.
+fn fenced(text: &str) -> String {
+    let longest_backtick_run = text
+        .split(|c: char| c != '`')
+        .map(str::len)
+        .max()
+        .unwrap_or(0);
+    let fence = "`".repeat(MIN_FENCE_LEN.max(longest_backtick_run + 1));
+    format!("{fence}\n{text}\n{fence}")
+}
+
+pub fn tool_kind(name: &str) -> ToolKind {
+    if let Some(kind_str) = ToolRegistry::native()
+        .get(name)
+        .and_then(|e| e.tool.tool_kind().map(str::to_owned))
+    {
+        return parse_tool_kind(&kind_str);
+    }
+    match name {
+        "read" => ToolKind::Read,
+        "edit" | "multiedit" | "write" => ToolKind::Edit,
+        "grep" | "glob" | "semble" => ToolKind::Search,
+        "bash" | "code_execution" => ToolKind::Execute,
+        "webfetch" | "websearch" => ToolKind::Fetch,
+        "task" => ToolKind::Think,
+        _ => ToolKind::Other,
+    }
+}
+
+fn parse_tool_kind(s: &str) -> ToolKind {
+    match s {
+        "read" => ToolKind::Read,
+        "edit" => ToolKind::Edit,
+        "delete" => ToolKind::Delete,
+        "move" => ToolKind::Move,
+        "search" => ToolKind::Search,
+        "execute" => ToolKind::Execute,
+        "think" => ToolKind::Think,
+        "fetch" => ToolKind::Fetch,
+        "switch_mode" => ToolKind::SwitchMode,
+        _ => ToolKind::Other,
+    }
+}
+
+pub fn text_delta(text: &str) -> SessionUpdate {
+    SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(TextContent::new(
+        text.to_string(),
+    ))))
+}
+
+pub fn thinking_delta(text: &str) -> SessionUpdate {
+    SessionUpdate::AgentThoughtChunk(ContentChunk::new(ContentBlock::Text(TextContent::new(
+        text.to_string(),
+    ))))
+}
+
+pub fn tool_pending(id: &str, name: &str) -> SessionUpdate {
+    let kind = tool_kind(name);
+    SessionUpdate::ToolCall(
+        ToolCall::new(ToolCallId::from(id.to_string()), name.to_string())
+            .kind(kind)
+            .status(ToolCallStatus::Pending),
+    )
+}
+
+pub fn tool_start(event: &ToolStartEvent) -> SessionUpdate {
+    let mut fields = ToolCallUpdateFields::new()
+        .status(ToolCallStatus::InProgress)
+        .title(event.summary.clone());
+
+    if let Some(raw) = &event.raw_input {
+        fields = fields.raw_input(raw.clone());
+    }
+
+    let mut locations = Vec::new();
+    if event.input.is_some()
+        && let Some(path) = input_path(event.raw_input.as_ref())
+    {
+        locations.push(ToolCallLocation::new(path));
+    }
+    if !locations.is_empty() {
+        fields = fields.locations(locations);
+    }
+
+    SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+        ToolCallId::from(event.id.clone()),
+        fields,
+    ))
+}
+
+fn input_path(raw_input: Option<&serde_json::Value>) -> Option<std::path::PathBuf> {
+    raw_input
+        .and_then(|v| v.get("path"))
+        .and_then(|v| v.as_str())
+        .map(std::path::PathBuf::from)
+}
+
+pub fn batch_inner_start(event: &BatchProgressEvent) -> SessionUpdate {
+    let title = event.summary.clone().unwrap_or_else(|| event.tool.clone());
+    SessionUpdate::ToolCall(
+        ToolCall::new(
+            ToolCallId::from(format!("{}__{}", event.batch_id, event.index)),
+            title,
+        )
+        .kind(tool_kind(&event.tool))
+        .status(ToolCallStatus::InProgress),
+    )
+}
+
+pub fn tool_output(id: &str, content: &str) -> SessionUpdate {
+    let fields = ToolCallUpdateFields::new().content(vec![ToolCallContent::Content(Content::new(
+        ContentBlock::Text(TextContent::new(fenced(content))),
+    ))]);
+    SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+        ToolCallId::from(id.to_string()),
+        fields,
+    ))
+}
+
+pub fn tool_done(event: &ToolDoneEvent) -> SessionUpdate {
+    let status = if event.is_error {
+        ToolCallStatus::Failed
+    } else {
+        ToolCallStatus::Completed
+    };
+
+    let content = match &event.output {
+        ToolOutput::Diff {
+            path,
+            before,
+            after,
+            ..
+        } => {
+            let diff = if before.is_empty() {
+                Diff::new(path.as_str(), after.clone())
+            } else {
+                Diff::new(path.as_str(), after.clone()).old_text(before.clone())
+            };
+            vec![ToolCallContent::Diff(diff)]
+        }
+        _ => {
+            let text = event.output.as_text();
+            if text.is_empty() {
+                vec![]
+            } else {
+                vec![ToolCallContent::Content(Content::new(ContentBlock::Text(
+                    TextContent::new(fenced(&text)),
+                )))]
+            }
+        }
+    };
+
+    let raw_text = event.output.as_text();
+    let mut fields = ToolCallUpdateFields::new().status(status).content(content);
+    if !raw_text.is_empty() {
+        fields = fields.raw_output(serde_json::Value::String(raw_text));
+    }
+
+    SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+        ToolCallId::from(event.id.clone()),
+        fields,
+    ))
+}
+
+pub fn todo_list_to_plan(items: &[TodoItem]) -> SessionUpdate {
+    let entries: Vec<PlanEntry> = items
+        .iter()
+        .map(|item| {
+            PlanEntry::new(
+                &item.content,
+                map_priority(item.priority),
+                map_status(item.status),
+            )
+        })
+        .collect();
+    SessionUpdate::Plan(Plan::new(entries))
+}
+
+fn map_priority(p: TodoPriority) -> PlanEntryPriority {
+    match p {
+        TodoPriority::High => PlanEntryPriority::High,
+        TodoPriority::Medium => PlanEntryPriority::Medium,
+        TodoPriority::Low => PlanEntryPriority::Low,
+    }
+}
+
+fn map_status(s: TodoStatus) -> PlanEntryStatus {
+    match s {
+        TodoStatus::Pending => PlanEntryStatus::Pending,
+        TodoStatus::InProgress => PlanEntryStatus::InProgress,
+        TodoStatus::Completed | TodoStatus::Cancelled => PlanEntryStatus::Completed,
+    }
+}
+
+pub fn map_stop_reason(
+    sr: Option<maki_providers::StopReason>,
+) -> agent_client_protocol_schema::StopReason {
+    match sr {
+        Some(maki_providers::StopReason::EndTurn) | None => {
+            agent_client_protocol_schema::StopReason::EndTurn
+        }
+        Some(maki_providers::StopReason::MaxTokens) => {
+            agent_client_protocol_schema::StopReason::MaxTokens
+        }
+        Some(maki_providers::StopReason::ToolUse) => {
+            agent_client_protocol_schema::StopReason::EndTurn
+        }
+    }
+}
+
+pub fn replay_history(messages: &[Message]) -> Vec<SessionUpdate> {
+    let mut updates = Vec::new();
+    for msg in messages {
+        match msg.role {
+            MsgRole::User => replay_user(msg, &mut updates),
+            MsgRole::Assistant => replay_assistant(msg, &mut updates),
+        }
+    }
+    updates
+}
+
+fn replay_user(msg: &Message, updates: &mut Vec<SessionUpdate>) {
+    if let Some(text) = msg.user_text() {
+        updates.push(SessionUpdate::UserMessageChunk(ContentChunk::new(
+            ContentBlock::Text(TextContent::new(text.to_string())),
+        )));
+    }
+    for block in &msg.content {
+        match block {
+            MsgBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => updates.push(replay_tool_result(tool_use_id, content, *is_error)),
+            MsgBlock::Image { source } => {
+                updates.push(SessionUpdate::UserMessageChunk(ContentChunk::new(
+                    ContentBlock::Image(ImageContent::new(
+                        source.data.to_string(),
+                        mime_type(&source.media_type),
+                    )),
+                )));
+            }
+            _ => {}
+        }
+    }
+}
+
+fn replay_assistant(msg: &Message, updates: &mut Vec<SessionUpdate>) {
+    for block in &msg.content {
+        match block {
+            MsgBlock::Text { text } => updates.push(text_delta(text)),
+            MsgBlock::Thinking { thinking, .. } => updates.push(thinking_delta(thinking)),
+            MsgBlock::ToolUse { id, name, input } => {
+                updates.push(replay_tool_call(id, name, input));
+            }
+            _ => {}
+        }
+    }
+}
+
+fn replay_tool_call(id: &str, name: &str, input: &serde_json::Value) -> SessionUpdate {
+    SessionUpdate::ToolCall(
+        ToolCall::new(ToolCallId::from(id.to_string()), name.to_string())
+            .kind(tool_kind(name))
+            .status(ToolCallStatus::Pending)
+            .raw_input(input.clone()),
+    )
+}
+
+fn replay_tool_result(id: &str, content: &str, is_error: bool) -> SessionUpdate {
+    let status = if is_error {
+        ToolCallStatus::Failed
+    } else {
+        ToolCallStatus::Completed
+    };
+    let mut fields = ToolCallUpdateFields::new().status(status);
+    if !content.is_empty() {
+        fields = fields.content(vec![ToolCallContent::Content(Content::new(
+            ContentBlock::Text(TextContent::new(fenced(content))),
+        ))]);
+    }
+    SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+        ToolCallId::from(id.to_string()),
+        fields,
+    ))
+}
+
+fn mime_type(media: &ImageMediaType) -> &'static str {
+    match media {
+        ImageMediaType::Png => "image/png",
+        ImageMediaType::Jpeg => "image/jpeg",
+        ImageMediaType::Gif => "image/gif",
+        ImageMediaType::Webp => "image/webp",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use maki_providers::ImageSource;
+    use test_case::test_case;
+
+    use super::*;
+
+    #[test_case("1: mod render\n2: mod segment", "```\n1: mod render\n2: mod segment\n```" ; "plain_text_gets_default_fence")]
+    #[test_case("has ```rust\ncode\n``` inside", "````\nhas ```rust\ncode\n``` inside\n````" ; "fence_longer_than_inner_backticks")]
+    fn fenced_wraps_in_code_block(input: &str, expected: &str) {
+        assert_eq!(fenced(input), expected);
+    }
+
+    #[test_case(Some("import"), "import"; "summary_becomes_title")]
+    #[test_case(None, "grep"; "title_falls_back_to_tool_name")]
+    fn batch_inner_start_composite_id_and_title(summary: Option<&str>, title: &str) {
+        let event = BatchProgressEvent {
+            batch_id: "b1".into(),
+            index: 2,
+            tool: "grep".into(),
+            status: maki_agent::BatchToolStatus::InProgress,
+            output: None,
+            summary: summary.map(Into::into),
+        };
+        let json = serde_json::to_value(batch_inner_start(&event)).unwrap();
+        assert_eq!(json["toolCallId"], "b1__2");
+        assert_eq!(json["title"], title);
+    }
+
+    #[test]
+    fn cancelled_todo_renders_as_completed_plan_entry() {
+        let items = [TodoItem {
+            content: "task".into(),
+            status: TodoStatus::Cancelled,
+            priority: TodoPriority::Low,
+        }];
+        let json = serde_json::to_value(todo_list_to_plan(&items)).unwrap();
+        assert_eq!(json["entries"][0]["status"], "completed");
+    }
+
+    #[test_case(None; "missing_stop_reason")]
+    #[test_case(Some(maki_providers::StopReason::ToolUse); "tool_use")]
+    fn stop_reason_without_acp_equivalent_maps_to_end_turn(sr: Option<maki_providers::StopReason>) {
+        assert_eq!(
+            map_stop_reason(sr),
+            agent_client_protocol_schema::StopReason::EndTurn
+        );
+    }
+
+    fn assistant(content: Vec<MsgBlock>) -> Message {
+        Message {
+            role: MsgRole::Assistant,
+            content,
+            display_text: None,
+        }
+    }
+
+    fn updates_json(messages: &[Message]) -> Vec<serde_json::Value> {
+        replay_history(messages)
+            .iter()
+            .map(|u| serde_json::to_value(u).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn replay_full_conversation_in_order() {
+        let messages = vec![
+            Message::user("hello".into()),
+            assistant(vec![
+                MsgBlock::Thinking {
+                    thinking: "hmm".into(),
+                    signature: None,
+                },
+                MsgBlock::Text {
+                    text: "let me check".into(),
+                },
+                MsgBlock::ToolUse {
+                    id: "tu-1".into(),
+                    name: "bash".into(),
+                    input: serde_json::json!({"command": "ls"}),
+                },
+            ]),
+            Message {
+                role: MsgRole::User,
+                content: vec![MsgBlock::ToolResult {
+                    tool_use_id: "tu-1".into(),
+                    content: "file.rs".into(),
+                    is_error: false,
+                }],
+                display_text: None,
+            },
+            assistant(vec![MsgBlock::Text {
+                text: "done".into(),
+            }]),
+        ];
+
+        let json = updates_json(&messages);
+        assert_eq!(json.len(), 6);
+        assert_eq!(json[0]["sessionUpdate"], "user_message_chunk");
+        assert_eq!(json[0]["content"]["text"], "hello");
+        assert_eq!(json[1]["sessionUpdate"], "agent_thought_chunk");
+        assert_eq!(json[1]["content"]["text"], "hmm");
+        assert_eq!(json[2]["sessionUpdate"], "agent_message_chunk");
+        assert_eq!(json[2]["content"]["text"], "let me check");
+        assert_eq!(json[3]["sessionUpdate"], "tool_call");
+        assert_eq!(json[3]["toolCallId"], "tu-1");
+        assert_eq!(json[3]["kind"], "execute");
+        assert_eq!(json[3]["rawInput"]["command"], "ls");
+        assert_eq!(json[4]["sessionUpdate"], "tool_call_update");
+        assert_eq!(json[4]["toolCallId"], "tu-1");
+        assert_eq!(json[4]["status"], "completed");
+        assert_eq!(
+            json[4]["content"][0]["content"]["text"],
+            "```\nfile.rs\n```"
+        );
+        assert_eq!(json[5]["sessionUpdate"], "agent_message_chunk");
+        assert_eq!(json[5]["content"]["text"], "done");
+    }
+
+    #[test]
+    fn replay_prefers_display_text_over_model_text() {
+        let msg = Message::user_display("expanded with context".into(), "what user typed".into());
+        let json = updates_json(&[msg]);
+        assert_eq!(json.len(), 1);
+        assert_eq!(json[0]["content"]["text"], "what user typed");
+    }
+
+    #[test]
+    fn replay_hides_synthetic_messages() {
+        assert!(updates_json(&[Message::synthetic("injected".into())]).is_empty());
+    }
+
+    #[test]
+    fn replay_failed_tool_result_maps_to_failed_status() {
+        let msg = Message {
+            role: MsgRole::User,
+            content: vec![MsgBlock::ToolResult {
+                tool_use_id: "tu-err".into(),
+                content: "boom".into(),
+                is_error: true,
+            }],
+            display_text: None,
+        };
+        let json = updates_json(&[msg]);
+        assert_eq!(json[0]["sessionUpdate"], "tool_call_update");
+        assert_eq!(json[0]["status"], "failed");
+    }
+
+    #[test]
+    fn replay_user_image_keeps_mime_type() {
+        let msg = Message::user_with_images(
+            String::new(),
+            vec![ImageSource {
+                media_type: ImageMediaType::Png,
+                data: std::sync::Arc::from("b64data"),
+            }],
+        );
+        let json = updates_json(&[msg]);
+        assert_eq!(json.len(), 1);
+        assert_eq!(json[0]["sessionUpdate"], "user_message_chunk");
+        assert_eq!(json[0]["content"]["type"], "image");
+        assert_eq!(json[0]["content"]["mimeType"], "image/png");
+        assert_eq!(json[0]["content"]["data"], "b64data");
+    }
+
+    #[test_case("read", ToolKind::Read ; "read")]
+    #[test_case("edit", ToolKind::Edit ; "edit")]
+    #[test_case("delete", ToolKind::Delete ; "delete")]
+    #[test_case("move", ToolKind::Move ; "move_kind")]
+    #[test_case("search", ToolKind::Search ; "search")]
+    #[test_case("execute", ToolKind::Execute ; "execute")]
+    #[test_case("think", ToolKind::Think ; "think")]
+    #[test_case("fetch", ToolKind::Fetch ; "fetch")]
+    #[test_case("switch_mode", ToolKind::SwitchMode ; "switch_mode")]
+    #[test_case("other", ToolKind::Other ; "other")]
+    #[test_case("bogus", ToolKind::Other ; "unknown_maps_to_other")]
+    fn parse_tool_kind_maps_wire_strings(input: &str, expected: ToolKind) {
+        assert_eq!(parse_tool_kind(input), expected);
+    }
+
+    #[test_case("read", ToolKind::Read ; "native_read")]
+    #[test_case("bash", ToolKind::Execute ; "native_bash")]
+    #[test_case("task", ToolKind::Think ; "native_task")]
+    #[test_case("nonexistent_plugin_tool", ToolKind::Other ; "unknown_tool_is_other")]
+    fn tool_kind_name_based_fallback(name: &str, expected: ToolKind) {
+        assert_eq!(tool_kind(name), expected);
+    }
+}

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -1,22 +1,71 @@
+use std::mem;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use async_lock::Mutex;
 use flume::Receiver;
+use maki_providers::Message;
+use maki_providers::Timeouts;
+use maki_providers::TokenUsage;
+use maki_providers::model::Model;
+use maki_providers::provider::{self, Provider};
+use maki_storage::StateDir;
+use maki_storage::sessions::Session;
 use serde_json::Value;
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::agent::{self, History};
+use crate::cancel::CancelToken;
 use crate::permissions::PermissionManager;
 use crate::prompt::ResolvedSlots;
 use crate::template;
 use crate::tools::{DescriptionContext, FileReadTracker, ToolFilter, ToolRegistry};
 use crate::{
     Agent, AgentConfig, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, Envelope,
-    EventSender, McpHandle, PermissionsConfig, ToolOutputLines,
+    EventSender, McpHandle, PermissionsConfig, ToolOutput, ToolOutputLines,
 };
-use maki_providers::Timeouts;
-use maki_providers::model::Model;
-use maki_providers::provider::{self, Provider};
+
+type StoredSession = Session<Message, TokenUsage, ToolOutput>;
+
+struct SessionStore {
+    dir: StateDir,
+    session: StoredSession,
+}
+
+impl SessionStore {
+    fn open(session_id: &str, cwd: &str, model_spec: &str) -> Option<Self> {
+        let dir = StateDir::resolve()
+            .map_err(|e| warn!(error = %e, "state dir unavailable; session will not be persisted"))
+            .ok()?;
+        Some(Self::open_in(dir, session_id, cwd, model_spec))
+    }
+
+    fn open_in(dir: StateDir, session_id: &str, cwd: &str, model_spec: &str) -> Self {
+        match StoredSession::load(session_id, &dir) {
+            Ok(session) => Self { dir, session },
+            Err(_) => {
+                let mut session = StoredSession::new(model_spec, cwd);
+                session.id = session_id.to_owned();
+                let mut store = Self { dir, session };
+                store.save();
+                store
+            }
+        }
+    }
+
+    fn save(&mut self) {
+        if let Err(e) = self.session.save(&self.dir) {
+            warn!(error = %e, session_id = %self.session.id, "failed to persist session");
+        }
+    }
+
+    fn record_turn(&mut self, messages: &[Message], model_spec: String) {
+        self.session.messages = messages.to_vec();
+        self.session.model = model_spec;
+        self.session.update_title_if_default();
+        self.save();
+    }
+}
 
 pub struct HeadlessParams {
     pub model: Model,
@@ -39,20 +88,60 @@ pub struct HeadlessHandle {
     pub task: smol::Task<()>,
 }
 
-pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
-    let working_dir = params.initial_wd.to_string_lossy().into_owned();
+struct AgentSetup {
+    vars: template::Vars,
+    instructions: agent::Instructions,
+    tools: Value,
+}
+
+fn setup(
+    model: &Model,
+    config: &AgentConfig,
+    excluded_tools: &[&'static str],
+    mcp_handle: Option<&McpHandle>,
+) -> AgentSetup {
     let vars = template::env_vars();
-    let mode = AgentMode::Build;
     let instructions = agent::load_instructions(&vars.apply("{cwd}"));
+    let tools = tool_definitions(&vars, model, config, excluded_tools, mcp_handle);
 
-    let filter = ToolFilter::from_config(&params.config, &params.excluded_tools);
+    AgentSetup {
+        vars,
+        instructions,
+        tools,
+    }
+}
+
+fn tool_definitions(
+    vars: &template::Vars,
+    model: &Model,
+    config: &AgentConfig,
+    excluded_tools: &[&'static str],
+    mcp_handle: Option<&McpHandle>,
+) -> Value {
+    let filter = ToolFilter::from_config(config, excluded_tools);
     let ctx = DescriptionContext { filter: &filter };
-    let mut tools =
-        ToolRegistry::native().definitions(&vars, &ctx, params.model.supports_tool_examples());
+    let mut tools = ToolRegistry::native().definitions(vars, &ctx, model.supports_tool_examples());
 
-    if let Some(handle) = &params.mcp_handle {
+    if let Some(handle) = mcp_handle {
         handle.extend_tools(&mut tools);
     }
+
+    tools
+}
+
+pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
+    let working_dir = params.initial_wd.to_string_lossy().into_owned();
+    let mode = AgentMode::Build;
+    let AgentSetup {
+        vars,
+        instructions,
+        tools,
+    } = setup(
+        &params.model,
+        &params.config,
+        &params.excluded_tools,
+        params.mcp_handle.as_ref(),
+    );
 
     let system = agent::build_system_prompt(&vars, &mode, &instructions.text, &params.prompt_slots);
 
@@ -137,6 +226,191 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
     }
 }
 
+pub struct InteractiveParams {
+    pub model: Model,
+    pub config: AgentConfig,
+    pub permissions_config: PermissionsConfig,
+    pub timeouts: Timeouts,
+    pub prompt_slots: Arc<ResolvedSlots>,
+    pub excluded_tools: Vec<&'static str>,
+    pub mcp_handle: Option<McpHandle>,
+    pub initial_wd: PathBuf,
+    pub session_id: Option<String>,
+    pub initial_history: Vec<Message>,
+    pub yolo: bool,
+}
+
+pub struct InteractiveHandle {
+    pub event_rx: Receiver<Envelope>,
+    pub input_tx: flume::Sender<AgentInput>,
+    pub answer_tx: flume::Sender<String>,
+    pub cancel_tx: flume::Sender<()>,
+    pub model_tx: flume::Sender<Model>,
+    pub session_id: String,
+    pub task: smol::Task<()>,
+}
+
+pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
+    let AgentSetup {
+        vars,
+        instructions,
+        mut tools,
+    } = setup(
+        &params.model,
+        &params.config,
+        &params.excluded_tools,
+        params.mcp_handle.as_ref(),
+    );
+
+    let (raw_tx, event_rx) = flume::unbounded::<Envelope>();
+    let (input_tx, input_rx) = flume::unbounded::<AgentInput>();
+    let (answer_tx, answer_rx) = flume::unbounded::<String>();
+    let (cancel_tx, cancel_rx) = flume::bounded::<()>(1);
+    let (model_tx, model_rx) = flume::unbounded::<Model>();
+
+    let session_id = params
+        .session_id
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    let working_dir = params.initial_wd.to_string_lossy().into_owned();
+    let permissions = Arc::new(PermissionManager::new(
+        params.permissions_config,
+        params.initial_wd,
+    ));
+    if params.yolo {
+        permissions.toggle_yolo();
+    }
+
+    let answer_rx = Arc::new(Mutex::new(answer_rx));
+    let file_tracker = FileReadTracker::fresh();
+
+    let task = smol::spawn({
+        let session_id = session_id.clone();
+        async move {
+            let mut model = params.model;
+            let mut provider: Arc<dyn Provider> =
+                match provider::from_model_async(&model, params.timeouts).await {
+                    Ok(p) => Arc::from(p),
+                    Err(e) => {
+                        error!(error = %e, "provider error");
+                        let _ = EventSender::new(raw_tx, 0).send(AgentEvent::Error {
+                            message: e.user_message(),
+                        });
+                        return;
+                    }
+                };
+
+            let mut store = SessionStore::open(&session_id, &working_dir, &model.spec());
+            let mut history = History::new(params.initial_history);
+            let mut run_id: u64 = 0;
+
+            while let Ok(input) = input_rx.recv_async().await {
+                let event_tx = EventSender::new(raw_tx.clone(), run_id);
+                let error_tx = event_tx.clone();
+
+                if let Some(new_model) = model_rx.try_iter().last()
+                    && new_model.spec() != model.spec()
+                {
+                    match provider::from_model_async(&new_model, params.timeouts).await {
+                        Ok(p) => {
+                            provider = Arc::from(p);
+                            tools = tool_definitions(
+                                &vars,
+                                &new_model,
+                                &params.config,
+                                &params.excluded_tools,
+                                params.mcp_handle.as_ref(),
+                            );
+                            model = new_model;
+                        }
+                        Err(e) => {
+                            error!(error = %e, "provider error");
+                            let _ = error_tx.send(AgentEvent::Error {
+                                message: e.user_message(),
+                            });
+                            run_id += 1;
+                            continue;
+                        }
+                    }
+                }
+
+                let system = agent::build_system_prompt(
+                    &vars,
+                    &input.mode,
+                    &instructions.text,
+                    &params.prompt_slots,
+                );
+
+                let (trigger, cancel) = CancelToken::new();
+                let cancel_task = smol::spawn({
+                    let cancel_rx = cancel_rx.clone();
+                    async move {
+                        if cancel_rx.recv_async().await.is_ok() {
+                            trigger.cancel();
+                        }
+                    }
+                });
+
+                while answer_rx.lock().await.try_recv().is_ok() {}
+
+                let agent = Agent::new(
+                    AgentParams {
+                        provider: Arc::clone(&provider),
+                        model: model.clone(),
+                        config: params.config.clone(),
+                        tool_output_lines: ToolOutputLines::default(),
+                        permissions: Arc::clone(&permissions),
+                        session_id: Some(session_id.clone()),
+                        timeouts: params.timeouts,
+                        file_tracker: Arc::clone(&file_tracker),
+                        prompt_slots: Arc::clone(&params.prompt_slots),
+                    },
+                    AgentRunParams {
+                        history: mem::replace(&mut history, History::new(Vec::new())),
+                        system,
+                        event_tx,
+                        tools: tools.clone(),
+                    },
+                )
+                .with_loaded_instructions(instructions.loaded.clone())
+                .with_user_response_rx(Arc::clone(&answer_rx))
+                .with_cancel(cancel)
+                .with_mcp(params.mcp_handle.clone());
+
+                let outcome = agent.run(input).await;
+                cancel_task.cancel().await;
+
+                if let Err(ref e) = outcome.result {
+                    error!(error = %e, "agent error");
+                    let _ = error_tx.send(AgentEvent::Error {
+                        message: e.user_message(),
+                    });
+                }
+
+                history = outcome.history;
+                if let Some(store) = &mut store {
+                    store.record_turn(history.as_slice(), model.spec());
+                }
+                run_id += 1;
+            }
+
+            if let Some(handle) = params.mcp_handle {
+                handle.shutdown().await;
+            }
+        }
+    });
+
+    InteractiveHandle {
+        event_rx,
+        input_tx,
+        answer_tx,
+        cancel_tx,
+        model_tx,
+        session_id,
+        task,
+    }
+}
+
 fn extract_tool_names(tools: &Value) -> Vec<String> {
     tools
         .as_array()
@@ -146,4 +420,73 @@ fn extract_tool_names(tools: &Value) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use maki_storage::sessions::generate_title;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    const SESSION_ID: &str = "acp-test-session";
+    const CWD: &str = "/project";
+    const MODEL_SPEC: &str = "anthropic/claude-test";
+
+    fn store_in(tmp: &TempDir) -> SessionStore {
+        SessionStore::open_in(
+            StateDir::from_path(tmp.path().to_path_buf()),
+            SESSION_ID,
+            CWD,
+            MODEL_SPEC,
+        )
+    }
+
+    fn load(tmp: &TempDir) -> StoredSession {
+        StoredSession::load(SESSION_ID, &StateDir::from_path(tmp.path().to_path_buf())).unwrap()
+    }
+
+    #[test]
+    fn new_session_is_loadable_before_first_turn() {
+        let tmp = TempDir::new().unwrap();
+        store_in(&tmp);
+        let loaded = load(&tmp);
+        assert_eq!(loaded.id, SESSION_ID);
+        assert_eq!(loaded.cwd, CWD);
+        assert_eq!(loaded.model, MODEL_SPEC);
+        assert!(loaded.messages.is_empty());
+    }
+
+    #[test]
+    fn record_turn_persists_messages_and_title() {
+        let tmp = TempDir::new().unwrap();
+        let mut store = store_in(&tmp);
+        let messages = vec![Message::user("fix the login bug".into())];
+        store.record_turn(&messages, MODEL_SPEC.into());
+
+        let loaded = load(&tmp);
+        assert_eq!(loaded.messages.len(), 1);
+        assert_eq!(loaded.title, generate_title(&messages));
+    }
+
+    #[test]
+    fn reopening_resumes_existing_session() {
+        let tmp = TempDir::new().unwrap();
+        let mut store = store_in(&tmp);
+        store.record_turn(&[Message::user("first prompt".into())], MODEL_SPEC.into());
+        drop(store);
+
+        let mut store = store_in(&tmp);
+        assert_eq!(store.session.messages.len(), 1);
+
+        let messages = vec![
+            Message::user("first prompt".into()),
+            Message::user("second prompt".into()),
+        ];
+        store.record_turn(&messages, "other/model".into());
+
+        let loaded = load(&tmp);
+        assert_eq!(loaded.messages.len(), 2);
+        assert_eq!(loaded.model, "other/model");
+    }
 }

--- a/maki-agent/src/tools/batch.rs
+++ b/maki-agent/src/tools/batch.rs
@@ -177,6 +177,7 @@ impl Batch {
                         BatchProgressEvent {
                             batch_id,
                             index: i,
+                            tool: name,
                             status: BatchToolStatus::Error,
                             output: None,
                             summary: None,
@@ -200,6 +201,7 @@ impl Batch {
                     .try_send(AgentEvent::BatchProgress(Box::new(BatchProgressEvent {
                         batch_id: batch_id.clone(),
                         index: i,
+                        tool: name.clone(),
                         status: BatchToolStatus::InProgress,
                         output: None,
                         summary: Some(summary.clone()),
@@ -232,6 +234,7 @@ impl Batch {
                     .try_send(AgentEvent::BatchProgress(Box::new(BatchProgressEvent {
                         batch_id,
                         index: i,
+                        tool: name,
                         status,
                         output: Some(done.output.clone()),
                         summary: Some(summary.clone()),

--- a/maki-agent/src/tools/registry.rs
+++ b/maki-agent/src/tools/registry.rs
@@ -165,6 +165,9 @@ pub trait Tool: Send + Sync + 'static {
     fn audience(&self) -> ToolAudience {
         ToolAudience::default()
     }
+    fn tool_kind(&self) -> Option<&str> {
+        None
+    }
     fn parse(&self, input: &Value) -> Result<Box<dyn ToolInvocation>, ParseError>;
 }
 

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -616,6 +616,7 @@ pub struct TurnCompleteEvent {
 pub struct BatchProgressEvent {
     pub batch_id: String,
     pub index: usize,
+    pub tool: String,
     pub status: BatchToolStatus,
     pub output: Option<ToolOutput>,
     pub summary: Option<String>,

--- a/maki-docgen/src/lua_util.rs
+++ b/maki-docgen/src/lua_util.rs
@@ -58,10 +58,10 @@ pub fn extract_lua_description(source: &str) -> Option<String> {
         let quoted = trimmed
             .strip_prefix(".. \"")
             .or_else(|| trimmed.strip_prefix("description = \""));
-        if let Some(s) = quoted {
-            if let Some(end) = s.rfind('"') {
-                parts.push(unescape_lua_string(&s[..end]));
-            }
+        if let Some(s) = quoted
+            && let Some(end) = s.rfind('"')
+        {
+            parts.push(unescape_lua_string(&s[..end]));
         }
         if !trimmed.contains("..") && trimmed.ends_with(',') {
             break;

--- a/maki-lua/src/api/fn_api.rs
+++ b/maki-lua/src/api/fn_api.rs
@@ -190,10 +190,10 @@ impl JobStore {
     }
 
     pub fn kill(&mut self, job_id: u32) {
-        if let Some(meta) = self.jobs.get_mut(&job_id) {
-            if meta.alive {
-                kill_job(meta);
-            }
+        if let Some(meta) = self.jobs.get_mut(&job_id)
+            && meta.alive
+        {
+            kill_job(meta);
         }
     }
 

--- a/maki-lua/src/api/fs.rs
+++ b/maki-lua/src/api/fs.rs
@@ -16,10 +16,10 @@ pub(crate) fn expand_tilde(path: &str) -> PathBuf {
         if let Some(home) = maki_storage::paths::home() {
             return home.join(rest);
         }
-    } else if path == "~" {
-        if let Some(home) = maki_storage::paths::home() {
-            return home;
-        }
+    } else if path == "~"
+        && let Some(home) = maki_storage::paths::home()
+    {
+        return home;
     }
     PathBuf::from(path)
 }

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -39,6 +39,7 @@ pub(crate) struct PendingTool {
     pub(crate) description: String,
     pub(crate) schema: &'static ParamSchema,
     pub(crate) audience: ToolAudience,
+    pub(crate) kind: Option<Arc<str>>,
     pub(crate) handler_key: RegistryKey,
     pub(crate) header_key: Option<RegistryKey>,
     pub(crate) restore_key: Option<RegistryKey>,
@@ -54,6 +55,7 @@ pub(crate) struct LuaTool {
     pub(crate) description: String,
     pub(crate) schema: &'static ParamSchema,
     pub(crate) audience: ToolAudience,
+    pub(crate) kind: Option<Arc<str>>,
     pub(crate) tx: Sender<Request>,
     pub(crate) plugin: Arc<str>,
     pub(crate) has_header_fn: bool,
@@ -76,6 +78,10 @@ impl Tool for LuaTool {
 
     fn audience(&self) -> ToolAudience {
         self.audience
+    }
+
+    fn tool_kind(&self) -> Option<&str> {
+        self.kind.as_deref()
     }
 
     fn parse(&self, input: &Value) -> Result<Box<dyn ToolInvocation>, ParseError> {
@@ -473,6 +479,10 @@ fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> Lua
 
     let header_fn: Option<Function> = spec.get("header").ok();
     let restore_fn: Option<Function> = spec.get("restore").ok();
+    let kind: Option<Arc<str>> = spec
+        .get::<String>("kind")
+        .ok()
+        .map(|s| Arc::from(s.as_str()));
     let audience = parse_audience(audiences)?;
     let timeout = parse_timeout(spec)?;
     let handler_key: RegistryKey = lua.create_registry_value(handler)?;
@@ -492,6 +502,7 @@ fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> Lua
             description,
             schema: param_schema,
             audience,
+            kind,
             handler_key,
             header_key,
             restore_key,
@@ -706,6 +717,7 @@ mod tests {
             description: "test".into(),
             schema,
             audience: ToolAudience::default(),
+            kind: None,
             tx,
             plugin: Arc::from("test"),
             has_header_fn: false,
@@ -870,6 +882,7 @@ mod tests {
             description: "test".into(),
             schema,
             audience: ToolAudience::default(),
+            kind: None,
             tx,
             plugin: Arc::from("test"),
             has_header_fn: false,
@@ -1080,5 +1093,34 @@ mod tests {
         assert!(is_valid_tool_name(&max_ok));
         let too_long: String = "a".repeat(TOOL_NAME_MAX + 1);
         assert!(!is_valid_tool_name(&too_long));
+    }
+
+    #[test]
+    fn lua_tool_kind_returns_configured_value() {
+        let schema = try_from_json(&serde_json::json!({
+            "type": "object",
+            "properties": {},
+        }))
+        .unwrap();
+        let (tx, _rx) = flume::unbounded();
+        let tool = LuaTool {
+            name: Arc::from("my_reader"),
+            description: "reads things".into(),
+            schema,
+            audience: ToolAudience::default(),
+            kind: Some(Arc::from("read")),
+            tx,
+            plugin: Arc::from("test"),
+            has_header_fn: false,
+            permission_scope_kind: None,
+            timeout: None,
+        };
+        assert_eq!(tool.tool_kind(), Some("read"));
+    }
+
+    #[test]
+    fn lua_tool_kind_none_by_default() {
+        let tool = make_lua_tool(None);
+        assert_eq!(tool.tool_kind(), None);
     }
 }

--- a/maki-lua/src/api/treesitter/language.rs
+++ b/maki-lua/src/api/treesitter/language.rs
@@ -20,12 +20,12 @@ pub(crate) fn create_language_module(lua: &Lua) -> mlua::Result<Table> {
     t.set(
         "add",
         lua.create_function(move |_, (lang, opts): (String, Option<Table>)| {
-            if let Some(ref opts) = opts {
-                if opts.contains_key("path")? {
-                    return Err(mlua::Error::runtime(
-                        "custom grammar paths not supported yet",
-                    ));
-                }
+            if let Some(ref opts) = opts
+                && opts.contains_key("path")?
+            {
+                return Err(mlua::Error::runtime(
+                    "custom grammar paths not supported yet",
+                ));
             }
             if Language::from_name(&lang).is_none() {
                 return Err(mlua::Error::runtime(format!("language not found: {lang}")));

--- a/maki-lua/src/api/ui.rs
+++ b/maki-lua/src/api/ui.rs
@@ -187,12 +187,11 @@ pub(crate) fn create_ui_table(
 }
 
 pub(crate) fn try_parse_dimension(tbl: &Table, key: &str) -> Option<Dimension> {
-    if let Ok(s) = tbl.get::<String>(key) {
-        if let Some(pct) = s.strip_suffix('%') {
-            if let Ok(v) = pct.parse::<u16>() {
-                return Some(Dimension::Percent(v));
-            }
-        }
+    if let Ok(s) = tbl.get::<String>(key)
+        && let Some(pct) = s.strip_suffix('%')
+        && let Ok(v) = pct.parse::<u16>()
+    {
+        return Some(Dimension::Percent(v));
     }
     if let Ok(v) = tbl.get::<u16>(key) {
         return Some(Dimension::Abs(v));

--- a/maki-lua/src/api/win.rs
+++ b/maki-lua/src/api/win.rs
@@ -96,10 +96,10 @@ impl UserData for WinHandle {
             if let Ok(t) = opts.get::<String>("title") {
                 patch.title = Some(t);
             }
-            if let Ok(f) = parse_footer(&opts) {
-                if !f.is_empty() {
-                    patch.footer = Some(f);
-                }
+            if let Ok(f) = parse_footer(&opts)
+                && !f.is_empty()
+            {
+                patch.footer = Some(f);
             }
             if let Ok(b) = opts.get::<String>("border") {
                 patch.border = Some(Border::parse(&b));

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -225,7 +225,7 @@ fn install_interrupt(lua: &Lua, shutdown: Arc<AtomicBool>) {
         }
         let tick = interrupt_tick.get().wrapping_add(1);
         interrupt_tick.set(tick);
-        if tick % INTERRUPT_CANCEL_CHECK_INTERVAL != 0 {
+        if !tick.is_multiple_of(INTERRUPT_CANCEL_CHECK_INTERVAL) {
             return Ok(VmState::Continue);
         }
         let stop = interrupt_lua.app_data_ref::<TaskHandle>().and_then(|h| {
@@ -537,14 +537,14 @@ fn drain_spawn_queue(lua: &Lua, ex: &Rc<smol::LocalExecutor<'_>>, gate: &Rc<Infl
                 tracing::debug!(error = %e, "async.run: task failed");
             }
 
-            if let Some(ref live) = task.live_ctx {
-                if let Some(ref buf) = task.live_buf {
-                    let _ = live.event_tx.send(maki_agent::AgentEvent::ToolSnapshot {
-                        id: live.tool_use_id.clone(),
-                        snapshot: buf.take(),
-                        theme_gen: None,
-                    });
-                }
+            if let Some(ref live) = task.live_ctx
+                && let Some(ref buf) = task.live_buf
+            {
+                let _ = live.event_tx.send(maki_agent::AgentEvent::ToolSnapshot {
+                    id: live.tool_use_id.clone(),
+                    snapshot: buf.take(),
+                    theme_gen: None,
+                });
             }
 
             drop(scope);
@@ -630,42 +630,42 @@ impl LuaRuntime {
                 if let Err(e) = self.lua.remove_registry_value(tk.handler) {
                     tracing::warn!(plugin = name, error = %e, "failed to drop lua handler key");
                 }
-                if let Some(sk) = tk.header {
-                    if let Err(e) = self.lua.remove_registry_value(sk) {
-                        tracing::warn!(plugin = name, error = %e, "failed to drop lua header key");
-                    }
+                if let Some(sk) = tk.header
+                    && let Err(e) = self.lua.remove_registry_value(sk)
+                {
+                    tracing::warn!(plugin = name, error = %e, "failed to drop lua header key");
                 }
-                if let Some(sk) = tk.permission_scopes {
-                    if let Err(e) = self.lua.remove_registry_value(sk) {
-                        tracing::warn!(plugin = name, error = %e, "failed to drop lua permission_scopes key");
-                    }
-                }
-            }
-        }
-        if let Some(mut cmd_map) = self.lua.app_data_mut::<CommandHandlerMap>() {
-            if let Some(cmds) = cmd_map.remove(name) {
-                for (_, entry) in cmds {
-                    if let Err(e) = self.lua.remove_registry_value(entry.handler) {
-                        tracing::warn!(plugin = name, error = %e, "failed to drop command handler key");
-                    }
-                }
-                drop(cmd_map);
-                if let (Some(map), Some(writer)) = (
-                    self.lua.app_data_ref::<CommandHandlerMap>(),
-                    self.lua.app_data_ref::<LuaCommandWriter>(),
-                ) {
-                    publish_command_snapshot(&map, &writer);
+                if let Some(sk) = tk.permission_scopes
+                    && let Err(e) = self.lua.remove_registry_value(sk)
+                {
+                    tracing::warn!(plugin = name, error = %e, "failed to drop lua permission_scopes key");
                 }
             }
         }
-        if let Some(mut hints) = self.lua.app_data_mut::<PromptHintCallbacks>() {
-            if let Some(regs) = hints.remove(name) {
-                for reg in regs {
-                    if let HintContent::Callback(key) = reg.content {
-                        if let Err(e) = self.lua.remove_registry_value(key) {
-                            tracing::warn!(plugin = name, error = %e, "failed to drop prompt hint key");
-                        }
-                    }
+        if let Some(mut cmd_map) = self.lua.app_data_mut::<CommandHandlerMap>()
+            && let Some(cmds) = cmd_map.remove(name)
+        {
+            for (_, entry) in cmds {
+                if let Err(e) = self.lua.remove_registry_value(entry.handler) {
+                    tracing::warn!(plugin = name, error = %e, "failed to drop command handler key");
+                }
+            }
+            drop(cmd_map);
+            if let (Some(map), Some(writer)) = (
+                self.lua.app_data_ref::<CommandHandlerMap>(),
+                self.lua.app_data_ref::<LuaCommandWriter>(),
+            ) {
+                publish_command_snapshot(&map, &writer);
+            }
+        }
+        if let Some(mut hints) = self.lua.app_data_mut::<PromptHintCallbacks>()
+            && let Some(regs) = hints.remove(name)
+        {
+            for reg in regs {
+                if let HintContent::Callback(key) = reg.content
+                    && let Err(e) = self.lua.remove_registry_value(key)
+                {
+                    tracing::warn!(plugin = name, error = %e, "failed to drop prompt hint key");
                 }
             }
         }
@@ -777,15 +777,15 @@ impl LuaRuntime {
             if let Err(e) = self.lua.remove_registry_value(t.handler_key) {
                 tracing::warn!(error = %e, "failed to drop lua handler key on rollback");
             }
-            if let Some(sk) = t.header_key {
-                if let Err(e) = self.lua.remove_registry_value(sk) {
-                    tracing::warn!(error = %e, "failed to drop lua header key on rollback");
-                }
+            if let Some(sk) = t.header_key
+                && let Err(e) = self.lua.remove_registry_value(sk)
+            {
+                tracing::warn!(error = %e, "failed to drop lua header key on rollback");
             }
-            if let Some(sk) = t.permission_scopes_key {
-                if let Err(e) = self.lua.remove_registry_value(sk) {
-                    tracing::warn!(error = %e, "failed to drop lua permission_scopes key on rollback");
-                }
+            if let Some(sk) = t.permission_scopes_key
+                && let Err(e) = self.lua.remove_registry_value(sk)
+            {
+                tracing::warn!(error = %e, "failed to drop lua permission_scopes key on rollback");
             }
         }
     }
@@ -829,10 +829,10 @@ impl LuaRuntime {
                 ));
             }
 
-            if let Ok(cached) = loaded.get::<LuaValue>(modname.as_str()) {
-                if cached != LuaValue::Nil {
-                    return Ok(cached);
-                }
+            if let Ok(cached) = loaded.get::<LuaValue>(modname.as_str())
+                && cached != LuaValue::Nil
+            {
+                return Ok(cached);
             }
 
             if loading.get::<bool>(modname.as_str()).unwrap_or(false) {
@@ -845,10 +845,10 @@ impl LuaRuntime {
 
             let source_str: Result<Option<String>, mlua::Error> = (|| {
                 for dir in bundled_dirs {
-                    if let Some(file) = dir.get_file(&rel_path) {
-                        if let Some(contents) = file.contents_utf8() {
-                            return Ok(Some(contents.to_owned()));
-                        }
+                    if let Some(file) = dir.get_file(&rel_path)
+                        && let Some(contents) = file.contents_utf8()
+                    {
+                        return Ok(Some(contents.to_owned()));
                     }
                 }
                 let Some(dir) = lua_dir.as_ref() else {
@@ -972,6 +972,7 @@ impl LuaRuntime {
                     description: t.description.clone(),
                     schema: t.schema,
                     audience: t.audience,
+                    kind: t.kind.clone(),
                     tx: self.tx.clone(),
                     plugin: Arc::clone(&name),
                     has_header_fn: t.header_key.is_some(),

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -191,6 +191,34 @@ fn permission_scope_valid_string_field_accepted() {
 }
 
 #[test]
+fn tool_kind_flows_to_trait() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "my_fetcher",
+            description = "fetches things",
+            schema = {MINIMAL_SCHEMA},
+            kind = "fetch",
+            handler = function() return "" end
+        }})"#,
+    );
+    host.load_source("kind_plugin", &src).unwrap();
+    let entry = reg.get("my_fetcher").expect("tool not registered");
+    assert_eq!(entry.tool.tool_kind(), Some("fetch"));
+}
+
+#[test]
+fn tool_kind_defaults_to_none() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source("echo_plugin", ECHO_PLUGIN).unwrap();
+    let entry = reg.get("echo_").expect("tool not registered");
+    assert_eq!(entry.tool.tool_kind(), None);
+}
+
+#[test]
 fn interrupt_kills_infinite_loop_and_vm_recovers() {
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -281,6 +281,24 @@ pub struct ModelBatch {
     pub warnings: Vec<String>,
 }
 
+/// Offline version of model discovery: returns specs from static tables
+/// and configured dynamic providers. See [`fetch_all_models`] for live lookups.
+pub fn available_model_specs() -> Vec<String> {
+    let mut specs: Vec<String> = ProviderKind::iter()
+        .filter(|kind| kind.is_available())
+        .flat_map(|kind| {
+            models_for_provider(kind)
+                .iter()
+                .flat_map(|entry| entry.prefixes.iter())
+                .map(move |p| format!("{kind}/{p}"))
+        })
+        .collect();
+    for slug in dynamic::discovered_slugs() {
+        specs.extend(dynamic::dynamic_model_specs_for(slug));
+    }
+    specs
+}
+
 pub async fn fetch_all_models(mut on_ready: impl FnMut(ModelBatch)) {
     let (tx, rx) = flume::unbounded();
     let timeouts = Timeouts::default();

--- a/plugins/bash/init.lua
+++ b/plugins/bash/init.lua
@@ -238,6 +238,7 @@ maki.api.register_prompt_hint({
 
 maki.api.register_tool({
   name = "bash",
+  kind = "execute",
   description = description,
   schema = {
     type = "object",

--- a/plugins/glob/init.lua
+++ b/plugins/glob/init.lua
@@ -12,6 +12,7 @@ end
 
 maki.api.register_tool({
   name = "glob",
+  kind = "search",
   description = [[Find files by glob pattern.
 
 - Respects .gitignore.

--- a/plugins/index/init.lua
+++ b/plugins/index/init.lua
@@ -122,6 +122,7 @@ maki.api.register_prompt_hint({
 
 maki.api.register_tool({
   name = "index",
+  kind = "read",
   description = [[
 Return a compact overview of a source file: imports, type definitions, function signatures, and structure with their line numbers surrounded by []. ~70-90% more efficient than reading the full file.
 

--- a/plugins/skill/init.lua
+++ b/plugins/skill/init.lua
@@ -86,6 +86,7 @@ local description = "Load a skill that provides instructions and workflows for s
 
 maki.api.register_tool({
   name = "skill",
+  kind = "read",
   description = description,
 
   schema = {

--- a/plugins/webfetch/init.lua
+++ b/plugins/webfetch/init.lua
@@ -70,6 +70,7 @@ end
 
 maki.api.register_tool({
   name = "webfetch",
+  kind = "fetch",
   description = [[Fetch a URL and return its contents.
 
 - Supports markdown (default), text, or html output formats.

--- a/plugins/websearch/init.lua
+++ b/plugins/websearch/init.lua
@@ -13,6 +13,7 @@ end
 
 maki.api.register_tool({
   name = "websearch",
+  kind = "search",
   description = "Search the web for real-time information using Exa AI.\n\n"
     .. "Today's date is "
     .. os.date("%Y-%m-%d")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -95,6 +95,15 @@ pub enum Command {
     },
     /// Rollback to the previous version
     Rollback,
+    /// Run as an ACP (Agent Client Protocol) server over stdio
+    Acp {
+        /// Model spec (provider/model-id)
+        #[arg(short, long)]
+        model: Option<String>,
+        /// Skip all permission prompts
+        #[arg(long)]
+        yolo: bool,
+    },
     /// Data migration utilities
     Migrate {
         #[command(subcommand)]

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -1,0 +1,71 @@
+use std::env;
+use std::sync::Arc;
+
+use color_eyre::Result;
+use color_eyre::eyre::Context;
+
+use maki_agent::tools::ToolRegistry;
+use maki_config::{load_env_files, load_permissions};
+use maki_lua::PluginHost;
+use maki_storage::StateDir;
+
+use crate::setup;
+
+pub fn run(model_arg: Option<String>, yolo: bool) -> Result<()> {
+    let storage = StateDir::resolve().context("resolve data directory")?;
+    maki_providers::tier_map::load_from_storage(&storage);
+
+    let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
+    load_env_files(&cwd);
+
+    let mut plugin_host = PluginHost::new(Arc::clone(ToolRegistry::native_arc()))
+        .context("initialize lua plugin host")?;
+
+    let raw_config = plugin_host
+        .load_init_files(&cwd)
+        .context("load init.lua files")?;
+
+    let mut config = raw_config
+        .unwrap_or_default()
+        .into_config(false)
+        .context("invalid config")?;
+    config.permissions = load_permissions(&cwd);
+
+    if yolo || config.always_yolo {
+        config.permissions.allow_all = true;
+    }
+    config.validate()?;
+
+    plugin_host
+        .load_builtins(&config.plugins)
+        .context("load builtin plugins")?;
+
+    let timeouts = maki_providers::Timeouts {
+        connect: config.provider.connect_timeout,
+        low_speed: config.provider.low_speed_timeout,
+        stream: config.provider.stream_timeout,
+    };
+
+    let model = setup::resolve_model(model_arg.as_deref(), &config.provider, &storage)?;
+
+    setup::init_logging(&storage, &config.storage);
+    setup::install_panic_log_hook();
+
+    let (mcp_handle, _mcp_config_errors) = smol::block_on(maki_agent::mcp::start(&cwd));
+
+    let prompt_slots = plugin_host
+        .event_handle()
+        .map(|h| h.collect_prompt_slots())
+        .unwrap_or_default();
+
+    maki_acp::run(maki_acp::AcpParams {
+        model,
+        config: config.agent,
+        permissions_config: config.permissions,
+        timeouts,
+        initial_wd: cwd,
+        mcp_handle,
+        prompt_slots: Arc::new(prompt_slots),
+        yolo,
+    })
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,3 +1,4 @@
+mod acp;
 mod migrate;
 mod subcmd;
 mod tui;
@@ -37,6 +38,9 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         }
         Some(Command::Rollback) => {
             update::rollback().map_err(|e| color_eyre::eyre::eyre!("{e}"))?;
+        }
+        Some(Command::Acp { model, yolo }) => {
+            acp::run(model, yolo)?;
         }
         Some(Command::Migrate { action }) => match action {
             MigrateAction::Xdg => migrate::xdg()?,


### PR DESCRIPTION
New `maki-acp` crate speaks Agent Client Protocol v1 so editors like Zed can drive maki over NDJSON stdio.

The headless driver in `maki-agent` got a multi-turn `spawn_interactive` that carries `History` across prompts, persists the session to storage on create and after every turn, routes permission answers back through `answer_tx`, and supports per-run cancellation.

`maki-acp` handles `initialize`, `session/new`, `session/load`, `session/prompt`, `session/set_mode`, and `session/cancel`, translating every `AgentEvent` into the right `session/update` notification (diffs, tool calls with correct `ToolKind`, plan entries from `todo_write`, thinking chunks, permission requests).

Without persistence, reopening a thread in Zed died with `Resource not found`; on `session/load` the stored conversation is also replayed as `session/update` notifications before the response, which is how the editor gets its history back on screen.

Workspace `rust-version` bumped to 1.88 for `agent-client-protocol-schema` 0.13.