### PR TITLE
providers: require explicit login for Copilot provider

### DIFF
--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -161,7 +161,7 @@ fn build_sections() -> Vec<ProviderSection> {
                     kind,
                     name: kind.display_name(),
                     auth_line: format!(
-                        "{} or `~/.config/github-copilot/{{hosts.json,apps.json}}`",
+                        "{} (or run `maki auth login copilot` to import a token from gh)",
                         format_auth(kind)
                     ),
                     urls: vec![kind.base_url()],

--- a/maki-providers/src/providers/copilot/auth.rs
+++ b/maki-providers/src/providers/copilot/auth.rs
@@ -2,13 +2,20 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
+use maki_storage::StateDir;
+use maki_storage::auth::{
+    ProviderCredentials, delete_provider_credentials, load_provider_credentials,
+    save_provider_credentials,
+};
 use serde_json::Value as JsonValue;
 use serde_yaml::Value as YamlValue;
+use tracing::debug;
 
 use crate::AgentError;
 
 const TOKEN_ENV_VARS: &[&str] = &["GH_COPILOT_TOKEN", "COPILOT_GITHUB_TOKEN"];
 const COPILOT_DOMAIN: &str = "github.com";
+const PROVIDER: &str = "copilot";
 
 pub(crate) fn load_token() -> Result<String, AgentError> {
     for key in TOKEN_ENV_VARS {
@@ -19,12 +26,19 @@ pub(crate) fn load_token() -> Result<String, AgentError> {
         }
     }
 
-    if let Ok(dir) = maki_storage::StateDir::resolve()
-        && let Some(creds) = maki_storage::auth::load_provider_credentials(&dir, "copilot")
+    if let Ok(dir) = StateDir::resolve()
+        && let Some(creds) = load_provider_credentials(&dir, PROVIDER)
     {
+        debug!("using saved Copilot credentials");
         return Ok(creds.api_key);
     }
 
+    Err(AgentError::Config {
+        message: "not authenticated, run `maki auth login copilot` or set GH_COPILOT_TOKEN".into(),
+    })
+}
+
+fn discover_token() -> Result<String, AgentError> {
     for path in copilot_config_paths() {
         if let Ok(contents) = fs::read_to_string(path)
             && let Some(token) = extract_json_oauth_token(&contents, COPILOT_DOMAIN)
@@ -42,25 +56,37 @@ pub(crate) fn load_token() -> Result<String, AgentError> {
     }
 
     Err(AgentError::Config {
-        message: "Copilot token not found. Run `gh auth login --web`, sign in with GitHub Copilot, or set GH_COPILOT_TOKEN.".into(),
+        message: "Copilot token not found. Run `gh auth login --web`, sign in with the Copilot \
+            client, or set GH_COPILOT_TOKEN."
+            .into(),
     })
 }
 
-pub fn login() -> Result<(), AgentError> {
-    let _ = load_token()?;
-    println!("Copilot token found.");
+pub fn login(dir: &StateDir) -> Result<(), AgentError> {
+    if load_token().is_ok() {
+        println!("Already authenticated with Copilot.");
+        return Ok(());
+    }
+
+    let token = discover_token()?;
+    save_provider_credentials(dir, PROVIDER, &ProviderCredentials { api_key: token })?;
+    println!("Copilot token imported from gh CLI / Copilot client config.");
     Ok(())
 }
 
-pub fn logout() -> Result<(), AgentError> {
-    Err(AgentError::Config {
-        message: "Copilot auth is managed by GitHub Copilot. Sign out from your Copilot client or remove GH_COPILOT_TOKEN.".into(),
-    })
+pub fn logout(dir: &StateDir) -> Result<(), AgentError> {
+    if delete_provider_credentials(dir, PROVIDER)? {
+        println!("Logged out of Copilot.");
+    } else {
+        println!("Not currently logged in to Copilot.");
+    }
+    Ok(())
 }
 
 fn copilot_config_paths() -> Vec<PathBuf> {
-    let base = config_dir().map(|config| config.join("github-copilot"));
-    base.map(|base| vec![base.join("hosts.json"), base.join("apps.json")])
+    config_dir()
+        .map(|config| config.join("github-copilot"))
+        .map(|base| vec![base.join("hosts.json"), base.join("apps.json")])
         .unwrap_or_default()
 }
 
@@ -101,49 +127,25 @@ fn extract_yaml_oauth_token(contents: &str, domain: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_case::test_case;
 
-    #[test]
-    fn extracts_matching_oauth_token() {
-        let contents = r#"{
-            "github.com": {
-                "oauth_token": "token-1"
-            }
-        }"#;
-        assert_eq!(
-            extract_json_oauth_token(contents, "github.com").as_deref(),
-            Some("token-1")
-        );
+    #[test_case(
+        r#"{"github.com": {"oauth_token": "token-1"}}"#, "github.com" => Some("token-1".to_string()); "json_matching_domain"
+    )]
+    #[test_case(
+        r#"{"enterprise.example.com": {"oauth_token": "token-1"}}"#, "github.com" => None; "json_other_domain"
+    )]
+    fn extract_json_oauth_token_by_domain(contents: &str, domain: &str) -> Option<String> {
+        extract_json_oauth_token(contents, domain)
     }
 
-    #[test]
-    fn ignores_other_domains() {
-        let contents = r#"{
-            "enterprise.example.com": {
-                "oauth_token": "token-1"
-            }
-        }"#;
-        assert_eq!(extract_json_oauth_token(contents, "github.com"), None);
-    }
-
-    #[test]
-    fn extracts_matching_gh_oauth_token() {
-        let contents = r#"
-github.com:
-  oauth_token: token-1
-  user: octocat
-"#;
-        assert_eq!(
-            extract_yaml_oauth_token(contents, "github.com").as_deref(),
-            Some("token-1")
-        );
-    }
-
-    #[test]
-    fn ignores_other_gh_domains() {
-        let contents = r#"
-enterprise.example.com:
-  oauth_token: token-1
-"#;
-        assert_eq!(extract_yaml_oauth_token(contents, "github.com"), None);
+    #[test_case(
+        "github.com:\n  oauth_token: token-1\n  user: octocat\n", "github.com" => Some("token-1".to_string()); "yaml_matching_domain"
+    )]
+    #[test_case(
+        "enterprise.example.com:\n  oauth_token: token-1\n", "github.com" => None; "yaml_other_domain"
+    )]
+    fn extract_yaml_oauth_token_by_domain(contents: &str, domain: &str) -> Option<String> {
+        extract_yaml_oauth_token(contents, domain)
     }
 }

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -79,7 +79,7 @@ Defaults: gemini-2.5-pro (strong), gemini-2.5-flash (medium), gemini-2.0-flash-l
 
 ### Copilot
 
-- **Env var**: `GH_COPILOT_TOKEN` or `~/.config/github-copilot/{hosts.json,apps.json}`
+- **Env var**: `GH_COPILOT_TOKEN` (or run `maki auth login copilot` to import a token from gh)
 - **API**: `https://api.githubcopilot.com (or GraphQL-discovered Copilot API endpoint)`
 - **Features**: Native Copilot Chat HTTP API with model endpoint discovery
 

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -26,7 +26,7 @@ use maki_storage::model::persist_model;
 pub fn auth_login(provider: Option<&str>, storage: &StateDir) -> Result<()> {
     match provider {
         Some("openai") => openai_auth::login(storage)?,
-        Some("copilot") => copilot_auth::login()?,
+        Some("copilot") => copilot_auth::login(storage)?,
         Some(slug) => login_provider(&slugify(slug), storage)?,
         None => login_interactive(storage)?,
     }
@@ -333,7 +333,7 @@ pub fn auth_logout(provider: &str, storage: &StateDir) -> Result<()> {
     let slug = slugify(provider);
     match provider {
         "openai" => openai_auth::logout(storage)?,
-        "copilot" => copilot_auth::logout()?,
+        "copilot" => copilot_auth::logout(storage)?,
         _ => {
             let mut config = ProvidersConfig::load();
             let deleted =


### PR DESCRIPTION
Since I'm logged in to the `gh` CLI but I don't have a Copilot seat for either my personal or work accounts, maki takes a few seconds to load with an empty terminal screen, and then opens with a 403 error in the status line saying "not licensed to use Copilot". This proposes a change to require explicit log in for Copilot like with other providers so that the "SUPER fast startup" selling point holds for everyone. Until this fix lands, there's _no config path to bypass this_. 

`load_token` now reads only `GH_COPILOT_TOKEN`/`COPILOT_GITHUB_TOKEN` or maki-stored credentials. Existing users who relied on the implicit token loading now need to run `maki auth login copilot` once. 

Authored with maki.