### PR TITLE
feat(lua): stream job callbacks into parked handlers, and `maki.split`

### DIFF
--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -261,15 +261,15 @@ fn kill_job(meta: &mut JobMeta) {
 /// @param opts table? Optional settings:
 ///   `cwd` (string?) working directory (tilde is expanded).
 ///   `env` (table?) extra environment variables, `{ VAR = "value" }`.
-///   `on_stdout` (function?) called with each stdout line.
-///   `on_stderr` (function?) called with each stderr line.
-///   `on_exit` (function?) called with the exit code when the process finishes.
+///   `on_stdout` (function?) called with `(job_id, line)` for each stdout line.
+///   `on_stderr` (function?) called with `(job_id, line)` for each stderr line.
+///   `on_exit` (function?) called with `(job_id, code)` when the process finishes.
 /// @return (integer) Job id.
 /// @example
 /// local id = maki.fn.jobstart("ls -la", {
 ///   cwd = "~/projects",
-///   on_stdout = function(line) print(line) end,
-///   on_exit = function(code) print("exit: " .. code) end,
+///   on_stdout = function(_, line) print(line) end,
+///   on_exit = function(_, code) print("exit: " .. code) end,
 /// })
 #[lua_fn(guard = Run)]
 fn jobstart(lua: &Lua, cmd: String, opts: Option<Table>) -> LuaResult<u32> {
@@ -323,6 +323,10 @@ fn jobstop(lua: &Lua, job_id: u32) -> LuaResult<()> {
 /// table with `stdout`, `stderr`, and `exit_code`. Returns `nil` if the
 /// job does not finish before the timeout.
 ///
+/// While waiting, the job's `on_stdout`, `on_stderr`, and `on_exit`
+/// callbacks fire as events arrive (like Neovim), so you can stream
+/// output into a buffer while parked here.
+///
 /// @param job_id integer Job id returned by `jobstart`.
 /// @param timeout_ms integer? Maximum wait in milliseconds (default 30000).
 /// @return (table?) `{ stdout, stderr, exit_code }`, or nil on timeout.
@@ -351,13 +355,14 @@ async fn jobwait(lua: Lua, job_id: u32, timeout_ms: Option<u64>) -> LuaResult<Va
         })
         .await;
 
+        let Some(event) = event else {
+            return Ok(mlua::Value::Nil);
+        };
+        deliver_job_event(&lua, job_id, &event)?;
         match event {
-            None => return Ok(mlua::Value::Nil),
-            Some(JobEvent::Stdout(line)) => stdout_lines.push(line),
-            Some(JobEvent::Stderr(line)) => stderr_lines.push(line),
-            Some(JobEvent::Exit(code)) => {
-                break code;
-            }
+            JobEvent::Stdout(line) => stdout_lines.push(line),
+            JobEvent::Stderr(line) => stderr_lines.push(line),
+            JobEvent::Exit(code) => break code,
         }
     };
 
@@ -366,6 +371,30 @@ async fn jobwait(lua: Lua, job_id: u32, timeout_ms: Option<u64>) -> LuaResult<Va
     result.set("stderr", stderr_lines.join("\n"))?;
     result.set("exit_code", exit_code)?;
     Ok(mlua::Value::Table(result))
+}
+
+/// Fire the job's Lua callback for {event} (if any) and mark the job
+/// dead on exit. Shared by `jobwait` and the async dispatch loop so
+/// both deliver events identically.
+pub(crate) fn deliver_job_event(lua: &Lua, job_id: u32, event: &JobEvent) -> LuaResult<()> {
+    let callback = with_task_jobs(lua, |store| {
+        store
+            .callback_key(job_id, event)
+            .and_then(|key| lua.registry_value::<Function>(key).ok())
+    });
+    if let Some(callback) = callback {
+        let arg = match event {
+            JobEvent::Stdout(line) | JobEvent::Stderr(line) => {
+                Value::String(lua.create_string(line)?)
+            }
+            JobEvent::Exit(code) => Value::Integer(*code as i64),
+        };
+        callback.call::<()>((job_id, arg))?;
+    }
+    if let JobEvent::Exit(_) = event {
+        with_task_jobs(lua, |store| store.mark_dead(job_id));
+    }
+    Ok(())
 }
 
 /// Check whether {name} can be found on `$PATH` or is an absolute path

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod net;
 pub(crate) mod options;
 pub(crate) mod session;
 pub(crate) mod slot;
+pub(crate) mod split;
 pub(crate) mod text;
 pub(crate) mod tool;
 pub(crate) mod treesitter;
@@ -65,6 +66,7 @@ pub(crate) fn create_maki_global(
         ui::create_ui_table(lua, ui_action_tx, Arc::clone(&plugin))?,
     )?;
     maki.set("fn", r#fn::create_fn_table(lua, permissions)?)?;
+    split::split__register(&maki, lua)?;
     maki.set("async", r#async::create_async_table(lua)?)?;
     maki.set(
         "interpreter",

--- a/maki-lua/src/api/split.rs
+++ b/maki-lua/src/api/split.rs
@@ -1,0 +1,104 @@
+use maki_lua_macro::lua_fn;
+use mlua::{Function, Lua, Result as LuaResult, Table, Value};
+
+const OPTS_TYPE_MSG: &str = "split: opts must be a table or boolean";
+const INFINITE_LOOP_MSG: &str = "split: separator matched an empty string (infinite loop)";
+
+/// Split {s} at each occurrence of {sep} and return the pieces as a
+/// list. Mirrors Neovim's `vim.split`, so code using it can be copied
+/// between Neovim and maki. {sep} is a Lua pattern unless `plain` is
+/// set; an empty {sep} splits into single characters.
+///
+/// @param s string String to split.
+/// @param sep string Separator: a Lua pattern, or literal text with `plain`.
+/// @param opts table? Optional settings:
+///   `plain` (boolean?) treat {sep} as literal text instead of a pattern.
+///   `trimempty` (boolean?) drop empty pieces from the start and end of the result.
+/// @return (table) List of split pieces.
+/// @example
+/// maki.split("a,b,c", ",")                   -- { "a", "b", "c" }
+/// maki.split("x*y*z", "*", { plain = true }) -- { "x", "y", "z" }
+/// maki.split("\nhello\nworld\n", "\n", { trimempty = true }) -- { "hello", "world" }
+#[lua_fn]
+fn split(lua: &Lua, s: mlua::String, sep: mlua::String, opts: Option<Value>) -> LuaResult<Table> {
+    let (plain, trimempty) = parse_opts(opts)?;
+    let bytes = s.as_bytes();
+    let mut parts: Vec<mlua::String> = Vec::new();
+
+    if sep.as_bytes().is_empty() {
+        for i in 0..bytes.len() {
+            parts.push(lua.create_string(&bytes[i..=i])?);
+        }
+        return lua.create_sequence_from(parts);
+    }
+
+    let find: Function = lua.globals().get::<Table>("string")?.get("find")?;
+    let mut start = 1i64;
+    while let (Some(i), Some(j)) =
+        find.call::<(Option<i64>, Option<i64>)>((&s, &sep, start, plain))?
+    {
+        if j < start {
+            return Err(mlua::Error::runtime(INFINITE_LOOP_MSG));
+        }
+        parts.push(lua.create_string(&bytes[start as usize - 1..i as usize - 1])?);
+        start = j + 1;
+    }
+    parts.push(lua.create_string(&bytes[start as usize - 1..])?);
+
+    if trimempty {
+        while parts.last().is_some_and(|p| p.as_bytes().is_empty()) {
+            parts.pop();
+        }
+        let leading = parts.iter().take_while(|p| p.as_bytes().is_empty()).count();
+        parts.drain(..leading);
+    }
+    lua.create_sequence_from(parts)
+}
+
+fn parse_opts(opts: Option<Value>) -> LuaResult<(bool, bool)> {
+    match opts {
+        None | Some(Value::Nil) => Ok((false, false)),
+        Some(Value::Boolean(plain)) => Ok((plain, false)),
+        Some(Value::Table(t)) => Ok((
+            t.get::<bool>("plain").unwrap_or(false),
+            t.get::<bool>("trimempty").unwrap_or(false),
+        )),
+        Some(_) => Err(mlua::Error::runtime(OPTS_TYPE_MSG)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    fn eval(chunk: &str) -> mlua::Result<Vec<String>> {
+        let lua = Lua::new();
+        let maki = lua.create_table().unwrap();
+        split__register(&maki, &lua).unwrap();
+        lua.globals().set("maki", maki).unwrap();
+        lua.load(chunk).eval()
+    }
+
+    #[test_case(r#"maki.split("a,b,c", ",")"#, &["a", "b", "c"] ; "basic")]
+    #[test_case(r#"maki.split(":aa::b:", ":")"#, &["", "aa", "", "b", ""] ; "keeps_empty_pieces")]
+    #[test_case(r#"maki.split(":aa::b:", ":", { trimempty = true })"#, &["aa", "", "b"] ; "trimempty_only_trims_ends")]
+    #[test_case(r#"maki.split("x*y*z", "*", { plain = true })"#, &["x", "y", "z"] ; "plain_disables_patterns")]
+    #[test_case(r#"maki.split("|x|y|z|", "|", true)"#, &["", "x", "y", "z", ""] ; "legacy_boolean_plain")]
+    #[test_case(r#"maki.split("a1b22c333", "%d+")"#, &["a", "b", "c", ""] ; "pattern_separator")]
+    #[test_case(r#"maki.split("abc", "")"#, &["a", "b", "c"] ; "empty_sep_splits_chars")]
+    #[test_case(r#"maki.split("", ",")"#, &[""] ; "empty_string_one_piece")]
+    #[test_case(r#"maki.split("", "")"#, &[] ; "empty_string_empty_sep")]
+    #[test_case(r#"maki.split("a\nb", "\n")"#, &["a", "b"] ; "newline_no_trailing")]
+    #[test_case(r#"maki.split("a\nb\n", "\n")"#, &["a", "b", ""] ; "newline_trailing_empty")]
+    fn split_matches_vim_split(chunk: &str, expected: &[&str]) {
+        assert_eq!(eval(chunk).unwrap(), expected);
+    }
+
+    #[test_case(r#"maki.split("ab", "x*")"#, INFINITE_LOOP_MSG ; "empty_match_pattern")]
+    #[test_case(r#"maki.split("a", ",", 5)"#, OPTS_TYPE_MSG ; "bad_opts_type")]
+    fn split_rejects(chunk: &str, expected_err: &str) {
+        let err = eval(chunk).unwrap_err().to_string();
+        assert!(err.contains(expected_err), "got: {err}");
+    }
+}

--- a/maki-lua/src/api/ui/win.rs
+++ b/maki-lua/src/api/ui/win.rs
@@ -98,7 +98,7 @@ const recv__doc: FnDoc = FnDoc {
         channel disconnects. Pass {timeout_ms} to also get `{type=\"timeout\"}` \
         events so your plugin can animate while idle.\n\n\
         Event tables by type:\n\
-        - `{type=\"key\", key}` -- keypress. Key is a string like \"q\", \"j\", or \"<Esc>\".\n\
+        - `{type=\"key\", key}` -- keypress. Key is a string like \"q\", \"j\", or \"esc\".\n\
         - `{type=\"resize\", width, height}` -- terminal was resized.\n\
         - `{type=\"paste\", text}` -- bracketed paste.\n\
         - `{type=\"close\"}` -- window was closed externally.\n\

--- a/maki-lua/src/api/util/setup.rs
+++ b/maki-lua/src/api/util/setup.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 use maki_config::RawConfig;
 use mlua::{Function, Lua, LuaSerdeExt, Result as LuaResult};
 
+use crate::api::split::split__doc;
 use crate::docs::{DocKind, FnDoc, ModuleDoc, ParamDoc};
 
 pub(crate) type ConfigStore = Arc<Mutex<Option<RawConfig>>>;
@@ -13,23 +14,26 @@ pub(crate) const DOCS: ModuleDoc = ModuleDoc {
     name: "maki",
     kind: DocKind::Table,
     desc: "The global entry point. Every API lives under this table.",
-    fns: &[FnDoc {
-        name: "setup",
-        args: "{config}",
-        desc: "Apply your personal configuration. This is only available inside \
+    fns: &[
+        FnDoc {
+            name: "setup",
+            args: "{config}",
+            desc: "Apply your personal configuration. This is only available inside \
 `init.lua` (not in plugins) and can be called at most once. The table \
 accepts the same keys as the Configuration reference.",
-        params: &[ParamDoc {
-            name: "{config}",
-            ty: "table",
-            desc: "Configuration table.",
-        }],
-        returns: "",
-        example: "maki.setup({\n\
+            params: &[ParamDoc {
+                name: "{config}",
+                ty: "table",
+                desc: "Configuration table.",
+            }],
+            returns: "",
+            example: "maki.setup({\n\
   model = \"opus\",\n\
   keymaps = false,\n\
 })",
-    }],
+        },
+        split__doc,
+    ],
 };
 
 pub(crate) fn create_setup_fn(lua: &Lua, store: ConfigStore) -> LuaResult<Function> {

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -26,7 +26,7 @@ use maki_config::RawConfig;
 
 use crate::api::autocmd::AutocmdStore;
 use crate::api::create_maki_global;
-use crate::api::r#fn::{JobEvent, JobStore};
+use crate::api::r#fn::{JobStore, deliver_job_event};
 use crate::api::keymap::KeymapReader;
 use crate::api::keymap::{KeymapStore, KeymapWriter};
 use crate::api::options::{PluginOptionSpecs, PluginOpts, collect_plugin_options};
@@ -498,10 +498,27 @@ impl TaskScope {
 /// Runs an async system callback under a [detached] scope so callers
 /// can't forget to set one up.
 ///
+/// Job callbacks (`on_stdout` etc.) are pumped whenever {fut} is
+/// suspended, so a handler parked in e.g. `win:recv()` still streams
+/// job output, like Neovim firing callbacks from its idle event loop.
+///
 /// [detached]: TaskScope::detached
 pub(crate) async fn run_detached<F: std::future::Future>(lua: &Lua, fut: F) -> F::Output {
     let scope = TaskScope::detached(lua);
-    let out = scope.scope_future(fut).await;
+    let handle = Arc::clone(scope.handle());
+    let pump = async {
+        let mut event_buf = Vec::new();
+        loop {
+            lock_cell(&handle).jobs.drain_events(&mut event_buf);
+            for (job_id, event) in event_buf.drain(..) {
+                if let Err(e) = deliver_job_event(lua, job_id, &event) {
+                    tracing::warn!(error = %strip_traceback(&e), "detached job callback failed");
+                }
+            }
+            smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
+        }
+    };
+    let out = scope.scope_future(smol::future::or(fut, pump)).await;
     drop(scope);
     out
 }
@@ -1822,31 +1839,8 @@ async fn dispatch_async(
         }
 
         for (job_id, event) in event_buf.drain(..) {
-            let is_exit = matches!(event, JobEvent::Exit(_));
-
-            let callback = lock_cell(&handle)
-                .jobs
-                .callback_key(job_id, &event)
-                .and_then(|k| lua.registry_value::<Function>(k).ok());
-
-            if let Some(func) = callback {
-                let arg: LuaValue = match &event {
-                    JobEvent::Stdout(line) | JobEvent::Stderr(line) => lua
-                        .create_string(line)
-                        .map(LuaValue::String)
-                        .unwrap_or(LuaValue::Nil),
-                    JobEvent::Exit(code) => LuaValue::Integer(*code as i64),
-                };
-                if let Err(e) = func.call::<()>((job_id, arg)) {
-                    return ToolCallReply::err(format!(
-                        "job callback error: {}",
-                        strip_traceback(&e)
-                    ));
-                }
-            }
-
-            if is_exit {
-                lock_cell(&handle).jobs.mark_dead(job_id);
+            if let Err(e) = deliver_job_event(lua, job_id, &event) {
+                return ToolCallReply::err(format!("job callback error: {}", strip_traceback(&e)));
             }
         }
     }

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -1076,6 +1076,35 @@ fn async_job_on_exit_receives_exit_code() {
 }
 
 #[test]
+fn jobwait_fires_callbacks_while_waiting() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "job_stream",
+            description = "streams lines during jobwait",
+            schema = {MINIMAL_SCHEMA},
+            audiences = {{ "main" }},
+            handler = function(input, ctx)
+                local seen = {{}}
+                local exit_code
+                local id = maki.fn.jobstart("echo a; echo b; exit 7", {{
+                    on_stdout = function(_, line) seen[#seen + 1] = line end,
+                    on_exit = function(_, code) exit_code = code end,
+                }})
+                local res = maki.fn.jobwait(id)
+                return table.concat(seen, ",")
+                    .. " exit=" .. tostring(exit_code)
+                    .. " stdout=" .. (res.stdout:gsub("\n", ","))
+            end
+        }})"#,
+    );
+    host.load_source("job_stream", &src).unwrap();
+    let out = exec_tool(&reg, "job_stream", serde_json::json!({})).unwrap();
+    assert_eq!(out, "a,b exit=7 stdout=a,b");
+}
+
+#[test]
 fn jobstart_invalid_cwd_errors_with_expanded_path() {
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
@@ -3319,4 +3348,35 @@ fn async_run_from_parked_command_handler_runs_promptly() {
         .recv_timeout(Duration::from_secs(5))
         .expect("async.run task starved while its command handler was parked");
     assert!(matches!(action, maki_lua::UiAction::Flash(msg) if msg == "task-ran"));
+}
+
+/// Job callbacks must fire while a detached command handler is parked
+/// (the homepage `/standup` example: jobstart, then a `win:recv` loop).
+#[test]
+fn job_callbacks_fire_while_command_handler_parked() {
+    let host = PluginHost::new(fresh_registry()).unwrap();
+    host.load_source(
+        "p",
+        r#"
+        maki.api.register_command({
+            name = "/stream",
+            description = "streams job output while parked",
+            handler = function()
+                maki.fn.jobstart("echo hi", {
+                    on_stdout = function(_, line) maki.ui.flash("job:" .. line) end,
+                })
+                maki.async.await(1, function(_cb) end)
+            end,
+        })
+        "#,
+    )
+    .unwrap();
+    let rx = host.ui_action_rx().unwrap();
+    let handle = host.event_handle().unwrap();
+    handle.run_command(Arc::from("p"), Arc::from("/stream"), String::new());
+
+    let action = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("job callbacks starved while command handler was parked");
+    assert!(matches!(action, maki_lua::UiAction::Flash(msg) if msg == "job:hi"));
 }

--- a/plugins/bash/init.lua
+++ b/plugins/bash/init.lua
@@ -315,23 +315,17 @@ maki.api.register_tool({
     elseif is_error then
       local body, code = output:match("^(.-)\nExit code: (%d+)$")
       if body then
-        for line in (body .. "\n"):gmatch("([^\n]*)\n") do
-          view:append(line)
-        end
+        view:append_text(body)
         view:append({ { "Exit code: " .. code, "dim" } })
       else
-        for line in (output .. "\n"):gmatch("([^\n]*)\n") do
-          view:append(line)
-        end
+        view:append_text(output)
       end
     else
       if output == "Exit code: 0" or output == "" then
         view:clear()
         view:append({ { "No output", "dim" } })
       else
-        for line in (output .. "\n"):gmatch("([^\n]*)\n") do
-          view:append(line)
-        end
+        view:append_text(output)
       end
     end
     view:finish()

--- a/plugins/batch/init.lua
+++ b/plugins/batch/init.lua
@@ -278,7 +278,7 @@ local function children_from_llm(children, output)
   end
   local sections = {}
   local body, prev
-  for line in (output .. "\n"):gmatch("([^\n]*)\n") do
+  for _, line in ipairs(maki.split(output, "\n")) do
     local tool = line:match(SECTION_PAT)
     local nxt = children[#sections + 1]
     -- render_llm puts a blank line before every header except the first;
@@ -482,7 +482,7 @@ local function legacy_restore(children, output, tol)
   local header = render_children(children)
   append_separator(header)
   view:set_header(header)
-  for line in (output .. "\n"):gmatch("([^\n]*)\n") do
+  for _, line in ipairs(maki.split(output, "\n")) do
     view:append(BODY_INDENT .. line)
   end
   view:finish()

--- a/plugins/code_execution/init.lua
+++ b/plugins/code_execution/init.lua
@@ -31,12 +31,6 @@ local function new_view(ctx, buf)
   return ToolView.new(buf, { max_lines = ctx:tool_output_lines().code_execution or 30 })
 end
 
-local function append_lines(view, text)
-  for line in (text .. "\n"):gmatch("([^\n]*)\n") do
-    view:append(line)
-  end
-end
-
 local function line_nr_fmt(count)
   local w = math.max(1, math.floor(math.log(count, 10)) + 1)
   return "%" .. w .. "d "
@@ -46,10 +40,7 @@ end
 -- script renders the same no matter which lifecycle callbacks ran. The
 -- header is always rebuilt from scratch; nothing mutates existing lines.
 local function build_body(ctx, code)
-  local lines = {}
-  for line in (code:gsub("\n+$", "") .. "\n"):gmatch("([^\n]*)\n") do
-    lines[#lines + 1] = line
-  end
+  local lines = maki.split(code:gsub("\n+$", ""), "\n")
   local hl
   local buf = maki.ui.buf()
   local view = new_view(ctx, buf)
@@ -264,7 +255,7 @@ local function handler(input, ctx)
     if waiting then
       view:clear()
     end
-    append_lines(view, err)
+    view:append_text(err)
     view:finish()
     return { llm_output = err, is_error = true, body = buf }
   end
@@ -299,7 +290,7 @@ local function restore(input, output, is_error, ctx)
   elseif output == NO_OUTPUT then
     view:append({ { "No output", "dim" } })
   else
-    append_lines(view, output)
+    view:append_text(output)
   end
   view:finish()
   highlight()

--- a/plugins/edit/edit_helpers.lua
+++ b/plugins/edit/edit_helpers.lua
@@ -4,11 +4,7 @@ local function split_lines(s)
   if s:sub(-1) == "\n" then
     s = s:sub(1, -2)
   end
-  local lines = {}
-  for line in (s .. "\n"):gmatch("([^\n]*)\n") do
-    lines[#lines + 1] = line
-  end
-  return lines
+  return maki.split(s, "\n")
 end
 
 function M.replace_lines(content, start_line, end_line, new_string)

--- a/plugins/edit/init.lua
+++ b/plugins/edit/init.lua
@@ -39,10 +39,7 @@ local function edit_header(input)
 end
 
 local function split_lines(text)
-  local lines = {}
-  for line in (text .. "\n"):gmatch("([^\n]*)\n") do
-    lines[#lines + 1] = line
-  end
+  local lines = maki.split(text, "\n")
   if lines[#lines] == "" then
     lines[#lines] = nil
   end

--- a/plugins/grep/init.lua
+++ b/plugins/grep/init.lua
@@ -161,7 +161,7 @@ end
 local function parse_llm_output(text)
   local entries = {}
   local current
-  for line in (text .. "\n"):gmatch("([^\n]*)\n") do
+  for _, line in ipairs(maki.split(text, "\n")) do
     local path = line:match("^(%S.+):$")
     if path then
       current = { path = path, groups = { { lines = {} } } }

--- a/plugins/index/indexer.lua
+++ b/plugins/index/indexer.lua
@@ -542,10 +542,7 @@ end
 local function emit_body_with_range(body, range, out, meta)
   if body:find("\n", 1, true) then
     local leading = body:match("^(%s*)") or ""
-    local lines = {}
-    for line in (body .. "\n"):gmatch("([^\n]*)\n") do
-      lines[#lines + 1] = line
-    end
+    local lines = maki.split(body, "\n")
     for i, line in ipairs(lines) do
       if i == 1 then
         out[#out + 1] = line .. " " .. range

--- a/plugins/index/init.lua
+++ b/plugins/index/init.lua
@@ -54,11 +54,8 @@ local function infer_line_meta(line)
 end
 
 local function render_skeleton(view, text, meta)
-  text = text:gsub("\n+$", "") .. "\n"
   local hl_entries = {}
-  local line_nr = 0
-  for line in text:gmatch("([^\n]*)\n") do
-    line_nr = line_nr + 1
+  for line_nr, line in ipairs(maki.split(text:gsub("\n+$", ""), "\n")) do
     local m = (meta and meta[line_nr]) or infer_line_meta(line)
     if line == "" then
       view:append("")

--- a/plugins/lib/maki/tool_view.lua
+++ b/plugins/lib/maki/tool_view.lua
@@ -93,6 +93,12 @@ function ToolView:append(line)
   end
 end
 
+function ToolView:append_text(text)
+  for _, line in ipairs(maki.split(text, "\n")) do
+    self:append(line)
+  end
+end
+
 function ToolView:set_highlight(content, ext)
   ext = ext or "md"
   if content:sub(-1) == "\n" then
@@ -101,10 +107,7 @@ function ToolView:set_highlight(content, ext)
   if content == "" then
     return false
   end
-  local lines = {}
-  for line in (content .. "\n"):gmatch("([^\n]*)\n") do
-    lines[#lines + 1] = line
-  end
+  local lines = maki.split(content, "\n")
 
   local fmt = line_nr_fmt(#lines)
   for idx, line in ipairs(lines) do
@@ -206,11 +209,7 @@ function ToolView.restore_lines(lines, opts)
 end
 
 function ToolView.restore(output, opts)
-  local lines = {}
-  for line in (output .. "\n"):gmatch("([^\n]*)\n") do
-    lines[#lines + 1] = line
-  end
-  return ToolView.restore_lines(lines, opts)
+  return ToolView.restore_lines(maki.split(output, "\n"), opts)
 end
 
 return ToolView

--- a/plugins/memory/init.lua
+++ b/plugins/memory/init.lua
@@ -67,9 +67,7 @@ local function render_content(content, path, ctx)
 
   local ext = path:match("%.([^%.]+)$") or "md"
   if not view:set_highlight(content, ext) then
-    for line in (content .. "\n"):gmatch("([^\n]*)\n") do
-      view:append(line)
-    end
+    view:append_text(content)
   end
   view:finish()
   return buf

--- a/plugins/read/init.lua
+++ b/plugins/read/init.lua
@@ -101,9 +101,7 @@ end
 local function build_dir_view(text, ctx)
   local buf = maki.ui.buf()
   local view = ToolView.new(buf, read_view_opts(ctx))
-  for line in (text .. "\n"):gmatch("([^\n]*)\n") do
-    view:append(line)
-  end
+  view:append_text(text)
   view:finish()
   buf:on("click", function()
     view:toggle()
@@ -268,7 +266,7 @@ maki.api.register_tool({
 
   restore = function(input, output, _is_error, ctx)
     local lines, start_line, total_lines = {}, nil, nil
-    for raw in (output .. "\n"):gmatch("([^\n]*)\n") do
+    for _, raw in ipairs(maki.split(output, "\n")) do
       local nr, text = raw:match("^%s*(%d+): (.*)$")
       if nr then
         start_line = start_line or tonumber(nr)

--- a/plugins/skill/init.lua
+++ b/plugins/skill/init.lua
@@ -124,10 +124,8 @@ maki.api.register_tool({
     end
 
     local lines = {}
-    local i = 1
-    for line in (skill.content .. "\n"):gmatch("([^\n]*)\n") do
+    for i, line in ipairs(maki.split(skill.content, "\n")) do
       lines[#lines + 1] = string.format("%4d | %s", i, line)
-      i = i + 1
     end
     local formatted = skill.location .. "\n" .. table.concat(lines, "\n")
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -115,6 +115,37 @@ keymaps = false,
 })
 ```
 
+---
+
+### `maki.split()` {#maki-split}
+
+```lua
+maki.split({s}, {sep}, {opts?})
+```
+
+Split {s} at each occurrence of {sep} and return the pieces as a
+list. Mirrors Neovim's `vim.split`, so code using it can be copied
+between Neovim and maki. {sep} is a Lua pattern unless `plain` is
+set; an empty {sep} splits into single characters.
+
+**Parameters:**
+
+- `{s}` (`string`) String to split.
+- `{sep}` (`string`) Separator: a Lua pattern, or literal text with `plain`.
+- `{opts?}` (`table?`) Optional settings:
+  - `plain` (`boolean?`) treat {sep} as literal text instead of a pattern.
+  - `trimempty` (`boolean?`) drop empty pieces from the start and end of the result.
+
+**Returns:** (`table`) List of split pieces.
+
+**Example:**
+
+```lua
+maki.split("a,b,c", ",")                   -- { "a", "b", "c" }
+maki.split("x*y*z", "*", { plain = true }) -- { "x", "y", "z" }
+maki.split("\nhello\nworld\n", "\n", { trimempty = true }) -- { "hello", "world" }
+```
+
 
 ## maki.api {#maki-api}
 
@@ -1211,9 +1242,9 @@ that you can pass to `jobstop` or `jobwait` to control the process.
 - `{opts?}` (`table?`) Optional settings:
   - `cwd` (`string?`) working directory (tilde is expanded).
   - `env` (`table?`) extra environment variables, `{ VAR = "value" }`.
-  - `on_stdout` (`function?`) called with each stdout line.
-  - `on_stderr` (`function?`) called with each stderr line.
-  - `on_exit` (`function?`) called with the exit code when the process finishes.
+  - `on_stdout` (`function?`) called with `(job_id, line)` for each stdout line.
+  - `on_stderr` (`function?`) called with `(job_id, line)` for each stderr line.
+  - `on_exit` (`function?`) called with `(job_id, code)` when the process finishes.
 
 **Returns:** (`integer`) Job id.
 
@@ -1222,8 +1253,8 @@ that you can pass to `jobstop` or `jobwait` to control the process.
 ```lua
 local id = maki.fn.jobstart("ls -la", {
   cwd = "~/projects",
-  on_stdout = function(line) print(line) end,
-  on_exit = function(code) print("exit: " .. code) end,
+  on_stdout = function(_, line) print(line) end,
+  on_exit = function(_, code) print("exit: " .. code) end,
 })
 ```
 
@@ -1259,6 +1290,10 @@ maki.fn.jobwait({job_id}, {timeout_ms?})
 Wait for a job to finish and collect its output. Returns a result
 table with `stdout`, `stderr`, and `exit_code`. Returns `nil` if the
 job does not finish before the timeout.
+
+While waiting, the job's `on_stdout`, `on_stderr`, and `on_exit`
+callbacks fire as events arrive (like Neovim), so you can stream
+output into a buffer while parked here.
 
 **Parameters:**
 
@@ -3969,7 +4004,7 @@ Win:recv({timeout_ms?})
 Waits for the next event from this window. Call this in a loop to build an interactive UI. Returns nil once the window is closed or the channel disconnects. Pass {timeout_ms} to also get `{type="timeout"}` events so your plugin can animate while idle.
 
 Event tables by type:
-- `{type="key", key}` -- keypress. Key is a string like "q", "j", or "<Esc>".
+- `{type="key", key}` -- keypress. Key is a string like "q", "j", or "esc".
 - `{type="resize", width, height}` -- terminal was resized.
 - `{type="paste", text}` -- bracketed paste.
 - `{type="close"}` -- window was closed externally.

--- a/site/index.html
+++ b/site/index.html
@@ -1519,17 +1519,19 @@ imports = <span class="fn">set</span>()
         <div class="exec-pane">
           <div class="exec-pane-label">add /standup: show yesterday's commits</div>
           <pre><span class="fn">maki.api.register_command</span>({
-  name = <span class="st">"standup"</span>,
+  name = <span class="st">"/standup"</span>,
   description = <span class="st">"Yesterday's commits"</span>,
   handler = <span class="kw">function</span>()
     <span class="kw">local</span> buf = <span class="fn">maki.ui.buf</span>()
+    <span class="kw">local</span> win = <span class="fn">maki.ui.open_win</span>(buf, { title = <span class="st">"standup"</span> })
     <span class="fn">maki.fn.jobstart</span>(
       <span class="st">"git log --since=yesterday --oneline"</span>, {
-        on_stdout = <span class="kw">function</span>(l) <span class="fn">buf:line</span>(l) <span class="kw">end</span>,
-        on_exit = <span class="kw">function</span>()
-          <span class="fn">maki.ui.open_win</span>(buf, { title = <span class="st">"standup"</span> })
-        <span class="kw">end</span>,
+        on_stdout = <span class="kw">function</span>(_, line) <span class="fn">buf:line</span>(line) <span class="kw">end</span>,
       })
+    <span class="kw">repeat</span>
+      <span class="kw">local</span> ev = <span class="fn">win:recv</span>()
+    <span class="kw">until</span> <span class="kw">not</span> ev <span class="kw">or</span> ev.key == <span class="st">"esc"</span>
+    <span class="fn">win:close</span>()
   <span class="kw">end</span>,
 })</pre>
         </div>


### PR DESCRIPTION
The homepage `/standup` example never worked: job callbacks are only pumped by the tool dispatch loop, and a slash-command handler runs detached, so `jobstart`'s `on_stdout` never fired and the window stayed empty.

`run_detached` now races the handler against a pump that fires `on_stdout`, `on_stderr` and `on_exit` whenever the handler is suspended, like Neovim firing callbacks from its idle event loop, and `jobwait` pumps the same way while it blocks.

So the example is just `jobstart` plus a `win:recv()` loop that closes on `esc`, output streams in live and the window can be closed even while the job is still running, which then kills the job at scope drop.

`maki.split` is a port of `vim.split` (Lua patterns, `plain`, `trimempty`, even the legacy boolean opts), and every plugin that hand-rolled the `gmatch` line-splitting idiom now uses it.

The `recv` doc also claimed keys look like `"<Esc>"` when they are lowercase `"esc"`.