### PR TITLE
Fix Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -34,12 +34,12 @@
               # rebuild to get the correct value.
               outputHashes = {
                 "monty-0.0.18" = "sha256-p9mDjS9FTvsITU98B8AeyUCk4wQhgk71HoyOsNPpB0Y=";
-                "ruff_python_ast-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
-                "ruff_python_parser-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
-                "ruff_python_stdlib-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
-                "ruff_python_trivia-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
-                "ruff_source_file-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
-                "ruff_text_size-0.0.0" = "sha256-nVQC4ZaLWiZBUEReLqzpXKxXVxCdUW6b+mda9J8JSA0=";
+                "ruff_python_ast-0.0.0" = "sha256-m5U5OVUvhn5t3yTSSbT/JA+xmydEDQq+zKFNMN7K/MI=";
+                "ruff_python_parser-0.0.0" = "sha256-m5U5OVUvhn5t3yTSSbT/JA+xmydEDQq+zKFNMN7K/MI=";
+                "ruff_python_stdlib-0.0.0" = "sha256-m5U5OVUvhn5t3yTSSbT/JA+xmydEDQq+zKFNMN7K/MI=";
+                "ruff_python_trivia-0.0.0" = "sha256-m5U5OVUvhn5t3yTSSbT/JA+xmydEDQq+zKFNMN7K/MI=";
+                "ruff_source_file-0.0.0" = "sha256-m5U5OVUvhn5t3yTSSbT/JA+xmydEDQq+zKFNMN7K/MI=";
+                "ruff_text_size-0.0.0" = "sha256-m5U5OVUvhn5t3yTSSbT/JA+xmydEDQq+zKFNMN7K/MI=";
               };
             };
             cargoBuildFlags = [
@@ -56,9 +56,12 @@
             # the relative path
             postPatch = ''
               for f in "$cargoDepsCopy"/monty-*/src/lib.rs; do
+              # monty-macros doesn't include the readme
+              if [[ "$f" != *"monty-macros"* ]]; then
                 substituteInPlace "$f" \
                   --replace-fail '#![doc = include_str!("../../../README.md")]' \
                                  '#![doc = "Monty Python bridge."]'
+              fi
               done
             '';
             buildInputs = with pkgs; [ openssl ];


### PR DESCRIPTION
Hello I tried to build maki using the Nix flake (`nix build .`) and had some issues. I run git bisect and it flagged https://github.com/tontinton/maki/pull/410 as the PR where the flake stopped working.

Here I changed:
- `nix flake update nixpkgs` to pick up a newer Rust compiler, as required by `monty` 0.18;
- hashes of the `ruff` dependencies
- exclude `monty-macro` from the paths where we remove the references to `README.md` because it is not referenced

After these changes `nix build .` works again. I am wondering if the project should have a GitHub action to check that the flake builds correctly. It shouldn't be too difficult to add it but I am not sure if there is appetite to have it.