### PR TITLE
fix(batch): stray single-line snapshot and missing child rendering

### DIFF
--- a/maki-highlight/src/lib.rs
+++ b/maki-highlight/src/lib.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt::Write;
 use std::sync::{Arc, OnceLock, RwLock};
 
@@ -11,8 +12,11 @@ use syntect::util::LinesWithEndings;
 const TOKEN_ALIASES: &[(&str, &str)] = &[("jsx", "js")];
 pub const TAB_SPACES: &str = "  ";
 
+type Rgb = (u8, u8, u8);
+
 static SYNTAX_SET: OnceLock<SyntaxSet> = OnceLock::new();
 static THEME: OnceLock<RwLock<Arc<Theme>>> = OnceLock::new();
+static UI_COLORS: OnceLock<RwLock<HashMap<String, Rgb>>> = OnceLock::new();
 
 fn theme_lock() -> &'static RwLock<Arc<Theme>> {
     THEME.get_or_init(|| RwLock::new(Arc::new(Theme::default())))
@@ -40,7 +44,24 @@ pub fn theme() -> Arc<Theme> {
         .clone()
 }
 
-pub fn theme_color(name: &str) -> Option<(u8, u8, u8)> {
+fn ui_colors_lock() -> &'static RwLock<HashMap<String, Rgb>> {
+    UI_COLORS.get_or_init(RwLock::default)
+}
+
+/// Extra named colors (like diff backgrounds) that [`theme_color`] checks
+/// before falling back to the syntect theme settings.
+pub fn set_ui_colors(colors: HashMap<String, Rgb>) {
+    *ui_colors_lock().write().unwrap_or_else(|e| e.into_inner()) = colors;
+}
+
+pub fn theme_color(name: &str) -> Option<Rgb> {
+    if let Some(&c) = ui_colors_lock()
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(name)
+    {
+        return Some(c);
+    }
     let settings = &theme().settings;
     let map = serde_json::to_value(settings).ok()?;
     let obj = map.as_object()?;

--- a/maki-lua/src/api/async.rs
+++ b/maki-lua/src/api/async.rs
@@ -227,7 +227,6 @@ pub(crate) fn create_async_table(lua: &Lua) -> LuaResult<Table> {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
     use std::pin::pin;
     use std::sync::Mutex;
 
@@ -236,8 +235,6 @@ mod tests {
     use test_case::test_case;
 
     use super::*;
-    use crate::api::r#fn::JobStore;
-    use crate::api::ui::buf::BufferStore;
     use crate::runtime::{CANCELLED_MSG, TaskCell};
 
     const ERR_TOO_FEW_ARGS: &str = "maki.async.await requires at least 2 arguments: argc, fun, ...";
@@ -459,17 +456,7 @@ mod tests {
     fn cancelled_task_handle() -> TaskHandle {
         let (trigger, token) = CancelToken::new();
         trigger.cancel();
-        Arc::new(Mutex::new(TaskCell {
-            cancel: token,
-            deadline: Cell::new(None),
-            deadline_secs: Cell::new(None),
-            jobs: JobStore::new(),
-            bufs: BufferStore::new(),
-            live: None,
-            root_buf: None,
-            live_sink: None,
-            inline_spawn: None,
-        }))
+        Arc::new(Mutex::new(TaskCell::new(token, None, None)))
     }
 
     #[test_case(0 ; "zero_clamps_to_capacity_one")]

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -730,24 +730,27 @@ fn get_tool_from_lua(lua: &Lua, name: String) -> LuaResult<LuaValue> {
     Ok(LuaValue::Table(t))
 }
 
-/// The one contract every `get_tool` handle obeys: it never throws; an
-/// error from the wrapped fn is logged and becomes nil.
+/// Never throws: errors are logged and become nil. Async because wrapped
+/// fns like bash restore need to await (e.g. inline highlighting).
 fn wrap_nothrow(
     lua: &Lua,
     tool: String,
     handle: &'static str,
     f: Function,
-    norm: impl Fn(&Lua, LuaValue) -> LuaResult<LuaValue> + Send + 'static,
+    norm: impl Fn(&Lua, LuaValue) -> LuaResult<LuaValue> + Clone + Send + Sync + 'static,
 ) -> LuaResult<Function> {
-    lua.create_function(
-        move |lua, args: MultiValue| match f.call::<LuaValue>(args) {
-            Ok(v) => norm(lua, v),
-            Err(e) => {
-                tracing::warn!(tool, handle, error = %e, "get_tool handle failed");
-                Ok(LuaValue::Nil)
+    lua.create_async_function(move |lua, args: MultiValue| {
+        let (f, tool, norm) = (f.clone(), tool.clone(), norm.clone());
+        async move {
+            match f.call_async::<LuaValue>(args).await {
+                Ok(v) => norm(&lua, v),
+                Err(e) => {
+                    tracing::warn!(tool, handle, error = %e, "get_tool handle failed");
+                    Ok(LuaValue::Nil)
+                }
             }
-        },
-    )
+        }
+    })
 }
 
 /// Normalizes a header fn to one spans line or nil: a plain string gets
@@ -781,13 +784,16 @@ fn wrap_header(lua: &Lua, tool: String, f: Function) -> LuaResult<Function> {
 /// a real `LuaCtx` or a plain `{ tool_output_lines =, state = }` table (how
 /// batch drives child restores); either way the fn sees a restore `LuaCtx`.
 fn wrap_restore(lua: &Lua, tool: String, f: Function) -> LuaResult<Function> {
-    let prepped = lua.create_function(move |lua, mut args: MultiValue| {
-        let ctx = normalize_restore_ctx(lua, args.get(3))?;
-        while args.len() < 4 {
-            args.push_back(LuaValue::Nil);
+    let prepped = lua.create_async_function(move |lua, mut args: MultiValue| {
+        let f = f.clone();
+        async move {
+            let ctx = normalize_restore_ctx(&lua, args.get(3))?;
+            while args.len() < 4 {
+                args.push_back(LuaValue::Nil);
+            }
+            args[3] = ctx;
+            f.call_async::<MultiValue>(args).await
         }
-        args[3] = ctx;
-        f.call::<MultiValue>(args)
     })?;
     wrap_nothrow(lua, tool, "restore", prepped, |_lua, v| {
         Ok(match &v {

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -233,10 +233,19 @@ pub(crate) struct TaskCell {
     /// When `Some`, `maki.async.run` tasks queue here instead of the global
     /// `SpawnQueue` so restore can run them inline before snapshotting.
     pub(crate) inline_spawn: Option<Vec<PendingAsyncTask>>,
+    /// Claims on `bufs`: one for the live `TaskScope`, plus one per queued
+    /// `maki.async.run` task (a batch recomposes its body through buf
+    /// watchers after its scope drops). Whoever drops the last claim runs
+    /// `bufs.clear()`, breaking the watcher/click cycles.
+    pub(crate) buf_claims: usize,
 }
 
 impl TaskCell {
-    fn new(cancel: CancelToken, deadline: Option<Instant>, live: Option<LiveCtx>) -> Self {
+    pub(crate) fn new(
+        cancel: CancelToken,
+        deadline: Option<Instant>,
+        live: Option<LiveCtx>,
+    ) -> Self {
         Self {
             cancel,
             deadline: Cell::new(deadline),
@@ -247,6 +256,7 @@ impl TaskCell {
             root_buf: None,
             live_sink: None,
             inline_spawn: None,
+            buf_claims: 1,
         }
     }
 }
@@ -357,8 +367,8 @@ impl Drop for TaskScope {
             let mut cell = lock_cell(&self.handle);
             cell.jobs.kill_all();
             cell.jobs.clear(&self.lua);
-            cell.bufs.clear();
         }
+        release_claim(&self.handle);
         match self.prev.take() {
             Some(p) => {
                 self.lua.set_app_data(p);
@@ -425,32 +435,28 @@ pub(crate) fn with_live_ctx<R>(lua: &Lua, f: impl FnOnce(&LiveCtx) -> R) -> Opti
 
 pub(crate) fn enqueue_async_task(lua: &Lua, work_fn: RegistryKey) -> Result<(), mlua::Error> {
     let handle = lua.app_data_ref::<TaskHandle>();
-    let (cancel, live_ctx, live_buf) = match &handle {
+    let (cancel, live_ctx) = match &handle {
         Some(h) => {
             let cell = lock_cell(h);
-            (
-                cell.cancel.clone(),
-                cell.live.clone(),
-                cell.bufs.live_buf().cloned(),
-            )
+            (cell.cancel.clone(), cell.live.clone())
         }
-        None => (CancelToken::none(), None, None),
+        None => (CancelToken::none(), None),
     };
 
-    let task = PendingAsyncTask {
+    let mut task = PendingAsyncTask {
         work_fn,
         cancel,
         deadline: Some(Instant::now() + ASYNC_RUN_DEFAULT_DEADLINE),
         live_ctx,
-        live_buf,
+        owner: None,
     };
 
     if let Some(h) = &handle {
-        let mut cell = lock_cell(h);
-        if let Some(inline) = cell.inline_spawn.as_mut() {
+        if let Some(inline) = lock_cell(h).inline_spawn.as_mut() {
             inline.push(task);
             return Ok(());
         }
+        task.owner = Some(OwnerClaim::new(Arc::clone(h)));
     }
 
     let queue = lua
@@ -535,7 +541,28 @@ pub(crate) struct PendingAsyncTask {
     pub cancel: CancelToken,
     pub deadline: Option<Instant>,
     pub live_ctx: Option<LiveCtx>,
-    pub live_buf: Option<Arc<SharedBuf>>,
+    pub owner: Option<OwnerClaim>,
+}
+
+/// Keeps the owner's bufs alive while this task is queued. Root buf is
+/// resolved at snapshot time because it does not exist yet at enqueue time.
+pub(crate) struct OwnerClaim(TaskHandle);
+
+impl OwnerClaim {
+    fn new(handle: TaskHandle) -> Self {
+        lock_cell(&handle).buf_claims += 1;
+        Self(handle)
+    }
+
+    fn root_buf(&self) -> Option<Arc<SharedBuf>> {
+        resolve_root_buf(&self.0)
+    }
+}
+
+impl Drop for OwnerClaim {
+    fn drop(&mut self) {
+        release_claim(&self.0);
+    }
 }
 
 pub(crate) type SpawnQueue = RefCell<Vec<PendingAsyncTask>>;
@@ -556,6 +583,14 @@ async fn run_work_fn(
             .await
         }
         None => fut.await,
+    }
+}
+
+fn release_claim(handle: &TaskHandle) {
+    let mut cell = lock_cell(handle);
+    cell.buf_claims = cell.buf_claims.saturating_sub(1);
+    if cell.buf_claims == 0 {
+        cell.bufs.clear();
     }
 }
 
@@ -596,11 +631,12 @@ fn drain_spawn_queue(lua: &Lua, ex: &Rc<smol::LocalExecutor<'_>>, gate: &Rc<Infl
             }
 
             if let Some(ref live) = task.live_ctx
-                && let Some(ref buf) = task.live_buf
+                && let Some(buf) = task.owner.as_ref().and_then(OwnerClaim::root_buf)
+                && let Some(lines) = buf.read_if_dirty()
             {
                 let _ = live.event_tx.send(maki_agent::AgentEvent::ToolSnapshot {
                     id: live.tool_use_id.clone(),
-                    snapshot: buf.take(),
+                    snapshot: maki_agent::BufferSnapshot::from_arc(lines),
                     theme_gen: None,
                 });
             }
@@ -1523,13 +1559,8 @@ fn strip_traceback(err: &mlua::Error) -> String {
 /// The error message format is load-bearing: the bash plugin's `restore`
 /// parses it to re-render the timeout sentinel on session reload.
 fn timeout_reply(handle: &TaskHandle, plugin: &str, tool: &str) -> ToolCallReply {
-    let (secs, live_buf) = {
-        let cell = lock_cell(handle);
-        (
-            cell.deadline_secs.get().unwrap_or(0),
-            cell.bufs.live_buf().cloned(),
-        )
-    };
+    let secs = lock_cell(handle).deadline_secs.get().unwrap_or(0);
+    let live_buf = resolve_root_buf(handle);
     let qualified = if plugin == tool || plugin.is_empty() {
         tool.to_owned()
     } else {
@@ -1682,15 +1713,11 @@ async fn run_tool_call(
         };
         match handler_result {
             Ok(LuaValue::Nil) => {
-                let (live, sink, buf) = {
+                let (live, sink) = {
                     let cell = lock_cell(&handle);
-                    (
-                        cell.live.clone(),
-                        cell.live_sink.clone(),
-                        cell.bufs.live_buf().cloned(),
-                    )
+                    (cell.live.clone(), cell.live_sink.clone())
                 };
-                if let Some(buf) = buf {
+                if let Some(buf) = resolve_root_buf(&handle) {
                     if let Some(live) = live {
                         let _ = live.event_tx.send(maki_agent::AgentEvent::LiveToolBuf {
                             id: live.tool_use_id.clone(),
@@ -2276,7 +2303,7 @@ mod tests {
         let queue = lua.app_data_ref::<SpawnQueue>().unwrap();
         let queued = &queue.borrow()[0];
         assert!(queued.live_ctx.is_none());
-        assert!(queued.live_buf.is_none());
+        assert!(queued.owner.is_none());
     }
 
     #[test]
@@ -2316,6 +2343,46 @@ mod tests {
         );
     }
 
+    #[test]
+    fn scope_drop_defers_watcher_clear_until_owned_tasks_release() {
+        use crate::api::ui::buf::HandlerSlot;
+
+        let lua = enqueue_test_lua();
+        let scope = set_active(&lua, TaskCell::new(CancelToken::none(), None, None));
+        let handle = Arc::clone(scope.handle());
+
+        let buf = Arc::new(SharedBuf::new());
+        let fired = Arc::new(AtomicBool::new(false));
+        let f = Arc::clone(&fired);
+        buf.set_on_change(move || f.store(true, Ordering::Release));
+        lock_cell(&handle)
+            .bufs
+            .track(HandlerSlot::Change(Arc::clone(&buf)));
+
+        enqueue_async_task(&lua, enqueue_dummy(&lua)).unwrap();
+        drop(scope);
+
+        buf.set_lines(Vec::new());
+        assert!(
+            fired.load(Ordering::Acquire),
+            "watcher must survive scope drop while an owned async task is pending"
+        );
+
+        let task = lua
+            .app_data_ref::<SpawnQueue>()
+            .unwrap()
+            .borrow_mut()
+            .pop()
+            .unwrap();
+        drop(task);
+        fired.store(false, Ordering::Release);
+        buf.set_lines(Vec::new());
+        assert!(
+            !fired.load(Ordering::Acquire),
+            "dropping the last owned task must clear the deferred watcher"
+        );
+    }
+
     fn push_pending_task(lua: &Lua, cancel: CancelToken, deadline: Option<Instant>) {
         let work_fn = enqueue_dummy(lua);
         lua.app_data_ref::<SpawnQueue>()
@@ -2326,7 +2393,7 @@ mod tests {
                 cancel,
                 deadline,
                 live_ctx: None,
-                live_buf: None,
+                owner: None,
             });
     }
 

--- a/maki-lua/tests/batch_live_snapshot.rs
+++ b/maki-lua/tests/batch_live_snapshot.rs
@@ -1,0 +1,126 @@
+//! Regression: async tasks spawned by child restores (e.g. highlighting)
+//! used to snapshot the first-created buf instead of the batch root buf.
+//! That meant one child's tiny header could overwrite the full batch render.
+
+use std::sync::Arc;
+
+use maki_agent::tools::ToolRegistry;
+use maki_agent::tools::test_support::stub_ctx_with;
+use maki_agent::{AgentEvent, AgentMode, BufferSnapshot, EventSender, SpanStyle};
+use maki_lua::PluginHost;
+use serde_json::json;
+
+const BATCH_PLUGIN_SRC: &str = include_str!("../../plugins/batch/init.lua");
+const BATCH_ID: &str = "batch_id";
+
+const CHILD_SRC: &str = r#"
+local ToolView = require("maki.tool_view")
+maki.api.register_tool({
+  name = "hl",
+  description = "styled header + async-highlight restore",
+  schema = { type = "object", properties = {} },
+  audiences = { "main" },
+  header = function(input)
+    local b = maki.ui.buf()
+    b:set_lines({ { { "hl-header", "tool" } } })
+    return b
+  end,
+  restore = function(input, output, is_error, rctx)
+    local buf = maki.ui.buf()
+    local view = ToolView.new(buf, { max_lines = 10, keep = "head" })
+    view:set_highlight(output, "lua")
+    view:finish()
+    return buf
+  end,
+  handler = function() return "local x = 1" end,
+})
+"#;
+
+#[test]
+fn async_highlight_tasks_never_shrink_and_reach_final_snapshot() {
+    let snapshots = run_batch(CHILD_SRC, "hl");
+    for text in snapshots.iter().map(BufferSnapshot::text) {
+        assert_eq!(
+            text.matches("hl> ").count(),
+            2,
+            "every batch snapshot must carry all children, got:\n{text}"
+        );
+    }
+    let last = snapshots.last().expect("at least one batch snapshot");
+    let has_inline = last
+        .lines
+        .iter()
+        .flat_map(|l| &l.spans)
+        .any(|s| matches!(s.style, SpanStyle::Inline(_)));
+    assert!(
+        has_inline,
+        "final snapshot must contain highlighted spans, got:\n{}",
+        last.text()
+    );
+}
+
+/// A child restore that awaits an async API inline (like bash highlighting
+/// its `$ command` header) must not error out of the sync `get_tool`
+/// wrapper and degrade to the plain fallback body.
+#[test]
+fn child_restore_awaiting_async_api_keeps_its_body() {
+    let snapshots = run_batch(SYNC_HL_CHILD_SRC, "cmd");
+    let last = snapshots.last().expect("at least one batch snapshot");
+    let text = last.text();
+    assert!(
+        text.contains("echo header-marker"),
+        "child restore header must survive, got:\n{text}"
+    );
+}
+
+const SYNC_HL_CHILD_SRC: &str = r#"
+local ToolView = require("maki.tool_view")
+maki.api.register_tool({
+  name = "cmd",
+  description = "restore awaits maki.ui.highlight inline",
+  schema = { type = "object", properties = {} },
+  audiences = { "main" },
+  restore = function(input, output, is_error, rctx)
+    local buf = maki.ui.buf()
+    local view = ToolView.new(buf, { max_lines = 10, keep = "tail" })
+    local header = maki.ui.highlight("echo header-marker", "bash") or { { { "echo header-marker" } } }
+    view:set_header(header)
+    view:append(output)
+    view:finish()
+    return buf
+  end,
+  handler = function() return "cmd-output" end,
+})
+"#;
+
+fn run_batch(child_src: &str, tool: &str) -> Vec<BufferSnapshot> {
+    let reg = Arc::new(ToolRegistry::new());
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source("stray_repro", &format!("{child_src}\n{BATCH_PLUGIN_SRC}"))
+        .unwrap();
+
+    let (tx, rx) = flume::unbounded();
+    let event_tx = EventSender::new(tx, 0);
+    let mut ctx = stub_ctx_with(&AgentMode::Build, Some(&event_tx), Some(BATCH_ID));
+    ctx.registry = Arc::clone(&reg);
+
+    let input = json!({ "tool_calls": [
+        { "tool": tool, "parameters": {} },
+        { "tool": tool, "parameters": {} },
+    ]});
+    let entry = reg.get("batch").unwrap();
+    let inv = entry.tool.parse(&input).unwrap();
+    let done = smol::block_on(async { inv.execute(&ctx).await });
+    assert!(done.output.is_ok(), "batch failed: {:?}", done.output);
+
+    host.load_source("barrier", "").unwrap();
+
+    let mut snapshots = Vec::new();
+    for env in rx.drain() {
+        if let AgentEvent::ToolSnapshot { id, snapshot, .. } = env.event {
+            assert_eq!(id, BATCH_ID);
+            snapshots.push(snapshot);
+        }
+    }
+    snapshots
+}

--- a/maki-lua/tests/batch_policy.rs
+++ b/maki-lua/tests/batch_policy.rs
@@ -248,13 +248,6 @@ fn nested_batch_rejected_without_dispatch() {
 }
 
 #[test]
-fn empty_tool_calls_is_an_error() {
-    let (reg, _host) = load_batch_host();
-    let err = run_batch(&reg, json!([])).unwrap_err();
-    assert_eq!(err, EMPTY_ERROR);
-}
-
-#[test]
 fn overflow_entries_discarded_with_section() {
     let (reg, _host) = load_batch_host();
     let entries: Vec<Value> = (0..MAX_BATCH_SIZE + 1)
@@ -535,21 +528,59 @@ fn throwing_child_callbacks_degrade_to_plain() {
     assert!(text.contains("restore body"), "plain body fallback: {text}");
 }
 
-/// Old sessions carry no structured state. Headers still render from the
-/// input; the stored llm output becomes one plain body.
+/// No stored state: recover per-child views by parsing `## tool` sections
+/// from the LLM output.
+#[test]
+fn restore_without_state_parses_llm_sections() {
+    let (_reg, host) = load_batch_host();
+    let stored = format!(
+        "{}{}{}",
+        section("hdrtool", "line one\nline two"),
+        section("ok", &format!("{ERROR_PREFIX}{BOOM_ERR}")),
+        summary_mixed(1, 2, 1)
+    );
+    let lines = restore_snapshot_lines(
+        &host,
+        json!({ "tool_calls": [
+            { "tool": "hdrtool", "parameters": { "x": "A" } },
+            { "tool": "ok", "parameters": {} },
+        ] }),
+        &stored,
+        None,
+    );
+    assert_eq!(lines[0][2].0, "H:A", "child header fn still applies");
+    let text = lines_text(&lines);
+    assert!(
+        lines.iter().any(|l| l
+            .iter()
+            .any(|(_, s)| *s == SpanStyle::Named("tool_error".into()))),
+        "[ERROR] section maps to error status: {lines:?}"
+    );
+    assert!(text.contains("line one"), "body from section: {text}");
+    assert!(text.contains(BOOM_ERR), "error body: {text}");
+    assert!(
+        !text.contains(ERROR_PREFIX),
+        "llm error prefix must not render: {text}"
+    );
+    assert!(
+        !text.contains("successfully"),
+        "summary line must not render: {text}"
+    );
+}
+
+/// Unparseable output: headers from input, raw text as one plain body.
 #[test]
 fn restore_without_state_falls_back_to_raw_output() {
     let (_reg, host) = load_batch_host();
-    let stored = format!("{}{}", section("ok", "ok:a"), summary_all_ok(1));
     let lines = restore_snapshot_lines(
         &host,
         json!({ "tool_calls": [{ "tool": "ok", "parameters": { "tag": "a" } }] }),
-        &stored,
+        "not the section format",
         None,
     );
     let text = lines_text(&lines);
     assert!(text.contains("ok> "), "header from input: {text}");
-    assert!(text.contains("ok:a"), "raw output body: {text}");
+    assert!(text.contains("not the section format"), "raw body: {text}");
 }
 
 /// A replayed click row must reach exactly the child it lands on and run

--- a/maki-ui/src/highlight.rs
+++ b/maki-ui/src/highlight.rs
@@ -18,6 +18,18 @@ pub(crate) fn is_ready() -> bool {
 pub(crate) fn refresh_syntax_theme() {
     let theme = theme::current();
     maki_highlight::set_theme(theme.syntax.clone());
+    maki_highlight::set_ui_colors(
+        [
+            ("diff_old", theme.diff_old.bg),
+            ("diff_new", theme.diff_new.bg),
+        ]
+        .into_iter()
+        .filter_map(|(name, color)| match color {
+            Some(Color::Rgb(r, g, b)) => Some((name.to_owned(), (r, g, b))),
+            _ => None,
+        })
+        .collect(),
+    );
 }
 
 pub fn highlight_line(hl: &mut maki_highlight::Highlighter, text: &str) -> Vec<Span<'static>> {

--- a/plugins/batch/init.lua
+++ b/plugins/batch/init.lua
@@ -23,6 +23,11 @@ local NESTED_ERROR = "cannot nest batch inside batch"
 local CANCELLED_ERROR = "cancelled"
 local DISCARDED_ERROR = string.format("maximum of %d tools per batch", MAX_BATCH_SIZE)
 local SECTION_FMT = "## %s\n"
+local SECTION_PAT = "^## (.+)$"
+local SUMMARY_PATS = {
+  "^All %d+ tools executed successfully%.$",
+  "^Executed %d+/%d+ successfully%. %d+ failed%.$",
+}
 local SUMMARY_MIXED_FMT = "Executed %d/%d successfully. %d failed."
 local SUMMARY_ALL_OK_FMT = "All %d tools executed successfully."
 local RESETTLE_FMT = "batch: child %s settled twice (%s -> %s)"
@@ -246,6 +251,52 @@ local function to_state(children)
   return { children = out }
 end
 
+-- Old sessions have no structured state. Try to recover per-child results
+-- by parsing `## tool` sections from the LLM output. Returns nil when the
+-- format does not match so the caller can fall back to a raw dump.
+local function children_from_llm(children, output)
+  if #children == 0 then
+    return nil
+  end
+  local sections = {}
+  local body
+  for line in (output .. "\n"):gmatch("([^\n]*)\n") do
+    local tool = line:match(SECTION_PAT)
+    local nxt = children[#sections + 1]
+    if tool and nxt and tool == nxt.tool then
+      body = {}
+      sections[#sections + 1] = body
+    elseif body then
+      body[#body + 1] = line
+    else
+      return nil
+    end
+  end
+  if #sections ~= #children then
+    return nil
+  end
+  local last = sections[#sections]
+  for _, pat in ipairs(SUMMARY_PATS) do
+    if last[#last] and last[#last]:match(pat) then
+      last[#last] = nil
+      break
+    end
+  end
+  local out = {}
+  for i, lines in ipairs(sections) do
+    while #lines > 0 and lines[#lines] == "" do
+      lines[#lines] = nil
+    end
+    local text = table.concat(lines, "\n")
+    local failed = text:sub(1, #ERROR_PREFIX) == ERROR_PREFIX
+    out[i] = {
+      status = failed and STATUS.ERROR or STATUS.SUCCESS,
+      output = failed and text:sub(#ERROR_PREFIX + 1) or text,
+    }
+  end
+  return out
+end
+
 --- Batch view-model ---------------------------------------------------------
 
 local Batch = {}
@@ -389,9 +440,7 @@ local function handler(input, ctx)
   }
 end
 
--- Old or foreign session with no structured state: headers are still a
--- pure function of the input, and the stored llm output becomes one
--- plain collapsible body.
+-- Fallback when we have no state and the output is not section-formatted.
 local function legacy_restore(children, output, tol)
   local buf = maki.ui.buf()
   local view = ToolView.new(buf, { max_lines = tol.other, keep = "head" })
@@ -416,11 +465,11 @@ local function restore(input, output, _is_error, rctx)
   end
 
   local st = rctx:state()
-  if st and type(st.children) == "table" and #st.children == #children then
-    -- Rehydrate before a Batch owns the children, and do not trust
-    -- storage: anything non-terminal there (corrupt or foreign) becomes
-    -- an error. Batch.new attaches the terminal bodies itself.
-    for i, sc in ipairs(st.children) do
+  local kids = st and type(st.children) == "table" and #st.children == #children and st.children
+    or children_from_llm(children, output)
+  if kids then
+    -- Treat non-terminal statuses as errors (corrupt or foreign data).
+    for i, sc in ipairs(kids) do
       local c = children[i]
       c.status = TERMINAL[sc.status] and sc.status or STATUS.ERROR
       c.output, c.annotation = sc.output, sc.annotation

--- a/plugins/edit/init.lua
+++ b/plugins/edit/init.lua
@@ -3,6 +3,8 @@ local ToolView = require("maki.tool_view")
 local fuzzy_replace = require("maki.fuzzy_replace")
 local replace_lines = require("edit_helpers").replace_lines
 
+local FALLBACK_VIEW_LINES = 10
+
 local EDIT_LINES_DESCRIPTION =
   [[Edit lines by number. Omit `end` to insert before `start` without removing lines. Set `end` to replace or delete (empty `new_string`) a range.]]
 
@@ -48,27 +50,61 @@ local function edit_view_opts(ctx)
   return { max_lines = (tol and tol.write) or FALLBACK_VIEW_LINES, keep = "head" }
 end
 
--- Old lines red, new lines green, one block per edit. Rebuilt purely from
--- the input, so a batch child can render the change without the file
--- snapshots (those live in ToolOutput::Diff, which Rust renders standalone).
-local function diff_view(blocks, ctx)
+-- Builds the diff view from input alone (batch children don't have file
+-- snapshots). Syntax highlighting is layered async on top of diff backgrounds.
+local function append_diff_lines(view, text, style, jobs)
+  local lines = split_lines(text or "")
+  if #lines == 0 then
+    return
+  end
+  jobs[#jobs + 1] = { first = #view.all_lines + 1, text = table.concat(lines, "\n"), style = style }
+  for _, line in ipairs(lines) do
+    view:append({ { line, style } })
+  end
+end
+
+local function apply_highlights(view, jobs, ext)
+  maki.async.run(function()
+    for _, job in ipairs(jobs) do
+      local bg = maki.ui.theme_color(job.style)
+      local highlighted = bg and maki.ui.highlight(job.text, ext)
+      for i, hl_line in ipairs(highlighted or {}) do
+        local idx = job.first + i - 1
+        if not view.all_lines[idx] then
+          break
+        end
+        local spans = {}
+        for _, seg in ipairs(hl_line) do
+          local style = type(seg[2]) == "table" and seg[2] or {}
+          style.bg = bg
+          spans[#spans + 1] = { seg[1], style }
+        end
+        view:update_line(idx, spans)
+      end
+    end
+    view:flush()
+  end)
+end
+
+local function diff_view(blocks, path, ctx)
   local buf = maki.ui.buf()
   local view = ToolView.new(buf, edit_view_opts(ctx))
+  local jobs = {}
   for i, block in ipairs(blocks) do
     if i > 1 then
       view:append({})
     end
-    for _, line in ipairs(split_lines(block.old or "")) do
-      view:append({ { line, "diff_old" } })
-    end
-    for _, line in ipairs(split_lines(block.new or "")) do
-      view:append({ { line, "diff_new" } })
-    end
+    append_diff_lines(view, block.old, "diff_old", jobs)
+    append_diff_lines(view, block.new, "diff_new", jobs)
   end
   view:finish()
   buf:on("click", function()
     view:toggle()
   end)
+  local ext = (path or ""):match("%.([^%.]+)$")
+  if #jobs > 0 and ext then
+    apply_highlights(view, jobs, ext)
+  end
   return buf
 end
 
@@ -77,7 +113,7 @@ local function diff_restore(blocks_from)
     if is_error then
       return ToolView.restore(output, edit_view_opts(ctx))
     end
-    return diff_view(blocks_from(input), ctx)
+    return diff_view(blocks_from(input), input.path, ctx)
   end
 end
 


### PR DESCRIPTION
Batch tools collapsed to a single header line after completion. `maki.async.run` tasks (child highlight jobs) inherited the batch `tool_use_id` but captured `bufs.live_buf()`, which is the *first* buf created in the task. In a batch that first buf is a child header, not the batch body. On completion each async task emitted that one-line header as the batch `ToolSnapshot`, overwriting the full render. `PendingAsyncTask` now carries the owner `TaskHandle` and resolves `resolve_root_buf` at completion time, so the real body (set by `ctx:live_buf` or the reply) is always used.

Batch restore sometimes showed raw `## tool` llm sections instead of per-child renders. This happened when structured `state` was missing (older sessions, non-serializable state). Added `children_from_llm` in the batch plugin that parses the pinned section format back into per-child status and output, so each child still renders through its own tool view with proper indicators.