### PR TITLE
print mode: attach image files as vision content 🤖🤖🤖

### DIFF
--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -21,7 +21,7 @@ use crate::template;
 use crate::tools::{DescriptionContext, FileReadTracker, ToolFilter, ToolRegistry};
 use crate::{
     Agent, AgentConfig, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, Envelope,
-    EventSender, McpHandle, PermissionsConfig, ToolOutput, ToolOutputLines,
+    EventSender, ImageSource, McpHandle, PermissionsConfig, ToolOutput, ToolOutputLines,
 };
 
 type StoredSession = Session<Message, TokenUsage, ToolOutput>;
@@ -72,6 +72,7 @@ pub struct HeadlessParams {
     pub permissions_config: PermissionsConfig,
     pub timeouts: Timeouts,
     pub prompt: String,
+    pub images: Vec<ImageSource>,
     pub prompt_slots: ResolvedSlots,
     pub excluded_tools: Vec<&'static str>,
     pub mcp_handle: Option<McpHandle>,
@@ -207,6 +208,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
                 .run(AgentInput {
                     message: params.prompt,
                     mode,
+                    images: params.images,
                     fast,
                     ..Default::default()
                 })

--- a/maki-ui/src/image.rs
+++ b/maki-ui/src/image.rs
@@ -18,6 +18,14 @@ const IMAGE_EXTENSIONS: &[(&str, ImageMediaType)] = &[
     ("webp", ImageMediaType::Webp),
 ];
 
+pub fn media_type_for(path: &Path) -> Option<ImageMediaType> {
+    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+    IMAGE_EXTENSIONS
+        .iter()
+        .find(|(e, _)| *e == ext)
+        .map(|&(_, mt)| mt)
+}
+
 pub(crate) fn try_parse_image_path(text: &str) -> Option<(PathBuf, ImageMediaType)> {
     let trimmed = text.trim().trim_matches('\'');
     let (path_str, was_file_uri) = match trimmed.strip_prefix("file://") {
@@ -37,18 +45,11 @@ pub(crate) fn try_parse_image_path(text: &str) -> Option<(PathBuf, ImageMediaTyp
     } else {
         PathBuf::from(&path_str)
     };
-    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
-    let media_type = IMAGE_EXTENSIONS
-        .iter()
-        .find(|(e, _)| *e == ext)
-        .map(|(_, mt)| *mt)?;
+    let media_type = media_type_for(&path)?;
     Some((path, media_type))
 }
 
-pub(crate) fn load_file_image(
-    path: &Path,
-    media_type: ImageMediaType,
-) -> Result<ImageSource, String> {
+pub fn load_file_image(path: &Path, media_type: ImageMediaType) -> Result<ImageSource, String> {
     let bytes = fs::read(path).map_err(|e| format!("{}: {e}", path.display()))?;
     if bytes.len() > MAX_IMAGE_BYTES {
         return Err("Image file exceeds 20MB limit".into());

--- a/maki-ui/src/lib.rs
+++ b/maki-ui/src/lib.rs
@@ -12,7 +12,7 @@ pub use components::command::{BUILTIN_COMMANDS, BuiltinCommand};
 pub use components::keybindings;
 mod highlight;
 pub use highlight::highlight_ansi;
-mod image;
+pub mod image;
 mod markdown;
 mod render_worker;
 mod selection;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand, ValueEnum};
 use color_eyre::Result;
 use color_eyre::eyre::bail;
@@ -30,6 +32,10 @@ pub struct Cli {
     /// Non-interactive mode. Runs the prompt and exits. Compatible with Claude Code's --print flag
     #[arg(short, long)]
     pub print: bool,
+
+    /// Attach an image to the prompt in --print mode as vision content (repeatable)
+    #[arg(long = "image", value_name = "PATH")]
+    pub images: Vec<PathBuf>,
 
     /// Model spec (provider/model-id). Defaults to last used model, or claude-opus-4-6
     #[arg(short, long)]

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -155,6 +155,7 @@ pub fn run(cli: Cli) -> Result<()> {
         crate::print::run(
             &model,
             cli.initial_prompt,
+            cli.images,
             cli.output_format,
             cli.verbose,
             config.agent,

--- a/src/print.rs
+++ b/src/print.rs
@@ -8,14 +8,15 @@
 //! Check their docs before changing anything here.
 
 use std::io::{self, Read};
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use clap::ValueEnum;
 use color_eyre::Result;
-use color_eyre::eyre::Context;
+use color_eyre::eyre::{Context, eyre};
 use maki_agent::headless::{HeadlessHandle, HeadlessParams};
 use maki_agent::tools::QUESTION_TOOL_NAME;
-use maki_agent::{AgentConfig, AgentEvent, Envelope, PermissionsConfig};
+use maki_agent::{AgentConfig, AgentEvent, Envelope, ImageSource, PermissionsConfig};
 use maki_lua::EventHandle;
 use maki_providers::model::Model;
 use maki_providers::{StopReason, TokenUsage};
@@ -23,6 +24,20 @@ use serde::Serialize;
 use serde_json::Value;
 
 const AGENT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+// Fails fast: silently dropping an image the caller explicitly attached
+// would be worse than erroring.
+fn load_images(paths: &[PathBuf]) -> Result<Vec<ImageSource>> {
+    paths
+        .iter()
+        .map(|path| {
+            let media_type = maki_ui::image::media_type_for(path)
+                .ok_or_else(|| eyre!("unsupported image type: {}", path.display()))?;
+            maki_ui::image::load_file_image(path, media_type)
+                .map_err(|e| eyre!("failed to load image: {e}"))
+        })
+        .collect()
+}
 
 #[derive(Clone, ValueEnum)]
 pub enum OutputFormat {
@@ -121,6 +136,7 @@ impl VerboseOutput {
 pub fn run(
     model: &Model,
     prompt_arg: Option<String>,
+    image_paths: Vec<PathBuf>,
     format: OutputFormat,
     verbose: bool,
     config: AgentConfig,
@@ -137,6 +153,8 @@ pub fn run(
             buf
         }
     };
+
+    let images = load_images(&image_paths)?;
 
     let prompt_slots = lua_handle
         .as_ref()
@@ -155,6 +173,7 @@ pub fn run(
         permissions_config,
         timeouts,
         prompt,
+        images,
         prompt_slots,
         excluded_tools: vec![QUESTION_TOOL_NAME],
         mcp_handle,

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -22,7 +22,7 @@ use maki_agent::{
     AgentConfig, AgentEvent, AgentInput, AgentMode, Envelope, PermissionsConfig, ToolOutput,
 };
 use maki_providers::model::Model;
-use maki_providers::{Message, StopReason, Timeouts, TokenUsage};
+use maki_providers::{ImageSource, Message, StopReason, Timeouts, TokenUsage};
 use maki_storage::StateDir;
 use maki_storage::sessions::Session;
 use serde::Serialize;
@@ -559,6 +559,7 @@ pub fn run(params: SdkParams) -> Result<()> {
                 };
                 let content = user.message.content;
                 let prompt = content_text(&content).unwrap_or_else(|| content.to_string());
+                let images = content_images(&content);
                 let mode = {
                     let mut shared = shared.lock().unwrap();
                     shared.turn_start = Instant::now();
@@ -567,6 +568,7 @@ pub fn run(params: SdkParams) -> Result<()> {
                 let input = AgentInput {
                     message: prompt,
                     mode: mode.agent_mode(&cwd),
+                    images,
                     fast,
                     ..Default::default()
                 };
@@ -671,6 +673,20 @@ fn content_text(content: &Value) -> Option<String> {
         ),
         _ => None,
     }
+}
+
+// Claude Code stream-json block shape:
+// {"type":"image","source":{"type":"base64","media_type":"image/png","data":"..."}}
+// `source` deserializes straight into ImageSource; malformed blocks are skipped.
+fn content_images(content: &Value) -> Vec<ImageSource> {
+    let Value::Array(blocks) = content else {
+        return Vec::new();
+    };
+    blocks
+        .iter()
+        .filter(|b| b.get("type").and_then(Value::as_str) == Some("image"))
+        .filter_map(|b| serde_json::from_value::<ImageSource>(b.get("source")?.clone()).ok())
+        .collect()
 }
 
 fn handle_control_request(
@@ -1205,6 +1221,24 @@ mod tests {
         ]);
         assert_eq!(content_text(&blocks), Some("a\nb".into()));
         assert_eq!(content_text(&serde_json::json!(42)), None);
+    }
+
+    #[test]
+    fn content_images_extracts_base64_blocks() {
+        let blocks = serde_json::json!([
+            {"type": "text", "text": "look at this"},
+            {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"}},
+            {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": "BBBB"}},
+        ]);
+        let images = content_images(&blocks);
+        assert_eq!(images.len(), 2);
+        assert_eq!(&*images[0].data, "AAAA");
+        assert_eq!(&*images[1].data, "BBBB");
+
+        // Non-array content and malformed image blocks yield no images.
+        assert!(content_images(&serde_json::json!("hi")).is_empty());
+        let bad = serde_json::json!([{"type": "image", "source": {"data": "x"}}]);
+        assert!(content_images(&bad).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What

Print mode (`-p`) and SDK mode can now attach image files as native vision content:

```sh
maki -p --image screenshot.png "why does this dialog overflow?"
maki -p --images before.png,after.png "what changed between these?"
```

- `--image` / `--images <PATHS>`: comma-separated or repeated. Files load by extension (png/jpg/jpeg/gif/webp) through the same loader the TUI paste path uses (now `pub`), so the 20MB limit and media-type mapping stay in one place.
- SDK mode (`--input-format stream-json`) now extracts Claude Code style base64 `image` content blocks from user messages into `AgentInput.images` instead of dropping them in `content_text`.
- A missing or unsupported file fails the run loudly rather than silently dropping an image the caller explicitly attached.

## Why

`AgentInput.images` has existed all along (the TUI paste path uses it), but headless callers had no way to reach it — image blocks sent over stream-json were silently discarded, and there was no CLI flag. We hit this wiring a web frontend that drives `maki -p` per turn and wanted screenshots to reach the model as real vision content, not prompt text.

Small and focused per the CONTRIBUTING note: no changes to the agent loop, tools, or providers; existing behavior is untouched when no images are given.

## Testing

- `content_images_extracts_base64_blocks` unit test (mirrors the existing `content_text` test).
- `just ci` locally: fmt, clippy `-D warnings`, gen-docs-check, tests — `maki` bin 47/47, `maki-ui` 1006/1006. Two `maki-agent` tests (`audience_matrix_is_locked`, `command_matches_its_own_generalized_rule::edit_path`) fail identically on clean master in my environment, unrelated to this change.
- Manual: `maki -p --image diag.png "what shape is this?"` → "A diagonal line." with zero tool calls (native vision); multi-image and stream-json block input verified the same way; missing file errors out.

## AI use

Implemented with an AI coding agent under human direction: the agent traced the TUI image path to find `AgentInput.images`, wrote the patch, and verified behavior by running the built binary against generated test images; I reviewed the diff and drove the design choices (flag shape, loud failure on bad paths, reusing the TUI loader).
