### PR TITLE
feat(ui): add Ctrl+Shift+C to copy selected text

### DIFF
--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -755,6 +755,10 @@ impl App {
                 self.file_picker.open(&self.state.session.cwd);
             } else if key.code == KeyCode::Char('v') && self.image_paste_rx.is_empty() {
                 self.start_image_paste();
+            } else if key::COPY.matches(key) {
+                if let Some(SelectionState::Dragging { sel, .. }) = self.selection_state.take() {
+                    self.selection_state = Some(SelectionState::PendingCopy { sel });
+                }
             } else if let InputAction::PaletteSync(val) = self.input_box.handle_key(key) {
                 self.command_palette.sync(&val);
             }

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -756,7 +756,9 @@ impl App {
             } else if key.code == KeyCode::Char('v') && self.image_paste_rx.is_empty() {
                 self.start_image_paste();
             } else if key::COPY.matches(key) {
-                if let Some(SelectionState::Dragging { sel, .. }) = self.selection_state.take() {
+                if let Some(SelectionState::Dragging { sel, .. }) = self.selection_state.take()
+                    && !sel.is_empty()
+                {
                     self.selection_state = Some(SelectionState::PendingCopy { sel });
                 }
             } else if let InputAction::PaletteSync(val) = self.input_box.handle_key(key) {

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -155,6 +155,13 @@ pub mod key {
         modifiers: KeyModifiers::ALT,
         label: "Alt+O",
     };
+    pub const COPY: Bind = Bind {
+        code: KeyCode::Char('c'),
+        modifiers: KeyModifiers::from_bits_truncate(
+            KeyModifiers::CONTROL.bits() | KeyModifiers::SHIFT.bits(),
+        ),
+        label: "Ctrl+Shift+C",
+    };
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter)]
@@ -348,6 +355,12 @@ pub const KEYBINDS: &[Keybind] = &[
     Keybind {
         label: KeyLabel::Single(key::TASKS.label),
         description: "Open tasks",
+        context: KeybindContext::General,
+        platform: Platform::All,
+    },
+    Keybind {
+        label: KeyLabel::Single(key::COPY.label),
+        description: "Copy selection",
         context: KeybindContext::General,
         platform: Platform::All,
     },

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -21,6 +21,7 @@ On macOS, some bindings use Option or Fn keys instead (run `/help` for exact key
 | `Ctrl+O` | Open plan in editor |
 | `Ctrl+T` | Toggle plan panel |
 | `Ctrl+X` | Open tasks |
+| `Ctrl+Shift+C` | Copy selection |
 
 ## Editing
 


### PR DESCRIPTION
## Summary

Adds keyboard shortcut `Ctrl+Shift+C` to copy selected text to the system clipboard. Purely additive.

## Changes

- **`maki-ui/src/components/keybindings.rs`**: Added `key::COPY` binding (`CONTROL | SHIFT`) and `KEYBINDS` entry for help menu
- **`maki-ui/src/app/mod.rs`**: Added handler in `handle_main_chat_key()` that transitions `Dragging` selection state to `PendingCopy`, triggering the existing clipboard copy on next render

## How it works

Maki captures mouse events for internal text selection, which prevents the terminal's native `Ctrl+Shift+C` from working. This PR adds an internal keyboard shortcut that:

1. When `Ctrl+Shift+C` is pressed with an active mouse selection (`Dragging` state), transitions to `PendingCopy`
2. The existing `apply_selection()` in `view.rs` picks up `PendingCopy` and calls `copy_selection()` on the next render
3. If no selection exists, the shortcut silently no-ops

## Safety

- `Bind::matches()` requires exact modifier equality, so `Ctrl+C` (QUIT) is unaffected
- `is_ctrl()` accepts `Ctrl+Shift` combinations (only rejects Alt)
- Tests pass: 10 keybinding tests + 179 app tests