### PR TITLE
feat(agent): nudge model on empty response after tool calls

### DIFF
--- a/maki-agent/src/agent/history.rs
+++ b/maki-agent/src/agent/history.rs
@@ -52,6 +52,16 @@ impl History {
         self.messages.is_empty()
     }
 
+    pub fn has_recent_tool_results(&self, depth: usize) -> bool {
+        let msgs = self.as_slice();
+        let start = msgs.len().saturating_sub(depth);
+        msgs[start..].iter().any(|m| {
+            m.content
+                .iter()
+                .any(|b| matches!(b, ContentBlock::ToolResult { .. }))
+        })
+    }
+
     pub fn replace(&mut self, messages: Vec<Message>) {
         self.edit(|msgs| *msgs = messages);
     }
@@ -418,5 +428,40 @@ mod tests {
             })
             .collect();
         assert_eq!(results, ["t1"]);
+    }
+
+    #[test_case(
+        vec![Message::user("go".into())],
+        0
+        ; "no_tool_results"
+    )]
+    #[test_case(
+        vec![
+            Message::user("go".into()),
+            make_tool_result_msg(&["t1"]),
+        ],
+        1
+        ; "recent_tool_result"
+    )]
+    #[test_case(
+        vec![
+            Message::user("old1".into()),
+            Message::user("old2".into()),
+            Message::user("old3".into()),
+            Message::user("old4".into()),
+            Message::user("old5".into()),
+            make_tool_result_msg(&["t1"]),
+        ],
+        1
+        ; "at_depth_boundary"
+    )]
+    fn has_recent_tool_results(messages: Vec<Message>, depth: usize) {
+        let history = History::new(messages);
+        let result = if depth == 0 {
+            history.has_recent_tool_results(0)
+        } else {
+            history.has_recent_tool_results(depth)
+        };
+        assert_eq!(result, depth > 0);
     }
 }

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -3,9 +3,10 @@ use std::sync::Arc;
 use serde_json::Value;
 use tracing::{error, info, warn};
 
-use maki_providers::ContentBlock;
 use maki_providers::provider::Provider;
-use maki_providers::{Message, Model, RequestOptions, StopReason, StreamResponse, TokenUsage};
+use maki_providers::{
+    ContentBlock, Message, Model, RequestOptions, Role, StopReason, StreamResponse, TokenUsage,
+};
 
 use super::compaction::{self, CONTINUE_AFTER_COMPACT};
 use super::history::{History, sanitize_cancelled_history};
@@ -23,6 +24,7 @@ use crate::{
 use maki_config::ToolOutputLines;
 
 const MAX_REAUTH_ATTEMPTS: u32 = 2;
+const NUDGE_PROMPT: &str = "You just executed tool calls but returned an empty response. Please process the tool results above and continue with the task.";
 
 pub fn resolve_compaction_model(
     provider: &Arc<dyn Provider>,
@@ -88,6 +90,7 @@ pub struct Agent<'h> {
     config: AgentConfig,
     tool_output_lines: ToolOutputLines,
     reauth_attempts: u32,
+    post_tool_empty_retried: bool,
     permissions: Arc<PermissionManager>,
     opts: RequestOptions,
     session_id: Option<String>,
@@ -123,6 +126,7 @@ impl<'h> Agent<'h> {
             rollback_len: 0,
             mcp: None,
             reauth_attempts: 0,
+            post_tool_empty_retried: false,
             opts: RequestOptions::default(),
             session_id: params.session_id,
             file_tracker: params.file_tracker,
@@ -259,6 +263,24 @@ impl<'h> Agent<'h> {
             self.context_size +=
                 estimate_message_tokens(&self.history.as_slice()[history_len_before..]);
         } else {
+            let has_text = response.message.first_text_content().is_some();
+
+            if !has_text && !self.post_tool_empty_retried && self.history.has_recent_tool_results(5)
+            {
+                self.post_tool_empty_retried = true;
+                warn!("empty response after tool calls, nudging model to continue");
+                self.event_tx.send(AgentEvent::Nudge)?;
+                self.history.push(Message {
+                    role: Role::Assistant,
+                    content: vec![ContentBlock::Text {
+                        text: "(empty)".into(),
+                    }],
+                    ..Default::default()
+                });
+                self.history.push(Message::synthetic(NUDGE_PROMPT.into()));
+                return Ok(TurnOutcome::Continue);
+            }
+
             self.history.push(response.message);
 
             if stop_reason == Some(StopReason::MaxTokens)
@@ -335,6 +357,7 @@ impl<'h> Agent<'h> {
     }
 
     async fn process_tool_calls(&mut self, response: StreamResponse) -> Result<(), AgentError> {
+        self.post_tool_empty_retried = false;
         let ctx = self.tool_context();
         tool_dispatch::process_tool_calls(
             response,
@@ -538,6 +561,18 @@ mod tests {
             },
             usage: TokenUsage::default(),
             stop_reason: Some(stop_reason),
+        }
+    }
+
+    fn empty_response() -> StreamResponse {
+        StreamResponse {
+            message: Message {
+                role: Role::Assistant,
+                content: vec![],
+                ..Default::default()
+            },
+            usage: TokenUsage::default(),
+            stop_reason: Some(StopReason::EndTurn),
         }
     }
 
@@ -860,6 +895,54 @@ mod tests {
                 e,
                 AgentEvent::ToolDone(done) if done.is_error && done.id == expected_error_id
             )));
+        });
+    }
+
+    #[test_case(
+        vec![
+            tool_call_response("glob", "t1"),
+            empty_response(),
+            text_response(StopReason::EndTurn),
+        ],
+        3, true
+        ; "nudge_on_empty_after_tools"
+    )]
+    #[test_case(
+        vec![
+            tool_call_response("glob", "t1"),
+            text_response(StopReason::EndTurn),
+        ],
+        2, false
+        ; "no_nudge_when_text_after_tools"
+    )]
+    #[test_case(
+        vec![
+            empty_response(),
+            text_response(StopReason::EndTurn),
+        ],
+        1, false
+        ; "no_nudge_without_recent_tools"
+    )]
+    fn nudge_behavior(responses: Vec<StreamResponse>, expected_turns: u32, expect_nudge: bool) {
+        smol::block_on(async {
+            let mut history = History::new(Vec::new());
+            let (mut agent, event_rx) = make_agent(MockProvider::new(responses), &mut history);
+            let _ = agent.run(default_input()).await;
+            drop(agent);
+            let events = drain_events(&event_rx);
+
+            assert_eq!(
+                has_event(&events, |e| matches!(e, AgentEvent::Nudge)),
+                expect_nudge,
+            );
+            let done = events
+                .iter()
+                .find_map(|e| match &e.event {
+                    AgentEvent::Done { num_turns, .. } => Some(*num_turns),
+                    _ => None,
+                })
+                .expect("expected Done event");
+            assert_eq!(done, expected_turns);
         });
     }
 }

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -513,6 +513,7 @@ pub enum AgentEvent {
         scopes: Vec<String>,
     },
     AuthRequired,
+    Nudge,
     SubagentHistory {
         tool_use_id: String,
         messages: Vec<Message>,

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -159,7 +159,7 @@ impl Message {
         }
     }
 
-    fn first_text_content(&self) -> Option<&str> {
+    pub fn first_text_content(&self) -> Option<&str> {
         self.content.iter().find_map(|b| match b {
             ContentBlock::Text { text } if !text.is_empty() => Some(text.as_str()),
             _ => None,

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -159,6 +159,13 @@ impl Chat {
                 self.messages_panel
                     .tool_header_snapshot(&id, snapshot, theme_gen);
             }
+            AgentEvent::Nudge => {
+                self.messages_panel.flush();
+                self.messages_panel.push(DisplayMessage::new(
+                    DisplayRole::Assistant,
+                    "Model stalled after tool calls, nudging...".into(),
+                ));
+            }
             AgentEvent::SubagentHistory { .. } => {}
             AgentEvent::LiveToolBuf { id, body } => {
                 self.messages_panel.register_live_buf(id, body);

--- a/src/print.rs
+++ b/src/print.rs
@@ -221,7 +221,8 @@ pub fn run(
             | AgentEvent::SubagentHistory { .. }
             | AgentEvent::ToolSnapshot { .. }
             | AgentEvent::ToolHeaderSnapshot { .. }
-            | AgentEvent::LiveToolBuf { .. } => {}
+            | AgentEvent::LiveToolBuf { .. }
+            | AgentEvent::Nudge => {}
             AgentEvent::Retry {
                 attempt,
                 message,

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -890,7 +890,8 @@ impl EventPump {
             | AgentEvent::SubagentHistory { .. }
             | AgentEvent::ToolSnapshot { .. }
             | AgentEvent::ToolHeaderSnapshot { .. }
-            | AgentEvent::LiveToolBuf { .. } => {}
+            | AgentEvent::LiveToolBuf { .. }
+            | AgentEvent::Nudge => {}
             AgentEvent::Retry {
                 attempt,
                 message,


### PR DESCRIPTION
Weaker models sometimes return an empty response after executing tool calls (no text, no tool uses, just end_turn), silently abandoning incomplete multi-step tasks.

When this happens, inject a synthetic user message asking the model to process the tool results and continue. Guarded by a per-tool-round flag and the global turn limit to prevent infinite loops.

- Add AgentEvent::Nudge variant and UI handling
- Add History::has_recent_tool_results() helper
- Make Message::first_text_content() public
- Add nudge detection in turn() with synthetic message injection

Ported from: https://github.com/NousResearch/hermes-agent/pull/10065

Addresses issue #299 (among others)