### PR TITLE
fix(plugins/skill): honor tool_output_lines.other

### DIFF
--- a/plugins/skill/init.lua
+++ b/plugins/skill/init.lua
@@ -126,7 +126,7 @@ maki.api.register_tool({
     local buf = maki.ui.buf()
     local tol = ctx:tool_output_lines()
     local view = ToolView.new(buf, {
-      max_lines = (tol and tol.skill) or 20,
+      max_lines = (tol and tol.other) or 20,
       keep = "head",
     })
     buf:on("click", function()


### PR DESCRIPTION
`plugins/skill/init.lua` reads `tol.skill`, a field that doesn't exist on `ToolOutputLines` (`maki-config/src/lib.rs`). The struct exposes `bash`, `code_execution`, `task`, `index`, `grep`, `read`, `write`, `web`, and `other`. So:

- Setting `tool_output_lines = { skill = N }` errors at config load with `unknown field 'skill'`.
- Setting `tool_output_lines = { other = N }` is accepted but the `skill` plugin ignores it and keeps emitting up to 20 lines.

The fix reads `tol.other` like `glob`, `grep`, and `memory` already do:

```diff
-      max_lines = (tol and tol.skill) or 20,
+      max_lines = (tol and tol.other) or 20,
```

The `or 20` fallback is preserved, so anyone who hasn't set `tool_output_lines.other` sees the same 20-line skill output as before.

> Note: the fallback value doesn't seem consistent between plugins so I left the default 20 as is.

## Verification

- `just ci` green on the branch.
- Manual: with `tool_output_lines = { other = 1 }` in `~/.config/maki/init.lua`, invoking a skill collapses output to one line on this branch and stays at the full body on `main`.

## AI disclosure

Behavior and potential fix was diagnosed in a maki session with Claude Opus 4.7. The edit and verification was done by hand.
