### PR TITLE
fix(lua): keep dynamic provider slug when resolving subagent tiers

### DIFF
--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -61,7 +61,11 @@ fn resolve_model_from_ctx(ctx: &AgentContext, tier: Option<&str>) -> Result<Mode
     let map = maki_providers::model_registry::model_registry()
         .read()
         .unwrap();
-    map.spec_for_tier(ctx.model.provider, effective)
+    ctx.model
+        .dynamic_slug
+        .is_none()
+        .then(|| map.spec_for_tier(ctx.model.provider, effective))
+        .flatten()
         .or_else(|| map.spec_for_tier_any(effective))
         .and_then(|s| Model::from_spec(&s).ok())
         .map(Ok)


### PR DESCRIPTION
Now `resolve_model_from_ctx` skips the base provider registry lookup
when the model carries a dynamic slug, falling through to
`Model::from_tier_dynamic` which keeps the slug, while tier overrides
still apply via `spec_for_tier_any`.