### PR TITLE
keymap: dispatch Lua overrides before built-in ctrl handlers

### DIFF
--- a/maki-docgen/src/gen_keybindings.rs
+++ b/maki-docgen/src/gen_keybindings.rs
@@ -139,6 +139,52 @@ pub fn generate() -> String {
 
     write_context_specific(&mut out);
     write_inheritance(&mut out);
+    write_overrides(&mut out);
 
     out
+}
+
+fn write_overrides(out: &mut String) {
+    out.push_str("\n## Overriding Keybindings\n\n");
+    out.push_str(
+        "Plugins and `init.lua` can rebind keys at runtime with \
+         `maki.keymap.set` and `maki.keymap.del`. The tables above are the \
+         built-in defaults. An override on the same key wins, unless a \
+         modal or overlay is open (help, plan form, permission prompt).\n\n",
+    );
+    out.push_str("Precedence, high to low:\n\n");
+    out.push_str(
+        "1. **Suspend** (`Ctrl+Z`, Unix). Always wins, non-remappable.\n\
+         2. **Modal and overlay keys.** An open modal or picker consumes \
+         its keys first, so they cannot be shadowed while open.\n\
+         3. **Lua overrides** from `maki.keymap.set`. Last set wins; \
+         binding the same key twice warns.\n\
+         4. **Built-in defaults.** An override on the same key shadows \
+         them; `maki.keymap.del` lifts the override so the default returns. \
+         Suspend is the only binding outside this layer, so every key is \
+         remappable except `Ctrl+Z`.\n\n",
+    );
+    out.push_str(
+        "Only single-key bindings can be overridden. Multi-key combinations \
+         and non-key rows (like `Type` to filter) cannot.\n\n",
+    );
+    out.push_str(
+        "The `/help` modal and the splash show default labels, not live \
+         overrides, but pressing the key still runs the override.\n\n",
+    );
+    out.push_str("### Recovering from a bad keymap\n\n");
+    out.push_str(
+        "If an override leaves Maki stuck (a rebound `Ctrl+C`, a modal \
+         that won't close, a plugin that throws on load), boot without \
+         plugins:\n\n",
+    );
+    out.push_str("```bash\nmaki --no-plugins\n```\n\n");
+    out.push_str(
+        "This skips the Lua host and runs the full default keymap from \
+         Rust, so quit, Esc, scroll, and suspend always work.\n\n",
+    );
+    out.push_str(
+        "The defaults live in Rust, not Lua, so `--no-plugins` never \
+         drops them.\n",
+    );
 }

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -20,6 +20,8 @@ pub use plugin_permissions::{Permission, PluginPermissions};
 pub use runtime::{RestoreItem, WARM_TOOL_CAP};
 
 pub mod test_support {
+    use crate::KeymapReader;
+    use crate::api::keymap::{KeymapEntry, KeymapWriter};
     use crate::api::util::command::{LuaCommandInfo, LuaCommandReader, LuaCommandWriter};
 
     pub struct LuaCommandWriterHandle(LuaCommandWriter);
@@ -58,5 +60,11 @@ pub mod test_support {
     pub fn probed_event_handle() -> (crate::EventHandle, RequestProbe) {
         let (tx, rx) = flume::unbounded();
         (crate::EventHandle::from_tx(tx), RequestProbe(rx))
+    }
+
+    pub fn keymap_reader_with(entries: Vec<KeymapEntry>) -> KeymapReader {
+        let (writer, reader) = KeymapWriter::new();
+        writer.publish(entries);
+        reader
     }
 }

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -59,7 +59,7 @@ pub mod test_support {
 
     pub fn probed_event_handle() -> (crate::EventHandle, RequestProbe) {
         let (tx, rx) = flume::unbounded();
-        (crate::EventHandle::from_tx(tx), RequestProbe(rx))
+        (crate::EventHandle::probed_for_test(tx), RequestProbe(rx))
     }
 
     pub fn keymap_reader_with(entries: Vec<KeymapEntry>) -> KeymapReader {

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -206,6 +206,23 @@ impl PluginHost {
         if self.inner.is_none() {
             return Ok(());
         }
+        for (plugin, opts) in &config.opts {
+            let keys: Vec<&str> = opts.keys().map(String::as_str).collect();
+            if !BUNDLED_PLUGINS.iter().any(|p| p.name == plugin.as_str()) {
+                return Err(PluginError::UnknownPluginOptions {
+                    plugin: plugin.clone(),
+                    keys: keys.join(", "),
+                });
+            }
+            if !config.names.contains(plugin) {
+                tracing::warn!(
+                    plugin = plugin.as_str(),
+                    keys = keys.join(", "),
+                    "plugin is disabled; its plugins.{} options are ignored until re-enabled",
+                    plugin
+                );
+            }
+        }
         for builtin in &config.names {
             let dir = match BUNDLED_PLUGINS.iter().find(|p| p.name == builtin.as_str()) {
                 Some(p) => &p.dir,
@@ -416,6 +433,17 @@ impl EventHandle {
         Self::from_tx(flume::unbounded().0)
     }
 
+    /// Test probe sibling of `from_tx`: collapses both senders onto one
+    /// channel so a `RequestProbe` sees every request, including the
+    /// `prio_tx`-routed commands and keybind callbacks that `from_tx`
+    /// would route to a disconnected channel.
+    pub(crate) fn probed_for_test(shared: flume::Sender<Request>) -> Self {
+        Self {
+            tx: shared.clone(),
+            prio_tx: shared,
+        }
+    }
+
     pub fn run_command(&self, plugin: Arc<str>, command: Arc<str>, args: String) {
         let _ = self.prio_tx.try_send(Request::RunCommand {
             plugin,
@@ -494,8 +522,10 @@ impl EventHandle {
         });
     }
 
-    pub fn run_keybind_callback(&self, id: u64) {
-        let _ = self.prio_tx.try_send(Request::RunKeybindCallback { id });
+    pub fn run_keybind_callback(&self, id: u64) -> bool {
+        self.prio_tx
+            .try_send(Request::RunKeybindCallback { id })
+            .is_ok()
     }
 }
 
@@ -644,8 +674,8 @@ mod tests {
     /// to the snapshot, EventHandle::run_keybind_callback dispatches the request,
     /// the runtime resolves the Function by id from the registry, and the callback
     /// executes with an observable side effect. This is the load-bearing path the
-    /// dispatch reorder and the store hardening rest on; unit tests only cover the
-    /// layers in isolation.
+    /// dispatch reorder and the dead-host fallback rest on; unit tests only cover
+    /// the layers in isolation.
     #[test]
     fn keybind_callback_runs_end_to_end() {
         let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
@@ -716,9 +746,9 @@ mod tests {
     #[test]
     fn disabled_host_skips_load_builtins() {
         let mut host = PluginHost::disabled();
-        let config = PluginsConfig::from_tools(HashMap::new());
+        let config = PluginsConfig::from_plugins(HashMap::new());
         assert!(
-            !config.tools.is_empty(),
+            !config.names.is_empty(),
             "default config enables builtin plugins"
         );
         host.load_builtins(&config)

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -163,6 +163,9 @@ impl PluginHost {
     }
 
     pub fn load_init_files(&self, cwd: &Path) -> Result<Option<RawConfig>, PluginError> {
+        if self.inner.is_none() {
+            return Ok(None);
+        }
         let mut merged: Option<RawConfig> = None;
 
         for global_dir in maki_config::global_config_dirs() {
@@ -202,23 +205,6 @@ impl PluginHost {
     pub fn load_builtins(&mut self, config: &PluginsConfig) -> Result<(), PluginError> {
         if self.inner.is_none() {
             return Ok(());
-        }
-        for (plugin, opts) in &config.opts {
-            let keys: Vec<&str> = opts.keys().map(String::as_str).collect();
-            if !BUNDLED_PLUGINS.iter().any(|p| p.name == plugin.as_str()) {
-                return Err(PluginError::UnknownPluginOptions {
-                    plugin: plugin.clone(),
-                    keys: keys.join(", "),
-                });
-            }
-            if !config.names.contains(plugin) {
-                tracing::warn!(
-                    plugin = plugin.as_str(),
-                    keys = keys.join(", "),
-                    "plugin is disabled; its plugins.{} options are ignored until re-enabled",
-                    plugin
-                );
-            }
         }
         for builtin in &config.names {
             let dir = match BUNDLED_PLUGINS.iter().find(|p| p.name == builtin.as_str()) {
@@ -519,6 +505,7 @@ mod tests {
     use crate::api::util::command::{LuaCommandInfo, LuaCommandWriter};
     use maki_agent::prompt::{PromptId, ResolvedSlots, Slot};
     use maki_agent::tools::ToolRegistry;
+    use std::time::Instant;
     use test_case::test_case;
 
     /// jit=true is exercised by the whole integration suite
@@ -653,6 +640,55 @@ mod tests {
         assert!(reader.load().generation > 0);
     }
 
+    /// End-to-end: a plugin registers a keymap override, the override is published
+    /// to the snapshot, EventHandle::run_keybind_callback dispatches the request,
+    /// the runtime resolves the Function by id from the registry, and the callback
+    /// executes with an observable side effect. This is the load-bearing path the
+    /// dispatch reorder and the store hardening rest on; unit tests only cover the
+    /// layers in isolation.
+    #[test]
+    fn keybind_callback_runs_end_to_end() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        host.load_source(
+            "kb",
+            r#"
+            maki.keymap.set("n", "<C-g>", function()
+                maki.api.register_command({
+                    name = "/fired",
+                    description = "callback ran",
+                    handler = function() end,
+                })
+            end, { desc = "test override" })
+            "#,
+        )
+        .unwrap();
+
+        let snap = host.keymap_reader().load();
+        assert_eq!(snap.entries.len(), 1, "override published to snapshot");
+        let entry = &snap.entries[0];
+        assert_eq!(entry.desc, "test override");
+        assert!(
+            host.command_reader().load().commands.is_empty(),
+            "callback has not fired yet"
+        );
+
+        let handle = host.event_handle().expect("host is live");
+        handle.run_keybind_callback(entry.id);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let cmds = &host.command_reader().load().commands;
+            if cmds.iter().any(|c| c.name.as_ref() == "/fired") {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "keybind callback did not register /fired within 2s"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
     #[test]
     fn disabled_host_returns_defaults() {
         let host = PluginHost::disabled();
@@ -660,6 +696,33 @@ mod tests {
         assert_eq!(snap.commands.len(), 0);
         assert_eq!(snap.generation, 0);
         assert!(host.ui_action_rx().is_none());
+    }
+
+    #[test_case(true ; "with_init_lua_present")]
+    #[test_case(false ; "without_init_lua")]
+    fn disabled_host_skips_init_files(with_init: bool) {
+        let dir = tempfile::tempdir().unwrap();
+        if with_init {
+            fs::create_dir_all(dir.path().join(".maki")).unwrap();
+            fs::write(dir.path().join(".maki/init.lua"), "error('should not run')").unwrap();
+        }
+        let host = PluginHost::disabled();
+        let config = host
+            .load_init_files(dir.path())
+            .expect("disabled host skips init");
+        assert!(config.is_none(), "disabled host returns no config");
+    }
+
+    #[test]
+    fn disabled_host_skips_load_builtins() {
+        let mut host = PluginHost::disabled();
+        let config = PluginsConfig::from_tools(HashMap::new());
+        assert!(
+            !config.tools.is_empty(),
+            "default config enables builtin plugins"
+        );
+        host.load_builtins(&config)
+            .expect("disabled host skips builtin plugin load");
     }
 
     #[test]

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -683,12 +683,12 @@ impl App {
             return actions;
         }
 
-        if let Some(actions) = self.handle_ctrl(key) {
-            return actions;
+        if self.dispatch_override(key) {
+            return vec![];
         }
 
-        if self.dispatch_plugin_keymap(key) {
-            return vec![];
+        if let Some(actions) = self.handle_ctrl(key) {
+            return actions;
         }
 
         if !self.is_main_chat() {
@@ -712,7 +712,7 @@ impl App {
         self.handle_main_chat_key(key)
     }
 
-    fn dispatch_plugin_keymap(&self, key: KeyEvent) -> bool {
+    fn dispatch_override(&self, key: KeyEvent) -> bool {
         let snap = self.keymap_reader.load();
         for entry in &snap.entries {
             if entry.key == key.code && entry.modifiers == key.modifiers {

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -683,7 +683,9 @@ impl App {
             return actions;
         }
 
-        if self.dispatch_override(key) {
+        if !(self.status == Status::Streaming && is_streaming_stop_key(key))
+            && self.dispatch_override(key)
+        {
             return vec![];
         }
 
@@ -715,10 +717,11 @@ impl App {
     fn dispatch_override(&self, key: KeyEvent) -> bool {
         let snap = self.keymap_reader.load();
         for entry in &snap.entries {
-            if entry.key == key.code && entry.modifiers == key.modifiers {
-                if let Some(ref handle) = self.lua_event_handle {
-                    handle.run_keybind_callback(entry.id);
-                }
+            if entry.key == key.code
+                && entry.modifiers == key.modifiers
+                && let Some(ref handle) = self.lua_event_handle
+                && handle.run_keybind_callback(entry.id)
+            {
                 return true;
             }
         }
@@ -1562,6 +1565,10 @@ impl App {
         actions.extend(self.start_from_queue(&msg));
         actions
     }
+}
+
+fn is_streaming_stop_key(key: KeyEvent) -> bool {
+    key::QUIT.matches(key) || key.code == KeyCode::Esc
 }
 
 fn sync_search_highlight(modal: &SearchModal, chat: &mut Chat) {

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -2339,6 +2339,8 @@ fn override_shadows_builtin_ctrl_when_no_overlay_open() {
     };
     let reader = maki_lua::test_support::keymap_reader_with(vec![entry]);
     let mut app = test_app();
+    let (handle, _probe) = maki_lua::test_support::probed_event_handle();
+    app.lua_event_handle = Some(handle);
     app.keymap_reader = reader;
     assert!(!app.help_modal.is_open());
 
@@ -2362,6 +2364,8 @@ fn override_shadows_quit_builtin() {
     };
     let reader = maki_lua::test_support::keymap_reader_with(vec![entry]);
     let mut app = test_app();
+    let (handle, _probe) = maki_lua::test_support::probed_event_handle();
+    app.lua_event_handle = Some(handle);
     app.status = Status::Idle;
     app.keymap_reader = reader;
 
@@ -2386,6 +2390,8 @@ fn override_shadows_tab_mode_toggle() {
     };
     let reader = maki_lua::test_support::keymap_reader_with(vec![entry]);
     let mut app = test_app();
+    let (handle, _probe) = maki_lua::test_support::probed_event_handle();
+    app.lua_event_handle = Some(handle);
     let initial_mode = app.state.mode;
     app.keymap_reader = reader;
 
@@ -2409,6 +2415,8 @@ fn override_shadows_esc_builtin() {
     };
     let reader = maki_lua::test_support::keymap_reader_with(vec![entry]);
     let mut app = test_app();
+    let (handle, _probe) = maki_lua::test_support::probed_event_handle();
+    app.lua_event_handle = Some(handle);
     app.keymap_reader = reader;
 
     let actions = app.update(Msg::Key(key(KeyCode::Esc)));
@@ -2470,6 +2478,83 @@ fn overlay_wins_over_override_when_plan_form_open() {
     app.update(Msg::Key(kb::PLAN_TOGGLE.to_key_event()));
 
     assert!(!app.plan_form.is_visible());
+}
+
+#[test]
+fn streaming_cancel_wins_over_quit_override() {
+    let entry = maki_lua::KeymapEntry {
+        key: kb::QUIT.code,
+        modifiers: kb::QUIT.modifiers,
+        desc: "plugin quit override".into(),
+        plugin: std::sync::Arc::from("test-plugin"),
+        id: 7,
+    };
+    let reader = maki_lua::test_support::keymap_reader_with(vec![entry]);
+    let mut app = test_app();
+    let (handle, _probe) = maki_lua::test_support::probed_event_handle();
+    app.lua_event_handle = Some(handle);
+    app.status = Status::Streaming;
+    app.run_id = 1;
+    app.keymap_reader = reader;
+
+    let actions = app.update(Msg::Key(kb::QUIT.to_key_event()));
+
+    assert!(
+        matches!(&actions[0], Action::CancelAgent { .. }),
+        "built-in cancel must win while streaming even when Ctrl+C is overridden"
+    );
+    assert_eq!(app.status, Status::Idle);
+    assert_eq!(app.exit_request, ExitRequest::None);
+}
+
+#[test]
+fn dead_host_override_falls_back_to_builtin() {
+    let entry = maki_lua::KeymapEntry {
+        key: kb::HELP.code,
+        modifiers: kb::HELP.modifiers,
+        desc: "plugin help override".into(),
+        plugin: std::sync::Arc::from("test-plugin"),
+        id: 8,
+    };
+    let reader = maki_lua::test_support::keymap_reader_with(vec![entry]);
+    let mut app = test_app();
+    app.lua_event_handle = Some(maki_lua::EventHandle::disconnected_for_test());
+    app.keymap_reader = reader;
+    assert!(!app.help_modal.is_open());
+
+    app.update(Msg::Key(kb::HELP.to_key_event()));
+
+    assert!(
+        app.help_modal.is_open(),
+        "dead lua host must fall back to the built-in HELP handler"
+    );
+}
+
+#[test]
+fn streaming_cancel_wins_over_esc_override() {
+    let entry = maki_lua::KeymapEntry {
+        key: KeyCode::Esc,
+        modifiers: KeyModifiers::NONE,
+        desc: "plugin esc override".into(),
+        plugin: std::sync::Arc::from("test-plugin"),
+        id: 9,
+    };
+    let reader = maki_lua::test_support::keymap_reader_with(vec![entry]);
+    let mut app = test_app();
+    let (handle, _probe) = maki_lua::test_support::probed_event_handle();
+    app.lua_event_handle = Some(handle);
+    app.status = Status::Streaming;
+    app.run_id = 1;
+    app.last_esc = Some(Instant::now());
+    app.keymap_reader = reader;
+
+    let actions = app.update(Msg::Key(key(KeyCode::Esc)));
+
+    assert!(
+        matches!(&actions[0], Action::CancelAgent { .. }),
+        "built-in cancel must win while streaming even when Esc is overridden"
+    );
+    assert_eq!(app.status, Status::Idle);
 }
 
 #[test]

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -2329,6 +2329,150 @@ fn ctrl_t_noop_when_plan_not_ready() {
 }
 
 #[test]
+fn override_shadows_builtin_ctrl_when_no_overlay_open() {
+    let entry = maki_lua::KeymapEntry {
+        key: kb::HELP.code,
+        modifiers: kb::HELP.modifiers,
+        desc: "plugin help override".into(),
+        plugin: std::sync::Arc::from("test-plugin"),
+        id: 1,
+    };
+    let reader = maki_lua::test_support::keymap_reader_with(vec![entry]);
+    let mut app = test_app();
+    app.keymap_reader = reader;
+    assert!(!app.help_modal.is_open());
+
+    let actions = app.update(Msg::Key(kb::HELP.to_key_event()));
+
+    assert!(actions.is_empty());
+    assert!(
+        !app.help_modal.is_open(),
+        "override must consume the key before the built-in HELP handler runs"
+    );
+}
+
+#[test]
+fn override_shadows_quit_builtin() {
+    let entry = maki_lua::KeymapEntry {
+        key: kb::QUIT.code,
+        modifiers: kb::QUIT.modifiers,
+        desc: "plugin quit override".into(),
+        plugin: std::sync::Arc::from("test-plugin"),
+        id: 3,
+    };
+    let reader = maki_lua::test_support::keymap_reader_with(vec![entry]);
+    let mut app = test_app();
+    app.status = Status::Idle;
+    app.keymap_reader = reader;
+
+    let actions = app.update(Msg::Key(kb::QUIT.to_key_event()));
+
+    assert!(actions.is_empty());
+    assert_eq!(
+        app.exit_request,
+        ExitRequest::None,
+        "override must consume Ctrl+C before the built-in quit handler runs"
+    );
+}
+
+#[test]
+fn override_shadows_tab_mode_toggle() {
+    let entry = maki_lua::KeymapEntry {
+        key: KeyCode::Tab,
+        modifiers: KeyModifiers::NONE,
+        desc: "plugin tab override".into(),
+        plugin: std::sync::Arc::from("test-plugin"),
+        id: 4,
+    };
+    let reader = maki_lua::test_support::keymap_reader_with(vec![entry]);
+    let mut app = test_app();
+    let initial_mode = app.state.mode;
+    app.keymap_reader = reader;
+
+    let actions = app.update(Msg::Key(key(KeyCode::Tab)));
+
+    assert!(actions.is_empty());
+    assert_eq!(
+        app.state.mode, initial_mode,
+        "override must consume Tab before the built-in mode toggle runs"
+    );
+}
+
+#[test]
+fn override_shadows_esc_builtin() {
+    let entry = maki_lua::KeymapEntry {
+        key: KeyCode::Esc,
+        modifiers: KeyModifiers::NONE,
+        desc: "plugin esc override".into(),
+        plugin: std::sync::Arc::from("test-plugin"),
+        id: 5,
+    };
+    let reader = maki_lua::test_support::keymap_reader_with(vec![entry]);
+    let mut app = test_app();
+    app.keymap_reader = reader;
+
+    let actions = app.update(Msg::Key(key(KeyCode::Esc)));
+
+    assert!(actions.is_empty());
+    assert!(
+        app.last_esc.is_none(),
+        "override must consume Esc before the built-in esc handler runs"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn override_does_not_shadow_suspend() {
+    let entry = maki_lua::KeymapEntry {
+        key: kb::SUSPEND.code,
+        modifiers: kb::SUSPEND.modifiers,
+        desc: "plugin suspend override".into(),
+        plugin: std::sync::Arc::from("test-plugin"),
+        id: 6,
+    };
+    let reader = maki_lua::test_support::keymap_reader_with(vec![entry]);
+    let mut app = test_app();
+    app.keymap_reader = reader;
+
+    let actions = app.update(Msg::Key(kb::SUSPEND.to_key_event()));
+
+    assert!(
+        actions.iter().any(|a| matches!(a, Action::Suspend)),
+        "suspend is non-remappable: override must not shadow Ctrl+Z"
+    );
+}
+
+#[test]
+fn builtin_runs_when_no_override() {
+    let mut app = test_app();
+    assert!(!app.help_modal.is_open());
+
+    app.update(Msg::Key(kb::HELP.to_key_event()));
+
+    assert!(app.help_modal.is_open());
+}
+
+#[test]
+fn overlay_wins_over_override_when_plan_form_open() {
+    let entry = maki_lua::KeymapEntry {
+        key: kb::PLAN_TOGGLE.code,
+        modifiers: kb::PLAN_TOGGLE.modifiers,
+        desc: "plugin plan override".into(),
+        plugin: std::sync::Arc::from("test-plugin"),
+        id: 2,
+    };
+    let reader = maki_lua::test_support::keymap_reader_with(vec![entry]);
+    let mut app = plan_app();
+    app.keymap_reader = reader;
+    assert!(app.plan_form.is_visible());
+    assert!(app.lua_event_handle.is_none());
+
+    app.update(Msg::Key(kb::PLAN_TOGGLE.to_key_event()));
+
+    assert!(!app.plan_form.is_visible());
+}
+
+#[test]
 fn reset_session_closes_plan_form() {
     let mut app = plan_app();
     assert!(app.plan_form.is_visible());

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -92,7 +92,7 @@ Some pickers add extra bindings on top of the defaults:
 
 Child contexts inherit their parent's bindings and add their own.
 
-- **Pickers** is the base for: Task Picker, Session Picker, Rewind Picker, Theme Picker, Model Picker, Queue, Commands, Search, File Picker
+- **Pickers** is the base for: Task Picker, Rewind Picker, Theme Picker, Model Picker, Queue, Commands, Search, File Picker
 
 ## Overriding Keybindings
 

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -92,4 +92,31 @@ Some pickers add extra bindings on top of the defaults:
 
 Child contexts inherit their parent's bindings and add their own.
 
-- **Pickers** is the base for: Task Picker, Rewind Picker, Theme Picker, Model Picker, Queue, Commands, Search, File Picker
+- **Pickers** is the base for: Task Picker, Session Picker, Rewind Picker, Theme Picker, Model Picker, Queue, Commands, Search, File Picker
+
+## Overriding Keybindings
+
+Plugins and `init.lua` can rebind keys at runtime with `maki.keymap.set` and `maki.keymap.del`. The tables above are the built-in defaults. An override on the same key wins, unless a modal or overlay is open (help, plan form, permission prompt).
+
+Precedence, high to low:
+
+1. **Suspend** (`Ctrl+Z`, Unix). Always wins, non-remappable.
+2. **Modal and overlay keys.** An open modal or picker consumes its keys first, so they cannot be shadowed while open.
+3. **Lua overrides** from `maki.keymap.set`. Last set wins; binding the same key twice warns.
+4. **Built-in defaults.** An override on the same key shadows them; `maki.keymap.del` lifts the override so the default returns. Suspend is the only binding outside this layer, so every key is remappable except `Ctrl+Z`.
+
+Only single-key bindings can be overridden. Multi-key combinations and non-key rows (like `Type` to filter) cannot.
+
+The `/help` modal and the splash show default labels, not live overrides, but pressing the key still runs the override.
+
+### Recovering from a bad keymap
+
+If an override leaves Maki stuck (a rebound `Ctrl+C`, a modal that won't close, a plugin that throws on load), boot without plugins:
+
+```bash
+maki --no-plugins
+```
+
+This skips the Lua host and runs the full default keymap from Rust, so quit, Esc, scroll, and suspend always work.
+
+The defaults live in Rust, not Lua, so `--no-plugins` never drops them.

--- a/site/docs/content/quick-start/_index.md
+++ b/site/docs/content/quick-start/_index.md
@@ -85,6 +85,8 @@ Type a prompt, press **Enter**, and the agent starts working.
 
 ## Keybindings
 
+These are the defaults. Plugins and `init.lua` can rebind most of them with `maki.keymap.set`; see [Keybindings](../keybindings/) for precedence and caveats.
+
 - **Newline in input**: \\+Enter, Ctrl+J, or Alt+Enter
 - **Scroll output**: Ctrl+U / Ctrl+D (half page)
 - **Cancel streaming**: Esc Esc


### PR DESCRIPTION
To prep for allowing ~almost~ full configurability of the keymap via Lua, this PR changes keymap logic to run Lua keymap overrides before the built-in `Ctrl-*` handlers. Bonus, `Ctrl+t` for `todo_write` no longer collides with `key::PLAN_TOGGLE`. Manually tested.

While I was at it, I added docs for keymap overrides, and some unit tests that felt valuable. `--no-plugins` is documented on the keybindings page as the recovery path when an override breaks a session.

The follow-ups, by the way:
1. Put `maki-keymap.set`/`del` behind a new `keymap` plugin permission to allow blocking Quit/Suspend/etc. overrides from malicious plugins.
2. Have the `/help` modal and splash screen reflect live overrides instead of the hard-coded constants.
3. Move config of default keymappings into Lua, ensure that unset keymappings are handled in Lua and warned on.

Implemented with Maki + GLM-5.2.