### PR TITLE
feat(ui): show a working indicator while the model is active

### DIFF
--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -148,8 +148,15 @@ impl App {
 
     fn render_messages(&mut self, frame: &mut Frame, layout: &ViewLayout, render_chat: usize) {
         let accent = self.effective_mode_color();
+        let is_working = (self.status == Status::Streaming && render_chat == 0)
+            || self.chats[render_chat].is_working();
         self.chats[render_chat].set_accent(accent);
-        self.chats[render_chat].view(frame, layout.msg_area, self.selection_state.is_some());
+        self.chats[render_chat].view(
+            frame,
+            layout.msg_area,
+            self.selection_state.is_some(),
+            is_working,
+        );
     }
 
     fn render_bottom_panel(&mut self, frame: &mut Frame, layout: &ViewLayout) {

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -220,8 +220,13 @@ impl Chat {
         self.messages_panel.is_animating()
     }
 
-    pub fn view(&mut self, frame: &mut Frame, area: Rect, has_selection: bool) {
-        self.messages_panel.view(frame, area, has_selection);
+    pub fn is_working(&self) -> bool {
+        self.messages_panel.is_working()
+    }
+
+    pub fn view(&mut self, frame: &mut Frame, area: Rect, has_selection: bool, is_working: bool) {
+        self.messages_panel
+            .view(frame, area, has_selection, is_working);
     }
 
     pub fn scroll_top(&self) -> u16 {

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -37,9 +37,10 @@ use maki_agent::{
 use maki_lua::{EventHandle, WARM_TOOL_CAP};
 
 use ratatui::Frame;
-use ratatui::layout::Rect;
+use ratatui::layout::{Alignment, Rect};
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
+use ratatui::widgets::{Paragraph, Widget};
 
 const THINKING_HIDDEN_HEADER: &str = "thinking> ...";
 
@@ -84,6 +85,8 @@ pub struct MessagesPanel {
     /// only bumps when colors actually land.
     rebake_requested: HashMap<String, u64>,
     prompt_progress: Option<PromptProgress>,
+    working_start: Instant,
+    was_working: bool,
 }
 
 impl MessagesPanel {
@@ -128,6 +131,8 @@ impl MessagesPanel {
             thinking_collapsed: !ui_config.show_thinking,
             rebake_requested: HashMap::new(),
             prompt_progress: None,
+            working_start: Instant::now(),
+            was_working: false,
         }
     }
 
@@ -427,6 +432,13 @@ impl MessagesPanel {
             .count()
     }
 
+    pub fn is_working(&self) -> bool {
+        self.in_progress_count() > 0
+            || self.streaming_thinking.is_animating()
+            || self.streaming_text.is_animating()
+            || !self.live_bufs.is_empty()
+    }
+
     #[cfg(test)]
     pub fn toggle_expansion(&mut self, tool_id: &str) -> bool {
         let Some(seg) = self
@@ -684,7 +696,12 @@ impl MessagesPanel {
             && self.streaming_text.is_empty()
     }
 
-    pub fn view(&mut self, frame: &mut Frame, area: Rect, has_selection: bool) {
+    pub fn view(&mut self, frame: &mut Frame, area: Rect, has_selection: bool, is_working: bool) {
+        if is_working && !self.was_working {
+            self.working_start = Instant::now();
+        }
+        self.was_working = is_working;
+
         self.viewport_height = area.height;
         let width = area.width.saturating_sub(1);
         let theme_gen = theme::generation();
@@ -840,6 +857,30 @@ impl MessagesPanel {
         if total_lines > area.height {
             render_vertical_scrollbar(frame, area, total_lines, self.scroll_top);
         }
+
+        if is_working {
+            self.render_working_indicator(frame, viewport);
+        }
+    }
+
+    fn render_working_indicator(&self, frame: &mut Frame, area: Rect) {
+        let elapsed = self.working_start.elapsed().as_millis();
+        let spinner = spinner_str(elapsed);
+        let style = theme::current().spinner;
+        let line = Line::from(vec![
+            Span::styled(spinner, style),
+            Span::styled(" thinking...", style),
+        ]);
+        let width = line.width() as u16;
+        if width == 0 || width > area.width || area.height == 0 {
+            return;
+        }
+        let x = area.right().saturating_sub(width);
+        let y = area.bottom().saturating_sub(1);
+        let pill_area = Rect::new(x, y, width, 1);
+        Paragraph::new(line)
+            .alignment(Alignment::Right)
+            .render(pill_area, frame.buffer_mut());
     }
 
     fn max_scroll(&self) -> u16 {

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -214,7 +214,7 @@ fn render_sel(
     let mut terminal = ratatui::Terminal::new(backend).unwrap();
     terminal
         .draw(|f| {
-            panel.view(f, f.area(), has_selection);
+            panel.view(f, f.area(), has_selection, false);
         })
         .unwrap();
     terminal
@@ -224,8 +224,39 @@ fn render(panel: &mut MessagesPanel, width: u16, height: u16) -> ratatui::Termin
     render_sel(panel, width, height, false)
 }
 
+fn render_working(
+    panel: &mut MessagesPanel,
+    width: u16,
+    height: u16,
+) -> ratatui::Terminal<TestBackend> {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = ratatui::Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            panel.view(f, f.area(), false, true);
+        })
+        .unwrap();
+    terminal
+}
+
 fn rebuild(panel: &mut MessagesPanel) {
     render(panel, 80, 24);
+}
+
+#[test]
+fn working_indicator_renders_when_streaming() {
+    let mut panel = MessagesPanel::new(UiConfig::default());
+    panel.text_delta("hello");
+    let terminal = render_working(&mut panel, 80, 10);
+    let buf = terminal.backend().buffer();
+    let last_row = buf.area.height - 1;
+    let row_text: String = (0..buf.area.width)
+        .filter_map(|x| buf.cell((x, last_row)).map(|c| c.symbol().to_string()))
+        .collect();
+    assert!(
+        row_text.contains("thinking..."),
+        "working indicator should render in last row: {row_text:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Adds a floating spinner pill to the bottom-right of the messages panel that appears whenever the model is streaming, a tool is in progress, or live output is being collected. This gives users a clear visual cue that maki is working even before the first token arrives.

## Changes
- Add `MessagesPanel::is_working` and `Chat::is_working` helpers.
- Pass `is_working` through `Chat::view` and `MessagesPanel::view`.
- Render a small right-aligned `⠋ thinking...` pill using existing spinner frames and theme color.
- Add a unit test verifying the indicator renders while streaming.

#### Test plan
- [x] `cargo clippy -p maki-ui --tests -- -D warnings`
- [x] `cargo nextest run -p maki-ui`