### PR TITLE
fix(storage): write logs to the logs dir, not the state dir

### DIFF
--- a/maki-storage/src/log.rs
+++ b/maki-storage/src/log.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use tracing::warn;
 
-use crate::StateDir;
+use crate::paths;
 
 const LOG_FILE_NAME: &str = "maki.log";
 const LOCK_FILE_NAME: &str = "maki.log.lock";
@@ -25,6 +25,35 @@ fn flock_exclusive(file: &File) -> io::Result<()> {
     file.lock()
 }
 
+/// Logs used to live in the state dir. Move any leftover `maki.*.log` files
+/// to the logs dir once. Never overwrites: on any conflict or rename failure
+/// the source file stays where it is.
+fn migrate_stale_logs(old_dir: &Path, new_dir: &Path) {
+    if old_dir == new_dir {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(old_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if name == LOCK_FILE_NAME {
+            fs::remove_file(entry.path()).ok();
+            continue;
+        }
+        if !name.starts_with("maki.") || !name.ends_with(".log") {
+            continue;
+        }
+        let dst = new_dir.join(name);
+        if !dst.exists() {
+            fs::rename(entry.path(), &dst).ok();
+        }
+    }
+}
+
 pub struct RotatingFileWriter {
     dir: PathBuf,
     file: File,
@@ -34,8 +63,12 @@ pub struct RotatingFileWriter {
 }
 
 impl RotatingFileWriter {
-    pub fn new(data_dir: &StateDir, max_bytes: u64, max_files: u32) -> io::Result<Self> {
-        Self::with_limits(data_dir.path(), max_bytes, max_files)
+    pub fn new(max_bytes: u64, max_files: u32) -> io::Result<Self> {
+        let logs = paths::logs_dir()?;
+        if let Ok(state) = paths::state_dir() {
+            migrate_stale_logs(&state, &logs);
+        }
+        Self::with_limits(&logs, max_bytes, max_files)
     }
 
     fn with_limits(dir: &Path, max_bytes: u64, max_files: u32) -> io::Result<Self> {
@@ -197,6 +230,60 @@ mod tests {
             file_path(tmp.path(), 1).exists(),
             "should have rotated on first write since pre-existing data exceeded threshold"
         );
+    }
+
+    #[test]
+    fn migrates_only_log_files_and_removes_lock() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old = tmp.path().join("state");
+        let new = tmp.path().join("logs");
+        fs::create_dir_all(&old).unwrap();
+        fs::create_dir_all(&new).unwrap();
+        for name in [
+            LOG_FILE_NAME,
+            "maki.1.log",
+            LOCK_FILE_NAME,
+            "cwd_latest.json",
+        ] {
+            fs::write(old.join(name), "").unwrap();
+        }
+
+        migrate_stale_logs(&old, &new);
+
+        assert!(new.join(LOG_FILE_NAME).exists());
+        assert!(new.join("maki.1.log").exists());
+        assert!(!old.join(LOG_FILE_NAME).exists());
+        assert!(!old.join(LOCK_FILE_NAME).exists());
+        assert!(old.join("cwd_latest.json").exists());
+    }
+
+    #[test]
+    fn migration_never_overwrites_destination() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old = tmp.path().join("state");
+        let new = tmp.path().join("logs");
+        fs::create_dir_all(&old).unwrap();
+        fs::create_dir_all(&new).unwrap();
+        fs::write(old.join(LOG_FILE_NAME), "old").unwrap();
+        fs::write(new.join(LOG_FILE_NAME), "existing").unwrap();
+
+        migrate_stale_logs(&old, &new);
+
+        assert_eq!(
+            fs::read_to_string(new.join(LOG_FILE_NAME)).unwrap(),
+            "existing"
+        );
+        assert_eq!(fs::read_to_string(old.join(LOG_FILE_NAME)).unwrap(), "old");
+    }
+
+    #[test]
+    fn migration_keeps_live_lock_when_dirs_are_same() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join(LOCK_FILE_NAME), "").unwrap();
+
+        migrate_stale_logs(tmp.path(), tmp.path());
+
+        assert!(tmp.path().join(LOCK_FILE_NAME).exists());
     }
 
     #[test]

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -48,7 +48,7 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_jit: bool) -> Result<()> {
 
     let model = setup::resolve_model(model_arg.as_deref(), &config.provider, &storage)?;
 
-    setup::init_logging(&storage, &config.storage);
+    setup::init_logging(&config.storage);
     setup::install_panic_log_hook();
 
     let (mcp_handle, _mcp_config_errors) = smol::block_on(maki_agent::mcp::start(&cwd));

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -133,7 +133,7 @@ pub fn run(cli: Cli) -> Result<()> {
         Err(e) => return Err(e),
     };
 
-    setup::init_logging(&storage, &config.storage);
+    setup::init_logging(&config.storage);
     setup::install_panic_log_hook();
 
     let commands = discover_commands(cli.no_commands);

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -77,12 +77,10 @@ pub fn install_panic_log_hook() {
     }));
 }
 
-pub fn init_logging(storage: &StateDir, storage_config: &maki_config::StorageConfig) {
-    let Ok(writer) = RotatingFileWriter::new(
-        storage,
-        storage_config.max_log_bytes,
-        storage_config.max_log_files,
-    ) else {
+pub fn init_logging(storage_config: &maki_config::StorageConfig) {
+    let Ok(writer) =
+        RotatingFileWriter::new(storage_config.max_log_bytes, storage_config.max_log_files)
+    else {
         return;
     };
     let writer = Mutex::new(writer);


### PR DESCRIPTION
`paths.rs` always had a `logs_dir()` pointing at `~/.local/logs/maki`, and `maki migrate xdg` even moved legacy logs there, but `RotatingFileWriter` kept taking the `StateDir` and dropped every log into `~/.local/state/maki`.

The writer now resolves `logs_dir()` itself, and on startup a small `migrate_stale_logs` renames any leftover `maki.*.log` from the state dir and removes the stale `maki.log.lock`.

The migration is built to never lose data: only atomic renames, existing destination files are never overwritten, and any failure just leaves the file where it was.