### PR TITLE
feat(providers): add opencode enable_free_models option, default false

### DIFF
--- a/maki-config/src/providers.rs
+++ b/maki-config/src/providers.rs
@@ -143,6 +143,10 @@ pub struct ProviderDef {
     pub default_model: Option<String>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub discover_models: bool,
+    /// Opencode-only: when `Some(false)`, free catalog models are hidden
+    /// entirely. Defaults to `false` when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enable_free_models: Option<bool>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub models: Vec<ModelDef>,
 }
@@ -325,6 +329,7 @@ mod tests {
                 base_url: Some("https://api.example.com/v1".into()),
                 api_key_env: Some("MY_API_KEY".into()),
                 discover_models: true,
+                enable_free_models: Some(false),
                 ..Default::default()
             },
         );
@@ -338,6 +343,18 @@ mod tests {
             parsed.get("my-provider").unwrap().base_url,
             Some("https://api.example.com/v1".into())
         );
+        assert_eq!(
+            parsed.get("my-provider").unwrap().enable_free_models,
+            Some(false)
+        );
+    }
+
+    const EMPTY_PROVIDER_DEF_TOML: &str = "";
+
+    #[test]
+    fn provider_def_enable_free_models_defaults_none() {
+        let def: ProviderDef = toml::from_str(EMPTY_PROVIDER_DEF_TOML).unwrap();
+        assert_eq!(def.enable_free_models, None);
     }
 
     const UNKNOWN_TIER_TOML: &str = r#"id = "x"

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -35,6 +35,15 @@ You will need `AWS_REGION` and one of the following for auth:
 
 You can override the model with `ANTHROPIC_MODEL` and the endpoint with `ANTHROPIC_BEDROCK_BASE_URL`. These env var names match Claude Code, so if you were already using Bedrock there, the same setup works here."#;
 
+const OPENCODE_FREE_MODELS_NOTE: &str = r#"By default Maki hides free models from the Opencode catalog. To list free models (they use a public fallback, no API key needed), add this to `~/.config/maki/providers.toml`:
+
+```toml
+[opencode]
+enable_free_models = true
+```
+
+The default is `false`."#;
+
 const MODEL_IDENTIFIERS: &str = r#"## Model Identifiers
 
 Models are referenced as `provider/model_id`:
@@ -299,6 +308,10 @@ fn write_section(out: &mut String, section: &ProviderSection) {
     if section.name == "Anthropic" {
         let _ = writeln!(out, "\n{LONG_CONTEXT_NOTE}");
         let _ = writeln!(out, "\n{BEDROCK_NOTE}");
+    }
+
+    if section.kind == ProviderKind::Opencode {
+        let _ = writeln!(out, "\n{OPENCODE_FREE_MODELS_NOTE}");
     }
 }
 

--- a/maki-providers/src/providers/opencode.rs
+++ b/maki-providers/src/providers/opencode.rs
@@ -463,7 +463,7 @@ fn determine_catalog_format(npm: &str) -> EndpointType {
 
 const ALLOWED_NPM: &[&str] = &["@ai-sdk/openai-compatible", "@ai-sdk/anthropic"];
 
-fn catalog_to_data(index: CatalogIndex) -> CatalogData {
+fn catalog_to_data(index: CatalogIndex, enable_free_models: bool) -> CatalogData {
     let mut entries: HashMap<ModelWithProvider, CatalogMeta> = HashMap::new();
     let mut auths = HashMap::new();
 
@@ -494,6 +494,10 @@ fn catalog_to_data(index: CatalogIndex) -> CatalogData {
                 .and_then(|c| c.output)
                 .unwrap_or(0.0);
             let is_free = input_price == 0.0 && output_price == 0.0;
+
+            if is_free && !enable_free_models {
+                continue;
+            }
 
             if !(has_key || provider_id == "opencode" && is_free) {
                 continue;
@@ -555,10 +559,14 @@ fn catalog_to_data(index: CatalogIndex) -> CatalogData {
 }
 
 fn init_catalog_blocking() -> CatalogData {
+    let enable_free_models = maki_config::providers::ProvidersConfig::load()
+        .get("opencode")
+        .and_then(|d| d.enable_free_models)
+        .unwrap_or(false);
     // Try cache first (fast, no network)
     if let Some(index) = smol::block_on(load_cached_catalog_async()) {
         debug!("using cached catalog");
-        return catalog_to_data(index);
+        return catalog_to_data(index, enable_free_models);
     }
 
     // Fetch from remote (blocks the current thread)
@@ -571,7 +579,7 @@ fn init_catalog_blocking() -> CatalogData {
     match smol::block_on(fetch_remote_catalog_async(&client)) {
         Ok(index) => {
             smol::block_on(save_cached_catalog_async(&index));
-            catalog_to_data(index)
+            catalog_to_data(index, enable_free_models)
         }
         Err(e) => {
             warn!(error = %e, "catalog fetch failed, using empty catalog");
@@ -798,7 +806,7 @@ mod tests {
             },
         );
 
-        let result = catalog_to_data(providers);
+        let result = catalog_to_data(providers, true);
         // Without env var, NO models should pass (not even free ones for non-opencode)
         assert!(
             result.entries.is_empty(),
@@ -849,7 +857,7 @@ mod tests {
             },
         );
 
-        let result = catalog_to_data(providers);
+        let result = catalog_to_data(providers, true);
         // Without key set, has_api_key is false, so only free models pass
         // but has_api_key is false, so only free models pass
         assert!(
@@ -909,7 +917,7 @@ mod tests {
         );
 
         unsafe { std::env::set_var("MAKI_TEST_OPENCODE_ALL_81274", "real-key") };
-        let result = catalog_to_data(providers);
+        let result = catalog_to_data(providers, true);
         unsafe { std::env::remove_var("MAKI_TEST_OPENCODE_ALL_81274") };
 
         // With key set, has_api_key is true, so all models pass
@@ -924,6 +932,85 @@ mod tests {
                 .contains_key(&("opencode".into(), "paid-model".into()))
         );
         assert!(result.auths.contains_key("opencode"));
+    }
+
+    fn opencode_catalog_with_free_and_paid(env_var: &str) -> CatalogIndex {
+        let mut models = HashMap::new();
+        models.insert(
+            "paid-model".into(),
+            CatalogModel {
+                limit: None,
+                cost: Some(CatalogCost {
+                    input: Some(5.0),
+                    output: Some(25.0),
+                    cache_read: None,
+                    cache_write: None,
+                }),
+                provider: None,
+            },
+        );
+        models.insert(
+            "free-model".into(),
+            CatalogModel {
+                limit: None,
+                cost: Some(CatalogCost {
+                    input: Some(0.0),
+                    output: Some(0.0),
+                    cache_read: None,
+                    cache_write: None,
+                }),
+                provider: None,
+            },
+        );
+        let mut providers = HashMap::new();
+        providers.insert(
+            "opencode".into(),
+            CatalogProvider {
+                name: "Opencode".into(),
+                env: vec![env_var.into()],
+                npm: "@ai-sdk/openai-compatible".into(),
+                api: Some("https://opencode.ai/zen/v1".into()),
+                models,
+            },
+        );
+        providers
+    }
+
+    const DISABLE_FREE_TEST_KEY: &str = "MAKI_TEST_OPENCODE_DISABLE_FREE_94421";
+
+    #[test]
+    fn catalog_to_data_opencode_hides_free_models_when_disabled() {
+        unsafe { std::env::set_var(DISABLE_FREE_TEST_KEY, "real-key") };
+        let index = opencode_catalog_with_free_and_paid(DISABLE_FREE_TEST_KEY);
+        let result = catalog_to_data(index, false);
+        unsafe { std::env::remove_var(DISABLE_FREE_TEST_KEY) };
+
+        assert!(
+            !result
+                .entries
+                .contains_key(&("opencode".into(), "free-model".into())),
+            "free model should be hidden when enable_free_models=false: {:?}",
+            result.entries.keys()
+        );
+        assert!(
+            result
+                .entries
+                .contains_key(&("opencode".into(), "paid-model".into()))
+        );
+        assert!(result.auths.contains_key("opencode"));
+    }
+
+    #[test]
+    fn catalog_to_data_opencode_no_models_without_key_when_disabled() {
+        let index = opencode_catalog_with_free_and_paid(DISABLE_FREE_TEST_KEY);
+        let result = catalog_to_data(index, false);
+
+        assert!(
+            result.entries.is_empty(),
+            "no models should be listed without a key when enable_free_models=false: {:?}",
+            result.entries.keys()
+        );
+        assert!(!result.auths.contains_key("opencode"));
     }
 
     #[test]
@@ -970,7 +1057,7 @@ mod tests {
 
         // Set the env var so has_key = true
         unsafe { std::env::set_var("MAKI_TEST_VENDOR_KEY_81274", "test-key") };
-        let result = catalog_to_data(providers);
+        let result = catalog_to_data(providers, true);
         unsafe { std::env::remove_var("MAKI_TEST_VENDOR_KEY_81274") };
 
         assert!(
@@ -999,7 +1086,7 @@ mod tests {
             },
         );
 
-        let result = catalog_to_data(providers);
+        let result = catalog_to_data(providers, true);
         assert!(result.entries.is_empty());
         assert!(result.auths.is_empty());
     }
@@ -1052,7 +1139,7 @@ mod tests {
         );
 
         unsafe { std::env::set_var("MAKI_TEST_OTHER_KEY_COLLISION", "key") };
-        let result = catalog_to_data(providers);
+        let result = catalog_to_data(providers, true);
         unsafe { std::env::remove_var("MAKI_TEST_OTHER_KEY_COLLISION") };
 
         // Both providers' entries are preserved
@@ -1102,7 +1189,7 @@ mod tests {
             },
         );
 
-        let data = catalog_to_data(providers);
+        let data = catalog_to_data(providers, true);
         let (meta, _) = data.lookup("opencode/opus").unwrap();
         assert_eq!(meta.provider_id, "opencode");
     }
@@ -1136,7 +1223,7 @@ mod tests {
         );
 
         unsafe { std::env::set_var("MAKI_TEST_NVIDIA_KEY_LOOKUP", "key") };
-        let data = catalog_to_data(providers);
+        let data = catalog_to_data(providers, true);
         unsafe { std::env::remove_var("MAKI_TEST_NVIDIA_KEY_LOOKUP") };
 
         // Entry is stored as ("nvidia", "openai/gpt-oss-120b")
@@ -1176,7 +1263,7 @@ mod tests {
         );
 
         unsafe { std::env::set_var("MAKI_TEST_NVIDIA_DIRECT", "key") };
-        let data = catalog_to_data(providers);
+        let data = catalog_to_data(providers, true);
         unsafe { std::env::remove_var("MAKI_TEST_NVIDIA_DIRECT") };
 
         // The lookup key constructed by stream_message:
@@ -1216,7 +1303,7 @@ mod tests {
         );
 
         unsafe { std::env::set_var("MAKI_TEST_FIREWORKS_DEEP", "key") };
-        let data = catalog_to_data(providers);
+        let data = catalog_to_data(providers, true);
         unsafe { std::env::remove_var("MAKI_TEST_FIREWORKS_DEEP") };
 
         // stream_message constructs key as "{sub_provider}/{model.id}"

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -186,6 +186,15 @@ No hardcoded model catalog. Use any model ID supported by this provider.
 
 No hardcoded model catalog. Use any model ID supported by this provider.
 
+By default Maki hides free models from the Opencode catalog. To list free models (they use a public fallback, no API key needed), add this to `~/.config/maki/providers.toml`:
+
+```toml
+[opencode]
+enable_free_models = true
+```
+
+The default is `false`.
+
 ## Model Identifiers
 
 Models are referenced as `provider/model_id`:


### PR DESCRIPTION
## Summary

Adds an `enable_free_models` option to the `[opencode]` section of `providers.toml`, letting users show or hide free models from the Opencode catalog. **Default is `false`** (free models hidden).

## Background

The Opencode provider lists models from the [models.dev](https://models.dev/) catalog. Free models can be shown even without an `OPENCODE_API_KEY` (they use a public fallback key). Since free models can be noisy and not always desirable, they are now hidden by default; users who want them can opt in.

## Changes

- **`maki-config`**: add `enable_free_models: Option<bool>` to `ProviderDef`. Defaults to `false` (`None` resolves to `false`). `Option<bool>` is used so `derive(Default)` and the serde default agree, and non-opencode providers stay clean in serialized output.
- **`maki-providers` (`opencode.rs`)**: `catalog_to_data` now takes `enable_free_models`. When `false`, all free models are filtered out regardless of key; paid models still require a key. So `enable_free_models = false` (default) + no `OPENCODE_API_KEY` ⇒ no Opencode models are listed.
- **Docs**: regenerated provider docs (`maki-docgen`) with a note under the Opencode section.

## Usage

```toml
# ~/.config/maki/providers.toml
[opencode]
enable_free_models = true   # show free models (opt-in); default is false
```

| `enable_free_models` | `OPENCODE_API_KEY` | Result |
|---|---|---|
| `false` (default) | unset | no models listed |
| `false` (default) | set | paid models only |
| `true` | unset | free models via public fallback |
| `true` | set | all models |

## Notes

- The model list comes from `models.dev`, not an Opencode `/models` endpoint. `enable_free_models` only affects filtering of the fetched catalog; it does not change whether the catalog is fetched.
- Config is read once at first catalog init; restart maki to pick up `providers.toml` changes.

## Verification

- `cargo fmt --all`
- `cargo clippy --all --tests -- -D warnings`
- `cargo test -p maki-config -p maki-providers` (411 passed)
- `cargo run -p maki-docgen -- --check`