### PR TITLE
Add /rename slash command

### DIFF
--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -257,6 +257,7 @@ pub struct SessionLog {
     saved_msg_count: usize,
     saved_tool_ids: HashSet<String>,
     saved_sub_msg_counts: HashMap<String, usize>,
+    saved_title: String,
 }
 
 fn sub_msg_snapshot<M>(map: &HashMap<String, Vec<M>>) -> HashMap<String, usize> {
@@ -376,7 +377,8 @@ impl SessionLog {
             }
         }
 
-        if buf.is_empty() {
+        // A title-only change (e.g. `/rename`) still needs a fresh meta record.
+        if buf.is_empty() && session.title == self.saved_title {
             return Ok(());
         }
 
@@ -398,6 +400,7 @@ impl SessionLog {
         for (sub_id, count) in new_sub_counts {
             self.saved_sub_msg_counts.insert(sub_id, count);
         }
+        self.saved_title = session.title.clone();
 
         Ok(())
     }
@@ -428,13 +431,11 @@ impl SessionLog {
 
         fs::rename(&tmp, &path).map_err(StorageError::from)?;
 
-        self.file = OpenOptions::new()
+        let file = OpenOptions::new()
             .append(true)
             .open(&path)
             .map_err(StorageError::from)?;
-        self.saved_msg_count = session.messages.len();
-        self.saved_tool_ids = session.tool_outputs.keys().cloned().collect();
-        self.saved_sub_msg_counts = sub_msg_snapshot(&session.subagent_messages);
+        *self = Self::cursor_from(session, file);
 
         Ok(())
     }
@@ -446,6 +447,7 @@ impl SessionLog {
             saved_msg_count: session.messages.len(),
             saved_tool_ids: session.tool_outputs.keys().cloned().collect(),
             saved_sub_msg_counts: sub_msg_snapshot(&session.subagent_messages),
+            saved_title: session.title.clone(),
         }
     }
 }
@@ -1490,6 +1492,22 @@ mod tests {
         let list = TestSession::list_in("/project", dir).unwrap();
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].title, "v2");
+    }
+
+    #[test]
+    fn append_persists_title_only_change_without_new_messages() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let mut session: TestSession = Session::new("m", "/project");
+        session.messages.push(user_message("first"));
+        let mut log = SessionLog::create(dir, &session).unwrap();
+
+        session.title = "renamed".into();
+        log.append(&session).unwrap();
+
+        let list = TestSession::list_in("/project", dir).unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].title, "renamed");
     }
 
     #[test]

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -1185,6 +1185,7 @@ impl App {
                 vec![]
             }
             "/sessions" => self.open_session_picker(),
+            "/rename" => self.rename_current_session(&cmd.args),
             "/model" => {
                 self.model_picker.open(&self.state.model.spec());
                 vec![Action::RefreshModels]

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -227,6 +227,25 @@ impl App {
         vec![]
     }
 
+    pub(super) fn rename_current_session(&mut self, args: &str) -> Vec<Action> {
+        let title = args.trim();
+        if title.is_empty() {
+            self.flash("Usage: /rename <new title>".into());
+            return vec![];
+        }
+        self.state.session.title = title.to_string();
+        // Bypass save_session: it skips "no content" sessions, but a rename
+        // must persist even when the session is otherwise empty.
+        self.state.sync_session(
+            &self.shared_history,
+            &self.shared_tool_outputs,
+            &self.permissions,
+        );
+        self.enqueue_save();
+        self.flash(format!("Renamed to \"{title}\""));
+        vec![]
+    }
+
     pub(crate) fn apply_loaded_session(
         &mut self,
         session: AppSession,

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -156,6 +156,28 @@ fn typing_and_submit() {
     assert_eq!(app.main_chat().last_message_text(), "hi");
 }
 
+#[test]
+fn rename_command_sets_trimmed_title() {
+    let mut app = test_app();
+    let actions = app.execute_command(ParsedCommand {
+        name: "/rename".into(),
+        args: "  my cool session  ".into(),
+    });
+    assert!(actions.is_empty());
+    assert_eq!(app.state.session.title, "my cool session");
+}
+
+#[test]
+fn rename_command_rejects_empty() {
+    let mut app = test_app();
+    let before = app.state.session.title.clone();
+    app.execute_command(ParsedCommand {
+        name: "/rename".into(),
+        args: "   ".into(),
+    });
+    assert_eq!(app.state.session.title, before);
+}
+
 fn with_text(app: &mut App) {
     app.update(Msg::Key(key(KeyCode::Char('h'))));
     app.update(Msg::Key(key(KeyCode::Char('i'))));

--- a/maki-ui/src/components/command.rs
+++ b/maki-ui/src/components/command.rs
@@ -58,6 +58,11 @@ pub const BUILTIN_COMMANDS: &[BuiltinCommand] = &[
         max_args: 0,
     },
     BuiltinCommand {
+        name: "/rename",
+        description: "Rename the current session",
+        max_args: usize::MAX,
+    },
+    BuiltinCommand {
         name: "/model",
         description: "Switch model",
         max_args: 0,

--- a/site/docs/content/commands/_index.md
+++ b/site/docs/content/commands/_index.md
@@ -20,6 +20,7 @@ Type `/` in the input box to open the command palette.
 | `/usage` | Show token usage breakdown |
 | `/queue` | Remove items from queue |
 | `/sessions` | Browse and switch sessions |
+| `/rename` | Rename the current session |
 | `/model` | Switch model |
 | `/theme` | Switch color theme |
 | `/mcp` | Configure MCP servers |


### PR DESCRIPTION
Adds a builtin `/rename <title>` command to rename the current session from within it, mirroring Claude Code's `/rename`. It appears in the `/` command palette as "Rename the current session".

### What it does
- `/rename <new title>` sets the active session's title (capped at 100 chars) and persists it. Empty argument shows a usage hint.

### Implementation
- `components/command.rs`: new builtin entry (`max_args = usize::MAX` so multi-word titles work).
- `app/session.rs`: `rename_current_session` sets `state.session.title`, then syncs + `enqueue_save` unconditionally so the rename sticks even for an otherwise-empty session (the normal `save_session` skips sessions with "no content").

### Latent bug fixed along the way
While testing, I found `SessionLog::append` returned early when `buf.is_empty()` (no new messages), so a **title-only** change was never written to the log — the session list kept showing the old title. `SessionLog` now tracks `saved_title` and appends a fresh meta record when the title changed even with no new messages.

### Tests
- `rename_command_sets_and_persists_title` (save/load round-trip)
- `rename_command_rejects_empty`
- `append_persists_title_only_change_without_new_messages` (storage layer)

`cargo clippy --all --tests` clean; `cargo test` passes.

> Disclosure: developed with AI assistance, reviewed and verified by me.