### PR TITLE
providers: Refactor do_list_models() to allow providers to provide a parsing function

### DIFF
--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -215,44 +215,32 @@ impl Provider for Mistral {
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
-            let base = auth
-                .base_url
-                .as_deref()
-                .unwrap_or(self.compat.config().base_url);
-            let url = format!("{base}/models");
-            let body_text = self.compat.get_text(&auth, &url).await?;
-            let body: Value = serde_json::from_str(&body_text)?;
-            let mut models: Vec<crate::model::ModelInfo> = body["data"]
-                .as_array()
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|m| {
-                            // Only include models with completion_chat: true
-                            let has_completion_chat = m
-                                .get("capabilities")
-                                .and_then(Value::as_object)
-                                .and_then(|c| c.get("completion_chat"))
-                                .and_then(Value::as_bool)
-                                .unwrap_or(false);
-                            if !has_completion_chat {
-                                return None;
-                            }
-                            let id = m["id"].as_str()?;
-                            let context_window = m["max_context_length"]
-                                .as_u64()
-                                .and_then(|v| u32::try_from(v).ok());
-                            Some(crate::model::ModelInfo {
-                                id: id.to_string(),
-                                context_window,
-                                max_output_tokens: None,
-                                pricing: None,
-                            })
-                        })
-                        .collect()
+            self.compat
+                .fetch_and_parse_models(&auth, |m| {
+                    // Filter: only completion_chat capable models
+                    let has_completion_chat = m
+                        .get("capabilities")
+                        .and_then(Value::as_object)
+                        .and_then(|c| c.get("completion_chat"))
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false);
+                    if !has_completion_chat {
+                        return None;
+                    }
+
+                    // Parse with Mistral-specific field names
+                    let id = m["id"].as_str()?;
+                    let context_window = m["max_context_length"]
+                        .as_u64()
+                        .and_then(|v| u32::try_from(v).ok());
+                    Some(crate::model::ModelInfo {
+                        id: id.to_string(),
+                        context_window,
+                        max_output_tokens: None,
+                        pricing: None,
+                    })
                 })
-                .unwrap_or_default();
-            models.sort_by(|a, b| a.id.cmp(&b.id));
-            Ok(models)
+                .await
         })
     }
 

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -54,7 +54,10 @@ impl OpenAiCompatProvider {
         auth: &ResolvedAuth,
         url: &str,
     ) -> Result<String, AgentError> {
-        let mut builder = Request::builder().method("GET").uri(url);
+        let mut builder = Request::builder()
+            .method("GET")
+            .uri(url)
+            .header("user-agent", super::user_agent());
         for (key, value) in &auth.headers {
             builder = builder.header(key.as_str(), value.as_str());
         }
@@ -73,7 +76,10 @@ impl OpenAiCompatProvider {
         content_type: &str,
         body: &[u8],
     ) -> Result<String, AgentError> {
-        let mut builder = Request::builder().method("POST").uri(url);
+        let mut builder = Request::builder()
+            .method("POST")
+            .uri(url)
+            .header("user-agent", super::user_agent());
         for (key, value) in &auth.headers {
             builder = builder.header(key.as_str(), value.as_str());
         }

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -170,54 +170,68 @@ impl OpenAiCompatProvider {
         }
     }
 
+    pub async fn fetch_and_parse_models(
+        &self,
+        auth: &ResolvedAuth,
+        parse_fn: impl Fn(&Value) -> Option<crate::model::ModelInfo>,
+    ) -> Result<Vec<crate::model::ModelInfo>, AgentError> {
+        let base = auth.base_url.as_deref().unwrap_or(self.config.base_url);
+        let url = format!("{base}/models");
+        let body_text = self.get_text(auth, &url).await?;
+        let body: Value = serde_json::from_str(&body_text)?;
+
+        let mut models: Vec<crate::model::ModelInfo> = body["data"]
+            .as_array()
+            .map(|arr| arr.iter().filter_map(parse_fn).collect())
+            .unwrap_or_default();
+        models.sort_by(|a, b| a.id.cmp(&b.id));
+        Ok(models)
+    }
+
+    fn default_model_parser(m: &Value) -> Option<crate::model::ModelInfo> {
+        let id = m["id"].as_str()?;
+        let context_window = m["context_length"]
+            .as_u64()
+            .or_else(|| m["max_model_len"].as_u64())
+            .or_else(|| m["max_context_length"].as_u64())
+            .and_then(|v| u32::try_from(v).ok());
+        let max_output_tokens = m["max_tokens"].as_u64().and_then(|v| u32::try_from(v).ok());
+        let pricing = m["pricing"]
+            .as_object()
+            .and_then(|p| {
+                Some(crate::model::ModelPricing {
+                    input: p.get("prompt")?.as_str()?.parse().ok()?,
+                    output: p.get("completion")?.as_str()?.parse().ok()?,
+                    cache_write: p
+                        .get("cache_creation")?
+                        .as_str()?
+                        .parse::<f64>()
+                        .ok()
+                        .unwrap_or(0.0),
+                    cache_read: p
+                        .get("cache_read")?
+                        .as_str()?
+                        .parse::<f64>()
+                        .ok()
+                        .unwrap_or(0.0),
+                    fast: None,
+                })
+            })
+            .unwrap_or_default();
+        Some(crate::model::ModelInfo {
+            id: id.to_string(),
+            context_window,
+            max_output_tokens,
+            pricing: Some(pricing),
+        })
+    }
+
     pub async fn do_list_models(
         &self,
         auth: &ResolvedAuth,
     ) -> Result<Vec<crate::model::ModelInfo>, AgentError> {
-        let request = self.build_request("GET", "/models", auth).body(())?;
-        let mut response = self.client.send_async(request).await?;
-        if response.status().as_u16() != 200 {
-            return Err(AgentError::from_response(response).await);
-        }
-
-        let body: Value = serde_json::from_str(&response.text().await?)?;
-        let mut models: Vec<crate::model::ModelInfo> = body["data"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|m| {
-                        let id = m["id"].as_str()?;
-                        let context_window = m["context_length"]
-                            .as_u64()
-                            .or_else(|| m["max_model_len"].as_u64())
-                            .or_else(|| m["max_context_length"].as_u64())
-                            .and_then(|v| u32::try_from(v).ok());
-                        let max_output_tokens =
-                            m["max_tokens"].as_u64().and_then(|v| u32::try_from(v).ok());
-                        let pricing = m["pricing"]
-                            .as_object()
-                            .and_then(|p| {
-                                Some(crate::model::ModelPricing {
-                                    input: p.get("prompt")?.as_str()?.parse().ok()?,
-                                    output: p.get("completion")?.as_str()?.parse().ok()?,
-                                    cache_write: p.get("cache_creation")?.as_str()?.parse().ok()?,
-                                    cache_read: p.get("cache_read")?.as_str()?.parse().ok()?,
-                                    fast: None,
-                                })
-                            })
-                            .unwrap_or_default();
-                        Some(crate::model::ModelInfo {
-                            id: id.to_string(),
-                            context_window,
-                            max_output_tokens,
-                            pricing: Some(pricing),
-                        })
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-        models.sort_by(|a, b| a.id.cmp(&b.id));
-        Ok(models)
+        self.fetch_and_parse_models(auth, Self::default_model_parser)
+            .await
     }
 }
 

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -101,67 +101,52 @@ impl Provider for OpenRouter {
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
-            let base = auth
-                .base_url
-                .as_deref()
-                .unwrap_or(self.compat.config().base_url);
-            let url = format!("{base}/models");
-            let body_text = self.compat.get_text(&auth, &url).await?;
-            let body: Value = serde_json::from_str(&body_text)?;
-            let mut models: Vec<crate::model::ModelInfo> = body["data"]
-                .as_array()
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|m| {
-                            // Skip models without required architecture fields
-                            let architecture = m["architecture"].as_object()?;
-                            let input_modalities = architecture["input_modalities"].as_array()?;
-                            let output_modalities = architecture["output_modalities"].as_array()?;
+            self.compat
+                .fetch_and_parse_models(&auth, |m| {
+                    // Filter: only text input/output models
+                    let architecture = m["architecture"].as_object()?;
+                    let input_modalities = architecture["input_modalities"].as_array()?;
+                    let output_modalities = architecture["output_modalities"].as_array()?;
 
-                            // Check if both input and output modalities contain "text"
-                            let has_text_input =
-                                input_modalities.iter().any(|m| m.as_str() == Some("text"));
-                            let has_text_output =
-                                output_modalities.iter().any(|m| m.as_str() == Some("text"));
+                    let has_text_input =
+                        input_modalities.iter().any(|m| m.as_str() == Some("text"));
+                    let has_text_output =
+                        output_modalities.iter().any(|m| m.as_str() == Some("text"));
+                    if !has_text_input || !has_text_output {
+                        return None;
+                    }
 
-                            if !has_text_input || !has_text_output {
-                                return None;
-                            }
-
-                            let id = m["id"].as_str()?;
-                            let context_window = m["context_length"]
-                                .as_u64()
-                                .and_then(|v| u32::try_from(v).ok());
-                            let pricing = m["pricing"]
-                                .as_object()
-                                .and_then(|p| {
-                                    Some(crate::model::ModelPricing {
-                                        input: p.get("prompt")?.as_str()?.parse().ok()?,
-                                        output: p.get("completion")?.as_str()?.parse().ok()?,
-                                        cache_write: p
-                                            .get("input_cache_write")
-                                            .and_then(|p| p.as_str()?.parse().ok())
-                                            .unwrap_or(0.0),
-                                        cache_read: p
-                                            .get("input_cache_read")
-                                            .and_then(|p| p.as_str()?.parse().ok())
-                                            .unwrap_or(0.0),
-                                        fast: None,
-                                    })
-                                })
-                                .unwrap_or_default();
-                            Some(crate::model::ModelInfo {
-                                id: id.to_string(),
-                                context_window,
-                                max_output_tokens: None,
-                                pricing: Some(pricing),
+                    // Parse with OpenRouter-specific pricing field names
+                    let id = m["id"].as_str()?;
+                    let context_window = m["context_length"]
+                        .as_u64()
+                        .and_then(|v| u32::try_from(v).ok());
+                    let pricing = m["pricing"]
+                        .as_object()
+                        .and_then(|p| {
+                            Some(crate::model::ModelPricing {
+                                input: p.get("prompt")?.as_str()?.parse().ok()?,
+                                output: p.get("completion")?.as_str()?.parse().ok()?,
+                                cache_write: p
+                                    .get("input_cache_write")
+                                    .and_then(|p| p.as_str()?.parse().ok())
+                                    .unwrap_or(0.0),
+                                cache_read: p
+                                    .get("input_cache_read")
+                                    .and_then(|p| p.as_str()?.parse().ok())
+                                    .unwrap_or(0.0),
+                                fast: None,
                             })
                         })
-                        .collect()
+                        .unwrap_or_default();
+                    Some(crate::model::ModelInfo {
+                        id: id.to_string(),
+                        context_window,
+                        max_output_tokens: None,
+                        pricing: Some(pricing),
+                    })
                 })
-                .unwrap_or_default();
-            models.sort_by(|a, b| a.id.cmp(&b.id));
-            Ok(models)
+                .await
         })
     }
 


### PR DESCRIPTION
This allows the Mistral and OpenRouter providers to do their special
parsing of additional fields while keeping the fetching/etc generic.

----

What do you think, is that worth it? @tontinton 

Second commit should probably go in regardless.