### PR TITLE
fix(providers): alias `reasoning` field for vLLM compat

### DIFF
--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -378,6 +378,7 @@ struct FunctionDelta {
 #[derive(Deserialize)]
 struct ChunkDelta {
     content: Option<ContentDelta>,
+    #[serde(alias = "reasoning")]
     reasoning_content: Option<String>,
     tool_calls: Option<Vec<ToolCallDelta>>,
 }


### PR DESCRIPTION
vLLM sends thinking content in a field called `reasoning`, while llama.cpp uses `reasoning_content`. Both claim to be OpenAI compatible, but this part of the spec is loosely defined. Adding a serde alias covers both without affecting existing providers.

Closes #498