### PR TITLE
perf(grep): parallelize walker and cache mtime sort

### DIFF
--- a/maki-agent/src/tools/grep.rs
+++ b/maki-agent/src/tools/grep.rs
@@ -1,11 +1,13 @@
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use crate::{GrepFileEntry, GrepLine, GrepMatchGroup};
 use grep_regex::RegexMatcher;
 use grep_searcher::Searcher;
 use grep_searcher::SearcherBuilder;
 use grep_searcher::{Sink, SinkContext, SinkFinish, SinkMatch};
+use ignore::WalkState;
 use tracing::debug;
 
 use super::{mtime, resolve_search_path, truncate_bytes, walk_builder};
@@ -80,8 +82,6 @@ pub fn grep_search(params: GrepParams) -> Result<(PathBuf, Vec<GrepFileEntry>), 
         builder.heap_limit(Some(MULTILINE_HEAP_LIMIT));
     }
 
-    let mut searcher = builder.build();
-
     let search = Path::new(&search_path);
     let base = if search.is_file() {
         search.parent().unwrap_or(search)
@@ -89,42 +89,58 @@ pub fn grep_search(params: GrepParams) -> Result<(PathBuf, Vec<GrepFileEntry>), 
         search
     };
     let has_context = params.context_before > 0 || params.context_after > 0;
-    let mut entries: Vec<GrepFileEntry> = Vec::new();
+    let max_line_bytes = params.max_line_bytes;
+    let results: Arc<Mutex<Vec<GrepFileEntry>>> = Arc::new(Mutex::new(Vec::new()));
+    let base: Arc<Path> = Arc::from(base);
 
-    for entry in walker.build().flatten() {
-        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
-            continue;
+    walker.build_parallel().run({
+        let results = Arc::clone(&results);
+        let matcher = Arc::new(matcher);
+        let base = Arc::clone(&base);
+        move || {
+            let mut searcher = builder.build();
+            let matcher = Arc::clone(&matcher);
+            let results = Arc::clone(&results);
+            let base = Arc::clone(&base);
+            Box::new(move |entry| {
+                let entry = match entry {
+                    Ok(e) => e,
+                    Err(_) => return WalkState::Continue,
+                };
+                if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+                    return WalkState::Continue;
+                }
+                let path = entry.into_path();
+                let mut groups = Vec::new();
+                let mut sink = GrepSink {
+                    groups: &mut groups,
+                    current_group: Vec::new(),
+                    max_line_bytes,
+                    has_context,
+                };
+                let _ = searcher.search_path(&*matcher, &path, &mut sink);
+
+                if !groups.is_empty() {
+                    let rel = path
+                        .strip_prefix(&*base)
+                        .unwrap_or(&path)
+                        .to_string_lossy()
+                        .into_owned();
+                    let mut guard = results.lock().unwrap_or_else(|e| e.into_inner());
+                    guard.push(GrepFileEntry { path: rel, groups });
+                }
+                WalkState::Continue
+            })
         }
-        let path = entry.into_path();
-        let mut groups = Vec::new();
+    });
 
-        let mut sink = GrepSink {
-            groups: &mut groups,
-            current_group: Vec::new(),
-            max_line_bytes: params.max_line_bytes,
-            has_context,
-        };
-        let _ = searcher.search_path(&matcher, &path, &mut sink);
-
-        if !groups.is_empty() {
-            let rel = path
-                .strip_prefix(base)
-                .unwrap_or(&path)
-                .to_string_lossy()
-                .into_owned();
-            entries.push(GrepFileEntry { path: rel, groups });
-        }
-    }
+    let mut entries = std::mem::take(&mut *results.lock().unwrap_or_else(|e| e.into_inner()));
 
     if entries.is_empty() {
         return Ok((base.to_path_buf(), entries));
     }
 
-    entries.sort_by(|a, b| {
-        let a_abs = base.join(&a.path);
-        let b_abs = base.join(&b.path);
-        mtime(&b_abs).cmp(&mtime(&a_abs))
-    });
+    entries.sort_by_cached_key(|e| std::cmp::Reverse(mtime(&base.join(&e.path))));
 
     let mut total_groups = 0;
     for entry in &mut entries {

--- a/maki-agent/src/tools/grep.rs
+++ b/maki-agent/src/tools/grep.rs
@@ -140,7 +140,12 @@ pub fn grep_search(params: GrepParams) -> Result<(PathBuf, Vec<GrepFileEntry>), 
         return Ok((base.to_path_buf(), entries));
     }
 
-    entries.sort_by_cached_key(|e| std::cmp::Reverse(mtime(&base.join(&e.path))));
+    entries.sort_by_cached_key(|e| {
+        (
+            std::cmp::Reverse(mtime(&base.join(&e.path))),
+            e.path.clone(),
+        )
+    });
 
     let mut total_groups = 0;
     for entry in &mut entries {

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -696,6 +696,95 @@ mod tests {
     }
 
     #[test]
+    fn grep_search_multiline_groups_spanning_lines() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("span.rs"), "fn foo() {\n    bar\n}\n").unwrap();
+
+        let mut params = grep::GrepParams::new("(?s)foo.*\\n}".into());
+        params.path = Some(dir.path().to_string_lossy().into());
+        let (_, entries) = grep::grep_search(params).unwrap();
+        assert_eq!(entries.len(), 1);
+        let lines = &entries[0].groups[0].lines;
+        assert!(lines.iter().any(|l| l.text.contains("foo") && l.is_match));
+    }
+
+    #[test]
+    fn grep_search_context_lines_surround_matches() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("ctx.rs"),
+            "l1\nl2\nA\nl4\nl5\nl6\nl7\nl8\nB\nl10\n",
+        )
+        .unwrap();
+
+        let mut params = grep::GrepParams::new("A|B".into());
+        params.path = Some(dir.path().to_string_lossy().into());
+        params.context_before = 1;
+        params.context_after = 1;
+        let (_, entries) = grep::grep_search(params).unwrap();
+        assert_eq!(entries[0].groups.len(), 2);
+
+        let g0 = &entries[0].groups[0].lines;
+        assert!(g0.iter().any(|l| l.text == "l2" && !l.is_match));
+        assert!(g0.iter().any(|l| l.text == "A" && l.is_match));
+
+        let g1 = &entries[0].groups[1].lines;
+        assert!(g1.iter().any(|l| l.text == "B" && l.is_match));
+        assert!(g1.iter().any(|l| l.text == "l10" && !l.is_match));
+    }
+
+    #[test]
+    fn grep_search_parallel_stable_under_repeated_calls() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        for i in 0..20u32 {
+            fs::write(root.join(format!("f{i:03}.rs")), format!("needle {i}\n")).unwrap();
+        }
+        let path_str = root.to_string_lossy().to_string();
+
+        let mut reference: Option<Vec<(String, usize, bool)>> = None;
+        for _ in 0..20 {
+            let mut params = grep::GrepParams::new("needle".into());
+            params.path = Some(path_str.clone());
+            params.limit = 1000;
+            let (_, entries) = grep::grep_search(params).unwrap();
+
+            let mut flat: Vec<(String, usize, bool)> = entries
+                .iter()
+                .flat_map(|e| {
+                    e.groups.iter().flat_map(|g| {
+                        g.lines
+                            .iter()
+                            .map(|l| (e.path.clone(), l.line_nr, l.is_match))
+                    })
+                })
+                .collect();
+            flat.sort();
+            match &reference {
+                None => reference = Some(flat),
+                Some(prev) => assert_eq!(flat, *prev),
+            }
+        }
+    }
+
+    #[test]
+    fn grep_search_limit_truncates_groups_after_sort() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        for i in 0..10u32 {
+            fs::write(root.join(format!("m_{i}.rs")), "hit\n").unwrap();
+        }
+
+        let mut params = grep::GrepParams::new("hit".into());
+        params.path = Some(root.to_string_lossy().into());
+        params.limit = 3;
+        let (_, entries) = grep::grep_search(params).unwrap();
+
+        let total_groups: usize = entries.iter().map(|e| e.groups.len()).sum();
+        assert_eq!(total_groups, 3);
+    }
+
+    #[test]
     fn walk_builder_excludes_dot_git_shows_dotfiles_and_filters_globs() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -569,7 +569,7 @@ pub mod test_support {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::fs::{self, File};
 
     use tempfile::TempDir;
     use test_case::test_case;
@@ -737,8 +737,12 @@ mod tests {
     fn grep_search_parallel_stable_under_repeated_calls() {
         let dir = TempDir::new().unwrap();
         let root = dir.path();
+        let tied_mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(1_600_000_000);
         for i in 0..20u32 {
-            fs::write(root.join(format!("f{i:03}.rs")), format!("needle {i}\n")).unwrap();
+            let path = root.join(format!("f{i:03}.rs"));
+            fs::write(&path, format!("needle {i}\n")).unwrap();
+            let f = File::options().write(true).open(&path).unwrap();
+            f.set_modified(tied_mtime).unwrap();
         }
         let path_str = root.to_string_lossy().to_string();
 
@@ -749,7 +753,7 @@ mod tests {
             params.limit = 1000;
             let (_, entries) = grep::grep_search(params).unwrap();
 
-            let mut flat: Vec<(String, usize, bool)> = entries
+            let flat: Vec<(String, usize, bool)> = entries
                 .iter()
                 .flat_map(|e| {
                     e.groups.iter().flat_map(|g| {
@@ -759,7 +763,6 @@ mod tests {
                     })
                 })
                 .collect();
-            flat.sort();
             match &reference {
                 None => reference = Some(flat),
                 Some(prev) => assert_eq!(flat, *prev),


### PR DESCRIPTION
I found myself disabling the built-in `grep` tool today because I've been running into issues this past week or so where it would run for 15 minutes or so on my work repo, appearing to be stuck. Though adding a default timeout parameter would be a good idea as well, there seem to be two reasonably cheap perf improvements to add: parallelization and `mtime` caching. `ripgrep` also mmap's files, but that's `unsafe`, so I avoided that option.

10k-file synthetic fixture, warm cache, `rg --json` as ground truth:

| | Before | After |
|---|---|---|
| maki grep | ~258ms | ~28ms |
| rg --json | ~16ms | ~16ms |

Added some integ tests for this and other missing grep usage scenarios.

Written with Maki + GLM-5.2.