### PR TITLE
providers: longest-prefix model lookup + Codex plan context window

### DIFF
--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -33,8 +33,8 @@ pub fn resolve_compaction_model(
         .read()
         .unwrap()
         .spec_for_tier_any(maki_providers::ModelTier::Compaction)
-        && let Ok(m) = Model::from_spec(&spec)
-        && let Ok(p) = maki_providers::provider::from_model(&m, timeouts)
+        && let Ok(mut m) = Model::from_spec(&spec)
+        && let Ok(p) = maki_providers::provider::from_model(&mut m, timeouts)
     {
         return (Arc::from(p), m);
     }

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -157,8 +157,9 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
         let working_dir_path = params.initial_wd.clone();
         async move {
             let event_tx = EventSender::new(raw_tx, 0);
+            let mut model = params.model;
             let provider: Arc<dyn Provider> =
-                match provider::from_model_async(&params.model, params.timeouts).await {
+                match provider::from_model_async(&mut model, params.timeouts).await {
                     Ok(p) => Arc::from(p),
                     Err(e) => {
                         error!(error = %e, "provider error");
@@ -173,7 +174,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
             let mut agent = Agent::new(
                 AgentParams {
                     provider,
-                    model: params.model,
+                    model,
                     config: params.config,
                     tool_output_lines: ToolOutputLines::default(),
                     permissions: Arc::new(PermissionManager::new(
@@ -296,7 +297,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
         async move {
             let mut model = params.model;
             let mut provider: Arc<dyn Provider> =
-                match provider::from_model_async(&model, params.timeouts).await {
+                match provider::from_model_async(&mut model, params.timeouts).await {
                     Ok(p) => Arc::from(p),
                     Err(e) => {
                         error!(error = %e, "provider error");
@@ -315,10 +316,10 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                 let event_tx = EventSender::new(raw_tx.clone(), run_id);
                 let error_tx = event_tx.clone();
 
-                if let Some(new_model) = model_rx.try_iter().last()
+                if let Some(mut new_model) = model_rx.try_iter().last()
                     && new_model.spec() != model.spec()
                 {
-                    match provider::from_model_async(&new_model, params.timeouts).await {
+                    match provider::from_model_async(&mut new_model, params.timeouts).await {
                         Ok(p) => {
                             provider = Arc::from(p);
                             tools = tool_definitions(

--- a/maki-agent/src/tools/task.rs
+++ b/maki-agent/src/tools/task.rs
@@ -66,7 +66,7 @@ impl Task {
             if effective == ctx.model.tier {
                 (Model::clone(&ctx.model), Arc::clone(&ctx.provider))
             } else {
-                let resolved_model = {
+                let mut resolved_model = {
                     let map = maki_providers::model_registry::model_registry()
                         .read()
                         .unwrap();
@@ -82,9 +82,10 @@ impl Task {
                     )
                     .map_err(|e| e.to_string())?,
                 );
-                let resolved_provider = provider::from_model_async(&resolved_model, ctx.timeouts)
-                    .await
-                    .map_err(|e| e.to_string())?;
+                let resolved_provider =
+                    provider::from_model_async(&mut resolved_model, ctx.timeouts)
+                        .await
+                        .map_err(|e| e.to_string())?;
                 (resolved_model, Arc::from(resolved_provider))
             }
         } else {

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -148,7 +148,10 @@ fn lookup_entry<'a>(
 ) -> Result<&'a ModelEntry, ModelError> {
     entries
         .iter()
-        .find(|e| e.prefixes.iter().any(|p| model_id.starts_with(p)))
+        .flat_map(|e| e.prefixes.iter().map(move |p| (p, e)))
+        .filter(|(p, _)| model_id.starts_with(*p))
+        .max_by_key(|(p, _)| p.len())
+        .map(|(_, e)| e)
         .ok_or_else(|| ModelError::UnknownModel(model_id.to_string()))
 }
 

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -240,9 +240,11 @@ pub trait Provider: Send + Sync {
     fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
         Box::pin(async { Ok(false) })
     }
+
+    fn adjust_model(&self, _model: &mut Model) {}
 }
 
-pub fn from_model(model: &Model, timeouts: Timeouts) -> Result<Box<dyn Provider>, AgentError> {
+pub fn from_model(model: &mut Model, timeouts: Timeouts) -> Result<Box<dyn Provider>, AgentError> {
     if let Some(slug) = &model.dynamic_slug {
         if dynamic::display_name(slug).is_some() {
             debug!(slug, model = %model.id, "dynamic provider created");
@@ -252,11 +254,12 @@ pub fn from_model(model: &Model, timeouts: Timeouts) -> Result<Box<dyn Provider>
         return crate::providers::custom::create(slug, timeouts);
     }
     let provider = model.provider.create(timeouts)?;
+    provider.adjust_model(model);
     debug!(provider = %model.provider, model = %model.id, "provider created");
     Ok(provider)
 }
 
-pub fn from_model_fallback(model: &Model, timeouts: Timeouts) -> Box<dyn Provider> {
+pub fn from_model_fallback(model: &mut Model, timeouts: Timeouts) -> Box<dyn Provider> {
     match from_model(model, timeouts) {
         Ok(provider) => provider,
         Err(e) => {
@@ -298,7 +301,7 @@ impl Provider for UnconfiguredProvider {
 }
 
 pub async fn from_model_async(
-    model: &Model,
+    model: &mut Model,
     timeouts: Timeouts,
 ) -> Result<Box<dyn Provider>, AgentError> {
     let slug = model.dynamic_slug.clone();
@@ -312,6 +315,9 @@ pub async fn from_model_async(
         }
     })
     .await?;
+    if model.dynamic_slug.is_none() {
+        provider.adjust_model(model);
+    }
     debug!(provider = %kind, model = %id, "provider created");
     Ok(provider)
 }

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -425,7 +425,11 @@ pub fn base_for_slug(slug: &str) -> Option<ProviderKind> {
 
 pub fn lookup_model(slug: &str, model_id: &str) -> Option<Model> {
     let meta = find_meta(slug)?;
-    let script_model = meta.models.iter().find(|m| model_id.starts_with(&m.id))?;
+    let script_model = meta
+        .models
+        .iter()
+        .filter(|m| model_id.starts_with(&m.id))
+        .max_by_key(|m| m.id.len())?;
     Some(Model {
         id: model_id.to_string(),
         provider: meta.base,

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -22,7 +22,9 @@ static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
 };
 
 // NOTE: OpenAI also offers these models for subscription usage via the Coding Plan
-const PLAN_MODELS: &[&str] = &["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.2"];
+pub(crate) const PLAN_MODELS: &[&str] = &["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.2"];
+
+const CODEX_PLAN_CONTEXT_WINDOW: u32 = 272_000;
 
 fn is_codex_model(model_id: &str) -> bool {
     model_id.contains("-codex") || PLAN_MODELS.contains(&model_id)
@@ -219,5 +221,11 @@ impl Provider for OpenAi {
             debug!("reloaded OpenAI auth from storage");
             Ok(())
         })
+    }
+
+    fn adjust_model(&self, model: &mut Model) {
+        if self.is_oauth() && PLAN_MODELS.iter().any(|p| model.id.starts_with(p)) {
+            model.context_window = model.context_window.min(CODEX_PLAN_CONTEXT_WINDOW);
+        }
     }
 }

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -109,14 +109,14 @@ fn spawn_model_fetch(model_slot: &Arc<ArcSwap<ModelSlot>>, timeouts: Timeouts) -
         let warn_tx = warn_tx_bg;
         let done = Box::new(move || {
             let spec = model_slot.load().model.spec();
-            let resolved = match Model::from_spec(&spec) {
+            let mut resolved = match Model::from_spec(&spec) {
                 Ok(m) => m,
                 Err(e) => {
                     warn!(spec = %spec, error = %e, "failed to resolve model after discovery");
                     return;
                 }
             };
-            let provider = match from_model(&resolved, timeouts) {
+            let provider = match from_model(&mut resolved, timeouts) {
                 Ok(p) => p,
                 Err(e) => {
                     warn!(spec = %spec, error = %e, "failed to create provider after discovery");
@@ -159,7 +159,7 @@ impl<'t> EventLoop<'t> {
         params: EventLoopParams,
     ) -> Result<Self> {
         let EventLoopParams {
-            model,
+            mut model,
             needs_login,
             commands,
             session,
@@ -190,10 +190,10 @@ impl<'t> EventLoop<'t> {
 
         let provider: Arc<dyn Provider> = if needs_login {
             Arc::from(maki_providers::provider::from_model_fallback(
-                &model, timeouts,
+                &mut model, timeouts,
             ))
         } else {
-            Arc::from(from_model(&model, timeouts).context("create provider")?)
+            Arc::from(from_model(&mut model, timeouts).context("create provider")?)
         };
         let model_slot = Arc::new(ArcSwap::from_pointee(ModelSlot {
             model: model.clone(),
@@ -476,8 +476,8 @@ impl<'t> EventLoop<'t> {
             Action::LoadSession(loaded) => {
                 let loaded = *loaded;
                 if loaded.model_spec != self.model_slot.load().model.spec()
-                    && let Ok(new_model) = Model::from_spec(&loaded.model_spec)
-                    && let Ok(new_provider) = from_model(&new_model, self.timeouts)
+                    && let Ok(mut new_model) = Model::from_spec(&loaded.model_spec)
+                    && let Ok(new_provider) = from_model(&mut new_model, self.timeouts)
                 {
                     self.model_slot.store(Arc::new(ModelSlot {
                         model: new_model,
@@ -551,7 +551,7 @@ impl<'t> EventLoop<'t> {
 
     fn change_model(&mut self, spec: String) {
         match Model::from_spec(&spec) {
-            Ok(new_model) => match from_model(&new_model, self.timeouts) {
+            Ok(mut new_model) => match from_model(&mut new_model, self.timeouts) {
                 Ok(new_provider) => {
                     self.app.update_model(&new_model);
                     self.model_slot.store(Arc::new(ModelSlot {
@@ -580,10 +580,10 @@ impl<'t> EventLoop<'t> {
         let current_model = &current.model;
 
         if current_model.provider.to_string() == slug {
-            if let Ok(provider) = maki_providers::provider::from_model(current_model, self.timeouts)
-            {
+            let mut m = current_model.clone();
+            if let Ok(provider) = maki_providers::provider::from_model(&mut m, self.timeouts) {
                 self.model_slot.store(Arc::new(ModelSlot {
-                    model: current_model.clone(),
+                    model: m,
                     provider: Arc::from(provider),
                 }));
             }


### PR DESCRIPTION
Model lookup used `starts_with` with the first match, so `glm-5.2-short` would silently inherit the `glm-5.2` context window.  Both `lookup_entry` and dynamic `lookup_model` now pick the longest matching prefix instead.

Added `Provider::adjust_model` to the trait (default no-op) so providers can tweak model fields after construction.  `OpenAi` implements it to cap `context_window` at 272k when the user is on the Codex Coding Plan (OAuth), since OpenAI serves that limit instead of the 1.05M advertised by the API.  `from_model` / `from_model_async` now take `&mut Model` and call the hook.

#360.