### PR TITLE
refactor(build nix): use crane

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,50 @@
+name: Nix
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - "flake.*"
+              - "**.nix"
+              - "Cargo.toml"
+              - "Cargo.lock"
+              - "**.rs"
+              - "**.toml"
+              - "**.lua"
+              - "plugins/**"
+              - "prompts/**"
+              - "themes/**"
+              - "words/**"
+              - ".github/workflows/nix.yml"
+
+  build:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+        with:
+          use-flakehub: false
+      - name: Check hash drift
+        run: nix build .#checks.x86_64-linux.git-dep-hashes
+      - name: Check Nix formatting
+        run: nix build .#checks.x86_64-linux.fmt
+      - name: Build
+        run: nix build

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ runs.csv
 /.direnv/
 /site/_build/
 /site/.bin/
+/result

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,13 @@ Maki is an AI coding agent (like Claude Code and opencode), that is built bottom
 
 Read `justfile` for more.
 
+## Nix
+
+- `nix build` — build the project in a sandboxed environment
+- `nix develop` — enter the dev shell (Rust toolchain, formatters, CLI tools)
+- `nix fmt` — format all `.nix` files with `nixfmt`
+- `nix flake check` — run all flake checks (including git-dep-hashes drift detection)
+
 ## Architecture
 
 Rust workspace, key crates in root dir:

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,27 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1784407669,
+        "narHash": "sha256-gcFMcRjw0ZSn380Rx2QLlU1goUQeSrKX/DF12omI6+o=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "1316b7d278ad77a16aec024b71d971366e123bec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783224372,
-        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
         "type": "github"
       },
       "original": {
@@ -18,7 +33,29 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "crane": "crane",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784438913,
+        "narHash": "sha256-NYF7ZM5ip0u+w1pBFDpIGEbrbgN/wpnLFAmBkWkYMXw=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "afacd6819d3765a05814ee8e3de74c77d42ac799",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,13 +3,21 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    crane.url = "github:ipetkov/crane";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =
-    { self, nixpkgs }:
+    {
+      nixpkgs,
+      crane,
+      rust-overlay,
+      ...
+    }:
     let
       lib = nixpkgs.lib;
-      cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+      cargoToml = fromTOML (builtins.readFile ./Cargo.toml);
       packageName = cargoToml.package.name;
       version = cargoToml.workspace.package.version;
       systems = [
@@ -18,72 +26,188 @@
         "x86_64-darwin"
         "aarch64-darwin"
       ];
-      forEachSystem = f: lib.genAttrs systems (system: f system (import nixpkgs { inherit system; }));
+      forEachSystem =
+        f:
+        lib.genAttrs systems (
+          system:
+          f system (
+            import nixpkgs {
+              inherit system;
+              overlays = [ (import rust-overlay) ];
+            }
+          )
+        );
+
+      mkCraneLib =
+        pkgs:
+        let
+          rustToolchain = pkgs.rust-bin.stable."1.95.0".default.override {
+            extensions = [
+              "rust-src"
+              "rust-analyzer"
+            ];
+          };
+        in
+        (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+      mkWorkspaceSrc =
+        craneLib:
+        lib.cleanSourceWith {
+          filter =
+            path: type:
+            (craneLib.filterCargoSources path type)
+            || (builtins.match ".*/plugins/.*" path != null)
+            || (builtins.match ".*/prompts/.*" path != null)
+            || (builtins.match ".*/themes/.*" path != null)
+            || (builtins.match ".*/words/.*" path != null)
+            || (lib.hasSuffix ".lua" path);
+          src = lib.cleanSource ./.;
+        };
+
+      cargoLockParsed = builtins.fromTOML (builtins.readFile ./Cargo.lock);
+
+      # Exact Cargo.lock source strings (with fragment) of all git deps
+      gitDepSources = lib.unique (
+        builtins.filter (lib.hasPrefix "git+") (map (p: p.source or "") cargoLockParsed.package)
+      );
+
+      # Fixed-output fetches for git deps: cold evals skip full-history
+      # builtins.fetchGit clones, and CI gets substitutable cache hits instead.
+      # Keys embed the dep's tag/rev and locked commit, so a dep bump changes
+      # the key itself: replace the old key with the new Cargo.lock source
+      # string, set the hash to "", rebuild, and paste the hash from the error.
+      # The `git-dep-hashes` CI check names both the key to add and the stale
+      # key to remove.
+      #
+      # Two failure modes:
+      # - Missing key (dep bumped, flake not yet updated): crane falls back
+      #   to fetchGit with an eval warning. Nothing breaks; cold evals are
+      #   just slower until the key and its hash are added.
+      # - Wrong hash for an existing key: the build fails with a hash
+      #   mismatch that prints the real hash. This is both the recovery
+      #   path for updates and a hard stop if pinned content ever changes.
+      gitDepHashes = {
+        "git+https://github.com/pydantic/monty.git?tag=v0.0.18#45a3b2d57e6ce723fed4166fb032242ece74a663" =
+          "sha256-p9mDjS9FTvsITU98B8AeyUCk4wQhgk71HoyOsNPpB0Y=";
+        "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30" =
+          "sha256-m5U5OVUvhn5t3yTSSbT/JA+xmydEDQq+zKFNMN7K/MI=";
+      };
+
+      missingGitDepHashes = builtins.filter (s: !(builtins.hasAttr s gitDepHashes)) gitDepSources;
+
+      staleGitDepHashes = builtins.filter (k: !(builtins.elem k gitDepSources)) (
+        builtins.attrNames gitDepHashes
+      );
+
+      gitDepHashDrift =
+        lib.optionalString (missingGitDepHashes != [ ]) ''
+          missing entries (add with hash "", rebuild, paste the hash from the error):
+            ${lib.concatStringsSep "\n  " missingGitDepHashes}
+        ''
+        + lib.optionalString (staleGitDepHashes != [ ]) ''
+          stale entries (remove):
+            ${lib.concatStringsSep "\n  " staleGitDepHashes}
+        '';
     in
     {
       packages = forEachSystem (
         system: pkgs:
         let
-          maki = pkgs.rustPlatform.buildRustPackage {
-            pname = packageName;
-            inherit version;
-            src = ./.;
-            cargoLock = {
-              lockFile = ./Cargo.lock;
-              # NOTE: these are cargo git dependencies; set hash to "" and
-              # rebuild to get the correct value.
-              outputHashes = {
-                "monty-0.0.18" = "sha256-p9mDjS9FTvsITU98B8AeyUCk4wQhgk71HoyOsNPpB0Y=";
-                "ruff_python_ast-0.0.0" = "sha256-m5U5OVUvhn5t3yTSSbT/JA+xmydEDQq+zKFNMN7K/MI=";
-                "ruff_python_parser-0.0.0" = "sha256-m5U5OVUvhn5t3yTSSbT/JA+xmydEDQq+zKFNMN7K/MI=";
-                "ruff_python_stdlib-0.0.0" = "sha256-m5U5OVUvhn5t3yTSSbT/JA+xmydEDQq+zKFNMN7K/MI=";
-                "ruff_python_trivia-0.0.0" = "sha256-m5U5OVUvhn5t3yTSSbT/JA+xmydEDQq+zKFNMN7K/MI=";
-                "ruff_source_file-0.0.0" = "sha256-m5U5OVUvhn5t3yTSSbT/JA+xmydEDQq+zKFNMN7K/MI=";
-                "ruff_text_size-0.0.0" = "sha256-m5U5OVUvhn5t3yTSSbT/JA+xmydEDQq+zKFNMN7K/MI=";
-              };
-            };
-            cargoBuildFlags = [
-              "--package"
-              packageName
-            ];
+          craneLib = mkCraneLib pkgs;
+          workspaceSrc = mkWorkspaceSrc craneLib;
+
+          # TODO: Upstream monty includes a relative README path that doesn't
+          # survive nix vendoring. Remove this once `monty` stops including
+          # the relative path
+          vendorDeps = craneLib.vendorCargoDeps {
+            src = workspaceSrc;
+            outputHashes = gitDepHashes;
+          };
+          cargoVendorDir = pkgs.runCommandLocal "vendor-cargo-deps" { } ''
+            cp -rL ${vendorDeps} $out
+            chmod -R +w $out
+            # config.toml has absolute paths to the original vendor dir;
+            # rewrite them to point to our patched copy
+            substituteInPlace "$out/config.toml" \
+              --replace-fail "${vendorDeps}" "$out"
+            find "$out" -name "*.rs" -print0 | while IFS= read -r -d "" f; do
+              if grep -qF '#![doc = include_str!("../../../README.md")]' "$f"; then
+                substituteInPlace "$f" \
+                  --replace-fail '#![doc = include_str!("../../../README.md")]' \
+                            '#![doc = "Monty Python bridge."]'
+              fi
+            done
+          '';
+
+          commonArgs = {
             nativeBuildInputs = with pkgs; [
               pkg-config
               perl
               python3
             ];
-            # TODO: Upstream monty includes a relative README path that doesn't
-            # survive nix vendoring. Remove this once `monty` stops including
-            # the relative path
-            postPatch = ''
-              for f in "$cargoDepsCopy"/monty-*/src/lib.rs; do
-              # monty-macros doesn't include the readme
-              if [[ "$f" != *"monty-macros"* ]]; then
-                substituteInPlace "$f" \
-                  --replace-fail '#![doc = include_str!("../../../README.md")]' \
-                                 '#![doc = "Monty Python bridge."]'
-              fi
-              done
-            '';
-            buildInputs = with pkgs; [ openssl stdenv.cc.cc.lib ];
-            doCheck = false;
+            buildInputs = with pkgs; [
+              openssl
+              stdenv.cc.cc.lib
+            ];
+            inherit cargoVendorDir;
           };
+
+          cargoArtifacts = craneLib.buildDepsOnly (
+            commonArgs
+            // {
+              pname = "${packageName}-deps";
+              inherit version;
+              src = workspaceSrc;
+            }
+          );
         in
         {
-          default = maki;
+          default = craneLib.buildPackage (
+            commonArgs
+            // {
+              pname = packageName;
+              inherit version;
+              src = workspaceSrc;
+              cargoArtifacts = cargoArtifacts;
+              cargoExtraArgs = "--package ${packageName}";
+              doCheck = false;
+            }
+          );
+        }
+      );
+
+      checks = forEachSystem (
+        system: pkgs: {
+          git-dep-hashes =
+            if missingGitDepHashes == [ ] && staleGitDepHashes == [ ] then
+              pkgs.runCommandLocal "git-dep-hashes" { } "touch $out"
+            else
+              builtins.throw ''
+                flake.nix gitDepHashes is out of sync with Cargo.lock git sources:
+                ${gitDepHashDrift}'';
+          fmt =
+            pkgs.runCommandLocal "check-nix-format"
+              {
+                nativeBuildInputs = [ pkgs.nixfmt ];
+                src = lib.cleanSource ./.;
+              }
+              ''
+                find "$src" -name '*.nix' -type f -exec nixfmt --check {} +
+                touch $out
+              '';
         }
       );
 
       devShells = forEachSystem (
         _: pkgs:
         let
+          craneLib = mkCraneLib pkgs;
           certs = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
         in
         {
-          default = pkgs.mkShell {
+          default = craneLib.devShell {
             packages = with pkgs; [
-              cargo
               cargo-nextest
-              clippy
               git
               just
               openssl
@@ -92,9 +216,6 @@
               python3
               ripgrep
               ruff
-              rust-analyzer
-              rustc
-              rustfmt
               stylua
               ty
             ];
@@ -109,6 +230,6 @@
         }
       );
 
-      formatter = forEachSystem (_: pkgs: pkgs.nixfmt-rfc-style);
+      formatter = forEachSystem (_: pkgs: pkgs.nixfmt);
     };
 }


### PR DESCRIPTION
Reduces maintenance surface and overhead for the Nix flake.

- Hash maintenance:
    - Previously, there were seven hashes in the flake that required manual updates on dependency bumps, and would completely break the flake until they were updated (see #463)
    - Now we're down to two hashes (monty + ruff as a single repo)
    - When those two hashes are invalidated by bumps, the flake still works. In that case, they're effectively just missing a cache key and consequently will fully rebuild each time. It's build speed degredation, but is not catastrophic
- Better caching:
    - We now split dependencies and the maki package itself into two separate derivations
    - Previously, any change, in code or deps, would mean rebuilding the whole world
    - Now, e.g., a code change leaves the dep derivation untouched, allowing it to be pulled from the store instead of rebuilt
- Rust toolchain pinning:
    - Previously, we used whatever rust toolchain was current in nixpkgs
    - Now, it's pinned to 1.95
    - If, e.g., someone is using a nix channel with an older, incompatible Rust version, they'll now get an explicit error
- Build toolchain is now identical to devShell toolchain
- More robust vendor patching
- CI pipeline to:
    - Ensure flake builds
    - Check for hash drift
    - Check for correct formatting of Nix files
- Update Nix formatter
    - Use of `nixfmt-rfc-style` is deprecated