### PR TITLE
lua: use `bash` instead of `sh` for the bash tool

### DIFF
--- a/maki-lua/src/api/fn_api.rs
+++ b/maki-lua/src/api/fn_api.rs
@@ -220,7 +220,7 @@ impl JobStore {
 fn shell_command(cmd: &str) -> Command {
     #[cfg(unix)]
     {
-        let mut c = Command::new("sh");
+        let mut c = Command::new("bash");
         c.arg("-c").arg(cmd);
         c
     }


### PR DESCRIPTION
The bash tool ran commands through `sh -c`, which on Debian and Ubuntu points to `dash`.

LLMs generate bash syntax (arrays, `[[`, process substitution) that `dash` does not support, causing silent failures and wasted tokens.

`shell_command()` now invokes `bash -c` on unix so the tool behaves like its name promises.

Fixes #346.