### PR TITLE
feat(deepseek): add quota report for /usage command

### DIFF
--- a/maki-providers/src/providers/anthropic/mod.rs
+++ b/maki-providers/src/providers/anthropic/mod.rs
@@ -163,7 +163,7 @@ fn credits_limit(u: &OauthUsage) -> Option<UsageLimit> {
     };
     Some(UsageLimit {
         label: "Usage credits".into(),
-        percentage: percent.round() as u32,
+        percentage: Some(percent.round() as u32),
         reset_at: None,
         detail,
     })
@@ -177,7 +177,7 @@ impl From<OauthUsage> for ProviderUsage {
             .filter_map(|l| {
                 Some(UsageLimit {
                     label: limit_label(l),
-                    percentage: l.percent?.round() as u32,
+                    percentage: Some(l.percent?.round() as u32),
                     reset_at: l.resets_at.as_deref().and_then(parse_reset),
                     detail: None,
                 })
@@ -194,7 +194,7 @@ impl From<OauthUsage> for ProviderUsage {
                 let w = w.as_ref()?;
                 Some(UsageLimit {
                     label: label.into(),
-                    percentage: w.utilization?.round() as u32,
+                    percentage: Some(w.utilization?.round() as u32),
                     reset_at: w.resets_at.as_deref().and_then(parse_reset),
                     detail: None,
                 })
@@ -528,14 +528,14 @@ mod tests {
         assert!(usage.plan.is_none());
         assert_eq!(usage.limits.len(), 4);
         assert_eq!(usage.limits[0].label, "Current session");
-        assert_eq!(usage.limits[0].percentage, 14);
+        assert_eq!(usage.limits[0].percentage, Some(14));
         assert_eq!(usage.limits[0].reset_at, Some(1770415200000));
         assert_eq!(usage.limits[1].label, "Current week (all models)");
-        assert_eq!(usage.limits[1].percentage, 2);
+        assert_eq!(usage.limits[1].percentage, Some(2));
         assert_eq!(usage.limits[2].label, "Current week (Fable)");
-        assert_eq!(usage.limits[2].percentage, 3);
+        assert_eq!(usage.limits[2].percentage, Some(3));
         assert_eq!(usage.limits[3].label, "Usage credits");
-        assert_eq!(usage.limits[3].percentage, 2);
+        assert_eq!(usage.limits[3].percentage, Some(2));
         assert_eq!(usage.limits[3].reset_at, None);
         assert_eq!(usage.limits[3].detail.as_deref(), Some("$2.33 spent"));
     }
@@ -553,14 +553,14 @@ mod tests {
         let usage: ProviderUsage = parsed.into();
         assert_eq!(usage.limits.len(), 5);
         assert_eq!(usage.limits[0].label, "Current session");
-        assert_eq!(usage.limits[0].percentage, 35);
+        assert_eq!(usage.limits[0].percentage, Some(35));
         assert_eq!(usage.limits[0].reset_at, Some(1770415200000));
         assert_eq!(usage.limits[1].label, "Current week (all models)");
         assert_eq!(usage.limits[2].label, "Current week (Sonnet)");
         assert_eq!(usage.limits[3].label, "Current week (Opus)");
-        assert_eq!(usage.limits[3].percentage, 3);
+        assert_eq!(usage.limits[3].percentage, Some(3));
         assert_eq!(usage.limits[4].label, "Usage credits");
-        assert_eq!(usage.limits[4].percentage, 2);
+        assert_eq!(usage.limits[4].percentage, Some(2));
         assert_eq!(usage.limits[4].detail.as_deref(), Some("$2.33 spent"));
     }
 

--- a/maki-providers/src/providers/deepseek.rs
+++ b/maki-providers/src/providers/deepseek.rs
@@ -2,11 +2,13 @@ use std::sync::{Arc, Mutex};
 
 use flume::Sender;
 use maki_storage::id::SessionRef;
+use serde::Deserialize;
 use serde_json::Value;
 use tracing::warn;
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
+use crate::types::{ProviderUsage, UsageLimit};
 use crate::{
     AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig, dialect,
 };
@@ -16,6 +18,7 @@ use super::{KeyPool, ResolvedAuth};
 
 const PAD: &str = "";
 const V4_MARKER: &str = "deepseek-v4";
+const BALANCE_URL: &str = "https://api.deepseek.com/user/balance";
 
 static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     api_key_env: "DEEPSEEK_API_KEY",
@@ -72,6 +75,51 @@ pub(crate) fn models() -> &'static [ModelEntry] {
             context_window: 1_000_000,
         },
     ]
+}
+
+#[derive(Deserialize)]
+struct BalanceResponse {
+    balance_infos: Vec<BalanceInfo>,
+}
+
+#[derive(Deserialize)]
+struct BalanceInfo {
+    currency: String,
+    total_balance: String,
+    granted_balance: String,
+    topped_up_balance: String,
+}
+
+impl From<BalanceResponse> for ProviderUsage {
+    fn from(resp: BalanceResponse) -> Self {
+        let limits = resp
+            .balance_infos
+            .into_iter()
+            .map(|b| {
+                let symbol = match b.currency.as_str() {
+                    "USD" => "$",
+                    "CNY" => "¥",
+                    _ => "",
+                };
+
+                UsageLimit {
+                    label: "Balance".into(),
+                    percentage: None,
+                    reset_at: None,
+                    detail: Some(format!(
+                        "total: {}{}, topped-up: {}{}, granted: {}{}",
+                        symbol,
+                        b.total_balance,
+                        symbol,
+                        b.topped_up_balance,
+                        symbol,
+                        b.granted_balance
+                    )),
+                }
+            })
+            .collect();
+        ProviderUsage { plan: None, limits }
+    }
 }
 
 pub struct DeepSeek {
@@ -146,6 +194,15 @@ impl Provider for DeepSeek {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
             self.compat.do_list_models(&auth).await
+        })
+    }
+
+    fn fetch_usage(&self) -> BoxFuture<'_, Result<Option<ProviderUsage>, AgentError>> {
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            let body = self.compat.get_text(&auth, BALANCE_URL).await?;
+            let parsed: BalanceResponse = serde_json::from_str(&body)?;
+            Ok(Some(parsed.into()))
         })
     }
 

--- a/maki-providers/src/providers/zai/mod.rs
+++ b/maki-providers/src/providers/zai/mod.rs
@@ -69,7 +69,7 @@ impl From<QuotaResponse> for ProviderUsage {
                 .into_iter()
                 .map(|l| UsageLimit {
                     label: quota_label(&l.kind, l.unit),
-                    percentage: l.percentage,
+                    percentage: Some(l.percentage),
                     reset_at: l.next_reset_time,
                     detail: None,
                 })
@@ -385,7 +385,7 @@ mod tests {
         assert_eq!(usage.plan.as_deref(), Some("lite"));
         assert_eq!(usage.limits.len(), 3);
         assert_eq!(usage.limits[0].label, "5-hour tokens");
-        assert_eq!(usage.limits[0].percentage, 16);
+        assert_eq!(usage.limits[0].percentage, Some(16));
         assert_eq!(usage.limits[0].reset_at, Some(1777819631597));
         assert_eq!(usage.limits[1].label, "Weekly tokens");
         assert_eq!(usage.limits[2].label, "Subscription time");
@@ -401,7 +401,7 @@ mod tests {
         let usage: ProviderUsage = parsed.into();
         assert!(usage.plan.is_none());
         assert_eq!(usage.limits[0].label, "TOKENS_LIMIT #9");
-        assert_eq!(usage.limits[0].percentage, 50);
+        assert_eq!(usage.limits[0].percentage, Some(50));
         assert_eq!(usage.limits[0].reset_at, None);
     }
 }

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -615,7 +615,8 @@ pub struct UsageLimit {
     /// Human-readable label for the window, provided by the provider.
     pub label: String,
     /// Usage percentage within the window, 0-100.
-    pub percentage: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub percentage: Option<u32>,
     /// When the window resets, as epoch milliseconds.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reset_at: Option<u64>,

--- a/maki-ui/src/components/usage_modal.rs
+++ b/maki-ui/src/components/usage_modal.rs
@@ -318,11 +318,14 @@ fn quota_lines(state: &UsageFetchState, theme: &crate::theme::Theme) -> Vec<Line
                 .max()
                 .unwrap_or(0);
             for limit in &usage.limits {
-                let mut spans = vec![
-                    Span::styled(format!("{PREFIX}{:<label_w$}", limit.label), fg),
-                    Span::styled(format!("{:>3}%", limit.percentage), theme.accent),
-                    Span::styled(" used", dim),
-                ];
+                let mut spans = vec![Span::styled(
+                    format!("{PREFIX}{:<label_w$}", limit.label),
+                    fg,
+                )];
+                if let Some(pct) = limit.percentage {
+                    spans.push(Span::styled(format!("{pct:>3}%"), theme.accent));
+                    spans.push(Span::styled(" used", dim));
+                }
                 if let Some(detail) = &limit.detail {
                     spans.push(Span::styled(format!("  {detail}"), dim));
                 }
@@ -414,13 +417,13 @@ mod tests {
             limits: vec![
                 UsageLimit {
                     label: "Current session".into(),
-                    percentage: 16,
+                    percentage: Some(16),
                     reset_at: Some(0),
                     detail: None,
                 },
                 UsageLimit {
                     label: "Usage credits".into(),
-                    percentage: 4,
+                    percentage: Some(4),
                     reset_at: None,
                     detail: Some("$2.33 spent".into()),
                 },


### PR DESCRIPTION
Some provider quota responses omit the usage percentage field, showing 0% of usage, which is misleading.

When percentage is None, filter it in the UI's usage modal.

----

Implement fetch_usage() on the DeepSeek provider by calling GET /user/balance, parsing the response, and converting it to ProviderUsage for display in the TUI usage modal.

Added BalanceResponse/BalanceInfo deserialization types matching the API schema, a From impl that maps each balance entry (currency + total/topped-up/granted amounts) into a UsageLimit, and wired it into fetch_usage() using the existing OpenAiCompatProvider::get_text helper (same pattern as Z.AI).