### PR TITLE
feat(index): add YAML language indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2641,6 +2641,7 @@ dependencies = [
  "tree-sitter-starlark",
  "tree-sitter-swift",
  "tree-sitter-typescript",
+ "tree-sitter-yaml",
  "tree-sitter-zig",
  "unicode-width",
 ]
@@ -5405,6 +5406,16 @@ name = "tree-sitter-typescript"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-yaml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,7 @@ tree-sitter-swift = "0.7"
 tree-sitter-typescript = "0.23"
 tree-sitter-zig = "1.1"
 tree-sitter-dart = "0.2.0"
+tree-sitter-yaml = "0.7.2"
 monty = { git = "https://github.com/pydantic/monty.git", tag = "v0.0.18", package = "monty" }
 notify = { version = "9.0.0-rc.2", default-features = false, features = ["flume", "macos_fsevent"] }
 serde_yaml = "0.9"

--- a/maki-lua/Cargo.toml
+++ b/maki-lua/Cargo.toml
@@ -64,6 +64,7 @@ tree-sitter-swift = { workspace = true }
 tree-sitter-typescript = { workspace = true }
 tree-sitter-zig = { workspace = true }
 tree-sitter-dart = { workspace = true }
+tree-sitter-yaml = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 

--- a/maki-lua/src/language.rs
+++ b/maki-lua/src/language.rs
@@ -26,6 +26,7 @@ pub enum Language {
     Zig,
     Nix,
     Dart,
+    Yaml,
 }
 
 impl Language {
@@ -55,6 +56,7 @@ impl Language {
             "zig" => Some(Self::Zig),
             "nix" => Some(Self::Nix),
             "dart" => Some(Self::Dart),
+            "yaml" => Some(Self::Yaml),
             _ => None,
         }
     }
@@ -85,6 +87,7 @@ impl Language {
             "zig" => Some(Self::Zig),
             "nix" => Some(Self::Nix),
             "dart" => Some(Self::Dart),
+            "yaml" | "yml" => Some(Self::Yaml),
             _ => None,
         }
     }
@@ -115,6 +118,7 @@ impl Language {
             Self::Zig => tree_sitter_zig::LANGUAGE.into(),
             Self::Nix => tree_sitter_nix::LANGUAGE.into(),
             Self::Dart => tree_sitter_dart::LANGUAGE.into(),
+            Self::Yaml => tree_sitter_yaml::LANGUAGE.into(),
         }
     }
 }

--- a/plugins/index/indexer.lua
+++ b/plugins/index/indexer.lua
@@ -48,6 +48,8 @@ local EXT_TO_LANG = {
   zig = "zig",
   nix = "nix",
   dart = "dart",
+  yaml = "yaml",
+  yml = "yaml",
 }
 
 local FILENAME_TO_LANG = {

--- a/plugins/index/lang/yaml.lua
+++ b/plugins/index/lang/yaml.lua
@@ -1,0 +1,104 @@
+-- YAML is data, not code: there are no functions or types to extract.
+-- The useful skeleton is the top-level mapping keys (config sections, service
+-- names, etc.) with one level of nested mapping keys as their children, so a
+-- glance at the index shows the document's shape. Sequence values and scalars
+-- are not indexed on their own — they only matter as the body of the key that
+-- owns them. Sequences of mappings are unwrapped one level so a list of objects
+-- still contributes its keys.
+return function(U)
+  local get_text = U.get_text
+  local compact_ws = U.compact_ws
+  local new_entry = U.new_entry
+  local format_skeleton = U.format_skeleton
+  local SECTION = U.SECTION
+
+  local pair_entry, for_each_pair
+
+  local function key_text(pair, source)
+    local key_node = pair:field("key")[1]
+    if not key_node then
+      return nil
+    end
+    local raw = get_text(key_node, source)
+    local cleaned = compact_ws(raw):gsub("^%s+", ""):gsub("%s+$", "")
+    cleaned = cleaned:gsub('^"(.-)"$', "%1"):gsub("^'(.-)'$", "%1")
+    if cleaned == "" then
+      return nil
+    end
+    return cleaned
+  end
+
+  local SEQUENCE_KINDS = {
+    block_sequence = true,
+    block_sequence_item = true,
+    flow_sequence = true,
+  }
+
+  local function for_each_pair_fn(node, source, callback)
+    if not node then
+      return
+    end
+    local kind = node:type()
+    if kind == "block_node" or kind == "flow_node" or SEQUENCE_KINDS[kind] then
+      for _, child in ipairs(node:children()) do
+        for_each_pair(child, source, callback)
+      end
+      return
+    end
+    if kind == "block_mapping" or kind == "flow_mapping" then
+      for _, child in ipairs(node:children()) do
+        local ck = child:type()
+        if ck == "block_mapping_pair" or ck == "flow_pair" then
+          callback(child)
+        end
+      end
+    end
+  end
+  for_each_pair = for_each_pair_fn
+
+  local function pair_entry_fn(pair, source, recurse)
+    local key = key_text(pair, source)
+    if not key then
+      return nil
+    end
+    local entry = new_entry(SECTION.Constant, pair, key)
+    if recurse then
+      local children = {}
+      for_each_pair(pair:field("value")[1], source, function(child)
+        local e = pair_entry(child, source, false)
+        if e then
+          children[#children + 1] = e
+        end
+      end)
+      entry.children = children
+    end
+    return entry
+  end
+  pair_entry = pair_entry_fn
+
+  return {
+    extract = function(source, root)
+      local entries = {}
+      for _, child in ipairs(root:children()) do
+        if child:type() == "document" then
+          for _, doc_child in ipairs(child:children()) do
+            for_each_pair(doc_child, source, function(pair)
+              local e = pair_entry(pair, source, true)
+              if e then
+                entries[#entries + 1] = e
+              end
+            end)
+          end
+        else
+          for_each_pair(child, source, function(pair)
+            local e = pair_entry(pair, source, true)
+            if e then
+              entries[#entries + 1] = e
+            end
+          end)
+        end
+      end
+      return format_skeleton(entries, {}, nil, ".")
+    end,
+  }
+end

--- a/plugins/index/tests/lang/yaml.lua
+++ b/plugins/index/tests/lang/yaml.lua
@@ -1,0 +1,464 @@
+local helpers = require("tests.helpers")
+local case = helpers.case
+local idx = helpers.idx
+local has = helpers.has
+local lacks = helpers.lacks
+
+case("yaml_top_level_keys", function()
+  local src = [==[
+name: maki
+version: "0.4.0"
+description: AI coding agent
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "name",
+    "version",
+    "description",
+  })
+end)
+
+case("yaml_nested_mapping_as_children", function()
+  local src = [==[
+services:
+  web:
+    image: nginx
+    port: 80
+  db:
+    image: postgres
+    port: 5432
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "services",
+    "web",
+    "db",
+  })
+  lacks(out, {
+    "image",
+    "port",
+  })
+end)
+
+case("yaml_sequence_values_not_indexed", function()
+  local src = [==[
+env:
+  - FOO=1
+  - BAR=2
+ports:
+  - 8080
+  - 8443
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "env",
+    "ports",
+  })
+  lacks(out, {
+    "FOO=1",
+    "BAR=2",
+    "8080",
+  })
+end)
+
+case("yaml_flow_mapping_keys", function()
+  local src = [==[
+meta: {a: 1, b: 2}
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "meta",
+    "a",
+    "b",
+  })
+end)
+
+case("yaml_quoted_keys_preserved", function()
+  local src = [==[
+"full name": maki
+'machine': x86
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "full name",
+    "machine",
+  })
+end)
+
+case("yaml_multi_document_stream", function()
+  local src = [==[
+---
+title: first
+---
+title: second
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "title",
+  })
+end)
+
+case("yaml_sequence_of_mappings", function()
+  local src = [==[
+items:
+  - name: first
+    value: 1
+  - name: second
+    value: 2
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "items",
+    "name",
+    "value",
+  })
+  lacks(out, {
+    "first",
+    "second",
+    " 1 ",
+    " 2 ",
+  })
+end)
+
+case("yaml_top_level_sequence_of_mappings", function()
+  local src = [==[
+- name: alpha
+  value: 1
+- name: beta
+  value: 2
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "name",
+    "value",
+  })
+  lacks(out, {
+    "alpha",
+    "beta",
+  })
+end)
+
+case("yaml_flow_sequence_of_inline_tables", function()
+  local src = [==[
+items: [{name: a}, {name: b}]
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "items",
+    "name",
+  })
+  lacks(out, {
+    " a ",
+    " b ",
+  })
+end)
+
+case("yaml_block_scalar_not_indexed", function()
+  local src = [==[
+key: |
+  multi
+  line
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "key",
+  })
+  lacks(out, {
+    "multi",
+    "line",
+  })
+end)
+
+case("yaml_null_and_boolean_values", function()
+  local src = [==[
+enabled: true
+count: 42
+empty: null
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "enabled",
+    "count",
+    "empty",
+  })
+end)
+
+case("yaml_empty_mapping_and_sequence", function()
+  local src = [==[
+config: {}
+items: []
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "config",
+    "items",
+  })
+end)
+
+case("yaml_scalar_only_document", function()
+  local out = idx("just a scalar value\n", "yaml")
+  lacks(out, {
+    "consts:",
+    "scalar",
+  })
+end)
+
+case("yaml_comments_only", function()
+  local src = [==[
+# just a comment
+]==]
+  local out = idx(src, "yaml")
+  assert(out == "", "expected empty output for comment-only document")
+end)
+
+case("yaml_explicit_document_marker", function()
+  local src = [==[
+%YAML 1.2
+---
+name: marked
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "name",
+  })
+end)
+
+case("yaml_nested_flow_mapping_in_block", function()
+  local src = [==[
+settings:
+  tags: [a, b]
+  meta: {x: 1}
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "settings",
+    "tags",
+    "meta",
+  })
+  lacks(out, {
+    " a ",
+    " b ",
+    " 1 ",
+    " x ",
+  })
+end)
+
+case("yaml_mixed_quoted_and_unquoted_keys", function()
+  local src = [==[
+"first key": one
+second_key: two
+'3rd-key': three
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "first key",
+    "second_key",
+    "3rd-key",
+  })
+end)
+
+case("yaml_real_world_deployment", function()
+  local src = [==[
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          ports:
+            - containerPort: 80
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "apiVersion",
+    "kind",
+    "metadata",
+    "name",
+    "spec",
+    "replicas",
+    "template",
+  })
+  lacks(out, {
+    "containers",
+    "image",
+    "ports",
+    "nginx",
+    "nginx:latest",
+    "containerPort",
+    "80",
+  })
+end)
+
+case("yaml_ranged_meta", function()
+  local src = [==[
+name: maki
+metadata:
+  author: alice
+]==]
+  local out, meta = helpers.idx_with_meta(src, "yaml")
+  helpers.assert_ranged_meta(out, meta, {
+    "name",
+    "metadata",
+    "author",
+  })
+end)
+
+case("yaml_github_actions", function()
+  local src = [==[
+name: CI
+on:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo test
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "name",
+    "on",
+    "push",
+    "jobs",
+    "build",
+  })
+  lacks(out, {
+    "ubuntu-latest",
+    "actions/checkout@v4",
+    "cargo test",
+    "runs-on",
+    "steps",
+    "branches",
+    "main",
+  })
+end)
+
+case("yaml_docker_compose", function()
+  local src = [==[
+version: "3.8"
+services:
+  web:
+    image: nginx:latest
+    ports:
+      - "8080:80"
+    environment:
+      - DEBUG=1
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "version",
+    "services",
+    "web",
+  })
+  lacks(out, {
+    "nginx",
+    "8080:80",
+    "DEBUG=1",
+    "image",
+    "ports",
+    "environment",
+  })
+end)
+
+case("yaml_helm_values", function()
+  local src = [==[
+image:
+  repository: nginx
+  tag: "1.27"
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+ingress:
+  enabled: false
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "image",
+    "repository",
+    "tag",
+    "pullPolicy",
+    "service",
+    "type",
+    "port",
+    "ingress",
+    "enabled",
+  })
+  lacks(out, {
+    "nginx",
+    "1.27",
+    "ClusterIP",
+    "IfNotPresent",
+    " 80 ",
+  })
+end)
+
+case("yaml_top_level_flow_sequence_of_tables", function()
+  local src = [==[
+[{name: first}, {name: second}]
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "name",
+  })
+  lacks(out, {
+    " first",
+    " second",
+  })
+end)
+
+case("yaml_trailing_comma_flow_sequence", function()
+  local src = [==[
+items: [{name: a}, {name: b},]
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "items",
+    "name",
+  })
+end)
+
+case("yaml_empty_and_comment_documents", function()
+  local src = [==[
+---
+# document one
+title: first
+---
+# empty doc
+---
+title: last
+]==]
+  local out = idx(src, "yaml")
+  has(out, {
+    "consts:",
+    "title",
+  })
+end)

--- a/plugins/index/tests/spec.lua
+++ b/plugins/index/tests/spec.lua
@@ -28,6 +28,7 @@ require("tests.lang.rust")
 require("tests.lang.scala")
 require("tests.lang.swift")
 require("tests.lang.typescript")
+require("tests.lang.yaml")
 require("tests.lang.zig")
 
 require("tests.helpers").report()


### PR DESCRIPTION
## Summary

Adds YAML language indexing to the indexer plugin.

- Registers `tree-sitter-yaml` in `maki-lua` and the workspace `Cargo.toml`.
- Adds `plugins/index/lang/yaml.lua` extractor.
- Adds `plugins/index/tests/lang/yaml.lua` spec cases, wired into `plugins/index/tests/spec.lua`.
- Updates `plugins/index/indexer.lua` extension map and `maki-lua/src/language.rs` parser registry.
- Handles quoted keys, unwraps one level of nested mapping keys, and unwraps sequences of mappings so a list of objects still contributes its keys.

Also includes small clippy/forward-compatibility fixes required by the current toolchain:
- Simplify `map_or(' ', |c| c)` fallback in `permission_prompt.rs`.
- Replace `bail!` macro calls in expression positions with `return Err(eyre!(...))`.

## Test plan

- [x] `cargo clippy --all --tests -- -D warnings`
- [x] `cargo nextest run --workspace`