### PR TITLE
lua: stop `multiedit` from leaking memory until OOM

### DIFF
--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -48,6 +48,9 @@ const MAX_INFLIGHT_TOOLS: usize = 64;
 const GC_STEP_INTERVAL: usize = 4;
 const INTERRUPT_CANCEL_CHECK_INTERVAL: u32 = 128;
 const ASYNC_RUN_DEFAULT_DEADLINE: Duration = Duration::from_secs(60);
+/// Without a cap, a runaway plugin gets OOM-killed by the OS and takes the
+/// whole host down. With one, it hits a catchable Lua error instead.
+const LUA_MEMORY_LIMIT: usize = 512 * 1024 * 1024;
 
 pub type LoadResult = Result<(), PluginError>;
 pub(crate) enum HintContent {
@@ -597,6 +600,11 @@ impl LuaRuntime {
         hint_writer: HintWriter,
     ) -> Result<Self, PluginError> {
         let lua = Lua::new();
+        lua.set_memory_limit(LUA_MEMORY_LIMIT)
+            .map_err(|e| PluginError::Lua {
+                plugin: "<init>".to_owned(),
+                source: e,
+            })?;
         let pending: PendingTools = Arc::new(Mutex::new(Vec::new()));
 
         install_interrupt(&lua, Arc::clone(&shutdown));

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -1431,3 +1431,25 @@ fn pure_functions_not_guarded() {
     assert!(result.contains("basename=true"), "got: {result}");
     assert!(result.contains("json=true"), "got: {result}");
 }
+
+#[test]
+fn runaway_allocation_hits_memory_limit_instead_of_oom() {
+    const LIMITED: &str = "limited";
+    let src = r#"
+        local ok, err = pcall(function()
+            local t = {}
+            local chunk = string.rep("x", 1024 * 1024)
+            while true do
+                t[#t + 1] = chunk .. tostring(#t)
+            end
+        end)
+        if ok then error("expected allocation to fail under the memory limit") end
+        if not string.find(tostring(err), "memory") then
+            error("expected an out-of-memory error, got: " .. tostring(err))
+        end
+    "#;
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source(LIMITED, src)
+        .expect("plugin should hit the memory limit and recover, not crash the process");
+}

--- a/plugins/edit/tests/spec.lua
+++ b/plugins/edit/tests/spec.lua
@@ -24,6 +24,7 @@ end
 local R = "REPLACED"
 local NO_MATCH = fr.NO_MATCH
 local MULTIPLE_MATCHES = fr.MULTIPLE_MATCHES
+local EMPTY_OLD_STRING = fr.EMPTY_OLD_STRING
 
 -- fuzzy_replace unit tests
 
@@ -154,7 +155,13 @@ end)
 case("empty_old_string", function()
   local result, err = fr.replace("abc", "", "x", false)
   eq(result, nil)
-  eq(err, MULTIPLE_MATCHES)
+  eq(err, EMPTY_OLD_STRING)
+end)
+
+case("empty_old_string_replace_all_does_not_hang", function()
+  local result, err = fr.replace("abc", "", "x", true)
+  eq(result, nil)
+  eq(err, EMPTY_OLD_STRING)
 end)
 
 case("replace_all_no_occurrences", function()

--- a/plugins/lib/maki/fuzzy_replace.lua
+++ b/plugins/lib/maki/fuzzy_replace.lua
@@ -2,6 +2,7 @@ local M = {}
 
 M.NO_MATCH = "old_string not found in file"
 M.MULTIPLE_MATCHES = "old_string matches multiple locations; add surrounding context to make it unique"
+M.EMPTY_OLD_STRING = "old_string must not be empty"
 
 local SINGLE_CANDIDATE_THRESHOLD = 0.0
 local MULTI_CANDIDATE_THRESHOLD = 0.3
@@ -484,6 +485,10 @@ local function replace_all_occurrences(content, matched, replacement)
 end
 
 function M.replace(content, old_string, new_string, replace_all)
+  if old_string == "" then
+    return nil, M.EMPTY_OLD_STRING
+  end
+
   local any_found = false
 
   local function try_match(candidates, replacement)


### PR DESCRIPTION
`fuzzy_replace`'s `replace_all` looped forever when `old_string` was empty, since Luau's `find("", pos)` is a zero-width match so `pos` never moved and a table grew until the OS killed `maki`. Now we reject an empty `old_string` up front.

As a backstop the Lua VM had no memory cap at all, so any runaway plugin could take down the whole process. Added a 512MB limit so it fails with a catchable error instead.