### PR TITLE
feat(lua): add max_args to register_command for argument limiting

### DIFF
--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -648,6 +648,14 @@ fn register_tool(lua: &Lua, #[ctx] pending: PendingTools, spec: Table) -> LuaRes
 ///   name        (string)   Required. The command name (e.g. "/hello"; a leading
 ///                            slash is added when missing).
 ///   description (string)   Optional. Short description shown in the command palette.
+///   max_args    (integer)  Optional. Maximum number of arguments accepted.
+///                          Defaults to 0 (no arguments). Set to -1 for
+///                          unlimited. An "argument" is a whitespace-separated
+///                          word, so max_args = 1 breaks on the first space.
+///                          Handler receives the raw arg string, not a list.
+///                          If the user types more arguments than max_args, the
+///                          command silently stops matching and the input is sent
+///                          to the model as a normal message instead.
 ///   handler     (function) Required. Called when the user runs the command.
 /// @return
 /// @example
@@ -1190,6 +1198,21 @@ fn register_command_from_lua(lua: &Lua, spec: &Table, plugin: Arc<str>) -> LuaRe
         name.insert(0, '/');
     }
     let description: String = spec.get("description").unwrap_or_default();
+    let max_args: i64 = spec
+        .get::<Option<i64>>("max_args")
+        .map_err(|_| mlua::Error::runtime("register_command: 'max_args' must be an integer"))?
+        .unwrap_or(0);
+    let max_args: usize = match max_args {
+        -1 => usize::MAX,
+        n if n >= 0 => n
+            .try_into()
+            .map_err(|_| mlua::Error::runtime("register_command: 'max_args' is too large"))?,
+        _ => {
+            return Err(mlua::Error::runtime(
+                "register_command: 'max_args' must be non-negative or -1 for unlimited",
+            ));
+        }
+    };
     let handler: Function = spec
         .get("handler")
         .map_err(|_| mlua::Error::runtime("register_command: missing 'handler'"))?;
@@ -1207,6 +1230,7 @@ fn register_command_from_lua(lua: &Lua, spec: &Table, plugin: Arc<str>) -> LuaRe
             CommandEntry {
                 handler: handler_key,
                 description,
+                max_args,
             },
         );
     }

--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -12,6 +12,7 @@ pub struct LuaCommandInfo {
     pub name: Arc<str>,
     pub description: Arc<str>,
     pub plugin: Arc<str>,
+    pub max_args: usize,
 }
 
 #[derive(Clone, Default)]
@@ -118,6 +119,7 @@ impl HintWriter {
 pub(crate) struct CommandEntry {
     pub handler: RegistryKey,
     pub description: Arc<str>,
+    pub max_args: usize,
 }
 
 pub(crate) type CommandHandlerMap = HashMap<Arc<str>, HashMap<Arc<str>, CommandEntry>>;
@@ -130,6 +132,7 @@ pub(crate) fn publish_command_snapshot(map: &CommandHandlerMap, writer: &LuaComm
                 name: Arc::clone(name),
                 description: Arc::clone(&entry.description),
                 plugin: Arc::clone(plugin),
+                max_args: entry.max_args,
             })
         })
         .collect();
@@ -431,6 +434,7 @@ mod tests {
         CommandEntry {
             handler: key,
             description: Arc::from(desc),
+            max_args: 0,
         }
     }
 

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -652,6 +652,7 @@ mod tests {
             name: Arc::from("/test"),
             description: Arc::from("desc"),
             plugin: Arc::from("p"),
+            max_args: 0,
         }]);
         let snap = reader.load();
         assert_eq!(snap.commands.len(), 1);

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -2200,6 +2200,68 @@ fn register_command_happy_path() {
     assert_eq!(snap.commands[0].name.as_ref(), "/hello");
     assert_eq!(snap.commands[0].description.as_ref(), "says hello");
     assert_eq!(snap.commands[0].plugin.as_ref(), "cmd_plugin");
+    assert_eq!(snap.commands[0].max_args, 0);
+}
+
+#[test]
+fn register_command_max_args_custom() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source(
+        "cmd_max",
+        r#"
+        maki.api.register_command({
+            name = "/onearg",
+            description = "takes one arg",
+            max_args = 1,
+            handler = function(args) end,
+        })
+        maki.api.register_command({
+            name = "/noargs",
+            description = "takes no args",
+            max_args = 0,
+            handler = function() end,
+        })
+        "#,
+    )
+    .unwrap();
+
+    let snap = host.command_reader().load();
+    assert_eq!(snap.commands.len(), 2);
+    let one_arg = snap
+        .commands
+        .iter()
+        .find(|c| c.name.as_ref() == "/onearg")
+        .unwrap();
+    assert_eq!(one_arg.max_args, 1);
+    let no_args = snap
+        .commands
+        .iter()
+        .find(|c| c.name.as_ref() == "/noargs")
+        .unwrap();
+    assert_eq!(no_args.max_args, 0);
+}
+
+#[test]
+fn register_command_max_args_unlimited() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source(
+        "cmd_unlimited",
+        r#"
+        maki.api.register_command({
+            name = "/unlimited",
+            description = "takes unlimited args",
+            max_args = -1,
+            handler = function(args) end,
+        })
+        "#,
+    )
+    .unwrap();
+
+    let snap = host.command_reader().load();
+    assert_eq!(snap.commands.len(), 1);
+    assert_eq!(snap.commands[0].max_args, usize::MAX);
 }
 
 #[test_case::test_case(
@@ -2209,6 +2271,18 @@ fn register_command_happy_path() {
 #[test_case::test_case(
     r#"maki.api.register_command({ name = "/test", description = "no handler" })"#,
     "handler" ; "missing_handler"
+)]
+#[test_case::test_case(
+    r#"maki.api.register_command({ name = "/test", max_args = -2, handler = function() end })"#,
+    "non-negative or -1" ; "negative_max_args"
+)]
+#[test_case::test_case(
+    r#"maki.api.register_command({ name = "/test", max_args = "one", handler = function() end })"#,
+    "must be an integer" ; "string_max_args"
+)]
+#[test_case::test_case(
+    r#"maki.api.register_command({ name = "/test", max_args = math.huge, handler = function() end })"#,
+    "must be an integer" ; "infinite_max_args"
 )]
 fn register_command_validation_rejects(src: &str, expected_err: &str) {
     let reg = fresh_registry();

--- a/maki-ui/src/components/command.rs
+++ b/maki-ui/src/components/command.rs
@@ -239,7 +239,7 @@ impl CommandPalette {
         for (i, cmd) in lua_commands.iter().enumerate() {
             let item = CommandItem {
                 name: cmd.name.to_string(),
-                max_args: 0,
+                max_args: cmd.max_args,
                 command_type: CommandType::Lua(i),
             };
             injector.push(item, |item, cols| {
@@ -418,7 +418,7 @@ impl CommandPalette {
             CommandType::Builtin(cmd) => cmd.max_args > 0,
             CommandType::Custom(i) => self.custom[*i].has_args(),
             CommandType::McpPrompt(i) => !self.mcp_prompts[*i].arguments.is_empty(),
-            CommandType::Lua(_) => false,
+            CommandType::Lua(i) => self.lua_commands[*i].max_args > 0,
         }
     }
 
@@ -894,11 +894,13 @@ mod tests {
                 name: Arc::from("/memory"),
                 description: Arc::from("View memory files"),
                 plugin: Arc::from("memory"),
+                max_args: 0,
             },
             LuaCommandInfo {
                 name: Arc::from("/deploy"),
                 description: Arc::from("Deploy the project"),
                 plugin: Arc::from("deploy_plugin"),
+                max_args: 0,
             },
         ])
     }
@@ -956,6 +958,7 @@ mod tests {
             name: Arc::from("/old"),
             description: Arc::from("old command"),
             plugin: Arc::from("p"),
+            max_args: 0,
         }]);
         let mut p = CommandPalette::new(Arc::from([]), empty_snapshot(), reader);
         p.sync("/");
@@ -971,11 +974,13 @@ mod tests {
                 name: Arc::from("/new1"),
                 description: Arc::from("new"),
                 plugin: Arc::from("p"),
+                max_args: 0,
             },
             LuaCommandInfo {
                 name: Arc::from("/new2"),
                 description: Arc::from("new2"),
                 plugin: Arc::from("p"),
+                max_args: 0,
             },
         ]);
         p.sync("/");
@@ -987,5 +992,41 @@ mod tests {
         assert_eq!(updated_lua, 2);
         assert!(p.find_lua_command("/old").is_none());
         assert!(p.find_lua_command("/new1").is_some());
+    }
+
+    #[test]
+    fn lua_command_respects_max_args_zero() {
+        let reader = LuaCommandReader::from_commands(vec![LuaCommandInfo {
+            name: Arc::from("/noargs"),
+            description: Arc::from("takes no args"),
+            plugin: Arc::from("p"),
+            max_args: 0,
+        }]);
+        // Without args, command is visible
+        let mut p = CommandPalette::new(Arc::from([]), empty_snapshot(), reader.clone());
+        p.sync("/noargs");
+        assert!(p.is_active());
+
+        // With args, command is filtered out
+        p.sync("/noargs foo");
+        assert!(!p.is_active());
+    }
+
+    #[test]
+    fn lua_command_respects_max_args_one() {
+        let reader = LuaCommandReader::from_commands(vec![LuaCommandInfo {
+            name: Arc::from("/onearg"),
+            description: Arc::from("takes one arg"),
+            plugin: Arc::from("p"),
+            max_args: 1,
+        }]);
+        // One arg is fine
+        let mut p = CommandPalette::new(Arc::from([]), empty_snapshot(), reader.clone());
+        p.sync("/onearg foo");
+        assert!(p.is_active());
+
+        // Two args filters it out
+        p.sync("/onearg foo bar");
+        assert!(!p.is_active());
     }
 }

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -253,6 +253,14 @@ browsing memory files or toggling settings.
   - `name` (`string`) Required. The command name (e.g. "/hello"; a leading
     slash is added when missing).
   - `description` (`string`) Optional. Short description shown in the command palette.
+  - `max_args` (`integer`) Optional. Maximum number of arguments accepted.
+    Defaults to 0 (no arguments). Set to -1 for
+    unlimited. An "argument" is a whitespace-separated
+    word, so max_args = 1 breaks on the first space.
+    Handler receives the raw arg string, not a list.
+    If the user types more arguments than max_args, the
+    command silently stops matching and the input is sent
+    to the model as a normal message instead.
   - `handler` (`function`) Required. Called when the user runs the command.
 
 **Example:**


### PR DESCRIPTION
Enables` registering command+sub-command handlers in lua plugins.

Sample plugin:
```lua
maki.api.register_command({
  name = "/deploy",
  description = "Deploy with subcommands",
  max_args = 1,
  handler = function(args)
    if not args or args == "" then
      maki.ui.flash("Usage: /deploy <staging|production>")
      return
    end

    -- Split on whitespace; first token is the subcommand
    local parts = maki.split(args, " ")
    local subcmd = parts[1]

    if subcmd == "staging" then
      maki.ui.flash("Deploying to staging...")
    elseif subcmd == "production" then
      maki.ui.flash("Deploying to production...")
    else
      maki.ui.flash("Unknown subcommand: " .. subcmd)
    end
  end,
})
```

AI disclosure: maki + qwen3.6-27b