### PR TITLE
feat(keymap): gate keymap API on `Keymap` permission

### DIFF
--- a/maki-lua/src/api/keymap.rs
+++ b/maki-lua/src/api/keymap.rs
@@ -6,6 +6,8 @@ use crossterm::event::{KeyCode, KeyModifiers};
 use maki_lua_macro::{lua_fn, lua_table};
 use mlua::{Lua, RegistryKey, Result as LuaResult, Table};
 
+use crate::plugin_permissions::PluginPermissions;
+
 static NEXT_KEYMAP_ID: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Clone, Debug)]
@@ -107,10 +109,15 @@ impl KeymapStore {
         (id, old)
     }
 
-    pub fn del(&mut self, key: KeyCode, modifiers: KeyModifiers) -> Option<RegistryKey> {
+    pub fn del(
+        &mut self,
+        key: KeyCode,
+        modifiers: KeyModifiers,
+        plugin: &Arc<str>,
+    ) -> Option<RegistryKey> {
         self.bindings
             .iter()
-            .position(|b| b.key == key && b.modifiers == modifiers)
+            .position(|b| b.key == key && b.modifiers == modifiers && &b.plugin == plugin)
             .map(|pos| self.bindings.remove(pos).callback)
     }
 
@@ -266,7 +273,7 @@ fn publish_keymap_snapshot(lua: &Lua) {
 /// maki.keymap.set("n", "<C-t>", function()
 ///   print("toggle!")
 /// end, { desc = "Toggle panel" })
-#[lua_fn]
+#[lua_fn(guard = Keymap)]
 fn set(
     lua: &Lua,
     #[ctx] plugin: Arc<str>,
@@ -292,28 +299,35 @@ fn set(
         .set(key, modifiers, registry_key, Arc::clone(&plugin), desc);
     if let Some(old_key) = old {
         tracing::warn!(key = %lhs, plugin = %plugin, "keymap shadowed by plugin");
-        let _ = lua.remove_registry_value(old_key);
+        if let Err(e) = lua.remove_registry_value(old_key) {
+            tracing::warn!(key = %lhs, plugin = %plugin, error = %e, "leaked keymap registry value");
+        }
     }
     publish_keymap_snapshot(lua);
     Ok(())
 }
 
 /// Remove the mapping for {lhs} in {mode}. Does nothing if no mapping
-/// exists for that key.
+/// exists for that key. Only normal mode (`"n"`) is supported today.
 ///
-/// @param mode string Mode letter (reserved for future modes).
+/// @param mode string Mode letter. Currently only `"n"` is accepted.
 /// @param lhs string Key to unmap, in Vim notation.
 /// @example
 /// maki.keymap.del("n", "<C-t>")
-#[lua_fn]
+#[lua_fn(guard = Keymap)]
 fn del(lua: &Lua, #[ctx] plugin: Arc<str>, mode: String, lhs: String) -> LuaResult<()> {
-    let _ = (mode, &plugin);
+    if mode != "n" {
+        return Err(mlua::Error::runtime(format!(
+            "unsupported keymap mode: {mode}"
+        )));
+    }
     let (key, modifiers) = parse_key_notation(&lhs).map_err(mlua::Error::runtime)?;
     let old = lua
         .app_data_mut::<KeymapStore>()
-        .and_then(|mut store| store.del(key, modifiers));
-    if let Some(old_key) = old {
-        let _ = lua.remove_registry_value(old_key);
+        .ok_or_else(|| mlua::Error::runtime("keymap store not initialized"))?
+        .del(key, modifiers, &plugin);
+    if let Err(e) = old.map_or(Ok(()), |k| lua.remove_registry_value(k)) {
+        tracing::warn!(key = %lhs, plugin = %plugin, error = %e, "leaked keymap registry value");
     }
     publish_keymap_snapshot(lua);
     Ok(())
@@ -328,8 +342,8 @@ lua_table! {
     ///   print("hello")
     /// end, { desc = "Say hello" })
     /// ```
-    "maki.keymap" => pub(crate) fn create_keymap_table(plugin: Arc<str>), DOCS [
-        set(plugin), del(plugin),
+    "maki.keymap" => pub(crate) fn create_keymap_table(plugin: Arc<str>, perms: &PluginPermissions), DOCS [
+        set(perms, plugin), del(perms, plugin),
     ]
 }
 
@@ -433,11 +447,19 @@ mod tests {
         );
         assert_eq!(store.bindings.len(), 1);
 
-        let removed = store.del(KeyCode::Char('x'), KeyModifiers::ALT);
+        let wrong = store.del(KeyCode::Char('x'), KeyModifiers::ALT, &Arc::from("other"));
+        assert!(wrong.is_none());
+        assert_eq!(
+            store.bindings.len(),
+            1,
+            "del by another plugin must not remove an existing binding"
+        );
+
+        let removed = store.del(KeyCode::Char('x'), KeyModifiers::ALT, &Arc::from("p"));
         assert!(removed.is_some());
         assert!(store.bindings.is_empty());
 
-        let missing = store.del(KeyCode::Char('x'), KeyModifiers::ALT);
+        let missing = store.del(KeyCode::Char('x'), KeyModifiers::ALT, &Arc::from("p"));
         assert!(missing.is_none());
     }
 

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -75,7 +75,7 @@ pub(crate) fn create_maki_global(
     maki.set("agent", agent::create_agent_table(lua)?)?;
     maki.set(
         "keymap",
-        keymap::create_keymap_table(lua, Arc::clone(&plugin))?,
+        keymap::create_keymap_table(lua, Arc::clone(&plugin), permissions)?,
     )?;
 
     Ok(maki)

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -787,6 +787,81 @@ mod tests {
         }
     }
 
+    /// End-to-end permission gate: a plugin loaded with denied permissions cannot
+    /// call maki.keymap.set. The guard returns a runtime error that surfaces
+    /// through load_source. The guard helper is unit-tested elsewhere; this
+    /// test confirms the wiring through create_maki_global.
+    #[test]
+    fn keymap_permission_denied_blocks_set() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        let err = host
+            .load_source_with_permissions(
+                "untrusted",
+                r#"maki.keymap.set("n", "<C-x>", function() end)"#,
+                PluginPermissions::denied(),
+            )
+            .expect_err("denied permissions must block keymap.set");
+        let msg = err.to_string();
+        assert!(msg.contains("permission denied"), "got: {msg}");
+        assert!(msg.contains("keymap"), "got: {msg}");
+        assert!(
+            host.keymap_reader().load().entries.is_empty(),
+            "no binding should be stored when denied"
+        );
+    }
+
+    /// Trusted posture allows keymap.set: confirms the default init posture
+    /// matches the security model, where init files run fully trusted.
+    #[test]
+    fn keymap_permission_trusted_allows_set() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        host.load_source_with_permissions(
+            "init",
+            r#"maki.keymap.set("n", "<C-y>", function() end, { desc = "trusted" })"#,
+            PluginPermissions::trusted(),
+        )
+        .expect("trusted permissions must allow keymap.set");
+        let snap = host.keymap_reader().load();
+        assert_eq!(snap.entries.len(), 1);
+        assert_eq!(snap.entries[0].desc, "trusted");
+    }
+
+    /// Plugin-scoped del through the real load wiring: a plugin can remove
+    /// its own binding, and cannot remove another plugin's binding for the
+    /// same key. Drives the guard + scoping through create_maki_global, not
+    /// just the store unit.
+    #[test]
+    fn keymap_del_scoped_to_owning_plugin() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        host.load_source_with_permissions(
+            "owner",
+            r#"maki.keymap.set("n", "<C-x>", function() end, { desc = "owned" })"#,
+            PluginPermissions::trusted(),
+        )
+        .expect("owner must be able to set");
+        host.load_source_with_permissions(
+            "intruder",
+            r#"maki.keymap.del("n", "<C-x>")"#,
+            PluginPermissions::trusted(),
+        )
+        .expect("del returns Ok even when the binding is not mine to remove");
+        let snap = host.keymap_reader().load();
+        assert_eq!(
+            snap.entries.len(),
+            1,
+            "intruder must not remove owner's binding"
+        );
+        assert_eq!(snap.entries[0].desc, "owned");
+
+        host.load_source_with_permissions(
+            "owner",
+            r#"maki.keymap.del("n", "<C-x>")"#,
+            PluginPermissions::trusted(),
+        )
+        .expect("owner must be able to del its own binding");
+        assert!(host.keymap_reader().load().entries.is_empty());
+    }
+
     #[test]
     fn disabled_host_returns_defaults() {
         let host = PluginHost::disabled();

--- a/maki-lua/src/plugin_permissions.rs
+++ b/maki-lua/src/plugin_permissions.rs
@@ -13,16 +13,19 @@ pub enum Permission {
     Net,
     Run,
     Env,
+    Keymap,
 }
 
 impl Permission {
-    const ALL: [Permission; 5] = [
+    const ALL: [Permission; Self::LEN] = [
         Permission::FsRead,
         Permission::FsWrite,
         Permission::Net,
         Permission::Run,
         Permission::Env,
+        Permission::Keymap,
     ];
+    pub(crate) const LEN: usize = 6;
 
     fn manifest_key(self) -> &'static str {
         match self {
@@ -31,6 +34,7 @@ impl Permission {
             Permission::Net => "net",
             Permission::Run => "run",
             Permission::Env => "env",
+            Permission::Keymap => "keymap",
         }
     }
 }
@@ -43,17 +47,19 @@ impl fmt::Display for Permission {
 
 #[derive(Debug, Clone)]
 pub struct PluginPermissions {
-    allowed: [bool; 5],
+    allowed: [bool; Permission::LEN],
 }
 
 impl PluginPermissions {
     pub fn trusted() -> Self {
-        Self { allowed: [true; 5] }
+        Self {
+            allowed: [true; Permission::LEN],
+        }
     }
 
     pub fn denied() -> Self {
         Self {
-            allowed: [false; 5],
+            allowed: [false; Permission::LEN],
         }
     }
 
@@ -63,7 +69,7 @@ impl PluginPermissions {
 
     pub fn from_manifest(manifest: &toml::Value) -> Self {
         let perms = manifest.get("permissions");
-        let mut allowed = [true; 5];
+        let mut allowed = [true; Permission::LEN];
         for perm in Permission::ALL {
             allowed[perm as usize] = perms
                 .and_then(|p| p.get(perm.manifest_key()))
@@ -169,6 +175,7 @@ mod tests {
             [permissions]
             fs_read = false
             net = false
+            keymap = false
             "#,
         )
         .unwrap();
@@ -178,6 +185,7 @@ mod tests {
         assert!(!p.is_allowed(Permission::Net));
         assert!(p.is_allowed(Permission::Run));
         assert!(p.is_allowed(Permission::Env));
+        assert!(!p.is_allowed(Permission::Keymap));
     }
 
     #[test]
@@ -191,14 +199,18 @@ mod tests {
 
     #[test]
     fn set_modifies_single_permission() {
-        let mut p = PluginPermissions::trusted();
-        p.set(Permission::Net, false);
-        p.set(Permission::Run, false);
-        assert!(p.is_allowed(Permission::FsRead));
-        assert!(p.is_allowed(Permission::FsWrite));
-        assert!(!p.is_allowed(Permission::Net));
-        assert!(!p.is_allowed(Permission::Run));
-        assert!(p.is_allowed(Permission::Env));
+        for toggled in Permission::ALL {
+            let mut p = PluginPermissions::trusted();
+            p.set(toggled, false);
+            for other in Permission::ALL {
+                let want = other != toggled;
+                assert_eq!(
+                    p.is_allowed(other),
+                    want,
+                    "toggling {toggled} should leave {other} as {want}"
+                );
+            }
+        }
     }
 
     #[test]
@@ -210,6 +222,42 @@ mod tests {
             .unwrap();
         let result: i32 = func.call(()).unwrap();
         assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn load_plugin_permissions_no_dir_denies_all() {
+        let p = load_plugin_permissions(None);
+        for perm in Permission::ALL {
+            assert!(
+                !p.is_allowed(perm),
+                "{perm} should be denied without a plugin dir"
+            );
+        }
+    }
+
+    #[test]
+    fn load_plugin_permissions_missing_manifest_denies_all() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = load_plugin_permissions(Some(dir.path()));
+        for perm in Permission::ALL {
+            assert!(
+                !p.is_allowed(perm),
+                "{perm} should be denied without a plugin.toml"
+            );
+        }
+    }
+
+    #[test]
+    fn load_plugin_permissions_invalid_manifest_denies_all() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(MANIFEST_FILE), "not = valid = toml").unwrap();
+        let p = load_plugin_permissions(Some(dir.path()));
+        for perm in Permission::ALL {
+            assert!(
+                !p.is_allowed(perm),
+                "{perm} should be denied on invalid manifest"
+            );
+        }
     }
 
     #[test]

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -2206,11 +2206,11 @@ maki.keymap.del({mode}, {lhs})
 ```
 
 Remove the mapping for {lhs} in {mode}. Does nothing if no mapping
-exists for that key.
+exists for that key. Only normal mode (`"n"`) is supported today.
 
 **Parameters:**
 
-- `{mode}` (`string`) Mode letter (reserved for future modes).
+- `{mode}` (`string`) Mode letter. Currently only `"n"` is accepted.
 - `{lhs}` (`string`) Key to unmap, in Vim notation.
 
 **Example:**

--- a/site/docs/content/permissions/_index.md
+++ b/site/docs/content/permissions/_index.md
@@ -145,6 +145,36 @@ When you pick "always allow", the saved scope is generalized so it stays useful 
 
 For MCP tools, both allow and deny decisions generalize to `*` (the entire tool). This is because MCP tool inputs are opaque JSON with no meaningful scope pattern to differentiate. Denying a single MCP invocation denies the tool entirely until you revoke the rule.
 
+## Plugin Permissions
+
+Plugins (bundled or third-party) run Lua inside Maki and can touch the filesystem, network, shell, environment, and keymap. Each plugin carries a permission set that gates these capabilities, separate from the tool-call rules above.
+
+| Permission | Gates |
+|------------|-------|
+| `fs_read` | `maki.fs.read`, `read_bytes`, `metadata`, `dir`, `glob`, `grep`, `root` |
+| `fs_write` | `maki.fs.write`, `rm`, `mkdir` |
+| `net` | `maki.net.*` |
+| `run` | `maki.fn.job*`, `maki.interpreter.run`, and shell spawning |
+| `env` | `maki.env.*`, `maki.uv.*`, and `maki.fn.executable` |
+| `keymap` | `maki.keymap.set` and `maki.keymap.del` |
+
+**Bundled plugins** (shipped with Maki) always run fully trusted. **Init files** (`~/.config/maki/init.lua`, `.maki/init.lua`) and third-party plugins loaded from a plugin directory derive their permissions from a `plugin.toml` beside their `init.lua`:
+
+```toml
+[permissions]
+fs_read = true
+net = false
+keymap = false
+```
+
+All six default to `true` when the `[permissions]` table omits a key. A plugin that omits `[permissions]` entirely is granted everything. If no `plugin.toml` is found next to the init file or plugin, all permissions are denied. To grant an init file access to a gated API, ship an empty `plugin.toml` (or one with the relevant key set to `true`) beside the init.lua.
+
+Third-party plugins are not loadable yet; bundled plugins and init files are the only plugin sources loaded today.
+
+Of the gated APIs, only `maki.keymap.del` is plugin-scoped: a plugin can only remove a binding it owns. `maki.keymap.set` is not scoped, so a keymap-authorized plugin can still shadow another plugin's binding for the same key by setting its own callback. The previous callback is dropped.
+
+To boot without loading any plugins or init files, use `--no-plugins`.
+
 ## YOLO Mode
 
 To skip all prompts, toggle YOLO with the `/yolo` command, or run with `--yolo`. Explicit deny rules still apply.


### PR DESCRIPTION
Adds the `Keymap` permission I mentioned as a followup to #537, putting `maki.keymap.set` and `maki.keymap.del` behind it. They now both only work in normal mode for now (as was the case already for `set`), and `del` can only touch bindings set in the same plugin.

When I set `keymap = false` in my `plugin.toml` and set a keymap in my `init.lua`:

```
❯ cargo run
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.30s
     Running `target/debug/maki`

✖ load init.lua files
├─ lua error in global/init.lua: runtime error: permission denied: 'keymap' not granted for this plugin
stack traceback:
        [C]: in ?
        [string "global/init.lua"]:13: in function <[string "global/init.lua"]:1>

└─ runtime error: permission denied: 'keymap' not granted for this plugin
stack traceback:
        [C]: in ?
        [string "global/init.lua"]:13: in function <[string "global/init.lua"]:1>
```

Implemented with Maki + GLM-5.2.