### PR TITLE
fix(ui): reduce edge-scroll interval to match frame rate

### DIFF
--- a/maki-ui/src/app/mouse.rs
+++ b/maki-ui/src/app/mouse.rs
@@ -8,7 +8,7 @@ use ratatui::layout::Rect;
 use super::App;
 
 pub(super) const EDGE_SCROLL_LINES: i32 = 1;
-pub(super) const EDGE_SCROLL_INTERVAL: Duration = Duration::from_millis(25);
+pub(super) const EDGE_SCROLL_INTERVAL: Duration = Duration::from_millis(16);
 
 impl App {
     pub(super) fn handle_mouse(&mut self, event: MouseEvent) {


### PR DESCRIPTION
## Summary
Lower the selection edge-scroll tick interval from 25 ms to 16 ms so that auto-scrolling during mouse-drag selection stays smooth at the 60 fps render rate.

## Changes
- `EDGE_SCROLL_INTERVAL` in `maki-ui/src/app/mouse.rs` reduced from 25 ms to 16 ms.

#### Test plan
- [x] `cargo clippy -p maki-ui --tests -- -D warnings`
- [x] `cargo nextest run -p maki-ui`