### PR TITLE
providers: mistral: Fix reasoning handling

### DIFF
--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -106,6 +106,48 @@ pub struct Mistral {
     system_prefix: Option<String>,
 }
 
+fn convert_assistant_messages_in_place(messages: &mut Value) {
+    if let Some(msgs) = messages.as_array_mut() {
+        for msg in msgs {
+            if let Some(obj) = msg.as_object_mut()
+                && obj.get("role").and_then(Value::as_str) == Some("assistant")
+            {
+                let Some(reasoning_val) = obj.remove("reasoning_content") else {
+                    continue;
+                };
+                let Some(reasoning_text) = reasoning_val.as_str() else {
+                    continue;
+                };
+
+                let thinking_block = json!({
+                    "type": "thinking",
+                    "thinking": [{"type": "text", "text": reasoning_text}]
+                });
+
+                if let Some(content) = obj.get_mut("content") {
+                    if let Some(content_str) = content.as_str()
+                        && !content_str.is_empty()
+                    {
+                        // Has text content, create array with both
+                        let text_content = json!({"type": "text", "text": content_str});
+                        *content = json!([thinking_block, text_content]);
+                    } else if content.is_string() {
+                        // Empty string content, just use thinking
+                        *content = json!([thinking_block]);
+                    } else if let Some(arr) = content.as_array_mut() {
+                        // Already an array, prepend thinking
+                        arr.insert(0, thinking_block);
+                    } else {
+                        *content = json!([thinking_block]);
+                    }
+                } else {
+                    obj.insert("content".to_string(), json!([thinking_block]));
+                }
+            }
+        }
+    }
+}
+
 impl Mistral {
     pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
         let pool = KeyPool::resolve("mistral", CONFIG.api_key_env)?;
@@ -148,10 +190,13 @@ impl Provider for Mistral {
             let mut buf = String::new();
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
-
-            if !matches!(opts.thinking, ThinkingConfig::Off) {
+            // Ministral does not support reasoning, Mistral Small 4 and Mistral Medium 3.5 do
+            if !matches!(opts.thinking, ThinkingConfig::Off) && !model.id.starts_with("ministral-")
+            {
                 body["reasoning_effort"] = json!("high");
             }
+            // Convert assistant messages to Mistral's expected format with thinking content
+            convert_assistant_messages_in_place(body.get_mut("messages").unwrap());
 
             let mut extra_headers = vec![];
             if let Some(session_id) = session_id {
@@ -177,5 +222,74 @@ impl Provider for Mistral {
                 .as_ref()
                 .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Value, json};
+    use test_case::test_case;
+
+    #[test_case(
+        json!([
+            {"role": "system", "content": "sys"},
+            {"role": "assistant", "content": "text", "reasoning_content": "thinking"}
+        ]),
+        json!([
+            {"role": "system", "content": "sys"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": [{"type": "text", "text": "thinking"}]},
+                    {"type": "text", "text": "text"}
+                ]
+            }
+        ])
+        ; "assistant_text_and_thinking"
+    )]
+    #[test_case(
+        json!([
+            {"role": "system", "content": "sys"},
+            {"role": "assistant", "content": "", "reasoning_content": "thinking"}
+        ]),
+        json!([
+            {"role": "system", "content": "sys"},
+            {
+                "role": "assistant",
+                "content": [{"type": "thinking", "thinking": [{"type": "text", "text": "thinking"}]}]
+            }
+        ])
+        ; "assistant_empty_content_with_thinking"
+    )]
+    #[test_case(
+        json!([
+            {"role": "system", "content": "sys"},
+            {"role": "assistant", "reasoning_content": "thinking"}
+        ]),
+        json!([
+            {"role": "system", "content": "sys"},
+            {
+                "role": "assistant",
+                "content": [{"type": "thinking", "thinking": [{"type": "text", "text": "thinking"}]}]
+            }
+        ])
+        ; "assistant_no_content_with_thinking"
+    )]
+    #[test_case(
+        json!([
+            {"role": "system", "content": "sys"},
+            {"role": "assistant", "content": "text"}
+        ]),
+        json!([
+            {"role": "system", "content": "sys"},
+            {"role": "assistant", "content": "text"}
+        ])
+        ; "assistant_text_only_no_thinking"
+    )]
+    fn convert_assistant_messages_in_place_test(input: Value, expected: Value) {
+        let mut input_clone = input.clone();
+        convert_assistant_messages_in_place(&mut input_clone);
+        assert_eq!(input_clone, expected);
     }
 }


### PR DESCRIPTION
    Ministral doesn't support reasoning and setting reasoning_effort for it
    will fail.
    
    Models that do support reasoning want to have the past reasoning content
    of assistant messages in a specific format, which we have to convert to.
