### PR TITLE
fix: make Ctrl+E jump to end of line in input

### DIFF
--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -444,14 +444,6 @@ impl App {
             self.active_chat().scroll(-half);
             return Some(vec![]);
         }
-        if key::SCROLL_LINE_UP.matches(key) {
-            self.active_chat().scroll(1);
-            return Some(vec![]);
-        }
-        if key::SCROLL_LINE_DOWN.matches(key) {
-            self.active_chat().scroll(-1);
-            return Some(vec![]);
-        }
         if key::SCROLL_TOP.matches(key) {
             self.active_chat().scroll_to_top();
             return Some(vec![]);

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -148,6 +148,7 @@ pub mod key {
     pub const DELETE: Bind = ctrl_bind!('d');
     pub const KILL_LINE: Bind = ctrl_bind!('k');
     pub const LINE_START: Bind = ctrl_bind!('a');
+    pub const LINE_END: Bind = ctrl_bind!('e');
     pub const EDIT_INPUT: Bind = Bind {
         code: KeyCode::Char('o'),
         modifiers: KeyModifiers::ALT,
@@ -392,7 +393,7 @@ pub const KEYBINDS: &[Keybind] = &[
         label: KeyLabel::Alt("⌥←", "⌥→"),
         description: "Move word left / right",
         context: KeybindContext::Editing,
-        platform: Platform::MacOnly,
+        platform: Platform::All,
     },
     Keybind {
         label: KeyLabel::Alt(mod_key!("Del"), "⌥Del"),
@@ -410,13 +411,13 @@ pub const KEYBINDS: &[Keybind] = &[
         label: KeyLabel::Single(key::LINE_START.label),
         description: "Jump to start of line",
         context: KeybindContext::Editing,
-        platform: Platform::MacOnly,
+        platform: Platform::All,
     },
     Keybind {
         label: KeyLabel::Alt("Home", "End"),
         description: "Jump to start/end of line",
         context: KeybindContext::Editing,
-        platform: Platform::MacOnly,
+        platform: Platform::All,
     },
     Keybind {
         label: KeyLabel::Alt(key::SCROLL_HALF_UP.label, key::SCROLL_HALF_DOWN.label),
@@ -425,8 +426,8 @@ pub const KEYBINDS: &[Keybind] = &[
         platform: Platform::All,
     },
     Keybind {
-        label: KeyLabel::Alt(key::SCROLL_LINE_UP.label, key::SCROLL_LINE_DOWN.label),
-        description: "Scroll one line up / down",
+        label: KeyLabel::Single(key::LINE_END.label),
+        description: "Jump to end of line",
         context: KeybindContext::Editing,
         platform: Platform::All,
     },

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -390,7 +390,7 @@ pub const KEYBINDS: &[Keybind] = &[
         platform: Platform::All,
     },
     Keybind {
-        label: KeyLabel::Alt("⌥←", "⌥→"),
+        label: KeyLabel::MacMulti(&["Alt+←", "Alt+→"], &["⌥←", "⌥→"]),
         description: "Move word left / right",
         context: KeybindContext::Editing,
         platform: Platform::All,

--- a/maki-ui/src/text_buffer.rs
+++ b/maki-ui/src/text_buffer.rs
@@ -321,6 +321,10 @@ impl TextBuffer {
                     self.move_home();
                     EditResult::Moved
                 }
+                KeyCode::Char('e') => {
+                    self.move_end();
+                    EditResult::Moved
+                }
                 _ => EditResult::Ignored,
             };
         }
@@ -653,6 +657,7 @@ mod tests {
     #[test_case(plain(KeyCode::Char('a')),      EditResult::Changed ; "plain_changed")]
     #[test_case(plain(KeyCode::Left),            EditResult::Moved   ; "plain_moved")]
     #[test_case(plain(KeyCode::F(1)),            EditResult::Ignored ; "plain_ignored")]
+    #[test_case(ctrl(KeyCode::Char('e')),        EditResult::Moved   ; "ctrl_e_moved")]
     #[test_case(ctrl(KeyCode::Char('k')),        EditResult::Changed ; "ctrl_changed")]
     #[test_case(ctrl(KeyCode::Char('a')),        EditResult::Moved   ; "ctrl_moved")]
     #[test_case(ctrl(KeyCode::Char('z')),        EditResult::Ignored ; "ctrl_ignored")]

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -31,10 +31,11 @@ On macOS, some bindings use Option or Fn keys instead (run `/help` for exact key
 | `Tab` | Toggle mode |
 | `/command` | Open command palette |
 | `Ctrl+W` | Delete word backward |
+| `Alt+←` / `Alt+→` | Move word left / right |
 | `Ctrl+A` | Jump to start of line |
-| `Ctrl+E` | Jump to end of line |
 | `Home` / `End` | Jump to start/end of line |
 | `Ctrl+U` / `Ctrl+D` | Scroll half page up / down |
+| `Ctrl+E` | Jump to end of line |
 | `Ctrl+G` | Scroll to top |
 | `Ctrl+B` | Scroll to bottom |
 | `Ctrl+Q` | Pop queue |
@@ -45,7 +46,6 @@ On macOS, some bindings use Option or Fn keys instead (run `/help` for exact key
 
 | Key | Action |
 |-----|--------|
-| `⌥←` / `⌥→` | Move word left / right |
 | `Ctrl+Del` / `⌥Del` | Delete word forward |
 | `Ctrl+K` | Delete to end of line |
 

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -31,8 +31,10 @@ On macOS, some bindings use Option or Fn keys instead (run `/help` for exact key
 | `Tab` | Toggle mode |
 | `/command` | Open command palette |
 | `Ctrl+W` | Delete word backward |
+| `Ctrl+A` | Jump to start of line |
+| `Ctrl+E` | Jump to end of line |
+| `Home` / `End` | Jump to start/end of line |
 | `Ctrl+U` / `Ctrl+D` | Scroll half page up / down |
-| `Ctrl+Y` / `Ctrl+E` | Scroll one line up / down |
 | `Ctrl+G` | Scroll to top |
 | `Ctrl+B` | Scroll to bottom |
 | `Ctrl+Q` | Pop queue |
@@ -46,8 +48,6 @@ On macOS, some bindings use Option or Fn keys instead (run `/help` for exact key
 | `⌥←` / `⌥→` | Move word left / right |
 | `Ctrl+Del` / `⌥Del` | Delete word forward |
 | `Ctrl+K` | Delete to end of line |
-| `Ctrl+A` | Jump to start of line |
-| `Home` / `End` | Jump to start/end of line |
 
 ## While Streaming
 

--- a/site/docs/content/quick-start/_index.md
+++ b/site/docs/content/quick-start/_index.md
@@ -59,7 +59,7 @@ Type a prompt, press **Enter**, and the agent starts working.
 ## Keybindings
 
 - **Newline in input**: \\+Enter, Ctrl+J, or Alt+Enter
-- **Scroll output**: Ctrl+U / Ctrl+D (half page), Ctrl+Y / Ctrl+E (line)
+- **Scroll output**: Ctrl+U / Ctrl+D (half page)
 - **Cancel streaming**: Esc Esc
 - **Rewind (when idle)**: Esc Esc
 - **Quit**: Ctrl+C


### PR DESCRIPTION
I'd love to have ctrl+a and ctrl+e work, very useful for POSIX-style keyboard-driven prompt editing. Seems like it was already suggested and positively acknowledged in #191, so I took the liberty to implement it. There was a conflict with ctrl+e and ctrl+y being used for line scrolling, but my proposed behavior is more terminal prompt standard, so I removed both of those rather than leaving an asymmetric ctrl+y by itself.

I also marked Del, Home/End, and Alt+Left/Right as Linux _and_ OSX-viable binds, I tested by building the app on my Linux server and running it there, they all seemed to work.

Love maki by the way, thanks for building it! Wrote this PR with maki, MiMo v2.5 Pro and a good deal of nudging.