### PR TITLE
providers: per-model `supports_thinking` instead of per-provider

### DIFF
--- a/maki-agent/src/agent/streaming.rs
+++ b/maki-agent/src/agent/streaming.rs
@@ -32,6 +32,7 @@ pub(crate) async fn stream_with_retry(
     opts: RequestOptions,
     session_id: Option<&str>,
 ) -> Result<StreamResponse, AgentError> {
+    let opts = opts.clamped(model);
     let mut retry = RetryState::new();
     loop {
         let (ptx, prx) = flume::unbounded();

--- a/maki-config/src/providers.rs
+++ b/maki-config/src/providers.rs
@@ -37,6 +37,8 @@ pub struct ModelDef {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub supports_tool_examples: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supports_thinking: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pricing_input: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pricing_output: Option<f64>,

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -74,7 +74,7 @@ If your provider serves models not in the base catalog, add a `models` subcomman
 [{{"id": "my-model-v2", "tier": "strong", "context_window": 200000, "max_output_tokens": 16384}}]
 ```
 
-Only `id` is required. Optional fields: `tier` (default `medium`), `context_window` (128K), `max_output_tokens` (16K), `pricing` (`{{input, output, cache_write, cache_read}}`, all per 1M tokens), `supports_tool_examples` (defaults to the base provider's setting). The first model listed per tier is used for sub-agents. Without this subcommand, the base provider's models are used.
+Only `id` is required. Optional fields: `tier` (default `medium`), `context_window` (128K), `max_output_tokens` (16K), `pricing` (`{{input, output, cache_write, cache_read}}`, all per 1M tokens), `supports_tool_examples` (defaults to the base provider's setting), `supports_thinking` (defaults to the base provider's setting). The first model listed per tier is used for sub-agents. Without this subcommand, the base provider's models are used.
 
 Dynamic provider models are namespaced as `{{slug}}/{{model_id}}` (e.g. `myproxy/claude-sonnet-4-6`).
 

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -16,6 +16,6 @@ pub use providers::copilot::auth as copilot_auth;
 pub use providers::dynamic;
 pub use providers::openai::auth as openai_auth;
 pub use types::{
-    ContentBlock, ImageMediaType, ImageSource, Message, ProviderEvent, RequestOptions, Role,
-    StopReason, StreamResponse, ThinkingConfig,
+    ContentBlock, EffortScale, ImageMediaType, ImageSource, Message, ProviderEvent, RequestOptions,
+    Role, StopReason, StreamResponse, ThinkingConfig,
 };

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -206,6 +206,7 @@ pub struct Model {
     pub tier: ModelTier,
     pub family: ModelFamily,
     pub supports_tool_examples_override: Option<bool>,
+    pub supports_thinking_override: Option<bool>,
     pub pricing: ModelPricing,
     pub max_output_tokens: u32,
     pub context_window: u32,
@@ -255,10 +256,16 @@ impl Model {
             tier,
             family,
             supports_tool_examples_override: None,
+            supports_thinking_override: None,
             pricing,
             max_output_tokens,
             context_window,
         }
+    }
+
+    pub fn supports_thinking(&self) -> bool {
+        self.supports_thinking_override
+            .unwrap_or_else(|| self.provider.supports_thinking())
     }
 
     pub fn supports_tool_examples(&self) -> bool {

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -93,6 +93,7 @@ pub fn lookup_model(slug: &str, model_id: &str) -> Option<Model> {
         .and_then(|m| m.context_window)
         .unwrap_or_else(|| kind.fallback_context_window());
     let supports_tool_examples_override = declared.and_then(|m| m.supports_tool_examples);
+    let supports_thinking_override = declared.and_then(|m| m.supports_thinking);
     let pricing = declared
         .filter(|m| m.has_pricing())
         .map(|m| ModelPricing {
@@ -115,6 +116,7 @@ pub fn lookup_model(slug: &str, model_id: &str) -> Option<Model> {
         tier,
         family: kind.family(),
         supports_tool_examples_override,
+        supports_thinking_override,
         pricing,
         max_output_tokens,
         context_window,

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -59,6 +59,8 @@ struct ScriptModel {
     tier: ModelTier,
     #[serde(default)]
     supports_tool_examples: Option<bool>,
+    #[serde(default)]
+    supports_thinking: Option<bool>,
     #[serde(default = "default_max_output_tokens")]
     max_output_tokens: u32,
     #[serde(default = "default_context_window")]
@@ -453,6 +455,7 @@ pub fn lookup_model(slug: &str, model_id: &str) -> Option<Model> {
         tier: script_model.tier,
         family: meta.base.family(),
         supports_tool_examples_override: script_model.supports_tool_examples,
+        supports_thinking_override: script_model.supports_thinking,
         pricing: script_model.pricing.clone().unwrap_or_default(),
         max_output_tokens: script_model.max_output_tokens,
         context_window: script_model.context_window,
@@ -469,6 +472,7 @@ pub fn find_model_for_tier(slug: &str, tier: ModelTier) -> Option<Model> {
         tier,
         family: meta.base.family(),
         supports_tool_examples_override: script_model.supports_tool_examples,
+        supports_thinking_override: script_model.supports_thinking,
         pricing: script_model.pricing.clone().unwrap_or_default(),
         max_output_tokens: script_model.max_output_tokens,
         context_window: script_model.context_window,

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -175,14 +175,7 @@ impl Google {
             body["systemInstruction"] = json!({"parts": [{"text": system}]});
         }
 
-        if !matches!(thinking, ThinkingConfig::Off) {
-            let config = match thinking {
-                ThinkingConfig::Budget(n) => json!({"thinkingBudget": n}),
-                ThinkingConfig::Adaptive => json!({"includeThoughts": true}),
-                ThinkingConfig::Off => unreachable!(),
-            };
-            body["generationConfig"]["thinkingConfig"] = config;
-        }
+        thinking.apply_google_thinking(&mut body);
 
         if model.max_output_tokens > 0 {
             body["generationConfig"]["maxOutputTokens"] = json!(model.max_output_tokens);
@@ -607,20 +600,25 @@ mod tests {
         }
     }
 
-    #[test]
-    fn google_build_body_basic() {
-        let google = Google::with_auth(test_auth(), test_timeouts());
-        let model = Model {
+    fn test_model() -> Model {
+        Model {
             id: "gemini-2.5-flash".into(),
             provider: crate::provider::ProviderKind::Google,
             dynamic_slug: None,
             tier: ModelTier::Medium,
             family: ModelFamily::Gemini,
             supports_tool_examples_override: None,
+            supports_thinking_override: None,
             pricing: ModelPricing::default(),
             max_output_tokens: 8192,
             context_window: 1_048_576,
-        };
+        }
+    }
+
+    #[test]
+    fn google_build_body_basic() {
+        let google = Google::with_auth(test_auth(), test_timeouts());
+        let model = test_model();
         let messages = vec![Message::user("hello".into())];
         let body = google.build_body(
             &model,
@@ -639,19 +637,14 @@ mod tests {
     #[test]
     fn google_build_body_thinking_adaptive() {
         let google = Google::with_auth(test_auth(), test_timeouts());
-        let model = Model {
-            id: "gemini-2.5-flash".into(),
-            provider: crate::provider::ProviderKind::Google,
-            dynamic_slug: None,
-            tier: ModelTier::Medium,
-            family: ModelFamily::Gemini,
-            supports_tool_examples_override: None,
-            pricing: ModelPricing::default(),
-            max_output_tokens: 8192,
-            context_window: 1_048_576,
-        };
-        let messages = vec![Message::user("think about this".into())];
-        let body = google.build_body(&model, &messages, "", &json!([]), ThinkingConfig::Adaptive);
+        let messages = vec![Message::user("think".into())];
+        let body = google.build_body(
+            &test_model(),
+            &messages,
+            "",
+            &json!([]),
+            ThinkingConfig::Adaptive,
+        );
 
         assert_eq!(
             body["generationConfig"]["thinkingConfig"]["includeThoughts"],
@@ -662,20 +655,9 @@ mod tests {
     #[test]
     fn google_build_body_thinking_budget() {
         let google = Google::with_auth(test_auth(), test_timeouts());
-        let model = Model {
-            id: "gemini-2.5-flash".into(),
-            provider: crate::provider::ProviderKind::Google,
-            dynamic_slug: None,
-            tier: ModelTier::Medium,
-            family: ModelFamily::Gemini,
-            supports_tool_examples_override: None,
-            pricing: ModelPricing::default(),
-            max_output_tokens: 8192,
-            context_window: 1_048_576,
-        };
         let messages = vec![Message::user("think hard".into())];
         let body = google.build_body(
-            &model,
+            &test_model(),
             &messages,
             "",
             &json!([]),

--- a/maki-providers/src/providers/local.rs
+++ b/maki-providers/src/providers/local.rs
@@ -8,7 +8,7 @@ use tracing::warn;
 
 use crate::model::Model;
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
@@ -124,12 +124,7 @@ impl Provider for LocalEndpoint {
             let mut body = self.compat.build_body(model, messages, system, tools);
 
             if self.thinking_budget_field {
-                let budget = match opts.thinking {
-                    ThinkingConfig::Off => 0,
-                    ThinkingConfig::Adaptive => -1,
-                    ThinkingConfig::Budget(n) => n as i64,
-                };
-                body["thinking_budget_tokens"] = json!(budget);
+                opts.thinking.apply_local_thinking(&mut body);
             }
 
             self.compat

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -5,7 +5,7 @@ use serde_json::{Value, json};
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig};
+use crate::{AgentError, EffortScale, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
@@ -194,11 +194,8 @@ impl Provider for Mistral {
             let mut buf = String::new();
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
-            // Ministral does not support reasoning, Mistral Small 4 and Mistral Medium 3.5 do
-            if !matches!(opts.thinking, ThinkingConfig::Off) && !model.id.starts_with("ministral-")
-            {
-                body["reasoning_effort"] = json!("high");
-            }
+            opts.thinking
+                .apply_reasoning_effort(&mut body, EffortScale::HighOnly);
             // Convert assistant messages to Mistral's expected format with thinking content
             convert_assistant_messages_in_place(body.get_mut("messages").unwrap());
 
@@ -251,6 +248,16 @@ impl Provider for Mistral {
                 .as_ref()
                 .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
         })
+    }
+
+    fn adjust_model(&self, model: &mut Model) {
+        adjust_model(model);
+    }
+}
+
+fn adjust_model(model: &mut Model) {
+    if model.id.starts_with("ministral-") {
+        model.supports_thinking_override = Some(false);
     }
 }
 
@@ -320,5 +327,13 @@ mod tests {
         let mut input_clone = input.clone();
         convert_assistant_messages_in_place(&mut input_clone);
         assert_eq!(input_clone, expected);
+    }
+
+    #[test_case("mistral/ministral-14b-latest", false ; "ministral_no_thinking")]
+    #[test_case("mistral/mistral-medium-latest", true ; "mistral_medium_supports_thinking")]
+    fn adjust_model_sets_thinking_support(spec: &str, expected: bool) {
+        let mut model = Model::from_spec(spec).unwrap();
+        adjust_model(&mut model);
+        assert_eq!(model.supports_thinking(), expected);
     }
 }

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -7,7 +7,7 @@ use tracing::{debug, warn};
 
 use crate::model::Model;
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
+use crate::{AgentError, EffortScale, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 use super::auth;
 use crate::providers::ResolvedAuth;
@@ -171,7 +171,8 @@ impl Provider for OpenAi {
             }
 
             let mut body = self.compat.build_body(model, messages, system, tools);
-            opts.thinking.apply_reasoning_effort(&mut body);
+            opts.thinking
+                .apply_reasoning_effort(&mut body, EffortScale::Standard);
             self.with_oauth_retry(|| async {
                 let auth = self.current_auth();
                 self.compat

--- a/maki-providers/src/providers/opencode.rs
+++ b/maki-providers/src/providers/opencode.rs
@@ -14,7 +14,7 @@ use tracing::{debug, warn};
 use crate::model::{Model, ModelInfo, ModelPricing};
 use crate::provider::{BoxFuture, Provider};
 use crate::providers::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
-use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig};
+use crate::{AgentError, EffortScale, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 use super::{ResolvedAuth, http_client};
 use crate::providers::anthropic::shared;
@@ -241,15 +241,8 @@ impl Opencode {
         opts: &RequestOptions,
     ) -> Result<StreamResponse, AgentError> {
         let mut body = self.chat_compat.build_body(model, messages, system, tools);
-        match opts.thinking {
-            ThinkingConfig::Off => {}
-            ThinkingConfig::Adaptive => {
-                body["reasoning_effort"] = json!("high");
-            }
-            ThinkingConfig::Budget(n) => {
-                body["reasoning_effort"] = json!(ThinkingConfig::budget_to_effort(n));
-            }
-        }
+        opts.thinking
+            .apply_reasoning_effort(&mut body, EffortScale::PreferHigh);
         self.chat_compat
             .do_stream(model, &[], &body, event_tx, auth)
             .await

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -5,7 +5,7 @@ use serde_json::{Value, json};
 
 use crate::model::{Model, ModelEntry};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig};
+use crate::{AgentError, EffortScale, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
@@ -77,15 +77,8 @@ impl Provider for OpenRouter {
 
             body["cache_control"] = json!({"type": "ephemeral"});
 
-            match opts.thinking {
-                ThinkingConfig::Off => {}
-                ThinkingConfig::Adaptive => {
-                    body["reasoning_effort"] = json!("high");
-                }
-                ThinkingConfig::Budget(n) => {
-                    body["reasoning_effort"] = json!(ThinkingConfig::budget_to_effort(n));
-                }
-            }
+            opts.thinking
+                .apply_reasoning_effort(&mut body, EffortScale::PreferHigh);
 
             if let Some(sid) = session_id {
                 body["session_id"] = json!(sid);

--- a/maki-providers/src/providers/synthetic.rs
+++ b/maki-providers/src/providers/synthetic.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
+use crate::{AgentError, EffortScale, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
@@ -129,7 +129,8 @@ impl Provider for Synthetic {
             let mut buf = String::new();
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
-            opts.thinking.apply_reasoning_effort(&mut body);
+            opts.thinking
+                .apply_reasoning_effort(&mut body, EffortScale::Standard);
             self.compat
                 .do_stream(model, &[], &body, event_tx, &auth)
                 .await

--- a/maki-providers/src/providers/zai/mod.rs
+++ b/maki-providers/src/providers/zai/mod.rs
@@ -8,7 +8,7 @@ use tracing::warn;
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
 use crate::providers::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
-use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
+use crate::{AgentError, EffortScale, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 use super::{KeyPool, ResolvedAuth};
 
@@ -224,14 +224,18 @@ impl Provider for Zai {
         system: &'a str,
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
-        _opts: RequestOptions,
+        opts: RequestOptions,
         _session_id: Option<&str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
             let mut buf = String::new();
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
-            let body = self.compat.build_body(model, messages, system, tools);
+            let mut body = self.compat.build_body(model, messages, system, tools);
+            if model.supports_thinking() {
+                opts.thinking
+                    .apply_reasoning_effort(&mut body, EffortScale::Glm);
+            }
             match self
                 .compat
                 .do_stream(model, &[], &body, event_tx, &auth)
@@ -266,5 +270,30 @@ impl Provider for Zai {
                 .as_ref()
                 .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
         })
+    }
+
+    fn adjust_model(&self, model: &mut Model) {
+        adjust_model(model);
+    }
+}
+
+fn adjust_model(model: &mut Model) {
+    if model.id.starts_with("glm-5.2") {
+        model.supports_thinking_override = Some(true);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    #[test_case("zai/glm-5.2", true ; "glm_5_2_supports_thinking")]
+    #[test_case("zai/glm-5.1", false ; "glm_5_1_no_thinking")]
+    #[test_case("zai/glm-4.7", false ; "glm_4_7_no_thinking")]
+    fn adjust_model_sets_thinking_support(spec: &str, expected: bool) {
+        let mut model = Model::from_spec(spec).unwrap();
+        adjust_model(&mut model);
+        assert_eq!(model.supports_thinking(), expected);
     }
 }

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -238,6 +238,22 @@ impl StopReason {
 }
 
 const THINKING_USAGE: &str = "Usage: /thinking [off|adaptive|<budget\u{2265}1024>]";
+const GLM_XHIGH_THRESHOLD: u32 = 8192;
+
+/// Each provider speaks a different dialect of `reasoning_effort`.
+/// New providers get a variant here instead of a new body-mutating method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EffortScale {
+    /// low / medium / high. Adaptive = medium.
+    Standard,
+    /// low / medium / high. Adaptive = high.
+    PreferHigh,
+    /// Always "high", ignores budget.
+    HighOnly,
+    /// none / high / xhigh. GLM reasons by default, so Off sends "none"
+    /// explicitly. Only use behind `Model::supports_thinking`.
+    Glm,
+}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum ThinkingConfig {
@@ -293,13 +309,46 @@ impl ThinkingConfig {
         (major, minor) >= (4, 7)
     }
 
-    pub fn apply_reasoning_effort(self, body: &mut Value) {
-        let effort = match self {
-            Self::Off => return,
-            Self::Adaptive => "medium",
-            Self::Budget(n) => Self::budget_to_effort(n),
+    pub fn apply_reasoning_effort(self, body: &mut Value, scale: EffortScale) {
+        let effort = match (self, scale) {
+            (Self::Off, EffortScale::Glm) => "none",
+            (Self::Off, _) => return,
+            (Self::Adaptive, EffortScale::Standard) => "medium",
+            (Self::Adaptive, _) => "high",
+            (Self::Budget(_), EffortScale::HighOnly) => "high",
+            (Self::Budget(n), EffortScale::Glm) => {
+                if n >= GLM_XHIGH_THRESHOLD {
+                    "xhigh"
+                } else {
+                    "high"
+                }
+            }
+            (Self::Budget(n), EffortScale::Standard | EffortScale::PreferHigh) => {
+                Self::budget_to_effort(n)
+            }
         };
         body["reasoning_effort"] = json!(effort);
+    }
+
+    pub fn apply_google_thinking(self, body: &mut Value) {
+        match self {
+            Self::Off => {}
+            Self::Adaptive => {
+                body["generationConfig"]["thinkingConfig"] = json!({"includeThoughts": true});
+            }
+            Self::Budget(n) => {
+                body["generationConfig"]["thinkingConfig"] = json!({"thinkingBudget": n});
+            }
+        }
+    }
+
+    pub fn apply_local_thinking(self, body: &mut Value) {
+        let budget = match self {
+            Self::Off => 0,
+            Self::Adaptive => -1,
+            Self::Budget(n) => n as i64,
+        };
+        body["thinking_budget_tokens"] = json!(budget);
     }
 
     pub fn parse(input: &str, current: Self) -> Result<Self, &'static str> {
@@ -357,9 +406,24 @@ impl From<ThinkingConfig> for StoredThinking {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct RequestOptions {
     pub thinking: ThinkingConfig,
-    /// Just what the user asked for. The provider re-checks `supports_fast()`
-    /// before sending it, so a stale flag never bills an ineligible model.
+    /// Raw user preference, reconciled by [`RequestOptions::clamped`] before use.
     pub fast: bool,
+}
+
+impl RequestOptions {
+    /// Strips options the model does not support. Called once before every
+    /// request so UI state, restored sessions, and subagent flags all go
+    /// through the same gate.
+    pub fn clamped(self, model: &crate::model::Model) -> Self {
+        Self {
+            thinking: if model.supports_thinking() {
+                self.thinking
+            } else {
+                ThinkingConfig::Off
+            },
+            fast: self.fast && model.supports_fast(),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -445,18 +509,91 @@ mod tests {
         assert_eq!(body, expected);
     }
 
-    #[test_case(ThinkingConfig::Off,          None            ; "off")]
-    #[test_case(ThinkingConfig::Adaptive,     Some("medium")  ; "adaptive")]
-    #[test_case(ThinkingConfig::Budget(1024), Some("low")     ; "budget_low")]
-    #[test_case(ThinkingConfig::Budget(4096), Some("medium")  ; "budget_medium")]
-    #[test_case(ThinkingConfig::Budget(8192), Some("high")    ; "budget_high")]
-    fn thinking_apply_reasoning_effort(config: ThinkingConfig, expected: Option<&str>) {
+    use EffortScale::{Glm, HighOnly, PreferHigh, Standard};
+
+    #[test_case(Standard,   ThinkingConfig::Off,          None            ; "off_noop")]
+    #[test_case(Standard,   ThinkingConfig::Adaptive,     Some("medium")  ; "standard_adaptive")]
+    #[test_case(Standard,   ThinkingConfig::Budget(1024), Some("low")     ; "standard_budget_low")]
+    #[test_case(Standard,   ThinkingConfig::Budget(4096), Some("medium")  ; "standard_budget_medium")]
+    #[test_case(Standard,   ThinkingConfig::Budget(8192), Some("high")    ; "standard_budget_high")]
+    #[test_case(PreferHigh, ThinkingConfig::Adaptive,     Some("high")    ; "prefer_high_adaptive")]
+    #[test_case(PreferHigh, ThinkingConfig::Budget(1024), Some("low")     ; "prefer_high_budget_low")]
+    #[test_case(HighOnly,   ThinkingConfig::Adaptive,     Some("high")    ; "high_only_adaptive")]
+    #[test_case(HighOnly,   ThinkingConfig::Budget(1024), Some("high")    ; "high_only_budget")]
+    #[test_case(Glm,        ThinkingConfig::Off,          Some("none")    ; "glm_off_explicit_none")]
+    #[test_case(Glm,        ThinkingConfig::Adaptive,     Some("high")    ; "glm_adaptive")]
+    #[test_case(Glm,        ThinkingConfig::Budget(1024), Some("high")    ; "glm_budget_low")]
+    #[test_case(Glm,        ThinkingConfig::Budget(8192), Some("xhigh")   ; "glm_budget_xhigh")]
+    fn thinking_apply_reasoning_effort(
+        scale: EffortScale,
+        config: ThinkingConfig,
+        expected: Option<&str>,
+    ) {
         let mut body = json!({"model": "test"});
-        config.apply_reasoning_effort(&mut body);
+        config.apply_reasoning_effort(&mut body, scale);
         match expected {
             Some(e) => assert_eq!(body["reasoning_effort"], e),
             None => assert!(body.get("reasoning_effort").is_none()),
         }
+    }
+
+    #[test_case(ThinkingConfig::Off,          json!({})                                                                  ; "off")]
+    #[test_case(ThinkingConfig::Adaptive,     json!({"generationConfig": {"thinkingConfig": {"includeThoughts": true}}}) ; "adaptive")]
+    #[test_case(ThinkingConfig::Budget(4096), json!({"generationConfig": {"thinkingConfig": {"thinkingBudget": 4096}}}) ; "budget")]
+    fn thinking_apply_google_thinking(config: ThinkingConfig, expected: Value) {
+        let mut body = json!({});
+        config.apply_google_thinking(&mut body);
+        assert_eq!(body, expected);
+    }
+
+    #[test_case(ThinkingConfig::Off,          0    ; "off")]
+    #[test_case(ThinkingConfig::Adaptive,     -1   ; "adaptive")]
+    #[test_case(ThinkingConfig::Budget(4096), 4096 ; "budget")]
+    fn thinking_apply_local_thinking(config: ThinkingConfig, expected: i64) {
+        let mut body = json!({});
+        config.apply_local_thinking(&mut body);
+        assert_eq!(body["thinking_budget_tokens"], expected);
+    }
+
+    fn clamp_test_model(provider: crate::provider::ProviderKind) -> crate::model::Model {
+        crate::model::Model {
+            id: "test-model".into(),
+            provider,
+            dynamic_slug: None,
+            tier: crate::model::ModelTier::Medium,
+            family: provider.family(),
+            supports_tool_examples_override: None,
+            supports_thinking_override: None,
+            pricing: crate::model::ModelPricing::default(),
+            max_output_tokens: 8192,
+            context_window: 200_000,
+        }
+    }
+
+    #[test_case(None,        ThinkingConfig::Adaptive, ThinkingConfig::Adaptive ; "provider_default_keeps")]
+    #[test_case(Some(false), ThinkingConfig::Adaptive, ThinkingConfig::Off      ; "override_false_clamps")]
+    fn request_options_clamped_thinking(
+        supports: Option<bool>,
+        thinking: ThinkingConfig,
+        expected: ThinkingConfig,
+    ) {
+        let mut model = clamp_test_model(crate::provider::ProviderKind::Anthropic);
+        model.supports_thinking_override = supports;
+        let opts = RequestOptions {
+            thinking,
+            fast: false,
+        };
+        assert_eq!(opts.clamped(&model).thinking, expected);
+    }
+
+    #[test]
+    fn request_options_clamped_fast_requires_model_support() {
+        let model = clamp_test_model(crate::provider::ProviderKind::Google);
+        let opts = RequestOptions {
+            thinking: ThinkingConfig::Off,
+            fast: true,
+        };
+        assert!(!opts.clamped(&model).fast);
     }
 
     #[test_case("",         ThinkingConfig::Off,      Ok(ThinkingConfig::Adaptive)  ; "toggle_on")]

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -1175,8 +1175,8 @@ impl App {
                 vec![]
             }
             "/thinking" => {
-                if !self.state.model.provider.supports_thinking() {
-                    self.flash("Thinking requires a provider that supports it".into());
+                if !self.state.model.supports_thinking() {
+                    self.flash("Thinking requires a model that supports it".into());
                     return vec![];
                 }
                 match ThinkingConfig::parse(cmd.args.trim(), self.state.thinking) {

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -69,10 +69,14 @@ impl SessionState {
         let context_size = session.meta.context_size;
 
         Self {
-            thinking: session.meta.thinking.map(Into::into).unwrap_or_default(),
-            // The saved model may have changed or fallen back to a parse failure
-            // since, so reconcile against the live model. This keeps the flag
-            // honest for everyone who reads it (the UI badge, the agent).
+            // Saved model may differ from the live one (updated, removed, etc).
+            // Reconcile so the UI badge and agent always see the truth.
+            thinking: session
+                .meta
+                .thinking
+                .map(Into::into)
+                .filter(|_| model.supports_thinking())
+                .unwrap_or_default(),
             fast: session.meta.fast && model.supports_fast(),
             session,
             model,
@@ -109,7 +113,7 @@ impl SessionState {
     }
 
     pub fn update_model(&mut self, model: &Model) {
-        if !model.provider.supports_thinking() {
+        if !model.supports_thinking() {
             self.thinking = ThinkingConfig::Off;
         }
         if !model.supports_fast() {

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -2267,9 +2267,9 @@ fn thinking_explicit_args() {
 }
 
 #[test]
-fn thinking_non_anthropic_flashes_error() {
+fn thinking_unsupported_model_flashes_error() {
     let mut app = test_app();
-    app.state.model.provider = maki_providers::provider::ProviderKind::Ollama;
+    app.state.model.supports_thinking_override = Some(false);
 
     app.execute_command(cmd("/thinking"));
     assert_eq!(app.state.thinking, ThinkingConfig::Off);

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -388,6 +388,7 @@ pub(crate) fn test_model() -> maki_providers::Model {
         tier: maki_providers::ModelTier::Medium,
         family: maki_providers::ModelFamily::Claude,
         supports_tool_examples_override: None,
+        supports_thinking_override: None,
         pricing: test_pricing(),
         max_output_tokens: 8192,
         context_window: TEST_CONTEXT_WINDOW,

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -221,7 +221,7 @@ If your provider serves models not in the base catalog, add a `models` subcomman
 [{"id": "my-model-v2", "tier": "strong", "context_window": 200000, "max_output_tokens": 16384}]
 ```
 
-Only `id` is required. Optional fields: `tier` (default `medium`), `context_window` (128K), `max_output_tokens` (16K), `pricing` (`{input, output, cache_write, cache_read}`, all per 1M tokens), `supports_tool_examples` (defaults to the base provider's setting). The first model listed per tier is used for sub-agents. Without this subcommand, the base provider's models are used.
+Only `id` is required. Optional fields: `tier` (default `medium`), `context_window` (128K), `max_output_tokens` (16K), `pricing` (`{input, output, cache_write, cache_read}`, all per 1M tokens), `supports_tool_examples` (defaults to the base provider's setting), `supports_thinking` (defaults to the base provider's setting). The first model listed per tier is used for sub-agents. Without this subcommand, the base provider's models are used.
 
 Dynamic provider models are namespaced as `{slug}/{model_id}` (e.g. `myproxy/claude-sonnet-4-6`).
 


### PR DESCRIPTION
`supports_thinking()` lived on `ProviderKind`, so Z.AI had to answer `false` for every GLM model even though `glm-5.2` can reason.

`Model` now carries a `supports_thinking_override` (also settable in `ModelDef` config and dynamic provider scripts), which Zai flips on for `glm-5.2` via `adjust_model` and Mistral flips off for `ministral-*`.

Wiring GLM's `none`/`high`/`xhigh` values exposed that every provider had its own copy of the effort match, so they all collapsed into `apply_reasoning_effort(body, EffortScale)` with a variant per dialect (`Standard`, `PreferHigh`, `HighOnly`, `Glm`), plus `apply_google_thinking`/`apply_local_thinking` for the non-effort bodies.

A new `RequestOptions::clamped(model)` runs once before every request, so thinking and fast flags from the UI, restored sessions, or subagents never reach a model that cannot honor them.

Closes #373.