### PR TITLE
fix(mcp): tolerate prompt discovery failures

### DIFF
--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -57,6 +57,7 @@ pub fn internal_tool_name(wire: &str) -> String {
     wire.replacen(WIRE_SEPARATOR, SEPARATOR, 1)
 }
 const MCP_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+const PROMPT_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(2);
 
 struct McpToolDef {
     qualified_name: Arc<str>,
@@ -508,13 +509,29 @@ struct StartResult {
 }
 
 async fn discover_prompts(transport: &dyn McpTransport) -> Vec<protocol::PromptInfo> {
-    match transport::list_prompts(transport).await {
-        Ok(prompts) => prompts,
-        Err(error) => {
+    let result = futures_lite::future::or(
+        async { Some(transport::list_prompts(transport).await) },
+        async {
+            smol::Timer::after(PROMPT_DISCOVERY_TIMEOUT).await;
+            None
+        },
+    )
+    .await;
+    match result {
+        Some(Ok(prompts)) => prompts,
+        Some(Err(error)) => {
             warn!(
                 server = %transport.server_name(),
                 error = %error,
                 "MCP prompt discovery failed, continuing without prompts"
+            );
+            Vec::new()
+        }
+        None => {
+            warn!(
+                server = %transport.server_name(),
+                timeout_ms = PROMPT_DISCOVERY_TIMEOUT.as_millis() as u64,
+                "MCP prompt discovery timed out, continuing without prompts"
             );
             Vec::new()
         }
@@ -746,7 +763,7 @@ mod tests {
     use super::*;
     use async_lock::Mutex as AsyncMutex;
     use config::{RawServerConfig, RawStdioFields, RawTransport};
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 
@@ -783,6 +800,7 @@ mod tests {
         call_entered: flume::Sender<()>,
         call_entered_rx: flume::Receiver<()>,
         call_gate: AsyncMutex<()>,
+        prompts_hang: AtomicBool,
     }
 
     impl FakeTransport {
@@ -794,6 +812,7 @@ mod tests {
                 call_entered,
                 call_entered_rx,
                 call_gate: AsyncMutex::new(()),
+                prompts_hang: AtomicBool::new(false),
             })
         }
 
@@ -814,10 +833,15 @@ mod tests {
                     let _g = self.call_gate.lock().await;
                     Ok(json!({ "content": [{ "type": "text", "text": "ok" }] }))
                 } else if method == "prompts/list" {
-                    Err(McpError::Timeout {
-                        server: self.name.to_string(),
-                        timeout_ms: DEFAULT_TIMEOUT_MS,
-                    })
+                    if self.prompts_hang.load(Ordering::SeqCst) {
+                        let _g = self.call_gate.lock().await;
+                        Ok(json!({ "prompts": [] }))
+                    } else {
+                        Err(McpError::Timeout {
+                            server: self.name.to_string(),
+                            timeout_ms: DEFAULT_TIMEOUT_MS,
+                        })
+                    }
                 } else {
                     Ok(Value::Null)
                 }
@@ -847,6 +871,20 @@ mod tests {
         smol::block_on(async {
             let transport = FakeTransport::new();
             assert!(discover_prompts(transport.as_ref()).await.is_empty());
+        });
+    }
+
+    #[test]
+    fn prompt_discovery_timeout_is_non_fatal() {
+        smol::block_on(async {
+            let transport = FakeTransport::new();
+            transport.prompts_hang.store(true, Ordering::SeqCst);
+            let held = transport.call_gate.lock().await;
+            let start = std::time::Instant::now();
+
+            assert!(discover_prompts(transport.as_ref()).await.is_empty());
+            assert!(start.elapsed() < Duration::from_secs(3));
+            drop(held);
         });
     }
 

--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -507,6 +507,20 @@ struct StartResult {
     prompt_infos: Vec<protocol::PromptInfo>,
 }
 
+async fn discover_prompts(transport: &dyn McpTransport) -> Vec<protocol::PromptInfo> {
+    match transport::list_prompts(transport).await {
+        Ok(prompts) => prompts,
+        Err(error) => {
+            warn!(
+                server = %transport.server_name(),
+                error = %error,
+                "MCP prompt discovery failed, continuing without prompts"
+            );
+            Vec::new()
+        }
+    }
+}
+
 async fn start_server(config: &ServerConfig) -> Result<StartResult, McpError> {
     let transport: Arc<dyn McpTransport> = match &config.transport {
         Transport::Stdio {
@@ -530,7 +544,7 @@ async fn start_server(config: &ServerConfig) -> Result<StartResult, McpError> {
     };
     transport::initialize(transport.as_ref()).await?;
     let tool_infos = transport::list_tools(transport.as_ref()).await?;
-    let prompt_infos = transport::list_prompts(transport.as_ref()).await?;
+    let prompt_infos = discover_prompts(transport.as_ref()).await;
     info!(
         server = config.name,
         tool_count = tool_infos.len(),
@@ -799,6 +813,11 @@ mod tests {
                     let _ = self.call_entered.try_send(());
                     let _g = self.call_gate.lock().await;
                     Ok(json!({ "content": [{ "type": "text", "text": "ok" }] }))
+                } else if method == "prompts/list" {
+                    Err(McpError::Timeout {
+                        server: self.name.to_string(),
+                        timeout_ms: DEFAULT_TIMEOUT_MS,
+                    })
                 } else {
                     Ok(Value::Null)
                 }
@@ -821,6 +840,14 @@ mod tests {
         fn transport_kind(&self) -> &'static str {
             "fake"
         }
+    }
+
+    #[test]
+    fn prompt_discovery_failure_is_non_fatal() {
+        smol::block_on(async {
+            let transport = FakeTransport::new();
+            assert!(discover_prompts(transport.as_ref()).await.is_empty());
+        });
     }
 
     fn fake_entry(name: &str, transport: Arc<dyn McpTransport>) -> ServerEntry {


### PR DESCRIPTION
## Summary

- treat MCP prompt discovery as an optional capability
- bound optional `prompts/list` discovery to two seconds
- keep servers available when prompt discovery times out or otherwise fails
- log the discovery failure and continue with no prompts

Some MCP servers expose tools but do not correctly answer unsupported `prompts/list` requests. Codex MCP, for example, completes `initialize` and `tools/list` but leaves `prompts/list` unanswered, previously causing Maki to wait for the full server timeout and discard its otherwise usable tools.

Initialization and tool discovery remain fatal. Only optional prompt discovery is best-effort.

## Testing

- `cargo fmt --all -- --check`
- `cargo nextest run -p maki-agent -E 'test(mcp::)'` (86 passed)\n- `cargo clippy -p maki-agent --all-targets -- -D warnings`