### PR TITLE
ui: replace fixed zone registry with push-list

### DIFF
--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -49,7 +49,7 @@ use crate::components::{
 };
 use crate::event_loop::BufClickHandler;
 use crate::image;
-use crate::selection::{SelectionState, SelectionZone, ZoneRegistry};
+use crate::selection::{SelectionState, ZoneRegistry};
 use arc_swap::{ArcSwap, ArcSwapOption};
 use crossterm::event::{KeyCode, KeyEvent, MouseEvent};
 use maki_agent::permissions::PermissionManager;
@@ -239,7 +239,7 @@ impl App {
             pending_input: PendingInput::None,
             run_id: 0,
             retry_info: None,
-            zones: [None; SelectionZone::COUNT],
+            zones: ZoneRegistry::new(),
             selection_state: None,
             clipboard: ClipboardState::new(),
             last_esc: None,
@@ -268,6 +268,10 @@ impl App {
 
     fn is_main_chat(&self) -> bool {
         self.active_chat == 0
+    }
+
+    fn plan_form_active(&self) -> bool {
+        self.state.mode == Mode::Plan && self.plan_form.is_visible()
     }
 
     pub(crate) fn update_model(&mut self, model: &Model) {
@@ -485,7 +489,7 @@ impl App {
         }
 
         // plan_form is non-modal: Passthrough falls through to the rest of dispatch
-        if self.state.mode == Mode::Plan && self.plan_form.is_visible() {
+        if self.plan_form_active() {
             let action = self.plan_form.handle_key(key);
             if action != PlanFormAction::Passthrough {
                 return Some(self.handle_plan_form_action(action));
@@ -1425,7 +1429,7 @@ impl App {
     }
 
     fn route_text_paste(&mut self, text: &str) {
-        if self.state.mode == Mode::Plan && self.plan_form.is_visible() {
+        if self.plan_form_active() {
             return;
         }
         if self.permission_prompt.handle_paste(text) {

--- a/maki-ui/src/app/mouse.rs
+++ b/maki-ui/src/app/mouse.rs
@@ -2,9 +2,7 @@ use std::time::{Duration, Instant};
 
 use crate::clipboard::CopyResult;
 use crate::components::messages::ClickResult;
-use crate::selection::{
-    self, ContentRegion, EdgeScroll, SelectableZone, Selection, SelectionState, SelectionZone,
-};
+use crate::selection::{self, ContentRegion, EdgeScroll, Selection, SelectionState, SelectionZone};
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;
 
@@ -191,7 +189,7 @@ impl App {
                 }];
                 selection::extract_selected_text(buf, &screen_sel, &regions)
             }
-            SelectionZone::StatusBar | SelectionZone::Overlay => {
+            SelectionZone::Overlay => {
                 let scroll = self.scroll_offset(sel.zone);
                 let Some(screen_sel) = sel.to_screen(scroll) else {
                     self.selection_state = None;
@@ -213,15 +211,15 @@ impl App {
         self.selection_state = None;
     }
 
-    pub(super) fn zone_at(&self, row: u16, col: u16) -> Option<SelectableZone> {
-        selection::zone_at(&self.zones, row, col)
+    pub(super) fn zone_at(&self, row: u16, col: u16) -> Option<selection::SelectableZone> {
+        self.zones.zone_at(row, col)
     }
 
     pub(super) fn scroll_offset(&self, zone: SelectionZone) -> u32 {
         match zone {
             SelectionZone::Messages => self.chats[self.active_chat].scroll_top() as u32,
             SelectionZone::Input => self.input_box.scroll_y() as u32,
-            SelectionZone::StatusBar | SelectionZone::Overlay => 0,
+            SelectionZone::Overlay => 0,
         }
     }
 
@@ -229,13 +227,17 @@ impl App {
         match zone {
             SelectionZone::Messages => self.chats[self.active_chat].scroll(delta),
             SelectionZone::Input => self.input_box.scroll(delta),
-            SelectionZone::StatusBar | SelectionZone::Overlay => {}
+            SelectionZone::Overlay => {}
         }
     }
 
     pub(super) fn msg_area(&self) -> Rect {
-        self.zones[SelectionZone::Messages.idx()]
-            .map(|z| z.highlight_area)
+        self.zones
+            .find(SelectionZone::Messages)
+            .map(|z| {
+                let a = z.area;
+                Rect::new(a.x, a.y, a.width.saturating_sub(1), a.height)
+            })
             .unwrap_or_default()
     }
 }

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -23,11 +23,7 @@ use tempfile::TempDir;
 use test_case::test_case;
 
 fn set_zone(app: &mut App, zone: SelectionZone, area: Rect) {
-    app.zones[zone.idx()] = Some(SelectableZone {
-        area,
-        highlight_area: area,
-        zone,
-    });
+    app.zones.push(SelectableZone { area, zone });
 }
 
 fn test_app() -> App {
@@ -1356,22 +1352,6 @@ fn stale_done_does_not_drain_queue() {
     ));
     assert_eq!(app.queue.len(), 1);
     assert_eq!(app.status, Status::Idle);
-}
-
-#[test]
-fn zone_at_returns_correct_zone() {
-    let mut app = test_app();
-    let msg = Rect::new(0, 0, 80, 15);
-    let input = Rect::new(0, 15, 80, 5);
-    let status = Rect::new(0, 20, 80, 1);
-    set_zone(&mut app, SelectionZone::Messages, msg);
-    set_zone(&mut app, SelectionZone::Input, input);
-    set_zone(&mut app, SelectionZone::StatusBar, status);
-
-    assert_eq!(app.zone_at(5, 10).unwrap().zone, SelectionZone::Messages);
-    assert_eq!(app.zone_at(16, 10).unwrap().zone, SelectionZone::Input);
-    assert_eq!(app.zone_at(20, 10).unwrap().zone, SelectionZone::StatusBar);
-    assert!(app.zone_at(22, 10).is_none());
 }
 
 #[test]

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -6,7 +6,7 @@ use crate::components::keybindings::KeybindContext;
 use crate::components::queue_panel;
 use crate::components::split_layout::{MIN_CHAT_ROWS, SplitLayout, carve};
 use crate::components::status_bar::{StatusBarContext, UsageStats};
-use crate::selection::{self, SelectableZone, SelectionZone};
+use crate::selection::{self, SelectableZone, SelectionZone, ZoneRegistry};
 use crate::theme;
 use maki_lua::Split;
 use ratatui::Frame;
@@ -24,15 +24,14 @@ struct ViewLayout {
     panel_windows: Vec<(usize, Rect)>,
     input_area: Rect,
     splits: SplitLayout,
+    bottom_takeover: bool,
 }
 
 impl App {
     pub fn view(&mut self, frame: &mut Frame) {
         self.status_bar.clear_expired_hint();
 
-        let in_plan = self.state.mode == Mode::Plan;
-        let form_visible =
-            self.permission_prompt.is_open() || (in_plan && self.plan_form.is_visible());
+        let form_visible = self.permission_prompt.is_open() || self.plan_form_active();
         let layout = self.compute_layout(frame.area(), form_visible);
         let render_chat = self.resolve_render_chat();
 
@@ -129,6 +128,7 @@ impl App {
             panel_windows,
             input_area,
             splits,
+            bottom_takeover,
         }
     }
 
@@ -155,7 +155,6 @@ impl App {
     }
 
     fn render_bottom_panel(&mut self, frame: &mut Frame, layout: &ViewLayout) {
-        let in_plan = self.state.mode == Mode::Plan;
         if self.permission_prompt.is_open() {
             self.permission_prompt.view(frame, layout.bottom_area);
         } else if !self.is_main_chat() {
@@ -187,7 +186,7 @@ impl App {
                 .borders(Borders::TOP)
                 .border_style(self.separator_style());
             frame.render_widget(sep, sep_area);
-        } else if in_plan && self.plan_form.is_visible() {
+        } else if self.plan_form_active() {
             self.plan_form.view(frame, layout.bottom_area);
         } else if layout.bottom_area.height > 0 {
             let queue_entries = self.queue.panel_entries();
@@ -196,7 +195,7 @@ impl App {
                 self.float_mgr.view_panel(frame, idx, rect);
             }
             let streaming = self.status == Status::Streaming;
-            let panel_hint = in_plan
+            let panel_hint = (self.state.mode == Mode::Plan)
                 .then(|| self.plan_form.hint_line())
                 .flatten()
                 .or_else(|| self.lua_hint_line());
@@ -312,55 +311,62 @@ impl App {
     }
 
     fn register_zones(&mut self, layout: &ViewLayout, overlay_rect: Rect) {
-        self.zones[SelectionZone::Messages.idx()] = Some(SelectableZone {
+        // Push order = z-order. zone_at() walks in reverse, so later entries win.
+        self.zones = ZoneRegistry::new();
+
+        self.zones.push(SelectableZone {
             area: layout.msg_area,
-            highlight_area: Rect::new(
-                layout.msg_area.x,
-                layout.msg_area.y,
-                layout.msg_area.width.saturating_sub(1),
-                layout.msg_area.height,
-            ),
             zone: SelectionZone::Messages,
         });
 
-        if layout.input_area.height > 0 {
+        if layout.input_area.height > 0 && !layout.bottom_takeover && self.is_main_chat() {
             let input_inner = Rect::new(
                 layout.input_area.x,
                 layout.input_area.y + 1,
                 layout.input_area.width,
                 layout.input_area.height.saturating_sub(2),
             );
-            self.zones[SelectionZone::Input.idx()] = Some(SelectableZone {
+            self.zones.push(SelectableZone {
                 area: input_inner,
-                highlight_area: input_inner,
                 zone: SelectionZone::Input,
             });
-        } else {
-            self.zones[SelectionZone::Input.idx()] = None;
         }
 
-        self.zones[SelectionZone::StatusBar.idx()] = Some(SelectableZone {
-            area: layout.status_area,
-            highlight_area: layout.status_area,
-            zone: SelectionZone::StatusBar,
-        });
+        self.zones.push_overlay(layout.status_area);
+
+        if self.permission_prompt.is_open() || self.plan_form_active() {
+            self.zones.push_overlay(layout.bottom_area);
+        }
+
+        for &(_, rect) in &layout.panel_windows {
+            self.zones.push_overlay(selection::inset_border(rect));
+        }
+
+        if !self.is_main_chat() && layout.bottom_area.height > 0 {
+            self.zones.push_overlay(layout.bottom_area);
+        }
+
+        if layout.queue_area.height > 0 && !layout.bottom_takeover {
+            self.zones.push_overlay(layout.queue_area);
+        }
+
+        for dir in Split::ALL {
+            if let Some(rect) = layout.splits.rect(dir) {
+                self.zones.push_overlay(selection::inset_border(rect));
+            }
+        }
 
         if overlay_rect.width > 0 {
-            let inner = selection::inset_border(overlay_rect);
-            self.zones[SelectionZone::Overlay.idx()] = Some(SelectableZone {
-                area: inner,
-                highlight_area: inner,
-                zone: SelectionZone::Overlay,
-            });
-        } else {
-            self.zones[SelectionZone::Overlay.idx()] = None;
-            if self
-                .selection_state
-                .as_ref()
-                .is_some_and(|s| s.sel().zone == SelectionZone::Overlay)
-            {
-                self.selection_state = None;
-            }
+            self.zones
+                .push_overlay(selection::inset_border(overlay_rect));
+        }
+
+        // Overlay zone was removed (e.g. dialog closed), drop the dangling selection
+        if let Some(ref state) = self.selection_state
+            && state.sel().zone == SelectionZone::Overlay
+            && self.zones.find_area(state.sel().area).is_none()
+        {
+            self.selection_state = None;
         }
     }
 
@@ -370,13 +376,9 @@ impl App {
         };
 
         let sel = state.sel();
-        let zone = sel.zone;
-        let scroll = self.scroll_offset(zone);
+        let scroll = self.scroll_offset(sel.zone);
         if let Some(screen_sel) = sel.to_screen(scroll) {
-            let highlight_area = self.zones[zone.idx()]
-                .map(|z| z.highlight_area)
-                .unwrap_or_default();
-            selection::apply_highlight(frame.buffer_mut(), highlight_area, &screen_sel);
+            selection::apply_highlight(frame.buffer_mut(), sel.highlight_area(), &screen_sel);
         }
         if state.is_pending_copy() {
             let sel = *sel;
@@ -388,9 +390,7 @@ impl App {
     /// input_area, splits)`.
     #[cfg(test)]
     pub(super) fn layout_geometry(&self, area: Rect) -> (Rect, Rect, Rect, Rect, SplitLayout) {
-        let in_plan = self.state.mode == Mode::Plan;
-        let form_visible =
-            self.permission_prompt.is_open() || (in_plan && self.plan_form.is_visible());
+        let form_visible = self.permission_prompt.is_open() || self.plan_form_active();
         let layout = self.compute_layout(area, form_visible);
         (
             layout.msg_area,
@@ -419,7 +419,7 @@ impl App {
     #[cfg(test)]
     pub(super) fn active_keybind_contexts(&self) -> Vec<KeybindContext> {
         let mut contexts = vec![KeybindContext::General];
-        if self.state.mode == Mode::Plan && self.plan_form.is_visible() {
+        if self.plan_form_active() {
             contexts.push(KeybindContext::FormInput);
         } else if self.queue.focus().is_some() {
             contexts.push(KeybindContext::QueueFocus);

--- a/maki-ui/src/selection.rs
+++ b/maki-ui/src/selection.rs
@@ -16,7 +16,7 @@
 //! messages panel so the viewport stays put while the user drags.
 //!
 //! The rightmost column of each area is reserved for the scrollbar, so
-//! `highlight_area` / `msg_area()` are 1 column narrower than the full
+//! `highlight_area()` / `msg_area()` are 1 column narrower than the full
 //! area and all column math uses `width - 1`.
 //!
 //! When text is word-wrapped, ratatui eats the space at the break point,
@@ -67,46 +67,79 @@ impl Ord for DocPos {
 }
 
 /// Selection is locked to one zone for its entire lifetime.
-///
-/// Variant order matters: higher index = higher z-order priority in `zone_at`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SelectionZone {
     Messages,
     Input,
-    StatusBar,
     Overlay,
-}
-
-impl SelectionZone {
-    pub const COUNT: usize = 4;
-
-    pub const fn idx(self) -> usize {
-        self as usize
-    }
 }
 
 #[derive(Clone, Copy, Debug)]
 pub struct SelectableZone {
     pub area: Rect,
-    pub highlight_area: Rect,
     pub zone: SelectionZone,
 }
 
-pub type ZoneRegistry = [Option<SelectableZone>; SelectionZone::COUNT];
+const ZONE_CAP: usize = 12;
 
-/// Returns the zone at `(row, col)`, preferring higher-index (higher z-order) zones.
-pub fn zone_at(zones: &ZoneRegistry, row: u16, col: u16) -> Option<SelectableZone> {
-    let pos = ratatui::layout::Position::new(col, row);
-    zones
-        .iter()
-        .rev()
-        .flatten()
-        .find(|z| z.area.contains(pos))
-        .copied()
+const EMPTY_ZONE: SelectableZone = SelectableZone {
+    area: Rect::new(0, 0, 0, 0),
+    zone: SelectionZone::Messages,
+};
+
+pub struct ZoneRegistry {
+    entries: [SelectableZone; ZONE_CAP],
+    len: u8,
+}
+
+impl ZoneRegistry {
+    pub fn new() -> Self {
+        Self {
+            entries: [EMPTY_ZONE; ZONE_CAP],
+            len: 0,
+        }
+    }
+
+    pub fn push(&mut self, zone: SelectableZone) {
+        let i = self.len as usize;
+        if i >= ZONE_CAP {
+            return;
+        }
+        self.entries[i] = zone;
+        self.len += 1;
+    }
+
+    pub fn push_overlay(&mut self, area: Rect) {
+        self.push(SelectableZone {
+            area,
+            zone: SelectionZone::Overlay,
+        });
+    }
+
+    pub fn zone_at(&self, row: u16, col: u16) -> Option<SelectableZone> {
+        let pos = ratatui::layout::Position::new(col, row);
+        self.entries[..self.len as usize]
+            .iter()
+            .rev()
+            .find(|z| z.area.contains(pos))
+            .copied()
+    }
+
+    pub fn find(&self, zone: SelectionZone) -> Option<&SelectableZone> {
+        self.entries[..self.len as usize]
+            .iter()
+            .find(|z| z.zone == zone)
+    }
+
+    pub fn find_area(&self, area: Rect) -> Option<&SelectableZone> {
+        self.entries[..self.len as usize]
+            .iter()
+            .find(|z| z.area == area)
+    }
 }
 
 /// Anchor + cursor in doc space. `area` and `zone` are captured at mouse-down
-/// and stay fixed so layout changes mid-drag don't break the selection.
+/// so layout changes mid-drag don't break the selection.
 #[derive(Clone, Copy, Debug)]
 pub struct Selection {
     anchor: DocPos,
@@ -146,6 +179,18 @@ impl Selection {
 
     pub fn is_empty(&self) -> bool {
         self.anchor == self.cursor
+    }
+
+    pub fn highlight_area(&self) -> Rect {
+        match self.zone {
+            SelectionZone::Messages => Rect::new(
+                self.area.x,
+                self.area.y,
+                self.area.width.saturating_sub(1),
+                self.area.height,
+            ),
+            _ => self.area,
+        }
     }
 
     pub fn normalized(&self) -> (DocPos, DocPos) {
@@ -898,24 +943,19 @@ mod tests {
     fn zone_at_overlay_wins_over_messages() {
         let msg_area = Rect::new(0, 0, 80, 20);
         let overlay_area = Rect::new(10, 5, 60, 10);
-        let mut zones: ZoneRegistry = [None; SelectionZone::COUNT];
-        zones[SelectionZone::Messages.idx()] = Some(SelectableZone {
+        let mut zones = ZoneRegistry::new();
+        zones.push(SelectableZone {
             area: msg_area,
-            highlight_area: msg_area,
             zone: SelectionZone::Messages,
         });
-        zones[SelectionZone::Overlay.idx()] = Some(SelectableZone {
+        zones.push(SelectableZone {
             area: overlay_area,
-            highlight_area: overlay_area,
             zone: SelectionZone::Overlay,
         });
 
-        assert_eq!(zone_at(&zones, 7, 20).unwrap().zone, SelectionZone::Overlay);
-        assert_eq!(
-            zone_at(&zones, 2, 20).unwrap().zone,
-            SelectionZone::Messages
-        );
-        assert_eq!(zone_at(&zones, 7, 5).unwrap().zone, SelectionZone::Messages);
+        assert_eq!(zones.zone_at(7, 20).unwrap().zone, SelectionZone::Overlay);
+        assert_eq!(zones.zone_at(2, 20).unwrap().zone, SelectionZone::Messages);
+        assert_eq!(zones.zone_at(7, 5).unwrap().zone, SelectionZone::Messages);
     }
 
     #[test_case(doc(0, 0), doc(2, 9), 0, 2, 0, 9, true  ; "exact_match")]
@@ -1042,14 +1082,13 @@ mod tests {
 
     #[test]
     fn zone_at_returns_none_when_outside() {
-        let mut zones: ZoneRegistry = [None; SelectionZone::COUNT];
-        assert!(zone_at(&zones, 10, 10).is_none(), "no zones registered");
-        zones[SelectionZone::Messages.idx()] = Some(SelectableZone {
+        let mut zones = ZoneRegistry::new();
+        assert!(zones.zone_at(10, 10).is_none(), "no zones registered");
+        zones.push(SelectableZone {
             area: Rect::new(0, 0, 80, 20),
-            highlight_area: Rect::new(0, 0, 80, 20),
             zone: SelectionZone::Messages,
         });
-        assert!(zone_at(&zones, 25, 10).is_none(), "outside all zones");
+        assert!(zones.zone_at(25, 10).is_none(), "outside all zones");
     }
 
     fn wrap_extract(input: &str, width: u16) -> String {


### PR DESCRIPTION
The old `ZoneRegistry` was a fixed array indexed by enum discriminant, so only one `Overlay` zone could exist at a time. Splits, panels, permission prompt, and queue all rendered into areas with no selection zone.

`ZoneRegistry` is now a stack-allocated struct with `push()` where push order equals z-order. `register_zones` is the single function that pushes every selectable area (messages, input, status bar, panels, splits, queue, floating overlay), so forgetting to register something becomes harder.

`SelectionZone::StatusBar` is merged into `Overlay` since they share the same behavior (buffer scrape, no scroll). `Selection` captures `highlight_area` at mouse-down so `apply_selection` no longer looks it up from the registry each frame.