### PR TITLE
docs: fix code block colors in light theme

### DIFF
--- a/site/docs/templates/base.html
+++ b/site/docs/templates/base.html
@@ -13,9 +13,11 @@
       var dark = t === 'dark' || (!t && window.matchMedia('(prefers-color-scheme: dark)').matches);
       if (dark) {
         document.documentElement.setAttribute('data-theme', 'dark');
+        document.documentElement.style.colorScheme = 'dark';
         document.documentElement.style.background = 'oklch(16% 0.02 270)';
       } else {
         document.documentElement.setAttribute('data-theme', 'light');
+        document.documentElement.style.colorScheme = 'light';
         document.documentElement.style.background = 'oklch(97% 0.015 90)';
       }
     })();
@@ -33,6 +35,7 @@
     *,*::before,*::after { margin: 0; padding: 0; box-sizing: border-box; }
 
     :root {
+      color-scheme: light;
       --lavender: oklch(85% 0.06 280);
       --periwinkle: oklch(78% 0.08 275);
       --soft-pink: oklch(82% 0.06 350);
@@ -53,7 +56,7 @@
       --accent-soft: oklch(92% 0.05 275);
       --accent-hover: oklch(42% 0.16 275);
       --code-bg: oklch(94% 0.03 278);
-      --code-block-bg: oklch(18% 0.02 270);
+      --code-block-bg: #1E1E2E;
       --code-block-fg: oklch(86% 0.02 270);
       --sidebar-w: 240px;
       --content-max: 740px;
@@ -107,6 +110,7 @@
     }
 
     [data-theme="dark"] {
+      color-scheme: dark;
       --cream: oklch(16% 0.02 270);
       --deep-navy: oklch(92% 0.02 275);
       --navy-light: oklch(80% 0.03 275);
@@ -122,7 +126,7 @@
       --accent-soft: oklch(25% 0.05 275);
       --accent-hover: oklch(75% 0.14 275);
       --code-bg: oklch(22% 0.025 275);
-      --code-block-bg: oklch(12% 0.015 270);
+      --code-block-bg: #1E1E2E;
       --code-block-fg: oklch(82% 0.02 270);
       --surface-glow: oklch(22% 0.04 280);
       --topnav-bg: oklch(16% 0.02 270 / 0.85);
@@ -419,7 +423,9 @@
 
     /* ── CODE BLOCKS ── */
     pre {
-      background: var(--code-block-bg);
+      background: var(--code-block-bg) !important;
+      color: var(--code-block-fg) !important;
+      color-scheme: dark !important;
       border-radius: 10px;
       padding: 1.25rem 1.5rem;
       overflow-x: auto;
@@ -762,6 +768,7 @@
       setTimeout(() => document.documentElement.classList.remove('theme-transition'), 400);
     }
     document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+    document.documentElement.style.colorScheme = dark ? 'dark' : 'light';
     document.documentElement.style.background = dark ? 'oklch(16% 0.02 270)' : 'oklch(97% 0.015 90)';
     localStorage.setItem('theme', dark ? 'dark' : 'light');
   }


### PR DESCRIPTION
Zola inlines syntax colors using CSS `light-dark()`, which picks light or dark values based on the `color-scheme` property. The docs site toggled themes via `data-theme` attribute but never set `color-scheme`, so the browser fell back to OS preference.

Users with a light OS theme got catppuccin-latte colors (soft pastels for light backgrounds) rendered on our dark code block background, making everything washed out and hard to read.

Now `color-scheme` is synced with `data-theme` in both the init script and the toggle function.
Code blocks force `color-scheme: dark` so `light-dark()` always picks catppuccin-mocha, and `!important` on `background`/`color` ensures our `#1E1E2E` wins over the inline styles Zola generates.

Fixed #351.