### PR TITLE
plugins: edit: Split edit_lines into edit_lines and insert_lines

### DIFF
--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -83,9 +83,9 @@ pub const DEFAULT_BUILTINS: &[&str] = &[
     "write",
 ];
 
-pub const OPT_IN_TOOLS: &[&str] = &["edit_lines"];
+pub const OPT_IN_TOOLS: &[&str] = &["edit_lines", "insert_lines"];
 
-pub const FILE_WRITE_TOOLS: &[&str] = &["write", "edit", "multiedit", "edit_lines"];
+pub const FILE_WRITE_TOOLS: &[&str] = &["write", "edit", "multiedit", "edit_lines", "insert_lines"];
 
 #[derive(Debug, Clone, Copy)]
 pub enum ConfigValue {

--- a/maki-docgen/src/gen_tools.rs
+++ b/maki-docgen/src/gen_tools.rs
@@ -21,6 +21,7 @@ const SECTIONS: &[(&str, &[&str])] = &[
             "edit",
             "multiedit",
             "edit_lines",
+            "insert_lines",
             "glob",
             "grep",
             "index",

--- a/plugins/edit/edit_helpers.lua
+++ b/plugins/edit/edit_helpers.lua
@@ -36,7 +36,7 @@ function M.replace_lines(content, start_line, end_line, new_string)
   for i = 1, skip_from - 1 do
     result[#result + 1] = lines[i]
   end
-  if new_string ~= "" then
+  if new_string ~= "" or inserting then
     for _, line in ipairs(split_lines(new_string)) do
       result[#result + 1] = line
     end

--- a/plugins/edit/init.lua
+++ b/plugins/edit/init.lua
@@ -6,10 +6,10 @@ local replace_lines = require("edit_helpers").replace_lines
 local SNIPPET_MAX_CHARS = 32
 
 local EDIT_LINES_DESCRIPTION =
-  [[Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new_string`. Use empty `new_string` to delete a range.]]
+  [[Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new_string`. Use empty `new_string` to delete a range. Do not use with the batch tool.]]
 
 local INSERT_LINES_DESCRIPTION =
-  [[Insert lines before a given line number. Lines at `line` and below shift down. Existing lines are preserved.]]
+  [[Insert lines before a given line number. Lines at `line` and below shift down. Existing lines are preserved. Do not use with the batch tool.]]
 
 local EDIT_DESCRIPTION = [[Replace an exact string match in a file.
 

--- a/plugins/edit/init.lua
+++ b/plugins/edit/init.lua
@@ -6,7 +6,10 @@ local replace_lines = require("edit_helpers").replace_lines
 local SNIPPET_MAX_CHARS = 32
 
 local EDIT_LINES_DESCRIPTION =
-  [[Edit lines by number. Omit `end` to insert before `start` without removing lines. Set `end` to replace or delete (empty `new_string`) a range.]]
+  [[Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new_string`. Use empty `new_string` to delete a range.]]
+
+local INSERT_LINES_DESCRIPTION =
+  [[Insert lines before a given line number. Lines at `line` and below shift down. Existing lines are preserved.]]
 
 local EDIT_DESCRIPTION = [[Replace an exact string match in a file.
 
@@ -286,7 +289,8 @@ maki.api.register_tool({
       },
       ["end"] = {
         type = "integer",
-        description = "Last line, inclusive. Omit to insert before start without removing lines.",
+        description = "Last line, inclusive",
+        required = true,
       },
       new_string = {
         type = "string",
@@ -302,16 +306,61 @@ maki.api.register_tool({
   end),
 
   handler = function(input, ctx)
-    local end_line = input["end"]
     local result, err = apply_edit(input.path, ctx, function(content)
-      return replace_lines(content, input.start, end_line, input.new_string)
+      return replace_lines(content, input.start, input["end"], input.new_string)
     end)
     if not result then
       return { llm_output = err, is_error = true }
     end
-    local summary = end_line
-        and string.format("replaced lines %d-%d in %s", input.start, end_line, shorten_path(result.path))
-      or string.format("inserted at line %d in %s", input.start, shorten_path(result.path))
-    return diff_result(result, summary)
+    return diff_result(
+      result,
+      string.format("replaced lines %d-%d in %s", input.start, input["end"], shorten_path(result.path))
+    )
+  end,
+})
+
+maki.api.register_tool({
+  name = "insert_lines",
+  kind = "edit",
+  mutable_path = "path",
+  permission_scopes = "path",
+  audiences = { "main", "general_sub", "interpreter" },
+  description = INSERT_LINES_DESCRIPTION,
+
+  schema = {
+    type = "object",
+    properties = {
+      path = {
+        type = "string",
+        description = "Absolute path to the file",
+        required = true,
+        alias = "file_path",
+      },
+      line = {
+        type = "integer",
+        description = "Line number to insert before (1-indexed). Use 1 to insert at the top.",
+        required = true,
+      },
+      new_string = {
+        type = "string",
+        description = "Text to insert",
+        required = true,
+      },
+    },
+  },
+
+  header = edit_header,
+  restore = diff_restore(function(input)
+    return { { new = input.new_string } }
+  end),
+
+  handler = function(input, ctx)
+    local result, err = apply_edit(input.path, ctx, function(content)
+      return replace_lines(content, input.line, nil, input.new_string)
+    end)
+    if not result then
+      return { llm_output = err, is_error = true }
+    end
+    return diff_result(result, string.format("inserted at line %d in %s", input.line, shorten_path(result.path)))
   end,
 })

--- a/plugins/edit/tests/spec.lua
+++ b/plugins/edit/tests/spec.lua
@@ -257,6 +257,9 @@ case("replace_lines_insert_mode", function()
   has(e1, "out of range")
   local _, e2 = replace_lines(content, 5, nil, "x")
   has(e2, "out of range")
+
+  local r4 = replace_lines(content, 2, nil, "")
+  eq(r4, "aaa\n\nbbb\nccc\n")
 end)
 
 if #failures > 0 then

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -65,7 +65,7 @@ Prefer this over edit when making multiple changes to the same file.
 
 ### `edit_lines` *(lua plugin, opt-in)*
 
-Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new_string`. Use empty `new_string` to delete a range.
+Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new_string`. Use empty `new_string` to delete a range. Do not use with the batch tool.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -76,7 +76,7 @@ Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new
 
 ### `insert_lines` *(lua plugin, opt-in)*
 
-Insert lines before a given line number. Lines at `line` and below shift down. Existing lines are preserved.
+Insert lines before a given line number. Lines at `line` and below shift down. Existing lines are preserved. Do not use with the batch tool.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -7,7 +7,7 @@ group = "Reference"
 
 # Tools
 
-Maki ships with 19 built-in tools. This is the full reference.
+Maki ships with 20 built-in tools. This is the full reference.
 
 ## File Operations
 
@@ -65,14 +65,24 @@ Prefer this over edit when making multiple changes to the same file.
 
 ### `edit_lines` *(lua plugin, opt-in)*
 
-Edit lines by number. Omit `end` to insert before `start` without removing lines. Set `end` to replace or delete (empty `new_string`) a range.
+Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new_string`. Use empty `new_string` to delete a range.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `end` | integer | no | Last line, inclusive. Omit to insert before start without removing lines. |
+| `end` | integer | yes | Last line, inclusive |
 | `new_string` | string | yes | Replacement text |
 | `path` | string | yes | Absolute path to the file |
 | `start` | integer | yes | First line (1-indexed) |
+
+### `insert_lines` *(lua plugin, opt-in)*
+
+Insert lines before a given line number. Lines at `line` and below shift down. Existing lines are preserved.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `line` | integer | yes | Line number to insert before (1-indexed). Use 1 to insert at the top. |
+| `new_string` | string | yes | Text to insert |
+| `path` | string | yes | Absolute path to the file |
 
 ### `glob` *(lua plugin)*
 


### PR DESCRIPTION
The optional `end` parameter confused models regularly and they failed to provide it and then were confused that lines were duplicated.

----

Just putting this out for discussion here. Split like this, I had `edit_lines` used quite often successfully by qwen3.6 27B. Without it was always failing one way or another when trying to use it.