### PR TITLE
refactor(providers): unify model metadata tracking into ModelRegistry

### DIFF
--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -157,7 +157,7 @@ mod tests {
             })
         }
 
-        fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+        fn list_models(&self) -> BoxFuture<'_, Result<Vec<maki_providers::ModelInfo>, AgentError>> {
             Box::pin(async { unimplemented!() })
         }
     }

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -465,7 +465,7 @@ mod tests {
             })
         }
 
-        fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+        fn list_models(&self) -> BoxFuture<'_, Result<Vec<maki_providers::ModelInfo>, AgentError>> {
             Box::pin(async { unimplemented!() })
         }
     }
@@ -738,7 +738,10 @@ mod tests {
                         unreachable!()
                     })
                 }
-                fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+                fn list_models(
+                    &self,
+                ) -> BoxFuture<'_, Result<Vec<maki_providers::ModelInfo>, AgentError>>
+                {
                     Box::pin(async { unimplemented!() })
                 }
             }

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -573,7 +573,9 @@ impl Provider for NullProvider {
         Box::pin(async { unimplemented!() })
     }
 
-    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, crate::AgentError>> {
+    fn list_models(
+        &self,
+    ) -> BoxFuture<'_, Result<Vec<maki_providers::ModelInfo>, crate::AgentError>> {
         Box::pin(async { unimplemented!() })
     }
 }

--- a/maki-agent/src/tools/task.rs
+++ b/maki-agent/src/tools/task.rs
@@ -67,7 +67,9 @@ impl Task {
                 (Model::clone(&ctx.model), Arc::clone(&ctx.provider))
             } else {
                 let resolved_model = {
-                    let map = maki_providers::tier_map::tier_map().read().unwrap();
+                    let map = maki_providers::model_registry::model_registry()
+                        .read()
+                        .unwrap();
                     map.spec_for_tier(ctx.model.provider, effective)
                         .or_else(|| map.spec_for_tier_any(effective))
                         .and_then(|spec| Model::from_spec(&spec).ok())

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -1,15 +1,15 @@
 pub(crate) mod error;
 pub mod model;
+pub mod model_registry;
 pub mod provider;
 pub(crate) mod providers;
 pub mod retry;
-pub mod tier_map;
 pub(crate) mod types;
 
 pub use error::AgentError;
 pub use model::{
-    FastPricing, Model, ModelEntry, ModelError, ModelFamily, ModelPricing, ModelTier, TokenUsage,
-    models_for_provider,
+    FastPricing, Model, ModelEntry, ModelError, ModelFamily, ModelInfo, ModelPricing, ModelTier,
+    TokenUsage, models_for_provider,
 };
 pub use providers::Timeouts;
 pub use providers::copilot::auth as copilot_auth;

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -44,6 +44,27 @@ pub struct ModelPricing {
     pub fast: Option<FastPricing>,
 }
 
+/// Metadata discovered at runtime from a provider's `/models` endpoint.
+/// All fields optional -- most providers only return an ID.
+#[derive(Debug, Clone)]
+pub struct ModelInfo {
+    pub id: String,
+    pub context_window: Option<u32>,
+    pub max_output_tokens: Option<u32>,
+    pub pricing: Option<ModelPricing>,
+}
+
+impl ModelInfo {
+    pub fn id_only(id: String) -> Self {
+        Self {
+            id,
+            context_window: None,
+            max_output_tokens: None,
+            pricing: None,
+        }
+    }
+}
+
 /// Cache rates are missing on purpose: Anthropic derives them from `input` with
 /// the same multipliers it uses for standard pricing, so storing them would just
 /// invite the two copies to drift apart.
@@ -175,11 +196,10 @@ impl Model {
             Some(slug) => format!("{slug}/{model_id}"),
             None => format!("{provider}/{model_id}"),
         };
-        let tier = crate::tier_map::tier_map().read().unwrap().tier_for(
-            &spec,
-            provider,
-            static_entry.map(|e| e.tier),
-        );
+        let tier = crate::model_registry::model_registry()
+            .read()
+            .unwrap()
+            .tier_for(&spec, provider, static_entry.map(|e| e.tier));
         let (family, pricing, max_output_tokens, context_window) = match static_entry {
             Some(e) => (
                 e.family,
@@ -187,12 +207,22 @@ impl Model {
                 e.max_output_tokens,
                 anthropic::shared::long_context_window(model_id).unwrap_or(e.context_window),
             ),
-            None => (
-                provider.family(),
-                ModelPricing::ZERO,
-                provider.fallback_max_output(),
-                provider.fallback_context_window(),
-            ),
+            None => {
+                let guard = crate::model_registry::model_registry().read().unwrap();
+                let discovered = guard.discovered(provider, model_id);
+                (
+                    provider.family(),
+                    discovered
+                        .and_then(|d| d.pricing.clone())
+                        .unwrap_or_default(),
+                    discovered
+                        .and_then(|d| d.max_output_tokens)
+                        .unwrap_or_else(|| provider.fallback_max_output()),
+                    discovered
+                        .and_then(|d| d.context_window)
+                        .unwrap_or_else(|| provider.fallback_context_window()),
+                )
+            }
         };
         Self {
             id: model_id.to_string(),
@@ -229,7 +259,7 @@ impl Model {
     }
 
     pub fn from_tier(provider: ProviderKind, tier: ModelTier) -> Result<Self, ModelError> {
-        if let Some(spec) = crate::tier_map::tier_map()
+        if let Some(spec) = crate::model_registry::model_registry()
             .read()
             .unwrap()
             .spec_for_tier(provider, tier)
@@ -575,5 +605,36 @@ mod tests {
             output: 150.0,
         });
         assert!(!model.supports_fast());
+    }
+
+    #[test]
+    fn discovered_context_window_flows_into_from_base_for_unknown_model() {
+        use crate::model::ModelInfo;
+        use crate::model_registry::model_registry;
+
+        let provider = ProviderKind::Ollama;
+        let model_id = "test-discovered-context-window-model";
+        let expected_window: u32 = 131_072;
+
+        // Seed discovered metadata into the global registry
+        {
+            let mut reg = model_registry().write().unwrap();
+            reg.set_known_models(
+                provider,
+                vec![ModelInfo {
+                    id: model_id.to_string(),
+                    context_window: Some(expected_window),
+                    max_output_tokens: None,
+                    pricing: None,
+                }],
+            );
+        }
+
+        // from_base for this unknown model should pick up the discovered context_window
+        let model = Model::from_base(provider, model_id, None);
+        assert_eq!(model.id, model_id);
+        assert_eq!(model.context_window, expected_window);
+        // max_output_tokens falls back to provider default since not discovered
+        assert_eq!(model.max_output_tokens, provider.fallback_max_output());
     }
 }

--- a/maki-providers/src/model_registry.rs
+++ b/maki-providers/src/model_registry.rs
@@ -3,6 +3,13 @@
 //! Three layers, checked in order: user overrides (persisted, one model per
 //! tier) > static entries from the provider registry > auto-assignment by
 //! position in `list_models()`.
+//!
+//! Discovered metadata (context windows, pricing) from `/models` endpoints is
+//! stored in `known_models` and consulted by [`crate::model::Model::from_base`].
+//!
+//! All reads and writes go through [`model_registry`]. The module owns
+//! persistence: [`load_from_storage`] at startup, [`set_and_persist`] on user
+//! edits. Callers never touch the on-disk format directly.
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
@@ -11,56 +18,58 @@ use std::sync::{OnceLock, RwLock};
 use maki_storage::{StateDir, atomic_write};
 use tracing::warn;
 
-use crate::model::ModelTier;
+use crate::model::{ModelInfo, ModelTier};
 use crate::provider::ProviderKind;
 
 const TIERS_FILE: &str = "model-tiers";
 
-static TIERS: OnceLock<RwLock<TierMap>> = OnceLock::new();
+static REGISTRY: OnceLock<RwLock<ModelRegistry>> = OnceLock::new();
 
-pub fn tier_map() -> &'static RwLock<TierMap> {
-    TIERS.get_or_init(|| RwLock::new(TierMap::default()))
+pub fn model_registry() -> &'static RwLock<ModelRegistry> {
+    REGISTRY.get_or_init(|| RwLock::new(ModelRegistry::default()))
 }
 
 pub fn load_from_storage(dir: &StateDir) {
     let overrides = read_overrides(dir.path().join(TIERS_FILE).as_path());
-    tier_map().write().unwrap().set_overrides(overrides);
+    model_registry().write().unwrap().set_overrides(overrides);
 }
 
 pub fn set_and_persist(spec: String, tier: ModelTier, dir: &StateDir) {
     let snapshot = {
-        let mut map = tier_map().write().unwrap();
-        map.set(spec, tier);
-        map.overrides.clone()
+        let mut reg = model_registry().write().unwrap();
+        reg.set(spec, tier);
+        reg.overrides.clone()
     };
     write_overrides(dir.path().join(TIERS_FILE).as_path(), &snapshot);
 }
 
 pub fn unset_and_persist(spec: &str, tier: ModelTier, dir: &StateDir) {
     let snapshot = {
-        let mut map = tier_map().write().unwrap();
-        map.unset(spec, tier);
-        map.overrides.clone()
+        let mut reg = model_registry().write().unwrap();
+        reg.unset(spec, tier);
+        reg.overrides.clone()
     };
     write_overrides(dir.path().join(TIERS_FILE).as_path(), &snapshot);
 }
 
 #[derive(Debug, Default)]
-pub struct TierMap {
+pub struct ModelRegistry {
     /// Keyed by tier (not spec) so inserting a model automatically evicts the
     /// previous holder. Persisted to disk.
     overrides: BTreeMap<ModelTier, String>,
-    /// Rebuilt every session from `list_models()`. Position 0 = strong, etc.
-    known_models: HashMap<ProviderKind, Vec<String>>,
+    /// Ordered model info per provider, populated from `list_models()`.
+    /// Not persisted - rebuilt every session. Used for auto-tier assignment
+    /// and discovered metadata lookup.
+    known_models: HashMap<ProviderKind, Vec<ModelInfo>>,
 }
 
-impl TierMap {
+impl ModelRegistry {
     pub fn set_overrides(&mut self, overrides: BTreeMap<ModelTier, String>) {
         self.overrides = overrides;
     }
 
-    pub fn set_known_models(&mut self, provider: ProviderKind, ids: Vec<String>) {
-        self.known_models.insert(provider, ids);
+    pub fn set_known_models(&mut self, provider: ProviderKind, models: Vec<ModelInfo>) {
+        self.known_models.insert(provider, models);
     }
 
     pub fn set(&mut self, spec: String, tier: ModelTier) {
@@ -77,6 +86,14 @@ impl TierMap {
         self.overrides.get(&tier).map(String::as_str) == Some(spec)
     }
 
+    /// Lookup discovered metadata for a model by ID.
+    pub fn discovered(&self, provider: ProviderKind, model_id: &str) -> Option<&ModelInfo> {
+        self.known_models
+            .get(&provider)?
+            .iter()
+            .find(|m| m.id == model_id)
+    }
+
     pub fn tier_for(
         &self,
         spec: &str,
@@ -91,7 +108,7 @@ impl TierMap {
         }
         if let Some((_, model_id)) = spec.split_once('/')
             && let Some(models) = self.known_models.get(&provider)
-            && let Some(pos) = models.iter().position(|id| id == model_id)
+            && let Some(pos) = models.iter().position(|m| m.id == model_id)
         {
             return tier_for_position(pos);
         }
@@ -113,7 +130,7 @@ impl TierMap {
             ModelTier::Weak => 2,
         };
         let idx = slot.min(models.len() - 1);
-        let spec = format!("{provider}/{}", models[idx]);
+        let spec = format!("{provider}/{}", models[idx].id);
 
         let overridden_elsewhere = self.overrides.iter().any(|(&t, s)| s == &spec && t != tier);
         (!overridden_elsewhere).then_some(spec)
@@ -141,11 +158,18 @@ impl TierMap {
             .collect();
         (!tiers.is_empty()).then(|| tiers.join("/"))
     }
+
+    pub fn is_override(&self, spec: &str) -> bool {
+        self.overrides.values().any(|s| s.as_str() == spec)
+    }
 }
 
 fn tier_for_position(pos: usize) -> ModelTier {
     [ModelTier::Strong, ModelTier::Medium, ModelTier::Weak][pos.min(2)]
 }
+
+// On-disk format: { "provider/model": "tier", ... } for human readability.
+// Inverted to/from the in-memory BTreeMap<ModelTier, String>.
 
 fn read_overrides(path: &Path) -> BTreeMap<ModelTier, String> {
     let Ok(raw) = std::fs::read_to_string(path) else {
@@ -168,7 +192,10 @@ fn read_overrides(path: &Path) -> BTreeMap<ModelTier, String> {
 }
 
 fn write_overrides(path: &Path, overrides: &BTreeMap<ModelTier, String>) {
-    let json = match serde_json::to_vec_pretty(overrides) {
+    // Invert to human-readable { "spec": "tier" } format on disk.
+    let disk: BTreeMap<String, ModelTier> =
+        overrides.iter().map(|(t, s)| (s.clone(), *t)).collect();
+    let json = match serde_json::to_vec_pretty(&disk) {
         Ok(v) => v,
         Err(e) => {
             warn!(error = %e, "failed to serialize tier overrides");
@@ -185,24 +212,27 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn make_map(overrides: &[(ModelTier, &str)], models: &[&str]) -> TierMap {
-        let mut map = TierMap::default();
-        map.set_overrides(overrides.iter().map(|(t, s)| (*t, s.to_string())).collect());
+    fn make_map(overrides: &[(ModelTier, &str)], models: &[&str]) -> ModelRegistry {
+        let mut reg = ModelRegistry::default();
+        reg.set_overrides(overrides.iter().map(|(t, s)| (*t, s.to_string())).collect());
         if !models.is_empty() {
-            map.set_known_models(
+            reg.set_known_models(
                 ProviderKind::Ollama,
-                models.iter().map(|s| s.to_string()).collect(),
+                models
+                    .iter()
+                    .map(|s| ModelInfo::id_only(s.to_string()))
+                    .collect(),
             );
         }
-        map
+        reg
     }
 
     #[test]
     fn tier_for_resolution_priority() {
-        let mut map = make_map(&[], &["pos0", "pos1", "pos2"]);
-        map.set("ollama/pos1".into(), ModelTier::Weak);
+        let mut reg = make_map(&[], &["pos0", "pos1", "pos2"]);
+        reg.set("ollama/pos1".into(), ModelTier::Weak);
 
-        let t = |spec, static_tier| map.tier_for(spec, ProviderKind::Ollama, static_tier);
+        let t = |spec, static_tier| reg.tier_for(spec, ProviderKind::Ollama, static_tier);
 
         assert_eq!(t("ollama/pos1", Some(ModelTier::Strong)), ModelTier::Weak);
         assert_eq!(t("ollama/pos0", Some(ModelTier::Weak)), ModelTier::Weak);
@@ -214,11 +244,11 @@ mod tests {
 
     #[test]
     fn spec_for_tier_resolution() {
-        let map = make_map(
+        let reg = make_map(
             &[(ModelTier::Strong, "ollama/custom")],
             &["big", "mid", "small"],
         );
-        let s = |t| map.spec_for_tier(ProviderKind::Ollama, t);
+        let s = |t| reg.spec_for_tier(ProviderKind::Ollama, t);
 
         assert_eq!(s(ModelTier::Strong), Some("ollama/custom".into()));
         assert_eq!(s(ModelTier::Medium), Some("ollama/mid".into()));
@@ -239,7 +269,7 @@ mod tests {
 
     #[test]
     fn spec_for_tier_any_cross_provider() {
-        let map = make_map(
+        let reg = make_map(
             &[
                 (ModelTier::Weak, "zai/glm-5"),
                 (ModelTier::Strong, "openai/gpt-foo"),
@@ -247,17 +277,44 @@ mod tests {
             &["big", "mid", "small"],
         );
         assert_eq!(
-            map.spec_for_tier_any(ModelTier::Strong),
+            reg.spec_for_tier_any(ModelTier::Strong),
             Some("openai/gpt-foo".into())
         );
         assert_eq!(
-            map.spec_for_tier_any(ModelTier::Weak),
+            reg.spec_for_tier_any(ModelTier::Weak),
             Some("zai/glm-5".into())
         );
         assert_eq!(
-            map.spec_for_tier_any(ModelTier::Medium),
+            reg.spec_for_tier_any(ModelTier::Medium),
             Some("ollama/mid".into())
         );
+    }
+
+    #[test]
+    fn discovered_looks_up_by_id() {
+        let mut reg = ModelRegistry::default();
+        reg.set_known_models(
+            ProviderKind::LlamaCpp,
+            vec![
+                ModelInfo {
+                    id: "model-a".into(),
+                    context_window: Some(32_000),
+                    max_output_tokens: None,
+                    pricing: None,
+                },
+                ModelInfo {
+                    id: "model-b".into(),
+                    context_window: Some(128_000),
+                    max_output_tokens: None,
+                    pricing: None,
+                },
+            ],
+        );
+        let info = reg.discovered(ProviderKind::LlamaCpp, "model-a").unwrap();
+        assert_eq!(info.id, "model-a");
+        assert_eq!(info.context_window, Some(32_000));
+        assert!(reg.discovered(ProviderKind::LlamaCpp, "model-x").is_none());
+        assert!(reg.discovered(ProviderKind::Ollama, "model-a").is_none());
     }
 
     #[test]
@@ -295,30 +352,30 @@ mod tests {
 
     #[test]
     fn unset_removes_matching_override() {
-        let mut map = make_map(&[(ModelTier::Strong, "ollama/a")], &[]);
-        map.unset("ollama/a", ModelTier::Strong);
-        assert!(!map.has_override("ollama/a", ModelTier::Strong));
-        assert!(map.overrides.is_empty());
+        let mut reg = make_map(&[(ModelTier::Strong, "ollama/a")], &[]);
+        reg.unset("ollama/a", ModelTier::Strong);
+        assert!(!reg.has_override("ollama/a", ModelTier::Strong));
+        assert!(reg.overrides.is_empty());
     }
 
     #[test]
     fn unset_ignores_mismatched_spec() {
-        let mut map = make_map(&[(ModelTier::Strong, "ollama/a")], &[]);
-        map.unset("ollama/b", ModelTier::Strong);
-        assert!(map.has_override("ollama/a", ModelTier::Strong));
+        let mut reg = make_map(&[(ModelTier::Strong, "ollama/a")], &[]);
+        reg.unset("ollama/b", ModelTier::Strong);
+        assert!(reg.has_override("ollama/a", ModelTier::Strong));
     }
 
     #[test]
     fn unset_ignores_mismatched_tier() {
-        let mut map = make_map(&[(ModelTier::Strong, "ollama/a")], &[]);
-        map.unset("ollama/a", ModelTier::Weak);
-        assert!(map.has_override("ollama/a", ModelTier::Strong));
+        let mut reg = make_map(&[(ModelTier::Strong, "ollama/a")], &[]);
+        reg.unset("ollama/a", ModelTier::Weak);
+        assert!(reg.has_override("ollama/a", ModelTier::Strong));
     }
 
     #[test]
     fn has_override_returns_false_for_no_override() {
-        let map = make_map(&[], &[]);
-        assert!(!map.has_override("ollama/a", ModelTier::Strong));
+        let reg = make_map(&[], &[]);
+        assert!(!reg.has_override("ollama/a", ModelTier::Strong));
     }
 
     #[test]

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use strum::{Display, EnumIter, EnumString, IntoEnumIterator};
 use tracing::{debug, warn};
 
-use crate::model::{Model, ModelFamily, models_for_provider};
+use crate::model::{Model, ModelFamily, ModelInfo, models_for_provider};
 use crate::providers::Timeouts;
 use crate::providers::anthropic::Anthropic;
 use crate::providers::anthropic::bedrock;
@@ -226,7 +226,7 @@ pub trait Provider: Send + Sync {
         session_id: Option<&'a str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>>;
 
-    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>>;
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<ModelInfo>, AgentError>>;
 
     fn refresh_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
         Box::pin(async { Ok(()) })
@@ -287,7 +287,7 @@ impl Provider for UnconfiguredProvider {
         })
     }
 
-    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<ModelInfo>, AgentError>> {
         Box::pin(async {
             Err(AgentError::Config {
                 message: NOT_CONFIGURED.to_string(),
@@ -338,7 +338,10 @@ pub fn available_model_specs() -> Vec<String> {
     specs
 }
 
-pub async fn fetch_all_models(mut on_ready: impl FnMut(ModelBatch)) {
+pub async fn fetch_all_models(
+    mut on_ready: impl FnMut(ModelBatch),
+    on_done: Option<Box<dyn FnOnce() + Send>>,
+) {
     let (tx, rx) = flume::unbounded();
     let timeouts = Timeouts::default();
 
@@ -350,25 +353,25 @@ pub async fn fetch_all_models(mut on_ready: impl FnMut(ModelBatch)) {
         let tx = tx.clone();
         smol::spawn(async move {
             let batch = match provider.list_models().await {
-                Ok(ids) => {
+                Ok(models) => {
                     if kind.accepts_arbitrary_models() {
-                        crate::tier_map::tier_map()
+                        crate::model_registry::model_registry()
                             .write()
                             .unwrap()
-                            .set_known_models(kind, ids.clone());
+                            .set_known_models(kind, models.clone());
                     }
-                    let mut models: Vec<String> =
-                        ids.into_iter().map(|id| format!("{kind}/{id}")).collect();
+                    let mut specs: Vec<String> =
+                        models.iter().map(|m| format!("{kind}/{}", m.id)).collect();
                     for entry in models_for_provider(kind) {
                         for prefix in entry.prefixes {
                             let spec = format!("{kind}/{prefix}");
-                            if !models.contains(&spec) {
-                                models.push(spec);
+                            if !specs.contains(&spec) {
+                                specs.push(spec);
                             }
                         }
                     }
                     ModelBatch {
-                        models,
+                        models: specs,
                         warnings: Vec::new(),
                     }
                 }
@@ -410,8 +413,8 @@ pub async fn fetch_all_models(mut on_ready: impl FnMut(ModelBatch)) {
             };
             let batch = match dynamic::create(&slug, timeouts) {
                 Ok(provider) => match provider.list_models().await {
-                    Ok(ids) => ModelBatch {
-                        models: ids.into_iter().map(|id| format!("{slug}/{id}")).collect(),
+                    Ok(models) => ModelBatch {
+                        models: models.iter().map(|m| format!("{slug}/{}", m.id)).collect(),
                         warnings: Vec::new(),
                     },
                     Err(e) => static_fallback(e.to_string()),
@@ -441,5 +444,8 @@ pub async fn fetch_all_models(mut on_ready: impl FnMut(ModelBatch)) {
 
     while let Ok(batch) = rx.recv_async().await {
         on_ready(batch);
+    }
+    if let Some(done) = on_done {
+        done();
     }
 }

--- a/maki-providers/src/providers/anthropic/bedrock.rs
+++ b/maki-providers/src/providers/anthropic/bedrock.rs
@@ -669,11 +669,11 @@ impl Provider for Bedrock {
         })
     }
 
-    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         Box::pin(async {
-            let models: Vec<String> = shared::models()
+            let models: Vec<crate::model::ModelInfo> = shared::models()
                 .iter()
-                .map(|entry| entry.prefixes[0].to_string())
+                .map(|entry| crate::model::ModelInfo::id_only(entry.prefixes[0].to_string()))
                 .collect();
             Ok(models)
         })

--- a/maki-providers/src/providers/anthropic/mod.rs
+++ b/maki-providers/src/providers/anthropic/mod.rs
@@ -144,7 +144,7 @@ impl Anthropic {
         }
     }
 
-    async fn do_list_models(&self) -> Result<Vec<String>, AgentError> {
+    async fn do_list_models(&self) -> Result<Vec<crate::model::ModelInfo>, AgentError> {
         let mut models = Vec::new();
         let mut after_id: Option<String> = None;
 
@@ -163,12 +163,14 @@ impl Anthropic {
             let body_text = response.text().await?;
             let page: ModelsPage = serde_json::from_str(&body_text)?;
             for m in page.data {
-                // The API never tells us about `-1m`, so we mint it ourselves for
-                // any model that reports a 1M window.
                 if m.max_input_tokens >= shared::LONG_CONTEXT_WINDOW {
-                    models.push(format!("{}{}", m.id, shared::LONG_CONTEXT_SUFFIX));
+                    models.push(crate::model::ModelInfo::id_only(format!(
+                        "{}{}",
+                        m.id,
+                        shared::LONG_CONTEXT_SUFFIX
+                    )));
                 }
-                models.push(m.id);
+                models.push(crate::model::ModelInfo::id_only(m.id));
             }
 
             if !page.has_more {
@@ -177,7 +179,7 @@ impl Anthropic {
             after_id = page.last_id;
         }
 
-        models.sort();
+        models.sort_by(|a, b| a.id.cmp(&b.id));
         Ok(models)
     }
 }
@@ -233,7 +235,7 @@ impl Provider for Anthropic {
         })
     }
 
-    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         Box::pin(self.do_list_models())
     }
 
@@ -257,7 +259,7 @@ impl Provider for Anthropic {
 }
 
 #[derive(Deserialize)]
-struct ModelInfo {
+struct ApiModelInfo {
     id: String,
     #[serde(default)]
     max_input_tokens: u32,
@@ -265,7 +267,7 @@ struct ModelInfo {
 
 #[derive(Deserialize)]
 struct ModelsPage {
-    data: Vec<ModelInfo>,
+    data: Vec<ApiModelInfo>,
     has_more: bool,
     last_id: Option<String>,
 }

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -552,17 +552,17 @@ impl Provider for Copilot {
         })
     }
 
-    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         Box::pin(async move {
             let models = self.fetch_models().await?;
-            let ids = models
+            let infos = models
                 .iter()
-                .map(|model| model.id.clone())
+                .map(|model| crate::model::ModelInfo::id_only(model.id.clone()))
                 .collect::<Vec<_>>();
             let mut guard = self.models.lock().unwrap();
             guard.clear();
             guard.extend(models.into_iter().map(|model| (model.id.clone(), model)));
-            Ok(ids)
+            Ok(infos)
         })
     }
 

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -110,7 +110,7 @@ pub fn discover_models(timeouts: Timeouts) -> Vec<String> {
                 match result {
                     Ok(models) => {
                         for m in models {
-                            all_specs.push(format!("{slug_c}/{m}"));
+                            all_specs.push(format!("{slug_c}/{}", m.id));
                         }
                     }
                     Err(e) => {
@@ -154,7 +154,7 @@ impl Provider for CustomOpenAiProvider {
         })
     }
 
-    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         let auth = self.auth.lock().unwrap().clone();
         Box::pin(async move { self.compat.do_list_models(&auth).await })
     }

--- a/maki-providers/src/providers/deepseek.rs
+++ b/maki-providers/src/providers/deepseek.rs
@@ -143,7 +143,7 @@ impl Provider for DeepSeek {
         })
     }
 
-    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
             self.compat.do_list_models(&auth).await

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -498,7 +498,7 @@ impl Provider for DynamicProvider {
             .stream_message(model, messages, system, tools, event_tx, opts, session_id)
     }
 
-    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         self.inner.list_models()
     }
 

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -236,7 +236,7 @@ impl Provider for Google {
         Box::pin(self.do_stream(model, messages, system, tools, event_tx, opts.thinking))
     }
 
-    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         let url = self.models_url();
         let request = self.build_request("GET", &url).body(()).unwrap();
         let client = self.client.clone();
@@ -247,7 +247,7 @@ impl Provider for Google {
             }
             let body_text = response.text().await?;
             let models_response: ModelsListResponse = serde_json::from_str(&body_text)?;
-            let mut ids: Vec<String> = models_response
+            let mut infos: Vec<crate::model::ModelInfo> = models_response
                 .models
                 .into_iter()
                 .filter(|m| {
@@ -256,14 +256,16 @@ impl Provider for Google {
                         .any(|m| m == "generateContent")
                 })
                 .map(|m| {
-                    m.name
+                    let id = m
+                        .name
                         .strip_prefix("models/")
                         .map(String::from)
-                        .unwrap_or(m.name)
+                        .unwrap_or(m.name);
+                    crate::model::ModelInfo::id_only(id)
                 })
                 .collect();
-            ids.sort();
-            Ok(ids)
+            infos.sort_by(|a, b| a.id.cmp(&b.id));
+            Ok(infos)
         })
     }
 
@@ -468,12 +470,12 @@ struct SseResponse {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ModelsListResponse {
-    models: Vec<ModelInfo>,
+    models: Vec<ApiModelInfo>,
 }
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct ModelInfo {
+struct ApiModelInfo {
     name: String,
     #[serde(default)]
     supported_generation_methods: Vec<String>,

--- a/maki-providers/src/providers/local.rs
+++ b/maki-providers/src/providers/local.rs
@@ -117,7 +117,7 @@ impl Provider for LocalEndpoint {
         })
     }
 
-    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
             self.compat.do_list_models(&auth).await

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -163,7 +163,7 @@ impl Provider for Mistral {
         })
     }
 
-    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
             self.compat.do_list_models(&auth).await

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -180,14 +180,14 @@ impl Provider for OpenAi {
         })
     }
 
-    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         Box::pin(async {
             if self.is_oauth() {
                 let models = super::models()
                     .iter()
                     .flat_map(|e| e.prefixes.iter())
                     .filter(|id| is_codex_model(id))
-                    .map(|&s| s.to_string())
+                    .map(|&s| crate::model::ModelInfo::id_only(s.to_string()))
                     .collect();
                 return Ok(models);
             }

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -127,7 +127,10 @@ impl OpenAiCompatProvider {
         }
     }
 
-    pub async fn do_list_models(&self, auth: &ResolvedAuth) -> Result<Vec<String>, AgentError> {
+    pub async fn do_list_models(
+        &self,
+        auth: &ResolvedAuth,
+    ) -> Result<Vec<crate::model::ModelInfo>, AgentError> {
         let request = self.build_request("GET", "/models", auth).body(())?;
         let mut response = self.client.send_async(request).await?;
         if response.status().as_u16() != 200 {
@@ -135,15 +138,41 @@ impl OpenAiCompatProvider {
         }
 
         let body: Value = serde_json::from_str(&response.text().await?)?;
-        let mut models: Vec<String> = body["data"]
+        let mut models: Vec<crate::model::ModelInfo> = body["data"]
             .as_array()
             .map(|arr| {
                 arr.iter()
-                    .filter_map(|m| m["id"].as_str().map(String::from))
+                    .filter_map(|m| {
+                        let id = m["id"].as_str()?;
+                        let context_window = m["context_length"]
+                            .as_u64()
+                            .or_else(|| m["max_model_len"].as_u64())
+                            .and_then(|v| u32::try_from(v).ok());
+                        let max_output_tokens =
+                            m["max_tokens"].as_u64().and_then(|v| u32::try_from(v).ok());
+                        let pricing = m["pricing"]
+                            .as_object()
+                            .and_then(|p| {
+                                Some(crate::model::ModelPricing {
+                                    input: p.get("prompt")?.as_str()?.parse().ok()?,
+                                    output: p.get("completion")?.as_str()?.parse().ok()?,
+                                    cache_write: p.get("cache_creation")?.as_str()?.parse().ok()?,
+                                    cache_read: p.get("cache_read")?.as_str()?.parse().ok()?,
+                                    fast: None,
+                                })
+                            })
+                            .unwrap_or_default();
+                        Some(crate::model::ModelInfo {
+                            id: id.to_string(),
+                            context_window,
+                            max_output_tokens,
+                            pricing: Some(pricing),
+                        })
+                    })
                     .collect()
             })
             .unwrap_or_default();
-        models.sort();
+        models.sort_by(|a, b| a.id.cmp(&b.id));
         Ok(models)
     }
 }

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -98,7 +98,7 @@ impl Provider for OpenRouter {
         })
     }
 
-    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
             self.compat.do_list_models(&auth).await

--- a/maki-providers/src/providers/synthetic.rs
+++ b/maki-providers/src/providers/synthetic.rs
@@ -136,7 +136,7 @@ impl Provider for Synthetic {
         })
     }
 
-    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
             self.compat.do_list_models(&auth).await

--- a/maki-providers/src/providers/zai/mod.rs
+++ b/maki-providers/src/providers/zai/mod.rs
@@ -252,7 +252,7 @@ impl Provider for Zai {
         })
     }
 
-    fn list_models(&self) -> BoxFuture<'_, Result<Vec<String>, AgentError>> {
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
             self.compat.do_list_models(&auth).await

--- a/maki-ui/src/components/model_picker.rs
+++ b/maki-ui/src/components/model_picker.rs
@@ -8,8 +8,8 @@ use ratatui::text::{Line, Span};
 
 use maki_providers::ModelTier;
 use maki_providers::dynamic;
+use maki_providers::model_registry;
 use maki_providers::provider::ProviderKind;
-use maki_providers::tier_map;
 
 use crate::components::Overlay;
 use crate::components::list_picker::{ListPicker, PickerAction, PickerItem};
@@ -200,7 +200,7 @@ fn parse_model_entry(spec: &str) -> Option<ModelEntry> {
         maki_config::providers::resolve_display_name(provider_str, config.get(provider_str))
     };
 
-    let map = tier_map::tier_map().read().unwrap();
+    let map = model_registry::model_registry().read().unwrap();
     let override_tiers: Vec<ModelTier> = [ModelTier::Strong, ModelTier::Medium, ModelTier::Weak]
         .into_iter()
         .filter(|&t| map.has_override(spec, t))

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -99,14 +99,36 @@ fn merge_batch(
     available.store(Some(Arc::new(merged)));
 }
 
-fn spawn_model_fetch() -> BackgroundModels {
+fn spawn_model_fetch(model_slot: &Arc<ArcSwap<ModelSlot>>, timeouts: Timeouts) -> BackgroundModels {
     let available: Arc<ArcSwapOption<Vec<String>>> = Arc::new(ArcSwapOption::empty());
     let bg = Arc::clone(&available);
     let (warn_tx, warn_rx) = flume::unbounded::<String>();
     let warn_tx_bg = warn_tx.clone();
+    let model_slot = Arc::clone(model_slot);
     let task = smol::spawn(async move {
         let warn_tx = warn_tx_bg;
-        fetch_all_models(|batch| merge_batch(&bg, batch, &warn_tx)).await;
+        let done = Box::new(move || {
+            let spec = model_slot.load().model.spec();
+            let resolved = match Model::from_spec(&spec) {
+                Ok(m) => m,
+                Err(e) => {
+                    warn!(spec = %spec, error = %e, "failed to resolve model after discovery");
+                    return;
+                }
+            };
+            let provider = match from_model(&resolved, timeouts) {
+                Ok(p) => p,
+                Err(e) => {
+                    warn!(spec = %spec, error = %e, "failed to create provider after discovery");
+                    return;
+                }
+            };
+            model_slot.store(Arc::new(ModelSlot {
+                model: resolved,
+                provider: Arc::from(provider),
+            }));
+        });
+        fetch_all_models(|batch| merge_batch(&bg, batch, &warn_tx), Some(done)).await;
     });
     BackgroundModels {
         available,
@@ -159,7 +181,6 @@ impl<'t> EventLoop<'t> {
         std::thread::spawn(crate::highlight::warmup);
         crate::update::spawn_check();
 
-        let bg = spawn_model_fetch();
         let storage_writer = Arc::new(StorageWriter::new(storage.clone()));
         let (shell_tx, shell_rx) = flume::unbounded::<ShellEvent>();
 
@@ -178,6 +199,7 @@ impl<'t> EventLoop<'t> {
             model: model.clone(),
             provider,
         }));
+        let bg = spawn_model_fetch(&model_slot, timeouts);
         let handles = AgentHandles::spawn(
             &model_slot,
             initial_history,
@@ -461,10 +483,10 @@ impl<'t> EventLoop<'t> {
             Action::ChangeModel(spec) => self.change_model(spec),
             Action::RefreshProvider { slug } => self.refresh_provider(slug),
             Action::AssignTier(spec, tier) => {
-                maki_providers::tier_map::set_and_persist(spec, tier, &self.app.storage);
+                maki_providers::model_registry::set_and_persist(spec, tier, &self.app.storage);
             }
             Action::UnassignTier(spec, tier) => {
-                maki_providers::tier_map::unset_and_persist(&spec, tier, &self.app.storage);
+                maki_providers::model_registry::unset_and_persist(&spec, tier, &self.app.storage);
             }
             Action::Compact => {
                 self.handles.queue.push(QueueItem::Compact {
@@ -537,7 +559,7 @@ impl<'t> EventLoop<'t> {
         let warn_tx = self.warn_tx.clone();
         available.store(None);
         smol::spawn(async move {
-            fetch_all_models(|batch| merge_batch(&available, batch, &warn_tx)).await;
+            fetch_all_models(|batch| merge_batch(&available, batch, &warn_tx), None).await;
         })
         .detach();
     }

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -13,7 +13,7 @@ use crate::setup;
 
 pub fn run(model_arg: Option<String>, yolo: bool) -> Result<()> {
     let storage = StateDir::resolve().context("resolve data directory")?;
-    maki_providers::tier_map::load_from_storage(&storage);
+    maki_providers::model_registry::load_from_storage(&storage);
 
     let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
     load_env_files(&cwd);

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -435,14 +435,17 @@ pub fn auth_status(storage: &StateDir) -> Result<()> {
 }
 
 pub fn models() {
-    smol::block_on(fetch_all_models(|batch| {
-        for model in batch.models {
-            println!("{model}");
-        }
-        for warning in batch.warnings {
-            eprintln!("warning: {warning}");
-        }
-    }));
+    smol::block_on(fetch_all_models(
+        |batch| {
+            for model in batch.models {
+                println!("{model}");
+            }
+            for warning in batch.warnings {
+                eprintln!("warning: {warning}");
+            }
+        },
+        None,
+    ));
 }
 
 pub fn index(path: &str, no_plugins: bool) -> Result<()> {

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -62,7 +62,7 @@ fn read_initial_prompt(cli_prompt: Option<String>) -> Result<Option<String>> {
 
 pub fn run(cli: Cli) -> Result<()> {
     let storage = StateDir::resolve().context("resolve data directory")?;
-    maki_providers::tier_map::load_from_storage(&storage);
+    maki_providers::model_registry::load_from_storage(&storage);
 
     let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
 


### PR DESCRIPTION
- Rename TierMap to ModelRegistry; consolidate tier overrides, discovered metadata, and per-provider model lists into a single registry
- Change Provider::list_models() return type from Vec<String> to Vec<ModelInfo> carrying id, context_window, max_output_tokens, and pricing
- Add ModelInfo struct to model.rs with id_only() helper
- Update all ~15 provider implementations to return Vec<ModelInfo>
- Model::from_base() consults discovered metadata for unknown models
- fetch_all_models() accepts optional on_done callback for post-discovery actions
- event_loop.rs re-resolves current model after discovery completes
- openai_compat::do_list_models() extracts context_length/max_model_len from API responses (Ollama, llama.cpp, OpenRouter)
- Rename Anthropic/Google private ModelInfo structs to ApiModelInfo