### PR TITLE
fix(fs): support directory removal in maki.fs.rm

### DIFF
--- a/maki-lua/src/api/fs.rs
+++ b/maki-lua/src/api/fs.rs
@@ -436,17 +436,51 @@ async fn write(lua: Lua, path: String, content: String) -> LuaResult<(Value, Val
     result_pair(&lua, smol::fs::write(&abs, content).await.map(|()| true))
 }
 
-/// Delete the file at {path}. Does not remove directories.
+/// Delete the file, symlink, or directory at {path}.
+/// Pass `recursive = true` to remove a non-empty directory tree (like `rm -r`).
+/// Unlike `vim.fs.rm`, this also removes an empty directory without `recursive`.
+/// Symlinks are removed themselves, never followed.
 ///
-/// @param path string Path to the file to remove.
+/// @param path string Path to the file or directory to remove.
+/// @param opts table? `recursive` (boolean, default false): remove a directory and its contents recursively. `force` (boolean, default false): silently ignore a missing path.
 /// @return (true?, string?) `true` on success, or nil plus an error message.
 /// @example
 /// local ok, err = maki.fs.rm("temp.txt")
 /// if err then print("rm failed: " .. err) end
+/// maki.fs.rm("stale_dir", { recursive = true, force = true })
 #[lua_fn(guard = FsWrite)]
-async fn rm(lua: Lua, path: String) -> LuaResult<(Value, Value)> {
+async fn rm(lua: Lua, path: String, opts: Option<Table>) -> LuaResult<(Value, Value)> {
     let abs = make_absolute(&path)?;
-    result_pair(&lua, smol::fs::remove_file(&abs).await.map(|()| true))
+    let recursive = opts
+        .as_ref()
+        .and_then(|t| t.get::<bool>("recursive").ok())
+        .unwrap_or(false);
+    let force = opts
+        .as_ref()
+        .and_then(|t| t.get::<bool>("force").ok())
+        .unwrap_or(false);
+    let result = smol::unblock(move || -> std::io::Result<()> {
+        let meta = match std::fs::symlink_metadata(&abs) {
+            Ok(m) => m,
+            Err(e) if force && e.kind() == ErrorKind::NotFound => return Ok(()),
+            Err(e) => return Err(e),
+        };
+        if meta.is_dir() {
+            if recursive {
+                std::fs::remove_dir_all(&abs)
+            } else {
+                std::fs::remove_dir(&abs)
+            }
+        } else {
+            match std::fs::remove_file(&abs) {
+                Ok(()) => Ok(()),
+                Err(e) if meta.file_type().is_symlink() => std::fs::remove_dir(&abs).map_err(|_| e),
+                Err(e) => Err(e),
+            }
+        }
+    })
+    .await;
+    result_pair(&lua, result.map(|()| true))
 }
 
 /// Create the directory at {path}. Set `parents = true` to create
@@ -937,6 +971,142 @@ mod tests {
             "should fail for nonexistent"
         );
         assert!(matches!(err, mlua::Value::String(_)));
+    }
+
+    #[test]
+    fn rm_force_ignores_missing() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("ghost.txt");
+
+        let lua = Lua::new();
+        let tbl = create_fs_table(&lua, &PluginPermissions::trusted()).unwrap();
+        let rm: mlua::Function = tbl.get("rm").unwrap();
+        let opts = lua.create_table().unwrap();
+        opts.set("force", true).unwrap();
+        let (ok, err): (mlua::Value, mlua::Value) =
+            smol::block_on(rm.call_async((file.to_str().unwrap(), opts))).unwrap();
+        assert!(
+            matches!(ok, mlua::Value::Boolean(true)),
+            "force should suppress NotFound"
+        );
+        assert!(matches!(err, mlua::Value::Nil));
+    }
+
+    #[test]
+    fn rm_force_ignores_missing_dir() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("never_existed");
+
+        let lua = Lua::new();
+        let tbl = create_fs_table(&lua, &PluginPermissions::trusted()).unwrap();
+        let rm: mlua::Function = tbl.get("rm").unwrap();
+        let opts = lua.create_table().unwrap();
+        opts.set("recursive", true).unwrap();
+        opts.set("force", true).unwrap();
+        let (ok, err): (mlua::Value, mlua::Value) =
+            smol::block_on(rm.call_async((dir.to_str().unwrap(), opts))).unwrap();
+        assert!(matches!(ok, mlua::Value::Boolean(true)));
+        assert!(matches!(err, mlua::Value::Nil));
+    }
+
+    #[test]
+    fn rm_empty_dir_without_recursive() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("emptydir");
+        std::fs::create_dir(&dir).unwrap();
+
+        let lua = Lua::new();
+        let tbl = create_fs_table(&lua, &PluginPermissions::trusted()).unwrap();
+        let rm: mlua::Function = tbl.get("rm").unwrap();
+        let (ok, _): (mlua::Value, mlua::Value) =
+            smol::block_on(rm.call_async(dir.to_str().unwrap())).unwrap();
+        assert!(matches!(ok, mlua::Value::Boolean(true)));
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn rm_nonempty_dir_without_recursive_fails() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("nonempty");
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::write(dir.join("child.txt"), "x").unwrap();
+
+        let lua = Lua::new();
+        let tbl = create_fs_table(&lua, &PluginPermissions::trusted()).unwrap();
+        let rm: mlua::Function = tbl.get("rm").unwrap();
+        let (ok, err): (mlua::Value, mlua::Value) =
+            smol::block_on(rm.call_async(dir.to_str().unwrap())).unwrap();
+        assert!(
+            matches!(ok, mlua::Value::Nil),
+            "should fail without recursive"
+        );
+        assert!(matches!(err, mlua::Value::String(_)));
+        assert!(dir.exists(), "non-empty dir should still exist");
+    }
+
+    #[test]
+    fn rm_recursive_removes_tree() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("tree");
+        std::fs::create_dir_all(dir.join("sub/deeper")).unwrap();
+        std::fs::write(dir.join("a.txt"), "a").unwrap();
+        std::fs::write(dir.join("sub/b.txt"), "b").unwrap();
+        std::fs::write(dir.join("sub/deeper/c.txt"), "c").unwrap();
+
+        let lua = Lua::new();
+        let tbl = create_fs_table(&lua, &PluginPermissions::trusted()).unwrap();
+        let rm: mlua::Function = tbl.get("rm").unwrap();
+        let opts = lua.create_table().unwrap();
+        opts.set("recursive", true).unwrap();
+        let (ok, _): (mlua::Value, mlua::Value) =
+            smol::block_on(rm.call_async((dir.to_str().unwrap(), opts))).unwrap();
+        assert!(matches!(ok, mlua::Value::Boolean(true)));
+        assert!(!dir.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rm_symlink_removes_link_not_target() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("target.txt");
+        std::fs::write(&target, "data").unwrap();
+        let link = tmp.path().join("link.txt");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let lua = Lua::new();
+        let tbl = create_fs_table(&lua, &PluginPermissions::trusted()).unwrap();
+        let rm: mlua::Function = tbl.get("rm").unwrap();
+        let (ok, _): (mlua::Value, mlua::Value) =
+            smol::block_on(rm.call_async(link.to_str().unwrap())).unwrap();
+        assert!(matches!(ok, mlua::Value::Boolean(true)));
+        assert!(!link.exists(), "symlink should be removed");
+        assert!(target.exists(), "target should remain");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rm_recursive_symlink_to_dir_does_not_follow() {
+        let tmp = TempDir::new().unwrap();
+        let real_dir = tmp.path().join("real");
+        std::fs::create_dir_all(real_dir.join("sub")).unwrap();
+        std::fs::write(real_dir.join("sub/keep.txt"), "data").unwrap();
+        let link = tmp.path().join("link");
+        std::os::unix::fs::symlink(&real_dir, &link).unwrap();
+
+        let lua = Lua::new();
+        let tbl = create_fs_table(&lua, &PluginPermissions::trusted()).unwrap();
+        let rm: mlua::Function = tbl.get("rm").unwrap();
+        let opts = lua.create_table().unwrap();
+        opts.set("recursive", true).unwrap();
+        let (ok, _): (mlua::Value, mlua::Value) =
+            smol::block_on(rm.call_async((link.to_str().unwrap(), opts))).unwrap();
+        assert!(matches!(ok, mlua::Value::Boolean(true)));
+        assert!(!link.exists(), "symlink should be removed");
+        assert!(real_dir.exists(), "target dir should remain");
+        assert!(
+            real_dir.join("sub/keep.txt").exists(),
+            "target dir contents should remain"
+        );
     }
 
     #[test]

--- a/plugins/memory/tests/spec.lua
+++ b/plugins/memory/tests/spec.lua
@@ -31,18 +31,7 @@ local function mktmpdir()
 end
 
 local function rmtree(dir)
-  local entries = maki.fs.dir(dir)
-  if entries then
-    for _, e in ipairs(entries) do
-      local p = maki.fs.joinpath(dir, e[1])
-      if e[2] == "directory" then
-        rmtree(p)
-      else
-        maki.fs.rm(p)
-      end
-    end
-  end
-  maki.fs.rm(dir)
+  maki.fs.rm(dir, { recursive = true })
 end
 
 case("fnv1a_known_vectors", function()

--- a/plugins/read/tests/spec.lua
+++ b/plugins/read/tests/spec.lua
@@ -82,18 +82,7 @@ local function mktmpdir()
 end
 
 local function rmtree(dir)
-  local entries = maki.fs.dir(dir)
-  if entries then
-    for _, e in ipairs(entries) do
-      local p = maki.fs.joinpath(dir, e[1])
-      if e[2] == "directory" then
-        rmtree(p)
-      else
-        maki.fs.rm(p)
-      end
-    end
-  end
-  maki.fs.rm(dir)
+  maki.fs.rm(dir, { recursive = true })
 end
 
 -- line_nr_fmt: table-driven across all boundaries + alignment

--- a/plugins/write/tests/spec.lua
+++ b/plugins/write/tests/spec.lua
@@ -22,18 +22,7 @@ local function mktmpdir()
 end
 
 local function rmtree(dir)
-  local entries = maki.fs.dir(dir)
-  if entries then
-    for _, e in ipairs(entries) do
-      local p = maki.fs.joinpath(dir, e[1])
-      if e[2] == "directory" then
-        rmtree(p)
-      else
-        maki.fs.rm(p)
-      end
-    end
-  end
-  maki.fs.rm(dir)
+  maki.fs.rm(dir, { recursive = true })
 end
 
 case("write_new_file_succeeds", function()

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -1723,14 +1723,18 @@ if err then print("write failed: " .. err) end
 ### `maki.fs.rm()` {#maki-fs-rm}
 
 ```lua
-maki.fs.rm({path})
+maki.fs.rm({path}, {opts?})
 ```
 
-Delete the file at {path}. Does not remove directories.
+Delete the file, symlink, or directory at {path}.
+Pass `recursive = true` to remove a non-empty directory tree (like `rm -r`).
+Unlike `vim.fs.rm`, this also removes an empty directory without `recursive`.
+Symlinks are removed themselves, never followed.
 
 **Parameters:**
 
-- `{path}` (`string`) Path to the file to remove.
+- `{path}` (`string`) Path to the file or directory to remove.
+- `{opts?}` (`table?`) `recursive` (boolean, default false): remove a directory and its contents recursively. `force` (boolean, default false): silently ignore a missing path.
 
 **Returns:** (`true?`, `string?`) `true` on success, or nil plus an error message.
 
@@ -1739,6 +1743,7 @@ Delete the file at {path}. Does not remove directories.
 ```lua
 local ok, err = maki.fs.rm("temp.txt")
 if err then print("rm failed: " .. err) end
+maki.fs.rm("stale_dir", { recursive = true, force = true })
 ```
 
 ---


### PR DESCRIPTION
After running a bunch of tests, I noticed that `maki` had polluted my `/tmp/` directory and not cleaned anything up. Here's a PR about it.