### PR TITLE
ui: themes: Add Ayu light and mirage themes

### DIFF
--- a/maki-ui/src/theme.rs
+++ b/maki-ui/src/theme.rs
@@ -133,6 +133,14 @@ pub static BUNDLED_THEMES: &[ThemeEntry] = &[
         toml: include_str!("themes/ayu_dark.toml"),
     },
     ThemeEntry {
+        name: "ayu_light",
+        toml: include_str!("themes/ayu_light.toml"),
+    },
+    ThemeEntry {
+        name: "ayu_mirage",
+        toml: include_str!("themes/ayu_mirage.toml"),
+    },
+    ThemeEntry {
         name: "carbonfox",
         toml: include_str!("themes/carbonfox.toml"),
     },

--- a/maki-ui/src/themes/ayu_light.toml
+++ b/maki-ui/src/themes/ayu_light.toml
@@ -1,4 +1,4 @@
-# Ayu Dark -- palette sourced from ayu-colors/themes/dark.yaml
+# Ayu Light -- palette sourced from ayu-colors/themes/light.yaml
 # Each palette entry is commented with its official Ayu YAML path.
 
 "comment"                         = { fg = "comment" }
@@ -87,39 +87,39 @@
 
 [palette]
 # surface.base
-background   = "#0d1017"
+background   = "#f8f9fa"
 # editor.fg
-foreground   = "#bfbdb6"
+foreground   = "#5c6166"
 # syntax.comment  (palette.gray.l4)
-comment      = "#5a6673"
-# syntax.entity  (palette.blue.l3)
-blue         = "#59c2ff"
-# syntax.regexp  (palette.teal.l5)
-cyan         = "#95e6cb"
-# syntax.string  (palette.green.l4)
-green        = "#aad94c"
+comment      = "#adaeb1"
+# syntax.entity  (palette.blue.l2)
+blue         = "#22a4e6"
+# syntax.regexp  (palette.teal.l3)
+cyan         = "#4cbf99"
+# syntax.string  (palette.green.l3)
+green        = "#86b300"
 # syntax.keyword  (palette.orange.l3)
-orange       = "#ff8f40"
-# palette.pink.l3
-pink         = "#f29668"
-# syntax.constant  (palette.purple.l3)
-purple       = "#d2a6ff"
+orange       = "#fa8532"
+# palette.pink.l4
+pink         = "#f2a191"
+# syntax.constant  (palette.purple.l2)
+purple       = "#a37acc"
 # vcs.removed
-red          = "#f26d78"
+red          = "#ff7383"
 # syntax.func  (palette.yellow.l4)
-yellow       = "#ffb454"
-# editor.line
-current_line = "#161a24"
-# ui.line
-selection    = "#1b1f29"
+yellow       = "#eba400"
+# surface.sunk
+current_line = "#ebeef0"
+# Derived: subtle shade of surface.base
+selection    = "#e5e8ec"
 
 [ui]
 user               = { fg = "blue" }
 assistant          = { fg = "foreground" }
 assistant_prefix   = { fg = "orange" }
 thinking           = { fg = "comment", modifiers = ["italic"] }
-# surface.base
-tool_bg            = { bg = "#0d1017" }
+# surface.sunk
+tool_bg            = { bg = "#ebeef0" }
 tool               = { fg = "foreground" }
 tool_path          = { fg = "yellow" }
 tool_annotation    = { fg = "comment" }
@@ -134,10 +134,10 @@ plan_rule          = { fg = "orange", modifiers = ["bold"] }
 code_block         = { fg = "foreground" }
 horizontal_rule    = { fg = "comment" }
 table_border       = { fg = "comment" }
-diff_old           = { bg = "#3d1c1c" }
-diff_new           = { bg = "#1c3020" }
-diff_old_emphasis  = { bg = "#5c2a2a" }
-diff_new_emphasis  = { bg = "#2a4a30" }
+diff_old           = { bg = "#f5d5d5" }
+diff_new           = { bg = "#d5ecd5" }
+diff_old_emphasis  = { bg = "#edb0b0" }
+diff_new_emphasis  = { bg = "#b5dd9a" }
 diff_line_nr       = { fg = "comment" }
 todo_completed     = { fg = "green" }
 todo_in_progress   = { fg = "yellow" }

--- a/maki-ui/src/themes/ayu_mirage.toml
+++ b/maki-ui/src/themes/ayu_mirage.toml
@@ -1,4 +1,4 @@
-# Ayu Dark -- palette sourced from ayu-colors/themes/dark.yaml
+# Ayu Mirage -- palette sourced from ayu-colors/themes/mirage.yaml
 # Each palette entry is commented with its official Ayu YAML path.
 
 "comment"                         = { fg = "comment" }
@@ -87,39 +87,39 @@
 
 [palette]
 # surface.base
-background   = "#0d1017"
+background   = "#1f2430"
 # editor.fg
-foreground   = "#bfbdb6"
-# syntax.comment  (palette.gray.l4)
-comment      = "#5a6673"
+foreground   = "#cccac2"
+# syntax.comment  (palette.gray.l1)
+comment      = "#6e7c8f"
 # syntax.entity  (palette.blue.l3)
-blue         = "#59c2ff"
-# syntax.regexp  (palette.teal.l5)
+blue         = "#73d0ff"
+# syntax.regexp  (palette.teal.l4)
 cyan         = "#95e6cb"
-# syntax.string  (palette.green.l4)
-green        = "#aad94c"
-# syntax.keyword  (palette.orange.l3)
-orange       = "#ff8f40"
-# palette.pink.l3
-pink         = "#f29668"
-# syntax.constant  (palette.purple.l3)
-purple       = "#d2a6ff"
+# syntax.string  (palette.green.l5)
+green        = "#d5ff80"
+# syntax.keyword  (palette.orange.l2)
+orange       = "#ffa659"
+# palette.pink.l2
+pink         = "#f29e74"
+# syntax.constant  (palette.purple.l4)
+purple       = "#dfbfff"
 # vcs.removed
-red          = "#f26d78"
+red          = "#f27983"
 # syntax.func  (palette.yellow.l4)
-yellow       = "#ffb454"
+yellow       = "#ffcd66"
 # editor.line
-current_line = "#161a24"
+current_line = "#1a1f29"
 # ui.line
-selection    = "#1b1f29"
+selection    = "#171b24"
 
 [ui]
 user               = { fg = "blue" }
 assistant          = { fg = "foreground" }
 assistant_prefix   = { fg = "orange" }
 thinking           = { fg = "comment", modifiers = ["italic"] }
-# surface.base
-tool_bg            = { bg = "#0d1017" }
+# surface.sunk
+tool_bg            = { bg = "#181c26" }
 tool               = { fg = "foreground" }
 tool_path          = { fg = "yellow" }
 tool_annotation    = { fg = "comment" }
@@ -134,10 +134,10 @@ plan_rule          = { fg = "orange", modifiers = ["bold"] }
 code_block         = { fg = "foreground" }
 horizontal_rule    = { fg = "comment" }
 table_border       = { fg = "comment" }
-diff_old           = { bg = "#3d1c1c" }
-diff_new           = { bg = "#1c3020" }
-diff_old_emphasis  = { bg = "#5c2a2a" }
-diff_new_emphasis  = { bg = "#2a4a30" }
+diff_old           = { bg = "#3a2225" }
+diff_new           = { bg = "#223a28" }
+diff_old_emphasis  = { bg = "#4d2c30" }
+diff_new_emphasis  = { bg = "#2c4d35" }
 diff_line_nr       = { fg = "comment" }
 todo_completed     = { fg = "green" }
 todo_in_progress   = { fg = "yellow" }


### PR DESCRIPTION
And fix Ayu dark to be more in line with the official color scheme.

Colors taken from https://github.com/ayu-theme/ayu-colors , maki with Qwen 3.6 27B did the work

----

## Old Ayu dark

<img width="3840" height="1552" alt="Screenshot From 2026-07-06 14-11-19" src="https://github.com/user-attachments/assets/0937a03e-9e9a-44da-8737-f408c2327ce1" />

## New Ayu dark

<img width="3840" height="1552" alt="Screenshot From 2026-07-06 14-11-24" src="https://github.com/user-attachments/assets/8bb60439-69a2-4065-899c-4a21346c062f" />

## Ayu mirage

<img width="3840" height="1552" alt="Screenshot From 2026-07-06 14-11-50" src="https://github.com/user-attachments/assets/a998d09e-5b34-4f89-b7e8-0cb837bb97df" />

## Ayu light

<img width="3840" height="1552" alt="Screenshot From 2026-07-06 14-12-00" src="https://github.com/user-attachments/assets/4ff80e21-7422-4560-b03e-5c49128696ed" />
