### PR TITLE
providers: set custom maki user-agent on all HTTP requests

### DIFF
--- a/maki-providers/build.rs
+++ b/maki-providers/build.rs
@@ -1,0 +1,18 @@
+use std::process::Command;
+
+fn main() {
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                String::from_utf8(o.stdout).ok()
+            } else {
+                None
+            }
+        })
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=GIT_SHORT_HASH={hash}");
+}

--- a/maki-providers/src/providers/anthropic/bedrock.rs
+++ b/maki-providers/src/providers/anthropic/bedrock.rs
@@ -603,7 +603,10 @@ impl Provider for Bedrock {
                 AuthKind::None => None,
             };
 
-            let mut builder = Request::builder().method("POST").uri(&url);
+            let mut builder = Request::builder()
+                .method("POST")
+                .uri(&url)
+                .header("user-agent", super::super::user_agent());
             for (k, v) in &extra_headers {
                 builder = builder.header(*k, *v);
             }

--- a/maki-providers/src/providers/anthropic/mod.rs
+++ b/maki-providers/src/providers/anthropic/mod.rs
@@ -105,7 +105,8 @@ impl Anthropic {
         let mut builder = Request::builder()
             .method(method)
             .uri(url)
-            .header("anthropic-version", API_VERSION);
+            .header("anthropic-version", API_VERSION)
+            .header("user-agent", super::user_agent());
         for (key, value) in &auth.headers {
             builder = builder.header(key.as_str(), value.as_str());
         }

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -421,6 +421,7 @@ async fn try_discover_api_endpoint(client: &HttpClient, token: &str) -> Result<S
         .uri("https://api.github.com/graphql")
         .header("authorization", format!("Bearer {token}"))
         .header("content-type", "application/json")
+        .header("user-agent", super::user_agent())
         .body(serde_json::to_vec(&body)?)?;
 
     let mut response = client.send_async(request).await?;
@@ -446,7 +447,8 @@ fn copilot_request(
         .header("authorization", format!("Bearer {}", auth.token))
         .header("content-type", "application/json")
         .header("editor-version", EDITOR_VERSION_HEADER)
-        .header("x-github-api-version", API_VERSION_HEADER);
+        .header("x-github-api-version", API_VERSION_HEADER)
+        .header("user-agent", super::user_agent());
 
     if let Some(interaction_type) = interaction_type {
         builder

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -122,7 +122,10 @@ impl Google {
 
     fn build_request(&self, method: &str, url: &str) -> isahc::http::request::Builder {
         let auth = self.auth.lock().unwrap();
-        let mut builder = Request::builder().method(method).uri(url);
+        let mut builder = Request::builder()
+            .method(method)
+            .uri(url)
+            .header("user-agent", super::user_agent());
         for (key, value) in &auth.headers {
             builder = builder.header(key.as_str(), value.as_str());
         }

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -28,6 +28,15 @@ pub(crate) mod zai;
 
 const LOW_SPEED_BYTES_PER_SEC: u32 = 1;
 
+pub(crate) fn user_agent() -> &'static str {
+    concat!(
+        "maki/v",
+        env!("CARGO_PKG_VERSION"),
+        "-g",
+        env!("GIT_SHORT_HASH")
+    )
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct Timeouts {
     pub connect: Duration,

--- a/maki-providers/src/providers/openai/responses.rs
+++ b/maki-providers/src/providers/openai/responses.rs
@@ -152,7 +152,8 @@ pub(crate) async fn do_stream(
     let mut builder = Request::builder()
         .method("POST")
         .uri(format!("{base}{RESPONSES_PATH}"))
-        .header("content-type", "application/json");
+        .header("content-type", "application/json")
+        .header("user-agent", super::super::user_agent());
     for (key, value) in &auth.headers {
         builder = builder.header(key.as_str(), value.as_str());
     }

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -102,7 +102,8 @@ impl OpenAiCompatProvider {
         let base = auth.base_url.as_deref().unwrap_or(self.config.base_url);
         let mut builder = Request::builder()
             .method(method)
-            .uri(format!("{base}{path}"));
+            .uri(format!("{base}{path}"))
+            .header("user-agent", super::user_agent());
         for (key, value) in &auth.headers {
             builder = builder.header(key.as_str(), value.as_str());
         }


### PR DESCRIPTION
Replace isahc's curl-derived default User-Agent with a maki-specific string: `maki/v<version>-g<git-short-hash>` (e.g. maki/v0.3.20-g24628c3). A build script captures the git short hash at compile time. Applied to every provider request builder (anthropic, openai responses, google, openai_compat, copilot, bedrock).

Should fix #374 