### PR TITLE
providers: Add support for parsing thinking support from model listing

### DIFF
--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -3,9 +3,11 @@
 //! so dated snapshots resolve without registry churn. `context_tokens()` sums input + output
 //! + cache reads/writes because the context window limit applies to all of them combined.
 
+use std::any::Any;
 use std::fmt;
 use std::ops::AddAssign;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use maki_storage::sessions::StoredTokenUsage;
 use serde::{Deserialize, Serialize};
@@ -53,6 +55,9 @@ pub struct ModelInfo {
     pub context_window: Option<u32>,
     pub max_output_tokens: Option<u32>,
     pub pricing: Option<ModelPricing>,
+    pub supports_thinking: Option<bool>,
+    /// Store of additional metadata from the provider.
+    pub provider_info: Option<Arc<dyn Any + Send + Sync>>,
 }
 
 impl ModelInfo {
@@ -62,6 +67,8 @@ impl ModelInfo {
             context_window: None,
             max_output_tokens: None,
             pricing: None,
+            supports_thinking: None,
+            provider_info: None,
         }
     }
 }
@@ -279,6 +286,12 @@ impl Model {
 
     pub fn supports_thinking(&self) -> bool {
         self.supports_thinking_override
+            .or_else(|| {
+                let guard = crate::model_registry::model_registry().read().unwrap();
+                guard
+                    .discovered(self.provider, &self.id)
+                    .and_then(|d| d.supports_thinking)
+            })
             .unwrap_or_else(|| self.provider.supports_thinking())
     }
 
@@ -741,6 +754,8 @@ mod tests {
                     context_window: Some(expected_window),
                     max_output_tokens: None,
                     pricing: None,
+                    supports_thinking: None,
+                    provider_info: None,
                 }],
             );
         }

--- a/maki-providers/src/model_registry.rs
+++ b/maki-providers/src/model_registry.rs
@@ -316,12 +316,16 @@ mod tests {
                     context_window: Some(32_000),
                     max_output_tokens: None,
                     pricing: None,
+                    supports_thinking: None,
+                    provider_info: None,
                 },
                 ModelInfo {
                     id: "model-b".into(),
                     context_window: Some(128_000),
                     max_output_tokens: None,
                     pricing: None,
+                    supports_thinking: None,
+                    provider_info: None,
                 },
             ],
         );

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -536,6 +536,8 @@ impl Provider for DynamicProvider {
                     context_window: Some(m.context_window),
                     max_output_tokens: Some(m.max_output_tokens),
                     pricing: m.pricing.clone(),
+                    supports_thinking: None,
+                    provider_info: None,
                 })
                 .collect())
         })

--- a/maki-providers/src/providers/local.rs
+++ b/maki-providers/src/providers/local.rs
@@ -283,6 +283,8 @@ impl LocalEndpoint {
                     context_window: Some(context_window),
                     max_output_tokens: None,
                     pricing: Some(crate::model::ModelPricing::ZERO),
+                    supports_thinking: None,
+                    provider_info: None,
                 }
             })
             .collect();
@@ -388,6 +390,8 @@ impl LocalEndpoint {
                 context_window,
                 max_output_tokens: None,
                 pricing: Some(crate::model::ModelPricing::ZERO),
+                supports_thinking: None,
+                provider_info: None,
             })
             .collect();
         models.sort_by(|a, b| a.id.cmp(&b.id));

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -233,11 +233,18 @@ impl Provider for Mistral {
                     let context_window = m["max_context_length"]
                         .as_u64()
                         .and_then(|v| u32::try_from(v).ok());
+                    let supports_thinking = m
+                        .get("capabilities")
+                        .and_then(Value::as_object)
+                        .and_then(|c| c.get("reasoning"))
+                        .and_then(Value::as_bool);
                     Some(crate::model::ModelInfo {
                         id: id.to_string(),
                         context_window,
                         max_output_tokens: None,
                         pricing: None,
+                        supports_thinking,
+                        provider_info: None,
                     })
                 })
                 .await

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -227,6 +227,8 @@ impl OpenAiCompatProvider {
             context_window,
             max_output_tokens,
             pricing: Some(pricing),
+            supports_thinking: None,
+            provider_info: None,
         })
     }
 

--- a/maki-providers/src/providers/opencode.rs
+++ b/maki-providers/src/providers/opencode.rs
@@ -175,6 +175,8 @@ impl CatalogData {
                     cache_write: meta.cache_write,
                     fast: None,
                 }),
+                supports_thinking: None,
+                provider_info: None,
             })
             .collect();
         models.sort_by(|a, b| a.id.cmp(&b.id));

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -5,7 +5,7 @@ use serde_json::{Value, json};
 
 use crate::model::{Model, ModelEntry};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, EffortScale, Message, ProviderEvent, RequestOptions, StreamResponse};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
@@ -23,6 +23,13 @@ static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
 
 pub(crate) fn models() -> &'static [ModelEntry] {
     &[]
+}
+
+#[derive(Debug)]
+struct OpenRouterModelInfo {
+    reasoning_mandatory: bool,
+    reasoning_default_enabled: bool,
+    reasoning_efforts: Vec<String>,
 }
 
 pub struct OpenRouter {
@@ -58,6 +65,24 @@ impl OpenRouter {
     }
 }
 
+fn map_effort_to_supported<'a>(requested: &'a str, supported: &'a [String]) -> &'a str {
+    const EFFORT_ORDER: &[&str] = &["max", "xhigh", "high", "medium", "low", "minimal", "none"];
+
+    if supported.iter().any(|s| s == requested) {
+        return requested;
+    }
+    let req_idx = EFFORT_ORDER
+        .iter()
+        .position(|&e| e == requested)
+        .unwrap_or(0);
+    for effort in EFFORT_ORDER.iter().skip(req_idx) {
+        if supported.contains(&effort.to_string()) {
+            return effort;
+        }
+    }
+    supported.last().map(|s| s.as_str()).unwrap_or(requested)
+}
+
 impl Provider for OpenRouter {
     fn stream_message<'a>(
         &'a self,
@@ -77,8 +102,53 @@ impl Provider for OpenRouter {
 
             body["cache_control"] = json!({"type": "ephemeral"});
 
-            opts.thinking
-                .apply_reasoning_effort(&mut body, EffortScale::PreferHigh);
+            let reasoning_info: Option<Arc<OpenRouterModelInfo>> = {
+                let guard = crate::model_registry::model_registry().read().unwrap();
+                guard
+                    .discovered(model.provider, &model.id)
+                    .and_then(|d| d.provider_info.clone())
+                    .map(|arc| {
+                        Arc::downcast::<OpenRouterModelInfo>(arc).expect("wrong provider info type")
+                    })
+            };
+
+            let (mandatory, default_enabled) = reasoning_info
+                .as_ref()
+                .map(|r| (r.reasoning_mandatory, r.reasoning_default_enabled))
+                .unwrap_or((false, false));
+
+            // Determine if and how to send reasoning config for OpenRouter.
+            // Models have three states:
+            // 1. mandatory: true - reasoning always on, can't be disabled.
+            // 2. default_enabled: true - reasoning on by default, disable with effort: "none".
+            // 3. default off - reasoning off by default, enabled with any reasoning object.
+            let reasoning_body = if model.supports_thinking() {
+                let effort = match opts.thinking {
+                    ThinkingConfig::Off => "none",
+                    // FIXME: Should probably use default_effort if provided instead of high
+                    ThinkingConfig::Adaptive => "high",
+                    ThinkingConfig::Budget(n) => ThinkingConfig::budget_to_effort(n),
+                };
+                match opts.thinking {
+                    ThinkingConfig::Off if mandatory => None,
+                    ThinkingConfig::Off if default_enabled => Some(json!({"effort": "none"})),
+                    ThinkingConfig::Off => None,
+                    _ => {
+                        let final_effort = if let Some(info) = &reasoning_info {
+                            map_effort_to_supported(effort, &info.reasoning_efforts)
+                        } else {
+                            effort
+                        };
+                        Some(json!({"effort": final_effort}))
+                    }
+                }
+            } else {
+                None
+            };
+
+            if let Some(reasoning) = reasoning_body {
+                body["reasoning"] = reasoning;
+            }
 
             if let Some(sid) = session_id {
                 body["session_id"] = json!(sid);
@@ -132,11 +202,40 @@ impl Provider for OpenRouter {
                             })
                         })
                         .unwrap_or_default();
+
+                    let reasoning = m.get("reasoning").and_then(|v| v.as_object()).map(|v| {
+                        OpenRouterModelInfo {
+                            reasoning_mandatory: v.get("mandatory").and_then(Value::as_bool)
+                                == Some(true),
+                            reasoning_default_enabled: v
+                                .get("default_enabled")
+                                .and_then(Value::as_bool)
+                                == Some(true),
+                            reasoning_efforts: v
+                                .get("supported_efforts")
+                                .and_then(Value::as_array)
+                                .map(|arr| {
+                                    arr.iter()
+                                        .filter_map(|v| v.as_str().map(String::from))
+                                        .collect()
+                                })
+                                .unwrap_or_default(),
+                        }
+                    });
+
+                    let supports_thinking = reasoning.is_some()
+                        || m.get("supported_parameters")
+                            .and_then(|v| v.as_array())
+                            .is_some_and(|v| v.iter().any(|v| v.as_str() == Some("reasoning")));
+
                     Some(crate::model::ModelInfo {
                         id: id.to_string(),
                         context_window,
                         max_output_tokens: None,
                         pricing: Some(pricing),
+                        supports_thinking: Some(supports_thinking),
+                        provider_info: reasoning
+                            .map(|r| Arc::new(r) as Arc<dyn std::any::Any + Send + Sync>),
                     })
                 })
                 .await

--- a/maki-providers/src/providers/tensorx.rs
+++ b/maki-providers/src/providers/tensorx.rs
@@ -34,6 +34,12 @@ pub(crate) fn models() -> &'static [ModelEntry] {
     &[]
 }
 
+#[derive(Debug)]
+struct TensorXModelInfo {
+    has_thinking: bool,
+    has_reasoning_effort: bool,
+}
+
 pub struct TensorX {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
@@ -84,14 +90,39 @@ impl Provider for TensorX {
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
 
-            // See https://docs.tensorx.ai/api-reference/chat-completions#reasoning
-            if !matches!(opts.thinking, ThinkingConfig::Off)
+            let (has_thinking, has_reasoning_effort) = {
+                let guard = crate::model_registry::model_registry().read().unwrap();
+                let info = guard
+                    .discovered(model.provider, &model.id)
+                    .and_then(|d| d.provider_info.clone())
+                    .map(|arc| {
+                        Arc::downcast::<TensorXModelInfo>(arc).expect("wrong provider info type")
+                    });
+                if let Some(info) = info {
+                    (info.has_thinking, info.has_reasoning_effort)
+                } else {
+                    (false, false)
+                }
+            };
+
+            if has_thinking {
+                body["thinking"] = json!(!matches!(opts.thinking, ThinkingConfig::Off));
+            }
+            if has_reasoning_effort {
+                let effort = match opts.thinking {
+                    ThinkingConfig::Adaptive => "high",
+                    ThinkingConfig::Budget(n) => ThinkingConfig::budget_to_effort(n),
+                    ThinkingConfig::Off => "none",
+                };
+                body["reasoning_effort"] = json!(effort);
+            }
+            // Fallback for deepseek models that use chat_template_kwargs
+            else if !has_thinking
+                && !matches!(opts.thinking, ThinkingConfig::Off)
                 && model.id.starts_with("deepseek/deepseek-v4")
             {
                 body["chat_template_kwargs"] = json!({"thinking": true});
             }
-            // For other models it seems to be hardcoded, e.g. minimax m3 requests
-            // fail when setting reasoning_effort=none
 
             self.compat
                 .do_stream(model, &[], &body, event_tx, &auth)
@@ -158,11 +189,29 @@ impl Provider for TensorX {
                                 None
                             };
 
+                            let supports_thinking =
+                                info.get("supports_reasoning").and_then(Value::as_bool);
+
+                            let supported_params = info
+                                .get("supported_openai_params")
+                                .and_then(Value::as_array)
+                                .map(|params| TensorXModelInfo {
+                                    has_thinking: params
+                                        .iter()
+                                        .any(|v| v.as_str() == Some("thinking")),
+                                    has_reasoning_effort: params
+                                        .iter()
+                                        .any(|v| v.as_str() == Some("reasoning_effort")),
+                                });
+
                             Some(ModelInfo {
                                 id: id.to_string(),
                                 context_window,
                                 max_output_tokens,
                                 pricing,
+                                supports_thinking,
+                                provider_info: supported_params
+                                    .map(|p| Arc::new(p) as Arc<dyn std::any::Any + Send + Sync>),
                             })
                         })
                         .collect()


### PR DESCRIPTION
And make use of that for OpenRouter, TensorX and Mistral.

----

 - [x] Need to add TensorX. This has additional complications, I'd like to add some free-form JSON storage to the `ModelInfo` for that
 - [x] Need to add OpenRouter. Documented here: https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
 - [x] This all still needs serious review from myself too, and testing.