### PR TITLE
fix(ui): refresh model list when opening /model command

### DIFF
--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -1149,7 +1149,7 @@ impl App {
             "/sessions" => self.open_session_picker(),
             "/model" => {
                 self.model_picker.open(&self.state.model.spec());
-                vec![]
+                vec![Action::RefreshModels]
             }
             "/theme" => {
                 self.theme_picker.open();


### PR DESCRIPTION
The model picker was only showing the stale cached list from startup. Now /model also emits Action::RefreshModels to refetch from providers.