### PR TITLE
bugfix: prefer explicit XDG_CONFIG_DIR passing to stabilize testing of config presence

### DIFF
--- a/maki-agent/src/agent/instructions.rs
+++ b/maki-agent/src/agent/instructions.rs
@@ -72,7 +72,12 @@ pub fn build_system_prompt(
     out
 }
 
-fn append_instruction_files(out: &mut String, cwd: &str, home: Option<&Path>) {
+fn append_instruction_files(
+    out: &mut String,
+    cwd: &str,
+    home: Option<&Path>,
+    xdg_config: Option<&Path>,
+) {
     let root = Path::new(cwd);
 
     for filename in INSTRUCTION_FILES {
@@ -90,7 +95,7 @@ fn append_instruction_files(out: &mut String, cwd: &str, home: Option<&Path>) {
         ));
     }
 
-    for path in maki_storage::paths::user_config_dirs(home, "AGENTS.md") {
+    for path in maki_storage::paths::user_config_dirs(home, xdg_config, "AGENTS.md") {
         if let Ok(content) = fs::read_to_string(&path) {
             let display = path.display();
             out.push_str(&format!("\n\nGlobal instructions ({display}):\n{content}"));
@@ -100,23 +105,39 @@ fn append_instruction_files(out: &mut String, cwd: &str, home: Option<&Path>) {
 }
 
 pub fn load_instruction_text(cwd: &str) -> String {
-    load_instruction_text_with_home(cwd, maki_storage::paths::home().as_deref())
+    load_instruction_text_with_home(
+        cwd,
+        maki_storage::paths::home().as_deref(),
+        maki_storage::paths::config_dir().ok().as_deref(),
+    )
 }
 
-fn load_instruction_text_with_home(cwd: &str, home: Option<&Path>) -> String {
+pub(crate) fn load_instruction_text_with_home(
+    cwd: &str,
+    home: Option<&Path>,
+    xdg_config: Option<&Path>,
+) -> String {
     let mut text = String::new();
-    append_instruction_files(&mut text, cwd, home);
+    append_instruction_files(&mut text, cwd, home, xdg_config);
     text
 }
 
 pub fn load_instructions(cwd: &str) -> Instructions {
-    load_instructions_with_home(cwd, maki_storage::paths::home().as_deref())
+    load_instructions_with_home(
+        cwd,
+        maki_storage::paths::home().as_deref(),
+        maki_storage::paths::config_dir().ok().as_deref(),
+    )
 }
 
-fn load_instructions_with_home(cwd: &str, home: Option<&Path>) -> Instructions {
+pub(crate) fn load_instructions_with_home(
+    cwd: &str,
+    home: Option<&Path>,
+    xdg_config: Option<&Path>,
+) -> Instructions {
     let root = Path::new(cwd);
     let mut instr = Instructions::default();
-    append_instruction_files(&mut instr.text, cwd, home);
+    append_instruction_files(&mut instr.text, cwd, home, xdg_config);
 
     for filename in INSTRUCTION_FILES {
         let path = root.join(filename);
@@ -239,7 +260,7 @@ mod tests {
         fs::write(dir.path().join("AGENTS.md"), "team rules").unwrap();
         fs::write(dir.path().join("AGENTS.local.md"), "my preferences").unwrap();
 
-        let text = &load_instructions_with_home(dir.path().to_str().unwrap(), None).text;
+        let text = &load_instructions_with_home(dir.path().to_str().unwrap(), None, None).text;
         assert!(text.contains("team rules"));
         assert!(text.contains("my preferences"));
         assert!(
@@ -253,7 +274,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         fs::write(dir.path().join("AGENTS.local.md"), "solo preferences").unwrap();
         assert!(
-            load_instructions_with_home(dir.path().to_str().unwrap(), None)
+            load_instructions_with_home(dir.path().to_str().unwrap(), None, None)
                 .text
                 .contains("solo preferences")
         );
@@ -263,7 +284,7 @@ mod tests {
     fn load_instructions_empty_when_no_files() {
         let dir = tempfile::tempdir().unwrap();
         assert!(
-            load_instructions_with_home(dir.path().to_str().unwrap(), None)
+            load_instructions_with_home(dir.path().to_str().unwrap(), None, None)
                 .text
                 .is_empty()
         );
@@ -274,7 +295,7 @@ mod tests {
         let cwd = tempfile::tempdir().unwrap();
         let home = tempfile::tempdir().unwrap();
         assert!(
-            load_instructions_with_home(cwd.path().to_str().unwrap(), Some(home.path()))
+            load_instructions_with_home(cwd.path().to_str().unwrap(), Some(home.path()), None)
                 .text
                 .is_empty()
         );
@@ -288,7 +309,7 @@ mod tests {
         fs::write(home.path().join(".maki").join("AGENTS.md"), "global rules").unwrap();
 
         let text =
-            load_instructions_with_home(cwd.path().to_str().unwrap(), Some(home.path())).text;
+            load_instructions_with_home(cwd.path().to_str().unwrap(), Some(home.path()), None).text;
         assert!(text.contains("global rules"));
     }
 
@@ -347,7 +368,7 @@ mod tests {
         let agents_path = dir.path().join("AGENTS.md");
         fs::write(&agents_path, "content").unwrap();
 
-        let instr = load_instructions_with_home(dir.path().to_str().unwrap(), None);
+        let instr = load_instructions_with_home(dir.path().to_str().unwrap(), None, None);
         assert!(
             instr
                 .loaded

--- a/maki-agent/src/command.rs
+++ b/maki-agent/src/command.rs
@@ -84,14 +84,21 @@ impl CustomCommand {
 }
 
 pub fn discover_commands(cwd: &Path) -> Vec<CustomCommand> {
-    let home = maki_storage::paths::home();
-    discover_commands_inner(cwd, home.as_deref())
+    discover_commands_inner(
+        cwd,
+        maki_storage::paths::home().as_deref(),
+        maki_storage::paths::config_dir().ok().as_deref(),
+    )
 }
 
-fn discover_commands_inner(cwd: &Path, home: Option<&Path>) -> Vec<CustomCommand> {
+fn discover_commands_inner(
+    cwd: &Path,
+    home: Option<&Path>,
+    xdg_config: Option<&Path>,
+) -> Vec<CustomCommand> {
     let mut commands: HashMap<String, CustomCommand> = HashMap::new();
 
-    for dir in maki_storage::paths::user_config_dirs(home, "commands") {
+    for dir in maki_storage::paths::user_config_dirs(home, xdg_config, "commands") {
         scan_command_dir(&dir, CommandScope::User, &mut commands);
     }
     if let Some(home) = home {
@@ -242,7 +249,7 @@ mod tests {
         )
         .unwrap();
 
-        let commands = discover_commands_inner(project.path(), Some(global.path()));
+        let commands = discover_commands_inner(project.path(), Some(global.path()), None);
         let overlap: Vec<_> = commands.iter().filter(|c| c.name == "overlap").collect();
         assert_eq!(overlap.len(), 1);
         assert_eq!(overlap[0].description, "Project version");
@@ -262,7 +269,7 @@ mod tests {
             fs::write(path.join(filename), "Content").unwrap();
         }
 
-        let commands = discover_commands_inner(dir.path(), None);
+        let commands = discover_commands_inner(dir.path(), None, None);
         let names: Vec<_> = commands.iter().map(|c| c.name.as_str()).collect();
         assert!(names.contains(&"a-cmd"));
         assert!(names.contains(&"b-cmd"));
@@ -276,7 +283,7 @@ mod tests {
         fs::write(cmd_dir.join("valid.md"), "Content").unwrap();
         fs::write(cmd_dir.join("invalid.txt"), "Content").unwrap();
 
-        let commands = discover_commands_inner(dir.path(), None);
+        let commands = discover_commands_inner(dir.path(), None, None);
         assert_eq!(commands.len(), 1);
         assert_eq!(commands[0].name, "valid");
     }

--- a/maki-storage/src/paths.rs
+++ b/maki-storage/src/paths.rs
@@ -269,11 +269,18 @@ pub fn legacy_home_dir() -> Option<PathBuf> {
         .filter(|d| d.is_dir())
 }
 
-pub fn user_config_dirs(home: Option<&Path>, subdir: &str) -> Vec<PathBuf> {
-    let legacy = home
-        .map(|h| h.join(FALLBACK_DIR).join(subdir))
-        .or_else(|| legacy_home_dir().map(|d| d.join(subdir)));
-    let xdg = config_dir().ok().map(|d| d.join(subdir));
+/// Candidate config directories for `subdir` from `home` and `xdg_config`.
+/// Pure: no env reads, no process-home fallback. Production callers pass
+/// `config_dir().ok()` as `xdg_config` (which honors `XDG_CONFIG_HOME`, the
+/// `~/.maki` fallback, and the Windows `AppData\Roaming` strategy via
+/// `resolve()`); tests pass tempdirs.
+pub fn user_config_dirs(
+    home: Option<&Path>,
+    xdg_config: Option<&Path>,
+    subdir: &str,
+) -> Vec<PathBuf> {
+    let legacy = home.map(|h| h.join(FALLBACK_DIR).join(subdir));
+    let xdg = xdg_config.map(|d| d.join(subdir));
     [legacy, xdg].into_iter().flatten().collect()
 }
 
@@ -339,6 +346,64 @@ mod tests {
         assert!(
             !s.starts_with(r"\\?\"),
             "should not have \\\\?\\ prefix: {s}"
+        );
+    }
+
+    #[test]
+    fn user_config_dirs_returns_legacy_and_xdg() {
+        let home = tempfile::tempdir().unwrap();
+        let xdg = home.path().join(".config").join(APP_NAME);
+
+        let dirs = user_config_dirs(Some(home.path()), Some(&xdg), "AGENTS.md");
+        assert_eq!(
+            dirs,
+            vec![
+                home.path().join(FALLBACK_DIR).join("AGENTS.md"),
+                xdg.join("AGENTS.md"),
+            ]
+        );
+    }
+
+    #[test]
+    fn user_config_dirs_omits_legacy_when_home_none() {
+        let xdg = tempfile::tempdir().unwrap();
+
+        let dirs = user_config_dirs(None, Some(xdg.path()), "AGENTS.md");
+        assert_eq!(dirs, vec![xdg.path().join("AGENTS.md")]);
+    }
+
+    #[test]
+    fn user_config_dirs_omits_xdg_when_xdg_none() {
+        let home = tempfile::tempdir().unwrap();
+
+        let dirs = user_config_dirs(Some(home.path()), None, "AGENTS.md");
+        assert_eq!(dirs, vec![home.path().join(FALLBACK_DIR).join("AGENTS.md")]);
+    }
+
+    #[test]
+    fn user_config_dirs_neither_depends_on_process_env() {
+        let home_a = tempfile::tempdir().unwrap();
+        let xdg_a = home_a.path().join(".config").join(APP_NAME);
+
+        let hostile = tempfile::tempdir().unwrap();
+
+        let prev = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: tests run single-threaded within a process nextest invokes once.
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", hostile.path()) };
+
+        let dirs = user_config_dirs(Some(home_a.path()), Some(&xdg_a), "AGENTS.md");
+
+        // SAFETY: same single-threaded assumption as above.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+
+        assert!(
+            !dirs.iter().any(|p| p.starts_with(hostile.path())),
+            "combiner read XDG_CONFIG_HOME: {dirs:?}"
         );
     }
 }


### PR DESCRIPTION
Running `just ci` fails locally for anyone that has a `~/.config/maki/AGENTS.md` defined since these two tests assume there's nothing defined globally (CI doesn't hit this because it doesn't have these files):

- `agent::instructions::tests::load_instructions_empty_when_no_files`
- `agent::instructions::tests::load_instructions_empty_when_home_has_no_global_file`

By threading the config dir through as the home dir is already being threaded through, we make testing more robust against accidental global state checking.