### PR TITLE
types: base58-encoded UUIDv7 EntityId newtype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.13.6"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c290bfa00c6b52339db66f8e9cf711d5f08530800529f7d619ff24d6cba253d0"
+checksum = "1fec685c82933a27b9d0c34594749b8b47d26ab4c2fb0e7bee268798cebe1c8b"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -128,9 +128,18 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "arboard"
@@ -155,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -259,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
  "async-io",
  "async-lock",
@@ -316,7 +325,7 @@ dependencies = [
  "manyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -332,14 +341,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "quote-use",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -409,15 +418,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -464,20 +473,26 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytecount"
@@ -487,9 +502,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 
 [[package]]
 name = "byteorder"
@@ -505,9 +520,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cast"
@@ -526,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -550,9 +565,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -591,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -613,14 +628,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -680,9 +695,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -778,9 +793,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -788,18 +803,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -808,7 +823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "base64",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -857,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fc3b6dd0b87ba36e565715bf9a2ced221311db47bd18011676f24a6066edbc"
+checksum = "3a45ee8994e5307cb4c60cfc1c20bf7263ffb771ddc135c9f768a14bcbc15b09"
 dependencies = [
  "curl-sys",
  "libc",
@@ -867,14 +882,14 @@ dependencies = [
  "openssl-sys",
  "schannel",
  "socket2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "curl-sys"
-version = "0.4.87+curl-8.19.0"
+version = "0.4.90+curl-8.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a460380f0ef783703dcbe909107f39c162adeac050d73c850055118b5b6327"
+checksum = "97799a0d220bfb3361e0fe4936966ff8c4b24d65c3f06dfc70d7b680b44e7897"
 dependencies = [
  "cc",
  "libc",
@@ -882,17 +897,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -901,22 +906,8 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -929,18 +920,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -949,9 +929,40 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -966,7 +977,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -978,7 +988,7 @@ checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1000,7 +1010,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -1021,19 +1031,19 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "objc2",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1065,9 +1075,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "email_address"
@@ -1224,33 +1234,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
+name = "fast-srgb8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
 name = "fax"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1384,16 +1386,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
-
-[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1462,7 +1454,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1512,7 +1504,7 @@ checksum = "c9f8ab1b98a1284961d722ce994d9a0f3018ab1917618d4113824a72b9f71bc9"
 dependencies = [
  "attribute-derive",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1555,10 +1547,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1568,22 +1558,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1703,6 +1693,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapless"
@@ -1747,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "htmd"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de550515ae03ff01fb033658945ba393c8db391297978a1f988ecb436e072f87"
+checksum = "7eee9b00ee2e599b4f86507157e3db786e7a3319fc225f0e9584151dbea2291d"
 dependencies = [
  "html5ever",
  "markup5ever_rcdom",
@@ -1758,9 +1753,9 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
  "markup5ever",
@@ -1779,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "iana-time-zone"
@@ -1809,12 +1804,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1822,9 +1818,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1835,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1849,15 +1845,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1869,15 +1865,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1887,12 +1883,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -1913,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1923,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1939,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.9"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -1952,8 +1942,8 @@ dependencies = [
  "num-traits",
  "png",
  "tiff",
- "zune-core 0.5.1",
- "zune-jpeg 0.5.15",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -2025,35 +2015,35 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.1"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "instability"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2089,7 +2079,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2121,9 +2111,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "isahc"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49980b382c0e59635b99bb2d9ef4c039a90aefa1b821d5d7a8526d4504e14594"
+checksum = "fbce0b6b4f5c50b8e014e227d51ddf721558308566b4f6ba608abcea4d272cce"
 dependencies = [
  "async-channel",
  "castaway",
@@ -2171,27 +2161,28 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-link",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2211,21 +2202,22 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -2280,9 +2272,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -2290,11 +2282,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -2309,12 +2301,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lexical-parse-float"
@@ -2343,9 +2329,9 @@ checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2355,9 +2341,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -2371,7 +2357,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2409,17 +2395,17 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2430,12 +2416,6 @@ checksum = "e73f7d752fe2ef0a41f132b83d0be154c6ae0ed84967b4df80a16901866be075"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "mac_address"
@@ -2503,7 +2483,7 @@ dependencies = [
  "async-lock",
  "async-process",
  "base64",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "event-listener",
  "flume 0.11.1",
  "futures-lite",
@@ -2533,7 +2513,6 @@ dependencies = [
  "toml",
  "toml_edit",
  "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -2559,7 +2538,7 @@ version = "0.3.27"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2659,7 +2638,6 @@ dependencies = [
  "tree-sitter-swift",
  "tree-sitter-typescript",
  "tree-sitter-zig",
- "uuid",
 ]
 
 [[package]]
@@ -2704,6 +2682,7 @@ dependencies = [
 name = "maki-storage"
 version = "0.3.27"
 dependencies = [
+ "bs58",
  "etcetera",
  "getrandom 0.3.4",
  "isahc",
@@ -2769,7 +2748,7 @@ dependencies = [
  "manyhow-macros",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2785,9 +2764,9 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
  "tendril",
@@ -2796,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "markup5ever_rcdom"
-version = "0.36.0+unofficial"
+version = "0.38.0+unofficial"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5fc8802e8797c0dfdd2ce5c21aa0aee21abbc7b3b18559100651b3352a7b63"
+checksum = "333171ccdf66e915257740d44e38ea5b1b19ce7b45d33cc35cb6f118fbd981ff"
 dependencies = [
  "html5ever",
  "markup5ever",
@@ -2817,15 +2796,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -2869,9 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -2925,7 +2904,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2964,14 +2943,14 @@ source = "git+https://github.com/pydantic/monty.git?tag=v0.0.18#45a3b2d57e6ce723
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "moxcms"
-version = "0.7.11"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -2989,7 +2968,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3017,11 +2996,11 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "9.0.0-rc.2"
+version = "9.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8b6510a5042c64929d0278a8d24f5f90aa3a9b5be52e08e4f8bf7403adb01dc"
+checksum = "b44b771d4dd781ef14c84078693e67495da6b47f609f72e8a4da8420a861240e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "flume 0.12.0",
  "inotify",
  "kqueue",
@@ -3042,7 +3021,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3082,9 +3061,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3120,7 +3099,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3134,11 +3113,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -3187,7 +3165,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -3199,7 +3177,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
 ]
@@ -3210,7 +3188,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -3239,7 +3217,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3250,7 +3228,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3284,13 +3262,12 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open"
-version = "5.3.3"
+version = "5.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+checksum = "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a"
 dependencies = [
  "is-wsl",
  "libc",
- "pathdiff",
 ]
 
 [[package]]
@@ -3301,18 +3278,18 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.5+3.5.5"
+version = "300.6.1+3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -3371,6 +3348,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3400,12 +3401,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3413,9 +3408,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -3423,9 +3418,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3433,25 +3428,24 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
 dependencies = [
  "pest",
- "sha2",
 ]
 
 [[package]]
@@ -3536,7 +3530,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3549,7 +3543,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3572,22 +3566,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3609,19 +3603,19 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64",
  "indexmap 2.14.0",
- "quick-xml 0.38.4",
+ "quick-xml 0.41.0",
  "serde",
  "time",
 ]
@@ -3660,7 +3654,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3689,9 +3683,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -3740,16 +3734,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3768,7 +3752,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3793,9 +3777,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "pyo3"
@@ -3841,7 +3825,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3854,7 +3838,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3865,27 +3849,27 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -3909,7 +3893,7 @@ dependencies = [
  "proc-macro-utils",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3932,9 +3916,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -3962,32 +3946,36 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
 dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-macros",
+ "ratatui-termina",
  "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "compact_str",
- "hashbrown 0.16.1",
- "indoc",
+ "critical-section",
+ "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
  "lru",
- "strum 0.27.2",
+ "palette",
+ "serde",
+ "strum 0.28.0",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -3996,9 +3984,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -4008,19 +3996,30 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
 ]
 
 [[package]]
-name = "ratatui-termwiz"
+name = "ratatui-termina"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -4028,18 +4027,19 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.16.1",
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "strum 0.27.2",
+ "serde",
+ "strum 0.28.0",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -4047,9 +4047,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -4071,7 +4071,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4091,7 +4091,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4110,9 +4110,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4122,9 +4122,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4133,9 +4133,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "ruff_python_ast"
@@ -4143,7 +4143,7 @@ version = "0.0.0"
 source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
 dependencies = [
  "aho-corasick",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "compact_str",
  "get-size2",
  "is-macro",
@@ -4161,7 +4161,7 @@ name = "ruff_python_parser"
 version = "0.0.0"
 source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bstr",
  "compact_str",
  "get-size2",
@@ -4182,7 +4182,7 @@ name = "ruff_python_stdlib"
 version = "0.0.0"
 source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "unicode-ident",
 ]
 
@@ -4216,15 +4216,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -4241,7 +4241,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4250,9 +4250,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -4312,7 +4312,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4323,9 +4323,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -4364,7 +4364,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4375,14 +4375,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -4427,10 +4427,10 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4474,9 +4474,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -4527,9 +4527,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -4550,9 +4550,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -4576,9 +4576,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4632,6 +4632,7 @@ dependencies = [
  "parking_lot",
  "phf_shared 0.13.1",
  "precomputed-hash",
+ "serde",
 ]
 
 [[package]]
@@ -4679,7 +4680,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4691,7 +4692,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4713,9 +4714,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4730,7 +4731,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4773,7 +4774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4781,13 +4782,24 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
- "futf",
- "mac",
- "utf-8",
+ "new_debug_unreachable",
+]
+
+[[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4819,7 +4831,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
@@ -4871,7 +4883,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4882,7 +4894,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "test-case-core",
 ]
 
@@ -4918,7 +4930,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4929,40 +4941,39 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "tiff"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
 dependencies = [
  "fax",
  "flate2",
  "half",
  "quick-error",
  "weezl",
- "zune-jpeg 0.4.21",
+ "zune-jpeg",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -4974,15 +4985,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5010,9 +5021,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5084,7 +5095,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5137,9 +5148,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.8"
+version = "0.26.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538"
+checksum = "3c343ed63e3f5c64d1acdecb5d2c13d4e169cb5fde0052106ebaa6c6f27f9e55"
 dependencies = [
  "cc",
  "regex",
@@ -5161,9 +5172,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-c"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3aad8f0129083a59fe8596157552d2bb7148c492d44c21558d68ca1c722707"
+checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -5171,9 +5182,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-c-sharp"
-version = "0.23.1"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67f06accca7b45351758663b8215089e643d53bd9a660ce0349314263737fcb0"
+checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -5337,9 +5348,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-scala"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83079f50ea7d03e0faf6be6260ed97538e6df7349ec3cbcbf5771f7b38e3c8b7"
+checksum = "3394d6bc99bceae03c75482a93f1bcefff11e69d3a405f1410e864212b52739a"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -5357,9 +5368,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-swift"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef216011c3e3df4fa864736f347cb8d509b1066cf0c8549fb1fd81ac9832e59"
+checksum = "fe36052155b9dd69ca82b3b8f1b4ccfb2d867125ac1a4db1dd7331829242668c"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -5415,9 +5426,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -5442,9 +5453,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
@@ -5510,12 +5521,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5529,12 +5534,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "atomic",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -5616,27 +5621,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.46.0",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5647,9 +5643,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5657,58 +5653,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
 ]
 
 [[package]]
@@ -5730,7 +5692,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -5738,11 +5700,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.12"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -5754,7 +5716,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -5768,7 +5730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.39.2",
+ "quick-xml 0.39.4",
  "quote",
 ]
 
@@ -5783,9 +5745,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5793,9 +5755,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
@@ -5933,7 +5895,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5944,7 +5906,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5973,20 +5935,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -6000,42 +5953,20 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -6045,21 +5976,9 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6069,21 +5988,9 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6093,33 +6000,15 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6138,97 +6027,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wl-clipboard-rs"
@@ -6250,9 +6051,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -6282,9 +6083,9 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xml5ever"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f57dd51b88a4b9f99f9b55b136abb86210629d61c48117ddb87f567e51e66be7"
+checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
 dependencies = [
  "log",
  "markup5ever",
@@ -6292,9 +6093,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
 
 [[package]]
 name = "yaml-rust"
@@ -6307,9 +6108,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6324,35 +6125,35 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -6365,7 +6166,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -6399,7 +6200,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6410,24 +6211,9 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zune-core"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
-
-[[package]]
-name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-jpeg"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
-dependencies = [
- "zune-core 0.4.12",
-]
 
 [[package]]
 name = "zune-jpeg"
@@ -6435,5 +6221,5 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
- "zune-core 0.5.1",
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,8 @@ maki-highlight = { path = "maki-highlight" }
 maki-markdown = { path = "maki-markdown" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
-uuid = { version = "1", default-features = false, features = ["v4"] }
+bs58 = "0.5"
+uuid = { version = "1", default-features = false, features = ["std", "v7"] }
 ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
 crossterm = { version = "0.29", features = ["osc52"] }
 color-eyre = { version = "0.6", default-features = false, features = ["track-caller"] }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,5 @@
+disallowed-methods = [
+  { path = "uuid::Uuid::new_v4", reason = "use maki_storage::id::MakiId::generate (base58-encoded UUIDv7)", allow-invalid = true },
+  { path = "uuid::Uuid::new_v7", reason = "use maki_storage::id::MakiId::generate (base58-encoded UUIDv7)", allow-invalid = true },
+  { path = "uuid::Uuid::now_v7", reason = "use maki_storage::id::MakiId::generate (base58-encoded UUIDv7)", allow-invalid = true },
+]

--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -19,6 +19,7 @@ use maki_agent::{AgentInput, AgentMode, Envelope, ImageMediaType, ImageSource};
 use maki_providers::Message;
 use maki_providers::model::Model;
 use maki_providers::provider::available_model_specs;
+use maki_storage::id::{MakiId, SessionRef};
 use serde::Serialize;
 use serde_json::Value;
 use smol::io::AsyncBufReadExt;
@@ -125,19 +126,22 @@ fn handle_request(srv: &mut Server, method: &str, id: RequestId, raw: &Value, pa
         "session/new" => parse_params::<NewSessionRequest>(raw).map(|req| {
             let handle = spawn_session(params, req.cwd, None, Vec::new());
             let spec = params.model.spec();
-            let resp = methods::new_session_response(&handle.session_id)
+            let resp = methods::new_session_response(handle.session_id.as_str())
                 .config_options(vec![methods::model_config_option(&spec, &srv.model_specs)]);
             install_session(srv, handle, spec);
             AgentResponse::NewSessionResponse(resp)
         }),
         "session/load" => parse_params::<LoadSessionRequest>(raw).and_then(|req| {
-            let session_id = req.session_id.0.to_string();
-            let history = load_history(&session_id)?;
-            let sid = SessionId::from(session_id.clone());
+            let session_ref: SessionRef =
+                req.session_id.0.parse().map_err(|_| {
+                    AcpError::resource_not_found(Some(req.session_id.0.to_string()))
+                })?;
+            let history = load_history(session_ref.id())?;
+            let sid = SessionId::from(session_ref.to_string());
             for update in translate::replay_history(&history) {
                 session_update(&srv.out_tx, &sid, update);
             }
-            let handle = spawn_session(params, req.cwd, Some(session_id), history);
+            let handle = spawn_session(params, req.cwd, Some(session_ref), history);
             let spec = params.model.spec();
             let resp = methods::load_session_response()
                 .config_options(vec![methods::model_config_option(&spec, &srv.model_specs)]);
@@ -158,7 +162,7 @@ fn handle_request(srv: &mut Server, method: &str, id: RequestId, raw: &Value, pa
 fn spawn_session(
     params: &AcpParams,
     cwd: PathBuf,
-    session_id: Option<String>,
+    session_id: Option<SessionRef>,
     history: Vec<Message>,
 ) -> InteractiveHandle {
     headless::spawn_interactive(InteractiveParams {
@@ -195,7 +199,7 @@ fn install_session(srv: &mut Server, handle: InteractiveHandle, current_model: S
     });
 }
 
-fn load_history(session_id: &str) -> Result<Vec<Message>, AcpError> {
+fn load_history(session_id: MakiId) -> Result<Vec<Message>, AcpError> {
     let storage = maki_storage::StateDir::resolve()
         .map_err(|e| AcpError::internal_error().data(json_str(&e)))?;
     load_history_from(&storage, session_id)
@@ -203,7 +207,7 @@ fn load_history(session_id: &str) -> Result<Vec<Message>, AcpError> {
 
 fn load_history_from(
     storage: &maki_storage::StateDir,
-    session_id: &str,
+    session_id: MakiId,
 ) -> Result<Vec<Message>, AcpError> {
     let session: maki_storage::sessions::Session<
         Message,
@@ -249,7 +253,7 @@ fn handle_set_mode(srv: &mut Server, raw: &Value) -> Result<AgentResponse, AcpEr
     let session = srv.session.as_mut().ok_or_else(no_session)?;
     session.current_mode = new_mode;
 
-    let sid = SessionId::from(session.handle.session_id.clone());
+    let sid = SessionId::from(session.handle.session_id.to_string());
     session_update(
         &srv.out_tx,
         &sid,
@@ -353,12 +357,12 @@ fn image_media_type(mime: &str) -> ImageMediaType {
 
 fn start_event_pump(
     event_rx: Receiver<Envelope>,
-    session_id: String,
+    session_id: SessionRef,
     out_tx: Sender<Value>,
     pending: PendingPrompt,
 ) {
     smol::spawn(async move {
-        let sid = SessionId::from(session_id);
+        let sid = SessionId::from(session_id.to_string());
         let mut next_request_id = FIRST_OUTGOING_REQUEST_ID;
 
         while let Ok(Envelope {
@@ -480,7 +484,8 @@ mod tests {
         session.messages = messages.clone();
         session.save(&dir).unwrap();
 
-        let history = load_history_from(&dir, &session.id).unwrap();
+        let id: MakiId = session.id;
+        let history = load_history_from(&dir, id).unwrap();
         assert_eq!(
             serde_json::to_value(&history).unwrap(),
             serde_json::to_value(&messages).unwrap()
@@ -491,7 +496,7 @@ mod tests {
     fn load_missing_session_is_resource_not_found() {
         let tmp = TempDir::new().unwrap();
         let dir = StateDir::from_path(tmp.path().to_path_buf());
-        let err = load_history_from(&dir, "missing-id").unwrap_err();
+        let err = load_history_from(&dir, MakiId::generate()).unwrap_err();
         assert_eq!(err.code, AcpError::resource_not_found(None).code);
     }
 }

--- a/maki-agent/Cargo.toml
+++ b/maki-agent/Cargo.toml
@@ -37,7 +37,6 @@ sha2 = { workspace = true }
 serde_yaml = { workspace = true }
 base64 = { workspace = true }
 getrandom = { workspace = true }
-uuid = { workspace = true }
 
 
 [dev-dependencies]

--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -224,6 +224,7 @@ mod tests {
         ContentBlock, Message, Model, ProviderEvent, RequestOptions, Role, StopReason,
         StreamResponse, TokenUsage,
     };
+    use maki_storage::id::SessionRef;
     use serde_json::Value;
     use test_case::test_case;
 
@@ -251,7 +252,7 @@ mod tests {
             _: &'a Value,
             _: &'a flume::Sender<ProviderEvent>,
             _: RequestOptions,
-            _: Option<&str>,
+            _: Option<&'a SessionRef>,
         ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
             Box::pin(async {
                 let mut responses = self.responses.lock().unwrap();

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -22,6 +22,7 @@ use crate::{
     InterruptSource, TurnCompleteEvent,
 };
 use maki_config::ToolOutputLines;
+use maki_storage::id::SessionRef;
 
 const MAX_REAUTH_ATTEMPTS: u32 = 2;
 const NUDGE_PROMPT: &str = "You just executed tool calls but returned an empty response. Please process the tool results above and continue with the task.";
@@ -55,7 +56,7 @@ pub struct AgentParams {
     pub config: AgentConfig,
     pub tool_output_lines: ToolOutputLines,
     pub permissions: Arc<PermissionManager>,
-    pub session_id: Option<String>,
+    pub session_id: Option<SessionRef>,
     pub timeouts: maki_providers::Timeouts,
     pub file_tracker: Arc<FileReadTracker>,
     pub prompt_slots: Arc<crate::prompt::ResolvedSlots>,
@@ -96,7 +97,7 @@ pub struct Agent<'h> {
     post_tool_empty_retried: bool,
     permissions: Arc<PermissionManager>,
     opts: RequestOptions,
-    session_id: Option<String>,
+    session_id: Option<SessionRef>,
     timeouts: maki_providers::Timeouts,
     file_tracker: Arc<FileReadTracker>,
     prompt_slots: Arc<crate::prompt::ResolvedSlots>,
@@ -237,7 +238,7 @@ impl<'h> Agent<'h> {
             &self.event_tx,
             &self.cancel,
             self.opts,
-            self.session_id.as_deref(),
+            self.session_id.as_ref(),
         )
         .await
         {
@@ -557,7 +558,7 @@ mod tests {
             _: &'a Value,
             _: &'a flume::Sender<ProviderEvent>,
             _: RequestOptions,
-            _: Option<&str>,
+            _: Option<&'a SessionRef>,
         ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
             Box::pin(async {
                 let mut responses = self.responses.lock().unwrap();
@@ -849,7 +850,7 @@ mod tests {
                     _: &'a Value,
                     _: &'a flume::Sender<ProviderEvent>,
                     _: RequestOptions,
-                    _: Option<&'a str>,
+                    _: Option<&'a SessionRef>,
                 ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
                     Box::pin(async {
                         futures_lite::future::pending::<()>().await;

--- a/maki-agent/src/agent/streaming.rs
+++ b/maki-agent/src/agent/streaming.rs
@@ -1,6 +1,7 @@
 use maki_providers::provider::Provider;
 use maki_providers::retry::{MAX_TIMEOUT_RETRIES, RetryState};
 use maki_providers::{Message, Model, ProviderEvent, RequestOptions, StreamResponse};
+use maki_storage::id::SessionRef;
 use serde_json::Value;
 use tracing::warn;
 
@@ -30,7 +31,7 @@ pub(crate) async fn stream_with_retry(
     event_tx: &EventSender,
     cancel: &CancelToken,
     opts: RequestOptions,
-    session_id: Option<&str>,
+    session_id: Option<&SessionRef>,
 ) -> Result<StreamResponse, AgentError> {
     let opts = opts.clamped(model);
     let messages = maki_providers::adapt_images_for_model(model, messages);

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -9,6 +9,7 @@ use maki_providers::TokenUsage;
 use maki_providers::model::Model;
 use maki_providers::provider::{self, Provider};
 use maki_storage::StateDir;
+use maki_storage::id::{MakiId, SessionRef};
 use maki_storage::sessions::Session;
 use serde_json::Value;
 use tracing::{error, warn};
@@ -32,19 +33,19 @@ struct SessionStore {
 }
 
 impl SessionStore {
-    fn open(session_id: &str, cwd: &str, model_spec: &str) -> Option<Self> {
+    fn open(session_id: MakiId, cwd: &str, model_spec: &str) -> Option<Self> {
         let dir = StateDir::resolve()
             .map_err(|e| warn!(error = %e, "state dir unavailable; session will not be persisted"))
             .ok()?;
         Some(Self::open_in(dir, session_id, cwd, model_spec))
     }
 
-    fn open_in(dir: StateDir, session_id: &str, cwd: &str, model_spec: &str) -> Self {
+    fn open_in(dir: StateDir, session_id: MakiId, cwd: &str, model_spec: &str) -> Self {
         match StoredSession::load(session_id, &dir) {
             Ok(session) => Self { dir, session },
             Err(_) => {
                 let mut session = StoredSession::new(model_spec, cwd);
-                session.id = session_id.to_owned();
+                session.id = session_id;
                 let mut store = Self { dir, session };
                 store.save();
                 store
@@ -84,7 +85,7 @@ pub struct HeadlessParams {
 pub struct HeadlessHandle {
     pub event_rx: Receiver<Envelope>,
     pub tool_names: Vec<String>,
-    pub session_id: String,
+    pub session_id: SessionRef,
     pub cwd: String,
     pub task: smol::Task<()>,
 }
@@ -172,12 +173,12 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
 
     let (raw_tx, event_rx) = flume::unbounded::<Envelope>();
 
-    let session_id = uuid::Uuid::new_v4().to_string();
-
+    let session_id = MakiId::generate();
+    let session_ref = SessionRef::from(session_id);
+    let session_ref_clone = session_ref.clone();
     let fast = params.fast;
     let workflow = params.workflow;
     let task = smol::spawn({
-        let session_id = session_id.clone();
         let mcp_shutdown = params.mcp_handle.clone();
         let working_dir_path = params.initial_wd.clone();
         async move {
@@ -206,7 +207,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
                         params.permissions_config,
                         working_dir_path,
                     )),
-                    session_id: Some(session_id),
+                    session_id: Some(session_ref_clone.clone()),
                     timeouts: params.timeouts,
                     file_tracker: FileReadTracker::fresh(),
                     prompt_slots: Arc::new(params.prompt_slots),
@@ -254,7 +255,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
     HeadlessHandle {
         event_rx,
         tool_names,
-        session_id,
+        session_id: session_ref,
         cwd: working_dir,
         task,
     }
@@ -269,7 +270,7 @@ pub struct InteractiveParams {
     pub excluded_tools: Vec<&'static str>,
     pub mcp_handle: Option<McpHandle>,
     pub initial_wd: PathBuf,
-    pub session_id: Option<String>,
+    pub session_id: Option<SessionRef>,
     pub initial_history: Vec<Message>,
     pub yolo: bool,
     pub system_prompt_override: Option<String>,
@@ -284,7 +285,7 @@ pub struct InteractiveHandle {
     pub answer_tx: flume::Sender<String>,
     pub cancel_tx: flume::Sender<()>,
     pub model_tx: flume::Sender<Model>,
-    pub session_id: String,
+    pub session_id: SessionRef,
     pub permissions: Arc<PermissionManager>,
     pub task: smol::Task<()>,
 }
@@ -310,9 +311,13 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
     let (cancel_tx, cancel_rx) = flume::bounded::<()>(1);
     let (model_tx, model_rx) = flume::unbounded::<Model>();
 
-    let session_id = params
-        .session_id
-        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    let (session_id, session_ref) = match params.session_id.clone() {
+        Some(w) => (w.id(), w),
+        None => {
+            let id = MakiId::generate();
+            (id, SessionRef::from(id))
+        }
+    };
 
     let working_dir = params.initial_wd.to_string_lossy().into_owned();
     let permissions = Arc::new(PermissionManager::new(
@@ -326,8 +331,8 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
     let answer_rx = Arc::new(Mutex::new(answer_rx));
     let file_tracker = FileReadTracker::fresh();
 
+    let session_ref_clone = session_ref.clone();
     let task = smol::spawn({
-        let session_id = session_id.clone();
         let permissions = Arc::clone(&permissions);
         async move {
             let mut model = params.model;
@@ -343,7 +348,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                     }
                 };
 
-            let mut store = SessionStore::open(&session_id, &working_dir, &model.spec());
+            let mut store = SessionStore::open(session_id, &working_dir, &model.spec());
             let mut history = History::restored(params.initial_history);
             let mut run_id: u64 = 0;
 
@@ -412,7 +417,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                         config: params.config.clone(),
                         tool_output_lines: ToolOutputLines::default(),
                         permissions: Arc::clone(&permissions),
-                        session_id: Some(session_id.clone()),
+                        session_id: Some(session_ref_clone.clone()),
                         timeouts: params.timeouts,
                         file_tracker: Arc::clone(&file_tracker),
                         prompt_slots: Arc::clone(&params.prompt_slots),
@@ -462,7 +467,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
         answer_tx,
         cancel_tx,
         model_tx,
-        session_id,
+        session_id: session_ref,
         permissions,
         task,
     }
@@ -486,21 +491,25 @@ mod tests {
 
     use super::*;
 
-    const SESSION_ID: &str = "acp-test-session";
+    const SESSION_ID: &str = "01965087-4c71-7f00-8000-000000000000";
     const CWD: &str = "/project";
     const MODEL_SPEC: &str = "anthropic/claude-test";
+
+    fn session_id() -> MakiId {
+        SESSION_ID.parse().unwrap()
+    }
 
     fn store_in(tmp: &TempDir) -> SessionStore {
         SessionStore::open_in(
             StateDir::from_path(tmp.path().to_path_buf()),
-            SESSION_ID,
+            session_id(),
             CWD,
             MODEL_SPEC,
         )
     }
 
     fn load(tmp: &TempDir) -> StoredSession {
-        StoredSession::load(SESSION_ID, &StateDir::from_path(tmp.path().to_path_buf())).unwrap()
+        StoredSession::load(session_id(), &StateDir::from_path(tmp.path().to_path_buf())).unwrap()
     }
 
     #[test]
@@ -508,7 +517,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         store_in(&tmp);
         let loaded = load(&tmp);
-        assert_eq!(loaded.id, SESSION_ID);
+        assert_eq!(loaded.id, session_id());
         assert_eq!(loaded.cwd, CWD);
         assert_eq!(loaded.model, MODEL_SPEC);
         assert!(loaded.messages.is_empty());

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -38,6 +38,7 @@ use maki_config::ToolOutputLines;
 use maki_providers::Model;
 use maki_providers::RequestOptions;
 use maki_providers::provider::Provider;
+use maki_storage::id::SessionRef;
 
 pub struct DescriptionContext<'a> {
     pub filter: &'a ToolFilter,
@@ -384,7 +385,7 @@ impl Provider for NullProvider {
         _: &'a Value,
         _: &'a flume::Sender<ProviderEvent>,
         _: RequestOptions,
-        _: Option<&str>,
+        _: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, crate::AgentError>> {
         Box::pin(async { unimplemented!() })
     }

--- a/maki-lua/Cargo.toml
+++ b/maki-lua/Cargo.toml
@@ -38,7 +38,6 @@ isahc = { workspace = true }
 htmd = { workspace = true }
 jsonschema = { workspace = true }
 toml = { workspace = true }
-uuid = { workspace = true }
 tree-sitter-bash = { workspace = true }
 tree-sitter-c = { workspace = true }
 tree-sitter-c-sharp = { workspace = true }

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -25,12 +25,12 @@ use maki_agent::{
 use maki_providers::model::ModelTier;
 use maki_providers::provider;
 use maki_providers::{ContentBlock, Model, ModelError, Role, ThinkingConfig};
+use maki_storage::id::MakiId;
 use mlua::{
     Function, Lua, Result as LuaResult, Table, UserData, UserDataMethods, Value as LuaValue,
 };
 use serde_json::Value as JsonValue;
 use tracing::info;
-use uuid::Uuid;
 
 use crate::api::ui::buf::BufHandle;
 use crate::api::util::convert::{json_to_lua, lua_to_json, lua_tool_result};
@@ -561,7 +561,7 @@ async fn session(
         None => agent_ctx.opts.thinking,
     };
 
-    let session_id = Uuid::new_v4().to_string();
+    let session_id = MakiId::generate();
     let (sub_tx, sub_rx) = flume::unbounded::<Envelope>();
     let sub_event_tx = EventSender::new(sub_tx, agent_ctx.event_tx.run_id());
     let parent_tx = agent_ctx.event_tx.clone();
@@ -618,7 +618,7 @@ async fn session(
             config: agent_ctx.config.clone(),
             tool_output_lines: maki_config::ToolOutputLines::default(),
             permissions: Arc::clone(&agent_ctx.permissions),
-            session_id: Some(session_id),
+            session_id: Some(session_id.into()),
             timeouts: agent_ctx.timeouts,
             file_tracker: FileReadTracker::fresh(),
             prompt_slots: Arc::clone(&agent_ctx.prompt_slots),

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -6,6 +6,8 @@ use serde_json::Value;
 use strum::{Display, EnumIter, EnumString, IntoEnumIterator};
 use tracing::{debug, warn};
 
+use maki_storage::id::SessionRef;
+
 use crate::model::{Model, ModelFamily, ModelInfo, models_for_provider};
 use crate::providers::Timeouts;
 use crate::providers::anthropic::Anthropic;
@@ -258,7 +260,7 @@ pub trait Provider: Send + Sync {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        session_id: Option<&'a str>,
+        session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>>;
 
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<ModelInfo>, AgentError>>;
@@ -326,7 +328,7 @@ impl Provider for UnconfiguredProvider {
         _tools: &'a Value,
         _event_tx: &'a Sender<ProviderEvent>,
         _opts: RequestOptions,
-        _session_id: Option<&'a str>,
+        _session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async {
             Err(AgentError::Config {

--- a/maki-providers/src/providers/anthropic/bedrock.rs
+++ b/maki-providers/src/providers/anthropic/bedrock.rs
@@ -9,6 +9,7 @@ use flume::Sender;
 use hmac::{Hmac, Mac};
 use isahc::config::Configurable;
 use isahc::{HttpClient, ReadResponseExt, Request};
+use maki_storage::id::SessionRef;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use tracing::{debug, warn};
@@ -524,7 +525,7 @@ impl Provider for Bedrock {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        _session_id: Option<&'a str>,
+        _session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
             if self.needs_refresh() {

--- a/maki-providers/src/providers/anthropic/mod.rs
+++ b/maki-providers/src/providers/anthropic/mod.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use flume::Sender;
 use futures_lite::io::{AsyncBufReadExt, BufReader};
 use isahc::{AsyncReadResponseExt, HttpClient, Request};
+use maki_storage::id::SessionRef;
 use serde::Deserialize;
 use serde_json::{Value, json};
 use tracing::debug;
@@ -356,7 +357,7 @@ impl Provider for Anthropic {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        _session_id: Option<&str>,
+        _session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
             let system_blocks = if let Some(prefix) = &self.system_prefix {

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use flume::Sender;
 use futures_lite::io::BufReader;
 use isahc::{AsyncReadResponseExt, HttpClient, Request};
+use maki_storage::id::SessionRef;
 use serde::Deserialize;
 use serde_json::{Value, json};
 use tracing::{debug, warn};
@@ -543,7 +544,7 @@ impl Provider for Copilot {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        _session_id: Option<&'a str>,
+        _session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
             let mut prefixed_system = String::new();

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -7,6 +7,7 @@ use maki_config::providers::{
     Protocol, ProvidersConfig, builtin_provider, resolve_api_key_env, resolve_base_url,
     resolve_protocol,
 };
+use maki_storage::id::SessionRef;
 
 use super::ResolvedAuth;
 use super::openai::responses;
@@ -215,7 +216,7 @@ impl Provider for CustomOpenAiProvider {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        _session_id: Option<&'a str>,
+        _session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();

--- a/maki-providers/src/providers/deepseek.rs
+++ b/maki-providers/src/providers/deepseek.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
+use maki_storage::id::SessionRef;
 use serde_json::Value;
 use tracing::warn;
 
@@ -113,7 +114,7 @@ impl Provider for DeepSeek {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        _session_id: Option<&'a str>,
+        _session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use flume::Sender;
+use maki_storage::id::SessionRef;
 use serde::Deserialize;
 use serde_json::Value;
 use strum::IntoEnumIterator;
@@ -517,7 +518,7 @@ impl Provider for DynamicProvider {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        session_id: Option<&'a str>,
+        session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         self.inner
             .stream_message(model, messages, system, tools, event_tx, opts, session_id)

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, Instant};
 use flume::Sender;
 use futures_lite::io::{AsyncBufReadExt, BufReader};
 use isahc::{AsyncReadResponseExt, HttpClient, Request};
+use maki_storage::id::SessionRef;
 use serde::Deserialize;
 use serde_json::{Value, json};
 use tracing::warn;
@@ -228,7 +229,7 @@ impl Provider for Google {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        _session_id: Option<&'a str>,
+        _session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(self.do_stream(model, messages, system, tools, event_tx, opts.thinking))
     }

--- a/maki-providers/src/providers/local.rs
+++ b/maki-providers/src/providers/local.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use flume::Sender;
 use futures::future::join_all;
+use maki_storage::id::SessionRef;
 use serde::Deserialize;
 use serde_json::{Value, json};
 use tracing::warn;
@@ -134,7 +135,7 @@ impl Provider for LocalEndpoint {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        _session_id: Option<&'a str>,
+        _session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
+use maki_storage::id::SessionRef;
 use serde_json::{Value, json};
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
@@ -190,7 +191,7 @@ impl Provider for Mistral {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        session_id: Option<&'a str>,
+        session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
@@ -204,7 +205,7 @@ impl Provider for Mistral {
 
             let mut extra_headers = vec![];
             if let Some(session_id) = session_id {
-                extra_headers.push(("x-affinity", session_id));
+                extra_headers.push(("x-affinity", session_id.as_str()));
             }
             self.compat
                 .do_stream(model, &extra_headers, &body, event_tx, &auth)

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use flume::Sender;
 use maki_storage::StateDir;
+use maki_storage::id::SessionRef;
 use serde_json::Value;
 use tracing::{debug, warn};
 
@@ -173,7 +174,7 @@ impl Provider for OpenAi {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        _session_id: Option<&str>,
+        _session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
             let mut buf = String::new();

--- a/maki-providers/src/providers/opencode.rs
+++ b/maki-providers/src/providers/opencode.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, SystemTime};
 use flume::Sender;
 use isahc::config::Configurable;
 use isahc::{AsyncReadResponseExt, HttpClient, Request};
+use maki_storage::id::SessionRef;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tracing::{debug, warn};
@@ -313,7 +314,7 @@ impl Provider for Opencode {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        _session_id: Option<&'a str>,
+        _session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
             let model_for_stream = model.clone();

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
+use maki_storage::id::SessionRef;
 use serde_json::{Value, json};
 
 use crate::model::{Model, ModelEntry};
@@ -92,7 +93,7 @@ impl Provider for OpenRouter {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        session_id: Option<&'a str>,
+        session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
@@ -151,7 +152,7 @@ impl Provider for OpenRouter {
             }
 
             if let Some(sid) = session_id {
-                body["session_id"] = json!(sid);
+                body["session_id"] = json!(sid.to_string());
             }
 
             let extra_headers = [("HTTP-Referer", REFERER), ("X-OpenRouter-Title", APP_TITLE)];

--- a/maki-providers/src/providers/synthetic.rs
+++ b/maki-providers/src/providers/synthetic.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
+use maki_storage::id::SessionRef;
 use serde_json::Value;
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
@@ -125,7 +126,7 @@ impl Provider for Synthetic {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        _session_id: Option<&str>,
+        _session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();

--- a/maki-providers/src/providers/tensorx.rs
+++ b/maki-providers/src/providers/tensorx.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
+use maki_storage::id::SessionRef;
 use serde_json::{Value, json};
 
 use crate::model::{Model, ModelEntry, ModelInfo, ModelPricing};
@@ -82,7 +83,7 @@ impl Provider for TensorX {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        _session_id: Option<&str>,
+        _session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();

--- a/maki-providers/src/providers/zai/mod.rs
+++ b/maki-providers/src/providers/zai/mod.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use flume::Sender;
 use maki_config::providers::{BuiltInProvider, Protocol, ProviderPlan};
+use maki_storage::id::SessionRef;
 use serde::Deserialize;
 use serde_json::Value;
 use tracing::warn;
@@ -290,7 +291,7 @@ impl Provider for Zai {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        _session_id: Option<&str>,
+        _session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();

--- a/maki-storage/Cargo.toml
+++ b/maki-storage/Cargo.toml
@@ -12,9 +12,11 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 etcetera = { workspace = true }
+bs58 = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }
 tempfile = { workspace = true }
 isahc = { workspace = true }
+serde_json = { workspace = true }

--- a/maki-storage/src/id.rs
+++ b/maki-storage/src/id.rs
@@ -1,0 +1,243 @@
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use thiserror::Error;
+use uuid::Uuid;
+
+const UUID_BYTES: usize = 16;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum MakiIdParseError {
+    #[error("empty id")]
+    Empty,
+    #[error("invalid base58 character {0:?} at {1}")]
+    InvalidBase58(char, usize),
+    #[error("base58 string has a length that cannot decode to whole bytes")]
+    InvalidBase58Length,
+    #[error("id decoded to {0} bytes, expected {UUID_BYTES}")]
+    InvalidByteLen(usize),
+}
+
+/// The canonical unique id for anything in maki (sessions, and message
+/// nodes once history is a tree): time-ordered, base58-encoded, backed by a
+/// UUIDv7.
+///
+/// Serializes as base58. Accepts legacy v4-hex-uuid strings on parse
+/// (either hyphenated 8-4-4-4-12 or the unhyphenated 32 hex variant)
+/// so existing on-disk sessions resume; the canonical form is base58.
+///
+/// Note: base58 encoding is variable-length (21-22 chars for 16 bytes).
+/// New v7 ids encode to a stable 21 chars, so lexical sort orders them
+/// chronologically; legacy v4 ids (no embedded timestamp) mix 21-22 chars
+/// and don't sort by time regardless. Nothing in maki sorts by the string
+/// form today; storage uses the embedded timestamp directly. See issue
+/// #264 for future tree-ordered history work.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct MakiId([u8; UUID_BYTES]);
+
+impl MakiId {
+    #[allow(clippy::disallowed_methods)]
+    pub fn generate() -> Self {
+        Self(Uuid::now_v7().into_bytes())
+    }
+
+    pub fn as_bytes(&self) -> &[u8; UUID_BYTES] {
+        &self.0
+    }
+}
+
+impl fmt::Display for MakiId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&bs58::encode(&self.0).into_string())
+    }
+}
+
+impl FromStr for MakiId {
+    type Err = MakiIdParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(MakiIdParseError::Empty);
+        }
+        if let Ok(u) = Uuid::parse_str(s) {
+            return Ok(Self(u.into_bytes()));
+        }
+        decode_base58(s)
+    }
+}
+
+fn decode_base58(s: &str) -> Result<MakiId, MakiIdParseError> {
+    let bytes = bs58::decode(s).into_vec().map_err(|e| match e {
+        bs58::decode::Error::InvalidCharacter { character, index } => {
+            MakiIdParseError::InvalidBase58(character, index)
+        }
+        bs58::decode::Error::NonAsciiCharacter { index } => {
+            MakiIdParseError::InvalidBase58('\u{FFFD}', index)
+        }
+        _ => MakiIdParseError::InvalidBase58Length,
+    })?;
+    if bytes.len() != UUID_BYTES {
+        return Err(MakiIdParseError::InvalidByteLen(bytes.len()));
+    }
+    let mut arr = [0u8; UUID_BYTES];
+    arr.copy_from_slice(&bytes);
+    Ok(MakiId(arr))
+}
+
+impl Serialize for MakiId {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for MakiId {
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(de)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+/// A reference to a session as provided at an application boundary (ACP,
+/// session resume, SDK mode).
+///
+/// Preserves the caller's exact string verbatim (legacy hex ids resume
+/// unchanged) so wire echo and client correlation hold. The parsed [`MakiId`]
+/// is cached so [`id`](Self::id) is infallible. Canonical when self-generated
+/// via [`from_id`](Self::from_id) (base58).
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SessionRef {
+    id: MakiId,
+    raw: String,
+}
+
+impl SessionRef {
+    pub fn from_id(id: MakiId) -> Self {
+        Self {
+            id,
+            raw: id.to_string(),
+        }
+    }
+
+    pub fn generate() -> Self {
+        Self::from_id(MakiId::generate())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.raw
+    }
+
+    pub fn id(&self) -> MakiId {
+        self.id
+    }
+}
+
+impl From<MakiId> for SessionRef {
+    fn from(id: MakiId) -> Self {
+        Self::from_id(id)
+    }
+}
+
+impl fmt::Display for SessionRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.raw)
+    }
+}
+
+impl FromStr for SessionRef {
+    type Err = MakiIdParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let id = s.parse::<MakiId>()?;
+        Ok(Self {
+            id,
+            raw: s.to_string(),
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for SessionRef {
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(de)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+impl Serialize for SessionRef {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.raw)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    const SAMPLE_HEX: &str = "01965087-4c71-7f00-8000-000000000000";
+
+    fn parse(s: &str) -> MakiId {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn generate_is_v7() {
+        let id = MakiId::generate();
+        let uuid = Uuid::from_bytes(id.0);
+        assert_eq!(uuid.get_version(), Some(uuid::Version::SortRand));
+    }
+
+    #[test]
+    fn roundtrip_base58() {
+        let id = MakiId::generate();
+        let s = id.to_string();
+        assert!((21..=22).contains(&s.len()));
+        assert_eq!(s.parse::<MakiId>().unwrap(), id);
+    }
+
+    #[test_case("00000000-0000-7000-8000-000000000000")]
+    #[test_case("00000001-0002-7000-8000-000000000000")]
+    fn roundtrips_leading_zero_bytes(hex: &str) {
+        let id: MakiId = hex.parse().unwrap();
+        assert_eq!(id.to_string().parse::<MakiId>().unwrap(), id);
+    }
+
+    #[test_case(SAMPLE_HEX)]
+    #[test_case("019650874c717f008000000000000000")]
+    fn parses_legacy_and_canonical(s: &str) {
+        let expected = MakiId(Uuid::parse_str(SAMPLE_HEX).unwrap().into_bytes());
+        assert_eq!(parse(s), expected);
+    }
+
+    #[test_case("" => matches Err(MakiIdParseError::Empty))]
+    #[test_case("O" => matches Err(MakiIdParseError::InvalidBase58('O', 0)))]
+    #[test_case("2j87v4grC" => matches Err(MakiIdParseError::InvalidByteLen(_)))]
+    fn rejects_bad(s: &str) -> Result<MakiId, MakiIdParseError> {
+        s.parse()
+    }
+
+    #[test]
+    fn serde_keyed_base58() {
+        let id = MakiId::generate();
+        let s = serde_json::to_string(&id).unwrap();
+        assert!((23..=24).contains(&s.len()));
+        let back: MakiId = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, id);
+    }
+
+    #[test_case(SAMPLE_HEX)]
+    #[test_case("019650874c717f008000000000000000")]
+    fn ref_preserves_caller_string(s: &str) {
+        let session_ref: SessionRef = s.parse().unwrap();
+        assert_eq!(session_ref.as_str(), s);
+        assert_eq!(session_ref.id(), parse(s));
+    }
+
+    #[test]
+    fn ref_from_id_is_canonical_base58() {
+        let id = MakiId::generate();
+        let session_ref = SessionRef::from(id);
+        assert_eq!(session_ref.as_str(), id.to_string());
+        assert_eq!(session_ref.id(), id);
+    }
+}

--- a/maki-storage/src/lib.rs
+++ b/maki-storage/src/lib.rs
@@ -3,6 +3,7 @@
 //! `atomic_write_permissions` sets file mode before persist (for auth keys at 0600).
 
 pub mod auth;
+pub mod id;
 pub mod input_history;
 pub mod log;
 pub mod model;

--- a/maki-storage/src/log.rs
+++ b/maki-storage/src/log.rs
@@ -4,6 +4,8 @@ use std::io::{self, Write};
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
+use tracing::warn;
+
 use crate::StateDir;
 
 const LOG_FILE_NAME: &str = "maki.log";
@@ -74,7 +76,11 @@ impl RotatingFileWriter {
 
         if needs_rotate {
             let last = self.max_files - 1;
-            let _ = fs::remove_file(file_path(&self.dir, last));
+            match fs::remove_file(file_path(&self.dir, last)) {
+                Ok(()) => {}
+                Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+                Err(e) => warn!(error = %e, "log rotate: failed to remove oldest file"),
+            }
 
             for i in (0..last).rev() {
                 let src = file_path(&self.dir, i);

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -968,8 +968,8 @@ where
         if path != canonical {
             if let Err(e) = SessionLog::write_canonical(dir, &session) {
                 warn!(error = %e, "failed migrate to canonical jsonl; keeping legacy file");
-            } else if let Err(e) = fs::remove_file(&path) {
-                warn!(error = %e, path = %path.display(), "legacy file remains after migration");
+            } else if let Err(e) = remove_legacy_files(dir, id) {
+                warn!(error = %e, "legacy files remain after migration");
             }
         }
         Ok(session)
@@ -1526,6 +1526,35 @@ mod tests {
         let loaded = TestSession::load_from(id, dir).unwrap();
         assert_eq!(loaded.messages.len(), 1);
         assert_eq!(loaded.messages[0], user_message("newer"));
+    }
+
+    #[test]
+    fn load_dual_legacy_files_does_not_leave_duplicate_in_list() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        let id: MakiId = LEGACY_HEX_ID.parse().unwrap();
+        let mut jsonl_session: TestSession = Session::new("m", "/project");
+        jsonl_session.id = id;
+        jsonl_session.messages.push(user_message("newer"));
+        let legacy_jsonl = dir.join(format!("{LEGACY_HEX_ID}.jsonl"));
+        write_legacy_jsonl(&legacy_jsonl, &jsonl_session);
+
+        let mut json_session: TestSession = Session::new("m", "/project");
+        json_session.id = id;
+        json_session.messages.push(user_message("older"));
+        let legacy_json = dir.join(format!("{LEGACY_HEX_ID}.json"));
+        fs::write(&legacy_json, serde_json::to_vec(&json_session).unwrap()).unwrap();
+
+        TestSession::load_from(id, dir).unwrap();
+
+        assert!(!legacy_json.exists(), "legacy .json sibling left behind");
+        let list = TestSession::list_in("/project", dir).unwrap();
+        assert_eq!(
+            list.len(),
+            1,
+            "session shows up more than once in the picker"
+        );
     }
 
     #[test]

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -10,11 +10,12 @@
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom, Write};
+use std::io::{BufRead, BufReader, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use tracing::warn;
 
+use crate::id::{MakiId, MakiIdParseError};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
@@ -24,6 +25,7 @@ const SESSION_VERSION: u32 = 1;
 const LOG_FORMAT_VERSION: u32 = 2;
 pub const SESSIONS_DIR: &str = "sessions";
 const CWD_INDEX_FILE: &str = "cwd_latest.json";
+const CWD_INDEX_STEM: &str = "cwd_latest";
 const DEFAULT_TITLE: &str = "New session";
 const MAX_TITLE_LEN: usize = 60;
 
@@ -34,7 +36,13 @@ pub enum SessionError {
     #[error("incompatible session version {found} (expected {expected})")]
     VersionMismatch { found: u32, expected: u32 },
     #[error("session ID mismatch: log owns {log_id}, got {given_id}")]
-    IdMismatch { log_id: String, given_id: String },
+    IdMismatch { log_id: MakiId, given_id: MakiId },
+    #[error("session log {path} has header id {raw_id:?} that is not a valid id: {source}")]
+    CorruptHeaderId {
+        path: String,
+        raw_id: String,
+        source: MakiIdParseError,
+    },
     #[error("cursor ahead of session (log has {saved}, session has {actual}); compact required")]
     CursorAhead { saved: usize, actual: usize },
 }
@@ -104,7 +112,7 @@ pub struct SessionMeta {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session<M, U, T> {
     pub version: u32,
-    pub id: String,
+    pub id: MakiId,
     pub title: String,
     pub cwd: String,
     pub model: String,
@@ -121,7 +129,7 @@ pub struct Session<M, U, T> {
 }
 
 pub struct SessionSummary {
-    pub id: String,
+    pub id: MakiId,
     pub title: String,
     pub updated_at: u64,
 }
@@ -191,7 +199,7 @@ pub struct StoredSubagent {
 #[derive(Deserialize)]
 struct LegacyHeader {
     version: u32,
-    id: String,
+    id: MakiId,
     title: String,
     cwd: String,
     updated_at: u64,
@@ -228,7 +236,7 @@ enum LogRecord<M, U, T> {
     #[serde(rename = "header")]
     Header {
         v: u32,
-        id: String,
+        id: MakiId,
         model: String,
         cwd: String,
         created_at: u64,
@@ -252,7 +260,7 @@ enum LogRecord<M, U, T> {
 // -- SessionLog: append-only persistence --
 
 pub struct SessionLog {
-    session_id: String,
+    session_id: MakiId,
     file: File,
     saved_msg_count: usize,
     saved_tool_ids: HashSet<String>,
@@ -270,27 +278,42 @@ impl SessionLog {
         U: Serialize,
         T: Serialize,
     {
+        let log = Self::write_canonical(dir, session)?;
+        update_cwd_index(dir, &session.cwd, session.id)?;
+        Ok(log)
+    }
+
+    /// Writes the canonical `{id}.jsonl` without touching the cwd→latest index.
+    /// Used by read-path migration, where merely opening an old session must not
+    /// repoint "latest" at it.
+    fn write_canonical<M, U, T>(
+        dir: &Path,
+        session: &Session<M, U, T>,
+    ) -> Result<Self, SessionError>
+    where
+        M: Serialize,
+        U: Serialize,
+        T: Serialize,
+    {
         fs::create_dir_all(dir).map_err(StorageError::from)?;
-        let path = dir.join(format!("{}.jsonl", session.id));
+        let path = jsonl_path(dir, session.id);
         let mut file = File::create(&path).map_err(StorageError::from)?;
         write_full_session(&mut file, session)?;
         file.sync_data().map_err(StorageError::from)?;
-
-        update_cwd_index(dir, &session.cwd, &session.id)?;
 
         Ok(Self::cursor_from(session, file))
     }
 
     pub fn open<M, U, T>(
         dir: &Path,
-        session_id: &str,
+        session_id: MakiId,
     ) -> Result<(Session<M, U, T>, Self), SessionError>
     where
         M: Serialize + DeserializeOwned,
         U: Serialize + DeserializeOwned + Default,
         T: Serialize + DeserializeOwned,
     {
-        let path = dir.join(format!("{session_id}.jsonl"));
+        let path = jsonl_path(dir, session_id);
         let session = load_jsonl::<M, U, T>(&path)?;
 
         let file = OpenOptions::new()
@@ -302,8 +325,8 @@ impl SessionLog {
         Ok((session, log))
     }
 
-    pub fn session_id(&self) -> &str {
-        &self.session_id
+    pub fn session_id(&self) -> MakiId {
+        self.session_id
     }
 
     pub fn append<M, U, T>(&mut self, session: &Session<M, U, T>) -> Result<(), SessionError>
@@ -312,25 +335,9 @@ impl SessionLog {
         U: Serialize,
         T: Serialize,
     {
-        if session.id != self.session_id {
-            return Err(SessionError::IdMismatch {
-                log_id: self.session_id.clone(),
-                given_id: session.id.clone(),
-            });
-        }
+        self.require_same_id(session)?;
 
-        if self.saved_msg_count > session.messages.len()
-            || self
-                .saved_tool_ids
-                .iter()
-                .any(|id| !session.tool_outputs.contains_key(id))
-            || self.saved_sub_msg_counts.iter().any(|(sub, &count)| {
-                session
-                    .subagent_messages
-                    .get(sub)
-                    .is_none_or(|msgs| count > msgs.len())
-            })
-        {
+        if self.cursor_ahead(session) {
             return Err(SessionError::CursorAhead {
                 saved: self.saved_msg_count,
                 actual: session.messages.len(),
@@ -412,14 +419,9 @@ impl SessionLog {
         U: Serialize,
         T: Serialize,
     {
-        if session.id != self.session_id {
-            return Err(SessionError::IdMismatch {
-                log_id: self.session_id.clone(),
-                given_id: session.id.clone(),
-            });
-        }
+        self.require_same_id(session)?;
 
-        let path = dir.join(format!("{}.jsonl", session.id));
+        let path = jsonl_path(dir, session.id);
         let tmp = path.with_extension("jsonl.tmp");
 
         let mut tmp_file = File::create(&tmp).map_err(StorageError::from)?;
@@ -432,22 +434,63 @@ impl SessionLog {
             .append(true)
             .open(&path)
             .map_err(StorageError::from)?;
-        self.saved_msg_count = session.messages.len();
-        self.saved_tool_ids = session.tool_outputs.keys().cloned().collect();
-        self.saved_sub_msg_counts = sub_msg_snapshot(&session.subagent_messages);
+        self.sync_cursors(session);
 
         Ok(())
     }
 
     fn cursor_from<M, U, T>(session: &Session<M, U, T>, file: File) -> Self {
-        Self {
-            session_id: session.id.clone(),
+        let mut log = Self {
+            session_id: session.id,
             file,
-            saved_msg_count: session.messages.len(),
-            saved_tool_ids: session.tool_outputs.keys().cloned().collect(),
-            saved_sub_msg_counts: sub_msg_snapshot(&session.subagent_messages),
-        }
+            saved_msg_count: 0,
+            saved_tool_ids: HashSet::new(),
+            saved_sub_msg_counts: HashMap::new(),
+        };
+        log.sync_cursors(session);
+        log
     }
+
+    fn require_same_id<M, U, T>(&self, session: &Session<M, U, T>) -> Result<(), SessionError> {
+        if session.id != self.session_id {
+            return Err(SessionError::IdMismatch {
+                log_id: self.session_id,
+                given_id: session.id,
+            });
+        }
+        Ok(())
+    }
+
+    fn cursor_ahead<M, U, T>(&self, session: &Session<M, U, T>) -> bool {
+        self.saved_msg_count > session.messages.len()
+            || self
+                .saved_tool_ids
+                .iter()
+                .any(|id| !session.tool_outputs.contains_key(id))
+            || self.saved_sub_msg_counts.iter().any(|(sub, &count)| {
+                session
+                    .subagent_messages
+                    .get(sub)
+                    .is_none_or(|msgs| count > msgs.len())
+            })
+    }
+
+    fn sync_cursors<M, U, T>(&mut self, session: &Session<M, U, T>) {
+        self.saved_msg_count = session.messages.len();
+        self.saved_tool_ids = session.tool_outputs.keys().cloned().collect();
+        self.saved_sub_msg_counts = sub_msg_snapshot(&session.subagent_messages);
+    }
+}
+
+fn write_record<R: Serialize>(
+    file: &mut File,
+    buf: &mut Vec<u8>,
+    record: &R,
+) -> Result<(), SessionError> {
+    buf.clear();
+    append_record(buf, record)?;
+    file.write_all(buf).map_err(StorageError::from)?;
+    Ok(())
 }
 
 fn write_full_session<M, U, T>(
@@ -460,48 +503,44 @@ where
     T: Serialize,
 {
     let mut buf = Vec::new();
-    append_record(
+    write_record(
+        file,
         &mut buf,
         &LogRecord::<&M, &U, &T>::Header {
             v: LOG_FORMAT_VERSION,
-            id: session.id.clone(),
+            id: session.id,
             model: session.model.clone(),
             cwd: session.cwd.clone(),
             created_at: session.created_at,
         },
     )?;
-    file.write_all(&buf).map_err(StorageError::from)?;
     for msg in &session.messages {
-        buf.clear();
-        append_record(&mut buf, &LogRecord::<&M, &U, &T>::Msg { d: msg })?;
-        file.write_all(&buf).map_err(StorageError::from)?;
+        write_record(file, &mut buf, &LogRecord::<&M, &U, &T>::Msg { d: msg })?;
     }
     for (id, output) in &session.tool_outputs {
-        buf.clear();
-        append_record(
+        write_record(
+            file,
             &mut buf,
             &LogRecord::<&M, &U, &T>::Out {
                 id: id.clone(),
                 d: output,
             },
         )?;
-        file.write_all(&buf).map_err(StorageError::from)?;
     }
     for (sub_id, msgs) in &session.subagent_messages {
         for msg in msgs {
-            buf.clear();
-            append_record(
+            write_record(
+                file,
                 &mut buf,
                 &LogRecord::<&M, &U, &T>::SubMsg {
                     sub: sub_id.clone(),
                     d: msg,
                 },
             )?;
-            file.write_all(&buf).map_err(StorageError::from)?;
         }
     }
-    buf.clear();
-    append_record(
+    write_record(
+        file,
         &mut buf,
         &LogRecord::<&M, &U, &T>::Meta {
             title: session.title.clone(),
@@ -509,9 +548,7 @@ where
             updated_at: session.updated_at,
             meta: session.meta.clone(),
         },
-    )?;
-    file.write_all(&buf).map_err(StorageError::from)?;
-    Ok(())
+    )
 }
 
 fn append_record<R: Serialize>(buf: &mut Vec<u8>, record: &R) -> Result<(), SessionError> {
@@ -520,17 +557,28 @@ fn append_record<R: Serialize>(buf: &mut Vec<u8>, record: &R) -> Result<(), Sess
     Ok(())
 }
 
+/// Tag-only probe used to classify a line that failed the strict `LogRecord`
+/// parse: distinguishes a header with a bad id from a genuinely unknown record.
+#[derive(Deserialize)]
+#[serde(tag = "t", rename_all = "lowercase")]
+enum RawTag {
+    Header {
+        id: String,
+    },
+    #[serde(other)]
+    Other,
+}
+
 fn load_jsonl<M, U, T>(path: &Path) -> Result<Session<M, U, T>, SessionError>
 where
     M: DeserializeOwned,
     U: DeserializeOwned + Default,
     T: DeserializeOwned,
 {
-    let file = File::open(path).map_err(StorageError::from)?;
-    let reader = BufReader::new(file);
+    let reader = BufReader::new(File::open(path).map_err(StorageError::from)?);
     let mut line_count = 0usize;
 
-    let mut id = String::new();
+    let mut id: Option<MakiId> = None;
     let mut model = String::new();
     let mut cwd = String::new();
     let mut created_at = 0u64;
@@ -552,6 +600,20 @@ where
         let record: LogRecord<M, U, T> = match serde_json::from_str(&line) {
             Ok(r) => r,
             Err(e) => {
+                // A header whose only defect is an unparseable id fails the
+                // strict LogRecord parse; surface that precisely instead of
+                // silently skipping to a misleading NotFound. The header is
+                // always the first line, so only probe until we have one.
+                if !got_header
+                    && let Ok(RawTag::Header { id: raw_id }) = serde_json::from_str::<RawTag>(&line)
+                    && let Err(source) = raw_id.parse::<MakiId>()
+                {
+                    return Err(SessionError::CorruptHeaderId {
+                        path: path.display().to_string(),
+                        raw_id,
+                        source,
+                    });
+                }
                 warn!(
                     path = %path.display(),
                     error = %e,
@@ -575,7 +637,7 @@ where
                         expected: LOG_FORMAT_VERSION,
                     });
                 }
-                id = h_id;
+                id = Some(h_id);
                 model = h_model;
                 cwd = h_cwd;
                 created_at = h_created;
@@ -602,9 +664,7 @@ where
         }
     }
 
-    if !got_header {
-        return Err(StorageError::NotFound(path.display().to_string()).into());
-    }
+    let id = id.ok_or(StorageError::NotFound(path.display().to_string()))?;
 
     Ok(Session {
         version: SESSION_VERSION,
@@ -631,24 +691,44 @@ fn load_cwd_index(dir: &Path) -> HashMap<String, String> {
         .unwrap_or_default()
 }
 
-fn update_cwd_index(dir: &Path, cwd: &str, session_id: &str) -> Result<(), StorageError> {
+fn update_cwd_index(dir: &Path, cwd: &str, session_id: MakiId) -> Result<(), StorageError> {
     let mut index = load_cwd_index(dir);
     index.insert(cwd.to_string(), session_id.to_string());
     atomic_write(&dir.join(CWD_INDEX_FILE), &serde_json::to_vec(&index)?)
 }
 
+fn jsonl_path(dir: &Path, id: MakiId) -> PathBuf {
+    dir.join(format!("{id}.jsonl"))
+}
+
+fn json_path(dir: &Path, id: MakiId) -> PathBuf {
+    dir.join(format!("{id}.json"))
+}
+
+fn is_jsonl(path: &Path) -> bool {
+    path.extension().is_some_and(|e| e == "jsonl")
+}
+
+fn remove_legacy_files(dir: &Path, id: MakiId) -> Result<bool, SessionError> {
+    let mut removed = try_remove(&json_path(dir, id))?;
+    for legacy in find_legacy_files(dir, id) {
+        removed |= try_remove(&legacy)?;
+    }
+    Ok(removed)
+}
+
 fn try_remove(path: &Path) -> Result<bool, StorageError> {
     match fs::remove_file(path) {
         Ok(()) => Ok(true),
-        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(false),
         Err(e) => Err(e.into()),
     }
 }
 
-fn remove_from_cwd_index(dir: &Path, session_id: &str) -> Result<(), StorageError> {
+fn remove_from_cwd_index(dir: &Path, session_id: MakiId) -> Result<(), StorageError> {
     let mut index = load_cwd_index(dir);
     let before = index.len();
-    index.retain(|_, v| v != session_id);
+    index.retain(|_, v| v.parse::<MakiId>() != Ok(session_id));
     if index.len() != before {
         atomic_write(&dir.join(CWD_INDEX_FILE), &serde_json::to_vec(&index)?)?;
     }
@@ -660,7 +740,7 @@ fn remove_from_cwd_index(dir: &Path, session_id: &str) -> Result<(), StorageErro
 #[derive(Deserialize)]
 struct JsonlHeader {
     v: u32,
-    id: String,
+    id: MakiId,
     cwd: String,
 }
 
@@ -676,24 +756,16 @@ enum ScanRecord {
 }
 
 fn scan_headers(cwd: &str, dir: &Path) -> Result<Vec<SessionSummary>, StorageError> {
-    let mut out = Vec::new();
-    for path in session_entries(dir)? {
-        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-        match ext {
-            "jsonl" => {
-                if let Some(summary) = scan_jsonl_header(cwd, &path) {
-                    out.push(summary);
-                }
+    Ok(session_entries(dir)?
+        .into_iter()
+        .filter_map(|p| {
+            if is_jsonl(&p) {
+                scan_jsonl_header(cwd, &p)
+            } else {
+                scan_legacy_header(cwd, &p)
             }
-            "json" => {
-                if let Some(summary) = scan_legacy_header(cwd, &path) {
-                    out.push(summary);
-                }
-            }
-            _ => {}
-        }
-    }
-    Ok(out)
+        })
+        .collect())
 }
 
 const TAIL_BUF: u64 = 4096;
@@ -758,24 +830,65 @@ fn scan_legacy_header(cwd: &str, path: &Path) -> Option<SessionSummary> {
 }
 
 fn session_entries(dir: &Path) -> Result<Vec<PathBuf>, StorageError> {
-    let mut entries = Vec::new();
-    for entry in fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
-            continue;
-        };
-        if stem == CWD_INDEX_FILE.trim_end_matches(".json") {
-            continue;
-        }
-        if path
-            .extension()
-            .is_some_and(|e| e == "json" || e == "jsonl")
-        {
-            entries.push(path);
+    Ok(fs::read_dir(dir)?
+        .map(|e| e.map(|e| e.path()))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .filter(|p| is_session_file(p))
+        .collect())
+}
+
+fn is_session_file(p: &Path) -> bool {
+    p.file_stem().and_then(|s| s.to_str()) != Some(CWD_INDEX_STEM)
+        && p.extension().is_some_and(|e| e == "json" || e == "jsonl")
+}
+
+fn find_legacy_files(dir: &Path, id: MakiId) -> Vec<PathBuf> {
+    let canonical = id.to_string();
+    session_entries(dir)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|p| {
+            p.file_stem()
+                .and_then(|s| s.to_str())
+                .is_some_and(|s| s != canonical && s.parse::<MakiId>() == Ok(id))
+        })
+        .collect()
+}
+
+fn locate_session_file(dir: &Path, id: MakiId) -> Option<PathBuf> {
+    for ext in ["jsonl", "json"] {
+        let path = dir.join(format!("{id}.{ext}"));
+        if path.exists() {
+            return Some(path);
         }
     }
-    Ok(entries)
+    let legacy = find_legacy_files(dir, id);
+    legacy
+        .iter()
+        .find(|p| is_jsonl(p))
+        .or_else(|| legacy.first())
+        .cloned()
+}
+
+fn load_session_at<M, U, T>(path: &Path) -> Result<Session<M, U, T>, SessionError>
+where
+    M: DeserializeOwned,
+    U: DeserializeOwned + Default,
+    T: DeserializeOwned,
+{
+    if path.extension().is_some_and(|e| e == "jsonl") {
+        return load_jsonl(path);
+    }
+    let data = fs::read(path).map_err(StorageError::from)?;
+    let session: Session<M, U, T> = serde_json::from_slice(&data).map_err(StorageError::from)?;
+    if session.version != SESSION_VERSION {
+        return Err(SessionError::VersionMismatch {
+            found: session.version,
+            expected: SESSION_VERSION,
+        });
+    }
+    Ok(session)
 }
 
 // -- Session impl --
@@ -790,7 +903,7 @@ where
         let now = now_epoch();
         Self {
             version: SESSION_VERSION,
-            id: uuid::Uuid::new_v4().to_string(),
+            id: MakiId::generate(),
             title: DEFAULT_TITLE.into(),
             cwd: cwd.into(),
             model: model.into(),
@@ -841,28 +954,23 @@ where
         Ok(())
     }
 
-    pub fn load(id: &str, dir: &StateDir) -> Result<Self, SessionError> {
+    pub fn load(id: MakiId, dir: &StateDir) -> Result<Self, SessionError> {
         let sessions_dir = dir.ensure_subdir(SESSIONS_DIR)?;
         Self::load_from(id, &sessions_dir)
     }
 
-    pub fn load_from(id: &str, dir: &Path) -> Result<Self, SessionError> {
-        let jsonl_path = dir.join(format!("{id}.jsonl"));
-        if jsonl_path.exists() {
-            return load_jsonl(&jsonl_path);
-        }
-
-        let json_path = dir.join(format!("{id}.json"));
-        if !json_path.exists() {
-            return Err(StorageError::NotFound(id.into()).into());
-        }
-        let data = fs::read(&json_path).map_err(StorageError::from)?;
-        let session: Self = serde_json::from_slice(&data).map_err(StorageError::from)?;
-        if session.version != SESSION_VERSION {
-            return Err(SessionError::VersionMismatch {
-                found: session.version,
-                expected: SESSION_VERSION,
-            });
+    pub fn load_from(id: MakiId, dir: &Path) -> Result<Self, SessionError> {
+        let Some(path) = locate_session_file(dir, id) else {
+            return Err(StorageError::NotFound(id.to_string()).into());
+        };
+        let session = load_session_at::<M, U, T>(&path)?;
+        let canonical = jsonl_path(dir, id);
+        if path != canonical {
+            if let Err(e) = SessionLog::write_canonical(dir, &session) {
+                warn!(error = %e, "failed migrate to canonical jsonl; keeping legacy file");
+            } else if let Err(e) = fs::remove_file(&path) {
+                warn!(error = %e, path = %path.display(), "legacy file remains after migration");
+            }
         }
         Ok(session)
     }
@@ -884,18 +992,22 @@ where
     }
 
     pub fn latest_in(cwd: &str, dir: &Path) -> Result<Option<Self>, SessionError> {
-        let index = load_cwd_index(dir);
-        if let Some(id) = index.get(cwd)
-            && let Ok(s) = Self::load_from(id, dir)
-        {
-            return Ok(Some(s));
+        if let Some(id) = load_cwd_index(dir).get(cwd).map(|s| s.parse::<MakiId>()) {
+            match id {
+                Ok(id) => match Self::load_from(id, dir) {
+                    Ok(s) => return Ok(Some(s)),
+                    Err(e) => warn!(error = %e, cwd, "indexed session missing on disk; rescanning"),
+                },
+                Err(e) => warn!(error = %e, cwd, "indexed session id unparseable; rescanning"),
+            }
         }
-        let summaries = scan_headers(cwd, dir)?;
-        let latest = summaries.into_iter().max_by_key(|s| s.updated_at);
-        match latest {
-            Some(s) => Self::load_from(&s.id, dir).map(Some),
-            None => Ok(None),
-        }
+
+        // The indexed entry is stale or corrupt; fall back to scanning disk.
+        scan_headers(cwd, dir)?
+            .into_iter()
+            .max_by_key(|s| s.updated_at)
+            .map(|s| Self::load_from(s.id, dir).map(Some))
+            .unwrap_or(Ok(None))
     }
 
     pub fn update_title_if_default(&mut self) {
@@ -904,26 +1016,24 @@ where
         }
     }
 
-    pub fn delete(id: &str, dir: &StateDir) -> Result<(), SessionError> {
+    pub fn delete(id: MakiId, dir: &StateDir) -> Result<(), SessionError> {
         let sessions_dir = dir.ensure_subdir(SESSIONS_DIR)?;
         Self::delete_from(id, &sessions_dir)
     }
 
-    pub fn delete_from(id: &str, dir: &Path) -> Result<(), SessionError> {
-        let jsonl_gone = try_remove(&dir.join(format!("{id}.jsonl")))?;
-        let json_gone = try_remove(&dir.join(format!("{id}.json")))?;
-
-        if !jsonl_gone && !json_gone {
-            return Err(StorageError::NotFound(id.into()).into());
+    pub fn delete_from(id: MakiId, dir: &Path) -> Result<(), SessionError> {
+        let mut removed = try_remove(&jsonl_path(dir, id))?;
+        removed |= remove_legacy_files(dir, id)?;
+        if !removed {
+            return Err(StorageError::NotFound(id.to_string()).into());
         }
-
         remove_from_cwd_index(dir, id)?;
         Ok(())
     }
 
     pub fn migrate_to_jsonl(dir: &Path, session: &Self) -> Result<SessionLog, SessionError> {
         let log = SessionLog::create(dir, session)?;
-        let _ = fs::remove_file(dir.join(format!("{}.json", session.id)));
+        remove_legacy_files(dir, session.id)?;
         Ok(log)
     }
 }
@@ -934,9 +1044,11 @@ mod tests {
     use super::ThinkingParseError;
     use super::{
         CWD_INDEX_FILE, DEFAULT_TITLE, MAX_TITLE_LEN, SESSION_VERSION, StoredSubagent, TAIL_BUF,
-        generate_title, load_cwd_index, update_cwd_index,
+        generate_title, json_path, jsonl_path, load_cwd_index, update_cwd_index,
+        write_full_session,
     };
     use super::{Session, SessionError, SessionLog, StorageError, TitleSource};
+    use crate::id::MakiId;
     use serde_json::Value;
     use std::collections::HashMap;
     use std::fs::{self, OpenOptions};
@@ -946,6 +1058,8 @@ mod tests {
     use test_case::test_case;
 
     type TestSession = Session<Value, Value, Value>;
+
+    const LEGACY_HEX_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
 
     impl TitleSource for Value {
         fn first_user_text(&self) -> Option<&str> {
@@ -964,17 +1078,30 @@ mod tests {
     }
 
     fn user_message(text: &str) -> Value {
+        text_message("user", text)
+    }
+
+    fn assistant_message(text: &str) -> Value {
+        text_message("assistant", text)
+    }
+
+    fn text_message(role: &str, text: &str) -> Value {
         serde_json::json!({
-            "role": "user",
+            "role": role,
             "content": [{"type": "text", "text": text}]
         })
     }
 
-    fn assistant_message(text: &str) -> Value {
-        serde_json::json!({
-            "role": "assistant",
-            "content": [{"type": "text", "text": text}]
-        })
+    fn write_legacy_jsonl(path: &Path, session: &TestSession) {
+        let mut file = std::fs::File::create(path).unwrap();
+        write_full_session(&mut file, session).unwrap();
+    }
+
+    fn append_raw_msg(path: &Path, message: Value) {
+        let record = serde_json::to_string(&serde_json::json!({"t":"msg","d": message})).unwrap();
+        let mut file = OpenOptions::new().append(true).open(path).unwrap();
+        file.write_all(record.as_bytes()).unwrap();
+        file.write_all(b"\n").unwrap();
     }
 
     #[test]
@@ -1035,7 +1162,7 @@ mod tests {
         );
         session.save_to(dir).unwrap();
 
-        let loaded = TestSession::load_from(&session.id, dir).unwrap();
+        let loaded = TestSession::load_from(session.id, dir).unwrap();
         assert_eq!(loaded.id, session.id);
         assert_eq!(loaded.model, "anthropic/claude-sonnet-4");
         assert_eq!(loaded.cwd, "/home/test/project");
@@ -1068,7 +1195,7 @@ mod tests {
         );
         session.save_to(dir).unwrap();
 
-        let loaded = TestSession::load_from(&session.id, dir).unwrap();
+        let loaded = TestSession::load_from(session.id, dir).unwrap();
         let sonnet = &loaded.meta.usage_by_model["claude-sonnet-4"];
         assert_eq!(sonnet.input, 100);
         assert_eq!(sonnet.output, 20);
@@ -1079,12 +1206,15 @@ mod tests {
 
     #[test]
     fn usage_by_model_absent_on_legacy_session() {
-        let json = r#"{"t":"header","v":2,"id":"x","model":"m","cwd":"/","created_at":0}
-{"t":"meta","title":"t","token_usage":null,"updated_at":0}"#;
+        let id: MakiId = LEGACY_HEX_ID.parse().unwrap();
+        let json = format!(
+            r#"{{"t":"header","v":2,"id":"{LEGACY_HEX_ID}","model":"m","cwd":"/","created_at":0}}
+{{"t":"meta","title":"t","token_usage":null,"updated_at":0}}"#
+        );
         let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("x.jsonl");
+        let path = tmp.path().join(format!("{LEGACY_HEX_ID}.jsonl"));
         fs::write(&path, json).unwrap();
-        let loaded = TestSession::load_from("x", tmp.path()).unwrap();
+        let loaded = TestSession::load_from(id, tmp.path()).unwrap();
         assert!(loaded.meta.usage_by_model.is_empty());
     }
 
@@ -1117,7 +1247,7 @@ mod tests {
             .insert("sub-2".into(), vec![user_message("sub-2-prompt")]);
         log.append(&session).unwrap();
 
-        let loaded = TestSession::load_from(&session.id, dir).unwrap();
+        let loaded = TestSession::load_from(session.id, dir).unwrap();
         assert_eq!(loaded.messages.len(), 3);
         assert_eq!(loaded.tool_outputs.len(), 1);
         assert!(loaded.tool_outputs.contains_key("tool-1"));
@@ -1145,11 +1275,11 @@ mod tests {
         session.messages.push(user_message("survives"));
         session.save_to(dir).unwrap();
 
-        let path = dir.join(format!("{}.jsonl", session.id));
+        let path = jsonl_path(dir, session.id);
         let mut file = OpenOptions::new().append(true).open(&path).unwrap();
         file.write_all(b"{\"t\":\"msg\",\"d\":{\"trun").unwrap();
 
-        let loaded = TestSession::load_from(&session.id, dir).unwrap();
+        let loaded = TestSession::load_from(session.id, dir).unwrap();
         assert_eq!(loaded.messages.len(), 1);
     }
 
@@ -1177,7 +1307,7 @@ mod tests {
         session.messages.push(user_message("after-compact-3"));
         log.append(&session).unwrap();
 
-        let loaded = TestSession::load_from(&session.id, dir).unwrap();
+        let loaded = TestSession::load_from(session.id, dir).unwrap();
         assert_eq!(loaded.messages.len(), 8);
         assert!(loaded.subagent_messages.is_empty());
     }
@@ -1189,19 +1319,19 @@ mod tests {
         let mut session: TestSession = Session::new("m", "/project");
         session.messages.push(user_message("legacy"));
 
-        let json_path = dir.join(format!("{}.json", session.id));
+        let json_path = json_path(dir, session.id);
         fs::write(&json_path, serde_json::to_vec(&session).unwrap()).unwrap();
-        update_cwd_index(dir, &session.cwd, &session.id).unwrap();
+        update_cwd_index(dir, &session.cwd, session.id).unwrap();
 
-        let loaded = TestSession::load_from(&session.id, dir).unwrap();
+        let loaded = TestSession::load_from(session.id, dir).unwrap();
         assert_eq!(loaded.messages.len(), 1);
 
         let _log = TestSession::migrate_to_jsonl(dir, &loaded).unwrap();
 
         assert!(!json_path.exists());
-        assert!(dir.join(format!("{}.jsonl", session.id)).exists());
+        assert!(jsonl_path(dir, session.id).exists());
 
-        let reloaded = TestSession::load_from(&session.id, dir).unwrap();
+        let reloaded = TestSession::load_from(session.id, dir).unwrap();
         assert_eq!(reloaded.messages.len(), 1);
         assert_eq!(reloaded.model, "m");
     }
@@ -1209,11 +1339,34 @@ mod tests {
     #[test]
     fn load_nonexistent_returns_not_found() {
         let tmp = TempDir::new().unwrap();
-        let err = TestSession::load_from("nonexistent-id", tmp.path()).unwrap_err();
+        let id = MakiId::generate();
+        let err = TestSession::load_from(id, tmp.path()).unwrap_err();
         assert!(matches!(
             err,
             SessionError::Storage(StorageError::NotFound(_))
         ));
+    }
+
+    #[test_case("550e8400-e29b-41d4-a716-446655440000")]
+    #[test_case("550e8400e29b41d4a716446655440000")]
+    fn load_legacy_hex_filename_migrates_to_canonical(legacy: &str) {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        let id: MakiId = legacy.parse().unwrap();
+        let mut session: TestSession = Session::new("m", "/project");
+        session.id = id;
+        session.messages.push(user_message("legacy"));
+        let legacy_path = dir.join(format!("{legacy}.jsonl"));
+        write_legacy_jsonl(&legacy_path, &session);
+
+        let loaded = TestSession::load_from(id, dir).unwrap();
+        assert_eq!(loaded.id, id);
+        assert_eq!(loaded.messages.len(), 1);
+
+        assert!(!legacy_path.exists());
+        let canonical = jsonl_path(dir, id);
+        assert!(canonical.exists());
     }
 
     #[test]
@@ -1235,7 +1388,7 @@ mod tests {
     fn save_with_time(session: &mut TestSession, dir: &Path, time: u64) {
         session.updated_at = time;
         SessionLog::create(dir, session).unwrap();
-        update_cwd_index(dir, &session.cwd, &session.id).unwrap();
+        update_cwd_index(dir, &session.cwd, session.id).unwrap();
     }
 
     #[test]
@@ -1297,21 +1450,195 @@ mod tests {
         let mut s2: TestSession = Session::new("m", "/other");
         s2.save_to(dir).unwrap();
 
-        TestSession::delete_from(&s1.id, dir).unwrap();
-        assert!(!dir.join(format!("{}.jsonl", s1.id)).exists());
+        TestSession::delete_from(s1.id, dir).unwrap();
+        assert!(!jsonl_path(dir, s1.id).exists());
         let index = load_cwd_index(dir);
-        assert!(!index.values().any(|v| v == &s1.id));
-        assert_eq!(index.get("/other"), Some(&s2.id));
+        assert!(!index.values().any(|v| *v == s1.id.to_string()));
+        assert_eq!(index.get("/other"), Some(&s2.id.to_string()));
     }
 
     #[test]
     fn delete_nonexistent_returns_not_found() {
         let tmp = TempDir::new().unwrap();
-        let err = TestSession::delete_from("nonexistent", tmp.path()).unwrap_err();
+        let id = MakiId::generate();
+        let err = TestSession::delete_from(id, tmp.path()).unwrap_err();
         assert!(matches!(
             err,
             SessionError::Storage(StorageError::NotFound(_))
         ));
+    }
+
+    #[test_case("550e8400-e29b-41d4-a716-446655440000")]
+    #[test_case("550e8400e29b41d4a716446655440000")]
+    fn delete_legacy_hex_filename_removes_file(legacy: &str) {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        let id: MakiId = legacy.parse().unwrap();
+        let mut session: TestSession = Session::new("m", "/project");
+        session.id = id;
+        session.messages.push(user_message("legacy"));
+        let legacy_path = dir.join(format!("{legacy}.jsonl"));
+        write_legacy_jsonl(&legacy_path, &session);
+
+        TestSession::delete_from(id, dir).unwrap();
+        assert!(!legacy_path.exists());
+        let canonical = jsonl_path(dir, id);
+        assert!(!canonical.exists());
+    }
+
+    #[test]
+    fn delete_removes_coexisting_json_and_jsonl() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let mut session: TestSession = Session::new("m", "/project");
+        session.messages.push(user_message("hi"));
+
+        let jsonl_file = jsonl_path(dir, session.id);
+        write_legacy_jsonl(&jsonl_file, &session);
+        let json_file = json_path(dir, session.id);
+        fs::write(&json_file, serde_json::to_vec(&session).unwrap()).unwrap();
+
+        TestSession::delete_from(session.id, dir).unwrap();
+        assert!(!jsonl_file.exists());
+        assert!(!json_file.exists());
+    }
+
+    #[test]
+    fn load_picks_jsonl_when_legacy_dual_file_exists() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        let id: MakiId = LEGACY_HEX_ID.parse().unwrap();
+        let mut jsonl_session: TestSession = Session::new("m", "/project");
+        jsonl_session.id = id;
+        jsonl_session.messages.push(user_message("newer"));
+
+        let legacy_jsonl = dir.join(format!("{LEGACY_HEX_ID}.jsonl"));
+        write_legacy_jsonl(&legacy_jsonl, &jsonl_session);
+
+        let mut json_session: TestSession = Session::new("m", "/project");
+        json_session.id = id;
+        json_session.messages.push(user_message("older"));
+        let legacy_json = dir.join(format!("{LEGACY_HEX_ID}.json"));
+        fs::write(&legacy_json, serde_json::to_vec(&json_session).unwrap()).unwrap();
+
+        let loaded = TestSession::load_from(id, dir).unwrap();
+        assert_eq!(loaded.messages.len(), 1);
+        assert_eq!(loaded.messages[0], user_message("newer"));
+    }
+
+    #[test]
+    fn delete_drains_coexisting_legacy_json_and_jsonl() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        let id: MakiId = LEGACY_HEX_ID.parse().unwrap();
+        let mut session: TestSession = Session::new("m", "/project");
+        session.id = id;
+        session.messages.push(user_message("legacy"));
+
+        let legacy_jsonl = dir.join(format!("{LEGACY_HEX_ID}.jsonl"));
+        write_legacy_jsonl(&legacy_jsonl, &session);
+
+        let legacy_json = dir.join(format!("{LEGACY_HEX_ID}.json"));
+        fs::write(&legacy_json, serde_json::to_vec(&session).unwrap()).unwrap();
+
+        TestSession::delete_from(id, dir).unwrap();
+        assert!(!legacy_jsonl.exists());
+        assert!(!legacy_json.exists());
+    }
+
+    #[test]
+    fn migrate_to_jsonl_removes_legacy_named_files() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        let id: MakiId = LEGACY_HEX_ID.parse().unwrap();
+        let mut session: TestSession = Session::new("m", "/project");
+        session.id = id;
+        session.messages.push(user_message("legacy"));
+
+        let legacy_jsonl = dir.join(format!("{LEGACY_HEX_ID}.jsonl"));
+        write_legacy_jsonl(&legacy_jsonl, &session);
+
+        let legacy_json = dir.join(format!("{LEGACY_HEX_ID}.json"));
+        fs::write(&legacy_json, serde_json::to_vec(&session).unwrap()).unwrap();
+
+        let _log = TestSession::migrate_to_jsonl(dir, &session).unwrap();
+
+        assert!(!legacy_jsonl.exists());
+        assert!(!legacy_json.exists());
+        assert!(jsonl_path(dir, id).exists());
+    }
+
+    #[test]
+    fn load_migration_does_not_steal_latest_pointer() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        let mut newest: TestSession = Session::new("m", "/project");
+        newest.title = "newest".into();
+        save_with_time(&mut newest, dir, 3000);
+
+        let mut older: TestSession = Session::new("m", "/project");
+        older.title = "older".into();
+        older.updated_at = 1000;
+        let json_path = json_path(dir, older.id);
+        fs::write(&json_path, serde_json::to_vec(&older).unwrap()).unwrap();
+
+        // Opening the older session migrates it to canonical jsonl, but must not
+        // repoint cwd→latest at it.
+        let loaded = TestSession::load_from(older.id, dir).unwrap();
+        assert_eq!(loaded.title, "older");
+        assert!(!json_path.exists());
+
+        let latest = TestSession::latest_in("/project", dir).unwrap().unwrap();
+        assert_eq!(latest.title, "newest");
+    }
+
+    #[test]
+    fn load_surfaces_corrupt_header_id() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let id = MakiId::generate();
+        let mut session: TestSession = Session::new("m", "/project");
+        session.id = id;
+
+        let path = jsonl_path(dir, id);
+        write_legacy_jsonl(&path, &session);
+
+        let corrupted =
+            fs::read_to_string(&path)
+                .unwrap()
+                .replacen(&id.to_string(), "not-a-valid-id", 1);
+        fs::write(&path, corrupted).unwrap();
+
+        let err = TestSession::load_from(id, dir).unwrap_err();
+        assert!(matches!(err, SessionError::CorruptHeaderId { .. }));
+    }
+
+    #[test]
+    fn remove_from_cwd_index_matches_legacy_hex_value() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        let legacy = "550e8400-e29b-41d4-a716-446655440000";
+        let id: MakiId = legacy.parse().unwrap();
+        let mut session: TestSession = Session::new("m", "/project");
+        session.id = id;
+
+        let mut index: HashMap<String, String> = HashMap::new();
+        index.insert("/project".into(), legacy.to_string());
+        fs::write(
+            dir.join(CWD_INDEX_FILE),
+            serde_json::to_vec(&index).unwrap(),
+        )
+        .unwrap();
+
+        super::remove_from_cwd_index(dir, session.id).unwrap();
+        let after = load_cwd_index(dir);
+        assert!(!after.contains_key("/project"));
     }
 
     #[test]
@@ -1333,7 +1660,7 @@ mod tests {
 
         let mut s2: TestSession = Session::new("m", "/project");
         s2.title = "json-session".into();
-        let json_path = dir.join(format!("{}.json", s2.id));
+        let json_path = json_path(dir, s2.id);
         fs::write(&json_path, serde_json::to_vec(&s2).unwrap()).unwrap();
 
         let list = TestSession::list_in("/project", dir).unwrap();
@@ -1346,10 +1673,10 @@ mod tests {
         let dir = tmp.path();
         let mut session: TestSession = Session::new("test/model", "/tmp");
         session.version = 999;
-        let path = dir.join(format!("{}.json", session.id));
+        let path = json_path(dir, session.id);
         fs::write(&path, serde_json::to_vec(&session).unwrap()).unwrap();
 
-        let err = TestSession::load_from(&session.id, dir).unwrap_err();
+        let err = TestSession::load_from(session.id, dir).unwrap_err();
         assert!(matches!(
             err,
             SessionError::VersionMismatch { found: 999, .. }
@@ -1368,14 +1695,14 @@ mod tests {
         log.append(&session).unwrap();
         drop(log);
 
-        let (loaded, mut log) = SessionLog::open::<Value, Value, Value>(dir, &session.id).unwrap();
+        let (loaded, mut log) = SessionLog::open::<Value, Value, Value>(dir, session.id).unwrap();
         assert_eq!(loaded.messages.len(), 2);
 
         session.messages.push(user_message("second"));
         log.append(&session).unwrap();
         drop(log);
 
-        let reloaded = TestSession::load_from(&session.id, dir).unwrap();
+        let reloaded = TestSession::load_from(session.id, dir).unwrap();
         assert_eq!(reloaded.messages.len(), 3);
     }
 
@@ -1386,15 +1713,16 @@ mod tests {
         let bad_header = serde_json::json!({
             "t": "header",
             "v": 999,
-            "id": "test-id",
+            "id": "01965087-4c71-7f00-8000-000000000000",
             "model": "m",
             "cwd": "/tmp",
             "created_at": 0
         });
-        let path = dir.join("test-id.jsonl");
+        let id: MakiId = "01965087-4c71-7f00-8000-000000000000".parse().unwrap();
+        let path = jsonl_path(dir, id);
         fs::write(&path, format!("{}\n", bad_header)).unwrap();
 
-        let err = TestSession::load_from("test-id", dir).unwrap_err();
+        let err = TestSession::load_from(id, dir).unwrap_err();
         assert!(matches!(
             err,
             SessionError::VersionMismatch { found: 999, .. }
@@ -1440,7 +1768,7 @@ mod tests {
         session.meta.workflow = true;
         session.save_to(dir).unwrap();
 
-        let loaded = TestSession::load_from(&session.id, dir).unwrap();
+        let loaded = TestSession::load_from(session.id, dir).unwrap();
         assert_eq!(
             loaded.meta.thinking,
             Some(StoredThinking::Budget { tokens: 8192 })
@@ -1461,18 +1789,13 @@ mod tests {
         let mut log = SessionLog::create(dir, &session).unwrap();
         log.append(&session).unwrap();
 
-        let path = dir.join(format!("{}.jsonl", session.id));
+        let path = jsonl_path(dir, session.id);
         let mut file = OpenOptions::new().append(true).open(&path).unwrap();
         file.write_all(b"CORRUPT\n").unwrap();
-        file.write_all(
-            serde_json::to_string(&serde_json::json!({"t":"msg","d": user_message("second")}))
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
-        file.write_all(b"\n").unwrap();
+        drop(file);
+        append_raw_msg(&path, user_message("second"));
 
-        let loaded = TestSession::load_from(&session.id, dir).unwrap();
+        let loaded = TestSession::load_from(session.id, dir).unwrap();
         assert_eq!(loaded.messages.len(), 2);
         assert!(loaded.tool_outputs.contains_key("t1"));
     }
@@ -1481,8 +1804,8 @@ mod tests {
     fn corrupt_header_line_only_returns_not_found() {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
-        let id = "fake-session-id";
-        let path = dir.join(format!("{id}.jsonl"));
+        let id: MakiId = "01965087-4c71-7f00-8000-000000000000".parse().unwrap();
+        let path = jsonl_path(dir, id);
         fs::write(&path, "NOT_A_HEADER\n").unwrap();
 
         let err = TestSession::load_from(id, dir).unwrap_err();
@@ -1500,18 +1823,13 @@ mod tests {
         session.messages.push(user_message("msg"));
         session.save_to(dir).unwrap();
 
-        let path = dir.join(format!("{}.jsonl", session.id));
+        let path = jsonl_path(dir, session.id);
         let mut file = OpenOptions::new().append(true).open(&path).unwrap();
         file.write_all(b"\n\n\n").unwrap();
-        file.write_all(
-            serde_json::to_string(&serde_json::json!({"t":"msg","d": user_message("after")}))
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
-        file.write_all(b"\n").unwrap();
+        drop(file);
+        append_raw_msg(&path, user_message("after"));
 
-        let loaded = TestSession::load_from(&session.id, dir).unwrap();
+        let loaded = TestSession::load_from(session.id, dir).unwrap();
         assert_eq!(loaded.messages.len(), 2);
     }
 
@@ -1523,19 +1841,14 @@ mod tests {
         session.messages.push(user_message("first"));
         session.save_to(dir).unwrap();
 
-        let path = dir.join(format!("{}.jsonl", session.id));
+        let path = jsonl_path(dir, session.id);
         let mut file = OpenOptions::new().append(true).open(&path).unwrap();
         file.write_all(b"{\"t\":\"future_type\",\"d\":{}}\n")
             .unwrap();
-        file.write_all(
-            serde_json::to_string(&serde_json::json!({"t":"msg","d": user_message("second")}))
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
-        file.write_all(b"\n").unwrap();
+        drop(file);
+        append_raw_msg(&path, user_message("second"));
 
-        let loaded = TestSession::load_from(&session.id, dir).unwrap();
+        let loaded = TestSession::load_from(session.id, dir).unwrap();
         assert_eq!(loaded.messages.len(), 2);
     }
 
@@ -1565,7 +1878,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let session: TestSession = Session::new("m", "/project");
-        let path = dir.join(format!("{}.jsonl", session.id));
+        let path = jsonl_path(dir, session.id);
         let header = serde_json::json!({"t":"header","v":2,"id":session.id,"model":"m","cwd":"/project","created_at":0});
         fs::write(&path, format!("{}\n", header)).unwrap();
 

--- a/maki-storage/src/theme.rs
+++ b/maki-storage/src/theme.rs
@@ -1,11 +1,15 @@
 use std::fs;
 
+use tracing::warn;
+
 use crate::StateDir;
 
 const THEME_FILE: &str = "theme";
 
 pub fn persist_theme_name(dir: &StateDir, name: &str) {
-    let _ = fs::write(dir.path().join(THEME_FILE), name);
+    if let Err(e) = fs::write(dir.path().join(THEME_FILE), name) {
+        warn!(error = %e, "failed to persist theme name");
+    }
 }
 
 pub fn read_theme_name(dir: &StateDir) -> Option<String> {

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -17,6 +17,7 @@ use maki_agent::{
 };
 use maki_lua::EventHandle;
 use maki_providers::{AgentError, Message, Model, TokenUsage};
+use maki_storage::id::SessionRef;
 use serde_json::Value;
 use tracing::error;
 
@@ -42,7 +43,7 @@ pub(super) struct AgentLoop {
     agent_tx: flume::Sender<Envelope>,
     answer_rx: Arc<async_lock::Mutex<flume::Receiver<String>>>,
     queue: Arc<QueueReceiver>,
-    session_id: Option<String>,
+    session_id: Option<SessionRef>,
     timeouts: maki_providers::Timeouts,
     lua_handle: Option<EventHandle>,
     subagent_cancels: Arc<CancelMap<String>>,
@@ -64,7 +65,7 @@ impl AgentLoop {
         queue: Arc<QueueReceiver>,
         cancel_map: Arc<RunCancelMap>,
         init_cancel: CancelToken,
-        session_id: Option<String>,
+        session_id: Option<SessionRef>,
         timeouts: maki_providers::Timeouts,
         lua_handle: Option<EventHandle>,
         subagent_cancels: Arc<CancelMap<String>>,

--- a/maki-ui/src/agent/mod.rs
+++ b/maki-ui/src/agent/mod.rs
@@ -17,6 +17,7 @@ use maki_agent::{
     McpSnapshotReader, ToolOutput, ToolOutputLines,
 };
 use maki_lua::EventHandle;
+use maki_storage::id::SessionRef;
 
 use self::cancel_map::new_run_cancel_map;
 use maki_providers::provider::Provider;
@@ -66,7 +67,7 @@ impl AgentHandles {
         tool_output_lines: ToolOutputLines,
         permissions: &Arc<PermissionManager>,
         cwd: PathBuf,
-        session_id: Option<String>,
+        session_id: Option<SessionRef>,
         timeouts: maki_providers::Timeouts,
         lua_handle: Option<EventHandle>,
     ) -> Self {
@@ -140,7 +141,7 @@ impl AgentHandles {
             permissions,
             self.mcp_handle.clone(),
             self.mcp_config_errors.clone(),
-            Some(app.state.session.id.clone()),
+            Some(SessionRef::from(app.state.session.id)),
             self.timeouts,
             lua_handle,
         );
@@ -189,7 +190,7 @@ fn spawn_agent_internal(
     permissions: &Arc<PermissionManager>,
     mcp_handle: Option<McpHandle>,
     mcp_config_errors: McpConfigErrors,
-    session_id: Option<String>,
+    session_id: Option<SessionRef>,
     timeouts: maki_providers::Timeouts,
     lua_handle: Option<EventHandle>,
 ) -> AgentHandles {

--- a/maki-ui/src/app/btw.rs
+++ b/maki-ui/src/app/btw.rs
@@ -4,6 +4,7 @@ use flume::Sender;
 use futures_lite::future;
 use maki_providers::provider::Provider;
 use maki_providers::{Message, Model, ProviderEvent, RequestOptions};
+use maki_storage::id::SessionRef;
 use serde_json::Value;
 
 use crate::components::btw_modal::BtwEvent;
@@ -47,7 +48,7 @@ impl App {
         let (tx, rx) = flume::bounded(64);
         self.btw_modal.open(&question, rx);
 
-        let session_id = self.state.session.id.clone();
+        let session_id = SessionRef::from(self.state.session.id);
         smol::spawn(run_btw(
             provider,
             model,
@@ -66,7 +67,7 @@ async fn run_btw(
     system: String,
     messages: Vec<Message>,
     btw_tx: Sender<BtwEvent>,
-    session_id: Option<String>,
+    session_id: Option<SessionRef>,
 ) {
     let (event_tx, event_rx) = flume::unbounded();
     let tools = Value::Array(vec![]);
@@ -79,7 +80,7 @@ async fn run_btw(
         &tools,
         &event_tx,
         RequestOptions::default(),
-        session_id.as_deref(),
+        session_id.as_ref(),
     );
 
     let forward_fut = async {

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -6,6 +6,7 @@ use crate::components::DisplayRole;
 use crate::components::rewind_picker::RewindEntry;
 use crate::components::{Action, LoadedSession};
 use maki_providers::{Model, TokenUsage};
+use maki_storage::id::MakiId;
 use maki_storage::sessions::StoredSubagent;
 
 use crate::AppSession;
@@ -217,7 +218,7 @@ impl App {
     pub(super) fn open_session_picker(&mut self) -> Vec<Action> {
         self.session_picker.open(
             &self.state.session.cwd,
-            &self.state.session.id,
+            self.state.session.id,
             &self.storage,
         );
         vec![]
@@ -241,8 +242,8 @@ impl App {
         self.loaded_session_snapshot()
     }
 
-    pub(super) fn load_session(&mut self, session_id: String) -> Vec<Action> {
-        let session = match AppSession::load(&session_id, &self.storage) {
+    pub(super) fn load_session(&mut self, session_id: MakiId) -> Vec<Action> {
+        let session = match AppSession::load(session_id, &self.storage) {
             Ok(s) => s,
             Err(e) => {
                 self.status_bar
@@ -255,13 +256,13 @@ impl App {
         vec![Action::LoadSession(Box::new(loaded))]
     }
 
-    pub(super) fn delete_session(&mut self, session_id: String) -> Vec<Action> {
-        if let Err(e) = AppSession::delete(&session_id, &self.storage) {
+    pub(super) fn delete_session(&mut self, session_id: MakiId) -> Vec<Action> {
+        if let Err(e) = AppSession::delete(session_id, &self.storage) {
             self.status_bar
                 .flash(format!("Failed to delete session: {e}"));
             return vec![];
         }
-        self.session_picker.remove_entry(&session_id);
+        self.session_picker.remove_entry(session_id);
         self.status_bar.flash("Session deleted".into());
         vec![]
     }

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -509,7 +509,7 @@ fn load_session_clears_plan() {
         .messages
         .push(Message::user("test".into()));
     app.state.session.save(&app.storage).unwrap();
-    let id = app.state.session.id.clone();
+    let id = app.state.session.id;
     app.state.mode = Mode::Build;
     app.state.plan = PlanState::Ready(PathBuf::from("old-plan.md"));
     app.load_session(id);

--- a/maki-ui/src/components/session_picker.rs
+++ b/maki-ui/src/components/session_picker.rs
@@ -8,6 +8,7 @@ use crate::components::list_picker::{ListPicker, PickerAction, PickerItem};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use jiff::Timestamp;
 use maki_storage::StateDir;
+use maki_storage::id::MakiId;
 use ratatui::Frame;
 use ratatui::layout::{Position, Rect};
 
@@ -17,14 +18,14 @@ const FOOTER_HINTS: &[(&str, &str)] = &[("Enter", "open"), (key::DELETE.label, "
 
 pub enum SessionPickerAction {
     Consumed,
-    Select(String),
+    Select(MakiId),
     ConfirmDelete,
-    Delete(String),
+    Delete(MakiId),
     Close,
 }
 
 struct SessionEntry {
-    id: String,
+    id: MakiId,
     title: String,
     relative_time: String,
 }
@@ -40,7 +41,7 @@ impl PickerItem for SessionEntry {
 
 pub struct SessionPicker {
     picker: ListPicker<SessionEntry>,
-    confirming: Option<(String, u64)>,
+    confirming: Option<(MakiId, u64)>,
     pending_rx: Option<flume::Receiver<Result<Vec<SessionEntry>, String>>>,
     flash: Option<String>,
 }
@@ -55,10 +56,9 @@ impl SessionPicker {
         }
     }
 
-    pub fn open(&mut self, cwd: &str, current_session_id: &str, dir: &StateDir) {
+    pub fn open(&mut self, cwd: &str, current_session_id: MakiId, dir: &StateDir) {
         self.picker.open_loading(TITLE);
         let cwd = cwd.to_owned();
-        let current_session_id = current_session_id.to_owned();
         let dir = dir.clone();
         let (tx, rx) = flume::bounded(1);
         thread::spawn(move || {
@@ -120,7 +120,7 @@ impl SessionPicker {
         self.pending_rx = None;
     }
 
-    pub fn remove_entry(&mut self, id: &str) {
+    pub fn remove_entry(&mut self, id: MakiId) {
         self.picker.retain(|e| e.id != id);
     }
 
@@ -166,10 +166,10 @@ impl SessionPicker {
             .as_ref()
             .is_some_and(|(id, g)| id == &selected.id && *g == generation)
         {
-            return SessionPickerAction::Delete(selected.id.clone());
+            return SessionPickerAction::Delete(selected.id);
         }
 
-        self.confirming = Some((selected.id.clone(), generation));
+        self.confirming = Some((selected.id, generation));
         SessionPickerAction::ConfirmDelete
     }
 

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -17,6 +17,7 @@ use maki_providers::Timeouts;
 use maki_providers::provider::{Provider, fetch_all_models, from_model};
 use maki_providers::{Message, Model};
 use maki_storage::StateDir;
+use maki_storage::id::{MakiId, SessionRef};
 use tracing::warn;
 
 use crate::AppSession;
@@ -204,7 +205,7 @@ impl<'t> EventLoop<'t> {
             ui_config.tool_output_lines,
             &permissions,
             cwd,
-            Some(session.id.clone()),
+            Some(SessionRef::from(session.id)),
             timeouts,
             lua_event_handle.clone(),
         );
@@ -262,7 +263,7 @@ impl<'t> EventLoop<'t> {
         })
     }
 
-    pub(crate) fn run(mut self, initial_prompt: Option<String>) -> Result<(Option<String>, i32)> {
+    pub(crate) fn run(mut self, initial_prompt: Option<String>) -> Result<(Option<MakiId>, i32)> {
         if let Some(prompt) = initial_prompt {
             let sub = Submission {
                 text: prompt,
@@ -609,12 +610,9 @@ impl<'t> EventLoop<'t> {
         }
     }
 
-    fn shutdown(mut self) -> (Option<String>, i32) {
+    fn shutdown(mut self) -> (Option<MakiId>, i32) {
         let exit_code = self.app.exit_request.code();
-        let session_id = self
-            .app
-            .has_content()
-            .then(|| self.app.state.session.id.clone());
+        let session_id = self.app.has_content().then_some(self.app.state.session.id);
         maki_agent::mcp::kill_process_groups(&self.handles.mcp_reader().load().pids);
         self.app.cmd_tx = None;
         self.app.answer_tx = None;

--- a/maki-ui/src/lib.rs
+++ b/maki-ui/src/lib.rs
@@ -30,6 +30,7 @@ use color_eyre::Result;
 use maki_agent::ToolOutput;
 use maki_providers::Message;
 use maki_providers::TokenUsage;
+use maki_storage::id::MakiId;
 
 pub type AppSession = maki_storage::sessions::Session<Message, TokenUsage, ToolOutput>;
 
@@ -39,7 +40,7 @@ pub use event_loop::EventLoopParams;
 pub fn run(
     params: EventLoopParams,
     initial_prompt: Option<String>,
-) -> Result<(Option<String>, i32)> {
+) -> Result<(Option<MakiId>, i32)> {
     let (_guard, mut terminal) = terminal::TerminalGuard::init()?;
     let el = event_loop::EventLoop::new(&mut terminal, params)?;
     el.run(initial_prompt)

--- a/maki-ui/src/storage_writer.rs
+++ b/maki-ui/src/storage_writer.rs
@@ -98,11 +98,12 @@ fn open_or_create_log(
 ) -> Result<SessionLog, maki_storage::sessions::SessionError> {
     let jsonl_path = sessions_dir.join(format!("{}.jsonl", session.id));
     if jsonl_path.exists() {
+        let id = session.id;
         let (_loaded, log) = SessionLog::open::<
             maki_providers::Message,
             maki_providers::TokenUsage,
             maki_agent::ToolOutput,
-        >(sessions_dir, &session.id)?;
+        >(sessions_dir, id)?;
         Ok(log)
     } else {
         AppSession::migrate_to_jsonl(sessions_dir, session)

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -11,6 +11,7 @@ use maki_config::{load_env_files, load_permissions};
 use maki_lua::PluginHost;
 use maki_providers::model::Model;
 use maki_storage::StateDir;
+use maki_storage::id::MakiId;
 use maki_ui::AppSession;
 
 use crate::cli::{Cli, normalize_tool_name};
@@ -26,13 +27,16 @@ fn discover_commands(disable: bool) -> Vec<CustomCommand> {
 
 fn resolve_session(
     continue_session: bool,
-    session_id: Option<String>,
+    session_id: Option<&str>,
     model: &str,
     cwd: &str,
     storage: &StateDir,
 ) -> Result<AppSession> {
-    if let Some(id) = session_id {
-        return AppSession::load(&id, storage).map_err(|e| color_eyre::eyre::eyre!("{e}"));
+    if let Some(raw) = session_id {
+        let id: MakiId = raw
+            .parse()
+            .map_err(|e| color_eyre::eyre::eyre!("invalid session id {raw:?}: {e}"))?;
+        return AppSession::load(id, storage).map_err(|e| color_eyre::eyre::eyre!("{e}"));
     }
     if continue_session {
         match AppSession::latest(cwd, storage) {
@@ -171,7 +175,7 @@ pub fn run(cli: Cli) -> Result<()> {
         let cwd_str = cwd.to_string_lossy().into_owned();
         let mut session = resolve_session(
             cli.continue_session,
-            cli.session,
+            cli.session.as_deref(),
             &model.spec(),
             &cwd_str,
             &storage,

--- a/src/print.rs
+++ b/src/print.rs
@@ -20,6 +20,7 @@ use maki_agent::{AgentConfig, AgentEvent, Envelope, ImageSource, PermissionsConf
 use maki_lua::EventHandle;
 use maki_providers::model::Model;
 use maki_providers::{StopReason, TokenUsage};
+use maki_storage::id::SessionRef;
 use serde::Serialize;
 use serde_json::Value;
 
@@ -56,7 +57,7 @@ struct PrintResult {
     num_turns: u32,
     result: String,
     stop_reason: Option<StopReason>,
-    session_id: String,
+    session_id: SessionRef,
     total_cost_usd: f64,
     usage: TokenUsage,
 }
@@ -67,7 +68,7 @@ struct InitEvent<'a> {
     event_type: &'static str,
     subtype: &'static str,
     cwd: &'a str,
-    session_id: &'a str,
+    session_id: &'a SessionRef,
     tools: &'a [String],
     model: &'a str,
 }
@@ -77,7 +78,7 @@ struct AssistantEvent<'a> {
     #[serde(rename = "type")]
     event_type: &'static str,
     message: AssistantMessage<'a>,
-    session_id: &'a str,
+    session_id: &'a SessionRef,
     #[serde(skip_serializing_if = "Option::is_none")]
     parent_tool_use_id: Option<&'a str>,
 }
@@ -95,7 +96,7 @@ struct UserEvent<'a> {
     #[serde(rename = "type")]
     event_type: &'static str,
     message: UserMessage<'a>,
-    session_id: &'a str,
+    session_id: &'a SessionRef,
     #[serde(skip_serializing_if = "Option::is_none")]
     parent_tool_use_id: Option<&'a str>,
 }
@@ -114,7 +115,7 @@ struct RetryEvent<'a> {
     attempt: u32,
     retry_delay_ms: u64,
     error: &'a str,
-    session_id: &'a str,
+    session_id: &'a SessionRef,
 }
 
 enum VerboseOutput {
@@ -383,7 +384,7 @@ mod tests {
             num_turns: 2,
             result: "done".into(),
             stop_reason: Some(StopReason::EndTurn),
-            session_id: "sess-123".into(),
+            session_id: SessionRef::generate(),
             total_cost_usd: 0.003,
             usage: TokenUsage::default(),
         };
@@ -392,11 +393,12 @@ mod tests {
             assert!(json.get(field).is_some(), "PrintResult missing: {field}");
         }
 
+        let sid = SessionRef::generate();
         let init = InitEvent {
             event_type: "system",
             subtype: "init",
             cwd: "/tmp",
-            session_id: "abc",
+            session_id: &sid,
             tools: &["bash".into(), "read".into()],
             model: "test-model",
         };
@@ -411,7 +413,7 @@ mod tests {
             attempt: 2,
             retry_delay_ms: 3000,
             error: "rate_limit",
-            session_id: "abc",
+            session_id: &sid,
         };
         let json: Value = serde_json::to_value(&retry).unwrap();
         for field in RETRY_EVENT_FIELDS {

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -2,6 +2,10 @@
 //!
 //! Wire protocol matches Claude Code's SDK interface so tools like Conductor, Windsurf, and custom
 //! orchestrators work without adaptation.
+//!
+//! Per-message wire ids (`uuid`, assistant `message.id`) use `uuid::Uuid::now_v7()` to emit the
+//! hyphenated-hex UUIDv7 shape that Claude Code SDK consumers expect, rather than maki's base58
+//! `MakiId` canonical form.
 
 use std::collections::{HashMap, HashSet};
 use std::io::{self, BufRead, Write};
@@ -24,6 +28,7 @@ use maki_agent::{
 use maki_providers::model::Model;
 use maki_providers::{ImageSource, Message, StopReason, Timeouts, TokenUsage};
 use maki_storage::StateDir;
+use maki_storage::id::SessionRef;
 use maki_storage::sessions::Session;
 use serde::Serialize;
 use serde_json::Value;
@@ -49,6 +54,13 @@ const TOOL_NAME_MAP: &[(&str, &str)] = &[
     ("question", "Question"),
     ("skill", "Skill"),
 ];
+
+/// Emits a hyphenated-hex UUIDv7 string for Claude Code SDK wire ids
+/// (message.id, assistant message.id).
+#[allow(clippy::disallowed_methods)]
+fn wire_uuid() -> String {
+    uuid::Uuid::now_v7().to_string()
+}
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 enum PermissionMode {
@@ -101,7 +113,7 @@ impl PermissionMode {
 struct WireMessage {
     #[serde(flatten)]
     inner: WireInner,
-    session_id: String,
+    session_id: SessionRef,
     uuid: String,
 }
 
@@ -336,7 +348,7 @@ impl StreamSynth {
         vec![serde_json::json!({
             "type": "message_start",
             "message": {
-                "id": uuid::Uuid::new_v4().to_string(),
+                "id": wire_uuid(),
                 "type": "message",
                 "role": "assistant",
                 "content": [],
@@ -389,7 +401,7 @@ fn maki_to_claude_tool_name(name: &str) -> &str {
 
 #[derive(Clone)]
 struct SdkWriter {
-    session_id: String,
+    session_id: SessionRef,
     out_tx: Sender<String>,
 }
 
@@ -398,7 +410,7 @@ impl SdkWriter {
         let msg = WireMessage {
             inner,
             session_id: self.session_id.clone(),
-            uuid: uuid::Uuid::new_v4().to_string(),
+            uuid: wire_uuid(),
         };
         self.out_tx
             .send(serde_json::to_string(&msg)?)
@@ -633,24 +645,37 @@ pub fn run(params: SdkParams) -> Result<()> {
 
 type StoredSession = Session<Message, TokenUsage, ToolOutput>;
 
-fn resolve_session(cli: &Cli, cwd: &str) -> Result<(Option<String>, Vec<Message>)> {
+fn resolve_session(cli: &Cli, cwd: &str) -> Result<(Option<SessionRef>, Vec<Message>)> {
     let (resumed_id, history) = if let Some(id) = &cli.session {
         let storage = StateDir::resolve().context("resolve state dir")?;
-        let session =
-            StoredSession::load(id, &storage).map_err(|e| eyre!("load session {id}: {e}"))?;
-        let resumed = (!cli.fork_session).then_some(session.id);
+        let session_ref: SessionRef = id
+            .parse()
+            .map_err(|e| eyre!("invalid session id {id}: {e}"))?;
+        let session = StoredSession::load(session_ref.id(), &storage)
+            .map_err(|e| eyre!("load session {id}: {e}"))?;
+        let resumed = (!cli.fork_session).then_some(session_ref);
         (resumed, session.messages)
     } else if cli.continue_session {
         let storage = StateDir::resolve().context("resolve state dir")?;
         match StoredSession::latest(cwd, &storage) {
-            Ok(Some(session)) => (Some(session.id), session.messages),
+            Ok(Some(session)) => (Some(SessionRef::from(session.id)), session.messages),
             _ => (None, Vec::new()),
         }
     } else {
         (None, Vec::new())
     };
 
-    Ok((cli.session_id.clone().or(resumed_id), history))
+    let cli_session_id = cli.session_id.as_deref().map(|s| {
+        s.parse::<SessionRef>()
+            .map_err(|e| eyre!("invalid session id {s:?}: {e}"))
+    });
+    let cli_session_id = match cli_session_id {
+        Some(Ok(id)) => Some(id),
+        Some(Err(e)) => return Err(e),
+        None => None,
+    };
+
+    Ok((cli_session_id.or(resumed_id), history))
 }
 
 fn parse_or_warn<T: serde::de::DeserializeOwned>(payload: Value, what: &str) -> Option<T> {
@@ -939,7 +964,7 @@ impl EventPump {
                 }
                 self.writer.emit(WireInner::Assistant(AssistantPayload {
                     message: AssistantMessage {
-                        id: uuid::Uuid::new_v4().to_string(),
+                        id: wire_uuid(),
                         model: tc.model.clone(),
                         role: "assistant",
                         content: map_tool_names_in_content(&content_value),
@@ -1260,7 +1285,7 @@ mod tests {
                 usage: TokenUsage::default(),
                 permission_denials: Vec::new(),
             }),
-            session_id: "s".into(),
+            session_id: SessionRef::generate(),
             uuid: "u".into(),
         };
         let json: Value = serde_json::to_value(&msg).unwrap();
@@ -1282,7 +1307,7 @@ mod tests {
                     "permissionMode": "default",
                 }),
             }),
-            session_id: "s".into(),
+            session_id: SessionRef::generate(),
             uuid: "u".into(),
         };
         let json: Value = serde_json::to_value(&msg).unwrap();
@@ -1302,7 +1327,7 @@ mod tests {
                     error: None,
                 },
             }),
-            session_id: "s".into(),
+            session_id: SessionRef::generate(),
             uuid: "u".into(),
         };
         let json: Value = serde_json::to_value(&msg).unwrap();
@@ -1322,7 +1347,7 @@ mod tests {
                     tool_use_id: Some("tool_123".into()),
                 },
             }),
-            session_id: "s".into(),
+            session_id: SessionRef::generate(),
             uuid: "u".into(),
         };
         let json: Value = serde_json::to_value(&msg).unwrap();


### PR DESCRIPTION
While trying to work up a design for https://github.com/tontinton/maki/issues/264 I found myself reaching for a better ID pattern that I find myself reusing a lot. UUIDv7 is half-timestamp-based UUID, and when rendered via [base58](https://base58.io/base58-decoder), it becomes a great ID type with these properties:
- short (22 vs 36 chars with default UUIDs)
- lexographically sortable (the timestamp in the UUIDv7 gives us this)
- human readable (base58 avoids confusing chars like O and 0 to improve on base64)
- easily selectable with double-click (there are no hyphens or underscores)

For now, this mainly targets session IDs, but would also help with message IDs when implementing tree message history, pi-style.

This PR replaces all UUIDv4 usage with an `EntityId` newtype that all random IDs need to use, and bans all `UUIDv4` and `UUIDv7` direct creation with a new `clippy.toml` to avoid accidental bad ID creation. For backwards compatibility, we allow parsing UUIDs as `EntityId`s to let old session IDs continue to work. For session picking and usage, we show the new ID format in the picker, and migrate session filenames when we save them. Maybe in a month or so we can drop this migration support code path?

I made a new `maki-util` crate to hold this cross-crate utility since it didn't seem to belong anywhere and I can see other tools fitting here. I'm okay with something like `maki-types` if you want to avoid the kitchen sink utilities crate.

Implemented with Maki + GLM-5.2, read through all changes manually.