### PR TITLE
fix(bench): pass accent color to Splash::render and fix clippy lints

### DIFF
--- a/maki-ui/benches/splash.rs
+++ b/maki-ui/benches/splash.rs
@@ -2,6 +2,7 @@ use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use maki_ui::splash::Splash;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
+use ratatui::style::Color;
 
 fn bench_splash_render(c: &mut Criterion) {
     let splash = Splash::new(true);
@@ -11,7 +12,7 @@ fn bench_splash_render(c: &mut Criterion) {
     c.bench_function("splash_render_120x40", |b| {
         b.iter(|| {
             buf.reset();
-            splash.render(black_box(area), &mut buf);
+            splash.render(black_box(area), &mut buf, Color::White);
         })
     });
 
@@ -21,7 +22,7 @@ fn bench_splash_render(c: &mut Criterion) {
     c.bench_function("splash_render_200x60", |b| {
         b.iter(|| {
             large_buf.reset();
-            splash.render(black_box(large_area), &mut large_buf);
+            splash.render(black_box(large_area), &mut large_buf, Color::White);
         })
     });
 }

--- a/maki-ui/src/components/permission_prompt.rs
+++ b/maki-ui/src/components/permission_prompt.rs
@@ -300,7 +300,7 @@ impl PermissionPrompt {
             };
             let (before, after) = display_text.split_at(cursor_pos);
             let mut chars = after.chars();
-            let cursor_ch = chars.next().map_or(' ', |c| c);
+            let cursor_ch = chars.next().unwrap_or(' ');
             let rest: String = chars.collect();
 
             let mut spans = vec![Span::raw("  "), Span::styled("guide ", label_style)];

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use color_eyre::Result;
-use color_eyre::eyre::{Context, bail};
+use color_eyre::eyre::{Context, bail, eyre};
 
 use maki_agent::mcp::{config as mcp_config, oauth as mcp_oauth};
 use maki_agent::tools::ToolRegistry;
@@ -208,7 +208,7 @@ fn login_custom(storage: &StateDir) -> Result<()> {
         "1" | "openai" => "openai",
         "2" | "anthropic" => "anthropic",
         "3" | "google" => "google",
-        _ => bail!("invalid protocol selection"),
+        _ => return Err(eyre!("invalid protocol selection")),
     };
 
     print!("  Base URL: ");
@@ -498,7 +498,7 @@ pub fn index(path: &str, no_plugins: bool) -> Result<()> {
     let result = smol::block_on(async { inv.execute(&ctx).await });
     match result.output {
         Ok(output) => print!("{}", output.as_text()),
-        Err(e) => bail!("index failed: {e}"),
+        Err(e) => return Err(eyre!("index failed: {e}")),
     }
     Ok(())
 }
@@ -513,7 +513,7 @@ pub fn mcp_auth(server: &str, storage: &StateDir) -> Result<()> {
             .ok_or_else(|| color_eyre::eyre::eyre!("unknown MCP server: {server}"))?;
         let url = match mcp_config::parse_server(server.to_owned(), raw.clone())?.transport {
             mcp_config::Transport::Http { url, .. } => url,
-            _ => color_eyre::eyre::bail!("server '{server}' is not an HTTP transport"),
+            _ => return Err(eyre!("server '{server}' is not an HTTP transport")),
         };
         mcp_oauth::authenticate(server, &url, None, storage, mcp_oauth::Interaction::Cli).await?;
         eprintln!("Successfully authenticated with MCP server '{server}'");


### PR DESCRIPTION
Fixes the splash bench by passing an accent `Color` to `Splash::render`, and resolves two clippy lints that break `cargo clippy --workspace --all-targets -- -D warnings`: `map_or_identity` in `permission_prompt.rs` and `semicolon_in_expressions_from_macros` in `cmd/subcmd.rs`.