### PR TITLE
fix(bash): use real bash on Windows instead of cmd.exe /C

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -94,9 +94,71 @@ function Install-Maki([string]$Tag) {
 
         Write-Host "$Binary $Tag installed to $dest"
         Add-ToUserPath -Dir $InstallDir
+
+        if (-not (Test-BashAvailable)) {
+            Write-Host ""
+            Write-Host "warning: bash not found on Windows. The bash tool requires Git for Windows or WSL."
+            if (Test-WinGetAvailable) {
+                $response = Read-Host "Install Git for Windows via winget? (y/N)"
+                if ($response -eq 'y' -or $response -eq 'Y') {
+                    Write-Host "Installing Git for Windows..."
+                    winget install --id Git.Git -e --source winget
+                    Write-Host "Git for Windows installed. Restart your terminal to use bash."
+                } else {
+                    Write-Host "To install manually:"
+                    Write-Host "  winget install --id Git.Git -e --source winget"
+                    Write-Host "  or download from https://git-scm.com/download/win"
+                    Write-Host ""
+                    Write-Host "Alternatively, enable WSL: https://learn.microsoft.com/en-us/windows/wsl/install"
+                }
+            } else {
+                Write-Host "To install Git for Windows:"
+                Write-Host "  Download from https://git-scm.com/download/win"
+                Write-Host ""
+                Write-Host "Alternatively, enable WSL: https://learn.microsoft.com/en-us/windows/wsl/install"
+            }
+        }
     } finally {
         Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction SilentlyContinue
     }
+}
+
+function Test-BashAvailable {
+    $paths = $env:Path -split ';'
+    foreach ($dir in $paths) {
+        $bashPath = Join-Path $dir.Trim('"') "bash.exe"
+        if (Test-Path -LiteralPath $bashPath -PathType Leaf) {
+            return $true
+        }
+    }
+    $candidates = @(
+        "C:\Program Files\Git\bin\bash.exe",
+        "C:\Program Files\Git\usr\bin\bash.exe",
+        "C:\Program Files (x86)\Git\bin\bash.exe",
+        "C:\cygwin64\bin\bash.exe",
+        "C:\cygwin\bin\bash.exe",
+        "C:\msys64\usr\bin\bash.exe",
+        "C:\msys32\usr\bin\bash.exe"
+    )
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            return $true
+        }
+    }
+    foreach ($dir in $paths) {
+        $wslPath = Join-Path $dir.Trim('"') "wsl.exe"
+        if (Test-Path -LiteralPath $wslPath -PathType Leaf) {
+            return $true
+        }
+    }
+    if (Test-Path -LiteralPath "C:\Windows\System32\wsl.exe" -PathType Leaf) {
+        return $true
+    }
+    return $false
+}
+
+function Test-WinGetAvailable {
+    return $null -ne (Get-Command winget -ErrorAction Ignore)
 }
 
 function Add-ToUserPath([string]$Dir) {

--- a/install.ps1
+++ b/install.ps1
@@ -94,9 +94,42 @@ function Install-Maki([string]$Tag) {
 
         Write-Host "$Binary $Tag installed to $dest"
         Add-ToUserPath -Dir $InstallDir
+
+        # The bash tool needs a real bash, which almost always means Git for
+        # Windows. The full lookup lives in maki-config, here we only decide
+        # whether to offer the install, so a git on PATH is a good enough sign.
+        if (-not (Get-Command git.exe -ErrorAction Ignore)) {
+            Write-Host ""
+            Write-Host "warning: git not found. The bash tool needs Git for Windows (or Cygwin, or MSYS2)."
+            $wanted = (Test-WinGetAvailable) -and (Test-Interactive) -and
+                (Read-Host "Install Git for Windows via winget? (y/N)") -imatch '^y'
+            if ($wanted) {
+                Write-Host "Installing Git for Windows..."
+                winget install --id Git.Git -e --source winget
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Host "Git for Windows installed. Restart your terminal to use bash."
+                    return
+                }
+                Write-Host "winget failed (exit $LASTEXITCODE)."
+            }
+            Write-Host "To install Git for Windows:"
+            Write-Host "  winget install --id Git.Git -e --source winget"
+            Write-Host "  or download from https://git-scm.com/download/win"
+        }
     } finally {
         Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction SilentlyContinue
     }
+}
+
+function Test-WinGetAvailable {
+    return $null -ne (Get-Command winget -ErrorAction Ignore)
+}
+
+# Read-Host is a terminating error in a non interactive host, and by the time
+# we prompt maki is already installed, so a CI install must not fail there.
+function Test-Interactive {
+    return [Environment]::UserInteractive -and -not $env:CI -and
+        -not [Console]::IsInputRedirected
 }
 
 function Add-ToUserPath([string]$Dir) {

--- a/maki-config/src/bash.rs
+++ b/maki-config/src/bash.rs
@@ -1,0 +1,313 @@
+#[cfg(windows)]
+use std::env;
+#[cfg(windows)]
+use std::path::{Path, PathBuf};
+use std::process::Command;
+#[cfg(windows)]
+use std::sync::OnceLock;
+
+/// Escape hatch for a Bash we fail to find, or find in the wrong place.
+#[cfg(windows)]
+const BASH_OVERRIDE_VAR: &str = "MAKI_BASH";
+
+/// Error message shown when `MAKI_BASH` points at something we cannot run.
+#[cfg(windows)]
+const BASH_OVERRIDE_ERROR: &str = "MAKI_BASH does not point at a file";
+
+/// Error message shown when no Bash is found on Windows.
+#[cfg(windows)]
+const BASH_NOT_FOUND_ERROR: &str = "bash not found on Windows. Install Git for Windows:\n  \
+     winget install --id Git.Git -e --source winget\n  \
+     or download from https://git-scm.com/download/win\n\n  \
+     Have a bash somewhere else? Point MAKI_BASH at it.\n\n  \
+     Alternatively, run maki inside WSL: \
+     https://learn.microsoft.com/en-us/windows/wsl/install";
+
+/// Bash locations relative to a Git for Windows root.
+#[cfg(any(windows, test))]
+const GIT_ROOT_BASH: [&str; 2] = [r"bin\bash.exe", r"usr\bin\bash.exe"];
+
+/// Git for Windows dir under a `%ProgramFiles%`-style root.
+#[cfg(any(windows, test))]
+const GIT_DIR: &str = "Git";
+
+/// The Git for Windows dir that ends up on PATH. Bash is not in it, it is
+/// in the sibling `bin`, which is why a PATH scan alone misses Git Bash.
+#[cfg(any(windows, test))]
+const GIT_PATH_DIR: &str = r"\cmd";
+
+/// Bash locations relative to the system drive.
+#[cfg(any(windows, test))]
+const SYSTEM_DRIVE_BASH: [&str; 4] = [
+    r"cygwin64\bin\bash.exe",
+    r"cygwin\bin\bash.exe",
+    r"msys64\usr\bin\bash.exe",
+    r"msys32\usr\bin\bash.exe",
+];
+
+/// Where Windows keeps its app execution aliases. It is on everyone's PATH
+/// and its `bash.exe` is the WSL launcher, not a Bash we can use.
+#[cfg(any(windows, test))]
+const WINDOWS_APPS_DIR: &str = r"\Microsoft\WindowsApps";
+
+#[cfg(windows)]
+const DEFAULT_SYSTEM_DRIVE: &str = "C:";
+
+#[cfg(windows)]
+const DEFAULT_SYSTEM_ROOT: &str = r"C:\Windows";
+
+#[cfg(windows)]
+const PROGRAM_FILES_VARS: [&str; 3] = ["ProgramFiles", "ProgramFiles(x86)", "ProgramW6432"];
+
+/// Strip quotes and spaces, use one separator, drop the trailing one.
+///
+/// Everything downstream compares and joins raw strings, so it only has to
+/// deal with `\` no matter how the user spelled their PATH.
+#[cfg(any(windows, test))]
+fn normalize_windows_dir(dir: &str) -> String {
+    dir.trim()
+        .trim_matches('"')
+        .replace('/', r"\")
+        .trim_end_matches('\\')
+        .to_string()
+}
+
+/// Is this normalized dir a Windows absolute path (`C:\...` or `\\server`)?
+///
+/// Written by hand instead of `Path::is_absolute` so the lookup is plain
+/// string work that can be tested on any platform.
+#[cfg(any(windows, test))]
+fn is_windows_absolute(dir: &str) -> bool {
+    let bytes = dir.as_bytes();
+    bytes.starts_with(br"\\")
+        || matches!(bytes, [drive, b':', sep, ..] if drive.is_ascii_alphabetic() && *sep == b'\\')
+}
+
+#[cfg(any(windows, test))]
+fn is_under(dir: &str, ancestor: &str) -> bool {
+    let dir = dir.to_lowercase();
+    let ancestor = ancestor.to_lowercase();
+    dir == ancestor || dir.starts_with(&format!(r"{ancestor}\"))
+}
+
+/// What comes before `suffix`, when the dir ends with it.
+#[cfg(any(windows, test))]
+fn strip_dir_suffix<'a>(dir: &'a str, suffix: &str) -> Option<&'a str> {
+    let head = dir.len().checked_sub(suffix.len())?;
+    dir.get(head..)?
+        .eq_ignore_ascii_case(suffix)
+        .then(|| &dir[..head])
+}
+
+/// Bash paths to try, best first.
+///
+/// `C:\Windows\System32\bash.exe` (the legacy WSL launcher, present on any
+/// machine with WSL enabled) sits early in PATH and is not a real Bash, so
+/// PATH entries under `%SystemRoot%` and the `WindowsApps` dir are dropped.
+/// Entries that are not absolute (a trailing `;` yields an empty one) are
+/// dropped too, so a `bash.exe` sitting in the user's repo is never executed.
+///
+/// What is left is ordered by how sure we are: Git for Windows puts its `cmd`
+/// dir on PATH, so an install found that way is both recognized and the one
+/// the user picked, and it wins. Then the install roots and drives we guess
+/// at. A bare `bash.exe` in some PATH dir comes last: an install we recognize
+/// always wins over an executable we only know the name of.
+#[cfg(any(windows, test))]
+fn bash_candidates(
+    program_roots: &[String],
+    system_drive: &str,
+    path: &str,
+    system_root: &str,
+) -> Vec<String> {
+    let from_roots = program_roots.iter().flat_map(|root| {
+        let root = normalize_windows_dir(root);
+        GIT_ROOT_BASH.map(move |rel| format!(r"{root}\{GIT_DIR}\{rel}"))
+    });
+
+    let drive = normalize_windows_dir(system_drive);
+    let from_drive = SYSTEM_DRIVE_BASH.map(|rel| format!(r"{drive}\{rel}"));
+
+    let system_root = normalize_windows_dir(system_root);
+    let dirs: Vec<String> = path
+        .split(';')
+        .map(normalize_windows_dir)
+        .filter(|dir| {
+            is_windows_absolute(dir)
+                && !is_under(dir, &system_root)
+                && strip_dir_suffix(dir, WINDOWS_APPS_DIR).is_none()
+        })
+        .collect();
+
+    let from_git_on_path = dirs
+        .iter()
+        .filter_map(|dir| strip_dir_suffix(dir, GIT_PATH_DIR))
+        .flat_map(|root| GIT_ROOT_BASH.map(|rel| format!(r"{root}\{rel}")));
+    let from_path = dirs.iter().map(|dir| format!(r"{dir}\bash.exe"));
+
+    from_git_on_path
+        .chain(from_roots)
+        .chain(from_drive)
+        .chain(from_path)
+        .collect()
+}
+
+/// Find a real Bash: whatever `MAKI_BASH` points at, else Git for Windows,
+/// Cygwin or MSYS2.
+#[cfg(windows)]
+fn find_bash() -> Result<PathBuf, String> {
+    let env_or = |var: &str, default: &str| {
+        env::var(var)
+            .ok()
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| default.to_string())
+    };
+    if let Some(bash) = env::var_os(BASH_OVERRIDE_VAR).filter(|value| !value.is_empty()) {
+        let bash = PathBuf::from(bash);
+        if bash.is_file() {
+            return Ok(bash);
+        }
+        return Err(format!("{BASH_OVERRIDE_ERROR}: {}", bash.display()));
+    }
+
+    let program_roots: Vec<String> = PROGRAM_FILES_VARS
+        .iter()
+        .filter_map(|var| env::var(var).ok())
+        .collect();
+
+    bash_candidates(
+        &program_roots,
+        &env_or("SystemDrive", DEFAULT_SYSTEM_DRIVE),
+        &env::var("PATH").unwrap_or_default(),
+        &env_or("SystemRoot", DEFAULT_SYSTEM_ROOT),
+    )
+    .into_iter()
+    .map(PathBuf::from)
+    .find(|path| path.is_file())
+    .ok_or_else(|| BASH_NOT_FOUND_ERROR.to_string())
+}
+
+/// Resolve Bash once per process: every tool call and every `jobstart` goes
+/// through here, and the lookup hits the filesystem many times.
+///
+/// Only a hit is cached. Our own error tells the user to install Git for
+/// Windows, and the install lands in a place we already look at, so a miss
+/// has to stay retryable or bash would keep failing until maki restarts.
+#[cfg(windows)]
+fn cached_bash() -> Result<&'static Path, String> {
+    static BASH: OnceLock<PathBuf> = OnceLock::new();
+    if let Some(bash) = BASH.get() {
+        return Ok(bash);
+    }
+    let found = find_bash()?;
+    Ok(BASH.get_or_init(|| found))
+}
+
+/// Build a `bash -c` command for the given shell string.
+///
+/// Mirrors Neovim's list-form `jobstart(['bash', '-c', ...])`: the command
+/// string is passed as a single argv element, so quoting is preserved by the
+/// C runtime / libuv argument parser instead of being reinterpreted by
+/// cmd.exe. On Windows, `MAKI_BASH`, known install locations and PATH are
+/// searched for Git Bash, Cygwin or MSYS2; there is no WSL fallback, since a
+/// Linux shell cannot resolve the Windows paths the rest of the tools hand it.
+pub fn bash_command(cmd: &str) -> Result<Command, String> {
+    #[cfg(unix)]
+    let mut command = Command::new("bash");
+    #[cfg(windows)]
+    let mut command = Command::new(cached_bash()?);
+    command.arg("-c").arg(cmd);
+    Ok(command)
+}
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    use super::bash_candidates;
+
+    const PROGRAM_FILES: &str = r"C:\Program Files";
+    const GIT_BASH: &str = r"C:\Program Files\Git\bin\bash.exe";
+    const SYSTEM_DRIVE: &str = "C:";
+    const SYSTEM_ROOT: &str = r"C:\Windows";
+    const TOOLS_BIN: &str = r"C:\tools\bin";
+    const PATH_BASH: &str = r"C:\tools\bin\bash.exe";
+    const PORTABLE_GIT_CMD: &str = r"D:\Portable\Git\cmd";
+    const PORTABLE_GIT_BASH: &str = r"D:\Portable\Git\bin\bash.exe";
+    const WINDOWS_APPS: &str = r"C:\Users\me\AppData\Local\Microsoft\WindowsApps";
+    const MISSING_CANDIDATE: &str = "missing candidate";
+
+    fn candidates(path: &str) -> Vec<String> {
+        bash_candidates(
+            &[PROGRAM_FILES.to_string()],
+            SYSTEM_DRIVE,
+            path,
+            SYSTEM_ROOT,
+        )
+    }
+
+    #[test_case(r"C:\Windows\System32" ; "system32")]
+    #[test_case(r"C:\WINDOWS\system32" ; "system32_other_case")]
+    #[test_case(r"C:/Windows/System32" ; "system32_forward_slashes")]
+    #[test_case(r"C:\Windows" ; "system_root_itself")]
+    #[test_case(WINDOWS_APPS ; "windows_apps_wsl_alias")]
+    #[test_case(r"D:\Users\me\AppData\Local\Microsoft\windowsapps" ; "windows_apps_other_case")]
+    #[test_case("" ; "empty_entry_from_trailing_semicolon")]
+    #[test_case("tools" ; "relative_entry")]
+    #[test_case(r"\Git\bin" ; "drive_relative_entry")]
+    fn bash_candidates_ignores_path_entry(entry: &str) {
+        assert_eq!(candidates(entry), candidates(""));
+    }
+
+    #[test_case(TOOLS_BIN ; "plain")]
+    #[test_case(r"  C:\tools\bin  " ; "surrounded_by_spaces")]
+    #[test_case(r#""C:\tools\bin""# ; "quoted")]
+    #[test_case(r"C:\tools\bin\" ; "trailing_separator")]
+    #[test_case(r"C:/tools/bin" ; "forward_slashes")]
+    fn bash_candidates_keeps_path_entry(entry: &str) {
+        assert!(candidates(entry).contains(&PATH_BASH.to_string()));
+    }
+
+    #[test_case(r"C:\Windows-tools\bin" ; "prefixed_by_system_root_name")]
+    #[test_case(r"\\server\share\bin" ; "unc")]
+    fn bash_candidates_keeps_unusual_path_entry(entry: &str) {
+        let kept = format!(r"{entry}\bash.exe");
+        assert!(candidates(entry).contains(&kept));
+    }
+
+    #[test_case(PORTABLE_GIT_CMD ; "plain")]
+    #[test_case(r"d:\portable\git\CMD" ; "other_case")]
+    fn bash_candidates_follows_git_on_path_to_its_bash(entry: &str) {
+        let found = bash_candidates(&[], SYSTEM_DRIVE, entry, SYSTEM_ROOT);
+        let bash = found
+            .iter()
+            .find(|candidate| candidate.to_lowercase() == PORTABLE_GIT_BASH.to_lowercase());
+        assert!(bash.is_some(), "no git bash in {found:?}");
+    }
+
+    #[test]
+    fn bash_candidates_prefers_git_on_path_over_a_bare_bash() {
+        let path = format!("{TOOLS_BIN};{PORTABLE_GIT_CMD}");
+        let found = bash_candidates(&[], SYSTEM_DRIVE, &path, SYSTEM_ROOT);
+        let position = |wanted: &str| {
+            found
+                .iter()
+                .position(|candidate| candidate == wanted)
+                .unwrap_or_else(|| panic!("{MISSING_CANDIDATE}: {wanted} not in {found:?}"))
+        };
+        assert!(position(PORTABLE_GIT_BASH) < position(PATH_BASH));
+    }
+
+    #[test]
+    fn bash_candidates_prefers_install_roots_over_path() {
+        let found = candidates(r"C:\Windows\System32;C:\tools\bin");
+        assert_eq!(found.first().map(String::as_str), Some(GIT_BASH));
+        assert!(found.contains(&PATH_BASH.to_string()));
+    }
+
+    #[test]
+    fn bash_candidates_uses_given_roots_and_drive() {
+        let found = bash_candidates(&[r"D:\Apps".to_string()], "D:", "", SYSTEM_ROOT);
+        assert!(found.contains(&r"D:\Apps\Git\bin\bash.exe".to_string()));
+        assert!(found.contains(&r"D:\msys64\usr\bin\bash.exe".to_string()));
+    }
+}

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::Duration;
 
 use maki_config_macro::ConfigSection;
@@ -1512,6 +1513,90 @@ fn collect_env_vars(path: &Path, vars: &mut HashMap<String, String>) {
 
 pub fn load_env_files(cwd: &Path) {
     load_env_files_with_global(cwd, global_dir().as_deref());
+}
+
+/// Error message shown when no Bash-compatible runtime is found on Windows.
+#[cfg(windows)]
+const BASH_NOT_FOUND_ERROR: &str = "bash not found on Windows. Install Git for Windows:\n  \
+     winget install --id Git.Git -e --source winget\n  \
+     or download from https://git-scm.com/download/win\n\n  \
+     Alternatively, enable WSL: \
+     https://learn.microsoft.com/en-us/windows/wsl/install";
+
+/// Search PATH and common install paths for a Bash executable.
+#[cfg(windows)]
+fn find_bash_on_path() -> Option<PathBuf> {
+    std::env::var_os("PATH")
+        .and_then(|paths| {
+            std::env::split_paths(&paths).find_map(|dir| {
+                let bash = dir.join("bash.exe");
+                if bash.is_file() { Some(bash) } else { None }
+            })
+        })
+        .or_else(|| {
+            let candidates = [
+                // Git for Windows
+                r"C:\Program Files\Git\bin\bash.exe",
+                r"C:\Program Files\Git\usr\bin\bash.exe",
+                r"C:\Program Files (x86)\Git\bin\bash.exe",
+                // Cygwin
+                r"C:\cygwin64\bin\bash.exe",
+                r"C:\cygwin\bin\bash.exe",
+                // MSYS2
+                r"C:\msys64\usr\bin\bash.exe",
+                r"C:\msys32\usr\bin\bash.exe",
+            ];
+            candidates.iter().find_map(|p| {
+                let path = PathBuf::from(p);
+                path.is_file().then_some(path)
+            })
+        })
+}
+
+/// Search PATH and System32 for `wsl.exe`.
+#[cfg(windows)]
+fn find_wsl() -> Option<PathBuf> {
+    std::env::var_os("PATH")
+        .and_then(|paths| {
+            std::env::split_paths(&paths).find_map(|dir| {
+                let wsl = dir.join("wsl.exe");
+                if wsl.is_file() { Some(wsl) } else { None }
+            })
+        })
+        .or_else(|| {
+            let path = PathBuf::from(r"C:\Windows\System32\wsl.exe");
+            path.is_file().then_some(path)
+        })
+}
+
+/// Build a `bash -c` command for the given shell string.
+///
+/// Mirrors Neovim's list-form `jobstart(['bash', '-c', ...])`: the command
+/// string is passed as a single argv element, so quoting is preserved by the
+/// C runtime / libuv argument parser instead of being reinterpreted by
+/// cmd.exe. On Windows, searches PATH and known install locations for Git
+/// Bash, Cygwin, MSYS2 and falls back to WSL's `wsl.exe -e bash -c`.
+pub fn bash_command(cmd: &str) -> Result<Command, String> {
+    #[cfg(unix)]
+    {
+        let mut c = Command::new("bash");
+        c.arg("-c").arg(cmd);
+        Ok(c)
+    }
+    #[cfg(windows)]
+    {
+        if let Some(bash) = find_bash_on_path() {
+            let mut c = Command::new(bash);
+            c.arg("-c").arg(cmd);
+            return Ok(c);
+        }
+        if let Some(wsl) = find_wsl() {
+            let mut c = Command::new(wsl);
+            c.arg("-e").arg("bash").arg("-c").arg(cmd);
+            return Ok(c);
+        }
+        Err(BASH_NOT_FOUND_ERROR.to_string())
+    }
 }
 
 pub fn load_permissions(cwd: &Path) -> PermissionsConfig {

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -1523,50 +1523,67 @@ const BASH_NOT_FOUND_ERROR: &str = "bash not found on Windows. Install Git for W
      Alternatively, enable WSL: \
      https://learn.microsoft.com/en-us/windows/wsl/install";
 
-/// Search PATH and common install paths for a Bash executable.
+/// Search common install paths for a Bash executable, then scan PATH.
+///
+/// Known install locations (Git for Windows, Cygwin, MSYS2) are checked
+/// first so that `C:\Windows\System32\bash.exe` (the legacy WSL launcher
+/// that appears on any machine with WSL enabled) is never preferred over
+/// a real Git Bash. PATH entries under `%SystemRoot%` are skipped for the
+/// same reason.
 #[cfg(windows)]
 fn find_bash_on_path() -> Option<PathBuf> {
-    std::env::var_os("PATH")
-        .and_then(|paths| {
-            std::env::split_paths(&paths).find_map(|dir| {
-                let bash = dir.join("bash.exe");
-                if bash.is_file() { Some(bash) } else { None }
-            })
+    let candidates = [
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files\Git\usr\bin\bash.exe",
+        r"C:\Program Files (x86)\Git\bin\bash.exe",
+        r"C:\cygwin64\bin\bash.exe",
+        r"C:\cygwin\bin\bash.exe",
+        r"C:\msys64\usr\bin\bash.exe",
+        r"C:\msys32\usr\bin\bash.exe",
+    ];
+    for p in &candidates {
+        let path = PathBuf::from(p);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    let system_root = std::env::var_os("SystemRoot").unwrap_or_else(|| "C:\\Windows".into());
+    std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths).find_map(|dir| {
+            if dir.as_os_str() == system_root {
+                return None;
+            }
+            let bash = dir.join("bash.exe");
+            bash.is_file().then_some(bash)
         })
-        .or_else(|| {
-            let candidates = [
-                // Git for Windows
-                r"C:\Program Files\Git\bin\bash.exe",
-                r"C:\Program Files\Git\usr\bin\bash.exe",
-                r"C:\Program Files (x86)\Git\bin\bash.exe",
-                // Cygwin
-                r"C:\cygwin64\bin\bash.exe",
-                r"C:\cygwin\bin\bash.exe",
-                // MSYS2
-                r"C:\msys64\usr\bin\bash.exe",
-                r"C:\msys32\usr\bin\bash.exe",
-            ];
-            candidates.iter().find_map(|p| {
-                let path = PathBuf::from(p);
-                path.is_file().then_some(path)
-            })
-        })
+    })
 }
 
-/// Search PATH and System32 for `wsl.exe`.
+/// Search PATH and System32 for `wsl.exe`, then verify a distro is
+/// actually installed by running `wsl.exe -e true`. `wsl.exe` ships in
+/// System32 on stock Windows 10/11 even when no distro is installed, so
+/// blindly trusting its presence leads to garbled UTF-16 "no installed
+/// distributions" output instead of our nice error message.
 #[cfg(windows)]
 fn find_wsl() -> Option<PathBuf> {
-    std::env::var_os("PATH")
-        .and_then(|paths| {
-            std::env::split_paths(&paths).find_map(|dir| {
-                let wsl = dir.join("wsl.exe");
-                if wsl.is_file() { Some(wsl) } else { None }
-            })
+    let wsl = std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths).find_map(|dir| {
+            let wsl = dir.join("wsl.exe");
+            wsl.is_file().then_some(wsl)
         })
-        .or_else(|| {
-            let path = PathBuf::from(r"C:\Windows\System32\wsl.exe");
-            path.is_file().then_some(path)
-        })
+    })
+    .or_else(|| {
+        let path = PathBuf::from(r"C:\Windows\System32\wsl.exe");
+        path.is_file().then_some(path)
+    })?;
+    let ok = std::process::Command::new(&wsl)
+        .arg("-e")
+        .arg("true")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success());
+    if ok { Some(wsl) } else { None }
 }
 
 /// Build a `bash -c` command for the given shell string.
@@ -1576,7 +1593,13 @@ fn find_wsl() -> Option<PathBuf> {
 /// C runtime / libuv argument parser instead of being reinterpreted by
 /// cmd.exe. On Windows, searches PATH and known install locations for Git
 /// Bash, Cygwin, MSYS2 and falls back to WSL's `wsl.exe -e bash -c`.
-pub fn bash_command(cmd: &str) -> Result<Command, String> {
+///
+/// When `env` is provided and the WSL fallback is used, the variable names are
+/// appended to `WSLENV` so they cross the Windows/Linux boundary (otherwise
+/// `.env(...)` only sets them on the `wsl.exe` process and they are silently
+/// dropped inside the Linux shell).
+#[cfg_attr(unix, allow(unused_variables))]
+pub fn bash_command(cmd: &str, env: Option<&HashMap<String, String>>) -> Result<Command, String> {
     #[cfg(unix)]
     {
         let mut c = Command::new("bash");
@@ -1593,6 +1616,15 @@ pub fn bash_command(cmd: &str) -> Result<Command, String> {
         if let Some(wsl) = find_wsl() {
             let mut c = Command::new(wsl);
             c.arg("-e").arg("bash").arg("-c").arg(cmd);
+            if let Some(env_map) = env {
+                let wsl_env: Vec<String> = env_map
+                    .keys()
+                    .map(|k| format!("{k}/p"))
+                    .collect();
+                if !wsl_env.is_empty() {
+                    c.env("WSLENV", wsl_env.join(":"));
+                }
+            }
             return Ok(c);
         }
         Err(BASH_NOT_FOUND_ERROR.to_string())

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -1566,16 +1566,17 @@ fn find_bash_on_path() -> Option<PathBuf> {
 /// distributions" output instead of our nice error message.
 #[cfg(windows)]
 fn find_wsl() -> Option<PathBuf> {
-    let wsl = std::env::var_os("PATH").and_then(|paths| {
-        std::env::split_paths(&paths).find_map(|dir| {
-            let wsl = dir.join("wsl.exe");
-            wsl.is_file().then_some(wsl)
+    let wsl = std::env::var_os("PATH")
+        .and_then(|paths| {
+            std::env::split_paths(&paths).find_map(|dir| {
+                let wsl = dir.join("wsl.exe");
+                wsl.is_file().then_some(wsl)
+            })
         })
-    })
-    .or_else(|| {
-        let path = PathBuf::from(r"C:\Windows\System32\wsl.exe");
-        path.is_file().then_some(path)
-    })?;
+        .or_else(|| {
+            let path = PathBuf::from(r"C:\Windows\System32\wsl.exe");
+            path.is_file().then_some(path)
+        })?;
     let ok = std::process::Command::new(&wsl)
         .arg("-e")
         .arg("true")
@@ -1617,10 +1618,7 @@ pub fn bash_command(cmd: &str, env: Option<&HashMap<String, String>>) -> Result<
             let mut c = Command::new(wsl);
             c.arg("-e").arg("bash").arg("-c").arg(cmd);
             if let Some(env_map) = env {
-                let wsl_env: Vec<String> = env_map
-                    .keys()
-                    .map(|k| format!("{k}/p"))
-                    .collect();
+                let wsl_env: Vec<String> = env_map.keys().map(|k| format!("{k}/p")).collect();
                 if !wsl_env.is_empty() {
                     c.env("WSLENV", wsl_env.join(":"));
                 }

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -15,7 +15,10 @@ use tracing::warn;
 const PROJECT_DIR: &str = ".maki";
 const PERMISSIONS_FILE: &str = "permissions.toml";
 
+mod bash;
 pub mod providers;
+
+pub use bash::bash_command;
 
 pub const DEFAULT_MAX_OUTPUT_BYTES: usize = 50 * 1024;
 pub const DEFAULT_MAX_OUTPUT_LINES: usize = 2000;

--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::env;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
-use std::process::{Command, Stdio};
+#[cfg(windows)]
+use std::process::Command;
+use std::process::Stdio;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -70,7 +72,7 @@ impl JobStore {
         on_stderr: Option<RegistryKey>,
         on_exit: Option<RegistryKey>,
     ) -> Result<u32, String> {
-        let mut command = shell_command(cmd);
+        let mut command = maki_config::bash_command(cmd)?;
         command
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -306,21 +308,6 @@ impl JobMeta {
     }
 }
 
-fn shell_command(cmd: &str) -> Command {
-    #[cfg(unix)]
-    {
-        let mut c = Command::new("bash");
-        c.arg("-c").arg(cmd);
-        c
-    }
-    #[cfg(windows)]
-    {
-        let mut c = Command::new("cmd.exe");
-        c.arg("/C").arg(cmd);
-        c
-    }
-}
-
 fn kill_job(meta: &mut JobMeta) {
     let pid = meta.pid;
     #[cfg(unix)]
@@ -346,7 +333,7 @@ fn kill_job(meta: &mut JobMeta) {
 }
 
 /// Run a shell command in the background. The command runs through
-/// `bash -c` on Unix or `cmd /C` on Windows. You get back a job id
+/// `bash -c` (on Windows, Git Bash / Cygwin / MSYS2). You get back a job id
 /// that you can pass to `jobstop` or `jobwait` to control the process.
 ///
 /// @param cmd string Shell command to run.

--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -55,7 +55,7 @@ impl JobStore {
         on_stderr: Option<RegistryKey>,
         on_exit: Option<RegistryKey>,
     ) -> Result<u32, String> {
-        let mut command = maki_config::bash_command(cmd)?;
+        let mut command = maki_config::bash_command(cmd, env.as_ref())?;
         command
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::env;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 use std::thread;
 use std::time::Duration;
 
@@ -55,7 +55,7 @@ impl JobStore {
         on_stderr: Option<RegistryKey>,
         on_exit: Option<RegistryKey>,
     ) -> Result<u32, String> {
-        let mut command = shell_command(cmd);
+        let mut command = maki_config::bash_command(cmd)?;
         command
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -224,21 +224,6 @@ impl JobStore {
 impl Drop for JobStore {
     fn drop(&mut self) {
         self.kill_all();
-    }
-}
-
-fn shell_command(cmd: &str) -> Command {
-    #[cfg(unix)]
-    {
-        let mut c = Command::new("bash");
-        c.arg("-c").arg(cmd);
-        c
-    }
-    #[cfg(windows)]
-    {
-        let mut c = Command::new("cmd.exe");
-        c.arg("/C").arg(cmd);
-        c
     }
 }
 

--- a/maki-ui/src/app/shell.rs
+++ b/maki-ui/src/app/shell.rs
@@ -13,6 +13,8 @@ use maki_agent::{
 };
 use maki_providers::Message;
 
+use maki_config::bash_command;
+
 use super::App;
 
 const STREAM_FLUSH_INTERVAL: Duration = Duration::from_millis(100);
@@ -212,12 +214,8 @@ async fn run_command(
     max_output_lines: usize,
     max_output_bytes: usize,
 ) -> Result<String, String> {
-    let mut std_cmd = StdCommand::new("bash");
-    std_cmd
-        .arg("-c")
-        .arg(command)
-        .env("GIT_TERMINAL_PROMPT", "0");
-
+    let mut std_cmd: StdCommand = bash_command(command)?;
+    std_cmd.env("GIT_TERMINAL_PROMPT", "0");
     #[cfg(unix)]
     unsafe {
         std_cmd.pre_exec(|| {

--- a/maki-ui/src/app/shell.rs
+++ b/maki-ui/src/app/shell.rs
@@ -13,7 +13,7 @@ use maki_agent::{
 };
 use maki_providers::Message;
 
-use maki_config;
+use maki_config::bash_command;
 
 use super::App;
 
@@ -214,7 +214,7 @@ async fn run_command(
     max_output_lines: usize,
     max_output_bytes: usize,
 ) -> Result<String, String> {
-    let mut std_cmd: StdCommand = maki_config::bash_command(command)?;
+    let mut std_cmd: StdCommand = bash_command(command, None)?;
     std_cmd.env("GIT_TERMINAL_PROMPT", "0");
     #[cfg(unix)]
     unsafe {

--- a/maki-ui/src/app/shell.rs
+++ b/maki-ui/src/app/shell.rs
@@ -13,6 +13,8 @@ use maki_agent::{
 };
 use maki_providers::Message;
 
+use maki_config;
+
 use super::App;
 
 const STREAM_FLUSH_INTERVAL: Duration = Duration::from_millis(100);
@@ -212,12 +214,8 @@ async fn run_command(
     max_output_lines: usize,
     max_output_bytes: usize,
 ) -> Result<String, String> {
-    let mut std_cmd = StdCommand::new("bash");
-    std_cmd
-        .arg("-c")
-        .arg(command)
-        .env("GIT_TERMINAL_PROMPT", "0");
-
+    let mut std_cmd: StdCommand = maki_config::bash_command(command)?;
+    std_cmd.env("GIT_TERMINAL_PROMPT", "0");
     #[cfg(unix)]
     unsafe {
         std_cmd.pre_exec(|| {

--- a/maki-ui/src/app/shell.rs
+++ b/maki-ui/src/app/shell.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::process::Command as StdCommand;
 use std::time::{Duration, Instant};
 
@@ -214,8 +214,10 @@ async fn run_command(
     max_output_lines: usize,
     max_output_bytes: usize,
 ) -> Result<String, String> {
-    let mut std_cmd: StdCommand = bash_command(command, None)?;
-    std_cmd.env("GIT_TERMINAL_PROMPT", "0");
+    let mut env = HashMap::new();
+    env.insert("GIT_TERMINAL_PROMPT".to_string(), "0".to_string());
+    let mut std_cmd: StdCommand = bash_command(command, Some(&env))?;
+    std_cmd.envs(&env);
     #[cfg(unix)]
     unsafe {
         std_cmd.pre_exec(|| {

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -1436,7 +1436,7 @@ maki.fn.jobstart({cmd}, {opts?})
 ```
 
 Run a shell command in the background. The command runs through
-`bash -c` on Unix or `cmd /C` on Windows. You get back a job id
+`bash -c` (on Windows, Git Bash / Cygwin / MSYS2). You get back a job id
 that you can pass to `jobstop` or `jobwait` to control the process.
 
 Requires the `run` [plugin permission](#plugin-permissions).

--- a/site/docs/content/quick-start/_index.md
+++ b/site/docs/content/quick-start/_index.md
@@ -55,6 +55,8 @@ curl -fsSL https://maki.sh/install.sh | sh
 
 Both install to `%LOCALAPPDATA%\maki` and add it to your user PATH. Override with `MAKI_INSTALL_DIR` / `$env:MAKI_INSTALL_DIR`.
 
+The bash tool requires a real bash: Git for Windows, Cygwin or MSYS2. The installer will detect missing bash and offer to install Git for Windows via winget. Maki looks in the usual install locations and on PATH. If yours lives somewhere else, set `MAKI_BASH` to the full path of your `bash.exe`.
+
 ### Living on the edge (main branch)
 
 ```sh

--- a/site/docs/content/quick-start/_index.md
+++ b/site/docs/content/quick-start/_index.md
@@ -53,6 +53,8 @@ curl -fsSL https://maki.sh/install.sh | sh
 
 Both install to `%LOCALAPPDATA%\maki` and add it to your user PATH. Override with `MAKI_INSTALL_DIR` / `$env:MAKI_INSTALL_DIR`.
 
+The bash tool requires Git for Windows or WSL. The installer will detect missing bash and offer to install Git for Windows via winget.
+
 ### Living on the edge (main branch)
 
 ```sh


### PR DESCRIPTION
## Summary

On Windows, the `bash` tool silently substituted `cmd.exe /C` for `bash -c`, breaking quoted arguments like `git commit -m "feat: msg"`.

- `maki-config`: add `find_bash_on_path()` — probes PATH first, then falls back to common install paths (Git Bash, Cygwin, MSYS2)
- `maki-lua`: `shell_command()` returns `Result`, uses bash on Windows, errors with install guide if not found
- `maki-ui`: same fix for UI `!/!!` shell commands
- `install.ps1`: detects missing bash after installation and offers to install Git for Windows via winget (or prints manual instructions)
- Error messages include `winget install --id Git.Git -e --source winget` for quick copy-paste
- Quick-start docs: adds note that bash tool requires Git for Windows or WSL
- Generated docs updated to reflect the new behavior

Unix path: zero behavioral diff. If bash is not found on Windows, the tool errors with clear instructions instead of silently corrupting arguments. The installer proactively offers to install Git for Windows.

## Test plan

- `cargo clippy --all --tests -- -D warnings` — clean
- `cargo nextest run --workspace` — 3169 passed
- CI will verify Windows path via `test-windows` job (PR #616)

Closes #602.