### PR TITLE
feat: token-savings follow-up (dynamic tools, MCP guard, Google cache, Anthropic breakpoints, session compaction, prompt compression)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,14 @@ rust-version = "1.88"
 name = "maki"
 path = "src/main.rs"
 
+[[bin]]
+name = "anthropic_cache_benchmark"
+path = "scripts/anthropic_cache_benchmark.rs"
+
+[[bin]]
+name = "dynamic_tool_size"
+path = "scripts/dynamic_tool_size.rs"
+
 [dependencies]
 maki-ui = { workspace = true }
 maki-agent = { workspace = true }

--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -11,7 +11,53 @@ use super::streaming::stream_with_retry;
 use crate::cancel::CancelToken;
 use crate::{AgentError, AgentEvent, EventSender, TurnCompleteEvent};
 
-pub(super) const CONTINUE_AFTER_COMPACT: &str = "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed. If the summary contains a todo list, restore it with todo_write and keep it updated. If you learned important project context during this session, consider saving it to memory before it's lost.";
+pub(super) const CONTINUE_AFTER_COMPACT: &str = "Continue if you have next steps, or stop and ask for clarification if unsure. Restore todo lists with todo_write. Save important context to memory before it's lost.";
+
+const MINIMAL_CONTEXT_RATIO: f64 = 0.2;
+const AGGRESSIVE_CONTEXT_RATIO: f64 = 0.4;
+const NORMAL_BUDGET_RATIO: f64 = 0.15;
+const AGGRESSIVE_BUDGET_RATIO: f64 = 0.10;
+const MINIMAL_BUDGET_RATIO: f64 = 0.05;
+const MIN_COMPACTION_BUDGET: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompactionTier {
+    Normal,
+    Aggressive,
+    Minimal,
+}
+
+impl CompactionTier {
+    #[must_use]
+    pub fn from_remaining_context(remaining: u32, context_window: u32) -> Self {
+        if context_window == 0 {
+            return Self::Normal;
+        }
+        let ratio = f64::from(remaining) / f64::from(context_window);
+        if ratio < MINIMAL_CONTEXT_RATIO {
+            Self::Minimal
+        } else if ratio < AGGRESSIVE_CONTEXT_RATIO {
+            Self::Aggressive
+        } else {
+            Self::Normal
+        }
+    }
+
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    pub fn token_budget(self, context_window: u32) -> u32 {
+        if context_window == 0 {
+            return 0;
+        }
+        let ratio = match self {
+            Self::Normal => NORMAL_BUDGET_RATIO,
+            Self::Aggressive => AGGRESSIVE_BUDGET_RATIO,
+            Self::Minimal => MINIMAL_BUDGET_RATIO,
+        };
+        ((f64::from(context_window) * ratio) as u32).max(MIN_COMPACTION_BUDGET)
+    }
+}
+
 const IMAGE_PLACEHOLDER: &str = "[image]";
 
 pub(super) async fn compact_history(
@@ -26,7 +72,22 @@ pub(super) async fn compact_history(
     strip_images(&mut compaction_history);
     strip_thinking(&mut compaction_history);
     strip_old_tool_results(&mut compaction_history);
-    compaction_history.push(Message::user(crate::prompt::COMPACTION_USER.to_string()));
+
+    let context_window = model.context_window;
+    let current_usage = crate::agent::run::estimate_message_tokens(&compaction_history);
+    let remaining = context_window.saturating_sub(current_usage);
+    let tier = CompactionTier::from_remaining_context(remaining, context_window);
+    let budget = tier.token_budget(context_window);
+
+    let user_prompt = format!(
+        "{}\n\nToken budget: {} tokens (tier: {:?}, remaining: {}/{} context)",
+        crate::prompt::COMPACTION_USER,
+        budget,
+        tier,
+        remaining,
+        context_window
+    );
+    compaction_history.push(Message::user(user_prompt));
 
     let empty_tools = serde_json::json!([]);
     let max_attempts = 3;
@@ -277,6 +338,44 @@ mod tests {
         let mut model = default_model();
         model.context_window = context_window;
         model
+    }
+
+    #[test_case(0,     0, CompactionTier::Normal    ; "zero_context_window_defaults_normal")]
+    #[test_case(0,   100, CompactionTier::Minimal    ; "empty_remaining_is_minimal")]
+    #[test_case(10,  100, CompactionTier::Minimal    ; "low_ratio_minimal")]
+    #[test_case(19,  100, CompactionTier::Minimal    ; "just_below_0_2")]
+    #[test_case(20,  100, CompactionTier::Aggressive ; "at_0_2_boundary")]
+    #[test_case(30,  100, CompactionTier::Aggressive ; "mid_ratio_aggressive")]
+    #[test_case(39,  100, CompactionTier::Aggressive ; "just_below_0_4")]
+    #[test_case(40,  100, CompactionTier::Normal     ; "at_0_4_boundary")]
+    #[test_case(50,  100, CompactionTier::Normal     ; "high_ratio_normal")]
+    #[test_case(199, 1000, CompactionTier::Minimal    ; "just_below_0_2_at_1000")]
+    #[test_case(200, 1000, CompactionTier::Aggressive ; "at_0_2_boundary_1000")]
+    #[test_case(399, 1000, CompactionTier::Aggressive ; "just_below_0_4_at_1000")]
+    #[test_case(400, 1000, CompactionTier::Normal     ; "at_0_4_boundary_1000")]
+    #[test_case(1999, 10000, CompactionTier::Minimal    ; "just_below_0_2_at_10000")]
+    #[test_case(2000, 10000, CompactionTier::Aggressive ; "at_0_2_boundary_10000")]
+    #[test_case(3999, 10000, CompactionTier::Aggressive ; "just_below_0_4_at_10000")]
+    #[test_case(4000, 10000, CompactionTier::Normal     ; "at_0_4_boundary_10000")]
+    fn compaction_tier_from_remaining(
+        remaining: u32,
+        context_window: u32,
+        expected: CompactionTier,
+    ) {
+        assert_eq!(
+            CompactionTier::from_remaining_context(remaining, context_window),
+            expected
+        );
+    }
+
+    #[test_case(CompactionTier::Normal,     100, 15 ; "normal_budget")]
+    #[test_case(CompactionTier::Aggressive, 100, 10 ; "aggressive_budget")]
+    #[test_case(CompactionTier::Minimal,    100,  5 ; "minimal_budget")]
+    #[test_case(CompactionTier::Minimal,      1,  1 ; "tiny_window_minimum_budget")]
+    #[test_case(CompactionTier::Minimal,      2,  1 ; "small_window_still_minimum")]
+    #[test_case(CompactionTier::Normal,       0,  0 ; "zero_window_zero_budget")]
+    fn compaction_tier_budget(tier: CompactionTier, context_window: u32, expected: u32) {
+        assert_eq!(tier.token_budget(context_window), expected);
     }
 
     fn text_response(stop_reason: StopReason) -> StreamResponse {
@@ -586,5 +685,45 @@ mod tests {
         truncate_oldest_round(&mut messages);
         assert!(!messages.is_empty());
         assert!(matches!(messages[0].role, Role::User));
+    }
+
+    #[test]
+    fn compact_produces_user_assistant_pair() {
+        smol::block_on(async {
+            let provider: std::sync::Arc<dyn Provider> =
+                std::sync::Arc::new(MockProvider::new(vec![text_response(StopReason::EndTurn)]));
+            let model = default_model();
+            let (raw_tx, _rx) = flume::unbounded();
+            let mut history = History::new(vec![
+                Message::user("first".into()),
+                Message {
+                    role: Role::Assistant,
+                    content: vec![ContentBlock::Text {
+                        text: "reply".into(),
+                    }],
+                    ..Default::default()
+                },
+            ]);
+
+            compact(
+                &*provider,
+                &model,
+                &mut history,
+                &EventSender::new(raw_tx, 0),
+            )
+            .await
+            .unwrap();
+
+            let msgs = history.as_slice();
+            assert_eq!(msgs.len(), 2);
+            assert!(matches!(msgs[0].role, Role::User));
+            assert!(matches!(msgs[1].role, Role::Assistant));
+            assert!(
+                msgs[0]
+                    .first_text_content()
+                    .unwrap()
+                    .contains("What did we do so far?")
+            );
+        });
     }
 }

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -17,7 +17,11 @@ use super::tool_dispatch::{self, RecentCalls};
 use crate::cancel::{CancelMap, CancelToken};
 use crate::mcp::McpSession;
 use crate::permissions::PermissionManager;
-use crate::tools::{Deadline, FileReadTracker, LocalTools, ToolAudience, ToolContext};
+use crate::template;
+use crate::tools::{
+    Deadline, DescriptionContext, FileReadTracker, LocalTools, ToolAudience, ToolContext,
+    ToolFilter,
+};
 use crate::{
     AgentConfig, AgentError, AgentEvent, AgentInput, AgentMode, EventSender, ExtractedCommand,
     InterruptSource, TurnCompleteEvent,
@@ -107,6 +111,8 @@ pub struct Agent<'h> {
     audience: ToolAudience,
     workflow: bool,
     local_tools: LocalTools,
+    activated_tools: std::collections::HashSet<Arc<str>>,
+    excluded_tools: Vec<&'static str>,
 }
 
 impl<'h> Agent<'h> {
@@ -145,6 +151,8 @@ impl<'h> Agent<'h> {
             audience: params.audience,
             workflow: false,
             local_tools: LocalTools::default(),
+            activated_tools: std::collections::HashSet::new(),
+            excluded_tools: Vec::new(),
         }
     }
 
@@ -176,9 +184,37 @@ impl<'h> Agent<'h> {
         self
     }
 
+    pub fn with_excluded_tools(mut self, excluded: &[&'static str]) -> Self {
+        self.excluded_tools = excluded.to_vec();
+        self
+    }
+
     pub fn with_loaded_instructions(mut self, loaded: LoadedInstructions) -> Self {
         self.loaded_instructions = loaded;
         self
+    }
+
+    fn rebuild_tools(&self) -> Value {
+        let vars = template::env_vars();
+        let filter = ToolFilter::from_config(&self.config, &self.model, &self.excluded_tools);
+        let ctx = DescriptionContext {
+            filter: &filter,
+            audience: self.audience,
+            workflow: self.workflow,
+        };
+        let mode = &self.config.dynamic_tools.default_mode;
+        let additional: Vec<Arc<str>> = self.activated_tools.iter().cloned().collect();
+        let allowed = self.registry.active_tools_for_mode(mode, &additional);
+        let mut tools = self.registry.definitions_filtered(
+            &vars,
+            &ctx,
+            self.model.supports_tool_examples(),
+            &allowed,
+        );
+        if let Some(ref mcp) = self.mcp {
+            mcp.extend_tools(&mut tools);
+        }
+        tools
     }
 
     pub async fn run(&mut self, input: AgentInput) -> Result<(), AgentError> {
@@ -190,6 +226,7 @@ impl<'h> Agent<'h> {
         self.opts = RequestOptions {
             thinking: input.thinking,
             fast: input.fast,
+            message_cache_breakpoints: 2,
         };
 
         info!(
@@ -244,6 +281,9 @@ impl<'h> Agent<'h> {
         if self.cancel.is_cancelled() {
             return Err(AgentError::Cancelled);
         }
+        if self.config.dynamic_tools.enabled {
+            self.tools = self.rebuild_tools();
+        }
         let tools = self.request_tools();
         let response = match stream_with_retry(
             &*self.provider,
@@ -294,8 +334,9 @@ impl<'h> Agent<'h> {
         if has_tools {
             let history_len_before = self.history.len();
             self.process_tool_calls(response).await?;
-            self.context_size +=
-                estimate_message_tokens(&self.history.as_slice()[history_len_before..]);
+            self.context_size = self.context_size.saturating_add(estimate_message_tokens(
+                &self.history.as_slice()[history_len_before..],
+            ));
         } else {
             let has_text = response.message.first_text_content().is_some();
 
@@ -393,6 +434,18 @@ impl<'h> Agent<'h> {
     async fn process_tool_calls(&mut self, response: StreamResponse) -> Result<(), AgentError> {
         self.post_tool_empty_retried = false;
         let ctx = self.tool_context();
+
+        if self.config.dynamic_tools.enabled {
+            for call in &response.message.content {
+                if let maki_providers::ContentBlock::ToolUse { name, input, .. } = call
+                    && name == "activate_tool"
+                    && let Some(tool_name) = input.get("tool_name").and_then(|v| v.as_str())
+                {
+                    self.activated_tools.insert(Arc::from(tool_name));
+                }
+            }
+        }
+
         tool_dispatch::process_tool_calls(
             response,
             &mut self.recent_calls,
@@ -516,7 +569,17 @@ pub fn estimate_message_tokens(messages: &[Message]) -> u32 {
             _ => None,
         })
         .sum();
-    (total_bytes.max(CHARS_PER_TOKEN) / CHARS_PER_TOKEN) as u32
+    let count = total_bytes.max(CHARS_PER_TOKEN) / CHARS_PER_TOKEN;
+    match u32::try_from(count) {
+        Ok(n) => n,
+        Err(_) => {
+            warn!(
+                count,
+                "estimated token count exceeded u32 range; saturating"
+            );
+            u32::MAX
+        }
+    }
 }
 
 #[cfg(test)]
@@ -627,12 +690,20 @@ mod tests {
         provider: MockProvider,
         history: &mut History,
     ) -> (Agent<'_>, flume::Receiver<Envelope>) {
+        make_agent_with_config(provider, history, AgentConfig::default())
+    }
+
+    fn make_agent_with_config(
+        provider: MockProvider,
+        history: &mut History,
+        config: AgentConfig,
+    ) -> (Agent<'_>, flume::Receiver<Envelope>) {
         let (raw_tx, event_rx) = flume::unbounded();
         let agent = Agent::new(
             AgentParams {
                 provider: Arc::new(provider),
                 model: default_model(),
-                config: AgentConfig::default(),
+                config,
                 tool_output_lines: ToolOutputLines::default(),
                 permissions: Arc::new(PermissionManager::new(
                     maki_config::PermissionsConfig {
@@ -1044,5 +1115,76 @@ mod tests {
                 .expect("expected Done event");
             assert_eq!(done, expected_turns);
         });
+    }
+
+    #[test]
+    fn activate_tool_adds_to_activated_set() {
+        smol::block_on(async {
+            let mut config = AgentConfig::default();
+            config.dynamic_tools.enabled = true;
+
+            let activate_response = StreamResponse {
+                message: Message {
+                    role: Role::Assistant,
+                    content: vec![ContentBlock::ToolUse {
+                        id: "t1".into(),
+                        name: "activate_tool".into(),
+                        input: serde_json::json!({"tool_name": "write_tool"}),
+                    }],
+                    ..Default::default()
+                },
+                usage: TokenUsage::default(),
+                stop_reason: Some(StopReason::EndTurn),
+            };
+
+            let responses = vec![activate_response, text_response(StopReason::EndTurn)];
+
+            let mut history = History::new(Vec::new());
+            let (mut agent, _event_rx) =
+                make_agent_with_config(MockProvider::new(responses), &mut history, config);
+
+            let input = AgentInput {
+                message: "activate write_tool".into(),
+                images: vec![],
+                mode: AgentMode::default(),
+                workflow: false,
+                thinking: maki_providers::ThinkingConfig::Off,
+                fast: false,
+                preamble: vec![],
+                prompt: None,
+            };
+
+            let _ = agent.run(input).await;
+            assert!(agent.activated_tools.contains(&Arc::from("write_tool")));
+        });
+    }
+
+    #[test]
+    fn estimate_message_tokens_empty_is_zero() {
+        assert_eq!(estimate_message_tokens(&[]), 0);
+    }
+
+    #[test]
+    fn estimate_message_tokens_counts_bytes_per_four() {
+        let messages = vec![
+            Message::user("hello world".into()),
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::Text {
+                    text: "response".into(),
+                }],
+                ..Default::default()
+            },
+        ];
+        let count = estimate_message_tokens(&messages);
+        assert_eq!(count, 4, "expected 4 tokens for 19 bytes at 4 bytes/token");
+    }
+
+    #[test]
+    fn context_size_addition_uses_saturating_add() {
+        let context_size: u32 = u32::MAX - 100;
+        let addition: u32 = 200;
+        let result = context_size.saturating_add(addition);
+        assert_eq!(result, u32::MAX);
     }
 }

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -462,6 +462,7 @@ pub(super) async fn process_tool_calls(
 
     let mut all_results = results;
     all_results.extend(immediate_errors);
+
     let tool_msg = crate::types::tool_results(all_results);
     event_tx.send(AgentEvent::ToolResultsSubmitted {
         message: Box::new(tool_msg.clone()),
@@ -961,6 +962,46 @@ mod tests {
                 !executed.load(Ordering::SeqCst),
                 "execute must not run after denial"
             );
+        });
+    }
+
+    #[test]
+    fn local_tool_progress_keywords_returned_unchanged() {
+        smol::block_on(async {
+            const PROGRESS_TEXT: &str = "Building project... 100% complete ==> Done";
+            let ctx = local_ctx("progress", |_| Ok(PROGRESS_TEXT.to_string()));
+            let done = run(
+                ToolRegistry::global(),
+                None,
+                "t1".into(),
+                "progress",
+                &serde_json::json!({}),
+                &ctx,
+                Emit::Silent,
+            )
+            .await;
+            assert!(!done.is_error);
+            assert_eq!(done.output.as_text(), PROGRESS_TEXT);
+        });
+    }
+
+    #[test]
+    fn local_tool_error_preserves_message_unchanged() {
+        smol::block_on(async {
+            const ERROR_MSG: &str = "100% failed";
+            let ctx = local_ctx("fail", |_| Err(ERROR_MSG.to_string()));
+            let done = run(
+                ToolRegistry::global(),
+                None,
+                "t1".into(),
+                "fail",
+                &serde_json::json!({}),
+                &ctx,
+                Emit::Silent,
+            )
+            .await;
+            assert!(done.is_error);
+            assert_eq!(done.output.as_text(), ERROR_MSG);
         });
     }
 }

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -10,7 +11,7 @@ use maki_providers::model::Model;
 use maki_providers::provider::{self, Provider};
 use maki_storage::StateDir;
 use maki_storage::id::{MakiId, SessionRef};
-use maki_storage::sessions::Session;
+use maki_storage::sessions::{Session, compact_tool_outputs};
 use serde_json::Value;
 use tracing::{error, warn};
 
@@ -64,6 +65,18 @@ impl SessionStore {
         self.session.messages = messages.to_vec();
         self.session.model = model_spec;
         self.session.update_title_if_default();
+
+        const RECENT_TURNS: usize = 3;
+        let recent_turn_start = messages.len().saturating_sub(RECENT_TURNS);
+        let mut recent_tool_ids = HashSet::new();
+
+        for msg in &messages[recent_turn_start..] {
+            for (id, _, _) in msg.tool_uses() {
+                recent_tool_ids.insert(id.to_string());
+            }
+        }
+
+        compact_tool_outputs(&mut self.session, &recent_tool_ids);
         self.save();
     }
 }
@@ -97,6 +110,16 @@ struct AgentSetup {
     tools: Value,
 }
 
+struct ToolDefinitionsParams<'a> {
+    vars: &'a template::Vars,
+    model: &'a Model,
+    config: &'a AgentConfig,
+    excluded_tools: &'a [&'static str],
+    workflow: bool,
+    registry: &'a ToolRegistry,
+    additional_active: &'a [Arc<str>],
+}
+
 fn setup(
     model: &Model,
     config: &AgentConfig,
@@ -105,14 +128,16 @@ fn setup(
 ) -> AgentSetup {
     let vars = template::env_vars();
     let instructions = agent::load_instructions(&vars.apply("{cwd}"));
-    let tools = tool_definitions(
-        &vars,
+    let params = ToolDefinitionsParams {
+        vars: &vars,
         model,
         config,
         excluded_tools,
         workflow,
-        ToolRegistry::global(),
-    );
+        registry: ToolRegistry::global(),
+        additional_active: &[],
+    };
+    let tools = tool_definitions(&params);
 
     AgentSetup {
         vars,
@@ -121,23 +146,29 @@ fn setup(
     }
 }
 
-/// Base definitions only. MCP definitions are injected per request by
-/// `Agent::request_tools`; storing them here would freeze the catalog.
-fn tool_definitions(
-    vars: &template::Vars,
-    model: &Model,
-    config: &AgentConfig,
-    excluded_tools: &[&'static str],
-    workflow: bool,
-    registry: &ToolRegistry,
-) -> Value {
-    let filter = ToolFilter::from_config(config, model, excluded_tools);
+fn tool_definitions(params: &ToolDefinitionsParams) -> Value {
+    let filter = ToolFilter::from_config(params.config, params.model, params.excluded_tools);
     let ctx = DescriptionContext {
         filter: &filter,
         audience: ToolAudience::MAIN,
-        workflow,
+        workflow: params.workflow,
     };
-    registry.definitions(vars, &ctx, model.supports_tool_examples())
+    if params.config.dynamic_tools.enabled {
+        let mode = &params.config.dynamic_tools.default_mode;
+        let allowed = params
+            .registry
+            .active_tools_for_mode(mode, params.additional_active);
+        params.registry.definitions_filtered(
+            params.vars,
+            &ctx,
+            params.model.supports_tool_examples(),
+            &allowed,
+        )
+    } else {
+        params
+            .registry
+            .definitions(params.vars, &ctx, params.model.supports_tool_examples())
+    }
 }
 
 /// Names advertised to SDK clients: base tools plus what the first request
@@ -227,7 +258,8 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
                 },
             )
             .with_loaded_instructions(instructions.loaded)
-            .with_mcp(mcp);
+            .with_mcp(mcp)
+            .with_excluded_tools(&params.excluded_tools);
 
             let result = agent
                 .run(AgentInput {
@@ -369,14 +401,16 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                     match provider::from_model_async(&mut new_model, params.timeouts).await {
                         Ok(p) => {
                             provider = Arc::from(p);
-                            tools = tool_definitions(
-                                &vars,
-                                &new_model,
-                                &params.config,
-                                &params.excluded_tools,
-                                params.workflow,
-                                ToolRegistry::global(),
-                            );
+                            let tool_params = ToolDefinitionsParams {
+                                vars: &vars,
+                                model: &new_model,
+                                config: &params.config,
+                                excluded_tools: params.excluded_tools.as_slice(),
+                                workflow: params.workflow,
+                                registry: ToolRegistry::global(),
+                                additional_active: &[],
+                            };
+                            tools = tool_definitions(&tool_params);
                             model = new_model;
                         }
                         Err(e) => {
@@ -441,7 +475,8 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                 .with_loaded_instructions(instructions.loaded.clone())
                 .with_user_response_rx(Arc::clone(&answer_rx))
                 .with_cancel(cancel)
-                .with_mcp(mcp.clone());
+                .with_mcp(mcp.clone())
+                .with_excluded_tools(&params.excluded_tools);
 
                 let result = agent.run(input).await;
                 drop(agent);

--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -29,6 +29,8 @@ use maki_providers::{ContentBlock, Message};
 use serde_json::{Value, json};
 use tracing::{info, warn};
 
+use crate::tools::schema::{sanitize_tool_input_schema, truncate_on_word_boundary};
+
 use self::config::{
     McpConfig, McpConfigErrors, McpServerInfo, McpServerStatus, ServerConfig, Transport,
     load_config, parse_server, transport_kind,
@@ -183,6 +185,7 @@ impl ServerEntry {
 struct McpManagerInner {
     entries: Vec<ServerEntry>,
     generation: u64,
+    max_desc_chars: usize,
 }
 
 #[derive(Default)]
@@ -542,15 +545,15 @@ impl McpHandle {
     }
 }
 
-pub async fn start(cwd: &Path) -> (Option<McpHandle>, McpConfigErrors) {
+pub async fn start(cwd: &Path, max_desc_chars: usize) -> (Option<McpHandle>, McpConfigErrors) {
     tracing::info!(cwd = %cwd.display(), "starting MCP");
     let cwd = cwd.to_owned();
     let (config, config_errors) = smol::unblock(move || load_config(&cwd)).await;
-    let handle = start_with_config(config).await;
+    let handle = start_with_config(config, max_desc_chars).await;
     (handle, config_errors)
 }
 
-pub async fn start_with_config(config: McpConfig) -> Option<McpHandle> {
+pub async fn start_with_config(config: McpConfig, max_desc_chars: usize) -> Option<McpHandle> {
     if config.is_empty() {
         tracing::info!("no MCP servers configured, skipping");
         return None;
@@ -558,12 +561,13 @@ pub async fn start_with_config(config: McpConfig) -> Option<McpHandle> {
 
     let defer_tools = config.defer_tools.unwrap_or(DEFAULT_DEFER_TOOLS);
     let mut inner = parse_entries(config);
+    inner.max_desc_chars = max_desc_chars;
     start_enabled(&mut inner).await;
     inner.generation += 1;
 
     let snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot::default()));
     let index: Arc<ArcSwap<ToolIndex>> = Arc::new(ArcSwap::from_pointee(ToolIndex::default()));
-    publish(&inner, &index, &snapshot);
+    publish(&inner, &index, &snapshot, max_desc_chars);
 
     let (cmd_tx, cmd_rx) = flume::unbounded();
     let handle = McpHandle {
@@ -608,11 +612,11 @@ async fn run(
             }
         }
         inner.generation += 1;
-        publish(&inner, &index, &snapshot);
+        publish(&inner, &index, &snapshot, inner.max_desc_chars);
     }
     shutdown_all(&mut inner).await;
     inner.generation += 1;
-    publish(&inner, &index, &snapshot);
+    publish(&inner, &index, &snapshot, inner.max_desc_chars);
     if let Some(tx) = ack {
         let _ = tx.try_send(());
     }
@@ -807,6 +811,7 @@ fn parse_entries(config: McpConfig) -> McpManagerInner {
     McpManagerInner {
         entries,
         generation: 0,
+        max_desc_chars: maki_config::DEFAULT_MCP_TOOL_DESC_MAX_CHARS,
     }
 }
 
@@ -847,7 +852,12 @@ fn apply_start_result(
 }
 
 /// The only place read-side state is updated. Every mutation in the command loop ends here.
-fn publish(inner: &McpManagerInner, index: &ArcSwap<ToolIndex>, snapshot: &ArcSwap<McpSnapshot>) {
+fn publish(
+    inner: &McpManagerInner,
+    index: &ArcSwap<ToolIndex>,
+    snapshot: &ArcSwap<McpSnapshot>,
+    max_desc_chars: usize,
+) {
     let mut tools = HashMap::new();
     let mut prompts = HashMap::new();
     let mut descriptors: Vec<ToolDescriptor> = Vec::new();
@@ -873,13 +883,31 @@ fn publish(inner: &McpManagerInner, index: &ArcSwap<ToolIndex>, snapshot: &ArcSw
                         transport: Arc::clone(transport),
                     },
                 );
+
+                let description_chars = t.description.chars().count();
+                let description = if description_chars > max_desc_chars {
+                    let truncated = truncate_on_word_boundary(&t.description, max_desc_chars);
+                    warn!(
+                        tool = %t.qualified_name,
+                        original_len = description_chars,
+                        truncated_len = truncated.chars().count(),
+                        max_len = max_desc_chars,
+                        "truncated MCP tool description"
+                    );
+                    truncated
+                } else {
+                    t.description.clone()
+                };
+
+                let input_schema = sanitize_tool_input_schema(t.input_schema.clone());
+
                 descriptors.push(ToolDescriptor {
                     qualified_name: Arc::clone(&t.qualified_name),
                     always_load,
                     definition: json!({
                         "name": wire_tool_name(&t.qualified_name),
-                        "description": t.description,
-                        "input_schema": t.input_schema,
+                        "description": description,
+                        "input_schema": input_schema,
                     }),
                 });
             }
@@ -948,10 +976,11 @@ pub(crate) fn stub_session(tools: &[(&str, &str)]) -> McpSession {
     let inner = McpManagerInner {
         entries: vec![entry],
         generation: 0,
+        max_desc_chars: maki_config::DEFAULT_MCP_TOOL_DESC_MAX_CHARS,
     };
     let index = Arc::new(ArcSwap::from_pointee(ToolIndex::default()));
     let snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot::default()));
-    publish(&inner, &index, &snapshot);
+    publish(&inner, &index, &snapshot, inner.max_desc_chars);
     McpSession::new(
         McpHandle {
             cmd_tx: flume::unbounded().0,
@@ -1257,10 +1286,11 @@ mod tests {
         let inner = McpManagerInner {
             entries,
             generation: 0,
+            max_desc_chars: maki_config::DEFAULT_MCP_TOOL_DESC_MAX_CHARS,
         };
         let index = Arc::new(ArcSwap::from_pointee(ToolIndex::default()));
         let snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot::default()));
-        publish(&inner, &index, &snapshot);
+        publish(&inner, &index, &snapshot, inner.max_desc_chars);
         let handle = McpHandle {
             cmd_tx: flume::unbounded().0,
             index,
@@ -1612,7 +1642,7 @@ mod tests {
     #[test]
     fn start_with_config_produces_terminal_statuses() {
         smol::block_on(async {
-            let handle = start_with_config(McpConfig::default()).await;
+            let handle = start_with_config(McpConfig::default(), 300).await;
             assert!(handle.is_none());
 
             let mut disabled = stdio_raw(&["unused-disabled-cmd"]);
@@ -1621,7 +1651,7 @@ mod tests {
                 ("disabled-srv", disabled),
                 ("bad-srv", stdio_raw(&[])),
             ]);
-            let handle = start_with_config(config).await;
+            let handle = start_with_config(config, 300).await;
             let handle = handle.unwrap();
             let infos = handle.reader().load().infos.clone();
 
@@ -1666,7 +1696,12 @@ mod tests {
             assert_eq!(tools[0]["name"], TOOL_SEARCH_TOOL_NAME);
 
             handle_toggle(&mut inner, "srv", false).await;
-            publish(&inner, &handle.index, &handle.snapshot);
+            publish(
+                &inner,
+                &handle.index,
+                &handle.snapshot,
+                inner.max_desc_chars,
+            );
 
             let entry = &inner.entries[0];
             assert_eq!(t.shutdowns(), 1);
@@ -1699,7 +1734,12 @@ mod tests {
 
             entered.recv_async().await.unwrap();
             inner.generation += 1;
-            publish(&inner, &handle.index, &handle.snapshot);
+            publish(
+                &inner,
+                &handle.index,
+                &handle.snapshot,
+                inner.max_desc_chars,
+            );
             assert_eq!(handle.snapshot.load().generation, 1);
 
             drop(held);
@@ -1717,6 +1757,7 @@ mod tests {
                     fake_entry("b", Arc::clone(&t2) as _),
                 ],
                 generation: 0,
+                max_desc_chars: maki_config::DEFAULT_MCP_TOOL_DESC_MAX_CHARS,
             };
             let index = Arc::new(ArcSwap::from_pointee(ToolIndex::default()));
             let snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot::default()));
@@ -1745,6 +1786,57 @@ mod tests {
         // Valid: alphanumeric, underscore, hyphen, 1-64 chars
         assert!(is_valid_tool_name("search"));
         assert!(is_valid_tool_name("web_search"));
+    }
+
+    #[test]
+    fn publish_truncates_long_descriptions() {
+        let t = FakeTransport::new();
+        let mut entry = fake_entry("srv", Arc::clone(&t) as _);
+        entry.tools[0].description = "a".repeat(500);
+        let inner = McpManagerInner {
+            entries: vec![entry],
+            generation: 0,
+            max_desc_chars: 100,
+        };
+        let index = Arc::new(ArcSwap::from_pointee(ToolIndex::default()));
+        let snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot::default()));
+        publish(&inner, &index, &snapshot, 100);
+
+        let descriptors = &index.load().descriptors;
+        assert_eq!(descriptors.len(), 1);
+        let desc = descriptors[0].definition["description"].as_str().unwrap();
+        assert!(desc.len() <= 103);
+        assert!(desc.ends_with("..."));
+    }
+
+    #[test]
+    fn publish_sanitizes_tool_schemas() {
+        let t = FakeTransport::new();
+        let mut entry = fake_entry("srv", Arc::clone(&t) as _);
+        entry.tools[0].input_schema = json!({
+            "properties": {
+                "path": {"type": "string"}
+            }
+        });
+        let inner = McpManagerInner {
+            entries: vec![entry],
+            generation: 0,
+            max_desc_chars: 300,
+        };
+        let index = Arc::new(ArcSwap::from_pointee(ToolIndex::default()));
+        let snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot::default()));
+        publish(&inner, &index, &snapshot, 300);
+
+        let descriptors = &index.load().descriptors;
+        assert_eq!(descriptors.len(), 1);
+        let schema = &descriptors[0].definition["input_schema"];
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"].is_object());
+    }
+
+    #[test]
+    fn is_valid_tool_name_enforces_wire_format_full() {
+        use config::is_valid_tool_name;
         assert!(is_valid_tool_name("my-tool"));
         assert!(is_valid_tool_name(&"a".repeat(64)));
         // Invalid: empty, dots, special chars, too long

--- a/maki-agent/src/prompt.rs
+++ b/maki-agent/src/prompt.rs
@@ -51,6 +51,7 @@ pub enum SlotKind {
 pub enum Slot {
     Identity,
     Tone,
+    Environment,
     ToolUsage,
     EfficientTools,
     Conventions,
@@ -62,6 +63,7 @@ impl Slot {
         match self {
             Slot::Identity => "{{identity}}",
             Slot::Tone => "{{tone}}",
+            Slot::Environment => "{{environment}}",
             Slot::ToolUsage => "{{tool_usage}}",
             Slot::EfficientTools => "{{efficient_tools}}",
             Slot::Conventions => "{{conventions}}",
@@ -71,7 +73,7 @@ impl Slot {
 
     pub fn kind(self) -> SlotKind {
         match self {
-            Slot::Identity | Slot::Tone => SlotKind::Singleton,
+            Slot::Identity | Slot::Tone | Slot::Environment => SlotKind::Singleton,
             Slot::ToolUsage
             | Slot::EfficientTools
             | Slot::Conventions
@@ -463,7 +465,120 @@ mod tests {
             },
         );
         let out = assemble(PromptId::System, &s, "");
-        assert!(out.contains("Never assume a library is available"));
+        assert!(out.contains("Never assume library availability"));
         assert!(out.contains("- Extra rule"));
+    }
+
+    #[test]
+    fn prompt_templates_compressed_by_at_least_10_percent() {
+        // Baseline sizes before compression (from T061 audit):
+        const SYSTEM_BASELINE: usize = 1418;
+        const GENERAL_BASELINE: usize = 1759;
+        const RESEARCH_BASELINE: usize = 1438;
+        const COMPACTION_USER_BASELINE: usize = 927;
+        const COMPACTION_BASELINE: usize = 669;
+        const PLAN_BASELINE: usize = 1031;
+
+        let system_current = SYSTEM_PROMPT.len();
+        let general_current = GENERAL_PROMPT.len();
+        let research_current = RESEARCH_PROMPT.len();
+        let compaction_user_current = COMPACTION_USER.len();
+        let compaction_current = COMPACTION_SYSTEM.len();
+        let plan_current = PLAN_PROMPT.len();
+
+        // Assert each template is at least 10% smaller than baseline
+        assert!(
+            system_current <= (SYSTEM_BASELINE * 9 / 10),
+            "system.md not compressed enough: {} bytes (baseline: {}, target: {})",
+            system_current,
+            SYSTEM_BASELINE,
+            SYSTEM_BASELINE * 9 / 10
+        );
+        assert!(
+            general_current <= (GENERAL_BASELINE * 9 / 10),
+            "general.md not compressed enough: {} bytes (baseline: {}, target: {})",
+            general_current,
+            GENERAL_BASELINE,
+            GENERAL_BASELINE * 9 / 10
+        );
+        assert!(
+            research_current <= (RESEARCH_BASELINE * 9 / 10),
+            "research.md not compressed enough: {} bytes (baseline: {}, target: {})",
+            research_current,
+            RESEARCH_BASELINE,
+            RESEARCH_BASELINE * 9 / 10
+        );
+        assert!(
+            compaction_user_current <= (COMPACTION_USER_BASELINE * 9 / 10),
+            "compaction_user.md not compressed enough: {} bytes (baseline: {}, target: {})",
+            compaction_user_current,
+            COMPACTION_USER_BASELINE,
+            COMPACTION_USER_BASELINE * 9 / 10
+        );
+        assert!(
+            compaction_current <= (COMPACTION_BASELINE * 9 / 10),
+            "compaction.md not compressed enough: {} bytes (baseline: {}, target: {})",
+            compaction_current,
+            COMPACTION_BASELINE,
+            COMPACTION_BASELINE * 9 / 10
+        );
+        assert!(
+            plan_current <= (PLAN_BASELINE * 9 / 10),
+            "plan.md not compressed enough: {} bytes (baseline: {}, target: {})",
+            plan_current,
+            PLAN_BASELINE,
+            PLAN_BASELINE * 9 / 10
+        );
+    }
+
+    #[test]
+    fn assemble_system_without_environment_has_no_heading_or_marker() {
+        let out = assemble(PromptId::System, &ResolvedSlots::default(), "");
+        assert!(!out.contains("# Environment"));
+        assert!(!out.contains("{{environment}}"));
+    }
+
+    #[test]
+    fn assemble_system_with_environment_shows_heading_and_content() {
+        const ENV_CONTENT: &str = "# Environment\nCurrent date: 2026-07-21";
+        let mut s = ResolvedSlots::default();
+        s.insert(
+            PromptId::System,
+            Slot::Environment,
+            SlotEntry {
+                plugin: Arc::from("test"),
+                content: ENV_CONTENT.into(),
+            },
+        );
+        let out = assemble(PromptId::System, &s, "");
+        assert!(out.contains("# Environment"));
+        assert!(out.contains("Current date: 2026-07-21"));
+        assert!(!out.contains("{{environment}}"));
+    }
+
+    #[test]
+    fn environment_section_placed_between_objectivity_and_tool_usage() {
+        const ENV_CONTENT: &str = "# Environment\nCurrent date: 2026-07-21";
+        let mut s = ResolvedSlots::default();
+        s.insert(
+            PromptId::System,
+            Slot::Environment,
+            SlotEntry {
+                plugin: Arc::from("test"),
+                content: ENV_CONTENT.into(),
+            },
+        );
+        let out = assemble(PromptId::System, &s, "");
+        let obj_idx = out.find("# Professional objectivity").unwrap();
+        let env_idx = out.find("# Environment").unwrap();
+        let tool_idx = out.find("# Tool usage").unwrap();
+        assert!(
+            obj_idx < env_idx,
+            "Environment should be after Professional objectivity"
+        );
+        assert!(
+            env_idx < tool_idx,
+            "Environment should be before Tool usage"
+        );
     }
 }

--- a/maki-agent/src/prompts/compaction.md
+++ b/maki-agent/src/prompts/compaction.md
@@ -1,14 +1,1 @@
-You are a helpful AI assistant tasked with summarizing conversations.
-
-When asked to summarize, provide a detailed but concise summary of the conversation.
-Focus on information that would be helpful for continuing the conversation, including:
-- What was done
-- What is currently being worked on
-- Which files are being modified
-- What needs to be done next
-- Key user requests, constraints, or preferences that should persist
-- Important technical decisions and why they were made
-
-Your summary should be comprehensive enough to provide context but concise enough to be quickly understood.
-
-Do not respond to any questions in the conversation, only output the summary.
+Summarize the conversation concisely for continuation. Cover: what was done, what's in progress, which files are affected, what's next, key user constraints, and important technical decisions. Output only the summary.

--- a/maki-agent/src/prompts/compaction_user.md
+++ b/maki-agent/src/prompts/compaction_user.md
@@ -1,24 +1,27 @@
-Provide a detailed summary for continuing our conversation above.
-Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next.
+Summarize the conversation above concisely. Focus on:
 
-Stick to this template:
+- Goal and current progress
+- Files being modified
+- Key user constraints
+- Next steps
+
+Use this template:
 ---
 ## Goal
-[What goal(s) is the user trying to accomplish?]
+[What is the user trying to accomplish?]
 
-## Instructions
-- [Important instructions the user gave that are relevant]
-- [If there is a plan or spec, include information about it]
+## Progress
+[What was done, what is in progress, what remains]
 
-## Discoveries
-[Notable things learned during this conversation]
+## Files
+[Relevant files read/edited/created]
 
-## Accomplished
-[What work has been completed, what is still in progress, what is left?]
-
-## Relevant files / directories
-[Structured list of relevant files that have been read, edited, or created]
+## Constraints
+[Key user instructions or preferences]
 
 ## Todo list
-[If a todo list was in use, repeat it here verbatim with each item's current status; it must be kept up to date with todo_write after continuing. Otherwise omit this section]
+[All open todo items, if any, so they can be restored with todo_write]
+
+## Next
+[What to do next]
 ---

--- a/maki-agent/src/prompts/general.md
+++ b/maki-agent/src/prompts/general.md
@@ -1,36 +1,36 @@
-You are a general-purpose coding agent. You can explore codebases, modify files, and execute multi-step tasks autonomously.
+You are a general-purpose coding agent. Explore codebases, modify files, execute multi-step tasks autonomously.
 
 Environment:
 - Working directory: {cwd}
 - Platform: {platform}
 
 # Output discipline
-Your entire response is injected into the parent agent's context. Every unnecessary token wastes the caller's budget.
-- Return a **concise summary** of what you did with `file_path:line_number` references.
-- NEVER dump large blocks of code in your response. Quote only minimal relevant snippets when needed.
-- NEVER create documentation, summary, or report files. Only create/modify files that are part of the actual task.
+Your response is injected into parent agent's context. Every unnecessary token wastes budget.
+- Return **concise summary** with `file_path:line_number` references.
+- NEVER dump large code blocks. Quote only minimal relevant snippets.
+- NEVER create docs/summary/report files. Only create/modify task files.
 
-You must NEVER generate or guess URLs unless they are for helping the user with programming.
+NEVER generate/guess URLs unless for programming help.
 
 # Tool usage
-- Every tool result grows your context. Minimize use of verbose tool calls, prefer compact results.
-- **Use batch** for 2+ independent parallel calls, **code_execution** for dependent/chained calls or filtering/processing results.
-- Read files before editing them. Look at surrounding context and imports to match conventions.
-- Prefer edit/multiedit over write; targeted edits use far fewer tokens.
-- NEVER create files unless absolutely necessary. Prefer editing existing files.
+- Tool results grow context. Minimize verbose calls; prefer compact results.
+- Use **batch** for 2+ independent parallel calls, **code_execution** for dependent/chained calls or filtering.
+- Read before editing. Check context/imports to match conventions.
+- Prefer edit/multiedit over write; targeted edits use fewer tokens.
+- NEVER create files unless necessary. Prefer editing existing files.
 {{tool_usage}}
 
 {{efficient_tools}}
 
 # Conventions
-- Never assume a library is available. Check the project's dependency files first.
-- Match existing code style, naming conventions, and patterns.
-- Follow security best practices. Never expose secrets or keys.
+- Never assume library availability. Check dependency files first.
+- Match existing code style, naming, patterns.
+- Follow security best practices. Never expose secrets/keys.
 - Do NOT commit or push changes.
-- When referencing code, use `file_path:line_number` format.
+- Reference code as `file_path:line_number`.
 {{conventions}}
 
 # When done
-- Return a concise summary of what you did and any findings.
-- If you cannot complete what was asked for, say so clearly and explain why.
+- Return concise summary of work and findings.
+- If unable to complete, say so clearly and explain why.
 {{instructions}}

--- a/maki-agent/src/prompts/plan.md
+++ b/maki-agent/src/prompts/plan.md
@@ -3,16 +3,16 @@
 <system-reminder>
 # Plan Mode
 
-CRITICAL: Plan mode ACTIVE. STRICTLY FORBIDDEN: edits, modifications, or system changes to ANY file EXCEPT the plan file below. Do NOT use bash to manipulate files - commands may ONLY read/inspect. You may use write, edit, or multiedit ONLY on the plan file. Any modification to other files is a critical violation. ZERO exceptions.
+CRITICAL: Plan mode ACTIVE. STRICTLY FORBIDDEN: edits/modifications/system changes to ANY file EXCEPT plan file below. Do NOT use bash to manipulate files - commands may ONLY read/inspect. You may use write/edit/multiedit ONLY on plan file. Any modification to other files is critical violation. ZERO exceptions.
 
 ---
 
 ## Responsibility
 
-Your responsibility is to think, read, search, and construct a well-formed plan that accomplishes the user's goal. Your plan should be comprehensive yet concise, detailed enough to execute effectively while avoiding unnecessary verbosity.
+Think, read, search, construct well-formed plan accomplishing user's goal. Plan should be comprehensive yet concise, detailed enough to execute effectively while avoiding unnecessary verbosity.
 
-Use the Question tool freely to ask clarifying questions or get the user's opinion when weighing tradeoffs. Don't make large assumptions about user intent. The goal is to present a well-researched plan and tie up loose ends before implementation begins.
+Use Question tool freely to ask clarifying questions or get user's opinion when weighing tradeoffs. Don't make large assumptions about user intent. Goal: present well-researched plan and tie up loose ends before implementation begins.
 
-Write your plan to: {plan_path} only after all questions are resolved and the plan is finalized.
-When complete, tell the user.
+Write plan to: {plan_path} only after all questions resolved and plan finalized.
+When complete, tell user.
 </system-reminder>

--- a/maki-agent/src/prompts/research.md
+++ b/maki-agent/src/prompts/research.md
@@ -1,24 +1,24 @@
-You are a research agent. Your job is to explore codebases, gather information, and answer questions autonomously.
+You are a research agent. Explore codebases, gather information, answer questions autonomously.
 
-Do NOT modify files. You are read-only.
+Do NOT modify files. Read-only.
 
 Environment:
 - Working directory: {cwd}
 - Platform: {platform}
 
 # Output discipline
-Your entire response is injected into the parent agent's context. Every unnecessary token wastes the caller's budget.
-- Return a **concise summary** of findings with `file_path:line_number` references.
-- NEVER dump large blocks of code. Quote only the minimal relevant snippet (a few lines) when needed.
-- NEVER write files to disk (summary files, reports, notes, etc.).
-- If asked to "find X", return locations and a brief description - not the full contents.
+Your response is injected into parent agent's context. Every unnecessary token wastes budget.
+- Return **concise summary** of findings with `file_path:line_number` references.
+- NEVER dump large code blocks. Quote only minimal relevant snippets (few lines).
+- NEVER write files to disk (summary files, reports, notes).
+- If asked to "find X", return locations + brief description, not full contents.
 
-You must NEVER generate or guess URLs unless they are for helping the user with programming.
+NEVER generate/guess URLs unless for programming help.
 
 # Tool usage
-- Every tool result grows your context. Minimize use of verbose tool calls, prefer compact results.
-- **Use batch** for 2+ independent reads, greps, or globs. Never call them one at a time sequentially.
-- **Use code_execution** for dependent/chained calls (e.g. glob then read matches) or filtering large tool outputs.
+- Tool results grow context. Minimize verbose calls; prefer compact results.
+- Use **batch** for 2+ independent reads/greps/globs. Never call sequentially.
+- Use **code_execution** for dependent/chained calls (e.g. glob then read matches) or filtering large outputs.
 {{tool_usage}}
 
 {{efficient_tools}}
@@ -26,6 +26,6 @@ You must NEVER generate or guess URLs unless they are for helping the user with 
 # Guidelines
 - Search broadly first (glob, grep), then drill into relevant files.
 - Include specific file paths and line numbers when referencing code.
-- If you cannot find what was asked for, say so clearly.
-- Do not speculate beyond what the code shows.
+- If unable to find, say so clearly.
+- Do not speculate beyond what code shows.
 {{instructions}}

--- a/maki-agent/src/prompts/system.md
+++ b/maki-agent/src/prompts/system.md
@@ -4,28 +4,35 @@
 {{tone}}
 
 # Professional objectivity
-Prioritize technical accuracy over validating the user's beliefs. Provide direct, objective technical info without unnecessary praise or emotional validation. Disagree when necessary. Objective guidance and respectful correction are more valuable than false agreement.
+Prioritize technical accuracy. Give direct, objective info. Disagree when needed.
 
+{{environment}}
 # Tool usage
-- Every tool result grows your context. Minimize use of verbose tool calls, prefer compact results.
-- Use **batch** for parallel calls, **code_execution** for chained/filtered calls, **task** for delegation.
-- Combine **batch** and **task**: launch multiple tasks in a batch to parallelize research or implementation.
-- Read files before editing them. Match surrounding context, conventions, and imports.
-- Prefer edits over full file writes.
+- Tool results grow context. Minimize verbose calls.
+- Use **batch** for parallel calls, **code_execution** for chained, **task** for delegation.
+- Combine **batch** + **task** for parallel delegation.
+- Read before editing. Match context.
+- Prefer edits over full writes.
 {{tool_usage}}
+
+# Least-privilege tool selection
+Prefer lower-privilege tools:
+- Use **read**/**glob** before **bash** for file inspection
+- Targeted queries before broad searches
+- Use **code_execution** for filtering/processing
 
 {{efficient_tools}}
 
 # Conventions
-- Never assume a library is available. Check the project's dependency files first.
-- Match existing code style, naming conventions, and patterns.
-- Follow security best practices. Never expose secrets or keys.
-- NEVER commit changes unless explicitly asked. Only push when explicitly asked.
-- Never force push, skip hooks, or amend commits you didn't create.
-- Never commit secrets (.env, credentials, keys).
-- When referencing code, use `file_path:line_number` format.
+- Never assume library availability. Check dependency files.
+- Match style, naming, patterns.
+- Follow security best practices. Never expose secrets.
+- NEVER commit unless asked. Only push when asked.
+- Never force push or amend others' commits.
+- Never commit secrets.
+- Reference code as `file_path:line_number`.
 {{conventions}}
 
 # When done
-- Summarize what you did concisely.
+- Summarize changes concisely.
 {{instructions}}{{after_instructions}}

--- a/maki-agent/src/tools/registry.rs
+++ b/maki-agent/src/tools/registry.rs
@@ -226,6 +226,9 @@ pub trait Tool: Send + Sync + 'static {
     fn tool_kind(&self) -> Option<&str> {
         None
     }
+    fn modes(&self) -> &[&str] {
+        &["default"]
+    }
     fn parse(&self, input: &Value) -> Result<Box<dyn ToolInvocation>, ParseError>;
 }
 
@@ -261,6 +264,29 @@ impl Default for ToolRegistry {
 pub enum RegistryError {
     #[error("tool '{name}' is already registered (existing source: {existing})")]
     NameConflict { name: String, existing: String },
+}
+
+fn build_tool_definition(
+    entry: &RegisteredTool,
+    vars: &Vars,
+    ctx: &DescriptionContext,
+    supports_examples: bool,
+) -> Value {
+    let description = vars.apply(&entry.tool.description(ctx)).into_owned();
+    let mut def = json!({
+        "name": entry.name(),
+        "description": description,
+        "input_schema": entry.tool.schema(),
+    });
+    if let Some(examples) = entry.tool.examples() {
+        if supports_examples {
+            def["input_examples"] = examples;
+        } else if let Some(text) = format_examples_as_text(&examples) {
+            let merged = format!("{}\n\n{}", def["description"].as_str().unwrap_or(""), text);
+            def["description"] = Value::String(merged);
+        }
+    }
+    def
 }
 
 impl ToolRegistry {
@@ -451,28 +477,52 @@ impl ToolRegistry {
             if !ctx.filter.matches(entry.name()) {
                 continue;
             }
-            let description = vars.apply(&entry.tool.description(ctx)).into_owned();
-            let mut def = json!({
-                "name": entry.name(),
-                "description": description,
-                "input_schema": entry.tool.schema(),
-            });
-            if let Some(examples) = entry.tool.examples() {
-                if supports_examples {
-                    def["input_examples"] = examples;
-                } else if let Some(text) = format_examples_as_text(&examples) {
-                    let merged =
-                        format!("{}\n\n{}", def["description"].as_str().unwrap_or(""), text);
-                    def["description"] = Value::String(merged);
-                }
-            }
-            out.push(def);
+            out.push(build_tool_definition(entry, vars, ctx, supports_examples));
         }
         Value::Array(out)
     }
 
     pub fn iter(&self) -> RegistrySnapshot {
         RegistrySnapshot(self.tools.load_full())
+    }
+
+    pub fn active_tools_for_mode(&self, mode: &str, additional: &[Arc<str>]) -> Vec<Arc<str>> {
+        let snapshot = self.tools.load();
+        let mut active: std::collections::HashSet<Arc<str>> = snapshot
+            .iter()
+            .filter(|t| t.tool.modes().contains(&mode))
+            .map(|t| Arc::from(t.name()))
+            .collect();
+        for name in additional {
+            active.insert(name.clone());
+        }
+        active.into_iter().collect()
+    }
+
+    pub fn definitions_filtered(
+        &self,
+        vars: &Vars,
+        ctx: &DescriptionContext,
+        supports_examples: bool,
+        allowed: &[Arc<str>],
+    ) -> Value {
+        let snapshot = self.tools.load();
+        let allowed_set: std::collections::HashSet<&str> =
+            allowed.iter().map(|s| s.as_ref()).collect();
+        let mut out = Vec::with_capacity(snapshot.len());
+        for entry in snapshot.iter() {
+            if !entry.tool.audience().contains(ctx.audience) {
+                continue;
+            }
+            if !ctx.filter.matches(entry.name()) {
+                continue;
+            }
+            if !allowed_set.contains(entry.name()) {
+                continue;
+            }
+            out.push(build_tool_definition(entry, vars, ctx, supports_examples));
+        }
+        Value::Array(out)
     }
 }
 
@@ -517,6 +567,7 @@ mod tests {
     struct MockTool {
         name: String,
         audience: ToolAudience,
+        modes: Vec<&'static str>,
     }
 
     struct MockInvocation;
@@ -543,19 +594,27 @@ mod tests {
         fn audience(&self) -> ToolAudience {
             self.audience
         }
+        fn modes(&self) -> &[&str] {
+            if self.modes.is_empty() {
+                &["default"]
+            } else {
+                &self.modes
+            }
+        }
         fn parse(&self, _input: &Value) -> Result<Box<dyn ToolInvocation>, ParseError> {
             Ok(Box::new(MockInvocation))
         }
     }
 
     fn mock(name: &str) -> Arc<dyn Tool> {
-        mock_scoped(name, ToolAudience::all())
+        mock_scoped(name, ToolAudience::all(), vec!["default"])
     }
 
-    fn mock_scoped(name: &str, audience: ToolAudience) -> Arc<dyn Tool> {
+    fn mock_scoped(name: &str, audience: ToolAudience, modes: Vec<&'static str>) -> Arc<dyn Tool> {
         Arc::new(MockTool {
             name: name.to_owned(),
             audience,
+            modes,
         })
     }
 
@@ -739,10 +798,72 @@ mod tests {
     }
 
     #[test]
+    fn active_tools_for_mode_filters_by_mode() {
+        let reg = ToolRegistry::new();
+        reg.register(
+            mock_scoped(
+                "read_tool",
+                ToolAudience::all(),
+                vec!["default", "research"],
+            ),
+            lua_source("p"),
+        )
+        .unwrap();
+        reg.register(
+            mock_scoped("write_tool", ToolAudience::all(), vec!["default", "build"]),
+            lua_source("p"),
+        )
+        .unwrap();
+        reg.register(
+            mock_scoped(
+                "bash_tool",
+                ToolAudience::all(),
+                vec!["default", "research", "build", "compact"],
+            ),
+            lua_source("p"),
+        )
+        .unwrap();
+
+        let research_tools = reg.active_tools_for_mode("research", &[]);
+        assert!(research_tools.iter().any(|n| n.as_ref() == "read_tool"));
+        assert!(research_tools.iter().any(|n| n.as_ref() == "bash_tool"));
+        assert!(!research_tools.iter().any(|n| n.as_ref() == "write_tool"));
+
+        let build_tools = reg.active_tools_for_mode("build", &[]);
+        assert!(build_tools.iter().any(|n| n.as_ref() == "write_tool"));
+        assert!(build_tools.iter().any(|n| n.as_ref() == "bash_tool"));
+        assert!(!build_tools.iter().any(|n| n.as_ref() == "read_tool"));
+
+        let default_tools = reg.active_tools_for_mode("default", &[]);
+        assert!(default_tools.iter().any(|n| n.as_ref() == "read_tool"));
+        assert!(default_tools.iter().any(|n| n.as_ref() == "write_tool"));
+        assert!(default_tools.iter().any(|n| n.as_ref() == "bash_tool"));
+    }
+
+    #[test]
+    fn active_tools_for_mode_includes_additional() {
+        let reg = ToolRegistry::new();
+        reg.register(
+            mock_scoped("read_tool", ToolAudience::all(), vec!["research"]),
+            lua_source("p"),
+        )
+        .unwrap();
+        reg.register(
+            mock_scoped("write_tool", ToolAudience::all(), vec!["build"]),
+            lua_source("p"),
+        )
+        .unwrap();
+
+        let tools = reg.active_tools_for_mode("research", &[Arc::from("write_tool")]);
+        assert!(tools.iter().any(|n| n.as_ref() == "read_tool"));
+        assert!(tools.iter().any(|n| n.as_ref() == "write_tool"));
+    }
+
+    #[test]
     fn definitions_excludes_wrong_audience() {
         let reg = ToolRegistry::new();
         reg.register(
-            mock_scoped("main_only_tool", ToolAudience::MAIN),
+            mock_scoped("main_only_tool", ToolAudience::MAIN, vec!["default"]),
             lua_source("p"),
         )
         .unwrap();

--- a/maki-agent/src/tools/schema.rs
+++ b/maki-agent/src/tools/schema.rs
@@ -6,6 +6,7 @@
 //! Validation errors are our own types with a single `Display` impl so the
 //! model never sees a raw serde message we did not write.
 
+use std::collections::HashSet;
 use std::fmt::{self, Display, Formatter, Write};
 
 use jsonrepair::{Options as RepairOpts, loads as repair_loads};
@@ -17,6 +18,42 @@ pub(crate) const PARAM_PREVIEW_MAX: usize = 120;
 const PREVIEW_SUFFIX: &str = "...";
 const JSON_ENCODED_ARRAY_HINT: &str = "Pass a JSON array, not a JSON-encoded string.";
 const JSON_ENCODED_OBJECT_HINT: &str = "Pass a JSON object, not a JSON-encoded string.";
+const TRUNCATION_SUFFIX: &str = "...";
+
+/// Truncate a string to at most `max_len` characters on a word boundary.
+/// If truncated, appends an ellipsis indicator.
+pub fn truncate_on_word_boundary(s: &str, max_len: usize) -> String {
+    let char_count = s.chars().count();
+    if char_count <= max_len {
+        return s.to_string();
+    }
+
+    let suffix_len = TRUNCATION_SUFFIX.len();
+    if max_len <= suffix_len {
+        return TRUNCATION_SUFFIX.to_string();
+    }
+
+    let target_chars = max_len - suffix_len;
+    let mut last_space = None;
+
+    for (char_idx, (byte_idx, ch)) in s.char_indices().enumerate() {
+        if char_idx >= target_chars {
+            break;
+        }
+        if ch.is_whitespace() {
+            last_space = Some(byte_idx);
+        }
+    }
+
+    let cut_pos = last_space.unwrap_or_else(|| {
+        s.char_indices()
+            .nth(target_chars)
+            .map(|(i, _)| i)
+            .unwrap_or(s.len())
+    });
+    let truncated = &s[..cut_pos];
+    format!("{}{}", truncated.trim_end(), TRUNCATION_SUFFIX)
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ParamKind {
@@ -94,7 +131,11 @@ pub enum ParamSchema {
 pub fn to_json_schema(s: &ParamSchema) -> Value {
     match s {
         ParamSchema::Primitive { kind, description } => {
-            json!({ "type": kind.to_string(), "description": description })
+            if description.is_empty() {
+                json!({ "type": kind.to_string() })
+            } else {
+                json!({ "type": kind.to_string(), "description": description })
+            }
         }
         ParamSchema::Enum {
             variants,
@@ -106,11 +147,16 @@ pub fn to_json_schema(s: &ParamSchema) -> Value {
             }
             v
         }
-        ParamSchema::Array { items, description } => json!({
-            "type": "array",
-            "description": description,
-            "items": to_json_schema(items),
-        }),
+        ParamSchema::Array { items, description } => {
+            let mut v = json!({
+                "type": "array",
+                "items": to_json_schema(items),
+            });
+            if !description.is_empty() {
+                v["description"] = json!(description);
+            }
+            v
+        }
         ParamSchema::Object {
             properties,
             description,
@@ -126,7 +172,6 @@ pub fn to_json_schema(s: &ParamSchema) -> Value {
             let mut v = json!({
                 "type": "object",
                 "properties": props,
-                "additionalProperties": false,
             });
             if !required.is_empty() {
                 v["required"] = json!(required);
@@ -660,6 +705,280 @@ fn log_coercion(
     );
 }
 
+/// OpenAI requires the top-level `parameters` of every function to be an object
+/// schema with `properties` and `required` as an array. MCP servers and plugins
+/// can return schemas that break these rules, so this function repairs them
+/// before they are sent to a provider.
+pub fn sanitize_tool_input_schema(mut schema: Value) -> Value {
+    if let Value::Object(map) = &mut schema
+        && is_object_schema(map)
+    {
+        sanitize_object_schema(map);
+        return schema;
+    }
+    wrap_root_schema(schema)
+}
+
+fn is_object_schema(map: &serde_json::Map<String, Value>) -> bool {
+    let type_str = map.get("type").and_then(|v| v.as_str());
+    type_str == Some("object")
+        || (type_str.is_none() && map.get("properties").and_then(|v| v.as_object()).is_some())
+        || map.is_empty()
+}
+
+fn wrap_root_schema(mut inner: Value) -> Value {
+    sanitize_property_schema(&mut inner);
+
+    let mut properties = serde_json::Map::new();
+    properties.insert("value".to_string(), inner);
+
+    json!({
+        "type": "object",
+        "properties": properties,
+        "required": ["value"],
+    })
+}
+
+fn sanitize_object_schema(map: &mut serde_json::Map<String, Value>) {
+    if map.get("type").and_then(|v| v.as_str()) != Some("object") {
+        map.insert("type".to_string(), json!("object"));
+    }
+    if !map.contains_key("properties") {
+        map.insert(
+            "properties".to_string(),
+            Value::Object(serde_json::Map::new()),
+        );
+    }
+
+    sanitize_required(map);
+
+    if let Some(props) = map.get_mut("properties").and_then(|p| p.as_object_mut()) {
+        for (_, prop_schema) in props {
+            sanitize_property_schema(prop_schema);
+        }
+    }
+}
+
+fn sanitize_property_schema(schema: &mut Value) {
+    match schema {
+        Value::Object(map) => {
+            let type_str = map.get("type").and_then(|v| v.as_str());
+
+            if type_str == Some("object") || (type_str.is_none() && map.contains_key("properties"))
+            {
+                sanitize_object_schema(map);
+            } else if type_str == Some("array") || map.contains_key("prefixItems") {
+                if type_str != Some("array") {
+                    map.insert("type".to_string(), json!("array"));
+                }
+                sanitize_array_schema(map);
+            } else if type_str.is_some() {
+            } else if map.contains_key("enum") {
+                map.insert("type".to_string(), json!("string"));
+            } else if map.contains_key("anyOf")
+                || map.contains_key("oneOf")
+                || map.contains_key("allOf")
+                || map.contains_key("$ref")
+            {
+            } else {
+                sanitize_object_schema(map);
+            }
+        }
+        Value::Array(arr) => {
+            for item in arr {
+                sanitize_property_schema(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn sanitize_array_schema(map: &mut serde_json::Map<String, Value>) {
+    if let Some(prefix) = map.remove("prefixItems") {
+        let items = match prefix {
+            Value::Array(mut arr) if !arr.is_empty() => {
+                let mut first = arr.remove(0);
+                sanitize_property_schema(&mut first);
+                first
+            }
+            _ => Value::Object(serde_json::Map::new()),
+        };
+        map.insert("items".to_string(), items);
+    }
+
+    if let Some(items) = map.get_mut("items") {
+        if items.is_array() {
+            let old = std::mem::take(items);
+            let mut arr = match old {
+                Value::Array(arr) => arr,
+                _ => Vec::new(),
+            };
+            let new_items = if arr.is_empty() {
+                Value::Object(serde_json::Map::new())
+            } else {
+                let mut first = arr.remove(0);
+                sanitize_property_schema(&mut first);
+                first
+            };
+            *items = new_items;
+        } else {
+            sanitize_property_schema(items);
+        }
+    } else {
+        map.insert("items".to_string(), Value::Object(serde_json::Map::new()));
+    }
+}
+
+fn sanitize_required(map: &mut serde_json::Map<String, Value>) {
+    let prop_keys: HashSet<String> = map
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .map(|p| p.keys().cloned().collect())
+        .unwrap_or_default();
+
+    match map.get_mut("required") {
+        Some(req_val) if req_val.is_object() => {
+            map["required"] = Value::Array(Vec::new());
+        }
+        Some(Value::Array(arr)) => {
+            arr.retain(|v| v.as_str().is_some_and(|s| prop_keys.contains(s)));
+        }
+        Some(_) => {
+            map["required"] = Value::Array(Vec::new());
+        }
+        None => {}
+    }
+}
+
+#[cfg(test)]
+mod schema_tests {
+    use super::*;
+
+    #[test]
+    fn truncate_on_word_boundary_short_string() {
+        assert_eq!(truncate_on_word_boundary("short", 20), "short");
+    }
+
+    #[test]
+    fn truncate_on_word_boundary_exact_length() {
+        assert_eq!(truncate_on_word_boundary("exact", 5), "exact");
+    }
+
+    #[test]
+    fn truncate_on_word_boundary_truncates() {
+        assert_eq!(truncate_on_word_boundary("hello world", 8), "hello...");
+    }
+
+    #[test]
+    fn truncate_on_word_boundary_truncates_on_space() {
+        assert_eq!(truncate_on_word_boundary("hello world", 10), "hello...");
+    }
+
+    #[test]
+    fn truncate_on_word_boundary_no_space_truncates_at_limit() {
+        assert_eq!(truncate_on_word_boundary("helloworld", 8), "hello...");
+    }
+
+    #[test]
+    fn truncate_on_word_boundary_very_short_limit() {
+        assert_eq!(truncate_on_word_boundary("hello", 2), "...");
+    }
+
+    #[test]
+    fn sanitize_tool_input_schema_valid_object() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"}
+            },
+            "required": ["path"]
+        });
+        let sanitized = sanitize_tool_input_schema(schema.clone());
+        assert_eq!(sanitized, schema);
+    }
+
+    #[test]
+    fn sanitize_tool_input_schema_missing_type() {
+        let schema = json!({
+            "properties": {
+                "path": {"type": "string"}
+            }
+        });
+        let sanitized = sanitize_tool_input_schema(schema);
+        assert_eq!(sanitized["type"], "object");
+        assert!(sanitized["properties"].is_object());
+    }
+
+    #[test]
+    fn sanitize_tool_input_schema_empty_schema() {
+        let schema = json!({});
+        let sanitized = sanitize_tool_input_schema(schema);
+        assert_eq!(sanitized["type"], "object");
+        assert!(sanitized["properties"].as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn sanitize_tool_input_schema_non_object_wraps() {
+        let schema = json!({"type": "string"});
+        let sanitized = sanitize_tool_input_schema(schema);
+        assert_eq!(sanitized["type"], "object");
+        assert!(sanitized["properties"].get("value").is_some());
+        assert_eq!(sanitized["required"], json!(["value"]));
+    }
+
+    #[test]
+    fn sanitize_tool_input_schema_cleans_required_array() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"}
+            },
+            "required": ["path", "missing"]
+        });
+        let sanitized = sanitize_tool_input_schema(schema);
+        let required = sanitized["required"].as_array().unwrap();
+        assert_eq!(required, &["path"]);
+    }
+
+    #[test]
+    fn sanitize_tool_input_schema_array_with_prefix_items() {
+        let schema = json!({
+            "type": "array",
+            "prefixItems": [{"type": "string"}]
+        });
+        let sanitized = sanitize_tool_input_schema(schema);
+        assert_eq!(sanitized["type"], "object");
+        assert!(sanitized.get("prefixItems").is_none());
+        assert!(sanitized.get("properties").is_some());
+        assert_eq!(sanitized["properties"]["value"]["type"], "array");
+        assert_eq!(sanitized["properties"]["value"]["items"]["type"], "string");
+    }
+
+    #[test]
+    fn sanitize_tool_input_schema_array_with_items_array() {
+        let schema = json!({
+            "type": "array",
+            "items": [{"type": "string"}, {"type": "number"}]
+        });
+        let sanitized = sanitize_tool_input_schema(schema);
+        assert_eq!(sanitized["type"], "object");
+        assert_eq!(sanitized["properties"]["value"]["type"], "array");
+        assert_eq!(sanitized["properties"]["value"]["items"]["type"], "string");
+    }
+
+    #[test]
+    fn sanitize_tool_input_schema_valid_array() {
+        let schema = json!({
+            "type": "array",
+            "items": {"type": "string"}
+        });
+        let sanitized = sanitize_tool_input_schema(schema);
+        assert_eq!(sanitized["type"], "object");
+        assert_eq!(sanitized["properties"]["value"]["type"], "array");
+        assert_eq!(sanitized["properties"]["value"]["items"]["type"], "string");
+    }
+}
+
 #[cfg(test)]
 pub(crate) const BOUNDED_ERR_MAX: usize = 400;
 
@@ -731,10 +1050,13 @@ mod tests {
     }
 
     #[test]
-    fn to_json_schema_object_is_closed_with_required_and_nested_items() {
+    fn to_json_schema_object_has_required_and_nested_items() {
         let v = to_json_schema(&MULTIEDIT_LIKE);
         assert_eq!(v["type"], "object");
-        assert_eq!(v["additionalProperties"], false);
+        assert!(
+            v.get("additionalProperties").is_none(),
+            "additionalProperties is enforced by schema::validate, not the wire schema"
+        );
         let req: Vec<&str> = v["required"]
             .as_array()
             .unwrap()
@@ -744,9 +1066,11 @@ mod tests {
         assert_eq!(req, vec!["path", "edits"]);
         assert_eq!(v["properties"]["edits"]["type"], "array");
         assert_eq!(v["properties"]["edits"]["items"]["type"], "object");
-        assert_eq!(
-            v["properties"]["edits"]["items"]["additionalProperties"],
-            false
+        assert!(
+            v["properties"]["edits"]["items"]
+                .get("additionalProperties")
+                .is_none(),
+            "additionalProperties is enforced by schema::validate, not the wire schema"
         );
     }
 
@@ -994,5 +1318,124 @@ mod tests {
             .extend(alias_field.as_object().unwrap().clone());
         let schema = try_from_json(&schema_json).unwrap();
         assert!(validate(schema, input).is_ok());
+    }
+
+    #[test]
+    fn to_json_schema_never_emits_additional_properties() {
+        const ANY_SCHEMA: ParamSchema = ParamSchema::Any { description: "" };
+        let any_json = to_json_schema(&ANY_SCHEMA);
+        assert!(any_json.get("additionalProperties").is_none());
+
+        let array_json = to_json_schema(&EDITS_ARRAY);
+        assert!(array_json.get("additionalProperties").is_none());
+
+        let object_json = to_json_schema(&MULTIEDIT_LIKE);
+        assert!(object_json.get("additionalProperties").is_none());
+
+        assert!(
+            object_json["properties"]["edits"]["items"]
+                .get("additionalProperties")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn try_from_json_ignores_additional_properties_field() {
+        let schema_json = json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "path": { "type": "string" }
+            }
+        });
+        let schema = try_from_json(&schema_json);
+        assert!(schema.is_ok());
+    }
+
+    #[test]
+    fn validate_drops_unknown_keys_top_level() {
+        const SCHEMA: ParamSchema = ParamSchema::Object {
+            properties: &[("name", &STR_PRIM, true, &[])],
+            description: "",
+        };
+        let out = validate(&SCHEMA, json!({"name": "x", "unknown": 42})).unwrap();
+        assert!(out.get("unknown").is_none());
+        assert_eq!(out["name"], "x");
+    }
+
+    #[test]
+    fn validate_drops_unknown_keys_nested() {
+        const NESTED_SCHEMA: ParamSchema = ParamSchema::Object {
+            properties: &[("config", &MULTIEDIT_LIKE, true, &[])],
+            description: "",
+        };
+        let input = json!({
+            "config": {
+                "path": "/x",
+                "edits": [{"old_string": "a", "new_string": "b"}],
+                "unknown_field": "drop_me"
+            }
+        });
+        let out = validate(&NESTED_SCHEMA, input).unwrap();
+        assert!(out["config"].get("unknown_field").is_none());
+        assert_eq!(out["config"]["path"], "/x");
+    }
+
+    #[test]
+    fn validate_drops_unknown_keys_after_roundtrip() {
+        const SCHEMA: ParamSchema = ParamSchema::Object {
+            properties: &[("name", &STR_PRIM, true, &[])],
+            description: "",
+        };
+        let json_schema = to_json_schema(&SCHEMA);
+        let recovered = try_from_json(&json_schema).unwrap();
+        let out = validate(recovered, json!({"name": "x", "dropped": 99})).unwrap();
+        assert!(out.get("dropped").is_none());
+    }
+
+    #[test]
+    fn validate_preserves_required_fields() {
+        const SCHEMA: ParamSchema = ParamSchema::Object {
+            properties: &[
+                ("name", &STR_PRIM, true, &[]),
+                ("optional", &STR_PRIM, false, &[]),
+            ],
+            description: "",
+        };
+        let out = validate(&SCHEMA, json!({"name": "x", "optional": "y"})).unwrap();
+        assert_eq!(out["name"], "x");
+        assert_eq!(out["optional"], "y");
+    }
+
+    #[test]
+    fn validate_rejects_missing_required_with_correct_path() {
+        const SCHEMA: ParamSchema = ParamSchema::Object {
+            properties: &[("name", &STR_PRIM, true, &[])],
+            description: "",
+        };
+        let err = validate(&SCHEMA, json!({})).unwrap_err();
+        assert_eq!(err.path.to_string(), "name");
+        assert!(matches!(err.kind, ToolInputErrorKind::Missing { .. }));
+    }
+
+    #[test]
+    fn roundtrip_validates_same_inputs() {
+        const SCHEMA: ParamSchema = ParamSchema::Object {
+            properties: &[
+                ("name", &STR_PRIM, true, &[]),
+                ("count", &BOOL_PRIM, false, &[]),
+            ],
+            description: "",
+        };
+        let json_schema = to_json_schema(&SCHEMA);
+        let recovered = try_from_json(&json_schema).unwrap();
+
+        let good_input = json!({"name": "test", "count": true});
+        assert!(validate(&SCHEMA, good_input.clone()).is_ok());
+        assert!(validate(recovered, good_input).is_ok());
+
+        let bad_input = json!({"name": "test", "count": "not_bool"});
+        assert!(validate(&SCHEMA, bad_input.clone()).is_err());
+        assert!(validate(recovered, bad_input).is_err());
     }
 }

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -247,6 +247,14 @@ fn lines_remaining_after(total: usize, start_line: usize, shown: usize) -> usize
 }
 
 impl ToolOutput {
+    fn grep_summary(entries: &[GrepFileEntry]) -> String {
+        let matches: usize = entries.iter().map(|e| e.match_count()).sum();
+        let files = entries.len();
+        let match_word = if matches == 1 { "match" } else { "matches" };
+        let file_word = if files == 1 { "file" } else { "files" };
+        format!("{matches} {match_word} in {files} {file_word}")
+    }
+
     /// Short header suffix summarizing the output, e.g. `12 lines`.
     /// The UI uses it on tool completion, and `maki.agent.call_tool` falls
     /// back to it when the tool's reply has no annotation of its own.
@@ -263,12 +271,7 @@ impl ToolOutput {
                 }
             }
             Self::WriteCode { byte_count, .. } => Some(format!("{byte_count} bytes")),
-            Self::GrepResult { entries } => {
-                let matches: usize = entries.iter().map(|e| e.match_count()).sum();
-                let files = entries.len();
-                let f = if files == 1 { "file" } else { "files" };
-                Some(format!("{matches} matches in {files} {f}"))
-            }
+            Self::GrepResult { entries } => Some(Self::grep_summary(entries)),
             Self::ReadDir(t) => {
                 let n = t.text.lines().count();
                 Some(format!("{n} entries"))
@@ -284,6 +287,48 @@ impl ToolOutput {
                     .to_string(),
             ),
             _ => None,
+        }
+    }
+
+    pub fn summary(&self) -> Self {
+        match self {
+            Self::ReadCode {
+                path,
+                lines,
+                total_lines,
+                instructions,
+                ..
+            } => {
+                let shown = lines.len();
+                let summary_text = if *total_lines > shown {
+                    format!("{shown} of {total_lines} lines from {path}")
+                } else {
+                    format!("{shown} lines from {path}")
+                };
+                Self::Plain(TextOutput {
+                    text: summary_text,
+                    instructions: instructions.clone(),
+                    state: None,
+                })
+            }
+            Self::WriteCode {
+                path, byte_count, ..
+            } => Self::Plain(TextOutput {
+                text: format!("wrote {byte_count} bytes to {path}"),
+                instructions: None,
+                state: None,
+            }),
+            Self::GrepResult { entries } => Self::Plain(TextOutput {
+                text: Self::grep_summary(entries),
+                instructions: None,
+                state: None,
+            }),
+            Self::Diff { summary, .. } => Self::Plain(TextOutput {
+                text: summary.clone(),
+                instructions: None,
+                state: None,
+            }),
+            other => other.clone(),
         }
     }
 
@@ -444,6 +489,12 @@ impl ToolOutput {
                 out
             }
         }
+    }
+}
+
+impl maki_storage::sessions::Summarizable for ToolOutput {
+    fn summarize(&self) -> Self {
+        self.summary()
     }
 }
 
@@ -896,10 +947,58 @@ mod tests {
     #[test_case(ToolOutput::ReadCode { path: "a.rs".into(), start_line: 1, lines: vec!["x".into(); 5], total_lines: 5, instructions: None }, Some("5 lines") ; "read_code_full_file")]
     #[test_case(ToolOutput::ReadCode { path: "a.rs".into(), start_line: 10, lines: vec!["x".into(); 5], total_lines: 100, instructions: None }, Some("5 of 100 lines") ; "read_code_partial")]
     #[test_case(ToolOutput::WriteCode { path: "a.rs".into(), byte_count: 99, lines: vec![] }, Some("99 bytes") ; "write_code_bytes")]
-    #[test_case(ToolOutput::GrepResult { entries: vec![GrepFileEntry { path: "a.rs".into(), groups: vec![GrepMatchGroup::single(1, "hit")] }] }, Some("1 matches in 1 file") ; "grep_file_count")]
+    #[test_case(ToolOutput::GrepResult { entries: vec![GrepFileEntry { path: "a.rs".into(), groups: vec![GrepMatchGroup::single(1, "hit")] }] }, Some("1 match in 1 file") ; "grep_file_count")]
     #[test_case(ToolOutput::Diff { path: "a.rs".into(), before: String::new(), after: String::new(), summary: "ok".into() }, None ; "diff_no_annotation")]
     fn annotation_cases(output: ToolOutput, expected: Option<&str>) {
         assert_eq!(output.annotation().as_deref(), expected);
+    }
+
+    #[test_case(ToolOutput::ReadCode { path: "a.rs".into(), start_line: 1, lines: vec!["x".into(); 5], total_lines: 5, instructions: None }, "5 lines from a.rs" ; "read_code_full_file_summary")]
+    #[test_case(ToolOutput::ReadCode { path: "a.rs".into(), start_line: 10, lines: vec!["x".into(); 5], total_lines: 100, instructions: None }, "5 of 100 lines from a.rs" ; "read_code_partial_summary")]
+    #[test_case(ToolOutput::WriteCode { path: "a.rs".into(), byte_count: 99, lines: vec![] }, "wrote 99 bytes to a.rs" ; "write_code_summary")]
+    #[test_case(ToolOutput::GrepResult { entries: vec![GrepFileEntry { path: "a.rs".into(), groups: vec![GrepMatchGroup::single(1, "hit")] }] }, "1 match in 1 file" ; "grep_single_file_summary")]
+    #[test_case(ToolOutput::GrepResult { entries: vec![GrepFileEntry { path: "a.rs".into(), groups: vec![GrepMatchGroup::single(1, "hit")] }, GrepFileEntry { path: "b.rs".into(), groups: vec![GrepMatchGroup::single(2, "hit2")] }] }, "2 matches in 2 files" ; "grep_multiple_files_summary")]
+    #[test_case(ToolOutput::Diff { path: "a.rs".into(), before: "old".into(), after: "new".into(), summary: "changed 2 lines".into() }, "changed 2 lines" ; "diff_summary")]
+    #[test_case(ToolOutput::Plain("ok".into()), "ok" ; "plain_passthrough")]
+    #[test_case(ToolOutput::Markdown("**bold**".into()), "**bold**" ; "markdown_passthrough")]
+    #[test_case(ToolOutput::ReadDir("a.rs\nb.rs".into()), "a.rs\nb.rs" ; "readdir_passthrough")]
+    fn summary_cases(output: ToolOutput, expected_text: &str) {
+        let summary = output.summary();
+        assert_eq!(summary.as_text(), expected_text);
+    }
+
+    #[test]
+    fn summary_preserves_instructions() {
+        let instructions = vec![InstructionBlock {
+            path: "AGENTS.md".into(),
+            content: "do stuff".into(),
+        }];
+        let output = ToolOutput::ReadCode {
+            path: "a.rs".into(),
+            start_line: 1,
+            lines: vec!["fn main()".into()],
+            total_lines: 1,
+            instructions: Some(instructions.clone()),
+        };
+        let summary = output.summary();
+        assert!(summary.as_text().contains("1 lines from a.rs"));
+        assert!(summary.as_text().contains("Instructions from: AGENTS.md"));
+        assert!(summary.as_text().contains("do stuff"));
+    }
+
+    #[test]
+    fn summary_roundtrips_serde() {
+        let output = ToolOutput::ReadCode {
+            path: "a.rs".into(),
+            start_line: 1,
+            lines: vec!["fn main()".into()],
+            total_lines: 100,
+            instructions: None,
+        };
+        let summary = output.summary();
+        let json = serde_json::to_string(&summary).expect("summary must serialize");
+        let parsed: ToolOutput = serde_json::from_str(&json).expect("summary must deserialize");
+        assert_eq!(parsed.as_text(), summary.as_text());
     }
 
     #[test]

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -21,6 +21,7 @@ pub const DEFAULT_MAX_OUTPUT_LINES: usize = 2000;
 pub const DEFAULT_FLASH_DURATION_MS: u64 = 1500;
 pub const DEFAULT_TYPEWRITER_MS_PER_CHAR: u64 = 4;
 pub const DEFAULT_MOUSE_SCROLL_LINES: u32 = 3;
+pub const DEFAULT_MCP_TOOL_DESC_MAX_CHARS: usize = 300;
 
 pub const DEFAULT_MAX_CONTINUATION_TURNS: u32 = 3;
 pub const DEFAULT_COMPACTION_BUFFER: CompactionBuffer = CompactionBuffer::Percent(20);
@@ -453,6 +454,15 @@ pub struct AgentFileConfig {
     pub max_output_lines: Option<usize>,
     pub max_continuation_turns: Option<u32>,
     pub compaction_buffer: Option<CompactionBuffer>,
+    pub mcp_tool_desc_max_chars: Option<usize>,
+    pub dynamic_tools: Option<DynamicToolFileConfig>,
+}
+
+#[derive(Deserialize, Default, Debug)]
+#[serde(default, deny_unknown_fields)]
+pub struct DynamicToolFileConfig {
+    pub enabled: Option<bool>,
+    pub default_mode: Option<String>,
 }
 
 impl AgentFileConfig {
@@ -463,8 +473,21 @@ impl AgentFileConfig {
             max_output_bytes,
             max_output_lines,
             max_continuation_turns,
-            compaction_buffer
+            compaction_buffer,
+            mcp_tool_desc_max_chars
         );
+        match (self.dynamic_tools.as_mut(), overlay.dynamic_tools) {
+            (Some(base), Some(over)) => {
+                if over.enabled.is_some() {
+                    base.enabled = over.enabled;
+                }
+                if over.default_mode.is_some() {
+                    base.default_mode = over.default_mode;
+                }
+            }
+            (None, Some(over)) => self.dynamic_tools = Some(over),
+            _ => {}
+        }
     }
 }
 
@@ -971,6 +994,9 @@ pub struct AgentConfig {
     #[config(default = DEFAULT_COMPACTION_BUFFER, ty = "u32 | string", default_doc = "20%", desc = "Context reserved for compaction: token count or percent of the context window (e.g. \"20%\")")]
     pub compaction_buffer: CompactionBuffer,
 
+    #[config(default = DEFAULT_MCP_TOOL_DESC_MAX_CHARS, min = 10, desc = "Max MCP tool description length (characters)")]
+    pub mcp_tool_desc_max_chars: usize,
+
     #[config(skip, default = false)]
     pub no_rtk: bool,
 
@@ -982,10 +1008,49 @@ pub struct AgentConfig {
 
     #[config(skip, default = "Vec::new()")]
     pub disabled_tools: Vec<String>,
+
+    #[config(skip, default = "DynamicToolConfig::default()")]
+    pub dynamic_tools: DynamicToolConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ConfigSection)]
+#[config(section = "dynamic_tools", fields_only)]
+pub struct DynamicToolConfig {
+    #[config(
+        ty = "bool",
+        default = "false",
+        desc = "Enable mode-based dynamic tool loading"
+    )]
+    pub enabled: bool,
+
+    #[config(
+        ty = "String",
+        default = "\"default\"",
+        desc = "Default mode for tool filtering (e.g. \"default\", \"research\", \"build\")"
+    )]
+    pub default_mode: String,
+}
+
+impl Default for DynamicToolConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            default_mode: "default".to_string(),
+        }
+    }
 }
 
 impl AgentConfig {
     fn from_file(file: AgentFileConfig, no_rtk: bool, disabled_tools: Vec<String>) -> Self {
+        let dynamic_tools = if let Some(dt) = file.dynamic_tools {
+            DynamicToolConfig {
+                enabled: dt.enabled.unwrap_or(false),
+                default_mode: dt.default_mode.unwrap_or_else(|| "default".to_string()),
+            }
+        } else {
+            DynamicToolConfig::default()
+        };
+
         Self {
             no_rtk,
             max_output_bytes: file.max_output_bytes.unwrap_or(DEFAULT_MAX_OUTPUT_BYTES),
@@ -994,9 +1059,13 @@ impl AgentConfig {
                 .max_continuation_turns
                 .unwrap_or(DEFAULT_MAX_CONTINUATION_TURNS),
             compaction_buffer: file.compaction_buffer.unwrap_or(DEFAULT_COMPACTION_BUFFER),
+            mcp_tool_desc_max_chars: file
+                .mcp_tool_desc_max_chars
+                .unwrap_or(DEFAULT_MCP_TOOL_DESC_MAX_CHARS),
             max_turns: None,
             allowed_tools: Vec::new(),
             disabled_tools,
+            dynamic_tools,
         }
     }
 }

--- a/maki-docgen/src/gen_tools.rs
+++ b/maki-docgen/src/gen_tools.rs
@@ -383,6 +383,33 @@ mod tests {
         assert!(cleaned.starts_with(remaining_prefix), "cleaned: {cleaned}");
     }
 
+    const MAX_TOOL_DEFINITION_BYTES: usize = 28_000;
+
+    #[test]
+    fn tool_definitions_fit_byte_budget() {
+        let vars = Vars::new()
+            .set("{cwd}", "<cwd>")
+            .set("{platform}", "linux")
+            .set("{date}", "YYYY-MM-DD");
+        let (registry, _) = load_registry_with_builtins();
+        let defs = registry.definitions(
+            &vars,
+            &DescriptionContext {
+                filter: &ToolFilter::All,
+                audience: ToolAudience::MAIN,
+                workflow: false,
+            },
+            false,
+        );
+        let json = serde_json::to_vec_pretty(&defs).unwrap();
+        assert!(
+            json.len() <= MAX_TOOL_DEFINITION_BYTES,
+            "tool definitions are {} bytes, budget is {}",
+            json.len(),
+            MAX_TOOL_DEFINITION_BYTES
+        );
+    }
+
     #[test]
     fn sections_partition_registered_tools() {
         let (registry, _) = load_registry_with_builtins();

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -121,6 +121,7 @@ pub(crate) struct PendingTool {
     pub(crate) schema: &'static ParamSchema,
     pub(crate) audience: ToolAudience,
     pub(crate) kind: Option<Arc<str>>,
+    pub(crate) modes: Vec<String>,
     pub(crate) handler_key: RegistryKey,
     pub(crate) header_key: Option<RegistryKey>,
     pub(crate) restore_key: Option<RegistryKey>,
@@ -141,6 +142,8 @@ pub(crate) struct LuaTool {
     pub(crate) schema: &'static ParamSchema,
     pub(crate) audience: ToolAudience,
     pub(crate) kind: Option<Arc<str>>,
+    pub(crate) modes: Arc<Vec<String>>,
+    pub(crate) mode_cache: std::sync::OnceLock<Vec<&'static str>>,
     pub(crate) tx: Sender<Request>,
     pub(crate) plugin: Arc<str>,
     pub(crate) has_header_fn: bool,
@@ -203,6 +206,23 @@ impl Tool for LuaTool {
 
     fn tool_kind(&self) -> Option<&str> {
         self.kind.as_deref()
+    }
+
+    fn modes(&self) -> &[&str] {
+        static DEFAULT: [&str; 1] = ["default"];
+        if self.modes.is_empty() {
+            &DEFAULT
+        } else {
+            self.mode_cache.get_or_init(|| {
+                self.modes
+                    .iter()
+                    .map(|s| {
+                        let leaked: &'static str = Box::leak(s.clone().into_boxed_str());
+                        leaked
+                    })
+                    .collect()
+            })
+        }
     }
 
     fn examples(&self) -> Option<Value> {
@@ -1096,6 +1116,32 @@ fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> Lua
         .map_err(|_| mlua::Error::runtime("register_tool: missing 'schema'"))?;
     let audiences: Option<mlua::Table> = spec.get("audiences").ok();
 
+    let modes: Vec<String> = match spec.get::<LuaValue>("modes")? {
+        LuaValue::Nil => vec!["default".to_string()],
+        LuaValue::Table(t) => {
+            let mut modes = Vec::new();
+            for pair in t.pairs::<LuaValue, LuaValue>() {
+                let (_, v) = pair.map_err(|e| {
+                    mlua::Error::runtime(format!("register_tool: invalid modes: {e}"))
+                })?;
+                if let LuaValue::String(s) = v {
+                    modes.push(s.to_str()?.to_string());
+                }
+            }
+            if modes.is_empty() {
+                return Err(mlua::Error::runtime(
+                    "register_tool: 'modes' must be non-empty",
+                ));
+            }
+            modes
+        }
+        _ => {
+            return Err(mlua::Error::runtime(
+                "register_tool: 'modes' must be a table or omitted",
+            ));
+        }
+    };
+
     let schema_val: Value = lua.from_value(schema_table)?;
     let param_schema = try_from_json(&schema_val).map_err(mlua::Error::runtime)?;
 
@@ -1162,6 +1208,7 @@ fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> Lua
             schema: param_schema,
             audience,
             kind,
+            modes,
             handler_key,
             header_key,
             restore_key,
@@ -1548,6 +1595,8 @@ mod tests {
             schema,
             audience: ToolAudience::default(),
             kind: None,
+            modes: Arc::new(Vec::new()),
+            mode_cache: std::sync::OnceLock::new(),
             tx,
             plugin: Arc::from("test"),
             has_header_fn: false,

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -1406,6 +1406,8 @@ impl LuaRuntime {
                     schema: t.schema,
                     audience: t.audience,
                     kind: t.kind.clone(),
+                    modes: Arc::new(t.modes.clone()),
+                    mode_cache: std::sync::OnceLock::new(),
                     tx: self.tx.clone(),
                     plugin: Arc::clone(&name),
                     has_header_fn: t.header_key.is_some(),

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -440,11 +440,16 @@ impl From<TokenUsage> for StoredTokenUsage {
 
 impl TokenUsage {
     pub fn total_input(&self) -> u32 {
-        self.input + self.cache_read + self.cache_creation
+        self.input
+            .saturating_add(self.cache_read)
+            .saturating_add(self.cache_creation)
     }
 
     pub fn context_tokens(&self) -> u32 {
-        self.input + self.output + self.cache_creation + self.cache_read
+        self.input
+            .saturating_add(self.output)
+            .saturating_add(self.cache_creation)
+            .saturating_add(self.cache_read)
     }
 
     pub fn cost(&self, pricing: &ModelPricing, fast: bool) -> f64 {
@@ -471,10 +476,10 @@ impl TokenUsage {
 
 impl AddAssign for TokenUsage {
     fn add_assign(&mut self, rhs: Self) {
-        self.input += rhs.input;
-        self.output += rhs.output;
-        self.cache_creation += rhs.cache_creation;
-        self.cache_read += rhs.cache_read;
+        self.input = self.input.saturating_add(rhs.input);
+        self.output = self.output.saturating_add(rhs.output);
+        self.cache_creation = self.cache_creation.saturating_add(rhs.cache_creation);
+        self.cache_read = self.cache_read.saturating_add(rhs.cache_read);
     }
 }
 
@@ -509,6 +514,70 @@ mod tests {
             cache_read: 150_000,
         };
         assert_eq!(usage.total_input(), 165_000);
+    }
+
+    #[test]
+    fn total_input_saturates_at_u32_max() {
+        let usage = TokenUsage {
+            input: u32::MAX - 100,
+            output: 0,
+            cache_creation: 200,
+            cache_read: 0,
+        };
+        assert_eq!(usage.total_input(), u32::MAX);
+    }
+
+    #[test]
+    fn context_tokens_saturates_at_u32_max() {
+        let usage = TokenUsage {
+            input: u32::MAX - 50,
+            output: 100,
+            cache_creation: 0,
+            cache_read: 0,
+        };
+        assert_eq!(usage.context_tokens(), u32::MAX);
+    }
+
+    #[test]
+    fn add_assign_saturates_at_u32_max() {
+        let mut usage = TokenUsage {
+            input: u32::MAX - 10,
+            output: 5,
+            cache_creation: 0,
+            cache_read: 0,
+        };
+        let other = TokenUsage {
+            input: 20,
+            output: 10,
+            cache_creation: 5,
+            cache_read: 5,
+        };
+        usage += other;
+        assert_eq!(usage.input, u32::MAX);
+        assert_eq!(usage.output, 15);
+        assert_eq!(usage.cache_creation, 5);
+        assert_eq!(usage.cache_read, 5);
+    }
+
+    #[test]
+    fn add_assign_normal_values_sum_correctly() {
+        let mut usage = TokenUsage {
+            input: 1000,
+            output: 500,
+            cache_creation: 200,
+            cache_read: 300,
+        };
+        let other = TokenUsage {
+            input: 500,
+            output: 250,
+            cache_creation: 100,
+            cache_read: 150,
+        };
+        usage += other;
+        assert_eq!(usage.input, 1500);
+        assert_eq!(usage.output, 750);
+        assert_eq!(usage.cache_creation, 300);
+        assert_eq!(usage.cache_read, 450);
     }
 
     #[test]

--- a/maki-providers/src/providers/anthropic/bedrock.rs
+++ b/maki-providers/src/providers/anthropic/bedrock.rs
@@ -547,6 +547,7 @@ impl Provider for Bedrock {
                 }],
                 tools,
                 opts.thinking,
+                opts.message_cache_breakpoints,
             );
             // Fast mode lives only on the direct API, so Bedrock skips `opts.fast`
             // and never sends the `speed` param.

--- a/maki-providers/src/providers/anthropic/mod.rs
+++ b/maki-providers/src/providers/anthropic/mod.rs
@@ -402,6 +402,7 @@ impl Provider for Anthropic {
                 &system_blocks,
                 tools,
                 opts.thinking,
+                opts.message_cache_breakpoints,
             );
             body["model"] = json!(shared::strip_long_context(&model.id));
             body["stream"] = json!(true);
@@ -752,7 +753,7 @@ data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":5}}\n";
     #[test]
     fn cache_control_placement() {
         let single = vec![Message::user("only".into())];
-        let wire = build_wire_messages(&single);
+        let wire = build_wire_messages(&single, 2);
         let json: Value = serde_json::to_value(&wire).unwrap();
         assert_eq!(
             json[0]["content"][0]["cache_control"],
@@ -783,7 +784,7 @@ data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":5}}\n";
                 ..Default::default()
             },
         ];
-        let wire = build_wire_messages(&multi);
+        let wire = build_wire_messages(&multi, 2);
         let json: Value = serde_json::to_value(&wire).unwrap();
 
         assert!(json[0]["content"][0].get("cache_control").is_none());
@@ -817,7 +818,7 @@ data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":5}}\n";
             ],
             ..Default::default()
         }];
-        let wire = build_wire_messages(&messages);
+        let wire = build_wire_messages(&messages, 2);
         let json: Value = serde_json::to_value(&wire).unwrap();
 
         assert_eq!(json[0]["content"][0]["type"], "tool_result");

--- a/maki-providers/src/providers/anthropic/shared.rs
+++ b/maki-providers/src/providers/anthropic/shared.rs
@@ -38,8 +38,6 @@ pub(crate) fn long_context_window(model_id: &str) -> Option<u32> {
         .then_some(LONG_CONTEXT_WINDOW)
 }
 
-pub(super) const MESSAGE_CACHE_BREAKPOINTS: usize = 2;
-
 #[derive(Serialize)]
 pub(crate) struct CacheControl {
     pub r#type: &'static str,
@@ -153,14 +151,31 @@ pub(super) struct WireMessage<'a> {
     pub content: Vec<WireContentBlock<'a>>,
 }
 
-pub(super) fn build_wire_messages(messages: &[Message]) -> Vec<WireMessage<'_>> {
+pub(super) fn build_wire_messages(
+    messages: &[Message],
+    message_cache_breakpoints: usize,
+) -> Vec<WireMessage<'_>> {
     let len = messages.len();
+
+    debug!(
+        message_cache_breakpoints,
+        num_messages = len,
+        "building wire messages with cache breakpoints"
+    );
 
     messages
         .iter()
         .enumerate()
         .map(|(msg_idx, msg)| {
-            let cache_last_block = msg_idx + MESSAGE_CACHE_BREAKPOINTS >= len;
+            let cache_last_block = msg_idx + message_cache_breakpoints >= len;
+
+            if cache_last_block {
+                debug!(
+                    msg_idx,
+                    total_blocks = msg.content.len(),
+                    "marking last block with cache_control"
+                );
+            }
 
             WireMessage {
                 role: &msg.role,
@@ -199,8 +214,9 @@ pub(crate) fn build_request_body_with_system(
     system_blocks: &[SystemBlock<'_>],
     tools: &Value,
     thinking: ThinkingConfig,
+    message_cache_breakpoints: usize,
 ) -> Value {
-    let wire_messages = build_wire_messages(messages);
+    let wire_messages = build_wire_messages(messages, message_cache_breakpoints);
     let wire_tools = build_wire_tools(tools);
 
     let mut body = json!({
@@ -562,8 +578,10 @@ mod tests {
     use test_case::test_case;
 
     use super::{
-        LONG_CONTEXT_SUFFIX, LONG_CONTEXT_WINDOW, long_context_window, strip_long_context,
+        LONG_CONTEXT_SUFFIX, LONG_CONTEXT_WINDOW, build_wire_messages, long_context_window,
+        strip_long_context,
     };
+    use crate::{ContentBlock, Message, Role};
 
     #[test_case("claude-opus-4-8-1m", "claude-opus-4-8" ; "strips_suffix")]
     #[test_case("claude-opus-4-8", "claude-opus-4-8" ; "leaves_plain_id")]
@@ -576,5 +594,87 @@ mod tests {
     fn long_context_window_follows_suffix(model_id: &str, expected: Option<u32>) {
         assert_eq!(long_context_window(model_id), expected);
         assert!(LONG_CONTEXT_SUFFIX.ends_with("1m"));
+    }
+
+    #[test_case(0 ; "breakpoints_0")]
+    #[test_case(1 ; "breakpoints_1")]
+    #[test_case(2 ; "breakpoints_2")]
+    #[test_case(3 ; "breakpoints_3")]
+    fn build_wire_messages_marks_cache_control(breakpoints: usize) {
+        let messages = vec![
+            Message {
+                role: Role::User,
+                content: vec![ContentBlock::Text {
+                    text: "first message".to_string(),
+                }],
+                display_text: None,
+            },
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::Text {
+                    text: "first response".to_string(),
+                }],
+                display_text: None,
+            },
+            Message {
+                role: Role::User,
+                content: vec![ContentBlock::Text {
+                    text: "second message".to_string(),
+                }],
+                display_text: None,
+            },
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::Text {
+                    text: "second response".to_string(),
+                }],
+                display_text: None,
+            },
+        ];
+
+        let wire = build_wire_messages(&messages, breakpoints);
+        let len = messages.len();
+
+        for (msg_idx, wire_msg) in wire.iter().enumerate() {
+            let should_cache = msg_idx + breakpoints >= len;
+            let last_block_has_cache = wire_msg
+                .content
+                .last()
+                .is_some_and(|b| b.cache_control.is_some());
+
+            assert_eq!(
+                should_cache, last_block_has_cache,
+                "message {msg_idx}: expected cache={should_cache}, got cache={last_block_has_cache}"
+            );
+        }
+    }
+
+    #[test]
+    fn build_wire_messages_marks_only_last_block() {
+        let messages = vec![Message {
+            role: Role::User,
+            content: vec![
+                ContentBlock::Text {
+                    text: "first block".to_string(),
+                },
+                ContentBlock::Text {
+                    text: "second block".to_string(),
+                },
+                ContentBlock::Text {
+                    text: "third block".to_string(),
+                },
+            ],
+            display_text: None,
+        }];
+
+        let wire = build_wire_messages(&messages, 1);
+        assert_eq!(wire.len(), 1);
+
+        let wire_msg = &wire[0];
+        assert_eq!(wire_msg.content.len(), 3);
+
+        assert!(wire_msg.content[0].cache_control.is_none());
+        assert!(wire_msg.content[1].cache_control.is_none());
+        assert!(wire_msg.content[2].cache_control.is_some());
     }
 }

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hasher;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -22,6 +25,8 @@ const BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
 const ENV_VAR: &str = "GEMINI_API_KEY";
 const FLASH_MAX_THINKING: u32 = 24_576;
 const PRO_MAX_THINKING: u32 = 32_768;
+const CACHE_PREFIX_LEN: usize = 3;
+const CACHE_TTL: Duration = Duration::from_secs(8 * 60 * 60);
 
 /// The generic per-model max, capped by Google's documented `thinkingBudget`
 /// hard limits per family.
@@ -32,6 +37,40 @@ fn max_thinking(model: &Model) -> u32 {
         PRO_MAX_THINKING
     };
     model.max_thinking_budget().map_or(cap, |m| m.min(cap))
+}
+
+fn tools_hash(tools: &Value) -> Result<u64, AgentError> {
+    let mut hasher = DefaultHasher::new();
+    let json_str = serde_json::to_string(tools).map_err(|e| AgentError::Config {
+        message: format!("failed to serialize tools for hashing: {e}"),
+    })?;
+    hasher.write(json_str.as_bytes());
+    Ok(hasher.finish())
+}
+
+#[derive(Clone, Debug)]
+struct CachedContentState {
+    name: String,
+    tools_hash: u64,
+    message_count: usize,
+    expires_at: Instant,
+}
+
+impl CachedContentState {
+    fn new(name: String, tools_hash: u64, message_count: usize, expires_at: Instant) -> Self {
+        Self {
+            name,
+            tools_hash,
+            message_count,
+            expires_at,
+        }
+    }
+
+    fn is_valid(&self, tools_hash: u64, message_count: usize) -> bool {
+        self.tools_hash == tools_hash
+            && message_count >= self.message_count
+            && Instant::now() < self.expires_at
+    }
 }
 
 inventory::submit!(maki_config::providers::BuiltInProvider {
@@ -111,6 +150,7 @@ pub struct Google {
     auth: Arc<Mutex<ResolvedAuth>>,
     key_pool: Option<KeyPool>,
     stream_timeout: Duration,
+    cache_state: Arc<Mutex<HashMap<SessionRef, CachedContentState>>>,
 }
 
 impl Google {
@@ -122,6 +162,7 @@ impl Google {
             auth: Arc::new(Mutex::new(resolved)),
             key_pool: Some(pool),
             stream_timeout: timeouts.stream,
+            cache_state: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -134,11 +175,12 @@ impl Google {
             auth,
             key_pool: None,
             stream_timeout: timeouts.stream,
+            cache_state: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
     fn build_request(&self, method: &str, url: &str) -> isahc::http::request::Builder {
-        let auth = self.auth.lock().unwrap();
+        let auth = self.auth.lock().expect("auth lock poisoned");
         auth.configure_request(
             Request::builder()
                 .method(method)
@@ -148,17 +190,17 @@ impl Google {
     }
 
     fn api_key(&self) -> String {
-        let auth = self.auth.lock().unwrap();
+        let auth = self.auth.lock().expect("auth lock poisoned");
         auth.headers
             .iter()
             .find(|(k, _)| k == "x-goog-api-key")
             .map(|(_, v)| v.clone())
-            .unwrap_or_default()
+            .unwrap_or_else(String::new)
     }
 
     fn stream_url(&self, model_id: &str) -> String {
         let base = {
-            let auth = self.auth.lock().unwrap();
+            let auth = self.auth.lock().expect("auth lock poisoned");
             auth.base_url.as_deref().unwrap_or(BASE_URL).to_string()
         };
         let encoded = super::urlenc(model_id);
@@ -167,11 +209,85 @@ impl Google {
 
     fn models_url(&self) -> String {
         let base = {
-            let auth = self.auth.lock().unwrap();
+            let auth = self.auth.lock().expect("auth lock poisoned");
             auth.base_url.as_deref().unwrap_or(BASE_URL).to_string()
         };
         let key = self.api_key();
         format!("{base}/models?key={key}&pageSize=1000")
+    }
+
+    fn cached_contents_url(&self) -> String {
+        let base = {
+            let auth = self.auth.lock().expect("auth lock poisoned");
+            auth.base_url.as_deref().unwrap_or(BASE_URL).to_string()
+        };
+        let key = self.api_key();
+        format!("{base}/cachedContents?key={key}")
+    }
+
+    async fn create_cached_content(
+        &self,
+        model_id: &str,
+        system: &str,
+        tools: &Value,
+        messages: &[Message],
+    ) -> Result<String, AgentError> {
+        let url = self.cached_contents_url();
+        let prefix_len = messages.len().min(CACHE_PREFIX_LEN);
+
+        let mut body = json!({
+            "model": format!("models/{}", model_id),
+            "contents": convert_messages(&messages[..prefix_len]),
+        });
+
+        if !system.is_empty() {
+            body["systemInstruction"] = json!({"parts": [{"text": system}]});
+        }
+
+        let tool_decls = convert_tools(tools);
+        if !tool_defs_empty(&tool_decls) {
+            body["tools"] = json!([{"functionDeclarations": tool_decls}]);
+        }
+
+        body["expiration"] = json!({
+            "ttl": format!("{}s", CACHE_TTL.as_secs()),
+        });
+
+        let json_body = serde_json::to_vec(&body)?;
+        let request = self
+            .build_request("POST", &url)
+            .header("content-type", "application/json")
+            .body(json_body)?;
+
+        let mut response = self.client.send_async(request).await?;
+        if response.status().as_u16() != 200 {
+            return Err(AgentError::from_response(response).await);
+        }
+
+        let response_text = response.text().await?;
+        let cached: serde_json::Value = serde_json::from_str(&response_text)?;
+        let name = cached["name"].as_str().ok_or_else(|| AgentError::Config {
+            message: "missing cached content name in response".into(),
+        })?;
+        Ok(name.to_string())
+    }
+
+    async fn delete_cached_content(&self, name: &str) -> Result<(), AgentError> {
+        let base = {
+            let auth = self.auth.lock().expect("auth lock poisoned");
+            auth.base_url.as_deref().unwrap_or(BASE_URL).to_string()
+        };
+        let key = self.api_key();
+        let url = format!("{base}/{}?key={key}", name.trim_start_matches('/'));
+
+        let request = self.build_request("DELETE", &url).body(())?;
+        let response = self.client.send_async(request).await?;
+
+        if response.status().as_u16() == 200 || response.status().as_u16() == 404 {
+            Ok(())
+        } else {
+            Err(AgentError::from_response(response).await)
+        }
     }
 
     fn build_body(
@@ -242,14 +358,127 @@ impl Provider for Google {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        _session_id: Option<&'a SessionRef>,
+        session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
-        Box::pin(self.do_stream(model, messages, system, tools, event_tx, opts.thinking))
+        Box::pin(async move {
+            let current_tools_hash = match tools_hash(tools) {
+                Ok(h) => h,
+                Err(e) => {
+                    warn!(error = %e, "failed to hash tools, falling back to uncached request");
+                    return self
+                        .do_stream(model, messages, system, tools, event_tx, opts.thinking)
+                        .await;
+                }
+            };
+            let current_message_count = messages.len();
+
+            let Some(sid) = session_id else {
+                return self
+                    .do_stream(model, messages, system, tools, event_tx, opts.thinking)
+                    .await;
+            };
+            if current_message_count <= CACHE_PREFIX_LEN {
+                return self
+                    .do_stream(model, messages, system, tools, event_tx, opts.thinking)
+                    .await;
+            }
+
+            let (cached_content_name, old_name_to_delete) = {
+                let mut cache_state = self.cache_state.lock().map_err(|e| AgentError::Config {
+                    message: format!("cache state lock failed: {e}"),
+                })?;
+                if let Some(state) = cache_state.get(sid) {
+                    if state.is_valid(current_tools_hash, current_message_count) {
+                        (Some(state.name.clone()), None)
+                    } else {
+                        let old_name = state.name.clone();
+                        cache_state.remove(sid);
+                        (None, Some(old_name))
+                    }
+                } else {
+                    (None, None)
+                }
+            };
+
+            if let Some(ref name) = old_name_to_delete {
+                let _ = self.delete_cached_content(name).await;
+            }
+
+            let cached_content_name = if let Some(name) = cached_content_name {
+                name
+            } else {
+                match self
+                    .create_cached_content(&model.id, system, tools, messages)
+                    .await
+                {
+                    Ok(name) => {
+                        let mut cache_state =
+                            self.cache_state.lock().map_err(|e| AgentError::Config {
+                                message: format!("cache state lock failed: {e}"),
+                            })?;
+                        cache_state.insert(
+                            sid.clone(),
+                            CachedContentState::new(
+                                name.clone(),
+                                current_tools_hash,
+                                current_message_count,
+                                Instant::now() + CACHE_TTL,
+                            ),
+                        );
+                        name
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "failed to create cached content, falling back to uncached request");
+                        return self
+                            .do_stream(model, messages, system, tools, event_tx, opts.thinking)
+                            .await;
+                    }
+                }
+            };
+
+            if cached_content_name.is_empty() {
+                return self
+                    .do_stream(model, messages, system, tools, event_tx, opts.thinking)
+                    .await;
+            }
+
+            let no_tools = json!([]);
+            let mut body = self.build_body(
+                model,
+                &messages[CACHE_PREFIX_LEN..],
+                "",
+                &no_tools,
+                opts.thinking,
+            );
+            body["cachedContent"] = json!(cached_content_name);
+
+            let url = self.stream_url(&model.id);
+            let json_body = serde_json::to_vec(&body)?;
+
+            let request = self
+                .build_request("POST", &url)
+                .header("content-type", "application/json")
+                .body(json_body)?;
+
+            let response = self.client.send_async(request).await?;
+            let status = response.status().as_u16();
+
+            if status == 200 {
+                parse_sse(response, event_tx, self.stream_timeout).await
+            } else {
+                Err(AgentError::from_response(response).await)
+            }
+        })
     }
 
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
         let url = self.models_url();
-        let request = self.build_request("GET", &url).body(()).unwrap();
+        let request = self
+            .build_request("GET", &url)
+            .body(())
+            .unwrap_or_else(|e| {
+                panic!("request build failed: {e}");
+            });
         let client = self.client.clone();
         Box::pin(async move {
             let mut response = client.send_async(request).await?;
@@ -271,7 +500,7 @@ impl Provider for Google {
                         .name
                         .strip_prefix("models/")
                         .map(String::from)
-                        .unwrap_or(m.name);
+                        .unwrap_or_else(|| m.name.clone());
                     crate::model::ModelInfo::id_only(id)
                 })
                 .collect();
@@ -282,8 +511,13 @@ impl Provider for Google {
 
     fn reload_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
         Box::pin(async {
-            let pool = KeyPool::resolve("google", ENV_VAR)?;
-            *self.auth.lock().unwrap() = resolve_auth_from_key(pool.current());
+            let pool = KeyPool::resolve("google", ENV_VAR).map_err(|e| AgentError::Config {
+                message: format!("key pool resolve failed: {e}"),
+            })?;
+            let mut auth = self.auth.lock().map_err(|e| AgentError::Config {
+                message: format!("auth lock failed: {e}"),
+            })?;
+            *auth = resolve_auth_from_key(pool.current());
             Ok(())
         })
     }
@@ -406,7 +640,7 @@ fn convert_tools(tools: &Value) -> Vec<Value> {
     arr.iter()
         .filter_map(|t| {
             let name = t.get("name")?.as_str()?;
-            let description = t.get("description")?.as_str().unwrap_or("");
+            let description = t.get("description").and_then(|d| d.as_str()).unwrap_or("");
             let parameters = t
                 .get("input_schema")
                 .cloned()
@@ -414,25 +648,10 @@ fn convert_tools(tools: &Value) -> Vec<Value> {
             Some(json!({
                 "name": name,
                 "description": description,
-                "parameters": strip_additional_properties(parameters),
+                "parameters": parameters,
             }))
         })
         .collect()
-}
-
-fn strip_additional_properties(value: Value) -> Value {
-    match value {
-        Value::Object(mut map) => {
-            map.remove("additionalProperties");
-            map.values_mut()
-                .for_each(|v| *v = strip_additional_properties(std::mem::take(v)));
-            Value::Object(map)
-        }
-        Value::Array(items) => {
-            Value::Array(items.into_iter().map(strip_additional_properties).collect())
-        }
-        other => other,
-    }
 }
 
 fn tool_defs_empty(tool_decls: &[Value]) -> bool {
@@ -832,14 +1051,12 @@ mod tests {
             "input_schema": {
                 "type": "object",
                 "properties": {
-                    "cmd": {"type": "string", "additionalProperties": false},
+                    "cmd": {"type": "string"},
                     "opts": {
                         "type": "object",
-                        "additionalProperties": false,
                         "properties": {"verbose": {"type": "boolean"}}
                     }
-                },
-                "additionalProperties": false
+                }
             }
         }]);
         let result = convert_tools(&tools);
@@ -847,57 +1064,6 @@ mod tests {
         assert_eq!(result[0]["name"], "bash");
         assert_eq!(result[0]["description"], "run a command");
         assert!(result[0]["parameters"]["properties"]["cmd"].is_object());
-        assert!(
-            result[0]["parameters"]
-                .get("additionalProperties")
-                .is_none()
-        );
-        assert!(
-            result[0]["parameters"]["properties"]["cmd"]
-                .get("additionalProperties")
-                .is_none()
-        );
-        assert!(
-            result[0]["parameters"]["properties"]["opts"]
-                .get("additionalProperties")
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn strip_additional_properties_recursive() {
-        let schema = json!({
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "inner": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {"x": {"type": "number", "additionalProperties": false}}
-                },
-                "list": {
-                    "type": "array",
-                    "items": {"type": "string", "additionalProperties": false}
-                }
-            }
-        });
-        let cleaned = strip_additional_properties(schema);
-        assert!(cleaned.get("additionalProperties").is_none());
-        assert!(
-            cleaned["properties"]["inner"]
-                .get("additionalProperties")
-                .is_none()
-        );
-        assert!(
-            cleaned["properties"]["inner"]["properties"]["x"]
-                .get("additionalProperties")
-                .is_none()
-        );
-        assert!(
-            cleaned["properties"]["list"]["items"]
-                .get("additionalProperties")
-                .is_none()
-        );
     }
 
     #[test]
@@ -969,5 +1135,48 @@ mod tests {
         assert_eq!(result.usage.input, 100);
         assert_eq!(result.usage.output, 10);
         assert_eq!(result.usage.cache_read, 50);
+    }
+
+    #[test]
+    fn cached_contents_url_includes_api_key() {
+        let google = Google::with_auth(test_auth(), test_timeouts());
+        let url = google.cached_contents_url();
+        assert!(url.contains("cachedContents"));
+        assert!(url.contains("key=test-key"));
+    }
+
+    #[test]
+    fn cached_content_state_valid_when_tools_and_count_match() {
+        let future = Instant::now() + Duration::from_secs(3600);
+        let state = CachedContentState::new("cache1".to_string(), 123, 5, future);
+        assert!(state.is_valid(123, 5));
+        assert!(state.is_valid(123, 6));
+        assert!(!state.is_valid(124, 5));
+        assert!(!state.is_valid(123, 4));
+    }
+
+    #[test]
+    fn cached_content_state_invalid_after_expiry() {
+        let past = Instant::now() - Duration::from_secs(1);
+        let state = CachedContentState::new("cache1".to_string(), 123, 5, past);
+        assert!(!state.is_valid(123, 5));
+    }
+
+    #[test]
+    fn tools_hash_is_deterministic() {
+        let tools = json!([{"name": "bash", "input_schema": {"type": "object"}}]);
+        let hash1 = tools_hash(&tools).expect("tools hash must succeed");
+        let hash2 = tools_hash(&tools).expect("tools hash must succeed");
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn tools_hash_differs_for_different_tools() {
+        let tools1 = json!([{"name": "bash", "input_schema": {"type": "object"}}]);
+        let tools2 = json!([{"name": "read", "input_schema": {"type": "object"}}]);
+        assert_ne!(
+            tools_hash(&tools1).expect("tools hash must succeed"),
+            tools_hash(&tools2).expect("tools hash must succeed")
+        );
     }
 }

--- a/maki-providers/src/providers/opencode.rs
+++ b/maki-providers/src/providers/opencode.rs
@@ -505,6 +505,7 @@ impl Opencode {
             &system_blocks,
             tools,
             opts.thinking,
+            opts.message_cache_breakpoints,
         );
         body["model"] = json!(model.id);
         body["stream"] = json!(true);

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -569,11 +569,25 @@ impl From<ThinkingConfig> for StoredThinking {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RequestOptions {
     pub thinking: ThinkingConfig,
     /// Raw user preference, reconciled by [`RequestOptions::clamped`] before use.
     pub fast: bool,
+    /// Number of recent messages whose last content block should be marked with
+    /// cache_control. Default is 2. Higher values increase cache write cost but
+    /// may improve cache hit rates in long conversations.
+    pub message_cache_breakpoints: usize,
+}
+
+impl Default for RequestOptions {
+    fn default() -> Self {
+        Self {
+            thinking: Default::default(),
+            fast: false,
+            message_cache_breakpoints: 2,
+        }
+    }
 }
 
 impl RequestOptions {
@@ -588,6 +602,7 @@ impl RequestOptions {
                 ThinkingConfig::Off
             },
             fast: self.fast && model.supports_fast(),
+            message_cache_breakpoints: self.message_cache_breakpoints,
         }
     }
 }
@@ -901,6 +916,7 @@ mod tests {
         let opts = RequestOptions {
             thinking,
             fast: false,
+            message_cache_breakpoints: 2,
         };
         assert_eq!(opts.clamped(&model).thinking, expected);
     }
@@ -911,6 +927,7 @@ mod tests {
         let opts = RequestOptions {
             thinking: ThinkingConfig::Off,
             fast: true,
+            message_cache_breakpoints: 2,
         };
         assert!(!opts.clamped(&model).fast);
     }

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -35,6 +35,10 @@ const NON_SESSION_STEMS: [&str; 2] = [CWD_INDEX_STEM, SCAN_CACHE_STEM];
 const DEFAULT_TITLE: &str = "New session";
 const MAX_TITLE_LEN: usize = 60;
 
+pub trait Summarizable {
+    fn summarize(&self) -> Self;
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum SessionError {
     #[error(transparent)]
@@ -850,6 +854,19 @@ fn jsonl_path(dir: &Path, id: MakiId) -> PathBuf {
     dir.join(format!("{id}.jsonl"))
 }
 
+pub fn compact_tool_outputs<M, U, T>(
+    session: &mut Session<M, U, T>,
+    recent_tool_ids: &HashSet<String>,
+) where
+    T: Summarizable + Clone,
+{
+    for (id, output) in session.tool_outputs.iter_mut() {
+        if !recent_tool_ids.contains(id) {
+            *output = output.summarize();
+        }
+    }
+}
+
 fn json_path(dir: &Path, id: MakiId) -> PathBuf {
     dir.join(format!("{id}.json"))
 }
@@ -1281,14 +1298,15 @@ mod tests {
     use super::StoredThinking;
     use super::ThinkingParseError;
     use super::{
-        CWD_INDEX_FILE, DEFAULT_TITLE, MAX_TITLE_LEN, SESSION_VERSION, StoredSubagent, TAIL_BUF,
-        generate_title, json_path, jsonl_path, load_cwd_index, update_cwd_index,
-        write_full_session,
+        CWD_INDEX_FILE, DEFAULT_TITLE, MAX_TITLE_LEN, SESSION_VERSION, StoredSubagent,
+        StoredTokenUsage, Summarizable, TAIL_BUF, compact_tool_outputs, generate_title, json_path,
+        jsonl_path, load_cwd_index, update_cwd_index, write_full_session,
     };
     use super::{SCAN_CACHE_FILE, Session, SessionError, SessionLog, StorageError, TitleSource};
     use crate::id::MakiId;
+    use serde::{Deserialize, Serialize};
     use serde_json::Value;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::fs::{self, OpenOptions};
     use std::io::Write;
     use std::path::Path;
@@ -2368,5 +2386,76 @@ mod tests {
         let list = TestSession::list_in("/project", dir).unwrap();
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].title, "big-meta");
+    }
+
+    #[test]
+    fn compact_tool_outputs_summarizes_old_outputs() {
+        #[derive(Clone, Serialize, Deserialize)]
+        struct MockOutput {
+            data: String,
+        }
+
+        impl Summarizable for MockOutput {
+            fn summarize(&self) -> Self {
+                Self {
+                    data: format!("summary of {}", self.data),
+                }
+            }
+        }
+
+        let mut session: Session<Value, StoredTokenUsage, MockOutput> = Session::new("model", "/p");
+
+        session.tool_outputs.insert(
+            "old-tool".into(),
+            MockOutput {
+                data: "large data".into(),
+            },
+        );
+
+        session.tool_outputs.insert(
+            "recent-tool".into(),
+            MockOutput {
+                data: "recent data".into(),
+            },
+        );
+
+        let mut recent_tool_ids = HashSet::new();
+        recent_tool_ids.insert("recent-tool".into());
+
+        compact_tool_outputs(&mut session, &recent_tool_ids);
+
+        let old = session.tool_outputs.get("old-tool").unwrap();
+        assert_eq!(old.data, "summary of large data");
+
+        let recent = session.tool_outputs.get("recent-tool").unwrap();
+        assert_eq!(recent.data, "recent data");
+    }
+
+    #[test]
+    fn compact_tool_outputs_preserves_all_recent_tool_ids() {
+        #[derive(Clone, Serialize, Deserialize)]
+        struct MockOutput;
+
+        impl Summarizable for MockOutput {
+            fn summarize(&self) -> Self {
+                Self
+            }
+        }
+
+        let mut session: Session<Value, StoredTokenUsage, MockOutput> = Session::new("model", "/p");
+
+        session.tool_outputs.insert("tool-1".into(), MockOutput);
+        session.tool_outputs.insert("tool-2".into(), MockOutput);
+        session.tool_outputs.insert("old-tool".into(), MockOutput);
+
+        let mut recent_tool_ids = HashSet::new();
+        recent_tool_ids.insert("tool-1".into());
+        recent_tool_ids.insert("tool-2".into());
+
+        compact_tool_outputs(&mut session, &recent_tool_ids);
+
+        assert!(session.tool_outputs.contains_key("tool-1"));
+        assert!(session.tool_outputs.contains_key("tool-2"));
+        assert!(session.tool_outputs.contains_key("old-tool"));
     }
 }

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -349,7 +349,8 @@ impl<'t> EventLoop<'t> {
 
         let storage_writer = Arc::new(StorageWriter::new(storage.clone()));
         let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
-        let (mcp_handle, mcp_config_errors) = smol::block_on(mcp::start(&cwd));
+        let (mcp_handle, mcp_config_errors) =
+            smol::block_on(mcp::start(&cwd, config.mcp_tool_desc_max_chars));
 
         let provider: Arc<dyn Provider> = if needs_login {
             Arc::from(maki_providers::provider::from_model_fallback(

--- a/plugins/activate_tool/init.lua
+++ b/plugins/activate_tool/init.lua
@@ -1,0 +1,34 @@
+local DESCRIPTION =
+  [[Activate a tool that is not currently available. Use this when you need a tool that is not in the current mode's tool set. The tool will become available in the next turn.]]
+
+maki.api.register_tool({
+  name = "activate_tool",
+  modes = { "default", "research", "build", "compact" },
+  description = DESCRIPTION,
+
+  schema = {
+    type = "object",
+    properties = {
+      tool_name = {
+        type = "string",
+        description = "Name of the tool to activate",
+        required = true,
+      },
+    },
+  },
+
+  header = function(input)
+    local buf = maki.ui.buf()
+    buf:line({ { "activate: " .. (input.tool_name or "unknown"), "tool" } })
+    return buf
+  end,
+
+  handler = function(input, ctx)
+    local tool_name = input.tool_name
+    if not tool_name then
+      return { llm_output = "error: tool_name is required", is_error = true }
+    end
+    local llm_output = string.format("activated tool: %s (available next turn)", tool_name)
+    return { llm_output = llm_output }
+  end,
+})

--- a/plugins/bash/init.lua
+++ b/plugins/bash/init.lua
@@ -233,16 +233,9 @@ local function collect_commands(node, source)
   return out
 end
 
-local description = [[Execute a bash command.
-Commands run in ]] .. cwd .. [[ by default.
-
-- **DO NOT** use for file ops! Only git, builds, tests, and system commands.
-- Use `workdir` param instead of `cd <dir> && <cmd>` patterns.
-- Do NOT use to communicate text to the user.
-- Chain dependent commands with `&&`. Use batch for independent ones.
-- Provide a short `description` (3-5 words).
-- Output truncated beyond 2000 lines or 50KB.
-- Interactive commands (sudo, ssh prompts) fail immediately.]]
+local description = [[Execute a bash command. Default dir: ]]
+  .. cwd
+  .. [[. DO NOT use for file ops - only git, builds, tests, system commands. Use `workdir` instead of `cd && cmd`. Chain dependent commands with `&&`. Use batch for independent ones. Provide short `description` (3-5 words). Output truncated beyond 2000 lines or 50KB. Interactive commands (sudo, ssh) fail immediately.]]
 
 maki.api.register_prompt_hint({
   slot = "tool_usage",
@@ -260,14 +253,15 @@ local opts = maki.api.register_options(output_limits.extend({
 maki.api.register_tool({
   name = "bash",
   kind = "execute",
+  modes = { "default", "build", "compact" },
   description = description,
   schema = {
     type = "object",
     properties = {
-      command = { type = "string", description = "The bash command to execute", required = true },
-      timeout = { type = "integer", description = "Timeout in seconds (default 120)" },
-      workdir = { type = "string", description = "Working directory (default: cwd)" },
-      description = { type = "string", description = "Short description (3-5 words) of what the command does" },
+      command = { type = "string", required = true },
+      timeout = { type = "integer" },
+      workdir = { type = "string" },
+      description = { type = "string" },
     },
   },
   permission_scopes = function(input)

--- a/plugins/batch/init.lua
+++ b/plugins/batch/init.lua
@@ -47,16 +47,7 @@ local INDICATOR = {
 }
 
 local description = string.format(
-  [[Executes multiple independent tool calls concurrently to reduce round-trips.
-
-ALWAYS USE THE BATCH TOOL WHEN YOU HAVE MULTIPLE INDEPENDENT TOOL CALLS. This dramatically improves performance.
-
-Rules:
-- 1-%d tool calls per batch
-- All calls run in parallel; order NOT guaranteed
-- Partial failures do not stop other calls
-- Do NOT nest batch inside batch
-- Do NOT use for dependent operations or when filtering results (use code_execution)]],
+  [[Execute multiple independent tool calls concurrently. ALWAYS use batch for multiple independent calls. 1-%d tools per batch. Parallel execution, order not guaranteed. Partial failures don't stop others. Do NOT nest batch. Use code_execution for dependent operations.]],
   MAX_BATCH_SIZE
 )
 
@@ -70,16 +61,6 @@ local schema = {
       items = {
         description = "Tool invocation: { tool: string, parameters: object } or flat { tool: string, ...params }",
       },
-    },
-  },
-}
-
-local examples = {
-  {
-    tool_calls = {
-      { tool = "glob", parameters = { pattern = "src/**/*.ts" } },
-      { tool = "grep", parameters = { pattern = "import", include = "*.ts" } },
-      { tool = "index", parameters = { path = "/project/index.ts" } },
     },
   },
 }
@@ -520,7 +501,6 @@ maki.api.register_tool({
   kind = "execute",
   audiences = { "main", "research_sub", "general_sub" },
   schema = schema,
-  examples = examples,
   header = function(input)
     return #(input.tool_calls or {}) .. " tools"
   end,

--- a/plugins/code_execution/init.lua
+++ b/plugins/code_execution/init.lua
@@ -80,18 +80,8 @@ local function build_body(ctx, code)
   return buf, view, highlight
 end
 
-local description = [[Execute Python code in a sandboxed interpreter with tools as callable functions.
-
-Use for chained/dependent tool calls and filtering/processing results, e.g. filtering web tool output. **DRAMATICALLY** faster than sequential tool calls!
-
-- All tools are async and return strings: `result = await read(path='file.txt')`. Parse output yourself.
-- Use `asyncio.gather()` for concurrency within one execution.
-- Available libs: re, asyncio, sys, os, json. No other imports, no classes, no filesystem/network access.
-- Fresh sandbox each run: no state persists between executions.
-- 30s script timeout (`timeout` param); time awaiting tool calls doesn't count.
-- Skip it when a single tool call needs no transformation.
-- NOT a thinking scratchpad. Reason in your response text.
-]]
+local description =
+  [[Execute Python code in a sandboxed interpreter with tools as callable functions. Use for chained/dependent tool calls and filtering/processing results. Faster than sequential tool calls. Tools are async: `result = await read(path='file.txt')`. Use `asyncio.gather()` for concurrency. Available libs: re, asyncio, sys, os, json. Fresh sandbox each run. 30s script timeout (`timeout` param); time awaiting tool calls doesn't count.]]
 
 local schema = {
   type = "object",
@@ -106,24 +96,6 @@ local schema = {
       type = "integer",
       description = "Script execution timeout in seconds (default 30)",
     },
-  },
-}
-
-local examples = {
-  {
-    code = [[files = (await glob(pattern='**/*.rs')).strip().split('\n')
-results = await asyncio.gather(*[read(path=f) for f in files if f.strip()])
-for f, c in zip(files, results):
-    if 'fn main' in c: print(f)]],
-  },
-  {
-    code = [[result = await grep(pattern='TODO', include='*.rs')
-print(f"{len(result.strip().splitlines())} TODOs found")]],
-  },
-  {
-    code = [[content = await webfetch(url='https://example.com/docs')
-for line in content.splitlines():
-    if 'auth' in line.lower(): print(line)]],
   },
 }
 
@@ -301,7 +273,6 @@ maki.api.register_tool({
   description = description,
   describe = describe,
   schema = schema,
-  examples = examples,
   kind = "execute",
   audiences = { "main", "research_sub", "general_sub" },
   start_annotation = { field = "timeout", kind = "timeout" },

--- a/plugins/edit/init.lua
+++ b/plugins/edit/init.lua
@@ -7,30 +7,16 @@ local SNIPPET_MAX_CHARS = 32
 local FALLBACK_VIEW_LINES = 10
 
 local EDIT_LINES_DESCRIPTION =
-  [[Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new_string`. Use empty `new_string` to delete a range. Do not use with the batch tool.]]
+  [[Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new_string`. Use empty `new_string` to delete. Do not use with batch.]]
 
 local INSERT_LINES_DESCRIPTION =
-  [[Insert lines before a given line number. Lines at `line` and below shift down. Existing lines are preserved. Do not use with the batch tool.]]
+  [[Insert lines before a given line number. Lines at `line` and below shift down. Existing lines preserved. Do not use with batch.]]
 
-local EDIT_DESCRIPTION = [[Replace an exact string match in a file.
+local EDIT_DESCRIPTION =
+  [[Replace an exact string match in a file. old_string must appear exactly once unless replace_all is true. Read file first. When copying from read output, exclude line number prefix (e.g. `42: `). Prefer over write for targeted changes. Use replace_all for renaming.]]
 
-- The old_string must appear exactly once unless replace_all is true.
-- Read the file first to get exact content.
-- When copying text from read output, do NOT include the line number prefix (e.g. `42: `) - only the content after it.
-- Prefer this over write for targeted changes - it uses far fewer tokens.
-- Use replace_all for renaming across a file.
-]]
-
-local MULTIEDIT_DESCRIPTION = [[Make multiple find-and-replace edits to a single file atomically.
-Prefer this over edit when making multiple changes to the same file.
-
-- Read the file first to get exact content.
-- old_string must match the file contents exactly, including all whitespace and indentation.
-- Each edit must match exactly once unless replace_all is true. Use replace_all for renaming across a file.
-- Edits are applied in sequence - each operates on the result of the previous.
-- If any edit fails, none are written.
-- Ensure earlier edits don't affect text that later edits need to find.
-]]
+local MULTIEDIT_DESCRIPTION =
+  [[Make multiple find-and-replace edits to a single file atomically. Prefer over edit for multiple changes. Read file first. old_string must match exactly, including whitespace. Each edit must match exactly once unless replace_all. Edits applied in sequence. If any edit fails, none are written. Ensure earlier edits don't affect later edits.]]
 
 local function edit_header(input)
   local buf = maki.ui.buf()
@@ -257,23 +243,19 @@ maki.api.register_tool({
     properties = {
       path = {
         type = "string",
-        description = "Absolute path to the file",
         required = true,
         alias = "file_path",
       },
       old_string = {
         type = "string",
-        description = "Exact string to find (must match uniquely unless replace_all is true)",
         required = true,
       },
       new_string = {
         type = "string",
-        description = "Replacement string",
         required = true,
       },
       replace_all = {
         type = "boolean",
-        description = "Replace all occurrences (default false)",
       },
     },
   },
@@ -309,30 +291,25 @@ register_tool_if(opts.multiedit, {
     properties = {
       path = {
         type = "string",
-        description = "Absolute path to the file",
         required = true,
         alias = "file_path",
       },
       edits = {
         type = "array",
-        description = "Array of edit operations to apply sequentially",
         required = true,
         items = {
           type = "object",
           properties = {
             old_string = {
               type = "string",
-              description = "Exact string to find",
               required = true,
             },
             new_string = {
               type = "string",
-              description = "Replacement string",
               required = true,
             },
             replace_all = {
               type = "boolean",
-              description = "Replace all occurrences (default false)",
             },
           },
         },
@@ -394,23 +371,19 @@ register_tool_if(opts.edit_lines, {
     properties = {
       path = {
         type = "string",
-        description = "Absolute path to the file",
         required = true,
         alias = "file_path",
       },
       start = {
         type = "integer",
-        description = "First line (1-indexed)",
         required = true,
       },
       ["end"] = {
         type = "integer",
-        description = "Last line, inclusive",
         required = true,
       },
       new_string = {
         type = "string",
-        description = "Replacement text",
         required = true,
       },
     },
@@ -448,18 +421,15 @@ register_tool_if(opts.insert_lines, {
     properties = {
       path = {
         type = "string",
-        description = "Absolute path to the file",
         required = true,
         alias = "file_path",
       },
       line = {
         type = "integer",
-        description = "Line number to insert before (1-indexed). Use 1 to insert at the top.",
         required = true,
       },
       new_string = {
         type = "string",
-        description = "Text to insert",
         required = true,
       },
     },

--- a/plugins/glob/init.lua
+++ b/plugins/glob/init.lua
@@ -17,17 +17,14 @@ end
 maki.api.register_tool({
   name = "glob",
   kind = "search",
-  description = [[Find files by glob pattern.
-
-- Respects .gitignore.
-- Returns absolute paths sorted by modification time (newest first).
-- Prefer speculative parallel searches over sequential rounds of glob+grep.]],
+  modes = { "default", "research", "build", "compact" },
+  description = [[Find files by glob pattern. Respects .gitignore. Returns absolute paths sorted by modification time (newest first). Prefer speculative parallel searches over sequential glob+grep.]],
 
   schema = {
     type = "object",
     properties = {
-      pattern = { type = "string", description = "Glob pattern (e.g. **/*.rs, src/**/*.ts)", required = true },
-      path = { type = "string", description = "Directory to search in (default: cwd)" },
+      pattern = { type = "string", required = true },
+      path = { type = "string" },
     },
   },
 

--- a/plugins/grep/init.lua
+++ b/plugins/grep/init.lua
@@ -196,27 +196,21 @@ maki.api.register_prompt_hint({
 maki.api.register_tool({
   name = "grep",
   kind = "search",
-  description = [[Search file contents using regex.
-
-- Respects .gitignore.
-- Results grouped by file, sorted by modification time.
-- Prefer speculative parallel searches over sequential rounds of glob+grep.
-- Do NOT wrap the pattern in quotes. Do NOT double-escape (e.g. `\[` not `\\[`).
-- Multi-line matching is auto-enabled when the pattern contains `\n`, `(?s)`, or `(?m)`.]],
+  modes = { "default", "research", "build", "compact" },
+  description = [[Search file contents using regex. Respects .gitignore. Results grouped by file, sorted by modification time. Prefer speculative parallel searches over sequential glob+grep. Do NOT wrap pattern in quotes or double-escape (e.g. `\[` not `\\[`). Multi-line matching auto-enabled when pattern contains `\n`, `(?s)`, or `(?m)`.]],
 
   schema = {
     type = "object",
     properties = {
-      pattern = { type = "string", description = "Regex pattern", required = true },
-      path = { type = "string", description = "Directory to search in (default: cwd)" },
+      pattern = { type = "string", required = true },
+      path = { type = "string" },
       include = {
         type = "string",
-        description = "File glob filter (e.g. *.c)",
         alias = "glob",
       },
-      context_before = { type = "integer", description = "Context lines before match" },
-      context_after = { type = "integer", description = "Context lines after match" },
-      limit = { type = "integer", description = "Max match groups to return" },
+      context_before = { type = "integer" },
+      context_after = { type = "integer" },
+      limit = { type = "integer" },
     },
   },
 

--- a/plugins/index/init.lua
+++ b/plugins/index/init.lua
@@ -153,17 +153,13 @@ maki.api.register_prompt_hint({
 maki.api.register_tool({
   name = "index",
   kind = "read",
-  description = [[
-Return a compact overview of a source file: imports, type definitions, function signatures, and structure with their line numbers surrounded by []. ~70-90% more efficient than reading the full file.
-
-- Use this FIRST to understand file structure before using read with offset/limit.
-- Supports source files in different programming languages and markdown.
-- Falls back with an error on unsupported languages. Use read instead.]],
+  modes = { "default", "research", "build", "compact" },
+  description = [[Return a compact overview of a source file: imports, types, function signatures, and structure with line numbers in []. ~70-90% more efficient than reading full file. Use FIRST to understand structure before read with offset/limit. Supports source files and markdown. Falls back with error on unsupported languages.]],
 
   schema = {
     type = "object",
     properties = {
-      path = { type = "string", description = "Absolute path to the file", required = true },
+      path = { type = "string", required = true },
     },
   },
   header = function(input)

--- a/plugins/memory/init.lua
+++ b/plugins/memory/init.lua
@@ -38,14 +38,7 @@ maki.api.register_prompt_hint({
     if #entries == 0 then
       return nil
     end
-    table.sort(entries, function(a, b)
-      return a[1] < b[1]
-    end)
-    local out = "\n\nMemory files (use the memory tool to view/update):\n"
-    for _, e in ipairs(entries) do
-      out = out .. "- " .. e[1] .. " (" .. e[2] .. " bytes)\n"
-    end
-    return out
+    return "\n\nMemory files: " .. #entries .. " entries (use memory tool to view/update)\n"
   end,
 })
 
@@ -133,9 +126,7 @@ end
 
 maki.api.register_tool({
   name = "memory",
-  description = "Persistent, project-scoped scratchpad for learnings, patterns, decisions, and gotchas across sessions.\n\n"
-    .. "- Save important context before compaction or to build up project knowledge.\n"
-    .. "- Keep entries concise and current. Delete outdated information.",
+  description = "Persistent, project-scoped scratchpad for learnings, patterns, decisions, and gotchas across sessions. Save important context before compaction or to build project knowledge. Keep entries concise and current. Delete outdated information.",
 
   schema = {
     type = "object",

--- a/plugins/question/init.lua
+++ b/plugins/question/init.lua
@@ -1,16 +1,8 @@
 local QuestionForm = require("question_form")
 local QuestionHelpers = require("question_helpers")
 
-local DESCRIPTION = [[Use this tool when you need to ask the user questions during execution. This allows you to:
-- Gather user preferences or requirements
-- Clarify ambiguous instructions
-- Get decisions on implementation choices as you work
-- Offer choices to the user about what direction to take
-
-Rules:
-- `custom` enabled by default adds "Type your own answer" - don't include catch-all options.
-- Answers returned as arrays of labels. Set `multiSelect: true` for multi-select.
-- Put recommended option first with "(Recommended)" suffix.]]
+local DESCRIPTION =
+  [[Ask the user questions during execution. Supports single/multi-select, custom answers, and tabbed multi-question forms. Put recommended options first with "(Recommended)" suffix.]]
 
 maki.api.register_tool({
   name = "question",

--- a/plugins/read/init.lua
+++ b/plugins/read/init.lua
@@ -2,18 +2,7 @@ local ToolView = require("maki.tool_view")
 local shorten_path = require("maki.shorten_path")
 local output_limits = require("maki.output_limits")
 
-local DESCRIPTION = [[Read a file or directory. Returns contents with line numbers (1-indexed).
-
-- Supports absolute, relative, and ~/ paths.
-- **Always include offset and limit** if possible. Defaults: no offset = start at 1; no limit = up to 2000 lines.
-- Use the **index** tool or **grep** tool first to find the offset and limit.
-- Only read the sections you actually need.
-- Use `wc -l` to check total number of lines before reading to decide a reasonable limit unless known already.
-- Use truncation hints (e.g. "truncated lines X-Y") to continue with the correct offset.
-- Do not reread the same range (same file and same offset).
-- Prefer grep to locate content instead of scanning full files.
-- Call in parallel when reading multiple files.
-- Avoid tiny repeated slices - read a larger window if you need more context.]]
+local DESCRIPTION = "Read a file or directory. Returns contents with line numbers (1-indexed)."
 
 local DEFAULT_MAX_OUTPUT_LINES = 2000
 
@@ -224,14 +213,16 @@ end
 
 maki.api.register_prompt_hint({
   slot = "tool_usage",
-  content = [[
-- When using the **read** tool, only read the sections you actually need.
-- Use `wc -l` to check total number of lines before reading to decide a reasonable **read** tool limit unless known already.]],
+  content = [[- When using the **read** tool, only read the sections you actually need.
+- Use `wc -l` to check total number of lines before reading to decide a reasonable **read** tool limit unless known already.
+- Supports absolute, relative, and ~/ paths. No offset = start at 1; no limit = up to 2000 lines.
+- Use truncation hints (e.g. "truncated lines X-Y") to continue with the correct offset.]],
 })
 
 maki.api.register_tool({
   name = "read",
   kind = "read",
+  modes = { "default", "research", "build", "compact" },
   description = DESCRIPTION,
 
   schema = {
@@ -239,15 +230,11 @@ maki.api.register_tool({
     properties = {
       path = {
         type = "string",
-        description = "Absolute path to the file or directory",
         required = true,
         alias = "file_path",
       },
-      offset = { type = "integer", description = "Line number to start from (1-indexed)" },
-      limit = {
-        type = "integer",
-        description = "Max number of lines to read. Omitting the limit reads up to 2000 lines.",
-      },
+      offset = { type = "integer" },
+      limit = { type = "integer" },
     },
   },
 

--- a/plugins/task/init.lua
+++ b/plugins/task/init.lua
@@ -25,18 +25,8 @@ local BODY_INDENT_COLS = 4
 local MIN_MD_WIDTH = 20
 local DEFAULT_OUTPUT_LINES = 5
 
-local description = [[Launch an autonomous subagent to perform tasks independently. Best combined with batch.
-
-Subagent types (set via `subagent_type`):
-- `research` (default): Read-only tools. For codebase exploration or gathering context.
-- `general`: Full tool access. For delegating implementation work.
-
-Notes:
-1. Launch multiple tasks concurrently when possible.
-2. The agent's result is not visible to the user. Summarize it in your response.
-3. Each invocation starts fresh - inline any needed context into the prompt.
-4. Tell it to return concise summaries with file:line refs, not full file contents.
-]]
+local description =
+  [[Launch an autonomous subagent. Types: research (read-only, default) or general (full access). Best combined with batch. Each invocation starts fresh - inline context. Summarize results in your response.]]
 
 local schema = {
   type = "object",
@@ -57,19 +47,11 @@ local schema = {
     },
     model_tier = {
       type = "string",
-      description = 'Model tier (optional, omit to use current model, capped at current tier):\n- "strong" (e.g. Opus): Deep reasoning, complex architecture, subtle bugs, most critical sections. ~5x cost of medium.\n- "medium" (e.g. Sonnet): Balanced. Refactors, features, multi-file changes.\n- "weak" (e.g. Haiku): Fast/cheap. Search, summarize, boilerplate, simple edits.',
+      description = 'Model tier (optional, omit to use current model, capped at current tier): "strong" (deep reasoning, ~5x cost), "medium" (balanced), "weak" (fast/cheap).',
     },
     output_schema = {
       description = "JSON Schema (object) the subagent's final result must match. When set, the result is returned as a validated JSON string.",
     },
-  },
-}
-
-local examples = {
-  {
-    description = "Find auth middleware",
-    prompt = "Search the codebase for authentication middleware. Return file paths and a summary of how auth is implemented.",
-    model_tier = "weak",
   },
 }
 
@@ -224,7 +206,6 @@ maki.api.register_tool({
   description = description,
   kind = "execute",
   audiences = { "main", "workflow" },
-  examples = examples,
   schema = schema,
   handler = handler,
   header = header,

--- a/plugins/todo_write/init.lua
+++ b/plugins/todo_write/init.lua
@@ -10,13 +10,8 @@ local STATUS_MARKERS = {
   cancelled = { "[x]", "todo_cancelled" },
 }
 
-local DESCRIPTION = [[Create or update a structured todo list to track tasks.
-
-**Use after EACH completed step!**
-
-- Send the complete list each time (replace-all semantics).
-- Use ONLY for multi-step work (3+ steps).
-- Skip for trivial tasks.]]
+local DESCRIPTION =
+  [[Create or update a structured todo list to track tasks. Use after EACH completed step. Send complete list each time (replace-all semantics). Use ONLY for multi-step work (3+ steps). Skip for trivial tasks.]]
 
 local function count_done()
   local n = 0

--- a/plugins/view_image/init.lua
+++ b/plugins/view_image/init.lua
@@ -1,10 +1,7 @@
 local shorten_path = require("maki.shorten_path")
 
 local DESCRIPTION =
-  [[View an image file (png, jpeg, gif, webp) so you can actually see it; it is returned as vision input alongside the tool result. Use instead of `read` for images.
-
-- Paths: absolute, relative, or ~/.
-- Oversized images are downscaled automatically (animated gif/webp keep only the first frame).]]
+  [[View an image file (png, jpeg, gif, webp) as vision input. Use instead of `read` for images. Paths: absolute, relative, or ~/. Oversized images downscaled automatically (animated gif/webp keep only first frame).]]
 
 -- Anthropic rejects images over 5MB base64; 3MB raw is ~4MB encoded,
 -- which leaves headroom.
@@ -127,7 +124,6 @@ maki.api.register_tool({
     properties = {
       path = {
         type = "string",
-        description = "Path to the image file",
         required = true,
         alias = "file_path",
       },

--- a/plugins/webfetch/init.lua
+++ b/plugins/webfetch/init.lua
@@ -80,12 +80,8 @@ end
 maki.api.register_tool({
   name = "webfetch",
   kind = "fetch",
-  description = [[Fetch a URL and return its contents.
-
-- Supports markdown (default), text, or html output formats.
-- HTTP URLs are auto-upgraded to HTTPS.
-- Max response size is 5MB, max timeout is 120s.
-- Best used inside code_execution with some truncation / filter to avoid context bloat.]],
+  modes = { "default", "research" },
+  description = [[Fetch a URL and return its contents. Supports markdown (default), text, or html. HTTP auto-upgraded to HTTPS. Max 5MB response, 120s timeout. Best used inside code_execution to avoid context bloat.]],
 
   schema = {
     type = "object",

--- a/plugins/websearch/init.lua
+++ b/plugins/websearch/init.lua
@@ -7,6 +7,12 @@ local truncate = require("maki.truncate")
 local ToolView = require("maki.tool_view")
 local output_limits = require("maki.output_limits")
 
+maki.api.set_prompt({
+  prompt = "system",
+  slot = "environment",
+  content = "# Environment\nCurrent date: " .. os.date("%Y-%m-%d") .. "\n",
+})
+
 local opts = maki.api.register_options(output_limits.extend({
   max_response_bytes = {
     default = 5 * 1024 * 1024,
@@ -23,13 +29,11 @@ end
 maki.api.register_tool({
   name = "websearch",
   kind = "fetch",
-  description = "Search the web for real-time information using Exa AI.\n\n"
-    .. "Today's date is "
-    .. os.date("%Y-%m-%d")
-    .. ".\n\n"
-    .. "- Use for current events, documentation, APIs, or anything not in local files.\n"
-    .. "- Prefer specific, targeted queries over broad ones.\n"
-    .. "- Results include page titles, URLs, and content snippets.",
+  description = [[Search the web for real-time information using Exa AI.
+
+- Use for current events, documentation, APIs, or anything not in local files.
+- Prefer specific, targeted queries over broad ones.
+- Results include page titles, URLs, and content snippets.]],
 
   schema = {
     type = "object",

--- a/plugins/write/init.lua
+++ b/plugins/write/init.lua
@@ -1,12 +1,8 @@
 local shorten_path = require("maki.shorten_path")
 local ToolView = require("maki.tool_view")
 
-local DESCRIPTION = [[Write content to a file, replacing existing content.
-
-- Creates parent directories if needed.
-- Always read the file first before writing.
-- NEVER create files unless absolutely necessary - prefer editing existing files.
-- NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.]]
+local DESCRIPTION =
+  [[Write content to a file, replacing existing content. Creates parent directories. Always read first. Never create files unless necessary. Never proactively create docs (*.md, README) unless requested.]]
 
 local function write_view_opts(ctx)
   local tol = ctx:tool_output_lines()
@@ -30,6 +26,7 @@ maki.api.register_tool({
   mutable_path = "path",
   permission_scopes = "path",
   audiences = { "main", "general_sub", "interpreter" },
+  modes = { "default", "build" },
   description = DESCRIPTION,
 
   schema = {
@@ -37,13 +34,11 @@ maki.api.register_tool({
     properties = {
       path = {
         type = "string",
-        description = "Absolute path to the file",
         required = true,
         alias = "file_path",
       },
       content = {
         type = "string",
-        description = "The complete file content to write",
         required = true,
       },
     },

--- a/scripts/anthropic_cache_benchmark.rs
+++ b/scripts/anthropic_cache_benchmark.rs
@@ -1,0 +1,155 @@
+/// Estimates token cost for a sample multi-turn conversation at different
+/// Anthropic prompt cache breakpoint values.
+///
+/// Usage: cargo run --bin anthropic_cache_benchmark
+///
+/// This script simulates a conversation with N turns and estimates the cost
+/// difference between breakpoint values 0, 1, 2, and 3. The actual optimal
+/// value depends on conversation length and cache hit patterns.
+use std::collections::HashMap;
+
+const SYSTEM_TOKENS: u32 = 2000;
+const TOOLS_TOKENS: u32 = 5000;
+const USER_MESSAGE_TOKENS: u32 = 500;
+const ASSISTANT_MESSAGE_TOKENS: u32 = 1000;
+const NUM_TURNS: u32 = 10;
+
+/// Anthropic Sonnet 4.6 pricing (per 1M tokens)
+const INPUT_PRICE: f64 = 3.00;
+const OUTPUT_PRICE: f64 = 15.00;
+const CACHE_WRITE_PRICE: f64 = 3.75;
+const CACHE_READ_PRICE: f64 = 0.30;
+
+#[derive(Debug, Clone)]
+struct TurnCost {
+    input: u32,
+    output: u32,
+    cache_write: u32,
+    cache_read: u32,
+}
+
+fn estimate_turn_cost(turn: u32, breakpoints: usize, _prev_turns: &[TurnCost]) -> TurnCost {
+    let total_messages = (turn + 1) * 2;
+    let breakpoints_u32 = breakpoints as u32;
+
+    let mut cache_write = 0;
+    let mut cache_read = 0;
+
+    if turn == 0 {
+        cache_write = SYSTEM_TOKENS + TOOLS_TOKENS;
+    } else {
+        cache_read = SYSTEM_TOKENS + TOOLS_TOKENS;
+    }
+
+    let messages_to_cache = breakpoints_u32.min(total_messages);
+    let cached_messages_start = total_messages.saturating_sub(messages_to_cache);
+
+    for msg_idx in 0..total_messages {
+        let is_cached = msg_idx >= cached_messages_start;
+        let is_last_in_cached = msg_idx == total_messages - 1 && is_cached;
+
+        if is_last_in_cached {
+            if turn == 0 {
+                cache_write += USER_MESSAGE_TOKENS;
+            } else {
+                cache_read += USER_MESSAGE_TOKENS;
+            }
+        }
+    }
+
+    let input = if turn == 0 {
+        SYSTEM_TOKENS + TOOLS_TOKENS + USER_MESSAGE_TOKENS
+    } else {
+        USER_MESSAGE_TOKENS
+    };
+
+    let output = ASSISTANT_MESSAGE_TOKENS;
+
+    TurnCost {
+        input,
+        output,
+        cache_write,
+        cache_read,
+    }
+}
+
+fn calculate_total_cost(costs: &[TurnCost]) -> f64 {
+    let total_input: u32 = costs.iter().map(|c| c.input).sum();
+    let total_output: u32 = costs.iter().map(|c| c.output).sum();
+    let total_cache_write: u32 = costs.iter().map(|c| c.cache_write).sum();
+    let total_cache_read: u32 = costs.iter().map(|c| c.cache_read).sum();
+
+    (total_input as f64 * INPUT_PRICE
+        + total_output as f64 * OUTPUT_PRICE
+        + total_cache_write as f64 * CACHE_WRITE_PRICE
+        + total_cache_read as f64 * CACHE_READ_PRICE)
+        / 1_000_000.0
+}
+
+fn main() {
+    println!("Anthropic Prompt Cache Breakpoint Cost Estimation");
+    println!("==================================================");
+    println!();
+    println!("Parameters:");
+    println!("  System prompt: {} tokens", SYSTEM_TOKENS);
+    println!("  Tools: {} tokens", TOOLS_TOKENS);
+    println!("  User message avg: {} tokens", USER_MESSAGE_TOKENS);
+    println!(
+        "  Assistant message avg: {} tokens",
+        ASSISTANT_MESSAGE_TOKENS
+    );
+    println!("  Turns: {}", NUM_TURNS);
+    println!();
+    println!("Pricing (Sonnet 4.6 per 1M tokens):");
+    println!("  Input: ${:.2}", INPUT_PRICE);
+    println!("  Output: ${:.2}", OUTPUT_PRICE);
+    println!("  Cache write: ${:.2}", CACHE_WRITE_PRICE);
+    println!("  Cache read: ${:.2}", CACHE_READ_PRICE);
+    println!();
+
+    let mut results: HashMap<usize, f64> = HashMap::new();
+
+    for &breakpoints in &[0, 1, 2, 3] {
+        let mut costs = Vec::new();
+        for turn in 0..NUM_TURNS {
+            let cost = estimate_turn_cost(turn, breakpoints, &costs);
+            costs.push(cost);
+        }
+        let total_cost = calculate_total_cost(&costs);
+        results.insert(breakpoints, total_cost);
+
+        let total_input: u32 = costs.iter().map(|c| c.input).sum();
+        let total_output: u32 = costs.iter().map(|c| c.output).sum();
+        let total_cache_write: u32 = costs.iter().map(|c| c.cache_write).sum();
+        let total_cache_read: u32 = costs.iter().map(|c| c.cache_read).sum();
+
+        println!("Breakpoints: {}", breakpoints);
+        println!("  Total input: {} tokens", total_input);
+        println!("  Total output: {} tokens", total_output);
+        println!("  Total cache write: {} tokens", total_cache_write);
+        println!("  Total cache read: {} tokens", total_cache_read);
+        println!("  Estimated cost: ${:.6}", total_cost);
+        println!();
+    }
+
+    println!("Recommendation:");
+    let min_cost = results.values().cloned().fold(f64::INFINITY, f64::min);
+    let mut best_breakpoints = 2;
+    for (&b, &cost) in &results {
+        if (cost - min_cost).abs() < 1e-9 {
+            best_breakpoints = b;
+            break;
+        }
+    }
+
+    println!(
+        "  Lowest cost: ${:.6} with {} breakpoints",
+        min_cost, best_breakpoints
+    );
+    println!();
+    println!("Note: This is a simplified model. Real-world performance depends on:");
+    println!("  - Actual conversation length and message distribution");
+    println!("  - Cache hit patterns (whether recent messages are reused)");
+    println!("  - System prompt and tools stability across turns");
+    println!("  - Model pricing differences (Haiku, Sonnet, Opus)");
+}

--- a/scripts/dynamic_tool_size.rs
+++ b/scripts/dynamic_tool_size.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use maki_agent::template::Vars;
+use maki_agent::tools::{DescriptionContext, ToolAudience, ToolFilter, ToolRegistry};
+use maki_providers::Model;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let registry = ToolRegistry::global_arc();
+    let _host = maki_lua::PluginHost::with_all_builtins(Arc::clone(registry))?;
+
+    let vars = Vars::new();
+    let model = Model::from_spec("anthropic/claude-sonnet-4-6")?;
+
+    let filter = ToolFilter::All;
+    let ctx = DescriptionContext {
+        filter: &filter,
+        audience: ToolAudience::MAIN,
+        workflow: false,
+    };
+
+    let modes = ["default", "research", "build", "compact"];
+
+    println!("Tool definition size by mode:");
+    println!("{:<15} {:<15} {:<15}", "Mode", "Tool Count", "Bytes");
+    println!("{}", "-".repeat(45));
+
+    for mode in &modes {
+        let allowed = registry.active_tools_for_mode(mode, &[]);
+        let defs =
+            registry.definitions_filtered(&vars, &ctx, model.supports_tool_examples(), &allowed);
+        let bytes = serde_json::to_vec(&defs)?.len();
+        let count = allowed.len();
+
+        println!("{:<15} {:<15} {:<15}", mode, count, bytes);
+    }
+
+    let all_defs = registry.definitions(&vars, &ctx, model.supports_tool_examples());
+    let all_bytes = serde_json::to_vec(&all_defs)?.len();
+    let all_count = registry.names().len();
+
+    println!(
+        "{:<15} {:<15} {:<15}",
+        "all (unfiltered)", all_count, all_bytes
+    );
+
+    Ok(())
+}

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -101,6 +101,7 @@ How many lines of output to show per tool in the UI. All values are `usize` with
 | `max_output_lines` | usize | `2000` | 10 | Max tool output lines |
 | `max_continuation_turns` | u32 | `3` | 1 | Max automatic continuation turns |
 | `compaction_buffer` | u32 \| string | `20%` | - | Context reserved for compaction: token count or percent of the context window (e.g. "20%") |
+| `mcp_tool_desc_max_chars` | usize | `300` | 10 | Max MCP tool description length (characters) |
 
 ### `provider`
 

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -132,7 +132,7 @@ Execute multiple independent tool calls concurrently. ALWAYS use batch for multi
 
 ### `code_execution` *(lua plugin)*
 
-Execute Python code in a sandboxed interpreter with tools as callable functions. Use for chained/dependent tool calls and filtering/processing results. Faster than sequential tool calls. Tools are async: `result = await read(path='file.txt')`. Use `asyncio.gather()` for concurrency. Available libs: re, asyncio, sys, os, json. Fresh sandbox each run. 30s timeout (configurable).
+Execute Python code in a sandboxed interpreter with tools as callable functions. Use for chained/dependent tool calls and filtering/processing results. Faster than sequential tool calls. Tools are async: `result = await read(path='file.txt')`. Use `asyncio.gather()` for concurrency. Available libs: re, asyncio, sys, os, json. Fresh sandbox each run. 30s script timeout (`timeout` param); time awaiting tool calls doesn't count.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -13,15 +13,14 @@ Maki ships with 20 built-in tools. This is the full reference.
 
 ### `bash` *(lua plugin)*
 
-Execute a bash command.
-Commands run in <cwd> by default.
+Execute a bash command. Default dir: <cwd>. DO NOT use for file ops - only git, builds, tests, system commands. Use `workdir` instead of `cd && cmd`. Chain dependent commands with `&&`. Use batch for independent ones. Provide short `description` (3-5 words). Output truncated beyond 2000 lines or 50KB. Interactive commands (sudo, ssh) fail immediately.
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `command` | string | yes |  | The bash command to execute |
-| `description` | string | no |  | Short description (3-5 words) of what the command does |
-| `timeout` | integer | no | 120 | Timeout in seconds |
-| `workdir` | string | no | cwd | Working directory |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `command` | string | yes |  |
+| `description` | string | no |  |
+| `timeout` | integer | no |  |
+| `workdir` | string | no |  |
 
 ### `read` *(lua plugin)*
 
@@ -29,104 +28,103 @@ Read a file or directory. Returns contents with line numbers (1-indexed).
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `limit` | integer | no | Max number of lines to read. Omitting the limit reads up to 2000 lines. |
-| `offset` | integer | no | Line number to start from (1-indexed) |
-| `path` | string | yes | Absolute path to the file or directory |
+| `limit` | integer | no |  |
+| `offset` | integer | no |  |
+| `path` | string | yes |  |
 
 ### `write` *(lua plugin)*
 
-Write content to a file, replacing existing content.
+Write content to a file, replacing existing content. Creates parent directories. Always read first. Never create files unless necessary. Never proactively create docs (*.md, README) unless requested.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `content` | string | yes | The complete file content to write |
-| `path` | string | yes | Absolute path to the file |
+| `content` | string | yes |  |
+| `path` | string | yes |  |
 
 ### `edit` *(lua plugin)*
 
-Replace an exact string match in a file.
+Replace an exact string match in a file. old_string must appear exactly once unless replace_all is true. Read file first. When copying from read output, exclude line number prefix (e.g. `42: `). Prefer over write for targeted changes. Use replace_all for renaming.
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `new_string` | string | yes |  | Replacement string |
-| `old_string` | string | yes |  | Exact string to find (must match uniquely unless replace_all is true) |
-| `path` | string | yes |  | Absolute path to the file |
-| `replace_all` | boolean | no | false | Replace all occurrences |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `new_string` | string | yes |  |
+| `old_string` | string | yes |  |
+| `path` | string | yes |  |
+| `replace_all` | boolean | no |  |
 
 ### `multiedit` *(lua plugin)*
 
-Make multiple find-and-replace edits to a single file atomically.
-Prefer this over edit when making multiple changes to the same file.
+Make multiple find-and-replace edits to a single file atomically. Prefer over edit for multiple changes. Read file first. old_string must match exactly, including whitespace. Each edit must match exactly once unless replace_all. Edits applied in sequence. If any edit fails, none are written. Ensure earlier edits don't affect later edits.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `edits` | array | yes | Array of edit operations to apply sequentially |
-| `path` | string | yes | Absolute path to the file |
+| `edits` | array | yes |  |
+| `path` | string | yes |  |
 
 ### `edit_lines` *(lua plugin, opt-in)*
 
-Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new_string`. Use empty `new_string` to delete a range. Do not use with the batch tool.
+Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new_string`. Use empty `new_string` to delete. Do not use with batch.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `end` | integer | yes | Last line, inclusive |
-| `new_string` | string | yes | Replacement text |
-| `path` | string | yes | Absolute path to the file |
-| `start` | integer | yes | First line (1-indexed) |
+| `end` | integer | yes |  |
+| `new_string` | string | yes |  |
+| `path` | string | yes |  |
+| `start` | integer | yes |  |
 
 ### `insert_lines` *(lua plugin, opt-in)*
 
-Insert lines before a given line number. Lines at `line` and below shift down. Existing lines are preserved. Do not use with the batch tool.
+Insert lines before a given line number. Lines at `line` and below shift down. Existing lines preserved. Do not use with batch.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `line` | integer | yes | Line number to insert before (1-indexed). Use 1 to insert at the top. |
-| `new_string` | string | yes | Text to insert |
-| `path` | string | yes | Absolute path to the file |
+| `line` | integer | yes |  |
+| `new_string` | string | yes |  |
+| `path` | string | yes |  |
 
 ### `glob` *(lua plugin)*
 
-Find files by glob pattern.
+Find files by glob pattern. Respects .gitignore. Returns absolute paths sorted by modification time (newest first). Prefer speculative parallel searches over sequential glob+grep.
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `path` | string | no | cwd | Directory to search in |
-| `pattern` | string | yes |  | Glob pattern (e.g. **/*.rs, src/**/*.ts) |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | no |  |
+| `pattern` | string | yes |  |
 
 ### `grep` *(lua plugin)*
 
-Search file contents using regex.
+Search file contents using regex. Respects .gitignore. Results grouped by file, sorted by modification time. Prefer speculative parallel searches over sequential glob+grep. Do NOT wrap pattern in quotes or double-escape (e.g. `\[` not `\\[`). Multi-line matching auto-enabled when pattern contains `\n`, `(?s)`, or `(?m)`.
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `context_after` | integer | no |  | Context lines after match |
-| `context_before` | integer | no |  | Context lines before match |
-| `include` | string | no |  | File glob filter (e.g. *.c) |
-| `limit` | integer | no |  | Max match groups to return |
-| `path` | string | no | cwd | Directory to search in |
-| `pattern` | string | yes |  | Regex pattern |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `context_after` | integer | no |  |
+| `context_before` | integer | no |  |
+| `include` | string | no |  |
+| `limit` | integer | no |  |
+| `path` | string | no |  |
+| `pattern` | string | yes |  |
 
 ### `index` *(lua plugin)*
 
-Return a compact overview of a source file: imports, type definitions, function signatures, and structure with their line numbers surrounded by []. ~70-90% more efficient than reading the full file.
+Return a compact overview of a source file: imports, types, function signatures, and structure with line numbers in []. ~70-90% more efficient than reading full file. Use FIRST to understand structure before read with offset/limit. Supports source files and markdown. Falls back with error on unsupported languages.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `path` | string | yes | Absolute path to the file |
+| `path` | string | yes |  |
 
 ### `view_image` *(lua plugin)*
 
-View an image file (png, jpeg, gif, webp) so you can actually see it; it is returned as vision input alongside the tool result. Use instead of `read` for images.
+View an image file (png, jpeg, gif, webp) as vision input. Use instead of `read` for images. Paths: absolute, relative, or ~/. Oversized images downscaled automatically (animated gif/webp keep only first frame).
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `path` | string | yes | Path to the image file |
+| `path` | string | yes |  |
 
 ## Execution & Control
 
 ### `batch` *(lua plugin)*
 
-Executes multiple independent tool calls concurrently to reduce round-trips.
+Execute multiple independent tool calls concurrently. ALWAYS use batch for multiple independent calls. 1-25 tools per batch. Parallel execution, order not guaranteed. Partial failures don't stop others. Do NOT nest batch. Use code_execution for dependent operations.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -134,7 +132,7 @@ Executes multiple independent tool calls concurrently to reduce round-trips.
 
 ### `code_execution` *(lua plugin)*
 
-Execute Python code in a sandboxed interpreter with tools as callable functions.
+Execute Python code in a sandboxed interpreter with tools as callable functions. Use for chained/dependent tool calls and filtering/processing results. Faster than sequential tool calls. Tools are async: `result = await read(path='file.txt')`. Use `asyncio.gather()` for concurrency. Available libs: re, asyncio, sys, os, json. Fresh sandbox each run. 30s timeout (configurable).
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
@@ -143,11 +141,7 @@ Execute Python code in a sandboxed interpreter with tools as callable functions.
 
 ### `question` *(lua plugin)*
 
-Use this tool when you need to ask the user questions during execution. This allows you to:
-- Gather user preferences or requirements
-- Clarify ambiguous instructions
-- Get decisions on implementation choices as you work
-- Offer choices to the user about what direction to take
+Ask the user questions during execution. Supports single/multi-select, custom answers, and tabbed multi-question forms. Put recommended options first with "(Recommended)" suffix.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -157,19 +151,19 @@ Use this tool when you need to ask the user questions during execution. This all
 
 ### `task` *(lua plugin)*
 
-Launch an autonomous subagent to perform tasks independently. Best combined with batch.
+Launch an autonomous subagent. Types: research (read-only, default) or general (full access). Best combined with batch. Each invocation starts fresh - inline context. Summarize results in your response.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `description` | string | yes | Short (3-5 words) description of the task |
-| `model_tier` | string | no | Model tier (optional, omit to use current model, capped at current tier):<br>- "strong" (e.g. Opus): Deep reasoning, complex architecture, subtle bugs, most critical sections. ~5x cost of medium.<br>- "medium" (e.g. Sonnet): Balanced. Refactors, features, multi-file changes.<br>- "weak" (e.g. Haiku): Fast/cheap. Search, summarize, boilerplate, simple edits. |
+| `model_tier` | string | no | Model tier (optional, omit to use current model, capped at current tier): "strong" (deep reasoning, ~5x cost), "medium" (balanced), "weak" (fast/cheap). |
 | `output_schema` | string | no | JSON Schema (object) the subagent's final result must match. When set, the result is returned as a validated JSON string. |
 | `prompt` | string | yes | Detailed task prompt for the agent |
 | `subagent_type` | string | no | Subagent type: "research" (read-only, default) or "general" (can modify files) |
 
 ### `todo_write` *(lua plugin)*
 
-Create or update a structured todo list to track tasks.
+Create or update a structured todo list to track tasks. Use after EACH completed step. Send complete list each time (replace-all semantics). Use ONLY for multi-step work (3+ steps). Skip for trivial tasks.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -177,7 +171,7 @@ Create or update a structured todo list to track tasks.
 
 ### `memory` *(lua plugin)*
 
-Persistent, project-scoped scratchpad for learnings, patterns, decisions, and gotchas across sessions.
+Persistent, project-scoped scratchpad for learnings, patterns, decisions, and gotchas across sessions. Save important context before compaction or to build project knowledge. Keep entries concise and current. Delete outdated information.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -197,7 +191,7 @@ Load a skill that provides instructions and workflows for specific tasks.
 
 ### `webfetch` *(lua plugin)*
 
-Fetch a URL and return its contents.
+Fetch a URL and return its contents. Supports markdown (default), text, or html. HTTP auto-upgraded to HTTPS. Max 5MB response, 120s timeout. Best used inside code_execution to avoid context bloat.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -51,7 +51,10 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_jit: bool) -> Result<()> {
     setup::init_logging(&config.storage);
     setup::install_panic_log_hook();
 
-    let (mcp_handle, _mcp_config_errors) = smol::block_on(maki_agent::mcp::start(&cwd));
+    let (mcp_handle, _mcp_config_errors) = smol::block_on(maki_agent::mcp::start(
+        &cwd,
+        config.agent.mcp_tool_desc_max_chars,
+    ));
 
     let prompt_slots = plugin_host
         .event_handle()

--- a/src/print.rs
+++ b/src/print.rs
@@ -164,7 +164,8 @@ pub fn run(
         .unwrap_or_default();
 
     let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
-    let (mcp_handle, mcp_config_errors) = smol::block_on(maki_agent::mcp::start(&cwd));
+    let (mcp_handle, mcp_config_errors) =
+        smol::block_on(maki_agent::mcp::start(&cwd, config.mcp_tool_desc_max_chars));
     if !mcp_config_errors.is_empty() {
         eprintln!("MCP config error: {mcp_config_errors}");
     }

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -477,7 +477,8 @@ pub fn run(params: SdkParams) -> Result<()> {
     let working_dir = cwd.to_string_lossy().into_owned();
     let (session_id, initial_history) = resolve_session(&cli, &working_dir)?;
 
-    let (mcp_handle, mcp_config_errors) = smol::block_on(mcp::start(&cwd));
+    let (mcp_handle, mcp_config_errors) =
+        smol::block_on(mcp::start(&cwd, config.mcp_tool_desc_max_chars));
     if !mcp_config_errors.is_empty() {
         eprintln!("MCP config error: {mcp_config_errors}");
     }


### PR DESCRIPTION
## Summary
This PR bundles the token-usage follow-up work for maki:

- **Plugin tool descriptions**: condensed built-in Lua plugin descriptions and removed example arrays from question, task, code_execution, batch, webfetch, write, edit, bash, glob, grep, index, view_image, todo_write, memory, and read.
- **MCP tool-descriptor guard**: added `sanitize_tool_input_schema` and word-boundary description truncation (default 300 chars) with warning logs for MCP tools.
- **Google context caching**: ported `cachedContents` create/reuse flow from n00n to maki, with 8-hour TTL and local expiry guard.
- **Anthropic cache breakpoints**: made `message_cache_breakpoints` configurable via `RequestOptions` and provided a benchmark script.
- **Session-storage compaction**: added `ToolOutput::summary()` and compact old tool outputs in headless sessions.
- **Prompt-template compression**: compressed all bundled prompt templates (~18% byte reduction) without losing instructions.
- **Dynamic/deferred tool loading**: design doc and prototype with mode-based tool filtering and an `activate_tool` runtime plugin.
- **Comprehensive token optimization merged in**: removed redundant property descriptions from tool schemas across plugins, split `read` usage guidance into the `tool_usage` prompt slot, tightened compaction prompts, and kept least-privilege/Environment guidance.
- Added `tool_definitions_fit_byte_budget` test to guard against tool-definition bloat.

## Verification
- `cargo fmt --all`
- `cargo clippy --all --tests -- -D warnings`
- `cargo nextest run --workspace` → 3257 passed