### PR TITLE
fix: update context size estimate after rewind

### DIFF
--- a/maki-agent/src/agent/mod.rs
+++ b/maki-agent/src/agent/mod.rs
@@ -11,4 +11,6 @@ pub use instructions::{
     Instructions, LoadedInstructions, build_system_prompt, find_subdirectory_instructions,
     is_instruction_file, load_instruction_text, load_instructions,
 };
-pub use run::{Agent, AgentParams, AgentRunParams, resolve_compaction_model};
+pub use run::{
+    Agent, AgentParams, AgentRunParams, estimate_message_tokens, resolve_compaction_model,
+};

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -484,7 +484,10 @@ impl<'h> Agent<'h> {
 
 const CHARS_PER_TOKEN: usize = 4;
 
-fn estimate_message_tokens(messages: &[Message]) -> u32 {
+pub fn estimate_message_tokens(messages: &[Message]) -> u32 {
+    if messages.is_empty() {
+        return 0;
+    }
     let total_bytes: usize = messages
         .iter()
         .flat_map(|m| &m.content)

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -203,6 +203,8 @@ impl App {
             self.state.session.tool_outputs.remove(id);
             self.state.session.subagent_messages.remove(id);
         }
+        self.state.context_size =
+            maki_agent::agent::estimate_message_tokens(&self.state.session.messages);
 
         self.reset_ui_chrome();
         self.restore_display();

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -1639,6 +1639,7 @@ fn build_rewind_app() -> App {
 #[test]
 fn rewind_to_middle_truncates_and_populates_input() {
     let mut app = build_rewind_app();
+    app.state.context_size = 100_000;
     let old_run_id = app.run_id;
     let entry = crate::components::rewind_picker::RewindEntry {
         turn_index: 2,
@@ -1651,6 +1652,9 @@ fn rewind_to_middle_truncates_and_populates_input() {
     assert!(app.state.session.tool_outputs.contains_key("tool-1"));
     assert_eq!(app.input_box.buffer.value(), "second prompt");
     assert_eq!(app.run_id, old_run_id + 1);
+    let expected_ctx = maki_agent::agent::estimate_message_tokens(&app.state.session.messages);
+    assert_eq!(app.state.context_size, expected_ctx);
+    assert_eq!(app.chats[0].context_size, expected_ctx);
 
     let Action::LoadSession(ref loaded) = actions[0] else {
         panic!("expected LoadSession");
@@ -1662,6 +1666,7 @@ fn rewind_to_middle_truncates_and_populates_input() {
 #[test]
 fn rewind_to_first_turn_clears_everything() {
     let mut app = build_rewind_app();
+    app.state.context_size = 100_000;
     app.state.token_usage.input = 500;
     app.state.token_usage.output = 200;
     let entry = crate::components::rewind_picker::RewindEntry {
@@ -1675,6 +1680,8 @@ fn rewind_to_first_turn_clears_everything() {
     assert!(!app.state.session.tool_outputs.contains_key("tool-1"));
     assert_eq!(app.state.token_usage.input, 500);
     assert_eq!(app.state.token_usage.output, 200);
+    assert_eq!(app.state.context_size, 0);
+    assert_eq!(app.chats[0].context_size, 0);
     assert!(matches!(&actions[0], Action::LoadSession(_)));
 }
 


### PR DESCRIPTION
After a rewind the context size was not reduced, this PR fixes it