### PR TITLE
providers(openrouter): Fix discovered pricing scale

### DIFF
--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use flume::Sender;
 use serde_json::{Value, json};
 
-use crate::model::{Model, ModelEntry};
+use crate::model::{Model, ModelEntry, ModelInfo, ModelPricing};
 use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig};
 
@@ -12,6 +12,7 @@ use super::{KeyPool, ResolvedAuth};
 
 const REFERER: &str = "https://maki.sh";
 const APP_TITLE: &str = "maki";
+const PER_MILLION: f64 = 1_000_000.0;
 
 static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     api_key_env: "OPENROUTER_API_KEY",
@@ -81,6 +82,78 @@ fn map_effort_to_supported<'a>(requested: &'a str, supported: &'a [String]) -> &
         }
     }
     supported.last().map(|s| s.as_str()).unwrap_or(requested)
+}
+
+fn parse_model(m: &Value) -> Option<ModelInfo> {
+    // Filter: only text input/output models
+    let architecture = m["architecture"].as_object()?;
+    let input_modalities = architecture["input_modalities"].as_array()?;
+    let output_modalities = architecture["output_modalities"].as_array()?;
+
+    let has_text_input = input_modalities.iter().any(|m| m.as_str() == Some("text"));
+    let has_text_output = output_modalities.iter().any(|m| m.as_str() == Some("text"));
+    if !has_text_input || !has_text_output {
+        return None;
+    }
+
+    let supports_vision = input_modalities.iter().any(|m| m.as_str() == Some("image"));
+
+    // Parse with OpenRouter-specific pricing field names. OpenRouter reports
+    // per-token prices; scale to $/M as `ModelPricing` expects.
+    let id = m["id"].as_str()?;
+    let context_window = m["context_length"]
+        .as_u64()
+        .and_then(|v| u32::try_from(v).ok());
+    let per_token =
+        |p: &Value| -> Option<f64> { Some(p.as_str()?.parse::<f64>().ok()? * PER_MILLION) };
+    let pricing = m["pricing"]
+        .as_object()
+        .and_then(|p| {
+            Some(ModelPricing {
+                input: per_token(p.get("prompt")?)?,
+                output: per_token(p.get("completion")?)?,
+                cache_write: p
+                    .get("input_cache_write")
+                    .and_then(per_token)
+                    .unwrap_or(0.0),
+                cache_read: p.get("input_cache_read").and_then(per_token).unwrap_or(0.0),
+                fast: None,
+            })
+        })
+        .unwrap_or_default();
+
+    let reasoning = m
+        .get("reasoning")
+        .and_then(|v| v.as_object())
+        .map(|v| OpenRouterModelInfo {
+            reasoning_mandatory: v.get("mandatory").and_then(Value::as_bool) == Some(true),
+            reasoning_default_enabled: v.get("default_enabled").and_then(Value::as_bool)
+                == Some(true),
+            reasoning_efforts: v
+                .get("supported_efforts")
+                .and_then(Value::as_array)
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default(),
+        });
+
+    let supports_thinking = reasoning.is_some()
+        || m.get("supported_parameters")
+            .and_then(|v| v.as_array())
+            .is_some_and(|v| v.iter().any(|v| v.as_str() == Some("reasoning")));
+
+    Some(ModelInfo {
+        id: id.to_string(),
+        context_window,
+        max_output_tokens: None,
+        pricing: Some(pricing),
+        supports_thinking: Some(supports_thinking),
+        supports_vision: Some(supports_vision),
+        provider_info: reasoning.map(|r| Arc::new(r) as Arc<dyn std::any::Any + Send + Sync>),
+    })
 }
 
 impl Provider for OpenRouter {
@@ -161,88 +234,10 @@ impl Provider for OpenRouter {
         })
     }
 
-    fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<ModelInfo>, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
-            self.compat
-                .fetch_and_parse_models(&auth, |m| {
-                    // Filter: only text input/output models
-                    let architecture = m["architecture"].as_object()?;
-                    let input_modalities = architecture["input_modalities"].as_array()?;
-                    let output_modalities = architecture["output_modalities"].as_array()?;
-
-                    let has_text_input =
-                        input_modalities.iter().any(|m| m.as_str() == Some("text"));
-                    let has_text_output =
-                        output_modalities.iter().any(|m| m.as_str() == Some("text"));
-                    if !has_text_input || !has_text_output {
-                        return None;
-                    }
-
-                    let supports_vision =
-                        input_modalities.iter().any(|m| m.as_str() == Some("image"));
-
-                    // Parse with OpenRouter-specific pricing field names
-                    let id = m["id"].as_str()?;
-                    let context_window = m["context_length"]
-                        .as_u64()
-                        .and_then(|v| u32::try_from(v).ok());
-                    let pricing = m["pricing"]
-                        .as_object()
-                        .and_then(|p| {
-                            Some(crate::model::ModelPricing {
-                                input: p.get("prompt")?.as_str()?.parse().ok()?,
-                                output: p.get("completion")?.as_str()?.parse().ok()?,
-                                cache_write: p
-                                    .get("input_cache_write")
-                                    .and_then(|p| p.as_str()?.parse().ok())
-                                    .unwrap_or(0.0),
-                                cache_read: p
-                                    .get("input_cache_read")
-                                    .and_then(|p| p.as_str()?.parse().ok())
-                                    .unwrap_or(0.0),
-                                fast: None,
-                            })
-                        })
-                        .unwrap_or_default();
-
-                    let reasoning = m.get("reasoning").and_then(|v| v.as_object()).map(|v| {
-                        OpenRouterModelInfo {
-                            reasoning_mandatory: v.get("mandatory").and_then(Value::as_bool)
-                                == Some(true),
-                            reasoning_default_enabled: v
-                                .get("default_enabled")
-                                .and_then(Value::as_bool)
-                                == Some(true),
-                            reasoning_efforts: v
-                                .get("supported_efforts")
-                                .and_then(Value::as_array)
-                                .map(|arr| {
-                                    arr.iter()
-                                        .filter_map(|v| v.as_str().map(String::from))
-                                        .collect()
-                                })
-                                .unwrap_or_default(),
-                        }
-                    });
-
-                    let supports_thinking = reasoning.is_some()
-                        || m.get("supported_parameters")
-                            .and_then(|v| v.as_array())
-                            .is_some_and(|v| v.iter().any(|v| v.as_str() == Some("reasoning")));
-
-                    Some(crate::model::ModelInfo {
-                        id: id.to_string(),
-                        context_window,
-                        max_output_tokens: None,
-                        pricing: Some(pricing),
-                        supports_thinking: Some(supports_thinking),
-                        supports_vision: Some(supports_vision),
-                        provider_info: reasoning
-                            .map(|r| Arc::new(r) as Arc<dyn std::any::Any + Send + Sync>),
-                    })
-                })
-                .await
+            self.compat.fetch_and_parse_models(&auth, parse_model).await
         })
     }
 
@@ -253,5 +248,67 @@ impl Provider for OpenRouter {
                 .as_ref()
                 .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    use super::*;
+
+    fn kimi_k3_json() -> Value {
+        json!({
+            "id": "moonshotai/kimi-k3",
+            "context_length": 1_048_576,
+            "architecture": {
+                "input_modalities": ["text", "image"],
+                "output_modalities": ["text"],
+            },
+            "pricing": {
+                "prompt": "0.000003",
+                "completion": "0.000015",
+                "input_cache_read": "0.0000003",
+            },
+            "supported_parameters": ["reasoning"],
+        })
+    }
+
+    #[test]
+    fn parse_model_scales_pricing_to_per_million() {
+        let info = parse_model(&kimi_k3_json()).expect("model should parse");
+
+        assert_eq!(info.id, "moonshotai/kimi-k3");
+        assert_eq!(info.context_window, Some(1_048_576));
+        assert_eq!(info.supports_vision, Some(true));
+        assert_eq!(info.supports_thinking, Some(true));
+        let pricing = info.pricing.expect("pricing should be parsed");
+        assert_eq!(pricing.input, 3.0);
+        assert_eq!(pricing.output, 15.0);
+        assert_eq!(pricing.cache_read, 0.3);
+        assert_eq!(pricing.cache_write, 0.0);
+    }
+
+    #[test]
+    fn parse_model_scales_cache_write() {
+        let mut m = kimi_k3_json();
+        m["pricing"]["input_cache_write"] = json!("0.00000375");
+
+        let pricing = parse_model(&m)
+            .expect("model should parse")
+            .pricing
+            .expect("pricing should be parsed");
+        assert_eq!(pricing.cache_write, 3.75);
+    }
+
+    #[test_case(json!(["image"]), json!(["image"]); "image_only")]
+    #[test_case(json!(["image"]), json!(["text"]); "image_input_only")]
+    #[test_case(json!(["text"]), json!(["image"]); "image_output_only")]
+    fn parse_model_skips_non_text_models(input: Value, output: Value) {
+        let mut m = kimi_k3_json();
+        m["architecture"]["input_modalities"] = input;
+        m["architecture"]["output_modalities"] = output;
+
+        assert!(parse_model(&m).is_none());
     }
 }


### PR DESCRIPTION
OpenRouter's `/models` API returns per-token prices as strings (e.g. kimi-k3: `"prompt": "0.000003"`), but `ModelPricing` expects $/M tokens and `TokenUsage::cost` divides by 1M. Discovered OpenRouter model costs were therefore 1,000,000x too small (every session showed "$0.000").

Changes:

1. Scale discovered pricing to $/M: extracted the `list_models` closure into a free `parse_model` fn and multiply `prompt`, `completion`, `input_cache_write`, and `input_cache_read` by `PER_MILLION` (matches the conversion tensorx.rs already does). Fixes cost reporting for all discovered OpenRouter models.