### PR TITLE
providers: declare custom-provider models statically in providers.toml

### DIFF
--- a/maki-config/src/providers.rs
+++ b/maki-config/src/providers.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
+use std::process;
 
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -9,13 +10,26 @@ use tracing::debug;
 use maki_storage::paths;
 
 const PROVIDERS_FILE: &str = "providers.toml";
-const DEFAULT_TIER: &str = "medium";
+const BAD_CONFIG_EXIT_CODE: i32 = 2;
+
+/// Coarse capability classification used by maki-providers to dispatch tiered
+/// requests. Mirrors `maki_providers::ModelTier` shape but lives here so the
+/// config layer can validate inputs without depending on maki-providers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Tier {
+    Weak,
+    #[default]
+    Medium,
+    Strong,
+    Compaction,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelDef {
     pub id: String,
-    #[serde(default = "default_tier")]
-    pub tier: String,
+    #[serde(default)]
+    pub tier: Tier,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context_window: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -48,10 +62,6 @@ impl ModelDef {
     pub fn has_fast_pricing(&self) -> bool {
         self.pricing_fast_input.is_some() || self.pricing_fast_output.is_some()
     }
-}
-
-fn default_tier() -> String {
-    DEFAULT_TIER.to_string()
 }
 
 /// Normalize a provider name into a lowercase, hyphen-separated slug.
@@ -142,25 +152,29 @@ pub struct ProvidersConfig {
 }
 
 impl ProvidersConfig {
+    /// Read and parse `providers.toml`. Hard-exits on parse errors so a typo
+    /// in tier or pricing surfaces immediately instead of silently dropping
+    /// every provider and starting maki with an empty registry.
     pub fn load() -> Self {
         let path = providers_file_path();
         if !path.exists() {
             return Self::default();
         }
-        match fs::read_to_string(&path) {
-            Ok(content) => match toml::from_str(&content) {
-                Ok(config) => {
-                    debug!(path = %path.display(), "loaded providers config");
-                    config
-                }
-                Err(e) => {
-                    tracing::warn!(path = %path.display(), error = %e, "invalid providers.toml, ignoring");
-                    Self::default()
-                }
-            },
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
             Err(e) => {
                 tracing::warn!(path = %path.display(), error = %e, "cannot read providers.toml");
-                Self::default()
+                return Self::default();
+            }
+        };
+        match toml::from_str(&content) {
+            Ok(config) => {
+                debug!(path = %path.display(), "loaded providers config");
+                config
+            }
+            Err(e) => {
+                eprintln!("error: invalid {}: {e}", path.display());
+                process::exit(BAD_CONFIG_EXIT_CODE);
             }
         }
     }
@@ -322,6 +336,37 @@ mod tests {
             parsed.get("my-provider").unwrap().base_url,
             Some("https://api.example.com/v1".into())
         );
+    }
+
+    const UNKNOWN_TIER_TOML: &str = r#"id = "x"
+tier = "mediums"
+"#;
+
+    #[test]
+    fn model_def_rejects_unknown_tier() {
+        let err = toml::from_str::<ModelDef>(UNKNOWN_TIER_TOML).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("medium"), "expected enum hint, got: {msg}");
+    }
+
+    #[test]
+    fn model_def_tier_defaults_to_medium() {
+        let m: ModelDef = toml::from_str(r#"id = "x""#).unwrap();
+        assert_eq!(m.tier, Tier::Medium);
+    }
+
+    #[test_case("weak", Tier::Weak ; "weak")]
+    #[test_case("medium", Tier::Medium ; "medium")]
+    #[test_case("strong", Tier::Strong ; "strong")]
+    #[test_case("compaction", Tier::Compaction ; "compaction")]
+    fn model_def_tier_roundtrip(input: &str, expected: Tier) {
+        let toml = format!(
+            r#"id = "x"
+tier = "{input}"
+"#
+        );
+        let m: ModelDef = toml::from_str(&toml).unwrap();
+        assert_eq!(m.tier, expected);
     }
 
     #[test_case("anthropic", None => "ANTHROPIC_API_KEY".to_string(); "builtin_default")]

--- a/maki-config/src/providers.rs
+++ b/maki-config/src/providers.rs
@@ -9,6 +9,50 @@ use tracing::debug;
 use maki_storage::paths;
 
 const PROVIDERS_FILE: &str = "providers.toml";
+const DEFAULT_TIER: &str = "medium";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelDef {
+    pub id: String,
+    #[serde(default = "default_tier")]
+    pub tier: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_output_tokens: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supports_tool_examples: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pricing_input: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pricing_output: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pricing_cache_write: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pricing_cache_read: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pricing_fast_input: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pricing_fast_output: Option<f64>,
+}
+
+impl ModelDef {
+    /// Any pricing field set means the user provided pricing (other fields default to 0).
+    pub fn has_pricing(&self) -> bool {
+        self.pricing_input.is_some()
+            || self.pricing_output.is_some()
+            || self.pricing_cache_write.is_some()
+            || self.pricing_cache_read.is_some()
+    }
+
+    pub fn has_fast_pricing(&self) -> bool {
+        self.pricing_fast_input.is_some() || self.pricing_fast_output.is_some()
+    }
+}
+
+fn default_tier() -> String {
+    DEFAULT_TIER.to_string()
+}
 
 /// Normalize a provider name into a lowercase, hyphen-separated slug.
 /// "My Cool Provider" -> "my-cool-provider"
@@ -87,6 +131,8 @@ pub struct ProviderDef {
     pub default_model: Option<String>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub discover_models: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub models: Vec<ModelDef>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -290,6 +290,9 @@ impl Model {
             if let Some(model) = dynamic::find_model_for_tier(slug, tier) {
                 return Ok(model);
             }
+            if let Some(model) = super::providers::custom::find_model_for_tier(slug, tier) {
+                return Ok(model);
+            }
             let mut model = Self::from_tier(provider, tier)?;
             model.dynamic_slug = Some(slug.to_string());
             return Ok(model);

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -132,6 +132,18 @@ impl FromStr for ModelTier {
     }
 }
 
+impl From<maki_config::providers::Tier> for ModelTier {
+    fn from(t: maki_config::providers::Tier) -> Self {
+        use maki_config::providers::Tier;
+        match t {
+            Tier::Weak => Self::Weak,
+            Tier::Medium => Self::Medium,
+            Tier::Strong => Self::Strong,
+            Tier::Compaction => Self::Compaction,
+        }
+    }
+}
+
 pub struct ModelEntry {
     pub prefixes: &'static [&'static str],
     pub tier: ModelTier,

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -342,6 +342,11 @@ pub fn available_model_specs() -> Vec<String> {
     for slug in dynamic::discovered_slugs() {
         specs.extend(dynamic::dynamic_model_specs_for(slug));
     }
+    for spec in crate::providers::custom::declared_model_specs() {
+        if !specs.contains(&spec) {
+            specs.push(spec);
+        }
+    }
     specs
 }
 
@@ -436,13 +441,24 @@ pub async fn fetch_all_models(
     let custom_timeouts = timeouts;
     let tx_custom = tx.clone();
     smol::spawn(async move {
+        let declared = crate::providers::custom::declared_model_specs();
+        if !declared.is_empty() {
+            let _ = tx_custom
+                .send_async(ModelBatch {
+                    models: declared,
+                    warnings: Vec::new(),
+                })
+                .await;
+        }
         let custom_specs =
             smol::unblock(move || crate::providers::custom::discover_models(custom_timeouts)).await;
         if !custom_specs.is_empty() {
-            let _ = tx_custom.send(ModelBatch {
-                models: custom_specs,
-                warnings: Vec::new(),
-            });
+            let _ = tx_custom
+                .send_async(ModelBatch {
+                    models: custom_specs,
+                    warnings: Vec::new(),
+                })
+                .await;
         }
     })
     .detach();

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -10,7 +10,7 @@ use maki_config::providers::{
 
 use super::ResolvedAuth;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
-use crate::model::{Model, ModelTier};
+use crate::model::{FastPricing, Model, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider, ProviderKind};
 use crate::providers::Timeouts;
 use crate::types::ThinkingConfig;
@@ -75,20 +75,83 @@ pub fn create(slug: &str, timeouts: Timeouts) -> Result<Box<dyn Provider>, Agent
 }
 
 pub fn lookup_model(slug: &str, model_id: &str) -> Option<Model> {
-    let kind = resolve_provider_kind(slug)?;
+    let config = ProvidersConfig::load();
+    let def = config.get(slug)?;
+    let kind = match def.protocol? {
+        Protocol::Openai => ProviderKind::OpenAi,
+        Protocol::Anthropic => ProviderKind::Anthropic,
+        Protocol::Google => ProviderKind::Google,
+    };
+    let declared = def.models.iter().find(|m| m.id == model_id);
+    let tier = declared
+        .and_then(|m| m.tier.parse::<ModelTier>().ok())
+        .unwrap_or(ModelTier::Medium);
+    let max_output_tokens = declared
+        .and_then(|m| m.max_output_tokens)
+        .unwrap_or_else(|| kind.fallback_max_output());
+    let context_window = declared
+        .and_then(|m| m.context_window)
+        .unwrap_or_else(|| kind.fallback_context_window());
+    let supports_tool_examples_override = declared.and_then(|m| m.supports_tool_examples);
+    let pricing = declared
+        .filter(|m| m.has_pricing())
+        .map(|m| ModelPricing {
+            input: m.pricing_input.unwrap_or(0.0),
+            output: m.pricing_output.unwrap_or(0.0),
+            cache_write: m.pricing_cache_write.unwrap_or(0.0),
+            cache_read: m.pricing_cache_read.unwrap_or(0.0),
+            fast: declared
+                .filter(|d| d.has_fast_pricing())
+                .map(|d| FastPricing {
+                    input: d.pricing_fast_input.unwrap_or(0.0),
+                    output: d.pricing_fast_output.unwrap_or(0.0),
+                }),
+        })
+        .unwrap_or_default();
     Some(Model {
         id: model_id.to_string(),
         provider: kind,
         dynamic_slug: Some(slug.to_string()),
-        tier: ModelTier::Medium,
+        tier,
         family: kind.family(),
-        supports_tool_examples_override: None,
-        pricing: Default::default(),
-        max_output_tokens: kind.fallback_max_output(),
-        context_window: kind.fallback_context_window(),
+        supports_tool_examples_override,
+        pricing,
+        max_output_tokens,
+        context_window,
     })
 }
 
+/// Specs declared statically in `providers.toml` (no HTTP).
+pub fn declared_model_specs() -> Vec<String> {
+    let config = ProvidersConfig::load();
+    let mut specs = Vec::new();
+    for (slug, def) in &config.providers {
+        if builtin_provider(slug).is_some() {
+            continue;
+        }
+        if resolve_protocol(slug, Some(def)).is_none() {
+            continue;
+        }
+        for m in &def.models {
+            specs.push(format!("{slug}/{}", m.id));
+        }
+    }
+    specs
+}
+
+pub fn find_model_for_tier(slug: &str, tier: ModelTier) -> Option<Model> {
+    let config = ProvidersConfig::load();
+    let def = config.get(slug)?;
+    let declared = def
+        .models
+        .iter()
+        .find(|m| m.tier.parse::<ModelTier>().ok() == Some(tier))?;
+    lookup_model(slug, &declared.id)
+}
+
+/// Skip definitions handled by [`declared_model_specs`]; only HTTP `/models`
+/// goes through here, so an empty `discover_models = false` provider returns
+/// nothing and never hits the network.
 pub fn discover_models(timeouts: Timeouts) -> Vec<String> {
     let config = ProvidersConfig::load();
     let mut all_specs = Vec::new();

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -84,7 +84,7 @@ pub fn lookup_model(slug: &str, model_id: &str) -> Option<Model> {
     };
     let declared = def.models.iter().find(|m| m.id == model_id);
     let tier = declared
-        .and_then(|m| m.tier.parse::<ModelTier>().ok())
+        .map(|m| ModelTier::from(m.tier))
         .unwrap_or(ModelTier::Medium);
     let max_output_tokens = declared
         .and_then(|m| m.max_output_tokens)
@@ -145,7 +145,7 @@ pub fn find_model_for_tier(slug: &str, tier: ModelTier) -> Option<Model> {
     let declared = def
         .models
         .iter()
-        .find(|m| m.tier.parse::<ModelTier>().ok() == Some(tier))?;
+        .find(|m| ModelTier::from(m.tier) == tier)?;
     lookup_model(slug, &declared.id)
 }
 


### PR DESCRIPTION
Previously, only `discover_models = true` could populate the model
picker for custom providers, which forces a `GET /models` request on
every startup. Self-hosted endpoints often do not expose `/models`, and
users that already know their model IDs were paying a network round trip
for no benefit.

Add a `models` array on `ProviderDef` so each slug can declare its
catalog inline. `fetch_all_models` emits these specs synchronously
before the HTTP discovery path, so they appear in the picker even when
`discover_models = false` and no request is sent. `available_model_specs`
includes them too, keeping the offline path (ACP, `maki models`,
`Model::from_spec`) consistent with the UI.

`ModelDef` mirrors what the dynamic-provider script protocol already
exposes via `ScriptModel`: `tier`, `context_window`,
`max_output_tokens`, `supports_tool_examples`, plus pricing. Pricing is
flattened into `pricing_input` / `pricing_output` / `pricing_cache_*`
/ `pricing_fast_*` rather than a nested table so TOML stays readable
under `[[slug.models]]` and `maki-config` does not need to depend on
`maki-providers` for `ModelPricing`.

`custom::lookup_model` now reads declared values when present and falls
back to the provider's defaults otherwise, so `Model::from_spec` returns
accurate windows/pricing without the registry. `find_model_for_tier`
lets `Model::from_tier_dynamic` resolve tiered requests (subagent
dispatch, compaction) against declared models for custom slugs, matching
the existing dynamic-provider behaviour.