### PR TITLE
feat(agent): tool search and deferred loading

### DIFF
--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -16,10 +16,12 @@ use super::tool_dispatch::{self, RecentCalls};
 use crate::cancel::{CancelMap, CancelToken};
 use crate::mcp::McpHandle;
 use crate::permissions::PermissionManager;
-use crate::tools::{Deadline, FileReadTracker, LocalTools, ToolAudience, ToolContext};
+use crate::tools::{
+    ActiveTools, Deadline, FileReadTracker, LocalTools, ToolAudience, ToolContext, ToolFilter,
+};
 use crate::{
     AgentConfig, AgentError, AgentEvent, AgentInput, AgentMode, EventSender, ExtractedCommand,
-    InterruptSource, TurnCompleteEvent,
+    InterruptSource, ToolDoneEvent, TurnCompleteEvent,
 };
 use maki_config::ToolOutputLines;
 use maki_storage::id::SessionRef;
@@ -70,6 +72,7 @@ pub struct AgentRunParams<'h> {
     pub system: String,
     pub event_tx: EventSender,
     pub tools: Value,
+    pub tool_filter: ToolFilter,
 }
 
 pub struct Agent<'h> {
@@ -106,11 +109,15 @@ pub struct Agent<'h> {
     audience: ToolAudience,
     workflow: bool,
     local_tools: LocalTools,
+    tool_filter: ToolFilter,
+    active_tools: ActiveTools,
+    supports_tool_examples: bool,
 }
 
 impl<'h> Agent<'h> {
     pub fn new(params: AgentParams, run: AgentRunParams<'h>) -> Self {
-        Self {
+        let supports_tool_examples = params.model.supports_tool_examples();
+        let mut agent = Self {
             provider: params.provider,
             model: Arc::new(params.model),
             config: params.config,
@@ -144,7 +151,12 @@ impl<'h> Agent<'h> {
             audience: params.audience,
             workflow: false,
             local_tools: LocalTools::default(),
-        }
+            tool_filter: run.tool_filter,
+            active_tools: ActiveTools::default(),
+            supports_tool_examples,
+        };
+        agent.warm_active_tools();
+        agent
     }
 
     pub fn with_mcp(mut self, mcp: Option<McpHandle>) -> Self {
@@ -277,7 +289,10 @@ impl<'h> Agent<'h> {
 
         if has_tools {
             let history_len_before = self.history.len();
-            self.process_tool_calls(response).await?;
+            let tool_results = self.process_tool_calls(response).await?;
+            if self.apply_tool_search_results(&tool_results) {
+                self.rebuild_tools();
+            }
             self.context_size +=
                 estimate_message_tokens(&self.history.as_slice()[history_len_before..]);
         } else {
@@ -374,7 +389,10 @@ impl<'h> Agent<'h> {
         })
     }
 
-    async fn process_tool_calls(&mut self, response: StreamResponse) -> Result<(), AgentError> {
+    async fn process_tool_calls(
+        &mut self,
+        response: StreamResponse,
+    ) -> Result<Vec<ToolDoneEvent>, AgentError> {
         self.post_tool_empty_retried = false;
         let ctx = self.tool_context();
         tool_dispatch::process_tool_calls(
@@ -414,6 +432,69 @@ impl<'h> Agent<'h> {
             local_tools: Arc::clone(&self.local_tools),
             live_sink: None,
         }
+    }
+
+    fn rebuild_tools(&mut self) {
+        let vars = crate::template::env_vars();
+        let ctx = crate::tools::DescriptionContext {
+            filter: &self.tool_filter,
+            audience: self.audience,
+            workflow: self.workflow,
+        };
+        let mut tools = self.registry.definitions_active(
+            &vars,
+            &ctx,
+            self.supports_tool_examples,
+            &self.active_tools,
+        );
+        if let Some(mcp) = &self.mcp {
+            mcp.extend_tools(&mut tools);
+        }
+        self.tools = tools;
+    }
+
+    fn warm_active_tools(&mut self) {
+        let Some(arr) = self.tools.as_array() else {
+            return;
+        };
+        for def in arr {
+            let Some(name) = def.get("name").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            if let Some(entry) = self.registry.get(name) && entry.defer_loading {
+                self.active_tools.names.insert(name.to_owned());
+            }
+        }
+    }
+
+    fn apply_tool_search_results(&mut self, results: &[ToolDoneEvent]) -> bool {
+        let mut dirty = false;
+        for done in results {
+            match done.tool.as_ref() {
+                "tool_search" => {
+                    let text = done.output.as_text();
+                    if let Ok(Value::Array(items)) = serde_json::from_str::<Value>(&text) {
+                        for item in items {
+                            if let Some(name) = item.get("name").and_then(|v| v.as_str()) {
+                                self.active_tools.names.insert(name.to_owned());
+                                dirty = true;
+                            }
+                        }
+                    }
+                }
+                "load_namespace" => {
+                    let text = done.output.as_text();
+                    if let Ok(Value::Object(obj)) = serde_json::from_str::<Value>(&text)
+                        && let Some(ns) = obj.get("namespace").and_then(|v| v.as_str())
+                    {
+                        self.active_tools.namespaces.insert(ns.to_owned());
+                        dirty = true;
+                    }
+                }
+                _ => {}
+            }
+        }
+        dirty
     }
 
     async fn try_auto_compact(&mut self) -> Result<bool, AgentError> {
@@ -635,6 +716,7 @@ mod tests {
                 system: "system".into(),
                 event_tx: EventSender::new(raw_tx, 0),
                 tools: serde_json::json!([]),
+                tool_filter: ToolFilter::All,
             },
         );
         (agent, event_rx)
@@ -898,6 +980,7 @@ mod tests {
                     system: "system".into(),
                     event_tx: EventSender::new(raw_tx, 0),
                     tools: serde_json::json!([]),
+                    tool_filter: ToolFilter::All,
                 },
             )
             .with_cancel(cancel);

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -461,7 +461,9 @@ impl<'h> Agent<'h> {
             let Some(name) = def.get("name").and_then(|v| v.as_str()) else {
                 continue;
             };
-            if let Some(entry) = self.registry.get(name) && entry.defer_loading {
+            if let Some(entry) = self.registry.get(name)
+                && entry.defer_loading
+            {
                 self.active_tools.names.insert(name.to_owned());
             }
         }

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -349,7 +349,7 @@ pub(super) async fn process_tool_calls(
     history: &mut super::history::History,
     event_tx: &crate::EventSender,
     ctx: &ToolContext,
-) -> Result<(), AgentError> {
+) -> Result<Vec<crate::ToolDoneEvent>, AgentError> {
     let tool_uses: Vec<(String, String, Value)> = response
         .message
         .tool_uses()
@@ -423,12 +423,12 @@ pub(super) async fn process_tool_calls(
 
     let mut all_results = results;
     all_results.extend(immediate_errors);
-    let tool_msg = crate::types::tool_results(all_results);
+    let tool_msg = crate::types::tool_results(all_results.clone());
     event_tx.send(AgentEvent::ToolResultsSubmitted {
         message: Box::new(tool_msg.clone()),
     })?;
     history.push(tool_msg);
-    Ok(())
+    Ok(all_results)
 }
 
 /// Test-only entry that skips native lookup, letting plan-mode and MCP tests

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -19,7 +19,9 @@ use crate::cancel::{CancelMap, CancelToken};
 use crate::permissions::PermissionManager;
 use crate::prompt::ResolvedSlots;
 use crate::template;
-use crate::tools::{DescriptionContext, FileReadTracker, ToolAudience, ToolFilter, ToolRegistry};
+use crate::tools::{
+    ActiveTools, DescriptionContext, FileReadTracker, ToolAudience, ToolFilter, ToolRegistry,
+};
 use crate::{
     Agent, AgentConfig, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, Envelope,
     EventSender, ImageSource, McpHandle, PermissionsConfig, ToolOutput, ToolOutputLines,
@@ -94,6 +96,7 @@ struct AgentSetup {
     vars: template::Vars,
     instructions: agent::Instructions,
     tools: Value,
+    tool_filter: ToolFilter,
 }
 
 fn setup(
@@ -105,13 +108,13 @@ fn setup(
 ) -> AgentSetup {
     let vars = template::env_vars();
     let instructions = agent::load_instructions(&vars.apply("{cwd}"));
+    let tool_filter = ToolFilter::from_config(config, model, excluded_tools);
     let tools = tool_definitions(
         &vars,
-        model,
-        config,
-        excluded_tools,
+        &tool_filter,
         mcp_handle,
         workflow,
+        model,
         ToolRegistry::global(),
     );
 
@@ -119,25 +122,29 @@ fn setup(
         vars,
         instructions,
         tools,
+        tool_filter,
     }
 }
 
 fn tool_definitions(
     vars: &template::Vars,
-    model: &Model,
-    config: &AgentConfig,
-    excluded_tools: &[&'static str],
+    tool_filter: &ToolFilter,
     mcp_handle: Option<&McpHandle>,
     workflow: bool,
+    model: &Model,
     registry: &ToolRegistry,
 ) -> Value {
-    let filter = ToolFilter::from_config(config, model, excluded_tools);
     let ctx = DescriptionContext {
-        filter: &filter,
+        filter: tool_filter,
         audience: ToolAudience::MAIN,
         workflow,
     };
-    let mut tools = registry.definitions(vars, &ctx, model.supports_tool_examples());
+    let mut tools = registry.definitions_active(
+        vars,
+        &ctx,
+        model.supports_tool_examples(),
+        &ActiveTools::default(),
+    );
 
     if let Some(handle) = mcp_handle {
         handle.extend_tools(&mut tools);
@@ -153,6 +160,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
         vars,
         instructions,
         tools,
+        tool_filter,
     } = setup(
         &params.model,
         &params.config,
@@ -220,6 +228,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
                     system,
                     event_tx,
                     tools,
+                    tool_filter: tool_filter.clone(),
                 },
             )
             .with_loaded_instructions(instructions.loaded)
@@ -295,6 +304,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
         vars,
         instructions,
         mut tools,
+        mut tool_filter,
     } = setup(
         &params.model,
         &params.config,
@@ -362,13 +372,17 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                     match provider::from_model_async(&mut new_model, params.timeouts).await {
                         Ok(p) => {
                             provider = Arc::from(p);
+                            tool_filter = ToolFilter::from_config(
+                                &params.config,
+                                &new_model,
+                                &params.excluded_tools,
+                            );
                             tools = tool_definitions(
                                 &vars,
-                                &new_model,
-                                &params.config,
-                                &params.excluded_tools,
+                                &tool_filter,
                                 params.mcp_handle.as_ref(),
                                 params.workflow,
+                                &new_model,
                                 ToolRegistry::global(),
                             );
                             model = new_model;
@@ -430,6 +444,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                         system,
                         event_tx,
                         tools: tools.clone(),
+                        tool_filter: tool_filter.clone(),
                     },
                 )
                 .with_loaded_instructions(instructions.loaded.clone())

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -10,12 +10,13 @@ pub mod grep;
 pub mod interpreter_bridge;
 pub mod registry;
 pub mod schema;
+pub mod tool_search;
 
 pub use file_tracker::FileReadTracker;
 pub use registry::{
-    BoxFuture, ExecFuture, HeaderFuture, HeaderResult, ParseError, PermissionScopes,
+    ActiveTools, BoxFuture, ExecFuture, HeaderFuture, HeaderResult, ParseError, PermissionScopes,
     RegisteredTool, RegistryError, Tool, ToolAudience, ToolExecResult, ToolInvocation,
-    ToolRegistry, ToolSource,
+    ToolRegistry, ToolSearchResult, ToolSource,
 };
 
 use std::collections::HashMap;

--- a/maki-agent/src/tools/registry.rs
+++ b/maki-agent/src/tools/registry.rs
@@ -226,6 +226,12 @@ pub trait Tool: Send + Sync + 'static {
     fn tool_kind(&self) -> Option<&str> {
         None
     }
+    fn defer_loading(&self) -> bool {
+        false
+    }
+    fn namespace(&self) -> Option<&str> {
+        None
+    }
     fn parse(&self, input: &Value) -> Result<Box<dyn ToolInvocation>, ParseError>;
 }
 
@@ -233,6 +239,8 @@ pub trait Tool: Send + Sync + 'static {
 pub struct RegisteredTool {
     pub tool: Arc<dyn Tool>,
     pub source: ToolSource,
+    pub defer_loading: bool,
+    pub namespace: Option<Arc<str>>,
 }
 
 impl RegisteredTool {
@@ -292,6 +300,8 @@ impl ToolRegistry {
 
     pub fn register(&self, tool: Arc<dyn Tool>, source: ToolSource) -> Result<(), RegistryError> {
         let name = tool.name().to_owned();
+        let defer_loading = tool.defer_loading();
+        let namespace = tool.namespace().map(Arc::from);
         let mut conflict = None;
         self.tools.rcu(|current| {
             conflict = None;
@@ -304,6 +314,8 @@ impl ToolRegistry {
             next.push(RegisteredTool {
                 tool: Arc::clone(&tool),
                 source: source.clone(),
+                defer_loading,
+                namespace: namespace.clone(),
             });
             next
         });
@@ -336,6 +348,8 @@ impl ToolRegistry {
                 next.push(RegisteredTool {
                     tool: Arc::clone(tool),
                     source: source.clone(),
+                    defer_loading: tool.defer_loading(),
+                    namespace: tool.namespace().map(Arc::from).clone(),
                 });
             }
             next
@@ -385,6 +399,8 @@ impl ToolRegistry {
                 next.push(RegisteredTool {
                     tool: Arc::clone(tool),
                     source: source.clone(),
+                    defer_loading: tool.defer_loading(),
+                    namespace: tool.namespace().map(Arc::from).clone(),
                 });
             }
             next
@@ -474,6 +490,101 @@ impl ToolRegistry {
     pub fn iter(&self) -> RegistrySnapshot {
         RegistrySnapshot(self.tools.load_full())
     }
+
+    pub fn search(&self, query: &str) -> Vec<ToolSearchResult> {
+        let query_lower = query.to_lowercase();
+        let snapshot = self.tools.load();
+        let mut results = Vec::new();
+        for entry in snapshot.iter() {
+            if !entry.defer_loading {
+                continue;
+            }
+            let name = entry.name();
+            let description = entry.tool.description(&DescriptionContext {
+                filter: &crate::tools::ToolFilter::All,
+                audience: ToolAudience::MAIN,
+                workflow: false,
+            });
+            let name_matches = name.to_lowercase().contains(&query_lower);
+            let desc_matches = description.to_lowercase().contains(&query_lower);
+            if name_matches || desc_matches {
+                let truncated = if description.len() > 120 {
+                    format!(
+                        "{}...",
+                        &description[..description.floor_char_boundary(120)]
+                    )
+                } else {
+                    description.into_owned()
+                };
+                results.push(ToolSearchResult {
+                    name: name.to_owned(),
+                    namespace: entry.namespace.as_deref().map(String::from),
+                    description: truncated,
+                });
+            }
+        }
+        results
+    }
+
+    pub fn definitions_active(
+        &self,
+        vars: &Vars,
+        ctx: &DescriptionContext,
+        supports_examples: bool,
+        active: &ActiveTools,
+    ) -> Value {
+        let snapshot = self.tools.load();
+        let mut out = Vec::with_capacity(snapshot.len());
+        for entry in snapshot.iter() {
+            if !entry.tool.audience().contains(ctx.audience) {
+                continue;
+            }
+            if !ctx.filter.matches(entry.name()) {
+                continue;
+            }
+            if entry.defer_loading {
+                let name_matches = active.names.contains(entry.name());
+                let namespace_matches = entry
+                    .namespace
+                    .as_ref()
+                    .map(|ns| active.namespaces.contains(ns.as_ref()))
+                    .unwrap_or(false);
+                if !name_matches && !namespace_matches {
+                    continue;
+                }
+            }
+            let description = vars.apply(&entry.tool.description(ctx)).into_owned();
+            let mut def = json!({
+                "name": entry.name(),
+                "description": description,
+                "input_schema": entry.tool.schema(),
+            });
+            if let Some(examples) = entry.tool.examples() {
+                if supports_examples {
+                    def["input_examples"] = examples;
+                } else if let Some(text) = format_examples_as_text(&examples) {
+                    let merged =
+                        format!("{}\n\n{}", def["description"].as_str().unwrap_or(""), text);
+                    def["description"] = Value::String(merged);
+                }
+            }
+            out.push(def);
+        }
+        Value::Array(out)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolSearchResult {
+    pub name: String,
+    pub namespace: Option<String>,
+    pub description: String,
+}
+
+#[derive(Clone, Default)]
+pub struct ActiveTools {
+    pub names: std::collections::HashSet<String>,
+    pub namespaces: std::collections::HashSet<String>,
 }
 
 pub struct RegistrySnapshot(Arc<Vec<RegisteredTool>>);
@@ -517,6 +628,8 @@ mod tests {
     struct MockTool {
         name: String,
         audience: ToolAudience,
+        defer_loading: bool,
+        namespace: Option<String>,
     }
 
     struct MockInvocation;
@@ -543,6 +656,12 @@ mod tests {
         fn audience(&self) -> ToolAudience {
             self.audience
         }
+        fn defer_loading(&self) -> bool {
+            self.defer_loading
+        }
+        fn namespace(&self) -> Option<&str> {
+            self.namespace.as_deref()
+        }
         fn parse(&self, _input: &Value) -> Result<Box<dyn ToolInvocation>, ParseError> {
             Ok(Box::new(MockInvocation))
         }
@@ -556,6 +675,8 @@ mod tests {
         Arc::new(MockTool {
             name: name.to_owned(),
             audience,
+            defer_loading: false,
+            namespace: None,
         })
     }
 
@@ -782,5 +903,97 @@ mod tests {
         let result: ToolExecResult = base.into();
         let result = result.with_written_path(path);
         assert_eq!(result.written_path.as_deref(), expected);
+    }
+
+    #[test]
+    fn search_returns_deferred_tools_matching_query() {
+        let reg = ToolRegistry::new();
+        let deferred = Arc::new(MockTool {
+            name: "deferred_tool".to_owned(),
+            audience: ToolAudience::all(),
+            defer_loading: true,
+            namespace: None,
+        });
+        reg.register(deferred, lua_source("p")).unwrap();
+        reg.register(mock("active_tool"), lua_source("p")).unwrap();
+
+        let results = reg.search("deferred");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "deferred_tool");
+    }
+
+    #[test]
+    fn search_excludes_non_deferred_tools() {
+        let reg = ToolRegistry::new();
+        reg.register(mock("active_tool"), lua_source("p")).unwrap();
+
+        let results = reg.search("active");
+        assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn definitions_active_excludes_deferred_tools_unless_in_active_set() {
+        let reg = ToolRegistry::new();
+        let deferred = Arc::new(MockTool {
+            name: "deferred_tool".to_owned(),
+            audience: ToolAudience::all(),
+            defer_loading: true,
+            namespace: None,
+        });
+        reg.register(deferred, lua_source("p")).unwrap();
+        reg.register(mock("active_tool"), lua_source("p")).unwrap();
+
+        let filter = crate::tools::ToolFilter::All;
+        let ctx = DescriptionContext {
+            filter: &filter,
+            audience: ToolAudience::MAIN,
+            workflow: false,
+        };
+        let vars = Vars::new();
+        let active = ActiveTools::default();
+
+        let defs = reg.definitions_active(&vars, &ctx, false, &active);
+        let arr = defs.as_array().expect("definitions returns array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["name"].as_str(), Some("active_tool"));
+
+        let mut active_with_deferred = ActiveTools::default();
+        active_with_deferred
+            .names
+            .insert("deferred_tool".to_string());
+        let defs = reg.definitions_active(&vars, &ctx, false, &active_with_deferred);
+        let arr = defs.as_array().expect("definitions returns array");
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn definitions_active_includes_namespace_tools() {
+        let reg = ToolRegistry::new();
+        let deferred = Arc::new(MockTool {
+            name: "deferred_tool".to_owned(),
+            audience: ToolAudience::all(),
+            defer_loading: true,
+            namespace: Some("test_ns".to_string()),
+        });
+        reg.register(deferred, ToolSource::Lua { plugin: "p".into() })
+            .unwrap();
+        let entry = reg.get("deferred_tool").unwrap();
+        assert!(entry.defer_loading);
+        assert_eq!(entry.namespace.as_deref(), Some("test_ns"));
+
+        let filter = crate::tools::ToolFilter::All;
+        let ctx = DescriptionContext {
+            filter: &filter,
+            audience: ToolAudience::MAIN,
+            workflow: false,
+        };
+        let vars = Vars::new();
+        let mut active = ActiveTools::default();
+        active.namespaces.insert("test_ns".to_string());
+
+        let defs = reg.definitions_active(&vars, &ctx, false, &active);
+        let arr = defs.as_array().expect("definitions returns array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["name"].as_str(), Some("deferred_tool"));
     }
 }

--- a/maki-agent/src/tools/tool_search.rs
+++ b/maki-agent/src/tools/tool_search.rs
@@ -1,11 +1,11 @@
 use std::borrow::Cow;
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
+use crate::ToolOutput;
 use crate::tools::registry::{HeaderFuture, HeaderResult, ParseError, ToolInvocation};
 use crate::tools::schema::ToolInputErrorKind;
 use crate::tools::{DescriptionContext, ToolContext, ToolExecResult};
-use crate::ToolOutput;
 
 pub struct ToolSearch;
 
@@ -42,16 +42,22 @@ impl ToolInvocation for ToolSearchInvocation {
             } else {
                 results
             };
-            let output = format!("[{}]", filtered
-                .iter()
-                .map(|r| format!(
-                    r#"{{"name":"{}","namespace":{},"description":"{}"}}"#,
-                    r.name,
-                    r.namespace.as_ref().map(|s| format!(r#""{}""#, s)).unwrap_or("null".to_string()),
-                    r.description.replace('"', r#"\""#)
-                ))
-                .collect::<Vec<_>>()
-                .join(","));
+            let output = format!(
+                "[{}]",
+                filtered
+                    .iter()
+                    .map(|r| format!(
+                        r#"{{"name":"{}","namespace":{},"description":"{}"}}"#,
+                        r.name,
+                        r.namespace
+                            .as_ref()
+                            .map(|s| format!(r#""{}""#, s))
+                            .unwrap_or("null".to_string()),
+                        r.description.replace('"', r#"\""#)
+                    ))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            );
             ToolExecResult::from(Ok(ToolOutput::Plain(output.into())))
         })
     }
@@ -141,7 +147,11 @@ impl ToolInvocation for LoadNamespaceInvocation {
             let output = format!(
                 r#"{{"namespace":"{}","tools":[{}]}}"#,
                 self.namespace,
-                tools.iter().map(|t| format!(r#""{}""#, t)).collect::<Vec<_>>().join(",")
+                tools
+                    .iter()
+                    .map(|t| format!(r#""{}""#, t))
+                    .collect::<Vec<_>>()
+                    .join(",")
             );
             ToolExecResult::from(Ok(ToolOutput::Plain(output.into())))
         })

--- a/maki-agent/src/tools/tool_search.rs
+++ b/maki-agent/src/tools/tool_search.rs
@@ -1,0 +1,187 @@
+use std::borrow::Cow;
+
+use serde_json::{json, Value};
+
+use crate::tools::registry::{HeaderFuture, HeaderResult, ParseError, ToolInvocation};
+use crate::tools::schema::ToolInputErrorKind;
+use crate::tools::{DescriptionContext, ToolContext, ToolExecResult};
+use crate::ToolOutput;
+
+pub struct ToolSearch;
+
+impl ToolSearch {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ToolSearch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct ToolSearchInvocation {
+    query: String,
+    namespace: Option<String>,
+}
+
+impl ToolInvocation for ToolSearchInvocation {
+    fn start_header(&self) -> HeaderFuture {
+        HeaderFuture::Ready(HeaderResult::plain(format!("tool_search: {}", self.query)))
+    }
+
+    fn execute<'a>(self: Box<Self>, ctx: &'a ToolContext) -> crate::tools::ExecFuture<'a> {
+        Box::pin(async move {
+            let results = ctx.registry.search(&self.query);
+            let filtered: Vec<_> = if let Some(ns) = &self.namespace {
+                results
+                    .into_iter()
+                    .filter(|r| r.namespace.as_deref() == Some(ns.as_str()))
+                    .collect()
+            } else {
+                results
+            };
+            let output = format!("[{}]", filtered
+                .iter()
+                .map(|r| format!(
+                    r#"{{"name":"{}","namespace":{},"description":"{}"}}"#,
+                    r.name,
+                    r.namespace.as_ref().map(|s| format!(r#""{}""#, s)).unwrap_or("null".to_string()),
+                    r.description.replace('"', r#"\""#)
+                ))
+                .collect::<Vec<_>>()
+                .join(","));
+            ToolExecResult::from(Ok(ToolOutput::Plain(output.into())))
+        })
+    }
+}
+
+impl crate::tools::registry::Tool for ToolSearch {
+    fn name(&self) -> &str {
+        "tool_search"
+    }
+
+    fn description(&self, _ctx: &DescriptionContext) -> Cow<'_, str> {
+        "Search for deferred tools by name or description. Returns a list of tools that can be loaded on demand.".into()
+    }
+
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query to match tool names or descriptions"
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Optional namespace filter"
+                }
+            },
+            "required": ["query"],
+            "additionalProperties": false
+        })
+    }
+
+    fn parse(&self, input: &Value) -> Result<Box<dyn ToolInvocation>, ParseError> {
+        let query = input
+            .get("query")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ParseError {
+                path: Default::default(),
+                kind: ToolInputErrorKind::InternalBug {
+                    detail: "missing required field 'query'".to_string(),
+                },
+            })?
+            .to_string();
+        let namespace = input
+            .get("namespace")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        Ok(Box::new(ToolSearchInvocation { query, namespace }))
+    }
+}
+
+pub struct LoadNamespace;
+
+impl LoadNamespace {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for LoadNamespace {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct LoadNamespaceInvocation {
+    namespace: String,
+}
+
+impl ToolInvocation for LoadNamespaceInvocation {
+    fn start_header(&self) -> HeaderFuture {
+        HeaderFuture::Ready(HeaderResult::plain(format!(
+            "load_namespace: {}",
+            self.namespace
+        )))
+    }
+
+    fn execute<'a>(self: Box<Self>, ctx: &'a ToolContext) -> crate::tools::ExecFuture<'a> {
+        Box::pin(async move {
+            let tools: Vec<String> = ctx
+                .registry
+                .iter()
+                .iter()
+                .filter(|t| t.namespace.as_deref() == Some(self.namespace.as_str()))
+                .map(|t| t.name().to_string())
+                .collect();
+            let output = format!(
+                r#"{{"namespace":"{}","tools":[{}]}}"#,
+                self.namespace,
+                tools.iter().map(|t| format!(r#""{}""#, t)).collect::<Vec<_>>().join(",")
+            );
+            ToolExecResult::from(Ok(ToolOutput::Plain(output.into())))
+        })
+    }
+}
+
+impl crate::tools::registry::Tool for LoadNamespace {
+    fn name(&self) -> &str {
+        "load_namespace"
+    }
+
+    fn description(&self, _ctx: &DescriptionContext) -> Cow<'_, str> {
+        "Load all tools from a namespace. Returns the list of tools that were loaded.".into()
+    }
+
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "namespace": {
+                    "type": "string",
+                    "description": "Namespace to load"
+                }
+            },
+            "required": ["namespace"],
+            "additionalProperties": false
+        })
+    }
+
+    fn parse(&self, input: &Value) -> Result<Box<dyn ToolInvocation>, ParseError> {
+        let namespace = input
+            .get("namespace")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ParseError {
+                path: Default::default(),
+                kind: ToolInputErrorKind::InternalBug {
+                    detail: "missing required field 'namespace'".to_string(),
+                },
+            })?
+            .to_string();
+        Ok(Box::new(LoadNamespaceInvocation { namespace }))
+    }
+}

--- a/maki-docgen/src/gen_tools.rs
+++ b/maki-docgen/src/gen_tools.rs
@@ -30,7 +30,13 @@ const SECTIONS: &[(&str, &[&str])] = &[
     ),
     (
         "Execution & Control",
-        &["batch", "code_execution", "question", "tool_search", "load_namespace"],
+        &[
+            "batch",
+            "code_execution",
+            "question",
+            "tool_search",
+            "load_namespace",
+        ],
     ),
     (
         "Agent & Knowledge",

--- a/maki-docgen/src/gen_tools.rs
+++ b/maki-docgen/src/gen_tools.rs
@@ -30,7 +30,7 @@ const SECTIONS: &[(&str, &[&str])] = &[
     ),
     (
         "Execution & Control",
-        &["batch", "code_execution", "question"],
+        &["batch", "code_execution", "question", "tool_search", "load_namespace"],
     ),
     (
         "Agent & Knowledge",

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -15,8 +15,8 @@ use maki_agent::cancel::CancelMap;
 use maki_agent::tools::interpreter_bridge;
 use maki_agent::tools::registry::ToolRegistry;
 use maki_agent::tools::{
-    Deadline, DescriptionContext, FileReadTracker, LocalToolFn, LocalTools, ToolAudience,
-    ToolContext, ToolFilter, ToolLive,
+    ActiveTools, Deadline, DescriptionContext, FileReadTracker, LocalToolFn, LocalTools,
+    ToolAudience, ToolContext, ToolFilter, ToolLive,
 };
 use maki_agent::{
     Agent, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, Envelope, EventSender,
@@ -399,6 +399,12 @@ async fn session(
         let _ = sink.send(ToolLive::Annotation(model.spec()));
     }
 
+    let tool_filter = if tools_val.is_some() {
+        ToolFilter::All
+    } else {
+        ToolFilter::from_config(&agent_ctx.config, &model, &[])
+    };
+
     let mut tools_json: JsonValue = match tools_val {
         Some(val) => {
             let tools = lua_to_json(&lua, &val)?;
@@ -407,7 +413,24 @@ async fn session(
             }
             tools
         }
-        None => JsonValue::Array(vec![]),
+        None => {
+            let vars = maki_agent::template::env_vars();
+            let ctx = DescriptionContext {
+                filter: &tool_filter,
+                audience,
+                workflow: false,
+            };
+            let mut defs = ToolRegistry::global().definitions_active(
+                &vars,
+                &ctx,
+                model.supports_tool_examples(),
+                &ActiveTools::default(),
+            );
+            if let Some(ref mcp) = agent_ctx.mcp {
+                mcp.extend_tools(&mut defs);
+            }
+            defs
+        }
     };
 
     let mut local_map: HashMap<String, LocalToolFn> = HashMap::new();
@@ -524,6 +547,7 @@ async fn session(
         },
         system: system.unwrap_or_default(),
         tools: tools_json,
+        tool_filter,
         thinking,
         fast,
         mcp: agent_ctx.mcp.clone(),
@@ -644,6 +668,7 @@ struct SessionState {
     params: AgentParams,
     system: String,
     tools: JsonValue,
+    tool_filter: ToolFilter,
     thinking: ThinkingConfig,
     fast: bool,
     mcp: Option<maki_agent::mcp::McpHandle>,
@@ -750,6 +775,7 @@ async fn prompt(
             system: s.system.clone(),
             event_tx: s.sub_event_tx.clone(),
             tools: s.tools.clone(),
+            tool_filter: s.tool_filter.clone(),
         },
     )
     .with_user_response_rx(Arc::clone(&s.answer_rx))

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -131,6 +131,8 @@ pub(crate) struct PendingTool {
     pub(crate) start_annotation: Option<StartAnnotation>,
     pub(crate) examples: Option<Value>,
     pub(crate) describe_key: Option<RegistryKey>,
+    pub(crate) defer_loading: bool,
+    pub(crate) namespace: Option<Arc<str>>,
 }
 
 pub(crate) type PendingTools = Arc<Mutex<Vec<PendingTool>>>;
@@ -151,6 +153,8 @@ pub(crate) struct LuaTool {
     pub(crate) start_annotation: Option<StartAnnotation>,
     pub(crate) examples: Option<Value>,
     pub(crate) has_describe_fn: bool,
+    pub(crate) defer_loading: bool,
+    pub(crate) namespace: Option<Arc<str>>,
 }
 
 impl Tool for LuaTool {
@@ -207,6 +211,14 @@ impl Tool for LuaTool {
 
     fn examples(&self) -> Option<Value> {
         self.examples.clone()
+    }
+
+    fn defer_loading(&self) -> bool {
+        self.defer_loading
+    }
+
+    fn namespace(&self) -> Option<&str> {
+        self.namespace.as_deref()
     }
 
     fn parse(&self, input: &Value) -> Result<Box<dyn ToolInvocation>, ParseError> {
@@ -1150,6 +1162,12 @@ fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> Lua
             .transpose()
             .map_err(|e| mlua::Error::runtime(format!("register_tool: invalid examples: {e}")))?;
 
+    let defer_loading: bool = spec.get("defer_loading").unwrap_or(false);
+    let namespace: Option<Arc<str>> = spec
+        .get::<String>("namespace")
+        .ok()
+        .map(|s| Arc::from(s.as_str()));
+
     let name: Arc<str> = Arc::from(name.as_str());
 
     pending
@@ -1171,6 +1189,8 @@ fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> Lua
             start_annotation,
             examples,
             describe_key,
+            defer_loading,
+            namespace,
         });
 
     Ok(())
@@ -1554,6 +1574,8 @@ mod tests {
             has_start_fn: false,
             examples: None,
             has_describe_fn: false,
+            defer_loading: false,
+            namespace: None,
         }
     }
 

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -15,6 +15,7 @@ use event_listener::Event;
 use include_dir::Dir;
 use maki_agent::cancel::CancelToken;
 use maki_agent::prompt::{PromptId, ResolvedSlots, Slot, SlotEntry};
+use maki_agent::tools::tool_search::{LoadNamespace, ToolSearch};
 use maki_agent::tools::{
     HeaderResult, PermissionScopes, RegistryError, Tool, ToolLive, ToolRegistry, ToolSource,
 };
@@ -42,6 +43,31 @@ use crate::api::util::setup::ConfigStore;
 use crate::docs_render;
 use crate::error::PluginError;
 use crate::plugin_permissions::{PluginPermissions, load_plugin_permissions};
+
+fn register_builtin_tools(registry: &Arc<ToolRegistry>) -> Result<(), PluginError> {
+    let tool_search: Arc<dyn Tool> = Arc::new(ToolSearch::new());
+    let load_namespace: Arc<dyn Tool> = Arc::new(LoadNamespace::new());
+    registry
+        .register_many([
+            (
+                tool_search,
+                ToolSource::Lua {
+                    plugin: "builtin".into(),
+                },
+            ),
+            (
+                load_namespace,
+                ToolSource::Lua {
+                    plugin: "builtin".into(),
+                },
+            ),
+        ])
+        .map_err(|e| PluginError::Lua {
+            plugin: "builtin".to_owned(),
+            source: mlua::Error::runtime(format!("failed to register builtin tools: {e}")),
+        })?;
+    Ok(())
+}
 
 const INTERRUPT_SHUTDOWN_MSG: &str = "plugin interrupted: host shutting down";
 const INTERRUPT_CANCELLED_MSG: &str = "plugin interrupted: task cancelled";
@@ -968,6 +994,8 @@ impl LuaRuntime {
         lua.set_app_data(hint_writer);
         lua.set_app_data(Arc::clone(&registry));
 
+        register_builtin_tools(&registry)?;
+
         let plugins: PluginMap = Rc::new(RefCell::new(HashMap::new()));
         {
             let lua = lua.clone();
@@ -1419,6 +1447,8 @@ impl LuaRuntime {
                     start_annotation: t.start_annotation.clone(),
                     examples: t.examples.clone(),
                     has_describe_fn: t.describe_key.is_some(),
+                    defer_loading: t.defer_loading,
+                    namespace: t.namespace.clone(),
                 });
                 (
                     tool,

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -45,27 +45,33 @@ use crate::error::PluginError;
 use crate::plugin_permissions::{PluginPermissions, load_plugin_permissions};
 
 fn register_builtin_tools(registry: &Arc<ToolRegistry>) -> Result<(), PluginError> {
-    let tool_search: Arc<dyn Tool> = Arc::new(ToolSearch::new());
-    let load_namespace: Arc<dyn Tool> = Arc::new(LoadNamespace::new());
-    registry
-        .register_many([
-            (
-                tool_search,
-                ToolSource::Lua {
-                    plugin: "builtin".into(),
-                },
-            ),
-            (
-                load_namespace,
-                ToolSource::Lua {
-                    plugin: "builtin".into(),
-                },
-            ),
-        ])
-        .map_err(|e| PluginError::Lua {
-            plugin: "builtin".to_owned(),
-            source: mlua::Error::runtime(format!("failed to register builtin tools: {e}")),
-        })?;
+    let tools: [(Arc<dyn Tool>, ToolSource); 2] = [
+        (
+            Arc::new(ToolSearch::new()),
+            ToolSource::Lua {
+                plugin: "builtin".into(),
+            },
+        ),
+        (
+            Arc::new(LoadNamespace::new()),
+            ToolSource::Lua {
+                plugin: "builtin".into(),
+            },
+        ),
+    ];
+    for (tool, source) in tools {
+        match registry.register(tool, source) {
+            Ok(()) => {}
+            Err(RegistryError::NameConflict { name, .. })
+                if name == "tool_search" || name == "load_namespace" => {}
+            Err(e) => {
+                return Err(PluginError::Lua {
+                    plugin: "builtin".to_owned(),
+                    source: mlua::Error::runtime(format!("failed to register builtin tools: {e}")),
+                });
+            }
+        }
+    }
     Ok(())
 }
 

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -2,10 +2,16 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use maki_agent::tools::{ToolRegistry, ToolSource, timeout_annotation};
+use maki_agent::template::env_vars;
+use maki_agent::tools::{
+    ActiveTools, DescriptionContext, ToolAudience, ToolFilter, ToolRegistry, ToolSource,
+    timeout_annotation,
+};
 use maki_config::{AlwaysThinking, PluginsConfig, ToolOutputLines};
 use maki_lua::{PluginError, PluginHost, WARM_TOOL_CAP};
 use std::path::Path;
+
+const TOOL_DEFINITIONS_BYTE_BUDGET: usize = 25_000;
 
 fn fresh_registry() -> Arc<ToolRegistry> {
     Arc::new(ToolRegistry::new())
@@ -17,6 +23,28 @@ fn builtins_host() -> (Arc<ToolRegistry>, PluginHost) {
     host.load_builtins(&PluginsConfig::from_plugins(HashMap::new()))
         .unwrap();
     (reg, host)
+}
+
+#[test]
+fn builtin_main_tool_definitions_stay_within_prompt_budget() {
+    let (registry, _host) = builtins_host();
+    let definitions = registry.definitions_active(
+        &env_vars(),
+        &DescriptionContext {
+            filter: &ToolFilter::All,
+            audience: ToolAudience::MAIN,
+            workflow: false,
+        },
+        true,
+        &ActiveTools::default(),
+    );
+    let bytes = serde_json::to_vec_pretty(&definitions).unwrap().len() + 1;
+
+    assert!(registry.has("task"), "required tool disappeared: task");
+    assert!(
+        bytes <= TOOL_DEFINITIONS_BYTE_BUDGET,
+        "builtin main tool definitions use {bytes} bytes; budget is {TOOL_DEFINITIONS_BYTE_BUDGET}"
+    );
 }
 
 fn exec_tool(reg: &ToolRegistry, name: &str, input: serde_json::Value) -> Result<String, String> {

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -817,7 +817,9 @@ greet.setup()
     host.load_plugin_file(&init_path).unwrap();
 
     assert!(reg.has("greet"));
-    assert_eq!(reg.names().len(), 1);
+    assert!(reg.has("tool_search"));
+    assert!(reg.has("load_namespace"));
+    assert_eq!(reg.names().len(), 3);
 }
 
 #[test]
@@ -2265,6 +2267,51 @@ fn sessions_plugin_registers_commands() {
         "missing /sessions in {names:?}"
     );
     assert!(names.contains(&"/rename"), "missing /rename in {names:?}");
+}
+
+#[test]
+fn register_tool_accepts_defer_loading_and_namespace() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source(
+        "deferred",
+        r#"maki.api.register_tool({
+            name = "deferred_test",
+            description = "A deferred tool",
+            defer_loading = true,
+            namespace = "test_ns",
+            schema = {MINIMAL_SCHEMA},
+            audiences = { "main" },
+            handler = function(input) return "ok" end
+        })"#,
+    )
+    .unwrap();
+
+    let entry = reg.get("deferred_test").expect("tool should be registered");
+    assert!(entry.defer_loading, "defer_loading should be true");
+    assert_eq!(entry.namespace.as_deref(), Some("test_ns"));
+}
+
+#[test]
+fn tool_search_builtin_works_end_to_end() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source(
+        "deferred",
+        r#"maki.api.register_tool({
+            name = "searchable_tool",
+            description = "A tool that can be searched",
+            defer_loading = true,
+            schema = {MINIMAL_SCHEMA},
+            audiences = { "main" },
+            handler = function(input) return "ok" end
+        })"#,
+    )
+    .unwrap();
+
+    let results = reg.search("searchable");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].name, "searchable_tool");
 }
 
 #[test]

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -8,7 +8,7 @@ use maki_agent::permissions::PermissionManager;
 use maki_agent::template;
 use maki_agent::template::Vars;
 use maki_agent::tools::{
-    DescriptionContext, FileReadTracker, ToolAudience, ToolFilter, ToolRegistry,
+    ActiveTools, DescriptionContext, FileReadTracker, ToolAudience, ToolFilter, ToolRegistry,
 };
 use maki_agent::{
     Agent, AgentConfig, AgentEvent, AgentInput, AgentParams, AgentRunParams, CancelMap,
@@ -47,6 +47,7 @@ pub(super) struct AgentLoop {
     timeouts: maki_providers::Timeouts,
     lua_handle: Option<EventHandle>,
     subagent_cancels: Arc<CancelMap<String>>,
+    tool_filter: ToolFilter,
 }
 
 impl AgentLoop {
@@ -92,6 +93,7 @@ impl AgentLoop {
             timeouts,
             lua_handle,
             subagent_cancels,
+            tool_filter: ToolFilter::default(),
         }
     }
 
@@ -144,7 +146,8 @@ impl AgentLoop {
         self.publish_btw_system(&maki_agent::prompt::ResolvedSlots::default());
 
         let slot = self.model_slot.load();
-        self.tools = self.build_tools(&slot.model, false);
+        self.tool_filter = ToolFilter::from_config(&self.config, &slot.model, &[]);
+        self.tools = self.build_tools(&slot.model, false, &self.tool_filter);
         if let Some(ref mcp) = self.mcp_handle {
             mcp.extend_tools(&mut self.tools);
             spawn_oauth_for_needs_auth(mcp);
@@ -243,6 +246,7 @@ impl AgentLoop {
                 system,
                 event_tx,
                 tools: self.tools.clone(),
+                tool_filter: self.tool_filter.clone(),
             },
         )
         .with_loaded_instructions(self.instructions.loaded.clone())
@@ -264,22 +268,27 @@ impl AgentLoop {
     }
 
     fn rebuild_tools(&mut self, model: &Model, workflow: bool) {
-        let mut tools = self.build_tools(model, workflow);
+        self.tool_filter = ToolFilter::from_config(&self.config, model, &[]);
+        let mut tools = self.build_tools(model, workflow, &self.tool_filter);
         if let Some(ref mcp) = self.mcp_handle {
             mcp.extend_tools(&mut tools);
         }
         self.tools = tools;
     }
 
-    fn build_tools(&self, model: &Model, workflow: bool) -> Value {
+    fn build_tools(&self, model: &Model, workflow: bool, filter: &ToolFilter) -> Value {
         let examples = model.supports_tool_examples();
-        let filter = ToolFilter::from_config(&self.config, model, &[]);
         let ctx = DescriptionContext {
-            filter: &filter,
+            filter,
             audience: ToolAudience::MAIN,
             workflow,
         };
-        ToolRegistry::global().definitions(&self.vars, &ctx, examples)
+        ToolRegistry::global().definitions_active(
+            &self.vars,
+            &ctx,
+            examples,
+            &ActiveTools::default(),
+        )
     }
 
     async fn reload_instructions(&mut self) {

--- a/plugins/bash/init.lua
+++ b/plugins/bash/init.lua
@@ -232,16 +232,7 @@ local function collect_commands(node, source)
   return out
 end
 
-local description = [[Execute a bash command.
-Commands run in ]] .. cwd .. [[ by default.
-
-- **DO NOT** use for file ops! Only git, builds, tests, and system commands.
-- Use `workdir` param instead of `cd <dir> && <cmd>` patterns.
-- Do NOT use to communicate text to the user.
-- Chain dependent commands with `&&`. Use batch for independent ones.
-- Provide a short `description` (3-5 words).
-- Output truncated beyond 2000 lines or 50KB.
-- Interactive commands (sudo, ssh prompts) fail immediately.]]
+local description = [[Execute a bash command (runs in ]] .. cwd .. [[ by default). Use only for git, builds, tests, and system commands; do not use for file operations. Use `workdir` instead of `cd`. Chain dependent commands with `&&` and batch for independent ones. Output truncated beyond 2000 lines or 50KB. Interactive commands fail immediately.]]
 
 maki.api.register_prompt_hint({
   slot = "tool_usage",

--- a/plugins/bash/init.lua
+++ b/plugins/bash/init.lua
@@ -232,7 +232,9 @@ local function collect_commands(node, source)
   return out
 end
 
-local description = [[Execute a bash command (runs in ]] .. cwd .. [[ by default). Use only for git, builds, tests, and system commands; do not use for file operations. Use `workdir` instead of `cd`. Chain dependent commands with `&&` and batch for independent ones. Output truncated beyond 2000 lines or 50KB. Interactive commands fail immediately.]]
+local description = [[Execute a bash command (runs in ]]
+  .. cwd
+  .. [[ by default). Use only for git, builds, tests, and system commands; do not use for file operations. Use `workdir` instead of `cd`. Chain dependent commands with `&&` and batch for independent ones. Output truncated beyond 2000 lines or 50KB. Interactive commands fail immediately.]]
 
 maki.api.register_prompt_hint({
   slot = "tool_usage",

--- a/plugins/batch/init.lua
+++ b/plugins/batch/init.lua
@@ -519,6 +519,7 @@ maki.api.register_tool({
   description = description,
   kind = "execute",
   audiences = { "main", "research_sub", "general_sub" },
+  defer_loading = true,
   schema = schema,
   examples = examples,
   header = function(input)

--- a/plugins/code_execution/init.lua
+++ b/plugins/code_execution/init.lua
@@ -82,14 +82,14 @@ end
 
 local description = [[Execute Python code in a sandboxed interpreter with tools as callable functions.
 
-Use for chained/dependent tool calls and filtering/processing results, e.g. filtering web tool output. **DRAMATICALLY** faster than sequential tool calls!
+Use for chained/dependent tool calls and filtering/processing results. Much faster than sequential tool calls!
 
-- All tools are async and return strings: `result = await read(path='file.txt')`. Parse output yourself.
-- Use `asyncio.gather()` for concurrency within one execution.
+- Tools are async and return strings: `result = await read(path='file.txt')`. Parse output yourself.
+- Use `asyncio.gather()` for concurrency.
 - Available libs: re, asyncio, sys, os, json. No other imports, no classes, no filesystem/network access.
-- Fresh sandbox each run: no state persists between executions.
+- Fresh sandbox each run: no state persists.
 - 30 second timeout (configurable via `timeout` parameter).
-- Skip it when a single tool call needs no transformation.
+- Skip when a single tool call needs no transformation.
 - NOT a thinking scratchpad. Reason in your response text.
 ]]
 
@@ -100,7 +100,7 @@ local schema = {
   properties = {
     code = {
       type = "string",
-      description = "Python code to execute. Tools are async functions that return strings (not objects). You MUST await every call: `result = await read(path='/file')`. Use `await asyncio.gather(...)` for concurrency.",
+      description = "Python code to execute. Tools are async functions that return strings. You MUST await every call: `result = await read(path='/file')`. Use `await asyncio.gather(...)` for concurrency.",
     },
     timeout = {
       type = "integer",

--- a/plugins/edit/init.lua
+++ b/plugins/edit/init.lua
@@ -12,9 +12,11 @@ local EDIT_LINES_DESCRIPTION =
 local INSERT_LINES_DESCRIPTION =
   [[Insert `new_string` before the given 1-indexed line number. Existing lines shift down.]]
 
-local EDIT_DESCRIPTION = [[Replace an exact string match in a file. The old_string must appear exactly once unless replace_all is true. Read the file first; do NOT include line-number prefixes from read output. Prefer this over write for targeted changes; use replace_all for renaming.]]
+local EDIT_DESCRIPTION =
+  [[Replace an exact string match in a file. The old_string must appear exactly once unless replace_all is true. Read the file first; do NOT include line-number prefixes from read output. Prefer this over write for targeted changes; use replace_all for renaming.]]
 
-local MULTIEDIT_DESCRIPTION = [[Apply multiple find-and-replace edits to a single file atomically. Read the file first; each old_string must match exactly once unless replace_all is true. Edits apply in sequence; if any fails, none are written. Ensure earlier edits do not alter text later edits need.]]
+local MULTIEDIT_DESCRIPTION =
+  [[Apply multiple find-and-replace edits to a single file atomically. Read the file first; each old_string must match exactly once unless replace_all is true. Edits apply in sequence; if any fails, none are written. Ensure earlier edits do not alter text later edits need.]]
 
 local function edit_header(input)
   local buf = maki.ui.buf()

--- a/plugins/edit/init.lua
+++ b/plugins/edit/init.lua
@@ -7,30 +7,14 @@ local SNIPPET_MAX_CHARS = 32
 local FALLBACK_VIEW_LINES = 10
 
 local EDIT_LINES_DESCRIPTION =
-  [[Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new_string`. Use empty `new_string` to delete a range. Do not use with the batch tool.]]
+  [[Replace a line range (start to end, inclusive) with `new_string`; empty `new_string` deletes the range.]]
 
 local INSERT_LINES_DESCRIPTION =
-  [[Insert lines before a given line number. Lines at `line` and below shift down. Existing lines are preserved. Do not use with the batch tool.]]
+  [[Insert `new_string` before the given 1-indexed line number. Existing lines shift down.]]
 
-local EDIT_DESCRIPTION = [[Replace an exact string match in a file.
+local EDIT_DESCRIPTION = [[Replace an exact string match in a file. The old_string must appear exactly once unless replace_all is true. Read the file first; do NOT include line-number prefixes from read output. Prefer this over write for targeted changes; use replace_all for renaming.]]
 
-- The old_string must appear exactly once unless replace_all is true.
-- Read the file first to get exact content.
-- When copying text from read output, do NOT include the line number prefix (e.g. `42: `) - only the content after it.
-- Prefer this over write for targeted changes - it uses far fewer tokens.
-- Use replace_all for renaming across a file.
-]]
-
-local MULTIEDIT_DESCRIPTION = [[Make multiple find-and-replace edits to a single file atomically.
-Prefer this over edit when making multiple changes to the same file.
-
-- Read the file first to get exact content.
-- old_string must match the file contents exactly, including all whitespace and indentation.
-- Each edit must match exactly once unless replace_all is true. Use replace_all for renaming across a file.
-- Edits are applied in sequence - each operates on the result of the previous.
-- If any edit fails, none are written.
-- Ensure earlier edits don't affect text that later edits need to find.
-]]
+local MULTIEDIT_DESCRIPTION = [[Apply multiple find-and-replace edits to a single file atomically. Read the file first; each old_string must match exactly once unless replace_all is true. Edits apply in sequence; if any fails, none are written. Ensure earlier edits do not alter text later edits need.]]
 
 local function edit_header(input)
   local buf = maki.ui.buf()

--- a/plugins/glob/init.lua
+++ b/plugins/glob/init.lua
@@ -17,11 +17,7 @@ end
 maki.api.register_tool({
   name = "glob",
   kind = "search",
-  description = [[Find files by glob pattern.
-
-- Respects .gitignore.
-- Returns absolute paths sorted by modification time (newest first).
-- Prefer speculative parallel searches over sequential rounds of glob+grep.]],
+  description = [[Find files by glob pattern. Respects .gitignore and returns absolute paths sorted by modification time (newest first). Prefer parallel searches.]],
 
   schema = {
     type = "object",

--- a/plugins/grep/init.lua
+++ b/plugins/grep/init.lua
@@ -196,13 +196,7 @@ maki.api.register_prompt_hint({
 maki.api.register_tool({
   name = "grep",
   kind = "search",
-  description = [[Search file contents using regex.
-
-- Respects .gitignore.
-- Results grouped by file, sorted by modification time.
-- Prefer speculative parallel searches over sequential rounds of glob+grep.
-- Do NOT wrap the pattern in quotes. Do NOT double-escape (e.g. `\[` not `\\[`).
-- Multi-line matching is auto-enabled when the pattern contains `\n`, `(?s)`, or `(?m)`.]],
+  description = [[Search file contents with regex. Respects .gitignore, returns results grouped by file. Prefer parallel searches. Do not quote or double-escape the pattern. Multi-line matching auto-enables for `\n`, `(?s)`, or `(?m)`.]],
 
   schema = {
     type = "object",

--- a/plugins/index/init.lua
+++ b/plugins/index/init.lua
@@ -153,12 +153,7 @@ maki.api.register_prompt_hint({
 maki.api.register_tool({
   name = "index",
   kind = "read",
-  description = [[
-Return a compact overview of a source file: imports, type definitions, function signatures, and structure with their line numbers surrounded by []. ~70-90% more efficient than reading the full file.
-
-- Use this FIRST to understand file structure before using read with offset/limit.
-- Supports source files in different programming languages and markdown.
-- Falls back with an error on unsupported languages. Use read instead.]],
+  description = [[Return a compact overview of a source file: imports, types, function signatures, and structure with line numbers. Use before read to understand file structure; falls back with an error on unsupported languages.]],
 
   schema = {
     type = "object",

--- a/plugins/memory/init.lua
+++ b/plugins/memory/init.lua
@@ -136,6 +136,7 @@ maki.api.register_tool({
   description = "Persistent, project-scoped scratchpad for learnings, patterns, decisions, and gotchas across sessions.\n\n"
     .. "- Save important context before compaction or to build up project knowledge.\n"
     .. "- Keep entries concise and current. Delete outdated information.",
+  defer_loading = true,
 
   schema = {
     type = "object",

--- a/plugins/question/init.lua
+++ b/plugins/question/init.lua
@@ -1,16 +1,7 @@
 local QuestionForm = require("question_form")
 local QuestionHelpers = require("question_helpers")
 
-local DESCRIPTION = [[Use this tool when you need to ask the user questions during execution. This allows you to:
-- Gather user preferences or requirements
-- Clarify ambiguous instructions
-- Get decisions on implementation choices as you work
-- Offer choices to the user about what direction to take
-
-Rules:
-- `custom` enabled by default adds "Type your own answer" - don't include catch-all options.
-- Answers returned as arrays of labels. Set `multiSelect: true` for multi-select.
-- Put recommended option first with "(Recommended)" suffix.]]
+local DESCRIPTION = [[Ask the user questions during execution to gather preferences, clarify instructions, or get decisions. `custom` is enabled by default; don't add catch-all options. Answers are arrays of labels; use `multiSelect` for multi-select. Put the recommended option first.]]
 
 maki.api.register_tool({
   name = "question",

--- a/plugins/question/init.lua
+++ b/plugins/question/init.lua
@@ -1,7 +1,8 @@
 local QuestionForm = require("question_form")
 local QuestionHelpers = require("question_helpers")
 
-local DESCRIPTION = [[Ask the user questions during execution to gather preferences, clarify instructions, or get decisions. `custom` is enabled by default; don't add catch-all options. Answers are arrays of labels; use `multiSelect` for multi-select. Put the recommended option first.]]
+local DESCRIPTION =
+  [[Ask the user questions during execution to gather preferences, clarify instructions, or get decisions. `custom` is enabled by default; don't add catch-all options. Answers are arrays of labels; use `multiSelect` for multi-select. Put the recommended option first.]]
 
 maki.api.register_tool({
   name = "question",

--- a/plugins/read/init.lua
+++ b/plugins/read/init.lua
@@ -2,18 +2,9 @@ local ToolView = require("maki.tool_view")
 local shorten_path = require("maki.shorten_path")
 local output_limits = require("maki.output_limits")
 
-local DESCRIPTION = [[Read a file or directory. Returns contents with line numbers (1-indexed).
+local DESCRIPTION = [[Read a file or directory with line numbers (1-indexed).
 
-- Supports absolute, relative, and ~/ paths.
-- **Always include offset and limit** if possible. Defaults: no offset = start at 1; no limit = up to 2000 lines.
-- Use the **index** tool or **grep** tool first to find the offset and limit.
-- Only read the sections you actually need.
-- Use `wc -l` to check total number of lines before reading to decide a reasonable limit unless known already.
-- Use truncation hints (e.g. "truncated lines X-Y") to continue with the correct offset.
-- Do not reread the same range (same file and same offset).
-- Prefer grep to locate content instead of scanning full files.
-- Call in parallel when reading multiple files.
-- Avoid tiny repeated slices - read a larger window if you need more context.]]
+Include offset and limit when possible; default limit is 2000 lines. Use grep/index to find offsets, read only the sections you need, and call in parallel for multiple files. Avoid re-reading the same range.]]
 
 local DEFAULT_MAX_OUTPUT_LINES = 2000
 

--- a/plugins/task/init.lua
+++ b/plugins/task/init.lua
@@ -24,18 +24,7 @@ local BODY_INDENT_COLS = 4
 local MIN_MD_WIDTH = 20
 local DEFAULT_OUTPUT_LINES = 5
 
-local description = [[Launch an autonomous subagent to perform tasks independently. Best combined with batch.
-
-Subagent types (set via `subagent_type`):
-- `research` (default): Read-only tools. For codebase exploration or gathering context.
-- `general`: Full tool access. For delegating implementation work.
-
-Notes:
-1. Launch multiple tasks concurrently when possible.
-2. The agent's result is not visible to the user. Summarize it in your response.
-3. Each invocation starts fresh - inline any needed context into the prompt.
-4. Tell it to return concise summaries with file:line refs, not full file contents.
-]]
+local description = [[Launch an autonomous subagent for independent tasks. Use `subagent_type` "research" for read-only exploration or "general" for implementation work. Launch multiple tasks concurrently when possible; inline needed context and ask for concise, file:line summaries.]]
 
 local schema = {
   type = "object",
@@ -56,10 +45,10 @@ local schema = {
     },
     model_tier = {
       type = "string",
-      description = 'Model tier (optional, omit to use current model, capped at current tier):\n- "strong" (e.g. Opus): Deep reasoning, complex architecture, subtle bugs, most critical sections. ~5x cost of medium.\n- "medium" (e.g. Sonnet): Balanced. Refactors, features, multi-file changes.\n- "weak" (e.g. Haiku): Fast/cheap. Search, summarize, boilerplate, simple edits.',
+      description = 'Optional capped model tier: "weak", "medium", or "strong".',
     },
     output_schema = {
-      description = "JSON Schema (object) the subagent's final result must match. When set, the result is returned as a validated JSON string.",
+      description = "JSON Schema the subagent's final result must match. Returned as a validated JSON string.",
     },
   },
 }

--- a/plugins/task/init.lua
+++ b/plugins/task/init.lua
@@ -24,7 +24,8 @@ local BODY_INDENT_COLS = 4
 local MIN_MD_WIDTH = 20
 local DEFAULT_OUTPUT_LINES = 5
 
-local description = [[Launch an autonomous subagent for independent tasks. Use `subagent_type` "research" for read-only exploration or "general" for implementation work. Launch multiple tasks concurrently when possible; inline needed context and ask for concise, file:line summaries.]]
+local description =
+  [[Launch an autonomous subagent for independent tasks. Use `subagent_type` "research" for read-only exploration or "general" for implementation work. Launch multiple tasks concurrently when possible; inline needed context and ask for concise, file:line summaries.]]
 
 local schema = {
   type = "object",

--- a/plugins/todo_write/init.lua
+++ b/plugins/todo_write/init.lua
@@ -10,13 +10,7 @@ local STATUS_MARKERS = {
   cancelled = { "[x]", "todo_cancelled" },
 }
 
-local DESCRIPTION = [[Create or update a structured todo list to track tasks.
-
-**Use after EACH completed step!**
-
-- Send the complete list each time (replace-all semantics).
-- Use ONLY for multi-step work (3+ steps).
-- Skip for trivial tasks.]]
+local DESCRIPTION = [[Create or update a structured todo list for multi-step work (3+ steps). Send the complete list each time (replace-all) and update after each completed step. Skip for trivial tasks.]]
 
 local function count_done()
   local n = 0

--- a/plugins/todo_write/init.lua
+++ b/plugins/todo_write/init.lua
@@ -10,7 +10,8 @@ local STATUS_MARKERS = {
   cancelled = { "[x]", "todo_cancelled" },
 }
 
-local DESCRIPTION = [[Create or update a structured todo list for multi-step work (3+ steps). Send the complete list each time (replace-all) and update after each completed step. Skip for trivial tasks.]]
+local DESCRIPTION =
+  [[Create or update a structured todo list for multi-step work (3+ steps). Send the complete list each time (replace-all) and update after each completed step. Skip for trivial tasks.]]
 
 local function count_done()
   local n = 0

--- a/plugins/view_image/init.lua
+++ b/plugins/view_image/init.lua
@@ -121,6 +121,7 @@ maki.api.register_tool({
   -- No interpreter audience: the code_execution bridge flattens tool output
   -- to text, so the pixels could never reach the model from there.
   audiences = { "main", "research_sub", "general_sub" },
+  defer_loading = true,
 
   schema = {
     type = "object",

--- a/plugins/webfetch/init.lua
+++ b/plugins/webfetch/init.lua
@@ -80,12 +80,7 @@ end
 maki.api.register_tool({
   name = "webfetch",
   kind = "fetch",
-  description = [[Fetch a URL and return its contents.
-
-- Supports markdown (default), text, or html output formats.
-- HTTP URLs are auto-upgraded to HTTPS.
-- Max response size is 5MB, max timeout is 120s.
-- Best used inside code_execution with some truncation / filter to avoid context bloat.]],
+  description = [[Fetch a URL and return its contents. Supports markdown (default), text, and html. HTTP auto-upgrades to HTTPS. Max 5MB response, 120s timeout. Use inside code_execution with truncation to avoid bloat.]],
 
   schema = {
     type = "object",

--- a/plugins/websearch/init.lua
+++ b/plugins/websearch/init.lua
@@ -23,13 +23,9 @@ end
 maki.api.register_tool({
   name = "websearch",
   kind = "fetch",
-  description = "Search the web for real-time information using Exa AI.\n\n"
-    .. "Today's date is "
+  description = "Search the web using Exa AI (today is "
     .. os.date("%Y-%m-%d")
-    .. ".\n\n"
-    .. "- Use for current events, documentation, APIs, or anything not in local files.\n"
-    .. "- Prefer specific, targeted queries over broad ones.\n"
-    .. "- Results include page titles, URLs, and content snippets.",
+    .. "). Use for current events, docs, APIs, or anything not in local files. Prefer targeted queries.",
 
   schema = {
     type = "object",

--- a/plugins/write/init.lua
+++ b/plugins/write/init.lua
@@ -1,12 +1,7 @@
 local shorten_path = require("maki.shorten_path")
 local ToolView = require("maki.tool_view")
 
-local DESCRIPTION = [[Write content to a file, replacing existing content.
-
-- Creates parent directories if needed.
-- Always read the file first before writing.
-- NEVER create files unless absolutely necessary - prefer editing existing files.
-- NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.]]
+local DESCRIPTION = [[Write content to a file, replacing existing content. Creates parent directories if needed. Read the file first; prefer editing existing files. Only create documentation files when explicitly requested.]]
 
 local function write_view_opts(ctx)
   local tol = ctx:tool_output_lines()

--- a/plugins/write/init.lua
+++ b/plugins/write/init.lua
@@ -1,7 +1,8 @@
 local shorten_path = require("maki.shorten_path")
 local ToolView = require("maki.tool_view")
 
-local DESCRIPTION = [[Write content to a file, replacing existing content. Creates parent directories if needed. Read the file first; prefer editing existing files. Only create documentation files when explicitly requested.]]
+local DESCRIPTION =
+  [[Write content to a file, replacing existing content. Creates parent directories if needed. Read the file first; prefer editing existing files. Only create documentation files when explicitly requested.]]
 
 local function write_view_opts(ctx)
   local tol = ctx:tool_output_lines()

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -7,14 +7,13 @@ group = "Reference"
 
 # Tools
 
-Maki ships with 20 built-in tools. This is the full reference.
+Maki ships with 22 built-in tools. This is the full reference.
 
 ## File Operations
 
 ### `bash` *(lua plugin)*
 
-Execute a bash command.
-Commands run in <cwd> by default.
+Execute a bash command (runs in <cwd> by default). Use only for git, builds, tests, and system commands; do not use for file operations. Use `workdir` instead of `cd`. Chain dependent commands with `&&` and batch for independent ones. Output truncated beyond 2000 lines or 50KB. Interactive commands fail immediately.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
@@ -25,7 +24,7 @@ Commands run in <cwd> by default.
 
 ### `read` *(lua plugin)*
 
-Read a file or directory. Returns contents with line numbers (1-indexed).
+Read a file or directory with line numbers (1-indexed).
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -35,7 +34,7 @@ Read a file or directory. Returns contents with line numbers (1-indexed).
 
 ### `write` *(lua plugin)*
 
-Write content to a file, replacing existing content.
+Write content to a file, replacing existing content. Creates parent directories if needed. Read the file first; prefer editing existing files. Only create documentation files when explicitly requested.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -44,7 +43,7 @@ Write content to a file, replacing existing content.
 
 ### `edit` *(lua plugin)*
 
-Replace an exact string match in a file.
+Replace an exact string match in a file. The old_string must appear exactly once unless replace_all is true. Read the file first; do NOT include line-number prefixes from read output. Prefer this over write for targeted changes; use replace_all for renaming.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
@@ -55,8 +54,7 @@ Replace an exact string match in a file.
 
 ### `multiedit` *(lua plugin)*
 
-Make multiple find-and-replace edits to a single file atomically.
-Prefer this over edit when making multiple changes to the same file.
+Apply multiple find-and-replace edits to a single file atomically. Read the file first; each old_string must match exactly once unless replace_all is true. Edits apply in sequence; if any fails, none are written. Ensure earlier edits do not alter text later edits need.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -65,7 +63,7 @@ Prefer this over edit when making multiple changes to the same file.
 
 ### `edit_lines` *(lua plugin, opt-in)*
 
-Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new_string`. Use empty `new_string` to delete a range. Do not use with the batch tool.
+Replace a line range (start to end, inclusive) with `new_string`; empty `new_string` deletes the range.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -76,7 +74,7 @@ Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new
 
 ### `insert_lines` *(lua plugin, opt-in)*
 
-Insert lines before a given line number. Lines at `line` and below shift down. Existing lines are preserved. Do not use with the batch tool.
+Insert `new_string` before the given 1-indexed line number. Existing lines shift down.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -86,7 +84,7 @@ Insert lines before a given line number. Lines at `line` and below shift down. E
 
 ### `glob` *(lua plugin)*
 
-Find files by glob pattern.
+Find files by glob pattern. Respects .gitignore and returns absolute paths sorted by modification time (newest first). Prefer parallel searches.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
@@ -95,7 +93,7 @@ Find files by glob pattern.
 
 ### `grep` *(lua plugin)*
 
-Search file contents using regex.
+Search file contents with regex. Respects .gitignore, returns results grouped by file. Prefer parallel searches. Do not quote or double-escape the pattern. Multi-line matching auto-enables for `\n`, `(?s)`, or `(?m)`.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
@@ -108,7 +106,7 @@ Search file contents using regex.
 
 ### `index` *(lua plugin)*
 
-Return a compact overview of a source file: imports, type definitions, function signatures, and structure with their line numbers surrounded by []. ~70-90% more efficient than reading the full file.
+Return a compact overview of a source file: imports, types, function signatures, and structure with line numbers. Use before read to understand file structure; falls back with an error on unsupported languages.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -138,38 +136,51 @@ Execute Python code in a sandboxed interpreter with tools as callable functions.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `code` | string | yes |  | Python code to execute. Tools are async functions that return strings (not objects). You MUST await every call: `result = await read(path='/file')`. Use `await asyncio.gather(...)` for concurrency. |
+| `code` | string | yes |  | Python code to execute. Tools are async functions that return strings. You MUST await every call: `result = await read(path='/file')`. Use `await asyncio.gather(...)` for concurrency. |
 | `timeout` | integer | no | 30, max 300 | Timeout in seconds |
 
 ### `question` *(lua plugin)*
 
-Use this tool when you need to ask the user questions during execution. This allows you to:
-- Gather user preferences or requirements
-- Clarify ambiguous instructions
-- Get decisions on implementation choices as you work
-- Offer choices to the user about what direction to take
+Ask the user questions during execution to gather preferences, clarify instructions, or get decisions. `custom` is enabled by default; don't add catch-all options. Answers are arrays of labels; use `multiSelect` for multi-select. Put the recommended option first.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `questions` | array | yes | List of questions to ask the user |
 
+### `tool_search` *(lua plugin)*
+
+Search for deferred tools by name or description. Returns a list of tools that can be loaded on demand.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `namespace` | string | no | Optional namespace filter |
+| `query` | string | yes | Search query to match tool names or descriptions |
+
+### `load_namespace` *(lua plugin)*
+
+Load all tools from a namespace. Returns the list of tools that were loaded.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `namespace` | string | yes | Namespace to load |
+
 ## Agent & Knowledge
 
 ### `task` *(lua plugin)*
 
-Launch an autonomous subagent to perform tasks independently. Best combined with batch.
+Launch an autonomous subagent for independent tasks. Use `subagent_type` "research" for read-only exploration or "general" for implementation work. Launch multiple tasks concurrently when possible; inline needed context and ask for concise, file:line summaries.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `description` | string | yes | Short (3-5 words) description of the task |
-| `model_tier` | string | no | Model tier (optional, omit to use current model, capped at current tier):<br>- "strong" (e.g. Opus): Deep reasoning, complex architecture, subtle bugs, most critical sections. ~5x cost of medium.<br>- "medium" (e.g. Sonnet): Balanced. Refactors, features, multi-file changes.<br>- "weak" (e.g. Haiku): Fast/cheap. Search, summarize, boilerplate, simple edits. |
-| `output_schema` | string | no | JSON Schema (object) the subagent's final result must match. When set, the result is returned as a validated JSON string. |
+| `model_tier` | string | no | Optional capped model tier: "weak", "medium", or "strong". |
+| `output_schema` | string | no | JSON Schema the subagent's final result must match. Returned as a validated JSON string. |
 | `prompt` | string | yes | Detailed task prompt for the agent |
 | `subagent_type` | string | no | Subagent type: "research" (read-only, default) or "general" (can modify files) |
 
 ### `todo_write` *(lua plugin)*
 
-Create or update a structured todo list to track tasks.
+Create or update a structured todo list for multi-step work (3+ steps). Send the complete list each time (replace-all) and update after each completed step. Skip for trivial tasks.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -197,7 +208,7 @@ Load a skill that provides instructions and workflows for specific tasks.
 
 ### `webfetch` *(lua plugin)*
 
-Fetch a URL and return its contents.
+Fetch a URL and return its contents. Supports markdown (default), text, and html. HTTP auto-upgrades to HTTPS. Max 5MB response, 120s timeout. Use inside code_execution with truncation to avoid bloat.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
@@ -207,7 +218,7 @@ Fetch a URL and return its contents.
 
 ### `websearch` *(lua plugin)*
 
-Search the web for real-time information using Exa AI.
+Search the web using Exa AI (today is YYYY-MM-DD). Use for current events, docs, APIs, or anything not in local files. Prefer targeted queries.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|


### PR DESCRIPTION
## Summary
- Adds `tool_search` and `load_namespace` built-in tools.
- Extends the tool registry with `defer_loading`, `namespace`, `search()`, and `definitions_active()`.
- Wires dynamic active tool rebuilding into the agent run loop.
- Updates headless/UI/lua session entry points to build initial tool lists with `definitions_active` and pass the matching `ToolFilter`.
- Defers `batch`, `memory`, and `view_image` plugin loading by default to reduce prompt tokens.
- Adds a prompt-budget eval for builtin main tool definitions.

## Verification
- `cargo fmt --all`
- `cargo clippy --all --tests -- -D warnings`
- `cargo nextest run --workspace` (3195 passed)

Upstreamed from `w0wl0lxd/n00n#58`