### PR TITLE
feat(agent): load AGENTS.md from parent directories

### DIFF
--- a/maki-agent/src/agent/instructions.rs
+++ b/maki-agent/src/agent/instructions.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 use maki_providers::model::Model;
 
 use crate::AgentMode;
+use crate::command::find_project_ancestor_dirs;
 use crate::template::Vars;
 
 const INSTRUCTION_FILES: &[&str] = &[
@@ -72,36 +73,62 @@ pub fn build_system_prompt(
     out
 }
 
-fn append_instruction_files(
-    out: &mut String,
+fn read_instruction(path: &Path, loaded: &LoadedInstructions) -> Option<(PathBuf, String)> {
+    let canonical = path.canonicalize().ok()?;
+    if loaded.contains_or_insert(canonical.clone()) {
+        return None;
+    }
+    let content = fs::read_to_string(&canonical).ok()?;
+    Some((canonical, content))
+}
+
+fn collect_instruction_files(
     cwd: &str,
     home: Option<&Path>,
     xdg_config: Option<&Path>,
-) {
-    let root = Path::new(cwd);
+    loaded: &LoadedInstructions,
+) -> Vec<(String, String)> {
+    let mut out = Vec::new();
 
-    for filename in INSTRUCTION_FILES {
-        if let Ok(content) = fs::read_to_string(root.join(filename)) {
-            out.push_str(&format!(
-                "\n\nProject instructions ({filename}):\n{content}"
-            ));
-            break;
+    let ancestor_dirs: Vec<_> = find_project_ancestor_dirs(Path::new(cwd)).collect();
+    let has_git_root = ancestor_dirs.iter().any(|dir| dir.join(".git").exists());
+    let project_dirs = if has_git_root {
+        ancestor_dirs
+    } else {
+        ancestor_dirs.into_iter().take(1).collect()
+    };
+
+    // Load root instructions first so cwd instructions come last and override on conflicts.
+    for dir in project_dirs.into_iter().rev() {
+        for filename in INSTRUCTION_FILES {
+            if let Some((canonical, content)) = read_instruction(&dir.join(filename), loaded) {
+                out.push((
+                    format!("Project instructions ({})", canonical.display()),
+                    content,
+                ));
+                break;
+            }
         }
-    }
 
-    if let Ok(content) = fs::read_to_string(root.join(LOCAL_INSTRUCTION_FILE)) {
-        out.push_str(&format!(
-            "\n\nLocal instructions ({LOCAL_INSTRUCTION_FILE}):\n{content}"
-        ));
+        if let Some((canonical, content)) =
+            read_instruction(&dir.join(LOCAL_INSTRUCTION_FILE), loaded)
+        {
+            out.push((
+                format!("Local instructions ({})", canonical.display()),
+                content,
+            ));
+        }
     }
 
     for path in maki_storage::paths::user_config_dirs(home, xdg_config, "AGENTS.md") {
-        if let Ok(content) = fs::read_to_string(&path) {
-            let display = path.display();
-            out.push_str(&format!("\n\nGlobal instructions ({display}):\n{content}"));
+        if let Some((canonical, content)) = read_instruction(&path, loaded) {
+            let label = format!("Global instructions ({})", canonical.display());
+            out.push((label, content));
             break;
         }
     }
+
+    out
 }
 
 pub fn load_instruction_text(cwd: &str) -> String {
@@ -117,8 +144,13 @@ pub(crate) fn load_instruction_text_with_home(
     home: Option<&Path>,
     xdg_config: Option<&Path>,
 ) -> String {
+    let loaded = LoadedInstructions::new();
+    let files = collect_instruction_files(cwd, home, xdg_config, &loaded);
+
     let mut text = String::new();
-    append_instruction_files(&mut text, cwd, home, xdg_config);
+    for (label, content) in files {
+        text.push_str(&format!("\n\n{label}:\n{content}"));
+    }
     text
 }
 
@@ -135,16 +167,11 @@ pub(crate) fn load_instructions_with_home(
     home: Option<&Path>,
     xdg_config: Option<&Path>,
 ) -> Instructions {
-    let root = Path::new(cwd);
     let mut instr = Instructions::default();
-    append_instruction_files(&mut instr.text, cwd, home, xdg_config);
+    let files = collect_instruction_files(cwd, home, xdg_config, &instr.loaded);
 
-    for filename in INSTRUCTION_FILES {
-        let path = root.join(filename);
-        if let Ok(canonical) = path.canonicalize() {
-            instr.loaded.contains_or_insert(canonical);
-            break;
-        }
+    for (label, content) in files {
+        instr.text.push_str(&format!("\n\n{label}:\n{content}"));
     }
 
     instr
@@ -170,15 +197,8 @@ pub fn find_subdirectory_instructions(
     let mut current = dir.as_path();
     while current != cwd {
         for filename in INSTRUCTION_FILES {
-            let Ok(canonical) = current.join(filename).canonicalize() else {
-                continue;
-            };
-            if loaded.contains_or_insert(canonical.clone()) {
-                continue;
-            }
-            if let Ok(content) = fs::read_to_string(&canonical) {
-                let display = canonical.display().to_string();
-                results.push((display, content));
+            if let Some((canonical, content)) = read_instruction(&current.join(filename), loaded) {
+                results.push((canonical.display().to_string(), content));
                 break;
             }
         }
@@ -311,6 +331,32 @@ mod tests {
         let text =
             load_instructions_with_home(cwd.path().to_str().unwrap(), Some(home.path()), None).text;
         assert!(text.contains("global rules"));
+    }
+
+    #[test]
+    fn load_instructions_includes_parent_directory_instructions() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join(".git")).unwrap();
+
+        let sub = dir.path().join("crates").join("a");
+        fs::create_dir_all(&sub).unwrap();
+
+        fs::write(dir.path().join("AGENTS.md"), "root rules").unwrap();
+        fs::write(sub.join("AGENTS.md"), "crate rules").unwrap();
+
+        let text = load_instructions_with_home(sub.to_str().unwrap(), None, None).text;
+        assert!(
+            text.contains("crate rules"),
+            "should load instructions from cwd"
+        );
+        assert!(
+            text.contains("root rules"),
+            "should load instructions from project root"
+        );
+        assert!(
+            text.find("root rules").unwrap() < text.find("crate rules").unwrap(),
+            "root instructions should come before closer instructions"
+        );
     }
 
     #[test]

--- a/maki-agent/src/command.rs
+++ b/maki-agent/src/command.rs
@@ -17,19 +17,16 @@ struct Frontmatter {
     argument_hint: Option<String>,
 }
 
-fn find_project_ancestor_dirs(cwd: &Path) -> Vec<PathBuf> {
-    let mut dirs = vec![cwd.to_path_buf()];
-    let mut current = cwd;
+pub(crate) fn find_project_ancestor_dirs(cwd: &Path) -> impl Iterator<Item = PathBuf> {
+    let mut current = Some(cwd.to_path_buf());
 
-    while let Some(parent) = current.parent() {
-        dirs.push(parent.to_path_buf());
-        if parent.join(".git").exists() {
-            break;
+    std::iter::from_fn(move || {
+        let dir = current.take()?;
+        if !dir.join(".git").exists() {
+            current = dir.parent().map(Path::to_path_buf);
         }
-        current = parent;
-    }
-
-    dirs
+        Some(dir)
+    })
 }
 
 fn parse_frontmatter(content: &str) -> (Frontmatter, &str) {
@@ -316,7 +313,7 @@ mod tests {
         fs::create_dir_all(&deep).unwrap();
         fs::create_dir_all(tmp.path().join("a/.git")).unwrap();
 
-        let dirs = find_project_ancestor_dirs(&deep);
+        let dirs: Vec<_> = find_project_ancestor_dirs(&deep).collect();
         let dir_strs: Vec<_> = dirs
             .iter()
             .map(|d| d.to_string_lossy().into_owned())


### PR DESCRIPTION
## Summary

Closes #486.

When maki starts in a subdirectory of a project (e.g. a cargo workspace sub-crate), it now walks ancestors up to the `.git` root and loads any project instruction files (`AGENTS.md` and friends) it finds along the way. Closer directories still take precedence in ordering.

- Extracts a shared `read_instruction` helper with canonicalization and `LoadedInstructions` deduplication.
- Reuses `command::find_project_ancestor_dirs` in `instructions.rs`.
- `find_project_ancestor_dirs` now stops at the directory that contains `.git`, avoiding scans above the project root.
- Fixes pre-existing clippy lints (`unwrap_or`, allow attribute).

## Impact

Maki now picks up root-level `AGENTS.md` files even when invoked from a subcrate or subdirectory, so project-wide instructions are never silently missed. Existing behavior when cwd is the project root is unchanged.

## Test plan
- `cargo clippy --all --tests -- -D warnings` passes.
- `cargo nextest run --workspace` — 3170 passed.
- New test: `load_instructions_includes_parent_directory_instructions` validates that closer instructions appear before root instructions.