### PR TITLE
fix(providers): emit string content on assistant tool-call messages

### DIFF
--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -319,12 +319,10 @@ pub fn convert_messages(messages: &[Message], system: &str) -> Vec<Value> {
                 }
 
                 if !text.is_empty() || !tool_calls.is_empty() || !reasoning_text.is_empty() {
-                    let mut msg_obj = json!({"role": "assistant"});
-                    if !text.is_empty() {
-                        msg_obj["content"] = Value::String(text);
-                    } else if !reasoning_text.is_empty() {
-                        msg_obj["content"] = Value::String(String::new());
-                    }
+                    // Always emit string `content` (""): some OpenAI-compatible
+                    // backends (e.g. Cloudflare Workers AI gpt-oss) reject
+                    // omitted/null content on assistant tool-call messages.
+                    let mut msg_obj = json!({"role": "assistant", "content": text});
                     if !reasoning_text.is_empty() {
                         msg_obj["reasoning_content"] = Value::String(reasoning_text);
                     }
@@ -811,6 +809,30 @@ data: [DONE]\n";
         assert_eq!(wire[3]["role"], "tool");
         assert_eq!(wire[3]["tool_call_id"], "tc_1");
         assert_eq!(wire[3]["content"], "file.txt");
+    }
+
+    #[test]
+    fn convert_messages_assistant_tool_calls_only_has_content() {
+        let messages = vec![
+            Message::user("list files".to_string()),
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::ToolUse {
+                    id: "tc_1".to_string(),
+                    name: "bash".to_string(),
+                    input: json!({"command": "ls"}),
+                }],
+                ..Default::default()
+            },
+        ];
+
+        let wire = convert_messages(&messages, "be helpful");
+
+        assert_eq!(wire[2]["role"], "assistant");
+        // `content` must be a present string ("") even with only tool_calls;
+        // strict OpenAI-compatible backends reject null/omitted content.
+        assert_eq!(wire[2]["content"], "");
+        assert_eq!(wire[2]["tool_calls"][0]["function"]["name"], "bash");
     }
 
     #[test]


### PR DESCRIPTION
`convert_messages` omitted `content` on assistant messages that carried only `tool_calls`. OpenAI tolerates this, but Cloudflare Workers AI's `@cf/openai/gpt-oss-120b` rejects it, breaking every multi-turn tool-call for `task` with that model. If we always emit the string even when it's empty, that seems to fix the issue.

Built maki and successfully ran a `gpt-oss-120b` multi-turn research task that previously 400'd, other models like `glm-5.2` still work there.

Written with Maki + GLM-5.2.