### PR TITLE
feat(mcp): headless OAuth via pasted redirect URL

### DIFF
--- a/maki-agent/src/mcp/oauth/callback.rs
+++ b/maki-agent/src/mcp/oauth/callback.rs
@@ -1,12 +1,9 @@
-use std::time::Duration;
-
 use futures_lite::AsyncWriteExt;
 use smol::net::TcpListener;
 
 const PREFERRED_PORT: u16 = 19876;
 const MAX_HEADER_SIZE: usize = 8192;
 const CALLBACK_PATH: &str = "/mcp/oauth/callback";
-const TIMEOUT: Duration = Duration::from_secs(300);
 const SUCCESS_HTML: &str =
     "<html><body><h1>Authentication successful</h1><p>You can close this tab.</p></body></html>";
 const ERROR_HTML: &str =
@@ -38,14 +35,6 @@ impl CallbackServer {
     }
 
     pub async fn wait_for_callback(self, expected_state: &str) -> Result<CallbackResult, String> {
-        futures_lite::future::race(self.accept_loop(expected_state), async {
-            smol::Timer::after(TIMEOUT).await;
-            Err("OAuth callback timed out after 5 minutes".into())
-        })
-        .await
-    }
-
-    async fn accept_loop(self, expected_state: &str) -> Result<CallbackResult, String> {
         loop {
             let (mut stream, _) = self
                 .listener
@@ -117,7 +106,7 @@ impl CallbackServer {
     }
 }
 
-fn parse_query(query: &str) -> Vec<(String, String)> {
+pub(crate) fn parse_query(query: &str) -> Vec<(String, String)> {
     query
         .split('&')
         .filter(|p| !p.is_empty())

--- a/maki-agent/src/mcp/oauth/manual.rs
+++ b/maki-agent/src/mcp/oauth/manual.rs
@@ -1,0 +1,122 @@
+use futures_lite::{AsyncBufReadExt, StreamExt, io::BufReader};
+use smol::Unblock;
+
+use super::callback::{CallbackResult, parse_query};
+
+const PASTE_HINT: &str = "Paste the full redirect URL (or its query string with code= and state=):";
+const MISSING_PARAMS: &str = "missing code or state parameter";
+const STATE_MISMATCH: &str = "state mismatch (wrong or stale login attempt)";
+
+pub(crate) async fn wait_for_paste(expected_state: &str) -> Result<CallbackResult, String> {
+    // If the callback server wins the race, the Unblock stdin thread is dropped
+    // mid-read and may swallow one buffered line. Fine here: this only runs in the
+    // CLI flow, which exits right after authentication completes.
+    let mut lines = BufReader::new(Unblock::new(std::io::stdin())).lines();
+
+    while let Some(line) = lines.next().await {
+        let line = line.map_err(|e| format!("stdin read failed: {e}"))?;
+        let line = line.trim();
+
+        if line.is_empty() {
+            continue;
+        }
+
+        match parse_pasted(line, expected_state)? {
+            Outcome::Code(code) => return Ok(CallbackResult { code }),
+            Outcome::Retry(msg) => eprintln!("{msg}\n{PASTE_HINT}"),
+        }
+    }
+
+    Err("stdin closed before a redirect URL was pasted".into())
+}
+
+#[derive(Debug)]
+enum Outcome {
+    Code(String),
+    Retry(&'static str),
+}
+
+fn parse_pasted(input: &str, expected_state: &str) -> Result<Outcome, String> {
+    let params = parse_query(extract_query(input));
+
+    if let Some((_, error)) = params.iter().find(|(k, _)| k == "error") {
+        let desc = params
+            .iter()
+            .find(|(k, _)| k == "error_description")
+            .map(|(_, v)| v.as_str())
+            .unwrap_or(error);
+        return Err(format!("OAuth error: {desc}"));
+    }
+
+    let state = params
+        .iter()
+        .find(|(k, _)| k == "state")
+        .map(|(_, v)| v.as_str());
+
+    let code = params
+        .iter()
+        .find(|(k, _)| k == "code")
+        .map(|(_, v)| v.clone());
+
+    let (Some(state), Some(code)) = (state, code) else {
+        return Ok(Outcome::Retry(MISSING_PARAMS));
+    };
+
+    if state != expected_state {
+        return Ok(Outcome::Retry(STATE_MISMATCH));
+    }
+
+    Ok(Outcome::Code(code))
+}
+
+fn extract_query(input: &str) -> &str {
+    let no_fragment = input.split('#').next().unwrap_or(input);
+    match no_fragment.split_once('?') {
+        Some((_, query)) => query,
+        None => no_fragment,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    const STATE: &str = "expected-state";
+
+    #[test_case("http://127.0.0.1:19876/mcp/oauth/callback?code=abc&state=expected-state", "abc" ; "full_redirect_url")]
+    #[test_case("code=abc&state=expected-state", "abc" ; "bare_query_string")]
+    #[test_case("code=a%2Bb%20c&state=expected-state", "a+b c" ; "url_encoded_code")]
+    #[test_case("http://127.0.0.1:19876/mcp/oauth/callback?state=expected-state&code=xyz#frag", "xyz" ; "fragment_stripped")]
+    fn accepts_code(input: &str, expected_code: &str) {
+        match parse_pasted(input, STATE).unwrap() {
+            Outcome::Code(code) => assert_eq!(code, expected_code),
+            Outcome::Retry(msg) => panic!("expected code, got retry: {msg}"),
+        }
+    }
+
+    #[test_case("state=expected-state" ; "missing_code")]
+    #[test_case("code=abc" ; "missing_state")]
+    #[test_case("not a url at all" ; "garbage_input")]
+    fn retries_on_missing_params(input: &str) {
+        match parse_pasted(input, STATE).unwrap() {
+            Outcome::Retry(msg) => assert_eq!(msg, MISSING_PARAMS),
+            Outcome::Code(_) => panic!("expected retry"),
+        }
+    }
+
+    #[test]
+    fn retries_on_state_mismatch() {
+        match parse_pasted("code=abc&state=wrong", STATE).unwrap() {
+            Outcome::Retry(msg) => assert_eq!(msg, STATE_MISMATCH),
+            Outcome::Code(_) => panic!("expected retry"),
+        }
+    }
+
+    #[test]
+    fn errors_on_oauth_error_param() {
+        let err =
+            parse_pasted("error=access_denied&error_description=User%20denied", STATE).unwrap_err();
+        assert_eq!(err, "OAuth error: User denied");
+    }
+}

--- a/maki-agent/src/mcp/oauth/mod.rs
+++ b/maki-agent/src/mcp/oauth/mod.rs
@@ -1,8 +1,26 @@
 pub mod callback;
 pub mod discovery;
+pub mod manual;
 pub mod pkce;
 pub mod registration;
 pub mod token;
+
+use std::time::Duration;
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use futures_lite::future;
+use isahc::HttpClient;
+use isahc::config::{Configurable, RedirectPolicy};
+use maki_storage::StateDir;
+use maki_storage::auth::{McpAuthData, load_mcp_auth, save_mcp_auth};
+use tracing::{info, warn};
+
+use self::callback::{CallbackResult, CallbackServer};
+use self::discovery::parse_www_authenticate;
+use super::error::McpError;
+
+const AUTH_TIMEOUT: Duration = Duration::from_secs(600);
 
 #[derive(Debug, thiserror::Error)]
 pub enum OAuthError {
@@ -16,23 +34,18 @@ pub enum OAuthError {
     Other(String),
 }
 
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use isahc::HttpClient;
-use isahc::config::{Configurable, RedirectPolicy};
-use maki_storage::StateDir;
-use maki_storage::auth::{McpAuthData, load_mcp_auth, save_mcp_auth};
-use tracing::{info, warn};
-
-use self::callback::CallbackServer;
-use self::discovery::parse_www_authenticate;
-use super::error::McpError;
+#[derive(Clone, Copy)]
+pub enum Interaction {
+    Cli,
+    Background,
+}
 
 pub async fn authenticate(
     server_name: &str,
     server_url: &str,
     www_authenticate: Option<&str>,
     storage: &StateDir,
+    interaction: Interaction,
 ) -> Result<McpAuthData, McpError> {
     let wrap = |e: OAuthError| McpError::OAuthFailed {
         server: server_name.into(),
@@ -149,15 +162,46 @@ pub async fn authenticate(
         server_url,
     );
 
-    info!(server = server_name, endpoint = %auth_server.authorization_endpoint, "opening browser for OAuth");
-    if let Err(e) = open::that(&auth_url) {
-        warn!(server = server_name, error = %e, "failed to open browser - manually visit the auth URL in logs");
-    }
+    info!(server = server_name, endpoint = %auth_server.authorization_endpoint, "starting OAuth authorization");
+    let result = match interaction {
+        Interaction::Cli => {
+            eprintln!("\nOpen this URL in your browser:\n\n  {auth_url}\n");
 
-    let result = callback
-        .wait_for_callback(&state)
-        .await
-        .map_err(|e| wrap(OAuthError::Other(e)))?;
+            if is_headless() {
+                info!(
+                    server = server_name,
+                    "no display detected, skipping browser open"
+                );
+            } else if let Err(e) = open::that(&auth_url) {
+                warn!(server = server_name, error = %e, "failed to open browser");
+            }
+
+            eprintln!("Waiting for callback on 127.0.0.1:{}...", callback.port);
+            eprintln!("If this machine has no browser, log in on another device and paste");
+            eprintln!("the full redirect URL ({redirect_uri}?...) here:");
+
+            let callback_or_paste = future::race(
+                callback.wait_for_callback(&state),
+                manual::wait_for_paste(&state),
+            );
+
+            future::race(callback_or_paste, auth_timeout()).await
+        }
+        Interaction::Background => {
+            let cause = if is_headless() {
+                Some("no display to open a browser".to_string())
+            } else {
+                open::that(&auth_url)
+                    .err()
+                    .map(|e| format!("failed to open browser: {e}"))
+            };
+            match cause {
+                Some(cause) => Err(format!("{cause}; run 'maki mcp auth {server_name}'")),
+                None => future::race(callback.wait_for_callback(&state), auth_timeout()).await,
+            }
+        }
+    }
+    .map_err(|e| wrap(OAuthError::Other(e)))?;
 
     let tokens = token::exchange_code(
         &client,
@@ -199,6 +243,20 @@ async fn discover_auth_server_for(
         .cloned()
         .unwrap_or_else(|| discovery::server_origin(server_url));
     discovery::discover_auth_server(client, &auth_server_url).await
+}
+
+async fn auth_timeout() -> Result<CallbackResult, String> {
+    smol::Timer::after(AUTH_TIMEOUT).await;
+    Err(format!(
+        "OAuth flow timed out after {} minutes",
+        AUTH_TIMEOUT.as_secs() / 60
+    ))
+}
+
+fn is_headless() -> bool {
+    cfg!(target_os = "linux")
+        && std::env::var_os("DISPLAY").is_none()
+        && std::env::var_os("WAYLAND_DISPLAY").is_none()
 }
 
 fn build_http_client() -> Result<HttpClient, isahc::Error> {

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -354,6 +354,7 @@ fn spawn_oauth_for_needs_auth(handle: &McpHandle) {
                 &server_url,
                 www_auth.as_deref(),
                 &storage,
+                maki_agent::mcp::oauth::Interaction::Background,
             )
             .await
             {

--- a/maki-ui/src/components/mcp_picker.rs
+++ b/maki-ui/src/components/mcp_picker.rs
@@ -38,7 +38,10 @@ fn build_entries(infos: &[McpServerInfo]) -> (Vec<McpEntry>, Vec<bool>) {
                     format!("{} \u{00b7} error: {}", info.transport_kind, e)
                 }
                 McpServerStatus::NeedsAuth { .. } => {
-                    format!("{} \u{00b7} needs auth", info.transport_kind)
+                    format!(
+                        "{} \u{00b7} needs auth \u{00b7} run 'maki mcp auth {}'",
+                        info.transport_kind, info.name
+                    )
                 }
             },
         })

--- a/site/docs/content/mcp/_index.md
+++ b/site/docs/content/mcp/_index.md
@@ -79,6 +79,10 @@ maki mcp auth <server-name>     # manually trigger auth
 maki mcp logout <server-name>   # remove stored tokens
 ```
 
+### Headless machines
+
+On a machine without a browser (say, a dev server over SSH), run `maki mcp auth <server-name>`. Maki prints the login URL. Open it on your laptop and log in. The browser lands on a `http://127.0.0.1:19876/...` page that fails to load. Copy that full URL from the address bar and paste it into the terminal to finish the login.
+
 ## Prompts
 
 MCP servers can expose prompts (reusable message templates). Maki shows them as slash commands in the command palette: `/server:prompt-name`. Type `/` to filter.

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -503,7 +503,7 @@ pub fn mcp_auth(server: &str, storage: &StateDir) -> Result<()> {
             mcp_config::Transport::Http { url, .. } => url,
             _ => color_eyre::eyre::bail!("server '{server}' is not an HTTP transport"),
         };
-        mcp_oauth::authenticate(server, &url, None, storage).await?;
+        mcp_oauth::authenticate(server, &url, None, storage, mcp_oauth::Interaction::Cli).await?;
         eprintln!("Successfully authenticated with MCP server '{server}'");
         Ok(())
     })


### PR DESCRIPTION
Hey. We are evaluating Maki at [Twin](https://twin.so/) and I'm really liking it so far. There's one issue that's kind of a deal breaker for rest of the team (and in some way for me too): for MCP servers that require an OAuth flow such as Linear, Maki tries to open a browser and waits for callback. We have beefy dev machines for the team, and doing this flow requires me to login on my personal machine first, then scp the authentication file to the server (repeat after a few days when the refresh token gets old).

With OpenCode, our workflow is: start the auth process, OpenCode prints the URL, open it in the browser, copy the callback url from the browser and curl it in the server. I think we can do better than that: here you can paste the URL to the prompt and you don't need to use curl.

The prompt looks like this in the cli auth:

```
Open this URL in your browser:

  https://auth.example.com/authorize?response_type=code&client_id=...

Waiting for callback on 127.0.0.1:19876...
If this machine has no browser, log in on another device and paste
the full redirect URL (http://127.0.0.1:19876/mcp/oauth/callback?...) here:

```

Disclaimer: I used Maki and Fable 5 to implement this pull request. I let it to observe the local coding style and read all old pull requests to find out any annoyances you don't want. And I reviewed and tested this myself of course.