### PR TITLE
feat(providers): add /v1/responses endpoint support for local providers

### DIFF
--- a/maki-config/src/providers.rs
+++ b/maki-config/src/providers.rs
@@ -83,9 +83,10 @@ pub fn slugify(name: &str) -> String {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 pub enum Protocol {
     Openai,
+    OpenaiResponses,
     Anthropic,
     Google,
 }
@@ -96,6 +97,7 @@ impl FromStr for Protocol {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "openai" => Ok(Self::Openai),
+            "openai-responses" => Ok(Self::OpenaiResponses),
             "anthropic" => Ok(Self::Anthropic),
             "google" => Ok(Self::Google),
             _ => Err(format!("unknown protocol: {s}")),

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -9,6 +9,7 @@ use maki_config::providers::{
 };
 
 use super::ResolvedAuth;
+use super::openai::responses;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use crate::model::{FastPricing, Model, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider, ProviderKind};
@@ -28,7 +29,7 @@ fn resolve_provider_kind(slug: &str) -> Option<ProviderKind> {
     let config = ProvidersConfig::load();
     let def = config.get(slug)?;
     match def.protocol? {
-        Protocol::Openai => Some(ProviderKind::OpenAi),
+        Protocol::Openai | Protocol::OpenaiResponses => Some(ProviderKind::OpenAi),
         Protocol::Anthropic => Some(ProviderKind::Anthropic),
         Protocol::Google => Some(ProviderKind::Google),
     }
@@ -57,6 +58,9 @@ pub fn create(slug: &str, timeouts: Timeouts) -> Result<Box<dyn Provider>, Agent
     let resolved = resolve_custom_auth(slug)?;
     let auth = Arc::new(Mutex::new(resolved));
 
+    let config = ProvidersConfig::load();
+    let protocol = resolve_protocol(slug, config.get(slug)).unwrap_or(Protocol::Openai);
+
     match kind {
         ProviderKind::Anthropic => Ok(Box::new(super::anthropic::Anthropic::with_auth(
             auth, timeouts,
@@ -64,6 +68,7 @@ pub fn create(slug: &str, timeouts: Timeouts) -> Result<Box<dyn Provider>, Agent
         ProviderKind::OpenAi => Ok(Box::new(CustomOpenAiProvider {
             compat: OpenAiCompatProvider::new(&CUSTOM_OPENAI_CONFIG, timeouts),
             auth,
+            protocol,
         })),
         ProviderKind::Google => Ok(Box::new(super::google::Google::with_auth(auth, timeouts))),
         _ => Err(AgentError::Config {
@@ -78,7 +83,7 @@ pub fn lookup_model(slug: &str, model_id: &str) -> Option<Model> {
     let config = ProvidersConfig::load();
     let def = config.get(slug)?;
     let kind = match def.protocol? {
-        Protocol::Openai => ProviderKind::OpenAi,
+        Protocol::Openai | Protocol::OpenaiResponses => ProviderKind::OpenAi,
         Protocol::Anthropic => ProviderKind::Anthropic,
         Protocol::Google => ProviderKind::Google,
     };
@@ -198,6 +203,7 @@ pub fn discover_models(timeouts: Timeouts) -> Vec<String> {
 struct CustomOpenAiProvider {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
+    protocol: Protocol,
 }
 
 impl Provider for CustomOpenAiProvider {
@@ -211,12 +217,27 @@ impl Provider for CustomOpenAiProvider {
         opts: RequestOptions,
         _session_id: Option<&'a str>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
-        let auth = self.auth.lock().unwrap().clone();
-        let mut body = self.compat.build_body(model, messages, system, tools);
-        if matches!(opts.thinking, ThinkingConfig::Off) {
-            body["thinking"] = serde_json::json!({"type": "disabled"});
-        }
         Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+
+            if self.protocol == Protocol::OpenaiResponses {
+                let body = responses::build_body(model, messages, system, tools);
+                // TODO: wire thinking budget into responses API when llama.cpp supports it
+                return responses::do_stream(
+                    self.compat.client(),
+                    model,
+                    &body,
+                    event_tx,
+                    &auth,
+                    self.compat.stream_timeout(),
+                )
+                .await;
+            }
+
+            let mut body = self.compat.build_body(model, messages, system, tools);
+            if matches!(opts.thinking, ThinkingConfig::Off) {
+                body["thinking"] = serde_json::json!({"type": "disabled"});
+            }
             self.compat
                 .do_stream(model, &[], &body, event_tx, &auth)
                 .await

--- a/maki-providers/src/providers/local.rs
+++ b/maki-providers/src/providers/local.rs
@@ -6,10 +6,13 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use tracing::warn;
 
+use maki_config::providers::Protocol;
+
 use crate::model::Model;
 use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
 
+use super::openai::responses;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
 
@@ -26,6 +29,13 @@ pub(crate) struct LocalEndpointConfig {
     pub thinking_budget_field: bool,
 }
 
+fn resolve_protocol_for_local(slug: &str) -> Option<Protocol> {
+    maki_config::providers::resolve_protocol(
+        slug,
+        maki_config::providers::ProvidersConfig::load().get(slug),
+    )
+}
+
 pub(crate) struct LocalEndpoint {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
@@ -33,6 +43,7 @@ pub(crate) struct LocalEndpoint {
     system_prefix: Option<String>,
     thinking_budget_field: bool,
     discovery_mode: DiscoveryMode,
+    protocol: Option<Protocol>,
 }
 
 impl LocalEndpoint {
@@ -41,12 +52,17 @@ impl LocalEndpoint {
         timeouts: super::Timeouts,
     ) -> Result<Self, AgentError> {
         let key_pool = KeyPool::resolve(cfg.slug, cfg.api_key_env).ok();
-        let config = maki_config::providers::ProvidersConfig::load();
-        let host = config
+        let host = maki_config::providers::ProvidersConfig::load()
             .get(cfg.slug)
             .and_then(|d| d.base_url.clone())
             .or_else(|| std::env::var(cfg.host_env).ok());
-        Self::build(cfg, timeouts, key_pool, host)
+        Self::build(
+            cfg,
+            timeouts,
+            key_pool,
+            host,
+            resolve_protocol_for_local(cfg.slug),
+        )
     }
 
     pub(crate) fn with_auth(
@@ -61,6 +77,7 @@ impl LocalEndpoint {
             system_prefix: None,
             thinking_budget_field: cfg.thinking_budget_field,
             discovery_mode: cfg.discovery_mode,
+            protocol: resolve_protocol_for_local(cfg.slug),
         }
     }
 
@@ -74,6 +91,7 @@ impl LocalEndpoint {
         timeouts: super::Timeouts,
         key_pool: Option<KeyPool>,
         host: Option<String>,
+        protocol: Option<Protocol>,
     ) -> Result<Self, AgentError> {
         let api_key = key_pool.as_ref().map(|p| p.current().to_string());
         let base_url = match host {
@@ -102,6 +120,7 @@ impl LocalEndpoint {
             system_prefix: None,
             thinking_budget_field: cfg.thinking_budget_field,
             discovery_mode: cfg.discovery_mode,
+            protocol,
         })
     }
 }
@@ -119,6 +138,23 @@ impl Provider for LocalEndpoint {
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
+
+            if matches!(self.protocol, Some(Protocol::OpenaiResponses)) {
+                let mut buf = String::new();
+                let system = super::with_prefix(&self.system_prefix, system, &mut buf);
+                let body = responses::build_body(model, messages, system, tools);
+                // TODO: wire thinking budget into responses API when llama.cpp supports it
+                return responses::do_stream(
+                    self.compat.client(),
+                    model,
+                    &body,
+                    event_tx,
+                    &auth,
+                    self.compat.stream_timeout(),
+                )
+                .await;
+            }
+
             let mut buf = String::new();
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
@@ -478,7 +514,7 @@ mod tests {
 
     #[test]
     fn from_env_without_host_or_api_key_errors() {
-        match LocalEndpoint::build(&OLLAMA, TEST_TIMEOUTS, None, None) {
+        match LocalEndpoint::build(&OLLAMA, TEST_TIMEOUTS, None, None, None) {
             Err(AgentError::Config { message }) => {
                 assert_eq!(message, "OLLAMA_HOST not set");
             }
@@ -488,8 +524,14 @@ mod tests {
 
     #[test]
     fn from_env_with_host_builds_auth() {
-        let ep = LocalEndpoint::build(&OLLAMA, TEST_TIMEOUTS, None, Some("http://x:1234".into()))
-            .unwrap();
+        let ep = LocalEndpoint::build(
+            &OLLAMA,
+            TEST_TIMEOUTS,
+            None,
+            Some("http://x:1234".into()),
+            None,
+        )
+        .unwrap();
         let auth = ep.auth.lock().unwrap();
         assert_eq!(auth.base_url.as_deref(), Some("http://x:1234/v1"));
         assert!(auth.headers.is_empty());
@@ -498,7 +540,7 @@ mod tests {
     #[test]
     fn from_env_with_api_key_uses_cloud_for_ollama() {
         let pool = KeyPool::from_keys(vec!["test-key".into()]);
-        let ep = LocalEndpoint::build(&OLLAMA, TEST_TIMEOUTS, Some(pool), None).unwrap();
+        let ep = LocalEndpoint::build(&OLLAMA, TEST_TIMEOUTS, Some(pool), None, None).unwrap();
         let auth = ep.auth.lock().unwrap();
         assert_eq!(auth.base_url.as_deref(), Some("https://ollama.com/v1"));
         assert_eq!(auth.headers.len(), 1);
@@ -513,6 +555,7 @@ mod tests {
             TEST_TIMEOUTS,
             Some(pool),
             Some("http://local:1234".into()),
+            None,
         )
         .unwrap();
         let auth = ep.auth.lock().unwrap();
@@ -523,7 +566,7 @@ mod tests {
 
     #[test]
     fn llamacpp_without_host_errors() {
-        match LocalEndpoint::build(&LLAMACPP, TEST_TIMEOUTS, None, None) {
+        match LocalEndpoint::build(&LLAMACPP, TEST_TIMEOUTS, None, None, None) {
             Err(AgentError::Config { message }) => {
                 assert_eq!(message, "LLAMA_CPP_HOST not set");
             }
@@ -533,8 +576,14 @@ mod tests {
 
     #[test]
     fn llamacpp_with_host_builds_auth() {
-        let ep = LocalEndpoint::build(&LLAMACPP, TEST_TIMEOUTS, None, Some("http://x:1234".into()))
-            .unwrap();
+        let ep = LocalEndpoint::build(
+            &LLAMACPP,
+            TEST_TIMEOUTS,
+            None,
+            Some("http://x:1234".into()),
+            None,
+        )
+        .unwrap();
         let auth = ep.auth.lock().unwrap();
         assert_eq!(auth.base_url.as_deref(), Some("http://x:1234/v1"));
         assert!(auth.headers.is_empty());
@@ -543,7 +592,7 @@ mod tests {
     #[test]
     fn llamacpp_no_cloud_fallback() {
         let pool = KeyPool::from_keys(vec!["key".into()]);
-        match LocalEndpoint::build(&LLAMACPP, TEST_TIMEOUTS, Some(pool), None) {
+        match LocalEndpoint::build(&LLAMACPP, TEST_TIMEOUTS, Some(pool), None, None) {
             Err(AgentError::Config { message }) => {
                 assert_eq!(message, "LLAMA_CPP_HOST not set");
             }
@@ -553,15 +602,27 @@ mod tests {
 
     #[test]
     fn ollama_uses_ollama_discovery() {
-        let ep = LocalEndpoint::build(&OLLAMA, TEST_TIMEOUTS, None, Some("http://x:1234".into()))
-            .unwrap();
+        let ep = LocalEndpoint::build(
+            &OLLAMA,
+            TEST_TIMEOUTS,
+            None,
+            Some("http://x:1234".into()),
+            None,
+        )
+        .unwrap();
         assert!(matches!(ep.discovery_mode, DiscoveryMode::Ollama));
     }
 
     #[test]
     fn llamacpp_uses_llamacpp_discovery() {
-        let ep = LocalEndpoint::build(&LLAMACPP, TEST_TIMEOUTS, None, Some("http://x:1234".into()))
-            .unwrap();
+        let ep = LocalEndpoint::build(
+            &LLAMACPP,
+            TEST_TIMEOUTS,
+            None,
+            Some("http://x:1234".into()),
+            None,
+        )
+        .unwrap();
         assert!(matches!(ep.discovery_mode, DiscoveryMode::LlamaCpp));
     }
 


### PR DESCRIPTION
It happens llama.cpp supports the /v1/responses endpoint since around January 2026...

Add OpenaiResponses variant to Protocol enum in maki-config. Both LocalEndpoint (local.rs) and CustomOpenAiProvider (custom.rs) dispatch on Protocol::OpenaiResponses to use the /v1/responses API instead of /v1/chat/completions.

To opt-in with a llama.cpp backend, set protocol in providers.toml:

  [llama-cpp]
  protocol = "openai-responses"

The builtin default remains "openai" (chat completions).

Did this in preparation for support of [this new feature in llama.cpp](https://github.com/ggml-org/llama.cpp/pull/25348)
