### PR TITLE
fix: sanitize restored session history before sending to API

### DIFF
--- a/maki-agent/src/agent/history.rs
+++ b/maki-agent/src/agent/history.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use maki_providers::{ContentBlock, Message, Role};
+use tracing::warn;
 
 const CANCEL_MARKER: &str = "[Cancelled by user]";
 const UNAVAILABLE_RESULT: &str = "[Tool result not available]";
@@ -15,6 +16,14 @@ pub struct History {
 
 impl History {
     pub fn new(messages: Vec<Message>) -> Self {
+        Self {
+            messages,
+            mirror: None,
+        }
+    }
+
+    pub fn restored(mut messages: Vec<Message>) -> Self {
+        sanitize_restored(&mut messages);
         Self {
             messages,
             mirror: None,
@@ -65,6 +74,51 @@ impl History {
         let mut snapshot = self.messages.clone();
         close_dangling_tool_calls(&mut snapshot, UNAVAILABLE_RESULT);
         mirror.store(Arc::new(snapshot));
+    }
+}
+
+/// Restored sessions can have orphaned tool_results or unclosed tool_uses
+/// (e.g. the process was killed mid-turn). The API returns 400 if it sees those.
+fn sanitize_restored(messages: &mut Vec<Message>) {
+    let len_before = messages.len();
+    let mut i = 0;
+    while i < messages.len() {
+        if !matches!(messages[i].role, Role::User) {
+            i += 1;
+            continue;
+        }
+
+        let valid_ids: Vec<String> = if i > 0 && matches!(messages[i - 1].role, Role::Assistant) {
+            messages[i - 1]
+                .tool_uses()
+                .map(|(id, _, _)| id.to_owned())
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        messages[i].content.retain(|b| match b {
+            ContentBlock::ToolResult { tool_use_id, .. } => {
+                valid_ids.iter().any(|id| id == tool_use_id)
+            }
+            _ => true,
+        });
+
+        if messages[i].content.is_empty() {
+            messages.remove(i);
+        } else {
+            i += 1;
+        }
+    }
+
+    close_dangling_tool_calls(messages, UNAVAILABLE_RESULT);
+
+    if messages.len() != len_before {
+        warn!(
+            before = len_before,
+            after = messages.len(),
+            "sanitized restored history"
+        );
     }
 }
 
@@ -124,6 +178,21 @@ mod tests {
                 })
                 .collect(),
             ..Default::default()
+        }
+    }
+
+    fn make_tool_result_msg(ids: &[&str]) -> Message {
+        Message {
+            role: Role::User,
+            content: ids
+                .iter()
+                .map(|id| ContentBlock::ToolResult {
+                    tool_use_id: id.to_string(),
+                    content: "ok".into(),
+                    is_error: false,
+                })
+                .collect(),
+            display_text: Some(String::new()),
         }
     }
 
@@ -290,5 +359,64 @@ mod tests {
             b,
             ContentBlock::ToolResult { content, is_error: true, .. } if content == CANCEL_MARKER
         )));
+    }
+
+    fn text_msg(role: Role, text: &str) -> Message {
+        Message {
+            role,
+            content: vec![ContentBlock::Text { text: text.into() }],
+            ..Default::default()
+        }
+    }
+
+    #[test_case(
+        vec![make_tool_result_msg(&["t1"])],
+        0
+        ; "orphan_at_start_removed"
+    )]
+    #[test_case(
+        vec![
+            Message::user("go".into()),
+            text_msg(Role::Assistant, "done"),
+            make_tool_result_msg(&["orphan1", "orphan2"]),
+        ],
+        2
+        ; "orphans_after_non_tool_assistant_removed"
+    )]
+    #[test_case(
+        vec![
+            Message::user("go".into()),
+            make_tool_use_msg(&["t1", "t2"]),
+            make_tool_result_msg(&["t1", "t2"]),
+        ],
+        3
+        ; "valid_pairing_preserved"
+    )]
+    #[test_case(
+        vec![Message::user("go".into()), make_tool_use_msg(&["t1"])],
+        3
+        ; "dangling_tool_use_closed_with_synthetic_result"
+    )]
+    fn sanitize_restored_cases(messages: Vec<Message>, expected_len: usize) {
+        let history = History::restored(messages);
+        assert_eq!(history.len(), expected_len);
+    }
+
+    #[test]
+    fn sanitize_restored_partial_orphan_keeps_matched_ids() {
+        let history = History::restored(vec![
+            Message::user("go".into()),
+            make_tool_use_msg(&["t1"]),
+            make_tool_result_msg(&["t1", "t2"]),
+        ]);
+        let results: Vec<&str> = history.as_slice()[2]
+            .content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::ToolResult { tool_use_id, .. } => Some(tool_use_id.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(results, ["t1"]);
     }
 }

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -307,7 +307,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                 };
 
             let mut store = SessionStore::open(&session_id, &working_dir, &model.spec());
-            let mut history = History::new(params.initial_history);
+            let mut history = History::restored(params.initial_history);
             let mut run_id: u64 = 0;
 
             while let Ok(input) = input_rx.recv_async().await {

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -73,7 +73,7 @@ impl AgentLoop {
             instructions: Instructions::default(),
             tools: Value::Null,
             mcp_handle,
-            history: History::new(initial_history).with_mirror(shared_history),
+            history: History::restored(initial_history).with_mirror(shared_history),
             btw_system,
             cancel_map,
             init_cancel,


### PR DESCRIPTION
After restoring a session, the Anthropic API sometimes rejected the conversation with a 400 about an `unexpected tool_use_id in tool_result blocks`. This happens when a stored session has orphaned `tool_result` blocks whose matching `tool_use` got lost (crash mid-tool-execution, compaction, or a cancel that saved via the mirror snapshot).

`History::restored()` now runs `sanitize_restored` on load: it walks every user message, checks each `tool_result` against the preceding assistant message's `tool_use` ids, strips orphans, drops empty messages, and closes any dangling `tool_use` at the end. A warning is logged when anything gets patched up.