### PR TITLE
providers: mistral: Update models list

### DIFF
--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -24,14 +24,14 @@ inventory::submit!(maki_config::providers::BuiltInProvider {
     protocol: maki_config::providers::Protocol::Openai,
     default_base_url: "https://api.mistral.ai/v1",
     default_api_key_env: "MISTRAL_API_KEY",
-    default_model: "mistral/devstral-latest",
+    default_model: "mistral/mistral-medium-latest",
     plans: Some(&[
         (
             "standard",
             maki_config::providers::ProviderPlan {
                 display_name: "Standard",
                 base_url: "https://api.mistral.ai/v1",
-                default_model: Some("mistral/devstral-latest"),
+                default_model: Some("mistral/mistral-medium-latest"),
                 login_url: None,
             }
         ),
@@ -52,28 +52,17 @@ inventory::submit!(maki_config::providers::BuiltInProvider {
 pub(crate) fn models() -> &'static [ModelEntry] {
     &[
         ModelEntry {
-            prefixes: &["devstral-latest", "devstral-medium-latest", "devstral-2512"],
+            prefixes: &[
+                "mistral-medium-latest",
+                "mistral-medium-3.5",
+                "mistral-medium-2604",
+            ],
             tier: ModelTier::Strong,
             family: ModelFamily::Generic,
             default: true,
             pricing: ModelPricing {
-                input: 0.4,
-                output: 2.0,
-                cache_write: 0.00,
-                cache_read: 0.00,
-                fast: None,
-            },
-            max_output_tokens: 262_144,
-            context_window: 262_144,
-        },
-        ModelEntry {
-            prefixes: &["mistral-large-latest", "mistral-large-2512"],
-            tier: ModelTier::Medium,
-            family: ModelFamily::Generic,
-            default: true,
-            pricing: ModelPricing {
-                input: 0.5,
-                output: 1.5,
+                input: 1.5,
+                output: 7.5,
                 cache_write: 0.00,
                 cache_read: 0.00,
                 fast: None,
@@ -83,12 +72,27 @@ pub(crate) fn models() -> &'static [ModelEntry] {
         },
         ModelEntry {
             prefixes: &["mistral-small-latest", "mistral-small-2603"],
-            tier: ModelTier::Weak,
+            tier: ModelTier::Medium,
             family: ModelFamily::Generic,
             default: true,
             pricing: ModelPricing {
                 input: 0.15,
                 output: 0.60,
+                cache_write: 0.00,
+                cache_read: 0.00,
+                fast: None,
+            },
+            max_output_tokens: 262_144,
+            context_window: 262_144,
+        },
+        ModelEntry {
+            prefixes: &["ministral-14b-latest", "ministral-14b-2512"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Generic,
+            default: true,
+            pricing: ModelPricing {
+                input: 0.20,
+                output: 0.20,
                 cache_write: 0.00,
                 cache_read: 0.00,
                 fast: None,

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -114,11 +114,11 @@ Connects to any OpenAI-compatible `/v1` endpoint. Point `LLAMA_CPP_HOST` to your
 
 | Tier | Models | Pricing (in/out per 1M tokens) | Context |
 |------|--------|-------------------------------|---------|
-| Weak | **mistral-small-latest, mistral-small-2603** (default) | $0.15 / $0.60 | 262K ctx / 262K out |
-| Medium | **mistral-large-latest, mistral-large-2512** (default) | $0.50 / $1.50 | 262K ctx / 262K out |
-| Strong | **devstral-latest, devstral-medium-latest, devstral-2512** (default) | $0.40 / $2.00 | 262K ctx / 262K out |
+| Weak | **ministral-14b-latest, ministral-14b-2512** (default) | $0.20 / $0.20 | 262K ctx / 262K out |
+| Medium | **mistral-small-latest, mistral-small-2603** (default) | $0.15 / $0.60 | 262K ctx / 262K out |
+| Strong | **mistral-medium-latest, mistral-medium-3.5, mistral-medium-2604** (default) | $1.50 / $7.50 | 262K ctx / 262K out |
 
-Defaults: devstral-latest (strong), mistral-large-latest (medium), mistral-small-latest (weak)
+Defaults: mistral-medium-latest (strong), mistral-small-latest (medium), ministral-14b-latest (weak)
 
 ### Z.AI
 


### PR DESCRIPTION
devstral 2 is deprecated in favour of medium 3.5 now, so let's use that as strong model. Update mistral small 4 to medium and add ministral 14b as weak model.

----

@lu-zero Also something to confirm from your side.