### PR TITLE
agent: Print full command to resume session on exit

### DIFF
--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -218,7 +218,7 @@ pub fn run(cli: Cli) -> Result<()> {
         )
         .context("run UI")?;
         if let Some(session_id) = session_id {
-            eprintln!("session: {session_id}");
+            eprintln!("Resume session:\n\n  maki -s {session_id}");
         }
         if exit_code != 0 {
             std::process::exit(exit_code);


### PR DESCRIPTION
If we only print the session id at the end of a session then the user needs to copy the session id and then type `maki -s <paste>` to resume a previous session.

If we print the full command needed to resume the session instead, then the user can just select the whole thing and paste it to the terminal prompt.

By putting this on a line by itself, we make it easy for users to triple click to select the full line and then paste.