### PR TITLE
agent: live shared_history via History mirror

### DIFF
--- a/maki-agent/src/agent/history.rs
+++ b/maki-agent/src/agent/history.rs
@@ -1,14 +1,30 @@
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
 use maki_providers::{ContentBlock, Message, Role};
 
 const CANCEL_MARKER: &str = "[Cancelled by user]";
+const UNAVAILABLE_RESULT: &str = "[Tool result not available]";
+
+pub type SharedMessages = Arc<ArcSwap<Vec<Message>>>;
 
 pub struct History {
     messages: Vec<Message>,
+    mirror: Option<SharedMessages>,
 }
 
 impl History {
     pub fn new(messages: Vec<Message>) -> Self {
-        Self { messages }
+        Self {
+            messages,
+            mirror: None,
+        }
+    }
+
+    pub fn with_mirror(mut self, mirror: SharedMessages) -> Self {
+        self.mirror = Some(mirror);
+        self.publish();
+        self
     }
 
     pub fn as_slice(&self) -> &[Message] {
@@ -16,7 +32,7 @@ impl History {
     }
 
     pub fn push(&mut self, msg: Message) {
-        self.messages.push(msg);
+        self.edit(|msgs| msgs.push(msg));
     }
 
     pub fn len(&self) -> usize {
@@ -28,39 +44,58 @@ impl History {
     }
 
     pub fn replace(&mut self, messages: Vec<Message>) {
-        self.messages = messages;
+        self.edit(|msgs| *msgs = messages);
     }
 
     pub fn truncate(&mut self, len: usize) {
-        self.messages.truncate(len);
+        self.edit(|msgs| msgs.truncate(len));
     }
 
     pub fn into_vec(self) -> Vec<Message> {
         self.messages
     }
+
+    fn edit(&mut self, f: impl FnOnce(&mut Vec<Message>)) {
+        f(&mut self.messages);
+        self.publish();
+    }
+
+    fn publish(&self) {
+        let Some(mirror) = &self.mirror else { return };
+        let mut snapshot = self.messages.clone();
+        close_dangling_tool_calls(&mut snapshot, UNAVAILABLE_RESULT);
+        mirror.store(Arc::new(snapshot));
+    }
+}
+
+fn close_dangling_tool_calls(messages: &mut Vec<Message>, note: &str) {
+    let Some(last) = messages.last() else { return };
+    if !matches!(last.role, Role::Assistant) || !last.has_tool_calls() {
+        return;
+    }
+    let error_results: Vec<ContentBlock> = last
+        .tool_uses()
+        .map(|(id, _, _)| ContentBlock::ToolResult {
+            tool_use_id: id.to_owned(),
+            content: note.to_owned(),
+            is_error: true,
+        })
+        .collect();
+    messages.push(Message {
+        role: Role::User,
+        content: error_results,
+        display_text: Some(String::new()),
+    });
 }
 
 pub(crate) fn sanitize_cancelled_history(history: &mut History, rollback_len: usize) {
     if history.len() <= rollback_len {
         return;
     }
-    let last = history.as_slice().last().unwrap();
-    if matches!(last.role, Role::Assistant) && last.has_tool_calls() {
-        let error_results: Vec<ContentBlock> = last
-            .tool_uses()
-            .map(|(id, _, _)| ContentBlock::ToolResult {
-                tool_use_id: id.to_owned(),
-                content: CANCEL_MARKER.to_owned(),
-                is_error: true,
-            })
-            .collect();
-        history.push(Message {
-            role: Role::User,
-            content: error_results,
-            display_text: Some(String::new()),
-        });
-    }
-    history.push(Message::synthetic(CANCEL_MARKER.into()));
+    history.edit(|msgs| {
+        close_dangling_tool_calls(msgs, CANCEL_MARKER);
+        msgs.push(Message::synthetic(CANCEL_MARKER.into()));
+    });
 }
 
 #[cfg(test)]
@@ -75,6 +110,40 @@ mod tests {
         let last = history.as_slice().last().unwrap();
         assert!(matches!(last.role, Role::User));
         assert!(matches!(&last.content[0], ContentBlock::Text { text } if text == CANCEL_MARKER));
+    }
+
+    fn make_tool_use_msg(ids: &[&str]) -> Message {
+        Message {
+            role: Role::Assistant,
+            content: ids
+                .iter()
+                .map(|id| ContentBlock::ToolUse {
+                    id: id.to_string(),
+                    name: "read".into(),
+                    input: serde_json::json!({}),
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    fn make_mirror() -> SharedMessages {
+        Arc::new(ArcSwap::from_pointee(Vec::new()))
+    }
+
+    #[track_caller]
+    fn extract_error_ids(msg: &Message) -> Vec<&str> {
+        msg.content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::ToolResult {
+                    tool_use_id,
+                    is_error: true,
+                    ..
+                } => Some(tool_use_id.as_str()),
+                _ => None,
+            })
+            .collect()
     }
 
     #[test_case(
@@ -119,42 +188,107 @@ mod tests {
     fn sanitize_dangling_tool_use_adds_error_results() {
         let mut history = History::new(vec![
             Message::user("hello".into()),
-            Message {
-                role: Role::Assistant,
-                content: vec![
-                    ContentBlock::Text {
-                        text: "let me check".into(),
-                    },
-                    ContentBlock::ToolUse {
-                        id: "t1".into(),
-                        name: "read".into(),
-                        input: serde_json::json!({"path": "/tmp"}),
-                    },
-                    ContentBlock::ToolUse {
-                        id: "t2".into(),
-                        name: "glob".into(),
-                        input: serde_json::json!({"pattern": "*.rs"}),
-                    },
-                ],
-                ..Default::default()
-            },
+            make_tool_use_msg(&["t1", "t2"]),
         ]);
         sanitize_cancelled_history(&mut history, 0);
 
-        let tool_result_msg = &history.as_slice()[2];
-        let error_ids: Vec<&str> = tool_result_msg
-            .content
-            .iter()
-            .filter_map(|b| match b {
-                ContentBlock::ToolResult {
-                    tool_use_id,
-                    is_error: true,
-                    ..
-                } => Some(tool_use_id.as_str()),
-                _ => None,
-            })
-            .collect();
-        assert_eq!(error_ids, ["t1", "t2"]);
+        assert_eq!(extract_error_ids(&history.as_slice()[2]), ["t1", "t2"]);
         assert_ends_with_cancel_marker(&history);
+    }
+
+    #[test]
+    fn mirror_sequential_mutations_always_consistent() {
+        let mirror = make_mirror();
+        let mut history = History::new(Vec::new()).with_mirror(Arc::clone(&mirror));
+
+        for i in 0..10 {
+            history.push(Message::user(format!("msg-{i}")));
+            assert_eq!(mirror.load().len(), i + 1);
+        }
+
+        history.truncate(3);
+        assert_eq!(mirror.load().len(), 3);
+
+        history.replace(vec![Message::user("fresh".into())]);
+        assert_eq!(mirror.load().len(), 1);
+
+        history.push(make_tool_use_msg(&["t_final"]));
+        assert_eq!(history.len(), 2, "history has 2");
+        assert_eq!(mirror.load().len(), 3, "mirror has 3 (dangling closed)");
+    }
+
+    #[test]
+    fn snapshot_closes_dangling_tool_uses_without_mutating_history() {
+        let mirror = make_mirror();
+        let history = History::new(vec![
+            Message::user("go".into()),
+            make_tool_use_msg(&["t1", "t2"]),
+        ])
+        .with_mirror(Arc::clone(&mirror));
+
+        assert_eq!(history.len(), 2, "history itself unchanged");
+
+        let snap = mirror.load();
+        assert_eq!(snap.len(), 3, "snapshot has extra closing message");
+
+        let closing = &snap[2];
+        assert!(matches!(closing.role, Role::User));
+        assert_eq!(extract_error_ids(closing), ["t1", "t2"]);
+        assert_eq!(closing.display_text.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn snapshot_not_dangling_when_tool_result_already_present() {
+        let mirror = make_mirror();
+        let mut history =
+            History::new(vec![Message::user("go".into()), make_tool_use_msg(&["t1"])])
+                .with_mirror(Arc::clone(&mirror));
+
+        assert_eq!(mirror.load().len(), 3, "dangling before result");
+
+        history.push(Message {
+            role: Role::User,
+            content: vec![ContentBlock::ToolResult {
+                tool_use_id: "t1".into(),
+                content: "file contents".into(),
+                is_error: false,
+            }],
+            ..Default::default()
+        });
+
+        let snap = mirror.load();
+        assert_eq!(snap.len(), 3, "no extra closing after real result");
+    }
+
+    #[test]
+    fn into_vec_returns_inner_not_snapshot() {
+        let mirror = make_mirror();
+        let history = History::new(vec![Message::user("go".into()), make_tool_use_msg(&["t1"])])
+            .with_mirror(Arc::clone(&mirror));
+
+        assert_eq!(mirror.load().len(), 3, "snapshot has closing message");
+        assert_eq!(history.into_vec().len(), 2, "into_vec returns raw messages");
+    }
+
+    #[test]
+    fn sanitize_cancelled_on_mirrored_history() {
+        let mirror = make_mirror();
+        let mut history =
+            History::new(vec![Message::user("go".into()), make_tool_use_msg(&["t1"])])
+                .with_mirror(Arc::clone(&mirror));
+
+        sanitize_cancelled_history(&mut history, 0);
+
+        let snap = mirror.load();
+        assert_eq!(snap.len(), history.len(), "mirror matches history length");
+
+        let last = snap.last().unwrap();
+        assert!(matches!(&last.content[0], ContentBlock::Text { text } if text == CANCEL_MARKER));
+
+        let tool_result_msg = &snap[snap.len() - 2];
+        assert!(tool_result_msg.content.iter().any(|b| matches!(
+            b,
+            ContentBlock::ToolResult { content, is_error: true, .. } if content == CANCEL_MARKER
+        )));
     }
 }

--- a/maki-agent/src/agent/mod.rs
+++ b/maki-agent/src/agent/mod.rs
@@ -6,10 +6,10 @@ mod streaming;
 pub mod tool_dispatch;
 
 pub use compaction::compact;
-pub use history::History;
+pub use history::{History, SharedMessages};
 pub(crate) use instructions::is_instruction_file;
 pub use instructions::{
     Instructions, LoadedInstructions, build_system_prompt, find_subdirectory_instructions,
     load_instruction_text, load_instructions,
 };
-pub use run::{Agent, AgentParams, AgentRunParams, RunOutcome};
+pub use run::{Agent, AgentParams, AgentRunParams};

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -28,11 +28,6 @@ enum TurnOutcome {
     Done(Option<StopReason>),
 }
 
-pub struct RunOutcome {
-    pub history: History,
-    pub result: Result<(), AgentError>,
-}
-
 pub struct AgentParams {
     pub provider: Arc<dyn Provider>,
     pub model: Model,
@@ -45,17 +40,17 @@ pub struct AgentParams {
     pub prompt_slots: Arc<crate::prompt::ResolvedSlots>,
 }
 
-pub struct AgentRunParams {
-    pub history: History,
+pub struct AgentRunParams<'h> {
+    pub history: &'h mut History,
     pub system: String,
     pub event_tx: EventSender,
     pub tools: Value,
 }
 
-pub struct Agent {
+pub struct Agent<'h> {
     provider: Arc<dyn Provider>,
     model: Arc<Model>,
-    history: History,
+    history: &'h mut History,
     system: String,
     event_tx: EventSender,
     tools: Value,
@@ -81,8 +76,8 @@ pub struct Agent {
     prompt_slots: Arc<crate::prompt::ResolvedSlots>,
 }
 
-impl Agent {
-    pub fn new(params: AgentParams, run: AgentRunParams) -> Self {
+impl<'h> Agent<'h> {
+    pub fn new(params: AgentParams, run: AgentRunParams<'h>) -> Self {
         Self {
             provider: params.provider,
             model: Arc::new(params.model),
@@ -141,7 +136,7 @@ impl Agent {
         self
     }
 
-    pub async fn run(mut self, input: AgentInput) -> RunOutcome {
+    pub async fn run(&mut self, input: AgentInput) -> Result<(), AgentError> {
         self.rollback_len = self.history.len();
         let msg = Message::user_with_images(input.message.clone(), input.images);
         self.history.push(msg);
@@ -161,13 +156,10 @@ impl Agent {
         let result = self.run_loop().await;
 
         if matches!(result, Err(AgentError::Cancelled)) {
-            sanitize_cancelled_history(&mut self.history, self.rollback_len);
+            sanitize_cancelled_history(self.history, self.rollback_len);
         }
 
-        RunOutcome {
-            history: self.history,
-            result,
-        }
+        result
     }
 
     async fn run_loop(&mut self) -> Result<(), AgentError> {
@@ -315,7 +307,7 @@ impl Agent {
             response,
             &mut self.recent_calls,
             self.mcp.as_ref(),
-            &mut self.history,
+            self.history,
             &self.event_tx,
             &ctx,
         )
@@ -360,7 +352,7 @@ impl Agent {
         self.total_usage += compaction::compact_history(
             &*self.provider,
             &self.model,
-            &mut self.history,
+            self.history,
             &self.event_tx,
             &self.cancel,
         )
@@ -490,7 +482,10 @@ mod tests {
         }
     }
 
-    fn make_agent(provider: MockProvider, history: History) -> (Agent, flume::Receiver<Envelope>) {
+    fn make_agent(
+        provider: MockProvider,
+        history: &mut History,
+    ) -> (Agent<'_>, flume::Receiver<Envelope>) {
         let (raw_tx, event_rx) = flume::unbounded();
         let agent = Agent::new(
             AgentParams {
@@ -537,7 +532,8 @@ mod tests {
     }
 
     async fn run_agent(provider: MockProvider) -> (u32, Option<StopReason>) {
-        let (agent, event_rx) = make_agent(provider, History::new(Vec::new()));
+        let mut history = History::new(Vec::new());
+        let (mut agent, event_rx) = make_agent(provider, &mut history);
         let _ = agent.run(default_input()).await;
         drain_events(&event_rx)
             .into_iter()
@@ -636,13 +632,12 @@ mod tests {
                 ]
             };
 
-            let (agent, event_rx) =
-                make_agent(MockProvider::new(responses), History::new(Vec::new()));
-            let agent = match source {
-                Some(s) => agent.with_interrupt_source(s),
-                None => agent,
-            };
-            let outcome = agent.run(default_input()).await;
+            let mut history = History::new(Vec::new());
+            let (mut agent, event_rx) = make_agent(MockProvider::new(responses), &mut history);
+            if let Some(s) = source {
+                agent = agent.with_interrupt_source(s);
+            }
+            let _ = agent.run(default_input()).await;
             let events = drain_events(&event_rx);
 
             assert_eq!(
@@ -653,7 +648,7 @@ mod tests {
                 expect_consumed,
             );
             assert_eq!(
-                has_interrupt_in_history(outcome.history.as_slice()),
+                has_interrupt_in_history(history.as_slice()),
                 expect_injected
             );
         });
@@ -673,13 +668,14 @@ mod tests {
         smol::block_on(async {
             let source = MockInterruptSource::new(commands);
 
-            let (agent, _event_rx) = make_agent(MockProvider::new(responses), History::new(prior));
-            let outcome = agent
+            let mut history = History::new(prior);
+            let (agent, _event_rx) = make_agent(MockProvider::new(responses), &mut history);
+            let result = agent
                 .with_interrupt_source(source)
                 .run(default_input())
                 .await;
 
-            assert!(outcome.result.is_ok());
+            assert!(result.is_ok());
         });
     }
 
@@ -693,10 +689,8 @@ mod tests {
             } else {
                 vec![]
             };
-            let (mut agent, event_rx) = make_agent(
-                MockProvider::new(responses),
-                History::new(vec![Message::user("go".into())]),
-            );
+            let mut history = History::new(vec![Message::user("go".into())]);
+            let (mut agent, event_rx) = make_agent(MockProvider::new(responses), &mut history);
             agent.model = Arc::new(small_context_model(1000, 200));
             agent.auto_compact = enabled;
 
@@ -747,7 +741,8 @@ mod tests {
             trigger.cancel();
 
             let (raw_tx, _rx) = flume::unbounded();
-            let agent = Agent::new(
+            let mut history = History::new(Vec::new());
+            let mut agent = Agent::new(
                 AgentParams {
                     provider: Arc::new(HangingProvider),
                     model: default_model(),
@@ -766,7 +761,7 @@ mod tests {
                     prompt_slots: Arc::new(crate::prompt::ResolvedSlots::default()),
                 },
                 AgentRunParams {
-                    history: History::new(Vec::new()),
+                    history: &mut history,
                     system: "system".into(),
                     event_tx: EventSender::new(raw_tx, 0),
                     tools: serde_json::json!([]),
@@ -774,9 +769,10 @@ mod tests {
             )
             .with_cancel(cancel);
 
-            let outcome = agent.run(default_input()).await;
-            assert!(matches!(outcome.result, Err(AgentError::Cancelled)));
-            assert_ends_with_cancel_marker(&outcome.history);
+            let result = agent.run(default_input()).await;
+            assert!(matches!(result, Err(AgentError::Cancelled)));
+            drop(agent);
+            assert_ends_with_cancel_marker(&history);
         });
     }
 
@@ -792,9 +788,10 @@ mod tests {
     )]
     fn error_emits_tool_done_event(responses: Vec<StreamResponse>, expected_error_id: &str) {
         smol::block_on(async {
-            let (agent, event_rx) =
-                make_agent(MockProvider::new(responses), History::new(Vec::new()));
+            let mut history = History::new(Vec::new());
+            let (mut agent, event_rx) = make_agent(MockProvider::new(responses), &mut history);
             let _ = agent.run(default_input()).await;
+            drop(agent);
             let events = drain_events(&event_rx);
 
             assert!(has_event(&events, |e| matches!(

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -1,4 +1,3 @@
-use std::mem;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -170,7 +169,8 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
                     }
                 };
             let error_tx = event_tx.clone();
-            let agent = Agent::new(
+            let mut history = History::new(Vec::new());
+            let mut agent = Agent::new(
                 AgentParams {
                     provider,
                     model: params.model,
@@ -186,7 +186,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
                     prompt_slots: Arc::new(params.prompt_slots),
                 },
                 AgentRunParams {
-                    history: History::new(Vec::new()),
+                    history: &mut history,
                     system,
                     event_tx,
                     tools,
@@ -195,7 +195,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
             .with_loaded_instructions(instructions.loaded)
             .with_mcp(params.mcp_handle);
 
-            let outcome = agent
+            let result = agent
                 .run(AgentInput {
                     message: params.prompt,
                     mode,
@@ -203,8 +203,9 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
                     ..Default::default()
                 })
                 .await;
+            drop(agent);
 
-            if let Err(e) = outcome.result {
+            if let Err(e) = result {
                 error!(error = %e, "agent error");
                 let _ = error_tx.send(AgentEvent::Error {
                     message: e.user_message(),
@@ -353,7 +354,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
 
                 while answer_rx.lock().await.try_recv().is_ok() {}
 
-                let agent = Agent::new(
+                let mut agent = Agent::new(
                     AgentParams {
                         provider: Arc::clone(&provider),
                         model: model.clone(),
@@ -366,7 +367,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                         prompt_slots: Arc::clone(&params.prompt_slots),
                     },
                     AgentRunParams {
-                        history: mem::replace(&mut history, History::new(Vec::new())),
+                        history: &mut history,
                         system,
                         event_tx,
                         tools: tools.clone(),
@@ -377,17 +378,17 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                 .with_cancel(cancel)
                 .with_mcp(params.mcp_handle.clone());
 
-                let outcome = agent.run(input).await;
+                let result = agent.run(input).await;
+                drop(agent);
                 cancel_task.cancel().await;
 
-                if let Err(ref e) = outcome.result {
+                if let Err(ref e) = result {
                     error!(error = %e, "agent error");
                     let _ = error_tx.send(AgentEvent::Error {
                         message: e.user_message(),
                     });
                 }
 
-                history = outcome.history;
                 if let Some(store) = &mut store {
                     store.record_turn(history.as_slice(), model.spec());
                 }

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -11,7 +11,7 @@ pub use mcp::protocol::PromptRole;
 pub use mcp::{McpCommand, McpHandle, McpPromptArg, McpPromptInfo, McpSnapshot, McpSnapshotReader};
 pub(crate) mod task_set;
 pub use agent::{
-    Agent, AgentParams, AgentRunParams, History, Instructions, LoadedInstructions, RunOutcome,
+    Agent, AgentParams, AgentRunParams, History, Instructions, LoadedInstructions, SharedMessages,
 };
 pub use cancel::{CancelToken, CancelTrigger};
 pub use maki_config::{AgentConfig, PermissionsConfig, ToolOutputLines};

--- a/maki-agent/src/tools/task.rs
+++ b/maki-agent/src/tools/task.rs
@@ -162,7 +162,8 @@ impl Task {
             ..Default::default()
         };
 
-        let agent = Agent::new(
+        let mut history = crate::History::new(Vec::new());
+        let mut agent = Agent::new(
             AgentParams {
                 provider,
                 model,
@@ -175,7 +176,7 @@ impl Task {
                 prompt_slots: Arc::clone(&ctx.prompt_slots),
             },
             AgentRunParams {
-                history: crate::History::new(Vec::new()),
+                history: &mut history,
                 system,
                 event_tx: sub_event_tx,
                 tools,
@@ -185,16 +186,15 @@ impl Task {
         .with_cancel(child_cancel)
         .with_mcp(ctx.mcp.clone());
         let start = Instant::now();
-        let outcome = agent.run(input).await;
+        let result = agent.run(input).await;
         let duration_ms = start.elapsed().as_millis() as u64;
+        drop(agent);
         drop(child_trigger);
-        let success = outcome.result.is_ok();
+        let success = result.is_ok();
         info!(description = %self.description, duration_ms, success, "subagent completed");
-        outcome
-            .result
-            .map_err(|e| format!("sub-agent error: {e}"))?;
+        result.map_err(|e| format!("sub-agent error: {e}"))?;
 
-        let messages = outcome.history.into_vec();
+        let messages = history.into_vec();
 
         let text = messages
             .iter()

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -1,4 +1,3 @@
-use std::mem;
 use std::sync::{Arc, Mutex};
 
 use arc_swap::ArcSwap;
@@ -32,7 +31,6 @@ pub(super) struct AgentLoop {
     tools: Value,
     mcp_handle: Option<McpHandle>,
     history: History,
-    shared_history: Arc<ArcSwap<Vec<Message>>>,
     btw_system: Arc<ArcSwap<String>>,
     cancel_map: Arc<Mutex<CancelMap>>,
     init_cancel: CancelToken,
@@ -75,8 +73,7 @@ impl AgentLoop {
             instructions: Instructions::default(),
             tools: Value::Null,
             mcp_handle,
-            history: History::new(initial_history),
-            shared_history,
+            history: History::new(initial_history).with_mirror(shared_history),
             btw_system,
             cancel_map,
             init_cancel,
@@ -151,10 +148,7 @@ impl AgentLoop {
 
     async fn do_compact(&mut self, event_tx: &EventSender) -> Result<(), AgentError> {
         let slot = self.model_slot.load();
-        let result =
-            agent::compact(&*slot.provider, &slot.model, &mut self.history, event_tx).await;
-        self.sync_shared_history();
-        result
+        agent::compact(&*slot.provider, &slot.model, &mut self.history, event_tx).await
     }
 
     async fn do_agent_run(
@@ -172,7 +166,7 @@ impl AgentLoop {
         }
         self.rebuild_tools(&slot.model);
 
-        for msg in mem::take(&mut input.preamble) {
+        for msg in std::mem::take(&mut input.preamble) {
             self.history.push(msg);
         }
 
@@ -204,8 +198,6 @@ impl AgentLoop {
             }
         }
 
-        self.sync_shared_history_with_pending(&input);
-
         let prompt_slots = match self.lua_handle.as_ref() {
             Some(h) => h.collect_prompt_slots_async().await,
             None => maki_agent::prompt::ResolvedSlots::default(),
@@ -222,7 +214,7 @@ impl AgentLoop {
 
         while self.answer_rx.lock().await.try_recv().is_ok() {}
 
-        let agent = Agent::new(
+        let mut agent = Agent::new(
             AgentParams {
                 provider: Arc::clone(&slot.provider),
                 model: slot.model.clone(),
@@ -235,7 +227,7 @@ impl AgentLoop {
                 prompt_slots: Arc::new(prompt_slots),
             },
             AgentRunParams {
-                history: mem::replace(&mut self.history, History::new(Vec::new())),
+                history: &mut self.history,
                 system,
                 event_tx,
                 tools: self.tools.clone(),
@@ -247,17 +239,16 @@ impl AgentLoop {
         .with_cancel(cancel)
         .with_mcp(self.mcp_handle.clone());
 
-        let outcome = agent.run(input).await;
+        let result = agent.run(input).await;
+        drop(agent);
 
         self.clear_cancel_trigger(run_id);
-        self.history = outcome.history;
-        self.sync_shared_history();
 
-        if matches!(outcome.result, Err(AgentError::Cancelled)) {
+        if matches!(result, Err(AgentError::Cancelled)) {
             self.min_run_id = run_id + 1;
         }
 
-        outcome.result
+        result
     }
 
     fn rebuild_tools(&mut self, model: &Model) {
@@ -290,17 +281,6 @@ impl AgentLoop {
             prompt_slots,
         );
         self.btw_system.store(Arc::new(system));
-    }
-
-    fn sync_shared_history(&self) {
-        self.shared_history
-            .store(Arc::new(self.history.as_slice().to_vec()));
-    }
-
-    fn sync_shared_history_with_pending(&self, input: &AgentInput) {
-        let mut snapshot = self.history.as_slice().to_vec();
-        snapshot.push(Message::user(input.message.clone()));
-        self.shared_history.store(Arc::new(snapshot));
     }
 
     fn set_cancel_trigger(&self, run_id: u64, trigger: CancelTrigger) {


### PR DESCRIPTION
`/btw` and session saves only saw conversation history from the last completed run because `shared_history` was updated at run boundaries, not during.

`History` now has an optional `SharedMessages` mirror that auto-publishes a snapshot on every mutation (`push`, `replace`, `truncate`) through a single `edit()` funnel. Snapshots close dangling `tool_use` blocks with `[Tool result not available]` so every reader gets a valid API sequence without consumer-side fixups.

`Agent` borrows `&mut History` instead of taking ownership, which kills the `mem::replace` / `RunOutcome` dance and the "stale view" bug class with it.