### PR TITLE
ui, providers: add support for prompt processing progress in status bar with openai responses API

### DIFF
--- a/maki-agent/src/agent/streaming.rs
+++ b/maki-agent/src/agent/streaming.rs
@@ -14,6 +14,15 @@ async fn forward_provider_events(prx: flume::Receiver<ProviderEvent>, event_tx: 
             ProviderEvent::TextDelta { text } => AgentEvent::TextDelta { text },
             ProviderEvent::ThinkingDelta { text } => AgentEvent::ThinkingDelta { text },
             ProviderEvent::ToolUseStart { id, name } => AgentEvent::ToolPending { id, name },
+            ProviderEvent::PromptProgress {
+                processed,
+                total,
+                cache,
+            } => AgentEvent::PromptProgress {
+                processed,
+                total,
+                cache,
+            },
         };
         if event_tx.send(ae).is_err() {
             break;

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -596,6 +596,11 @@ pub enum AgentEvent {
         id: String,
         body: Arc<SharedBuf>,
     },
+    PromptProgress {
+        processed: u32,
+        total: u32,
+        cache: u32,
+    },
 }
 
 /// Append-only buffer for streaming tool output to the UI. Writers append

--- a/maki-providers/src/providers/local.rs
+++ b/maki-providers/src/providers/local.rs
@@ -143,7 +143,8 @@ impl Provider for LocalEndpoint {
             if matches!(self.protocol, Some(Protocol::OpenaiResponses)) {
                 let mut buf = String::new();
                 let system = super::with_prefix(&self.system_prefix, system, &mut buf);
-                let body = responses::build_body(model, messages, system, tools);
+                let mut body = responses::build_body(model, messages, system, tools);
+                body["return_progress"] = serde_json::Value::Bool(true);
                 // TODO: wire thinking budget into responses API when llama.cpp supports it
                 return responses::do_stream(
                     self.compat.client(),

--- a/maki-providers/src/providers/openai/responses.rs
+++ b/maki-providers/src/providers/openai/responses.rs
@@ -310,6 +310,25 @@ pub(crate) async fn parse_sse(
                 }
             }
 
+            "response.in_progress" => {
+                let parsed: Value = match serde_json::from_str(data) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                if let Some(pp) = parsed.get("prompt_progress") {
+                    let processed = pp["processed"].as_u64().unwrap_or(0) as u32;
+                    let total = pp["total"].as_u64().unwrap_or(0) as u32;
+                    let cache = pp["cache"].as_u64().unwrap_or(0) as u32;
+                    event_tx
+                        .send_async(ProviderEvent::PromptProgress {
+                            processed,
+                            total,
+                            cache,
+                        })
+                        .await?;
+                }
+            }
+
             "response.output_item.done" => {
                 let parsed: Value = match serde_json::from_str(data) {
                     Ok(v) => v,
@@ -795,6 +814,40 @@ data: {\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":5,\"ou
             assert_eq!(tools[0].1, "glob");
             assert_eq!(tools[0].2["pattern"], "*.rs");
             assert_eq!(tools[0].2["path"], "src");
+        })
+    }
+
+    #[test]
+    fn parse_sse_prompt_progress_events() {
+        smol::block_on(async {
+            let sse = "\
+event: response.in_progress\n\
+data: {\"prompt_progress\":{\"processed\":100,\"total\":1000,\"cache\":50}}\n\
+\n\
+event: response.in_progress\n\
+data: {\"prompt_progress\":{\"processed\":500,\"total\":1000,\"cache\":50}}\n\
+\n\
+event: response.output_text.delta\n\
+data: {\"delta\":\"Hello\"}\n\
+\n\
+event: response.completed\n\
+data: {\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":100,\"output_tokens\":10}}}\n\
+\n";
+
+            let (_resp, events) = run_sse(sse).await;
+
+            let progress: Vec<_> = events
+                .iter()
+                .filter_map(|e| match e {
+                    ProviderEvent::PromptProgress {
+                        processed,
+                        total,
+                        cache,
+                    } => Some((*processed, *total, *cache)),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(progress, vec![(100, 1000, 50), (500, 1000, 50)]);
         })
     }
 }

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -737,6 +737,7 @@ data: [DONE]\n";
                     ProviderEvent::ThinkingDelta { text } => thinking.push(text),
                     ProviderEvent::TextDelta { text } => text_deltas.push(text),
                     ProviderEvent::ToolUseStart { .. } => {}
+                    ProviderEvent::PromptProgress { .. } => {}
                 }
             }
             assert_eq!(thinking, vec!["Let me think", "..."]);

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -247,9 +247,21 @@ impl TitleSource for Message {
 
 #[derive(Debug, Clone, Serialize)]
 pub enum ProviderEvent {
-    TextDelta { text: String },
-    ThinkingDelta { text: String },
-    ToolUseStart { id: String, name: String },
+    TextDelta {
+        text: String,
+    },
+    ThinkingDelta {
+        text: String,
+    },
+    ToolUseStart {
+        id: String,
+        name: String,
+    },
+    PromptProgress {
+        processed: u32,
+        total: u32,
+        cache: u32,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Display, IntoStaticStr)]

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::components::messages::MessagesPanel;
+use crate::components::messages::{MessagesPanel, PromptProgress};
 use crate::components::tool_display::append_annotation;
 use crate::components::{DisplayMessage, DisplayRole, ToolRole, ToolStatus};
 use crate::markdown::truncate_output;
@@ -77,8 +77,14 @@ impl Chat {
 
     pub fn handle_event(&mut self, event: AgentEvent, plan_path: Option<&Path>) -> ChatEventResult {
         match event {
-            AgentEvent::ThinkingDelta { text } => self.messages_panel.thinking_delta(&text),
-            AgentEvent::TextDelta { text } => self.messages_panel.text_delta(&text),
+            AgentEvent::ThinkingDelta { text } => {
+                self.messages_panel.clear_prompt_progress();
+                self.messages_panel.thinking_delta(&text);
+            }
+            AgentEvent::TextDelta { text } => {
+                self.messages_panel.clear_prompt_progress();
+                self.messages_panel.text_delta(&text);
+            }
             AgentEvent::ToolPending { id, name } => self.messages_panel.tool_pending(id, &name),
             AgentEvent::ToolStart(e) => self.messages_panel.tool_start(*e),
             AgentEvent::ToolOutput { id, content } => {
@@ -157,6 +163,18 @@ impl Chat {
             AgentEvent::SubagentHistory { .. } => {}
             AgentEvent::LiveToolBuf { id, body } => {
                 self.messages_panel.register_live_buf(id, body);
+            }
+            AgentEvent::PromptProgress {
+                processed,
+                total,
+                cache,
+            } => {
+                self.messages_panel
+                    .set_prompt_progress((processed < total).then_some(PromptProgress {
+                        processed,
+                        total,
+                        cache,
+                    }));
             }
         }
         ChatEventResult::Continue

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -38,6 +38,7 @@ use maki_lua::EventHandle;
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 
 const THINKING_HIDDEN_HEADER: &str = "thinking> ...";
@@ -46,7 +47,6 @@ const THINKING_HIDDEN_HEADER: &str = "thinking> ...";
 pub struct PromptProgress {
     pub processed: u32,
     pub total: u32,
-    #[allow(dead_code)]
     pub cache: u32,
 }
 
@@ -493,7 +493,6 @@ impl MessagesPanel {
     pub fn clear_prompt_progress(&mut self) {
         self.prompt_progress = None;
     }
-    }
 
     pub fn flush(&mut self) {
         self.flush_thinking();
@@ -807,6 +806,8 @@ impl MessagesPanel {
                 &crate::components::progress_bar::ProgressBarConfig {
                     ratio,
                     style: theme::current().progress_bar,
+                    cache_ratio: pp.cache as f64 / pp.total as f64,
+                    cache_style: Style::new().fg(Color::Green),
                     label: Some(label),
                     label_style: Some(theme::current().tool_dim),
                     bar_width,

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -42,6 +42,14 @@ use ratatui::text::{Line, Span};
 
 const THINKING_HIDDEN_HEADER: &str = "thinking> ...";
 
+#[derive(Clone, Copy)]
+pub struct PromptProgress {
+    pub processed: u32,
+    pub total: u32,
+    #[allow(dead_code)]
+    pub cache: u32,
+}
+
 pub struct MessagesPanel {
     messages: Vec<DisplayMessage>,
     streaming_thinking: StreamingContent,
@@ -70,6 +78,7 @@ pub struct MessagesPanel {
     /// One re-bake per tool per generation; `snapshot_theme_gen`
     /// only bumps when colors actually land.
     rebake_requested: HashMap<String, u64>,
+    prompt_progress: Option<PromptProgress>,
 }
 
 impl MessagesPanel {
@@ -112,6 +121,7 @@ impl MessagesPanel {
             show_thinking: ui_config.show_thinking,
             thinking_collapsed: !ui_config.show_thinking,
             rebake_requested: HashMap::new(),
+            prompt_progress: None,
         }
     }
 
@@ -476,8 +486,18 @@ impl MessagesPanel {
         self.streaming_thinking.is_empty()
     }
 
+    pub fn set_prompt_progress(&mut self, progress: Option<PromptProgress>) {
+        self.prompt_progress = progress;
+    }
+
+    pub fn clear_prompt_progress(&mut self) {
+        self.prompt_progress = None;
+    }
+    }
+
     pub fn flush(&mut self) {
         self.flush_thinking();
+        self.prompt_progress = None;
         if !self.streaming_text.is_empty() {
             self.messages.push(DisplayMessage::new(
                 DisplayRole::Assistant,
@@ -768,6 +788,30 @@ impl MessagesPanel {
                     cursor.render(sc.cached_lines(), h, None, false, frame);
                 }
             }
+        }
+
+        if let Some(pp) = self.prompt_progress
+            && pp.total > 0
+        {
+            let ratio = pp.processed as f64 / pp.total as f64;
+            let bar_width = (width as f64 * 0.1).round() as u16;
+            let label = " Processing ";
+            let label_width = label.len() as u16;
+            let total_width = label_width + bar_width;
+            let bar_x = area.x + width.saturating_sub(total_width);
+            let bar_y = area.y + area.height.saturating_sub(1);
+            let bar_area = Rect::new(bar_x, bar_y, total_width, 1);
+            crate::components::progress_bar::render(
+                frame,
+                bar_area,
+                &crate::components::progress_bar::ProgressBarConfig {
+                    ratio,
+                    style: theme::current().progress_bar,
+                    label: Some(label),
+                    label_style: Some(theme::current().tool_dim),
+                    bar_width,
+                },
+            );
         }
 
         if total_lines > area.height {

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod modal;
 pub(crate) mod model_picker;
 pub(crate) mod permission_prompt;
 pub(crate) mod plan_form;
+pub(crate) mod progress_bar;
 pub mod queue_panel;
 pub(crate) mod rewind_picker;
 pub(crate) mod scrollbar;

--- a/maki-ui/src/components/progress_bar.rs
+++ b/maki-ui/src/components/progress_bar.rs
@@ -1,0 +1,152 @@
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+
+const BAR_CHAR: &str = "━";
+const UNFILLED_COLOR: Color = Color::DarkGray;
+
+pub struct ProgressBarConfig<'a> {
+    pub ratio: f64,
+    pub style: Style,
+    pub label: Option<&'a str>,
+    pub label_style: Option<Style>,
+    pub bar_width: u16,
+}
+
+pub fn render(frame: &mut Frame, area: Rect, config: &ProgressBarConfig<'_>) {
+    if area.is_empty() {
+        return;
+    }
+
+    let ratio = config.ratio.clamp(0.0, 1.0);
+    let width = config.bar_width as usize;
+    let filled = (ratio * width as f64).round() as usize;
+
+    let mut spans = Vec::with_capacity(width);
+
+    if let Some(label) = config.label {
+        let style = config.label_style.unwrap_or_default();
+        spans.push(Span::styled(label, style));
+    }
+
+    for i in 0..width {
+        let style = if i < filled {
+            config.style
+        } else {
+            Style::new().fg(UNFILLED_COLOR)
+        };
+        spans.push(Span::styled(BAR_CHAR, style));
+    }
+
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use test_case::test_case;
+
+    fn render_gauge(ratio: f64, width: u16) -> Terminal<TestBackend> {
+        let backend = TestBackend::new(width, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                render(
+                    f,
+                    Rect::new(0, 0, width, 1),
+                    &ProgressBarConfig {
+                        ratio,
+                        style: Style::default(),
+                        label: None,
+                        label_style: None,
+                        bar_width: width,
+                    },
+                );
+            })
+            .unwrap();
+        terminal
+    }
+
+    fn filled_count(terminal: &Terminal<TestBackend>) -> usize {
+        let buf = terminal.backend().buffer();
+        (0..buf.area.width)
+            .filter(|&x| buf.cell((x, 0)).is_some_and(|c| c.fg != UNFILLED_COLOR))
+            .count()
+    }
+
+    #[test_case(0.0, 20, 0  ; "ratio_zero")]
+    #[test_case(0.5, 20, 10 ; "ratio_half")]
+    #[test_case(1.0, 20, 20 ; "ratio_full")]
+    fn render_filled_cell_count(ratio: f64, width: u16, expected_filled: usize) {
+        let terminal = render_gauge(ratio, width);
+        assert_eq!(
+            filled_count(&terminal),
+            expected_filled,
+            "expected {expected_filled} filled cells for ratio {ratio}"
+        );
+    }
+
+    #[test_case(1.5 ; "ratio_over_one_clamped")]
+    #[test_case(-0.5 ; "ratio_negative_clamped")]
+    fn render_clamps_ratio(ratio: f64) {
+        let terminal = render_gauge(ratio, 20);
+        let filled = filled_count(&terminal);
+        assert!(
+            (0..=20).contains(&filled),
+            "clamped ratio should produce 0..=20 filled cells, got {filled}"
+        );
+    }
+
+    #[test]
+    fn render_zero_width_is_empty() {
+        let backend = TestBackend::new(0, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                render(
+                    f,
+                    Rect::new(0, 0, 0, 1),
+                    &ProgressBarConfig {
+                        ratio: 0.5,
+                        style: Style::default(),
+                        label: None,
+                        label_style: None,
+                        bar_width: 0,
+                    },
+                );
+            })
+            .unwrap();
+        assert_eq!(filled_count(&terminal), 0);
+    }
+
+    #[test]
+    fn render_with_label_preserves_label_width() {
+        let width = 30;
+        let backend = TestBackend::new(width, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                render(
+                    f,
+                    Rect::new(0, 0, width, 1),
+                    &ProgressBarConfig {
+                        ratio: 0.5,
+                        style: Style::default(),
+                        label: Some(" PP:"),
+                        label_style: None,
+                        bar_width: width,
+                    },
+                );
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer();
+        let label_cells = (0..width)
+            .take_while(|&x| buf.cell((x, 0)).is_some_and(|c| c.symbol() != BAR_CHAR))
+            .count();
+        assert_eq!(label_cells, 4, "label 'PP:' should occupy 4 cells");
+    }
+}

--- a/maki-ui/src/components/progress_bar.rs
+++ b/maki-ui/src/components/progress_bar.rs
@@ -10,6 +10,8 @@ const UNFILLED_COLOR: Color = Color::DarkGray;
 pub struct ProgressBarConfig<'a> {
     pub ratio: f64,
     pub style: Style,
+    pub cache_ratio: f64,
+    pub cache_style: Style,
     pub label: Option<&'a str>,
     pub label_style: Option<Style>,
     pub bar_width: u16,
@@ -21,8 +23,11 @@ pub fn render(frame: &mut Frame, area: Rect, config: &ProgressBarConfig<'_>) {
     }
 
     let ratio = config.ratio.clamp(0.0, 1.0);
+    let cache_ratio = config.cache_ratio.clamp(0.0, 1.0);
     let width = config.bar_width as usize;
     let filled = (ratio * width as f64).round() as usize;
+    let cache_filled = (cache_ratio * width as f64).round() as usize;
+    let cache_filled = cache_filled.min(filled);
 
     let mut spans = Vec::with_capacity(width);
 
@@ -32,7 +37,9 @@ pub fn render(frame: &mut Frame, area: Rect, config: &ProgressBarConfig<'_>) {
     }
 
     for i in 0..width {
-        let style = if i < filled {
+        let style = if i < cache_filled {
+            config.cache_style
+        } else if i < filled {
             config.style
         } else {
             Style::new().fg(UNFILLED_COLOR)
@@ -50,7 +57,13 @@ mod tests {
     use ratatui::backend::TestBackend;
     use test_case::test_case;
 
+    const CACHE_STYLE: Style = Style::new().fg(Color::Green);
+
     fn render_gauge(ratio: f64, width: u16) -> Terminal<TestBackend> {
+        render_gauge_with_cache(ratio, 0.0, width)
+    }
+
+    fn render_gauge_with_cache(ratio: f64, cache_ratio: f64, width: u16) -> Terminal<TestBackend> {
         let backend = TestBackend::new(width, 1);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
@@ -61,6 +74,8 @@ mod tests {
                     &ProgressBarConfig {
                         ratio,
                         style: Style::default(),
+                        cache_ratio,
+                        cache_style: CACHE_STYLE,
                         label: None,
                         label_style: None,
                         bar_width: width,
@@ -75,6 +90,13 @@ mod tests {
         let buf = terminal.backend().buffer();
         (0..buf.area.width)
             .filter(|&x| buf.cell((x, 0)).is_some_and(|c| c.fg != UNFILLED_COLOR))
+            .count()
+    }
+
+    fn cache_cell_count(terminal: &Terminal<TestBackend>) -> usize {
+        let buf = terminal.backend().buffer();
+        (0..buf.area.width)
+            .filter(|&x| buf.cell((x, 0)).is_some_and(|c| c.fg == Color::Green))
             .count()
     }
 
@@ -113,6 +135,8 @@ mod tests {
                     &ProgressBarConfig {
                         ratio: 0.5,
                         style: Style::default(),
+                        cache_ratio: 0.0,
+                        cache_style: CACHE_STYLE,
                         label: None,
                         label_style: None,
                         bar_width: 0,
@@ -136,6 +160,8 @@ mod tests {
                     &ProgressBarConfig {
                         ratio: 0.5,
                         style: Style::default(),
+                        cache_ratio: 0.0,
+                        cache_style: CACHE_STYLE,
                         label: Some(" PP:"),
                         label_style: None,
                         bar_width: width,
@@ -148,5 +174,20 @@ mod tests {
             .take_while(|&x| buf.cell((x, 0)).is_some_and(|c| c.symbol() != BAR_CHAR))
             .count();
         assert_eq!(label_cells, 4, "label 'PP:' should occupy 4 cells");
+    }
+
+    #[test_case(0.5, 0.0, 0, 10  ; "no_cache")]
+    #[test_case(0.5, 0.5, 10, 10 ; "cache_equals_progress")]
+    #[test_case(0.5, 0.25, 5, 10 ; "cache_half_of_progress")]
+    #[test_case(0.5, 1.0, 10, 10 ; "cache_exceeds_progress_clamped")]
+    fn render_cache_segment(
+        ratio: f64,
+        cache_ratio: f64,
+        expected_cache: usize,
+        expected_filled: usize,
+    ) {
+        let terminal = render_gauge_with_cache(ratio, cache_ratio, 20);
+        assert_eq!(cache_cell_count(&terminal), expected_cache);
+        assert_eq!(filled_count(&terminal), expected_filled);
     }
 }

--- a/maki-ui/src/theme.rs
+++ b/maki-ui/src/theme.rs
@@ -406,6 +406,7 @@ pub struct Theme {
     pub index_line_nr: Style,
     pub index_keyword: Style,
     pub shell_prefix: Style,
+    pub progress_bar: Style,
 
     pub syntax: syntect::highlighting::Theme,
 }
@@ -788,6 +789,14 @@ impl Theme {
             index_line_nr: derived_style("index_line_nr", &["comment"], Modifier::empty()),
             index_keyword: derived_style("index_keyword", &["keyword"], Modifier::empty()),
             shell_prefix: derived_style("shell_prefix", &["string"], Modifier::BOLD),
+            progress_bar: {
+                let s = style("progress_bar");
+                if s == Style::default() {
+                    style("accent")
+                } else {
+                    s
+                }
+            },
             syntax,
         })
     }

--- a/src/print.rs
+++ b/src/print.rs
@@ -244,7 +244,8 @@ pub fn run(
             | AgentEvent::ToolSnapshot { .. }
             | AgentEvent::ToolHeaderSnapshot { .. }
             | AgentEvent::LiveToolBuf { .. }
-            | AgentEvent::Nudge => {}
+            | AgentEvent::Nudge
+            | AgentEvent::PromptProgress { .. } => {}
             AgentEvent::Retry {
                 attempt,
                 message,

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -938,7 +938,8 @@ impl EventPump {
             | AgentEvent::ToolSnapshot { .. }
             | AgentEvent::ToolHeaderSnapshot { .. }
             | AgentEvent::LiveToolBuf { .. }
-            | AgentEvent::Nudge => {}
+            | AgentEvent::Nudge
+            | AgentEvent::PromptProgress { .. } => {}
             AgentEvent::Retry {
                 attempt,
                 message,


### PR DESCRIPTION
since [this PR](https://github.com/ggml-org/llama.cpp/pull/25348) llama.cpp sends progress events during prompt processing

this PR adds support for displaying the progress during prompt processing in the status bar when using the responses API (cf. PR #466 )