### PR TITLE
perf(ui): gate terminal.draw behind a dirty flag

### DIFF
--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -208,6 +208,10 @@ pub(crate) struct EventLoop<'t> {
     warn_tx: flume::Sender<String>,
     ui_action_rx: Option<flume::Receiver<UiAction>>,
     _model_fetch_task: smol::Task<()>,
+    /// Set when UI state changed and a fresh frame must be painted. Draws are
+    /// gated on this (or active animation) so we don't re-diff the whole
+    /// buffer on every idle tick. Resize also sets it.
+    dirty: bool,
 }
 
 /// One item from any of the event loop's sources; `None` from `next_wake`
@@ -401,6 +405,7 @@ impl<'t> EventLoop<'t> {
             warn_tx: bg.warn_tx,
             ui_action_rx,
             _model_fetch_task: bg.task,
+            dirty: true,
         })
     }
 
@@ -422,9 +427,13 @@ impl<'t> EventLoop<'t> {
             if let Err(e) = self.drain_channels() {
                 break Err(e);
             }
+            let should_draw = self.dirty || self.sessions[self.focused].app.is_animating();
             let app = &mut self.sessions[self.focused].app;
-            if let Err(e) = self.terminal.draw(|f| app.view(f)) {
-                break Err(e.into());
+            if should_draw {
+                if let Err(e) = self.terminal.draw(|f| app.view(f)) {
+                    break Err(e.into());
+                }
+                self.dirty = false;
             }
 
             if let Some(i) = self
@@ -485,6 +494,7 @@ impl<'t> EventLoop<'t> {
     }
 
     fn handle_wake(&mut self, wake: Wake) -> Result<()> {
+        self.dirty = true;
         match wake {
             Wake::Input(ev) => self.handle_input(ev),
             Wake::InputGone => return Err(eyre!("terminal input reader stopped")),
@@ -528,6 +538,7 @@ impl<'t> EventLoop<'t> {
         for rt in &mut self.sessions {
             if rt.app.status == Status::Streaming && rt.handles.agent_rx.is_disconnected() {
                 rt.app.status = Status::error("agent stopped unexpectedly".into());
+                self.dirty = true;
             }
         }
 
@@ -536,6 +547,7 @@ impl<'t> EventLoop<'t> {
         for rt in &mut self.sessions {
             if rt.app.state.session.model != spec {
                 rt.app.update_model(&slot_model.model);
+                self.dirty = true;
             }
         }
         drop(slot_model);
@@ -814,6 +826,10 @@ impl<'t> EventLoop<'t> {
 
     fn translate(&mut self, raw: Event) -> (Option<Msg>, Option<Event>) {
         match raw {
+            Event::Resize(..) => {
+                self.dirty = true;
+                (None, None)
+            }
             Event::Key(key) if key.kind == KeyEventKind::Press => (Some(Msg::Key(key)), None),
             Event::Key(_) => (None, None),
             Event::Paste(text) => (Some(Msg::Paste(text)), None),


### PR DESCRIPTION
## Summary
The event loop blocks on a selector with an idle/animation timeout, but repainted the entire terminal buffer on **every** iteration regardless of whether anything changed. This wastes CPU re-diffing/flushing the whole screen while idle.

- Add `EventLoop.dirty`; set it on every `Wake` handled, on `Event::Resize`, on model switch, and on agent-stopped detection in `drain_channels`.
- Gate `terminal.draw` on `dirty || focused app is_animating()`.
- `Event::Resize` now marks dirty (previously silently dropped), so resizes always repaint.
- Input handling still runs on every wake, so latency is unaffected.

## Impact
Idle CPU drops from continuous full-buffer re-diff to ~0 draws when nothing changes (per ratatui community guidance: https://github.com/ratatui/ratatui/discussions/1927).

## Test plan
- `cargo clippy -p maki-ui --tests -- -D warnings` passes.
- Manual: launch maki, let it idle (observe no CPU churn), resize terminal (repaints correctly), stream a reply (animates smoothly), send key input (responds immediately).

🤖 Generated with opencode