### PR TITLE
feat(question): render answered choices as a durable artifact card

### DIFF
--- a/maki-ui/src/components/permission_prompt.rs
+++ b/maki-ui/src/components/permission_prompt.rs
@@ -300,7 +300,7 @@ impl PermissionPrompt {
             };
             let (before, after) = display_text.split_at(cursor_pos);
             let mut chars = after.chars();
-            let cursor_ch = chars.next().map_or(' ', |c| c);
+            let cursor_ch = chars.next().unwrap_or(' ');
             let rest: String = chars.collect();
 
             let mut spans = vec![Span::raw("  "), Span::styled("guide ", label_style)];

--- a/plugins/question/init.lua
+++ b/plugins/question/init.lua
@@ -1,5 +1,6 @@
 local QuestionForm = require("question_form")
 local QuestionHelpers = require("question_helpers")
+local ToolView = require("maki.tool_view")
 
 local DESCRIPTION = [[Use this tool when you need to ask the user questions during execution. This allows you to:
 - Gather user preferences or requirements
@@ -11,6 +12,22 @@ Rules:
 - `custom` enabled by default adds "Type your own answer" - don't include catch-all options.
 - Answers returned as arrays of labels. Set `multiSelect: true` for multi-select.
 - Put recommended option first with "(Recommended)" suffix.]]
+
+local function card_width()
+  local ok, size = pcall(maki.ui.terminal_size)
+  if ok and type(size) == "table" and type(size.cols) == "number" then
+    return math.max(40, size.cols - 8)
+  end
+  return 80
+end
+
+local function normalize_questions(questions)
+  for _, q in ipairs(questions or {}) do
+    q.options = q.options or {}
+    q.header = q.header or ""
+    q.multiple = q.multiSelect or false
+  end
+end
 
 maki.api.register_tool({
   name = "question",
@@ -60,15 +77,33 @@ maki.api.register_tool({
     if #input.questions == 0 then
       return { llm_output = "error: at least one question is required", is_error = true }
     end
-    for _, q in ipairs(input.questions) do
-      q.options = q.options or {}
-      q.header = q.header or ""
-      q.multiple = q.multiSelect or false
-    end
+    normalize_questions(input.questions)
     local result = QuestionForm.open(input.questions)
+    local width = card_width()
     if result.type == "dismiss" then
-      return { llm_output = "(question dismissed by user)" }
+      return {
+        llm_output = "(question dismissed by user)",
+        state = { dismissed = true },
+        body = QuestionHelpers.render_card(input.questions, {}, { width = width, dismissed = true }),
+      }
     end
-    return { llm_output = QuestionHelpers.format_answer_list(input.questions, result.answers), format = "markdown" }
+    return {
+      llm_output = QuestionHelpers.format_answer_list(input.questions, result.answers),
+      format = "markdown",
+      state = { answers = result.answers },
+      body = QuestionHelpers.render_card(input.questions, result.answers, { width = width }),
+    }
+  end,
+  restore = function(input, output, _is_error, ctx)
+    normalize_questions(input.questions)
+    local state = ctx:state()
+    local width = card_width()
+    if state and state.answers then
+      return { body = QuestionHelpers.render_card(input.questions, state.answers, { width = width }) }
+    end
+    if state and state.dismissed then
+      return { body = QuestionHelpers.render_card(input.questions, {}, { width = width, dismissed = true }) }
+    end
+    return { body = ToolView.restore(output, { max_lines = 80 }) }
   end,
 })

--- a/plugins/question/question_helpers.lua
+++ b/plugins/question/question_helpers.lua
@@ -18,4 +18,119 @@ function QuestionHelpers.format_answer_list(questions, answers)
   return table.concat(blocks, "\n\n")
 end
 
+local function is_selected(answers, label)
+  if not answers then
+    return false
+  end
+  for _, v in ipairs(answers) do
+    if v == label then
+      return true
+    end
+  end
+  return false
+end
+
+local function find_custom(answers, options)
+  if not answers then
+    return nil
+  end
+  local predefined = {}
+  for _, opt in ipairs(options or {}) do
+    predefined[opt.label] = true
+  end
+  local customs = {}
+  for _, v in ipairs(answers) do
+    if not predefined[v] then
+      customs[#customs + 1] = v
+    end
+  end
+  if #customs == 0 then
+    return nil
+  end
+  return customs
+end
+
+local function default_width()
+  local ok, size = pcall(maki.ui.terminal_size)
+  if ok and type(size) == "table" and type(size.cols) == "number" then
+    return math.max(40, size.cols - 8)
+  end
+  return 80
+end
+
+local function question_md(text, width)
+  local ok, lines = pcall(maki.ui.markdown, text, width)
+  if not ok or type(lines) ~= "table" or #lines == 0 then
+    return { { { text, "" } } }
+  end
+  return lines
+end
+
+local function append_spans(out, src)
+  for _, sp in ipairs(src) do
+    out[#out + 1] = sp
+  end
+end
+
+local function render_option_line(opt, selected)
+  local line = {}
+  if selected then
+    line[1] = { "✓ ", "success" }
+    line[2] = { opt.label, "success" }
+  else
+    line[1] = { "  ", "dim" }
+    line[2] = { opt.label, "dim" }
+  end
+  if opt.description and opt.description ~= "" then
+    line[#line + 1] = { " — ", "dim" }
+    line[#line + 1] = { opt.description, selected and "success" or "dim" }
+  end
+  return line
+end
+
+function QuestionHelpers.render_card(questions, answers, opts)
+  opts = opts or {}
+  local width = opts.width or default_width()
+  local dismissed = opts.dismissed or false
+  local buf = maki.ui.buf()
+
+  if dismissed then
+    buf:line({ { "Dismissed by user", "dim" } })
+    buf:line({})
+  end
+
+  for i, q in ipairs(questions) do
+    q.options = q.options or {}
+
+    local md_lines = question_md(q.question, width)
+    for j, md_line in ipairs(md_lines) do
+      local prefix = j == 1 and ("Q" .. i .. ". ") or "    "
+      local line = { { prefix, "bold" } }
+      append_spans(line, md_line)
+      buf:line(line)
+    end
+
+    local ans = (not dismissed) and answers and answers[i] or nil
+    if not ans or #ans == 0 then
+      buf:line({ { "    (no answer)", "dim" } })
+    else
+      for _, opt in ipairs(q.options) do
+        buf:line(render_option_line(opt, is_selected(ans, opt.label)))
+      end
+      local customs = find_custom(ans, q.options)
+      if customs then
+        for _, text in ipairs(customs) do
+          buf:line({ { "    ✓ Custom: ", "success" }, { text, "success" } })
+        end
+      end
+    end
+
+    if i < #questions then
+      buf:line({})
+    end
+  end
+
+  return buf
+end
+
 return QuestionHelpers

--- a/plugins/question/question_helpers.lua
+++ b/plugins/question/question_helpers.lua
@@ -66,69 +66,128 @@ local function question_md(text, width)
   return lines
 end
 
+local function desc_md(text, width)
+  local ok, lines = pcall(maki.ui.markdown, text, width)
+  if not ok or type(lines) ~= "table" or #lines == 0 then
+    return { { { text, "" } } }
+  end
+  return lines
+end
+
 local function append_spans(out, src)
   for _, sp in ipairs(src) do
     out[#out + 1] = sp
   end
 end
 
-local function render_option_line(opt, selected)
-  local line = {}
-  if selected then
-    line[1] = { "✓ ", "success" }
-    line[2] = { opt.label, "success" }
-  else
-    line[1] = { "  ", "dim" }
-    line[2] = { opt.label, "dim" }
-  end
-  if opt.description and opt.description ~= "" then
-    line[#line + 1] = { " — ", "dim" }
-    line[#line + 1] = { opt.description, selected and "success" or "dim" }
-  end
-  return line
-end
+local DESC_INDENT = "        "
 
 function QuestionHelpers.render_card(questions, answers, opts)
   opts = opts or {}
   local width = opts.width or default_width()
   local dismissed = opts.dismissed or false
   local buf = maki.ui.buf()
+  local expanded = {}
+  local line_map = {}
 
-  if dismissed then
-    buf:line({ { "Dismissed by user", "dim" } })
-    buf:line({})
+  local function opt_key(q_idx, opt)
+    return q_idx .. "\0" .. opt.label
   end
 
-  for i, q in ipairs(questions) do
-    q.options = q.options or {}
+  local function is_expanded(q_idx, opt)
+    return expanded[opt_key(q_idx, opt)] == true
+  end
 
-    local md_lines = question_md(q.question, width)
-    for j, md_line in ipairs(md_lines) do
-      local prefix = j == 1 and ("Q" .. i .. ". ") or "    "
-      local line = { { prefix, "bold" } }
-      append_spans(line, md_line)
-      buf:line(line)
+  local function toggle(q_idx, opt)
+    local key = opt_key(q_idx, opt)
+    expanded[key] = not expanded[key]
+  end
+
+  local function render()
+    local lines = {}
+    line_map = {}
+    local line_no = 1
+
+    if dismissed then
+      lines[#lines + 1] = { { "Dismissed by user", "dim" } }
+      lines[#lines + 1] = {}
+      line_no = line_no + 2
     end
 
-    local ans = (not dismissed) and answers and answers[i] or nil
-    if not ans or #ans == 0 then
-      buf:line({ { "    (no answer)", "dim" } })
-    else
-      for _, opt in ipairs(q.options) do
-        buf:line(render_option_line(opt, is_selected(ans, opt.label)))
+    for i, q in ipairs(questions) do
+      q.options = q.options or {}
+
+      local md_lines = question_md(q.question, width)
+      for j, md_line in ipairs(md_lines) do
+        local prefix = j == 1 and ("Q" .. i .. ". ") or "    "
+        local line = { { prefix, "bold" } }
+        append_spans(line, md_line)
+        lines[#lines + 1] = line
+        line_no = line_no + 1
       end
-      local customs = find_custom(ans, q.options)
-      if customs then
-        for _, text in ipairs(customs) do
-          buf:line({ { "    ✓ Custom: ", "success" }, { text, "success" } })
+
+      local ans = (not dismissed) and answers and answers[i] or nil
+      if not ans or #ans == 0 then
+        lines[#lines + 1] = { { "    (no answer)", "dim" } }
+        line_no = line_no + 1
+      else
+        for _, opt in ipairs(q.options) do
+          local selected = is_selected(ans, opt.label)
+          local line = {}
+          if selected then
+            line[1] = { "    ✓ ", "success" }
+            line[2] = { opt.label, "success" }
+          else
+            line[1] = { "      ", "" }
+            line[2] = { opt.label, "dim" }
+          end
+          local has_desc = opt.description and opt.description ~= ""
+          if has_desc then
+            local hint = is_expanded(i, opt) and " (−)" or " (+)"
+            line[#line + 1] = { hint, "dim" }
+          end
+          lines[#lines + 1] = line
+          line_map[line_no] = { q_idx = i, opt = opt }
+          line_no = line_no + 1
+
+          if has_desc and is_expanded(i, opt) then
+            local desc_lines = desc_md(opt.description, width - #DESC_INDENT)
+            for _, dl in ipairs(desc_lines) do
+              local desc_line = { { DESC_INDENT, "" } }
+              append_spans(desc_line, dl)
+              lines[#lines + 1] = desc_line
+              line_no = line_no + 1
+            end
+          end
+        end
+
+        local customs = find_custom(ans, q.options)
+        if customs then
+          for _, text in ipairs(customs) do
+            lines[#lines + 1] = { { "    ✓ Custom: ", "success" }, { text, "success" } }
+            line_no = line_no + 1
+          end
         end
       end
+
+      if i < #questions then
+        lines[#lines + 1] = {}
+        line_no = line_no + 1
+      end
     end
 
-    if i < #questions then
-      buf:line({})
-    end
+    buf:set_lines(lines)
   end
+
+  render()
+
+  buf:on("click", function(ev)
+    local info = line_map[ev.row]
+    if info then
+      toggle(info.q_idx, info.opt)
+      render()
+    end
+  end)
 
   return buf
 end

--- a/plugins/question/tests/spec.lua
+++ b/plugins/question/tests/spec.lua
@@ -16,6 +16,39 @@ local function eq(actual, expected, msg)
   end
 end
 
+local function with_mock_ui(fn)
+  local original = {
+    buf = maki.ui.buf,
+    markdown = maki.ui.markdown,
+    terminal_size = maki.ui.terminal_size,
+  }
+  local captured = { _lines = {} }
+  local buf = {
+    line = function(_, l)
+      table.insert(captured._lines, l)
+    end,
+    get_lines = function()
+      return captured._lines
+    end,
+  }
+  maki.ui.buf = function()
+    return buf
+  end
+  maki.ui.markdown = function(text, _width)
+    return { { { text, "" } } }
+  end
+  maki.ui.terminal_size = function()
+    return { rows = 40, cols = 100 }
+  end
+  local ok, err = pcall(fn, buf)
+  maki.ui.buf = original.buf
+  maki.ui.markdown = original.markdown
+  maki.ui.terminal_size = original.terminal_size
+  if not ok then
+    error(err)
+  end
+end
+
 local MODE = QuestionForm.MODE
 
 local function single_question(overrides)
@@ -551,6 +584,62 @@ case("open_requests_bottom_split", function()
   assert(ok, "open must not error: " .. tostring(err))
   assert(captured, "open_win must be called")
   eq(captured.split, "below", "form must request a bottom split")
+end)
+
+local function find_span(lines, text)
+  for _, line in ipairs(lines) do
+    for _, span in ipairs(line) do
+      if span[1]:find(text, 1, true) then
+        return span
+      end
+    end
+  end
+  return nil
+end
+
+case("render_card_colors_selected_answers_and_dims_unselected", function()
+  with_mock_ui(function(buf)
+    local questions = {
+      { question = "Pick one", options = { { label = "Yes" }, { label = "No" } } },
+    }
+    QuestionHelpers.render_card(questions, { { "Yes" } })
+    local yes = find_span(buf.get_lines(), "Yes")
+    local no = find_span(buf.get_lines(), "No")
+    assert(yes, "selected answer must be present")
+    assert(no, "unselected answer must be present")
+    eq(yes[2], "success", "selected answer must use success style")
+    eq(no[2], "dim", "unselected answer must use dim style")
+  end)
+end)
+
+case("render_card_shows_no_answer_when_answers_empty", function()
+  with_mock_ui(function(buf)
+    local questions = { { question = "Pick one", options = { { label = "A" } } } }
+    QuestionHelpers.render_card(questions, { {} })
+    local placeholder = find_span(buf.get_lines(), "(no answer)")
+    assert(placeholder, "empty answer must show placeholder")
+    eq(placeholder[2], "dim", "placeholder must be dim")
+  end)
+end)
+
+case("render_card_shows_custom_answer", function()
+  with_mock_ui(function(buf)
+    local questions = { { question = "Pick one", options = { { label = "A" } } } }
+    QuestionHelpers.render_card(questions, { { "my custom" } })
+    local custom = find_span(buf.get_lines(), "my custom")
+    assert(custom, "custom answer must be present")
+    eq(custom[2], "success", "custom answer must use success style")
+  end)
+end)
+
+case("render_card_shows_dismissed_banner", function()
+  with_mock_ui(function(buf)
+    local questions = { { question = "Pick one", options = { { label = "A" } } } }
+    QuestionHelpers.render_card(questions, {}, { dismissed = true })
+    local dismissed = find_span(buf.get_lines(), "Dismissed by user")
+    assert(dismissed, "dismissed banner must be present")
+    eq(dismissed[2], "dim", "dismissed banner must be dim")
+  end)
 end)
 
 if #failures > 0 then

--- a/plugins/question/tests/spec.lua
+++ b/plugins/question/tests/spec.lua
@@ -23,12 +23,25 @@ local function with_mock_ui(fn)
     terminal_size = maki.ui.terminal_size,
   }
   local captured = { _lines = {} }
+  local handlers = {}
   local buf = {
     line = function(_, l)
       table.insert(captured._lines, l)
     end,
+    set_lines = function(_, lines)
+      captured._lines = lines
+    end,
     get_lines = function()
       return captured._lines
+    end,
+    on = function(_, event, fn)
+      handlers[event] = fn
+    end,
+    emit = function(_, event, ev)
+      local h = handlers[event]
+      if h then
+        h(ev)
+      end
     end,
   }
   maki.ui.buf = function()
@@ -639,6 +652,38 @@ case("render_card_shows_dismissed_banner", function()
     local dismissed = find_span(buf.get_lines(), "Dismissed by user")
     assert(dismissed, "dismissed banner must be present")
     eq(dismissed[2], "dim", "dismissed banner must be dim")
+  end)
+end)
+
+case("render_card_click_expands_description", function()
+  with_mock_ui(function(buf)
+    local desc = "Expanded reasoning for why this choice is correct."
+    local questions = {
+      { question = "Pick one", options = { { label = "A", description = desc } } },
+    }
+    QuestionHelpers.render_card(questions, { { "A" } })
+    local before = buf.get_lines()
+    assert(find_span(before, " (+)"), "collapsed option must show expand hint")
+    assert(not find_span(before, "Expanded reasoning"), "description must be hidden by default")
+
+    local row = nil
+    for i, line in ipairs(before) do
+      if find_span({ line }, "A") then
+        row = i
+        break
+      end
+    end
+    assert(row, "option row must exist")
+
+    buf:emit("click", { row = row })
+    local after = buf.get_lines()
+    assert(find_span(after, " (−)"), "expanded option must show collapse hint")
+    assert(find_span(after, "Expanded reasoning"), "description must appear after click")
+
+    buf:emit("click", { row = row })
+    local again = buf.get_lines()
+    assert(find_span(again, " (+)"), "second click must collapse back")
+    assert(not find_span(again, "Expanded reasoning"), "description must hide after second click")
   end)
 end)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(semicolon_in_expressions_from_macros)]
+
 mod cli;
 mod cmd;
 mod print;


### PR DESCRIPTION
## Summary
- The `question` tool now renders its output as a durable, styled artifact card in the chat history, not just a markdown answer list.
- The card shows each question, its options, and the selected answer(s) highlighted with the `success` style; unselected options and empty answers are dimmed.
- Answer state is persisted across sessions via the tool `state` field and restored through `restore`.
- Legacy sessions without state fall back to the existing `ToolView` rendering.

## Test plan
- [x] `cargo nextest run -p maki-lua` passes (666/666).
- [x] `cargo clippy -p maki-lua --tests -- -D warnings` passes.
- [x] Added plugin spec tests for `QuestionHelpers.render_card` covering selected/unselected styles, empty answers, custom answers, and the dismissed banner.