### PR TITLE
fix(ui): drop stray spaces when copying CJK selection

### DIFF
--- a/maki-ui/src/selection.rs
+++ b/maki-ui/src/selection.rs
@@ -35,7 +35,7 @@ use ratatui::layout::Rect;
 use ratatui::style::Modifier;
 use ratatui::text::Line;
 
-use unicode_width::UnicodeWidthChar;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::theme;
 use maki_markdown::render::{CODE_BAR, CODE_BAR_WRAP};
@@ -549,8 +549,24 @@ pub(crate) fn append_rows(
 
         let (col_start, col_end) = col_range(ss, area.x, right, row);
         let line_start = out.len();
+        // A wide grapheme (CJK, emoji) occupies its first cell and leaves the
+        // following cell(s) as `Cell::EMPTY`, whose `symbol()` returns " ". We
+        // must skip those continuation cells or every wide char gains a space.
+        let mut skip_next: usize = if col_start > area.x {
+            let prev_w = UnicodeWidthStr::width(buf[(col_start - 1, row)].symbol());
+            prev_w.saturating_sub(1)
+        } else {
+            0
+        };
         for col in col_start..=col_end {
-            out.push_str(buf[(col, row)].symbol());
+            if skip_next > 0 {
+                skip_next -= 1;
+                continue;
+            }
+            let sym = buf[(col, row)].symbol();
+            let w = UnicodeWidthStr::width(sym);
+            out.push_str(sym);
+            skip_next = w.saturating_sub(1);
         }
 
         let stripped = if col_start == area.x {
@@ -1120,6 +1136,9 @@ mod tests {
     #[test_case("abcde fghij", 5, "abcde fghij" ; "word_fills_row_exactly")]
     #[test_case("ab cd ef",    3, "ab cd ef"    ; "three_short_words")]
     #[test_case("a    b",      4, "a b"         ; "many_spaces_between_words")]
+    #[test_case("你好世界",    4, "你好世界"   ; "cjk_wraps_no_extra_spaces")]
+    #[test_case("你好world",  10, "你好world"  ; "cjk_mixed_ascii")]
+    #[test_case("a你b好",     10, "a你b好"     ; "mixed_single_double_width")]
     fn wrap_copy(input: &str, width: u16, expected: &str) {
         assert_eq!(wrap_extract(input, width), expected);
     }
@@ -1262,5 +1281,50 @@ mod tests {
         };
         let text = extract_selected_text(&buf, &ss(0, 0, height - 1, 5), &[region]);
         assert_eq!(text, "hello world\nok");
+    }
+
+    #[test]
+    fn append_rows_cjk_no_padding_spaces() {
+        use ratatui::widgets::{Paragraph, Widget, Wrap};
+        let lines = vec![Line::from("你好世界")];
+        let area = Rect::new(0, 0, 10, 1);
+        let mut buf = Buffer::empty(area);
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: false })
+            .render(area, &mut buf);
+        let mut out = String::new();
+        append_rows(
+            &buf,
+            area,
+            &ss(0, 0, 0, 9),
+            0,
+            1,
+            &mut out,
+            &LineBreaks::EveryRow,
+        );
+        assert_eq!(out, "你好世界");
+    }
+
+    #[test]
+    fn append_rows_partial_from_wide_continuation() {
+        use ratatui::widgets::{Paragraph, Widget, Wrap};
+        let lines = vec![Line::from("你好")];
+        let area = Rect::new(0, 0, 4, 1);
+        let mut buf = Buffer::empty(area);
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: false })
+            .render(area, &mut buf);
+        let mut out = String::new();
+        // selection starts on the continuation cell of 你 (col 1)
+        append_rows(
+            &buf,
+            area,
+            &ss(0, 1, 0, 3),
+            0,
+            1,
+            &mut out,
+            &LineBreaks::EveryRow,
+        );
+        assert_eq!(out, "好");
     }
 }


### PR DESCRIPTION
## Problem

Selecting Chinese (or other wide-char) text and releasing the mouse to auto-copy pastes with a stray space after every character, e.g. `你好世界` → `你 好 世 界 `.

## Root cause

`append_rows` in `maki-ui/src/selection.rs` scrapes text cell-by-cell:

```rust
for col in col_start..=col_end {
    out.push_str(buf[(col, row)].symbol());
}
```

ratatui renders a wide grapheme (CJK/emoji) into its first buffer cell and leaves the continuation cell as `Cell::EMPTY`, whose `symbol()` returns `" "` (ratatui-core `cell.rs`: `EMPTY.symbol = None`, `symbol()` maps `None` → `" "`). The scrape therefore emits a space after every wide character. `Paragraph::render_line` doesn't touch the continuation cell or set `skip`, so this affects all copy paths that funnel through `append_rows` (Messages, Input partial, Overlay).

## Fix

Track the previous character's display width (`UnicodeWidthStr::width`) and skip that many continuation cells, including the boundary case where the selection starts mid-glyph on a continuation cell:

```rust
let mut skip_next: usize = if col_start > area.x {
    UnicodeWidthStr::width(buf[(col_start - 1, row)].symbol()).saturating_sub(1)
} else { 0 };
for col in col_start..=col_end {
    if skip_next > 0 { skip_next -= 1; continue; }
    let sym = buf[(col, row)].symbol();
    let w = UnicodeWidthStr::width(sym);
    out.push_str(sym);
    skip_next = w.saturating_sub(1);
}
```

ASCII is unaffected (`width == 1` → `skip_next == 0`).

## Tests

- `wrap_copy`: CJK-only with wrapping, CJK+ASCII mix, interleaved single/double width.
- `append_rows_cjk_no_padding_spaces`: full-row CJK selection yields `你好世界`.
- `append_rows_partial_from_wide_continuation`: selection starting on a continuation cell yields just `好`.

## Verification

- `cargo test -p maki-ui --lib` → 1031 passed.
- `cargo clippy --all --tests -- -D warnings` → clean.