### PR TITLE
Fix custom provider resolution in from_model_async

### DIFF
--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -244,14 +244,18 @@ pub trait Provider: Send + Sync {
     fn adjust_model(&self, _model: &mut Model) {}
 }
 
+fn provider_for_slug(slug: &str, timeouts: Timeouts) -> Result<Box<dyn Provider>, AgentError> {
+    if dynamic::display_name(slug).is_some() {
+        dynamic::create(slug, timeouts)
+    } else {
+        crate::providers::custom::create(slug, timeouts)
+    }
+}
+
 pub fn from_model(model: &mut Model, timeouts: Timeouts) -> Result<Box<dyn Provider>, AgentError> {
     if let Some(slug) = &model.dynamic_slug {
-        if dynamic::display_name(slug).is_some() {
-            debug!(slug, model = %model.id, "dynamic provider created");
-            return dynamic::create(slug, timeouts);
-        }
-        debug!(slug, model = %model.id, "custom provider created");
-        return crate::providers::custom::create(slug, timeouts);
+        debug!(slug, model = %model.id, "slug provider created");
+        return provider_for_slug(slug, timeouts);
     }
     let provider = model.provider.create(timeouts)?;
     provider.adjust_model(model);
@@ -309,7 +313,7 @@ pub async fn from_model_async(
     let id = model.id.clone();
     let provider = smol::unblock(move || {
         if let Some(slug) = &slug {
-            dynamic::create(slug, timeouts)
+            provider_for_slug(slug, timeouts)
         } else {
             kind.create(timeouts)
         }


### PR DESCRIPTION
from_model_async only called dynamic::create for any dynamic_slug, ignoring custom providers (config-based). This broke task subagents and headless mode when a custom provider was configured and a different model_tier was requested, failing with 'unknown dynamic provider'.

Extract provider_for_slug helper shared by from_model and from_model_async so the dynamic-vs-custom branching cannot diverge.