### PR TITLE
feat(ui): clickable and draggable scrollbars

### DIFF
--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -163,6 +163,7 @@ pub struct App {
     pub(super) retry_info: Option<RetryInfo>,
     pub(super) zones: ZoneRegistry,
     pub(super) selection_state: Option<SelectionState>,
+    pub(super) scrollbar_drag: Option<mouse::ScrollbarDrag>,
     pub(super) clipboard: ClipboardState,
     pub(super) last_esc: Option<Instant>,
 
@@ -243,6 +244,7 @@ impl App {
             retry_info: None,
             zones: ZoneRegistry::new(),
             selection_state: None,
+            scrollbar_drag: None,
             clipboard: ClipboardState::new(),
             last_esc: None,
             storage,

--- a/maki-ui/src/app/mouse.rs
+++ b/maki-ui/src/app/mouse.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 use crate::clipboard::CopyResult;
+use crate::components::scrollbar;
 use crate::selection::{self, ContentRegion, EdgeScroll, Selection, SelectionState, SelectionZone};
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;
@@ -10,8 +11,20 @@ use super::App;
 pub(super) const EDGE_SCROLL_LINES: i32 = 1;
 pub(super) const EDGE_SCROLL_INTERVAL: Duration = Duration::from_millis(25);
 
+pub(crate) struct ScrollbarDrag {
+    zone: SelectionZone,
+    content_len: u16,
+    viewport_height: u16,
+    thumb_len: u16,
+    grab_offset: i32,
+    track_y_start: u16,
+}
+
 impl App {
     pub(super) fn handle_mouse(&mut self, event: MouseEvent) {
+        if self.handle_scrollbar_mouse(&event) {
+            return;
+        }
         match event.kind {
             MouseEventKind::Down(MouseButton::Left) => {
                 if let Some(zone) = self.zone_at(event.row, event.column) {
@@ -50,6 +63,83 @@ impl App {
                 }
             }
             _ => {}
+        }
+    }
+
+    fn handle_scrollbar_mouse(&mut self, event: &MouseEvent) -> bool {
+        match event.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                let Some(zone) = self.zone_at(event.row, event.column) else {
+                    return false;
+                };
+                let Some(info) = zone.scroll_info else {
+                    return false;
+                };
+                if event.column != zone.area.right().saturating_sub(1) {
+                    return false;
+                }
+                let Some((thumb_start, thumb_end)) =
+                    scrollbar::vertical_thumb_bounds(info.content_len, zone.area.height, info.position)
+                else {
+                    return false;
+                };
+
+                let row_rel = event.row.saturating_sub(zone.area.y);
+                let thumb_len = thumb_end.saturating_sub(thumb_start);
+                self.selection_state = None;
+
+                if row_rel >= thumb_start && row_rel < thumb_end {
+                    self.scrollbar_drag = Some(ScrollbarDrag {
+                        zone: zone.zone,
+                        content_len: info.content_len,
+                        viewport_height: zone.area.height,
+                        thumb_len,
+                        grab_offset: row_rel as i32 - thumb_start as i32,
+                        track_y_start: zone.area.y,
+                    });
+                } else {
+                    let page = zone.area.height as i32;
+                    let delta = if row_rel < thumb_start { page } else { -page };
+                    self.scroll_zone(zone.zone, delta);
+                }
+                true
+            }
+            MouseEventKind::Drag(MouseButton::Left) => {
+                let (zone, content_len, viewport_height, thumb_len, grab_offset, track_y_start) = {
+                    let Some(ref drag) = self.scrollbar_drag else {
+                        return false;
+                    };
+                    (
+                        drag.zone,
+                        drag.content_len,
+                        drag.viewport_height,
+                        drag.thumb_len,
+                        drag.grab_offset,
+                        drag.track_y_start,
+                    )
+                };
+                let row_rel = event.row.saturating_sub(track_y_start) as i32;
+                let max_thumb_start = (viewport_height as i32 - thumb_len as i32).max(0);
+                let new_thumb_start = (row_rel - grab_offset).clamp(0, max_thumb_start) as u16;
+                let position =
+                    scrollbar::position_for_thumb_row(content_len, viewport_height, new_thumb_start);
+                self.set_scroll_zone(zone, position);
+                true
+            }
+            MouseEventKind::Up(MouseButton::Left) if self.scrollbar_drag.is_some() => {
+                self.scrollbar_drag = None;
+                true
+            }
+            MouseEventKind::Up(MouseButton::Left) => false,
+            _ => false,
+        }
+    }
+
+    fn set_scroll_zone(&mut self, zone: SelectionZone, position: u16) {
+        match zone {
+            SelectionZone::Messages => self.chats[self.active_chat].set_scroll_top(position),
+            SelectionZone::Input => self.input_box.set_scroll_y(position),
+            SelectionZone::Overlay => {}
         }
     }
 

--- a/maki-ui/src/app/mouse.rs
+++ b/maki-ui/src/app/mouse.rs
@@ -67,6 +67,14 @@ impl App {
     }
 
     fn handle_scrollbar_mouse(&mut self, event: &MouseEvent) -> bool {
+        if !scrollbar::is_enabled() {
+            return false;
+        }
+        if self.has_modal_overlay() {
+            self.scrollbar_drag = None;
+            return false;
+        }
+
         match event.kind {
             MouseEventKind::Down(MouseButton::Left) => {
                 let Some(zone) = self.zone_at(event.row, event.column) else {
@@ -122,7 +130,7 @@ impl App {
                 let max_thumb_start = (viewport_height as i32 - thumb_len as i32).max(0);
                 let new_thumb_start = (row_rel - grab_offset).clamp(0, max_thumb_start) as u16;
                 let position =
-                    scrollbar::position_for_thumb_row(content_len, viewport_height, new_thumb_start);
+                    scrollbar::position_for_thumb_row(content_len, viewport_height, thumb_len, new_thumb_start);
                 self.set_scroll_zone(zone, position);
                 true
             }

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -971,7 +971,7 @@ fn mouse_drag_clamps_to_area() {
 
     let state = app.selection_state.as_ref().unwrap();
     let (_, end) = state.sel().normalized();
-    assert_eq!(end.col, 79);
+    assert_eq!(end.col, 78);
     assert_eq!(end.row, 19, "clamped to area bottom");
     assert!(
         app.selection_state.as_ref().unwrap().is_edge_scrolling(),

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -23,7 +23,11 @@ use tempfile::TempDir;
 use test_case::test_case;
 
 fn set_zone(app: &mut App, zone: SelectionZone, area: Rect) {
-    app.zones.push(SelectableZone { area, zone });
+    app.zones.push(SelectableZone {
+        area,
+        zone,
+        scroll_info: None,
+    });
 }
 
 fn test_app() -> App {

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -330,9 +330,12 @@ impl App {
         // Push order = z-order. zone_at() walks in reverse, so later entries win.
         self.zones = ZoneRegistry::new();
 
+        let render_chat = self.resolve_render_chat();
+        let msg_scroll = self.chats[render_chat].scroll_info(layout.msg_area.height);
         self.zones.push(SelectableZone {
             area: layout.msg_area,
             zone: SelectionZone::Messages,
+            scroll_info: msg_scroll,
         });
 
         if layout.input_area.height > 0 && !layout.bottom_takeover && self.is_main_chat() {
@@ -342,9 +345,11 @@ impl App {
                 layout.input_area.width,
                 layout.input_area.height.saturating_sub(2),
             );
+            let input_scroll = self.input_box.scroll_info(input_inner);
             self.zones.push(SelectableZone {
                 area: input_inner,
                 zone: SelectionZone::Input,
+                scroll_info: input_scroll,
             });
         }
 

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -4,8 +4,8 @@
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
-
 use crate::components::messages::{MessagesPanel, PromptProgress};
+use crate::components::scrollbar::ScrollInfo;
 use crate::components::tool_display::append_annotation;
 use crate::components::{DisplayMessage, DisplayRole, ToolRole, ToolStatus};
 use crate::markdown::truncate_output;
@@ -226,6 +226,18 @@ impl Chat {
 
     pub fn scroll_top(&self) -> u16 {
         self.messages_panel.scroll_top()
+    }
+
+    pub fn total_lines(&self) -> u16 {
+        self.messages_panel.total_lines()
+    }
+
+    pub fn scroll_info(&self, viewport_height: u16) -> Option<ScrollInfo> {
+        self.messages_panel.scroll_info(viewport_height)
+    }
+
+    pub fn set_scroll_top(&mut self, y: u16) {
+        self.messages_panel.set_scroll_top(y);
     }
 
     pub fn segment_heights(&self) -> Vec<u16> {

--- a/maki-ui/src/components/input.rs
+++ b/maki-ui/src/components/input.rs
@@ -18,7 +18,7 @@ use ratatui::style::Style;
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, BorderType, Borders, Paragraph};
 
-use super::scrollbar::render_vertical_scrollbar;
+use super::scrollbar::{ScrollInfo, render_vertical_scrollbar};
 use super::{apply_scroll_delta, visual_line_count};
 use crate::selection::LineBreaks;
 
@@ -77,6 +77,7 @@ pub struct InputBox {
     follow_cursor: bool,
     placeholder_hint: &'static str,
     pending_images: Vec<ImageSource>,
+    last_total_vl: u16,
 }
 
 impl InputBox {
@@ -166,6 +167,7 @@ impl InputBox {
             follow_cursor: true,
             placeholder_hint: random_placeholder_hint(),
             pending_images: Vec::new(),
+            last_total_vl: 1,
         }
     }
 
@@ -337,6 +339,7 @@ impl InputBox {
         }
         let max_scroll = total_vl.saturating_sub(content_height);
         self.scroll_y = self.scroll_y.min(max_scroll);
+        self.last_total_vl = total_vl;
 
         let is_empty = self.buffer.value().is_empty();
         let mut styled_lines: Vec<Line> = if is_empty && self.pending_images.is_empty() {
@@ -427,6 +430,23 @@ impl InputBox {
 
     pub fn scroll_y(&self) -> u16 {
         self.scroll_y
+    }
+
+    pub fn scroll_info(&self, area: Rect) -> Option<ScrollInfo> {
+        if self.last_total_vl > area.height {
+            let max_scroll = self.last_total_vl.saturating_sub(area.height);
+            Some(ScrollInfo {
+                content_len: self.last_total_vl,
+                position: self.scroll_y.min(max_scroll),
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn set_scroll_y(&mut self, y: u16) {
+        self.scroll_y = y;
+        self.follow_cursor = false;
     }
 
     pub fn history(&self) -> &InputHistory {

--- a/maki-ui/src/components/input.rs
+++ b/maki-ui/src/components/input.rs
@@ -78,6 +78,7 @@ pub struct InputBox {
     placeholder_hint: &'static str,
     pending_images: Vec<ImageSource>,
     last_total_vl: u16,
+    last_content_height: u16,
 }
 
 impl InputBox {
@@ -168,6 +169,7 @@ impl InputBox {
             placeholder_hint: random_placeholder_hint(),
             pending_images: Vec::new(),
             last_total_vl: 1,
+            last_content_height: 1,
         }
     }
 
@@ -340,6 +342,7 @@ impl InputBox {
         let max_scroll = total_vl.saturating_sub(content_height);
         self.scroll_y = self.scroll_y.min(max_scroll);
         self.last_total_vl = total_vl;
+        self.last_content_height = content_height.max(1);
 
         let is_empty = self.buffer.value().is_empty();
         let mut styled_lines: Vec<Line> = if is_empty && self.pending_images.is_empty() {
@@ -454,7 +457,10 @@ impl InputBox {
     }
 
     pub fn scroll(&mut self, delta: i32) {
-        self.scroll_y = apply_scroll_delta(self.scroll_y, delta);
+        let max_scroll = self
+            .last_total_vl
+            .saturating_sub(self.last_content_height.max(1));
+        self.scroll_y = apply_scroll_delta(self.scroll_y, delta).min(max_scroll);
         self.follow_cursor = false;
     }
 }

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -28,7 +28,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::Instant;
 
-use super::scrollbar::render_vertical_scrollbar;
+use super::scrollbar::{ScrollInfo, render_vertical_scrollbar};
 use super::streaming_content::StreamingContent;
 use maki_agent::{
     BufferSnapshot, EventSender, InstructionBlock, NO_FILES_FOUND, SharedBuf, ToolDoneEvent,
@@ -848,6 +848,28 @@ impl MessagesPanel {
 
     pub fn scroll_top(&self) -> u16 {
         self.scroll_top
+    }
+
+    pub fn total_lines(&self) -> u16 {
+        self.last_total_lines
+    }
+
+    pub fn scroll_info(&self, viewport_height: u16) -> Option<ScrollInfo> {
+        let content_len = self.last_total_lines;
+        if content_len > viewport_height {
+            let max_scroll = content_len.saturating_sub(viewport_height);
+            Some(ScrollInfo {
+                content_len,
+                position: self.scroll_top.min(max_scroll),
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn set_scroll_top(&mut self, y: u16) {
+        self.scroll_top = y;
+        self.auto_scroll = false;
     }
 
     pub fn segment_heights(&self) -> Vec<u16> {

--- a/maki-ui/src/components/permission_prompt.rs
+++ b/maki-ui/src/components/permission_prompt.rs
@@ -300,7 +300,7 @@ impl PermissionPrompt {
             };
             let (before, after) = display_text.split_at(cursor_pos);
             let mut chars = after.chars();
-            let cursor_ch = chars.next().map_or(' ', |c| c);
+            let cursor_ch = chars.next().unwrap_or(' ');
             let rest: String = chars.collect();
 
             let mut spans = vec![Span::raw("  "), Span::styled("guide ", label_style)];

--- a/maki-ui/src/components/scrollbar.rs
+++ b/maki-ui/src/components/scrollbar.rs
@@ -12,6 +12,12 @@ pub fn set_enabled(enabled: bool) {
     ENABLED.store(enabled, Ordering::Relaxed);
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct ScrollInfo {
+    pub content_len: u16,
+    pub position: u16,
+}
+
 pub fn render_vertical_scrollbar(frame: &mut Frame, area: Rect, content_len: u16, position: u16) {
     if !ENABLED.load(Ordering::Relaxed) {
         return;
@@ -28,4 +34,38 @@ pub fn render_vertical_scrollbar(frame: &mut Frame, area: Rect, content_len: u16
         .end_symbol(None);
 
     frame.render_stateful_widget(scrollbar, area, &mut state);
+}
+
+pub fn vertical_thumb_bounds(
+    content_len: u16,
+    viewport_height: u16,
+    position: u16,
+) -> Option<(u16, u16)> {
+    if content_len <= viewport_height || viewport_height == 0 {
+        return None;
+    }
+    let content = f64::from(content_len);
+    let track = f64::from(viewport_height);
+    let max_scroll = content_len.saturating_sub(viewport_height);
+    let pos = f64::from(position.min(max_scroll));
+    let viewport = f64::from(viewport_height);
+
+    let thumb_start = (pos * track / content).round() as u16;
+    let thumb_end = ((pos + viewport) * track / content).round() as u16;
+    let thumb_len = thumb_end.saturating_sub(thumb_start).max(1);
+    Some((thumb_start, thumb_start.saturating_add(thumb_len)))
+}
+
+pub fn position_for_thumb_row(
+    content_len: u16,
+    viewport_height: u16,
+    thumb_row: u16,
+) -> u16 {
+    if content_len <= viewport_height || viewport_height == 0 {
+        return 0;
+    }
+    let max_scroll = content_len.saturating_sub(viewport_height);
+    let pos = (f64::from(thumb_row) * f64::from(content_len) / f64::from(viewport_height)).round()
+        as u16;
+    pos.min(max_scroll)
 }

--- a/maki-ui/src/components/scrollbar.rs
+++ b/maki-ui/src/components/scrollbar.rs
@@ -12,6 +12,10 @@ pub fn set_enabled(enabled: bool) {
     ENABLED.store(enabled, Ordering::Relaxed);
 }
 
+pub fn is_enabled() -> bool {
+    ENABLED.load(Ordering::Relaxed)
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct ScrollInfo {
     pub content_len: u16,
@@ -53,19 +57,93 @@ pub fn vertical_thumb_bounds(
     let thumb_start = (pos * track / content).round() as u16;
     let thumb_end = ((pos + viewport) * track / content).round() as u16;
     let thumb_len = thumb_end.saturating_sub(thumb_start).max(1);
-    Some((thumb_start, thumb_start.saturating_add(thumb_len)))
+
+    let thumb_start = thumb_start.min(viewport_height.saturating_sub(thumb_len));
+    let thumb_end = (thumb_start + thumb_len).min(viewport_height);
+
+    Some((thumb_start, thumb_end))
 }
 
 pub fn position_for_thumb_row(
     content_len: u16,
     viewport_height: u16,
+    thumb_len: u16,
     thumb_row: u16,
 ) -> u16 {
-    if content_len <= viewport_height || viewport_height == 0 {
+    if content_len <= viewport_height || viewport_height == 0 || thumb_len == 0 {
         return 0;
     }
     let max_scroll = content_len.saturating_sub(viewport_height);
-    let pos = (f64::from(thumb_row) * f64::from(content_len) / f64::from(viewport_height)).round()
-        as u16;
-    pos.min(max_scroll)
+    let max_thumb_start = viewport_height.saturating_sub(thumb_len).max(1);
+    let pos = ((u32::from(thumb_row) * u32::from(max_scroll)) + (u32::from(max_thumb_start) / 2))
+        / u32::from(max_thumb_start);
+    pos.min(u32::from(max_scroll)) as u16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vertical_thumb_bounds_stays_inside_track() {
+        let (start, end) = vertical_thumb_bounds(200, 10, 190).unwrap();
+        assert!(end <= 10, "thumb end {end} exceeds viewport 10");
+        assert!(start < end, "thumb start {start} must be below end {end}");
+    }
+
+    #[test]
+    fn vertical_thumb_bounds_top_and_bottom() {
+        let top = vertical_thumb_bounds(200, 10, 0).unwrap();
+        assert_eq!(top.0, 0);
+
+        let bottom = vertical_thumb_bounds(200, 10, 190).unwrap();
+        assert_eq!(bottom.1, 10);
+    }
+
+    #[test]
+    fn position_for_thumb_row_reaches_max_scroll() {
+        let content_len = 200;
+        let viewport_height = 10;
+        let thumb_len = 1;
+        let max_scroll = content_len - viewport_height;
+
+        let top = position_for_thumb_row(content_len, viewport_height, thumb_len, 0);
+        assert_eq!(top, 0);
+
+        let bottom = position_for_thumb_row(content_len, viewport_height, thumb_len, viewport_height - thumb_len);
+        assert_eq!(bottom, max_scroll);
+    }
+
+    #[test]
+    fn position_for_thumb_row_inverse_scales_linearly() {
+        let content_len = 200;
+        let viewport_height = 10;
+        let thumb_len = 1;
+        let max_scroll = content_len - viewport_height;
+
+        // Half-way down the available thumb track should be about half the content.
+        let mid_row = (viewport_height - thumb_len) / 2;
+        let pos = position_for_thumb_row(content_len, viewport_height, thumb_len, mid_row);
+        let expected = (u32::from(max_scroll) * u32::from(mid_row)
+            + u32::from(viewport_height - thumb_len) / 2)
+            / u32::from(viewport_height - thumb_len);
+        assert_eq!(pos, expected as u16);
+    }
+
+    #[test]
+    fn is_enabled_reflects_set() {
+        let before = is_enabled();
+        set_enabled(!before);
+        assert_eq!(is_enabled(), !before);
+        set_enabled(before);
+    }
+
+    #[test]
+    fn render_is_noop_when_disabled() {
+        // Rendering when disabled should not panic and should not access frame.
+        set_enabled(false);
+        // No frame to exercise; the function returns early.
+        assert!(!is_enabled());
+        set_enabled(true);
+    }
 }

--- a/maki-ui/src/selection.rs
+++ b/maki-ui/src/selection.rs
@@ -851,7 +851,7 @@ mod tests {
     }
 
     #[test_case(Rect::new(0,2,80,20), 10, 5, 25, 5, 0, 19, 5 ; "clamp_row_to_bottom")]
-    #[test_case(Rect::new(5,0,40,20), 10,10, 10,50, 0, 10,44 ; "clamp_col_to_right")]
+    #[test_case(Rect::new(5,0,40,20), 10,10, 10,50, 0, 10,43 ; "clamp_col_to_right")]
     #[test_case(Rect::new(5,0,40,20), 10,10, 10, 2, 0, 10, 5 ; "clamp_col_to_left")]
     #[allow(clippy::too_many_arguments)]
     fn update_clamps(

--- a/maki-ui/src/selection.rs
+++ b/maki-ui/src/selection.rs
@@ -159,8 +159,8 @@ fn screen_to_doc(screen_row: u16, area: Rect, scroll_offset: u32) -> u32 {
 
 fn clamp_col(col: u16, area: Rect, zone: SelectionZone) -> u16 {
     let reserve = match zone {
-        SelectionZone::Messages | SelectionZone::Input => 2,
-        SelectionZone::Overlay => 1,
+        SelectionZone::Messages => 2,
+        SelectionZone::Input | SelectionZone::Overlay => 1,
     };
     col.clamp(area.x, area.x + area.width.saturating_sub(reserve))
 }
@@ -191,8 +191,8 @@ impl Selection {
 
     pub fn highlight_area(&self) -> Rect {
         let width = match self.zone {
-            SelectionZone::Messages | SelectionZone::Input => self.area.width.saturating_sub(1),
-            SelectionZone::Overlay => self.area.width,
+            SelectionZone::Messages => self.area.width.saturating_sub(1),
+            SelectionZone::Input | SelectionZone::Overlay => self.area.width,
         };
         Rect::new(self.area.x, self.area.y, width, self.area.height)
     }

--- a/maki-ui/src/selection.rs
+++ b/maki-ui/src/selection.rs
@@ -37,6 +37,7 @@ use ratatui::text::Line;
 
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
+use crate::components::scrollbar::ScrollInfo;
 use crate::theme;
 use maki_markdown::render::{CODE_BAR, CODE_BAR_WRAP};
 
@@ -78,6 +79,7 @@ pub enum SelectionZone {
 pub struct SelectableZone {
     pub area: Rect,
     pub zone: SelectionZone,
+    pub scroll_info: Option<ScrollInfo>,
 }
 
 const ZONE_CAP: usize = 12;
@@ -85,6 +87,7 @@ const ZONE_CAP: usize = 12;
 const EMPTY_ZONE: SelectableZone = SelectableZone {
     area: Rect::new(0, 0, 0, 0),
     zone: SelectionZone::Messages,
+    scroll_info: None,
 };
 
 pub struct ZoneRegistry {
@@ -113,6 +116,7 @@ impl ZoneRegistry {
         self.push(SelectableZone {
             area,
             zone: SelectionZone::Overlay,
+            scroll_info: None,
         });
     }
 
@@ -153,14 +157,18 @@ fn screen_to_doc(screen_row: u16, area: Rect, scroll_offset: u32) -> u32 {
     scroll_offset + (clamped - area.y) as u32
 }
 
-fn clamp_col(col: u16, area: Rect) -> u16 {
-    col.clamp(area.x, area.x + area.width.saturating_sub(1))
+fn clamp_col(col: u16, area: Rect, zone: SelectionZone) -> u16 {
+    let reserve = match zone {
+        SelectionZone::Messages | SelectionZone::Input => 2,
+        SelectionZone::Overlay => 1,
+    };
+    col.clamp(area.x, area.x + area.width.saturating_sub(reserve))
 }
 
 impl Selection {
     pub fn start(row: u16, col: u16, area: Rect, zone: SelectionZone, scroll_offset: u32) -> Self {
         let doc_row = screen_to_doc(row, area, scroll_offset);
-        let doc_col = clamp_col(col, area);
+        let doc_col = clamp_col(col, area, zone);
         let pos = DocPos::new(doc_row, doc_col);
         Self {
             anchor: pos,
@@ -173,7 +181,7 @@ impl Selection {
     pub fn update(&mut self, row: u16, col: u16, scroll_offset: u32) {
         self.cursor = DocPos::new(
             screen_to_doc(row, self.area, scroll_offset),
-            clamp_col(col, self.area),
+            clamp_col(col, self.area, self.zone),
         );
     }
 
@@ -182,15 +190,11 @@ impl Selection {
     }
 
     pub fn highlight_area(&self) -> Rect {
-        match self.zone {
-            SelectionZone::Messages => Rect::new(
-                self.area.x,
-                self.area.y,
-                self.area.width.saturating_sub(1),
-                self.area.height,
-            ),
-            _ => self.area,
-        }
+        let width = match self.zone {
+            SelectionZone::Messages | SelectionZone::Input => self.area.width.saturating_sub(1),
+            SelectionZone::Overlay => self.area.width,
+        };
+        Rect::new(self.area.x, self.area.y, width, self.area.height)
     }
 
     pub fn normalized(&self) -> (DocPos, DocPos) {
@@ -960,10 +964,12 @@ mod tests {
         zones.push(SelectableZone {
             area: msg_area,
             zone: SelectionZone::Messages,
+            scroll_info: None,
         });
         zones.push(SelectableZone {
             area: overlay_area,
             zone: SelectionZone::Overlay,
+            scroll_info: None,
         });
 
         assert_eq!(zones.zone_at(7, 20).unwrap().zone, SelectionZone::Overlay);
@@ -1029,7 +1035,7 @@ mod tests {
     fn selection_start_col_clamped() {
         let area = Rect::new(10, 5, 40, 20);
         let right = Selection::start(8, 200, area, SelectionZone::Messages, 0);
-        assert_eq!(right.normalized().0.col, 49, "clamped to area right edge");
+        assert_eq!(right.normalized().0.col, 48, "clamped to content right edge");
         let left = Selection::start(8, 0, area, SelectionZone::Messages, 0);
         assert_eq!(left.normalized().0.col, 10, "clamped to area left edge");
     }
@@ -1100,6 +1106,7 @@ mod tests {
         zones.push(SelectableZone {
             area: Rect::new(0, 0, 80, 20),
             zone: SelectionZone::Messages,
+            scroll_info: None,
         });
         assert!(zones.zone_at(25, 10).is_none(), "outside all zones");
     }


### PR DESCRIPTION
## Summary
- Adds interactive scrollbar hit-testing to the messages panel and input box.
- Thumb drags translate mouse position back to content offset using the same ratatui 0.30.x scrollbar geometry.
- Track clicks page up/down.
- Selection clamping now excludes the rightmost scrollbar column so text cannot be selected there.

## Test plan
- [x] `cargo clippy -p maki-ui -- -D warnings`
- [x] `cargo nextest run -p maki-ui`