### PR TITLE
highlight: fix syntax colors when reading files with offset

### DIFF
--- a/maki-highlight/src/lib.rs
+++ b/maki-highlight/src/lib.rs
@@ -184,8 +184,13 @@ impl StyledSegment {
     }
 }
 
-pub fn highlight_code(lang: &str, code: &str) -> Vec<Vec<StyledSegment>> {
+pub fn highlight_code(lang: &str, code: &str, prefix: &str) -> Vec<Vec<StyledSegment>> {
     let mut hl = Highlighter::for_token(lang);
+    if !prefix.is_empty() {
+        for line in LinesWithEndings::from(prefix) {
+            hl.advance(line);
+        }
+    }
     LinesWithEndings::from(code)
         .map(|raw| hl.highlight_line(raw))
         .collect()
@@ -309,15 +314,15 @@ mod tests {
     #[test]
     fn highlight_code_line_handling() {
         warmup();
-        let single = highlight_code("rust", "fn main() {}\n");
+        let single = highlight_code("rust", "fn main() {}\n", "");
         assert_eq!(single.len(), 1);
         assert_eq!(segments_text(&single[0]), "fn main() {}");
 
-        let no_newline = highlight_code("rust", "let x = 1;");
+        let no_newline = highlight_code("rust", "let x = 1;", "");
         assert_eq!(no_newline.len(), 1);
         assert_eq!(segments_text(&no_newline[0]), "let x = 1;");
 
-        let trailing = highlight_code("rust", "let x = 1;\n\n\n");
+        let trailing = highlight_code("rust", "let x = 1;\n\n\n", "");
         assert_eq!(trailing.len(), 3);
         assert_eq!(segments_text(&trailing[1]), "");
     }
@@ -329,7 +334,7 @@ mod tests {
         let target_line = "let x = 42;\n";
         let combined = format!("{context_line}{target_line}");
 
-        let stateful = highlight_code("rust", &combined);
+        let stateful = highlight_code("rust", &combined, "");
         let independent = highlight_lines_independent("rust", &combined);
 
         assert_eq!(
@@ -368,7 +373,7 @@ mod tests {
     fn code_highlighter_streaming_consistency() {
         warmup();
         let full_code = "fn main() {\n    let x = 42;\n    println!(\"{}\", x);\n}\n";
-        let full = highlight_code("rust", full_code);
+        let full = highlight_code("rust", full_code, "");
 
         let mut ch = CodeHighlighter::new("rust");
         ch.update("fn main() {\n");

--- a/maki-lua/src/api/ui.rs
+++ b/maki-lua/src/api/ui.rs
@@ -93,13 +93,17 @@ pub(crate) fn create_ui_table(
         lua.create_async_function(
             |lua, (code, lang, opts): (String, String, Option<mlua::Table>)| async move {
                 let independent = opts
+                    .as_ref()
                     .and_then(|t| t.get::<bool>("independent").ok())
                     .unwrap_or(false);
+                let prefix = opts
+                    .and_then(|t| t.get::<String>("prefix").ok())
+                    .unwrap_or_default();
                 let segments = smol::unblock(move || {
                     if independent {
                         maki_highlight::highlight_lines_independent(&lang, &code)
                     } else {
-                        maki_highlight::highlight_code(&lang, &code)
+                        maki_highlight::highlight_code(&lang, &code, &prefix)
                     }
                 })
                 .await;

--- a/plugins/read/init.lua
+++ b/plugins/read/init.lua
@@ -40,12 +40,13 @@ local function read_view_opts(ctx)
   return { max_lines = (tol and tol.read) or 10, keep = "head" }
 end
 
-local function apply_highlights(view, hl_lines, ext)
+local function apply_highlights(view, hl_lines, ext, prefix)
   local texts = {}
   for _, fl in ipairs(hl_lines) do
     texts[#texts + 1] = fl.text
   end
-  local highlighted = maki.ui.highlight(table.concat(texts, "\n"), ext)
+  local opts = prefix and { prefix = prefix } or nil
+  local highlighted = maki.ui.highlight(table.concat(texts, "\n"), ext, opts)
   if not highlighted then
     return
   end
@@ -58,7 +59,7 @@ local function apply_highlights(view, hl_lines, ext)
   view:flush()
 end
 
-local function build_file_view(lines, start_line, total_lines, path, ctx, sync)
+local function build_file_view(lines, start_line, total_lines, path, ctx, sync, prefix)
   local buf = maki.ui.buf()
   local view = ToolView.new(buf, read_view_opts(ctx))
   local nr_fmt = line_nr_fmt(total_lines)
@@ -87,10 +88,10 @@ local function build_file_view(lines, start_line, total_lines, path, ctx, sync)
 
   local ext = path:match("%.([^%.]+)$") or ""
   if sync then
-    apply_highlights(view, hl_lines, ext)
+    apply_highlights(view, hl_lines, ext, prefix)
   else
     maki.async.run(function()
-      apply_highlights(view, hl_lines, ext)
+      apply_highlights(view, hl_lines, ext, prefix)
     end)
   end
 
@@ -162,6 +163,8 @@ local function read_file(path, offset, limit, ctx)
   local annotation = shown < total_lines and string.format("%d of %d lines", shown, total_lines)
     or string.format("%d lines", shown)
 
+  local prefix = start > 1 and table.concat(all_lines, "\n", 1, start - 1) or nil
+
   local basename = path:match("([^/]+)$")
   if not ctx:is_instruction_file(basename) then
     local parent = maki.fs.dirname(path)
@@ -170,7 +173,7 @@ local function read_file(path, offset, limit, ctx)
       if #instructions > 0 then
         return {
           llm_output = llm_output,
-          body = build_file_view(lines, start, total_lines, path, ctx),
+          body = build_file_view(lines, start, total_lines, path, ctx, false, prefix),
           annotation = annotation,
           instructions = instructions,
         }
@@ -180,7 +183,7 @@ local function read_file(path, offset, limit, ctx)
 
   return {
     llm_output = llm_output,
-    body = build_file_view(lines, start, total_lines, path, ctx),
+    body = build_file_view(lines, start, total_lines, path, ctx, false, prefix),
     annotation = annotation,
   }
 end


### PR DESCRIPTION
When the read tool shows a file starting from an offset, the highlighter had no context about what came before. If line 1258 sits inside a docstring or block comment, everything got the wrong colors.

`highlight_code_with_prefix` feeds the preceding lines through the parser via `advance()` to build up state before highlighting the visible range. The `maki.ui.highlight` Lua API accepts an optional `prefix` field in opts, and the read plugin passes `all_lines[1..start-1]` when `start > 1`. Same trick syntect-based editors use, and 5000 prefix lines parse in about 5ms so it costs nothing.