### PR TITLE
feat: configurable compaction model via 'Compaction' model tier

### DIFF
--- a/maki-agent/src/agent/mod.rs
+++ b/maki-agent/src/agent/mod.rs
@@ -11,4 +11,4 @@ pub use instructions::{
     Instructions, LoadedInstructions, build_system_prompt, find_subdirectory_instructions,
     is_instruction_file, load_instruction_text, load_instructions,
 };
-pub use run::{Agent, AgentParams, AgentRunParams};
+pub use run::{Agent, AgentParams, AgentRunParams, resolve_compaction_model};

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -23,6 +23,23 @@ use maki_config::ToolOutputLines;
 
 const MAX_REAUTH_ATTEMPTS: u32 = 2;
 
+pub fn resolve_compaction_model(
+    provider: &Arc<dyn Provider>,
+    model: &Model,
+    timeouts: maki_providers::Timeouts,
+) -> (Arc<dyn Provider>, Model) {
+    if let Some(spec) = maki_providers::model_registry::model_registry()
+        .read()
+        .unwrap()
+        .spec_for_tier_any(maki_providers::ModelTier::Compaction)
+        && let Ok(m) = Model::from_spec(&spec)
+        && let Ok(p) = maki_providers::provider::from_model(&m, timeouts)
+    {
+        return (Arc::from(p), m);
+    }
+    (Arc::clone(provider), model.clone())
+}
+
 enum TurnOutcome {
     Continue,
     Done(Option<StopReason>),
@@ -359,9 +376,11 @@ impl<'h> Agent<'h> {
     }
 
     async fn do_compact(&mut self) -> Result<(), AgentError> {
+        let (compact_provider, compact_model) =
+            resolve_compaction_model(&self.provider, &self.model, self.timeouts);
         self.total_usage += compaction::compact_history(
-            &*self.provider,
-            &self.model,
+            &*compact_provider,
+            &compact_model,
             self.history,
             &self.event_tx,
             &self.cancel,

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -10,7 +10,7 @@ weight = 5
 group = "Reference"
 +++"#;
 
-const TIER_PICKER_NOTE: &str = r#"Open the model picker with `/model` and press `1`, `2`, or `3` on any row to reassign it to strong, medium, or weak. Your overrides are saved to `~/.local/state/maki/model-tiers` and apply across sessions."#;
+const TIER_PICKER_NOTE: &str = r#"Open the model picker with `/model` and press `1`, `2`, `3`, or `4` on any row to assign it to strong, medium, weak, or compaction. Press the same key again to remove the assignment. Your overrides are saved to `~/.local/state/maki/model-tiers` and apply across sessions."#;
 
 const AUTH_RELOADING: &str = r#"## Auth Reloading
 
@@ -93,6 +93,7 @@ fn tier_label(tier: ModelTier) -> &'static str {
         ModelTier::Weak => "Weak",
         ModelTier::Medium => "Medium",
         ModelTier::Strong => "Strong",
+        ModelTier::Compaction => "Compaction",
     }
 }
 
@@ -310,7 +311,8 @@ pub fn generate() -> String {
         out,
         "Maki talks to LLM providers over their HTTP APIs. \
          Models are split into three tiers: **weak** (cheap and fast), \
-         **medium** (balanced), and **strong** (highest capability, highest cost).\n"
+         **medium** (balanced), and **strong** (highest capability, highest cost). \
+         There is also a **compaction** tier for choosing a dedicated model to summarize context when the conversation grows long.\n"
     );
     let _ = writeln!(out, "{TIER_PICKER_NOTE}\n");
     let _ = writeln!(out, "{AUTH_RELOADING}\n");

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -104,6 +104,7 @@ pub enum ModelTier {
     Weak,
     Medium,
     Strong,
+    Compaction,
 }
 
 impl fmt::Display for ModelTier {
@@ -112,6 +113,7 @@ impl fmt::Display for ModelTier {
             Self::Weak => "weak",
             Self::Medium => "medium",
             Self::Strong => "strong",
+            Self::Compaction => "compaction",
         })
     }
 }
@@ -124,6 +126,7 @@ impl FromStr for ModelTier {
             "weak" => Ok(Self::Weak),
             "medium" => Ok(Self::Medium),
             "strong" => Ok(Self::Strong),
+            "compaction" => Ok(Self::Compaction),
             other => Err(ModelError::InvalidTier(other.to_string())),
         }
     }
@@ -373,7 +376,12 @@ mod tests {
     use strum::IntoEnumIterator;
     use test_case::test_case;
 
-    const TIERS: [ModelTier; 3] = [ModelTier::Weak, ModelTier::Medium, ModelTier::Strong];
+    const TIERS: [ModelTier; 4] = [
+        ModelTier::Weak,
+        ModelTier::Medium,
+        ModelTier::Strong,
+        ModelTier::Compaction,
+    ];
 
     #[test_case("no-slash-here", ModelError::InvalidFormat ; "invalid_format")]
     #[test_case("foobar/gpt-4", ModelError::UnsupportedProvider("foobar".into()) ; "unsupported_provider")]
@@ -499,6 +507,10 @@ mod tests {
                 if provider == ProviderKind::DeepSeek && tier == ModelTier::Weak {
                     continue;
                 }
+                // Compaction is user-assigned only, not in static registry
+                if tier == ModelTier::Compaction {
+                    continue;
+                }
                 let model = Model::from_tier(provider, tier).unwrap();
                 assert_eq!(model.provider, provider);
                 assert_eq!(model.tier, tier);
@@ -529,6 +541,10 @@ mod tests {
             let entries = models_for_provider(provider);
             for &tier in &TIERS {
                 if provider == ProviderKind::DeepSeek && tier == ModelTier::Weak {
+                    continue;
+                }
+                // Compaction is user-assigned only, not in static registry
+                if tier == ModelTier::Compaction {
                     continue;
                 }
                 let count = entries

--- a/maki-providers/src/model_registry.rs
+++ b/maki-providers/src/model_registry.rs
@@ -128,6 +128,7 @@ impl ModelRegistry {
             ModelTier::Strong => 0,
             ModelTier::Medium => 1,
             ModelTier::Weak => 2,
+            ModelTier::Compaction => return None,
         };
         let idx = slot.min(models.len() - 1);
         let spec = format!("{provider}/{}", models[idx].id);

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -151,7 +151,9 @@ impl AgentLoop {
 
     async fn do_compact(&mut self, event_tx: &EventSender) -> Result<(), AgentError> {
         let slot = self.model_slot.load();
-        agent::compact(&*slot.provider, &slot.model, &mut self.history, event_tx).await
+        let (provider, model) =
+            agent::resolve_compaction_model(&slot.provider, &slot.model, self.timeouts);
+        agent::compact(&*provider, &model, &mut self.history, event_tx).await
     }
 
     async fn do_agent_run(

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -533,8 +533,8 @@ pub const KEYBINDS: &[Keybind] = &[
         platform: Platform::All,
     },
     Keybind {
-        label: KeyLabel::Single("1/2/3"),
-        description: "Set tier (strong/medium/weak)",
+        label: KeyLabel::Single("1/2/3/4"),
+        description: "Set tier (strong/medium/weak/compaction)",
         context: KeybindContext::ModelPicker,
         platform: Platform::All,
     },

--- a/maki-ui/src/components/model_picker.rs
+++ b/maki-ui/src/components/model_picker.rs
@@ -28,21 +28,25 @@ fn footer_line() -> Line<'static> {
         Span::styled(" medium", t.tool_dim),
         Span::styled("  3", t.keybind_key),
         Span::styled(" weak", t.tool_dim),
+        Span::styled("  4", t.keybind_key),
+        Span::styled(" compaction", t.tool_dim),
     ])
 }
 
 fn tier_for_shortcut(key: KeyEvent) -> Option<ModelTier> {
     let digit = match key.code {
-        KeyCode::Char(c @ '1'..='3') => c,
+        KeyCode::Char(c @ '1'..='4') => c,
         KeyCode::Char('¡') => '1',
         KeyCode::Char('™') => '2',
         KeyCode::Char('£') => '3',
+        KeyCode::Char('$') | KeyCode::Char('€') => '4',
         _ => return None,
     };
     match digit {
         '1' => Some(ModelTier::Strong),
         '2' => Some(ModelTier::Medium),
         '3' => Some(ModelTier::Weak),
+        '4' => Some(ModelTier::Compaction),
         _ => None,
     }
 }
@@ -201,10 +205,15 @@ fn parse_model_entry(spec: &str) -> Option<ModelEntry> {
     };
 
     let map = model_registry::model_registry().read().unwrap();
-    let override_tiers: Vec<ModelTier> = [ModelTier::Strong, ModelTier::Medium, ModelTier::Weak]
-        .into_iter()
-        .filter(|&t| map.has_override(spec, t))
-        .collect();
+    let override_tiers: Vec<ModelTier> = [
+        ModelTier::Strong,
+        ModelTier::Medium,
+        ModelTier::Weak,
+        ModelTier::Compaction,
+    ]
+    .into_iter()
+    .filter(|&t| map.has_override(spec, t))
+    .collect();
     let override_label = map.override_tier_label(spec);
     drop(map);
     let tier = override_label.unwrap_or_else(|| match maki_providers::Model::from_spec(spec) {
@@ -337,15 +346,18 @@ mod tests {
         assert!(parse_model_entry("no-slash").is_none());
     }
 
-    #[test_case(key(KeyCode::Char('1')),           ModelTier::Strong ; "bare_1_strong")]
-    #[test_case(key(KeyCode::Char('2')),           ModelTier::Medium ; "bare_2_medium")]
-    #[test_case(key(KeyCode::Char('3')),           ModelTier::Weak   ; "bare_3_weak")]
-    #[test_case(alt_key(KeyCode::Char('1')),       ModelTier::Strong ; "alt_1_strong")]
-    #[test_case(alt_key(KeyCode::Char('2')),       ModelTier::Medium ; "alt_2_medium")]
-    #[test_case(alt_key(KeyCode::Char('3')),       ModelTier::Weak   ; "alt_3_weak")]
-    #[test_case(key(KeyCode::Char('\u{00A1}')),    ModelTier::Strong ; "macos_opt_1_strong")]
-    #[test_case(key(KeyCode::Char('\u{2122}')),    ModelTier::Medium ; "macos_opt_2_medium")]
-    #[test_case(key(KeyCode::Char('\u{00A3}')),    ModelTier::Weak   ; "macos_opt_3_weak")]
+    #[test_case(key(KeyCode::Char('1')),           ModelTier::Strong     ; "bare_1_strong")]
+    #[test_case(key(KeyCode::Char('2')),           ModelTier::Medium     ; "bare_2_medium")]
+    #[test_case(key(KeyCode::Char('3')),           ModelTier::Weak       ; "bare_3_weak")]
+    #[test_case(key(KeyCode::Char('4')),           ModelTier::Compaction ; "bare_4_compaction")]
+    #[test_case(alt_key(KeyCode::Char('1')),       ModelTier::Strong     ; "alt_1_strong")]
+    #[test_case(alt_key(KeyCode::Char('2')),       ModelTier::Medium     ; "alt_2_medium")]
+    #[test_case(alt_key(KeyCode::Char('3')),       ModelTier::Weak       ; "alt_3_weak")]
+    #[test_case(key(KeyCode::Char('\u{00A1}')),    ModelTier::Strong     ; "macos_opt_1_strong")]
+    #[test_case(key(KeyCode::Char('\u{2122}')),    ModelTier::Medium     ; "macos_opt_2_medium")]
+    #[test_case(key(KeyCode::Char('\u{00A3}')),    ModelTier::Weak       ; "macos_opt_3_weak")]
+    #[test_case(key(KeyCode::Char('$')),           ModelTier::Compaction ; "dollar_compaction")]
+    #[test_case(key(KeyCode::Char('€')),           ModelTier::Compaction ; "euro_compaction")]
     fn tier_shortcut_assigns_and_keeps_picker_open(k: KeyEvent, want: ModelTier) {
         let mut p = ModelPicker::new(test_models());
         p.open("");

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -82,7 +82,7 @@ Some pickers add extra bindings on top of the defaults:
 | Session Picker | `Ctrl+D` | Delete session |
 | Queue | `Enter` | Remove item |
 | Commands | `Tab` | Complete command |
-| Model Picker | `1/2/3` | Set tier (strong/medium/weak) |
+| Model Picker | `1/2/3/4` | Set tier (strong/medium/weak/compaction) |
 
 ## Context Inheritance
 

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -7,9 +7,9 @@ group = "Reference"
 
 # Providers
 
-Maki talks to LLM providers over their HTTP APIs. Models are split into three tiers: **weak** (cheap and fast), **medium** (balanced), and **strong** (highest capability, highest cost).
+Maki talks to LLM providers over their HTTP APIs. Models are split into three tiers: **weak** (cheap and fast), **medium** (balanced), and **strong** (highest capability, highest cost). There is also a **compaction** tier for choosing a dedicated model to summarize context when the conversation grows long.
 
-Open the model picker with `/model` and press `1`, `2`, or `3` on any row to reassign it to strong, medium, or weak. Your overrides are saved to `~/.local/state/maki/model-tiers` and apply across sessions.
+Open the model picker with `/model` and press `1`, `2`, `3`, or `4` on any row to assign it to strong, medium, weak, or compaction. Press the same key again to remove the assignment. Your overrides are saved to `~/.local/state/maki/model-tiers` and apply across sessions.
 
 ## Auth Reloading
 


### PR DESCRIPTION
Allow switching to a different model for compaction (eg. a model with faster execution or larger context, cloud or local).

When unset, compaction uses the current model (existing behavior).

addresses issue #320 