### PR TITLE
agent: fix plan mode blocked by `check_physical_boundary`

### DIFF
--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -99,17 +99,21 @@ pub async fn run(
             }
         };
 
-        if let AgentMode::Plan(plan_path) = &ctx.mode
-            && let Some(target) = invocation.mutable_path()
-            && target != plan_path.as_path()
-        {
-            warn!(
-                tool = %name,
-                target = %target.display(),
-                plan = %plan_path.display(),
-                "blocked write in plan mode"
-            );
-            return done_error(crate::tools::PLAN_WRITE_RESTRICTED.into());
+        if let Some(target) = invocation.mutable_path() {
+            let is_plan_target = matches!(&ctx.mode, AgentMode::Plan(pp) if target == pp.as_path());
+            if !is_plan_target {
+                if matches!(&ctx.mode, AgentMode::Plan(_)) {
+                    warn!(
+                        tool = %name,
+                        target = %target.display(),
+                        "blocked write in plan mode"
+                    );
+                    return done_error(crate::tools::PLAN_WRITE_RESTRICTED.into());
+                }
+                if let Err(e) = ctx.permissions.check_physical_boundary(target) {
+                    return done_error(e);
+                }
+            }
         }
 
         let header_result = invocation.start_header().await;
@@ -203,9 +207,6 @@ async fn enforce_permission(
             )
             .await
             .map_err(|e| e.to_string())?;
-    }
-    if let Some(target) = inv.mutable_path() {
-        ctx.permissions.check_physical_boundary(target)?;
     }
     Ok(())
 }


### PR DESCRIPTION
`check_physical_boundary` lived in `enforce_permission()`, which runs after the plan-mode gate in `run()`. Plan files live at `~/.local/state/maki/plans/` (outside cwd), so the boundary check rejected them even though the plan-mode gate already approved the path.

Moved `check_physical_boundary` out of `enforce_permission()` and into `run()`, co-located with the plan-mode gate. Both checks now share the same `mutable_path()` block: if the target is the plan file it skips both, otherwise it enforces both. This keeps `enforce_permission()` mode-unaware and avoids the two checks drifting apart.

Closes #393.