### PR TITLE
ui: Flush streaming buffers after compaction to prevent message merging

### DIFF
--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -446,6 +446,7 @@ impl<'h> Agent<'h> {
         )
         .await?;
         self.rollback_len = self.history.len();
+        self.event_tx.send(AgentEvent::CompactionDone)?;
         self.history
             .push(Message::synthetic(CONTINUE_AFTER_COMPACT.into()));
         Ok(())

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -559,6 +559,7 @@ pub enum AgentEvent {
         stop_reason: Option<StopReason>,
     },
     AutoCompacting,
+    CompactionDone,
     Retry {
         attempt: u32,
         message: String,

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -111,6 +111,9 @@ impl Chat {
                     "Auto-compacting conversation...".into(),
                 ));
             }
+            AgentEvent::CompactionDone => {
+                self.messages_panel.flush();
+            }
             AgentEvent::QueueItemConsumed { text, image_count } => {
                 return ChatEventResult::QueueItemConsumed { text, image_count };
             }
@@ -337,6 +340,16 @@ impl Chat {
     #[cfg(test)]
     pub fn last_message_role(&self) -> Option<&DisplayRole> {
         self.messages_panel.last_message_role()
+    }
+
+    #[cfg(test)]
+    pub fn streaming_text_is_empty(&self) -> bool {
+        self.messages_panel.streaming_text_is_empty()
+    }
+
+    #[cfg(test)]
+    pub fn streaming_thinking_is_empty(&self) -> bool {
+        self.messages_panel.streaming_thinking_is_empty()
     }
 }
 
@@ -949,5 +962,38 @@ mod tests {
         let mut no_output = tool_msg_with_input("bash");
         no_output.tool_output = None;
         assert!(restore_item_for(&no_output, tol, RESTORE_THEME_GEN).is_none());
+    }
+
+    #[test]
+    fn compaction_done_flushes_streaming_buffers() {
+        let mut chat = Chat::new("Main".into(), UiConfig::default());
+
+        chat.handle_event(AgentEvent::AutoCompacting, None);
+        assert_eq!(chat.message_count(), 1);
+
+        chat.handle_event(
+            AgentEvent::TextDelta {
+                text: "summary".into(),
+            },
+            None,
+        );
+        chat.handle_event(
+            AgentEvent::ThinkingDelta {
+                text: "thinking".into(),
+            },
+            None,
+        );
+        assert!(!chat.streaming_text_is_empty());
+        assert!(!chat.streaming_thinking_is_empty());
+
+        chat.handle_event(AgentEvent::CompactionDone, None);
+        assert!(chat.streaming_text_is_empty());
+        assert!(chat.streaming_thinking_is_empty());
+        assert_eq!(chat.message_count(), 3);
+
+        chat.handle_event(AgentEvent::TextDelta { text: "new".into() }, None);
+        chat.flush();
+        assert_eq!(chat.message_count(), 4);
+        assert_eq!(chat.last_message_text(), "new");
     }
 }

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -466,6 +466,16 @@ impl MessagesPanel {
         self.current_snapshot_gen(tool_id)
     }
 
+    #[cfg(test)]
+    pub fn streaming_text_is_empty(&self) -> bool {
+        self.streaming_text.is_empty()
+    }
+
+    #[cfg(test)]
+    pub fn streaming_thinking_is_empty(&self) -> bool {
+        self.streaming_thinking.is_empty()
+    }
+
     pub fn flush(&mut self) {
         self.flush_thinking();
         if !self.streaming_text.is_empty() {

--- a/src/print.rs
+++ b/src/print.rs
@@ -236,6 +236,7 @@ pub fn run(
             | AgentEvent::ToolDone(_)
             | AgentEvent::QueueItemConsumed { .. }
             | AgentEvent::AutoCompacting
+            | AgentEvent::CompactionDone
             | AgentEvent::AuthRequired
             | AgentEvent::PermissionRequest { .. }
             | AgentEvent::SubagentHistory { .. }

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -907,6 +907,7 @@ impl EventPump {
             | AgentEvent::ToolDone(_)
             | AgentEvent::QueueItemConsumed { .. }
             | AgentEvent::AutoCompacting
+            | AgentEvent::CompactionDone
             | AgentEvent::AuthRequired
             | AgentEvent::SubagentHistory { .. }
             | AgentEvent::ToolSnapshot { .. }


### PR DESCRIPTION
After compaction, the model's next response was rendered as a continuation of the compaction summary instead of a new message. Thinking was appended to the last thinking block and text output merged with the last text without separation.

Add a CompactionDone event emitted after compact_history returns. This causes the UI to flush the streaming buffers, committing the compaction response as a proper message and clearing the buffers so the next turn starts below the compaction response.

Fixes https://github.com/tontinton/maki/issues/492

----

 * [x] Needs to be tested in practice too outside the test