### PR TITLE
perf(ui): apply REVERSED via Paragraph style instead of per-cell loop

### DIFF
--- a/maki-ui/src/components/messages/render.rs
+++ b/maki-ui/src/components/messages/render.rs
@@ -1,6 +1,6 @@
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::Modifier;
+use ratatui::style::{Modifier, Style};
 use ratatui::text::Line;
 use ratatui::widgets::{Paragraph, Wrap};
 
@@ -29,7 +29,7 @@ impl RenderCursor {
         &mut self,
         lines: &[Line<'static>],
         h: u16,
-        style: Option<ratatui::style::Style>,
+        style: Option<Style>,
         highlight: bool,
         frame: &mut Frame,
     ) {
@@ -45,23 +45,16 @@ impl RenderCursor {
             .min(self.bottom.saturating_sub(self.y));
         let seg_area = Rect::new(self.viewport.x, self.y, self.viewport.width, visible_h);
         let mut p = Paragraph::new(lines.to_vec()).wrap(Wrap { trim: false });
-        if let Some(s) = style {
-            p = p.style(s);
+        let mut base = style.unwrap_or_default();
+        if highlight {
+            base = base.add_modifier(Modifier::REVERSED);
         }
+        p = p.style(base);
         if self.skip > 0 {
             p = p.scroll((self.skip, 0));
             self.skip = 0;
         }
         frame.render_widget(p, seg_area);
-        if highlight {
-            for row in seg_area.y..seg_area.y + seg_area.height {
-                for col in seg_area.x..seg_area.x + seg_area.width {
-                    if let Some(cell) = frame.buffer_mut().cell_mut((col, row)) {
-                        cell.set_style(cell.style().add_modifier(Modifier::REVERSED));
-                    }
-                }
-            }
-        }
         self.y += visible_h;
     }
 }


### PR DESCRIPTION
## Summary
`RenderCursor.render` reversed highlighted regions by iterating **every cell** of the segment (O(rows×cols)) after painting and calling `set_style` on each. For large selections that is a hot inner loop run on every render frame.

Apply `Modifier::REVERSED` to the `Paragraph`'s style instead. Ratatui merges the widget style additively with each painted cell, so the visual result is identical (every painted cell gets REVERSED) at O(1) regardless of area size.

## Impact
Selection / highlighted-region repaints no longer scale with area; removes the per-cell mutation loop entirely.

## Test plan
- `cargo clippy -p maki-ui --tests -- -D warnings` — clean.
- Manual: select a large block of text and confirm the reversed highlight renders identically.

🤖 Generated with opencode