### PR TITLE
fix(cli): `--no-plugins` keeps builtin plugins, only skips user `init.lua`

### DIFF
--- a/maki-docgen/src/gen_keybindings.rs
+++ b/maki-docgen/src/gen_keybindings.rs
@@ -176,15 +176,17 @@ fn write_overrides(out: &mut String) {
     out.push_str(
         "If an override leaves Maki stuck (a rebound `Ctrl+C`, a modal \
          that won't close, a plugin that throws on load), boot without \
-         plugins:\n\n",
+         user `init.lua`:\n\n",
     );
     out.push_str("```bash\nmaki --no-plugins\n```\n\n");
     out.push_str(
-        "This skips the Lua host and runs the full default keymap from \
-         Rust, so quit, Esc, scroll, and suspend always work.\n\n",
+        "Skips user `init.lua` files (global and project) but keeps the \
+         Lua host and builtin plugins running, so tools still work. \
+         `permissions.toml`, custom commands, and env files load as \
+         usual.\n\n",
     );
     out.push_str(
-        "The defaults live in Rust, not Lua, so `--no-plugins` never \
-         drops them.\n",
+        "The default keymap lives in Rust, not Lua, so `--no-plugins` \
+         never drops it.\n",
     );
 }

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -119,19 +119,16 @@ static BUNDLED_DIRS: LazyLock<&'static [&'static Dir<'static>]> = LazyLock::new(
 });
 
 pub struct PluginHost {
-    inner: Option<LuaThread>,
+    inner: LuaThread,
 }
 
 impl Drop for PluginHost {
     fn drop(&mut self) {
-        let Some(ref mut inner) = self.inner else {
+        let Some(handle) = self.inner.join.take() else {
             return;
         };
-        let Some(handle) = inner.join.take() else {
-            return;
-        };
-        inner.shutdown.store(true, Ordering::Release);
-        let _ = inner.tx.send(Request::Shutdown);
+        self.inner.shutdown.store(true, Ordering::Release);
+        let _ = self.inner.tx.send(Request::Shutdown);
         let (done_tx, done_rx) = flume::bounded(1);
         std::thread::spawn(move || {
             let _ = done_tx.send(handle.join().is_err());
@@ -154,11 +151,7 @@ impl PluginHost {
     /// every chunk gets it, init.lua files included.
     pub fn with_jit(registry: Arc<ToolRegistry>, jit: bool) -> Result<Self, PluginError> {
         let lua = runtime::spawn(registry, *BUNDLED_DIRS, jit)?;
-        Ok(Self { inner: Some(lua) })
-    }
-
-    pub fn disabled() -> Self {
-        Self { inner: None }
+        Ok(Self { inner: lua })
     }
 
     /// Stop the Lua thread from taking new work without joining it, so the
@@ -169,12 +162,10 @@ impl PluginHost {
     /// makes every later host call fail right at the send; `&mut self`
     /// rules out a call racing the swap. `Drop` still joins the thread.
     pub fn begin_shutdown(&mut self) {
-        if let Some(ref mut inner) = self.inner {
-            inner.shutdown.store(true, Ordering::Release);
-            let _ = inner.prio_tx.send(Request::Shutdown);
-            inner.tx = flume::unbounded().0;
-            inner.prio_tx = flume::unbounded().0;
-        }
+        self.inner.shutdown.store(true, Ordering::Release);
+        let _ = self.inner.prio_tx.send(Request::Shutdown);
+        self.inner.tx = flume::unbounded().0;
+        self.inner.prio_tx = flume::unbounded().0;
     }
 
     /// Boots the runtime and loads every default bundled plugin into `registry`.
@@ -187,9 +178,6 @@ impl PluginHost {
     }
 
     pub fn load_init_files(&self, cwd: &Path) -> Result<Option<RawConfig>, PluginError> {
-        if self.inner.is_none() {
-            return Ok(None);
-        }
         let mut merged: Option<RawConfig> = None;
 
         for global_dir in maki_config::global_config_dirs() {
@@ -201,6 +189,20 @@ impl PluginHost {
         self.run_init_file(&cwd.join(".maki/init.lua"), "project/init.lua", &mut merged)?;
 
         Ok(merged)
+    }
+
+    /// `--no-plugins` recovery path: skip every user `init.lua` while the
+    /// host and builtin plugins stay live. Centralized so every entry point
+    /// (TUI, index, acp, prompt) honors the flag identically.
+    pub fn load_init_files_or_skip(
+        &self,
+        no_plugins: bool,
+        cwd: &Path,
+    ) -> Result<Option<RawConfig>, PluginError> {
+        if no_plugins {
+            return Ok(None);
+        }
+        self.load_init_files(cwd)
     }
 
     fn run_init_file(
@@ -227,9 +229,6 @@ impl PluginHost {
     }
 
     pub fn load_builtins(&mut self, config: &PluginsConfig) -> Result<(), PluginError> {
-        if self.inner.is_none() {
-            return Ok(());
-        }
         for (plugin, opts) in &config.opts {
             let keys: Vec<&str> = opts.keys().map(String::as_str).collect();
             if !BUNDLED_PLUGINS.iter().any(|p| p.name == plugin.as_str()) {
@@ -281,13 +280,6 @@ impl PluginHost {
         Ok(())
     }
 
-    fn tx(&self) -> Result<&flume::Sender<Request>, PluginError> {
-        self.inner
-            .as_ref()
-            .map(|r| &r.tx)
-            .ok_or(PluginError::HostDead)
-    }
-
     fn send_load(
         &self,
         name: Arc<str>,
@@ -296,26 +288,28 @@ impl PluginHost {
         permissions: PluginPermissions,
         opts: PluginOpts,
     ) -> Result<(), PluginError> {
-        let tx = self.tx()?;
         let (reply_tx, reply_rx) = flume::bounded(1);
-        tx.send(Request::LoadSource {
-            name,
-            source,
-            plugin_dir,
-            permissions,
-            opts,
-            reply: reply_tx,
-        })
-        .map_err(|_| PluginError::HostDead)?;
+        self.inner
+            .tx
+            .send(Request::LoadSource {
+                name,
+                source,
+                plugin_dir,
+                permissions,
+                opts,
+                reply: reply_tx,
+            })
+            .map_err(|_| PluginError::HostDead)?;
         reply_rx.recv().map_err(|_| PluginError::HostDead)?
     }
 
     /// Option specs declared by loaded plugins via `maki.api.register_options`,
     /// keyed by plugin name. Used by docgen.
     pub fn plugin_options(&self) -> Result<PluginOptionSpecs, PluginError> {
-        let tx = self.tx()?;
         let (reply_tx, reply_rx) = flume::bounded(1);
-        tx.send(Request::CollectPluginOptions { reply: reply_tx })
+        self.inner
+            .tx
+            .send(Request::CollectPluginOptions { reply: reply_tx })
             .map_err(|_| PluginError::HostDead)?;
         reply_rx.recv().map_err(|_| PluginError::HostDead)
     }
@@ -326,26 +320,28 @@ impl PluginHost {
         source_name: String,
         plugin_dir: Option<PathBuf>,
     ) -> Result<Option<RawConfig>, PluginError> {
-        let tx = self.tx()?;
         let (reply_tx, reply_rx) = flume::bounded(1);
-        tx.send(Request::RunInitLua {
-            source,
-            source_name,
-            plugin_dir,
-            reply: reply_tx,
-        })
-        .map_err(|_| PluginError::HostDead)?;
+        self.inner
+            .tx
+            .send(Request::RunInitLua {
+                source,
+                source_name,
+                plugin_dir,
+                reply: reply_tx,
+            })
+            .map_err(|_| PluginError::HostDead)?;
         reply_rx.recv().map_err(|_| PluginError::HostDead)?
     }
 
     pub fn unload(&self, plugin: &str) -> Result<(), PluginError> {
-        let tx = self.tx()?;
         let (reply_tx, reply_rx) = flume::bounded(1);
-        tx.send(Request::ClearPlugin {
-            plugin: Arc::from(plugin),
-            reply: reply_tx,
-        })
-        .map_err(|_| PluginError::HostDead)?;
+        self.inner
+            .tx
+            .send(Request::ClearPlugin {
+                plugin: Arc::from(plugin),
+                reply: reply_tx,
+            })
+            .map_err(|_| PluginError::HostDead)?;
         reply_rx.recv().map_err(|_| PluginError::HostDead)?;
         Ok(())
     }
@@ -404,36 +400,27 @@ impl PluginHost {
         )
     }
 
-    pub fn event_handle(&self) -> Option<EventHandle> {
-        self.inner.as_ref().map(|t| EventHandle {
-            tx: t.tx.clone(),
-            prio_tx: t.prio_tx.clone(),
-        })
+    pub fn event_handle(&self) -> EventHandle {
+        EventHandle {
+            tx: self.inner.tx.clone(),
+            prio_tx: self.inner.prio_tx.clone(),
+        }
     }
 
     pub fn command_reader(&self) -> LuaCommandReader {
-        self.inner
-            .as_ref()
-            .map(|t| t.command_reader.clone())
-            .unwrap_or_else(LuaCommandReader::empty)
+        self.inner.command_reader.clone()
     }
 
     pub fn keymap_reader(&self) -> KeymapReader {
-        self.inner
-            .as_ref()
-            .map(|t| t.keymap_reader.clone())
-            .unwrap_or_else(KeymapReader::empty)
+        self.inner.keymap_reader.clone()
     }
 
     pub fn hint_reader(&self) -> HintReader {
-        self.inner
-            .as_ref()
-            .map(|t| t.hint_reader.clone())
-            .unwrap_or_else(HintReader::empty)
+        self.inner.hint_reader.clone()
     }
 
-    pub fn ui_action_rx(&self) -> Option<flume::Receiver<UiAction>> {
-        self.inner.as_ref().map(|t| t.ui_action_rx.clone())
+    pub fn ui_action_rx(&self) -> flume::Receiver<UiAction> {
+        self.inner.ui_action_rx.clone()
     }
 }
 
@@ -455,6 +442,15 @@ impl EventHandle {
     #[doc(hidden)]
     pub fn disconnected_for_test() -> Self {
         Self::from_tx(flume::unbounded().0)
+    }
+
+    /// True when no runtime is draining requests. Production handles stay
+    /// connected for the host's lifetime; the disconnected-for-test handle
+    /// and a host whose thread has shut down both report true. Callers use
+    /// this to skip async side effects (e.g. a restore-complete flip) that
+    /// no live consumer would ever observe.
+    pub fn is_disconnected(&self) -> bool {
+        self.tx.is_disconnected() && self.prio_tx.is_disconnected()
     }
 
     /// Test probe sibling of `from_tx`: collapses both senders onto one
@@ -574,13 +570,6 @@ mod tests {
         assert!(reg.has("glob"));
     }
 
-    #[test]
-    fn load_builtins_on_disabled_host_is_noop() {
-        let mut host = PluginHost::disabled();
-        host.load_builtins(&PluginsConfig::from_plugins(HashMap::new()))
-            .unwrap();
-    }
-
     /// The second call sends `Shutdown` on a sender that is already
     /// disconnected; it must swallow that error and keep rejecting work.
     #[test]
@@ -590,11 +579,6 @@ mod tests {
         assert!(host.load_source("late", "return {}").is_err());
         host.begin_shutdown();
         assert!(host.load_source("later", "return {}").is_err());
-    }
-
-    #[test]
-    fn begin_shutdown_on_disabled_host_is_noop() {
-        PluginHost::disabled().begin_shutdown();
     }
 
     /// Regression for the exit drain in `runtime::spawn`. An `EventHandle`
@@ -611,7 +595,7 @@ mod tests {
             r#"maki.api.register_prompt_hint({ slot = "tool_usage", content = "live" })"#,
         )
         .unwrap();
-        let handle = host.event_handle().unwrap();
+        let handle = host.event_handle();
         host.begin_shutdown();
 
         let slots = handle.collect_prompt_slots();
@@ -630,7 +614,7 @@ mod tests {
     fn slots_from(plugin: &str, src: &str) -> (PluginHost, ResolvedSlots) {
         let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
         host.load_source(plugin, src).unwrap();
-        let slots = host.event_handle().unwrap().collect_prompt_slots();
+        let slots = host.event_handle().collect_prompt_slots();
         (host, slots)
     }
 
@@ -791,7 +775,7 @@ mod tests {
             "callback has not fired yet"
         );
 
-        let handle = host.event_handle().expect("host is live");
+        let handle = host.event_handle();
         handle.run_keybind_callback(entry.id);
 
         let deadline = Instant::now() + Duration::from_secs(2);
@@ -808,40 +792,36 @@ mod tests {
         }
     }
 
+    /// `load_init_files_or_skip` is the single seam every entry point
+    /// (TUI, index, acp, prompt) uses to honor `--no-plugins`. Verify both
+    /// halves: the flag skips a broken init.lua, and absence runs it (so
+    /// the skip path is not a tautology that hides a regression in the
+    /// unconditional loader).
     #[test]
-    fn disabled_host_returns_defaults() {
-        let host = PluginHost::disabled();
-        let snap = host.command_reader().load();
-        assert_eq!(snap.commands.len(), 0);
-        assert_eq!(snap.generation, 0);
-        assert!(host.ui_action_rx().is_none());
-    }
-
-    #[test_case(true ; "with_init_lua_present")]
-    #[test_case(false ; "without_init_lua")]
-    fn disabled_host_skips_init_files(with_init: bool) {
+    fn load_init_files_or_skip_respects_flag() {
         let dir = tempfile::tempdir().unwrap();
-        if with_init {
-            fs::create_dir_all(dir.path().join(".maki")).unwrap();
-            fs::write(dir.path().join(".maki/init.lua"), "error('should not run')").unwrap();
-        }
-        let host = PluginHost::disabled();
-        let config = host
-            .load_init_files(dir.path())
-            .expect("disabled host skips init");
-        assert!(config.is_none(), "disabled host returns no config");
-    }
+        fs::create_dir_all(dir.path().join(".maki")).unwrap();
+        fs::write(
+            dir.path().join(".maki/init.lua"),
+            "error('broken init lua must not run')",
+        )
+        .unwrap();
 
-    #[test]
-    fn disabled_host_skips_load_builtins() {
-        let mut host = PluginHost::disabled();
-        let config = PluginsConfig::from_plugins(HashMap::new());
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+
+        let skipped = host
+            .load_init_files_or_skip(true, dir.path())
+            .expect("no-plugins skips broken init.lua");
         assert!(
-            !config.names.is_empty(),
-            "default config enables builtin plugins"
+            skipped.is_none(),
+            "--no-plugins must skip user init.lua entirely"
         );
-        host.load_builtins(&config)
-            .expect("disabled host skips builtin plugin load");
+
+        let ran = host.load_init_files_or_skip(false, dir.path());
+        assert!(
+            ran.is_err(),
+            "without --no-plugins the broken init.lua must surface as an error"
+        );
     }
 
     #[test]
@@ -972,7 +952,7 @@ mod tests {
             )
             .unwrap();
         }
-        let slots = host.event_handle().unwrap().collect_prompt_slots();
+        let slots = host.event_handle().collect_prompt_slots();
         assert_eq!(
             contents(&slots, PromptId::System, Slot::ToolUsage),
             ["from_aaa", "from_zzz"],
@@ -992,7 +972,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        let handle = host.event_handle().unwrap();
+        let handle = host.event_handle();
 
         let slots = handle.collect_prompt_slots();
         assert_eq!(
@@ -1074,7 +1054,7 @@ mod tests {
             r#"maki.api.set_prompt({ slot = "identity", content = "ZZZ" })"#,
         )
         .unwrap();
-        let slots = host.event_handle().unwrap().collect_prompt_slots();
+        let slots = host.event_handle().collect_prompt_slots();
         let entries = slots.get(PromptId::System, Slot::Identity);
         assert_eq!(entries.len(), 2);
         assert_eq!(entries.last().unwrap().content, "ZZZ");
@@ -1165,7 +1145,7 @@ mod tests {
             r#"maki.api.set_prompt({ slot = "identity", content = "SET" })"#,
         )
         .unwrap();
-        let slots = host.event_handle().unwrap().collect_prompt_slots();
+        let slots = host.event_handle().collect_prompt_slots();
         assert_eq!(
             contents(&slots, PromptId::System, Slot::ToolUsage),
             ["HINT"]

--- a/maki-lua/tests/batch_policy.rs
+++ b/maki-lua/tests/batch_policy.rs
@@ -335,7 +335,7 @@ fn restore_snapshot_lines_opts(
     state: Option<Value>,
     clicks: Vec<usize>,
 ) -> Vec<Vec<(String, SpanStyle)>> {
-    let handle = host.event_handle().expect("event handle available");
+    let handle = host.event_handle();
     let (tx, rx) = flume::unbounded();
     handle.request_restore(
         maki_lua::RestoreItem {

--- a/maki-lua/tests/code_execution_policy.rs
+++ b/maki-lua/tests/code_execution_policy.rs
@@ -347,7 +347,7 @@ fn handler_error_keeps_script_and_drops_waiting_notice() {
 
 fn restore_lines_with(code: &str, output: &str, is_error: bool, clicks: Vec<usize>) -> Vec<String> {
     let (_reg, host) = setup();
-    let eh = host.event_handle().expect("event handle");
+    let eh = host.event_handle();
     let (tx, rx) = flume::unbounded::<maki_agent::Envelope>();
     eh.request_restore(
         maki_lua::RestoreItem {

--- a/maki-lua/tests/events_slots.rs
+++ b/maki-lua/tests/events_slots.rs
@@ -228,7 +228,6 @@ end }})
     );
     load(&host, "listener", &listener);
     host.event_handle()
-        .unwrap()
         .fire_autocmd("TurnEnd", serde_json::json!({ "k": "v" }));
     assert_eq!(exec_tool(&reg, "probe_turn_end"), "TurnEnd|nil|v");
 }

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -368,7 +368,7 @@ fn restore_snapshot_text(
 ) -> String {
     let host = PluginHost::new(fresh_registry()).unwrap();
     host.load_source("restore_plugin", src).unwrap();
-    let handle = host.event_handle().expect("event handle available");
+    let handle = host.event_handle();
     let (tx, rx) = flume::unbounded();
 
     handle.request_restore(
@@ -1187,7 +1187,7 @@ fn click_until_finished(
     tool: &str,
     click_id: &'static str,
 ) -> String {
-    let eh = host.event_handle().expect("event handle available");
+    let eh = host.event_handle();
     let entry = reg.get(tool).expect("tool registered");
     let inv = entry.tool.parse(&serde_json::json!({})).expect("parse");
     let worker = std::thread::spawn(move || {
@@ -1407,7 +1407,7 @@ fn warm_click_reaches_finished_tool(is_error: bool) {
     let body = recv_live_buf(&rx, WARM_ID).expect("live buf published");
 
     let (fb_tx, fb_rx) = flume::unbounded();
-    let eh = host.event_handle().expect("event handle available");
+    let eh = host.event_handle();
     eh.request_click_with_fallback(
         WARM_ID.to_owned(),
         0,
@@ -1432,7 +1432,7 @@ fn click_fallback_restores_when_warm_missing() {
     let (_reg, host) = warm_host(false, true);
     let (tx, rx) = flume::unbounded();
 
-    let eh = host.event_handle().expect("event handle available");
+    let eh = host.event_handle();
     eh.request_click_with_fallback(
         GONE_ID.to_owned(),
         0,
@@ -1459,7 +1459,7 @@ fn click_fallback_restores_when_warm_buf_has_no_handler() {
     recv_live_buf(&rx, WARM_ID).expect("live buf published");
 
     let (fb_tx, fb_rx) = flume::unbounded();
-    let eh = host.event_handle().expect("event handle available");
+    let eh = host.event_handle();
     eh.request_click_with_fallback(
         WARM_ID.to_owned(),
         0,
@@ -1487,7 +1487,7 @@ fn restore_evicts_warm_handle() {
     let body = recv_live_buf(&rx, WARM_ID).expect("live buf published");
 
     let (tx, _rx) = flume::unbounded();
-    let eh = host.event_handle().expect("event handle available");
+    let eh = host.event_handle();
     eh.request_restore(
         warm_restore_item(WARM_ID, Vec::new()),
         maki_agent::EventSender::new(tx, 0),
@@ -1516,7 +1516,7 @@ fn warm_fifo_evicts_oldest_runtime_side() {
         bufs.push(recv_live_buf(&rx, &id).expect("live buf published"));
     }
 
-    let eh = host.event_handle().expect("event handle available");
+    let eh = host.event_handle();
     eh.request_click("t1".to_owned(), 0);
     eh.request_click("t0".to_owned(), 0);
     barrier(&host);
@@ -1544,7 +1544,7 @@ fn warm_map_cleared_by_load_source() {
     let body = recv_live_buf(&rx, WARM_ID).expect("live buf published");
 
     barrier(&host);
-    let eh = host.event_handle().expect("event handle available");
+    let eh = host.event_handle();
     eh.request_click(WARM_ID.to_owned(), 0);
     barrier(&host);
 
@@ -1584,7 +1584,7 @@ fn warm_click_runs_async_jobs() {
     exec_warm_tool(&reg, "warm_async", &ctx).expect("tool output");
     let body = recv_live_buf(&rx, WARM_ID).expect("live buf published");
 
-    let eh = host.event_handle().expect("event handle available");
+    let eh = host.event_handle();
     eh.request_click(WARM_ID.to_owned(), 0);
     barrier(&host);
 
@@ -1605,7 +1605,7 @@ fn warm_click_survives_post_completion_cancel() {
     let body = recv_live_buf(&rx, WARM_ID).expect("live buf published");
     trigger.cancel();
 
-    let eh = host.event_handle().expect("event handle available");
+    let eh = host.event_handle();
     eh.request_click(WARM_ID.to_owned(), 0);
     barrier(&host);
 
@@ -2241,9 +2241,8 @@ fn command_handler_receives_args_and_fargs(args: &str, expected_flash: &str) {
         "#,
     )
     .unwrap();
-    let rx = host.ui_action_rx().unwrap();
+    let rx = host.ui_action_rx();
     host.event_handle()
-        .unwrap()
         .run_command(Arc::from("p"), Arc::from("/echo"), args.into());
 
     let action = rx
@@ -2405,7 +2404,7 @@ fn restore_tool_async_ordering_and_delivery() {
 
     let input = serde_json::json!({"command": "echo ok", "timeout": 1});
 
-    let handle = host.event_handle().expect("event handle available");
+    let handle = host.event_handle();
     let (tx, rx) = flume::unbounded();
     let event_tx = maki_agent::EventSender::new(tx, 0);
 
@@ -2483,7 +2482,7 @@ fn restore_rebuilds_body_from_input_content(
     expected: &[&str],
 ) {
     let (_reg, host) = builtins_host();
-    let handle = host.event_handle().expect("event handle available");
+    let handle = host.event_handle();
     let (tx, rx) = flume::unbounded();
 
     handle.request_restore(
@@ -3402,8 +3401,8 @@ fn async_run_from_parked_command_handler_runs_promptly() {
         "#,
     )
     .unwrap();
-    let rx = host.ui_action_rx().unwrap();
-    let handle = host.event_handle().unwrap();
+    let rx = host.ui_action_rx();
+    let handle = host.event_handle();
     handle.run_command(Arc::from("p"), Arc::from("/park"), String::new());
 
     let action = rx
@@ -3433,8 +3432,8 @@ fn job_callbacks_fire_while_command_handler_parked() {
         "#,
     )
     .unwrap();
-    let rx = host.ui_action_rx().unwrap();
-    let handle = host.event_handle().unwrap();
+    let rx = host.ui_action_rx();
+    let handle = host.event_handle();
     handle.run_command(Arc::from("p"), Arc::from("/stream"), String::new());
 
     let action = rx

--- a/maki-lua/tests/real_plugins_restore.rs
+++ b/maki-lua/tests/real_plugins_restore.rs
@@ -56,7 +56,7 @@ fn restore(
     state: Option<Value>,
     clicks: Vec<usize>,
 ) -> Restored {
-    let handle = host.event_handle().unwrap();
+    let handle = host.event_handle();
     let (tx, rx) = flume::unbounded();
     handle.request_restore(
         maki_lua::RestoreItem {

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -45,7 +45,7 @@ pub(super) struct AgentLoop {
     queue: Arc<QueueReceiver>,
     session_id: Option<SessionRef>,
     timeouts: maki_providers::Timeouts,
-    lua_handle: Option<EventHandle>,
+    lua_handle: EventHandle,
     subagent_cancels: Arc<CancelMap<String>>,
 }
 
@@ -67,7 +67,7 @@ impl AgentLoop {
         init_cancel: CancelToken,
         session_id: Option<SessionRef>,
         timeouts: maki_providers::Timeouts,
-        lua_handle: Option<EventHandle>,
+        lua_handle: EventHandle,
         subagent_cancels: Arc<CancelMap<String>>,
     ) -> Self {
         let mcp = mcp_handle.map(|h| McpSession::new(h, &initial_history));
@@ -206,10 +206,7 @@ impl AgentLoop {
             }
         }
 
-        let prompt_slots = match self.lua_handle.as_ref() {
-            Some(h) => h.collect_prompt_slots_async().await,
-            None => maki_agent::prompt::ResolvedSlots::default(),
-        };
+        let prompt_slots = self.lua_handle.collect_prompt_slots_async().await;
         let system = agent::build_system_prompt(
             &self.vars,
             &input.mode,

--- a/maki-ui/src/agent/mod.rs
+++ b/maki-ui/src/agent/mod.rs
@@ -69,7 +69,7 @@ impl AgentHandles {
         permissions: &Arc<PermissionManager>,
         session_id: Option<SessionRef>,
         timeouts: maki_providers::Timeouts,
-        lua_handle: Option<EventHandle>,
+        lua_handle: EventHandle,
         mcp_handle: Option<McpHandle>,
         mcp_config_errors: McpConfigErrors,
     ) -> Self {
@@ -105,7 +105,7 @@ impl AgentHandles {
             maki_agent::EventSender::new(self.agent_tx.clone(), crate::app::RESTORE_RUN_ID);
         app.restore_event_tx = Some(restore_tx.clone());
         for chat in &mut app.chats {
-            chat.set_restore_channel(app.lua_event_handle.clone(), Some(restore_tx.clone()));
+            chat.set_restore_channel(Some(restore_tx.clone()));
         }
     }
 
@@ -128,7 +128,7 @@ impl AgentHandles {
         tool_output_lines: ToolOutputLines,
         permissions: &Arc<PermissionManager>,
         app: &mut App,
-        lua_handle: Option<EventHandle>,
+        lua_handle: EventHandle,
     ) {
         // The output channel survives the respawn, so this bump is the only
         // thing that makes the old loop's in-flight envelopes stale. It lives
@@ -206,7 +206,7 @@ fn spawn_agent_internal(
     mcp_config_errors: McpConfigErrors,
     session_id: Option<SessionRef>,
     timeouts: maki_providers::Timeouts,
-    lua_handle: Option<EventHandle>,
+    lua_handle: EventHandle,
 ) -> AgentHandles {
     let (cmd_tx, cmd_rx) = flume::unbounded::<AgentCommand>();
     let (answer_tx, answer_rx) = flume::unbounded::<String>();
@@ -321,7 +321,7 @@ mod tests {
             &permissions,
             None,
             maki_providers::Timeouts::default(),
-            None,
+            EventHandle::disconnected_for_test(),
             None,
             McpConfigErrors::new(PathBuf::new()),
         );
@@ -341,7 +341,7 @@ mod tests {
             ToolOutputLines::default(),
             permissions,
             app,
-            None,
+            EventHandle::disconnected_for_test(),
         );
     }
 

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -176,7 +176,7 @@ pub struct App {
     pub(crate) shell: shell::ShellState,
     pub(crate) ui_config: UiConfig,
     pub(crate) permissions: Arc<PermissionManager>,
-    pub(crate) lua_event_handle: Option<EventHandle>,
+    pub(crate) lua_event_handle: EventHandle,
     pub(super) keymap_reader: KeymapReader,
     pub(super) hint_reader: HintReader,
     pub(crate) restore_event_tx: Option<maki_agent::EventSender>,
@@ -201,6 +201,7 @@ impl App {
         input_history_size: usize,
         permissions: Arc<PermissionManager>,
         custom_commands: Arc<[maki_agent::command::CustomCommand]>,
+        lua_event_handle: EventHandle,
     ) -> Self {
         scrollbar::set_enabled(ui_config.scrollbar);
         let state = SessionState::from_session(session, model, &storage);
@@ -211,7 +212,11 @@ impl App {
             ui_config.max_input_lines,
         );
         let mut app = Self {
-            chats: vec![Chat::new("Main".into(), ui_config.clone())],
+            chats: vec![Chat::new(
+                "Main".into(),
+                ui_config.clone(),
+                lua_event_handle.clone(),
+            )],
             active_chat: 0,
             chat_index: HashMap::new(),
             input_box,
@@ -259,7 +264,7 @@ impl App {
             shell: shell::ShellState::default(),
             ui_config,
             permissions,
-            lua_event_handle: None,
+            lua_event_handle,
             keymap_reader,
             hint_reader,
             restore_event_tx: None,
@@ -298,15 +303,13 @@ impl App {
     }
 
     pub(crate) fn fire_session_autocmd(&self, event: &str, mut data: serde_json::Value) {
-        if let Some(ref handle) = self.lua_event_handle {
-            if let Some(map) = data.as_object_mut() {
-                map.insert(
-                    "session_id".into(),
-                    serde_json::Value::String(self.state.session.id.to_string()),
-                );
-            }
-            handle.fire_autocmd(event, data);
+        if let Some(map) = data.as_object_mut() {
+            map.insert(
+                "session_id".into(),
+                serde_json::Value::String(self.state.session.id.to_string()),
+            );
         }
+        self.lua_event_handle.fire_autocmd(event, data);
     }
 
     pub fn tick_error_expiry(&mut self) {
@@ -727,8 +730,7 @@ impl App {
         for entry in &snap.entries {
             if entry.key == key.code
                 && entry.modifiers == key.modifiers
-                && let Some(ref handle) = self.lua_event_handle
-                && handle.run_keybind_callback(entry.id)
+                && self.lua_event_handle.run_keybind_callback(entry.id)
             {
                 return true;
             }
@@ -1139,8 +1141,12 @@ impl App {
         if let Some(ref model) = subagent.model {
             self.chats[0].update_tool_model(id, model);
         }
-        let mut chat = Chat::new(subagent.name.clone(), self.ui_config.clone());
-        chat.set_restore_channel(self.lua_event_handle.clone(), self.restore_event_tx.clone());
+        let mut chat = Chat::new(
+            subagent.name.clone(),
+            self.ui_config.clone(),
+            self.lua_event_handle.clone(),
+        );
+        chat.set_restore_channel(self.restore_event_tx.clone());
         chat.model_id = subagent.model.clone();
         if let Some(ref prompt) = subagent.prompt {
             chat.push_user_message(prompt);
@@ -1279,10 +1285,11 @@ impl App {
         let Some(lua_cmd) = self.command_palette.find_lua_command(name) else {
             return;
         };
-        let Some(handle) = &self.lua_event_handle else {
-            return;
-        };
-        handle.run_command(Arc::clone(&lua_cmd.plugin), Arc::clone(&lua_cmd.name), args);
+        self.lua_event_handle.run_command(
+            Arc::clone(&lua_cmd.plugin),
+            Arc::clone(&lua_cmd.name),
+            args,
+        );
     }
 
     fn execute_mcp_prompt(&mut self, name: &str, args: &str) -> Vec<Action> {

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -73,8 +73,12 @@ impl App {
 
     pub(super) fn reset_ui_chrome(&mut self) {
         self.chats.clear();
-        let mut main = Chat::new("Main".into(), self.ui_config.clone());
-        main.set_restore_channel(self.lua_event_handle.clone(), self.restore_event_tx.clone());
+        let mut main = Chat::new(
+            "Main".into(),
+            self.ui_config.clone(),
+            self.lua_event_handle.clone(),
+        );
+        main.set_restore_channel(self.restore_event_tx.clone());
         self.chats.push(main);
         self.active_chat = 0;
         self.chat_index.clear();
@@ -111,8 +115,12 @@ impl App {
         for sa in std::mem::take(&mut self.state.session.meta.subagents) {
             let idx = self.chats.len();
             self.chat_index.insert(sa.tool_use_id.clone(), idx);
-            let mut chat = Chat::new(sa.name, self.ui_config.clone());
-            chat.set_restore_channel(self.lua_event_handle.clone(), self.restore_event_tx.clone());
+            let mut chat = Chat::new(
+                sa.name,
+                self.ui_config.clone(),
+                self.lua_event_handle.clone(),
+            );
+            chat.set_restore_channel(self.restore_event_tx.clone());
             chat.model_id = sa.model;
             if let Some(messages) = self.state.session.subagent_messages.get(&sa.tool_use_id) {
                 let (display, items) = history_to_display(
@@ -127,18 +135,20 @@ impl App {
             self.chats.push(chat);
         }
 
-        if let Some(eh) = &self.lua_event_handle {
-            eh.send_restore_complete(restoring);
-        } else {
+        let eh = &self.lua_event_handle;
+        if eh.is_disconnected() {
             self.restoring
                 .store(false, std::sync::atomic::Ordering::Relaxed);
+        } else {
+            eh.send_restore_complete(restoring);
         }
     }
 
     fn fire_restore_items(&self, items: Vec<maki_lua::RestoreItem>) {
-        let (Some(eh), Some(tx)) = (&self.lua_event_handle, &self.restore_event_tx) else {
+        let Some(tx) = &self.restore_event_tx else {
             return;
         };
+        let eh = &self.lua_event_handle;
         let theme_gen = crate::theme::generation();
         for mut item in items {
             item.theme_gen = Some(theme_gen);

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -60,6 +60,7 @@ fn build_app_with_lua(
             PathBuf::from("/tmp"),
         )),
         Arc::from([]),
+        maki_lua::EventHandle::disconnected_for_test(),
     )
 }
 
@@ -1814,7 +1815,7 @@ fn typed_lua_command_with_args_executes() {
         }]),
     );
     let (handle, probe) = maki_lua::test_support::probed_event_handle();
-    app.lua_event_handle = Some(handle);
+    app.lua_event_handle = handle;
 
     let actions = type_and_submit(&mut app, "/rename my title");
 
@@ -2532,7 +2533,7 @@ fn install_override(
         id: 1,
     }]);
     let (handle, probe) = maki_lua::test_support::probed_event_handle();
-    app.lua_event_handle = Some(handle);
+    app.lua_event_handle = handle;
     probe
 }
 
@@ -2668,7 +2669,7 @@ fn streaming_cancel_wins_over_quit_override() {
 fn dead_host_override_falls_back_to_builtin() {
     let mut app = test_app();
     let _probe = install_override(&mut app, kb::HELP.code, kb::HELP.modifiers);
-    app.lua_event_handle = Some(maki_lua::EventHandle::disconnected_for_test());
+    app.lua_event_handle = maki_lua::EventHandle::disconnected_for_test();
 
     app.update(Msg::Key(kb::HELP.to_key_event()));
 

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -50,14 +50,14 @@ pub struct Chat {
 }
 
 impl Chat {
-    pub fn new(name: String, ui_config: UiConfig) -> Self {
+    pub fn new(name: String, ui_config: UiConfig, lua_event_handle: maki_lua::EventHandle) -> Self {
         Self {
             name,
             token_usage: TokenUsage::default(),
             context_size: 0,
             model_id: None,
             pending_turn_usage: None,
-            messages_panel: MessagesPanel::new(ui_config),
+            messages_panel: MessagesPanel::new(ui_config, lua_event_handle),
             finished: false,
         }
     }
@@ -66,13 +66,8 @@ impl Chat {
         self.pending_turn_usage = Some(usage);
     }
 
-    pub(crate) fn set_restore_channel(
-        &mut self,
-        event_handle: Option<maki_lua::EventHandle>,
-        event_tx: Option<maki_agent::EventSender>,
-    ) {
-        self.messages_panel
-            .set_restore_channel(event_handle, event_tx);
+    pub(crate) fn set_restore_channel(&mut self, event_tx: Option<maki_agent::EventSender>) {
+        self.messages_panel.set_restore_channel(event_tx);
     }
 
     pub fn handle_event(&mut self, event: AgentEvent, plan_path: Option<&Path>) -> ChatEventResult {
@@ -630,7 +625,11 @@ mod tests {
 
     #[test]
     fn tool_lifecycle() {
-        let mut chat = Chat::new("Main".into(), UiConfig::default());
+        let mut chat = Chat::new(
+            "Main".into(),
+            UiConfig::default(),
+            maki_lua::EventHandle::disconnected_for_test(),
+        );
         chat.handle_event(tool_start("t1", "bash"), None);
         assert_eq!(chat.in_progress_count(), 1);
 
@@ -643,7 +642,11 @@ mod tests {
 
     #[test]
     fn plan_write_renders_file_content() {
-        let mut chat = Chat::new("Main".into(), UiConfig::default());
+        let mut chat = Chat::new(
+            "Main".into(),
+            UiConfig::default(),
+            maki_lua::EventHandle::disconnected_for_test(),
+        );
         let dir = tempfile::tempdir().unwrap();
         let plan_path = dir.path().join("plan.md");
         std::fs::write(&plan_path, "# My Plan\n\n- Step 1").unwrap();
@@ -663,7 +666,11 @@ mod tests {
 
     #[test]
     fn plan_write_ignores_different_path() {
-        let mut chat = Chat::new("Main".into(), UiConfig::default());
+        let mut chat = Chat::new(
+            "Main".into(),
+            UiConfig::default(),
+            maki_lua::EventHandle::disconnected_for_test(),
+        );
         let plan_path = Path::new("/plans/123.md");
         chat.handle_event(tool_start("w1", "write"), Some(plan_path));
         let (output, wp) = write_output("src/main.rs");
@@ -676,7 +683,11 @@ mod tests {
 
     #[test]
     fn plan_edit_shows_path_only() {
-        let mut chat = Chat::new("Main".into(), UiConfig::default());
+        let mut chat = Chat::new(
+            "Main".into(),
+            UiConfig::default(),
+            maki_lua::EventHandle::disconnected_for_test(),
+        );
         let dir = tempfile::tempdir().unwrap();
         let plan_path = dir.path().join("plan.md");
         std::fs::write(&plan_path, "# My Plan\n\n- Step 1").unwrap();
@@ -984,7 +995,11 @@ mod tests {
 
     #[test]
     fn compaction_done_flushes_streaming_buffers() {
-        let mut chat = Chat::new("Main".into(), UiConfig::default());
+        let mut chat = Chat::new(
+            "Main".into(),
+            UiConfig::default(),
+            maki_lua::EventHandle::disconnected_for_test(),
+        );
 
         chat.handle_event(AgentEvent::AutoCompacting, None);
         assert_eq!(chat.message_count(), 1);

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -77,7 +77,7 @@ pub struct MessagesPanel {
     /// warm cache.
     watched_bufs: VecDeque<(String, Arc<SharedBuf>)>,
     tool_output_lines: ToolOutputLines,
-    lua_event_handle: Option<EventHandle>,
+    lua_event_handle: EventHandle,
     restore_event_tx: Option<EventSender>,
     show_thinking: bool,
     thinking_collapsed: bool,
@@ -88,7 +88,7 @@ pub struct MessagesPanel {
 }
 
 impl MessagesPanel {
-    pub fn new(ui_config: UiConfig) -> Self {
+    pub fn new(ui_config: UiConfig, lua_event_handle: EventHandle) -> Self {
         let thinking = thinking_style();
         let assistant = assistant_style();
         let ms = ui_config.typewriter_ms_per_char;
@@ -123,7 +123,7 @@ impl MessagesPanel {
             live_bufs: HashMap::new(),
             watched_bufs: VecDeque::new(),
             tool_output_lines: ui_config.tool_output_lines,
-            lua_event_handle: None,
+            lua_event_handle,
             restore_event_tx: None,
             show_thinking: ui_config.show_thinking,
             thinking_collapsed: !ui_config.show_thinking,
@@ -132,12 +132,7 @@ impl MessagesPanel {
         }
     }
 
-    pub fn set_restore_channel(
-        &mut self,
-        event_handle: Option<EventHandle>,
-        event_tx: Option<EventSender>,
-    ) {
-        self.lua_event_handle = event_handle;
+    pub fn set_restore_channel(&mut self, event_tx: Option<EventSender>) {
         self.restore_event_tx = event_tx;
     }
 
@@ -593,9 +588,8 @@ impl MessagesPanel {
             let rel = u16::try_from(doc_row - seg_start).unwrap_or(u16::MAX);
             let buf_row = seg.source_line_at(rel, width).map_or(0, |l| seg.buf_row(l));
             if self.tool_in_progress(tool_id) {
-                if let Some(eh) = &self.lua_event_handle {
-                    eh.request_click(tool_id.to_owned(), buf_row);
-                }
+                self.lua_event_handle
+                    .request_click(tool_id.to_owned(), buf_row);
                 return true;
             }
             // Recorded even when the warm path serves the click: theme
@@ -608,11 +602,10 @@ impl MessagesPanel {
                 item.clicks = self.lua_clicks[tool_id].clone();
                 item
             });
-            let (Some(eh), Some(tx)) =
-                (self.lua_event_handle.clone(), self.restore_event_tx.clone())
-            else {
+            let Some(tx) = self.restore_event_tx.clone() else {
                 return true;
             };
+            let eh = &self.lua_event_handle;
             // Watching the buf means a runtime-side warm click would be
             // visible here, so try the fast path; the fallback item lets
             // the runtime degrade to restore+replay if its cache is cold.
@@ -933,10 +926,10 @@ impl MessagesPanel {
     /// Re-restores every snapshot still painted with old-theme colors.
     /// Replies carry a generation so stale ones can't overwrite fresher colors.
     fn rebake_stale_snapshots(&mut self, current_gen: u64) {
-        let (Some(eh), Some(tx)) = (self.lua_event_handle.clone(), self.restore_event_tx.clone())
-        else {
+        let Some(tx) = self.restore_event_tx.clone() else {
             return;
         };
+        let eh = &self.lua_event_handle;
         self.rebake_requested.retain(|_, g| *g >= current_gen);
         let tol = self.tool_output_lines;
         let mut requested = Vec::new();

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -32,7 +32,7 @@ fn start(id: &str, tool: &str) -> ToolStartEvent {
 }
 
 fn panel_with_tools(ids: &[(&str, &'static str)]) -> MessagesPanel {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     for &(id, tool) in ids {
         panel.tool_start(start(id, tool));
     }
@@ -72,7 +72,7 @@ fn finish_with_live_buf(
 #[test_case(false, ToolStatus::Success ; "success_updates_start_to_success")]
 #[test_case(true,  ToolStatus::Error   ; "error_updates_start_to_error")]
 fn tool_done_updates_start_status(is_error: bool, expected: ToolStatus) {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_start(start("t1", "bash"));
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
@@ -101,7 +101,7 @@ fn tool_done_updates_start_status(is_error: bool, expected: ToolStatus) {
     ; "grep_files"
 )]
 fn tool_done_sets_annotation(tool: &'static str, output: ToolOutput, expected: Option<&str>) {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_start(start("t1", tool));
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
@@ -117,7 +117,7 @@ fn tool_done_sets_annotation(tool: &'static str, output: ToolOutput, expected: O
 #[test_case("line\n".repeat(200).as_str(), Some("2m timeout · 200 lines") ; "merges_start_and_output_annotations")]
 #[test_case("ok",                           Some("2m timeout · 1 lines") ; "merges_start_and_short_output")]
 fn tool_done_annotation_merge(output: &str, expected: Option<&str>) {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     let mut event = start("t1", BASH_TOOL_NAME);
     event.annotation = Some("2m timeout".into());
     panel.tool_start(event);
@@ -145,7 +145,7 @@ fn grep_output(n_files: usize) -> ToolOutput {
 
 #[test]
 fn tool_done_grep_shows_matches() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_start(start("t1", GREP_TOOL_NAME));
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
@@ -162,7 +162,7 @@ fn tool_done_grep_shows_matches() {
 
 #[test]
 fn tool_start_flushes_streaming_text() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.streaming_text.set_buffer("partial response");
 
     panel.tool_start(start("t1", "read"));
@@ -174,7 +174,7 @@ fn tool_start_flushes_streaming_text() {
 
 #[test]
 fn thinking_delta_separate_from_text() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.thinking_delta("reasoning");
     assert_eq!(panel.streaming_thinking, "reasoning");
     assert!(panel.streaming_text.is_empty());
@@ -188,7 +188,7 @@ fn thinking_delta_separate_from_text() {
 
 #[test]
 fn scroll_up_pins_viewport_during_streaming() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.streaming_text.set_buffer(&"a\n".repeat(30));
     render(&mut panel, 80, 10);
 
@@ -230,7 +230,7 @@ fn rebuild(panel: &mut MessagesPanel) {
 
 #[test]
 fn ctrl_d_to_bottom_re_enables_auto_scroll() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.streaming_text.set_buffer(&"a\n".repeat(30));
     render(&mut panel, 80, 10);
     assert!(panel.auto_scroll);
@@ -247,7 +247,7 @@ fn ctrl_d_to_bottom_re_enables_auto_scroll() {
 
 #[test]
 fn unknown_tool_id_is_noop() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_output("ghost", "data");
     panel.tool_done(ToolDoneEvent {
         id: "orphan".into(),
@@ -297,7 +297,7 @@ fn has_scrollbar_thumb(terminal: &ratatui::Terminal<TestBackend>) -> bool {
 #[test_case(40, true  ; "rendered_when_content_overflows")]
 #[test_case(1,  false ; "hidden_when_content_fits")]
 fn scrollbar_visibility(line_count: usize, expected: bool) {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel
         .streaming_text
         .set_buffer(&"line\n".repeat(line_count));
@@ -374,7 +374,7 @@ fn bash_code_start(panel: &mut MessagesPanel, id: &str, code: &str) {
 
 #[test]
 fn bash_live_output_with_code_input() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     bash_code_start(&mut panel, "t1", "echo hello");
     rebuild(&mut panel);
 
@@ -451,7 +451,7 @@ fn tool_done_after_cancel_in_progress_does_not_underflow() {
 
 #[test]
 fn selection_freezes_viewport_during_auto_scroll() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.streaming_text.set_buffer(&"a\n".repeat(30));
     render(&mut panel, 80, 10);
     assert!(panel.auto_scroll);
@@ -481,7 +481,7 @@ fn seg_search(panel: &MessagesPanel, tool_id: &str) -> String {
 
 #[test]
 fn search_text_grep_result_includes_structured_output() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_start(start("t1", "grep"));
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
@@ -498,7 +498,7 @@ fn search_text_grep_result_includes_structured_output() {
 
 #[test]
 fn search_text_diff_output_includes_hunks() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_start(start("t1", "edit"));
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
@@ -520,7 +520,7 @@ fn search_text_diff_output_includes_hunks() {
 
 #[test]
 fn search_text_bash_with_code_input() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     bash_code_start(&mut panel, "t1", "echo hello");
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
@@ -538,7 +538,7 @@ fn search_text_bash_with_code_input() {
 #[test]
 fn search_text_includes_role_prefix() {
     let md = "# Heading\n\nSome **bold** text";
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.push(DisplayMessage::new(DisplayRole::User, "hello".into()));
     panel.push(DisplayMessage::new(DisplayRole::Assistant, md.into()));
     panel.push(DisplayMessage::new(DisplayRole::Thinking, "hmm".into()));
@@ -580,7 +580,7 @@ fn update_tool_model_sets_annotation() {
 
 #[test]
 fn scroll_clamps_to_max_scroll() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.streaming_text.set_buffer(&"a\n".repeat(15));
     render(&mut panel, 80, 10);
     let max = panel.max_scroll();
@@ -592,7 +592,7 @@ fn scroll_clamps_to_max_scroll() {
 #[test_case("bash", 1, 1 ; "known_tool_creates_message")]
 #[test_case("nonexistent_tool", 1, 1 ; "unknown_tool_accepted")]
 fn tool_pending(tool: &str, expected_msgs: usize, expected_in_progress: usize) {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_pending("t1".into(), tool);
     assert_eq!(panel.messages.len(), expected_msgs);
     assert_eq!(panel.in_progress_count(), expected_in_progress);
@@ -600,7 +600,7 @@ fn tool_pending(tool: &str, expected_msgs: usize, expected_in_progress: usize) {
 
 #[test]
 fn tool_start_upgrades_pending_in_place() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_pending("t1".into(), "bash");
     assert_eq!(panel.messages.len(), 1);
     assert_eq!(panel.in_progress_count(), 1);
@@ -645,7 +645,7 @@ fn make_sel(area: Rect, anchor: (u32, u16), cursor: (u32, u16)) -> Selection {
 }
 
 fn panel_with_msgs(texts: &[&str], width: u16, height: u16) -> MessagesPanel {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     for &text in texts {
         panel.push(DisplayMessage::new(DisplayRole::Assistant, text.into()));
     }
@@ -679,7 +679,7 @@ fn extract_skips_out_of_range_segments() {
 
 #[test]
 fn extract_off_screen_rows_via_temp_buffer() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     let text = (0..20)
         .map(|i| format!("line {i}"))
         .collect::<Vec<_>>()
@@ -712,7 +712,7 @@ fn extract_mixed_fully_enclosed_and_partial() {
 #[test_case(&["line-0\nline-1\nline-2\nline-3"], "line-0", "line-3" ; "single_segment")]
 #[test_case(&["seg-A-text", "seg-B-text"],      "seg-A-text", "seg-B-text" ; "across_segments")]
 fn extract_partial_col_symmetric(msgs: &[&str], expect_start: &str, expect_end: &str) {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     for &text in msgs {
         panel.push(DisplayMessage::new(DisplayRole::Assistant, text.into()));
     }
@@ -733,7 +733,7 @@ fn extract_partial_col_symmetric(msgs: &[&str], expect_start: &str, expect_end: 
 fn extract_wrapped_no_soft_breaks(template: &str, anchor: (u32, u16)) {
     let long = "x".repeat(200);
     let msg = template.replace("{L}", &long);
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.push(DisplayMessage::new(DisplayRole::Assistant, msg));
     render(&mut panel, 40, 30);
     let total: u16 = panel.segment_heights().iter().sum();
@@ -748,7 +748,7 @@ fn extract_wrapped_no_soft_breaks(template: &str, anchor: (u32, u16)) {
 
 #[test]
 fn extract_partial_last_line_truncated() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.push(DisplayMessage::new(
         DisplayRole::Assistant,
         "first\nABCDEFGHIJKLMNOP".into(),
@@ -767,7 +767,7 @@ fn panel_with_long_tool(line_count: usize) -> MessagesPanel {
         .map(|i| format!("line {i}"))
         .collect::<Vec<_>>()
         .join("\n");
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_start(ToolStartEvent {
         id: "t1".into(),
         tool: BASH_TOOL_NAME.into(),
@@ -832,7 +832,7 @@ fn panel_with_grep_tool(match_count: usize) -> MessagesPanel {
             .map(|i| GrepMatchGroup::single(i, format!("match_{i}")))
             .collect(),
     }];
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_start(ToolStartEvent {
         id: "t1".into(),
         tool: GREP_TOOL_NAME.into(),
@@ -886,7 +886,7 @@ fn buffer_text(terminal: &ratatui::Terminal<TestBackend>) -> String {
 
 #[test]
 fn streaming_with_cached_segments_shows_end_on_auto_scroll() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.push(DisplayMessage::new(
         DisplayRole::User,
         "a\n".repeat(20).trim().into(),
@@ -912,7 +912,7 @@ fn search_text_includes_truncated_bash_output() {
         .map(|i| format!("line {i}"))
         .collect::<Vec<_>>()
         .join("\n");
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     bash_code_start(&mut panel, "t1", "echo lines");
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
@@ -950,7 +950,7 @@ fn prev_segment_is_spacer(panel: &MessagesPanel, tool_id: &str) -> bool {
 
 #[test]
 fn instruction_segment_has_spacer_before_it() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_start(start("t1", "read"));
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
@@ -979,7 +979,7 @@ fn seg_line_count(panel: &MessagesPanel, tool_id: &str) -> usize {
 
 #[test]
 fn toggle_instruction_segment_expands_and_collapses() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     let blocks = vec![InstructionBlock {
         path: "agents.md".into(),
         content: "x\n".repeat(100),
@@ -1007,7 +1007,7 @@ fn toggle_instruction_segment_expands_and_collapses() {
 
 #[test]
 fn handle_click_returns_nothing_when_no_segment_at_row() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     render(&mut panel, 80, 24);
     let area = Rect::new(0, 0, 80, 24);
     assert!(!panel.handle_click(23, area));
@@ -1015,7 +1015,7 @@ fn handle_click_returns_nothing_when_no_segment_at_row() {
 
 #[test]
 fn handle_click_on_done_tool_records_click_row() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_start(start("t1", BASH_TOOL_NAME));
     panel.tool_done(ToolDoneEvent {
         id: "t1".into(),
@@ -1038,7 +1038,7 @@ fn handle_click_on_done_tool_records_click_row() {
 
 #[test]
 fn handle_click_on_running_tool_forwards_live_without_recording() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_start(start("t1", BASH_TOOL_NAME));
     panel.tool_snapshot(
         "t1",
@@ -1060,7 +1060,7 @@ fn handle_click_returns_toggled_for_truncated_tool_without_snapshot() {
 
 #[test]
 fn handle_click_non_tool_segment_returns_nothing() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.push(DisplayMessage::new(
         DisplayRole::User,
         "user message".into(),
@@ -1075,7 +1075,7 @@ fn tool_done_removes_live_buf_and_snapshots_dirty() {
     let buf = Arc::new(maki_agent::SharedBuf::new());
     buf.set_lines(vec![snap_line("dirty content")]);
 
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.register_live_buf("t1".into(), Arc::clone(&buf));
     panel.tool_start(start("t1", BASH_TOOL_NAME));
     panel.tool_done(ToolDoneEvent {
@@ -1103,7 +1103,7 @@ fn second_register_live_buf_replaces_first() {
     let handler = Arc::new(maki_agent::SharedBuf::new());
     handler.set_lines(vec![snap_line("handler")]);
 
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_start(start("t1", BASH_TOOL_NAME));
     panel.register_live_buf("t1".into(), Arc::clone(&preview));
     panel.register_live_buf("t1".into(), Arc::clone(&handler));
@@ -1124,8 +1124,8 @@ fn second_register_live_buf_replaces_first() {
 fn handle_click_on_watched_tool_sends_click_with_fallback(is_error: bool) {
     let (eh, probe) = maki_lua::test_support::probed_event_handle();
     let (tx, _rx) = flume::unbounded();
-    let mut panel = MessagesPanel::new(UiConfig::default());
-    panel.set_restore_channel(Some(eh), Some(EventSender::new(tx, 0)));
+    let mut panel = MessagesPanel::new(UiConfig::default(), eh);
+    panel.set_restore_channel(Some(EventSender::new(tx, 0)));
     finish_with_live_buf(&mut panel, "t1", "body", is_error);
     assert!(panel.watching("t1"));
 
@@ -1140,7 +1140,7 @@ fn handle_click_on_watched_tool_sends_click_with_fallback(is_error: bool) {
 
 #[test]
 fn tool_done_moves_live_buf_to_watched_polled_but_not_animating() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     let buf = finish_with_live_buf(&mut panel, "t1", "before", false);
     assert!(panel.watching("t1"));
     assert!(
@@ -1161,8 +1161,8 @@ fn tool_done_moves_live_buf_to_watched_polled_but_not_animating() {
 fn watched_fifo_evicts_oldest_which_stops_polling_and_restores_with_recorded_clicks() {
     let (eh, probe) = maki_lua::test_support::probed_event_handle();
     let (tx, _rx) = flume::unbounded();
-    let mut panel = MessagesPanel::new(UiConfig::default());
-    panel.set_restore_channel(Some(eh), Some(EventSender::new(tx, 0)));
+    let mut panel = MessagesPanel::new(UiConfig::default(), eh);
+    panel.set_restore_channel(Some(EventSender::new(tx, 0)));
     let buf = finish_with_live_buf(&mut panel, "t0", "before", false);
 
     render(&mut panel, 80, 24);
@@ -1202,8 +1202,8 @@ fn watched_fifo_evicts_oldest_which_stops_polling_and_restores_with_recorded_cli
 fn tool_done_without_live_buf_is_not_watched_and_click_restores() {
     let (eh, probe) = maki_lua::test_support::probed_event_handle();
     let (tx, _rx) = flume::unbounded();
-    let mut panel = MessagesPanel::new(UiConfig::default());
-    panel.set_restore_channel(Some(eh), Some(EventSender::new(tx, 0)));
+    let mut panel = MessagesPanel::new(UiConfig::default(), eh);
+    panel.set_restore_channel(Some(EventSender::new(tx, 0)));
     let mut ev = start("t1", BASH_TOOL_NAME);
     ev.raw_input = Some(serde_json::json!({ "command": "true" }));
     panel.tool_start(ev);
@@ -1232,8 +1232,8 @@ fn tool_done_without_live_buf_is_not_watched_and_click_restores() {
 fn cancel_in_progress_retires_live_buf_to_watched() {
     let (eh, probe) = maki_lua::test_support::probed_event_handle();
     let (tx, _rx) = flume::unbounded();
-    let mut panel = MessagesPanel::new(UiConfig::default());
-    panel.set_restore_channel(Some(eh), Some(EventSender::new(tx, 0)));
+    let mut panel = MessagesPanel::new(UiConfig::default(), eh);
+    panel.set_restore_channel(Some(EventSender::new(tx, 0)));
     let buf = Arc::new(maki_agent::SharedBuf::new());
     buf.set_lines(vec![snap_line("body")]);
     let mut ev = start("t1", BASH_TOOL_NAME);
@@ -1270,8 +1270,8 @@ fn cancel_in_progress_retires_live_buf_to_watched() {
 fn restore_reply_stops_watching_buf() {
     let (eh, probe) = maki_lua::test_support::probed_event_handle();
     let (tx, _rx) = flume::unbounded();
-    let mut panel = MessagesPanel::new(UiConfig::default());
-    panel.set_restore_channel(Some(eh), Some(EventSender::new(tx, 0)));
+    let mut panel = MessagesPanel::new(UiConfig::default(), eh);
+    panel.set_restore_channel(Some(EventSender::new(tx, 0)));
     let buf = finish_with_live_buf(&mut panel, "t1", "old-theme", false);
     assert!(panel.watching("t1"));
 
@@ -1309,8 +1309,8 @@ fn restore_reply_stops_watching_buf() {
 fn rebake_request_stops_watching_buf() {
     let (eh, probe) = maki_lua::test_support::probed_event_handle();
     let (tx, _rx) = flume::unbounded();
-    let mut panel = MessagesPanel::new(UiConfig::default());
-    panel.set_restore_channel(Some(eh), Some(EventSender::new(tx, 0)));
+    let mut panel = MessagesPanel::new(UiConfig::default(), eh);
+    panel.set_restore_channel(Some(EventSender::new(tx, 0)));
     finish_with_live_buf(&mut panel, "t1", "old-theme", false);
     assert!(panel.watching("t1"));
 
@@ -1324,7 +1324,7 @@ fn rebake_request_stops_watching_buf() {
 #[test]
 fn live_buf_streams_across_clean_polls() {
     let buf = Arc::new(maki_agent::SharedBuf::new());
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_start(start("t1", BASH_TOOL_NAME));
     panel.register_live_buf("t1".into(), Arc::clone(&buf));
 
@@ -1342,7 +1342,7 @@ fn live_buf_streams_across_clean_polls() {
 
 #[test]
 fn tool_done_without_live_buf_preserves_existing_snapshot() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_start(start("t1", BASH_TOOL_NAME));
     panel.tool_snapshot(
         "t1",
@@ -1369,7 +1369,7 @@ fn tool_done_without_live_buf_preserves_existing_snapshot() {
 fn tool_done_clean_live_buf_does_not_snapshot() {
     let buf = Arc::new(maki_agent::SharedBuf::new());
 
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.register_live_buf("t1".into(), Arc::clone(&buf));
     panel.tool_start(start("t1", BASH_TOOL_NAME));
     panel.tool_done(ToolDoneEvent {
@@ -1396,7 +1396,7 @@ const SUPERSEDED_DROP_MSG: &str =
     "a re-bake reply older than the applied generation must be dropped (monotonic)";
 
 fn bash_tool_with_snapshot(id: &str) -> MessagesPanel {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_start(start(id, BASH_TOOL_NAME));
     panel.tool_done(ToolDoneEvent {
         id: id.into(),
@@ -1424,10 +1424,7 @@ fn rebake_walk_requests_without_stamping_displayed_generation() {
     panel.find_tool_msg_mut("t1").unwrap().tool_raw_input =
         Some(Arc::new(serde_json::json!({ "command": "echo" })));
     panel.push(DisplayMessage::new(DisplayRole::Assistant, "plain".into()));
-    panel.set_restore_channel(
-        Some(maki_lua::EventHandle::disconnected_for_test()),
-        Some(test_event_sender()),
-    );
+    panel.set_restore_channel(Some(test_event_sender()));
 
     let baked_gen = panel.snapshot_gen_of("t1").unwrap();
     let next_gen = baked_gen + 1;
@@ -1473,7 +1470,7 @@ const REBAKE_NOOP_MSG: &str = "rebake without channel must be a no-op (no reques
 #[test_case(false ; "fresh_start")]
 #[test_case(true  ; "upgrade_from_pending")]
 fn tool_start_propagates_raw_input(pre_pending: bool) {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     if pre_pending {
         panel.tool_pending("t1".into(), BASH_TOOL_NAME);
     }
@@ -1496,7 +1493,7 @@ fn tool_start_propagates_raw_input(pre_pending: bool) {
 
 #[test]
 fn header_snapshot_stamps_gen_on_top_level() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_start(start("t1", BASH_TOOL_NAME));
     panel.tool_header_snapshot("t1", rendered_snapshot(), Some(5));
 
@@ -1507,7 +1504,7 @@ fn header_snapshot_stamps_gen_on_top_level() {
 
 #[test]
 fn live_snapshot_uses_panel_generation() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.tool_start(start("t1", BASH_TOOL_NAME));
     panel.tool_snapshot("t1", rendered_snapshot(), None);
 
@@ -1531,10 +1528,13 @@ fn rebake_without_channel_is_noop() {
 
 #[test]
 fn hide_collapses_streaming_thinking() {
-    let mut panel = MessagesPanel::new(UiConfig {
-        show_thinking: false,
-        ..UiConfig::default()
-    });
+    let mut panel = MessagesPanel::new(
+        UiConfig {
+            show_thinking: false,
+            ..UiConfig::default()
+        },
+        EventHandle::disconnected_for_test(),
+    );
     panel
         .streaming_thinking
         .set_buffer("line one\nline two\nline three");
@@ -1560,10 +1560,13 @@ fn hide_collapses_streaming_thinking() {
 
 #[test]
 fn hide_click_expands_streaming_thinking() {
-    let mut panel = MessagesPanel::new(UiConfig {
-        show_thinking: false,
-        ..UiConfig::default()
-    });
+    let mut panel = MessagesPanel::new(
+        UiConfig {
+            show_thinking: false,
+            ..UiConfig::default()
+        },
+        EventHandle::disconnected_for_test(),
+    );
     panel.streaming_thinking.set_buffer("secret reasoning");
     let area = Rect::new(0, 0, 80, 10);
     render(&mut panel, 80, 10);
@@ -1586,10 +1589,13 @@ fn hide_click_expands_streaming_thinking() {
 
 #[test]
 fn hide_keeps_cached_thinking_as_indicator() {
-    let mut panel = MessagesPanel::new(UiConfig {
-        show_thinking: false,
-        ..UiConfig::default()
-    });
+    let mut panel = MessagesPanel::new(
+        UiConfig {
+            show_thinking: false,
+            ..UiConfig::default()
+        },
+        EventHandle::disconnected_for_test(),
+    );
     panel.thinking_delta("reasoning here");
     panel.flush();
     assert!(matches!(
@@ -1618,7 +1624,7 @@ fn hide_keeps_cached_thinking_as_indicator() {
 
 #[test]
 fn full_default_renders_streaming_thinking() {
-    let mut panel = MessagesPanel::new(UiConfig::default());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.streaming_thinking.set_buffer("visible reasoning");
     let terminal = render(&mut panel, 80, 10);
     let text = buffer_text(&terminal);
@@ -1630,10 +1636,13 @@ fn full_default_renders_streaming_thinking() {
 
 #[test]
 fn hide_cached_thinking_persists_as_indicator() {
-    let mut panel = MessagesPanel::new(UiConfig {
-        show_thinking: false,
-        ..UiConfig::default()
-    });
+    let mut panel = MessagesPanel::new(
+        UiConfig {
+            show_thinking: false,
+            ..UiConfig::default()
+        },
+        EventHandle::disconnected_for_test(),
+    );
     let lines: Vec<String> = (1..=7).map(|n| format!("cached line {n}")).collect();
     panel.thinking_delta(&lines.join("\n"));
     panel.flush();
@@ -1664,10 +1673,13 @@ fn hide_cached_thinking_persists_as_indicator() {
 
 #[test]
 fn hide_cached_thinking_click_expands() {
-    let mut panel = MessagesPanel::new(UiConfig {
-        show_thinking: false,
-        ..UiConfig::default()
-    });
+    let mut panel = MessagesPanel::new(
+        UiConfig {
+            show_thinking: false,
+            ..UiConfig::default()
+        },
+        EventHandle::disconnected_for_test(),
+    );
     panel.thinking_delta("hidden cached reasoning");
     panel.flush();
     let area = Rect::new(0, 0, 80, 12);
@@ -1690,10 +1702,13 @@ fn hide_cached_thinking_click_expands() {
 
 #[test]
 fn stream_reset_clears_thinking_expand_state() {
-    let mut panel = MessagesPanel::new(UiConfig {
-        show_thinking: false,
-        ..UiConfig::default()
-    });
+    let mut panel = MessagesPanel::new(
+        UiConfig {
+            show_thinking: false,
+            ..UiConfig::default()
+        },
+        EventHandle::disconnected_for_test(),
+    );
     panel.streaming_thinking.set_buffer("secret reasoning");
     let area = Rect::new(0, 0, 80, 10);
     render(&mut panel, 80, 10);

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -80,8 +80,8 @@ pub struct EventLoopParams {
     pub lua_command_reader: LuaCommandReader,
     pub keymap_reader: KeymapReader,
     pub hint_reader: HintReader,
-    pub ui_action_rx: Option<flume::Receiver<UiAction>>,
-    pub lua_event_handle: Option<EventHandle>,
+    pub ui_action_rx: flume::Receiver<UiAction>,
+    pub lua_event_handle: EventHandle,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -143,7 +143,7 @@ struct SpawnCtx {
     lua_command_reader: LuaCommandReader,
     keymap_reader: KeymapReader,
     hint_reader: HintReader,
-    lua_event_handle: Option<EventHandle>,
+    lua_event_handle: EventHandle,
     mcp_handle: Option<McpHandle>,
     mcp_config_errors: McpConfigErrors,
     model_slot: Arc<ArcSwap<ModelSlot>>,
@@ -182,8 +182,8 @@ impl SpawnCtx {
             self.input_history_size,
             permissions,
             Arc::clone(&self.custom_commands),
+            self.lua_event_handle.clone(),
         );
-        app.lua_event_handle = self.lua_event_handle.clone();
         handles.apply_to_app(&mut app);
         if resumed {
             app.restore_resumed_session();
@@ -207,7 +207,7 @@ pub(crate) struct EventLoop<'t> {
     input: InputReader,
     warn_rx: flume::Receiver<String>,
     warn_tx: flume::Sender<String>,
-    ui_action_rx: Option<flume::Receiver<UiAction>>,
+    ui_action_rx: flume::Receiver<UiAction>,
     _model_fetch_task: smol::Task<()>,
 }
 
@@ -465,12 +465,8 @@ impl<'t> EventLoop<'t> {
             Ok(ev) => Some(Wake::Input(ev)),
             Err(_) => Some(Wake::InputGone),
         });
-        if let Some(rx) = self
-            .ui_action_rx
-            .as_ref()
-            .filter(|rx| !rx.is_disconnected())
-        {
-            sel = sel.recv(rx, |res| res.ok().map(Wake::Ui));
+        if !self.ui_action_rx.is_disconnected() {
+            sel = sel.recv(&self.ui_action_rx, |res| res.ok().map(Wake::Ui));
         }
         sel = sel.recv(&self.warn_rx, |res| res.ok().map(Wake::Warn));
         for (i, rt) in self.sessions.iter().enumerate() {
@@ -587,9 +583,7 @@ impl<'t> EventLoop<'t> {
     }
 
     fn emit_status_changes(&mut self) {
-        let Some(handle) = self.ctx.lua_event_handle.as_ref() else {
-            return;
-        };
+        let handle = &self.ctx.lua_event_handle;
         for (i, rt) in self.sessions.iter_mut().enumerate() {
             let status = SessionStatus::of(&rt.app);
             if status == rt.last_status {

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -111,12 +111,12 @@ The `/help` modal and the splash show default labels, not live overrides, but pr
 
 ### Recovering from a bad keymap
 
-If an override leaves Maki stuck (a rebound `Ctrl+C`, a modal that won't close, a plugin that throws on load), boot without plugins:
+If an override leaves Maki stuck (a rebound `Ctrl+C`, a modal that won't close, a plugin that throws on load), boot without user `init.lua`:
 
 ```bash
 maki --no-plugins
 ```
 
-This skips the Lua host and runs the full default keymap from Rust, so quit, Esc, scroll, and suspend always work.
+Skips user `init.lua` files (global and project) but keeps the Lua host and builtin plugins running, so tools still work. `permissions.toml`, custom commands, and env files load as usual.
 
-The defaults live in Rust, not Lua, so `--no-plugins` never drops them.
+The default keymap lives in Rust, not Lua, so `--no-plugins` never drops it.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,7 +69,11 @@ pub struct Cli {
     #[arg(long)]
     pub no_rtk: bool,
 
-    /// Disable the Lua plugin system
+    /// Skip user `init.lua` files (global and project) but keep the Lua
+    /// host and every builtin plugin running, so tools and the default
+    /// keymap still load. Use this to recover from a broken `init.lua`
+    /// or keymap override. Only Lua `init.lua` files are affected;
+    /// `permissions.toml`, custom commands, and env files load as usual.
     #[arg(long)]
     pub no_plugins: bool,
 

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -11,7 +11,7 @@ use maki_storage::StateDir;
 
 use crate::setup;
 
-pub fn run(model_arg: Option<String>, yolo: bool, no_jit: bool) -> Result<()> {
+pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool) -> Result<()> {
     let storage = StateDir::resolve().context("resolve data directory")?;
     maki_providers::model_registry::load_from_storage(&storage);
 
@@ -22,7 +22,7 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_jit: bool) -> Result<()> {
         .context("initialize lua plugin host")?;
 
     let raw_config = plugin_host
-        .load_init_files(&cwd)
+        .load_init_files_or_skip(no_plugins, &cwd)
         .context("load init.lua files")?;
 
     let mut config = raw_config
@@ -53,10 +53,7 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_jit: bool) -> Result<()> {
 
     let (mcp_handle, _mcp_config_errors) = smol::block_on(maki_agent::mcp::start(&cwd));
 
-    let prompt_slots = plugin_host
-        .event_handle()
-        .map(|h| h.collect_prompt_slots())
-        .unwrap_or_default();
+    let prompt_slots = plugin_host.event_handle().collect_prompt_slots();
 
     maki_acp::run(maki_acp::AcpParams {
         model,

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -43,7 +43,7 @@ pub fn dispatch(cli: Cli) -> Result<()> {
             update::rollback().map_err(|e| color_eyre::eyre::eyre!("{e}"))?;
         }
         Some(Command::Acp { model, yolo }) => {
-            acp::run(model, yolo, cli.no_jit)?;
+            acp::run(model, yolo, cli.no_plugins, cli.no_jit)?;
         }
         Some(Command::Migrate { action }) => match action {
             MigrateAction::Xdg => migrate::xdg()?,
@@ -54,7 +54,7 @@ pub fn dispatch(cli: Cli) -> Result<()> {
             tools,
             names,
         }) => {
-            subcmd::prompt(&variant, plan, tools, names, cli.no_jit)?;
+            subcmd::prompt(&variant, plan, tools, names, cli.no_plugins, cli.no_jit)?;
         }
         None => {
             tui::run(cli)?;

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -551,14 +551,12 @@ pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
     let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
     load_env_files(&cwd);
 
-    let mut host = if no_plugins {
-        PluginHost::disabled()
-    } else {
-        PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
-            .context("initialize lua plugin host")?
-    };
+    let mut host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
+        .context("initialize lua plugin host")?;
 
-    let raw_config = host.load_init_files(&cwd).context("load init.lua files")?;
+    let raw_config = host
+        .load_init_files_or_skip(no_plugins, &cwd)
+        .context("load init.lua files")?;
 
     let mut config = raw_config
         .unwrap_or_default()
@@ -623,6 +621,7 @@ pub fn prompt(
     plan: bool,
     tools: bool,
     names: bool,
+    no_plugins: bool,
     no_jit: bool,
 ) -> Result<()> {
     use crate::cli::PromptVariant;
@@ -643,7 +642,9 @@ pub fn prompt(
     let reg = ToolRegistry::global_arc();
     let mut host =
         PluginHost::with_jit(Arc::clone(reg), !no_jit).context("initialize lua plugin host")?;
-    let raw_config = host.load_init_files(&cwd).context("load init.lua files")?;
+    let raw_config = host
+        .load_init_files_or_skip(no_plugins, &cwd)
+        .context("load init.lua files")?;
     let config = raw_config
         .unwrap_or_default()
         .into_config(false)
@@ -675,10 +676,7 @@ pub fn prompt(
 
     let cwd_str = cwd.to_string_lossy();
     let instructions = load_instruction_text(&cwd_str);
-    let slots = host
-        .event_handle()
-        .map(|h| h.collect_prompt_slots())
-        .unwrap_or_default();
+    let slots = host.event_handle().collect_prompt_slots();
 
     let output = match variant {
         PromptVariant::System => {

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -82,7 +82,7 @@ fn discover_commands(disable: bool) -> Vec<CustomCommand> {
 
 fn load_config(plugin_host: &PluginHost, cli: &Cli, cwd: &Path) -> Result<Config> {
     let raw_config = plugin_host
-        .load_init_files(cwd)
+        .load_init_files_or_skip(cli.no_plugins, cwd)
         .context("load init.lua files")?;
 
     let mut config = raw_config
@@ -138,12 +138,8 @@ fn build_stack(
 ) -> Result<(Stack, Vec<String>)> {
     let mut warnings = Vec::new();
 
-    let mut plugin_host = if cli.no_plugins {
-        PluginHost::disabled()
-    } else {
-        PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !cli.no_jit)
-            .context("initialize lua plugin host")?
-    };
+    let mut plugin_host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !cli.no_jit)
+        .context("initialize lua plugin host")?;
 
     let (fallback_config, fallback_model) = fallback.unzip();
     let reloading = fallback_model.is_some();
@@ -245,11 +241,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
 
     if cli.is_sdk_mode() {
         let fast = stack.config.always_fast && stack.model.supports_fast();
-        let prompt_slots = stack
-            .plugin_host
-            .event_handle()
-            .map(|h| h.collect_prompt_slots())
-            .unwrap_or_default();
+        let prompt_slots = stack.plugin_host.event_handle().collect_prompt_slots();
         let timeouts = stack.timeouts();
         crate::sdk_mode::run(crate::sdk_mode::SdkParams {
             cli,
@@ -406,6 +398,8 @@ mod tests {
     use super::*;
     use color_eyre::eyre::eyre;
     use maki_config::RawConfig;
+    use std::fs;
+    use std::path::PathBuf;
     use std::sync::atomic::{AtomicBool, Ordering};
 
     /// `second_saw_first` requires both joins: `defer` joining the first
@@ -477,5 +471,75 @@ mod tests {
         };
         assert!(err.to_string().contains("boom"));
         assert!(warnings.is_empty());
+    }
+
+    /// `--no-plugins` keeps the Lua host live (tools + default keymap
+    /// still load) but skips user `init.lua`, so a broken project
+    /// `init.lua` must not be executed in that mode.
+    #[test]
+    fn no_plugins_skips_broken_init_lua_but_keeps_host_alive() {
+        use clap::Parser;
+        use maki_agent::tools::ToolRegistry;
+        use tempfile::tempdir;
+
+        let dir = tempdir().expect("tempdir");
+        let maki_dir: PathBuf = dir.path().join(".maki");
+        fs::create_dir_all(&maki_dir).expect("mkdir .maki");
+        fs::write(
+            maki_dir.join("init.lua"),
+            "error('broken init lua must not run')",
+        )
+        .expect("write init.lua");
+
+        let cli = Cli::parse_from(["maki", "--no-plugins"]);
+        assert!(cli.no_plugins);
+
+        let mut plugin_host = PluginHost::with_jit(Arc::new(ToolRegistry::new()), true)
+            .expect("live host boots under --no-plugins");
+
+        let config = load_config(&plugin_host, &cli, dir.path())
+            .expect("no-plugins must skip the broken init.lua and still load defaults");
+        assert!(
+            !config.plugins.names.is_empty(),
+            "default builtin plugins must still be enabled under --no-plugins"
+        );
+
+        plugin_host
+            .load_builtins(&config.plugins)
+            .expect("builtins load on the live host under --no-plugins");
+
+        plugin_host.begin_shutdown();
+    }
+
+    /// Negative control for the test above: without `--no-plugins`, the
+    /// same broken `init.lua` must surface as an error so the skip path
+    /// cannot silently regress into a tautology.
+    #[test]
+    fn broken_init_lua_errors_without_no_plugins() {
+        use clap::Parser;
+        use maki_agent::tools::ToolRegistry;
+        use tempfile::tempdir;
+
+        let dir = tempdir().expect("tempdir");
+        let maki_dir: PathBuf = dir.path().join(".maki");
+        fs::create_dir_all(&maki_dir).expect("mkdir .maki");
+        fs::write(
+            maki_dir.join("init.lua"),
+            "error('broken init lua must not run')",
+        )
+        .expect("write init.lua");
+
+        let cli = Cli::parse_from(["maki"]);
+        assert!(!cli.no_plugins);
+
+        let mut plugin_host =
+            PluginHost::with_jit(Arc::new(ToolRegistry::new()), true).expect("live host boots");
+
+        match load_config(&plugin_host, &cli, dir.path()) {
+            Err(_) => {}
+            Ok(_) => panic!("broken init.lua must error without --no-plugins"),
+        }
+
+        plugin_host.begin_shutdown();
     }
 }

--- a/src/print.rs
+++ b/src/print.rs
@@ -143,7 +143,7 @@ pub fn run(
     config: AgentConfig,
     permissions_config: PermissionsConfig,
     timeouts: maki_providers::Timeouts,
-    lua_handle: Option<EventHandle>,
+    lua_handle: EventHandle,
     fast: bool,
     workflow: bool,
 ) -> Result<()> {
@@ -158,10 +158,7 @@ pub fn run(
 
     let images = load_images(&image_paths)?;
 
-    let prompt_slots = lua_handle
-        .as_ref()
-        .map(|h| h.collect_prompt_slots())
-        .unwrap_or_default();
+    let prompt_slots = lua_handle.collect_prompt_slots();
 
     let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
     let (mcp_handle, mcp_config_errors) = smol::block_on(maki_agent::mcp::start(&cwd));


### PR DESCRIPTION
The `--no-plugins` flag turns off the Lua runtime entirely. This used to make sense before all tools were migrated to Lua, but now disabling the Lua runtime would mean agents would have zero tools to use. I think it's better for us to just embrace always having a runtime enabled and then separately deal with when it crashes, which is not being handled today properly anyway.

To that end, this PR drops the `Option`ality of the `LuaThread` to always be enabled and simply avoids loading the user's `init.lua` which in turn disables plugin loading. I think with the current Lua testing level, the "recovery mode" from `--no-plugins` should be trustworthy enough even if we're still running Lua. As an outcome of this, we simply a lot of the code that handles when there's no runtime. We also can define things like default keybinds in Lua as well to use the exact same API everywhere, better matching neovim as well (this is why I made this PR in the first place). Moving providers to Lua is blocked by this also.

Tested by setting a malformed `init.lua` and seeing maki only boot when `--no-plugins` was passed, and being able to use the `grep` and `memory` tools but not `bash` when `--no-plugins` was passed.

As mentioned, we should handle when Lua crashes in another PR. I'm thinking we should pause execution, show the error message to the user, and ask them if they want to `/reload` or quit.

Written with Maki + GLM-5.2.