### PR TITLE
fix(ui): sync discovered context window to all sessions after model discovery

### DIFF
--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -534,7 +534,9 @@ impl<'t> EventLoop<'t> {
         let slot_model = self.ctx.model_slot.load();
         let spec = slot_model.model.spec();
         for rt in &mut self.sessions {
-            if rt.app.state.session.model != spec {
+            if rt.app.state.session.model != spec
+                || rt.app.state.model.context_window != slot_model.model.context_window
+            {
                 rt.app.update_model(&slot_model.model);
             }
         }


### PR DESCRIPTION
The multi-session refactor (4867eed138) dropped the tick() sync that
propagated the discovered context_window from model_slot into each
app's model state. LlamaCpp model discovery still correctly populated
the registry and updated model_slot via the done callback, but the
app never received the updated model, so it fell back to the 128k
default.
    
Discovered via git bisect: regressed in 4867eed138.

AI disclosure: maki + qwen3.6 27b