### PR TITLE
providers: envelope env-key built-ins behind ManifestProvider + AuthSource

### DIFF
--- a/maki-config/src/providers.rs
+++ b/maki-config/src/providers.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use thiserror::Error;
 use tracing::debug;
 
 use maki_storage::paths;
@@ -161,32 +162,67 @@ pub struct ProvidersConfig {
     pub providers: HashMap<String, ProviderDef>,
 }
 
+#[derive(Debug, Error)]
+pub enum ProvidersConfigError {
+    #[error("cannot read {path}: {source}")]
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("invalid {path}: {message}")]
+    Parse {
+        path: PathBuf,
+        message: String,
+        #[source]
+        source: Box<toml::de::Error>,
+    },
+}
+
 impl ProvidersConfig {
-    /// Read and parse `providers.toml`. Hard-exits on parse errors so a typo
-    /// in tier or pricing surfaces immediately instead of silently dropping
-    /// every provider and starting maki with an empty registry.
+    /// Read and parse `providers.toml`. Hard-exits on any error so a typo
+    /// in tier or pricing (or an unreadable file) surfaces immediately
+    /// instead of silently dropping every provider and starting maki with an
+    /// empty registry. Missing files are treated as an empty registry (see
+    /// `load_from`) and never reach this path.
     pub fn load() -> Self {
-        let path = providers_file_path();
-        if !path.exists() {
-            return Self::default();
-        }
-        let content = match fs::read_to_string(&path) {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::warn!(path = %path.display(), error = %e, "cannot read providers.toml");
-                return Self::default();
+        Self::try_load().unwrap_or_else(|error| {
+            eprintln!("error: {error}");
+            process::exit(BAD_CONFIG_EXIT_CODE);
+        })
+    }
+
+    /// Read and parse `providers.toml`, returning a typed error instead of
+    /// hard-exiting. Use for runtime callers that must not kill the process
+    /// (e.g. refreshing the key pool on demand).
+    pub fn try_load() -> Result<Self, ProvidersConfigError> {
+        Self::load_from(&providers_file_path())
+    }
+
+    fn load_from(path: &Path) -> Result<Self, ProvidersConfigError> {
+        let content = match fs::read_to_string(path) {
+            Ok(content) => content,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Self::default());
+            }
+            Err(source) => {
+                return Err(ProvidersConfigError::Read {
+                    path: path.to_path_buf(),
+                    source,
+                });
             }
         };
-        match toml::from_str(&content) {
-            Ok(config) => {
-                debug!(path = %path.display(), "loaded providers config");
-                config
+        // `toml::de::Error`'s `Display` leaks the raw offending line (which
+        // may contain a secret api_key embedded in malformed TOML); `message`
+        // surfaces only the parse error and position.
+        let config = toml::from_str(&content).map_err(|source: toml::de::Error| {
+            ProvidersConfigError::Parse {
+                path: path.to_path_buf(),
+                message: source.message().to_owned(),
+                source: Box::new(source),
             }
-            Err(e) => {
-                eprintln!("error: invalid {}: {e}", path.display());
-                process::exit(BAD_CONFIG_EXIT_CODE);
-            }
-        }
+        })?;
+        debug!(path = %path.display(), "loaded providers config");
+        Ok(config)
     }
 
     pub fn save(&self) -> Result<(), std::io::Error> {
@@ -321,7 +357,26 @@ pub fn resolve_login_url(slug: &str, plan: Option<&str>) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::NamedTempFile;
     use test_case::test_case;
+
+    #[test]
+    fn load_from_returns_parse_error_for_invalid_toml() {
+        // Malformed TOML whose error message would otherwise leak the literal
+        // api_key line (containing a secret) — assert the typed error message
+        // suppresses it via `toml::de::Error::message()`.
+        const SECRET: &str = "secret-api-key";
+        let file = NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), format!("[deepseek]\napi_key = \"{SECRET}\n")).unwrap();
+
+        let error = ProvidersConfig::load_from(file.path()).unwrap_err();
+
+        assert!(matches!(error, ProvidersConfigError::Parse { .. }));
+        assert!(
+            !error.to_string().contains(SECRET),
+            "parse error message leaked secret: {error}"
+        );
+    }
 
     #[test]
     fn provider_def_roundtrip() {

--- a/maki-providers/src/auth_source.rs
+++ b/maki-providers/src/auth_source.rs
@@ -1,0 +1,199 @@
+use std::sync::{Arc, Mutex};
+
+use tracing::debug;
+
+use crate::AgentError;
+use crate::providers::KeyPool;
+use crate::providers::ResolvedAuth;
+
+pub trait AuthSource: Send + Sync {
+    // Sync signatures suffice for Env/OAuth (env var read, on-disk token load).
+    // A future Lua-backed AuthSource (over the Lua host thread) would block
+    // the caller; resolve/reload must become async BoxFutures before that
+    // impl lands.
+    fn resolve(&self, auth: &Arc<Mutex<ResolvedAuth>>) -> Result<(), AgentError>;
+    fn reload(&self, _auth: &Arc<Mutex<ResolvedAuth>>) -> Result<(), AgentError> {
+        Ok(())
+    }
+    fn refresh(&self, _auth: &Arc<Mutex<ResolvedAuth>>) -> Result<(), AgentError> {
+        Ok(())
+    }
+    fn rotate_key(&self, _auth: &Arc<Mutex<ResolvedAuth>>) -> Result<bool, AgentError> {
+        Ok(false)
+    }
+}
+
+pub struct EnvAuthSource {
+    slug: &'static str,
+    env_var: &'static str,
+    build: Arc<dyn Fn(&str) -> ResolvedAuth + Send + Sync>,
+    resolve_pool: fn(&'static str, &'static str) -> Result<KeyPool, AgentError>,
+    state: Mutex<EnvAuthState>,
+}
+
+#[derive(Default)]
+struct EnvAuthState {
+    pool: Option<KeyPool>,
+    revision: u64,
+}
+
+struct PendingRotation {
+    key: String,
+    revision: u64,
+}
+
+impl EnvAuthState {
+    fn install(&mut self, pool: KeyPool) {
+        self.pool = Some(pool);
+        self.revision = self.revision.wrapping_add(1);
+    }
+
+    fn prepare_rotation(&mut self) -> Option<PendingRotation> {
+        let pool = self.pool.as_ref()?;
+        if !pool.rotate() {
+            return None;
+        }
+        self.revision = self.revision.wrapping_add(1);
+        Some(PendingRotation {
+            key: pool.current().to_owned(),
+            revision: self.revision,
+        })
+    }
+
+    fn is_current(&self, revision: u64) -> bool {
+        self.revision == revision
+    }
+}
+
+impl EnvAuthSource {
+    pub(crate) fn new(
+        slug: &'static str,
+        env_var: &'static str,
+        build: impl Fn(&str) -> ResolvedAuth + Send + Sync + 'static,
+    ) -> Self {
+        Self::with_resolver(slug, env_var, build, KeyPool::resolve)
+    }
+
+    pub(crate) fn with_resolver(
+        slug: &'static str,
+        env_var: &'static str,
+        build: impl Fn(&str) -> ResolvedAuth + Send + Sync + 'static,
+        resolve_pool: fn(&'static str, &'static str) -> Result<KeyPool, AgentError>,
+    ) -> Self {
+        Self {
+            slug,
+            env_var,
+            build: Arc::new(build),
+            resolve_pool,
+            state: Mutex::default(),
+        }
+    }
+
+    fn pool(&self) -> Result<KeyPool, AgentError> {
+        let mut state = self.state.lock().unwrap();
+        if let Some(pool) = state.pool.as_ref() {
+            return Ok(pool.clone());
+        }
+        let pool = (self.resolve_pool)(self.slug, self.env_var)?;
+        state.install(pool.clone());
+        Ok(pool)
+    }
+}
+
+impl AuthSource for EnvAuthSource {
+    fn resolve(&self, auth: &Arc<Mutex<ResolvedAuth>>) -> Result<(), AgentError> {
+        let pool = self.pool()?;
+        *auth.lock().unwrap() = (self.build)(pool.current());
+        debug!(slug = self.slug, keys = pool.len(), "resolved env auth");
+        Ok(())
+    }
+
+    fn reload(&self, auth: &Arc<Mutex<ResolvedAuth>>) -> Result<(), AgentError> {
+        let pool = (self.resolve_pool)(self.slug, self.env_var)?;
+        // Bump revision so any in-flight `prepare_rotation` whose key has not
+        // yet been written to `auth` is invalidated before publish — its
+        // captured revision no longer matches state.
+        let key = pool.current().to_owned();
+        {
+            let mut state = self.state.lock().unwrap();
+            state.install(pool);
+        }
+        *auth.lock().unwrap() = (self.build)(&key);
+        debug!(slug = self.slug, "reloaded env auth");
+        Ok(())
+    }
+
+    fn rotate_key(&self, auth: &Arc<Mutex<ResolvedAuth>>) -> Result<bool, AgentError> {
+        let pending = {
+            let mut state = self.state.lock().unwrap();
+            state.prepare_rotation()
+        };
+        let Some(pending) = pending else {
+            return Ok(false);
+        };
+        // Between prepare and publish, a reload may have replaced the pool
+        // and bumped the revision. In that case the rotated key is stale —
+        // surface no-op rather than overwriting fresh auth with a key from the
+        // previous pool.
+        let still_current = self.state.lock().unwrap().is_current(pending.revision);
+        if still_current {
+            *auth.lock().unwrap() = (self.build)(&pending.key);
+        }
+        Ok(still_current)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bearer_header_value(auth: &Arc<Mutex<ResolvedAuth>>) -> String {
+        auth.lock()
+            .unwrap()
+            .headers
+            .iter()
+            .find_map(|(name, value)| (name == "authorization").then(|| value.clone()))
+            .unwrap()
+    }
+
+    #[test]
+    fn reload_refreshes_cached_key_pool_so_rotate_key_uses_new_env() {
+        let env_var: &'static str =
+            Box::leak(format!("MAKI_TEST_RELOAD_{}", fastrand::u32(..)).into_boxed_str());
+        unsafe { std::env::set_var(env_var, "sk-1, sk-2") };
+
+        let source = EnvAuthSource::new("test", env_var, ResolvedAuth::bearer);
+        let auth = Arc::new(Mutex::new(ResolvedAuth {
+            base_url: None,
+            headers: Vec::new(),
+        }));
+        source.resolve(&auth).unwrap();
+        assert_eq!(bearer_header_value(&auth), "Bearer sk-1");
+
+        // Reload must replace the pool so rotation cannot revive a removed key.
+        unsafe { std::env::set_var(env_var, "sk-3") };
+        source.reload(&auth).unwrap();
+        assert_eq!(bearer_header_value(&auth), "Bearer sk-3");
+
+        let rotated = source.rotate_key(&auth).unwrap();
+        assert!(
+            !rotated,
+            "rotate_key must report no rotation for a single-key pool"
+        );
+        assert_eq!(bearer_header_value(&auth), "Bearer sk-3");
+
+        unsafe { std::env::remove_var(env_var) };
+    }
+
+    #[test]
+    fn reload_invalidates_pending_rotation() {
+        let mut state = EnvAuthState::default();
+        state.install(KeyPool::from_keys(vec!["old-1".into(), "old-2".into()]));
+        let pending = state.prepare_rotation().unwrap();
+
+        state.install(KeyPool::from_keys(vec!["new-1".into()]));
+
+        assert!(!state.is_current(pending.revision));
+        assert_eq!(state.pool.unwrap().current(), "new-1");
+    }
+}

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -1,5 +1,7 @@
+pub(crate) mod auth_source;
 pub(crate) mod error;
 pub mod manifest;
+pub(crate) mod manifest_provider;
 pub mod model;
 pub mod model_registry;
 pub mod provider;

--- a/maki-providers/src/manifest.rs
+++ b/maki-providers/src/manifest.rs
@@ -4,6 +4,12 @@ use crate::providers::{
     openrouter, synthetic, tensorx, zai,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthKind {
+    Env,
+    OAuth,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ProviderManifest {
     pub slug: &'static str,
@@ -14,6 +20,7 @@ pub struct ProviderManifest {
     pub fallback_max_output: Option<u32>,
     pub fallback_context_window: u32,
     pub models: &'static [ModelEntry],
+    pub auth_kind: AuthKind,
 }
 
 const ANTHROPIC: ProviderManifest = ProviderManifest {
@@ -25,6 +32,7 @@ const ANTHROPIC: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(128_000),
     fallback_context_window: 200_000,
     models: anthropic::models(),
+    auth_kind: AuthKind::Env,
 };
 
 const OPENAI: ProviderManifest = ProviderManifest {
@@ -36,6 +44,7 @@ const OPENAI: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(100_000),
     fallback_context_window: 200_000,
     models: openai::models(),
+    auth_kind: AuthKind::OAuth,
 };
 
 const GOOGLE: ProviderManifest = ProviderManifest {
@@ -47,6 +56,7 @@ const GOOGLE: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(65_536),
     fallback_context_window: 1_000_000,
     models: google::models(),
+    auth_kind: AuthKind::Env,
 };
 
 const COPILOT: ProviderManifest = ProviderManifest {
@@ -58,6 +68,7 @@ const COPILOT: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(100_000),
     fallback_context_window: 200_000,
     models: copilot::models(),
+    auth_kind: AuthKind::OAuth,
 };
 
 const OLLAMA: ProviderManifest = ProviderManifest {
@@ -69,6 +80,7 @@ const OLLAMA: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(16_384),
     fallback_context_window: 128_000,
     models: ollama::models(),
+    auth_kind: AuthKind::Env,
 };
 
 const LLAMA_CPP: ProviderManifest = ProviderManifest {
@@ -80,6 +92,7 @@ const LLAMA_CPP: ProviderManifest = ProviderManifest {
     fallback_max_output: None,
     fallback_context_window: 128_000,
     models: llama_cpp::models(),
+    auth_kind: AuthKind::Env,
 };
 
 const MISTRAL: ProviderManifest = ProviderManifest {
@@ -91,6 +104,7 @@ const MISTRAL: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(32_000),
     fallback_context_window: 128_000,
     models: mistral::models(),
+    auth_kind: AuthKind::Env,
 };
 
 const ZAI: ProviderManifest = ProviderManifest {
@@ -102,6 +116,7 @@ const ZAI: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(16_000),
     fallback_context_window: 128_000,
     models: zai::models(),
+    auth_kind: AuthKind::Env,
 };
 
 const DEEPSEEK: ProviderManifest = ProviderManifest {
@@ -113,6 +128,7 @@ const DEEPSEEK: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(384_000),
     fallback_context_window: 1_000_000,
     models: deepseek::models(),
+    auth_kind: AuthKind::Env,
 };
 
 const OPENROUTER: ProviderManifest = ProviderManifest {
@@ -124,6 +140,7 @@ const OPENROUTER: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(128_000),
     fallback_context_window: 200_000,
     models: openrouter::models(),
+    auth_kind: AuthKind::Env,
 };
 
 const SYNTHETIC: ProviderManifest = ProviderManifest {
@@ -135,6 +152,7 @@ const SYNTHETIC: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(32_000),
     fallback_context_window: 128_000,
     models: synthetic::models(),
+    auth_kind: AuthKind::Env,
 };
 
 const TENSORX: ProviderManifest = ProviderManifest {
@@ -146,6 +164,7 @@ const TENSORX: ProviderManifest = ProviderManifest {
     fallback_max_output: None,
     fallback_context_window: 200_000,
     models: tensorx::models(),
+    auth_kind: AuthKind::Env,
 };
 
 const OPENCODE: ProviderManifest = ProviderManifest {
@@ -157,6 +176,7 @@ const OPENCODE: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(128_000),
     fallback_context_window: 256_000,
     models: &[],
+    auth_kind: AuthKind::Env,
 };
 
 const BUILTINS: &[ProviderManifest] = &[

--- a/maki-providers/src/manifest_provider.rs
+++ b/maki-providers/src/manifest_provider.rs
@@ -1,0 +1,370 @@
+use std::sync::{Arc, Mutex, OnceLock};
+
+use flume::Sender;
+use maki_config::providers::{ProvidersConfig, resolve_base_url};
+use maki_storage::id::SessionRef;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::AgentError;
+use crate::auth_source::{AuthSource, EnvAuthSource};
+use crate::manifest::{AuthKind, ManifestRegistry};
+use crate::model::{Model, ModelInfo};
+use crate::provider::{BoxFuture, Provider};
+use crate::providers::ResolvedAuth;
+use crate::providers::{
+    KeyPool, Timeouts, anthropic, deepseek, google, mistral, openrouter, synthetic, tensorx, zai,
+};
+use crate::{Message, ProviderEvent, ProviderUsage, RequestOptions, StreamResponse};
+
+pub struct ManifestProvider {
+    slug: &'static str,
+    auth: Arc<Mutex<ResolvedAuth>>,
+    auth_source: Box<dyn AuthSource>,
+    engine: OnceLock<Box<dyn Provider>>,
+    timeouts: Timeouts,
+}
+
+impl ManifestProvider {
+    pub fn try_for_slug(
+        slug: &str,
+        timeouts: Timeouts,
+    ) -> Result<Option<Box<dyn Provider>>, AgentError> {
+        let Some(manifest) = ManifestRegistry::get(slug) else {
+            return Ok(None);
+        };
+        if !matches!(manifest.auth_kind, AuthKind::Env) {
+            return Ok(None);
+        }
+        let provider =
+            build_env(manifest.slug, timeouts)?.map(|p| Box::new(p) as Box<dyn Provider>);
+        Ok(provider)
+    }
+
+    fn engine(&self) -> Result<&dyn Provider, AgentError> {
+        if let Some(engine) = self.engine.get() {
+            return Ok(engine.as_ref());
+        }
+        // Auth is resolved eagerly at construction (build_env today, build_oauth
+        // in the OAuth follow-up PR) so the engine reads a populated handle here.
+        // AuthSource's reload/refresh/rotate_key mutate the same Arc the engine
+        // reads per-request, so no re-resolve is needed at engine-build time.
+        let built = build_engine(self.slug, self.auth.clone(), self.timeouts)?;
+        if self.engine.set(built).is_err() {
+            // Another caller won the race; use its engine.
+            return Ok(self
+                .engine
+                .get()
+                .expect("engine set by concurrent init")
+                .as_ref());
+        }
+        debug!(slug = self.slug, "built manifest provider engine");
+        Ok(self.engine.get().expect("just set").as_ref())
+    }
+}
+
+const ENV_ENVELOPED_SLUGS: &[&str] = &[
+    "anthropic",
+    "google",
+    "mistral",
+    "deepseek",
+    "zai",
+    "synthetic",
+    "tensorx",
+    "openrouter",
+];
+
+fn build_env(
+    slug: &'static str,
+    timeouts: Timeouts,
+) -> Result<Option<ManifestProvider>, AgentError> {
+    // Partition check: any env builtin not listed here falls through to
+    // `provider_for_slug`'s next routing tier. Listing a slug here without a
+    // match arm below is an authoring bug (unreachable!), not a missing-key
+    // runtime error.
+    if !ENV_ENVELOPED_SLUGS.contains(&slug) {
+        return Ok(None);
+    }
+    let auth_source: Box<dyn AuthSource> = match slug {
+        "anthropic" => Box::new(EnvAuthSource::new(
+            "anthropic",
+            anthropic::ENV_VAR,
+            anthropic::resolve_auth_from_key,
+        )),
+        "google" => Box::new(EnvAuthSource::new(
+            "google",
+            google::ENV_VAR,
+            google::resolve_auth_from_key,
+        )),
+        "mistral" => Box::new(EnvAuthSource::new(
+            "mistral",
+            mistral::CONFIG.api_key_env,
+            ResolvedAuth::bearer,
+        )),
+        "deepseek" => Box::new(EnvAuthSource::new(
+            "deepseek",
+            deepseek::CONFIG.api_key_env,
+            ResolvedAuth::bearer,
+        )),
+        "zai" => {
+            let config = ProvidersConfig::try_load().map_err(|error| AgentError::Config {
+                message: format!("failed to load provider config for 'zai': {error}"),
+            })?;
+            let base_url = resolve_base_url("zai", config.get("zai"));
+            Box::new(EnvAuthSource::new(
+                "zai",
+                zai::CONFIG_STANDARD.api_key_env,
+                move |key| bearer_with_base_url(key, base_url.clone()),
+            ))
+        }
+        "synthetic" => Box::new(EnvAuthSource::new(
+            "synthetic",
+            synthetic::CONFIG.api_key_env,
+            ResolvedAuth::bearer,
+        )),
+        "tensorx" => Box::new(EnvAuthSource::new(
+            "tensorx",
+            tensorx::CONFIG.api_key_env,
+            ResolvedAuth::bearer,
+        )),
+        "openrouter" => Box::new(EnvAuthSource::with_resolver(
+            "openrouter",
+            openrouter::CONFIG.api_key_env,
+            ResolvedAuth::bearer,
+            env_only,
+        )),
+        _ => unreachable!("slug matched ENV_ENVELOPED_SLUGS but has no auth_source arm"),
+    };
+    let auth = Arc::new(Mutex::new(ResolvedAuth {
+        base_url: None,
+        headers: Vec::new(),
+    }));
+    // Eager auth resolution preserves the precondition the old per-shim
+    // factories enforced: `provider_for_slug` fails fast when no API key is
+    // available, so `provider_available` reflects key presence and the setup
+    // flow does not surface a confusing error on first stream.
+    auth_source.resolve(&auth)?;
+    Ok(Some(ManifestProvider {
+        slug,
+        auth,
+        auth_source,
+        engine: OnceLock::new(),
+        timeouts,
+    }))
+}
+
+fn env_only(_slug: &'static str, env_var: &'static str) -> Result<KeyPool, AgentError> {
+    KeyPool::from_env(env_var)
+}
+
+fn bearer_with_base_url(api_key: &str, base_url: Option<String>) -> ResolvedAuth {
+    let mut auth = ResolvedAuth::bearer(api_key);
+    auth.base_url = base_url;
+    auth
+}
+
+fn build_engine(
+    slug: &str,
+    auth: Arc<Mutex<ResolvedAuth>>,
+    timeouts: Timeouts,
+) -> Result<Box<dyn Provider>, AgentError> {
+    match slug {
+        "anthropic" => Ok(Box::new(anthropic::Anthropic::with_auth(auth, timeouts))),
+        "google" => Ok(Box::new(google::Google::with_auth(auth, timeouts))),
+        "mistral" => Ok(Box::new(mistral::Mistral::with_auth(auth, timeouts))),
+        "deepseek" => Ok(Box::new(deepseek::DeepSeek::with_auth(auth, timeouts))),
+        "zai" => Ok(Box::new(zai::Zai::with_auth(auth, timeouts))),
+        "synthetic" => Ok(Box::new(synthetic::Synthetic::with_auth(auth, timeouts))),
+        "tensorx" => Ok(Box::new(tensorx::TensorX::with_auth(auth, timeouts))),
+        "openrouter" => Ok(Box::new(openrouter::OpenRouter::with_auth(auth, timeouts))),
+        other => unreachable!("slug '{other}' reached build_engine but not ENV_ENVELOPED_SLUGS"),
+    }
+}
+
+impl Provider for ManifestProvider {
+    fn stream_message<'a>(
+        &'a self,
+        model: &'a Model,
+        messages: &'a [Message],
+        system: &'a str,
+        tools: &'a Value,
+        event_tx: &'a Sender<ProviderEvent>,
+        opts: RequestOptions,
+        session_id: Option<&'a SessionRef>,
+    ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
+        Box::pin(async move {
+            let engine = self.engine()?;
+            engine
+                .stream_message(model, messages, system, tools, event_tx, opts, session_id)
+                .await
+        })
+    }
+
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<ModelInfo>, AgentError>> {
+        Box::pin(async move {
+            let engine = self.engine()?;
+            engine.list_models().await
+        })
+    }
+
+    fn fetch_usage(&self) -> BoxFuture<'_, Result<Option<ProviderUsage>, AgentError>> {
+        Box::pin(async move {
+            let engine = self.engine()?;
+            engine.fetch_usage().await
+        })
+    }
+
+    fn refresh_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
+        Box::pin(async move { self.auth_source.refresh(&self.auth) })
+    }
+
+    fn reload_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
+        Box::pin(async move { self.auth_source.reload(&self.auth) })
+    }
+
+    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
+        Box::pin(async move { self.auth_source.rotate_key(&self.auth) })
+    }
+
+    fn adjust_model(&self, model: &mut Model) {
+        if let Ok(engine) = self.engine() {
+            engine.adjust_model(model);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LOCAL_HOST_SLUGS: &[&str] = &["ollama", "llama-cpp", "opencode"];
+    const OAUTH_SLUGS: &[&str] = &["openai", "copilot"];
+
+    #[test]
+    fn try_for_slug_local_manifests_return_ok_none() {
+        for slug in LOCAL_HOST_SLUGS {
+            assert!(
+                ManifestProvider::try_for_slug(slug, Timeouts::default())
+                    .unwrap()
+                    .is_none(),
+                "{slug} must return Ok(None) so provider_for_slug falls through to ProviderKind::create"
+            );
+        }
+    }
+
+    #[test]
+    fn try_for_slug_oauth_manifests_return_ok_none() {
+        for slug in OAUTH_SLUGS {
+            assert!(
+                ManifestProvider::try_for_slug(slug, Timeouts::default())
+                    .unwrap()
+                    .is_none(),
+                "{slug} is OAuth and stays on ProviderKind::create until the OAuth follow-up PR"
+            );
+        }
+    }
+
+    #[test]
+    fn every_builtin_manifest_is_in_exactly_one_routing_bucket() {
+        for manifest in ManifestRegistry::builtins() {
+            let buckets = [
+                (
+                    "ENV_ENVELOPED",
+                    ENV_ENVELOPED_SLUGS.contains(&manifest.slug),
+                ),
+                ("LOCAL_HOST", LOCAL_HOST_SLUGS.contains(&manifest.slug)),
+                ("OAUTH", OAUTH_SLUGS.contains(&manifest.slug)),
+            ];
+            let count = buckets.iter().filter(|(_, in_bucket)| *in_bucket).count();
+            assert_eq!(
+                count, 1,
+                "manifest slug {:?} appears in {} routing buckets, expected 1",
+                manifest.slug, count,
+            );
+        }
+    }
+
+    #[test]
+    fn routing_buckets_match_auth_kind_from_manifest() {
+        for (bucket_slugs, expected) in [
+            (ENV_ENVELOPED_SLUGS, AuthKind::Env),
+            (LOCAL_HOST_SLUGS, AuthKind::Env),
+            (OAUTH_SLUGS, AuthKind::OAuth),
+        ] {
+            for slug in bucket_slugs {
+                let manifest = ManifestRegistry::get(slug).unwrap_or_else(|| {
+                    panic!("routing bucket slug {slug:?} has no ProviderManifest")
+                });
+                assert_eq!(
+                    manifest.auth_kind, expected,
+                    "slug {slug:?} in routing bucket but manifest has auth_kind {:?}, expected {:?}",
+                    manifest.auth_kind, expected,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn try_for_slug_unknown_returns_none() {
+        assert!(
+            ManifestProvider::try_for_slug("not-a-provider", Timeouts::default())
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn env_enveloped_slugs_have_manifest_and_build_env_arm() {
+        // Every slug in ENV_ENVELOPED_SLUGS must have both (a) a ProviderManifest
+        // and (b) a match arm in build_env. Without (a) try_for_slug returns
+        // Ok(None) before reaching build_env, so the panic check below wouldn't
+        // fire; the manifest assertion guards that. Without (b) build_env hits
+        // unreachable!() and panics — caught by catch_unwind. The panic fires
+        // before resolve runs, so the test is environment-agnostic.
+        for slug in ENV_ENVELOPED_SLUGS {
+            assert!(
+                ManifestRegistry::get(slug).is_some(),
+                "slug {slug:?} in ENV_ENVELOPED_SLUGS has no ProviderManifest",
+            );
+            let result = std::panic::catch_unwind(|| {
+                ManifestProvider::try_for_slug(slug, Timeouts::default())
+            });
+            assert!(
+                result.is_ok(),
+                "slug {slug:?} in ENV_ENVELOPED_SLUGS panicked build_env \
+                 (missing match arm): {:?}",
+                result.err(),
+            );
+        }
+    }
+
+    #[test]
+    fn env_auth_source_resolve_fails_when_env_missing() {
+        let env_var: &'static str =
+            Box::leak(format!("MAKI_TEST_AUTH_NONE_{}", fastrand::u32(..)).into_boxed_str());
+        let source = EnvAuthSource::new("test", env_var, ResolvedAuth::bearer);
+        let auth = Arc::new(Mutex::new(ResolvedAuth {
+            base_url: None,
+            headers: Vec::new(),
+        }));
+        let err = source.resolve(&auth).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains(env_var),
+            "error must reference missing env var: {msg}"
+        );
+    }
+
+    #[test]
+    fn bearer_with_base_url_preserves_both_values() {
+        let auth = bearer_with_base_url("sk-test", Some("https://example.com".into()));
+        assert_eq!(
+            auth.headers
+                .iter()
+                .find(|(name, _)| name == "authorization")
+                .map(|(_, value)| value.as_str()),
+            Some("Bearer sk-test")
+        );
+        assert_eq!(auth.base_url.as_deref(), Some("https://example.com"));
+    }
+}

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -12,20 +12,12 @@ use maki_storage::id::SessionRef;
 
 use crate::model::{Model, ModelFamily, ModelInfo};
 use crate::providers::Timeouts;
-use crate::providers::anthropic::Anthropic;
-use crate::providers::anthropic::bedrock;
+use crate::providers::anthropic::bedrock::{self, Bedrock};
 use crate::providers::copilot::Copilot;
-use crate::providers::deepseek::DeepSeek;
 use crate::providers::dynamic;
-use crate::providers::google::Google;
 use crate::providers::local::{LLAMACPP, LocalEndpoint, OLLAMA};
-use crate::providers::mistral::Mistral;
 use crate::providers::openai::OpenAi;
 use crate::providers::opencode::Opencode;
-use crate::providers::openrouter::OpenRouter;
-use crate::providers::synthetic::Synthetic;
-use crate::providers::tensorx::TensorX;
-use crate::providers::zai::Zai;
 use crate::{AgentError, Message, ProviderEvent, ProviderUsage, RequestOptions, StreamResponse};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumString, EnumIter)]
@@ -197,26 +189,34 @@ impl ProviderKind {
 
     pub fn create(self, timeouts: Timeouts) -> Result<Box<dyn Provider>, AgentError> {
         match self {
-            Self::Anthropic => {
-                if bedrock::is_enabled() {
-                    Ok(Box::new(bedrock::Bedrock::new(timeouts)?))
-                } else {
-                    Ok(Box::new(Anthropic::new(timeouts)?))
-                }
-            }
+            Self::Anthropic if bedrock::is_enabled() => Ok(Box::new(Bedrock::new(timeouts)?)),
             Self::OpenAi => Ok(Box::new(OpenAi::new(timeouts)?)),
-            Self::Google => Ok(Box::new(Google::new(timeouts)?)),
             Self::Copilot => Ok(Box::new(Copilot::new(timeouts)?)),
             Self::Ollama => Ok(Box::new(LocalEndpoint::new(&OLLAMA, timeouts)?)),
             Self::LlamaCpp => Ok(Box::new(LocalEndpoint::new(&LLAMACPP, timeouts)?)),
-            Self::Mistral => Ok(Box::new(Mistral::new(timeouts)?)),
-            Self::Zai => Ok(Box::new(Zai::new(timeouts)?)),
-            Self::DeepSeek => Ok(Box::new(DeepSeek::new(timeouts)?)),
-            Self::OpenRouter => Ok(Box::new(OpenRouter::new(timeouts)?)),
-            Self::Synthetic => Ok(Box::new(Synthetic::new(timeouts)?)),
-            Self::TensorX => Ok(Box::new(TensorX::new(timeouts)?)),
             Self::Opencode => Ok(Box::new(Opencode::new(timeouts)?)),
+            Self::Anthropic
+            | Self::Google
+            | Self::Mistral
+            | Self::Zai
+            | Self::DeepSeek
+            | Self::OpenRouter
+            | Self::Synthetic
+            | Self::TensorX => self.create_enveloped(timeouts),
         }
+    }
+
+    fn create_enveloped(self, timeouts: Timeouts) -> Result<Box<dyn Provider>, AgentError> {
+        // `provider_for_slug` already routes enveloped slugs through
+        // ManifestProvider. Reaching here means a caller invoked create()
+        // directly without provider_for_slug — still surface the same routing
+        // so direct callers don't see a misleading error.
+        let slug = self.to_string();
+        crate::manifest_provider::ManifestProvider::try_for_slug(&slug, timeouts)?.ok_or_else(
+            || AgentError::Config {
+                message: format!("provider '{slug}' has no env manifest route"),
+            },
+        )
     }
 }
 
@@ -259,6 +259,14 @@ pub trait Provider: Send + Sync {
 }
 
 pub fn provider_for_slug(slug: &str, timeouts: Timeouts) -> Result<Box<dyn Provider>, AgentError> {
+    if slug == "anthropic" && bedrock::is_enabled() {
+        return Ok(Box::new(Bedrock::new(timeouts)?));
+    }
+    if let Some(provider) =
+        crate::manifest_provider::ManifestProvider::try_for_slug(slug, timeouts)?
+    {
+        return Ok(provider);
+    }
     if let Ok(kind) = ProviderKind::from_str(slug) {
         return kind.create(timeouts);
     }
@@ -485,5 +493,42 @@ pub async fn fetch_all_models(
     }
     if let Some(done) = on_done {
         done();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct EnvGuard {
+        name: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(name: &'static str, value: &str) -> Self {
+            let previous = std::env::var(name).ok();
+            unsafe { std::env::set_var(name, value) };
+            Self { name, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => unsafe { std::env::set_var(self.name, value) },
+                None => unsafe { std::env::remove_var(self.name) },
+            }
+        }
+    }
+
+    #[test]
+    fn provider_kind_create_preserves_enveloped_provider_factory() {
+        let _env = EnvGuard::set("DEEPSEEK_API_KEY", "sk-test");
+        let result = ProviderKind::DeepSeek.create(Timeouts::default());
+
+        if let Err(error) = result {
+            panic!("DeepSeek factory failed: {error}");
+        }
     }
 }

--- a/maki-providers/src/providers/anthropic/mod.rs
+++ b/maki-providers/src/providers/anthropic/mod.rs
@@ -21,8 +21,6 @@ use crate::{
     AgentError, Message, ProviderEvent, ProviderUsage, RequestOptions, StreamResponse, UsageLimit,
 };
 
-use super::KeyPool;
-
 const API_VERSION: &str = "2023-06-01";
 const MESSAGES_URL: &str = "https://api.anthropic.com/v1/messages";
 const MODELS_URL: &str = "https://api.anthropic.com/v1/models?limit=1000";
@@ -33,7 +31,7 @@ const MONEY_EXPONENT: u32 = 2;
 const LABEL_SESSION: &str = "Current session";
 const LABEL_WEEK_ALL: &str = "Current week (all models)";
 
-const ENV_VAR: &str = "ANTHROPIC_API_KEY";
+pub(crate) const ENV_VAR: &str = "ANTHROPIC_API_KEY";
 
 inventory::submit!(maki_config::providers::BuiltInProvider {
     slug: "anthropic",
@@ -217,7 +215,7 @@ fn usage_eligible(auth: &super::ResolvedAuth) -> bool {
             .is_none_or(|u| u.contains("api.anthropic.com"))
 }
 
-fn resolve_auth_from_key(key: &str) -> super::ResolvedAuth {
+pub(crate) fn resolve_auth_from_key(key: &str) -> super::ResolvedAuth {
     super::ResolvedAuth {
         base_url: Some("https://api.anthropic.com/v1/messages".into()),
         headers: vec![("x-api-key".into(), key.to_string())],
@@ -227,25 +225,11 @@ fn resolve_auth_from_key(key: &str) -> super::ResolvedAuth {
 pub struct Anthropic {
     client: HttpClient,
     auth: Arc<Mutex<super::ResolvedAuth>>,
-    key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
     stream_timeout: Duration,
 }
 
 impl Anthropic {
-    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
-        let pool = KeyPool::resolve("anthropic", ENV_VAR)?;
-        let resolved = resolve_auth_from_key(pool.current());
-        debug!(keys = pool.len(), "using API key authentication");
-        Ok(Self {
-            client: super::http_client(timeouts),
-            auth: Arc::new(Mutex::new(resolved)),
-            key_pool: Some(pool),
-            system_prefix: None,
-            stream_timeout: timeouts.stream,
-        })
-    }
-
     pub(crate) fn with_auth(
         auth: Arc<Mutex<super::ResolvedAuth>>,
         timeouts: super::Timeouts,
@@ -253,7 +237,6 @@ impl Anthropic {
         Self {
             client: super::http_client(timeouts),
             auth,
-            key_pool: None,
             system_prefix: None,
             stream_timeout: timeouts.stream,
         }
@@ -401,24 +384,6 @@ impl Provider for Anthropic {
 
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         Box::pin(self.do_list_models())
-    }
-
-    fn reload_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
-        Box::pin(async {
-            let pool = KeyPool::resolve("anthropic", ENV_VAR)?;
-            *self.auth.lock().unwrap() = resolve_auth_from_key(pool.current());
-            debug!("reloaded Anthropic auth from env");
-            Ok(())
-        })
-    }
-
-    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
-        Box::pin(async {
-            Ok(self
-                .key_pool
-                .as_ref()
-                .is_some_and(|p| p.rotate_auth(&self.auth, resolve_auth_from_key)))
-        })
     }
 
     fn fetch_usage(&self) -> BoxFuture<'_, Result<Option<ProviderUsage>, AgentError>> {

--- a/maki-providers/src/providers/deepseek.rs
+++ b/maki-providers/src/providers/deepseek.rs
@@ -11,13 +11,13 @@ use crate::{
     AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig, dialect,
 };
 
+use super::ResolvedAuth;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
-use super::{KeyPool, ResolvedAuth};
 
 const PAD: &str = "";
 const V4_MARKER: &str = "deepseek-v4";
 
-static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
+pub(crate) static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     api_key_env: "DEEPSEEK_API_KEY",
     base_url: "https://api.deepseek.com",
     max_tokens_field: "max_tokens",
@@ -77,26 +77,14 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
 pub struct DeepSeek {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
-    key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
 }
 
 impl DeepSeek {
-    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
-        let pool = KeyPool::resolve("deepseek", CONFIG.api_key_env)?;
-        Ok(Self {
-            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
-            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(pool.current()))),
-            key_pool: Some(pool),
-            system_prefix: None,
-        })
-    }
-
     pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
         Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
             auth,
-            key_pool: None,
             system_prefix: None,
         }
     }
@@ -146,15 +134,6 @@ impl Provider for DeepSeek {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
             self.compat.do_list_models(&auth).await
-        })
-    }
-
-    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
-        Box::pin(async {
-            Ok(self
-                .key_pool
-                .as_ref()
-                .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
         })
     }
 }

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -16,10 +16,10 @@ use crate::{
     StreamResponse, ThinkingConfig, TokenUsage,
 };
 
-use super::{KeyPool, ResolvedAuth, http_client, next_sse_line};
+use super::{ResolvedAuth, http_client, next_sse_line};
 
 const BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
-const ENV_VAR: &str = "GEMINI_API_KEY";
+pub(crate) const ENV_VAR: &str = "GEMINI_API_KEY";
 const FLASH_MAX_THINKING: u32 = 24_576;
 const PRO_MAX_THINKING: u32 = 32_768;
 
@@ -99,7 +99,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
     ]
 }
 
-fn resolve_auth_from_key(key: &str) -> ResolvedAuth {
+pub(crate) fn resolve_auth_from_key(key: &str) -> ResolvedAuth {
     ResolvedAuth {
         base_url: None,
         headers: vec![("x-goog-api-key".into(), key.to_string())],
@@ -109,22 +109,10 @@ fn resolve_auth_from_key(key: &str) -> ResolvedAuth {
 pub struct Google {
     client: HttpClient,
     auth: Arc<Mutex<ResolvedAuth>>,
-    key_pool: Option<KeyPool>,
     stream_timeout: Duration,
 }
 
 impl Google {
-    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
-        let pool = KeyPool::resolve("google", ENV_VAR)?;
-        let resolved = resolve_auth_from_key(pool.current());
-        Ok(Self {
-            client: http_client(timeouts),
-            auth: Arc::new(Mutex::new(resolved)),
-            key_pool: Some(pool),
-            stream_timeout: timeouts.stream,
-        })
-    }
-
     pub(crate) fn with_auth(
         auth: Arc<Mutex<super::ResolvedAuth>>,
         timeouts: super::Timeouts,
@@ -132,7 +120,6 @@ impl Google {
         Self {
             client: http_client(timeouts),
             auth,
-            key_pool: None,
             stream_timeout: timeouts.stream,
         }
     }
@@ -277,23 +264,6 @@ impl Provider for Google {
                 .collect();
             infos.sort_by(|a, b| a.id.cmp(&b.id));
             Ok(infos)
-        })
-    }
-
-    fn reload_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
-        Box::pin(async {
-            let pool = KeyPool::resolve("google", ENV_VAR)?;
-            *self.auth.lock().unwrap() = resolve_auth_from_key(pool.current());
-            Ok(())
-        })
-    }
-
-    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
-        Box::pin(async {
-            Ok(self
-                .key_pool
-                .as_ref()
-                .is_some_and(|p| p.rotate_auth(&self.auth, resolve_auth_from_key)))
         })
     }
 }

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -8,10 +8,10 @@ use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
+use super::ResolvedAuth;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
-use super::{KeyPool, ResolvedAuth};
 
-static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
+pub(crate) static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     api_key_env: "MISTRAL_API_KEY",
     base_url: "https://api.mistral.ai/v1",
     max_tokens_field: "max_tokens",
@@ -110,7 +110,6 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
 pub struct Mistral {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
-    key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
 }
 
@@ -157,21 +156,10 @@ fn convert_assistant_messages_in_place(messages: &mut Value) {
 }
 
 impl Mistral {
-    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
-        let pool = KeyPool::resolve("mistral", CONFIG.api_key_env)?;
-        Ok(Self {
-            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
-            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(pool.current()))),
-            key_pool: Some(pool),
-            system_prefix: None,
-        })
-    }
-
     pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
         Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
             auth,
-            key_pool: None,
             system_prefix: None,
         }
     }
@@ -256,15 +244,6 @@ impl Provider for Mistral {
                     })
                 })
                 .await
-        })
-    }
-
-    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
-        Box::pin(async {
-            Ok(self
-                .key_pool
-                .as_ref()
-                .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
         })
     }
 

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -207,7 +207,7 @@ impl KeyPool {
             debug!(slug, "resolved API key from saved credentials");
             return Ok(Self::from_keys(vec![key]));
         }
-        if let Some(key) = Self::key_from_config(slug) {
+        if let Some(key) = Self::key_from_config(slug)? {
             debug!(slug, "resolved API key from providers.toml");
             return Ok(Self::from_keys(vec![key]));
         }
@@ -223,10 +223,15 @@ impl KeyPool {
         maki_storage::auth::load_provider_credentials(&dir, slug).map(|c| c.api_key)
     }
 
-    fn key_from_config(slug: &str) -> Option<String> {
-        maki_config::providers::ProvidersConfig::load()
+    fn key_from_config(slug: &str) -> Result<Option<String>, AgentError> {
+        let config = maki_config::providers::ProvidersConfig::try_load().map_err(|error| {
+            AgentError::Config {
+                message: format!("failed to load provider config for '{slug}': {error}"),
+            }
+        })?;
+        Ok(config
             .get(slug)
-            .and_then(|d| d.api_key.clone())
+            .and_then(|definition| definition.api_key.clone()))
     }
 
     pub(crate) fn from_keys(keys: Vec<String>) -> Self {
@@ -245,18 +250,6 @@ impl KeyPool {
             return false;
         }
         self.index.fetch_add(1, Ordering::Relaxed);
-        true
-    }
-
-    pub fn rotate_auth(
-        &self,
-        auth: &Mutex<ResolvedAuth>,
-        build: impl FnOnce(&str) -> ResolvedAuth,
-    ) -> bool {
-        if !self.rotate() {
-            return false;
-        }
-        *auth.lock().unwrap() = build(self.current());
         true
     }
 

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -11,14 +11,14 @@ use crate::{
     dialect,
 };
 
+use super::ResolvedAuth;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
-use super::{KeyPool, ResolvedAuth};
 
 const REFERER: &str = "https://maki.sh";
 const APP_TITLE: &str = "maki";
 const PER_MILLION: f64 = 1_000_000.0;
 
-static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
+pub(crate) static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     api_key_env: "OPENROUTER_API_KEY",
     base_url: "https://openrouter.ai/api/v1",
     max_tokens_field: "max_tokens",
@@ -40,26 +40,14 @@ struct OpenRouterModelInfo {
 pub struct OpenRouter {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
-    key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
 }
 
 impl OpenRouter {
-    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
-        let pool = KeyPool::from_env(CONFIG.api_key_env)?;
-        Ok(Self {
-            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
-            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(pool.current()))),
-            key_pool: Some(pool),
-            system_prefix: None,
-        })
-    }
-
     pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
         Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
             auth,
-            key_pool: None,
             system_prefix: None,
         }
     }
@@ -217,15 +205,6 @@ impl Provider for OpenRouter {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
             self.compat.fetch_and_parse_models(&auth, parse_model).await
-        })
-    }
-
-    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
-        Box::pin(async {
-            Ok(self
-                .key_pool
-                .as_ref()
-                .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
         })
     }
 }

--- a/maki-providers/src/providers/synthetic.rs
+++ b/maki-providers/src/providers/synthetic.rs
@@ -8,10 +8,10 @@ use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
+use super::ResolvedAuth;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
-use super::{KeyPool, ResolvedAuth};
 
-static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
+pub(crate) static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     api_key_env: "SYNTHETIC_API_KEY",
     base_url: "https://api.synthetic.new/openai/v1",
     max_tokens_field: "max_completion_tokens",
@@ -87,26 +87,14 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
 pub struct Synthetic {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
-    key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
 }
 
 impl Synthetic {
-    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
-        let pool = KeyPool::resolve("synthetic", CONFIG.api_key_env)?;
-        Ok(Self {
-            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
-            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(pool.current()))),
-            key_pool: Some(pool),
-            system_prefix: None,
-        })
-    }
-
     pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
         Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
             auth,
-            key_pool: None,
             system_prefix: None,
         }
     }
@@ -145,15 +133,6 @@ impl Provider for Synthetic {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
             self.compat.do_list_models(&auth).await
-        })
-    }
-
-    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
-        Box::pin(async {
-            Ok(self
-                .key_pool
-                .as_ref()
-                .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
         })
     }
 }

--- a/maki-providers/src/providers/tensorx.rs
+++ b/maki-providers/src/providers/tensorx.rs
@@ -8,10 +8,10 @@ use crate::model::{Model, ModelEntry, ModelInfo, ModelPricing};
 use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
+use super::ResolvedAuth;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
-use super::{KeyPool, ResolvedAuth};
 
-static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
+pub(crate) static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     api_key_env: "TENSORX_API_KEY",
     base_url: "https://api.tensorx.ai/v1",
     max_tokens_field: "max_tokens",
@@ -44,26 +44,14 @@ struct TensorXModelInfo {
 pub struct TensorX {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
-    key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
 }
 
 impl TensorX {
-    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
-        let pool = KeyPool::resolve("tensorx", CONFIG.api_key_env)?;
-        Ok(Self {
-            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
-            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(pool.current()))),
-            key_pool: Some(pool),
-            system_prefix: None,
-        })
-    }
-
     pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
         Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
             auth,
-            key_pool: None,
             system_prefix: None,
         }
     }
@@ -224,15 +212,6 @@ impl Provider for TensorX {
                 .unwrap_or_default();
             models.sort_by(|a, b| a.id.cmp(&b.id));
             Ok(models)
-        })
-    }
-
-    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
-        Box::pin(async {
-            Ok(self
-                .key_pool
-                .as_ref()
-                .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
         })
     }
 }

--- a/maki-providers/src/providers/zai/mod.rs
+++ b/maki-providers/src/providers/zai/mod.rs
@@ -15,9 +15,9 @@ use crate::{
     dialect,
 };
 
-use super::{KeyPool, ResolvedAuth};
+use super::ResolvedAuth;
 
-static CONFIG_STANDARD: OpenAiCompatConfig = OpenAiCompatConfig {
+pub(crate) static CONFIG_STANDARD: OpenAiCompatConfig = OpenAiCompatConfig {
     api_key_env: "ZHIPU_API_KEY",
     base_url: "https://api.z.ai/api/paas/v4",
     max_tokens_field: "max_tokens",
@@ -245,33 +245,14 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
 pub struct Zai {
     compat: OpenAiCompatProvider,
     auth: Arc<Mutex<ResolvedAuth>>,
-    key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
 }
 
 impl Zai {
-    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
-        let pool = KeyPool::resolve("zai", CONFIG_STANDARD.api_key_env)?;
-        let mut auth = ResolvedAuth::bearer(pool.current());
-        let provider_config = maki_config::providers::ProvidersConfig::load();
-        if let Some(url) =
-            maki_config::providers::resolve_base_url("zai", provider_config.get("zai"))
-        {
-            auth.base_url = Some(url);
-        }
-        Ok(Self {
-            compat: OpenAiCompatProvider::new(&CONFIG_STANDARD, timeouts),
-            auth: Arc::new(Mutex::new(auth)),
-            key_pool: Some(pool),
-            system_prefix: None,
-        })
-    }
-
     pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
         Self {
             compat: OpenAiCompatProvider::new(&CONFIG_STANDARD, timeouts),
             auth,
-            key_pool: None,
             system_prefix: None,
         }
     }
@@ -335,15 +316,6 @@ impl Provider for Zai {
             let body = self.compat.get_text(&auth, QUOTA_LIMIT_URL).await?;
             let parsed: QuotaResponse = serde_json::from_str(&body)?;
             Ok(Some(parsed.into()))
-        })
-    }
-
-    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
-        Box::pin(async {
-            Ok(self
-                .key_pool
-                .as_ref()
-                .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
         })
     }
 


### PR DESCRIPTION
Part of #481.

This works towards the deletion of `ProviderKind` by creating a central `AuthSource` trait that is currently only backed by the `EnvAuthSource`, but will have `OAuthAuthSource`/`ScriptAuthSource`/`ConfigAuthSource` in a follow-up. Once we have everything going through `AuthSource`, in the Lua plugin code, we can remove the temporary `maki-providers/src/manifest.rs` and the other Rust-based config.

Ran deepseek-backed usage with this, both via the `DEEPSEEK_API_KEY` env var and the `maki auth login` route. I don't have Anthropic for personal use to test, unfortunately, would definitely check that if I could.

Written with Maki + GLM-5.2.