### PR TITLE
feat(ui): Ctrl+R to reload quota in `/usage` modal

### DIFF
--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -504,6 +504,9 @@ impl App {
         }
 
         if self.usage_modal.is_open() {
+            if key::REFRESH.matches(key) {
+                return Some(vec![Action::RefreshUsage]);
+            }
             self.usage_modal.handle_key(key);
             return Some(vec![]);
         }

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -1547,6 +1547,20 @@ fn usage_command_toggles_modal() {
 }
 
 #[test]
+fn ctrl_r_refreshes_usage_while_modal_open() {
+    let mut app = test_app();
+    app.execute_command(cmd("/usage"));
+    assert!(app.usage_modal.is_open());
+
+    let actions = app.update(Msg::Key(kb::REFRESH.to_key_event()));
+    assert!(
+        actions.iter().any(|a| matches!(a, Action::RefreshUsage)),
+        "Ctrl+R should emit RefreshUsage"
+    );
+    assert!(app.usage_modal.is_open(), "modal should stay open");
+}
+
+#[test]
 fn cd_command_behavior() {
     let mut app = test_app();
     app.execute_command(ParsedCommand {

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -144,6 +144,7 @@ pub mod key {
     pub const OPEN_EDITOR: Bind = ctrl_bind!('o');
     pub const PLAN_TOGGLE: Bind = ctrl_bind!('t');
     pub const TASKS: Bind = ctrl_bind!('x');
+    pub const REFRESH: Bind = ctrl_bind!('r');
     pub const SUSPEND: Bind = ctrl_bind!('z');
     pub const DELETE: Bind = ctrl_bind!('d');
     pub const KILL_LINE: Bind = ctrl_bind!('k');

--- a/maki-ui/src/components/usage_modal.rs
+++ b/maki-ui/src/components/usage_modal.rs
@@ -109,6 +109,20 @@ impl UsageModal {
             render_vertical_scrollbar(frame, inner, total, scroll);
         }
 
+        let hint = Line::from(vec![
+            Span::raw(" "),
+            Span::styled("Ctrl+R", theme.keybind_key),
+            Span::styled(" reload ", theme.tool_dim),
+        ]);
+        let hint_w = hint.width() as u16;
+        let hint_area = Rect {
+            x: popup.x + popup.width.saturating_sub(hint_w + 1),
+            y: popup.y + popup.height.saturating_sub(1),
+            width: hint_w,
+            height: 1,
+        };
+        frame.render_widget(Paragraph::new(hint), hint_area);
+
         popup
     }
 }


### PR DESCRIPTION
The `/usage` modal already re-rendered token tables every frame from app state, but the quota section needed an explicit `Action::RefreshUsage` to refetch from the provider.  `Ctrl+R` now triggers that refresh while the modal stays open, and a styled `Ctrl+R reload` hint sits on the bottom border of the popup so it is discoverable.