### PR TITLE
fix(nix): provide libstdc++ in devShell and package runtime deps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
               fi
               done
             '';
-            buildInputs = with pkgs; [ openssl ];
+            buildInputs = with pkgs; [ openssl stdenv.cc.cc.lib ];
             doCheck = false;
           };
         in
@@ -101,6 +101,10 @@
 
             SSL_CERT_FILE = certs;
             NIX_SSL_CERT_FILE = certs;
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+              pkgs.openssl
+              pkgs.stdenv.cc.cc.lib
+            ];
           };
         }
       );


### PR DESCRIPTION
## Summary

`maki-lua` links luau (C++) and the binary fails at runtime with `libstdc++.so.6: cannot open shared object file` in a pure Nix shell. Add `stdenv.cc.cc.lib` to the package `buildInputs` and expose it (plus `openssl`) in the devShell `LD_LIBRARY_PATH` so `cargo nextest` and `maki` can run.

## Test plan

- [x] `nix develop` starts successfully and sets `LD_LIBRARY_PATH`.
- [x] `cargo nextest run -p maki-lua --test task_policy` passes inside the shell.