### PR TITLE
feat(ui): display max context window size in the status bar

### DIFF
--- a/maki-ui/src/components/status_bar.rs
+++ b/maki-ui/src/components/status_bar.rs
@@ -185,8 +185,9 @@ impl StatusBar {
                 }
 
                 let rest_text = format!(
-                    "  {} ({}%) ${:.3} ",
+                    "  {}/{} ({}%) ${:.3} ",
                     format_tokens(ctx.stats.context_size),
+                    format_tokens(ctx.stats.context_window),
                     pct,
                     ctx.stats.usage.cost(ctx.stats.pricing, ctx.fast),
                 );


### PR DESCRIPTION
Display the maxium context window size alongside the current context size in the TUI's status bar (helps me diagnose/debug context size issues)