### PR TITLE
perf(token-optimization): shrink skill tool definition and count tool tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,6 +1213,17 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
@@ -2510,6 +2521,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror 2.0.18",
+ "tiktoken-rs",
  "toml",
  "toml_edit",
  "tracing",
@@ -2890,7 +2902,7 @@ dependencies = [
  "mlua_derive",
  "num-traits",
  "parking_lot",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustversion",
  "serde",
  "serde-value",
@@ -4168,7 +4180,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "thin-vec",
  "thiserror 2.0.18",
 ]
@@ -4186,7 +4198,7 @@ dependencies = [
  "ruff_python_ast",
  "ruff_python_trivia",
  "ruff_text_size",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "static_assertions",
  "thin-vec",
  "unicode-ident",
@@ -4236,6 +4248,12 @@ name = "rustc-demangle"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -4982,6 +5000,21 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "tiktoken-rs"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bstr",
+ "fancy-regex 0.13.0",
+ "lazy_static",
+ "regex",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ maki-highlight = { path = "maki-highlight" }
 maki-markdown = { path = "maki-markdown" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
+tiktoken-rs = "0.9"
 bs58 = "0.5"
 uuid = { version = "1", default-features = false, features = ["std", "v7"] }
 ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }

--- a/maki-agent/Cargo.toml
+++ b/maki-agent/Cargo.toml
@@ -37,6 +37,7 @@ sha2 = { workspace = true }
 serde_yaml = { workspace = true }
 base64 = { workspace = true }
 getrandom = { workspace = true }
+tiktoken-rs = { workspace = true }
 
 
 [dev-dependencies]

--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -6,6 +6,7 @@ use maki_providers::{
 };
 use tracing::info;
 
+use super::estimate_message_tokens;
 use super::history::History;
 use super::streaming::stream_with_retry;
 use crate::cancel::CancelToken;
@@ -79,18 +80,18 @@ fn finish_compact(
     compact_start: std::time::Instant,
     model: &Model,
 ) -> TokenUsage {
-    let _ = event_tx.send(AgentEvent::TurnComplete(Box::new(TurnCompleteEvent {
-        message: response.message.clone(),
-        usage: response.usage,
-        model: model.id.clone(),
-        context_size: Some(response.usage.output),
-    })));
-
+    let message = response.message.clone();
     let new_history = vec![
         Message::user("What did we do so far?".into()),
         response.message,
     ];
     history.replace(new_history);
+    let _ = event_tx.send(AgentEvent::TurnComplete(Box::new(TurnCompleteEvent {
+        message,
+        usage: response.usage,
+        model: model.id.clone(),
+        context_size: Some(estimate_message_tokens(history.as_slice())),
+    })));
     info!(
         model = %model.id,
         duration_ms = compact_start.elapsed().as_millis() as u64,

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -551,8 +551,8 @@ mod tests {
 
     use maki_providers::provider::{BoxFuture, Provider};
     use maki_providers::{
-        ContentBlock, Message, Model, ProviderEvent, RequestOptions, Role, StopReason,
-        StreamResponse, TokenUsage,
+        ContentBlock, ImageMediaType, ImageSource, Message, Model, ProviderEvent, RequestOptions,
+        Role, StopReason, StreamResponse, TokenUsage,
     };
     use serde_json::Value;
     use test_case::test_case;
@@ -574,6 +574,60 @@ mod tests {
         let tools = serde_json::json!([{"name": "skill", "description": "A tool"}]);
         let tokens = estimate_tool_tokens(&tools);
         assert!(tokens > 0, "expected positive token count for tools");
+    }
+
+    #[test]
+    fn estimate_message_tokens_empty_is_zero() {
+        assert_eq!(estimate_message_tokens(&[]), 0);
+    }
+
+    #[test]
+    fn estimate_message_tokens_counts_each_content_block() {
+        let messages = vec![Message {
+            role: Role::User,
+            content: vec![
+                ContentBlock::Text { text: "hi".into() },
+                ContentBlock::Image {
+                    source: ImageSource {
+                        media_type: ImageMediaType::Png,
+                        data: Arc::from("data"),
+                    },
+                },
+            ],
+            ..Default::default()
+        }];
+        let tokens = estimate_message_tokens(&messages);
+        assert!(
+            tokens >= u32_from_usize(IMAGE_TOKEN_ESTIMATE),
+            "image blocks should add {IMAGE_TOKEN_ESTIMATE} tokens"
+        );
+    }
+
+    #[test]
+    fn estimate_message_tokens_counts_thinking_and_signature() {
+        let messages = vec![Message {
+            role: Role::Assistant,
+            content: vec![
+                ContentBlock::Thinking {
+                    thinking: "thinking text".into(),
+                    signature: Some("sig".into()),
+                },
+                ContentBlock::RedactedThinking {
+                    data: "redacted".into(),
+                },
+            ],
+            ..Default::default()
+        }];
+        let tokens = estimate_message_tokens(&messages);
+        assert!(
+            tokens > 0,
+            "thinking and redacted blocks should contribute tokens"
+        );
+    }
+
+    #[test]
+    fn estimate_tool_tokens_empty_array_costs_one() {
+        assert_eq!(estimate_tool_tokens(&serde_json::json!([])), 1);
     }
 
     struct MockInterruptSource {
@@ -909,6 +963,29 @@ mod tests {
                 .await;
 
             assert!(result.is_ok());
+        });
+    }
+
+    #[test]
+    fn oversized_initial_context_compacts_before_normal_request() {
+        smol::block_on(async {
+            let prior = vec![Message::user("x".repeat(680_000))];
+            let mut history = History::new(prior);
+            let (mut agent, event_rx) = make_agent(
+                MockProvider::new(vec![
+                    text_response(StopReason::EndTurn),
+                    text_response(StopReason::EndTurn),
+                ]),
+                &mut history,
+            );
+            agent.model = Arc::new(small_context_model(200_000, 8_192));
+
+            agent.run(default_input()).await.unwrap();
+
+            assert!(has_event(&drain_events(&event_rx), |event| matches!(
+                event,
+                AgentEvent::AutoCompacting
+            )));
         });
     }
 

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -25,8 +25,11 @@ use crate::{
 use maki_config::ToolOutputLines;
 use maki_storage::id::SessionRef;
 
+use crate::tokenize::{count_json, count_tokens};
+
 const MAX_REAUTH_ATTEMPTS: u32 = 2;
 const NUDGE_PROMPT: &str = "You just executed tool calls but returned an empty response. Please process the tool results above and continue with the task.";
+const IMAGE_TOKEN_ESTIMATE: usize = 2_048;
 
 pub fn resolve_compaction_model(
     provider: &Arc<dyn Provider>,
@@ -185,6 +188,8 @@ impl<'h> Agent<'h> {
         self.rollback_len = self.history.len();
         let msg = Message::user_with_images(input.message.clone(), input.images);
         self.history.push(msg);
+        self.context_size =
+            estimate_message_tokens(self.history.as_slice()) + estimate_tool_tokens(&self.tools);
         self.mode = input.mode;
         self.workflow = input.workflow;
         self.opts = RequestOptions {
@@ -199,7 +204,11 @@ impl<'h> Agent<'h> {
             "agent run started"
         );
 
-        let result = self.run_loop().await;
+        let result = async {
+            self.try_auto_compact().await?;
+            self.run_loop().await
+        }
+        .await;
 
         if matches!(result, Err(AgentError::Cancelled)) {
             sanitize_cancelled_history(self.history, self.rollback_len);
@@ -466,6 +475,8 @@ impl<'h> Agent<'h> {
         self.event_tx.send(AgentEvent::CompactionDone)?;
         self.history
             .push(Message::synthetic(CONTINUE_AFTER_COMPACT.into()));
+        self.context_size =
+            estimate_message_tokens(self.history.as_slice()) + estimate_tool_tokens(&self.tools);
         Ok(())
     }
 
@@ -500,23 +511,37 @@ impl<'h> Agent<'h> {
     }
 }
 
-const CHARS_PER_TOKEN: usize = 4;
+#[must_use]
+fn u32_from_usize(value: usize) -> u32 {
+    u32::try_from(value).unwrap_or(u32::MAX)
+}
 
+#[must_use]
 pub fn estimate_message_tokens(messages: &[Message]) -> u32 {
     if messages.is_empty() {
         return 0;
     }
-    let total_bytes: usize = messages
+    let total: usize = messages
         .iter()
         .flat_map(|m| &m.content)
-        .filter_map(|b| match b {
-            ContentBlock::Text { text } => Some(text.len()),
-            ContentBlock::ToolResult { content, .. } => Some(content.len()),
-            ContentBlock::ToolUse { input, .. } => Some(input.to_string().len()),
-            _ => None,
+        .map(|b| match b {
+            ContentBlock::Text { text } => count_tokens(text),
+            ContentBlock::Thinking {
+                thinking,
+                signature,
+            } => count_tokens(thinking) + signature.as_ref().map_or(0, |s| count_tokens(s)),
+            ContentBlock::RedactedThinking { data } => count_tokens(data),
+            ContentBlock::ToolResult { content, .. } => count_tokens(content),
+            ContentBlock::ToolUse { input, .. } => count_json(input),
+            ContentBlock::Image { .. } => IMAGE_TOKEN_ESTIMATE,
         })
         .sum();
-    (total_bytes.max(CHARS_PER_TOKEN) / CHARS_PER_TOKEN) as u32
+    u32_from_usize(total)
+}
+
+#[must_use]
+pub fn estimate_tool_tokens(tools: &Value) -> u32 {
+    u32_from_usize(count_json(tools))
 }
 
 #[cfg(test)]
@@ -536,6 +561,20 @@ mod tests {
     use crate::Envelope;
     use crate::mcp::tool_names;
     use crate::permissions::PermissionManager;
+
+    #[test]
+    fn estimate_message_tokens_counts_content_blocks() {
+        let messages = vec![Message::user("hello world".into())];
+        let tokens = estimate_message_tokens(&messages);
+        assert!(tokens > 0, "expected positive token count for messages");
+    }
+
+    #[test]
+    fn estimate_tool_tokens_counts_json() {
+        let tools = serde_json::json!([{"name": "skill", "description": "A tool"}]);
+        let tokens = estimate_tool_tokens(&tools);
+        assert!(tokens > 0, "expected positive token count for tools");
+    }
 
     struct MockInterruptSource {
         commands: Mutex<VecDeque<ExtractedCommand>>,

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -188,8 +188,8 @@ impl<'h> Agent<'h> {
         self.rollback_len = self.history.len();
         let msg = Message::user_with_images(input.message.clone(), input.images);
         self.history.push(msg);
-        self.context_size =
-            estimate_message_tokens(self.history.as_slice()) + estimate_tool_tokens(&self.tools);
+        self.context_size = estimate_message_tokens(self.history.as_slice())
+            .saturating_add(estimate_tool_tokens(&self.tools));
         self.mode = input.mode;
         self.workflow = input.workflow;
         self.opts = RequestOptions {
@@ -303,8 +303,9 @@ impl<'h> Agent<'h> {
         if has_tools {
             let history_len_before = self.history.len();
             self.process_tool_calls(response).await?;
-            self.context_size +=
-                estimate_message_tokens(&self.history.as_slice()[history_len_before..]);
+            self.context_size = self.context_size.saturating_add(estimate_message_tokens(
+                &self.history.as_slice()[history_len_before..],
+            ));
         } else {
             let has_text = response.message.first_text_content().is_some();
 
@@ -475,8 +476,8 @@ impl<'h> Agent<'h> {
         self.event_tx.send(AgentEvent::CompactionDone)?;
         self.history
             .push(Message::synthetic(CONTINUE_AFTER_COMPACT.into()));
-        self.context_size =
-            estimate_message_tokens(self.history.as_slice()) + estimate_tool_tokens(&self.tools);
+        self.context_size = estimate_message_tokens(self.history.as_slice())
+            .saturating_add(estimate_tool_tokens(&self.tools));
         Ok(())
     }
 
@@ -512,8 +513,13 @@ impl<'h> Agent<'h> {
 }
 
 #[must_use]
-fn u32_from_usize(value: usize) -> u32 {
-    u32::try_from(value).unwrap_or(u32::MAX)
+fn u32_from_usize_saturating(value: usize) -> u32 {
+    if let Ok(n) = u32::try_from(value) {
+        n
+    } else {
+        warn!(value, "token count exceeded u32 range; saturating");
+        u32::MAX
+    }
 }
 
 #[must_use]
@@ -536,12 +542,12 @@ pub fn estimate_message_tokens(messages: &[Message]) -> u32 {
             ContentBlock::Image { .. } => IMAGE_TOKEN_ESTIMATE,
         })
         .sum();
-    u32_from_usize(total)
+    u32_from_usize_saturating(total)
 }
 
 #[must_use]
 pub fn estimate_tool_tokens(tools: &Value) -> u32 {
-    u32_from_usize(count_json(tools))
+    u32_from_usize_saturating(count_json(tools))
 }
 
 #[cfg(test)]
@@ -598,7 +604,7 @@ mod tests {
         }];
         let tokens = estimate_message_tokens(&messages);
         assert!(
-            tokens >= u32_from_usize(IMAGE_TOKEN_ESTIMATE),
+            tokens >= u32_from_usize_saturating(IMAGE_TOKEN_ESTIMATE),
             "image blocks should add {IMAGE_TOKEN_ESTIMATE} tokens"
         );
     }
@@ -628,6 +634,11 @@ mod tests {
     #[test]
     fn estimate_tool_tokens_empty_array_costs_one() {
         assert_eq!(estimate_tool_tokens(&serde_json::json!([])), 1);
+    }
+
+    #[test]
+    fn u32_from_usize_saturating_overflows_to_max() {
+        assert_eq!(u32_from_usize_saturating(usize::MAX), u32::MAX);
     }
 
     struct MockInterruptSource {

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -23,6 +23,7 @@ pub mod diff;
 pub mod permissions;
 pub mod prompt;
 pub mod template;
+pub mod tokenize;
 pub mod tools;
 pub use tools::ToolFilter;
 pub mod types;

--- a/maki-agent/src/tokenize.rs
+++ b/maki-agent/src/tokenize.rs
@@ -62,4 +62,40 @@ mod tests {
             "large json should produce positive token count"
         );
     }
+
+    #[test]
+    fn counts_empty_text() {
+        let tokens = count_tokens("");
+        assert_eq!(tokens, 0, "empty string should have zero tokens");
+    }
+
+    #[test]
+    fn counts_non_ascii_text() {
+        let text = "héllo wörld 世界";
+        let tokens = count_tokens(text);
+        assert!(tokens > 0, "non-ascii text should have positive tokens");
+    }
+
+    #[test]
+    fn uses_tiktoken_up_to_threshold_and_fallback_after() {
+        let at_threshold = "x".repeat(TIKTOKEN_MAX_CHARS);
+        let over_threshold = "x".repeat(TIKTOKEN_MAX_CHARS + 1);
+
+        let at_tokens = count_tokens(&at_threshold);
+        let over_tokens = count_tokens(&over_threshold);
+
+        assert!(at_tokens > 0, "text at threshold should be counted");
+        assert_eq!(
+            over_tokens,
+            over_threshold.len() / BYTES_PER_TOKEN_ESTIMATE,
+            "text over threshold should use bytes/4 fallback"
+        );
+    }
+
+    #[test]
+    fn count_json_falls_back_for_non_serializable() {
+        let value = Value::Null;
+        let tokens = count_json(&value);
+        assert_eq!(tokens, 1, "null serializes to one token-ish string");
+    }
 }

--- a/maki-agent/src/tokenize.rs
+++ b/maki-agent/src/tokenize.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
 use tiktoken_rs::cl100k_base_singleton;
+use tracing::warn;
 
 const TIKTOKEN_MAX_CHARS: usize = 4_096;
 const BYTES_PER_TOKEN_ESTIMATE: usize = 4;
@@ -16,7 +17,10 @@ pub fn count_tokens(text: &str) -> usize {
 pub fn count_json(value: &Value) -> usize {
     match serde_json::to_string(value) {
         Ok(text) => count_tokens(&text),
-        Err(_) => 0,
+        Err(e) => {
+            warn!(error = %e, "failed to serialize JSON for token count; using byte fallback");
+            count_tokens(&value.to_string())
+        }
     }
 }
 

--- a/maki-agent/src/tokenize.rs
+++ b/maki-agent/src/tokenize.rs
@@ -98,4 +98,69 @@ mod tests {
         let tokens = count_json(&value);
         assert_eq!(tokens, 1, "null serializes to one token-ish string");
     }
+
+    #[test]
+    fn tokenize_fuzz_smoke() {
+        fn xorshift64(state: &mut u64) -> u64 {
+            *state ^= *state << 13;
+            *state ^= *state >> 7;
+            *state ^= *state << 17;
+            *state
+        }
+
+        fn gen_text(state: &mut u64, max_len: usize) -> String {
+            const ALPHABET: &[u8] =
+                b"abcdefghijklmnopqrstuvwxyz0123456789 \n\t!@#$%^&*()_+-=[]{}|;':\",./<>?";
+            let len = (xorshift64(state) as usize) % max_len;
+            let mut out = String::with_capacity(len);
+            for _ in 0..len {
+                let idx = (xorshift64(state) as usize) % ALPHABET.len();
+                out.push(ALPHABET[idx] as char);
+            }
+            out
+        }
+
+        fn gen_value(state: &mut u64, depth: usize) -> Value {
+            let kind = xorshift64(state) % 6;
+            match kind {
+                0 => Value::Null,
+                1 => Value::Bool((xorshift64(state) & 1) == 1),
+                2 => Value::Number(((xorshift64(state) % 1000) as i64).into()),
+                3 => Value::String(gen_text(state, 50)),
+                4 if depth > 0 => {
+                    let len = (xorshift64(state) as usize) % 4;
+                    Value::Array((0..len).map(|_| gen_value(state, depth - 1)).collect())
+                }
+                5 if depth > 0 => {
+                    let len = (xorshift64(state) as usize) % 4;
+                    let mut m = serde_json::Map::new();
+                    for i in 0..len {
+                        m.insert(format!("k{i}"), gen_value(state, depth - 1));
+                    }
+                    Value::Object(m)
+                }
+                _ => Value::String(gen_text(state, 10)),
+            }
+        }
+
+        let mut state = 0x1234_5678_9ABC_DEF0u64;
+        for _ in 0..500 {
+            let text = gen_text(&mut state, 6_000);
+            let tokens = count_tokens(&text);
+            assert!(
+                tokens <= text.len().max(1),
+                "token count {tokens} exceeds text length {}",
+                text.len()
+            );
+
+            let value = gen_value(&mut state, 4);
+            let tokens = count_json(&value);
+            let json_text = serde_json::to_string(&value).unwrap();
+            assert!(
+                tokens <= json_text.len().max(1),
+                "json token count {tokens} exceeds json length {}",
+                json_text.len()
+            );
+        }
+    }
 }

--- a/maki-agent/src/tokenize.rs
+++ b/maki-agent/src/tokenize.rs
@@ -1,0 +1,65 @@
+use serde_json::Value;
+use tiktoken_rs::cl100k_base_singleton;
+
+const TIKTOKEN_MAX_CHARS: usize = 4_096;
+const BYTES_PER_TOKEN_ESTIMATE: usize = 4;
+
+#[must_use]
+pub fn count_tokens(text: &str) -> usize {
+    if text.len() > TIKTOKEN_MAX_CHARS {
+        return text.len() / BYTES_PER_TOKEN_ESTIMATE;
+    }
+    cl100k_base_singleton().encode_ordinary(text).len()
+}
+
+#[must_use]
+pub fn count_json(value: &Value) -> usize {
+    match serde_json::to_string(value) {
+        Ok(text) => count_tokens(&text),
+        Err(_) => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn counts_short_text() {
+        let text = "hello world";
+        let tokens = count_tokens(text);
+        assert!(
+            tokens > 0 && tokens < 10,
+            "expected positive token count, got {tokens}"
+        );
+    }
+
+    #[test]
+    fn counts_json_object() {
+        let value = json!({"name": "skill", "list": true});
+        let tokens = count_json(&value);
+        assert!(tokens > 0, "expected positive token count for json");
+    }
+
+    #[test]
+    fn counts_long_text_uses_byte_fallback() {
+        let text = "x".repeat(10_000);
+        let tokens = count_tokens(&text);
+        assert_eq!(
+            tokens, 2_500,
+            "long repeated text should use bytes/4 fallback"
+        );
+    }
+
+    #[test]
+    fn counts_large_json_uses_byte_fallback() {
+        let value = json!({"data": "x".repeat(10_000)});
+        let tokens = count_json(&value);
+        assert!(
+            tokens > 2_000,
+            "large json should produce positive token count"
+        );
+    }
+}

--- a/maki-lua/tests/code_execution_policy.rs
+++ b/maki-lua/tests/code_execution_policy.rs
@@ -14,9 +14,10 @@ const CODE_EXECUTION_SRC: &str = include_str!("../../plugins/code_execution/init
 const ECHO_PREFIX: &str = "echo:";
 const TASK_PREFIX: &str = "task:";
 const WORKFLOW_NOTE_SUBSTR: &str = "Workflow mode: orchestrate subagents";
-const INTERP_ECHO_SIG: &str = "- interp_echo(msg: str, count: int = None, flag: bool = None, items: list = None, raw: any = None) -> str";
-const WF_TASK_SIG: &str = "- wf_task(prompt: str, model_tier: str = None) -> str";
-const SUB_TOOL_SIG: &str = "- sub_tool() -> str";
+const INTERP_ECHO_SIG: &str =
+    "- interp_echo(msg: str, count?: int, flag?: bool, items?: list, raw?: any)";
+const WF_TASK_SIG: &str = "- wf_task(prompt: str, model_tier?: str)";
+const SUB_TOOL_SIG: &str = "- sub_tool()";
 
 fn fixture_plugin() -> String {
     format!(

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -3380,3 +3380,43 @@ fn job_callbacks_fire_while_command_handler_parked() {
         .expect("job callbacks starved while command handler was parked");
     assert!(matches!(action, maki_lua::UiAction::Flash(msg) if msg == "job:hi"));
 }
+
+#[test]
+fn skill_tool_list_returns_catalog() {
+    let (reg, _host) = builtins_host();
+    let out = exec_tool(&reg, "skill", serde_json::json!({"list": true})).unwrap();
+    assert!(
+        out.contains("<available_skills>"),
+        "list=true should return skill catalog"
+    );
+}
+
+#[test]
+fn skill_tool_missing_name_returns_available_names() {
+    let (reg, _host) = builtins_host();
+    let out = exec_tool(&reg, "skill", serde_json::json!({})).unwrap_err();
+    assert!(out.contains("error:"), "missing name should be an error");
+    assert!(
+        out.contains("Available skills"),
+        "missing name should list available skills"
+    );
+}
+
+#[test]
+fn skill_tool_unknown_name_returns_available_names() {
+    let (reg, _host) = builtins_host();
+    let out = exec_tool(
+        &reg,
+        "skill",
+        serde_json::json!({"name": "nonexistent-skill"}),
+    )
+    .unwrap_err();
+    assert!(
+        out.contains("skill not found"),
+        "unknown skill should be reported"
+    );
+    assert!(
+        out.contains("Available skills"),
+        "unknown skill should list available skills"
+    );
+}

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -440,11 +440,16 @@ impl From<TokenUsage> for StoredTokenUsage {
 
 impl TokenUsage {
     pub fn total_input(&self) -> u32 {
-        self.input + self.cache_read + self.cache_creation
+        self.input
+            .saturating_add(self.cache_read)
+            .saturating_add(self.cache_creation)
     }
 
     pub fn context_tokens(&self) -> u32 {
-        self.input + self.output + self.cache_creation + self.cache_read
+        self.input
+            .saturating_add(self.output)
+            .saturating_add(self.cache_creation)
+            .saturating_add(self.cache_read)
     }
 
     pub fn cost(&self, pricing: &ModelPricing, fast: bool) -> f64 {
@@ -471,10 +476,10 @@ impl TokenUsage {
 
 impl AddAssign for TokenUsage {
     fn add_assign(&mut self, rhs: Self) {
-        self.input += rhs.input;
-        self.output += rhs.output;
-        self.cache_creation += rhs.cache_creation;
-        self.cache_read += rhs.cache_read;
+        self.input = self.input.saturating_add(rhs.input);
+        self.output = self.output.saturating_add(rhs.output);
+        self.cache_creation = self.cache_creation.saturating_add(rhs.cache_creation);
+        self.cache_read = self.cache_read.saturating_add(rhs.cache_read);
     }
 }
 
@@ -555,6 +560,64 @@ mod tests {
         assert!(fast > usage.cost(&pricing, false));
     }
 
+    #[test]
+    fn total_input_saturates_at_u32_max() {
+        let usage = TokenUsage {
+            input: u32::MAX,
+            output: 0,
+            cache_creation: 1,
+            cache_read: 1,
+        };
+        assert_eq!(usage.total_input(), u32::MAX);
+    }
+
+    #[test]
+    fn context_tokens_saturates_at_u32_max() {
+        let usage = TokenUsage {
+            input: u32::MAX,
+            output: 1,
+            cache_creation: 1,
+            cache_read: 1,
+        };
+        assert_eq!(usage.context_tokens(), u32::MAX);
+    }
+
+    #[test]
+    fn add_assign_saturates_at_u32_max() {
+        let mut usage = TokenUsage {
+            input: u32::MAX - 100,
+            output: 0,
+            cache_creation: 0,
+            cache_read: 0,
+        };
+        usage += TokenUsage {
+            input: 200,
+            output: 0,
+            cache_creation: 0,
+            cache_read: 0,
+        };
+        assert_eq!(usage.input, u32::MAX);
+    }
+
+    #[test]
+    fn add_assign_normal_values_sum_correctly() {
+        let mut usage = TokenUsage {
+            input: 100,
+            output: 50,
+            cache_creation: 25,
+            cache_read: 10,
+        };
+        usage += TokenUsage {
+            input: 100,
+            output: 50,
+            cache_creation: 25,
+            cache_read: 10,
+        };
+        assert_eq!(usage.input, 200);
+        assert_eq!(usage.output, 100);
+        assert_eq!(usage.cache_creation, 50);
+        assert_eq!(usage.cache_read, 20);
+    }
     #[test]
     fn fast_flag_ignored_without_fast_tier() {
         let pricing = ModelPricing {

--- a/plugins/code_execution/init.lua
+++ b/plugins/code_execution/init.lua
@@ -13,7 +13,8 @@ local MAX_SCRIPT_LINES = 2000
 local NO_OUTPUT = "(no output)"
 local SEPARATOR = "──────"
 local PREAMBLE = "import re\nimport asyncio\nimport sys\nimport os\nimport json\n"
-local TOOLS_HEADER = "\n\nAvailable tools (called as Python functions with keyword arguments). Optional params are marked with '?'.\n"
+local TOOLS_HEADER =
+  "\n\nAvailable tools (called as Python functions with keyword arguments). Optional params are marked with '?'.\n"
 local WORKFLOW_TOOLS_NOTE =
   "\nWorkflow mode: orchestrate subagents from this script. Await every `task(...)` call and use `asyncio.gather` for parallel fan-out. Pass `output_schema` to task for machine-readable results (a JSON string, parse with `json.loads`).\n"
 local PY_TYPES = { string = "str", integer = "int", boolean = "bool", array = "list" }

--- a/plugins/code_execution/init.lua
+++ b/plugins/code_execution/init.lua
@@ -13,7 +13,7 @@ local MAX_SCRIPT_LINES = 2000
 local NO_OUTPUT = "(no output)"
 local SEPARATOR = "──────"
 local PREAMBLE = "import re\nimport asyncio\nimport sys\nimport os\nimport json\n"
-local TOOLS_HEADER = "\n\nAvailable tools (called as Python functions with keyword arguments):\n"
+local TOOLS_HEADER = "\n\nAvailable tools (called as Python functions with keyword arguments). Optional params are marked with '?'.\n"
 local WORKFLOW_TOOLS_NOTE =
   "\nWorkflow mode: orchestrate subagents from this script. Await every `task(...)` call and use `asyncio.gather` for parallel fan-out. Pass `output_schema` to task for machine-readable results (a JSON string, parse with `json.loads`).\n"
 local PY_TYPES = { string = "str", integer = "int", boolean = "bool", array = "list" }
@@ -184,9 +184,10 @@ local function signature(t)
   local params = {}
   for _, pname in ipairs(names) do
     local ptype = PY_TYPES[schema_props[pname].type] or "any"
-    params[#params + 1] = required[pname] and (pname .. ": " .. ptype) or (pname .. ": " .. ptype .. " = None")
+    local suffix = required[pname] and (": " .. ptype) or ("?: " .. ptype)
+    params[#params + 1] = pname .. suffix
   end
-  return "- " .. t.name .. "(" .. table.concat(params, ", ") .. ") -> str"
+  return "- " .. t.name .. "(" .. table.concat(params, ", ") .. ")"
 end
 
 -- Keep cheap: runs on every request build. get_tools skips descriptions

--- a/plugins/skill/init.lua
+++ b/plugins/skill/init.lua
@@ -7,6 +7,7 @@ local ToolView = require("maki.tool_view")
 local helpers = require("skill_helpers")
 local parse_frontmatter = helpers.parse_frontmatter
 local build_skill_list = helpers.build_skill_list
+local build_skill_names = helpers.build_skill_names
 
 local PROJECT_SKILL_DIRS = {
   ".maki/skills",
@@ -127,24 +128,28 @@ local function discover_skills()
   return skills
 end
 
-local boot_skills = discover_skills()
-local description = "Load a skill that provides instructions and workflows for specific tasks."
-  .. build_skill_list(boot_skills)
+local DESCRIPTION =
+  "Load a skill that provides instructions and workflows for specific tasks. Use `list=true` to enumerate available skills; then call with the exact skill `name`."
 
 maki.api.register_tool({
   name = "skill",
   kind = "read",
-  description = description,
+  description = DESCRIPTION,
 
   schema = {
     type = "object",
     properties = {
-      name = { type = "string", description = "Name of the skill to load", required = true },
+      list = {
+        type = "boolean",
+        default = false,
+        description = "Return the list of available skills with their descriptions instead of loading one.",
+      },
+      name = { type = "string", description = "Name of the skill to load." },
     },
   },
 
   header = function(input)
-    return input.name
+    return input.list and "skill list" or input.name
   end,
 
   restore = function(_input, output, _is_error, ctx)
@@ -156,15 +161,19 @@ maki.api.register_tool({
   end,
 
   handler = function(input, ctx)
-    if not input.name then
-      return { llm_output = "error: name is required", is_error = true }
+    local skills = discover_skills()
+
+    if input.list then
+      return { llm_output = build_skill_list(skills) }
     end
 
-    local skills = discover_skills()
+    if not input.name or #input.name == 0 then
+      return { llm_output = "error: name is required" .. build_skill_names(skills), is_error = true }
+    end
+
     local skill = skills[input.name]
     if not skill then
-      local available = build_skill_list(skills)
-      return { llm_output = NOT_FOUND .. input.name .. available, is_error = true }
+      return { llm_output = NOT_FOUND .. input.name .. build_skill_names(skills), is_error = true }
     end
     if skill.resolve then
       skill.content = skill.resolve()

--- a/plugins/skill/skill_helpers.lua
+++ b/plugins/skill/skill_helpers.lua
@@ -38,4 +38,17 @@ function M.build_skill_list(skills)
   return "\n\n<available_skills>\n" .. table.concat(lines, "\n") .. "\n</available_skills>"
 end
 
+function M.build_skill_names(skills)
+  local names = {}
+  for _, s in pairs(skills) do
+    names[#names + 1] = s.name
+  end
+  table.sort(names)
+
+  if #names == 0 then
+    return ""
+  end
+  return "\n\nAvailable skills: " .. table.concat(names, ", ")
+end
+
 return M

--- a/plugins/skill/skill_helpers.lua
+++ b/plugins/skill/skill_helpers.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.parse_frontmatter(content)
-  local rest = content:match("^%s*%-%-%-\n(.*)")
+  local rest = content:match("^%s*%-%-%-[ \t]*\n(.*)")
   if not rest then
     return {}, content
   end
@@ -9,7 +9,7 @@ function M.parse_frontmatter(content)
   if not end_pos then
     return {}, content
   end
-  local yaml_str = rest:sub(1, end_pos)
+  local yaml_str = rest:sub(1, end_pos - 1)
   local body = rest:sub(end_pos + 4):match("^%s*(.-)%s*$")
   local fm, _ = maki.yaml.decode(yaml_str)
   if not fm then

--- a/plugins/skill/tests/spec.lua
+++ b/plugins/skill/tests/spec.lua
@@ -1,6 +1,7 @@
 local helpers = require("skill_helpers")
 local parse_frontmatter = helpers.parse_frontmatter
 local build_skill_list = helpers.build_skill_list
+local build_skill_names = helpers.build_skill_names
 
 local failures = {}
 
@@ -95,6 +96,29 @@ case("build_skill_list_sorted_alphabetically", function()
     m = { name = "middle", description = "M skill" },
   }
   local result = build_skill_list(skills)
+  local alpha_pos = result:find("alpha")
+  local middle_pos = result:find("middle")
+  local zebra_pos = result:find("zebra")
+  assert(alpha_pos < middle_pos, "alpha should come before middle")
+  assert(middle_pos < zebra_pos, "middle should come before zebra")
+end)
+
+-- ── build_skill_names ──
+
+case("build_skill_names_empty", function()
+  eq(build_skill_names({}), "")
+end)
+
+case("build_skill_names_sorted", function()
+  local skills = {
+    z = { name = "zebra" },
+    a = { name = "alpha" },
+    m = { name = "middle" },
+  }
+  local result = build_skill_names(skills)
+  assert(result:find("alpha"), "should contain alpha")
+  assert(result:find("middle"), "should contain middle")
+  assert(result:find("zebra"), "should contain zebra")
   local alpha_pos = result:find("alpha")
   local middle_pos = result:find("middle")
   local zebra_pos = result:find("zebra")

--- a/plugins/task/init.lua
+++ b/plugins/task/init.lua
@@ -150,6 +150,9 @@ local function handler(input, ctx)
   end
 
   local permit = semaphore:acquire()
+  if not permit then
+    return { llm_output = "failed to acquire subagent permit", is_error = true }
+  end
 
   -- pcall so a raised error cannot leak the permit.
   local ok, out = pcall(function()
@@ -186,7 +189,7 @@ local function handler(input, ctx)
       local msg = last_errors and (STRUCTURED_INVALID_ERROR .. ":\n" .. last_errors) or STRUCTURED_MISSING_ERROR
       return { llm_output = msg, is_error = true }
     end
-    return { llm_output = captured and maki.json.encode(captured) or result.text, format = "markdown" }
+    return { llm_output = captured and maki.json.encode(captured) or (result and result.text or ""), format = "markdown" }
   end)
 
   permit:release()

--- a/plugins/task/init.lua
+++ b/plugins/task/init.lua
@@ -57,7 +57,7 @@ local schema = {
     },
     model_tier = {
       type = "string",
-      description = 'Model tier (optional, omit to use current model, capped at current tier):\n- "strong" (e.g. Opus): Deep reasoning, complex architecture, subtle bugs, most critical sections. ~5x cost of medium.\n- "medium" (e.g. Sonnet): Balanced. Refactors, features, multi-file changes.\n- "weak" (e.g. Haiku): Fast/cheap. Search, summarize, boilerplate, simple edits.',
+      description = 'Optional capped tier: "weak" for simple work, "medium" for normal changes, or "strong" for complex/critical work.',
     },
     output_schema = {
       description = "JSON Schema (object) the subagent's final result must match. When set, the result is returned as a validated JSON string.",

--- a/plugins/task/init.lua
+++ b/plugins/task/init.lua
@@ -189,7 +189,10 @@ local function handler(input, ctx)
       local msg = last_errors and (STRUCTURED_INVALID_ERROR .. ":\n" .. last_errors) or STRUCTURED_MISSING_ERROR
       return { llm_output = msg, is_error = true }
     end
-    return { llm_output = captured and maki.json.encode(captured) or (result and result.text or ""), format = "markdown" }
+    return {
+      llm_output = captured and maki.json.encode(captured) or (result and result.text or ""),
+      format = "markdown",
+    }
   end)
 
   permit:release()

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -162,7 +162,7 @@ Launch an autonomous subagent to perform tasks independently. Best combined with
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `description` | string | yes | Short (3-5 words) description of the task |
-| `model_tier` | string | no | Model tier (optional, omit to use current model, capped at current tier):<br>- "strong" (e.g. Opus): Deep reasoning, complex architecture, subtle bugs, most critical sections. ~5x cost of medium.<br>- "medium" (e.g. Sonnet): Balanced. Refactors, features, multi-file changes.<br>- "weak" (e.g. Haiku): Fast/cheap. Search, summarize, boilerplate, simple edits. |
+| `model_tier` | string | no | Optional capped tier: "weak" for simple work, "medium" for normal changes, or "strong" for complex/critical work. |
 | `output_schema` | string | no | JSON Schema (object) the subagent's final result must match. When set, the result is returned as a validated JSON string. |
 | `prompt` | string | yes | Detailed task prompt for the agent |
 | `subagent_type` | string | no | Subagent type: "research" (read-only, default) or "general" (can modify files) |
@@ -187,11 +187,12 @@ Persistent, project-scoped scratchpad for learnings, patterns, decisions, and go
 
 ### `skill` *(lua plugin)*
 
-Load a skill that provides instructions and workflows for specific tasks.
+Load a skill that provides instructions and workflows for specific tasks. Use `list=true` to enumerate available skills; then call with the exact skill `name`.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `name` | string | yes | Name of the skill to load |
+| `list` | boolean | no | Return the list of available skills with their descriptions instead of loading one. |
+| `name` | string | no | Name of the skill to load. |
 
 ## Web
 


### PR DESCRIPTION
## Summary

This PR shrinks the `skill` tool definition and improves token accounting:

- Shrinks the `skill` tool's static description by moving the dynamic skill catalog behind a new `list` parameter. Users call `skill(list=true)` to enumerate skills, then `skill(name=...)` to load one.
- Adds `tiktoken-rs` based token counting in `maki-agent/src/tokenize.rs`.
- Includes tool definition tokens in the agent's `context_size` estimate in `maki-agent/src/agent/run.rs`.
- Adds a safe fallback to `bytes / 4` for strings longer than 4 KB to avoid `tiktoken-rs` BPE quadratic blow-up on pathological single-token strings.
- Further trims tool-definition bloat: shortens `code_execution` interpreter signatures from `name: type = None` / `-> str` to `name?: type`, and condenses the `task` `model_tier` description.

## Review fixes

- Rename `u32_from_usize` to `u32_from_usize_saturating` and log when a token count exceeds the `u32` range.
- Use `saturating_add` for `context_size` estimates and `TokenUsage` sums to prevent `u32` overflow/wrap.
- Update `count_json` to log and fall back to `value.to_string()` instead of silently returning `0` on serialization failure.
- Add unit tests for `u32_from_usize_saturating` overflow and `TokenUsage` saturation.

## Savings (main tool definitions, `to_vec_pretty`)

| metric | before | after | savings |
|---|---|---|---|
| `skill` tool definition | 8,578 B | 573 B | 8,005 B (~93%) |
| total main tool definitions | 30,860 B | ~22,480 B | ~8,380 B (~27%) |

The `skill` tool alone went from ~28% of the main catalog to ~3%.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all --tests -- -D warnings` passes.
- [x] `cargo nextest run --workspace` passes (3,193 passed, 0 skipped).
- [x] `maki-lua` `skill_plugin_spec` passes (including new `build_skill_names` cases).
- [x] `maki-agent` `oversized_initial_context_compacts_before_normal_request` passes.
- [x] `maki-lua` `plugin_host` tests for `skill(list=true)`, missing name, and unknown name pass.
- [x] `maki-lua` `code_execution_policy` passes with updated signature constants.
- [x] `maki-agent` `tokenize_fuzz_smoke` passes (seeded xorshift, 500 random strings + JSON values).