### PR TITLE
feat(websearch): use EXA_API_KEY env var as x-api-key header when set

### DIFF
--- a/maki-lua/src/api/uv.rs
+++ b/maki-lua/src/api/uv.rs
@@ -21,5 +21,10 @@ pub(crate) fn create_uv_table(lua: &Lua, perms: &PluginPermissions) -> LuaResult
         })?,
     )?;
 
+    t.set(
+        "os_getenv",
+        perms.guard(Env, lua, |_, name: String| Ok(std::env::var(&name).ok()))?,
+    )?;
+
     Ok(t)
 }

--- a/maki-lua/tests/uv_api.rs
+++ b/maki-lua/tests/uv_api.rs
@@ -1,0 +1,56 @@
+use std::sync::Arc;
+
+use maki_agent::tools::ToolRegistry;
+use maki_lua::{PluginHost, PluginPermissions};
+
+fn setup() -> PluginHost {
+    let reg = Arc::new(ToolRegistry::new());
+    PluginHost::new(reg).unwrap()
+}
+
+#[test]
+fn os_getenv_reads_existing_var() {
+    let host = setup();
+    host.load_source(
+        "getenv_existing",
+        r#"
+        local home = maki.uv.os_getenv("HOME")
+        assert(home ~= nil, "HOME should be set")
+        assert(type(home) == "string", "HOME should be a string")
+        "#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn os_getenv_returns_nil_for_missing_var() {
+    let host = setup();
+    host.load_source(
+        "getenv_missing",
+        r#"
+        local val = maki.uv.os_getenv("MAKI_TEST_VAR_DOES_NOT_EXIST_12345")
+        assert(val == nil, "unset var should return nil, got: " .. tostring(val))
+        "#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn os_getenv_denied_without_env_permission() {
+    let host = setup();
+    host.load_source_with_permissions(
+        "getenv_denied",
+        r#"
+        local ok, err = pcall(function()
+            return maki.uv.os_getenv("HOME")
+        end)
+        assert(not ok, "should fail without env permission")
+        assert(
+            tostring(err):find("permission denied"),
+            "should mention permission denied, got: " .. tostring(err)
+        )
+        "#,
+        PluginPermissions::denied(),
+    )
+    .unwrap();
+}

--- a/plugins/websearch/init.lua
+++ b/plugins/websearch/init.lua
@@ -71,13 +71,19 @@ maki.api.register_tool({
     local max_lines = (config and config.max_output_lines) or 2000
     local max_bytes = (config and config.max_output_bytes) or (50 * 1024)
 
+    local headers = {
+      ["Content-Type"] = "application/json",
+      ["Accept"] = "application/json, text/event-stream",
+    }
+    local api_key = os.getenv("EXA_API_KEY")
+    if api_key then
+      headers["x-api-key"] = api_key
+    end
+
     local resp, err = maki.net.request(EXA_MCP_ENDPOINT, {
       method = "POST",
       body = payload,
-      headers = {
-        ["Content-Type"] = "application/json",
-        ["Accept"] = "application/json, text/event-stream",
-      },
+      headers = headers,
       timeout = REQUEST_TIMEOUT_SECS,
       max_bytes = max_response,
     })

--- a/plugins/websearch/init.lua
+++ b/plugins/websearch/init.lua
@@ -75,7 +75,7 @@ maki.api.register_tool({
       ["Content-Type"] = "application/json",
       ["Accept"] = "application/json, text/event-stream",
     }
-    local api_key = os.getenv("EXA_API_KEY")
+    local api_key = maki.uv.os_getenv("EXA_API_KEY")
     if api_key then
       headers["x-api-key"] = api_key
     end


### PR DESCRIPTION
When the `EXA_API_KEY` environment variable is set, the websearch plugin now passes it as an `x-api-key` header when calling the Exa MCP API. Anonymous requests continue to work as before when the variable is not set.