### PR TITLE
Add `maki agents` multi-session dashboard

### DIFF
--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -99,6 +99,14 @@ pub struct SessionMeta {
     pub workflow: bool,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub usage_by_model: HashMap<String, StoredTokenUsage>,
+    #[serde(default, skip_serializing_if = "is_default_status")]
+    pub status: SessionStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+}
+
+fn is_default_status(status: &SessionStatus) -> bool {
+    matches!(status, SessionStatus::Idle)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -124,6 +132,8 @@ pub struct SessionSummary {
     pub id: String,
     pub title: String,
     pub updated_at: u64,
+    pub status: SessionStatus,
+    pub summary: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -131,6 +141,24 @@ pub struct SessionSummary {
 pub enum StoredEffect {
     Allow,
     Deny,
+}
+
+/// Lifecycle status of a session, used by the `maki agents` dashboard to group
+/// sessions into Needs input / Working / Completed sections.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStatus {
+    /// Exists, not running, not waiting on the user.
+    #[default]
+    Idle,
+    /// Agent loop is actively running.
+    Working,
+    /// Paused waiting on the user (permission prompt or question).
+    NeedsInput,
+    /// Last run finished normally.
+    Completed,
+    /// Last run ended in an error.
+    Error,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -257,6 +285,7 @@ pub struct SessionLog {
     saved_msg_count: usize,
     saved_tool_ids: HashSet<String>,
     saved_sub_msg_counts: HashMap<String, usize>,
+    saved_title: String,
 }
 
 fn sub_msg_snapshot<M>(map: &HashMap<String, Vec<M>>) -> HashMap<String, usize> {
@@ -376,7 +405,10 @@ impl SessionLog {
             }
         }
 
-        if buf.is_empty() {
+        // A title-only change (e.g. `/rename`) produces no new messages, but
+        // must still be persisted so the last meta record reflects it.
+        let title_changed = session.title != self.saved_title;
+        if buf.is_empty() && !title_changed {
             return Ok(());
         }
 
@@ -398,6 +430,7 @@ impl SessionLog {
         for (sub_id, count) in new_sub_counts {
             self.saved_sub_msg_counts.insert(sub_id, count);
         }
+        self.saved_title = session.title.clone();
 
         Ok(())
     }
@@ -446,6 +479,7 @@ impl SessionLog {
             saved_msg_count: session.messages.len(),
             saved_tool_ids: session.tool_outputs.keys().cloned().collect(),
             saved_sub_msg_counts: sub_msg_snapshot(&session.subagent_messages),
+            saved_title: session.title.clone(),
         }
     }
 }
@@ -665,11 +699,21 @@ struct JsonlHeader {
 }
 
 #[derive(Deserialize)]
+struct ScanMeta {
+    #[serde(default)]
+    status: SessionStatus,
+    #[serde(default)]
+    summary: Option<String>,
+}
+
+#[derive(Deserialize)]
 #[serde(tag = "t", rename_all = "snake_case")]
 enum ScanRecord {
     Meta {
         title: String,
         updated_at: u64,
+        #[serde(flatten)]
+        meta: Box<ScanMeta>,
     },
     #[serde(other)]
     Other,
@@ -710,17 +754,19 @@ fn scan_jsonl_header(cwd: &str, path: &Path) -> Option<SessionSummary> {
         return None;
     }
 
-    let (title, updated_at) =
-        read_last_meta(&mut file).unwrap_or_else(|| (DEFAULT_TITLE.to_string(), 0));
+    let (title, updated_at, status, summary) = read_last_meta(&mut file)
+        .unwrap_or_else(|| (DEFAULT_TITLE.to_string(), 0, SessionStatus::default(), None));
 
     Some(SessionSummary {
         id: header.id,
         title,
         updated_at,
+        status,
+        summary,
     })
 }
 
-fn read_last_meta(file: &mut File) -> Option<(String, u64)> {
+fn read_last_meta(file: &mut File) -> Option<(String, u64, SessionStatus, Option<String>)> {
     let len = file.seek(SeekFrom::End(0)).ok()?;
     let mut tail = TAIL_BUF.min(len);
     loop {
@@ -731,8 +777,13 @@ fn read_last_meta(file: &mut File) -> Option<(String, u64)> {
         let content = buf.strip_suffix(b"\n").unwrap_or(&buf);
         if let Some(nl) = content.iter().rposition(|&b| b == b'\n') {
             let last_line = &content[nl + 1..];
-            if let Ok(ScanRecord::Meta { title, updated_at }) = serde_json::from_slice(last_line) {
-                return Some((title, updated_at));
+            if let Ok(ScanRecord::Meta {
+                title,
+                updated_at,
+                meta,
+            }) = serde_json::from_slice(last_line)
+            {
+                return Some((title, updated_at, meta.status, meta.summary));
             }
             return None;
         }
@@ -754,6 +805,8 @@ fn scan_legacy_header(cwd: &str, path: &Path) -> Option<SessionSummary> {
         id: h.id,
         title: h.title,
         updated_at: h.updated_at,
+        status: SessionStatus::default(),
+        summary: None,
     })
 }
 
@@ -913,7 +966,7 @@ mod tests {
         CWD_INDEX_FILE, DEFAULT_TITLE, MAX_TITLE_LEN, SESSION_VERSION, TAIL_BUF, generate_title,
         load_cwd_index, update_cwd_index,
     };
-    use super::{Session, SessionError, SessionLog, StorageError, TitleSource};
+    use super::{Session, SessionError, SessionLog, SessionStatus, StorageError, TitleSource};
     use serde_json::Value;
     use std::collections::HashMap;
     use std::fs::{self, OpenOptions};
@@ -1272,6 +1325,42 @@ mod tests {
         assert_eq!(list.len(), 2);
     }
 
+    #[test_case(SessionStatus::Idle ; "idle")]
+    #[test_case(SessionStatus::Working ; "working")]
+    #[test_case(SessionStatus::NeedsInput ; "needs_input")]
+    #[test_case(SessionStatus::Completed ; "completed")]
+    #[test_case(SessionStatus::Error ; "error")]
+    fn session_status_serde_round_trip(variant: SessionStatus) {
+        let json = serde_json::to_string(&variant).unwrap();
+        let parsed: SessionStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, variant);
+    }
+
+    #[test]
+    fn scan_surfaces_status_and_defaults_idle_for_legacy() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        let mut with_status: TestSession = Session::new("m", "/project");
+        with_status.meta.status = SessionStatus::NeedsInput;
+        with_status.meta.summary = Some("waiting on approval".into());
+        with_status.save_to(dir).unwrap();
+
+        let mut legacy: TestSession = Session::new("m", "/project");
+        legacy.title = "legacy".into();
+        let json_path = dir.join(format!("{}.json", legacy.id));
+        fs::write(&json_path, serde_json::to_vec(&legacy).unwrap()).unwrap();
+
+        let list = TestSession::list_in("/project", dir).unwrap();
+        let by_id = |id: &str| list.iter().find(|s| s.id == id).unwrap();
+
+        let scanned = by_id(&with_status.id);
+        assert_eq!(scanned.status, SessionStatus::NeedsInput);
+        assert_eq!(scanned.summary.as_deref(), Some("waiting on approval"));
+
+        assert_eq!(by_id(&legacy.id).status, SessionStatus::Idle);
+    }
+
     #[test]
     fn load_wrong_version_legacy_returns_error() {
         let tmp = TempDir::new().unwrap();
@@ -1490,6 +1579,23 @@ mod tests {
         let list = TestSession::list_in("/project", dir).unwrap();
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].title, "v2");
+    }
+
+    #[test]
+    fn append_persists_title_only_change_without_new_messages() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let mut session: TestSession = Session::new("m", "/project");
+        session.messages.push(user_message("first"));
+        let mut log = SessionLog::create(dir, &session).unwrap();
+
+        // Rename with no new messages (the /rename case).
+        session.title = "renamed".into();
+        log.append(&session).unwrap();
+
+        let list = TestSession::list_in("/project", dir).unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].title, "renamed");
     }
 
     #[test]

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -40,6 +40,7 @@ use crate::components::plan_form::{PlanForm, PlanFormAction};
 use crate::components::rewind_picker::{RewindPicker, RewindPickerAction};
 use crate::components::scrollbar;
 use crate::components::search_modal::{SearchAction, SearchModal};
+use crate::components::session_dashboard::{DashboardAction, SessionDashboard};
 use crate::components::session_picker::{SessionPicker, SessionPickerAction};
 use crate::components::status_bar::StatusBar;
 use crate::components::theme_picker::{ThemePicker, ThemePickerAction};
@@ -51,7 +52,7 @@ use crate::components::{
 use crate::image;
 use crate::selection::{SelectionState, ZoneRegistry};
 use arc_swap::{ArcSwap, ArcSwapOption};
-use crossterm::event::{KeyCode, KeyEvent, MouseEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent};
 use maki_agent::permissions::PermissionManager;
 use maki_agent::{
     AgentEvent, Envelope, ImageSource, McpConfigErrors, McpPromptInfo, McpSnapshotReader,
@@ -141,6 +142,7 @@ pub struct App {
     pub(super) login_picker: LoginPicker,
     pub(super) mcp_picker: McpPicker,
     pub(super) session_picker: SessionPicker,
+    pub(super) session_dashboard: SessionDashboard,
     pub(super) rewind_picker: RewindPicker,
     pub(super) help_modal: HelpModal,
     pub(super) usage_modal: UsageModal,
@@ -182,6 +184,9 @@ pub struct App {
     pub(crate) restore_event_tx: Option<maki_agent::EventSender>,
     pub(super) restoring: Arc<AtomicBool>,
     subagent_answers: HashMap<String, flume::Sender<String>>,
+    /// When true, the UI launched via `maki agents` and should present the
+    /// multi-session dashboard as its landing screen.
+    pub(crate) dashboard: bool,
 }
 
 impl App {
@@ -221,6 +226,7 @@ impl App {
             login_picker: LoginPicker::new(),
             mcp_picker: McpPicker::new(mcp_reader, mcp_config_errors),
             session_picker: SessionPicker::new(),
+            session_dashboard: SessionDashboard::new(),
             rewind_picker: RewindPicker::new(),
             help_modal: HelpModal::new(),
             usage_modal: UsageModal::new(),
@@ -261,6 +267,7 @@ impl App {
             restore_event_tx: None,
             restoring: Arc::new(AtomicBool::new(false)),
             subagent_answers: HashMap::new(),
+            dashboard: false,
         };
         app.model_picker
             .set_recents(maki_storage::model::read_recents(&app.storage));
@@ -318,13 +325,14 @@ impl App {
             Msg::Key(key) => self.handle_key(key),
             Msg::Paste(text) => {
                 let text = text.replace("\r\n", "\n").replace('\r', "\n");
+                let input_active = self.is_main_chat() || self.session_dashboard.is_open();
                 if text.is_empty() {
-                    if self.is_main_chat() && self.image_paste_rx.is_empty() {
+                    if input_active && self.image_paste_rx.is_empty() {
                         self.start_image_paste();
                     }
                 } else {
                     let mut any_image = false;
-                    if self.is_main_chat() {
+                    if input_active {
                         for line in text.lines() {
                             if let Some((path, mt)) = image::try_parse_image_path(line) {
                                 self.start_file_image_paste(path, mt);
@@ -395,6 +403,7 @@ impl App {
             };
         }
         try_picker!(self.session_picker);
+        try_picker!(self.session_dashboard);
         try_picker!(self.rewind_picker);
         try_picker!(self.task_picker);
         try_picker!(self.model_picker);
@@ -604,6 +613,36 @@ impl App {
             });
         }
 
+        if self.session_dashboard.is_open() {
+            let action = self.session_dashboard.handle_key(key);
+            return Some(match action {
+                DashboardAction::Consumed => vec![],
+                DashboardAction::None => {
+                    // Esc closed the dashboard; nothing else to do.
+                    vec![]
+                }
+                DashboardAction::Open(id) => {
+                    self.session_dashboard.close();
+                    self.input_box.discard();
+                    vec![Action::FocusSession(id)]
+                }
+                DashboardAction::NewSession => {
+                    self.session_dashboard.close();
+                    self.input_box.discard();
+                    vec![Action::SpawnSession(None)]
+                }
+                DashboardAction::ConfirmDelete => {
+                    self.status_bar.flash(format!(
+                        "Press {} again to confirm delete",
+                        key::DELETE.label
+                    ));
+                    vec![]
+                }
+                DashboardAction::Delete(id) => self.delete_session(id),
+                DashboardAction::Passthrough(key) => self.dashboard_input_key(key),
+            });
+        }
+
         if self.session_picker.is_open() {
             return Some(match self.session_picker.handle_key(key) {
                 SessionPickerAction::Consumed => vec![],
@@ -778,6 +817,24 @@ impl App {
         }
 
         let streaming = self.status == Status::Streaming;
+
+        // Arrow keys navigate between sessions whenever the input box is empty,
+        // even while the current session is still streaming (its agent keeps
+        // running in the background). When the input has text, arrows move the
+        // cursor as usual. Left returns to the agents dashboard; Up/Down cycle
+        // to the previous/next session (Claude Code parity).
+        if self.is_main_chat() && self.input_box.is_empty() && key.modifiers.is_empty() {
+            match key.code {
+                KeyCode::Left => {
+                    self.open_dashboard();
+                    return vec![];
+                }
+                KeyCode::Up => return vec![Action::FocusPrevSession],
+                KeyCode::Down => return vec![Action::FocusNextSession],
+                _ => {}
+            }
+        }
+
         match self.input_box.handle_key(key) {
             InputAction::Submit(sub) => self.handle_submit(sub),
             InputAction::PaletteSync(val) => {
@@ -875,6 +932,58 @@ impl App {
         } else {
             self.run_id += 1;
             self.start_from_queue(&msg)
+        }
+    }
+
+    /// Handle a key routed from the dashboard to the shared input box. Mirrors
+    /// the normal input flow (command palette, file picker, image paste), but a
+    /// submit spawns a new session seeded with the text instead of sending to
+    /// the current session. Enter on an empty box opens the selected session.
+    fn dashboard_input_key(&mut self, key: KeyEvent) -> Vec<Action> {
+        if key::FILE_PICKER.matches(key) {
+            self.file_picker.open(&self.state.session.cwd);
+            return vec![];
+        }
+        if key.code == KeyCode::Char('v')
+            && key.modifiers.contains(KeyModifiers::CONTROL)
+            && self.image_paste_rx.is_empty()
+        {
+            self.start_image_paste();
+            return vec![];
+        }
+
+        match self
+            .command_palette
+            .handle_key(key, &self.input_box.buffer.value())
+        {
+            CommandAction::Consumed => return vec![],
+            CommandAction::Execute(cmd) => return self.execute_command(cmd),
+            CommandAction::Complete(text) => {
+                self.command_palette.sync(&text);
+                self.input_box.set_input(text);
+                self.input_box.buffer.move_to_end();
+                return vec![];
+            }
+            CommandAction::Passthrough => {}
+        }
+
+        match self.input_box.handle_key(key) {
+            InputAction::Submit(sub) => {
+                if sub.is_empty() {
+                    if let Some(id) = self.session_dashboard.selected_id() {
+                        self.session_dashboard.close();
+                        return vec![Action::FocusSession(id)];
+                    }
+                    return vec![];
+                }
+                self.session_dashboard.close();
+                vec![Action::SpawnSession(Some(Box::new(sub)))]
+            }
+            InputAction::PaletteSync(val) => {
+                self.command_palette.sync(&val);
+                vec![]
+            }
+            _ => vec![],
         }
     }
 
@@ -1060,6 +1169,7 @@ impl App {
 
         if let ChatEventResult::PermissionRequest { id, tool, scopes } = result {
             self.permission_prompt.open(id, tool, scopes, subagent_id);
+            self.save_session();
             return vec![];
         }
 
@@ -1185,6 +1295,7 @@ impl App {
                 vec![]
             }
             "/sessions" => self.open_session_picker(),
+            "/rename" => self.rename_current_session(&cmd.args),
             "/model" => {
                 self.model_picker.open(&self.state.model.spec());
                 vec![Action::RefreshModels]
@@ -1392,7 +1503,7 @@ impl App {
         vec![]
     }
 
-    fn overlays(&self) -> [&dyn Overlay; 14] {
+    fn overlays(&self) -> [&dyn Overlay; 15] {
         [
             &self.help_modal,
             &self.usage_modal,
@@ -1402,6 +1513,7 @@ impl App {
             &self.file_picker,
             &self.task_picker,
             &self.session_picker,
+            &self.session_dashboard,
             &self.rewind_picker,
             &self.theme_picker,
             &self.model_picker,
@@ -1411,7 +1523,7 @@ impl App {
         ]
     }
 
-    fn overlays_mut(&mut self) -> [&mut dyn Overlay; 14] {
+    fn overlays_mut(&mut self) -> [&mut dyn Overlay; 15] {
         [
             &mut self.help_modal,
             &mut self.usage_modal,
@@ -1421,6 +1533,7 @@ impl App {
             &mut self.file_picker,
             &mut self.task_picker,
             &mut self.session_picker,
+            &mut self.session_dashboard,
             &mut self.rewind_picker,
             &mut self.theme_picker,
             &mut self.model_picker,
@@ -1502,6 +1615,14 @@ impl App {
         try_picker!(self.model_picker);
         try_picker!(self.mcp_picker);
         try_picker!(self.login_picker);
+        // When the dashboard is open, pasted text / dropped file paths belong in
+        // the shared new-session input box, not the picker's filter.
+        if self.session_dashboard.is_open() {
+            if let InputAction::PaletteSync(val) = self.input_box.handle_paste(text) {
+                self.command_palette.sync(&val);
+            }
+            return;
+        }
         if !self.is_main_chat() {
             return;
         }

--- a/maki-ui/src/app/queue.rs
+++ b/maki-ui/src/app/queue.rs
@@ -147,6 +147,7 @@ impl App {
         }
         self.main_chat()
             .show_user_message(format_with_images(&msg.text, msg.images.len()));
+        self.save_session();
         vec![super::Action::SendMessage(Box::new(
             self.build_agent_input(msg),
         ))]

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::AtomicBool;
 use crate::chat::{Chat, DONE_TEXT, history_to_display};
 use crate::components::DisplayRole;
 use crate::components::rewind_picker::RewindEntry;
-use crate::components::{Action, LoadedSession};
+use crate::components::{Action, LoadedSession, Overlay};
 use maki_providers::{Model, TokenUsage};
 use maki_storage::sessions::StoredSubagent;
 
@@ -60,6 +60,23 @@ impl App {
                 model: chat.model_id.clone(),
             })
             .collect();
+
+        self.sync_session_status();
+    }
+
+    /// Derive the persisted dashboard status from the current runtime state so
+    /// `maki agents` can group this session correctly.
+    fn sync_session_status(&mut self) {
+        use super::Status;
+        use maki_storage::sessions::SessionStatus;
+
+        self.state.session.meta.status = match self.status {
+            Status::Streaming => SessionStatus::Working,
+            Status::Error { .. } => SessionStatus::Error,
+            Status::Idle if self.permission_prompt.is_open() => SessionStatus::NeedsInput,
+            Status::Idle if self.has_content() => SessionStatus::Completed,
+            Status::Idle => SessionStatus::Idle,
+        };
     }
 
     pub(super) fn save_input_history(&self) {
@@ -227,6 +244,33 @@ impl App {
         vec![]
     }
 
+    /// `/rename <title>` - set the current session's title and persist it.
+    pub(super) fn rename_current_session(&mut self, args: &str) -> Vec<Action> {
+        let title = args.trim();
+        if title.is_empty() {
+            self.flash("Usage: /rename <new title>".into());
+            return vec![];
+        }
+        const MAX_TITLE_LEN: usize = 100;
+        let title: String = title.chars().take(MAX_TITLE_LEN).collect();
+        self.state.session.title = title.clone();
+        // Persist unconditionally: a rename must stick even for an otherwise
+        // empty session (save_session would skip it as "no content").
+        self.state.sync_session(
+            &self.shared_history,
+            &self.shared_tool_outputs,
+            &self.permissions,
+        );
+        self.enqueue_save();
+        self.flash(format!("Renamed to \"{title}\""));
+        vec![]
+    }
+
+    pub(crate) fn open_dashboard(&mut self) {
+        self.session_dashboard
+            .open(&self.state.session.cwd, &self.storage);
+    }
+
     pub(crate) fn apply_loaded_session(
         &mut self,
         session: AppSession,
@@ -266,6 +310,7 @@ impl App {
             return vec![];
         }
         self.session_picker.remove_entry(&session_id);
+        self.session_dashboard.remove_entry(&session_id);
         self.status_bar.flash("Session deleted".into());
         vec![]
     }

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -156,6 +156,62 @@ fn typing_and_submit() {
     assert_eq!(app.main_chat().last_message_text(), "hi");
 }
 
+#[test]
+fn submit_marks_session_working_then_completed() {
+    use maki_storage::sessions::SessionStatus;
+
+    let mut app = test_app();
+    app.update(Msg::Key(key(KeyCode::Char('h'))));
+    app.update(Msg::Key(key(KeyCode::Char('i'))));
+    app.update(Msg::Key(key(KeyCode::Enter)));
+
+    // Streaming submit persists the session as Working.
+    assert_eq!(app.status, Status::Streaming);
+    assert_eq!(app.state.session.meta.status, SessionStatus::Working);
+
+    // Returning to Idle with content on screen marks it Completed.
+    app.state
+        .session
+        .messages
+        .push(maki_providers::Message::user("hi".into()));
+    app.status = Status::Idle;
+    app.save_session();
+    assert_eq!(app.state.session.meta.status, SessionStatus::Completed);
+}
+
+#[test]
+fn rename_command_sets_and_persists_title() {
+    let mut app = test_app();
+    app.state
+        .session
+        .messages
+        .push(maki_providers::Message::user("hello".into()));
+
+    let actions = app.execute_command(ParsedCommand {
+        name: "/rename".into(),
+        args: "my cool session".into(),
+    });
+    assert!(actions.is_empty());
+    assert_eq!(app.state.session.title, "my cool session");
+
+    // The renamed title survives a synchronous save/load round-trip.
+    let dir = app.storage.clone();
+    app.state.session.save(&dir).unwrap();
+    let loaded = AppSession::load(&app.state.session.id, &dir).unwrap();
+    assert_eq!(loaded.title, "my cool session");
+}
+
+#[test]
+fn rename_command_rejects_empty() {
+    let mut app = test_app();
+    let before = app.state.session.title.clone();
+    app.execute_command(ParsedCommand {
+        name: "/rename".into(),
+        args: "   ".into(),
+    });
+    assert_eq!(app.state.session.title, before);
+}
+
 fn with_text(app: &mut App) {
     app.update(Msg::Key(key(KeyCode::Char('h'))));
     app.update(Msg::Key(key(KeyCode::Char('i'))));

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -156,6 +156,11 @@ impl App {
     }
 
     fn render_bottom_panel(&mut self, frame: &mut Frame, layout: &ViewLayout) {
+        // The dashboard renders the shared input box inside its own panel, so
+        // skip the normal bottom-panel input to avoid a duplicate.
+        if self.session_dashboard.is_open() {
+            return;
+        }
         if self.permission_prompt.is_open() {
             self.permission_prompt.view(frame, layout.bottom_area);
         } else if !self.is_main_chat() {
@@ -212,6 +217,8 @@ impl App {
         }
     }
 
+    /// Single-line new-session prompt for the dashboard, backed by the shared
+    /// input box state (so `/` commands, file picker, and image paste all work).
     fn render_splits(&mut self, frame: &mut Frame, layout: &ViewLayout) {
         for dir in Split::ALL {
             if let Some(rect) = layout.splits.rect(dir) {
@@ -237,6 +244,48 @@ impl App {
                 self.status_bar.flash(flash);
             }
             overlay_rect = self.file_picker.view(frame, full);
+        }
+
+        if self.session_dashboard.is_open() {
+            self.session_dashboard.tick();
+            // The picker centers a modal at 65% width with a 1-col border each
+            // side; size the input box to that inner width so it wraps at the
+            // right place and grows to multiple rows.
+            let popup_width = full.width.saturating_mul(65) / 100;
+            let input_inner_width = popup_width.saturating_sub(2).max(1);
+            let max_input = (full.height / 2).max(3);
+            let input_height = self.input_box.height(input_inner_width).clamp(3, max_input);
+            let dash = self.session_dashboard.view(frame, full, input_height);
+            overlay_rect = dash.popup;
+
+            // Render maki's real input box inside the panel: full editing,
+            // horizontal scroll, multiline, image display.
+            self.input_box.view(
+                frame,
+                dash.input_area,
+                false,
+                self.separator_style(),
+                true,
+                None,
+            );
+            // Left-aligned "New session" label on the input's top border row.
+            let label_area = Rect {
+                x: dash.input_area.x + 1,
+                y: dash.input_area.y,
+                width: dash.input_area.width.saturating_sub(2),
+                height: 1,
+            };
+            frame.render_widget(
+                ratatui::widgets::Paragraph::new(Line::from(Span::styled(
+                    " New session ",
+                    crate::theme::current().panel_title,
+                ))),
+                label_area,
+            );
+            self.command_palette.view(frame, dash.input_area);
+            if let Some(flash) = self.session_dashboard.take_flash() {
+                self.status_bar.flash(flash);
+            }
         }
 
         if self.session_picker.is_open() {

--- a/maki-ui/src/components/command.rs
+++ b/maki-ui/src/components/command.rs
@@ -58,6 +58,11 @@ pub const BUILTIN_COMMANDS: &[BuiltinCommand] = &[
         max_args: 0,
     },
     BuiltinCommand {
+        name: "/rename",
+        description: "Rename the current session",
+        max_args: usize::MAX,
+    },
+    BuiltinCommand {
         name: "/model",
         description: "Switch model",
         max_args: 0,

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -19,6 +19,7 @@ pub mod queue_panel;
 pub(crate) mod rewind_picker;
 pub(crate) mod scrollbar;
 pub(crate) mod search_modal;
+pub(crate) mod session_dashboard;
 pub(crate) mod session_picker;
 pub(crate) mod split_layout;
 pub mod status_bar;
@@ -85,6 +86,32 @@ pub(crate) fn apply_scroll_delta(offset: u16, delta: i32) -> u16 {
 
 pub fn is_ctrl(key: &KeyEvent) -> bool {
     key.modifiers.contains(KeyModifiers::CONTROL) && !key.modifiers.contains(KeyModifiers::ALT)
+}
+
+pub(crate) fn format_relative_time(epoch_secs: u64) -> String {
+    let ts = jiff::Timestamp::from_second(epoch_secs as i64).unwrap_or(jiff::Timestamp::UNIX_EPOCH);
+    let now = jiff::Timestamp::now();
+    let secs = now.as_second().saturating_sub(ts.as_second()).max(0) as u64;
+    humanize_secs(secs)
+}
+
+fn humanize_secs(secs: u64) -> String {
+    const MINUTE: u64 = 60;
+    const HOUR: u64 = 3600;
+    const DAY: u64 = 86400;
+    const WEEK: u64 = 604800;
+    const MONTH: u64 = 2592000;
+    const YEAR: u64 = 31536000;
+
+    match secs {
+        0..MINUTE => "just now".into(),
+        MINUTE..HOUR => format!("{}m ago", secs / MINUTE),
+        HOUR..DAY => format!("{}h ago", secs / HOUR),
+        DAY..WEEK => format!("{}d ago", secs / DAY),
+        WEEK..MONTH => format!("{}w ago", secs / WEEK),
+        MONTH..YEAR => format!("{}mo ago", secs / MONTH),
+        _ => format!("{}y ago", secs / YEAR),
+    }
 }
 
 pub(crate) struct ModalScroll {
@@ -194,6 +221,21 @@ pub enum Action {
     },
     NewSession,
     LoadSession(Box<LoadedSession>),
+    /// Open a stored session (by id) in the multi-session dashboard: focus its
+    /// live runtime if one exists, otherwise attach it as a new background
+    /// runtime and focus it. Unlike `LoadSession`, this does not replace the
+    /// currently focused session.
+    FocusSession(String),
+    /// Create a brand-new background session, optionally seeded with an initial
+    /// task submission (text + attached images), and focus it. Used by the
+    /// dashboard's "new session" box.
+    SpawnSession(Option<Box<crate::components::input::Submission>>),
+    /// Return focus to the agents dashboard (no session rendered on top).
+    ShowDashboard,
+    /// Move focus to the previous / next background session in the dashboard's
+    /// ordering. Used by Up/Down inside a session when the input box is empty.
+    FocusPrevSession,
+    FocusNextSession,
     ChangeModel(String),
     RefreshProvider {
         slug: String,
@@ -460,5 +502,16 @@ mod tests {
     #[test_case(0, 5, 0    ; "clamp_underflow")]
     fn apply_scroll_delta_cases(offset: u16, delta: i32, expected: u16) {
         assert_eq!(apply_scroll_delta(offset, delta), expected);
+    }
+
+    #[test_case(0, "just now" ; "below_minute")]
+    #[test_case(60, "1m ago" ; "minute_boundary")]
+    #[test_case(3600, "1h ago" ; "hour_boundary")]
+    #[test_case(86400, "1d ago" ; "day_boundary")]
+    #[test_case(604800, "1w ago" ; "week_boundary")]
+    #[test_case(2592000, "1mo ago" ; "month_boundary")]
+    #[test_case(31536000, "1y ago" ; "year_boundary")]
+    fn relative_time_formatting(secs: u64, expected: &str) {
+        assert_eq!(humanize_secs(secs), expected);
     }
 }

--- a/maki-ui/src/components/session_dashboard.rs
+++ b/maki-ui/src/components/session_dashboard.rs
@@ -1,0 +1,389 @@
+use std::thread;
+
+use crate::AppSession;
+use crate::components::format_relative_time;
+use crate::components::keybindings::key;
+use crate::components::list_picker::{ListPicker, PickerAction, PickerItem};
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use maki_storage::StateDir;
+use maki_storage::sessions::SessionStatus;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Position, Rect};
+
+const TITLE: &str = " Agents ";
+const NO_SESSIONS_MSG: &str = "No sessions yet in this directory";
+const FOOTER_HINTS: &[(&str, &str)] = &[
+    ("↑/↓", "navigate"),
+    ("→", "open"),
+    ("Enter", "open/spawn"),
+    (key::DELETE.label, "delete"),
+];
+
+const SECTION_NEEDS_INPUT: &str = "Needs input";
+const SECTION_WORKING: &str = "Working";
+const SECTION_COMPLETED: &str = "Completed";
+
+/// The event loop ticks roughly per frame; refreshing the board about once a
+/// second keeps background status changes visible without hammering storage.
+const REFRESH_INTERVAL_TICKS: u16 = 60;
+
+
+#[derive(Debug)]
+pub enum DashboardAction {
+    Consumed,
+    Open(String),
+    NewSession,
+    ConfirmDelete,
+    Delete(String),
+    /// Not a dashboard navigation key: the caller should route it to the
+    /// shared input box (typing the new-session task, file picker, etc.).
+    Passthrough(KeyEvent),
+    None,
+}
+
+struct DashboardEntry {
+    id: String,
+    title: String,
+    detail: String,
+    section: &'static str,
+    spinning: bool,
+}
+
+impl PickerItem for DashboardEntry {
+    fn label(&self) -> &str {
+        &self.title
+    }
+    fn detail(&self) -> Option<&str> {
+        Some(&self.detail)
+    }
+    fn section(&self) -> Option<&str> {
+        Some(self.section)
+    }
+    fn is_spinning(&self) -> bool {
+        self.spinning
+    }
+}
+
+/// Full-screen multi-session overview shown by `maki agents`. Lists the current
+/// directory's sessions grouped into Needs input / Working / Completed sections.
+pub struct SessionDashboard {
+    picker: ListPicker<DashboardEntry>,
+    confirming: Option<(String, u64)>,
+    pending_rx: Option<flume::Receiver<Result<Vec<DashboardEntry>, String>>>,
+    flash: Option<String>,
+    source: Option<(String, StateDir)>,
+    refreshing: bool,
+    ticks_since_refresh: u16,
+}
+
+impl SessionDashboard {
+    pub fn new() -> Self {
+        Self {
+            picker: ListPicker::new().with_footer(FOOTER_HINTS),
+            confirming: None,
+            pending_rx: None,
+            flash: None,
+            source: None,
+            refreshing: false,
+            ticks_since_refresh: 0,
+        }
+    }
+
+    pub fn open(&mut self, cwd: &str, dir: &StateDir) {
+        self.picker.open_loading(TITLE);
+        self.source = Some((cwd.to_owned(), dir.clone()));
+        self.refreshing = false;
+        self.ticks_since_refresh = 0;
+        self.pending_rx = Some(spawn_scan(cwd.to_owned(), dir.clone()));
+    }
+
+    fn try_resolve(&mut self) {
+        let Some(ref rx) = self.pending_rx else {
+            return;
+        };
+        let Ok(result) = rx.try_recv() else {
+            return;
+        };
+        self.pending_rx = None;
+        let was_refresh = self.refreshing;
+        self.refreshing = false;
+        match result {
+            Ok(entries) if entries.is_empty() => {
+                self.picker.resolve(entries);
+                self.picker.set_error_text(Some(NO_SESSIONS_MSG.into()));
+            }
+            // A live refresh replaces items in place so the user's current
+            // selection and scroll position survive the status update.
+            Ok(entries) if was_refresh => {
+                self.picker.set_error_text(None);
+                self.picker.replace_items(entries);
+            }
+            Ok(entries) => self.picker.resolve(entries),
+            Err(e) => {
+                if !was_refresh {
+                    self.picker.resolve(Vec::new());
+                    self.picker.set_error_text(Some(e));
+                }
+            }
+        }
+    }
+
+    /// Kick off a background re-scan to reflect status changes from other
+    /// sessions without disturbing the current selection. No-op while an
+    /// initial load or another refresh is in flight.
+    fn refresh(&mut self) {
+        if self.pending_rx.is_some() || self.picker.is_loading() {
+            return;
+        }
+        let Some((cwd, dir)) = self.source.clone() else {
+            return;
+        };
+        self.refreshing = true;
+        self.pending_rx = Some(spawn_scan(cwd, dir));
+    }
+
+    pub fn take_flash(&mut self) -> Option<String> {
+        self.flash.take()
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.picker.is_open()
+    }
+
+    pub fn close(&mut self) {
+        self.picker.close();
+        self.pending_rx = None;
+        self.source = None;
+        self.refreshing = false;
+    }
+
+    pub fn remove_entry(&mut self, id: &str) {
+        self.picker.retain(|e| e.id != id);
+    }
+
+    pub fn contains(&self, pos: Position) -> bool {
+        self.picker.contains(pos)
+    }
+
+    pub fn scroll(&mut self, delta: i32) {
+        self.picker.scroll(delta);
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> DashboardAction {
+        if is_delete_key(&key) {
+            return self.handle_delete_key();
+        }
+
+        // Ctrl-N spawns a brand-new empty session.
+        if key.modifiers.contains(KeyModifiers::CONTROL)
+            && !key.modifiers.contains(KeyModifiers::ALT)
+            && key.code == KeyCode::Char('n')
+        {
+            return DashboardAction::NewSession;
+        }
+
+        // Navigation keys drive the session list. Everything else (typing the
+        // task, `/` commands, file picker, paste) is passed through to the
+        // shared input box owned by the App.
+        match key.code {
+            KeyCode::Up | KeyCode::Down if key.modifiers.is_empty() => {
+                self.picker.handle_key(key);
+                DashboardAction::Consumed
+            }
+            KeyCode::Right if key.modifiers.is_empty() => match self.picker.selected_item() {
+                Some(item) => DashboardAction::Open(item.id.clone()),
+                None => DashboardAction::Consumed,
+            },
+            KeyCode::Esc => match self.picker.handle_key(key) {
+                PickerAction::Close => DashboardAction::None,
+                _ => DashboardAction::Consumed,
+            },
+            _ => DashboardAction::Passthrough(key),
+        }
+    }
+
+    pub fn selected_id(&self) -> Option<String> {
+        self.picker.selected_item().map(|item| item.id.clone())
+    }
+
+    fn handle_delete_key(&mut self) -> DashboardAction {
+        let Some(selected) = self.picker.selected_item() else {
+            return DashboardAction::Consumed;
+        };
+
+        let generation = self.picker.generation();
+        if self
+            .confirming
+            .as_ref()
+            .is_some_and(|(id, g)| id == &selected.id && *g == generation)
+        {
+            return DashboardAction::Delete(selected.id.clone());
+        }
+
+        self.confirming = Some((selected.id.clone(), generation));
+        DashboardAction::ConfirmDelete
+    }
+
+    pub fn tick(&mut self) {
+        self.try_resolve();
+
+        self.ticks_since_refresh = self.ticks_since_refresh.saturating_add(1);
+        if self.ticks_since_refresh >= REFRESH_INTERVAL_TICKS {
+            self.ticks_since_refresh = 0;
+            self.refresh();
+        }
+    }
+
+    /// Renders the session list and reserves the bottom of the panel for the
+    /// shared new-session input box. Returns the `Rect` the caller renders the
+    /// real input box into (so it gets horizontal scroll, multiline, cursor,
+    /// and image display for free).
+    pub fn view(&mut self, frame: &mut Frame, area: Rect, input_height: u16) -> DashboardLayout {
+        // The input box draws its own top+bottom border, so it needs at least 3
+        // rows (border, one content line, border). Give it what the caller asks.
+        let reserved = input_height.max(3);
+        let [list_area, bottom] =
+            Layout::vertical([Constraint::Min(1), Constraint::Length(reserved)]).areas(area);
+
+        let popup = self.picker.view(frame, list_area);
+
+        let input_area = Rect {
+            x: popup.x,
+            y: bottom.y,
+            width: popup.width.max(1),
+            height: reserved.min(bottom.height),
+        };
+
+        DashboardLayout { popup, input_area }
+    }
+}
+
+/// Where the dashboard drew itself: `popup` is the modal rect (for overlay
+/// bookkeeping), `input_area` is where the caller renders the shared input box.
+pub struct DashboardLayout {
+    pub popup: Rect,
+    pub input_area: Rect,
+}
+
+impl crate::components::Overlay for SessionDashboard {
+    fn is_open(&self) -> bool {
+        self.is_open()
+    }
+
+    fn close(&mut self) {
+        self.close()
+    }
+}
+
+fn is_delete_key(key: &KeyEvent) -> bool {
+    key::DELETE.matches(*key)
+}
+
+fn section_rank(status: SessionStatus) -> u8 {
+    match status {
+        SessionStatus::NeedsInput => 0,
+        SessionStatus::Working => 1,
+        SessionStatus::Completed | SessionStatus::Idle | SessionStatus::Error => 2,
+    }
+}
+
+fn section_label(status: SessionStatus) -> &'static str {
+    match status {
+        SessionStatus::NeedsInput => SECTION_NEEDS_INPUT,
+        SessionStatus::Working => SECTION_WORKING,
+        SessionStatus::Completed | SessionStatus::Idle | SessionStatus::Error => SECTION_COMPLETED,
+    }
+}
+
+fn spawn_scan(cwd: String, dir: StateDir) -> flume::Receiver<Result<Vec<DashboardEntry>, String>> {
+    let (tx, rx) = flume::bounded(1);
+    thread::spawn(move || {
+        let result = AppSession::list(&cwd, &dir)
+            .map(|mut summaries| {
+                summaries.sort_by(|a, b| {
+                    section_rank(a.status)
+                        .cmp(&section_rank(b.status))
+                        .then(b.updated_at.cmp(&a.updated_at))
+                });
+                summaries.into_iter().map(entry_from_summary).collect()
+            })
+            .map_err(|e| format!("Failed to list sessions: {e}"));
+        let _ = tx.send(result);
+    });
+    rx
+}
+
+fn entry_from_summary(s: maki_storage::sessions::SessionSummary) -> DashboardEntry {
+    let time = format_relative_time(s.updated_at);
+    let detail = match &s.summary {
+        Some(summary) if !summary.is_empty() => format!("{summary}  ·  {time}"),
+        _ => time,
+    };
+    DashboardEntry {
+        id: s.id,
+        title: s.title,
+        detail,
+        section: section_label(s.status),
+        spinning: matches!(s.status, SessionStatus::Working),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    #[test_case(SessionStatus::NeedsInput, 0 ; "needs_input_first")]
+    #[test_case(SessionStatus::Working, 1 ; "working_second")]
+    #[test_case(SessionStatus::Completed, 2 ; "completed_last")]
+    #[test_case(SessionStatus::Idle, 2 ; "idle_with_completed")]
+    #[test_case(SessionStatus::Error, 2 ; "error_with_completed")]
+    fn status_orders_into_sections(status: SessionStatus, expected_rank: u8) {
+        assert_eq!(section_rank(status), expected_rank);
+    }
+
+    #[test_case(SessionStatus::NeedsInput, SECTION_NEEDS_INPUT ; "needs_input_label")]
+    #[test_case(SessionStatus::Working, SECTION_WORKING ; "working_label")]
+    #[test_case(SessionStatus::Completed, SECTION_COMPLETED ; "completed_label")]
+    fn status_maps_to_section_label(status: SessionStatus, expected: &str) {
+        assert_eq!(section_label(status), expected);
+    }
+
+    fn press(dash: &mut SessionDashboard, code: KeyCode) -> DashboardAction {
+        dash.handle_key(KeyEvent::new(code, KeyModifiers::empty()))
+    }
+
+    #[test]
+    fn typing_and_enter_pass_through_to_shared_input() {
+        let mut dash = SessionDashboard::new();
+        // Printable keys and Enter are not dashboard-navigation, so they are
+        // passed through to the App's shared input box.
+        assert!(matches!(
+            press(&mut dash, KeyCode::Char('x')),
+            DashboardAction::Passthrough(_)
+        ));
+        assert!(matches!(
+            press(&mut dash, KeyCode::Enter),
+            DashboardAction::Passthrough(_)
+        ));
+    }
+
+    #[test]
+    fn navigation_keys_stay_in_dashboard() {
+        let mut dash = SessionDashboard::new();
+        assert!(matches!(
+            press(&mut dash, KeyCode::Up),
+            DashboardAction::Consumed
+        ));
+        assert!(matches!(
+            press(&mut dash, KeyCode::Down),
+            DashboardAction::Consumed
+        ));
+        // Right with no selection is consumed (nothing to open).
+        assert!(matches!(
+            press(&mut dash, KeyCode::Right),
+            DashboardAction::Consumed
+        ));
+    }
+}

--- a/maki-ui/src/components/session_picker.rs
+++ b/maki-ui/src/components/session_picker.rs
@@ -2,11 +2,11 @@ use std::thread;
 
 use crate::AppSession;
 use crate::components::Overlay;
+use crate::components::format_relative_time;
 use crate::components::keybindings::key;
 use crate::components::list_picker::{ListPicker, PickerAction, PickerItem};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use jiff::Timestamp;
 use maki_storage::StateDir;
 use ratatui::Frame;
 use ratatui::layout::{Position, Rect};
@@ -189,48 +189,5 @@ impl Overlay for SessionPicker {
 
     fn close(&mut self) {
         self.close()
-    }
-}
-
-fn format_relative_time(epoch_secs: u64) -> String {
-    let ts = Timestamp::from_second(epoch_secs as i64).unwrap_or(Timestamp::UNIX_EPOCH);
-    let now = Timestamp::now();
-    let secs = now.as_second().saturating_sub(ts.as_second()).max(0) as u64;
-    humanize_secs(secs)
-}
-
-fn humanize_secs(secs: u64) -> String {
-    const MINUTE: u64 = 60;
-    const HOUR: u64 = 3600;
-    const DAY: u64 = 86400;
-    const WEEK: u64 = 604800;
-    const MONTH: u64 = 2592000;
-    const YEAR: u64 = 31536000;
-
-    match secs {
-        0..MINUTE => "just now".into(),
-        MINUTE..HOUR => format!("{}m ago", secs / MINUTE),
-        HOUR..DAY => format!("{}h ago", secs / HOUR),
-        DAY..WEEK => format!("{}d ago", secs / DAY),
-        WEEK..MONTH => format!("{}w ago", secs / WEEK),
-        MONTH..YEAR => format!("{}mo ago", secs / MONTH),
-        _ => format!("{}y ago", secs / YEAR),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use test_case::test_case;
-
-    #[test_case(0, "just now" ; "below_minute")]
-    #[test_case(60, "1m ago" ; "minute_boundary")]
-    #[test_case(3600, "1h ago" ; "hour_boundary")]
-    #[test_case(86400, "1d ago" ; "day_boundary")]
-    #[test_case(604800, "1w ago" ; "week_boundary")]
-    #[test_case(2592000, "1mo ago" ; "month_boundary")]
-    #[test_case(31536000, "1y ago" ; "year_boundary")]
-    fn relative_time_formatting(secs: u64, expected: &str) {
-        assert_eq!(humanize_secs(secs), expected);
     }
 }

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -9,6 +9,7 @@ use crossterm::event::{
     self, Event, KeyEventKind, MouseButton, MouseEvent as CtMouseEvent, MouseEventKind,
 };
 use maki_agent::command::CustomCommand;
+use std::path::PathBuf;
 use maki_agent::permissions::PermissionManager;
 use maki_agent::{AgentConfig, CancelToken, McpCommand};
 use maki_config::UiConfig;
@@ -50,24 +51,51 @@ pub struct EventLoopParams {
     pub hint_reader: HintReader,
     pub ui_action_rx: Option<flume::Receiver<UiAction>>,
     pub lua_event_handle: Option<EventHandle>,
+    /// Open directly on the multi-session agents dashboard (`maki agents`).
+    pub dashboard: bool,
+}
+
+/// One interactive session: its UI `App`, the agent runner driving it, and the
+/// shell channel scoped to that session. The event loop owns a set of these and
+/// focuses one at a time; unfocused runtimes keep making progress because their
+/// agent tasks live on the smol executor regardless of focus.
+pub(crate) struct SessionRuntime {
+    app: App,
+    handles: AgentHandles,
+    shell_tx: flume::Sender<ShellEvent>,
+    shell_rx: flume::Receiver<ShellEvent>,
 }
 
 pub(crate) struct EventLoop<'t> {
     terminal: &'t mut ratatui::DefaultTerminal,
-    app: App,
-    handles: AgentHandles,
+    sessions: Vec<SessionRuntime>,
+    focused: usize,
     model_slot: Arc<ArcSwap<ModelSlot>>,
     config: AgentConfig,
     permissions: Arc<PermissionManager>,
-    shell_tx: flume::Sender<ShellEvent>,
-    shell_rx: flume::Receiver<ShellEvent>,
     warn_rx: flume::Receiver<String>,
     warn_tx: flume::Sender<String>,
     available_models: Arc<ArcSwapOption<Vec<String>>>,
     storage_writer: Arc<StorageWriter>,
     timeouts: Timeouts,
     ui_action_rx: Option<flume::Receiver<UiAction>>,
+    spawn_ctx: SpawnContext,
     _model_fetch_task: smol::Task<()>,
+}
+
+/// Cloneable inputs needed to build additional `SessionRuntime`s at runtime
+/// (e.g. when the dashboard spawns or opens a session). All fields are cheap
+/// Arc-backed handles or shared config.
+struct SpawnContext {
+    storage: StateDir,
+    ui_config: UiConfig,
+    input_history_size: usize,
+    lua_command_reader: LuaCommandReader,
+    keymap_reader: KeymapReader,
+    hint_reader: HintReader,
+    lua_event_handle: Option<EventHandle>,
+    custom_commands: Arc<[CustomCommand]>,
+    cwd: PathBuf,
 }
 
 struct BackgroundModels {
@@ -173,6 +201,7 @@ impl<'t> EventLoop<'t> {
             hint_reader,
             ui_action_rx,
             lua_event_handle,
+            dashboard,
         } = params;
 
         std::thread::spawn(crate::highlight::warmup);
@@ -203,13 +232,24 @@ impl<'t> EventLoop<'t> {
             config.clone(),
             ui_config.tool_output_lines,
             &permissions,
-            cwd,
+            cwd.clone(),
             Some(session.id.clone()),
             timeouts,
             lua_event_handle.clone(),
         );
 
         let custom_commands: Arc<[CustomCommand]> = Arc::from(commands);
+        let spawn_ctx = SpawnContext {
+            storage: storage.clone(),
+            ui_config,
+            input_history_size,
+            lua_command_reader: lua_command_reader.clone(),
+            keymap_reader: keymap_reader.clone(),
+            hint_reader: hint_reader.clone(),
+            lua_event_handle: lua_event_handle.clone(),
+            custom_commands: Arc::clone(&custom_commands),
+            cwd,
+        };
         let mut app = App::new(
             &model,
             session,
@@ -228,6 +268,10 @@ impl<'t> EventLoop<'t> {
         );
         app.exit_on_done = exit_on_done;
         app.lua_event_handle = lua_event_handle;
+        app.dashboard = dashboard;
+        if dashboard {
+            app.open_dashboard();
+        }
 
         if needs_login {
             app.login_picker.open(app.storage.clone());
@@ -245,19 +289,23 @@ impl<'t> EventLoop<'t> {
 
         Ok(Self {
             terminal,
-            app,
-            handles,
+            sessions: vec![SessionRuntime {
+                app,
+                handles,
+                shell_tx,
+                shell_rx,
+            }],
+            focused: 0,
             model_slot,
             config,
             permissions,
-            shell_tx,
-            shell_rx,
             warn_rx: bg.warn_rx,
             warn_tx: bg.warn_tx,
             available_models: bg.available,
             storage_writer,
             timeouts,
             ui_action_rx,
+            spawn_ctx,
             _model_fetch_task: bg.task,
         })
     }
@@ -268,15 +316,15 @@ impl<'t> EventLoop<'t> {
                 text: prompt,
                 images: Vec::new(),
             };
-            let actions = self.app.handle_submit(sub);
-            self.dispatch(actions);
+            let actions = self.sessions[self.focused].app.handle_submit(sub);
+            self.dispatch(self.focused, actions);
         }
         loop {
             self.tick();
             let had_agent_msg = self.drain_channels();
-            self.terminal.draw(|f| self.app.view(f))?;
+            self.terminal.draw(|f| self.sessions[self.focused].app.view(f))?;
 
-            if self.app.exit_request != ExitRequest::None {
+            if self.sessions[self.focused].app.exit_request != ExitRequest::None {
                 return Ok(self.shutdown());
             }
 
@@ -285,56 +333,49 @@ impl<'t> EventLoop<'t> {
     }
 
     fn tick(&mut self) {
-        self.app.tick_edge_scroll();
-        self.app.tick_error_expiry();
-        self.app.poll_image_paste();
-        self.app.btw_modal.poll();
-        self.app.status_bar.poll_branch_update();
-        self.app.mcp_picker.refresh();
-        self.app.float_mgr.tick();
+        // Only the focused session drives UI-affecting timers/pollers; the
+        // background sessions still make agent progress via drain_channels.
+        let rt = &mut self.sessions[self.focused];
+        rt.app.tick_edge_scroll();
+        rt.app.tick_error_expiry();
+        rt.app.poll_image_paste();
+        rt.app.btw_modal.poll();
+        rt.app.status_bar.poll_branch_update();
+        rt.app.mcp_picker.refresh();
+        rt.app.float_mgr.tick();
     }
 
     fn drain_channels(&mut self) -> bool {
-        while let Ok(event) = self.shell_rx.try_recv() {
-            self.app.handle_shell_event(event);
-        }
-
         let mut had_agent_msg = false;
-        loop {
-            match self.handles.agent_rx.try_recv() {
-                Ok(envelope) => {
-                    had_agent_msg = true;
-                    let actions = self.app.update(Msg::Agent(Box::new(envelope)));
-                    self.dispatch(actions);
-                }
-                Err(flume::TryRecvError::Disconnected) if self.app.status == Status::Streaming => {
-                    self.app.status = Status::error("agent stopped unexpectedly".into());
-                    break;
-                }
-                Err(_) => break,
-            }
+
+        // Every session advances, focused or not, so background work keeps
+        // progressing while the user supervises from another session/dashboard.
+        for idx in 0..self.sessions.len() {
+            had_agent_msg |= self.drain_session(idx);
         }
 
         while let Ok(warning) = self.warn_rx.try_recv() {
-            self.app.flash(warning);
+            self.sessions[self.focused].app.flash(warning);
         }
 
         let slot_model = self.model_slot.load();
-        if slot_model.model.context_window != self.app.state.model.context_window {
-            self.app.update_model(&slot_model.model);
+        if slot_model.model.context_window
+            != self.sessions[self.focused].app.state.model.context_window
+        {
+            self.sessions[self.focused].app.update_model(&slot_model.model);
         }
 
         if let Some(rx) = &self.ui_action_rx {
             while let Ok(action) = rx.try_recv() {
                 match action {
                     UiAction::Flash(msg) => {
-                        self.app.flash(msg);
+                        self.sessions[self.focused].app.flash(msg);
                     }
                     UiAction::OpenEditor { path, reply_tx } => {
                         let code = match crate::terminal::open_in_editor(&path, self.terminal) {
                             Ok(code) => code,
                             Err(e) => {
-                                self.app.flash(e);
+                                self.sessions[self.focused].app.flash(e);
                                 -1
                             }
                         };
@@ -347,11 +388,11 @@ impl<'t> EventLoop<'t> {
                         event_tx,
                         cmd_rx,
                     } => {
-                        self.app
+                        self.sessions[self.focused].app
                             .float_mgr
                             .open(buf, config, focus, event_tx, cmd_rx);
                         if focus {
-                            self.app
+                            self.sessions[self.focused].app
                                 .transition_plan(crate::app::mode::PlanTrigger::InteractivePrompt);
                         }
                     }
@@ -366,7 +407,7 @@ impl<'t> EventLoop<'t> {
         let has_pending_ui_action = self.ui_action_rx.as_ref().is_some_and(|rx| !rx.is_empty());
         let poll_duration = if had_agent_msg || has_pending_ui_action {
             Duration::ZERO
-        } else if self.app.is_animating() {
+        } else if self.sessions[self.focused].app.is_animating() {
             Duration::from_millis(ANIMATION_INTERVAL_MS)
         } else {
             Duration::from_millis(IDLE_POLL_INTERVAL_MS)
@@ -377,8 +418,8 @@ impl<'t> EventLoop<'t> {
         }
 
         if let Some(msg) = self.translate_input()? {
-            let actions = self.app.update(msg);
-            self.dispatch(actions);
+            let actions = self.sessions[self.focused].app.update(msg);
+            self.dispatch(self.focused, actions);
         }
         Ok(())
     }
@@ -400,12 +441,12 @@ impl<'t> EventLoop<'t> {
                 let (scroll, extra) = aggregate_scroll(
                     mouse.column,
                     mouse.row,
-                    scroll_delta(mouse.kind, self.app.ui_config.mouse_scroll_lines),
-                    self.app.ui_config.mouse_scroll_lines,
+                    scroll_delta(mouse.kind, self.sessions[self.focused].app.ui_config.mouse_scroll_lines),
+                    self.sessions[self.focused].app.ui_config.mouse_scroll_lines,
                 );
                 if let Some(extra) = extra {
-                    let actions = self.app.update(scroll);
-                    self.dispatch(actions);
+                    let actions = self.sessions[self.focused].app.update(scroll);
+                    self.dispatch(self.focused, actions);
                     Some(extra)
                 } else {
                     Some(scroll)
@@ -413,40 +454,188 @@ impl<'t> EventLoop<'t> {
             }
             MouseEventKind::Drag(MouseButton::Left) => {
                 let (drag, extra) = coalesce_drag(mouse);
-                let actions = self.app.update(Msg::Mouse(drag));
-                self.dispatch(actions);
+                let actions = self.sessions[self.focused].app.update(Msg::Mouse(drag));
+                self.dispatch(self.focused, actions);
                 extra
             }
             _ => Some(Msg::Mouse(mouse)),
         }
     }
 
-    fn dispatch(&mut self, actions: Vec<Action>) {
+    fn drain_session(&mut self, idx: usize) -> bool {
+        while let Ok(event) = self.sessions[idx].shell_rx.try_recv() {
+            self.sessions[idx].app.handle_shell_event(event);
+        }
+
+        let mut had_agent_msg = false;
+        loop {
+            match self.sessions[idx].handles.agent_rx.try_recv() {
+                Ok(envelope) => {
+                    had_agent_msg = true;
+                    let actions = self.sessions[idx].app.update(Msg::Agent(Box::new(envelope)));
+                    self.dispatch(idx, actions);
+                }
+                Err(flume::TryRecvError::Disconnected)
+                    if self.sessions[idx].app.status == Status::Streaming =>
+                {
+                    self.sessions[idx].app.status =
+                        Status::error("agent stopped unexpectedly".into());
+                    break;
+                }
+                Err(_) => break,
+            }
+        }
+        had_agent_msg
+    }
+
+    fn dispatch(&mut self, idx: usize, actions: Vec<Action>) {
         for action in actions {
-            self.handle_action(action);
+            self.handle_action(idx, action);
         }
     }
 
-    fn respawn_agent(&mut self, history: Vec<Message>) {
-        let lua_handle = self.app.lua_event_handle.clone();
-        self.handles.respawn(
-            history,
+    /// Build a fresh background `SessionRuntime` for the given stored session,
+    /// sharing the process-wide resources captured in `spawn_ctx`.
+    fn build_runtime(&self, session: AppSession, initial_history: Vec<Message>) -> SessionRuntime {
+        let ctx = &self.spawn_ctx;
+        let (shell_tx, shell_rx) = flume::unbounded::<ShellEvent>();
+        let model = self.model_slot.load().model.clone();
+
+        let handles = AgentHandles::spawn(
             &self.model_slot,
+            initial_history,
             self.config.clone(),
-            self.app.ui_config.tool_output_lines,
+            ctx.ui_config.tool_output_lines,
             &self.permissions,
-            &mut self.app,
+            ctx.cwd.clone(),
+            Some(session.id.clone()),
+            self.timeouts,
+            ctx.lua_event_handle.clone(),
+        );
+
+        let mut app = App::new(
+            &model,
+            session,
+            ctx.storage.clone(),
+            Arc::clone(&self.available_models),
+            handles.mcp_reader(),
+            handles.mcp_config_errors.clone(),
+            ctx.lua_command_reader.clone(),
+            ctx.keymap_reader.clone(),
+            ctx.hint_reader.clone(),
+            Arc::clone(&self.storage_writer),
+            ctx.ui_config,
+            ctx.input_history_size,
+            Arc::clone(&self.permissions),
+            Arc::clone(&ctx.custom_commands),
+        );
+        app.lua_event_handle = ctx.lua_event_handle.clone();
+        handles.apply_to_app(&mut app);
+        if !handles.mcp_config_errors.is_empty() {
+            app.flash(format!("MCP config error: {}", handles.mcp_config_errors));
+        }
+
+        SessionRuntime {
+            app,
+            handles,
+            shell_tx,
+            shell_rx,
+        }
+    }
+
+    /// Move focus to the previous (-1) or next (+1) live session runtime,
+    /// wrapping around. No-op when only one session is running.
+    fn cycle_focus(&mut self, delta: i32) {
+        let n = self.sessions.len();
+        if n <= 1 {
+            return;
+        }
+        let cur = self.focused as i32;
+        let next = (cur + delta).rem_euclid(n as i32) as usize;
+        self.focused = next;
+    }
+
+    /// Focus an existing runtime by session id, or attach the stored session as
+    /// a new background runtime and focus it. Does not disturb other sessions.
+    fn focus_session(&mut self, id: String) {
+        if let Some(pos) = self
+            .sessions
+            .iter()
+            .position(|rt| rt.app.state.session.id == id)
+        {
+            self.focused = pos;
+            return;
+        }
+
+        let session = match AppSession::load(&id, &self.spawn_ctx.storage) {
+            Ok(s) => s,
+            Err(e) => {
+                self.sessions[self.focused]
+                    .app
+                    .flash(format!("Failed to load session: {e}"));
+                return;
+            }
+        };
+        let history = session.messages.clone();
+        let mut rt = self.build_runtime(session, history.clone());
+        if !history.is_empty() {
+            restore_session(&mut rt.app, &rt.handles);
+        }
+        self.sessions.push(rt);
+        self.focused = self.sessions.len() - 1;
+    }
+
+    /// Create a brand-new background session, optionally seeded with a task
+    /// prompt, and focus it.
+    fn spawn_session(&mut self, submission: Option<Box<Submission>>) {
+        let cwd = self.spawn_ctx.cwd.to_string_lossy().into_owned();
+        let model_spec = self.model_slot.load().model.spec();
+        let mut session = AppSession::new(&model_spec, &cwd);
+        if let Err(e) = session.save(&self.spawn_ctx.storage) {
+            self.sessions[self.focused]
+                .app
+                .flash(format!("Failed to create session: {e}"));
+            return;
+        }
+        let rt = self.build_runtime(session, Vec::new());
+        self.sessions.push(rt);
+        self.focused = self.sessions.len() - 1;
+
+        if let Some(sub) = submission {
+            let sub = *sub;
+            if !sub.is_empty() {
+                let idx = self.focused;
+                let actions = self.sessions[idx].app.handle_submit(sub);
+                self.dispatch(idx, actions);
+            }
+        }
+    }
+
+    fn respawn_agent(&mut self, idx: usize, history: Vec<Message>) {
+        let model_slot = Arc::clone(&self.model_slot);
+        let permissions = Arc::clone(&self.permissions);
+        let config = self.config.clone();
+        let rt = &mut self.sessions[idx];
+        let lua_handle = rt.app.lua_event_handle.clone();
+        let tool_output_lines = rt.app.ui_config.tool_output_lines;
+        rt.handles.respawn(
+            history,
+            &model_slot,
+            config,
+            tool_output_lines,
+            &permissions,
+            &mut rt.app,
             lua_handle,
         );
     }
 
-    fn handle_action(&mut self, action: Action) {
+    fn handle_action(&mut self, idx: usize, action: Action) {
         match action {
             Action::SendMessage(input) => {
                 let mut input = *input;
-                input.preamble = self.app.shell.drain_results();
-                let run_id = self.app.run_id;
-                self.handles.queue.push(QueueItem::Message {
+                input.preamble = self.sessions[idx].app.shell.drain_results();
+                let run_id = self.sessions[idx].app.run_id;
+                self.sessions[idx].handles.queue.push(QueueItem::Message {
                     text: input.message.clone(),
                     image_count: input.images.len(),
                     input,
@@ -455,19 +644,19 @@ impl<'t> EventLoop<'t> {
                 });
             }
             Action::CancelAgent { run_id } => {
-                let _ = self
+                let _ = self.sessions[idx]
                     .handles
                     .cmd_tx
                     .try_send(AgentCommand::Cancel { run_id });
             }
             Action::CancelSubagent { tool_use_id } => {
-                let _ = self
+                let _ = self.sessions[idx]
                     .handles
                     .cmd_tx
                     .try_send(AgentCommand::CancelSubagent { tool_use_id });
             }
             Action::NewSession => {
-                self.respawn_agent(Vec::new());
+                self.respawn_agent(idx, Vec::new());
             }
             Action::LoadSession(loaded) => {
                 let loaded = *loaded;
@@ -475,14 +664,14 @@ impl<'t> EventLoop<'t> {
                     && let Ok(mut new_model) = Model::from_spec(&loaded.model_spec)
                     && let Ok(new_provider) = from_model(&mut new_model, self.timeouts)
                 {
-                    self.app.usage_slot.store(None);
+                    self.sessions[idx].app.usage_slot.store(None);
                     self.model_slot.store(Arc::new(ModelSlot {
                         model: new_model,
                         provider: Arc::from(new_provider),
                     }));
                 }
-                self.respawn_agent(loaded.messages);
-                *self
+                self.respawn_agent(idx, loaded.messages);
+                *self.sessions[idx]
                     .handles
                     .tool_outputs
                     .lock()
@@ -491,18 +680,18 @@ impl<'t> EventLoop<'t> {
             Action::ChangeModel(spec) => self.change_model(spec),
             Action::RefreshProvider { slug } => self.refresh_provider(slug),
             Action::AssignTier(spec, tier) => {
-                maki_providers::model_registry::set_and_persist(spec, tier, &self.app.storage);
+                maki_providers::model_registry::set_and_persist(spec, tier, &self.sessions[idx].app.storage);
             }
             Action::UnassignTier(spec, tier) => {
-                maki_providers::model_registry::unset_and_persist(&spec, tier, &self.app.storage);
+                maki_providers::model_registry::unset_and_persist(&spec, tier, &self.sessions[idx].app.storage);
             }
             Action::Compact => {
-                self.handles.queue.push(QueueItem::Compact {
-                    run_id: self.app.run_id,
+                self.sessions[idx].handles.queue.push(QueueItem::Compact {
+                    run_id: self.sessions[idx].app.run_id,
                 });
             }
             Action::ToggleMcp(server_name, enabled) => {
-                self.handles.send_mcp(McpCommand::Toggle {
+                self.sessions[idx].handles.send_mcp(McpCommand::Toggle {
                     server: server_name,
                     enabled,
                 });
@@ -513,32 +702,42 @@ impl<'t> EventLoop<'t> {
                 visible,
             } => {
                 let (trigger, cancel) = CancelToken::new();
-                self.app.shell.add_trigger(trigger);
+                self.sessions[idx].app.shell.add_trigger(trigger);
                 spawn_shell(
                     command,
                     id,
                     visible,
-                    self.shell_tx.clone(),
+                    self.sessions[idx].shell_tx.clone(),
                     cancel,
                     self.config.clone(),
                 );
             }
             Action::OpenEditor(path) => {
                 if let Err(e) = terminal::open_in_editor(&path, self.terminal) {
-                    self.app.flash(e);
+                    self.sessions[idx].app.flash(e);
                 }
             }
             Action::EditInputInEditor => {
-                let current_text = self.app.input_box.buffer.value();
+                let current_text = self.sessions[idx].app.input_box.buffer.value();
                 match terminal::edit_temp_content(&current_text, self.terminal) {
-                    Ok(edited) => self.app.input_box.set_input(edited),
-                    Err(e) => self.app.flash(e),
+                    Ok(edited) => self.sessions[idx].app.input_box.set_input(edited),
+                    Err(e) => self.sessions[idx].app.flash(e),
                 }
             }
             Action::Btw(question) => {
                 let slot = self.model_slot.load();
-                self.app
-                    .start_btw(question, Arc::clone(&slot.provider), slot.model.clone());
+                self.sessions[idx].app.start_btw(
+                    question,
+                    Arc::clone(&slot.provider),
+                    slot.model.clone(),
+                );
+            }
+            Action::FocusSession(id) => self.focus_session(id),
+            Action::SpawnSession(prompt) => self.spawn_session(prompt),
+            Action::FocusPrevSession => self.cycle_focus(-1),
+            Action::FocusNextSession => self.cycle_focus(1),
+            Action::ShowDashboard => {
+                self.sessions[idx].app.open_dashboard();
             }
             Action::Suspend => terminal::suspend(self.terminal),
             Action::RefreshModels => self.refresh_models(),
@@ -551,17 +750,17 @@ impl<'t> EventLoop<'t> {
         match Model::from_spec(&spec) {
             Ok(mut new_model) => match from_model(&mut new_model, self.timeouts) {
                 Ok(new_provider) => {
-                    self.app.update_model(&new_model);
-                    self.app.record_recent_model(&spec);
-                    self.app.usage_slot.store(None);
+                    self.sessions[self.focused].app.update_model(&new_model);
+                    self.sessions[self.focused].app.record_recent_model(&spec);
+                    self.sessions[self.focused].app.usage_slot.store(None);
                     self.model_slot.store(Arc::new(ModelSlot {
                         model: new_model,
                         provider: Arc::from(new_provider),
                     }));
                 }
-                Err(e) => self.app.flash(format!("Failed to create provider: {e}")),
+                Err(e) => self.sessions[self.focused].app.flash(format!("Failed to create provider: {e}")),
             },
-            Err(e) => self.app.flash(format!("Invalid model: {e}")),
+            Err(e) => self.sessions[self.focused].app.flash(format!("Invalid model: {e}")),
         }
     }
 
@@ -577,7 +776,7 @@ impl<'t> EventLoop<'t> {
 
     fn refresh_usage(&self) {
         let provider = Arc::clone(&self.model_slot.load().provider);
-        let slot = Arc::clone(&self.app.usage_slot);
+        let slot = Arc::clone(&self.sessions[self.focused].app.usage_slot);
         slot.store(Some(Arc::new(UsageFetchState::Loading)));
         smol::spawn(async move {
             let state = match provider.fetch_usage().await {
@@ -597,7 +796,7 @@ impl<'t> EventLoop<'t> {
         if current_model.provider.to_string() == slug {
             let mut m = current_model.clone();
             if let Ok(provider) = maki_providers::provider::from_model(&mut m, self.timeouts) {
-                self.app.usage_slot.store(None);
+                self.sessions[self.focused].app.usage_slot.store(None);
                 self.model_slot.store(Arc::new(ModelSlot {
                     model: m,
                     provider: Arc::from(provider),
@@ -610,16 +809,24 @@ impl<'t> EventLoop<'t> {
     }
 
     fn shutdown(mut self) -> (Option<String>, i32) {
-        let exit_code = self.app.exit_request.code();
-        let session_id = self
+        let focused = self.focused;
+        let exit_code = self.sessions[focused].app.exit_request.code();
+        let session_id = self.sessions[focused]
             .app
             .has_content()
-            .then(|| self.app.state.session.id.clone());
-        maki_agent::mcp::kill_process_groups(&self.handles.mcp_reader().load().pids);
-        self.app.cmd_tx = None;
-        self.app.answer_tx = None;
-        drop(self.app);
-        self.handles.shutdown(Duration::from_secs(3));
+            .then(|| self.sessions[focused].app.state.session.id.clone());
+
+        for rt in self.sessions.drain(..) {
+            let SessionRuntime {
+                mut app, handles, ..
+            } = rt;
+            maki_agent::mcp::kill_process_groups(&handles.mcp_reader().load().pids);
+            app.cmd_tx = None;
+            app.answer_tx = None;
+            drop(app);
+            handles.shutdown(Duration::from_secs(3));
+        }
+
         match Arc::try_unwrap(self.storage_writer) {
             Ok(writer) => writer.shutdown(Duration::from_secs(3)),
             Err(_) => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -225,6 +225,12 @@ pub enum Command {
         #[arg(long)]
         yolo: bool,
     },
+    /// Open the multi-session agents dashboard
+    Agents {
+        /// Model spec (provider/model-id)
+        #[arg(short, long)]
+        model: Option<String>,
+    },
     /// Show the rendered system prompt or tool definitions
     Prompt {
         /// Prompt variant: system (default), research, general

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -11,8 +11,8 @@ use maki_storage::StateDir;
 use crate::cli::{AuthAction, Cli, Command, McpAction, MigrateAction};
 use crate::update;
 
-pub fn dispatch(cli: Cli) -> Result<()> {
-    match cli.command {
+pub fn dispatch(mut cli: Cli) -> Result<()> {
+    match cli.command.take() {
         Some(Command::Auth { action }) => {
             let storage = StateDir::resolve().context("resolve data directory")?;
             match action {
@@ -44,6 +44,12 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         }
         Some(Command::Acp { model, yolo }) => {
             acp::run(model, yolo)?;
+        }
+        Some(Command::Agents { model }) => {
+            if model.is_some() {
+                cli.model = model;
+            }
+            tui::run_dashboard(cli)?;
         }
         Some(Command::Migrate { action }) => match action {
             MigrateAction::Xdg => migrate::xdg()?,

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -61,6 +61,15 @@ fn read_initial_prompt(cli_prompt: Option<String>) -> Result<Option<String>> {
 }
 
 pub fn run(cli: Cli) -> Result<()> {
+    run_inner(cli, false)
+}
+
+/// Launch the TUI directly on the multi-session agents dashboard (`maki agents`).
+pub fn run_dashboard(cli: Cli) -> Result<()> {
+    run_inner(cli, true)
+}
+
+fn run_inner(cli: Cli, dashboard: bool) -> Result<()> {
     let storage = StateDir::resolve().context("resolve data directory")?;
     maki_providers::model_registry::load_from_storage(&storage);
 
@@ -210,6 +219,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 hint_reader: plugin_host.hint_reader(),
                 ui_action_rx,
                 lua_event_handle: plugin_host.event_handle(),
+                dashboard,
             },
             initial_prompt,
         )


### PR DESCRIPTION
A Claude Code-style multi-session dashboard, opened with a new `maki agents` subcommand. Plain `maki` is unchanged.

## What you get
Run `maki agents` to get a board of the current directory's sessions grouped by status — **Needs input / Working / Completed** — that refreshes live (~1s). From it you can:
- **Spawn** a new session by typing a task and pressing Enter (Ctrl-N for an empty one).
- **Open** a session (Right/Enter), **navigate** (Up/Down), **delete** (Ctrl-D).
- The new-session prompt is maki's real input box, so it supports the `/` command palette, the file picker, image paste/drag, multi-row wrapping, and Shift+Enter / Ctrl+J for newlines. Attached images are sent with the first message.

Inside a session, when the input box is empty: **Left** returns to the board and **Up/Down** jump to the previous/next live session — even while a session is mid-response.

## Background concurrency (the interesting part)
Sessions run **concurrently in the background**. `EventLoop` now holds `sessions: Vec<SessionRuntime>` + a focused index and a `SpawnContext` of shared Arc-backed resources. Every session is drained each tick so background agents keep making progress while unfocused; only the focused session renders. `dispatch`/`handle_action` are session-indexed. A backgrounded session that hits a permission prompt flips to `NeedsInput` and waits until you focus it (maki isn't `--yolo` by default).

This is done as an in-process supervisor over the existing single-`App` design (each session keeps its own `App` + `AgentHandles`), reusing the smol + flume runtime — so spawning N agent loops just works.

## Also included
- `SessionStatus` on `SessionMeta`/`SessionSummary`, persisted and derived from the runtime state, so the board reflects Working/NeedsInput/Completed live. Back-compat: old sessions default to `Idle`.
- The `/rename <title>` slash command (this is also up as the smaller standalone #494 — this PR includes it; merge whichever you prefer).
- Fix: `SessionLog::append` used to drop title-only changes (no new messages) — it now persists them.

## Notes / open questions
- The dashboard is currently a per-`App` component that reads the shared session store; a future cleanup could hoist it to a loop-level screen. Happy to adjust the architecture to your taste — this is a large change and I expect you'll have opinions on the concurrency model.
- Two clean commits: storage schema/persistence, then the dashboard + concurrency.

`cargo clippy --all --tests` clean; `cargo test` passes (storage 88, ui 1007).

> Disclosure: developed with AI assistance (it's maki-in-spirit), reviewed and verified by me. Branched off an earlier main; builds cleanly against current main.