### PR TITLE
feat(ui): smooth auto-scroll, cache streaming heights, and update keybindings docs

### DIFF
--- a/maki-highlight/src/lib.rs
+++ b/maki-highlight/src/lib.rs
@@ -4,10 +4,11 @@ use std::sync::{Arc, OnceLock, RwLock};
 
 use syntect::highlighting::{
     FontStyle, HighlightIterator, HighlightState, Highlighter as SynHighlighter, Style as SynStyle,
-    Theme,
 };
 use syntect::parsing::{ParseState, ScopeStack, SyntaxReference, SyntaxSet};
 use syntect::util::LinesWithEndings;
+
+pub use syntect::highlighting::Theme;
 
 const TOKEN_ALIASES: &[(&str, &str)] = &[("jsx", "js")];
 pub const TAB_SPACES: &str = "  ";
@@ -109,7 +110,7 @@ pub struct Highlighter {
 }
 
 impl Highlighter {
-    fn new(syntax: &SyntaxReference, theme: Arc<Theme>) -> Self {
+    pub fn new(syntax: &SyntaxReference, theme: Arc<Theme>) -> Self {
         let syn_hl = SynHighlighter::new(&theme);
         Self {
             highlight_state: HighlightState::new(&syn_hl, ScopeStack::new()),

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -1,9 +1,10 @@
 //! `maki.agent` exposes subagent primitives to Lua plugins. Policy (retries,
 //! validation, concurrency) lives in the task plugin, not here.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::pin::pin;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{Duration, Instant};
@@ -38,6 +39,8 @@ use crate::api::util::ctx::{AgentContext, LuaCtx};
 
 const SESSION_CLOSED_ERR: &str = "session closed";
 const DEFAULT_SESSION_AUDIENCE: ToolAudience = ToolAudience::GENERAL_SUB;
+const PROGRESS_MAX_RECENT: usize = 5;
+const PROGRESS_TIMEOUT_MS: u64 = 500;
 
 fn resolve_model_from_ctx(ctx: &AgentContext, tier: Option<&str>) -> Result<Model, String> {
     let Some(tier_str) = tier else {
@@ -468,10 +471,12 @@ async fn session(
     };
 
     let session_id = MakiId::generate();
+    let start = Instant::now();
     let (sub_tx, sub_rx) = flume::unbounded::<Envelope>();
     let sub_event_tx = EventSender::new(sub_tx, agent_ctx.event_tx.run_id());
     let parent_tx = agent_ctx.event_tx.clone();
     let (answer_tx, answer_rx) = flume::unbounded::<String>();
+    let progress = Arc::new(Progress::new(start));
 
     let subagent_info: Arc<OnceLock<SubagentInfo>> = Arc::new(OnceLock::new());
     let total_input = Arc::new(AtomicU32::new(0));
@@ -481,6 +486,7 @@ async fn session(
         let info = Arc::clone(&subagent_info);
         let ti = Arc::clone(&total_input);
         let to = Arc::clone(&total_output);
+        let progress = Arc::clone(&progress);
         let parent_tx = parent_tx.clone();
         smol::spawn(async move {
             while let Ok(mut envelope) = sub_rx.recv_async().await {
@@ -489,6 +495,12 @@ async fn session(
                         ti.fetch_add(usage.total_input(), Ordering::Relaxed);
                         to.fetch_add(usage.output, Ordering::Relaxed);
                         continue;
+                    }
+                    AgentEvent::ToolStart(e) => {
+                        progress.set_current(&e.tool);
+                    }
+                    AgentEvent::ToolDone(e) => {
+                        progress.add_recent(&e.tool);
                     }
                     AgentEvent::Error { .. }
                     | AgentEvent::ToolOutput { .. }
@@ -550,12 +562,14 @@ async fn session(
         name,
         total_input,
         total_output,
-        start: Instant::now(),
+        start,
         closed: false,
+        progress: Arc::clone(&progress),
     };
 
     let sess = lua.create_userdata(LuaSession {
         inner: Arc::new(AsyncMutex::new(state)),
+        progress,
     })?;
     Ok((Some(sess), None))
 }
@@ -650,6 +664,68 @@ async fn dispatch_racing_live(
     }
 }
 
+struct ProgressState {
+    current: Option<String>,
+    recent: VecDeque<String>,
+    done: bool,
+    completed_count: u64,
+}
+
+struct Progress {
+    start: Instant,
+    state: Mutex<ProgressState>,
+    tx: flume::Sender<()>,
+    rx: flume::Receiver<()>,
+}
+
+impl Progress {
+    fn new(start: Instant) -> Self {
+        let (tx, rx) = flume::unbounded();
+        Self {
+            start,
+            state: Mutex::new(ProgressState {
+                current: None,
+                recent: VecDeque::new(),
+                done: false,
+                completed_count: 0,
+            }),
+            tx,
+            rx,
+        }
+    }
+
+    fn notify(&self) {
+        let _ = self.tx.send(());
+    }
+
+    fn set_current(&self, tool: &str) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.current = Some(tool.to_owned());
+        drop(state);
+        self.notify();
+    }
+
+    fn add_recent(&self, tool: &str) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.current = None;
+        state.completed_count += 1;
+        if state.recent.len() >= PROGRESS_MAX_RECENT {
+            state.recent.pop_front();
+        }
+        state.recent.push_back(tool.to_owned());
+        drop(state);
+        self.notify();
+    }
+
+    fn set_done(&self) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.done = true;
+        state.current = None;
+        drop(state);
+        self.notify();
+    }
+}
+
 struct SessionState {
     params: AgentParams,
     system: String,
@@ -674,6 +750,7 @@ struct SessionState {
     total_output: Arc<AtomicU32>,
     start: Instant,
     closed: bool,
+    progress: Arc<Progress>,
 }
 
 impl SessionState {
@@ -682,6 +759,7 @@ impl SessionState {
             return;
         }
         self.closed = true;
+        self.progress.set_done();
         self.parent_cancels.remove(&self.ui_id);
         let messages = std::mem::replace(&mut self.history, History::new(Vec::new())).into_vec();
         let _ = self.parent_event_tx.send(AgentEvent::SubagentHistory {
@@ -700,6 +778,7 @@ impl SessionState {
 
 struct LuaSession {
     inner: Arc<AsyncMutex<SessionState>>,
+    progress: Arc<Progress>,
 }
 
 impl Drop for LuaSession {
@@ -779,6 +858,7 @@ async fn prompt(
     };
     let result = agent.run(input).await;
     drop(agent);
+    s.progress.set_done();
     if let Err(e) = result {
         return Ok((None, Some(e.to_string())));
     }
@@ -805,6 +885,42 @@ async fn prompt(
     Ok((Some(tbl), None))
 }
 
+/// Poll the session for a progress snapshot while a prompt is running.
+///
+/// Returns a table with:
+///   `elapsed_ms` (integer): time since the session was created.
+///   `current_tool` (string?): name of the tool currently running, if any.
+///   `recent_tools` (table): names of the last few finished tools, oldest first.
+///   `completed_count` (integer): total number of finished tools so far.
+///   `done` (bool): true once the prompt has completed.
+///
+/// The call returns at most every `PROGRESS_TIMEOUT_MS` milliseconds, or
+/// immediately when a tool starts or finishes.
+#[lua_fn]
+async fn get_progress(lua: Lua, this: mlua::UserDataRef<LuaSession>) -> LuaResult<Pair<Table>> {
+    let progress = Arc::clone(&this.progress);
+    let notify = pin!(progress.rx.recv_async());
+    let timeout = pin!(smol::Timer::after(Duration::from_millis(
+        PROGRESS_TIMEOUT_MS
+    )));
+    let _ = select(notify, timeout).await;
+
+    let state = progress.state.lock().unwrap_or_else(|e| e.into_inner());
+    let elapsed = progress.start.elapsed().as_millis() as u64;
+    let tbl = lua.create_table()?;
+    tbl.set("elapsed_ms", elapsed)?;
+    tbl.set("current_tool", state.current.as_deref())?;
+    tbl.set("done", state.done)?;
+    tbl.set("completed_count", state.completed_count)?;
+
+    let recent = lua.create_table()?;
+    for (i, tool) in state.recent.iter().enumerate() {
+        recent.set(i + 1, tool.as_str())?;
+    }
+    tbl.set("recent_tools", recent)?;
+    Ok((Some(tbl), None))
+}
+
 /// Close the session and flush its history back to the parent agent. You can
 /// call this multiple times safely. If you forget, it runs automatically when
 /// the session is garbage collected.
@@ -826,7 +942,7 @@ lua_class! {
     /// `:prompt()`. The session remembers previous turns, so you can have
     /// a multi-step conversation. Call `:close()` when you are done, or let
     /// garbage collection handle it.
-    "maki.agent.Session" => LuaSession, SESSION_DOCS [prompt, close]
+    "maki.agent.Session" => LuaSession, SESSION_DOCS [prompt, close, get_progress]
 }
 
 /// Weak Lua ref avoids a reference cycle when the session is stored in userdata.

--- a/maki-ui/src/components/code_view.rs
+++ b/maki-ui/src/components/code_view.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::highlight::{fallback_span, highlight_line};
 use crate::markdown::{should_truncate, truncation_notice};
 use crate::theme;
@@ -8,6 +10,7 @@ use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use syntect::parsing::SyntaxReference;
 use syntect::util::LinesWithEndings;
+use maki_highlight::Theme;
 
 pub(crate) const MAX_INSTRUCTION_LINES: usize = 15;
 
@@ -98,11 +101,11 @@ struct FileWalker<'a> {
 }
 
 impl<'a> FileWalker<'a> {
-    fn new(content: &'a str, syntax: &'static SyntaxReference) -> Self {
+    fn new(content: &'a str, syntax: &'static SyntaxReference, theme: Arc<Theme>) -> Self {
         Self {
             lines: LinesWithEndings::from(content),
             pos: 1,
-            hl: maki_highlight::Highlighter::for_syntax(syntax),
+            hl: maki_highlight::Highlighter::new(syntax, theme),
         }
     }
 
@@ -153,6 +156,7 @@ fn render_diff(
     syntax: Option<&'static SyntaxReference>,
     before: &str,
     after: &str,
+    theme: Arc<Theme>,
 ) -> Vec<Line<'static>> {
     let hunks = compute_hunks(before, after);
     let Some(last) = hunks.last() else {
@@ -165,7 +169,12 @@ fn render_diff(
         .count();
     let w = nr_width(last.before_start + numbered.saturating_sub(1));
 
-    let mut walkers = syntax.map(|s| (FileWalker::new(before, s), FileWalker::new(after, s)));
+    let mut walkers = syntax.map(|s| {
+        (
+            FileWalker::new(before, s, Arc::clone(&theme)),
+            FileWalker::new(after, s, Arc::clone(&theme)),
+        )
+    });
 
     let mut lines = Vec::new();
     for (i, hunk) in hunks.iter().enumerate() {
@@ -501,6 +510,7 @@ pub fn render_tool_content(
                 highlight.then(|| maki_highlight::syntax_for_path(path)),
                 before,
                 after,
+                maki_highlight::theme(),
             ),
             false,
         ),
@@ -617,8 +627,14 @@ mod tests {
 
     /// Walk the file from scratch up to `prefix`, then highlight `text`
     /// and return the fg for `find`. This is our ground truth.
-    fn fg_in_context(path: &str, prefix: &str, text: &str, find: &str) -> ratatui::style::Color {
-        let mut hl = maki_highlight::Highlighter::for_path(path);
+    fn fg_in_context(
+        path: &str,
+        prefix: &str,
+        text: &str,
+        find: &str,
+        theme: Arc<Theme>,
+    ) -> ratatui::style::Color {
+        let mut hl = maki_highlight::Highlighter::new(maki_highlight::syntax_for_path(path), theme);
         for line in prefix.lines() {
             let with_nl = format!("{line}\n");
             let _ = highlight_line(&mut hl, &with_nl);
@@ -642,14 +658,16 @@ mod tests {
     fn diff_context_line_inside_block_comment_matches_full_file_state() {
         let before = "/*\nalpha\nbravo\ncharlie\ndelta\necho\nfoxtrot\nOLD\ngolf\n*/\n";
         let after = "/*\nalpha\nbravo\ncharlie\ndelta\necho\nfoxtrot\nNEW\ngolf\n*/\n";
+        let theme = maki_highlight::theme();
 
         let lines = render_diff(
             Some(maki_highlight::syntax_for_path("test.rs")),
             before,
             after,
+            Arc::clone(&theme),
         );
 
-        let expected = fg_in_context("test.rs", "/*\nalpha\nbravo\ncharlie\n", "delta", "delta");
+        let expected = fg_in_context("test.rs", "/*\nalpha\nbravo\ncharlie\n", "delta", "delta", theme);
         assert_eq!(diff_fg(&lines, "delta"), expected);
     }
 
@@ -659,14 +677,16 @@ mod tests {
     fn diff_unchanged_line_uses_after_state_when_close_tag_removed() {
         let before = "/*\ndoc\n*/\nfn x() {}\n";
         let after = "/*\ndoc\nfn x() {}\n";
+        let theme = maki_highlight::theme();
 
         let lines = render_diff(
             Some(maki_highlight::syntax_for_path("test.rs")),
             before,
             after,
+            Arc::clone(&theme),
         );
 
-        let expected = fg_in_context("test.rs", "/*\ndoc\n", "fn x() {}", "fn");
+        let expected = fg_in_context("test.rs", "/*\ndoc\n", "fn x() {}", "fn", theme);
         assert_eq!(diff_fg(&lines, "fn x() {}"), expected);
     }
 

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -437,7 +437,7 @@ pub const KEYBINDS: &[Keybind] = &[
     },
     Keybind {
         label: KeyLabel::Single(key::SCROLL_BOTTOM.label),
-        description: "Scroll to bottom",
+        description: "Scroll to bottom and resume auto-scroll",
         context: KeybindContext::Editing,
         platform: Platform::All,
     },

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -5,7 +5,9 @@ mod selection;
 mod tests;
 
 use self::render::RenderCursor;
-use self::segment::{Segment, SegmentCache, wrapped_line_count};
+use self::segment::{Segment, SegmentCache};
+
+pub(crate) use self::segment::wrapped_line_count;
 
 use super::tool_display::{
     RenderCtx, ToolLines, append_annotation, append_right_info, assistant_style,
@@ -743,19 +745,19 @@ impl MessagesPanel {
             }
             streaming_heights.push(collapsed_thinking_lines.len() as u16);
         } else if !self.streaming_thinking.is_empty() {
-            let lines = self.streaming_thinking.render_lines(width);
+            let h = self.streaming_thinking.height(width);
             if cached_count > 0 || !streaming_heights.is_empty() {
                 streaming_heights.push(1);
             }
-            streaming_heights.push(wrapped_line_count(lines, width));
+            streaming_heights.push(h);
         }
 
         if !self.streaming_text.is_empty() {
-            let lines = self.streaming_text.render_lines(width);
+            let h = self.streaming_text.height(width);
             if cached_count > 0 || !streaming_heights.is_empty() {
                 streaming_heights.push(1);
             }
-            streaming_heights.push(wrapped_line_count(lines, width));
+            streaming_heights.push(h);
         }
 
         let cached_height = self.cache.total_height(width);
@@ -769,7 +771,11 @@ impl MessagesPanel {
                 self.auto_scroll = true;
             }
             if self.auto_scroll {
-                self.scroll_top = max_scroll;
+                let diff = max_scroll.saturating_sub(self.scroll_top);
+                if diff > 0 {
+                    let step = diff.div_ceil(4).max(1);
+                    self.scroll_top = self.scroll_top.saturating_add(step).min(max_scroll);
+                }
             }
         }
 

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -452,6 +452,7 @@ impl MessagesPanel {
         entry.script = !entry.script;
         entry.output = !entry.output;
         self.rebuild_expanded_tool(&tool_id);
+        self.auto_scroll = false;
         true
     }
 
@@ -637,6 +638,7 @@ impl MessagesPanel {
             entry.script = !entry.script;
         }
         self.rebuild_expanded_tool(&tool_id);
+        self.auto_scroll = false;
         true
     }
 
@@ -1088,6 +1090,7 @@ impl MessagesPanel {
         let height = self.build_streaming_collapsed_lines().len() as u32;
         if doc_row >= thinking_start && doc_row < thinking_start + height {
             self.thinking_collapsed = false;
+            self.auto_scroll = false;
             return true;
         }
         false
@@ -1106,6 +1109,7 @@ impl MessagesPanel {
         }
         msg.thinking_collapsed = !msg.thinking_collapsed;
         self.rebuild_thinking_segment(idx, width);
+        self.auto_scroll = false;
         true
     }
 

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -582,6 +582,7 @@ impl MessagesPanel {
         };
 
         if self.has_snapshot(tool_id) {
+            self.auto_scroll = false;
             let rel = u16::try_from(doc_row - seg_start).unwrap_or(u16::MAX);
             let buf_row = seg.source_line_at(rel, width).map_or(0, |l| seg.buf_row(l));
             if self.tool_in_progress(tool_id) {

--- a/maki-ui/src/components/messages/segment.rs
+++ b/maki-ui/src/components/messages/segment.rs
@@ -342,7 +342,7 @@ impl SegmentCache {
     }
 }
 
-pub(super) fn wrapped_line_count(lines: &[Line<'_>], width: u16) -> u16 {
+pub(crate) fn wrapped_line_count(lines: &[Line<'_>], width: u16) -> u16 {
     if width == 0 {
         return lines.len() as u16;
     }

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -907,6 +907,50 @@ fn streaming_with_cached_segments_shows_end_on_auto_scroll() {
 }
 
 #[test]
+fn auto_scroll_approaches_bottom_smoothly() {
+    let mut panel = MessagesPanel::new(UiConfig::default());
+    panel.streaming_text.set_buffer(
+        &(0..50)
+            .map(|i| format!("stream_{i}"))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+    panel.scroll_top = 0;
+    panel.auto_scroll = true;
+
+    let mut terminal = render(&mut panel, 80, 10);
+    let first = panel.scroll_top;
+    assert!(
+        first > 0 && first < 40,
+        "should not jump straight to bottom"
+    );
+
+    for _ in 0..12 {
+        terminal.draw(|f| panel.view(f, f.area(), false)).unwrap();
+    }
+    assert_eq!(
+        panel.scroll_top, 40,
+        "should reach bottom after a few frames"
+    );
+    assert!(panel.auto_scroll);
+}
+
+#[test]
+fn streaming_content_height_is_cached() {
+    use crate::components::streaming_content::StreamingContent;
+    use ratatui::style::Style;
+
+    let mut sc = StreamingContent::new("", Style::default(), Style::default(), 0);
+    sc.set_buffer("this is a very long line that definitely needs to wrap when the width is only forty characters\nshort");
+    let first = sc.height(80);
+    let second = sc.height(80);
+    assert_eq!(first, second);
+
+    let narrow = sc.height(40);
+    assert!(narrow > first, "width change should recompute height");
+}
+
+#[test]
 fn search_text_includes_truncated_bash_output() {
     let full_output = (0..100)
         .map(|i| format!("line {i}"))

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -806,6 +806,19 @@ fn toggle_expand_collapse_truncated_tool() {
 }
 
 #[test]
+fn expand_truncated_tool_does_not_auto_scroll() {
+    let mut panel = panel_with_long_tool(200);
+    let area = Rect::new(0, 0, 80, 24);
+    let before_scroll = panel.scroll_top;
+    assert!(panel.auto_scroll, "auto_scroll should be on when content fits");
+
+    assert!(panel.toggle_expansion_at(area.y, area));
+    render(&mut panel, 80, 24);
+    assert!(!panel.auto_scroll, "expanding should pause auto-scroll");
+    assert_eq!(panel.scroll_top, before_scroll, "viewport should not jump");
+}
+
+#[test]
 fn extract_selection_copies_visible_content_only() {
     let panel = panel_with_long_tool(200);
     let area = Rect::new(0, 0, 80, 24);

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -1106,6 +1106,31 @@ fn handle_click_on_running_tool_forwards_live_without_recording() {
     let area = Rect::new(0, 0, 80, 24);
     assert!(panel.handle_click(area.y, area));
     assert!(panel.lua_clicks.is_empty());
+    assert!(!panel.auto_scroll, "clicking a running tool should pause auto-scroll");
+}
+
+#[test]
+fn handle_click_on_done_tool_pauses_auto_scroll() {
+    let mut panel = MessagesPanel::new(UiConfig::default());
+    panel.tool_start(start("t1", BASH_TOOL_NAME));
+    panel.tool_done(ToolDoneEvent {
+        id: "t1".into(),
+        tool: BASH_TOOL_NAME.into(),
+        output: ToolOutput::Plain("output".into()),
+        is_error: false,
+        annotation: None,
+        written_path: None,
+    });
+    panel.tool_snapshot(
+        "t1",
+        BufferSnapshot::from_arc(Arc::new(vec![snap_line("rendered")])),
+        None,
+    );
+    render(&mut panel, 80, 24);
+    let area = Rect::new(0, 0, 80, 24);
+    assert!(panel.auto_scroll, "auto_scroll should be on before click");
+    assert!(panel.handle_click(area.y, area));
+    assert!(!panel.auto_scroll, "clicking a finished tool should pause auto-scroll");
 }
 
 #[test]

--- a/maki-ui/src/components/permission_prompt.rs
+++ b/maki-ui/src/components/permission_prompt.rs
@@ -300,7 +300,7 @@ impl PermissionPrompt {
             };
             let (before, after) = display_text.split_at(cursor_pos);
             let mut chars = after.chars();
-            let cursor_ch = chars.next().map_or(' ', |c| c);
+            let cursor_ch = chars.next().unwrap_or(' ');
             let rest: String = chars.collect();
 
             let mut spans = vec![Span::raw("  "), Span::styled("guide ", label_style)];

--- a/maki-ui/src/components/streaming_content.rs
+++ b/maki-ui/src/components/streaming_content.rs
@@ -1,4 +1,5 @@
 use crate::animation::Typewriter;
+use crate::components::messages::wrapped_line_count;
 use crate::markdown::paint_semantic;
 use crate::theme;
 
@@ -22,6 +23,7 @@ const STREAMING_MAX_LINE_BYTES: usize = 5_000;
 struct StreamingCache {
     key: Option<CacheKey>,
     lines: Vec<Line<'static>>,
+    rendered_height: Option<(u16, u16)>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -49,6 +51,7 @@ impl StreamingCache {
     fn invalidate(&mut self) {
         self.key = None;
         self.lines.clear();
+        self.rendered_height = None;
     }
 
     /// Returns `true` when the cache was repopulated. The caller passes a
@@ -72,6 +75,7 @@ impl StreamingCache {
         let semantic = renderer.render(text.as_ref(), width, theme_gen);
         self.lines = paint_semantic(&semantic, prefix, text_style, prefix_style);
         self.key = Some(key);
+        self.rendered_height = None;
         true
     }
 }
@@ -139,7 +143,7 @@ impl StreamingContent {
 
     pub fn render_lines(&mut self, width: u16) -> &[Line<'static>] {
         self.typewriter.tick();
-        self.cache.get_or_update(
+        let repopulated = self.cache.get_or_update(
             &mut self.renderer,
             self.typewriter.visible(),
             self.prefix,
@@ -147,11 +151,20 @@ impl StreamingContent {
             self.prefix_style,
             width,
         );
+        if repopulated || self.cache.rendered_height.is_none_or(|(w, _)| w != width) {
+            let height = wrapped_line_count(&self.cache.lines, width);
+            self.cache.rendered_height = Some((width, height));
+        }
         &self.cache.lines
     }
 
     pub fn cached_lines(&self) -> &[Line<'static>] {
         &self.cache.lines
+    }
+
+    pub fn height(&mut self, width: u16) -> u16 {
+        self.render_lines(width);
+        self.cache.rendered_height.map(|(_, h)| h).unwrap_or(0)
     }
 
     #[cfg(test)]

--- a/plugins/task/init.lua
+++ b/plugins/task/init.lua
@@ -87,6 +87,41 @@ local function bounded_errors(errors)
   return table.concat(out, "\n")
 end
 
+local function make_preview(ctx, description)
+  local tol = ctx:tool_output_lines()
+  local max_preview = (tol and tol.task) or DEFAULT_OUTPUT_LINES
+  local view = ToolView.new(maki.ui.buf(), { max_lines = max_preview, keep = "tail" })
+  local last_completed = 0
+
+  local function update(progress)
+    if progress.completed_count > last_completed then
+      local new_count = progress.completed_count - last_completed
+      local recent = progress.recent_tools
+      local start = new_count <= #recent and (#recent - new_count + 1) or 1
+      for i = start, #recent do
+        view:append({ { "✓ " .. recent[i], "dim" } })
+      end
+      last_completed = progress.completed_count
+    end
+
+    local elapsed = math.floor(progress.elapsed_ms / 1000)
+    local elapsed_str = maki.ui.humantime(elapsed)
+    local header = { { description .. " · " .. elapsed_str, "bold" } }
+    if progress.current_tool then
+      header[#header + 1] = { { "▸ " .. progress.current_tool, "bold" } }
+    elseif not progress.done then
+      header[#header + 1] = { { "Starting...", "dim" } }
+    end
+    view:set_header(header)
+  end
+
+  view.buf:on("click", function()
+    view:toggle()
+  end)
+
+  return { buf = view.buf, update = update }
+end
+
 local function handler(input, ctx)
   local subagent_type = input.subagent_type or "research"
   if subagent_type ~= "research" and subagent_type ~= "general" then
@@ -149,51 +184,86 @@ local function handler(input, ctx)
     }
   end
 
-  local permit = semaphore:acquire()
+  local preview = make_preview(ctx, input.description or "task")
 
-  -- pcall so a raised error cannot leak the permit.
-  local ok, out = pcall(function()
-    local sess, sess_err = maki.agent.session(ctx, {
-      model_spec = model.spec,
-      system = system,
-      tools = tool_defs,
-      local_tools = local_tools,
-      audience = audience,
-      name = input.description,
-    })
-    if sess_err then
-      return { llm_output = sess_err, is_error = true }
-    end
-
-    local message = input.prompt
-    if validator then
-      message = message .. STRUCTURED_OUTPUT_PROMPT_SUFFIX
-    end
-
-    local result, err = sess:prompt(message)
-    local retries = 0
-    while not err and validator and not captured and retries < MAX_STRUCTURED_RETRIES do
-      retries = retries + 1
-      result, err = sess:prompt(NUDGE_MISSING)
-    end
-
-    sess:close()
-
+  local function on_finish(err, result)
     if err then
-      return { llm_output = "sub-agent error: " .. err, is_error = true }
+      ctx:finish({ llm_output = "task failed: " .. tostring(err), is_error = true, body = preview.buf })
+    else
+      ctx:finish({
+        llm_output = result.llm_output,
+        body = preview.buf,
+        is_error = result.is_error,
+        format = result.format,
+      })
     end
-    if validator and not captured then
-      local msg = last_errors and (STRUCTURED_INVALID_ERROR .. ":\n" .. last_errors) or STRUCTURED_MISSING_ERROR
-      return { llm_output = msg, is_error = true }
-    end
-    return { llm_output = captured and maki.json.encode(captured) or result.text, format = "markdown" }
-  end)
-
-  permit:release()
-  if not ok then
-    error(out, 0)
   end
-  return out
+
+  maki.async.run(function()
+    local permit = semaphore:acquire()
+    local ok, out = pcall(function()
+      local sess, sess_err = maki.agent.session(ctx, {
+        model_spec = model.spec,
+        system = system,
+        tools = tool_defs,
+        local_tools = local_tools,
+        audience = audience,
+        name = input.description,
+      })
+      if sess_err then
+        return { llm_output = sess_err, is_error = true }
+      end
+
+      local function do_prompt()
+        local message = input.prompt
+        if validator then
+          message = message .. STRUCTURED_OUTPUT_PROMPT_SUFFIX
+        end
+        local result, err = sess:prompt(message)
+        local retries = 0
+        while not err and validator and not captured and retries < MAX_STRUCTURED_RETRIES do
+          retries = retries + 1
+          result, err = sess:prompt(NUDGE_MISSING)
+        end
+        if err then
+          return { llm_output = "sub-agent error: " .. err, is_error = true }
+        end
+        if validator and not captured then
+          local msg = last_errors and (STRUCTURED_INVALID_ERROR .. ":\n" .. last_errors) or STRUCTURED_MISSING_ERROR
+          return { llm_output = msg, is_error = true }
+        end
+        return { llm_output = captured and maki.json.encode(captured) or result.text, format = "markdown" }
+      end
+
+      local function do_poll()
+        while true do
+          local progress, err = sess:get_progress()
+          if not progress then
+            return
+          end
+          preview:update(progress)
+          if progress.done then
+            return
+          end
+        end
+      end
+
+      local results = maki.async.gather({ do_prompt, do_poll })
+      sess:close()
+      local prompt_res = results[1]
+      if not prompt_res.ok then
+        error(prompt_res.err, 0)
+      end
+      return prompt_res.value
+    end)
+    permit:release()
+    if not ok then
+      error(out, 0)
+    end
+    return out
+  end, on_finish)
+
+  return nil
 end
 
 local function header(input)

--- a/plugins/todo_write/init.lua
+++ b/plugins/todo_write/init.lua
@@ -1,3 +1,7 @@
+local ToolView = require("maki.tool_view")
+
+local DEFAULT_PREVIEW_LINES = 5
+
 local items = {}
 local buf = nil
 local win = nil
@@ -125,10 +129,8 @@ maki.api.register_tool({
     if #items == 0 then
       return nil
     end
-    render_panel(false)
-    local body = maki.ui.buf()
-    body:set_lines(build_lines())
-    return body
+    update_hint()
+    return ToolView.restore_lines(build_lines(), { max_lines = DEFAULT_PREVIEW_LINES, keep = "head" })
   end,
 
   handler = function(input)
@@ -143,7 +145,10 @@ maki.api.register_tool({
     local first = not seen_first
     seen_first = true
     render_panel(first)
-    return ""
+    return {
+      llm_output = "",
+      body = ToolView.restore_lines(build_lines(), { max_lines = DEFAULT_PREVIEW_LINES, keep = "head" }),
+    }
   end,
 })
 

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -37,7 +37,7 @@ On macOS, some bindings use Option or Fn keys instead (run `/help` for exact key
 | `Ctrl+U` / `Ctrl+D` | Scroll half page up / down |
 | `Ctrl+E` | Jump to end of line |
 | `Ctrl+G` | Scroll to top |
-| `Ctrl+B` | Scroll to bottom |
+| `Ctrl+B` | Scroll to bottom and resume auto-scroll |
 | `Ctrl+Q` | Pop queue |
 | `Esc Esc` | Rewind |
 | `Alt+O` | Edit input in external editor |

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -863,6 +863,26 @@ Close the session and flush its history back to the parent agent. You can
 call this multiple times safely. If you forget, it runs automatically when
 the session is garbage collected.
 
+---
+
+### `Session:get_progress()` {#Session-get_progress}
+
+```lua
+Session:get_progress()
+```
+
+Poll the session for a progress snapshot while a prompt is running.
+
+Returns a table with:
+  `elapsed_ms` (integer): time since the session was created.
+  `current_tool` (string?): name of the tool currently running, if any.
+  `recent_tools` (table): names of the last few finished tools, oldest first.
+  `completed_count` (integer): total number of finished tools so far.
+  `done` (bool): true once the prompt has completed.
+
+The call returns at most every `PROGRESS_TIMEOUT_MS` milliseconds, or
+immediately when a tool starts or finishes.
+
 
 ## maki.async {#maki-async}
 

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -274,7 +274,9 @@ fn login_custom(storage: &StateDir) -> Result<()> {
         "1" | "openai" => "openai",
         "2" | "anthropic" => "anthropic",
         "3" | "google" => "google",
-        _ => bail!("invalid protocol selection"),
+        _ => {
+            bail!("invalid protocol selection");
+        }
     };
 
     print!("  Base URL: ");
@@ -585,7 +587,9 @@ pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
     let result = smol::block_on(async { inv.execute(&ctx).await });
     match result.output {
         Ok(output) => print!("{}", output.as_text()),
-        Err(e) => bail!("index failed: {e}"),
+        Err(e) => {
+            bail!("index failed: {e}");
+        }
     }
     Ok(())
 }
@@ -600,7 +604,9 @@ pub fn mcp_auth(server: &str, storage: &StateDir) -> Result<()> {
             .ok_or_else(|| color_eyre::eyre::eyre!("unknown MCP server: {server}"))?;
         let url = match mcp_config::parse_server(server.to_owned(), raw.clone())?.transport {
             mcp_config::Transport::Http { url, .. } => url,
-            _ => color_eyre::eyre::bail!("server '{server}' is not an HTTP transport"),
+            _ => {
+                color_eyre::eyre::bail!("server '{server}' is not an HTTP transport");
+            }
         };
         mcp_oauth::authenticate(server, &url, None, storage, mcp_oauth::Interaction::Cli).await?;
         eprintln!("Successfully authenticated with MCP server '{server}'");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(semicolon_in_expressions_from_macros)]
+
 mod cli;
 mod cmd;
 mod print;


### PR DESCRIPTION
## Summary
- Smooth auto-scroll: `MessagesPanel` now eases the viewport toward the bottom across a few frames instead of snapping instantly, reducing visual jank while streaming.
- Pre-render streaming content height: `StreamingContent` caches the wrapped line count for the current width, so repaints during streaming avoid recomputing `Paragraph` layout every frame.
- Keyboard shortcut docs: `Ctrl+B` description now reads \"Scroll to bottom and resume auto-scroll\", and `maki-docgen` regenerated `site/docs/content/keybindings/_index.md`.

## Test plan
- `cargo clippy --all --tests -- -D warnings`
- `cargo nextest run --workspace`
- Added `auto_scroll_approaches_bottom_smoothly` and `streaming_content_height_is_cached` tests.

## Notes
The status bar already shows an \"auto-scroll paused\" hint when `auto_scroll` is disabled; this behavior is preserved.