### PR TITLE
agent: opt-in idle auto-compaction

### DIFF
--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -209,7 +209,7 @@ fn truncate_oldest_round(messages: &mut Vec<Message>) {
     }
 }
 
-pub(super) fn auto_compact_enabled() -> bool {
+pub fn auto_compact_enabled() -> bool {
     env::var("MAKI_DISABLE_AUTOCOMPACT")
         .map(|v| v != "1" && v != "true")
         .unwrap_or(true)

--- a/maki-agent/src/agent/mod.rs
+++ b/maki-agent/src/agent/mod.rs
@@ -5,7 +5,7 @@ mod run;
 mod streaming;
 pub mod tool_dispatch;
 
-pub use compaction::compact;
+pub use compaction::{auto_compact_enabled, compact};
 pub use history::{History, SharedMessages};
 pub use instructions::{
     Instructions, LoadedInstructions, build_system_prompt, find_subdirectory_instructions,

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -12,7 +12,7 @@ pub use mcp::{McpCommand, McpHandle, McpPromptArg, McpPromptInfo, McpSnapshot, M
 pub(crate) mod task_set;
 pub use agent::{
     Agent, AgentParams, AgentRunParams, History, Instructions, LoadedInstructions, SharedMessages,
-    find_subdirectory_instructions, is_instruction_file,
+    auto_compact_enabled, find_subdirectory_instructions, is_instruction_file,
 };
 pub use cancel::{CancelMap, CancelToken, CancelTrigger};
 pub use maki_config::{AgentConfig, PermissionsConfig, ToolOutputLines};

--- a/maki-config-macro/src/lib.rs
+++ b/maki-config-macro/src/lib.rs
@@ -178,6 +178,7 @@ fn config_value_expr(ty_name: &str, default: &Option<Expr>) -> TokenStream2 {
             let val = default.as_ref().expect("usize field requires default");
             quote! { ConfigValue::Usize(#val) }
         }
+        "Option<u64>" => quote! { ConfigValue::OptionalU64 },
         "String" => quote! { ConfigValue::OptionalString },
         other => panic!("unsupported config type: {other}"),
     }
@@ -231,6 +232,8 @@ fn derive_impl(input: &DeriveInput) -> syn::Result<TokenStream2> {
         let ty_string = type_to_name(ty);
         let ty_name = attrs.ty_override.as_deref().unwrap_or(&ty_string);
         let desc = attrs.desc.as_deref().unwrap_or("");
+        let is_optional_u64 = ty_name == "Option<u64>";
+        let display_ty = if is_optional_u64 { "u64" } else { ty_name };
         let default_expr = config_value_expr(ty_name, &attrs.default);
         let min_expr = match &attrs.min {
             Some(m) => quote! { Some(#m as u64) },
@@ -240,7 +243,7 @@ fn derive_impl(input: &DeriveInput) -> syn::Result<TokenStream2> {
         fields_entries.push(quote! {
             ConfigField {
                 name: #field_name,
-                ty: #ty_name,
+                ty: #display_ty,
                 default: #default_expr,
                 min: #min_expr,
                 description: #desc,
@@ -257,9 +260,17 @@ fn derive_impl(input: &DeriveInput) -> syn::Result<TokenStream2> {
             };
             let ident_str = ident.to_string();
             let field_name_for_check = attrs.key.as_deref().unwrap_or(&ident_str);
-            validate_checks.push(quote! {
-                check(#section, #field_name_for_check, #val_expr as u64, #min as u64)?;
-            });
+            if is_optional_u64 {
+                validate_checks.push(quote! {
+                    if let Some(v) = #val_expr {
+                        check(#section, #field_name_for_check, v as u64, #min as u64)?;
+                    }
+                });
+            } else {
+                validate_checks.push(quote! {
+                    check(#section, #field_name_for_check, #val_expr as u64, #min as u64)?;
+                });
+            }
         }
     }
 

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -27,6 +27,7 @@ pub const DEFAULT_BASH_TIMEOUT_SECS: u64 = 120;
 pub const DEFAULT_CODE_EXECUTION_TIMEOUT_SECS: u64 = 30;
 pub const DEFAULT_MAX_CONTINUATION_TURNS: u32 = 3;
 pub const DEFAULT_COMPACTION_BUFFER: u32 = 40_000;
+pub const DEFAULT_COMPACTION_IDLE_MINUTES: Option<u64> = None;
 pub const DEFAULT_SEARCH_RESULT_LIMIT: usize = 100;
 pub const DEFAULT_INTERPRETER_MAX_MEMORY_MB: usize = 50;
 
@@ -48,6 +49,7 @@ pub const MIN_BASH_TIMEOUT_SECS: u64 = 5;
 pub const MIN_CODE_EXECUTION_TIMEOUT_SECS: u64 = 5;
 pub const MIN_MAX_CONTINUATION_TURNS: u32 = 1;
 pub const MIN_COMPACTION_BUFFER: u32 = 1_000;
+pub const MIN_COMPACTION_IDLE_MINUTES: u64 = 1;
 pub const MIN_SEARCH_RESULT_LIMIT: usize = 10;
 pub const MIN_INTERPRETER_MAX_MEMORY_MB: usize = 10;
 pub const MIN_MOUSE_SCROLL_LINES: u32 = 1;
@@ -90,6 +92,7 @@ pub enum ConfigValue {
     U64(u64),
     Usize(usize),
     OptionalString,
+    OptionalU64,
 }
 
 impl ConfigValue {
@@ -99,7 +102,7 @@ impl ConfigValue {
             Self::U32(v) => v.to_string(),
             Self::U64(v) => v.to_string(),
             Self::Usize(v) => v.to_string(),
-            Self::OptionalString => "none".to_string(),
+            Self::OptionalString | Self::OptionalU64 => "none".to_string(),
         }
     }
 }
@@ -334,6 +337,7 @@ pub struct AgentFileConfig {
     pub code_execution_timeout_secs: Option<u64>,
     pub max_continuation_turns: Option<u32>,
     pub compaction_buffer: Option<u32>,
+    pub compaction_idle_minutes: Option<u64>,
     pub search_result_limit: Option<usize>,
     pub interpreter_max_memory_mb: Option<usize>,
 }
@@ -351,6 +355,7 @@ impl AgentFileConfig {
             code_execution_timeout_secs,
             max_continuation_turns,
             compaction_buffer,
+            compaction_idle_minutes,
             search_result_limit,
             interpreter_max_memory_mb
         );
@@ -676,6 +681,9 @@ pub struct AgentConfig {
     #[config(default = DEFAULT_COMPACTION_BUFFER, min = MIN_COMPACTION_BUFFER, desc = "Token buffer reserved during compaction")]
     pub compaction_buffer: u32,
 
+    #[config(default = DEFAULT_COMPACTION_IDLE_MINUTES, min = MIN_COMPACTION_IDLE_MINUTES, desc = "Compact the conversation after this many minutes of no user input. `nil` (the default) disables it. Respects `MAKI_DISABLE_AUTOCOMPACT`")]
+    pub compaction_idle_minutes: Option<u64>,
+
     #[config(default = DEFAULT_SEARCH_RESULT_LIMIT, min = MIN_SEARCH_RESULT_LIMIT, desc = "Max results from grep/glob searches")]
     pub search_result_limit: usize,
 
@@ -721,6 +729,7 @@ impl AgentConfig {
                 .max_continuation_turns
                 .unwrap_or(DEFAULT_MAX_CONTINUATION_TURNS),
             compaction_buffer: file.compaction_buffer.unwrap_or(DEFAULT_COMPACTION_BUFFER),
+            compaction_idle_minutes: file.compaction_idle_minutes,
             search_result_limit: file
                 .search_result_limit
                 .unwrap_or(DEFAULT_SEARCH_RESULT_LIMIT),
@@ -1861,6 +1870,61 @@ mod tests {
         assert_eq!(tol.bash, Some(100), "overlay wins");
         assert_eq!(tol.read, Some(30), "base preserved");
         assert_eq!(tol.grep, Some(15), "overlay added");
+    }
+
+    #[test]
+    fn merge_compaction_idle_minutes_overlay() {
+        let mut base = RawConfig {
+            agent: AgentFileConfig {
+                compaction_idle_minutes: Some(10),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let overlay = RawConfig {
+            agent: AgentFileConfig {
+                compaction_idle_minutes: Some(30),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        base.merge(overlay);
+        assert_eq!(base.agent.compaction_idle_minutes, Some(30), "overlay wins");
+    }
+
+    #[test]
+    fn into_config_compaction_idle_minutes() {
+        let raw = RawConfig {
+            agent: AgentFileConfig {
+                compaction_idle_minutes: Some(25),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let config = raw.into_config(false).unwrap();
+        assert_eq!(config.agent.compaction_idle_minutes, Some(25));
+    }
+
+    #[test]
+    fn into_config_compaction_default_off() {
+        let config = RawConfig::default().into_config(false).unwrap();
+        assert_eq!(config.agent.compaction_idle_minutes, None, "off by default");
+    }
+
+    #[test]
+    fn compaction_idle_minutes_below_min_errors() {
+        let raw = RawConfig {
+            agent: AgentFileConfig {
+                compaction_idle_minutes: Some(0),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let config = raw.into_config(false).unwrap();
+        let err = config.validate().unwrap_err();
+        assert!(
+            matches!(err, ConfigError::BelowMinimum { field, min, .. } if field == "compaction_idle_minutes" && min == MIN_COMPACTION_IDLE_MINUTES)
+        );
     }
 
     #[test]

--- a/maki-docgen/src/gen_config.rs
+++ b/maki-docgen/src/gen_config.rs
@@ -121,6 +121,7 @@ maki.setup({{
     agent = {{
         bash_timeout_secs = {bash_timeout},
         max_output_lines = {max_output_lines},
+        compaction_idle_minutes = 30,
     }},
     provider = {{
         default_model = \"anthropic/claude-sonnet-4-6\",

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use arc_swap::{ArcSwap, ArcSwapOption};
 use color_eyre::Result;
@@ -31,6 +31,7 @@ use crate::terminal;
 
 const ANIMATION_INTERVAL_MS: u64 = 16;
 const IDLE_POLL_INTERVAL_MS: u64 = 100;
+const MIN_MESSAGES_FOR_IDLE_COMPACT: usize = 2;
 
 pub struct EventLoopParams {
     pub model: Model,
@@ -66,6 +67,9 @@ pub(crate) struct EventLoop<'t> {
     storage_writer: Arc<StorageWriter>,
     timeouts: Timeouts,
     ui_action_rx: Option<flume::Receiver<UiAction>>,
+    idle_threshold: Option<Duration>,
+    last_input: Instant,
+    idle_compact_fired: bool,
     _model_fetch_task: smol::Task<()>,
 }
 
@@ -94,6 +98,33 @@ fn merge_batch(
         }
     }
     available.store(Some(Arc::new(merged)));
+}
+
+fn idle_threshold(config: &AgentConfig) -> Option<Duration> {
+    if !maki_agent::auto_compact_enabled() {
+        return None;
+    }
+    config
+        .compaction_idle_minutes
+        .map(|m| Duration::from_secs(m * 60))
+}
+
+fn should_idle_compact(
+    threshold: Option<Duration>,
+    elapsed_since_input: Duration,
+    already_fired: bool,
+    history_len: usize,
+) -> bool {
+    let Some(threshold) = threshold else {
+        return false;
+    };
+    if already_fired {
+        return false;
+    }
+    if elapsed_since_input < threshold {
+        return false;
+    }
+    history_len > MIN_MESSAGES_FOR_IDLE_COMPACT
 }
 
 fn spawn_model_fetch(model_slot: &Arc<ArcSwap<ModelSlot>>, timeouts: Timeouts) -> BackgroundModels {
@@ -195,6 +226,7 @@ impl<'t> EventLoop<'t> {
             model: model.clone(),
             provider,
         }));
+        let idle_threshold = idle_threshold(&config);
         let bg = spawn_model_fetch(&model_slot, timeouts);
         let handles = AgentHandles::spawn(
             &model_slot,
@@ -257,6 +289,9 @@ impl<'t> EventLoop<'t> {
             storage_writer,
             timeouts,
             ui_action_rx,
+            idle_threshold,
+            last_input: Instant::now(),
+            idle_compact_fired: false,
             _model_fetch_task: bg.task,
         })
     }
@@ -363,6 +398,10 @@ impl<'t> EventLoop<'t> {
 
     fn poll_and_handle_input(&mut self, had_agent_msg: bool) -> Result<()> {
         let has_pending_ui_action = self.ui_action_rx.as_ref().is_some_and(|rx| !rx.is_empty());
+        let idle = !had_agent_msg
+            && !has_pending_ui_action
+            && !self.app.is_animating()
+            && self.app.status != Status::Streaming;
         let poll_duration = if had_agent_msg || has_pending_ui_action {
             Duration::ZERO
         } else if self.app.is_animating() {
@@ -372,14 +411,41 @@ impl<'t> EventLoop<'t> {
         };
 
         if !event::poll(poll_duration)? {
+            if idle {
+                self.maybe_idle_compact();
+            }
             return Ok(());
         }
 
         if let Some(msg) = self.translate_input()? {
+            self.last_input = Instant::now();
+            self.idle_compact_fired = false;
             let actions = self.app.update(msg);
             self.dispatch(actions);
         }
         Ok(())
+    }
+
+    fn maybe_idle_compact(&mut self) {
+        let history_len = self
+            .app
+            .shared_history
+            .as_ref()
+            .map(|h| h.load().len())
+            .unwrap_or(0);
+        let elapsed = self.last_input.elapsed();
+        if !should_idle_compact(
+            self.idle_threshold,
+            elapsed,
+            self.idle_compact_fired,
+            history_len,
+        ) {
+            return;
+        }
+        self.idle_compact_fired = true;
+        self.handles.queue.push(QueueItem::Compact {
+            run_id: self.app.run_id,
+        });
     }
 
     fn translate_input(&mut self) -> Result<Option<Msg>> {
@@ -651,4 +717,65 @@ fn coalesce_drag(mut latest: CtMouseEvent) -> (CtMouseEvent, Option<Msg>) {
         }
     }
     (latest, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MIN_MESSAGES_FOR_IDLE_COMPACT, should_idle_compact};
+    use std::time::Duration;
+
+    const THRESHOLD: Duration = Duration::from_secs(60);
+
+    #[test]
+    fn fires_when_idle_beyond_threshold_with_enough_history() {
+        assert!(should_idle_compact(
+            Some(THRESHOLD),
+            THRESHOLD + Duration::from_secs(1),
+            false,
+            MIN_MESSAGES_FOR_IDLE_COMPACT + 1,
+        ));
+    }
+
+    #[test]
+    fn no_threshold_means_disabled() {
+        // MAKI_DISABLE_AUTOCOMPACT=1 path: idle_threshold returns None.
+        assert!(!should_idle_compact(
+            None,
+            THRESHOLD + Duration::from_secs(1),
+            false,
+            MIN_MESSAGES_FOR_IDLE_COMPACT + 1,
+        ));
+    }
+
+    #[test]
+    fn typing_resets_clock() {
+        // User typed within the idle window: elapsed < threshold.
+        assert!(!should_idle_compact(
+            Some(THRESHOLD),
+            THRESHOLD - Duration::from_secs(1),
+            false,
+            MIN_MESSAGES_FOR_IDLE_COMPACT + 1,
+        ));
+    }
+
+    #[test]
+    fn short_history_skips_compaction() {
+        // 2-message history is the post-compaction summary; don't re-compact it.
+        assert!(!should_idle_compact(
+            Some(THRESHOLD),
+            THRESHOLD + Duration::from_secs(1),
+            false,
+            MIN_MESSAGES_FOR_IDLE_COMPACT,
+        ));
+    }
+
+    #[test]
+    fn already_fired_does_not_refire() {
+        assert!(!should_idle_compact(
+            Some(THRESHOLD),
+            THRESHOLD + Duration::from_secs(1),
+            true,
+            MIN_MESSAGES_FOR_IDLE_COMPACT + 1,
+        ));
+    }
 }

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -31,6 +31,7 @@ maki.setup({
     agent = {
         bash_timeout_secs = 180,
         max_output_lines = 3000,
+        compaction_idle_minutes = 30,
     },
     provider = {
         default_model = "anthropic/claude-sonnet-4-6",
@@ -96,6 +97,7 @@ How many lines of output to show per tool in the UI. All values are `usize` with
 | `code_execution_timeout_secs` | u64 | `30` | 5 | Code execution timeout (seconds) |
 | `max_continuation_turns` | u32 | `3` | 1 | Max automatic continuation turns |
 | `compaction_buffer` | u32 | `40000` | 1000 | Token buffer reserved during compaction |
+| `compaction_idle_minutes` | u64 | `none` | 1 | Compact the conversation after this many minutes of no user input. `nil` (the default) disables it. Respects `MAKI_DISABLE_AUTOCOMPACT` |
 | `search_result_limit` | usize | `100` | 10 | Max results from grep/glob searches |
 | `interpreter_max_memory_mb` | usize | `50` | 10 | Memory limit for code interpreter (MB) |
 


### PR DESCRIPTION
At work, to manage cost, I've been running `/compact` like a maniac to make sure that I don't spend Claude Bucks™ on 500k uncached input tokens if I walk away for an hour or two. And annoying as that is to have to do that, there's nothing I can do if I leave sessions running overnight, even compacting immediately the next morning still pays the toll. I tried to implement this as a Lua plugin, but since that wasn't viable without changes to core maki, I figured it made enough sense as built-in behavior to implement that instead.

This just piggybacks off of the existing input polling loop to check if we've had more than 4 messages since start of session/last compaction. It's off by default, I'm _personally_ going for 30 minutes because most caches live until _about_ an hour to my knowledge, hence the docs example of 30 minutes.

Written with Maki, reviewed manually.