### PR TITLE
lua: run restore async tasks inline so highlighting survives expand

### DIFF
--- a/maki-lua/src/api/async.rs
+++ b/maki-lua/src/api/async.rs
@@ -468,6 +468,7 @@ mod tests {
             live: None,
             root_buf: None,
             live_sink: None,
+            inline_spawn: None,
         }))
     }
 

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -48,6 +48,10 @@ const MAX_INFLIGHT_TOOLS: usize = 64;
 const GC_STEP_INTERVAL: usize = 4;
 const INTERRUPT_CANCEL_CHECK_INTERVAL: u32 = 128;
 const ASYNC_RUN_DEFAULT_DEADLINE: Duration = Duration::from_secs(60);
+/// Async tasks spawned during restore may spawn further tasks; cap the rounds.
+const RESTORE_SPAWN_ROUNDS: usize = 8;
+/// Keeps a buggy plugin's restore task from freezing the lua loop.
+const RESTORE_ASYNC_DEADLINE: Duration = Duration::from_secs(10);
 const TURN_END_EVENT: &str = "TurnEnd";
 /// Without a cap, a runaway plugin OOM-kills the whole process.
 /// With one, it hits a catchable Lua error instead.
@@ -225,6 +229,9 @@ pub(crate) struct TaskCell {
     /// Forwards live bufs and annotations to a parent
     /// `maki.agent.call_tool(on_live_buf/on_annotation)`.
     pub(crate) live_sink: Option<flume::Sender<ToolLive>>,
+    /// When `Some`, `maki.async.run` tasks queue here instead of the global
+    /// `SpawnQueue` so restore can run them inline before snapshotting.
+    pub(crate) inline_spawn: Option<Vec<PendingAsyncTask>>,
 }
 
 impl TaskCell {
@@ -238,6 +245,7 @@ impl TaskCell {
             live,
             root_buf: None,
             live_sink: None,
+            inline_spawn: None,
         }
     }
 }
@@ -415,9 +423,10 @@ pub(crate) fn with_live_ctx<R>(lua: &Lua, f: impl FnOnce(&LiveCtx) -> R) -> Opti
 }
 
 pub(crate) fn enqueue_async_task(lua: &Lua, work_fn: RegistryKey) -> Result<(), mlua::Error> {
-    let (cancel, live_ctx, live_buf) = match lua.app_data_ref::<TaskHandle>() {
+    let handle = lua.app_data_ref::<TaskHandle>();
+    let (cancel, live_ctx, live_buf) = match &handle {
         Some(h) => {
-            let cell = lock_cell(&h);
+            let cell = lock_cell(h);
             (
                 cell.cancel.clone(),
                 cell.live.clone(),
@@ -434,6 +443,14 @@ pub(crate) fn enqueue_async_task(lua: &Lua, work_fn: RegistryKey) -> Result<(), 
         live_ctx,
         live_buf,
     };
+
+    if let Some(h) = &handle {
+        let mut cell = lock_cell(h);
+        if let Some(inline) = cell.inline_spawn.as_mut() {
+            inline.push(task);
+            return Ok(());
+        }
+    }
 
     let queue = lua
         .app_data_ref::<SpawnQueue>()
@@ -522,6 +539,25 @@ pub(crate) struct PendingAsyncTask {
 
 pub(crate) type SpawnQueue = RefCell<Vec<PendingAsyncTask>>;
 
+async fn run_work_fn(
+    lua: &Lua,
+    work_fn: &RegistryKey,
+    deadline: Option<Instant>,
+) -> Result<LuaValue, mlua::Error> {
+    let func: Function = lua.registry_value(work_fn)?;
+    let fut = lua.create_thread(func)?.into_async::<LuaValue>(())?;
+    match deadline {
+        Some(dl) => {
+            futures_lite::future::race(fut, async {
+                smol::Timer::at(dl).await;
+                Err(mlua::Error::runtime("timeout"))
+            })
+            .await
+        }
+        None => fut.await,
+    }
+}
+
 fn drain_spawn_queue(lua: &Lua, ex: &Rc<smol::LocalExecutor<'_>>, gate: &Rc<InflightGate>) {
     let tasks: Vec<PendingAsyncTask> = {
         let Some(queue) = lua.app_data_ref::<SpawnQueue>() else {
@@ -551,23 +587,9 @@ fn drain_spawn_queue(lua: &Lua, ex: &Rc<smol::LocalExecutor<'_>>, gate: &Rc<Infl
                 &lua,
                 TaskCell::new(task.cancel.clone(), task.deadline, task.live_ctx.clone()),
             );
-            let run = scope.scope_future(async {
-                let work_fn: Function = lua.registry_value(&task.work_fn)?;
-                let thread = lua.create_thread(work_fn)?;
-                let async_thread = thread.into_async::<LuaValue>(())?;
-                match task.deadline {
-                    Some(dl) => {
-                        futures_lite::future::race(async_thread, async {
-                            smol::Timer::at(dl).await;
-                            Err(mlua::Error::runtime("timeout"))
-                        })
-                        .await
-                    }
-                    None => async_thread.await,
-                }
-            });
-
-            let result = run.await;
+            let result = scope
+                .scope_future(run_work_fn(&lua, &task.work_fn, task.deadline))
+                .await;
             if let Err(e) = &result {
                 tracing::debug!(error = %e, "async.run: task failed");
             }
@@ -1225,6 +1247,7 @@ impl LuaRuntime {
             .into_async::<LuaValue>((input_lua, &*item.output, item.is_error, ctx_ud))
             .ok()?;
         let scope = TaskScope::new(&self.lua, cell);
+        lock_cell(scope.handle()).inline_spawn = Some(Vec::new());
         let ret = scope
             .scope_future(inner)
             .await
@@ -1232,6 +1255,7 @@ impl LuaRuntime {
                 |e| tracing::warn!(tool = &*item.tool, error = %e, "restore callback failed"),
             )
             .ok()?;
+        self.run_inline_tasks(&scope).await;
 
         if let Some(buf) = crate::api::ui::buf::buf_from_reply(&ret) {
             lock_cell(scope.handle()).root_buf = Some(buf);
@@ -1250,6 +1274,7 @@ impl LuaRuntime {
                     tracing::warn!(tool = &*item.tool, error = %e, "click replay failed");
                     break;
                 }
+                self.run_inline_tasks(&scope).await;
             }
         }
 
@@ -1263,6 +1288,33 @@ impl LuaRuntime {
             );
         }
         Some(reply)
+    }
+
+    /// Runs `maki.async.run` tasks queued during restore inline, so their
+    /// buf mutations land before the snapshot is extracted. Tasks may queue
+    /// more tasks, hence the rounds.
+    async fn run_inline_tasks(&self, scope: &TaskScope) {
+        for _ in 0..RESTORE_SPAWN_ROUNDS {
+            let tasks = {
+                let mut cell = lock_cell(scope.handle());
+                match cell.inline_spawn.as_mut() {
+                    Some(queue) if !queue.is_empty() => std::mem::take(queue),
+                    _ => return,
+                }
+            };
+            for task in tasks {
+                if !task.cancel.is_cancelled() {
+                    let deadline = Some(Instant::now() + RESTORE_ASYNC_DEADLINE);
+                    if let Err(e) = scope
+                        .scope_future(run_work_fn(&self.lua, &task.work_fn, deadline))
+                        .await
+                    {
+                        tracing::debug!(error = %e, "restore inline async task failed");
+                    }
+                }
+                self.lua.remove_registry_value(task.work_fn).ok();
+            }
+        }
     }
 
     fn compute_permission_scopes(
@@ -2224,6 +2276,25 @@ mod tests {
             .unwrap();
         let err = enqueue_async_task(&lua, key).unwrap_err();
         assert!(err.to_string().contains(SPAWN_QUEUE_NOT_INIT));
+    }
+
+    #[test]
+    fn enqueue_async_task_routes_to_inline_spawn_when_set() {
+        let lua = enqueue_test_lua();
+        let scope = set_active(&lua, TaskCell::new(CancelToken::none(), None, None));
+        lock_cell(scope.handle()).inline_spawn = Some(Vec::new());
+
+        enqueue_async_task(&lua, enqueue_dummy(&lua)).unwrap();
+
+        assert!(
+            lua.app_data_ref::<SpawnQueue>()
+                .unwrap()
+                .borrow()
+                .is_empty(),
+            "task must not reach the global queue"
+        );
+        let cell = lock_cell(scope.handle());
+        assert_eq!(cell.inline_spawn.as_ref().unwrap().len(), 1);
     }
 
     #[test]

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -347,12 +347,53 @@ fn handler_state_flows_to_tool_output_and_serde() {
     assert_eq!(parsed.state(), Some(&expected), "state must survive serde");
 }
 
+/// Restores `tool` from `src` and returns the snapshot's concatenated text.
+/// `collect_prompt_slots` blocks on the same request channel, so once it
+/// returns the restore has finished; no sleeps needed.
+fn restore_snapshot_text(
+    src: &str,
+    tool: &str,
+    clicks: Vec<usize>,
+    state: Option<serde_json::Value>,
+) -> String {
+    let host = PluginHost::new(fresh_registry()).unwrap();
+    host.load_source("restore_plugin", src).unwrap();
+    let handle = host.event_handle().expect("event handle available");
+    let (tx, rx) = flume::unbounded();
+
+    handle.request_restore(
+        maki_lua::RestoreItem {
+            tool: Arc::from(tool),
+            tool_use_id: "restore_id".to_owned(),
+            output: "ok".to_owned(),
+            input: serde_json::json!({}),
+            is_error: false,
+            tool_output_lines: ToolOutputLines::default(),
+            theme_gen: None,
+            clicks,
+            state,
+        },
+        maki_agent::EventSender::new(tx, 0),
+    );
+    let _ = handle.collect_prompt_slots();
+
+    let mut text = String::new();
+    for env in rx.drain() {
+        if let maki_agent::AgentEvent::ToolSnapshot { snapshot, .. } = env.event {
+            for line in snapshot.lines.iter() {
+                for span in &line.spans {
+                    text.push_str(&span.text);
+                }
+            }
+        }
+    }
+    text
+}
+
 #[test_case::test_case(true, "n=3 tag=hi" ; "state_present")]
 #[test_case::test_case(false, "no state" ; "state_absent_falls_back")]
 fn restore_reads_persisted_state(with_state: bool, expected: &str) {
     let state = with_state.then(|| serde_json::json!({ "n": 3, "tag": "hi" }));
-    let reg = fresh_registry();
-    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
     let src = format!(
         r#"maki.api.register_tool({{
             name = "state_restore",
@@ -371,37 +412,44 @@ fn restore_reads_persisted_state(with_state: bool, expected: &str) {
             end
         }})"#,
     );
-    host.load_source("state_restore_plugin", &src).unwrap();
-    let handle = host.event_handle().expect("event handle available");
-    let (tx, rx) = flume::unbounded();
-
-    handle.request_restore(
-        maki_lua::RestoreItem {
-            tool: Arc::from("state_restore"),
-            tool_use_id: "restore_id".to_owned(),
-            output: "ok".to_owned(),
-            input: serde_json::json!({}),
-            is_error: false,
-            tool_output_lines: ToolOutputLines::default(),
-            theme_gen: None,
-            clicks: Vec::new(),
-            state,
-        },
-        maki_agent::EventSender::new(tx, 0),
-    );
-    let _ = handle.collect_prompt_slots();
-
-    let mut text = String::new();
-    for env in rx.drain() {
-        if let maki_agent::AgentEvent::ToolSnapshot { snapshot, .. } = env.event {
-            for line in snapshot.lines.iter() {
-                for span in &line.spans {
-                    text.push_str(&span.text);
-                }
-            }
-        }
-    }
+    let text = restore_snapshot_text(&src, "state_restore", Vec::new(), state);
     assert!(text.contains(expected), "expected {expected:?} in: {text}");
+}
+
+/// Restore used to lose anything drawn via `maki.async.run`: those tasks
+/// landed in the global spawn queue, which runs after the snapshot is
+/// taken. The runtime must run them inline, after the restore fn and after
+/// each replayed click.
+#[test_case::test_case(Vec::new(), "restore async line" ; "restore_async_task_runs_inline")]
+#[test_case::test_case(vec![0], "click async line" ; "click_replay_async_task_runs_inline")]
+fn restore_snapshot_contains_async_run_content(clicks: Vec<usize>, expected: &str) {
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "async_restore",
+            description = "t",
+            schema = {MINIMAL_SCHEMA},
+            handler = function() return "ok" end,
+            restore = function(input, output, is_error, rctx)
+                local buf = maki.ui.buf()
+                buf:line("sync line")
+                maki.async.run(function()
+                    buf:line("restore async line")
+                end)
+                buf:on("click", function()
+                    maki.async.run(function()
+                        buf:line("click async line")
+                    end)
+                end)
+                return buf
+            end
+        }})"#,
+    );
+    let text = restore_snapshot_text(&src, "async_restore", clicks, None);
+    assert!(text.contains("sync line"), "sync content missing: {text}");
+    assert!(
+        text.contains(expected),
+        "async content missing {expected:?}: {text}"
+    );
 }
 
 #[test]

--- a/plugins/lib/maki/tool_view.lua
+++ b/plugins/lib/maki/tool_view.lua
@@ -5,8 +5,9 @@
 -- itself, so any wrapper of the same buf (a batch child's foreign handle)
 -- reaches the same toggle. Expansion is never stored: the UI records
 -- clicked rows and replays them through `restore` in order, so `toggle`
--- must stay deterministic or the replayed view drifts from what the user
--- last saw.
+-- stays a pure flag flip + re-render, deterministic across replays.
+-- Async highlighting goes through `maki.async.run`; during restore the
+-- runtime runs those tasks inline before snapshotting.
 local ToolView = {}
 ToolView.__index = ToolView
 
@@ -17,18 +18,6 @@ end
 local function line_nr_fmt(count)
   local w = math.max(1, math.floor(math.log(count, 10)) + 1)
   return "%" .. w .. "d "
-end
-
-local function build_highlighted_lines(highlighted, fmt, start_idx)
-  local result = {}
-  for idx, hl_line in ipairs(highlighted) do
-    local spans = { format_line_nr(fmt, start_idx + idx - 1) }
-    for _, seg in ipairs(hl_line) do
-      spans[#spans + 1] = seg
-    end
-    result[#result + 1] = spans
-  end
-  return result
 end
 
 function ToolView.new(buf, opts)
@@ -62,7 +51,6 @@ function ToolView:clear()
   self.all_lines = {}
   self.all_skipped = 0
   self.ring_map = {}
-  self._hl = nil
   self:flush()
 end
 
@@ -110,41 +98,33 @@ function ToolView:set_highlight(content, ext)
   if content:sub(-1) == "\n" then
     content = content:sub(1, -2)
   end
+  if content == "" then
+    return false
+  end
   local lines = {}
   for line in (content .. "\n"):gmatch("([^\n]*)\n") do
     lines[#lines + 1] = line
   end
-  if #lines == 0 then
-    return false
-  end
-
-  self._hl = {
-    content = content,
-    ext = ext,
-    line_count = #lines,
-    expanded_done = false,
-  }
 
   local fmt = line_nr_fmt(#lines)
   for idx, line in ipairs(lines) do
     self:append({ format_line_nr(fmt, idx), { line } })
   end
 
-  local visible_count = math.min(#lines, self.max)
-  local visible_start = self.keep == "head" and 1 or (#lines - visible_count + 1)
-  local visible_content = table.concat(lines, "\n", visible_start, visible_start + visible_count - 1)
-
   maki.async.run(function()
-    local highlighted = maki.ui.highlight(visible_content, ext)
+    local highlighted = maki.ui.highlight(content, ext)
     if not highlighted then
       return
     end
-    local hl_lines = build_highlighted_lines(highlighted, fmt, visible_start)
-    self.ring = {}
-    self.ring_start = 1
-    self.ring_count = #hl_lines
-    for i, l in ipairs(hl_lines) do
-      self.ring[i] = l
+    for idx, hl_line in ipairs(highlighted) do
+      if not self.all_lines[idx] then
+        break
+      end
+      local spans = { format_line_nr(fmt, idx) }
+      for _, seg in ipairs(hl_line) do
+        spans[#spans + 1] = seg
+      end
+      self:update_line(idx, spans)
     end
     self:flush()
   end)
@@ -154,26 +134,7 @@ end
 
 function ToolView:toggle()
   self.expanded = not self.expanded
-  if self.expanded and self._hl and not self._hl.expanded_done then
-    self:_highlight_full()
-  else
-    self:flush()
-  end
-end
-
-function ToolView:_highlight_full()
   self:flush()
-  local hl = self._hl
-  maki.async.run(function()
-    local highlighted = maki.ui.highlight(hl.content, hl.ext)
-    if not highlighted then
-      return
-    end
-    hl.expanded_done = true
-    local fmt = line_nr_fmt(hl.line_count)
-    self.all_lines = build_highlighted_lines(highlighted, fmt, 1)
-    self:flush()
-  end)
 end
 
 function ToolView:flush()

--- a/plugins/lib/tests/spec.lua
+++ b/plugins/lib/tests/spec.lua
@@ -1053,6 +1053,31 @@ case("set_highlight_number_width_scales", function()
   eq(buf.lines[1][1][2], "line_nr")
 end)
 
+case("set_highlight_empty_content_returns_false", function()
+  local buf = mock_buf()
+  local view = ToolView.new(buf, { max_lines = 3 })
+  eq(view:set_highlight("", "txt"), false)
+  eq(view:set_highlight("\n", "txt"), false)
+  eq(buf.lines, nil, "nothing flushed for empty content")
+end)
+
+case("set_highlight_toggle_keeps_lines_and_collapses_back", function()
+  local buf = mock_buf()
+  local view = ToolView.new(buf, { max_lines = 3, keep = "head" })
+  eq(view:set_highlight("a\nb\nc\nd\ne", "txt"), true)
+
+  view:toggle()
+  eq(view.expanded, true)
+  eq(#buf.lines, 5, "expanded renders every line")
+  eq(buf.lines[1][2][1], "a")
+  eq(buf.lines[5][2][1], "e")
+
+  view:toggle()
+  eq(view.expanded, false)
+  eq(buf.lines[3][2][1], "c", "collapsed shows the head window")
+  eq(buf.lines[4][1][1], "... (2 lines) (click to expand)")
+end)
+
 local render_lines = ListPicker._render_lines
 
 case("render_lines_string_items_basic", function()

--- a/plugins/read/init.lua
+++ b/plugins/read/init.lua
@@ -41,34 +41,29 @@ local function read_view_opts(ctx)
   return { max_lines = (tol and tol.read) or 10, keep = "head" }
 end
 
-local function apply_highlights(view, hl_lines, ext, prefix)
-  local texts = {}
-  for _, fl in ipairs(hl_lines) do
-    texts[#texts + 1] = fl.text
-  end
+local function apply_highlights(view, lines, ext, prefix)
   local opts = prefix and { prefix = prefix } or nil
-  local highlighted = maki.ui.highlight(table.concat(texts, "\n"), ext, opts)
+  local highlighted = maki.ui.highlight(table.concat(lines, "\n"), ext, opts)
   if not highlighted then
     return
   end
-  for i, fl in ipairs(hl_lines) do
-    local hl_spans = highlighted[i]
-    if hl_spans then
-      view:update_line(fl.idx, { view.all_lines[fl.idx][1], table.unpack(hl_spans) })
+  for i, hl_spans in ipairs(highlighted) do
+    local plain = view.all_lines[i]
+    if not plain then
+      break
     end
+    view:update_line(i, { plain[1], table.unpack(hl_spans) })
   end
   view:flush()
 end
 
-local function build_file_view(lines, start_line, total_lines, path, ctx, sync, prefix)
+local function build_file_view(lines, start_line, total_lines, path, ctx, prefix)
   local buf = maki.ui.buf()
   local view = ToolView.new(buf, read_view_opts(ctx))
   local nr_fmt = line_nr_fmt(total_lines)
 
-  local hl_lines = {}
   for i, line in ipairs(lines) do
     view:append({ { string.format(nr_fmt, start_line + i - 1), "line_nr" }, { line } })
-    hl_lines[#hl_lines + 1] = { idx = #view.all_lines, text = line }
   end
 
   local trunc_start = start_line + #lines
@@ -88,13 +83,9 @@ local function build_file_view(lines, start_line, total_lines, path, ctx, sync, 
   view:finish()
 
   local ext = path:match("%.([^%.]+)$") or ""
-  if sync then
-    apply_highlights(view, hl_lines, ext, prefix)
-  else
-    maki.async.run(function()
-      apply_highlights(view, hl_lines, ext, prefix)
-    end)
-  end
+  maki.async.run(function()
+    apply_highlights(view, lines, ext, prefix)
+  end)
 
   buf:on("click", function()
     view:toggle()
@@ -174,7 +165,7 @@ local function read_file(path, offset, limit, ctx)
       if #instructions > 0 then
         return {
           llm_output = llm_output,
-          body = build_file_view(lines, start, total_lines, path, ctx, false, prefix),
+          body = build_file_view(lines, start, total_lines, path, ctx, prefix),
           annotation = annotation,
           instructions = instructions,
         }
@@ -184,7 +175,7 @@ local function read_file(path, offset, limit, ctx)
 
   return {
     llm_output = llm_output,
-    body = build_file_view(lines, start, total_lines, path, ctx, false, prefix),
+    body = build_file_view(lines, start, total_lines, path, ctx, prefix),
     annotation = annotation,
   }
 end
@@ -290,7 +281,7 @@ maki.api.register_tool({
     end
     start_line = start_line or 1
     total_lines = total_lines or (start_line + #lines - 1)
-    return build_file_view(lines, start_line, total_lines, input.path or "", ctx, true)
+    return build_file_view(lines, start_line, total_lines, input.path or "", ctx)
   end,
 
   handler = function(input, ctx)

--- a/plugins/write/init.lua
+++ b/plugins/write/init.lua
@@ -13,55 +13,11 @@ local function write_view_opts(ctx)
   return { max_lines = (tol and tol.write) or 10, keep = "head" }
 end
 
-local function split_lines(content)
-  local lines = {}
-  for line in (content .. "\n"):gmatch("([^\n]*)\n") do
-    lines[#lines + 1] = line
-  end
-  if #lines > 0 and lines[#lines] == "" then
-    lines[#lines] = nil
-  end
-  return lines
-end
-
-local function line_nr_fmt(count)
-  local w = math.max(1, math.floor(math.log(count + 1, 10)) + 1)
-  return "%" .. w .. "d "
-end
-
-local function build_view(lines, path, ctx, sync)
+local function build_view(content, path, ctx)
   local buf = maki.ui.buf()
   local view = ToolView.new(buf, write_view_opts(ctx))
-  local nr_fmt = line_nr_fmt(#lines)
-
-  local hl_lines = {}
-  for i, line in ipairs(lines) do
-    view:append({ { string.format(nr_fmt, i), "line_nr" }, { line } })
-    hl_lines[#hl_lines + 1] = { idx = i, text = line }
-  end
+  view:set_highlight(content, path:match("%.([^%.]+)$") or "")
   view:finish()
-
-  local ext = path:match("%.([^%.]+)$") or ""
-  local function do_highlight()
-    local highlighted = maki.ui.highlight(table.concat(lines, "\n"), ext)
-    if not highlighted then
-      return
-    end
-    for _, fl in ipairs(hl_lines) do
-      local hl_spans = highlighted[fl.idx]
-      if hl_spans then
-        view:update_line(fl.idx, { view.all_lines[fl.idx][1], table.unpack(hl_spans) })
-      end
-    end
-    view:flush()
-  end
-
-  if sync then
-    do_highlight()
-  else
-    maki.async.run(do_highlight)
-  end
-
   buf:on("click", function()
     view:toggle()
   end)
@@ -100,11 +56,11 @@ maki.api.register_tool({
   end,
 
   restore = function(input, output, _is_error, ctx)
-    local lines = split_lines(input.content or "")
-    if #lines == 0 then
+    local content = input.content or ""
+    if content == "" then
       return ToolView.restore(output, write_view_opts(ctx))
     end
-    return build_view(lines, input.path or "", ctx, true)
+    return build_view(content, input.path or "", ctx)
   end,
 
   handler = function(input, ctx)
@@ -143,7 +99,7 @@ maki.api.register_tool({
 
     return {
       llm_output = llm_output,
-      body = build_view(split_lines(content), path, ctx),
+      body = build_view(content, path, ctx),
       annotation = annotation,
       written_path = path,
     }


### PR DESCRIPTION
Clicking a completed tool replays it through `restore`, but anything a plugin scheduled via `maki.async.run` (all syntax highlighting) landed in the global spawn queue after the snapshot was taken, reporting into a dummy channel, so index and memory lost their colors on expand.  Now `TaskCell.inline_spawn` routes those tasks into the restore's own cell, and `run_inline_tasks` drains them after the restore fn and after each replayed click (capped at 8 spawn rounds, 10s per task), so the snapshot sees everything and plugins get one code path for live and restore.

That removes the per-plugin workarounds: read and write drop their `sync` params, and `ToolView:set_highlight` becomes a single async full-content pass through `update_line`, which turns `toggle` into a pure flag flip instead of a second stateful highlight trigger.