### PR TITLE
feat(ui): highlight the messages scrollbar while streaming

### DIFF
--- a/maki-ui/src/components/btw_modal.rs
+++ b/maki-ui/src/components/btw_modal.rs
@@ -150,7 +150,7 @@ impl BtwModal {
         frame.render_widget(paragraph, padded);
 
         if total > viewport_h {
-            render_vertical_scrollbar(frame, inner, total, scroll);
+            render_vertical_scrollbar(frame, inner, total, scroll, None);
         }
 
         popup

--- a/maki-ui/src/components/file_picker.rs
+++ b/maki-ui/src/components/file_picker.rs
@@ -321,7 +321,7 @@ impl FilePickerModal {
         render_search(frame, search_area, s);
 
         if match_count > s.viewport_height as u16 {
-            render_vertical_scrollbar(frame, list_area, match_count, s.scroll_offset as u16);
+            render_vertical_scrollbar(frame, list_area, match_count, s.scroll_offset as u16, None);
         }
 
         popup

--- a/maki-ui/src/components/help_modal.rs
+++ b/maki-ui/src/components/help_modal.rs
@@ -215,7 +215,7 @@ impl HelpModal {
         frame.render_widget(paragraph, inner);
 
         if total > viewport_h {
-            render_vertical_scrollbar(frame, inner, total, scroll);
+            render_vertical_scrollbar(frame, inner, total, scroll, None);
         }
 
         popup

--- a/maki-ui/src/components/input.rs
+++ b/maki-ui/src/components/input.rs
@@ -421,7 +421,7 @@ impl InputBox {
 
         if max_scroll > 0 {
             let inner = area.inner(ratatui::layout::Margin::new(0, 1));
-            render_vertical_scrollbar(frame, inner, total_vl, self.scroll_y);
+            render_vertical_scrollbar(frame, inner, total_vl, self.scroll_y, None);
         }
     }
 

--- a/maki-ui/src/components/list_picker.rs
+++ b/maki-ui/src/components/list_picker.rs
@@ -551,7 +551,13 @@ fn render_ready<T: PickerItem>(
     let total_visual = visual_rows_in_range(&s.filtered, &s.items, 0, s.filtered.len());
     if total_visual as u16 > viewport_h {
         let visual_offset = visual_rows_in_range(&s.filtered, &s.items, 0, s.scroll_offset);
-        render_vertical_scrollbar(frame, list_area, total_visual as u16, visual_offset as u16);
+        render_vertical_scrollbar(
+            frame,
+            list_area,
+            total_visual as u16,
+            visual_offset as u16,
+            None,
+        );
     }
 
     s.inner_area = inner;

--- a/maki-ui/src/components/lua_float.rs
+++ b/maki-ui/src/components/lua_float.rs
@@ -474,6 +474,7 @@ impl FloatManager {
                 scroll_area,
                 scrollable as u16,
                 win.scroll_offset as u16,
+                None,
             );
         }
 

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -838,7 +838,12 @@ impl MessagesPanel {
         }
 
         if total_lines > area.height {
-            render_vertical_scrollbar(frame, area, total_lines, self.scroll_top);
+            let is_active = self.in_progress_count() > 0
+                || !self.streaming_text.is_empty()
+                || !self.streaming_thinking.is_empty()
+                || !self.live_bufs.is_empty();
+            let style = is_active.then_some(theme::current().spinner);
+            render_vertical_scrollbar(frame, area, total_lines, self.scroll_top, style);
         }
     }
 

--- a/maki-ui/src/components/scrollbar.rs
+++ b/maki-ui/src/components/scrollbar.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
+use ratatui::style::Style;
 use ratatui::widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState};
 
 pub const SCROLLBAR_THUMB: &str = "\u{2590}";
@@ -12,7 +13,13 @@ pub fn set_enabled(enabled: bool) {
     ENABLED.store(enabled, Ordering::Relaxed);
 }
 
-pub fn render_vertical_scrollbar(frame: &mut Frame, area: Rect, content_len: u16, position: u16) {
+pub fn render_vertical_scrollbar(
+    frame: &mut Frame,
+    area: Rect,
+    content_len: u16,
+    position: u16,
+    style: Option<Style>,
+) {
     if !ENABLED.load(Ordering::Relaxed) {
         return;
     }
@@ -21,11 +28,14 @@ pub fn render_vertical_scrollbar(frame: &mut Frame, area: Rect, content_len: u16
         .content_length(max_scroll as usize + 1)
         .position(position as usize);
 
-    let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+    let mut scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
         .thumb_symbol(SCROLLBAR_THUMB)
         .track_symbol(None)
         .begin_symbol(None)
         .end_symbol(None);
+    if let Some(style) = style {
+        scrollbar = scrollbar.style(style);
+    }
 
     frame.render_stateful_widget(scrollbar, area, &mut state);
 }

--- a/maki-ui/src/components/search_modal.rs
+++ b/maki-ui/src/components/search_modal.rs
@@ -219,7 +219,7 @@ impl SearchModal {
 
         let total = self.matches.len() as u16;
         if total > viewport_h as u16 {
-            render_vertical_scrollbar(frame, list_area, total, self.scroll_offset as u16);
+            render_vertical_scrollbar(frame, list_area, total, self.scroll_offset as u16, None);
         }
 
         popup

--- a/maki-ui/src/components/usage_modal.rs
+++ b/maki-ui/src/components/usage_modal.rs
@@ -106,7 +106,7 @@ impl UsageModal {
         frame.render_widget(Paragraph::new(lines).scroll((scroll, 0)), inner);
 
         if total > viewport_h {
-            render_vertical_scrollbar(frame, inner, total, scroll);
+            render_vertical_scrollbar(frame, inner, total, scroll, None);
         }
 
         let hint = Line::from(vec![


### PR DESCRIPTION
## Summary
Make the messages panel scrollbar thumb switch to the theme spinner/accent style whenever content is actively streaming or a tool is in progress.

## Changes
- Add an optional `style` argument to `render_vertical_scrollbar`.
- Pass the spinner style from `MessagesPanel` when active content is present.
- Keep all other scrollbars (pickers, input, modals) unchanged.

#### Test plan
- [x] `cargo clippy -p maki-ui --tests -- -D warnings`
- [x] `cargo nextest run -p maki-ui`