### PR TITLE
fix(plugins): expand write/memory tools to file content, not the summary

### DIFF
--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -11,6 +11,14 @@ fn fresh_registry() -> Arc<ToolRegistry> {
     Arc::new(ToolRegistry::new())
 }
 
+fn builtins_host() -> (Arc<ToolRegistry>, PluginHost) {
+    let reg = fresh_registry();
+    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_builtins(&PluginsConfig::from_tools(HashMap::new()))
+        .unwrap();
+    (reg, host)
+}
+
 fn exec_tool(reg: &ToolRegistry, name: &str, input: serde_json::Value) -> Result<String, String> {
     let entry = reg
         .get(name)
@@ -1216,10 +1224,7 @@ fn ctx_set_deadline_twice_errors() {
 
 #[test]
 fn restore_tool_async_ordering_and_delivery() {
-    let reg = fresh_registry();
-    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    host.load_builtins(&PluginsConfig::from_tools(HashMap::new()))
-        .unwrap();
+    let (_reg, host) = builtins_host();
 
     let input = serde_json::json!({"command": "echo ok", "timeout": 1});
 
@@ -1228,7 +1233,7 @@ fn restore_tool_async_ordering_and_delivery() {
     let event_tx = maki_agent::EventSender::new(tx, 0);
 
     let bash_item = |id: &str| maki_lua::RestoreItem {
-        tool: std::sync::Arc::from("bash"),
+        tool: Arc::from("bash"),
         tool_use_id: id.to_owned(),
         output: "tool bash timed out after 1s".to_owned(),
         input: input.clone(),
@@ -1238,7 +1243,7 @@ fn restore_tool_async_ordering_and_delivery() {
         expanded: false,
     };
     let unknown_item = maki_lua::RestoreItem {
-        tool: std::sync::Arc::from("definitely_not_a_tool"),
+        tool: Arc::from("definitely_not_a_tool"),
         tool_use_id: "unknown_id".to_owned(),
         output: "ignored".to_owned(),
         input: serde_json::json!({}),
@@ -1278,16 +1283,75 @@ fn restore_tool_async_ordering_and_delivery() {
     );
 }
 
+#[test_case::test_case(
+    "write",
+    serde_json::json!({"path": "/tmp/x.md", "content": "alpha\nbeta"}),
+    "wrote 10 bytes to /tmp/x.md",
+    &["alpha", "beta"]
+    ; "write_tool_restores_file_content"
+)]
+#[test_case::test_case(
+    "memory",
+    serde_json::json!({"command": "write", "path": "n.md", "content": "gamma"}),
+    "wrote n.md (1 lines)",
+    &["gamma"]
+    ; "memory_write_restores_saved_content"
+)]
+fn restore_rebuilds_body_from_input_content(
+    tool: &str,
+    input: serde_json::Value,
+    summary: &str,
+    expected: &[&str],
+) {
+    let (_reg, host) = builtins_host();
+    let handle = host.event_handle().expect("event handle available");
+    let (tx, rx) = flume::unbounded();
+
+    handle.request_restore(
+        maki_lua::RestoreItem {
+            tool: Arc::from(tool),
+            tool_use_id: "restore_id".to_owned(),
+            output: summary.to_owned(),
+            input,
+            is_error: false,
+            tool_output_lines: ToolOutputLines::default(),
+            theme_gen: None,
+            expanded: true,
+        },
+        maki_agent::EventSender::new(tx, 0),
+    );
+    let _ = handle.collect_prompt_slots();
+
+    let mut text = String::new();
+    for env in rx.drain() {
+        if let maki_agent::AgentEvent::ToolSnapshot { snapshot, .. } = env.event {
+            for line in snapshot.lines.iter() {
+                for span in &line.spans {
+                    text.push_str(&span.text);
+                }
+            }
+        }
+    }
+
+    for needle in expected {
+        assert!(
+            text.contains(needle),
+            "restored body missing '{needle}', got: {text}"
+        );
+    }
+    assert!(
+        !text.contains(summary),
+        "restored body should show content, not the summary: {text}"
+    );
+}
+
 /// Guards the stale-cancelled-handle bug: `permission_scopes` must call
 /// the plugin callback and return parsed scopes, not fall back to raw JSON.
 /// A leaked `{"command":...}` scope would break allow rules.
 #[test_case::test_case("git status" ; "parseable command")]
 #[test_case::test_case("echo 'unterminated" ; "unparseable command")]
 fn bash_permission_scopes_never_falls_back_to_json(command: &str) {
-    let reg = fresh_registry();
-    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    host.load_builtins(&PluginsConfig::from_tools(HashMap::new()))
-        .unwrap();
+    let (reg, _host) = builtins_host();
 
     let input = serde_json::json!({ "command": command });
     let entry = reg.get("bash").expect("bash registered");

--- a/plugins/memory/init.lua
+++ b/plugins/memory/init.lua
@@ -156,7 +156,8 @@ maki.api.register_tool({
   end,
 
   restore = function(input, output, _is_error, ctx)
-    return render_content(output, input.path or "file.md", ctx)
+    local content = (input.command == "write" and input.content) or output
+    return render_content(content, input.path or "file.md", ctx)
   end,
 
   handler = function(input, ctx)

--- a/plugins/write/init.lua
+++ b/plugins/write/init.lua
@@ -13,6 +13,17 @@ local function write_view_opts(ctx)
   return { max_lines = (tol and tol.write) or 10, keep = "head" }
 end
 
+local function split_lines(content)
+  local lines = {}
+  for line in (content .. "\n"):gmatch("([^\n]*)\n") do
+    lines[#lines + 1] = line
+  end
+  if #lines > 0 and lines[#lines] == "" then
+    lines[#lines] = nil
+  end
+  return lines
+end
+
 local function line_nr_fmt(count)
   local w = math.max(1, math.floor(math.log(count + 1, 10)) + 1)
   return "%" .. w .. "d "
@@ -89,13 +100,7 @@ maki.api.register_tool({
   end,
 
   restore = function(input, output, _is_error, ctx)
-    local lines = {}
-    for line in (output .. "\n"):gmatch("([^\n]*)\n") do
-      lines[#lines + 1] = line
-    end
-    if #lines > 0 and lines[#lines] == "" then
-      lines[#lines] = nil
-    end
+    local lines = split_lines(input.content or "")
     if #lines == 0 then
       return ToolView.restore(output, write_view_opts(ctx))
     end
@@ -136,17 +141,9 @@ maki.api.register_tool({
     local llm_output = string.format("wrote %d bytes to %s", byte_count, rel)
     local annotation = string.format("%d bytes", byte_count)
 
-    local preview_lines = {}
-    for line in (content .. "\n"):gmatch("([^\n]*)\n") do
-      preview_lines[#preview_lines + 1] = line
-    end
-    if #preview_lines > 0 and preview_lines[#preview_lines] == "" then
-      preview_lines[#preview_lines] = nil
-    end
-
     return {
       llm_output = llm_output,
-      body = build_view(preview_lines, path, ctx),
+      body = build_view(split_lines(content), path, ctx),
       annotation = annotation,
       written_path = path,
     }


### PR DESCRIPTION
Clicking a completed lua tool rebuilds its view through the plugin's `restore(input, output, ...)` callback, where `output` is only the `llm_output` summary. The `write` and `memory` plugins rebuilt their body from that summary, so expanding a write showed just "wrote 42 bytes to path" instead of the file preview. They now rebuild from `input.content` (for `memory`, only when `command == "write"`).

All other plugins were checked and are fine: their `llm_output` already is the content (read, bash, grep, ...), they restore from input (`todo_write`), or they bypass lua restore entirely (the edit family renders `ToolOutput::Diff` natively in Rust).

A parameterized regression test in `plugin_host.rs` restores both tools with `expanded: true` and asserts the emitted `ToolSnapshot` contains the content instead of the summary.