### PR TITLE
fix(agent): scale compaction_buffer with the context window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2545,6 +2545,7 @@ dependencies = [
  "maki-config-macro",
  "maki-storage",
  "serde",
+ "serde_json",
  "tempfile",
  "test-case",
  "thiserror 2.0.18",

--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -1,5 +1,6 @@
 use std::env;
 
+use maki_config::CompactionBuffer;
 use maki_providers::{
     ContentBlock, Message, Model, RequestOptions, Role, StreamResponse, TokenUsage,
 };
@@ -117,8 +118,10 @@ pub async fn compact(
     Ok(())
 }
 
-pub(super) fn is_overflow(usage: &TokenUsage, model: &Model, compaction_buffer: u32) -> bool {
-    let usable = model.context_window.saturating_sub(compaction_buffer);
+pub(super) fn is_overflow(usage: &TokenUsage, model: &Model, buffer: CompactionBuffer) -> bool {
+    let usable = model
+        .context_window
+        .saturating_sub(buffer.resolve(model.context_window));
     usage.context_tokens() >= usable
 }
 
@@ -329,6 +332,8 @@ mod tests {
     #[test_case(5_000,   165_000, 10_000,  0,      200_000, true  ; "cached_tokens_count_toward_overflow")]
     #[test_case(100_000, 0,       0,       80_000, 200_000, true  ; "output_tokens_count_toward_overflow")]
     #[test_case(262_144, 0,       0,       0,      262_144, true  ; "equal_context_and_max_output")]
+    #[test_case(51_199,  0,       0,       0,      64_000,  false ; "small_window_below_scaled_threshold")]
+    #[test_case(51_200,  0,       0,       0,      64_000,  true  ; "small_window_at_scaled_threshold")]
     fn overflow_detection(
         input: u32,
         cache_read: u32,
@@ -348,6 +353,18 @@ mod tests {
             is_overflow(&usage, &model, AgentConfig::default().compaction_buffer),
             expected
         );
+    }
+
+    #[test_case(CompactionBuffer::Tokens(10_000), 53_999, false ; "explicit_tokens_below")]
+    #[test_case(CompactionBuffer::Tokens(10_000), 54_000, true  ; "explicit_tokens_honored")]
+    #[test_case(CompactionBuffer::Percent(50),    32_000, true  ; "explicit_percent_at_threshold")]
+    fn overflow_with_explicit_buffer(buffer: CompactionBuffer, input: u32, expected: bool) {
+        let model = small_context_model(64_000);
+        let usage = TokenUsage {
+            input,
+            ..Default::default()
+        };
+        assert_eq!(is_overflow(&usage, &model, buffer), expected);
     }
 
     #[test]

--- a/maki-config-macro/src/lib.rs
+++ b/maki-config-macro/src/lib.rs
@@ -50,6 +50,7 @@ struct StructAttrs {
 struct FieldAttrs {
     skip: bool,
     default: Option<Expr>,
+    default_doc: Option<LitStr>,
     min: Option<Expr>,
     desc: Option<String>,
     key: Option<String>,
@@ -98,6 +99,7 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
     let mut attrs = FieldAttrs {
         skip: false,
         default: None,
+        default_doc: None,
         min: None,
         desc: None,
         key: None,
@@ -122,6 +124,11 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
                         return Err(syn::Error::new(item.key.span(), "default requires a value"));
                     }
                 },
+                "default_doc" => {
+                    if let ConfigAttrValue::Str(lit) = item.value {
+                        attrs.default_doc = Some(lit);
+                    }
+                }
                 "min" => {
                     if let ConfigAttrValue::Expr(expr) = item.value {
                         attrs.min = Some(*expr);
@@ -166,19 +173,11 @@ fn config_value_expr(ty_name: &str, default: &Option<Expr>) -> TokenStream2 {
             let val = default.as_ref().expect("bool field requires default");
             quote! { ConfigValue::Bool(#val) }
         }
-        "u32" => {
-            let val = default.as_ref().expect("u32 field requires default");
-            quote! { ConfigValue::U32(#val) }
+        "u32" | "u64" | "usize" => {
+            let val = default.as_ref().expect("numeric field requires default");
+            quote! { ConfigValue::U64(#val as u64) }
         }
-        "u64" => {
-            let val = default.as_ref().expect("u64 field requires default");
-            quote! { ConfigValue::U64(#val) }
-        }
-        "usize" => {
-            let val = default.as_ref().expect("usize field requires default");
-            quote! { ConfigValue::Usize(#val) }
-        }
-        "String" => quote! { ConfigValue::OptionalString },
+        "String" => quote! { ConfigValue::Str("none") },
         other => panic!("unsupported config type: {other}"),
     }
 }
@@ -231,7 +230,10 @@ fn derive_impl(input: &DeriveInput) -> syn::Result<TokenStream2> {
         let ty_string = type_to_name(ty);
         let ty_name = attrs.ty_override.as_deref().unwrap_or(&ty_string);
         let desc = attrs.desc.as_deref().unwrap_or("");
-        let default_expr = config_value_expr(ty_name, &attrs.default);
+        let default_expr = match &attrs.default_doc {
+            Some(doc) => quote! { ConfigValue::Str(#doc) },
+            None => config_value_expr(ty_name, &attrs.default),
+        };
         let min_expr = match &attrs.min {
             Some(m) => quote! { Some(#m as u64) },
             None => quote! { None },

--- a/maki-config/Cargo.toml
+++ b/maki-config/Cargo.toml
@@ -17,3 +17,4 @@ inventory = { workspace = true }
 [dev-dependencies]
 test-case = { workspace = true }
 tempfile = { workspace = true }
+serde_json = { workspace = true }

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -26,7 +26,7 @@ pub const DEFAULT_MOUSE_SCROLL_LINES: u32 = 3;
 pub const DEFAULT_BASH_TIMEOUT_SECS: u64 = 120;
 pub const DEFAULT_CODE_EXECUTION_TIMEOUT_SECS: u64 = 30;
 pub const DEFAULT_MAX_CONTINUATION_TURNS: u32 = 3;
-pub const DEFAULT_COMPACTION_BUFFER: u32 = 40_000;
+pub const DEFAULT_COMPACTION_BUFFER: CompactionBuffer = CompactionBuffer::Percent(20);
 pub const DEFAULT_SEARCH_RESULT_LIMIT: usize = 100;
 pub const DEFAULT_INTERPRETER_MAX_MEMORY_MB: usize = 50;
 pub const DEFAULT_TASK_MAX_CONCURRENT: usize = 8;
@@ -49,6 +49,9 @@ pub const MIN_BASH_TIMEOUT_SECS: u64 = 5;
 pub const MIN_CODE_EXECUTION_TIMEOUT_SECS: u64 = 5;
 pub const MIN_MAX_CONTINUATION_TURNS: u32 = 1;
 pub const MIN_COMPACTION_BUFFER: u32 = 1_000;
+const MAX_COMPACTION_PERCENT: u8 = 99;
+const COMPACTION_BUFFER_EXPECTED: &str =
+    r#"a token count (e.g. 12000) or a percent of the context window (e.g. "20%")"#;
 pub const MIN_SEARCH_RESULT_LIMIT: usize = 10;
 pub const MIN_INTERPRETER_MAX_MEMORY_MB: usize = 10;
 pub const MIN_TASK_MAX_CONCURRENT: usize = 1;
@@ -90,20 +93,16 @@ pub const FILE_WRITE_TOOLS: &[&str] = &["write", "edit", "multiedit", "edit_line
 #[derive(Debug, Clone, Copy)]
 pub enum ConfigValue {
     Bool(bool),
-    U32(u32),
     U64(u64),
-    Usize(usize),
-    OptionalString,
+    Str(&'static str),
 }
 
 impl ConfigValue {
     pub fn format_default(&self) -> String {
         match self {
             Self::Bool(b) => if *b { "true" } else { "false" }.to_string(),
-            Self::U32(v) => v.to_string(),
             Self::U64(v) => v.to_string(),
-            Self::Usize(v) => v.to_string(),
-            Self::OptionalString => "none".to_string(),
+            Self::Str(s) => (*s).to_string(),
         }
     }
 }
@@ -345,6 +344,74 @@ impl ToolOutputLinesFile {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompactionBuffer {
+    Tokens(u32),
+    Percent(u8),
+}
+
+impl CompactionBuffer {
+    pub fn resolve(self, context_window: u32) -> u32 {
+        match self {
+            Self::Tokens(n) => n,
+            Self::Percent(p) => (u64::from(context_window) * u64::from(p) / 100) as u32,
+        }
+    }
+}
+
+impl Serialize for CompactionBuffer {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Tokens(n) => s.serialize_u32(*n),
+            Self::Percent(p) => s.collect_str(&format_args!("{p}%")),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CompactionBuffer {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct BufferVisitor;
+
+        impl serde::de::Visitor<'_> for BufferVisitor {
+            type Value = CompactionBuffer;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str(COMPACTION_BUFFER_EXPECTED)
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                u32::try_from(v)
+                    .ok()
+                    .filter(|n| *n >= MIN_COMPACTION_BUFFER)
+                    .map(CompactionBuffer::Tokens)
+                    .ok_or_else(|| {
+                        E::custom(format!(
+                            "compaction_buffer must be at least {MIN_COMPACTION_BUFFER} tokens"
+                        ))
+                    })
+            }
+
+            fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
+                self.visit_u64(u64::try_from(v).unwrap_or(0))
+            }
+
+            fn visit_str<E: serde::de::Error>(self, s: &str) -> Result<Self::Value, E> {
+                s.strip_suffix('%')
+                    .and_then(|n| n.trim().parse::<u8>().ok())
+                    .filter(|p| (1..=MAX_COMPACTION_PERCENT).contains(p))
+                    .map(CompactionBuffer::Percent)
+                    .ok_or_else(|| {
+                        E::custom(format!(
+                            "invalid compaction_buffer {s:?}: expected {COMPACTION_BUFFER_EXPECTED}"
+                        ))
+                    })
+            }
+        }
+
+        d.deserialize_any(BufferVisitor)
+    }
+}
+
 #[derive(Deserialize, Default, Debug)]
 #[serde(default, deny_unknown_fields)]
 pub struct AgentFileConfig {
@@ -355,7 +422,7 @@ pub struct AgentFileConfig {
     pub bash_timeout_secs: Option<u64>,
     pub code_execution_timeout_secs: Option<u64>,
     pub max_continuation_turns: Option<u32>,
-    pub compaction_buffer: Option<u32>,
+    pub compaction_buffer: Option<CompactionBuffer>,
     pub search_result_limit: Option<usize>,
     pub interpreter_max_memory_mb: Option<usize>,
     pub task_max_concurrent: Option<usize>,
@@ -900,8 +967,8 @@ pub struct AgentConfig {
     #[config(default = DEFAULT_MAX_CONTINUATION_TURNS, min = MIN_MAX_CONTINUATION_TURNS, desc = "Max automatic continuation turns")]
     pub max_continuation_turns: u32,
 
-    #[config(default = DEFAULT_COMPACTION_BUFFER, min = MIN_COMPACTION_BUFFER, desc = "Token buffer reserved during compaction")]
-    pub compaction_buffer: u32,
+    #[config(default = DEFAULT_COMPACTION_BUFFER, ty = "u32 | string", default_doc = "20%", desc = "Context reserved for compaction: token count or percent of the context window (e.g. \"20%\")")]
+    pub compaction_buffer: CompactionBuffer,
 
     #[config(default = DEFAULT_SEARCH_RESULT_LIMIT, min = MIN_SEARCH_RESULT_LIMIT, desc = "Max results from grep/glob searches")]
     pub search_result_limit: usize,
@@ -1786,6 +1853,41 @@ mod tests {
 
     fn global_config_dir(dir: &Path) -> PathBuf {
         dir.join(".config/maki")
+    }
+
+    #[test_case("12000", CompactionBuffer::Tokens(12_000) ; "tokens_number")]
+    #[test_case("\"20%\"", CompactionBuffer::Percent(20) ; "percent_string")]
+    #[test_case("\" 5 %\"", CompactionBuffer::Percent(5) ; "percent_with_spaces")]
+    fn compaction_buffer_deserializes(json: &str, expected: CompactionBuffer) {
+        let parsed: CompactionBuffer = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed, expected);
+    }
+
+    #[test_case("500" ; "tokens_below_min")]
+    #[test_case("-1" ; "negative_tokens")]
+    #[test_case("\"0%\"" ; "zero_percent")]
+    #[test_case("\"100%\"" ; "percent_too_high")]
+    #[test_case("\"abc%\"" ; "non_numeric_percent")]
+    fn compaction_buffer_rejects(json: &str) {
+        assert!(serde_json::from_str::<CompactionBuffer>(json).is_err());
+    }
+
+    #[test_case(CompactionBuffer::Tokens(10_000), 64_000, 10_000 ; "tokens_ignore_window")]
+    #[test_case(CompactionBuffer::Percent(20), 64_000, 12_800 ; "percent_of_window")]
+    fn compaction_buffer_resolves(buffer: CompactionBuffer, window: u32, expected: u32) {
+        assert_eq!(buffer.resolve(window), expected);
+    }
+
+    #[test]
+    fn compaction_buffer_serializes_percent_as_string() {
+        assert_eq!(
+            serde_json::to_value(CompactionBuffer::Percent(20)).unwrap(),
+            serde_json::json!("20%")
+        );
+        assert_eq!(
+            serde_json::to_value(CompactionBuffer::Tokens(9_000)).unwrap(),
+            serde_json::json!(9_000)
+        );
     }
 
     #[test]

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -1398,6 +1398,26 @@ fn setup_happy_path() {
 }
 
 #[test_case::test_case(
+    r#"maki.setup({ agent = { compaction_buffer = 10000 } })"#,
+    maki_config::CompactionBuffer::Tokens(10_000)
+    ; "compaction_buffer_tokens"
+)]
+#[test_case::test_case(
+    r#"maki.setup({ agent = { compaction_buffer = "15%" } })"#,
+    maki_config::CompactionBuffer::Percent(15)
+    ; "compaction_buffer_percent"
+)]
+fn setup_compaction_buffer(lua_src: &str, expected: maki_config::CompactionBuffer) {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let raw = host
+        .send_run_init_lua(lua_src.to_owned(), "test_init.lua".to_owned(), None)
+        .unwrap()
+        .expect("expected Some(RawConfig)");
+    assert_eq!(raw.agent.compaction_buffer, Some(expected));
+}
+
+#[test_case::test_case(
     "maki.setup({ ui = { splash_animaton = false } })",
     UNKNOWN_FIELD_ERR
     ; "unknown_field"

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -97,7 +97,7 @@ How many lines of output to show per tool in the UI. All values are `usize` with
 | `bash_timeout_secs` | u64 | `120` | 5 | Bash command timeout (seconds) |
 | `code_execution_timeout_secs` | u64 | `30` | 5 | Code execution timeout (seconds) |
 | `max_continuation_turns` | u32 | `3` | 1 | Max automatic continuation turns |
-| `compaction_buffer` | u32 | `40000` | 1000 | Token buffer reserved during compaction |
+| `compaction_buffer` | u32 \| string | `20%` | - | Context reserved for compaction: token count or percent of the context window (e.g. "20%") |
 | `search_result_limit` | usize | `100` | 10 | Max results from grep/glob searches |
 | `interpreter_max_memory_mb` | usize | `50` | 10 | Memory limit for code interpreter (MB) |
 | `task_max_concurrent` | usize | `8` | 1 | Max concurrently running subagents (task tool) |


### PR DESCRIPTION
A flat 40k token default meant a 64k context window auto-compacted at 38% usage (#484).

`compaction_buffer` now accepts either a token count (`10000`) or a percent string (`"20%"`), resolved against the model's context window at check time.

The default is `20%`, which matches the old 40k on 200k windows and scales down for small local models.

Fixes #484.