### PR TITLE
feat(lua): expose plugin primitives for idle-driven compaction 🤖🤖🤖

### DIFF
--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod json;
 pub(crate) mod keymap;
 pub(crate) mod log;
 pub(crate) mod net;
+mod session;
 pub(crate) mod text;
 pub(crate) mod tool;
 pub(crate) mod treesitter;
@@ -43,7 +44,10 @@ pub(crate) fn create_maki_global(
     maki.set("fs", fs::create_fs_table(lua, permissions)?)?;
     maki.set("log", log::create_log_table(lua, Arc::clone(&plugin))?)?;
     maki.set("treesitter", treesitter::create_treesitter_table(lua)?)?;
-    maki.set("uv", uv::create_uv_table(lua, permissions)?)?;
+    maki.set(
+        "uv",
+        uv::create_uv_table(lua, permissions, Arc::clone(&plugin))?,
+    )?;
     maki.set("base64", base64::create_base64_table(lua)?)?;
     maki.set("image", image::create_image_table(lua)?)?;
     maki.set("json", json::create_json_table(lua)?)?;
@@ -52,7 +56,7 @@ pub(crate) fn create_maki_global(
     maki.set("text", text::create_text_table(lua)?)?;
     maki.set(
         "ui",
-        ui::create_ui_table(lua, ui_action_tx, Arc::clone(&plugin))?,
+        ui::create_ui_table(lua, ui_action_tx.clone(), Arc::clone(&plugin))?,
     )?;
     maki.set("fn", r#fn::create_fn_table(lua, permissions)?)?;
     maki.set("async", r#async::create_async_table(lua)?)?;
@@ -61,6 +65,7 @@ pub(crate) fn create_maki_global(
         interpreter::create_interpreter_table(lua, permissions)?,
     )?;
     agent::register(lua, &maki)?;
+    session::register(lua, &maki, ui_action_tx)?;
     maki.set(
         "keymap",
         keymap::create_keymap_table(lua, Arc::clone(&plugin))?,

--- a/maki-lua/src/api/session.rs
+++ b/maki-lua/src/api/session.rs
@@ -1,0 +1,42 @@
+//! `maki.session` exposes host-side session control to Lua plugins:
+//! triggering compaction and inspecting conversation history length.
+
+use mlua::{Lua, Result as LuaResult, Table};
+
+use crate::api::util::command::UiAction;
+
+pub(crate) fn register(
+    lua: &Lua,
+    maki: &Table,
+    ui_action_tx: Option<flume::Sender<UiAction>>,
+) -> LuaResult<()> {
+    let session = lua.create_table()?;
+
+    session.set(
+        "compact",
+        lua.create_function(move |_, ()| {
+            match &ui_action_tx {
+                Some(tx) => {
+                    if let Err(e) = tx.try_send(UiAction::Compact) {
+                        tracing::warn!(error = %e, "compact: ui action channel send failed");
+                    }
+                }
+                None => tracing::warn!("compact: no ui action channel available"),
+            }
+            Ok(())
+        })?,
+    )?;
+
+    session.set(
+        "history_len",
+        lua.create_function(|lua, ()| {
+            let len = lua
+                .app_data_ref::<maki_agent::SharedMessages>()
+                .map(|h| h.load().len());
+            Ok(len)
+        })?,
+    )?;
+
+    maki.set("session", session)?;
+    Ok(())
+}

--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -400,6 +400,7 @@ pub enum UiAction {
         path: PathBuf,
         reply_tx: flume::Sender<i32>,
     },
+    Compact,
 }
 
 #[cfg(test)]

--- a/maki-lua/src/api/uv.rs
+++ b/maki-lua/src/api/uv.rs
@@ -1,8 +1,259 @@
-use mlua::{Lua, Result as LuaResult, Table};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use mlua::{Lua, Result as LuaResult, Table, UserData, UserDataMethods};
 
 use crate::plugin_permissions::{Permission::Env, PluginPermissions};
+use crate::runtime::Request;
 
-pub(crate) fn create_uv_table(lua: &Lua, perms: &PluginPermissions) -> LuaResult<Table> {
+static NEXT_TIMER_ID: AtomicU64 = AtomicU64::new(1);
+#[cfg(test)]
+const MS_PER_SEC: u64 = 1_000;
+
+pub(crate) struct TimerEntry {
+    callback: Option<mlua::RegistryKey>,
+    plugin: Arc<str>,
+    task: Option<smol::Task<()>>,
+    cancel: Arc<AtomicBool>,
+    repeat: Duration,
+    started: bool,
+}
+
+impl TimerEntry {
+    fn cancel_task(&mut self) {
+        self.cancel.store(true, Ordering::Relaxed);
+        self.task = None;
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct TimerStore {
+    timers: HashMap<u64, TimerEntry>,
+}
+
+impl TimerStore {
+    fn insert(&mut self, id: u64, entry: TimerEntry) {
+        self.timers.insert(id, entry);
+    }
+
+    pub(crate) fn load_callback(&self, lua: &Lua, id: u64) -> Option<mlua::Function> {
+        self.timers
+            .get(&id)
+            .filter(|e| e.task.is_some())
+            .and_then(|e| e.callback.as_ref())
+            .and_then(|key| lua.registry_value::<mlua::Function>(key).ok())
+    }
+
+    fn stop(&mut self, id: u64) {
+        if let Some(entry) = self.timers.get_mut(&id) {
+            entry.cancel_task();
+        }
+    }
+
+    pub(crate) fn close(&mut self, lua: &Lua, id: u64) {
+        if let Some(mut entry) = self.timers.remove(&id) {
+            entry.cancel_task();
+            if let Some(key) = entry.callback.take() {
+                let _ = lua.remove_registry_value(key);
+            }
+        }
+    }
+
+    pub fn clear_plugin(&mut self, lua: &Lua, plugin: &str) {
+        let ids: Vec<u64> = self
+            .timers
+            .iter()
+            .filter(|(_, e)| e.plugin.as_ref() == plugin)
+            .map(|(id, _)| *id)
+            .collect();
+        for id in ids {
+            self.close(lua, id);
+        }
+    }
+}
+
+struct TimerHandle {
+    id: u64,
+    tx: flume::Sender<Request>,
+    plugin: Arc<str>,
+}
+
+impl Drop for TimerHandle {
+    fn drop(&mut self) {
+        let _ = self.tx.try_send(Request::TimerClose { id: self.id });
+    }
+}
+
+fn spawn_timer_task(
+    tx: flume::Sender<Request>,
+    id: u64,
+    delay: Duration,
+    repeat: Duration,
+    cancel: Arc<AtomicBool>,
+) -> smol::Task<()> {
+    smol::spawn(async move {
+        if cancel.load(Ordering::Relaxed) {
+            return;
+        }
+        smol::Timer::after(delay).await;
+        if cancel.load(Ordering::Relaxed) {
+            return;
+        }
+        if tx.send(Request::TimerFire { id }).is_err() {
+            return;
+        }
+        if repeat.is_zero() {
+            return;
+        }
+        loop {
+            smol::Timer::after(repeat).await;
+            if cancel.load(Ordering::Relaxed) {
+                return;
+            }
+            if tx.send(Request::TimerFire { id }).is_err() {
+                return;
+            }
+        }
+    })
+}
+
+impl UserData for TimerHandle {
+    fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method_mut(
+            "start",
+            |lua,
+             this,
+             (delay_ms, repeat_ms, cb): (u64, u64, mlua::Function)|
+             -> mlua::Result<i64> {
+                let key = lua.create_registry_value(cb)?;
+                let plugin = Arc::clone(&this.plugin);
+                let repeat = Duration::from_millis(repeat_ms);
+                let delay = Duration::from_millis(delay_ms);
+                let tx = this.tx.clone();
+                let id = this.id;
+                let cancel = Arc::new(AtomicBool::new(false));
+                let task = spawn_timer_task(tx, id, delay, repeat, Arc::clone(&cancel));
+
+                let Some(mut store) = lua.app_data_mut::<TimerStore>() else {
+                    return Err(mlua::Error::runtime("timer store not initialized"));
+                };
+                let Some(entry) = store.timers.get_mut(&id) else {
+                    return Err(mlua::Error::runtime("timer entry not found"));
+                };
+                let prev_cb = entry.callback.replace(key);
+                entry.plugin = plugin;
+                entry.cancel_task();
+                entry.task = Some(task);
+                entry.cancel = cancel;
+                entry.repeat = repeat;
+                entry.started = true;
+                drop(store);
+                if let Some(prev) = prev_cb {
+                    let _ = lua.remove_registry_value(prev);
+                }
+                Ok(0)
+            },
+        );
+
+        methods.add_method_mut("stop", |lua, this, ()| -> mlua::Result<i64> {
+            if let Some(mut store) = lua.app_data_mut::<TimerStore>() {
+                store.stop(this.id);
+            }
+            Ok(0)
+        });
+
+        methods.add_method_mut("again", |lua, this, ()| -> mlua::Result<i64> {
+            let (repeat, plugin, started) = lua
+                .app_data_ref::<TimerStore>()
+                .and_then(|store| {
+                    store
+                        .timers
+                        .get(&this.id)
+                        .map(|e| (e.repeat, Arc::clone(&e.plugin), e.started))
+                })
+                .ok_or_else(|| mlua::Error::runtime("EINVAL: timer not started"))?;
+            if !started {
+                return Err(mlua::Error::runtime("EINVAL: timer never started"));
+            }
+            if repeat.is_zero() {
+                if let Some(mut store) = lua.app_data_mut::<TimerStore>() {
+                    store.stop(this.id);
+                }
+                return Ok(0);
+            }
+            let tx = this.tx.clone();
+            let id = this.id;
+            let cancel = Arc::new(AtomicBool::new(false));
+            let task = spawn_timer_task(tx, id, repeat, repeat, Arc::clone(&cancel));
+            if let Some(mut store) = lua.app_data_mut::<TimerStore>()
+                && let Some(entry) = store.timers.get_mut(&id)
+            {
+                entry.plugin = plugin;
+                entry.cancel_task();
+                entry.task = Some(task);
+                entry.cancel = cancel;
+            }
+            Ok(0)
+        });
+
+        methods.add_method_mut("set_repeat", |lua, this, repeat_ms: u64| {
+            if let Some(mut store) = lua.app_data_mut::<TimerStore>()
+                && let Some(entry) = store.timers.get_mut(&this.id)
+            {
+                entry.repeat = Duration::from_millis(repeat_ms);
+            }
+            Ok(())
+        });
+
+        methods.add_method("get_repeat", |lua, this, ()| {
+            let repeat_ms = lua
+                .app_data_ref::<TimerStore>()
+                .and_then(|store| store.timers.get(&this.id).map(|e| e.repeat))
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0);
+            Ok(repeat_ms)
+        });
+
+        methods.add_method_mut("close", |lua, this, ()| {
+            if let Some(mut store) = lua.app_data_mut::<TimerStore>() {
+                store.close(lua, this.id);
+            }
+            Ok(())
+        });
+
+        methods.add_method("is_active", |lua, this, ()| {
+            let active = lua
+                .app_data_ref::<TimerStore>()
+                .and_then(|store| store.timers.get(&this.id).map(|e| e.task.is_some()))
+                .unwrap_or(false);
+            Ok(active)
+        });
+
+        methods.add_method("is_closed", |lua, this, ()| {
+            let closed = lua
+                .app_data_ref::<TimerStore>()
+                .map(|store| !store.timers.contains_key(&this.id))
+                .unwrap_or(true);
+            Ok(closed)
+        });
+    }
+}
+
+pub(crate) struct TimerTx(pub(crate) flume::Sender<Request>);
+
+#[cfg(test)]
+pub(crate) fn install_timer_dispatch(lua: &Lua, tx: flume::Sender<Request>) {
+    lua.set_app_data(TimerStore::default());
+    lua.set_app_data(TimerTx(tx));
+}
+
+pub(crate) fn create_uv_table(
+    lua: &Lua,
+    perms: &PluginPermissions,
+    plugin: Arc<str>,
+) -> LuaResult<Table> {
     let t = lua.create_table()?;
 
     t.set(
@@ -26,5 +277,240 @@ pub(crate) fn create_uv_table(lua: &Lua, perms: &PluginPermissions) -> LuaResult
         perms.guard(Env, lua, |_, name: String| Ok(std::env::var(&name).ok()))?,
     )?;
 
+    t.set("hrtime", lua.create_function(hrtime)?)?;
+
+    let plugin_for_handle = Arc::clone(&plugin);
+    t.set(
+        "new_timer",
+        lua.create_function(move |lua, ()| {
+            let tx = lua
+                .app_data_ref::<TimerTx>()
+                .map(|t| t.0.clone())
+                .ok_or_else(|| mlua::Error::runtime("timer dispatch not initialized"))?;
+            let id = NEXT_TIMER_ID.fetch_add(1, Ordering::Relaxed);
+            if let Some(mut store) = lua.app_data_mut::<TimerStore>() {
+                store.insert(
+                    id,
+                    TimerEntry {
+                        callback: None,
+                        plugin: Arc::clone(&plugin_for_handle),
+                        task: None,
+                        cancel: Arc::new(AtomicBool::new(false)),
+                        repeat: Duration::ZERO,
+                        started: false,
+                    },
+                );
+            }
+            Ok(TimerHandle {
+                id,
+                tx,
+                plugin: Arc::clone(&plugin_for_handle),
+            })
+        })?,
+    )?;
+
     Ok(t)
+}
+
+fn hrtime(_lua: &Lua, (): ()) -> LuaResult<u64> {
+    Ok(hrtime_now())
+}
+
+fn hrtime_now() -> u64 {
+    static START: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+    let start = START.get_or_init(Instant::now);
+    start.elapsed().as_nanos() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mlua::Lua;
+
+    fn store_with_entry(lua: &Lua, id: u64, plugin: &str) -> TimerStore {
+        let mut store = TimerStore::default();
+        let key = lua
+            .create_registry_value(lua.create_function(|_, ()| Ok(())).unwrap())
+            .unwrap();
+        store.timers.insert(
+            id,
+            TimerEntry {
+                callback: Some(key),
+                plugin: Arc::from(plugin),
+                task: None,
+                cancel: Arc::new(AtomicBool::new(false)),
+                repeat: Duration::from_millis(MS_PER_SEC),
+                started: false,
+            },
+        );
+        store
+    }
+
+    #[test]
+    fn stop_drops_task_slot() {
+        let lua = Lua::new();
+        let mut store = store_with_entry(&lua, 1, "p");
+        store.stop(1);
+        assert!(
+            store
+                .timers
+                .get(&1)
+                .map(|e| e.task.is_none())
+                .unwrap_or(false)
+        );
+    }
+
+    #[test]
+    fn close_removes_entry() {
+        let lua = Lua::new();
+        let mut store = store_with_entry(&lua, 7, "p");
+        assert!(store.timers.contains_key(&7));
+        store.close(&lua, 7);
+        assert!(!store.timers.contains_key(&7));
+    }
+
+    #[test]
+    fn close_missing_is_noop() {
+        let lua = Lua::new();
+        let mut store = TimerStore::default();
+        store.close(&lua, 999);
+        assert!(store.timers.is_empty());
+    }
+
+    #[test]
+    fn clear_plugin_removes_only_matching() {
+        let lua = Lua::new();
+        let mut store = TimerStore::default();
+        let mk = |lua: &Lua, id: u64, plug: &str| {
+            let f = lua.create_function(|_, ()| Ok(())).unwrap();
+            let key = lua.create_registry_value(f).unwrap();
+            (
+                id,
+                TimerEntry {
+                    callback: Some(key),
+                    plugin: Arc::from(plug),
+                    task: None,
+                    cancel: Arc::new(AtomicBool::new(false)),
+                    repeat: Duration::ZERO,
+                    started: false,
+                },
+            )
+        };
+        let (i1, e1) = mk(&lua, 1, "plugA");
+        let (i2, e2) = mk(&lua, 2, "plugB");
+        store.timers.insert(i1, e1);
+        store.timers.insert(i2, e2);
+        store.clear_plugin(&lua, "plugA");
+        assert!(!store.timers.contains_key(&1));
+        assert!(store.timers.contains_key(&2));
+        assert_eq!(store.timers[&2].plugin.as_ref(), "plugB");
+    }
+
+    #[test]
+    fn cancel_flag_set_on_stop() {
+        let lua = Lua::new();
+        let mut store = store_with_entry(&lua, 3, "p");
+        store.stop(3);
+        assert!(store.timers[&3].cancel.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn cancel_flag_set_on_close() {
+        let lua = Lua::new();
+        let mut store = store_with_entry(&lua, 5, "p");
+        let flag = Arc::clone(&store.timers[&5].cancel);
+        store.close(&lua, 5);
+        assert!(flag.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn hrtime_is_monotonic_nondecreasing() {
+        let a = hrtime_now();
+        let b = hrtime_now();
+        assert!(b >= a);
+    }
+
+    #[test]
+    fn timer_handle_lifecycle_via_lua() {
+        let lua = Lua::new();
+        let (tx, _rx) = flume::unbounded::<Request>();
+        install_timer_dispatch(&lua, tx);
+        let t = create_uv_table(&lua, &PluginPermissions::trusted(), Arc::from("test")).unwrap();
+        let globals = lua.globals();
+        globals.set("maki", t).unwrap();
+        let rep: u64 = lua
+            .load(
+                r#"
+                local t = maki.new_timer()
+                assert(not t:is_closed())
+                assert(not t:is_active())
+                local rc = t:start(10, 0, function() end)
+                assert(rc == 0, "start returns 0 on success, got " .. tostring(rc))
+                local rep = t:get_repeat()
+                assert(t:is_active())
+                assert(not t:is_closed())
+                t:stop()
+                assert(not t:is_active())
+                assert(not t:is_closed())
+                t:close()
+                assert(not t:is_active())
+                assert(t:is_closed())
+                return rep
+                "#,
+            )
+            .eval()
+            .unwrap();
+        assert_eq!(rep, 0);
+    }
+
+    #[test]
+    fn again_on_never_started_errors() {
+        let lua = Lua::new();
+        let (tx, _rx) = flume::unbounded::<Request>();
+        install_timer_dispatch(&lua, tx);
+        let t = create_uv_table(&lua, &PluginPermissions::trusted(), Arc::from("test")).unwrap();
+        let globals = lua.globals();
+        globals.set("maki", t).unwrap();
+        let err = lua
+            .load(
+                r#"
+                local t = maki.new_timer()
+                t:again()
+                "#,
+            )
+            .exec()
+            .unwrap_err();
+        assert!(err.to_string().contains("EINVAL"), "{}", err);
+    }
+
+    #[test]
+    fn new_timer_without_dispatch_errors() {
+        let lua = Lua::new();
+        let t = create_uv_table(&lua, &PluginPermissions::trusted(), Arc::from("test")).unwrap();
+        let globals = lua.globals();
+        globals.set("maki", t).unwrap();
+        let result: mlua::Error = lua.load("local _ = maki.new_timer()").exec().unwrap_err();
+        assert!(result.to_string().contains("timer dispatch"));
+    }
+
+    #[test]
+    fn set_repeat_get_repeat_round_trip() {
+        let lua = Lua::new();
+        let (tx, _rx) = flume::unbounded::<Request>();
+        install_timer_dispatch(&lua, tx);
+        let t = create_uv_table(&lua, &PluginPermissions::trusted(), Arc::from("test")).unwrap();
+        let globals = lua.globals();
+        globals.set("maki", t).unwrap();
+        let rep: u64 = lua
+            .load(
+                r#"
+                local t = maki.new_timer()
+                t:set_repeat(250)
+                return t:get_repeat()
+                "#,
+            )
+            .eval()
+            .unwrap();
+        assert_eq!(rep, 250);
+    }
 }

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -383,6 +383,10 @@ impl EventHandle {
         });
     }
 
+    pub fn set_history(&self, history: maki_agent::SharedMessages) {
+        let _ = self.tx.send(Request::SetHistory { history });
+    }
+
     pub fn run_keybind_callback(&self, id: u64) {
         let _ = self.tx.try_send(Request::RunKeybindCallback { id });
     }

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -128,6 +128,15 @@ pub enum Request {
         event: String,
         data: Value,
     },
+    SetHistory {
+        history: maki_agent::SharedMessages,
+    },
+    TimerFire {
+        id: u64,
+    },
+    TimerClose {
+        id: u64,
+    },
     ClickTool {
         tool_use_id: String,
         /// 1-based line in the tool's live buffer; 0 means the click landed
@@ -659,6 +668,8 @@ impl LuaRuntime {
         lua.set_app_data(keymap_writer);
         lua.set_app_data(HintStore::new());
         lua.set_app_data(hint_writer);
+        lua.set_app_data(crate::api::uv::TimerStore::default());
+        lua.set_app_data(crate::api::uv::TimerTx(tx.clone()));
         lua.set_app_data(Arc::clone(&registry));
 
         let plugins: PluginMap = Rc::new(RefCell::new(HashMap::new()));
@@ -1139,6 +1150,9 @@ impl LuaRuntime {
                 writer.publish(entries);
             }
         }
+        if let Some(mut store) = self.lua.app_data_mut::<crate::api::uv::TimerStore>() {
+            store.clear_plugin(&self.lua, plugin);
+        }
     }
 
     fn call_sync_detached<R: mlua::FromLuaMulti>(
@@ -1358,8 +1372,17 @@ fn extract_restore_reply(ret: &LuaValue) -> Option<RestoreReply> {
     Some(RestoreReply { body, header })
 }
 
-/// Handler returned nil, meaning it went async. Polls job events
-/// until `ctx:finish()`, all jobs die, or the deadline expires.
+fn is_timed_out(handle: &TaskHandle) -> bool {
+    lock_cell(handle)
+        .deadline
+        .get()
+        .is_some_and(|d| Instant::now() > d)
+}
+
+// Handler returned nil, meaning it went async. Polls job events
+// until `ctx:finish()`, all jobs die, or the deadline expires.
+// When there are no jobs to observe, this still loops: a timer or other
+// async completion may fire `finish` from outside the job system.
 async fn dispatch_async(
     lua: &Lua,
     handle: TaskHandle,
@@ -1374,26 +1397,31 @@ async fn dispatch_async(
 
     if !has_jobs {
         lua.gc_collect().ok();
-        smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
-        return match finish_rx.try_recv() {
-            Ok(reply) => reply,
-            _ => ToolCallReply::err(NIL_WITHOUT_FINISH_MSG),
-        };
+        loop {
+            if cancel.is_cancelled() {
+                return ToolCallReply::err(CANCELLED_MSG);
+            }
+            if is_timed_out(&handle) {
+                return timeout_reply(&handle, plugin, tool);
+            }
+            match finish_rx.try_recv() {
+                Ok(reply) => return reply,
+                Err(flume::TryRecvError::Disconnected) => {
+                    return ToolCallReply::err(NIL_WITHOUT_FINISH_MSG);
+                }
+                Err(flume::TryRecvError::Empty) => {}
+            }
+            smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
+        }
     }
 
-    let timed_out = || {
-        lock_cell(&handle)
-            .deadline
-            .get()
-            .is_some_and(|d| Instant::now() > d)
-    };
     let mut event_buf = Vec::new();
 
     loop {
         if cancel.is_cancelled() {
             return ToolCallReply::err(CANCELLED_MSG);
         }
-        if timed_out() {
+        if is_timed_out(&handle) {
             return timeout_reply(&handle, plugin, tool);
         }
 
@@ -1411,10 +1439,15 @@ async fn dispatch_async(
             let has_alive = lock_cell(&handle).jobs.has_alive_jobs();
             if !has_alive {
                 smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
-                return match finish_rx.try_recv() {
-                    Ok(reply) => reply,
-                    _ => ToolCallReply::err(NIL_WITHOUT_FINISH_MSG),
-                };
+                match finish_rx.try_recv() {
+                    Ok(reply) => return reply,
+                    Err(flume::TryRecvError::Disconnected) => {
+                        return ToolCallReply::err(NIL_WITHOUT_FINISH_MSG);
+                    }
+                    Err(flume::TryRecvError::Empty) => {
+                        return ToolCallReply::err(NIL_WITHOUT_FINISH_MSG);
+                    }
+                }
             }
             smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
             continue;
@@ -1920,6 +1953,26 @@ pub fn spawn(
                             }
                             if event == TURN_END_EVENT {
                                 rt.lua.gc_collect().ok();
+                            }
+                        }
+                        Request::SetHistory { history } => {
+                            rt.lua.set_app_data(history);
+                        }
+                        Request::TimerFire { id } => {
+                            let func = rt
+                                .lua
+                                .app_data_ref::<crate::api::uv::TimerStore>()
+                                .and_then(|store| store.load_callback(&rt.lua, id));
+                            if let Some(func) = func {
+                                if let Err(e) = rt.call_sync_detached::<()>(&func, ()) {
+                                    tracing::warn!(timer = id, error = %e, "timer callback failed");
+                                }
+                                drain_spawn_queue(&rt.lua, &ex, &gate);
+                            }
+                        }
+                        Request::TimerClose { id } => {
+                            if let Some(mut store) = rt.lua.app_data_mut::<crate::api::uv::TimerStore>() {
+                                store.close(&rt.lua, id);
                             }
                         }
                         Request::Describe {

--- a/maki-lua/tests/fixtures/idle_compact.lua
+++ b/maki-lua/tests/fixtures/idle_compact.lua
@@ -1,0 +1,44 @@
+local IDLE_CHECK_INTERVAL_MS = 60_000
+local MIN_HISTORY_FOR_COMPACT = 2
+local NS_PER_MINUTE = 60 * 1_000_000_000
+local DEFAULT_IDLE_MINUTES = 10
+
+local function idle_minutes()
+  local raw = maki.uv.os_getenv("MAKI_IDLE_COMPACT_MINUTES")
+  local n = tonumber(raw)
+  if n and n > 0 then
+    return n
+  end
+  return DEFAULT_IDLE_MINUTES
+end
+
+local last_input = maki.uv.hrtime()
+local compacted_since_input = false
+
+local function resetidle()
+  last_input = maki.uv.hrtime()
+  compacted_since_input = false
+end
+
+local function check_idle()
+  if compacted_since_input then
+    return
+  end
+  local elapsed_min = (maki.uv.hrtime() - last_input) / NS_PER_MINUTE
+  if elapsed_min < idle_minutes() then
+    return
+  end
+  local len = maki.session.history_len()
+  if len == nil or len <= MIN_HISTORY_FOR_COMPACT then
+    return
+  end
+  maki.session.compact()
+  compacted_since_input = true
+end
+
+maki.api.create_autocmd({ "UserInput", "TurnEnd", "TurnError" }, {
+  callback = resetidle,
+})
+
+local timer = maki.uv.new_timer()
+timer:start(IDLE_CHECK_INTERVAL_MS, IDLE_CHECK_INTERVAL_MS, check_idle)

--- a/maki-lua/tests/idle_compact.rs
+++ b/maki-lua/tests/idle_compact.rs
@@ -1,0 +1,296 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maki_agent::tools::ToolRegistry;
+use maki_lua::PluginHost;
+
+const IDLE_COMPACT_PLUGIN: &str = include_str!("fixtures/idle_compact.lua");
+
+fn host() -> PluginHost {
+    PluginHost::new(Arc::new(ToolRegistry::new())).unwrap()
+}
+
+fn exec_tool(reg: &ToolRegistry, name: &str, input: serde_json::Value) -> Result<String, String> {
+    let entry = reg
+        .get(name)
+        .unwrap_or_else(|| panic!("tool {name} not registered"));
+    let inv = entry.tool.parse(&input).expect("parse failed");
+    let ctx = maki_agent::tools::test_support::stub_ctx(&maki_agent::AgentMode::Build);
+    smol::block_on(async { inv.execute(&ctx).await })
+        .output
+        .map(|out| match out {
+            maki_agent::ToolOutput::Plain(s) => s.text,
+            other => panic!("unexpected output: {other:?}"),
+        })
+}
+
+#[test]
+fn session_compact_publishes_to_ui_channel() {
+    let host = host();
+    let rx = host.ui_action_rx().expect("ui action rx present");
+    host.load_source(
+        "session_compact_present",
+        r#"
+        maki.session.compact()
+        "#,
+    )
+    .unwrap();
+    let action = rx.recv_timeout(Duration::from_secs(1)).unwrap();
+    assert!(matches!(action, maki_lua::UiAction::Compact));
+}
+
+#[test]
+fn session_history_len_returns_nil_without_history() {
+    let host = host();
+    host.load_source(
+        "session_history_missing",
+        r#"
+        local n = maki.session.history_len()
+        assert(n == nil, "history_len without shared history should be nil, got: " .. tostring(n))
+        "#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn uv_hrtime_returns_integer() {
+    let host = host();
+    host.load_source(
+        "hrtime_basic",
+        r#"
+        local t = maki.uv.hrtime()
+        assert(type(t) == "number", "hrtime must return a number")
+        assert(t >= 0, "hrtime must be non-negative")
+        "#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn uv_new_timer_methods_exist() {
+    let host = host();
+    host.load_source(
+        "timer_methods",
+        r#"
+        local t = maki.uv.new_timer()
+        assert(type(t.start) == "function")
+        assert(type(t.stop) == "function")
+        assert(type(t.close) == "function")
+        assert(type(t.again) == "function")
+        assert(type(t.set_repeat) == "function")
+        assert(type(t.get_repeat) == "function")
+        t:close()
+        "#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn user_input_autocmd_fires_on_event() {
+    let host = host();
+    let rx = host.ui_action_rx().expect("ui action rx present");
+    let eh = host.event_handle().expect("event handle available");
+    host.load_source(
+        "user_input_autocmd",
+        r#"
+        maki.api.create_autocmd("UserInput", {
+          callback = function() maki.session.compact() end,
+        })
+        "#,
+    )
+    .unwrap();
+    eh.fire_autocmd("UserInput", serde_json::json!({}));
+    let action = rx.recv_timeout(Duration::from_secs(1)).unwrap();
+    assert!(matches!(action, maki_lua::UiAction::Compact));
+}
+
+#[test]
+fn idle_compact_plugin_loads() {
+    let host = host();
+    host.load_source("idle_compact", IDLE_COMPACT_PLUGIN)
+        .unwrap_or_else(|e| panic!("idle_compact plugin failed to load: {e}"));
+}
+
+const TIMER_FIRES_PLUGIN: &str = r#"
+maki.api.register_tool({
+    name = "timer_fires",
+    description = "starts a one-shot timer that finishes the tool",
+    schema = { type = "object", properties = {}, additionalProperties = false },
+    audiences = { "main" },
+    handler = function(input, ctx)
+        local t = maki.uv.new_timer()
+        t:start(20, 0, function()
+            t:close()
+            ctx:finish("timer-fired")
+        end)
+        return nil
+    end
+})
+"#;
+
+#[test]
+fn one_shot_timer_callback_runs_on_runtime_thread() {
+    let reg = Arc::new(ToolRegistry::new());
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source("timer_fires_plugin", TIMER_FIRES_PLUGIN)
+        .unwrap();
+    let out = exec_tool(&reg, "timer_fires", serde_json::json!({})).unwrap();
+    assert_eq!(out, "timer-fired");
+}
+
+const REPEAT_TIMER_PLUGIN: &str = r#"
+maki.api.register_tool({
+    name = "repeat_timer",
+    description = "counts timer fires then finishes",
+    schema = { type = "object", properties = {}, additionalProperties = false },
+    audiences = { "main" },
+    handler = function(input, ctx)
+        local count = 0
+        local t = maki.uv.new_timer()
+        t:start(10, 10, function()
+            count = count + 1
+            if count >= 3 then
+                t:stop()
+                t:close()
+                ctx:finish("count=" .. count)
+            end
+        end)
+        return nil
+    end
+})
+"#;
+
+#[test]
+fn repeating_timer_fires_multiple_times() {
+    let reg = Arc::new(ToolRegistry::new());
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source("repeat_timer_plugin", REPEAT_TIMER_PLUGIN)
+        .unwrap();
+    let out = exec_tool(&reg, "repeat_timer", serde_json::json!({})).unwrap();
+    assert_eq!(out, "count=3");
+}
+
+const AGAIN_AFTER_STOP_PLUGIN: &str = r#"
+maki.api.register_tool({
+    name = "again_after_stop",
+    description = "starts, stops, then again a repeating timer",
+    schema = { type = "object", properties = {}, additionalProperties = false },
+    audiences = { "main" },
+    handler = function(input, ctx)
+        local t = maki.uv.new_timer()
+        t:start(10, 10, function()
+            t:close()
+            ctx:finish("again-fired")
+        end)
+        t:stop()
+        t:again()
+        return nil
+    end
+})
+"#;
+
+#[test]
+fn again_restarts_after_stop() {
+    let reg = Arc::new(ToolRegistry::new());
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source("again_after_stop_plugin", AGAIN_AFTER_STOP_PLUGIN)
+        .unwrap();
+    let out = exec_tool(&reg, "again_after_stop", serde_json::json!({})).unwrap();
+    assert_eq!(out, "again-fired");
+}
+
+const START_TWICE_PLUGIN: &str = r#"
+maki.api.register_tool({
+    name = "start_twice",
+    description = "starts a timer twice; only the second callback fires",
+    schema = { type = "object", properties = {}, additionalProperties = false },
+    audiences = { "main" },
+    handler = function(input, ctx)
+        local t = maki.uv.new_timer()
+        local fired = {}
+        t:start(50, 0, function() fired.first = true end)
+        t:start(10, 0, function()
+            t:close()
+            ctx:finish("fired=" .. tostring(fired.first))
+        end)
+        return nil
+    end
+})
+"#;
+
+#[test]
+fn start_twice_replaces_callback_no_double_fire() {
+    let reg = Arc::new(ToolRegistry::new());
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source("start_twice_plugin", START_TWICE_PLUGIN)
+        .unwrap();
+    let out = exec_tool(&reg, "start_twice", serde_json::json!({})).unwrap();
+    assert_eq!(out, "fired=nil");
+}
+
+const CLOSE_WHILE_ACTIVE_PLUGIN: &str = r#"
+maki.api.register_tool({
+    name = "close_while_active",
+    description = "closes an active repeating timer after one fire then waits",
+    schema = { type = "object", properties = {}, additionalProperties = false },
+    audiences = { "main" },
+    handler = function(input, ctx)
+        local t = maki.uv.new_timer()
+        local count = 0
+        t:start(10, 10, function()
+            count = count + 1
+            if count >= 1 then
+                t:close()
+            end
+        end)
+        local watcher = maki.uv.new_timer()
+        watcher:start(60, 0, function()
+            watcher:close()
+            ctx:finish("count=" .. count)
+        end)
+        return nil
+    end
+})
+"#;
+
+#[test]
+fn close_while_active_stops_fires() {
+    let reg = Arc::new(ToolRegistry::new());
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source("close_while_active_plugin", CLOSE_WHILE_ACTIVE_PLUGIN)
+        .unwrap();
+    let out = exec_tool(&reg, "close_while_active", serde_json::json!({})).unwrap();
+    assert_eq!(out, "count=1");
+}
+
+const DROP_HANDLE_PLUGIN: &str = r#"
+maki.api.register_tool({
+    name = "drop_handle",
+    description = "drops a timer handle without explicit close",
+    schema = { type = "object", properties = {}, additionalProperties = false },
+    audiences = { "main" },
+    handler = function(input, ctx)
+        do
+            local t = maki.uv.new_timer()
+            t:start(10, 0, function() end)
+            assert(t:is_active())
+        end
+        local t2 = maki.uv.new_timer()
+        t2:start(50, 0, function()
+            t2:close()
+            ctx:finish("dropped")
+        end)
+        return nil
+    end
+})
+"#;
+
+#[test]
+fn drop_handle_without_close_cleans_up() {
+    let reg = Arc::new(ToolRegistry::new());
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source("drop_handle_plugin", DROP_HANDLE_PLUGIN)
+        .unwrap();
+    let out = exec_tool(&reg, "drop_handle", serde_json::json!({})).unwrap();
+    assert_eq!(out, "dropped");
+}

--- a/maki-ui/src/agent/shared_queue.rs
+++ b/maki-ui/src/agent/shared_queue.rs
@@ -143,6 +143,12 @@ impl QueueSender {
         lock(&self.items).clear();
     }
 
+    pub(crate) fn has_compact(&self) -> bool {
+        lock(&self.items)
+            .iter()
+            .any(|item| matches!(item, QueueItem::Compact { .. }))
+    }
+
     pub(crate) fn text_messages(&self) -> Vec<String> {
         lock(&self.items)
             .iter()

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -868,6 +868,15 @@ impl App {
                 visible: prefix.visible,
             }];
         }
+        if let Some(ref handle) = self.lua_event_handle {
+            handle.fire_autocmd(
+                "UserInput",
+                serde_json::json!({
+                    "text": sub.text,
+                    "image_count": sub.images.len(),
+                }),
+            );
+        }
         let msg: QueuedMessage = sub.into();
         if self.status == Status::Streaming {
             self.queue_and_notify(msg);
@@ -1143,6 +1152,16 @@ impl App {
         idx
     }
 
+    pub(crate) fn request_compact(&mut self) -> Vec<Action> {
+        if self.status == Status::Streaming {
+            self.queue_compact();
+            return vec![];
+        }
+        self.run_id += 1;
+        self.status = Status::Streaming;
+        vec![Action::Compact]
+    }
+
     fn execute_command(&mut self, cmd: ParsedCommand) -> Vec<Action> {
         self.input_box.discard();
         match cmd.name.as_str() {
@@ -1150,14 +1169,7 @@ impl App {
                 self.open_tasks();
                 vec![]
             }
-            "/compact" => {
-                if self.status == Status::Streaming {
-                    self.queue_compact();
-                    return vec![];
-                }
-                self.status = Status::Streaming;
-                vec![Action::Compact]
-            }
+            "/compact" => self.request_compact(),
             "/help" => {
                 self.help_modal.toggle();
                 vec![]

--- a/maki-ui/src/app/queue.rs
+++ b/maki-ui/src/app/queue.rs
@@ -126,6 +126,9 @@ impl App {
         let Some(ref shared) = self.queue.shared else {
             return;
         };
+        if shared.has_compact() {
+            return;
+        }
         shared.push(QueueItem::Compact {
             run_id: self.run_id,
         });

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -235,6 +235,10 @@ impl<'t> EventLoop<'t> {
 
         handles.apply_to_app(&mut app);
 
+        if let (Some(handle), Some(history)) = (&app.lua_event_handle, &app.shared_history) {
+            handle.set_history(Arc::clone(history));
+        }
+
         if !handles.mcp_config_errors.is_empty() {
             app.flash(format!("MCP config error: {}", handles.mcp_config_errors));
         }
@@ -324,6 +328,7 @@ impl<'t> EventLoop<'t> {
             self.app.update_model(&slot_model.model);
         }
 
+        let mut pending_actions: Vec<Action> = Vec::new();
         if let Some(rx) = &self.ui_action_rx {
             while let Ok(action) = rx.try_recv() {
                 match action {
@@ -355,8 +360,14 @@ impl<'t> EventLoop<'t> {
                                 .transition_plan(crate::app::mode::PlanTrigger::InteractivePrompt);
                         }
                     }
+                    UiAction::Compact => {
+                        pending_actions.extend(self.app.request_compact());
+                    }
                 }
             }
+        }
+        if !pending_actions.is_empty() {
+            self.dispatch(pending_actions);
         }
 
         had_agent_msg
@@ -438,6 +449,11 @@ impl<'t> EventLoop<'t> {
             &mut self.app,
             lua_handle,
         );
+        if let (Some(handle), Some(history)) =
+            (&self.app.lua_event_handle, &self.app.shared_history)
+        {
+            handle.set_history(Arc::clone(history));
+        }
     }
 
     fn handle_action(&mut self, action: Action) {


### PR DESCRIPTION
## What

Exposes a small set of plugin primitives so an idle-auto-compaction flow can be written as a user Lua plugin instead of being special-cased in core. Inspired by the discussion on #442, where the preference was to expose general primitives rather than hardcode idle-compaction.

## Primitives added

- `maki.uv.new_timer()` with `start/stop/close/again/set_repeat/get_repeat/is_active/is_closed`, and `maki.uv.hrtime()`. Signatures mirror `vim.uv` (luv). Callbacks marshal through a new `Request::TimerFire` so they run on the single-threaded Lua runtime.
- `UserInput` autocmd, fired from `handle_submit` on every submitted message. Lets a plugin observe idle gaps and reset/schedule timers.
- `UiAction::Compact`, routed through the existing `App::request_compact` (the same path `/compact` uses), so plugins trigger compaction without touching `History` directly (reentrancy safe).
- `maki.agent.compact()` (returns nil) and `maki.agent.history_len()` (reads a `SharedMessages` mirror) for introspection.
- `EventHandle::set_history` + `Request::SetHistory` plumbing so the agent mirror stays in sync.

## Why this shape

One real new primitive (`new_timer`) plus a new event, and three thin control functions that reuse existing seams. No changes to `History` or the agent loop internals. The compaction decision (thresholds, idle window) lives entirely in user config, where it belongs.

## Example plugin

`maki-lua/tests/fixtures/idle_compact.lua` shows the pattern: register a `UserInput` autocmd, start an idle timer, fire compaction when the threshold is crossed.

## Verification

- `cargo clippy --all --tests -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- `cargo nextest run -p maki-lua -p maki-ui`: 1554 passed
- Integration tests in `maki-lua/tests/idle_compact.rs` cover the timer dispatch path end-to-end via `PluginHost` (one-shot + repeating timers run the callback on the real runtime thread), and the `UserInput` autocmd fired through `EventHandle`.
- `just gen-docs-check` passes.

### Pre-existing, unrelated failures

Two `maki-agent` instruction tests fail on `main` as well as here: `load_instructions_empty_when_*` read `~/.config/maki/AGENTS.md` from the test environment. Confirmed not introduced by this change.

`just ci` steps I could not run locally: `pylint` (needs `ty` / basedpyright) and `machete` (needs `cargo-machete`). Both pass on the parts that are installed (ruff, clippy, fmt, gen-docs-check).

## Follow-ups (not in this PR)

- Auto-discovery: load `~/.config/maki/plugins/<name>/init.lua` based on `[tools]` config, so the plugin works without explicit `load_source`.
- Verify `set_history` edge case in the `restore_session` path.

## AI use

Designed and implemented with an AI coding agent (maki). Used parallel subagents for review passes (parity with luv, API surface, reentrancy). Prompts followed the style in CONTRIBUTING (KISS/DRY/SRP, eliminate classes of bugs, review for 2am maintainability).