### PR TITLE
refactor(providers): one Effort model instead of per-provider effort

### DIFF
--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -709,7 +709,7 @@ mod tests {
     fn small_context_model(context_window: u32, max_output_tokens: u32) -> Model {
         let mut model = default_model();
         model.context_window = context_window;
-        model.max_output_tokens = max_output_tokens;
+        model.max_output_tokens = Some(max_output_tokens);
         model
     }
 

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -130,7 +130,7 @@ pub const TOP_LEVEL_FIELDS: &[ConfigField] = &[
         ty: "bool | string",
         default: ConfigValue::Bool(false),
         min: None,
-        description: "Start every session with extended thinking (true/\"adaptive\", \"off\", or a token budget)",
+        description: "Start every session with extended thinking (true/\"adaptive\", \"off\", an effort level (\"minimal\" to \"max\"), or a token budget)",
     },
 ];
 
@@ -1796,6 +1796,7 @@ fn insert_permission_entry(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use maki_storage::sessions::Effort;
     use std::fs;
     use tempfile::TempDir;
     use test_case::test_case;
@@ -1954,6 +1955,8 @@ mod tests {
     #[test_case(AlwaysThinking::Toggle(true), StoredThinking::Adaptive ; "toggle_true")]
     #[test_case(AlwaysThinking::Toggle(false), StoredThinking::Off ; "toggle_false")]
     #[test_case(AlwaysThinking::Budget(8192), StoredThinking::Budget { tokens: 8192 } ; "budget_number")]
+    #[test_case(AlwaysThinking::Mode("xhigh".into()), StoredThinking::Effort { level: Effort::XHigh } ; "effort_xhigh")]
+    #[test_case(AlwaysThinking::Mode("minimal".into()), StoredThinking::Effort { level: Effort::Minimal } ; "effort_minimal")]
     fn always_thinking_toggle_resolve(input: AlwaysThinking, expected: StoredThinking) {
         assert_eq!(input.resolve(), Ok(expected));
     }

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -27,6 +27,7 @@ use maki_providers::model::ModelTier;
 use maki_providers::provider;
 use maki_providers::{ContentBlock, Model, ModelError, Role, ThinkingConfig};
 use maki_storage::id::MakiId;
+use maki_storage::sessions::StoredThinking;
 use mlua::{Function, IntoLuaMulti, Lua, Result as LuaResult, Table, Value as LuaValue};
 use serde_json::Value as JsonValue;
 use tracing::info;
@@ -351,8 +352,10 @@ async fn call_tool(
 ///     `(string)` or `(nil, err)`.
 ///   `name` (string?) - display name for logs and UI.
 ///   `audience` (string?) - tool audience for capability gating. Default: `"general_sub"`.
-///   `thinking` (string|integer?) - thinking mode: `"off"`, `"adaptive"`, or a
-///     budget integer (token count). Inherits parent setting if omitted.
+///   `thinking` (string|integer?) - thinking mode: `"off"`, `"adaptive"`, an
+///     effort level (`"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`,
+///     `"max"`), or a budget integer (token count). Inherits parent setting
+///     if omitted.
 ///   `fast` (boolean?) - use fast mode. Inherits parent setting if omitted.
 /// @return (Session?, string?) Session handle, or `(nil, err)` on failure.
 /// @example
@@ -446,13 +449,20 @@ async fn session(
     }
 
     let thinking = match thinking_val {
-        Some(LuaValue::String(s)) => match s.to_str()?.as_ref() {
-            "off" => ThinkingConfig::Off,
-            "adaptive" => ThinkingConfig::Adaptive,
-            other => return Ok(err_pair(format!("invalid thinking: {other}"))),
+        Some(LuaValue::String(s)) => match StoredThinking::parse_setting(&s.to_str()?) {
+            Ok(stored) => ThinkingConfig::from(stored),
+            Err(e) => return Ok(err_pair(format!("invalid thinking: {e}"))),
         },
-        Some(LuaValue::Integer(n)) => ThinkingConfig::Budget(n as u32),
-        Some(LuaValue::Number(n)) => ThinkingConfig::Budget(n as u32),
+        Some(LuaValue::Integer(n)) => match u32::try_from(n) {
+            Ok(tokens) if tokens > 0 => ThinkingConfig::Budget(tokens),
+            _ => return Ok(err_pair(format!("invalid thinking budget: {n}"))),
+        },
+        Some(LuaValue::Number(n)) if n >= 1.0 && n <= f64::from(u32::MAX) => {
+            ThinkingConfig::Budget(n as u32)
+        }
+        Some(LuaValue::Number(n)) => {
+            return Ok(err_pair(format!("invalid thinking budget: {n}")));
+        }
         Some(_) => return Err(mlua::Error::runtime("thinking must be string or number")),
         None => agent_ctx.opts.thinking,
     };

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -19,7 +19,7 @@ pub use providers::opencode::{
     ProviderData, catalog_provider, catalog_providers, catalog_providers_if_available,
 };
 pub use types::{
-    ContentBlock, EffortScale, IMAGE_OMITTED_NOTE, ImageMediaType, ImageSource, Message,
+    ContentBlock, Effort, EffortDialect, IMAGE_OMITTED_NOTE, ImageMediaType, ImageSource, Message,
     ProviderEvent, ProviderUsage, RequestOptions, Role, StopReason, StreamResponse, ThinkingConfig,
-    UsageLimit, adapt_images_for_model,
+    UsageLimit, adapt_images_for_model, dialect,
 };

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -9,7 +9,7 @@ use std::ops::AddAssign;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use maki_storage::sessions::StoredTokenUsage;
+use maki_storage::sessions::{MIN_THINKING_BUDGET, StoredTokenUsage};
 use serde::{Deserialize, Serialize};
 
 use crate::provider::ProviderKind;
@@ -227,7 +227,8 @@ pub struct Model {
     pub supports_thinking_override: Option<bool>,
     pub supports_vision_override: Option<bool>,
     pub pricing: ModelPricing,
-    pub max_output_tokens: u32,
+    /// `None` when unknown, see [`ProviderKind::fallback_max_output`].
+    pub max_output_tokens: Option<u32>,
     pub context_window: u32,
 }
 
@@ -248,7 +249,7 @@ impl Model {
             Some(e) => (
                 e.family,
                 e.pricing.clone(),
-                e.max_output_tokens,
+                Some(e.max_output_tokens),
                 anthropic::shared::long_context_window(model_id).unwrap_or(e.context_window),
             ),
             None => {
@@ -261,7 +262,7 @@ impl Model {
                         .unwrap_or_default(),
                     discovered
                         .and_then(|d| d.max_output_tokens)
-                        .unwrap_or_else(|| provider.fallback_max_output()),
+                        .or_else(|| provider.fallback_max_output()),
                     discovered
                         .and_then(|d| d.context_window)
                         .unwrap_or_else(|| provider.fallback_context_window()),
@@ -313,6 +314,15 @@ impl Model {
     pub fn supports_tool_examples(&self) -> bool {
         self.supports_tool_examples_override
             .unwrap_or_else(|| self.family.supports_tool_examples())
+    }
+
+    /// Half the output window, so the answer always has room after the
+    /// thinking. `None` when the window is unknown: callers must then let
+    /// budgets through unclamped. Providers cap further only where the API
+    /// documents a hard limit (currently just Google).
+    pub fn max_thinking_budget(&self) -> Option<u32> {
+        self.max_output_tokens
+            .map(|n| (n / 2).max(MIN_THINKING_BUDGET))
     }
 
     /// A model supports fast mode exactly when it carries fast-tier pricing, so
@@ -627,8 +637,9 @@ mod tests {
                 let model = Model::from_tier(provider, tier).unwrap();
                 assert_eq!(model.provider, provider);
                 assert_eq!(model.tier, tier);
-                assert!(model.max_output_tokens > 0);
-                assert!(model.context_window >= model.max_output_tokens);
+                let max_output = model.max_output_tokens.unwrap();
+                assert!(max_output > 0);
+                assert!(model.context_window >= max_output);
             }
         }
     }

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -182,22 +182,26 @@ impl ProviderKind {
         )
     }
 
-    pub const fn fallback_max_output(self) -> u32 {
+    /// `None` when we honestly don't know the output window: llama.cpp
+    /// serves whatever model the user loaded, and TensorX rejects explicit
+    /// max_tokens (see tensorx.rs). Unknown means "don't limit", never
+    /// "assume small"; a `0` sentinel here once silently capped llama.cpp
+    /// thinking budgets at the floor.
+    pub const fn fallback_max_output(self) -> Option<u32> {
         match self {
-            Self::Anthropic => 128_000,
-            Self::OpenAi => 100_000,
-            Self::Google => 65_536,
-            Self::Copilot => 100_000,
-            Self::Ollama => 16_384,
-            Self::LlamaCpp => 0,
-            Self::Mistral => 32_000,
-            Self::Zai => 16_000,
-            Self::DeepSeek => 384_000,
-            Self::OpenRouter => 128_000,
-            Self::Synthetic => 32_000,
-            // FIXME: See comment in tensorx.rs
-            Self::TensorX => 0,
-            Self::Opencode => 128_000,
+            Self::Anthropic => Some(128_000),
+            Self::OpenAi => Some(100_000),
+            Self::Google => Some(65_536),
+            Self::Copilot => Some(100_000),
+            Self::Ollama => Some(16_384),
+            Self::LlamaCpp => None,
+            Self::Mistral => Some(32_000),
+            Self::Zai => Some(16_000),
+            Self::DeepSeek => Some(384_000),
+            Self::OpenRouter => Some(128_000),
+            Self::Synthetic => Some(32_000),
+            Self::TensorX => None,
+            Self::Opencode => Some(128_000),
         }
     }
 

--- a/maki-providers/src/providers/anthropic/shared.rs
+++ b/maki-providers/src/providers/anthropic/shared.rs
@@ -13,6 +13,11 @@ use crate::{
 
 pub(super) const BETA_TOOL_EXAMPLES_BEDROCK: &str = "tool-examples-2025-10-29";
 
+/// The messages API refuses requests without max_tokens. Anthropic-kind
+/// models always get a window from the fallback table, so this only fires if
+/// an unknown-window model is ever routed here; 32k is safe for every Claude.
+pub(crate) const FALLBACK_MAX_TOKENS: u32 = 32_000;
+
 /// A `-1m` suffix is our own convention for asking Anthropic for the 1M context
 /// window. We strip it from the id before sending and add [`LONG_CONTEXT_BETA`]
 /// to the request instead.
@@ -199,13 +204,13 @@ pub(crate) fn build_request_body_with_system(
     let wire_tools = build_wire_tools(tools);
 
     let mut body = json!({
-        "max_tokens": model.max_output_tokens,
+        "max_tokens": model.max_output_tokens.unwrap_or(FALLBACK_MAX_TOKENS),
         "system": system_blocks,
         "messages": wire_messages,
         "tools": wire_tools,
     });
 
-    thinking.apply_to_body(&mut body, &model.id);
+    thinking.apply_to_body(&mut body, model);
     body
 }
 

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use tracing::{debug, warn};
 
+use super::anthropic::shared;
 use super::openai::responses;
 use super::openai_compat;
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
@@ -285,13 +286,13 @@ impl Copilot {
         let auth = self.auth().await?;
         let mut body = json!({
             "model": model.id,
-            "max_tokens": model.max_output_tokens,
+            "max_tokens": model.max_output_tokens.unwrap_or(shared::FALLBACK_MAX_TOKENS),
             "system": [{"type": "text", "text": system}],
             "messages": anthropic_messages(messages),
             "tools": tools,
             "stream": true,
         });
-        thinking.apply_to_body(&mut body, &model.id);
+        thinking.apply_to_body(&mut body, model);
 
         let request = self
             .build_post(&auth, MESSAGES_PATH, Some("conversation-agent"), &body)?

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -94,7 +94,7 @@ pub fn lookup_model(slug: &str, model_id: &str) -> Option<Model> {
         .unwrap_or(ModelTier::Medium);
     let max_output_tokens = declared
         .and_then(|m| m.max_output_tokens)
-        .unwrap_or_else(|| kind.fallback_max_output());
+        .or_else(|| kind.fallback_max_output());
     let context_window = declared
         .and_then(|m| m.context_window)
         .unwrap_or_else(|| kind.fallback_context_window());

--- a/maki-providers/src/providers/deepseek.rs
+++ b/maki-providers/src/providers/deepseek.rs
@@ -7,7 +7,9 @@ use tracing::warn;
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig};
+use crate::{
+    AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig, dialect,
+};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
@@ -122,22 +124,16 @@ impl Provider for DeepSeek {
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
 
-            // DeepSeek enables reasoning by default; Adaptive and Budget
-            // use the model's default reasoning behavior.
-            match opts.thinking {
-                ThinkingConfig::Off => {
-                    body["thinking"] = serde_json::json!({"type": "disabled"});
-                }
-                ThinkingConfig::Adaptive => {
-                    body["thinking"] = serde_json::json!({"type": "enabled"});
-                    pad_reasoning_content(&model.id, &mut body);
-                }
-                ThinkingConfig::Budget(_) => {
-                    body["thinking"] = serde_json::json!({"type": "enabled"});
-                    body["reasoning_effort"] = serde_json::json!("max");
+            if opts.thinking.is_enabled() {
+                body["thinking"] = serde_json::json!({"type": "enabled"});
+                opts.thinking
+                    .apply_reasoning_effort(&mut body, &dialect::DEEPSEEK, model);
+                if matches!(opts.thinking, ThinkingConfig::Budget(_)) {
                     warn!("DeepSeek reasoning does not support token budgets");
-                    pad_reasoning_content(&model.id, &mut body);
                 }
+                pad_reasoning_content(&model.id, &mut body);
+            } else {
+                body["thinking"] = serde_json::json!({"type": "disabled"});
             }
 
             self.compat

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -84,7 +84,7 @@ impl ScriptModel {
             supports_thinking_override: self.supports_thinking,
             supports_vision_override: self.supports_vision,
             pricing: self.pricing.clone().unwrap_or_default(),
-            max_output_tokens: self.max_output_tokens,
+            max_output_tokens: Some(self.max_output_tokens),
             context_window: self.context_window,
         }
     }

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -20,6 +20,19 @@ use super::{KeyPool, ResolvedAuth, http_client, next_sse_line};
 
 const BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
 const ENV_VAR: &str = "GEMINI_API_KEY";
+const FLASH_MAX_THINKING: u32 = 24_576;
+const PRO_MAX_THINKING: u32 = 32_768;
+
+/// The generic per-model max, capped by Google's documented `thinkingBudget`
+/// hard limits per family.
+fn max_thinking(model: &Model) -> u32 {
+    let cap = if model.id.contains("flash") {
+        FLASH_MAX_THINKING
+    } else {
+        PRO_MAX_THINKING
+    };
+    model.max_thinking_budget().map_or(cap, |m| m.min(cap))
+}
 
 inventory::submit!(maki_config::providers::BuiltInProvider {
     slug: "google",
@@ -177,10 +190,10 @@ impl Google {
             body["systemInstruction"] = json!({"parts": [{"text": system}]});
         }
 
-        thinking.apply_google_thinking(&mut body);
+        thinking.apply_google_thinking(&mut body, max_thinking(model));
 
-        if model.max_output_tokens > 0 {
-            body["generationConfig"]["maxOutputTokens"] = json!(model.max_output_tokens);
+        if let Some(max_output) = model.max_output_tokens {
+            body["generationConfig"]["maxOutputTokens"] = json!(max_output);
         }
 
         let tool_decls = convert_tools(tools);
@@ -623,7 +636,7 @@ mod tests {
             supports_tool_examples_override: None,
             supports_thinking_override: None,
             pricing: ModelPricing::default(),
-            max_output_tokens: 8192,
+            max_output_tokens: Some(8192),
             context_window: 1_048_576,
         }
     }
@@ -677,9 +690,10 @@ mod tests {
             ThinkingConfig::Budget(8192),
         );
 
+        // Clamped to the model's max thinking budget (half of 8192 output tokens).
         assert_eq!(
             body["generationConfig"]["thinkingConfig"]["thinkingBudget"],
-            8192
+            4096
         );
     }
 

--- a/maki-providers/src/providers/local.rs
+++ b/maki-providers/src/providers/local.rs
@@ -162,7 +162,7 @@ impl Provider for LocalEndpoint {
             let mut body = self.compat.build_body(model, messages, system, tools);
 
             if self.thinking_budget_field {
-                opts.thinking.apply_local_thinking(&mut body);
+                opts.thinking.apply_local_thinking(&mut body, model);
             }
 
             self.compat

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, EffortScale, Message, ProviderEvent, RequestOptions, StreamResponse};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
@@ -199,7 +199,7 @@ impl Provider for Mistral {
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
             opts.thinking
-                .apply_reasoning_effort(&mut body, EffortScale::HighOnly);
+                .apply_reasoning_effort(&mut body, &dialect::HIGH_ONLY, model);
             // Convert assistant messages to Mistral's expected format with thinking content
             convert_assistant_messages_in_place(body.get_mut("messages").unwrap());
 

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -8,7 +8,7 @@ use tracing::{debug, warn};
 
 use crate::model::Model;
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, EffortScale, Message, ProviderEvent, RequestOptions, StreamResponse};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
 use super::auth;
 use crate::providers::ResolvedAuth;
@@ -201,7 +201,7 @@ impl Provider for OpenAi {
 
             let mut body = self.compat.build_body(model, messages, system, tools);
             opts.thinking
-                .apply_reasoning_effort(&mut body, EffortScale::Standard);
+                .apply_reasoning_effort(&mut body, &dialect::STANDARD, model);
             self.with_oauth_retry(|| async {
                 let auth = self.current_auth();
                 self.compat

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -108,8 +108,8 @@ impl OpenAiCompatProvider {
             "messages": wire_messages,
             "stream": true,
         });
-        if model.max_output_tokens != 0 {
-            body[self.config.max_tokens_field] = json!(model.max_output_tokens);
+        if let Some(max_output) = model.max_output_tokens {
+            body[self.config.max_tokens_field] = json!(max_output);
         }
         if self.config.include_stream_usage {
             body["stream_options"] = json!({"include_usage": true});

--- a/maki-providers/src/providers/opencode.rs
+++ b/maki-providers/src/providers/opencode.rs
@@ -19,7 +19,7 @@ use maki_storage::auth::load_provider_credentials;
 use crate::model::{Model, ModelInfo, ModelPricing};
 use crate::provider::{BoxFuture, Provider};
 use crate::providers::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
-use crate::{AgentError, EffortScale, Message, ProviderEvent, RequestOptions, StreamResponse};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
 use super::{ResolvedAuth, http_client};
 use crate::providers::anthropic::shared;
@@ -476,7 +476,7 @@ impl Opencode {
     ) -> Result<StreamResponse, AgentError> {
         let mut body = self.chat_compat.build_body(model, messages, system, tools);
         opts.thinking
-            .apply_reasoning_effort(&mut body, EffortScale::PreferHigh);
+            .apply_reasoning_effort(&mut body, &dialect::PREFER_HIGH, model);
         self.chat_compat
             .do_stream(model, &[], &body, event_tx, auth)
             .await
@@ -586,7 +586,7 @@ impl Provider for Opencode {
 
             let model = Model {
                 id: actual_id.to_string(),
-                max_output_tokens: meta.output,
+                max_output_tokens: Some(meta.output),
                 context_window: meta.context,
                 ..model_for_stream
             };

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -6,7 +6,10 @@ use serde_json::{Value, json};
 
 use crate::model::{Model, ModelEntry, ModelInfo, ModelPricing};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig};
+use crate::{
+    AgentError, Effort, EffortDialect, Message, ProviderEvent, RequestOptions, StreamResponse,
+    dialect,
+};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
@@ -31,7 +34,7 @@ pub(crate) fn models() -> &'static [ModelEntry] {
 struct OpenRouterModelInfo {
     reasoning_mandatory: bool,
     reasoning_default_enabled: bool,
-    reasoning_efforts: Vec<String>,
+    reasoning_efforts: Vec<Effort>,
 }
 
 pub struct OpenRouter {
@@ -67,22 +70,23 @@ impl OpenRouter {
     }
 }
 
-fn map_effort_to_supported<'a>(requested: &'a str, supported: &'a [String]) -> &'a str {
-    const EFFORT_ORDER: &[&str] = &["max", "xhigh", "high", "medium", "low", "minimal", "none"];
-
-    if supported.iter().any(|s| s == requested) {
-        return requested;
+/// OpenRouter models come in three reasoning states, encoded here as a
+/// dialect so `effort_str` can resolve them like any other provider:
+/// 1. mandatory - always on; Off sends nothing (can't disable).
+/// 2. default_enabled - on by default; Off sends effort "none".
+/// 3. default off - Off sends nothing; any effort string turns it on.
+fn effort_dialect(info: Option<&OpenRouterModelInfo>) -> EffortDialect<'_> {
+    let Some(info) = info else {
+        return dialect::PREFER_HIGH;
+    };
+    EffortDialect {
+        supported: match info.reasoning_efforts.as_slice() {
+            [] => dialect::PREFER_HIGH.supported,
+            declared => declared,
+        },
+        off: (info.reasoning_default_enabled && !info.reasoning_mandatory).then_some(dialect::OFF),
+        ..dialect::PREFER_HIGH
     }
-    let req_idx = EFFORT_ORDER
-        .iter()
-        .position(|&e| e == requested)
-        .unwrap_or(0);
-    for effort in EFFORT_ORDER.iter().skip(req_idx) {
-        if supported.contains(&effort.to_string()) {
-            return effort;
-        }
-    }
-    supported.last().map(|s| s.as_str()).unwrap_or(requested)
 }
 
 fn parse_model(m: &Value) -> Option<ModelInfo> {
@@ -134,9 +138,12 @@ fn parse_model(m: &Value) -> Option<ModelInfo> {
                 .get("supported_efforts")
                 .and_then(Value::as_array)
                 .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(String::from))
-                        .collect()
+                    let mut efforts: Vec<Effort> = arr
+                        .iter()
+                        .filter_map(|v| v.as_str()?.parse().ok())
+                        .collect();
+                    efforts.sort_unstable();
+                    efforts
                 })
                 .unwrap_or_default(),
         });
@@ -186,42 +193,11 @@ impl Provider for OpenRouter {
                     })
             };
 
-            let (mandatory, default_enabled) = reasoning_info
-                .as_ref()
-                .map(|r| (r.reasoning_mandatory, r.reasoning_default_enabled))
-                .unwrap_or((false, false));
-
-            // Determine if and how to send reasoning config for OpenRouter.
-            // Models have three states:
-            // 1. mandatory: true - reasoning always on, can't be disabled.
-            // 2. default_enabled: true - reasoning on by default, disable with effort: "none".
-            // 3. default off - reasoning off by default, enabled with any reasoning object.
-            let reasoning_body = if model.supports_thinking() {
-                let effort = match opts.thinking {
-                    ThinkingConfig::Off => "none",
-                    // FIXME: Should probably use default_effort if provided instead of high
-                    ThinkingConfig::Adaptive => "high",
-                    ThinkingConfig::Budget(n) => ThinkingConfig::budget_to_effort(n),
-                };
-                match opts.thinking {
-                    ThinkingConfig::Off if mandatory => None,
-                    ThinkingConfig::Off if default_enabled => Some(json!({"effort": "none"})),
-                    ThinkingConfig::Off => None,
-                    _ => {
-                        let final_effort = if let Some(info) = &reasoning_info {
-                            map_effort_to_supported(effort, &info.reasoning_efforts)
-                        } else {
-                            effort
-                        };
-                        Some(json!({"effort": final_effort}))
-                    }
-                }
-            } else {
-                None
-            };
-
-            if let Some(reasoning) = reasoning_body {
-                body["reasoning"] = reasoning;
+            let effort_dialect = effort_dialect(reasoning_info.as_deref());
+            if model.supports_thinking()
+                && let Some(effort) = opts.thinking.effort_str(&effort_dialect, model)
+            {
+                body["reasoning"] = json!({"effort": effort});
             }
 
             if let Some(sid) = session_id {
@@ -257,6 +233,7 @@ mod tests {
     use test_case::test_case;
 
     use super::*;
+    use crate::ThinkingConfig;
 
     fn kimi_k3_json() -> Value {
         json!({
@@ -300,6 +277,90 @@ mod tests {
             .pricing
             .expect("pricing should be parsed");
         assert_eq!(pricing.cache_write, 3.75);
+    }
+
+    #[test]
+    fn parse_model_reasoning_efforts_skips_unknown_and_sorts() {
+        let mut m = kimi_k3_json();
+        m["reasoning"] = json!({
+            "mandatory": false,
+            "default_enabled": true,
+            "supported_efforts": ["high", "bogus", "low", "none"],
+        });
+
+        let info = parse_model(&m).expect("model should parse");
+        let provider_info = info.provider_info.expect("reasoning info should be set");
+        let reasoning = provider_info
+            .downcast_ref::<OpenRouterModelInfo>()
+            .expect("wrong provider info type");
+        assert!(reasoning.reasoning_default_enabled);
+        assert!(!reasoning.reasoning_mandatory);
+        assert_eq!(reasoning.reasoning_efforts, vec![Effort::Low, Effort::High]);
+    }
+
+    fn openrouter_model(info: Option<&OpenRouterModelInfo>) -> (EffortDialect<'_>, Model) {
+        let model = Model {
+            id: "test-model".into(),
+            provider: crate::provider::ProviderKind::OpenRouter,
+            dynamic_slug: None,
+            tier: crate::model::ModelTier::Medium,
+            family: crate::model::ModelFamily::Generic,
+            supports_tool_examples_override: None,
+            supports_thinking_override: None,
+            supports_vision_override: None,
+            pricing: ModelPricing::default(),
+            max_output_tokens: Some(8192),
+            context_window: 200_000,
+        };
+        (effort_dialect(info), model)
+    }
+
+    fn reasoning_info(efforts: &[Effort]) -> OpenRouterModelInfo {
+        OpenRouterModelInfo {
+            reasoning_mandatory: false,
+            reasoning_default_enabled: false,
+            reasoning_efforts: efforts.to_vec(),
+        }
+    }
+
+    #[test_case(&[Effort::High, Effort::XHigh], ThinkingConfig::Effort(Effort::XHigh), "xhigh" ; "declared_xhigh_passes_through")]
+    #[test_case(&[Effort::High, Effort::XHigh], ThinkingConfig::Effort(Effort::Max),   "xhigh" ; "max_snaps_to_declared_xhigh")]
+    #[test_case(&[Effort::Minimal, Effort::Low], ThinkingConfig::Adaptive,             "low"   ; "adaptive_snaps_into_declared")]
+    #[test_case(&[], ThinkingConfig::Effort(Effort::XHigh), "high" ; "no_declared_falls_back_to_static")]
+    fn effort_dialect_snaps_once_against_declared_levels(
+        efforts: &[Effort],
+        config: ThinkingConfig,
+        expected: &str,
+    ) {
+        let info = reasoning_info(efforts);
+        let (dialect, model) = openrouter_model(Some(&info));
+        assert_eq!(config.effort_str(&dialect, &model), Some(expected));
+    }
+
+    #[test]
+    fn no_reasoning_info_still_requests_high_effort() {
+        let (dialect, model) = openrouter_model(None);
+        assert_eq!(
+            ThinkingConfig::Adaptive.effort_str(&dialect, &model),
+            Some("high")
+        );
+    }
+
+    #[test_case(false, false, None         ; "default_off_sends_nothing")]
+    #[test_case(true,  false, Some("none") ; "default_enabled_disables_with_none")]
+    #[test_case(true,  true,  None         ; "mandatory_cannot_be_disabled")]
+    fn off_resolves_per_reasoning_flags(
+        default_enabled: bool,
+        mandatory: bool,
+        expected: Option<&str>,
+    ) {
+        let info = OpenRouterModelInfo {
+            reasoning_mandatory: mandatory,
+            reasoning_default_enabled: default_enabled,
+            reasoning_efforts: vec![],
+        };
+        let (dialect, model) = openrouter_model(Some(&info));
+        assert_eq!(ThinkingConfig::Off.effort_str(&dialect, &model), expected);
     }
 
     #[test_case(json!(["image"]), json!(["image"]); "image_only")]

--- a/maki-providers/src/providers/synthetic.rs
+++ b/maki-providers/src/providers/synthetic.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, EffortScale, Message, ProviderEvent, RequestOptions, StreamResponse};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
@@ -134,7 +134,7 @@ impl Provider for Synthetic {
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
             opts.thinking
-                .apply_reasoning_effort(&mut body, EffortScale::Standard);
+                .apply_reasoning_effort(&mut body, &dialect::STANDARD, model);
             self.compat
                 .do_stream(model, &[], &body, event_tx, &auth)
                 .await

--- a/maki-providers/src/providers/tensorx.rs
+++ b/maki-providers/src/providers/tensorx.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 
 use crate::model::{Model, ModelEntry, ModelInfo, ModelPricing};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::{KeyPool, ResolvedAuth};
@@ -107,19 +107,15 @@ impl Provider for TensorX {
             };
 
             if has_thinking {
-                body["thinking"] = json!(!matches!(opts.thinking, ThinkingConfig::Off));
+                body["thinking"] = json!(opts.thinking.is_enabled());
             }
             if has_reasoning_effort {
-                let effort = match opts.thinking {
-                    ThinkingConfig::Adaptive => "high",
-                    ThinkingConfig::Budget(n) => ThinkingConfig::budget_to_effort(n),
-                    ThinkingConfig::Off => "none",
-                };
-                body["reasoning_effort"] = json!(effort);
+                opts.thinking
+                    .apply_reasoning_effort(&mut body, &dialect::TENSORX, model);
             }
             // Fallback for deepseek models that use chat_template_kwargs
             else if !has_thinking
-                && !matches!(opts.thinking, ThinkingConfig::Off)
+                && opts.thinking.is_enabled()
                 && model.id.starts_with("deepseek/deepseek-v4")
             {
                 body["chat_template_kwargs"] = json!({"thinking": true});

--- a/maki-providers/src/providers/zai/mod.rs
+++ b/maki-providers/src/providers/zai/mod.rs
@@ -11,8 +11,8 @@ use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
 use crate::providers::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use crate::{
-    AgentError, EffortScale, Message, ProviderEvent, ProviderUsage, RequestOptions, StreamResponse,
-    UsageLimit,
+    AgentError, Message, ProviderEvent, ProviderUsage, RequestOptions, StreamResponse, UsageLimit,
+    dialect,
 };
 
 use super::{KeyPool, ResolvedAuth};
@@ -300,7 +300,7 @@ impl Provider for Zai {
             let mut body = self.compat.build_body(model, messages, system, tools);
             if model.supports_thinking() {
                 opts.thinking
-                    .apply_reasoning_effort(&mut body, EffortScale::Glm);
+                    .apply_reasoning_effort(&mut body, &dialect::GLM, model);
             }
             match self
                 .compat

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -6,7 +6,8 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
-use maki_storage::sessions::{StoredThinking, TitleSource};
+pub use maki_storage::sessions::Effort;
+use maki_storage::sessions::{MIN_THINKING_BUDGET, StoredThinking, TitleSource};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use strum::{Display, IntoStaticStr};
@@ -305,22 +306,83 @@ impl StopReason {
     }
 }
 
-const THINKING_USAGE: &str = "Usage: /thinking [off|adaptive|<budget\u{2265}1024>]";
-const GLM_XHIGH_THRESHOLD: u32 = 8192;
+const THINKING_USAGE: &str =
+    "Usage: /thinking [off|adaptive|minimal|low|medium|high|xhigh|max|<budget>]";
 
-/// Each provider speaks a different dialect of `reasoning_effort`.
-/// New providers get a variant here instead of a new body-mutating method.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum EffortScale {
-    /// low / medium / high. Adaptive = medium.
-    Standard,
-    /// low / medium / high. Adaptive = high.
-    PreferHigh,
-    /// Always "high", ignores budget.
-    HighOnly,
-    /// none / high / xhigh. GLM reasons by default, so Off sends "none"
-    /// explicitly. Only use behind `Model::supports_thinking`.
-    Glm,
+/// Effort levels are percentages, so they need a ceiling even when the model
+/// never told us its output window. 32k matches common frontier thinking
+/// caps. Explicit user budgets never go through this.
+const FALLBACK_MAX_THINKING_BUDGET: u32 = 32_768;
+
+/// How a provider's effort knob speaks: which levels its API accepts, what
+/// `adaptive` means there, and whether "off" needs an explicit string.
+/// New providers add a const in [`dialect`]; providers with dynamic model
+/// listings build one from the model's declared levels (see OpenRouter).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffortDialect<'a> {
+    /// Accepted levels, non-empty and ascending (checked by test).
+    pub supported: &'a [Effort],
+    /// What `Adaptive` maps to. `None` means the API has its own adaptive or
+    /// default behavior: send nothing and let it decide.
+    pub adaptive: Option<Effort>,
+    /// Explicit opt-out string, e.g. GLM `"none"`.
+    pub off: Option<&'static str>,
+}
+
+pub mod dialect {
+    use super::EffortDialect;
+    use maki_storage::sessions::Effort::{High, Low, Max, Medium, Minimal, XHigh};
+
+    /// Wire string that disables reasoning, for APIs that need an explicit
+    /// opt-out.
+    pub const OFF: &str = "none";
+
+    /// OpenAI platform, synthetic.
+    pub const STANDARD: EffortDialect = EffortDialect {
+        supported: &[Minimal, Low, Medium, High],
+        adaptive: Some(Medium),
+        off: None,
+    };
+    /// opencode chat-completions, openrouter (static fallback).
+    pub const PREFER_HIGH: EffortDialect = EffortDialect {
+        supported: &[Low, Medium, High],
+        adaptive: Some(High),
+        off: None,
+    };
+    /// Mistral.
+    pub const HIGH_ONLY: EffortDialect = EffortDialect {
+        supported: &[High],
+        adaptive: Some(High),
+        off: None,
+    };
+    /// Z.AI. GLM reasons by default, so Off sends "none" explicitly.
+    /// Only use behind `Model::supports_thinking`.
+    pub const GLM: EffortDialect = EffortDialect {
+        supported: &[High, XHigh],
+        adaptive: Some(High),
+        off: Some(OFF),
+    };
+    /// DeepSeek accepts only "max"; Adaptive keeps the model's own default
+    /// reasoning depth by sending no effort at all.
+    pub const DEEPSEEK: EffortDialect = EffortDialect {
+        supported: &[Max],
+        adaptive: None,
+        off: None,
+    };
+    /// `output_config.effort` on Anthropic adaptive-thinking models. The API
+    /// has native adaptive mode, so Adaptive sends no effort.
+    pub const ANTHROPIC_ADAPTIVE: EffortDialect = EffortDialect {
+        supported: &[Low, Medium, High],
+        adaptive: None,
+        off: None,
+    };
+    /// TensorX routes models that may reason by default, so Off sends "none"
+    /// explicitly and Adaptive asks for full depth.
+    pub const TENSORX: EffortDialect = EffortDialect {
+        supported: &[Low, Medium, High],
+        adaptive: Some(High),
+        off: Some(OFF),
+    };
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -328,7 +390,16 @@ pub enum ThinkingConfig {
     #[default]
     Off,
     Adaptive,
+    Effort(Effort),
     Budget(u32),
+}
+
+/// Resolved thinking value for token-budget APIs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Budgeted {
+    Off,
+    Adaptive,
+    Tokens(u32),
 }
 
 impl ThinkingConfig {
@@ -336,38 +407,76 @@ impl ThinkingConfig {
         !matches!(self, Self::Off)
     }
 
-    pub fn budget_to_effort(n: u32) -> &'static str {
-        if n < 2048 {
-            "low"
-        } else if n < 8192 {
-            "medium"
-        } else {
-            "high"
+    /// The effort string to send, snapped to the dialect's supported levels
+    /// here and nowhere else (never chain snaps). `None` means send nothing:
+    /// `Off` without an explicit off string, or `Adaptive` on APIs with their
+    /// own default behavior.
+    pub fn effort_str(self, dialect: &EffortDialect, model: &Model) -> Option<&'static str> {
+        let level = match self {
+            Self::Off => return dialect.off,
+            Self::Adaptive => dialect.adaptive?,
+            Self::Effort(e) => e,
+            Self::Budget(n) => Effort::from_budget(
+                n,
+                model
+                    .max_thinking_budget()
+                    .unwrap_or(FALLBACK_MAX_THINKING_BUDGET),
+            ),
+        };
+        Some(level.snap(dialect.supported).as_str())
+    }
+
+    /// The token budget to send, clamped to `[MIN_THINKING_BUDGET, max]` here
+    /// and nowhere else. An unknown `max` never caps: the user's number goes
+    /// through as asked, and effort levels scale the fallback ceiling.
+    fn budget(self, max: Option<u32>) -> Budgeted {
+        match self {
+            Self::Off => Budgeted::Off,
+            Self::Adaptive => Budgeted::Adaptive,
+            Self::Effort(e) => {
+                Budgeted::Tokens(e.budget(max.unwrap_or(FALLBACK_MAX_THINKING_BUDGET)))
+            }
+            Self::Budget(n) => Budgeted::Tokens(match max {
+                Some(max) => n.clamp(MIN_THINKING_BUDGET, max.max(MIN_THINKING_BUDGET)),
+                None => n.max(MIN_THINKING_BUDGET),
+            }),
         }
     }
 
-    pub fn apply_to_body(self, body: &mut Value, model_id: &str) {
-        match self {
-            Self::Off => {}
-            Self::Adaptive => {
-                body["thinking"] = json!({"type": "adaptive"});
+    /// Anthropic messages API body. Adaptive-thinking models get the native
+    /// adaptive knob plus `output_config.effort`; legacy models get a plain
+    /// token budget.
+    pub fn apply_to_body(self, body: &mut Value, model: &Model) {
+        if Self::requires_adaptive(&model.id) {
+            match self {
+                Self::Off => {}
+                Self::Adaptive => body["thinking"] = json!({"type": "adaptive"}),
+                Self::Effort(_) | Self::Budget(_) => {
+                    body["thinking"] = json!({"type": "adaptive"});
+                    if let Some(effort) = self.effort_str(&dialect::ANTHROPIC_ADAPTIVE, model) {
+                        body["output_config"]["effort"] = json!(effort);
+                    }
+                }
             }
-            Self::Budget(n) if Self::requires_adaptive(model_id) => {
-                body["thinking"] = json!({"type": "adaptive"});
-                body["output_config"]["effort"] = json!(Self::budget_to_effort(n));
-            }
-            Self::Budget(n) => {
+            return;
+        }
+        match self.budget(model.max_thinking_budget()) {
+            Budgeted::Off => {}
+            Budgeted::Adaptive => body["thinking"] = json!({"type": "adaptive"}),
+            Budgeted::Tokens(n) => {
                 body["thinking"] = json!({"type": "enabled", "budget_tokens": n});
             }
         }
     }
 
-    /// Version check, not an allowlist, so future Opus releases work automatically.
+    /// Version check, not an allowlist, so future Opus releases work
+    /// automatically. Splits on `-` and `.` since Copilot uses dotted ids
+    /// (`claude-opus-4.7`).
     fn requires_adaptive(model_id: &str) -> bool {
         let Some(version) = model_id.strip_prefix("claude-opus-") else {
             return false;
         };
-        let mut parts = version.split('-');
+        let mut parts = version.split(['-', '.']);
         let (Some(Ok(major)), Some(Ok(minor))) = (
             parts.next().map(str::parse::<u32>),
             parts.next().map(str::parse::<u32>),
@@ -377,44 +486,29 @@ impl ThinkingConfig {
         (major, minor) >= (4, 7)
     }
 
-    pub fn apply_reasoning_effort(self, body: &mut Value, scale: EffortScale) {
-        let effort = match (self, scale) {
-            (Self::Off, EffortScale::Glm) => "none",
-            (Self::Off, _) => return,
-            (Self::Adaptive, EffortScale::Standard) => "medium",
-            (Self::Adaptive, _) => "high",
-            (Self::Budget(_), EffortScale::HighOnly) => "high",
-            (Self::Budget(n), EffortScale::Glm) => {
-                if n >= GLM_XHIGH_THRESHOLD {
-                    "xhigh"
-                } else {
-                    "high"
-                }
-            }
-            (Self::Budget(n), EffortScale::Standard | EffortScale::PreferHigh) => {
-                Self::budget_to_effort(n)
-            }
-        };
-        body["reasoning_effort"] = json!(effort);
+    pub fn apply_reasoning_effort(self, body: &mut Value, dialect: &EffortDialect, model: &Model) {
+        if let Some(effort) = self.effort_str(dialect, model) {
+            body["reasoning_effort"] = json!(effort);
+        }
     }
 
-    pub fn apply_google_thinking(self, body: &mut Value) {
-        match self {
-            Self::Off => {}
-            Self::Adaptive => {
+    pub fn apply_google_thinking(self, body: &mut Value, max: u32) {
+        match self.budget(Some(max)) {
+            Budgeted::Off => {}
+            Budgeted::Adaptive => {
                 body["generationConfig"]["thinkingConfig"] = json!({"includeThoughts": true});
             }
-            Self::Budget(n) => {
+            Budgeted::Tokens(n) => {
                 body["generationConfig"]["thinkingConfig"] = json!({"thinkingBudget": n});
             }
         }
     }
 
-    pub fn apply_local_thinking(self, body: &mut Value) {
-        let budget = match self {
-            Self::Off => 0,
-            Self::Adaptive => -1,
-            Self::Budget(n) => n as i64,
+    pub fn apply_local_thinking(self, body: &mut Value, model: &Model) {
+        let budget = match self.budget(model.max_thinking_budget()) {
+            Budgeted::Off => 0,
+            Budgeted::Adaptive => -1,
+            Budgeted::Tokens(n) => i64::from(n),
         };
         body["thinking_budget_tokens"] = json!(budget);
     }
@@ -436,6 +530,7 @@ impl ThinkingConfig {
         match self {
             Self::Off => None,
             Self::Adaptive => Some(Cow::Borrowed("thinking")),
+            Self::Effort(e) => Some(Cow::Owned(format!("thinking: {e}"))),
             Self::Budget(n) => Some(Cow::Owned(format!("thinking: {n}"))),
         }
     }
@@ -446,6 +541,7 @@ impl std::fmt::Display for ThinkingConfig {
         match self {
             Self::Off => f.write_str("off"),
             Self::Adaptive => f.write_str("adaptive"),
+            Self::Effort(e) => f.write_str(e.as_str()),
             Self::Budget(n) => write!(f, "{n}"),
         }
     }
@@ -456,6 +552,7 @@ impl From<StoredThinking> for ThinkingConfig {
         match s {
             StoredThinking::Off => Self::Off,
             StoredThinking::Adaptive => Self::Adaptive,
+            StoredThinking::Effort { level } => Self::Effort(level),
             StoredThinking::Budget { tokens } => Self::Budget(tokens),
         }
     }
@@ -466,6 +563,7 @@ impl From<ThinkingConfig> for StoredThinking {
         match c {
             ThinkingConfig::Off => Self::Off,
             ThinkingConfig::Adaptive => Self::Adaptive,
+            ThinkingConfig::Effort(e) => Self::Effort { level: e },
             ThinkingConfig::Budget(n) => Self::Budget { tokens: n },
         }
     }
@@ -648,64 +746,131 @@ mod tests {
         assert_eq!(&*deserialized.data, "abc123");
     }
 
+    use Effort::{High, Low, Max, Minimal, XHigh};
+
+    /// `max_output_tokens: 8192`, so `max_thinking_budget()` is 4096.
+    fn thinking_model(id: &str) -> crate::model::Model {
+        crate::model::Model {
+            id: id.into(),
+            ..clamp_test_model(crate::provider::ProviderKind::Anthropic)
+        }
+    }
+
+    #[test]
+    fn dialects_have_non_empty_ascending_supported() {
+        let all = [
+            &dialect::STANDARD,
+            &dialect::PREFER_HIGH,
+            &dialect::HIGH_ONLY,
+            &dialect::GLM,
+            &dialect::DEEPSEEK,
+            &dialect::ANTHROPIC_ADAPTIVE,
+            &dialect::TENSORX,
+        ];
+        for d in all {
+            assert!(!d.supported.is_empty());
+            for pair in d.supported.windows(2) {
+                assert!(pair[0] < pair[1], "supported must be strictly ascending");
+            }
+            if let Some(adaptive) = d.adaptive {
+                assert!(d.supported.contains(&adaptive));
+            }
+        }
+    }
+
     #[test_case(ThinkingConfig::Off, "claude-opus-4-5", json!({}) ; "off")]
     #[test_case(ThinkingConfig::Adaptive, "claude-opus-4-5", json!({"thinking": {"type": "adaptive"}}) ; "adaptive")]
-    #[test_case(ThinkingConfig::Budget(10000), "claude-opus-4-5", json!({"thinking": {"type": "enabled", "budget_tokens": 10000}}) ; "budget_legacy_old_opus")]
-    #[test_case(ThinkingConfig::Budget(10000), "claude-sonnet-4-6", json!({"thinking": {"type": "enabled", "budget_tokens": 10000}}) ; "budget_legacy_sonnet")]
-    #[test_case(ThinkingConfig::Budget(10000), "claude-opus-4-6", json!({"thinking": {"type": "enabled", "budget_tokens": 10000}}) ; "budget_legacy_opus_4_6")]
+    #[test_case(ThinkingConfig::Budget(2048), "claude-opus-4-5", json!({"thinking": {"type": "enabled", "budget_tokens": 2048}}) ; "budget_legacy_in_range")]
+    #[test_case(ThinkingConfig::Budget(10000), "claude-opus-4-5", json!({"thinking": {"type": "enabled", "budget_tokens": 4096}}) ; "budget_legacy_clamped_to_max")]
+    #[test_case(ThinkingConfig::Budget(10000), "claude-sonnet-4-6", json!({"thinking": {"type": "enabled", "budget_tokens": 4096}}) ; "budget_legacy_sonnet")]
+    #[test_case(ThinkingConfig::Budget(10000), "claude-opus-4-6", json!({"thinking": {"type": "enabled", "budget_tokens": 4096}}) ; "budget_legacy_opus_4_6")]
+    #[test_case(ThinkingConfig::Off, "claude-opus-4-7", json!({}) ; "off_adaptive_model")]
+    #[test_case(ThinkingConfig::Adaptive, "claude-opus-4-7", json!({"thinking": {"type": "adaptive"}}) ; "adaptive_adaptive_model")]
     #[test_case(ThinkingConfig::Budget(10000), "claude-opus-4-7", json!({"thinking": {"type": "adaptive"}, "output_config": {"effort": "high"}}) ; "budget_adaptive_opus_4_7")]
+    #[test_case(ThinkingConfig::Effort(Low), "claude-opus-4-7", json!({"thinking": {"type": "adaptive"}, "output_config": {"effort": "low"}}) ; "effort_low_passthrough")]
     #[test_case(ThinkingConfig::Budget(10000), "claude-opus-4-8-1m", json!({"thinking": {"type": "adaptive"}, "output_config": {"effort": "high"}}) ; "budget_adaptive_opus_4_8_long_context")]
     #[test_case(ThinkingConfig::Budget(10000), "claude-opus-5-0", json!({"thinking": {"type": "adaptive"}, "output_config": {"effort": "high"}}) ; "budget_adaptive_future_opus_5")]
+    #[test_case(ThinkingConfig::Budget(10000), "claude-opus-4.7", json!({"thinking": {"type": "adaptive"}, "output_config": {"effort": "high"}}) ; "budget_adaptive_copilot_dotted_id")]
+    #[test_case(ThinkingConfig::Budget(10000), "claude-opus-4.6", json!({"thinking": {"type": "enabled", "budget_tokens": 4096}}) ; "budget_legacy_copilot_dotted_4_6")]
     fn thinking_apply_to_body(config: ThinkingConfig, model_id: &str, expected: Value) {
         let mut body = json!({});
-        config.apply_to_body(&mut body, model_id);
+        config.apply_to_body(&mut body, &thinking_model(model_id));
         assert_eq!(body, expected);
     }
 
-    use EffortScale::{Glm, HighOnly, PreferHigh, Standard};
-
-    #[test_case(Standard,   ThinkingConfig::Off,          None            ; "off_noop")]
-    #[test_case(Standard,   ThinkingConfig::Adaptive,     Some("medium")  ; "standard_adaptive")]
-    #[test_case(Standard,   ThinkingConfig::Budget(1024), Some("low")     ; "standard_budget_low")]
-    #[test_case(Standard,   ThinkingConfig::Budget(4096), Some("medium")  ; "standard_budget_medium")]
-    #[test_case(Standard,   ThinkingConfig::Budget(8192), Some("high")    ; "standard_budget_high")]
-    #[test_case(PreferHigh, ThinkingConfig::Adaptive,     Some("high")    ; "prefer_high_adaptive")]
-    #[test_case(PreferHigh, ThinkingConfig::Budget(1024), Some("low")     ; "prefer_high_budget_low")]
-    #[test_case(HighOnly,   ThinkingConfig::Adaptive,     Some("high")    ; "high_only_adaptive")]
-    #[test_case(HighOnly,   ThinkingConfig::Budget(1024), Some("high")    ; "high_only_budget")]
-    #[test_case(Glm,        ThinkingConfig::Off,          Some("none")    ; "glm_off_explicit_none")]
-    #[test_case(Glm,        ThinkingConfig::Adaptive,     Some("high")    ; "glm_adaptive")]
-    #[test_case(Glm,        ThinkingConfig::Budget(1024), Some("high")    ; "glm_budget_low")]
-    #[test_case(Glm,        ThinkingConfig::Budget(8192), Some("xhigh")   ; "glm_budget_xhigh")]
+    #[test_case(&dialect::STANDARD, ThinkingConfig::Off,             None            ; "standard_off_noop")]
+    #[test_case(&dialect::STANDARD, ThinkingConfig::Adaptive,        Some("medium")  ; "standard_adaptive")]
+    #[test_case(&dialect::STANDARD, ThinkingConfig::Effort(Minimal), Some("minimal") ; "standard_minimal_passthrough")]
+    #[test_case(&dialect::STANDARD, ThinkingConfig::Effort(Max),     Some("high")    ; "standard_max_snaps_down")]
+    #[test_case(&dialect::STANDARD, ThinkingConfig::Budget(1024),    Some("medium")  ; "standard_quarter_budget")]
+    #[test_case(&dialect::PREFER_HIGH, ThinkingConfig::Adaptive,        Some("high") ; "prefer_high_adaptive")]
+    #[test_case(&dialect::HIGH_ONLY, ThinkingConfig::Adaptive,        Some("high") ; "high_only_adaptive")]
+    #[test_case(&dialect::HIGH_ONLY, ThinkingConfig::Effort(Minimal), Some("high") ; "high_only_minimal")]
+    #[test_case(&dialect::GLM, ThinkingConfig::Off,          Some("none")  ; "glm_off_explicit_none")]
+    #[test_case(&dialect::GLM, ThinkingConfig::Adaptive,     Some("high")  ; "glm_adaptive")]
+    #[test_case(&dialect::GLM, ThinkingConfig::Effort(Max),  Some("xhigh") ; "glm_max_snaps_to_xhigh")]
+    #[test_case(&dialect::DEEPSEEK, ThinkingConfig::Adaptive,        None        ; "deepseek_adaptive_uses_api_default")]
+    #[test_case(&dialect::DEEPSEEK, ThinkingConfig::Effort(Minimal), Some("max") ; "deepseek_minimal")]
+    #[test_case(&dialect::ANTHROPIC_ADAPTIVE, ThinkingConfig::Adaptive,      None         ; "anthropic_adaptive_is_native")]
+    #[test_case(&dialect::ANTHROPIC_ADAPTIVE, ThinkingConfig::Effort(XHigh), Some("high") ; "anthropic_xhigh_snaps_down")]
+    #[test_case(&dialect::TENSORX, ThinkingConfig::Off,             Some("none") ; "tensorx_off_explicit_none")]
     fn thinking_apply_reasoning_effort(
-        scale: EffortScale,
+        dialect: &EffortDialect,
         config: ThinkingConfig,
         expected: Option<&str>,
     ) {
         let mut body = json!({"model": "test"});
-        config.apply_reasoning_effort(&mut body, scale);
+        config.apply_reasoning_effort(&mut body, dialect, &thinking_model("test-model"));
         match expected {
             Some(e) => assert_eq!(body["reasoning_effort"], e),
             None => assert!(body.get("reasoning_effort").is_none()),
         }
     }
 
+    #[test_case(ThinkingConfig::Off,             Some(4096), Budgeted::Off            ; "off")]
+    #[test_case(ThinkingConfig::Adaptive,        Some(4096), Budgeted::Adaptive       ; "adaptive")]
+    #[test_case(ThinkingConfig::Effort(Max),     Some(4096), Budgeted::Tokens(4096)   ; "effort_delegates_to_level_budget")]
+    #[test_case(ThinkingConfig::Budget(2048),    Some(4096), Budgeted::Tokens(2048)   ; "budget_in_range")]
+    #[test_case(ThinkingConfig::Budget(512),     Some(4096), Budgeted::Tokens(1024)   ; "budget_floored")]
+    #[test_case(ThinkingConfig::Budget(10000),   Some(4096), Budgeted::Tokens(4096)   ; "budget_clamped_to_max")]
+    #[test_case(ThinkingConfig::Budget(2048),    Some(512),  Budgeted::Tokens(1024)   ; "tiny_max_raised_to_floor")]
+    #[test_case(ThinkingConfig::Budget(16384),   None,       Budgeted::Tokens(16384)  ; "unknown_max_passes_budget_through")]
+    #[test_case(ThinkingConfig::Budget(512),     None,       Budgeted::Tokens(1024)   ; "unknown_max_still_floors")]
+    #[test_case(ThinkingConfig::Effort(Max),     None,       Budgeted::Tokens(32_768) ; "unknown_max_effort_scales_fallback")]
+    #[test_case(ThinkingConfig::Effort(Minimal), None,       Budgeted::Tokens(3_276)  ; "unknown_max_minimal_effort")]
+    fn thinking_budget_resolver(config: ThinkingConfig, max: Option<u32>, expected: Budgeted) {
+        assert_eq!(config.budget(max), expected);
+    }
+
     #[test_case(ThinkingConfig::Off,          json!({})                                                                  ; "off")]
     #[test_case(ThinkingConfig::Adaptive,     json!({"generationConfig": {"thinkingConfig": {"includeThoughts": true}}}) ; "adaptive")]
     #[test_case(ThinkingConfig::Budget(4096), json!({"generationConfig": {"thinkingConfig": {"thinkingBudget": 4096}}}) ; "budget")]
+    #[test_case(ThinkingConfig::Budget(10000), json!({"generationConfig": {"thinkingConfig": {"thinkingBudget": 8192}}}) ; "budget_clamped")]
     fn thinking_apply_google_thinking(config: ThinkingConfig, expected: Value) {
         let mut body = json!({});
-        config.apply_google_thinking(&mut body);
+        config.apply_google_thinking(&mut body, 8192);
         assert_eq!(body, expected);
     }
 
-    #[test_case(ThinkingConfig::Off,          0    ; "off")]
-    #[test_case(ThinkingConfig::Adaptive,     -1   ; "adaptive")]
-    #[test_case(ThinkingConfig::Budget(4096), 4096 ; "budget")]
+    #[test_case(ThinkingConfig::Off,            0    ; "off")]
+    #[test_case(ThinkingConfig::Adaptive,       -1   ; "adaptive")]
+    #[test_case(ThinkingConfig::Budget(4096),   4096 ; "budget")]
+    #[test_case(ThinkingConfig::Budget(10000),  4096 ; "budget_clamped")]
     fn thinking_apply_local_thinking(config: ThinkingConfig, expected: i64) {
         let mut body = json!({});
-        config.apply_local_thinking(&mut body);
+        config.apply_local_thinking(&mut body, &thinking_model("local-model"));
         assert_eq!(body["thinking_budget_tokens"], expected);
+    }
+
+    /// llama.cpp models have no known output window; the budget the user
+    /// asked for must reach the server untouched.
+    #[test]
+    fn local_thinking_unknown_window_passes_budget_through() {
+        let mut model = thinking_model("llama-cpp-model");
+        model.max_output_tokens = None;
+        let mut body = json!({});
+        ThinkingConfig::Budget(16_384).apply_local_thinking(&mut body, &model);
+        assert_eq!(body["thinking_budget_tokens"], 16_384);
     }
 
     fn clamp_test_model(provider: crate::provider::ProviderKind) -> crate::model::Model {
@@ -719,7 +884,7 @@ mod tests {
             supports_thinking_override: None,
             supports_vision_override: Some(provider.family().supports_vision()),
             pricing: crate::model::ModelPricing::default(),
-            max_output_tokens: 8192,
+            max_output_tokens: Some(8192),
             context_window: 200_000,
         }
     }
@@ -754,6 +919,7 @@ mod tests {
     #[test_case("",         ThinkingConfig::Adaptive, Ok(ThinkingConfig::Off)       ; "toggle_off")]
     #[test_case("off",      ThinkingConfig::Adaptive, Ok(ThinkingConfig::Off)       ; "explicit_off")]
     #[test_case("adaptive", ThinkingConfig::Off,      Ok(ThinkingConfig::Adaptive)  ; "explicit_adaptive")]
+    #[test_case("high",     ThinkingConfig::Off,      Ok(ThinkingConfig::Effort(High)) ; "explicit_effort")]
     #[test_case("8192",     ThinkingConfig::Off,      Ok(ThinkingConfig::Budget(8192)) ; "explicit_budget")]
     #[test_case("512",      ThinkingConfig::Off,      Ok(ThinkingConfig::Budget(512)) ; "small_budget")]
     #[test_case("0",        ThinkingConfig::Off,      Err(())                       ; "budget_zero")]
@@ -765,6 +931,7 @@ mod tests {
 
     #[test_case(ThinkingConfig::Off      ; "off")]
     #[test_case(ThinkingConfig::Adaptive ; "adaptive")]
+    #[test_case(ThinkingConfig::Effort(Max) ; "effort")]
     #[test_case(ThinkingConfig::Budget(8192) ; "budget")]
     fn thinking_display_round_trip(config: ThinkingConfig) {
         let s = config.to_string();

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -9,9 +9,11 @@
 
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::time::UNIX_EPOCH;
 
 use tracing::warn;
@@ -163,10 +165,113 @@ pub struct StoredRule {
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ThinkingParseError {
-    #[error("unknown thinking value {0:?} (use off, adaptive, or a token budget)")]
+    #[error(
+        "unknown thinking value {0:?} (use off, adaptive, minimal, low, medium, high, xhigh, max, or a token budget)"
+    )]
     Unknown(String),
     #[error("thinking budget must be greater than zero")]
     BudgetZero,
+}
+
+/// Floor for every token budget sent to a provider; some APIs reject smaller values.
+pub const MIN_THINKING_BUDGET: u32 = 1024;
+
+/// Thinking effort level. Declaration order is intensity order: the `Ord`
+/// derive and [`Effort::ALL`] rely on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Effort {
+    Minimal,
+    Low,
+    Medium,
+    High,
+    XHigh,
+    Max,
+}
+
+impl Effort {
+    pub const ALL: [Self; 6] = [
+        Self::Minimal,
+        Self::Low,
+        Self::Medium,
+        Self::High,
+        Self::XHigh,
+        Self::Max,
+    ];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Minimal => "minimal",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::XHigh => "xhigh",
+            Self::Max => "max",
+        }
+    }
+
+    /// Percentage of the model's max thinking budget this level spends.
+    pub const fn percent(self) -> u32 {
+        match self {
+            Self::Minimal => 10,
+            Self::Low => 20,
+            Self::Medium => 40,
+            Self::High => 60,
+            Self::XHigh => 80,
+            Self::Max => 100,
+        }
+    }
+
+    /// `percent` of `max`, clamped to `[MIN_THINKING_BUDGET, max]`.
+    /// A `max` below the floor is raised to it.
+    pub fn budget(self, max: u32) -> u32 {
+        let max = max.max(MIN_THINKING_BUDGET);
+        let tokens = (u64::from(max) * u64::from(self.percent()) / 100) as u32;
+        tokens.clamp(MIN_THINKING_BUDGET, max)
+    }
+
+    /// Inverse of [`Self::budget`]: the lowest level whose percentage covers
+    /// `n` tokens out of `max`. Budgets at or above `max` map to `Max`.
+    pub fn from_budget(n: u32, max: u32) -> Self {
+        let pct = u64::from(n).saturating_mul(100) / u64::from(max.max(1));
+        Self::ALL
+            .into_iter()
+            .find(|e| u64::from(e.percent()) >= pct)
+            .unwrap_or(Self::Max)
+    }
+
+    /// Nearest level a provider accepts: exact match keeps `self`, otherwise
+    /// the closest lower supported level, otherwise the lowest supported.
+    /// An empty `supported` list returns `self` unchanged (dynamic model
+    /// listings may not declare supported efforts).
+    pub fn snap(self, supported: &[Self]) -> Self {
+        if supported.is_empty() || supported.contains(&self) {
+            return self;
+        }
+        supported
+            .iter()
+            .rev()
+            .find(|&&e| e < self)
+            .copied()
+            .unwrap_or(supported[0])
+    }
+}
+
+impl fmt::Display for Effort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Effort {
+    type Err = ThinkingParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|e| e.as_str() == s)
+            .ok_or_else(|| ThinkingParseError::Unknown(s.to_string()))
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -174,19 +279,27 @@ pub enum ThinkingParseError {
 pub enum StoredThinking {
     Off,
     Adaptive,
+    Effort { level: Effort },
     Budget { tokens: u32 },
 }
 
 impl StoredThinking {
+    /// The one string-to-thinking parser: `/thinking`, `always_thinking`
+    /// config, and the Lua agent API all delegate here.
     pub fn parse_setting(input: &str) -> Result<Self, ThinkingParseError> {
         match input.trim() {
             "off" => Ok(Self::Off),
             "adaptive" => Ok(Self::Adaptive),
-            other => match other.parse::<u32>() {
-                Ok(0) => Err(ThinkingParseError::BudgetZero),
-                Ok(n) => Ok(Self::Budget { tokens: n }),
-                Err(_) => Err(ThinkingParseError::Unknown(other.to_string())),
-            },
+            other => {
+                if let Ok(level) = other.parse::<Effort>() {
+                    return Ok(Self::Effort { level });
+                }
+                match other.parse::<u32>() {
+                    Ok(0) => Err(ThinkingParseError::BudgetZero),
+                    Ok(n) => Ok(Self::Budget { tokens: n }),
+                    Err(_) => Err(ThinkingParseError::Unknown(other.to_string())),
+                }
+            }
         }
     }
 }
@@ -1154,6 +1267,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::Effort;
     use super::StoredThinking;
     use super::ThinkingParseError;
     use super::{
@@ -1997,6 +2111,7 @@ mod tests {
 
     #[test_case(StoredThinking::Off ; "off")]
     #[test_case(StoredThinking::Adaptive ; "adaptive")]
+    #[test_case(StoredThinking::Effort { level: Effort::XHigh } ; "effort")]
     #[test_case(StoredThinking::Budget { tokens: 4096 } ; "budget")]
     fn stored_thinking_serde_round_trip(variant: StoredThinking) {
         let json = serde_json::to_string(&variant).unwrap();
@@ -2011,8 +2126,65 @@ mod tests {
     #[test_case("1", Ok(StoredThinking::Budget { tokens: 1 }) ; "minimum_budget")]
     #[test_case("0", Err(ThinkingParseError::BudgetZero) ; "budget_zero")]
     #[test_case("fast", Err(ThinkingParseError::Unknown("fast".into())) ; "garbage")]
+    #[test_case("high", Ok(StoredThinking::Effort { level: Effort::High }) ; "effort_level")]
     fn parse_setting(input: &str, expected: Result<StoredThinking, ThinkingParseError>) {
         assert_eq!(StoredThinking::parse_setting(input), expected);
+    }
+
+    // Six ascending values in a six-variant enum also proves ALL is complete.
+    #[test]
+    fn effort_all_ascending_with_increasing_percent() {
+        for pair in Effort::ALL.windows(2) {
+            assert!(pair[0] < pair[1], "ALL must be ascending");
+            assert!(
+                pair[0].percent() < pair[1].percent(),
+                "percent must be strictly increasing"
+            );
+        }
+    }
+
+    #[test]
+    fn effort_wire_strings_round_trip() {
+        let expected = ["minimal", "low", "medium", "high", "xhigh", "max"];
+        for (e, s) in Effort::ALL.into_iter().zip(expected) {
+            assert_eq!(e.as_str(), s);
+            assert_eq!(s.parse::<Effort>(), Ok(e));
+        }
+    }
+
+    #[test_case(Effort::High, &[Effort::Low, Effort::Medium, Effort::High], Effort::High ; "exact_match")]
+    #[test_case(Effort::Max, &[Effort::Low, Effort::Medium, Effort::High], Effort::High ; "downgrade_to_nearest_lower")]
+    #[test_case(Effort::Minimal, &[Effort::Low, Effort::Medium], Effort::Low ; "below_lowest_takes_lowest")]
+    #[test_case(Effort::Medium, &[], Effort::Medium ; "empty_supported_keeps_self")]
+    #[test_case(Effort::Max, &[Effort::High, Effort::XHigh], Effort::XHigh ; "glm_max_snaps_to_xhigh")]
+    fn effort_snap(level: Effort, supported: &[Effort], expected: Effort) {
+        assert_eq!(level.snap(supported), expected);
+    }
+
+    #[test_case(Effort::Minimal, 32_768, 3_276 ; "minimal_ten_percent")]
+    #[test_case(Effort::Medium, 32_768, 13_107 ; "medium_forty_percent")]
+    #[test_case(Effort::Max, 32_768, 32_768 ; "max_full_budget")]
+    #[test_case(Effort::Minimal, 4_096, 1_024 ; "small_max_floors_at_min")]
+    #[test_case(Effort::Max, 512, 1_024 ; "tiny_max_raised_to_floor")]
+    fn effort_budget(level: Effort, max: u32, expected: u32) {
+        assert_eq!(level.budget(max), expected);
+    }
+
+    #[test_case(32_768, 32_768, Effort::Max ; "full_budget_is_max")]
+    #[test_case(64_000, 32_768, Effort::Max ; "above_max_is_max")]
+    #[test_case(0, 32_768, Effort::Minimal ; "zero_is_minimal")]
+    #[test_case(13_107, 32_768, Effort::Medium ; "forty_percent_is_medium")]
+    #[test_case(1_024, 0, Effort::Max ; "zero_max_saturates")]
+    fn effort_from_budget(n: u32, max: u32, expected: Effort) {
+        assert_eq!(Effort::from_budget(n, max), expected);
+    }
+
+    #[test]
+    fn effort_budget_round_trips_at_realistic_max() {
+        const MAX: u32 = 32_768;
+        for e in Effort::ALL {
+            assert_eq!(Effort::from_budget(e.budget(MAX), MAX), e);
+        }
     }
 
     #[test]

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -14,7 +14,7 @@ use maki_agent::{
 };
 use maki_config::{PermissionsConfig, UiConfig};
 use maki_lua::{HintReader, KeymapReader, LuaCommandReader};
-use maki_providers::{ContentBlock, Role, TokenUsage};
+use maki_providers::{ContentBlock, Effort, Role, TokenUsage};
 use maki_storage::sessions::StoredThinking;
 use ratatui::layout::Rect;
 use std::env;
@@ -2617,6 +2617,12 @@ fn thinking_explicit_args() {
         args: "8192".into(),
     });
     assert_eq!(app.state.thinking, ThinkingConfig::Budget(8192));
+
+    app.execute_command(ParsedCommand {
+        name: "/thinking".into(),
+        args: "high".into(),
+    });
+    assert_eq!(app.state.thinking, ThinkingConfig::Effort(Effort::High));
 }
 
 #[test]

--- a/maki-ui/src/components/command.rs
+++ b/maki-ui/src/components/command.rs
@@ -89,7 +89,7 @@ pub const BUILTIN_COMMANDS: &[BuiltinCommand] = &[
     },
     BuiltinCommand {
         name: "/thinking",
-        description: "Toggle extended thinking (off, adaptive, or budget)",
+        description: "Toggle extended thinking (off, adaptive, effort level, or budget)",
         max_args: 1,
     },
     BuiltinCommand {

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -395,7 +395,7 @@ pub(crate) fn test_model() -> maki_providers::Model {
         supports_thinking_override: None,
         supports_vision_override: Some(true),
         pricing: test_pricing(),
-        max_output_tokens: 8192,
+        max_output_tokens: Some(8192),
         context_window: TEST_CONTEXT_WINDOW,
     }
 }

--- a/plugins/skill/plugin_dev.lua
+++ b/plugins/skill/plugin_dev.lua
@@ -181,230 +181,230 @@ optional, `{...}` is variadic.
 - L539 `maki.agent.call_tool({ctx}, {name}, {input}, {opts?})` - Run a tool by name and wait for the result.
 - L572 `maki.agent.session({ctx}, {opts})` - Create a new subagent session.
 
-## maki.agent.Session - L615
-- L624 `Session:prompt({message})` - Send a message to the subagent and wait for its full response.
-- L648 `Session:close()` - Close the session and flush its history back to the parent agent.
+## maki.agent.Session - L617
+- L626 `Session:prompt({message})` - Send a message to the subagent and wait for its full response.
+- L650 `Session:close()` - Close the session and flush its history back to the parent agent.
 
-## maki.async - L655
-- L671 `maki.async.run({fn}, {on_finish?})` - Fire off a function as a new async task.
-- L691 `maki.async.await({argc}, {fn}, {...})` - Turn a callback-based function into a normal call you can use in a coroutine.
-- L709 `maki.async.wrap({argc}, {fn})` - Create a coroutine-friendly wrapper around a callback-based function.
-- L727 `maki.async.join({max_jobs}, {fns})` - Run all functions in {fns} with at most {max_jobs} going at once.
-- L746 `maki.async.gather({fns})` - Run all functions in {fns} at the same time and collect their results.
-- L773 `maki.async.semaphore({n})` - Create a counting semaphore that allows at most {n} concurrent permits.
+## maki.async - L657
+- L673 `maki.async.run({fn}, {on_finish?})` - Fire off a function as a new async task.
+- L693 `maki.async.await({argc}, {fn}, {...})` - Turn a callback-based function into a normal call you can use in a coroutine.
+- L711 `maki.async.wrap({argc}, {fn})` - Create a coroutine-friendly wrapper around a callback-based function.
+- L729 `maki.async.join({max_jobs}, {fns})` - Run all functions in {fns} with at most {max_jobs} going at once.
+- L748 `maki.async.gather({fns})` - Run all functions in {fns} at the same time and collect their results.
+- L775 `maki.async.semaphore({n})` - Create a counting semaphore that allows at most {n} concurrent permits.
 
-## maki.async.Semaphore - L795
-- L803 `Semaphore:acquire()` - Wait for a permit from the semaphore.
+## maki.async.Semaphore - L797
+- L805 `Semaphore:acquire()` - Wait for a permit from the semaphore.
 
-## maki.async.Permit - L820
-- L827 `Permit:release()` - Give the permit back to the semaphore so another task can acquire it.
+## maki.async.Permit - L822
+- L829 `Permit:release()` - Give the permit back to the semaphore so another task can acquire it.
 
-## maki.base64 - L833
-- L845 `maki.base64.encode({data})` - Encode {data} to standard Base64.
-- L862 `maki.base64.decode({str})` - Decode a Base64-encoded {str} back to its original bytes.
+## maki.base64 - L835
+- L847 `maki.base64.encode({data})` - Encode {data} to standard Base64.
+- L864 `maki.base64.decode({str})` - Decode a Base64-encoded {str} back to its original bytes.
 
-## maki.env - L880
-- L890 `maki.env.state_dir()` - Return the directory where maki stores runtime state (sessions, auth tokens, etc.).
-- L903 `maki.env.config_dir()` - Return the directory where maki looks for user configuration files.
-- L916 `maki.env.logs_dir()` - Return the directory where maki writes its log files (`maki.log`).
-- L929 `maki.env.legacy_dir()` - Return the legacy config path (`~/.maki`), if it exists on disk.
+## maki.env - L882
+- L892 `maki.env.state_dir()` - Return the directory where maki stores runtime state (sessions, auth tokens, etc.).
+- L905 `maki.env.config_dir()` - Return the directory where maki looks for user configuration files.
+- L918 `maki.env.logs_dir()` - Return the directory where maki writes its log files (`maki.log`).
+- L931 `maki.env.legacy_dir()` - Return the legacy config path (`~/.maki`), if it exists on disk.
 
-## maki.fn - L937
-- L952 `maki.fn.jobstart({cmd}, {opts?})` - Run a shell command in the background.
-- L980 `maki.fn.jobstop({job_id})` - Kill a running job immediately (SIGKILL on Unix).
-- L995 `maki.fn.jobwait({job_id}, {timeout_ms?})` - Wait for a job to finish and collect its output.
-- L1022 `maki.fn.executable({name})` - Check whether {name} can be found on `$PATH` or is an absolute path
+## maki.fn - L939
+- L954 `maki.fn.jobstart({cmd}, {opts?})` - Run a shell command in the background.
+- L982 `maki.fn.jobstop({job_id})` - Kill a running job immediately (SIGKILL on Unix).
+- L997 `maki.fn.jobwait({job_id}, {timeout_ms?})` - Wait for a job to finish and collect its output.
+- L1024 `maki.fn.executable({name})` - Check whether {name} can be found on `$PATH` or is an absolute path
 
-## maki.fs - L1043
-- L1055 `maki.fs.read({path})` - Read the entire file at {path} as a UTF-8 string.
-- L1077 `maki.fs.read_bytes({path})` - Read the entire file at {path} as raw bytes, returned as a Luau buffer.
-- L1096 `maki.fs.metadata({path})` - Get metadata for the file or directory at {path}.
-- L1117 `maki.fs.dirname({path})` - Return the parent directory of {path}.
-- L1133 `maki.fs.basename({path})` - Return the final component (the file name) of {path}.
-- L1149 `maki.fs.joinpath({...})` - Join one or more path segments into a single path.
-- L1165 `maki.fs.normalize({path})` - Clean up `.` and `..` segments and make {path} absolute.
-- L1182 `maki.fs.abspath({path})` - Make {path} absolute by prepending the current working directory when needed.
-- L1199 `maki.fs.parents({path})` - Return all ancestor directories of {path}, from the immediate parent up to the root.
-- L1217 `maki.fs.root({source}, {marker})` - Walk upward from {source} looking for a directory that contains one of the
-- L1237 `maki.fs.relpath({base}, {target})` - Compute a relative path from {base} to {target}.
-- L1254 `maki.fs.ext({path})` - Return the file extension of {path}, without the leading dot.
-- L1271 `maki.fs.dir({path}, {opts?})` - List the contents of the directory at {path}.
-- L1294 `maki.fs.write({path}, {content})` - Write {content} to the file at {path}, creating it if it does not exist
-- L1313 `maki.fs.rm({path})` - Delete the file at {path}.
-- L1330 `maki.fs.mkdir({path}, {opts?})` - Create the directory at {path}.
-- L1348 `maki.fs.glob({pattern}, {opts?})` - Find files matching one or more glob patterns.
-- L1369 `maki.fs.grep({pattern}, {opts?})` - Search file contents for a regex {pattern}.
+## maki.fs - L1045
+- L1057 `maki.fs.read({path})` - Read the entire file at {path} as a UTF-8 string.
+- L1079 `maki.fs.read_bytes({path})` - Read the entire file at {path} as raw bytes, returned as a Luau buffer.
+- L1098 `maki.fs.metadata({path})` - Get metadata for the file or directory at {path}.
+- L1119 `maki.fs.dirname({path})` - Return the parent directory of {path}.
+- L1135 `maki.fs.basename({path})` - Return the final component (the file name) of {path}.
+- L1151 `maki.fs.joinpath({...})` - Join one or more path segments into a single path.
+- L1167 `maki.fs.normalize({path})` - Clean up `.` and `..` segments and make {path} absolute.
+- L1184 `maki.fs.abspath({path})` - Make {path} absolute by prepending the current working directory when needed.
+- L1201 `maki.fs.parents({path})` - Return all ancestor directories of {path}, from the immediate parent up to the root.
+- L1219 `maki.fs.root({source}, {marker})` - Walk upward from {source} looking for a directory that contains one of the
+- L1239 `maki.fs.relpath({base}, {target})` - Compute a relative path from {base} to {target}.
+- L1256 `maki.fs.ext({path})` - Return the file extension of {path}, without the leading dot.
+- L1273 `maki.fs.dir({path}, {opts?})` - List the contents of the directory at {path}.
+- L1296 `maki.fs.write({path}, {content})` - Write {content} to the file at {path}, creating it if it does not exist
+- L1315 `maki.fs.rm({path})` - Delete the file at {path}.
+- L1332 `maki.fs.mkdir({path}, {opts?})` - Create the directory at {path}.
+- L1350 `maki.fs.glob({pattern}, {opts?})` - Find files matching one or more glob patterns.
+- L1371 `maki.fs.grep({pattern}, {opts?})` - Search file contents for a regex {pattern}.
 
-## maki.image - L1399
-- L1412 `maki.image.probe({data})` - Read image metadata (format, dimensions) from raw bytes without fully
-- L1435 `maki.image.decode({data})` - Decode raw image bytes into an Image handle you can resize and re-encode.
+## maki.image - L1401
+- L1414 `maki.image.probe({data})` - Read image metadata (format, dimensions) from raw bytes without fully
+- L1437 `maki.image.decode({data})` - Decode raw image bytes into an Image handle you can resize and re-encode.
 
-## maki.image.Image - L1455
-- L1462 `Image:width()` - Get the width of the image in pixels.
-- L1468 `Image:height()` - Get the height of the image in pixels.
-- L1474 `Image:resize({max_w}, {max_h})` - Shrink the image to fit inside {max_w} x {max_h}, keeping the aspect
-- L1494 `Image:encode({format})` - Encode the image into raw bytes in the given format.
+## maki.image.Image - L1457
+- L1464 `Image:width()` - Get the width of the image in pixels.
+- L1470 `Image:height()` - Get the height of the image in pixels.
+- L1476 `Image:resize({max_w}, {max_h})` - Shrink the image to fit inside {max_w} x {max_h}, keeping the aspect
+- L1496 `Image:encode({format})` - Encode the image into raw bytes in the given format.
 
-## maki.interpreter - L1513
-- L1529 `maki.interpreter.run({code}, {opts})` - Run Python code in a sandboxed interpreter with memory and time limits.
+## maki.interpreter - L1515
+- L1531 `maki.interpreter.run({code}, {opts})` - Run Python code in a sandboxed interpreter with memory and time limits.
 
-## maki.json - L1570
-- L1581 `maki.json.encode({value})` - Turn a Lua value into a JSON string.
-- L1600 `maki.json.decode({str})` - Parse a JSON string into a Lua value.
-- L1618 `maki.json.schema_validator({schema})` - Compile a JSON Schema into a reusable validator object.
+## maki.json - L1572
+- L1583 `maki.json.encode({value})` - Turn a Lua value into a JSON string.
+- L1602 `maki.json.decode({str})` - Parse a JSON string into a Lua value.
+- L1620 `maki.json.schema_validator({schema})` - Compile a JSON Schema into a reusable validator object.
 
-## maki.json.SchemaValidator - L1643
-- L1647 `SchemaValidator:validate({value})` - Check {value} against the compiled schema.
+## maki.json.SchemaValidator - L1645
+- L1649 `SchemaValidator:validate({value})` - Check {value} against the compiled schema.
 
-## maki.keymap - L1667
-- L1678 `maki.keymap.set({mode}, {lhs}, {rhs}, {opts?})` - Bind a key to a Lua function, just like `vim.keymap.set`.
-- L1700 `maki.keymap.del({mode}, {lhs})` - Remove the mapping for {lhs} in {mode}.
+## maki.keymap - L1669
+- L1680 `maki.keymap.set({mode}, {lhs}, {rhs}, {opts?})` - Bind a key to a Lua function, just like `vim.keymap.set`.
+- L1702 `maki.keymap.del({mode}, {lhs})` - Remove the mapping for {lhs} in {mode}.
 
-## maki.log - L1717
-- L1729 `maki.log.debug({msg})` - Emit a DEBUG-level log message.
-- L1744 `maki.log.info({msg})` - Emit an INFO-level log message.
-- L1758 `maki.log.warn({msg})` - Emit a WARN-level log message.
-- L1772 `maki.log.error({msg})` - Emit an ERROR-level log message.
+## maki.log - L1719
+- L1731 `maki.log.debug({msg})` - Emit a DEBUG-level log message.
+- L1746 `maki.log.info({msg})` - Emit an INFO-level log message.
+- L1760 `maki.log.warn({msg})` - Emit a WARN-level log message.
+- L1774 `maki.log.error({msg})` - Emit an ERROR-level log message.
 
-## maki.net - L1787
-- L1799 `maki.net.request({url}, {opts?})` - Make an HTTP request and return the response body.
+## maki.net - L1789
+- L1801 `maki.net.request({url}, {opts?})` - Make an HTTP request and return the response body.
 
-## maki.session - L1835
-- L1843 `maki.session.list()` - Lists sessions stored for the current project.
-- L1856 `maki.session.live()` - Lists the sessions currently running in this UI.
-- L1869 `maki.session.current()` - Returns the id of the currently focused session.
-- L1881 `maki.session.focus({id})` - Switches the UI to the session with {id}.
-- L1897 `maki.session.delete({id})` - Deletes a session and its stored history, cancelling it first if it
-- L1914 `maki.session.new({opts?})` - Starts a new session in the current project.
-- L1933 `maki.session.set_title({opts})` - Renames a session, live or stored.
+## maki.session - L1837
+- L1845 `maki.session.list()` - Lists sessions stored for the current project.
+- L1858 `maki.session.live()` - Lists the sessions currently running in this UI.
+- L1871 `maki.session.current()` - Returns the id of the currently focused session.
+- L1883 `maki.session.focus({id})` - Switches the UI to the session with {id}.
+- L1899 `maki.session.delete({id})` - Deletes a session and its stored history, cancelling it first if it
+- L1916 `maki.session.new({opts?})` - Starts a new session in the current project.
+- L1935 `maki.session.set_title({opts})` - Renames a session, live or stored.
 
-## maki.text - L1951
-- L1961 `maki.text.html_to_markdown({html})` - Convert an HTML string to Markdown.
+## maki.text - L1953
+- L1963 `maki.text.html_to_markdown({html})` - Convert an HTML string to Markdown.
 
-## maki.treesitter - L1981
-- L1995 `maki.treesitter.get_parser({source}, {lang})` - Creates a `LanguageTree` for {source} using the grammar named {lang}.
-- L2015 `maki.treesitter.get_string_parser({source}, {lang})` - Alias for `get_parser`.
-- L2026 `maki.treesitter.get_node_text({node}, {source})` - Gets the text that {node} covers in {source}.
-- L2045 `maki.treesitter.get_node_range({node})` - Returns the range of {node} as four 0-based integers: start_row, start_col, end_row, end_col.
-- L2061 `maki.treesitter.get_range({node})` - Returns a six-element table for {node}: `{start_row, start_col, start_byte, end_row, end_col, end_byte}`.
-- L2079 `maki.treesitter.is_ancestor({dest}, {source})` - Checks whether {dest} is an ancestor of {source} (or the same node).
-- L2091 `maki.treesitter.is_in_node_range({node}, {line}, {col})` - Checks whether the 0-based position ({line}, {col}) falls inside {node}.
-- L2104 `maki.treesitter.node_contains({node}, {range})` - Checks whether {node} fully contains the given {range}.
-- L2115 `maki.treesitter.get_node({opts?})` - Placeholder for cursor-based node lookup (not yet implemented, always returns nil).
+## maki.treesitter - L1983
+- L1997 `maki.treesitter.get_parser({source}, {lang})` - Creates a `LanguageTree` for {source} using the grammar named {lang}.
+- L2017 `maki.treesitter.get_string_parser({source}, {lang})` - Alias for `get_parser`.
+- L2028 `maki.treesitter.get_node_text({node}, {source})` - Gets the text that {node} covers in {source}.
+- L2047 `maki.treesitter.get_node_range({node})` - Returns the range of {node} as four 0-based integers: start_row, start_col, end_row, end_col.
+- L2063 `maki.treesitter.get_range({node})` - Returns a six-element table for {node}: `{start_row, start_col, start_byte, end_row, end_col, end_byte}`.
+- L2081 `maki.treesitter.is_ancestor({dest}, {source})` - Checks whether {dest} is an ancestor of {source} (or the same node).
+- L2093 `maki.treesitter.is_in_node_range({node}, {line}, {col})` - Checks whether the 0-based position ({line}, {col}) falls inside {node}.
+- L2106 `maki.treesitter.node_contains({node}, {range})` - Checks whether {node} fully contains the given {range}.
+- L2117 `maki.treesitter.get_node({opts?})` - Placeholder for cursor-based node lookup (not yet implemented, always returns nil).
 
-## maki.treesitter.language - L2126
-- L2138 `maki.treesitter.language.add({lang}, {opts?})` - Registers {lang} for use with tree-sitter.
-- L2155 `maki.treesitter.language.register({lang}, {filetype})` - Associates {lang} with one or more filetypes, so you can look up the right
-- L2171 `maki.treesitter.language.get_lang({filetype})` - Looks up the tree-sitter language name for {filetype}.
-- L2190 `maki.treesitter.language.get_filetypes({lang})` - Returns all filetypes that have been registered for {lang}.
-- L2207 `maki.treesitter.language.inspect({lang})` - Returns metadata about the grammar for {lang}.
+## maki.treesitter.language - L2128
+- L2140 `maki.treesitter.language.add({lang}, {opts?})` - Registers {lang} for use with tree-sitter.
+- L2157 `maki.treesitter.language.register({lang}, {filetype})` - Associates {lang} with one or more filetypes, so you can look up the right
+- L2173 `maki.treesitter.language.get_lang({filetype})` - Looks up the tree-sitter language name for {filetype}.
+- L2192 `maki.treesitter.language.get_filetypes({lang})` - Returns all filetypes that have been registered for {lang}.
+- L2209 `maki.treesitter.language.inspect({lang})` - Returns metadata about the grammar for {lang}.
 
-## maki.treesitter.query - L2227
-- L2238 `maki.treesitter.query.parse({lang}, {query})` - Compiles a tree-sitter query string for {lang}.
-- L2256 `maki.treesitter.query.get({lang}, {name})` - Looks up a named built-in query for {lang} (not yet implemented, always returns nil).
+## maki.treesitter.query - L2229
+- L2240 `maki.treesitter.query.parse({lang}, {query})` - Compiles a tree-sitter query string for {lang}.
+- L2258 `maki.treesitter.query.get({lang}, {name})` - Looks up a named built-in query for {lang} (not yet implemented, always returns nil).
 
-## maki.treesitter.Query - L2268
-- L2282 `Query:iter_captures({node}, {source}, {start_row?}, {stop_row?})` - Iterates over every capture matched by this query.
-- L2304 `Query:iter_matches({node}, {source}, {start_row?}, {stop_row?})` - Iterates over every full pattern match in this query.
+## maki.treesitter.Query - L2270
+- L2284 `Query:iter_captures({node}, {source}, {start_row?}, {stop_row?})` - Iterates over every capture matched by this query.
+- L2306 `Query:iter_matches({node}, {source}, {start_row?}, {stop_row?})` - Iterates over every full pattern match in this query.
 
-## maki.treesitter.Tree - L2330
-- L2342 `Tree:root()` - Returns the root node of this tree.
-- L2356 `Tree:copy()` - Returns an independent copy of this tree.
+## maki.treesitter.Tree - L2332
+- L2344 `Tree:root()` - Returns the root node of this tree.
+- L2358 `Tree:copy()` - Returns an independent copy of this tree.
 
-## maki.treesitter.Node - L2364
-- L2379 `Node:type()` - Returns the grammar type name for this node, like `"function_definition"` or `"identifier"`.
-- L2385 `Node:symbol()` - Returns the numeric symbol id for this node's grammar type.
-- L2392 `Node:id()` - Returns a unique string identifier for this specific node in the tree.
-- L2399 `Node:range({include_bytes?})` - Returns the range of this node as multiple return values.
-- L2418 `Node:start()` - Returns the start position of this node: row, column, and byte offset (all 0-based).
-- L2424 `Node:end_()` - Returns the end position of this node: row, column, and byte offset (all 0-based).
-- L2430 `Node:byte_length()` - Returns how many bytes this node spans in the source text.
-- L2436 `Node:child({index})` - Returns the child at position {index} (0-based), including anonymous nodes like punctuation.
-- L2447 `Node:named_child({index})` - Returns the named child at position {index} (0-based), skipping anonymous nodes.
-- L2458 `Node:child_count()` - Returns the total number of children, including anonymous nodes.
-- L2464 `Node:named_child_count()` - Returns the number of named children (skipping anonymous punctuation nodes).
-- L2470 `Node:children()` - Returns all children (named and anonymous) as a Lua table.
-- L2484 `Node:named_children()` - Returns all named children as a Lua table, skipping anonymous nodes.
-- L2490 `Node:iter_children()` - Returns an iterator function that yields `(child, field_name)` for every child.
-- L2505 `Node:field({name})` - Returns all children assigned to the grammar field {name} as a table.
-- L2522 `Node:parent()` - Returns the parent of this node, or nil if this is the root.
-- L2528 `Node:next_sibling()` - Returns the next sibling (named or anonymous), or nil if this is the last child.
-- L2534 `Node:prev_sibling()` - Returns the previous sibling (named or anonymous), or nil if this is the first child.
-- L2540 `Node:next_named_sibling()` - Returns the next named sibling, skipping anonymous nodes.
-- L2546 `Node:prev_named_sibling()` - Returns the previous named sibling, skipping anonymous nodes.
-- L2552 `Node:child_with_descendant({descendant})` - Finds the direct child of this node that contains {descendant}.
-- L2563 `Node:descendant_for_range({start_row}, {start_col}, {end_row}, {end_col})` - Finds the smallest node inside this node that spans the given point range.
-- L2577 `Node:named_descendant_for_range({start_row}, {start_col}, {end_row}, {end_col})` - Like `descendant_for_range`, but only considers named nodes.
-- L2590 `Node:named()` - Returns true if this is a named node (not anonymous punctuation like `,` or `(`).
-- L2596 `Node:extra()` - Returns true if this node is an "extra" (like a comment) that can appear anywhere in the grammar.
-- L2602 `Node:missing()` - Returns true if this node is "missing", meaning it was inserted by the parser during error recovery.
-- L2608 `Node:has_error()` - Returns true if this node or any of its descendants contain a syntax error.
-- L2614 `Node:has_changes()` - Returns true if this node has been marked as changed since the last parse.
-- L2620 `Node:equal({other})` - Returns true if this node and {other} are the same node in the tree.
-- L2630 `Node:sexpr()` - Returns the S-expression (lisp-like) string for this node and its children.
-- L2643 `Node:tree()` - Returns the Tree that this node belongs to.
+## maki.treesitter.Node - L2366
+- L2381 `Node:type()` - Returns the grammar type name for this node, like `"function_definition"` or `"identifier"`.
+- L2387 `Node:symbol()` - Returns the numeric symbol id for this node's grammar type.
+- L2394 `Node:id()` - Returns a unique string identifier for this specific node in the tree.
+- L2401 `Node:range({include_bytes?})` - Returns the range of this node as multiple return values.
+- L2420 `Node:start()` - Returns the start position of this node: row, column, and byte offset (all 0-based).
+- L2426 `Node:end_()` - Returns the end position of this node: row, column, and byte offset (all 0-based).
+- L2432 `Node:byte_length()` - Returns how many bytes this node spans in the source text.
+- L2438 `Node:child({index})` - Returns the child at position {index} (0-based), including anonymous nodes like punctuation.
+- L2449 `Node:named_child({index})` - Returns the named child at position {index} (0-based), skipping anonymous nodes.
+- L2460 `Node:child_count()` - Returns the total number of children, including anonymous nodes.
+- L2466 `Node:named_child_count()` - Returns the number of named children (skipping anonymous punctuation nodes).
+- L2472 `Node:children()` - Returns all children (named and anonymous) as a Lua table.
+- L2486 `Node:named_children()` - Returns all named children as a Lua table, skipping anonymous nodes.
+- L2492 `Node:iter_children()` - Returns an iterator function that yields `(child, field_name)` for every child.
+- L2507 `Node:field({name})` - Returns all children assigned to the grammar field {name} as a table.
+- L2524 `Node:parent()` - Returns the parent of this node, or nil if this is the root.
+- L2530 `Node:next_sibling()` - Returns the next sibling (named or anonymous), or nil if this is the last child.
+- L2536 `Node:prev_sibling()` - Returns the previous sibling (named or anonymous), or nil if this is the first child.
+- L2542 `Node:next_named_sibling()` - Returns the next named sibling, skipping anonymous nodes.
+- L2548 `Node:prev_named_sibling()` - Returns the previous named sibling, skipping anonymous nodes.
+- L2554 `Node:child_with_descendant({descendant})` - Finds the direct child of this node that contains {descendant}.
+- L2565 `Node:descendant_for_range({start_row}, {start_col}, {end_row}, {end_col})` - Finds the smallest node inside this node that spans the given point range.
+- L2579 `Node:named_descendant_for_range({start_row}, {start_col}, {end_row}, {end_col})` - Like `descendant_for_range`, but only considers named nodes.
+- L2592 `Node:named()` - Returns true if this is a named node (not anonymous punctuation like `,` or `(`).
+- L2598 `Node:extra()` - Returns true if this node is an "extra" (like a comment) that can appear anywhere in the grammar.
+- L2604 `Node:missing()` - Returns true if this node is "missing", meaning it was inserted by the parser during error recovery.
+- L2610 `Node:has_error()` - Returns true if this node or any of its descendants contain a syntax error.
+- L2616 `Node:has_changes()` - Returns true if this node has been marked as changed since the last parse.
+- L2622 `Node:equal({other})` - Returns true if this node and {other} are the same node in the tree.
+- L2632 `Node:sexpr()` - Returns the S-expression (lisp-like) string for this node and its children.
+- L2645 `Node:tree()` - Returns the Tree that this node belongs to.
 
-## maki.treesitter.LanguageTree - L2650
-- L2665 `LanguageTree:parse({range?})` - Parses the source and returns a table containing the resulting Tree.
-- L2683 `LanguageTree:lang()` - Returns the language name this parser was created with.
-- L2689 `LanguageTree:children()` - Returns child LanguageTrees for injected languages.
-- L2696 `LanguageTree:trees()` - Returns all parsed trees as a table (at most one for now).
-- L2703 `LanguageTree:source()` - Returns the source string this parser was created with.
-- L2709 `LanguageTree:is_valid({exclude_children?}, {range?})` - Checks whether the parse tree is still valid.
-- L2721 `LanguageTree:for_each_tree({fn})` - Calls {fn} with `(tree, nil)` for the parsed tree.
-- L2738 `LanguageTree:included_regions()` - Returns the regions this parser covers.
-- L2745 `LanguageTree:contains({range})` - Checks whether this parser covers the given {range}.
-- L2756 `LanguageTree:destroy()` - Drops the cached parse tree and frees its memory.
+## maki.treesitter.LanguageTree - L2652
+- L2667 `LanguageTree:parse({range?})` - Parses the source and returns a table containing the resulting Tree.
+- L2685 `LanguageTree:lang()` - Returns the language name this parser was created with.
+- L2691 `LanguageTree:children()` - Returns child LanguageTrees for injected languages.
+- L2698 `LanguageTree:trees()` - Returns all parsed trees as a table (at most one for now).
+- L2705 `LanguageTree:source()` - Returns the source string this parser was created with.
+- L2711 `LanguageTree:is_valid({exclude_children?}, {range?})` - Checks whether the parse tree is still valid.
+- L2723 `LanguageTree:for_each_tree({fn})` - Calls {fn} with `(tree, nil)` for the parsed tree.
+- L2740 `LanguageTree:included_regions()` - Returns the regions this parser covers.
+- L2747 `LanguageTree:contains({range})` - Checks whether this parser covers the given {range}.
+- L2758 `LanguageTree:destroy()` - Drops the cached parse tree and frees its memory.
 
-## maki.ui - L2762
-- L2774 `maki.ui.buf()` - Creates a new buffer for building UI content.
-- L2790 `maki.ui.theme_color({name})` - Looks up a semantic color from the current theme.
-- L2810 `maki.ui.highlight({code}, {lang}, {opts?})` - Syntax-highlights a chunk of source code.
-- L2835 `maki.ui.markdown({text}, {width})` - Renders Markdown into styled lines ready to display in a buffer.
-- L2859 `maki.ui.humantime({secs})` - Formats a number of seconds into a short, human-friendly string.
-- L2877 `maki.ui.terminal_size()` - Returns the current terminal size.
-- L2891 `maki.ui.flash({msg})` - Shows a brief message in the status bar.
-- L2907 `maki.ui.open_editor({path})` - Opens {path} in the user's `$EDITOR` (e.g.
-- L2928 `maki.ui.open_win({buf}, {opts})` - Opens a floating or split window that displays the contents of {buf}.
-- L2972 `maki.ui.set_status_hint({spans})` - Shows key hints in the status bar for your plugin.
+## maki.ui - L2764
+- L2776 `maki.ui.buf()` - Creates a new buffer for building UI content.
+- L2792 `maki.ui.theme_color({name})` - Looks up a semantic color from the current theme.
+- L2812 `maki.ui.highlight({code}, {lang}, {opts?})` - Syntax-highlights a chunk of source code.
+- L2837 `maki.ui.markdown({text}, {width})` - Renders Markdown into styled lines ready to display in a buffer.
+- L2861 `maki.ui.humantime({secs})` - Formats a number of seconds into a short, human-friendly string.
+- L2879 `maki.ui.terminal_size()` - Returns the current terminal size.
+- L2893 `maki.ui.flash({msg})` - Shows a brief message in the status bar.
+- L2909 `maki.ui.open_editor({path})` - Opens {path} in the user's `$EDITOR` (e.g.
+- L2930 `maki.ui.open_win({buf}, {opts})` - Opens a floating or split window that displays the contents of {buf}.
+- L2974 `maki.ui.set_status_hint({spans})` - Shows key hints in the status bar for your plugin.
 
-## maki.ui.Win - L2989
-- L3007 `Win:recv({timeout_ms?})` - Waits for the next event from this window.
-- L3037 `Win:set_config({opts})` - Updates the window layout on the fly.
-- L3064 `Win:set_cursor({row})` - Moves the highlighted cursor line to {row} (1-indexed).
-- L3079 `Win:close()` - Closes the window and frees its resources.
-- L3091 `Win:is_open()` - Returns true if the window is still alive (not closed).
-- L3106 `Win:show()` - Makes the window visible again after it was hidden with `hide()`.
-- L3116 `Win:hide()` - Hides the window without closing it.
-- L3129 `Win:is_visible()` - Returns true if the window is both open and visible (not hidden).
+## maki.ui.Win - L2991
+- L3009 `Win:recv({timeout_ms?})` - Waits for the next event from this window.
+- L3039 `Win:set_config({opts})` - Updates the window layout on the fly.
+- L3066 `Win:set_cursor({row})` - Moves the highlighted cursor line to {row} (1-indexed).
+- L3081 `Win:close()` - Closes the window and frees its resources.
+- L3093 `Win:is_open()` - Returns true if the window is still alive (not closed).
+- L3108 `Win:show()` - Makes the window visible again after it was hidden with `hide()`.
+- L3118 `Win:hide()` - Hides the window without closing it.
+- L3131 `Win:is_visible()` - Returns true if the window is both open and visible (not hidden).
 
-## maki.ui.Buf - L3136
-- L3148 `Buf:line({line})` - Appends a single line to the end of the buffer.
-- L3167 `Buf:lines({lines})` - Appends several lines at once.
-- L3186 `Buf:set_lines({lines})` - Replaces every line in the buffer with {lines}.
-- L3202 `Buf:len()` - Returns how many lines the buffer currently holds.
-- L3216 `Buf:get_lines()` - Returns all lines in the buffer as a Lua table.
-- L3232 `Buf:on({event}, {callback})` - Registers an event handler on the buffer.
-- L3257 `Buf:click({ev})` - Programmatically fires the buffer's click handler with event {ev}.
-- L3273 `Buf:blit({fb}, {width}, {height}, {opts?})` - Replaces the whole buffer with a pixel frame drawn as `"▀"` cells.
+## maki.ui.Buf - L3138
+- L3150 `Buf:line({line})` - Appends a single line to the end of the buffer.
+- L3169 `Buf:lines({lines})` - Appends several lines at once.
+- L3188 `Buf:set_lines({lines})` - Replaces every line in the buffer with {lines}.
+- L3204 `Buf:len()` - Returns how many lines the buffer currently holds.
+- L3218 `Buf:get_lines()` - Returns all lines in the buffer as a Lua table.
+- L3234 `Buf:on({event}, {callback})` - Registers an event handler on the buffer.
+- L3259 `Buf:click({ev})` - Programmatically fires the buffer's click handler with event {ev}.
+- L3275 `Buf:blit({fb}, {width}, {height}, {opts?})` - Replaces the whole buffer with a pixel frame drawn as `"▀"` cells.
 
-## maki.uv - L3314
-- L3325 `maki.uv.cwd()` - Return the current working directory as an absolute path.
-- L3338 `maki.uv.os_homedir()` - Return the current user's home directory.
-- L3350 `maki.uv.os_getenv({name})` - Look up the environment variable {name}.
+## maki.uv - L3316
+- L3327 `maki.uv.cwd()` - Return the current working directory as an absolute path.
+- L3340 `maki.uv.os_homedir()` - Return the current user's home directory.
+- L3352 `maki.uv.os_getenv({name})` - Look up the environment variable {name}.
 
-## maki.yaml - L3368
-- L3378 `maki.yaml.encode({value})` - Turn a Lua value into a YAML string.
-- L3396 `maki.yaml.decode({str})` - Parse a YAML string into a Lua value.
+## maki.yaml - L3370
+- L3380 `maki.yaml.encode({value})` - Turn a Lua value into a YAML string.
+- L3398 `maki.yaml.decode({str})` - Parse a YAML string into a Lua value.
 
-## Shared helper modules - L3417
-- L3422 `require("maki.color")`
-- L3449 `require("maki.fuzzy_replace")`
-- L3462 `require("maki.list_picker")` - Open a fuzzy-filter picker in a floating window and block until the user
-- L3476 `require("maki.output_limits")` - Shared per-tool output limit options, so the tools that support them
-- L3508 `require("maki.shorten_path")`
-- L3539 `require("maki.text_input")` - TextInput: multi-line editable buffer with a byte-offset cursor.
-- L3597 `require("maki.tool_view")` - The shared truncate/expand body that tool plugins render through.
-- L3635 `require("maki.truncate")`
+## Shared helper modules - L3419
+- L3424 `require("maki.color")`
+- L3451 `require("maki.fuzzy_replace")`
+- L3464 `require("maki.list_picker")` - Open a fuzzy-filter picker in a floating window and block until the user
+- L3478 `require("maki.output_limits")` - Shared per-tool output limit options, so the tools that support them
+- L3510 `require("maki.shorten_path")`
+- L3541 `require("maki.text_input")` - TextInput: multi-line editable buffer with a byte-offset cursor.
+- L3599 `require("maki.tool_view")` - The shared truncate/expand body that tool plugins render through.
+- L3637 `require("maki.truncate")`
 ]=],
 }

--- a/plugins/skill/plugin_dev_reference.lua
+++ b/plugins/skill/plugin_dev_reference.lua
@@ -594,8 +594,10 @@ and tool set.
     `(string)` or `(nil, err)`.
   - `name` (`string?`) display name for logs and UI.
   - `audience` (`string?`) tool audience for capability gating. Default: `"general_sub"`.
-  - `thinking` (`string|integer?`) thinking mode: `"off"`, `"adaptive"`, or a
-    budget integer (token count). Inherits parent setting if omitted.
+  - `thinking` (`string|integer?`) thinking mode: `"off"`, `"adaptive"`, an
+    effort level (`"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`,
+    `"max"`), or a budget integer (token count). Inherits parent setting
+    if omitted.
   - `fast` (`boolean?`) use fast mode. Inherits parent setting if omitted.
 
 **Returns:** (`Session?`, `string?`) Session handle, or `(nil, err)` on failure.

--- a/site/docs/content/commands/_index.md
+++ b/site/docs/content/commands/_index.md
@@ -26,7 +26,7 @@ Type `/` in the input box to open the command palette.
 | `/cd` | Change working directory |
 | `/btw` | Ask a quick question (no tools, no history pollution) |
 | `/yolo` | Toggle YOLO mode (skip all permission prompts) |
-| `/thinking` | Toggle extended thinking (off, adaptive, or budget) |
+| `/thinking` | Toggle extended thinking (off, adaptive, effort level, or budget) |
 | `/fast` | Toggle Anthropic fast mode (Opus only) |
 | `/workflow` | Toggle workflow mode (task callable inside code_execution) |
 | `/exit` | Exit the application |

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -57,7 +57,7 @@ All fields are optional. Typos in field names cause an error right away.
 | `always_yolo` | bool | `false` | Start every session with YOLO mode (skip permission prompts, deny rules still apply) |
 | `always_fast` | bool | `false` | Start every session with Anthropic fast mode (Opus only; ignored otherwise) |
 | `always_workflow` | bool | `false` | Start every session with workflow mode (task callable inside code_execution) |
-| `always_thinking` | bool \| string | `false` | Start every session with extended thinking (true/"adaptive", "off", or a token budget) |
+| `always_thinking` | bool \| string | `false` | Start every session with extended thinking (true/"adaptive", "off", an effort level ("minimal" to "max"), or a token budget) |
 
 ### `ui`
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -789,8 +789,10 @@ and tool set.
     `(string)` or `(nil, err)`.
   - `name` (`string?`) display name for logs and UI.
   - `audience` (`string?`) tool audience for capability gating. Default: `"general_sub"`.
-  - `thinking` (`string|integer?`) thinking mode: `"off"`, `"adaptive"`, or a
-    budget integer (token count). Inherits parent setting if omitted.
+  - `thinking` (`string|integer?`) thinking mode: `"off"`, `"adaptive"`, an
+    effort level (`"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`,
+    `"max"`), or a budget integer (token count). Inherits parent setting
+    if omitted.
   - `fast` (`boolean?`) use fast mode. Inherits parent setting if omitted.
 
 **Returns:** ([`Session?`](#maki-agent-Session), `string?`) Session handle, or `(nil, err)` on failure.


### PR DESCRIPTION
Effort handling was scattered: hardcoded 2048/8192 budget thresholds, a GLM xhigh cutoff, OpenRouter's private effort ordering and DeepSeek's inline `"max"`, each free to drift on its own.

There is now a single `Effort` enum (`minimal` to `max`, each a percentage of the model's max thinking budget) and two pure resolvers on `ThinkingConfig`: providers with a native effort knob get a string snapped to their dialect's supported levels, budget-token APIs get `percent * max` clamped to `[1024, max]`, so providers shrink to one-line serializers.

The max comes from `Model::max_thinking_budget()` (half the output window), which makes budget-to-effort mapping model-relative instead of absolute, and only Google caps it further per its documented limits.

Effort names are accepted everywhere a thinking setting goes: `/thinking high`, `always_thinking` config, the Lua `thinking` param and session persistence, all through the one `parse_setting` parser.

Closes #388.