### PR TITLE
fix(ui): preserve text selection while scrolling

### DIFF
--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -49,7 +49,7 @@ use crate::components::{
     Action, DisplayMessage, DisplayRole, ExitRequest, Overlay, RetryInfo, Status, is_ctrl,
 };
 use crate::image;
-use crate::selection::{SelectionState, ZoneRegistry};
+use crate::selection::{SelectionState, SelectionZone, ZoneRegistry};
 use arc_swap::{ArcSwap, ArcSwapOption};
 use crossterm::event::{KeyCode, KeyEvent, MouseEvent};
 use maki_agent::permissions::PermissionManager;
@@ -343,8 +343,26 @@ impl App {
                 vec![]
             }
             Msg::Scroll { column, row, delta } => {
-                self.clear_selection_unless_pending_copy();
+                let drag_zone = self.selection_state.as_ref().and_then(|s| match s {
+                    SelectionState::Dragging { sel, .. } => Some(sel.zone),
+                    _ => None,
+                });
                 self.handle_scroll(column, row, delta);
+                if let Some(zone) = self.zone_at(row, column) {
+                    if drag_zone == Some(zone.zone)
+                        && matches!(zone.zone, SelectionZone::Messages | SelectionZone::Input)
+                    {
+                        let scroll = self.scroll_offset(zone.zone);
+                        if let Some(SelectionState::Dragging { sel, .. }) = &mut self.selection_state
+                        {
+                            sel.update(row, column, scroll);
+                        }
+                    } else {
+                        self.clear_selection_unless_pending_copy();
+                    }
+                } else {
+                    self.clear_selection_unless_pending_copy();
+                }
                 vec![]
             }
             Msg::Agent(envelope) => self.handle_agent_event(*envelope),

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -1131,8 +1131,7 @@ fn send_scroll(app: &mut App) {
     });
 }
 
-#[test_case(send_key as fn(&mut App)    ; "key")]
-#[test_case(send_scroll as fn(&mut App) ; "scroll")]
+#[test_case(send_key as fn(&mut App) ; "key")]
 fn interrupt_clears_dragging_but_preserves_pending_copy(interrupt: fn(&mut App)) {
     let mut app = test_app();
     set_zone(&mut app, SelectionZone::Messages, Rect::new(0, 0, 80, 20));
@@ -1145,6 +1144,27 @@ fn interrupt_clears_dragging_but_preserves_pending_copy(interrupt: fn(&mut App))
     assert!(
         app.selection_state.as_ref().unwrap().is_pending_copy(),
         "preserves pending copy"
+    );
+}
+
+#[test]
+fn scroll_preserves_dragging_and_updates_cursor() {
+    let mut app = test_app();
+    set_zone(&mut app, SelectionZone::Messages, Rect::new(0, 0, 80, 20));
+    app.update(mouse_event(MouseEventKind::Down(MouseButton::Left), 5, 5));
+
+    send_scroll(&mut app);
+
+    assert!(
+        matches!(app.selection_state.as_ref().unwrap(), SelectionState::Dragging { .. }),
+        "scroll keeps dragging"
+    );
+
+    make_pending_copy(&mut app);
+    send_scroll(&mut app);
+    assert!(
+        app.selection_state.as_ref().unwrap().is_pending_copy(),
+        "scroll preserves pending copy"
     );
 }
 

--- a/maki-ui/src/components/input.rs
+++ b/maki-ui/src/components/input.rs
@@ -77,6 +77,8 @@ pub struct InputBox {
     follow_cursor: bool,
     placeholder_hint: &'static str,
     pending_images: Vec<ImageSource>,
+    last_total_vl: u16,
+    last_content_height: u16,
 }
 
 impl InputBox {
@@ -166,6 +168,8 @@ impl InputBox {
             follow_cursor: true,
             placeholder_hint: random_placeholder_hint(),
             pending_images: Vec::new(),
+            last_total_vl: 1,
+            last_content_height: 1,
         }
     }
 
@@ -337,6 +341,8 @@ impl InputBox {
         }
         let max_scroll = total_vl.saturating_sub(content_height);
         self.scroll_y = self.scroll_y.min(max_scroll);
+        self.last_total_vl = total_vl;
+        self.last_content_height = content_height.max(1);
 
         let is_empty = self.buffer.value().is_empty();
         let mut styled_lines: Vec<Line> = if is_empty && self.pending_images.is_empty() {
@@ -434,7 +440,10 @@ impl InputBox {
     }
 
     pub fn scroll(&mut self, delta: i32) {
-        self.scroll_y = apply_scroll_delta(self.scroll_y, delta);
+        let max_scroll = self
+            .last_total_vl
+            .saturating_sub(self.last_content_height.max(1));
+        self.scroll_y = apply_scroll_delta(self.scroll_y, delta).min(max_scroll);
         self.follow_cursor = false;
     }
 }

--- a/maki-ui/src/components/permission_prompt.rs
+++ b/maki-ui/src/components/permission_prompt.rs
@@ -300,7 +300,7 @@ impl PermissionPrompt {
             };
             let (before, after) = display_text.split_at(cursor_pos);
             let mut chars = after.chars();
-            let cursor_ch = chars.next().map_or(' ', |c| c);
+            let cursor_ch = chars.next().unwrap_or(' ');
             let rest: String = chars.collect();
 
             let mut spans = vec![Span::raw("  "), Span::styled("guide ", label_style)];


### PR DESCRIPTION
## Summary
- Wheel scroll events over the messages panel and input box no longer clear an active drag selection.
- The selection cursor is re-projected with the new scroll offset, keeping the highlight anchored to the content.
- Pending-copy selections continue to be preserved on scroll.

## Test plan
- [x] `cargo clippy -p maki-ui --tests -- -D warnings`
- [x] `cargo nextest run -p maki-ui`