### PR TITLE
feat(copilot): use discovered model metadata

### DIFF
--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -55,6 +55,7 @@ pub struct ModelInfo {
     pub pricing: Option<ModelPricing>,
     pub supports_thinking: Option<bool>,
     pub supports_vision: Option<bool>,
+    pub tier: Option<ModelTier>,
     /// Store of additional metadata from the provider.
     pub provider_info: Option<Arc<dyn Any + Send + Sync>>,
 }
@@ -68,6 +69,7 @@ impl ModelInfo {
             pricing: None,
             supports_thinking: None,
             supports_vision: None,
+            tier: None,
             provider_info: None,
         }
     }
@@ -222,35 +224,24 @@ impl Model {
         let spec = format!("{slug}/{model_id}");
         // Discovery keys `known_models` by the builtin slug, so a dynamic or
         // custom slug reads positional tiers and metadata through its base.
-        let tier = model_registry().read().unwrap().tier_for(
-            &spec,
-            manifest.slug,
-            static_entry.map(|e| e.tier),
-        );
-        let (family, pricing, max_output_tokens, context_window) = match static_entry {
-            Some(e) => (
-                e.family,
-                e.pricing.clone(),
-                Some(e.max_output_tokens),
-                anthropic::shared::long_context_window(model_id).unwrap_or(e.context_window),
-            ),
-            None => {
-                let guard = model_registry().read().unwrap();
-                let discovered = guard.discovered(manifest.slug, model_id);
-                (
-                    manifest.family,
-                    discovered
-                        .and_then(|d| d.pricing.clone())
-                        .unwrap_or_default(),
-                    discovered
-                        .and_then(|d| d.max_output_tokens)
-                        .or(manifest.fallback_max_output),
-                    discovered
-                        .and_then(|d| d.context_window)
-                        .unwrap_or(manifest.fallback_context_window),
-                )
-            }
-        };
+        let guard = model_registry().read().unwrap();
+        let discovered = guard.discovered(manifest.slug, model_id);
+        let tier = guard.tier_for(&spec, manifest.slug, static_entry.map(|e| e.tier));
+        let family = static_entry.map_or(manifest.family, |entry| entry.family);
+        let pricing = discovered
+            .and_then(|info| info.pricing.clone())
+            .or_else(|| static_entry.map(|entry| entry.pricing.clone()))
+            .unwrap_or_default();
+        let max_output_tokens = discovered
+            .and_then(|info| info.max_output_tokens)
+            .or_else(|| static_entry.map(|entry| entry.max_output_tokens))
+            .or(manifest.fallback_max_output);
+        let context_window = discovered
+            .and_then(|info| info.context_window)
+            .or_else(|| anthropic::shared::long_context_window(model_id))
+            .or_else(|| static_entry.map(|entry| entry.context_window))
+            .unwrap_or(manifest.fallback_context_window);
+        drop(guard);
         Self {
             id: model_id.to_string(),
             provider: Arc::from(slug),
@@ -804,6 +795,7 @@ mod tests {
                     pricing: None,
                     supports_thinking: None,
                     supports_vision: None,
+                    tier: None,
                     provider_info: None,
                 }],
             );

--- a/maki-providers/src/model_registry.rs
+++ b/maki-providers/src/model_registry.rs
@@ -113,14 +113,21 @@ impl ModelRegistry {
                 t => t,
             };
         }
-        if let Some(t) = static_tier {
-            return t;
-        }
         if let Some((_, model_id)) = spec.split_once('/')
             && let Some(models) = self.known_models.get(provider)
-            && let Some(pos) = models.iter().position(|m| m.id == model_id)
+            && let Some(model) = models.iter().find(|model| model.id == model_id)
         {
-            return tier_for_position(pos);
+            if let Some(tier) = model.tier {
+                return tier;
+            }
+            if static_tier.is_none()
+                && let Some(pos) = models.iter().position(|candidate| candidate.id == model_id)
+            {
+                return tier_for_position(pos);
+            }
+        }
+        if let Some(t) = static_tier {
+            return t;
         }
         ModelTier::Medium
     }
@@ -134,19 +141,31 @@ impl ModelRegistry {
         }
 
         let candidate = self
-            .static_candidate(provider, tier)
+            .discovered_static_candidate(provider, tier)
+            .or_else(|| self.metadata_candidate(provider, tier))
+            .or_else(|| static_candidate(provider, tier))
             .or_else(|| self.positional_candidate(provider, tier))?;
 
         (!self.claimed_elsewhere(&candidate, tier)).then_some(candidate)
     }
 
-    fn static_candidate(&self, provider: &str, tier: ModelTier) -> Option<String> {
-        let manifest = crate::manifest::ManifestRegistry::get(provider)?;
-        manifest
-            .models
+    /// The curated default the provider actually offers, so discovery cannot
+    /// replace a still available default with whatever it lists first.
+    fn discovered_static_candidate(&self, provider: &str, tier: ModelTier) -> Option<String> {
+        static_prefixes(provider, tier)
+            .find(|prefix| self.discovered(provider, prefix).is_some())
+            .map(|prefix| format!("{provider}/{prefix}"))
+    }
+
+    /// Lowest ID wins, so the tier default survives provider list reordering.
+    fn metadata_candidate(&self, provider: &str, tier: ModelTier) -> Option<String> {
+        self.known_models
+            .get(provider)?
             .iter()
-            .find(|e| e.default && e.tier == tier)
-            .map(|e| format!("{provider}/{}", e.prefixes[0]))
+            .filter(|model| model.tier == Some(tier))
+            .map(|model| model.id.as_str())
+            .min()
+            .map(|id| format!("{provider}/{id}"))
     }
 
     fn positional_candidate(&self, provider: &str, tier: ModelTier) -> Option<String> {
@@ -189,6 +208,20 @@ impl ModelRegistry {
             .collect();
         (!tiers.is_empty()).then(|| tiers.join("/"))
     }
+}
+
+fn static_candidate(provider: &str, tier: ModelTier) -> Option<String> {
+    static_prefixes(provider, tier)
+        .next()
+        .map(|prefix| format!("{provider}/{prefix}"))
+}
+
+fn static_prefixes(provider: &str, tier: ModelTier) -> impl Iterator<Item = &'static str> {
+    crate::manifest::ManifestRegistry::get(provider)
+        .into_iter()
+        .flat_map(|manifest| manifest.models)
+        .filter(move |entry| entry.default && entry.tier == tier)
+        .flat_map(|entry| entry.prefixes.iter().copied())
 }
 
 fn tier_for_position(pos: usize) -> ModelTier {
@@ -237,6 +270,7 @@ fn write_overrides(path: &Path, overrides: &BTreeMap<ModelTier, String>) {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+    use test_case::test_case;
 
     fn make_map(overrides: &[(ModelTier, &str)], models: &[&str]) -> ModelRegistry {
         let mut reg = ModelRegistry::default();
@@ -266,6 +300,77 @@ mod tests {
         assert_eq!(t("ollama/pos1", None), ModelTier::Weak);
         assert_eq!(t("ollama/pos2", None), ModelTier::Weak);
         assert_eq!(t("ollama/unknown", None), ModelTier::Medium);
+    }
+
+    fn make_tiered(models: &[(&str, ModelTier)]) -> ModelRegistry {
+        let mut reg = ModelRegistry::default();
+        reg.set_known_models(
+            &Arc::<str>::from("copilot"),
+            models
+                .iter()
+                .map(|&(id, tier)| ModelInfo {
+                    tier: Some(tier),
+                    ..ModelInfo::id_only(id.into())
+                })
+                .collect(),
+        );
+        reg
+    }
+
+    #[test]
+    fn discovered_category_tier_beats_position_and_static_fallback() {
+        let reg = make_tiered(&[
+            ("terra", ModelTier::Medium),
+            ("luna", ModelTier::Weak),
+            ("gpt-5.6-sol", ModelTier::Strong),
+        ]);
+
+        assert_eq!(
+            reg.tier_for("copilot/gpt-5.6-sol", "copilot", Some(ModelTier::Medium)),
+            ModelTier::Strong
+        );
+        assert_eq!(
+            reg.tier_for("copilot/terra", "copilot", None),
+            ModelTier::Medium
+        );
+        assert_eq!(
+            reg.tier_for("copilot/luna", "copilot", None),
+            ModelTier::Weak
+        );
+        assert_eq!(
+            reg.spec_for_tier("copilot", ModelTier::Strong),
+            Some("copilot/gpt-5.6-sol".into())
+        );
+    }
+
+    #[test_case(&[("gpt-5.4", ModelTier::Strong), ("claude-opus-4.7", ModelTier::Strong)], "copilot/gpt-5.4"; "curated default beats discovered tier")]
+    #[test_case(&[("claude-opus-4.6", ModelTier::Strong), ("alpha", ModelTier::Strong)], "copilot/claude-opus-4.6"; "later curated prefix when first is unavailable")]
+    #[test_case(&[("zeta", ModelTier::Strong), ("alpha", ModelTier::Strong)], "copilot/alpha"; "lowest id when no curated default is entitled")]
+    fn spec_for_tier_prefers_entitled_curated_default(
+        models: &[(&str, ModelTier)],
+        expected: &str,
+    ) {
+        let reg = make_tiered(models);
+        assert_eq!(
+            reg.spec_for_tier("copilot", ModelTier::Strong),
+            Some(expected.into())
+        );
+    }
+
+    #[test]
+    fn spec_for_tier_ignores_discovery_list_order() {
+        let models = [
+            ("zeta", ModelTier::Strong),
+            ("alpha", ModelTier::Strong),
+            ("mid", ModelTier::Medium),
+        ];
+        let mut reversed = models;
+        reversed.reverse();
+
+        assert_eq!(
+            make_tiered(&models).spec_for_tier("copilot", ModelTier::Strong),
+            make_tiered(&reversed).spec_for_tier("copilot", ModelTier::Strong)
+        );
     }
 
     #[test]
@@ -337,6 +442,7 @@ mod tests {
                     pricing: None,
                     supports_thinking: None,
                     supports_vision: None,
+                    tier: None,
                     provider_info: None,
                 },
                 ModelInfo {
@@ -346,6 +452,7 @@ mod tests {
                     pricing: None,
                     supports_thinking: None,
                     supports_vision: None,
+                    tier: None,
                     provider_info: None,
                 },
             ],

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -13,9 +13,12 @@ use tracing::{debug, warn};
 use super::anthropic::shared;
 use super::openai::responses;
 use super::openai_compat;
-use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
+use crate::model::{Model, ModelEntry, ModelFamily, ModelInfo, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig};
+use crate::{
+    AgentError, Effort, EffortDialect, Message, ProviderEvent, RequestOptions, StreamResponse,
+    ThinkingConfig, dialect,
+};
 
 pub mod auth;
 
@@ -256,9 +259,27 @@ impl Copilot {
         system: &str,
         tools: &Value,
         event_tx: &Sender<ProviderEvent>,
+        thinking: ThinkingConfig,
     ) -> Result<StreamResponse, AgentError> {
         let auth = self.auth().await?;
-        let body = responses::build_body(model, messages, system, tools);
+        let mut body = responses::build_body(model, messages, system, tools);
+        let reasoning_info = crate::model_registry::model_registry()
+            .read()
+            .unwrap()
+            .discovered("copilot", &model.id)
+            .and_then(|info| info.provider_info.clone())
+            .and_then(|info| Arc::downcast::<CopilotModelInfo>(info).ok())
+            .or_else(|| {
+                self.models
+                    .lock()
+                    .unwrap()
+                    .get(&model.id)
+                    .map(CopilotModel::reasoning_info)
+                    .map(Arc::new)
+            });
+        if let Some(info) = reasoning_info {
+            apply_responses_reasoning(&mut body, thinking, model, &effort_dialect(&info));
+        }
         let resolved = super::ResolvedAuth {
             base_url: Some(auth.endpoint.clone()),
             headers: copilot_headers(&auth, Some("conversation-agent")),
@@ -353,6 +374,8 @@ struct CopilotModel {
     #[serde(default)]
     model_picker_enabled: bool,
     #[serde(default)]
+    model_picker_category: Option<CopilotModelCategory>,
+    #[serde(default)]
     supported_endpoints: Vec<String>,
 }
 
@@ -364,6 +387,55 @@ impl CopilotModel {
                 .policy
                 .as_ref()
                 .is_none_or(|policy| policy.state == "enabled")
+    }
+
+    fn model_info(&self) -> ModelInfo {
+        let reasoning = self.reasoning_info();
+        ModelInfo {
+            id: self.id.clone(),
+            context_window: self.capabilities.limits.max_context_window_tokens,
+            max_output_tokens: self.capabilities.limits.max_output_tokens,
+            pricing: None,
+            supports_thinking: Some(self.supports_thinking()),
+            supports_vision: Some(self.capabilities.supports.vision),
+            tier: self
+                .model_picker_category
+                .and_then(CopilotModelCategory::tier),
+            provider_info: Some(Arc::new(reasoning)),
+        }
+    }
+
+    /// The chat completions body carries no reasoning field, so declaring
+    /// thinking there would offer the user a setting the request drops.
+    fn supports_thinking(&self) -> bool {
+        let supports = &self.capabilities.supports;
+        self.endpoint() != Endpoint::ChatCompletions
+            && (!supports.reasoning_effort.is_empty()
+                || supports.adaptive_thinking
+                || supports.max_thinking_budget.is_some()
+                || supports.min_thinking_budget.is_some())
+    }
+
+    fn reasoning_info(&self) -> CopilotModelInfo {
+        let mut reasoning_efforts = self
+            .capabilities
+            .supports
+            .reasoning_effort
+            .iter()
+            .filter_map(|effort| effort.parse().ok())
+            .collect::<Vec<_>>();
+        reasoning_efforts.sort_unstable();
+        reasoning_efforts.dedup();
+        CopilotModelInfo {
+            reasoning_off: self
+                .capabilities
+                .supports
+                .reasoning_effort
+                .iter()
+                .any(|effort| effort == dialect::OFF),
+            reasoning_efforts,
+            adaptive_thinking: self.capabilities.supports.adaptive_thinking,
+        }
     }
 
     fn endpoint(&self) -> Endpoint {
@@ -385,6 +457,27 @@ impl CopilotModel {
     }
 }
 
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum CopilotModelCategory {
+    Lightweight,
+    Versatile,
+    Powerful,
+    #[serde(other)]
+    Unknown,
+}
+
+impl CopilotModelCategory {
+    const fn tier(self) -> Option<ModelTier> {
+        match self {
+            Self::Lightweight => Some(ModelTier::Weak),
+            Self::Versatile => Some(ModelTier::Medium),
+            Self::Powerful => Some(ModelTier::Strong),
+            Self::Unknown => None,
+        }
+    }
+}
+
 #[derive(Clone, Default, Deserialize)]
 struct CopilotModelPolicy {
     #[serde(default)]
@@ -395,6 +488,35 @@ struct CopilotModelPolicy {
 struct CopilotModelCapabilities {
     #[serde(default, rename = "type")]
     model_type: String,
+    #[serde(default)]
+    limits: CopilotModelLimits,
+    #[serde(default)]
+    supports: CopilotModelSupports,
+}
+
+#[derive(Clone, Default, Deserialize)]
+struct CopilotModelLimits {
+    max_context_window_tokens: Option<u32>,
+    max_output_tokens: Option<u32>,
+}
+
+#[derive(Clone, Default, Deserialize)]
+struct CopilotModelSupports {
+    #[serde(default)]
+    reasoning_effort: Vec<String>,
+    #[serde(default)]
+    adaptive_thinking: bool,
+    max_thinking_budget: Option<u32>,
+    min_thinking_budget: Option<u32>,
+    #[serde(default)]
+    vision: bool,
+}
+
+#[derive(Debug)]
+struct CopilotModelInfo {
+    reasoning_efforts: Vec<Effort>,
+    reasoning_off: bool,
+    adaptive_thinking: bool,
 }
 
 #[derive(Deserialize)]
@@ -535,6 +657,29 @@ fn anthropic_messages(messages: &[Message]) -> Value {
     )
 }
 
+fn effort_dialect(info: &CopilotModelInfo) -> EffortDialect<'_> {
+    EffortDialect {
+        supported: if info.reasoning_efforts.is_empty() {
+            dialect::PREFER_HIGH.supported
+        } else {
+            &info.reasoning_efforts
+        },
+        adaptive: (!info.adaptive_thinking).then_some(Effort::High),
+        off: info.reasoning_off.then_some(dialect::OFF),
+    }
+}
+
+fn apply_responses_reasoning(
+    body: &mut Value,
+    thinking: ThinkingConfig,
+    model: &Model,
+    dialect: &EffortDialect,
+) {
+    if let Some(effort) = thinking.effort_str(dialect, model) {
+        body["reasoning"] = json!({"effort": effort});
+    }
+}
+
 fn guess_endpoint(model_id: &str) -> Endpoint {
     if model_id.starts_with("claude-") {
         Endpoint::Messages
@@ -567,7 +712,7 @@ impl Provider for Copilot {
                         .await
                 }
                 Endpoint::Responses => {
-                    self.stream_responses(model, messages, system, tools, event_tx)
+                    self.stream_responses(model, messages, system, tools, event_tx, opts.thinking)
                         .await
                 }
                 Endpoint::Messages => {
@@ -583,7 +728,7 @@ impl Provider for Copilot {
             let models = self.fetch_models().await?;
             let infos = models
                 .iter()
-                .map(|model| crate::model::ModelInfo::id_only(model.id.clone()))
+                .map(CopilotModel::model_info)
                 .collect::<Vec<_>>();
             let mut guard = self.models.lock().unwrap();
             guard.clear();
@@ -604,6 +749,7 @@ impl Provider for Copilot {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_case::test_case;
 
     #[test]
     fn endpoint_prefers_messages_then_responses_then_chat() {
@@ -612,9 +758,11 @@ mod tests {
             policy: None,
             capabilities: CopilotModelCapabilities {
                 model_type: "chat".into(),
+                ..Default::default()
             },
             is_chat_default: false,
             model_picker_enabled: true,
+            model_picker_category: None,
             supported_endpoints: vec![CHAT_COMPLETIONS_PATH.into(), MESSAGES_PATH.into()],
         };
         assert_eq!(model.endpoint(), Endpoint::Messages);
@@ -627,6 +775,105 @@ mod tests {
     }
 
     #[test]
+    fn parses_discovered_capabilities_and_category() {
+        let model: CopilotModel = serde_json::from_value(json!({
+            "id": "gpt-5.6-sol",
+            "model_picker_enabled": true,
+            "model_picker_category": "powerful",
+            "supported_endpoints": ["/responses"],
+            "capabilities": {
+                "type": "chat",
+                "limits": {
+                    "max_context_window_tokens": 1_050_000,
+                    "max_output_tokens": 128_000
+                },
+                "supports": {
+                    "reasoning_effort": ["none", "low", "medium", "high"],
+                    "adaptive_thinking": true,
+                    "max_thinking_budget": 64_000,
+                    "min_thinking_budget": 1_024,
+                    "vision": true
+                }
+            }
+        }))
+        .unwrap();
+
+        let info = model.model_info();
+        assert_eq!(info.context_window, Some(1_050_000));
+        assert_eq!(info.max_output_tokens, Some(128_000));
+        assert_eq!(info.supports_thinking, Some(true));
+        assert_eq!(info.supports_vision, Some(true));
+        assert_eq!(info.tier, Some(ModelTier::Strong));
+        let provider_info = info
+            .provider_info
+            .unwrap()
+            .downcast::<CopilotModelInfo>()
+            .unwrap();
+        assert_eq!(
+            provider_info.reasoning_efforts,
+            vec![Effort::Low, Effort::Medium, Effort::High]
+        );
+        assert!(provider_info.reasoning_off);
+        assert!(provider_info.adaptive_thinking);
+    }
+
+    #[test]
+    fn unknown_category_keeps_model_without_tier() {
+        let model: CopilotModel = serde_json::from_value(json!({
+            "id": "gpt-6",
+            "model_picker_enabled": true,
+            "model_picker_category": "reasoning",
+            "capabilities": { "type": "chat" }
+        }))
+        .unwrap();
+
+        assert!(model.is_enabled_chat_model());
+        assert_eq!(model.model_info().tier, None);
+    }
+
+    #[test_case(RESPONSES_PATH, true; "responses honors reasoning")]
+    #[test_case(MESSAGES_PATH, true; "messages honors thinking")]
+    #[test_case(CHAT_COMPLETIONS_PATH, false; "chat completions drops reasoning")]
+    fn thinking_support_follows_endpoint(endpoint: &str, expected: bool) {
+        let model: CopilotModel = serde_json::from_value(json!({
+            "id": "reasoner",
+            "supported_endpoints": [endpoint],
+            "capabilities": {
+                "type": "chat",
+                "supports": {"reasoning_effort": ["low", "high"], "adaptive_thinking": true}
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(model.model_info().supports_thinking, Some(expected));
+    }
+
+    #[test]
+    fn responses_reasoning_uses_effort_object_and_explicit_none() {
+        let model = Model::from_spec("copilot/gpt-5.4").unwrap();
+        let info = CopilotModelInfo {
+            reasoning_efforts: vec![Effort::Low, Effort::Medium, Effort::High],
+            reasoning_off: true,
+            adaptive_thinking: false,
+        };
+        let dialect = effort_dialect(&info);
+
+        let mut body = json!({});
+        apply_responses_reasoning(&mut body, ThinkingConfig::Off, &model, &dialect);
+        assert_eq!(body, json!({"reasoning": {"effort": "none"}}));
+
+        let mut body = json!({});
+        apply_responses_reasoning(
+            &mut body,
+            ThinkingConfig::Effort(Effort::Medium),
+            &model,
+            &dialect,
+        );
+        assert_eq!(body, json!({"reasoning": {"effort": "medium"}}));
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
     fn filters_enabled_chat_models() {
         let enabled = CopilotModel {
             id: "gpt-5.4".into(),
@@ -635,9 +882,11 @@ mod tests {
             }),
             capabilities: CopilotModelCapabilities {
                 model_type: "chat".into(),
+                ..Default::default()
             },
             is_chat_default: false,
             model_picker_enabled: true,
+            model_picker_category: None,
             supported_endpoints: vec![],
         };
         assert!(enabled.is_enabled_chat_model());

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -561,6 +561,7 @@ impl Provider for DynamicProvider {
                     pricing: m.pricing.clone(),
                     supports_thinking: None,
                     supports_vision: m.supports_vision,
+                    tier: None,
                     provider_info: None,
                 })
                 .collect())

--- a/maki-providers/src/providers/local.rs
+++ b/maki-providers/src/providers/local.rs
@@ -308,6 +308,7 @@ impl LocalEndpoint {
                     pricing: Some(crate::model::ModelPricing::ZERO),
                     supports_thinking: None,
                     supports_vision,
+                    tier: None,
                     provider_info: None,
                 })
             })
@@ -416,6 +417,7 @@ impl LocalEndpoint {
                 pricing: Some(crate::model::ModelPricing::ZERO),
                 supports_thinking: None,
                 supports_vision: None,
+                tier: None,
                 provider_info: None,
             })
             .collect();

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -252,6 +252,7 @@ impl Provider for Mistral {
                         pricing: None,
                         supports_thinking,
                         supports_vision: Some(supports_vision),
+                        tier: None,
                         provider_info: None,
                     })
                 })

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -229,6 +229,7 @@ impl OpenAiCompatProvider {
             pricing: Some(pricing),
             supports_thinking: None,
             supports_vision: None,
+            tier: None,
             provider_info: None,
         })
     }

--- a/maki-providers/src/providers/opencode.rs
+++ b/maki-providers/src/providers/opencode.rs
@@ -234,6 +234,7 @@ impl ProviderData {
                     }),
                     supports_thinking: None,
                     supports_vision: None,
+                    tier: None,
                     provider_info: None,
                 })
             })

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -160,6 +160,7 @@ fn parse_model(m: &Value) -> Option<ModelInfo> {
         pricing: Some(pricing),
         supports_thinking: Some(supports_thinking),
         supports_vision: Some(supports_vision),
+        tier: None,
         provider_info: reasoning.map(|r| Arc::new(r) as Arc<dyn std::any::Any + Send + Sync>),
     })
 }

--- a/maki-providers/src/providers/tensorx.rs
+++ b/maki-providers/src/providers/tensorx.rs
@@ -215,6 +215,7 @@ impl Provider for TensorX {
                                 pricing,
                                 supports_thinking,
                                 supports_vision: Some(supports_vision),
+                                tier: None,
                                 provider_info: supported_params
                                     .map(|p| Arc::new(p) as Arc<dyn std::any::Any + Send + Sync>),
                             })


### PR DESCRIPTION
## Summary

- Populate Copilot model metadata from discovered capabilities, limits, vision support, and picker categories.
- Use provider-reported tiers when resolving weak, medium, and strong models.
- Pass supported reasoning effort to Copilot Responses requests.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all --tests -- -D warnings`
- `cargo test -p maki-providers`
- `cargo test --workspace` (one unrelated Windows path test fails: `permissions::tests::command_matches_its_own_generalized_rule::edit_path`)