### PR TITLE
feat(ui): Hide token cost display when pricing is zero

### DIFF
--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -83,6 +83,10 @@ impl ModelPricing {
         fast: None,
     };
 
+    pub fn is_zero(&self) -> bool {
+        self.input == 0.0 && self.output == 0.0 && self.cache_write == 0.0 && self.cache_read == 0.0
+    }
+
     /// Cache multipliers Anthropic applies on top of the base input rate.
     const CACHE_WRITE_MULTIPLIER: f64 = 1.25;
     const CACHE_READ_MULTIPLIER: f64 = 0.10;

--- a/maki-ui/src/components/status_bar.rs
+++ b/maki-ui/src/components/status_bar.rs
@@ -184,19 +184,26 @@ impl StatusBar {
                     right_spans.push(Span::styled(FAST_LABEL, theme::current().status_dim));
                 }
 
-                let rest_text = format!(
-                    "  {}/{} ({}%) ${:.3} ",
+                let context_text = format!(
+                    "  {}/{} ({}%)",
                     format_tokens(ctx.stats.context_size),
                     format_tokens(ctx.stats.context_window),
                     pct,
-                    ctx.stats.usage.cost(ctx.stats.pricing, ctx.fast),
                 );
+                let rest_text = if ctx.stats.pricing.is_zero() {
+                    format!("{context_text} ")
+                } else {
+                    format!(
+                        "{context_text} ${:.3} ",
+                        ctx.stats.usage.cost(ctx.stats.pricing, ctx.fast),
+                    )
+                };
                 right_spans.push(Span::styled(
                     rest_text,
                     Style::new().fg(theme::current().foreground),
                 ));
 
-                if ctx.stats.show_global {
+                if ctx.stats.show_global && !ctx.stats.pricing.is_zero() {
                     let global_text = format!(
                         " \u{03a3}${:.3} ",
                         ctx.stats.global_usage.cost(ctx.stats.pricing, ctx.fast),

--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -292,12 +292,17 @@ pub fn format_timestamp_now() -> String {
 }
 
 pub fn format_turn_usage(usage: &TokenUsage, pricing: &ModelPricing, fast: bool) -> String {
-    let cost = usage.cost(pricing, fast);
-    format!(
-        "{}↑ {}↓ ${cost:.3}",
+    let tokens = format!(
+        "{}↑ {}↓",
         format_tokens(usage.total_input()),
         format_tokens(usage.output),
-    )
+    );
+    if pricing.is_zero() {
+        tokens
+    } else {
+        let cost = usage.cost(pricing, fast);
+        format!("{tokens} ${cost:.3}")
+    }
 }
 
 pub fn append_right_info(


### PR DESCRIPTION
Local providers (ollama, llama_cpp) have zero pricing by default, so the TUI was showing meaningless $0.000. Skip the dollar amount in both the status bar and tool turn usage when all pricing fields are zero. Costs reappear if the user configures explicit pricing.