### PR TITLE
plugins: code_execution: move script rendering to Lua via a `start` hook

### DIFF
--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -126,13 +126,15 @@ pub async fn run(
             summary: header_result.text(),
             render_header: header_result.snapshot(),
             annotation: invocation.start_annotation(),
-            input: invocation.start_input(),
+            input: None,
             raw_input: Some(input.clone()),
             output: invocation.start_output(ctx),
         };
         if matches!(emit, Emit::Notify) {
             let _ = ctx.event_tx.send(AgentEvent::ToolStart(Box::new(start)));
         }
+
+        invocation.start(ctx).await;
 
         if let Err(e) = enforce_permission(invocation.as_ref(), name, ctx, &id).await {
             return done_error(e);
@@ -631,6 +633,114 @@ mod tests {
                 done.output.as_text().starts_with(PERMISSION_DENIED_PREFIX),
                 "error should be the permission-denied message, got: {}",
                 done.output.as_text()
+            );
+        });
+    }
+
+    const START_PROBE_NAME: &str = "start_probe";
+
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use crate::tools::{
+        BoxFuture, DescriptionContext, ExecFuture, HeaderFuture, HeaderResult, ParseError,
+        PermissionScopes, Tool, ToolExecResult,
+    };
+
+    #[derive(Default)]
+    struct StartProbe {
+        started: Arc<AtomicBool>,
+        executed: Arc<AtomicBool>,
+    }
+
+    struct StartProbeInvocation {
+        started: Arc<AtomicBool>,
+        executed: Arc<AtomicBool>,
+    }
+
+    impl ToolInvocation for StartProbeInvocation {
+        fn start_header(&self) -> HeaderFuture {
+            HeaderFuture::Ready(HeaderResult::plain("probe".into()))
+        }
+        fn start<'a>(&'a self, _ctx: &'a ToolContext) -> BoxFuture<'a, ()> {
+            self.started.store(true, Ordering::SeqCst);
+            Box::pin(std::future::ready(()))
+        }
+        fn permission_scopes(&self) -> BoxFuture<'_, Option<PermissionScopes>> {
+            Box::pin(std::future::ready(Some(PermissionScopes::single(
+                "probe".into(),
+            ))))
+        }
+        fn execute<'a>(self: Box<Self>, _ctx: &'a ToolContext) -> ExecFuture<'a> {
+            self.executed.store(true, Ordering::SeqCst);
+            Box::pin(async {
+                ToolExecResult::from(Ok::<_, String>(ToolOutput::Plain("ok".into())))
+            })
+        }
+    }
+
+    impl Tool for StartProbe {
+        fn name(&self) -> &str {
+            START_PROBE_NAME
+        }
+        fn description(&self, _ctx: &DescriptionContext) -> std::borrow::Cow<'_, str> {
+            "start probe".into()
+        }
+        fn schema(&self) -> Value {
+            serde_json::json!({"type": "object", "properties": {}, "additionalProperties": false})
+        }
+        fn parse(&self, _input: &Value) -> Result<Box<dyn ToolInvocation>, ParseError> {
+            Ok(Box::new(StartProbeInvocation {
+                started: Arc::clone(&self.started),
+                executed: Arc::clone(&self.executed),
+            }))
+        }
+    }
+
+    /// A denied tool should still get its preview, but never its `execute`.
+    #[test]
+    fn start_runs_before_permission_denial_blocks_execute() {
+        smol::block_on(async {
+            let deny_cfg = PermissionsConfig {
+                rules: vec![PermissionRule {
+                    tool: START_PROBE_NAME.into(),
+                    scope: None,
+                    effect: Effect::Deny,
+                }],
+                ..Default::default()
+            };
+            let dir = TempDir::new().unwrap();
+            let permissions = Arc::new(PermissionManager::new(deny_cfg, dir.path().to_path_buf()));
+            let ctx = crate::tools::test_support::stub_ctx_with_permissions(
+                &AgentMode::Build,
+                permissions,
+            );
+
+            let probe = StartProbe::default();
+            let (started, executed) = (Arc::clone(&probe.started), Arc::clone(&probe.executed));
+            let registry = ToolRegistry::new();
+            registry
+                .register(Arc::new(probe), ToolSource::Native)
+                .unwrap();
+
+            let done = run(
+                &registry,
+                None,
+                "t1".into(),
+                START_PROBE_NAME,
+                &serde_json::json!({}),
+                &ctx,
+                Emit::Silent,
+            )
+            .await;
+
+            assert!(done.is_error, "denial must error");
+            assert!(
+                started.load(Ordering::SeqCst),
+                "start must run before permission enforcement"
+            );
+            assert!(
+                !executed.load(Ordering::SeqCst),
+                "execute must not run after denial"
             );
         });
     }

--- a/maki-agent/src/tools/batch.rs
+++ b/maki-agent/src/tools/batch.rs
@@ -119,15 +119,12 @@ impl BatchEntry {
         output: Option<ToolOutput>,
         summary: Option<String>,
     ) -> BatchToolEntry {
-        let call = registry
-            .get(&self.tool)
-            .and_then(|e| e.tool.parse(&self.parameters).ok());
         BatchToolEntry {
             tool: self.tool.clone(),
             summary: summary
                 .unwrap_or_else(|| registry.resolve_header(&self.tool, &self.parameters)),
             status,
-            input: call.and_then(|c| c.start_input()),
+            input: None,
             raw_input: Some(self.parameters.clone()),
             output,
             annotation: None,

--- a/maki-agent/src/tools/registry.rs
+++ b/maki-agent/src/tools/registry.rs
@@ -13,7 +13,7 @@ use bitflags::bitflags;
 use serde_json::{Value, json};
 
 use crate::template::Vars;
-use crate::{BufferSnapshot, ToolInput as ToolInputEvent, ToolOutput};
+use crate::{BufferSnapshot, ToolOutput};
 
 use super::{DescriptionContext, ToolContext};
 
@@ -197,9 +197,6 @@ pub trait ToolInvocation: Send + Sync {
     fn start_annotation(&self) -> Option<String> {
         None
     }
-    fn start_input(&self) -> Option<ToolInputEvent> {
-        None
-    }
     fn start_output(&self, _ctx: &ToolContext) -> Option<ToolOutput> {
         None
     }
@@ -208,6 +205,12 @@ pub trait ToolInvocation: Send + Sync {
     }
     fn permission_scopes(&self) -> BoxFuture<'_, Option<PermissionScopes>> {
         Box::pin(std::future::ready(None))
+    }
+    /// Runs after `ToolStart` but before permission enforcement, so a tool
+    /// can paint a preview while the prompt is still up. Some call paths skip
+    /// it, so `execute` must never rely on it having run.
+    fn start<'a>(&'a self, _ctx: &'a ToolContext) -> BoxFuture<'a, ()> {
+        Box::pin(std::future::ready(()))
     }
     fn execute<'a>(self: Box<Self>, ctx: &'a ToolContext) -> ExecFuture<'a>;
 }

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -108,8 +108,16 @@ pub enum TodoPriority {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum ToolInput {
-    Code { language: String, code: String },
-    Script { language: String, code: String },
+    Code {
+        language: String,
+        code: String,
+    },
+    /// Nothing produces this anymore (script rendering moved to Lua), but
+    /// old persisted sessions still contain it and must keep loading.
+    Script {
+        language: String,
+        code: String,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -630,6 +638,21 @@ impl BufferSnapshot {
             .map(|l| l.spans.iter().map(|s| s.text.as_str()).collect())
             .unwrap_or_default()
     }
+
+    /// Search matches against this, so it must mirror exactly what the UI
+    /// renders.
+    pub fn text(&self) -> String {
+        let mut out = String::new();
+        for (i, line) in self.lines.iter().enumerate() {
+            if i > 0 {
+                out.push('\n');
+            }
+            for span in &line.spans {
+                out.push_str(&span.text);
+            }
+        }
+        out
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -761,6 +784,44 @@ pub struct Envelope {
 mod tests {
     use super::*;
     use test_case::test_case;
+
+    #[test]
+    fn batch_entry_with_script_input_still_deserializes() {
+        let json = r#"{"tool":"code_execution","summary":"1 lines","status":"Success","input":{"Script":{"language":"python","code":"print('x')"}},"output":null}"#;
+        let entry: BatchToolEntry =
+            serde_json::from_str(json).expect("old persisted session JSON must load");
+        assert_eq!(
+            entry.input,
+            Some(ToolInput::Script {
+                language: "python".into(),
+                code: "print('x')".into(),
+            })
+        );
+    }
+
+    /// Search and the UI's error-dedup guard depend on this exact shape:
+    /// spans join bare, lines join with one newline, no trailing newline.
+    #[test]
+    fn buffer_snapshot_text_joins_spans_and_lines() {
+        let snap = BufferSnapshot::from_arc(Arc::new(vec![
+            SnapshotLine {
+                spans: vec![
+                    SnapshotSpan {
+                        text: "1 ".into(),
+                        style: SpanStyle::Named("line_nr".into()),
+                    },
+                    SnapshotSpan {
+                        text: "print('hi')".into(),
+                        style: SpanStyle::Default,
+                    },
+                ],
+            },
+            SnapshotLine { spans: vec![] },
+            SnapshotLine::plain("out".into()),
+        ]));
+        assert_eq!(snap.text(), "1 print('hi')\n\nout");
+        assert_eq!(BufferSnapshot::from_arc(Arc::new(vec![])).text(), "");
+    }
 
     #[test]
     fn as_display_text_diff_renders_unified_text() {

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -14,10 +14,7 @@ use maki_agent::tools::{
     PermissionScopes, ToolAudience, ToolContext, ToolExecResult, ToolFilter, ToolInvocation,
     is_tool_enabled, timeout_annotation,
 };
-use maki_agent::{
-    AgentEvent, BufferSnapshot, InstructionBlock, SharedBuf, TextOutput,
-    ToolInput as ToolInputEvent, ToolOutput,
-};
+use maki_agent::{AgentEvent, BufferSnapshot, InstructionBlock, SharedBuf, TextOutput, ToolOutput};
 use mlua::{
     Function, Lua, LuaSerdeExt, RegistryKey, Result as LuaResult, Table, Value as LuaValue,
 };
@@ -68,12 +65,6 @@ fn dctx_json(ctx: &DescriptionContext) -> Value {
 }
 
 #[derive(Clone)]
-pub(crate) struct StartInputConfig {
-    field: Arc<str>,
-    language: Arc<str>,
-}
-
-#[derive(Clone)]
 pub(crate) enum StartAnnotation {
     Count(Arc<str>),
     Timeout(Arc<str>),
@@ -94,12 +85,12 @@ pub(crate) struct PendingTool {
     pub(crate) handler_key: RegistryKey,
     pub(crate) header_key: Option<RegistryKey>,
     pub(crate) restore_key: Option<RegistryKey>,
+    pub(crate) start_key: Option<RegistryKey>,
     pub(crate) permission_scope_kind: Option<PermissionScopeKind>,
     pub(crate) permission_scopes_key: Option<RegistryKey>,
     pub(crate) mutable_path_field: Option<Arc<str>>,
     pub(crate) timeout: Option<Duration>,
     pub(crate) start_annotation: Option<StartAnnotation>,
-    pub(crate) start_input: Option<StartInputConfig>,
     pub(crate) examples: Option<Value>,
     pub(crate) describe_key: Option<RegistryKey>,
 }
@@ -115,11 +106,11 @@ pub(crate) struct LuaTool {
     pub(crate) tx: Sender<Request>,
     pub(crate) plugin: Arc<str>,
     pub(crate) has_header_fn: bool,
+    pub(crate) has_start_fn: bool,
     pub(crate) permission_scope_kind: Option<PermissionScopeKind>,
     pub(crate) mutable_path_field: Option<Arc<str>>,
     pub(crate) timeout: Option<Duration>,
     pub(crate) start_annotation: Option<StartAnnotation>,
-    pub(crate) start_input: Option<StartInputConfig>,
     pub(crate) examples: Option<Value>,
     pub(crate) has_describe_fn: bool,
 }
@@ -197,13 +188,13 @@ impl Tool for LuaTool {
             tool: Arc::clone(&self.name),
             plugin: Arc::clone(&self.plugin),
             has_header_fn: self.has_header_fn,
+            has_start_fn: self.has_start_fn,
             input: validated,
             tx: self.tx.clone(),
             permission_state,
             mutable_path_field: self.mutable_path_field.clone(),
             timeout: self.timeout,
             start_annotation: self.start_annotation.clone(),
-            start_input: self.start_input.clone(),
         }))
     }
 }
@@ -217,13 +208,13 @@ struct LuaToolInvocation {
     tool: Arc<str>,
     plugin: Arc<str>,
     has_header_fn: bool,
+    has_start_fn: bool,
     input: Value,
     tx: Sender<Request>,
     permission_state: PermissionState,
     mutable_path_field: Option<Arc<str>>,
     timeout: Option<Duration>,
     start_annotation: Option<StartAnnotation>,
-    start_input: Option<StartInputConfig>,
 }
 
 impl ToolInvocation for LuaToolInvocation {
@@ -279,12 +270,28 @@ impl ToolInvocation for LuaToolInvocation {
         }
     }
 
-    fn start_input(&self) -> Option<ToolInputEvent> {
-        let cfg = self.start_input.as_ref()?;
-        let code = self.input.get(cfg.field.as_ref())?.as_str()?.to_owned();
-        Some(ToolInputEvent::Script {
-            language: cfg.language.to_string(),
-            code,
+    fn start<'a>(&'a self, ctx: &'a ToolContext) -> BoxFuture<'a, ()> {
+        let id = ctx.tool_use_id.as_ref().filter(|_| self.has_start_fn);
+        let Some(id) = id else {
+            return Box::pin(std::future::ready(()));
+        };
+        let (reply_tx, reply_rx) = flume::bounded::<()>(1);
+        let req = Request::StartTool {
+            plugin: Arc::clone(&self.plugin),
+            tool: Arc::clone(&self.tool),
+            input: self.input.clone(),
+            live: LiveCtx {
+                event_tx: ctx.event_tx.clone(),
+                tool_use_id: id.clone(),
+            },
+            tool_output_lines: ctx.tool_output_lines,
+            reply: reply_tx,
+        };
+        let tx = self.tx.clone();
+        Box::pin(async move {
+            if tx.send_async(req).await.is_ok() {
+                let _ = reply_rx.recv_async().await;
+            }
         })
     }
 
@@ -765,25 +772,6 @@ fn parse_start_annotation(spec: &Table, schema: &Value) -> LuaResult<Option<Star
     }
 }
 
-fn parse_start_input(spec: &Table, schema: &Value) -> LuaResult<Option<StartInputConfig>> {
-    let Some(tbl) = spec_opt::<Table>(spec, "start_input", "a table")? else {
-        return Ok(None);
-    };
-
-    let field: String = tbl
-        .get("field")
-        .map_err(|_| mlua::Error::runtime("register_tool: start_input.field required"))?;
-    let language: String = tbl
-        .get("language")
-        .map_err(|_| mlua::Error::runtime("register_tool: start_input.language required"))?;
-    check_schema_field(schema, "start_input", &field, "string")?;
-
-    Ok(Some(StartInputConfig {
-        field: Arc::from(field.as_str()),
-        language: Arc::from(language.as_str()),
-    }))
-}
-
 fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> LuaResult<()> {
     let name: String = spec
         .get("name")
@@ -830,6 +818,7 @@ fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> Lua
 
     let header_fn: Option<Function> = spec.get("header").ok();
     let restore_fn: Option<Function> = spec.get("restore").ok();
+    let start_fn: Option<Function> = spec.get("start").ok();
     let kind: Option<Arc<str>> = spec
         .get::<String>("kind")
         .ok()
@@ -844,8 +833,8 @@ fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> Lua
     let restore_key = restore_fn
         .map(|f| lua.create_registry_value(f))
         .transpose()?;
+    let start_key = start_fn.map(|f| lua.create_registry_value(f)).transpose()?;
 
-    let start_input = parse_start_input(spec, &schema_val)?;
     let describe_fn: Option<Function> = spec.get("describe").ok();
     let describe_key = describe_fn
         .map(|f| lua.create_registry_value(f))
@@ -871,12 +860,12 @@ fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> Lua
             handler_key,
             header_key,
             restore_key,
+            start_key,
             permission_scope_kind,
             permission_scopes_key,
             mutable_path_field,
             timeout,
             start_annotation,
-            start_input,
             examples,
             describe_key,
         });
@@ -1121,7 +1110,7 @@ mod tests {
             mutable_path_field: None,
             timeout: Some(Duration::from_secs(60)),
             start_annotation: None,
-            start_input: None,
+            has_start_fn: false,
         }
     }
 
@@ -1173,7 +1162,7 @@ mod tests {
             mutable_path_field: None,
             timeout: Some(Duration::from_secs(60)),
             start_annotation: None,
-            start_input: None,
+            has_start_fn: false,
             examples: None,
             has_describe_fn: false,
         }
@@ -1270,7 +1259,7 @@ mod tests {
             mutable_path_field: None,
             timeout: None,
             start_annotation: None,
-            start_input: None,
+            has_start_fn: false,
         };
         let scopes = smol::block_on(inv.permission_scopes()).expect("should fallback");
         assert!(scopes.force_prompt);
@@ -1288,7 +1277,7 @@ mod tests {
             mutable_path_field: None,
             timeout: None,
             start_annotation: None,
-            start_input: None,
+            has_start_fn: false,
         };
         std::thread::spawn(move || {
             if let Ok(Request::ComputePermissionScopes { reply, .. }) = rx2.recv() {
@@ -1312,7 +1301,7 @@ mod tests {
             mutable_path_field: None,
             timeout: None,
             start_annotation: None,
-            start_input: None,
+            has_start_fn: false,
         };
         std::thread::spawn(move || {
             if let Ok(Request::ComputePermissionScopes { reply, .. }) = rx.recv() {
@@ -1352,7 +1341,7 @@ mod tests {
             mutable_path_field: None,
             timeout: Some(Duration::from_secs(60)),
             start_annotation: None,
-            start_input: None,
+            has_start_fn: false,
             examples: None,
             has_describe_fn: false,
         };
@@ -1551,32 +1540,12 @@ mod tests {
     }
 
     #[test]
-    fn start_input_returns_script_when_field_present() {
+    fn start_without_tool_use_id_is_noop() {
         let inv = LuaToolInvocation {
-            start_input: Some(StartInputConfig {
-                field: Arc::from("code"),
-                language: Arc::from("python"),
-            }),
-            ..invocation(serde_json::json!({"code": "print('hello')"}))
+            has_start_fn: true,
+            ..invocation(serde_json::json!({"code": "x"}))
         };
-        let result = inv.start_input().unwrap();
-        assert!(matches!(
-            result,
-            ToolInputEvent::Script { language, code }
-                if language == "python" && code == "print('hello')"
-        ));
-    }
-
-    #[test_case::test_case(serde_json::json!({"other": "value"}) ; "field_missing")]
-    #[test_case::test_case(serde_json::json!({"code": 42})       ; "field_not_string")]
-    fn start_input_returns_none_on_bad_input(input: Value) {
-        let inv = LuaToolInvocation {
-            start_input: Some(StartInputConfig {
-                field: Arc::from("code"),
-                language: Arc::from("python"),
-            }),
-            ..invocation(input)
-        };
-        assert_eq!(inv.start_input(), None);
+        let ctx = maki_agent::tools::test_support::stub_ctx(&maki_agent::AgentMode::Build);
+        smol::block_on(inv.start(&ctx));
     }
 }

--- a/maki-lua/src/api/util/ctx.rs
+++ b/maki-lua/src/api/util/ctx.rs
@@ -27,6 +27,35 @@ impl UserData for RestoreCtx {
     }
 }
 
+/// The `start` hook runs before permission checks, so its ctx only lets a
+/// tool publish a preview; dispatching tools from it is structurally
+/// impossible.
+pub(crate) struct StartCtx {
+    pub(crate) tool_output_lines: ToolOutputLines,
+}
+
+impl UserData for StartCtx {
+    fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method("live_buf", |lua, _this, buf: mlua::AnyUserData| {
+            send_live_buf(lua, &buf)
+        });
+        methods.add_method("tool_output_lines", |lua, this, ()| {
+            lua.to_value(&this.tool_output_lines)
+        });
+    }
+}
+
+fn send_live_buf(lua: &mlua::Lua, buf: &mlua::AnyUserData) -> mlua::Result<()> {
+    let shared = buf.borrow::<BufHandle>().map(|h| Arc::clone(&h.buf))?;
+    if let Some(live) = lock_cell(&active_task(lua)).live.clone() {
+        let _ = live.event_tx.send(maki_agent::AgentEvent::LiveToolBuf {
+            id: live.tool_use_id.clone(),
+            body: shared,
+        });
+    }
+    Ok(())
+}
+
 /// Captured snapshot of the parent `ToolContext`. Per-call state (deadline,
 /// instructions, output lines) is reset so child calls start clean.
 #[derive(Clone)]
@@ -80,15 +109,7 @@ impl UserData for LuaCtx {
         });
 
         methods.add_method("live_buf", |lua, _this, buf: mlua::AnyUserData| {
-            let shared = buf.borrow::<BufHandle>().map(|h| Arc::clone(&h.buf))?;
-            let live = lock_cell(&active_task(lua)).live.clone();
-            if let Some(live) = live {
-                let _ = live.event_tx.send(maki_agent::AgentEvent::LiveToolBuf {
-                    id: live.tool_use_id.clone(),
-                    body: shared,
-                });
-            }
-            Ok(())
+            send_live_buf(lua, &buf)
         });
 
         methods.add_method("config", |lua, this, ()| lua.to_value(&this.config));

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -140,6 +140,17 @@ pub enum Request {
         dctx: Value,
         reply: flume::Sender<Option<String>>,
     },
+    /// Runs the tool's `start` fn so it can publish a live buf before the
+    /// permission prompt paints. Best-effort: Lua errors are logged, never
+    /// propagated.
+    StartTool {
+        plugin: Arc<str>,
+        tool: Arc<str>,
+        input: Value,
+        live: LiveCtx,
+        tool_output_lines: maki_config::ToolOutputLines,
+        reply: flume::Sender<()>,
+    },
 }
 
 pub struct RestoreItem {
@@ -561,6 +572,7 @@ struct ToolKeys {
     handler: RegistryKey,
     header: Option<RegistryKey>,
     restore: Option<RegistryKey>,
+    start: Option<RegistryKey>,
     permission_scopes: Option<RegistryKey>,
     describe: Option<RegistryKey>,
 }
@@ -664,6 +676,11 @@ impl LuaRuntime {
                     && let Err(e) = self.lua.remove_registry_value(sk)
                 {
                     tracing::warn!(plugin = name, error = %e, "failed to drop lua permission_scopes key");
+                }
+                if let Some(sk) = tk.start
+                    && let Err(e) = self.lua.remove_registry_value(sk)
+                {
+                    tracing::warn!(plugin = name, error = %e, "failed to drop lua start key");
                 }
                 if let Some(sk) = tk.describe
                     && let Err(e) = self.lua.remove_registry_value(sk)
@@ -1011,11 +1028,11 @@ impl LuaRuntime {
                     tx: self.tx.clone(),
                     plugin: Arc::clone(&name),
                     has_header_fn: t.header_key.is_some(),
+                    has_start_fn: t.start_key.is_some(),
                     permission_scope_kind: t.permission_scope_kind.clone(),
                     mutable_path_field: t.mutable_path_field.clone(),
                     timeout: t.timeout,
                     start_annotation: t.start_annotation.clone(),
-                    start_input: t.start_input.clone(),
                     examples: t.examples.clone(),
                     has_describe_fn: t.describe_key.is_some(),
                 });
@@ -1047,6 +1064,7 @@ impl LuaRuntime {
                         handler: t.handler_key,
                         header: t.header_key,
                         restore: t.restore_key,
+                        start: t.start_key,
                         permission_scopes: t.permission_scopes_key,
                         describe: t.describe_key,
                     },
@@ -1463,6 +1481,28 @@ fn run_describe(
     }
 }
 
+/// Sends no `ToolSnapshot` on completion: the preview buf must stay live so
+/// the UI keeps polling it until the handler's own `LiveToolBuf` takes over.
+async fn run_tool_start(
+    lua: &Lua,
+    func: Function,
+    tool: &str,
+    input: Value,
+    live: LiveCtx,
+    tool_output_lines: maki_config::ToolOutputLines,
+) {
+    let scope = TaskScope::new(lua, TaskCell::new(CancelToken::none(), None, Some(live)));
+    let run = async {
+        let input_lua = json_to_lua(lua, &input)?;
+        let ctx_ud = lua.create_userdata(crate::api::util::ctx::StartCtx { tool_output_lines })?;
+        let thread = lua.create_thread(func)?;
+        thread.into_async::<LuaValue>((input_lua, ctx_ud))?.await
+    };
+    if let Err(e) = scope.scope_future(run).await {
+        tracing::warn!(tool, error = %e, "start callback failed");
+    }
+}
+
 /// Two layers of deadline enforcement: the interrupt hook catches
 /// tight CPU loops, the dispatch loop catches I/O waits.
 #[allow(clippy::too_many_arguments)]
@@ -1833,6 +1873,39 @@ pub fn spawn(
                         } => {
                             let _ = reply
                                 .send(run_describe(&rt.lua, &rt.plugins, &plugin, &tool, &dctx));
+                        }
+                        Request::StartTool {
+                            plugin,
+                            tool,
+                            input,
+                            live,
+                            tool_output_lines,
+                            reply,
+                        } => {
+                            let func = {
+                                let plugins = rt.plugins.borrow();
+                                plugins
+                                    .get(&*plugin)
+                                    .and_then(|p| p.get(&*tool))
+                                    .and_then(|tk| tk.start.as_ref())
+                                    .and_then(|key| rt.lua.registry_value::<Function>(key).ok())
+                            };
+                            let Some(func) = func else {
+                                let _ = reply.send(());
+                                continue;
+                            };
+                            gate.wait_below(MAX_INFLIGHT_TOOLS).await;
+                            let lua = rt.lua.clone();
+                            let g = Rc::clone(&gate);
+                            let ex_ref = Rc::clone(&ex);
+                            ex.spawn(async move {
+                                let _gate_guard = GateGuard::new(&g);
+                                run_tool_start(&lua, func, &tool, input, live, tool_output_lines)
+                                    .await;
+                                drain_spawn_queue(&lua, &ex_ref, &g);
+                                let _ = reply.send(());
+                            })
+                            .detach();
                         }
                         Request::RunKeybindCallback { id } => {
                             let func = rt.lua.app_data_ref::<KeymapStore>().and_then(|store| {

--- a/maki-lua/tests/code_execution_policy.rs
+++ b/maki-lua/tests/code_execution_policy.rs
@@ -201,3 +201,215 @@ fn workflow_tool_callable_when_workflow_true() {
     .expect("workflow tool must be callable when workflow=true");
     assert!(out.contains(&format!("{TASK_PREFIX}x")), "got: {out}");
 }
+
+// --- script rendering ---
+
+const SCRIPT_TOOL_ID: &str = "ce-script-1";
+const MAX_SCRIPT_LINES: usize = 2000;
+const EXPAND_NOTICE: &str = "click to expand";
+const DIVIDER_LINE: &str = "──────";
+
+fn event_ctx(reg: &Arc<ToolRegistry>) -> (ToolContext, flume::Receiver<maki_agent::Envelope>) {
+    let (tx, rx) = flume::unbounded::<maki_agent::Envelope>();
+    let event_tx = maki_agent::EventSender::new(tx, 0);
+    let mut ctx = maki_agent::tools::test_support::stub_ctx_with(
+        &AgentMode::Build,
+        Some(&event_tx),
+        Some(SCRIPT_TOOL_ID),
+    );
+    ctx.registry = Arc::clone(reg);
+    (ctx, rx)
+}
+
+fn parse_code(reg: &ToolRegistry, code: &str) -> Box<dyn maki_agent::tools::ToolInvocation> {
+    reg.get("code_execution")
+        .expect("code_execution registered")
+        .tool
+        .parse(&serde_json::json!({ "code": code, "timeout": 10 }))
+        .expect("parse failed")
+}
+
+fn start_preview_text(code: &str) -> String {
+    let (reg, _host) = setup();
+    let inv = parse_code(&reg, code);
+    let (ctx, rx) = event_ctx(&reg);
+    smol::block_on(inv.start(&ctx));
+    let body = rx
+        .drain()
+        .find_map(|env| match env.event {
+            maki_agent::AgentEvent::LiveToolBuf { id, body } if id == SCRIPT_TOOL_ID => Some(body),
+            _ => None,
+        })
+        .expect("start must publish a preview buf");
+    body.take().text()
+}
+
+#[test]
+fn start_preview_contains_numbered_script_lines() {
+    let text = start_preview_text("print('a')\nprint('b')");
+    assert!(text.contains("1 print('a')"), "got: {text}");
+    assert!(text.contains("2 print('b')"), "got: {text}");
+}
+
+#[test_case::test_case(MAX_SCRIPT_LINES, false ; "at_cap_shows_all_lines_without_notice")]
+#[test_case::test_case(MAX_SCRIPT_LINES + 1, true ; "over_cap_hides_excess_with_notice")]
+fn start_preview_caps_script_at_max_lines(total: usize, truncated: bool) {
+    let code: String = (1..=total)
+        .map(|i| format!("print({i})"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let text = start_preview_text(&code);
+    assert!(
+        text.contains(&format!("print({MAX_SCRIPT_LINES})")),
+        "line at the cap must be visible"
+    );
+    assert!(
+        !text.contains(&format!("print({})", MAX_SCRIPT_LINES + 1)),
+        "line beyond the cap must be hidden"
+    );
+    assert_eq!(
+        text.contains(EXPAND_NOTICE),
+        truncated,
+        "expand notice must appear iff truncated, tail: {}",
+        &text[text.len().saturating_sub(200)..]
+    );
+}
+
+/// The async highlight task may snapshot mid-run, but the reply's
+/// `LiveToolBuf` and final `ToolSnapshot` always come after it, so the last
+/// body event holds the final content whatever the highlight timing.
+fn final_body_text(rx: &flume::Receiver<maki_agent::Envelope>) -> String {
+    rx.drain()
+        .filter_map(|env| match env.event {
+            maki_agent::AgentEvent::ToolSnapshot { id, snapshot, .. } if id == SCRIPT_TOOL_ID => {
+                Some(snapshot.text())
+            }
+            maki_agent::AgentEvent::LiveToolBuf { id, body } if id == SCRIPT_TOOL_ID => {
+                Some(body.take().text())
+            }
+            _ => None,
+        })
+        .last()
+        .expect("handler must publish a body")
+}
+
+/// Some call paths skip `start`, so `handler` must render the script itself.
+#[test]
+fn handler_renders_script_when_start_never_ran() {
+    let (reg, _host) = setup_native();
+    let inv = parse_code(&reg, "print('hi')");
+    let (ctx, rx) = event_ctx(&reg);
+    smol::block_on(inv.execute(&ctx))
+        .output
+        .expect("execute ok");
+    let text = final_body_text(&rx);
+    assert!(text.contains("1 print('hi')"), "script section: {text}");
+    assert!(text.contains("\nhi"), "interpreter output below: {text}");
+}
+
+/// A regression here shows phantom numbered lines, or crashes `start`, which
+/// silently swallows the preview since start errors are only logged.
+#[test_case::test_case("print('a')\n\n\n" ; "trailing_newlines")]
+#[test_case::test_case("" ; "empty_code")]
+fn start_preview_renders_single_line(code: &str) {
+    let text = start_preview_text(code);
+    assert_eq!(
+        text.trim_end().lines().count(),
+        2,
+        "one script line + divider, no phantom lines: {text:?}"
+    );
+    assert_eq!(text.trim_end().lines().last(), Some(DIVIDER_LINE));
+}
+
+#[test]
+fn handler_error_keeps_script_and_drops_waiting_notice() {
+    let (reg, _host) = setup_native();
+    let inv = parse_code(&reg, "print(boom_undefined)");
+    let (ctx, rx) = event_ctx(&reg);
+    let err = smol::block_on(inv.execute(&ctx))
+        .output
+        .expect_err("undefined name must error");
+    let text = final_body_text(&rx);
+
+    assert!(
+        text.contains("1 print(boom_undefined)"),
+        "script header must survive the error path: {text}"
+    );
+    assert!(
+        text.contains(err.trim_end()),
+        "error must render below the script, err: {err:?}, body: {text}"
+    );
+    assert!(
+        !text.contains("Waiting for output"),
+        "placeholder must be cleared on error: {text}"
+    );
+}
+
+fn restore_lines_with(code: &str, output: &str, is_error: bool, expanded: bool) -> Vec<String> {
+    let (_reg, host) = setup();
+    let eh = host.event_handle().expect("event handle");
+    let (tx, rx) = flume::unbounded::<maki_agent::Envelope>();
+    eh.request_restore(
+        maki_lua::RestoreItem {
+            tool: Arc::from("code_execution"),
+            tool_use_id: SCRIPT_TOOL_ID.into(),
+            output: output.into(),
+            input: serde_json::json!({ "code": code }),
+            is_error,
+            tool_output_lines: maki_config::ToolOutputLines::default(),
+            theme_gen: None,
+            expanded,
+        },
+        maki_agent::EventSender::new(tx, 0),
+    );
+    let snapshot = loop {
+        let env = rx
+            .recv_timeout(std::time::Duration::from_secs(60))
+            .expect("restore must emit a snapshot");
+        if let maki_agent::AgentEvent::ToolSnapshot { id, snapshot, .. } = env.event
+            && id == SCRIPT_TOOL_ID
+        {
+            break snapshot;
+        }
+    };
+    snapshot.text().lines().map(str::to_owned).collect()
+}
+
+fn restore_lines(output: &str, is_error: bool) -> Vec<String> {
+    restore_lines_with("print('x')", output, is_error, false)
+}
+
+#[test_case::test_case("out1\nout2", false, &["out1", "out2"] ; "output_lines_below_divider")]
+#[test_case::test_case("boom", true, &["boom"] ; "error_output_below_divider")]
+#[test_case::test_case("(no output)", false, &["No output"] ; "no_output_marker_renders_label")]
+fn restore_body_is_script_divider_output(output: &str, is_error: bool, tail: &[&str]) {
+    let mut expected = vec!["1 print('x')".to_owned(), DIVIDER_LINE.to_owned()];
+    expected.extend(tail.iter().map(|s| (*s).to_owned()));
+    assert_eq!(restore_lines(output, is_error), expected);
+}
+
+/// Restoring a session saved with the script expanded replays the buf's
+/// click handler, so the header must rebuild past `MAX_SCRIPT_LINES`.
+#[test]
+fn restore_expanded_shows_full_script_beyond_cap() {
+    let over = MAX_SCRIPT_LINES + 1;
+    let code: String = (1..=over)
+        .map(|i| format!("print({i})"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let lines = restore_lines_with(&code, "out1", false, true);
+    let text = lines.join("\n");
+    assert!(
+        text.contains(&format!("print({over})")),
+        "expanded restore must show lines beyond the cap"
+    );
+    assert!(
+        !text.contains(EXPAND_NOTICE),
+        "no truncation notice when expanded"
+    );
+    assert_eq!(
+        lines.last().map(String::as_str),
+        Some("out1"),
+        "output must stay below the expanded script"
+    );
+}

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use maki_agent::ToolInput as ToolInputEvent;
 use maki_agent::tools::{ToolRegistry, ToolSource, timeout_annotation};
 use maki_config::{AlwaysThinking, PluginsConfig, ToolOutputLines};
 use maki_lua::{PluginError, PluginHost};
@@ -102,8 +101,6 @@ const ARRAY_SCHEMA: &str = r#"{
     required = { "edits" },
 }"#;
 
-const START_INPUT_MISSING_FIELD_SRC: &str = r#"name = "si_bad", description = "test", start_input = { field = "code", language = "python" }"#;
-const START_INPUT_WRONG_TYPE_SRC: &str = r#"name = "si_bad2", description = "test", start_input = { field = "count", language = "python" }"#;
 const START_ANNOTATION_COUNT_NON_ARRAY_SRC: &str =
     r#"name = "sa_bad", description = "test", start_annotation = "name""#;
 const STRING_NAME_SCHEMA: &str = r#"{
@@ -1597,30 +1594,132 @@ fn runaway_allocation_hits_memory_limit_instead_of_oom() {
 }
 
 #[test]
-fn start_input_happy_path() {
+fn start_hook_publishes_live_buf_for_tool_use_id() {
+    let (reg, _host) = start_hook_fixture();
+    let rx = run_start(&reg, "st_tool", serde_json::json!({"code": "line1\nline2"}));
+    let body = recv_live_buf(&rx, START_TOOL_USE_ID).expect("start must publish a LiveToolBuf");
+    let text = body.take().text();
+    assert!(text.contains("line1"), "preview must render input: {text}");
+}
+
+#[test]
+fn start_hook_error_does_not_fail_tool() {
+    let (reg, _host) = start_hook_fixture();
+    let _rx = run_start(&reg, "st_boom", serde_json::json!({"code": "x"}));
+    let out = exec_tool(&reg, "st_boom", serde_json::json!({"code": "x"})).expect("handler ok");
+    assert_eq!(out, "handled");
+}
+
+#[test]
+fn start_skipped_for_tool_without_start_fn() {
+    let (reg, _host) = start_hook_fixture();
+    let rx = run_start(&reg, "st_plain", serde_json::json!({"code": "x"}));
+    assert!(
+        recv_live_buf(&rx, START_TOOL_USE_ID).is_none(),
+        "no start fn must mean no preview"
+    );
+}
+
+/// `start` runs before permission checks, so its ctx is not a `LuaCtx` and
+/// `maki.agent.call_tool` (which borrows `LuaCtx`) rejects it outright.
+#[test]
+fn start_ctx_cannot_dispatch_tools() {
+    let (reg, _host) = start_hook_fixture();
+    let rx = run_start(&reg, "st_probe", serde_json::json!({"code": "x"}));
+    let body = recv_live_buf(&rx, START_TOOL_USE_ID).expect("probe publishes a buf");
+    let text = body.take().text();
+    assert_eq!(
+        text, "call_tool_rejected finish_missing set_deadline_missing",
+        "StartCtx must expose no dispatch/finish/deadline capability"
+    );
+}
+
+const START_TOOL_USE_ID: &str = "start-tu-1";
+
+fn start_hook_fixture() -> (Arc<ToolRegistry>, PluginHost) {
+    let src = format!(
+        r#"
+local function preview(input, ctx)
+    local buf = maki.ui.buf()
+    buf:set_lines({{ input.code }})
+    ctx:live_buf(buf)
+end
+maki.api.register_tool({{
+    name = "st_tool",
+    description = "test",
+    schema = {CODE_SCHEMA},
+    start = preview,
+    handler = function(input, ctx) return "handled" end,
+}})
+maki.api.register_tool({{
+    name = "st_boom",
+    description = "test",
+    schema = {CODE_SCHEMA},
+    start = function(input, ctx) error("boom") end,
+    handler = function(input, ctx) return "handled" end,
+}})
+maki.api.register_tool({{
+    name = "st_plain",
+    description = "test",
+    schema = {CODE_SCHEMA},
+    handler = function(input, ctx) return "handled" end,
+}})
+maki.api.register_tool({{
+    name = "st_probe",
+    description = "test",
+    schema = {CODE_SCHEMA},
+    start = function(input, ctx)
+        local parts = {{}}
+        local ok = pcall(function() return maki.agent.call_tool(ctx, "st_plain", {{ code = "x" }}) end)
+        parts[1] = ok and "call_tool_allowed" or "call_tool_rejected"
+        parts[2] = ctx.finish == nil and "finish_missing" or "finish_present"
+        parts[3] = ctx.set_deadline == nil and "set_deadline_missing" or "set_deadline_present"
+        local buf = maki.ui.buf()
+        buf:set_lines({{ table.concat(parts, " ") }})
+        ctx:live_buf(buf)
+    end,
+    handler = function(input, ctx) return "handled" end,
+}})
+"#
+    );
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    let src = format!(
-        r#"maki.api.register_tool({{
-            name = "si_ok",
-            description = "test",
-            schema = {CODE_SCHEMA},
-            start_input = {{ field = "code", language = "python" }},
-            handler = function(input, ctx) return "" end
-        }})"#,
+    host.load_source("start_hooks", &src).unwrap();
+    (reg, host)
+}
+
+/// `start` is awaited to completion, so the returned receiver already holds
+/// everything the hook emitted.
+fn run_start(
+    reg: &ToolRegistry,
+    name: &str,
+    input: serde_json::Value,
+) -> flume::Receiver<maki_agent::Envelope> {
+    let (tx, rx) = flume::unbounded::<maki_agent::Envelope>();
+    let event_tx = maki_agent::EventSender::new(tx, 0);
+    let ctx = maki_agent::tools::test_support::stub_ctx_with(
+        &maki_agent::AgentMode::Build,
+        Some(&event_tx),
+        Some(START_TOOL_USE_ID),
     );
-    host.load_source("si_ok_plugin", &src).unwrap();
-    let entry = reg.get("si_ok").expect("tool not registered");
-    let inv = entry
+    let inv = reg
+        .get(name)
+        .unwrap_or_else(|| panic!("tool {name} not registered"))
         .tool
-        .parse(&serde_json::json!({"code": "print('hi')"}))
+        .parse(&input)
         .expect("parse failed");
-    let result = inv.start_input().expect("expected Some");
-    assert!(matches!(
-        result,
-        ToolInputEvent::Script { language, code }
-            if language == "python" && code == "print('hi')"
-    ));
+    smol::block_on(inv.start(&ctx));
+    rx
+}
+
+fn recv_live_buf(
+    rx: &flume::Receiver<maki_agent::Envelope>,
+    id: &str,
+) -> Option<Arc<maki_agent::SharedBuf>> {
+    rx.drain().find_map(|env| match env.event {
+        maki_agent::AgentEvent::LiveToolBuf { id: got, body } if got == id => Some(body),
+        _ => None,
+    })
 }
 
 #[test]
@@ -1667,8 +1766,6 @@ fn start_annotation_count_happy_path() {
     assert_eq!(inv.start_annotation(), Some("3 edits".to_owned()));
 }
 
-#[test_case::test_case(START_INPUT_MISSING_FIELD_SRC, MINIMAL_SCHEMA, "not in schema properties or not type 'string'" ; "start_input_validation_missing_field")]
-#[test_case::test_case(START_INPUT_WRONG_TYPE_SRC, NON_STRING_FIELD_SCHEMA, "not in schema properties or not type 'string'" ; "start_input_validation_wrong_type")]
 #[test_case::test_case(START_ANNOTATION_COUNT_NON_ARRAY_SRC, STRING_NAME_SCHEMA, "not in schema properties or not type 'array'" ; "start_annotation_count_non_array")]
 fn registration_with_schema_rejects(fields: &str, schema: &str, expected_err: &str) {
     let reg = fresh_registry();

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -386,7 +386,6 @@ pub fn history_to_display(
                             let tool_call: Option<Box<dyn ToolInvocation>> =
                                 reg.get(name).and_then(|entry| entry.try_parse(input));
                             let summary = reg.resolve_header(name, input);
-                            let tool_input = tool_call.as_deref().and_then(|tc| tc.start_input());
                             let (status, result_text) = results
                                 .get(id.as_str())
                                 .map(|(err, text)| {
@@ -435,7 +434,7 @@ pub fn history_to_display(
                                     name: static_name.into(),
                                 })),
                                 text,
-                                tool_input: tool_input.map(Arc::new),
+                                tool_input: None,
                                 tool_raw_input: Some(Arc::new(input.clone())),
                                 tool_output,
                                 live_output: None,

--- a/maki-ui/src/components/code_view.rs
+++ b/maki-ui/src/components/code_view.rs
@@ -9,7 +9,6 @@ use ratatui::text::{Line, Span};
 use syntect::parsing::SyntaxReference;
 use syntect::util::LinesWithEndings;
 
-pub(crate) const MAX_CODE_EXECUTION_LINES: usize = 2000;
 pub(crate) const MAX_INSTRUCTION_LINES: usize = 15;
 
 pub(crate) fn instruction_limit(expanded: bool) -> usize {
@@ -424,7 +423,7 @@ impl RenderLimits {
             script: if expanded.script {
                 usize::MAX
             } else {
-                MAX_CODE_EXECUTION_LINES
+                output_limit
             },
             output: if expanded.output {
                 usize::MAX

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -1229,6 +1229,28 @@ fn tool_done_removes_live_buf_and_snapshots_dirty() {
     );
 }
 
+/// The handler's buf must supersede the `start` preview: the UI keeps only
+/// the last registered buf per tool_use_id.
+#[test]
+fn second_register_live_buf_replaces_first() {
+    let preview = Arc::new(maki_agent::SharedBuf::new());
+    preview.set_lines(vec![snap_line("preview")]);
+    let handler = Arc::new(maki_agent::SharedBuf::new());
+    handler.set_lines(vec![snap_line("handler")]);
+
+    let mut panel = MessagesPanel::new(UiConfig::default());
+    panel.tool_start(start("t1", BASH_TOOL_NAME));
+    panel.register_live_buf("t1".into(), Arc::clone(&preview));
+    panel.register_live_buf("t1".into(), Arc::clone(&handler));
+    panel.poll_live_bufs();
+
+    let msg = panel.find_tool_msg_mut("t1").unwrap();
+    assert_eq!(
+        msg.render_snapshot.as_ref().unwrap().first_line_text(),
+        "handler"
+    );
+}
+
 #[test]
 fn live_buf_streams_across_clean_polls() {
     let buf = Arc::new(maki_agent::SharedBuf::new());

--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -642,6 +642,7 @@ impl ToolLineBuilder {
             TOOL_BODY_INDENT,
             0..total,
         ));
+        self.push_search_text(&snapshot.text());
         if let Some(text) = search_fallback {
             self.push_search_text(text);
         }
@@ -795,6 +796,24 @@ pub fn build_tool_lines(
             })
             .or(body);
         b.push_snapshot(snapshot, search_text);
+        // With pre-permission previews, an error (say a denial) can land
+        // while only the script snapshot is on screen. Show the error below
+        // it, unless the handler already drew it into the body.
+        if matches!(status, ToolStatus::Error) {
+            let err_text = msg.tool_output.as_deref().map(|o| o.as_text());
+            let shown = err_text.as_deref().or(body).map_or("", str::trim);
+            if !shown.is_empty() && !snapshot.text().contains(shown) {
+                let resolved = resolve_output(
+                    msg.tool_output.as_deref(),
+                    body,
+                    msg.live_output.as_deref(),
+                    msg.truncated_lines,
+                    b.limits,
+                    b.keep,
+                );
+                b.push_resolved_output(&resolved);
+            }
+        }
     } else {
         let resolved = resolve_output(
             msg.tool_output.as_deref(),
@@ -1492,6 +1511,74 @@ mod tests {
             },
         };
         state.snapshot_is_stale(CURRENT_GEN)
+    }
+
+    #[test]
+    fn snapshot_search_text_derives_from_rendered_lines() {
+        let snapshot = make_snapshot(vec![vec![SnapshotSpan {
+            text: "import asyncio".into(),
+            style: SpanStyle::Named("keyword".into()),
+        }]]);
+        let tl = build_tool_lines(
+            &snapshot_msg(snapshot),
+            ToolStatus::Success,
+            &test_rctx(80, &reg()),
+            SectionFlags::default(),
+        );
+        assert!(
+            tl.search_text.contains("import asyncio"),
+            "search must index the rendered snapshot body, got: {}",
+            tl.search_text
+        );
+    }
+
+    const DENIAL_MSG: &str = "Permission denied: user rejected";
+
+    fn error_snapshot_msg(snapshot_text: &str) -> DisplayMessage {
+        DisplayMessage {
+            role: DisplayRole::Tool(Box::new(ToolRole {
+                id: "t1".into(),
+                status: ToolStatus::Error,
+                name: "code_execution".into(),
+            })),
+            text: "2 lines".into(),
+            tool_output: Some(Arc::new(ToolOutput::Plain(DENIAL_MSG.into()))),
+            ..snapshot_msg(make_snapshot(vec![vec![SnapshotSpan {
+                text: snapshot_text.into(),
+                style: SpanStyle::Default,
+            }]]))
+        }
+    }
+
+    #[test]
+    fn error_with_snapshot_renders_error_below() {
+        let msg = error_snapshot_msg("1 print('hi')");
+        let tl = build_tool_lines(
+            &msg,
+            ToolStatus::Error,
+            &test_rctx(80, &reg()),
+            SectionFlags::default(),
+        );
+        let text = lines_text(&tl);
+        assert!(text.contains("print('hi')"), "snapshot stays: {text}");
+        assert!(text.contains(DENIAL_MSG), "denial must show: {text}");
+    }
+
+    #[test]
+    fn error_already_in_snapshot_is_not_duplicated() {
+        let msg = error_snapshot_msg(DENIAL_MSG);
+        let tl = build_tool_lines(
+            &msg,
+            ToolStatus::Error,
+            &test_rctx(80, &reg()),
+            SectionFlags::default(),
+        );
+        let text = lines_text(&tl);
+        assert_eq!(
+            text.matches(DENIAL_MSG).count(),
+            1,
+            "error must render exactly once: {text}"
+        );
     }
 
     #[test]

--- a/plugins/code_execution/init.lua
+++ b/plugins/code_execution/init.lua
@@ -8,7 +8,9 @@ local DEFAULT_TIMEOUT = 30
 local DEFAULT_MAX_MEMORY_MB = 50
 local DEFAULT_MAX_OUTPUT_LINES = 2000
 local DEFAULT_MAX_OUTPUT_BYTES = 50 * 1024
+local MAX_SCRIPT_LINES = 2000
 local NO_OUTPUT = "(no output)"
+local SEPARATOR = "──────"
 local PREAMBLE = "import re\nimport asyncio\nimport sys\nimport os\nimport json\n"
 local TOOLS_HEADER = "\n\nAvailable tools (called as Python functions with keyword arguments):\n"
 local WORKFLOW_TOOLS_NOTE =
@@ -23,6 +25,58 @@ local function append_lines(view, text)
   for line in (text .. "\n"):gmatch("([^\n]*)\n") do
     view:append(line)
   end
+end
+
+local function line_nr_fmt(count)
+  local w = math.max(1, math.floor(math.log(count, 10)) + 1)
+  return "%" .. w .. "d "
+end
+
+-- One body builder for every path (start preview, handler, restore), so the
+-- script renders the same no matter which lifecycle callbacks ran. The
+-- header is always rebuilt from scratch; nothing mutates existing lines.
+local function build_body(ctx, code)
+  local lines = {}
+  for line in (code:gsub("\n+$", "") .. "\n"):gmatch("([^\n]*)\n") do
+    lines[#lines + 1] = line
+  end
+  local hl
+  local buf = maki.ui.buf()
+  local view = new_view(ctx, buf)
+
+  local function header()
+    local total = #lines
+    local shown = view.expanded and total or math.min(total, MAX_SCRIPT_LINES)
+    local fmt = line_nr_fmt(shown)
+    local out = {}
+    for i = 1, shown do
+      local spans = { { string.format(fmt, i), "line_nr" } }
+      for _, seg in ipairs(hl and hl[i] or { { lines[i] } }) do
+        spans[#spans + 1] = seg
+      end
+      out[#out + 1] = spans
+    end
+    if shown < total then
+      out[#out + 1] = { { "... (" .. (total - shown) .. " lines) (click to expand)", "dim" } }
+    end
+    out[#out + 1] = { { SEPARATOR, "dim" } }
+    return out
+  end
+
+  view:set_header(header())
+  buf:on("click", function()
+    view:toggle()
+    view:set_header(header())
+  end)
+
+  local function highlight()
+    local highlighted = maki.ui.highlight(table.concat(lines, "\n"), "py")
+    if highlighted then
+      hl = highlighted
+      view:set_header(header())
+    end
+  end
+  return buf, view, highlight
 end
 
 local description = [[Execute Python code in a sandboxed interpreter with tools as callable functions.
@@ -151,16 +205,22 @@ local function describe(dctx)
   return table.concat(parts)
 end
 
+-- Publishes the script before the permission prompt paints. Highlight is
+-- awaited inline: an async task from here could outlive ToolDone on fast
+-- auto-allowed runs and bake a stale script-only snapshot.
+local function start(input, ctx)
+  local buf, _, highlight = build_body(ctx, input.code)
+  ctx:live_buf(buf)
+  highlight()
+end
+
 local function handler(input, ctx)
   local config = ctx:config()
   local timeout = input.timeout or config.code_execution_timeout_secs or DEFAULT_TIMEOUT
 
-  local buf = maki.ui.buf()
-  local view = new_view(ctx, buf)
-  buf:on("click", function()
-    view:toggle()
-  end)
+  local buf, view, highlight = build_body(ctx, input.code)
   ctx:live_buf(buf)
+  maki.async.run(highlight)
 
   ctx:set_deadline(timeout)
 
@@ -225,9 +285,8 @@ local function header(input)
   return lines .. " lines"
 end
 
-local function restore(_input, output, is_error, ctx)
-  local buf = maki.ui.buf()
-  local view = new_view(ctx, buf)
+local function restore(input, output, is_error, ctx)
+  local buf, view, highlight = build_body(ctx, input.code)
   if is_error then
     view:append(output)
   elseif output == NO_OUTPUT then
@@ -236,9 +295,7 @@ local function restore(_input, output, is_error, ctx)
     append_lines(view, output)
   end
   view:finish()
-  buf:on("click", function()
-    view:toggle()
-  end)
+  highlight()
   return buf
 end
 
@@ -250,8 +307,8 @@ maki.api.register_tool({
   examples = examples,
   kind = "execute",
   audiences = { "main", "research_sub", "general_sub" },
-  start_input = { field = "code", language = "python" },
   start_annotation = { field = "timeout", kind = "timeout" },
+  start = start,
   handler = handler,
   header = header,
   restore = restore,


### PR DESCRIPTION
The script preview was the last piece of tool rendering that lived in Rust: `start_input = { field = "code" }` emitted a `ToolInput::Script` event and `code_view.rs` capped it at a hardcoded 2000 lines.  A new `start` hook on `register_tool` runs at dispatch time, after `ToolStart` but before permission enforcement, so the plugin can publish the script body through `ctx:live_buf` while the permission prompt is still up.  Its `StartCtx` exposes only `live_buf`, `tool_output_lines` and `config`, which makes dispatching tools before approval structurally impossible instead of a convention.

The plugin now builds every body (preview, handler, restore) with one shared `build_body`, so the rendering is a pure function of input and output no matter which lifecycle callbacks ran.  The handler's later `LiveToolBuf` simply replaces the preview because the UI keeps the last registered buf per tool_use_id, now pinned by a test.  One catch: `start` awaits `maki.ui.highlight` inline rather than `maki.async.run`, since an async task from the start scope would bake a stale script-only snapshot after `ToolDone` on fast auto-allowed runs.

The `start_input` machinery is deleted end to end and `MAX_SCRIPT_LINES = 2000` lives only in init.lua.  Two generic UI fixes fell out: a denied tool keeps its preview snapshot so the error text now renders below it (with a guard against duplicating errors the handler already drew), and segment search text derives from the rendered snapshot lines, so every Lua tool body becomes searchable.