### PR TITLE
fix: prevent compaction from exceeding context window

### DIFF
--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -22,6 +22,7 @@ pub(super) async fn compact_history(
     let mut compaction_history: Vec<Message> = history.as_slice().to_vec();
     strip_images(&mut compaction_history);
     strip_thinking(&mut compaction_history);
+    strip_old_tool_results(&mut compaction_history);
     compaction_history.push(Message::user(crate::prompt::COMPACTION_USER.to_string()));
 
     let empty_tools = serde_json::json!([]);
@@ -103,6 +104,29 @@ fn strip_thinking(messages: &mut [Message]) {
                 ContentBlock::Thinking { .. } | ContentBlock::RedactedThinking { .. }
             )
         });
+    }
+}
+
+const TOOL_RESULT_PLACEHOLDER: &str = "[tool result]";
+const KEEP_LAST_TOOL_RESULTS: usize = 3;
+
+fn strip_old_tool_results(messages: &mut [Message]) {
+    let total: usize = messages
+        .iter()
+        .flat_map(|m| &m.content)
+        .filter(|b| matches!(b, ContentBlock::ToolResult { .. }))
+        .count();
+
+    let mut seen = 0;
+    for msg in messages {
+        for block in &mut msg.content {
+            if let ContentBlock::ToolResult { content, .. } = block {
+                if seen < total.saturating_sub(KEEP_LAST_TOOL_RESULTS) {
+                    *content = TOOL_RESULT_PLACEHOLDER.into();
+                }
+                seen += 1;
+            }
+        }
     }
 }
 
@@ -284,5 +308,63 @@ mod tests {
         strip_thinking(&mut messages);
         assert_eq!(messages[0].content.len(), 1);
         assert!(matches!(&messages[0].content[0], ContentBlock::Text { text } if text == "hello"));
+    }
+
+    #[test]
+    fn strip_old_tool_results_keeps_newest() {
+        let mut messages = vec![Message {
+            role: Role::User,
+            content: vec![
+                ContentBlock::ToolResult {
+                    tool_use_id: "t1".into(),
+                    content: "old result 1".into(),
+                    is_error: false,
+                },
+                ContentBlock::ToolResult {
+                    tool_use_id: "t2".into(),
+                    content: "old result 2".into(),
+                    is_error: false,
+                },
+                ContentBlock::ToolResult {
+                    tool_use_id: "t3".into(),
+                    content: "keep 1".into(),
+                    is_error: false,
+                },
+                ContentBlock::ToolResult {
+                    tool_use_id: "t4".into(),
+                    content: "keep 2".into(),
+                    is_error: false,
+                },
+                ContentBlock::ToolResult {
+                    tool_use_id: "t5".into(),
+                    content: "keep 3".into(),
+                    is_error: false,
+                },
+                ContentBlock::Text {
+                    text: "keep me".into(),
+                },
+            ],
+            ..Default::default()
+        }];
+        strip_old_tool_results(&mut messages);
+        assert_eq!(messages[0].content.len(), 6);
+        assert!(
+            matches!(&messages[0].content[0], ContentBlock::ToolResult { content, tool_use_id, .. } if content == TOOL_RESULT_PLACEHOLDER && tool_use_id == "t1")
+        );
+        assert!(
+            matches!(&messages[0].content[1], ContentBlock::ToolResult { content, tool_use_id, .. } if content == TOOL_RESULT_PLACEHOLDER && tool_use_id == "t2")
+        );
+        assert!(
+            matches!(&messages[0].content[2], ContentBlock::ToolResult { content, tool_use_id, .. } if content == "keep 1" && tool_use_id == "t3")
+        );
+        assert!(
+            matches!(&messages[0].content[3], ContentBlock::ToolResult { content, tool_use_id, .. } if content == "keep 2" && tool_use_id == "t4")
+        );
+        assert!(
+            matches!(&messages[0].content[4], ContentBlock::ToolResult { content, tool_use_id, .. } if content == "keep 3" && tool_use_id == "t5")
+        );
+        assert!(
+            matches!(&messages[0].content[5], ContentBlock::Text { text } if text == "keep me")
+        );
     }
 }

--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -1,6 +1,8 @@
 use std::env;
 
-use maki_providers::{ContentBlock, Message, Model, RequestOptions, TokenUsage};
+use maki_providers::{
+    ContentBlock, Message, Model, RequestOptions, Role, StreamResponse, TokenUsage,
+};
 use tracing::info;
 
 use super::history::History;
@@ -26,25 +28,62 @@ pub(super) async fn compact_history(
     compaction_history.push(Message::user(crate::prompt::COMPACTION_USER.to_string()));
 
     let empty_tools = serde_json::json!([]);
-    let response = stream_with_retry(
-        provider,
-        model,
-        &compaction_history,
-        crate::prompt::COMPACTION_SYSTEM,
-        &empty_tools,
-        event_tx,
-        cancel,
-        RequestOptions::default(),
-        None,
-    )
-    .await?;
+    let max_attempts = 3;
+    let mut last_error = None;
 
-    event_tx.send(AgentEvent::TurnComplete(Box::new(TurnCompleteEvent {
+    for attempt in 0..max_attempts {
+        match stream_with_retry(
+            provider,
+            model,
+            &compaction_history,
+            crate::prompt::COMPACTION_SYSTEM,
+            &empty_tools,
+            event_tx,
+            cancel,
+            RequestOptions::default(),
+            None,
+        )
+        .await
+        {
+            Ok(response) => {
+                if attempt > 0 {
+                    info!(
+                        attempt,
+                        "compaction succeeded after truncating oldest rounds"
+                    );
+                }
+                return Ok(finish_compact(
+                    response,
+                    history,
+                    event_tx,
+                    compact_start,
+                    model,
+                ));
+            }
+            Err(e) if e.is_context_overflow() && attempt < max_attempts - 1 => {
+                last_error = Some(e);
+                truncate_oldest_round(&mut compaction_history);
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    Err(last_error.unwrap())
+}
+
+fn finish_compact(
+    response: StreamResponse,
+    history: &mut History,
+    event_tx: &EventSender,
+    compact_start: std::time::Instant,
+    model: &Model,
+) -> TokenUsage {
+    let _ = event_tx.send(AgentEvent::TurnComplete(Box::new(TurnCompleteEvent {
         message: response.message.clone(),
         usage: response.usage,
         model: model.id.clone(),
         context_size: Some(response.usage.output),
-    })))?;
+    })));
 
     let new_history = vec![
         Message::user("What did we do so far?".into()),
@@ -57,7 +96,7 @@ pub(super) async fn compact_history(
         "compaction completed"
     );
 
-    Ok(response.usage)
+    response.usage
 }
 
 pub async fn compact(
@@ -127,6 +166,47 @@ fn strip_old_tool_results(messages: &mut [Message]) {
                 seen += 1;
             }
         }
+    }
+}
+
+fn truncate_oldest_round(messages: &mut Vec<Message>) {
+    if messages.len() <= 1 {
+        return;
+    }
+
+    let mut remove_count = 1;
+
+    if matches!(messages.first().map(|m| &m.role), Some(Role::Assistant)) {
+        let has_tool_calls = messages[0].has_tool_calls();
+        if has_tool_calls {
+            let next_has_tool_results = messages.get(1).is_some_and(|m| {
+                matches!(m.role, Role::User)
+                    && m.content
+                        .iter()
+                        .any(|b| matches!(b, ContentBlock::ToolResult { .. }))
+            });
+            if next_has_tool_results {
+                remove_count = 2;
+            }
+        }
+    } else if matches!(messages.first().map(|m| &m.role), Some(Role::User))
+        && matches!(messages.get(1).map(|m| &m.role), Some(Role::Assistant))
+    {
+        // Dropping a lone user message would leave assistant-first, which some providers reject.
+        // Remove the assistant too to keep the conversation well-formed.
+        remove_count = 2;
+    }
+
+    messages.drain(..remove_count);
+
+    // After draining, the first message might still be an assistant (e.g. consecutive
+    // assistant messages). Keep draining until the first message is user or we're empty.
+    while messages.len() > 1 && matches!(messages.first().map(|m| &m.role), Some(Role::Assistant)) {
+        let mut drop = 1;
+        if matches!(messages.get(1).map(|m| &m.role), Some(Role::User)) {
+            drop = 2;
+        }
+        messages.drain(..drop);
     }
 }
 
@@ -366,5 +446,130 @@ mod tests {
         assert!(
             matches!(&messages[0].content[5], ContentBlock::Text { text } if text == "keep me")
         );
+    }
+
+    #[test]
+    fn truncate_oldest_round_removes_single_user_message() {
+        let mut messages = vec![
+            Message::user("first".into()),
+            Message::user("second".into()),
+        ];
+        truncate_oldest_round(&mut messages);
+        assert_eq!(messages.len(), 1);
+        assert!(matches!(&messages[0].content[0], ContentBlock::Text { text } if text == "second"));
+    }
+
+    #[test]
+    fn truncate_oldest_round_removes_assistant_tool_pair() {
+        let mut messages = vec![
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::ToolUse {
+                    id: "t1".into(),
+                    name: "bash".into(),
+                    input: serde_json::json!({}),
+                }],
+                ..Default::default()
+            },
+            Message {
+                role: Role::User,
+                content: vec![ContentBlock::ToolResult {
+                    tool_use_id: "t1".into(),
+                    content: "output".into(),
+                    is_error: false,
+                }],
+                ..Default::default()
+            },
+            Message::user("keep me".into()),
+        ];
+        truncate_oldest_round(&mut messages);
+        assert_eq!(messages.len(), 1);
+        assert!(
+            matches!(&messages[0].content[0], ContentBlock::Text { text } if text == "keep me")
+        );
+    }
+
+    #[test]
+    fn truncate_oldest_round_removes_assistant_without_matching_tool_result() {
+        let mut messages = vec![
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::ToolUse {
+                    id: "t1".into(),
+                    name: "bash".into(),
+                    input: serde_json::json!({}),
+                }],
+                ..Default::default()
+            },
+            Message::user("no tool result".into()),
+        ];
+        truncate_oldest_round(&mut messages);
+        assert_eq!(messages.len(), 1);
+        assert!(
+            matches!(&messages[0].content[0], ContentBlock::Text { text } if text == "no tool result")
+        );
+    }
+
+    #[test]
+    fn truncate_oldest_round_noop_on_single_message() {
+        let mut messages = vec![Message::user("only".into())];
+        truncate_oldest_round(&mut messages);
+        assert_eq!(messages.len(), 1);
+    }
+
+    #[test]
+    fn truncate_oldest_round_removes_plain_assistant() {
+        let mut messages = vec![
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::Text {
+                    text: "reply".into(),
+                }],
+                ..Default::default()
+            },
+            Message::user("keep me".into()),
+        ];
+        truncate_oldest_round(&mut messages);
+        assert_eq!(messages.len(), 1);
+        assert!(
+            matches!(&messages[0].content[0], ContentBlock::Text { text } if text == "keep me")
+        );
+    }
+
+    #[test]
+    fn truncate_oldest_round_consecutive_assistants_drains_until_user() {
+        // [User, Assistant(no tools), Assistant(tools), User(results)] drains 2,
+        // leaving Assistant-first — keep draining until first is User.
+        let mut messages = vec![
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::Text {
+                    text: "plain reply".into(),
+                }],
+                ..Default::default()
+            },
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::ToolUse {
+                    id: "t1".into(),
+                    name: "bash".into(),
+                    input: serde_json::json!({}),
+                }],
+                ..Default::default()
+            },
+            Message {
+                role: Role::User,
+                content: vec![ContentBlock::ToolResult {
+                    tool_use_id: "t1".into(),
+                    content: "output".into(),
+                    is_error: false,
+                }],
+                ..Default::default()
+            },
+            Message::user("keep me".into()),
+        ];
+        truncate_oldest_round(&mut messages);
+        assert!(!messages.is_empty());
+        assert!(matches!(messages[0].role, Role::User));
     }
 }

--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -118,7 +118,7 @@ pub async fn compact(
 }
 
 pub(super) fn is_overflow(usage: &TokenUsage, model: &Model, compaction_buffer: u32) -> bool {
-    let reserved = compaction_buffer.min(model.max_output_tokens);
+    let reserved = compaction_buffer.max(model.max_output_tokens);
     let usable = model.context_window.saturating_sub(reserved);
     usage.context_tokens() >= usable
 }
@@ -325,9 +325,9 @@ mod tests {
         });
     }
 
-    #[test_case(179_999, 0,       0,       0,      200_000, 20_000, false ; "below_threshold")]
-    #[test_case(180_000, 0,       0,       0,      200_000, 20_000, true  ; "at_threshold")]
-    #[test_case(190_000, 0,       0,       0,      200_000, 10_000, true  ; "small_max_output_uses_it_as_reserve")]
+    #[test_case(159_999, 0,       0,       0,      200_000, 20_000, false ; "below_threshold")]
+    #[test_case(160_000, 0,       0,       0,      200_000, 20_000, true  ; "at_threshold")]
+    #[test_case(190_000, 0,       0,       0,      200_000, 10_000, true  ; "large_buffer_takes_precedence_over_small_max_output")]
     #[test_case(100,     0,       0,       0,      100,     20_000, true  ; "tiny_context_window")]
     #[test_case(5_000,   165_000, 10_000,  0,      200_000, 20_000, true  ; "cached_tokens_count_toward_overflow")]
     #[test_case(100_000, 0,       0,       80_000, 200_000, 20_000, true  ; "output_tokens_count_toward_overflow")]

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use serde_json::Value;
 use tracing::{error, info, warn};
 
+use maki_providers::ContentBlock;
 use maki_providers::provider::Provider;
 use maki_providers::{Message, Model, RequestOptions, StopReason, StreamResponse, TokenUsage};
 
@@ -77,6 +78,7 @@ pub struct Agent<'h> {
     interrupt_source: Option<Arc<dyn InterruptSource>>,
     cancel: CancelToken,
     total_usage: TokenUsage,
+    context_size: u32,
     num_turns: u32,
     recent_calls: RecentCalls,
     auto_compact: bool,
@@ -92,7 +94,7 @@ pub struct Agent<'h> {
     timeouts: maki_providers::Timeouts,
     file_tracker: Arc<FileReadTracker>,
     prompt_slots: Arc<crate::prompt::ResolvedSlots>,
-    subagent_cancels: Arc<CancelMap<String>>,
+    subagent_cancels: Arc<crate::cancel::CancelMap<String>>,
 }
 
 impl<'h> Agent<'h> {
@@ -113,6 +115,7 @@ impl<'h> Agent<'h> {
             interrupt_source: None,
             cancel: CancelToken::none(),
             total_usage: TokenUsage::default(),
+            context_size: 0,
             num_turns: 0,
             recent_calls: RecentCalls::new(),
             auto_compact: compaction::auto_compact_enabled(),
@@ -248,9 +251,13 @@ impl<'h> Agent<'h> {
         self.emit_turn_complete(&response)?;
         let usage = response.usage;
         self.total_usage += usage;
+        self.context_size = usage.total_input();
 
         if has_tools {
+            let history_len_before = self.history.len();
             self.process_tool_calls(response).await?;
+            self.context_size +=
+                estimate_message_tokens(&self.history.as_slice()[history_len_before..]);
         } else {
             self.history.push(response.message);
 
@@ -265,7 +272,7 @@ impl<'h> Agent<'h> {
             }
         }
 
-        if self.try_auto_compact(&usage).await? || self.handle_queued_command().await? {
+        if self.try_auto_compact().await? || self.handle_queued_command().await? {
             return Ok(TurnOutcome::Continue);
         }
 
@@ -363,13 +370,20 @@ impl<'h> Agent<'h> {
         }
     }
 
-    async fn try_auto_compact(&mut self, usage: &TokenUsage) -> Result<bool, AgentError> {
+    async fn try_auto_compact(&mut self) -> Result<bool, AgentError> {
         if !self.auto_compact
-            || !compaction::is_overflow(usage, &self.model, self.config.compaction_buffer)
+            || !compaction::is_overflow(
+                &TokenUsage {
+                    input: self.context_size,
+                    ..Default::default()
+                },
+                &self.model,
+                self.config.compaction_buffer,
+            )
         {
             return Ok(false);
         }
-        info!(total_input = usage.total_input(), "auto-compacting");
+        info!(context_size = self.context_size, "auto-compacting");
         self.event_tx.send(AgentEvent::AutoCompacting)?;
         self.do_compact().await?;
         Ok(true)
@@ -421,6 +435,22 @@ impl<'h> Agent<'h> {
         }
         Ok(true)
     }
+}
+
+const CHARS_PER_TOKEN: usize = 4;
+
+fn estimate_message_tokens(messages: &[Message]) -> u32 {
+    let total_bytes: usize = messages
+        .iter()
+        .flat_map(|m| &m.content)
+        .filter_map(|b| match b {
+            ContentBlock::Text { text } => Some(text.len()),
+            ContentBlock::ToolResult { content, .. } => Some(content.len()),
+            ContentBlock::ToolUse { input, .. } => Some(input.to_string().len()),
+            _ => None,
+        })
+        .sum();
+    (total_bytes.max(CHARS_PER_TOKEN) / CHARS_PER_TOKEN) as u32
 }
 
 #[cfg(test)]
@@ -709,10 +739,10 @@ mod tests {
         });
     }
 
-    #[test_case(true,  900, true  ; "enabled_and_over_threshold")]
-    #[test_case(true,  100, false ; "enabled_but_below_threshold")]
-    #[test_case(false, 900, false ; "disabled_even_over_threshold")]
-    fn try_auto_compact_behavior(enabled: bool, total_input: u32, expected: bool) {
+    #[test_case(true,  170_000, true  ; "enabled_and_over_threshold")]
+    #[test_case(true,  150_000, false ; "enabled_but_below_threshold")]
+    #[test_case(false, 170_000, false ; "disabled_even_over_threshold")]
+    fn try_auto_compact_behavior(enabled: bool, context_size: u32, expected: bool) {
         smol::block_on(async {
             let responses = if expected {
                 vec![text_response(StopReason::EndTurn)]
@@ -721,14 +751,10 @@ mod tests {
             };
             let mut history = History::new(vec![Message::user("go".into())]);
             let (mut agent, event_rx) = make_agent(MockProvider::new(responses), &mut history);
-            agent.model = Arc::new(small_context_model(1000, 200));
+            agent.model = Arc::new(small_context_model(200_000, 8_192));
             agent.auto_compact = enabled;
-
-            let usage = TokenUsage {
-                input: total_input,
-                ..Default::default()
-            };
-            let result = agent.try_auto_compact(&usage).await.unwrap();
+            agent.context_size = context_size;
+            let result = agent.try_auto_compact().await.unwrap();
 
             assert_eq!(result, expected);
             drop(agent);

--- a/maki-providers/src/error.rs
+++ b/maki-providers/src/error.rs
@@ -30,6 +30,9 @@ pub enum AgentError {
 
 impl AgentError {
     pub fn is_retryable(&self) -> bool {
+        if self.is_context_overflow() {
+            return false;
+        }
         match self {
             Self::Api { status, .. } => *status == 429 || *status >= 500,
             Self::Io(_) | Self::Http(_) | Self::Timeout { .. } => true,
@@ -39,6 +42,43 @@ impl AgentError {
             | Self::Json(_)
             | Self::Cancelled
             | Self::HttpRequest(_) => false,
+        }
+    }
+
+    /// Returns true if the error indicates a context window overflow.
+    ///
+    /// Provider error formats:
+    /// - Anthropic:  413 "prompt is too long"  <https://docs.anthropic.com/en/docs/errors>
+    /// - OpenAI:     400 "maximum context length is X tokens"  <https://platform.openai.com/docs/guides/error-codes>
+    /// - Gemini:     400 "input token count exceeds" / "too many tokens"  <https://ai.google.dev/gemini-api/docs/troubleshooting>
+    /// - Ollama:     400 "context length exceeded"  <https://docs.ollama.com/api/errors>
+    /// - llama.cpp:  400 "exceeds the available context size"  <https://github.com/ggml-org/llama.cpp/blob/master/tools/server/server-context.cpp>
+    /// - Bedrock:    400 ValidationException "Input is too long for requested model"  <https://repost.aws/knowledge-center/bedrock-validation-exception-errors>
+    /// - DeepSeek:   400 "maximum context length is X tokens"  <https://api-docs.deepseek.com/quick_start/pricing>
+    /// - Mistral:    400 "too large for model with X maximum context length"  <https://docs.mistral.ai/resources/known-limitations>
+    /// - OpenRouter: 400 "endpoint's maximum context length is X tokens"  <https://openrouter.ai/docs/api/reference/errors-and-debugging.mdx>
+    /// - Synthetic:  400 pass-through from upstream models (OpenAI-compatible)  <https://synthetic.new>
+    pub fn is_context_overflow(&self) -> bool {
+        match self {
+            Self::Api { status: 413, .. } => true,
+            Self::Api {
+                status: 400,
+                message,
+                ..
+            } => {
+                let m = message.to_lowercase();
+                let is_scope = m.contains("context")
+                    || m.contains("token")
+                    || m.contains("prompt")
+                    || m.contains("input");
+                let is_overflow = m.contains("exceeds")
+                    || m.contains("exceeded")
+                    || m.contains("too long")
+                    || m.contains("too many")
+                    || m.contains("maximum");
+                is_scope && is_overflow
+            }
+            _ => false,
         }
     }
 
@@ -123,6 +163,13 @@ mod tests {
         }
     }
 
+    fn api_msg(status: u16, message: &str) -> AgentError {
+        AgentError::Api {
+            status,
+            message: message.into(),
+        }
+    }
+
     #[test_case(429, true  ; "rate_limit")]
     #[test_case(500, true  ; "server_error")]
     #[test_case(529, true  ; "overloaded")]
@@ -161,5 +208,47 @@ mod tests {
     #[test]
     fn timeout_is_retryable() {
         assert!(AgentError::Timeout { secs: 30 }.is_retryable());
+    }
+
+    // llama.cpp: https://github.com/ggml-org/llama.cpp/blob/master/tools/server/server-context.cpp
+    #[test_case(400, "request (268914 tokens) exceeds the available context size (262144 tokens)", true   ; "llama_cpp_overshoot")]
+    // OpenAI: https://platform.openai.com/docs/guides/error-codes
+    #[test_case(400, "Input exceeds context limit", true                                                 ; "openai_style")]
+    // OpenAI: https://platform.openai.com/docs/guides/error-codes
+    #[test_case(400, "This model's maximum context length is 8192 tokens. However, you requested 9850 tokens", true ; "openai_max_context")]
+    // Gemini: https://ai.google.dev/gemini-api/docs/troubleshooting
+    #[test_case(400, "The input token count exceeds the maximum number of tokens allowed", true           ; "gemini_exceeds")]
+    // Gemini: https://ai.google.dev/gemini-api/docs/troubleshooting
+    #[test_case(400, "Request contains too many tokens. Please reduce the input size.", true              ; "gemini_too_many")]
+    // Gemini: https://ai.google.dev/gemini-api/docs/troubleshooting
+    #[test_case(400, "Your input context is too long.", true                                              ; "gemini_500_input")]
+    // Ollama: https://docs.ollama.com/api/errors
+    #[test_case(400, "context length exceeded", true                                                      ; "ollama")]
+    // Anthropic: https://docs.anthropic.com/en/docs/errors
+    #[test_case(413, "prompt is too long", true                                                           ; "anthropic_413")]
+    // HTTP 413: https://www.rfc-editor.org/rfc/rfc9110.html#name-413-content-too-large
+    #[test_case(413, "Payload too large", true                                                            ; "generic_413")]
+    // DeepSeek: https://api-docs.deepseek.com/quick_start/pricing
+    #[test_case(400, "This model's maximum context length is 131072 tokens. However, you requested 168754 tokens", true ; "deepseek")]
+    // Mistral: https://docs.mistral.ai/resources/known-limitations
+    #[test_case(400, "Prompt contains 321774 tokens and 0 draft tokens, too large for model with 262144 maximum context length", true ; "mistral")]
+    // OpenRouter: https://openrouter.ai/docs/api/reference/errors-and-debugging.mdx
+    #[test_case(400, "This endpoint's maximum context length is 200000 tokens. However, you requested about 5028244 tokens", true ; "openrouter")]
+    // Bedrock: https://repost.aws/knowledge-center/bedrock-validation-exception-errors
+    #[test_case(400, "Input is too long for requested model.", true                                                          ; "bedrock")]
+    #[test_case(400, "Input is too long for the model", true                                              ; "too_long_input")]
+    #[test_case(400, "Rate limit exceeded", false                                                         ; "not_context")]
+    #[test_case(400, "Invalid API key", false                                                             ; "auth_error")]
+    #[test_case(500, "Internal server error", false                                                       ; "server_error")]
+    #[test_case(400, "The output is too long", false                                                      ; "output_not_context")]
+    fn is_context_overflow(status: u16, message: &str, expected: bool) {
+        assert_eq!(api_msg(status, message).is_context_overflow(), expected);
+    }
+
+    #[test]
+    fn context_overflow_is_not_retryable() {
+        let err = api_msg(400, "request exceeds the available context size");
+        assert!(err.is_context_overflow());
+        assert!(!err.is_retryable());
     }
 }


### PR DESCRIPTION
Fixes #301                                                                                                                                            
                                                                                                                                                      
When a large tool call fills the context above the model's limit, compaction itself fails because the request is already too large. This implements the two-step fix discussed in the issue:                                                                                                              
                                                                                                                                                      
1. Strip old tool results before compaction: Replace the content of ToolResult blocks with a placeholder ([tool result]) before building the          
compaction request, following the same pattern as the existing strip_images and strip_thinking.                                                       
                                                                                                                                                      
2. Truncate retry: If the compaction request still fails with a context overflow error, remove the oldest message rounds (assistant+tool-result pairs 
or standalone messages) from the history and retry, up to 3 total attempts.                                                                           
                                                                                                                                                      
Both approaches are used by Claude Code and opencode.                                                                       

Made with Qwen3.6 27B + maki