### PR TITLE
feat(providers/copilot): add claude-opus-4.7 to model table

### DIFF
--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -72,6 +72,15 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             max_output_tokens: 100_000,
             context_window: 200_000,
         },
+        ModelEntry {
+            prefixes: &["claude-opus-4.7"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Generic,
+            default: false,
+            pricing: ModelPricing::ZERO,
+            max_output_tokens: 64_000,
+            context_window: 264_000,
+        },
     ]
 }
 

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -87,7 +87,7 @@ Defaults: gemini-2.5-pro (strong), gemini-2.5-flash (medium), gemini-2.0-flash-l
 |------|--------|-------------------------------|---------|
 | Weak | **gpt-5-mini, gpt-5 mini, claude-haiku-4.5** (default) | $0.00 / $0.00 | 200K ctx / 100K out |
 | Medium | **gpt-5.2, gpt-4.1, claude-sonnet-4.5** (default) | $0.00 / $0.00 | 200K ctx / 100K out |
-| Strong | **gpt-5.4, gpt-5.3-codex, claude-opus-4.6, grok-code-fast-1** (default) | $0.00 / $0.00 | 200K ctx / 100K out |
+| Strong | **gpt-5.4, gpt-5.3-codex, claude-opus-4.6, grok-code-fast-1** (default), claude-opus-4.7 | $0.00 / $0.00 | 200K ctx / 100K out |
 
 Defaults: gpt-5-mini (weak), gpt-5.2 (medium), gpt-5.4 (strong)
 


### PR DESCRIPTION
Selecting `claude-opus-4.7` against the Copilot provider currently falls through to `provider.fallback_*` because the static table in `maki-providers/src/providers/copilot/mod.rs` has no row for it. The fallback reports `context_window: 200_000, max_output_tokens: 100_000`. The real Copilot API values for opus-4.7 on Pro+/Business are `264_000` and `64_000`. Two consequences: the inflated `max_output_tokens` proposes requests above the API cap (`64_000`), and Maki's compaction trigger (`context_window - max(compaction_buffer, max_output_tokens)`) gets pushed past the user's configured buffer, effectively disabling compaction until the session hits the wall.

This PR adds one `ModelEntry` mirroring the existing strong-tier row shape. The `site/docs/content/providers/_index.md` hunk is a `just gen-docs` regen.

## Verification

Re-run against your own Copilot token:

```bash
curl -sf https://api.githubcopilot.com/models \
  -H "Authorization: Bearer $(gh auth token)" \
  -H "Copilot-Integration-Id: vscode-chat" \
  -H "Editor-Version: vscode/1.92.0" \
  | jq '.data[] | select(.id == "claude-opus-4.7") | .capabilities.limits'
```

Returns (verified 2026-06-28):

```json
{
  "max_context_window_tokens": 264000,
  "max_output_tokens": 64000,
  "max_prompt_tokens": 200000
}
```

The JSON shape is documented in Microsoft's own Copilot type definitions: `CCAModelLimits` in [microsoft/vscode `src/typings/copilot-api.d.ts`](https://github.com/microsoft/vscode/blob/99489178/src/typings/copilot-api.d.ts) and `IChatModelCapabilities.limits` in [microsoft/vscode-copilot-chat `src/platform/endpoint/common/endpointProvider.ts`](https://github.com/microsoft/vscode-copilot-chat/blob/a9900c5f/src/platform/endpoint/common/endpointProvider.ts) both declare `max_context_window_tokens`, `max_output_tokens`, and `max_prompt_tokens` under `capabilities.limits` on every chat model the Copilot endpoint serves.

`just ci` green locally.

## Related, not in this PR

- `claude-opus-4.6` returns the same `(264_000, 64_000)` from the live API, so its current row `(200_000, 100_000)` is wrong too. Kept out of this PR to stay additive; happy to send a follow-up if you want existing rows updated.
- The architecturally cleaner fix is to plumb `capabilities.limits` through `Copilot::list_models()` (it currently calls `ModelInfo::id_only` and throws the limits away). That fixes every current and future Copilot model in one change. Also happy to send as a follow-up.
- `site/docs/content/providers/_index.md` now shows the Copilot Strong row as `200K ctx / 100K out` because `maki-docgen/src/gen_providers.rs` renders one row per tier and pulls pricing/context from `tier_entries.first()`. opus-4.7's real `(264K, 64K)` isn't reflected there. This is a pre-existing limitation (the Anthropic Strong row has the same issue with `claude-opus-4-0` / `claude-opus-4-1` pricing).

## AI disclosure

Behavior and potential fix was diagnosed in a maki session with Claude Opus 4.7. The edit and verification was done by hand.
