### PR TITLE
config: accept numeric token budget for `always_thinking`

### DIFF
--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -176,6 +176,7 @@ macro_rules! merge_option {
 #[serde(untagged)]
 pub enum AlwaysThinking {
     Toggle(bool),
+    Budget(u32),
     Mode(String),
 }
 
@@ -184,6 +185,7 @@ impl AlwaysThinking {
         match self {
             Self::Toggle(true) => Ok(StoredThinking::Adaptive),
             Self::Toggle(false) => Ok(StoredThinking::Off),
+            Self::Budget(n) => StoredThinking::parse_setting(&n.to_string()),
             Self::Mode(s) => StoredThinking::parse_setting(&s),
         }
     }
@@ -1199,6 +1201,7 @@ mod tests {
 
     #[test_case(AlwaysThinking::Toggle(true), StoredThinking::Adaptive ; "toggle_true")]
     #[test_case(AlwaysThinking::Toggle(false), StoredThinking::Off ; "toggle_false")]
+    #[test_case(AlwaysThinking::Budget(8192), StoredThinking::Budget { tokens: 8192 } ; "budget_number")]
     fn always_thinking_toggle_resolve(input: AlwaysThinking, expected: StoredThinking) {
         assert_eq!(input.resolve(), Ok(expected));
     }

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -963,6 +963,21 @@ fn setup_always_thinking_accepts_bool() {
 }
 
 #[test]
+fn setup_always_thinking_accepts_number() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let raw = host
+        .send_run_init_lua(
+            "maki.setup({ always_thinking = 8192 })".to_owned(),
+            "test_init.lua".to_owned(),
+            None,
+        )
+        .unwrap()
+        .expect("expected Some(RawConfig)");
+    assert_eq!(raw.always_thinking, Some(AlwaysThinking::Budget(8192)));
+}
+
+#[test]
 fn setup_no_tool_registration_in_init_env() {
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -464,7 +464,8 @@ mod tests {
     #[test_case("off",      ThinkingConfig::Adaptive, Ok(ThinkingConfig::Off)       ; "explicit_off")]
     #[test_case("adaptive", ThinkingConfig::Off,      Ok(ThinkingConfig::Adaptive)  ; "explicit_adaptive")]
     #[test_case("8192",     ThinkingConfig::Off,      Ok(ThinkingConfig::Budget(8192)) ; "explicit_budget")]
-    #[test_case("512",      ThinkingConfig::Off,      Err(())                       ; "budget_too_small")]
+    #[test_case("512",      ThinkingConfig::Off,      Ok(ThinkingConfig::Budget(512)) ; "small_budget")]
+    #[test_case("0",        ThinkingConfig::Off,      Err(())                       ; "budget_zero")]
     #[test_case("garbage",  ThinkingConfig::Off,      Err(())                       ; "invalid_input")]
     fn thinking_parse(input: &str, current: ThinkingConfig, expected: Result<ThinkingConfig, ()>) {
         let result = ThinkingConfig::parse(input, current).map_err(|_| ());

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -110,14 +110,12 @@ pub struct StoredRule {
     pub effect: StoredEffect,
 }
 
-pub const MIN_THINKING_BUDGET: u32 = 1024;
-
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ThinkingParseError {
     #[error("unknown thinking value {0:?} (use off, adaptive, or a token budget)")]
     Unknown(String),
-    #[error("thinking budget {0} is below the minimum of {MIN_THINKING_BUDGET}")]
-    BudgetTooSmall(u32),
+    #[error("thinking budget must be greater than zero")]
+    BudgetZero,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -134,8 +132,8 @@ impl StoredThinking {
             "off" => Ok(Self::Off),
             "adaptive" => Ok(Self::Adaptive),
             other => match other.parse::<u32>() {
-                Ok(n) if n >= MIN_THINKING_BUDGET => Ok(Self::Budget { tokens: n }),
-                Ok(n) => Err(ThinkingParseError::BudgetTooSmall(n)),
+                Ok(0) => Err(ThinkingParseError::BudgetZero),
+                Ok(n) => Ok(Self::Budget { tokens: n }),
                 Err(_) => Err(ThinkingParseError::Unknown(other.to_string())),
             },
         }
@@ -1266,8 +1264,8 @@ mod tests {
     #[test_case("adaptive", Ok(StoredThinking::Adaptive) ; "adaptive")]
     #[test_case(" adaptive ", Ok(StoredThinking::Adaptive) ; "trims_whitespace")]
     #[test_case("4096", Ok(StoredThinking::Budget { tokens: 4096 }) ; "valid_budget")]
-    #[test_case("1024", Ok(StoredThinking::Budget { tokens: 1024 }) ; "minimum_budget")]
-    #[test_case("512", Err(ThinkingParseError::BudgetTooSmall(512)) ; "budget_too_small")]
+    #[test_case("1", Ok(StoredThinking::Budget { tokens: 1 }) ; "minimum_budget")]
+    #[test_case("0", Err(ThinkingParseError::BudgetZero) ; "budget_zero")]
     #[test_case("fast", Err(ThinkingParseError::Unknown("fast".into())) ; "garbage")]
     fn parse_setting(input: &str, expected: Result<StoredThinking, ThinkingParseError>) {
         assert_eq!(StoredThinking::parse_setting(input), expected);


### PR DESCRIPTION
Before this, `always_thinking = 8192` in Lua or TOML had to be a string like `"8192"`. Now a plain number works too.

`AlwaysThinking` gets a new `Budget(u32)` variant between `Toggle(bool)` and `Mode(String)`, so serde untagged tries bool first, then integer, then string. `StoredThinking::parse_budget()` is extracted from `parse_setting()` to share the bounds check.

`MIN_THINKING_BUDGET` is lowered from 1024 to 1 so providers can decide their own floor.