### PR TITLE
feat(memory): tags-first redesign with sectioned ListPicker

### DIFF
--- a/maki-docgen/src/gen_commands.rs
+++ b/maki-docgen/src/gen_commands.rs
@@ -4,6 +4,10 @@ use maki_ui::BUILTIN_COMMANDS;
 
 use crate::lua_util;
 
+fn write_row(out: &mut String, name: &str, description: &str) {
+    writeln!(out, "| `{name}` | {} |", description.replace('|', "\\|")).unwrap();
+}
+
 pub fn generate() -> String {
     let mut out = String::new();
     writeln!(out, "+++").unwrap();
@@ -27,10 +31,10 @@ pub fn generate() -> String {
     writeln!(out, "| Command | Description |").unwrap();
     writeln!(out, "|---------|-------------|").unwrap();
     for cmd in BUILTIN_COMMANDS {
-        writeln!(out, "| `{}` | {} |", cmd.name, cmd.description).unwrap();
+        write_row(&mut out, cmd.name, cmd.description);
     }
     for cmd in &lua_util::load_builtin_plugin_commands() {
-        writeln!(out, "| `{}` | {} |", cmd.name, cmd.description).unwrap();
+        write_row(&mut out, &cmd.name, &cmd.description);
     }
 
     writeln!(out).unwrap();

--- a/maki-docgen/src/gen_tools.rs
+++ b/maki-docgen/src/gen_tools.rs
@@ -119,7 +119,7 @@ fn write_param_table(out: &mut String, params: &[Param]) {
     };
     writeln!(out, "{header}").unwrap();
     for p in params {
-        let desc = p.description.replace('\n', "<br>");
+        let desc = p.description.replace('|', "\\|").replace('\n', "<br>");
         let required = if p.required { "yes" } else { "no" };
         if has_defaults {
             writeln!(

--- a/maki-lua/src/api/fs.rs
+++ b/maki-lua/src/api/fs.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use std::fs::FileType;
 use std::io::ErrorKind;
 use std::path::{Component, Path, PathBuf};
+use std::time::UNIX_EPOCH;
 
 use maki_lua_macro::{lua_fn, lua_table};
 use mlua::{IntoLua, Lua, Result as LuaResult, Table, Value};
@@ -147,7 +148,9 @@ async fn read_bytes(lua: Lua, path: String) -> LuaResult<(Value, Value)> {
 }
 
 /// Get metadata for the file or directory at {path}.
-/// Returns a table with `size` (integer), `is_file` (boolean), and `is_dir` (boolean).
+/// Returns a table with `size` (integer), `is_file` (boolean), `is_dir` (boolean),
+/// and `mtime` (number, fractional seconds since the Unix epoch; absent when the
+/// filesystem does not report a modification time).
 /// If {path} does not exist, returns nil with no error.
 ///
 /// @param path string Absolute or relative path.
@@ -166,6 +169,11 @@ async fn metadata(lua: Lua, path: String) -> LuaResult<(Value, Value)> {
             tbl.set("size", meta.len())?;
             tbl.set("is_file", meta.is_file())?;
             tbl.set("is_dir", meta.is_dir())?;
+            if let Ok(modified) = meta.modified()
+                && let Ok(dur) = modified.duration_since(UNIX_EPOCH)
+            {
+                tbl.set("mtime", dur.as_secs_f64())?;
+            }
             Ok((Value::Table(tbl), Value::Nil))
         }
         Err(e) if e.kind() == ErrorKind::NotFound => Ok((Value::Nil, Value::Nil)),
@@ -816,6 +824,7 @@ mod tests {
         assert!(f.get::<bool>("is_file").unwrap());
         assert!(!f.get::<bool>("is_dir").unwrap());
         assert_eq!(f.get::<u64>("size").unwrap(), 5);
+        assert!(f.get::<f64>("mtime").unwrap() > 0.0);
 
         let d: Table =
             smol::block_on(metadata.call_async::<Table>(tmp.path().to_str().unwrap())).unwrap();

--- a/maki-ui/src/components/scrollbar.rs
+++ b/maki-ui/src/components/scrollbar.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
 use ratatui::widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState};
 
 pub const SCROLLBAR_THUMB: &str = "\u{2590}";
@@ -23,6 +24,9 @@ pub fn render_vertical_scrollbar(frame: &mut Frame, area: Rect, content_len: u16
 
     let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
         .thumb_symbol(SCROLLBAR_THUMB)
+        // ListPicker renders highlighted rows over the scrollbar track; resetting
+        // the thumb style keeps its color stable instead of inheriting row bg.
+        .thumb_style(Style::new().fg(Color::Reset).bg(Color::Reset))
         .track_symbol(None)
         .begin_symbol(None)
         .end_symbol(None);

--- a/maki-ui/src/theme.rs
+++ b/maki-ui/src/theme.rs
@@ -338,6 +338,7 @@ pub fn style_by_name(name: &str) -> Style {
         "active" => t.active,
         "keybind_key" => t.keybind_key,
         "keybind_desc" => t.keybind_desc,
+        "keybind_section" => t.keybind_section,
         "success" | "todo_completed" => t.todo_completed,
         "warning" | "todo_in_progress" => t.todo_in_progress,
         "todo_pending" | "pending" => t.todo_pending,
@@ -1121,6 +1122,7 @@ mode_build = "#112233"
         assert_eq!(style_by_name("foreground"), Style::new().fg(t.foreground));
         assert_eq!(style_by_name("keybind_key"), t.keybind_key);
         assert_eq!(style_by_name("keybind_desc"), t.keybind_desc);
+        assert_eq!(style_by_name("keybind_section"), t.keybind_section);
         assert_eq!(style_by_name("selected"), t.item_selected);
         assert_eq!(style_by_name("success"), t.todo_completed);
         assert_eq!(style_by_name("warning"), t.todo_in_progress);

--- a/plugins/lib/maki/list_picker.lua
+++ b/plugins/lib/maki/list_picker.lua
@@ -70,6 +70,38 @@ local function highlight_spans(label, words, base, match_style)
   return spans
 end
 
+local function item_label(item)
+  return type(item) == "string" and item or item.label
+end
+
+local function item_section(item)
+  return type(item) == "table" and item.section or nil
+end
+
+local function next_section(item, prev)
+  local s = item_section(item)
+  if s and s ~= prev then
+    return s
+  end
+  return nil
+end
+
+local function section_rows(items)
+  local n = 0
+  local prev = nil
+  for _, item in ipairs(items) do
+    local s = next_section(item, prev)
+    if s then
+      n = n + 1
+      prev = s
+    end
+  end
+  if n == 0 then
+    return 0
+  end
+  return item_section(items[1]) and 2 * n - 1 or 2 * n
+end
+
 local function filter_items(items, query)
   local words = split_words(query)
   if #words == 0 then
@@ -81,8 +113,9 @@ local function filter_items(items, query)
   end
   local filtered, indices = {}, {}
   for i, item in ipairs(items) do
-    local label = type(item) == "string" and item or item.label
-    if matches(label, words) then
+    local section = item_section(item)
+    local hay = section and (item_label(item) .. " " .. section) or item_label(item)
+    if matches(hay, words) then
       filtered[#filtered + 1] = item
       indices[#indices + 1] = i
     end
@@ -94,13 +127,31 @@ local function render_lines(items, selected, width, query)
   width = width or 80
   local words = split_words(query)
   local lines = {}
+  local item_lines = {}
+  local prev_section = nil
   for i, item in ipairs(items) do
-    local label = type(item) == "string" and item or item.label
+    local label = item_label(item)
     local detail = type(item) == "table" and item.detail or nil
+    local section = next_section(item, prev_section)
     local is_sel = (i == selected)
     local style = is_sel and "selected" or "item"
     local detail_style = is_sel and "selected" or "dim"
     local match_style = is_sel and "match_selected" or "match"
+
+    if section then
+      if #lines > 0 then
+        lines[#lines + 1] = {}
+      end
+      local header = { { "  " .. section, "keybind_section" } }
+      local section_detail = type(item) == "table" and item.section_detail or nil
+      if section_detail then
+        header[#header + 1] = { " " .. section_detail, "dim" }
+      end
+      lines[#lines + 1] = header
+      prev_section = section
+    end
+
+    item_lines[i] = #lines + 1
 
     local spans = highlight_spans(label, words, style, match_style)
     if spans[1][2] == style then
@@ -126,7 +177,7 @@ local function render_lines(items, selected, width, query)
 
     lines[#lines + 1] = spans
   end
-  return lines
+  return lines, item_lines
 end
 
 -- Open a fuzzy-filter picker in a floating window and block until the user
@@ -147,13 +198,15 @@ function ListPicker.open(items, opts)
   local filtered, original_indices = filter_items(items, "")
 
   local cursor = math.max(math.min(opts.cursor or 1, #filtered), 1)
+  local item_lines = {}
 
   local function build_lines()
     local content
     if #filtered == 0 then
       content = { { { NO_MATCHES_LABEL, "dim" } } }
+      item_lines = {}
     else
-      content = render_lines(filtered, cursor, width, input:value())
+      content, item_lines = render_lines(filtered, cursor, width, input:value())
     end
     local r = input:render("\xe2\x9d\xaf ")
     for _, ln in ipairs(r.lines) do
@@ -165,7 +218,7 @@ function ListPicker.open(items, opts)
   local buf = maki.ui.buf()
 
   local border_chrome = 2
-  local content_h = #items + 1
+  local content_h = #items + section_rows(items) + 1
   local total_h = content_h + border_chrome
 
   local win = maki.ui.open_win(buf, {
@@ -180,12 +233,13 @@ function ListPicker.open(items, opts)
   local confirming = nil
 
   local function move_cursor(to)
-    if #filtered == 0 then
-      return
+    if #filtered > 0 then
+      cursor = math.max(math.min(to, #filtered), 1)
     end
-    cursor = math.max(math.min(to, #filtered), 1)
     buf:set_lines(build_lines())
-    win:set_cursor(cursor)
+    if item_lines[cursor] then
+      win:set_cursor(item_lines[cursor])
+    end
     confirming = nil
   end
 
@@ -254,5 +308,6 @@ ListPicker.highlight_spans = highlight_spans
 
 ListPicker._render_lines = render_lines
 ListPicker._filter_items = filter_items
+ListPicker._section_rows = section_rows
 
 return ListPicker

--- a/plugins/lib/tests/spec.lua
+++ b/plugins/lib/tests/spec.lua
@@ -1267,6 +1267,29 @@ case("filter_items_every_word_must_match", function()
   eq(filtered[1], "review gh pr 441")
 end)
 
+case("filter_items_matches_section", function()
+  local items = {
+    { label = "a.md", section = "auth (2)" },
+    { label = "b.md", section = "auth (2)" },
+    { label = "c.md", section = "storage (1)" },
+  }
+  local filtered, indices = filter_items(items, "auth")
+  eq(#filtered, 2, "typing a section name keeps its items")
+  eq(filtered[1].label, "a.md")
+  eq(filtered[2].label, "b.md")
+  eq(indices[2], 2)
+end)
+
+case("filter_items_words_split_across_label_and_section", function()
+  local items = {
+    { label = "gotchas.md", section = "auth (2)" },
+    { label = "notes.md", section = "auth (2)" },
+  }
+  local filtered = filter_items(items, "auth gotchas")
+  eq(#filtered, 1)
+  eq(filtered[1].label, "gotchas.md")
+end)
+
 case("highlight_spans_overlapping_words_merge", function()
   local spans = ListPicker.highlight_spans("alphabet", { "alpha", "phab" }, "item", "match")
   eq(#spans, 2)
@@ -1295,6 +1318,57 @@ case("render_lines_match_at_start_keeps_indent", function()
   eq(lines[1][1][2], "selected")
   eq(lines[1][2][1], "al")
   eq(lines[1][2][2], "match_selected")
+end)
+
+case("render_lines_sections_headers_and_item_lines", function()
+  local items = {
+    { label = "a", section = "auth", section_detail = "(2)" },
+    { label = "b", section = "auth", section_detail = "(2)" },
+    { label = "c", section = "storage" },
+  }
+  local lines, item_lines = render_lines(items, 1, 40)
+  eq(#lines, 6, "two headers + blank gap + three items, header never repeats within a section")
+  eq(lines[1][1][1], "  auth")
+  eq(lines[1][1][2], "keybind_section")
+  eq(lines[1][2][1], " (2)", "section detail rendered after the header")
+  eq(lines[1][2][2], "dim")
+  eq(lines[2][1][1], "  a")
+  eq(lines[3][1][1], "  b")
+  eq(#lines[4], 0, "blank line between sections")
+  eq(lines[5][1][1], "  storage")
+  eq(#lines[5], 1, "no detail span without section_detail")
+  eq(lines[6][1][1], "  c")
+  eq(item_lines[1], 2, "cursor mapping skips the header")
+  eq(item_lines[2], 3)
+  eq(item_lines[3], 6)
+end)
+
+case("render_lines_item_lines_identity_without_sections", function()
+  local lines, item_lines = render_lines({ "a", "b", "c" }, 1, 40)
+  eq(#lines, 3)
+  for i = 1, 3 do
+    eq(item_lines[i], i, "plain list maps item " .. i .. " straight to its line")
+  end
+end)
+
+case("section_rows_counts_headers_and_gaps", function()
+  local section_rows = ListPicker._section_rows
+  eq(section_rows({ "a", "b" }), 0)
+  eq(section_rows({ { label = "a", section = "s" }, "b" }), 1, "header on line one needs no gap")
+  eq(section_rows({ "a", { label = "b", section = "s" } }), 2, "gap precedes a header that follows items")
+  eq(section_rows({ { label = "a", section = "s" }, { label = "b", section = "t" } }), 3)
+end)
+
+case("render_lines_nil_sections_mix_with_grouped", function()
+  local lines = render_lines({ "plain", { label = "x", section = "grp" } }, 1, 40)
+  eq(lines[1][1][1], "  plain", "no header for a nil-section first item")
+  eq(#lines[2], 0, "blank line before a header that follows items")
+  eq(lines[3][1][1], "  grp")
+  eq(lines[4][1][1], "  x")
+
+  local _, item_lines = render_lines({ { label = "a", section = "grp" }, "b" }, 1, 40)
+  eq(item_lines[1], 2, "grouped item sits under its header")
+  eq(item_lines[2], 3, "nil-section item follows without a new header")
 end)
 
 if #failures > 0 then

--- a/plugins/memory/init.lua
+++ b/plugins/memory/init.lua
@@ -34,18 +34,11 @@ maki.api.register_prompt_hint({
     if not dir then
       return nil
     end
-    local entries = helpers.collect_file_entries(dir)
-    if #entries == 0 then
+    local tag_line = helpers.format_tag_line(dir, helpers.MAX_TAGS)
+    if not tag_line then
       return nil
     end
-    table.sort(entries, function(a, b)
-      return a[1] < b[1]
-    end)
-    local out = "\n\nMemory files (use the memory tool to view/update):\n"
-    for _, e in ipairs(entries) do
-      out = out .. "- " .. e[1] .. " (" .. e[2] .. " bytes)\n"
-    end
-    return out
+    return "\n\nMemory tags (memory tool, `read tags=[...]`): " .. tag_line .. "\n"
   end,
 })
 
@@ -73,10 +66,7 @@ local function render_content(content, path, ctx)
   return buf
 end
 
-local function cmd_view(path, dir, ctx)
-  if not path then
-    return helpers.list_memories(dir)
-  end
+local function cmd_read(path, dir, ctx)
   local file_path, err = helpers.safe_resolve(dir, path)
   if not file_path then
     return nil, err
@@ -85,33 +75,41 @@ local function cmd_view(path, dir, ctx)
   if not content then
     return nil, "read error: " .. err
   end
+  local formatted =
+    helpers.cap_read_output(helpers.format_read_entry(path, #content, content), helpers.CAP_HINT_REWRITE)
   return {
-    llm_output = content,
-    body = render_content(content, path, ctx),
+    llm_output = formatted,
+    body = render_content(formatted, path, ctx),
   }
 end
 
-local function cmd_write(path, content, dir, ctx)
-  local lc = helpers.count_lines(content)
-  if lc > helpers.MAX_LINES_PER_FILE then
-    return nil, "content exceeds " .. helpers.MAX_LINES_PER_FILE .. " lines (" .. lc .. " lines); reduce content size"
-  end
+local function cmd_write(path, content, tags, dir, ctx)
   local file_path, err = helpers.safe_resolve(dir, path)
   if not file_path then
     return nil, err
   end
-  local meta = maki.fs.metadata(file_path)
-  local existing_size = meta and meta.size or 0
-  if helpers.dir_total_bytes(dir) - existing_size + #content > helpers.MAX_DIR_BYTES then
-    return nil, "memory directory would exceed " .. helpers.MAX_DIR_BYTES .. " byte limit; delete stale entries first"
+
+  local size_err = helpers.validate_write_size(content)
+  if size_err then
+    return nil, size_err
   end
+  local normalized, tag_err, note = helpers.validate_write_tags(tags or {})
+  if tag_err then
+    return nil, tag_err
+  end
+  local full = helpers.encode_frontmatter(normalized) .. content
   maki.fs.mkdir(dir, { parents = true })
-  local ok, write_err = maki.fs.write(file_path, content)
+  local ok, write_err = maki.fs.write(file_path, full)
   if not ok then
     return nil, "write error: " .. tostring(write_err)
   end
   return {
-    llm_output = "wrote " .. path .. " (" .. lc .. " lines)",
+    llm_output = "wrote "
+      .. path
+      .. " (tags: "
+      .. (#normalized > 0 and table.concat(normalized, ", ") or "none")
+      .. ")"
+      .. (note and ("; " .. note) or ""),
     body = render_content(content, path, ctx),
   }
 end
@@ -134,58 +132,77 @@ end
 maki.api.register_tool({
   name = "memory",
   description = "Persistent, project-scoped scratchpad for learnings, patterns, decisions, and gotchas across sessions.\n\n"
+    .. "- Notes are retrieved by tag; reuse the tags from your system prompt when they fit.\n"
     .. "- Save important context before compaction or to build up project knowledge.\n"
     .. "- Keep entries concise and current. Delete outdated information.",
 
   schema = {
     type = "object",
     properties = {
-      command = { type = "string", description = "Command: view, write, delete", required = true },
-      path = { type = "string", description = "Relative path (e.g. 'architecture.md'). Omit to list all." },
-      content = { type = "string", description = "File content for 'write'" },
+      command = {
+        type = "string",
+        enum = { "list", "read", "write", "delete" },
+        description = "- `list [tags]`: tag-grouped index, no bodies.\n"
+          .. "- `read path|tags`: one body (path) or collated bodies (tags).\n"
+          .. "- `write path tags content`: create or overwrite a note.\n"
+          .. "- `delete path`",
+        required = true,
+      },
+      path = {
+        type = "string",
+        description = "Relative path, e.g. 'architecture.md'.",
+      },
+      content = { type = "string", description = "Body for write (frontmatter added automatically)." },
+      tags = {
+        type = "array",
+        items = { type = "string" },
+        description = "snake_case tags. Filter for list/read; assigned on write (defaults to filename stem).",
+      },
     },
   },
 
   header = function(input)
+    local parts = { input.command or "" }
     if input.path then
-      return (input.command or "") .. " " .. input.path
+      parts[#parts + 1] = input.path
+    elseif input.tags then
+      parts[#parts + 1] = table.concat(input.tags, ",")
     end
-    return input.command
+    return table.concat(parts, " ")
   end,
 
   restore = function(input, output, _is_error, ctx)
     local content = (input.command == "write" and input.content) or output
-    return render_content(content, input.path or "file.md", ctx)
+    return render_content(content, input.path or "memory.md", ctx)
   end,
 
   handler = function(input, ctx)
+    if type(input.tags) == "string" then
+      input.tags = { input.tags }
+    end
+    local verr = helpers.validate_input(input)
+    if verr then
+      return { llm_output = "error: " .. verr, is_error = true }
+    end
     local cmd = input.command
-    local dir, dir_err = resolve_dir(cmd == "view")
+    local dir, dir_err = resolve_dir(cmd == "list" or cmd == "read")
     if not dir then
       return { llm_output = "error: " .. dir_err, is_error = true }
     end
 
     local result, err
-    if cmd == "view" then
-      result, err = cmd_view(input.path, dir, ctx)
+    if cmd == "list" then
+      result, err = helpers.format_list(dir, input.tags)
+    elseif cmd == "read" then
+      if input.tags and #input.tags > 0 then
+        result, err = helpers.format_read(dir, input.tags)
+      else
+        result, err = cmd_read(input.path, dir, ctx)
+      end
     elseif cmd == "write" then
-      if not input.path then
-        return { llm_output = "error: 'path' is required for write", is_error = true }
-      end
-      if not input.content then
-        return { llm_output = "error: 'content' is required for write", is_error = true }
-      end
-      result, err = cmd_write(input.path, input.content, dir, ctx)
+      result, err = cmd_write(input.path, input.content, input.tags, dir, ctx)
     elseif cmd == "delete" then
-      if not input.path then
-        return { llm_output = "error: 'path' is required for delete", is_error = true }
-      end
       result, err = cmd_delete(input.path, dir)
-    else
-      return {
-        llm_output = "error: unknown command '" .. tostring(cmd) .. "'. Valid commands: view, write, delete",
-        is_error = true,
-      }
     end
     if err then
       return { llm_output = "error: " .. err, is_error = true }
@@ -193,6 +210,22 @@ maki.api.register_tool({
     return result
   end,
 })
+
+local function popup_build_items(dir)
+  local groups, warnings = helpers.grouped_tags(dir)
+  local items = {}
+  for _, g in ipairs(groups) do
+    for _, f in ipairs(g.files) do
+      items[#items + 1] = {
+        label = f.name,
+        detail = "(" .. f.size .. " bytes)",
+        section = g.tag,
+        section_detail = "(" .. #g.files .. ")",
+      }
+    end
+  end
+  return items, warnings
+end
 
 maki.api.register_command({
   name = "/memory",
@@ -204,26 +237,20 @@ maki.api.register_command({
       return
     end
 
-    local entries = helpers.collect_file_entries(dir)
-    if #entries == 0 then
-      maki.ui.flash("No memory files yet")
+    local items, warnings = popup_build_items(dir)
+    if #items == 0 then
+      maki.ui.flash("No memories yet")
       return
     end
-    table.sort(entries, function(a, b)
-      return a[1] < b[1]
-    end)
-
-    local function build_items()
-      local items = {}
-      for _, e in ipairs(entries) do
-        items[#items + 1] = { label = e[1], detail = "(" .. e[2] .. " bytes)" }
-      end
-      return items
+    if #warnings > 0 then
+      maki.ui.flash(#warnings .. " unreadable memory file(s)")
     end
-
     local last_cursor = 1
     while true do
-      local event = ListPicker.open(build_items(), {
+      if last_cursor > #items then
+        last_cursor = math.max(1, #items)
+      end
+      local event = ListPicker.open(items, {
         title = " Memory Files ",
         cursor = last_cursor,
         submit_keys = { "ctrl+o" },
@@ -240,28 +267,22 @@ maki.api.register_command({
 
       last_cursor = event.index
       if event.type == "choice" then
-        local item = entries[event.index]
+        local item = items[event.index]
         if item then
-          local path = maki.fs.joinpath(dir, item[1])
+          local path = maki.fs.joinpath(dir, item.label)
           local code = maki.ui.open_editor(path)
           if code == 0 then
-            local meta = maki.fs.metadata(path)
-            if meta then
-              item[2] = meta.size
-            end
+            items = popup_build_items(dir)
           end
         end
       elseif event.type == "delete" then
-        local item = entries[event.index]
-        local ok, err = maki.fs.rm(maki.fs.joinpath(dir, item[1]))
+        local item = items[event.index]
+        local ok, err = maki.fs.rm(maki.fs.joinpath(dir, item.label))
         if ok then
-          maki.ui.flash("Deleted " .. item[1])
-          table.remove(entries, event.index)
-          if #entries == 0 then
+          maki.ui.flash("Deleted " .. item.label)
+          items = popup_build_items(dir)
+          if #items == 0 then
             break
-          end
-          if last_cursor > #entries then
-            last_cursor = #entries
           end
         else
           maki.ui.flash("Delete failed: " .. tostring(err))

--- a/plugins/memory/memory_helpers.lua
+++ b/plugins/memory/memory_helpers.lua
@@ -1,7 +1,25 @@
 local M = {}
 
-M.MAX_LINES_PER_FILE = 200
-M.MAX_DIR_BYTES = 50 * 1024
+M.MAX_TAGS = 50
+M.MAX_FILE_BYTES = 20 * 1024
+M.CAP_HINT_REWRITE = "rewrite the memory to fit under the cap"
+M.CAP_HINT_NARROW = "narrow tags or read files by path"
+M.CAP_HINT_FILTER = "pass tags=[...] to filter the list"
+M.NO_MEMORIES_MSG = "No memories yet."
+
+local MAX_TAG_LEN = 64
+local MAX_REJECT_DISPLAY = 64
+local WRITE_REJECT_PREFIX = "invalid tag(s) rejected: "
+local READ_REJECT_PREFIX = "warning: ignored invalid tag(s): "
+local UNREADABLE_PREFIX = "warning: unreadable memory files: "
+local NO_MATCH_MSG = "no memory files matched any of the given tags; use `list` to see available tags"
+local PRUNE_ADVISORY = "Consider removing or consolidating stale memories to stay under " .. M.MAX_TAGS .. " tags."
+
+local COMMANDS = { "list", "read", "write", "delete" }
+local VALID_COMMANDS = {}
+for _, c in ipairs(COMMANDS) do
+  VALID_COMMANDS[c] = true
+end
 
 -- Lua's bit32 is 32-bit only, so we split the 64-bit FNV-1a state into
 -- hi/lo halves and propagate carries by hand during multiplication.
@@ -22,36 +40,17 @@ function M.fnv1a_64(data)
   return string.format("%08x%08x", hi, lo)
 end
 
--- Counts lines the way editors do: empty string is 1 line,
--- and a trailing newline does not start a new line.
-function M.count_lines(s)
-  if s == "" then
-    return 1
-  end
-  local _, newlines = s:gsub("\n", "")
-  if s:sub(-1) == "\n" then
-    return math.max(newlines, 1)
-  end
-  return newlines + 1
-end
-
 function M.project_id(path)
   local base = maki.fs.basename(path) or "root"
   return base .. "-" .. M.fnv1a_64(path)
 end
 
--- Normalize both paths and check the prefix to block "../" traversal
--- out of the memories sandbox.
 function M.safe_resolve(memories_dir, relative)
   if not relative or relative == "" then
     return nil, "path is required"
   end
   local first = relative:sub(1, 1)
-  if relative:find("\0") or first == "/" or first == "\\" then
-    return nil, "path must be relative"
-  end
-  -- Drive letter (C:\, D:/)
-  if relative:match("^%a:") then
+  if relative:find("\0") or first == "/" or first == "\\" or relative:match("^%a:") then
     return nil, "path must be relative"
   end
   local resolved = maki.fs.normalize(maki.fs.joinpath(memories_dir, relative))
@@ -64,48 +63,386 @@ function M.safe_resolve(memories_dir, relative)
   return resolved
 end
 
-function M.collect_file_entries(dir)
-  local entries = maki.fs.dir(dir)
-  if not entries then
-    return {}
-  end
+local function file_entries(dir)
   local files = {}
-  for _, entry in ipairs(entries) do
+  for _, entry in ipairs(maki.fs.dir(dir) or {}) do
     if entry[2] == "file" then
       local meta = maki.fs.metadata(maki.fs.joinpath(dir, entry[1]))
       if meta then
-        files[#files + 1] = { entry[1], meta.size }
+        files[#files + 1] = { entry[1], meta.size, meta.mtime }
       end
     end
-  end
-  return files
-end
-
-function M.dir_total_bytes(dir)
-  local total = 0
-  for _, f in ipairs(M.collect_file_entries(dir)) do
-    total = total + f[2]
-  end
-  return total
-end
-
-function M.list_memories(dir)
-  local files = M.collect_file_entries(dir)
-  if #files == 0 then
-    return "No memories yet."
   end
   table.sort(files, function(a, b)
     return a[1] < b[1]
   end)
-  local lines = {}
-  local total = 0
-  for _, f in ipairs(files) do
-    lines[#lines + 1] = f[1] .. " (" .. f[2] .. " bytes)"
-    total = total + f[2]
+  return files
+end
+
+-- Coerces rather than rejects: any non-alphanumeric run becomes "_".
+-- Returns nil only when nothing survives.
+function M.normalize_tag(raw)
+  if raw == nil then
+    return nil
   end
-  lines[#lines + 1] = ""
-  lines[#lines + 1] = #files .. " files, " .. total .. " bytes total"
-  return table.concat(lines, "\n")
+  local s = tostring(raw):lower():gsub("[^%a%d]+", "_"):gsub("^_+", ""):gsub("_+$", "")
+  if s == "" then
+    return nil
+  end
+  return s:sub(1, MAX_TAG_LEN)
+end
+
+local function stem_tag(path)
+  local base = maki.fs.basename(path) or path
+  local stem = base:gsub("%.[^.]*$", "")
+  if stem == "" then
+    stem = base
+  end
+  return M.normalize_tag(stem) or "untagged"
+end
+
+function M.normalize_tags(list)
+  local seen, out, rejected, coerced = {}, {}, {}, {}
+  for _, t in ipairs(list) do
+    local n = M.normalize_tag(t)
+    if n then
+      if not seen[n] then
+        seen[n] = true
+        out[#out + 1] = n
+      end
+      if n ~= tostring(t) then
+        coerced[#coerced + 1] = tostring(t) .. " -> " .. n
+      end
+    else
+      rejected[#rejected + 1] = tostring(t)
+    end
+  end
+  return out, rejected, coerced
+end
+
+function M.format_rejected(rejected)
+  if not rejected or #rejected == 0 then
+    return nil
+  end
+  local out = {}
+  for i, v in ipairs(rejected) do
+    out[i] = #v > MAX_REJECT_DISPLAY and v:sub(1, MAX_REJECT_DISPLAY) .. "..." or v
+  end
+  return table.concat(out, ", ")
+end
+
+function M.validate_input(input)
+  local cmd = input.command
+  if not VALID_COMMANDS[cmd] then
+    return "unknown command '" .. tostring(cmd) .. "'. Valid commands: " .. table.concat(COMMANDS, ", ")
+  end
+  if input.tags ~= nil and type(input.tags) ~= "table" then
+    return "'tags' must be an array"
+  end
+  local has_path = input.path ~= nil and input.path ~= ""
+  local has_tags = type(input.tags) == "table" and #input.tags > 0
+  if cmd == "read" then
+    if has_path and has_tags then
+      return "provide 'path' or 'tags', not both"
+    end
+    if not has_path and not has_tags then
+      return "'path' or 'tags' is required for read"
+    end
+  elseif cmd == "write" then
+    if not has_path then
+      return "'path' is required for write"
+    end
+    if not input.content then
+      return "'content' is required for write"
+    end
+  elseif cmd == "delete" then
+    if not has_path then
+      return "'path' is required for delete"
+    end
+  end
+  return nil
+end
+
+-- Returns (want set, warning?, error?): error when no tag survives
+-- normalization, warning when only some were rejected.
+local function normalize_to_want(raw_tags)
+  local normalized, rejected = M.normalize_tags(raw_tags)
+  local r = M.format_rejected(rejected)
+  if #normalized == 0 then
+    return nil, nil, "no valid tags after normalization" .. (r and ("; rejected: " .. r) or "")
+  end
+  local want = {}
+  for _, n in ipairs(normalized) do
+    want[n] = true
+  end
+  return want, r and (READ_REJECT_PREFIX .. r) or nil
+end
+
+function M.validate_write_tags(raw_tags)
+  local normalized, rejected, coerced = M.normalize_tags(raw_tags)
+  local r = M.format_rejected(rejected)
+  if r then
+    return nil, WRITE_REJECT_PREFIX .. r
+  end
+  local note = #coerced > 0 and ("normalized: " .. table.concat(coerced, ", ")) or nil
+  return normalized, nil, note
+end
+
+local function join_parts(sep, ...)
+  local parts = {}
+  for i = 1, select("#", ...) do
+    local v = select(i, ...)
+    if v then
+      parts[#parts + 1] = v
+    end
+  end
+  return table.concat(parts, sep)
+end
+
+local function combine_unreadable(warnings)
+  if #warnings == 0 then
+    return nil
+  end
+  return UNREADABLE_PREFIX .. table.concat(warnings, ", ")
+end
+
+function M.parse_frontmatter(content)
+  local rest = content:match("^%s*%-%-%-\n(.*)")
+  if not rest then
+    return {}, content
+  end
+  local end_pos = rest:find("\n%-%-%-")
+  if not end_pos then
+    return {}, content
+  end
+  local yaml_str = rest:sub(1, end_pos)
+  local body = rest:sub(end_pos + 4):match("^%s*(.-)%s*$")
+  local fm = maki.yaml.decode(yaml_str) or {}
+  return fm, body
+end
+
+function M.extract_tags(frontmatter)
+  if type(frontmatter) ~= "table" then
+    return nil
+  end
+  local raw = frontmatter.tags
+  if type(raw) == "string" then
+    raw = { raw }
+  end
+  if type(raw) ~= "table" then
+    return nil
+  end
+  local out = M.normalize_tags(raw)
+  return #out > 0 and out or nil
+end
+
+function M.tags_for_file(path, content, read_err)
+  if content then
+    local tags = M.extract_tags(M.parse_frontmatter(content))
+    if tags then
+      return tags, nil
+    end
+  end
+  return { stem_tag(path) }, read_err or (content == nil and "read error" or nil)
+end
+
+local function read_tags(dir, name)
+  local content, read_err = maki.fs.read(maki.fs.joinpath(dir, name))
+  local tags, warn = M.tags_for_file(name, content, read_err and tostring(read_err))
+  return tags, warn
+end
+
+-- Tags per file, keyed on mtime and size so unchanged files are never re-read.
+-- Unreadable files are never cached: a transient failure cannot pin stale stem tags.
+local tag_cache = {}
+
+local function cached_tags(dir, name, size, mtime)
+  local key = maki.fs.joinpath(dir, name)
+  local c = tag_cache[key]
+  if c and mtime and c.mtime == mtime and c.size == size then
+    return c.tags
+  end
+  local tags, warn = read_tags(dir, name)
+  if not warn and mtime then
+    tag_cache[key] = { mtime = mtime, size = size, tags = tags }
+  end
+  return tags, warn
+end
+
+local function has_wanted_tag(tags, want)
+  for _, t in ipairs(tags) do
+    if want[t] then
+      return true
+    end
+  end
+  return false
+end
+
+local function matching_entries(dir, want)
+  local matches, warnings = {}, {}
+  for _, f in ipairs(file_entries(dir)) do
+    local name, size, mtime = f[1], f[2], f[3]
+    local tags, warn = cached_tags(dir, name, size, mtime)
+    if warn then
+      warnings[#warnings + 1] = name .. ": " .. warn
+    elseif has_wanted_tag(tags, want) then
+      local content, read_err = maki.fs.read(maki.fs.joinpath(dir, name))
+      if content then
+        matches[#matches + 1] = { name = name, content = content, size = size }
+      else
+        warnings[#warnings + 1] = name .. ": " .. tostring(read_err)
+      end
+    end
+  end
+  return matches, warnings
+end
+
+-- Groups files under their tags, most-used tag first (name breaks ties).
+-- Unreadable files land in warnings instead of a group.
+function M.grouped_tags(dir)
+  local by_tag, groups, warnings = {}, {}, {}
+  for _, f in ipairs(file_entries(dir)) do
+    local name, size = f[1], f[2]
+    local tags, warn = cached_tags(dir, name, size, f[3])
+    if warn then
+      warnings[#warnings + 1] = name .. ": " .. warn
+    else
+      for _, t in ipairs(tags) do
+        local g = by_tag[t]
+        if not g then
+          g = { tag = t, files = {} }
+          by_tag[t] = g
+          groups[#groups + 1] = g
+        end
+        g.files[#g.files + 1] = { name = name, size = size }
+      end
+    end
+  end
+  table.sort(groups, function(a, b)
+    if #a.files == #b.files then
+      return a.tag < b.tag
+    end
+    return #a.files > #b.files
+  end)
+  return groups, warnings
+end
+
+function M.format_tag_line(dir, max_tags)
+  local groups, warnings = M.grouped_tags(dir)
+  if #groups == 0 and #warnings == 0 then
+    return nil
+  end
+  local tags = {}
+  for i, g in ipairs(groups) do
+    tags[i] = g.tag
+  end
+  local line = table.concat(tags, ", ", 1, math.min(#tags, max_tags))
+  if #tags > max_tags then
+    line = line .. " ... (" .. (#tags - max_tags) .. " tags omitted; use `list` to see all)"
+  end
+  if #warnings > 0 then
+    line = (#line > 0 and line .. " " or "") .. "(unreadable: " .. #warnings .. ")"
+  end
+  return line
+end
+
+-- serde_yaml renders an empty list as an empty mapping; extract_tags treats both as empty.
+function M.encode_frontmatter(tags)
+  local yaml, _ = maki.yaml.encode({ tags = tags })
+  return "---\n" .. yaml .. "---\n"
+end
+
+function M.cap_read_output(s, hint)
+  if #s <= M.MAX_FILE_BYTES then
+    return s
+  end
+  -- Back off UTF-8 continuation bytes so the cut never splits a codepoint.
+  local cut = M.MAX_FILE_BYTES
+  while cut > 0 do
+    local b = s:byte(cut + 1)
+    if b < 0x80 or b >= 0xC0 then
+      break
+    end
+    cut = cut - 1
+  end
+  return s:sub(1, cut) .. "\n... (output truncated at " .. M.MAX_FILE_BYTES .. " bytes; " .. hint .. ")"
+end
+
+function M.validate_write_size(content)
+  if #content > M.MAX_FILE_BYTES then
+    return "content exceeds "
+      .. M.MAX_FILE_BYTES
+      .. " bytes (got "
+      .. #content
+      .. "); split the memory or trim to stay under the cap"
+  end
+  return nil
+end
+
+function M.format_read_entry(name, size, content)
+  local fm, body = M.parse_frontmatter(content)
+  local tags = M.extract_tags(fm) or {}
+  local header = name .. " (" .. size .. " bytes)"
+  if #tags > 0 then
+    header = header .. " [" .. table.concat(tags, ", ") .. "]"
+  end
+  return header .. "\n\n" .. body
+end
+
+function M.format_list(dir, raw_tags)
+  local want, warning
+  if raw_tags and #raw_tags > 0 then
+    local werr
+    want, warning, werr = normalize_to_want(raw_tags)
+    if werr then
+      return nil, werr
+    end
+  end
+
+  local groups, read_warnings = M.grouped_tags(dir)
+  if #groups == 0 and not want then
+    return join_parts("\n", combine_unreadable(read_warnings), M.NO_MEMORIES_MSG)
+  end
+
+  local lines = {}
+  local matched = 0
+  for _, g in ipairs(groups) do
+    if not want or want[g.tag] then
+      matched = matched + 1
+      lines[#lines + 1] = g.tag .. " (" .. #g.files .. ")"
+      for _, f in ipairs(g.files) do
+        lines[#lines + 1] = "  - " .. f.name .. " (" .. f.size .. " bytes)"
+      end
+      lines[#lines + 1] = ""
+    end
+  end
+
+  local unreadable = combine_unreadable(read_warnings)
+  if matched == 0 then
+    return join_parts("\n", warning, unreadable, NO_MATCH_MSG)
+  end
+  local body = M.cap_read_output(table.concat(lines, "\n"), M.CAP_HINT_FILTER)
+  if not want and #groups > M.MAX_TAGS then
+    body = body .. "\n" .. PRUNE_ADVISORY
+  end
+  return join_parts("\n", warning, unreadable, body), nil
+end
+
+function M.format_read(dir, raw_tags)
+  local want, warning, err = normalize_to_want(raw_tags)
+  if err then
+    return nil, err
+  end
+
+  local matches, read_warnings = matching_entries(dir, want)
+  local parts = {}
+  for _, m in ipairs(matches) do
+    parts[#parts + 1] = M.format_read_entry(m.name, m.size, m.content)
+  end
+
+  local hint = #parts <= 1 and M.CAP_HINT_REWRITE or M.CAP_HINT_NARROW
+  local body = #parts > 0 and M.cap_read_output(table.concat(parts, "\n\n"), hint) or NO_MATCH_MSG
+  return join_parts("\n\n", warning, combine_unreadable(read_warnings), body)
 end
 
 return M

--- a/plugins/memory/tests/spec.lua
+++ b/plugins/memory/tests/spec.lua
@@ -1,11 +1,22 @@
 local h = require("memory_helpers")
 
 local fnv1a_64 = h.fnv1a_64
-local count_lines = h.count_lines
 local project_id = h.project_id
 local safe_resolve = h.safe_resolve
-local dir_total_bytes = h.dir_total_bytes
-local list_memories = h.list_memories
+local normalize_tag = h.normalize_tag
+local parse_frontmatter = h.parse_frontmatter
+local extract_tags = h.extract_tags
+local tags_for_file = h.tags_for_file
+local format_tag_line = h.format_tag_line
+local encode_frontmatter = h.encode_frontmatter
+local format_list = h.format_list
+local format_read = h.format_read
+local cap_read_output = h.cap_read_output
+local validate_write_tags = h.validate_write_tags
+local validate_write_size = h.validate_write_size
+local validate_input = h.validate_input
+
+local NO_MATCH_MSG = "no memory files matched any of the given tags; use `list` to see available tags"
 
 local failures = {}
 
@@ -23,15 +34,28 @@ local function eq(actual, expected, msg)
 end
 
 local _tmpdir_counter = 0
+-- time + clock + counter keeps dirs unique even across parallel test runs
 local function mktmpdir()
   _tmpdir_counter = _tmpdir_counter + 1
-  local name = "/tmp/maki_spec_" .. tostring(os.clock()):gsub("%.", "") .. "_" .. _tmpdir_counter
+  local name = "/tmp/maki_spec_" .. os.time() .. "_" .. tostring(os.clock()):gsub("%.", "") .. "_" .. _tmpdir_counter
   maki.fs.mkdir(name)
   return name
 end
 
-local function rmtree(dir)
-  maki.fs.rm(dir, { recursive = true })
+-- hands fn a fresh tmpdir and removes it even when the case fails
+local function case_tmp(name, fn)
+  case(name, function()
+    local dir = mktmpdir()
+    local ok, err = pcall(fn, dir)
+    maki.fs.rm(dir, { recursive = true })
+    if not ok then
+      error(err, 0)
+    end
+  end)
+end
+
+local function write_mem(dir, name, tags, body)
+  maki.fs.write(maki.fs.joinpath(dir, name), encode_frontmatter(tags) .. body)
 end
 
 case("fnv1a_known_vectors", function()
@@ -43,25 +67,8 @@ case("fnv1a_known_vectors", function()
   for _, v in ipairs(vectors) do
     eq(fnv1a_64(v[1]), v[2], "input: " .. ("%q"):format(v[1]))
   end
-end)
-
-case("fnv1a_high_bytes_no_overflow", function()
-  local result = fnv1a_64(string.rep("\xff", 64))
-  eq(#result, 16, "should always produce 16 hex chars")
-  assert(result:match("^%x+$"), "should be valid hex")
-end)
-
-case("count_lines", function()
-  local vectors = {
-    { "", 1 },
-    { "hello", 1 },
-    { "\n", 1 },
-    { "a\nb", 2 },
-    { "a\nb\n", 2 },
-  }
-  for _, v in ipairs(vectors) do
-    eq(count_lines(v[1]), v[2], "input: " .. ("%q"):format(v[1]))
-  end
+  local high = fnv1a_64(string.rep("\xff", 64))
+  assert(#high == 16 and high:match("^%x+$"), "high bytes must still hash to 16 hex chars")
 end)
 
 case("safe_resolve_rejects_bad_paths", function()
@@ -74,6 +81,9 @@ case("safe_resolve_rejects_bad_paths", function()
     { "../escape", "traversal" },
     { "a/../../escape", "traversal" },
     { "inside/../../../etc/shadow", "traversal" },
+    { "C:\\foo", "must be relative" },
+    { "c:foo", "must be relative" },
+    { "\\escape", "must be relative" },
   }
   for _, v in ipairs(bad) do
     local _, err = safe_resolve("/tmp/mem", v[1])
@@ -106,57 +116,491 @@ case("project_id", function()
   local root_id = project_id("/")
   assert(root_id:match("^root%-"), "/ should use 'root' as basename")
 
-  local id1 = project_id("/home/alice/myapp")
-  local id2 = project_id("/home/bob/myapp")
-  assert(id1 ~= id2, "different full paths should produce different IDs")
+  assert(project_id("/home/alice/myapp") ~= project_id("/home/bob/myapp"), "same basename, different paths")
 end)
 
-case("dir_total_bytes", function()
-  local tmpdir = mktmpdir()
-  eq(dir_total_bytes(tmpdir), 0, "empty dir")
-  eq(dir_total_bytes("/tmp/maki_test_surely_missing_" .. _tmpdir_counter), 0, "nonexistent dir")
-
-  maki.fs.write(maki.fs.joinpath(tmpdir, "a"), "12345")
-  maki.fs.write(maki.fs.joinpath(tmpdir, "b"), "67890")
-  eq(dir_total_bytes(tmpdir), 10, "sum of files")
-  rmtree(tmpdir)
+case_tmp("format_list_empty_or_missing_says_no_memories", function(dir)
+  eq(format_list(dir), h.NO_MEMORIES_MSG)
+  eq(format_list(dir .. "_missing"), h.NO_MEMORIES_MSG)
 end)
 
-case("list_memories_empty_or_missing", function()
-  local tmpdir = mktmpdir()
-  eq(list_memories(tmpdir), "No memories yet.")
-  eq(list_memories("/tmp/maki_test_does_not_exist_" .. _tmpdir_counter), "No memories yet.")
-  rmtree(tmpdir)
+case_tmp("format_list_groups_sorted_by_freq_no_bodies", function(dir)
+  write_mem(dir, "a.md", { "rare" }, "A body")
+  write_mem(dir, "b.md", { "common" }, "B")
+  write_mem(dir, "c.md", { "common" }, "C")
+  write_mem(dir, "d.md", { "common" }, "D")
+
+  local result, err = format_list(dir)
+  eq(err, nil)
+  local common_pos = result:find("common %(3%)")
+  local rare_pos = result:find("rare %(1%)")
+  assert(common_pos and rare_pos and common_pos < rare_pos, "groups sorted by frequency")
+  assert(result:find("  %- b%.md %(%d+ bytes%)"), "files listed under their tag")
+  assert(not result:find("A body"), "index has no bodies")
 end)
 
-case("list_memories_sorts_sums_and_ignores_subdirs", function()
-  local tmpdir = mktmpdir()
-  maki.fs.write(maki.fs.joinpath(tmpdir, "zebra.md"), "zzz")
-  maki.fs.write(maki.fs.joinpath(tmpdir, "alpha.md"), "a")
-  maki.fs.mkdir(maki.fs.joinpath(tmpdir, "subdir"))
-
-  local result = list_memories(tmpdir)
-  assert(result:find("alpha.md") < result:find("zebra.md"), "should be sorted")
-  assert(result:find("2 files"), "should count only files")
-  assert(result:find("4 bytes total"), "should sum: 1+3=4")
-  assert(not result:find("subdir"), "should not list subdirs")
-  rmtree(tmpdir)
+case_tmp("format_list_stem_pseudo_tag", function(dir)
+  maki.fs.write(maki.fs.joinpath(dir, "notes.md"), "no frontmatter")
+  assert(format_list(dir):find("notes %(1%)"), "untagged file grouped under its stem")
+  local filtered, err = format_list(dir, { "notes" })
+  eq(err, nil)
+  assert(filtered:find("notes%.md %(%d+ bytes%)"), "stem works as a filter tag too")
 end)
 
-case("write_read_delete_lifecycle", function()
-  local tmpdir = mktmpdir()
-  assert(not maki.fs.metadata(maki.fs.joinpath(tmpdir, "nope.md")), "metadata should be nil for nonexistent")
+case_tmp("format_list_filters_by_tag_union", function(dir)
+  write_mem(dir, "a.md", { "auth" }, "A")
+  write_mem(dir, "b.md", { "sessions" }, "B")
+  write_mem(dir, "c.md", { "storage" }, "C")
 
-  local file_path = safe_resolve(tmpdir, "arch.md")
-  maki.fs.write(file_path, "# Architecture\nMicroservices")
-  eq(maki.fs.read(file_path), "# Architecture\nMicroservices")
+  local result, err = format_list(dir, { "auth", "sessions" })
+  eq(err, nil)
+  assert(result:find("a%.md") and result:find("b%.md"), "union of requested tags")
+  assert(not result:find("c%.md"), "other tags filtered out")
 
-  maki.fs.write(file_path, "v2")
-  eq(maki.fs.read(file_path), "v2")
+  eq(format_list(dir, { "nope" }), NO_MATCH_MSG)
+end)
 
-  maki.fs.rm(file_path)
-  assert(not maki.fs.metadata(file_path), "file should be deleted")
-  rmtree(tmpdir)
+case_tmp("format_list_invalid_tags", function(dir)
+  write_mem(dir, "a.md", { "auth" }, "A")
+
+  local result, err = format_list(dir, { "!!!", "", "  " })
+  eq(result, nil)
+  assert(err:find("no valid tags") and err:find("!!!", 1, true), "all-invalid errors and names the raw values")
+
+  local partial, perr = format_list(dir, { "auth", "!!!" })
+  eq(perr, nil)
+  local wpos = partial:find("warning: ignored invalid tag")
+  local bpos = partial:find("a%.md")
+  assert(wpos and bpos and wpos < bpos, "partial invalid warns first, then lists matches")
+  assert(partial:find("!!!", 1, true), "warning names the rejected tag")
+end)
+
+case_tmp("format_list_prune_advisory_only_unfiltered_over_cap", function(dir)
+  for i = 1, h.MAX_TAGS + 1 do
+    write_mem(dir, "f" .. i .. ".md", { "tag" .. i }, "body" .. i)
+  end
+  assert(format_list(dir):find("to stay under " .. h.MAX_TAGS .. " tags"), "advisory when over the tag cap")
+  assert(not format_list(dir, { "tag1" }):find("stay under"), "no advisory on a filtered list")
+end)
+
+case_tmp("format_list_caps_oversized_output", function(dir)
+  local stem = string.rep("a", 180)
+  for i = 1, 130 do
+    maki.fs.write(maki.fs.joinpath(dir, stem .. i .. ".md"), "x")
+  end
+  local result = format_list(dir)
+  assert(#result <= h.MAX_FILE_BYTES + 200, "list output stays near the cap")
+  assert(result:find("truncated at", 1, true), "oversized list is capped")
+  assert(result:find(h.CAP_HINT_FILTER, 1, true), "cap hint suggests tag filtering")
+end)
+
+case("format_rejected", function()
+  eq(h.format_rejected({}), nil)
+  eq(h.format_rejected(nil), nil)
+  assert(h.format_rejected({ "bad!tag", "" }):find("bad!tag"), "lists rejected tag names")
+  local w = h.format_rejected({ string.rep("x", 200) })
+  eq(#w, 64 + 3, "long values truncated to 64 chars plus ellipsis")
+  eq(w:sub(-3), "...")
+end)
+
+case("normalize_tag", function()
+  eq(normalize_tag("Auth Flow"), "auth_flow")
+  eq(normalize_tag("auth-flow"), "auth_flow")
+  eq(normalize_tag("  AUTH_FLOW  "), "auth_flow")
+  eq(normalize_tag("auth--flow"), "auth_flow", "repeated separators collapse")
+  eq(normalize_tag("auth!flow"), "auth_flow", "punctuation coerced")
+  eq(normalize_tag("a,b"), "a_b")
+  eq(normalize_tag(nil), nil)
+  eq(normalize_tag(""), nil)
+  eq(normalize_tag("   "), nil)
+  eq(normalize_tag("!?"), nil, "nothing salvageable returns nil")
+  eq(normalize_tag(string.rep("a", 65)), string.rep("a", 64), "over 64 chars truncated")
+  eq(normalize_tag(string.rep("a", 64)), string.rep("a", 64), "exactly 64 ok")
+end)
+
+case("normalize_tags_dedupes_and_reports", function()
+  local out, rejected = h.normalize_tags({ "Auth Flow", "auth_flow", "Sessions", "", "auth-flow" })
+  eq(#out, 2, "variants dedupe to one normalized form")
+  eq(out[1], "auth_flow")
+  eq(out[2], "sessions")
+  eq(#rejected, 1, "empty string rejected")
+
+  local out2, rejected2, coerced = h.normalize_tags({ "valid", "bad!tag", "!", "" })
+  eq(#out2, 2)
+  eq(out2[2], "bad_tag")
+  eq(#rejected2, 2)
+  eq(#coerced, 1)
+  eq(coerced[1], "bad!tag -> bad_tag")
+
+  eq(#h.normalize_tags({}), 0)
+end)
+
+case("validate_write_size", function()
+  local max = h.MAX_FILE_BYTES
+  eq(validate_write_size(string.rep("a", max)), nil, "content exactly at cap accepted")
+  local err = validate_write_size(string.rep("x", max + 1))
+  assert(err and err:find("exceeds " .. max) and err:find("got " .. (max + 1)), "over cap rejected with both sizes")
+end)
+
+case("validate_write_tags", function()
+  local tags, err, note = validate_write_tags({ "auth_flow", "sessions" })
+  eq(err, nil)
+  eq(tags[1], "auth_flow")
+  eq(tags[2], "sessions")
+  eq(note, nil, "no note when nothing coerced")
+
+  local ctags, cerr, cnote = validate_write_tags({ "auth/login" })
+  eq(cerr, nil)
+  eq(ctags[1], "auth_login")
+  eq(cnote, "normalized: auth/login -> auth_login")
+
+  local etags, eerr = validate_write_tags({})
+  eq(eerr, nil, "empty tag list is valid, stem fallback")
+  eq(#etags, 0)
+
+  local rtags, rerr = validate_write_tags({ "good", "!", "??" })
+  eq(rtags, nil, "any unsalvageable tag rejects the write")
+  assert(rerr:find("!, ??", 1, true) and not rerr:find("good", 1, true), "error lists only the bad tags")
+end)
+
+case("parse_frontmatter_extracts_tags_and_body", function()
+  local fm, body = parse_frontmatter("---\ntags:\n  - auth\n  - sessions\n---\n# Body\nText")
+  eq(fm.tags[1], "auth")
+  eq(fm.tags[2], "sessions")
+  eq(body, "# Body\nText")
+end)
+
+case("parse_frontmatter_falls_back_to_whole_content", function()
+  local inputs = {
+    "Just content",
+    "---\ntags:\n  - a\nbody without close",
+    "---\n---\nbody",
+  }
+  for _, input in ipairs(inputs) do
+    local fm, body = parse_frontmatter(input)
+    eq(body, input, "invalid frontmatter keeps content intact: " .. ("%q"):format(input:sub(1, 24)))
+    eq(next(fm), nil)
+  end
+end)
+
+case("parse_frontmatter_malformed_yaml_keeps_body", function()
+  local fm, body = parse_frontmatter("---\ntags: [unterminated\n---\nbody")
+  eq(body, "body", "body survives a YAML decode failure")
+  eq(extract_tags(fm), nil)
+end)
+
+case("parse_frontmatter_empty_tags_and_mid_body_rule", function()
+  local fm, body = parse_frontmatter("---\ntags:\n  - a\n---\npara1\n---\npara2")
+  eq(body, "para1\n---\npara2", "mid-body thematic rule is not a closing fence")
+  eq(fm.tags[1], "a")
+
+  local fm2, body2 = parse_frontmatter("---\ntags: []\n---\nbody text")
+  eq(body2, "body text")
+  eq(extract_tags(fm2), nil, "empty tags list extracts to nil, stem fallback")
+end)
+
+case("extract_tags", function()
+  local tags = extract_tags({ tags = { "Auth Flow", "auth_flow", "Sessions", "" } })
+  eq(#tags, 2, "normalized and deduped")
+  eq(tags[1], "auth_flow")
+  eq(tags[2], "sessions")
+  eq(extract_tags({ tags = "single_tag" })[1], "single_tag", "bare string coerced to list")
+  eq(extract_tags({}), nil)
+  eq(extract_tags(nil), nil)
+  eq(extract_tags({ tags = 42 }), nil, "non-table/string ignored")
+end)
+
+case("tags_for_file_uses_frontmatter", function()
+  local tags = tags_for_file("arch.md", "---\ntags:\n  - architecture\n  - rust\n---\nMicroservices")
+  eq(#tags, 2)
+  eq(tags[1], "architecture")
+  eq(tags[2], "rust")
+end)
+
+case("tags_for_file_stem_fallbacks", function()
+  local vectors = {
+    { "architecture.md", "no frontmatter", "architecture" },
+    { "config.local.md", "no tags", "config_local" },
+    { ".bashrc", "no tags", "bashrc" },
+    { "...md", "no tags", "untagged" },
+    { "notes.md", "---\ntags: []\n---\nbody", "notes" },
+    { "deep/nested/Notes.md", "x", "notes" },
+  }
+  for _, v in ipairs(vectors) do
+    local tags = tags_for_file(v[1], v[2])
+    eq(#tags, 1, v[1])
+    eq(tags[1], v[3], v[1])
+  end
+end)
+
+case("tags_for_file_propagates_read_errors", function()
+  local tags, err = tags_for_file("Notes.md", nil)
+  eq(tags[1], "notes", "stem fallback still works without content")
+  eq(err, "read error")
+
+  local _, err2 = tags_for_file("Notes.md", nil, "disk error")
+  eq(err2, "disk error", "explicit read error wins over the default")
+end)
+
+case_tmp("format_tag_line_sorted_by_freq", function(dir)
+  eq(format_tag_line(dir, 50), nil, "empty dir renders no line")
+
+  write_mem(dir, "a.md", { "rare" }, "A")
+  write_mem(dir, "b.md", { "common" }, "B")
+  write_mem(dir, "c.md", { "common" }, "C")
+  write_mem(dir, "d.md", { "common" }, "D")
+  maki.fs.write(maki.fs.joinpath(dir, "untagged.md"), "no tags")
+
+  local line = format_tag_line(dir, 50)
+  local common_pos = line:find("common", 1, true)
+  local rare_pos = line:find("rare", 1, true)
+  assert(common_pos and rare_pos and common_pos < rare_pos, "most used tag first")
+  assert(line:find("untagged", 1, true), "stem pseudo-tag included")
+end)
+
+case_tmp("format_tag_line_truncates_above_cap", function(dir)
+  for i = 1, 5 do
+    write_mem(dir, "f" .. i .. ".md", { "tag" .. i }, tostring(i))
+  end
+  local line = format_tag_line(dir, 3)
+  assert(line:find("^tag1, tag2, tag3 "), "first three tags shown in order")
+  assert(line:find("2 tags omitted") and line:find("use `list` to see all"), "omission hint with count")
+end)
+
+local function with_read_stub(stub, fn)
+  local orig = maki.fs.read
+  maki.fs.read = stub
+  local ok, err = pcall(fn)
+  maki.fs.read = orig
+  if not ok then
+    error(err, 0)
+  end
+end
+
+case_tmp("grouped_tags_serves_unchanged_files_from_cache", function(dir)
+  write_mem(dir, "a.md", { "auth" }, "body")
+  local groups = h.grouped_tags(dir)
+  eq(groups[1].tag, "auth")
+
+  with_read_stub(function()
+    error("cache miss: unchanged file was re-read")
+  end, function()
+    local cached = h.grouped_tags(dir)
+    eq(cached[1].tag, "auth")
+    eq(#cached[1].files, 1)
+  end)
+end)
+
+case_tmp("grouped_tags_cache_invalidated_when_file_changes", function(dir)
+  write_mem(dir, "a.md", { "auth" }, "body")
+  eq(h.grouped_tags(dir)[1].tag, "auth")
+
+  write_mem(dir, "a.md", { "storage" }, "a longer body so size differs too")
+  local groups = h.grouped_tags(dir)
+  eq(groups[1].tag, "storage", "rewrite must evict the cached tags")
+  eq(#groups, 1)
+end)
+
+case_tmp("grouped_tags_never_caches_unreadable_files", function(dir)
+  write_mem(dir, "a.md", { "auth" }, "body")
+
+  with_read_stub(function()
+    return nil, "boom"
+  end, function()
+    local groups, warnings = h.grouped_tags(dir)
+    eq(#groups, 0, "unreadable file forms no group")
+    eq(#warnings, 1)
+    assert(warnings[1]:find("boom"), "warning carries the read error")
+  end)
+
+  local groups, warnings = h.grouped_tags(dir)
+  eq(groups[1].tag, "auth", "transient failure must not pin stale stem tags")
+  eq(#warnings, 0)
+end)
+
+case_tmp("format_list_and_tag_line_warn_when_all_files_unreadable", function(dir)
+  write_mem(dir, "a.md", { "auth" }, "body")
+  with_read_stub(function()
+    return nil, "boom"
+  end, function()
+    local out = format_list(dir)
+    assert(out:find("unreadable memory files: a.md: boom", 1, true), "list must not hide unreadable files")
+    assert(out:find(h.NO_MEMORIES_MSG, 1, true))
+    eq(format_tag_line(dir, 50), "(unreadable: 1)", "tag line surfaces unreadable-only dirs")
+  end)
+end)
+
+case_tmp("format_read_matches_on_cached_tags_and_reads_fresh_content", function(dir)
+  write_mem(dir, "a.md", { "auth" }, "old")
+  eq(h.grouped_tags(dir)[1].tag, "auth")
+
+  with_read_stub(function()
+    return "fresh body without frontmatter"
+  end, function()
+    local out = format_read(dir, { "auth" })
+    assert(
+      out:find("fresh body without frontmatter", 1, true),
+      "match must come from cached tags, content from a fresh read"
+    )
+  end)
+end)
+
+case_tmp("format_read_warns_when_matched_file_unreadable_at_read_time", function(dir)
+  write_mem(dir, "a.md", { "auth" }, "body")
+  eq(h.grouped_tags(dir)[1].tag, "auth")
+
+  with_read_stub(function()
+    return nil, "boom"
+  end, function()
+    local out = format_read(dir, { "auth" })
+    assert(out:find("unreadable memory files: a.md: boom", 1, true), "content read failure surfaces as warning")
+    assert(out:find(NO_MATCH_MSG, 1, true), "no bodies means the no-match message")
+  end)
+end)
+
+case("cap_read_output_caps_and_picks_hint", function()
+  local max = h.MAX_FILE_BYTES
+  local small = string.rep("a", 100)
+  eq(cap_read_output(small, h.CAP_HINT_REWRITE), small, "under the cap returned unchanged")
+
+  local big = string.rep("x", max + 50)
+  local out = cap_read_output(big, h.CAP_HINT_REWRITE)
+  assert(out:find("truncated at " .. max .. " bytes", 1, true), "marker renders the cap")
+  assert(out:sub(1, max) == string.rep("x", max), "prefix preserved up to the cap")
+  assert(out:find(h.CAP_HINT_REWRITE, 1, true), "caller-chosen hint rendered")
+  local narrow = cap_read_output(big, h.CAP_HINT_NARROW)
+  assert(
+    narrow:find(h.CAP_HINT_NARROW, 1, true) and not narrow:find(h.CAP_HINT_REWRITE, 1, true),
+    "only the requested hint appears"
+  )
+end)
+
+case("cap_read_output_never_splits_utf8_codepoint", function()
+  local max = h.MAX_FILE_BYTES
+  -- "é" is 2 bytes; the odd ASCII prefix forces the cap to land mid-codepoint
+  local big = "x" .. string.rep("\195\169", max)
+  local out = cap_read_output(big, h.CAP_HINT_REWRITE)
+  local prefix = out:match("^(.-)\n%.%.%. %(output truncated")
+  assert(prefix, "truncation marker present")
+  eq(#prefix, max - 1, "backs off one byte to the last codepoint boundary")
+  eq(prefix:byte(#prefix), 0xA9, "prefix ends on a complete codepoint")
+end)
+
+case("encode_frontmatter_round_trips", function()
+  local fm = encode_frontmatter({ "auth", "sessions" })
+  assert(fm:find("^%-%-%-\n") and fm:find("\n%-%-%-\n$"), "fenced frontmatter")
+  local parsed = extract_tags(parse_frontmatter(fm .. "body"))
+  eq(parsed[1], "auth")
+  eq(parsed[2], "sessions")
+
+  eq(extract_tags(parse_frontmatter(encode_frontmatter({}) .. "body")), nil, "empty tags round-trip to stem fallback")
+end)
+
+case_tmp("format_read_union_headers_and_no_match", function(dir)
+  write_mem(dir, "a.md", { "auth" }, "A body")
+  write_mem(dir, "b.md", { "sessions" }, "B body")
+  write_mem(dir, "c.md", { "auth", "sessions" }, "C body")
+
+  local result, err = format_read(dir, { "auth" })
+  eq(err, nil)
+  assert(result:find("a%.md %(%d+ bytes%) %[auth%]"), "header shows size and tags")
+  assert(result:find("c%.md %(%d+ bytes%) %[auth, sessions%]"), "match on any tag shows all tags")
+  assert(not result:find("b%.md"), "non-matching file excluded")
+  assert(result:find("A body") and not result:find("tags:"), "bodies included, frontmatter stripped")
+
+  local union = format_read(dir, { "auth", "sessions" })
+  assert(union:find("a%.md") and union:find("b%.md") and union:find("c%.md"), "tags select the union")
+
+  eq(format_read(dir, { "nope" }), NO_MATCH_MSG)
+end)
+
+case_tmp("format_read_normalizes_request_and_stem", function(dir)
+  write_mem(dir, "a.md", { "auth_flow" }, "A")
+  maki.fs.write(maki.fs.joinpath(dir, "notes.md"), "no frontmatter")
+
+  assert(format_read(dir, { "Auth-Flow", "AUTH FLOW" }):find("a%.md"), "request tags normalized before matching")
+
+  local result = format_read(dir, { "notes" })
+  assert(result:find("notes%.md") and result:find("no frontmatter"), "stem pseudo-tag readable")
+end)
+
+case_tmp("format_read_invalid_tags", function(dir)
+  write_mem(dir, "a.md", { "auth" }, "A")
+
+  local result, err = format_read(dir, { "!!!", "" })
+  eq(result, nil)
+  assert(err:find("no valid tags") and err:find("!!!", 1, true), "all-invalid errors and names the raw values")
+
+  local partial, perr = format_read(dir, { "auth", "!!!" })
+  eq(perr, nil)
+  local wpos = partial:find("warning: ignored invalid tag")
+  assert(wpos and wpos < partial:find("a%.md"), "partial invalid warns before the matches")
+end)
+
+case_tmp("format_read_oversized_picks_hint_by_match_count", function(dir)
+  local max = h.MAX_FILE_BYTES
+  local one = maki.fs.joinpath(dir, "one")
+  local many = maki.fs.joinpath(dir, "many")
+  maki.fs.mkdir(one)
+  maki.fs.mkdir(many)
+  write_mem(one, "big.md", { "bulk" }, string.rep("x", max + 50))
+  local half = math.floor(max / 2) + 100
+  write_mem(many, "a.md", { "bulk" }, string.rep("a", half))
+  write_mem(many, "b.md", { "bulk" }, string.rep("b", half))
+
+  local single = format_read(one, { "bulk" })
+  assert(single:find("truncated at", 1, true), "single oversized match truncated")
+  assert(
+    single:find(h.CAP_HINT_REWRITE, 1, true) and not single:find(h.CAP_HINT_NARROW, 1, true),
+    "one match asks for a rewrite"
+  )
+
+  local concat = format_read(many, { "bulk" })
+  assert(concat:find("truncated at", 1, true), "concat over the cap truncated")
+  assert(
+    concat:find(h.CAP_HINT_NARROW, 1, true) and not concat:find(h.CAP_HINT_REWRITE, 1, true),
+    "many matches ask to narrow"
+  )
+end)
+
+case("format_read_entry", function()
+  local formatted = h.format_read_entry("arch.md", 42, "---\ntags:\n  - auth\n  - sessions\n---\n# Body\ntext")
+  assert(formatted:find("^arch%.md %(42 bytes%) %[auth, sessions%]"), "header carries size and tags")
+  assert(formatted:find("\n# Body\ntext$") and not formatted:find("%-%-%-"), "body follows, fences stripped")
+
+  eq(
+    h.format_read_entry("notes.md", 12, "just a body"),
+    "notes.md (12 bytes)\n\njust a body",
+    "no brackets when untagged"
+  )
+end)
+
+case("validate_input", function()
+  local ok_inputs = {
+    { command = "list" },
+    { command = "read", tags = { "auth" } },
+    { command = "read", path = "a.md" },
+    { command = "write", path = "a.md", content = "x" },
+    { command = "write", path = "a.md", content = "x", tags = {} },
+    { command = "delete", path = "a.md" },
+  }
+  for i, input in ipairs(ok_inputs) do
+    eq(validate_input(input), nil, "ok input #" .. i .. " (" .. input.command .. ")")
+  end
+
+  local bad = {
+    { { command = "find" }, "unknown command" },
+    { { command = "read" }, "path.*or.*tags" },
+    { { command = "read", path = "a.md", tags = { "auth" } }, "not both" },
+    { { command = "read", tags = "auth" }, "must be an array" },
+    { { command = "write" }, "path" },
+    { { command = "write", path = "a.md" }, "content" },
+    { { command = "delete" }, "path" },
+  }
+  for _, v in ipairs(bad) do
+    local err = validate_input(v[1])
+    assert(err and err:find(v[2]), "expected error matching '" .. v[2] .. "', got: " .. tostring(err))
+  end
 end)
 
 if #failures > 0 then

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -1446,7 +1446,9 @@ maki.fs.metadata({path})
 ```
 
 Get metadata for the file or directory at {path}.
-Returns a table with `size` (integer), `is_file` (boolean), and `is_dir` (boolean).
+Returns a table with `size` (integer), `is_file` (boolean), `is_dir` (boolean),
+and `mtime` (number, fractional seconds since the Unix epoch; absent when the
+filesystem does not report a modification time).
 If {path} does not exist, returns nil with no error.
 
 **Parameters:**

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -181,9 +181,10 @@ Persistent, project-scoped scratchpad for learnings, patterns, decisions, and go
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `command` | string | yes | Command: view, write, delete |
-| `content` | string | no | File content for 'write' |
-| `path` | string | no | Relative path (e.g. 'architecture.md'). Omit to list all. |
+| `command` | string | yes | - `list [tags]`: tag-grouped index, no bodies.<br>- `read path\|tags`: one body (path) or collated bodies (tags).<br>- `write path tags content`: create or overwrite a note.<br>- `delete path` |
+| `content` | string | no | Body for write (frontmatter added automatically). |
+| `path` | string | no | Relative path, e.g. 'architecture.md'. |
+| `tags` | array | no | snake_case tags. Filter for list/read; assigned on write (defaults to filename stem). |
 
 ### `skill` *(lua plugin)*
 


### PR DESCRIPTION
Finally getting the implementation for https://github.com/tontinton/maki/issues/443 out of draft into something I'm happy with.

This PR switches to use tags as the primary unit of thought for the memory tool instead of files. This should allow us to keep a manageable context injection to models while allowing the removal of the file count limits (file size now capped at 20kb).

The new API for memory is `read`, `write`, `delete`, and `list`, same as before (renamed `view` to `read`) but with list for agents to check tags when they're truncated. We hint that memory should be pruned when the tag limit is hit (the limit is a display limit, not a storage limit) as a way to pressure agents to manage total memory size per project. Currently the limit is 50, I hope to make that user-configurable in a follow-up to this PR. Tags are `snake_case` normalized, files with no tags get their filename `snake_case`'d for a pseudo-tag for a migration stopgap until they get actual tags.

In order to support this tag-first memory model, I updated the `/memory` command to use tag sections (ordered by frequency, then name) in the `ListPicker`.

Some cleanup I didn't do:
- We are no longer only reading memory metadata and are now reading the full file, though we cache on mtime and file size. We could add a `maki.fs.read_head` function to read the starts of files, or some `maki.fs.read_frontmatter` that reads a YAML frontmatter into a Lua table, but until then this is a negligible perf cost best saved for a follow-up.
- When arrow-keys scrolling down and back up with the `ListPicker`, the top section title doesn't get scrolled back up into view because we don't scroll beyond the selected item. Not sure what's preferred here...
- The aforementioned configurability of the 50 tag soft limit.

I ran this locally on some existing memory files sans tags, some new ones with tags. Everything seems to work, though we'll have to see about the efficacy of the tag system once we get to larger project development with Maki. I'll admit I didn't read all of the Lua specs, just some of them. If you're gonna be doing that, then I'll definitely read through them as well, I just can't be bothered usually to read all tests.

Written with Maki + GLM-5.2.