### PR TITLE
lua: fix VM memory exhaustion from pinned click handlers

### DIFF
--- a/maki-lua/src/api/ui/buf.rs
+++ b/maki-lua/src/api/ui/buf.rs
@@ -5,10 +5,8 @@ use maki_agent::types::InlineStyle;
 use maki_agent::{SharedBuf, SnapshotLine, SnapshotSpan, SpanStyle};
 use mlua::{Function, Result as LuaResult, UserData, UserDataMethods, Value as LuaValue};
 
-use crate::runtime::{with_click_handlers, with_live_ctx};
-
-/// `live_buf` tracks the first buffer a handler creates, which is the one
-/// the runtime streams to the UI during execution.
+/// `live_buf` tracks the first buffer a handler creates, the one
+/// that gets streamed to the UI during execution.
 pub(crate) struct BufferStore {
     buffers: HashMap<u32, Arc<SharedBuf>>,
     next_id: u32,
@@ -106,20 +104,17 @@ impl UserData for BufHandle {
 
         methods.add_method("len", |_lua, this, ()| Ok(this.buf.len()));
 
-        methods.add_method("on", |lua, this, (event, callback): (String, Function)| {
+        methods.add_method("on", |lua, _this, (event, callback): (String, Function)| {
             if event != "click" {
                 return Err(mlua::Error::runtime(format!("unsupported event: {event}")));
             }
-            let Some(tool_id) = with_live_ctx(lua, |live| live.tool_use_id.clone()) else {
+            let Some(handle) = lua.app_data_ref::<crate::runtime::TaskHandle>() else {
                 return Ok(());
             };
             let key = lua.create_registry_value(callback)?;
-            let buf = Arc::clone(&this.buf);
-            with_click_handlers(lua, |handlers| {
-                if let Some((old_key, _)) = handlers.insert(tool_id, (key, buf)) {
-                    let _ = lua.remove_registry_value(old_key);
-                }
-            });
+            if let Some(old) = crate::runtime::lock_cell(&handle).click.replace(key) {
+                let _ = lua.remove_registry_value(old);
+            }
             Ok(())
         });
     }
@@ -540,43 +535,45 @@ mod tests {
         lua.globals().set("buf", ud).unwrap();
     }
 
-    fn test_lua_with_handlers() -> mlua::Lua {
-        let lua = test_lua();
-        lua.set_app_data(HashMap::<String, (mlua::RegistryKey, Arc<SharedBuf>)>::new());
-        lua
-    }
-
     #[test]
-    fn buf_on_click_without_live_ctx_is_noop() {
-        let lua = test_lua_with_handlers();
+    fn buf_on_click_without_task_scope_is_noop() {
+        let lua = test_lua();
         set_buf_global(&lua);
 
         lua.load(r#"buf:on("click", function() end)"#)
             .exec()
             .unwrap();
 
-        let handlers = lua
-            .app_data_ref::<HashMap<String, (mlua::RegistryKey, Arc<SharedBuf>)>>()
-            .unwrap();
-        assert!(handlers.is_empty(), "no-op should not register a handler");
+        assert!(
+            lua.app_data_ref::<crate::runtime::TaskHandle>().is_none(),
+            "no-op should not register a handler"
+        );
     }
 
     #[test]
-    fn buf_on_click_registers_and_replaces_handler() {
-        let lua = test_lua_with_handlers();
+    fn buf_on_click_stores_in_task_cell_and_replaces() {
+        let lua = test_lua();
         crate::runtime::install_live_ctx(&lua, "tool_123");
         set_buf_global(&lua);
 
         lua.load(r#"buf:on("click", function() return 1 end)"#)
             .exec()
             .unwrap();
-        let registered = with_click_handlers(&lua, |h| h.contains_key("tool_123")).unwrap_or(false);
-        assert!(registered, "handler should be registered for tool_123");
+        let handle = lua
+            .app_data_ref::<crate::runtime::TaskHandle>()
+            .unwrap()
+            .clone();
+        assert!(
+            crate::runtime::lock_cell(&handle).click.is_some(),
+            "handler should be stored in task cell"
+        );
 
         lua.load(r#"buf:on("click", function() return 2 end)"#)
             .exec()
             .unwrap();
-        let count = with_click_handlers(&lua, |h| h.len()).unwrap_or(0);
-        assert_eq!(count, 1, "second on() should replace, not accumulate");
+        assert!(
+            crate::runtime::lock_cell(&handle).click.is_some(),
+            "second on() should replace, not remove"
+        );
     }
 }

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -13,7 +13,7 @@ pub use api::util::command::{
 pub use error::PluginError;
 pub use loader::{EventHandle, PluginHost};
 pub use plugin_permissions::{Permission, PluginPermissions};
-pub use runtime::{ClickReply, RestoreItem};
+pub use runtime::RestoreItem;
 
 pub mod test_support {
     use crate::api::util::command::{LuaCommandInfo, LuaCommandReader, LuaCommandWriter};

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -12,7 +12,7 @@ use crate::api::keymap::KeymapReader;
 use crate::api::util::command::{HintReader, LuaCommandReader, UiAction};
 use crate::error::PluginError;
 use crate::plugin_permissions::{PluginPermissions, load_plugin_permissions};
-use crate::runtime::{self, ClickReply, LuaThread, Request, RestoreItem};
+use crate::runtime::{self, LuaThread, Request, RestoreItem};
 use maki_agent::prompt::ResolvedSlots;
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
@@ -22,8 +22,8 @@ struct BundledPlugin {
     dir: Dir<'static>,
 }
 
-/// `lib` is not a default builtin; it only exists so plugins can
-/// `require()` shared modules across plugin boundaries.
+/// `lib` is not a default builtin; it exists so plugins can
+/// `require()` shared modules across boundaries.
 static BUNDLED_PLUGINS: &[BundledPlugin] = &[
     BundledPlugin {
         name: "index",
@@ -318,15 +318,6 @@ impl EventHandle {
         let (tx, _rx) = flume::unbounded();
         Self { tx }
     }
-    pub fn fire_click(&self, tool_id: &str, row: u32) -> Option<ClickReply> {
-        let (tx, rx) = flume::bounded(1);
-        let _ = self.tx.try_send(Request::FireBufClick {
-            tool_id: tool_id.to_owned(),
-            row,
-            reply: tx,
-        });
-        rx.recv().ok().flatten()
-    }
 
     pub fn run_command(&self, plugin: Arc<str>, command: Arc<str>, args: String) {
         let _ = self.tx.try_send(Request::RunCommand {
@@ -376,8 +367,8 @@ mod tests {
     use maki_agent::tools::ToolRegistry;
     use test_case::test_case;
 
-    /// Load `src` as a single plugin and collect the resolved slots. Panics on
-    /// load failure; reach for `load_err` when you want to inspect the error.
+    /// Load `src` as one plugin, collect resolved slots.
+    /// Panics on failure; use `load_err` to inspect errors.
     fn slots_from(plugin: &str, src: &str) -> (PluginHost, ResolvedSlots) {
         let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
         host.load_source(plugin, src).unwrap();

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -48,8 +48,9 @@ const MAX_INFLIGHT_TOOLS: usize = 64;
 const GC_STEP_INTERVAL: usize = 4;
 const INTERRUPT_CANCEL_CHECK_INTERVAL: u32 = 128;
 const ASYNC_RUN_DEFAULT_DEADLINE: Duration = Duration::from_secs(60);
-/// Without a cap, a runaway plugin gets OOM-killed by the OS and takes the
-/// whole host down. With one, it hits a catchable Lua error instead.
+const TURN_END_EVENT: &str = "TurnEnd";
+/// Without a cap, a runaway plugin OOM-kills the whole process.
+/// With one, it hits a catchable Lua error instead.
 const LUA_MEMORY_LIMIT: usize = 512 * 1024 * 1024;
 
 pub type LoadResult = Result<(), PluginError>;
@@ -66,8 +67,8 @@ pub(crate) struct PromptHintRegistration {
 
 pub(crate) type PromptHintCallbacks = BTreeMap<Arc<str>, Vec<PromptHintRegistration>>;
 
-/// Load and clear requests drain in-flight tools first so we never
-/// mutate a plugin environment while a tool call is still running.
+/// Load/clear drain in-flight tools first so we never mutate a
+/// plugin environment while a tool call is still running.
 pub enum Request {
     LoadSource {
         name: Arc<str>,
@@ -107,11 +108,6 @@ pub enum Request {
         plugin_dir: Option<PathBuf>,
         reply: flume::Sender<Result<Option<RawConfig>, PluginError>>,
     },
-    FireBufClick {
-        tool_id: String,
-        row: u32,
-        reply: flume::Sender<Option<ClickReply>>,
-    },
     RunCommand {
         plugin: Arc<str>,
         command: Arc<str>,
@@ -137,8 +133,6 @@ pub enum Request {
     },
 }
 
-/// Everything needed to re-run a lua restore callback. Used by session
-/// restore and theme re-bake so both paths share a single struct.
 pub struct RestoreItem {
     pub tool: Arc<str>,
     pub tool_use_id: String,
@@ -148,6 +142,7 @@ pub struct RestoreItem {
     pub tool_output_lines: maki_config::ToolOutputLines,
     /// Lets the UI discard snapshots from a stale theme.
     pub theme_gen: Option<u64>,
+    pub expanded: bool,
 }
 
 pub(crate) struct RestoreReply {
@@ -179,18 +174,13 @@ impl RestoreReply {
     }
 }
 
-pub struct ClickReply {
-    pub snapshot: BufferSnapshot,
-    pub live_buf: Arc<SharedBuf>,
-}
-
 #[derive(Clone)]
 pub struct LiveCtx {
     pub event_tx: maki_agent::EventSender,
     pub tool_use_id: String,
 }
 
-/// The `Mutex` is never contended (Lua is single-threaded) but
+/// Lua is single-threaded so this Mutex never contends, but
 /// `Lua::app_data` requires `Send + Sync` with the `send` feature.
 pub(crate) struct TaskCell {
     pub(crate) cancel: CancelToken,
@@ -199,6 +189,7 @@ pub(crate) struct TaskCell {
     pub(crate) jobs: JobStore,
     pub(crate) bufs: BufferStore,
     pub(crate) live: Option<LiveCtx>,
+    pub(crate) click: Option<RegistryKey>,
 }
 
 impl TaskCell {
@@ -210,22 +201,19 @@ impl TaskCell {
             jobs: JobStore::new(),
             bufs: BufferStore::new(),
             live,
+            click: None,
         }
     }
 }
 
 pub(crate) type TaskHandle = Arc<Mutex<TaskCell>>;
 
-type ClickHandlerMap = HashMap<String, (RegistryKey, Arc<SharedBuf>)>;
-
 pub(crate) fn lock_cell(handle: &TaskHandle) -> std::sync::MutexGuard<'_, TaskCell> {
     handle.lock().unwrap_or_else(|e| e.into_inner())
 }
 
-/// Bails out of a plugin call once its `TaskHandle` is cancelled, its deadline
-/// passed, or the host is shutting down. Cancel and deadline sit behind a mutex,
-/// so we only peek every `INTERRUPT_CANCEL_CHECK_INTERVAL` ticks to keep this
-/// hot path cheap.
+/// Fires on every Lua VM instruction. Checking the mutex on each tick
+/// would be too expensive, so we only peek every N ticks.
 fn install_interrupt(lua: &Lua, shutdown: Arc<AtomicBool>) {
     let interrupt_lua = lua.clone();
     let interrupt_tick = Cell::new(0u32);
@@ -255,10 +243,9 @@ fn install_interrupt(lua: &Lua, shutdown: Arc<AtomicBool>) {
     });
 }
 
-/// Publishes a `TaskCell` into `Lua::app_data` for the duration of a
-/// task, and restores the previous one on drop. Async work must go
-/// through `scope_future` because concurrent tasks on the same executor
-/// overwrite `app_data` between yields.
+/// Scopes a `TaskCell` into `Lua::app_data` for one task, restoring
+/// the previous on drop. Async work must use `scope_future` because
+/// concurrent tasks on the same executor overwrite app_data between yields.
 pub(crate) struct TaskScope {
     lua: Lua,
     handle: TaskHandle,
@@ -276,12 +263,10 @@ impl TaskScope {
         }
     }
 
-    /// A fresh non-cancelled scope. The shared Lua keeps the last task's
-    /// `TaskHandle` around, so a system callback must run under one of these or
-    /// the interrupt checker aborts it the moment that stale handle looks
-    /// cancelled. Prefer [`run_detached`] (async) or
-    /// [`LuaRuntime::call_sync_detached`] (sync): a raw scope is easy to leak by
-    /// forgetting `drop`.
+    /// The shared Lua keeps the last task's handle around, so system
+    /// callbacks need a fresh scope or the interrupt hook kills them
+    /// (stale handle looks cancelled). Prefer [`run_detached`] or
+    /// [`LuaRuntime::call_sync_detached`] over raw scopes.
     pub(crate) fn detached(lua: &Lua) -> Self {
         Self::new(lua, TaskCell::new(CancelToken::none(), None, None))
     }
@@ -299,9 +284,8 @@ impl TaskScope {
     }
 }
 
-/// The one safe way to run an async system callback (hints, click/command
-/// handlers) on the shared Lua. It owns the [detached] scope for the whole
-/// call, so no caller can forget to set it up or `drop` it.
+/// Runs an async system callback under a [detached] scope so callers
+/// can't forget to set one up.
 ///
 /// [detached]: TaskScope::detached
 pub(crate) async fn run_detached<F: std::future::Future>(lua: &Lua, fut: F) -> F::Output {
@@ -318,6 +302,9 @@ impl Drop for TaskScope {
             cell.jobs.kill_all();
             cell.jobs.clear(&self.lua);
             cell.bufs.clear();
+            if let Some(k) = cell.click.take() {
+                let _ = self.lua.remove_registry_value(k);
+            }
         }
         match self.prev.take() {
             Some(p) => {
@@ -330,8 +317,8 @@ impl Drop for TaskScope {
     }
 }
 
-/// Re-publishes the task handle around every `poll` so each concurrent
-/// task on the shared Lua instance sees its own `TaskCell`.
+/// Re-publishes the task handle on every `poll` so concurrent tasks
+/// on the shared Lua each see their own `TaskCell`.
 pub(crate) struct ScopedFuture<F> {
     lua: Lua,
     handle: TaskHandle,
@@ -377,13 +364,7 @@ pub(crate) fn with_task_bufs<R>(lua: &Lua, f: impl FnOnce(&mut BufferStore) -> R
     f(&mut lock_cell(&active_task(lua)).bufs)
 }
 
-pub(crate) fn with_click_handlers<R>(
-    lua: &Lua,
-    f: impl FnOnce(&mut ClickHandlerMap) -> R,
-) -> Option<R> {
-    lua.app_data_mut::<ClickHandlerMap>().map(|mut m| f(&mut m))
-}
-
+#[cfg(test)]
 pub(crate) fn with_live_ctx<R>(lua: &Lua, f: impl FnOnce(&LiveCtx) -> R) -> Option<R> {
     let handle = lua.app_data_ref::<TaskHandle>()?;
     lock_cell(&handle).live.as_ref().map(f)
@@ -417,8 +398,8 @@ pub(crate) fn enqueue_async_task(lua: &Lua, work_fn: RegistryKey) -> Result<(), 
     Ok(())
 }
 
-/// Caps concurrent coroutines so they don't blow the Lua stack or starve
-/// the executor. Also serves as a drain barrier for load/clear ops.
+/// Caps concurrent coroutines to avoid blowing the Lua stack.
+/// Also serves as a drain barrier for load/clear ops.
 struct InflightGate {
     lua: Lua,
     count: Cell<usize>,
@@ -574,8 +555,6 @@ struct ToolKeys {
 
 type PluginMap = Rc<RefCell<HashMap<Arc<str>, HashMap<Arc<str>, ToolKeys>>>>;
 
-/// Plugins run sandboxed: `require`/`io`/`package` are removed, and
-/// `os`/`debug` go through Luau's built-in restrictions.
 struct LuaRuntime {
     lua: Lua,
     pending: PendingTools,
@@ -624,7 +603,6 @@ impl LuaRuntime {
             source: e,
         })?;
 
-        lua.set_app_data(ClickHandlerMap::new());
         lua.set_app_data(CommandHandlerMap::new());
         lua.set_app_data(SpawnQueue::default());
         lua.set_app_data(command_writer);
@@ -1073,8 +1051,6 @@ impl LuaRuntime {
         }
     }
 
-    /// The sync sibling of [`run_detached`]: runs a synchronous system callback
-    /// on the shared Lua under a [`TaskScope::detached`] guard.
     fn call_sync_detached<R: mlua::FromLuaMulti>(
         &self,
         func: &Function,
@@ -1084,7 +1060,6 @@ impl LuaRuntime {
         func.call::<R>(args)
     }
 
-    /// Registers a TaskCtx so `maki.ui.buf()` works inside the handler.
     fn compute_header(&self, plugin: &str, tool: &str, input: Value) -> HeaderResult {
         let plugins = self.plugins.borrow();
         let Some(tk) = plugins.get(plugin).and_then(|p| p.get(tool)) else {
@@ -1166,6 +1141,21 @@ impl LuaRuntime {
                 |e| tracing::warn!(tool = &*item.tool, error = %e, "restore callback failed"),
             )
             .ok()?;
+
+        if item.expanded {
+            let click_key = lock_cell(scope.handle()).click.take();
+            if let Some(key) = click_key
+                && let Ok(func) = self.lua.registry_value::<Function>(&key)
+                && let Ok(data) = self.lua.create_table()
+            {
+                let _ = data.set("row", 0);
+                if let Err(e) = scope.scope_future(func.call_async::<()>(data)).await {
+                    tracing::warn!(tool = &*item.tool, error = %e, "click expand failed");
+                }
+                let _ = self.lua.remove_registry_value(key);
+            }
+        }
+
         drop(scope);
 
         let mut reply = extract_restore_reply(&ret)?;
@@ -1271,9 +1261,8 @@ fn extract_restore_reply(ret: &LuaValue) -> Option<RestoreReply> {
     Some(RestoreReply { body, header })
 }
 
-/// Nil from the handler means "I went async". Polls job events until
-/// `ctx:finish()`, all jobs die, or the deadline (possibly set
-/// mid-flight via `ctx:set_deadline`) expires.
+/// Handler returned nil, meaning it went async. Polls job events
+/// until `ctx:finish()`, all jobs die, or the deadline expires.
 async fn dispatch_async(
     lua: &Lua,
     handle: TaskHandle,
@@ -1408,8 +1397,8 @@ fn timeout_reply(handle: &TaskHandle, plugin: &str, tool: &str) -> ToolCallReply
     reply
 }
 
-/// Deadlines work in two layers: the interrupt hook catches tight CPU
-/// loops, and the dispatch loop catches I/O waits between job events.
+/// Two layers of deadline enforcement: the interrupt hook catches
+/// tight CPU loops, the dispatch loop catches I/O waits.
 #[allow(clippy::too_many_arguments)]
 async fn run_tool_call(
     lua: Lua,
@@ -1504,9 +1493,8 @@ async fn run_tool_call(
         }
     });
 
-    // Both the dispatch loop and the interrupt hook read the live
-    // deadline from TaskCell. The outer `tool.rs` timeout is the
-    // absolute backstop.
+    // `tool.rs` timeout is the absolute backstop; the dispatch loop
+    // and interrupt hook enforce the per-plugin deadline from TaskCell.
     let reply = call_future.await;
     drop(scope);
     reply
@@ -1522,8 +1510,8 @@ pub(crate) struct LuaThread {
     pub ui_action_rx: flume::Receiver<UiAction>,
 }
 
-/// Lua gets its own OS thread so nothing needs a Mutex. `smol::block_on`
-/// drives cooperative async, and load/clear requests wait for in-flight tools.
+/// Lua lives on its own OS thread (no Send needed). `smol::block_on`
+/// drives async, load/clear requests wait for in-flight tools.
 pub fn spawn(
     registry: Arc<ToolRegistry>,
     bundled_dirs: &'static [&'static Dir<'static>],
@@ -1623,37 +1611,6 @@ pub fn spawn(
                             rt.clear_plugin(&plugin);
                             let _ = reply.send(());
                         }
-                        Request::FireBufClick { tool_id, row, reply } => {
-                            let entry =
-                                rt.lua.app_data_ref::<ClickHandlerMap>().and_then(|m| {
-                                    let (key, buf) = m.get(&tool_id)?;
-                                    let func = rt.lua.registry_value::<Function>(key).ok()?;
-                                    Some((func, Arc::clone(buf)))
-                                });
-                            if let Some((func, buf)) = entry {
-                                let lua = rt.lua.clone();
-                                let ex_ref = Rc::clone(&ex);
-                                let g = Rc::clone(&gate);
-                                ex.spawn(async move {
-                                    let Ok(data) = lua.create_table() else {
-                                        let _ = reply.send(None);
-                                        return;
-                                    };
-                                    let _ = data.set("row", row);
-                                    if let Err(e) = run_detached(&lua, func.call_async::<()>(data)).await {
-                                        tracing::warn!(tool_id, error = %e, "click handler failed");
-                                    }
-                                    drain_spawn_queue(&lua, &ex_ref, &g);
-                                    let _ = reply.send(Some(ClickReply {
-                                        snapshot: buf.take(),
-                                        live_buf: buf,
-                                    }));
-                                })
-                                .detach();
-                            } else {
-                                let _ = reply.send(None);
-                            }
-                        }
                         Request::RunCommand {
                             plugin,
                             command,
@@ -1726,45 +1683,44 @@ pub fn spawn(
                             flag.store(false, Ordering::Relaxed);
                         }
                         Request::FireAutocmd { event, data } => {
-                            let entries = {
-                                let mut store = match rt.lua.app_data_mut::<AutocmdStore>() {
-                                    Some(s) => s,
-                                    None => continue,
-                                };
-                                let Some(list) = store.listeners.get_mut(&event) else {
-                                    continue;
-                                };
-                                std::mem::take(list)
-                            };
-                            let ctx_table = rt.lua.create_table().ok();
-                            if let Some(ref tbl) = ctx_table
-                                && let Some(obj) = data.as_object()
+                            if let Some(mut store) = rt.lua.app_data_mut::<AutocmdStore>()
+                                && let Some(list) = store.listeners.get_mut(&event)
                             {
-                                for (k, v) in obj {
-                                    let _ = tbl.set(k.as_str(), json_to_lua(&rt.lua, v).unwrap_or(LuaValue::Nil));
-                                }
-                            }
-                            let mut keep = Vec::with_capacity(entries.len());
-                            for entry in entries {
-                                let once = entry.once;
-                                if let Ok(func) = rt.lua.registry_value::<Function>(&entry.callback) {
-                                    let arg = ctx_table.as_ref().map(|t| LuaValue::Table(t.clone())).unwrap_or(LuaValue::Nil);
-                                    if let Err(e) = rt.call_sync_detached::<()>(&func, arg) {
-                                        tracing::warn!(event = %event, plugin = %entry.plugin, error = %e, "autocmd callback failed");
+                                let entries = std::mem::take(list);
+                                drop(store);
+                                let ctx_table = rt.lua.create_table().ok();
+                                if let Some(ref tbl) = ctx_table
+                                    && let Some(obj) = data.as_object()
+                                {
+                                    for (k, v) in obj {
+                                        let _ = tbl.set(k.as_str(), json_to_lua(&rt.lua, v).unwrap_or(LuaValue::Nil));
                                     }
                                 }
-                                if once {
-                                    let _ = rt.lua.remove_registry_value(entry.callback);
-                                } else {
-                                    keep.push(entry);
+                                let mut keep = Vec::with_capacity(entries.len());
+                                for entry in entries {
+                                    let once = entry.once;
+                                    if let Ok(func) = rt.lua.registry_value::<Function>(&entry.callback) {
+                                        let arg = ctx_table.as_ref().map(|t| LuaValue::Table(t.clone())).unwrap_or(LuaValue::Nil);
+                                        if let Err(e) = rt.call_sync_detached::<()>(&func, arg) {
+                                            tracing::warn!(event = %event, plugin = %entry.plugin, error = %e, "autocmd callback failed");
+                                        }
+                                    }
+                                    if once {
+                                        let _ = rt.lua.remove_registry_value(entry.callback);
+                                    } else {
+                                        keep.push(entry);
+                                    }
                                 }
+                                if !keep.is_empty()
+                                    && let Some(mut store) = rt.lua.app_data_mut::<AutocmdStore>()
+                                {
+                                    store.listeners.entry(event.clone()).or_default().extend(keep);
+                                }
+                                drain_spawn_queue(&rt.lua, &ex, &gate);
                             }
-                            if !keep.is_empty()
-                                && let Some(mut store) = rt.lua.app_data_mut::<AutocmdStore>()
-                            {
-                                store.listeners.entry(event).or_default().extend(keep);
+                            if event == TURN_END_EVENT {
+                                rt.lua.gc_collect().ok();
                             }
-                            drain_spawn_queue(&rt.lua, &ex, &gate);
                         }
                         Request::RunKeybindCallback { id } => {
                             let func = rt.lua.app_data_ref::<KeymapStore>().and_then(|store| {
@@ -2099,8 +2055,6 @@ mod tests {
         }));
     }
 
-    /// Loops far past `INTERRUPT_CANCEL_CHECK_INTERVAL` so the interrupt handler
-    /// is guaranteed to run the cancel check at least once mid-call.
     fn looping_callback(lua: &Lua) -> Function {
         lua.load("for _ = 1, 100000 do end return true")
             .into_function()

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -1169,6 +1169,7 @@ fn restore_tool_async_ordering_and_delivery() {
         is_error: true,
         tool_output_lines: ToolOutputLines::default(),
         theme_gen: None,
+        expanded: false,
     };
     let unknown_item = maki_lua::RestoreItem {
         tool: std::sync::Arc::from("definitely_not_a_tool"),
@@ -1178,15 +1179,15 @@ fn restore_tool_async_ordering_and_delivery() {
         is_error: false,
         tool_output_lines: ToolOutputLines::default(),
         theme_gen: None,
+        expanded: false,
     };
 
     handle.request_restore(unknown_item, event_tx.clone());
     handle.request_restore(bash_item("a"), event_tx.clone());
     handle.request_restore(bash_item("b"), event_tx.clone());
 
-    // collect_prompt_slots is a synchronous round-trip: since the Lua
-    // thread is FIFO, it won't return until all prior requests (our
-    // restores) have been processed. Neat trick to drain without a latch.
+    // collect_prompt_slots is synchronous and FIFO, so it won't return
+    // until all prior requests (our restores) have drained. No latch needed.
     let _ = handle.collect_prompt_slots();
 
     let snapshots: Vec<maki_agent::Envelope> = rx.drain().collect();
@@ -1212,10 +1213,9 @@ fn restore_tool_async_ordering_and_delivery() {
     assert_eq!(body_count, 2, "two body snapshots for two bash items");
 }
 
-/// Guards the stale-cancelled-handle bug: `permission_scopes` must run the
-/// plugin callback and return its parsed result, never fall back to the raw
-/// input JSON. A leaked `{"command":...}` scope breaks allow rules, so we
-/// reprompt on every call. Covers both a parseable and an unparseable command.
+/// Guards the stale-cancelled-handle bug: `permission_scopes` must call
+/// the plugin callback and return parsed scopes, not fall back to raw JSON.
+/// A leaked `{"command":...}` scope would break allow rules.
 #[test_case::test_case("git status" ; "parseable command")]
 #[test_case::test_case("echo 'unterminated" ; "unparseable command")]
 fn bash_permission_scopes_never_falls_back_to_json(command: &str) {

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -47,7 +47,6 @@ use crate::components::tool_display::format_turn_usage;
 use crate::components::{
     Action, DisplayMessage, DisplayRole, ExitRequest, Overlay, RetryInfo, Status, is_ctrl,
 };
-use crate::event_loop::BufClickHandler;
 use crate::image;
 use crate::selection::{SelectionState, ZoneRegistry};
 use arc_swap::{ArcSwap, ArcSwapOption};
@@ -75,8 +74,8 @@ pub(crate) use queue::MessageQueue;
 use session_state::SessionState;
 
 const CANCEL_MSG: &str = "Cancelled.";
-/// Bypasses the per-run staleness filter in `handle_agent_event` since
-/// re-bake replies don't belong to any real agent run.
+/// Bypasses the per-run staleness filter because re-bake replies
+/// don't belong to any real agent run.
 pub(crate) const RESTORE_RUN_ID: u64 = u64::MAX;
 const FLASH_CANCEL: &str = "Press esc again to stop...";
 const FLASH_REWIND: &str = "Press esc again to rewind...";
@@ -91,8 +90,6 @@ const IMPLEMENT_PARALLEL_HINT: &str = "Use batch+task to parallelize, assign eac
 
 const TASK_DONE_DETAIL: &str = "✓ ";
 
-/// `Option<bool>` lets us distinguish the main chat (None, no status indicator)
-/// from subagents (Some, with spinner or checkmark).
 #[derive(Clone)]
 pub(super) struct TaskEntry {
     name: String,
@@ -174,7 +171,6 @@ pub struct App {
     pub(crate) shell: shell::ShellState,
     pub(crate) ui_config: UiConfig,
     pub(crate) permissions: Arc<PermissionManager>,
-    pub(super) buf_click: Option<BufClickHandler>,
     pub(crate) lua_event_handle: Option<EventHandle>,
     pub(super) keymap_reader: KeymapReader,
     pub(super) hint_reader: HintReader,
@@ -252,7 +248,6 @@ impl App {
             shell: shell::ShellState::default(),
             ui_config,
             permissions,
-            buf_click: None,
             lua_event_handle: None,
             keymap_reader,
             hint_reader,
@@ -405,7 +400,6 @@ impl App {
         self.task_picker.select(self.active_chat);
     }
 
-    /// Ctrl shortcuts that apply when no overlay owns input.
     fn handle_ctrl(&mut self, key: KeyEvent) -> Option<Vec<Action>> {
         if !is_ctrl(&key) {
             return None;
@@ -466,9 +460,6 @@ impl App {
         None
     }
 
-    /// Routes input to whichever overlay currently owns focus.
-    /// Returns `Some` when an overlay is open (consuming the key),
-    /// `None` when no overlay is active and input should continue.
     fn dispatch_overlay(&mut self, key: KeyEvent) -> Option<Vec<Action>> {
         if self.permission_prompt.is_open() {
             if let Some(answer) = self.permission_prompt.handle_key(key) {

--- a/maki-ui/src/app/mouse.rs
+++ b/maki-ui/src/app/mouse.rs
@@ -1,7 +1,6 @@
 use std::time::{Duration, Instant};
 
 use crate::clipboard::CopyResult;
-use crate::components::messages::ClickResult;
 use crate::selection::{self, ContentRegion, EdgeScroll, Selection, SelectionState, SelectionZone};
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;
@@ -45,19 +44,7 @@ impl App {
                         self.selection_state = None;
                         if zone == SelectionZone::Messages {
                             let area = self.msg_area();
-                            let result = self.chats[self.active_chat].handle_click(event.row, area);
-                            match result {
-                                ClickResult::LuaToolClick { tool_id, row } => {
-                                    if let Some(handler) = &self.buf_click
-                                        && let Some(reply) = handler(&tool_id, row)
-                                    {
-                                        let chat = &mut self.chats[self.active_chat];
-                                        chat.tool_snapshot(&tool_id, reply.snapshot, None);
-                                        chat.register_live_buf(tool_id, reply.live_buf);
-                                    }
-                                }
-                                ClickResult::Toggled | ClickResult::Nothing => {}
-                            }
+                            self.chats[self.active_chat].handle_click(event.row, area);
                         }
                     }
                 }

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -234,12 +234,8 @@ impl Chat {
         self.messages_panel.extract_selection_text(sel, msg_area)
     }
 
-    pub fn handle_click(
-        &mut self,
-        row: u16,
-        area: Rect,
-    ) -> super::components::messages::ClickResult {
-        self.messages_panel.handle_click(row, area)
+    pub fn handle_click(&mut self, row: u16, area: Rect) {
+        self.messages_panel.handle_click(row, area);
     }
 
     pub fn tool_snapshot(
@@ -317,9 +313,8 @@ impl Chat {
             .push(DisplayMessage::new(DisplayRole::User, text.into()));
     }
 
-    /// Flush any in-flight stream, push the bubble, then re-pin auto-scroll.
-    /// Doing all three together keeps the bubble from briefly landing in the
-    /// wrong row, which is what caused the one-frame hop after submit.
+    /// Flush, push, and re-pin scroll in one shot to avoid
+    /// the one-frame hop where the bubble briefly lands in the wrong row.
     pub fn show_user_message(&mut self, text: impl Into<String>) {
         self.flush();
         self.push_user_message(text);
@@ -436,6 +431,7 @@ pub fn history_to_display(
                                 is_error: status == ToolStatus::Error,
                                 tool_output_lines: *tool_output_lines,
                                 theme_gen: None,
+                                expanded: false,
                             });
                             display.push(DisplayMessage {
                                 role: DisplayRole::Tool(Box::new(ToolRole {
@@ -467,8 +463,8 @@ pub fn history_to_display(
     (display, restore_items)
 }
 
-/// The original `ToolResult` is gone after session load, so we rebuild a
-/// `RestoreItem` from whatever the `DisplayMessage` kept.
+/// `ToolResult` is gone after session load, so we rebuild from
+/// whatever the `DisplayMessage` kept.
 pub(crate) fn restore_item_for(
     msg: &DisplayMessage,
     tool_output_lines: maki_config::ToolOutputLines,
@@ -487,10 +483,10 @@ pub(crate) fn restore_item_for(
         is_error: role.status == ToolStatus::Error,
         tool_output_lines,
         theme_gen: Some(theme_gen),
+        expanded: false,
     })
 }
 
-/// Batch variant of `restore_item_for`.
 pub(crate) fn restore_item_for_batch_entry(
     entry: &maki_agent::BatchToolEntry,
     child_id: String,
@@ -507,11 +503,12 @@ pub(crate) fn restore_item_for_batch_entry(
         is_error: entry.status == BatchToolStatus::Error,
         tool_output_lines,
         theme_gen: Some(theme_gen),
+        expanded: false,
     })
 }
 
-/// Builds a loaded tool the same way the live `tool_done` path does, so
-/// restored sessions look identical to streamed ones.
+/// Mirrors the live `tool_done` path so restored sessions
+/// look the same as streamed ones.
 fn build_loaded_tool(
     tool: &str,
     summary: &str,

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -27,7 +27,7 @@ use crate::splash::{ColorTransition, Splash};
 use crate::theme;
 use maki_config::{ToolOutputLines, UiConfig};
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -48,13 +48,6 @@ struct LiveBufEntry {
     dirty_seen: bool,
 }
 
-#[derive(Debug)]
-pub enum ClickResult {
-    Nothing,
-    Toggled,
-    LuaToolClick { tool_id: String, row: u32 },
-}
-
 pub struct MessagesPanel {
     messages: Vec<DisplayMessage>,
     streaming_thinking: StreamingContent,
@@ -72,14 +65,15 @@ pub struct MessagesPanel {
     idle_splash: Splash,
     accent: ColorTransition,
     expanded_tools: HashMap<String, SectionFlags>,
+    lua_expanded: HashSet<String>,
     live_bufs: HashMap<String, LiveBufEntry>,
     batch_children: HashMap<String, BatchChildState>,
     tool_output_lines: ToolOutputLines,
     render_hints: RenderHintsRegistry,
     lua_event_handle: Option<EventHandle>,
     restore_event_tx: Option<EventSender>,
-    /// Deduplicates re-bake requests: we only fire one per tool per
-    /// generation, and `snapshot_theme_gen` only updates when colors land.
+    /// One re-bake per tool per generation; `snapshot_theme_gen`
+    /// only bumps when colors actually land.
     rebake_requested: HashMap<String, u64>,
 }
 
@@ -115,6 +109,7 @@ impl MessagesPanel {
             idle_splash: Splash::new(ui_config.splash_animation),
             accent: ColorTransition::new(theme::current().mode_build),
             expanded_tools: HashMap::new(),
+            lua_expanded: HashSet::new(),
             live_bufs: HashMap::new(),
             batch_children: HashMap::new(),
             tool_output_lines: ui_config.tool_output_lines,
@@ -142,6 +137,7 @@ impl MessagesPanel {
         self.messages = msgs;
         self.cache.clear();
         self.expanded_tools.clear();
+        self.lua_expanded.clear();
         self.batch_children.clear();
         self.live_bufs.clear();
         self.rebake_requested.clear();
@@ -631,24 +627,35 @@ impl MessagesPanel {
         self.accent.set(color);
     }
 
-    pub fn handle_click(&mut self, row: u16, area: Rect) -> ClickResult {
+    pub fn handle_click(&mut self, row: u16, area: Rect) -> bool {
         if area.height == 0 {
-            return ClickResult::Nothing;
+            return false;
         }
         let doc_row = (row.saturating_sub(area.y)) as u32 + self.scroll_top as u32;
         let width = self.viewport_width;
-        let Some((_, seg, seg_start)) = self.cache.segment_at_row(doc_row, width) else {
-            return ClickResult::Nothing;
+        let Some((_, seg, _seg_start)) = self.cache.segment_at_row(doc_row, width) else {
+            return false;
         };
         let Some(tool_id) = seg.tool_id.as_deref() else {
-            return ClickResult::Nothing;
+            return false;
         };
 
         if self.has_snapshot(tool_id) {
-            return ClickResult::LuaToolClick {
-                tool_id: tool_id.to_owned(),
-                row: doc_row - seg_start,
-            };
+            let expanded = !self.lua_expanded.contains(tool_id);
+            if expanded {
+                self.lua_expanded.insert(tool_id.to_owned());
+            } else {
+                self.lua_expanded.remove(tool_id);
+            }
+            if let Some(mut item) = self.lua_restore_item(tool_id) {
+                item.expanded = expanded;
+                if let (Some(eh), Some(tx)) =
+                    (self.lua_event_handle.clone(), self.restore_event_tx.clone())
+                {
+                    eh.request_restore(item, tx);
+                }
+            }
+            return true;
         }
 
         let exp = self
@@ -657,7 +664,7 @@ impl MessagesPanel {
             .copied()
             .unwrap_or_default();
         if !seg.truncation.any() && !exp.any() {
-            return ClickResult::Nothing;
+            return false;
         }
         let tool_id = tool_id.to_owned();
         let truncation = seg.truncation;
@@ -669,12 +676,12 @@ impl MessagesPanel {
             entry.script = !entry.script;
         }
         self.rebuild_expanded_tool(&tool_id);
-        ClickResult::Toggled
+        true
     }
 
     #[cfg(test)]
     pub fn toggle_expansion_at(&mut self, row: u16, area: Rect) -> bool {
-        matches!(self.handle_click(row, area), ClickResult::Toggled)
+        self.handle_click(row, area)
     }
 
     fn rebuild_expanded_tool(&mut self, tool_id: &str) {
@@ -869,9 +876,34 @@ impl MessagesPanel {
                 .is_some_and(|m| m.render_snapshot.is_some())
     }
 
-    /// Fires async re-restores for every snapshot baked with an old theme.
-    /// Replies carry their generation, so a stale reply can never overwrite
-    /// fresher colors (monotonic guard in `resolve_snapshot_gen`).
+    fn lua_restore_item(&self, tool_id: &str) -> Option<maki_lua::RestoreItem> {
+        if let Some((parent_id, idx)) = parse_batch_inner_id(tool_id) {
+            let msg = self
+                .messages
+                .iter()
+                .rfind(|m| matches!(&m.role, DisplayRole::Tool(t) if t.id == parent_id))?;
+            let entries = match msg.tool_output.as_deref()? {
+                ToolOutput::Batch { entries, .. } => entries,
+                _ => return None,
+            };
+            let entry = entries.get(idx)?;
+            crate::chat::restore_item_for_batch_entry(
+                entry,
+                tool_id.to_owned(),
+                self.tool_output_lines,
+                self.theme_generation,
+            )
+        } else {
+            let msg = self
+                .messages
+                .iter()
+                .rfind(|m| matches!(&m.role, DisplayRole::Tool(t) if t.id == tool_id))?;
+            crate::chat::restore_item_for(msg, self.tool_output_lines, self.theme_generation)
+        }
+    }
+
+    /// Re-restores every snapshot still painted with old-theme colors.
+    /// Replies carry a generation so stale ones can't overwrite fresher colors.
     fn rebake_stale_snapshots(&mut self, current_gen: u64) {
         let (Some(eh), Some(tx)) = (self.lua_event_handle.clone(), self.restore_event_tx.clone())
         else {
@@ -891,7 +923,8 @@ impl MessagesPanel {
             ) {
                 continue;
             }
-            if let Some(item) = crate::chat::restore_item_for(msg, tol, current_gen) {
+            if let Some(mut item) = crate::chat::restore_item_for(msg, tol, current_gen) {
+                item.expanded = self.lua_expanded.contains(&role.id);
                 eh.request_restore(item, tx.clone());
                 requested.push(role.id.clone());
             }
@@ -909,8 +942,6 @@ impl MessagesPanel {
         stale && self.rebake_requested.get(tool_id) != Some(&current_gen)
     }
 
-    /// Batch children live in `batch_children`, not in `self.messages`,
-    /// so they need a separate walk.
     fn stale_batch_child_items(&self, current_gen: u64) -> Vec<maki_lua::RestoreItem> {
         let tol = self.tool_output_lines;
         let mut items = Vec::new();
@@ -930,9 +961,13 @@ impl MessagesPanel {
                 if !self.should_request_rebake(&child_id, stale, current_gen) {
                     continue;
                 }
-                if let Some(item) =
-                    crate::chat::restore_item_for_batch_entry(entry, child_id, tol, current_gen)
-                {
+                if let Some(mut item) = crate::chat::restore_item_for_batch_entry(
+                    entry,
+                    child_id.clone(),
+                    tol,
+                    current_gen,
+                ) {
+                    item.expanded = self.lua_expanded.contains(&child_id);
                     items.push(item);
                 }
             }
@@ -940,8 +975,8 @@ impl MessagesPanel {
         items
     }
 
-    /// For live snapshots (`None`) we stamp the panel's generation. For
-    /// re-bake replies we enforce monotonicity: drop if something newer landed.
+    /// Live snapshots (`None`) get the panel's current generation.
+    /// Re-bake replies are monotonic: drop if something newer landed.
     fn resolve_snapshot_gen(&self, tool_id: &str, incoming: Option<u64>) -> Option<u64> {
         let Some(incoming_gen) = incoming else {
             return Some(self.theme_generation);
@@ -1005,8 +1040,8 @@ impl MessagesPanel {
             .rfind(|m| matches!(&m.role, DisplayRole::Tool(t) if t.id == tool_id))
     }
 
-    /// Re-bake replies fan to every chat, so we need to skip chats that
-    /// don't own this tool (otherwise phantom batch children appear).
+    /// Re-bake replies fan to every chat, so skip chats that don't
+    /// own this tool (avoids phantom batch children).
     fn has_tool_msg(&self, tool_id: &str) -> bool {
         self.messages
             .iter()

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -1113,11 +1113,11 @@ fn handle_click_returns_nothing_when_no_segment_at_row() {
     let mut panel = MessagesPanel::new(UiConfig::default());
     render(&mut panel, 80, 24);
     let area = Rect::new(0, 0, 80, 24);
-    assert!(matches!(panel.handle_click(23, area), ClickResult::Nothing));
+    assert!(!panel.handle_click(23, area));
 }
 
 #[test]
-fn handle_click_returns_lua_tool_click_when_snapshot_exists() {
+fn handle_click_returns_toggled_when_snapshot_exists() {
     let mut panel = MessagesPanel::new(UiConfig::default());
     panel.tool_start(start("t1", BASH_TOOL_NAME));
     panel.tool_done(ToolDoneEvent {
@@ -1135,22 +1135,15 @@ fn handle_click_returns_lua_tool_click_when_snapshot_exists() {
     );
     render(&mut panel, 80, 24);
     let area = Rect::new(0, 0, 80, 24);
-    match panel.handle_click(area.y, area) {
-        ClickResult::LuaToolClick { tool_id, .. } => {
-            assert_eq!(tool_id, "t1");
-        }
-        other => panic!("expected LuaToolClick, got {other:?}"),
-    }
+    assert!(panel.handle_click(area.y, area));
+    assert!(panel.lua_expanded.contains("t1"));
 }
 
 #[test]
 fn handle_click_returns_toggled_for_truncated_tool_without_snapshot() {
     let mut panel = panel_with_long_tool(200);
     let area = Rect::new(0, 0, 80, 24);
-    match panel.handle_click(area.y, area) {
-        ClickResult::Toggled => {}
-        other => panic!("expected Toggled, got {other:?}"),
-    }
+    assert!(panel.handle_click(area.y, area));
 }
 
 #[test]
@@ -1162,14 +1155,11 @@ fn handle_click_non_tool_segment_returns_nothing() {
     ));
     render(&mut panel, 80, 24);
     let area = Rect::new(0, 0, 80, 24);
-    assert!(matches!(
-        panel.handle_click(area.y, area),
-        ClickResult::Nothing
-    ));
+    assert!(!panel.handle_click(area.y, area));
 }
 
 #[test]
-fn handle_click_returns_lua_tool_click_for_batch_child() {
+fn handle_click_returns_toggled_for_batch_child_with_snapshot() {
     let mut panel = MessagesPanel::new(UiConfig::default());
     batch_start(
         &mut panel,
@@ -1186,12 +1176,18 @@ fn handle_click_returns_lua_tool_click_for_batch_child() {
     );
     render(&mut panel, 80, 24);
 
-    let area = Rect::new(0, 0, 80, 24);
-    let clicked = (0..area.height).find_map(|row| match panel.handle_click(row, area) {
-        ClickResult::LuaToolClick { tool_id, .. } if tool_id == "b1__0" => Some(tool_id),
-        _ => None,
-    });
-    assert_eq!(clicked.as_deref(), Some("b1__0"));
+    let width = 80;
+    let seg_idx = panel
+        .cache
+        .find_by_tool_id("b1__0")
+        .expect("child segment exists");
+    let row: u16 = panel.cache.segments()[..seg_idx]
+        .iter()
+        .map(|s| s.height(width))
+        .sum();
+    let area = Rect::new(0, 0, width, 24);
+    assert!(panel.handle_click(row, area));
+    assert!(panel.lua_expanded.contains("b1__0"));
 }
 
 #[test]

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -32,8 +32,6 @@ use crate::terminal;
 const ANIMATION_INTERVAL_MS: u64 = 16;
 const IDLE_POLL_INTERVAL_MS: u64 = 100;
 
-pub type BufClickHandler = Arc<dyn Fn(&str, u32) -> Option<maki_lua::ClickReply> + Send + Sync>;
-
 pub struct EventLoopParams {
     pub model: Model,
     pub needs_login: bool,
@@ -51,7 +49,6 @@ pub struct EventLoopParams {
     pub hint_reader: HintReader,
     pub ui_action_rx: Option<flume::Receiver<UiAction>>,
     pub lua_event_handle: Option<EventHandle>,
-    pub buf_click: Option<BufClickHandler>,
 }
 
 pub(crate) struct EventLoop<'t> {
@@ -175,7 +172,6 @@ impl<'t> EventLoop<'t> {
             hint_reader,
             ui_action_rx,
             lua_event_handle,
-            buf_click,
         } = params;
 
         std::thread::spawn(crate::highlight::warmup);
@@ -230,7 +226,6 @@ impl<'t> EventLoop<'t> {
             custom_commands,
         );
         app.exit_on_done = exit_on_done;
-        app.buf_click = buf_click;
         app.lua_event_handle = lua_event_handle;
 
         if needs_login {

--- a/maki-ui/src/lib.rs
+++ b/maki-ui/src/lib.rs
@@ -34,7 +34,7 @@ use maki_providers::TokenUsage;
 pub type AppSession = maki_storage::sessions::Session<Message, TokenUsage, ToolOutput>;
 
 pub(crate) use agent::AgentCommand;
-pub use event_loop::{BufClickHandler, EventLoopParams};
+pub use event_loop::EventLoopParams;
 
 pub fn run(
     params: EventLoopParams,

--- a/plugins/skill/init.lua
+++ b/plugins/skill/init.lua
@@ -103,6 +103,14 @@ maki.api.register_tool({
     return input.name
   end,
 
+  restore = function(_input, output, _is_error, ctx)
+    local tol = ctx:tool_output_lines()
+    return ToolView.restore(output, {
+      max_lines = (tol and tol.other) or 20,
+      keep = "head",
+    })
+  end,
+
   handler = function(input, ctx)
     if not input.name then
       return "error: name is required"

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -206,13 +206,6 @@ pub fn run(cli: Cli) -> Result<()> {
                 hint_reader: plugin_host.hint_reader(),
                 ui_action_rx,
                 lua_event_handle: plugin_host.event_handle(),
-                buf_click: plugin_host.event_handle().map(|eh| {
-                    Arc::new(
-                        move |tool_id: &str, row: u32| -> Option<maki_lua::ClickReply> {
-                            eh.fire_click(tool_id, row)
-                        },
-                    ) as maki_ui::BufClickHandler
-                }),
             },
             initial_prompt,
         )


### PR DESCRIPTION
Every `buf:on("click", cb)` call pinned the closure in a global `ClickHandlerMap` keyed by tool id, forever. The closure captures the `ToolView` which holds the entire tool output in Lua, so long sessions accumulated pinned state until the 512MB `LUA_MEMORY_LIMIT` hit and every tool started failing with `memory error`.

Click handlers now live in `TaskCell.click` and die with the tool invocation. Clicking a snapshot flips a `lua_expanded` flag in `MessagesPanel` and fires `request_restore` with `expanded: true`, which re-runs the restore callback, invokes the click handler once before snapshotting, and throws everything away. The `FireAutocmd` arm also runs `gc_collect()` on `TurnEnd` to reclaim any stragglers.

Removed `ClickReply`, `ClickHandlerMap`, `FireBufClick`, `BufClickHandler`, `fire_click`, and the entire synchronous click round-trip through `mouse.rs` and `cmd/tui.rs`. Added a `restore` callback to the skill plugin so it works with the new pipeline.

https://github.com/tontinton/maki/issues/412