### PR TITLE
feat(ui): add file picker sort order configuration

### DIFF
--- a/maki-config-macro/src/lib.rs
+++ b/maki-config-macro/src/lib.rs
@@ -55,6 +55,7 @@ struct FieldAttrs {
     key: Option<String>,
     ty_override: Option<String>,
     val: Option<String>,
+    enum_options: Option<Vec<String>>,
 }
 
 fn parse_struct_attrs(input: &DeriveInput) -> syn::Result<StructAttrs> {
@@ -103,6 +104,7 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
         key: None,
         ty_override: None,
         val: None,
+        enum_options: None,
     };
 
     for attr in &field.attrs {
@@ -147,6 +149,16 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
                         attrs.val = Some(lit.value());
                     }
                 }
+                "enum_options" => {
+                    if let ConfigAttrValue::Str(lit) = item.value {
+                        let options: Vec<String> = lit
+                            .value()
+                            .split(',')
+                            .map(|s| s.trim().to_string())
+                            .collect();
+                        attrs.enum_options = Some(options);
+                    }
+                }
                 other => {
                     return Err(syn::Error::new(
                         item.key.span(),
@@ -160,26 +172,41 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
     Ok(attrs)
 }
 
-fn config_value_expr(ty_name: &str, default: &Option<Expr>) -> TokenStream2 {
-    match ty_name {
-        "bool" => {
-            let val = default.as_ref().expect("bool field requires default");
-            quote! { ConfigValue::Bool(#val) }
+fn config_value_expr(
+    ty_name: &str,
+    default: &Option<Expr>,
+    enum_options: &Option<Vec<String>>,
+) -> TokenStream2 {
+    if let Some(options) = enum_options {
+        let options_refs: Vec<TokenStream2> = options.iter().map(|s| quote! { #s }).collect();
+        let default_str = options.first().map(|s| s.as_str()).unwrap_or("none");
+        quote! {
+            ConfigValue::Enum {
+                options: &[#(#options_refs),*],
+                default: #default_str,
+            }
         }
-        "u32" => {
-            let val = default.as_ref().expect("u32 field requires default");
-            quote! { ConfigValue::U32(#val) }
+    } else {
+        match ty_name {
+            "bool" => {
+                let val = default.as_ref().expect("bool field requires default");
+                quote! { ConfigValue::Bool(#val) }
+            }
+            "u32" => {
+                let val = default.as_ref().expect("u32 field requires default");
+                quote! { ConfigValue::U32(#val) }
+            }
+            "u64" => {
+                let val = default.as_ref().expect("u64 field requires default");
+                quote! { ConfigValue::U64(#val) }
+            }
+            "usize" => {
+                let val = default.as_ref().expect("usize field requires default");
+                quote! { ConfigValue::Usize(#val) }
+            }
+            "String" => quote! { ConfigValue::OptionalString },
+            other => panic!("unsupported config type: {other}"),
         }
-        "u64" => {
-            let val = default.as_ref().expect("u64 field requires default");
-            quote! { ConfigValue::U64(#val) }
-        }
-        "usize" => {
-            let val = default.as_ref().expect("usize field requires default");
-            quote! { ConfigValue::Usize(#val) }
-        }
-        "String" => quote! { ConfigValue::OptionalString },
-        other => panic!("unsupported config type: {other}"),
     }
 }
 
@@ -231,7 +258,7 @@ fn derive_impl(input: &DeriveInput) -> syn::Result<TokenStream2> {
         let ty_string = type_to_name(ty);
         let ty_name = attrs.ty_override.as_deref().unwrap_or(&ty_string);
         let desc = attrs.desc.as_deref().unwrap_or("");
-        let default_expr = config_value_expr(ty_name, &attrs.default);
+        let default_expr = config_value_expr(ty_name, &attrs.default, &attrs.enum_options);
         let min_expr = match &attrs.min {
             Some(m) => quote! { Some(#m as u64) },
             None => quote! { None },
@@ -244,6 +271,7 @@ fn derive_impl(input: &DeriveInput) -> syn::Result<TokenStream2> {
                 default: #default_expr,
                 min: #min_expr,
                 description: #desc,
+                enum_options: None,
             }
         });
 

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -93,6 +93,10 @@ pub enum ConfigValue {
     U64(u64),
     Usize(usize),
     OptionalString,
+    Enum {
+        options: &'static [&'static str],
+        default: &'static str,
+    },
 }
 
 impl ConfigValue {
@@ -103,6 +107,7 @@ impl ConfigValue {
             Self::U64(v) => v.to_string(),
             Self::Usize(v) => v.to_string(),
             Self::OptionalString => "none".to_string(),
+            Self::Enum { default, .. } => default.to_string(),
         }
     }
 }
@@ -114,6 +119,7 @@ pub struct ConfigField {
     pub default: ConfigValue,
     pub min: Option<u64>,
     pub description: &'static str,
+    pub enum_options: Option<&'static [&'static str]>,
 }
 
 pub const TOP_LEVEL_FIELDS: &[ConfigField] = &[
@@ -123,6 +129,7 @@ pub const TOP_LEVEL_FIELDS: &[ConfigField] = &[
         default: ConfigValue::Bool(false),
         min: None,
         description: "Start every session with YOLO mode (skip permission prompts, deny rules still apply)",
+        enum_options: None,
     },
     ConfigField {
         name: "always_fast",
@@ -130,6 +137,7 @@ pub const TOP_LEVEL_FIELDS: &[ConfigField] = &[
         default: ConfigValue::Bool(false),
         min: None,
         description: "Start every session with Anthropic fast mode (Opus only; ignored otherwise)",
+        enum_options: None,
     },
     ConfigField {
         name: "always_workflow",
@@ -137,6 +145,7 @@ pub const TOP_LEVEL_FIELDS: &[ConfigField] = &[
         default: ConfigValue::Bool(false),
         min: None,
         description: "Start every session with workflow mode (task callable inside code_execution)",
+        enum_options: None,
     },
     ConfigField {
         name: "always_thinking",
@@ -144,6 +153,7 @@ pub const TOP_LEVEL_FIELDS: &[ConfigField] = &[
         default: ConfigValue::Bool(false),
         min: None,
         description: "Start every session with extended thinking (true/\"adaptive\", \"off\", or a token budget)",
+        enum_options: None,
     },
 ];
 
@@ -153,6 +163,7 @@ pub const INDEX_FIELDS: &[ConfigField] = &[ConfigField {
     default: ConfigValue::U64(DEFAULT_MAX_FILE_SIZE_MB),
     min: Some(MIN_MAX_FILE_SIZE_MB),
     description: "Max file size for indexing (MB)",
+    enum_options: None,
 }];
 
 #[derive(Debug, Error)]
@@ -280,6 +291,16 @@ pub struct ToolFileConfig {
     pub enabled: Option<bool>,
 }
 
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum FilePickerSortOrder {
+    #[default]
+    None,
+    Name,
+    Mtime,
+    Size,
+}
+
 #[derive(Deserialize, Default, Debug)]
 #[serde(default, deny_unknown_fields)]
 pub struct UiFileConfig {
@@ -289,6 +310,7 @@ pub struct UiFileConfig {
     pub typewriter_ms_per_char: Option<u64>,
     pub mouse_scroll_lines: Option<u32>,
     pub show_thinking: Option<bool>,
+    pub file_picker_sort_order: Option<FilePickerSortOrder>,
     pub tool_output_lines: Option<ToolOutputLinesFile>,
 }
 
@@ -302,7 +324,8 @@ impl UiFileConfig {
             flash_duration_ms,
             typewriter_ms_per_char,
             mouse_scroll_lines,
-            show_thinking
+            show_thinking,
+            file_picker_sort_order
         );
         match (self.tool_output_lines.as_mut(), overlay.tool_output_lines) {
             (Some(base), Some(over)) => base.merge(over),
@@ -548,6 +571,13 @@ pub struct UiConfig {
     )]
     pub show_thinking: bool,
 
+    #[config(
+        enum_options = "none,name,mtime,size",
+        default = "FilePickerSortOrder::default()",
+        desc = "Sort order for file picker results (none, name, mtime, size)"
+    )]
+    pub file_picker_sort_order: FilePickerSortOrder,
+
     #[config(skip, default = "ToolOutputLines::default()")]
     pub tool_output_lines: ToolOutputLines,
 }
@@ -568,6 +598,7 @@ impl UiConfig {
             mouse_scroll_lines: f.mouse_scroll_lines.unwrap_or(DEFAULT_MOUSE_SCROLL_LINES),
             show_thinking: f.show_thinking.unwrap_or(true),
             tool_output_lines: ToolOutputLines::from_file(f.tool_output_lines),
+            file_picker_sort_order: f.file_picker_sort_order.unwrap_or_default(),
         }
     }
 

--- a/maki-docgen/src/gen_config.rs
+++ b/maki-docgen/src/gen_config.rs
@@ -13,12 +13,13 @@ fn write_table_with_min(out: &mut String, fields: &[ConfigField]) {
     for f in fields {
         let default = f.default.format_default();
         let min = f.min.map_or("-".to_string(), |v| v.to_string());
+        let desc = format_desc(f);
         writeln!(
             out,
             "| `{name}` | {ty} | `{default}` | {min} | {desc} |",
             name = f.name,
             ty = escape_pipes(f.ty),
-            desc = f.description,
+            desc = desc,
         )
         .unwrap();
     }
@@ -29,14 +30,27 @@ fn write_table_no_min(out: &mut String, fields: &[ConfigField]) {
     writeln!(out, "|-------|------|---------|-------------|").unwrap();
     for f in fields {
         let default = f.default.format_default();
+        let desc = format_desc(f);
         writeln!(
             out,
             "| `{name}` | {ty} | `{default}` | {desc} |",
             name = f.name,
             ty = escape_pipes(f.ty),
-            desc = f.description,
+            desc = desc,
         )
         .unwrap();
+    }
+}
+
+fn format_desc(f: &ConfigField) -> String {
+    if let Some(options) = f.enum_options {
+        format!(
+            "{desc} ({options})",
+            desc = f.description,
+            options = options.join(", ")
+        )
+    } else {
+        f.description.to_string()
     }
 }
 

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -753,7 +753,10 @@ impl App {
                 let auto = self.chats[self.active_chat].auto_scroll();
                 self.search_modal.open(top, auto);
             } else if key::FILE_PICKER.matches(key) {
-                self.file_picker.open(&self.state.session.cwd);
+                self.file_picker.open(
+                    &self.state.session.cwd,
+                    self.ui_config.file_picker_sort_order,
+                );
             } else if key.code == KeyCode::Char('v') && self.image_paste_rx.is_empty() {
                 self.start_image_paste();
             } else if let InputAction::PaletteSync(val) = self.input_box.handle_key(key) {

--- a/maki-ui/src/components/file_picker.rs
+++ b/maki-ui/src/components/file_picker.rs
@@ -1,5 +1,5 @@
 use std::mem;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
@@ -8,6 +8,7 @@ use std::time::Instant;
 use crossterm::event::{KeyCode, KeyEvent};
 use ignore::WalkBuilder;
 use ignore::overrides::OverrideBuilder;
+use maki_config::FilePickerSortOrder;
 use nucleo::pattern::{CaseMatching, Normalization};
 use nucleo::{Config, Matcher, Nucleo, Utf32String};
 use ratatui::Frame;
@@ -68,6 +69,9 @@ struct Session {
     walking: bool,
     matching: bool,
     visible: bool,
+
+    sort_order: FilePickerSortOrder,
+    root: PathBuf,
 }
 
 impl Drop for Session {
@@ -85,7 +89,7 @@ impl FilePickerModal {
         Self { session: None }
     }
 
-    pub fn open(&mut self, cwd: &str) {
+    pub fn open(&mut self, cwd: &str, sort_order: FilePickerSortOrder) {
         self.close();
 
         let notify = Arc::new(|| {});
@@ -96,6 +100,7 @@ impl FilePickerModal {
         let (done_tx, done_rx) = flume::bounded(1);
 
         let root = PathBuf::from(cwd);
+        let root_clone = root.clone();
         if let Err(e) = thread::Builder::new()
             .name("file-walker".into())
             .spawn(move || {
@@ -159,6 +164,8 @@ impl FilePickerModal {
             walking: true,
             matching: false,
             visible: false,
+            sort_order,
+            root: root_clone,
         });
     }
 
@@ -374,6 +381,49 @@ fn refresh_matches(s: &mut Session) {
 
         s.matches.push(Match { path, indices });
     }
+
+    if s.matches.len() > 1 {
+        sort_matches(&mut s.matches, s.sort_order, &s.root);
+    }
+}
+
+fn sort_matches(matches: &mut [Match], sort_order: FilePickerSortOrder, root: &Path) {
+    match sort_order {
+        FilePickerSortOrder::None => {}
+        FilePickerSortOrder::Name => {
+            matches.sort_by_key(|a| a.path.to_lowercase());
+        }
+        FilePickerSortOrder::Mtime => {
+            matches.sort_by(|a, b| {
+                let mtime_a = file_mtime(root, &a.path);
+                let mtime_b = file_mtime(root, &b.path);
+                mtime_b.cmp(&mtime_a).then_with(|| a.path.cmp(&b.path))
+            });
+        }
+        FilePickerSortOrder::Size => {
+            matches.sort_by(|a, b| {
+                let size_a = file_size(root, &a.path);
+                let size_b = file_size(root, &b.path);
+                size_b.cmp(&size_a).then_with(|| a.path.cmp(&b.path))
+            });
+        }
+    }
+}
+
+fn file_mtime(root: &Path, rel_path: &str) -> std::time::SystemTime {
+    root.join(rel_path)
+        .metadata()
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+}
+
+fn file_size(root: &Path, rel_path: &str) -> u64 {
+    root.join(rel_path)
+        .metadata()
+        .ok()
+        .map(|m| m.len())
+        .unwrap_or(0)
 }
 
 fn move_selection(s: &mut Session, delta: isize) {
@@ -554,6 +604,8 @@ mod tests {
             walking: true,
             matching: false,
             visible: false,
+            sort_order: FilePickerSortOrder::None,
+            root: PathBuf::from("/tmp/test-root"),
         });
         (picker, done_tx)
     }

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -69,6 +69,7 @@ All fields are optional. Typos in field names cause an error right away.
 | `typewriter_ms_per_char` | u64 | `4` | - | Typewriter effect speed (ms/char) |
 | `mouse_scroll_lines` | u32 | `3` | 1 | Lines per mouse wheel scroll |
 | `show_thinking` | bool | `true` | - | When true (default), show full model reasoning live and persisted. When false, hide reasoning behind an indicator (thinking> ...) with a click-to-expand hint, both while thinking and after it completes |
+| `file_picker_sort_order` | FilePickerSortOrder | `none` | - | Sort order for file picker results (none, name, mtime, size) |
 
 ### `ui.tool_output_lines`
 


### PR DESCRIPTION
Add ui.file_picker_sort_order config option to control how files are sorted in the file picker popup.

Supports:
  
- none (default): no sorting, walker order
-  name: case-insensitive alphabetical
-  mtime: newest first, name as tiebreaker
-  size: largest first, name as tiebreaker
    
Sorting is applied after nucleo materializes matches in refresh_matches().

Also add enum type support to config macro.