### PR TITLE
fix(mcp): silently refresh OAuth token on 401

### DIFF
--- a/maki-agent/src/mcp/http.rs
+++ b/maki-agent/src/mcp/http.rs
@@ -7,14 +7,17 @@ use std::time::{Duration, Instant};
 use async_lock::Mutex;
 use isahc::HttpClient;
 use isahc::config::{Configurable, RedirectPolicy};
-use isahc::http::header::{ACCEPT, CONTENT_TYPE};
+use isahc::http::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use isahc::http::{Method, Request, StatusCode, header::HeaderMap};
+use maki_storage::StateDir;
+use maki_storage::auth::load_mcp_auth;
 use serde_json::Value;
 
 use super::error::McpError;
+use super::oauth;
 use super::protocol::{JsonRpcNotification, JsonRpcRequest, JsonRpcResponse};
 use super::transport::{BoxFuture, McpTransport};
-use tracing::info;
+use tracing::{info, warn};
 
 pub(super) const MAX_REDIRECTS: u32 = 10;
 const SESSION_HEADER: &str = "mcp-session-id";
@@ -27,6 +30,8 @@ pub struct HttpTransport {
     url: String,
     client: HttpClient,
     headers: HashMap<String, String>,
+    auth: Mutex<Option<String>>,
+    storage: Option<StateDir>,
     session_id: Mutex<Option<String>>,
     next_id: AtomicU64,
 }
@@ -37,6 +42,7 @@ impl HttpTransport {
         url: &str,
         headers: &HashMap<String, String>,
         timeout: Duration,
+        storage: Option<StateDir>,
     ) -> Result<Self, McpError> {
         let client = HttpClient::builder()
             .redirect_policy(RedirectPolicy::Limit(MAX_REDIRECTS))
@@ -47,11 +53,24 @@ impl HttpTransport {
                 reason: e.to_string(),
             })?;
 
+        let mut headers = headers.clone();
+        let auth = headers
+            .keys()
+            .find(|k| k.eq_ignore_ascii_case(AUTHORIZATION.as_str()))
+            .cloned()
+            .and_then(|k| headers.remove(&k))
+            .or_else(|| {
+                let tokens = load_mcp_auth(storage.as_ref()?, name, url)?.tokens?;
+                Some(format!("Bearer {}", tokens.access))
+            });
+
         Ok(Self {
             name: Arc::from(name),
             url: url.to_string(),
             client,
-            headers: headers.clone(),
+            headers,
+            auth: Mutex::new(auth),
+            storage,
             session_id: Mutex::new(None),
             next_id: AtomicU64::new(1),
         })
@@ -65,6 +84,7 @@ impl HttpTransport {
         &self,
         body: Vec<u8>,
         session_id: Option<&str>,
+        auth: Option<&str>,
     ) -> Result<Request<Vec<u8>>, McpError> {
         let mut builder = Request::builder()
             .method(Method::POST)
@@ -74,6 +94,10 @@ impl HttpTransport {
 
         if let Some(sid) = session_id {
             builder = builder.header(SESSION_HEADER, sid);
+        }
+
+        if let Some(auth) = auth {
+            builder = builder.header(AUTHORIZATION, auth);
         }
 
         for (k, v) in &self.headers {
@@ -153,6 +177,36 @@ impl HttpTransport {
             *self.session_id.lock().await = Some(sid_str.to_string());
         }
     }
+
+    /// Single-flight token refresh after a 401. Holds the `auth` lock across the
+    /// refresh so concurrent callers park instead of racing the (rotating)
+    /// refresh token. If the stored value no longer matches the one the failed
+    /// request used, another caller already refreshed: reuse it.
+    async fn refreshed_auth(&self, used: Option<&str>) -> Option<String> {
+        let storage = self.storage.as_ref()?;
+        let mut guard = self.auth.lock().await;
+
+        if guard.as_deref() != used {
+            return guard.clone();
+        }
+
+        match oauth::silent_refresh(storage, &self.name, &self.url).await {
+            Ok(Some(data)) => {
+                let header = format!("Bearer {}", data.tokens?.access);
+                *guard = Some(header.clone());
+
+                info!(server = %self.name, "MCP OAuth token refreshed after 401");
+
+                Some(header)
+            }
+            Ok(None) => None,
+            Err(e) => {
+                warn!(server = %self.name, error = %e, "MCP OAuth token refresh failed");
+
+                None
+            }
+        }
+    }
 }
 
 impl McpTransport for HttpTransport {
@@ -165,44 +219,66 @@ impl McpTransport for HttpTransport {
             let start = Instant::now();
             let id = self.next_id.fetch_add(1, Ordering::Relaxed);
             let req = JsonRpcRequest::new(id, method, params);
-            let body = serde_json::to_vec(&req).map_err(|e| McpError::InvalidResponse {
-                server: self.server(),
-                reason: e.to_string(),
-            })?;
-
-            let session_id = self.session_id.lock().await;
-            let http_req = self.build_request(body, session_id.as_deref())?;
-            drop(session_id);
-
-            let (status, headers, body_str) = self.send_http(http_req).await?;
-
-            if !status.is_success() {
-                let reason = if status == StatusCode::UNAUTHORIZED {
-                    headers
-                        .get("www-authenticate")
-                        .and_then(|v| v.to_str().ok())
-                        .unwrap_or(&body_str)
-                        .to_string()
-                } else {
-                    body_str
-                };
-                return Err(McpError::HttpError {
+            let encode = || {
+                serde_json::to_vec(&req).map_err(|e| McpError::InvalidResponse {
                     server: self.server(),
-                    status: status.as_u16(),
-                    reason,
-                });
+                    reason: e.to_string(),
+                })
+            };
+
+            let mut auth = self.auth.lock().await.clone();
+            let mut refreshed = false;
+
+            loop {
+                let session_id = self.session_id.lock().await.clone();
+
+                let http_req =
+                    self.build_request(encode()?, session_id.as_deref(), auth.as_deref())?;
+
+                let (status, headers, body_str) = self.send_http(http_req).await?;
+
+                if status == StatusCode::UNAUTHORIZED
+                    && !refreshed
+                    && let Some(new_auth) = self.refreshed_auth(auth.as_deref()).await
+                {
+                    auth = Some(new_auth);
+                    refreshed = true;
+
+                    continue;
+                }
+
+                if !status.is_success() {
+                    let reason = if status == StatusCode::UNAUTHORIZED {
+                        headers
+                            .get("www-authenticate")
+                            .and_then(|v| v.to_str().ok())
+                            .unwrap_or(&body_str)
+                            .to_string()
+                    } else {
+                        body_str
+                    };
+
+                    return Err(McpError::HttpError {
+                        server: self.server(),
+                        status: status.as_u16(),
+                        reason,
+                    });
+                }
+
+                self.capture_session_id(&headers).await;
+
+                let is_sse = headers
+                    .get(CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok())
+                    .is_some_and(|ct| ct.contains(CT_SSE));
+
+                let result =
+                    self.parse_rpc_response(&body_str, if is_sse { CT_SSE } else { CT_JSON });
+
+                info!(server = %self.server(), method, status = %status, refreshed, duration_ms = start.elapsed().as_millis() as u64, "MCP HTTP request");
+
+                return result;
             }
-
-            self.capture_session_id(&headers).await;
-
-            let is_sse = headers
-                .get(CONTENT_TYPE)
-                .and_then(|v| v.to_str().ok())
-                .is_some_and(|ct| ct.contains(CT_SSE));
-
-            let result = self.parse_rpc_response(&body_str, if is_sse { CT_SSE } else { CT_JSON });
-            info!(server = %self.server(), method, status = %status, duration_ms = start.elapsed().as_millis() as u64, "MCP HTTP request");
-            result
         })
     }
 
@@ -218,9 +294,9 @@ impl McpTransport for HttpTransport {
                 reason: e.to_string(),
             })?;
 
-            let session_id = self.session_id.lock().await;
-            let http_req = self.build_request(body, session_id.as_deref())?;
-            drop(session_id);
+            let session_id = self.session_id.lock().await.clone();
+            let auth = self.auth.lock().await.clone();
+            let http_req = self.build_request(body, session_id.as_deref(), auth.as_deref())?;
 
             let (status, _, _) = self.send_http(http_req).await?;
 
@@ -305,18 +381,228 @@ mod tests {
     use serde_json::json;
     use test_case::test_case;
 
-    #[test_case("data: {\"id\":1}\n\n",                                     &[json!({"id":1})]                ; "single_event")]
-    #[test_case("data: {\"id\":1}\n\ndata: {\"id\":2}\n\n",                 &[json!({"id":1}), json!({"id":2})]; "multiple_events")]
-    #[test_case("data: {\"id\":1,\ndata:  \"result\":{}}\n\n",              &[json!({"id":1, "result":{}})]    ; "multiline_data")]
-    #[test_case(": comment\ndata: {\"id\":1}\n\n",                           &[json!({"id":1})]                ; "ignores_comments")]
-    #[test_case("event: message\nid: 42\nretry: 5000\ndata: {\"id\":1}\n\n",&[json!({"id":1})]                ; "ignores_non_data_fields")]
-    #[test_case("",                                                          &[]                               ; "empty_body")]
-    #[test_case("event: ping\n\n",                                           &[]                               ; "no_data_field")]
-    #[test_case("data: not json\n\ndata: {\"id\":1}\n\n",                   &[json!({"id":1})]                ; "malformed_json_skipped")]
-    #[test_case("data: {\"id\":1}",                                          &[json!({"id":1})]                ; "no_trailing_newline")]
-    #[test_case("data:{\"id\":1}\n\n",                                       &[json!({"id":1})]                ; "no_space_after_colon")]
+    use maki_storage::auth::{McpAuthData, OAuthTokens, save_mcp_auth};
+    use std::io::{BufRead, BufReader, Write as IoWrite};
+    use std::net::TcpListener;
+    use std::sync::atomic::AtomicUsize;
+
+    const RPC_OK: &str = r#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#;
+    const OLD_BEARER: &str = "Bearer old-token";
+    const NEW_BEARER: &str = "Bearer new-token";
+
+    struct Req {
+        path: String,
+        auth: Option<String>,
+    }
+
+    fn spawn_server<F>(make_handler: impl FnOnce(String) -> F) -> String
+    where
+        F: Fn(&Req) -> (u16, String) + Send + 'static,
+    {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let handler = make_handler(base.clone());
+
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { break };
+                let mut reader = BufReader::new(stream.try_clone().unwrap());
+                let mut line = String::new();
+
+                if reader.read_line(&mut line).is_err() || line.is_empty() {
+                    continue;
+                }
+
+                let path = line.split_whitespace().nth(1).unwrap_or("/").to_string();
+                let mut auth = None;
+                let mut content_length = 0usize;
+
+                loop {
+                    let mut header = String::new();
+
+                    if reader.read_line(&mut header).is_err() || header.trim().is_empty() {
+                        break;
+                    }
+
+                    let lower = header.to_ascii_lowercase();
+
+                    if let Some(v) = lower.strip_prefix("authorization:") {
+                        let start = header.len() - v.len();
+                        auth = Some(header[start..].trim().to_string());
+                    } else if let Some(v) = lower.strip_prefix("content-length:") {
+                        content_length = v.trim().parse().unwrap_or(0);
+                    }
+                }
+
+                let mut body = vec![0u8; content_length];
+                let _ = std::io::Read::read_exact(&mut reader, &mut body);
+
+                let (status, resp_body) = handler(&Req { path, auth });
+
+                let response = format!(
+                    "HTTP/1.1 {status} X\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{resp_body}",
+                    resp_body.len(),
+                );
+
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+        base
+    }
+
+    fn stored_auth(server_url: &str, access: &str, refresh: &str) -> McpAuthData {
+        McpAuthData {
+            server_url: server_url.to_string(),
+            tokens: Some(OAuthTokens {
+                access: access.to_string(),
+                refresh: refresh.to_string(),
+                expires: 0,
+                account_id: None,
+            }),
+            client_id: "cid".to_string(),
+            client_secret: None,
+            client_secret_expires_at: None,
+            redirect_uri: None,
+        }
+    }
+
+    fn transport_with(
+        url: &str,
+        headers: HashMap<String, String>,
+        storage: Option<StateDir>,
+    ) -> HttpTransport {
+        HttpTransport::new("srv", url, &headers, Duration::from_secs(5), storage).unwrap()
+    }
+
+    fn oauth_routes(base: &str, req: &Req) -> Option<(u16, String)> {
+        if req.path.contains("oauth-protected-resource") {
+            return Some((
+                200,
+                format!(r#"{{"authorization_servers":["{base}"],"resource":"{base}/mcp"}}"#),
+            ));
+        }
+
+        if req.path.contains("oauth-authorization-server")
+            || req.path.contains("openid-configuration")
+        {
+            return Some((
+                200,
+                format!(
+                    r#"{{"authorization_endpoint":"{base}/authorize","token_endpoint":"{base}/token","code_challenge_methods_supported":["S256"]}}"#
+                ),
+            ));
+        }
+
+        if req.path == "/token" {
+            return Some((
+                200,
+                r#"{"access_token":"new-token","expires_in":3600}"#.into(),
+            ));
+        }
+
+        None
+    }
+
+    #[test_case("data: {\"id\":1}\n\n",                                      &[json!({"id":1})]                  ; "single_event")]
+    #[test_case("data: {\"id\":1}\n\ndata: {\"id\":2}\n\n",                  &[json!({"id":1}), json!({"id":2})] ; "multiple_events")]
+    #[test_case("data: {\"id\":1,\ndata:  \"result\":{}}\n\n",               &[json!({"id":1, "result":{}})]     ; "multiline_data")]
+    #[test_case(": comment\ndata: {\"id\":1}\n\n",                           &[json!({"id":1})]                  ; "ignores_comments")]
+    #[test_case("event: message\nid: 42\nretry: 5000\ndata: {\"id\":1}\n\n", &[json!({"id":1})]                  ; "ignores_non_data_fields")]
+    #[test_case("",                                                          &[]                                 ; "empty_body")]
+    #[test_case("event: ping\n\n",                                           &[]                                 ; "no_data_field")]
+    #[test_case("data: not json\n\ndata: {\"id\":1}\n\n",                    &[json!({"id":1})]                  ; "malformed_json_skipped")]
+    #[test_case("data: {\"id\":1}",                                          &[json!({"id":1})]                  ; "no_trailing_newline")]
+    #[test_case("data:{\"id\":1}\n\n",                                       &[json!({"id":1})]                  ; "no_space_after_colon")]
     fn parse_sse(input: &str, expected: &[Value]) {
         let events = parse_sse_events(input);
         assert_eq!(events, expected);
+    }
+
+    #[test]
+    fn refreshes_token_and_retries_on_401() {
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = StateDir::from_path(tmp.path().to_path_buf());
+
+        let base = spawn_server(|base| {
+            move |req: &Req| {
+                if let Some(resp) = oauth_routes(&base, req) {
+                    return resp;
+                }
+                if req.auth.as_deref() == Some(NEW_BEARER) {
+                    (200, RPC_OK.into())
+                } else {
+                    (401, String::new())
+                }
+            }
+        });
+
+        let url = format!("{base}/mcp");
+        save_mcp_auth(&storage, "srv", &stored_auth(&url, "old-token", "r1")).unwrap();
+
+        let transport = transport_with(&url, HashMap::new(), Some(storage.clone()));
+        let result = smol::block_on(transport.send_request("tools/list", None)).unwrap();
+        assert_eq!(result, json!({"ok": true}));
+
+        let saved = load_mcp_auth(&storage, "srv", &url).unwrap();
+        let tokens = saved.tokens.unwrap();
+        assert_eq!(tokens.access, "new-token");
+        assert_eq!(tokens.refresh, "r1");
+    }
+
+    #[test]
+    fn unauthorized_without_storage_fails_without_retry() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_srv = Arc::clone(&hits);
+        let base = spawn_server(move |_| {
+            move |_req: &Req| {
+                hits_srv.fetch_add(1, Ordering::SeqCst);
+                (401, String::new())
+            }
+        });
+
+        let transport = transport_with(&format!("{base}/mcp"), HashMap::new(), None);
+        let err = smol::block_on(transport.send_request("tools/list", None)).unwrap_err();
+        assert!(matches!(err, McpError::HttpError { status: 401, .. }));
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn config_authorization_header_is_sent() {
+        let base = spawn_server(|_| {
+            move |req: &Req| {
+                if req.auth.as_deref() == Some(OLD_BEARER) {
+                    (200, RPC_OK.into())
+                } else {
+                    (401, String::new())
+                }
+            }
+        });
+
+        let headers = HashMap::from([("Authorization".to_string(), OLD_BEARER.to_string())]);
+        let transport = transport_with(&format!("{base}/mcp"), headers, None);
+        let result = smol::block_on(transport.send_request("tools/list", None)).unwrap();
+        assert_eq!(result, json!({"ok": true}));
+    }
+
+    #[test]
+    fn stored_token_injected_at_startup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = StateDir::from_path(tmp.path().to_path_buf());
+
+        let base = spawn_server(|_| {
+            move |req: &Req| {
+                if req.auth.as_deref() == Some(OLD_BEARER) {
+                    (200, RPC_OK.into())
+                } else {
+                    (401, String::new())
+                }
+            }
+        });
+        let url = format!("{base}/mcp");
+        save_mcp_auth(&storage, "srv", &stored_auth(&url, "old-token", "r1")).unwrap();
+
+        let transport = transport_with(&url, HashMap::new(), Some(storage));
+        let result = smol::block_on(transport.send_request("tools/list", None)).unwrap();
+        assert_eq!(result, json!({"ok": true}));
     }
 }

--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -236,8 +236,6 @@ pub enum McpCommand {
     },
     Reconnect {
         server: String,
-        url: String,
-        token: String,
     },
     /// Drain every running transport and stop the loop. The loop sends `()` on `ack` once
     /// every shutdown has finished, so callers can wait with a timeout.
@@ -388,8 +386,8 @@ async fn run(
             McpCommand::Toggle { server, enabled } => {
                 handle_toggle(&mut inner, &server, enabled).await;
             }
-            McpCommand::Reconnect { server, url, token } => {
-                handle_reconnect(&mut inner, &server, &url, &token).await;
+            McpCommand::Reconnect { server } => {
+                handle_reconnect(&mut inner, &server).await;
             }
             McpCommand::Shutdown { ack: tx } => {
                 ack = Some(tx);
@@ -418,7 +416,7 @@ async fn handle_toggle(inner: &mut McpManagerInner, server_name: &str, enabled: 
     }
 
     if enabled {
-        if let Err(e) = refresh_server(inner, server_name, None).await {
+        if let Err(e) = refresh_server(inner, server_name).await {
             warn!(server = %server_name, error = %e, "MCP server refresh failed");
         }
     } else if let Some(entry) = inner.entries.iter_mut().find(|e| e.name == server_name) {
@@ -429,12 +427,9 @@ async fn handle_toggle(inner: &mut McpManagerInner, server_name: &str, enabled: 
     info!(server = server_name, enabled, "MCP toggle complete");
 }
 
-async fn handle_reconnect(
-    inner: &mut McpManagerInner,
-    server_name: &str,
-    server_url: &str,
-    access_token: &str,
-) {
+/// Restart the server with its stored config. Fresh OAuth tokens are picked up
+/// from storage by the transport, so no credentials travel through the command.
+async fn handle_reconnect(inner: &mut McpManagerInner, server_name: &str) {
     let Some(entry) = inner.entries.iter().find(|e| e.name == server_name) else {
         warn!(server = server_name, "reconnect for unknown server");
         return;
@@ -446,21 +441,7 @@ async fn handle_reconnect(
         );
         return;
     }
-    let timeout = entry.config.as_ref().map(|c| c.timeout).unwrap_or_default();
-    let mut headers = HashMap::new();
-    headers.insert(
-        "Authorization".to_string(),
-        format!("Bearer {access_token}"),
-    );
-    let cfg = ServerConfig {
-        name: server_name.to_string(),
-        timeout,
-        transport: Transport::Http {
-            url: server_url.to_string(),
-            headers,
-        },
-    };
-    if let Err(e) = refresh_server(inner, server_name, Some(cfg)).await {
+    if let Err(e) = refresh_server(inner, server_name).await {
         warn!(server = %server_name, error = %e, "reconnect failed");
     }
     info!(server = server_name, "MCP reconnect complete");
@@ -479,25 +460,15 @@ async fn shutdown_all(inner: &mut McpManagerInner) {
 /// Tear the old transport down and wipe tools/prompts *before* starting the new one. That way
 /// a failed start leaves the entry empty instead of holding zombie tool references into a dead
 /// transport.
-async fn refresh_server(
-    inner: &mut McpManagerInner,
-    server_name: &str,
-    config_override: Option<ServerConfig>,
-) -> Result<(), McpError> {
+async fn refresh_server(inner: &mut McpManagerInner, server_name: &str) -> Result<(), McpError> {
     let Some(idx) = inner.entries.iter().position(|e| e.name == server_name) else {
         return Err(McpError::Config(format!("unknown server '{server_name}'")));
     };
 
-    let config = match config_override {
-        Some(c) => {
-            inner.entries[idx].config = Some(c.clone());
-            c
-        }
-        None => inner.entries[idx]
-            .config
-            .clone()
-            .ok_or_else(|| McpError::Config(format!("server '{server_name}' has no config")))?,
-    };
+    let config = inner.entries[idx]
+        .config
+        .clone()
+        .ok_or_else(|| McpError::Config(format!("server '{server_name}' has no config")))?;
 
     {
         let entry = &mut inner.entries[idx];
@@ -554,6 +525,7 @@ async fn start_server(config: &ServerConfig) -> Result<StartResult, McpError> {
             url,
             headers,
             config.timeout,
+            maki_storage::StateDir::resolve().ok(),
         )?),
     };
     transport::initialize(transport.as_ref()).await?;
@@ -934,7 +906,7 @@ mod tests {
             let (mut inner, _) = setup(vec![fake_entry("srv", Arc::clone(&t) as _)]);
             inner.entries[0].config = Some(bad_stdio_config("srv"));
 
-            assert!(refresh_server(&mut inner, "srv", None).await.is_err());
+            assert!(refresh_server(&mut inner, "srv").await.is_err());
 
             let entry = &inner.entries[0];
             assert_eq!(t.shutdowns(), 1);

--- a/maki-agent/src/mcp/oauth/mod.rs
+++ b/maki-agent/src/mcp/oauth/mod.rs
@@ -21,6 +21,10 @@ use self::discovery::parse_www_authenticate;
 use super::error::McpError;
 
 const AUTH_TIMEOUT: Duration = Duration::from_secs(600);
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+/// In-band refresh blocks requests waiting on the transport's auth lock, so it
+/// gets a much tighter budget than the interactive flow.
+const SILENT_REFRESH_HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Debug, thiserror::Error)]
 pub enum OAuthError {
@@ -51,41 +55,21 @@ pub async fn authenticate(
         server: server_name.into(),
         reason: e.to_string(),
     };
-    let client = build_http_client().map_err(|e| wrap(OAuthError::Other(e.to_string())))?;
+    let client =
+        build_http_client(HTTP_TIMEOUT).map_err(|e| wrap(OAuthError::Other(e.to_string())))?;
 
     if let Some(existing) = load_mcp_auth(storage, server_name, server_url)
         && let Some(ref tokens) = existing.tokens
+        && !tokens.is_expired()
     {
-        if !tokens.is_expired() {
-            return Ok(existing);
-        }
-        if !tokens.refresh.is_empty() {
-            let auth_server = discover_auth_server_for(&client, server_url, None)
-                .await
-                .map_err(&wrap)?;
-            match token::refresh_token(
-                &client,
-                &auth_server.token_endpoint,
-                &tokens.refresh,
-                &existing.client_id,
-                existing.client_secret.as_deref(),
-                server_url,
-            )
-            .await
-            {
-                Ok(new_tokens) => {
-                    let data = McpAuthData {
-                        tokens: Some(new_tokens),
-                        ..existing
-                    };
-                    save_mcp_auth(storage, server_name, &data)
-                        .map_err(|e| wrap(OAuthError::Other(e.to_string())))?;
-                    return Ok(data);
-                }
-                Err(e) => {
-                    warn!(server = server_name, error = %e, "token refresh failed, starting full flow");
-                }
-            }
+        return Ok(existing);
+    }
+
+    match silent_refresh(storage, server_name, server_url).await {
+        Ok(Some(data)) => return Ok(data),
+        Ok(None) => {}
+        Err(e) => {
+            warn!(server = server_name, error = %e, "token refresh failed, starting full flow");
         }
     }
 
@@ -231,6 +215,51 @@ pub async fn authenticate(
     Ok(data)
 }
 
+/// Refresh stored tokens without any user interaction. `Ok(None)` means an
+/// interactive flow is required (no stored auth or no refresh token).
+pub async fn silent_refresh(
+    storage: &StateDir,
+    server_name: &str,
+    server_url: &str,
+) -> Result<Option<McpAuthData>, OAuthError> {
+    let Some(existing) = load_mcp_auth(storage, server_name, server_url) else {
+        return Ok(None);
+    };
+
+    let Some(ref tokens) = existing.tokens else {
+        return Ok(None);
+    };
+
+    if tokens.refresh.is_empty() {
+        return Ok(None);
+    }
+
+    let client = build_http_client(SILENT_REFRESH_HTTP_TIMEOUT)
+        .map_err(|e| OAuthError::Other(e.to_string()))?;
+
+    let auth_server = discover_auth_server_for(&client, server_url, None).await?;
+
+    let new_tokens = token::refresh_token(
+        &client,
+        &auth_server.token_endpoint,
+        &tokens.refresh,
+        &existing.client_id,
+        existing.client_secret.as_deref(),
+        server_url,
+    )
+    .await?;
+
+    let data = McpAuthData {
+        tokens: Some(new_tokens),
+        ..existing
+    };
+
+    save_mcp_auth(storage, server_name, &data).map_err(|e| OAuthError::Other(e.to_string()))?;
+    info!(server = server_name, "MCP OAuth tokens refreshed");
+
+    Ok(Some(data))
+}
+
 async fn discover_auth_server_for(
     client: &HttpClient,
     server_url: &str,
@@ -259,10 +288,10 @@ fn is_headless() -> bool {
         && std::env::var_os("WAYLAND_DISPLAY").is_none()
 }
 
-fn build_http_client() -> Result<HttpClient, isahc::Error> {
+fn build_http_client(timeout: Duration) -> Result<HttpClient, isahc::Error> {
     HttpClient::builder()
         .redirect_policy(RedirectPolicy::Limit(super::http::MAX_REDIRECTS))
-        .timeout(std::time::Duration::from_secs(30))
+        .timeout(timeout)
         .build()
 }
 

--- a/maki-agent/src/mcp/oauth/token.rs
+++ b/maki-agent/src/mcp/oauth/token.rs
@@ -48,7 +48,11 @@ pub async fn refresh_token(
     if let Some(secret) = client_secret {
         params.push(("client_secret", secret));
     }
-    token_request(client, token_endpoint, &params).await
+    let mut tokens = token_request(client, token_endpoint, &params).await?;
+    if tokens.refresh.is_empty() {
+        tokens.refresh = refresh_token.to_string();
+    }
+    Ok(tokens)
 }
 
 async fn token_request(
@@ -92,8 +96,12 @@ async fn token_request(
         .read_to_string(&mut body_str)
         .map_err(|e| OAuthError::Network(e.to_string()))?;
 
+    parse_token_response(&body_str)
+}
+
+fn parse_token_response(body: &str) -> Result<OAuthTokens, OAuthError> {
     let resp: serde_json::Value =
-        serde_json::from_str(&body_str).map_err(|e| OAuthError::InvalidResponse(e.to_string()))?;
+        serde_json::from_str(body).map_err(|e| OAuthError::InvalidResponse(e.to_string()))?;
 
     let access = resp["access_token"]
         .as_str()
@@ -131,11 +139,25 @@ pub(super) fn url_encode(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_case::test_case;
 
     #[test]
     fn url_encode_basic() {
         assert_eq!(url_encode("hello world"), "hello%20world");
         assert_eq!(url_encode("foo=bar&baz"), "foo%3Dbar%26baz");
         assert_eq!(url_encode("abc-def_ghi.jkl~mno"), "abc-def_ghi.jkl~mno");
+    }
+
+    #[test_case(r#"{"access_token":"a1","refresh_token":"r1","expires_in":60}"#, "a1", "r1" ; "rotated_refresh")]
+    #[test_case(r#"{"access_token":"a1","expires_in":60}"#, "a1", "" ; "missing_refresh_is_empty")]
+    fn parse_token_response_fields(body: &str, access: &str, refresh: &str) {
+        let tokens = parse_token_response(body).unwrap();
+        assert_eq!(tokens.access, access);
+        assert_eq!(tokens.refresh, refresh);
+    }
+
+    #[test]
+    fn parse_token_response_missing_access_is_error() {
+        assert!(parse_token_response(r#"{"refresh_token":"r1"}"#).is_err());
     }
 }

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -350,7 +350,7 @@ fn spawn_oauth_for_needs_auth(handle: &McpHandle) {
                     return;
                 }
             };
-            let auth_data = match maki_agent::mcp::oauth::authenticate(
+            if let Err(e) = maki_agent::mcp::oauth::authenticate(
                 &server_name,
                 &server_url,
                 www_auth.as_deref(),
@@ -359,19 +359,11 @@ fn spawn_oauth_for_needs_auth(handle: &McpHandle) {
             )
             .await
             {
-                Ok(d) => d,
-                Err(e) => {
-                    tracing::warn!(server = %server_name, error = %e, "background OAuth failed");
-                    return;
-                }
-            };
-            let Some(ref tokens) = auth_data.tokens else {
+                tracing::warn!(server = %server_name, error = %e, "background OAuth failed");
                 return;
-            };
+            }
             handle.send(McpCommand::Reconnect {
                 server: server_name.clone(),
-                url: server_url,
-                token: tokens.access.clone(),
             });
             tracing::info!(server = %server_name, "MCP server authenticated via OAuth");
         })


### PR DESCRIPTION
A small annoyance, but every morning when I keep maki open the whole night (or seven of them in different zellij sessions), I need to restart it so the MCP servers using OAuth would refresh their tokens. This could happen automatically?

Now 401 triggers a single-flight silent refresh and one retry, stored tokens are injected at startup, and a non-rotating token endpoint no longer wipes the saved refresh token.