### PR TITLE
refactor(plugins): bless `{ llm_output, is_error = true }`

### DIFF
--- a/maki-lua/src/api/AGENTS.md
+++ b/maki-lua/src/api/AGENTS.md
@@ -10,3 +10,5 @@ Our goal is to let plugin authors have as much freedom as possible, that's why d
 
 Fallible runtime operations return the pair (value, err) and never throw.
 Throwing is reserved for programmer errors, like passing a number where a string belongs.
+
+Tool handlers fail with `{ llm_output = msg, is_error = true }`; a plain string is always success (only `is_error` flags the result as an error to the provider).

--- a/plugins/glob/init.lua
+++ b/plugins/glob/init.lua
@@ -45,7 +45,7 @@ maki.api.register_tool({
   handler = function(input, ctx)
     local pattern = input.pattern
     if not pattern then
-      return "error: pattern is required"
+      return { llm_output = "error: pattern is required", is_error = true }
     end
 
     local limit = ctx:config("search_result_limit", DEFAULT_SEARCH_LIMIT)
@@ -60,7 +60,7 @@ maki.api.register_tool({
     })
 
     if not files then
-      return "error: " .. err
+      return { llm_output = "error: " .. err, is_error = true }
     end
 
     if #files == 0 then

--- a/plugins/grep/init.lua
+++ b/plugins/grep/init.lua
@@ -235,7 +235,7 @@ maki.api.register_tool({
   handler = function(input, ctx)
     local pattern = input.pattern
     if not pattern then
-      return "error: pattern is required"
+      return { llm_output = "error: pattern is required", is_error = true }
     end
     pattern = pattern:gsub('"$', "")
 
@@ -258,7 +258,7 @@ maki.api.register_tool({
     })
 
     if not entries then
-      return "error: " .. tostring(err)
+      return { llm_output = "error: " .. tostring(err), is_error = true }
     end
 
     if #entries == 0 then

--- a/plugins/index/init.lua
+++ b/plugins/index/init.lua
@@ -176,7 +176,7 @@ Return a compact overview of a source file: imports, type definitions, function 
   handler = function(input, ctx)
     local path = input.path
     if not path then
-      return "error: path is required"
+      return { llm_output = "error: path is required", is_error = true }
     end
 
     local meta = maki.fs.metadata(path)
@@ -204,21 +204,24 @@ Return a compact overview of a source file: imports, type definitions, function 
 
     local max_file_size = ctx:config("index_max_file_size", (2 * 1024 * 1024))
     if meta and meta.size > max_file_size then
-      return "error: File too large ("
-        .. meta.size
-        .. " bytes, max "
-        .. max_file_size
-        .. "). Use read with offset/limit instead."
+      return {
+        llm_output = "error: File too large ("
+          .. meta.size
+          .. " bytes, max "
+          .. max_file_size
+          .. "). Use read with offset/limit instead.",
+        is_error = true,
+      }
     end
 
     local source, err = maki.fs.read(path)
     if not source then
-      return "error: " .. err
+      return { llm_output = "error: " .. err, is_error = true }
     end
 
     local skeleton, line_meta = indexer.index_source(source, lang)
     if not skeleton then
-      return "error: " .. tostring(line_meta)
+      return { llm_output = "error: " .. tostring(line_meta), is_error = true }
     end
 
     local ext = indexer.LANG_TO_EXT[lang] or path:match("%.([^%.]+)$") or ""

--- a/plugins/memory/init.lua
+++ b/plugins/memory/init.lua
@@ -164,7 +164,7 @@ maki.api.register_tool({
     local cmd = input.command
     local dir, dir_err = resolve_dir(cmd == "view")
     if not dir then
-      return "error: " .. dir_err
+      return { llm_output = "error: " .. dir_err, is_error = true }
     end
 
     local result, err
@@ -172,22 +172,25 @@ maki.api.register_tool({
       result, err = cmd_view(input.path, dir, ctx)
     elseif cmd == "write" then
       if not input.path then
-        return "error: 'path' is required for write"
+        return { llm_output = "error: 'path' is required for write", is_error = true }
       end
       if not input.content then
-        return "error: 'content' is required for write"
+        return { llm_output = "error: 'content' is required for write", is_error = true }
       end
       result, err = cmd_write(input.path, input.content, dir, ctx)
     elseif cmd == "delete" then
       if not input.path then
-        return "error: 'path' is required for delete"
+        return { llm_output = "error: 'path' is required for delete", is_error = true }
       end
       result, err = cmd_delete(input.path, dir)
     else
-      return "error: unknown command '" .. tostring(cmd) .. "'. Valid commands: view, write, delete"
+      return {
+        llm_output = "error: unknown command '" .. tostring(cmd) .. "'. Valid commands: view, write, delete",
+        is_error = true,
+      }
     end
     if err then
-      return "error: " .. err
+      return { llm_output = "error: " .. err, is_error = true }
     end
     return result
   end,

--- a/plugins/question/init.lua
+++ b/plugins/question/init.lua
@@ -58,7 +58,7 @@ maki.api.register_tool({
   end,
   handler = function(input, ctx)
     if #input.questions == 0 then
-      return "error: at least one question is required"
+      return { llm_output = "error: at least one question is required", is_error = true }
     end
     for _, q in ipairs(input.questions) do
       q.options = q.options or {}

--- a/plugins/skill/init.lua
+++ b/plugins/skill/init.lua
@@ -113,14 +113,14 @@ maki.api.register_tool({
 
   handler = function(input, ctx)
     if not input.name then
-      return "error: name is required"
+      return { llm_output = "error: name is required", is_error = true }
     end
 
     local skills = discover_skills()
     local skill = skills[input.name]
     if not skill then
       local available = build_skill_list(skills)
-      return NOT_FOUND .. input.name .. available
+      return { llm_output = NOT_FOUND .. input.name .. available, is_error = true }
     end
 
     local lines = {}

--- a/plugins/webfetch/init.lua
+++ b/plugins/webfetch/init.lua
@@ -103,12 +103,12 @@ maki.api.register_tool({
   handler = function(input, ctx)
     local url = input.url
     if not url then
-      return "error: url is required"
+      return { llm_output = "error: url is required", is_error = true }
     end
 
     local fmt = input.format or DEFAULT_FORMAT
     if not VALID_FORMATS[fmt] then
-      return "error: unknown format: " .. tostring(fmt)
+      return { llm_output = "error: unknown format: " .. tostring(fmt), is_error = true }
     end
 
     local config = ctx:config()
@@ -124,16 +124,16 @@ maki.api.register_tool({
       },
     })
     if not resp then
-      return "error: " .. tostring(err)
+      return { llm_output = "error: " .. tostring(err), is_error = true }
     end
 
     if resp.status < 200 or resp.status >= 300 then
-      return "error: HTTP " .. tostring(resp.status)
+      return { llm_output = "error: HTTP " .. tostring(resp.status), is_error = true }
     end
 
     local ct = resp.content_type or ""
     if ct:find("^image/") and not ct:find("svg") then
-      return "error: image content cannot be displayed as text"
+      return { llm_output = "error: image content cannot be displayed as text", is_error = true }
     end
 
     local body = resp.body

--- a/plugins/websearch/init.lua
+++ b/plugins/websearch/init.lua
@@ -45,7 +45,7 @@ maki.api.register_tool({
   handler = function(input, ctx)
     local query = input.query
     if not query then
-      return "error: query is required"
+      return { llm_output = "error: query is required", is_error = true }
     end
 
     local num_results = input.num_results or DEFAULT_NUM_RESULTS
@@ -65,7 +65,7 @@ maki.api.register_tool({
       },
     })
     if not payload then
-      return "error: failed to encode request: " .. tostring(encode_err)
+      return { llm_output = "error: failed to encode request: " .. tostring(encode_err), is_error = true }
     end
 
     local config = ctx:config()
@@ -90,17 +90,17 @@ maki.api.register_tool({
       max_bytes = max_response,
     })
     if not resp then
-      return "error: " .. tostring(err)
+      return { llm_output = "error: " .. tostring(err), is_error = true }
     end
 
     if resp.status < 200 or resp.status >= 300 then
       local preview = resp.body:sub(1, 200)
-      return "error: HTTP " .. tostring(resp.status) .. ": " .. preview
+      return { llm_output = "error: HTTP " .. tostring(resp.status) .. ": " .. preview, is_error = true }
     end
 
     local text, parse_err = parse_sse_response(resp.body)
     if not text then
-      return "error: " .. tostring(parse_err)
+      return { llm_output = "error: " .. tostring(parse_err), is_error = true }
     end
 
     local llm_output = truncate(text, max_lines, max_bytes)

--- a/site/index.html
+++ b/site/index.html
@@ -1491,7 +1491,9 @@ imports = <span class="fn">set</span>()
   handler = <span class="kw">function</span>()
     <span class="kw">local</span> res, err = <span class="fn">maki.net.request</span>(
       <span class="st">"https://ci.internal/runs?branch=main"</span>)
-    <span class="kw">if</span> err <span class="kw">then</span> <span class="kw">return</span> <span class="st">"error: "</span> .. err <span class="kw">end</span>
+    <span class="kw">if</span> err <span class="kw">then</span>
+      <span class="kw">return</span> { llm_output = err, is_error = <span class="kw">true</span> }
+    <span class="kw">end</span>
     <span class="kw">return</span> res.body
   <span class="kw">end</span>,
 })</pre>


### PR DESCRIPTION
Tool handlers used two error shapes: some returned the table, others a plain `"error: ..."` string that was silently reported as a success to the provider, since only `is_error` sets the error flag on the tool result.

Migrated the eight plugins still on plain strings (websearch, webfetch, glob, index, grep, memory, skill, question), recorded the convention in `maki-lua/src/api/AGENTS.md`, and fixed the `ci_status` example on the site to match.

A plain string return still works, but it now always means success.