### PR TITLE
bugfix: inject ToolRegistry via ToolContext to isolate tests

### DIFF
--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -59,6 +59,7 @@ pub struct AgentParams {
     pub file_tracker: Arc<FileReadTracker>,
     pub prompt_slots: Arc<crate::prompt::ResolvedSlots>,
     pub subagent_cancels: Arc<CancelMap<String>>,
+    pub registry: Arc<crate::tools::ToolRegistry>,
 }
 
 pub struct AgentRunParams<'h> {
@@ -98,6 +99,7 @@ pub struct Agent<'h> {
     file_tracker: Arc<FileReadTracker>,
     prompt_slots: Arc<crate::prompt::ResolvedSlots>,
     subagent_cancels: Arc<crate::cancel::CancelMap<String>>,
+    registry: Arc<crate::tools::ToolRegistry>,
 }
 
 impl<'h> Agent<'h> {
@@ -132,6 +134,7 @@ impl<'h> Agent<'h> {
             file_tracker: params.file_tracker,
             prompt_slots: params.prompt_slots,
             subagent_cancels: params.subagent_cancels,
+            registry: params.registry,
         }
     }
 
@@ -390,6 +393,7 @@ impl<'h> Agent<'h> {
             prompt_slots: Arc::clone(&self.prompt_slots),
             opts: self.opts,
             subagent_cancels: Arc::clone(&self.subagent_cancels),
+            registry: Arc::clone(&self.registry),
         }
     }
 
@@ -600,6 +604,7 @@ mod tests {
                 file_tracker: FileReadTracker::fresh(),
                 prompt_slots: Arc::new(crate::prompt::ResolvedSlots::default()),
                 subagent_cancels: Arc::new(crate::cancel::CancelMap::new()),
+                registry: Arc::new(crate::tools::ToolRegistry::with_natives()),
             },
             AgentRunParams {
                 history,
@@ -856,6 +861,7 @@ mod tests {
                     file_tracker: FileReadTracker::fresh(),
                     prompt_slots: Arc::new(crate::prompt::ResolvedSlots::default()),
                     subagent_cancels: Arc::new(crate::cancel::CancelMap::new()),
+                    registry: Arc::new(crate::tools::ToolRegistry::with_natives()),
                 },
                 AgentRunParams {
                     history: &mut history,

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -125,7 +125,7 @@ pub async fn run(
             annotation: invocation.start_annotation(),
             input: invocation.start_input(),
             raw_input: Some(input.clone()),
-            output: invocation.start_output(),
+            output: invocation.start_output(ctx),
         };
         if matches!(emit, Emit::Notify) {
             let _ = ctx.event_tx.send(AgentEvent::ToolStart(Box::new(start)));
@@ -321,7 +321,7 @@ pub(super) async fn process_tool_calls(
         let mcp_owned = mcp.cloned();
         set.spawn(async move {
             let done = run(
-                ToolRegistry::native(),
+                &tool_ctx.registry,
                 mcp_owned.as_ref(),
                 id,
                 &name,
@@ -418,7 +418,7 @@ mod tests {
         smol::block_on(async {
             let ctx = crate::tools::test_support::stub_ctx(&AgentMode::Build);
             let done = run(
-                ToolRegistry::native(),
+                &ctx.registry,
                 None,
                 "t1".into(),
                 "nonexistent__tool",

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -101,7 +101,14 @@ fn setup(
 ) -> AgentSetup {
     let vars = template::env_vars();
     let instructions = agent::load_instructions(&vars.apply("{cwd}"));
-    let tools = tool_definitions(&vars, model, config, excluded_tools, mcp_handle);
+    let tools = tool_definitions(
+        &vars,
+        model,
+        config,
+        excluded_tools,
+        mcp_handle,
+        ToolRegistry::native(),
+    );
 
     AgentSetup {
         vars,
@@ -116,10 +123,11 @@ fn tool_definitions(
     config: &AgentConfig,
     excluded_tools: &[&'static str],
     mcp_handle: Option<&McpHandle>,
+    registry: &ToolRegistry,
 ) -> Value {
     let filter = ToolFilter::from_config(config, excluded_tools);
     let ctx = DescriptionContext { filter: &filter };
-    let mut tools = ToolRegistry::native().definitions(vars, &ctx, model.supports_tool_examples());
+    let mut tools = registry.definitions(vars, &ctx, model.supports_tool_examples());
 
     if let Some(handle) = mcp_handle {
         handle.extend_tools(&mut tools);
@@ -192,6 +200,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
                     file_tracker: FileReadTracker::fresh(),
                     prompt_slots: Arc::new(params.prompt_slots),
                     subagent_cancels: Arc::new(CancelMap::new()),
+                    registry: Arc::clone(ToolRegistry::native_arc()),
                 },
                 AgentRunParams {
                     history: &mut history,
@@ -336,6 +345,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                                 &params.config,
                                 &params.excluded_tools,
                                 params.mcp_handle.as_ref(),
+                                ToolRegistry::native(),
                             );
                             model = new_model;
                         }
@@ -388,6 +398,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                         file_tracker: Arc::clone(&file_tracker),
                         prompt_slots: Arc::clone(&params.prompt_slots),
                         subagent_cancels: Arc::new(CancelMap::new()),
+                        registry: Arc::clone(ToolRegistry::native_arc()),
                     },
                     AgentRunParams {
                         history: &mut history,

--- a/maki-agent/src/tools/batch.rs
+++ b/maki-agent/src/tools/batch.rs
@@ -114,17 +114,18 @@ impl<'de> Deserialize<'de> for BatchEntry {
 impl BatchEntry {
     fn to_batch_entry(
         &self,
+        registry: &ToolRegistry,
         status: BatchToolStatus,
         output: Option<ToolOutput>,
         summary: Option<String>,
     ) -> BatchToolEntry {
-        let reg = ToolRegistry::native();
-        let call = reg
+        let call = registry
             .get(&self.tool)
             .and_then(|e| e.tool.parse(&self.parameters).ok());
         BatchToolEntry {
             tool: self.tool.clone(),
-            summary: summary.unwrap_or_else(|| reg.resolve_header(&self.tool, &self.parameters)),
+            summary: summary
+                .unwrap_or_else(|| registry.resolve_header(&self.tool, &self.parameters)),
             status,
             input: call.and_then(|c| c.start_input()),
             raw_input: Some(self.parameters.clone()),
@@ -193,9 +194,7 @@ impl Batch {
                     );
                 }
 
-                let summary = ToolRegistry::native()
-                    .resolve_header_async(&name, &params)
-                    .await;
+                let summary = ctx.registry.resolve_header_async(&name, &params).await;
 
                 ctx.event_tx
                     .try_send(AgentEvent::BatchProgress(Box::new(BatchProgressEvent {
@@ -212,7 +211,7 @@ impl Batch {
                     ..ctx.clone()
                 };
                 let done = tool_dispatch::run(
-                    ToolRegistry::native(),
+                    &ctx.registry,
                     inner_ctx.mcp.as_ref(),
                     id,
                     &name,
@@ -284,7 +283,7 @@ impl Batch {
                 } else {
                     BatchToolStatus::Error
                 };
-                entry.to_batch_entry(status, br.output.clone(), br.summary.clone())
+                entry.to_batch_entry(&ctx.registry, status, br.output.clone(), br.summary.clone())
             })
             .collect();
 
@@ -306,7 +305,7 @@ impl Batch {
                 "## {}\n[ERROR] maximum of {MAX_BATCH_SIZE} tools per batch\n\n",
                 entry.tool
             );
-            entries.push(entry.to_batch_entry(BatchToolStatus::Error, None, None));
+            entries.push(entry.to_batch_entry(&ctx.registry, BatchToolStatus::Error, None, None));
         }
 
         let succeeded = total - failed;
@@ -348,11 +347,11 @@ impl super::ToolInvocation for Batch {
     fn start_header(&self) -> super::HeaderFuture {
         super::HeaderFuture::Ready(super::HeaderResult::plain(Batch::start_header(self)))
     }
-    fn start_output(&self) -> Option<ToolOutput> {
+    fn start_output(&self, ctx: &super::ToolContext) -> Option<ToolOutput> {
         let entries = self
             .tool_calls
             .iter()
-            .map(|entry| entry.to_batch_entry(BatchToolStatus::Pending, None, None))
+            .map(|entry| entry.to_batch_entry(&ctx.registry, BatchToolStatus::Pending, None, None))
             .collect();
         Some(ToolOutput::Batch {
             entries,
@@ -368,7 +367,7 @@ impl super::ToolInvocation for Batch {
 mod tests {
     use crate::BatchToolEntry;
     use serde_json::json;
-    use std::sync::{Arc, Once};
+    use std::sync::Arc;
 
     use crate::AgentMode;
     use crate::tools::ToolSource;
@@ -376,12 +375,10 @@ mod tests {
 
     use super::*;
 
-    static REGISTER_TEST_TOOL: Once = Once::new();
-
-    fn ensure_test_tool() {
-        REGISTER_TEST_TOOL.call_once(|| {
-            let _ = ToolRegistry::native().register(Arc::new(GuardedMock), ToolSource::Native);
-        });
+    fn register_guarded(ctx: &ToolContext) {
+        let _ = ctx
+            .registry
+            .register(Arc::new(GuardedMock), ToolSource::Native);
     }
 
     async fn run_batch(input: Value) -> (Vec<BatchToolEntry>, String) {
@@ -422,8 +419,8 @@ mod tests {
     #[test]
     fn parallel_execution_with_mixed_results() {
         smol::block_on(async {
-            ensure_test_tool();
             let ctx = stub_ctx(&crate::AgentMode::Build);
+            register_guarded(&ctx);
 
             let (entries, _text) = execute_batch(
                 &ctx,
@@ -478,10 +475,10 @@ mod tests {
         use crate::{Envelope, EventSender};
 
         smol::block_on(async {
-            ensure_test_tool();
             let (tx, rx) = flume::unbounded::<Envelope>();
             let event_tx = EventSender::new(tx, 0);
             let ctx = stub_ctx_with(&AgentMode::Build, Some(&event_tx), None);
+            register_guarded(&ctx);
             execute_batch(
                 &ctx,
                 json!({

--- a/maki-agent/src/tools/interpreter_bridge.rs
+++ b/maki-agent/src/tools/interpreter_bridge.rs
@@ -8,7 +8,7 @@ use smol::future::block_on;
 use crate::agent::tool_dispatch::{self, Emit};
 use crate::task_set::TaskSet;
 
-use super::{ToolAudience, ToolContext, ToolRegistry};
+use super::{ToolAudience, ToolContext};
 
 async fn call(
     ctx: &ToolContext,
@@ -19,7 +19,7 @@ async fn call(
     ctx.deadline.check()?;
     let input = build_tool_input(args, kwargs)?;
     let done = tool_dispatch::run(
-        ToolRegistry::native(),
+        &ctx.registry,
         ctx.mcp.as_ref(),
         String::new(),
         name,
@@ -36,7 +36,7 @@ async fn call(
 }
 
 pub fn build_tool_fns(ctx: &ToolContext) -> HashMap<String, ToolFn> {
-    ToolRegistry::native()
+    ctx.registry
         .iter()
         .iter()
         .filter(|entry| entry.tool.audience().contains(ToolAudience::INTERPRETER))

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -192,6 +192,7 @@ pub struct ToolContext {
     pub prompt_slots: Arc<crate::prompt::ResolvedSlots>,
     pub opts: RequestOptions,
     pub subagent_cancels: Arc<CancelMap<String>>,
+    pub registry: Arc<ToolRegistry>,
 }
 
 pub(crate) fn resolve_path(path: &str) -> Result<String, String> {
@@ -579,6 +580,7 @@ pub fn interpreter_ctx(
     permissions: Arc<PermissionManager>,
     file_tracker: Arc<FileReadTracker>,
     user_response_rx: Option<Arc<async_lock::Mutex<flume::Receiver<String>>>>,
+    registry: Arc<ToolRegistry>,
 ) -> ToolContext {
     static PROVIDER: LazyLock<Arc<dyn Provider>> = LazyLock::new(|| Arc::new(NullProvider));
     static MODEL: LazyLock<Arc<Model>> =
@@ -602,6 +604,7 @@ pub fn interpreter_ctx(
         prompt_slots: Arc::new(crate::prompt::ResolvedSlots::default()),
         opts: RequestOptions::default(),
         subagent_cancels: Arc::new(CancelMap::new()),
+        registry,
     }
 }
 
@@ -624,6 +627,7 @@ pub fn cli_tool_ctx() -> ToolContext {
         )),
         Arc::new(FileReadTracker::new()),
         None,
+        Arc::clone(ToolRegistry::native_arc()),
     )
 }
 
@@ -705,6 +709,7 @@ pub mod test_support {
             Arc::clone(&TEST_PERMISSIONS),
             Arc::new(FileReadTracker::new()),
             None,
+            Arc::new(ToolRegistry::with_natives()),
         );
         ctx.tool_use_id = tool_use_id.map(String::from);
         ctx
@@ -728,6 +733,7 @@ pub mod test_support {
             permissions,
             Arc::new(FileReadTracker::new()),
             None,
+            Arc::new(ToolRegistry::with_natives()),
         );
         ctx.tool_use_id = None;
         ctx

--- a/maki-agent/src/tools/registry.rs
+++ b/maki-agent/src/tools/registry.rs
@@ -175,7 +175,7 @@ pub trait ToolInvocation: Send + Sync {
     fn start_input(&self) -> Option<ToolInputEvent> {
         None
     }
-    fn start_output(&self) -> Option<ToolOutput> {
+    fn start_output(&self, _ctx: &ToolContext) -> Option<ToolOutput> {
         None
     }
     fn mutable_path(&self) -> Option<&Path> {

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -297,6 +297,7 @@ async fn run(lua: Lua, (agent_ctx_ud, opts): (mlua::AnyUserData, Table)) -> LuaR
             file_tracker: FileReadTracker::fresh(),
             prompt_slots: Arc::clone(&agent_ctx.prompt_slots),
             subagent_cancels: Arc::new(CancelMap::new()),
+            registry: Arc::clone(maki_agent::tools::ToolRegistry::native_arc()),
         },
         AgentRunParams {
             history: &mut history,

--- a/maki-lua/src/api/interpreter.rs
+++ b/maki-lua/src/api/interpreter.rs
@@ -56,6 +56,7 @@ async fn interpreter_run(
         Arc::clone(&agent_ctx.permissions),
         Arc::clone(&agent_ctx.file_tracker),
         agent_ctx.user_response_rx.clone(),
+        Arc::clone(maki_agent::tools::ToolRegistry::native_arc()),
     );
     ctx.deadline = Deadline::after(timeout);
     ctx.config = agent_ctx.config.clone();

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -232,6 +232,7 @@ impl AgentLoop {
                 file_tracker: Arc::clone(&self.file_tracker),
                 prompt_slots: Arc::new(prompt_slots),
                 subagent_cancels: Arc::clone(&self.subagent_cancels),
+                registry: Arc::clone(maki_agent::tools::ToolRegistry::native_arc()),
             },
             AgentRunParams {
                 history: &mut self.history,


### PR DESCRIPTION
After fixing some config-relevant unit tests in https://github.com/tontinton/maki/pull/436, @clee [pointed out](https://github.com/tontinton/maki/pull/436#issuecomment-4887588796) another failing test, `tools::tests::audience_matrix_is_locked`.

```
assertion `left == right` failed: native tool count drift: expected 1, got 2 (["batch", "guarded_mock"])
```

`just ci` passes because it uses `cargo nextest` (one process per test). `cargo test` runs in a single process with parallel threads, so the global mutable registry leaks across tests. This does proper dependency injection of the `ToolRegistry` for proper test isolation.

Implemented with maki + GLM-5.2, reviewed manually.