### PR TITLE
fix(ui): preserve text selection while scrolling

### DIFF
--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -50,7 +50,7 @@ use crate::components::{
     Action, DisplayMessage, DisplayRole, ExitRequest, Overlay, RetryInfo, Status, is_ctrl,
 };
 use crate::image;
-use crate::selection::{SelectionState, ZoneRegistry};
+use crate::selection::{SelectionState, SelectionZone, ZoneRegistry};
 use arc_swap::{ArcSwap, ArcSwapOption};
 use crossterm::event::{KeyCode, KeyEvent, MouseEvent};
 use maki_agent::permissions::PermissionManager;
@@ -362,7 +362,6 @@ impl App {
                 vec![]
             }
             Msg::Scroll { column, row, delta } => {
-                self.clear_selection_unless_pending_copy();
                 self.handle_scroll(column, row, delta);
                 vec![]
             }
@@ -385,23 +384,23 @@ impl App {
         }
     }
 
-    fn handle_scroll(&mut self, column: u16, row: u16, delta: i32) {
+    fn scroll_at(&mut self, column: u16, row: u16, delta: i32) -> Option<SelectionZone> {
         if self.btw_modal.is_open() {
             self.btw_modal.scroll(delta);
-            return;
+            return None;
         }
         if self.help_modal.is_open() {
             self.help_modal.scroll(delta);
-            return;
+            return None;
         }
         if self.usage_modal.is_open() {
             self.usage_modal.scroll(delta);
-            return;
+            return None;
         }
         let pos = Position::new(column, row);
         if self.float_mgr.is_open() && self.float_mgr.contains(pos) {
             self.float_mgr.scroll(delta);
-            return;
+            return None;
         }
         macro_rules! try_picker {
             ($picker:expr) => {
@@ -409,7 +408,7 @@ impl App {
                     if $picker.contains(pos) {
                         $picker.scroll(delta);
                     }
-                    return;
+                    return None;
                 }
             };
         }
@@ -417,9 +416,9 @@ impl App {
         try_picker!(self.task_picker);
         try_picker!(self.model_picker);
         try_picker!(self.file_picker);
-        if let Some(zone) = self.zone_at(row, column) {
-            self.scroll_zone(zone.zone, delta);
-        }
+        let zone = self.zone_at(row, column)?.zone;
+        self.scroll_zone(zone, delta);
+        Some(zone)
     }
 
     fn open_tasks(&mut self) {

--- a/maki-ui/src/app/mouse.rs
+++ b/maki-ui/src/app/mouse.rs
@@ -53,6 +53,22 @@ impl App {
         }
     }
 
+    pub(super) fn handle_scroll(&mut self, column: u16, row: u16, delta: i32) {
+        let drag_zone = match self.selection_state {
+            Some(SelectionState::Dragging { ref sel, .. }) => Some(sel.zone),
+            _ => None,
+        };
+        match self.scroll_at(column, row, delta) {
+            Some(zone) if drag_zone == Some(zone) => {
+                let scroll = self.scroll_offset(zone);
+                if let Some(SelectionState::Dragging { sel, .. }) = &mut self.selection_state {
+                    sel.update(row, column, scroll);
+                }
+            }
+            _ => self.clear_selection_unless_pending_copy(),
+        }
+    }
+
     fn handle_drag(&mut self, row: u16, col: u16) {
         let (zone, area) = match self.selection_state {
             Some(SelectionState::Dragging {

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -1175,24 +1175,45 @@ fn make_pending_copy(app: &mut App) {
     app.update(mouse_event(MouseEventKind::Up(MouseButton::Left), 10, 10));
 }
 
+const DRAG_ROW: u16 = 5;
+const DRAG_COL: u16 = 5;
+const SCROLL_LINES: i32 = 3;
+const DRAG_ZONE_AREA: Rect = Rect {
+    x: 0,
+    y: 0,
+    width: 80,
+    height: 10,
+};
+const OTHER_ZONE_AREA: Rect = Rect {
+    x: 0,
+    y: DRAG_ZONE_AREA.height,
+    width: 80,
+    height: 10,
+};
+
 fn send_key(app: &mut App) {
     app.update(Msg::Key(key(KeyCode::Char('a'))));
 }
 
-fn send_scroll(app: &mut App) {
+fn send_scroll_outside_drag_zone(app: &mut App) {
     app.update(Msg::Scroll {
-        column: 10,
-        row: 10,
-        delta: 3,
+        column: DRAG_COL,
+        row: OTHER_ZONE_AREA.y + 1,
+        delta: SCROLL_LINES,
     });
 }
 
-#[test_case(send_key as fn(&mut App)    ; "key")]
-#[test_case(send_scroll as fn(&mut App) ; "scroll")]
+#[test_case(send_key as fn(&mut App) ; "key")]
+#[test_case(send_scroll_outside_drag_zone as fn(&mut App) ; "scroll_outside_drag_zone")]
 fn interrupt_clears_dragging_but_preserves_pending_copy(interrupt: fn(&mut App)) {
     let mut app = test_app();
-    set_zone(&mut app, SelectionZone::Messages, Rect::new(0, 0, 80, 20));
-    app.update(mouse_event(MouseEventKind::Down(MouseButton::Left), 5, 5));
+    set_zone(&mut app, SelectionZone::Messages, DRAG_ZONE_AREA);
+    set_zone(&mut app, SelectionZone::Input, OTHER_ZONE_AREA);
+    app.update(mouse_event(
+        MouseEventKind::Down(MouseButton::Left),
+        DRAG_COL,
+        DRAG_ROW,
+    ));
     interrupt(&mut app);
     assert!(app.selection_state.is_none(), "clears dragging");
 
@@ -1201,6 +1222,85 @@ fn interrupt_clears_dragging_but_preserves_pending_copy(interrupt: fn(&mut App))
     assert!(
         app.selection_state.as_ref().unwrap().is_pending_copy(),
         "preserves pending copy"
+    );
+}
+
+#[test]
+fn scroll_preserves_dragging_and_updates_cursor() {
+    let mut app = test_app();
+    for i in 0..50 {
+        app.active_chat()
+            .push(DisplayMessage::new(DisplayRole::User, format!("line {i}")));
+    }
+
+    let area = Rect::new(0, 0, 80, 20);
+    set_zone(&mut app, SelectionZone::Messages, area);
+
+    let backend = ratatui::backend::TestBackend::new(area.width, area.height);
+    let mut terminal = ratatui::Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            app.active_chat().view(frame, area, false);
+        })
+        .unwrap();
+
+    let max_scroll = app.active_chat().scroll_top();
+    assert!(
+        max_scroll > 0,
+        "scroll_top should be non-zero after rendering scrollable content"
+    );
+
+    app.update(Msg::Scroll {
+        column: DRAG_COL,
+        row: DRAG_ROW,
+        delta: SCROLL_LINES,
+    });
+    let scroll_before = app.active_chat().scroll_top();
+    assert!(
+        scroll_before < max_scroll,
+        "scroll up should move scroll_top away from max_scroll"
+    );
+
+    app.update(mouse_event(
+        MouseEventKind::Down(MouseButton::Left),
+        DRAG_COL,
+        DRAG_ROW,
+    ));
+
+    app.update(Msg::Scroll {
+        column: DRAG_COL,
+        row: DRAG_ROW,
+        delta: -SCROLL_LINES,
+    });
+
+    assert!(
+        matches!(
+            app.selection_state.as_ref().unwrap(),
+            SelectionState::Dragging { .. }
+        ),
+        "scroll keeps dragging"
+    );
+
+    let (start, end) = app.selection_state.as_ref().unwrap().sel().normalized();
+    let anchor_row = scroll_before as u32 + DRAG_ROW as u32;
+    assert_eq!(start.row, anchor_row, "anchor keeps its doc row");
+    assert_eq!(
+        end.row,
+        anchor_row + SCROLL_LINES as u32,
+        "cursor re-projects by the scrolled lines"
+    );
+    assert_eq!(start.col, DRAG_COL, "anchor column is unchanged");
+    assert_eq!(end.col, DRAG_COL, "cursor column is unchanged");
+
+    make_pending_copy(&mut app);
+    app.update(Msg::Scroll {
+        column: DRAG_COL,
+        row: DRAG_ROW,
+        delta: -SCROLL_LINES,
+    });
+    assert!(
+        app.selection_state.as_ref().unwrap().is_pending_copy(),
+        "scroll preserves pending copy"
     );
 }
 

--- a/maki-ui/src/components/input.rs
+++ b/maki-ui/src/components/input.rs
@@ -77,6 +77,8 @@ pub struct InputBox {
     placeholder_hint: &'static str,
     pending_images: Vec<ImageSource>,
     max_input_lines: u16,
+    last_total_lines: u16,
+    last_content_height: u16,
 }
 
 impl InputBox {
@@ -168,6 +170,8 @@ impl InputBox {
             placeholder_hint: random_placeholder_hint(),
             pending_images: Vec::new(),
             max_input_lines,
+            last_total_lines: 1,
+            last_content_height: 1,
         }
     }
 
@@ -338,7 +342,9 @@ impl InputBox {
         if !self.pending_images.is_empty() {
             total_vl += 1;
         }
-        let max_scroll = total_vl.saturating_sub(content_height);
+        self.last_total_lines = total_vl;
+        self.last_content_height = content_height.max(1);
+        let max_scroll = self.max_scroll();
         self.scroll_y = self.scroll_y.min(max_scroll);
 
         let is_empty = self.buffer.value().is_empty();
@@ -428,6 +434,11 @@ impl InputBox {
         }
     }
 
+    fn max_scroll(&self) -> u16 {
+        self.last_total_lines
+            .saturating_sub(self.last_content_height)
+    }
+
     pub fn scroll_y(&self) -> u16 {
         self.scroll_y
     }
@@ -437,7 +448,7 @@ impl InputBox {
     }
 
     pub fn scroll(&mut self, delta: i32) {
-        self.scroll_y = apply_scroll_delta(self.scroll_y, delta);
+        self.scroll_y = apply_scroll_delta(self.scroll_y, delta).min(self.max_scroll());
         self.follow_cursor = false;
     }
 }


### PR DESCRIPTION
## Summary
- Wheel scroll events over the messages panel and input box no longer clear an active drag selection.
- The selection cursor is re-projected with the new scroll offset, keeping the highlight anchored to the content.
- Pending-copy selections continue to be preserved on scroll.

## Test plan
- [x] `cargo clippy -p maki-ui --tests -- -D warnings`
- [x] `cargo nextest run -p maki-ui`
