### PR TITLE
providers: Don't set max-tokens field for llama.cpp

### DIFF
--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -163,7 +163,7 @@ impl ProviderKind {
             Self::Google => 65_536,
             Self::Copilot => 100_000,
             Self::Ollama => 16_384,
-            Self::LlamaCpp => 16_384,
+            Self::LlamaCpp => 0,
             Self::Mistral => 32_000,
             Self::Zai | Self::ZaiCodingPlan => 16_000,
             Self::DeepSeek => 384_000,

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -59,8 +59,10 @@ impl OpenAiCompatProvider {
             "model": model.id,
             "messages": wire_messages,
             "stream": true,
-            self.config.max_tokens_field: model.max_output_tokens,
         });
+        if model.max_output_tokens != 0 {
+            body[self.config.max_tokens_field] = json!(model.max_output_tokens);
+        }
         if self.config.include_stream_usage {
             body["stream_options"] = json!({"include_usage": true});
         }


### PR DESCRIPTION
Usually you would set this in your model configuration per model.