### PR TITLE
perf(agent): cache tool definitions in AgentLoop

### DIFF
--- a/maki-agent/src/template.rs
+++ b/maki-agent/src/template.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::env;
+use std::hash::{DefaultHasher, Hash, Hasher};
 
 use jiff::Timestamp;
 
@@ -37,6 +38,17 @@ impl Vars {
         }
         Cow::Owned(out)
     }
+
+    /// Cheap, order-sensitive digest of every (key, value) pair. Used as a
+    /// cache key so cached templated output is invalidated when any var changes.
+    pub fn content_hash(&self) -> u64 {
+        let mut h = DefaultHasher::new();
+        for (k, v) in &self.0 {
+            k.hash(&mut h);
+            v.hash(&mut h);
+        }
+        h.finish()
+    }
 }
 
 #[cfg(test)]
@@ -73,5 +85,22 @@ mod tests {
         let vars = env_vars();
         let result = vars.apply("{date}");
         assert_ne!(result.as_ref(), "{date}");
+    }
+
+    #[test]
+    fn content_hash_stable_until_a_var_changes() {
+        let a = Vars::new().set("{cwd}", "/x").set("{platform}", "linux");
+        let b = Vars::new().set("{cwd}", "/x").set("{platform}", "linux");
+        assert_eq!(a.content_hash(), b.content_hash());
+
+        let reordered = Vars::new().set("{platform}", "linux").set("{cwd}", "/x");
+        assert_ne!(
+            a.content_hash(),
+            reordered.content_hash(),
+            "hash is order-dependent"
+        );
+
+        let changed = Vars::new().set("{cwd}", "/y").set("{platform}", "linux");
+        assert_ne!(a.content_hash(), changed.content_hash());
     }
 }

--- a/maki-agent/src/tools/registry.rs
+++ b/maki-agent/src/tools/registry.rs
@@ -474,6 +474,15 @@ impl ToolRegistry {
     pub fn iter(&self) -> RegistrySnapshot {
         RegistrySnapshot(self.tools.load_full())
     }
+
+    /// Pins the current tool snapshot as a cloned `Arc`. Any later
+    /// `register`/`replace`/`clear` swaps in a fresh allocation, so
+    /// `Arc::ptr_eq` against a previously returned `Arc` detects the change.
+    /// Holding the old `Arc` keeps its allocation alive, so its address can't
+    /// be recycled by a future registration (ABA-safe).
+    pub fn snapshot_arc(&self) -> Arc<Vec<RegisteredTool>> {
+        self.tools.load_full()
+    }
 }
 
 pub struct RegistrySnapshot(Arc<Vec<RegisteredTool>>);
@@ -571,6 +580,23 @@ mod tests {
         reg.register(mock("dupe"), lua_source("p")).unwrap();
         let err = reg.register(mock("dupe"), lua_source("p")).unwrap_err();
         assert!(matches!(err, RegistryError::NameConflict { .. }));
+    }
+
+    #[test]
+    fn snapshot_arc_detects_registration() {
+        let reg = ToolRegistry::new();
+        let before = reg.snapshot_arc();
+        reg.register(mock("solo"), lua_source("p")).unwrap();
+        let after = reg.snapshot_arc();
+        assert!(
+            !Arc::ptr_eq(&before, &after),
+            "registering a tool must swap the snapshot Arc"
+        );
+        let again = reg.snapshot_arc();
+        assert!(
+            Arc::ptr_eq(&after, &again),
+            "snapshot is stable when nothing changes"
+        );
     }
 
     /// Tools added mid-session must show up in the next `definitions()` call.

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -8,7 +8,7 @@ use maki_agent::permissions::PermissionManager;
 use maki_agent::template;
 use maki_agent::template::Vars;
 use maki_agent::tools::{
-    DescriptionContext, FileReadTracker, ToolAudience, ToolFilter, ToolRegistry,
+    DescriptionContext, FileReadTracker, RegisteredTool, ToolAudience, ToolFilter, ToolRegistry,
 };
 use maki_agent::{
     Agent, AgentConfig, AgentEvent, AgentInput, AgentParams, AgentRunParams, CancelMap,
@@ -47,6 +47,15 @@ pub(super) struct AgentLoop {
     timeouts: maki_providers::Timeouts,
     lua_handle: Option<EventHandle>,
     subagent_cancels: Arc<CancelMap<String>>,
+    tools_cache: Option<ToolsCache>,
+}
+
+struct ToolsCache {
+    snap: Arc<Vec<RegisteredTool>>,
+    mcp_gen: Option<u64>,
+    model_id: String,
+    workflow: bool,
+    vars_hash: u64,
 }
 
 impl AgentLoop {
@@ -92,6 +101,7 @@ impl AgentLoop {
             timeouts,
             lua_handle,
             subagent_cancels,
+            tools_cache: None,
         }
     }
 
@@ -144,9 +154,8 @@ impl AgentLoop {
         self.publish_btw_system(&maki_agent::prompt::ResolvedSlots::default());
 
         let slot = self.model_slot.load();
-        self.tools = self.build_tools(&slot.model, false);
+        self.rebuild_tools(&slot.model, false);
         if let Some(ref mcp) = self.mcp_handle {
-            mcp.extend_tools(&mut self.tools);
             spawn_oauth_for_needs_auth(mcp);
         }
         !self.init_cancel.is_cancelled()
@@ -264,11 +273,33 @@ impl AgentLoop {
     }
 
     fn rebuild_tools(&mut self, model: &Model, workflow: bool) {
+        let snap = ToolRegistry::global().snapshot_arc();
+        let mcp_gen = self
+            .mcp_handle
+            .as_ref()
+            .map(|m| m.reader().load().generation);
+        let vars_hash = self.vars.content_hash();
+        if let Some(ref cache) = self.tools_cache
+            && Arc::ptr_eq(&cache.snap, &snap)
+            && cache.mcp_gen == mcp_gen
+            && cache.model_id == model.id
+            && cache.workflow == workflow
+            && cache.vars_hash == vars_hash
+        {
+            return;
+        }
         let mut tools = self.build_tools(model, workflow);
         if let Some(ref mcp) = self.mcp_handle {
             mcp.extend_tools(&mut tools);
         }
         self.tools = tools;
+        self.tools_cache = Some(ToolsCache {
+            snap,
+            mcp_gen,
+            model_id: model.id.clone(),
+            workflow,
+            vars_hash,
+        });
     }
 
     fn build_tools(&self, model: &Model, workflow: bool) -> Value {


### PR DESCRIPTION
## What

`AgentLoop::rebuild_tools` rebuilt the full tool-definition JSON array (`ToolRegistry::definitions` — iterate every tool, apply `Vars` to each description, build a `Value` per tool) on **every** agent run, even though the inputs rarely change between turns in a session.

This caches the result so a repeat build is skipped when nothing changed.

## How

Cache key: `(registry snapshot identity, MCP generation, model id, workflow flag, Vars content hash)`. On a hit `rebuild_tools` returns early, keeping the existing `self.tools`.

The registry identity is **ABA-safe**: `ToolRegistry::snapshot_arc()` pins the current `Arc<Vec<RegisteredTool>>`. Any `register` / `replace_plugin` / `clear_*` swaps in a fresh allocation, detected with `Arc::ptr_eq` — so a tool registered mid-session (MCP handshake, plugin reload) still invalidates the cache and shows up on the next turn (preserving the existing "rebuilt each request" guarantee).

MCP changes are detected via the existing `McpSnapshot::generation`.

## Changes

- `ToolRegistry::snapshot_arc` — cheap ABA-safe snapshot identity (one `load_full`).
- `Vars::content_hash` — order-sensitive digest for the cache key.
- `AgentLoop` — `tools_cache` field; `rebuild_tools` returns early on hit; `initialize` routes through `rebuild_tools` to prime the cache.

## Validation

- `cargo clippy -p maki-agent -p maki-ui --lib --tests -- -D warnings` clean (only a pre-existing unrelated `clippy::map_or_identity` on `origin/main` remains).
- `cargo nextest run -p maki-agent --lib`: 466 passed. `cargo nextest run -p maki-ui --lib` (agent/tool/message filters): 192 passed.
- New tests: `snapshot_arc_detects_registration`, `content_hash_stable_until_a_var_changes`.