### PR TITLE
fix: Windows path handling and separators.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,7 +2604,6 @@ dependencies = [
  "etcetera",
  "getrandom 0.3.4",
  "isahc",
- "libc",
  "serde",
  "serde_json",
  "tempfile",

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -204,6 +204,9 @@ async fn enforce_permission(
             .await
             .map_err(|e| e.to_string())?;
     }
+    if let Some(target) = inv.mutable_path() {
+        ctx.permissions.check_physical_boundary(target)?;
+    }
     Ok(())
 }
 

--- a/maki-agent/src/permissions.rs
+++ b/maki-agent/src/permissions.rs
@@ -21,9 +21,7 @@ pub const PERMISSION_DENIED_PREFIX: &str = "Permission denied for";
 fn builtin_rules(cwd: &Path) -> Vec<PermissionRule> {
     let cwd_glob = format!(
         "{}/**",
-        cwd.canonicalize()
-            .unwrap_or_else(|_| cwd.to_path_buf())
-            .display()
+        maki_storage::paths::canonicalize_clean(cwd).display()
     );
     let allow = |tool: &str, scope: &str| PermissionRule {
         tool: tool.into(),
@@ -263,6 +261,25 @@ impl PermissionManager {
         self.yolo.load(Ordering::Relaxed)
     }
 
+    /// Check whether a mutable path physically resolves inside the project
+    /// boundary (`cwd`). Returns `Err` if the path escapes via symlink,
+    /// or if the boundary itself cannot be determined (fails closed).
+    pub fn check_physical_boundary(&self, path: &Path) -> Result<(), String> {
+        match physical_boundary_check(&self.cwd, path) {
+            Some(true) => Ok(()),
+            Some(false) => Err(format!(
+                "Path {} resolves outside the project boundary \
+                 (symlink escape detected)",
+                path.display()
+            )),
+            None => Err(format!(
+                "Cannot verify project boundary for {} \
+                 (project root could not be resolved)",
+                path.display()
+            )),
+        }
+    }
+
     pub fn session_rules_snapshot(&self) -> Vec<PermissionRule> {
         self.session_rules().clone()
     }
@@ -406,12 +423,24 @@ fn matches_rule(rule: &PermissionRule, tool: &str, scope: &str) -> bool {
 /// must be tried before the bare `*`, otherwise a plain prefix would swallow
 /// them. `" *"` is the bash form `<command> *`: it has to match the bare
 /// command too (`pwd *` covers `pwd` and `pwd -L`, but not `pwdx`).
+///
+/// For the `/**` path pattern, `Path::starts_with` is used to compare
+/// components rather than characters, which handles both `/` and `\`
+/// transparently on all platforms.
 pub fn scope_matches(pattern: &str, value: &str) -> bool {
     if pattern == "*" || pattern == "**" {
         return true;
     }
     if let Some(prefix) = pattern.strip_suffix("/**") {
-        return value == prefix || value.starts_with(&format!("{prefix}/"));
+        let norm_prefix = maki_storage::paths::canonicalize_clean(Path::new(prefix));
+        // Use incremental canonicalization for the value so symlinks in
+        // existing path components are resolved before any `..` traversal.
+        // `canonicalize_clean` falls back to lexical normalization when the
+        // file doesn't exist, which breaks scope matching when the project
+        // dir itself is a symlink.
+        let norm_value = maki_storage::paths::incremental_canonicalize(Path::new(value))
+            .unwrap_or_else(|| maki_storage::paths::normalize_path(Path::new(value)));
+        return norm_value == norm_prefix || norm_value.starts_with(&norm_prefix);
     }
     if let Some(prefix) = pattern.strip_suffix(" *") {
         return value == prefix || value.starts_with(&format!("{prefix} "));
@@ -422,25 +451,33 @@ pub fn scope_matches(pattern: &str, value: &str) -> bool {
     pattern == value
 }
 
-pub fn canonicalize_scope_path(path: &str) -> String {
+/// Lexical normalization for scope paths. Resolves `..` and `.` without
+/// hitting the filesystem and without producing `\\?\` prefixes on Windows.
+/// Use this for display, logging, and scope matching.
+///
+/// For symlink-aware security checks, use [`physical_boundary_check`].
+pub fn normalize_scope_path(path: &str) -> String {
     let resolved = crate::tools::resolve_path(path).unwrap_or_else(|_| path.to_string());
-    let p = Path::new(&resolved);
-    match p.canonicalize() {
-        Ok(abs) => abs.to_string_lossy().into_owned(),
-        Err(_) => {
-            let mut result = PathBuf::new();
-            for component in p.components() {
-                match component {
-                    std::path::Component::ParentDir => {
-                        result.pop();
-                    }
-                    std::path::Component::CurDir => {}
-                    c => result.push(c),
-                }
-            }
-            result.to_string_lossy().into_owned()
-        }
-    }
+    maki_storage::paths::normalize_path(Path::new(&resolved))
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Check whether `child` is physically inside `parent`, following symlinks.
+///
+/// Uses incremental left-to-right canonicalization: each component is
+/// resolved through the filesystem (including symlinks) *before* any
+/// subsequent `..` component can act on it. This prevents symlink-based
+/// boundary escapes where a symlink followed by `..` resolves to a
+/// location outside the parent.
+///
+/// Returns `true` only when the resolved filesystem location of `child`
+/// is under `parent`. Returns `None` if the parent itself cannot be resolved.
+pub fn physical_boundary_check(parent: &Path, child: &Path) -> Option<bool> {
+    let parent_canon = maki_storage::paths::incremental_canonicalize(parent)?;
+    let child_canon =
+        maki_storage::paths::incremental_canonicalize(child).unwrap_or_else(|| child.to_path_buf());
+    Some(child_canon.starts_with(&parent_canon))
 }
 
 fn generalize_bash_segment(segment: &str) -> String {
@@ -571,8 +608,30 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    fn scope_matches_resolves_symlinked_parent() {
+        let tmp = std::env::temp_dir();
+        let real = tmp.join("__maki_test_scope_symlink_real");
+        let link = tmp.join("__maki_test_scope_symlink_link");
+        let _ = std::fs::remove_dir_all(&real);
+        let _ = std::fs::remove_file(&link);
+        std::fs::create_dir_all(&real).unwrap();
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let pattern = format!("{}/**", real.display());
+        let value = format!("{}/new_file.txt", link.display());
+        assert!(
+            scope_matches(&pattern, &value),
+            "symlinked parent should resolve: pattern={pattern}, value={value}"
+        );
+
+        let _ = std::fs::remove_dir_all(&real);
+        let _ = std::fs::remove_file(&link);
+    }
+
+    #[test]
     fn path_traversal_prompts() {
-        let path = canonicalize_scope_path("/tmp/../etc/passwd");
+        let path = normalize_scope_path("/tmp/../etc/passwd");
         assert!(matches!(
             default_mgr().check("write", &path),
             PermissionCheck::NeedsPrompt { .. }
@@ -640,6 +699,92 @@ mod tests {
             mgr.check("bash", "cargo build"),
             PermissionCheck::NeedsPrompt { .. }
         ));
+    }
+
+    #[test]
+    fn check_physical_boundary_inside_passes() {
+        let tmp = std::env::temp_dir();
+        let mgr = PermissionManager::new(PermissionsConfig::default(), tmp.clone());
+        assert!(
+            mgr.check_physical_boundary(&tmp.join("some_file.txt"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn check_physical_boundary_outside_fails() {
+        let tmp = std::env::temp_dir();
+        let mgr = PermissionManager::new(PermissionsConfig::default(), tmp);
+        // /etc/hosts (unix) or C:\Windows\System32\drivers\etc\hosts (windows)
+        // should always be outside the temp dir.
+        #[cfg(unix)]
+        let outside = Path::new("/etc/hosts");
+        #[cfg(windows)]
+        let outside = Path::new(r"C:\Windows\System32\drivers\etc\hosts");
+        assert!(mgr.check_physical_boundary(outside).is_err());
+    }
+
+    #[test]
+    fn physical_boundary_blocks_dotdot_smuggling() {
+        let tmp = std::env::temp_dir();
+        // Create a real subdir so the walk-up logic has an existing ancestor
+        // to canonicalize, but the `..` components end up in the tail.
+        let sub = tmp.join("__maki_test_boundary");
+        std::fs::create_dir_all(&sub).unwrap();
+        // Attack: /tmp/__maki_test_boundary/fake/../../actually_outside
+        // After normalization: /tmp/actually_outside (inside tmp, fine)
+        // But /tmp/__maki_test_boundary/../../../etc/passwd escapes tmp.
+        #[cfg(unix)]
+        let attack = sub
+            .join("x")
+            .join("..")
+            .join("..")
+            .join("..")
+            .join("etc")
+            .join("passwd");
+        #[cfg(windows)]
+        let attack = sub
+            .join("x")
+            .join("..")
+            .join("..")
+            .join("..")
+            .join("Windows")
+            .join("System32");
+        let mgr = PermissionManager::new(PermissionsConfig::default(), sub.clone());
+        assert!(
+            mgr.check_physical_boundary(&attack).is_err(),
+            "dotdot smuggling should be caught: {}",
+            attack.display()
+        );
+        let _ = std::fs::remove_dir_all(&sub);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn physical_boundary_catches_symlink_escape() {
+        // Simulates: /project/link -> /etc, target /project/link/../hosts
+        // Lexical normalization would resolve to /project/hosts (passes!).
+        // Incremental canonicalization follows the symlink to /etc first,
+        // then `..` goes to /, making the target /hosts (caught!).
+        let tmp = std::env::temp_dir();
+        let project = tmp.join("__maki_test_symlink_escape");
+        let _ = std::fs::remove_dir_all(&project);
+        std::fs::create_dir_all(&project).unwrap();
+
+        // Create symlink: project/link -> /tmp (points somewhere safe but outside project)
+        let link = project.join("link");
+        let _ = std::os::unix::fs::symlink(&tmp, &link);
+
+        // Attack: project/link/../escape_target
+        // OS resolution: follow link to /tmp, then .. to /, then escape_target = /escape_target
+        let attack = link.join("..").join("escape_target");
+        let mgr = PermissionManager::new(PermissionsConfig::default(), project.clone());
+        assert!(
+            mgr.check_physical_boundary(&attack).is_err(),
+            "symlink escape should be caught: {}",
+            attack.display()
+        );
+        let _ = std::fs::remove_dir_all(&project);
     }
 
     #[test]
@@ -734,8 +879,6 @@ mod tests {
         assert_eq!(result, vec!["cargo *", "git *"]);
     }
 
-    #[test_case("edit", "/home/user/project/src/main.rs" => "/home/user/project/src/**" ; "edit_uses_parent_dir")]
-    #[test_case("edit", "/Cargo.toml" => "//**" ; "edit_root_file")]
     #[test_case("webfetch", "some:scope" => "some:scope" ; "unknown_tool_preserves_exact")]
     #[test_case("mcp:fetch", "{\"url\":\"https://a\"}" => "*" ; "mcp_tool_generalizes_to_wildcard")]
     fn generalize_single_scope(tool: &str, scope: &str) -> String {
@@ -743,6 +886,29 @@ mod tests {
             .into_iter()
             .next()
             .unwrap()
+    }
+
+    #[test]
+    fn generalize_edit_uses_parent_dir() {
+        let result = generalize_scope("edit", "/home/user/project/src/main.rs");
+        let expected = format!(
+            "{}/**",
+            Path::new("/home/user/project/src/main.rs")
+                .parent()
+                .unwrap()
+                .display()
+        );
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn generalize_edit_root_file() {
+        let result = generalize_scope("edit", "/Cargo.toml");
+        let expected = format!(
+            "{}/**",
+            Path::new("/Cargo.toml").parent().unwrap().display()
+        );
+        assert_eq!(result, expected);
     }
 
     /// "Allow always" stores a command's generalized scope as a rule, so the

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -198,7 +198,7 @@ pub struct ToolContext {
 pub(crate) fn resolve_path(path: &str) -> Result<String, String> {
     let expanded = if let Some(rest) = path.strip_prefix("~/") {
         let home = HOME.as_deref().ok_or("cannot expand ~: HOME not set")?;
-        format!("{}/{rest}", home.display())
+        home.join(rest).to_string_lossy().into_owned()
     } else if path == "~" {
         let home = HOME.as_deref().ok_or("cannot expand ~: HOME not set")?;
         home.to_string_lossy().into_owned()
@@ -1017,14 +1017,28 @@ mod tests {
 
         assert_eq!(
             resolve_path("~/foo/bar").unwrap(),
-            format!("{}/foo/bar", home.display())
+            home.join("foo/bar").to_string_lossy()
         );
         assert_eq!(resolve_path("~").unwrap(), home.to_string_lossy());
-        assert_eq!(resolve_path("/etc/hosts").unwrap(), "/etc/hosts");
         assert_eq!(
             resolve_path("src/main.rs").unwrap(),
             cwd.join("src/main.rs").to_string_lossy()
         );
+
+        // `/etc/hosts` is absolute on Unix (passed through unchanged) but
+        // root-relative on Windows (no drive prefix, so `is_relative()` is
+        // true and it gets joined with cwd, producing e.g. `C:\etc\hosts`).
+        #[cfg(windows)]
+        {
+            #[allow(clippy::join_absolute_paths)]
+            let expected = cwd.join("/etc/hosts");
+            assert_eq!(
+                resolve_path("/etc/hosts").unwrap(),
+                expected.to_string_lossy()
+            );
+        }
+        #[cfg(not(windows))]
+        assert_eq!(resolve_path("/etc/hosts").unwrap(), "/etc/hosts");
     }
 
     #[test]

--- a/maki-lua/src/api/fs.rs
+++ b/maki-lua/src/api/fs.rs
@@ -542,6 +542,7 @@ pub(crate) fn create_fs_table(lua: &Lua, perms: &PluginPermissions) -> LuaResult
 
 #[cfg(test)]
 mod tests {
+    use std::fs::OpenOptions;
     use std::time::{Duration, SystemTime};
 
     use super::*;
@@ -952,11 +953,15 @@ mod tests {
 
         let old_time = SystemTime::now() - Duration::from_secs(60);
         let new_time = SystemTime::now();
-        std::fs::File::open(&old_path)
+        OpenOptions::new()
+            .write(true)
+            .open(&old_path)
             .unwrap()
             .set_modified(old_time)
             .unwrap();
-        std::fs::File::open(&new_path)
+        OpenOptions::new()
+            .write(true)
+            .open(&new_path)
             .unwrap()
             .set_modified(new_time)
             .unwrap();

--- a/maki-providers/src/providers/anthropic/bedrock.rs
+++ b/maki-providers/src/providers/anthropic/bedrock.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::ops::ControlFlow;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -91,7 +92,7 @@ fn resolve_bedrock_auth() -> Result<BedrockAuth, AgentError> {
     } else {
         let profile = env::var("AWS_PROFILE").unwrap_or_else(|_| "default".into());
         let creds_path = env::var("HOME")
-            .map(|h| format!("{h}/.aws/credentials"))
+            .map(|h| PathBuf::from(h).join(".aws").join("credentials"))
             .unwrap_or_default();
         if let Ok(content) = std::fs::read_to_string(&creds_path)
             && let Ok((access_key, secret_key, session_token)) =

--- a/maki-storage/Cargo.toml
+++ b/maki-storage/Cargo.toml
@@ -6,9 +6,9 @@ edition.workspace = true
 [dependencies]
 getrandom = { workspace = true }
 isahc = { workspace = true }
-libc = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 etcetera = { workspace = true }

--- a/maki-storage/src/lib.rs
+++ b/maki-storage/src/lib.rs
@@ -1,5 +1,6 @@
-//! Persistent storage. `atomic_write` writes to `.tmp` then renames for crash
-//! safety. `atomic_write_permissions` sets file mode before rename (for auth keys at 0600).
+//! Persistent storage. `atomic_write` writes to a `tempfile` in the same
+//! directory then persists (atomic rename) for crash safety.
+//! `atomic_write_permissions` sets file mode before persist (for auth keys at 0600).
 
 pub mod auth;
 pub mod input_history;
@@ -16,7 +17,12 @@ use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+#[cfg(windows)]
+use std::thread;
+#[cfg(windows)]
+use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tempfile::NamedTempFile;
 
 use paths::state_dir;
 
@@ -59,12 +65,19 @@ pub enum StorageError {
 }
 
 pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), StorageError> {
-    let tmp = path.with_extension("tmp");
-    let mut f = fs::File::create(&tmp)?;
-    f.write_all(data)?;
-    f.sync_data()?;
-    fs::rename(&tmp, path)?;
-    Ok(())
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = NamedTempFile::new_in(parent)?;
+    tmp.write_all(data)?;
+    tmp.as_file().sync_data()?;
+    // `into_parts` drops the auto-cleanup-on-drop guarantee, but we need the
+    // File handle closed (Windows can't rename an open file) and `persist()`
+    // doesn't support the fibonacci backoff retry that Windows virus scanners
+    // require. On failure below, we manually clean up the temp file.
+    let (_, tmp_path) = tmp.into_parts();
+    retry_rename(&tmp_path, path).map_err(|e| {
+        let _ = fs::remove_file(&tmp_path);
+        StorageError::Io(e)
+    })
 }
 
 pub(crate) fn atomic_write_permissions(
@@ -72,16 +85,51 @@ pub(crate) fn atomic_write_permissions(
     data: &[u8],
     mode: u32,
 ) -> Result<(), StorageError> {
-    let tmp = path.with_extension("tmp");
-    let mut f = fs::File::create(&tmp)?;
-    f.write_all(data)?;
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = NamedTempFile::new_in(parent)?;
+    tmp.write_all(data)?;
     #[cfg(unix)]
-    fs::set_permissions(&tmp, fs::Permissions::from_mode(mode))?;
+    fs::set_permissions(tmp.path(), fs::Permissions::from_mode(mode))?;
     #[cfg(not(unix))]
     let _ = mode;
-    f.sync_all()?;
-    fs::rename(&tmp, path)?;
-    Ok(())
+    tmp.as_file().sync_all()?;
+    // See `atomic_write` for the `into_parts` tradeoff.
+    let (_, tmp_path) = tmp.into_parts();
+    retry_rename(&tmp_path, path).map_err(|e| {
+        let _ = fs::remove_file(&tmp_path);
+        StorageError::Io(e)
+    })
+}
+
+/// Rename with fibonacci backoff to handle transient `PermissionDenied` from
+/// virus scanners on Windows. 20 steps from 1ms sums to ~18 seconds.
+/// Matches the pattern used by juliaup and rustup.
+///
+/// On non-Windows platforms, `PermissionDenied` from rename is a real
+/// permissions problem (different user, immutable flag, etc.) that
+/// retrying will not fix, so we just call rename once.
+#[cfg(windows)]
+fn retry_rename(src: &Path, dest: &Path) -> std::io::Result<()> {
+    let mut a: u64 = 0;
+    let mut b: u64 = 1;
+    for _ in 0..20 {
+        match fs::rename(src, dest) {
+            Ok(()) => return Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+                thread::sleep(Duration::from_millis(b));
+                let next = a.saturating_add(b);
+                a = b;
+                b = next;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    fs::rename(src, dest)
+}
+
+#[cfg(not(windows))]
+fn retry_rename(src: &Path, dest: &Path) -> std::io::Result<()> {
+    fs::rename(src, dest)
 }
 
 pub fn now_epoch() -> u64 {

--- a/maki-storage/src/log.rs
+++ b/maki-storage/src/log.rs
@@ -19,19 +19,8 @@ fn file_path(dir: &Path, index: u32) -> PathBuf {
     }
 }
 
-#[cfg(unix)]
 fn flock_exclusive(file: &File) -> io::Result<()> {
-    use std::os::unix::io::AsRawFd;
-    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
-    if rc != 0 {
-        return Err(io::Error::last_os_error());
-    }
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn flock_exclusive(_file: &File) -> io::Result<()> {
-    Ok(())
+    file.lock()
 }
 
 pub struct RotatingFileWriter {

--- a/maki-storage/src/paths.rs
+++ b/maki-storage/src/paths.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::OnceLock;
 
 use etcetera::base_strategy::BaseStrategy;
@@ -14,6 +14,140 @@ struct Paths {
     data: PathBuf,
     cache: PathBuf,
     fallback: bool,
+}
+
+/// Lexical path normalization that never hits the filesystem.
+///
+/// Returns an absolute path with `..` and `.` components resolved, but without
+/// calling `canonicalize`. This means no `\\?\` prefix on Windows and no symlink
+/// resolution. Use this for display, logging, and scope matching.
+pub fn normalize_path(path: &Path) -> PathBuf {
+    let abs = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
+    normalize_abs_path(&abs)
+}
+
+fn normalize_abs_path(abs: &Path) -> PathBuf {
+    let mut result = PathBuf::new();
+    for component in abs.components() {
+        match component {
+            Component::ParentDir => {
+                // Only pop if the trailing component is a normal directory,
+                // never a root or prefix.
+                if let Some(Component::Normal(_)) = result.components().next_back() {
+                    result.pop();
+                }
+            }
+            Component::CurDir => {}
+            other => result.push(other.as_os_str()),
+        }
+    }
+    result
+}
+
+/// Canonicalize a path (resolving symlinks) but strip the `\\?\` prefix
+/// that Windows adds. Falls back to `normalize_path` if the path does not
+/// exist yet.
+///
+/// Contract: the input is a "normal" path (no `\\?\` prefix). The output is
+/// always display-friendly: no `\\?\`, no `..` components. On Windows UNC
+/// paths (`\\?\UNC\server\share`), the result is `\\server\share`.
+///
+/// The result is for display, logging, and scope matching only. Do not pass
+/// it to Win32 filesystem APIs if the path exceeds 260 characters (the
+/// `\\?\` prefix is what bypasses that limit).
+pub fn canonicalize_clean(path: &Path) -> PathBuf {
+    match fs::canonicalize(path) {
+        Ok(canon) => strip_windows_extended_prefix(&canon),
+        Err(_) => normalize_path(path),
+    }
+}
+
+/// Canonicalize a path by resolving each component left-to-right through
+/// the filesystem.
+///
+/// At each step, the accumulated path is canonicalized so that symlinks
+/// are resolved *before* a subsequent `..` component can traverse through
+/// them. For non-existent tail components, falls back to lexical append.
+///
+/// This is the correct canonicalization for security-sensitive path checks
+/// (boundary verification, scope matching) where symlink escapes matter.
+/// Unlike `canonicalize_clean`, this never resolves `..` lexically when
+/// a symlink is in play.
+///
+/// Returns `None` if the root/prefix portion of the path cannot be resolved.
+pub fn incremental_canonicalize(path: &Path) -> Option<PathBuf> {
+    let mut current = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => {
+                current.push(component);
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let next = current.join("..");
+                if let Ok(canon) = next.canonicalize() {
+                    current = strip_windows_extended_prefix(&canon);
+                } else if let Some(Component::Normal(_)) = current.components().next_back() {
+                    current.pop();
+                }
+            }
+            Component::Normal(name) => {
+                let next = current.join(name);
+                match next.canonicalize() {
+                    Ok(canon) => current = strip_windows_extended_prefix(&canon),
+                    Err(_) => {
+                        // `current` is already canonical from a prior iteration,
+                        // so we can append the non-existent tail directly without
+                        // re-resolving the parent.
+                        current = next;
+                    }
+                }
+            }
+        }
+    }
+
+    if current.as_os_str().is_empty() {
+        None
+    } else {
+        Some(current)
+    }
+}
+
+/// Strip the `\\?\` prefix that Windows `canonicalize` adds, using the
+/// Rust `Prefix` enum for correct WTF-8 handling (no `.to_str()` lossy
+/// conversion).
+///
+/// `\\?\C:\foo` becomes `C:\foo`.
+/// `\\?\UNC\server\share\dir` becomes `\\server\share\dir`.
+///
+/// **Contract**: the result is for display, logging, and scope matching only.
+/// Do not pass it to Win32 filesystem APIs if the path exceeds 260 characters
+/// (the `\\?\` prefix is what bypasses that limit).
+#[cfg(windows)]
+fn strip_windows_extended_prefix(canon: &Path) -> PathBuf {
+    use std::path::Prefix;
+
+    let mut components = canon.components();
+    let Some(Component::Prefix(pfx)) = components.next() else {
+        return canon.to_path_buf();
+    };
+    let rest = components.as_path();
+    match pfx.kind() {
+        Prefix::VerbatimDisk(drive) => PathBuf::from(format!("{}:", drive as char)).join(rest),
+        Prefix::VerbatimUNC(server, share) => {
+            let mut base = PathBuf::from(r"\\");
+            base.push(server);
+            base.push(share);
+            base.join(rest)
+        }
+        _ => canon.to_path_buf(),
+    }
+}
+
+#[cfg(not(windows))]
+fn strip_windows_extended_prefix(canon: &Path) -> PathBuf {
+    canon.to_path_buf()
 }
 
 fn resolve() -> Option<&'static Paths> {
@@ -130,4 +264,70 @@ pub fn user_config_dirs(home: Option<&Path>, subdir: &str) -> Vec<PathBuf> {
         .or_else(|| legacy_home_dir().map(|d| d.join(subdir)));
     let xdg = config_dir().ok().map(|d| d.join(subdir));
     [legacy, xdg].into_iter().flatten().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_path_resolves_parent() {
+        let cwd = std::env::current_dir().unwrap();
+        let input = cwd.join("a").join("b").join("..").join("c");
+        let expected = cwd.join("a").join("c");
+        assert_eq!(normalize_path(&input), expected);
+    }
+
+    #[test]
+    fn normalize_path_resolves_dot() {
+        let cwd = std::env::current_dir().unwrap();
+        let input = cwd.join("a").join(".").join("b");
+        let expected = cwd.join("a").join("b");
+        assert_eq!(normalize_path(&input), expected);
+    }
+
+    #[test]
+    fn normalize_path_does_not_pop_past_root() {
+        // /../etc should produce /etc, not the relative "etc"
+        let result = normalize_path(Path::new("/../etc"));
+        assert!(result.is_absolute(), "must stay absolute: {result:?}");
+        #[cfg(unix)]
+        assert_eq!(result, PathBuf::from("/etc"));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn strip_extended_prefix_local_drive() {
+        let input = Path::new(r"\\?\C:\Users\test\file.txt");
+        let result = strip_windows_extended_prefix(input);
+        assert_eq!(result, PathBuf::from(r"C:\Users\test\file.txt"));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn strip_extended_prefix_unc_share() {
+        let input = Path::new(r"\\?\UNC\server\share\dir\file.txt");
+        let result = strip_windows_extended_prefix(input);
+        assert_eq!(result, PathBuf::from(r"\\server\share\dir\file.txt"));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn strip_extended_prefix_no_prefix() {
+        let input = Path::new(r"C:\already\normal\path.txt");
+        let result = strip_windows_extended_prefix(input);
+        assert_eq!(result, PathBuf::from(r"C:\already\normal\path.txt"));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn canonicalize_clean_strips_extended_prefix() {
+        let tmp = std::env::temp_dir();
+        let result = canonicalize_clean(&tmp);
+        let s = result.to_str().unwrap();
+        assert!(
+            !s.starts_with(r"\\?\"),
+            "should not have \\\\?\\ prefix: {s}"
+        );
+    }
 }

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -1490,8 +1490,12 @@ fn cd_command_behavior() {
     });
     let flash = app.status_bar.flash_text().unwrap();
     assert!(flash.starts_with("cd /tmp"), "flash={flash:?}");
-    let canonical = std::fs::canonicalize("/tmp").unwrap();
-    assert_eq!(app.state.session.cwd, canonical.to_string_lossy());
+    // Use `canonicalize_clean` (resolves symlinks like the OS does) rather
+    // than `absolute` which preserves symlinks. On macOS `/tmp` is a symlink
+    // to `/private/tmp`; production `cmd_cd` reads back `current_dir()` which
+    // returns the resolved form, so the test expectation must match.
+    let resolved = maki_storage::paths::canonicalize_clean(Path::new("/tmp"));
+    assert_eq!(app.state.session.cwd, resolved.to_string_lossy());
 
     app.execute_command(ParsedCommand {
         name: "/cd".into(),

--- a/plugins/bash/init.lua
+++ b/plugins/bash/init.lua
@@ -46,19 +46,30 @@ local function parse_cd_hint(input)
   return input.command, nil
 end
 
+local function normalize_sep(s)
+  return s:gsub("\\", "/")
+end
+
 local function relative_path(p)
+  local np = normalize_sep(p)
   local cwd = maki.uv.cwd()
-  if cwd and p:sub(1, #cwd + 1) == cwd .. "/" then
-    local rel = p:sub(#cwd + 2)
-    return rel == "" and "." or rel
-  end
-  if cwd and p == cwd then
-    return "."
+  if cwd then
+    cwd = normalize_sep(cwd)
+    if np:sub(1, #cwd + 1) == cwd .. "/" then
+      local rel = np:sub(#cwd + 2)
+      return rel == "" and "." or rel
+    end
+    if np == cwd then
+      return "."
+    end
   end
   local home = maki.uv.os_homedir()
-  if home and p:sub(1, #home + 1) == home .. "/" then
-    local rel = p:sub(#home + 2)
-    return rel == "" and "~" or "~/" .. rel
+  if home then
+    home = normalize_sep(home)
+    if np:sub(1, #home + 1) == home .. "/" then
+      local rel = np:sub(#home + 2)
+      return rel == "" and "~" or "~/" .. rel
+    end
   end
   return p
 end

--- a/plugins/lib/maki/shorten_path.lua
+++ b/plugins/lib/maki/shorten_path.lua
@@ -1,13 +1,24 @@
+local function normalize_sep(s)
+  return s:gsub("\\", "/")
+end
+
 local function shorten_path(path)
+  local p = normalize_sep(path)
   local cwd = maki.uv.cwd()
-  if cwd and path:sub(1, #cwd + 1) == cwd .. "/" then
-    local rel = path:sub(#cwd + 2)
-    return rel == "" and "." or rel
+  if cwd then
+    cwd = normalize_sep(cwd)
+    if p:sub(1, #cwd + 1) == cwd .. "/" then
+      local rel = p:sub(#cwd + 2)
+      return rel == "" and "." or rel
+    end
   end
   local home = maki.uv.os_homedir()
-  if home and path:sub(1, #home + 1) == home .. "/" then
-    local rel = path:sub(#home + 2)
-    return rel == "" and "~" or "~/" .. rel
+  if home then
+    home = normalize_sep(home)
+    if p:sub(1, #home + 1) == home .. "/" then
+      local rel = p:sub(#home + 2)
+      return rel == "" and "~" or "~/" .. rel
+    end
   end
   return path
 end

--- a/plugins/memory/memory_helpers.lua
+++ b/plugins/memory/memory_helpers.lua
@@ -46,12 +46,18 @@ function M.safe_resolve(memories_dir, relative)
   if not relative or relative == "" then
     return nil, "path is required"
   end
-  if relative:find("\0") or relative:sub(1, 1) == "/" then
+  local first = relative:sub(1, 1)
+  if relative:find("\0") or first == "/" or first == "\\" then
+    return nil, "path must be relative"
+  end
+  -- Drive letter (C:\, D:/)
+  if relative:match("^%a:") then
     return nil, "path must be relative"
   end
   local resolved = maki.fs.normalize(maki.fs.joinpath(memories_dir, relative))
   local norm_base = maki.fs.normalize(memories_dir)
-  local prefix = norm_base .. "/"
+  local sep = norm_base:find("\\") and "\\" or "/"
+  local prefix = norm_base .. sep
   if resolved:sub(1, #prefix) ~= prefix then
     return nil, "path traversal outside memories directory is not allowed"
   end

--- a/plugins/memory/tests/spec.lua
+++ b/plugins/memory/tests/spec.lua
@@ -96,9 +96,10 @@ case("safe_resolve_rejects_bad_paths", function()
 end)
 
 case("safe_resolve_accepts_good_paths", function()
+  local s = "[/\\\\]"
   local good = {
     { "notes.md", "notes%.md" },
-    { "sub/deep/notes.md", "sub/deep/notes%.md" },
+    { "sub/deep/notes.md", "sub" .. s .. "deep" .. s .. "notes%.md" },
     { "./notes.md", "notes%.md" },
   }
   for _, v in ipairs(good) do


### PR DESCRIPTION
Path separators need to be handled in a
platform-agnostic way. There are also a few
locking/Windows-specific quirks. This attempts to
handle all of the known issues.

For instance, this gets the various permissions,
config, and memories checks working on Windows.