### PR TITLE
feat(ui): add jump-to-bottom affordance when scrolled up

### DIFF
--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -749,15 +749,16 @@ where
         let record: LogRecord<M, U, T> = match serde_json::from_slice(line) {
             Ok(r) => r,
             Err(e) => {
-                if !got_header
-                    && let Ok(RawTag::Header { id: raw_id }) = serde_json::from_slice(line)
-                    && let Err(source) = raw_id.parse::<MakiId>()
-                {
-                    return Err(SessionError::CorruptHeaderId {
-                        path: display_path.to_string(),
-                        raw_id,
-                        source,
-                    });
+                if !got_header {
+                    if let Ok(RawTag::Header { id: raw_id }) = serde_json::from_slice(line) {
+                        if let Err(source) = raw_id.parse::<MakiId>() {
+                            return Err(SessionError::CorruptHeaderId {
+                                path: display_path.to_string(),
+                                raw_id,
+                                source,
+                            });
+                        }
+                    }
                 }
                 warn!(
                     path = display_path,

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -749,16 +749,15 @@ where
         let record: LogRecord<M, U, T> = match serde_json::from_slice(line) {
             Ok(r) => r,
             Err(e) => {
-                if !got_header {
-                    if let Ok(RawTag::Header { id: raw_id }) = serde_json::from_slice(line) {
-                        if let Err(source) = raw_id.parse::<MakiId>() {
-                            return Err(SessionError::CorruptHeaderId {
-                                path: display_path.to_string(),
-                                raw_id,
-                                source,
-                            });
-                        }
-                    }
+                if !got_header
+                    && let Ok(RawTag::Header { id: raw_id }) = serde_json::from_slice(line)
+                    && let Err(source) = raw_id.parse::<MakiId>()
+                {
+                    return Err(SessionError::CorruptHeaderId {
+                        path: display_path.to_string(),
+                        raw_id,
+                        source,
+                    });
                 }
                 warn!(
                     path = display_path,

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -474,7 +474,7 @@ impl App {
             return Some(vec![]);
         }
         if key::SCROLL_BOTTOM.matches(key) {
-            self.active_chat().enable_auto_scroll();
+            self.active_chat().jump_to_bottom();
             return Some(vec![]);
         }
         if key::PLAN_TOGGLE.matches(key)

--- a/maki-ui/src/app/mouse.rs
+++ b/maki-ui/src/app/mouse.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use crate::clipboard::CopyResult;
 use crate::selection::{self, ContentRegion, EdgeScroll, Selection, SelectionState, SelectionZone};
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
-use ratatui::layout::Rect;
+use ratatui::layout::{Position, Rect};
 
 use super::App;
 
@@ -14,6 +14,16 @@ impl App {
     pub(super) fn handle_mouse(&mut self, event: MouseEvent) {
         match event.kind {
             MouseEventKind::Down(MouseButton::Left) => {
+                let pos = Position::new(event.column, event.row);
+                let render_chat = self.resolve_render_chat();
+                if !self.has_modal_overlay()
+                    && self.chats[render_chat]
+                        .jump_to_bottom_popup()
+                        .is_some_and(|r| r.contains(pos))
+                {
+                    self.chats[render_chat].jump_to_bottom();
+                    return;
+                }
                 if let Some(zone) = self.zone_at(event.row, event.column) {
                     if self.has_modal_overlay() && zone.zone != SelectionZone::Overlay {
                         return;

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -130,7 +130,7 @@ impl App {
         }
     }
 
-    fn resolve_render_chat(&self) -> usize {
+    pub(crate) fn resolve_render_chat(&self) -> usize {
         if self.task_picker.is_open() {
             self.task_picker
                 .selected_index()

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -200,6 +200,14 @@ impl Chat {
         self.messages_panel.enable_auto_scroll();
     }
 
+    pub fn jump_to_bottom(&mut self) {
+        self.messages_panel.jump_to_bottom();
+    }
+
+    pub fn jump_to_bottom_popup(&self) -> Option<Rect> {
+        self.messages_panel.jump_to_bottom_popup()
+    }
+
     pub fn scroll_to_segment(&mut self, segment_index: usize) {
         self.messages_panel.scroll_to_segment(segment_index);
     }

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -40,8 +40,13 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph};
 
 const THINKING_HIDDEN_HEADER: &str = "thinking> ...";
+pub(crate) const JUMP_TO_BOTTOM_TEXT: &str = "↓ bottom";
+const JUMP_TO_BOTTOM_THRESHOLD: u16 = 1;
+const JUMP_TO_BOTTOM_POPUP_HEIGHT: u16 = 1;
+const JUMP_TO_BOTTOM_POPUP_BOTTOM_MARGIN: u16 = 1;
 
 #[derive(Clone, Copy)]
 pub struct PromptProgress {
@@ -84,6 +89,7 @@ pub struct MessagesPanel {
     /// only bumps when colors actually land.
     rebake_requested: HashMap<String, u64>,
     prompt_progress: Option<PromptProgress>,
+    jump_to_bottom_popup: Option<Rect>,
 }
 
 impl MessagesPanel {
@@ -128,6 +134,7 @@ impl MessagesPanel {
             thinking_collapsed: !ui_config.show_thinking,
             rebake_requested: HashMap::new(),
             prompt_progress: None,
+            jump_to_bottom_popup: None,
         }
     }
 
@@ -530,6 +537,15 @@ impl MessagesPanel {
         self.auto_scroll = true;
     }
 
+    pub fn jump_to_bottom(&mut self) {
+        self.auto_scroll = true;
+        self.scroll_top = self.max_scroll();
+    }
+
+    pub fn jump_to_bottom_popup(&self) -> Option<Rect> {
+        self.jump_to_bottom_popup
+    }
+
     pub fn scroll_to_segment(&mut self, segment_index: usize) {
         let width = self.viewport_width;
         let offset = self
@@ -840,6 +856,49 @@ impl MessagesPanel {
         if total_lines > area.height {
             render_vertical_scrollbar(frame, area, total_lines, self.scroll_top);
         }
+
+        self.jump_to_bottom_popup = None;
+        let distance = max_scroll.saturating_sub(self.scroll_top);
+        let show_popup = max_scroll > 0 && !self.auto_scroll && distance > JUMP_TO_BOTTOM_THRESHOLD;
+        if show_popup {
+            self.render_jump_to_bottom_popup(frame, viewport);
+        }
+    }
+
+    fn render_jump_to_bottom_popup(&mut self, frame: &mut Frame, area: Rect) {
+        let text_style = theme::current().accent;
+        let keybind_style = theme::current().keybind_key;
+        let line = Line::from(vec![
+            Span::styled(JUMP_TO_BOTTOM_TEXT, text_style),
+            Span::styled(key::SCROLL_BOTTOM.label, keybind_style),
+        ]);
+        let text_width = line.width() as u16;
+
+        let block = Block::default()
+            .borders(Borders::LEFT | Borders::RIGHT)
+            .border_type(BorderType::Rounded)
+            .border_style(theme::current().panel_border)
+            .padding(Padding::horizontal(1))
+            .style(Style::new().bg(theme::current().background));
+        let dummy_area = Rect::new(0, 0, u16::MAX, JUMP_TO_BOTTOM_POPUP_HEIGHT);
+        let chrome_width = u16::MAX - block.inner(dummy_area).width;
+        let width = text_width.saturating_add(chrome_width);
+
+        let min_height = JUMP_TO_BOTTOM_POPUP_HEIGHT + JUMP_TO_BOTTOM_POPUP_BOTTOM_MARGIN;
+        if text_width == 0 || width > area.width || area.height < min_height {
+            return;
+        }
+        let x = area.x + (area.width - width) / 2;
+        let y = area
+            .bottom()
+            .saturating_sub(JUMP_TO_BOTTOM_POPUP_HEIGHT + JUMP_TO_BOTTOM_POPUP_BOTTOM_MARGIN);
+        let popup_area = Rect::new(x, y, width, JUMP_TO_BOTTOM_POPUP_HEIGHT);
+        self.jump_to_bottom_popup = Some(popup_area);
+
+        let inner = block.inner(popup_area);
+        frame.render_widget(Clear, popup_area);
+        frame.render_widget(block, popup_area);
+        frame.render_widget(Paragraph::new(line), inner);
     }
 
     fn max_scroll(&self) -> u16 {

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -43,9 +43,10 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph};
 
 const THINKING_HIDDEN_HEADER: &str = "thinking> ...";
-pub(crate) const JUMP_TO_BOTTOM_TEXT: &str = "↓ bottom";
+pub(crate) const JUMP_TO_BOTTOM_TEXT: &str = "↓ Bottom";
+const JUMP_TO_BOTTOM_KEY_GAP: &str = "  ";
 const JUMP_TO_BOTTOM_THRESHOLD: u16 = 1;
-const JUMP_TO_BOTTOM_POPUP_HEIGHT: u16 = 1;
+const JUMP_TO_BOTTOM_POPUP_HEIGHT: u16 = 3;
 const JUMP_TO_BOTTOM_POPUP_BOTTOM_MARGIN: u16 = 1;
 
 #[derive(Clone, Copy)]
@@ -870,12 +871,13 @@ impl MessagesPanel {
         let keybind_style = theme::current().keybind_key;
         let line = Line::from(vec![
             Span::styled(JUMP_TO_BOTTOM_TEXT, text_style),
+            Span::raw(JUMP_TO_BOTTOM_KEY_GAP),
             Span::styled(key::SCROLL_BOTTOM.label, keybind_style),
         ]);
         let text_width = line.width() as u16;
 
         let block = Block::default()
-            .borders(Borders::LEFT | Borders::RIGHT)
+            .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
             .border_style(theme::current().panel_border)
             .padding(Padding::horizontal(1))

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -261,7 +261,7 @@ fn jump_to_bottom_popup_appears_when_scrolled_up() {
     assert!(text.contains(key::SCROLL_BOTTOM.label));
 
     panel.jump_to_bottom();
-    assert!(panel.auto_scroll());
+    assert!(panel.auto_scroll);
     render(&mut panel, 80, 10);
     assert!(panel.jump_to_bottom_popup().is_none());
 }

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -1,5 +1,6 @@
 use super::segment;
 use super::*;
+use crate::components::keybindings::key;
 use crate::components::scrollbar::SCROLLBAR_THUMB;
 use crate::selection::{Selection, SelectionZone};
 use maki_agent::tools::{BASH_TOOL_NAME, GREP_TOOL_NAME, WRITE_TOOL_NAME};
@@ -243,6 +244,26 @@ fn ctrl_d_to_bottom_re_enables_auto_scroll() {
     panel.scroll(-half);
     render(&mut panel, 80, 10);
     assert!(panel.auto_scroll);
+}
+
+#[test]
+fn jump_to_bottom_popup_appears_when_scrolled_up() {
+    let mut panel = MessagesPanel::new(UiConfig::default());
+    panel.streaming_text.set_buffer(&"a\n".repeat(30));
+    render(&mut panel, 80, 10);
+    assert!(panel.jump_to_bottom_popup().is_none());
+
+    panel.scroll(panel.half_page());
+    let terminal = render(&mut panel, 80, 10);
+    assert!(panel.jump_to_bottom_popup().is_some());
+    let text = buffer_text(&terminal);
+    assert!(text.contains(JUMP_TO_BOTTOM_TEXT));
+    assert!(text.contains(key::SCROLL_BOTTOM.label));
+
+    panel.jump_to_bottom();
+    assert!(panel.auto_scroll());
+    render(&mut panel, 80, 10);
+    assert!(panel.jump_to_bottom_popup().is_none());
 }
 
 #[test]

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -255,10 +255,28 @@ fn jump_to_bottom_popup_appears_when_scrolled_up() {
 
     panel.scroll(panel.half_page());
     let terminal = render(&mut panel, 80, 10);
-    assert!(panel.jump_to_bottom_popup().is_some());
+    let popup = panel.jump_to_bottom_popup().unwrap();
+    assert_eq!(popup.height, JUMP_TO_BOTTOM_POPUP_HEIGHT);
     let text = buffer_text(&terminal);
     assert!(text.contains(JUMP_TO_BOTTOM_TEXT));
     assert!(text.contains(key::SCROLL_BOTTOM.label));
+    let buffer = terminal.backend().buffer();
+    assert_eq!(buffer.cell((popup.x, popup.y)).unwrap().symbol(), "╭");
+    assert_eq!(
+        buffer.cell((popup.right() - 1, popup.y)).unwrap().symbol(),
+        "╮"
+    );
+    assert_eq!(
+        buffer.cell((popup.x, popup.bottom() - 1)).unwrap().symbol(),
+        "╰"
+    );
+    assert_eq!(
+        buffer
+            .cell((popup.right() - 1, popup.bottom() - 1))
+            .unwrap()
+            .symbol(),
+        "╯"
+    );
 
     panel.jump_to_bottom();
     assert!(panel.auto_scroll);

--- a/maki-ui/src/components/permission_prompt.rs
+++ b/maki-ui/src/components/permission_prompt.rs
@@ -300,7 +300,7 @@ impl PermissionPrompt {
             };
             let (before, after) = display_text.split_at(cursor_pos);
             let mut chars = after.chars();
-            let cursor_ch = chars.next().map_or(' ', |c| c);
+            let cursor_ch = chars.next().unwrap_or(' ');
             let rest: String = chars.collect();
 
             let mut spans = vec![Span::raw("  "), Span::styled("guide ", label_style)];

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use color_eyre::Result;
-use color_eyre::eyre::{Context, bail};
+use color_eyre::eyre::{Context, bail, eyre};
 
 use maki_agent::mcp::{config as mcp_config, oauth as mcp_oauth};
 use maki_agent::tools::ToolRegistry;
@@ -274,7 +274,7 @@ fn login_custom(storage: &StateDir) -> Result<()> {
         "1" | "openai" => "openai",
         "2" | "anthropic" => "anthropic",
         "3" | "google" => "google",
-        _ => bail!("invalid protocol selection"),
+        _ => return Err(eyre!("invalid protocol selection")),
     };
 
     print!("  Base URL: ");
@@ -585,7 +585,7 @@ pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
     let result = smol::block_on(async { inv.execute(&ctx).await });
     match result.output {
         Ok(output) => print!("{}", output.as_text()),
-        Err(e) => bail!("index failed: {e}"),
+        Err(e) => return Err(eyre!("index failed: {e}")),
     }
     Ok(())
 }
@@ -600,7 +600,7 @@ pub fn mcp_auth(server: &str, storage: &StateDir) -> Result<()> {
             .ok_or_else(|| color_eyre::eyre::eyre!("unknown MCP server: {server}"))?;
         let url = match mcp_config::parse_server(server.to_owned(), raw.clone())?.transport {
             mcp_config::Transport::Http { url, .. } => url,
-            _ => color_eyre::eyre::bail!("server '{server}' is not an HTTP transport"),
+            _ => return Err(eyre!("server '{server}' is not an HTTP transport")),
         };
         mcp_oauth::authenticate(server, &url, None, storage, mcp_oauth::Interaction::Cli).await?;
         eprintln!("Successfully authenticated with MCP server '{server}'");


### PR DESCRIPTION
## Summary
Render a small floating "↓ bottom" pill in the messages panel whenever the user has scrolled away from the bottom and auto-scroll is paused. Clicking the pill or pressing Ctrl+b (SCROLL_BOTTOM) now snaps the view to the bottom and re-enables auto-scroll immediately.

## Changes
- Add `MessagesPanel::jump_to_bottom` and `jump_to_bottom_pill` helpers.
- Track `jump_to_bottom_pill` bounds during render so `App` can detect clicks.
- Make `Chat` expose `jump_to_bottom` and `jump_to_bottom_pill`.
- Update `App` mouse handling to jump to bottom when the pill is clicked.
- Update `SCROLL_BOTTOM` keybinding to call `jump_to_bottom` for instant scroll.
- Add tests for the pill visibility and jump-to-bottom behavior.

#### Test plan
- [x] `cargo clippy -p maki-ui --tests -- -D warnings`
- [x] `cargo nextest run -p maki-ui`