### PR TITLE
feat(provider-hooks): add provider request/response hooks 🤖🤖🤖

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,6 +2571,8 @@ dependencies = [
 name = "maki-providers"
 version = "0.3.23"
 dependencies = [
+ "async-lock",
+ "async-process",
  "base64",
  "fastrand",
  "flume 0.11.1",
@@ -2579,6 +2581,7 @@ dependencies = [
  "hmac",
  "inventory",
  "isahc",
+ "libc",
  "maki-config",
  "maki-storage",
  "serde",

--- a/maki-acp/src/lib.rs
+++ b/maki-acp/src/lib.rs
@@ -6,6 +6,7 @@ pub mod translate;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use maki_agent::agent::ProviderHookSink;
 use maki_agent::prompt::ResolvedSlots;
 use maki_agent::{AgentConfig, PermissionsConfig};
 use maki_providers::Timeouts;
@@ -20,6 +21,7 @@ pub struct AcpParams {
     pub mcp_handle: Option<maki_agent::McpHandle>,
     pub prompt_slots: Arc<ResolvedSlots>,
     pub yolo: bool,
+    pub hooks: Option<Arc<dyn ProviderHookSink + Send + Sync>>,
 }
 
 pub fn run(params: AcpParams) -> color_eyre::Result<()> {

--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -175,6 +175,7 @@ fn spawn_session(
         yolo: params.yolo,
         system_prompt_override: None,
         append_system_prompt: None,
+        hooks: params.hooks.clone(),
     })
 }
 

--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -42,6 +42,7 @@ pub(super) async fn compact_history(
             cancel,
             RequestOptions::default(),
             None,
+            None,
         )
         .await
         {

--- a/maki-agent/src/agent/mod.rs
+++ b/maki-agent/src/agent/mod.rs
@@ -1,6 +1,7 @@
 mod compaction;
 mod history;
 mod instructions;
+mod provider_hooks;
 mod run;
 mod streaming;
 pub mod tool_dispatch;
@@ -11,4 +12,5 @@ pub use instructions::{
     Instructions, LoadedInstructions, build_system_prompt, find_subdirectory_instructions,
     is_instruction_file, load_instruction_text, load_instructions,
 };
+pub use provider_hooks::{ProviderHookSink, REQUEST_STAGE, RESPONSE_END_STAGE};
 pub use run::{Agent, AgentParams, AgentRunParams, resolve_compaction_model};

--- a/maki-agent/src/agent/provider_hooks.rs
+++ b/maki-agent/src/agent/provider_hooks.rs
@@ -1,0 +1,49 @@
+use std::time::Duration;
+
+use maki_providers::provider::BoxFuture;
+
+use crate::AgentError;
+
+pub const REQUEST_STAGE: &str = "request";
+pub const RESPONSE_END_STAGE: &str = "response_end";
+
+pub(crate) const PROVIDER_HOOKS_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub trait ProviderHookSink: Send + Sync {
+    fn run_hooks<'a>(
+        &'a self,
+        stage: &'a str,
+        slug: &'a str,
+        ctx: serde_json::Value,
+    ) -> BoxFuture<'a, Result<serde_json::Value, AgentError>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct NoopSink;
+
+    impl ProviderHookSink for NoopSink {
+        fn run_hooks<'a>(
+            &'a self,
+            _stage: &'a str,
+            _slug: &'a str,
+            ctx: serde_json::Value,
+        ) -> BoxFuture<'a, Result<serde_json::Value, AgentError>> {
+            Box::pin(async move { Ok(ctx) })
+        }
+    }
+
+    #[test]
+    fn run_hooks_returns_input_unchanged() {
+        const STAGE: &str = REQUEST_STAGE;
+        const SLUG: &str = "test-provider";
+        smol::block_on(async {
+            let sink = NoopSink;
+            let ctx = serde_json::json!({ "ping": 1 });
+            let out = sink.run_hooks(STAGE, SLUG, ctx).await.unwrap();
+            assert_eq!(out, serde_json::json!({ "ping": 1 }));
+        });
+    }
+}

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -11,6 +11,7 @@ use maki_providers::{
 use super::compaction::{self, CONTINUE_AFTER_COMPACT};
 use super::history::{History, sanitize_cancelled_history};
 use super::instructions::LoadedInstructions;
+use super::provider_hooks::ProviderHookSink;
 use super::streaming::stream_with_retry;
 use super::tool_dispatch::{self, RecentCalls};
 use crate::cancel::{CancelMap, CancelToken};
@@ -87,6 +88,7 @@ pub struct Agent<'h> {
     loaded_instructions: LoadedInstructions,
     rollback_len: usize,
     mcp: Option<McpHandle>,
+    hooks: Option<Arc<dyn ProviderHookSink + Send + Sync>>,
     config: AgentConfig,
     tool_output_lines: ToolOutputLines,
     reauth_attempts: u32,
@@ -125,6 +127,7 @@ impl<'h> Agent<'h> {
             loaded_instructions: LoadedInstructions::new(),
             rollback_len: 0,
             mcp: None,
+            hooks: None,
             reauth_attempts: 0,
             post_tool_empty_retried: false,
             opts: RequestOptions::default(),
@@ -137,6 +140,14 @@ impl<'h> Agent<'h> {
 
     pub fn with_mcp(mut self, mcp: Option<McpHandle>) -> Self {
         self.mcp = mcp;
+        self
+    }
+
+    pub fn with_provider_hooks(
+        mut self,
+        hooks: Option<Arc<dyn ProviderHookSink + Send + Sync>>,
+    ) -> Self {
+        self.hooks = hooks;
         self
     }
 
@@ -221,6 +232,9 @@ impl<'h> Agent<'h> {
             &self.cancel,
             self.opts,
             self.session_id.as_deref(),
+            self.hooks
+                .as_ref()
+                .map(|h| h.as_ref() as &dyn ProviderHookSink),
         )
         .await
         {
@@ -390,6 +404,7 @@ impl<'h> Agent<'h> {
             prompt_slots: Arc::clone(&self.prompt_slots),
             opts: self.opts,
             subagent_cancels: Arc::clone(&self.subagent_cancels),
+            hooks: self.hooks.clone(),
         }
     }
 

--- a/maki-agent/src/agent/streaming.rs
+++ b/maki-agent/src/agent/streaming.rs
@@ -1,9 +1,14 @@
 use maki_providers::provider::Provider;
 use maki_providers::retry::{MAX_TIMEOUT_RETRIES, RetryState};
-use maki_providers::{Message, Model, ProviderEvent, RequestOptions, StreamResponse};
+use maki_providers::{
+    Message, Model, ProviderEvent, RequestOptions, StopReason, StreamResponse, TokenUsage,
+};
 use serde_json::Value;
-use tracing::warn;
+use tracing::{debug, warn};
 
+use super::provider_hooks::{
+    PROVIDER_HOOKS_TIMEOUT, ProviderHookSink, REQUEST_STAGE, RESPONSE_END_STAGE,
+};
 use crate::cancel::CancelToken;
 use crate::{AgentError, AgentEvent, EventSender};
 
@@ -31,17 +36,62 @@ pub(crate) async fn stream_with_retry(
     cancel: &CancelToken,
     opts: RequestOptions,
     session_id: Option<&str>,
+    hooks: Option<&dyn ProviderHookSink>,
 ) -> Result<StreamResponse, AgentError> {
     let opts = opts.clamped(model);
+    let provider_slug = model.provider.to_string();
+    let slug = model.dynamic_slug.clone().unwrap_or(provider_slug);
     let mut retry = RetryState::new();
     loop {
         let (ptx, prx) = flume::unbounded();
+        let (req_messages, req_system, req_tools) = if let Some(sink) = hooks {
+            let ctx = serde_json::json!({
+                "messages": messages,
+                "system": system,
+                "tools": tools,
+            });
+            match futures_lite::future::race(sink.run_hooks(REQUEST_STAGE, &slug, ctx), async {
+                smol::Timer::after(PROVIDER_HOOKS_TIMEOUT).await;
+                Err(AgentError::Timeout {
+                    secs: PROVIDER_HOOKS_TIMEOUT.as_secs(),
+                })
+            })
+            .await
+            {
+                Ok(transformed) => {
+                    match extract_request_view(&transformed, messages, system, tools) {
+                        Some(v) => {
+                            debug!(stage = REQUEST_STAGE, slug = %slug, "provider hooks applied");
+                            v
+                        }
+                        None => {
+                            warn!(stage = REQUEST_STAGE, slug = %slug, "hooks returned invalid view; skipped");
+                            (messages.to_vec(), system.to_owned(), tools.clone())
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!(stage = REQUEST_STAGE, slug = %slug, error = %e, "hooks skipped");
+                    (messages.to_vec(), system.to_owned(), tools.clone())
+                }
+            }
+        } else {
+            (messages.to_vec(), system.to_owned(), tools.clone())
+        };
         let forwarder = smol::spawn({
             let event_tx = event_tx.clone();
             async move { forward_provider_events(prx, &event_tx).await }
         });
         let result = futures_lite::future::race(
-            provider.stream_message(model, messages, system, tools, &ptx, opts, session_id),
+            provider.stream_message(
+                model,
+                &req_messages,
+                &req_system,
+                &req_tools,
+                &ptx,
+                opts,
+                session_id,
+            ),
             async {
                 cancel.cancelled().await;
                 Err(AgentError::Cancelled)
@@ -51,7 +101,44 @@ pub(crate) async fn stream_with_retry(
         drop(ptx);
         let _ = forwarder.await;
         match result {
-            Ok(r) => return Ok(r),
+            Ok(r) => {
+                if let Some(sink) = hooks {
+                    let ctx = serde_json::json!({
+                        "message": r.message,
+                        "usage": r.usage,
+                        "stop_reason": r.stop_reason,
+                    });
+                    match futures_lite::future::race(
+                        sink.run_hooks(RESPONSE_END_STAGE, &slug, ctx),
+                        async {
+                            smol::Timer::after(PROVIDER_HOOKS_TIMEOUT).await;
+                            Err(AgentError::Timeout {
+                                secs: PROVIDER_HOOKS_TIMEOUT.as_secs(),
+                            })
+                        },
+                    )
+                    .await
+                    {
+                        Ok(transformed) => match apply_response_hook(&transformed, r) {
+                            Ok(out) => {
+                                debug!(stage = RESPONSE_END_STAGE, slug = %slug, "provider hooks applied");
+                                return Ok(out);
+                            }
+                            Err(original) => {
+                                warn!(stage = RESPONSE_END_STAGE, slug = %slug, "hooks returned invalid view; skipped");
+                                return Ok(original);
+                            }
+                        },
+                        Err(e) => warn!(
+                            stage = RESPONSE_END_STAGE,
+                            slug = %slug,
+                            error = %e,
+                            "hooks skipped"
+                        ),
+                    }
+                }
+                return Ok(r);
+            }
             Err(AgentError::Cancelled) => return Err(AgentError::Cancelled),
             Err(e) if e.is_retryable() => {
                 if e.should_rotate_key()
@@ -84,4 +171,54 @@ pub(crate) async fn stream_with_retry(
             Err(e) => return Err(e),
         }
     }
+}
+
+fn extract_request_view(
+    transformed: &Value,
+    messages: &[Message],
+    system: &str,
+    tools: &Value,
+) -> Option<(Vec<Message>, String, Value)> {
+    let out_messages = match transformed.get("messages") {
+        Some(v) => serde_json::from_value::<Vec<Message>>(v.clone()).ok()?,
+        None => messages.to_vec(),
+    };
+    let out_system = match transformed.get("system") {
+        Some(v) => v.as_str().map(str::to_owned)?,
+        None => system.to_owned(),
+    };
+    let out_tools = transformed
+        .get("tools")
+        .cloned()
+        .unwrap_or_else(|| tools.clone());
+    Some((out_messages, out_system, out_tools))
+}
+
+/// Applies a `response_end` hook's output to a `StreamResponse`. Absent
+/// fields pass through unchanged; present-but-malformed fields cause the
+/// whole transform to be rejected (`Err` carries back the original).
+/// Mirrors `extract_request_view`'s fail-loud-on-malformed semantics.
+fn apply_response_hook(
+    transformed: &Value,
+    mut r: StreamResponse,
+) -> Result<StreamResponse, StreamResponse> {
+    if let Some(v) = transformed.get("message") {
+        match serde_json::from_value::<Message>(v.clone()) {
+            Ok(m) => r.message = m,
+            Err(_) => return Err(r),
+        }
+    }
+    if let Some(v) = transformed.get("usage") {
+        match serde_json::from_value::<TokenUsage>(v.clone()) {
+            Ok(u) => r.usage = u,
+            Err(_) => return Err(r),
+        }
+    }
+    if let Some(v) = transformed.get("stop_reason") {
+        match serde_json::from_value::<StopReason>(v.clone()) {
+            Ok(s) => r.stop_reason = Some(s),
+            Err(_) => return Err(r),
+        }
+    }
+    Ok(r)
 }

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -13,7 +13,7 @@ use maki_storage::sessions::Session;
 use serde_json::Value;
 use tracing::{error, warn};
 
-use crate::agent::{self, History};
+use crate::agent::{self, History, ProviderHookSink};
 use crate::cancel::{CancelMap, CancelToken};
 use crate::permissions::PermissionManager;
 use crate::prompt::ResolvedSlots;
@@ -77,6 +77,7 @@ pub struct HeadlessParams {
     pub mcp_handle: Option<McpHandle>,
     pub initial_wd: PathBuf,
     pub fast: bool,
+    pub hooks: Option<Arc<dyn ProviderHookSink + Send + Sync>>,
 }
 
 pub struct HeadlessHandle {
@@ -201,7 +202,8 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
                 },
             )
             .with_loaded_instructions(instructions.loaded)
-            .with_mcp(params.mcp_handle);
+            .with_mcp(params.mcp_handle)
+            .with_provider_hooks(params.hooks);
 
             let result = agent
                 .run(AgentInput {
@@ -249,6 +251,7 @@ pub struct InteractiveParams {
     pub yolo: bool,
     pub system_prompt_override: Option<String>,
     pub append_system_prompt: Option<String>,
+    pub hooks: Option<Arc<dyn ProviderHookSink + Send + Sync>>,
 }
 
 pub struct InteractiveHandle {
@@ -399,7 +402,8 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                 .with_loaded_instructions(instructions.loaded.clone())
                 .with_user_response_rx(Arc::clone(&answer_rx))
                 .with_cancel(cancel)
-                .with_mcp(params.mcp_handle.clone());
+                .with_mcp(params.mcp_handle.clone())
+                .with_provider_hooks(params.hooks.clone());
 
                 let result = agent.run(input).await;
                 drop(agent);

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -192,6 +192,7 @@ pub struct ToolContext {
     pub prompt_slots: Arc<crate::prompt::ResolvedSlots>,
     pub opts: RequestOptions,
     pub subagent_cancels: Arc<CancelMap<String>>,
+    pub hooks: Option<Arc<dyn crate::agent::ProviderHookSink + Send + Sync>>,
 }
 
 pub(crate) fn resolve_path(path: &str) -> Result<String, String> {
@@ -602,6 +603,7 @@ pub fn interpreter_ctx(
         prompt_slots: Arc::new(crate::prompt::ResolvedSlots::default()),
         opts: RequestOptions::default(),
         subagent_cancels: Arc::new(CancelMap::new()),
+        hooks: None,
     }
 }
 

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -307,7 +307,8 @@ async fn run(lua: Lua, (agent_ctx_ud, opts): (mlua::AnyUserData, Table)) -> LuaR
     )
     .with_user_response_rx(answer_rx)
     .with_cancel(child_cancel)
-    .with_mcp(agent_ctx.mcp.clone());
+    .with_mcp(agent_ctx.mcp.clone())
+    .with_provider_hooks(agent_ctx.hooks.clone());
 
     let start = Instant::now();
     let result = agent.run(input).await;

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -9,6 +9,8 @@ pub(crate) mod json;
 pub(crate) mod keymap;
 pub(crate) mod log;
 pub(crate) mod net;
+pub(crate) mod provider;
+pub(crate) mod provider_hooks;
 pub(crate) mod text;
 pub(crate) mod tool;
 pub(crate) mod treesitter;
@@ -57,6 +59,10 @@ pub(crate) fn create_maki_global(
         interpreter::create_interpreter_table(lua, permissions)?,
     )?;
     agent::register(lua, &maki)?;
+    maki.set(
+        "provider",
+        provider::create_provider_table(lua, Arc::clone(&plugin), permissions)?,
+    )?;
     maki.set(
         "keymap",
         keymap::create_keymap_table(lua, Arc::clone(&plugin))?,

--- a/maki-lua/src/api/provider.rs
+++ b/maki-lua/src/api/provider.rs
@@ -1,0 +1,94 @@
+use std::sync::Arc;
+
+use mlua::{Lua, Result as LuaResult, Table};
+
+use crate::api::provider_hooks::{ProviderHookStore, next_hook_id};
+use crate::plugin_permissions::{Permission, PluginPermissions};
+use maki_agent::agent::{REQUEST_STAGE, RESPONSE_END_STAGE};
+
+const MISSING_CALLBACK_MSG: &str = "callback must be a function";
+const STORE_NOT_INITIALIZED_MSG: &str = "provider hook store not initialized";
+
+fn register_stage(
+    lua: &Lua,
+    t: &Table,
+    plugin: Arc<str>,
+    stage: &'static str,
+    fname: &str,
+) -> LuaResult<()> {
+    let p = Arc::clone(&plugin);
+    t.set(
+        fname,
+        lua.create_function(move |lua, opts: Table| {
+            let slug_filter: Option<String> = opts.get("slug").ok();
+            let callback: mlua::Function = opts
+                .get("callback")
+                .map_err(|_| mlua::Error::runtime(MISSING_CALLBACK_MSG))?;
+            let id = next_hook_id();
+            let key = lua.create_registry_value(callback)?;
+            let mut store = lua
+                .app_data_mut::<ProviderHookStore>()
+                .ok_or_else(|| mlua::Error::runtime(STORE_NOT_INITIALIZED_MSG))?;
+            store.register(id, stage.to_owned(), key, Arc::clone(&p), slug_filter);
+            Ok(id)
+        })?,
+    )?;
+    Ok(())
+}
+
+fn register_del(lua: &Lua, t: &Table) -> LuaResult<()> {
+    t.set(
+        "del_provider_hook",
+        lua.create_function(|lua, id: u64| {
+            let keys = lua
+                .app_data_mut::<ProviderHookStore>()
+                .map(|mut store| store.remove(id))
+                .unwrap_or_default();
+            for key in keys {
+                let _ = lua.remove_registry_value(key);
+            }
+            Ok(())
+        })?,
+    )?;
+    Ok(())
+}
+
+fn denied_hook(lua: &Lua, perm: Permission) -> LuaResult<mlua::Function> {
+    lua.create_function(move |_, _: mlua::MultiValue| -> LuaResult<mlua::Value> {
+        Err(mlua::Error::runtime(format!(
+            "permission denied: '{}' not granted for this plugin",
+            perm
+        )))
+    })
+}
+
+pub(crate) fn create_provider_table(
+    lua: &Lua,
+    plugin: Arc<str>,
+    perms: &PluginPermissions,
+) -> LuaResult<Table> {
+    let t = lua.create_table()?;
+    let perm = Permission::ProviderHooks;
+    if perms.is_allowed(perm) {
+        register_stage(
+            lua,
+            &t,
+            Arc::clone(&plugin),
+            REQUEST_STAGE,
+            "register_request_hook",
+        )?;
+        register_stage(
+            lua,
+            &t,
+            Arc::clone(&plugin),
+            RESPONSE_END_STAGE,
+            "register_response_hook",
+        )?;
+        register_del(lua, &t)?;
+    } else {
+        t.set("register_request_hook", denied_hook(lua, perm)?)?;
+        t.set("register_response_hook", denied_hook(lua, perm)?)?;
+        t.set("del_provider_hook", denied_hook(lua, perm)?)?;
+    }
+    Ok(t)
+}

--- a/maki-lua/src/api/provider_hooks.rs
+++ b/maki-lua/src/api/provider_hooks.rs
@@ -1,0 +1,133 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use mlua::RegistryKey;
+
+static NEXT_HOOK_ID: AtomicU64 = AtomicU64::new(1);
+
+pub(crate) fn next_hook_id() -> u64 {
+    NEXT_HOOK_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+pub(crate) struct ProviderHookEntry {
+    pub id: u64,
+    pub callback: RegistryKey,
+    pub plugin: Arc<str>,
+    pub slug_filter: Option<String>,
+}
+
+#[derive(Default)]
+pub(crate) struct ProviderHookStore {
+    pub(crate) listeners: HashMap<String, Vec<ProviderHookEntry>>,
+}
+
+impl ProviderHookStore {
+    pub fn register(
+        &mut self,
+        id: u64,
+        stage: String,
+        callback: RegistryKey,
+        plugin: Arc<str>,
+        slug_filter: Option<String>,
+    ) {
+        self.listeners
+            .entry(stage)
+            .or_default()
+            .push(ProviderHookEntry {
+                id,
+                callback,
+                plugin,
+                slug_filter,
+            });
+    }
+
+    pub fn remove(&mut self, id: u64) -> Vec<RegistryKey> {
+        let mut keys = Vec::new();
+        for entries in self.listeners.values_mut() {
+            if let Some(pos) = entries.iter().position(|e| e.id == id) {
+                keys.push(entries.remove(pos).callback);
+            }
+        }
+        keys
+    }
+
+    pub fn clear_plugin(&mut self, plugin: &str) -> Vec<RegistryKey> {
+        let mut keys = Vec::new();
+        for entries in self.listeners.values_mut() {
+            let mut i = 0;
+            while i < entries.len() {
+                if entries[i].plugin.as_ref() == plugin {
+                    keys.push(entries.remove(i).callback);
+                } else {
+                    i += 1;
+                }
+            }
+        }
+        self.listeners.retain(|_, v| !v.is_empty());
+        keys
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mlua::Lua;
+
+    #[test]
+    fn register_and_remove() {
+        let lua = Lua::new();
+        let mut store = ProviderHookStore::default();
+        let f = lua.create_function(|_, ()| Ok(())).unwrap();
+        let key = lua.create_registry_value(f).unwrap();
+        store.register(1, "request".into(), key, Arc::from("test"), None);
+        assert_eq!(store.listeners["request"].len(), 1);
+        let removed = store.remove(1);
+        assert_eq!(removed.len(), 1);
+        assert!(store.listeners["request"].is_empty());
+    }
+
+    #[test]
+    fn clear_plugin_removes_only_matching() {
+        let lua = Lua::new();
+        let mut store = ProviderHookStore::default();
+
+        let f1 = lua.create_function(|_, ()| Ok(())).unwrap();
+        let f2 = lua.create_function(|_, ()| Ok(())).unwrap();
+        let k1 = lua.create_registry_value(f1).unwrap();
+        let k2 = lua.create_registry_value(f2).unwrap();
+
+        store.register(1, "request".into(), k1, Arc::from("plugA"), None);
+        store.register(2, "request".into(), k2, Arc::from("plugB"), None);
+
+        let removed = store.clear_plugin("plugA");
+        assert_eq!(removed.len(), 1);
+        assert_eq!(store.listeners["request"].len(), 1);
+        assert_eq!(store.listeners["request"][0].plugin.as_ref(), "plugB");
+    }
+
+    #[test]
+    fn remove_nonexistent_returns_empty() {
+        let mut store = ProviderHookStore::default();
+        assert!(store.remove(999).is_empty());
+    }
+
+    #[test]
+    fn slug_filter_preserved() {
+        let lua = Lua::new();
+        let mut store = ProviderHookStore::default();
+        let f = lua.create_function(|_, ()| Ok(())).unwrap();
+        let key = lua.create_registry_value(f).unwrap();
+        store.register(
+            1,
+            "request".into(),
+            key,
+            Arc::from("test"),
+            Some("my-slug".into()),
+        );
+        assert_eq!(
+            store.listeners["request"][0].slug_filter.as_deref(),
+            Some("my-slug")
+        );
+    }
+}

--- a/maki-lua/src/api/util/ctx.rs
+++ b/maki-lua/src/api/util/ctx.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use maki_agent::agent::LoadedInstructions;
+use maki_agent::agent::{LoadedInstructions, ProviderHookSink};
 use maki_agent::cancel::{CancelMap, CancelToken};
 use maki_agent::mcp::McpHandle;
 use maki_agent::permissions::PermissionManager;
@@ -47,6 +47,7 @@ pub(crate) struct AgentContext {
     pub(crate) config: AgentConfig,
     pub(crate) file_tracker: Arc<FileReadTracker>,
     pub(crate) user_response_rx: Option<Arc<async_lock::Mutex<flume::Receiver<String>>>>,
+    pub(crate) hooks: Option<Arc<dyn ProviderHookSink + Send + Sync>>,
 }
 
 impl From<&maki_agent::tools::ToolContext> for AgentContext {
@@ -67,6 +68,7 @@ impl From<&maki_agent::tools::ToolContext> for AgentContext {
             config: ctx.config.clone(),
             file_tracker: Arc::clone(&ctx.file_tracker),
             user_response_rx: ctx.user_response_rx.clone(),
+            hooks: ctx.hooks.clone(),
         }
     }
 }

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -343,6 +343,24 @@ impl EventHandle {
         rx.recv_async().await.unwrap_or_default()
     }
 
+    pub async fn run_provider_hooks(
+        &self,
+        stage: &str,
+        slug: &str,
+        ctx: serde_json::Value,
+    ) -> Result<serde_json::Value, maki_agent::AgentError> {
+        let (tx, rx) = flume::bounded(1);
+        let _ = self.tx.send(Request::RunProviderHooks {
+            stage: stage.to_owned(),
+            slug: slug.to_owned(),
+            ctx,
+            reply: tx,
+        });
+        rx.recv_async()
+            .await
+            .map_err(|_| maki_agent::AgentError::Channel)?
+    }
+
     pub fn request_restore(&self, item: RestoreItem, event_tx: maki_agent::EventSender) {
         let _ = self.tx.send(Request::RestoreToolAsync { item, event_tx });
     }
@@ -364,6 +382,18 @@ impl EventHandle {
 
     pub fn run_keybind_callback(&self, id: u64) {
         let _ = self.tx.try_send(Request::RunKeybindCallback { id });
+    }
+}
+
+impl maki_agent::agent::ProviderHookSink for EventHandle {
+    fn run_hooks<'a>(
+        &'a self,
+        stage: &'a str,
+        slug: &'a str,
+        ctx: serde_json::Value,
+    ) -> maki_providers::provider::BoxFuture<'a, Result<serde_json::Value, maki_agent::AgentError>>
+    {
+        Box::pin(async move { self.run_provider_hooks(stage, slug, ctx).await })
     }
 }
 

--- a/maki-lua/src/plugin_permissions.rs
+++ b/maki-lua/src/plugin_permissions.rs
@@ -13,15 +13,17 @@ pub enum Permission {
     Net,
     Run,
     Env,
+    ProviderHooks,
 }
 
 impl Permission {
-    const ALL: [Permission; 5] = [
+    const ALL: [Permission; 6] = [
         Permission::FsRead,
         Permission::FsWrite,
         Permission::Net,
         Permission::Run,
         Permission::Env,
+        Permission::ProviderHooks,
     ];
 
     fn manifest_key(self) -> &'static str {
@@ -31,6 +33,7 @@ impl Permission {
             Permission::Net => "net",
             Permission::Run => "run",
             Permission::Env => "env",
+            Permission::ProviderHooks => "provider_hooks",
         }
     }
 }
@@ -43,17 +46,17 @@ impl fmt::Display for Permission {
 
 #[derive(Debug, Clone)]
 pub struct PluginPermissions {
-    allowed: [bool; 5],
+    allowed: [bool; 6],
 }
 
 impl PluginPermissions {
     pub fn trusted() -> Self {
-        Self { allowed: [true; 5] }
+        Self { allowed: [true; 6] }
     }
 
     pub fn denied() -> Self {
         Self {
-            allowed: [false; 5],
+            allowed: [false; 6],
         }
     }
 
@@ -63,7 +66,7 @@ impl PluginPermissions {
 
     pub fn from_manifest(manifest: &toml::Value) -> Self {
         let perms = manifest.get("permissions");
-        let mut allowed = [true; 5];
+        let mut allowed = [true; 6];
         for perm in Permission::ALL {
             allowed[perm as usize] = perms
                 .and_then(|p| p.get(perm.manifest_key()))
@@ -178,6 +181,7 @@ mod tests {
         assert!(!p.is_allowed(Permission::Net));
         assert!(p.is_allowed(Permission::Run));
         assert!(p.is_allowed(Permission::Env));
+        assert!(p.is_allowed(Permission::ProviderHooks));
     }
 
     #[test]
@@ -199,6 +203,7 @@ mod tests {
         assert!(!p.is_allowed(Permission::Net));
         assert!(!p.is_allowed(Permission::Run));
         assert!(p.is_allowed(Permission::Env));
+        assert!(p.is_allowed(Permission::ProviderHooks));
     }
 
     #[test]

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use event_listener::Event;
 
 use include_dir::Dir;
+use maki_agent::AgentError;
 use maki_agent::cancel::CancelToken;
 use maki_agent::prompt::{PromptId, ResolvedSlots, Slot, SlotEntry};
 use maki_agent::tools::{
@@ -26,12 +27,14 @@ use crate::api::create_maki_global;
 use crate::api::r#fn::{JobEvent, JobStore};
 use crate::api::keymap::KeymapReader;
 use crate::api::keymap::{KeymapStore, KeymapWriter};
+use crate::api::provider_hooks::ProviderHookStore;
 use crate::api::tool::{LuaTool, PendingTool, PendingTools, ToolCallReply};
 use crate::api::ui::HintStore;
 use crate::api::ui::buf::{BufHandle, BufferStore};
 use crate::api::util::command::{CommandHandlerMap, HintWriter, publish_command_snapshot};
 use crate::api::util::command::{LuaCommandReader, LuaCommandWriter, UiAction};
 use crate::api::util::convert::json_to_lua;
+use crate::api::util::convert::lua_to_json;
 use crate::api::util::ctx::LuaCtx;
 use crate::api::util::setup::ConfigStore;
 use crate::error::PluginError;
@@ -49,6 +52,7 @@ const GC_STEP_INTERVAL: usize = 4;
 const INTERRUPT_CANCEL_CHECK_INTERVAL: u32 = 128;
 const ASYNC_RUN_DEFAULT_DEADLINE: Duration = Duration::from_secs(60);
 const TURN_END_EVENT: &str = "TurnEnd";
+const PROVIDER_HOOKS_TOOL: &str = "provider_hooks";
 /// Without a cap, a runaway plugin OOM-kills the whole process.
 /// With one, it hits a catchable Lua error instead.
 const LUA_MEMORY_LIMIT: usize = 512 * 1024 * 1024;
@@ -130,6 +134,12 @@ pub enum Request {
     },
     ClickTool {
         tool_use_id: String,
+    },
+    RunProviderHooks {
+        stage: String,
+        slug: String,
+        ctx: Value,
+        reply: flume::Sender<Result<Value, AgentError>>,
     },
     RunKeybindCallback {
         id: u64,
@@ -614,6 +624,7 @@ impl LuaRuntime {
         lua.set_app_data(command_writer);
         lua.set_app_data(PromptHintCallbacks::default());
         lua.set_app_data(AutocmdStore::default());
+        lua.set_app_data(ProviderHookStore::default());
         lua.set_app_data(KeymapStore::new());
         lua.set_app_data(keymap_writer);
         lua.set_app_data(HintStore::new());
@@ -770,6 +781,68 @@ impl LuaRuntime {
             }
         }
         slots
+    }
+
+    async fn run_provider_hooks(
+        &self,
+        stage: &str,
+        slug: &str,
+        ctx: Value,
+    ) -> Result<Value, AgentError> {
+        let entries: Vec<(Arc<str>, Function)> = {
+            let Some(store) = self.lua.app_data_ref::<ProviderHookStore>() else {
+                return Ok(ctx);
+            };
+            let Some(list) = store.listeners.get(stage) else {
+                return Ok(ctx);
+            };
+            let mut filtered: Vec<(Arc<str>, Function)> = list
+                .iter()
+                .filter(|e| e.slug_filter.as_deref().is_none_or(|s| s == slug))
+                .filter_map(|e| {
+                    self.lua
+                        .registry_value::<Function>(&e.callback)
+                        .map(|f| (Arc::clone(&e.plugin), f))
+                        .ok()
+                })
+                .collect();
+            filtered.sort_by(|a, b| a.0.cmp(&b.0));
+            filtered
+        };
+
+        if entries.is_empty() {
+            return Ok(ctx);
+        }
+
+        let mut current = json_to_lua(&self.lua, &ctx).map_err(|e| AgentError::Tool {
+            tool: PROVIDER_HOOKS_TOOL.into(),
+            message: e.to_string(),
+        })?;
+
+        for (plugin, func) in entries {
+            let result: mlua::Result<LuaValue> = run_detached(&self.lua, async {
+                let thread = self.lua.create_thread(func)?;
+                thread.into_async::<LuaValue>(current.clone())?.await
+            })
+            .await;
+            match result {
+                Ok(LuaValue::Table(t)) if t.get::<bool>("stop").unwrap_or(false) => {
+                    if let Ok(Some(v)) = t.get::<Option<LuaValue>>("value") {
+                        current = v;
+                    }
+                    break;
+                }
+                Ok(ret) => current = ret,
+                Err(e) => {
+                    tracing::warn!(plugin = %plugin, stage, error = %e, "provider hook failed; skipping");
+                }
+            }
+        }
+
+        lua_to_json(&current).map_err(|e| AgentError::Tool {
+            tool: PROVIDER_HOOKS_TOOL.into(),
+            message: e.to_string(),
+        })
     }
 
     fn drain_pending(&self) -> Vec<PendingTool> {
@@ -1034,6 +1107,13 @@ impl LuaRuntime {
         self.registry.clear_plugin(plugin);
         self.drop_plugin_keys(plugin);
         if let Some(mut store) = self.lua.app_data_mut::<AutocmdStore>() {
+            let keys = store.clear_plugin(plugin);
+            drop(store);
+            for key in keys {
+                let _ = self.lua.remove_registry_value(key);
+            }
+        }
+        if let Some(mut store) = self.lua.app_data_mut::<ProviderHookStore>() {
             let keys = store.clear_plugin(plugin);
             drop(store);
             for key in keys {
@@ -1768,6 +1848,10 @@ pub fn spawn(
                             if event == TURN_END_EVENT {
                                 rt.lua.gc_collect().ok();
                             }
+                        }
+                        Request::RunProviderHooks { stage, slug, ctx, reply } => {
+                            let res = rt.run_provider_hooks(&stage, &slug, ctx).await;
+                            let _ = reply.send(res);
                         }
                         Request::RunKeybindCallback { id } => {
                             let func = rt.lua.app_data_ref::<KeymapStore>().and_then(|store| {

--- a/maki-lua/tests/provider_hooks.rs
+++ b/maki-lua/tests/provider_hooks.rs
@@ -1,0 +1,139 @@
+use std::sync::Arc;
+
+use maki_agent::tools::ToolRegistry;
+use maki_lua::{PluginHost, PluginPermissions};
+
+const REQUEST_STAGE: &str = "request";
+const RESPONSE_END_STAGE: &str = "response_end";
+const HOOK_SUFFIX: &str = " [hooked]";
+const STOPPED_VALUE: &str = "short";
+
+fn host() -> PluginHost {
+    PluginHost::new(Arc::new(ToolRegistry::new())).unwrap()
+}
+
+const REQUEST_HOOK_PLUGIN: &str = r#"
+maki.provider.register_request_hook({
+    callback = function(ctx)
+        ctx.system = ctx.system .. " [hooked]"
+        return ctx
+    end,
+})
+"#;
+
+const RESPONSE_HOOK_PLUGIN: &str = r#"
+maki.provider.register_response_hook({
+    callback = function(ctx)
+        ctx.message = "transformed"
+        return ctx
+    end,
+})
+"#;
+
+const SLUG_FILTER_PLUGIN: &str = r#"
+maki.provider.register_request_hook({
+    slug = "other",
+    callback = function(ctx)
+        ctx.system = ctx.system .. " [should-not-fire]"
+        return ctx
+    end,
+})
+"#;
+
+const STOP_HOOK_PLUGIN: &str = r#"
+maki.provider.register_request_hook({
+    callback = function(ctx)
+        return { stop = true, value = { system = "short" } }
+    end,
+})
+maki.provider.register_request_hook({
+    callback = function(ctx)
+        ctx.system = ctx.system .. " [second]"
+        return ctx
+    end,
+})
+"#;
+
+const ERROR_HOOK_PLUGIN: &str = r#"
+maki.provider.register_request_hook({
+    callback = function(ctx)
+        error("boom")
+    end,
+})
+maki.provider.register_request_hook({
+    callback = function(ctx)
+        ctx.system = ctx.system .. " [after-error]"
+        return ctx
+    end,
+})
+"#;
+
+#[test]
+fn request_hook_mutates_ctx() {
+    let host = host();
+    host.load_source_with_permissions("h", REQUEST_HOOK_PLUGIN, PluginPermissions::trusted())
+        .unwrap();
+    let handle = host.event_handle().expect("event handle");
+
+    let ctx = serde_json::json!({ "system": "hi", "messages": [], "tools": [] });
+    let out = smol::block_on(handle.run_provider_hooks(REQUEST_STAGE, "test", ctx)).unwrap();
+    assert_eq!(out["system"].as_str().unwrap(), format!("hi{HOOK_SUFFIX}"));
+}
+
+#[test]
+fn response_hook_mutates_message() {
+    let host = host();
+    host.load_source_with_permissions("h", RESPONSE_HOOK_PLUGIN, PluginPermissions::trusted())
+        .unwrap();
+    let handle = host.event_handle().expect("event handle");
+
+    let ctx = serde_json::json!({ "message": { "role": "assistant", "content": "original" } });
+    let out = smol::block_on(handle.run_provider_hooks(RESPONSE_END_STAGE, "test", ctx)).unwrap();
+    assert_eq!(out["message"].as_str().unwrap(), "transformed");
+}
+
+#[test]
+fn slug_filter_skips_non_matching() {
+    let host = host();
+    host.load_source_with_permissions("h", SLUG_FILTER_PLUGIN, PluginPermissions::trusted())
+        .unwrap();
+    let handle = host.event_handle().expect("event handle");
+
+    let ctx = serde_json::json!({ "system": "hi" });
+    let out = smol::block_on(handle.run_provider_hooks(REQUEST_STAGE, "test", ctx)).unwrap();
+    assert_eq!(out["system"].as_str().unwrap(), "hi");
+}
+
+#[test]
+fn stop_short_circuits_remaining_hooks() {
+    let host = host();
+    host.load_source_with_permissions("h", STOP_HOOK_PLUGIN, PluginPermissions::trusted())
+        .unwrap();
+    let handle = host.event_handle().expect("event handle");
+
+    let ctx = serde_json::json!({ "system": "begin" });
+    let out = smol::block_on(handle.run_provider_hooks(REQUEST_STAGE, "test", ctx)).unwrap();
+    assert_eq!(out["system"].as_str().unwrap(), STOPPED_VALUE);
+}
+
+#[test]
+fn failing_hook_skipped_but_chain_continues() {
+    let host = host();
+    host.load_source_with_permissions("h", ERROR_HOOK_PLUGIN, PluginPermissions::trusted())
+        .unwrap();
+    let handle = host.event_handle().expect("event handle");
+
+    let ctx = serde_json::json!({ "system": "begin" });
+    let out = smol::block_on(handle.run_provider_hooks(REQUEST_STAGE, "test", ctx)).unwrap();
+    assert_eq!(out["system"].as_str().unwrap(), "begin [after-error]");
+}
+
+#[test]
+fn no_hooks_returns_ctx_unchanged() {
+    let host = host();
+    let handle = host.event_handle().expect("event handle");
+
+    let ctx = serde_json::json!({ "system": "untouched" });
+    let out = smol::block_on(handle.run_provider_hooks(REQUEST_STAGE, "test", ctx)).unwrap();
+    assert_eq!(out["system"].as_str().unwrap(), "untouched");
+}

--- a/maki-providers/Cargo.toml
+++ b/maki-providers/Cargo.toml
@@ -23,6 +23,9 @@ wait-timeout = { workspace = true }
 fastrand = { workspace = true }
 maki-config = { workspace = true }
 inventory = { workspace = true }
+async-process = { workspace = true }
+async-lock = { workspace = true }
+libc = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/maki-providers/src/providers/anthropic/mod.rs
+++ b/maki-providers/src/providers/anthropic/mod.rs
@@ -4,6 +4,7 @@
 pub(crate) mod bedrock;
 pub(crate) mod shared;
 
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -19,6 +20,7 @@ use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
 
 use super::KeyPool;
+use super::transform::TransformProcess;
 
 const API_VERSION: &str = "2023-06-01";
 const MESSAGES_URL: &str = "https://api.anthropic.com/v1/messages";
@@ -64,6 +66,7 @@ pub struct Anthropic {
     auth: Arc<Mutex<super::ResolvedAuth>>,
     key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
+    transform: Option<PathBuf>,
     stream_timeout: Duration,
 }
 
@@ -77,6 +80,7 @@ impl Anthropic {
             auth: Arc::new(Mutex::new(resolved)),
             key_pool: Some(pool),
             system_prefix: None,
+            transform: None,
             stream_timeout: timeouts.stream,
         })
     }
@@ -90,12 +94,18 @@ impl Anthropic {
             auth,
             key_pool: None,
             system_prefix: None,
+            transform: None,
             stream_timeout: timeouts.stream,
         }
     }
 
     pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
         self.system_prefix = prefix;
+        self
+    }
+
+    pub(crate) fn with_transform(mut self, path: Option<PathBuf>) -> Self {
+        self.transform = path;
         self
     }
 
@@ -119,6 +129,7 @@ impl Anthropic {
         event_tx: &Sender<ProviderEvent>,
         fast: bool,
         long_context: bool,
+        transform: Option<TransformProcess>,
     ) -> Result<StreamResponse, AgentError> {
         let json_body = serde_json::to_vec(body)?;
         let mut builder = self
@@ -138,11 +149,19 @@ impl Anthropic {
         let response = self.client.send_async(request).await?;
         let status = response.status().as_u16();
 
-        if status == 200 {
-            parse_sse(response, event_tx, self.stream_timeout).await
-        } else {
-            Err(AgentError::from_response(response).await)
+        if status != 200 {
+            return Err(AgentError::from_response(response).await);
         }
+
+        let stream_timeout = self.stream_timeout;
+        super::transform::stream_with_transform(
+            event_tx,
+            transform,
+            move |sink: Sender<ProviderEvent>| {
+                Box::pin(async move { parse_sse(response, &sink, stream_timeout).await })
+            },
+        )
+        .await
     }
 
     async fn do_list_models(&self) -> Result<Vec<crate::model::ModelInfo>, AgentError> {
@@ -231,7 +250,16 @@ impl Provider for Anthropic {
             let long_context = model.id.ends_with(shared::LONG_CONTEXT_SUFFIX);
 
             debug!(model = %model.id, num_messages = messages.len(), thinking = ?opts.thinking, fast, long_context, "sending API request");
-            self.do_stream_request(&body, event_tx, fast, long_context)
+
+            let (transform, body) = if let Some(path) = &self.transform {
+                let auth = self.auth.lock().unwrap().clone();
+                TransformProcess::spawn_and_request(Some(path), body, &auth.headers, &model.id)
+                    .await?
+            } else {
+                (None, body)
+            };
+
+            self.do_stream_request(&body, event_tx, fast, long_context, transform)
                 .await
         })
     }

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -11,6 +12,7 @@ use tracing::{debug, warn};
 
 use super::openai::responses;
 use super::openai_compat;
+use super::transform::TransformProcess;
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig};
@@ -90,6 +92,7 @@ pub struct Copilot {
     auth: Arc<Mutex<Option<CopilotAuth>>>,
     resolved_auth: Option<Arc<Mutex<super::ResolvedAuth>>>,
     system_prefix: Option<String>,
+    transform: Option<PathBuf>,
     models: Arc<Mutex<HashMap<String, CopilotModel>>>,
 }
 
@@ -102,6 +105,7 @@ impl Copilot {
             auth: Arc::default(),
             resolved_auth: None,
             system_prefix: None,
+            transform: None,
             models: Arc::default(),
         })
     }
@@ -116,12 +120,18 @@ impl Copilot {
             auth: Arc::default(),
             resolved_auth: Some(auth),
             system_prefix: None,
+            transform: None,
             models: Arc::default(),
         }
     }
 
     pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
         self.system_prefix = prefix;
+        self
+    }
+
+    pub(crate) fn with_transform(mut self, path: Option<PathBuf>) -> Self {
+        self.transform = path;
         self
     }
 
@@ -217,6 +227,10 @@ impl Copilot {
             body["tools"] = wire_tools;
         }
 
+        let (transform, body) =
+            TransformProcess::spawn_and_request(self.transform.as_deref(), body, &[], &model.id)
+                .await?;
+
         let request = self
             .build_post(
                 &auth,
@@ -226,16 +240,28 @@ impl Copilot {
             )?
             .body(serde_json::to_vec(&body)?)?;
         let response = self.client.send_async(request).await?;
-        if response.status().is_success() {
-            openai_compat::parse_sse(
-                BufReader::new(response.into_body()),
-                event_tx,
-                self.stream_timeout,
-            )
-            .await
-        } else {
-            Err(AgentError::from_response(response).await)
+        if !response.status().is_success() {
+            if let Some(tf) = transform {
+                tf.shutdown().await;
+            }
+            return Err(AgentError::from_response(response).await);
         }
+        let stream_timeout = self.stream_timeout;
+        super::transform::stream_with_transform(
+            event_tx,
+            transform,
+            move |sink: Sender<ProviderEvent>| {
+                Box::pin(async move {
+                    openai_compat::parse_sse(
+                        BufReader::new(response.into_body()),
+                        &sink,
+                        stream_timeout,
+                    )
+                    .await
+                })
+            },
+        )
+        .await
     }
 
     async fn stream_responses(
@@ -259,6 +285,7 @@ impl Copilot {
             event_tx,
             &resolved,
             self.stream_timeout,
+            self.transform.as_deref(),
         )
         .await
     }
@@ -283,16 +310,32 @@ impl Copilot {
         });
         thinking.apply_to_body(&mut body, &model.id);
 
+        let (transform, body) =
+            TransformProcess::spawn_and_request(self.transform.as_deref(), body, &[], &model.id)
+                .await?;
+
         let request = self
             .build_post(&auth, MESSAGES_PATH, Some("conversation-agent"), &body)?
             .header("anthropic-version", "2023-06-01")
             .body(serde_json::to_vec(&body)?)?;
         let response = self.client.send_async(request).await?;
-        if response.status().is_success() {
-            super::anthropic::parse_sse(response, event_tx, self.stream_timeout).await
-        } else {
-            Err(AgentError::from_response(response).await)
+        if !response.status().is_success() {
+            if let Some(tf) = transform {
+                tf.shutdown().await;
+            }
+            return Err(AgentError::from_response(response).await);
         }
+        let stream_timeout = self.stream_timeout;
+        super::transform::stream_with_transform(
+            event_tx,
+            transform,
+            move |sink: Sender<ProviderEvent>| {
+                Box::pin(async move {
+                    super::anthropic::parse_sse(response, &sink, stream_timeout).await
+                })
+            },
+        )
+        .await
     }
 
     fn build_post(

--- a/maki-providers/src/providers/deepseek.rs
+++ b/maki-providers/src/providers/deepseek.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
@@ -98,6 +99,11 @@ impl DeepSeek {
 
     pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
         self.system_prefix = prefix;
+        self
+    }
+
+    pub(crate) fn with_transform(mut self, path: Option<PathBuf>) -> Self {
+        self.compat = self.compat.with_transform(path);
         self
     }
 }

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -39,6 +39,7 @@ struct DynamicProviderMeta {
     base: ProviderKind,
     system_prefix: Option<String>,
     has_auth: bool,
+    has_transform: bool,
     script_path: PathBuf,
     models: Vec<ScriptModel>,
 }
@@ -50,6 +51,8 @@ struct ScriptInfo {
     #[serde(default)]
     system_prefix: Option<String>,
     has_auth: bool,
+    #[serde(default)]
+    has_transform: bool,
 }
 
 #[derive(Deserialize)]
@@ -295,6 +298,7 @@ fn discover_in(dir: &Path) -> Vec<DynamicProviderMeta> {
             base,
             system_prefix: info.system_prefix.filter(|s| !s.is_empty()),
             has_auth: info.has_auth,
+            has_transform: info.has_transform,
             script_path: path,
             models,
         });
@@ -351,55 +355,71 @@ pub fn create(slug: &str, timeouts: super::Timeouts) -> Result<Box<dyn Provider>
     })?;
     let resolved = resolve_auth(meta)?;
     let auth = Arc::new(Mutex::new(resolved));
+    let transform_path = meta.has_transform.then(|| meta.script_path.clone());
 
     let inner: Box<dyn Provider> = match meta.base {
         ProviderKind::Anthropic => Box::new(
             Anthropic::with_auth(auth.clone(), timeouts)
-                .with_system_prefix(meta.system_prefix.clone()),
+                .with_system_prefix(meta.system_prefix.clone())
+                .with_transform(transform_path.clone()),
         ),
         ProviderKind::OpenAi => Box::new(
             OpenAi::with_auth(auth.clone(), timeouts)
-                .with_system_prefix(meta.system_prefix.clone()),
+                .with_system_prefix(meta.system_prefix.clone())
+                .with_transform(transform_path.clone()),
         ),
-        ProviderKind::Google => Box::new(Google::with_auth(auth.clone(), timeouts)),
+        ProviderKind::Google => Box::new(
+            Google::with_auth(auth.clone(), timeouts).with_transform(transform_path.clone()),
+        ),
         ProviderKind::Copilot => Box::new(
             Copilot::with_auth(auth.clone(), timeouts)
-                .with_system_prefix(meta.system_prefix.clone()),
+                .with_system_prefix(meta.system_prefix.clone())
+                .with_transform(transform_path.clone()),
         ),
         ProviderKind::Ollama => Box::new(
             LocalEndpoint::with_auth(&OLLAMA, auth.clone(), timeouts)
-                .with_system_prefix(meta.system_prefix.clone()),
+                .with_system_prefix(meta.system_prefix.clone())
+                .with_transform(transform_path.clone()),
         ),
         ProviderKind::LlamaCpp => Box::new(
             LocalEndpoint::with_auth(&LLAMACPP, auth.clone(), timeouts)
-                .with_system_prefix(meta.system_prefix.clone()),
+                .with_system_prefix(meta.system_prefix.clone())
+                .with_transform(transform_path.clone()),
         ),
         ProviderKind::Mistral => Box::new(
             Mistral::with_auth(auth.clone(), timeouts)
-                .with_system_prefix(meta.system_prefix.clone()),
+                .with_system_prefix(meta.system_prefix.clone())
+                .with_transform(transform_path.clone()),
         ),
         ProviderKind::Zai => Box::new(
-            Zai::with_auth(auth.clone(), timeouts).with_system_prefix(meta.system_prefix.clone()),
+            Zai::with_auth(auth.clone(), timeouts)
+                .with_system_prefix(meta.system_prefix.clone())
+                .with_transform(transform_path.clone()),
         ),
         ProviderKind::Synthetic => Box::new(
             Synthetic::with_auth(auth.clone(), timeouts)
-                .with_system_prefix(meta.system_prefix.clone()),
+                .with_system_prefix(meta.system_prefix.clone())
+                .with_transform(transform_path.clone()),
         ),
         ProviderKind::DeepSeek => Box::new(
             DeepSeek::with_auth(auth.clone(), timeouts)
-                .with_system_prefix(meta.system_prefix.clone()),
+                .with_system_prefix(meta.system_prefix.clone())
+                .with_transform(transform_path.clone()),
         ),
         ProviderKind::OpenRouter => Box::new(
             OpenRouter::with_auth(auth.clone(), timeouts)
-                .with_system_prefix(meta.system_prefix.clone()),
+                .with_system_prefix(meta.system_prefix.clone())
+                .with_transform(transform_path.clone()),
         ),
         ProviderKind::TensorX => Box::new(
             TensorX::with_auth(auth.clone(), timeouts)
-                .with_system_prefix(meta.system_prefix.clone()),
+                .with_system_prefix(meta.system_prefix.clone())
+                .with_transform(transform_path.clone()),
         ),
         ProviderKind::Opencode => Box::new(
             Opencode::with_auth(auth.clone(), timeouts)
-                .with_system_prefix(meta.system_prefix.clone()),
+                .with_system_prefix(meta.system_prefix.clone())
+                .with_transform(transform_path.clone()),
         ),
     };
 
@@ -600,11 +620,16 @@ mod tests {
         assert_eq!(info.display_name, "Test");
         assert_eq!(info.base, "anthropic");
         assert!(info.has_auth);
+        assert!(!info.has_transform);
         assert!(info.system_prefix.is_none());
 
         let with_prefix = r#"{"display_name": "T", "base": "openai", "has_auth": false, "system_prefix": "You are X."}"#;
         let info: ScriptInfo = serde_json::from_str(with_prefix).unwrap();
         assert_eq!(info.system_prefix.as_deref(), Some("You are X."));
+
+        let with_transform = r#"{"display_name": "T", "base": "anthropic", "has_auth": false, "has_transform": true}"#;
+        let info: ScriptInfo = serde_json::from_str(with_transform).unwrap();
+        assert!(info.has_transform);
     }
 
     #[test]
@@ -653,7 +678,22 @@ mod tests {
         assert_eq!(providers[0].display_name, "Test");
         assert_eq!(providers[0].base, ProviderKind::Anthropic);
         assert!(providers[0].has_auth);
+        assert!(!providers[0].has_transform);
         assert!(providers[0].models.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discover_detects_transform_support() {
+        let tmp = TempDir::new().unwrap();
+        write_script(
+            tmp.path(),
+            "transform-provider",
+            r#"{"display_name": "T", "base": "openai", "has_auth": false, "has_transform": true}"#,
+        );
+        let providers = discover_in(tmp.path());
+        assert_eq!(providers.len(), 1);
+        assert!(providers[0].has_transform);
     }
 
     #[cfg(unix)]

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -15,6 +16,7 @@ use crate::{
     StreamResponse, ThinkingConfig, TokenUsage,
 };
 
+use super::transform::TransformProcess;
 use super::{KeyPool, ResolvedAuth, http_client, next_sse_line};
 
 const BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
@@ -94,6 +96,7 @@ pub struct Google {
     auth: Arc<Mutex<ResolvedAuth>>,
     key_pool: Option<KeyPool>,
     stream_timeout: Duration,
+    transform: Option<PathBuf>,
 }
 
 impl Google {
@@ -105,6 +108,7 @@ impl Google {
             auth: Arc::new(Mutex::new(resolved)),
             key_pool: Some(pool),
             stream_timeout: timeouts.stream,
+            transform: None,
         })
     }
 
@@ -117,7 +121,13 @@ impl Google {
             auth,
             key_pool: None,
             stream_timeout: timeouts.stream,
+            transform: None,
         }
+    }
+
+    pub(crate) fn with_transform(mut self, path: Option<PathBuf>) -> Self {
+        self.transform = path;
+        self
     }
 
     fn build_request(&self, method: &str, url: &str) -> isahc::http::request::Builder {
@@ -199,6 +209,14 @@ impl Google {
         thinking: ThinkingConfig,
     ) -> Result<StreamResponse, AgentError> {
         let body = self.build_body(model, messages, system, tools, thinking);
+        let auth = self.auth.lock().unwrap().clone();
+        let (transform, body) = TransformProcess::spawn_and_request(
+            self.transform.as_deref(),
+            body,
+            &auth.headers,
+            &model.id,
+        )
+        .await?;
         let url = self.stream_url(&model.id);
         let json_body = serde_json::to_vec(&body)?;
 
@@ -210,11 +228,21 @@ impl Google {
         let response = self.client.send_async(request).await?;
         let status = response.status().as_u16();
 
-        if status == 200 {
-            parse_sse(response, event_tx, self.stream_timeout).await
-        } else {
-            Err(AgentError::from_response(response).await)
+        if status != 200 {
+            if let Some(tf) = transform {
+                tf.shutdown().await;
+            }
+            return Err(AgentError::from_response(response).await);
         }
+        let stream_timeout = self.stream_timeout;
+        super::transform::stream_with_transform(
+            event_tx,
+            transform,
+            move |sink: Sender<ProviderEvent>| {
+                Box::pin(async move { parse_sse(response, &sink, stream_timeout).await })
+            },
+        )
+        .await
     }
 }
 

--- a/maki-providers/src/providers/local.rs
+++ b/maki-providers/src/providers/local.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
@@ -66,6 +67,11 @@ impl LocalEndpoint {
 
     pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
         self.system_prefix = prefix;
+        self
+    }
+
+    pub(crate) fn with_transform(mut self, path: Option<PathBuf>) -> Self {
+        self.compat = self.compat.with_transform(path);
         self
     }
 

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
@@ -174,6 +175,11 @@ impl Mistral {
 
     pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
         self.system_prefix = prefix;
+        self
+    }
+
+    pub(crate) fn with_transform(mut self, path: Option<PathBuf>) -> Self {
+        self.compat = self.compat.with_transform(path);
         self
     }
 }

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod opencode;
 pub(crate) mod openrouter;
 pub(crate) mod synthetic;
 pub(crate) mod tensorx;
+pub(crate) mod transform;
 pub(crate) mod zai;
 
 const LOW_SPEED_BYTES_PER_SEC: u32 = 1;

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
@@ -35,6 +36,7 @@ pub struct OpenAi {
     auth: Arc<Mutex<ResolvedAuth>>,
     storage: Option<StateDir>,
     system_prefix: Option<String>,
+    transform: Option<PathBuf>,
 }
 
 impl OpenAi {
@@ -47,6 +49,7 @@ impl OpenAi {
             auth: Arc::new(Mutex::new(resolved)),
             storage: Some(storage),
             system_prefix: None,
+            transform: None,
         })
     }
 
@@ -59,11 +62,18 @@ impl OpenAi {
             auth,
             storage: None,
             system_prefix: None,
+            transform: None,
         }
     }
 
     pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
         self.system_prefix = prefix;
+        self
+    }
+
+    pub(crate) fn with_transform(mut self, path: Option<PathBuf>) -> Self {
+        self.compat = self.compat.with_transform(path.clone());
+        self.transform = path;
         self
     }
 
@@ -164,6 +174,7 @@ impl Provider for OpenAi {
                             event_tx,
                             &codex_auth,
                             stream_timeout,
+                            self.transform.as_deref(),
                         )
                         .await
                     })

--- a/maki-providers/src/providers/openai/responses.rs
+++ b/maki-providers/src/providers/openai/responses.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+use std::path::Path;
 use std::time::{Duration, Instant};
 
 use flume::Sender;
@@ -6,6 +8,7 @@ use isahc::{HttpClient, Request};
 use serde_json::{Value, json};
 use tracing::{debug, warn};
 
+use super::super::transform::TransformProcess;
 use crate::providers::ResolvedAuth;
 use crate::{
     AgentError, ContentBlock, Message, ProviderEvent, Role, StopReason, StreamResponse, TokenUsage,
@@ -143,11 +146,22 @@ pub(crate) async fn do_stream(
     event_tx: &Sender<ProviderEvent>,
     auth: &ResolvedAuth,
     stream_timeout: Duration,
+    transform_path: Option<&Path>,
 ) -> Result<StreamResponse, AgentError> {
     let base = auth.base_url.as_deref().ok_or_else(|| AgentError::Config {
         message: "Responses API requires a base_url in auth".into(),
     })?;
-    let json_body = serde_json::to_vec(body)?;
+    let transform = if let Some(path) = transform_path {
+        Some(TransformProcess::spawn(path)?)
+    } else {
+        None
+    };
+    let body = if let Some(tf) = &transform {
+        Cow::Owned(tf.request(body, &auth.headers, &model.id).await?)
+    } else {
+        Cow::Borrowed(body)
+    };
+    let json_body = serde_json::to_vec(&body)?;
 
     let mut builder = Request::builder()
         .method("POST")
@@ -168,16 +182,23 @@ pub(crate) async fn do_stream(
     let response = client.send_async(request).await?;
     let status = response.status().as_u16();
 
-    if status == 200 {
-        parse_sse(
-            BufReader::new(response.into_body()),
-            event_tx,
-            stream_timeout,
-        )
-        .await
-    } else {
-        Err(AgentError::from_response(response).await)
+    if status != 200 {
+        if let Some(tf) = transform {
+            tf.shutdown().await;
+        }
+        return Err(AgentError::from_response(response).await);
     }
+
+    super::super::transform::stream_with_transform(
+        event_tx,
+        transform,
+        move |sink: Sender<ProviderEvent>| {
+            Box::pin(async move {
+                parse_sse(BufReader::new(response.into_body()), &sink, stream_timeout).await
+            })
+        },
+    )
+    .await
 }
 
 struct ToolAccumulator {

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use flume::Sender;
@@ -8,6 +9,7 @@ use serde_json::{Value, json};
 use tracing::{debug, warn};
 
 use super::ResolvedAuth;
+use super::transform::TransformProcess;
 use crate::{
     AgentError, ContentBlock, Message, ProviderEvent, Role, StopReason, StreamResponse, TokenUsage,
 };
@@ -26,6 +28,7 @@ pub(crate) struct OpenAiCompatProvider {
     client: HttpClient,
     config: &'static OpenAiCompatConfig,
     stream_timeout: Duration,
+    transform: Option<PathBuf>,
 }
 
 impl OpenAiCompatProvider {
@@ -34,7 +37,13 @@ impl OpenAiCompatProvider {
             client: super::http_client(timeouts),
             config,
             stream_timeout: timeouts.stream,
+            transform: None,
         }
+    }
+
+    pub(crate) fn with_transform(mut self, path: Option<PathBuf>) -> Self {
+        self.transform = path;
+        self
     }
 
     pub(crate) fn client(&self) -> &HttpClient {
@@ -145,7 +154,14 @@ impl OpenAiCompatProvider {
         event_tx: &Sender<ProviderEvent>,
         auth: &ResolvedAuth,
     ) -> Result<StreamResponse, AgentError> {
-        let json_body = serde_json::to_vec(body)?;
+        let (transform, body) = TransformProcess::spawn_and_request(
+            self.transform.as_deref(),
+            body.clone(),
+            &auth.headers,
+            &model.id,
+        )
+        .await?;
+        let json_body = serde_json::to_vec(&body)?;
         let mut request = self
             .build_request("POST", "/chat/completions", auth)
             .header("content-type", "application/json");
@@ -164,16 +180,24 @@ impl OpenAiCompatProvider {
         let response = self.client.send_async(request).await?;
         let status = response.status().as_u16();
 
-        if status == 200 {
-            parse_sse(
-                BufReader::new(response.into_body()),
-                event_tx,
-                self.stream_timeout,
-            )
-            .await
-        } else {
-            Err(AgentError::from_response(response).await)
+        if status != 200 {
+            if let Some(tf) = transform {
+                tf.shutdown().await;
+            }
+            return Err(AgentError::from_response(response).await);
         }
+
+        let stream_timeout = self.stream_timeout;
+        super::transform::stream_with_transform(
+            event_tx,
+            transform,
+            move |sink: Sender<ProviderEvent>| {
+                Box::pin(async move {
+                    parse_sse(BufReader::new(response.into_body()), &sink, stream_timeout).await
+                })
+            },
+        )
+        .await
     }
 
     pub async fn fetch_and_parse_models(

--- a/maki-providers/src/providers/opencode.rs
+++ b/maki-providers/src/providers/opencode.rs
@@ -16,6 +16,7 @@ use crate::provider::{BoxFuture, Provider};
 use crate::providers::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use crate::{AgentError, EffortScale, Message, ProviderEvent, RequestOptions, StreamResponse};
 
+use super::transform::TransformProcess;
 use super::{ResolvedAuth, http_client};
 use crate::providers::anthropic::shared;
 
@@ -195,6 +196,7 @@ pub struct Opencode {
     chat_compat: OpenAiCompatProvider,
     auth: Option<Arc<Mutex<ResolvedAuth>>>,
     system_prefix: Option<String>,
+    transform: Option<PathBuf>,
     stream_timeout: Duration,
 }
 
@@ -208,6 +210,7 @@ impl Opencode {
             chat_compat: OpenAiCompatProvider::new(&CATALOG_CHAT_CONFIG, timeouts),
             auth,
             system_prefix: None,
+            transform: None,
             stream_timeout: timeouts.stream,
         }
     }
@@ -222,6 +225,12 @@ impl Opencode {
 
     pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
         self.system_prefix = prefix;
+        self
+    }
+
+    pub(crate) fn with_transform(mut self, path: Option<PathBuf>) -> Self {
+        self.chat_compat = self.chat_compat.with_transform(path.clone());
+        self.transform = path;
         self
     }
 
@@ -273,6 +282,15 @@ impl Opencode {
         );
         body["model"] = json!(model.id);
         body["stream"] = json!(true);
+
+        let (transform, body) = TransformProcess::spawn_and_request(
+            self.transform.as_deref(),
+            body,
+            &auth.headers,
+            &model.id,
+        )
+        .await?;
+
         let json_body = serde_json::to_vec(&body)?;
         let mut rb = Request::builder()
             .method("POST")
@@ -294,11 +312,21 @@ impl Opencode {
         let response = self.client.send_async(request).await?;
         let status = response.status().as_u16();
 
-        if status == 200 {
-            crate::providers::anthropic::parse_sse(response, event_tx, self.stream_timeout).await
-        } else {
-            Err(AgentError::from_response(response).await)
+        if status != 200 {
+            return Err(AgentError::from_response(response).await);
         }
+
+        let stream_timeout = self.stream_timeout;
+        super::transform::stream_with_transform(
+            event_tx,
+            transform,
+            move |sink: Sender<ProviderEvent>| {
+                Box::pin(async move {
+                    crate::providers::anthropic::parse_sse(response, &sink, stream_timeout).await
+                })
+            },
+        )
+        .await
     }
 }
 

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
@@ -54,6 +55,11 @@ impl OpenRouter {
 
     pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
         self.system_prefix = prefix;
+        self
+    }
+
+    pub(crate) fn with_transform(mut self, path: Option<PathBuf>) -> Self {
+        self.compat = self.compat.with_transform(path);
         self
     }
 }

--- a/maki-providers/src/providers/synthetic.rs
+++ b/maki-providers/src/providers/synthetic.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
@@ -105,6 +106,11 @@ impl Synthetic {
             key_pool: None,
             system_prefix: None,
         }
+    }
+
+    pub(crate) fn with_transform(mut self, path: Option<PathBuf>) -> Self {
+        self.compat = self.compat.with_transform(path);
+        self
     }
 
     pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {

--- a/maki-providers/src/providers/tensorx.rs
+++ b/maki-providers/src/providers/tensorx.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
@@ -63,6 +64,11 @@ impl TensorX {
 
     pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
         self.system_prefix = prefix;
+        self
+    }
+
+    pub(crate) fn with_transform(mut self, path: Option<PathBuf>) -> Self {
+        self.compat = self.compat.with_transform(path);
         self
     }
 }

--- a/maki-providers/src/providers/transform.rs
+++ b/maki-providers/src/providers/transform.rs
@@ -1,0 +1,459 @@
+use std::io;
+use std::path::Path;
+use std::time::Duration;
+
+use async_lock::Mutex;
+use async_process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use flume::Sender;
+use futures_lite::io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader};
+use serde_json::{Value, json};
+use tracing::warn;
+
+use crate::model::TokenUsage;
+use crate::types::StopReason;
+use crate::{AgentError, Message, ProviderEvent, StreamResponse};
+
+type LocalBoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
+
+const REQUEST_STAGE: &str = "request";
+const RESPONSE_DELTA_STAGE: &str = "response_delta";
+const RESPONSE_END_STAGE: &str = "response_end";
+const LINE_TIMEOUT: Duration = Duration::from_secs(30);
+
+const NO_TRANSFORM: &str = "transform subprocess produced no output line";
+
+/// Outcome of an `response_end`-stage transform. Each field is `Some` only
+/// when the transform returned a replacement value; `None` means passthrough.
+pub(crate) struct TransformedEnd {
+    pub message: Option<Message>,
+    pub usage: Option<TokenUsage>,
+    pub stop_reason: Option<StopReason>,
+}
+
+pub(crate) struct TransformProcess {
+    stdin: Mutex<ChildStdin>,
+    stdout: Mutex<BufReader<ChildStdout>>,
+    child: Option<Child>,
+}
+
+impl TransformProcess {
+    pub(crate) fn spawn(script: &Path) -> Result<Self, AgentError> {
+        let mut child = Command::new(script)
+            .arg("transform")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| transform_start_error(script, e))?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| transform_pipe_error(script))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| transform_pipe_error(script))?;
+
+        let stderr = child.stderr.take();
+        if let Some(stderr) = stderr {
+            smol::spawn(stderr_drain(stderr)).detach();
+        }
+
+        Ok(Self {
+            stdin: Mutex::new(stdin),
+            stdout: Mutex::new(BufReader::new(stdout)),
+            child: Some(child),
+        })
+    }
+
+    /// Spawns a transform for `path` (when set) and rewrites `body` through it.
+    /// Returns the spawned process (if any) alongside the transformed body.
+    pub(crate) async fn spawn_and_request(
+        path: Option<&Path>,
+        body: Value,
+        headers: &[(String, String)],
+        model: &str,
+    ) -> Result<(Option<Self>, Value), AgentError> {
+        let Some(path) = path else {
+            return Ok((None, body));
+        };
+        let tf = Self::spawn(path)?;
+        let out = tf.request(&body, headers, model).await?;
+        Ok((Some(tf), out))
+    }
+
+    pub(crate) async fn request(
+        &self,
+        body: &Value,
+        headers: &[(String, String)],
+        model: &str,
+    ) -> Result<Value, AgentError> {
+        let payload = json!({
+            "stage": REQUEST_STAGE,
+            "body": body,
+            "headers": serde_json::to_value(headers)?,
+            "model": model,
+        });
+        let reply = self.exchange(&payload).await?;
+        reply
+            .get("body")
+            .cloned()
+            .ok_or_else(|| AgentError::Config {
+                message: NO_TRANSFORM.into(),
+            })
+    }
+
+    pub(crate) async fn delta(
+        &self,
+        event: &ProviderEvent,
+    ) -> Result<Option<ProviderEvent>, AgentError> {
+        let payload = serde_json::to_value(event)?;
+        let payload = json!({ "stage": RESPONSE_DELTA_STAGE, "event": payload });
+        let reply = self.exchange(&payload).await?;
+        if reply.is_null() || reply.as_object().is_some_and(|m| m.is_empty()) {
+            return Ok(None);
+        }
+        if let Some(ev) = reply.get("event") {
+            if ev.is_null() {
+                return Ok(None);
+            }
+            return Ok(Some(serde_json::from_value(ev.clone())?));
+        }
+        Ok(None)
+    }
+
+    pub(crate) async fn end(
+        &self,
+        response: &StreamResponse,
+    ) -> Result<TransformedEnd, AgentError> {
+        let payload = json!({
+            "stage": RESPONSE_END_STAGE,
+            "message": serde_json::to_value(&response.message)?,
+            "usage": serde_json::to_value(response.usage)?,
+            "stop_reason": serde_json::to_value(response.stop_reason)?,
+        });
+        let reply = self.exchange(&payload).await?;
+        let message = match reply.get("message") {
+            Some(m) if !m.is_null() => Some(serde_json::from_value(m.clone())?),
+            _ => None,
+        };
+        let usage = match reply.get("usage") {
+            Some(u) if !u.is_null() => Some(serde_json::from_value(u.clone())?),
+            _ => None,
+        };
+        let stop_reason = match reply.get("stop_reason") {
+            Some(s) if !s.is_null() => Some(serde_json::from_value(s.clone())?),
+            _ => None,
+        };
+        Ok(TransformedEnd {
+            message,
+            usage,
+            stop_reason,
+        })
+    }
+
+    async fn exchange(&self, payload: &Value) -> Result<Value, AgentError> {
+        let mut buf = serde_json::to_vec(payload)?;
+        buf.push(b'\n');
+
+        let mut stdin = self.stdin.lock().await;
+        stdin.write_all(&buf).await.map_err(transform_write_error)?;
+        stdin.flush().await.map_err(transform_write_error)?;
+        drop(stdin);
+
+        let mut stdout = self.stdout.lock().await;
+        let line = read_line(&mut *stdout, LINE_TIMEOUT).await?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            return Err(AgentError::Config {
+                message: NO_TRANSFORM.into(),
+            });
+        }
+        serde_json::from_str::<Value>(trimmed).map_err(|e| AgentError::Config {
+            message: format!("transform subprocess produced invalid JSON: {e}"),
+        })
+    }
+
+    pub(crate) async fn shutdown(mut self) {
+        let _ = self.stdin.lock().await.close().await;
+        if let Some(child) = self.child.as_mut() {
+            let _ = futures_lite::future::or(
+                async {
+                    let _ = child.status().await;
+                },
+                async {
+                    smol::Timer::after(Duration::from_secs(2)).await;
+                },
+            )
+            .await;
+        }
+    }
+}
+
+impl Drop for TransformProcess {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            kill_process_group(child.id());
+            let _ = child.try_status();
+        }
+    }
+}
+
+async fn stderr_drain(stderr: async_process::ChildStderr) {
+    let mut reader = BufReader::new(stderr);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line).await {
+            Ok(0) | Err(_) => break,
+            Ok(_) => {
+                let trimmed = line.trim();
+                if !trimmed.is_empty() {
+                    warn!(target: "transform", "{trimmed}");
+                }
+            }
+        }
+    }
+}
+
+async fn read_line<R: AsyncBufRead + Unpin>(
+    reader: &mut R,
+    deadline: Duration,
+) -> Result<String, AgentError> {
+    let mut line = String::new();
+    futures_lite::future::or(
+        async {
+            reader
+                .read_line(&mut line)
+                .await
+                .map_err(transform_read_error)?;
+            Ok(line)
+        },
+        async {
+            smol::Timer::after(deadline).await;
+            Err(AgentError::Config {
+                message: format!(
+                    "transform subprocess timed out after {}s",
+                    deadline.as_secs()
+                ),
+            })
+        },
+    )
+    .await
+}
+
+#[cfg(unix)]
+fn kill_process_group(pid: u32) {
+    unsafe {
+        libc::killpg(pid as i32, libc::SIGKILL);
+    }
+}
+
+#[cfg(not(unix))]
+fn kill_process_group(_pid: u32) {}
+
+fn transform_start_error(script: &Path, e: io::Error) -> AgentError {
+    AgentError::Config {
+        message: format!("failed to spawn {} transform: {e}", script.display()),
+    }
+}
+
+fn transform_pipe_error(script: &Path) -> AgentError {
+    AgentError::Config {
+        message: format!("{} transform: no stdio pipe captured", script.display()),
+    }
+}
+
+fn transform_write_error(e: io::Error) -> AgentError {
+    AgentError::Config {
+        message: format!("transform subprocess write failed: {e}"),
+    }
+}
+
+fn transform_read_error(e: io::Error) -> AgentError {
+    AgentError::Config {
+        message: format!("transform subprocess read failed: {e}"),
+    }
+}
+
+pub(crate) struct TransformingSender<'a> {
+    inner: &'a Sender<ProviderEvent>,
+    transform: &'a TransformProcess,
+}
+
+impl<'a> TransformingSender<'a> {
+    pub(crate) fn new(inner: &'a Sender<ProviderEvent>, transform: &'a TransformProcess) -> Self {
+        Self { inner, transform }
+    }
+
+    pub(crate) async fn send(&self, event: ProviderEvent) -> Result<(), AgentError> {
+        match self.transform.delta(&event).await {
+            Ok(Some(transformed)) => {
+                self.inner.send_async(transformed).await?;
+            }
+            Ok(None) => {
+                self.inner.send_async(event).await?;
+            }
+            Err(e) => return Err(e),
+        }
+        Ok(())
+    }
+}
+
+pub(crate) async fn forward_events(
+    bridge_rx: flume::Receiver<ProviderEvent>,
+    sender: TransformingSender<'_>,
+) {
+    while let Ok(event) = bridge_rx.recv_async().await {
+        if sender.send(event).await.is_err() {
+            break;
+        }
+    }
+}
+
+const BRIDGE_BOUND: usize = 64;
+
+/// Drives a streaming parse through an optional transform subprocess.
+///
+/// When a transform is set, `parse` owns the bridge sender so that returning
+/// (or erroring) drops it and unblocks [`forward_events`] on the receiver.
+/// The transform's [`TransformProcess::end`] rewrites the final message.
+pub(crate) async fn stream_with_transform(
+    event_tx: &Sender<ProviderEvent>,
+    transform: Option<TransformProcess>,
+    parse: impl FnOnce(
+        Sender<ProviderEvent>,
+    ) -> LocalBoxFuture<'static, Result<StreamResponse, AgentError>>,
+) -> Result<StreamResponse, AgentError> {
+    let Some(tf) = transform else {
+        return parse(event_tx.clone()).await;
+    };
+    let (bridge_tx, bridge_rx) = flume::bounded::<ProviderEvent>(BRIDGE_BOUND);
+    let sender = TransformingSender::new(event_tx, &tf);
+    let (r, _) =
+        futures_lite::future::zip(parse(bridge_tx), forward_events(bridge_rx, sender)).await;
+    match r {
+        Ok(mut response) => {
+            let end = tf.end(&response).await?;
+            if let Some(msg) = end.message {
+                response.message = msg;
+            }
+            if let Some(usage) = end.usage {
+                response.usage = usage;
+            }
+            if let Some(stop_reason) = end.stop_reason {
+                response.stop_reason = Some(stop_reason);
+            }
+            tf.shutdown().await;
+            Ok(response)
+        }
+        Err(e) => {
+            tf.shutdown().await;
+            Err(e)
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::TempDir;
+
+    fn write_sh_transform(dir: &Path, name: &str, body: &str) -> std::path::PathBuf {
+        let path = dir.join(name);
+        let script = format!("#!/bin/sh\n{body}\n");
+        let mut file = std::fs::File::create(&path).unwrap();
+        use std::io::Write;
+        file.write_all(script.as_bytes()).unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    #[test]
+    fn request_transform_passthrough_via_cat() {
+        let tmp = TempDir::new().unwrap();
+        let script = write_sh_transform(tmp.path(), "passthrough", "awk '{ print; fflush() }'");
+        smol::block_on(async {
+            let process = TransformProcess::spawn(&script).unwrap();
+            let body = json!({"prompt": "hello"});
+            let result = process
+                .request(
+                    &body,
+                    &[("authorization".into(), "Bearer x".into())],
+                    "test-model",
+                )
+                .await
+                .unwrap();
+            assert_eq!(result["prompt"], "hello");
+            process.shutdown().await;
+        });
+    }
+
+    #[test]
+    fn request_transform_mutates_body() {
+        let tmp = TempDir::new().unwrap();
+        let script = write_sh_transform(
+            tmp.path(),
+            "mutator",
+            r#"
+while IFS= read -r line; do
+  echo "$line" | stdbuf -oL jq -c '.body.metadata = {"user_id":"u123"} | {body: .body}'
+done
+"#,
+        );
+        smol::block_on(async {
+            let process = TransformProcess::spawn(&script).unwrap();
+            let body = json!({"messages": []});
+            let result = process.request(&body, &[], "m").await.unwrap();
+            assert_eq!(result["metadata"]["user_id"], "u123");
+            process.shutdown().await;
+        });
+    }
+
+    #[test]
+    fn request_transform_crash_aborts() {
+        let tmp = TempDir::new().unwrap();
+        let script = write_sh_transform(tmp.path(), "crasher", "exit 1");
+        smol::block_on(async {
+            let process = TransformProcess::spawn(&script).unwrap();
+            let result = process.request(&json!({}), &[], "m").await;
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn request_transform_invalid_json_errors() {
+        let tmp = TempDir::new().unwrap();
+        let script = write_sh_transform(tmp.path(), "garbage", r#"echo 'not json'"#);
+        smol::block_on(async {
+            let process = TransformProcess::spawn(&script).unwrap();
+            let result = process.request(&json!({}), &[], "m").await;
+            assert!(matches!(result, Err(AgentError::Config { .. })));
+            process.shutdown().await;
+        });
+    }
+
+    #[test]
+    fn delta_transform_passthrough() {
+        let tmp = TempDir::new().unwrap();
+        let script = write_sh_transform(tmp.path(), "delta-id", "awk '{ print; fflush() }'");
+        smol::block_on(async {
+            let process = TransformProcess::spawn(&script).unwrap();
+            let event = ProviderEvent::TextDelta { text: "x".into() };
+            let result = process.delta(&event).await.unwrap();
+            assert!(result.is_some());
+            let transformed = result.unwrap();
+            match transformed {
+                ProviderEvent::TextDelta { text } => assert_eq!(text, "x"),
+                _ => panic!("wrong variant"),
+            }
+            process.shutdown().await;
+        });
+    }
+}

--- a/maki-providers/src/providers/zai/mod.rs
+++ b/maki-providers/src/providers/zai/mod.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
@@ -212,6 +213,11 @@ impl Zai {
 
     pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
         self.system_prefix = prefix;
+        self
+    }
+
+    pub(crate) fn with_transform(mut self, path: Option<PathBuf>) -> Self {
+        self.compat = self.compat.with_transform(path);
         self
     }
 }

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -189,14 +189,14 @@ impl TitleSource for Message {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ProviderEvent {
     TextDelta { text: String },
     ThinkingDelta { text: String },
     ToolUseStart { id: String, name: String },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Display, IntoStaticStr)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Display, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum StopReason {

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -244,7 +244,12 @@ impl AgentLoop {
         .with_user_response_rx(Arc::clone(&self.answer_rx))
         .with_interrupt_source(Arc::clone(&self.queue) as Arc<dyn maki_agent::InterruptSource>)
         .with_cancel(cancel)
-        .with_mcp(self.mcp_handle.clone());
+        .with_mcp(self.mcp_handle.clone())
+        .with_provider_hooks(
+            self.lua_handle
+                .clone()
+                .map(|h| Arc::new(h) as Arc<dyn maki_agent::agent::ProviderHookSink + Send + Sync>),
+        );
 
         let result = agent.run(input).await;
         drop(agent);

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -58,6 +58,12 @@ pub fn run(model_arg: Option<String>, yolo: bool) -> Result<()> {
         .map(|h| h.collect_prompt_slots())
         .unwrap_or_default();
 
+    let hooks = plugin_host
+        .event_handle()
+        .map(|h| Arc::new(h) as Arc<dyn maki_agent::agent::ProviderHookSink + Send + Sync>);
+
+    let _plugin_host = plugin_host;
+
     maki_acp::run(maki_acp::AcpParams {
         model,
         config: config.agent,
@@ -67,5 +73,6 @@ pub fn run(model_arg: Option<String>, yolo: bool) -> Result<()> {
         mcp_handle,
         prompt_slots: Arc::new(prompt_slots),
         yolo,
+        hooks,
     })
 }

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -148,6 +148,9 @@ pub fn run(cli: Cli) -> Result<()> {
             timeouts,
             prompt_slots,
             fast,
+            hooks: plugin_host
+                .event_handle()
+                .map(|h| Arc::new(h) as Arc<dyn maki_agent::agent::ProviderHookSink + Send + Sync>),
         })
         .context("run sdk mode")?;
     } else if cli.print {

--- a/src/print.rs
+++ b/src/print.rs
@@ -8,6 +8,7 @@
 //! Check their docs before changing anything here.
 
 use std::io::{self, Read};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use clap::ValueEnum;
@@ -160,6 +161,8 @@ pub fn run(
         mcp_handle,
         initial_wd: cwd,
         fast,
+        hooks: lua_handle
+            .map(|h| Arc::new(h) as Arc<dyn maki_agent::agent::ProviderHookSink + Send + Sync>),
     });
 
     let HeadlessHandle {

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -434,6 +434,7 @@ pub struct SdkParams {
     pub timeouts: Timeouts,
     pub prompt_slots: ResolvedSlots,
     pub fast: bool,
+    pub hooks: Option<Arc<dyn maki_agent::agent::ProviderHookSink + Send + Sync>>,
 }
 
 struct Shared {
@@ -452,6 +453,7 @@ pub fn run(params: SdkParams) -> Result<()> {
         timeouts,
         prompt_slots,
         fast,
+        hooks,
     } = params;
     cli.warn_ignored_flags();
     if let Some(max) = cli.max_turns {
@@ -483,6 +485,7 @@ pub fn run(params: SdkParams) -> Result<()> {
         yolo: permission_mode == PermissionMode::BypassPermissions,
         system_prompt_override: cli.system_prompt.clone().filter(|s| !s.is_empty()),
         append_system_prompt: cli.append_system_prompt.clone().filter(|s| !s.is_empty()),
+        hooks,
     });
 
     let (out_tx, out_rx) = flume::unbounded::<String>();


### PR DESCRIPTION
Addresses the provider-hooks part of #243. The models hook and display hooks named in the issue are left for follow-up.

## What

Two additive ways to intercept provider traffic.

### Layer 1 — Lua plugin hooks

`maki.provider.register_request_hook({slug=..., callback=fn})` and `register_response_hook` rewrite the typed request/response view:

- **request**: `{ messages, system, tools }` before `provider.stream_message`.
- **response_end**: `{ message, usage, stop_reason }` after the `StreamResponse` is assembled.

Hooks target a slug derived from `Model.provider` + `Model.dynamic_slug` (`None` matches all). Registration order with plugin-name tiebreak, short-circuit via `{stop=true, value=...}`, skip+continue on error, 5s batched timeout. Gated by an additive `provider_hooks` permission; `ProviderHookStore` mirrors `AutocmdStore` and is cleared in `clear_plugin`.

### Layer 2 — dynamic-provider `transform` subcommand

Optional NDJSON subcommand for the final wire body (Anthropic `metadata.user_id`, OpenAI `response_format`, thinking-token quirks) that the `Provider` trait abstracts away. One long-lived subprocess per request exchanges one JSON line per stage. Opt-in via an additive `has_transform` bool in the existing `info` output; absent means passthrough. Crash mid-stream aborts; per-line timeout skips.

### Why the trait lives in maki-agent

`maki-lua` depends on `maki-agent`, not the reverse, so `stream_with_retry` cannot name `Request`/`EventHandle`. `ProviderHookSink` is a trait in maki-agent; maki-lua implements it on `EventHandle`. Same seam as `with_mcp`.

## Backwards compatibility (unchanged)

`Provider` trait, `ProviderEvent`, `ResolvedAuth`, dynamic-provider protocol (additive only), autocmd API, model id namespacing, plugin permission set.

## Verification

- `cargo build --workspace` clean.
- `cargo test --workspace`: 431 passed, 3 failed. All 3 pre-existing on `origin/main` (2 `instructions::load_instructions_empty_*` env failures; `tools::tests::audience_matrix_is_locked` flake from shared `ToolRegistry::native()` mutated by `GuardedMock`-registering tests). Reproduced on a clean `origin/main` checkout.
- `cargo fmt --all --check`, `cargo clippy --all --tests -- -D warnings`, `cargo machete`, `cargo run -p maki-docgen -- --check` all clean.
- Tests cover: noop sink, register/remove/clear_plugin, slug filter, short-circuit, error-skip-continue, no-hooks passthrough, response_end mutation, transform passthrough via `cat`, body mutation via `jq`, crash abort, invalid JSON, delta passthrough.

## AI use

Designed and implemented with AI assistance (Claude). Three review rounds (v1→v2→v3) self-reviewed against the maki-lua runtime, which surfaced the crate dependency direction and single-threaded Lua constraints. Happy to paste the design notes on request.
