### PR TITLE
lua: stop empty todo panel popup on session restore

### DIFF
--- a/plugins/todo_write/init.lua
+++ b/plugins/todo_write/init.lua
@@ -59,8 +59,7 @@ local function ensure_win(visible)
   })
 end
 
-local function render_panel(visible)
-  ensure_win(visible)
+local function build_lines()
   local lines = {}
   for _, item in ipairs(items) do
     local marker = STATUS_MARKERS[item.status] or STATUS_MARKERS.pending
@@ -68,7 +67,12 @@ local function render_panel(visible)
       { marker[1] .. " " .. item.content, marker[2] },
     }
   end
-  buf:set_lines(lines)
+  return lines
+end
+
+local function render_panel(visible)
+  ensure_win(visible)
+  buf:set_lines(build_lines())
   win:set_config({ height = #items + 2 })
   if win:is_visible() then
     maki.ui.set_status_hint(nil)
@@ -118,10 +122,13 @@ maki.api.register_tool({
 
   restore = function(input)
     items = input.todos or {}
-    if #items > 0 then
-      render_panel(true)
+    if #items == 0 then
+      return nil
     end
-    return buf
+    render_panel(false)
+    local body = maki.ui.buf()
+    body:set_lines(build_lines())
+    return body
   end,
 
   handler = function(input)


### PR DESCRIPTION
When loading a session whose final state had completed todos, an empty todo panel popped up and after hiding it the status hint showed '6/6'.

Two issues:
1. `restore` called `render_panel(true)` to force the panel visible, which was unwanted on session reload (TurnEnd had already hidden it).
2. `return buf` triggered the runtime's `extract_restore_reply` to call `SharedBuf::take()`, which clears the dirty flag. The UI then processed the queued `OpenWin` command and seeded `cached_lines` via `read_if_dirty()`, which returned `None` because dirty had just been cleared, leaving the panel rendered empty.

Fix: `restore` now renders the panel hidden (so only the status hint shows) and returns a separate fresh buf for the inline history body, so the panel buf's dirty flag is preserved for the UI to pick up.