### PR TITLE
fix(copilot): support GitHub Enterprise (*.ghe.com) hosts

### DIFF
--- a/maki-providers/src/providers/copilot/auth.rs
+++ b/maki-providers/src/providers/copilot/auth.rs
@@ -14,15 +14,26 @@ use tracing::debug;
 use crate::AgentError;
 
 const TOKEN_ENV_VARS: &[&str] = &["GH_COPILOT_TOKEN", "COPILOT_GITHUB_TOKEN"];
-const COPILOT_DOMAIN: &str = "github.com";
+const DEFAULT_HOST: &str = "github.com";
 const PROVIDER: &str = "copilot";
 
-pub(crate) fn load_token() -> Result<String, AgentError> {
+pub(crate) fn graphql_url(host: &str) -> String {
+    if host == DEFAULT_HOST {
+        "https://api.github.com/graphql".to_owned()
+    } else {
+        format!("https://{host}/api/graphql")
+    }
+}
+
+pub(crate) fn load_token() -> Result<ProviderCredentials, AgentError> {
     for key in TOKEN_ENV_VARS {
         if let Ok(token) = env::var(key)
             && !token.trim().is_empty()
         {
-            return Ok(token);
+            return Ok(ProviderCredentials {
+                api_key: token,
+                host: None,
+            });
         }
     }
 
@@ -30,7 +41,7 @@ pub(crate) fn load_token() -> Result<String, AgentError> {
         && let Some(creds) = load_provider_credentials(&dir, PROVIDER)
     {
         debug!("using saved Copilot credentials");
-        return Ok(creds.api_key);
+        return Ok(creds);
     }
 
     Err(AgentError::Config {
@@ -38,20 +49,26 @@ pub(crate) fn load_token() -> Result<String, AgentError> {
     })
 }
 
-fn discover_token() -> Result<String, AgentError> {
+fn discover_token() -> Result<ProviderCredentials, AgentError> {
     for path in copilot_config_paths() {
         if let Ok(contents) = fs::read_to_string(path)
-            && let Some(token) = extract_json_oauth_token(&contents, COPILOT_DOMAIN)
+            && let Some((token, host)) = extract_oauth_token_json(&contents)
         {
-            return Ok(token);
+            return Ok(ProviderCredentials {
+                api_key: token,
+                host: (host != DEFAULT_HOST).then_some(host),
+            });
         }
     }
 
     for path in gh_config_paths() {
         if let Ok(contents) = fs::read_to_string(path)
-            && let Some(token) = extract_yaml_oauth_token(&contents, COPILOT_DOMAIN)
+            && let Some((token, host)) = extract_oauth_token_yaml(&contents)
         {
-            return Ok(token);
+            return Ok(ProviderCredentials {
+                api_key: token,
+                host: (host != DEFAULT_HOST).then_some(host),
+            });
         }
     }
 
@@ -68,9 +85,10 @@ pub fn login(dir: &StateDir) -> Result<(), AgentError> {
         return Ok(());
     }
 
-    let token = discover_token()?;
-    save_provider_credentials(dir, PROVIDER, &ProviderCredentials { api_key: token })?;
-    println!("Copilot token imported from gh CLI / Copilot client config.");
+    let creds = discover_token()?;
+    let host = creds.host.as_deref().unwrap_or(DEFAULT_HOST);
+    println!("Copilot token imported from gh CLI / Copilot client config ({host}).");
+    save_provider_credentials(dir, PROVIDER, &creds)?;
     Ok(())
 }
 
@@ -81,6 +99,10 @@ pub fn logout(dir: &StateDir) -> Result<(), AgentError> {
         println!("Not currently logged in to Copilot.");
     }
     Ok(())
+}
+
+fn is_github_host(host: &str) -> bool {
+    host == DEFAULT_HOST || host.ends_with(".ghe.com") || host.ends_with(".github.com")
 }
 
 fn copilot_config_paths() -> Vec<PathBuf> {
@@ -102,22 +124,27 @@ fn config_dir() -> Option<PathBuf> {
         .or_else(|| maki_storage::paths::home().map(|home| home.join(".config")))
 }
 
-fn extract_json_oauth_token(contents: &str, domain: &str) -> Option<String> {
+fn extract_oauth_token_json(contents: &str) -> Option<(String, String)> {
     let value: JsonValue = serde_json::from_str(contents).ok()?;
     value.as_object()?.iter().find_map(|(key, value)| {
-        if key.starts_with(domain) {
-            value["oauth_token"].as_str().map(ToOwned::to_owned)
+        if is_github_host(key) {
+            value["oauth_token"]
+                .as_str()
+                .map(|tok| (tok.to_owned(), key.clone()))
         } else {
             None
         }
     })
 }
 
-fn extract_yaml_oauth_token(contents: &str, domain: &str) -> Option<String> {
+fn extract_oauth_token_yaml(contents: &str) -> Option<(String, String)> {
     let value: YamlValue = serde_yaml::from_str(contents).ok()?;
     value.as_mapping()?.iter().find_map(|(key, value)| {
-        if key.as_str().is_some_and(|key| key.starts_with(domain)) {
-            value["oauth_token"].as_str().map(ToOwned::to_owned)
+        let host = key.as_str()?;
+        if is_github_host(host) {
+            value["oauth_token"]
+                .as_str()
+                .map(|tok| (tok.to_owned(), host.to_owned()))
         } else {
             None
         }
@@ -130,22 +157,42 @@ mod tests {
     use test_case::test_case;
 
     #[test_case(
-        r#"{"github.com": {"oauth_token": "token-1"}}"#, "github.com" => Some("token-1".to_string()); "json_matching_domain"
+        r#"{"github.com": {"oauth_token": "token-1"}}"# => Some(("token-1".to_string(), "github.com".to_string())); "json_matching_domain"
     )]
     #[test_case(
-        r#"{"enterprise.example.com": {"oauth_token": "token-1"}}"#, "github.com" => None; "json_other_domain"
+        r#"{"enterprise.example.com": {"oauth_token": "token-1"}}"# => None; "json_other_domain"
     )]
-    fn extract_json_oauth_token_by_domain(contents: &str, domain: &str) -> Option<String> {
-        extract_json_oauth_token(contents, domain)
+    #[test_case(
+        r#"{"myco.ghe.com": {"oauth_token": "ghe-tok"}}"# => Some(("ghe-tok".to_string(), "myco.ghe.com".to_string())); "json_ghe_host"
+    )]
+    fn extract_json_token(contents: &str) -> Option<(String, String)> {
+        extract_oauth_token_json(contents)
     }
 
     #[test_case(
-        "github.com:\n  oauth_token: token-1\n  user: octocat\n", "github.com" => Some("token-1".to_string()); "yaml_matching_domain"
+        "github.com:\n  oauth_token: token-1\n  user: octocat\n" => Some(("token-1".to_string(), "github.com".to_string())); "yaml_matching_domain"
     )]
     #[test_case(
-        "enterprise.example.com:\n  oauth_token: token-1\n", "github.com" => None; "yaml_other_domain"
+        "enterprise.example.com:\n  oauth_token: token-1\n" => None; "yaml_other_domain"
     )]
-    fn extract_yaml_oauth_token_by_domain(contents: &str, domain: &str) -> Option<String> {
-        extract_yaml_oauth_token(contents, domain)
+    #[test_case(
+        "myco.ghe.com:\n  oauth_token: ghe-tok\n" => Some(("ghe-tok".to_string(), "myco.ghe.com".to_string())); "yaml_ghe_host"
+    )]
+    fn extract_yaml_token(contents: &str) -> Option<(String, String)> {
+        extract_oauth_token_yaml(contents)
+    }
+
+    #[test_case("github.com" => true; "github_com")]
+    #[test_case("myco.ghe.com" => true; "ghe_com")]
+    #[test_case("gitlab.com" => false; "gitlab")]
+    #[test_case("evil-ghe.com" => false; "fake_ghe")]
+    fn test_is_github_host(host: &str) -> bool {
+        is_github_host(host)
+    }
+
+    #[test_case("github.com" => "https://api.github.com/graphql"; "graphql_default")]
+    #[test_case("myco.ghe.com" => "https://myco.ghe.com/api/graphql"; "graphql_ghe")]
+    fn test_graphql_url(host: &str) -> String {
+        graphql_url(host)
     }
 }

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -139,9 +139,14 @@ impl Copilot {
             return Ok(auth);
         }
 
-        let token = auth::load_token()?;
-        let endpoint = discover_api_endpoint(&self.client, &token).await;
-        let auth = CopilotAuth { token, endpoint };
+        let creds = auth::load_token()?;
+        let host = creds.host.as_deref().unwrap_or("github.com");
+        let endpoint =
+            discover_api_endpoint(&self.client, &creds.api_key, &auth::graphql_url(host)).await;
+        let auth = CopilotAuth {
+            token: creds.api_key,
+            endpoint,
+        };
         *self.auth.lock().unwrap() = Some(auth.clone());
         Ok(auth)
     }
@@ -418,8 +423,8 @@ struct GraphQlCopilotEndpoints {
     api: String,
 }
 
-async fn discover_api_endpoint(client: &HttpClient, token: &str) -> String {
-    match try_discover_api_endpoint(client, token).await {
+async fn discover_api_endpoint(client: &HttpClient, token: &str, graphql_url: &str) -> String {
+    match try_discover_api_endpoint(client, token, graphql_url).await {
         Ok(endpoint) => endpoint,
         Err(err) => {
             warn!(error = %err, fallback = DEFAULT_API_ENDPOINT, "Copilot endpoint discovery failed");
@@ -428,11 +433,15 @@ async fn discover_api_endpoint(client: &HttpClient, token: &str) -> String {
     }
 }
 
-async fn try_discover_api_endpoint(client: &HttpClient, token: &str) -> Result<String, AgentError> {
+async fn try_discover_api_endpoint(
+    client: &HttpClient,
+    token: &str,
+    graphql_url: &str,
+) -> Result<String, AgentError> {
     let body = json!({ "query": GRAPHQL_QUERY });
     let request = Request::builder()
         .method("POST")
-        .uri("https://api.github.com/graphql")
+        .uri(graphql_url)
         .header("authorization", format!("Bearer {token}"))
         .header("content-type", "application/json")
         .header("user-agent", super::user_agent())

--- a/maki-storage/src/auth.rs
+++ b/maki-storage/src/auth.rs
@@ -45,6 +45,8 @@ pub struct McpAuthData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderCredentials {
     pub api_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
 }
 
 pub fn now_millis() -> u64 {

--- a/maki-ui/src/components/login_picker.rs
+++ b/maki-ui/src/components/login_picker.rs
@@ -372,7 +372,10 @@ impl LoginPicker {
 
                     let has_key = !api_key.is_empty();
                     if has_key {
-                        let creds = ProviderCredentials { api_key };
+                        let creds = ProviderCredentials {
+                            api_key,
+                            host: None,
+                        };
                         if let Err(e) = save_provider_credentials(&storage, &slug_c, &creds) {
                             return self.transition(StepAction::GoDone {
                                 message: format!("Error: {e}"),

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -73,7 +73,10 @@ fn login_provider(slug: &str, storage: &StateDir) -> Result<()> {
 
     let has_key = !api_key.is_empty();
     if has_key {
-        let creds = ProviderCredentials { api_key };
+        let creds = ProviderCredentials {
+            api_key,
+            host: None,
+        };
         save_provider_credentials(storage, slug, &creds).context("save credentials")?;
     }
 
@@ -236,7 +239,10 @@ fn login_custom(storage: &StateDir) -> Result<()> {
 
     let has_key = !api_key.is_empty();
     if has_key {
-        let creds = ProviderCredentials { api_key };
+        let creds = ProviderCredentials {
+            api_key,
+            host: None,
+        };
         save_provider_credentials(storage, &slug, &creds).context("save credentials")?;
     }
 


### PR DESCRIPTION
Token discovery was hardcoded to `github.com`, so `gh auth login` tokens stored under enterprise domains were silently ignored. The GraphQL endpoint for Copilot API discovery was also hardcoded to `api.github.com/graphql`, which rejects enterprise tokens.

`discover_token` now accepts any `*.ghe.com` or `*.github.com` host and returns which domain the token came from. That domain is persisted in `ProviderCredentials` and used to build the correct GraphQL URL (`https://<host>/api/graphql` for GHE, `https://api.github.com/graphql` for regular GitHub).

Fixes #375.