### PR TITLE
providers: enforce one model per tier via structural invariant

### DIFF
--- a/maki-providers/src/tier_map.rs
+++ b/maki-providers/src/tier_map.rs
@@ -1,18 +1,8 @@
-//! Single source of truth for per-model tier assignments.
+//! Per-model tier assignments (strong / medium / weak).
 //!
-//! Tier resolution combines three layers, in priority order:
-//!
-//! 1. **User overrides** - explicit tier assignments persisted to
-//!    `~/.local/state/maki/model-tiers` (JSON). Apply to any provider.
-//! 2. **Static entries** - `ModelEntry::tier` from the provider's built-in
-//!    registry. Consulted by `model.rs` via [`TierMap::tier_for`].
-//! 3. **Auto-assignment** - for providers that accept arbitrary models
-//!    (e.g. Ollama), derived from the position in the ordered list returned
-//!    by `list_models()`.
-//!
-//! All tier reads and writes go through [`tier_map`]. The module also owns
-//! persistence: [`load_from_storage`] at startup, [`set_and_persist`] on user
-//! edits. Callers never touch the on-disk format directly.
+//! Three layers, checked in order: user overrides (persisted, one model per
+//! tier) > static entries from the provider registry > auto-assignment by
+//! position in `list_models()`.
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
@@ -28,23 +18,15 @@ const TIERS_FILE: &str = "model-tiers";
 
 static TIERS: OnceLock<RwLock<TierMap>> = OnceLock::new();
 
-/// Access the global `TierMap`. Lazily initialises to an empty map on first
-/// use, so the access order between [`load_from_storage`], `list_models()`,
-/// and ordinary reads does not matter.
 pub fn tier_map() -> &'static RwLock<TierMap> {
     TIERS.get_or_init(|| RwLock::new(TierMap::default()))
 }
 
-/// Load persisted overrides from `state_dir()/model-tiers` into the global map.
-/// Replaces any previously-loaded overrides but preserves `known_models`.
 pub fn load_from_storage(dir: &StateDir) {
     let overrides = read_overrides(dir.path().join(TIERS_FILE).as_path());
     tier_map().write().unwrap().set_overrides(overrides);
 }
 
-/// Atomically set an override and write the new state to disk.
-/// Releases the write lock before touching the filesystem, so I/O latency
-/// does not block other tier reads.
 pub fn set_and_persist(spec: String, tier: ModelTier, dir: &StateDir) {
     let snapshot = {
         let mut map = tier_map().write().unwrap();
@@ -56,19 +38,15 @@ pub fn set_and_persist(spec: String, tier: ModelTier, dir: &StateDir) {
 
 #[derive(Debug, Default)]
 pub struct TierMap {
-    /// User-assigned tier overrides keyed by full spec (e.g. "ollama/qwen3:8b").
-    /// Persisted to disk. `BTreeMap` for deterministic iteration and sorted
-    /// on-disk output.
-    overrides: BTreeMap<String, ModelTier>,
-    /// Ordered model IDs per provider, populated from `list_models()`.
-    /// Not persisted - rebuilt every session. Used for auto-assignment on
-    /// providers that accept arbitrary models.
+    /// Keyed by tier (not spec) so inserting a model automatically evicts the
+    /// previous holder. Persisted to disk.
+    overrides: BTreeMap<ModelTier, String>,
+    /// Rebuilt every session from `list_models()`. Position 0 = strong, etc.
     known_models: HashMap<ProviderKind, Vec<String>>,
 }
 
 impl TierMap {
-    /// Replace the overrides map wholesale. Preserves `known_models`.
-    pub fn set_overrides(&mut self, overrides: BTreeMap<String, ModelTier>) {
+    pub fn set_overrides(&mut self, overrides: BTreeMap<ModelTier, String>) {
         self.overrides = overrides;
     }
 
@@ -77,20 +55,16 @@ impl TierMap {
     }
 
     pub fn set(&mut self, spec: String, tier: ModelTier) {
-        self.overrides.insert(spec, tier);
+        self.overrides.insert(tier, spec);
     }
 
-    /// Resolve the tier for a given model spec.
-    ///
-    /// Priority: user override → `static_tier` → auto-assigned by position in
-    /// `known_models` → [`ModelTier::Medium`] as the safe default.
     pub fn tier_for(
         &self,
         spec: &str,
         provider: ProviderKind,
         static_tier: Option<ModelTier>,
     ) -> ModelTier {
-        if let Some(&t) = self.overrides.get(spec) {
+        if let Some((&t, _)) = self.overrides.iter().find(|(_, s)| s.as_str() == spec) {
             return t;
         }
         if let Some(t) = static_tier {
@@ -105,40 +79,30 @@ impl TierMap {
         ModelTier::Medium
     }
 
-    /// Find a model spec that matches the requested tier for a provider.
-    ///
-    /// Priority: first matching user override (sorted spec order) →
-    /// auto-assigned model at the tier's slot in `known_models`, unless the
-    /// user has overridden that exact spec to a different tier.
     pub fn spec_for_tier(&self, provider: ProviderKind, tier: ModelTier) -> Option<String> {
         let prefix = format!("{provider}/");
-        for (spec, &t) in &self.overrides {
-            if t == tier && spec.starts_with(&prefix) {
-                return Some(spec.clone());
-            }
+        if let Some(spec) = self.overrides.get(&tier)
+            && spec.starts_with(&prefix)
+        {
+            return Some(spec.clone());
         }
 
         let models = self.known_models.get(&provider).filter(|m| !m.is_empty())?;
-        let want = match tier {
+        let slot = match tier {
             ModelTier::Strong => 0,
             ModelTier::Medium => 1,
             ModelTier::Weak => 2,
         };
-        let idx = want.min(models.len() - 1);
+        let idx = slot.min(models.len() - 1);
         let spec = format!("{provider}/{}", models[idx]);
 
-        // Skip the auto-pick if the user explicitly assigned it to another tier.
-        match self.overrides.get(&spec) {
-            Some(&t) if t != tier => None,
-            _ => Some(spec),
-        }
+        let overridden_elsewhere = self.overrides.iter().any(|(&t, s)| s == &spec && t != tier);
+        (!overridden_elsewhere).then_some(spec)
     }
 
     pub fn spec_for_tier_any(&self, tier: ModelTier) -> Option<String> {
-        for (spec, &t) in &self.overrides {
-            if t == tier {
-                return Some(spec.clone());
-            }
+        if let Some(spec) = self.overrides.get(&tier) {
+            return Some(spec.clone());
         }
         for &provider in self.known_models.keys() {
             if let Some(spec) = self.spec_for_tier(provider, tier) {
@@ -149,33 +113,27 @@ impl TierMap {
     }
 
     pub fn is_override(&self, spec: &str) -> bool {
-        self.overrides.contains_key(spec)
+        self.overrides.values().any(|s| s == spec)
     }
 }
 
-/// Pure function: map a list position to a tier. Position 0 is Strong, 1 is
-/// Medium, the rest are Weak. The caller guarantees `pos < known_models.len()`.
 fn tier_for_position(pos: usize) -> ModelTier {
-    match pos {
-        0 => ModelTier::Strong,
-        1 => ModelTier::Medium,
-        _ => ModelTier::Weak,
-    }
+    [ModelTier::Strong, ModelTier::Medium, ModelTier::Weak][pos.min(2)]
 }
 
-// File format: pretty-printed JSON, `{ "provider/model": "tier", ... }`.
-// `serde` handles escaping for unusual characters in specs; `BTreeMap`
-// produces sorted, diff-friendly output.
-
-fn read_overrides(path: &Path) -> BTreeMap<String, ModelTier> {
+fn read_overrides(path: &Path) -> BTreeMap<ModelTier, String> {
     let Ok(raw) = std::fs::read_to_string(path) else {
         return BTreeMap::new();
     };
     if raw.trim().is_empty() {
         return BTreeMap::new();
     }
+    if let Ok(map) = serde_json::from_str::<BTreeMap<ModelTier, String>>(&raw) {
+        return map;
+    }
+    // Legacy format: { "provider/model": "tier" } — invert on read.
     match serde_json::from_str::<BTreeMap<String, ModelTier>>(&raw) {
-        Ok(map) => map,
+        Ok(legacy) => legacy.into_iter().map(|(s, t)| (t, s)).collect(),
         Err(e) => {
             warn!(path = %path.display(), error = %e, "failed to parse tier overrides, ignoring");
             BTreeMap::new()
@@ -183,7 +141,7 @@ fn read_overrides(path: &Path) -> BTreeMap<String, ModelTier> {
     }
 }
 
-fn write_overrides(path: &Path, overrides: &BTreeMap<String, ModelTier>) {
+fn write_overrides(path: &Path, overrides: &BTreeMap<ModelTier, String>) {
     let json = match serde_json::to_vec_pretty(overrides) {
         Ok(v) => v,
         Err(e) => {
@@ -201,9 +159,9 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn make_map(overrides: &[(&str, ModelTier)], models: &[&str]) -> TierMap {
+    fn make_map(overrides: &[(ModelTier, &str)], models: &[&str]) -> TierMap {
         let mut map = TierMap::default();
-        map.set_overrides(overrides.iter().map(|(s, t)| (s.to_string(), *t)).collect());
+        map.set_overrides(overrides.iter().map(|(t, s)| (*t, s.to_string())).collect());
         if !models.is_empty() {
             map.set_known_models(
                 ProviderKind::Ollama,
@@ -214,115 +172,65 @@ mod tests {
     }
 
     #[test]
-    fn tier_for_priority_and_positions() {
-        // Resolution order: user override > static_tier > auto-by-position > Medium default.
+    fn tier_for_resolution_priority() {
         let mut map = make_map(&[], &["pos0", "pos1", "pos2"]);
-        map.set("ollama/pos0".into(), ModelTier::Weak);
+        map.set("ollama/pos1".into(), ModelTier::Weak);
 
         let t = |spec, static_tier| map.tier_for(spec, ProviderKind::Ollama, static_tier);
 
-        assert_eq!(t("ollama/pos0", Some(ModelTier::Strong)), ModelTier::Weak);
-        assert_eq!(t("ollama/pos1", Some(ModelTier::Weak)), ModelTier::Weak);
-        assert_eq!(t("ollama/pos1", None), ModelTier::Medium);
+        assert_eq!(t("ollama/pos1", Some(ModelTier::Strong)), ModelTier::Weak);
+        assert_eq!(t("ollama/pos0", Some(ModelTier::Weak)), ModelTier::Weak);
+        assert_eq!(t("ollama/pos0", None), ModelTier::Strong);
+        assert_eq!(t("ollama/pos1", None), ModelTier::Weak);
         assert_eq!(t("ollama/pos2", None), ModelTier::Weak);
         assert_eq!(t("ollama/unknown", None), ModelTier::Medium);
     }
 
     #[test]
-    fn tier_for_auto_assigns_position_zero_to_strong() {
-        // Sibling test covers positions 1 and 2 but cannot cover pos 0 (overridden there).
-        let map = make_map(&[], &["only"]);
-        assert_eq!(
-            map.tier_for("ollama/only", ProviderKind::Ollama, None),
-            ModelTier::Strong
-        );
-    }
-
-    #[test]
-    fn spec_for_tier_override_first() {
+    fn spec_for_tier_resolution() {
         let map = make_map(
-            &[("ollama/custom", ModelTier::Strong)],
+            &[(ModelTier::Strong, "ollama/custom")],
             &["big", "mid", "small"],
         );
-        assert_eq!(
-            map.spec_for_tier(ProviderKind::Ollama, ModelTier::Strong),
-            Some("ollama/custom".into())
-        );
-    }
+        let s = |t| map.spec_for_tier(ProviderKind::Ollama, t);
 
-    #[test]
-    fn spec_for_tier_override_scan_is_deterministic() {
-        // Two overrides at the same tier; BTreeMap sorted order → "a" wins.
-        let map = make_map(
-            &[
-                ("ollama/b", ModelTier::Strong),
-                ("ollama/a", ModelTier::Strong),
-            ],
-            &[],
-        );
-        assert_eq!(
-            map.spec_for_tier(ProviderKind::Ollama, ModelTier::Strong),
-            Some("ollama/a".into())
-        );
-    }
+        assert_eq!(s(ModelTier::Strong), Some("ollama/custom".into()));
+        assert_eq!(s(ModelTier::Medium), Some("ollama/mid".into()));
+        assert_eq!(s(ModelTier::Weak), Some("ollama/small".into()));
 
-    #[test]
-    fn spec_for_tier_override_scoped_by_provider() {
-        let map = make_map(&[("openai/gpt-foo", ModelTier::Strong)], &[]);
+        let scoped = make_map(&[(ModelTier::Strong, "openai/gpt-foo")], &[]);
         assert_eq!(
-            map.spec_for_tier(ProviderKind::Ollama, ModelTier::Strong),
+            scoped.spec_for_tier(ProviderKind::Ollama, ModelTier::Strong),
+            None
+        );
+
+        let conflict = make_map(&[(ModelTier::Weak, "ollama/big")], &["big", "mid", "small"]);
+        assert_eq!(
+            conflict.spec_for_tier(ProviderKind::Ollama, ModelTier::Strong),
             None
         );
     }
 
     #[test]
-    fn spec_for_tier_auto_fallback() {
-        let map = make_map(&[], &["big", "mid", "small"]);
-        assert_eq!(
-            map.spec_for_tier(ProviderKind::Ollama, ModelTier::Strong),
-            Some("ollama/big".into())
-        );
-        assert_eq!(
-            map.spec_for_tier(ProviderKind::Ollama, ModelTier::Medium),
-            Some("ollama/mid".into())
-        );
-        assert_eq!(
-            map.spec_for_tier(ProviderKind::Ollama, ModelTier::Weak),
-            Some("ollama/small".into())
-        );
-    }
-
-    #[test]
-    fn spec_for_tier_skips_model_overridden_elsewhere() {
-        // "big" is at the Strong slot but overridden to Weak; don't return it for Strong.
-        let map = make_map(&[("ollama/big", ModelTier::Weak)], &["big", "mid", "small"]);
-        assert_eq!(
-            map.spec_for_tier(ProviderKind::Ollama, ModelTier::Strong),
-            None
-        );
-    }
-
-    #[test]
-    fn spec_for_tier_any_cross_provider_and_sorted() {
+    fn spec_for_tier_any_cross_provider() {
         let map = make_map(
             &[
-                ("zai/glm-5", ModelTier::Weak),
-                ("anthropic/opus", ModelTier::Weak),
-                ("openai/gpt-foo", ModelTier::Strong),
+                (ModelTier::Weak, "zai/glm-5"),
+                (ModelTier::Strong, "openai/gpt-foo"),
             ],
             &["big", "mid", "small"],
         );
         assert_eq!(
             map.spec_for_tier_any(ModelTier::Strong),
-            Some("openai/gpt-foo".into()),
+            Some("openai/gpt-foo".into())
         );
         assert_eq!(
             map.spec_for_tier_any(ModelTier::Weak),
-            Some("anthropic/opus".into()),
+            Some("zai/glm-5".into())
         );
         assert_eq!(
             map.spec_for_tier_any(ModelTier::Medium),
-            Some("ollama/mid".into()),
+            Some("ollama/mid".into())
         );
     }
 
@@ -334,14 +242,13 @@ mod tests {
         assert!(read_overrides(&path).is_empty());
 
         let mut m = BTreeMap::new();
-        m.insert("ollama/qwen3".into(), ModelTier::Strong);
-        m.insert("ollama/qwen3:8b".into(), ModelTier::Medium);
+        m.insert(ModelTier::Strong, "ollama/qwen3".into());
+        m.insert(ModelTier::Medium, "ollama/qwen3:8b".into());
         write_overrides(&path, &m);
 
         let loaded = read_overrides(&path);
-        assert_eq!(loaded.len(), 2);
-        assert_eq!(loaded.get("ollama/qwen3"), Some(&ModelTier::Strong));
-        assert_eq!(loaded.get("ollama/qwen3:8b"), Some(&ModelTier::Medium));
+        assert_eq!(loaded.get(&ModelTier::Strong).unwrap(), "ollama/qwen3");
+        assert_eq!(loaded.get(&ModelTier::Medium).unwrap(), "ollama/qwen3:8b");
     }
 
     #[test]
@@ -358,5 +265,17 @@ mod tests {
             std::fs::write(&path, bad).unwrap();
             assert!(read_overrides(&path).is_empty());
         }
+    }
+
+    #[test]
+    fn backwards_compat_reads_legacy_format() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join(TIERS_FILE);
+        let legacy = r#"{"ollama/a": "strong", "ollama/b": "strong", "ollama/c": "weak"}"#;
+        std::fs::write(&path, legacy).unwrap();
+
+        let loaded = read_overrides(&path);
+        assert_eq!(loaded.get(&ModelTier::Strong).unwrap(), "ollama/b");
+        assert_eq!(loaded.get(&ModelTier::Weak).unwrap(), "ollama/c");
     }
 }


### PR DESCRIPTION
The old `BTreeMap<String, ModelTier>` (spec to tier) allowed multiple models to share the same tier.

Flipping the map to `BTreeMap<ModelTier, String>` (tier to spec) makes the one-per-tier rule structural: `insert(tier, spec)` evicts the previous holder, no scanning or dedup needed.

On-disk format stays the same `{"spec": "tier"}` JSON, inverted on read and write back, so existing files just work.