### PR TITLE
index: syntax highlighting and structured metadata

### DIFF
--- a/plugins/index/indexer.lua
+++ b/plugins/index/indexer.lua
@@ -87,6 +87,10 @@ local function format_range(s, e)
   return "[" .. s .. "-" .. e .. "]"
 end
 
+local function ranged(text, range)
+  return { body = text, range = range }
+end
+
 local function find_child(node, kind)
   for _, child in ipairs(node:children()) do
     if child:type() == kind then
@@ -108,7 +112,11 @@ local function truncate(s, max)
   if boundary < 0 then
     boundary = 0
   end
-  return s:sub(1, boundary) .. "[truncated]"
+  local cut = s:sub(1, boundary)
+  if cut:find("\n", 1, true) then
+    return cut .. "\n[truncated]"
+  end
+  return cut .. "[truncated]"
 end
 
 local function truncated_msg(total)
@@ -426,7 +434,7 @@ local function extract_body_members(body, source, rules)
         local sig = rule.fn(child, source)
         if sig then
           local lr = format_range(line_start(child), line_end(child))
-          members[#members + 1] = sig .. " " .. lr
+          members[#members + 1] = ranged(sig, lr)
         end
       elseif rule.handler == "field" then
         local counter = rule.counter or kind
@@ -434,7 +442,7 @@ local function extract_body_members(body, source, rules)
         if field_counts[counter] <= FIELD_TRUNCATE_THRESHOLD then
           local text = rule.fn(child, source)
           local lr = format_range(line_start(child), line_end(child))
-          members[#members + 1] = text .. " " .. lr
+          members[#members + 1] = ranged(text, lr)
         end
       end
     end
@@ -519,22 +527,84 @@ end
 
 local render_item_lines
 
-render_item_lines = function(entry, out, indent)
+local TRUNCATED_SUFFIX = "[truncated]"
+local TRUNCATED_INFIX = " more truncated]"
+
+local function ends_with_truncation(s)
+  if s:sub(-#TRUNCATED_SUFFIX) == TRUNCATED_SUFFIX then
+    return true
+  end
+  return s:sub(1, 1) == "[" and s:sub(-#TRUNCATED_INFIX) == TRUNCATED_INFIX
+end
+
+local function emit_body_with_range(body, range, out, meta)
+  if body:find("\n", 1, true) then
+    local leading = body:match("^(%s*)") or ""
+    local lines = {}
+    for line in (body .. "\n"):gmatch("([^\n]*)\n") do
+      lines[#lines + 1] = line
+    end
+    for i, line in ipairs(lines) do
+      if i == 1 then
+        out[#out + 1] = line .. " " .. range
+        meta[#out] = { body = line, range = range }
+      else
+        line = leading .. line
+        out[#out + 1] = line
+        if ends_with_truncation(line) then
+          meta[#out] = { tag = "dim" }
+        end
+      end
+    end
+  else
+    out[#out + 1] = body .. " " .. range
+    if ends_with_truncation(body) then
+      meta[#out] = { tag = "dim" }
+    else
+      meta[#out] = { body = body, range = range }
+    end
+  end
+end
+
+render_item_lines = function(entry, out, indent, meta)
   local prefix = string.rep(" ", indent)
   for _, attr in ipairs(entry.attrs or {}) do
     out[#out + 1] = prefix .. attr
   end
-  out[#out + 1] = prefix .. entry.text .. " " .. format_range(entry.line_start, entry.line_end)
+  local range = format_range(entry.line_start, entry.line_end)
+  local body = prefix .. entry.text
+  emit_body_with_range(body, range, out, meta)
   if entry.child_kind == CHILD_BRIEF and #(entry.children or {}) > 0 then
-    for _, line in ipairs(wrap_csv(entry.children, prefix .. "  ")) do
+    local children = entry.children
+    local last = children[#children]
+    local has_trunc = type(last) == "string" and ends_with_truncation(last)
+    if has_trunc then
+      children = { table.unpack(children, 1, #children - 1) }
+    end
+    local csv_items = {}
+    for _, c in ipairs(children) do
+      csv_items[#csv_items + 1] = type(c) == "table" and (c.body .. " " .. c.range) or c
+    end
+    for _, line in ipairs(wrap_csv(csv_items, prefix .. "  ")) do
       out[#out + 1] = line
+      meta[#out] = { tag = "dim" }
+    end
+    if has_trunc then
+      out[#out + 1] = prefix .. "  " .. last
+      meta[#out] = { tag = "dim" }
     end
   else
     for _, child in ipairs(entry.children or {}) do
-      if type(child) == "table" then
-        render_item_lines(child, out, indent + 2)
+      if type(child) == "table" and child.body then
+        local cbody = prefix .. "  " .. child.body
+        emit_body_with_range(cbody, child.range, out, meta)
+      elseif type(child) == "table" then
+        render_item_lines(child, out, indent + 2, meta)
       else
         out[#out + 1] = prefix .. "  " .. child
+        if type(child) == "string" and ends_with_truncation(child) then
+          meta[#out] = { tag = "dim" }
+        end
       end
     end
   end
@@ -542,9 +612,41 @@ end
 
 local function format_skeleton(entries, test_lines, module_doc, import_sep)
   local out = {}
+  local meta = {}
+
+  local function emit_section(label, range)
+    out[#out + 1] = label .. (range or "")
+    meta[#out] = range and { tag = "section", body = label, range = range } or { tag = "section" }
+  end
+
+  local function items_range(items)
+    local lo, hi = MAX_INT, 0
+    for _, e in ipairs(items) do
+      if e.line_start < lo then
+        lo = e.line_start
+      end
+      if e.line_end > hi then
+        hi = e.line_end
+      end
+    end
+    return format_range(lo, hi)
+  end
+
+  local function lines_range(lines)
+    local lo, hi = MAX_INT, 0
+    for _, l in ipairs(lines) do
+      if l < lo then
+        lo = l
+      end
+      if l > hi then
+        hi = l
+      end
+    end
+    return format_range(lo, hi)
+  end
 
   if module_doc then
-    out[#out + 1] = "module doc: " .. format_range(module_doc[1], module_doc[2])
+    emit_section("module doc: ", format_range(module_doc[1], module_doc[2]))
   end
 
   local grouped = {}
@@ -563,20 +665,10 @@ local function format_skeleton(entries, test_lines, module_doc, import_sep)
     if items and #items > 0 then
       local header = SECTION_HEADER[sec]
       if sec == SECTION.Import then
-        local min_line, max_line = MAX_INT, 0
-        for _, e in ipairs(items) do
-          if e.line_start < min_line then
-            min_line = e.line_start
-          end
-          if e.line_end > max_line then
-            max_line = e.line_end
-          end
-        end
-
         if #out > 0 then
           out[#out + 1] = ""
         end
-        out[#out + 1] = "imports: " .. format_range(min_line, max_line)
+        emit_section("imports: ", items_range(items))
 
         local keyword_order = {}
         local keyword_tries = {}
@@ -608,19 +700,10 @@ local function format_skeleton(entries, test_lines, module_doc, import_sep)
           end
         end
       elseif sec == SECTION.Module then
-        local min_line, max_line = MAX_INT, 0
-        for _, e in ipairs(items) do
-          if e.line_start < min_line then
-            min_line = e.line_start
-          end
-          if e.line_end > max_line then
-            max_line = e.line_end
-          end
-        end
         if #out > 0 then
           out[#out + 1] = ""
         end
-        out[#out + 1] = header .. " " .. format_range(min_line, max_line)
+        emit_section(header .. " ", items_range(items))
         local names = {}
         for _, e in ipairs(items) do
           names[#names + 1] = e.text
@@ -632,18 +715,21 @@ local function format_skeleton(entries, test_lines, module_doc, import_sep)
         if #out > 0 then
           out[#out + 1] = ""
         end
-        out[#out + 1] = header
+        emit_section(header)
         for _, entry in ipairs(items) do
-          out[#out + 1] = "  " .. entry.text .. " " .. format_range(entry.line_start, entry.line_end)
+          local range = format_range(entry.line_start, entry.line_end)
+          local body = "  " .. entry.text
+          out[#out + 1] = body .. " " .. range
+          meta[#out] = { body = body, range = range }
         end
       else
         if #out > 0 then
           out[#out + 1] = ""
         end
-        out[#out + 1] = header
+        emit_section(header)
         for _, entry in ipairs(items) do
           if entry.kind == "item" then
-            render_item_lines(entry, out, 2)
+            render_item_lines(entry, out, 2, meta)
           end
         end
       end
@@ -651,25 +737,16 @@ local function format_skeleton(entries, test_lines, module_doc, import_sep)
   end
 
   if test_lines and #test_lines > 0 then
-    local min_t, max_t = MAX_INT, 0
-    for _, l in ipairs(test_lines) do
-      if l < min_t then
-        min_t = l
-      end
-      if l > max_t then
-        max_t = l
-      end
-    end
     if #out > 0 then
       out[#out + 1] = ""
     end
-    out[#out + 1] = "tests: " .. format_range(min_t, max_t)
+    emit_section("tests: ", lines_range(test_lines))
   end
 
   if #out == 0 then
-    return ""
+    return "", {}
   end
-  return table.concat(out, "\n") .. "\n"
+  return table.concat(out, "\n") .. "\n", meta
 end
 
 local U = {
@@ -682,6 +759,7 @@ local U = {
   line_end = line_end,
   find_child = find_child,
   compact_ws = compact_ws,
+  TRUNCATED_SUFFIX = TRUNCATED_SUFFIX,
   truncate = truncate,
   truncated_msg = truncated_msg,
   new_entry = new_entry,
@@ -689,6 +767,7 @@ local U = {
   simple_import = simple_import,
   expand_import = expand_import,
   format_range = format_range,
+  ranged = ranged,
   prefixed = prefixed,
   extract_enum_variants = extract_enum_variants,
   extract_fields_truncated = extract_fields_truncated,
@@ -805,8 +884,17 @@ local function index_source(source, lang_name)
   return extractor(source, root)
 end
 
+local LANG_TO_EXT = {}
+for ext, lang in pairs(EXT_TO_LANG) do
+  if not LANG_TO_EXT[lang] then
+    LANG_TO_EXT[lang] = ext
+  end
+end
+
 return {
   index_source = index_source,
   EXT_TO_LANG = EXT_TO_LANG,
+  LANG_TO_EXT = LANG_TO_EXT,
   FILENAME_TO_LANG = FILENAME_TO_LANG,
+  TRUNCATED_SUFFIX = TRUNCATED_SUFFIX,
 }

--- a/plugins/index/init.lua
+++ b/plugins/index/init.lua
@@ -2,86 +2,108 @@ local indexer = require("indexer")
 local ToolView = require("maki.tool_view")
 local shorten_path = require("maki.shorten_path")
 
-local KEYWORDS = {
-  pub = true,
-  fn = true,
-  struct = true,
-  enum = true,
-  trait = true,
-  type = true,
-  impl = true,
-  mod = true,
-  const = true,
-  static = true,
-  async = true,
-  class = true,
-  interface = true,
-  export = true,
-  ["macro_rules!"] = true,
-}
+local TRUNCATED_SUFFIX = indexer.TRUNCATED_SUFFIX
+local TRUNCATED_INFIX = " more truncated]"
 
-local function extract_line_range(line)
-  local pos = line:find("%[%d[%d%-%,% ]*%]$")
-  if not pos or pos <= 1 then
-    return nil
+local function split_trailing_range(line)
+  local pos = line:find(" %[%d[%d%-,]*%]$")
+  if not pos then
+    return nil, nil
   end
-  return line:sub(1, pos - 1), line:sub(pos)
-end
-
-local function append_styled(view, line, style)
-  local text, range = extract_line_range(line)
-  if range then
-    view:append({ { text, style }, { range, "line_nr" } })
-  else
-    view:append({ { line, style } })
-  end
-end
-
-local function append_entry(view, line)
-  local indent = line:sub(1, 2) == "  " and "  " or ""
-  local content = line:sub(#indent + 1)
-
-  local spans = {}
-  if indent ~= "" then
-    spans[#spans + 1] = { indent }
-  end
-
-  for kw in pairs(KEYWORDS) do
-    local next_char = content:sub(#kw + 1, #kw + 1)
-    if content:sub(1, #kw) == kw and (next_char == " " or next_char == "(") then
-      spans[#spans + 1] = { kw, "keyword" }
-      content = content:sub(#kw + 1)
-      break
-    end
-  end
-
-  local text, range = extract_line_range(content)
-  if range then
-    spans[#spans + 1] = { text, "tool" }
-    spans[#spans + 1] = { range, "line_nr" }
-  else
-    spans[#spans + 1] = { content, "tool" }
-  end
-
-  view:append(spans)
+  return line:sub(1, pos - 1), line:sub(pos + 1)
 end
 
 local function is_section_header(line)
+  if line:sub(1, 1) == " " then
+    return false
+  end
   local trimmed = line:match("^(.-)%s*$")
-  return trimmed:sub(-1) == ":" or (trimmed:sub(-1) == "]" and trimmed:find(": %[") ~= nil)
+  if trimmed:sub(-1) == ":" then
+    return true
+  end
+  local body = split_trailing_range(trimmed)
+  return body ~= nil and body:sub(-1) == ":"
 end
 
-local function render_skeleton(view, text)
+local function infer_line_meta(line)
+  if line == "" then
+    return nil
+  end
+  if is_section_header(line) then
+    local body, range = split_trailing_range(line)
+    if range then
+      return { tag = "section", body = body .. " ", range = range }
+    end
+    return { tag = "section" }
+  end
+  if
+    line:sub(-#TRUNCATED_SUFFIX) == TRUNCATED_SUFFIX
+    or (line:match("^%s*%[") and line:sub(-#TRUNCATED_INFIX) == TRUNCATED_INFIX)
+  then
+    return { tag = "dim" }
+  end
+  local body, range = split_trailing_range(line)
+  if range then
+    return { body = body, range = range }
+  end
+  return nil
+end
+
+local function render_skeleton(view, text, meta)
   text = text:gsub("\n+$", "") .. "\n"
+  local hl_entries = {}
+  local line_nr = 0
   for line in text:gmatch("([^\n]*)\n") do
+    line_nr = line_nr + 1
+    local m = (meta and meta[line_nr]) or infer_line_meta(line)
     if line == "" then
       view:append("")
-    elseif is_section_header(line) then
-      append_styled(view, line, "section")
+    elseif m and m.tag == "section" then
+      if m.range then
+        view:append({ { m.body, "section" }, { m.range, "line_nr" } })
+      else
+        view:append({ { line, "section" } })
+      end
+    elseif m and m.tag == "dim" then
+      view:append({ { line, "dim" } })
+    elseif m and m.range then
+      view:append({ { m.body }, { " " }, { m.range, "line_nr" } })
+      hl_entries[#hl_entries + 1] = { idx = #view.all_lines, text = m.body, range = m.range }
     else
-      append_entry(view, line)
+      view:append({ { line } })
+      hl_entries[#hl_entries + 1] = { idx = #view.all_lines, text = line }
     end
   end
+  return hl_entries
+end
+
+local function apply_highlights(view, hl_entries, ext)
+  if #hl_entries == 0 then
+    return
+  end
+  local texts = {}
+  for _, e in ipairs(hl_entries) do
+    texts[#texts + 1] = e.text
+  end
+  local highlighted = maki.ui.highlight(table.concat(texts, "\n"), ext, { independent = true })
+  if not highlighted then
+    return
+  end
+  for i, e in ipairs(hl_entries) do
+    local hl_spans = highlighted[i]
+    if hl_spans then
+      local new_line = {}
+      for _, span in ipairs(hl_spans) do
+        new_line[#new_line + 1] = span
+      end
+      if e.range then
+        new_line[#new_line + 1] = { " " }
+        new_line[#new_line + 1] = { e.range, "line_nr" }
+      end
+      view:update_line(e.idx, new_line)
+    end
+  end
+  view:flush()
 end
 
 local function render_header(path, line_count)
@@ -94,7 +116,7 @@ local function render_header(path, line_count)
   return buf
 end
 
-local function render_index(skeleton, path, ctx)
+local function render_index(skeleton, path, ctx, ext, line_meta)
   local tol = ctx:tool_output_lines()
   local buf = maki.ui.buf()
   local view = ToolView.new(buf, {
@@ -104,8 +126,15 @@ local function render_index(skeleton, path, ctx)
   buf:on("click", function()
     view:toggle()
   end)
-  render_skeleton(view, skeleton)
+  local hl_entries = render_skeleton(view, skeleton, line_meta)
   view:finish()
+
+  if ext then
+    maki.async.run(function()
+      apply_highlights(view, hl_entries, ext)
+    end)
+  end
+
   local line_count = select(2, skeleton:gsub("\n", "\n")) + 1
   return buf, render_header(path, line_count)
 end
@@ -140,7 +169,8 @@ Return a compact overview of a source file: imports, type definitions, function 
     return render_header(input.path)
   end,
   restore = function(input, output, _is_error, ctx)
-    local buf, header = render_index(output, input.path, ctx)
+    local ext = input.path:match("%.([^%.]+)$") or ""
+    local buf, header = render_index(output, input.path, ctx, ext)
     return { body = buf, header = header }
   end,
   handler = function(input, ctx)
@@ -174,7 +204,7 @@ Return a compact overview of a source file: imports, type definitions, function 
 
     local config = ctx:config()
     local max_file_size = (config and config.index_max_file_size) or (2 * 1024 * 1024)
-    if meta_ok and meta.size > max_file_size then
+    if meta and meta.size > max_file_size then
       return "error: File too large ("
         .. meta.size
         .. " bytes, max "
@@ -187,12 +217,13 @@ Return a compact overview of a source file: imports, type definitions, function 
       return "error: " .. err
     end
 
-    local skeleton, err = indexer.index_source(source, lang)
+    local skeleton, line_meta = indexer.index_source(source, lang)
     if not skeleton then
-      return "error: " .. tostring(err)
+      return "error: " .. tostring(line_meta)
     end
 
-    local buf, header = render_index(skeleton, path, ctx)
+    local ext = indexer.LANG_TO_EXT[lang] or path:match("%.([^%.]+)$") or ""
+    local buf, header = render_index(skeleton, path, ctx, ext, line_meta)
     return {
       llm_output = skeleton:gsub("\n+$", ""),
       body = buf,

--- a/plugins/index/lang/bazel/render.lua
+++ b/plugins/index/lang/bazel/render.lua
@@ -9,7 +9,6 @@ local INDENT_WIDTH = 2
 
 return function(U)
   local format_range = U.format_range
-
   local R = {}
 
   local function render_lines(header_line, items, render_fn)
@@ -40,6 +39,14 @@ return function(U)
     return table.concat(fields, " ")
   end
 
+  local function join_line_range_first(text, line_range)
+    if not text:find("\n", 1, true) then
+      return join_line(text, line_range)
+    end
+    local first_nl = text:find("\n", 1, true)
+    return text:sub(1, first_nl - 1) .. " " .. line_range .. text:sub(first_nl)
+  end
+
   function R.append_section_if_present(sections, section)
     if section then
       sections[#sections + 1] = section
@@ -58,16 +65,29 @@ return function(U)
     return format_range(item.line_start, item.line_end)
   end
 
+  local function indent_continuation(text, prefix)
+    if not text:find("\n", 1, true) then
+      return text
+    end
+    return (text:gsub("\n", "\n" .. prefix))
+  end
+
   function R.item_line(value, line_range, opts)
     local indent_level = opts and opts.indent or DEFAULT_INDENT_LEVEL
+    local prefix = indent(indent_level)
 
-    return join_line(indent(indent_level) .. value, line_range)
+    return join_line_range_first(prefix .. indent_continuation(value, prefix), line_range)
   end
 
   function R.label_line(label, value, line_range, opts)
     local indent_level = opts and opts.indent or DEFAULT_INDENT_LEVEL
+    local prefix = indent(indent_level)
+    local text = prefix .. label .. ":"
+    if value and value ~= "" then
+      text = text .. " " .. indent_continuation(value, prefix)
+    end
 
-    return join_line(indent(indent_level) .. label .. ":", value, line_range)
+    return join_line_range_first(text, line_range)
   end
 
   function R.render_doc(kind, collected)

--- a/plugins/index/lang/c.lua
+++ b/plugins/index/lang/c.lua
@@ -3,9 +3,6 @@ return function(U)
   local find_child = U.find_child
   local compact_ws = U.compact_ws
   local truncate = U.truncate
-  local format_range = U.format_range
-  local line_start = U.line_start
-  local line_end = U.line_end
   local new_entry = U.new_entry
   local new_import_entry = U.new_import_entry
   local SECTION = U.SECTION
@@ -65,8 +62,7 @@ return function(U)
   local function field_format(child, source)
     local raw = get_text(child, source)
     raw = raw:gsub(";%s*$", "")
-    local lr = format_range(line_start(child), line_end(child))
-    return compact_ws(raw):match("^%s*(.-)%s*$") .. " " .. lr
+    return compact_ws(raw):match("^%s*(.-)%s*$")
   end
 
   local function extract_struct(node, source)

--- a/plugins/index/lang/elixir.lua
+++ b/plugins/index/lang/elixir.lua
@@ -7,6 +7,7 @@ return function(U)
   local line_end = U.line_end
   local new_entry = U.new_entry
   local new_import_entry = U.new_import_entry
+  local ranged = U.ranged
   local SECTION = U.SECTION
 
   local DEF = "def"
@@ -158,7 +159,7 @@ return function(U)
             local t = call_target(child, source)
             local prefix = t == DEFP and "defp " or "def "
             local lr = format_range(line_start(child), line_end(child))
-            methods[#methods + 1] = compact_ws(prefix .. sig) .. " " .. lr
+            methods[#methods + 1] = ranged(compact_ws(prefix .. sig), lr)
           end
         end
       end

--- a/plugins/index/lang/go.lua
+++ b/plugins/index/lang/go.lua
@@ -9,6 +9,7 @@ return function(U)
   local new_import_entry = U.new_import_entry
   local truncate = U.truncate
   local extract_fields_truncated = U.extract_fields_truncated
+  local ranged = U.ranged
   local SECTION = U.SECTION
 
   local function strip_quotes(s)
@@ -113,11 +114,11 @@ return function(U)
                     local mname = get_text(mname_node, source)
                     local msig = mname .. params_result(m, source)
                     local lr = format_range(line_start(m), line_end(m))
-                    members[#members + 1] = compact_ws(msig) .. " " .. lr
+                    members[#members + 1] = ranged(compact_ws(msig), lr)
                   end
                 elseif mkind == "type_elem" then
                   local lr = format_range(line_start(m), line_end(m))
-                  members[#members + 1] = truncate(get_text(m, source), 60) .. " " .. lr
+                  members[#members + 1] = ranged(truncate(get_text(m, source), 60), lr)
                 end
               end
               entry.children = members

--- a/plugins/index/lang/kotlin.lua
+++ b/plugins/index/lang/kotlin.lua
@@ -11,6 +11,7 @@ return function(U)
   local FIELD_TRUNCATE_THRESHOLD = U.FIELD_TRUNCATE_THRESHOLD
   local CHILD_BRIEF = U.CHILD_BRIEF
   local truncated_msg = U.truncated_msg
+  local ranged = U.ranged
 
   local function modifiers_text(node, source)
     local mods = find_child(node, "modifiers")
@@ -130,7 +131,7 @@ return function(U)
         local sig = fn_sig(child, source)
         if sig then
           local lr = format_range(line_start(child), line_end(child))
-          members[#members + 1] = sig .. " " .. lr
+          members[#members + 1] = ranged(sig, lr)
         end
       elseif ck == "property_declaration" then
         prop_count = prop_count + 1
@@ -138,7 +139,7 @@ return function(U)
           local text = property_text(child, source)
           if text then
             local lr = format_range(line_start(child), line_end(child))
-            members[#members + 1] = text .. " " .. lr
+            members[#members + 1] = ranged(text, lr)
           end
         end
       elseif ck == "companion_object" then

--- a/plugins/index/lang/python.lua
+++ b/plugins/index/lang/python.lua
@@ -8,6 +8,7 @@ return function(U)
   local truncate = U.truncate
   local new_entry = U.new_entry
   local new_import_entry = U.new_import_entry
+  local ranged = U.ranged
   local SECTION = U.SECTION
 
   local function is_module_doc(node, source)
@@ -87,7 +88,7 @@ return function(U)
             end
           end
         end
-        methods[#methods + 1] = compact_ws(fn_name .. params .. ret_str .. " " .. lr)
+        methods[#methods + 1] = ranged(compact_ws(fn_name .. params .. ret_str), lr)
       end
     end
     local entry = new_entry(SECTION.Class, node, name)

--- a/plugins/index/lang/ruby.lua
+++ b/plugins/index/lang/ruby.lua
@@ -7,6 +7,7 @@ return function(U)
   local line_end = U.line_end
   local new_entry = U.new_entry
   local new_import_entry = U.new_import_entry
+  local ranged = U.ranged
   local truncate = U.truncate
   local SECTION = U.SECTION
 
@@ -74,7 +75,7 @@ return function(U)
           sig = inner and ("self." .. inner) or nil
         end
         if sig then
-          methods[#methods + 1] = sig .. " " .. format_range(line_start(child), line_end(child))
+          methods[#methods + 1] = ranged(sig, format_range(line_start(child), line_end(child)))
         end
       end
     end

--- a/plugins/index/lang/rust.lua
+++ b/plugins/index/lang/rust.lua
@@ -13,6 +13,7 @@ return function(U)
   local FIELD_TRUNCATE_THRESHOLD = U.FIELD_TRUNCATE_THRESHOLD
   local CHILD_BRIEF = U.CHILD_BRIEF
   local prefixed = U.prefixed
+  local ranged = U.ranged
 
   local function vis_prefix(node, source)
     for _, child in ipairs(node:children()) do
@@ -102,9 +103,9 @@ return function(U)
           local lr = format_range(line_start(child), line_end(child))
           if include_vis then
             local v = vis_prefix(child, source)
-            methods[#methods + 1] = prefixed(v, sig) .. " " .. lr
+            methods[#methods + 1] = ranged(prefixed(v, sig), lr)
           else
-            methods[#methods + 1] = sig .. " " .. lr
+            methods[#methods + 1] = ranged(sig, lr)
           end
         end
       end

--- a/plugins/index/lang/swift.lua
+++ b/plugins/index/lang/swift.lua
@@ -11,6 +11,7 @@ return function(U)
   local format_range = U.format_range
   local line_start = U.line_start
   local line_end = U.line_end
+  local ranged = U.ranged
 
   local function modifiers_text(node, source)
     local mods = find_child(node, "modifiers")
@@ -153,13 +154,13 @@ return function(U)
         end
         local lr = format_range(line_start(child), line_end(child))
         if #cases > 0 then
-          children[#children + 1] = table.concat(cases, ", ") .. " " .. lr
+          children[#children + 1] = ranged(table.concat(cases, ", "), lr)
         end
       elseif ckind == "function_declaration" then
         local sig = swift_fn_signature(child, source)
         if sig then
           local lr = format_range(line_start(child), line_end(child))
-          children[#children + 1] = sig .. " " .. lr
+          children[#children + 1] = ranged(sig, lr)
         end
       end
     end

--- a/plugins/index/lang/typescript.lua
+++ b/plugins/index/lang/typescript.lua
@@ -54,7 +54,7 @@ return function(U)
         local sig = class_member_sig(child, source)
         if sig then
           local lr = U.format_range(U.line_start(child), U.line_end(child))
-          methods[#methods + 1] = sig .. " " .. lr
+          methods[#methods + 1] = U.ranged(sig, lr)
         end
       elseif ckind == "public_field_definition" or ckind == "property_definition" then
         local counter = "field"
@@ -63,7 +63,7 @@ return function(U)
           local sig = class_member_sig(child, source)
           if sig then
             local lr = U.format_range(U.line_start(child), U.line_end(child))
-            methods[#methods + 1] = sig .. " " .. lr
+            methods[#methods + 1] = U.ranged(sig, lr)
           end
         end
       end

--- a/plugins/index/lang/zig.lua
+++ b/plugins/index/lang/zig.lua
@@ -1,9 +1,6 @@
 return function(U)
   local get_text = U.get_text
   local find_child = U.find_child
-  local format_range = U.format_range
-  local line_start = U.line_start
-  local line_end = U.line_end
   local new_entry = U.new_entry
   local new_import_entry = U.new_import_entry
   local compact_ws = U.compact_ws
@@ -105,8 +102,7 @@ return function(U)
       local fname = field_name_node and get_text(field_name_node, src) or "_"
       local ftype = field_type_node and get_text(field_type_node, src) or ""
       local text = ftype ~= "" and (fname .. ": " .. ftype) or fname
-      local lr = format_range(line_start(f), line_end(f))
-      return text .. " " .. lr
+      return text
     end)
     return entry
   end

--- a/plugins/index/tests/helpers.lua
+++ b/plugins/index/tests/helpers.lua
@@ -24,6 +24,12 @@ function M.idx(source, lang)
   return result
 end
 
+function M.idx_with_meta(source, lang)
+  local result, meta = indexer.index_source(source, lang)
+  assert(result, "index failed for " .. lang .. ": " .. tostring(meta))
+  return result, meta
+end
+
 function M.has(output, needles)
   for _, n in ipairs(needles) do
     assert(output:find(n, 1, true), "missing '" .. n .. "'")
@@ -34,6 +40,63 @@ function M.lacks(output, needles)
   for _, n in ipairs(needles) do
     assert(not output:find(n, 1, true), "unexpected '" .. n .. "'")
   end
+end
+
+function M.split_lines(text)
+  local lines = {}
+  for line in (text:gsub("\n+$", "") .. "\n"):gmatch("([^\n]*)\n") do
+    lines[#lines + 1] = line
+  end
+  return lines
+end
+
+function M.assert_ranged_meta(text, meta, needles)
+  local lines = M.split_lines(text)
+  local found = 0
+  for i, line in ipairs(lines) do
+    for _, needle in ipairs(needles) do
+      if line:find(needle, 1, true) then
+        local m = meta and meta[i]
+        assert(m, "missing meta for line " .. i .. ": " .. line)
+        assert(m.body, "missing body in meta for line " .. i)
+        assert(m.range, "missing range in meta for line " .. i)
+        found = found + 1
+        break
+      end
+    end
+  end
+  assert(found >= #needles, "expected " .. #needles .. " ranged lines, got " .. found)
+end
+
+function M.assert_truncated_dim(text, meta)
+  local lines = M.split_lines(text)
+  for i, line in ipairs(lines) do
+    if line:find("more truncated]", 1, true) then
+      local m = meta and meta[i]
+      assert(m, "truncated line " .. i .. " has no meta")
+      assert(m.tag == "dim", "truncated line " .. i .. " tag is '" .. tostring(m.tag) .. "', expected 'dim'")
+      return
+    end
+  end
+  error("no truncated line found in output")
+end
+
+function M.assert_fields_no_ranged_meta(text, meta, struct_needle, field_needles)
+  local lines = M.split_lines(text)
+  local struct_found = false
+  for i, line in ipairs(lines) do
+    local m = meta and meta[i]
+    if line:find(struct_needle, 1, true) then
+      struct_found = true
+      assert(m and m.range, struct_needle .. " line should have range in meta")
+    end
+    for _, f in ipairs(field_needles) do
+      if line:find(f, 1, true) then
+        assert(not (m and m.body and m.range), "field line should not have ranged meta: " .. line)
+      end
+    end
+  end
+  assert(struct_found, struct_needle .. " not found in output")
 end
 
 function M.report()

--- a/plugins/index/tests/indexer_core.lua
+++ b/plugins/index/tests/indexer_core.lua
@@ -1,0 +1,78 @@
+local helpers = require("tests.helpers")
+local case = helpers.case
+local idx_with_meta = helpers.idx_with_meta
+
+local function meta_count(meta)
+  local n = 0
+  for _ in pairs(meta) do
+    n = n + 1
+  end
+  return n
+end
+
+case("core_empty_and_trivial_source_returns_empty_meta", function()
+  local cases = {
+    { "", "empty" },
+    { "   \n  \n\n", "whitespace-only" },
+    { "// just a comment\n/* block comment */\n", "comments-only" },
+  }
+  for _, c in ipairs(cases) do
+    local text, meta = idx_with_meta(c[1], "rust")
+    assert(text == "", "expected empty text for " .. c[2] .. ", got: '" .. text .. "'")
+    assert(meta_count(meta) == 0, "expected empty meta for " .. c[2])
+  end
+end)
+
+case("core_meta_every_section_has_tag", function()
+  local src = [[
+use std::io;
+
+const MAX: usize = 42;
+
+pub struct Foo { x: i32 }
+
+pub trait Bar { fn bar(&self); }
+
+impl Foo { fn baz(&self) {} }
+
+pub fn run() {}
+
+pub mod utils;
+
+macro_rules! m { () => {}; }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {}
+}
+]]
+  local text, meta = idx_with_meta(src, "rust")
+  local lines = helpers.split_lines(text)
+  local section_headers = {
+    "imports:",
+    "consts:",
+    "types:",
+    "traits:",
+    "impls:",
+    "fns:",
+    "mod:",
+    "macros:",
+    "tests:",
+  }
+  for _, hdr in ipairs(section_headers) do
+    local found = false
+    for i, line in ipairs(lines) do
+      if line:find(hdr, 1, true) then
+        found = true
+        local m = meta[i]
+        assert(m, "section header '" .. hdr .. "' at line " .. i .. " has no meta")
+        assert(
+          m.tag == "section",
+          "section header '" .. hdr .. "' tag is '" .. tostring(m.tag) .. "', expected 'section'"
+        )
+      end
+    end
+    assert(found, "section header '" .. hdr .. "' not found in output")
+  end
+end)

--- a/plugins/index/tests/lang/bazel.lua
+++ b/plugins/index/tests/lang/bazel.lua
@@ -1,6 +1,7 @@
 local helpers = require("tests.helpers")
 local case = helpers.case
 local idx = helpers.idx
+local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has
 local lacks = helpers.lacks
 
@@ -411,15 +412,17 @@ loads:
 
 variable bindings:
   __MAX_ITERATIONS__ = 2 << 31 - 2 [22]
-  _BRACKETS = {
-    "close": {
-        "dict": "}",
-        "li[truncated] [24-35]
+  _BRACKETS = { [24-35]
+      "close": {
+          "dict": "}",
+          "li
+  [truncated]
   _FN_SENTINEL = "__starlark_fn__" [37]
   _FN_ARGS = "__starlark_fn_args__" [38]
-  foobar = struct(
-    bar = _bar,
-    lbar = lambda arg, **[truncated] [66-73]
+  foobar = struct( [66-73]
+      bar = _bar,
+      lbar = lambda arg, **
+  [truncated]
 
 functions:
   _foo(s) [40-41]
@@ -927,4 +930,76 @@ case("bazel_module_inline_comment_in_bazel_dep", function()
   local out = idx(src, "bazel_module")
   has(out, { '"@protobuf": "31.1"' })
   lacks(out, { "use latest version" })
+end)
+
+case("bazel_ranges_at_end_of_line", function()
+  local src = [==[
+cc_library(
+    name = "foo",
+    srcs = ["a.cc", "b.cc"],
+    deps = [
+        "//lib:bar",
+        "//lib:baz",
+    ],
+)
+
+FOO = 42]==]
+  local out = idx(src, "bazel_build")
+  local lines = helpers.split_lines(out)
+  for _, line in ipairs(lines) do
+    if line:find("foo: cc_library", 1, true) then
+      assert(line:find("%[%d+%-%d+%]$"), "multiline range not at end: " .. line)
+    end
+    if line:find("FOO: 42", 1, true) then
+      assert(line:match("%[%d+%]$"), "single-line range not at end: " .. line)
+    end
+  end
+end)
+
+case("bazel_multiline_continuation_indented", function()
+  local src = [==[
+MY_DICT = {
+    "key1": "val1",
+    "key2": "val2",
+}]==]
+  local out = idx(src, "bazel_bzl")
+  local lines = helpers.split_lines(out)
+  local in_binding = false
+  for _, line in ipairs(lines) do
+    if line:find("MY_DICT", 1, true) then
+      in_binding = true
+    elseif in_binding then
+      if line:find("%S") then
+        if line:find("MY_DICT", 1, true) or line:find("functions:", 1, true) or line:find("loads:", 1, true) then
+          break
+        end
+        assert(line:match("^%s"), "continuation line not indented: '" .. line .. "'")
+      end
+    end
+  end
+  assert(in_binding, "MY_DICT binding not found in output:\n" .. out)
+end)
+
+case("bazel_truncated_multiline_marker_on_own_line", function()
+  local src = [==[
+_BRACKETS = {
+    "close": {
+        "dict": "}",
+        "list": "]",
+        "tuple": ")",
+    },
+    "open": {
+        "dict": "{",
+        "list": "[",
+        "tuple": "(",
+    },
+}]==]
+  local out = idx(src, "bazel_bzl")
+  has(out, { "[truncated]" })
+  local lines = helpers.split_lines(out)
+  for _, line in ipairs(lines) do
+    if line:find("%[truncated%]") then
+      assert(line:match("^%s+%[truncated%]$"), "[truncated] not on its own indented line: '" .. line .. "'")
+    end
+  end
 end)

--- a/plugins/index/tests/lang/c.lua
+++ b/plugins/index/tests/lang/c.lua
@@ -5,7 +5,9 @@
 local helpers = require("tests.helpers")
 local case = helpers.case
 local idx = helpers.idx
+local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has
+local lacks = helpers.lacks
 
 case("c_all_sections", function()
   local src = [==[
@@ -216,6 +218,37 @@ void process(const char *input, size_t len);
       "void process(const char *input, size_t len)",
     })
   end
+end)
+
+case("c_struct_fields_are_plain_children", function()
+  local src = [==[
+struct Config {
+    int port;
+    char *host;
+    int timeout;
+};
+]==]
+  local text, meta = idx_with_meta(src, "c")
+  helpers.assert_fields_no_ranged_meta(text, meta, "struct Config", { "int port", "int timeout" })
+end)
+
+case("c_many_fields_truncated_dim_meta", function()
+  local src = [==[
+struct Big {
+    int a;
+    int b;
+    int c;
+    int d;
+    int e;
+    int f;
+    int g;
+    int h;
+    int i;
+    int j;
+};
+]==]
+  local text, meta = idx_with_meta(src, "c")
+  helpers.assert_truncated_dim(text, meta)
 end)
 
 case("c_single_include_pragma", function()

--- a/plugins/index/tests/lang/elixir.lua
+++ b/plugins/index/tests/lang/elixir.lua
@@ -1,6 +1,7 @@
 local helpers = require("tests.helpers")
 local case = helpers.case
 local idx = helpers.idx
+local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has
 
 case("elixir_all_sections", function()
@@ -51,4 +52,20 @@ end
     "fns:",
     "handle_event(event, state)",
   })
+end)
+
+case("elixir_module_methods_have_ranged_meta", function()
+  local src = [==[
+defmodule Calculator do
+  def add(a, b) do
+    a + b
+  end
+
+  defp validate(x) do
+    x > 0
+  end
+end
+]==]
+  local text, meta = idx_with_meta(src, "elixir")
+  helpers.assert_ranged_meta(text, meta, { "add", "validate" })
 end)

--- a/plugins/index/tests/lang/go.lua
+++ b/plugins/index/tests/lang/go.lua
@@ -1,6 +1,7 @@
 local helpers = require("tests.helpers")
 local case = helpers.case
 local idx = helpers.idx
+local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has
 
 case("go_all_sections", function()
@@ -63,4 +64,18 @@ func main() {
     "fns:",
     "main()",
   })
+end)
+
+case("go_interface_methods_have_ranged_meta", function()
+  local src = [==[
+package main
+
+type Storage interface {
+	Get(key string) (string, error)
+	Set(key string, value string) error
+	Delete(key string) error
+}
+]==]
+  local text, meta = idx_with_meta(src, "go")
+  helpers.assert_ranged_meta(text, meta, { "Get(key", "Set(key", "Delete(key" })
 end)

--- a/plugins/index/tests/lang/kotlin.lua
+++ b/plugins/index/tests/lang/kotlin.lua
@@ -1,6 +1,7 @@
 local helpers = require("tests.helpers")
 local case = helpers.case
 local idx = helpers.idx
+local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has
 
 case("kotlin_all_sections", function()
@@ -48,4 +49,20 @@ enum class Color {
     "fns:",
     "topLevel",
   })
+end)
+
+case("kotlin_class_members_have_ranged_meta", function()
+  local src = [==[
+class Account(val id: Int) {
+    val balance: Double = 0.0
+    fun deposit(amount: Double) {
+        println(amount)
+    }
+    fun withdraw(amount: Double): Boolean {
+        return true
+    }
+}
+]==]
+  local text, meta = idx_with_meta(src, "kotlin")
+  helpers.assert_ranged_meta(text, meta, { "deposit", "withdraw" })
 end)

--- a/plugins/index/tests/lang/python.lua
+++ b/plugins/index/tests/lang/python.lua
@@ -1,6 +1,7 @@
 local helpers = require("tests.helpers")
 local case = helpers.case
 local idx = helpers.idx
+local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has
 
 case("python_all_sections", function()
@@ -44,4 +45,17 @@ def process(data: list) -> dict:
     "fns:",
     "process(data: list) -> dict",
   })
+end)
+
+case("python_class_methods_have_ranged_meta", function()
+  local src = [==[class Repo:
+    def connect(self, url: str) -> None:
+        pass
+    def fetch(self, id: int) -> dict:
+        return {}
+    def close(self) -> None:
+        pass
+]==]
+  local text, meta = idx_with_meta(src, "python")
+  helpers.assert_ranged_meta(text, meta, { "connect(", "fetch(", "close(" })
 end)

--- a/plugins/index/tests/lang/ruby.lua
+++ b/plugins/index/tests/lang/ruby.lua
@@ -1,6 +1,7 @@
 local helpers = require("tests.helpers")
 local case = helpers.case
 local idx = helpers.idx
+local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has
 
 case("ruby_all_sections", function()
@@ -63,4 +64,19 @@ end
     "fns:",
     "standalone(x, y)",
   })
+end)
+
+case("ruby_class_methods_have_ranged_meta", function()
+  local src = [==[
+class Greeter
+  def hello(name)
+    puts name
+  end
+  def goodbye(name)
+    puts name
+  end
+end
+]==]
+  local text, meta = idx_with_meta(src, "ruby")
+  helpers.assert_ranged_meta(text, meta, { "hello", "goodbye" })
 end)

--- a/plugins/index/tests/lang/rust.lua
+++ b/plugins/index/tests/lang/rust.lua
@@ -1,6 +1,7 @@
 local helpers = require("tests.helpers")
 local case = helpers.case
 local idx = helpers.idx
+local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has
 local lacks = helpers.lacks
 
@@ -86,12 +87,35 @@ macro_rules! my_macro { () => {}; }
   })
 end)
 
-case("rust_many_fields_truncated", function()
-  local out = idx(
-    "struct Big {\n    a: u8,\n    b: u8,\n    c: u8,\n    d: u8,\n    e: u8,\n    f: u8,\n    g: u8,\n    h: u8,\n    i: u8,\n    j: u8,\n}\n",
-    "rust"
-  )
-  has(out, { "[2 more truncated]" })
+case("rust_truncated_children_tagged_dim", function()
+  local src = "struct Big {\n"
+  for i = 1, 10 do
+    src = src .. "    f" .. i .. ": u8,\n"
+  end
+  src = src .. "}\n"
+  local text, meta = idx_with_meta(src, "rust")
+  has(text, { "[2 more truncated]" })
+  helpers.assert_truncated_dim(text, meta)
+end)
+
+case("rust_struct_fields_no_ranged_meta", function()
+  local src = "pub struct Point {\n    pub x: f64,\n    pub y: f64,\n    pub z: f64,\n}\n"
+  local text, meta = idx_with_meta(src, "rust")
+  helpers.assert_fields_no_ranged_meta(text, meta, "pub struct Point", { "pub x:", "pub y:", "pub z:" })
+end)
+
+case("rust_impl_methods_have_ranged_meta", function()
+  local src = [[
+pub struct Widget;
+
+impl Widget {
+    pub fn new() -> Self { Widget }
+    pub fn render(&self) -> String { String::new() }
+    fn internal(&mut self, flag: bool) {}
+}
+]]
+  local text, meta = idx_with_meta(src, "rust")
+  helpers.assert_ranged_meta(text, meta, { "pub new()", "pub render(&self)", "internal(&mut self" })
 end)
 
 case("rust_test_module_collapsed", function()

--- a/plugins/index/tests/lang/swift.lua
+++ b/plugins/index/tests/lang/swift.lua
@@ -1,6 +1,7 @@
 local helpers = require("tests.helpers")
 local case = helpers.case
 local idx = helpers.idx
+local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has
 
 case("swift_all_sections", function()
@@ -57,4 +58,19 @@ let MAX_COUNT = 100
     "fns:",
     "process",
   })
+end)
+
+case("swift_class_methods_have_ranged_meta", function()
+  local src = [==[
+public class Engine {
+    public func start() {
+        print("started")
+    }
+    public func stop() {
+        print("stopped")
+    }
+}
+]==]
+  local text, meta = idx_with_meta(src, "swift")
+  helpers.assert_ranged_meta(text, meta, { "func start", "func stop" })
 end)

--- a/plugins/index/tests/lang/typescript.lua
+++ b/plugins/index/tests/lang/typescript.lua
@@ -1,6 +1,7 @@
 local helpers = require("tests.helpers")
 local case = helpers.case
 local idx = helpers.idx
+local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has
 
 case("ts_all_sections", function()
@@ -41,4 +42,15 @@ export function handler(req: Request): Response { return new Response(); }
     "fns:",
     "export handler(req: Request)",
   })
+end)
+
+case("ts_class_members_have_ranged_meta", function()
+  local src = [==[export class Router {
+    private routes: Map<string, Function>;
+    add(path: string, handler: Function): void { this.routes.set(path, handler); }
+    match(url: string): Function | null { return this.routes.get(url) || null; }
+}
+]==]
+  local text, meta = idx_with_meta(src, "typescript")
+  helpers.assert_ranged_meta(text, meta, { "add(", "match(" })
 end)

--- a/plugins/index/tests/lang/zig.lua
+++ b/plugins/index/tests/lang/zig.lua
@@ -1,6 +1,7 @@
 local helpers = require("tests.helpers")
 local case = helpers.case
 local idx = helpers.idx
+local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has
 
 case("zig_all_sections", function()
@@ -180,4 +181,15 @@ pub const Big = struct {
     "h: u8",
     "truncated",
   })
+end)
+
+case("zig_struct_fields_plain_children_no_meta", function()
+  local src = [==[
+pub const Point = struct {
+    x: f32,
+    y: f32,
+};
+]==]
+  local text, meta = idx_with_meta(src, "zig")
+  helpers.assert_fields_no_ranged_meta(text, meta, "struct Point", { "x: f32", "y: f32" })
 end)

--- a/plugins/index/tests/spec.lua
+++ b/plugins/index/tests/spec.lua
@@ -5,6 +5,7 @@
 -- existing file as a template) and adding a require line below — keep them
 -- alphabetized. Each spec uses the shared `case` helper from tests/helpers.lua,
 -- which collects failures so a single broken case does not abort the suite.
+require("tests.indexer_core")
 require("tests.lang.bash")
 require("tests.lang.bazel")
 require("tests.lang.c")


### PR DESCRIPTION
`format_skeleton()` now returns `(text, meta)` where `meta` tags each line as section, dim, or code with its range. `init.lua` feeds code lines through `maki.ui.highlight()` (syntect) for real syntax coloring, same approach as the `read` and `grep` plugins.

Multi-line truncated values used to be entirely dim. Now only the `[truncated]` line itself is dim, and the rest gets highlighted. Line ranges moved to the first line so weaker LLMs can associate the range with the declaration without scanning past the body.

All per-language extractors return `ranged()` structs instead of baking `[N-M]` into strings, so `init.lua` never has to regex-parse the output. Continuation lines of multi-line values get the entry's indent prefix, and `[truncated]` lines follow the same indentation. Bazel's custom renderer got a parallel set of fixes since it bypasses `format_skeleton()`.