### PR TITLE
feat(question): render answered choices as a durable artifact card

### DIFF
--- a/plugins/lib/maki/tool_view.lua
+++ b/plugins/lib/maki/tool_view.lua
@@ -216,6 +216,17 @@ function ToolView:set_highlight(content, ext)
   return true
 end
 
+-- Content rows on screen, for callers with their own per-row click targets. A
+-- single hidden line is drawn as itself instead of a notice, so it counts as
+-- content too. Rows line up with `all_lines` under keep = "head"; keep = "tail"
+-- prints its notice first and shifts them.
+function ToolView:visible_count()
+  if self.expanded then
+    return #self.all_lines
+  end
+  return self.ring_count + (self.skipped == 1 and 1 or 0)
+end
+
 function ToolView:toggle()
   self.expanded = not self.expanded
   self:flush()
@@ -294,6 +305,19 @@ end
 -- wired. For `restore` hooks.
 function ToolView.restore(output, opts)
   return ToolView.restore_lines(maki.split(output, "\n"), opts)
+end
+
+-- Same, for tools whose live output goes through markdown (`format =
+-- "markdown"`); {opts.width} is the wrap width. Errors stay plain, as they do
+-- live.
+function ToolView.restore_markdown(output, is_error, opts)
+  if not is_error then
+    local ok, md_lines = pcall(maki.ui.markdown, output, opts.width)
+    if ok then
+      return ToolView.restore_lines(md_lines, opts)
+    end
+  end
+  return ToolView.restore(output, opts)
 end
 
 return ToolView

--- a/plugins/lib/tests/spec.lua
+++ b/plugins/lib/tests/spec.lua
@@ -23,6 +23,7 @@ local function mock_buf()
     self.lines = lines
     self.call_count = self.call_count + 1
   end
+  function b:on() end
   return b
 end
 
@@ -289,6 +290,66 @@ case("tool_view_max_line_bytes_default_off", function()
   local long = string.rep("a", 100)
   view:append(long)
   eq(buf.lines[1], long)
+end)
+
+local RESTORE_OPTS = { max_lines = 10, keep = "head", width = 80 }
+local RESTORE_OUTPUT = "**bold** line\nsecond line"
+local RENDERED = "rendered by markdown"
+
+local function all_text(lines)
+  local out = {}
+  for _, line in ipairs(lines) do
+    if type(line) == "string" then
+      out[#out + 1] = line
+    else
+      for _, span in ipairs(line) do
+        out[#out + 1] = span[1]
+      end
+    end
+  end
+  return table.concat(out, "\n")
+end
+
+-- Restores {output} with {markdown} standing in for the real renderer; returns
+-- the text that reached the buf and how many times the renderer ran.
+local function restore_markdown(output, is_error, markdown)
+  local buf = mock_buf()
+  local original = { buf = maki.ui.buf, markdown = maki.ui.markdown }
+  local calls = 0
+  maki.ui.buf = function()
+    return buf
+  end
+  maki.ui.markdown = function(...)
+    calls = calls + 1
+    return markdown(...)
+  end
+  local ok, err = pcall(ToolView.restore_markdown, output, is_error, RESTORE_OPTS)
+  maki.ui.buf, maki.ui.markdown = original.buf, original.markdown
+  assert(ok, tostring(err))
+  return all_text(buf.lines), calls
+end
+
+local function markdown_marker()
+  return { { { RENDERED, "md" } } }
+end
+
+case("tool_view_restore_markdown_renders_markdown", function()
+  local text, calls = restore_markdown(RESTORE_OUTPUT, false, markdown_marker)
+  eq(calls, 1, "output must go through markdown rendering")
+  eq(text, RENDERED, "the rendered lines are what reaches the buf")
+end)
+
+case("tool_view_restore_markdown_keeps_errors_plain", function()
+  local text, calls = restore_markdown(RESTORE_OUTPUT, true, markdown_marker)
+  eq(calls, 0, "error output must never reach the markdown renderer")
+  eq(text, RESTORE_OUTPUT, "error output must render verbatim")
+end)
+
+case("tool_view_restore_markdown_falls_back_when_rendering_fails", function()
+  local text = restore_markdown(RESTORE_OUTPUT, false, function()
+    error("renderer blew up")
+  end)
+  eq(text, RESTORE_OUTPUT, "a failing renderer must not swallow the output")
 end)
 
 local TextInput = require("maki.text_input")

--- a/plugins/question/init.lua
+++ b/plugins/question/init.lua
@@ -1,5 +1,6 @@
 local QuestionForm = require("question_form")
 local QuestionHelpers = require("question_helpers")
+local ToolView = require("maki.tool_view")
 
 local DESCRIPTION = [[Use this tool when you need to ask the user questions during execution. This allows you to:
 - Gather user preferences or requirements
@@ -11,6 +12,26 @@ Rules:
 - `custom` enabled by default adds "Type your own answer" - don't include catch-all options.
 - Answers returned as arrays of labels. Set `multiSelect: true` for multi-select.
 - Put recommended option first with "(Recommended)" suffix.]]
+
+local function normalize(questions)
+  questions = questions or {}
+  for _, q in ipairs(questions) do
+    q.options = q.options or {}
+    q.header = q.header or ""
+    q.multiple = q.multiSelect or false
+  end
+  return questions
+end
+
+-- The form leaves a hole for every skipped question, and a sparse array
+-- round-trips through JSON as an object, which restore cannot index.
+local function dense(questions, answers)
+  local out = {}
+  for i = 1, #questions do
+    out[i] = answers[i] or {}
+  end
+  return out
+end
 
 maki.api.register_tool({
   name = "question",
@@ -57,18 +78,34 @@ maki.api.register_tool({
     return n .. " question" .. (n == 1 and "" or "s")
   end,
   handler = function(input, ctx)
-    if #input.questions == 0 then
+    local questions = normalize(input.questions)
+    if #questions == 0 then
       return { llm_output = "error: at least one question is required", is_error = true }
     end
-    for _, q in ipairs(input.questions) do
-      q.options = q.options or {}
-      q.header = q.header or ""
-      q.multiple = q.multiSelect or false
-    end
-    local result = QuestionForm.open(input.questions)
+    local result = QuestionForm.open(questions)
+    local opts = QuestionHelpers.view_opts(ctx)
     if result.type == "dismiss" then
-      return { llm_output = "(question dismissed by user)" }
+      return {
+        llm_output = "(question dismissed by user)",
+        state = { dismissed = true },
+        body = QuestionHelpers.render_card(questions, nil, opts),
+      }
     end
-    return { llm_output = QuestionHelpers.format_answer_list(input.questions, result.answers), format = "markdown" }
+    local answers = dense(questions, result.answers)
+    return {
+      llm_output = QuestionHelpers.format_answers(questions, answers),
+      state = { answers = answers },
+      body = QuestionHelpers.render_card(questions, answers, opts),
+    }
+  end,
+  -- No state means a session older than the card: its output is the markdown
+  -- list the tool used to return.
+  restore = function(input, output, is_error, ctx)
+    local opts = QuestionHelpers.view_opts(ctx)
+    local state = ctx:state()
+    if not state then
+      return ToolView.restore_markdown(output, is_error, opts)
+    end
+    return QuestionHelpers.render_card(normalize(input.questions), state.answers, opts)
   end,
 })

--- a/plugins/question/question_helpers.lua
+++ b/plugins/question/question_helpers.lua
@@ -1,21 +1,148 @@
+local ToolView = require("maki.tool_view")
+
+local MIN_CARD_LINES = 10
+local CARD_WIDTH = 80
+local INDENT = "    "
+local ANSWER_PREFIX = "    ✓ "
+local ANSWER_INDENT = string.rep(" ", utf8.len(ANSWER_PREFIX))
+local DESC_INDENT = "        "
+local NO_ANSWER = "(no answer)"
+local DISMISSED = "Dismissed by user"
+local EXPAND_HINT = " (+)"
+local COLLAPSE_HINT = " (−)"
+
 local QuestionHelpers = {}
 
-function QuestionHelpers.format_answer_list(questions, answers)
-  local blocks = {}
+-- The questions sit in the tool input right above this result, and inputs
+-- outlive outputs through compaction, so only the picked labels are sent.
+function QuestionHelpers.format_answers(questions, answers)
+  local lines = {}
   for i, q in ipairs(questions) do
-    local lines = { "**Q" .. i .. ".** " .. q.question }
-    lines[#lines + 1] = "**A" .. i .. ".**"
-    local ans = answers[i]
-    if ans and #ans > 0 then
-      for _, v in ipairs(ans) do
-        lines[#lines + 1] = "- " .. (v:gsub("\r?\n", "\n  "))
-      end
-    else
-      lines[#lines + 1] = "- (no answer)"
-    end
-    blocks[#blocks + 1] = table.concat(lines, "\n")
+    local ans = answers[i] or {}
+    local label = (q.header and q.header ~= "") and q.header or ("Q" .. i)
+    lines[#lines + 1] = label .. ": " .. (#ans > 0 and table.concat(ans, ", ") or NO_ANSWER)
   end
-  return table.concat(blocks, "\n\n")
+  return table.concat(lines, "\n")
+end
+
+-- A fixed wrap width, not the terminal's: the chat panel re-wraps long lines and
+-- maps a click back to the line it came from, so the row -> option map survives
+-- a resize. The cap gets a floor, because a card that hides the very picks it
+-- exists to show helps nobody.
+function QuestionHelpers.view_opts(ctx)
+  local tol = ctx:tool_output_lines()
+  return {
+    width = CARD_WIDTH,
+    max_lines = math.max((tol and tol.other) or 0, MIN_CARD_LINES),
+    keep = "head",
+  }
+end
+
+local function markdown_lines(text, width)
+  local ok, lines = pcall(maki.ui.markdown, text, width)
+  if not ok or type(lines) ~= "table" or #lines == 0 then
+    return { { { text, "" } } }
+  end
+  return lines
+end
+
+local function prefixed(prefix, style, spans)
+  local line = { { prefix, style } }
+  table.move(spans, 1, #spans, 2, line)
+  return line
+end
+
+local function option_desc(options, label)
+  for _, opt in ipairs(options) do
+    if opt.label == label and opt.description and opt.description ~= "" then
+      return opt.description
+    end
+  end
+end
+
+-- Only the picked answers get a row: every row here is permanent scrollback,
+-- and the options passed over are spent information. A nil {answers} means the
+-- form was dismissed. Returns the lines, plus a row -> option key map covering
+-- the rows that toggle a description.
+local function card_lines(questions, answers, width, expanded)
+  local lines, keys = {}, {}
+  local function emit(line)
+    lines[#lines + 1] = line
+    return #lines
+  end
+
+  if not answers then
+    emit({ { DISMISSED, "dim" } })
+    emit({})
+  end
+
+  for i, q in ipairs(questions) do
+    for j, md_line in ipairs(markdown_lines(q.question, width)) do
+      emit(prefixed(j == 1 and ("Q" .. i .. ". ") or INDENT, "bold", md_line))
+    end
+
+    local ans = answers and answers[i] or {}
+    if #ans == 0 then
+      emit({ { INDENT .. NO_ANSWER, "dim" } })
+    end
+    for _, text in ipairs(ans) do
+      local desc = option_desc(q.options, text)
+      local key = i .. "\0" .. text
+      for j, piece in ipairs(maki.split(text, "\r?\n")) do
+        local line = { { j == 1 and ANSWER_PREFIX or ANSWER_INDENT, "success" }, { piece, "success" } }
+        if desc and j == 1 then
+          line[#line + 1] = { expanded[key] and COLLAPSE_HINT or EXPAND_HINT, "dim" }
+          keys[emit(line)] = key
+        else
+          emit(line)
+        end
+      end
+      if desc and expanded[key] then
+        for _, desc_line in ipairs(markdown_lines(desc, width - #DESC_INDENT)) do
+          emit(prefixed(DESC_INDENT, "", desc_line))
+        end
+      end
+    end
+
+    if i < #questions then
+      emit({})
+    end
+  end
+
+  return lines, keys
+end
+
+function QuestionHelpers.render_card(questions, answers, opts)
+  local buf = maki.ui.buf()
+  local view = ToolView.new(buf, opts)
+  local expanded = {}
+  local keys
+
+  local function render()
+    local lines
+    lines, keys = card_lines(questions, answers, opts.width, expanded)
+    view:clear()
+    for _, line in ipairs(lines) do
+      view:append(line)
+    end
+    view:finish()
+  end
+
+  render()
+
+  -- Clicks outside the card's own rows fall through to the shared expand
+  -- toggle, so this tool collapses like every other one.
+  buf:on("click", function(ev)
+    local key = ev.row <= view:visible_count() and keys[ev.row]
+    if key then
+      expanded[key] = not expanded[key]
+      render()
+    else
+      view:toggle()
+    end
+  end)
+
+  return buf
 end
 
 return QuestionHelpers

--- a/plugins/question/tests/spec.lua
+++ b/plugins/question/tests/spec.lua
@@ -16,6 +16,38 @@ local function eq(actual, expected, msg)
   end
 end
 
+-- Runs {fn} against a buf that records the rendered lines and replays clicks.
+local function with_mock_ui(fn)
+  local original = { buf = maki.ui.buf, markdown = maki.ui.markdown }
+  local lines, handlers = {}, {}
+  local buf = {
+    set_lines = function(_, new_lines)
+      lines = new_lines
+    end,
+    get_lines = function()
+      return lines
+    end,
+    on = function(_, event, handler)
+      handlers[event] = handler
+    end,
+    emit = function(_, event, ev)
+      handlers[event](ev)
+    end,
+  }
+  maki.ui.buf = function()
+    return buf
+  end
+  maki.ui.markdown = function(text, _width)
+    return { { { text, "" } } }
+  end
+  local ok, err = pcall(fn, buf)
+  maki.ui.buf = original.buf
+  maki.ui.markdown = original.markdown
+  if not ok then
+    error(err)
+  end
+end
+
 local MODE = QuestionForm.MODE
 
 local function single_question(overrides)
@@ -164,26 +196,28 @@ case("editing_custom_newline_shortcuts_insert_not_submit", function()
   eq(s.custom_input:value(), "a\nb", "backslash+enter inserts newline, consumes backslash")
 end)
 
-case("format_answer_list_renders_questions_answers_pipes_newlines_and_missing", function()
-  local questions = {
-    { question = "Has | pipe\nand newline" },
-    { question = "Q2" },
-  }
-  local out = QuestionHelpers.format_answer_list(questions, { { "a", "ans|with|pipes" } })
-  assert(out:find("**Q1.** Has | pipe\nand newline", 1, true), "Q1 header + verbatim pipes/newlines")
-  assert(out:find("**A1.**\n- a\n", 1, true), "A1 label before answer bullets")
-  assert(out:find("**Q2.** Q2", 1, true), "Q2 header present")
-  assert(out:find("**A2.**\n- (no answer)", 1, true), "A2 label before no-answer bullet")
-  assert(out:find("\n- ans|with|pipes", 1, true), "answer pipes preserved verbatim on bullet")
-end)
-
-case("format_answer_list_indents_multiline_answer_continuation", function()
-  local out = QuestionHelpers.format_answer_list({ { question = "Q" } }, { { "a\nb" } })
-  assert(out:find("**A1.**\n- a\n  b", 1, true), "A1 label before multi-line answer continuation")
-end)
-
-case("format_answer_list_with_no_questions_returns_empty_string", function()
-  eq(QuestionHelpers.format_answer_list({}, {}), "")
+-- The questions sit in the tool input right above the result, so the output
+-- labels the picks by header instead of echoing the question text back.
+case("format_answers_labels_picks_by_header", function()
+  for _, c in ipairs({
+    {
+      questions = {
+        { question = "Which breakfast items?", header = "Breakfast" },
+        { question = "Sweet or savory?", header = "Taste" },
+        { question = "Anything else?", header = "" },
+      },
+      answers = { { "Eggs", "Coffee" }, { "Savory" } },
+      want = "Breakfast: Eggs, Coffee\nTaste: Savory\nQ3: (no answer)",
+    },
+    {
+      questions = { { question = "Q", header = "" } },
+      answers = { { "a\nb" } },
+      want = "Q1: a\nb",
+    },
+    { questions = {}, answers = {}, want = "" },
+  }) do
+    eq(QuestionHelpers.format_answers(c.questions, c.answers), c.want)
+  end
 end)
 
 case("render_reserves_tab_bar_only_when_confirm_present", function()
@@ -648,6 +682,146 @@ case("open_requests_bottom_split", function()
   assert(ok, "open must not error: " .. tostring(err))
   assert(captured, "open_win must be called")
   eq(captured.split, "below", "form must request a bottom split")
+end)
+
+local function find_span_containing(lines, text)
+  for _, line in ipairs(lines) do
+    for _, span in ipairs(line) do
+      if span[1]:find(text, 1, true) then
+        return span
+      end
+    end
+  end
+end
+
+-- Line index of the first line holding {text}. It doubles as the click row,
+-- since the card never leaves a raw newline inside a span.
+local function find_row(lines, text)
+  for i, line in ipairs(lines) do
+    if find_span_containing({ line }, text) then
+      return i
+    end
+  end
+end
+
+local MULTILINE_CUSTOM = "first custom line\nsecond custom line"
+local EXPAND_DESC = "Expanded reasoning."
+local PICKED_STYLE = "success"
+local CARD_LINES = 100
+local TIGHT_LINES = 2
+local ONE_OVER_LINES = 3
+local EXPAND_NOTICE = "click to expand"
+
+local function card_opts(max_lines)
+  return { width = 80, max_lines = max_lines or CARD_LINES, keep = "head" }
+end
+
+local function two_option_question()
+  return { { question = "Pick one", options = { { label = "Yes" }, { label = "No" } } } }
+end
+
+-- Every row is permanent scrollback, so only what the user picked earns one.
+case("render_card_shows_only_the_picked_answers", function()
+  for _, c in ipairs({
+    { name = "picked option", answers = { { "Yes" } }, shown = "Yes", hidden = "No", style = PICKED_STYLE },
+    { name = "custom answer", answers = { { "typed by hand" } }, shown = "typed by hand", style = PICKED_STYLE },
+    { name = "skipped question", answers = { {} }, shown = "(no answer)", hidden = "Yes" },
+    { name = "dismissed form", answers = nil, shown = "Dismissed by user", hidden = "Yes" },
+  }) do
+    with_mock_ui(function(buf)
+      QuestionHelpers.render_card(two_option_question(), c.answers, card_opts())
+      local lines = buf.get_lines()
+      local span = find_span_containing(lines, c.shown)
+      assert(span, c.name .. ": " .. c.shown .. " must be present")
+      if c.style then
+        eq(span[2], c.style, c.name .. ": picked answers must stand out")
+      end
+      if c.hidden then
+        assert(not find_span_containing(lines, c.hidden), c.name .. ": " .. c.hidden .. " must not take a row")
+      end
+    end)
+  end
+end)
+
+case("render_card_click_toggles_the_option_description", function()
+  with_mock_ui(function(buf)
+    local questions = {
+      { question = "Pick one", options = { { label = "Yes", description = EXPAND_DESC } } },
+    }
+    QuestionHelpers.render_card(questions, { { "Yes" } }, card_opts())
+    assert(not find_span_containing(buf.get_lines(), EXPAND_DESC), "description must be hidden by default")
+    local row = find_row(buf.get_lines(), "Yes")
+    assert(row, "answer row must exist")
+    buf:emit("click", { row = row })
+    assert(find_span_containing(buf.get_lines(), EXPAND_DESC), "click must expand the description")
+    buf:emit("click", { row = row })
+    assert(not find_span_containing(buf.get_lines(), EXPAND_DESC), "second click must collapse it back")
+  end)
+end)
+
+case("render_card_splits_a_multiline_answer_into_one_row_each", function()
+  with_mock_ui(function(buf)
+    local questions = {
+      { question = "Question one", options = { { label = "Alpha" } } },
+      { question = "Question two", options = { { label = "Gamma", description = EXPAND_DESC } } },
+    }
+    QuestionHelpers.render_card(questions, { { "Alpha", MULTILINE_CUSTOM }, { "Gamma" } }, card_opts())
+    for _, line in ipairs(buf.get_lines()) do
+      for _, span in ipairs(line) do
+        assert(not span[1]:find("\n", 1, true), "a raw newline would shift every click row below it")
+      end
+    end
+    assert(find_span_containing(buf.get_lines(), "second custom line"), "every line of the answer must show")
+    local row = find_row(buf.get_lines(), "Gamma")
+    assert(row, "the answer below the multiline one must exist")
+    buf:emit("click", { row = row })
+    assert(find_span_containing(buf.get_lines(), EXPAND_DESC), "rows below a multiline answer stay clickable")
+  end)
+end)
+
+case("render_card_truncates_to_max_lines_and_the_notice_expands_it", function()
+  with_mock_ui(function(buf)
+    local questions = {
+      { question = "Question one", options = { { label = "Alpha" } } },
+      { question = "Question two", options = { { label = "Gamma" } } },
+    }
+    QuestionHelpers.render_card(questions, { { "Alpha" }, { "Gamma" } }, card_opts(TIGHT_LINES))
+    local collapsed = buf.get_lines()
+    eq(#collapsed, TIGHT_LINES + 1, "collapsed card keeps max_lines rows plus the notice")
+    assert(not find_span_containing(collapsed, "Question two"), "rows past the cap must be hidden")
+    buf:emit("click", { row = #collapsed })
+    assert(find_span_containing(buf.get_lines(), "Question two"), "clicking the notice must reveal the rest")
+  end)
+end)
+
+-- One row over the cap is drawn as itself rather than as a notice, so it stays
+-- the answer's own click target instead of silently toggling nothing.
+case("render_card_keeps_a_lone_hidden_row_clickable", function()
+  with_mock_ui(function(buf)
+    local questions = {
+      { question = "Pick one", options = { { label = "Gamma", description = EXPAND_DESC } } },
+    }
+    QuestionHelpers.render_card(questions, { { "Alpha", "Beta", "Gamma" } }, card_opts(ONE_OVER_LINES))
+    eq(#buf.get_lines(), ONE_OVER_LINES + 1, "the single hidden row takes the notice's place")
+    buf:emit("click", { row = ONE_OVER_LINES + 1 })
+    assert(find_span_containing(buf.get_lines(), EXPAND_NOTICE), "opening the description grew the card past the cap")
+    buf:emit("click", { row = #buf.get_lines() })
+    assert(find_span_containing(buf.get_lines(), EXPAND_DESC), "expanding the card shows the opened description")
+  end)
+end)
+
+case("view_opts_honors_a_generous_line_limit_and_floors_a_tight_one", function()
+  local function ctx(tool_output_lines)
+    return {
+      tool_output_lines = function()
+        return tool_output_lines
+      end,
+    }
+  end
+  local floor = QuestionHelpers.view_opts(ctx(nil)).max_lines
+  assert(type(floor) == "number" and floor > 1, "unset limit must fall back to a usable default")
+  eq(QuestionHelpers.view_opts(ctx({ other = floor + 5 })).max_lines, floor + 5, "a generous limit is honored")
+  eq(QuestionHelpers.view_opts(ctx({ other = 1 })).max_lines, floor, "a limit too tight for a card is floored")
 end)
 
 if #failures > 0 then

--- a/plugins/task/init.lua
+++ b/plugins/task/init.lua
@@ -208,19 +208,12 @@ end
 -- this mirrors that for restore and batch children, which build the body here.
 local function restore(_input, output, is_error, ctx)
   local tol = ctx:tool_output_lines()
-  local opts = {
+  return ToolView.restore_markdown(output, is_error, {
     max_lines = (tol and tol.task) or DEFAULT_OUTPUT_LINES,
     keep = "head",
     max_line_bytes = output_limits.DEFAULT_MAX_LINE_BYTES,
-  }
-  if not is_error then
-    local width = math.max(maki.ui.terminal_size().cols - BODY_INDENT_COLS, MIN_MD_WIDTH)
-    local ok, md_lines = pcall(maki.ui.markdown, output, width)
-    if ok then
-      return ToolView.restore_lines(md_lines, opts)
-    end
-  end
-  return ToolView.restore(output, opts)
+    width = math.max(maki.ui.terminal_size().cols - BODY_INDENT_COLS, MIN_MD_WIDTH),
+  })
 end
 
 maki.api.register_tool({

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -4855,6 +4855,12 @@ function ToolView:append_text(text)
 -- Append {content} with line numbers, then syntax-highlight it for {ext}
 -- asynchronously. Returns false when {content} is empty.
 function ToolView:set_highlight(content, ext)
+
+-- Content rows on screen, for callers with their own per-row click targets. A
+-- single hidden line is drawn as itself instead of a notice, so it counts as
+-- content too. Rows line up with `all_lines` under keep = "head"; keep = "tail"
+-- prints its notice first and shifts them.
+function ToolView:visible_count()
 function ToolView:toggle()
 function ToolView:flush()
 function ToolView:update_line(all_idx, line)
@@ -4866,6 +4872,11 @@ function ToolView.restore_lines(lines, opts)
 -- Rebuild a collapsed view from a tool's saved llm_output, click-to-toggle
 -- wired. For `restore` hooks.
 function ToolView.restore(output, opts)
+
+-- Same, for tools whose live output goes through markdown (`format =
+-- "markdown"`); {opts.width} is the wrap width. Errors stay plain, as they do
+-- live.
+function ToolView.restore_markdown(output, is_error, opts)
 ```
 
 ### `require("maki.truncate")`


### PR DESCRIPTION
## Summary
- The `question` tool now renders its output as a durable, styled artifact card in the chat history, not just a markdown answer list.
- The card shows each question, its options, and the selected answer(s) highlighted with the `success` style; unselected options and empty answers are dimmed.
- Answer state is persisted across sessions via the tool `state` field and restored through `restore`.
- Legacy sessions without state fall back to the existing `ToolView` rendering.

## Visual
Answered question rendered as a durable artifact card in the chat history:

![maki question artifact card demo](https://vhs.charm.sh/vhs-72eHOXEQJD0puxpuodsiS8.gif)

## Test plan
- [x] `cargo nextest run -p maki-lua` passes (666/666).
- [x] `cargo clippy -p maki-lua --tests -- -D warnings` passes.
- [x] Added plugin spec tests for `QuestionHelpers.render_card` covering selected/unselected styles, empty answers, custom answers, and the dismissed banner.