### PR TITLE
fix(storage): freeze native tool core to isolate tests from registry mutations 🤖🤖🤖

### DIFF
--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -866,7 +866,7 @@ mod tests {
             "{\"path\": 123, \"pattern\": []}",
         ];
         let registry = ToolRegistry::native();
-        for entry in registry.iter().iter() {
+        for entry in registry.native_iter().iter() {
             let name = entry.name().to_owned();
             for raw in BOGUS_INPUTS {
                 let input: Value = serde_json::from_str(raw).unwrap();
@@ -944,7 +944,7 @@ mod tests {
         let expected: std::collections::BTreeMap<&str, ToolAudience> =
             std::collections::BTreeMap::from([(BATCH_TOOL_NAME, MAIN | RES | GEN)]);
 
-        let snapshot = ToolRegistry::native().iter();
+        let snapshot = ToolRegistry::native().native_iter();
         let actual: std::collections::BTreeMap<String, ToolAudience> = snapshot
             .iter()
             .map(|e| (e.name().to_owned(), e.tool.audience()))
@@ -1181,7 +1181,7 @@ mod tests {
     fn lua_tools_not_in_native_registry() {
         let lua_only = ["glob", "grep", "task"];
         let registry = ToolRegistry::native();
-        for entry in registry.iter().iter() {
+        for entry in registry.native_iter().iter() {
             assert!(
                 !lua_only.contains(&entry.name()),
                 "{} should not be in the native Rust tool registry",

--- a/maki-agent/src/tools/registry.rs
+++ b/maki-agent/src/tools/registry.rs
@@ -220,14 +220,13 @@ impl RegisteredTool {
     }
 }
 
-/// Lock-free reads via `ArcSwap`, writes swap in a new snapshot atomically.
-///
-/// Bundled Lua plugins can replace a native tool with their own version.
-/// The original native tool is kept in `native_fallbacks` so we can still
-/// look up its header info. User plugins are not allowed to replace tools
-/// that aren't native (that gives a `NameConflict` error).
+/// `tools` is the live list mutated by `register`/`replace_plugin`/`clear_*`.
+/// `native_core` is the frozen native set, never mutated, so tests enumerating
+/// natives are immune to other tests registering fixtures into the live list.
+/// `native_fallbacks` retains headers for natives displaced by plugins.
 pub struct ToolRegistry {
     tools: ArcSwap<Vec<RegisteredTool>>,
+    native_core: Arc<Vec<RegisteredTool>>,
     native_fallbacks: ArcSwap<Vec<RegisteredTool>>,
 }
 
@@ -247,6 +246,7 @@ impl ToolRegistry {
     pub fn new() -> Self {
         Self {
             tools: ArcSwap::from_pointee(Vec::new()),
+            native_core: Arc::new(Vec::new()),
             native_fallbacks: ArcSwap::from_pointee(Vec::new()),
         }
     }
@@ -268,7 +268,6 @@ impl ToolRegistry {
     /// `register_tools!` catches dupes at compile time. Plugins and MCP skip
     /// that macro, so this runtime check is the safety net.
     fn build_native() -> Self {
-        let registry = Self::new();
         let natives = super::native_tools();
         let mut vec: Vec<RegisteredTool> = Vec::with_capacity(natives.len());
         for tool in natives {
@@ -282,8 +281,12 @@ impl ToolRegistry {
                 source: ToolSource::Native,
             });
         }
-        registry.tools.store(Arc::new(vec));
-        registry
+        let native_core = Arc::new(vec.clone());
+        Self {
+            tools: ArcSwap::from_pointee(vec),
+            native_core,
+            native_fallbacks: ArcSwap::from_pointee(Vec::new()),
+        }
     }
 
     pub fn get(&self, name: &str) -> Option<RegisteredTool> {
@@ -524,6 +527,10 @@ impl ToolRegistry {
 
     pub fn iter(&self) -> RegistrySnapshot {
         RegistrySnapshot(self.tools.load_full())
+    }
+
+    pub fn native_iter(&self) -> RegistrySnapshot {
+        RegistrySnapshot(Arc::clone(&self.native_core))
     }
 }
 


### PR DESCRIPTION
## Problem

`cargo test -p maki-agent` fails on `tools::tests::audience_matrix_is_locked` (reported in https://github.com/tontinton/maki/pull/436#issuecomment-4887588796):

```
assertion `left == right` failed: native tool count drift: expected 1, got 2 (["batch", "guarded_mock"])
```

`just ci` passes because it uses `cargo nextest` (one process per test). `cargo test` runs in a single process with parallel threads, so the global mutable registry leaks across tests.

## Root cause

`ToolRegistry::native()` is a process-global `LazyLock` singleton. Batch tests call `ensure_test_tool()` which registers `GuardedMock` into it via `register()`. `audience_matrix_is_locked` then enumerates the same registry and sees the leaked `guarded_mock` alongside `batch`.

## Fix

Add `native_core: Arc<Vec<RegisteredTool>>` to `ToolRegistry`, frozen once in `build_native()` and never mutated. `register`/`replace_plugin`/`clear_*` still target the live `tools` list, so production behavior is unchanged. Tests that enumerate natives (`audience_matrix_is_locked`, `every_tool_rejects_bogus_input_without_internal_bug`, `lua_tools_not_in_native_registry`) use a new `native_iter()` over the frozen core and are immune to other tests' fixtures.

No production code path changed. No test-only feature flag or source variant.

## Verification

- `cargo test -p maki-agent tools::tests::audience_matrix_is_locked` passes
- `cargo test -p maki-agent` no longer fails on `audience_matrix_is_locked` (only the pre-existing XDG_CONFIG_HOME leak from #436 remains, out of scope here)
- `cargo clippy -p maki-agent --tests -- -D warnings` clean

## AI use

Authored by an AI coding agent (maki). The brainstorm that compared approaches 5 vs 7, the implementation, the test reproduction, and this PR description were all produced by the agent under human direction. No separate prompts to include.