### PR TITLE
plugins: edit: add `edit_lines` tool for line-number-based replacements

### DIFF
--- a/maki-agent/src/permissions.rs
+++ b/maki-agent/src/permissions.rs
@@ -4,7 +4,7 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use maki_config::{
-    DefaultEffect, Effect, PermissionRule, PermissionTarget, PermissionsConfig,
+    DefaultEffect, Effect, FILE_WRITE_TOOLS, PermissionRule, PermissionTarget, PermissionsConfig,
     append_permission_rule,
 };
 use thiserror::Error;
@@ -28,12 +28,12 @@ fn builtin_rules(cwd: &Path) -> Vec<PermissionRule> {
         scope: Some(scope.into()),
         effect: Effect::Allow,
     };
-    vec![
-        allow("write", &cwd_glob),
-        allow("edit", &cwd_glob),
-        allow("multiedit", &cwd_glob),
-        allow("task", "*"),
-    ]
+    let mut rules: Vec<PermissionRule> = FILE_WRITE_TOOLS
+        .iter()
+        .map(|tool| allow(tool, &cwd_glob))
+        .collect();
+    rules.push(allow("task", "*"));
+    rules
 }
 
 pub const BOUNDARY_UNVERIFIABLE_PREFIX: &str = "Cannot verify project boundary for";
@@ -494,7 +494,7 @@ pub fn generalized_scopes(tool: &str, scopes: &[String]) -> Vec<String> {
 fn generalize_scope(tool: &str, scope: &str) -> String {
     match tool {
         "bash" => generalize_bash_segment(scope),
-        "write" | "edit" | "multiedit" => {
+        tool if FILE_WRITE_TOOLS.contains(&tool) => {
             let p = Path::new(scope);
             match p.parent() {
                 Some(parent) if !parent.as_os_str().is_empty() => {

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -78,6 +78,10 @@ pub const DEFAULT_BUILTINS: &[&str] = &[
     "write",
 ];
 
+pub const OPT_IN_TOOLS: &[&str] = &["edit_lines"];
+
+pub const FILE_WRITE_TOOLS: &[&str] = &["write", "edit", "multiedit", "edit_lines"];
+
 #[derive(Debug, Clone, Copy)]
 pub enum ConfigValue {
     Bool(bool),
@@ -222,12 +226,17 @@ impl RawConfig {
     }
 
     pub fn into_config(self, no_rtk: bool) -> Result<Config, ConfigError> {
-        let disabled_tools: Vec<String> = self
+        let mut disabled_tools: Vec<String> = self
             .tools
             .iter()
             .filter(|(_, cfg)| cfg.enabled == Some(false))
             .map(|(name, _)| name.clone())
             .collect();
+        for &name in OPT_IN_TOOLS {
+            if self.tools.get(name).and_then(|t| t.enabled) != Some(true) {
+                disabled_tools.push(name.to_string());
+            }
+        }
         Ok(Config {
             always_yolo: self.always_yolo.unwrap_or(false),
             always_fast: self.always_fast.unwrap_or(false),
@@ -625,7 +634,8 @@ impl ToolOutputLines {
             "index" => self.index,
             "grep" | "glob" => self.grep,
             "read" => self.read,
-            "write" | "edit" | "multiedit" | "memory" => self.write,
+            "memory" => self.write,
+            name if FILE_WRITE_TOOLS.contains(&name) => self.write,
             "webfetch" | "websearch" => self.web,
             _ => self.other,
         }
@@ -1886,6 +1896,45 @@ mod tests {
                 "DEFAULT_BUILTINS not sorted: {:?} >= {:?}",
                 pair[0],
                 pair[1]
+            );
+        }
+    }
+
+    #[test]
+    fn opt_in_tools_require_explicit_enable() {
+        let default_config = RawConfig::default().into_config(false).unwrap();
+        for &name in OPT_IN_TOOLS {
+            assert!(
+                default_config
+                    .agent
+                    .disabled_tools
+                    .contains(&name.to_string()),
+                "{name} should be disabled by default"
+            );
+        }
+
+        let mut tools = HashMap::new();
+        for &name in OPT_IN_TOOLS {
+            tools.insert(
+                name.to_string(),
+                ToolFileConfig {
+                    enabled: Some(true),
+                },
+            );
+        }
+        let enabled_config = RawConfig {
+            tools,
+            ..Default::default()
+        }
+        .into_config(false)
+        .unwrap();
+        for &name in OPT_IN_TOOLS {
+            assert!(
+                !enabled_config
+                    .agent
+                    .disabled_tools
+                    .contains(&name.to_string()),
+                "{name} should be enabled when configured"
             );
         }
     }

--- a/plugins/edit/edit_helpers.lua
+++ b/plugins/edit/edit_helpers.lua
@@ -1,0 +1,52 @@
+local M = {}
+
+local function split_lines(s)
+  if s:sub(-1) == "\n" then
+    s = s:sub(1, -2)
+  end
+  local lines = {}
+  for line in (s .. "\n"):gmatch("([^\n]*)\n") do
+    lines[#lines + 1] = line
+  end
+  return lines
+end
+
+function M.replace_lines(content, start_line, end_line, new_string)
+  local trailing_nl = content:sub(-1) == "\n"
+  local lines = split_lines(content)
+  local inserting = end_line == nil
+
+  if inserting then
+    if start_line < 1 or start_line > #lines + 1 then
+      return nil, string.format("start line %d out of range (1-%d)", start_line, #lines + 1)
+    end
+  else
+    if start_line < 1 or start_line > #lines then
+      return nil, string.format("start line %d out of range (1-%d)", start_line, #lines)
+    end
+    if end_line < start_line or end_line > #lines then
+      return nil, string.format("end line %d out of range (%d-%d)", end_line, start_line, #lines)
+    end
+  end
+
+  local skip_from = inserting and start_line or start_line
+  local skip_to = inserting and start_line - 1 or end_line
+
+  local result = {}
+  for i = 1, skip_from - 1 do
+    result[#result + 1] = lines[i]
+  end
+  if new_string ~= "" then
+    for _, line in ipairs(split_lines(new_string)) do
+      result[#result + 1] = line
+    end
+  end
+  for i = skip_to + 1, #lines do
+    result[#result + 1] = lines[i]
+  end
+
+  local joined = table.concat(result, "\n")
+  return trailing_nl and joined .. "\n" or joined
+end
+
+return M

--- a/plugins/edit/init.lua
+++ b/plugins/edit/init.lua
@@ -1,6 +1,10 @@
 local shorten_path = require("maki.shorten_path")
 local ToolView = require("maki.tool_view")
 local fuzzy_replace = require("maki.fuzzy_replace")
+local replace_lines = require("edit_helpers").replace_lines
+
+local EDIT_LINES_DESCRIPTION =
+  [[Edit lines by number. Omit `end` to insert before `start` without removing lines. Set `end` to replace or delete (empty `new_string`) a range.]]
 
 local EDIT_DESCRIPTION = [[Replace an exact string match in a file.
 
@@ -195,5 +199,57 @@ maki.api.register_tool({
     local n = #edits
     local s = n == 1 and "" or "s"
     return diff_result(result, string.format("applied %d edit%s to %s", n, s, shorten_path(result.path)))
+  end,
+})
+
+maki.api.register_tool({
+  name = "edit_lines",
+  kind = "edit",
+  mutable_path = "path",
+  permission_scope = "path",
+  audiences = { "main", "general_sub", "interpreter" },
+  description = EDIT_LINES_DESCRIPTION,
+
+  schema = {
+    type = "object",
+    properties = {
+      path = {
+        type = "string",
+        description = "Absolute path to the file",
+        required = true,
+        alias = "file_path",
+      },
+      start = {
+        type = "integer",
+        description = "First line (1-indexed)",
+        required = true,
+      },
+      ["end"] = {
+        type = "integer",
+        description = "Last line, inclusive. Omit to insert before start without removing lines.",
+      },
+      new_string = {
+        type = "string",
+        description = "Replacement text",
+        required = true,
+      },
+    },
+  },
+
+  header = edit_header,
+  restore = edit_restore,
+
+  handler = function(input, ctx)
+    local end_line = input["end"]
+    local result, err = apply_edit(input.path, ctx, function(content)
+      return replace_lines(content, input.start, end_line, input.new_string)
+    end)
+    if not result then
+      return { llm_output = err, is_error = true }
+    end
+    local summary = end_line
+        and string.format("replaced lines %d-%d in %s", input.start, end_line, shorten_path(result.path))
+      or string.format("inserted at line %d in %s", input.start, shorten_path(result.path))
+    return diff_result(result, summary)
   end,
 })

--- a/plugins/edit/tests/spec.lua
+++ b/plugins/edit/tests/spec.lua
@@ -219,6 +219,46 @@ case("cjk_exact_match", function()
   has(result, "hello")
 end)
 
+local replace_lines = require("edit_helpers").replace_lines
+
+case("replace_lines_range_replace_and_delete", function()
+  local content = "aaa\nbbb\nccc\nddd\neee\n"
+
+  local r1 = replace_lines(content, 2, 4, "XXX\nYYY")
+  eq(r1, "aaa\nXXX\nYYY\neee\n")
+
+  local r2 = replace_lines(content, 3, 3, "ZZZ")
+  eq(r2, "aaa\nbbb\nZZZ\nddd\neee\n")
+
+  local r3 = replace_lines(content, 2, 3, "")
+  eq(r3, "aaa\nddd\neee\n")
+
+  local _, e1 = replace_lines(content, 0, 1, "x")
+  has(e1, "out of range")
+  local _, e2 = replace_lines(content, 2, 6, "x")
+  has(e2, "out of range")
+  local _, e3 = replace_lines(content, 3, 2, "x")
+  has(e3, "out of range")
+end)
+
+case("replace_lines_insert_mode", function()
+  local content = "aaa\nbbb\nccc\n"
+
+  local r1 = replace_lines(content, 1, nil, "ZZZ")
+  eq(r1, "ZZZ\naaa\nbbb\nccc\n")
+
+  local r2 = replace_lines(content, 2, nil, "XXX\nYYY")
+  eq(r2, "aaa\nXXX\nYYY\nbbb\nccc\n")
+
+  local r3 = replace_lines(content, 4, nil, "END")
+  eq(r3, "aaa\nbbb\nccc\nEND\n")
+
+  local _, e1 = replace_lines(content, 0, nil, "x")
+  has(e1, "out of range")
+  local _, e2 = replace_lines(content, 5, nil, "x")
+  has(e2, "out of range")
+end)
+
 if #failures > 0 then
   error(#failures .. " case(s) failed:\n\n" .. table.concat(failures, "\n\n"))
 end

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -7,7 +7,7 @@ group = "Reference"
 
 # Tools
 
-Maki ships with 17 built-in tools. This is the full reference.
+Maki ships with 18 built-in tools. This is the full reference.
 
 ## File Operations
 


### PR DESCRIPTION
Since `read` and `grep` already show lines as `<nr>: <content>`, it makes sense to have an edit tool that works with those line numbers directly. `edit_lines` takes `path`, `start`, `end` (defaults to `start`), and `new_string`, then splices the replacement into that range. Empty `new_string` deletes the range.

The line splitting needed a small trick: files ending with `\n` would produce a phantom empty line from the gmatch pattern, so we strip the trailing newline before splitting and restore it after joining.

Enable via :

```toml
[tools.edit_lines]
enabled = true
```

Closes #342.