### PR TITLE
feat(lua): `buf:blit` pixel canvas for plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,6 +2642,7 @@ dependencies = [
  "tree-sitter-swift",
  "tree-sitter-typescript",
  "tree-sitter-zig",
+ "unicode-width",
 ]
 
 [[package]]

--- a/maki-lua/Cargo.toml
+++ b/maki-lua/Cargo.toml
@@ -31,6 +31,7 @@ flume = { workspace = true }
 futures = { workspace = true }
 futures-lite = { workspace = true }
 tree-sitter = { workspace = true }
+unicode-width = { workspace = true }
 regex = { workspace = true }
 include_dir = { workspace = true }
 maki-storage = { workspace = true }

--- a/maki-lua/src/api/ui/blit.rs
+++ b/maki-lua/src/api/ui/blit.rs
@@ -1,0 +1,292 @@
+use maki_agent::types::InlineStyle;
+use maki_agent::{SnapshotLine, SnapshotSpan, SpanStyle};
+use thiserror::Error;
+use unicode_width::UnicodeWidthStr;
+
+pub(crate) const DEFAULT_CELL: &str = "▀";
+
+type Rgb = (u8, u8, u8);
+type Run = (Rgb, Option<Rgb>, usize);
+
+#[derive(Debug)]
+pub(crate) struct FormatSpec {
+    name: &'static str,
+    bpp: usize,
+    rgb_offsets: [usize; 3],
+}
+
+const FORMATS: &[FormatSpec] = &[
+    FormatSpec {
+        name: "rgb",
+        bpp: 3,
+        rgb_offsets: [0, 1, 2],
+    },
+    FormatSpec {
+        name: "rgba",
+        bpp: 4,
+        rgb_offsets: [0, 1, 2],
+    },
+    FormatSpec {
+        name: "bgra",
+        bpp: 4,
+        rgb_offsets: [2, 1, 0],
+    },
+];
+
+pub(crate) const DEFAULT_FORMAT: &str = "rgb";
+
+#[derive(Debug, PartialEq, Error)]
+pub(crate) enum BlitError {
+    #[error("blit: width and height must be > 0 (got {w}x{h})")]
+    ZeroDimension { w: usize, h: usize },
+    #[error("blit: buffer is {got} bytes but {w}x{h} {format} needs exactly {expected}")]
+    SizeMismatch {
+        got: usize,
+        expected: usize,
+        w: usize,
+        h: usize,
+        format: &'static str,
+    },
+    #[error("blit: unknown format {got:?}, valid formats: {valid}")]
+    UnknownFormat { got: String, valid: String },
+    #[error("blit: dimensions overflow ({w}x{h})")]
+    Overflow { w: usize, h: usize },
+    #[error("blit: char must be exactly one column wide, got {got:?}")]
+    BadCell { got: String },
+}
+
+pub(crate) fn parse_format(name: &str) -> Result<&'static FormatSpec, BlitError> {
+    FORMATS
+        .iter()
+        .find(|f| f.name == name)
+        .ok_or_else(|| BlitError::UnknownFormat {
+            got: name.to_owned(),
+            valid: FORMATS
+                .iter()
+                .map(|f| f.name)
+                .collect::<Vec<_>>()
+                .join(", "),
+        })
+}
+
+pub(crate) fn render(
+    bytes: &[u8],
+    w: usize,
+    h: usize,
+    fmt: &FormatSpec,
+    cell: &str,
+) -> Result<Vec<SnapshotLine>, BlitError> {
+    if w == 0 || h == 0 {
+        return Err(BlitError::ZeroDimension { w, h });
+    }
+    if cell.width() != 1 {
+        return Err(BlitError::BadCell {
+            got: cell.to_owned(),
+        });
+    }
+    let expected = w
+        .checked_mul(h)
+        .and_then(|px| px.checked_mul(fmt.bpp))
+        .ok_or(BlitError::Overflow { w, h })?;
+    if bytes.len() != expected {
+        return Err(BlitError::SizeMismatch {
+            got: bytes.len(),
+            expected,
+            w,
+            h,
+            format: fmt.name,
+        });
+    }
+
+    let pixel = |x: usize, y: usize| -> Rgb {
+        let base = (y * w + x) * fmt.bpp;
+        let [r, g, b] = fmt.rgb_offsets;
+        (bytes[base + r], bytes[base + g], bytes[base + b])
+    };
+
+    let mut lines = Vec::with_capacity(h.div_ceil(2));
+    for pair in 0..h.div_ceil(2) {
+        let (top, bottom) = (pair * 2, pair * 2 + 1);
+        let mut spans = Vec::new();
+        let mut run: Option<Run> = None;
+        for x in 0..w {
+            let fg = pixel(x, top);
+            let bg = (bottom < h).then(|| pixel(x, bottom));
+            match &mut run {
+                Some((rf, rb, count)) if (*rf, *rb) == (fg, bg) => *count += 1,
+                _ => {
+                    spans.extend(run.take().map(|r| run_span(r, cell)));
+                    run = Some((fg, bg, 1));
+                }
+            }
+        }
+        spans.extend(run.map(|r| run_span(r, cell)));
+        lines.push(SnapshotLine { spans });
+    }
+    Ok(lines)
+}
+
+fn run_span((fg, bg, count): Run, cell: &str) -> SnapshotSpan {
+    SnapshotSpan {
+        text: cell.repeat(count),
+        style: SpanStyle::Inline(InlineStyle {
+            fg: Some(fg),
+            bg,
+            ..InlineStyle::default()
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    const RED: (u8, u8, u8) = (255, 0, 0);
+    const GREEN: (u8, u8, u8) = (0, 255, 0);
+    const BLUE: (u8, u8, u8) = (0, 0, 255);
+    const WHITE: (u8, u8, u8) = (255, 255, 255);
+
+    fn assert_structure(lines: &[SnapshotLine], w: usize, h: usize) {
+        assert_eq!(lines.len(), h.div_ceil(2));
+        for line in lines {
+            let cells: usize = line
+                .spans
+                .iter()
+                .map(|s| s.text.matches(DEFAULT_CELL).count())
+                .sum();
+            assert_eq!(cells, w);
+        }
+    }
+
+    fn style(span: &SnapshotSpan) -> (Option<Rgb>, Option<Rgb>) {
+        match &span.style {
+            SpanStyle::Inline(i) => (i.fg, i.bg),
+            other => panic!("expected inline style, got {other:?}"),
+        }
+    }
+
+    fn rgb_bytes(pixels: &[(u8, u8, u8)]) -> Vec<u8> {
+        pixels.iter().flat_map(|&(r, g, b)| [r, g, b]).collect()
+    }
+
+    #[test]
+    fn even_height_maps_top_to_fg_bottom_to_bg() {
+        let bytes = rgb_bytes(&[RED, GREEN, BLUE, WHITE]);
+        let lines = render(&bytes, 2, 2, parse_format("rgb").unwrap(), DEFAULT_CELL).unwrap();
+        assert_structure(&lines, 2, 2);
+        assert_eq!(lines[0].spans.len(), 2);
+        assert_eq!(style(&lines[0].spans[0]), (Some(RED), Some(BLUE)));
+        assert_eq!(style(&lines[0].spans[1]), (Some(GREEN), Some(WHITE)));
+    }
+
+    #[test]
+    fn odd_height_last_line_has_no_bg() {
+        let bytes = rgb_bytes(&[RED, RED, GREEN, GREEN, BLUE, WHITE]);
+        let lines = render(&bytes, 2, 3, parse_format("rgb").unwrap(), DEFAULT_CELL).unwrap();
+        assert_structure(&lines, 2, 3);
+        assert_eq!(style(&lines[0].spans[0]), (Some(RED), Some(GREEN)));
+        assert_eq!(style(&lines[1].spans[0]), (Some(BLUE), None));
+        assert_eq!(style(&lines[1].spans[1]), (Some(WHITE), None));
+    }
+
+    #[test_case(DEFAULT_CELL ; "default_cell")]
+    #[test_case("█" ; "custom_cell")]
+    fn uniform_image_merges_into_one_span(cell: &str) {
+        let bytes = rgb_bytes(&[RED; 8]);
+        let lines = render(&bytes, 4, 2, parse_format("rgb").unwrap(), cell).unwrap();
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].spans.len(), 1);
+        assert_eq!(lines[0].spans[0].text, cell.repeat(4));
+        assert_eq!(style(&lines[0].spans[0]), (Some(RED), Some(RED)));
+    }
+
+    #[test]
+    fn bg_change_alone_breaks_run() {
+        let top = [RED, RED, RED, RED];
+        let bottom = [GREEN, GREEN, BLUE, BLUE];
+        let bytes = rgb_bytes(&[top.as_slice(), bottom.as_slice()].concat());
+        let lines = render(&bytes, 4, 2, parse_format("rgb").unwrap(), DEFAULT_CELL).unwrap();
+        assert_structure(&lines, 4, 2);
+        assert_eq!(lines[0].spans.len(), 2);
+        assert_eq!(style(&lines[0].spans[0]), (Some(RED), Some(GREEN)));
+        assert_eq!(style(&lines[0].spans[1]), (Some(RED), Some(BLUE)));
+    }
+
+    #[test]
+    fn all_formats_decode_same_logical_image() {
+        let pixels = [RED, GREEN, BLUE, WHITE];
+        let rgb = rgb_bytes(&pixels);
+        let rgba: Vec<u8> = pixels.iter().flat_map(|&(r, g, b)| [r, g, b, 0]).collect();
+        let bgra: Vec<u8> = pixels.iter().flat_map(|&(r, g, b)| [b, g, r, 0]).collect();
+
+        let expected = render(&rgb, 2, 2, parse_format("rgb").unwrap(), DEFAULT_CELL).unwrap();
+        for (name, bytes) in [("rgba", rgba), ("bgra", bgra)] {
+            let lines = render(&bytes, 2, 2, parse_format(name).unwrap(), DEFAULT_CELL).unwrap();
+            assert_eq!(lines, expected, "format {name} diverged from rgb");
+        }
+    }
+
+    #[test_case(0, 2 ; "zero_width")]
+    #[test_case(2, 0 ; "zero_height")]
+    fn zero_dimension_errors(w: usize, h: usize) {
+        let err = render(&[], w, h, parse_format("rgb").unwrap(), DEFAULT_CELL).unwrap_err();
+        assert_eq!(err, BlitError::ZeroDimension { w, h });
+    }
+
+    #[test_case(11 ; "one_byte_short")]
+    #[test_case(13 ; "one_byte_long")]
+    fn size_mismatch_errors(len: usize) {
+        let err = render(
+            &vec![0; len],
+            2,
+            2,
+            parse_format("rgb").unwrap(),
+            DEFAULT_CELL,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            BlitError::SizeMismatch {
+                got: len,
+                expected: 12,
+                w: 2,
+                h: 2,
+                format: "rgb",
+            }
+        );
+    }
+
+    #[test]
+    fn overflow_errors() {
+        let err = render(
+            &[],
+            usize::MAX,
+            2,
+            parse_format("rgb").unwrap(),
+            DEFAULT_CELL,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            BlitError::Overflow {
+                w: usize::MAX,
+                h: 2
+            }
+        );
+    }
+
+    #[test_case("" ; "empty")]
+    #[test_case("ab" ; "two_columns")]
+    #[test_case("字" ; "wide_char")]
+    fn bad_cell_errors(cell: &str) {
+        let bytes = rgb_bytes(&[RED]);
+        let err = render(&bytes, 1, 1, parse_format("rgb").unwrap(), cell).unwrap_err();
+        assert_eq!(
+            err,
+            BlitError::BadCell {
+                got: cell.to_owned()
+            }
+        );
+    }
+}

--- a/maki-lua/src/api/ui/buf.rs
+++ b/maki-lua/src/api/ui/buf.rs
@@ -6,6 +6,7 @@ use maki_agent::{SharedBuf, SnapshotLine, SnapshotSpan, SpanStyle};
 use maki_lua_macro::{lua_class, lua_fn};
 use mlua::{Function, Lua, Result as LuaResult, Table, Value as LuaValue};
 
+use super::blit;
 use crate::runtime::{TaskHandle, lock_cell};
 
 /// `live_buf` tracks the first buffer a handler creates, the one
@@ -298,6 +299,69 @@ async fn click(_lua: Lua, this: mlua::UserDataRef<BufHandle>, ev: LuaValue) -> L
     }
 }
 
+/// Replaces the whole buffer with a pixel frame drawn as `"▀"` cells.
+/// Each cell's foreground is the top pixel and its background the
+/// bottom one, so one text line fits two pixel rows. When {height} is
+/// odd the last line leaves its background unset and the terminal
+/// default shows through.
+///
+/// {fb} is a Luau `buffer` of raw pixel bytes in row-major order,
+/// top-left origin. Its size must be exactly
+/// `width * height * bytes_per_pixel` for the chosen format, otherwise
+/// the call throws. A mismatch usually means a wrong width or format,
+/// and an early error beats hunting down a garbled frame.
+///
+/// Formats: "rgb" is the default at 3 bytes per pixel. "rgba" and
+/// "bgra" take 4 bytes per pixel and ignore the 4th byte. "bgra" is
+/// what a little-endian `uint32` holding `0xRRGGBB` looks like in
+/// memory, the layout doomgeneric uses for its framebuffer.
+///
+/// `char` swaps the `"▀"` glyph for another one column wide string,
+/// e.g. `"█"` when only the foreground color should show. The
+/// foreground still comes from the top pixel and the background from
+/// the bottom one, whatever the glyph.
+///
+/// @param fb buffer Raw pixel bytes.
+/// @param width integer Frame width in pixels, > 0.
+/// @param height integer Frame height in pixels, > 0.
+/// @param opts table|nil Options: `format` = "rgb"|"rgba"|"bgra", `char` = one column wide string.
+/// @return
+/// @example
+/// local fb = buffer.create(160 * 100 * 3)
+/// buffer.writeu8(fb, (y * 160 + x) * 3, 255) -- red channel
+/// buf:blit(fb, 160, 100)
+/// buf:blit(fb32, 160, 100, { format = "bgra", char = "█" })
+#[lua_fn]
+fn blit(
+    _lua: &Lua,
+    this: &BufHandle,
+    fb: mlua::Buffer,
+    width: u32,
+    height: u32,
+    opts: Option<Table>,
+) -> LuaResult<()> {
+    let mut format = blit::DEFAULT_FORMAT.to_owned();
+    let mut cell = blit::DEFAULT_CELL.to_owned();
+    if let Some(opts) = opts {
+        for pair in opts.pairs::<String, String>() {
+            match pair? {
+                (key, val) if key == "format" => format = val,
+                (key, val) if key == "char" => cell = val,
+                (key, _) => {
+                    return Err(mlua::Error::runtime(format!(
+                        "blit: unknown opts key {key:?}"
+                    )));
+                }
+            }
+        }
+    }
+    let fmt = blit::parse_format(&format).map_err(mlua::Error::external)?;
+    let lines = blit::render(&fb.to_vec(), width as usize, height as usize, fmt, &cell)
+        .map_err(mlua::Error::external)?;
+    this.buf.set_lines(lines);
+    Ok(())
+}
+
 lua_class! {
     /// A content buffer that holds styled lines of text. Create one with
     /// `maki.ui.buf()` and pass it to `maki.ui.open_win()` to show it in
@@ -308,7 +372,7 @@ lua_class! {
     /// buf:line("hello")
     /// buf:line({ { "world", "bold" } })
     /// ```
-    "maki.ui.Buf" => BufHandle, DOCS [line, lines, set_lines, len, get_lines, on, click]
+    "maki.ui.Buf" => BufHandle, DOCS [line, lines, set_lines, len, get_lines, on, click, blit]
 }
 
 pub(crate) fn parse_line(arg: &LuaValue) -> LuaResult<SnapshotLine> {
@@ -924,6 +988,43 @@ mod tests {
             .eval()
             .unwrap();
         assert_eq!(text, "toggled");
+    }
+
+    #[test]
+    fn blit_replaces_content_with_rendered_frame() {
+        let lua = test_lua();
+        set_buf_global(&lua);
+
+        lua.load(
+            r#"
+            buf:set_lines({ "a", "b", "c" })
+            local fb = buffer.create(2 * 2 * 3)
+            buffer.writeu8(fb, 0, 255)
+            buffer.writeu8(fb, 4, 255)
+            buffer.writeu8(fb, 8, 255)
+            buf:blit(fb, 2, 2)
+            "#,
+        )
+        .exec()
+        .unwrap();
+
+        let mut bytes = [0u8; 12];
+        (bytes[0], bytes[4], bytes[8]) = (255, 255, 255);
+        let fmt = blit::parse_format(blit::DEFAULT_FORMAT).unwrap();
+        let expected = blit::render(&bytes, 2, 2, fmt, blit::DEFAULT_CELL).unwrap();
+        let ud: mlua::AnyUserData = lua.globals().get("buf").unwrap();
+        assert_eq!(*ud.borrow::<BufHandle>().unwrap().buf.read(), expected);
+    }
+
+    #[test_case(r#"buf:blit(buffer.create(3), 1, 1, { fromat = "bgra" })"#, "unknown opts key" ; "opts_key_typo")]
+    #[test_case(r#"buf:blit(buffer.create(3), 1, 1, { format = "argb" })"#, "unknown format" ; "unknown_format")]
+    #[test_case(r#"buf:blit(buffer.create(5), 1, 1)"#, "needs exactly 3" ; "wrong_size")]
+    fn blit_throws(code: &str, expected: &str) {
+        let lua = test_lua();
+        set_buf_global(&lua);
+
+        let err = lua.load(code).exec().unwrap_err().to_string();
+        assert!(err.contains(expected), "expected {expected:?} in: {err}");
     }
 
     #[test]

--- a/maki-lua/src/api/ui/mod.rs
+++ b/maki-lua/src/api/ui/mod.rs
@@ -12,6 +12,7 @@ use crate::api::util::command::{
     WinCommand, WinEvent,
 };
 use crate::docs::{FnDoc, ParamDoc};
+pub(crate) mod blit;
 pub(crate) mod buf;
 pub(crate) mod win;
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -4314,6 +4314,52 @@ or simulating user interaction from code.
 buf:click({ row = 1 })
 ```
 
+---
+
+### `Buf:blit()` {#Buf-blit}
+
+```lua
+Buf:blit({fb}, {width}, {height}, {opts?})
+```
+
+Replaces the whole buffer with a pixel frame drawn as `"▀"` cells.
+Each cell's foreground is the top pixel and its background the
+bottom one, so one text line fits two pixel rows. When {height} is
+odd the last line leaves its background unset and the terminal
+default shows through.
+
+{fb} is a Luau `buffer` of raw pixel bytes in row-major order,
+top-left origin. Its size must be exactly
+`width * height * bytes_per_pixel` for the chosen format, otherwise
+the call throws. A mismatch usually means a wrong width or format,
+and an early error beats hunting down a garbled frame.
+
+Formats: "rgb" is the default at 3 bytes per pixel. "rgba" and
+"bgra" take 4 bytes per pixel and ignore the 4th byte. "bgra" is
+what a little-endian `uint32` holding `0xRRGGBB` looks like in
+memory, the layout doomgeneric uses for its framebuffer.
+
+`char` swaps the `"▀"` glyph for another one column wide string,
+e.g. `"█"` when only the foreground color should show. The
+foreground still comes from the top pixel and the background from
+the bottom one, whatever the glyph.
+
+**Parameters:**
+
+- `{fb}` (`buffer`) Raw pixel bytes.
+- `{width}` (`integer`) Frame width in pixels, > 0.
+- `{height}` (`integer`) Frame height in pixels, > 0.
+- `{opts?}` (`table|nil`) Options: `format` = "rgb"|"rgba"|"bgra", `char` = one column wide string.
+
+**Example:**
+
+```lua
+local fb = buffer.create(160 * 100 * 3)
+buffer.writeu8(fb, (y * 160 + x) * 3, 255) -- red channel
+buf:blit(fb, 160, 100)
+buf:blit(fb32, 160, 100, { format = "bgra", char = "█" })
+```
+
 
 ## maki.uv {#maki-uv}
 


### PR DESCRIPTION
Plugins that render frames (games, animations) had to build span tables in Lua every frame, which allocates a lot and gets slow fast.

`buf:blit(fb, w, h, opts?)` takes a raw Luau `buffer` of pixels and replaces the buffer content in one call, drawing `▀` cells where fg is the top pixel and bg the bottom one, with equal runs merged into single spans.

Formats live in one const table (`rgb`, `rgba`, `bgra`, the last matching doomgeneric's little-endian `uint32`), and the byte count must match exactly: a wrong width or format throws a typed `BlitError` instead of showing a silently garbled frame.

Even a typo in the opts table like `fromat` throws, so nothing quietly falls back to defaults.