### PR TITLE
feat(agent): modular core with typed FSM and Lua hook surface 🤖🤖🤖

### DIFF
--- a/maki-agent/src/agent/hooks.rs
+++ b/maki-agent/src/agent/hooks.rs
@@ -1,0 +1,49 @@
+use maki_providers::AgentError;
+use maki_providers::provider::BoxFuture;
+use serde_json::Value;
+use std::sync::Arc;
+
+pub trait Hooks: Send + Sync {
+    fn fire<'a>(
+        &'a self,
+        event: &'a str,
+        payload: Value,
+    ) -> BoxFuture<'a, Result<Value, AgentError>>;
+}
+
+pub type DynHooks = Arc<dyn Hooks>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct Capturing {
+        seen: Mutex<Vec<String>>,
+    }
+
+    impl Hooks for Capturing {
+        fn fire<'a>(
+            &'a self,
+            event: &'a str,
+            payload: Value,
+        ) -> BoxFuture<'a, Result<Value, AgentError>> {
+            let event = event.to_owned();
+            Box::pin(async move {
+                self.seen.lock().unwrap().push(event);
+                Ok(payload)
+            })
+        }
+    }
+
+    #[test]
+    fn fire_returns_payload_unchanged() {
+        let hooks = Capturing {
+            seen: Mutex::new(Vec::new()),
+        };
+        let payload = Value::Null;
+        let result = smol::block_on(hooks.fire("PostTurn", payload.clone())).unwrap();
+        assert_eq!(result, payload);
+        assert_eq!(hooks.seen.lock().unwrap().as_slice(), ["PostTurn"]);
+    }
+}

--- a/maki-agent/src/agent/mod.rs
+++ b/maki-agent/src/agent/mod.rs
@@ -1,5 +1,6 @@
 mod compaction;
 mod history;
+pub mod hooks;
 mod instructions;
 mod run;
 mod streaming;

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -73,6 +73,7 @@ enum Phase {
 }
 
 const PRESTREAM_EVENT: &str = "PreStream";
+const PRECOMPACTION_EVENT: &str = "PreCompaction";
 
 enum PreStreamOutcome {
     Proceed { system: String, tools: Value },
@@ -612,6 +613,15 @@ impl<'h> Agent<'h> {
     async fn do_compact(&mut self) -> Result<TokenUsage, AgentError> {
         let (compact_provider, compact_model) =
             resolve_compaction_model(&self.provider, &self.model, self.timeouts);
+        if let Some(hooks) = &self.hooks {
+            let payload = serde_json::json!({
+                "history_len": self.history.len(),
+                "context_size": self.context_size,
+            });
+            if let Err(e) = hooks.fire(PRECOMPACTION_EVENT, payload).await {
+                warn!(error = %e, "PreCompaction hook failed");
+            }
+        }
         let usage = compaction::compact_history(
             &*compact_provider,
             &compact_model,

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -72,6 +72,24 @@ enum Phase {
     Done,
 }
 
+const PRESTREAM_EVENT: &str = "PreStream";
+
+enum PreStreamOutcome {
+    Proceed { system: String, tools: Value },
+    Aborted,
+}
+
+fn extract_tool_names_from_value(tools: &Value) -> Vec<String> {
+    tools
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|t| t.get("name").and_then(|n| n.as_str()).map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 #[derive(Clone)]
 pub struct AgentParams {
     pub provider: Arc<dyn Provider>,
@@ -129,6 +147,7 @@ pub struct Agent<'h> {
     workflow: bool,
     local_tools: LocalTools,
     hooks: Option<Arc<dyn Hooks>>,
+    previous_tool_names: Option<Vec<String>>,
 }
 
 impl<'h> Agent<'h> {
@@ -167,6 +186,7 @@ impl<'h> Agent<'h> {
             workflow: false,
             local_tools: LocalTools::default(),
             hooks: None,
+            previous_tool_names: None,
         }
     }
 
@@ -206,6 +226,74 @@ impl<'h> Agent<'h> {
     pub fn with_hooks(mut self, hooks: Arc<dyn Hooks>) -> Self {
         self.hooks = Some(hooks);
         self
+    }
+
+    async fn resolve_stream_inputs(&mut self) -> Result<PreStreamOutcome, AgentError> {
+        let Some(hooks) = &self.hooks else {
+            return Ok(PreStreamOutcome::Proceed {
+                system: self.system.clone(),
+                tools: self.tools.clone(),
+            });
+        };
+
+        let mode_str = match self.mode {
+            AgentMode::Build => "build",
+            AgentMode::Plan(_) => "plan",
+        };
+        let payload = serde_json::json!({
+            "system": &self.system,
+            "tools": &self.tools,
+            "mode": mode_str,
+            "workflow": self.workflow,
+        });
+
+        let result = match hooks.fire(PRESTREAM_EVENT, payload).await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(error = %e, "PreStream hook failed, using defaults");
+                return Ok(PreStreamOutcome::Proceed {
+                    system: self.system.clone(),
+                    tools: self.tools.clone(),
+                });
+            }
+        };
+
+        if result
+            .get("abort")
+            .is_some_and(|a| a.as_bool() == Some(true))
+        {
+            return Ok(PreStreamOutcome::Aborted);
+        }
+
+        let system = result
+            .get("system")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| self.system.clone());
+
+        if system.is_empty() {
+            warn!("PreStream returned empty system prompt, falling back");
+            return Ok(PreStreamOutcome::Proceed {
+                system: self.system.clone(),
+                tools: self.tools.clone(),
+            });
+        }
+
+        let tools = result
+            .get("tools")
+            .filter(|v| v.is_array())
+            .cloned()
+            .unwrap_or_else(|| self.tools.clone());
+
+        let new_names = extract_tool_names_from_value(&tools);
+        if let Some(prev) = &self.previous_tool_names
+            && prev != &new_names
+        {
+            warn!("PreStream returned a different tool set than the previous turn");
+        }
+        self.previous_tool_names = Some(new_names);
+
+        Ok(PreStreamOutcome::Proceed { system, tools })
     }
 
     pub async fn run(&mut self, input: AgentInput) -> Result<(), AgentError> {
@@ -258,12 +346,21 @@ impl<'h> Agent<'h> {
                 if self.cancel.is_cancelled() {
                     return Err(AgentError::Cancelled);
                 }
+
+                let (system, tools) = match self.resolve_stream_inputs().await? {
+                    PreStreamOutcome::Proceed { system, tools } => (system, tools),
+                    PreStreamOutcome::Aborted => {
+                        self.emit_done(None)?;
+                        return Ok(Phase::Done);
+                    }
+                };
+
                 let response = match stream_with_retry(
                     &*self.provider,
                     &self.model,
                     self.history.as_slice(),
-                    &self.system,
-                    &self.tools,
+                    &system,
+                    &tools,
                     &self.event_tx,
                     &self.cancel,
                     self.opts,

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -10,6 +10,7 @@ use maki_providers::{
 
 use super::compaction::{self, CONTINUE_AFTER_COMPACT};
 use super::history::{History, sanitize_cancelled_history};
+use super::hooks::Hooks;
 use super::instructions::LoadedInstructions;
 use super::streaming::stream_with_retry;
 use super::tool_dispatch::{self, RecentCalls};
@@ -118,6 +119,7 @@ pub struct Agent<'h> {
     audience: ToolAudience,
     workflow: bool,
     local_tools: LocalTools,
+    hooks: Option<Arc<dyn Hooks>>,
 }
 
 impl<'h> Agent<'h> {
@@ -155,6 +157,7 @@ impl<'h> Agent<'h> {
             audience: params.audience,
             workflow: false,
             local_tools: LocalTools::default(),
+            hooks: None,
         }
     }
 
@@ -188,6 +191,11 @@ impl<'h> Agent<'h> {
 
     pub fn with_loaded_instructions(mut self, loaded: LoadedInstructions) -> Self {
         self.loaded_instructions = loaded;
+        self
+    }
+
+    pub fn with_hooks(mut self, hooks: Arc<dyn Hooks>) -> Self {
+        self.hooks = Some(hooks);
         self
     }
 

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -43,9 +43,23 @@ pub fn resolve_compaction_model(
     (Arc::clone(provider), model.clone())
 }
 
-enum TurnOutcome {
-    Continue,
-    Done(Option<StopReason>),
+enum Phase {
+    Streaming {
+        nudged: bool,
+    },
+    StreamDone {
+        response: StreamResponse,
+        nudged: bool,
+    },
+    Dispatching {
+        response: StreamResponse,
+    },
+    PostToolNudge,
+    PostTurn {
+        stop_reason: Option<StopReason>,
+        nudged: bool,
+    },
+    Done,
 }
 
 #[derive(Clone)]
@@ -93,7 +107,6 @@ pub struct Agent<'h> {
     config: AgentConfig,
     tool_output_lines: ToolOutputLines,
     reauth_attempts: u32,
-    post_tool_empty_retried: bool,
     permissions: Arc<PermissionManager>,
     opts: RequestOptions,
     session_id: Option<String>,
@@ -133,7 +146,6 @@ impl<'h> Agent<'h> {
             rollback_len: 0,
             mcp: None,
             reauth_attempts: 0,
-            post_tool_empty_retried: false,
             opts: RequestOptions::default(),
             session_id: params.session_id,
             file_tracker: params.file_tracker,
@@ -207,84 +219,113 @@ impl<'h> Agent<'h> {
     }
 
     async fn run_loop(&mut self) -> Result<(), AgentError> {
+        let mut phase = Phase::Streaming { nudged: false };
         loop {
-            if let Some(max) = self.config.max_turns
+            if matches!(phase, Phase::Streaming { .. })
+                && let Some(max) = self.config.max_turns
                 && self.num_turns >= max
             {
                 self.emit_done(None)?;
                 return Ok(());
             }
-            match self.turn().await? {
-                TurnOutcome::Continue => {}
-                TurnOutcome::Done(stop_reason) => {
-                    self.emit_done(stop_reason)?;
-                    return Ok(());
-                }
+            phase = self.step(phase).await?;
+            if matches!(phase, Phase::Done) {
+                return Ok(());
             }
         }
     }
 
-    async fn turn(&mut self) -> Result<TurnOutcome, AgentError> {
-        if self.cancel.is_cancelled() {
-            return Err(AgentError::Cancelled);
-        }
-        let response = match stream_with_retry(
-            &*self.provider,
-            &self.model,
-            self.history.as_slice(),
-            &self.system,
-            &self.tools,
-            &self.event_tx,
-            &self.cancel,
-            self.opts,
-            self.session_id.as_deref(),
-        )
-        .await
-        {
-            Ok(r) => {
-                self.reauth_attempts = 0;
-                r
+    async fn step(&mut self, phase: Phase) -> Result<Phase, AgentError> {
+        match phase {
+            Phase::Streaming { nudged } => {
+                if self.cancel.is_cancelled() {
+                    return Err(AgentError::Cancelled);
+                }
+                let response = match stream_with_retry(
+                    &*self.provider,
+                    &self.model,
+                    self.history.as_slice(),
+                    &self.system,
+                    &self.tools,
+                    &self.event_tx,
+                    &self.cancel,
+                    self.opts,
+                    self.session_id.as_deref(),
+                )
+                .await
+                {
+                    Ok(r) => {
+                        self.reauth_attempts = 0;
+                        r
+                    }
+                    Err(e) if e.is_auth_error() => {
+                        return self.handle_reauth(e).await;
+                    }
+                    Err(e) => {
+                        error!(error = %e, model = %self.model.id, self.num_turns, "stream_message failed");
+                        return Err(e);
+                    }
+                };
+                self.num_turns += 1;
+                Ok(Phase::StreamDone { response, nudged })
             }
-            Err(e) if e.is_auth_error() => {
-                return self.wait_for_reauth(e).await;
+            Phase::StreamDone { response, nudged } => {
+                let has_tools = response.message.has_tool_calls();
+                let stop_reason = response.stop_reason;
+                info!(
+                    input_tokens = response.usage.input,
+                    output_tokens = response.usage.output,
+                    cache_creation = response.usage.cache_creation,
+                    cache_read = response.usage.cache_read,
+                    has_tools,
+                    self.num_turns,
+                    model = %self.model.id,
+                    stop_reason = stop_reason.map_or("none", Into::into),
+                    "API response received"
+                );
+
+                self.emit_turn_complete(&response)?;
+                let usage = response.usage;
+                self.total_usage += usage;
+                self.context_size = usage.total_input();
+
+                if has_tools {
+                    Ok(Phase::Dispatching { response })
+                } else {
+                    let has_text = response.message.first_text_content().is_some();
+                    if !has_text && !nudged && self.history.has_recent_tool_results(5) {
+                        Ok(Phase::PostToolNudge)
+                    } else {
+                        self.history.push(response.message);
+                        if stop_reason == Some(StopReason::MaxTokens)
+                            && self.num_turns <= self.config.max_continuation_turns
+                        {
+                            warn!(
+                                self.num_turns,
+                                "response truncated (max_tokens), re-prompting"
+                            );
+                            Ok(Phase::Streaming { nudged })
+                        } else {
+                            Ok(Phase::PostTurn {
+                                stop_reason,
+                                nudged,
+                            })
+                        }
+                    }
+                }
             }
-            Err(e) => {
-                error!(error = %e, model = %self.model.id, self.num_turns, "stream_message failed");
-                return Err(e);
+            Phase::Dispatching { response } => {
+                let history_len_before = self.history.len();
+                self.process_tool_calls(response).await?;
+                self.context_size +=
+                    estimate_message_tokens(&self.history.as_slice()[history_len_before..]);
+                let compacted = self.try_auto_compact().await?;
+                if !compacted {
+                    self.handle_queued_command().await?;
+                }
+                Ok(Phase::Streaming { nudged: false })
             }
-        };
-        self.num_turns += 1;
-
-        let has_tools = response.message.has_tool_calls();
-        let stop_reason = response.stop_reason;
-        info!(
-            input_tokens = response.usage.input,
-            output_tokens = response.usage.output,
-            cache_creation = response.usage.cache_creation,
-            cache_read = response.usage.cache_read,
-            has_tools,
-            self.num_turns,
-            model = %self.model.id,
-            stop_reason = stop_reason.map_or("none", Into::into),
-            "API response received"
-        );
-
-        self.emit_turn_complete(&response)?;
-        let usage = response.usage;
-        self.total_usage += usage;
-        self.context_size = usage.total_input();
-
-        if has_tools {
-            let history_len_before = self.history.len();
-            self.process_tool_calls(response).await?;
-            self.context_size +=
-                estimate_message_tokens(&self.history.as_slice()[history_len_before..]);
-        } else {
-            let has_text = response.message.first_text_content().is_some();
-
-            if !has_text && !self.post_tool_empty_retried && self.history.has_recent_tool_results(5)
-            {
-                self.post_tool_empty_retried = true;
+            Phase::PostToolNudge => {
                 warn!("empty response after tool calls, nudging model to continue");
                 self.event_tx.send(AgentEvent::Nudge)?;
                 self.history.push(Message {
@@ -295,34 +336,24 @@ impl<'h> Agent<'h> {
                     ..Default::default()
                 });
                 self.history.push(Message::synthetic(NUDGE_PROMPT.into()));
-                return Ok(TurnOutcome::Continue);
+                Ok(Phase::Streaming { nudged: true })
             }
-
-            self.history.push(response.message);
-
-            if stop_reason == Some(StopReason::MaxTokens)
-                && self.num_turns <= self.config.max_continuation_turns
-            {
-                warn!(
-                    self.num_turns,
-                    "response truncated (max_tokens), re-prompting"
-                );
-                return Ok(TurnOutcome::Continue);
+            Phase::PostTurn {
+                stop_reason,
+                nudged,
+            } => {
+                if self.try_auto_compact().await? || self.handle_queued_command().await? {
+                    Ok(Phase::Streaming { nudged })
+                } else {
+                    self.emit_done(stop_reason)?;
+                    Ok(Phase::Done)
+                }
             }
-        }
-
-        if self.try_auto_compact().await? || self.handle_queued_command().await? {
-            return Ok(TurnOutcome::Continue);
-        }
-
-        if has_tools {
-            Ok(TurnOutcome::Continue)
-        } else {
-            Ok(TurnOutcome::Done(stop_reason))
+            Phase::Done => Ok(Phase::Done),
         }
     }
 
-    async fn wait_for_reauth(&mut self, err: AgentError) -> Result<TurnOutcome, AgentError> {
+    async fn handle_reauth(&mut self, err: AgentError) -> Result<Phase, AgentError> {
         if self.reauth_attempts >= MAX_REAUTH_ATTEMPTS {
             error!(error = %err, attempts = self.reauth_attempts, "max re-auth attempts reached");
             return Err(err);
@@ -343,7 +374,7 @@ impl<'h> Agent<'h> {
         {
             Ok(_) => {
                 self.provider.refresh_auth().await?;
-                Ok(TurnOutcome::Continue)
+                Ok(Phase::Streaming { nudged: false })
             }
             Err(_) => Err(AgentError::Cancelled),
         }
@@ -374,7 +405,6 @@ impl<'h> Agent<'h> {
     }
 
     async fn process_tool_calls(&mut self, response: StreamResponse) -> Result<(), AgentError> {
-        self.post_tool_empty_retried = false;
         let ctx = self.tool_context();
         tool_dispatch::process_tool_calls(
             response,

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -27,6 +27,15 @@ use maki_config::ToolOutputLines;
 const MAX_REAUTH_ATTEMPTS: u32 = 2;
 const NUDGE_PROMPT: &str = "You just executed tool calls but returned an empty response. Please process the tool results above and continue with the task.";
 
+fn usage_json(usage: TokenUsage) -> Value {
+    serde_json::json!({
+        "input": usage.input,
+        "output": usage.output,
+        "cache_creation": usage.cache_creation,
+        "cache_read": usage.cache_read,
+    })
+}
+
 pub fn resolve_compaction_model(
     provider: &Arc<dyn Provider>,
     model: &Model,
@@ -297,6 +306,17 @@ impl<'h> Agent<'h> {
                 self.total_usage += usage;
                 self.context_size = usage.total_input();
 
+                if let Some(hooks) = &self.hooks {
+                    let payload = serde_json::json!({
+                        "usage": usage_json(usage),
+                        "has_tools": has_tools,
+                        "stop_reason": stop_reason.map(|s| s.to_string()),
+                    });
+                    if let Err(e) = hooks.fire("PostStream", payload).await {
+                        warn!(error = %e, "PostStream hook failed");
+                    }
+                }
+
                 if has_tools {
                     Ok(Phase::Dispatching { response })
                 } else {
@@ -353,6 +373,16 @@ impl<'h> Agent<'h> {
                 if self.try_auto_compact().await? || self.handle_queued_command().await? {
                     Ok(Phase::Streaming { nudged })
                 } else {
+                    if let Some(hooks) = &self.hooks {
+                        let payload = serde_json::json!({
+                            "stop_reason": stop_reason.map(|s| s.to_string()),
+                            "num_turns": self.num_turns,
+                            "total_usage": usage_json(self.total_usage),
+                        });
+                        if let Err(e) = hooks.fire("PostTurn", payload).await {
+                            warn!(error = %e, "PostTurn hook failed");
+                        }
+                    }
                     self.emit_done(stop_reason)?;
                     Ok(Phase::Done)
                 }
@@ -421,6 +451,7 @@ impl<'h> Agent<'h> {
             self.history,
             &self.event_tx,
             &ctx,
+            self.hooks.as_ref(),
         )
         .await
     }
@@ -468,14 +499,23 @@ impl<'h> Agent<'h> {
         }
         info!(context_size = self.context_size, "auto-compacting");
         self.event_tx.send(AgentEvent::AutoCompacting)?;
-        self.do_compact().await?;
+        let compaction_usage = self.do_compact().await?;
+        if let Some(hooks) = &self.hooks {
+            let payload = serde_json::json!({
+                "new_history_len": self.history.len(),
+                "compaction_usage": usage_json(compaction_usage),
+            });
+            if let Err(e) = hooks.fire("PostCompaction", payload).await {
+                warn!(error = %e, "PostCompaction hook failed");
+            }
+        }
         Ok(true)
     }
 
-    async fn do_compact(&mut self) -> Result<(), AgentError> {
+    async fn do_compact(&mut self) -> Result<TokenUsage, AgentError> {
         let (compact_provider, compact_model) =
             resolve_compaction_model(&self.provider, &self.model, self.timeouts);
-        self.total_usage += compaction::compact_history(
+        let usage = compaction::compact_history(
             &*compact_provider,
             &compact_model,
             self.history,
@@ -483,10 +523,11 @@ impl<'h> Agent<'h> {
             &self.cancel,
         )
         .await?;
+        self.total_usage += usage;
         self.rollback_len = self.history.len();
         self.history
             .push(Message::synthetic(CONTINUE_AFTER_COMPACT.into()));
-        Ok(())
+        Ok(usage)
     }
 
     async fn handle_queued_command(&mut self) -> Result<bool, AgentError> {
@@ -513,7 +554,7 @@ impl<'h> Agent<'h> {
                 self.history.push(Message::user_display(wrapped, display));
             }
             ExtractedCommand::Compact(_) => {
-                self.do_compact().await?;
+                let _ = self.do_compact().await?;
             }
         }
         Ok(true)

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 use serde_json::Value;
 use tracing::{debug, error, warn};
 
+use super::hooks::DynHooks;
 use crate::mcp::{McpHandle, UNKNOWN_MCP};
 use crate::task_set::TaskSet;
 use crate::tools::registry::{ToolInvocation, ToolRegistry};
@@ -321,6 +322,7 @@ pub(super) async fn process_tool_calls(
     history: &mut super::history::History,
     event_tx: &crate::EventSender,
     ctx: &ToolContext,
+    hooks: Option<&DynHooks>,
 ) -> Result<(), AgentError> {
     let tool_uses: Vec<(String, String, Value)> = response
         .message
@@ -355,8 +357,10 @@ pub(super) async fn process_tool_calls(
 
     let mut set = TaskSet::new();
     let mut spawned_ids: Vec<String> = Vec::new();
+    let mut spawned_inputs: Vec<(Arc<str>, Value)> = Vec::new();
     for (id, name, input) in runnable {
         spawned_ids.push(id.clone());
+        spawned_inputs.push((Arc::from(name.as_str()), input.clone()));
         let event_tx_clone = ctx.event_tx.clone();
         let tool_ctx = ToolContext {
             tool_use_id: Some(id.clone()),
@@ -392,6 +396,31 @@ pub(super) async fn process_tool_calls(
             }
         })
         .collect();
+
+    if let Some(hooks) = hooks {
+        for (done, (_, input)) in results.iter().zip(&spawned_inputs) {
+            let payload = serde_json::json!({
+                "tool": done.tool.as_ref(),
+                "input": input,
+                "output": done.output.as_text(),
+                "is_error": done.is_error,
+            });
+            if let Err(e) = hooks.fire("PostToolResult", payload).await {
+                warn!(error = %e, "PostToolResult hook failed");
+            }
+        }
+        for err in &immediate_errors {
+            let payload = serde_json::json!({
+                "tool": err.tool.as_ref(),
+                "input": Value::Null,
+                "output": err.output.as_text(),
+                "is_error": true,
+            });
+            if let Err(e) = hooks.fire("PostToolResult", payload).await {
+                warn!(error = %e, "PostToolResult hook failed");
+            }
+        }
+    }
 
     let mut all_results = results;
     all_results.extend(immediate_errors);

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -24,6 +24,7 @@ const DOOM_LOOP_THRESHOLD: usize = 3;
 const DOOM_LOOP_MESSAGE: &str = "You have called this tool with identical input 3 times in a row. You are stuck in a loop. Break out and try a different approach.";
 const MCP_BLOCKED_IN_PLAN: &str = "MCP tools are not available in plan mode";
 const UNKNOWN_TOOL_PREFIX: &str = "unknown tool";
+const PRETOOLDISPATCH_EVENT: &str = "PreToolDispatch";
 
 pub(super) struct RecentCalls(VecDeque<(String, u64)>);
 
@@ -355,10 +356,42 @@ pub(super) async fn process_tool_calls(
         event_tx.try_send(AgentEvent::ToolDone(Box::new(err.clone())));
     }
 
+    let effective_runnable = match hooks {
+        Some(hooks) => {
+            let tool_calls_json: Vec<Value> = runnable
+                .iter()
+                .map(|(id, name, input)| {
+                    serde_json::json!({ "id": id, "name": name, "input": input })
+                })
+                .collect();
+            let payload = serde_json::json!({ "tool_calls": tool_calls_json });
+            match hooks.fire(PRETOOLDISPATCH_EVENT, payload).await {
+                Ok(result) => match result.get("tool_calls").and_then(Value::as_array) {
+                    Some(filtered) => filtered
+                        .iter()
+                        .filter_map(|tc| {
+                            Some((
+                                tc.get("id")?.as_str()?.to_owned(),
+                                tc.get("name")?.as_str()?.to_owned(),
+                                tc.get("input").cloned().unwrap_or(Value::Null),
+                            ))
+                        })
+                        .collect::<Vec<_>>(),
+                    None => runnable,
+                },
+                Err(e) => {
+                    warn!(error = %e, "PreToolDispatch hook failed, proceeding with all calls");
+                    runnable
+                }
+            }
+        }
+        None => runnable,
+    };
+
     let mut set = TaskSet::new();
     let mut spawned_ids: Vec<String> = Vec::new();
     let mut spawned_inputs: Vec<(Arc<str>, Value)> = Vec::new();
-    for (id, name, input) in runnable {
+    for (id, name, input) in effective_runnable {
         spawned_ids.push(id.clone());
         spawned_inputs.push((Arc::from(name.as_str()), input.clone()));
         let event_tx_clone = ctx.event_tx.clone();

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -10,6 +10,7 @@ pub use mcp::config::{McpConfigError, McpConfigErrors, McpServerInfo, McpServerS
 pub use mcp::protocol::PromptRole;
 pub use mcp::{McpCommand, McpHandle, McpPromptArg, McpPromptInfo, McpSnapshot, McpSnapshotReader};
 pub(crate) mod task_set;
+pub use agent::hooks::{DynHooks, Hooks};
 pub use agent::{
     Agent, AgentParams, AgentRunParams, History, Instructions, LoadedInstructions, SharedMessages,
     find_subdirectory_instructions, is_instruction_file,

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -44,6 +44,7 @@ pub(crate) fn register(lua: &Lua, maki: &Table) -> LuaResult<()> {
 
     agent.set("resolve_model", lua.create_async_function(resolve_model)?)?;
     agent.set("system_prompt", lua.create_async_function(system_prompt)?)?;
+    agent.set("plan_prompt", lua.create_async_function(plan_prompt)?)?;
     agent.set("tools", lua.create_async_function(tools)?)?;
     agent.set("call_tool", lua.create_async_function(call_tool)?)?;
     agent.set("session", lua.create_async_function(session)?)?;
@@ -139,6 +140,10 @@ async fn system_prompt(
 
     let assembled = maki_agent::prompt::assemble(prompt_id, &ctx.agent.prompt_slots, &instructions);
     Ok(vars.apply(&assembled).into_owned())
+}
+
+async fn plan_prompt(_lua: Lua, (): ()) -> LuaResult<String> {
+    Ok(maki_agent::prompt::PLAN_PROMPT.to_string())
 }
 
 async fn tools(lua: Lua, (ctx, opts): (mlua::UserDataRef<LuaCtx>, Table)) -> LuaResult<LuaValue> {

--- a/maki-lua/src/api/autocmd.rs
+++ b/maki-lua/src/api/autocmd.rs
@@ -6,11 +6,14 @@ use mlua::{Lua, RegistryKey, Result as LuaResult, Table, Value};
 
 static NEXT_AUTOCMD_ID: AtomicU64 = AtomicU64::new(1);
 
+pub(crate) const DEFAULT_PRIORITY: i32 = 100;
+
 pub(crate) struct AutocmdEntry {
     pub id: u64,
     pub callback: RegistryKey,
     pub plugin: Arc<str>,
     pub once: bool,
+    pub priority: i32,
 }
 
 #[derive(Default)]
@@ -26,12 +29,14 @@ impl AutocmdStore {
         callback: RegistryKey,
         plugin: Arc<str>,
         once: bool,
+        priority: i32,
     ) {
         self.listeners.entry(event).or_default().push(AutocmdEntry {
             id,
             callback,
             plugin,
             once,
+            priority,
         });
     }
 
@@ -74,13 +79,14 @@ pub(crate) fn add_autocmd_methods(api_table: &Table, lua: &Lua, plugin: Arc<str>
             };
             let callback: mlua::Function = opts.get("callback")?;
             let once: bool = opts.get("once").unwrap_or(false);
+            let priority: i32 = opts.get("priority").unwrap_or(DEFAULT_PRIORITY);
             let id = NEXT_AUTOCMD_ID.fetch_add(1, Ordering::Relaxed);
             let mut store = lua
                 .app_data_mut::<AutocmdStore>()
                 .ok_or_else(|| mlua::Error::runtime("autocmd store not initialized"))?;
             for event in events {
                 let key = lua.create_registry_value(callback.clone())?;
-                store.register(id, event, key, Arc::clone(&p), once);
+                store.register(id, event, key, Arc::clone(&p), once, priority);
             }
             Ok(id)
         })?,
@@ -113,7 +119,14 @@ mod tests {
         let mut store = AutocmdStore::default();
         let f = lua.create_function(|_, ()| Ok(())).unwrap();
         let key = lua.create_registry_value(f).unwrap();
-        store.register(1, "TurnEnd".into(), key, Arc::from("test"), false);
+        store.register(
+            1,
+            "TurnEnd".into(),
+            key,
+            Arc::from("test"),
+            false,
+            DEFAULT_PRIORITY,
+        );
         assert!(store.listeners["TurnEnd"].len() == 1);
         let removed = store.remove(1);
         assert_eq!(removed.len(), 1);
@@ -130,8 +143,22 @@ mod tests {
         let k1 = lua.create_registry_value(f1).unwrap();
         let k2 = lua.create_registry_value(f2).unwrap();
 
-        store.register(1, "TurnEnd".into(), k1, Arc::from("plugA"), false);
-        store.register(2, "TurnEnd".into(), k2, Arc::from("plugB"), false);
+        store.register(
+            1,
+            "TurnEnd".into(),
+            k1,
+            Arc::from("plugA"),
+            false,
+            DEFAULT_PRIORITY,
+        );
+        store.register(
+            2,
+            "TurnEnd".into(),
+            k2,
+            Arc::from("plugB"),
+            false,
+            DEFAULT_PRIORITY,
+        );
 
         let removed = store.clear_plugin("plugA");
         assert_eq!(removed.len(), 1);
@@ -151,7 +178,14 @@ mod tests {
         let mut store = AutocmdStore::default();
         let f = lua.create_function(|_, ()| Ok(())).unwrap();
         let key = lua.create_registry_value(f).unwrap();
-        store.register(1, "TurnEnd".into(), key, Arc::from("test"), true);
+        store.register(
+            1,
+            "TurnEnd".into(),
+            key,
+            Arc::from("test"),
+            true,
+            DEFAULT_PRIORITY,
+        );
         assert!(store.listeners["TurnEnd"][0].once);
     }
 }

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -13,7 +13,7 @@ pub use api::util::command::{
 pub use error::PluginError;
 pub use loader::{EventHandle, PluginHost};
 pub use plugin_permissions::{Permission, PluginPermissions};
-pub use runtime::RestoreItem;
+pub use runtime::{LuaHooks, RestoreItem};
 
 pub mod test_support {
     use crate::api::util::command::{LuaCommandInfo, LuaCommandReader, LuaCommandWriter};

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -98,6 +98,10 @@ static BUNDLED_PLUGINS: &[BundledPlugin] = &[
         name: "lib",
         dir: include_dir!("$CARGO_MANIFEST_DIR/../plugins/lib"),
     },
+    BundledPlugin {
+        name: "system",
+        dir: include_dir!("$CARGO_MANIFEST_DIR/../plugins/system"),
+    },
 ];
 
 static BUNDLED_DIRS: LazyLock<&'static [&'static Dir<'static>]> = LazyLock::new(|| {

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -383,6 +383,10 @@ impl EventHandle {
         });
     }
 
+    pub fn hooks(&self) -> runtime::LuaHooks {
+        runtime::LuaHooks::new(self.tx.clone())
+    }
+
     pub fn run_keybind_callback(&self, id: u64) {
         let _ = self.tx.try_send(Request::RunKeybindCallback { id });
     }

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -50,7 +50,6 @@ const MAX_INFLIGHT_TOOLS: usize = 64;
 const GC_STEP_INTERVAL: usize = 4;
 const INTERRUPT_CANCEL_CHECK_INTERVAL: u32 = 128;
 const ASYNC_RUN_DEFAULT_DEADLINE: Duration = Duration::from_secs(60);
-const TURN_END_EVENT: &str = "TurnEnd";
 /// Without a cap, a runaway plugin OOM-kills the whole process.
 /// With one, it hits a catchable Lua error instead.
 const LUA_MEMORY_LIMIT: usize = 512 * 1024 * 1024;
@@ -2046,12 +2045,12 @@ pub fn spawn(
                                 }
                                 drain_spawn_queue(&rt.lua, &ex, &gate);
                             }
-                            if event == TURN_END_EVENT {
-                                rt.lua.gc_collect().ok();
-                            }
                         }
                         Request::RunHook { event, payload, reply } => {
                             let result = run_hook(&rt, &event, payload);
+                            if event == "PostTurn" {
+                                rt.lua.gc_collect().ok();
+                            }
                             let _ = reply.send(result);
                         }
                         Request::Describe {

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -16,7 +16,9 @@ use maki_agent::tools::{
     HeaderResult, PermissionScopes, RegistryError, Tool, ToolLive, ToolRegistry, ToolSource,
 };
 use maki_agent::{BufferSnapshot, SharedBuf, SnapshotLine, SnapshotSpan, SpanStyle};
-use mlua::{Function, Lua, RegistryKey, Value as LuaValue, VmState};
+use maki_providers::AgentError;
+use maki_providers::provider::BoxFuture;
+use mlua::{Function, Lua, RegistryKey, Result as LuaResult, Value as LuaValue, VmState};
 use serde_json::Value;
 
 use maki_config::RawConfig;
@@ -31,7 +33,7 @@ use crate::api::ui::HintStore;
 use crate::api::ui::buf::{BufHandle, BufferStore};
 use crate::api::util::command::{CommandHandlerMap, HintWriter, publish_command_snapshot};
 use crate::api::util::command::{LuaCommandReader, LuaCommandWriter, UiAction};
-use crate::api::util::convert::json_to_lua;
+use crate::api::util::convert::{json_to_lua, lua_to_json};
 use crate::api::util::ctx::LuaCtx;
 use crate::api::util::setup::ConfigStore;
 use crate::error::PluginError;
@@ -69,6 +71,7 @@ pub(crate) type PromptHintCallbacks = BTreeMap<Arc<str>, Vec<PromptHintRegistrat
 
 /// Load/clear drain in-flight tools first so we never mutate a
 /// plugin environment while a tool call is still running.
+#[non_exhaustive]
 pub enum Request {
     LoadSource {
         name: Arc<str>,
@@ -128,6 +131,11 @@ pub enum Request {
         event: String,
         data: Value,
     },
+    RunHook {
+        event: String,
+        payload: Value,
+        reply: flume::Sender<Result<Value, String>>,
+    },
     ClickTool {
         tool_use_id: String,
         /// 1-based line in the tool's live buffer; 0 means the click landed
@@ -154,6 +162,46 @@ pub enum Request {
         tool_output_lines: maki_config::ToolOutputLines,
         reply: flume::Sender<()>,
     },
+}
+
+pub struct LuaHooks {
+    tx: flume::Sender<Request>,
+}
+
+impl LuaHooks {
+    pub(crate) fn new(tx: flume::Sender<Request>) -> Self {
+        Self { tx }
+    }
+}
+
+impl maki_agent::agent::hooks::Hooks for LuaHooks {
+    fn fire<'a>(
+        &'a self,
+        event: &'a str,
+        payload: Value,
+    ) -> BoxFuture<'a, Result<Value, AgentError>> {
+        Box::pin(async move {
+            let (reply_tx, reply_rx) = flume::bounded(1);
+            self.tx
+                .send_async(Request::RunHook {
+                    event: event.to_owned(),
+                    payload,
+                    reply: reply_tx,
+                })
+                .await
+                .map_err(|_| AgentError::Channel)?;
+            reply_rx
+                .recv_async()
+                .await
+                .map_err(|_| AgentError::Channel)
+                .and_then(|r| {
+                    r.map_err(|e| AgentError::Tool {
+                        tool: event.to_string(),
+                        message: e,
+                    })
+                })
+        })
+    }
 }
 
 pub struct RestoreItem {
@@ -1358,6 +1406,85 @@ fn extract_restore_reply(ret: &LuaValue) -> Option<RestoreReply> {
     Some(RestoreReply { body, header })
 }
 
+fn run_hook(rt: &LuaRuntime, event: &str, payload: Value) -> Result<Value, String> {
+    let mut entries = {
+        let Some(mut store) = rt.lua.app_data_mut::<AutocmdStore>() else {
+            return Ok(Value::Null);
+        };
+        match store.listeners.get_mut(event) {
+            Some(list) if !list.is_empty() => std::mem::take(list),
+            _ => return Ok(Value::Null),
+        }
+    };
+
+    entries.sort_by_key(|e| e.priority);
+    let mut keep = Vec::with_capacity(entries.len());
+    let mut current = payload;
+
+    for entry in entries {
+        let once = entry.once;
+        let plugin = Arc::clone(&entry.plugin);
+        let func = match rt.lua.registry_value::<Function>(&entry.callback) {
+            Ok(f) => f,
+            Err(e) => {
+                return Err(format!("{}: {e}", plugin));
+            }
+        };
+
+        let arg = match build_hook_arg(&rt.lua, &current) {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(format!("{}: {e}", plugin));
+            }
+        };
+
+        match rt.call_sync_detached::<LuaValue>(&func, arg) {
+            Ok(ret) => match lua_to_json(&ret) {
+                Ok(v) => current = v,
+                Err(e) => {
+                    return Err(format!("{}: {e}", plugin));
+                }
+            },
+            Err(e) => {
+                return Err(strip_traceback(&e));
+            }
+        }
+
+        if once {
+            let _ = rt.lua.remove_registry_value(entry.callback);
+        } else {
+            keep.push(entry);
+        }
+    }
+
+    if !keep.is_empty()
+        && let Some(mut store) = rt.lua.app_data_mut::<AutocmdStore>()
+    {
+        store
+            .listeners
+            .entry(event.to_owned())
+            .or_default()
+            .extend(keep);
+    }
+
+    Ok(current)
+}
+
+fn build_hook_arg(lua: &Lua, payload: &Value) -> LuaResult<LuaValue> {
+    match payload {
+        Value::Null => Ok(LuaValue::Nil),
+        _ => {
+            let tbl = lua.create_table()?;
+            if let Some(obj) = payload.as_object() {
+                for (k, v) in obj {
+                    tbl.set(k.as_str(), json_to_lua(lua, v).unwrap_or(LuaValue::Nil))?;
+                }
+            }
+            Ok(LuaValue::Table(tbl))
+        }
+    }
+}
+
 /// Handler returned nil, meaning it went async. Polls job events
 /// until `ctx:finish()`, all jobs die, or the deadline expires.
 async fn dispatch_async(
@@ -1886,6 +2013,7 @@ pub fn spawn(
                             if let Some(mut store) = rt.lua.app_data_mut::<AutocmdStore>()
                                 && let Some(list) = store.listeners.get_mut(&event)
                             {
+                                list.sort_by_key(|e| e.priority);
                                 let entries = std::mem::take(list);
                                 drop(store);
                                 let ctx_table = rt.lua.create_table().ok();
@@ -1921,6 +2049,10 @@ pub fn spawn(
                             if event == TURN_END_EVENT {
                                 rt.lua.gc_collect().ok();
                             }
+                        }
+                        Request::RunHook { event, payload, reply } => {
+                            let result = run_hook(&rt, &event, payload);
+                            let _ = reply.send(result);
                         }
                         Request::Describe {
                             plugin,

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -250,6 +250,10 @@ impl AgentLoop {
         .with_cancel(cancel)
         .with_mcp(self.mcp_handle.clone());
 
+        if let Some(ref handle) = self.lua_handle {
+            agent = agent.with_hooks(Arc::new(handle.hooks()));
+        }
+
         let result = agent.run(input).await;
         drop(agent);
 

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -1086,9 +1086,6 @@ impl App {
                     self.chat_index.clear();
                     self.subagent_answers.clear();
                     self.status = Status::Idle;
-                    if let Some(ref handle) = self.lua_event_handle {
-                        handle.fire_autocmd("TurnEnd", serde_json::json!({}));
-                    }
                     if self.exit_on_done {
                         self.exit_request = ExitRequest::Success;
                     }

--- a/plugins/system/init.lua
+++ b/plugins/system/init.lua
@@ -1,0 +1,11 @@
+-- Default PreStream hook: forwards the Rust-assembled system prompt and
+-- tool definitions unchanged. Override this callback in your own plugin to
+-- customize the system prompt or tool set per turn.
+maki.api.create_autocmd("PreStream", {
+  callback = function(payload)
+    return {
+      system = payload.system,
+      tools = payload.tools,
+    }
+  end,
+})

--- a/plugins/todo_write/init.lua
+++ b/plugins/todo_write/init.lua
@@ -173,4 +173,4 @@ local function clear_todos()
   maki.ui.set_status_hint(nil)
 end
 
-maki.api.create_autocmd({ "TurnEnd", "SessionReset" }, { callback = clear_todos })
+maki.api.create_autocmd({ "PostTurn", "SessionReset" }, { callback = clear_todos })


### PR DESCRIPTION
## Summary

Modular agent core with two changes to `maki-agent`, designed to compose:

1. **Typed FSM core (Phase A).** The agent loop is a stepper over an explicit `enum Phase`, driven by `step(phase) -> Phase`. Phase-scoped state lives in variants; cross-cutting state stays in `Agent`.
2. **Lua hook surface (Phases B-E).** Phase boundaries are exposed as ordered Lua middleware that can observe and transform payloads. Prompt and tool-set assembly ("prompt-as-data") collapses into the `PreStream` hook. The loop's hard invariants stay in Rust; policy and presentation are scriptable.

## Phases (one commit per phase)

### Phase A: FSM refactor (`35df1419`)
- 6-variant `Phase` enum (`Streaming`, `StreamDone`, `Dispatching`, `PostToolNudge`, `PostTurn`, `Done`), `step()`, `run_loop()`, `handle_reauth()`.
- Pure refactor, behavior-preserving. No public API changes.
- `nudged` threaded through variants (phase-scoped). `reauth_attempts` kept in `Agent` struct (cross-cutting).

### Phase B: Hook pipeline infrastructure (`203dd00d`)
- `Hooks` trait in `maki-agent` (`fire(event, payload) -> BoxFuture<Result<Value, AgentError>>`), `DynHooks = Arc<dyn Hooks>`.
- `Request::RunHook` variant (reply-carrying, unlike `FireAutocmd`), `LuaHooks` struct bridging trait to Lua thread.
- `#[non_exhaustive]` on `Request`. Priority ordering in `AutocmdStore`.
- `with_hooks()` builder on `Agent`. `EventHandle::hooks()` in `maki-lua`.
- No hooks fire in `step()` yet. Pipeline is a no-op when empty.

### Phase C: Observe-only hooks (`a667da5f`)
- `PostStream`, `PostToolResult`, `PostCompaction`, `PostTurn` fired from `step()` at phase boundaries.
- Return values discarded (observe-only). Each fire gated on `self.hooks` being `Some`.
- `TurnEnd` removed from `maki-ui`; `PostTurn` fires from `step()` at `Done` entry instead. GC collection moved from `TurnEnd` to `PostTurn` in `RunHook` handler.
- `todo_write` plugin migrated from `TurnEnd` to `PostTurn`.
- `LuaHooks` wired into interactive `Agent` (agent_loop).

### Phase D: PreStream + prompt-as-data (`35aac124`)
- `PreStream` hook fires at `Streaming` entry before `stream_with_retry`. Only hook that can transform (`system`/`tools` overrides) and abort (`abort: true` routes to `Done`).
- Payload includes pre-assembled `system`/`tools` so a plugin can pass through or rebuild.
- Validation: empty `system` override falls back to Rust-assembled prompt.
- Churn guard: warns when tool-set changes between turns.
- `maki.agent.plan_prompt()` ctx-less host primitive returning `PLAN_PROMPT`.
- `plugins/system/init.lua` passthrough default and customization template.

### Phase E: PreCompaction + PreToolDispatch (`17e1ef45`)
- `PreCompaction` (observe-only): fires before `compact_history` with `{ history_len, context_size }`.
- `PreToolDispatch` (transform): fires after doom-loop dedup, before spawning. A plugin can filter or reorder the runnable tool calls by returning a modified `tool_calls` array.

## Testing

- 2798 workspace tests pass (unchanged from main; tests construct `Agent` without hooks so all hook firing is skipped).
- `cargo clippy --all --tests -- -D warnings` clean.
- `cargo fmt --all -- --check` + `stylua --check plugins/` clean.
- `cargo run -p maki-docgen -- --check` clean.
- `cargo machete` clean.

## Design doc

Full design at https://github.com/tontinton/maki/issues/481 (issue) / internal design doc.

## AI use

Implementation was done with AI assistance (Maki agent). Each phase was implemented by a subagent with the design doc as specification, then verified with CI gates (build, clippy, fmt, tests). 🤖🤖🤖