### PR TITLE
theme: add rose_pine_moon and rose_pine_dawn themes

### DIFF
--- a/maki-ui/src/theme.rs
+++ b/maki-ui/src/theme.rs
@@ -209,6 +209,14 @@ pub static BUNDLED_THEMES: &[ThemeEntry] = &[
         toml: include_str!("themes/rose_pine.toml"),
     },
     ThemeEntry {
+        name: "rose_pine_dawn",
+        toml: include_str!("themes/rose_pine_dawn.toml"),
+    },
+    ThemeEntry {
+        name: "rose_pine_moon",
+        toml: include_str!("themes/rose_pine_moon.toml"),
+    },
+    ThemeEntry {
         name: "solarized_dark",
         toml: include_str!("themes/solarized_dark.toml"),
     },

--- a/maki-ui/src/themes/rose_pine.toml
+++ b/maki-ui/src/themes/rose_pine.toml
@@ -1,4 +1,5 @@
 # Rosé Pine theme for Maki
+# https://rosepinetheme.com/palette/
 
 "comment"                         = { fg = "comment" }
 "comment.block"                   = { fg = "comment" }
@@ -85,84 +86,76 @@
 "variable.parameter"              = { fg = "orange", modifiers = ["italic"] }
 
 [palette]
-background       = "#191724"
-background_2     = "#1f1d2e"
-foreground       = "#e0def4"
-comment          = "#6e6a86"
-comment_lighter  = "#908caa"
-cyan             = "#9ccfd8"
-green            = "#9ccfd8"
-orange           = "#f6c177"
-pink             = "#eb6f92"
-purple           = "#c4a7e7"
-red              = "#eb6f92"
-yellow           = "#f6c177"
-current_line     = "#26233a"
-selection        = "#2a273f"
-gold             = "#f6c177"
-rose             = "#ebbcba"
-pine             = "#31748f"
-foam             = "#9ccfd8"
-iris             = "#c4a7e7"
-love             = "#eb6f92"
-mode_plan        = "#ebbcba"
+background        = "#191724"
+background_2      = "#1f1d2e"
+foreground        = "#e0def4"
+comment           = "#6e6a86"
+comment_lighter   = "#908caa"
+current_line      = "#21202e"
+selection         = "#403d52"
+highlight_high    = "#524f67"
+gold              = "#f6c177"
+rose              = "#ebbcba"
+pine              = "#31748f"
+foam              = "#9ccfd8"
+iris              = "#c4a7e7"
+love              = "#eb6f92"
+cyan              = "#9ccfd8"
+green             = "#9ccfd8"
+orange            = "#f6c177"
+pink              = "#eb6f92"
+purple            = "#c4a7e7"
+red               = "#eb6f92"
+yellow            = "#f6c177"
+mode_plan         = "#ebbcba"
 
 [ui]
-user               = { fg = "rose" }
-assistant_prefix   = { fg = "iris" }
-assistant          = { fg = "foreground" }
-thinking           = { fg = "comment", modifiers = ["italic"] }
-
-strikethrough      = { fg = "comment", modifiers = ["crossed_out"] }
-code_block         = { fg = "foreground" }
-
-plan_rule          = { fg = "rose", modifiers = ["bold"] }
-horizontal_rule    = { fg = "comment" }
-table_border       = { fg = "comment" }
-
-tool_bg            = { bg = "#1f1d2e" }
-tool               = { fg = "foreground" }
-tool_prefix        = { fg = "foreground", modifiers = ["bold"] }
-tool_path          = { fg = "foam" }
-tool_annotation    = { fg = "comment" }
-tool_success       = { fg = "foam" }
-tool_error         = { fg = "love" }
-tool_dim           = { fg = "comment" }
-
-diff_old           = { bg = "#2a1b2a" }
-diff_new           = { bg = "#1a2a2d" }
-diff_old_emphasis  = { bg = "#3d2636" }
-diff_new_emphasis  = { bg = "#223838" }
-diff_line_nr       = { fg = "comment" }
-
-item_selected      = { fg = "background", bg = "iris" }
-item               = { fg = "rose" }
-item_desc          = { fg = "comment" }
-accent             = { fg = "gold" }
-
-panel_border       = { fg = "iris" }
-panel_title        = { fg = "iris", modifiers = ["bold"] }
-cursor             = { fg = "background", bg = "foreground" }
-input_border       = { fg = "#403d52" }
-
-keybind_key        = { fg = "foam", modifiers = ["bold"] }
-keybind_section    = { fg = "iris", modifiers = ["bold"] }
-
-status_dim         = { fg = "comment" }
-error              = { fg = "love" }
-
-todo_completed     = { fg = "foam" }
-todo_in_progress   = { fg = "gold" }
-todo_pending       = { fg = "comment" }
-todo_cancelled     = { fg = "love", modifiers = ["crossed_out"] }
-keybind_desc       = { fg = "foreground" }
-queue              = { fg = "iris" }
-plan_path          = { fg = "gold", modifiers = ["bold"] }
-status_notice      = { fg = "gold" }
-status_retry_error = { fg = "love" }
-status_retry_info  = { fg = "comment" }
-input_placeholder  = { fg = "comment" }
-queue_delete       = { fg = "love", modifiers = ["bold"] }
-timestamp          = { fg = "comment" }
-spinner            = { fg = "gold" }
-active             = { fg = "foam" }
+user              = { fg = "rose" }
+assistant_prefix  = { fg = "iris" }
+assistant         = { fg = "foreground" }
+thinking          = { fg = "comment", modifiers = ["italic"] }
+strikethrough     = { fg = "comment", modifiers = ["crossed_out"] }
+code_block        = { fg = "foreground" }
+plan_rule         = { fg = "rose", modifiers = ["bold"] }
+horizontal_rule   = { fg = "comment" }
+table_border      = { fg = "comment" }
+tool_bg           = { bg = "background_2" }
+tool              = { fg = "foreground" }
+tool_prefix       = { fg = "foreground", modifiers = ["bold"] }
+tool_path         = { fg = "foam" }
+tool_annotation   = { fg = "comment" }
+tool_success      = { fg = "foam" }
+tool_error        = { fg = "love" }
+tool_dim          = { fg = "comment" }
+diff_old          = { bg = "#472a3c" }
+diff_new          = { bg = "#363f4c" }
+diff_old_emphasis = { bg = "#713c52" }
+diff_new_emphasis = { bg = "#506470" }
+diff_line_nr      = { fg = "comment" }
+item_selected     = { fg = "background", bg = "iris" }
+item              = { fg = "rose" }
+item_desc         = { fg = "comment" }
+accent            = { fg = "gold" }
+panel_border      = { fg = "iris" }
+panel_title       = { fg = "iris", modifiers = ["bold"] }
+cursor            = { fg = "background", bg = "foreground" }
+input_border      = { fg = "highlight_high" }
+keybind_key       = { fg = "foam", modifiers = ["bold"] }
+keybind_section   = { fg = "iris", modifiers = ["bold"] }
+status_dim        = { fg = "comment" }
+error             = { fg = "love" }
+todo_completed    = { fg = "foam" }
+todo_in_progress  = { fg = "gold" }
+todo_pending      = { fg = "comment" }
+todo_cancelled    = { fg = "love", modifiers = ["crossed_out"] }
+keybind_desc      = { fg = "foreground" }
+queue             = { fg = "iris" }
+plan_path         = { fg = "gold", modifiers = ["bold"] }
+status_notice     = { fg = "gold" }
+status_retry_error= { fg = "love" }
+status_retry_info = { fg = "comment" }
+input_placeholder = { fg = "comment" }
+queue_delete      = { fg = "love", modifiers = ["bold"] }
+timestamp         = { fg = "comment" }
+spinner           = { fg = "gold" }
+active            = { fg = "foam" }

--- a/maki-ui/src/themes/rose_pine_dawn.toml
+++ b/maki-ui/src/themes/rose_pine_dawn.toml
@@ -42,7 +42,7 @@
 "keyword.return"                  = { fg = "pine" }
 "keyword.storage"                 = { fg = "pine" }
 "keyword.storage.modifier"        = { fg = "pine" }
-"keyword.storage.type"           = { fg = "pine", modifiers = ["italic"] }
+"keyword.storage.type"            = { fg = "pine", modifiers = ["italic"] }
 
 "label"                           = { fg = "cyan" }
 "attribute"                       = { fg = "purple", modifiers = ["italic"] }
@@ -86,84 +86,76 @@
 "variable.parameter"              = { fg = "orange", modifiers = ["italic"] }
 
 [palette]
-background       = "#faf4ed"
-background_2     = "#fffaf3"
-foreground       = "#464261"
-comment          = "#9893a5"
-comment_lighter  = "#797593"
-cyan             = "#56949f"
-green            = "#56949f"
-orange           = "#ea9d34"
-pink             = "#b4637a"
-purple           = "#907aa9"
-red              = "#b4637a"
-yellow           = "#ea9d34"
-current_line     = "#f2e9e1"
-selection        = "#f2e9e1"
-gold             = "#ea9d34"
-rose             = "#d7827e"
-pine             = "#286983"
-foam             = "#56949f"
-iris             = "#907aa9"
-love             = "#b4637a"
-mode_plan        = "#d7827e"
+background        = "#faf4ed"
+background_2      = "#fffaf3"
+foreground        = "#464261"
+comment           = "#9893a5"
+comment_lighter   = "#797593"
+current_line      = "#f4ede8"
+selection         = "#dfdad9"
+highlight_high    = "#cecacd"
+gold              = "#ea9d34"
+rose              = "#d7827e"
+pine              = "#286983"
+foam              = "#56949f"
+iris              = "#907aa9"
+love              = "#b4637a"
+cyan              = "#56949f"
+green             = "#56949f"
+orange            = "#ea9d34"
+pink              = "#b4637a"
+purple            = "#907aa9"
+red               = "#b4637a"
+yellow            = "#ea9d34"
+mode_plan         = "#d7827e"
 
 [ui]
-user               = { fg = "rose" }
-assistant_prefix   = { fg = "iris" }
-assistant          = { fg = "foreground" }
-thinking           = { fg = "comment", modifiers = ["italic"] }
-
-strikethrough      = { fg = "comment", modifiers = ["crossed_out"] }
-code_block         = { fg = "foreground" }
-
-plan_rule          = { fg = "rose", modifiers = ["bold"] }
-horizontal_rule    = { fg = "comment" }
-table_border       = { fg = "comment" }
-
-tool_bg            = { bg = "#fffaf3" }
-tool               = { fg = "foreground" }
-tool_prefix        = { fg = "foreground", modifiers = ["bold"] }
-tool_path          = { fg = "foam" }
-tool_annotation    = { fg = "comment" }
-tool_success       = { fg = "foam" }
-tool_error         = { fg = "love" }
-tool_dim           = { fg = "comment" }
-
-diff_old           = { bg = "#f0dadb" }
-diff_new           = { bg = "#dde9e9" }
-diff_old_emphasis  = { bg = "#e8c4c6" }
-diff_new_emphasis  = { bg = "#c6dcdc" }
-diff_line_nr       = { fg = "comment" }
-
-item_selected      = { fg = "background", bg = "iris" }
-item               = { fg = "rose" }
-item_desc          = { fg = "comment" }
-accent             = { fg = "gold" }
-
-panel_border       = { fg = "iris" }
-panel_title        = { fg = "iris", modifiers = ["bold"] }
-cursor             = { fg = "background", bg = "foreground" }
-input_border       = { fg = "#c5c2d4" }
-
-keybind_key        = { fg = "foam", modifiers = ["bold"] }
-keybind_section    = { fg = "iris", modifiers = ["bold"] }
-
-status_dim         = { fg = "comment" }
-error              = { fg = "love" }
-
-todo_completed     = { fg = "foam" }
-todo_in_progress   = { fg = "gold" }
-todo_pending       = { fg = "comment" }
-todo_cancelled     = { fg = "love", modifiers = ["crossed_out"] }
-keybind_desc       = { fg = "foreground" }
-queue              = { fg = "iris" }
-plan_path          = { fg = "gold", modifiers = ["bold"] }
-status_notice      = { fg = "gold" }
-status_retry_error = { fg = "love" }
-status_retry_info  = { fg = "comment" }
-input_placeholder  = { fg = "comment" }
-queue_delete       = { fg = "love", modifiers = ["bold"] }
-timestamp          = { fg = "comment" }
-spinner            = { fg = "gold" }
-active             = { fg = "foam" }
+user              = { fg = "rose" }
+assistant_prefix  = { fg = "iris" }
+assistant         = { fg = "foreground" }
+thinking          = { fg = "comment", modifiers = ["italic"] }
+strikethrough     = { fg = "comment", modifiers = ["crossed_out"] }
+code_block        = { fg = "foreground" }
+plan_rule         = { fg = "rose", modifiers = ["bold"] }
+horizontal_rule   = { fg = "comment" }
+table_border      = { fg = "comment" }
+tool_bg           = { bg = "background_2" }
+tool              = { fg = "foreground" }
+tool_prefix       = { fg = "foreground", modifiers = ["bold"] }
+tool_path         = { fg = "foam" }
+tool_annotation   = { fg = "comment" }
+tool_success      = { fg = "foam" }
+tool_error        = { fg = "love" }
+tool_dim          = { fg = "comment" }
+diff_old          = { bg = "#ebd4d4" }
+diff_new          = { bg = "#d6dfdc" }
+diff_old_emphasis = { bg = "#ddb7bd" }
+diff_new_emphasis = { bg = "#b5cccc" }
+diff_line_nr      = { fg = "comment" }
+item_selected     = { fg = "background", bg = "iris" }
+item              = { fg = "rose" }
+item_desc         = { fg = "comment" }
+accent            = { fg = "gold" }
+panel_border      = { fg = "iris" }
+panel_title       = { fg = "iris", modifiers = ["bold"] }
+cursor            = { fg = "background", bg = "foreground" }
+input_border      = { fg = "highlight_high" }
+keybind_key       = { fg = "foam", modifiers = ["bold"] }
+keybind_section   = { fg = "iris", modifiers = ["bold"] }
+status_dim        = { fg = "comment" }
+error             = { fg = "love" }
+todo_completed    = { fg = "foam" }
+todo_in_progress  = { fg = "gold" }
+todo_pending      = { fg = "comment" }
+todo_cancelled    = { fg = "love", modifiers = ["crossed_out"] }
+keybind_desc      = { fg = "foreground" }
+queue             = { fg = "iris" }
+plan_path         = { fg = "gold", modifiers = ["bold"] }
+status_notice     = { fg = "gold" }
+status_retry_error= { fg = "love" }
+status_retry_info = { fg = "comment" }
+input_placeholder = { fg = "comment" }
+queue_delete      = { fg = "love", modifiers = ["bold"] }
+timestamp         = { fg = "comment" }
+spinner           = { fg = "gold" }
+active            = { fg = "foam" }

--- a/maki-ui/src/themes/rose_pine_dawn.toml
+++ b/maki-ui/src/themes/rose_pine_dawn.toml
@@ -1,0 +1,169 @@
+# Rosé Pine Dawn theme for Maki
+# https://rosepinetheme.com/palette/
+
+"comment"                         = { fg = "comment" }
+"comment.block"                   = { fg = "comment" }
+"comment.block.documentation"     = { fg = "comment" }
+"comment.line"                    = { fg = "comment" }
+"comment.line.documentation"      = { fg = "comment" }
+
+"constant"                        = { fg = "purple" }
+"constant.builtin"                = { fg = "purple" }
+"constant.builtin.boolean"        = { fg = "purple" }
+"constant.character"              = { fg = "cyan" }
+"constant.character.escape"       = { fg = "pink" }
+"constant.macro"                  = { fg = "purple" }
+"constant.numeric"                = { fg = "purple" }
+"constructor"                     = { fg = "purple" }
+
+"error"                           = { fg = "red" }
+"warning"                         = { fg = "yellow" }
+"info"                            = { fg = "cyan" }
+"hint"                            = { fg = "purple" }
+
+"diff.delta"                      = { fg = "orange" }
+"diff.minus"                      = { fg = "red" }
+"diff.plus"                       = { fg = "green" }
+
+"function"                        = { fg = "rose" }
+"function.builtin"                = { fg = "rose" }
+"function.call"                   = { fg = "rose" }
+"function.macro"                  = { fg = "purple" }
+"function.method"                 = { fg = "rose" }
+
+"keyword"                         = { fg = "pine" }
+"keyword.control.conditional"     = { fg = "pine" }
+"keyword.control.exception"       = { fg = "purple" }
+"keyword.control.import"          = { fg = "pine" }
+"keyword.control.repeat"          = { fg = "pine" }
+"keyword.directive"               = { fg = "green" }
+"keyword.function"                = { fg = "pine" }
+"keyword.operator"                = { fg = "pine" }
+"keyword.return"                  = { fg = "pine" }
+"keyword.storage"                 = { fg = "pine" }
+"keyword.storage.modifier"        = { fg = "pine" }
+"keyword.storage.type"           = { fg = "pine", modifiers = ["italic"] }
+
+"label"                           = { fg = "cyan" }
+"attribute"                       = { fg = "purple", modifiers = ["italic"] }
+"namespace"                       = { fg = "foreground" }
+"annotation"                      = { fg = "foreground" }
+
+"markup.bold"                     = { fg = "orange", modifiers = ["bold"] }
+"markup.heading"                  = { fg = "purple", modifiers = ["bold"] }
+"markup.italic"                   = { fg = "yellow", modifiers = ["italic"] }
+"markup.link.text"                = { fg = "pink" }
+"markup.link.url"                 = { fg = "cyan" }
+"markup.list"                     = { fg = "cyan" }
+"markup.quote"                    = { fg = "yellow", modifiers = ["italic"] }
+"markup.raw"                      = { fg = "foreground" }
+"markup.strikethrough"            = { modifiers = ["crossed_out"] }
+
+"punctuation"                     = { fg = "foreground" }
+"punctuation.bracket"             = { fg = "foreground" }
+"punctuation.delimiter"           = { fg = "foreground" }
+"punctuation.special"             = { fg = "pink" }
+
+"special"                         = { fg = "pink" }
+
+"string"                          = { fg = "yellow" }
+"string.regexp"                   = { fg = "red" }
+"string.special"                  = { fg = "orange" }
+"string.symbol"                   = { fg = "yellow" }
+
+"tag"                             = { fg = "pink" }
+"tag.attribute"                   = { fg = "purple" }
+"tag.delimiter"                   = { fg = "foreground" }
+
+"type"                            = { fg = "cyan", modifiers = ["italic"] }
+"type.builtin"                    = { fg = "cyan" }
+"type.enum.variant"               = { fg = "foreground", modifiers = ["italic"] }
+
+"variable"                        = { fg = "foreground" }
+"variable.builtin"                = { fg = "purple", modifiers = ["italic"] }
+"variable.other"                  = { fg = "foreground" }
+"variable.other.member"           = { fg = "foreground" }
+"variable.parameter"              = { fg = "orange", modifiers = ["italic"] }
+
+[palette]
+background       = "#faf4ed"
+background_2     = "#fffaf3"
+foreground       = "#464261"
+comment          = "#9893a5"
+comment_lighter  = "#797593"
+cyan             = "#56949f"
+green            = "#56949f"
+orange           = "#ea9d34"
+pink             = "#b4637a"
+purple           = "#907aa9"
+red              = "#b4637a"
+yellow           = "#ea9d34"
+current_line     = "#f2e9e1"
+selection        = "#f2e9e1"
+gold             = "#ea9d34"
+rose             = "#d7827e"
+pine             = "#286983"
+foam             = "#56949f"
+iris             = "#907aa9"
+love             = "#b4637a"
+mode_plan        = "#d7827e"
+
+[ui]
+user               = { fg = "rose" }
+assistant_prefix   = { fg = "iris" }
+assistant          = { fg = "foreground" }
+thinking           = { fg = "comment", modifiers = ["italic"] }
+
+strikethrough      = { fg = "comment", modifiers = ["crossed_out"] }
+code_block         = { fg = "foreground" }
+
+plan_rule          = { fg = "rose", modifiers = ["bold"] }
+horizontal_rule    = { fg = "comment" }
+table_border       = { fg = "comment" }
+
+tool_bg            = { bg = "#fffaf3" }
+tool               = { fg = "foreground" }
+tool_prefix        = { fg = "foreground", modifiers = ["bold"] }
+tool_path          = { fg = "foam" }
+tool_annotation    = { fg = "comment" }
+tool_success       = { fg = "foam" }
+tool_error         = { fg = "love" }
+tool_dim           = { fg = "comment" }
+
+diff_old           = { bg = "#f0dadb" }
+diff_new           = { bg = "#dde9e9" }
+diff_old_emphasis  = { bg = "#e8c4c6" }
+diff_new_emphasis  = { bg = "#c6dcdc" }
+diff_line_nr       = { fg = "comment" }
+
+item_selected      = { fg = "background", bg = "iris" }
+item               = { fg = "rose" }
+item_desc          = { fg = "comment" }
+accent             = { fg = "gold" }
+
+panel_border       = { fg = "iris" }
+panel_title        = { fg = "iris", modifiers = ["bold"] }
+cursor             = { fg = "background", bg = "foreground" }
+input_border       = { fg = "#c5c2d4" }
+
+keybind_key        = { fg = "foam", modifiers = ["bold"] }
+keybind_section    = { fg = "iris", modifiers = ["bold"] }
+
+status_dim         = { fg = "comment" }
+error              = { fg = "love" }
+
+todo_completed     = { fg = "foam" }
+todo_in_progress   = { fg = "gold" }
+todo_pending       = { fg = "comment" }
+todo_cancelled     = { fg = "love", modifiers = ["crossed_out"] }
+keybind_desc       = { fg = "foreground" }
+queue              = { fg = "iris" }
+plan_path          = { fg = "gold", modifiers = ["bold"] }
+status_notice      = { fg = "gold" }
+status_retry_error = { fg = "love" }
+status_retry_info  = { fg = "comment" }
+input_placeholder  = { fg = "comment" }
+queue_delete       = { fg = "love", modifiers = ["bold"] }
+timestamp          = { fg = "comment" }
+spinner            = { fg = "gold" }
+active             = { fg = "foam" }

--- a/maki-ui/src/themes/rose_pine_moon.toml
+++ b/maki-ui/src/themes/rose_pine_moon.toml
@@ -1,0 +1,169 @@
+# Rosé Pine Moon theme for Maki
+# https://rosepinetheme.com/palette/
+
+"comment"                         = { fg = "comment" }
+"comment.block"                   = { fg = "comment" }
+"comment.block.documentation"     = { fg = "comment" }
+"comment.line"                    = { fg = "comment" }
+"comment.line.documentation"      = { fg = "comment" }
+
+"constant"                        = { fg = "purple" }
+"constant.builtin"                = { fg = "purple" }
+"constant.builtin.boolean"        = { fg = "purple" }
+"constant.character"              = { fg = "cyan" }
+"constant.character.escape"       = { fg = "pink" }
+"constant.macro"                  = { fg = "purple" }
+"constant.numeric"                = { fg = "purple" }
+"constructor"                     = { fg = "purple" }
+
+"error"                           = { fg = "red" }
+"warning"                         = { fg = "yellow" }
+"info"                            = { fg = "cyan" }
+"hint"                            = { fg = "purple" }
+
+"diff.delta"                      = { fg = "orange" }
+"diff.minus"                      = { fg = "red" }
+"diff.plus"                       = { fg = "green" }
+
+"function"                        = { fg = "rose" }
+"function.builtin"                = { fg = "rose" }
+"function.call"                   = { fg = "rose" }
+"function.macro"                  = { fg = "purple" }
+"function.method"                 = { fg = "rose" }
+
+"keyword"                         = { fg = "pine" }
+"keyword.control.conditional"     = { fg = "pine" }
+"keyword.control.exception"       = { fg = "purple" }
+"keyword.control.import"          = { fg = "pine" }
+"keyword.control.repeat"          = { fg = "pine" }
+"keyword.directive"               = { fg = "green" }
+"keyword.function"                = { fg = "pine" }
+"keyword.operator"                = { fg = "pine" }
+"keyword.return"                  = { fg = "pine" }
+"keyword.storage"                 = { fg = "pine" }
+"keyword.storage.modifier"        = { fg = "pine" }
+"keyword.storage.type"           = { fg = "pine", modifiers = ["italic"] }
+
+"label"                           = { fg = "cyan" }
+"attribute"                       = { fg = "purple", modifiers = ["italic"] }
+"namespace"                       = { fg = "foreground" }
+"annotation"                      = { fg = "foreground" }
+
+"markup.bold"                     = { fg = "orange", modifiers = ["bold"] }
+"markup.heading"                  = { fg = "purple", modifiers = ["bold"] }
+"markup.italic"                   = { fg = "yellow", modifiers = ["italic"] }
+"markup.link.text"                = { fg = "pink" }
+"markup.link.url"                 = { fg = "cyan" }
+"markup.list"                     = { fg = "cyan" }
+"markup.quote"                    = { fg = "yellow", modifiers = ["italic"] }
+"markup.raw"                      = { fg = "foreground" }
+"markup.strikethrough"            = { modifiers = ["crossed_out"] }
+
+"punctuation"                     = { fg = "foreground" }
+"punctuation.bracket"             = { fg = "foreground" }
+"punctuation.delimiter"           = { fg = "foreground" }
+"punctuation.special"             = { fg = "pink" }
+
+"special"                         = { fg = "pink" }
+
+"string"                          = { fg = "yellow" }
+"string.regexp"                   = { fg = "red" }
+"string.special"                  = { fg = "orange" }
+"string.symbol"                   = { fg = "yellow" }
+
+"tag"                             = { fg = "pink" }
+"tag.attribute"                   = { fg = "purple" }
+"tag.delimiter"                   = { fg = "foreground" }
+
+"type"                            = { fg = "cyan", modifiers = ["italic"] }
+"type.builtin"                    = { fg = "cyan" }
+"type.enum.variant"               = { fg = "foreground", modifiers = ["italic"] }
+
+"variable"                        = { fg = "foreground" }
+"variable.builtin"                = { fg = "purple", modifiers = ["italic"] }
+"variable.other"                  = { fg = "foreground" }
+"variable.other.member"           = { fg = "foreground" }
+"variable.parameter"              = { fg = "orange", modifiers = ["italic"] }
+
+[palette]
+background       = "#232136"
+background_2     = "#2a273f"
+foreground       = "#e0def4"
+comment          = "#6e6a86"
+comment_lighter  = "#908caa"
+cyan             = "#9ccfd8"
+green            = "#9ccfd8"
+orange           = "#f6c177"
+pink             = "#eb6f92"
+purple           = "#c4a7e7"
+red              = "#eb6f92"
+yellow           = "#f6c177"
+current_line     = "#393552"
+selection        = "#2a273f"
+gold             = "#f6c177"
+rose             = "#ea9a97"
+pine             = "#3e8fb0"
+foam             = "#9ccfd8"
+iris             = "#c4a7e7"
+love             = "#eb6f92"
+mode_plan        = "#ea9a97"
+
+[ui]
+user               = { fg = "rose" }
+assistant_prefix   = { fg = "iris" }
+assistant          = { fg = "foreground" }
+thinking           = { fg = "comment", modifiers = ["italic"] }
+
+strikethrough      = { fg = "comment", modifiers = ["crossed_out"] }
+code_block         = { fg = "foreground" }
+
+plan_rule          = { fg = "rose", modifiers = ["bold"] }
+horizontal_rule    = { fg = "comment" }
+table_border       = { fg = "comment" }
+
+tool_bg            = { bg = "#2a273f" }
+tool               = { fg = "foreground" }
+tool_prefix        = { fg = "foreground", modifiers = ["bold"] }
+tool_path          = { fg = "foam" }
+tool_annotation    = { fg = "comment" }
+tool_success       = { fg = "foam" }
+tool_error         = { fg = "love" }
+tool_dim           = { fg = "comment" }
+
+diff_old           = { bg = "#3b2030" }
+diff_new           = { bg = "#1c2c30" }
+diff_old_emphasis  = { bg = "#522c40" }
+diff_new_emphasis  = { bg = "#243a40" }
+diff_line_nr       = { fg = "comment" }
+
+item_selected      = { fg = "background", bg = "iris" }
+item               = { fg = "rose" }
+item_desc          = { fg = "comment" }
+accent             = { fg = "gold" }
+
+panel_border       = { fg = "iris" }
+panel_title        = { fg = "iris", modifiers = ["bold"] }
+cursor             = { fg = "background", bg = "foreground" }
+input_border       = { fg = "#45425e" }
+
+keybind_key        = { fg = "foam", modifiers = ["bold"] }
+keybind_section    = { fg = "iris", modifiers = ["bold"] }
+
+status_dim         = { fg = "comment" }
+error              = { fg = "love" }
+
+todo_completed     = { fg = "foam" }
+todo_in_progress   = { fg = "gold" }
+todo_pending       = { fg = "comment" }
+todo_cancelled     = { fg = "love", modifiers = ["crossed_out"] }
+keybind_desc       = { fg = "foreground" }
+queue              = { fg = "iris" }
+plan_path          = { fg = "gold", modifiers = ["bold"] }
+status_notice      = { fg = "gold" }
+status_retry_error = { fg = "love" }
+status_retry_info  = { fg = "comment" }
+input_placeholder  = { fg = "comment" }
+queue_delete       = { fg = "love", modifiers = ["bold"] }
+timestamp          = { fg = "comment" }
+spinner            = { fg = "gold" }
+active             = { fg = "foam" }

--- a/maki-ui/src/themes/rose_pine_moon.toml
+++ b/maki-ui/src/themes/rose_pine_moon.toml
@@ -42,7 +42,7 @@
 "keyword.return"                  = { fg = "pine" }
 "keyword.storage"                 = { fg = "pine" }
 "keyword.storage.modifier"        = { fg = "pine" }
-"keyword.storage.type"           = { fg = "pine", modifiers = ["italic"] }
+"keyword.storage.type"            = { fg = "pine", modifiers = ["italic"] }
 
 "label"                           = { fg = "cyan" }
 "attribute"                       = { fg = "purple", modifiers = ["italic"] }
@@ -86,84 +86,76 @@
 "variable.parameter"              = { fg = "orange", modifiers = ["italic"] }
 
 [palette]
-background       = "#232136"
-background_2     = "#2a273f"
-foreground       = "#e0def4"
-comment          = "#6e6a86"
-comment_lighter  = "#908caa"
-cyan             = "#9ccfd8"
-green            = "#9ccfd8"
-orange           = "#f6c177"
-pink             = "#eb6f92"
-purple           = "#c4a7e7"
-red              = "#eb6f92"
-yellow           = "#f6c177"
-current_line     = "#393552"
-selection        = "#2a273f"
-gold             = "#f6c177"
-rose             = "#ea9a97"
-pine             = "#3e8fb0"
-foam             = "#9ccfd8"
-iris             = "#c4a7e7"
-love             = "#eb6f92"
-mode_plan        = "#ea9a97"
+background        = "#232136"
+background_2      = "#2a273f"
+foreground        = "#e0def4"
+comment           = "#6e6a86"
+comment_lighter   = "#908caa"
+current_line      = "#2a283e"
+selection         = "#44415a"
+highlight_high    = "#56526e"
+gold              = "#f6c177"
+rose              = "#ea9a97"
+pine              = "#3e8fb0"
+foam              = "#9ccfd8"
+iris              = "#c4a7e7"
+love              = "#eb6f92"
+cyan              = "#9ccfd8"
+green             = "#9ccfd8"
+orange            = "#f6c177"
+pink              = "#eb6f92"
+purple            = "#c4a7e7"
+red               = "#eb6f92"
+yellow            = "#f6c177"
+mode_plan         = "#ea9a97"
 
 [ui]
-user               = { fg = "rose" }
-assistant_prefix   = { fg = "iris" }
-assistant          = { fg = "foreground" }
-thinking           = { fg = "comment", modifiers = ["italic"] }
-
-strikethrough      = { fg = "comment", modifiers = ["crossed_out"] }
-code_block         = { fg = "foreground" }
-
-plan_rule          = { fg = "rose", modifiers = ["bold"] }
-horizontal_rule    = { fg = "comment" }
-table_border       = { fg = "comment" }
-
-tool_bg            = { bg = "#2a273f" }
-tool               = { fg = "foreground" }
-tool_prefix        = { fg = "foreground", modifiers = ["bold"] }
-tool_path          = { fg = "foam" }
-tool_annotation    = { fg = "comment" }
-tool_success       = { fg = "foam" }
-tool_error         = { fg = "love" }
-tool_dim           = { fg = "comment" }
-
-diff_old           = { bg = "#3b2030" }
-diff_new           = { bg = "#1c2c30" }
-diff_old_emphasis  = { bg = "#522c40" }
-diff_new_emphasis  = { bg = "#243a40" }
-diff_line_nr       = { fg = "comment" }
-
-item_selected      = { fg = "background", bg = "iris" }
-item               = { fg = "rose" }
-item_desc          = { fg = "comment" }
-accent             = { fg = "gold" }
-
-panel_border       = { fg = "iris" }
-panel_title        = { fg = "iris", modifiers = ["bold"] }
-cursor             = { fg = "background", bg = "foreground" }
-input_border       = { fg = "#45425e" }
-
-keybind_key        = { fg = "foam", modifiers = ["bold"] }
-keybind_section    = { fg = "iris", modifiers = ["bold"] }
-
-status_dim         = { fg = "comment" }
-error              = { fg = "love" }
-
-todo_completed     = { fg = "foam" }
-todo_in_progress   = { fg = "gold" }
-todo_pending       = { fg = "comment" }
-todo_cancelled     = { fg = "love", modifiers = ["crossed_out"] }
-keybind_desc       = { fg = "foreground" }
-queue              = { fg = "iris" }
-plan_path          = { fg = "gold", modifiers = ["bold"] }
-status_notice      = { fg = "gold" }
-status_retry_error = { fg = "love" }
-status_retry_info  = { fg = "comment" }
-input_placeholder  = { fg = "comment" }
-queue_delete       = { fg = "love", modifiers = ["bold"] }
-timestamp          = { fg = "comment" }
-spinner            = { fg = "gold" }
-active             = { fg = "foam" }
+user              = { fg = "rose" }
+assistant_prefix  = { fg = "iris" }
+assistant         = { fg = "foreground" }
+thinking          = { fg = "comment", modifiers = ["italic"] }
+strikethrough     = { fg = "comment", modifiers = ["crossed_out"] }
+code_block        = { fg = "foreground" }
+plan_rule         = { fg = "rose", modifiers = ["bold"] }
+horizontal_rule   = { fg = "comment" }
+table_border      = { fg = "comment" }
+tool_bg           = { bg = "background_2" }
+tool              = { fg = "foreground" }
+tool_prefix       = { fg = "foreground", modifiers = ["bold"] }
+tool_path         = { fg = "foam" }
+tool_annotation   = { fg = "comment" }
+tool_success      = { fg = "foam" }
+tool_error        = { fg = "love" }
+tool_dim          = { fg = "comment" }
+diff_old          = { bg = "#4f324a" }
+diff_new          = { bg = "#3e475a" }
+diff_old_emphasis = { bg = "#77425d" }
+diff_new_emphasis = { bg = "#566a7a" }
+diff_line_nr      = { fg = "comment" }
+item_selected     = { fg = "background", bg = "iris" }
+item              = { fg = "rose" }
+item_desc         = { fg = "comment" }
+accent            = { fg = "gold" }
+panel_border      = { fg = "iris" }
+panel_title       = { fg = "iris", modifiers = ["bold"] }
+cursor            = { fg = "background", bg = "foreground" }
+input_border      = { fg = "highlight_high" }
+keybind_key       = { fg = "foam", modifiers = ["bold"] }
+keybind_section   = { fg = "iris", modifiers = ["bold"] }
+status_dim        = { fg = "comment" }
+error             = { fg = "love" }
+todo_completed    = { fg = "foam" }
+todo_in_progress  = { fg = "gold" }
+todo_pending      = { fg = "comment" }
+todo_cancelled    = { fg = "love", modifiers = ["crossed_out"] }
+keybind_desc      = { fg = "foreground" }
+queue             = { fg = "iris" }
+plan_path         = { fg = "gold", modifiers = ["bold"] }
+status_notice     = { fg = "gold" }
+status_retry_error= { fg = "love" }
+status_retry_info = { fg = "comment" }
+input_placeholder = { fg = "comment" }
+queue_delete      = { fg = "love", modifiers = ["bold"] }
+timestamp         = { fg = "comment" }
+spinner           = { fg = "gold" }
+active            = { fg = "foam" }


### PR DESCRIPTION
I love Rosé Pine, it's my favorite theme set. I just pointed maki at https://rosepinetheme.com/palette/ and had it get all 3 themes using the official palette colors, including some clean-up of the base `rose_pine` palette to match the canonical colors. Did it with monty `code_execution`, so they should be exactly the same format.

Rose Piné has no diff-background role, so those are derived per variant by blending `love`/`foam` toward each variant's `base`.