### PR TITLE
ui: add "Refine plan" option to plan completion menu

### DIFF
--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -2093,8 +2093,8 @@ fn re_edit_keeps_plan_form_visible() {
     assert!(app.plan_form.is_visible());
 }
 
-#[test_case(0, Mode::Build, true,  true  ; "clear_and_implement")]
-#[test_case(1, Mode::Build, false, true  ; "implement_keeps_context")]
+#[test_case(1, Mode::Build, true,  true  ; "clear_and_implement")]
+#[test_case(2, Mode::Build, false, true  ; "implement_keeps_context")]
 fn plan_form_menu_options(
     downs: usize,
     expected_mode: Mode,
@@ -2128,6 +2128,8 @@ fn plan_form_menu_options(
 fn plan_form_implement_toggled_parallel() {
     let mut app = plan_app();
     app.update(Msg::Key(key(KeyCode::Char(' '))));
+    app.update(Msg::Key(key(KeyCode::Down)));
+    app.update(Msg::Key(key(KeyCode::Down)));
     let actions = app.update(Msg::Key(key(KeyCode::Enter)));
     let expected_msg = implement_msg(!PlanForm::new().parallel());
     assert!(

--- a/maki-ui/src/components/plan_form.rs
+++ b/maki-ui/src/components/plan_form.rs
@@ -32,6 +32,11 @@ struct MenuItem {
 
 const MENU: &[MenuItem] = &[
     MenuItem {
+        label: "Refine plan",
+        desc: "  Dismiss and keep editing the plan",
+        action: || PlanFormAction::Hide,
+    },
+    MenuItem {
         label: "Clear context and implement",
         desc: "  Start fresh session, then implement the plan",
         action: || PlanFormAction::ClearAndImplement,
@@ -282,8 +287,9 @@ mod tests {
         assert_eq!(form.selected, expected);
     }
 
-    #[test_case(0, PlanFormAction::ClearAndImplement ; "enter_at_0")]
-    #[test_case(1, PlanFormAction::Implement          ; "enter_at_1")]
+    #[test_case(0, PlanFormAction::Hide              ; "enter_at_0_refine")]
+    #[test_case(1, PlanFormAction::ClearAndImplement ; "enter_at_1")]
+    #[test_case(2, PlanFormAction::Implement          ; "enter_at_2")]
     fn enter_dispatches(selected: usize, expected: PlanFormAction) {
         let mut form = PlanForm::new();
         form.on_plan_ready();


### PR DESCRIPTION
When plan mode finishes, the form only offered "Clear context and implement" and "Implement plan". Added a "Refine plan" option at the top that dismisses the form so the user can type feedback and keep iterating on the plan before committing to implementation.

Reuses the existing `Hide` action since dismissing the form in plan mode already does exactly what we need.

Closes #371