### PR TITLE
fix(agent): strip `functions.` prefix from tool names

### DIFF
--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -68,6 +68,8 @@ pub async fn run(
     ctx: &ToolContext,
     emit: Emit,
 ) -> ToolDoneEvent {
+    // GPT-5.6 was likely trained on Codex sessions where tools are `functions.<name>`
+    let name = name.strip_prefix("functions.").unwrap_or(name);
     if let Some(local) = ctx.local_tools.get(name) {
         return run_local_tool(local, id, name, input, ctx, emit);
     }


### PR DESCRIPTION
GPT-5.6 was likely post-trained on Codex sessions where tool calls use `functions.<name>` instead of just `<name>`, so every call fails with "unknown tool".

Strip the prefix at the top of tool dispatch before any lookup.

Fixes #505.