### PR TITLE
lua: add set_prompt API and file-based prompt content

### DIFF
--- a/maki-agent/src/prompt.rs
+++ b/maki-agent/src/prompt.rs
@@ -1,7 +1,16 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use strum::EnumString;
+use strum::{Display, EnumIter, EnumString, IntoEnumIterator};
+
+pub trait ValidNames: IntoEnumIterator + std::fmt::Display {
+    fn valid_names() -> String {
+        Self::iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
 
 pub const SYSTEM_PROMPT: &str = include_str!("prompts/system.md");
 pub const PLAN_PROMPT: &str = include_str!("prompts/plan.md");
@@ -10,12 +19,38 @@ pub const GENERAL_PROMPT: &str = include_str!("prompts/general.md");
 pub const COMPACTION_SYSTEM: &str = include_str!("prompts/compaction.md");
 pub const COMPACTION_USER: &str = include_str!("prompts/compaction_user.md");
 
+pub const DEFAULT_IDENTITY: &str = r#"You are Maki, an interactive CLI coding agent. Use the tools available to assist the user with software engineering tasks. Complete tasks successfully while minimizing token usage and tool calls to avoid context bloat.
+
+You must NEVER generate or guess URLs unless they are for helping the user with programming."#;
+
+pub const DEFAULT_TONE: &str = r#"- Be concise. Your output is displayed on a CLI rendered in monospace. Use GitHub-flavored markdown.
+- Only use emojis if explicitly requested.
+- Do not add comments to code unless asked.
+- Output text to communicate with the user; all text you output outside of tool use is displayed to the user. Only use tools to complete tasks. NEVER use bash echo or other command-line tools to communicate thoughts, explanations, diagrams, or instructions to the user. Output all communication directly in your response text instead.
+- NEVER create files unless absolutely necessary. ALWAYS prefer editing existing files."#;
+
 const NATIVE_EFFICIENT_TOOLS: &[&str] = &["batch", "code_execution", "task"];
 const INSTRUCTIONS_MARKER: &str = "{{instructions}}";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumString)]
+/// Singleton: alphabetically last plugin wins, discarding all prior content
+/// and built-in defaults.  Used for slots with opinionated defaults where
+/// multiple contributors would conflict (identity, tone).
+///
+/// Aggregate: all entries are joined.  Used for genuinely additive slots
+/// where multiple plugins contributing is the point (tool usage hints,
+/// efficient tools, after-instructions).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumString, Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum SlotKind {
+    Singleton,
+    Aggregate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumString, Display, EnumIter)]
 #[strum(serialize_all = "snake_case")]
 pub enum Slot {
+    Identity,
+    Tone,
     ToolUsage,
     EfficientTools,
     Conventions,
@@ -25,6 +60,8 @@ pub enum Slot {
 impl Slot {
     fn marker(self) -> &'static str {
         match self {
+            Slot::Identity => "{{identity}}",
+            Slot::Tone => "{{tone}}",
             Slot::ToolUsage => "{{tool_usage}}",
             Slot::EfficientTools => "{{efficient_tools}}",
             Slot::Conventions => "{{conventions}}",
@@ -32,7 +69,39 @@ impl Slot {
         }
     }
 
+    pub fn kind(self) -> SlotKind {
+        match self {
+            Slot::Identity | Slot::Tone => SlotKind::Singleton,
+            Slot::ToolUsage
+            | Slot::EfficientTools
+            | Slot::Conventions
+            | Slot::AfterInstructions => SlotKind::Aggregate,
+        }
+    }
+
+    /// Built-in default content for singleton slots.  When no plugin
+    /// registers content for a singleton slot, the default is used.
+    /// Aggregate slots have no default (the template carries the static
+    /// text around the marker).
+    pub fn default_content(self) -> Option<&'static str> {
+        match self {
+            Slot::Identity => Some(DEFAULT_IDENTITY),
+            Slot::Tone => Some(DEFAULT_TONE),
+            _ => None,
+        }
+    }
+
+    pub fn names_for_kind(kind: SlotKind) -> String {
+        Self::iter()
+            .filter(|s| s.kind() == kind)
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
     const ALL: &[Slot] = &[
+        Slot::Identity,
+        Slot::Tone,
         Slot::ToolUsage,
         Slot::EfficientTools,
         Slot::Conventions,
@@ -40,7 +109,7 @@ impl Slot {
     ];
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumString)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumString, Display, EnumIter)]
 #[strum(serialize_all = "snake_case")]
 pub enum PromptId {
     System,
@@ -51,6 +120,9 @@ pub enum PromptId {
 impl PromptId {
     pub const ALL: &[PromptId] = &[PromptId::System, PromptId::Research, PromptId::General];
 }
+
+impl ValidNames for Slot {}
+impl ValidNames for PromptId {}
 
 pub struct SlotEntry {
     pub plugin: Arc<str>,
@@ -96,12 +168,26 @@ fn render_slot(slots: &ResolvedSlots, prompt: PromptId, slot: Slot) -> String {
     if slot == Slot::EfficientTools {
         return render_efficient_tools(slots, prompt);
     }
-    slots
-        .get(prompt, slot)
-        .iter()
-        .map(|e| e.content.as_str())
-        .collect::<Vec<_>>()
-        .join("\n")
+    let entries = slots.get(prompt, slot);
+    match slot.kind() {
+        SlotKind::Singleton => {
+            if let Some(last) = entries.last() {
+                last.content.clone()
+            } else if let Some(default) = slot.default_content() {
+                default.to_string()
+            } else {
+                String::new()
+            }
+        }
+        // Aggregate slots have no built-in defaults; content comes entirely from plugins.
+        SlotKind::Aggregate => {
+            let mut parts = Vec::new();
+            for entry in entries {
+                parts.push(entry.content.as_str());
+            }
+            parts.join("\n")
+        }
+    }
 }
 
 fn render_efficient_tools(slots: &ResolvedSlots, prompt: PromptId) -> String {
@@ -276,15 +362,23 @@ mod tests {
     #[test_case(PromptId::System, Slot::EfficientTools, true ; "system_efficient")]
     #[test_case(PromptId::System, Slot::Conventions, true ; "system_conventions")]
     #[test_case(PromptId::System, Slot::AfterInstructions, true ; "system_after")]
+    #[test_case(PromptId::System, Slot::Identity, true ; "system_identity")]
+    #[test_case(PromptId::System, Slot::Tone, true ; "system_tone")]
     #[test_case(PromptId::Research, Slot::Conventions, false ; "research_no_conventions")]
     #[test_case(PromptId::Research, Slot::AfterInstructions, false ; "research_no_after")]
+    #[test_case(PromptId::Research, Slot::Identity, false ; "research_no_identity")]
+    #[test_case(PromptId::Research, Slot::Tone, false ; "research_no_tone")]
     #[test_case(PromptId::General, Slot::AfterInstructions, false ; "general_no_after")]
+    #[test_case(PromptId::General, Slot::Identity, false ; "general_no_identity")]
+    #[test_case(PromptId::General, Slot::Tone, false ; "general_no_tone")]
     fn has_slot(prompt: PromptId, slot: Slot, expected: bool) {
         assert_eq!(prompt.has_slot(slot), expected);
     }
 
     #[test_case("after_instructions", Some(Slot::AfterInstructions) ; "valid_slot")]
     #[test_case("tool_usagee", None ; "typo_slot")]
+    #[test_case("identity", Some(Slot::Identity) ; "identity_slot")]
+    #[test_case("tone", Some(Slot::Tone) ; "tone_slot")]
     fn slot_parse_is_plugin_contract(input: &str, expected: Option<Slot>) {
         assert_eq!(input.parse::<Slot>().ok(), expected);
     }
@@ -293,5 +387,92 @@ mod tests {
     #[test_case("systm", None ; "typo_prompt")]
     fn prompt_parse_is_plugin_contract(input: &str, expected: Option<PromptId>) {
         assert_eq!(input.parse::<PromptId>().ok(), expected);
+    }
+
+    #[test_case(Slot::Identity, SlotKind::Singleton ; "identity_singleton")]
+    #[test_case(Slot::Tone, SlotKind::Singleton ; "tone_singleton")]
+    #[test_case(Slot::Conventions, SlotKind::Aggregate ; "conventions_aggregate")]
+    #[test_case(Slot::ToolUsage, SlotKind::Aggregate ; "tool_usage_aggregate")]
+    #[test_case(Slot::EfficientTools, SlotKind::Aggregate ; "efficient_aggregate")]
+    #[test_case(Slot::AfterInstructions, SlotKind::Aggregate ; "after_aggregate")]
+    fn slot_kind_matches_expectations(slot: Slot, expected: SlotKind) {
+        assert_eq!(slot.kind(), expected);
+    }
+
+    #[test]
+    fn singleton_default_used_when_empty() {
+        let out = assemble(PromptId::System, &ResolvedSlots::default(), "");
+        assert!(out.starts_with("You are Maki"));
+    }
+
+    #[test]
+    fn singleton_entry_replaces_default() {
+        let mut s = ResolvedSlots::default();
+        s.insert(
+            PromptId::System,
+            Slot::Identity,
+            SlotEntry {
+                plugin: Arc::from("user"),
+                content: "Custom identity".into(),
+            },
+        );
+        let out = assemble(PromptId::System, &s, "");
+        assert!(out.contains("Custom identity"));
+        assert!(!out.contains("You are Maki"));
+    }
+
+    #[test]
+    fn singleton_last_entry_wins() {
+        let mut s = ResolvedSlots::default();
+        s.insert(
+            PromptId::System,
+            Slot::Identity,
+            SlotEntry {
+                plugin: Arc::from("first"),
+                content: "FIRST".into(),
+            },
+        );
+        s.insert(
+            PromptId::System,
+            Slot::Identity,
+            SlotEntry {
+                plugin: Arc::from("second"),
+                content: "SECOND".into(),
+            },
+        );
+        let out = assemble(PromptId::System, &s, "");
+        assert!(out.contains("SECOND"));
+        assert!(!out.contains("FIRST"));
+        assert!(!out.contains("You are Maki"));
+    }
+
+    #[test]
+    fn identity_only_in_system_not_subagents() {
+        assert!(PromptId::System.has_slot(Slot::Identity));
+        assert!(!PromptId::Research.has_slot(Slot::Identity));
+        assert!(!PromptId::General.has_slot(Slot::Identity));
+    }
+
+    #[test]
+    fn tone_only_in_system_not_subagents() {
+        assert!(PromptId::System.has_slot(Slot::Tone));
+        assert!(!PromptId::Research.has_slot(Slot::Tone));
+        assert!(!PromptId::General.has_slot(Slot::Tone));
+    }
+
+    #[test]
+    fn conventions_entry_appends_to_template_defaults() {
+        let mut s = ResolvedSlots::default();
+        s.insert(
+            PromptId::System,
+            Slot::Conventions,
+            SlotEntry {
+                plugin: Arc::from("plugin"),
+                content: "- Extra rule".into(),
+            },
+        );
+        let out = assemble(PromptId::System, &s, "");
+        assert!(out.contains("Never assume a library is available"));
+        assert!(out.contains("- Extra rule"));
     }
 }

--- a/maki-agent/src/prompts/system.md
+++ b/maki-agent/src/prompts/system.md
@@ -1,13 +1,7 @@
-You are Maki, an interactive CLI coding agent. Use the tools available to assist the user with software engineering tasks. Complete tasks successfully while minimizing token usage and tool calls to avoid context bloat.
-
-You must NEVER generate or guess URLs unless they are for helping the user with programming.
+{{identity}}
 
 # Tone and style
-- Be concise. Your output is displayed on a CLI rendered in monospace. Use GitHub-flavored markdown.
-- Only use emojis if explicitly requested.
-- Do not add comments to code unless asked.
-- Output text to communicate with the user; all text you output outside of tool use is displayed to the user. Only use tools to complete tasks. NEVER use bash echo or other command-line tools to communicate thoughts, explanations, diagrams, or instructions to the user. Output all communication directly in your response text instead.
-- NEVER create files unless absolutely necessary. ALWAYS prefer editing existing files.
+{{tone}}
 
 # Professional objectivity
 Prioritize technical accuracy over validating the user's beliefs. Provide direct, objective technical info without unnecessary praise or emotional validation. Disagree when necessary. Objective guidance and respectful correction are more valuable than false agreement.

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use flume::Sender;
-use maki_agent::prompt::{PromptId, Slot};
+use maki_agent::prompt::{PromptId, Slot, SlotKind, ValidNames};
 use maki_agent::tools::Tool;
 use maki_agent::tools::schema::{ParamSchema, to_json_schema, try_from_json, validate};
 use maki_agent::tools::{
@@ -28,6 +28,7 @@ const TOOL_NAME_MAX: usize = 64;
 const TOOL_HANDLER_RETURN_ERR: &str =
     "tool handler must return string or {output=string, is_error?=bool}";
 const TIMEOUT_PARSE_ERR: &str = "register_tool: 'timeout' must be a positive number, 0, or false";
+const MAX_HINT_CONTENT_SIZE: usize = 1024 * 1024;
 
 #[derive(Clone)]
 pub(crate) enum PermissionScopeKind {
@@ -342,6 +343,89 @@ impl ToolInvocation for LuaToolInvocation {
     }
 }
 
+fn parse_slot(spec: &Table) -> LuaResult<Slot> {
+    spec.get::<String>("slot")
+        .map_err(|_| mlua::Error::runtime("'slot' is required"))?
+        .parse()
+        .map_err(|_| {
+            mlua::Error::runtime(format!("unknown 'slot'. Valid: {}", Slot::valid_names()))
+        })
+}
+
+fn parse_prompt_field(spec: &Table) -> LuaResult<Option<Vec<PromptId>>> {
+    let parse_one = |s: &str| -> mlua::Result<PromptId> {
+        s.parse().map_err(|_| {
+            mlua::Error::runtime(format!(
+                "unknown 'prompt'. Valid: {}",
+                PromptId::valid_names()
+            ))
+        })
+    };
+    match spec.get::<LuaValue>("prompt") {
+        Ok(LuaValue::String(s)) => Ok(Some(vec![parse_one(&s.to_str()?)?])),
+        Ok(LuaValue::Table(t)) => {
+            let mut ids = Vec::new();
+            for pair in t.sequence_values::<mlua::String>() {
+                ids.push(parse_one(&pair?.to_str()?)?);
+            }
+            if ids.is_empty() {
+                return Err(mlua::Error::runtime(
+                    "'prompt' table is empty or has no sequence entries; expected a list like {\"system\", \"general\"}",
+                ));
+            }
+            Ok(Some(ids))
+        }
+        Ok(LuaValue::Nil) | Err(_) => Ok(None),
+        Ok(_) => Err(mlua::Error::runtime(
+            "'prompt' must be a string or list of strings",
+        )),
+    }
+}
+
+fn validate_slot_prompt_compatibility(
+    slot: Slot,
+    prompts: &Option<Vec<PromptId>>,
+) -> LuaResult<()> {
+    if let Some(prompts) = prompts {
+        for &pid in prompts {
+            if !pid.has_slot(slot) {
+                return Err(mlua::Error::runtime(format!(
+                    "slot '{}' is not available for prompt '{}'",
+                    slot, pid
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn parse_hint_content(lua: &Lua, spec: &Table) -> LuaResult<HintContent> {
+    let has_content = spec.contains_key("content")?;
+    if !has_content {
+        return Err(mlua::Error::runtime("'content' is required"));
+    }
+
+    match spec.get("content")? {
+        LuaValue::String(s) => {
+            let text = s.to_string_lossy();
+            if text.is_empty() {
+                return Err(mlua::Error::runtime("'content' must not be empty"));
+            }
+            if text.len() > MAX_HINT_CONTENT_SIZE {
+                return Err(mlua::Error::runtime(format!(
+                    "content exceeds the {} byte limit",
+                    MAX_HINT_CONTENT_SIZE
+                )));
+            }
+            Ok(HintContent::Static(text))
+        }
+        LuaValue::Function(f) => Ok(HintContent::Callback(lua.create_registry_value(f)?)),
+        _ => Err(mlua::Error::runtime(
+            "'content' must be a string or function",
+        )),
+    }
+}
+
 pub(crate) fn create_api_table(
     lua: &Lua,
     pending: PendingTools,
@@ -361,51 +445,19 @@ pub(crate) fn create_api_table(
         t.set(
             "register_prompt_hint",
             lua.create_function(move |lua, spec: Table| {
-                let slot: Slot = spec
-                    .get::<String>("slot")
-                    .map_err(|_| mlua::Error::runtime("'slot' is required"))?
-                    .parse()
-                    .map_err(|_| {
-                        mlua::Error::runtime(
-                            "unknown 'slot'. Valid: tool_usage, efficient_tools, conventions, after_instructions",
-                        )
-                    })?;
+                let slot: Slot = parse_slot(&spec)?;
+                if slot.kind() == SlotKind::Singleton {
+                    return Err(mlua::Error::runtime(format!(
+                        "register_prompt_hint is for aggregate slots ({}); \
+                         use set_prompt for singleton slots ({})",
+                        Slot::names_for_kind(SlotKind::Aggregate),
+                        Slot::names_for_kind(SlotKind::Singleton),
+                    )));
+                }
+                let prompts = parse_prompt_field(&spec)?;
+                validate_slot_prompt_compatibility(slot, &prompts)?;
 
-                let parse_prompt = |s: &str| -> mlua::Result<PromptId> {
-                    s.parse().map_err(|_| {
-                        mlua::Error::runtime("unknown 'prompt'. Valid: system, research, general")
-                    })
-                };
-                let prompts: Option<Vec<PromptId>> = match spec.get::<LuaValue>("prompt") {
-                    Ok(LuaValue::String(s)) => Some(vec![parse_prompt(&s.to_str()?)?]),
-                    Ok(LuaValue::Table(t)) => {
-                        let mut ids = Vec::new();
-                        for pair in t.sequence_values::<mlua::String>() {
-                            ids.push(parse_prompt(&pair?.to_str()?)?);
-                        }
-                        Some(ids)
-                    }
-                    Ok(LuaValue::Nil) | Err(_) => None,
-                    Ok(_) => {
-                        return Err(mlua::Error::runtime(
-                            "'prompt' must be a string or list of strings",
-                        ));
-                    }
-                };
-
-                let content = match spec
-                    .get("content")
-                    .map_err(|_| mlua::Error::runtime("'content' is required"))?
-                {
-                    LuaValue::String(s) => HintContent::Static(s.to_string_lossy()),
-                    LuaValue::Function(f) => HintContent::Callback(lua.create_registry_value(f)?),
-                    _ => {
-                        return Err(mlua::Error::runtime(
-                            "'content' must be a string or function",
-                        ));
-                    }
-                };
-
+                let content = parse_hint_content(lua, &spec)?;
                 let reg = PromptHintRegistration {
                     prompts,
                     slot,
@@ -418,6 +470,39 @@ pub(crate) fn create_api_table(
                 Ok(())
             })?,
         )?;
+    }
+
+    {
+        let plugin = Arc::clone(&plugin);
+        t.set(
+            "set_prompt",
+            lua.create_function(move |lua, spec: Table| {
+                let slot: Slot = parse_slot(&spec)?;
+                if slot.kind() == SlotKind::Aggregate {
+                    return Err(mlua::Error::runtime(format!(
+                        "set_prompt is for singleton slots ({}); \
+                         use register_prompt_hint for aggregate slots ({})",
+                        Slot::names_for_kind(SlotKind::Singleton),
+                        Slot::names_for_kind(SlotKind::Aggregate),
+                    )));
+                }
+
+                let prompts = parse_prompt_field(&spec)?;
+                validate_slot_prompt_compatibility(slot, &prompts)?;
+
+                let content = parse_hint_content(lua, &spec)?;
+                let reg = PromptHintRegistration {
+                    prompts,
+                    slot,
+                    content,
+                };
+                let mut map = lua
+                    .app_data_mut::<PromptHintCallbacks>()
+                    .ok_or_else(|| mlua::Error::runtime("not initialized"))?;
+                map.entry(Arc::clone(&plugin)).or_default().push(reg);
+                Ok(())
+            })?,
+        )?
     }
 
     t.set(

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -569,8 +569,9 @@ mod tests {
 
     /// Targeting a prompt that does not have the slot quietly drops the hint.
     #[test]
-    fn explicit_prompt_without_slot_is_dropped() {
-        let (_host, slots) = slots_from(
+    fn register_prompt_hint_rejects_incompatible_slot_prompt() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        let r = host.load_source(
             "drop",
             r#"
             maki.api.register_prompt_hint({
@@ -580,7 +581,8 @@ mod tests {
             })
             "#,
         );
-        assert!(contents(&slots, PromptId::Research, Slot::AfterInstructions).is_empty());
+        assert!(r.is_err());
+        assert!(r.unwrap_err().to_string().contains("not available"));
     }
 
     #[test]
@@ -670,5 +672,215 @@ mod tests {
         let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
         let src = format!("maki.api.register_prompt_hint({spec})");
         assert!(host.load_source("bad", &src).is_err());
+    }
+
+    #[test]
+    fn identity_slot_lands_on_system_only() {
+        let (_host, slots) = slots_from(
+            "id",
+            r#"
+            maki.api.set_prompt({
+                slot = "identity",
+                content = "Custom identity",
+            })
+            "#,
+        );
+        assert_eq!(
+            contents(&slots, PromptId::System, Slot::Identity),
+            ["Custom identity"]
+        );
+        assert!(contents(&slots, PromptId::Research, Slot::Identity).is_empty());
+        assert!(contents(&slots, PromptId::General, Slot::Identity).is_empty());
+    }
+
+    #[test]
+    fn tone_slot_lands_on_system_only() {
+        let (_host, slots) = slots_from(
+            "tone",
+            r#"
+            maki.api.set_prompt({
+                slot = "tone",
+                content = "Custom tone",
+            })
+            "#,
+        );
+        assert_eq!(
+            contents(&slots, PromptId::System, Slot::Tone),
+            ["Custom tone"]
+        );
+        assert!(contents(&slots, PromptId::Research, Slot::Tone).is_empty());
+        assert!(contents(&slots, PromptId::General, Slot::Tone).is_empty());
+    }
+
+    #[test]
+    fn singleton_last_wins_across_plugins() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        host.load_source(
+            "aaa",
+            r#"maki.api.set_prompt({ slot = "identity", content = "AAA" })"#,
+        )
+        .unwrap();
+        host.load_source(
+            "zzz",
+            r#"maki.api.set_prompt({ slot = "identity", content = "ZZZ" })"#,
+        )
+        .unwrap();
+        let slots = host.event_handle().unwrap().collect_prompt_slots();
+        let entries = slots.get(PromptId::System, Slot::Identity);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries.last().unwrap().content, "ZZZ");
+    }
+
+    #[test]
+    fn content_required() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        let r = host.load_source("bad", r#"maki.api.set_prompt({ slot = "identity" })"#);
+        assert!(r.is_err());
+        assert!(r.unwrap_err().to_string().contains("'content' is required"));
+    }
+
+    #[test]
+    fn set_prompt_sets_identity() {
+        let (_host, slots) = slots_from(
+            "setter",
+            r#"
+            maki.api.set_prompt({
+                slot = "identity",
+                content = "New identity",
+            })
+            "#,
+        );
+        assert_eq!(
+            contents(&slots, PromptId::System, Slot::Identity),
+            ["New identity"]
+        );
+    }
+
+    #[test]
+    fn set_prompt_explicit_system_prompt() {
+        let (_host, slots) = slots_from(
+            "setter",
+            r#"
+            maki.api.set_prompt({
+                slot = "identity",
+                prompt = "system",
+                content = "Explicit identity",
+            })
+            "#,
+        );
+        assert_eq!(
+            contents(&slots, PromptId::System, Slot::Identity),
+            ["Explicit identity"]
+        );
+    }
+
+    #[test]
+    fn prompt_field_targets_specific_prompt() {
+        let (_host, slots) = slots_from(
+            "targeter",
+            r#"
+            maki.api.register_prompt_hint({
+                slot = "tool_usage",
+                prompt = "general",
+                content = "General hint",
+            })
+            "#,
+        );
+        assert_eq!(
+            contents(&slots, PromptId::General, Slot::ToolUsage),
+            ["General hint"]
+        );
+        assert!(contents(&slots, PromptId::System, Slot::ToolUsage).is_empty());
+    }
+
+    #[test]
+    fn set_prompt_invalid_prompt_rejected() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        let r = host.load_source(
+            "bad",
+            r#"maki.api.set_prompt({ slot = "identity", prompt = "nope", content = "x" })"#,
+        );
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn set_prompt_and_register_prompt_hint_coexist() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        host.load_source(
+            "hint",
+            r#"maki.api.register_prompt_hint({ slot = "tool_usage", content = "HINT" })"#,
+        )
+        .unwrap();
+        host.load_source(
+            "setter",
+            r#"maki.api.set_prompt({ slot = "identity", content = "SET" })"#,
+        )
+        .unwrap();
+        let slots = host.event_handle().unwrap().collect_prompt_slots();
+        assert_eq!(
+            contents(&slots, PromptId::System, Slot::ToolUsage),
+            ["HINT"]
+        );
+        assert_eq!(contents(&slots, PromptId::System, Slot::Identity), ["SET"]);
+    }
+
+    #[test]
+    fn set_prompt_rejects_aggregate_slot() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        let r = host.load_source(
+            "bad",
+            r#"maki.api.set_prompt({ slot = "tool_usage", content = "nope" })"#,
+        );
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn set_prompt_rejects_incompatible_slot_prompt() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        let r = host.load_source(
+            "bad",
+            r#"maki.api.set_prompt({ slot = "identity", prompt = "research", content = "x" })"#,
+        );
+        assert!(r.is_err());
+        assert!(r.unwrap_err().to_string().contains("not available"));
+    }
+
+    #[test]
+    fn empty_prompt_table_is_rejected() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        let r = host.load_source(
+            "bad",
+            r#"maki.api.set_prompt({ slot = "identity", prompt = {}, content = "x" })"#,
+        );
+        assert!(r.is_err());
+        assert!(r.unwrap_err().to_string().contains("no sequence entries"));
+    }
+
+    #[test]
+    fn content_must_not_be_empty() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        let r = host.load_source(
+            "bad",
+            r#"maki.api.set_prompt({ slot = "identity", content = "" })"#,
+        );
+        assert!(r.is_err());
+        assert!(r.unwrap_err().to_string().contains("empty"));
+    }
+
+    #[test]
+    fn set_prompt_with_callback() {
+        let (_host, slots) = slots_from(
+            "setter_cb",
+            r#"
+            maki.api.set_prompt({
+                slot = "identity",
+                content = function() return "Dyn identity" end,
+            })
+            "#,
+        );
+        assert_eq!(
+            contents(&slots, PromptId::System, Slot::Identity),
+            ["Dyn identity"]
+        );
     }
 }


### PR DESCRIPTION
Plugins and init.lua can now override identity/tone slots via set_prompt, or load prompt content from files via the new `file` parameter on both set_prompt and register_prompt_hint. Adds SlotKind (Singleton/Aggregate) to enforce replace vs append semantics, and hardens the file parameter against path traversal.

init.lua runs with trusted permissions so users can read their own files without a plugin.toml manifest.

closes #333 