### PR TITLE
feat(permissions): ToolKey enum, specificity-aware resolution, MCP nesting

### DIFF
--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -12,6 +12,7 @@ use crate::task_set::TaskSet;
 use crate::tools::registry::{ToolInvocation, ToolRegistry};
 use crate::tools::{LocalToolFn, ToolContext};
 use crate::{AgentError, AgentEvent, ToolDoneEvent, ToolOutput, ToolStartEvent};
+use maki_config::ToolKey;
 
 #[derive(Clone, Copy)]
 pub enum Emit {
@@ -71,10 +72,20 @@ pub async fn run(
         return run_local_tool(local, id, name, input, ctx, emit);
     }
     let entry = registry.get(name);
+    // LLM providers send tool names in wire format (server__tool) but our
+    // internal index uses server.tool. Only convert if the name isn't a
+    // native tool — avoids mangling native names that happen to contain __.
+    let mcp_name;
+    let mcp_lookup = if entry.is_none() && name.contains("__") && mcp.is_some() {
+        mcp_name = crate::mcp::internal_tool_name(name);
+        mcp_name.as_str()
+    } else {
+        name
+    };
     let tool_id: Arc<str> = entry
         .as_ref()
         .map(|e| Arc::from(e.tool.name()))
-        .or_else(|| mcp.map(|m| m.interned_name(name)))
+        .or_else(|| mcp.map(|m| m.interned_name(mcp_lookup)))
         .unwrap_or_else(|| Arc::from(UNKNOWN_MCP));
     let started = Instant::now();
 
@@ -171,12 +182,12 @@ pub async fn run(
                 done_error(message)
             }
         }
-    } else if mcp.is_some_and(|m| m.has_tool(name)) {
+    } else if mcp.is_some_and(|m| m.has_tool(mcp_lookup)) {
         // MCP tools skip parsing, so we assemble the start event manually.
         let start = ToolStartEvent {
             id: id.clone(),
             tool: Arc::clone(&tool_id),
-            summary: format!("mcp: {name}"),
+            summary: format!("mcp: {mcp_lookup}"),
             render_header: None,
             annotation: None,
             input: None,
@@ -186,10 +197,10 @@ pub async fn run(
         if matches!(emit, Emit::Notify) {
             let _ = ctx.event_tx.send(AgentEvent::ToolStart(Box::new(start)));
         }
-        execute_mcp_tool(ctx, &id, tool_id, name, input).await
+        execute_mcp_tool(ctx, &id, tool_id, mcp_lookup, input).await
     } else {
-        let msg = format!("{UNKNOWN_TOOL_PREFIX}: {name}");
-        warn!(tool = %name, "unknown tool");
+        let msg = format!("{UNKNOWN_TOOL_PREFIX}: {mcp_lookup}");
+        warn!(tool = %mcp_lookup, "unknown tool");
         done_error(msg)
     }
 }
@@ -233,16 +244,26 @@ fn run_local_tool(
     }
 }
 
+/// Enforce permission for a native tool. MCP tools bypass this — they go
+/// through `execute_mcp_tool` which handles permission checking internally.
+///
+/// Returns an error if `name` contains dots (not a valid native tool name).
 async fn enforce_permission(
     inv: &dyn ToolInvocation,
     name: &str,
     ctx: &ToolContext,
     id: &str,
 ) -> Result<(), String> {
+    if name.contains('.') {
+        return Err(format!(
+            "enforce_permission called with dotted name: {name}"
+        ));
+    }
     if let Some(scopes) = inv.permission_scopes().await {
+        let tool_key = ToolKey::native(name);
         ctx.permissions
             .enforce(
-                name,
+                &tool_key,
                 &scopes,
                 &ctx.event_tx,
                 ctx.user_response_rx.as_deref(),
@@ -276,7 +297,12 @@ async fn execute_mcp_tool(
         return done(MCP_BLOCKED_IN_PLAN.into(), true);
     }
 
-    let perm_tool = format!("mcp:{tool_name}");
+    let perm_tool = match ToolKey::parse(tool_name) {
+        Ok(k) => k,
+        Err(e) => {
+            return done(format!("invalid MCP tool key '{tool_name}': {e}"), true);
+        }
+    };
     let perm_scope = {
         let json = input.to_string();
         if json.len() > 200 {
@@ -425,7 +451,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
-    use maki_config::{Effect, PermissionRule, PermissionsConfig};
+    use maki_config::{Effect, PermissionRule, PermissionsConfig, ToolKey};
     use tempfile::TempDir;
     use test_case::test_case;
 
@@ -548,7 +574,7 @@ mod tests {
                 &ctx.registry,
                 None,
                 "t1".into(),
-                "nonexistent__tool",
+                "nonexistent.tool",
                 &serde_json::json!({}),
                 &ctx,
                 Emit::Silent,
@@ -558,7 +584,7 @@ mod tests {
             assert_eq!(done.tool.as_ref(), UNKNOWN_MCP);
             let text = done.output.as_text();
             assert!(text.starts_with(UNKNOWN_TOOL_PREFIX));
-            assert!(text.contains("nonexistent__tool"));
+            assert!(text.contains("nonexistent.tool"));
         });
     }
 
@@ -570,7 +596,7 @@ mod tests {
                     "/tmp/plan.md",
                 ))),
                 "t1",
-                "myserver__mytool",
+                "myserver.mytool",
                 &serde_json::json!({}),
             )
             .await;
@@ -585,7 +611,7 @@ mod tests {
             let result = dispatch_mcp(
                 &crate::tools::test_support::stub_ctx(&AgentMode::Build),
                 "t1",
-                "myserver__mytool",
+                "myserver.mytool",
                 &serde_json::json!({}),
             )
             .await;
@@ -599,7 +625,7 @@ mod tests {
         smol::block_on(async {
             let deny_cfg = PermissionsConfig {
                 rules: vec![PermissionRule {
-                    tool: GUARDED_TOOL_NAME.into(),
+                    tool: ToolKey::native(GUARDED_TOOL_NAME),
                     scope: None,
                     effect: Effect::Deny,
                 }],
@@ -707,7 +733,7 @@ mod tests {
         smol::block_on(async {
             let deny_cfg = PermissionsConfig {
                 rules: vec![PermissionRule {
-                    tool: START_PROBE_NAME.into(),
+                    tool: ToolKey::native(START_PROBE_NAME),
                     scope: None,
                     effect: Effect::Deny,
                 }],

--- a/maki-agent/src/mcp/config.rs
+++ b/maki-agent/src/mcp/config.rs
@@ -6,10 +6,9 @@ use std::time::Duration;
 use serde::Deserialize;
 use toml_edit::DocumentMut;
 
-use super::SEPARATOR;
 use super::error::McpError;
 use crate::tools::is_builtin_tool;
-use maki_config::global_config_dir;
+use maki_config::{global_config_dir, is_valid_server_name};
 
 const MCP_CONFIG_FILE: &str = "mcp.toml";
 const DEFAULT_TIMEOUT_MS: u64 = 30_000;
@@ -183,11 +182,7 @@ pub enum Transport {
     },
 }
 
-fn is_valid_server_name(name: &str) -> bool {
-    !name.is_empty()
-        && !name.contains(SEPARATOR)
-        && name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
-}
+pub(super) use maki_config::is_valid_wire_name as is_valid_tool_name;
 
 impl McpConfig {
     pub fn is_empty(&self) -> bool {

--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -1,6 +1,6 @@
 //! MCP client: manages transports and routes tool calls to servers.
 //!
-//! Tool names are namespaced as `server__tool` so two servers can both expose `search`
+//! Tool names are namespaced as `server.tool` so two servers can both expose `search`
 //! without colliding. Names are deduped via `Arc<str>` in a small cache.
 //!
 //! All mutable state lives in the `run` task, which owns `McpManagerInner` exclusively.
@@ -37,8 +37,25 @@ use self::http::HttpTransport;
 use self::stdio::StdioTransport;
 use self::transport::McpTransport;
 
-const SEPARATOR: &str = "__";
+const SEPARATOR: &str = ".";
+const WIRE_SEPARATOR: &str = "__";
 pub const UNKNOWN_MCP: &str = "unknown_mcp";
+
+/// Convert internal qualified name (`server.tool`) to wire format (`server__tool`)
+/// for LLM provider APIs that reject dots in tool names.
+///
+/// Lossless: server names can't contain `__` (only alphanumeric + `-`),
+/// so the first `__` in the wire name is always the separator boundary.
+pub fn wire_tool_name(qualified: &str) -> String {
+    qualified.replacen(SEPARATOR, WIRE_SEPARATOR, 1)
+}
+
+/// Convert wire format (`server__tool`) back to internal qualified name (`server.tool`).
+///
+/// Only the first `__` is the separator — tool names may contain underscores.
+pub fn internal_tool_name(wire: &str) -> String {
+    wire.replacen(WIRE_SEPARATOR, SEPARATOR, 1)
+}
 const MCP_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
 struct McpToolDef {
@@ -114,6 +131,24 @@ impl ServerEntry {
         } = result;
         self.tools = tool_infos
             .into_iter()
+            .filter(|info| {
+                if !config::is_valid_tool_name(&info.name) {
+                    warn!(tool = %info.name, server = %self.name, "skipping tool with invalid name");
+                    return false;
+                }
+                // Wire format is server__tool — check total length fits LLM API limits
+                let wire_len = self.name.len() + 2 + info.name.len();
+                if wire_len > 64 {
+                    warn!(
+                        tool = %info.name,
+                        server = %self.name,
+                        wire_len,
+                        "skipping tool — wire name exceeds 64 char LLM API limit"
+                    );
+                    return false;
+                }
+                true
+            })
             .map(|info| McpToolDef {
                 qualified_name: intern(format!("{}{SEPARATOR}{}", self.name, info.name)),
                 raw_name: info.name,
@@ -634,7 +669,7 @@ fn publish(inner: &McpManagerInner, index: &ArcSwap<ToolIndex>, snapshot: &ArcSw
                     },
                 );
                 descriptors.push(json!({
-                    "name": t.qualified_name.as_ref(),
+                    "name": wire_tool_name(&t.qualified_name),
                     "description": t.description,
                     "input_schema": t.input_schema,
                 }));
@@ -750,7 +785,8 @@ mod tests {
         McpConfig { mcp, origins }
     }
 
-    const TOOL_NAME: &str = "srv__tool";
+    const TOOL_NAME: &str = "srv.tool";
+    const WIRE_TOOL_NAME: &str = "srv__tool";
 
     /// Counts shutdowns, signals on `call_entered` the moment a `tools/call` begins, and holds
     /// the call inside `call_gate` until tests release it. That way tests can meet an in-flight
@@ -918,7 +954,7 @@ mod tests {
             assert!(handle.has_tool(TOOL_NAME));
             let mut tools = json!([]);
             handle.extend_tools(&mut tools);
-            assert_eq!(tools[0]["name"], TOOL_NAME);
+            assert_eq!(tools[0]["name"], WIRE_TOOL_NAME);
 
             handle_toggle(&mut inner, "srv", false).await;
             publish(&inner, &handle.index, &handle.snapshot);
@@ -992,5 +1028,22 @@ mod tests {
             assert_eq!(t2.shutdowns(), 1);
             assert!(snapshot.load().infos.iter().all(|i| i.tool_count == 0));
         });
+    }
+
+    #[test]
+    fn is_valid_tool_name_enforces_wire_format() {
+        use config::is_valid_tool_name;
+        // Valid: alphanumeric, underscore, hyphen, 1-64 chars
+        assert!(is_valid_tool_name("search"));
+        assert!(is_valid_tool_name("web_search"));
+        assert!(is_valid_tool_name("my-tool"));
+        assert!(is_valid_tool_name(&"a".repeat(64)));
+        // Invalid: empty, dots, special chars, too long
+        assert!(!is_valid_tool_name(""));
+        assert!(!is_valid_tool_name("web.search"));
+        assert!(!is_valid_tool_name("admin.delete"));
+        assert!(!is_valid_tool_name("tool!"));
+        assert!(!is_valid_tool_name("*"));
+        assert!(!is_valid_tool_name(&"a".repeat(65)));
     }
 }

--- a/maki-agent/src/permissions.rs
+++ b/maki-agent/src/permissions.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use maki_config::{
     DefaultEffect, Effect, FILE_WRITE_TOOLS, PermissionRule, PermissionTarget, PermissionsConfig,
-    append_permission_rule,
+    ToolKey, append_permission_rule,
 };
 use thiserror::Error;
 use tracing::{info, warn};
@@ -24,7 +24,7 @@ fn builtin_rules(cwd: &Path) -> Vec<PermissionRule> {
         maki_storage::paths::canonicalize_clean(cwd).display()
     );
     let allow = |tool: &str, scope: &str| PermissionRule {
-        tool: tool.into(),
+        tool: ToolKey::native(tool),
         scope: Some(scope.into()),
         effect: Effect::Allow,
     };
@@ -43,7 +43,7 @@ pub enum PermissionCheck {
     Allowed,
     Denied,
     NeedsPrompt {
-        tool: String,
+        tool: ToolKey,
         scopes: Vec<String>,
         force_prompt: bool,
     },
@@ -157,16 +157,42 @@ pub struct PermissionManager {
     builtin_rules: Vec<PermissionRule>,
     yolo: AtomicBool,
     default: DefaultEffect,
-    tool_defaults: HashMap<String, DefaultEffect>,
+    tool_defaults: HashMap<ToolKey, DefaultEffect>,
     cwd: PathBuf,
 }
 
 impl PermissionManager {
     pub fn new(config: PermissionsConfig, cwd: PathBuf) -> Self {
+        let config_rules = config.rules;
+        let builtin_rules = builtin_rules(&cwd);
+
+        // Warn if wildcard deny is present — it blocks ALL tools including builtins.
+        let has_wildcard_deny = config_rules
+            .iter()
+            .any(|r| matches!(r.tool, ToolKey::Wildcard) && r.effect == Effect::Deny);
+        if has_wildcard_deny {
+            warn!(
+                "wildcard deny detected — this blocks ALL tools including \
+                 builtins (write/edit/multiedit/task). Use per-tool rules \
+                 instead if you want selective access."
+            );
+        }
+        // Warn if wildcard allow is present — it permits ALL tools including write/edit/task.
+        let has_wildcard_allow = config_rules
+            .iter()
+            .any(|r| matches!(r.tool, ToolKey::Wildcard) && r.effect == Effect::Allow);
+        if has_wildcard_allow {
+            warn!(
+                "wildcard allow detected — this permits ALL tools including \
+                 write/edit/multiedit/task. Use per-tool rules \
+                 instead if you want selective access."
+            );
+        }
+
         Self {
-            builtin_rules: builtin_rules(&cwd),
+            builtin_rules,
             session_rules: Mutex::new(Vec::new()),
-            config_rules: config.rules,
+            config_rules,
             yolo: AtomicBool::new(config.yolo),
             default: config.default,
             tool_defaults: config.tool_defaults,
@@ -183,81 +209,120 @@ impl PermissionManager {
 
     fn check_inner(
         &self,
-        tool: &str,
+        tool: &ToolKey,
         scopes: &[&str],
         force_prompt: bool,
         plan_path: Option<&Path>,
     ) -> PermissionCheck {
         let session = self.session_rules();
-        let rules = session
-            .iter()
-            .chain(&self.config_rules)
-            .chain(&self.builtin_rules);
+
+        // Any matching deny wins. No specificity hierarchy — a Wildcard
+        // deny blocks everything, a tool-specific deny blocks that tool.
+        let mut unclaimed_scopes: Vec<&str> = if force_prompt {
+            Vec::new()
+        } else {
+            Vec::with_capacity(scopes.len())
+        };
 
         for scope in scopes {
-            for rule in rules.clone() {
-                if rule.effect == Effect::Deny && matches_rule(rule, tool, scope) {
-                    info!(tool, scope = %scope, "permission denied");
-                    return PermissionCheck::Denied;
+            let mut has_allow = false;
+            for r in session
+                .iter()
+                .chain(&self.config_rules)
+                .chain(&self.builtin_rules)
+            {
+                if !matches_rule(&r.tool, tool) || !rule_matches_scope(r, scope) {
+                    continue;
+                }
+                match r.effect {
+                    Effect::Deny => {
+                        info!(tool = %tool, scope = %scope, "permission denied");
+                        return PermissionCheck::Denied;
+                    }
+                    Effect::Allow => {
+                        has_allow = true;
+                    }
                 }
             }
+
+            if has_allow {
+                // allow wins for this scope (no deny matched)
+            } else if !force_prompt {
+                unclaimed_scopes.push(scope);
+            }
+            // force_prompt: all scopes will be prompted anyway
         }
 
         if self.yolo.load(Ordering::Relaxed) {
             return PermissionCheck::Allowed;
         }
 
-        if FILE_WRITE_TOOLS.contains(&tool)
-            && let Some(pp) = plan_path
-        {
-            let plan_scope = normalize_scope_path(&pp.display().to_string());
-            if scopes.iter().any(|s| normalize_scope_path(s) == plan_scope) {
-                return PermissionCheck::Allowed;
-            }
-        }
-
-        let is_allowed = |scope: &&str| {
-            rules
-                .clone()
-                .any(|rule| rule.effect == Effect::Allow && matches_rule(rule, tool, scope))
-        };
-
         let pending: Vec<&str> = if force_prompt {
             scopes.to_vec()
         } else {
-            scopes.iter().filter(|s| !is_allowed(s)).copied().collect()
+            unclaimed_scopes
         };
 
         if pending.is_empty() {
             return PermissionCheck::Allowed;
         }
 
+        // Plan file auto-allow: fires AFTER deny rules have been evaluated.
+        // Only triggers if ALL pending scopes match the plan file path.
+        // A single non-plan scope means we must prompt for the rest.
+        if !force_prompt && !pending.is_empty() {
+            let is_plan_write = plan_path.is_some_and(|pp| {
+                matches!(tool, ToolKey::Native(name) if FILE_WRITE_TOOLS.contains(&name.as_ref()))
+                    && {
+                        let normalized_plan = normalize_scope_path(&pp.display().to_string());
+                        pending
+                            .iter()
+                            .all(|s| normalize_scope_path(s) == normalized_plan)
+                    }
+            });
+            if is_plan_write {
+                return PermissionCheck::Allowed;
+            }
+        }
+
         let eff = self
             .tool_defaults
             .get(tool)
             .copied()
+            .or_else(|| {
+                // McpTool falls back to McpServer-level default (Arc clone, ~2ns)
+                let server = match tool {
+                    ToolKey::McpTool { server, .. } => server,
+                    _ => return None,
+                };
+                self.tool_defaults
+                    .get(&ToolKey::McpServer {
+                        server: server.clone(),
+                    })
+                    .copied()
+            })
             .unwrap_or(self.default);
         match eff {
             DefaultEffect::Deny => {
-                info!(tool, "denied by default");
+                info!(tool = %tool, "denied by default");
                 PermissionCheck::Denied
             }
             DefaultEffect::Allow => PermissionCheck::Allowed,
             DefaultEffect::Prompt => PermissionCheck::NeedsPrompt {
-                tool: tool.to_string(),
+                tool: tool.clone(),
                 scopes: pending.into_iter().map(|s| s.to_string()).collect(),
                 force_prompt,
             },
         }
     }
 
-    pub fn check(&self, tool: &str, scope: &str, plan_path: Option<&Path>) -> PermissionCheck {
+    pub fn check(&self, tool: &ToolKey, scope: &str, plan_path: Option<&Path>) -> PermissionCheck {
         self.check_inner(tool, &[scope], false, plan_path)
     }
 
     pub fn check_multi(
         &self,
-        tool: &str,
+        tool: &ToolKey,
         scopes: &[&str],
         force_prompt: bool,
         plan_path: Option<&Path>,
@@ -306,8 +371,11 @@ impl PermissionManager {
         *self.session_rules() = rules;
     }
 
-    pub fn apply_decision(&self, tool: &str, scopes: &[String], answer: &PermissionAnswer) {
-        let resolved = if answer.is_allow() {
+    pub fn apply_decision(&self, tool: &ToolKey, scopes: &[String], answer: &PermissionAnswer) {
+        let resolved = if answer.is_allow() || tool.is_mcp() {
+            // MCP scopes are always wildcarded — both allow and deny generalize to "*".
+            // This makes session and persisted rules consistent: a deny on an MCP tool
+            // blocks the tool entirely, not just the specific input that triggered it.
             generalized_scopes(tool, scopes)
         } else {
             scopes.to_vec()
@@ -320,7 +388,7 @@ impl PermissionManager {
             PermissionAnswer::AllowSession => {
                 for s in &resolved {
                     self.add_session_rule(PermissionRule {
-                        tool: tool.to_string(),
+                        tool: tool.clone(),
                         scope: Some(s.clone()),
                         effect: Effect::Allow,
                     });
@@ -343,7 +411,7 @@ impl PermissionManager {
                 };
                 for s in &resolved {
                     self.add_session_rule(PermissionRule {
-                        tool: tool.to_string(),
+                        tool: tool.clone(),
                         scope: Some(s.clone()),
                         effect,
                     });
@@ -358,7 +426,7 @@ impl PermissionManager {
     #[allow(clippy::too_many_arguments)]
     pub async fn enforce(
         &self,
-        tool: &str,
+        tool: &ToolKey,
         scopes: &crate::tools::PermissionScopes,
         event_tx: &EventSender,
         user_response_rx: Option<&async_lock::Mutex<flume::Receiver<String>>>,
@@ -367,12 +435,11 @@ impl PermissionManager {
         plan_path: Option<&Path>,
     ) -> Result<(), PermissionError> {
         let scope_refs: Vec<&str> = scopes.scopes.iter().map(|s| s.as_str()).collect();
-        let deny = |guidance: Option<String>| {
-            let display = scopes.scopes.join("; ");
-            match guidance {
-                Some(g) => PermissionError::with_guidance(tool, &display, g),
-                None => PermissionError::new(tool, &display),
-            }
+        let tool_string = tool.to_string();
+        let scope_display = || scopes.scopes.join("; ");
+        let deny = |guidance: Option<String>| match guidance {
+            Some(g) => PermissionError::with_guidance(&tool_string, &scope_display(), g),
+            None => PermissionError::new(&tool_string, &scope_display()),
         };
 
         let (pt, ps, force_prompt) =
@@ -387,7 +454,7 @@ impl PermissionManager {
             };
 
         let Some(rx) = user_response_rx else {
-            warn!(tool, scope = %scopes.scopes.join("; "), "no permission response channel");
+            warn!(tool = %tool, scope = %scope_display(), "no permission response channel");
             return Err(deny(None));
         };
 
@@ -410,7 +477,7 @@ impl PermissionManager {
         let answer = match response {
             Ok(Ok(a)) => a,
             Ok(Err(_)) => {
-                warn!(tool, scope = %scopes.scopes.join("; "), "permission channel closed");
+                warn!(tool = %tool, scope = %scope_display(), "permission channel closed");
                 return Err(deny(None));
             }
             Err(_) => return Err(deny(None)),
@@ -428,11 +495,27 @@ impl PermissionManager {
     }
 }
 
-fn matches_rule(rule: &PermissionRule, tool: &str, scope: &str) -> bool {
-    let tool_matches = rule.tool == "*" || rule.tool == tool;
-    if !tool_matches {
-        return false;
+fn matches_rule(rule_key: &ToolKey, actual: &ToolKey) -> bool {
+    match (rule_key, actual) {
+        (ToolKey::Wildcard, _) => true,
+        (ToolKey::Native(a), ToolKey::Native(b)) => a == b,
+        (ToolKey::McpServer { server: rs }, ToolKey::McpServer { server: as_ }) => rs == as_,
+        (ToolKey::McpServer { server: rs }, ToolKey::McpTool { server: as_, .. }) => rs == as_,
+        (
+            ToolKey::McpTool {
+                server: rs,
+                tool: rt,
+            },
+            ToolKey::McpTool {
+                server: as_,
+                tool: at,
+            },
+        ) => rs == as_ && rt == at,
+        _ => false,
     }
+}
+
+fn rule_matches_scope(rule: &PermissionRule, scope: &str) -> bool {
     match &rule.scope {
         None => true,
         Some(pattern) => scope_matches(pattern, scope),
@@ -505,7 +588,7 @@ fn generalize_bash_segment(segment: &str) -> String {
     format!("{first_token} *")
 }
 
-pub fn generalized_scopes(tool: &str, scopes: &[String]) -> Vec<String> {
+pub fn generalized_scopes(tool: &ToolKey, scopes: &[String]) -> Vec<String> {
     let mut seen = HashSet::new();
     scopes
         .iter()
@@ -514,10 +597,10 @@ pub fn generalized_scopes(tool: &str, scopes: &[String]) -> Vec<String> {
         .collect()
 }
 
-fn generalize_scope(tool: &str, scope: &str) -> String {
+fn generalize_scope(tool: &ToolKey, scope: &str) -> String {
     match tool {
-        "bash" => generalize_bash_segment(scope),
-        tool if FILE_WRITE_TOOLS.contains(&tool) => {
+        ToolKey::Native(name) if name.as_ref() == "bash" => generalize_bash_segment(scope),
+        ToolKey::Native(name) if FILE_WRITE_TOOLS.contains(&name.as_ref()) => {
             let p = Path::new(scope);
             match p.parent() {
                 Some(parent) if !parent.as_os_str().is_empty() => {
@@ -526,12 +609,11 @@ fn generalize_scope(tool: &str, scope: &str) -> String {
                 _ => "**".to_string(),
             }
         }
-        // MCP tool calls are dispatched as `mcp:<tool_name>` with a scope equal
-        // to the JSON-stringified input. "Allow always" should whitelist the
-        // tool regardless of its arguments, so generalize the scope to `*`. The
-        // rule's `tool` field (`mcp:<tool_name>`) still gates which MCP tool it
-        // applies to, keeping distinct tools distinct.
-        t if t.starts_with("mcp:") => "*".to_string(),
+        // MCP tool calls have a scope equal to the JSON-stringified input.
+        // "Allow always" should whitelist the tool regardless of its arguments,
+        // so generalize the scope to `*`. The rule's `tool` field still gates
+        // which MCP tool it applies to, keeping distinct tools distinct.
+        ToolKey::McpTool { .. } | ToolKey::McpServer { .. } => "*".to_string(),
         _ => scope.to_string(),
     }
 }
@@ -550,7 +632,7 @@ mod tests {
 
     fn allow_rule(scope: &str) -> PermissionRule {
         PermissionRule {
-            tool: "bash".into(),
+            tool: ToolKey::native("bash"),
             scope: Some(scope.into()),
             effect: Effect::Allow,
         }
@@ -558,7 +640,7 @@ mod tests {
 
     fn deny_rule(scope: &str) -> PermissionRule {
         PermissionRule {
-            tool: "bash".into(),
+            tool: ToolKey::native("bash"),
             scope: Some(scope.into()),
             effect: Effect::Deny,
         }
@@ -590,7 +672,7 @@ mod tests {
             make_config(rules.into_iter().map(allow_rule).collect()),
             PathBuf::from("/tmp"),
         );
-        let check = mgr.check_multi("bash", &scopes, false, None);
+        let check = mgr.check_multi(&ToolKey::native("bash"), &scopes, false, None);
         assert_eq!(matches!(check, PermissionCheck::Allowed), expect_allowed);
     }
 
@@ -605,7 +687,12 @@ mod tests {
             PathBuf::from("/tmp"),
         );
         assert!(matches!(
-            mgr.check_multi("bash", &["cd /tmp", "cargo test", "rm -rf /"], false, None),
+            mgr.check_multi(
+                &ToolKey::native("bash"),
+                &["cd /tmp", "cargo test", "rm -rf /"],
+                false,
+                None
+            ),
             PermissionCheck::Denied
         ));
     }
@@ -614,7 +701,7 @@ mod tests {
     fn complex_constructs_force_prompt_even_with_allow_star() {
         let mgr = PermissionManager::new(make_config(vec![allow_rule("*")]), PathBuf::from("/tmp"));
         assert!(matches!(
-            mgr.check_multi("bash", &["echo $(whoami)"], true, None),
+            mgr.check_multi(&ToolKey::native("bash"), &["echo $(whoami)"], true, None),
             PermissionCheck::NeedsPrompt { .. }
         ));
     }
@@ -625,7 +712,7 @@ mod tests {
     #[test_case("bash", "cargo test" => false ; "bash_prompts")]
     fn builtin_check(tool: &str, scope: &str) -> bool {
         matches!(
-            default_mgr().check(tool, scope, None),
+            default_mgr().check(&ToolKey::native(tool), scope, None),
             PermissionCheck::Allowed
         )
     }
@@ -656,7 +743,7 @@ mod tests {
     fn path_traversal_prompts() {
         let path = normalize_scope_path("/tmp/../etc/passwd");
         assert!(matches!(
-            default_mgr().check("write", &path, None),
+            default_mgr().check(&ToolKey::native("write"), &path, None),
             PermissionCheck::NeedsPrompt { .. }
         ));
     }
@@ -669,7 +756,7 @@ mod tests {
         );
         mgr.add_session_rule(deny_rule("cargo *"));
         assert!(matches!(
-            mgr.check("bash", "cargo test", None),
+            mgr.check(&ToolKey::native("bash"), "cargo test", None),
             PermissionCheck::Denied
         ));
     }
@@ -685,7 +772,7 @@ mod tests {
             PathBuf::from("/tmp"),
         );
         assert!(matches!(
-            mgr.check("bash", "rm -rf /", None),
+            mgr.check(&ToolKey::native("bash"), "rm -rf /", None),
             PermissionCheck::Denied
         ));
     }
@@ -696,12 +783,12 @@ mod tests {
     fn allow_decision_generalizes() {
         let mgr = default_mgr();
         mgr.apply_decision(
-            "bash",
+            &ToolKey::native("bash"),
             &["cargo test --all".into()],
             &PermissionAnswer::AllowSession,
         );
         assert!(matches!(
-            mgr.check("bash", "cargo build", None),
+            mgr.check(&ToolKey::native("bash"), "cargo build", None),
             PermissionCheck::Allowed
         ));
     }
@@ -710,16 +797,16 @@ mod tests {
     fn deny_decision_uses_exact() {
         let mgr = default_mgr();
         mgr.apply_decision(
-            "bash",
+            &ToolKey::native("bash"),
             &["cargo test".into()],
             &PermissionAnswer::DenyAlwaysLocal,
         );
         assert!(matches!(
-            mgr.check("bash", "cargo test", None),
+            mgr.check(&ToolKey::native("bash"), "cargo test", None),
             PermissionCheck::Denied
         ));
         assert!(matches!(
-            mgr.check("bash", "cargo build", None),
+            mgr.check(&ToolKey::native("bash"), "cargo build", None),
             PermissionCheck::NeedsPrompt { .. }
         ));
     }
@@ -829,10 +916,20 @@ mod tests {
             PathBuf::from("/tmp"),
         );
         assert!(matches!(
-            mgr.check_multi("bash", &["cargo test", "git push"], false, None),
+            mgr.check_multi(
+                &ToolKey::native("bash"),
+                &["cargo test", "git push"],
+                false,
+                None
+            ),
             PermissionCheck::Allowed
         ));
-        match mgr.check_multi("bash", &["cargo test", "git push"], true, None) {
+        match mgr.check_multi(
+            &ToolKey::native("bash"),
+            &["cargo test", "git push"],
+            true,
+            None,
+        ) {
             PermissionCheck::NeedsPrompt {
                 scopes,
                 force_prompt,
@@ -850,7 +947,7 @@ mod tests {
         let mgr =
             PermissionManager::new(make_config(vec![deny_rule("rm *")]), PathBuf::from("/tmp"));
         assert!(matches!(
-            mgr.check_multi("bash", &["rm -rf /"], true, None),
+            mgr.check_multi(&ToolKey::native("bash"), &["rm -rf /"], true, None),
             PermissionCheck::Denied
         ));
     }
@@ -861,7 +958,12 @@ mod tests {
             make_config(vec![allow_rule("cargo *")]),
             PathBuf::from("/tmp"),
         );
-        match mgr.check_multi("bash", &["cargo test", "git push", "ls"], false, None) {
+        match mgr.check_multi(
+            &ToolKey::native("bash"),
+            &["cargo test", "git push", "ls"],
+            false,
+            None,
+        ) {
             PermissionCheck::NeedsPrompt { scopes, .. } => {
                 assert_eq!(scopes, vec!["git push", "ls"]);
             }
@@ -873,16 +975,16 @@ mod tests {
     fn apply_decision_multi_scope_generalizes_all() {
         let mgr = default_mgr();
         mgr.apply_decision(
-            "bash",
+            &ToolKey::native("bash"),
             &["cargo test".into(), "git status".into()],
             &PermissionAnswer::AllowSession,
         );
         assert!(matches!(
-            mgr.check("bash", "cargo build", None),
+            mgr.check(&ToolKey::native("bash"), "cargo build", None),
             PermissionCheck::Allowed
         ));
         assert!(matches!(
-            mgr.check("bash", "git push", None),
+            mgr.check(&ToolKey::native("bash"), "git push", None),
             PermissionCheck::Allowed
         ));
     }
@@ -890,21 +992,21 @@ mod tests {
     #[test]
     fn generalized_scopes_deduplicates() {
         let scopes = vec!["cargo test".into(), "cargo build".into()];
-        let result = generalized_scopes("bash", &scopes);
+        let result = generalized_scopes(&ToolKey::native("bash"), &scopes);
         assert_eq!(result, vec!["cargo *"]);
     }
 
     #[test]
     fn generalized_scopes_preserves_distinct() {
         let scopes = vec!["cargo test".into(), "git status".into()];
-        let result = generalized_scopes("bash", &scopes);
+        let result = generalized_scopes(&ToolKey::native("bash"), &scopes);
         assert_eq!(result, vec!["cargo *", "git *"]);
     }
 
     #[test_case("webfetch", "some:scope" => "some:scope" ; "unknown_tool_preserves_exact")]
-    #[test_case("mcp:fetch", "{\"url\":\"https://a\"}" => "*" ; "mcp_tool_generalizes_to_wildcard")]
+    #[test_case("myserver.fetch", "{\"url\":\"https://a\"}" => "*" ; "mcp_tool_generalizes_to_wildcard")]
     fn generalize_single_scope(tool: &str, scope: &str) -> String {
-        generalized_scopes(tool, &[scope.into()])
+        generalized_scopes(&ToolKey::parse(tool).unwrap(), &[scope.into()])
             .into_iter()
             .next()
             .unwrap()
@@ -912,7 +1014,7 @@ mod tests {
 
     #[test]
     fn generalize_edit_uses_parent_dir() {
-        let result = generalize_scope("edit", "/home/user/project/src/main.rs");
+        let result = generalize_scope(&ToolKey::native("edit"), "/home/user/project/src/main.rs");
         let expected = format!(
             "{}/**",
             Path::new("/home/user/project/src/main.rs")
@@ -925,7 +1027,7 @@ mod tests {
 
     #[test]
     fn generalize_edit_root_file() {
-        let result = generalize_scope("edit", "/Cargo.toml");
+        let result = generalize_scope(&ToolKey::native("edit"), "/Cargo.toml");
         let expected = format!(
             "{}/**",
             Path::new("/Cargo.toml").parent().unwrap().display()
@@ -941,9 +1043,10 @@ mod tests {
     #[test_case("bash", "git status --short" ; "bash_command_with_flags")]
     #[test_case("edit", "/home/user/project/src/main.rs" ; "edit_path")]
     #[test_case("webfetch", "https://example.com" ; "unknown_tool_exact")]
-    #[test_case("mcp:fetch", "{\"url\":\"https://a\"}" ; "mcp_tool_call")]
+    #[test_case("myfetch.search", "{\"url\":\"https://a\"}" ; "mcp_tool_call")]
     fn command_matches_its_own_generalized_rule(tool: &str, scope: &str) {
-        let rule = &generalized_scopes(tool, &[scope.into()])[0];
+        let tool_key = ToolKey::parse(tool).unwrap();
+        let rule = &generalized_scopes(&tool_key, &[scope.into()])[0];
         assert!(
             scope_matches(rule, scope),
             "{scope:?} does not match its generalized rule {rule:?}"
@@ -957,18 +1060,26 @@ mod tests {
     fn mcp_allow_always_matches_any_args_but_stays_per_tool() {
         let mgr = default_mgr();
         mgr.apply_decision(
-            "mcp:fetch",
+            &ToolKey::parse("myfetch.search").unwrap(),
             &["{\"url\":\"https://a\"}".into()],
             &PermissionAnswer::AllowSession,
         );
         // Same tool, different arguments -> allowed without reprompting.
         assert!(matches!(
-            mgr.check("mcp:fetch", "{\"url\":\"https://b\"}", None),
+            mgr.check(
+                &ToolKey::parse("myfetch.search").unwrap(),
+                "{\"url\":\"https://b\"}",
+                None
+            ),
             PermissionCheck::Allowed
         ));
         // A distinct MCP tool is not covered by the fetch rule.
         assert!(!matches!(
-            mgr.check("mcp:exec", "{\"cmd\":\"ls\"}", None),
+            mgr.check(
+                &ToolKey::parse("myfetch.exec").unwrap(),
+                "{\"cmd\":\"ls\"}",
+                None
+            ),
             PermissionCheck::Allowed
         ));
     }
@@ -977,34 +1088,60 @@ mod tests {
     fn deny_rule_with_none_scope_blocks_everything() {
         let mgr = PermissionManager::new(
             make_config(vec![PermissionRule {
-                tool: "bash".into(),
+                tool: ToolKey::native("bash"),
                 scope: None,
                 effect: Effect::Deny,
             }]),
             PathBuf::from("/tmp"),
         );
         assert!(matches!(
-            mgr.check("bash", "anything", None),
+            mgr.check(&ToolKey::native("bash"), "anything", None),
             PermissionCheck::Denied
         ));
     }
 
     #[test]
-    fn wildcard_tool_rule_applies_cross_tool() {
+    fn wildcard_deny_blocks_all_tools() {
         let mgr = PermissionManager::new(
             make_config(vec![PermissionRule {
-                tool: "*".into(),
+                tool: ToolKey::Wildcard,
                 scope: None,
                 effect: Effect::Deny,
             }]),
             PathBuf::from("/tmp"),
         );
+        // Any deny wins: Wildcard deny blocks everything including builtins
         assert!(matches!(
-            mgr.check("bash", "ls", None),
+            mgr.check(&ToolKey::native("bash"), "ls", None),
             PermissionCheck::Denied
         ));
         assert!(matches!(
-            mgr.check("write", "/tmp/x", None),
+            mgr.check(&ToolKey::native("write"), "/tmp/x", None),
+            PermissionCheck::Denied
+        ));
+    }
+
+    #[test]
+    fn mcp_deny_always_blocks_all_arguments() {
+        let mgr = PermissionManager::new(make_config(vec![]), PathBuf::from("/tmp"));
+        let tool = ToolKey::McpTool {
+            server: "deepwiki".into(),
+            tool: "search".into(),
+        };
+        // User denies with specific arguments — should generalize to block all.
+        mgr.apply_decision(
+            &tool,
+            &["{\"q\":\"dangerous\"}".into()],
+            &PermissionAnswer::DenyAlwaysLocal,
+        );
+        // Different arguments: still denied.
+        assert!(matches!(
+            mgr.check(&tool, "{\"q\":\"safe\"}", None),
+            PermissionCheck::Denied
+        ));
+        // Even wildcard scope: denied.
+        assert!(matches!(
+            mgr.check(&tool, "*", None),
             PermissionCheck::Denied
         ));
     }
@@ -1016,11 +1153,11 @@ mod tests {
         mgr.toggle_yolo();
         assert!(mgr.is_yolo());
         assert!(matches!(
-            mgr.check("bash", "cargo test", None),
+            mgr.check(&ToolKey::native("bash"), "cargo test", None),
             PermissionCheck::Allowed
         ));
         assert!(matches!(
-            mgr.check("bash", "rm -rf /", None),
+            mgr.check(&ToolKey::native("bash"), "rm -rf /", None),
             PermissionCheck::Denied
         ));
     }
@@ -1039,7 +1176,7 @@ mod tests {
     #[test_case(PermissionAnswer::Deny ; "deny_once")]
     fn once_decisions_add_no_session_rules(answer: PermissionAnswer) {
         let mgr = default_mgr();
-        mgr.apply_decision("bash", &["cargo test".into()], &answer);
+        mgr.apply_decision(&ToolKey::native("bash"), &["cargo test".into()], &answer);
         assert!(mgr.session_rules_snapshot().is_empty());
     }
 
@@ -1053,7 +1190,7 @@ mod tests {
             PathBuf::from("/tmp"),
         );
         assert!(matches!(
-            mgr.check("bash", "cargo test", None),
+            mgr.check(&ToolKey::native("bash"), "cargo test", None),
             PermissionCheck::Denied
         ));
     }
@@ -1069,11 +1206,11 @@ mod tests {
             PathBuf::from("/tmp"),
         );
         assert!(matches!(
-            mgr.check("bash", "cargo test", None),
+            mgr.check(&ToolKey::native("bash"), "cargo test", None),
             PermissionCheck::Allowed
         ));
         assert!(matches!(
-            mgr.check("bash", "rm -rf /", None),
+            mgr.check(&ToolKey::native("bash"), "rm -rf /", None),
             PermissionCheck::Denied
         ));
     }
@@ -1088,7 +1225,7 @@ mod tests {
             PathBuf::from("/tmp"),
         );
         assert!(matches!(
-            mgr.check("bash", "cargo test", None),
+            mgr.check(&ToolKey::native("bash"), "cargo test", None),
             PermissionCheck::Allowed
         ));
     }
@@ -1097,8 +1234,69 @@ mod tests {
     fn default_prompt_is_default_behavior() {
         let mgr = PermissionManager::new(PermissionsConfig::default(), PathBuf::from("/tmp"));
         assert!(matches!(
-            mgr.check("bash", "cargo test", None),
+            mgr.check(&ToolKey::native("bash"), "cargo test", None),
             PermissionCheck::NeedsPrompt { .. }
+        ));
+    }
+
+    #[test]
+    fn mcp_server_wildcard_matches_all_server_tools() {
+        let mgr = PermissionManager::new(
+            make_config(vec![PermissionRule {
+                tool: ToolKey::McpServer {
+                    server: "deepwiki".into(),
+                },
+                scope: None,
+                effect: Effect::Allow,
+            }]),
+            PathBuf::from("/tmp"),
+        );
+        assert!(matches!(
+            mgr.check(
+                &ToolKey::McpTool {
+                    server: "deepwiki".into(),
+                    tool: "search".into()
+                },
+                "{}",
+                None
+            ),
+            PermissionCheck::Allowed
+        ));
+        assert!(matches!(
+            mgr.check(
+                &ToolKey::McpTool {
+                    server: "deepwiki".into(),
+                    tool: "web_search".into()
+                },
+                "{}",
+                None
+            ),
+            PermissionCheck::Allowed
+        ));
+    }
+
+    #[test]
+    fn mcp_server_wildcard_does_not_match_other_server() {
+        let mgr = PermissionManager::new(
+            make_config(vec![PermissionRule {
+                tool: ToolKey::McpServer {
+                    server: "deepwiki".into(),
+                },
+                scope: None,
+                effect: Effect::Allow,
+            }]),
+            PathBuf::from("/tmp"),
+        );
+        assert!(!matches!(
+            mgr.check(
+                &ToolKey::McpTool {
+                    server: "github".into(),
+                    tool: "search".into()
+                },
+                "{}",
+                None
+            ),
+            PermissionCheck::Allowed
         ));
     }
 
@@ -1107,18 +1305,18 @@ mod tests {
         let mgr = PermissionManager::new(
             PermissionsConfig {
                 default: DefaultEffect::Deny,
-                tool_defaults: HashMap::from([("bash".into(), DefaultEffect::Allow)]),
+                tool_defaults: HashMap::from([(ToolKey::native("bash"), DefaultEffect::Allow)]),
                 rules: vec![],
                 ..Default::default()
             },
             PathBuf::from("/tmp"),
         );
         assert!(matches!(
-            mgr.check("bash", "cargo test", None),
+            mgr.check(&ToolKey::native("bash"), "cargo test", None),
             PermissionCheck::Allowed
         ));
         assert!(matches!(
-            mgr.check("write", "/etc/passwd", None),
+            mgr.check(&ToolKey::native("write"), "/etc/passwd", None),
             PermissionCheck::Denied
         ));
     }
@@ -1132,10 +1330,39 @@ mod tests {
         let mgr = default_mgr();
         assert_eq!(
             matches!(
-                mgr.check(tool, plan, Some(plan_path)),
+                mgr.check(&ToolKey::native(tool), plan, Some(plan_path)),
                 PermissionCheck::Allowed
             ),
             expect_allowed,
         );
+    }
+
+    #[test]
+    fn plan_path_multi_scope_all_must_match() {
+        let plan = "/home/user/.local/state/maki/plans/test.md";
+        let plan_path = Path::new(plan);
+        let mgr = default_mgr();
+
+        // All scopes match plan → allowed
+        assert!(matches!(
+            mgr.check_multi(
+                &ToolKey::native("write"),
+                &[plan, plan],
+                false,
+                Some(plan_path),
+            ),
+            PermissionCheck::Allowed
+        ));
+
+        // One scope is non-plan → needs prompt
+        assert!(matches!(
+            mgr.check_multi(
+                &ToolKey::native("write"),
+                &[plan, "/etc/passwd"],
+                false,
+                Some(plan_path),
+            ),
+            PermissionCheck::NeedsPrompt { .. }
+        ));
     }
 }

--- a/maki-agent/src/tools/registry.rs
+++ b/maki-agent/src/tools/registry.rs
@@ -569,7 +569,7 @@ mod tests {
     fn definitions_reflects_mid_session_registration() {
         let reg = ToolRegistry::new();
         reg.register(
-            mock("late_server__probe"),
+            mock("late_server.probe"),
             ToolSource::Mcp {
                 server: "late_server".into(),
             },
@@ -587,7 +587,7 @@ mod tests {
         let arr = defs.as_array().expect("definitions returns array");
         assert!(
             arr.iter()
-                .any(|d| d["name"].as_str() == Some("late_server__probe")),
+                .any(|d| d["name"].as_str() == Some("late_server.probe")),
             "mid-session tool missing from definitions"
         );
     }
@@ -596,14 +596,14 @@ mod tests {
     fn clear_mcp_server_removes_only_that_server() {
         let reg = ToolRegistry::new();
         reg.register(
-            mock("serverA__one"),
+            mock("serverA.one"),
             ToolSource::Mcp {
                 server: "serverA".into(),
             },
         )
         .unwrap();
         reg.register(
-            mock("serverB__one"),
+            mock("serverB.one"),
             ToolSource::Mcp {
                 server: "serverB".into(),
             },
@@ -614,8 +614,8 @@ mod tests {
 
         reg.clear_mcp_server("serverA");
 
-        assert!(!reg.has("serverA__one"));
-        assert!(reg.has("serverB__one"));
+        assert!(!reg.has("serverA.one"));
+        assert!(reg.has("serverB.one"));
         assert!(reg.has("other_tool"));
     }
 
@@ -623,21 +623,21 @@ mod tests {
     fn clear_plugin_removes_only_that_plugin() {
         let reg = ToolRegistry::new();
         reg.register(
-            mock("pluginA__foo"),
+            mock("pluginA.foo"),
             ToolSource::Lua {
                 plugin: "pluginA".into(),
             },
         )
         .unwrap();
         reg.register(
-            mock("pluginB__bar"),
+            mock("pluginB.bar"),
             ToolSource::Lua {
                 plugin: "pluginB".into(),
             },
         )
         .unwrap();
         reg.register(
-            mock("mcp__tool"),
+            mock("mcp.tool"),
             ToolSource::Mcp {
                 server: "srv".into(),
             },
@@ -646,9 +646,9 @@ mod tests {
 
         reg.clear_plugin("pluginA");
 
-        assert!(!reg.has("pluginA__foo"));
-        assert!(reg.has("pluginB__bar"));
-        assert!(reg.has("mcp__tool"));
+        assert!(!reg.has("pluginA.foo"));
+        assert!(reg.has("pluginB.bar"));
+        assert!(reg.has("mcp.tool"));
     }
 
     #[test]

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
+use maki_config::ToolKey;
 use maki_providers::{AgentError, ContentBlock, Message, Role, StopReason, TokenUsage};
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
@@ -568,7 +569,7 @@ pub enum AgentEvent {
     },
     PermissionRequest {
         id: String,
-        tool: String,
+        tool: ToolKey,
         scopes: Vec<String>,
     },
     AuthRequired,

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -439,6 +439,8 @@ impl IndexFileConfig {
 struct PermissionsFileConfig {
     default: Option<DefaultEffect>,
     tools: HashMap<String, ToolPermissions>,
+    mcp_rules: Vec<PermissionRule>,
+    mcp_defaults: HashMap<ToolKey, DefaultEffect>,
 }
 
 impl<'de> Deserialize<'de> for PermissionsFileConfig {
@@ -453,12 +455,54 @@ impl<'de> Deserialize<'de> for PermissionsFileConfig {
                     .as_bool()?
                     .then_some(DefaultEffect::Allow)
             });
-        let tools = table
-            .iter()
-            .filter(|(k, _)| k != &"allow_all" && k != &"default")
-            .filter_map(|(k, v)| Some((k.clone(), v.clone().try_into::<ToolPermissions>().ok()?)))
-            .collect();
-        Ok(Self { default, tools })
+
+        let mut tools = HashMap::new();
+        let mut mcp_rules = Vec::new();
+        let mut mcp_defaults = HashMap::new();
+
+        for (k, v) in table.iter() {
+            if k == "allow_all" || k == "default" {
+                continue;
+            }
+            if k == "mcp" {
+                // TOML [mcp.server] creates nested table: mcp → {server → {...}}
+                if let Some(mcp_table) = v.as_table() {
+                    for (server_name, server_value) in mcp_table {
+                        if let Some(server_table) = server_value.as_table() {
+                            parse_mcp_server_table(
+                                server_name,
+                                server_table,
+                                &mut mcp_rules,
+                                &mut mcp_defaults,
+                            );
+                        } else {
+                            tracing::warn!(
+                                server = server_name.as_str(),
+                                "[mcp.{server_name}] is not a table — skipping"
+                            );
+                        }
+                    }
+                } else {
+                    tracing::warn!("[mcp] is not a table (got {}) — skipping", v.type_str());
+                }
+            } else if let Ok(tp) = v.clone().try_into::<ToolPermissions>() {
+                if k.contains('.') {
+                    tracing::warn!(
+                        key = k.as_str(),
+                        "tool section [{k}] contains a dot — did you mean [mcp.{k}]? Skipping."
+                    );
+                } else {
+                    tools.insert(k.clone(), tp);
+                }
+            }
+        }
+
+        Ok(Self {
+            default,
+            tools,
+            mcp_rules,
+            mcp_defaults,
+        })
     }
 }
 
@@ -476,19 +520,29 @@ enum ScopeSet {
     Scopes(Vec<String>),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
-pub enum DefaultEffect {
-    #[default]
-    Prompt,
-    Deny,
-    Allow,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Effect {
     Allow,
     Deny,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DefaultEffect {
+    Allow,
+    Deny,
+    #[default]
+    Prompt,
+}
+
+impl From<Effect> for DefaultEffect {
+    fn from(e: Effect) -> Self {
+        match e {
+            Effect::Allow => DefaultEffect::Allow,
+            Effect::Deny => DefaultEffect::Deny,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -497,9 +551,149 @@ pub enum PermissionTarget {
     Project(PathBuf),
 }
 
+use std::sync::Arc;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ToolKey {
+    Wildcard,
+    Native(Arc<str>),
+    McpServer { server: Arc<str> },
+    McpTool { server: Arc<str>, tool: Arc<str> },
+}
+
+/// NOTE: `ToolKey` deliberately does not implement `serde::Deserialize`.
+/// Use `ToolKey::parse(&str)` at deserialization boundaries — it performs
+/// validation (wire format, server name, length) that a blanket Deserialize
+/// would skip. All current deserialization paths go through `parse`.
+impl serde::Serialize for ToolKey {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+/// Check if a name matches the LLM wire format: `^[a-zA-Z0-9_-]{1,64}$`.
+/// Tool names with dots, over 64 chars, or special characters are rejected.
+pub fn is_valid_wire_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 64
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+}
+
+impl ToolKey {
+    /// Parse a qualified tool name into a `ToolKey`.
+    ///
+    /// Returns `Err` for malformed input (empty names, empty server/tool parts,
+    /// tool names that don't match the wire format `^[a-zA-Z0-9_-]{1,64}$`).
+    /// Use this at config/dispatch boundaries where input is untrusted.
+    pub fn parse(name: &str) -> Result<Self, ToolKeyParseError> {
+        if name.is_empty() {
+            return Err(ToolKeyParseError::EmptyName);
+        }
+        if name == "*" {
+            return Ok(Self::Wildcard);
+        }
+        match name.split_once('.') {
+            Some(("", _)) | Some((_, "")) => {
+                Err(ToolKeyParseError::MalformedParts(name.to_string()))
+            }
+            Some((server, "*")) => {
+                if !is_valid_server_name(server) {
+                    return Err(ToolKeyParseError::InvalidServerName(server.to_string()));
+                }
+                Ok(Self::McpServer {
+                    server: server.into(),
+                })
+            }
+            Some((server, tool)) => {
+                if !is_valid_server_name(server) {
+                    return Err(ToolKeyParseError::InvalidServerName(server.to_string()));
+                }
+                if !is_valid_wire_name(tool) {
+                    return Err(ToolKeyParseError::InvalidToolName(tool.to_string()));
+                }
+                // Wire format is server__tool — check total length fits LLM API limits
+                let wire_len = server.len() + 2 + tool.len();
+                if wire_len > 64 {
+                    return Err(ToolKeyParseError::WireNameTooLong {
+                        server: server.to_string(),
+                        tool: tool.to_string(),
+                        len: wire_len,
+                    });
+                }
+                Ok(Self::McpTool {
+                    server: server.into(),
+                    tool: tool.into(),
+                })
+            }
+            None => {
+                if !is_valid_wire_name(name) {
+                    return Err(ToolKeyParseError::InvalidToolName(name.to_string()));
+                }
+                Ok(Self::Native(name.into()))
+            }
+        }
+    }
+
+    /// Create a `ToolKey` from a known-valid native tool name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `name` is empty or contains dots. Use `ToolKey::parse` for
+    /// untrusted input or MCP tool names.
+    pub fn native(name: &str) -> Self {
+        match name {
+            "*" => Self::Wildcard,
+            _ => {
+                assert!(!name.is_empty(), "native tool name must not be empty");
+                assert!(
+                    !name.contains('.'),
+                    "native tool name must not contain dots: {name:?} - use ToolKey::parse for MCP tools"
+                );
+                Self::Native(name.into())
+            }
+        }
+    }
+
+    pub fn is_mcp(&self) -> bool {
+        matches!(self, Self::McpServer { .. } | Self::McpTool { .. })
+    }
+}
+
+impl std::fmt::Display for ToolKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Wildcard => write!(f, "*"),
+            Self::Native(name) => write!(f, "{name}"),
+            Self::McpServer { server } => write!(f, "{server}.*"),
+            Self::McpTool { server, tool } => write!(f, "{server}.{tool}"),
+        }
+    }
+}
+
+/// Error returned when a tool key string fails validation.
+#[derive(Debug, thiserror::Error)]
+pub enum ToolKeyParseError {
+    #[error("tool name is empty")]
+    EmptyName,
+    #[error("malformed tool key: empty server or tool part in {0:?}")]
+    MalformedParts(String),
+    #[error("invalid server name {0:?}: must match [a-zA-Z0-9-]{{1,64}}")]
+    InvalidServerName(String),
+    #[error("invalid tool name {0:?}: must match [a-zA-Z0-9_-]{{1,64}}")]
+    InvalidToolName(String),
+    #[error("wire name {server}__{tool} is {len} chars, max 64")]
+    WireNameTooLong {
+        server: String,
+        tool: String,
+        len: usize,
+    },
+}
+
 #[derive(Debug, Clone)]
 pub struct PermissionRule {
-    pub tool: String,
+    pub tool: ToolKey,
     pub scope: Option<String>,
     pub effect: Effect,
 }
@@ -507,7 +701,7 @@ pub struct PermissionRule {
 #[derive(Debug, Clone, Default)]
 pub struct PermissionsConfig {
     pub default: DefaultEffect,
-    pub tool_defaults: HashMap<String, DefaultEffect>,
+    pub tool_defaults: HashMap<ToolKey, DefaultEffect>,
     pub rules: Vec<PermissionRule>,
     pub yolo: bool,
 }
@@ -928,6 +1122,10 @@ fn push_rules(
     effect: Effect,
 ) {
     for (tool, perms) in tools {
+        if tool.is_empty() {
+            tracing::warn!("skipping permission rule for empty tool name");
+            continue;
+        }
         let scope_set = match effect {
             Effect::Deny => &perms.deny,
             Effect::Allow => &perms.allow,
@@ -937,20 +1135,203 @@ fn push_rules(
         };
         match scope_set {
             ScopeSet::All(true) => rules.push(PermissionRule {
-                tool: tool.clone(),
+                tool: ToolKey::native(tool),
                 scope: None,
                 effect,
             }),
             ScopeSet::Scopes(scopes) => {
                 for s in scopes {
                     rules.push(PermissionRule {
-                        tool: tool.clone(),
+                        tool: ToolKey::native(tool),
                         scope: Some(s.clone()),
                         effect,
                     });
                 }
             }
             ScopeSet::All(false) => {}
+        }
+    }
+}
+
+pub fn is_valid_server_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 64
+        && name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
+}
+
+/// Validates the *tool* portion of an MCP qualified name.
+/// Currently identical to `is_valid_wire_name`, but kept distinct
+/// in case MCP tools need different constraints from native wire names.
+fn is_valid_tool_name(name: &str) -> bool {
+    is_valid_wire_name(name)
+}
+
+fn push_mcp_tool_rule(
+    rules: &mut Vec<PermissionRule>,
+    server_name: &str,
+    tool_name: &str,
+    effect: Effect,
+) {
+    let qualified = format!("{server_name}.{tool_name}");
+    match ToolKey::parse(&qualified) {
+        Ok(key) => {
+            rules.push(PermissionRule {
+                tool: key,
+                scope: None,
+                effect,
+            });
+        }
+        Err(e) => {
+            tracing::warn!(
+                server = server_name,
+                tool = tool_name,
+                error = %e,
+                "skipping invalid MCP tool name"
+            );
+        }
+    }
+}
+
+fn insert_or_create_array(table: &mut toml_edit::Table, key: &str, value: &str) {
+    match table
+        .entry(key)
+        .or_insert_with(|| toml_edit::Item::Value(toml_edit::Value::Array(toml_edit::Array::new())))
+    {
+        toml_edit::Item::Value(toml_edit::Value::Array(arr)) => {
+            if !arr.iter().any(|v| v.as_str() == Some(value)) {
+                arr.push(value);
+            }
+        }
+        slot => {
+            *slot = toml_edit::Item::Value(toml_edit::Value::Array({
+                let mut arr = toml_edit::Array::new();
+                arr.push(value);
+                arr
+            }));
+        }
+    }
+}
+
+fn parse_mcp_server_table(
+    server_name: &str,
+    table: &toml::Table,
+    rules: &mut Vec<PermissionRule>,
+    mcp_defaults: &mut HashMap<ToolKey, DefaultEffect>,
+) {
+    if !is_valid_server_name(server_name) {
+        tracing::warn!(
+            server = server_name,
+            "skipping [mcp.{server_name}] — invalid server name; \
+             must contain only alphanumeric characters and hyphens"
+        );
+        return;
+    }
+
+    for (key, value) in table {
+        match key.as_str() {
+            "allow" | "deny" => {
+                let effect = if key == "allow" {
+                    Effect::Allow
+                } else {
+                    Effect::Deny
+                };
+                match value {
+                    toml::Value::Array(arr) => {
+                        for item in arr {
+                            if let Some(tool_name) = item.as_str() {
+                                if tool_name == "*" {
+                                    // `allow = ["*"]` / `deny = ["*"]` means server-wide.
+                                    // Create an McpServer rule so deny-wins logic applies:
+                                    // McpServer deny blocks all tools on the server.
+                                    // No allow can override a deny — any deny wins.
+                                    rules.push(PermissionRule {
+                                        tool: ToolKey::McpServer {
+                                            server: server_name.into(),
+                                        },
+                                        scope: None,
+                                        effect,
+                                    });
+                                    continue;
+                                }
+                                push_mcp_tool_rule(rules, server_name, tool_name, effect);
+                            }
+                        }
+                    }
+                    toml::Value::Boolean(true) => {
+                        tracing::warn!(
+                            server = server_name,
+                            key = key.as_str(),
+                            "{key} = true is deprecated — use default = \"{key}\" instead; ignoring"
+                        );
+                    }
+                    toml::Value::Boolean(false) => {
+                        // No-op: explicitly disabled.
+                    }
+                    toml::Value::String(s) => {
+                        let tool_name = s.as_str();
+                        if tool_name == "*" {
+                            // Treat `allow = "*"` the same as `allow = ["*"]` —
+                            // create a hard McpServer rule, not a default.
+                            rules.push(PermissionRule {
+                                tool: ToolKey::McpServer {
+                                    server: server_name.into(),
+                                },
+                                scope: None,
+                                effect,
+                            });
+                        } else {
+                            tracing::info!(
+                                server = server_name,
+                                tool = tool_name,
+                                "{key} = \"{tool_name}\" coerced to {key} = [\"{tool_name}\"] — \
+                                 consider using array syntax"
+                            );
+                            push_mcp_tool_rule(rules, server_name, tool_name, effect);
+                        }
+                    }
+                    other => {
+                        tracing::warn!(
+                            server = server_name,
+                            key = key.as_str(),
+                            value = ?other,
+                            "unexpected value for [mcp.{server_name}].{key} — \
+                             expected array of tool names or default = \"allow\"/\"deny\""
+                        );
+                    }
+                }
+            }
+            "default" => {
+                if let Ok(d) = value.clone().try_into::<DefaultEffect>() {
+                    mcp_defaults.insert(
+                        ToolKey::McpServer {
+                            server: server_name.into(),
+                        },
+                        d,
+                    );
+                } else {
+                    tracing::warn!(
+                        server = server_name,
+                        value = ?value,
+                        "invalid [mcp.{server_name}].default value — expected \"allow\", \"deny\", or \"prompt\""
+                    );
+                }
+            }
+            other => {
+                if value.is_table() {
+                    tracing::warn!(
+                        server = server_name,
+                        key = other,
+                        "unknown key [mcp.{server_name}.{other}] — server names cannot \
+                         contain dots; use [mcp.{other}] instead if this is a server name"
+                    );
+                } else {
+                    tracing::warn!(
+                        server = server_name,
+                        key = other,
+                        "unknown key in [mcp.{server_name}] — ignored"
+                    );
+                }
+            }
         }
     }
 }
@@ -969,21 +1350,66 @@ fn build_permissions(
     let mut tool_defaults = HashMap::new();
     for (tool, perms) in &global.tools {
         if let Some(d) = perms.default {
-            tool_defaults.insert(tool.clone(), d);
+            let key = ToolKey::native(tool);
+            if matches!(key, ToolKey::Wildcard) {
+                tracing::warn!(
+                    tool = tool,
+                    "ignoring [\"*\"].default — use the top-level `default` field instead \
+                     for global fallback behavior"
+                );
+            } else {
+                tool_defaults.insert(key, d);
+            }
         }
+    }
+    for (key, d) in &global.mcp_defaults {
+        tool_defaults.insert(key.clone(), *d);
     }
     for (tool, perms) in &project.tools {
         if let Some(d) = perms.default
             && d != DefaultEffect::Allow
         {
-            tool_defaults.insert(tool.clone(), d);
+            let key = ToolKey::native(tool);
+            if matches!(key, ToolKey::Wildcard) {
+                tracing::warn!(
+                    tool = tool,
+                    "ignoring project [\"*\"].default — use the top-level `default` field instead"
+                );
+            } else {
+                tool_defaults.insert(key, d);
+            }
+        }
+    }
+    for (key, d) in &project.mcp_defaults {
+        if *d != DefaultEffect::Allow {
+            tool_defaults.insert(key.clone(), *d);
         }
     }
 
     let mut rules = Vec::new();
+    for rule in &global.mcp_rules {
+        if rule.effect == Effect::Deny {
+            rules.push(rule.clone());
+        }
+    }
+    for rule in &global.mcp_rules {
+        if rule.effect == Effect::Allow {
+            rules.push(rule.clone());
+        }
+    }
     for tools in [&global.tools, &project.tools] {
         push_rules(&mut rules, tools, Effect::Deny);
         push_rules(&mut rules, tools, Effect::Allow);
+    }
+    for rule in &project.mcp_rules {
+        if rule.effect == Effect::Deny {
+            rules.push(rule.clone());
+        }
+    }
+    for rule in &project.mcp_rules {
+        if rule.effect == Effect::Allow {
+            rules.push(rule.clone());
+        }
     }
     PermissionsConfig {
         default,
@@ -1060,6 +1486,101 @@ fn load_permissions_inner(cwd: &Path, global_dirs: &[PathBuf]) -> PermissionsCon
     build_permissions(global_perms, project_perms)
 }
 
+fn migrate_mcp_entry(
+    doc: &mut toml_edit::DocumentMut,
+    server_name: &str,
+    tool_name: &str,
+    item: &toml_edit::Item,
+) {
+    // Old format: ["mcp:server__tool"] allow = ["scope_strings"]
+    // New format: [mcp.server] allow = ["tool_names"]
+    // Old array values were scope strings, but MCP scopes are always
+    // generalized to "*" at check time (see generalize_scope), so those
+    // scope strings were dead code. We replace them with the tool name
+    // extracted from the key, which is the correct semantic for the new format.
+
+    // Create [mcp.server] as nested table: mcp → server → {allow/deny}
+    let mcp_item = doc
+        .entry("mcp")
+        .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
+    let Some(mcp_table) = mcp_item.as_table_mut() else {
+        tracing::warn!(
+            server = server_name,
+            "[mcp] is not a table — skipping migration"
+        );
+        return;
+    };
+    let server_item = mcp_table
+        .entry(server_name)
+        .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
+    let Some(server_table) = server_item.as_table_mut() else {
+        tracing::warn!(
+            server = server_name,
+            "[mcp.{server_name}] is not a table — skipping migration"
+        );
+        return;
+    };
+
+    // Bare boolean: old format like [mcp]\ndeepwiki__search = true
+    // means "allow this tool" — treat as allow = [tool_name].
+    if let Some(toml_edit::Value::Boolean(b)) = item.as_value() {
+        if *b.value() {
+            insert_or_create_array(server_table, "allow", tool_name);
+        }
+        return;
+    }
+
+    if let Some(old_table) = item.as_table() {
+        for (effect_key, effect_value) in old_table {
+            let key_str: &str = effect_key;
+            match key_str {
+                "allow" | "deny" => {
+                    match effect_value {
+                        toml_edit::Item::Value(toml_edit::Value::Boolean(b)) if *b.value() => {
+                            insert_or_create_array(server_table, key_str, tool_name);
+                        }
+                        toml_edit::Item::Value(toml_edit::Value::Array(old_arr)) => {
+                            if !old_arr.is_empty() {
+                                tracing::warn!(
+                                    server = server_name,
+                                    tool = tool_name,
+                                    "old MCP scope strings dropped during migration \
+                                     (MCP scopes are always wildcarded)"
+                                );
+                            }
+                            insert_or_create_array(server_table, key_str, tool_name);
+                        }
+                        toml_edit::Item::Value(toml_edit::Value::Boolean(b)) if !b.value() => {
+                            // allow = false / deny = false → no rule, but log for transparency.
+                            tracing::info!(
+                                key = key_str,
+                                tool = tool_name,
+                                "{key_str} = false — no rule generated"
+                            );
+                        }
+                        _ => {
+                            tracing::warn!(
+                                key = key_str,
+                                tool = tool_name,
+                                value = format!("{:?}", effect_value),
+                                "unexpected value type for {key_str} in migration — skipping"
+                            );
+                        }
+                    }
+                }
+                _ => {
+                    tracing::warn!(
+                        key = key_str,
+                        server = server_name,
+                        tool = tool_name,
+                        "unknown key \"{key_str}\" in old MCP entry during migration — dropping"
+                    );
+                }
+            }
+        }
+    }
+}
+
 fn migrate_permissions_file(path: &Path) {
     let Ok(content) = fs::read_to_string(path) else {
         return;
@@ -1067,13 +1588,92 @@ fn migrate_permissions_file(path: &Path) {
     let Ok(mut doc) = content.parse::<toml_edit::DocumentMut>() else {
         return;
     };
-    let Some(item) = doc.remove("allow_all") else {
-        return;
-    };
-    if item.as_bool() == Some(true) {
-        doc.insert("default", toml_edit::value("allow"));
+    let mut migrated = false;
+
+    if let Some(item) = doc.remove("allow_all") {
+        migrated = true;
+        if item.as_bool() == Some(true) {
+            doc.insert("default", toml_edit::value("allow"));
+        }
     }
-    if let Err(e) = fs::write(path, doc.to_string()) {
+
+    // Migrate flat MCP keys: "mcp:server__tool" → [mcp.server]
+    // Two TOML representations to handle:
+    // 1. Quoted keys: ["mcp:server__tool"] → flat top-level key
+    // 2. Bare keys: [mcp:server__tool] → nested "mcp" → {"server__tool": ...}
+
+    // Path 1: Flat quoted keys starting with "mcp:" containing "__"
+    let flat_old_keys: Vec<String> = doc
+        .iter()
+        .filter_map(|(k, _)| {
+            k.strip_prefix("mcp:")
+                .and_then(|rest| rest.contains("__").then(|| k.to_string()))
+        })
+        .collect();
+
+    for old_key in flat_old_keys {
+        if let Some(item) = doc.remove(&old_key) {
+            let rest = &old_key[4..]; // strip "mcp:"
+            if let Some((server, tool)) = rest.split_once("__") {
+                if !is_valid_server_name(server) || !is_valid_tool_name(tool) {
+                    tracing::error!(
+                        key = old_key.as_str(),
+                        server = server,
+                        tool = tool,
+                        "SECURITY: skipping migration of malformed MCP key — \
+                         rules for this tool will not be restored"
+                    );
+                    continue;
+                }
+                migrate_mcp_entry(&mut doc, server, tool, &item);
+                migrated = true;
+            }
+        }
+    }
+
+    // Path 2: Nested "mcp" sub-table (bare key mcp: created nesting)
+    let nested_old_entries: Vec<(String, String, toml_edit::Item)> = {
+        let mut entries = Vec::new();
+        if let Some(toml_edit::Item::Table(mcp_table)) = doc.get("mcp") {
+            for (key, _) in mcp_table.iter() {
+                if key.contains("__")
+                    && let Some((server, tool)) = key.split_once("__")
+                {
+                    let item = mcp_table.get(key).cloned();
+                    if let Some(item) = item {
+                        entries.push((server.to_string(), tool.to_string(), item));
+                    }
+                }
+            }
+        }
+        entries
+    };
+
+    for (server_name, tool_name, item) in nested_old_entries {
+        if !is_valid_server_name(&server_name) || !is_valid_tool_name(&tool_name) {
+            tracing::error!(
+                server = server_name.as_str(),
+                tool = &*tool_name,
+                "SECURITY: skipping migration of malformed nested MCP key — \
+                 rules for this tool will not be restored"
+            );
+            continue;
+        }
+        if let Some(toml_edit::Item::Table(mcp_table)) = doc.get_mut("mcp") {
+            mcp_table.remove(&format!("{server_name}__{tool_name}"));
+        }
+        migrate_mcp_entry(&mut doc, &server_name, &tool_name, &item);
+        migrated = true;
+    }
+
+    // Clean up the now-empty "mcp" parent table if it has no children
+    if let Some(toml_edit::Item::Table(mcp_table)) = doc.get("mcp")
+        && mcp_table.is_empty()
+    {
+        doc.remove("mcp");
+    }
+
+    if migrated && let Err(e) = maki_storage::atomic_write(path, doc.to_string().as_bytes()) {
         warn!(path = %path.display(), error = %e, "failed to migrate permissions file");
     }
 }
@@ -1098,7 +1698,7 @@ pub fn global_config_dirs() -> Vec<PathBuf> {
 }
 
 pub fn append_permission_rule(
-    tool: &str,
+    tool: &ToolKey,
     scope: Option<&str>,
     effect: Effect,
     target: &PermissionTarget,
@@ -1110,7 +1710,7 @@ pub fn append_permission_rule(
 }
 
 fn append_permission_rule_with_global(
-    tool: &str,
+    tool: &ToolKey,
     scope: Option<&str>,
     effect: Effect,
     target: &PermissionTarget,
@@ -1123,7 +1723,7 @@ fn append_permission_rule_with_global(
 }
 
 fn append_global_permission(
-    tool: &str,
+    tool: &ToolKey,
     scope: Option<&str>,
     effect: Effect,
     global: Option<PathBuf>,
@@ -1141,12 +1741,13 @@ fn append_global_permission(
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| format!("cannot create config dir: {e}"))?;
     }
-    std::fs::write(&path, doc.to_string()).map_err(|e| format!("cannot write permissions: {e}"))?;
+    maki_storage::atomic_write(&path, doc.to_string().as_bytes())
+        .map_err(|e| format!("cannot write permissions: {e}"))?;
     Ok(())
 }
 
 fn append_project_permission(
-    tool: &str,
+    tool: &ToolKey,
     scope: Option<&str>,
     effect: Effect,
     cwd: &Path,
@@ -1162,14 +1763,14 @@ fn append_project_permission(
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| format!("cannot create .maki dir: {e}"))?;
     }
-    std::fs::write(&path, doc.to_string())
+    maki_storage::atomic_write(&path, doc.to_string().as_bytes())
         .map_err(|e| format!("cannot write .maki/{PERMISSIONS_FILE}: {e}"))?;
     Ok(())
 }
 
 fn insert_permission_entry(
     doc: &mut toml_edit::DocumentMut,
-    tool: &str,
+    tool_key: &ToolKey,
     scope: Option<&str>,
     effect: Effect,
 ) -> Result<(), String> {
@@ -1178,26 +1779,43 @@ fn insert_permission_entry(
         Effect::Deny => "deny",
     };
 
-    let tool_table = doc
-        .entry(tool)
-        .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
-    let tool_table = tool_table
-        .as_table_mut()
-        .ok_or_else(|| format!("[{tool}] is not a table"))?;
+    match tool_key {
+        ToolKey::McpTool {
+            server,
+            tool: tool_name,
+        } => {
+            // MCP scopes are always wildcarded — scope parameter is intentionally ignored.
+            if scope.is_some() {
+                tracing::debug!(
+                    tool = %tool_name,
+                    scope = ?scope,
+                    "MCP tool scope ignored (always wildcarded)"
+                );
+            }
+            let mcp_item = doc
+                .entry("mcp")
+                .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
+            let mcp_table = mcp_item
+                .as_table_mut()
+                .ok_or_else(|| "[mcp] is not a table".to_string())?;
+            let server_item = mcp_table
+                .entry(server)
+                .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
+            let server_table = server_item
+                .as_table_mut()
+                .ok_or_else(|| format!("[mcp.{server}] is not a table"))?;
 
-    match scope {
-        Some(s) => {
-            let arr = tool_table.entry(key).or_insert_with(|| {
+            let arr = server_table.entry(key).or_insert_with(|| {
                 toml_edit::Item::Value(toml_edit::Value::Array(toml_edit::Array::new()))
             });
             let arr = arr
                 .as_array_mut()
-                .ok_or_else(|| format!("[{tool}].{key} is not an array"))?;
+                .ok_or_else(|| format!("[mcp.{server}].{key} is not an array"))?;
             let already_exists = arr
                 .iter()
-                .any(|v| v.as_str().is_some_and(|existing| existing == s));
+                .any(|v| v.as_str().is_some_and(|existing| existing == &**tool_name));
             if !already_exists {
-                arr.push(s);
+                arr.push(&**tool_name);
                 arr.set_trailing("\n");
                 arr.set_trailing_comma(true);
                 for item in arr.iter_mut() {
@@ -1205,8 +1823,70 @@ fn insert_permission_entry(
                 }
             }
         }
-        None => {
-            tool_table.insert(key, toml_edit::value(true));
+        ToolKey::McpServer { server } => {
+            // Server-wide default: write default = "allow" / "deny"
+            if scope.is_some() {
+                tracing::debug!(
+                    server = %server,
+                    scope = ?scope,
+                    "MCP server scope ignored (always wildcarded)"
+                );
+            }
+            let default_str = match effect {
+                Effect::Allow => "allow",
+                Effect::Deny => "deny",
+            };
+            let mcp_item = doc
+                .entry("mcp")
+                .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
+            let mcp_table = mcp_item
+                .as_table_mut()
+                .ok_or_else(|| "[mcp] is not a table".to_string())?;
+            let server_item = mcp_table
+                .entry(server)
+                .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
+            let server_table = server_item
+                .as_table_mut()
+                .ok_or_else(|| format!("[mcp.{server}] is not a table"))?;
+            server_table.insert("default", toml_edit::value(default_str));
+        }
+        ToolKey::Wildcard => {
+            // Wildcard rules are config-only; runtime never writes them.
+            // A bare `*` key is invalid TOML, so we reject the write.
+            return Err("cannot write wildcard permission rule to config".to_string());
+        }
+        ToolKey::Native(name) => {
+            let tool_table = doc
+                .entry(name.as_ref())
+                .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
+            let tool_table = tool_table
+                .as_table_mut()
+                .ok_or_else(|| format!("[{name}] is not a table"))?;
+
+            match scope {
+                Some(s) => {
+                    let arr = tool_table.entry(key).or_insert_with(|| {
+                        toml_edit::Item::Value(toml_edit::Value::Array(toml_edit::Array::new()))
+                    });
+                    let arr = arr
+                        .as_array_mut()
+                        .ok_or_else(|| format!("[{name}].{key} is not an array"))?;
+                    let already_exists = arr
+                        .iter()
+                        .any(|v| v.as_str().is_some_and(|existing| existing == s));
+                    if !already_exists {
+                        arr.push(s);
+                        arr.set_trailing("\n");
+                        arr.set_trailing_comma(true);
+                        for item in arr.iter_mut() {
+                            item.decor_mut().set_prefix("\n    ");
+                        }
+                    }
+                }
+                None => {
+                    tool_table.insert(key, toml_edit::value(true));
+                }
+            }
         }
     }
     Ok(())
@@ -1470,10 +2150,10 @@ mod tests {
         assert_eq!(perms.default, DefaultEffect::Allow);
         assert_eq!(perms.rules.len(), 2);
         assert_eq!(perms.rules[0].effect, Effect::Deny);
-        assert_eq!(perms.rules[0].tool, "bash");
+        assert_eq!(perms.rules[0].tool, ToolKey::native("bash"));
         assert_eq!(perms.rules[0].scope.as_deref(), Some("rm -rf *"));
         assert_eq!(perms.rules[1].effect, Effect::Allow);
-        assert_eq!(perms.rules[1].tool, "bash");
+        assert_eq!(perms.rules[1].tool, ToolKey::native("bash"));
         assert_eq!(perms.rules[1].scope.as_deref(), Some("cargo *"));
     }
 
@@ -1510,12 +2190,12 @@ mod tests {
             .collect();
 
         assert_eq!(deny_rules.len(), 2);
-        assert_eq!(deny_rules[0].tool, "bash");
-        assert_eq!(deny_rules[1].tool, "write");
+        assert_eq!(deny_rules[0].tool, ToolKey::native("bash"));
+        assert_eq!(deny_rules[1].tool, ToolKey::native("write"));
 
         assert_eq!(allow_rules.len(), 2);
-        assert_eq!(allow_rules[0].tool, "bash");
-        assert_eq!(allow_rules[1].tool, "read");
+        assert_eq!(allow_rules[0].tool, ToolKey::native("bash"));
+        assert_eq!(allow_rules[1].tool, ToolKey::native("read"));
     }
 
     #[test]
@@ -1537,7 +2217,7 @@ mod tests {
         fs::create_dir_all(&global).unwrap();
 
         append_permission_rule_with_global(
-            "bash",
+            &ToolKey::native("bash"),
             Some("cargo *"),
             Effect::Allow,
             &PermissionTarget::Global,
@@ -1545,7 +2225,7 @@ mod tests {
         )
         .unwrap();
         append_permission_rule_with_global(
-            "bash",
+            &ToolKey::native("bash"),
             Some("rm -rf *"),
             Effect::Deny,
             &PermissionTarget::Global,
@@ -1558,6 +2238,28 @@ mod tests {
         assert!(content.contains("cargo *"));
         assert!(content.contains("rm -rf *"));
         assert!(!content.contains("[permissions]"));
+    }
+
+    #[test]
+    fn append_permission_rule_writes_mcp_nested_form() {
+        let dir = TempDir::new().unwrap();
+        let global = global_config_dir(dir.path());
+        fs::create_dir_all(&global).unwrap();
+
+        append_permission_rule_with_global(
+            &ToolKey::parse("deepwiki.search").unwrap(),
+            Some("*"),
+            Effect::Allow,
+            &PermissionTarget::Global,
+            Some(global.clone()),
+        )
+        .unwrap();
+
+        let content = fs::read_to_string(global.join("permissions.toml")).unwrap();
+        assert!(content.contains("[mcp.deepwiki]"), "nested table present");
+        assert!(content.contains("\"search\""), "tool name in array");
+        assert!(!content.contains("deepwiki.search"), "no flat key");
+        assert!(!content.contains("__"), "no __ separator");
     }
 
     #[test]
@@ -1605,7 +2307,7 @@ mod tests {
         let perms = load_permissions_inner(dir.path(), std::slice::from_ref(&global));
         assert_eq!(perms.default, DefaultEffect::Deny);
         assert_eq!(
-            perms.tool_defaults.get("bash").copied(),
+            perms.tool_defaults.get(&ToolKey::native("bash")).copied(),
             Some(DefaultEffect::Allow)
         );
     }
@@ -1625,7 +2327,7 @@ mod tests {
 
         let perms = load_permissions_inner(dir.path(), std::slice::from_ref(&global));
         assert_eq!(
-            perms.tool_defaults.get("bash").copied(),
+            perms.tool_defaults.get(&ToolKey::native("bash")).copied(),
             Some(DefaultEffect::Deny)
         );
     }
@@ -1680,7 +2382,7 @@ mod tests {
         fs::create_dir_all(&global).unwrap();
 
         append_permission_rule_with_global(
-            "bash",
+            &ToolKey::native("bash"),
             Some("cargo *"),
             Effect::Allow,
             &PermissionTarget::Global,
@@ -1688,7 +2390,7 @@ mod tests {
         )
         .unwrap();
         append_permission_rule_with_global(
-            "bash",
+            &ToolKey::native("bash"),
             Some("cargo *"),
             Effect::Allow,
             &PermissionTarget::Global,
@@ -1696,7 +2398,7 @@ mod tests {
         )
         .unwrap();
         append_permission_rule_with_global(
-            "bash",
+            &ToolKey::native("bash"),
             Some("cargo *"),
             Effect::Allow,
             &PermissionTarget::Global,
@@ -2032,5 +2734,198 @@ mod tests {
                 "{name} should be enabled when configured"
             );
         }
+    }
+
+    #[test]
+    fn permissions_mcp_per_tool_allow() {
+        let dir = TempDir::new().unwrap();
+        let global = global_config_dir(dir.path());
+        write_global_permissions(
+            dir.path(),
+            "[mcp.deepwiki]\nallow = [\"search\", \"fetch\"]\n",
+        );
+        let perms = load_permissions_inner(dir.path(), std::slice::from_ref(&global));
+        assert_eq!(perms.rules.len(), 2);
+        assert!(perms.rules.iter().any(|r| r.tool
+            == ToolKey::McpTool {
+                server: "deepwiki".into(),
+                tool: "search".into()
+            }
+            && r.effect == Effect::Allow));
+        assert!(perms.rules.iter().any(|r| r.tool
+            == ToolKey::McpTool {
+                server: "deepwiki".into(),
+                tool: "fetch".into()
+            }
+            && r.effect == Effect::Allow));
+    }
+
+    #[test]
+    fn permissions_mcp_server_wide_allow_true_ignored() {
+        let dir = TempDir::new().unwrap();
+        let global = global_config_dir(dir.path());
+        write_global_permissions(dir.path(), "[mcp.deepwiki]\nallow = true\n");
+        let perms = load_permissions_inner(dir.path(), std::slice::from_ref(&global));
+        assert_eq!(perms.rules.len(), 0, "no rules generated");
+        assert!(
+            !perms.tool_defaults.contains_key(&ToolKey::McpServer {
+                server: "deepwiki".into()
+            }),
+            "allow = true is deprecated and ignored — no default injected"
+        );
+    }
+
+    #[test]
+    fn permissions_mcp_deny_true_ignored() {
+        let dir = TempDir::new().unwrap();
+        let global = global_config_dir(dir.path());
+        write_global_permissions(dir.path(), "[mcp.server]\ndeny = true\n");
+        let perms = load_permissions_inner(dir.path(), std::slice::from_ref(&global));
+        assert!(
+            !perms.tool_defaults.contains_key(&ToolKey::McpServer {
+                server: "server".into()
+            }),
+            "deny = true is deprecated and ignored — no default injected"
+        );
+    }
+
+    #[test]
+    fn explicit_default_preserved_with_deprecated_deny_true() {
+        let dir = TempDir::new().unwrap();
+        let global = global_config_dir(dir.path());
+        write_global_permissions(
+            dir.path(),
+            "[mcp.server]\ndefault = \"allow\"\ndeny = true\n",
+        );
+        let perms = load_permissions_inner(dir.path(), std::slice::from_ref(&global));
+        assert_eq!(
+            perms.tool_defaults.get(&ToolKey::McpServer {
+                server: "server".into()
+            }),
+            Some(&DefaultEffect::Allow),
+            "explicit default still works; deprecated deny = true is ignored"
+        );
+    }
+
+    #[test]
+    fn permissions_mcp_deny_rules() {
+        let dir = TempDir::new().unwrap();
+        let global = global_config_dir(dir.path());
+        write_global_permissions(dir.path(), "[mcp.github]\ndeny = [\"admin_delete\"]\n");
+        let perms = load_permissions_inner(dir.path(), std::slice::from_ref(&global));
+        assert_eq!(perms.rules.len(), 1);
+        assert_eq!(
+            perms.rules[0].tool,
+            ToolKey::McpTool {
+                server: "github".into(),
+                tool: "admin_delete".into()
+            }
+        );
+        assert_eq!(perms.rules[0].effect, Effect::Deny);
+    }
+
+    #[test]
+    fn permissions_mcp_dotted_tool_name_rejected() {
+        let dir = TempDir::new().unwrap();
+        let global = global_config_dir(dir.path());
+        write_global_permissions(dir.path(), "[mcp.myserver]\nallow = [\"web.search\"]\n");
+        let perms = load_permissions_inner(dir.path(), std::slice::from_ref(&global));
+        assert_eq!(perms.rules.len(), 0, "dotted tool name should be rejected");
+    }
+
+    #[test]
+    fn permissions_mcp_default_allow() {
+        let dir = TempDir::new().unwrap();
+        let global = global_config_dir(dir.path());
+        write_global_permissions(
+            dir.path(),
+            "default = \"deny\"\n\n[mcp.exa]\ndefault = \"allow\"\n",
+        );
+        let perms = load_permissions_inner(dir.path(), std::slice::from_ref(&global));
+        assert_eq!(
+            perms.tool_defaults.get(&ToolKey::McpServer {
+                server: "exa".into()
+            }),
+            Some(&DefaultEffect::Allow),
+            "MCP server default should be extracted"
+        );
+    }
+
+    #[test]
+    fn permissions_mcp_default_prompt() {
+        let dir = TempDir::new().unwrap();
+        let global = global_config_dir(dir.path());
+        write_global_permissions(
+            dir.path(),
+            "[mcp.exa]\ndefault = \"prompt\"\nallow = [\"search\"]\n",
+        );
+        let perms = load_permissions_inner(dir.path(), std::slice::from_ref(&global));
+        assert_eq!(
+            perms.tool_defaults.get(&ToolKey::McpServer {
+                server: "exa".into()
+            }),
+            Some(&DefaultEffect::Prompt),
+            "MCP server default = prompt should be extracted"
+        );
+        assert_eq!(perms.rules.len(), 1);
+        assert_eq!(
+            perms.rules[0].tool,
+            ToolKey::McpTool {
+                server: "exa".into(),
+                tool: "search".into()
+            }
+        );
+    }
+
+    #[test]
+    fn migrate_mcp_old_flat_keys() {
+        let dir = TempDir::new().unwrap();
+        let global = global_config_dir(dir.path());
+        fs::create_dir_all(&global).unwrap();
+        // Old maki format used quoted TOML keys for mcp:server__tool
+        fs::write(
+            global.join("permissions.toml"),
+            "[\"mcp:deepwiki__search\"]\nallow = true\n\
+             [\"mcp:github__issue\"]\nallow = [\"read\"]\n",
+        )
+        .unwrap();
+
+        let _perms = load_permissions_inner(dir.path(), std::slice::from_ref(&global));
+
+        let content = fs::read_to_string(global.join("permissions.toml")).unwrap();
+        assert!(content.contains("[mcp.deepwiki]"), "server table present");
+        assert!(content.contains("[mcp.github]"), "server table present");
+        assert!(content.contains("\"search\""), "tool name migrated");
+        assert!(content.contains("\"issue\""), "tool name migrated");
+        assert!(
+            !content.contains("mcp:deepwiki__search"),
+            "old flat key gone"
+        );
+        assert!(!content.contains("mcp:github__issue"), "old flat key gone");
+        assert!(!content.contains("__"), "no old __ separator remains");
+    }
+
+    #[test]
+    fn migrate_mcp_nested_bare_keys() {
+        let dir = TempDir::new().unwrap();
+        let global = global_config_dir(dir.path());
+        fs::create_dir_all(&global).unwrap();
+        // Bare TOML key [mcp.deepwiki__search] creates nested mcp → deepwiki__search
+        fs::write(
+            global.join("permissions.toml"),
+            "[mcp]\n\
+             deepwiki__search = true\n\
+             github__issue = true\n",
+        )
+        .unwrap();
+
+        let _perms = load_permissions_inner(dir.path(), std::slice::from_ref(&global));
+
+        let content = fs::read_to_string(global.join("permissions.toml")).unwrap();
+        assert!(content.contains("[mcp.deepwiki]"), "server table present");
+        assert!(content.contains("[mcp.github]"), "server table present");
+        assert!(content.contains("\"search\""), "tool name migrated");
+        assert!(content.contains("\"issue\""), "tool name migrated");
+        assert!(!content.contains("__"), "no old __ separator remains");
     }
 }

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -1481,8 +1481,8 @@ fn load_permissions_inner(cwd: &Path, global_dirs: &[PathBuf]) -> PermissionsCon
         }
     }
 
-    let project_perms = read_permissions_file(&cwd.join(PROJECT_DIR).join(PERMISSIONS_FILE))
-        .unwrap_or_default();
+    let project_perms =
+        read_permissions_file(&cwd.join(PROJECT_DIR).join(PERMISSIONS_FILE)).unwrap_or_default();
 
     build_permissions(global_perms, project_perms)
 }
@@ -2840,6 +2840,9 @@ mod tests {
 
         assert_eq!(perms.rules.len(), 1);
         assert_eq!(perms.rules[0].effect, Effect::Deny);
-        assert_eq!(perms.rules[0].tool, ToolKey::parse("github.delete").unwrap());
+        assert_eq!(
+            perms.rules[0].tool,
+            ToolKey::parse("github.delete").unwrap()
+        );
     }
 }

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -461,7 +461,7 @@ impl<'de> Deserialize<'de> for PermissionsFileConfig {
         let mut mcp_defaults = HashMap::new();
 
         for (k, v) in table.iter() {
-            if k == "allow_all" || k == "default" {
+            if k.is_empty() || k == "allow_all" || k == "default" {
                 continue;
             }
             if k == "mcp" {
@@ -1122,10 +1122,6 @@ fn push_rules(
     effect: Effect,
 ) {
     for (tool, perms) in tools {
-        if tool.is_empty() {
-            tracing::warn!("skipping permission rule for empty tool name");
-            continue;
-        }
         let scope_set = match effect {
             Effect::Deny => &perms.deny,
             Effect::Allow => &perms.allow,
@@ -1192,24 +1188,32 @@ fn push_mcp_tool_rule(
     }
 }
 
-fn insert_or_create_array(table: &mut toml_edit::Table, key: &str, value: &str) {
-    match table
+fn child_table<'a>(
+    table: &'a mut toml_edit::Table,
+    key: &str,
+) -> Result<&'a mut toml_edit::Table, String> {
+    table
+        .entry(key)
+        .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()))
+        .as_table_mut()
+        .ok_or_else(|| format!("[{key}] is not a table"))
+}
+
+fn push_unique(table: &mut toml_edit::Table, key: &str, value: &str) -> Result<(), String> {
+    let arr = table
         .entry(key)
         .or_insert_with(|| toml_edit::Item::Value(toml_edit::Value::Array(toml_edit::Array::new())))
-    {
-        toml_edit::Item::Value(toml_edit::Value::Array(arr)) => {
-            if !arr.iter().any(|v| v.as_str() == Some(value)) {
-                arr.push(value);
-            }
-        }
-        slot => {
-            *slot = toml_edit::Item::Value(toml_edit::Value::Array({
-                let mut arr = toml_edit::Array::new();
-                arr.push(value);
-                arr
-            }));
+        .as_array_mut()
+        .ok_or_else(|| format!("{key} is not an array"))?;
+    if !arr.iter().any(|v| v.as_str() == Some(value)) {
+        arr.push(value);
+        arr.set_trailing("\n");
+        arr.set_trailing_comma(true);
+        for item in arr.iter_mut() {
+            item.decor_mut().set_prefix("\n    ");
         }
     }
+    Ok(())
 }
 
 fn parse_mcp_server_table(
@@ -1472,16 +1476,13 @@ pub fn load_permissions(cwd: &Path) -> PermissionsConfig {
 fn load_permissions_inner(cwd: &Path, global_dirs: &[PathBuf]) -> PermissionsConfig {
     let mut global_perms = PermissionsFileConfig::default();
     for dir in global_dirs {
-        let path = dir.join(PERMISSIONS_FILE);
-        migrate_permissions_file(&path);
-        if let Some(p) = read_permissions_file(&path) {
+        if let Some(p) = read_permissions_file(&dir.join(PERMISSIONS_FILE)) {
             global_perms = p;
         }
     }
 
-    let project_path = cwd.join(PROJECT_DIR).join(PERMISSIONS_FILE);
-    migrate_permissions_file(&project_path);
-    let project_perms = read_permissions_file(&project_path).unwrap_or_default();
+    let project_perms = read_permissions_file(&cwd.join(PROJECT_DIR).join(PERMISSIONS_FILE))
+        .unwrap_or_default();
 
     build_permissions(global_perms, project_perms)
 }
@@ -1492,88 +1493,46 @@ fn migrate_mcp_entry(
     tool_name: &str,
     item: &toml_edit::Item,
 ) {
-    // Old format: ["mcp:server__tool"] allow = ["scope_strings"]
-    // New format: [mcp.server] allow = ["tool_names"]
-    // Old array values were scope strings, but MCP scopes are always
-    // generalized to "*" at check time (see generalize_scope), so those
-    // scope strings were dead code. We replace them with the tool name
-    // extracted from the key, which is the correct semantic for the new format.
-
-    // Create [mcp.server] as nested table: mcp → server → {allow/deny}
-    let mcp_item = doc
-        .entry("mcp")
-        .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
-    let Some(mcp_table) = mcp_item.as_table_mut() else {
-        tracing::warn!(
-            server = server_name,
-            "[mcp] is not a table — skipping migration"
-        );
-        return;
-    };
-    let server_item = mcp_table
-        .entry(server_name)
-        .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
-    let Some(server_table) = server_item.as_table_mut() else {
-        tracing::warn!(
-            server = server_name,
-            "[mcp.{server_name}] is not a table — skipping migration"
-        );
-        return;
+    // Old format: ["mcp:server__tool"] with booleans or scope-string arrays.
+    // New format: [mcp.server] allow = ["tool_name"]. Old scope strings were
+    // dead code (MCP scopes are always wildcarded), so only the effect survives.
+    let mut push = |effect_key: &str| {
+        let res = child_table(doc.as_table_mut(), "mcp")
+            .and_then(|mcp| child_table(mcp, server_name))
+            .and_then(|server| push_unique(server, effect_key, tool_name));
+        if let Err(e) = res {
+            warn!(
+                server = server_name,
+                tool = tool_name,
+                error = %e,
+                "skipping MCP entry migration"
+            );
+        }
     };
 
     // Bare boolean: old format like [mcp]\ndeepwiki__search = true
-    // means "allow this tool" — treat as allow = [tool_name].
-    if let Some(toml_edit::Value::Boolean(b)) = item.as_value() {
-        if *b.value() {
-            insert_or_create_array(server_table, "allow", tool_name);
+    // means "allow this tool".
+    if let Some(b) = item.as_bool() {
+        if b {
+            push("allow");
         }
         return;
     }
 
     if let Some(old_table) = item.as_table() {
-        for (effect_key, effect_value) in old_table {
-            let key_str: &str = effect_key;
-            match key_str {
+        for (key, value) in old_table.iter() {
+            match key {
                 "allow" | "deny" => {
-                    match effect_value {
-                        toml_edit::Item::Value(toml_edit::Value::Boolean(b)) if *b.value() => {
-                            insert_or_create_array(server_table, key_str, tool_name);
-                        }
-                        toml_edit::Item::Value(toml_edit::Value::Array(old_arr)) => {
-                            if !old_arr.is_empty() {
-                                tracing::warn!(
-                                    server = server_name,
-                                    tool = tool_name,
-                                    "old MCP scope strings dropped during migration \
-                                     (MCP scopes are always wildcarded)"
-                                );
-                            }
-                            insert_or_create_array(server_table, key_str, tool_name);
-                        }
-                        toml_edit::Item::Value(toml_edit::Value::Boolean(b)) if !b.value() => {
-                            // allow = false / deny = false → no rule, but log for transparency.
-                            tracing::info!(
-                                key = key_str,
-                                tool = tool_name,
-                                "{key_str} = false — no rule generated"
-                            );
-                        }
-                        _ => {
-                            tracing::warn!(
-                                key = key_str,
-                                tool = tool_name,
-                                value = format!("{:?}", effect_value),
-                                "unexpected value type for {key_str} in migration — skipping"
-                            );
-                        }
+                    if value.as_bool() == Some(true) || value.as_array().is_some() {
+                        push(key);
                     }
                 }
                 _ => {
-                    tracing::warn!(
-                        key = key_str,
+                    warn!(
+                        key,
                         server = server_name,
                         tool = tool_name,
-                        "unknown key \"{key_str}\" in old MCP entry during migration — dropping"
+                        "dropping unknown key in old MCP entry during migration"
                     );
                 }
             }
@@ -1581,12 +1540,13 @@ fn migrate_mcp_entry(
     }
 }
 
-fn migrate_permissions_file(path: &Path) {
-    let Ok(content) = fs::read_to_string(path) else {
-        return;
-    };
+/// Migrates old permission formats and returns the (possibly rewritten)
+/// file content. The rewrite to disk is best-effort: loading uses the
+/// migrated content even when the write fails.
+fn migrate_permissions_file(path: &Path) -> Option<String> {
+    let content = fs::read_to_string(path).ok()?;
     let Ok(mut doc) = content.parse::<toml_edit::DocumentMut>() else {
-        return;
+        return Some(content);
     };
     let mut migrated = false;
 
@@ -1673,13 +1633,18 @@ fn migrate_permissions_file(path: &Path) {
         doc.remove("mcp");
     }
 
-    if migrated && let Err(e) = maki_storage::atomic_write(path, doc.to_string().as_bytes()) {
-        warn!(path = %path.display(), error = %e, "failed to migrate permissions file");
+    if !migrated {
+        return Some(content);
     }
+    let new_content = doc.to_string();
+    if let Err(e) = maki_storage::atomic_write(path, new_content.as_bytes()) {
+        warn!(path = %path.display(), error = %e, "failed to persist migrated permissions file");
+    }
+    Some(new_content)
 }
 
 fn read_permissions_file(path: &Path) -> Option<PermissionsFileConfig> {
-    let content = fs::read_to_string(path).ok()?;
+    let content = migrate_permissions_file(path)?;
     match toml::from_str(&content) {
         Ok(p) => Some(p),
         Err(e) => {
@@ -1780,109 +1745,23 @@ fn insert_permission_entry(
     };
 
     match tool_key {
-        ToolKey::McpTool {
-            server,
-            tool: tool_name,
-        } => {
-            // MCP scopes are always wildcarded — scope parameter is intentionally ignored.
-            if scope.is_some() {
-                tracing::debug!(
-                    tool = %tool_name,
-                    scope = ?scope,
-                    "MCP tool scope ignored (always wildcarded)"
-                );
-            }
-            let mcp_item = doc
-                .entry("mcp")
-                .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
-            let mcp_table = mcp_item
-                .as_table_mut()
-                .ok_or_else(|| "[mcp] is not a table".to_string())?;
-            let server_item = mcp_table
-                .entry(server)
-                .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
-            let server_table = server_item
-                .as_table_mut()
-                .ok_or_else(|| format!("[mcp.{server}] is not a table"))?;
-
-            let arr = server_table.entry(key).or_insert_with(|| {
-                toml_edit::Item::Value(toml_edit::Value::Array(toml_edit::Array::new()))
-            });
-            let arr = arr
-                .as_array_mut()
-                .ok_or_else(|| format!("[mcp.{server}].{key} is not an array"))?;
-            let already_exists = arr
-                .iter()
-                .any(|v| v.as_str().is_some_and(|existing| existing == &**tool_name));
-            if !already_exists {
-                arr.push(&**tool_name);
-                arr.set_trailing("\n");
-                arr.set_trailing_comma(true);
-                for item in arr.iter_mut() {
-                    item.decor_mut().set_prefix("\n    ");
-                }
-            }
+        // MCP scopes are always wildcarded, so `scope` is ignored for MCP keys.
+        ToolKey::McpTool { server, tool } => {
+            let server_table = child_table(child_table(doc.as_table_mut(), "mcp")?, server)?;
+            push_unique(server_table, key, tool)?;
         }
         ToolKey::McpServer { server } => {
-            // Server-wide default: write default = "allow" / "deny"
-            if scope.is_some() {
-                tracing::debug!(
-                    server = %server,
-                    scope = ?scope,
-                    "MCP server scope ignored (always wildcarded)"
-                );
-            }
-            let default_str = match effect {
-                Effect::Allow => "allow",
-                Effect::Deny => "deny",
-            };
-            let mcp_item = doc
-                .entry("mcp")
-                .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
-            let mcp_table = mcp_item
-                .as_table_mut()
-                .ok_or_else(|| "[mcp] is not a table".to_string())?;
-            let server_item = mcp_table
-                .entry(server)
-                .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
-            let server_table = server_item
-                .as_table_mut()
-                .ok_or_else(|| format!("[mcp.{server}] is not a table"))?;
-            server_table.insert("default", toml_edit::value(default_str));
+            let server_table = child_table(child_table(doc.as_table_mut(), "mcp")?, server)?;
+            server_table.insert("default", toml_edit::value(key));
         }
         ToolKey::Wildcard => {
             // Wildcard rules are config-only; runtime never writes them.
-            // A bare `*` key is invalid TOML, so we reject the write.
             return Err("cannot write wildcard permission rule to config".to_string());
         }
         ToolKey::Native(name) => {
-            let tool_table = doc
-                .entry(name.as_ref())
-                .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
-            let tool_table = tool_table
-                .as_table_mut()
-                .ok_or_else(|| format!("[{name}] is not a table"))?;
-
+            let tool_table = child_table(doc.as_table_mut(), name)?;
             match scope {
-                Some(s) => {
-                    let arr = tool_table.entry(key).or_insert_with(|| {
-                        toml_edit::Item::Value(toml_edit::Value::Array(toml_edit::Array::new()))
-                    });
-                    let arr = arr
-                        .as_array_mut()
-                        .ok_or_else(|| format!("[{name}].{key} is not an array"))?;
-                    let already_exists = arr
-                        .iter()
-                        .any(|v| v.as_str().is_some_and(|existing| existing == s));
-                    if !already_exists {
-                        arr.push(s);
-                        arr.set_trailing("\n");
-                        arr.set_trailing_comma(true);
-                        for item in arr.iter_mut() {
-                            item.decor_mut().set_prefix("\n    ");
-                        }
-                    }
-                }
+                Some(s) => push_unique(tool_table, key, s)?,
                 None => {
                     tool_table.insert(key, toml_edit::value(true));
                 }
@@ -2927,5 +2806,40 @@ mod tests {
         assert!(content.contains("\"search\""), "tool name migrated");
         assert!(content.contains("\"issue\""), "tool name migrated");
         assert!(!content.contains("__"), "no old __ separator remains");
+    }
+
+    #[test]
+    fn empty_tool_key_sections_ignored() {
+        let dir = TempDir::new().unwrap();
+        let global = global_config_dir(dir.path());
+        write_global_permissions(dir.path(), "[\"\"]\ndefault = \"allow\"\nallow = [\"x\"]\n");
+        let perms = load_permissions_inner(dir.path(), std::slice::from_ref(&global));
+        assert!(perms.rules.is_empty());
+        assert!(perms.tool_defaults.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn migration_applies_in_memory_when_write_fails() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let global = global_config_dir(dir.path());
+        fs::create_dir_all(&global).unwrap();
+        fs::write(
+            global.join("permissions.toml"),
+            "[\"mcp:github__delete\"]\ndeny = true\n",
+        )
+        .unwrap();
+        fs::set_permissions(&global, fs::Permissions::from_mode(0o555)).unwrap();
+        if fs::write(global.join("probe"), b"x").is_ok() {
+            return; // running as root, cannot simulate a read-only dir
+        }
+
+        let perms = load_permissions_inner(dir.path(), std::slice::from_ref(&global));
+        fs::set_permissions(&global, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert_eq!(perms.rules.len(), 1);
+        assert_eq!(perms.rules[0].effect, Effect::Deny);
+        assert_eq!(perms.rules[0].tool, ToolKey::parse("github.delete").unwrap());
     }
 }

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -1059,7 +1059,8 @@ impl App {
         }
 
         if let ChatEventResult::PermissionRequest { id, tool, scopes } = result {
-            self.permission_prompt.open(id, tool, scopes, subagent_id);
+            self.permission_prompt
+                .open(id, tool, scopes, subagent_id.clone());
             return vec![];
         }
 

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -139,27 +139,70 @@ impl From<Mode> for StoredMode {
 pub(crate) fn rules_to_stored(rules: &[maki_config::PermissionRule]) -> Vec<StoredRule> {
     rules
         .iter()
-        .map(|r| StoredRule {
-            tool: r.tool.clone(),
-            scope: r.scope.clone(),
-            effect: match r.effect {
+        .map(|r| {
+            let effect = match r.effect {
                 Effect::Allow => StoredEffect::Allow,
                 Effect::Deny => StoredEffect::Deny,
-            },
+            };
+            StoredRule {
+                tool: r.tool.to_string(),
+                scope: r.scope.clone(),
+                effect,
+            }
         })
         .collect()
+}
+
+/// Migrate old stored tool key formats to `ToolKey`.
+/// Handles `"mcp:server__tool"` (pre-PR1 format) -> `McpTool`.
+/// All other formats go through `ToolKey::parse` (current format: `server.tool`).
+fn migrate_stored_tool_key(s: &str) -> Option<maki_config::ToolKey> {
+    // Pre-PR1 format: "mcp:server__tool" — rewrite to new format and parse.
+    if let Some(rest) = s.strip_prefix("mcp:")
+        && let Some((server, tool)) = rest.split_once("__")
+    {
+        let new_form = format!("{server}.{tool}");
+        return maki_config::ToolKey::parse(&new_form)
+            .map_err(
+                |e| tracing::warn!(key = s, error = %e, "malformed stored tool key — skipping"),
+            )
+            .ok();
+    }
+    match maki_config::ToolKey::parse(s) {
+        Ok(key) => Some(key),
+        Err(e) => {
+            tracing::error!(key = s, error = %e, "malformed stored tool key — rule DROPPED; a deny rule may have been lost");
+            None
+        }
+    }
 }
 
 pub(crate) fn stored_to_rules(stored: &[StoredRule]) -> Vec<maki_config::PermissionRule> {
     stored
         .iter()
-        .map(|r| maki_config::PermissionRule {
-            tool: r.tool.clone(),
-            scope: r.scope.clone(),
-            effect: match r.effect {
+        .filter_map(|r| {
+            let tool = match migrate_stored_tool_key(&r.tool) {
+                Some(t) => t,
+                None => {
+                    if matches!(r.effect, StoredEffect::Deny) {
+                        tracing::error!(
+                            key = %r.tool,
+                            "SECURITY: stored DENY rule dropped — tool may now be accessible. \
+                             Re-add this rule manually in permissions.toml"
+                        );
+                    }
+                    return None;
+                }
+            };
+            let effect = match r.effect {
                 StoredEffect::Allow => Effect::Allow,
                 StoredEffect::Deny => Effect::Deny,
-            },
+            };
+            Some(maki_config::PermissionRule {
+                tool,
+                scope: r.scope.clone(),
+                effect,
+            })
         })
         .collect()
 }

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -2509,8 +2509,12 @@ fn agent_error_creates_synthetic_tool_done_with_message() {
 #[test]
 fn ctrl_c_denies_permission_prompt() {
     let mut app = test_app();
-    app.permission_prompt
-        .open("id".into(), "bash".into(), vec!["execute".into()], None);
+    app.permission_prompt.open(
+        "id".into(),
+        maki_config::ToolKey::native("bash"),
+        vec!["execute".into()],
+        None,
+    );
     assert!(app.permission_prompt.is_open());
 
     let actions = app.update(Msg::Key(kb::QUIT.to_key_event()));
@@ -2613,8 +2617,12 @@ fn permission_prompt_takes_bottom_precedence_over_below_split() {
     open_split_window(&mut app, maki_lua::Split::Below);
     open_split_window(&mut app, maki_lua::Split::Left);
     open_split_window(&mut app, maki_lua::Split::Above);
-    app.permission_prompt
-        .open("perm-1".into(), "bash".into(), vec!["ls".into()], None);
+    app.permission_prompt.open(
+        "perm-1".into(),
+        maki_config::ToolKey::native("bash"),
+        vec!["ls".into()],
+        None,
+    );
 
     let (_msg, _bottom, _status, _input, splits) = app.layout_geometry(TEST_AREA);
     assert!(

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -13,7 +13,7 @@ use crate::markdown::truncate_output;
 use crate::selection::Selection;
 use maki_agent::tools::{ToolInvocation, ToolRegistry, WRITE_TOOL_NAME};
 use maki_agent::{AgentEvent, BufferSnapshot, ToolDoneEvent, ToolOutput, ToolStartEvent};
-use maki_config::{ToolOutputLines, UiConfig};
+use maki_config::{ToolKey, ToolOutputLines, UiConfig};
 use maki_providers::{ContentBlock, Message, Role, TokenUsage};
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -33,7 +33,7 @@ pub enum ChatEventResult {
     Error(String),
     PermissionRequest {
         id: String,
-        tool: String,
+        tool: ToolKey,
         scopes: Vec<String>,
     },
     AuthRequired,

--- a/maki-ui/src/components/permission_prompt.rs
+++ b/maki-ui/src/components/permission_prompt.rs
@@ -6,6 +6,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Wrap};
 
 use maki_agent::permissions::{DEFAULT_DENY_GUIDANCE, PermissionAnswer, generalized_scopes};
+use maki_config::ToolKey;
 
 use crate::components::Overlay;
 use crate::components::form::render_form;
@@ -95,7 +96,7 @@ pub enum PermissionPrompt {
     Open {
         #[allow(dead_code)]
         id: String,
-        tool: String,
+        tool: ToolKey,
         scopes: Vec<String>,
         subagent_id: Option<String>,
         allow_scopes: Vec<String>,
@@ -126,7 +127,7 @@ impl PermissionPrompt {
     pub fn open(
         &mut self,
         id: String,
-        tool: String,
+        tool: ToolKey,
         scopes: Vec<String>,
         subagent_id: Option<String>,
     ) {
@@ -267,7 +268,7 @@ impl PermissionPrompt {
         if subagent_id.is_some() {
             tool_spans.push(Span::styled("[subtask] ", t.item_desc));
         }
-        tool_spans.push(Span::styled(tool.clone(), value_style));
+        tool_spans.push(Span::styled(tool.to_string(), value_style));
 
         let mut lines = vec![Line::raw(""), Line::from(tool_spans)];
         for (i, s) in scopes.iter().enumerate() {
@@ -365,12 +366,18 @@ impl PermissionPrompt {
 mod tests {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use maki_agent::permissions::PermissionAnswer;
+    use maki_config::ToolKey;
 
     use super::{PermissionPrompt, PromptState};
 
     fn open_prompt() -> PermissionPrompt {
         let mut prompt = PermissionPrompt::new();
-        prompt.open("id".into(), "bash".into(), vec!["execute".into()], None);
+        prompt.open(
+            "id".into(),
+            ToolKey::native("bash"),
+            vec!["execute".into()],
+            None,
+        );
         prompt
     }
 
@@ -450,5 +457,12 @@ mod tests {
         } else {
             panic!("expected Open");
         }
+    }
+
+    #[test]
+    fn wildcard_tool_key_opens() {
+        let mut prompt = PermissionPrompt::new();
+        prompt.open("id".into(), ToolKey::Wildcard, vec![], None);
+        assert!(matches!(prompt, PermissionPrompt::Open { .. }));
     }
 }

--- a/site/docs/content/permissions/_index.md
+++ b/site/docs/content/permissions/_index.md
@@ -9,21 +9,21 @@ group = "Reference"
 
 Maki uses a permission system to decide what each tool is allowed to do and when to ask you first.
 
-Rules come from three layers, checked in this order:
+Rules come from three layers, combined for resolution:
 
 1. **Session rules**, set during the current session (in-memory only)
 2. **Config rules**, loaded from TOML permission files
 3. **Builtin rules**, the hardcoded defaults
 
-First match wins.
+Any matching deny blocks the tool. No exceptions.
 
 ## Check Flow
 
 For every tool call, Maki resolves permission like this:
 
-1. If any **deny** rule matches, denied. Full stop.
-2. If **YOLO** is active, allowed.
-3. If all scopes match an **allow** rule, allowed.
+1. **Deny wins**: if any rule from any layer matches the tool and scope with a deny, the call is blocked immediately.
+2. If **YOLO** is active and no deny matched, allowed.
+3. **Plan file auto-allow**: file write tools targeting the plan file path are allowed automatically (only if no deny rule matched in step 1).
 4. Fall back to `default` (per-tool, then global). Built-in default is `"prompt"`.
 
 ## Builtin Defaults
@@ -64,10 +64,18 @@ deny = [
 ]
 
 [read]
-allow = true
+default = "allow"
+
+[mcp.deepwiki]
+allow = ["search", "fetch"]
+
+[mcp.github]
+deny = ["admin_delete"]
 ```
 
-Each tool gets its own section with `allow` and `deny` arrays. Values are glob-like scope patterns, or `true` to match everything.
+Each tool gets its own section with `allow` and `deny` arrays. Values are glob-like scope patterns.
+
+> **Note:** In MCP server sections (`[mcp.*]`), the boolean forms `allow = true` and `deny = true` are deprecated and ignored. Use `default = "allow"` or `default = "deny"` instead. For native tool sections (e.g. `[bash]`), `allow = true` still works.
 
 ### The `default` key
 
@@ -95,6 +103,23 @@ Note: `default = "allow"` only works in the global file. Projects cannot grant t
 | `dir/**` | `dir` itself or anything under it |
 | `exact` | Exact match only |
 
+## MCP Tool Permissions
+
+MCP tools use natural TOML nesting. Server names are table keys under `[mcp]`, tool names are array values:
+
+```toml
+[mcp.deepwiki]
+allow = ["search", "fetch"]    # allow these tools
+
+[mcp.github]
+deny = ["admin_delete"]         # deny this tool
+
+[mcp.lean-lsp]
+default = "allow"               # allow all tools on this server
+```
+
+Tool names must match `^[a-zA-Z0-9_-]{1,64}$` (no dots, max 64 chars). Server names cannot contain dots.
+
 ## Permission Prompts
 
 When a tool needs permission, Maki asks you. Here are the keys:
@@ -115,10 +140,10 @@ When you pick "always allow", the saved scope is generalized so it stays useful 
 
 - **bash**: `cargo test --all` becomes `cargo *`
 - **write/edit/multiedit**: `/path/to/file.rs` becomes `/path/to/**`
-- **MCP tools**: always `*` (per-tool, so allowing `mcp:fetch` won't cover `mcp:exec`)
+- **MCP tools**: always `*` (per-tool, so allowing `deepwiki.search` won't cover `deepwiki.fetch`)
 - **webfetch/websearch**: always `*`
 
-Deny rules are saved with the exact scope. You denied something specific, so it stays specific.
+For MCP tools, both allow and deny decisions generalize to `*` (the entire tool). This is because MCP tool inputs are opaque JSON with no meaningful scope pattern to differentiate. Denying a single MCP invocation denies the tool entirely until you revoke the rule.
 
 ## YOLO Mode
 

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -969,7 +969,7 @@ impl EventPump {
                     .tool_inputs
                     .get(id)
                     .cloned()
-                    .unwrap_or_else(|| (tool.clone(), Value::Null));
+                    .unwrap_or_else(|| (tool.to_string(), Value::Null));
 
                 self.request_counter += 1;
                 let req_id = format!("req_{}", self.request_counter);


### PR DESCRIPTION
Permission rules used flat strings for tool names, so MCP tools had to use ugly mcp:server__tool keys and first-match-wins made rule ordering matter more than intent. This rewrites tool identifiers as a typed enum with a ValidToolKey newtype (parse at boundary, never validate later), switches resolution to most-specific-wins with deny-wins-ties, and moves MCP config to natural TOML nesting. Old formats migrate automatically on load.

Fixes #405 