### PR TITLE
feat(ui): `/reload` rebuilds plugins and config without leaving the app

### DIFF
--- a/maki-agent/src/tools/registry.rs
+++ b/maki-agent/src/tools/registry.rs
@@ -395,6 +395,16 @@ impl ToolRegistry {
         Ok(())
     }
 
+    pub fn clear_lua(&self) {
+        self.tools.rcu(|current| {
+            current
+                .iter()
+                .filter(|t| !matches!(t.source, ToolSource::Lua { .. }))
+                .cloned()
+                .collect::<Vec<_>>()
+        });
+    }
+
     pub fn clear_plugin(&self, plugin: &str) {
         self.tools.rcu(|current| {
             current
@@ -590,6 +600,34 @@ mod tests {
                 .any(|d| d["name"].as_str() == Some("late_server.probe")),
             "mid-session tool missing from definitions"
         );
+    }
+
+    /// `/reload` re-registers the same lua tool names, so anything
+    /// `clear_lua` leaves behind becomes a `NameConflict` that breaks every
+    /// later reload.
+    #[test]
+    fn clear_lua_removes_lua_keeps_mcp_and_allows_reregistration() {
+        let reg = ToolRegistry::new();
+        reg.register(mock("lua_a"), lua_source("p1")).unwrap();
+        reg.register(mock("lua_b"), lua_source("p2")).unwrap();
+        reg.register(
+            mock("srv.tool"),
+            ToolSource::Mcp {
+                server: "srv".into(),
+            },
+        )
+        .unwrap();
+
+        reg.clear_lua();
+
+        assert!(!reg.has("lua_a"));
+        assert!(!reg.has("lua_b"));
+        assert!(reg.has("srv.tool"));
+
+        reg.register(mock("lua_a"), lua_source("p1")).unwrap();
+        reg.register(mock("lua_b"), lua_source("p2")).unwrap();
+        assert!(reg.has("lua_a"));
+        assert!(reg.has("lua_b"));
     }
 
     #[test]

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -779,6 +779,7 @@ pub struct PermissionsConfig {
     pub yolo: bool,
 }
 
+#[derive(Clone)]
 pub struct Config {
     pub always_yolo: bool,
     pub always_fast: bool,

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -820,9 +820,13 @@ impl App {
     }
 
     fn quit(&mut self) -> Vec<Action> {
+        self.quit_with(ExitRequest::Success)
+    }
+
+    fn quit_with(&mut self, req: ExitRequest) -> Vec<Action> {
         self.save_session();
         self.save_input_history();
-        self.exit_request = ExitRequest::Success;
+        self.exit_request = req;
         vec![]
     }
 
@@ -1242,6 +1246,7 @@ impl App {
                 vec![]
             }
             "/exit" => self.quit(),
+            "/reload" => self.quit_with(ExitRequest::Reload),
             name if name.starts_with("/project:") || name.starts_with("/user:") => {
                 self.execute_custom_command(name, &cmd.args)
             }

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -19,27 +19,22 @@ use maki_storage::sessions::StoredThinking;
 use ratatui::layout::Rect;
 use std::env;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use tempfile::TempDir;
 use test_case::test_case;
+
+const WRITER_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn set_zone(app: &mut App, zone: SelectionZone, area: Rect) {
     app.zones.push(SelectableZone { area, zone });
 }
 
-fn test_app() -> App {
-    let writer = Arc::new(StorageWriter::new(StateDir::from_path(env::temp_dir())));
-    let permissions = Arc::new(PermissionManager::new(
-        PermissionsConfig {
-            rules: vec![],
-            ..Default::default()
-        },
-        PathBuf::from("/tmp"),
-    ));
+fn build_app(dir: StateDir, writer: Arc<StorageWriter>) -> App {
     let model = test_model();
-    let mut app = App::new(
+    App::new(
         &model,
         AppSession::new("test-model", "/tmp/test"),
-        StateDir::from_path(env::temp_dir()),
+        dir,
         Arc::new(ArcSwapOption::empty()),
         McpSnapshotReader::empty(),
         McpConfigErrors::new(PathBuf::new()),
@@ -49,12 +44,31 @@ fn test_app() -> App {
         writer,
         UiConfig::default(),
         100,
-        permissions,
+        Arc::new(PermissionManager::new(
+            PermissionsConfig {
+                rules: vec![],
+                ..Default::default()
+            },
+            PathBuf::from("/tmp"),
+        )),
         Arc::from([]),
-    );
+    )
+}
+
+fn test_app() -> App {
+    let dir = StateDir::from_path(env::temp_dir());
+    let mut app = build_app(dir.clone(), Arc::new(StorageWriter::new(dir)));
     let (shared_queue, _rx) = shared_queue::queue();
     app.queue.set_shared(shared_queue);
     app
+}
+
+fn tempdir_app() -> (TempDir, StateDir, Arc<StorageWriter>, App) {
+    let tmp = TempDir::new().unwrap();
+    let dir = StateDir::from_path(tmp.path().to_path_buf());
+    let writer = Arc::new(StorageWriter::new(dir.clone()));
+    let app = build_app(dir.clone(), Arc::clone(&writer));
+    (tmp, dir, writer, app)
 }
 
 fn mouse_event(kind: MouseEventKind, column: u16, row: u16) -> Msg {
@@ -476,34 +490,7 @@ fn reset_session_clears_drafting_plan_in_build_mode() {
 
 #[test]
 fn load_session_clears_plan() {
-    let tmp = TempDir::new().unwrap();
-    let dir = StateDir::from_path(tmp.path().to_path_buf());
-    let writer = Arc::new(StorageWriter::new(StateDir::from_path(
-        tmp.path().to_path_buf(),
-    )));
-    let model = test_model();
-    let mut app = App::new(
-        &model,
-        AppSession::new("test-model", "/tmp/test"),
-        dir,
-        Arc::new(ArcSwapOption::empty()),
-        McpSnapshotReader::empty(),
-        McpConfigErrors::new(PathBuf::new()),
-        LuaCommandReader::empty(),
-        KeymapReader::empty(),
-        HintReader::empty(),
-        writer,
-        UiConfig::default(),
-        100,
-        Arc::new(PermissionManager::new(
-            PermissionsConfig {
-                rules: vec![],
-                ..Default::default()
-            },
-            PathBuf::from("/tmp"),
-        )),
-        Arc::from([]),
-    );
+    let (_tmp, _dir, _writer, mut app) = tempdir_app();
     app.state
         .session
         .messages
@@ -1508,6 +1495,57 @@ fn submit_exit_quits() {
     });
     assert_eq!(app.exit_request, ExitRequest::Success);
     assert!(actions.is_empty());
+}
+
+#[test]
+fn persisted_tab_none_for_empty_some_for_content() {
+    let mut app = test_app();
+    app.save_session();
+    assert_eq!(crate::event_loop::persisted_tab(&app), None);
+
+    app.update(Msg::Key(key(KeyCode::Char('x'))));
+    app.save_session();
+    assert_eq!(
+        crate::event_loop::persisted_tab(&app),
+        Some(app.state.session.id)
+    );
+}
+
+fn drain_writer(app: App, writer: Arc<StorageWriter>) {
+    drop(app);
+    Arc::try_unwrap(writer)
+        .ok()
+        .expect("app must hold the only other writer reference")
+        .shutdown(WRITER_DRAIN_TIMEOUT);
+}
+
+#[test]
+fn reload_persists_session_with_content_to_disk() {
+    let (_tmp, dir, writer, mut app) = tempdir_app();
+    app.state
+        .session
+        .messages
+        .push(Message::user("hello".into()));
+    let actions = app.execute_command(cmd("/reload"));
+    assert_eq!(app.exit_request, ExitRequest::Reload);
+    assert!(actions.is_empty());
+    let id = app.state.session.id;
+    drain_writer(app, writer);
+
+    assert_eq!(AppSession::load(id, &dir).unwrap().messages.len(), 1);
+}
+
+#[test]
+fn reload_leaves_empty_session_unpersisted_on_disk() {
+    let (tmp, _dir, writer, mut app) = tempdir_app();
+    app.execute_command(cmd("/reload"));
+    drain_writer(app, writer);
+
+    let sessions_dir = tmp.path().join(maki_storage::sessions::SESSIONS_DIR);
+    let entries = std::fs::read_dir(&sessions_dir)
+        .map(|d| d.count())
+        .unwrap_or(0);
+    assert_eq!(entries, 0);
 }
 
 #[test]

--- a/maki-ui/src/components/command.rs
+++ b/maki-ui/src/components/command.rs
@@ -107,6 +107,11 @@ pub const BUILTIN_COMMANDS: &[BuiltinCommand] = &[
         description: "Exit the application",
         max_args: 0,
     },
+    BuiltinCommand {
+        name: "/reload",
+        description: "Reload plugins and config",
+        max_args: 0,
+    },
 ];
 
 pub struct ParsedCommand {

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -218,12 +218,13 @@ pub enum ExitRequest {
     None,
     Success,
     Error,
+    Reload,
 }
 
 impl ExitRequest {
     pub fn code(&self) -> i32 {
         match self {
-            Self::None | Self::Success => 0,
+            Self::None | Self::Success | Self::Reload => 0,
             Self::Error => 1,
         }
     }

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -53,11 +53,21 @@ const DRAIN_BUDGET: usize = 256;
 const AGENT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
 const DELETE_FOCUSED_ERR: &str = "cannot delete the focused session";
 
+/// Per-tab persistence outcome after `shutdown`: `Some` iff the tab had
+/// content and was saved; `None` means a deliberately unpersisted empty tab.
+pub(crate) struct ShutdownReport {
+    pub exit: ExitRequest,
+    pub tabs: Vec<Option<MakiId>>,
+    pub focused: usize,
+}
+
 pub struct EventLoopParams {
     pub model: Model,
     pub needs_login: bool,
     pub commands: Vec<CustomCommand>,
-    pub session: AppSession,
+    pub sessions: Vec<AppSession>,
+    pub focused: usize,
+    pub startup_warnings: Vec<String>,
     pub storage: StateDir,
     pub config: AgentConfig,
     pub ui_config: UiConfig,
@@ -300,7 +310,9 @@ impl<'t> EventLoop<'t> {
             mut model,
             needs_login,
             commands,
-            session,
+            sessions,
+            focused,
+            startup_warnings,
             storage,
             config,
             ui_config,
@@ -315,8 +327,11 @@ impl<'t> EventLoop<'t> {
             lua_event_handle,
         } = params;
 
-        std::thread::spawn(crate::highlight::warmup);
-        crate::update::spawn_check();
+        static PROCESS_WARMUP: std::sync::Once = std::sync::Once::new();
+        PROCESS_WARMUP.call_once(|| {
+            std::thread::spawn(crate::highlight::warmup);
+            crate::update::spawn_check();
+        });
 
         let storage_writer = Arc::new(StorageWriter::new(storage.clone()));
         let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
@@ -354,20 +369,31 @@ impl<'t> EventLoop<'t> {
             storage_writer,
         };
 
-        let mut rt = ctx.spawn_runtime(session);
-        rt.app.exit_on_done = exit_on_done;
+        let mut runtimes: Vec<SessionRuntime> = sessions
+            .into_iter()
+            .map(|session| ctx.spawn_runtime(session))
+            .collect();
+        if runtimes.is_empty() {
+            return Err(eyre!("event loop needs at least one session"));
+        }
+        let focused = focused.min(runtimes.len() - 1);
+        let app = &mut runtimes[focused].app;
+        app.exit_on_done = exit_on_done;
         if needs_login {
-            rt.app.login_picker.open(rt.app.storage.clone());
+            app.login_picker.open(app.storage.clone());
         }
         if !ctx.mcp_config_errors.is_empty() {
-            rt.app
-                .flash(format!("MCP config error: {}", ctx.mcp_config_errors));
+            let msg = format!("MCP config error: {}", ctx.mcp_config_errors);
+            app.flash(msg);
+        }
+        for w in startup_warnings {
+            app.flash(w);
         }
 
         Ok(Self {
             terminal,
-            sessions: vec![rt],
-            focused: 0,
+            sessions: runtimes,
+            focused,
             ctx,
             input: InputReader::spawn(),
             warn_rx: bg.warn_rx,
@@ -381,7 +407,7 @@ impl<'t> EventLoop<'t> {
         &mut self.sessions[self.focused].app
     }
 
-    pub(crate) fn run(mut self, initial_prompt: Option<String>) -> Result<(Option<MakiId>, i32)> {
+    pub(crate) fn run(mut self, initial_prompt: Option<String>) -> Result<ShutdownReport> {
         if let Some(prompt) = initial_prompt {
             let sub = Submission {
                 text: prompt,
@@ -424,8 +450,8 @@ impl<'t> EventLoop<'t> {
         };
         // Fatal errors still save every session, kill MCP process groups,
         // and drain the storage writer before the process exits.
-        let (session_id, exit_code) = self.shutdown();
-        result.map(|()| (session_id, exit_code))
+        let report = self.shutdown();
+        result.map(|()| report)
     }
 
     /// Wait for the next event from any source, or time out so animations
@@ -1037,21 +1063,21 @@ impl<'t> EventLoop<'t> {
         }
     }
 
-    fn shutdown(mut self) -> (Option<MakiId>, i32) {
-        let focused = &self.sessions[self.focused].app;
-        let exit_code = focused.exit_request.code();
-        let session_id = focused.has_content().then_some(focused.state.session.id);
+    fn shutdown(mut self) -> ShutdownReport {
+        let exit = self.sessions[self.focused].app.exit_request;
         if let Some(ref h) = self.ctx.mcp_handle {
             mcp::kill_process_groups(&h.reader().load().pids);
         }
         for rt in &self.sessions {
             let _ = rt.handles.cmd_tx.try_send(AgentCommand::CancelAll);
         }
+        let mut tabs = Vec::with_capacity(self.sessions.len());
         for rt in self.sessions.drain(..) {
             let SessionRuntime {
                 mut app, handles, ..
             } = rt;
             app.save_session();
+            tabs.push(persisted_tab(&app));
             drop(app);
             handles.shutdown(AGENT_SHUTDOWN_TIMEOUT);
         }
@@ -1064,8 +1090,18 @@ impl<'t> EventLoop<'t> {
                 warn!("storage writer has outstanding references, skipping graceful shutdown")
             }
         }
-        (session_id, exit_code)
+        ShutdownReport {
+            exit,
+            tabs,
+            focused: self.focused,
+        }
     }
+}
+
+/// Uses the same `has_content` check as `App::save_session`, so the report
+/// and the disk can never disagree about which tabs were saved.
+pub(crate) fn persisted_tab(app: &App) -> Option<MakiId> {
+    app.has_content().then_some(app.state.session.id)
 }
 
 fn scroll_delta(kind: MouseEventKind, lines: u32) -> i32 {

--- a/maki-ui/src/lib.rs
+++ b/maki-ui/src/lib.rs
@@ -38,11 +38,33 @@ pub type AppSession = maki_storage::sessions::Session<Message, TokenUsage, ToolO
 pub(crate) use agent::AgentCommand;
 pub use event_loop::EventLoopParams;
 
-pub fn run(
-    params: EventLoopParams,
-    initial_prompt: Option<String>,
-) -> Result<(Option<MakiId>, i32)> {
-    let (_guard, mut terminal) = terminal::TerminalGuard::init()?;
-    let el = event_loop::EventLoop::new(&mut terminal, params)?;
-    el.run(initial_prompt)
+/// How a UI generation ended. On `Reload`, each tab is its saved session id,
+/// or `None` for an empty tab, so the caller can reopen everything from disk.
+pub enum RunOutcome {
+    Exit {
+        session_id: Option<MakiId>,
+        code: i32,
+    },
+    Reload {
+        tabs: Vec<Option<MakiId>>,
+        focused: usize,
+    },
+}
+
+pub fn run(params: EventLoopParams, initial_prompt: Option<String>) -> Result<RunOutcome> {
+    let report = {
+        let (_guard, mut terminal) = terminal::TerminalGuard::init()?;
+        let el = event_loop::EventLoop::new(&mut terminal, params)?;
+        el.run(initial_prompt)?
+    };
+    Ok(match report.exit {
+        components::ExitRequest::Reload => RunOutcome::Reload {
+            tabs: report.tabs,
+            focused: report.focused,
+        },
+        _ => RunOutcome::Exit {
+            session_id: report.tabs.get(report.focused).copied().flatten(),
+            code: report.exit.code(),
+        },
+    })
 }

--- a/site/docs/content/commands/_index.md
+++ b/site/docs/content/commands/_index.md
@@ -30,6 +30,7 @@ Type `/` in the input box to open the command palette.
 | `/fast` | Toggle Anthropic fast mode (Opus only) |
 | `/workflow` | Toggle workflow mode (task callable inside code_execution) |
 | `/exit` | Exit the application |
+| `/reload` | Reload plugins and config |
 | `/memory` | View, edit, and delete memory files |
 | `/rename` | Rename the current session |
 | `/sessions` | Browse and switch sessions |

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::io::{self, IsTerminal, Read};
+use std::path::Path;
 use std::sync::Arc;
 
 use color_eyre::Result;
@@ -7,15 +8,41 @@ use color_eyre::eyre::Context;
 
 use maki_agent::command::{self, CustomCommand};
 use maki_agent::tools::ToolRegistry;
-use maki_config::{load_env_files, load_permissions};
+use maki_config::{Config, load_env_files, load_permissions};
 use maki_lua::PluginHost;
 use maki_providers::model::Model;
 use maki_storage::StateDir;
 use maki_storage::id::MakiId;
-use maki_ui::AppSession;
+use maki_ui::{AppSession, RunOutcome};
 
 use crate::cli::{Cli, normalize_tool_name};
 use crate::setup;
+
+const FALLBACK_MODEL_SPEC: &str = "anthropic/claude-sonnet-4-20250514";
+const CONFIG_FALLBACK_WARNING: &str = "config reload failed, using previous config";
+const MODEL_FALLBACK_WARNING: &str = "model resolution failed, keeping previous model";
+const RELOAD_TAB_WARNING: &str = "failed to reopen session";
+const RESUME_HINT: &str = "maki -s";
+
+/// One generation of the app: everything torn down and rebuilt on `/reload`.
+/// Dropping it joins the Lua thread via `PluginHost::drop`.
+struct Stack {
+    plugin_host: PluginHost,
+    config: Config,
+    commands: Vec<CustomCommand>,
+    model: Model,
+    needs_login: bool,
+}
+
+impl Stack {
+    fn timeouts(&self) -> maki_providers::Timeouts {
+        maki_providers::Timeouts {
+            connect: self.config.provider.connect_timeout,
+            low_speed: self.config.provider.low_speed_timeout,
+            stream: self.config.provider.stream_timeout,
+        }
+    }
+}
 
 fn discover_commands(disable: bool) -> Vec<CustomCommand> {
     if disable {
@@ -23,6 +50,116 @@ fn discover_commands(disable: bool) -> Vec<CustomCommand> {
     }
     let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
     command::discover_commands(&cwd)
+}
+
+fn load_config(plugin_host: &PluginHost, cli: &Cli, cwd: &Path) -> Result<Config> {
+    let raw_config = plugin_host
+        .load_init_files(cwd)
+        .context("load init.lua files")?;
+
+    let mut config = raw_config
+        .unwrap_or_default()
+        .into_config(cli.no_rtk)
+        .context("invalid config")?;
+    config.permissions = load_permissions(cwd);
+
+    if cli.yolo || config.always_yolo {
+        config.permissions.yolo = true;
+    }
+    if !cli.allowed_tools.is_empty() {
+        config.agent.allowed_tools = cli
+            .allowed_tools
+            .iter()
+            .map(|t| normalize_tool_name(t))
+            .collect::<Result<Vec<_>>>()?;
+    }
+    if !cli.disallowed_tools.is_empty() {
+        config.agent.disabled_tools.extend(
+            cli.disallowed_tools
+                .iter()
+                .filter_map(|t| normalize_tool_name(t).ok()),
+        );
+    }
+    config.validate()?;
+    Ok(config)
+}
+
+fn config_or_fallback(
+    loaded: Result<Config>,
+    fallback: Option<Config>,
+    warnings: &mut Vec<String>,
+) -> Result<Config> {
+    match (loaded, fallback) {
+        (Ok(config), _) => Ok(config),
+        (Err(e), Some(last_good)) => {
+            warnings.push(format!("{CONFIG_FALLBACK_WARNING}: {e:#}"));
+            Ok(last_good)
+        }
+        (Err(e), None) => Err(e),
+    }
+}
+
+/// The one construction path for a generation: first startup passes
+/// `fallback: None` (fail-fast); `/reload` passes the last-good config and
+/// model so a broken config reopens the UI with a warning instead of exiting.
+fn build_stack(
+    cli: &Cli,
+    cwd: &Path,
+    storage: &StateDir,
+    fallback: Option<(Config, Model)>,
+) -> Result<(Stack, Vec<String>)> {
+    let mut warnings = Vec::new();
+
+    let mut plugin_host = if cli.no_plugins {
+        PluginHost::disabled()
+    } else {
+        PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !cli.no_jit)
+            .context("initialize lua plugin host")?
+    };
+
+    let (fallback_config, fallback_model) = fallback.unzip();
+    let reloading = fallback_model.is_some();
+    let config = config_or_fallback(
+        load_config(&plugin_host, cli, cwd),
+        fallback_config,
+        &mut warnings,
+    )?;
+
+    if let Err(e) = plugin_host.load_builtins(&config.plugins) {
+        let e = color_eyre::eyre::Report::from(e).wrap_err("load builtin plugins");
+        if reloading {
+            warnings.push(format!("{e:#}"));
+        } else {
+            return Err(e);
+        }
+    }
+
+    let commands = discover_commands(cli.no_commands);
+
+    let model_result = setup::resolve_model(cli.model.as_deref(), &config.provider, storage);
+    let (model, needs_login) = match (model_result, fallback_model) {
+        (Ok(m), _) => (m, false),
+        (Err(e), Some(last_model)) => {
+            warnings.push(format!("{MODEL_FALLBACK_WARNING}: {e:#}"));
+            (last_model, false)
+        }
+        (Err(_), None) if !cli.print => {
+            let placeholder = Model::from_spec(FALLBACK_MODEL_SPEC).expect("fallback model");
+            (placeholder, true)
+        }
+        (Err(e), None) => return Err(e),
+    };
+
+    Ok((
+        Stack {
+            plugin_host,
+            config,
+            commands,
+            model,
+            needs_login,
+        },
+        warnings,
+    ))
 }
 
 fn resolve_session(
@@ -52,6 +189,34 @@ fn resolve_session(
     Ok(AppSession::new(model, cwd))
 }
 
+/// Reopen every tab from disk after a reload. A saved tab that fails to load
+/// flashes a warning and comes back fresh; a `None` slot was empty and starts
+/// as a new session.
+fn resolve_reload_tabs(
+    ids: &[Option<MakiId>],
+    model: &str,
+    cwd: &str,
+    storage: &StateDir,
+    warnings: &mut Vec<String>,
+) -> Vec<AppSession> {
+    let mut tabs: Vec<AppSession> = ids
+        .iter()
+        .map(|slot| match slot {
+            Some(id) => AppSession::load(*id, storage).unwrap_or_else(|e| {
+                warnings.push(format!(
+                    "{RELOAD_TAB_WARNING} {id}: {e}; it is still on disk, try `{RESUME_HINT} {id}`"
+                ));
+                AppSession::new(model, cwd)
+            }),
+            None => AppSession::new(model, cwd),
+        })
+        .collect();
+    if tabs.is_empty() {
+        tabs.push(AppSession::new(model, cwd));
+    }
+    tabs
+}
+
 fn read_initial_prompt(cli_prompt: Option<String>) -> Result<Option<String>> {
     match cli_prompt {
         Some(p) => Ok(Some(p)),
@@ -64,7 +229,7 @@ fn read_initial_prompt(cli_prompt: Option<String>) -> Result<Option<String>> {
     }
 }
 
-pub fn run(cli: Cli) -> Result<()> {
+pub fn run(mut cli: Cli) -> Result<()> {
     let storage = StateDir::resolve().context("resolve data directory")?;
     maki_providers::model_registry::load_from_storage(&storage);
 
@@ -73,159 +238,141 @@ pub fn run(cli: Cli) -> Result<()> {
     load_env_files(&cwd);
     warn_stale_config_toml(&cwd);
 
-    let mut plugin_host = if cli.no_plugins {
-        PluginHost::disabled()
-    } else {
-        PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !cli.no_jit)
-            .context("initialize lua plugin host")?
-    };
+    let (mut stack, _) = build_stack(&cli, &cwd, &storage, None)?;
 
-    let raw_config = plugin_host
-        .load_init_files(&cwd)
-        .context("load init.lua files")?;
-
-    let mut config = raw_config
-        .unwrap_or_default()
-        .into_config(cli.no_rtk)
-        .context("invalid config")?;
-    config.permissions = load_permissions(&cwd);
-
-    if cli.yolo || config.always_yolo {
-        config.permissions.yolo = true;
-    }
-    if !cli.allowed_tools.is_empty() {
-        config.agent.allowed_tools = cli
-            .allowed_tools
-            .iter()
-            .map(|t| normalize_tool_name(t))
-            .collect::<Result<Vec<_>>>()?;
-    }
-    if !cli.disallowed_tools.is_empty() {
-        config.agent.disabled_tools.extend(
-            cli.disallowed_tools
-                .iter()
-                .filter_map(|t| normalize_tool_name(t).ok()),
-        );
-    }
-    config.validate()?;
-
-    plugin_host
-        .load_builtins(&config.plugins)
-        .context("load builtin plugins")?;
-
-    let lua_command_reader = plugin_host.command_reader();
-    let ui_action_rx = plugin_host.ui_action_rx();
-
-    let timeouts = maki_providers::Timeouts {
-        connect: config.provider.connect_timeout,
-        low_speed: config.provider.low_speed_timeout,
-        stream: config.provider.stream_timeout,
-    };
-
-    let model_result = setup::resolve_model(cli.model.as_deref(), &config.provider, &storage);
-    let (model, needs_login) = match model_result {
-        Ok(m) => (m, false),
-        Err(_) if !cli.print => {
-            let fallback =
-                Model::from_spec("anthropic/claude-sonnet-4-20250514").expect("fallback model");
-            (fallback, true)
-        }
-        Err(e) => return Err(e),
-    };
-
-    setup::init_logging(&config.storage);
+    setup::init_logging(&stack.config.storage);
     setup::install_panic_log_hook();
 
-    let commands = discover_commands(cli.no_commands);
-
     if cli.is_sdk_mode() {
-        let fast = config.always_fast && model.supports_fast();
-        let prompt_slots = plugin_host
+        let fast = stack.config.always_fast && stack.model.supports_fast();
+        let prompt_slots = stack
+            .plugin_host
             .event_handle()
             .map(|h| h.collect_prompt_slots())
             .unwrap_or_default();
+        let timeouts = stack.timeouts();
         crate::sdk_mode::run(crate::sdk_mode::SdkParams {
             cli,
-            model,
-            config: config.agent,
-            permissions_config: config.permissions,
+            model: stack.model,
+            config: stack.config.agent,
+            permissions_config: stack.config.permissions,
             timeouts,
             prompt_slots,
             fast,
-            workflow: config.always_workflow,
+            workflow: stack.config.always_workflow,
         })
         .context("run sdk mode")?;
-    } else if cli.print {
-        let fast = config.always_fast && model.supports_fast();
+        return Ok(());
+    }
+    if cli.print {
+        let fast = stack.config.always_fast && stack.model.supports_fast();
+        let timeouts = stack.timeouts();
         crate::print::run(
-            &model,
+            &stack.model,
             cli.initial_prompt,
             cli.images,
             cli.output_format,
             cli.verbose,
-            config.agent,
-            config.permissions,
+            stack.config.agent,
+            stack.config.permissions,
             timeouts,
-            plugin_host.event_handle(),
+            stack.plugin_host.event_handle(),
             fast,
-            config.always_workflow,
+            stack.config.always_workflow,
         )
         .context("run print mode")?;
-    } else {
-        let cwd_str = cwd.to_string_lossy().into_owned();
-        let mut session = resolve_session(
-            cli.continue_session,
-            cli.session.as_deref(),
-            &model.spec(),
-            &cwd_str,
-            &storage,
-        )?;
-        if session.messages.is_empty() {
-            session.meta.fast |= config.always_fast;
-            session.meta.workflow |= config.always_workflow;
-            if let Some(thinking) = config.always_thinking {
-                session.meta.thinking = Some(thinking);
+        return Ok(());
+    }
+
+    let cwd_str = cwd.to_string_lossy().into_owned();
+    let mut tabs = vec![resolve_session(
+        cli.continue_session,
+        cli.session.as_deref(),
+        &stack.model.spec(),
+        &cwd_str,
+        &storage,
+    )?];
+    let mut focused = 0;
+    let mut warnings: Vec<String> = Vec::new();
+    let mut initial_prompt = read_initial_prompt(cli.initial_prompt.take())?;
+
+    loop {
+        for session in &mut tabs {
+            if session.messages.is_empty() {
+                session.meta.fast |= stack.config.always_fast;
+                session.meta.workflow |= stack.config.always_workflow;
+                if let Some(thinking) = stack.config.always_thinking {
+                    session.meta.thinking = Some(thinking);
+                }
             }
         }
-        let model = if session.messages.is_empty() {
-            model
+        let focused_tab = &tabs[focused];
+        let model = if focused_tab.messages.is_empty() {
+            stack.model.clone()
         } else {
-            Model::from_spec(&session.model).unwrap_or(model)
+            Model::from_spec(&focused_tab.model).unwrap_or_else(|_| stack.model.clone())
         };
-        let initial_prompt = read_initial_prompt(cli.initial_prompt)?;
-        let (session_id, exit_code) = maki_ui::run(
+
+        let outcome = maki_ui::run(
             maki_ui::EventLoopParams {
                 model,
-                needs_login,
-                commands,
-                session,
-                storage,
-                config: config.agent,
-                ui_config: config.ui,
-                input_history_size: config.storage.input_history_size,
+                needs_login: stack.needs_login,
+                commands: std::mem::take(&mut stack.commands),
+                sessions: std::mem::take(&mut tabs),
+                focused,
+                startup_warnings: std::mem::take(&mut warnings),
+                storage: storage.clone(),
+                config: stack.config.agent.clone(),
+                ui_config: stack.config.ui,
+                input_history_size: stack.config.storage.input_history_size,
                 permissions: Arc::new(maki_agent::permissions::PermissionManager::new(
-                    config.permissions,
+                    stack.config.permissions.clone(),
                     cwd.clone(),
                 )),
-                timeouts,
+                timeouts: stack.timeouts(),
                 exit_on_done: cli.exit_on_done,
-                lua_command_reader,
-                keymap_reader: plugin_host.keymap_reader(),
-                hint_reader: plugin_host.hint_reader(),
-                ui_action_rx,
-                lua_event_handle: plugin_host.event_handle(),
+                lua_command_reader: stack.plugin_host.command_reader(),
+                keymap_reader: stack.plugin_host.keymap_reader(),
+                hint_reader: stack.plugin_host.hint_reader(),
+                ui_action_rx: stack.plugin_host.ui_action_rx(),
+                lua_event_handle: stack.plugin_host.event_handle(),
             },
-            initial_prompt,
+            initial_prompt.take(),
         )
         .context("run UI")?;
-        if let Some(session_id) = session_id {
-            eprintln!("Resume session:\n\n  maki -s {session_id}");
-        }
-        if exit_code != 0 {
-            std::process::exit(exit_code);
+
+        match outcome {
+            RunOutcome::Exit { session_id, code } => {
+                if let Some(session_id) = session_id {
+                    eprintln!("Resume session:\n\n  maki -s {session_id}");
+                }
+                if code != 0 {
+                    std::process::exit(code);
+                }
+                return Ok(());
+            }
+            RunOutcome::Reload {
+                tabs: ids,
+                focused: f,
+            } => {
+                let last_good = (stack.config.clone(), stack.model.clone());
+                drop(stack);
+                ToolRegistry::global().clear_lua();
+                let (new_stack, mut new_warnings) =
+                    build_stack(&cli, &cwd, &storage, Some(last_good))?;
+                tabs = resolve_reload_tabs(
+                    &ids,
+                    &new_stack.model.spec(),
+                    &cwd_str,
+                    &storage,
+                    &mut new_warnings,
+                );
+                stack = new_stack;
+                warnings = new_warnings;
+                focused = f.min(tabs.len() - 1);
+            }
         }
     }
-    Ok(())
 }
 
 fn warn_stale_config_toml(cwd: &std::path::Path) {
@@ -240,5 +387,146 @@ fn warn_stale_config_toml(cwd: &std::path::Path) {
                 "config.toml found but no longer used. Migrate to init.lua. See https://maki.sh/docs/configuration/"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use color_eyre::eyre::eyre;
+    use maki_config::RawConfig;
+    use tempfile::TempDir;
+
+    const TEST_MODEL: &str = "test/model";
+    const TEST_CWD: &str = "/tmp/reload-test";
+
+    fn test_config() -> Config {
+        RawConfig::default()
+            .into_config(false)
+            .expect("default config")
+    }
+
+    #[test]
+    fn broken_config_with_fallback_uses_last_good_and_warns() {
+        let mut last_good = test_config();
+        last_good.always_fast = true;
+        let mut warnings = Vec::new();
+
+        let config = config_or_fallback(Err(eyre!("boom")), Some(last_good), &mut warnings)
+            .expect("fallback config");
+
+        assert!(config.always_fast);
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            warnings[0].starts_with(CONFIG_FALLBACK_WARNING),
+            "{warnings:?}"
+        );
+        assert!(warnings[0].contains("boom"), "{warnings:?}");
+    }
+
+    #[test]
+    fn broken_config_without_fallback_is_fatal() {
+        let mut warnings = Vec::new();
+        let err = match config_or_fallback(Err(eyre!("boom")), None, &mut warnings) {
+            Err(e) => e,
+            Ok(_) => panic!("expected error without fallback"),
+        };
+        assert!(err.to_string().contains("boom"));
+        assert!(warnings.is_empty());
+    }
+
+    fn temp_storage() -> (TempDir, StateDir) {
+        let dir = TempDir::new().expect("tempdir");
+        let storage = StateDir::from_path(dir.path().to_path_buf());
+        (dir, storage)
+    }
+
+    #[test]
+    fn resolve_reload_roundtrips_saved_session() {
+        let (_dir, storage) = temp_storage();
+        let mut session = AppSession::new(TEST_MODEL, TEST_CWD);
+        session.title = "persisted title".into();
+        session.save(&storage).expect("save");
+        let id = session.id;
+        let mut warnings = Vec::new();
+
+        let tabs = resolve_reload_tabs(&[Some(id)], TEST_MODEL, TEST_CWD, &storage, &mut warnings);
+
+        assert_eq!(tabs.len(), 1);
+        assert_eq!(tabs[0].id, id);
+        assert_eq!(tabs[0].title, "persisted title");
+        assert!(warnings.is_empty(), "{warnings:?}");
+    }
+
+    #[test]
+    fn resolve_reload_missing_id_warns_and_falls_back_fresh() {
+        let (_dir, storage) = temp_storage();
+        let missing = MakiId::generate();
+        let mut warnings = Vec::new();
+
+        let tabs = resolve_reload_tabs(
+            &[Some(missing)],
+            TEST_MODEL,
+            TEST_CWD,
+            &storage,
+            &mut warnings,
+        );
+
+        assert_eq!(tabs.len(), 1);
+        assert_ne!(tabs[0].id, missing);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].starts_with(RELOAD_TAB_WARNING), "{warnings:?}");
+        assert!(warnings[0].contains(&missing.to_string()), "{warnings:?}");
+        assert!(warnings[0].contains(RESUME_HINT), "{warnings:?}");
+    }
+
+    #[test]
+    fn resolve_reload_none_slot_becomes_fresh_session() {
+        let (_dir, storage) = temp_storage();
+        let mut warnings = Vec::new();
+
+        let tabs = resolve_reload_tabs(&[None], TEST_MODEL, TEST_CWD, &storage, &mut warnings);
+
+        assert_eq!(tabs.len(), 1);
+        assert_eq!(tabs[0].model, TEST_MODEL);
+        assert_eq!(tabs[0].cwd, TEST_CWD);
+        assert!(warnings.is_empty(), "{warnings:?}");
+    }
+
+    #[test]
+    fn resolve_reload_empty_ids_yields_one_fresh_tab() {
+        let (_dir, storage) = temp_storage();
+        let mut warnings = Vec::new();
+
+        let tabs = resolve_reload_tabs(&[], TEST_MODEL, TEST_CWD, &storage, &mut warnings);
+
+        assert_eq!(tabs.len(), 1);
+        assert_eq!(tabs[0].model, TEST_MODEL);
+        assert!(warnings.is_empty(), "{warnings:?}");
+    }
+
+    #[test]
+    fn resolve_reload_preserves_tab_order_with_mixed_slots() {
+        let (_dir, storage) = temp_storage();
+        let mut saved = AppSession::new(TEST_MODEL, TEST_CWD);
+        saved.save(&storage).expect("save");
+        let saved_id = saved.id;
+        let missing = MakiId::generate();
+        let mut warnings = Vec::new();
+
+        let tabs = resolve_reload_tabs(
+            &[Some(saved_id), None, Some(missing)],
+            TEST_MODEL,
+            TEST_CWD,
+            &storage,
+            &mut warnings,
+        );
+
+        assert_eq!(tabs.len(), 3);
+        assert_eq!(tabs[0].id, saved_id);
+        assert_ne!(tabs[1].id, saved_id);
+        assert_ne!(tabs[2].id, missing);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].contains(&missing.to_string()), "{warnings:?}");
     }
 }


### PR DESCRIPTION
A new `/reload` command tears down the whole generation (`PluginHost` and its Lua thread, config, MCP, terminal) and rebuilds it in an outer loop in `src/cmd/tui.rs`, since swapping Lua state live under readers handed out at startup would never answer "is this reader current".

Disk is the only carrier across generations: shutdown saves every tab and reports a per-tab `Option<MakiId>` through the same `has_content` predicate as `save_session`, so an empty tab cannot be confused with a lost session and every reload exercises the real `maki -s` resume path.

A broken `init.lua` reopens the UI on the last-good `Config` (now `Clone`) with a flashed warning, and a failed model resolve keeps the previous model instead of falling back to the hardcoded login placeholder.

Teardown leaves the global registry MCP-only via `ToolRegistry::clear_lua`, and `Once` guards keep highlight warmup and the update check from running once per generation.