### PR TITLE
fix(agent): carry the todo list across compaction (#493)

### DIFF
--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -10,7 +10,7 @@ use super::streaming::stream_with_retry;
 use crate::cancel::CancelToken;
 use crate::{AgentError, AgentEvent, EventSender, TurnCompleteEvent};
 
-pub(super) const CONTINUE_AFTER_COMPACT: &str = "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed. If you learned important project context during this session, consider saving it to memory before it's lost.";
+pub(super) const CONTINUE_AFTER_COMPACT: &str = "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed. If the summary contains a todo list, restore it with todo_write and keep it updated. If you learned important project context during this session, consider saving it to memory before it's lost.";
 const IMAGE_PLACEHOLDER: &str = "[image]";
 
 pub(super) async fn compact_history(

--- a/maki-agent/src/prompts/compaction_user.md
+++ b/maki-agent/src/prompts/compaction_user.md
@@ -18,4 +18,7 @@ Stick to this template:
 
 ## Relevant files / directories
 [Structured list of relevant files that have been read, edited, or created]
+
+## Todo list
+[If a todo list was in use, repeat it here verbatim with each item's current status; it must be kept up to date with todo_write after continuing. Otherwise omit this section]
 ---


### PR DESCRIPTION
After compaction the model forgot its todo list and stopped updating it.

The summary template now has a `## Todo list` section that repeats the list verbatim with statuses, and `CONTINUE_AFTER_COMPACT` tells the model to restore it with `todo_write` and keep it updated.