### PR TITLE
fix(read): clamp `table.concat` end index to actual line count

### DIFF
--- a/plugins/read/init.lua
+++ b/plugins/read/init.lua
@@ -164,7 +164,7 @@ local function read_file(path, offset, limit, ctx)
   local annotation = shown < total_lines and string.format("%d of %d lines", shown, total_lines)
     or string.format("%d lines", shown)
 
-  local prefix = start > 1 and table.concat(all_lines, "\n", 1, start - 1) or nil
+  local prefix = start > 1 and table.concat(all_lines, "\n", 1, math.min(start - 1, total_lines)) or nil
 
   local basename = path:match("([^/]+)$")
   if not ctx:is_instruction_file(basename) then


### PR DESCRIPTION
When `offset` exceeds the file length, the read plugin tried to `table.concat(all_lines, "\n", 1, start - 1)` where `start - 1` goes past `#all_lines`. Lua does not fill the gap with empty strings, so `table.concat` hits a nil at the first out-of-bounds index and crashes.

Wrap the end index in `math.min(start - 1, total_lines)` so the prefix never reads past the table.