### PR TITLE
fix(sessions): keep the time label aligned when a title has newlines

### DIFF
--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -333,9 +333,10 @@ pub fn generate_title<M: TitleSource>(messages: &[M]) -> String {
     let Some(text) = first_user_text.map(str::trim).filter(|t| !t.is_empty()) else {
         return DEFAULT_TITLE.into();
     };
+    let text = text.split_whitespace().collect::<Vec<_>>().join(" ");
 
     if text.len() <= MAX_TITLE_LEN {
-        return text.to_string();
+        return text;
     }
 
     let boundary = text.floor_char_boundary(MAX_TITLE_LEN);
@@ -1758,6 +1759,11 @@ mod tests {
         "This is a very long title that exceeds the sixty character limit and should be truncated at a word boundary",
         "This is a very long title that exceeds the sixty character…"
         ; "long_truncates_at_word"
+    )]
+    #[test_case(
+        "added:\n\n```\nmaki.api.register_command({\n  name = \"/standup\"",
+        "added: ``` maki.api.register_command({ name = \"/standup\""
+        ; "newlines_collapse_to_spaces"
     )]
     fn title_extraction(input: &str, expected: &str) {
         let messages: Vec<Value> = if input.is_empty() {

--- a/plugins/sessions/init.lua
+++ b/plugins/sessions/init.lua
@@ -240,6 +240,7 @@ local function refresh()
   end
   board.counts = { needs_input = 0, working = 0 }
   for _, s in ipairs(all) do
+    s.title = s.title:gsub("%s+", " ")
     if board.counts[s.status] then
       board.counts[s.status] = board.counts[s.status] + 1
     end


### PR DESCRIPTION
Session titles come from the first user message, so pasting a code block bakes real `\n` characters into the title.

The terminal renders `\n` as zero cells, but the picker measures width with `utf8.len` which counts it as one, so the padding overshoots and the right side time label drifts left on exactly those rows.

`generate_title` now collapses whitespace runs into single spaces, and the `/sessions` refresh does the same `gsub` so titles already persisted in `meta` records get fixed too.