### PR TITLE
providers: Lua config phase 1 - slug-based interim Rust provider registration

### DIFF
--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -1,4 +1,5 @@
-use maki_providers::model::{ModelEntry, ModelTier, models_for_provider};
+use maki_providers::manifest::ManifestRegistry;
+use maki_providers::model::{ModelEntry, ModelTier};
 use maki_providers::provider::ProviderKind;
 use std::fmt::Write;
 use strum::IntoEnumIterator;
@@ -152,7 +153,7 @@ fn build_sections() -> Vec<ProviderSection> {
                         "https://api.z.ai/api/coding/paas/v4",
                     ],
                     features: ProviderKind::Zai.features(),
-                    entries: models_for_provider(ProviderKind::Zai),
+                    entries: ManifestRegistry::get("zai").unwrap().models,
                 });
             }
             ProviderKind::OpenAi => {
@@ -162,7 +163,7 @@ fn build_sections() -> Vec<ProviderSection> {
                     auth_line: format!("{} (also supports OAuth device flow)", format_auth(kind)),
                     urls: vec![kind.base_url()],
                     features: kind.features(),
-                    entries: models_for_provider(kind),
+                    entries: ManifestRegistry::get(&kind.to_string()).unwrap().models,
                 });
             }
             ProviderKind::Copilot => {
@@ -175,7 +176,7 @@ fn build_sections() -> Vec<ProviderSection> {
                     ),
                     urls: vec![kind.base_url()],
                     features: kind.features(),
-                    entries: models_for_provider(kind),
+                    entries: ManifestRegistry::get(&kind.to_string()).unwrap().models,
                 });
             }
             _ => {
@@ -185,7 +186,7 @@ fn build_sections() -> Vec<ProviderSection> {
                     auth_line: format_auth(kind),
                     urls: vec![kind.base_url()],
                     features: kind.features(),
-                    entries: models_for_provider(kind),
+                    entries: ManifestRegistry::get(&kind.to_string()).unwrap().models,
                 });
             }
         }

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -48,25 +48,15 @@ fn resolve_model_from_ctx(ctx: &AgentContext, tier: Option<&str>) -> Result<Mode
     if effective == ctx.model.tier {
         return Ok(Model::clone(&ctx.model));
     }
+    let slug = &ctx.model.provider;
     let map = maki_providers::model_registry::model_registry()
         .read()
         .unwrap();
-    ctx.model
-        .dynamic_slug
-        .is_none()
-        .then(|| map.spec_for_tier(ctx.model.provider, effective))
-        .flatten()
+    map.spec_for_tier(slug, effective)
         .or_else(|| map.spec_for_tier_any(effective))
         .and_then(|s| Model::from_spec(&s).ok())
         .map(Ok)
-        .unwrap_or_else(|| {
-            Model::from_tier_dynamic(
-                ctx.model.provider,
-                effective,
-                ctx.model.dynamic_slug.as_deref(),
-            )
-            .map_err(|e| e.to_string())
-        })
+        .unwrap_or_else(|| Model::from_tier_dynamic(slug, effective).map_err(|e| e.to_string()))
 }
 
 fn model_to_lua_table(lua: &Lua, model: &Model) -> LuaResult<Table> {

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -1,4 +1,5 @@
 pub(crate) mod error;
+pub mod manifest;
 pub mod model;
 pub mod model_registry;
 pub mod provider;
@@ -9,7 +10,7 @@ pub(crate) mod types;
 pub use error::AgentError;
 pub use model::{
     FastPricing, Model, ModelEntry, ModelError, ModelFamily, ModelInfo, ModelPricing, ModelTier,
-    TokenUsage, models_for_provider,
+    TokenUsage,
 };
 pub use providers::Timeouts;
 pub use providers::copilot::auth as copilot_auth;

--- a/maki-providers/src/manifest.rs
+++ b/maki-providers/src/manifest.rs
@@ -1,0 +1,275 @@
+use crate::model::{ModelEntry, ModelFamily, ModelTier};
+use crate::providers::{
+    anthropic, copilot, custom, deepseek, dynamic, google, llama_cpp, mistral, ollama, openai,
+    openrouter, synthetic, tensorx, zai,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct ProviderManifest {
+    pub slug: &'static str,
+    pub display_name: &'static str,
+    pub family: ModelFamily,
+    pub supports_thinking: bool,
+    pub accepts_arbitrary_models: bool,
+    pub fallback_max_output: Option<u32>,
+    pub fallback_context_window: u32,
+    pub models: &'static [ModelEntry],
+}
+
+const ANTHROPIC: ProviderManifest = ProviderManifest {
+    slug: "anthropic",
+    display_name: "Anthropic",
+    family: ModelFamily::Claude,
+    supports_thinking: true,
+    accepts_arbitrary_models: false,
+    fallback_max_output: Some(128_000),
+    fallback_context_window: 200_000,
+    models: anthropic::models(),
+};
+
+const OPENAI: ProviderManifest = ProviderManifest {
+    slug: "openai",
+    display_name: "OpenAI",
+    family: ModelFamily::Gpt,
+    supports_thinking: true,
+    accepts_arbitrary_models: false,
+    fallback_max_output: Some(100_000),
+    fallback_context_window: 200_000,
+    models: openai::models(),
+};
+
+const GOOGLE: ProviderManifest = ProviderManifest {
+    slug: "google",
+    display_name: "Google",
+    family: ModelFamily::Gemini,
+    supports_thinking: true,
+    accepts_arbitrary_models: true,
+    fallback_max_output: Some(65_536),
+    fallback_context_window: 1_000_000,
+    models: google::models(),
+};
+
+const COPILOT: ProviderManifest = ProviderManifest {
+    slug: "copilot",
+    display_name: "Copilot",
+    family: ModelFamily::Generic,
+    supports_thinking: false,
+    accepts_arbitrary_models: true,
+    fallback_max_output: Some(100_000),
+    fallback_context_window: 200_000,
+    models: copilot::models(),
+};
+
+const OLLAMA: ProviderManifest = ProviderManifest {
+    slug: "ollama",
+    display_name: "Ollama",
+    family: ModelFamily::Generic,
+    supports_thinking: false,
+    accepts_arbitrary_models: true,
+    fallback_max_output: Some(16_384),
+    fallback_context_window: 128_000,
+    models: ollama::models(),
+};
+
+const LLAMA_CPP: ProviderManifest = ProviderManifest {
+    slug: "llama-cpp",
+    display_name: "LlamaCpp",
+    family: ModelFamily::Generic,
+    supports_thinking: true,
+    accepts_arbitrary_models: true,
+    fallback_max_output: None,
+    fallback_context_window: 128_000,
+    models: llama_cpp::models(),
+};
+
+const MISTRAL: ProviderManifest = ProviderManifest {
+    slug: "mistral",
+    display_name: "Mistral",
+    family: ModelFamily::Generic,
+    supports_thinking: true,
+    accepts_arbitrary_models: true,
+    fallback_max_output: Some(32_000),
+    fallback_context_window: 128_000,
+    models: mistral::models(),
+};
+
+const ZAI: ProviderManifest = ProviderManifest {
+    slug: "zai",
+    display_name: "Z.AI",
+    family: ModelFamily::Glm,
+    supports_thinking: false,
+    accepts_arbitrary_models: false,
+    fallback_max_output: Some(16_000),
+    fallback_context_window: 128_000,
+    models: zai::models(),
+};
+
+const DEEPSEEK: ProviderManifest = ProviderManifest {
+    slug: "deepseek",
+    display_name: "DeepSeek",
+    family: ModelFamily::Generic,
+    supports_thinking: true,
+    accepts_arbitrary_models: false,
+    fallback_max_output: Some(384_000),
+    fallback_context_window: 1_000_000,
+    models: deepseek::models(),
+};
+
+const OPENROUTER: ProviderManifest = ProviderManifest {
+    slug: "openrouter",
+    display_name: "OpenRouter",
+    family: ModelFamily::Generic,
+    supports_thinking: true,
+    accepts_arbitrary_models: true,
+    fallback_max_output: Some(128_000),
+    fallback_context_window: 200_000,
+    models: openrouter::models(),
+};
+
+const SYNTHETIC: ProviderManifest = ProviderManifest {
+    slug: "synthetic",
+    display_name: "Synthetic",
+    family: ModelFamily::Synthetic,
+    supports_thinking: true,
+    accepts_arbitrary_models: false,
+    fallback_max_output: Some(32_000),
+    fallback_context_window: 128_000,
+    models: synthetic::models(),
+};
+
+const TENSORX: ProviderManifest = ProviderManifest {
+    slug: "tensorx",
+    display_name: "TensorX",
+    family: ModelFamily::Generic,
+    supports_thinking: true,
+    accepts_arbitrary_models: true,
+    fallback_max_output: None,
+    fallback_context_window: 200_000,
+    models: tensorx::models(),
+};
+
+const OPENCODE: ProviderManifest = ProviderManifest {
+    slug: "opencode",
+    display_name: "Opencode",
+    family: ModelFamily::Generic,
+    supports_thinking: true,
+    accepts_arbitrary_models: true,
+    fallback_max_output: Some(128_000),
+    fallback_context_window: 256_000,
+    models: &[],
+};
+
+const BUILTINS: &[ProviderManifest] = &[
+    ANTHROPIC, OPENAI, GOOGLE, COPILOT, OLLAMA, LLAMA_CPP, MISTRAL, ZAI, DEEPSEEK, OPENROUTER,
+    SYNTHETIC, TENSORX, OPENCODE,
+];
+
+pub struct ManifestRegistry;
+
+impl ManifestRegistry {
+    pub fn get(slug: &str) -> Option<&'static ProviderManifest> {
+        BUILTINS.iter().find(|m| m.slug == slug)
+    }
+
+    /// Like `get`, but resolves dynamic and custom (providers.toml) slugs to
+    /// their base provider's manifest so capability lookups (thinking, display
+    /// name, tier defaults) still work for stubs that declare no models. `None`
+    /// for an unknown slug, so callers pick a fallback instead of silently
+    /// inheriting a zeroed manifest.
+    pub fn for_slug(slug: &str) -> Option<&'static ProviderManifest> {
+        Self::get(slug)
+            .or_else(|| dynamic::base_for_slug(slug).and_then(|base| Self::get(&base.to_string())))
+            .or_else(|| custom::base_kind(slug).and_then(|base| Self::get(&base.to_string())))
+    }
+
+    pub fn builtins() -> &'static [ProviderManifest] {
+        BUILTINS
+    }
+
+    pub fn find_default_for_tier(slug: &str, tier: ModelTier) -> Option<&'static ModelEntry> {
+        Self::for_slug(slug)?
+            .models
+            .iter()
+            .find(|e| e.default && e.tier == tier)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::ProviderKind;
+    use maki_config::providers::BuiltInProvider;
+    use std::str::FromStr;
+    use strum::IntoEnumIterator;
+
+    #[test]
+    fn every_builtin_manifest_matches_provider_kind_for_mirrored_fields() {
+        for manifest in BUILTINS {
+            let kind = ProviderKind::from_str(manifest.slug)
+                .unwrap_or_else(|_| panic!("manifest slug {} has no ProviderKind", manifest.slug));
+            // Slug must equal `ProviderKind`'s `Display`, or slug-based routing
+            // and spec formatting would silently diverge.
+            assert_eq!(kind.to_string(), manifest.slug, "{}", manifest.slug);
+            assert_eq!(
+                manifest.display_name,
+                kind.display_name(),
+                "{}",
+                manifest.slug
+            );
+            assert_eq!(manifest.family, kind.family(), "{}", manifest.slug);
+            assert_eq!(
+                manifest.fallback_max_output,
+                kind.fallback_max_output(),
+                "{}",
+                manifest.slug,
+            );
+            assert_eq!(
+                manifest.fallback_context_window,
+                kind.fallback_context_window(),
+                "{}",
+                manifest.slug,
+            );
+        }
+    }
+
+    #[test]
+    fn for_slug_returns_none_for_unknown_slug() {
+        assert!(ManifestRegistry::for_slug("totally-unknown-slug").is_none());
+    }
+
+    #[test]
+    fn for_slug_returns_builtin_directly() {
+        let manifest = ManifestRegistry::for_slug("anthropic").unwrap();
+        assert_eq!(manifest.slug, "anthropic");
+        assert_eq!(manifest.display_name, "Anthropic");
+    }
+
+    #[test]
+    fn builtin_count_matches_provider_kind_count() {
+        let kind_count = ProviderKind::iter().count();
+        assert_eq!(
+            BUILTINS.len(),
+            kind_count,
+            "BUILTINS has {} manifests but ProviderKind has {} variants",
+            BUILTINS.len(),
+            kind_count,
+        );
+    }
+
+    #[test]
+    fn every_builtin_provider_inventory_entry_has_matching_manifest() {
+        for builtin in inventory::iter::<BuiltInProvider>() {
+            let manifest = ManifestRegistry::get(builtin.slug).unwrap_or_else(|| {
+                panic!(
+                    "BuiltInProvider slug {:?} has no ProviderManifest",
+                    builtin.slug,
+                )
+            });
+            assert_eq!(
+                manifest.display_name, builtin.display_name,
+                "display_name mismatch between manifest and BuiltInProvider for slug {:?}",
+                builtin.slug,
+            );
+        }
+    }
+}

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -12,11 +12,9 @@ use std::sync::Arc;
 use maki_storage::sessions::{MIN_THINKING_BUDGET, StoredTokenUsage};
 use serde::{Deserialize, Serialize};
 
-use crate::provider::ProviderKind;
-use crate::providers::{
-    anthropic, copilot, deepseek, dynamic, google, llama_cpp, mistral, ollama, openai, openrouter,
-    synthetic, tensorx, zai,
-};
+use crate::manifest::{ManifestRegistry, ProviderManifest};
+use crate::model_registry::model_registry;
+use crate::providers::{anthropic, custom, dynamic};
 
 const PER_MILLION: f64 = 1_000_000.0;
 
@@ -31,7 +29,7 @@ pub enum ModelError {
     #[error("invalid model tier '{0}' (expected: strong, medium, weak)")]
     InvalidTier(String),
     #[error("no default model for {0}/{1}")]
-    NoDefault(ProviderKind, ModelTier),
+    NoDefault(String, ModelTier),
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -158,6 +156,7 @@ impl From<maki_config::providers::Tier> for ModelTier {
     }
 }
 
+#[derive(Debug)]
 pub struct ModelEntry {
     pub prefixes: &'static [&'static str],
     pub tier: ModelTier,
@@ -170,7 +169,7 @@ pub struct ModelEntry {
     pub context_window: u32,
 }
 
-fn lookup_entry<'a>(
+pub(crate) fn lookup_entry<'a>(
     entries: &'a [ModelEntry],
     model_id: &str,
 ) -> Result<&'a ModelEntry, ModelError> {
@@ -181,24 +180,6 @@ fn lookup_entry<'a>(
         .max_by_key(|(p, _)| p.len())
         .map(|(_, e)| e)
         .ok_or_else(|| ModelError::UnknownModel(model_id.to_string()))
-}
-
-pub fn models_for_provider(provider: ProviderKind) -> &'static [ModelEntry] {
-    match provider {
-        ProviderKind::Anthropic => anthropic::models(),
-        ProviderKind::OpenAi => openai::models(),
-        ProviderKind::Copilot => copilot::models(),
-        ProviderKind::Ollama => ollama::models(),
-        ProviderKind::LlamaCpp => llama_cpp::models(),
-        ProviderKind::Mistral => mistral::models(),
-        ProviderKind::Google => google::models(),
-        ProviderKind::Zai => zai::models(),
-        ProviderKind::Synthetic => synthetic::models(),
-        ProviderKind::TensorX => tensorx::models(),
-        ProviderKind::DeepSeek => deepseek::models(),
-        ProviderKind::OpenRouter => openrouter::models(),
-        ProviderKind::Opencode => &[],
-    }
 }
 
 impl ModelFamily {
@@ -216,11 +197,12 @@ impl ModelFamily {
     }
 }
 
+const FAST_PROVIDER: &str = "anthropic";
+
 #[derive(Debug, Clone)]
 pub struct Model {
     pub id: String,
-    pub provider: ProviderKind,
-    pub dynamic_slug: Option<String>,
+    pub provider: Arc<str>,
     pub tier: ModelTier,
     pub family: ModelFamily,
     pub supports_tool_examples_override: Option<bool>,
@@ -235,16 +217,16 @@ pub struct Model {
 impl Model {
     /// When no static entry matches (a freshly released model the table has not
     /// caught up to yet), fall back to the provider defaults so it still resolves.
-    fn from_base(provider: ProviderKind, model_id: &str, dynamic_slug: Option<&str>) -> Self {
-        let static_entry = lookup_entry(models_for_provider(provider), model_id).ok();
-        let spec = match dynamic_slug {
-            Some(slug) => format!("{slug}/{model_id}"),
-            None => format!("{provider}/{model_id}"),
-        };
-        let tier = crate::model_registry::model_registry()
-            .read()
-            .unwrap()
-            .tier_for(&spec, provider, static_entry.map(|e| e.tier));
+    fn from_base(manifest: &ProviderManifest, slug: &str, model_id: &str) -> Self {
+        let static_entry = lookup_entry(manifest.models, model_id).ok();
+        let spec = format!("{slug}/{model_id}");
+        // Discovery keys `known_models` by the builtin slug, so a dynamic or
+        // custom slug reads positional tiers and metadata through its base.
+        let tier = model_registry().read().unwrap().tier_for(
+            &spec,
+            manifest.slug,
+            static_entry.map(|e| e.tier),
+        );
         let (family, pricing, max_output_tokens, context_window) = match static_entry {
             Some(e) => (
                 e.family,
@@ -253,26 +235,25 @@ impl Model {
                 anthropic::shared::long_context_window(model_id).unwrap_or(e.context_window),
             ),
             None => {
-                let guard = crate::model_registry::model_registry().read().unwrap();
-                let discovered = guard.discovered(provider, model_id);
+                let guard = model_registry().read().unwrap();
+                let discovered = guard.discovered(manifest.slug, model_id);
                 (
-                    provider.family(),
+                    manifest.family,
                     discovered
                         .and_then(|d| d.pricing.clone())
                         .unwrap_or_default(),
                     discovered
                         .and_then(|d| d.max_output_tokens)
-                        .or_else(|| provider.fallback_max_output()),
+                        .or(manifest.fallback_max_output),
                     discovered
                         .and_then(|d| d.context_window)
-                        .unwrap_or_else(|| provider.fallback_context_window()),
+                        .unwrap_or(manifest.fallback_context_window),
                 )
             }
         };
         Self {
             id: model_id.to_string(),
-            provider,
-            dynamic_slug: dynamic_slug.map(str::to_string),
+            provider: Arc::from(slug),
             tier,
             family,
             supports_tool_examples_override: None,
@@ -285,27 +266,38 @@ impl Model {
     }
 
     pub fn supports_thinking(&self) -> bool {
-        self.supports_thinking_override
-            .or_else(|| {
-                let guard = crate::model_registry::model_registry().read().unwrap();
-                guard
-                    .discovered(self.provider, &self.id)
-                    .and_then(|d| d.supports_thinking)
-            })
-            .unwrap_or_else(|| self.provider.supports_thinking())
+        if let Some(thinking) = self.supports_thinking_override {
+            return thinking;
+        }
+        // Discovery keys `known_models` by the builtin slug; resolve dynamic
+        // and custom slugs through their base manifest before looking up.
+        let Some(manifest) = ManifestRegistry::for_slug(&self.provider) else {
+            return false;
+        };
+        model_registry()
+            .read()
+            .unwrap()
+            .discovered(manifest.slug, &self.id)
+            .and_then(|d| d.supports_thinking)
+            .unwrap_or(manifest.supports_thinking)
     }
 
     pub fn supports_vision(&self) -> bool {
-        self.supports_vision_override
-            .or_else(|| {
-                let guard = crate::model_registry::model_registry().read().unwrap();
-                guard
-                    .discovered(self.provider, &self.id)
+        if let Some(vision) = self.supports_vision_override {
+            return vision;
+        }
+        let manifest = ManifestRegistry::for_slug(&self.provider);
+        manifest
+            .and_then(|m| {
+                model_registry()
+                    .read()
+                    .unwrap()
+                    .discovered(m.slug, &self.id)
                     .and_then(|d| d.supports_vision)
             })
             .or_else(|| {
-                lookup_entry(models_for_provider(self.provider), &self.id)
-                    .ok()
+                manifest
+                    .and_then(|m| lookup_entry(m.models, &self.id).ok())
                     .map(|e| e.vision)
             })
             .unwrap_or_else(|| self.family.supports_vision())
@@ -326,76 +318,88 @@ impl Model {
     }
 
     /// A model supports fast mode exactly when it carries fast-tier pricing, so
-    /// capability and billing can never disagree. Bedrock reuses
-    /// `ProviderKind::Anthropic` and the same table, so we also gate on the
-    /// provider here: fast mode only exists on the direct API.
+    /// capability and billing can never disagree. The provider gate keeps fast
+    /// mode to Anthropic-based providers, resolved through the base manifest so
+    /// oauth scripts keep it; Bedrock separately ignores `opts.fast` at request
+    /// time.
     pub fn supports_fast(&self) -> bool {
-        self.pricing.fast.is_some() && self.provider == ProviderKind::Anthropic
+        self.pricing.fast.is_some()
+            && ManifestRegistry::for_slug(&self.provider).is_some_and(|m| m.slug == FAST_PROVIDER)
     }
 
     pub fn spec(&self) -> String {
-        if let Some(slug) = &self.dynamic_slug {
-            format!("{slug}/{}", self.id)
-        } else {
-            format!("{}/{}", self.provider, self.id)
-        }
+        format!("{}/{}", self.provider, self.id)
     }
 
-    pub fn from_tier(provider: ProviderKind, tier: ModelTier) -> Result<Self, ModelError> {
-        if let Some(spec) = crate::model_registry::model_registry()
-            .read()
-            .unwrap()
-            .spec_for_tier(provider, tier)
-        {
+    pub fn provider_display_name(&self) -> &'static str {
+        ManifestRegistry::for_slug(&self.provider).map_or("Unknown", |m| m.display_name)
+    }
+
+    pub fn from_tier(slug: &str, tier: ModelTier) -> Result<Self, ModelError> {
+        if let Some(spec) = model_registry().read().unwrap().spec_for_tier(slug, tier) {
             return Self::from_spec(&spec);
         }
-        let entries = models_for_provider(provider);
-        let entry = entries
-            .iter()
-            .find(|e| e.default && e.tier == tier)
-            .ok_or(ModelError::NoDefault(provider, tier))?;
+        let entry = ManifestRegistry::find_default_for_tier(slug, tier)
+            .ok_or_else(|| ModelError::NoDefault(slug.to_string(), tier))?;
         let model_id = entry.prefixes[0];
-        Self::from_spec(&format!("{provider}/{model_id}"))
+        Self::from_spec(&format!("{slug}/{model_id}"))
     }
 
-    pub fn from_tier_dynamic(
-        provider: ProviderKind,
-        tier: ModelTier,
-        dynamic_slug: Option<&str>,
-    ) -> Result<Self, ModelError> {
-        if let Some(slug) = dynamic_slug {
-            if let Some(model) = dynamic::find_model_for_tier(slug, tier) {
-                return Ok(model);
-            }
-            if let Some(model) = super::providers::custom::find_model_for_tier(slug, tier) {
-                return Ok(model);
-            }
-            let mut model = Self::from_tier(provider, tier)?;
-            model.dynamic_slug = Some(slug.to_string());
+    pub fn from_tier_dynamic(slug: &str, tier: ModelTier) -> Result<Self, ModelError> {
+        if let Some(model) = dynamic::find_model_for_tier(slug, tier) {
             return Ok(model);
         }
-        Self::from_tier(provider, tier)
+        // One providers.toml read, three answers: a model declared at this tier,
+        // the provider exists but declares nothing here (inherit the base
+        // protocol default under the custom slug, keeping its tier and pricing),
+        // or no such provider.
+        match custom::resolve_tier(slug, tier) {
+            custom::TierLookup::Model(model) => return Ok(model),
+            custom::TierLookup::NoModelForTier(base) => {
+                let manifest = ManifestRegistry::get(&base.to_string())
+                    .ok_or_else(|| ModelError::NoDefault(slug.to_string(), tier))?;
+                let entry = manifest
+                    .models
+                    .iter()
+                    .find(|e| e.default && e.tier == tier)
+                    .ok_or_else(|| ModelError::NoDefault(slug.to_string(), tier))?;
+                return Ok(Self::from_base(manifest, slug, entry.prefixes[0]));
+            }
+            custom::TierLookup::Unknown => {}
+        }
+        // Builtin or dynamic slug: resolve the base default under the slug
+        // (dynamic slugs route through `base_for_slug`).
+        if ManifestRegistry::get(slug).is_some() || dynamic::base_for_slug(slug).is_some() {
+            return Self::from_tier(slug, tier);
+        }
+        Err(ModelError::UnsupportedProvider(slug.to_string()))
     }
 
     pub fn from_spec(spec: &str) -> Result<Self, ModelError> {
-        let (provider_str, model_id) = spec.split_once('/').ok_or(ModelError::InvalidFormat)?;
+        let (slug, model_id) = spec.split_once('/').ok_or(ModelError::InvalidFormat)?;
 
-        if let Ok(provider) = ProviderKind::from_str(provider_str) {
-            return Ok(Self::from_base(provider, model_id, None));
+        // Precedence: builtin, then dynamic script, then providers.toml custom.
+        // Discovery drops any script slug a builtin or custom entry already owns,
+        // so a script and a custom provider can never share a slug here.
+        if let Some(manifest) = ManifestRegistry::get(slug) {
+            return Ok(Self::from_base(manifest, slug, model_id));
         }
 
-        if let Some(base) = dynamic::base_for_slug(provider_str) {
-            if let Some(model) = dynamic::lookup_model(provider_str, model_id) {
-                return Ok(model);
-            }
-            return Ok(Self::from_base(base, model_id, Some(provider_str)));
-        }
-
-        if let Some(model) = super::providers::custom::lookup_model(provider_str, model_id) {
+        if let Some(model) = dynamic::lookup_model(slug, model_id) {
             return Ok(model);
         }
 
-        Err(ModelError::UnsupportedProvider(provider_str.to_string()))
+        if let Some(base) = dynamic::base_for_slug(slug)
+            && let Some(manifest) = ManifestRegistry::get(&base.to_string())
+        {
+            return Ok(Self::from_base(manifest, slug, model_id));
+        }
+
+        if let Some(model) = custom::lookup_model(slug, model_id) {
+            return Ok(model);
+        }
+
+        Err(ModelError::UnsupportedProvider(slug.to_string()))
     }
 }
 
@@ -477,8 +481,6 @@ impl AddAssign for TokenUsage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::provider::ProviderKind;
-    use strum::IntoEnumIterator;
     use test_case::test_case;
 
     const TIERS: [ModelTier; 4] = [
@@ -573,15 +575,15 @@ mod tests {
 
     #[test]
     fn fast_pricing_is_always_a_premium() {
-        for provider in ProviderKind::iter() {
-            for entry in models_for_provider(provider) {
+        for manifest in ManifestRegistry::builtins() {
+            for entry in manifest.models {
                 let Some(fast) = &entry.pricing.fast else {
                     continue;
                 };
                 assert!(
                     fast.input >= entry.pricing.input && fast.output >= entry.pricing.output,
                     "{}/{}: fast pricing must not be cheaper than standard",
-                    provider,
+                    manifest.slug,
                     entry.prefixes[0],
                 );
             }
@@ -590,11 +592,11 @@ mod tests {
 
     #[test]
     fn spec_roundtrip() {
-        for provider in ProviderKind::iter() {
-            if provider.accepts_arbitrary_models() {
+        for manifest in ManifestRegistry::builtins() {
+            if manifest.accepts_arbitrary_models {
                 continue;
             }
-            let model = Model::from_tier(provider, ModelTier::Medium).unwrap();
+            let model = Model::from_tier(manifest.slug, ModelTier::Medium).unwrap();
             let round = Model::from_spec(&model.spec()).unwrap();
             assert_eq!(round.id, model.id);
             assert_eq!(round.provider, model.provider);
@@ -605,7 +607,7 @@ mod tests {
     fn opencode_from_spec_parses_four_levels() {
         let spec = "opencode/nvidia/openai/gpt-oss-120b";
         let model = Model::from_spec(spec).unwrap();
-        assert_eq!(model.provider, ProviderKind::Opencode);
+        assert_eq!(model.provider, Arc::<str>::from("opencode"));
         assert_eq!(model.id, "nvidia/openai/gpt-oss-120b");
         assert_eq!(model.spec(), spec);
     }
@@ -614,28 +616,29 @@ mod tests {
     fn opencode_from_spec_parses_three_levels() {
         let spec = "opencode/opencode/big-pickle";
         let model = Model::from_spec(spec).unwrap();
-        assert_eq!(model.provider, ProviderKind::Opencode);
+        assert_eq!(model.provider, Arc::<str>::from("opencode"));
         assert_eq!(model.id, "opencode/big-pickle");
         assert_eq!(model.spec(), spec);
     }
 
     #[test]
     fn from_tier_covers_all_providers() {
-        for provider in ProviderKind::iter() {
-            if provider.accepts_arbitrary_models() {
+        for manifest in ManifestRegistry::builtins() {
+            if manifest.accepts_arbitrary_models {
                 continue;
             }
+            let slug: Arc<str> = Arc::from(manifest.slug);
             for &tier in &TIERS {
                 // DeepSeek has no Weak tier model
-                if provider == ProviderKind::DeepSeek && tier == ModelTier::Weak {
+                if manifest.slug == "deepseek" && tier == ModelTier::Weak {
                     continue;
                 }
                 // Compaction is user-assigned only, not in static registry
                 if tier == ModelTier::Compaction {
                     continue;
                 }
-                let model = Model::from_tier(provider, tier).unwrap();
-                assert_eq!(model.provider, provider);
+                let model = Model::from_tier(manifest.slug, tier).unwrap();
+                assert_eq!(model.provider, slug);
                 assert_eq!(model.tier, tier);
                 let max_output = model.max_output_tokens.unwrap();
                 assert!(max_output > 0);
@@ -658,13 +661,13 @@ mod tests {
 
     #[test]
     fn exactly_one_default_per_provider_tier() {
-        for provider in ProviderKind::iter() {
-            if provider.accepts_arbitrary_models() {
+        for manifest in ManifestRegistry::builtins() {
+            if manifest.accepts_arbitrary_models {
                 continue;
             }
-            let entries = models_for_provider(provider);
+            let entries = manifest.models;
             for &tier in &TIERS {
-                if provider == ProviderKind::DeepSeek && tier == ModelTier::Weak {
+                if manifest.slug == "deepseek" && tier == ModelTier::Weak {
                     continue;
                 }
                 // Compaction is user-assigned only, not in static registry
@@ -677,37 +680,41 @@ mod tests {
                     .count();
                 assert_eq!(
                     count, 1,
-                    "{provider}/{tier}: expected exactly 1 default, found {count}"
+                    "{}/{}: expected exactly 1 default, found {count}",
+                    manifest.slug, tier
                 );
             }
         }
     }
 
-    #[test_case("anthropic/claude-99-turbo", ProviderKind::Anthropic, "claude-99-turbo" ; "unknown_anthropic_model_accepted")]
-    #[test_case("zai/glm-99", ProviderKind::Zai, "glm-99" ; "unknown_zai_model_accepted")]
-    #[test_case("openai/gpt-99", ProviderKind::OpenAi, "gpt-99" ; "unknown_openai_model_accepted")]
-    #[test_case("synthetic/hf:nonexistent", ProviderKind::Synthetic, "hf:nonexistent" ; "unknown_synthetic_model_accepted")]
-    #[test_case("ollama/my-custom-model", ProviderKind::Ollama, "my-custom-model" ; "unknown_ollama_model_accepted")]
-    #[test_case("deepseek/my-custom-model", ProviderKind::DeepSeek, "my-custom-model" ; "unknown_deepseek_model_accepted")]
-    fn unknown_model_accepted(spec: &str, expected_provider: ProviderKind, expected_id: &str) {
+    #[test_case("anthropic/claude-99-turbo", "anthropic", "claude-99-turbo" ; "unknown_anthropic_model_accepted")]
+    #[test_case("zai/glm-99", "zai", "glm-99" ; "unknown_zai_model_accepted")]
+    #[test_case("openai/gpt-99", "openai", "gpt-99" ; "unknown_openai_model_accepted")]
+    #[test_case("synthetic/hf:nonexistent", "synthetic", "hf:nonexistent" ; "unknown_synthetic_model_accepted")]
+    #[test_case("ollama/my-custom-model", "ollama", "my-custom-model" ; "unknown_ollama_model_accepted")]
+    #[test_case("deepseek/my-custom-model", "deepseek", "my-custom-model" ; "unknown_deepseek_model_accepted")]
+    fn unknown_model_accepted(spec: &str, expected_slug: &str, expected_id: &str) {
         let model = Model::from_spec(spec).unwrap();
-        assert_eq!(model.provider, expected_provider);
+        assert_eq!(model.provider, Arc::<str>::from(expected_slug));
         assert_eq!(model.id, expected_id);
-        assert_eq!(model.family, expected_provider.family());
+        let manifest = ManifestRegistry::get(expected_slug).unwrap();
+        assert_eq!(model.family, manifest.family);
     }
 
     #[test]
-    fn from_base_dynamic_unknown_model_uses_provider_fallbacks() {
+    fn from_base_unknown_model_uses_provider_fallbacks() {
         // Deliberately fake id so this stays valid when the model table changes.
-        let base = ProviderKind::Anthropic;
-        let model = Model::from_base(base, "claude-nonexistent-99", Some("anthropic-oauth"));
-        assert_eq!(model.provider, base);
+        let model = Model::from_base(
+            ManifestRegistry::get("anthropic").unwrap(),
+            "anthropic",
+            "claude-nonexistent-99",
+        );
+        assert_eq!(model.provider, Arc::<str>::from("anthropic"));
         assert_eq!(model.id, "claude-nonexistent-99");
-        assert_eq!(model.dynamic_slug.as_deref(), Some("anthropic-oauth"));
-        assert_eq!(model.spec(), "anthropic-oauth/claude-nonexistent-99");
-        assert_eq!(model.family, base.family());
-        assert_eq!(model.max_output_tokens, base.fallback_max_output());
-        assert_eq!(model.context_window, base.fallback_context_window());
+        assert_eq!(model.spec(), "anthropic/claude-nonexistent-99");
+        assert_eq!(model.family, ModelFamily::Claude);
+        assert_eq!(model.max_output_tokens, Some(128_000));
+        assert_eq!(model.context_window, 200_000);
         let p = &model.pricing;
         assert_eq!(
             (p.input, p.output, p.cache_write, p.cache_read),
@@ -733,7 +740,11 @@ mod tests {
     #[test_case("claude-opus-4-7" ; "opus_4_7")]
     #[test_case("claude-opus-4-8" ; "opus_4_8")]
     fn supports_fast_true_for_anthropic_opus(model_id: &str) {
-        let model = Model::from_base(ProviderKind::Anthropic, model_id, None);
+        let model = Model::from_base(
+            ManifestRegistry::get("anthropic").unwrap(),
+            "anthropic",
+            model_id,
+        );
         assert!(model.supports_fast());
     }
 
@@ -741,19 +752,31 @@ mod tests {
     #[test_case("claude-haiku-4-5" ; "haiku")]
     #[test_case("claude-opus-4-5" ; "opus_4_5")]
     fn supports_fast_false_for_other_anthropic_models(model_id: &str) {
-        let model = Model::from_base(ProviderKind::Anthropic, model_id, None);
+        let model = Model::from_base(
+            ManifestRegistry::get("anthropic").unwrap(),
+            "anthropic",
+            model_id,
+        );
         assert!(!model.supports_fast());
     }
 
     #[test]
     fn supports_fast_false_for_unknown_anthropic_model() {
-        let model = Model::from_base(ProviderKind::Anthropic, "claude-opus-99", None);
+        let model = Model::from_base(
+            ManifestRegistry::get("anthropic").unwrap(),
+            "anthropic",
+            "claude-opus-99",
+        );
         assert!(!model.supports_fast());
     }
 
     #[test]
     fn supports_fast_false_for_non_anthropic_even_with_fast_pricing() {
-        let mut model = Model::from_base(ProviderKind::Google, "gemini-2.5-pro", None);
+        let mut model = Model::from_base(
+            ManifestRegistry::get("google").unwrap(),
+            "google",
+            "gemini-2.5-pro",
+        );
         model.pricing.fast = Some(FastPricing {
             input: 30.0,
             output: 150.0,
@@ -764,9 +787,8 @@ mod tests {
     #[test]
     fn discovered_context_window_flows_into_from_base_for_unknown_model() {
         use crate::model::ModelInfo;
-        use crate::model_registry::model_registry;
 
-        let provider = ProviderKind::Ollama;
+        let slug: Arc<str> = Arc::from("ollama");
         let model_id = "test-discovered-context-window-model";
         let expected_window: u32 = 131_072;
 
@@ -774,7 +796,7 @@ mod tests {
         {
             let mut reg = model_registry().write().unwrap();
             reg.set_known_models(
-                provider,
+                &slug,
                 vec![ModelInfo {
                     id: model_id.to_string(),
                     context_window: Some(expected_window),
@@ -788,10 +810,19 @@ mod tests {
         }
 
         // from_base for this unknown model should pick up the discovered context_window
-        let model = Model::from_base(provider, model_id, None);
+        let model = Model::from_base(ManifestRegistry::get("ollama").unwrap(), "ollama", model_id);
         assert_eq!(model.id, model_id);
         assert_eq!(model.context_window, expected_window);
         // max_output_tokens falls back to provider default since not discovered
-        assert_eq!(model.max_output_tokens, provider.fallback_max_output());
+        assert_eq!(model.max_output_tokens, Some(16_384));
+
+        // A dynamic/custom slug shares its base provider's discovery.
+        let wrapped = Model::from_base(
+            ManifestRegistry::get("ollama").unwrap(),
+            "my-ollama-wrap",
+            model_id,
+        );
+        assert_eq!(wrapped.spec(), format!("my-ollama-wrap/{model_id}"));
+        assert_eq!(wrapped.context_window, expected_window);
     }
 }

--- a/maki-providers/src/model_registry.rs
+++ b/maki-providers/src/model_registry.rs
@@ -13,13 +13,12 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
-use std::sync::{OnceLock, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
 
 use maki_storage::{StateDir, atomic_write};
 use tracing::warn;
 
-use crate::model::{ModelInfo, ModelTier, models_for_provider};
-use crate::provider::ProviderKind;
+use crate::model::{ModelInfo, ModelTier};
 
 const TIERS_FILE: &str = "model-tiers";
 
@@ -60,7 +59,7 @@ pub struct ModelRegistry {
     /// Ordered model info per provider, populated from `list_models()`.
     /// Not persisted - rebuilt every session. Used for auto-tier assignment
     /// and discovered metadata lookup.
-    known_models: HashMap<ProviderKind, Vec<ModelInfo>>,
+    known_models: HashMap<Arc<str>, Vec<ModelInfo>>,
 }
 
 impl ModelRegistry {
@@ -68,8 +67,8 @@ impl ModelRegistry {
         self.overrides = overrides;
     }
 
-    pub fn set_known_models(&mut self, provider: ProviderKind, models: Vec<ModelInfo>) {
-        self.known_models.insert(provider, models);
+    pub fn set_known_models(&mut self, provider: &Arc<str>, models: Vec<ModelInfo>) {
+        self.known_models.insert(Arc::clone(provider), models);
     }
 
     pub fn set(&mut self, spec: String, tier: ModelTier) {
@@ -87,9 +86,9 @@ impl ModelRegistry {
     }
 
     /// Lookup discovered metadata for a model by ID.
-    pub fn discovered(&self, provider: ProviderKind, model_id: &str) -> Option<&ModelInfo> {
+    pub fn discovered(&self, provider: &str, model_id: &str) -> Option<&ModelInfo> {
         self.known_models
-            .get(&provider)?
+            .get(provider)?
             .iter()
             .find(|m| m.id == model_id)
     }
@@ -97,7 +96,7 @@ impl ModelRegistry {
     pub fn tier_for(
         &self,
         spec: &str,
-        provider: ProviderKind,
+        provider: &str,
         static_tier: Option<ModelTier>,
     ) -> ModelTier {
         // A spec may hold several tiers; prefer the strongest agent tier,
@@ -118,7 +117,7 @@ impl ModelRegistry {
             return t;
         }
         if let Some((_, model_id)) = spec.split_once('/')
-            && let Some(models) = self.known_models.get(&provider)
+            && let Some(models) = self.known_models.get(provider)
             && let Some(pos) = models.iter().position(|m| m.id == model_id)
         {
             return tier_for_position(pos);
@@ -126,7 +125,7 @@ impl ModelRegistry {
         ModelTier::Medium
     }
 
-    pub fn spec_for_tier(&self, provider: ProviderKind, tier: ModelTier) -> Option<String> {
+    pub fn spec_for_tier(&self, provider: &str, tier: ModelTier) -> Option<String> {
         let prefix = format!("{provider}/");
         if let Some(spec) = self.overrides.get(&tier)
             && spec.starts_with(&prefix)
@@ -141,15 +140,17 @@ impl ModelRegistry {
         (!self.claimed_elsewhere(&candidate, tier)).then_some(candidate)
     }
 
-    fn static_candidate(&self, provider: ProviderKind, tier: ModelTier) -> Option<String> {
-        models_for_provider(provider)
+    fn static_candidate(&self, provider: &str, tier: ModelTier) -> Option<String> {
+        let manifest = crate::manifest::ManifestRegistry::get(provider)?;
+        manifest
+            .models
             .iter()
             .find(|e| e.default && e.tier == tier)
             .map(|e| format!("{provider}/{}", e.prefixes[0]))
     }
 
-    fn positional_candidate(&self, provider: ProviderKind, tier: ModelTier) -> Option<String> {
-        let models = self.known_models.get(&provider).filter(|m| !m.is_empty())?;
+    fn positional_candidate(&self, provider: &str, tier: ModelTier) -> Option<String> {
+        let models = self.known_models.get(provider).filter(|m| !m.is_empty())?;
         let slot = match tier {
             ModelTier::Strong => 0,
             ModelTier::Medium => 1,
@@ -170,7 +171,7 @@ impl ModelRegistry {
         if let Some(spec) = self.overrides.get(&tier) {
             return Some(spec.clone());
         }
-        for &provider in self.known_models.keys() {
+        for provider in self.known_models.keys() {
             if let Some(spec) = self.spec_for_tier(provider, tier) {
                 return Some(spec);
             }
@@ -242,7 +243,7 @@ mod tests {
         reg.set_overrides(overrides.iter().map(|(t, s)| (*t, s.to_string())).collect());
         if !models.is_empty() {
             reg.set_known_models(
-                ProviderKind::Ollama,
+                &Arc::<str>::from("ollama"),
                 models
                     .iter()
                     .map(|s| ModelInfo::id_only(s.to_string()))
@@ -257,7 +258,7 @@ mod tests {
         let mut reg = make_map(&[], &["pos0", "pos1", "pos2"]);
         reg.set("ollama/pos1".into(), ModelTier::Weak);
 
-        let t = |spec, static_tier| reg.tier_for(spec, ProviderKind::Ollama, static_tier);
+        let t = |spec, static_tier| reg.tier_for(spec, "ollama", static_tier);
 
         assert_eq!(t("ollama/pos1", Some(ModelTier::Strong)), ModelTier::Weak);
         assert_eq!(t("ollama/pos0", Some(ModelTier::Weak)), ModelTier::Weak);
@@ -275,7 +276,7 @@ mod tests {
         reg.set("ollama/multi".into(), ModelTier::Compaction);
         reg.set("ollama/compact-only".into(), ModelTier::Compaction);
 
-        let t = |spec| reg.tier_for(spec, ProviderKind::Ollama, None);
+        let t = |spec| reg.tier_for(spec, "ollama", None);
 
         assert_eq!(t("ollama/multi"), ModelTier::Strong);
         assert_eq!(t("ollama/compact-only"), ModelTier::Compaction);
@@ -287,23 +288,17 @@ mod tests {
             &[(ModelTier::Strong, "ollama/custom")],
             &["big", "mid", "small"],
         );
-        let s = |t| reg.spec_for_tier(ProviderKind::Ollama, t);
+        let s = |t| reg.spec_for_tier("ollama", t);
 
         assert_eq!(s(ModelTier::Strong), Some("ollama/custom".into()));
         assert_eq!(s(ModelTier::Medium), Some("ollama/mid".into()));
         assert_eq!(s(ModelTier::Weak), Some("ollama/small".into()));
 
         let scoped = make_map(&[(ModelTier::Strong, "openai/gpt-foo")], &[]);
-        assert_eq!(
-            scoped.spec_for_tier(ProviderKind::Ollama, ModelTier::Strong),
-            None
-        );
+        assert_eq!(scoped.spec_for_tier("ollama", ModelTier::Strong), None);
 
         let conflict = make_map(&[(ModelTier::Weak, "ollama/big")], &["big", "mid", "small"]);
-        assert_eq!(
-            conflict.spec_for_tier(ProviderKind::Ollama, ModelTier::Strong),
-            None
-        );
+        assert_eq!(conflict.spec_for_tier("ollama", ModelTier::Strong), None);
     }
 
     #[test]
@@ -333,7 +328,7 @@ mod tests {
     fn discovered_looks_up_by_id() {
         let mut reg = ModelRegistry::default();
         reg.set_known_models(
-            ProviderKind::LlamaCpp,
+            &Arc::<str>::from("llama-cpp"),
             vec![
                 ModelInfo {
                     id: "model-a".into(),
@@ -355,11 +350,11 @@ mod tests {
                 },
             ],
         );
-        let info = reg.discovered(ProviderKind::LlamaCpp, "model-a").unwrap();
+        let info = reg.discovered("llama-cpp", "model-a").unwrap();
         assert_eq!(info.id, "model-a");
         assert_eq!(info.context_window, Some(32_000));
-        assert!(reg.discovered(ProviderKind::LlamaCpp, "model-x").is_none());
-        assert!(reg.discovered(ProviderKind::Ollama, "model-a").is_none());
+        assert!(reg.discovered("llama-cpp", "model-x").is_none());
+        assert!(reg.discovered("ollama", "model-a").is_none());
     }
 
     #[test]

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -1,14 +1,16 @@
 use std::future::Future;
 use std::pin::Pin;
+use std::str::FromStr;
+use std::sync::Arc;
 
 use flume::Sender;
 use serde_json::Value;
-use strum::{Display, EnumIter, EnumString, IntoEnumIterator};
+use strum::{Display, EnumIter, EnumString};
 use tracing::{debug, warn};
 
 use maki_storage::id::SessionRef;
 
-use crate::model::{Model, ModelFamily, ModelInfo, models_for_provider};
+use crate::model::{Model, ModelFamily, ModelInfo};
 use crate::providers::Timeouts;
 use crate::providers::anthropic::Anthropic;
 use crate::providers::anthropic::bedrock;
@@ -106,22 +108,6 @@ impl ProviderKind {
         }
     }
 
-    pub const fn supports_thinking(self) -> bool {
-        matches!(
-            self,
-            Self::Anthropic
-                | Self::Google
-                | Self::Mistral
-                | Self::DeepSeek
-                | Self::Synthetic
-                | Self::OpenAi
-                | Self::OpenRouter
-                | Self::LlamaCpp
-                | Self::TensorX
-                | Self::Opencode
-        )
-    }
-
     pub const fn features(self) -> Option<&'static str> {
         match self {
             Self::Anthropic => {
@@ -166,20 +152,6 @@ impl ProviderKind {
             Self::TensorX => ModelFamily::Generic,
             Self::Opencode => ModelFamily::Generic,
         }
-    }
-
-    pub const fn accepts_arbitrary_models(self) -> bool {
-        matches!(
-            self,
-            Self::Ollama
-                | Self::LlamaCpp
-                | Self::Google
-                | Self::Copilot
-                | Self::OpenRouter
-                | Self::TensorX
-                | Self::Mistral
-                | Self::Opencode
-        )
     }
 
     /// `None` when we honestly don't know the output window: llama.cpp
@@ -246,10 +218,6 @@ impl ProviderKind {
             Self::Opencode => Ok(Box::new(Opencode::new(timeouts)?)),
         }
     }
-
-    pub fn is_available(self) -> bool {
-        self.create(Timeouts::default()).is_ok()
-    }
 }
 
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
@@ -290,7 +258,10 @@ pub trait Provider: Send + Sync {
     fn adjust_model(&self, _model: &mut Model) {}
 }
 
-fn provider_for_slug(slug: &str, timeouts: Timeouts) -> Result<Box<dyn Provider>, AgentError> {
+pub fn provider_for_slug(slug: &str, timeouts: Timeouts) -> Result<Box<dyn Provider>, AgentError> {
+    if let Ok(kind) = ProviderKind::from_str(slug) {
+        return kind.create(timeouts);
+    }
     if dynamic::display_name(slug).is_some() {
         dynamic::create(slug, timeouts)
     } else {
@@ -298,12 +269,12 @@ fn provider_for_slug(slug: &str, timeouts: Timeouts) -> Result<Box<dyn Provider>
     }
 }
 
+pub fn provider_available(slug: &str) -> bool {
+    provider_for_slug(slug, Timeouts::default()).is_ok()
+}
+
 pub fn from_model(model: &mut Model, timeouts: Timeouts) -> Result<Box<dyn Provider>, AgentError> {
-    if let Some(slug) = &model.dynamic_slug {
-        debug!(slug, model = %model.id, "slug provider created");
-        return provider_for_slug(slug, timeouts);
-    }
-    let provider = model.provider.create(timeouts)?;
+    let provider = provider_for_slug(&model.provider, timeouts)?;
     provider.adjust_model(model);
     debug!(provider = %model.provider, model = %model.id, "provider created");
     Ok(provider)
@@ -354,21 +325,11 @@ pub async fn from_model_async(
     model: &mut Model,
     timeouts: Timeouts,
 ) -> Result<Box<dyn Provider>, AgentError> {
-    let slug = model.dynamic_slug.clone();
-    let kind = model.provider;
+    let slug = Arc::clone(&model.provider);
     let id = model.id.clone();
-    let provider = smol::unblock(move || {
-        if let Some(slug) = &slug {
-            provider_for_slug(slug, timeouts)
-        } else {
-            kind.create(timeouts)
-        }
-    })
-    .await?;
-    if model.dynamic_slug.is_none() {
-        provider.adjust_model(model);
-    }
-    debug!(provider = %kind, model = %id, "provider created");
+    let provider = smol::unblock(move || provider_for_slug(&slug, timeouts)).await?;
+    provider.adjust_model(model);
+    debug!(provider = %model.provider, model = %id, "provider created");
     Ok(provider)
 }
 
@@ -380,13 +341,14 @@ pub struct ModelBatch {
 /// Offline version of model discovery: returns specs from static tables
 /// and configured dynamic providers. See [`fetch_all_models`] for live lookups.
 pub fn available_model_specs() -> Vec<String> {
-    let mut specs: Vec<String> = ProviderKind::iter()
-        .filter(|kind| kind.is_available())
-        .flat_map(|kind| {
-            models_for_provider(kind)
+    let mut specs: Vec<String> = crate::manifest::ManifestRegistry::builtins()
+        .iter()
+        .filter(|m| provider_available(m.slug))
+        .flat_map(|m| {
+            m.models
                 .iter()
                 .flat_map(|entry| entry.prefixes.iter())
-                .map(move |p| format!("{kind}/{p}"))
+                .map(move |p| format!("{}/{}", m.slug, p))
         })
         .collect();
     for slug in dynamic::discovered_slugs() {
@@ -407,26 +369,29 @@ pub async fn fetch_all_models(
     let (tx, rx) = flume::unbounded();
     let timeouts = Timeouts::default();
 
-    for kind in ProviderKind::iter() {
-        let Ok(provider) = smol::unblock(move || kind.create(timeouts)).await else {
-            warn!(provider = %kind, "failed to create provider, skipping");
+    for manifest in crate::manifest::ManifestRegistry::builtins() {
+        let slug = manifest.slug;
+        let Ok(provider) = smol::unblock(move || provider_for_slug(slug, timeouts)).await else {
+            warn!(provider = slug, "failed to create provider, skipping");
             continue;
         };
+        let display_name = manifest.display_name;
         let tx = tx.clone();
         smol::spawn(async move {
             let batch = match provider.list_models().await {
                 Ok(models) => {
-                    if kind.accepts_arbitrary_models() {
+                    if manifest.accepts_arbitrary_models {
+                        let slug: Arc<str> = Arc::from(slug);
                         crate::model_registry::model_registry()
                             .write()
                             .unwrap()
-                            .set_known_models(kind, models.clone());
+                            .set_known_models(&slug, models.clone());
                     }
                     let mut specs: Vec<String> =
-                        models.iter().map(|m| format!("{kind}/{}", m.id)).collect();
-                    for entry in models_for_provider(kind) {
+                        models.iter().map(|m| format!("{slug}/{}", m.id)).collect();
+                    for entry in manifest.models {
                         for prefix in entry.prefixes {
-                            let spec = format!("{kind}/{prefix}");
+                            let spec = format!("{slug}/{prefix}");
                             if !specs.contains(&spec) {
                                 specs.push(spec);
                             }
@@ -438,17 +403,17 @@ pub async fn fetch_all_models(
                     }
                 }
                 Err(e) => {
-                    warn!(provider = %kind, error = %e, "failed to list models, using static fallback");
-                    let fallback: Vec<String> = models_for_provider(kind)
+                    warn!(provider = slug, error = %e, "failed to list models, using static fallback");
+                    let fallback: Vec<String> = manifest
+                        .models
                         .iter()
                         .flat_map(|entry| entry.prefixes.iter())
-                        .map(|p| format!("{kind}/{p}"))
+                        .map(|p| format!("{slug}/{p}"))
                         .collect();
                     ModelBatch {
                         models: fallback,
                         warnings: vec![format!(
-                            "{}: {e} (using static fallback)",
-                            kind.display_name()
+                            "{display_name}: {e} (using static fallback)"
                         )],
                     }
                 }

--- a/maki-providers/src/providers/anthropic/shared.rs
+++ b/maki-providers/src/providers/anthropic/shared.rs
@@ -382,7 +382,7 @@ impl EventParser {
     }
 }
 
-pub(crate) fn models() -> &'static [ModelEntry] {
+pub(crate) const fn models() -> &'static [ModelEntry] {
     const MODELS: &[ModelEntry] = &[
         ModelEntry {
             prefixes: &["claude-haiku-4-5"],

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -40,7 +40,7 @@ const RESPONSES_PATH: &str = "/responses";
 const MESSAGES_PATH: &str = "/v1/messages";
 const MODELS_PATH: &str = "/models";
 
-pub(crate) fn models() -> &'static [ModelEntry] {
+pub(crate) const fn models() -> &'static [ModelEntry] {
     &[
         ModelEntry {
             prefixes: &["gpt-5-mini", "gpt-5 mini", "claude-haiku-4.5"],

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -4,14 +4,14 @@ use flume::Sender;
 use serde_json::Value;
 
 use maki_config::providers::{
-    Protocol, ProvidersConfig, builtin_provider, resolve_api_key_env, resolve_base_url,
-    resolve_protocol,
+    Protocol, ProviderDef, ProvidersConfig, resolve_api_key_env, resolve_base_url, resolve_protocol,
 };
 use maki_storage::id::SessionRef;
 
 use super::ResolvedAuth;
 use super::openai::responses;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+use crate::manifest::ManifestRegistry;
 use crate::model::{FastPricing, Model, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider, ProviderKind};
 use crate::providers::Timeouts;
@@ -26,14 +26,24 @@ static CUSTOM_OPENAI_CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     provider_name: "custom",
 };
 
-fn resolve_provider_kind(slug: &str) -> Option<ProviderKind> {
-    let config = ProvidersConfig::load();
-    let def = config.get(slug)?;
-    match def.protocol? {
-        Protocol::Openai | Protocol::OpenaiResponses => Some(ProviderKind::OpenAi),
-        Protocol::Anthropic => Some(ProviderKind::Anthropic),
-        Protocol::Google => Some(ProviderKind::Google),
+fn protocol_kind(protocol: Protocol) -> ProviderKind {
+    match protocol {
+        Protocol::Openai | Protocol::OpenaiResponses => ProviderKind::OpenAi,
+        Protocol::Anthropic => ProviderKind::Anthropic,
+        Protocol::Google => ProviderKind::Google,
     }
+}
+
+/// Builtins win their slug in `from_spec`/`create`, so every custom path skips
+/// them. Key off the manifest (all 13 builtins), not `builtin_provider`, which
+/// omits `openrouter`/`opencode` and would let them shadow the builtin.
+fn is_builtin_slug(slug: &str) -> bool {
+    ManifestRegistry::get(slug).is_some()
+}
+
+pub fn base_kind(slug: &str) -> Option<ProviderKind> {
+    let config = ProvidersConfig::load();
+    Some(protocol_kind(config.get(slug)?.protocol?))
 }
 
 fn resolve_custom_auth(slug: &str) -> Result<ResolvedAuth, AgentError> {
@@ -53,7 +63,7 @@ fn resolve_custom_auth(slug: &str) -> Result<ResolvedAuth, AgentError> {
 }
 
 pub fn create(slug: &str, timeouts: Timeouts) -> Result<Box<dyn Provider>, AgentError> {
-    let kind = resolve_provider_kind(slug).ok_or_else(|| AgentError::Config {
+    let kind = base_kind(slug).ok_or_else(|| AgentError::Config {
         message: format!("unknown custom provider '{slug}'"),
     })?;
     let resolved = resolve_custom_auth(slug)?;
@@ -81,13 +91,18 @@ pub fn create(slug: &str, timeouts: Timeouts) -> Result<Box<dyn Provider>, Agent
 }
 
 pub fn lookup_model(slug: &str, model_id: &str) -> Option<Model> {
+    if is_builtin_slug(slug) {
+        return None;
+    }
     let config = ProvidersConfig::load();
     let def = config.get(slug)?;
-    let kind = match def.protocol? {
-        Protocol::Openai | Protocol::OpenaiResponses => ProviderKind::OpenAi,
-        Protocol::Anthropic => ProviderKind::Anthropic,
-        Protocol::Google => ProviderKind::Google,
-    };
+    let kind = protocol_kind(def.protocol?);
+    Some(model_from_def(def, kind, slug, model_id))
+}
+
+/// Build a model from an already-loaded provider definition so tier resolution
+/// and id lookup can share one `providers.toml` read instead of loading twice.
+fn model_from_def(def: &ProviderDef, kind: ProviderKind, slug: &str, model_id: &str) -> Model {
     let declared = def.models.iter().find(|m| m.id == model_id);
     let tier = declared
         .map(|m| ModelTier::from(m.tier))
@@ -99,7 +114,9 @@ pub fn lookup_model(slug: &str, model_id: &str) -> Option<Model> {
         .and_then(|m| m.context_window)
         .unwrap_or_else(|| kind.fallback_context_window());
     let supports_tool_examples_override = declared.and_then(|m| m.supports_tool_examples);
-    let supports_thinking_override = declared.and_then(|m| m.supports_thinking);
+    let supports_thinking_override = declared
+        .and_then(|m| m.supports_thinking)
+        .or_else(|| ManifestRegistry::get(&kind.to_string()).map(|m| m.supports_thinking));
     let supports_vision_override = declared.and_then(|m| m.supports_vision);
     let pricing = declared
         .filter(|m| m.has_pricing())
@@ -116,10 +133,9 @@ pub fn lookup_model(slug: &str, model_id: &str) -> Option<Model> {
                 }),
         })
         .unwrap_or_default();
-    Some(Model {
+    Model {
         id: model_id.to_string(),
-        provider: kind,
-        dynamic_slug: Some(slug.to_string()),
+        provider: Arc::from(slug),
         tier,
         family: kind.family(),
         supports_tool_examples_override,
@@ -128,15 +144,18 @@ pub fn lookup_model(slug: &str, model_id: &str) -> Option<Model> {
         pricing,
         max_output_tokens,
         context_window,
-    })
+    }
 }
 
 /// Specs declared statically in `providers.toml` (no HTTP).
 pub fn declared_model_specs() -> Vec<String> {
-    let config = ProvidersConfig::load();
+    declared_specs_from(&ProvidersConfig::load())
+}
+
+fn declared_specs_from(config: &ProvidersConfig) -> Vec<String> {
     let mut specs = Vec::new();
     for (slug, def) in &config.providers {
-        if builtin_provider(slug).is_some() {
+        if is_builtin_slug(slug) {
             continue;
         }
         if resolve_protocol(slug, Some(def)).is_none() {
@@ -149,14 +168,33 @@ pub fn declared_model_specs() -> Vec<String> {
     specs
 }
 
-pub fn find_model_for_tier(slug: &str, tier: ModelTier) -> Option<Model> {
+/// Outcome of resolving a tier against `providers.toml` in a single read.
+pub enum TierLookup {
+    Model(Model),
+    /// Provider exists but declares no model at this tier; carries the base kind
+    /// so the caller can inherit the base protocol's default.
+    NoModelForTier(ProviderKind),
+    Unknown,
+}
+
+pub fn resolve_tier(slug: &str, tier: ModelTier) -> TierLookup {
+    // Builtins are never overridden through providers.toml (from_spec/create
+    // check builtin first); keep the tier path consistent with that.
+    if is_builtin_slug(slug) {
+        return TierLookup::Unknown;
+    }
     let config = ProvidersConfig::load();
-    let def = config.get(slug)?;
-    let declared = def
-        .models
-        .iter()
-        .find(|m| ModelTier::from(m.tier) == tier)?;
-    lookup_model(slug, &declared.id)
+    let Some(def) = config.get(slug) else {
+        return TierLookup::Unknown;
+    };
+    let Some(protocol) = def.protocol else {
+        return TierLookup::Unknown;
+    };
+    let kind = protocol_kind(protocol);
+    match def.models.iter().find(|m| ModelTier::from(m.tier) == tier) {
+        Some(declared) => TierLookup::Model(model_from_def(def, kind, slug, &declared.id)),
+        None => TierLookup::NoModelForTier(kind),
+    }
 }
 
 /// Skip definitions handled by [`declared_model_specs`]; only HTTP `/models`
@@ -166,7 +204,7 @@ pub fn discover_models(timeouts: Timeouts) -> Vec<String> {
     let config = ProvidersConfig::load();
     let mut all_specs = Vec::new();
     for slug in config.providers.keys() {
-        if builtin_provider(slug).is_some() {
+        if is_builtin_slug(slug) {
             continue;
         }
         let def = config.get(slug).unwrap();
@@ -246,5 +284,39 @@ impl Provider for CustomOpenAiProvider {
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         let auth = self.auth.lock().unwrap().clone();
         Box::pin(async move { self.compat.do_list_models(&auth).await })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn openai_def(model_id: &str) -> ProviderDef {
+        serde_json::from_str(&format!(
+            r#"{{"protocol":"openai","models":[{{"id":"{model_id}"}}]}}"#
+        ))
+        .unwrap()
+    }
+
+    // `openrouter` is a builtin whose slug is absent from the `builtin_provider`
+    // inventory; the old guard leaked it into the picker, where it then resolved
+    // as the builtin and silently dropped the custom model. Listing must skip
+    // every builtin slug so a providers.toml entry can never shadow one.
+    #[test]
+    fn declared_specs_skip_builtin_named_entries_but_keep_custom() {
+        let mut config = ProvidersConfig::default();
+        config.upsert("openrouter".to_string(), openai_def("shadow-model"));
+        config.upsert("my-custom".to_string(), openai_def("real-model"));
+
+        let specs = declared_specs_from(&config);
+        assert!(
+            !specs.iter().any(|s| s.starts_with("openrouter/")),
+            "builtin slug must be skipped in custom listing: {specs:?}"
+        );
+        assert!(specs.contains(&"my-custom/real-model".to_string()));
+
+        // Resolution owns the builtin slug regardless of the providers.toml entry.
+        let model = Model::from_spec("openrouter/shadow-model").unwrap();
+        assert_eq!(model.provider.as_ref(), "openrouter");
     }
 }

--- a/maki-providers/src/providers/deepseek.rs
+++ b/maki-providers/src/providers/deepseek.rs
@@ -37,7 +37,7 @@ inventory::submit!(maki_config::providers::BuiltInProvider {
     needs_url: false,
 });
 
-pub(crate) fn models() -> &'static [ModelEntry] {
+pub(crate) const fn models() -> &'static [ModelEntry] {
     &[
         ModelEntry {
             prefixes: &["deepseek-v4-flash"],

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -6,13 +6,15 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use flume::Sender;
+use maki_config::providers::ProvidersConfig;
 use maki_storage::id::SessionRef;
 use serde::Deserialize;
 use serde_json::Value;
 use strum::IntoEnumIterator;
 use tracing::{debug, warn};
 
-use crate::model::{Model, ModelPricing, ModelTier, models_for_provider};
+use crate::manifest::ManifestRegistry;
+use crate::model::{Model, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider, ProviderKind};
 use crate::{AgentError, Message, ProviderEvent, ProviderUsage, RequestOptions, StreamResponse};
 
@@ -76,8 +78,7 @@ impl ScriptModel {
     fn to_model(&self, slug: &str, base: ProviderKind, id: String, tier: ModelTier) -> Model {
         Model {
             id,
-            provider: base,
-            dynamic_slug: Some(slug.to_string()),
+            provider: Arc::from(slug),
             tier,
             family: base.family(),
             supports_tool_examples_override: self.supports_tool_examples,
@@ -327,7 +328,27 @@ fn discover_in(dir: &Path) -> Vec<DynamicProviderMeta> {
 static DISCOVERED: OnceLock<Vec<DynamicProviderMeta>> = OnceLock::new();
 
 fn discover() -> &'static [DynamicProviderMeta] {
-    DISCOVERED.get_or_init(|| providers_dir().map(|d| discover_in(&d)).unwrap_or_default())
+    DISCOVERED.get_or_init(|| {
+        // Load config first: it hard-exits on malformed providers.toml, so fail
+        // before spawning every provider script.
+        let custom = ProvidersConfig::load();
+        let mut metas = providers_dir().map(|d| discover_in(&d)).unwrap_or_default();
+        // A script and a providers.toml entry must not share a slug. The script
+        // loses, the same way it already loses to a builtin, and we say so
+        // instead of silently picking a winner.
+        metas.retain(|m| {
+            if custom.get(&m.slug).is_some() {
+                warn!(
+                    slug = %m.slug,
+                    "provider slug also defined in providers.toml, skipping script"
+                );
+                false
+            } else {
+                true
+            }
+        });
+        metas
+    })
 }
 
 fn find_meta(slug: &str) -> Option<&'static DynamicProviderMeta> {
@@ -441,7 +462,10 @@ pub fn dynamic_model_specs_for(slug: &str) -> Vec<String> {
         return Vec::new();
     };
     if meta.models.is_empty() {
-        models_for_provider(meta.base)
+        let base_slug = meta.base.to_string();
+        ManifestRegistry::get(&base_slug)
+            .map(|m| m.models)
+            .unwrap_or(&[])
             .iter()
             .flat_map(|entry| entry.prefixes.iter())
             .map(|prefix| format!("{slug}/{prefix}"))

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -46,7 +46,7 @@ inventory::submit!(maki_config::providers::BuiltInProvider {
     needs_url: false,
 });
 
-pub(crate) fn models() -> &'static [ModelEntry] {
+pub(crate) const fn models() -> &'static [ModelEntry] {
     &[
         ModelEntry {
             prefixes: &["gemini-2.5-pro"],
@@ -628,8 +628,7 @@ mod tests {
     fn test_model() -> Model {
         Model {
             id: "gemini-2.5-flash".into(),
-            provider: crate::provider::ProviderKind::Google,
-            dynamic_slug: None,
+            provider: Arc::<str>::from("google"),
             tier: ModelTier::Medium,
             family: ModelFamily::Gemini,
             supports_vision_override: Some(true),

--- a/maki-providers/src/providers/llama_cpp.rs
+++ b/maki-providers/src/providers/llama_cpp.rs
@@ -14,6 +14,6 @@ inventory::submit!(maki_config::providers::BuiltInProvider {
     needs_url: true,
 });
 
-pub(crate) fn models() -> &'static [ModelEntry] {
+pub(crate) const fn models() -> &'static [ModelEntry] {
     &[]
 }

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -50,7 +50,7 @@ inventory::submit!(maki_config::providers::BuiltInProvider {
     needs_url: false,
 });
 
-pub(crate) fn models() -> &'static [ModelEntry] {
+pub(crate) const fn models() -> &'static [ModelEntry] {
     &[
         ModelEntry {
             prefixes: &[

--- a/maki-providers/src/providers/ollama.rs
+++ b/maki-providers/src/providers/ollama.rs
@@ -14,6 +14,6 @@ inventory::submit!(maki_config::providers::BuiltInProvider {
     needs_url: true,
 });
 
-pub(crate) fn models() -> &'static [ModelEntry] {
+pub(crate) const fn models() -> &'static [ModelEntry] {
     &[]
 }

--- a/maki-providers/src/providers/openai/mod.rs
+++ b/maki-providers/src/providers/openai/mod.rs
@@ -21,7 +21,7 @@ inventory::submit!(maki_config::providers::BuiltInProvider {
     needs_url: false,
 });
 
-pub(crate) fn models() -> &'static [ModelEntry] {
+pub(crate) const fn models() -> &'static [ModelEntry] {
     &[
         ModelEntry {
             prefixes: &["gpt-5.6-luna"],

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -26,7 +26,7 @@ static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     provider_name: "OpenRouter",
 };
 
-pub(crate) fn models() -> &'static [ModelEntry] {
+pub(crate) const fn models() -> &'static [ModelEntry] {
     &[]
 }
 
@@ -185,8 +185,10 @@ impl Provider for OpenRouter {
 
             let reasoning_info: Option<Arc<OpenRouterModelInfo>> = {
                 let guard = crate::model_registry::model_registry().read().unwrap();
+                // Discovery keys by the builtin slug; a dynamic wrap's model
+                // carries its own slug, so don't key by model.provider.
                 guard
-                    .discovered(model.provider, &model.id)
+                    .discovered("openrouter", &model.id)
                     .and_then(|d| d.provider_info.clone())
                     .map(|arc| {
                         Arc::downcast::<OpenRouterModelInfo>(arc).expect("wrong provider info type")
@@ -301,8 +303,7 @@ mod tests {
     fn openrouter_model(info: Option<&OpenRouterModelInfo>) -> (EffortDialect<'_>, Model) {
         let model = Model {
             id: "test-model".into(),
-            provider: crate::provider::ProviderKind::OpenRouter,
-            dynamic_slug: None,
+            provider: "openrouter".into(),
             tier: crate::model::ModelTier::Medium,
             family: crate::model::ModelFamily::Generic,
             supports_tool_examples_override: None,

--- a/maki-providers/src/providers/synthetic.rs
+++ b/maki-providers/src/providers/synthetic.rs
@@ -31,7 +31,7 @@ inventory::submit!(maki_config::providers::BuiltInProvider {
     needs_url: false,
 });
 
-pub(crate) fn models() -> &'static [ModelEntry] {
+pub(crate) const fn models() -> &'static [ModelEntry] {
     &[
         ModelEntry {
             prefixes: &["hf:moonshotai/Kimi-K2.5"],

--- a/maki-providers/src/providers/tensorx.rs
+++ b/maki-providers/src/providers/tensorx.rs
@@ -31,7 +31,7 @@ inventory::submit!(maki_config::providers::BuiltInProvider {
     needs_url: false,
 });
 
-pub(crate) fn models() -> &'static [ModelEntry] {
+pub(crate) const fn models() -> &'static [ModelEntry] {
     &[]
 }
 
@@ -93,8 +93,10 @@ impl Provider for TensorX {
 
             let (has_thinking, has_reasoning_effort) = {
                 let guard = crate::model_registry::model_registry().read().unwrap();
+                // Discovery keys by the builtin slug; a dynamic wrap's model
+                // carries its own slug, so don't key by model.provider.
                 let info = guard
-                    .discovered(model.provider, &model.id)
+                    .discovered("tensorx", &model.id)
                     .and_then(|d| d.provider_info.clone())
                     .map(|arc| {
                         Arc::downcast::<TensorXModelInfo>(arc).expect("wrong provider info type")

--- a/maki-providers/src/providers/zai/mod.rs
+++ b/maki-providers/src/providers/zai/mod.rs
@@ -109,7 +109,7 @@ inventory::submit!(BuiltInProvider {
     needs_url: false,
 });
 
-pub(crate) fn models() -> &'static [ModelEntry] {
+pub(crate) const fn models() -> &'static [ModelEntry] {
     &[
         ModelEntry {
             prefixes: &["glm-5-code"],

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -876,8 +876,7 @@ mod tests {
     fn clamp_test_model(provider: crate::provider::ProviderKind) -> crate::model::Model {
         crate::model::Model {
             id: "test-model".into(),
-            provider,
-            dynamic_slug: None,
+            provider: std::sync::Arc::<str>::from(provider.to_string()),
             tier: crate::model::ModelTier::Medium,
             family: provider.family(),
             supports_tool_examples_override: None,

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -387,8 +387,7 @@ pub(crate) fn test_pricing() -> ModelPricing {
 pub(crate) fn test_model() -> maki_providers::Model {
     maki_providers::Model {
         id: "test-model".into(),
-        provider: maki_providers::provider::ProviderKind::Anthropic,
-        dynamic_slug: None,
+        provider: std::sync::Arc::<str>::from("anthropic"),
         tier: maki_providers::ModelTier::Medium,
         family: maki_providers::ModelFamily::Claude,
         supports_tool_examples_override: None,

--- a/maki-ui/src/components/usage_modal.rs
+++ b/maki-ui/src/components/usage_modal.rs
@@ -157,7 +157,7 @@ fn build_lines(ctx: &UsageModalContext, theme: &crate::theme::Theme) -> Vec<Line
     if let Some(state) = ctx.quota {
         lines.push(Line::default());
         lines.push(Line::from(Span::styled(
-            format!("{PREFIX}{} quota", ctx.model.provider.display_name()),
+            format!("{PREFIX}{} quota", ctx.model.provider_display_name()),
             theme.keybind_section,
         )));
         lines.extend(quota_lines(state, theme));

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -4,19 +4,18 @@ use color_eyre::Result;
 use color_eyre::eyre::Context;
 
 use maki_providers::model::{Model, ModelTier};
-use maki_providers::provider::ProviderKind;
 use maki_storage::StateDir;
 use maki_storage::log::RotatingFileWriter;
 use maki_storage::model::read_model;
 use tracing_subscriber::EnvFilter;
 
-const PROVIDER_PRIORITY: &[ProviderKind] = &[
-    ProviderKind::Anthropic,
-    ProviderKind::OpenAi,
-    ProviderKind::Copilot,
-    ProviderKind::Zai,
-    ProviderKind::Synthetic,
-    ProviderKind::DeepSeek,
+const PROVIDER_PRIORITY: &[&str] = &[
+    "anthropic",
+    "openai",
+    "copilot",
+    "zai",
+    "synthetic",
+    "deepseek",
 ];
 
 pub fn resolve_model(
@@ -46,9 +45,9 @@ pub fn resolve_model(
 
 fn auto_detect_model() -> Option<Model> {
     for tier in [ModelTier::Strong, ModelTier::Medium] {
-        for &provider in PROVIDER_PRIORITY {
-            if provider.is_available()
-                && let Ok(model) = Model::from_tier(provider, tier)
+        for &slug in PROVIDER_PRIORITY {
+            if maki_providers::provider::provider_available(slug)
+                && let Ok(model) = Model::from_tier(slug, tier)
             {
                 return Some(model);
             }


### PR DESCRIPTION
Implements phase one of https://github.com/tontinton/maki/issues/481 to configure providers with Lua.

Makes an interim store of slug-based providers and points provider lookup at it instead of the `ProviderKind` enum source of providers. Next is OAuth generic extraction for common use in OpenAI and Copilot.

Written with Maki + GLM-5.2.