### PR TITLE
providers: use inner provider when dynamic script declares no models

### DIFF
--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -520,6 +520,9 @@ impl Provider for DynamicProvider {
     }
 
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
+        if self.models.is_empty() {
+            return self.inner.list_models();
+        }
         Box::pin(async {
             Ok(self
                 .models


### PR DESCRIPTION
In f4e3dc971b15 - `DynamicProvider::list_models()` was changed to return the static list from the provider script instead of delegating to the inner provider's API.

When a script does not declare any models, the static list is empty and `fetch_all_models` sends a batch with zero entries, so the provider's models never show up in `/model`.