### PR TITLE
test(theme): serialize theme mutation tests and recover from lock poisoning

### DIFF
--- a/maki-ui/src/components/permission_prompt.rs
+++ b/maki-ui/src/components/permission_prompt.rs
@@ -300,7 +300,7 @@ impl PermissionPrompt {
             };
             let (before, after) = display_text.split_at(cursor_pos);
             let mut chars = after.chars();
-            let cursor_ch = chars.next().map_or(' ', |c| c);
+            let cursor_ch = chars.next().unwrap_or(' ');
             let rest: String = chars.collect();
 
             let mut spans = vec![Span::raw("  "), Span::styled("guide ", label_style)];

--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -1671,7 +1671,9 @@ mod tests {
 
     #[test]
     fn default_span_resolves_to_theme_tool() {
-        let _guard = crate::theme::THEME_TEST_LOCK.lock().unwrap();
+        let _guard = crate::theme::THEME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         theme::set(theme::load_by_name("dracula").expect("dracula theme"));
         assert_eq!(
             resolve_span_style(&SpanStyle::Default),

--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -1671,6 +1671,7 @@ mod tests {
 
     #[test]
     fn default_span_resolves_to_theme_tool() {
+        let _guard = crate::theme::THEME_TEST_LOCK.lock().unwrap();
         theme::set(theme::load_by_name("dracula").expect("dracula theme"));
         assert_eq!(
             resolve_span_style(&SpanStyle::Default),

--- a/maki-ui/src/theme.rs
+++ b/maki-ui/src/theme.rs
@@ -1080,7 +1080,7 @@ mode_build = "#112233"
 
     #[test]
     fn style_by_name_resolves() {
-        let _guard = THEME_TEST_LOCK.lock().unwrap();
+        let _guard = THEME_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         set(dracula());
         let t = current();
         assert_eq!(style_by_name("dim"), t.tool_dim);
@@ -1132,7 +1132,7 @@ mode_build = "#112233"
 
     #[test]
     fn set_advances_generation() {
-        let _guard = THEME_TEST_LOCK.lock().unwrap();
+        let _guard = THEME_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let before = generation();
         set(dracula());
         assert!(generation() > before);
@@ -1140,7 +1140,7 @@ mode_build = "#112233"
 
     #[test]
     fn set_installs_theme_before_generation_observed() {
-        let _guard = THEME_TEST_LOCK.lock().unwrap();
+        let _guard = THEME_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let theme = tokyonight();
         let expected_syntax_bg = theme.syntax.settings.background;
         let before = generation();
@@ -1159,7 +1159,7 @@ mode_build = "#112233"
 
     #[test]
     fn set_generation_is_monotonic_across_switches() {
-        let _guard = THEME_TEST_LOCK.lock().unwrap();
+        let _guard = THEME_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let g0 = generation();
         set(dracula());
         let g1 = generation();

--- a/maki-ui/src/theme.rs
+++ b/maki-ui/src/theme.rs
@@ -13,6 +13,9 @@ use syntect::highlighting::{
 const DEFAULT_THEME: &str = "dracula";
 const RESERVED_KEYS: &[&str] = &["palette", "ui", "inherits"];
 
+#[cfg(test)]
+pub(crate) static THEME_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 const HELIX_TO_TEXTMATE: &[(&str, &str)] = &[
     ("comment", "comment, comment punctuation.definition.comment"),
     (
@@ -1077,6 +1080,7 @@ mode_build = "#112233"
 
     #[test]
     fn style_by_name_resolves() {
+        let _guard = THEME_TEST_LOCK.lock().unwrap();
         set(dracula());
         let t = current();
         assert_eq!(style_by_name("dim"), t.tool_dim);
@@ -1128,6 +1132,7 @@ mode_build = "#112233"
 
     #[test]
     fn set_advances_generation() {
+        let _guard = THEME_TEST_LOCK.lock().unwrap();
         let before = generation();
         set(dracula());
         assert!(generation() > before);
@@ -1135,6 +1140,7 @@ mode_build = "#112233"
 
     #[test]
     fn set_installs_theme_before_generation_observed() {
+        let _guard = THEME_TEST_LOCK.lock().unwrap();
         let theme = tokyonight();
         let expected_syntax_bg = theme.syntax.settings.background;
         let before = generation();
@@ -1153,6 +1159,7 @@ mode_build = "#112233"
 
     #[test]
     fn set_generation_is_monotonic_across_switches() {
+        let _guard = THEME_TEST_LOCK.lock().unwrap();
         let g0 = generation();
         set(dracula());
         let g1 = generation();


### PR DESCRIPTION
## Summary
- Serialize theme mutation tests with a crate-shared `THEME_TEST_LOCK` to prevent palette race failures when tests set/read the active theme concurrently.
- Recover from mutex poisoning with `unwrap_or_else(|e| e.into_inner())` so a failing test does not cascade into "poisoned mutex" panics for every subsequent test.
- Also silences a pre-existing `clippy::map_or_identity` lint in `permission_prompt.rs`.

## Verification
- `cargo nextest run -p maki-ui`: all tests pass.
- `cargo clippy -p maki-ui --tests -- -D warnings`: clean.