### PR TITLE
feat(ui): add show_thinking option to hide model reasoning

### DIFF
--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -269,6 +269,7 @@ pub struct UiFileConfig {
     pub flash_duration_ms: Option<u64>,
     pub typewriter_ms_per_char: Option<u64>,
     pub mouse_scroll_lines: Option<u32>,
+    pub show_thinking: Option<bool>,
     pub tool_output_lines: Option<ToolOutputLinesFile>,
 }
 
@@ -281,7 +282,8 @@ impl UiFileConfig {
             scrollbar,
             flash_duration_ms,
             typewriter_ms_per_char,
-            mouse_scroll_lines
+            mouse_scroll_lines,
+            show_thinking
         );
         match (self.tool_output_lines.as_mut(), overlay.tool_output_lines) {
             (Some(base), Some(over)) => base.merge(over),
@@ -518,6 +520,12 @@ pub struct UiConfig {
     #[config(default = DEFAULT_MOUSE_SCROLL_LINES, min = MIN_MOUSE_SCROLL_LINES, desc = "Lines per mouse wheel scroll")]
     pub mouse_scroll_lines: u32,
 
+    #[config(
+        default = true,
+        desc = "When true (default), show full model reasoning live and persisted. When false, hide reasoning behind an indicator (thinking> ...) with a click-to-expand hint, both while thinking and after it completes"
+    )]
+    pub show_thinking: bool,
+
     #[config(skip, default = "ToolOutputLines::default()")]
     pub tool_output_lines: ToolOutputLines,
 }
@@ -536,6 +544,7 @@ impl UiConfig {
                 .typewriter_ms_per_char
                 .unwrap_or(DEFAULT_TYPEWRITER_MS_PER_CHAR),
             mouse_scroll_lines: f.mouse_scroll_lines.unwrap_or(DEFAULT_MOUSE_SCROLL_LINES),
+            show_thinking: f.show_thinking.unwrap_or(true),
             tool_output_lines: ToolOutputLines::from_file(f.tool_output_lines),
         }
     }
@@ -1730,6 +1739,25 @@ mod tests {
             Some(true),
             "overlay-only key added"
         );
+    }
+
+    #[test]
+    fn show_thinking_deserializes_true() {
+        let raw: RawConfig = toml::from_str("[ui]\nshow_thinking = true\n").unwrap();
+        assert!(raw.ui.show_thinking.unwrap());
+    }
+
+    #[test]
+    fn show_thinking_deserializes_false() {
+        let raw: RawConfig = toml::from_str("[ui]\nshow_thinking = false\n").unwrap();
+        assert!(!raw.ui.show_thinking.unwrap());
+    }
+
+    #[test]
+    fn show_thinking_missing_defaults_true() {
+        let raw: RawConfig = toml::from_str("").unwrap();
+        let config = raw.into_config(false).unwrap();
+        assert!(config.ui.show_thinking);
     }
 
     #[test_case("[ui]\nsplash_animaton = true\n" ; "top_level_typo")]

--- a/maki-ui/src/animation.rs
+++ b/maki-ui/src/animation.rs
@@ -90,6 +90,14 @@ impl Typewriter {
         self.buffer.is_empty()
     }
 
+    pub fn buffer_line_count(&self) -> usize {
+        if self.buffer.is_empty() {
+            0
+        } else {
+            self.buffer.bytes().filter(|&b| b == b'\n').count() + 1
+        }
+    }
+
     pub fn clear(&mut self) {
         self.buffer.clear();
         self.reset_anim();

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -447,6 +447,7 @@ pub fn history_to_display(
                                 render_snapshot: None,
                                 render_header: None,
                                 snapshot_theme_gen: 0,
+                                thinking_collapsed: false,
                             });
                         }
                         _ => {}

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -43,6 +43,8 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::text::{Line, Span};
 
+const THINKING_HIDDEN_HEADER: &str = "thinking> ...";
+
 pub struct MessagesPanel {
     messages: Vec<DisplayMessage>,
     streaming_thinking: StreamingContent,
@@ -67,6 +69,8 @@ pub struct MessagesPanel {
     render_hints: RenderHintsRegistry,
     lua_event_handle: Option<EventHandle>,
     restore_event_tx: Option<EventSender>,
+    show_thinking: bool,
+    thinking_collapsed: bool,
     /// One re-bake per tool per generation; `snapshot_theme_gen`
     /// only bumps when colors actually land.
     rebake_requested: HashMap<String, u64>,
@@ -111,6 +115,8 @@ impl MessagesPanel {
             render_hints: RenderHintsRegistry::new(),
             lua_event_handle: None,
             restore_event_tx: None,
+            show_thinking: ui_config.show_thinking,
+            thinking_collapsed: !ui_config.show_thinking,
             rebake_requested: HashMap::new(),
         }
     }
@@ -128,7 +134,14 @@ impl MessagesPanel {
         self.messages.push(msg);
     }
 
-    pub fn load_messages(&mut self, msgs: Vec<DisplayMessage>) {
+    pub fn load_messages(&mut self, mut msgs: Vec<DisplayMessage>) {
+        if !self.show_thinking {
+            for msg in &mut msgs {
+                if matches!(msg.role, DisplayRole::Thinking) {
+                    msg.thinking_collapsed = true;
+                }
+            }
+        }
         self.messages = msgs;
         self.cache.clear();
         self.expanded_tools.clear();
@@ -137,6 +150,7 @@ impl MessagesPanel {
         self.live_bufs.clear();
         self.rebake_requested.clear();
         self.highlight_segment = None;
+        self.thinking_collapsed = !self.show_thinking;
     }
 
     pub fn thinking_delta(&mut self, text: &str) {
@@ -437,6 +451,7 @@ impl MessagesPanel {
     pub fn stream_reset(&mut self) {
         self.streaming_thinking.clear();
         self.streaming_text.clear();
+        self.thinking_collapsed = !self.show_thinking;
         self.cancel_in_progress();
     }
 
@@ -629,10 +644,11 @@ impl MessagesPanel {
         let doc_row = (row.saturating_sub(area.y)) as u32 + self.scroll_top as u32;
         let width = self.viewport_width;
         let Some((_, seg, _seg_start)) = self.cache.segment_at_row(doc_row, width) else {
-            return false;
+            return self.try_toggle_collapsed_thinking(doc_row, width);
         };
         let Some(tool_id) = seg.tool_id.as_deref() else {
-            return false;
+            let msg_idx = seg.msg_index;
+            return self.try_toggle_cached_thinking(msg_idx, width);
         };
 
         if self.has_snapshot(tool_id) {
@@ -727,6 +743,11 @@ impl MessagesPanel {
             || self.show_idle_splash()
             || self.accent.is_animating()
             || !self.live_bufs.is_empty()
+            || self.streaming_thinking_collapsed()
+    }
+
+    fn streaming_thinking_collapsed(&self) -> bool {
+        self.thinking_collapsed && !self.streaming_thinking.is_empty()
     }
 
     fn show_idle_splash(&self) -> bool {
@@ -780,11 +801,29 @@ impl MessagesPanel {
         let cached_count = self.cache.len();
         let spacer_lines: [Line<'static>; 1] = [Line::default()];
         let mut streaming_heights: Vec<u16> = Vec::new();
-        for sc in [&mut self.streaming_thinking, &mut self.streaming_text] {
-            if sc.is_empty() {
-                continue;
+
+        let thinking_collapsed = self.streaming_thinking_collapsed();
+        let collapsed_thinking_lines = if thinking_collapsed {
+            self.build_streaming_collapsed_lines()
+        } else {
+            Vec::new()
+        };
+
+        if thinking_collapsed {
+            if cached_count > 0 || !streaming_heights.is_empty() {
+                streaming_heights.push(1);
             }
-            let lines = sc.render_lines(width);
+            streaming_heights.push(collapsed_thinking_lines.len() as u16);
+        } else if !self.streaming_thinking.is_empty() {
+            let lines = self.streaming_thinking.render_lines(width);
+            if cached_count > 0 || !streaming_heights.is_empty() {
+                streaming_heights.push(1);
+            }
+            streaming_heights.push(wrapped_line_count(lines, width));
+        }
+
+        if !self.streaming_text.is_empty() {
+            let lines = self.streaming_text.render_lines(width);
             if cached_count > 0 || !streaming_heights.is_empty() {
                 streaming_heights.push(1);
             }
@@ -820,7 +859,11 @@ impl MessagesPanel {
         }
 
         let mut height_idx = 0usize;
-        for sc in [&self.streaming_thinking, &self.streaming_text] {
+        let streamed: [(&StreamingContent, bool); 2] = [
+            (&self.streaming_thinking, thinking_collapsed),
+            (&self.streaming_text, false),
+        ];
+        for (sc, collapsed) in streamed {
             if sc.is_empty() || height_idx >= streaming_heights.len() || cursor.past_bottom() {
                 continue;
             }
@@ -832,7 +875,11 @@ impl MessagesPanel {
             if height_idx < streaming_heights.len() {
                 let h = streaming_heights[height_idx];
                 height_idx += 1;
-                cursor.render(sc.cached_lines(), h, None, false, frame);
+                if collapsed {
+                    cursor.render(&collapsed_thinking_lines, h, None, false, frame);
+                } else {
+                    cursor.render(sc.cached_lines(), h, None, false, frame);
+                }
             }
         }
 
@@ -1116,11 +1163,86 @@ impl MessagesPanel {
     }
 
     fn flush_thinking(&mut self) {
-        if !self.streaming_thinking.is_empty() {
-            self.messages.push(DisplayMessage::new(
-                DisplayRole::Thinking,
-                self.streaming_thinking.take_all(),
-            ));
+        if self.streaming_thinking.is_empty() {
+            return;
+        }
+        let mut msg =
+            DisplayMessage::new(DisplayRole::Thinking, self.streaming_thinking.take_all());
+        msg.thinking_collapsed = self.thinking_collapsed;
+        self.thinking_collapsed = !self.show_thinking;
+        self.messages.push(msg);
+    }
+
+    fn build_streaming_collapsed_lines(&self) -> Vec<Line<'static>> {
+        thinking_indicator(self.streaming_thinking.line_count())
+    }
+
+    fn build_cached_thinking_indicator(&self, text: &str) -> Vec<Line<'static>> {
+        thinking_indicator(logical_line_count(text))
+    }
+
+    fn try_toggle_collapsed_thinking(&mut self, doc_row: u32, width: u16) -> bool {
+        if !self.streaming_thinking_collapsed() {
+            return false;
+        }
+        let cached_height = self.cache.total_height(width);
+        let spacer = if self.cache.len() > 0 { 1 } else { 0 };
+        let thinking_start = cached_height + spacer;
+        let height = self.build_streaming_collapsed_lines().len() as u32;
+        if doc_row >= thinking_start && doc_row < thinking_start + height {
+            self.thinking_collapsed = false;
+            return true;
+        }
+        false
+    }
+
+    fn try_toggle_cached_thinking(&mut self, msg_idx: Option<usize>, width: u16) -> bool {
+        if self.show_thinking {
+            return false;
+        }
+        let Some(idx) = msg_idx else { return false };
+        let Some(msg) = self.messages.get_mut(idx) else {
+            return false;
+        };
+        if !matches!(msg.role, DisplayRole::Thinking) {
+            return false;
+        }
+        msg.thinking_collapsed = !msg.thinking_collapsed;
+        self.rebuild_thinking_segment(idx, width);
+        true
+    }
+
+    fn rebuild_thinking_segment(&mut self, msg_idx: usize, width: u16) {
+        let Some((text, collapsed)) = self
+            .messages
+            .get(msg_idx)
+            .map(|m| (m.text.clone(), m.thinking_collapsed))
+        else {
+            return;
+        };
+        let lines = if collapsed {
+            self.build_cached_thinking_indicator(&text)
+        } else {
+            let style = thinking_style();
+            text_to_lines(
+                &text,
+                style.prefix,
+                style.text_style,
+                style.prefix_style,
+                width,
+                None,
+            )
+        };
+        let search_text = format!("thinking> {text}");
+        let seg_idx = self
+            .cache
+            .segments()
+            .iter()
+            .position(|s| s.msg_index == Some(msg_idx) && s.tool_id.is_none());
+        let Some(seg_idx) = seg_idx else { return };
+        if let Some(seg) = self.cache.get_mut(seg_idx) {
+            seg.set_lines(lines);
+            seg.search_text = search_text;
         }
     }
 
@@ -1321,6 +1443,15 @@ impl MessagesPanel {
                     }
                 }
             } else {
+                if matches!(&msg.role, DisplayRole::Thinking) && msg.thinking_collapsed {
+                    let text = msg.text.clone();
+                    let lines = self.build_cached_thinking_indicator(&text);
+                    let search_text = format!("thinking> {text}");
+                    self.cache.push_spacer_if_needed();
+                    self.cache
+                        .push(Segment::with_lines(lines, search_text, Some(i)));
+                    continue;
+                }
                 let style = match &msg.role {
                     DisplayRole::User => user_style(),
                     DisplayRole::Assistant => assistant_style(),
@@ -1377,5 +1508,27 @@ impl MessagesPanel {
             }
         }
         self.cache.mark_built(self.messages.len());
+    }
+}
+
+/// Two-line thinking indicator: a header (`thinking> ...`) followed by a
+/// `(N lines) (click to expand)` footer. Shared by the streaming and cached
+/// views when `show_thinking` is off.
+fn thinking_indicator(line_count: usize) -> Vec<Line<'static>> {
+    let theme = theme::current();
+    vec![
+        Line::from(Span::styled(THINKING_HIDDEN_HEADER, theme.thinking)),
+        Line::from(vec![
+            Span::styled(format!("({line_count} lines) "), theme.tool_dim),
+            Span::styled("(click to expand)", theme.thinking),
+        ]),
+    ]
+}
+
+fn logical_line_count(text: &str) -> usize {
+    if text.is_empty() {
+        0
+    } else {
+        text.bytes().filter(|&b| b == b'\n').count() + 1
     }
 }

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -1530,3 +1530,194 @@ fn header_snapshot_for_batch_child_stamps_gen() {
 
     assert_eq!(panel.snapshot_gen_of("b1__0"), Some(7), "{HEADER_GEN_MSG}");
 }
+
+#[test]
+fn hide_collapses_streaming_thinking() {
+    let mut panel = MessagesPanel::new(UiConfig {
+        show_thinking: false,
+        ..UiConfig::default()
+    });
+    panel
+        .streaming_thinking
+        .set_buffer("line one\nline two\nline three");
+    let terminal = render(&mut panel, 80, 10);
+    let text = buffer_text(&terminal);
+    assert!(
+        text.contains("thinking> ..."),
+        "collapsed view should show hint; got: {text}"
+    );
+    assert!(
+        text.contains("3 lines"),
+        "should show live line counter; got: {text}"
+    );
+    assert!(
+        text.contains("click to expand"),
+        "should hint click-to-expand; got: {text}"
+    );
+    assert!(
+        !text.contains("line one"),
+        "reasoning must stay hidden; got: {text}"
+    );
+}
+
+#[test]
+fn hide_click_expands_streaming_thinking() {
+    let mut panel = MessagesPanel::new(UiConfig {
+        show_thinking: false,
+        ..UiConfig::default()
+    });
+    panel.streaming_thinking.set_buffer("secret reasoning");
+    let area = Rect::new(0, 0, 80, 10);
+    render(&mut panel, 80, 10);
+    assert!(
+        panel.handle_click(0, area),
+        "clicking collapsed thinking should toggle expand"
+    );
+    assert!(!panel.thinking_collapsed);
+    let terminal = render(&mut panel, 80, 10);
+    let text = buffer_text(&terminal);
+    assert!(
+        text.contains("secret reasoning"),
+        "expanded view should show reasoning; got: {text}"
+    );
+    assert!(
+        !text.contains("click to expand"),
+        "collapsed hint should not appear after expand; got: {text}"
+    );
+}
+
+#[test]
+fn hide_keeps_cached_thinking_as_indicator() {
+    let mut panel = MessagesPanel::new(UiConfig {
+        show_thinking: false,
+        ..UiConfig::default()
+    });
+    panel.thinking_delta("reasoning here");
+    panel.flush();
+    assert!(matches!(
+        panel.last_message_role(),
+        Some(DisplayRole::Thinking)
+    ));
+    let terminal = render(&mut panel, 80, 10);
+    let text = buffer_text(&terminal);
+    assert!(
+        text.contains("thinking> ..."),
+        "cached thinking should persist as an indicator, not hide; got: {text}"
+    );
+    assert!(
+        text.contains("(1 lines)"),
+        "footer always shows the line count; got: {text}"
+    );
+    assert!(
+        text.contains("click to expand"),
+        "footer should hint click-to-expand; got: {text}"
+    );
+    assert!(
+        !text.contains("reasoning here"),
+        "reasoning must stay hidden in the indicator; got: {text}"
+    );
+}
+
+#[test]
+fn full_default_renders_streaming_thinking() {
+    let mut panel = MessagesPanel::new(UiConfig::default());
+    panel.streaming_thinking.set_buffer("visible reasoning");
+    let terminal = render(&mut panel, 80, 10);
+    let text = buffer_text(&terminal);
+    assert!(
+        text.contains("visible reasoning"),
+        "default config renders reasoning; got: {text}"
+    );
+}
+
+#[test]
+fn hide_cached_thinking_persists_as_indicator() {
+    let mut panel = MessagesPanel::new(UiConfig {
+        show_thinking: false,
+        ..UiConfig::default()
+    });
+    let lines: Vec<String> = (1..=7).map(|n| format!("cached line {n}")).collect();
+    panel.thinking_delta(&lines.join("\n"));
+    panel.flush();
+    assert!(matches!(
+        panel.last_message_role(),
+        Some(DisplayRole::Thinking)
+    ));
+    let terminal = render(&mut panel, 80, 12);
+    let text = buffer_text(&terminal);
+    assert!(
+        text.contains("thinking> ..."),
+        "cached thinking should persist as an indicator, not hide; got: {text}"
+    );
+    assert!(text.contains("(7 lines)"), "footer line count; got: {text}");
+    assert!(
+        text.contains("click to expand"),
+        "footer should hint click-to-expand; got: {text}"
+    );
+    assert!(
+        !text.contains("cached line 7"),
+        "reasoning must stay hidden in the indicator; got: {text}"
+    );
+    assert!(
+        !text.contains("cached line 1"),
+        "reasoning must stay hidden in the indicator; got: {text}"
+    );
+}
+
+#[test]
+fn hide_cached_thinking_click_expands() {
+    let mut panel = MessagesPanel::new(UiConfig {
+        show_thinking: false,
+        ..UiConfig::default()
+    });
+    panel.thinking_delta("hidden cached reasoning");
+    panel.flush();
+    let area = Rect::new(0, 0, 80, 12);
+    render(&mut panel, 80, 12);
+    assert!(
+        panel.handle_click(0, area),
+        "clicking persisted thinking should toggle expand"
+    );
+    let terminal = render(&mut panel, 80, 12);
+    let text = buffer_text(&terminal);
+    assert!(
+        text.contains("hidden cached reasoning"),
+        "expanded view shows full reasoning; got: {text}"
+    );
+    assert!(
+        !text.contains("click to expand"),
+        "footer should disappear when expanded; got: {text}"
+    );
+}
+
+#[test]
+fn stream_reset_clears_thinking_expand_state() {
+    let mut panel = MessagesPanel::new(UiConfig {
+        show_thinking: false,
+        ..UiConfig::default()
+    });
+    panel.streaming_thinking.set_buffer("secret reasoning");
+    let area = Rect::new(0, 0, 80, 10);
+    render(&mut panel, 80, 10);
+    assert!(
+        panel.handle_click(0, area),
+        "clicking collapsed thinking should toggle expand"
+    );
+    assert!(!panel.thinking_collapsed);
+    panel.stream_reset();
+    assert!(
+        panel.thinking_collapsed,
+        "stream_reset must restore the collapsed default so it does not leak into retries"
+    );
+    panel.streaming_thinking.set_buffer("fresh reasoning");
+    let terminal = render(&mut panel, 80, 10);
+    let text = buffer_text(&terminal);
+    assert!(
+        text.contains("thinking> ..."),
+        "new stream after reset should collapse again; got: {text}"
+    );
+    assert!(
+        !text.contains("fresh reasoning"),
+        "new stream must stay hidden; got: {text}"
+    );
+}

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -289,6 +289,7 @@ pub struct DisplayMessage {
     pub render_snapshot: Option<BufferSnapshot>,
     pub render_header: Option<BufferSnapshot>,
     pub snapshot_theme_gen: u64,
+    pub thinking_collapsed: bool,
 }
 
 impl DisplayMessage {
@@ -308,6 +309,7 @@ impl DisplayMessage {
             render_snapshot: None,
             render_header: None,
             snapshot_theme_gen: 0,
+            thinking_collapsed: false,
         }
     }
 
@@ -327,6 +329,7 @@ impl DisplayMessage {
             render_snapshot: None,
             render_header: None,
             snapshot_theme_gen: 0,
+            thinking_collapsed: false,
         }
     }
 

--- a/maki-ui/src/components/streaming_content.rs
+++ b/maki-ui/src/components/streaming_content.rs
@@ -122,6 +122,10 @@ impl StreamingContent {
         self.typewriter.is_empty()
     }
 
+    pub fn line_count(&self) -> usize {
+        self.typewriter.buffer_line_count()
+    }
+
     pub fn is_animating(&self) -> bool {
         self.typewriter.is_animating()
     }

--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -1015,6 +1015,7 @@ mod tests {
             render_snapshot: None,
             render_header: None,
             snapshot_theme_gen: 0,
+            thinking_collapsed: false,
         }
     }
 
@@ -1309,6 +1310,7 @@ mod tests {
             render_snapshot: None,
             render_header: None,
             snapshot_theme_gen: 0,
+            thinking_collapsed: false,
         }
     }
 
@@ -1424,6 +1426,7 @@ mod tests {
             render_snapshot: None,
             render_header: None,
             snapshot_theme_gen: 0,
+            thinking_collapsed: false,
         }
     }
 
@@ -1463,6 +1466,7 @@ mod tests {
             render_snapshot: Some(snapshot),
             render_header: None,
             snapshot_theme_gen: 0,
+            thinking_collapsed: false,
         }
     }
 
@@ -1644,6 +1648,7 @@ mod tests {
             render_snapshot: None,
             render_header: None,
             snapshot_theme_gen: 0,
+            thinking_collapsed: false,
         }
     }
 
@@ -1749,6 +1754,7 @@ mod tests {
             render_snapshot: None,
             render_header: None,
             snapshot_theme_gen: 0,
+            thinking_collapsed: false,
         }
     }
 
@@ -1896,6 +1902,7 @@ mod tests {
             render_snapshot: Some(snapshot),
             render_header: None,
             snapshot_theme_gen: 0,
+            thinking_collapsed: false,
         };
         let tl = build_tool_lines(
             &msg,
@@ -1934,6 +1941,7 @@ mod tests {
             render_snapshot: Some(snapshot),
             render_header: None,
             snapshot_theme_gen: 0,
+            thinking_collapsed: false,
         };
         let tl = build_tool_lines(
             &msg,

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -67,6 +67,7 @@ All fields are optional. Typos in field names cause an error right away.
 | `flash_duration_ms` | u64 | `1500` | - | Duration of flash messages (ms) |
 | `typewriter_ms_per_char` | u64 | `4` | - | Typewriter effect speed (ms/char) |
 | `mouse_scroll_lines` | u32 | `3` | 1 | Lines per mouse wheel scroll |
+| `show_thinking` | bool | `true` | - | When true (default), show full model reasoning live and persisted. When false, hide reasoning behind an indicator (thinking> ...) with a click-to-expand hint, both while thinking and after it completes |
 
 ### `ui.tool_output_lines`
 


### PR DESCRIPTION
Adds a `show_thinking` UI config option (bool, default `true`) that controls how model reasoning is displayed.

- `true` (default): show full reasoning live and persisted, as before.
- `false`: hide reasoning behind an indicator (`thinking> ...`) with a click-to-expand hint, both while thinking and after it completes.

Config example:

```lua
maki.setup({
  ui={
    show_thinking=false,
...
```
