### PR TITLE
fix(skill): guard against nil cwd in find_project_ancestors

### DIFF
--- a/plugins/skill/init.lua
+++ b/plugins/skill/init.lua
@@ -45,6 +45,9 @@ end
 
 local function find_project_ancestors()
   local cwd = maki.uv.cwd()
+  if not cwd then
+    return {}
+  end
   local dirs = { cwd }
   for _, parent in ipairs(maki.fs.parents(cwd)) do
     dirs[#dirs + 1] = parent


### PR DESCRIPTION
Maki crashed when I was running in a worktree that another terminal deleted from this. Though it's not likely for others to run into this, it'd still be nice to gracefully fail than to just crash outright. Still, that'd be a much bigger change than this 3-liner.