### PR TITLE
fix(permissions): auto-allow plan file writes

### DIFF
--- a/maki-agent/src/agent/instructions.rs
+++ b/maki-agent/src/agent/instructions.rs
@@ -64,7 +64,7 @@ pub fn build_system_prompt(
     let instructions = format!("{env}{instructions}");
     let mut out = crate::prompt::assemble(crate::prompt::PromptId::System, slots, &instructions);
 
-    if let AgentMode::Plan(plan_path) = mode {
+    if let Some(plan_path) = mode.plan_path() {
         let plan_vars = Vars::new().set("{plan_path}", plan_path.display().to_string());
         out.push_str(&plan_vars.apply(crate::prompt::PLAN_PROMPT));
     }

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -11,7 +11,7 @@ use crate::mcp::{McpHandle, UNKNOWN_MCP};
 use crate::task_set::TaskSet;
 use crate::tools::ToolContext;
 use crate::tools::registry::{ToolInvocation, ToolRegistry};
-use crate::{AgentError, AgentEvent, AgentMode, ToolDoneEvent, ToolOutput, ToolStartEvent};
+use crate::{AgentError, AgentEvent, ToolDoneEvent, ToolOutput, ToolStartEvent};
 
 #[derive(Clone, Copy)]
 pub enum Emit {
@@ -100,9 +100,9 @@ pub async fn run(
         };
 
         if let Some(target) = invocation.mutable_path() {
-            let is_plan_target = matches!(&ctx.mode, AgentMode::Plan(pp) if target == pp.as_path());
+            let is_plan_target = ctx.mode.plan_path().is_some_and(|pp| target == pp);
             if !is_plan_target {
-                if matches!(&ctx.mode, AgentMode::Plan(_)) {
+                if ctx.mode.plan_path().is_some() {
                     warn!(
                         tool = %name,
                         target = %target.display(),
@@ -204,6 +204,7 @@ async fn enforce_permission(
                 ctx.user_response_rx.as_deref(),
                 id,
                 &ctx.cancel,
+                ctx.mode.plan_path(),
             )
             .await
             .map_err(|e| e.to_string())?;
@@ -227,7 +228,7 @@ async fn execute_mcp_tool(
         written_path: None,
     };
 
-    if matches!(ctx.mode, AgentMode::Plan(_)) {
+    if ctx.mode.plan_path().is_some() {
         return done(MCP_BLOCKED_IN_PLAN.into(), true);
     }
 
@@ -251,6 +252,7 @@ async fn execute_mcp_tool(
             ctx.user_response_rx.as_deref(),
             id,
             &ctx.cancel,
+            ctx.mode.plan_path(),
         )
         .await
     {
@@ -384,6 +386,7 @@ mod tests {
     use test_case::test_case;
 
     use super::*;
+    use crate::AgentMode;
     use crate::permissions::{PERMISSION_DENIED_PREFIX, PermissionManager};
     use crate::tools::registry::ToolSource;
     use crate::tools::test_support::{GUARDED_TOOL_NAME, GuardedMock};

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -259,6 +259,7 @@ pub struct InteractiveHandle {
     pub cancel_tx: flume::Sender<()>,
     pub model_tx: flume::Sender<Model>,
     pub session_id: String,
+    pub permissions: Arc<PermissionManager>,
     pub task: smol::Task<()>,
 }
 
@@ -300,6 +301,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
 
     let task = smol::spawn({
         let session_id = session_id.clone();
+        let permissions = Arc::clone(&permissions);
         async move {
             let mut model = params.model;
             let mut provider: Arc<dyn Provider> =
@@ -430,6 +432,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
         cancel_tx,
         model_tx,
         session_id,
+        permissions,
         task,
     }
 }

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -26,7 +26,7 @@ pub use tools::ToolFilter;
 pub mod types;
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub use maki_providers::AgentError;
 use maki_providers::Message;
@@ -43,6 +43,15 @@ pub enum AgentMode {
     #[default]
     Build,
     Plan(PathBuf),
+}
+
+impl AgentMode {
+    pub fn plan_path(&self) -> Option<&Path> {
+        match self {
+            Self::Plan(p) => Some(p),
+            Self::Build => None,
+        }
+    }
 }
 
 pub enum ExtractedCommand {

--- a/maki-agent/src/permissions.rs
+++ b/maki-agent/src/permissions.rs
@@ -181,7 +181,13 @@ impl PermissionManager {
         })
     }
 
-    fn check_inner(&self, tool: &str, scopes: &[&str], force_prompt: bool) -> PermissionCheck {
+    fn check_inner(
+        &self,
+        tool: &str,
+        scopes: &[&str],
+        force_prompt: bool,
+        plan_path: Option<&Path>,
+    ) -> PermissionCheck {
         let session = self.session_rules();
         let rules = session
             .iter()
@@ -199,6 +205,15 @@ impl PermissionManager {
 
         if self.yolo.load(Ordering::Relaxed) {
             return PermissionCheck::Allowed;
+        }
+
+        if FILE_WRITE_TOOLS.contains(&tool)
+            && let Some(pp) = plan_path
+        {
+            let plan_scope = normalize_scope_path(&pp.display().to_string());
+            if scopes.iter().any(|s| normalize_scope_path(s) == plan_scope) {
+                return PermissionCheck::Allowed;
+            }
         }
 
         let is_allowed = |scope: &&str| {
@@ -236,12 +251,18 @@ impl PermissionManager {
         }
     }
 
-    pub fn check(&self, tool: &str, scope: &str) -> PermissionCheck {
-        self.check_inner(tool, &[scope], false)
+    pub fn check(&self, tool: &str, scope: &str, plan_path: Option<&Path>) -> PermissionCheck {
+        self.check_inner(tool, &[scope], false, plan_path)
     }
 
-    pub fn check_multi(&self, tool: &str, scopes: &[&str], force_prompt: bool) -> PermissionCheck {
-        self.check_inner(tool, scopes, force_prompt)
+    pub fn check_multi(
+        &self,
+        tool: &str,
+        scopes: &[&str],
+        force_prompt: bool,
+        plan_path: Option<&Path>,
+    ) -> PermissionCheck {
+        self.check_inner(tool, scopes, force_prompt, plan_path)
     }
 
     pub fn add_session_rule(&self, rule: PermissionRule) {
@@ -334,6 +355,7 @@ impl PermissionManager {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn enforce(
         &self,
         tool: &str,
@@ -342,6 +364,7 @@ impl PermissionManager {
         user_response_rx: Option<&async_lock::Mutex<flume::Receiver<String>>>,
         request_id: &str,
         cancel: &crate::CancelToken,
+        plan_path: Option<&Path>,
     ) -> Result<(), PermissionError> {
         let scope_refs: Vec<&str> = scopes.scopes.iter().map(|s| s.as_str()).collect();
         let deny = |guidance: Option<String>| {
@@ -352,16 +375,16 @@ impl PermissionManager {
             }
         };
 
-        let (pt, ps, force_prompt) = match self.check_inner(tool, &scope_refs, scopes.force_prompt)
-        {
-            PermissionCheck::Allowed => return Ok(()),
-            PermissionCheck::Denied => return Err(deny(None)),
-            PermissionCheck::NeedsPrompt {
-                tool,
-                scopes,
-                force_prompt,
-            } => (tool, scopes, force_prompt),
-        };
+        let (pt, ps, force_prompt) =
+            match self.check_inner(tool, &scope_refs, scopes.force_prompt, plan_path) {
+                PermissionCheck::Allowed => return Ok(()),
+                PermissionCheck::Denied => return Err(deny(None)),
+                PermissionCheck::NeedsPrompt {
+                    tool,
+                    scopes,
+                    force_prompt,
+                } => (tool, scopes, force_prompt),
+            };
 
         let Some(rx) = user_response_rx else {
             warn!(tool, scope = %scopes.scopes.join("; "), "no permission response channel");
@@ -370,7 +393,7 @@ impl PermissionManager {
 
         let guard = rx.lock().await;
         let refs: Vec<&str> = ps.iter().map(|s| s.as_str()).collect();
-        let (t2, s2) = match self.check_inner(&pt, &refs, force_prompt) {
+        let (t2, s2) = match self.check_inner(&pt, &refs, force_prompt, plan_path) {
             PermissionCheck::Allowed => return Ok(()),
             PermissionCheck::Denied => return Err(deny(None)),
             PermissionCheck::NeedsPrompt { tool, scopes, .. } => (tool, scopes),
@@ -567,7 +590,7 @@ mod tests {
             make_config(rules.into_iter().map(allow_rule).collect()),
             PathBuf::from("/tmp"),
         );
-        let check = mgr.check_multi("bash", &scopes, false);
+        let check = mgr.check_multi("bash", &scopes, false, None);
         assert_eq!(matches!(check, PermissionCheck::Allowed), expect_allowed);
     }
 
@@ -582,7 +605,7 @@ mod tests {
             PathBuf::from("/tmp"),
         );
         assert!(matches!(
-            mgr.check_multi("bash", &["cd /tmp", "cargo test", "rm -rf /"], false),
+            mgr.check_multi("bash", &["cd /tmp", "cargo test", "rm -rf /"], false, None),
             PermissionCheck::Denied
         ));
     }
@@ -591,7 +614,7 @@ mod tests {
     fn complex_constructs_force_prompt_even_with_allow_star() {
         let mgr = PermissionManager::new(make_config(vec![allow_rule("*")]), PathBuf::from("/tmp"));
         assert!(matches!(
-            mgr.check_multi("bash", &["echo $(whoami)"], true),
+            mgr.check_multi("bash", &["echo $(whoami)"], true, None),
             PermissionCheck::NeedsPrompt { .. }
         ));
     }
@@ -601,7 +624,10 @@ mod tests {
     #[test_case("task", "task:research" => true ; "task_allowed")]
     #[test_case("bash", "cargo test" => false ; "bash_prompts")]
     fn builtin_check(tool: &str, scope: &str) -> bool {
-        matches!(default_mgr().check(tool, scope), PermissionCheck::Allowed)
+        matches!(
+            default_mgr().check(tool, scope, None),
+            PermissionCheck::Allowed
+        )
     }
 
     #[test]
@@ -630,7 +656,7 @@ mod tests {
     fn path_traversal_prompts() {
         let path = normalize_scope_path("/tmp/../etc/passwd");
         assert!(matches!(
-            default_mgr().check("write", &path),
+            default_mgr().check("write", &path, None),
             PermissionCheck::NeedsPrompt { .. }
         ));
     }
@@ -643,7 +669,7 @@ mod tests {
         );
         mgr.add_session_rule(deny_rule("cargo *"));
         assert!(matches!(
-            mgr.check("bash", "cargo test"),
+            mgr.check("bash", "cargo test", None),
             PermissionCheck::Denied
         ));
     }
@@ -659,7 +685,7 @@ mod tests {
             PathBuf::from("/tmp"),
         );
         assert!(matches!(
-            mgr.check("bash", "rm -rf /"),
+            mgr.check("bash", "rm -rf /", None),
             PermissionCheck::Denied
         ));
     }
@@ -675,7 +701,7 @@ mod tests {
             &PermissionAnswer::AllowSession,
         );
         assert!(matches!(
-            mgr.check("bash", "cargo build"),
+            mgr.check("bash", "cargo build", None),
             PermissionCheck::Allowed
         ));
     }
@@ -689,11 +715,11 @@ mod tests {
             &PermissionAnswer::DenyAlwaysLocal,
         );
         assert!(matches!(
-            mgr.check("bash", "cargo test"),
+            mgr.check("bash", "cargo test", None),
             PermissionCheck::Denied
         ));
         assert!(matches!(
-            mgr.check("bash", "cargo build"),
+            mgr.check("bash", "cargo build", None),
             PermissionCheck::NeedsPrompt { .. }
         ));
     }
@@ -803,10 +829,10 @@ mod tests {
             PathBuf::from("/tmp"),
         );
         assert!(matches!(
-            mgr.check_multi("bash", &["cargo test", "git push"], false),
+            mgr.check_multi("bash", &["cargo test", "git push"], false, None),
             PermissionCheck::Allowed
         ));
-        match mgr.check_multi("bash", &["cargo test", "git push"], true) {
+        match mgr.check_multi("bash", &["cargo test", "git push"], true, None) {
             PermissionCheck::NeedsPrompt {
                 scopes,
                 force_prompt,
@@ -824,7 +850,7 @@ mod tests {
         let mgr =
             PermissionManager::new(make_config(vec![deny_rule("rm *")]), PathBuf::from("/tmp"));
         assert!(matches!(
-            mgr.check_multi("bash", &["rm -rf /"], true),
+            mgr.check_multi("bash", &["rm -rf /"], true, None),
             PermissionCheck::Denied
         ));
     }
@@ -835,7 +861,7 @@ mod tests {
             make_config(vec![allow_rule("cargo *")]),
             PathBuf::from("/tmp"),
         );
-        match mgr.check_multi("bash", &["cargo test", "git push", "ls"], false) {
+        match mgr.check_multi("bash", &["cargo test", "git push", "ls"], false, None) {
             PermissionCheck::NeedsPrompt { scopes, .. } => {
                 assert_eq!(scopes, vec!["git push", "ls"]);
             }
@@ -852,11 +878,11 @@ mod tests {
             &PermissionAnswer::AllowSession,
         );
         assert!(matches!(
-            mgr.check("bash", "cargo build"),
+            mgr.check("bash", "cargo build", None),
             PermissionCheck::Allowed
         ));
         assert!(matches!(
-            mgr.check("bash", "git push"),
+            mgr.check("bash", "git push", None),
             PermissionCheck::Allowed
         ));
     }
@@ -937,12 +963,12 @@ mod tests {
         );
         // Same tool, different arguments -> allowed without reprompting.
         assert!(matches!(
-            mgr.check("mcp:fetch", "{\"url\":\"https://b\"}"),
+            mgr.check("mcp:fetch", "{\"url\":\"https://b\"}", None),
             PermissionCheck::Allowed
         ));
         // A distinct MCP tool is not covered by the fetch rule.
         assert!(!matches!(
-            mgr.check("mcp:exec", "{\"cmd\":\"ls\"}"),
+            mgr.check("mcp:exec", "{\"cmd\":\"ls\"}", None),
             PermissionCheck::Allowed
         ));
     }
@@ -958,7 +984,7 @@ mod tests {
             PathBuf::from("/tmp"),
         );
         assert!(matches!(
-            mgr.check("bash", "anything"),
+            mgr.check("bash", "anything", None),
             PermissionCheck::Denied
         ));
     }
@@ -973,9 +999,12 @@ mod tests {
             }]),
             PathBuf::from("/tmp"),
         );
-        assert!(matches!(mgr.check("bash", "ls"), PermissionCheck::Denied));
         assert!(matches!(
-            mgr.check("write", "/tmp/x"),
+            mgr.check("bash", "ls", None),
+            PermissionCheck::Denied
+        ));
+        assert!(matches!(
+            mgr.check("write", "/tmp/x", None),
             PermissionCheck::Denied
         ));
     }
@@ -987,11 +1016,11 @@ mod tests {
         mgr.toggle_yolo();
         assert!(mgr.is_yolo());
         assert!(matches!(
-            mgr.check("bash", "cargo test"),
+            mgr.check("bash", "cargo test", None),
             PermissionCheck::Allowed
         ));
         assert!(matches!(
-            mgr.check("bash", "rm -rf /"),
+            mgr.check("bash", "rm -rf /", None),
             PermissionCheck::Denied
         ));
     }
@@ -1024,7 +1053,7 @@ mod tests {
             PathBuf::from("/tmp"),
         );
         assert!(matches!(
-            mgr.check("bash", "cargo test"),
+            mgr.check("bash", "cargo test", None),
             PermissionCheck::Denied
         ));
     }
@@ -1040,11 +1069,11 @@ mod tests {
             PathBuf::from("/tmp"),
         );
         assert!(matches!(
-            mgr.check("bash", "cargo test"),
+            mgr.check("bash", "cargo test", None),
             PermissionCheck::Allowed
         ));
         assert!(matches!(
-            mgr.check("bash", "rm -rf /"),
+            mgr.check("bash", "rm -rf /", None),
             PermissionCheck::Denied
         ));
     }
@@ -1059,7 +1088,7 @@ mod tests {
             PathBuf::from("/tmp"),
         );
         assert!(matches!(
-            mgr.check("bash", "cargo test"),
+            mgr.check("bash", "cargo test", None),
             PermissionCheck::Allowed
         ));
     }
@@ -1068,7 +1097,7 @@ mod tests {
     fn default_prompt_is_default_behavior() {
         let mgr = PermissionManager::new(PermissionsConfig::default(), PathBuf::from("/tmp"));
         assert!(matches!(
-            mgr.check("bash", "cargo test"),
+            mgr.check("bash", "cargo test", None),
             PermissionCheck::NeedsPrompt { .. }
         ));
     }
@@ -1085,12 +1114,28 @@ mod tests {
             PathBuf::from("/tmp"),
         );
         assert!(matches!(
-            mgr.check("bash", "cargo test"),
+            mgr.check("bash", "cargo test", None),
             PermissionCheck::Allowed
         ));
         assert!(matches!(
-            mgr.check("write", "/etc/passwd"),
+            mgr.check("write", "/etc/passwd", None),
             PermissionCheck::Denied
         ));
+    }
+
+    #[test_case("write", true ; "write_tool_allowed")]
+    #[test_case("edit", true ; "edit_tool_allowed")]
+    #[test_case("bash", false ; "non_write_tool_prompts")]
+    fn plan_path_auto_allows_file_write_tools_only(tool: &str, expect_allowed: bool) {
+        let plan = "/home/user/.local/state/maki/plans/test.md";
+        let plan_path = Path::new(plan);
+        let mgr = default_mgr();
+        assert_eq!(
+            matches!(
+                mgr.check(tool, plan, Some(plan_path)),
+                PermissionCheck::Allowed
+            ),
+            expect_allowed,
+        );
     }
 }


### PR DESCRIPTION
Two gatekeeping systems, `tool_dispatch` (plan-mode restriction) and `PermissionManager` (permission rules), both needed to know the plan file is special but only `tool_dispatch` did. So writing the plan file (which lives outside `{cwd}`) always triggered a permission prompt.

Added a `plan_path` field to `PermissionManager` that auto-allows `FILE_WRITE_TOOLS` for that exact path. The check sits after deny rules and yolo, so explicit denies still win.

Closes #420.