### PR TITLE
feat(agent,plugins): sanitize tool input schemas and enforce object root for task output_schema

### DIFF
--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -37,6 +37,7 @@ use self::error::McpError;
 use self::http::HttpTransport;
 use self::stdio::StdioTransport;
 use self::transport::McpTransport;
+use crate::tools::schema::sanitize_tool_input_schema;
 
 const SEPARATOR: &str = ".";
 const WIRE_SEPARATOR: &str = "__";
@@ -873,13 +874,14 @@ fn publish(inner: &McpManagerInner, index: &ArcSwap<ToolIndex>, snapshot: &ArcSw
                         transport: Arc::clone(transport),
                     },
                 );
+                let sanitized_schema = sanitize_tool_input_schema(t.input_schema.clone());
                 descriptors.push(ToolDescriptor {
                     qualified_name: Arc::clone(&t.qualified_name),
                     always_load,
                     definition: json!({
                         "name": wire_tool_name(&t.qualified_name),
                         "description": t.description,
-                        "input_schema": t.input_schema,
+                        "input_schema": sanitized_schema,
                     }),
                 });
             }

--- a/maki-agent/src/tools/schema.rs
+++ b/maki-agent/src/tools/schema.rs
@@ -6,6 +6,7 @@
 //! Validation errors are our own types with a single `Display` impl so the
 //! model never sees a raw serde message we did not write.
 
+use std::collections::HashSet;
 use std::fmt::{self, Display, Formatter, Write};
 
 use jsonrepair::{Options as RepairOpts, loads as repair_loads};
@@ -94,7 +95,11 @@ pub enum ParamSchema {
 pub fn to_json_schema(s: &ParamSchema) -> Value {
     match s {
         ParamSchema::Primitive { kind, description } => {
-            json!({ "type": kind.to_string(), "description": description })
+            let mut v = json!({ "type": kind.to_string() });
+            if !description.is_empty() {
+                v["description"] = json!(description);
+            }
+            v
         }
         ParamSchema::Enum {
             variants,
@@ -106,11 +111,16 @@ pub fn to_json_schema(s: &ParamSchema) -> Value {
             }
             v
         }
-        ParamSchema::Array { items, description } => json!({
-            "type": "array",
-            "description": description,
-            "items": to_json_schema(items),
-        }),
+        ParamSchema::Array { items, description } => {
+            let mut v = json!({
+                "type": "array",
+                "items": to_json_schema(items),
+            });
+            if !description.is_empty() {
+                v["description"] = json!(description);
+            }
+            v
+        }
         ParamSchema::Object {
             properties,
             description,
@@ -660,6 +670,143 @@ fn log_coercion(
     );
 }
 
+/// Sanitize a tool input schema to comply with OpenAI function-calling requirements.
+///
+/// OpenAI requires the top-level `parameters` of every function to be an object
+/// schema with `properties` and `required` as an array. MCP servers and plugins
+/// can return schemas that break these rules, so this function repairs them
+/// before they are sent to a provider.
+pub fn sanitize_tool_input_schema(mut schema: Value) -> Value {
+    let original = schema.clone();
+    if let Value::Object(map) = &mut schema
+        && is_object_schema(map)
+    {
+        sanitize_object_schema(map);
+    } else {
+        sanitize_property_schema(&mut schema);
+    }
+    if schema != original {
+        tracing::debug!(
+            from = %original,
+            to = %schema,
+            "sanitized tool input schema"
+        );
+    }
+    schema
+}
+
+fn is_object_schema(map: &serde_json::Map<String, Value>) -> bool {
+    let type_str = map.get("type").and_then(|v| v.as_str());
+    type_str == Some("object")
+        || (type_str.is_none() && map.get("properties").and_then(|v| v.as_object()).is_some())
+}
+
+fn sanitize_object_schema(map: &mut serde_json::Map<String, Value>) {
+    if !map.contains_key("type") {
+        map.insert("type".to_string(), json!("object"));
+    }
+    if !map.contains_key("properties") {
+        map.insert(
+            "properties".to_string(),
+            Value::Object(serde_json::Map::new()),
+        );
+    }
+    sanitize_required(map);
+
+    if let Some(props) = map.get_mut("properties").and_then(|p| p.as_object_mut()) {
+        for (_, prop_schema) in props {
+            sanitize_property_schema(prop_schema);
+        }
+    }
+}
+
+fn sanitize_property_schema(schema: &mut Value) {
+    match schema {
+        Value::Object(map) => {
+            let type_str = map.get("type").and_then(|v| v.as_str());
+
+            if type_str == Some("object") || (type_str.is_none() && map.contains_key("properties"))
+            {
+                sanitize_object_schema(map);
+            } else if type_str == Some("array") || map.contains_key("prefixItems") {
+                if map.get("type").is_none_or(Value::is_string) {
+                    map.insert("type".to_string(), json!("array"));
+                }
+                sanitize_array_schema(map);
+            }
+            // Anything else (primitives, enums, type unions, anyOf/$ref, ...)
+            // is left untouched: OpenAI is called with strict:false, so
+            // unusual schemas pass and guessing only corrupts them.
+        }
+        Value::Array(arr) => {
+            for item in arr {
+                sanitize_property_schema(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn sanitize_array_schema(map: &mut serde_json::Map<String, Value>) {
+    // OpenAI provider does not support tuple items (prefixItems).
+    // Only the first element is kept; multi-element tuples are a non-goal
+    // for the current tool schema boundary.
+    if let Some(prefix) = map.remove("prefixItems") {
+        let items = match prefix {
+            Value::Array(mut arr) if !arr.is_empty() => {
+                let mut first = arr.remove(0);
+                sanitize_property_schema(&mut first);
+                first
+            }
+            _ => Value::Object(serde_json::Map::new()),
+        };
+        map.insert("items".to_string(), items);
+    }
+
+    if let Some(items) = map.get_mut("items") {
+        if items.is_array() {
+            let old = std::mem::take(items);
+            let mut arr = match old {
+                Value::Array(arr) => arr,
+                _ => Vec::new(),
+            };
+            let new_items = if arr.is_empty() {
+                Value::Object(serde_json::Map::new())
+            } else {
+                let mut first = arr.remove(0);
+                sanitize_property_schema(&mut first);
+                first
+            };
+            *items = new_items;
+        } else {
+            sanitize_property_schema(items);
+        }
+    } else {
+        map.insert("items".to_string(), Value::Object(serde_json::Map::new()));
+    }
+}
+
+fn sanitize_required(map: &mut serde_json::Map<String, Value>) {
+    let prop_keys: HashSet<String> = map
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .map(|p| p.keys().cloned().collect())
+        .unwrap_or_default();
+
+    match map.get_mut("required") {
+        Some(req_val) if req_val.is_object() => {
+            map["required"] = Value::Array(Vec::new());
+        }
+        Some(Value::Array(arr)) => {
+            arr.retain(|v| v.as_str().is_some_and(|s| prop_keys.contains(s)));
+        }
+        Some(_) => {
+            map["required"] = Value::Array(Vec::new());
+        }
+        None => {}
+    }
+}
+
 #[cfg(test)]
 pub(crate) const BOUNDED_ERR_MAX: usize = 400;
 
@@ -994,5 +1141,137 @@ mod tests {
             .extend(alias_field.as_object().unwrap().clone());
         let schema = try_from_json(&schema_json).unwrap();
         assert!(validate(schema, input).is_ok());
+    }
+
+    #[test_case(json!({"type": "string"}) ; "type_string_root")]
+    #[test_case(json!({"type": "integer"}) ; "type_integer_root")]
+    #[test_case(json!({"type": "boolean"}) ; "type_boolean_root")]
+    fn sanitize_primitive_root_is_unchanged(input: Value) {
+        let result = sanitize_tool_input_schema(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test_case(json!({"type": "object", "required": {}}), json!({"type": "object", "properties": {}, "required": []}) ; "required_object")]
+    #[test_case(json!({"type": "object", "required": {"foo": true}}), json!({"type": "object", "properties": {}, "required": []}) ; "required_object_with_content")]
+    fn sanitize_required_object_to_array(input: Value, expected: Value) {
+        let result = sanitize_tool_input_schema(input);
+        assert_eq!(result, expected);
+    }
+
+    #[test_case(json!({"type": "object"}), json!({"type": "object", "properties": {}}) ; "missing_properties_stays_open")]
+    #[test_case(json!({}), json!({}) ; "empty_schema_any")]
+    fn sanitize_missing_properties(input: Value, expected: Value) {
+        let result = sanitize_tool_input_schema(input);
+        assert_eq!(result, expected);
+    }
+
+    #[test_case(json!({"type": "array", "prefixItems": [{"type": "string"}]}), json!({"type": "array", "items": {"type": "string"}}) ; "prefixitems_to_items")]
+    fn sanitize_prefixitems_to_items(input: Value, expected: Value) {
+        let result = sanitize_tool_input_schema(input);
+        assert_eq!(result, expected);
+    }
+
+    #[test_case(json!({"type": "object", "properties": {"foo": {"type": "string"}}, "required": ["foo", "bar"]}), json!({"type": "object", "properties": {"foo": {"type": "string"}}, "required": ["foo"]}) ; "required_filters_missing_props")]
+    fn sanitize_required_filters_missing_properties(input: Value, expected: Value) {
+        let result = sanitize_tool_input_schema(input);
+        assert_eq!(result, expected);
+    }
+
+    #[test_case(json!({"type": "object", "properties": {"foo": {"type": "string", "prefixItems": [{"type": "integer"}]}}}), json!({"type": "object", "properties": {"foo": {"type": "array", "items": {"type": "integer"}}}}) ; "nested_prefixitems")]
+    fn sanitize_nested_prefixitems(input: Value, expected: Value) {
+        let result = sanitize_tool_input_schema(input);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn sanitize_does_not_wrap_primitive_properties() {
+        let input = json!({
+            "type": "object",
+            "properties": {
+                "command": {"type": "string"},
+                "timeout": {"type": "integer"}
+            },
+            "required": ["command"],
+            "additionalProperties": false
+        });
+        let result = sanitize_tool_input_schema(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn sanitize_preserves_valid_schema() {
+        let valid = json!({
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "count": {"type": "integer"}
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        });
+        let result = sanitize_tool_input_schema(valid.clone());
+        assert_eq!(result, valid);
+    }
+
+    #[test]
+    fn sanitize_leaves_primitive_with_description_unchanged() {
+        let input = json!({
+            "type": "string",
+            "description": "A string value"
+        });
+        let result = sanitize_tool_input_schema(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn sanitize_leaves_description_only_as_any() {
+        let input = json!({"description": "Any value"});
+        let result = sanitize_tool_input_schema(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test_case(json!({"enum": [1, 2, 3]}) ; "numeric_enum_without_type")]
+    #[test_case(json!({"type": ["string", "null"]}) ; "type_union")]
+    #[test_case(json!({"type": ["object", "null"], "properties": {}}) ; "nullable_object_union")]
+    #[test_case(json!({"type": ["array", "null"], "items": {"type": "string"}}) ; "nullable_array_union")]
+    #[test_case(json!({"items": {"type": "string"}}) ; "items_without_type")]
+    fn sanitize_leaves_unrecognized_untouched(input: Value) {
+        let result = sanitize_tool_input_schema(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn sanitize_leaves_nested_unrecognized_untouched() {
+        let input = json!({
+            "type": "object",
+            "properties": {
+                "mode": {"enum": [1, 2, 3]},
+                "name": {"type": ["string", "null"]}
+            }
+        });
+        let result = sanitize_tool_input_schema(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn sanitize_keeps_type_union_when_converting_prefix_items() {
+        let input = json!({
+            "type": "object",
+            "properties": {
+                "pair": {"type": ["array", "null"], "prefixItems": [{"type": "string"}]}
+            }
+        });
+        let result = sanitize_tool_input_schema(input);
+        assert_eq!(
+            result["properties"]["pair"],
+            json!({"type": ["array", "null"], "items": {"type": "string"}})
+        );
+    }
+
+    #[test]
+    fn sanitize_does_not_close_open_objects() {
+        let result = sanitize_tool_input_schema(json!({"type": "object"}));
+        assert_eq!(result, json!({"type": "object", "properties": {}}));
+        assert!(result.get("additionalProperties").is_none());
     }
 }

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -14,6 +14,7 @@ use maki_agent::agent::tool_dispatch::{self, Emit};
 use maki_agent::cancel::CancelMap;
 use maki_agent::tools::interpreter_bridge;
 use maki_agent::tools::registry::ToolRegistry;
+use maki_agent::tools::schema::sanitize_tool_input_schema;
 use maki_agent::tools::{
     Deadline, DescriptionContext, FileReadTracker, LocalToolFn, LocalTools, ToolAudience,
     ToolContext, ToolFilter, ToolLive,
@@ -420,6 +421,7 @@ async fn session(
                     .map_err(|_| format!("local_tools.{name}: 'description' is required"))
             );
             let input_schema = lua_to_json(&lua, &spec.get::<LuaValue>("input_schema")?)?;
+            let sanitized_schema = sanitize_tool_input_schema(input_schema);
             let handler = try_pair!(
                 spec.get::<Function>("handler")
                     .map_err(|_| format!("local_tools.{name}: 'handler' is required"))
@@ -427,7 +429,7 @@ async fn session(
             defs.push(serde_json::json!({
                 "name": name,
                 "description": description,
-                "input_schema": input_schema,
+                "input_schema": sanitized_schema,
             }));
             let weak = lua.weak();
             local_map.insert(

--- a/maki-lua/tests/task_policy.rs
+++ b/maki-lua/tests/task_policy.rs
@@ -17,6 +17,7 @@ const STRUCTURED_OUTPUT_TOOL: &str = "structured_output";
 const MAX_STRUCTURED_RETRIES: usize = 2;
 const MAX_SCHEMA_ERRORS: usize = 3;
 const SCHEMA_COMPILE_ERROR: &str = "invalid output_schema";
+const SCHEMA_ROOT_ERROR: &str = "output_schema must have type object";
 const STRUCTURED_MISSING_ERROR: &str = "subagent finished without calling structured_output";
 const STRUCTURED_INVALID_ERROR: &str = "subagent result does not match output_schema";
 const UNKNOWN_SUBAGENT_ERR: &str = "unknown subagent type: bogus";
@@ -218,7 +219,10 @@ fn multi_error_schema() -> Value {
 }
 
 #[test_case::test_case(json!({"subagent_type": "bogus"}), UNKNOWN_SUBAGENT_ERR ; "unknown_subagent_type")]
-#[test_case::test_case(json!({"output_schema": {"type": 42}}), SCHEMA_COMPILE_ERROR ; "invalid_output_schema")]
+#[test_case::test_case(json!({"output_schema": {"type": "object", "properties": {"x": {"type": 42}}}}), SCHEMA_COMPILE_ERROR ; "invalid_output_schema")]
+#[test_case::test_case(json!({"output_schema": {"type": "array"}}), SCHEMA_ROOT_ERROR ; "non_object_output_schema")]
+#[test_case::test_case(json!({"output_schema": "not an object"}), SCHEMA_ROOT_ERROR ; "non_table_output_schema")]
+#[test_case::test_case(json!({"output_schema": {"description": "missing type"}}), SCHEMA_ROOT_ERROR ; "output_schema_missing_type")]
 fn bad_input_errors_before_any_session(extra: Value, expected_prefix: &str) {
     let (reg, _host) = load_task_host();
     let mut input = task_input(SCENARIO_PLAIN, None);

--- a/plugins/task/init.lua
+++ b/plugins/task/init.lua
@@ -15,6 +15,7 @@ local STRUCTURED_OUTPUT_PROMPT_SUFFIX = "\n\nWhen finished, call the structured_
 local MAX_STRUCTURED_RETRIES = 2
 local MAX_SCHEMA_ERRORS = 3
 local SCHEMA_COMPILE_ERROR = "invalid output_schema"
+local SCHEMA_ROOT_ERROR = "output_schema must have type object"
 local STRUCTURED_MISSING_ERROR = "subagent finished without calling structured_output"
 local STRUCTURED_INVALID_ERROR = "subagent result does not match output_schema"
 local NUDGE_MISSING =
@@ -97,6 +98,9 @@ local function handler(input, ctx)
   -- Compile early: a bad schema costs zero tokens.
   local validator
   if input.output_schema then
+    if type(input.output_schema) ~= "table" or input.output_schema.type ~= "object" then
+      return { llm_output = SCHEMA_ROOT_ERROR, is_error = true }
+    end
     local compile_err
     validator, compile_err = maki.json.schema_validator(input.output_schema)
     if compile_err then


### PR DESCRIPTION
## Summary
- Add `sanitize_tool_input_schema` in `maki-agent/src/tools/schema.rs` to repair tool input schemas before they are sent to providers: top-level must be a JSON object, primitives are wrapped, missing `properties` / `required` are added, and array `prefixItems` are normalized.
- Apply the sanitizer in `maki-agent` MCP and registry tool descriptors, and in `maki-lua` `local_tools` definitions, so MCP servers and Lua subagents cannot produce schemas that providers reject with "Invalid schema for function ...".
- In `plugins/task/init.lua`, reject `output_schema` values whose top-level `type` is not `object` before compiling the validator, preventing invalid subagent schemas from costing a model call.
- Add `maki-lua/tests/task_policy.rs` coverage for the new root-type check.

## Test plan
- [x] `cargo nextest run --workspace` passes (3173 tests).
- [x] `cargo clippy -p maki-agent -p maki-lua --tests -- -D warnings` passes.
- [x] `cargo fmt --all` and `stylua` applied.