### PR TITLE
prompt: add @-mention file picker

### DIFF
--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -535,7 +535,12 @@ impl App {
                     vec![]
                 }
                 FilePickerModalAction::Close => {
+                    let was_at = self.file_picker.take_at_mention();
                     self.file_picker.close();
+                    if was_at {
+                        self.input_box.buffer.push_char('@');
+                        self.command_palette.sync(&self.input_box.buffer.value());
+                    }
                     vec![]
                 }
             });
@@ -755,6 +760,10 @@ impl App {
             InputAction::Submit(sub) => self.handle_submit(sub),
             InputAction::PaletteSync(val) => {
                 self.command_palette.sync(&val);
+                vec![]
+            }
+            InputAction::OpenFilePicker => {
+                self.file_picker.open_via_at(&self.state.session.cwd);
                 vec![]
             }
             InputAction::Passthrough(key) => {

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -827,6 +827,38 @@ fn overlay_blocks_ctrl_shortcuts(setup: fn(&mut App)) {
 }
 
 #[test]
+fn at_mention_opens_and_esc_leaves_literal() {
+    let mut app = test_app();
+    app.update(Msg::Key(key(KeyCode::Char('@'))));
+    assert!(app.file_picker.is_open());
+    assert_eq!(app.input_box.buffer.value(), "");
+
+    app.update(Msg::Key(key(KeyCode::Esc)));
+    assert!(!app.file_picker.is_open());
+    assert_eq!(app.input_box.buffer.value(), "@");
+}
+
+#[test]
+fn at_mention_does_not_trigger_mid_word() {
+    let mut app = test_app();
+    for c in "em".chars() {
+        app.update(Msg::Key(key(KeyCode::Char(c))));
+    }
+    app.update(Msg::Key(key(KeyCode::Char('@'))));
+    assert!(!app.file_picker.is_open());
+    assert_eq!(app.input_box.buffer.value(), "em@");
+}
+
+#[test]
+fn ctrl_s_file_picker_unaffected_by_at_mention_flag() {
+    let mut app = test_app();
+    app.update(Msg::Key(key(KeyCode::Char('x'))));
+    app.update(Msg::Key(kb::FILE_PICKER.to_key_event()));
+    assert!(app.file_picker.is_open());
+    assert_eq!(app.input_box.buffer.value(), "x");
+}
+
+#[test]
 fn compact_command_sets_streaming() {
     let mut app = test_app();
     let actions = app.execute_command(cmd("/compact"));

--- a/maki-ui/src/components/file_picker.rs
+++ b/maki-ui/src/components/file_picker.rs
@@ -78,15 +78,20 @@ impl Drop for Session {
 
 pub struct FilePickerModal {
     session: Option<Session>,
+    opened_via_at: bool,
 }
 
 impl FilePickerModal {
     pub fn new() -> Self {
-        Self { session: None }
+        Self {
+            session: None,
+            opened_via_at: false,
+        }
     }
 
     pub fn open(&mut self, cwd: &str) {
         self.close();
+        self.opened_via_at = false;
 
         let notify = Arc::new(|| {});
         let nucleo = Nucleo::new(Config::DEFAULT.match_paths(), notify, None, 1);
@@ -162,8 +167,18 @@ impl FilePickerModal {
         });
     }
 
+    pub fn open_via_at(&mut self, cwd: &str) {
+        self.open(cwd);
+        self.opened_via_at = true;
+    }
+
+    pub fn take_at_mention(&mut self) -> bool {
+        std::mem::replace(&mut self.opened_via_at, false)
+    }
+
     pub fn close(&mut self) {
         self.session = None;
+        self.opened_via_at = false;
     }
 
     pub fn is_open(&self) -> bool {

--- a/maki-ui/src/components/input.rs
+++ b/maki-ui/src/components/input.rs
@@ -47,6 +47,7 @@ pub enum InputAction {
     ContinueLine,
     PaletteSync(String),
     Passthrough(KeyEvent),
+    OpenFilePicker,
     None,
 }
 
@@ -93,6 +94,11 @@ impl InputBox {
                 return InputAction::None;
             }
             KeyCode::Tab | KeyCode::Esc => return InputAction::Passthrough(key),
+            KeyCode::Char('@')
+                if key.modifiers.is_empty() && self.char_before_cursor_is_whitespace_or_start() =>
+            {
+                return InputAction::OpenFilePicker;
+            }
             _ if is_newline_key(&key) => {
                 self.buffer.add_line();
                 return InputAction::ContinueLine;
@@ -209,14 +215,21 @@ impl InputBox {
         self.buffer.y() == self.buffer.line_count().saturating_sub(1)
     }
 
-    pub fn char_before_cursor_is_backslash(&self) -> bool {
-        let line = &self.buffer.lines()[self.buffer.y()];
+    fn byte_before_cursor(&self) -> Option<u8> {
         let x = self.buffer.x();
-        if x == 0 {
-            return false;
+        let line = &self.buffer.lines()[self.buffer.y()];
+        (x > 0).then(|| line.as_bytes()[TextBuffer::char_to_byte(line, x - 1)])
+    }
+
+    pub fn char_before_cursor_is_backslash(&self) -> bool {
+        self.byte_before_cursor() == Some(b'\\')
+    }
+
+    fn char_before_cursor_is_whitespace_or_start(&self) -> bool {
+        match self.byte_before_cursor() {
+            None => true,
+            Some(b) => b.is_ascii_whitespace(),
         }
-        let byte_idx = TextBuffer::char_to_byte(line, x - 1);
-        line.as_bytes()[byte_idx] == b'\\'
     }
 
     pub fn continue_line(&mut self) {
@@ -608,6 +621,7 @@ fn total_visual_lines(buffer: &TextBuffer, ew: usize, cursor_visible: bool) -> u
 mod tests {
     use super::*;
     use crate::components::scrollbar::SCROLLBAR_THUMB;
+    use crossterm::event::KeyModifiers;
     use test_case::test_case;
 
     fn type_text(input: &mut InputBox, text: &str) {
@@ -1041,5 +1055,63 @@ mod tests {
         type_text(&mut input, "read");
         input.handle_paste_with_spaces("file.rs");
         assert_eq!(input.buffer.value(), "read file.rs");
+    }
+
+    const TEST_AT: char = '@';
+
+    fn key_char(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn at_mention_opens_picker_at_line_start() {
+        let mut input = InputBox::new(InputHistory::default());
+        let action = input.handle_key(key_char(TEST_AT));
+        assert!(matches!(action, InputAction::OpenFilePicker));
+        assert_eq!(input.buffer.value(), "");
+    }
+
+    #[test]
+    fn at_mention_opens_picker_after_space() {
+        let mut input = InputBox::new(InputHistory::default());
+        type_text(&mut input, "hello ");
+        let action = input.handle_key(key_char(TEST_AT));
+        assert!(matches!(action, InputAction::OpenFilePicker));
+        assert_eq!(input.buffer.value(), "hello ");
+    }
+
+    #[test]
+    fn at_mention_opens_picker_at_second_line_start() {
+        let mut input = InputBox::new(InputHistory::default());
+        type_text(&mut input, "hi");
+        input.buffer.add_line();
+        let action = input.handle_key(key_char(TEST_AT));
+        assert!(matches!(action, InputAction::OpenFilePicker));
+        assert_eq!(input.buffer.value(), "hi\n");
+    }
+
+    #[test]
+    fn at_mention_literal_mid_word() {
+        let mut input = InputBox::new(InputHistory::default());
+        type_text(&mut input, "em");
+        let action = input.handle_key(key_char(TEST_AT));
+        assert!(!matches!(action, InputAction::OpenFilePicker));
+        assert_eq!(input.buffer.value(), "em@");
+    }
+
+    #[test]
+    fn at_mention_literal_after_punctuation() {
+        let mut input = InputBox::new(InputHistory::default());
+        type_text(&mut input, "see (");
+        let action = input.handle_key(key_char(TEST_AT));
+        assert!(!matches!(action, InputAction::OpenFilePicker));
+        assert_eq!(input.buffer.value(), "see (@");
+    }
+
+    #[test]
+    fn at_mention_literal_with_ctrl_modifier() {
+        let mut input = InputBox::new(InputHistory::default());
+        let action = input.handle_key(KeyEvent::new(KeyCode::Char(TEST_AT), KeyModifiers::CONTROL));
+        assert!(!matches!(action, InputAction::OpenFilePicker));
     }
 }

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -384,6 +384,12 @@ pub const KEYBINDS: &[Keybind] = &[
         platform: Platform::All,
     },
     Keybind {
+        label: KeyLabel::Single("@"),
+        description: "Mention a file (Esc leaves a literal @)",
+        context: KeybindContext::Editing,
+        platform: Platform::All,
+    },
+    Keybind {
         label: KeyLabel::MacAlt(key::DELETE_WORD.label, "⌥⌫"),
         description: "Delete word backward",
         context: KeybindContext::Editing,

--- a/maki-ui/src/splash.rs
+++ b/maki-ui/src/splash.rs
@@ -21,6 +21,7 @@ const TIPS: &[(&str, &str)] = &[
         key::FILE_PICKER.label,
         "to grab file paths with fuzzy search",
     ),
+    ("@", "to mention a file in your prompt"),
     (key::TASKS.label, "to see what your subagents are up to"),
     (key::SEARCH.label, "to find things in the conversation"),
     ("/btw", "to ask something without interrupting the session"),

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -30,6 +30,7 @@ On macOS, some bindings use Option or Fn keys instead (run `/help` for exact key
 | `\+Enter` / `Ctrl+J` / `Alt+Enter` | Newline |
 | `Tab` | Toggle mode |
 | `/command` | Open command palette |
+| `@` | Mention a file (Esc leaves a literal @) |
 | `Ctrl+W` | Delete word backward |
 | `Alt+←` / `Alt+→` | Move word left / right |
 | `Ctrl+A` | Jump to start of line |

--- a/site/docs/content/quick-start/_index.md
+++ b/site/docs/content/quick-start/_index.md
@@ -62,6 +62,7 @@ Type a prompt, press **Enter**, and the agent starts working.
 - **Scroll output**: Ctrl+U / Ctrl+D (half page)
 - **Cancel streaming**: Esc Esc
 - **Rewind (when idle)**: Esc Esc
+- **Insert file path**: type `@` after whitespace to open the file picker (Esc leaves a literal `@`)
 - **Quit**: Ctrl+C
 - **All keybindings**: Ctrl+H
 


### PR DESCRIPTION
Implement `@`-mention opening the existing file picker modal alongside the ctrl+s binding, as described in https://github.com/tontinton/maki/issues/431. Check the issue for behavior. Tested manually, implemented with maki.