### PR TITLE
add `maki prompt` subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,14 @@ use maki_agent::tools::{all_builtin_tool_names, is_builtin_tool};
 use crate::print::OutputFormat;
 
 #[derive(Clone, ValueEnum, Default)]
+pub enum PromptVariant {
+    #[default]
+    System,
+    Research,
+    General,
+}
+
+#[derive(Clone, ValueEnum, Default)]
 pub enum InputFormat {
     #[default]
     Text,
@@ -140,7 +148,8 @@ pub struct Cli {
     pub thinking_display: Option<String>,
 
     /// Initial prompt (reads stdin if piped)
-    pub prompt: Option<String>,
+    #[arg(value_name = "PROMPT")]
+    pub initial_prompt: Option<String>,
 }
 
 impl Cli {
@@ -209,6 +218,21 @@ pub enum Command {
         /// Skip all permission prompts
         #[arg(long)]
         yolo: bool,
+    },
+    /// Show the rendered system prompt or tool definitions
+    Prompt {
+        /// Prompt variant: system (default), research, general
+        #[arg(value_enum, default_value_t = PromptVariant::System)]
+        variant: PromptVariant,
+        /// Append the plan mode reminder to the system prompt
+        #[arg(long)]
+        plan: bool,
+        /// Show tool definitions (JSON) instead of prompt text
+        #[arg(long)]
+        tools: bool,
+        /// With --tools: show only tool names, one per line
+        #[arg(long, requires = "tools")]
+        names: bool,
     },
     /// Data migration utilities
     Migrate {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -48,6 +48,14 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         Some(Command::Migrate { action }) => match action {
             MigrateAction::Xdg => migrate::xdg()?,
         },
+        Some(Command::Prompt {
+            variant,
+            plan,
+            tools,
+            names,
+        }) => {
+            subcmd::prompt(&variant, plan, tools, names)?;
+        }
         None => {
             tui::run(cli)?;
         }

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -518,3 +518,77 @@ pub fn mcp_logout(server: &str, storage: &StateDir) -> Result<()> {
     }
     Ok(())
 }
+
+pub fn prompt(
+    variant: &crate::cli::PromptVariant,
+    plan: bool,
+    tools: bool,
+    names: bool,
+) -> Result<()> {
+    use crate::cli::PromptVariant;
+    use maki_agent::agent::{build_system_prompt, load_instruction_text};
+    use maki_agent::prompt::{PromptId, assemble};
+    use maki_agent::template;
+    use maki_agent::tools::{DescriptionContext, ToolFilter, ToolRegistry};
+
+    if plan && !matches!(variant, PromptVariant::System) {
+        bail!("--plan can only be used with the 'system' prompt variant");
+    }
+
+    let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
+    load_env_files(&cwd);
+
+    let vars = template::env_vars();
+    let reg = ToolRegistry::native_arc();
+    let mut host = PluginHost::new(Arc::clone(reg)).context("initialize lua plugin host")?;
+    let raw_config = host.load_init_files(&cwd).context("load init.lua files")?;
+    let config = raw_config
+        .unwrap_or_default()
+        .into_config(false)
+        .context("invalid config")?;
+    host.load_builtins(&config.plugins)
+        .context("load builtin plugins")?;
+
+    if tools {
+        let ctx = DescriptionContext {
+            filter: &ToolFilter::All,
+        };
+        let defs = reg.definitions(&vars, &ctx, true);
+        if names {
+            for name in defs
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(|d| d["name"].as_str())
+            {
+                println!("{name}");
+            }
+        } else {
+            println!("{}", serde_json::to_string_pretty(&defs)?);
+        }
+        return Ok(());
+    }
+
+    let cwd_str = cwd.to_string_lossy();
+    let instructions = load_instruction_text(&cwd_str);
+    let slots = host
+        .event_handle()
+        .map(|h| h.collect_prompt_slots())
+        .unwrap_or_default();
+
+    let output = match variant {
+        PromptVariant::System => {
+            let mode = if plan {
+                maki_agent::AgentMode::Plan(std::path::PathBuf::from("plan.md"))
+            } else {
+                maki_agent::AgentMode::Build
+            };
+            build_system_prompt(&vars, &mode, &instructions, &slots)
+        }
+        PromptVariant::Research => assemble(PromptId::Research, &slots, &instructions),
+        PromptVariant::General => assemble(PromptId::General, &slots, &instructions),
+    };
+
+    print!("{output}");
+    Ok(())
+}

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -154,7 +154,7 @@ pub fn run(cli: Cli) -> Result<()> {
         let fast = config.always_fast && model.supports_fast();
         crate::print::run(
             &model,
-            cli.prompt,
+            cli.initial_prompt,
             cli.output_format,
             cli.verbose,
             config.agent,
@@ -184,7 +184,7 @@ pub fn run(cli: Cli) -> Result<()> {
         } else {
             Model::from_spec(&session.model).unwrap_or(model)
         };
-        let initial_prompt = read_initial_prompt(cli.prompt)?;
+        let initial_prompt = read_initial_prompt(cli.initial_prompt)?;
         let (session_id, exit_code) = maki_ui::run(
             maki_ui::EventLoopParams {
                 model,


### PR DESCRIPTION
Shows the fully rendered system prompt including Lua plugin contributions. Supports `system`, `research`, and `general` variants as a positional arg, `--plan` to append the plan mode reminder, and `--tools` / `--tools --names` for tool definitions.

The positional `prompt` field on `Cli` was renamed to `initial_prompt` to avoid clashing with the new subcommand name (clap ate it as the positional arg first). Display name stays `PROMPT` via `value_name`.