### PR TITLE
perf(ui): stop /reload from waiting on disk and serial shutdowns

### DIFF
--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -161,6 +161,22 @@ impl PluginHost {
         Self { inner: None }
     }
 
+    /// Stop the Lua thread from taking new work without joining it, so the
+    /// caller can rebuild shared state (like the tool registry) while the
+    /// old VM winds down on its own. The flag makes the watchdog abort
+    /// in-flight callbacks, `Shutdown` on the priority lane skips ahead of
+    /// queued bulk work, and swapping the senders for disconnected ones
+    /// makes every later host call fail right at the send; `&mut self`
+    /// rules out a call racing the swap. `Drop` still joins the thread.
+    pub fn begin_shutdown(&mut self) {
+        if let Some(ref mut inner) = self.inner {
+            inner.shutdown.store(true, Ordering::Release);
+            let _ = inner.prio_tx.send(Request::Shutdown);
+            inner.tx = flume::unbounded().0;
+            inner.prio_tx = flume::unbounded().0;
+        }
+    }
+
     /// Boots the runtime and loads every default bundled plugin into `registry`.
     /// For callers like tests and docgen that want the full builtin set
     /// without building a config.
@@ -563,6 +579,50 @@ mod tests {
         let mut host = PluginHost::disabled();
         host.load_builtins(&PluginsConfig::from_plugins(HashMap::new()))
             .unwrap();
+    }
+
+    /// The second call sends `Shutdown` on a sender that is already
+    /// disconnected; it must swallow that error and keep rejecting work.
+    #[test]
+    fn begin_shutdown_rejects_later_loads_and_is_idempotent() {
+        let mut host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        host.begin_shutdown();
+        assert!(host.load_source("late", "return {}").is_err());
+        host.begin_shutdown();
+        assert!(host.load_source("later", "return {}").is_err());
+    }
+
+    #[test]
+    fn begin_shutdown_on_disabled_host_is_noop() {
+        PluginHost::disabled().begin_shutdown();
+    }
+
+    /// Regression for the exit drain in `runtime::spawn`. An `EventHandle`
+    /// clone keeps queued requests alive after the Lua thread exits, and
+    /// dispatch prefers the priority lane, so a bulk request queued behind
+    /// `Shutdown` is never served. Without the drain its reply sender lives
+    /// forever and `collect_prompt_slots` blocks; with it, the call falls
+    /// back to defaults right away.
+    #[test]
+    fn live_event_handle_does_not_hang_after_begin_shutdown() {
+        let mut host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        host.load_source(
+            "hinted",
+            r#"maki.api.register_prompt_hint({ slot = "tool_usage", content = "live" })"#,
+        )
+        .unwrap();
+        let handle = host.event_handle().unwrap();
+        host.begin_shutdown();
+
+        let slots = handle.collect_prompt_slots();
+        assert!(
+            contents(&slots, PromptId::System, Slot::ToolUsage).is_empty(),
+            "dead host must yield defaults, not real slots"
+        );
+
+        drop(host);
+        let slots = handle.collect_prompt_slots();
+        assert!(contents(&slots, PromptId::System, Slot::ToolUsage).is_empty());
     }
 
     /// Load `src` as one plugin, collect resolved slots.

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -2414,6 +2414,12 @@ pub fn spawn(
                     }
                 }
             }));
+            // Clones of the host (`EventHandle`, `LuaTool`) can still hold
+            // a live sender, so dropping the receivers alone does not free
+            // queued requests. Drain them so their reply channels drop and
+            // no caller blocks on a dead host.
+            for _ in rx.drain() {}
+            for _ in prio_rx.drain() {}
         })
         .map_err(|e| PluginError::Io {
             path: PathBuf::from("lua-thread"),

--- a/maki-ui/src/agent/mod.rs
+++ b/maki-ui/src/agent/mod.rs
@@ -150,28 +150,39 @@ impl AgentHandles {
         old.cancel();
     }
 
-    pub(crate) fn shutdown(self, timeout: Duration) {
-        let _ = self.cmd_tx.try_send(AgentCommand::CancelAll);
-        let task = self.task;
-        drop((self.cmd_tx, self.agent_rx, self.answer_tx, self.queue));
-        info!("waiting for agent to finish (timeout {timeout:?})");
-        smol::block_on(async {
-            let finished = futures_lite::future::or(
-                async {
-                    task.await;
-                    true
-                },
-                async {
-                    smol::Timer::after(timeout).await;
-                    false
-                },
-            )
-            .await;
-            if !finished {
-                warn!("agent did not finish within {timeout:?}, forcing shutdown");
-            }
-        });
+    /// Hand back the agent task, dropping every channel so the loop can
+    /// wind down. The caller sends `CancelAll` first and then awaits all
+    /// tabs at once via [`join_all`] instead of paying a serial timeout
+    /// per tab.
+    pub(crate) fn into_task(self) -> smol::Task<()> {
+        self.task
     }
+}
+
+/// Wait for every agent task under one shared timeout, not one per task.
+pub(crate) fn join_all(tasks: Vec<smol::Task<()>>, timeout: Duration) {
+    info!(
+        count = tasks.len(),
+        "waiting for agents to finish (timeout {timeout:?})"
+    );
+    smol::block_on(async {
+        let finished = futures_lite::future::or(
+            async {
+                for task in tasks {
+                    task.await;
+                }
+                true
+            },
+            async {
+                smol::Timer::after(timeout).await;
+                false
+            },
+        )
+        .await;
+        if !finished {
+            warn!("agents did not finish within {timeout:?}, forcing shutdown");
+        }
+    });
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -243,5 +254,37 @@ fn spawn_agent_internal(
         queue: queue_tx,
         timeouts,
         task,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use super::*;
+
+    const LONG_TIMEOUT: Duration = Duration::from_secs(60);
+    const SHORT_TIMEOUT: Duration = Duration::from_millis(50);
+
+    #[test]
+    fn join_all_returns_when_all_tasks_complete() {
+        join_all(Vec::new(), LONG_TIMEOUT);
+        join_all(
+            (0..3).map(|_| smol::spawn(async {})).collect(),
+            LONG_TIMEOUT,
+        );
+    }
+
+    #[test]
+    fn join_all_stuck_task_returns_after_shared_timeout() {
+        let start = Instant::now();
+        join_all(
+            vec![
+                smol::spawn(async {}),
+                smol::spawn(futures_lite::future::pending::<()>()),
+            ],
+            SHORT_TIMEOUT,
+        );
+        assert!(start.elapsed() >= SHORT_TIMEOUT);
     }
 }

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -71,6 +71,7 @@ pub(crate) use mode::{Mode, PlanState, PlanTrigger};
 #[cfg(test)]
 use mouse::EDGE_SCROLL_LINES;
 pub(crate) use queue::{MessageQueue, SubmitOutcome};
+pub(crate) use session::session_has_content;
 use session_state::SessionState;
 
 const CANCEL_MSG: &str = "Cancelled.";

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -15,19 +15,20 @@ use super::session_state::{SessionState, stored_to_rules};
 use super::{App, Mode, PendingInput, PlanState};
 use crate::agent::QueuedMessage;
 
+/// The single content predicate: `App::save_session` persists a session
+/// iff this holds, and the shutdown path reuses it to tell which tabs were
+/// saved, so the report and the disk can never disagree. Sync the session
+/// first (`save_session` does).
+pub(crate) fn session_has_content(session: &AppSession) -> bool {
+    !session.messages.is_empty()
+        || session.meta.input_draft.is_some()
+        || !session.meta.queued_messages.is_empty()
+        || session.meta.mode != Some(maki_storage::sessions::StoredMode::Build)
+}
+
 impl App {
-    pub(crate) fn has_messages(&self) -> bool {
-        !self.state.session.messages.is_empty()
-    }
-
-    pub(crate) fn has_ephemeral(&self) -> bool {
-        self.state.session.meta.input_draft.is_some()
-            || !self.state.session.meta.queued_messages.is_empty()
-            || self.state.session.meta.mode != Some(maki_storage::sessions::StoredMode::Build)
-    }
-
     pub(crate) fn has_content(&self) -> bool {
-        self.has_messages() || self.has_ephemeral()
+        session_has_content(&self.state.session)
     }
 
     pub(crate) fn save_session(&mut self) {

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -15,7 +15,7 @@ use maki_agent::{
 use maki_config::{PermissionsConfig, UiConfig};
 use maki_lua::{HintReader, KeymapReader, LuaCommandReader};
 use maki_providers::{ContentBlock, Effort, Role, TokenUsage};
-use maki_storage::sessions::StoredThinking;
+use maki_storage::sessions::{StoredMode, StoredThinking};
 use ratatui::layout::Rect;
 use std::env;
 use std::path::{Path, PathBuf};
@@ -1539,17 +1539,54 @@ fn submit_exit_quits() {
 }
 
 #[test]
-fn persisted_tab_none_for_empty_some_for_content() {
+fn session_has_content_covers_each_branch() {
+    let mut session = AppSession::new("test-model", "/tmp/test");
+    assert!(!session_has_content(&session));
+
+    session.meta.input_draft = Some("draft".into());
+    assert!(session_has_content(&session));
+    session.meta.input_draft = None;
+
+    session.meta.queued_messages = vec!["queued".into()];
+    assert!(session_has_content(&session));
+    session.meta.queued_messages.clear();
+
+    session.meta.mode = Some(StoredMode::Plan);
+    assert!(session_has_content(&session));
+    session.meta.mode = Some(StoredMode::Build);
+
+    session.messages.push(Message::user("hello".into()));
+    assert!(session_has_content(&session));
+}
+
+#[test]
+fn save_session_syncs_ephemeral_content_into_meta() {
     let mut app = test_app();
     app.save_session();
-    assert_eq!(crate::event_loop::persisted_tab(&app), None);
+    assert!(!session_has_content(&app.state.session));
 
     app.update(Msg::Key(key(KeyCode::Char('x'))));
     app.save_session();
-    assert_eq!(
-        crate::event_loop::persisted_tab(&app),
-        Some(app.state.session.id)
-    );
+    assert!(session_has_content(&app.state.session));
+
+    app.update(Msg::Key(key(KeyCode::Backspace)));
+    app.save_session();
+    assert!(app.state.session.meta.input_draft.is_none());
+    assert!(!session_has_content(&app.state.session));
+
+    app.update(Msg::Key(key(KeyCode::Tab)));
+    app.save_session();
+    assert_eq!(app.state.session.meta.mode, Some(StoredMode::Plan));
+    assert!(session_has_content(&app.state.session));
+
+    let mut queued = app_with_queued_message();
+    queued.save_session();
+    let session = &queued.state.session;
+    assert!(session.messages.is_empty());
+    assert!(session.meta.input_draft.is_none());
+    assert_eq!(session.meta.mode, Some(StoredMode::Build));
+    assert_eq!(session.meta.queued_messages, vec!["queued".to_string()]);
+    assert!(session_has_content(session));
 }
 
 fn drain_writer(app: App, writer: Arc<StorageWriter>) {

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -54,11 +54,11 @@ const AGENT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
 const DELETE_FOCUSED_ERR: &str = "cannot delete the focused session";
 const NOT_LIVE_ERR: &str = "session not live";
 
-/// Per-tab persistence outcome after `shutdown`: `Some` iff the tab had
-/// content and was saved; `None` means a deliberately unpersisted empty tab.
+/// Tabs carry their in-memory sessions so `/reload` reopens them without a
+/// disk round-trip; `session_has_content` tells which ones were saved.
 pub(crate) struct ShutdownReport {
     pub exit: ExitRequest,
-    pub tabs: Vec<Option<MakiId>>,
+    pub tabs: Vec<AppSession>,
     pub focused: usize,
 }
 
@@ -1094,15 +1094,18 @@ impl<'t> EventLoop<'t> {
             let _ = rt.handles.cmd_tx.try_send(AgentCommand::CancelAll);
         }
         let mut tabs = Vec::with_capacity(self.sessions.len());
+        let mut agent_tasks = Vec::with_capacity(self.sessions.len());
         for rt in self.sessions.drain(..) {
             let SessionRuntime {
                 mut app, handles, ..
             } = rt;
             app.save_session();
-            tabs.push(persisted_tab(&app));
-            drop(app);
-            handles.shutdown(AGENT_SHUTDOWN_TIMEOUT);
+            // `app` drops at the end of this iteration, closing the
+            // channels the agent loop waits on, so `join_all` can finish.
+            tabs.push(app.state.session);
+            agent_tasks.push(handles.into_task());
         }
+        crate::agent::join_all(agent_tasks, AGENT_SHUTDOWN_TIMEOUT);
         if let Some(ref h) = self.ctx.mcp_handle {
             smol::block_on(h.shutdown());
         }
@@ -1118,12 +1121,6 @@ impl<'t> EventLoop<'t> {
             focused: self.focused,
         }
     }
-}
-
-/// Uses the same `has_content` check as `App::save_session`, so the report
-/// and the disk can never disagree about which tabs were saved.
-pub(crate) fn persisted_tab(app: &App) -> Option<MakiId> {
-    app.has_content().then_some(app.state.session.id)
 }
 
 fn scroll_delta(kind: MouseEventKind, lines: u32) -> i32 {

--- a/maki-ui/src/lib.rs
+++ b/maki-ui/src/lib.rs
@@ -38,15 +38,15 @@ pub type AppSession = maki_storage::sessions::Session<Message, TokenUsage, ToolO
 pub(crate) use agent::AgentCommand;
 pub use event_loop::EventLoopParams;
 
-/// How a UI generation ended. On `Reload`, each tab is its saved session id,
-/// or `None` for an empty tab, so the caller can reopen everything from disk.
+/// How a UI generation ended. On `Reload`, each tab carries its in-memory
+/// session so the caller reopens everything without re-reading from disk.
 pub enum RunOutcome {
     Exit {
         session_id: Option<MakiId>,
         code: i32,
     },
     Reload {
-        tabs: Vec<Option<MakiId>>,
+        tabs: Vec<AppSession>,
         focused: usize,
     },
 }
@@ -63,7 +63,11 @@ pub fn run(params: EventLoopParams, initial_prompt: Option<String>) -> Result<Ru
             focused: report.focused,
         },
         _ => RunOutcome::Exit {
-            session_id: report.tabs.get(report.focused).copied().flatten(),
+            session_id: report
+                .tabs
+                .get(report.focused)
+                .filter(|s| app::session_has_content(s))
+                .map(|s| s.id),
             code: report.exit.code(),
         },
     })

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::io::{self, IsTerminal, Read};
 use std::path::Path;
 use std::sync::Arc;
+use std::thread::{self, JoinHandle};
 
 use color_eyre::Result;
 use color_eyre::eyre::Context;
@@ -21,8 +22,6 @@ use crate::setup;
 const FALLBACK_MODEL_SPEC: &str = "anthropic/claude-sonnet-4-20250514";
 const CONFIG_FALLBACK_WARNING: &str = "config reload failed, using previous config";
 const MODEL_FALLBACK_WARNING: &str = "model resolution failed, keeping previous model";
-const RELOAD_TAB_WARNING: &str = "failed to reopen session";
-const RESUME_HINT: &str = "maki -s";
 
 /// One generation of the app: everything torn down and rebuilt on `/reload`.
 /// Dropping it joins the Lua thread via `PluginHost::drop`.
@@ -41,6 +40,35 @@ impl Stack {
             low_speed: self.config.provider.low_speed_timeout,
             stream: self.config.provider.stream_timeout,
         }
+    }
+}
+
+/// Background teardown of the previous generation. `defer` keeps the slow
+/// drop (a Lua thread join, capped at 2s in `PluginHost::drop`) off the
+/// `/reload` hot path. Joining on replace and on drop covers every exit
+/// path, including `?` unwinds, so no VM is abandoned mid-shutdown and at
+/// most one teardown is ever in flight.
+#[derive(Default)]
+struct Teardown(Option<JoinHandle<()>>);
+
+impl Teardown {
+    fn defer(&mut self, work: impl FnOnce() + Send + 'static) {
+        self.join();
+        self.0 = Some(thread::spawn(work));
+    }
+
+    fn join(&mut self) {
+        if let Some(handle) = self.0.take()
+            && handle.join().is_err()
+        {
+            tracing::warn!("background teardown panicked");
+        }
+    }
+}
+
+impl Drop for Teardown {
+    fn drop(&mut self) {
+        self.join();
     }
 }
 
@@ -189,34 +217,6 @@ fn resolve_session(
     Ok(AppSession::new(model, cwd))
 }
 
-/// Reopen every tab from disk after a reload. A saved tab that fails to load
-/// flashes a warning and comes back fresh; a `None` slot was empty and starts
-/// as a new session.
-fn resolve_reload_tabs(
-    ids: &[Option<MakiId>],
-    model: &str,
-    cwd: &str,
-    storage: &StateDir,
-    warnings: &mut Vec<String>,
-) -> Vec<AppSession> {
-    let mut tabs: Vec<AppSession> = ids
-        .iter()
-        .map(|slot| match slot {
-            Some(id) => AppSession::load(*id, storage).unwrap_or_else(|e| {
-                warnings.push(format!(
-                    "{RELOAD_TAB_WARNING} {id}: {e}; it is still on disk, try `{RESUME_HINT} {id}`"
-                ));
-                AppSession::new(model, cwd)
-            }),
-            None => AppSession::new(model, cwd),
-        })
-        .collect();
-    if tabs.is_empty() {
-        tabs.push(AppSession::new(model, cwd));
-    }
-    tabs
-}
-
 fn read_initial_prompt(cli_prompt: Option<String>) -> Result<Option<String>> {
     match cli_prompt {
         Some(p) => Ok(Some(p)),
@@ -295,6 +295,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
     let mut focused = 0;
     let mut warnings: Vec<String> = Vec::new();
     let mut initial_prompt = read_initial_prompt(cli.initial_prompt.take())?;
+    let mut teardown = Teardown::default();
 
     loop {
         for session in &mut tabs {
@@ -347,29 +348,39 @@ pub fn run(mut cli: Cli) -> Result<()> {
                     eprintln!("Resume session:\n\n  maki -s {session_id}");
                 }
                 if code != 0 {
+                    teardown.join();
                     std::process::exit(code);
                 }
                 return Ok(());
             }
             RunOutcome::Reload {
-                tabs: ids,
+                tabs: reloaded,
                 focused: f,
             } => {
+                let started = std::time::Instant::now();
                 let last_good = (stack.config.clone(), stack.model.clone());
-                drop(stack);
+                // Shut the old host down first so nothing can repopulate
+                // the registry after the clear: its senders disconnect, the
+                // watchdog aborts in-flight callbacks, and only this thread
+                // issues loads. The old VM then shares nothing with the new
+                // stack, so its slow join (up to 2s) can run on a
+                // background thread.
+                stack.plugin_host.begin_shutdown();
                 ToolRegistry::global().clear_lua();
-                let (new_stack, mut new_warnings) =
-                    build_stack(&cli, &cwd, &storage, Some(last_good))?;
-                tabs = resolve_reload_tabs(
-                    &ids,
-                    &new_stack.model.spec(),
-                    &cwd_str,
-                    &storage,
-                    &mut new_warnings,
-                );
+                teardown.defer(move || drop(stack));
+                let (new_stack, new_warnings) = build_stack(&cli, &cwd, &storage, Some(last_good))?;
+                tabs = reloaded;
+                if tabs.is_empty() {
+                    tabs.push(AppSession::new(&new_stack.model.spec(), &cwd_str));
+                }
                 stack = new_stack;
                 warnings = new_warnings;
                 focused = f.min(tabs.len() - 1);
+                tracing::info!(
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    tabs = tabs.len(),
+                    "reload: rebuilt plugins and config"
+                );
             }
         }
     }
@@ -395,10 +406,43 @@ mod tests {
     use super::*;
     use color_eyre::eyre::eyre;
     use maki_config::RawConfig;
-    use tempfile::TempDir;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
-    const TEST_MODEL: &str = "test/model";
-    const TEST_CWD: &str = "/tmp/reload-test";
+    /// `second_saw_first` requires both joins: `defer` joining the first
+    /// closure before spawning the second, and `Drop` joining the second
+    /// before the assert reads the flag.
+    #[test]
+    fn teardown_defer_joins_previous_and_drop_joins_last() {
+        let first_done = Arc::new(AtomicBool::new(false));
+        let second_saw_first = Arc::new(AtomicBool::new(false));
+        let mut teardown = Teardown::default();
+
+        let set = Arc::clone(&first_done);
+        teardown.defer(move || set.store(true, Ordering::Release));
+
+        let read = Arc::clone(&first_done);
+        let record = Arc::clone(&second_saw_first);
+        teardown.defer(move || record.store(read.load(Ordering::Acquire), Ordering::Release));
+
+        drop(teardown);
+        assert!(second_saw_first.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn teardown_swallows_panic_and_keeps_working() {
+        let prev_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+
+        let after_panic_ran = Arc::new(AtomicBool::new(false));
+        let mut teardown = Teardown::default();
+        teardown.defer(|| panic!("intentional"));
+        let set = Arc::clone(&after_panic_ran);
+        teardown.defer(move || set.store(true, Ordering::Release));
+        drop(teardown);
+
+        std::panic::set_hook(prev_hook);
+        assert!(after_panic_ran.load(Ordering::Acquire));
+    }
 
     fn test_config() -> Config {
         RawConfig::default()
@@ -433,100 +477,5 @@ mod tests {
         };
         assert!(err.to_string().contains("boom"));
         assert!(warnings.is_empty());
-    }
-
-    fn temp_storage() -> (TempDir, StateDir) {
-        let dir = TempDir::new().expect("tempdir");
-        let storage = StateDir::from_path(dir.path().to_path_buf());
-        (dir, storage)
-    }
-
-    #[test]
-    fn resolve_reload_roundtrips_saved_session() {
-        let (_dir, storage) = temp_storage();
-        let mut session = AppSession::new(TEST_MODEL, TEST_CWD);
-        session.title = "persisted title".into();
-        session.save(&storage).expect("save");
-        let id = session.id;
-        let mut warnings = Vec::new();
-
-        let tabs = resolve_reload_tabs(&[Some(id)], TEST_MODEL, TEST_CWD, &storage, &mut warnings);
-
-        assert_eq!(tabs.len(), 1);
-        assert_eq!(tabs[0].id, id);
-        assert_eq!(tabs[0].title, "persisted title");
-        assert!(warnings.is_empty(), "{warnings:?}");
-    }
-
-    #[test]
-    fn resolve_reload_missing_id_warns_and_falls_back_fresh() {
-        let (_dir, storage) = temp_storage();
-        let missing = MakiId::generate();
-        let mut warnings = Vec::new();
-
-        let tabs = resolve_reload_tabs(
-            &[Some(missing)],
-            TEST_MODEL,
-            TEST_CWD,
-            &storage,
-            &mut warnings,
-        );
-
-        assert_eq!(tabs.len(), 1);
-        assert_ne!(tabs[0].id, missing);
-        assert_eq!(warnings.len(), 1, "{warnings:?}");
-        assert!(warnings[0].starts_with(RELOAD_TAB_WARNING), "{warnings:?}");
-        assert!(warnings[0].contains(&missing.to_string()), "{warnings:?}");
-        assert!(warnings[0].contains(RESUME_HINT), "{warnings:?}");
-    }
-
-    #[test]
-    fn resolve_reload_none_slot_becomes_fresh_session() {
-        let (_dir, storage) = temp_storage();
-        let mut warnings = Vec::new();
-
-        let tabs = resolve_reload_tabs(&[None], TEST_MODEL, TEST_CWD, &storage, &mut warnings);
-
-        assert_eq!(tabs.len(), 1);
-        assert_eq!(tabs[0].model, TEST_MODEL);
-        assert_eq!(tabs[0].cwd, TEST_CWD);
-        assert!(warnings.is_empty(), "{warnings:?}");
-    }
-
-    #[test]
-    fn resolve_reload_empty_ids_yields_one_fresh_tab() {
-        let (_dir, storage) = temp_storage();
-        let mut warnings = Vec::new();
-
-        let tabs = resolve_reload_tabs(&[], TEST_MODEL, TEST_CWD, &storage, &mut warnings);
-
-        assert_eq!(tabs.len(), 1);
-        assert_eq!(tabs[0].model, TEST_MODEL);
-        assert!(warnings.is_empty(), "{warnings:?}");
-    }
-
-    #[test]
-    fn resolve_reload_preserves_tab_order_with_mixed_slots() {
-        let (_dir, storage) = temp_storage();
-        let mut saved = AppSession::new(TEST_MODEL, TEST_CWD);
-        saved.save(&storage).expect("save");
-        let saved_id = saved.id;
-        let missing = MakiId::generate();
-        let mut warnings = Vec::new();
-
-        let tabs = resolve_reload_tabs(
-            &[Some(saved_id), None, Some(missing)],
-            TEST_MODEL,
-            TEST_CWD,
-            &storage,
-            &mut warnings,
-        );
-
-        assert_eq!(tabs.len(), 3);
-        assert_eq!(tabs[0].id, saved_id);
-        assert_ne!(tabs[1].id, saved_id);
-        assert_ne!(tabs[2].id, missing);
-        assert_eq!(warnings.len(), 1, "{warnings:?}");
-        assert!(warnings[0].contains(&missing.to_string()), "{warnings:?}");
     }
 }


### PR DESCRIPTION
Reloading felt slow because three waits stacked up: every tab re-read and parsed its whole session JSONL from disk (10MB+ for long sessions), each agent task was joined one by one with its own 3s timeout, and the old Lua VM teardown (a thread join with a 2s cap) blocked the rebuild.

`RunOutcome::Reload` now hands the in-memory sessions straight to the next generation, so disk is only written, never read back.

Agent tasks release their channels first and are joined together under one shared timeout, and the old stack drops on a background thread once the tool registry is cleared, since it shares nothing with the new one.

The storage writer drain stays synchronous on purpose: the next generation opens a new writer on the same files, and overlapping writers would tear the session logs.

The rebuild also logs `reload: rebuilt plugins and config` with `elapsed_ms`, so the next slow reload shows where the time went.