### PR TITLE
feat(ui): @-mention file picker in prompt

### DIFF
--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -562,7 +562,12 @@ impl App {
                     vec![]
                 }
                 FilePickerModalAction::Close => {
+                    let was_at = self.file_picker.take_at_mention();
                     self.file_picker.close();
+                    if was_at {
+                        self.input_box.buffer.push_char('@');
+                        self.command_palette.sync(&self.input_box.buffer.value());
+                    }
                     vec![]
                 }
             });
@@ -780,6 +785,10 @@ impl App {
         let streaming = self.status == Status::Streaming;
         match self.input_box.handle_key(key) {
             InputAction::Submit(sub) => self.handle_submit(sub),
+            InputAction::OpenFilePicker => {
+                self.file_picker.open_via_at(&self.state.session.cwd);
+                vec![]
+            }
             InputAction::PaletteSync(val) => {
                 self.command_palette.sync(&val);
                 vec![]

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -870,6 +870,38 @@ fn overlay_blocks_ctrl_shortcuts(setup: fn(&mut App)) {
 }
 
 #[test]
+fn at_mention_opens_file_picker_and_esc_leaves_literal() {
+    let mut app = test_app();
+    app.update(Msg::Key(key(KeyCode::Char('@'))));
+    assert!(app.file_picker.is_open());
+    assert_eq!(app.input_box.buffer.value(), "");
+
+    app.update(Msg::Key(key(KeyCode::Esc)));
+    assert!(!app.file_picker.is_open());
+    assert_eq!(app.input_box.buffer.value(), "@");
+}
+
+#[test]
+fn at_mention_does_not_open_mid_word() {
+    let mut app = test_app();
+    for c in "em".chars() {
+        app.update(Msg::Key(key(KeyCode::Char(c))));
+    }
+    app.update(Msg::Key(key(KeyCode::Char('@'))));
+    assert!(!app.file_picker.is_open());
+    assert_eq!(app.input_box.buffer.value(), "em@");
+}
+
+#[test]
+fn ctrl_s_file_picker_unaffected_by_at_mention_flag() {
+    let mut app = test_app();
+    app.update(Msg::Key(key(KeyCode::Char('x'))));
+    app.update(Msg::Key(kb::FILE_PICKER.to_key_event()));
+    assert!(app.file_picker.is_open());
+    assert_eq!(app.input_box.buffer.value(), "x");
+}
+
+#[test]
 fn compact_command_sets_streaming() {
     let mut app = test_app();
     let actions = app.execute_command(cmd("/compact"));

--- a/maki-ui/src/components/file_picker.rs
+++ b/maki-ui/src/components/file_picker.rs
@@ -78,11 +78,15 @@ impl Drop for Session {
 
 pub struct FilePickerModal {
     session: Option<Session>,
+    opened_via_at: bool,
 }
 
 impl FilePickerModal {
     pub fn new() -> Self {
-        Self { session: None }
+        Self {
+            session: None,
+            opened_via_at: false,
+        }
     }
 
     pub fn open(&mut self, cwd: &str) {
@@ -162,8 +166,18 @@ impl FilePickerModal {
         });
     }
 
+    pub fn open_via_at(&mut self, cwd: &str) {
+        self.open(cwd);
+        self.opened_via_at = true;
+    }
+
+    pub fn take_at_mention(&mut self) -> bool {
+        std::mem::replace(&mut self.opened_via_at, false)
+    }
+
     pub fn close(&mut self) {
         self.session = None;
+        self.opened_via_at = false;
     }
 
     pub fn is_open(&self) -> bool {

--- a/maki-ui/src/components/input.rs
+++ b/maki-ui/src/components/input.rs
@@ -7,7 +7,7 @@ use crate::highlight;
 use crate::text_buffer::{EditResult, TextBuffer, is_newline_key};
 use crate::theme;
 
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use maki_storage::input_history::InputHistory;
 use std::mem;
 
@@ -45,6 +45,7 @@ const PLACEHOLDER_SUGGESTIONS: &[&str] = &[
 pub enum InputAction {
     Submit(Submission),
     ContinueLine,
+    OpenFilePicker,
     PaletteSync(String),
     Passthrough(KeyEvent),
     None,
@@ -93,6 +94,12 @@ impl InputBox {
                 return InputAction::None;
             }
             KeyCode::Tab | KeyCode::Esc => return InputAction::Passthrough(key),
+            KeyCode::Char('@')
+                if !key.modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+                    && self.char_before_cursor_is_whitespace_or_start() =>
+            {
+                return InputAction::OpenFilePicker;
+            }
             _ if is_newline_key(&key) => {
                 self.buffer.add_line();
                 return InputAction::ContinueLine;
@@ -209,14 +216,25 @@ impl InputBox {
         self.buffer.y() == self.buffer.line_count().saturating_sub(1)
     }
 
-    pub fn char_before_cursor_is_backslash(&self) -> bool {
-        let line = &self.buffer.lines()[self.buffer.y()];
+    fn char_before_cursor(&self) -> Option<char> {
         let x = self.buffer.x();
         if x == 0 {
-            return false;
+            return None;
         }
+        let line = &self.buffer.lines()[self.buffer.y()];
         let byte_idx = TextBuffer::char_to_byte(line, x - 1);
-        line.as_bytes()[byte_idx] == b'\\'
+        line[byte_idx..].chars().next()
+    }
+
+    pub fn char_before_cursor_is_backslash(&self) -> bool {
+        self.char_before_cursor() == Some('\\')
+    }
+
+    fn char_before_cursor_is_whitespace_or_start(&self) -> bool {
+        match self.char_before_cursor() {
+            None => true,
+            Some(c) => c.is_whitespace(),
+        }
     }
 
     pub fn continue_line(&mut self) {
@@ -1041,5 +1059,62 @@ mod tests {
         type_text(&mut input, "read");
         input.handle_paste_with_spaces("file.rs");
         assert_eq!(input.buffer.value(), "read file.rs");
+    }
+
+    fn key_char(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn at_mention_opens_picker_at_start() {
+        let mut input = InputBox::new(InputHistory::default());
+        let action = input.handle_key(key_char('@'));
+        assert!(matches!(action, InputAction::OpenFilePicker));
+        assert_eq!(input.buffer.value(), "");
+    }
+
+    #[test]
+    fn at_mention_opens_picker_after_whitespace() {
+        let mut input = InputBox::new(InputHistory::default());
+        type_text(&mut input, "read ");
+        let action = input.handle_key(key_char('@'));
+        assert!(matches!(action, InputAction::OpenFilePicker));
+        assert_eq!(input.buffer.value(), "read ");
+    }
+
+    #[test]
+    fn at_mention_opens_picker_at_new_line_start() {
+        let mut input = InputBox::new(InputHistory::default());
+        type_text(&mut input, "read");
+        input.buffer.add_line();
+        let action = input.handle_key(key_char('@'));
+        assert!(matches!(action, InputAction::OpenFilePicker));
+        assert_eq!(input.buffer.value(), "read\n");
+    }
+
+    #[test]
+    fn at_mention_is_literal_mid_word() {
+        let mut input = InputBox::new(InputHistory::default());
+        type_text(&mut input, "em");
+        let action = input.handle_key(key_char('@'));
+        assert!(!matches!(action, InputAction::OpenFilePicker));
+        assert_eq!(input.buffer.value(), "em@");
+    }
+
+    #[test]
+    fn at_mention_is_literal_after_punctuation() {
+        let mut input = InputBox::new(InputHistory::default());
+        type_text(&mut input, "see(");
+        let action = input.handle_key(key_char('@'));
+        assert!(!matches!(action, InputAction::OpenFilePicker));
+        assert_eq!(input.buffer.value(), "see(@");
+    }
+
+    #[test]
+    fn at_mention_is_literal_with_ctrl_modifier() {
+        let mut input = InputBox::new(InputHistory::default());
+        let action = input.handle_key(KeyEvent::new(KeyCode::Char('@'), KeyModifiers::CONTROL));
+        assert!(!matches!(action, InputAction::OpenFilePicker));
+        assert_eq!(input.buffer.value(), "");
     }
 }

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -385,6 +385,12 @@ pub const KEYBINDS: &[Keybind] = &[
         platform: Platform::All,
     },
     Keybind {
+        label: KeyLabel::Single("@"),
+        description: "Mention a file (Esc leaves a literal @)",
+        context: KeybindContext::Editing,
+        platform: Platform::All,
+    },
+    Keybind {
         label: KeyLabel::MacAlt(key::DELETE_WORD.label, "⌥⌫"),
         description: "Delete word backward",
         context: KeybindContext::Editing,

--- a/maki-ui/src/components/permission_prompt.rs
+++ b/maki-ui/src/components/permission_prompt.rs
@@ -300,7 +300,7 @@ impl PermissionPrompt {
             };
             let (before, after) = display_text.split_at(cursor_pos);
             let mut chars = after.chars();
-            let cursor_ch = chars.next().map_or(' ', |c| c);
+            let cursor_ch = chars.next().unwrap_or(' ');
             let rest: String = chars.collect();
 
             let mut spans = vec![Span::raw("  "), Span::styled("guide ", label_style)];

--- a/maki-ui/src/splash.rs
+++ b/maki-ui/src/splash.rs
@@ -21,6 +21,7 @@ const TIPS: &[(&str, &str)] = &[
         key::FILE_PICKER.label,
         "to grab file paths with fuzzy search",
     ),
+    ("@", "to mention a file in your prompt"),
     (key::TASKS.label, "to see what your subagents are up to"),
     (key::SEARCH.label, "to find things in the conversation"),
     ("/btw", "to ask something without interrupting the session"),

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -30,6 +30,7 @@ On macOS, some bindings use Option or Fn keys instead (run `/help` for exact key
 | `\+Enter` / `Ctrl+J` / `Alt+Enter` | Newline |
 | `Tab` | Toggle mode |
 | `/command` | Open command palette |
+| `@` | Mention a file (Esc leaves a literal @) |
 | `Ctrl+W` | Delete word backward |
 | `Alt+←` / `Alt+→` | Move word left / right |
 | `Ctrl+A` | Jump to start of line |

--- a/site/docs/content/quick-start/_index.md
+++ b/site/docs/content/quick-start/_index.md
@@ -87,6 +87,7 @@ Type a prompt, press **Enter**, and the agent starts working.
 - **Scroll output**: Ctrl+U / Ctrl+D (half page)
 - **Cancel streaming**: Esc Esc
 - **Rewind (when idle)**: Esc Esc
+- **Insert file path**: type `@` after whitespace to open the file picker (Esc leaves a literal `@`)
 - **Quit**: Ctrl+C
 - **All keybindings**: Ctrl+H
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(semicolon_in_expressions_from_macros)]
+
 mod cli;
 mod cmd;
 mod print;


### PR DESCRIPTION
## Summary
Closes #431.

Typing `@` at the start of the prompt or after whitespace opens the fuzzy file picker. If the picker is dismissed with Esc, the `@` is preserved as a literal character. The existing `Ctrl+S` file picker is unchanged.

- Adds `InputAction::OpenFilePicker` and handles it in `App::handle_key`.
- `FilePickerModal` tracks whether it was opened via `@` so closing can re-insert the character.
- `InputBox` checks the character before the cursor; only triggers `@` when it is whitespace or at the start of input, and ignores `Ctrl`/`Alt` modifiers.
- Updates keybindings help, splash tips, generated keybindings docs, and quick-start.
- Includes the same pre-existing clippy lint fixes as the other recent PRs so CI stays green.

## Test plan
- [x] `cargo nextest run --workspace` passes (2925/2925).
- [x] `cargo clippy --all --tests -- -D warnings` passes.
- [x] Added `InputBox` tests for start-of-input, after whitespace, new line, mid-word, after punctuation, and Ctrl modifier.
- [x] Added `App` tests for open/escape behavior, mid-word, and `Ctrl+S` unaffected.