### PR TITLE
Implement login for the catalog based providers

### DIFF
--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -15,6 +15,9 @@ pub use providers::Timeouts;
 pub use providers::copilot::auth as copilot_auth;
 pub use providers::dynamic;
 pub use providers::openai::auth as openai_auth;
+pub use providers::opencode::{
+    ProviderData, catalog_provider, catalog_providers, catalog_providers_if_available,
+};
 pub use types::{
     ContentBlock, EffortScale, IMAGE_OMITTED_NOTE, ImageMediaType, ImageSource, Message,
     ProviderEvent, ProviderUsage, RequestOptions, Role, StopReason, StreamResponse, ThinkingConfig,

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -23,7 +23,7 @@ pub(crate) mod mistral;
 pub(crate) mod ollama;
 pub(crate) mod openai;
 pub(crate) mod openai_compat;
-pub(crate) mod opencode;
+pub mod opencode;
 pub(crate) mod openrouter;
 pub(crate) mod synthetic;
 pub(crate) mod tensorx;

--- a/maki-providers/src/providers/opencode.rs
+++ b/maki-providers/src/providers/opencode.rs
@@ -7,10 +7,14 @@ use std::time::{Duration, SystemTime};
 use flume::Sender;
 use isahc::config::Configurable;
 use isahc::{AsyncReadResponseExt, HttpClient, Request};
+use maki_config::providers::builtin_provider;
 use maki_storage::id::SessionRef;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tracing::{debug, warn};
+
+use maki_storage::StateDir;
+use maki_storage::auth::load_provider_credentials;
 
 use crate::model::{Model, ModelInfo, ModelPricing};
 use crate::provider::{BoxFuture, Provider};
@@ -20,6 +24,8 @@ use crate::{AgentError, EffortScale, Message, ProviderEvent, RequestOptions, Str
 use super::{ResolvedAuth, http_client};
 use crate::providers::anthropic::shared;
 
+const BLOCKED_PROVIDER_IN_CATALOG: &[&str] = &["zai", "zai-coding-plan", "github-copilot"];
+
 const CATALOG_URL: &str = "https://models.dev/api.json";
 const CATALOG_CACHE_FILE: &str = "models-dev-catalog.json";
 const CATALOG_CACHE_TTL: Duration = Duration::from_secs(86400);
@@ -27,7 +33,7 @@ const CATALOG_CACHE_TTL: Duration = Duration::from_secs(86400);
 const MESSAGES_PATH: &str = "/messages";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum EndpointType {
+pub enum EndpointType {
     ChatCompletions,
     Messages,
 }
@@ -42,42 +48,6 @@ struct CatalogProvider {
     npm: String,
     api: Option<String>,
     models: HashMap<String, CatalogModel>,
-}
-
-impl CatalogProvider {
-    fn resolve_api_key(&self) -> String {
-        for var in &self.env {
-            if let Ok(val) = std::env::var(var) {
-                debug!(provider = %self.name, var = %var, "api key resolved from env");
-                return val;
-            }
-            debug!(provider = %self.name, var = %var, "env var not set");
-        }
-        if self.env.iter().any(|v| v == "OPENCODE_API_KEY") {
-            debug!(provider = %self.name, "using public fallback key");
-            return "public".to_string();
-        }
-        debug!(provider = %self.name, "no api key available");
-        String::new()
-    }
-
-    fn has_api_key(&self) -> bool {
-        let found = self.env.iter().any(|v| std::env::var(v).is_ok());
-        debug!(provider = %self.name, has_api_key = found, "api key presence check");
-        found
-    }
-
-    fn build_auth(&self) -> ResolvedAuth {
-        let api_key = self.resolve_api_key();
-        let headers = match self.npm.as_str() {
-            "@ai-sdk/anthropic" => vec![("x-api-key".into(), api_key)],
-            _ => vec![("authorization".into(), format!("Bearer {api_key}"))],
-        };
-        ResolvedAuth {
-            base_url: self.api.clone(),
-            headers,
-        }
-    }
 }
 
 #[derive(Deserialize, Serialize, Clone)]
@@ -117,72 +87,328 @@ struct CatalogShape {
     shape: Option<String>,
 }
 
-#[derive(Clone)]
-struct CatalogMeta {
-    provider_id: String,
-    api_format: EndpointType,
-    context: u32,
-    output: u32,
-    input_price: f64,
-    output_price: f64,
-    cache_read: f64,
-    cache_write: f64,
+/// Provider metadata from the catalog, exposed for the login UI.
+#[derive(Clone, Debug)]
+pub struct ProviderData {
+    pub slug: String,
+    pub display_name: String,
+    /// Environment variable names for API keys
+    pub env_keys: Vec<String>,
+    /// API base URL
+    pub base_url: Option<String>,
+    /// NPM package name
+    pub npm: String,
+    /// API format (ChatCompletions or Messages)
+    pub api_format: EndpointType,
+    /// Models for this provider
+    pub models: HashMap<String, CatalogMeta>,
 }
 
-type ModelWithProvider = (String, String);
-
-struct CatalogData {
-    entries: HashMap<ModelWithProvider, CatalogMeta>,
-    auths: HashMap<String, ResolvedAuth>,
-}
-
-impl CatalogData {
-    fn lookup(&self, key: &str) -> Result<(CatalogMeta, ResolvedAuth), AgentError> {
-        let (provider, model_id) = key.split_once('/').ok_or_else(|| AgentError::Config {
-            message: format!("invalid model key '{key}': expected 'provider/model_id'"),
-        })?;
-        let meta = self
-            .entries
-            .get(&(provider.to_string(), model_id.to_string()))
-            .cloned()
-            .ok_or_else(|| AgentError::Config {
-                message: format!("model '{key}' not found in catalog"),
-            })?;
-        let auth =
-            self.auths
-                .get(&meta.provider_id)
-                .cloned()
-                .ok_or_else(|| AgentError::Config {
-                    message: format!(
-                        "auth for provider '{}' not found in catalog",
-                        meta.provider_id
-                    ),
-                })?;
-        Ok((meta, auth))
+impl ProviderData {
+    fn new(
+        slug: String,
+        catalog_provider: &CatalogProvider,
+        api_format: EndpointType,
+        models: HashMap<String, CatalogMeta>,
+    ) -> Self {
+        Self {
+            slug,
+            display_name: catalog_provider.name.clone(),
+            env_keys: catalog_provider.env.clone(),
+            base_url: catalog_provider.api.clone(),
+            npm: catalog_provider.npm.clone(),
+            api_format,
+            models,
+        }
     }
 
-    fn all_models(&self) -> Vec<ModelInfo> {
-        let mut models: Vec<ModelInfo> = self
-            .entries
+    /// Load API key from storage
+    pub fn load_key_from_storage(&self, state_dir: &StateDir) -> Option<String> {
+        let creds = load_provider_credentials(state_dir, &self.slug)?;
+        Some(creds.api_key)
+    }
+
+    /// Resolve API key from environment or storage
+    pub fn resolve_api_key(&self, state_dir: &StateDir) -> Option<String> {
+        for var in &self.env_keys {
+            if let Ok(val) = std::env::var(var) {
+                debug!(provider = %self.display_name, var = %var, "api key resolved from env");
+                return Some(val);
+            }
+        }
+        if let Some(key) = self.load_key_from_storage(state_dir) {
+            debug!(provider = %self.display_name, "api key resolved from storage");
+            return Some(key);
+        }
+        None
+    }
+
+    /// Returns the name of the first API key environment variable that is set.
+    pub fn env_key_set(&self) -> Option<&str> {
+        self.env_keys
             .iter()
-            .map(|((provider, model_id), meta)| ModelInfo {
-                id: format!("{provider}/{model_id}"),
-                context_window: Some(meta.context),
-                max_output_tokens: Some(meta.output),
-                pricing: Some(ModelPricing {
-                    input: meta.input_price,
-                    output: meta.output_price,
-                    cache_read: meta.cache_read,
-                    cache_write: meta.cache_write,
-                    fast: None,
-                }),
-                supports_thinking: None,
-                supports_vision: None,
-                provider_info: None,
+            .find(|e| std::env::var(e).is_ok())
+            .map(|s| s.as_str())
+    }
+
+    fn auth_headers(&self, api_key: &str) -> Vec<(String, String)> {
+        match self.npm.as_str() {
+            "@ai-sdk/anthropic" => vec![("x-api-key".into(), api_key.into())],
+            _ => vec![("authorization".into(), format!("Bearer {api_key}"))],
+        }
+    }
+
+    /// Build authentication from available credentials
+    pub fn build_auth(&self, state_dir: &StateDir) -> Authentication {
+        let api_key = match self.resolve_api_key(state_dir) {
+            Some(key) => key,
+            None if self.slug == "opencode" => {
+                return Authentication::OpenCodeFreeKey(ResolvedAuth {
+                    base_url: self.base_url.clone(),
+                    headers: self.auth_headers("public"),
+                });
+            }
+            None => return Authentication::NoAuth,
+        };
+        Authentication::KeyBased(ResolvedAuth {
+            base_url: self.base_url.clone(),
+            headers: self.auth_headers(&api_key),
+        })
+    }
+
+    /// Get resolved auth for use in requests
+    pub fn resolve_auth(&self, state_dir: &StateDir) -> Option<ResolvedAuth> {
+        match self.build_auth(state_dir) {
+            Authentication::KeyBased(auth) | Authentication::OpenCodeFreeKey(auth) => Some(auth),
+            Authentication::NoAuth => None,
+        }
+    }
+
+    /// Resolve auth with optional dynamic override (e.g. from Lua).
+    pub fn resolve_auth_with_override(
+        &self,
+        override_auth: Option<&Arc<Mutex<ResolvedAuth>>>,
+        state_dir: &StateDir,
+    ) -> Option<ResolvedAuth> {
+        if self.slug == "opencode"
+            && let Some(auth) = override_auth
+        {
+            return Some(auth.lock().unwrap().clone());
+        }
+        self.resolve_auth(state_dir)
+    }
+
+    /// Get all available models for this provider based on auth state.
+    pub fn available_models(
+        &self,
+        state_dir: &StateDir,
+        enable_free_models: bool,
+    ) -> Vec<ModelInfo> {
+        let auth = self.build_auth(state_dir);
+        let mut models: Vec<ModelInfo> = self
+            .models
+            .iter()
+            .filter_map(|(model_id, meta)| {
+                let is_free = meta.input_price == 0.0 && meta.output_price == 0.0;
+                if is_free && !enable_free_models {
+                    return None;
+                }
+                let allow_model = match &auth {
+                    Authentication::KeyBased(_) => true,
+                    Authentication::OpenCodeFreeKey(_) => is_free,
+                    Authentication::NoAuth => false,
+                };
+                if !allow_model {
+                    return None;
+                }
+                Some(ModelInfo {
+                    id: format!("{}/{}", self.slug, model_id),
+                    context_window: Some(meta.context),
+                    max_output_tokens: Some(meta.output),
+                    pricing: Some(ModelPricing {
+                        input: meta.input_price,
+                        output: meta.output_price,
+                        cache_read: meta.cache_read,
+                        cache_write: meta.cache_write,
+                        fast: None,
+                    }),
+                    supports_thinking: None,
+                    supports_vision: None,
+                    provider_info: None,
+                })
             })
             .collect();
         models.sort_by(|a, b| a.id.cmp(&b.id));
         models
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CatalogMeta {
+    pub context: u32,
+    pub output: u32,
+    pub input_price: f64,
+    pub output_price: f64,
+    pub cache_read: f64,
+    pub cache_write: f64,
+}
+
+#[derive(Clone)]
+pub enum Authentication {
+    /// User has a configured API key — all models accessible
+    KeyBased(ResolvedAuth),
+    /// No real key configured — only free/zero-cost models via public fallback
+    OpenCodeFreeKey(ResolvedAuth),
+    /// No authentication available
+    NoAuth,
+}
+
+struct CatalogData {
+    providers: HashMap<String, ProviderData>,
+    enable_free_models: bool,
+    state_dir: StateDir,
+}
+
+fn enable_free_models_config() -> bool {
+    maki_config::providers::ProvidersConfig::load()
+        .get("opencode")
+        .and_then(|d| d.enable_free_models)
+        .unwrap_or(false)
+}
+
+impl CatalogData {
+    fn from_index(index: CatalogIndex, enable_free_models: bool, state_dir: &StateDir) -> Self {
+        let mut providers = HashMap::new();
+
+        for (provider_id, provider) in index {
+            if !ALLOWED_NPM.contains(&provider.npm.as_str()) {
+                debug!(npm = %provider.npm, "skipping provider: unsupported npm package");
+                continue;
+            }
+            if BLOCKED_PROVIDER_IN_CATALOG.contains(&provider_id.as_str()) {
+                debug!(
+                    provider = &provider_id,
+                    "skipping providers from the catalog"
+                );
+                continue;
+            }
+
+            let Some(_base_url) = &provider.api else {
+                debug!(provider = %provider_id, "skipping: no API URL in catalog");
+                continue;
+            };
+
+            if builtin_provider(&provider_id).is_some() {
+                debug!(
+                    provider = &provider_id,
+                    "skipping providers supported by built-in providers"
+                );
+                continue;
+            }
+
+            let api_format = determine_catalog_format(&provider.npm);
+
+            let mut models = HashMap::new();
+            for (model_id, model_data) in &provider.models {
+                let input_price = model_data
+                    .cost
+                    .as_ref()
+                    .and_then(|c| c.input)
+                    .unwrap_or(0.0);
+                let output_price = model_data
+                    .cost
+                    .as_ref()
+                    .and_then(|c| c.output)
+                    .unwrap_or(0.0);
+
+                let context = model_data
+                    .limit
+                    .as_ref()
+                    .and_then(|l| l.context)
+                    .unwrap_or(128_000);
+                let output = model_data
+                    .limit
+                    .as_ref()
+                    .and_then(|l| l.output)
+                    .unwrap_or(64_000);
+
+                let cache_read = model_data
+                    .cost
+                    .as_ref()
+                    .and_then(|c| c.cache_read)
+                    .unwrap_or(0.0);
+                let cache_write = model_data
+                    .cost
+                    .as_ref()
+                    .and_then(|c| c.cache_write)
+                    .unwrap_or(0.0);
+
+                models.insert(
+                    model_id.clone(),
+                    CatalogMeta {
+                        context,
+                        output,
+                        input_price,
+                        output_price,
+                        cache_read,
+                        cache_write,
+                    },
+                );
+            }
+
+            let model_count = models.len();
+            let provider_data =
+                ProviderData::new(provider_id.clone(), &provider, api_format, models);
+            providers.insert(provider_id.clone(), provider_data);
+
+            debug!(
+                provider = %provider_id,
+                models = model_count,
+                format = %provider.npm,
+                "catalog provider registered",
+            );
+        }
+
+        Self {
+            providers,
+            enable_free_models,
+            state_dir: state_dir.clone(),
+        }
+    }
+
+    fn lookup(
+        &self,
+        provider: &str,
+        model_id: &str,
+    ) -> Result<(&CatalogMeta, &ProviderData), AgentError> {
+        let provider_data = self
+            .providers
+            .get(provider)
+            .ok_or_else(|| config_error(format!("provider '{provider}' not found in catalog")))?;
+        let meta = provider_data.models.get(model_id).ok_or_else(|| {
+            config_error(format!(
+                "model '{provider}/{model_id}' not found in catalog"
+            ))
+        })?;
+        Ok((meta, provider_data))
+    }
+
+    fn all_models(&self) -> Vec<ModelInfo> {
+        let mut models: Vec<ModelInfo> = self
+            .providers
+            .values()
+            .flat_map(|provider_data| {
+                provider_data.available_models(&self.state_dir, self.enable_free_models)
+            })
+            .collect();
+        models.sort_by(|a, b| a.id.cmp(&b.id));
+        models
+    }
+
+    fn all_providers(&self) -> Vec<ProviderData> {
+        let mut providers: Vec<ProviderData> = self.providers.values().cloned().collect();
+        providers.sort_by_key(|p| p.display_name.to_lowercase());
+        providers
     }
 }
 
@@ -204,9 +430,12 @@ pub struct Opencode {
 
 static CATALOG: OnceLock<Mutex<CatalogData>> = OnceLock::new();
 
+fn init_catalog_if_needed() -> &'static Mutex<CatalogData> {
+    CATALOG.get_or_init(|| Mutex::new(init_catalog_blocking()))
+}
+
 impl Opencode {
     fn new_impl(timeouts: super::Timeouts, auth: Option<Arc<Mutex<ResolvedAuth>>>) -> Self {
-        CATALOG.get_or_init(|| Mutex::new(init_catalog_blocking()));
         Self {
             client: http_client(timeouts),
             chat_compat: OpenAiCompatProvider::new(&CATALOG_CHAT_CONFIG, timeouts),
@@ -230,7 +459,8 @@ impl Opencode {
     }
 
     async fn do_list_models(&self) -> Result<Vec<ModelInfo>, AgentError> {
-        Ok(CATALOG.get().unwrap().lock().unwrap().all_models())
+        // Delegate to a background thread
+        Ok(smol::unblock(|| init_catalog_if_needed().lock().unwrap().all_models()).await)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -304,6 +534,31 @@ impl Opencode {
             Err(AgentError::from_response(response).await)
         }
     }
+
+    async fn lookup(
+        &self,
+        sub_provider: &str,
+        actual_id: &str,
+    ) -> Result<(CatalogMeta, EndpointType, ResolvedAuth), AgentError> {
+        let sub_provider = sub_provider.to_string();
+        let actual_id = actual_id.to_string();
+        let auth_override = self.auth.clone();
+        smol::unblock(move || {
+            let guard = init_catalog_if_needed().lock().unwrap();
+            let (meta, provider_data) = guard.lookup(&sub_provider, &actual_id)?;
+            let state_dir = &guard.state_dir;
+            // Dynamic provider auth (e.g. from Lua) overrides the opencode route
+            let auth = provider_data
+                .resolve_auth_with_override(auth_override.as_ref(), state_dir)
+                .ok_or_else(|| {
+                    config_error(format!(
+                        "authentication required for provider '{sub_provider}', run `maki auth login {sub_provider}`"
+                    ))
+                })?;
+            Ok((meta.clone(), provider_data.api_format, auth))
+        })
+        .await
+    }
 }
 
 impl Provider for Opencode {
@@ -324,16 +579,7 @@ impl Provider for Opencode {
             let (sub_provider, actual_id) =
                 model_id.split_once('/').unwrap_or(("opencode", model_id));
 
-            let (meta, auth) = {
-                let guard = CATALOG.get().unwrap().lock().unwrap();
-                let (meta, auth) = guard.lookup(&format!("{sub_provider}/{actual_id}"))?;
-                // Dynamic provider auth (e.g. from Lua) overrides the opencode route
-                let auth = match (&self.auth, meta.provider_id.as_str()) {
-                    (Some(provider_auth), "opencode") => provider_auth.lock().unwrap().clone(),
-                    _ => auth,
-                };
-                (meta, auth)
-            };
+            let (meta, api_format, auth) = self.lookup(sub_provider, actual_id).await?;
 
             let mut buf = String::new();
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
@@ -345,7 +591,7 @@ impl Provider for Opencode {
                 ..model_for_stream
             };
 
-            match meta.api_format {
+            match api_format {
                 EndpointType::ChatCompletions => {
                     self.handle_catalog_chat_completions(
                         &model, messages, system, tools, event_tx, &auth, &opts,
@@ -369,6 +615,31 @@ impl Provider for Opencode {
     fn reload_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
         Box::pin(async { Ok(()) })
     }
+}
+
+fn config_error(message: String) -> AgentError {
+    AgentError::Config { message }
+}
+
+/// Returns the list of all providers in alphabetical order.
+pub fn catalog_providers() -> Vec<ProviderData> {
+    let guard = init_catalog_if_needed().lock().unwrap();
+
+    guard.all_providers()
+}
+
+/// Returns the list of catalog providers only if the catalog has already been downloaded.
+/// Does NOT trigger downloading.
+pub fn catalog_providers_if_available() -> Option<Vec<ProviderData>> {
+    let catalog = CATALOG.get()?;
+    let guard = catalog.lock().ok()?;
+    Some(guard.all_providers())
+}
+
+/// Returns the ProviderData for a specific catalog provider, if found.
+pub fn catalog_provider(provider_id: &str) -> Option<ProviderData> {
+    let guard = init_catalog_if_needed().lock().ok()?;
+    guard.providers.get(provider_id).cloned()
 }
 
 // --- Catalog helpers ---
@@ -436,26 +707,26 @@ async fn fetch_remote_catalog_async(client: &HttpClient) -> Result<CatalogIndex,
 
     let mut resp = client.send_async(request).await.map_err(|e| {
         warn!(error = %e, CATALOG_URL, "failed to fetch catalog");
-        AgentError::Config {
-            message: format!("failed to fetch catalog from {CATALOG_URL}: {e}"),
-        }
+        config_error(format!("failed to fetch catalog from {CATALOG_URL}: {e}"))
     })?;
 
     let status = resp.status().as_u16();
     if status != 200 {
+        // Drain the body so isahc can reuse the connection
+        let _ = resp.text().await;
         return Err(AgentError::Api {
             status,
             message: format!("catalog fetch returned HTTP {status}"),
         });
     }
 
-    let text = resp.text().await.map_err(|e| AgentError::Config {
-        message: format!("failed to read catalog response body: {e}"),
-    })?;
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| config_error(format!("failed to read catalog response body: {e}")))?;
 
-    serde_json::from_str(&text).map_err(|e| AgentError::Config {
-        message: format!("failed to parse catalog JSON: {e}"),
-    })
+    serde_json::from_str(&text)
+        .map_err(|e| config_error(format!("failed to parse catalog JSON: {e}")))
 }
 
 fn determine_catalog_format(npm: &str) -> EndpointType {
@@ -467,113 +738,25 @@ fn determine_catalog_format(npm: &str) -> EndpointType {
 
 const ALLOWED_NPM: &[&str] = &["@ai-sdk/openai-compatible", "@ai-sdk/anthropic"];
 
-fn catalog_to_data(index: CatalogIndex, enable_free_models: bool) -> CatalogData {
-    let mut entries: HashMap<ModelWithProvider, CatalogMeta> = HashMap::new();
-    let mut auths = HashMap::new();
-
-    for (provider_id, provider) in &index {
-        if !ALLOWED_NPM.contains(&provider.npm.as_str()) {
-            debug!(npm = %provider.npm, "skipping provider: unsupported npm package");
-            continue;
-        }
-
-        let Some(_base_url) = &provider.api else {
-            debug!(provider = %provider_id, "skipping: no API URL in catalog");
-            continue;
-        };
-
-        let has_key = provider.has_api_key();
-        let auth = provider.build_auth();
-
-        let mut model_count = 0u32;
-        for (model_id, model_data) in &provider.models {
-            let input_price = model_data
-                .cost
-                .as_ref()
-                .and_then(|c| c.input)
-                .unwrap_or(0.0);
-            let output_price = model_data
-                .cost
-                .as_ref()
-                .and_then(|c| c.output)
-                .unwrap_or(0.0);
-            let is_free = input_price == 0.0 && output_price == 0.0;
-
-            if is_free && !enable_free_models {
-                continue;
-            }
-
-            if !(has_key || provider_id == "opencode" && is_free) {
-                continue;
-            }
-
-            let api_format = determine_catalog_format(&provider.npm);
-
-            let context = model_data
-                .limit
-                .as_ref()
-                .and_then(|l| l.context)
-                .unwrap_or(128_000);
-            let output = model_data
-                .limit
-                .as_ref()
-                .and_then(|l| l.output)
-                .unwrap_or(64_000);
-
-            let cache_read = model_data
-                .cost
-                .as_ref()
-                .and_then(|c| c.cache_read)
-                .unwrap_or(0.0);
-            let cache_write = model_data
-                .cost
-                .as_ref()
-                .and_then(|c| c.cache_write)
-                .unwrap_or(0.0);
-
-            let key = (provider_id.clone(), model_id.clone());
-            entries.insert(
-                key,
-                CatalogMeta {
-                    provider_id: provider_id.clone(),
-                    api_format,
-                    context,
-                    output,
-                    input_price,
-                    output_price,
-                    cache_read,
-                    cache_write,
-                },
-            );
-            model_count += 1;
-        }
-
-        if model_count > 0 {
-            auths.insert(provider_id.clone(), auth);
-            debug!(
-                provider = %provider_id,
-                models = model_count,
-                has_key,
-                "catalog provider registered",
-            );
-        }
-    }
-
-    CatalogData { entries, auths }
-}
-
+// Try cache first, then fetch from remote
 fn init_catalog_blocking() -> CatalogData {
-    let enable_free_models = maki_config::providers::ProvidersConfig::load()
-        .get("opencode")
-        .and_then(|d| d.enable_free_models)
-        .unwrap_or(false);
-    // Try cache first (fast, no network)
+    let enable_free_models = enable_free_models_config();
+    let state_dir = StateDir::resolve();
+    let state_dir = match state_dir {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(error = %e, "failed to resolve state dir");
+            return CatalogData {
+                providers: HashMap::new(),
+                enable_free_models: false,
+                state_dir: StateDir::from_path("".into()),
+            };
+        }
+    };
     if let Some(index) = smol::block_on(load_cached_catalog_async()) {
-        debug!("using cached catalog");
-        return catalog_to_data(index, enable_free_models);
+        return CatalogData::from_index(index, enable_free_models, &state_dir);
     }
 
-    // Fetch from remote (blocks the current thread)
     let client = isahc::HttpClient::builder()
         .connect_timeout(Duration::from_secs(10))
         .low_speed_timeout(1, Duration::from_secs(30))
@@ -583,13 +766,14 @@ fn init_catalog_blocking() -> CatalogData {
     match smol::block_on(fetch_remote_catalog_async(&client)) {
         Ok(index) => {
             smol::block_on(save_cached_catalog_async(&index));
-            catalog_to_data(index, enable_free_models)
+            CatalogData::from_index(index, enable_free_models, &state_dir)
         }
         Err(e) => {
             warn!(error = %e, "catalog fetch failed, using empty catalog");
             CatalogData {
-                entries: HashMap::new(),
-                auths: HashMap::new(),
+                providers: HashMap::new(),
+                enable_free_models: false,
+                state_dir,
             }
         }
     }
@@ -598,6 +782,12 @@ fn init_catalog_blocking() -> CatalogData {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn temp_state_dir() -> (tempfile::TempDir, StateDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_dir = StateDir::from_path(tmp.path().to_path_buf());
+        (tmp, state_dir)
+    }
 
     #[test]
     fn catalog_format_messages_for_anthropic() {
@@ -714,32 +904,53 @@ mod tests {
 
     #[test]
     fn catalog_provider_resolve_api_key_from_env() {
+        let (_tmp, state_dir) = temp_state_dir();
         let provider = CatalogProvider {
             name: "Test".into(),
-            env: vec!["MAKI_TEST_UNUSED_VAR_1".into()],
+            env: vec!["MAKI_TEST_UNUSED_VAR_1"]
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect(),
             npm: "@ai-sdk/openai".into(),
             api: None,
             models: HashMap::new(),
         };
-        // No env var set — returns empty (no OPENCODE_API_KEY in env)
-        assert!(provider.resolve_api_key().is_empty());
+        let provider_data = ProviderData::new(
+            "test".into(),
+            &provider,
+            EndpointType::ChatCompletions,
+            HashMap::new(),
+        );
+        // No env var set — returns None (no OPENCODE_API_KEY in env)
+        assert!(provider_data.resolve_api_key(&state_dir).is_none());
     }
 
     #[test]
     fn catalog_provider_resolve_api_key_anthropic_fallback() {
+        let (_tmp, state_dir) = temp_state_dir();
         let provider = CatalogProvider {
             name: "Anthropic".into(),
-            env: vec!["ANTHROPIC_SECRET_KEY".into()],
+            env: vec!["ANTHROPIC_SECRET_KEY"]
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect(),
             npm: "@ai-sdk/anthropic".into(),
             api: None,
             models: HashMap::new(),
         };
+        let provider_data = ProviderData::new(
+            "anthropic".into(),
+            &provider,
+            EndpointType::Messages,
+            HashMap::new(),
+        );
         // ANTHROPIC_SECRET_KEY is not set.
-        assert!(provider.resolve_api_key().is_empty());
+        assert!(provider_data.resolve_api_key(&state_dir).is_none());
     }
 
     #[test]
-    fn catalog_provider_build_auth_bearer_default() {
+    fn catalog_provider_build_auth_no_key_returns_none() {
+        let (_tmp, state_dir) = temp_state_dir();
         let provider = CatalogProvider {
             name: "Test".into(),
             env: vec![],
@@ -747,29 +958,113 @@ mod tests {
             api: None,
             models: HashMap::new(),
         };
-        let auth = provider.build_auth();
-        assert_eq!(auth.headers[0].0, "authorization");
-        assert_eq!(auth.headers[0].1, "Bearer ");
-        assert_eq!(auth.base_url.as_deref(), None);
+        let provider_data = ProviderData::new(
+            "test".into(),
+            &provider,
+            EndpointType::ChatCompletions,
+            HashMap::new(),
+        );
+        // No env vars and no OPENCODE_API_KEY fallback — no auth
+        assert!(matches!(
+            provider_data.build_auth(&state_dir),
+            Authentication::NoAuth
+        ));
+    }
+
+    #[test]
+    fn catalog_provider_build_auth_public_fallback() {
+        let (_tmp, state_dir) = temp_state_dir();
+        let provider = CatalogProvider {
+            name: "Test".into(),
+            env: vec!["OPENCODE_API_KEY"]
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect(),
+            npm: "@ai-sdk/openai-compatible".into(),
+            api: None,
+            models: HashMap::new(),
+        };
+        let provider_data = ProviderData::new(
+            "opencode".into(),
+            &provider,
+            EndpointType::ChatCompletions,
+            HashMap::new(),
+        );
+        let auth = provider_data.build_auth(&state_dir);
+        match auth {
+            Authentication::OpenCodeFreeKey(resolved) => {
+                assert_eq!(resolved.headers[0].0, "authorization");
+                assert_eq!(resolved.headers[0].1, "Bearer public");
+            }
+            _ => panic!("expected OpenCodeFreeKey"),
+        }
+    }
+
+    #[test]
+    fn catalog_provider_build_auth_key_based() {
+        let (_tmp, state_dir) = temp_state_dir();
+        unsafe { std::env::set_var("MAKI_TEST_AUTH_KEY", "sk-real-key") };
+        let provider = CatalogProvider {
+            name: "Test".into(),
+            env: vec!["MAKI_TEST_AUTH_KEY"]
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect(),
+            npm: "@ai-sdk/openai-compatible".into(),
+            api: None,
+            models: HashMap::new(),
+        };
+        let provider_data = ProviderData::new(
+            "test".into(),
+            &provider,
+            EndpointType::ChatCompletions,
+            HashMap::new(),
+        );
+        let auth = provider_data.build_auth(&state_dir);
+        match auth {
+            Authentication::KeyBased(resolved) => {
+                assert_eq!(resolved.headers[0].0, "authorization");
+                assert_eq!(resolved.headers[0].1, "Bearer sk-real-key");
+            }
+            _ => panic!("expected KeyBased"),
+        }
+        unsafe { std::env::remove_var("MAKI_TEST_AUTH_KEY") };
     }
 
     #[test]
     fn catalog_provider_build_auth_x_api_key() {
+        let (_tmp, state_dir) = temp_state_dir();
+        unsafe { std::env::set_var("MAKI_TEST_ANTHROPIC_KEY", "sk-ant-key") };
         let provider = CatalogProvider {
             name: "Anthropic".into(),
-            env: vec![],
+            env: vec!["MAKI_TEST_ANTHROPIC_KEY"]
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect(),
             npm: "@ai-sdk/anthropic".into(),
             api: None,
             models: HashMap::new(),
         };
-        let auth = provider.build_auth();
-        assert_eq!(auth.headers[0].0, "x-api-key");
-        assert_eq!(auth.headers[0].1, "");
-        assert_eq!(auth.base_url.as_deref(), None);
+        let provider_data = ProviderData::new(
+            "anthropic".into(),
+            &provider,
+            EndpointType::Messages,
+            HashMap::new(),
+        );
+        let auth = provider_data.build_auth(&state_dir);
+        match auth {
+            Authentication::KeyBased(resolved) => {
+                assert_eq!(resolved.headers[0].0, "x-api-key");
+                assert_eq!(resolved.headers[0].1, "sk-ant-key");
+            }
+            _ => panic!("expected KeyBased"),
+        }
+        unsafe { std::env::remove_var("MAKI_TEST_ANTHROPIC_KEY") };
     }
 
     #[test]
     fn catalog_to_data_filters_nonfree_without_key() {
+        let (_tmp, state_dir) = temp_state_dir();
         let mut models = HashMap::new();
         models.insert(
             "paid-model".into(),
@@ -810,17 +1105,15 @@ mod tests {
             },
         );
 
-        let result = catalog_to_data(providers, true);
-        // Without env var, NO models should pass (not even free ones for non-opencode)
-        assert!(
-            result.entries.is_empty(),
-            "should be empty: {:?}",
-            result.entries.keys()
-        );
+        let result = CatalogData::from_index(providers, true, &state_dir);
+        // No key filter — all models pass regardless of key status
+        let vendor = result.providers.get("some-vendor").unwrap();
+        assert_eq!(vendor.models.len(), 2, "all models included");
     }
 
     #[test]
     fn catalog_to_data_opencode_free_models_without_key() {
+        let (_tmp, state_dir) = temp_state_dir();
         let mut models = HashMap::new();
         models.insert(
             "paid-model".into(),
@@ -854,32 +1147,27 @@ mod tests {
             "opencode".into(),
             CatalogProvider {
                 name: "Opencode".into(),
-                env: vec!["MAKI_TEST_OPENCODE_FREE_60924".into()],
+                env: vec!["OPENCODE_API_KEY".into()],
                 npm: "@ai-sdk/openai-compatible".into(),
                 api: Some("https://opencode.ai/zen/v1".into()),
                 models,
             },
         );
 
-        let result = catalog_to_data(providers, true);
-        // Without key set, has_api_key is false, so only free models pass
-        // but has_api_key is false, so only free models pass
-        assert!(
-            result
-                .entries
-                .contains_key(&("opencode".into(), "free-model".into()))
-        );
-        assert!(
-            !result
-                .entries
-                .contains_key(&("opencode".into(), "paid-model".into()))
-        );
-        // Route should exist
-        assert!(result.auths.contains_key("opencode"));
+        let result = CatalogData::from_index(providers, true, &state_dir);
+        // No key filter — all models pass regardless of key status
+        let opencode = result.providers.get("opencode").unwrap();
+        assert_eq!(opencode.models.len(), 2, "all models included");
+        // Public fallback auth registered
+        assert!(matches!(
+            opencode.build_auth(&state_dir),
+            Authentication::OpenCodeFreeKey(_)
+        ));
     }
 
     #[test]
     fn catalog_to_data_opencode_all_models_with_key() {
+        let (_tmp, state_dir) = temp_state_dir();
         let mut models = HashMap::new();
         models.insert(
             "paid-model".into(),
@@ -921,24 +1209,20 @@ mod tests {
         );
 
         unsafe { std::env::set_var("MAKI_TEST_OPENCODE_ALL_81274", "real-key") };
-        let result = catalog_to_data(providers, true);
-        unsafe { std::env::remove_var("MAKI_TEST_OPENCODE_ALL_81274") };
+        let result = CatalogData::from_index(providers, true, &state_dir);
 
         // With key set, has_api_key is true, so all models pass
-        assert!(
-            result
-                .entries
-                .contains_key(&("opencode".into(), "free-model".into()))
-        );
-        assert!(
-            result
-                .entries
-                .contains_key(&("opencode".into(), "paid-model".into()))
-        );
-        assert!(result.auths.contains_key("opencode"));
+        let opencode = result.providers.get("opencode").unwrap();
+        assert!(opencode.models.contains_key("free-model"));
+        assert!(opencode.models.contains_key("paid-model"));
+        assert!(matches!(
+            opencode.build_auth(&state_dir),
+            Authentication::KeyBased(_)
+        ));
+        unsafe { std::env::remove_var("MAKI_TEST_OPENCODE_ALL_81274") };
     }
 
-    fn opencode_catalog_with_free_and_paid(env_var: &str) -> CatalogIndex {
+    fn opencode_catalog_with_free_and_paid(_env_var: &str) -> CatalogIndex {
         let mut models = HashMap::new();
         models.insert(
             "paid-model".into(),
@@ -971,7 +1255,7 @@ mod tests {
             "opencode".into(),
             CatalogProvider {
                 name: "Opencode".into(),
-                env: vec![env_var.into()],
+                env: vec![],
                 npm: "@ai-sdk/openai-compatible".into(),
                 api: Some("https://opencode.ai/zen/v1".into()),
                 models,
@@ -980,45 +1264,47 @@ mod tests {
         providers
     }
 
-    const DISABLE_FREE_TEST_KEY: &str = "MAKI_TEST_OPENCODE_DISABLE_FREE_94421";
-
     #[test]
     fn catalog_to_data_opencode_hides_free_models_when_disabled() {
-        unsafe { std::env::set_var(DISABLE_FREE_TEST_KEY, "real-key") };
-        let index = opencode_catalog_with_free_and_paid(DISABLE_FREE_TEST_KEY);
-        let result = catalog_to_data(index, false);
-        unsafe { std::env::remove_var(DISABLE_FREE_TEST_KEY) };
+        let (_tmp, state_dir) = temp_state_dir();
+        let index = opencode_catalog_with_free_and_paid("unused");
+        let result = CatalogData::from_index(index, false, &state_dir);
 
-        assert!(
-            !result
-                .entries
-                .contains_key(&("opencode".into(), "free-model".into())),
-            "free model should be hidden when enable_free_models=false: {:?}",
-            result.entries.keys()
-        );
-        assert!(
-            result
-                .entries
-                .contains_key(&("opencode".into(), "paid-model".into()))
-        );
-        assert!(result.auths.contains_key("opencode"));
+        // All models are in entries (filtering happens in all_models)
+        let opencode = result.providers.get("opencode").unwrap();
+        assert!(opencode.models.contains_key("free-model"));
+        assert!(opencode.models.contains_key("paid-model"));
+        // Provider ID is "opencode" so slug becomes "opencode" -> OpenCodeFreeKey fallback
+        assert!(matches!(
+            opencode.build_auth(&state_dir),
+            Authentication::OpenCodeFreeKey(_)
+        ));
+        // all_models with OpenCodeFreeKey only shows free models; with enable_free_models=false, no models shown
+        assert_eq!(result.all_models().len(), 0);
     }
 
     #[test]
     fn catalog_to_data_opencode_no_models_without_key_when_disabled() {
-        let index = opencode_catalog_with_free_and_paid(DISABLE_FREE_TEST_KEY);
-        let result = catalog_to_data(index, false);
+        let (_tmp, state_dir) = temp_state_dir();
+        let index = opencode_catalog_with_free_and_paid("unused");
+        let result = CatalogData::from_index(index, false, &state_dir);
 
-        assert!(
-            result.entries.is_empty(),
-            "no models should be listed without a key when enable_free_models=false: {:?}",
-            result.entries.keys()
-        );
-        assert!(!result.auths.contains_key("opencode"));
+        // All models are in entries (filtering happens in all_models)
+        let opencode = result.providers.get("opencode").unwrap();
+        assert!(opencode.models.contains_key("free-model"));
+        assert!(opencode.models.contains_key("paid-model"));
+        // Provider ID is "opencode" so slug becomes "opencode" -> OpenCodeFreeKey fallback
+        assert!(matches!(
+            opencode.build_auth(&state_dir),
+            Authentication::OpenCodeFreeKey(_)
+        ));
+        // all_models filters both free (enable_free_models=false) and paid (OpenCodeFreeKey only shows free)
+        assert_eq!(result.all_models().len(), 0);
     }
 
     #[test]
     fn catalog_to_data_all_models_with_key() {
+        let (_tmp, state_dir) = temp_state_dir();
         let mut models = HashMap::new();
         models.insert(
             "cheap".into(),
@@ -1059,25 +1345,31 @@ mod tests {
             },
         );
 
-        // Set the env var so has_key = true
         unsafe { std::env::set_var("MAKI_TEST_VENDOR_KEY_81274", "test-key") };
-        let result = catalog_to_data(providers, true);
+        let result = CatalogData::from_index(providers, true, &state_dir);
         unsafe { std::env::remove_var("MAKI_TEST_VENDOR_KEY_81274") };
 
         assert!(
             result
-                .entries
-                .contains_key(&("some-vendor".into(), "cheap".into()))
+                .providers
+                .get("some-vendor")
+                .unwrap()
+                .models
+                .contains_key("cheap")
         );
         assert!(
             result
-                .entries
-                .contains_key(&("some-vendor".into(), "freebie".into()))
+                .providers
+                .get("some-vendor")
+                .unwrap()
+                .models
+                .contains_key("freebie")
         );
     }
 
     #[test]
     fn catalog_to_data_skips_providers_without_api_url() {
+        let (_tmp, state_dir) = temp_state_dir();
         let mut providers = HashMap::new();
         providers.insert(
             "no-api".into(),
@@ -1090,13 +1382,13 @@ mod tests {
             },
         );
 
-        let result = catalog_to_data(providers, true);
-        assert!(result.entries.is_empty());
-        assert!(result.auths.is_empty());
+        let result = CatalogData::from_index(providers, true, &state_dir);
+        assert!(result.providers.is_empty());
     }
 
     #[test]
     fn catalog_to_data_handles_model_id_collisions() {
+        let (_tmp, state_dir) = temp_state_dir();
         let mut models: HashMap<String, CatalogModel> = HashMap::new();
         models.insert(
             "shared-model".into(),
@@ -1123,7 +1415,7 @@ mod tests {
             "opencode".into(),
             CatalogProvider {
                 name: "Opencode".into(),
-                env: vec![],
+                env: vec!["OPENCODE_API_KEY".into()],
                 npm: "@ai-sdk/openai-compatible".into(),
                 api: Some("https://opencode.ai/zen/v1".into()),
                 models: models.clone(),
@@ -1143,30 +1435,37 @@ mod tests {
         );
 
         unsafe { std::env::set_var("MAKI_TEST_OTHER_KEY_COLLISION", "key") };
-        let result = catalog_to_data(providers, true);
+        let result = CatalogData::from_index(providers, true, &state_dir);
         unsafe { std::env::remove_var("MAKI_TEST_OTHER_KEY_COLLISION") };
 
         // Both providers' entries are preserved
         assert!(
             result
-                .entries
-                .contains_key(&("opencode".into(), "shared-model".into()))
+                .providers
+                .get("opencode")
+                .unwrap()
+                .models
+                .contains_key("shared-model")
         );
         assert!(
             result
-                .entries
-                .contains_key(&("other-vendor".into(), "shared-model".into()))
+                .providers
+                .get("other-vendor")
+                .unwrap()
+                .models
+                .contains_key("shared-model")
         );
-        assert_eq!(result.entries.len(), 2);
+        assert_eq!(result.providers.len(), 2);
 
         // lookup prefers the "opencode" provider
-        // lookup expects \"provider/model_id\" format
-        let (meta, _) = result.lookup("opencode/shared-model").unwrap();
-        assert_eq!(meta.provider_id, "opencode");
+        // lookup expects "provider/model_id" format
+        let (_meta, provider_data) = result.lookup("opencode", "shared-model").unwrap();
+        assert_eq!(provider_data.slug, "opencode");
     }
 
     #[test]
     fn lookup_finds_opencode_own_models() {
+        let (_tmp, state_dir) = temp_state_dir();
         let mut models = HashMap::new();
         models.insert(
             "opus".into(),
@@ -1193,13 +1492,14 @@ mod tests {
             },
         );
 
-        let data = catalog_to_data(providers, true);
-        let (meta, _) = data.lookup("opencode/opus").unwrap();
-        assert_eq!(meta.provider_id, "opencode");
+        let data = CatalogData::from_index(providers, true, &state_dir);
+        let (_meta, provider_data) = data.lookup("opencode", "opus").unwrap();
+        assert_eq!(provider_data.slug, "opencode");
     }
 
     #[test]
     fn lookup_finds_model_id_with_slashes() {
+        let (_tmp, state_dir) = temp_state_dir();
         let mut models = HashMap::new();
         models.insert(
             "openai/gpt-oss-120b".into(),
@@ -1227,16 +1527,17 @@ mod tests {
         );
 
         unsafe { std::env::set_var("MAKI_TEST_NVIDIA_KEY_LOOKUP", "key") };
-        let data = catalog_to_data(providers, true);
+        let data = CatalogData::from_index(providers, true, &state_dir);
         unsafe { std::env::remove_var("MAKI_TEST_NVIDIA_KEY_LOOKUP") };
 
         // Entry is stored as ("nvidia", "openai/gpt-oss-120b")
-        let (meta, _) = data.lookup("nvidia/openai/gpt-oss-120b").unwrap();
-        assert_eq!(meta.provider_id, "nvidia");
+        let (_meta, provider_data) = data.lookup("nvidia", "openai/gpt-oss-120b").unwrap();
+        assert_eq!(provider_data.slug, "nvidia");
     }
 
     #[test]
     fn lookup_spec_is_sub_provider_plus_model_id() {
+        let (_tmp, state_dir) = temp_state_dir();
         // Simulates the stream_message pattern:
         // lookup key = "{sub_provider}/{model.id}"
         // e.g. "nvidia/openai/gpt-oss-120b"
@@ -1267,19 +1568,20 @@ mod tests {
         );
 
         unsafe { std::env::set_var("MAKI_TEST_NVIDIA_DIRECT", "key") };
-        let data = catalog_to_data(providers, true);
+        let data = CatalogData::from_index(providers, true, &state_dir);
         unsafe { std::env::remove_var("MAKI_TEST_NVIDIA_DIRECT") };
 
         // The lookup key constructed by stream_message:
         // format!("{}/{}", sub_provider, model.id)
         // = "nvidia/openai/gpt-oss-120b"
-        let key = format!("{}/{}", "nvidia", "openai/gpt-oss-120b");
-        let (meta, _) = data.lookup(&key).unwrap();
-        assert_eq!(meta.provider_id, "nvidia");
+        let _key = format!("{}/{}", "nvidia", "openai/gpt-oss-120b");
+        let (_meta, provider_data) = data.lookup("nvidia", "openai/gpt-oss-120b").unwrap();
+        assert_eq!(provider_data.slug, "nvidia");
     }
 
     #[test]
     fn lookup_nested_model_id_uses_sub_provider_key() {
+        let (_tmp, state_dir) = temp_state_dir();
         let mut models = HashMap::new();
         models.insert(
             "deepseek-ai/DeepSeek-R1".into(),
@@ -1307,13 +1609,138 @@ mod tests {
         );
 
         unsafe { std::env::set_var("MAKI_TEST_FIREWORKS_DEEP", "key") };
-        let data = catalog_to_data(providers, true);
+        let data = CatalogData::from_index(providers, true, &state_dir);
         unsafe { std::env::remove_var("MAKI_TEST_FIREWORKS_DEEP") };
 
         // stream_message constructs key as "{sub_provider}/{model.id}"
         // = "fireworks/deepseek-ai/DeepSeek-R1"
-        let key = format!("{}/{}", "fireworks", "deepseek-ai/DeepSeek-R1");
-        let (meta, _) = data.lookup(&key).unwrap();
-        assert_eq!(meta.provider_id, "fireworks");
+        let _key = format!("{}/{}", "fireworks", "deepseek-ai/DeepSeek-R1");
+        let (_meta, provider_data) = data.lookup("fireworks", "deepseek-ai/DeepSeek-R1").unwrap();
+        assert_eq!(provider_data.slug, "fireworks");
+    }
+
+    #[test]
+    fn catalog_all_models_filters_keyless_providers() {
+        let (_tmp, state_dir) = temp_state_dir();
+        let auth_dir = state_dir.path().join("auth");
+        std::fs::create_dir_all(&auth_dir).unwrap();
+        std::fs::write(auth_dir.join("keyed.json"), r#"{"api_key": "sk-abc123"}"#).unwrap();
+
+        let mut providers: CatalogIndex = HashMap::new();
+        providers.insert(
+            "keyed".into(),
+            CatalogProvider {
+                name: "Keyed".into(),
+                env: vec![],
+                npm: "@ai-sdk/openai-compatible".into(),
+                api: Some("https://keyed.api/v1".into()),
+                models: HashMap::from([(
+                    "m1".into(),
+                    CatalogModel {
+                        limit: None,
+                        cost: None,
+                        provider: None,
+                    },
+                )]),
+            },
+        );
+        providers.insert(
+            "keyless".into(),
+            CatalogProvider {
+                name: "Keyless".into(),
+                env: vec![],
+                npm: "@ai-sdk/openai-compatible".into(),
+                api: Some("https://keyless.api/v1".into()),
+                models: HashMap::from([(
+                    "m2".into(),
+                    CatalogModel {
+                        limit: None,
+                        cost: Some(CatalogCost {
+                            input: Some(5.0),
+                            output: Some(10.0),
+                            cache_read: None,
+                            cache_write: None,
+                        }),
+                        provider: None,
+                    },
+                )]),
+            },
+        );
+
+        let data = CatalogData::from_index(providers, true, &state_dir);
+
+        // Entries include both providers
+        assert_eq!(data.providers.len(), 2);
+
+        // all_models should only include the keyed provider's model
+        let models = data.all_models();
+        assert_eq!(
+            models.len(),
+            1,
+            "should only include models from providers with keys"
+        );
+        assert_eq!(models[0].id, "keyed/m1");
+    }
+
+    #[test]
+    fn catalog_all_models_public_fallback_shows_only_free() {
+        let (_tmp, state_dir) = temp_state_dir();
+        // Provider with OPENCODE_API_KEY in env but no key set gets "public" fallback.
+        // Only free (zero-cost) models should appear in all_models.
+        let mut models = HashMap::new();
+        models.insert(
+            "free-model".into(),
+            CatalogModel {
+                limit: None,
+                cost: Some(CatalogCost {
+                    input: Some(0.0),
+                    output: Some(0.0),
+                    cache_read: None,
+                    cache_write: None,
+                }),
+                provider: None,
+            },
+        );
+        models.insert(
+            "paid-model".into(),
+            CatalogModel {
+                limit: None,
+                cost: Some(CatalogCost {
+                    input: Some(1.0),
+                    output: Some(3.0),
+                    cache_read: None,
+                    cache_write: None,
+                }),
+                provider: None,
+            },
+        );
+
+        let mut providers = HashMap::new();
+        providers.insert(
+            "opencode".into(),
+            CatalogProvider {
+                name: "Opencode".into(),
+                env: vec!["OPENCODE_API_KEY".into()],
+                npm: "@ai-sdk/openai-compatible".into(),
+                api: Some("https://opencode.ai/zen/v1".into()),
+                models,
+            },
+        );
+
+        // No OPENCODE_API_KEY set in env — falls back to "public"
+        let data = CatalogData::from_index(providers, true, &state_dir);
+
+        // Both models are in providers
+        let opencode = data.providers.get("opencode").unwrap();
+        assert_eq!(opencode.models.len(), 2);
+        // But all_models only returns the free one
+        let result = data.all_models();
+        assert_eq!(
+            result.len(),
+            1,
+            "public fallback should only show free models"
+        );
+        assert_eq!(result[0].id, "opencode/free-model");
+        assert_eq!(result[0].pricing.as_ref().unwrap().input, 0.0);
     }
 }

--- a/maki-storage/src/auth.rs
+++ b/maki-storage/src/auth.rs
@@ -49,6 +49,20 @@ pub struct ProviderCredentials {
     pub host: Option<String>,
 }
 
+impl ProviderCredentials {
+    pub fn masked_api_key(&self) -> String {
+        if self.api_key.len() > 8 {
+            format!(
+                "{}...{}",
+                &self.api_key[..4],
+                &self.api_key[self.api_key.len() - 4..]
+            )
+        } else {
+            "****".to_string()
+        }
+    }
+}
+
 pub fn now_millis() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/maki-ui/src/components/login_picker.rs
+++ b/maki-ui/src/components/login_picker.rs
@@ -6,6 +6,8 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Wrap;
 
 use maki_config::providers::{self, Protocol, ProviderDef, ProvidersConfig, slugify};
+use maki_providers::catalog_providers_if_available;
+use maki_storage::StateDir;
 use maki_storage::auth::{
     ProviderCredentials, load_provider_credentials, save_provider_credentials,
 };
@@ -18,6 +20,7 @@ use crate::text_buffer::TextBuffer;
 use crate::theme;
 
 const TITLE: &str = " Login ";
+const CATALOG_UNAVAILABLE_SLUG: &str = "catalog-unavailable";
 
 const PROTOCOLS: &[(&str, &str)] = &[
     ("openai", "OpenAI-compatible"),
@@ -32,11 +35,16 @@ struct ProviderItem {
     has_key: bool,
     has_env: bool,
     configured: bool,
+    section: Option<&'static str>,
 }
 
 impl PickerItem for ProviderItem {
     fn label(&self) -> &str {
         &self.display_name
+    }
+
+    fn section(&self) -> Option<&str> {
+        self.section
     }
 
     fn detail(&self) -> Option<&str> {
@@ -185,12 +193,13 @@ impl LoginPicker {
                     has_key,
                     has_env,
                     configured,
+                    section: None,
                 }
             })
             .collect();
 
         for (slug, def) in &config.providers {
-            if providers::builtin_provider(slug).is_some() {
+            if slug == "opencode" || providers::builtin_provider(slug).is_some() {
                 continue;
             }
             let has_key = load_provider_credentials(&storage, slug).is_some();
@@ -204,6 +213,35 @@ impl LoginPicker {
                 has_key,
                 has_env,
                 configured: false,
+                section: None,
+            });
+        }
+
+        if let Some(catalog) = catalog_providers_if_available() {
+            let state_dir = StateDir::resolve().ok();
+            for cat in catalog {
+                let has_key = state_dir
+                    .as_ref()
+                    .and_then(|s| cat.load_key_from_storage(s))
+                    .is_some();
+                let has_env = cat.env_key_set().is_some();
+                items.push(ProviderItem {
+                    slug: cat.slug.clone(),
+                    display_name: cat.display_name.clone(),
+                    has_key,
+                    has_env,
+                    configured: false,
+                    section: Some("Providers from Models.dev"),
+                });
+            }
+        } else {
+            items.push(ProviderItem {
+                slug: CATALOG_UNAVAILABLE_SLUG.to_string(),
+                display_name: "Models.dev providers (not yet downloaded)".to_string(),
+                has_key: false,
+                has_env: false,
+                configured: false,
+                section: Some("Providers from Models.dev"),
             });
         }
 
@@ -213,6 +251,7 @@ impl LoginPicker {
             has_key: false,
             has_env: false,
             configured: false,
+            section: None,
         });
 
         self.provider_items = items.clone();
@@ -240,7 +279,9 @@ impl LoginPicker {
             Step::Closed => return LoginPickerAction::Consumed,
             Step::PickProvider(picker) => match picker.handle_key(key) {
                 PickerAction::Select(_, item) => {
-                    if item.slug == "custom" {
+                    if item.slug == CATALOG_UNAVAILABLE_SLUG {
+                        StepAction::None
+                    } else if item.slug == "custom" {
                         StepAction::GoCustomName
                     } else {
                         let slug = item.slug.clone();
@@ -252,7 +293,12 @@ impl LoginPicker {
                         if has_plans {
                             StepAction::GoPickPlan { slug }
                         } else {
-                            let display_name = providers::resolve_display_name(&slug, def);
+                            let display_name =
+                                if providers::builtin_provider(&slug).is_some() || def.is_some() {
+                                    providers::resolve_display_name(&slug, def)
+                                } else {
+                                    item.display_name.clone()
+                                };
                             let needs_url =
                                 providers::builtin_provider(&slug).is_some_and(|b| b.needs_url);
                             if needs_url {

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -15,6 +15,7 @@ use maki_config::providers::{
 use maki_config::{load_env_files, load_permissions};
 use maki_lua::PluginHost;
 use maki_providers::provider::fetch_all_models;
+use maki_providers::{ProviderData, catalog_providers};
 use maki_providers::{copilot_auth, dynamic, openai_auth};
 use maki_storage::StateDir;
 use maki_storage::auth::ProviderCredentials;
@@ -27,7 +28,18 @@ pub fn auth_login(provider: Option<&str>, storage: &StateDir) -> Result<()> {
     match provider {
         Some("openai") => openai_auth::login(storage)?,
         Some("copilot") => copilot_auth::login(storage)?,
-        Some(slug) => login_provider(&slugify(slug), storage)?,
+        Some(slug) => {
+            let slug = slugify(slug);
+            if builtin_provider(&slug).is_none()
+                && dynamic::display_name(&slug).is_none()
+                && ProvidersConfig::load().get(&slug).is_none()
+                && let Some(provider_data) = maki_providers::catalog_provider(&slug)
+            {
+                login_catalog_provider(&provider_data, storage)?;
+            } else {
+                login_provider(&slug, storage)?;
+            }
+        }
         None => login_interactive(storage)?,
     }
     Ok(())
@@ -122,7 +134,7 @@ fn login_interactive(storage: &StateDir) -> Result<()> {
     let custom_slugs: Vec<&String> = config
         .providers
         .keys()
-        .filter(|s| builtin_provider(s).is_none())
+        .filter(|s| builtin_provider(s).is_none() && *s != "opencode")
         .collect();
 
     println!();
@@ -152,6 +164,20 @@ fn login_interactive(storage: &StateDir) -> Result<()> {
             .unwrap_or(slug);
         println!("  {} {}. {:<14} {}", status, idx, slug, display);
     }
+
+    let catalog_entries = catalog_providers();
+    for cat in &catalog_entries {
+        idx += 1;
+        let status = if load_provider_credentials(storage, &cat.slug).is_some() {
+            "\x1b[32m✓\x1b[0m"
+        } else {
+            " "
+        };
+        println!(
+            "  {} {}. {:<14} {}",
+            status, idx, cat.slug, cat.display_name
+        );
+    }
     idx += 1;
     let custom_idx = idx;
     println!("    {}. Custom provider...", custom_idx);
@@ -172,11 +198,51 @@ fn login_interactive(storage: &StateDir) -> Result<()> {
     } else if choice <= builtins.len() {
         let slug = builtins[choice - 1].slug;
         login_provider(slug, storage)?;
-    } else {
+    } else if choice <= builtins.len() + custom_slugs.len() {
         let slug = custom_slugs[choice - builtins.len() - 1];
         login_provider(slug, storage)?;
+    } else {
+        let provider = &catalog_entries[choice - builtins.len() - custom_slugs.len() - 1];
+        login_catalog_provider(provider, storage)?;
     }
 
+    Ok(())
+}
+
+fn login_catalog_provider(provider: &ProviderData, storage: &StateDir) -> Result<()> {
+    println!();
+    if let Some(ref var) = provider.env_keys.first() {
+        println!("  Provider: {} (env: {var})", provider.slug);
+    } else {
+        println!("  Provider: {}", provider.slug);
+    }
+    print!("  API key: ");
+    io::stdout().flush()?;
+    let mut key = String::new();
+    io::stdin().read_line(&mut key)?;
+    let key = key.trim().to_string();
+    if key.is_empty() {
+        println!("  Skipped (no key entered)");
+        return Ok(());
+    }
+    let creds = ProviderCredentials {
+        api_key: key,
+        host: None,
+    };
+    save_provider_credentials(storage, &provider.slug, &creds).context("save credentials")?;
+    println!("  \x1b[32m✓\x1b[0m Saved credentials for {}", provider.slug);
+    println!(
+        "  Credentials: ~/.local/state/maki/auth/{}.json",
+        provider.slug
+    );
+    println!(
+        "  You can also set via: {}",
+        provider
+            .env_keys
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "API key environment variable".to_string())
+    );
     Ok(())
 }
 
@@ -401,23 +467,19 @@ pub fn auth_status(storage: &StateDir) -> Result<()> {
     }
 
     for (slug, def) in &config.providers {
-        if builtin_provider(slug).is_some() {
+        // 'opencode' could show up here, when the user configured free models on that provider.
+        if builtin_provider(slug).is_some()
+            || (slug == "opencode" && def.enable_free_models.is_some())
+        {
             continue;
         }
         let display = def.display_name.as_deref().unwrap_or(slug);
         if let Some(creds) = load_provider_credentials(storage, slug) {
-            let masked = if creds.api_key.len() > 8 {
-                format!(
-                    "{}...{}",
-                    &creds.api_key[..4],
-                    &creds.api_key[creds.api_key.len() - 4..]
-                )
-            } else {
-                "****".to_string()
-            };
             println!(
                 "  \x1b[32m✓\x1b[0m {:<14} {} (key: {})",
-                slug, display, masked
+                slug,
+                display,
+                creds.masked_api_key()
             );
         } else {
             let default_env = format!("{}_API_KEY", slug.to_uppercase().replace('-', "_"));
@@ -435,7 +497,32 @@ pub fn auth_status(storage: &StateDir) -> Result<()> {
             }
         }
     }
-    println!();
+    // Catalog providers from models.dev
+    let catalog_entries = catalog_providers();
+    if !catalog_entries.is_empty() {
+        println!("  \x1b[1mCatalog Providers (models.dev):\x1b[0m");
+        for entry in &catalog_entries {
+            if let Some(creds) = load_provider_credentials(storage, &entry.slug) {
+                println!(
+                    "  \x1b[32m✓\x1b[0m {:<14} {} (key: {})",
+                    entry.slug,
+                    entry.display_name,
+                    creds.masked_api_key()
+                );
+            } else if let Some(env) = entry.env_key_set() {
+                println!(
+                    "  \x1b[33m~\x1b[0m {:<14} {} (via {})",
+                    entry.slug, entry.display_name, env
+                );
+            } else {
+                println!(
+                    "  \x1b[31m✗\x1b[0m {:<14} {} (run: maki auth login {})",
+                    entry.slug, entry.display_name, entry.slug
+                );
+            }
+        }
+        println!();
+    }
 
     Ok(())
 }


### PR DESCRIPTION
 and refactor catalog types: move provider fields out of CatalogMeta, add ProviderData, fix login flow

- Split provider-level fields (env_keys, api_format, base_url, npm) from CatalogMeta into a new ProviderData struct
- Add providers map to CatalogData keyed by provider_id