### PR TITLE
feat(ui): configurable startup theme

### DIFF
--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -321,6 +321,7 @@ pub struct UiFileConfig {
     pub typewriter_ms_per_char: Option<u64>,
     pub mouse_scroll_lines: Option<u32>,
     pub show_thinking: Option<bool>,
+    pub theme: Option<String>,
     pub tool_output_lines: Option<ToolOutputLinesFile>,
 }
 
@@ -334,7 +335,8 @@ impl UiFileConfig {
             flash_duration_ms,
             typewriter_ms_per_char,
             mouse_scroll_lines,
-            show_thinking
+            show_thinking,
+            theme
         );
         match (self.tool_output_lines.as_mut(), overlay.tool_output_lines) {
             (Some(base), Some(over)) => base.merge(over),
@@ -793,7 +795,7 @@ pub struct Config {
     pub plugins: PluginsConfig,
 }
 
-#[derive(Debug, Clone, Copy, ConfigSection)]
+#[derive(Debug, Clone, ConfigSection)]
 #[config(section = "ui")]
 pub struct UiConfig {
     #[config(default = true, desc = "Show splash animation on startup")]
@@ -817,6 +819,9 @@ pub struct UiConfig {
     )]
     pub show_thinking: bool,
 
+    #[config(skip, default = "None")]
+    pub theme: Option<String>,
+
     #[config(skip, default = "ToolOutputLines::default()")]
     pub tool_output_lines: ToolOutputLines,
 }
@@ -836,6 +841,7 @@ impl UiConfig {
                 .unwrap_or(DEFAULT_TYPEWRITER_MS_PER_CHAR),
             mouse_scroll_lines: f.mouse_scroll_lines.unwrap_or(DEFAULT_MOUSE_SCROLL_LINES),
             show_thinking: f.show_thinking.unwrap_or(true),
+            theme: f.theme,
             tool_output_lines: ToolOutputLines::from_file(f.tool_output_lines),
         }
     }

--- a/maki-docgen/src/gen_config.rs
+++ b/maki-docgen/src/gen_config.rs
@@ -103,6 +103,24 @@ fn collect_plugin_options() -> PluginOptionSpecs {
     specs
 }
 
+fn write_theme_section(out: &mut String) {
+    writeln!(out, "### `ui.theme`\n").unwrap();
+    writeln!(
+        out,
+        "Name of the color theme to load at startup, overriding the theme you \
+         last picked interactively. If unset, Maki keeps your last selection \
+         (the built-in default on first run). An unknown name is ignored with \
+         a warning.\n"
+    )
+    .unwrap();
+    let names = maki_ui::BUNDLED_THEMES
+        .iter()
+        .map(|t| format!("`{}`", t.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    writeln!(out, "Available themes: {names}.\n").unwrap();
+}
+
 fn write_tool_output_section(out: &mut String) {
     writeln!(out, "### `ui.tool_output_lines`\n").unwrap();
     writeln!(
@@ -150,6 +168,7 @@ maki.setup({{
     ui = {{
         splash_animation = true,
         mouse_scroll_lines = {mouse_scroll},
+        theme = \"tokyonight\",
         tool_output_lines = {{
             bash = {tol_bash},
             read = {tol_read},
@@ -190,6 +209,7 @@ All fields are optional. Typos in field names cause an error right away.
     writeln!(out).unwrap();
 
     write_section(&mut out, "[ui]", UiConfig::FIELDS);
+    write_theme_section(&mut out);
     write_tool_output_section(&mut out);
     write_section(&mut out, "[agent]", AgentConfig::FIELDS);
     write_section(&mut out, "[provider]", ProviderConfig::FIELDS);

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -203,8 +203,10 @@ impl App {
     ) -> Self {
         scrollbar::set_enabled(ui_config.scrollbar);
         let state = SessionState::from_session(session, model, &storage);
+        let typewriter = ui_config.typewriter_ms_per_char;
+        let flash = ui_config.flash_duration();
         let mut app = Self {
-            chats: vec![Chat::new("Main".into(), ui_config)],
+            chats: vec![Chat::new("Main".into(), ui_config.clone())],
             active_chat: 0,
             chat_index: HashMap::new(),
             input_box: InputBox::new(InputHistory::load(&storage, input_history_size)),
@@ -222,13 +224,13 @@ impl App {
             rewind_picker: RewindPicker::new(),
             help_modal: HelpModal::new(),
             usage_modal: UsageModal::new(),
-            btw_modal: BtwModal::new(ui_config.typewriter_ms_per_char),
+            btw_modal: BtwModal::new(typewriter),
             float_mgr: FloatManager::new(),
             search_modal: SearchModal::new(),
             file_picker: FilePickerModal::new(),
             permission_prompt: PermissionPrompt::new(),
             plan_form: PlanForm::new(),
-            status_bar: StatusBar::new(ui_config.flash_duration()),
+            status_bar: StatusBar::new(flash),
             status: Status::Idle,
             state,
             exit_request: ExitRequest::None,
@@ -1122,7 +1124,7 @@ impl App {
         if let Some(ref model) = subagent.model {
             self.chats[0].update_tool_model(id, model);
         }
-        let mut chat = Chat::new(subagent.name.clone(), self.ui_config);
+        let mut chat = Chat::new(subagent.name.clone(), self.ui_config.clone());
         chat.set_restore_channel(self.lua_event_handle.clone(), self.restore_event_tx.clone());
         chat.model_id = subagent.model.clone();
         if let Some(ref prompt) = subagent.prompt {

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -77,7 +77,7 @@ impl App {
 
     pub(super) fn reset_ui_chrome(&mut self) {
         self.chats.clear();
-        let mut main = Chat::new("Main".into(), self.ui_config);
+        let mut main = Chat::new("Main".into(), self.ui_config.clone());
         main.set_restore_channel(self.lua_event_handle.clone(), self.restore_event_tx.clone());
         self.chats.push(main);
         self.active_chat = 0;
@@ -123,7 +123,7 @@ impl App {
         for sa in std::mem::take(&mut self.state.session.meta.subagents) {
             let idx = self.chats.len();
             self.chat_index.insert(sa.tool_use_id.clone(), idx);
-            let mut chat = Chat::new(sa.name, self.ui_config);
+            let mut chat = Chat::new(sa.name, self.ui_config.clone());
             chat.set_restore_channel(self.lua_event_handle.clone(), self.restore_event_tx.clone());
             chat.model_id = sa.model;
             if let Some(messages) = self.state.session.subagent_messages.get(&sa.tool_use_id) {

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -177,7 +177,7 @@ impl SpawnCtx {
             self.keymap_reader.clone(),
             self.hint_reader.clone(),
             Arc::clone(&self.storage_writer),
-            self.ui_config,
+            self.ui_config.clone(),
             self.input_history_size,
             permissions,
             Arc::clone(&self.custom_commands),
@@ -313,7 +313,7 @@ impl<'t> EventLoop<'t> {
             commands,
             sessions,
             focused,
-            startup_warnings,
+            mut startup_warnings,
             storage,
             config,
             ui_config,
@@ -327,6 +327,19 @@ impl<'t> EventLoop<'t> {
             ui_action_rx,
             lua_event_handle,
         } = params;
+
+        // Apply the config theme before the warmup thread spawns, or warmup
+        // could bake the syntax palette from the old theme. Only the
+        // in-memory name is set, so the user's saved pick survives.
+        if let Some(ref name) = ui_config.theme {
+            match crate::theme::load_by_name(name) {
+                Ok(theme) => {
+                    crate::theme::set_current_name(name);
+                    crate::theme::set(theme);
+                }
+                Err(e) => startup_warnings.push(format!("config ui.theme: {e}")),
+            }
+        }
 
         static PROCESS_WARMUP: std::sync::Once = std::sync::Once::new();
         PROCESS_WARMUP.call_once(|| {

--- a/maki-ui/src/lib.rs
+++ b/maki-ui/src/lib.rs
@@ -20,6 +20,7 @@ pub mod splash;
 mod storage_writer;
 mod text_buffer;
 mod theme;
+pub use theme::BUNDLED_THEMES;
 pub mod update;
 
 mod agent;

--- a/maki-ui/src/theme.rs
+++ b/maki-ui/src/theme.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, LazyLock};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use arc_swap::{ArcSwap, Guard};
 use maki_storage::StateDir;
@@ -251,6 +251,8 @@ static THEME: LazyLock<ArcSwap<Theme>> =
 
 static GENERATION: AtomicU64 = AtomicU64::new(0);
 
+static CURRENT_NAME: Mutex<Option<String>> = Mutex::new(None);
+
 pub fn current() -> Guard<Arc<Theme>> {
     THEME.load()
 }
@@ -275,7 +277,12 @@ pub fn load_by_name(name: &str) -> Result<Theme, String> {
         .unwrap_or_else(|| Err(format!("unknown theme: {name}")))
 }
 
+pub fn set_current_name(name: &str) {
+    *CURRENT_NAME.lock().unwrap() = Some(name.to_owned());
+}
+
 pub fn persist_theme(name: &str) {
+    set_current_name(name);
     if let Ok(dir) = StateDir::resolve() {
         maki_storage::theme::persist_theme_name(&dir, name);
     }
@@ -287,6 +294,9 @@ fn read_theme_name() -> Option<String> {
 }
 
 pub fn current_theme_name() -> String {
+    if let Some(name) = CURRENT_NAME.lock().unwrap().clone() {
+        return name;
+    }
     read_theme_name().unwrap_or_else(|| DEFAULT_THEME.to_owned())
 }
 
@@ -994,6 +1004,12 @@ mod tests {
     #[test]
     fn load_by_name_unknown() {
         assert!(load_by_name("nonexistent").is_err());
+    }
+
+    #[test]
+    fn current_theme_name_prefers_in_memory_name() {
+        set_current_name("zenburn");
+        assert_eq!(current_theme_name(), "zenburn");
     }
 
     #[test]

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -23,6 +23,7 @@ maki.setup({
     ui = {
         splash_animation = true,
         mouse_scroll_lines = 5,
+        theme = "tokyonight",
         tool_output_lines = {
             bash = 8,
             read = 5,
@@ -69,6 +70,12 @@ All fields are optional. Typos in field names cause an error right away.
 | `typewriter_ms_per_char` | u64 | `4` | - | Typewriter effect speed (ms/char) |
 | `mouse_scroll_lines` | u32 | `3` | 1 | Lines per mouse wheel scroll |
 | `show_thinking` | bool | `true` | - | When true (default), show full model reasoning live and persisted. When false, hide reasoning behind an indicator (thinking> ...) with a click-to-expand hint, both while thinking and after it completes |
+
+### `ui.theme`
+
+Name of the color theme to load at startup, overriding the theme you last picked interactively. If unset, Maki keeps your last selection (the built-in default on first run). An unknown name is ignored with a warning.
+
+Available themes: `ayu_dark`, `ayu_light`, `ayu_mirage`, `carbonfox`, `catppuccin_frappe`, `catppuccin_latte`, `catppuccin_macchiato`, `catppuccin_mocha`, `dracula`, `everforest_dark`, `fleet_dark`, `github_dark`, `gruvbox`, `gruvbox_light`, `kanagawa`, `material_darker`, `monokai_pro`, `night_owl`, `nightfox`, `nord`, `onedark`, `rose_pine`, `rose_pine_dawn`, `rose_pine_moon`, `solarized_dark`, `solarized_light`, `tokyonight`, `vscode_dark_plus`, `zenburn`.
 
 ### `ui.tool_output_lines`
 

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -324,7 +324,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
                 startup_warnings: std::mem::take(&mut warnings),
                 storage: storage.clone(),
                 config: stack.config.agent.clone(),
-                ui_config: stack.config.ui,
+                ui_config: stack.config.ui.clone(),
                 input_history_size: stack.config.storage.input_history_size,
                 permissions: Arc::new(maki_agent::permissions::PermissionManager::new(
                     stack.config.permissions.clone(),


### PR DESCRIPTION
Adds a `theme` key to the `[ui]` config section so users can pin a bundled theme at startup instead of relying on the persisted/last-used theme.

```toml
[ui]
theme = "dracula"
```

## Behavior

- On startup, if ui.theme is set, the named bundled theme is loaded and installed.
- The name is also persisted, so the interactive theme picker opens on the configured entry and stays consistent with the live theme.
- The theme is applied before the syntax-highlight warmup thread starts, avoiding a race where the warmup thread could re-install a stale syntax palette after the config theme was set.
- An unknown/misspelled name logs a warning and leaves the current theme untouched (no hard failure).

## Notes

- UiConfig gains an owned String field and so drops Copy; affected call sites now .clone(). Behavior is otherwise unchanged.

## Testing

- cargo nextest run -p maki-ui -p maki-config — 1120 passed.
- fmt / clippy (-D warnings) / gen-docs-check clean.

Disclosure: Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>