### PR TITLE
feat(config): make input line limit configurable

### DIFF
--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -21,6 +21,9 @@ pub const DEFAULT_MAX_OUTPUT_LINES: usize = 2000;
 pub const DEFAULT_FLASH_DURATION_MS: u64 = 1500;
 pub const DEFAULT_TYPEWRITER_MS_PER_CHAR: u64 = 4;
 pub const DEFAULT_MOUSE_SCROLL_LINES: u32 = 3;
+pub const DEFAULT_MAX_INPUT_LINES: u32 = 20;
+
+pub const MIN_MAX_INPUT_LINES: u32 = 1;
 
 pub const DEFAULT_MAX_CONTINUATION_TURNS: u32 = 3;
 pub const DEFAULT_COMPACTION_BUFFER: CompactionBuffer = CompactionBuffer::Percent(20);
@@ -323,6 +326,7 @@ pub struct UiFileConfig {
     pub show_thinking: Option<bool>,
     pub theme: Option<String>,
     pub tool_output_lines: Option<ToolOutputLinesFile>,
+    pub max_input_lines: Option<u32>,
 }
 
 impl UiFileConfig {
@@ -336,7 +340,8 @@ impl UiFileConfig {
             typewriter_ms_per_char,
             mouse_scroll_lines,
             show_thinking,
-            theme
+            theme,
+            max_input_lines
         );
         match (self.tool_output_lines.as_mut(), overlay.tool_output_lines) {
             (Some(base), Some(over)) => base.merge(over),
@@ -813,6 +818,9 @@ pub struct UiConfig {
     #[config(default = DEFAULT_MOUSE_SCROLL_LINES, min = MIN_MOUSE_SCROLL_LINES, desc = "Lines per mouse wheel scroll")]
     pub mouse_scroll_lines: u32,
 
+    #[config(default = DEFAULT_MAX_INPUT_LINES, min = MIN_MAX_INPUT_LINES, desc = "Maximum visible input lines")]
+    pub max_input_lines: u32,
+
     #[config(
         default = true,
         desc = "When true (default), show full model reasoning live and persisted. When false, hide reasoning behind an indicator (thinking> ...) with a click-to-expand hint, both while thinking and after it completes"
@@ -840,6 +848,7 @@ impl UiConfig {
                 .typewriter_ms_per_char
                 .unwrap_or(DEFAULT_TYPEWRITER_MS_PER_CHAR),
             mouse_scroll_lines: f.mouse_scroll_lines.unwrap_or(DEFAULT_MOUSE_SCROLL_LINES),
+            max_input_lines: f.max_input_lines.unwrap_or(DEFAULT_MAX_INPUT_LINES),
             show_thinking: f.show_thinking.unwrap_or(true),
             theme: f.theme,
             tool_output_lines: ToolOutputLines::from_file(f.tool_output_lines),
@@ -2029,6 +2038,7 @@ mod tests {
     #[test_case("provider", "connect_timeout_secs", 0 ; "provider_zero_connect_timeout")]
     #[test_case("storage",  "max_log_files",        0 ; "storage_zero_log_files")]
     #[test_case("ui",       "mouse_scroll_lines",   0 ; "ui_zero_scroll_lines")]
+    #[test_case("ui",       "max_input_lines",      0 ; "ui_zero_max_input_lines")]
     #[test_case("agent",    "max_output_lines",     1 ; "agent_output_lines_too_low")]
     fn validate_rejects_invalid_sections(section: &str, field: &str, value: u64) {
         let mut config = Config {
@@ -2049,6 +2059,7 @@ mod tests {
             }
             ("storage", "max_log_files") => config.storage.max_log_files = value as u32,
             ("ui", "mouse_scroll_lines") => config.ui.mouse_scroll_lines = value as u32,
+            ("ui", "max_input_lines") => config.ui.max_input_lines = value as u32,
             ("agent", "max_output_lines") => config.agent.max_output_lines = value as usize,
             _ => unreachable!(),
         }
@@ -2441,6 +2452,16 @@ mod tests {
         let raw: RawConfig = toml::from_str("").unwrap();
         let config = raw.into_config(false).unwrap();
         assert!(config.ui.show_thinking);
+    }
+
+    #[test]
+    fn max_input_lines_defaults_and_deserializes() {
+        let raw: RawConfig = toml::from_str("").unwrap();
+        let config = raw.into_config(false).unwrap();
+        assert_eq!(config.ui.max_input_lines, DEFAULT_MAX_INPUT_LINES);
+
+        let raw: RawConfig = toml::from_str("[ui]\nmax_input_lines = 5\n").unwrap();
+        assert_eq!(raw.ui.max_input_lines.unwrap(), 5);
     }
 
     #[test_case("[ui]\nsplash_animaton = true\n" ; "top_level_typo")]

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -205,11 +205,15 @@ impl App {
         let state = SessionState::from_session(session, model, &storage);
         let typewriter = ui_config.typewriter_ms_per_char;
         let flash = ui_config.flash_duration();
+        let input_box = InputBox::new(
+            InputHistory::load(&storage, input_history_size),
+            ui_config.max_input_lines,
+        );
         let mut app = Self {
             chats: vec![Chat::new("Main".into(), ui_config.clone())],
             active_chat: 0,
             chat_index: HashMap::new(),
-            input_box: InputBox::new(InputHistory::load(&storage, input_history_size)),
+            input_box,
             command_palette: CommandPalette::new(
                 custom_commands,
                 mcp_reader.clone(),

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -80,7 +80,7 @@ impl App {
             let panel_h: u16 = self.float_mgr.panel_reqs().iter().map(|(_, h)| *h).sum();
             queue_panel::height(self.queue.panel_len())
                 + panel_h
-                + self.input_box.height(inner.width)
+                + self.input_box.height(inner.width).min(max_bottom)
         } else {
             let panel_h: u16 = self.float_mgr.panel_reqs().iter().map(|(_, h)| *h).sum();
             if panel_h > 0 { panel_h + 1 } else { 1 }

--- a/maki-ui/src/components/input.rs
+++ b/maki-ui/src/components/input.rs
@@ -22,7 +22,6 @@ use super::scrollbar::render_vertical_scrollbar;
 use super::{apply_scroll_delta, visual_line_count};
 use crate::selection::LineBreaks;
 
-const MAX_INPUT_LINES: u16 = 20;
 const CHEVRON: &str = super::CHEVRON;
 const NEWLINE_PAD: &str = "  ";
 const PREFIX_WIDTH: u16 = 2;
@@ -77,6 +76,7 @@ pub struct InputBox {
     follow_cursor: bool,
     placeholder_hint: &'static str,
     pending_images: Vec<ImageSource>,
+    max_input_lines: u16,
 }
 
 impl InputBox {
@@ -156,7 +156,8 @@ impl InputBox {
         self.handle_paste(&spaced)
     }
 
-    pub fn new(history: InputHistory) -> Self {
+    pub fn new(history: InputHistory, max_input_lines: u32) -> Self {
+        let max_input_lines = max_input_lines.clamp(1, u16::MAX as u32 - 2) as u16;
         Self {
             buffer: TextBuffer::new(String::new()),
             history,
@@ -166,6 +167,7 @@ impl InputBox {
             follow_cursor: true,
             placeholder_hint: random_placeholder_hint(),
             pending_images: Vec::new(),
+            max_input_lines,
         }
     }
 
@@ -198,7 +200,8 @@ impl InputBox {
         if !self.pending_images.is_empty() {
             visual_lines += 1;
         }
-        (visual_lines as u16).min(MAX_INPUT_LINES) + 2
+        let capped = visual_lines.min(self.max_input_lines as usize);
+        (capped + 2) as u16
     }
 
     pub fn is_at_first_line(&self) -> bool {
@@ -623,7 +626,7 @@ mod tests {
 
     #[test]
     fn submit() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         assert!(input.submit().is_none());
 
         type_text(&mut input, " ");
@@ -643,13 +646,13 @@ mod tests {
 
     #[test]
     fn backslash_continuation() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         type_text(&mut input, "hello\\");
         assert!(input.char_before_cursor_is_backslash());
         input.continue_line();
         assert_eq!(input.buffer.lines(), &["hello", ""]);
 
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         type_text(&mut input, "asd\\asd");
         for _ in 0..3 {
             input.buffer.move_left();
@@ -663,18 +666,27 @@ mod tests {
 
     #[test]
     fn height_capped_at_max() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         let base = input.height(TEST_WIDTH);
         for _ in 0..20 {
             input.buffer.add_line();
         }
         assert!(input.height(TEST_WIDTH) > base);
-        assert!(input.height(TEST_WIDTH) <= MAX_INPUT_LINES + 2);
+        assert!(input.height(TEST_WIDTH) <= 20 + 2);
+    }
+
+    #[test]
+    fn height_respects_configured_max() {
+        let mut input = InputBox::new(InputHistory::default(), 3);
+        for _ in 0..10 {
+            input.buffer.add_line();
+        }
+        assert_eq!(input.height(TEST_WIDTH), 3 + 2);
     }
 
     #[test]
     fn first_last_line() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         assert!(input.is_at_first_line());
         assert!(input.is_at_last_line());
 
@@ -689,7 +701,7 @@ mod tests {
 
     #[test]
     fn history() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
 
         input.history_up();
         input.history_down();
@@ -752,10 +764,10 @@ mod tests {
         let width: u16 = 12;
         let ew = effective_width(width as usize);
 
-        let mut at_boundary = InputBox::new(InputHistory::default());
+        let mut at_boundary = InputBox::new(InputHistory::default(), 20);
         type_text(&mut at_boundary, &"x".repeat(ew));
 
-        let mut before_boundary = InputBox::new(InputHistory::default());
+        let mut before_boundary = InputBox::new(InputHistory::default(), 20);
         type_text(&mut before_boundary, &"x".repeat(ew - 1));
 
         assert_eq!(
@@ -808,17 +820,17 @@ mod tests {
     #[test_case(20, true  ; "visible_when_content_overflows")]
     #[test_case(0,  false ; "hidden_when_content_fits")]
     fn scrollbar_visibility(extra_lines: usize, expect_visible: bool) {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         for _ in 0..extra_lines {
             input.buffer.add_line();
         }
-        let terminal = render_input(&mut input, 40, MAX_INPUT_LINES + 2);
+        let terminal = render_input(&mut input, 40, 20 + 2);
         assert_eq!(has_scrollbar_thumb(&terminal), expect_visible);
     }
 
     #[test]
     fn scroll_clamped_on_content_shrink() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         for _ in 0..20 {
             input.buffer.add_line();
         }
@@ -834,7 +846,7 @@ mod tests {
 
     #[test]
     fn multibyte_input_renders_without_panic() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         type_text(&mut input, "● grep> hello");
         input.buffer.move_home();
         input.buffer.move_right();
@@ -845,7 +857,7 @@ mod tests {
     #[test_case("●\\", true  ; "after_multibyte")]
     #[test_case("●", false   ; "inside_multibyte_would_be_false")]
     fn char_before_cursor_backslash(input: &str, expected: bool) {
-        let mut input_box = InputBox::new(InputHistory::default());
+        let mut input_box = InputBox::new(InputHistory::default(), 20);
         type_text(&mut input_box, input);
         assert_eq!(input_box.char_before_cursor_is_backslash(), expected);
     }
@@ -864,7 +876,7 @@ mod tests {
 
     #[test]
     fn prefix_on_single_line() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         type_text(&mut input, "hello");
         let terminal = render_input(&mut input, 20, 4);
         let row = rendered_row(&terminal, 1);
@@ -874,7 +886,7 @@ mod tests {
 
     #[test]
     fn prefix_on_multiline() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         type_text(&mut input, "aaa");
         input.buffer.add_line();
         type_text(&mut input, "bbb");
@@ -887,7 +899,7 @@ mod tests {
 
     #[test]
     fn wrapped_line_gets_no_padding() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         let ew = effective_width(14);
         type_text(&mut input, &"x".repeat(ew + 3));
         let terminal = render_input(&mut input, 14, 5);
@@ -906,10 +918,10 @@ mod tests {
 
     #[test]
     fn copy_text_includes_prefix() {
-        let input = InputBox::new(InputHistory::default());
+        let input = InputBox::new(InputHistory::default(), 20);
         assert_eq!(input.copy_text(), CHEVRON);
 
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         type_text(&mut input, "line1");
         input.buffer.add_line();
         type_text(&mut input, "line2");
@@ -918,7 +930,7 @@ mod tests {
 
     #[test]
     fn placeholder_has_prefix() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         let terminal = render_input(&mut input, 40, 4);
         let row = rendered_row(&terminal, 1);
         assert!(row.starts_with(CHEVRON), "placeholder row: {row:?}");
@@ -932,7 +944,7 @@ mod tests {
 
     #[test]
     fn submit_with_images() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
 
         input.attach_image(test_image());
         let sub = input.submit().unwrap();
@@ -951,7 +963,7 @@ mod tests {
 
     #[test]
     fn image_label_rendered() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         input.attach_image(test_image());
         let h = input.height(40);
         let terminal = render_input(&mut input, 40, h);
@@ -961,7 +973,7 @@ mod tests {
 
     #[test]
     fn height_accounts_for_pending_images() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         let base_height = input.height(TEST_WIDTH);
         input.attach_image(test_image());
         assert_eq!(input.height(TEST_WIDTH), base_height + 1);
@@ -979,7 +991,7 @@ mod tests {
     #[test_case("$(cmd)", "src/main.rs", " src/main.rs" ; "leading_after_closing_paren")]
     #[test_case("arr[0]", "src/main.rs", " src/main.rs" ; "leading_after_closing_bracket")]
     fn paste_with_spaces_leading(before: &str, paste: &str, expected_suffix: &str) {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         type_text(&mut input, before);
         input.handle_paste_with_spaces(paste);
         assert_eq!(input.buffer.value(), format!("{before}{expected_suffix}"));
@@ -991,7 +1003,7 @@ mod tests {
     #[test_case("in  between", 3, "file.rs", "in file.rs between" ; "neither_side_between_spaces")]
     #[test_case("read ''", 6, "src/main.rs", "read 'src/main.rs'" ; "neither_side_between_quotes")]
     fn paste_with_spaces_at_cursor(before: &str, cursor_at: usize, paste: &str, expected: &str) {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         type_text(&mut input, before);
         let back = before.chars().count() - cursor_at;
         for _ in 0..back {
@@ -1003,14 +1015,14 @@ mod tests {
 
     #[test]
     fn paste_with_spaces_empty_line() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         input.handle_paste_with_spaces("file.rs");
         assert_eq!(input.buffer.value(), "file.rs");
     }
 
     #[test]
     fn paste_with_spaces_text_has_leading_space() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         type_text(&mut input, "read");
         input.handle_paste_with_spaces(" file.rs");
         assert_eq!(input.buffer.value(), "read file.rs");
@@ -1018,7 +1030,7 @@ mod tests {
 
     #[test]
     fn paste_with_spaces_text_has_trailing_space() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         type_text(&mut input, "file");
         for _ in 0..4 {
             input.buffer.move_left();
@@ -1029,7 +1041,7 @@ mod tests {
 
     #[test]
     fn paste_with_spaces_multiline_buffer_cursor_on_second_line() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         input.handle_paste("first\nread");
         input.handle_paste_with_spaces("file.rs");
         assert_eq!(input.buffer.value(), "first\nread file.rs");
@@ -1037,7 +1049,7 @@ mod tests {
 
     #[test]
     fn paste_with_spaces_cursor_at_end_no_trailing() {
-        let mut input = InputBox::new(InputHistory::default());
+        let mut input = InputBox::new(InputHistory::default(), 20);
         type_text(&mut input, "read");
         input.handle_paste_with_spaces("file.rs");
         assert_eq!(input.buffer.value(), "read file.rs");

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -69,6 +69,7 @@ All fields are optional. Typos in field names cause an error right away.
 | `flash_duration_ms` | u64 | `1500` | - | Duration of flash messages (ms) |
 | `typewriter_ms_per_char` | u64 | `4` | - | Typewriter effect speed (ms/char) |
 | `mouse_scroll_lines` | u32 | `3` | 1 | Lines per mouse wheel scroll |
+| `max_input_lines` | u32 | `20` | 1 | Maximum visible input lines |
 | `show_thinking` | bool | `true` | - | When true (default), show full model reasoning live and persisted. When false, hide reasoning behind an indicator (thinking> ...) with a click-to-expand hint, both while thinking and after it completes |
 
 ### `ui.theme`


### PR DESCRIPTION
## Summary
Move the hard-coded 20-line cap on the input box into `UiConfig` as `max_input_lines` so users can adjust it without rebuilding. The default remains 20.

## Changes
- Add `max_input_lines` to `UiConfig` and `UiFileConfig` with `DEFAULT_MAX_INPUT_LINES = 20`.
- Add `InputBox::set_max_input_lines` and use it in `App::new`.
- Add unit tests for the configurable cap and config parsing.

## Visual
With `max_input_lines = 3` the input box stops expanding after three visible lines:

![maki configurable max input lines demo](https://vhs.charm.sh/vhs-ZNOJAkvF6wQJWFRlCIgss.gif)

#### Test plan
- [x] `cargo clippy -p maki-config -p maki-ui --tests -- -D warnings`
- [x] `cargo nextest run -p maki-config -p maki-ui`