### PR TITLE
refactor(config): move tool settings into their plugins

### DIFF
--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -361,13 +361,13 @@ pub fn truncate_output(text: String, max_lines: usize, max_bytes: usize) -> Stri
 }
 
 pub fn is_builtin_tool(name: &str) -> bool {
-    maki_config::DEFAULT_BUILTINS.contains(&name) || maki_config::OPT_IN_TOOLS.contains(&name)
+    maki_config::DEFAULT_BUILTINS.contains(&name) || maki_config::EDIT_SUB_TOOLS.contains(&name)
 }
 
 pub fn all_builtin_tool_names() -> Vec<&'static str> {
     maki_config::DEFAULT_BUILTINS
         .iter()
-        .chain(maki_config::OPT_IN_TOOLS.iter())
+        .chain(maki_config::EDIT_SUB_TOOLS.iter())
         .copied()
         .collect()
 }

--- a/maki-config/Cargo.toml
+++ b/maki-config/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 maki-config-macro = { workspace = true }
 maki-storage = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
@@ -17,4 +18,3 @@ inventory = { workspace = true }
 [dev-dependencies]
 test-case = { workspace = true }
 tempfile = { workspace = true }
-serde_json = { workspace = true }

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -7,6 +7,7 @@ use maki_config_macro::ConfigSection;
 use maki_storage::paths;
 use maki_storage::sessions::{StoredThinking, ThinkingParseError};
 use serde::{Deserialize, Serialize};
+use serde_json::{Map as JsonMap, Value as JsonValue};
 use thiserror::Error;
 use tracing::warn;
 
@@ -17,19 +18,12 @@ pub mod providers;
 
 pub const DEFAULT_MAX_OUTPUT_BYTES: usize = 50 * 1024;
 pub const DEFAULT_MAX_OUTPUT_LINES: usize = 2000;
-pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 5 * 1024 * 1024;
-pub const DEFAULT_MAX_LINE_BYTES: usize = 500;
 pub const DEFAULT_FLASH_DURATION_MS: u64 = 1500;
 pub const DEFAULT_TYPEWRITER_MS_PER_CHAR: u64 = 4;
 pub const DEFAULT_MOUSE_SCROLL_LINES: u32 = 3;
 
-pub const DEFAULT_BASH_TIMEOUT_SECS: u64 = 120;
-pub const DEFAULT_CODE_EXECUTION_TIMEOUT_SECS: u64 = 30;
 pub const DEFAULT_MAX_CONTINUATION_TURNS: u32 = 3;
 pub const DEFAULT_COMPACTION_BUFFER: CompactionBuffer = CompactionBuffer::Percent(20);
-pub const DEFAULT_SEARCH_RESULT_LIMIT: usize = 100;
-pub const DEFAULT_INTERPRETER_MAX_MEMORY_MB: usize = 50;
-pub const DEFAULT_TASK_MAX_CONCURRENT: usize = 8;
 
 pub const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
 pub const DEFAULT_LOW_SPEED_TIMEOUT_SECS: u64 = 120;
@@ -39,28 +33,18 @@ pub const DEFAULT_MAX_LOG_BYTES_MB: u64 = 200;
 pub const DEFAULT_MAX_LOG_FILES: u32 = 10;
 pub const DEFAULT_INPUT_HISTORY_SIZE: usize = 100;
 
-pub const DEFAULT_MAX_FILE_SIZE_MB: u64 = 2;
-
 pub const MIN_OUTPUT_BYTES: usize = 1024;
 pub const MIN_OUTPUT_LINES: usize = 10;
-pub const MIN_RESPONSE_BYTES: usize = 1024;
-pub const MIN_LINE_BYTES: usize = 80;
-pub const MIN_BASH_TIMEOUT_SECS: u64 = 5;
-pub const MIN_CODE_EXECUTION_TIMEOUT_SECS: u64 = 5;
 pub const MIN_MAX_CONTINUATION_TURNS: u32 = 1;
 pub const MIN_COMPACTION_BUFFER: u32 = 1_000;
 const MAX_COMPACTION_PERCENT: u8 = 99;
 const COMPACTION_BUFFER_EXPECTED: &str =
     r#"a token count (e.g. 12000) or a percent of the context window (e.g. "20%")"#;
-pub const MIN_SEARCH_RESULT_LIMIT: usize = 10;
-pub const MIN_INTERPRETER_MAX_MEMORY_MB: usize = 10;
-pub const MIN_TASK_MAX_CONCURRENT: usize = 1;
 pub const MIN_MOUSE_SCROLL_LINES: u32 = 1;
 pub const MIN_TOOL_OUTPUT_LINES: usize = 1;
 pub const MIN_MAX_LOG_BYTES_MB: u64 = 1;
 pub const MIN_MAX_LOG_FILES: u32 = 1;
 pub const MIN_INPUT_HISTORY_SIZE: usize = 10;
-pub const MIN_MAX_FILE_SIZE_MB: u64 = 1;
 pub const MIN_CONNECT_TIMEOUT_SECS: u64 = 1;
 pub const MIN_LOW_SPEED_TIMEOUT_SECS: u64 = 1;
 pub const MIN_STREAM_TIMEOUT_SECS: u64 = 10;
@@ -74,7 +58,6 @@ pub const DEFAULT_BUILTINS: &[&str] = &[
     "grep",
     "index",
     "memory",
-    "multiedit",
     "question",
     "read",
     "sessions",
@@ -87,7 +70,10 @@ pub const DEFAULT_BUILTINS: &[&str] = &[
     "write",
 ];
 
-pub const OPT_IN_TOOLS: &[&str] = &["edit_lines", "insert_lines"];
+/// These used to be their own `tools.<name>` tables and are now edit plugin
+/// options; the config layer uses this list to reject the old form with a
+/// pointer to the new one.
+pub const EDIT_SUB_TOOLS: &[&str] = &["edit_lines", "insert_lines", "multiedit"];
 
 pub const FILE_WRITE_TOOLS: &[&str] = &["write", "edit", "multiedit", "edit_lines", "insert_lines"];
 
@@ -148,14 +134,6 @@ pub const TOP_LEVEL_FIELDS: &[ConfigField] = &[
     },
 ];
 
-pub const INDEX_FIELDS: &[ConfigField] = &[ConfigField {
-    name: "max_file_size_mb",
-    ty: "u64",
-    default: ConfigValue::U64(DEFAULT_MAX_FILE_SIZE_MB),
-    min: Some(MIN_MAX_FILE_SIZE_MB),
-    description: "Max file size for indexing (MB)",
-}];
-
 #[derive(Debug, Error)]
 pub enum ConfigError {
     #[error("invalid config: {section}.{field} = {value} is below minimum ({min})")]
@@ -167,6 +145,25 @@ pub enum ConfigError {
     },
     #[error("invalid config: always_thinking: {0}")]
     Thinking(#[from] ThinkingParseError),
+    #[error(
+        "invalid config: plugins.{tool} was removed; {tool} is provided by the edit plugin, \
+         set plugins.edit = {{ {tool} = true|false }} instead"
+    )]
+    RemovedEditSubTool { tool: &'static str },
+    #[error(
+        "invalid config: plugins.{plugin}: no bundled plugin is named \"{plugin}\" \
+         (bundled plugins: {valid})"
+    )]
+    UnknownPlugin { plugin: String, valid: String },
+    #[error(
+        "invalid config: the `tools` table in maki.setup was renamed to `plugins` \
+         (plugins can provide more than tools).\n\n\
+         Fix your config with:\n\n    \
+         sed -i.bak 's/^\\( *\\)tools *=/\\1plugins =/' ~/.config/maki/init.lua\n\n\
+         Run it on .maki/init.lua too if you keep a project config. \
+         A .bak backup is left next to the file."
+    )]
+    RenamedToolsTable,
 }
 
 fn check(
@@ -223,8 +220,10 @@ pub struct RawConfig {
     pub agent: AgentFileConfig,
     pub provider: ProviderFileConfig,
     pub storage: StorageFileConfig,
-    pub index: IndexFileConfig,
-    pub tools: HashMap<String, ToolFileConfig>,
+    pub plugins: HashMap<String, PluginFileConfig>,
+    /// Renamed to `plugins`; kept so old configs fail with a pointer to the
+    /// new name instead of a generic unknown-field error.
+    tools: HashMap<String, PluginFileConfig>,
 }
 
 impl RawConfig {
@@ -241,22 +240,24 @@ impl RawConfig {
         self.agent.merge(overlay.agent);
         self.provider.merge(overlay.provider);
         self.storage.merge(overlay.storage);
-        self.index.merge(overlay.index);
+        for (name, plugin) in overlay.plugins {
+            let entry = self.plugins.entry(name).or_default();
+            if plugin.enabled.is_some() {
+                entry.enabled = plugin.enabled;
+            }
+            entry.opts.extend(plugin.opts);
+        }
         self.tools.extend(overlay.tools);
     }
 
     pub fn into_config(self, no_rtk: bool) -> Result<Config, ConfigError> {
-        let mut disabled_tools: Vec<String> = self
-            .tools
+        self.validate_plugin_tables()?;
+        let disabled_tools: Vec<String> = self
+            .plugins
             .iter()
             .filter(|(_, cfg)| cfg.enabled == Some(false))
             .map(|(name, _)| name.clone())
             .collect();
-        for &name in OPT_IN_TOOLS {
-            if self.tools.get(name).and_then(|t| t.enabled) != Some(true) {
-                disabled_tools.push(name.to_string());
-            }
-        }
         Ok(Config {
             always_yolo: self.always_yolo.unwrap_or(false),
             always_fast: self.always_fast.unwrap_or(false),
@@ -266,19 +267,49 @@ impl RawConfig {
                 .map(AlwaysThinking::resolve)
                 .transpose()?,
             ui: UiConfig::from_file(self.ui),
-            agent: AgentConfig::from_file(self.agent, no_rtk, &self.index, disabled_tools),
+            agent: AgentConfig::from_file(self.agent, no_rtk, disabled_tools),
             provider: ProviderConfig::from_file(self.provider),
             storage: StorageConfig::from_file(self.storage),
             permissions: PermissionsConfig::default(),
-            plugins: PluginsConfig::from_tools(self.tools),
+            plugins: PluginsConfig::from_plugins(self.plugins),
         })
+    }
+
+    /// A `plugins.<name>` key that matches no bundled plugin is a typo or an
+    /// old config, so fail loudly instead of letting it silently drift.
+    fn validate_plugin_tables(&self) -> Result<(), ConfigError> {
+        if !self.tools.is_empty() {
+            return Err(ConfigError::RenamedToolsTable);
+        }
+        for &name in EDIT_SUB_TOOLS {
+            if self.plugins.contains_key(name) {
+                return Err(ConfigError::RemovedEditSubTool { tool: name });
+            }
+        }
+        let mut unknown: Vec<&String> = self
+            .plugins
+            .keys()
+            .filter(|name| !DEFAULT_BUILTINS.contains(&name.as_str()))
+            .collect();
+        unknown.sort();
+        if let Some(&plugin) = unknown.first() {
+            return Err(ConfigError::UnknownPlugin {
+                plugin: plugin.clone(),
+                valid: DEFAULT_BUILTINS.join(", "),
+            });
+        }
+        Ok(())
     }
 }
 
 #[derive(Deserialize, Default, Debug)]
-#[serde(default, deny_unknown_fields)]
-pub struct ToolFileConfig {
+#[serde(default)]
+pub struct PluginFileConfig {
     pub enabled: Option<bool>,
+    /// Plugin-specific options passed through opaquely; each plugin declares
+    /// and validates its own via `maki.api.register_options`.
+    #[serde(flatten)]
+    pub opts: JsonMap<String, JsonValue>,
 }
 
 #[derive(Deserialize, Default, Debug)]
@@ -418,15 +449,8 @@ impl<'de> Deserialize<'de> for CompactionBuffer {
 pub struct AgentFileConfig {
     pub max_output_bytes: Option<usize>,
     pub max_output_lines: Option<usize>,
-    pub max_response_bytes: Option<usize>,
-    pub max_line_bytes: Option<usize>,
-    pub bash_timeout_secs: Option<u64>,
-    pub code_execution_timeout_secs: Option<u64>,
     pub max_continuation_turns: Option<u32>,
     pub compaction_buffer: Option<CompactionBuffer>,
-    pub search_result_limit: Option<usize>,
-    pub interpreter_max_memory_mb: Option<usize>,
-    pub task_max_concurrent: Option<usize>,
 }
 
 impl AgentFileConfig {
@@ -436,15 +460,8 @@ impl AgentFileConfig {
             overlay,
             max_output_bytes,
             max_output_lines,
-            max_response_bytes,
-            max_line_bytes,
-            bash_timeout_secs,
-            code_execution_timeout_secs,
             max_continuation_turns,
-            compaction_buffer,
-            search_result_limit,
-            interpreter_max_memory_mb,
-            task_max_concurrent
+            compaction_buffer
         );
     }
 }
@@ -488,18 +505,6 @@ impl StorageFileConfig {
             max_log_files,
             input_history_size
         );
-    }
-}
-
-#[derive(Deserialize, Default, Debug)]
-#[serde(default, deny_unknown_fields)]
-pub struct IndexFileConfig {
-    pub max_file_size_mb: Option<u64>,
-}
-
-impl IndexFileConfig {
-    fn merge(&mut self, overlay: IndexFileConfig) {
-        merge_option!(self, overlay, max_file_size_mb);
     }
 }
 
@@ -953,38 +958,14 @@ pub struct AgentConfig {
     #[config(default = DEFAULT_MAX_OUTPUT_LINES, min = MIN_OUTPUT_LINES, desc = "Max tool output lines")]
     pub max_output_lines: usize,
 
-    #[config(default = DEFAULT_MAX_RESPONSE_BYTES, min = MIN_RESPONSE_BYTES, desc = "Max LLM response size (bytes)")]
-    pub max_response_bytes: usize,
-
-    #[config(default = DEFAULT_MAX_LINE_BYTES, min = MIN_LINE_BYTES, desc = "Max bytes per line before truncation")]
-    pub max_line_bytes: usize,
-
-    #[config(default = DEFAULT_BASH_TIMEOUT_SECS, min = MIN_BASH_TIMEOUT_SECS, desc = "Bash command timeout (seconds)")]
-    pub bash_timeout_secs: u64,
-
-    #[config(default = DEFAULT_CODE_EXECUTION_TIMEOUT_SECS, min = MIN_CODE_EXECUTION_TIMEOUT_SECS, desc = "Code execution timeout (seconds)")]
-    pub code_execution_timeout_secs: u64,
-
     #[config(default = DEFAULT_MAX_CONTINUATION_TURNS, min = MIN_MAX_CONTINUATION_TURNS, desc = "Max automatic continuation turns")]
     pub max_continuation_turns: u32,
 
     #[config(default = DEFAULT_COMPACTION_BUFFER, ty = "u32 | string", default_doc = "20%", desc = "Context reserved for compaction: token count or percent of the context window (e.g. \"20%\")")]
     pub compaction_buffer: CompactionBuffer,
 
-    #[config(default = DEFAULT_SEARCH_RESULT_LIMIT, min = MIN_SEARCH_RESULT_LIMIT, desc = "Max results from grep/glob searches")]
-    pub search_result_limit: usize,
-
-    #[config(default = DEFAULT_INTERPRETER_MAX_MEMORY_MB, min = MIN_INTERPRETER_MAX_MEMORY_MB, desc = "Memory limit for code interpreter (MB)")]
-    pub interpreter_max_memory_mb: usize,
-
-    #[config(default = DEFAULT_TASK_MAX_CONCURRENT, min = MIN_TASK_MAX_CONCURRENT, desc = "Max concurrently running subagents (task tool)")]
-    pub task_max_concurrent: usize,
-
     #[config(skip, default = false)]
     pub no_rtk: bool,
-
-    #[config(skip, default = "DEFAULT_MAX_FILE_SIZE_MB * 1024 * 1024")]
-    pub index_max_file_size: u64,
 
     #[config(skip, default = "None")]
     pub max_turns: Option<u32>,
@@ -997,57 +978,19 @@ pub struct AgentConfig {
 }
 
 impl AgentConfig {
-    fn from_file(
-        file: AgentFileConfig,
-        no_rtk: bool,
-        index_file_config: &IndexFileConfig,
-        disabled_tools: Vec<String>,
-    ) -> Self {
+    fn from_file(file: AgentFileConfig, no_rtk: bool, disabled_tools: Vec<String>) -> Self {
         Self {
             no_rtk,
             max_output_bytes: file.max_output_bytes.unwrap_or(DEFAULT_MAX_OUTPUT_BYTES),
             max_output_lines: file.max_output_lines.unwrap_or(DEFAULT_MAX_OUTPUT_LINES),
-            max_response_bytes: file
-                .max_response_bytes
-                .unwrap_or(DEFAULT_MAX_RESPONSE_BYTES),
-            max_line_bytes: file.max_line_bytes.unwrap_or(DEFAULT_MAX_LINE_BYTES),
-            bash_timeout_secs: file.bash_timeout_secs.unwrap_or(DEFAULT_BASH_TIMEOUT_SECS),
-            code_execution_timeout_secs: file
-                .code_execution_timeout_secs
-                .unwrap_or(DEFAULT_CODE_EXECUTION_TIMEOUT_SECS),
             max_continuation_turns: file
                 .max_continuation_turns
                 .unwrap_or(DEFAULT_MAX_CONTINUATION_TURNS),
             compaction_buffer: file.compaction_buffer.unwrap_or(DEFAULT_COMPACTION_BUFFER),
-            search_result_limit: file
-                .search_result_limit
-                .unwrap_or(DEFAULT_SEARCH_RESULT_LIMIT),
-            interpreter_max_memory_mb: file
-                .interpreter_max_memory_mb
-                .unwrap_or(DEFAULT_INTERPRETER_MAX_MEMORY_MB),
-            task_max_concurrent: file
-                .task_max_concurrent
-                .unwrap_or(DEFAULT_TASK_MAX_CONCURRENT),
-            index_max_file_size: index_file_config
-                .max_file_size_mb
-                .unwrap_or(DEFAULT_MAX_FILE_SIZE_MB)
-                * 1024
-                * 1024,
             max_turns: None,
             allowed_tools: Vec::new(),
             disabled_tools,
         }
-    }
-
-    pub fn validate_all(&self) -> Result<(), ConfigError> {
-        self.validate()?;
-        check(
-            "agent",
-            "max_file_size_mb",
-            self.index_max_file_size / (1024 * 1024),
-            MIN_MAX_FILE_SIZE_MB,
-        )?;
-        Ok(())
     }
 }
 
@@ -1146,18 +1089,21 @@ impl StorageConfig {
 #[derive(Debug, Clone, Default)]
 pub struct PluginsConfig {
     pub enabled: bool,
-    pub tools: Vec<String>,
+    pub names: Vec<String>,
+    /// Per-plugin option tables, without `enabled`. Each plugin validates its
+    /// own via `maki.api.register_options` at load time.
+    pub opts: HashMap<String, JsonMap<String, JsonValue>>,
 }
 
 impl PluginsConfig {
-    pub fn from_tools(tools: HashMap<String, ToolFileConfig>) -> Self {
+    pub fn from_plugins(plugins: HashMap<String, PluginFileConfig>) -> Self {
         let mut all: Vec<String> = DEFAULT_BUILTINS
             .iter()
-            .filter(|name| tools.get(**name).and_then(|t| t.enabled).unwrap_or(true))
+            .filter(|name| plugins.get(**name).and_then(|t| t.enabled).unwrap_or(true))
             .map(|s| s.to_string())
             .collect();
 
-        let mut extra: Vec<&String> = tools
+        let mut extra: Vec<&String> = plugins
             .iter()
             .filter(|(name, cfg)| {
                 !DEFAULT_BUILTINS.contains(&name.as_str()) && cfg.enabled.unwrap_or(false)
@@ -1167,9 +1113,16 @@ impl PluginsConfig {
         extra.sort();
         all.extend(extra.into_iter().cloned());
 
+        let opts = plugins
+            .iter()
+            .filter(|(_, cfg)| !cfg.opts.is_empty())
+            .map(|(name, cfg)| (name.clone(), cfg.opts.clone()))
+            .collect();
+
         Self {
             enabled: true,
-            tools: all,
+            names: all,
+            opts,
         }
     }
 }
@@ -1177,7 +1130,7 @@ impl PluginsConfig {
 impl Config {
     pub fn validate(&self) -> Result<(), ConfigError> {
         self.ui.validate_all()?;
-        self.agent.validate_all()?;
+        self.agent.validate()?;
         self.provider.validate()?;
         self.storage.validate()?;
         Ok(())
@@ -1846,6 +1799,13 @@ mod tests {
     use tempfile::TempDir;
     use test_case::test_case;
 
+    fn plugin_enabled(enabled: bool) -> PluginFileConfig {
+        PluginFileConfig {
+            enabled: Some(enabled),
+            opts: JsonMap::new(),
+        }
+    }
+
     fn write_global_permissions(dir: &Path, content: &str) {
         let perms_dir = dir.join(".config/maki");
         fs::create_dir_all(&perms_dir).unwrap();
@@ -1911,14 +1871,12 @@ mod tests {
         let raw = RawConfig {
             agent: AgentFileConfig {
                 max_output_lines: Some(5000),
-                bash_timeout_secs: Some(60),
                 ..Default::default()
             },
             ..Default::default()
         };
         let config = raw.into_config(false).unwrap();
         assert_eq!(config.agent.max_output_lines, 5000);
-        assert_eq!(config.agent.bash_timeout_secs, 60);
         assert_eq!(config.agent.max_output_bytes, DEFAULT_MAX_OUTPUT_BYTES);
     }
 
@@ -1933,7 +1891,7 @@ mod tests {
             },
             agent: AgentFileConfig {
                 max_output_lines: Some(3000),
-                max_line_bytes: Some(800),
+                max_output_bytes: Some(80_000),
                 ..Default::default()
             },
             ..Default::default()
@@ -1950,7 +1908,7 @@ mod tests {
 
         assert_eq!(base.always_yolo, Some(true), "overlay wins");
         assert_eq!(base.agent.max_output_lines, Some(5000), "overlay wins");
-        assert_eq!(base.agent.max_line_bytes, Some(800), "base preserved");
+        assert_eq!(base.agent.max_output_bytes, Some(80_000), "base preserved");
         assert_eq!(base.ui.splash_animation, Some(false), "base preserved");
         assert_eq!(base.ui.flash_duration_ms, Some(2000), "base preserved");
     }
@@ -1992,24 +1950,6 @@ mod tests {
         assert!(raw.into_config(false).unwrap().always_workflow);
     }
 
-    #[test]
-    fn task_max_concurrent_resolves_default_and_set() {
-        let defaults = RawConfig::default().into_config(false).unwrap();
-        assert_eq!(
-            defaults.agent.task_max_concurrent,
-            DEFAULT_TASK_MAX_CONCURRENT
-        );
-
-        let raw = RawConfig {
-            agent: AgentFileConfig {
-                task_max_concurrent: Some(3),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        assert_eq!(raw.into_config(false).unwrap().agent.task_max_concurrent, 3);
-    }
-
     #[test_case(AlwaysThinking::Toggle(true), StoredThinking::Adaptive ; "toggle_true")]
     #[test_case(AlwaysThinking::Toggle(false), StoredThinking::Off ; "toggle_false")]
     #[test_case(AlwaysThinking::Budget(8192), StoredThinking::Budget { tokens: 8192 } ; "budget_number")]
@@ -2042,19 +1982,12 @@ mod tests {
 
     #[test_case("max_output_bytes",  0 ; "zero_output_bytes")]
     #[test_case("max_output_lines",  0 ; "zero_output_lines")]
-    #[test_case("max_response_bytes", 0 ; "zero_response_bytes")]
-    #[test_case("max_line_bytes",    0 ; "zero_line_bytes")]
     #[test_case("max_output_bytes",  500 ; "below_min_output_bytes")]
-    #[test_case("max_line_bytes",    10 ; "below_min_line_bytes")]
-    #[test_case("task_max_concurrent", 0 ; "zero_task_max_concurrent")]
     fn validate_rejects_invalid_agent(field: &str, value: usize) {
         let mut config = AgentConfig::default();
         match field {
             "max_output_bytes" => config.max_output_bytes = value,
             "max_output_lines" => config.max_output_lines = value,
-            "max_response_bytes" => config.max_response_bytes = value,
-            "max_line_bytes" => config.max_line_bytes = value,
-            "task_max_concurrent" => config.task_max_concurrent = value,
             _ => unreachable!(),
         }
         let err = config.validate().unwrap_err();
@@ -2085,9 +2018,8 @@ mod tests {
 
     #[test_case("provider", "connect_timeout_secs", 0 ; "provider_zero_connect_timeout")]
     #[test_case("storage",  "max_log_files",        0 ; "storage_zero_log_files")]
-    #[test_case("agent",    "max_file_size_mb",     0 ; "agent_zero_file_size")]
     #[test_case("ui",       "mouse_scroll_lines",   0 ; "ui_zero_scroll_lines")]
-    #[test_case("agent",    "bash_timeout_secs",    1 ; "agent_bash_timeout_too_low")]
+    #[test_case("agent",    "max_output_lines",     1 ; "agent_output_lines_too_low")]
     fn validate_rejects_invalid_sections(section: &str, field: &str, value: u64) {
         let mut config = Config {
             always_yolo: false,
@@ -2106,9 +2038,8 @@ mod tests {
                 config.provider.connect_timeout = Duration::from_secs(value)
             }
             ("storage", "max_log_files") => config.storage.max_log_files = value as u32,
-            ("agent", "max_file_size_mb") => config.agent.index_max_file_size = value * 1024 * 1024,
             ("ui", "mouse_scroll_lines") => config.ui.mouse_scroll_lines = value as u32,
-            ("agent", "bash_timeout_secs") => config.agent.bash_timeout_secs = value,
+            ("agent", "max_output_lines") => config.agent.max_output_lines = value as usize,
             _ => unreachable!(),
         }
         let err = config.validate().unwrap_err();
@@ -2435,59 +2366,51 @@ mod tests {
     }
 
     #[test]
-    fn plugins_default_builtins_populated_when_enabled() {
-        let config = RawConfig::default().into_config(false).unwrap();
-        assert!(
-            !config.plugins.tools.is_empty(),
-            "enabled plugins should have default builtins"
-        );
-    }
-
-    #[test]
-    fn merge_tools_overlay_replaces_and_preserves() {
-        let mut base = RawConfig::default();
-        base.tools.insert(
-            "index".to_string(),
-            ToolFileConfig {
-                enabled: Some(true),
-            },
-        );
-        base.tools.insert(
-            "websearch".to_string(),
-            ToolFileConfig {
-                enabled: Some(true),
-            },
-        );
-
-        let mut overlay = RawConfig::default();
-        overlay.tools.insert(
-            "websearch".to_string(),
-            ToolFileConfig {
-                enabled: Some(false),
-            },
-        );
-        overlay.tools.insert(
-            "alpha_tool".to_string(),
-            ToolFileConfig {
-                enabled: Some(true),
-            },
-        );
+    fn merge_plugins_overlay_wins_per_key() {
+        let mut base: RawConfig = toml::from_str(
+            "[plugins.index]\nenabled = true\n\
+             [plugins.websearch]\nenabled = true\n\
+             [plugins.grep]\nenabled = true\nsearch_result_limit = 200\nmax_line_bytes = 900\n",
+        )
+        .unwrap();
+        let overlay: RawConfig = toml::from_str(
+            "[plugins.websearch]\nenabled = false\n\
+             [plugins.alpha_tool]\nenabled = true\n\
+             [plugins.grep]\nsearch_result_limit = 50\n",
+        )
+        .unwrap();
 
         base.merge(overlay);
         assert_eq!(
-            base.tools["index"].enabled,
+            base.plugins["index"].enabled,
             Some(true),
             "base-only key preserved"
         );
         assert_eq!(
-            base.tools["websearch"].enabled,
+            base.plugins["websearch"].enabled,
             Some(false),
             "overlay replaces"
         );
         assert_eq!(
-            base.tools["alpha_tool"].enabled,
+            base.plugins["alpha_tool"].enabled,
             Some(true),
             "overlay-only key added"
+        );
+        let grep = &base.plugins["grep"];
+        assert_eq!(
+            grep.enabled,
+            Some(true),
+            "enabled preserved when overlay omits it"
+        );
+        assert_eq!(
+            grep.opts["search_result_limit"],
+            serde_json::json!(50),
+            "overlay opt wins"
+        );
+        assert_eq!(
+            grep.opts["max_line_bytes"],
+            serde_json::json!(900),
+            "base opt preserved"
         );
     }
 
@@ -2511,8 +2434,9 @@ mod tests {
     }
 
     #[test_case("[ui]\nsplash_animaton = true\n" ; "top_level_typo")]
-    #[test_case("agent = { bsh_timeout_secs = 60 }\n" ; "nested_section_typo")]
-    #[test_case("[tools.bash]\nenabled = true\ntypo_field = 42\n" ; "tool_config_typo")]
+    #[test_case("agent = { bash_timeout_secs = 60 }\n" ; "moved_bash_timeout")]
+    #[test_case("agent = { search_result_limit = 50 }\n" ; "moved_search_limit")]
+    #[test_case("[index]\nmax_file_size_mb = 4\n" ; "removed_index_section")]
     fn deny_unknown_fields_rejects(toml_str: &str) {
         let result: Result<RawConfig, _> = toml::from_str(toml_str);
         assert!(
@@ -2522,67 +2446,85 @@ mod tests {
     }
 
     #[test]
-    fn deny_unknown_fields_accepts_valid_tools() {
-        const VALID: &str = "[tools.bash]\nenabled = true\n[tools.websearch]\nenabled = false\n";
+    fn deny_unknown_fields_accepts_valid_plugins() {
+        const VALID: &str =
+            "[plugins.bash]\nenabled = true\n[plugins.websearch]\nenabled = false\n";
         let result: Result<RawConfig, _> = toml::from_str(VALID);
         assert!(
             result.is_ok(),
-            "valid tools section should parse: {:?}",
+            "valid plugins section should parse: {:?}",
             result.err()
         );
     }
 
     #[test]
-    fn plugins_from_tools_default() {
-        let plugins = PluginsConfig::from_tools(HashMap::new());
+    fn plugin_extra_keys_parse_into_opts() {
+        let raw: RawConfig =
+            toml::from_str("[plugins.bash]\nenabled = true\ntimeout_secs = 180\n").unwrap();
+        let bash = &raw.plugins["bash"];
+        assert_eq!(bash.enabled, Some(true));
+        assert_eq!(bash.opts["timeout_secs"], serde_json::json!(180));
+    }
+
+    #[test]
+    fn into_config_wires_plugin_names_and_opts() {
+        let raw: RawConfig = toml::from_str(
+            "[plugins.bash]\ntimeout_secs = 180\n[plugins.websearch]\nenabled = false\n",
+        )
+        .unwrap();
+        let config = raw.into_config(false).unwrap();
+        assert!(config.plugins.names.contains(&"bash".to_string()));
+        assert!(!config.plugins.names.contains(&"websearch".to_string()));
+        assert!(
+            config.plugins.names.contains(&"index".to_string()),
+            "untouched builtin stays"
+        );
+        assert_eq!(
+            config.plugins.opts["bash"]["timeout_secs"],
+            serde_json::json!(180)
+        );
+        assert!(
+            !config.plugins.opts.contains_key("websearch"),
+            "enabled-only tables produce no opts"
+        );
+    }
+
+    #[test]
+    fn from_plugins_default() {
+        let plugins = PluginsConfig::from_plugins(HashMap::new());
         let expected: Vec<String> = DEFAULT_BUILTINS.iter().map(|s| s.to_string()).collect();
-        assert_eq!(plugins.tools, expected);
+        assert_eq!(plugins.names, expected);
         assert!(plugins.enabled);
     }
 
     #[test]
-    fn plugins_from_tools_enable_disable_and_sort() {
-        let mut tools = HashMap::new();
-        tools.insert(
-            "websearch".to_string(),
-            ToolFileConfig {
-                enabled: Some(false),
-            },
-        );
-        tools.insert(
-            "zeta".to_string(),
-            ToolFileConfig {
-                enabled: Some(true),
-            },
-        );
-        tools.insert(
-            "alpha".to_string(),
-            ToolFileConfig {
-                enabled: Some(true),
-            },
-        );
-        tools.insert("custom_tool".to_string(), ToolFileConfig { enabled: None });
+    fn from_plugins_enable_disable_and_sort() {
+        let mut entries = HashMap::new();
+        entries.insert("websearch".to_string(), plugin_enabled(false));
+        entries.insert("zeta".to_string(), plugin_enabled(true));
+        entries.insert("alpha".to_string(), plugin_enabled(true));
+        entries.insert("custom_tool".to_string(), PluginFileConfig::default());
 
-        let plugins = PluginsConfig::from_tools(tools);
+        let plugins = PluginsConfig::from_plugins(entries);
         assert!(
-            !plugins.tools.contains(&"websearch".to_string()),
+            !plugins.names.contains(&"websearch".to_string()),
             "disabled builtin removed"
         );
         assert!(
-            plugins.tools.contains(&"index".to_string()),
+            plugins.names.contains(&"index".to_string()),
             "untouched builtin stays"
         );
         assert!(
-            plugins.tools.contains(&"bash".to_string()),
+            plugins.names.contains(&"bash".to_string()),
             "bash is a default builtin"
         );
         assert!(
-            !plugins.tools.contains(&"custom_tool".to_string()),
+            !plugins.names.contains(&"custom_tool".to_string()),
             "enabled=None non-default ignored"
         );
 
         let extras: Vec<_> = plugins
-            .tools
+            .names
             .iter()
             .filter(|t| !DEFAULT_BUILTINS.contains(&t.as_str()))
             .cloned()
@@ -2592,22 +2534,6 @@ mod tests {
             vec!["alpha", "zeta"],
             "extras sorted alphabetically"
         );
-    }
-
-    #[test]
-    fn plugins_from_tools_all_builtins_disabled() {
-        let mut tools = HashMap::new();
-        for name in DEFAULT_BUILTINS {
-            tools.insert(
-                name.to_string(),
-                ToolFileConfig {
-                    enabled: Some(false),
-                },
-            );
-        }
-        let plugins = PluginsConfig::from_tools(tools);
-        assert!(plugins.tools.is_empty());
-        assert!(plugins.enabled);
     }
 
     #[test]
@@ -2642,32 +2568,6 @@ mod tests {
     }
 
     #[test]
-    fn into_config_tools_flow_to_plugins() {
-        let mut tools = HashMap::new();
-        tools.insert(
-            "bash".to_string(),
-            ToolFileConfig {
-                enabled: Some(true),
-            },
-        );
-        tools.insert(
-            "websearch".to_string(),
-            ToolFileConfig {
-                enabled: Some(false),
-            },
-        );
-        let raw = RawConfig {
-            tools,
-            ..Default::default()
-        };
-        let config = raw.into_config(false).unwrap();
-
-        assert!(config.plugins.tools.contains(&"bash".to_string()));
-        assert!(!config.plugins.tools.contains(&"websearch".to_string()));
-        assert!(config.plugins.tools.contains(&"index".to_string()));
-    }
-
-    #[test]
     fn default_builtins_sorted() {
         for pair in DEFAULT_BUILTINS.windows(2) {
             assert!(
@@ -2680,42 +2580,74 @@ mod tests {
     }
 
     #[test]
-    fn opt_in_tools_require_explicit_enable() {
-        let default_config = RawConfig::default().into_config(false).unwrap();
-        for &name in OPT_IN_TOOLS {
+    fn removed_sub_tool_tables_error() {
+        for &tool in EDIT_SUB_TOOLS {
+            let raw: RawConfig = toml::from_str(&format!("[plugins.{tool}]\n")).unwrap();
+            let Err(err) = raw.into_config(false) else {
+                panic!("plugins.{tool} should be rejected");
+            };
+            let msg = err.to_string();
             assert!(
-                default_config
-                    .agent
-                    .disabled_tools
-                    .contains(&name.to_string()),
-                "{name} should be disabled by default"
+                msg.contains(&format!("plugins.{tool} was removed"))
+                    && msg.contains("plugins.edit = {"),
+                "error should point at plugins.edit, got: {msg}"
             );
         }
+    }
 
-        let mut tools = HashMap::new();
-        for &name in OPT_IN_TOOLS {
-            tools.insert(
-                name.to_string(),
-                ToolFileConfig {
-                    enabled: Some(true),
-                },
-            );
-        }
-        let enabled_config = RawConfig {
-            tools,
-            ..Default::default()
-        }
-        .into_config(false)
-        .unwrap();
-        for &name in OPT_IN_TOOLS {
-            assert!(
-                !enabled_config
-                    .agent
-                    .disabled_tools
-                    .contains(&name.to_string()),
-                "{name} should be enabled when configured"
-            );
-        }
+    #[test_case("enabled = false" ; "enabled_false")]
+    #[test_case("search_result_limit = 50" ; "opts_only")]
+    fn unknown_plugin_name_errors(body: &str) {
+        let raw: RawConfig = toml::from_str(&format!("[plugins.gerp]\n{body}\n")).unwrap();
+        let Err(err) = raw.into_config(false) else {
+            panic!("plugins.gerp should be rejected");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no bundled plugin is named \"gerp\"") && msg.contains("grep"),
+            "error should name the typo and list bundled plugins, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn disabled_plugin_keeps_opts_but_not_load_entry() {
+        let raw: RawConfig =
+            toml::from_str("[plugins.bash]\nenabled = false\ntimeout_secs = 180\n").unwrap();
+        let config = raw.into_config(false).unwrap();
+        assert!(!config.plugins.names.contains(&"bash".to_string()));
+        assert_eq!(
+            config.plugins.opts["bash"]["timeout_secs"],
+            serde_json::json!(180),
+            "opts survive for when the plugin is re-enabled"
+        );
+    }
+
+    #[test]
+    fn renamed_tools_table_errors() {
+        let raw: RawConfig = toml::from_str("[tools.bash]\nenabled = true\n").unwrap();
+        let Err(err) = raw.into_config(false) else {
+            panic!("old tools table should be rejected");
+        };
+        assert!(
+            err.to_string().contains("renamed to `plugins`"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn edit_sub_tool_toggles_flow_as_edit_opts() {
+        let raw: RawConfig =
+            toml::from_str("[plugins.edit]\nmultiedit = false\nedit_lines = true\n").unwrap();
+        let config = raw.into_config(false).unwrap();
+        assert_eq!(
+            config.plugins.opts["edit"]["multiedit"],
+            serde_json::json!(false)
+        );
+        assert_eq!(
+            config.plugins.opts["edit"]["edit_lines"],
+            serde_json::json!(true)
+        );
+        assert!(config.agent.disabled_tools.is_empty());
     }
 
     #[test]

--- a/maki-docgen/src/gen_config.rs
+++ b/maki-docgen/src/gen_config.rs
@@ -1,11 +1,13 @@
 use std::fmt::Write;
+use std::sync::Arc;
 
+use maki_agent::tools::ToolRegistry;
 use maki_config::{
-    AgentConfig, ConfigField, DEFAULT_BASH_TIMEOUT_SECS, DEFAULT_MAX_FILE_SIZE_MB,
-    DEFAULT_MAX_LOG_FILES, DEFAULT_MAX_OUTPUT_LINES, DEFAULT_MOUSE_SCROLL_LINES, INDEX_FIELDS,
-    MIN_TOOL_OUTPUT_LINES, ProviderConfig, StorageConfig, TOP_LEVEL_FIELDS, ToolOutputLines,
-    UiConfig,
+    AgentConfig, ConfigField, DEFAULT_MAX_LOG_FILES, DEFAULT_MAX_OUTPUT_LINES,
+    DEFAULT_MOUSE_SCROLL_LINES, MIN_TOOL_OUTPUT_LINES, ProviderConfig, StorageConfig,
+    TOP_LEVEL_FIELDS, ToolOutputLines, UiConfig,
 };
+use maki_lua::{PluginHost, PluginOptionSpecs};
 
 fn write_table_with_min(out: &mut String, fields: &[ConfigField]) {
     writeln!(out, "| Field | Type | Default | Min | Description |").unwrap();
@@ -66,6 +68,41 @@ fn write_section(out: &mut String, heading: &str, fields: &[ConfigField]) {
     writeln!(out).unwrap();
 }
 
+fn write_plugin_options(out: &mut String, specs: &PluginOptionSpecs) {
+    for (plugin, options) in specs {
+        writeln!(out, "### `plugins.{plugin}`\n").unwrap();
+        writeln!(out, "| Field | Type | Default | Min | Description |").unwrap();
+        writeln!(out, "|-------|------|---------|-----|-------------|").unwrap();
+        for o in options {
+            let default = o
+                .default
+                .as_ref()
+                .map_or("-".to_string(), |d| format!("`{d}`"));
+            let min = o.min.map_or("-".to_string(), |m| m.to_string());
+            writeln!(
+                out,
+                "| `{name}` | {ty} | {default} | {min} | {desc} |",
+                name = o.name,
+                ty = o.ty,
+                desc = o.desc,
+            )
+            .unwrap();
+        }
+        writeln!(out).unwrap();
+    }
+}
+
+fn collect_plugin_options() -> PluginOptionSpecs {
+    let host =
+        PluginHost::with_all_builtins(Arc::new(ToolRegistry::new())).expect("loading builtins");
+    let specs = host.plugin_options().expect("collecting plugin options");
+    assert!(
+        !specs.is_empty(),
+        "no plugin declared options; the plugins reference would be empty"
+    );
+    specs
+}
+
 fn write_tool_output_section(out: &mut String) {
     writeln!(out, "### `ui.tool_output_lines`\n").unwrap();
     writeln!(
@@ -119,7 +156,6 @@ maki.setup({{
         }},
     }},
     agent = {{
-        bash_timeout_secs = {bash_timeout},
         max_output_lines = {max_output_lines},
     }},
     provider = {{
@@ -128,8 +164,9 @@ maki.setup({{
     storage = {{
         max_log_files = {max_log_files},
     }},
-    index = {{
-        max_file_size_mb = {max_file_size},
+    plugins = {{
+        bash = {{ timeout_secs = 180 }},
+        index = {{ max_file_size_mb = 4 }},
     }},
 }})
 ```
@@ -143,10 +180,8 @@ All fields are optional. Typos in field names cause an error right away.
         mouse_scroll = DEFAULT_MOUSE_SCROLL_LINES + 2,
         tol_bash = ToolOutputLines::DEFAULT.bash + 3,
         tol_read = ToolOutputLines::DEFAULT.read + 2,
-        bash_timeout = DEFAULT_BASH_TIMEOUT_SECS + 60,
         max_output_lines = DEFAULT_MAX_OUTPUT_LINES + 1000,
         max_log_files = DEFAULT_MAX_LOG_FILES / 2,
-        max_file_size = DEFAULT_MAX_FILE_SIZE_MB + 2,
     )
     .unwrap();
 
@@ -159,14 +194,20 @@ All fields are optional. Typos in field names cause an error right away.
     write_section(&mut out, "[agent]", AgentConfig::FIELDS);
     write_section(&mut out, "[provider]", ProviderConfig::FIELDS);
     write_section(&mut out, "[storage]", StorageConfig::FIELDS);
-    write_section(&mut out, "[index]", INDEX_FIELDS);
 
-    writeln!(out, "## Tools\n").unwrap();
+    writeln!(out, "## Plugins\n").unwrap();
     writeln!(
         out,
-        "The `tools` table lets you turn tools on or off. \
-         By default `index`, `webfetch`, and `websearch` are on. \
-         `bash` is off by default.\n"
+        "The `plugins` table turns plugins on or off and passes options to \
+         them. All bundled plugins are on by default. Set \
+         `enabled = false` to turn one off.\n\n\
+         Each plugin checks its own options at startup. A typo, a wrong \
+         type, or an unknown plugin name gives you a clear error right \
+         away.\n\n\
+         The edit plugin's extra tools are options too: \
+         `plugins.edit = {{ multiedit = false, edit_lines = true }}`. \
+         The old `tools` table is gone. If your config still uses it, \
+         Maki stops at startup and shows you the new form.\n"
     )
     .unwrap();
     writeln!(
@@ -174,14 +215,16 @@ All fields are optional. Typos in field names cause an error right away.
         "\
 ```lua
 maki.setup({{
-    tools = {{
-        bash = {{ enabled = true }},
+    plugins = {{
+        bash = {{ timeout_secs = 180 }},
         websearch = {{ enabled = false }},
     }},
 }})
 ```\n"
     )
     .unwrap();
+
+    write_plugin_options(&mut out, &collect_plugin_options());
 
     writeln!(out, "## Validation\n").unwrap();
     writeln!(
@@ -230,46 +273,7 @@ On top of `AGENTS.md`, you can add your own instructions in two places:
 - `AGENTS.local.md` at project root for per-project preferences (gitignored)
 - `~/.config/maki/AGENTS.md` for preferences that apply to all projects
 
-Both are added to the system prompt at the start of every session.
-
-## Migrating from config.toml
-
-Still have a `config.toml`? Here is how to switch over.
-
-**Rename your config files:**
-
-```
-~/.config/maki/config.toml  ->  ~/.config/maki/init.lua
-.maki/config.toml           ->  .maki/init.lua
-```
-
-**Wrap the content in `maki.setup()`:**
-
-Before:
-
-```toml
-[agent]
-bash_timeout_secs = 180
-```
-
-After:
-
-```lua
-maki.setup({{
-    agent = {{ bash_timeout_secs = 180 }},
-}})
-```
-
-Same field names, just Lua syntax instead of TOML.
-
-**Move MCP sections to `mcp.toml`.**
-
-- `~/.config/maki/mcp.toml` (global)
-- `.maki/mcp.toml` (per-project)
-
-Same format, just a different file. See [MCP](/docs/mcp/).
-
-**Permissions stay in `permissions.toml`.**"
+Both are added to the system prompt at the start of every session."
     )
     .unwrap();
 

--- a/maki-docgen/src/gen_tools.rs
+++ b/maki-docgen/src/gen_tools.rs
@@ -1,13 +1,13 @@
 use maki_agent::template::Vars;
 use maki_agent::tools::{DescriptionContext, ToolAudience, ToolFilter, ToolRegistry, ToolSource};
-use maki_config::OPT_IN_TOOLS;
+use maki_config::{PluginFileConfig, PluginsConfig};
 use regex::Regex;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use std::sync::Arc;
 
-use maki_lua::PluginHost;
+use maki_lua::{OptionType, PluginHost};
 
 const DATE_PLACEHOLDER: &str = "YYYY-MM-DD";
 
@@ -141,7 +141,7 @@ fn source_label(source: &ToolSource) -> &'static str {
     }
 }
 
-fn write_tool_entry(out: &mut String, name: &str, info: &ToolInfo) {
+fn write_tool_entry(out: &mut String, name: &str, info: &ToolInfo, opt_in: &HashSet<String>) {
     let description = info
         .def
         .get("description")
@@ -153,7 +153,7 @@ fn write_tool_entry(out: &mut String, name: &str, info: &ToolInfo) {
 
     writeln!(out).unwrap();
     let mut badge_text = source_label(&info.source).to_string();
-    if OPT_IN_TOOLS.contains(&name) {
+    if opt_in.contains(name) {
         badge_text.push_str(", opt-in");
     }
     writeln!(out, "### `{name}` *({badge_text})*").unwrap();
@@ -226,11 +226,31 @@ fn collect_tool_info(
     })
 }
 
-fn load_registry_with_builtins() -> Arc<ToolRegistry> {
+/// Loads every builtin with all sub-tools on, so the reference documents
+/// opt-in tools too. "Opt-in" means the plugin declares the tool as a boolean
+/// option defaulting to false, so the badge cannot drift from the defaults.
+fn load_registry_with_builtins() -> (Arc<ToolRegistry>, HashSet<String>) {
     let registry = Arc::new(ToolRegistry::new());
-    let _host =
-        PluginHost::with_all_builtins(Arc::clone(&registry)).expect("loading builtin plugins");
-    registry
+    let mut host = PluginHost::new(Arc::clone(&registry)).expect("plugin host");
+
+    let mut plugins = HashMap::new();
+    let mut edit = PluginFileConfig::default();
+    for &sub in maki_config::EDIT_SUB_TOOLS {
+        edit.opts.insert(sub.to_owned(), Value::Bool(true));
+    }
+    plugins.insert("edit".to_owned(), edit);
+    host.load_builtins(&PluginsConfig::from_plugins(plugins))
+        .expect("loading builtin plugins");
+
+    let opt_in = host
+        .plugin_options()
+        .expect("collecting plugin options")
+        .into_values()
+        .flatten()
+        .filter(|o| o.ty == OptionType::Boolean && o.default == Some(Value::Bool(false)))
+        .map(|o| o.name)
+        .collect();
+    (registry, opt_in)
 }
 
 pub fn generate() -> String {
@@ -239,7 +259,7 @@ pub fn generate() -> String {
         .set("{platform}", "linux")
         .set("{date}", "YYYY-MM-DD");
 
-    let registry = load_registry_with_builtins();
+    let (registry, opt_in) = load_registry_with_builtins();
     let defs = registry.definitions(
         &vars,
         &DescriptionContext {
@@ -295,7 +315,7 @@ pub fn generate() -> String {
         writeln!(out, "## {section_name}").unwrap();
         for name in present {
             let info = tools.get(name).expect("checked above");
-            write_tool_entry(&mut out, name, info);
+            write_tool_entry(&mut out, name, info, &opt_in);
             rendered.insert(name);
         }
     }
@@ -311,7 +331,7 @@ pub fn generate() -> String {
         writeln!(out, "## Additional tools").unwrap();
         for name in leftovers {
             let info = tools.get(name).expect("checked above");
-            write_tool_entry(&mut out, name, info);
+            write_tool_entry(&mut out, name, info, &opt_in);
         }
     }
 
@@ -365,7 +385,7 @@ mod tests {
 
     #[test]
     fn sections_partition_registered_tools() {
-        let registry = load_registry_with_builtins();
+        let (registry, _) = load_registry_with_builtins();
         let snapshot = registry.iter();
         let registered: HashSet<&str> = snapshot.iter().map(|e| e.name()).collect();
 

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod json;
 pub(crate) mod keymap;
 pub(crate) mod log;
 pub(crate) mod net;
+pub(crate) mod options;
 pub(crate) mod session;
 pub(crate) mod slot;
 pub(crate) mod text;
@@ -25,6 +26,7 @@ use std::sync::Arc;
 
 use mlua::{Lua, Result as LuaResult, Table};
 
+use crate::api::options::PluginOpts;
 use crate::api::tool::PendingTools;
 use crate::api::util::command::UiAction;
 use crate::plugin_permissions::PluginPermissions;
@@ -35,10 +37,11 @@ pub(crate) fn create_maki_global(
     plugin: Arc<str>,
     ui_action_tx: Option<flume::Sender<UiAction>>,
     permissions: &PluginPermissions,
+    opts: PluginOpts,
 ) -> LuaResult<Table> {
     let maki = lua.create_table()?;
 
-    let api = tool::create_api_table(lua, pending, Arc::clone(&plugin))?;
+    let api = tool::create_api_table(lua, pending, Arc::clone(&plugin), opts)?;
     autocmd::add_autocmd_methods(&api, lua, Arc::clone(&plugin))?;
     slot::add_slot_methods(&api, lua, Arc::clone(&plugin))?;
     maki.set("api", api)?;

--- a/maki-lua/src/api/options.rs
+++ b/maki-lua/src/api/options.rs
@@ -1,0 +1,288 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::Arc;
+
+use maki_lua_macro::lua_fn;
+use mlua::{Lua, Result as LuaResult, Table, Value as LuaValue};
+use serde_json::{Map as JsonMap, Value as JsonValue};
+
+use crate::api::util::convert::json_to_lua;
+
+/// The user's `plugins.<name>` table from `maki.setup`, passed through opaquely.
+pub(crate) type PluginOpts = Arc<JsonMap<String, JsonValue>>;
+
+/// Option specs declared via `register_options`, keyed by plugin name. Read
+/// by docgen and by the loader to reject `plugins.<name>` keys no plugin ever
+/// declared.
+pub type PluginOptionSpecs = BTreeMap<Arc<str>, Vec<OptionSpec>>;
+
+const SPEC_KEYS: &[&str] = &["default", "type", "min", "desc"];
+/// `plugins.<name>.enabled` is consumed by the config layer and never reaches
+/// the plugin, so declaring it would be dead.
+const RESERVED_NAMES: &[&str] = &["enabled"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OptionType {
+    Boolean,
+    Integer,
+    Number,
+    String,
+}
+
+impl OptionType {
+    const ALL: &[Self] = &[Self::Boolean, Self::Integer, Self::Number, Self::String];
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Boolean => "boolean",
+            Self::Integer => "integer",
+            Self::Number => "number",
+            Self::String => "string",
+        }
+    }
+
+    fn parse(s: &str) -> Option<Self> {
+        Self::ALL.iter().copied().find(|t| t.as_str() == s)
+    }
+
+    fn valid_list() -> String {
+        Self::ALL
+            .iter()
+            .map(|t| t.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
+    fn of_json(value: &JsonValue) -> Option<Self> {
+        match value {
+            JsonValue::Bool(_) => Some(Self::Boolean),
+            JsonValue::Number(n) if n.is_i64() || n.is_u64() => Some(Self::Integer),
+            JsonValue::Number(_) => Some(Self::Number),
+            JsonValue::String(_) => Some(Self::String),
+            _ => None,
+        }
+    }
+
+    fn matches(self, value: &JsonValue) -> bool {
+        match self {
+            Self::Number => value.is_number(),
+            _ => Self::of_json(value) == Some(self),
+        }
+    }
+
+    fn is_numeric(self) -> bool {
+        matches!(self, Self::Integer | Self::Number)
+    }
+}
+
+impl fmt::Display for OptionType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Single source for user-value validation and the generated config docs.
+#[derive(Debug, Clone)]
+pub struct OptionSpec {
+    pub name: String,
+    pub ty: OptionType,
+    pub default: Option<JsonValue>,
+    pub min: Option<f64>,
+    pub desc: String,
+}
+
+pub(crate) fn collect_plugin_options(lua: &Lua) -> PluginOptionSpecs {
+    lua.app_data_ref::<PluginOptionSpecs>()
+        .map(|store| store.clone())
+        .unwrap_or_default()
+}
+
+fn spec_error(name: &str, msg: &str) -> mlua::Error {
+    mlua::Error::runtime(format!("register_options: option \"{name}\": {msg}"))
+}
+
+fn default_to_json(name: &str, value: LuaValue) -> LuaResult<Option<JsonValue>> {
+    Ok(Some(match value {
+        LuaValue::Nil => return Ok(None),
+        LuaValue::Boolean(b) => JsonValue::Bool(b),
+        LuaValue::Integer(i) => JsonValue::from(i),
+        LuaValue::Number(n) => serde_json::Number::from_f64(n)
+            .map(JsonValue::Number)
+            .ok_or_else(|| spec_error(name, "default must be a finite number"))?,
+        LuaValue::String(s) => JsonValue::String(s.to_str()?.to_owned()),
+        _ => {
+            return Err(spec_error(
+                name,
+                "default must be a boolean, number, or string",
+            ));
+        }
+    }))
+}
+
+fn parse_spec(name: &str, spec: &Table) -> LuaResult<OptionSpec> {
+    if RESERVED_NAMES.contains(&name) {
+        return Err(spec_error(
+            name,
+            "reserved name (`enabled` is handled by the config layer)",
+        ));
+    }
+    for pair in spec.pairs::<String, LuaValue>() {
+        let (key, _) = pair.map_err(|_| spec_error(name, "spec keys must be strings"))?;
+        if !SPEC_KEYS.contains(&key.as_str()) {
+            return Err(spec_error(
+                name,
+                &format!(
+                    "unknown spec key \"{key}\" (expected one of: {})",
+                    SPEC_KEYS.join(", ")
+                ),
+            ));
+        }
+    }
+
+    let default = default_to_json(name, spec.get("default")?)?;
+    let ty = match spec.get::<Option<String>>("type")? {
+        Some(s) => OptionType::parse(&s).ok_or_else(|| {
+            spec_error(
+                name,
+                &format!(
+                    "invalid type \"{s}\" (expected one of: {})",
+                    OptionType::valid_list()
+                ),
+            )
+        })?,
+        None => match &default {
+            Some(d) => OptionType::of_json(d).expect("default_to_json only keeps scalar types"),
+            None => {
+                return Err(spec_error(
+                    name,
+                    "type is required when there is no default",
+                ));
+            }
+        },
+    };
+    if let Some(d) = &default
+        && !ty.matches(d)
+    {
+        return Err(spec_error(
+            name,
+            &format!("default {d} does not match type {ty}"),
+        ));
+    }
+
+    let min: Option<f64> = spec.get("min")?;
+    if let Some(min) = min {
+        if !ty.is_numeric() {
+            return Err(spec_error(
+                name,
+                &format!("min is not allowed for type {ty}"),
+            ));
+        }
+        if let Some(d) = &default
+            && d.as_f64().is_some_and(|v| v < min)
+        {
+            return Err(spec_error(
+                name,
+                &format!("default {d} is below min ({min})"),
+            ));
+        }
+    }
+
+    let desc: String = spec
+        .get::<Option<String>>("desc")?
+        .filter(|d| !d.is_empty())
+        .ok_or_else(|| spec_error(name, "desc is required"))?;
+
+    Ok(OptionSpec {
+        name: name.to_owned(),
+        ty,
+        default,
+        min,
+        desc,
+    })
+}
+
+fn validate_user_opts(
+    plugin: &str,
+    opts: &JsonMap<String, JsonValue>,
+    specs: &[OptionSpec],
+) -> LuaResult<()> {
+    for (key, value) in opts {
+        let Some(spec) = specs.iter().find(|s| &s.name == key) else {
+            let valid: Vec<&str> = specs.iter().map(|s| s.name.as_str()).collect();
+            return Err(mlua::Error::runtime(format!(
+                "unknown option \"{key}\" for plugins.{plugin} (valid options: {})",
+                valid.join(", ")
+            )));
+        };
+        if !spec.ty.matches(value) {
+            return Err(mlua::Error::runtime(format!(
+                "invalid value for plugins.{plugin}.{key}: expected {}, got {value}",
+                spec.ty
+            )));
+        }
+        if let Some(min) = spec.min
+            && value.as_f64().is_some_and(|v| v < min)
+        {
+            return Err(mlua::Error::runtime(format!(
+                "invalid value for plugins.{plugin}.{key}: {value} is below minimum ({min})"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Declare the options your plugin accepts under `plugins.<name>` in
+/// `maki.setup`, and get back what the user set merged with your defaults.
+/// Call it once, at the top level of your plugin file.
+///
+/// An unknown key, a wrong type, or a value below `min` fails the plugin
+/// load with a clear message, so users catch typos right away. Bad specs
+/// fail the load too. The specs also feed the generated configuration docs.
+///
+/// @param spec table Map of option name to a spec table:
+///   default (boolean|number|string) Optional. Used when the user sets nothing. Its Lua type becomes the option type.
+///   type    (string) Required when there is no default: "boolean", "integer", "number", or "string".
+///   min     (number) Optional. Minimum accepted value, numeric options only.
+///   desc    (string) Required. One line shown in the configuration docs.
+/// @return (table) Merged options: the user's value where set, otherwise the default, or nil when neither exists.
+/// @example
+/// local opts = maki.api.register_options({
+///   timeout_secs = { default = 120, min = 5, desc = "Kill the command after this many seconds." },
+///   max_output_lines = { type = "integer", desc = "Override agent.max_output_lines for this tool." },
+/// })
+#[lua_fn]
+fn register_options(
+    lua: &Lua,
+    #[ctx] plugin: Arc<str>,
+    #[ctx] opts: PluginOpts,
+    spec: Table,
+) -> LuaResult<Table> {
+    let mut entries: Vec<(String, Table)> = spec
+        .pairs::<String, Table>()
+        .collect::<LuaResult<_>>()
+        .map_err(|e| mlua::Error::runtime(format!("register_options: invalid spec: {e}")))?;
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let specs: Vec<OptionSpec> = entries
+        .iter()
+        .map(|(name, s)| parse_spec(name, s))
+        .collect::<LuaResult<_>>()?;
+
+    validate_user_opts(&plugin, &opts, &specs)?;
+
+    let merged = lua.create_table()?;
+    for spec in &specs {
+        if let Some(v) = opts.get(&spec.name).or(spec.default.as_ref()) {
+            merged.set(spec.name.as_str(), json_to_lua(lua, v)?)?;
+        }
+    }
+
+    if let Some(mut store) = lua.app_data_mut::<PluginOptionSpecs>()
+        && store.insert(Arc::clone(&plugin), specs).is_some()
+    {
+        return Err(mlua::Error::runtime(
+            "register_options: called more than once; call it once at the top level of the plugin",
+        ));
+    }
+    Ok(merged)
+}

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -28,6 +28,7 @@ use mlua::{
 };
 use serde_json::{Value, json};
 
+use crate::api::options::{PluginOpts, register_options__doc, register_options__register};
 use crate::api::ui::buf::{BufHandle, line_to_lua};
 use crate::api::util::command::{
     CommandEntry, CommandHandlerMap, LuaCommandWriter, publish_command_snapshot,
@@ -833,9 +834,9 @@ lua_table! {
     /// maki.api.register_tool({ name = "greet", ... })
     /// maki.api.register_prompt_hint({ slot = "tool_usage", content = "..." })
     /// ```
-    extend "maki.api" => pub(crate) fn add_tool_fns(pending: PendingTools, plugin: Arc<str>), DOCS [
+    extend "maki.api" => pub(crate) fn add_tool_fns(pending: PendingTools, plugin: Arc<str>, opts: PluginOpts), DOCS [
         register_tool(pending), register_command(plugin), register_prompt_hint(plugin),
-        set_prompt(plugin), get_tools, get_tool,
+        register_options(plugin, opts), set_prompt(plugin), get_tools, get_tool,
     ]
 }
 
@@ -843,9 +844,10 @@ pub(crate) fn create_api_table(
     lua: &Lua,
     pending: PendingTools,
     plugin: Arc<str>,
+    opts: PluginOpts,
 ) -> LuaResult<Table> {
     let t = lua.create_table()?;
-    add_tool_fns(&t, lua, pending, plugin)?;
+    add_tool_fns(&t, lua, pending, plugin, opts)?;
     Ok(t)
 }
 

--- a/maki-lua/src/docs.rs
+++ b/maki-lua/src/docs.rs
@@ -126,6 +126,7 @@ mod tests {
             Arc::from("docs-test"),
             Some(ui_tx),
             &PluginPermissions::trusted(),
+            Arc::default(),
         )
         .unwrap();
 

--- a/maki-lua/src/error.rs
+++ b/maki-lua/src/error.rs
@@ -17,6 +17,12 @@ pub enum PluginError {
         #[source]
         source: io::Error,
     },
+    #[error(
+        "plugins.{plugin} sets options ({keys}), but there is no bundled plugin named \"{plugin}\""
+    )]
+    UnknownPluginOptions { plugin: String, keys: String },
+    #[error("no bundled plugin named \"{plugin}\" (enabled via plugins.{plugin})")]
+    UnknownPlugin { plugin: String },
     #[error("plugin host is not running")]
     HostDead,
 }

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -7,6 +7,7 @@ pub(crate) mod plugin_permissions;
 mod runtime;
 
 pub use api::keymap::{KeymapEntry, KeymapReader, KeymapSnapshot};
+pub use api::options::{OptionSpec, OptionType, PluginOptionSpecs};
 pub use api::util::command::{
     Anchor, Axis, Border, Dimension, Edge, FloatConfig, FloatConfigPatch, HintReader, HintSnapshot,
     LuaCommandInfo, LuaCommandReader, SessionReply, SessionRequest, Split, TitlePos, UiAction,

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -10,6 +10,7 @@ use maki_agent::tools::ToolRegistry;
 use maki_config::{PluginsConfig, RawConfig};
 
 use crate::api::keymap::KeymapReader;
+use crate::api::options::{PluginOptionSpecs, PluginOpts};
 use crate::api::util::command::{HintReader, LuaCommandReader, UiAction};
 use crate::error::PluginError;
 use crate::plugin_permissions::{PluginPermissions, load_plugin_permissions};
@@ -153,12 +154,11 @@ impl PluginHost {
     }
 
     /// Boots the runtime and loads every default bundled plugin into `registry`.
-    /// A convenience over `new` + `load_builtins(PluginsConfig::from_tools(defaults))`
-    /// for callers (tests, docgen, headless runs) that want the full builtin set
-    /// without permuting a config.
+    /// For callers like tests and docgen that want the full builtin set
+    /// without building a config.
     pub fn with_all_builtins(registry: Arc<ToolRegistry>) -> Result<Self, PluginError> {
         let mut host = Self::new(registry)?;
-        host.load_builtins(&PluginsConfig::from_tools(HashMap::new()))?;
+        host.load_builtins(&PluginsConfig::from_plugins(HashMap::new()))?;
         Ok(host)
     }
 
@@ -203,15 +203,30 @@ impl PluginHost {
         if self.inner.is_none() {
             return Ok(());
         }
-        for builtin in &config.tools {
+        for (plugin, opts) in &config.opts {
+            let keys: Vec<&str> = opts.keys().map(String::as_str).collect();
+            if !BUNDLED_PLUGINS.iter().any(|p| p.name == plugin.as_str()) {
+                return Err(PluginError::UnknownPluginOptions {
+                    plugin: plugin.clone(),
+                    keys: keys.join(", "),
+                });
+            }
+            if !config.names.contains(plugin) {
+                tracing::warn!(
+                    plugin = plugin.as_str(),
+                    keys = keys.join(", "),
+                    "plugin is disabled; its plugins.{} options are ignored until re-enabled",
+                    plugin
+                );
+            }
+        }
+        for builtin in &config.names {
             let dir = match BUNDLED_PLUGINS.iter().find(|p| p.name == builtin.as_str()) {
                 Some(p) => &p.dir,
                 None => {
-                    tracing::warn!(
-                        builtin = builtin.as_str(),
-                        "unknown builtin plugin, skipping"
-                    );
-                    continue;
+                    return Err(PluginError::UnknownPlugin {
+                        plugin: builtin.clone(),
+                    });
                 }
             };
             let init = dir
@@ -222,7 +237,19 @@ impl PluginHost {
                     source: mlua::Error::runtime("bundled plugin missing init.lua"),
                 })?;
             let name: Arc<str> = Arc::from(builtin.as_str());
-            self.send_load(name, init.to_owned(), None, PluginPermissions::trusted())?;
+            let opts = config
+                .opts
+                .get(builtin.as_str())
+                .cloned()
+                .map(Arc::new)
+                .unwrap_or_default();
+            self.send_load(
+                name,
+                init.to_owned(),
+                None,
+                PluginPermissions::trusted(),
+                opts,
+            )?;
         }
         Ok(())
     }
@@ -240,6 +267,7 @@ impl PluginHost {
         source: String,
         plugin_dir: Option<PathBuf>,
         permissions: PluginPermissions,
+        opts: PluginOpts,
     ) -> Result<(), PluginError> {
         let tx = self.tx()?;
         let (reply_tx, reply_rx) = flume::bounded(1);
@@ -248,10 +276,21 @@ impl PluginHost {
             source,
             plugin_dir,
             permissions,
+            opts,
             reply: reply_tx,
         })
         .map_err(|_| PluginError::HostDead)?;
         reply_rx.recv().map_err(|_| PluginError::HostDead)?
+    }
+
+    /// Option specs declared by loaded plugins via `maki.api.register_options`,
+    /// keyed by plugin name. Used by docgen.
+    pub fn plugin_options(&self) -> Result<PluginOptionSpecs, PluginError> {
+        let tx = self.tx()?;
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        tx.send(Request::CollectPluginOptions { reply: reply_tx })
+            .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)
     }
 
     pub fn send_run_init_lua(
@@ -285,11 +324,21 @@ impl PluginHost {
     }
 
     pub fn load_source(&self, name: &str, source: &str) -> Result<(), PluginError> {
+        self.load_source_with_opts(name, source, serde_json::Map::new())
+    }
+
+    pub fn load_source_with_opts(
+        &self,
+        name: &str,
+        source: &str,
+        opts: serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(), PluginError> {
         self.send_load(
             Arc::from(name),
             source.to_owned(),
             None,
             PluginPermissions::trusted(),
+            Arc::new(opts),
         )
     }
 
@@ -299,7 +348,13 @@ impl PluginHost {
         source: &str,
         permissions: PluginPermissions,
     ) -> Result<(), PluginError> {
-        self.send_load(Arc::from(name), source.to_owned(), None, permissions)
+        self.send_load(
+            Arc::from(name),
+            source.to_owned(),
+            None,
+            permissions,
+            PluginOpts::default(),
+        )
     }
 
     pub fn load_plugin_file(&self, path: &Path) -> Result<(), PluginError> {
@@ -309,7 +364,17 @@ impl PluginHost {
         })?;
         let plugin_dir = path.parent().map(Path::to_path_buf);
         let permissions = load_plugin_permissions(plugin_dir.as_deref());
-        self.send_load(Arc::from("user"), source, plugin_dir, permissions)
+        // Test-only path today. Once user plugin dirs exist: derive a real
+        // plugin name, since the hardcoded "user" would collide across files,
+        // pass the `plugins.<name>` opts through, and teach the
+        // unknown-plugin guards about user plugin names.
+        self.send_load(
+            Arc::from("user"),
+            source,
+            plugin_dir,
+            permissions,
+            PluginOpts::default(),
+        )
     }
 
     pub fn event_handle(&self) -> Option<EventHandle> {
@@ -463,7 +528,7 @@ mod tests {
     fn with_jit_off_loads_builtins_and_registers_tools() {
         let reg = Arc::new(ToolRegistry::new());
         let mut host = PluginHost::with_jit(Arc::clone(&reg), false).unwrap();
-        host.load_builtins(&PluginsConfig::from_tools(HashMap::new()))
+        host.load_builtins(&PluginsConfig::from_plugins(HashMap::new()))
             .unwrap();
         assert!(reg.has("glob"));
     }
@@ -471,7 +536,7 @@ mod tests {
     #[test]
     fn load_builtins_on_disabled_host_is_noop() {
         let mut host = PluginHost::disabled();
-        host.load_builtins(&PluginsConfig::from_tools(HashMap::new()))
+        host.load_builtins(&PluginsConfig::from_plugins(HashMap::new()))
             .unwrap();
     }
 

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -29,6 +29,7 @@ use crate::api::create_maki_global;
 use crate::api::r#fn::{JobEvent, JobStore};
 use crate::api::keymap::KeymapReader;
 use crate::api::keymap::{KeymapStore, KeymapWriter};
+use crate::api::options::{PluginOptionSpecs, PluginOpts, collect_plugin_options};
 use crate::api::slot::SlotStore;
 use crate::api::tool::{LuaTool, PendingTool, PendingTools, PermissionScopeSpec, ToolCallReply};
 use crate::api::ui::HintStore;
@@ -98,6 +99,7 @@ pub enum Request {
         source: String,
         plugin_dir: Option<PathBuf>,
         permissions: PluginPermissions,
+        opts: PluginOpts,
         reply: flume::Sender<LoadResult>,
     },
     CallTool {
@@ -138,6 +140,9 @@ pub enum Request {
     },
     CollectPromptSlots {
         reply: flume::Sender<ResolvedSlots>,
+    },
+    CollectPluginOptions {
+        reply: flume::Sender<PluginOptionSpecs>,
     },
     Shutdown,
     RestoreToolAsync {
@@ -936,6 +941,7 @@ impl LuaRuntime {
         lua.set_app_data(SpawnQueue::new());
         lua.set_app_data(command_writer);
         lua.set_app_data(PromptHintCallbacks::default());
+        lua.set_app_data(PluginOptionSpecs::default());
         lua.set_app_data(AutocmdStore::default());
         lua.set_app_data(SlotStore::default());
         lua.set_app_data(KeymapStore::new());
@@ -982,6 +988,9 @@ impl LuaRuntime {
 
     fn drop_plugin_keys(&mut self, name: &str) {
         self.warm_tools.borrow_mut().clear();
+        if let Some(mut store) = self.lua.app_data_mut::<PluginOptionSpecs>() {
+            store.remove(name);
+        }
         if let Some(mut store) = self.lua.app_data_mut::<AutocmdStore>() {
             store.clear_plugin(name);
         }
@@ -1285,12 +1294,32 @@ impl LuaRuntime {
         })
     }
 
+    /// `plugins.<name>` options only reach a plugin through
+    /// `maki.api.register_options`; if the plugin never declared any, every
+    /// key the user set is a typo or unsupported, so fail the load loudly.
+    fn check_opts_consumed(&self, name: &str, opts: &PluginOpts) -> Result<(), mlua::Error> {
+        if opts.is_empty()
+            || self
+                .lua
+                .app_data_ref::<PluginOptionSpecs>()
+                .is_some_and(|store| store.contains_key(name))
+        {
+            return Ok(());
+        }
+        let keys: Vec<&str> = opts.keys().map(String::as_str).collect();
+        Err(mlua::Error::runtime(format!(
+            "unknown options in plugins.{name}: {} (this plugin declares no options via maki.api.register_options)",
+            keys.join(", ")
+        )))
+    }
+
     async fn load_source(
         &mut self,
         name: Arc<str>,
         source: &str,
         plugin_dir: Option<PathBuf>,
         permissions: &PluginPermissions,
+        opts: PluginOpts,
         config_store: Option<&ConfigStore>,
     ) -> LoadResult {
         let map_err = |e: mlua::Error| PluginError::Lua {
@@ -1312,6 +1341,7 @@ impl LuaRuntime {
             Arc::clone(&name),
             self.ui_action_tx.clone(),
             permissions,
+            Arc::clone(&opts),
         )
         .map_err(&map_err)?;
 
@@ -1333,6 +1363,7 @@ impl LuaRuntime {
             .exec_async()
             .await;
 
+        let exec_result = exec_result.and_then(|()| self.check_opts_consumed(&name, &opts));
         if let Err(e) = exec_result {
             let stale = self.drain_pending();
             self.discard_pending(stale);
@@ -1490,6 +1521,7 @@ impl LuaRuntime {
             source,
             plugin_dir,
             &perms,
+            PluginOpts::default(),
             Some(&config_store),
         )
         .await?;
@@ -2150,10 +2182,11 @@ pub fn spawn(
                             source,
                             plugin_dir,
                             permissions,
+                            opts,
                             reply,
                         } => {
                             drain_barrier(&rt.lua, &ex, &gate, &spawn_rx).await;
-                            let res = rt.load_source(Arc::clone(&name), &source, plugin_dir, &permissions, None).await;
+                            let res = rt.load_source(Arc::clone(&name), &source, plugin_dir, &permissions, opts, None).await;
                             let _ = reply.send(res);
                         }
                         Request::CallTool {
@@ -2252,6 +2285,9 @@ pub fn spawn(
                         Request::CollectPromptSlots { reply } => {
                             let slots = rt.collect_prompt_slots().await;
                             let _ = reply.send(slots);
+                        }
+                        Request::CollectPluginOptions { reply } => {
+                            let _ = reply.send(collect_plugin_options(&rt.lua));
                         }
                         Request::RestoreToolAsync { item, event_tx } => {
                             spawn_restore(&ex, &gate, &restores, &rt, item, event_tx);

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -14,7 +14,7 @@ fn fresh_registry() -> Arc<ToolRegistry> {
 fn builtins_host() -> (Arc<ToolRegistry>, PluginHost) {
     let reg = fresh_registry();
     let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    host.load_builtins(&PluginsConfig::from_tools(HashMap::new()))
+    host.load_builtins(&PluginsConfig::from_plugins(HashMap::new()))
         .unwrap();
     (reg, host)
 }
@@ -1727,13 +1727,13 @@ fn setup_happy_path() {
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
     let raw = host
         .send_run_init_lua(
-            "maki.setup({ agent = { bash_timeout_secs = 120 } })".to_owned(),
+            "maki.setup({ agent = { max_output_lines = 3000 } })".to_owned(),
             "test_init.lua".to_owned(),
             None,
         )
         .unwrap();
     let raw = raw.expect("expected Some(RawConfig)");
-    assert_eq!(raw.agent.bash_timeout_secs, Some(120));
+    assert_eq!(raw.agent.max_output_lines, Some(3000));
 }
 
 #[test_case::test_case(
@@ -1762,9 +1762,14 @@ fn setup_compaction_buffer(lua_src: &str, expected: maki_config::CompactionBuffe
     ; "unknown_field"
 )]
 #[test_case::test_case(
-    r#"maki.setup({ agent = { bash_timeout_secs = "not a number" } })"#,
+    r#"maki.setup({ agent = { max_output_lines = "not a number" } })"#,
     ""
     ; "wrong_type"
+)]
+#[test_case::test_case(
+    "maki.setup({ agent = { bash_timeout_secs = 120 } })",
+    UNKNOWN_FIELD_ERR
+    ; "moved_plugin_option"
 )]
 fn setup_rejects_bad_input(lua_src: &str, expected_substr: &str) {
     let reg = fresh_registry();
@@ -1817,11 +1822,10 @@ fn setup_all_sections_at_once() {
                 always_fast = true,
                 always_thinking = "adaptive",
                 ui = { splash_animation = false, mouse_scroll_lines = 5 },
-                agent = { bash_timeout_secs = 120, max_output_lines = 9000 },
+                agent = { max_output_lines = 9000 },
                 provider = { default_model = "anthropic/claude-opus-4-6" },
                 storage = { max_log_files = 3 },
-                index = { max_file_size_mb = 8 },
-                tools = { bash = { enabled = true }, websearch = { enabled = false } },
+                plugins = { bash = { enabled = true, timeout_secs = 180 }, websearch = { enabled = false } },
             })"#
             .to_owned(),
             "test_init.lua".to_owned(),
@@ -1837,16 +1841,272 @@ fn setup_all_sections_at_once() {
     );
     assert_eq!(raw.ui.splash_animation, Some(false));
     assert_eq!(raw.ui.mouse_scroll_lines, Some(5));
-    assert_eq!(raw.agent.bash_timeout_secs, Some(120));
     assert_eq!(raw.agent.max_output_lines, Some(9000));
     assert_eq!(
         raw.provider.default_model.as_deref(),
         Some("anthropic/claude-opus-4-6")
     );
     assert_eq!(raw.storage.max_log_files, Some(3));
-    assert_eq!(raw.index.max_file_size_mb, Some(8));
-    assert_eq!(raw.tools["bash"].enabled, Some(true));
-    assert_eq!(raw.tools["websearch"].enabled, Some(false));
+    assert_eq!(raw.plugins["bash"].enabled, Some(true));
+    assert_eq!(
+        raw.plugins["bash"].opts["timeout_secs"],
+        serde_json::json!(180)
+    );
+    assert_eq!(raw.plugins["websearch"].enabled, Some(false));
+}
+
+const OPTS_PROBE_PLUGIN: &str = r#"
+local opts = maki.api.register_options({
+    timeout_secs = { default = 120, min = 5, desc = "Timeout." },
+    label = { type = "string", desc = "Label." },
+})
+maki.api.register_tool({
+    name = "opts_probe",
+    description = "returns merged opts",
+    schema = { type = "object", properties = {}, additionalProperties = false },
+    audiences = { "main" },
+    handler = function(input, ctx)
+        return (maki.json.encode({
+            timeout_secs = opts.timeout_secs,
+            label = opts.label,
+        }))
+    end
+})
+"#;
+
+const UNKNOWN_OPTION_ERR: &str =
+    "unknown option \"typo\" for plugins.opts_plugin (valid options: label, timeout_secs)";
+const OPTION_TYPE_ERR: &str =
+    "invalid value for plugins.opts_plugin.timeout_secs: expected integer";
+const OPTION_MIN_ERR: &str =
+    "invalid value for plugins.opts_plugin.timeout_secs: 1 is below minimum (5)";
+const OPTION_DESC_ERR: &str = "option \"timeout_secs\": desc is required";
+const OPTION_NO_TYPE_ERR: &str = "option \"bare\": type is required when there is no default";
+const OPTION_SPEC_KEY_ERR: &str = "option \"timeout_secs\": unknown spec key \"mins\"";
+const OPTION_DEFAULT_TYPE_ERR: &str =
+    "option \"timeout_secs\": default 120 does not match type string";
+const OPTION_DEFAULT_MIN_ERR: &str = "option \"timeout_secs\": default 1 is below min (5)";
+const OPTION_MIN_ON_STRING_ERR: &str = "option \"label\": min is not allowed for type string";
+const OPTION_RESERVED_ERR: &str = "option \"enabled\": reserved name";
+const OPTION_TWICE_ERR: &str = "register_options: called more than once";
+const UNDECLARED_OPTS_ERR: &str = "unknown options in plugins.bare_plugin: timeout_secs \
+(this plugin declares no options via maki.api.register_options)";
+
+fn probe_opts(reg: &ToolRegistry) -> serde_json::Value {
+    let out = exec_tool(reg, "opts_probe", serde_json::json!({})).unwrap();
+    serde_json::from_str(&out).unwrap()
+}
+
+fn json_obj(v: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+    v.as_object().expect("test opts must be an object").clone()
+}
+
+#[test_case::test_case(
+    serde_json::json!({}),
+    serde_json::json!(120), serde_json::Value::Null
+    ; "defaults_without_user_opts"
+)]
+#[test_case::test_case(
+    serde_json::json!({ "timeout_secs": 30, "label": "x" }),
+    serde_json::json!(30), serde_json::json!("x")
+    ; "user_opts_win"
+)]
+fn register_options_merges(
+    opts: serde_json::Value,
+    timeout_secs: serde_json::Value,
+    label: serde_json::Value,
+) {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source_with_opts("opts_plugin", OPTS_PROBE_PLUGIN, json_obj(opts))
+        .unwrap();
+
+    let snap = probe_opts(&reg);
+    assert_eq!(snap["timeout_secs"], timeout_secs);
+    assert_eq!(snap["label"], label);
+}
+
+#[test_case::test_case(serde_json::json!({ "typo": 1 }), UNKNOWN_OPTION_ERR ; "unknown_key")]
+#[test_case::test_case(serde_json::json!({ "timeout_secs": "abc" }), OPTION_TYPE_ERR ; "wrong_type")]
+#[test_case::test_case(serde_json::json!({ "timeout_secs": 12.5 }), OPTION_TYPE_ERR ; "float_for_integer")]
+#[test_case::test_case(serde_json::json!({ "timeout_secs": 1 }), OPTION_MIN_ERR ; "below_min")]
+fn register_options_rejects_bad_user_opts(opts: serde_json::Value, expected: &str) {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_source_with_opts("opts_plugin", OPTS_PROBE_PLUGIN, json_obj(opts))
+        .expect_err("plugin load should fail");
+    assert!(err.to_string().contains(expected), "got: {err}");
+}
+
+#[test_case::test_case(
+    r#"maki.api.register_options({ timeout_secs = { default = 120 } })"#,
+    OPTION_DESC_ERR
+    ; "missing_desc"
+)]
+#[test_case::test_case(
+    r#"maki.api.register_options({ bare = { desc = "no type or default" } })"#,
+    OPTION_NO_TYPE_ERR
+    ; "missing_type_and_default"
+)]
+#[test_case::test_case(
+    r#"maki.api.register_options({ timeout_secs = { default = 120, mins = 5, desc = "T." } })"#,
+    OPTION_SPEC_KEY_ERR
+    ; "unknown_spec_key"
+)]
+#[test_case::test_case(
+    r#"maki.api.register_options({ timeout_secs = { type = "string", default = 120, desc = "T." } })"#,
+    OPTION_DEFAULT_TYPE_ERR
+    ; "default_contradicts_type"
+)]
+#[test_case::test_case(
+    r#"maki.api.register_options({ timeout_secs = { default = 1, min = 5, desc = "T." } })"#,
+    OPTION_DEFAULT_MIN_ERR
+    ; "default_below_min"
+)]
+#[test_case::test_case(
+    r#"maki.api.register_options({ label = { type = "string", min = 1, desc = "L." } })"#,
+    OPTION_MIN_ON_STRING_ERR
+    ; "min_on_string"
+)]
+#[test_case::test_case(
+    r#"maki.api.register_options({ enabled = { default = true, desc = "E." } })"#,
+    OPTION_RESERVED_ERR
+    ; "reserved_enabled"
+)]
+#[test_case::test_case(
+    r#"
+    maki.api.register_options({ a = { default = 1, desc = "A." } })
+    maki.api.register_options({ b = { default = 2, desc = "B." } })
+    "#,
+    OPTION_TWICE_ERR
+    ; "called_twice"
+)]
+fn register_options_rejects_bad_spec(src: &str, expected: &str) {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_source("opts_plugin", src)
+        .expect_err("plugin load should fail");
+    assert!(err.to_string().contains(expected), "got: {err}");
+}
+
+#[test]
+fn builtin_opts_flow_from_setup_plugins() {
+    let reg = fresh_registry();
+    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let raw = host
+        .send_run_init_lua(
+            "maki.setup({ plugins = { grep = { search_result_limit = 42 } } })".to_owned(),
+            "test_init.lua".to_owned(),
+            None,
+        )
+        .unwrap()
+        .expect("expected Some(RawConfig)");
+    host.load_builtins(&PluginsConfig::from_plugins(raw.plugins))
+        .unwrap();
+
+    let options = host.plugin_options().unwrap();
+    let grep = options.get("grep").expect("grep options registered");
+    let limit = grep
+        .iter()
+        .find(|o| o.name == "search_result_limit")
+        .expect("search_result_limit declared");
+    assert!(limit.default.is_some(), "declared default surfaces");
+    assert!(limit.min.is_some(), "declared min surfaces");
+    assert!(!limit.desc.is_empty(), "declared desc surfaces");
+}
+
+#[test_case::test_case(
+    serde_json::json!({}),
+    &["edit", "multiedit"], &["edit_lines", "insert_lines"]
+    ; "multiedit_on_others_opt_in"
+)]
+#[test_case::test_case(
+    serde_json::json!({ "multiedit": false, "edit_lines": true }),
+    &["edit", "edit_lines"], &["multiedit", "insert_lines"]
+    ; "toggles_flip_sub_tools"
+)]
+fn edit_sub_tools_follow_edit_opts(opts: serde_json::Value, on: &[&str], off: &[&str]) {
+    let reg = fresh_registry();
+    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let config = PluginsConfig {
+        enabled: true,
+        names: vec!["edit".to_owned()],
+        opts: HashMap::from([("edit".to_owned(), json_obj(opts))]),
+    };
+    host.load_builtins(&config).unwrap();
+    for tool in on {
+        assert!(reg.get(tool).is_some(), "{tool} should be registered");
+    }
+    for tool in off {
+        assert!(reg.get(tool).is_none(), "{tool} should not be registered");
+    }
+}
+
+#[test]
+fn undeclared_opts_fail_the_load() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_source_with_opts(
+            "bare_plugin",
+            "local x = 1",
+            json_obj(serde_json::json!({ "timeout_secs": 30 })),
+        )
+        .expect_err("plugin load should fail");
+    assert!(err.to_string().contains(UNDECLARED_OPTS_ERR), "got: {err}");
+}
+
+#[test]
+fn opts_for_unknown_plugin_fail_load_builtins() {
+    let reg = fresh_registry();
+    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let mut config = PluginsConfig::from_plugins(HashMap::new());
+    config.opts.insert(
+        "bsah".to_owned(),
+        json_obj(serde_json::json!({ "timeout_secs": 5 })),
+    );
+    let err = host
+        .load_builtins(&config)
+        .expect_err("load_builtins should fail");
+    assert!(
+        err.to_string()
+            .contains("plugins.bsah sets options (timeout_secs)"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn unknown_plugin_name_fails_load_builtins() {
+    let reg = fresh_registry();
+    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let mut config = PluginsConfig::from_plugins(HashMap::new());
+    config.names.push("gerp".to_string());
+    let err = host
+        .load_builtins(&config)
+        .expect_err("load_builtins should fail");
+    assert!(
+        err.to_string().contains("no bundled plugin named \"gerp\""),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn disabled_plugin_opts_are_ignored_not_rejected() {
+    let reg = fresh_registry();
+    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let config = PluginsConfig {
+        enabled: true,
+        names: vec!["grep".to_owned()],
+        opts: HashMap::from([(
+            "bash".to_owned(),
+            json_obj(serde_json::json!({ "timeout_secs": 180 })),
+        )]),
+    };
+    host.load_builtins(&config).unwrap();
+    assert!(reg.get("bash").is_none(), "bash stays disabled");
+    assert!(reg.get("grep").is_some(), "enabled plugin still loads");
 }
 
 #[test_case::test_case("true", AlwaysThinking::Toggle(true) ; "bool")]

--- a/maki-lua/tests/task_policy.rs
+++ b/maki-lua/tests/task_policy.rs
@@ -28,6 +28,8 @@ const TASK_PROMPT: &str = "do the thing";
 const PLAIN_TEXT: &str = "plain text result";
 const PROMPT_ERR_MSG: &str = "model exploded";
 const RAISE_MSG: &str = "stub prompt kaboom";
+/// Mirrors the task plugin's `max_concurrent` default.
+const TASK_DEFAULT_MAX_CONCURRENT: u64 = 8;
 
 const SCENARIO_PLAIN: &str = "plain";
 const SCENARIO_HAPPY: &str = "happy";
@@ -140,7 +142,6 @@ maki.api.register_tool({
       first_err = recorder.first_err,
       second_ack = recorder.second_ack,
       second_err = recorder.second_err,
-      task_cap = ctx:config().task_max_concurrent,
       acquired = recorder.acquired,
       released = recorder.released,
       sem_size = recorder.sem_size,
@@ -355,11 +356,10 @@ fn raising_prompt_does_not_leak_semaphore_permit() {
     assert!(err.contains(RAISE_MSG), "got: {err}");
 
     let snap = probe(&reg);
-    let cap = snap["task_cap"].as_u64().expect("task_cap missing");
     assert_eq!(
         snap["sem_size"],
-        json!(cap),
-        "semaphore not sized from config"
+        json!(TASK_DEFAULT_MAX_CONCURRENT),
+        "semaphore not sized from the default max_concurrent option"
     );
     assert_eq!(snap["acquired"], json!(1));
     assert_eq!(snap["released"], json!(1), "permit not explicitly released");

--- a/plugins/bash/init.lua
+++ b/plugins/bash/init.lua
@@ -1,5 +1,6 @@
 local truncate = require("maki.truncate")
 local ToolView = require("maki.tool_view")
+local output_limits = require("maki.output_limits")
 
 local RTK_REWRITE_TIMEOUT_MS = 2000
 local RTK_UNSUPPORTED_FLAGS = {
@@ -247,6 +248,14 @@ maki.api.register_prompt_hint({
   content = "- Reserve bash for system commands (git, builds, tests). Do NOT use bash for file operations, including on files outside the working dir.",
 })
 
+local opts = maki.api.register_options(output_limits.extend({
+  timeout_secs = {
+    default = 120,
+    min = 5,
+    desc = "Kill the command after this many seconds. A call's `timeout` param overrides it.",
+  },
+}))
+
 maki.api.register_tool({
   name = "bash",
   kind = "execute",
@@ -335,9 +344,8 @@ maki.api.register_tool({
     end
 
     local command, workdir = parse_cd_hint(input)
-    local timeout_secs = input.timeout or ctx:config("bash_timeout_secs", 120)
-    local max_lines = ctx:config("max_output_lines", 2000)
-    local max_bytes = ctx:config("max_output_bytes", (50 * 1024))
+    local timeout_secs = input.timeout or opts.timeout_secs
+    local max_lines, max_bytes = output_limits.resolve(opts, ctx)
 
     ctx:set_deadline(timeout_secs)
 

--- a/plugins/code_execution/init.lua
+++ b/plugins/code_execution/init.lua
@@ -5,9 +5,8 @@
 
 local truncate = require("maki.truncate")
 local ToolView = require("maki.tool_view")
+local output_limits = require("maki.output_limits")
 
-local DEFAULT_TIMEOUT = 30
-local DEFAULT_MAX_MEMORY_MB = 50
 local DEFAULT_MAX_OUTPUT_LINES = 2000
 local DEFAULT_MAX_OUTPUT_BYTES = 50 * 1024
 local MAX_SCRIPT_LINES = 2000
@@ -18,6 +17,15 @@ local TOOLS_HEADER = "\n\nAvailable tools (called as Python functions with keywo
 local WORKFLOW_TOOLS_NOTE =
   "\nWorkflow mode: orchestrate subagents from this script. Await every `task(...)` call and use `asyncio.gather` for parallel fan-out. Pass `output_schema` to task for machine-readable results (a JSON string, parse with `json.loads`). Raise this tool's `timeout` param: subagents outlive the default code_execution timeout.\n"
 local PY_TYPES = { string = "str", integer = "int", boolean = "bool", array = "list" }
+
+local opts = maki.api.register_options(output_limits.extend({
+  timeout_secs = {
+    default = 30,
+    min = 5,
+    desc = "Stop the script after this many seconds. A call's `timeout` param overrides it.",
+  },
+  max_memory_mb = { default = 50, min = 10, desc = "Memory limit for the Python sandbox (MB)." },
+}))
 
 local function new_view(ctx, buf)
   return ToolView.new(buf, { max_lines = ctx:tool_output_lines().code_execution or 30 })
@@ -218,7 +226,7 @@ end
 
 local function handler(input, ctx)
   local config = ctx:config()
-  local timeout = input.timeout or config.code_execution_timeout_secs or DEFAULT_TIMEOUT
+  local timeout = input.timeout or opts.timeout_secs
 
   local buf, view, highlight = build_body(ctx, input.code)
   ctx:live_buf(buf)
@@ -247,7 +255,7 @@ local function handler(input, ctx)
 
   local result, err = maki.interpreter.run(PREAMBLE .. input.code, {
     timeout = timeout,
-    max_memory_mb = config.interpreter_max_memory_mb or DEFAULT_MAX_MEMORY_MB,
+    max_memory_mb = opts.max_memory_mb,
     on_output = show,
     tools = tools,
   })
@@ -272,11 +280,8 @@ local function handler(input, ctx)
     view:append({ { "No output", "dim" } })
   end
 
-  local llm_output = truncate(
-    output,
-    config.max_output_lines or DEFAULT_MAX_OUTPUT_LINES,
-    config.max_output_bytes or DEFAULT_MAX_OUTPUT_BYTES
-  )
+  local max_lines, max_bytes = output_limits.resolve(opts, ctx)
+  local llm_output = truncate(output, max_lines, max_bytes)
   view:finish()
 
   return { llm_output = llm_output, body = buf }

--- a/plugins/edit/init.lua
+++ b/plugins/edit/init.lua
@@ -235,6 +235,18 @@ local function diff_result(edit_result, summary)
   }
 end
 
+local opts = maki.api.register_options({
+  multiedit = { default = true, desc = "Provide the `multiedit` tool." },
+  edit_lines = { default = false, desc = "Provide the opt-in `edit_lines` tool." },
+  insert_lines = { default = false, desc = "Provide the opt-in `insert_lines` tool." },
+})
+
+local function register_tool_if(enabled, tool)
+  if enabled then
+    maki.api.register_tool(tool)
+  end
+end
+
 maki.api.register_tool({
   name = "edit",
   kind = "edit",
@@ -286,7 +298,7 @@ maki.api.register_tool({
   end,
 })
 
-maki.api.register_tool({
+register_tool_if(opts.multiedit, {
   name = "multiedit",
   kind = "edit",
   mutable_path = "path",
@@ -372,7 +384,7 @@ maki.api.register_tool({
   end,
 })
 
-maki.api.register_tool({
+register_tool_if(opts.edit_lines, {
   name = "edit_lines",
   kind = "edit",
   mutable_path = "path",
@@ -426,7 +438,7 @@ maki.api.register_tool({
   end,
 })
 
-maki.api.register_tool({
+register_tool_if(opts.insert_lines, {
   name = "insert_lines",
   kind = "edit",
   mutable_path = "path",

--- a/plugins/glob/init.lua
+++ b/plugins/glob/init.lua
@@ -1,9 +1,13 @@
 local truncate = require("maki.truncate")
 local ToolView = require("maki.tool_view")
 local shorten_path = require("maki.shorten_path")
+local output_limits = require("maki.output_limits")
 
-local DEFAULT_SEARCH_LIMIT = 100
 local NO_FILES_FOUND = "No files found"
+
+local opts = maki.api.register_options(output_limits.extend({
+  search_result_limit = { default = 100, min = 10, desc = "Max files returned per search." },
+}))
 
 local function glob_view_opts(ctx)
   local tol = ctx:tool_output_lines()
@@ -48,9 +52,8 @@ maki.api.register_tool({
       return { llm_output = "error: pattern is required", is_error = true }
     end
 
-    local limit = ctx:config("search_result_limit", DEFAULT_SEARCH_LIMIT)
-    local max_lines = ctx:config("max_output_lines", 2000)
-    local max_bytes = ctx:config("max_output_bytes", (50 * 1024))
+    local limit = opts.search_result_limit
+    local max_lines, max_bytes = output_limits.resolve(opts, ctx)
 
     local files, err = maki.fs.glob(pattern, {
       path = input.path,

--- a/plugins/grep/init.lua
+++ b/plugins/grep/init.lua
@@ -2,10 +2,20 @@ local truncate = require("maki.truncate")
 local ToolView = require("maki.tool_view")
 local shorten_path = require("maki.shorten_path")
 local color = require("maki.color")
+local output_limits = require("maki.output_limits")
 
 local NO_MATCHES = "No files found"
 local MAX_PER_CALL_LIMIT = 1000
 local DIM_FACTOR = 0.3
+
+local opts = maki.api.register_options(output_limits.extend({
+  search_result_limit = {
+    default = 100,
+    min = 10,
+    desc = "Max match groups per search. A call's `limit` param overrides it.",
+  },
+  max_line_bytes = { default = 500, min = 80, desc = "Skip lines longer than this many bytes." },
+}))
 
 local function has_context(groups)
   for _, group in ipairs(groups) do
@@ -239,14 +249,11 @@ maki.api.register_tool({
     end
     pattern = pattern:gsub('"$', "")
 
-    local config = ctx:config()
-    local search_limit = (config and config.search_result_limit) or 100
-    local max_lines = (config and config.max_output_lines) or 2000
-    local max_bytes = (config and config.max_output_bytes) or (50 * 1024)
+    local max_lines, max_bytes = output_limits.resolve(opts, ctx)
 
-    local limit = math.min(input.limit or search_limit, MAX_PER_CALL_LIMIT)
+    local limit = math.min(input.limit or opts.search_result_limit, MAX_PER_CALL_LIMIT)
 
-    local max_line_bytes = config and config.max_line_bytes
+    local max_line_bytes = opts.max_line_bytes
 
     local entries, err = maki.fs.grep(pattern, {
       path = input.path,

--- a/plugins/index/init.lua
+++ b/plugins/index/init.lua
@@ -5,6 +5,10 @@ local shorten_path = require("maki.shorten_path")
 local TRUNCATED_SUFFIX = indexer.TRUNCATED_SUFFIX
 local TRUNCATED_INFIX = " more truncated]"
 
+local opts = maki.api.register_options({
+  max_file_size_mb = { default = 2, min = 1, desc = "Refuse to index files larger than this many MB." },
+})
+
 local function split_trailing_range(line)
   local pos = line:find(" %[%d[%d%-,]*%]$")
   if not pos then
@@ -202,7 +206,7 @@ Return a compact overview of a source file: imports, type definitions, function 
       end
     end
 
-    local max_file_size = ctx:config("index_max_file_size", (2 * 1024 * 1024))
+    local max_file_size = opts.max_file_size_mb * 1024 * 1024
     if meta and meta.size > max_file_size then
       return {
         llm_output = "error: File too large ("

--- a/plugins/lib/maki/output_limits.lua
+++ b/plugins/lib/maki/output_limits.lua
@@ -1,0 +1,27 @@
+-- Shared per-tool output limit options, so the tools that support them
+-- cannot drift apart.
+
+local DEFAULT_MAX_OUTPUT_LINES = 2000
+local DEFAULT_MAX_OUTPUT_BYTES = 50 * 1024
+
+local M = {}
+
+M.specs = {
+  max_output_lines = { type = "integer", desc = "Override `agent.max_output_lines` for this tool." },
+  max_output_bytes = { type = "integer", desc = "Override `agent.max_output_bytes` for this tool." },
+}
+
+function M.extend(spec)
+  for name, s in pairs(M.specs) do
+    spec[name] = s
+  end
+  return spec
+end
+
+--- Returns max_lines, max_bytes: tool override when set, agent-wide otherwise.
+function M.resolve(opts, ctx)
+  return opts.max_output_lines or ctx:config("max_output_lines", DEFAULT_MAX_OUTPUT_LINES),
+    opts.max_output_bytes or ctx:config("max_output_bytes", DEFAULT_MAX_OUTPUT_BYTES)
+end
+
+return M

--- a/plugins/read/init.lua
+++ b/plugins/read/init.lua
@@ -1,5 +1,6 @@
 local ToolView = require("maki.tool_view")
 local shorten_path = require("maki.shorten_path")
+local output_limits = require("maki.output_limits")
 
 local DESCRIPTION = [[Read a file or directory. Returns contents with line numbers (1-indexed).
 
@@ -15,7 +16,11 @@ local DESCRIPTION = [[Read a file or directory. Returns contents with line numbe
 - Avoid tiny repeated slices - read a larger window if you need more context.]]
 
 local DEFAULT_MAX_OUTPUT_LINES = 2000
-local DEFAULT_MAX_LINE_BYTES = 3000
+
+local opts = maki.api.register_options({
+  max_line_bytes = { default = 500, min = 80, desc = "Truncate lines longer than this many bytes." },
+  max_output_lines = output_limits.specs.max_output_lines,
+})
 
 local function line_nr_fmt(count)
   local w = math.max(1, math.floor(math.log(count + 1, 10)) + 1)
@@ -123,8 +128,8 @@ local function read_file(path, offset, limit, ctx)
   local total_lines = #all_lines
 
   local start = math.max(offset or 1, 1)
-  local max_lines = limit or ctx:config("max_output_lines", DEFAULT_MAX_OUTPUT_LINES)
-  local max_line_bytes = ctx:config("max_line_bytes", DEFAULT_MAX_LINE_BYTES)
+  local max_lines = limit or opts.max_output_lines or ctx:config("max_output_lines", DEFAULT_MAX_OUTPUT_LINES)
+  local max_line_bytes = opts.max_line_bytes
 
   local lines = {}
   for i = start, math.min(start + max_lines - 1, total_lines) do

--- a/plugins/task/init.lua
+++ b/plugins/task/init.lua
@@ -72,7 +72,12 @@ local examples = {
   },
 }
 
-local semaphore
+local opts = maki.api.register_options({
+  max_concurrent = { default = 8, min = 1, desc = "Max concurrently running subagents." },
+})
+
+-- Process-wide cap on concurrent subagents.
+local semaphore = maki.async.semaphore(opts.max_concurrent)
 
 local function bounded_errors(errors)
   local out = {}
@@ -144,10 +149,6 @@ local function handler(input, ctx)
     }
   end
 
-  -- Process-wide cap on concurrent subagents, sized from config on first use.
-  if not semaphore then
-    semaphore = maki.async.semaphore(math.max(ctx:config("task_max_concurrent", 1), 1))
-  end
   local permit = semaphore:acquire()
 
   -- pcall so a raised error cannot leak the permit.

--- a/plugins/webfetch/init.lua
+++ b/plugins/webfetch/init.lua
@@ -62,6 +62,15 @@ end
 
 local truncate = require("maki.truncate")
 local ToolView = require("maki.tool_view")
+local output_limits = require("maki.output_limits")
+
+local opts = maki.api.register_options(output_limits.extend({
+  max_response_bytes = {
+    default = 5 * 1024 * 1024,
+    min = 1024,
+    desc = "Stop reading a response after this many bytes.",
+  },
+}))
 
 local function web_view_opts(ctx)
   local tol = ctx:tool_output_lines()
@@ -111,14 +120,11 @@ maki.api.register_tool({
       return { llm_output = "error: unknown format: " .. tostring(fmt), is_error = true }
     end
 
-    local config = ctx:config()
-    local max_response = (config and config.max_response_bytes) or (5 * 1024 * 1024)
-    local max_lines = (config and config.max_output_lines) or 2000
-    local max_bytes = (config and config.max_output_bytes) or (50 * 1024)
+    local max_lines, max_bytes = output_limits.resolve(opts, ctx)
 
     local resp, err = maki.net.request(url, {
       timeout = input.timeout or 30,
-      max_bytes = max_response,
+      max_bytes = opts.max_response_bytes,
       headers = {
         ["Accept"] = ACCEPT_HEADERS[fmt],
       },

--- a/plugins/websearch/init.lua
+++ b/plugins/websearch/init.lua
@@ -5,6 +5,15 @@ local DEFAULT_NUM_RESULTS = 8
 local parse_sse_response = require("parse_sse")
 local truncate = require("maki.truncate")
 local ToolView = require("maki.tool_view")
+local output_limits = require("maki.output_limits")
+
+local opts = maki.api.register_options(output_limits.extend({
+  max_response_bytes = {
+    default = 5 * 1024 * 1024,
+    min = 1024,
+    desc = "Stop reading a response after this many bytes.",
+  },
+}))
 
 local function web_view_opts(ctx)
   local tol = ctx:tool_output_lines()
@@ -68,10 +77,7 @@ maki.api.register_tool({
       return { llm_output = "error: failed to encode request: " .. tostring(encode_err), is_error = true }
     end
 
-    local config = ctx:config()
-    local max_response = (config and config.max_response_bytes) or (5 * 1024 * 1024)
-    local max_lines = (config and config.max_output_lines) or 2000
-    local max_bytes = (config and config.max_output_bytes) or (50 * 1024)
+    local max_lines, max_bytes = output_limits.resolve(opts, ctx)
 
     local headers = {
       ["Content-Type"] = "application/json",
@@ -87,7 +93,7 @@ maki.api.register_tool({
       body = payload,
       headers = headers,
       timeout = REQUEST_TIMEOUT_SECS,
-      max_bytes = max_response,
+      max_bytes = opts.max_response_bytes,
     })
     if not resp then
       return { llm_output = "error: " .. tostring(err), is_error = true }

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -29,7 +29,6 @@ maki.setup({
         },
     },
     agent = {
-        bash_timeout_secs = 180,
         max_output_lines = 3000,
     },
     provider = {
@@ -38,8 +37,9 @@ maki.setup({
     storage = {
         max_log_files = 5,
     },
-    index = {
-        max_file_size_mb = 4,
+    plugins = {
+        bash = { timeout_secs = 180 },
+        index = { max_file_size_mb = 4 },
     },
 })
 ```
@@ -92,15 +92,8 @@ How many lines of output to show per tool in the UI. All values are `usize` with
 |-------|------|---------|-----|-------------|
 | `max_output_bytes` | usize | `51200` | 1024 | Max tool output size (bytes) |
 | `max_output_lines` | usize | `2000` | 10 | Max tool output lines |
-| `max_response_bytes` | usize | `5242880` | 1024 | Max LLM response size (bytes) |
-| `max_line_bytes` | usize | `500` | 80 | Max bytes per line before truncation |
-| `bash_timeout_secs` | u64 | `120` | 5 | Bash command timeout (seconds) |
-| `code_execution_timeout_secs` | u64 | `30` | 5 | Code execution timeout (seconds) |
 | `max_continuation_turns` | u32 | `3` | 1 | Max automatic continuation turns |
 | `compaction_buffer` | u32 \| string | `20%` | - | Context reserved for compaction: token count or percent of the context window (e.g. "20%") |
-| `search_result_limit` | usize | `100` | 10 | Max results from grep/glob searches |
-| `interpreter_max_memory_mb` | usize | `50` | 10 | Memory limit for code interpreter (MB) |
-| `task_max_concurrent` | usize | `8` | 1 | Max concurrently running subagents (task tool) |
 
 ### `provider`
 
@@ -119,24 +112,99 @@ How many lines of output to show per tool in the UI. All values are `usize` with
 | `max_log_files` | u32 | `10` | 1 | Max number of log files to keep |
 | `input_history_size` | usize | `100` | 10 | Number of input history entries to retain |
 
-### `index`
+## Plugins
 
-| Field | Type | Default | Min | Description |
-|-------|------|---------|-----|-------------|
-| `max_file_size_mb` | u64 | `2` | 1 | Max file size for indexing (MB) |
+The `plugins` table turns plugins on or off and passes options to them. All bundled plugins are on by default. Set `enabled = false` to turn one off.
 
-## Tools
+Each plugin checks its own options at startup. A typo, a wrong type, or an unknown plugin name gives you a clear error right away.
 
-The `tools` table lets you turn tools on or off. By default `index`, `webfetch`, and `websearch` are on. `bash` is off by default.
+The edit plugin's extra tools are options too: `plugins.edit = { multiedit = false, edit_lines = true }`. The old `tools` table is gone. If your config still uses it, Maki stops at startup and shows you the new form.
 
 ```lua
 maki.setup({
-    tools = {
-        bash = { enabled = true },
+    plugins = {
+        bash = { timeout_secs = 180 },
         websearch = { enabled = false },
     },
 })
 ```
+
+### `plugins.bash`
+
+| Field | Type | Default | Min | Description |
+|-------|------|---------|-----|-------------|
+| `max_output_bytes` | integer | - | - | Override `agent.max_output_bytes` for this tool. |
+| `max_output_lines` | integer | - | - | Override `agent.max_output_lines` for this tool. |
+| `timeout_secs` | integer | `120` | 5 | Kill the command after this many seconds. A call's `timeout` param overrides it. |
+
+### `plugins.code_execution`
+
+| Field | Type | Default | Min | Description |
+|-------|------|---------|-----|-------------|
+| `max_memory_mb` | integer | `50` | 10 | Memory limit for the Python sandbox (MB). |
+| `max_output_bytes` | integer | - | - | Override `agent.max_output_bytes` for this tool. |
+| `max_output_lines` | integer | - | - | Override `agent.max_output_lines` for this tool. |
+| `timeout_secs` | integer | `30` | 5 | Stop the script after this many seconds. A call's `timeout` param overrides it. |
+
+### `plugins.edit`
+
+| Field | Type | Default | Min | Description |
+|-------|------|---------|-----|-------------|
+| `edit_lines` | boolean | `false` | - | Provide the opt-in `edit_lines` tool. |
+| `insert_lines` | boolean | `false` | - | Provide the opt-in `insert_lines` tool. |
+| `multiedit` | boolean | `true` | - | Provide the `multiedit` tool. |
+
+### `plugins.glob`
+
+| Field | Type | Default | Min | Description |
+|-------|------|---------|-----|-------------|
+| `max_output_bytes` | integer | - | - | Override `agent.max_output_bytes` for this tool. |
+| `max_output_lines` | integer | - | - | Override `agent.max_output_lines` for this tool. |
+| `search_result_limit` | integer | `100` | 10 | Max files returned per search. |
+
+### `plugins.grep`
+
+| Field | Type | Default | Min | Description |
+|-------|------|---------|-----|-------------|
+| `max_line_bytes` | integer | `500` | 80 | Skip lines longer than this many bytes. |
+| `max_output_bytes` | integer | - | - | Override `agent.max_output_bytes` for this tool. |
+| `max_output_lines` | integer | - | - | Override `agent.max_output_lines` for this tool. |
+| `search_result_limit` | integer | `100` | 10 | Max match groups per search. A call's `limit` param overrides it. |
+
+### `plugins.index`
+
+| Field | Type | Default | Min | Description |
+|-------|------|---------|-----|-------------|
+| `max_file_size_mb` | integer | `2` | 1 | Refuse to index files larger than this many MB. |
+
+### `plugins.read`
+
+| Field | Type | Default | Min | Description |
+|-------|------|---------|-----|-------------|
+| `max_line_bytes` | integer | `500` | 80 | Truncate lines longer than this many bytes. |
+| `max_output_lines` | integer | - | - | Override `agent.max_output_lines` for this tool. |
+
+### `plugins.task`
+
+| Field | Type | Default | Min | Description |
+|-------|------|---------|-----|-------------|
+| `max_concurrent` | integer | `8` | 1 | Max concurrently running subagents. |
+
+### `plugins.webfetch`
+
+| Field | Type | Default | Min | Description |
+|-------|------|---------|-----|-------------|
+| `max_output_bytes` | integer | - | - | Override `agent.max_output_bytes` for this tool. |
+| `max_output_lines` | integer | - | - | Override `agent.max_output_lines` for this tool. |
+| `max_response_bytes` | integer | `5242880` | 1024 | Stop reading a response after this many bytes. |
+
+### `plugins.websearch`
+
+| Field | Type | Default | Min | Description |
+|-------|------|---------|-----|-------------|
+| `max_output_bytes` | integer | - | - | Override `agent.max_output_bytes` for this tool. |
+| `max_output_lines` | integer | - | - | Override `agent.max_output_lines` for this tool. |
+| `max_response_bytes` | integer | `5242880` | 1024 | Stop reading a response after this many bytes. |
 
 ## Validation
 
@@ -179,42 +247,3 @@ On top of `AGENTS.md`, you can add your own instructions in two places:
 - `~/.config/maki/AGENTS.md` for preferences that apply to all projects
 
 Both are added to the system prompt at the start of every session.
-
-## Migrating from config.toml
-
-Still have a `config.toml`? Here is how to switch over.
-
-**Rename your config files:**
-
-```
-~/.config/maki/config.toml  ->  ~/.config/maki/init.lua
-.maki/config.toml           ->  .maki/init.lua
-```
-
-**Wrap the content in `maki.setup()`:**
-
-Before:
-
-```toml
-[agent]
-bash_timeout_secs = 180
-```
-
-After:
-
-```lua
-maki.setup({
-    agent = { bash_timeout_secs = 180 },
-})
-```
-
-Same field names, just Lua syntax instead of TOML.
-
-**Move MCP sections to `mcp.toml`.**
-
-- `~/.config/maki/mcp.toml` (global)
-- `.maki/mcp.toml` (per-project)
-
-Same format, just a different file. See [MCP](/docs/mcp/).
-
-**Permissions stay in `permissions.toml`.**

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -270,6 +270,41 @@ maki.api.register_prompt_hint({
 
 ---
 
+### `maki.api.register_options()` {#maki-api-register_options}
+
+```lua
+maki.api.register_options({spec})
+```
+
+Declare the options your plugin accepts under `plugins.<name>` in
+`maki.setup`, and get back what the user set merged with your defaults.
+Call it once, at the top level of your plugin file.
+
+An unknown key, a wrong type, or a value below `min` fails the plugin
+load with a clear message, so users catch typos right away. Bad specs
+fail the load too. The specs also feed the generated configuration docs.
+
+**Parameters:**
+
+- `{spec}` (`table`) Map of option name to a spec table:
+  - `default` (`boolean|number|string`) Optional. Used when the user sets nothing. Its Lua type becomes the option type.
+  - `type` (`string`) Required when there is no default: "boolean", "integer", "number", or "string".
+  - `min` (`number`) Optional. Minimum accepted value, numeric options only.
+  - `desc` (`string`) Required. One line shown in the configuration docs.
+
+**Returns:** (`table`) Merged options: the user's value where set, otherwise the default, or nil when neither exists.
+
+**Example:**
+
+```lua
+local opts = maki.api.register_options({
+  timeout_secs = { default = 120, min = 5, desc = "Kill the command after this many seconds." },
+  max_output_lines = { type = "integer", desc = "Override agent.max_output_lines for this tool." },
+})
+```
+
+---
+
 ### `maki.api.set_prompt()` {#maki-api-set_prompt}
 
 ```lua


### PR DESCRIPTION
Timeouts, size limits and concurrency caps lived as typed `AgentConfig` fields even though only one plugin ever read each of them, so adding an option meant touching Rust in three places.

Now each plugin declares its own defaults, minimums and docs via a new `maki.api.register_options`, which is also the only way to read them, so a typo, a wrong type, a too-small value, options for a plugin that declares none, or a name that matches no bundled plugin all fail startup with a clear message.

Since plugins like `sessions` provide no tools at all, the `tools` table became `plugins`, and the edit plugin's extra tools became plain options (`plugins.edit = { multiedit = false, edit_lines = true }`), so off now means never registered instead of registered then filtered.

Old configs fail at startup with a pointer to the new form, including a copy-pasteable `sed` one-liner that rewrites `tools =` to `plugins =` and keeps a `.bak` backup.

Docgen collects the declared specs over a new `CollectPluginOptions` request, so the `plugins.<name>` reference tables and even the "opt-in" badge are derived from the plugins themselves.