### PR TITLE
fix(batch): stray single-line snapshot and missing child rendering

### DIFF
--- a/maki-highlight/src/lib.rs
+++ b/maki-highlight/src/lib.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt::Write;
 use std::sync::{Arc, OnceLock, RwLock};
 
@@ -11,8 +12,11 @@ use syntect::util::LinesWithEndings;
 const TOKEN_ALIASES: &[(&str, &str)] = &[("jsx", "js")];
 pub const TAB_SPACES: &str = "  ";
 
+type Rgb = (u8, u8, u8);
+
 static SYNTAX_SET: OnceLock<SyntaxSet> = OnceLock::new();
 static THEME: OnceLock<RwLock<Arc<Theme>>> = OnceLock::new();
+static UI_COLORS: OnceLock<RwLock<HashMap<String, Rgb>>> = OnceLock::new();
 
 fn theme_lock() -> &'static RwLock<Arc<Theme>> {
     THEME.get_or_init(|| RwLock::new(Arc::new(Theme::default())))
@@ -40,7 +44,22 @@ pub fn theme() -> Arc<Theme> {
         .clone()
 }
 
-pub fn theme_color(name: &str) -> Option<(u8, u8, u8)> {
+fn ui_colors_lock() -> &'static RwLock<HashMap<String, Rgb>> {
+    UI_COLORS.get_or_init(RwLock::default)
+}
+
+pub fn set_ui_colors(colors: HashMap<String, Rgb>) {
+    *ui_colors_lock().write().unwrap_or_else(|e| e.into_inner()) = colors;
+}
+
+pub fn theme_color(name: &str) -> Option<Rgb> {
+    if let Some(&c) = ui_colors_lock()
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(name)
+    {
+        return Some(c);
+    }
     let settings = &theme().settings;
     let map = serde_json::to_value(settings).ok()?;
     let obj = map.as_object()?;

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -27,7 +27,8 @@ use maki_providers::provider;
 use maki_providers::{ContentBlock, Model, ModelError, Role, ThinkingConfig};
 use maki_storage::id::MakiId;
 use mlua::{
-    Function, Lua, Result as LuaResult, Table, UserData, UserDataMethods, Value as LuaValue,
+    Function, IntoLuaMulti, Lua, Result as LuaResult, Table, UserData, UserDataMethods,
+    Value as LuaValue,
 };
 use serde_json::Value as JsonValue;
 use tracing::info;
@@ -218,8 +219,7 @@ async fn tools(
 /// Returns `(text, err)`. While the child runs, `opts.on_live_buf`
 /// receives each buf it publishes (as a foreign `BufHandle`) and
 /// `opts.on_annotation` every annotation, live ones and the completion
-/// annotation alike. Both run synchronously on the Lua thread and must
-/// not yield.
+/// annotation alike. Both run on the Lua thread and may yield.
 async fn call_tool(
     lua: Lua,
     (ctx, name, input, opts): (mlua::UserDataRef<LuaCtx>, String, LuaValue, Option<Table>),
@@ -244,18 +244,12 @@ async fn call_tool(
     if let Err(e) = tctx.deadline.check() {
         return Ok(err_pair(e));
     }
-    let deliver = |ev: ToolLive| {
-        let res = match ev {
-            ToolLive::Buf(buf) => on_buf
-                .as_ref()
-                .map(|f| f.call::<()>(BufHandle::foreign(buf))),
-            ToolLive::Annotation(ann) => on_ann.as_ref().map(|f| f.call::<()>(ann)),
-        };
-        if let Some(Err(e)) = res {
-            tracing::warn!(tool = name, error = %e, "call_tool callback failed");
-        }
+    let cbs = LiveCallbacks {
+        tool: &name,
+        on_buf,
+        on_ann,
     };
-    let done = dispatch_racing_live(&tctx, &name, &input_json, rx, &deliver).await;
+    let done = dispatch_racing_live(&tctx, &name, &input_json, rx, &cbs).await;
     // Same fallback the UI applies on tool completion, so a batch child's
     // header carries the annotation its standalone run would get.
     let annotation = done
@@ -263,7 +257,7 @@ async fn call_tool(
         .clone()
         .or_else(|| (!done.is_error).then(|| done.output.annotation()).flatten());
     if let Some(a) = annotation {
-        deliver(ToolLive::Annotation(a));
+        cbs.deliver(ToolLive::Annotation(a)).await;
     }
     match interpreter_bridge::flatten(&done) {
         Ok(text) => Ok((Some(text), None)),
@@ -271,15 +265,42 @@ async fn call_tool(
     }
 }
 
+/// Must use `call_async`, not `call`: callbacks that yield (highlight,
+/// markdown) hit the C-call boundary otherwise.
+struct LiveCallbacks<'a> {
+    tool: &'a str,
+    on_buf: Option<Function>,
+    on_ann: Option<Function>,
+}
+
+impl LiveCallbacks<'_> {
+    async fn deliver(&self, ev: ToolLive) {
+        let res = match ev {
+            ToolLive::Buf(buf) => call_opt(&self.on_buf, BufHandle::foreign(buf)).await,
+            ToolLive::Annotation(ann) => call_opt(&self.on_ann, ann).await,
+        };
+        if let Some(Err(e)) = res {
+            tracing::warn!(tool = self.tool, error = %e, "call_tool callback failed");
+        }
+    }
+}
+
+async fn call_opt(f: &Option<Function>, arg: impl IntoLuaMulti) -> Option<LuaResult<()>> {
+    match f {
+        Some(f) => Some(f.call_async::<()>(arg).await),
+        None => None,
+    }
+}
+
 /// Like `interpreter_bridge::dispatch`, but keeps the full `ToolDoneEvent`
-/// (the annotation lives there) and feeds live events to `deliver` while
-/// the child runs.
+/// (the annotation lives there) and feeds live events to `cbs` while the
+/// child runs.
 async fn dispatch_racing_live(
     tctx: &ToolContext,
     name: &str,
     input: &JsonValue,
     rx: Option<flume::Receiver<ToolLive>>,
-    deliver: &impl Fn(ToolLive),
+    cbs: &LiveCallbacks<'_>,
 ) -> ToolDoneEvent {
     let run = tool_dispatch::run(
         &tctx.registry,
@@ -298,11 +319,11 @@ async fn dispatch_racing_live(
         match select(run.as_mut(), pin!(rx.recv_async())).await {
             Either::Left((done, _)) => {
                 while let Ok(ev) = rx.try_recv() {
-                    deliver(ev);
+                    cbs.deliver(ev).await;
                 }
                 return done;
             }
-            Either::Right((Ok(ev), _)) => deliver(ev),
+            Either::Right((Ok(ev), _)) => cbs.deliver(ev).await,
             // The sender is gone but no result arrived: just wait for the run.
             Either::Right((Err(_), _)) => return run.await,
         }

--- a/maki-lua/src/api/async.rs
+++ b/maki-lua/src/api/async.rs
@@ -227,7 +227,6 @@ pub(crate) fn create_async_table(lua: &Lua) -> LuaResult<Table> {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
     use std::pin::pin;
     use std::sync::Mutex;
 
@@ -236,8 +235,6 @@ mod tests {
     use test_case::test_case;
 
     use super::*;
-    use crate::api::r#fn::JobStore;
-    use crate::api::ui::buf::BufferStore;
     use crate::runtime::{CANCELLED_MSG, TaskCell};
 
     const ERR_TOO_FEW_ARGS: &str = "maki.async.await requires at least 2 arguments: argc, fun, ...";
@@ -459,17 +456,7 @@ mod tests {
     fn cancelled_task_handle() -> TaskHandle {
         let (trigger, token) = CancelToken::new();
         trigger.cancel();
-        Arc::new(Mutex::new(TaskCell {
-            cancel: token,
-            deadline: Cell::new(None),
-            deadline_secs: Cell::new(None),
-            jobs: JobStore::new(),
-            bufs: BufferStore::new(),
-            live: None,
-            root_buf: None,
-            live_sink: None,
-            inline_spawn: None,
-        }))
+        Arc::new(Mutex::new(TaskCell::new(token, None, None)))
     }
 
     #[test_case(0 ; "zero_clamps_to_capacity_one")]

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -730,24 +730,26 @@ fn get_tool_from_lua(lua: &Lua, name: String) -> LuaResult<LuaValue> {
     Ok(LuaValue::Table(t))
 }
 
-/// The one contract every `get_tool` handle obeys: it never throws; an
-/// error from the wrapped fn is logged and becomes nil.
+/// Async so wrapped fns can yield (e.g. bash restore highlights inline).
 fn wrap_nothrow(
     lua: &Lua,
     tool: String,
     handle: &'static str,
     f: Function,
-    norm: impl Fn(&Lua, LuaValue) -> LuaResult<LuaValue> + Send + 'static,
+    norm: fn(&Lua, LuaValue) -> LuaResult<LuaValue>,
 ) -> LuaResult<Function> {
-    lua.create_function(
-        move |lua, args: MultiValue| match f.call::<LuaValue>(args) {
-            Ok(v) => norm(lua, v),
-            Err(e) => {
-                tracing::warn!(tool, handle, error = %e, "get_tool handle failed");
-                Ok(LuaValue::Nil)
+    lua.create_async_function(move |lua, args: MultiValue| {
+        let (f, tool) = (f.clone(), tool.clone());
+        async move {
+            match f.call_async::<LuaValue>(args).await {
+                Ok(v) => norm(&lua, v),
+                Err(e) => {
+                    tracing::warn!(tool, handle, error = %e, "get_tool handle failed");
+                    Ok(LuaValue::Nil)
+                }
             }
-        },
-    )
+        }
+    })
 }
 
 /// Normalizes a header fn to one spans line or nil: a plain string gets
@@ -781,13 +783,16 @@ fn wrap_header(lua: &Lua, tool: String, f: Function) -> LuaResult<Function> {
 /// a real `LuaCtx` or a plain `{ tool_output_lines =, state = }` table (how
 /// batch drives child restores); either way the fn sees a restore `LuaCtx`.
 fn wrap_restore(lua: &Lua, tool: String, f: Function) -> LuaResult<Function> {
-    let prepped = lua.create_function(move |lua, mut args: MultiValue| {
-        let ctx = normalize_restore_ctx(lua, args.get(3))?;
-        while args.len() < 4 {
-            args.push_back(LuaValue::Nil);
+    let prepped = lua.create_async_function(move |lua, mut args: MultiValue| {
+        let f = f.clone();
+        async move {
+            let ctx = normalize_restore_ctx(&lua, args.get(3))?;
+            while args.len() < 4 {
+                args.push_back(LuaValue::Nil);
+            }
+            args[3] = ctx;
+            f.call_async::<MultiValue>(args).await
         }
-        args[3] = ctx;
-        f.call::<MultiValue>(args)
     })?;
     wrap_nothrow(lua, tool, "restore", prepped, |_lua, v| {
         Ok(match &v {

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -233,10 +233,17 @@ pub(crate) struct TaskCell {
     /// When `Some`, `maki.async.run` tasks queue here instead of the global
     /// `SpawnQueue` so restore can run them inline before snapshotting.
     pub(crate) inline_spawn: Option<Vec<PendingAsyncTask>>,
+    /// Set by [`TaskScope::new`]; `enqueue_async_task` upgrades it so queued
+    /// tasks share ownership of `bufs`. See [`BufsClaim`].
+    bufs_claim: Weak<BufsClaim>,
 }
 
 impl TaskCell {
-    fn new(cancel: CancelToken, deadline: Option<Instant>, live: Option<LiveCtx>) -> Self {
+    pub(crate) fn new(
+        cancel: CancelToken,
+        deadline: Option<Instant>,
+        live: Option<LiveCtx>,
+    ) -> Self {
         Self {
             cancel,
             deadline: Cell::new(deadline),
@@ -247,6 +254,7 @@ impl TaskCell {
             root_buf: None,
             live_sink: None,
             inline_spawn: None,
+            bufs_claim: Weak::new(),
         }
     }
 }
@@ -306,23 +314,28 @@ pub(crate) struct TaskScope {
     lua: Lua,
     handle: TaskHandle,
     prev: Option<TaskHandle>,
+    /// Dropped after `Drop::drop` runs, so jobs die before bufs can clear.
+    _bufs_claim: Arc<BufsClaim>,
 }
 
 impl TaskScope {
     pub(crate) fn new(lua: &Lua, cell: TaskCell) -> Self {
         let handle: TaskHandle = Arc::new(Mutex::new(cell));
+        let claim = Arc::new(BufsClaim(Arc::clone(&handle)));
+        lock_cell(&handle).bufs_claim = Arc::downgrade(&claim);
         let prev = lua.set_app_data::<TaskHandle>(Arc::clone(&handle));
         Self {
             lua: lua.clone(),
             handle,
             prev,
+            _bufs_claim: claim,
         }
     }
 
     /// The shared Lua keeps the last task's handle around, so system
     /// callbacks need a fresh scope or the interrupt hook kills them
-    /// (stale handle looks cancelled). Prefer [`run_detached`] or
-    /// [`LuaRuntime::call_sync_detached`] over raw scopes.
+    /// (stale handle looks cancelled). Prefer [`run_detached`] over raw
+    /// scopes.
     pub(crate) fn detached(lua: &Lua) -> Self {
         Self::new(lua, TaskCell::new(CancelToken::none(), None, None))
     }
@@ -357,7 +370,6 @@ impl Drop for TaskScope {
             let mut cell = lock_cell(&self.handle);
             cell.jobs.kill_all();
             cell.jobs.clear(&self.lua);
-            cell.bufs.clear();
         }
         match self.prev.take() {
             Some(p) => {
@@ -425,32 +437,31 @@ pub(crate) fn with_live_ctx<R>(lua: &Lua, f: impl FnOnce(&LiveCtx) -> R) -> Opti
 
 pub(crate) fn enqueue_async_task(lua: &Lua, work_fn: RegistryKey) -> Result<(), mlua::Error> {
     let handle = lua.app_data_ref::<TaskHandle>();
-    let (cancel, live_ctx, live_buf) = match &handle {
+    let (cancel, live_ctx) = match &handle {
         Some(h) => {
             let cell = lock_cell(h);
-            (
-                cell.cancel.clone(),
-                cell.live.clone(),
-                cell.bufs.live_buf().cloned(),
-            )
+            (cell.cancel.clone(), cell.live.clone())
         }
-        None => (CancelToken::none(), None, None),
+        None => (CancelToken::none(), None),
     };
 
-    let task = PendingAsyncTask {
+    let mut task = PendingAsyncTask {
         work_fn,
         cancel,
         deadline: Some(Instant::now() + ASYNC_RUN_DEFAULT_DEADLINE),
         live_ctx,
-        live_buf,
+        owner: None,
     };
 
     if let Some(h) = &handle {
         let mut cell = lock_cell(h);
+        // Inline tasks live inside the cell, so a claim there would be a
+        // strong Arc cycle; they run before the scope drops anyway.
         if let Some(inline) = cell.inline_spawn.as_mut() {
             inline.push(task);
             return Ok(());
         }
+        task.owner = cell.bufs_claim.upgrade();
     }
 
     let queue = lua
@@ -535,7 +546,26 @@ pub(crate) struct PendingAsyncTask {
     pub cancel: CancelToken,
     pub deadline: Option<Instant>,
     pub live_ctx: Option<LiveCtx>,
-    pub live_buf: Option<Arc<SharedBuf>>,
+    pub owner: Option<Arc<BufsClaim>>,
+}
+
+/// Shared ownership of a task's `bufs`: the scope holds one clone, each
+/// queued `maki.async.run` task holds one, so the `Arc` strong count is the
+/// single source of truth for liveness. Dropping the last clone clears the
+/// store, breaking Lua GC watcher/click cycles. Root buf is resolved lazily
+/// because it may not exist at enqueue time.
+pub(crate) struct BufsClaim(TaskHandle);
+
+impl BufsClaim {
+    fn root_buf(&self) -> Option<Arc<SharedBuf>> {
+        resolve_root_buf(&self.0)
+    }
+}
+
+impl Drop for BufsClaim {
+    fn drop(&mut self) {
+        lock_cell(&self.0).bufs.clear();
+    }
 }
 
 pub(crate) type SpawnQueue = RefCell<Vec<PendingAsyncTask>>;
@@ -596,11 +626,14 @@ fn drain_spawn_queue(lua: &Lua, ex: &Rc<smol::LocalExecutor<'_>>, gate: &Rc<Infl
             }
 
             if let Some(ref live) = task.live_ctx
-                && let Some(ref buf) = task.live_buf
+                && let Some(buf) = task.owner.as_ref().and_then(|c| c.root_buf())
             {
+                // Always `read`, not `read_if_dirty`: the dirty flag is
+                // consume-once and the UI polls each frame, so the flag
+                // races. Re-emitting identical content is harmless.
                 let _ = live.event_tx.send(maki_agent::AgentEvent::ToolSnapshot {
                     id: live.tool_use_id.clone(),
-                    snapshot: buf.take(),
+                    snapshot: maki_agent::BufferSnapshot::from_arc(buf.read()),
                     theme_gen: None,
                 });
             }
@@ -1170,39 +1203,46 @@ impl LuaRuntime {
         }
     }
 
-    fn call_sync_detached<R: mlua::FromLuaMulti>(
+    /// Resolves a plugin callback and converts its json input, warning on
+    /// failure. `None` when the tool has no such callback registered.
+    fn plugin_fn(
         &self,
-        func: &Function,
-        args: impl mlua::IntoLuaMulti,
-    ) -> mlua::Result<R> {
-        let _scope = TaskScope::detached(&self.lua);
-        func.call::<R>(args)
+        plugin: &str,
+        tool: &str,
+        callback: &'static str,
+        key: impl FnOnce(&ToolKeys) -> Option<&RegistryKey>,
+        input: &Value,
+    ) -> Option<(Function, LuaValue)> {
+        let func = {
+            let plugins = self.plugins.borrow();
+            let key = key(plugins.get(plugin)?.get(tool)?)?;
+            match self.lua.registry_value::<Function>(key) {
+                Ok(f) => f,
+                Err(e) => {
+                    tracing::warn!(plugin, tool, callback, error = %e, "callback registry lookup failed");
+                    return None;
+                }
+            }
+        };
+        match json_to_lua(&self.lua, input) {
+            Ok(v) => Some((func, v)),
+            Err(e) => {
+                tracing::warn!(plugin, tool, callback, error = %e, "callback input conversion failed");
+                None
+            }
+        }
     }
 
-    fn compute_header(&self, plugin: &str, tool: &str, input: Value) -> HeaderResult {
-        let plugins = self.plugins.borrow();
-        let Some(tk) = plugins.get(plugin).and_then(|p| p.get(tool)) else {
+    /// Async so header fns can yield (highlight, markdown). A sync call
+    /// would hit the C-call boundary and silently fall back to the plain name.
+    async fn compute_header(&self, plugin: &str, tool: &str, input: Value) -> HeaderResult {
+        let Some((func, input_lua)) =
+            self.plugin_fn(plugin, tool, "header", |tk| tk.header.as_ref(), &input)
+        else {
             return HeaderResult::plain(tool.to_string());
-        };
-        let Some(key) = tk.header.as_ref() else {
-            return HeaderResult::plain(tool.to_string());
-        };
-        let func = match self.lua.registry_value::<Function>(key) {
-            Ok(f) => f,
-            Err(e) => {
-                tracing::warn!(plugin, tool, error = %e, "header fn registry lookup failed");
-                return HeaderResult::plain(tool.to_string());
-            }
-        };
-        let input_lua = match json_to_lua(&self.lua, &input) {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::warn!(plugin, tool, error = %e, "header fn input serialization failed");
-                return HeaderResult::plain(tool.to_string());
-            }
         };
 
-        let result = self.call_sync_detached::<LuaValue>(&func, input_lua);
+        let result = run_detached(&self.lua, func.call_async::<LuaValue>(input_lua)).await;
 
         match result {
             Ok(LuaValue::String(s)) => match s.to_str() {
@@ -1288,6 +1328,7 @@ impl LuaRuntime {
         if reply.header.is_none() {
             reply.header = Some(
                 self.compute_header(&plugin_name, &item.tool, item.input)
+                    .await
                     .into_snapshot(),
             );
         }
@@ -1321,30 +1362,20 @@ impl LuaRuntime {
         }
     }
 
-    fn compute_permission_scopes(
+    async fn compute_permission_scopes(
         &self,
         plugin: &str,
         tool: &str,
         input: Value,
     ) -> Option<PermissionScopes> {
-        let plugins = self.plugins.borrow();
-        let tk = plugins.get(plugin)?.get(tool)?;
-        let key = tk.permission_scopes.as_ref()?;
-        let func = match self.lua.registry_value::<Function>(key) {
-            Ok(f) => f,
-            Err(e) => {
-                tracing::warn!(plugin, tool, error = %e, "failed to resolve permission_scopes callback");
-                return None;
-            }
-        };
-        let lua_input = match json_to_lua(&self.lua, &input) {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::warn!(plugin, tool, error = %e, "failed to convert input for permission_scopes");
-                return None;
-            }
-        };
-        let result: LuaValue = match self.call_sync_detached(&func, lua_input) {
+        let (func, lua_input) = self.plugin_fn(
+            plugin,
+            tool,
+            "permission_scopes",
+            |tk| tk.permission_scopes.as_ref(),
+            &input,
+        )?;
+        let result: LuaValue = match run_detached(&self.lua, func.call_async(lua_input)).await {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!(plugin, tool, error = %e, "permission_scopes callback failed");
@@ -1523,13 +1554,8 @@ fn strip_traceback(err: &mlua::Error) -> String {
 /// The error message format is load-bearing: the bash plugin's `restore`
 /// parses it to re-render the timeout sentinel on session reload.
 fn timeout_reply(handle: &TaskHandle, plugin: &str, tool: &str) -> ToolCallReply {
-    let (secs, live_buf) = {
-        let cell = lock_cell(handle);
-        (
-            cell.deadline_secs.get().unwrap_or(0),
-            cell.bufs.live_buf().cloned(),
-        )
-    };
+    let secs = lock_cell(handle).deadline_secs.get().unwrap_or(0);
+    let live_buf = resolve_root_buf(handle);
     let qualified = if plugin == tool || plugin.is_empty() {
         tool.to_owned()
     } else {
@@ -1682,15 +1708,11 @@ async fn run_tool_call(
         };
         match handler_result {
             Ok(LuaValue::Nil) => {
-                let (live, sink, buf) = {
+                let (live, sink) = {
                     let cell = lock_cell(&handle);
-                    (
-                        cell.live.clone(),
-                        cell.live_sink.clone(),
-                        cell.bufs.live_buf().cloned(),
-                    )
+                    (cell.live.clone(), cell.live_sink.clone())
                 };
-                if let Some(buf) = buf {
+                if let Some(buf) = resolve_root_buf(&handle) {
                     if let Some(live) = live {
                         let _ = live.event_tx.send(maki_agent::AgentEvent::LiveToolBuf {
                             id: live.tool_use_id.clone(),
@@ -1869,7 +1891,7 @@ pub fn spawn(
                             input,
                             reply,
                         } => {
-                            let res = rt.compute_header(&plugin, &tool, input);
+                            let res = rt.compute_header(&plugin, &tool, input).await;
                             let _ = reply.send(res);
                         }
                         Request::ComputePermissionScopes {
@@ -1878,7 +1900,7 @@ pub fn spawn(
                             input,
                             reply,
                         } => {
-                            let res = rt.compute_permission_scopes(&plugin, &tool, input);
+                            let res = rt.compute_permission_scopes(&plugin, &tool, input).await;
                             let _ = reply.send(res);
                         }
                         Request::RunInitLua {
@@ -2276,7 +2298,7 @@ mod tests {
         let queue = lua.app_data_ref::<SpawnQueue>().unwrap();
         let queued = &queue.borrow()[0];
         assert!(queued.live_ctx.is_none());
-        assert!(queued.live_buf.is_none());
+        assert!(queued.owner.is_none());
     }
 
     #[test]
@@ -2316,6 +2338,46 @@ mod tests {
         );
     }
 
+    #[test]
+    fn scope_drop_defers_watcher_clear_until_owned_tasks_release() {
+        use crate::api::ui::buf::HandlerSlot;
+
+        let lua = enqueue_test_lua();
+        let scope = set_active(&lua, TaskCell::new(CancelToken::none(), None, None));
+        let handle = Arc::clone(scope.handle());
+
+        let buf = Arc::new(SharedBuf::new());
+        let fired = Arc::new(AtomicBool::new(false));
+        let f = Arc::clone(&fired);
+        buf.set_on_change(move || f.store(true, Ordering::Release));
+        lock_cell(&handle)
+            .bufs
+            .track(HandlerSlot::Change(Arc::clone(&buf)));
+
+        enqueue_async_task(&lua, enqueue_dummy(&lua)).unwrap();
+        drop(scope);
+
+        buf.set_lines(Vec::new());
+        assert!(
+            fired.load(Ordering::Acquire),
+            "watcher must survive scope drop while an owned async task is pending"
+        );
+
+        let task = lua
+            .app_data_ref::<SpawnQueue>()
+            .unwrap()
+            .borrow_mut()
+            .pop()
+            .unwrap();
+        drop(task);
+        fired.store(false, Ordering::Release);
+        buf.set_lines(Vec::new());
+        assert!(
+            !fired.load(Ordering::Acquire),
+            "dropping the last owned task must clear the deferred watcher"
+        );
+    }
+
     fn push_pending_task(lua: &Lua, cancel: CancelToken, deadline: Option<Instant>) {
         let work_fn = enqueue_dummy(lua);
         lua.app_data_ref::<SpawnQueue>()
@@ -2326,7 +2388,7 @@ mod tests {
                 cancel,
                 deadline,
                 live_ctx: None,
-                live_buf: None,
+                owner: None,
             });
     }
 

--- a/maki-lua/tests/batch_policy.rs
+++ b/maki-lua/tests/batch_policy.rs
@@ -4,8 +4,8 @@
 use std::sync::Arc;
 
 use maki_agent::tools::ToolRegistry;
-use maki_agent::tools::test_support::stub_ctx;
-use maki_agent::{AgentMode, SpanStyle, ToolOutput};
+use maki_agent::tools::test_support::{stub_ctx, stub_ctx_with};
+use maki_agent::{AgentEvent, AgentMode, BufferSnapshot, EventSender, SpanStyle, ToolOutput};
 use maki_config::ToolOutputLines;
 use maki_lua::PluginHost;
 use serde_json::{Value, json};
@@ -248,13 +248,6 @@ fn nested_batch_rejected_without_dispatch() {
 }
 
 #[test]
-fn empty_tool_calls_is_an_error() {
-    let (reg, _host) = load_batch_host();
-    let err = run_batch(&reg, json!([])).unwrap_err();
-    assert_eq!(err, EMPTY_ERROR);
-}
-
-#[test]
 fn overflow_entries_discarded_with_section() {
     let (reg, _host) = load_batch_host();
     let entries: Vec<Value> = (0..MAX_BATCH_SIZE + 1)
@@ -356,13 +349,15 @@ fn restore_snapshot_lines_opts(
             clicks,
             state,
         },
-        maki_agent::EventSender::new(tx, 0),
+        EventSender::new(tx, 0),
     );
-    let _ = handle.collect_prompt_slots();
+    // Strong barrier: LoadSource drains the async gate, so spawned tasks
+    // (highlight rewrites etc.) have finished before we read snapshots.
+    host.load_source("barrier", "").unwrap();
 
     let mut lines = Vec::new();
     for env in rx.drain() {
-        if let maki_agent::AgentEvent::ToolSnapshot { snapshot, .. } = env.event {
+        if let AgentEvent::ToolSnapshot { snapshot, .. } = env.event {
             lines = snapshot
                 .lines
                 .iter()
@@ -387,7 +382,8 @@ fn lines_text(lines: &[Vec<(String, SpanStyle)>]) -> String {
 }
 
 /// Pins the child header contract: indicator span, `{tool}> ` prefix in
-/// `tool_prefix` style, then the child's own header spans.
+/// `tool_prefix` style, the child's own header spans, then the persisted
+/// annotation like standalone (`push_header` in tool_display.rs).
 #[test]
 fn restore_with_state_renders_child_header_contract() {
     let (_reg, host) = load_batch_host();
@@ -396,7 +392,7 @@ fn restore_with_state_renders_child_header_contract() {
         json!({ "tool_calls": [{ "tool": "hdrtool", "parameters": { "x": "A" } }] }),
         "irrelevant",
         Some(json!({ "children": [
-            { "tool": "hdrtool", "status": "success", "output": "line one\nline two" }
+            { "tool": "hdrtool", "status": "success", "output": "line one\nline two", "annotation": "12 lines" }
         ] })),
     );
     let header = &lines[0];
@@ -412,6 +408,14 @@ fn restore_with_state_renders_child_header_contract() {
         )
     );
     assert_eq!(header[2].0, "H:A", "child's own header spans must follow");
+    assert_eq!(
+        header.last().unwrap(),
+        &(
+            " (12 lines)".to_owned(),
+            SpanStyle::Named("tool_annotation".to_owned())
+        ),
+        "persisted annotation ends the header"
+    );
 
     let text = lines_text(&lines);
     assert!(text.contains("line one"), "body from state: {text}");
@@ -476,29 +480,6 @@ fn restore_child_body_equals_child_restore_view() {
     );
 }
 
-/// Persisted annotations render on the child header like standalone
-/// (`push_header` in tool_display.rs).
-#[test]
-fn restore_child_header_shows_annotation_span() {
-    let (_reg, host) = load_batch_host();
-    let lines = restore_snapshot_lines(
-        &host,
-        json!({ "tool_calls": [{ "tool": "hdrtool", "parameters": { "x": "A" } }] }),
-        "irrelevant",
-        Some(json!({ "children": [
-            { "tool": "hdrtool", "status": "success", "output": "body", "annotation": "12 lines" }
-        ] })),
-    );
-    let header = &lines[0];
-    assert_eq!(
-        header.last().unwrap(),
-        &(
-            " (12 lines)".to_owned(),
-            SpanStyle::Named("tool_annotation".to_owned())
-        )
-    );
-}
-
 /// A child can annotate more than once (a task child streams its model,
 /// then its completion note arrives on the same channel); batch joins
 /// them on the child header in order.
@@ -535,21 +516,89 @@ fn throwing_child_callbacks_degrade_to_plain() {
     assert!(text.contains("restore body"), "plain body fallback: {text}");
 }
 
-/// Old sessions carry no structured state. Headers still render from the
-/// input; the stored llm output becomes one plain body.
+/// No state: parse `## tool` sections from the LLM output.
 #[test]
-fn restore_without_state_falls_back_to_raw_output() {
+fn restore_without_state_parses_llm_sections() {
     let (_reg, host) = load_batch_host();
-    let stored = format!("{}{}", section("ok", "ok:a"), summary_all_ok(1));
+    let stored = format!(
+        "{}{}{}",
+        section("hdrtool", "line one\nline two"),
+        section("ok", &format!("{ERROR_PREFIX}{BOOM_ERR}")),
+        summary_mixed(1, 2, 1)
+    );
     let lines = restore_snapshot_lines(
         &host,
-        json!({ "tool_calls": [{ "tool": "ok", "parameters": { "tag": "a" } }] }),
+        json!({ "tool_calls": [
+            { "tool": "hdrtool", "parameters": { "x": "A" } },
+            { "tool": "ok", "parameters": {} },
+        ] }),
+        &stored,
+        None,
+    );
+    assert_eq!(lines[0][2].0, "H:A", "child header fn still applies");
+    let text = lines_text(&lines);
+    assert!(
+        lines.iter().any(|l| l
+            .iter()
+            .any(|(_, s)| *s == SpanStyle::Named("tool_error".into()))),
+        "[ERROR] section maps to error status: {lines:?}"
+    );
+    assert!(text.contains("line one"), "body from section: {text}");
+    assert!(text.contains(BOOM_ERR), "error body: {text}");
+    assert!(
+        !text.contains(ERROR_PREFIX),
+        "llm error prefix must not render: {text}"
+    );
+    assert!(
+        !text.contains("successfully"),
+        "summary line must not render: {text}"
+    );
+}
+
+/// A body line that looks like the next section header, but is not
+/// preceded by the blank line `render_llm` always emits, must stay body
+/// text instead of splitting the section early.
+#[test]
+fn restore_without_state_keeps_header_lookalike_in_body() {
+    let (_reg, host) = load_batch_host();
+    let stored = format!(
+        "{}{}{}",
+        section("ok", "body line\n## hdrtool\nbody tail"),
+        section("hdrtool", "real body"),
+        summary_all_ok(2)
+    );
+    let lines = restore_snapshot_lines(
+        &host,
+        json!({ "tool_calls": [
+            { "tool": "ok", "parameters": {} },
+            { "tool": "hdrtool", "parameters": { "x": "A" } },
+        ] }),
         &stored,
         None,
     );
     let text = lines_text(&lines);
+    assert!(text.contains("## hdrtool"), "lookalike stays body: {text}");
+    assert!(text.contains("body tail"), "section 1 intact: {text}");
+    assert!(text.contains("real body"), "section 2 body: {text}");
+    assert!(
+        !text.contains("successfully"),
+        "parsed path, not legacy fallback: {text}"
+    );
+}
+
+/// Unparseable output: raw text as one plain body.
+#[test]
+fn restore_without_state_falls_back_to_raw_output() {
+    let (_reg, host) = load_batch_host();
+    let lines = restore_snapshot_lines(
+        &host,
+        json!({ "tool_calls": [{ "tool": "ok", "parameters": { "tag": "a" } }] }),
+        "not the section format",
+        None,
+    );
+    let text = lines_text(&lines);
     assert!(text.contains("ok> "), "header from input: {text}");
-    assert!(text.contains("ok:a"), "raw output body: {text}");
+    assert!(text.contains("not the section format"), "raw body: {text}");
 }
 
 /// A replayed click row must reach exactly the child it lands on and run
@@ -569,10 +618,8 @@ fn replayed_click_expands_only_the_clicked_child() {
         { "tool": "viewer", "status": "success", "output": "b1\nb2\nb3\nb4\nb5" },
     ] });
 
-    // Buf rows are 1-based (row 0 is the header), so a click on snapshot
-    // line `i` replays as row `i + 1`. Find child2's truncation notice in
-    // the collapsed render instead of hardcoding a row, so layout-only
-    // changes (separator padding, header lines) cannot break click routing.
+    // Rows are 1-based (row 0 = header), so snapshot line i = row i+1.
+    // Find child2's notice dynamically so layout changes can't break this.
     let collapsed = restore_snapshot_lines(&host, input.clone(), "irrelevant", Some(state.clone()));
     let notice_row = 1 + collapsed
         .iter()
@@ -609,7 +656,10 @@ fn replayed_click_expands_only_the_clicked_child() {
 
 /// Regression: an edit child's body must show the code change (old lines
 /// in `diff_old`, new lines in `diff_new`), not the llm summary. Runs the
-/// real edit and batch plugins.
+/// real edit and batch plugins. The extensionless path outside any real
+/// filesystem pins the plain diff render: no async highlight rewrite (which
+/// replaces these spans; covered at text level in real_plugins_restore.rs)
+/// and no line numbers read back from disk.
 #[test]
 fn edit_child_body_renders_diff_not_summary() {
     let reg = Arc::new(ToolRegistry::new());
@@ -617,22 +667,154 @@ fn edit_child_body_renders_diff_not_summary() {
     let lines = restore_snapshot_lines(
         &host,
         json!({ "tool_calls": [{ "tool": "edit", "parameters": {
-            "path": "/tmp/f.rs",
+            "path": "/nonexistent/f",
             "old_string": "let a = 1;",
             "new_string": "let a = 2;",
         } }] }),
         "irrelevant",
         Some(json!({ "children": [
-            { "tool": "edit", "status": "success", "output": "edited /tmp/f.rs" }
+            { "tool": "edit", "status": "success", "output": "edited /nonexistent/f" }
         ] })),
     );
     let spans: Vec<(String, SpanStyle)> = lines.into_iter().flatten().collect();
-    let old_span = ("let a = 1;".to_owned(), SpanStyle::Named("diff_old".into()));
-    let new_span = ("let a = 2;".to_owned(), SpanStyle::Named("diff_new".into()));
+    let old_span = (
+        "- let a = 1;".to_owned(),
+        SpanStyle::Named("diff_old".into()),
+    );
+    let new_span = (
+        "+ let a = 2;".to_owned(),
+        SpanStyle::Named("diff_new".into()),
+    );
     assert!(spans.contains(&old_span), "old line in diff_old: {spans:?}");
     assert!(spans.contains(&new_span), "new line in diff_new: {spans:?}");
     assert!(
-        !spans.iter().any(|(t, _)| t.contains("edited /tmp/f.rs")),
+        !spans
+            .iter()
+            .any(|(t, _)| t.contains("edited /nonexistent/f")),
         "summary must not be the body: {spans:?}"
     );
+}
+
+// --- Live execution snapshots (real dispatch, no call_tool stub) ---
+
+/// Regression: child restores used to snapshot the first-created buf
+/// instead of the batch root buf, letting a tiny header overwrite the
+/// full batch render.
+#[test]
+fn async_highlight_tasks_never_shrink_and_reach_final_snapshot() {
+    let snapshots = run_live_batch(HL_CHILD_SRC, "hl");
+    let header_counts: Vec<usize> = snapshots
+        .iter()
+        .map(|s| s.text().matches("hl> ").count())
+        .collect();
+    assert!(
+        header_counts.windows(2).all(|w| w[0] <= w[1]),
+        "a later snapshot must never lose children: {header_counts:?}"
+    );
+    assert_eq!(
+        header_counts.last(),
+        Some(&2),
+        "final snapshot must carry all children"
+    );
+    let last = snapshots.last().expect("at least one batch snapshot");
+    let has_inline = last
+        .lines
+        .iter()
+        .flat_map(|l| &l.spans)
+        .any(|s| matches!(s.style, SpanStyle::Inline(_)));
+    assert!(
+        has_inline,
+        "final snapshot must contain highlighted spans, got:\n{}",
+        last.text()
+    );
+}
+
+/// Restores that await async APIs (like bash highlighting its header)
+/// must not throw out of the `get_tool` wrapper.
+#[test]
+fn child_restore_awaiting_async_api_keeps_its_body() {
+    let snapshots = run_live_batch(SYNC_HL_CHILD_SRC, "cmd");
+    let last = snapshots.last().expect("at least one batch snapshot");
+    let text = last.text();
+    assert!(
+        text.contains("echo header-marker"),
+        "child restore header must survive, got:\n{text}"
+    );
+}
+
+const BATCH_ID: &str = "batch_id";
+
+const HL_CHILD_SRC: &str = r#"
+local ToolView = require("maki.tool_view")
+maki.api.register_tool({
+  name = "hl",
+  description = "styled header + async-highlight restore",
+  schema = { type = "object", properties = {} },
+  audiences = { "main" },
+  header = function(input)
+    local b = maki.ui.buf()
+    b:set_lines({ { { "hl-header", "tool" } } })
+    return b
+  end,
+  restore = function(input, output, is_error, rctx)
+    local buf = maki.ui.buf()
+    local view = ToolView.new(buf, { max_lines = 10, keep = "head" })
+    view:set_highlight(output, "lua")
+    view:finish()
+    return buf
+  end,
+  handler = function() return "local x = 1" end,
+})
+"#;
+
+const SYNC_HL_CHILD_SRC: &str = r#"
+local ToolView = require("maki.tool_view")
+maki.api.register_tool({
+  name = "cmd",
+  description = "restore awaits maki.ui.highlight inline",
+  schema = { type = "object", properties = {} },
+  audiences = { "main" },
+  restore = function(input, output, is_error, rctx)
+    local buf = maki.ui.buf()
+    local view = ToolView.new(buf, { max_lines = 10, keep = "tail" })
+    local header = maki.ui.highlight("echo header-marker", "bash") or { { { "echo header-marker" } } }
+    view:set_header(header)
+    view:append(output)
+    view:finish()
+    return buf
+  end,
+  handler = function() return "cmd-output" end,
+})
+"#;
+
+fn run_live_batch(child_src: &str, tool: &str) -> Vec<BufferSnapshot> {
+    let reg = Arc::new(ToolRegistry::new());
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source("live_batch", &format!("{child_src}\n{BATCH_PLUGIN_SRC}"))
+        .unwrap();
+
+    let (tx, rx) = flume::unbounded();
+    let event_tx = EventSender::new(tx, 0);
+    let mut ctx = stub_ctx_with(&AgentMode::Build, Some(&event_tx), Some(BATCH_ID));
+    ctx.registry = Arc::clone(&reg);
+
+    let input = json!({ "tool_calls": [
+        { "tool": tool, "parameters": {} },
+        { "tool": tool, "parameters": {} },
+    ]});
+    let entry = reg.get(BATCH_TOOL).unwrap();
+    let inv = entry.tool.parse(&input).unwrap();
+    let done = smol::block_on(async { inv.execute(&ctx).await });
+    assert!(done.output.is_ok(), "batch failed: {:?}", done.output);
+
+    host.load_source("barrier", "").unwrap();
+
+    let mut snapshots = Vec::new();
+    for env in rx.drain() {
+        if let AgentEvent::ToolSnapshot { id, snapshot, .. } = env.event {
+            assert_eq!(id, BATCH_ID);
+            snapshots.push(snapshot);
+        }
+    }
+    snapshots
 }

--- a/maki-lua/tests/real_plugins_restore.rs
+++ b/maki-lua/tests/real_plugins_restore.rs
@@ -1,0 +1,247 @@
+//! Exercises real plugins (bash, grep, batch) through `request_restore`.
+//! A broken restore silently falls back to raw LLM output, so we assert
+//! things only the real views produce (gutters, command headers, truncation).
+
+use std::sync::Arc;
+
+use maki_agent::AgentEvent;
+use maki_agent::tools::ToolRegistry;
+use maki_config::ToolOutputLines;
+use maki_lua::PluginHost;
+use serde_json::{Value, json};
+
+const BASH_SRC: &str = include_str!("../../plugins/bash/init.lua");
+const GREP_SRC: &str = include_str!("../../plugins/grep/init.lua");
+const BATCH_SRC: &str = include_str!("../../plugins/batch/init.lua");
+
+/// Only the real ToolView emits this when collapsed.
+const EXPAND_HINT: &str = "click to expand";
+/// Fixed cap so truncation tests don't depend on the product default.
+const VIEW_CAP: usize = 3;
+
+const GREP_OUT: &str =
+    "src/a.rs:\n  1: fn main() {}\n  2: fn helper() {}\n\nsrc/b.rs:\n  10: fn other() {}";
+
+const BATCH_INPUT_GREP_BASH: &str = r#"{ "tool_calls": [
+    { "tool": "grep", "parameters": { "pattern": "fn" } },
+    { "tool": "bash", "parameters": { "command": "echo hello-from-bash" } }
+]}"#;
+
+fn load_host() -> PluginHost {
+    let reg = Arc::new(ToolRegistry::new());
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source("bash", BASH_SRC).unwrap();
+    host.load_source("grep", GREP_SRC).unwrap();
+    host.load_source("batch", BATCH_SRC).unwrap();
+    host
+}
+
+fn batch_state() -> Value {
+    json!({ "children": [
+        { "tool": "grep", "status": "success", "output": GREP_OUT },
+        { "tool": "bash", "status": "success", "output": "hello-from-bash" },
+    ]})
+}
+
+struct Restored {
+    body: String,
+    header: String,
+}
+
+fn restore(
+    host: &PluginHost,
+    tool: &str,
+    input: Value,
+    output: &str,
+    state: Option<Value>,
+    clicks: Vec<usize>,
+) -> Restored {
+    let handle = host.event_handle().unwrap();
+    let (tx, rx) = flume::unbounded();
+    handle.request_restore(
+        maki_lua::RestoreItem {
+            tool: Arc::from(tool),
+            tool_use_id: "restore_id".to_owned(),
+            output: output.to_owned(),
+            input,
+            is_error: false,
+            tool_output_lines: ToolOutputLines {
+                other: VIEW_CAP,
+                ..ToolOutputLines::DEFAULT
+            },
+            theme_gen: None,
+            clicks,
+            state,
+        },
+        maki_agent::EventSender::new(tx, 0),
+    );
+    // Drains the async gate so highlight tasks finish before we inspect.
+    host.load_source("barrier", "").unwrap();
+    let mut out = Restored {
+        body: String::new(),
+        header: String::new(),
+    };
+    for env in rx.drain() {
+        match env.event {
+            AgentEvent::ToolSnapshot { snapshot, .. } => out.body = snapshot.text(),
+            AgentEvent::ToolHeaderSnapshot { snapshot, .. } => out.header = snapshot.text(),
+            _ => {}
+        }
+    }
+    out
+}
+
+#[test]
+fn bash_restore_renders_real_view() {
+    let host = load_host();
+    let r = restore(
+        &host,
+        "bash",
+        json!({ "command": "echo hi", "description": "print hi" }),
+        "hi",
+        None,
+        Vec::new(),
+    );
+    assert!(
+        r.body.contains("echo hi"),
+        "real view renders the command header; the fallback body is raw output only: {}",
+        r.body
+    );
+    assert!(r.header.contains("print hi"), "header: {}", r.header);
+}
+
+/// Phase 1: children render through their own real views (grep gutter,
+/// bash command header), not the raw-llm fallback. Phase 2: a replayed
+/// click inside grep's range reaches its real toggle and expands only it.
+#[test]
+fn batch_restore_renders_real_children_and_click_expands_grep() {
+    let host = load_host();
+    let input: Value = serde_json::from_str(BATCH_INPUT_GREP_BASH).unwrap();
+    let collapsed = restore(
+        &host,
+        "batch",
+        input.clone(),
+        "whatever",
+        Some(batch_state()),
+        Vec::new(),
+    );
+    let text = &collapsed.body;
+    assert!(text.contains("grep> "), "grep child header: {text}");
+    assert!(text.contains("bash> "), "bash child header: {text}");
+    // grep's real view reformats `nr:` into gutter lines.
+    assert!(text.contains(" 1 fn main() {}"), "grep gutter: {text}");
+    assert!(
+        !text.contains("1: fn main"),
+        "raw llm text means the child restore degraded to fallback: {text}"
+    );
+    assert!(
+        text.contains(EXPAND_HINT),
+        "grep view collapsed past its cap: {text}"
+    );
+    assert!(
+        text.contains("echo hello-from-bash"),
+        "bash child rendered its real view (command header): {text}"
+    );
+    assert!(
+        text.lines().any(|l| l.trim() == "hello-from-bash"),
+        "bash output line: {text}"
+    );
+
+    // Rows are 1-based (row 0 = header), so snapshot line i = row i+1.
+    let notice_row = 1 + collapsed
+        .body
+        .lines()
+        .position(|l| l.contains(EXPAND_HINT))
+        .expect("grep truncation notice in collapsed render");
+    let clicked = restore(
+        &host,
+        "batch",
+        input,
+        "whatever",
+        Some(batch_state()),
+        vec![notice_row],
+    );
+    let text = &clicked.body;
+    assert!(
+        text.contains("10 fn other() {}"),
+        "expanded grep tail visible: {text}"
+    );
+    assert!(
+        !text.contains(EXPAND_HINT),
+        "grep no longer collapsed: {text}"
+    );
+    assert!(
+        text.contains("hello-from-bash"),
+        "bash child untouched: {text}"
+    );
+}
+
+/// Header fn that yields (e.g. highlight) must work, not fall back.
+#[test]
+fn restore_header_fn_may_await_async_apis() {
+    let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+    host.load_source(
+        "hdr",
+        r#"maki.api.register_tool({
+            name = "hdr_await",
+            description = "t",
+            schema = { type = "object", properties = {} },
+            handler = function() return "ok" end,
+            header = function(input)
+                local hl = maki.ui.highlight("echo marker", "bash") or { { { "echo marker" } } }
+                local buf = maki.ui.buf()
+                buf:set_lines(hl)
+                return buf
+            end,
+            restore = function(input, output)
+                local buf = maki.ui.buf()
+                buf:line("body")
+                return buf
+            end,
+        })"#,
+    )
+    .unwrap();
+    let r = restore(&host, "hdr_await", json!({}), "ok", None, Vec::new());
+    assert_eq!(r.body.trim(), "body");
+    assert!(
+        r.header.contains("echo marker"),
+        "awaiting header fn must survive: {}",
+        r.header
+    );
+}
+
+/// Standalone edit diffs never truncate (Rust hardcodes it), so batch
+/// children must match: whole diff, `-` lines numbered by finding the new
+/// text in the edited file, `+` lines with a blank gutter.
+#[test]
+fn multiedit_batch_child_shows_full_numbered_diff() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("f.rs");
+    std::fs::write(&path, "top\nzzz\nn1\nn2\nn3\nn4\nn5\nbottom\n").unwrap();
+
+    let host = PluginHost::with_all_builtins(Arc::new(ToolRegistry::new())).unwrap();
+    let input = json!({ "tool_calls": [{ "tool": "multiedit", "parameters": {
+        "path": path.to_str().unwrap(),
+        "edits": [{ "old_string": "old1\nold2\nold3\nold4\nold5", "new_string": "n1\nn2\nn3\nn4\nn5" }],
+    }}]});
+    let state = json!({ "children": [
+        { "tool": "multiedit", "status": "success", "output": "applied 1 edit" },
+    ]});
+    let r = restore(&host, "batch", input, "whatever", Some(state), Vec::new());
+
+    let text = &r.body;
+    // keep = "head" truncation would cut the tail, so the last added line
+    // present plus no collapse notice proves the 10-line diff is whole.
+    assert!(
+        text.contains("+ n5") && !text.contains(EXPAND_HINT),
+        "edit diffs must never truncate: {text}"
+    );
+    assert!(
+        text.contains("3 - old1") && text.contains("7 - old5"),
+        "removed lines numbered from the new text's file position: {text}"
+    );
+    assert!(
+        !text.contains("3 + n1"),
+        "added lines get a blank gutter: {text}"
+    );
+}

--- a/maki-ui/src/highlight.rs
+++ b/maki-ui/src/highlight.rs
@@ -18,6 +18,18 @@ pub(crate) fn is_ready() -> bool {
 pub(crate) fn refresh_syntax_theme() {
     let theme = theme::current();
     maki_highlight::set_theme(theme.syntax.clone());
+    maki_highlight::set_ui_colors(
+        [
+            ("diff_old", theme.diff_old.bg),
+            ("diff_new", theme.diff_new.bg),
+        ]
+        .into_iter()
+        .filter_map(|(name, color)| match color {
+            Some(Color::Rgb(r, g, b)) => Some((name.to_owned(), (r, g, b))),
+            _ => None,
+        })
+        .collect(),
+    );
 }
 
 pub fn highlight_line(hl: &mut maki_highlight::Highlighter, text: &str) -> Vec<Span<'static>> {

--- a/plugins/batch/init.lua
+++ b/plugins/batch/init.lua
@@ -23,8 +23,18 @@ local NESTED_ERROR = "cannot nest batch inside batch"
 local CANCELLED_ERROR = "cancelled"
 local DISCARDED_ERROR = string.format("maximum of %d tools per batch", MAX_BATCH_SIZE)
 local SECTION_FMT = "## %s\n"
+local SECTION_PAT = "^## (.+)$"
+
+-- Anchored pattern matching exactly what a `%d`-only format produces, so
+-- the no-state parser can never drift from the render formats below.
+local function fmt_to_pat(fmt)
+  local pat = fmt:gsub("%%d", "\1"):gsub("[%^%$%(%)%.%[%]%*%+%-%?%%]", "%%%0"):gsub("\1", "%%d+")
+  return "^" .. pat .. "$"
+end
+
 local SUMMARY_MIXED_FMT = "Executed %d/%d successfully. %d failed."
 local SUMMARY_ALL_OK_FMT = "All %d tools executed successfully."
+local SUMMARY_PATS = { fmt_to_pat(SUMMARY_ALL_OK_FMT), fmt_to_pat(SUMMARY_MIXED_FMT) }
 local RESETTLE_FMT = "batch: child %s settled twice (%s -> %s)"
 
 local STATUS = { PENDING = "pending", RUNNING = "running", SUCCESS = "success", ERROR = "error" }
@@ -246,6 +256,55 @@ local function to_state(children)
   return { children = out }
 end
 
+-- Try to recover per-child results from `## tool` sections in the LLM
+-- output. Returns nil when the format doesn't match.
+local function children_from_llm(children, output)
+  if #children == 0 then
+    return nil
+  end
+  local sections = {}
+  local body, prev
+  for line in (output .. "\n"):gmatch("([^\n]*)\n") do
+    local tool = line:match(SECTION_PAT)
+    local nxt = children[#sections + 1]
+    -- render_llm puts a blank line before every header except the first;
+    -- demand the same, so a body line that merely looks like the next
+    -- header stays body text.
+    if tool and nxt and tool == nxt.tool and (prev == nil or prev == "") then
+      body = {}
+      sections[#sections + 1] = body
+    elseif body then
+      body[#body + 1] = line
+    else
+      return nil
+    end
+    prev = line
+  end
+  if #sections ~= #children then
+    return nil
+  end
+  local last = sections[#sections]
+  for _, pat in ipairs(SUMMARY_PATS) do
+    if last[#last] and last[#last]:match(pat) then
+      last[#last] = nil
+      break
+    end
+  end
+  local out = {}
+  for i, lines in ipairs(sections) do
+    while #lines > 0 and lines[#lines] == "" do
+      lines[#lines] = nil
+    end
+    local text = table.concat(lines, "\n")
+    local failed = text:sub(1, #ERROR_PREFIX) == ERROR_PREFIX
+    out[i] = {
+      status = failed and STATUS.ERROR or STATUS.SUCCESS,
+      output = failed and text:sub(#ERROR_PREFIX + 1) or text,
+    }
+  end
+  return out
+end
+
 --- Batch view-model ---------------------------------------------------------
 
 local Batch = {}
@@ -389,9 +448,7 @@ local function handler(input, ctx)
   }
 end
 
--- Old or foreign session with no structured state: headers are still a
--- pure function of the input, and the stored llm output becomes one
--- plain collapsible body.
+-- Last resort: no state, output isn't section-formatted.
 local function legacy_restore(children, output, tol)
   local buf = maki.ui.buf()
   local view = ToolView.new(buf, { max_lines = tol.other, keep = "head" })
@@ -416,11 +473,11 @@ local function restore(input, output, _is_error, rctx)
   end
 
   local st = rctx:state()
-  if st and type(st.children) == "table" and #st.children == #children then
-    -- Rehydrate before a Batch owns the children, and do not trust
-    -- storage: anything non-terminal there (corrupt or foreign) becomes
-    -- an error. Batch.new attaches the terminal bodies itself.
-    for i, sc in ipairs(st.children) do
+  local kids = st and type(st.children) == "table" and #st.children == #children and st.children
+    or children_from_llm(children, output)
+  if kids then
+    -- Non-terminal statuses are treated as errors (corrupt data).
+    for i, sc in ipairs(kids) do
       local c = children[i]
       c.status = TERMINAL[sc.status] and sc.status or STATUS.ERROR
       c.output, c.annotation = sc.output, sc.annotation

--- a/plugins/edit/init.lua
+++ b/plugins/edit/init.lua
@@ -4,6 +4,7 @@ local fuzzy_replace = require("maki.fuzzy_replace")
 local replace_lines = require("edit_helpers").replace_lines
 
 local SNIPPET_MAX_CHARS = 32
+local FALLBACK_VIEW_LINES = 10
 
 local EDIT_LINES_DESCRIPTION =
   [[Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new_string`. Use empty `new_string` to delete a range. Do not use with the batch tool.]]
@@ -53,27 +54,133 @@ local function edit_view_opts(ctx)
   return { max_lines = (tol and tol.write) or FALLBACK_VIEW_LINES, keep = "head" }
 end
 
--- Old lines red, new lines green, one block per edit. Rebuilt purely from
--- the input, so a batch child can render the change without the file
--- snapshots (those live in ToolOutput::Diff, which Rust renders standalone).
-local function diff_view(blocks, ctx)
+-- Line number of `needle` in `content` (plain find, first match).
+local function line_of(content, needle)
+  local pos = content:find(needle, 1, true)
+  if not pos then
+    return nil
+  end
+  local _, newlines = content:sub(1, pos - 1):gsub("\n", "")
+  return newlines + 1
+end
+
+-- The edit already happened, so each block's `new` text sits in the file
+-- right now: read it once and recover real line numbers. Best effort,
+-- blocks stay unnumbered when the text moved or the file is gone.
+local function resolve_block_nrs(blocks, path)
+  if not path then
+    return
+  end
+  local content
+  for _, b in ipairs(blocks) do
+    if not b.nr and (b.new or "") ~= "" then
+      content = content or maki.fs.read(maki.fs.abspath(path))
+      if not content then
+        return
+      end
+      b.nr = line_of(content, b.new)
+    end
+  end
+end
+
+local function gutter_width(blocks)
+  local max_nr = 0
+  for _, b in ipairs(blocks) do
+    if b.nr then
+      local n = #split_lines(b.old or "")
+      if n == 0 then
+        n = #split_lines(b.new or "")
+      end
+      max_nr = math.max(max_nr, b.nr + n - 1)
+    end
+  end
+  return max_nr > 0 and #tostring(max_nr) or 0
+end
+
+-- The one gutter builder both render passes share: the plain render and
+-- the async highlight rewrite must produce byte-identical gutters or the
+-- columns shift when highlights land.
+local function nr_span(fmt, start_nr, i)
+  return { string.format(fmt, start_nr and (start_nr + i - 1) or ""), "line_nr" }
+end
+
+local function append_diff_lines(view, text, style, prefix, nr_fmt, start_nr, jobs)
+  local lines = split_lines(text or "")
+  if #lines == 0 then
+    return
+  end
+  jobs[#jobs + 1] = {
+    first = #view.all_lines + 1,
+    text = table.concat(lines, "\n"),
+    style = style,
+    prefix = prefix,
+    start_nr = start_nr,
+  }
+  for i, line in ipairs(lines) do
+    local spans = {}
+    if nr_fmt then
+      spans[#spans + 1] = nr_span(nr_fmt, start_nr, i)
+    end
+    spans[#spans + 1] = { prefix .. line, style }
+    view:append(spans)
+  end
+end
+
+-- Re-renders the block's lines with syntax colors on the diff backgrounds,
+-- keeping the gutter and prefix the plain render put there.
+local function apply_highlights(view, fmt, jobs, ext)
+  maki.async.run(function()
+    for _, job in ipairs(jobs) do
+      local bg = maki.ui.theme_color(job.style)
+      local highlighted = bg and maki.ui.highlight(job.text, ext)
+      for i, hl_line in ipairs(highlighted or {}) do
+        local idx = job.first + i - 1
+        if not view.all_lines[idx] then
+          break
+        end
+        local spans = {}
+        if fmt then
+          spans[#spans + 1] = nr_span(fmt, job.start_nr, i)
+        end
+        spans[#spans + 1] = { job.prefix, { bg = bg } }
+        for _, seg in ipairs(hl_line) do
+          local s = type(seg[2]) == "table" and seg[2] or {}
+          s.bg = bg
+          spans[#spans + 1] = { seg[1], s }
+        end
+        view:update_line(idx, spans)
+      end
+    end
+    view:flush()
+  end)
+end
+
+-- Mirrors the standalone Rust diff render (code_view.rs): numbered gutter
+-- on removed lines, blank gutter + `+` on added lines, and no truncation
+-- ever, a diff is exactly the change and hiding part of it lies.
+local function diff_view(blocks, path)
   local buf = maki.ui.buf()
-  local view = ToolView.new(buf, edit_view_opts(ctx))
+  local view = ToolView.new(buf, { max_lines = math.huge, keep = "head" })
+  resolve_block_nrs(blocks, path)
+  local w = gutter_width(blocks)
+  local fmt = w > 0 and ("%" .. w .. "s ") or nil
+  local jobs = {}
+  local function append(text, style, prefix, start_nr)
+    append_diff_lines(view, text, style, prefix, fmt, start_nr, jobs)
+  end
   for i, block in ipairs(blocks) do
     if i > 1 then
       view:append({})
     end
-    for _, line in ipairs(split_lines(block.old or "")) do
-      view:append({ { line, "diff_old" } })
-    end
-    for _, line in ipairs(split_lines(block.new or "")) do
-      view:append({ { line, "diff_new" } })
-    end
+    local has_old = (block.old or "") ~= ""
+    append(block.old, "diff_old", "- ", block.nr)
+    append(block.new, "diff_new", "+ ", not has_old and block.nr or nil)
   end
   view:finish()
-  buf:on("click", function()
-    view:toggle()
-  end)
+  local ext = (path or ""):match("%.([^%.]+)$")
+  if #jobs > 0 and ext then
+    apply_highlights(view, fmt, jobs, ext)
+  end
   return buf
 end
 
@@ -82,7 +189,7 @@ local function diff_restore(blocks_from)
     if is_error then
       return ToolView.restore(output, edit_view_opts(ctx))
     end
-    return diff_view(blocks_from(input), ctx)
+    return diff_view(blocks_from(input), input.path)
   end
 end
 
@@ -302,7 +409,7 @@ maki.api.register_tool({
 
   header = edit_header,
   restore = diff_restore(function(input)
-    return { { new = input.new_string } }
+    return { { new = input.new_string, nr = input.start } }
   end),
 
   handler = function(input, ctx)
@@ -351,7 +458,7 @@ maki.api.register_tool({
 
   header = edit_header,
   restore = diff_restore(function(input)
-    return { { new = input.new_string } }
+    return { { new = input.new_string, nr = input.line } }
   end),
 
   handler = function(input, ctx)

--- a/plugins/lib/maki/tool_view.lua
+++ b/plugins/lib/maki/tool_view.lua
@@ -162,7 +162,9 @@ function ToolView:flush()
     end
 
     for i = 0, self.ring_count - 1 do
-      local idx = ((self.ring_start - 1 + i) % self.max) + 1
+      -- Modulo only after the ring wrapped: `x % math.huge` is NaN in Luau,
+      -- and uncapped views (max_lines = math.huge) never wrap.
+      local idx = self.ring_start == 1 and (i + 1) or (((self.ring_start - 1 + i) % self.max) + 1)
       lines[#lines + 1] = self.ring[idx]
     end
 


### PR DESCRIPTION
Batch tools collapsed to a single header line after completion. `maki.async.run` tasks (child highlight jobs) inherited the batch `tool_use_id` but captured `bufs.live_buf()`, which is the *first* buf created in the task. In a batch that first buf is a child header, not the batch body. On completion each async task emitted that one-line header as the batch `ToolSnapshot`, overwriting the full render. `PendingAsyncTask` now carries the owner `TaskHandle` and resolves `resolve_root_buf` at completion time, so the real body (set by `ctx:live_buf` or the reply) is always used.

Batch restore sometimes showed raw `## tool` llm sections instead of per-child renders. This happened when structured `state` was missing (older sessions, non-serializable state). Added `children_from_llm` in the batch plugin that parses the pinned section format back into per-child status and output, so each child still renders through its own tool view with proper indicators.