### PR TITLE
providers: Parse vision support per model for llama.cpp and openrouter providers

### DIFF
--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -108,7 +108,7 @@ impl ToolFilter {
 /// One gate for every definitions builder (main loop, headless, Lua): a model
 /// without vision never learns `view_image` exists.
 pub fn capability_exclusions(model: &Model) -> &'static [&'static str] {
-    if model.vision {
+    if model.supports_vision() {
         &[]
     } else {
         &[VIEW_IMAGE_TOOL_NAME]
@@ -582,7 +582,7 @@ mod tests {
     #[test_case(false ; "text_only_model_loses_view_image")]
     fn from_config_gates_view_image_on_vision(vision: bool) {
         let mut model = Model::from_spec("anthropic/claude-opus-4-8").unwrap();
-        model.vision = vision;
+        model.supports_vision_override = Some(vision);
         let filter = ToolFilter::from_config(&AgentConfig::default(), &model, &[]);
         assert_eq!(filter.matches(VIEW_IMAGE_TOOL_NAME), vision);
         assert!(

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -56,6 +56,7 @@ pub struct ModelInfo {
     pub max_output_tokens: Option<u32>,
     pub pricing: Option<ModelPricing>,
     pub supports_thinking: Option<bool>,
+    pub supports_vision: Option<bool>,
     /// Store of additional metadata from the provider.
     pub provider_info: Option<Arc<dyn Any + Send + Sync>>,
 }
@@ -68,6 +69,7 @@ impl ModelInfo {
             max_output_tokens: None,
             pricing: None,
             supports_thinking: None,
+            supports_vision: None,
             provider_info: None,
         }
     }
@@ -223,8 +225,7 @@ pub struct Model {
     pub family: ModelFamily,
     pub supports_tool_examples_override: Option<bool>,
     pub supports_thinking_override: Option<bool>,
-    /// Resolved once at construction so every consumer reads the same answer.
-    pub vision: bool,
+    pub supports_vision_override: Option<bool>,
     pub pricing: ModelPricing,
     pub max_output_tokens: u32,
     pub context_window: u32,
@@ -243,13 +244,12 @@ impl Model {
             .read()
             .unwrap()
             .tier_for(&spec, provider, static_entry.map(|e| e.tier));
-        let (family, pricing, max_output_tokens, context_window, vision) = match static_entry {
+        let (family, pricing, max_output_tokens, context_window) = match static_entry {
             Some(e) => (
                 e.family,
                 e.pricing.clone(),
                 e.max_output_tokens,
                 anthropic::shared::long_context_window(model_id).unwrap_or(e.context_window),
-                e.vision,
             ),
             None => {
                 let guard = crate::model_registry::model_registry().read().unwrap();
@@ -265,7 +265,6 @@ impl Model {
                     discovered
                         .and_then(|d| d.context_window)
                         .unwrap_or_else(|| provider.fallback_context_window()),
-                    provider.family().supports_vision(),
                 )
             }
         };
@@ -277,7 +276,7 @@ impl Model {
             family,
             supports_tool_examples_override: None,
             supports_thinking_override: None,
-            vision,
+            supports_vision_override: None,
             pricing,
             max_output_tokens,
             context_window,
@@ -293,6 +292,22 @@ impl Model {
                     .and_then(|d| d.supports_thinking)
             })
             .unwrap_or_else(|| self.provider.supports_thinking())
+    }
+
+    pub fn supports_vision(&self) -> bool {
+        self.supports_vision_override
+            .or_else(|| {
+                let guard = crate::model_registry::model_registry().read().unwrap();
+                guard
+                    .discovered(self.provider, &self.id)
+                    .and_then(|d| d.supports_vision)
+            })
+            .or_else(|| {
+                lookup_entry(models_for_provider(self.provider), &self.id)
+                    .ok()
+                    .map(|e| e.vision)
+            })
+            .unwrap_or_else(|| self.family.supports_vision())
     }
 
     pub fn supports_tool_examples(&self) -> bool {
@@ -700,7 +715,7 @@ mod tests {
     #[test_case("anthropic/claude-nonexistent-99",  true  ; "unknown_model_uses_family_fallback")]
     #[test_case("deepseek/my-custom-model",         false ; "unknown_generic_defaults_off")]
     fn vision_resolved_from_entry_or_family(spec: &str, expected: bool) {
-        assert_eq!(Model::from_spec(spec).unwrap().vision, expected);
+        assert_eq!(Model::from_spec(spec).unwrap().supports_vision(), expected);
     }
 
     #[test_case("claude-opus-4-6" ; "opus_4_6")]
@@ -755,6 +770,7 @@ mod tests {
                     max_output_tokens: None,
                     pricing: None,
                     supports_thinking: None,
+                    supports_vision: None,
                     provider_info: None,
                 }],
             );

--- a/maki-providers/src/model_registry.rs
+++ b/maki-providers/src/model_registry.rs
@@ -317,6 +317,7 @@ mod tests {
                     max_output_tokens: None,
                     pricing: None,
                     supports_thinking: None,
+                    supports_vision: None,
                     provider_info: None,
                 },
                 ModelInfo {
@@ -325,6 +326,7 @@ mod tests {
                     max_output_tokens: None,
                     pricing: None,
                     supports_thinking: None,
+                    supports_vision: None,
                     provider_info: None,
                 },
             ],

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -99,9 +99,7 @@ pub fn lookup_model(slug: &str, model_id: &str) -> Option<Model> {
         .unwrap_or_else(|| kind.fallback_context_window());
     let supports_tool_examples_override = declared.and_then(|m| m.supports_tool_examples);
     let supports_thinking_override = declared.and_then(|m| m.supports_thinking);
-    let vision = declared
-        .and_then(|m| m.supports_vision)
-        .unwrap_or_else(|| kind.family().supports_vision());
+    let supports_vision_override = declared.and_then(|m| m.supports_vision);
     let pricing = declared
         .filter(|m| m.has_pricing())
         .map(|m| ModelPricing {
@@ -125,7 +123,7 @@ pub fn lookup_model(slug: &str, model_id: &str) -> Option<Model> {
         family: kind.family(),
         supports_tool_examples_override,
         supports_thinking_override,
-        vision,
+        supports_vision_override,
         pricing,
         max_output_tokens,
         context_window,

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -81,9 +81,7 @@ impl ScriptModel {
             family: base.family(),
             supports_tool_examples_override: self.supports_tool_examples,
             supports_thinking_override: self.supports_thinking,
-            vision: self
-                .supports_vision
-                .unwrap_or_else(|| base.family().supports_vision()),
+            supports_vision_override: self.supports_vision,
             pricing: self.pricing.clone().unwrap_or_default(),
             max_output_tokens: self.max_output_tokens,
             context_window: self.context_window,
@@ -537,6 +535,7 @@ impl Provider for DynamicProvider {
                     max_output_tokens: Some(m.max_output_tokens),
                     pricing: m.pricing.clone(),
                     supports_thinking: None,
+                    supports_vision: m.supports_vision,
                     provider_info: None,
                 })
                 .collect())

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -618,7 +618,7 @@ mod tests {
             dynamic_slug: None,
             tier: ModelTier::Medium,
             family: ModelFamily::Gemini,
-            vision: true,
+            supports_vision_override: Some(true),
             supports_tool_examples_override: None,
             supports_thinking_override: None,
             pricing: ModelPricing::default(),

--- a/maki-providers/src/providers/local.rs
+++ b/maki-providers/src/providers/local.rs
@@ -222,6 +222,16 @@ struct LlamaCppModelData {
     status: Option<LlamaCppStatus>,
     #[serde(default)]
     max_model_len: Option<u32>,
+    #[serde(default)]
+    architecture: Option<LlamaCppArchitecture>,
+}
+
+#[derive(Deserialize)]
+struct LlamaCppArchitecture {
+    #[serde(default)]
+    input_modalities: Vec<String>,
+    #[serde(default)]
+    output_modalities: Vec<String>,
 }
 
 #[derive(Deserialize)]
@@ -276,16 +286,28 @@ impl LocalEndpoint {
         let mut models: Vec<crate::model::ModelInfo> = body
             .data
             .into_iter()
-            .map(|m| {
+            .filter_map(|m| {
+                let arch = m.architecture.as_ref();
+                let has_text_input = arch
+                    .map(|a| a.input_modalities.iter().any(|m| m == "text"))
+                    .unwrap_or(true);
+                let has_text_output = arch
+                    .map(|a| a.output_modalities.iter().any(|m| m == "text"))
+                    .unwrap_or(true);
+                if !has_text_input || !has_text_output {
+                    return None;
+                }
                 let context_window = llamacpp_extract_ctx_from_model(&m, &mode, props_n_ctx);
-                crate::model::ModelInfo {
+                let supports_vision = arch.map(|a| a.input_modalities.iter().any(|m| m == "image"));
+                Some(crate::model::ModelInfo {
                     id: m.id,
                     context_window: Some(context_window),
                     max_output_tokens: None,
                     pricing: Some(crate::model::ModelPricing::ZERO),
                     supports_thinking: None,
+                    supports_vision,
                     provider_info: None,
-                }
+                })
             })
             .collect();
         models.sort_by(|a, b| a.id.cmp(&b.id));
@@ -391,6 +413,7 @@ impl LocalEndpoint {
                 max_output_tokens: None,
                 pricing: Some(crate::model::ModelPricing::ZERO),
                 supports_thinking: None,
+                supports_vision: None,
                 provider_info: None,
             })
             .collect();
@@ -639,6 +662,7 @@ mod tests {
                 meta: Some(LlamaCppMeta { n_ctx }),
                 status: None,
                 max_model_len: None,
+                architecture: None,
             }
         }
 
@@ -648,6 +672,7 @@ mod tests {
                 meta: None,
                 status: Some(LlamaCppStatus { args }),
                 max_model_len: None,
+                architecture: None,
             }
         }
 
@@ -657,6 +682,7 @@ mod tests {
                 meta: None,
                 status: None,
                 max_model_len: Some(v),
+                architecture: None,
             }
         }
 
@@ -666,6 +692,7 @@ mod tests {
                 meta: None,
                 status: None,
                 max_model_len: None,
+                architecture: None,
             }
         }
 

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -238,12 +238,19 @@ impl Provider for Mistral {
                         .and_then(Value::as_object)
                         .and_then(|c| c.get("reasoning"))
                         .and_then(Value::as_bool);
+                    let supports_vision = m
+                        .get("capabilities")
+                        .and_then(Value::as_object)
+                        .and_then(|c| c.get("vision"))
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false);
                     Some(crate::model::ModelInfo {
                         id: id.to_string(),
                         context_window,
                         max_output_tokens: None,
                         pricing: None,
                         supports_thinking,
+                        supports_vision: Some(supports_vision),
                         provider_info: None,
                     })
                 })

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -228,6 +228,7 @@ impl OpenAiCompatProvider {
             max_output_tokens,
             pricing: Some(pricing),
             supports_thinking: None,
+            supports_vision: None,
             provider_info: None,
         })
     }

--- a/maki-providers/src/providers/opencode.rs
+++ b/maki-providers/src/providers/opencode.rs
@@ -176,6 +176,7 @@ impl CatalogData {
                     fast: None,
                 }),
                 supports_thinking: None,
+                supports_vision: None,
                 provider_info: None,
             })
             .collect();

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -179,6 +179,9 @@ impl Provider for OpenRouter {
                         return None;
                     }
 
+                    let supports_vision =
+                        input_modalities.iter().any(|m| m.as_str() == Some("image"));
+
                     // Parse with OpenRouter-specific pricing field names
                     let id = m["id"].as_str()?;
                     let context_window = m["context_length"]
@@ -234,6 +237,7 @@ impl Provider for OpenRouter {
                         max_output_tokens: None,
                         pricing: Some(pricing),
                         supports_thinking: Some(supports_thinking),
+                        supports_vision: Some(supports_vision),
                         provider_info: reasoning
                             .map(|r| Arc::new(r) as Arc<dyn std::any::Any + Send + Sync>),
                     })

--- a/maki-providers/src/providers/tensorx.rs
+++ b/maki-providers/src/providers/tensorx.rs
@@ -189,6 +189,11 @@ impl Provider for TensorX {
                                 None
                             };
 
+                            let supports_vision = info
+                                .get("supports_vision")
+                                .and_then(Value::as_bool)
+                                .unwrap_or(false);
+
                             let supports_thinking =
                                 info.get("supports_reasoning").and_then(Value::as_bool);
 
@@ -210,6 +215,7 @@ impl Provider for TensorX {
                                 max_output_tokens,
                                 pricing,
                                 supports_thinking,
+                                supports_vision: Some(supports_vision),
                                 provider_info: supported_params
                                     .map(|p| Arc::new(p) as Arc<dyn std::any::Any + Send + Sync>),
                             })

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -95,7 +95,7 @@ pub fn adapt_images_for_model<'a>(model: &Model, messages: &'a [Message]) -> Cow
             .iter()
             .any(|b| matches!(b, ContentBlock::Image { .. }))
     };
-    if model.vision || !messages.iter().any(has_image) {
+    if model.supports_vision() || !messages.iter().any(has_image) {
         return Cow::Borrowed(messages);
     }
     let adapted = messages
@@ -587,7 +587,7 @@ mod tests {
         ));
 
         let mut text_only_model = model;
-        text_only_model.vision = false;
+        text_only_model.supports_vision_override = Some(false);
         let no_images = vec![Message::user("hi".into())];
         assert!(matches!(
             adapt_images_for_model(&text_only_model, &no_images),
@@ -598,7 +598,7 @@ mod tests {
     #[test]
     fn adapt_images_replaces_blocks_for_text_only_model() {
         let mut model = clamp_test_model(crate::provider::ProviderKind::Anthropic);
-        model.vision = false;
+        model.supports_vision_override = Some(false);
         let messages = vec![Message {
             role: Role::User,
             content: vec![
@@ -705,7 +705,7 @@ mod tests {
             family: provider.family(),
             supports_tool_examples_override: None,
             supports_thinking_override: None,
-            vision: provider.family().supports_vision(),
+            supports_vision_override: Some(provider.family().supports_vision()),
             pricing: crate::model::ModelPricing::default(),
             max_output_tokens: 8192,
             context_window: 200_000,

--- a/maki-ui/src/app/image_paste.rs
+++ b/maki-ui/src/app/image_paste.rs
@@ -10,7 +10,7 @@ const IMAGE_NOT_SUPPORTED_MSG: &str = "Model does not support image input";
 
 impl App {
     pub(super) fn start_file_image_paste(&mut self, path: PathBuf, media_type: ImageMediaType) {
-        if !self.state.model.vision {
+        if !self.state.model.supports_vision() {
             self.status_bar.flash(IMAGE_NOT_SUPPORTED_MSG.into());
             return;
         }
@@ -19,7 +19,7 @@ impl App {
     }
 
     pub(super) fn start_image_paste(&mut self) {
-        if !self.state.model.vision {
+        if !self.state.model.supports_vision() {
             self.status_bar.flash(IMAGE_NOT_SUPPORTED_MSG.into());
             return;
         }
@@ -49,7 +49,7 @@ impl App {
             self.image_paste_rx.swap_remove(i);
             match result {
                 Ok(source) => {
-                    if !self.state.model.vision {
+                    if !self.state.model.supports_vision() {
                         self.status_bar.flash(IMAGE_NOT_SUPPORTED_MSG.into());
                     } else {
                         self.input_box.attach_image(source);

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -393,7 +393,7 @@ pub(crate) fn test_model() -> maki_providers::Model {
         family: maki_providers::ModelFamily::Claude,
         supports_tool_examples_override: None,
         supports_thinking_override: None,
-        vision: true,
+        supports_vision_override: Some(true),
         pricing: test_pricing(),
         max_output_tokens: 8192,
         context_window: TEST_CONTEXT_WINDOW,


### PR DESCRIPTION
Also filter out non-text models from llama.cpp provider.

----

 * [x] On top of https://github.com/tontinton/maki/pull/425
 * [x] Need to add OpenRouter
 * [x] Need to add TensorX
 * [x] Need to add Mistral
 * [x] Testing and proper review