### PR TITLE
providers: add GPT-5.6 Coding Plan models

### DIFF
--- a/maki-providers/src/providers/openai/mod.rs
+++ b/maki-providers/src/providers/openai/mod.rs
@@ -6,6 +6,9 @@ pub use platform::OpenAi;
 
 use crate::model::{ModelEntry, ModelFamily, ModelPricing, ModelTier};
 
+const GPT_5_6_CONTEXT_WINDOW: u32 = 372_000;
+const GPT_5_6_MAX_OUTPUT_TOKENS: u32 = 128_000;
+
 inventory::submit!(maki_config::providers::BuiltInProvider {
     slug: "openai",
     display_name: "OpenAI",
@@ -21,11 +24,59 @@ inventory::submit!(maki_config::providers::BuiltInProvider {
 pub(crate) fn models() -> &'static [ModelEntry] {
     &[
         ModelEntry {
-            prefixes: &["gpt-5.4-nano"],
+            prefixes: &["gpt-5.6-luna"],
             tier: ModelTier::Weak,
             family: ModelFamily::Gpt,
             vision: true,
             default: true,
+            pricing: ModelPricing {
+                input: 1.00,
+                output: 6.00,
+                cache_write: 1.25,
+                cache_read: 0.10,
+                fast: None,
+            },
+            max_output_tokens: GPT_5_6_MAX_OUTPUT_TOKENS,
+            context_window: GPT_5_6_CONTEXT_WINDOW,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.6-terra"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Gpt,
+            vision: true,
+            default: true,
+            pricing: ModelPricing {
+                input: 2.50,
+                output: 15.00,
+                cache_write: 3.125,
+                cache_read: 0.25,
+                fast: None,
+            },
+            max_output_tokens: GPT_5_6_MAX_OUTPUT_TOKENS,
+            context_window: GPT_5_6_CONTEXT_WINDOW,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.6-sol"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Gpt,
+            vision: true,
+            default: true,
+            pricing: ModelPricing {
+                input: 5.00,
+                output: 30.00,
+                cache_write: 6.25,
+                cache_read: 0.50,
+                fast: None,
+            },
+            max_output_tokens: GPT_5_6_MAX_OUTPUT_TOKENS,
+            context_window: GPT_5_6_CONTEXT_WINDOW,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.4-nano"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Gpt,
+            vision: true,
+            default: false,
             pricing: ModelPricing {
                 input: 0.20,
                 output: 1.25,
@@ -89,7 +140,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             tier: ModelTier::Medium,
             family: ModelFamily::Gpt,
             vision: true,
-            default: true,
+            default: false,
             pricing: ModelPricing {
                 input: 2.00,
                 output: 8.00,
@@ -121,7 +172,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             tier: ModelTier::Strong,
             family: ModelFamily::Gpt,
             vision: true,
-            default: true,
+            default: false,
             pricing: ModelPricing {
                 input: 5.00,
                 output: 30.00,
@@ -245,4 +296,35 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             context_window: 400_000,
         },
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    use super::*;
+
+    #[test_case("gpt-5.6-luna", ModelTier::Weak, 1.0, 0.1, 1.25, 6.0)]
+    #[test_case("gpt-5.6-terra", ModelTier::Medium, 2.5, 0.25, 3.125, 15.0)]
+    #[test_case("gpt-5.6-sol", ModelTier::Strong, 5.0, 0.5, 6.25, 30.0)]
+    fn gpt_5_6_models_have_expected_tier_and_short_context_pricing(
+        model_id: &str,
+        tier: ModelTier,
+        input: f64,
+        cache_read: f64,
+        cache_write: f64,
+        output: f64,
+    ) {
+        let model = models()
+            .iter()
+            .find(|model| model.prefixes.contains(&model_id))
+            .expect("GPT-5.6 model should be registered");
+
+        assert_eq!(model.tier, tier);
+        assert_eq!(model.context_window, GPT_5_6_CONTEXT_WINDOW);
+        assert_eq!(model.pricing.input, input);
+        assert_eq!(model.pricing.cache_read, cache_read);
+        assert_eq!(model.pricing.cache_write, cache_write);
+        assert_eq!(model.pricing.output, output);
+    }
 }

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -21,13 +21,41 @@ static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     provider_name: "OpenAI",
 };
 
-// NOTE: OpenAI also offers these models for subscription usage via the Coding Plan
-pub(crate) const PLAN_MODELS: &[&str] = &["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.2"];
+// Non-codex models OpenAI offers for subscription usage via the Coding Plan.
+// Codex models are matched by their `-codex` substring in
+// `coding_plan_context_window`, so they never need listing here.
+pub(crate) const PLAN_MODELS: &[&str] = &[
+    "gpt-5.6-luna",
+    "gpt-5.6-terra",
+    "gpt-5.6-sol",
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.2",
+];
 
 const CODEX_PLAN_CONTEXT_WINDOW: u32 = 272_000;
+const GPT_5_6_PLAN_CONTEXT_WINDOW: u32 = 372_000;
 
 fn is_codex_model(model_id: &str) -> bool {
-    model_id.contains("-codex") || PLAN_MODELS.contains(&model_id)
+    coding_plan_context_window(model_id).is_some()
+}
+
+// Codex models match by substring so future releases route without a registry
+// edit; the named non-codex plans match exactly to avoid catching near-misses
+// like `gpt-5.6-terra-preview`.
+fn coding_plan_context_window(model_id: &str) -> Option<u32> {
+    if model_id.contains("-codex") {
+        return Some(CODEX_PLAN_CONTEXT_WINDOW);
+    }
+    if !PLAN_MODELS.contains(&model_id) {
+        return None;
+    }
+    Some(if model_id.starts_with("gpt-5.6-") {
+        GPT_5_6_PLAN_CONTEXT_WINDOW
+    } else {
+        CODEX_PLAN_CONTEXT_WINDOW
+    })
 }
 
 pub struct OpenAi {
@@ -225,8 +253,36 @@ impl Provider for OpenAi {
     }
 
     fn adjust_model(&self, model: &mut Model) {
-        if self.is_oauth() && PLAN_MODELS.iter().any(|p| model.id.starts_with(p)) {
-            model.context_window = model.context_window.min(CODEX_PLAN_CONTEXT_WINDOW);
+        if self.is_oauth()
+            && let Some(context_window) = coding_plan_context_window(&model.id)
+        {
+            model.context_window = model.context_window.min(context_window);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    use super::*;
+
+    #[test_case("gpt-5.6-luna")]
+    #[test_case("gpt-5.6-terra")]
+    #[test_case("gpt-5.6-sol")]
+    fn gpt_5_6_models_use_coding_plan(model_id: &str) {
+        assert!(is_codex_model(model_id));
+    }
+
+    #[test_case("gpt-5.6-luna", Some(372_000))]
+    #[test_case("gpt-5.6-terra", Some(372_000))]
+    #[test_case("gpt-5.6-sol", Some(372_000))]
+    #[test_case("gpt-5.5", Some(272_000))]
+    #[test_case("gpt-5.3-codex", Some(272_000))]
+    #[test_case("gpt-5.7-codex", Some(272_000) ; "unlisted codex model still routes")]
+    #[test_case("gpt-5.6-terra-preview", None ; "non-codex near-match is rejected")]
+    #[test_case("gpt-5.4-nano", None)]
+    fn coding_plan_context_window_resolves_plan_models(model_id: &str, expected: Option<u32>) {
+        assert_eq!(coding_plan_context_window(model_id), expected);
     }
 }

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -57,11 +57,11 @@ You can override the model with `ANTHROPIC_MODEL` and the endpoint with `ANTHROP
 
 | Tier | Models | Pricing (in/out per 1M tokens) | Context |
 |------|--------|-------------------------------|---------|
-| Weak | **gpt-5.4-nano** (default), gpt-5.4-mini, gpt-4.1-nano | $0.20 / $1.25 | 400K ctx / 128K out |
-| Medium | gpt-4.1-mini, **gpt-4.1** (default), o4-mini, gpt-5.1-codex-mini | $0.40 / $1.60 | 1047K ctx / 32K out |
-| Strong | **gpt-5.5** (default), gpt-5.4, o3, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-max, gpt-5.1-codex | $5.00 / $30.00 | 1050K ctx / 128K out |
+| Weak | **gpt-5.6-luna** (default), gpt-5.4-nano, gpt-5.4-mini, gpt-4.1-nano | $1.00 / $6.00 | 372K ctx / 128K out |
+| Medium | **gpt-5.6-terra** (default), gpt-4.1-mini, gpt-4.1, o4-mini, gpt-5.1-codex-mini | $2.50 / $15.00 | 372K ctx / 128K out |
+| Strong | **gpt-5.6-sol** (default), gpt-5.5, gpt-5.4, o3, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-max, gpt-5.1-codex | $5.00 / $30.00 | 372K ctx / 128K out |
 
-Defaults: gpt-5.4-nano (weak), gpt-4.1 (medium), gpt-5.5 (strong)
+Defaults: gpt-5.6-luna (weak), gpt-5.6-terra (medium), gpt-5.6-sol (strong)
 
 ### Google
 


### PR DESCRIPTION
Added GPT-5.6 luna/terra/sol to the OpenAI registry. Since I have them available early through work, I'm able to test this out. Currently terra and sol work for me, luna isn't for some reason, I think the early preview is bugged, should be fine.

The codex entries were dropped from `PLAN_MODELS` since the substring covers them. This replaces the earlier prefix match, which would have clamped near-matches, without reintroducing the "must remember to list every new codex model" footgun.

Implemented with Codex GPT-5.6 Sol.