### PR TITLE
feat(mcp): defer tool definitions behind a tool_search tool

### DIFF
--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use serde_json::Value;
@@ -14,7 +15,7 @@ use super::instructions::LoadedInstructions;
 use super::streaming::stream_with_retry;
 use super::tool_dispatch::{self, RecentCalls};
 use crate::cancel::{CancelMap, CancelToken};
-use crate::mcp::McpHandle;
+use crate::mcp::McpSession;
 use crate::permissions::PermissionManager;
 use crate::tools::{Deadline, FileReadTracker, LocalTools, ToolAudience, ToolContext};
 use crate::{
@@ -90,7 +91,7 @@ pub struct Agent<'h> {
     auto_compact: bool,
     loaded_instructions: LoadedInstructions,
     rollback_len: usize,
-    mcp: Option<McpHandle>,
+    mcp: Option<McpSession>,
     config: AgentConfig,
     tool_output_lines: ToolOutputLines,
     reauth_attempts: u32,
@@ -147,7 +148,7 @@ impl<'h> Agent<'h> {
         }
     }
 
-    pub fn with_mcp(mut self, mcp: Option<McpHandle>) -> Self {
+    pub fn with_mcp(mut self, mcp: Option<McpSession>) -> Self {
         self.mcp = mcp;
         self
     }
@@ -225,16 +226,31 @@ impl<'h> Agent<'h> {
         }
     }
 
+    /// `self.tools` holds base tools only; the MCP part is recomputed here
+    /// every turn so `tool_search` loads and late-connecting servers take
+    /// effect on the next request.
+    fn request_tools(&self) -> Cow<'_, Value> {
+        match &self.mcp {
+            Some(mcp) => {
+                let mut tools = self.tools.clone();
+                mcp.extend_tools(&mut tools);
+                Cow::Owned(tools)
+            }
+            None => Cow::Borrowed(&self.tools),
+        }
+    }
+
     async fn turn(&mut self) -> Result<TurnOutcome, AgentError> {
         if self.cancel.is_cancelled() {
             return Err(AgentError::Cancelled);
         }
+        let tools = self.request_tools();
         let response = match stream_with_retry(
             &*self.provider,
             &self.model,
             self.history.as_slice(),
             &self.system,
-            &self.tools,
+            tools.as_ref(),
             &self.event_tx,
             &self.cancel,
             self.opts,
@@ -518,6 +534,7 @@ mod tests {
 
     use super::*;
     use crate::Envelope;
+    use crate::mcp::tool_names;
     use crate::permissions::PermissionManager;
 
     struct MockInterruptSource {
@@ -540,12 +557,14 @@ mod tests {
 
     struct MockProvider {
         responses: Mutex<Vec<StreamResponse>>,
+        captured_tools: Arc<Mutex<Vec<Value>>>,
     }
 
     impl MockProvider {
         fn new(responses: Vec<StreamResponse>) -> Self {
             Self {
                 responses: Mutex::new(responses),
+                captured_tools: Arc::default(),
             }
         }
     }
@@ -556,12 +575,13 @@ mod tests {
             _: &'a Model,
             _: &'a [Message],
             _: &'a str,
-            _: &'a Value,
+            tools: &'a Value,
             _: &'a flume::Sender<ProviderEvent>,
             _: RequestOptions,
             _: Option<&'a SessionRef>,
         ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
             Box::pin(async {
+                self.captured_tools.lock().unwrap().push(tools.clone());
                 let mut responses = self.responses.lock().unwrap();
                 assert!(!responses.is_empty(), "MockProvider: no more responses");
                 Ok(responses.remove(0))
@@ -704,6 +724,50 @@ mod tests {
             usage: TokenUsage::default(),
             stop_reason: Some(StopReason::ToolUse),
         }
+    }
+
+    fn tool_use_response(tool_name: &str, input: Value) -> StreamResponse {
+        StreamResponse {
+            message: Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::ToolUse {
+                    id: "t1".into(),
+                    name: tool_name.into(),
+                    input,
+                }],
+                ..Default::default()
+            },
+            usage: TokenUsage::default(),
+            stop_reason: Some(StopReason::ToolUse),
+        }
+    }
+
+    #[test]
+    fn mcp_definitions_refresh_per_request() {
+        smol::block_on(async {
+            let provider = MockProvider::new(vec![
+                tool_use_response(
+                    crate::mcp::TOOL_SEARCH_TOOL_NAME,
+                    serde_json::json!({"query": "fetch issue"}),
+                ),
+                text_response(StopReason::EndTurn),
+            ]);
+            let captured = Arc::clone(&provider.captured_tools);
+            let mut history = History::new(Vec::new());
+            let (agent, _event_rx) = make_agent(provider, &mut history);
+            let mut agent = agent.with_mcp(Some(crate::mcp::stub_session(&[(
+                "srv.fetch_issue",
+                "Fetch a GitHub issue",
+            )])));
+            agent.run(default_input()).await.unwrap();
+
+            let captured = captured.lock().unwrap();
+            assert_eq!(captured.len(), 2);
+            let first = tool_names(&captured[0]);
+            assert!(first.contains(&crate::mcp::TOOL_SEARCH_TOOL_NAME));
+            assert!(!first.contains(&"srv__fetch_issue"));
+            assert!(tool_names(&captured[1]).contains(&"srv__fetch_issue"));
+        });
     }
 
     fn small_context_model(context_window: u32, max_output_tokens: u32) -> Model {

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 use serde_json::Value;
 use tracing::{debug, error, warn};
 
-use crate::mcp::{McpHandle, UNKNOWN_MCP};
+use crate::mcp::{McpSession, TOOL_SEARCH_TOOL_NAME, UNKNOWN_MCP};
 use crate::task_set::TaskSet;
 use crate::tools::registry::{ToolInvocation, ToolRegistry};
 use crate::tools::{LocalToolFn, ToolContext};
@@ -61,7 +61,7 @@ impl RecentCalls {
 /// shows a phantom spinner.
 pub async fn run(
     registry: &ToolRegistry,
-    mcp: Option<&McpHandle>,
+    mcp: Option<&McpSession>,
     id: String,
     name: &str,
     input: &Value,
@@ -184,26 +184,74 @@ pub async fn run(
                 done_error(message)
             }
         }
+    } else if let Some(mcp) = mcp.filter(|_| name == TOOL_SEARCH_TOOL_NAME) {
+        run_tool_search(mcp, id, input, ctx, emit)
     } else if mcp.is_some_and(|m| m.has_tool(mcp_lookup)) {
-        // MCP tools skip parsing, so we assemble the start event manually.
-        let start = ToolStartEvent {
-            id: id.clone(),
-            tool: Arc::clone(&tool_id),
-            summary: format!("mcp: {mcp_lookup}"),
-            render_header: None,
-            annotation: None,
-            input: None,
-            raw_input: Some(input.clone()),
-            output: None,
-        };
-        if matches!(emit, Emit::Notify) {
-            let _ = ctx.event_tx.send(AgentEvent::ToolStart(Box::new(start)));
-        }
+        emit_raw_start(
+            ctx,
+            emit,
+            &id,
+            &tool_id,
+            format!("mcp: {mcp_lookup}"),
+            input,
+        );
         execute_mcp_tool(ctx, &id, tool_id, mcp_lookup, input).await
     } else {
         let msg = format!("{UNKNOWN_TOOL_PREFIX}: {mcp_lookup}");
         warn!(tool = %mcp_lookup, "unknown tool");
         done_error(msg)
+    }
+}
+
+/// MCP, local, and search tools never go through invocation parsing,
+/// so there is no parsed input to show; the UI gets the raw JSON instead.
+fn emit_raw_start(
+    ctx: &ToolContext,
+    emit: Emit,
+    id: &str,
+    tool: &Arc<str>,
+    summary: String,
+    input: &Value,
+) {
+    if !matches!(emit, Emit::Notify) {
+        return;
+    }
+    let start = ToolStartEvent {
+        id: id.to_owned(),
+        tool: Arc::clone(tool),
+        summary,
+        render_header: None,
+        annotation: None,
+        input: None,
+        raw_input: Some(input.clone()),
+        output: None,
+    };
+    let _ = ctx.event_tx.send(AgentEvent::ToolStart(Box::new(start)));
+}
+
+/// Runs without a permission gate: search only reveals names the deferred
+/// catalog already showed the model.
+fn run_tool_search(
+    mcp: &McpSession,
+    id: String,
+    input: &Value,
+    ctx: &ToolContext,
+    emit: Emit,
+) -> ToolDoneEvent {
+    let tool_id: Arc<str> = Arc::from(TOOL_SEARCH_TOOL_NAME);
+    let query = input["query"].as_str().unwrap_or_default();
+    emit_raw_start(ctx, emit, &id, &tool_id, query.to_owned(), input);
+    let (output, is_error) = match mcp.search_tools(query) {
+        Ok(out) => (out, false),
+        Err(e) => (e, true),
+    };
+    ToolDoneEvent {
+        id,
+        tool: tool_id,
+        output: ToolOutput::Markdown(output.into()),
+        is_error,
+        annotation: None,
+        written_path: None,
     }
 }
 
@@ -216,19 +264,7 @@ fn run_local_tool(
     emit: Emit,
 ) -> ToolDoneEvent {
     let tool_id: Arc<str> = Arc::from(name);
-    if matches!(emit, Emit::Notify) {
-        let start = ToolStartEvent {
-            id: id.clone(),
-            tool: Arc::clone(&tool_id),
-            summary: name.to_owned(),
-            render_header: None,
-            annotation: None,
-            input: None,
-            raw_input: Some(input.clone()),
-            output: None,
-        };
-        let _ = ctx.event_tx.send(AgentEvent::ToolStart(Box::new(start)));
-    }
+    emit_raw_start(ctx, emit, &id, &tool_id, name.to_owned(), input);
     let (output, is_error) = match local(input) {
         Ok(output) => (output, false),
         Err(e) => {
@@ -335,6 +371,9 @@ async fn execute_mcp_tool(
         return done(format!("MCP manager not available for {tool_name}"), true);
     };
 
+    // A permitted call to a deferred tool counts as loading it, so its full
+    // definition joins the next request; a denied call must not load anything.
+    mcp.mark_loaded(tool_name);
     match mcp.call_tool(tool_name, input).await {
         Ok(text) => done(text, false),
         Err(e) => done(e.to_string(), true),
@@ -345,7 +384,7 @@ async fn execute_mcp_tool(
 pub(super) async fn process_tool_calls(
     response: maki_providers::StreamResponse,
     recent_calls: &mut RecentCalls,
-    mcp: Option<&McpHandle>,
+    mcp: Option<&McpSession>,
     history: &mut super::history::History,
     event_tx: &crate::EventSender,
     ctx: &ToolContext,
@@ -565,6 +604,148 @@ mod tests {
             assert_eq!(start.tool.as_ref(), "local_echo");
             assert_eq!(start.summary, "local_echo");
             assert_eq!(start.raw_input, Some(input));
+        });
+    }
+
+    #[test]
+    fn tool_search_routes_and_loads_matches() {
+        smol::block_on(async {
+            let mcp = crate::mcp::stub_session(&[("srv.fetch_issue", "Fetch a GitHub issue")]);
+            let ctx = crate::tools::test_support::stub_ctx(&AgentMode::Build);
+            let done = run(
+                ToolRegistry::global(),
+                Some(&mcp),
+                "t1".into(),
+                TOOL_SEARCH_TOOL_NAME,
+                &serde_json::json!({"query": "issue"}),
+                &ctx,
+                Emit::Silent,
+            )
+            .await;
+            assert!(!done.is_error, "got: {}", done.output.as_text());
+            assert_eq!(done.tool.as_ref(), TOOL_SEARCH_TOOL_NAME);
+            assert!(done.output.as_text().contains("srv__fetch_issue"));
+
+            let mut tools = serde_json::json!([]);
+            mcp.extend_tools(&mut tools);
+            assert!(
+                crate::mcp::tool_names(&tools).contains(&"srv__fetch_issue"),
+                "searched tool must join the next request"
+            );
+        });
+    }
+
+    #[test_case(serde_json::json!({"query": "  "}) ; "blank_query")]
+    #[test_case(serde_json::json!({}) ; "missing_query")]
+    fn tool_search_bad_query_is_error_event(input: Value) {
+        smol::block_on(async {
+            let mcp = crate::mcp::stub_session(&[("srv.tool", "")]);
+            let ctx = crate::tools::test_support::stub_ctx(&AgentMode::Build);
+            let done = run(
+                ToolRegistry::global(),
+                Some(&mcp),
+                "t1".into(),
+                TOOL_SEARCH_TOOL_NAME,
+                &input,
+                &ctx,
+                Emit::Silent,
+            )
+            .await;
+            assert!(done.is_error);
+            assert_eq!(done.output.as_text(), crate::mcp::SEARCH_EMPTY_QUERY);
+        });
+    }
+
+    #[test]
+    fn calling_deferred_mcp_tool_marks_it_loaded() {
+        smol::block_on(async {
+            let mcp = crate::mcp::stub_session(&[("srv.fetch_issue", "")]);
+            let mut ctx = crate::tools::test_support::stub_ctx(&AgentMode::Build);
+            ctx.mcp = Some(mcp.clone());
+            let done = run(
+                ToolRegistry::global(),
+                Some(&mcp),
+                "t1".into(),
+                "srv__fetch_issue",
+                &serde_json::json!({}),
+                &ctx,
+                Emit::Silent,
+            )
+            .await;
+            assert_eq!(done.tool.as_ref(), "srv.fetch_issue", "must route to MCP");
+
+            let mut tools = serde_json::json!([]);
+            mcp.extend_tools(&mut tools);
+            assert_eq!(
+                crate::mcp::tool_names(&tools),
+                vec!["srv__fetch_issue"],
+                "called tool must join the next request"
+            );
+        });
+    }
+
+    #[test]
+    fn denied_mcp_call_does_not_load_definition() {
+        smol::block_on(async {
+            let mcp = crate::mcp::stub_session(&[("srv.fetch_issue", "")]);
+            let deny_cfg = PermissionsConfig {
+                rules: vec![PermissionRule {
+                    tool: ToolKey::parse("srv.fetch_issue").unwrap(),
+                    scope: None,
+                    effect: Effect::Deny,
+                }],
+                ..Default::default()
+            };
+            let dir = TempDir::new().unwrap();
+            let permissions = Arc::new(PermissionManager::new(deny_cfg, dir.path().to_path_buf()));
+            let mut ctx = crate::tools::test_support::stub_ctx_with_permissions(
+                &AgentMode::Build,
+                permissions,
+            );
+            ctx.mcp = Some(mcp.clone());
+            let done = run(
+                ToolRegistry::global(),
+                Some(&mcp),
+                "t1".into(),
+                "srv__fetch_issue",
+                &serde_json::json!({}),
+                &ctx,
+                Emit::Silent,
+            )
+            .await;
+            assert!(done.is_error);
+            assert!(
+                done.output.as_text().starts_with(PERMISSION_DENIED_PREFIX),
+                "got: {}",
+                done.output.as_text()
+            );
+
+            let mut tools = serde_json::json!([]);
+            mcp.extend_tools(&mut tools);
+            assert_eq!(
+                crate::mcp::tool_names(&tools),
+                vec![TOOL_SEARCH_TOOL_NAME],
+                "denied call must not load the definition"
+            );
+        });
+    }
+
+    #[test]
+    fn local_tool_named_tool_search_shadows_mcp_search() {
+        smol::block_on(async {
+            let mcp = crate::mcp::stub_session(&[("srv.tool", "")]);
+            let ctx = local_ctx(TOOL_SEARCH_TOOL_NAME, |_| Ok("local wins".into()));
+            let done = run(
+                ToolRegistry::global(),
+                Some(&mcp),
+                "t1".into(),
+                TOOL_SEARCH_TOOL_NAME,
+                &serde_json::json!({"query": "tool"}),
+                &ctx,
+                Emit::Silent,
+            )
+            .await;
+            assert_eq!(done.output.as_text(), "local wins");
         });
     }
 

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -22,7 +22,8 @@ use crate::template;
 use crate::tools::{DescriptionContext, FileReadTracker, ToolAudience, ToolFilter, ToolRegistry};
 use crate::{
     Agent, AgentConfig, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, Envelope,
-    EventSender, ImageSource, McpHandle, PermissionsConfig, ToolOutput, ToolOutputLines,
+    EventSender, ImageSource, McpHandle, McpSession, PermissionsConfig, ToolOutput,
+    ToolOutputLines,
 };
 
 type StoredSession = Session<Message, TokenUsage, ToolOutput>;
@@ -100,7 +101,6 @@ fn setup(
     model: &Model,
     config: &AgentConfig,
     excluded_tools: &[&'static str],
-    mcp_handle: Option<&McpHandle>,
     workflow: bool,
 ) -> AgentSetup {
     let vars = template::env_vars();
@@ -110,7 +110,6 @@ fn setup(
         model,
         config,
         excluded_tools,
-        mcp_handle,
         workflow,
         ToolRegistry::global(),
     );
@@ -122,12 +121,13 @@ fn setup(
     }
 }
 
+/// Base definitions only. MCP definitions are injected per request by
+/// `Agent::request_tools`; storing them here would freeze the catalog.
 fn tool_definitions(
     vars: &template::Vars,
     model: &Model,
     config: &AgentConfig,
     excluded_tools: &[&'static str],
-    mcp_handle: Option<&McpHandle>,
     workflow: bool,
     registry: &ToolRegistry,
 ) -> Value {
@@ -137,13 +137,17 @@ fn tool_definitions(
         audience: ToolAudience::MAIN,
         workflow,
     };
-    let mut tools = registry.definitions(vars, &ctx, model.supports_tool_examples());
+    registry.definitions(vars, &ctx, model.supports_tool_examples())
+}
 
-    if let Some(handle) = mcp_handle {
-        handle.extend_tools(&mut tools);
+/// Names advertised to SDK clients: base tools plus what the first request
+/// would carry from MCP (always-load definitions and `tool_search`).
+fn advertised_tool_names(tools: &Value, mcp: Option<&McpSession>) -> Vec<String> {
+    let mut probe = tools.clone();
+    if let Some(mcp) = mcp {
+        mcp.extend_tools(&mut probe);
     }
-
-    tools
+    extract_tool_names(&probe)
 }
 
 pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
@@ -157,7 +161,6 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
         &params.model,
         &params.config,
         &params.excluded_tools,
-        params.mcp_handle.as_ref(),
         params.workflow,
     );
 
@@ -169,7 +172,8 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
         &params.model,
     );
 
-    let tool_names = extract_tool_names(&tools);
+    let mcp = params.mcp_handle.clone().map(|h| McpSession::new(h, &[]));
+    let tool_names = advertised_tool_names(&tools, mcp.as_ref());
 
     let (raw_tx, event_rx) = flume::unbounded::<Envelope>();
 
@@ -223,7 +227,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
                 },
             )
             .with_loaded_instructions(instructions.loaded)
-            .with_mcp(params.mcp_handle);
+            .with_mcp(mcp);
 
             let result = agent
                 .run(AgentInput {
@@ -299,11 +303,14 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
         &params.model,
         &params.config,
         &params.excluded_tools,
-        params.mcp_handle.as_ref(),
         params.workflow,
     );
 
-    let tool_names = extract_tool_names(&tools);
+    let mcp = params
+        .mcp_handle
+        .clone()
+        .map(|h| McpSession::new(h, &params.initial_history));
+    let tool_names = advertised_tool_names(&tools, mcp.as_ref());
 
     let (raw_tx, event_rx) = flume::unbounded::<Envelope>();
     let (input_tx, input_rx) = flume::unbounded::<AgentInput>();
@@ -367,7 +374,6 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                                 &new_model,
                                 &params.config,
                                 &params.excluded_tools,
-                                params.mcp_handle.as_ref(),
                                 params.workflow,
                                 ToolRegistry::global(),
                             );
@@ -435,7 +441,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                 .with_loaded_instructions(instructions.loaded.clone())
                 .with_user_response_rx(Arc::clone(&answer_rx))
                 .with_cancel(cancel)
-                .with_mcp(params.mcp_handle.clone());
+                .with_mcp(mcp.clone());
 
                 let result = agent.run(input).await;
                 drop(agent);
@@ -560,5 +566,23 @@ mod tests {
     fn extract_tool_names_filters_valid_entries() {
         let tools = serde_json::json!([{"name": "read"}, {"type": "function"}, {"name": "bash"}]);
         assert_eq!(extract_tool_names(&tools), vec!["read", "bash"]);
+    }
+
+    #[test]
+    fn advertised_names_show_tool_search_not_deferred_tools() {
+        let base = serde_json::json!([{"name": "read"}]);
+        let mcp = crate::mcp::stub_session(&[("srv.fetch_issue", "Fetch a GitHub issue")]);
+        let names = advertised_tool_names(&base, Some(&mcp));
+        assert_eq!(
+            names,
+            vec!["read", crate::mcp::TOOL_SEARCH_TOOL_NAME],
+            "clients must see the search tool, not deferred definitions"
+        );
+        assert_eq!(
+            base,
+            serde_json::json!([{"name": "read"}]),
+            "probing must not bake MCP entries into the base tools"
+        );
+        assert_eq!(advertised_tool_names(&base, None), vec!["read"]);
     }
 }

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -8,7 +8,9 @@ pub mod headless;
 pub mod mcp;
 pub use mcp::config::{McpConfigError, McpConfigErrors, McpServerInfo, McpServerStatus};
 pub use mcp::protocol::PromptRole;
-pub use mcp::{McpCommand, McpHandle, McpPromptArg, McpPromptInfo, McpSnapshot, McpSnapshotReader};
+pub use mcp::{
+    McpCommand, McpHandle, McpPromptArg, McpPromptInfo, McpSession, McpSnapshot, McpSnapshotReader,
+};
 pub(crate) mod task_set;
 pub use agent::{
     Agent, AgentParams, AgentRunParams, History, Instructions, LoadedInstructions, SharedMessages,

--- a/maki-agent/src/mcp/config.rs
+++ b/maki-agent/src/mcp/config.rs
@@ -125,6 +125,11 @@ pub struct McpServerInfo {
 
 #[derive(Deserialize, Default)]
 pub struct McpConfig {
+    /// Defer tools behind `tool_search` only when more than this many
+    /// non-`always_load` tools exist. `None` means the built-in default;
+    /// 0 always defers, a large value disables deferral.
+    #[serde(default)]
+    pub defer_tools: Option<usize>,
     #[serde(default)]
     pub mcp: HashMap<String, RawServerConfig>,
     #[serde(skip)]
@@ -137,6 +142,8 @@ pub struct RawServerConfig {
     pub enabled: bool,
     #[serde(default = "default_timeout")]
     pub timeout: u64,
+    #[serde(default)]
+    pub always_load: bool,
     #[serde(flatten)]
     pub transport: RawTransport,
 }
@@ -166,6 +173,9 @@ pub struct RawHttpFields {
 pub struct ServerConfig {
     pub name: String,
     pub timeout: Duration,
+    /// Skip deferral: every tool from this server enters the context upfront
+    /// instead of being discoverable through `tool_search`.
+    pub always_load: bool,
     pub transport: Transport,
 }
 
@@ -258,6 +268,7 @@ pub fn parse_server(name: String, server: RawServerConfig) -> Result<ServerConfi
     Ok(ServerConfig {
         name,
         timeout: Duration::from_millis(server.timeout),
+        always_load: server.always_load,
         transport,
     })
 }
@@ -269,47 +280,37 @@ pub fn transport_kind(raw: &RawTransport) -> &'static str {
     }
 }
 
+/// Call order is precedence: the caller merges global first, project last,
+/// so a project's servers and `defer_tools` beat the global ones.
+fn merge_config(merged: &mut McpConfig, errors: &mut McpConfigErrors, path: &Path) {
+    match read_config(path) {
+        Ok(None) => {}
+        Ok(Some(cfg)) => {
+            tracing::info!(
+                path = %path.display(),
+                servers = cfg.mcp.len(),
+                "loaded mcp config"
+            );
+            for name in cfg.mcp.keys() {
+                merged.origins.insert(name.clone(), path.to_path_buf());
+            }
+            merged.defer_tools = cfg.defer_tools.or(merged.defer_tools);
+            merged.mcp.extend(cfg.mcp);
+        }
+        Err(e) => errors.add_error(e),
+    }
+}
+
 pub fn load_config(cwd: &Path) -> (McpConfig, McpConfigErrors) {
     let mut merged = McpConfig::default();
     let mut errors = McpConfigErrors::new(cwd.to_path_buf());
 
     if let Some(global_dir) = global_config_dir() {
         let global_path = global_dir.join(MCP_CONFIG_FILE);
-        match read_config(&global_path) {
-            Ok(None) => {}
-            Ok(Some(cfg)) => {
-                tracing::info!(
-                    path = %global_path.display(),
-                    servers = cfg.mcp.len(),
-                    "loaded mcp config"
-                );
-                for name in cfg.mcp.keys() {
-                    merged.origins.insert(name.clone(), global_path.clone());
-                }
-                merged.mcp.extend(cfg.mcp);
-            }
-            Err(e) => errors.add_error(e),
-        }
+        merge_config(&mut merged, &mut errors, &global_path);
     }
-
     let project_path = cwd.join(".maki").join(MCP_CONFIG_FILE);
-    match read_config(&project_path) {
-        Ok(None) => {}
-        Ok(Some(cfg)) => {
-            tracing::info!(
-                path = %project_path.display(),
-                servers = cfg.mcp.len(),
-                "loaded mcp config"
-            );
-            for name in cfg.mcp.keys() {
-                merged.origins.insert(name.clone(), project_path.clone());
-            }
-            merged.mcp.extend(cfg.mcp);
-        }
-        Err(e) => {
-            errors.add_error(e);
-        }
-    }
+    merge_config(&mut merged, &mut errors, &project_path);
     (merged, errors)
 }
 
@@ -390,6 +391,7 @@ mod tests {
         RawServerConfig {
             enabled: true,
             timeout: DEFAULT_TIMEOUT_MS,
+            always_load: false,
             transport: RawTransport::Stdio(RawStdioFields {
                 command: cmd.iter().map(|s| s.to_string()).collect(),
                 environment: HashMap::new(),
@@ -401,6 +403,7 @@ mod tests {
         RawServerConfig {
             enabled: true,
             timeout: DEFAULT_TIMEOUT_MS,
+            always_load: false,
             transport: RawTransport::Http(RawHttpFields {
                 url: url.to_string(),
                 headers: HashMap::new(),
@@ -424,6 +427,31 @@ mod tests {
         cfg.timeout = timeout;
         let err = parse_server("srv".into(), cfg).unwrap_err();
         assert!(err.to_string().contains("timeout"));
+    }
+
+    #[test]
+    fn toml_deferral_fields_deserialize_and_default() {
+        let config: McpConfig = toml::from_str(
+            r#"
+defer_tools = 30
+
+[mcp.github]
+command = ["gh", "mcp-server"]
+always_load = true
+
+[mcp.other]
+command = ["other"]
+"#,
+        )
+        .unwrap();
+        assert_eq!(config.defer_tools, Some(30));
+        assert!(config.mcp["github"].always_load);
+        assert!(!config.mcp["other"].always_load);
+        let parsed = parse_server("github".into(), config.mcp["github"].clone()).unwrap();
+        assert!(parsed.always_load);
+
+        let bare: McpConfig = toml::from_str("[mcp.srv]\ncommand = [\"x\"]").unwrap();
+        assert_eq!(bare.defer_tools, None);
     }
 
     #[test]
@@ -565,6 +593,7 @@ enabled = true
             ]
             .into(),
             origins: [("enabled".into(), PathBuf::from("/test.toml"))].into(),
+            ..Default::default()
         };
         let mut infos = config.preliminary_infos(&["disabled-runtime".into()]);
         infos.sort_by(|a, b| a.name.cmp(&b.name));
@@ -573,6 +602,29 @@ enabled = true
         assert_eq!(infos[1].status, McpServerStatus::Disabled);
         assert_eq!(infos[2].status, McpServerStatus::Connecting);
         assert_eq!(infos[2].config_path, PathBuf::from("/test.toml"));
+    }
+
+    #[test_case("defer_tools = 7\n", Some(7) ; "project_overrides_global")]
+    #[test_case("", Some(5) ; "global_survives_unset_project")]
+    fn merge_config_defer_tools_precedence(project_toml: &str, expected: Option<usize>) {
+        let dir = tempfile::tempdir().unwrap();
+        let global = dir.path().join("global.toml");
+        let project = dir.path().join("project.toml");
+        fs::write(&global, "defer_tools = 5\n[mcp.srv]\ncommand = [\"a\"]").unwrap();
+        fs::write(
+            &project,
+            format!("{project_toml}[mcp.srv]\ncommand = [\"b\"]"),
+        )
+        .unwrap();
+
+        let mut merged = McpConfig::default();
+        let mut errors = McpConfigErrors::new(dir.path().to_path_buf());
+        merge_config(&mut merged, &mut errors, &global);
+        merge_config(&mut merged, &mut errors, &project);
+
+        assert!(errors.is_empty());
+        assert_eq!(merged.defer_tools, expected);
+        assert_eq!(merged.origins["srv"], project, "later config must win");
     }
 
     #[test]

--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -19,12 +19,13 @@ pub mod protocol;
 pub mod stdio;
 pub mod transport;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use arc_swap::{ArcSwap, Guard};
+use maki_providers::{ContentBlock, Message};
 use serde_json::{Value, json};
 use tracing::{info, warn};
 
@@ -40,6 +41,20 @@ use self::transport::McpTransport;
 const SEPARATOR: &str = ".";
 const WIRE_SEPARATOR: &str = "__";
 pub const UNKNOWN_MCP: &str = "unknown_mcp";
+pub const TOOL_SEARCH_TOOL_NAME: &str = "tool_search";
+/// Below this many deferrable tools, a search round-trip plus its
+/// prompt-cache miss cost more than a handful of upfront definitions.
+/// Overridden by `defer_tools` in mcp.toml.
+const DEFAULT_DEFER_TOOLS: usize = 10;
+/// Loads per search are capped so one broad query can't flood the context.
+const MAX_SEARCH_LOADS: usize = 5;
+const NAME_HIT_SCORE: usize = 2;
+const DESCRIPTION_HIT_SCORE: usize = 1;
+/// Overflow names shown to the model so it can re-search by exact name.
+const MAX_OVERFLOW_NAMES: usize = 20;
+const SEARCH_NO_MATCH: &str = "No deferred MCP tools matched";
+const SEARCH_OVERFLOW_PREFIX: &str = "Also matched but not loaded: ";
+pub(crate) const SEARCH_EMPTY_QUERY: &str = "query must not be empty";
 
 /// Convert internal qualified name (`server.tool`) to wire format (`server__tool`)
 /// for LLM provider APIs that reject dots in tool names.
@@ -174,7 +189,22 @@ struct McpManagerInner {
 struct ToolIndex {
     tools: HashMap<Arc<str>, ToolRef>,
     prompts: HashMap<String, PromptRef>,
-    descriptors: Arc<[Value]>,
+    descriptors: Arc<[ToolDescriptor]>,
+}
+
+/// One published MCP tool. Wire name and search text are derived from
+/// `definition` on demand: searches are model-paced and rare, so nothing
+/// to cache.
+struct ToolDescriptor {
+    qualified_name: Arc<str>,
+    always_load: bool,
+    definition: Value,
+}
+
+impl ToolDescriptor {
+    fn wire_name(&self) -> &str {
+        self.definition["name"].as_str().unwrap_or_default()
+    }
 }
 
 struct ToolRef {
@@ -249,6 +279,193 @@ pub struct McpHandle {
     cmd_tx: flume::Sender<McpCommand>,
     index: Arc<ArcSwap<ToolIndex>>,
     snapshot: Arc<ArcSwap<McpSnapshot>>,
+    /// Never changes after startup, so it lives here instead of being
+    /// copied into every republished `ToolIndex`.
+    defer_tools: usize,
+}
+
+/// One session's view of MCP: the shared handle plus the deferred tools
+/// this session loaded. Loads are per session, so a subagent's searches
+/// never bloat the parent's context.
+///
+/// `extend_tools` output must never be stored: recompute it every request
+/// or the `tool_search` catalog goes stale.
+#[derive(Clone)]
+pub struct McpSession {
+    handle: McpHandle,
+    loaded: Arc<Mutex<HashSet<Arc<str>>>>,
+}
+
+impl std::ops::Deref for McpSession {
+    type Target = McpHandle;
+    fn deref(&self) -> &McpHandle {
+        &self.handle
+    }
+}
+
+impl McpSession {
+    /// `history` seeds the loaded set when resuming: tools the model was
+    /// already calling stay declared across restarts. A pure string scan,
+    /// so it is safe before servers connect, and unknown names are inert.
+    pub fn new(handle: McpHandle, history: &[Message]) -> Self {
+        let loaded = history
+            .iter()
+            .flat_map(|m| &m.content)
+            .filter_map(|block| match block {
+                ContentBlock::ToolUse { name, .. } if name.contains(WIRE_SEPARATOR) => {
+                    Some(internal_tool_name(name).into())
+                }
+                _ => None,
+            })
+            .collect();
+        Self {
+            handle,
+            loaded: Arc::new(Mutex::new(loaded)),
+        }
+    }
+
+    /// A view over the same handle with no loads, for a new (sub)session.
+    pub fn fresh(&self) -> Self {
+        Self::new(self.handle.clone(), &[])
+    }
+
+    /// Append this request's MCP definitions: loaded and `always_load`
+    /// tools in full, the rest as names inside one `tool_search` catalog.
+    /// Names already in the array are skipped.
+    ///
+    /// The `defer_tools` threshold is measured against the full index, not
+    /// what's left deferred, so loading tools mid-session can never flip
+    /// the remainder into the context.
+    pub fn extend_tools(&self, tools: &mut Value) {
+        let Some(arr) = tools.as_array_mut() else {
+            debug_assert!(false, "tools must be a JSON array");
+            return;
+        };
+        let existing: HashSet<String> = arr
+            .iter()
+            .filter_map(|t| t["name"].as_str().map(String::from))
+            .collect();
+        let idx = self.handle.index.load();
+        let defer =
+            idx.descriptors.iter().filter(|d| !d.always_load).count() > self.handle.defer_tools;
+        let loaded = self.lock_loaded();
+        let mut deferred: Vec<&ToolDescriptor> = Vec::new();
+        for d in idx.descriptors.iter() {
+            if existing.contains(d.wire_name()) {
+                continue;
+            }
+            if !defer || d.always_load || loaded.contains(&*d.qualified_name) {
+                arr.push(d.definition.clone());
+            } else {
+                deferred.push(d);
+            }
+        }
+        drop(loaded);
+        if !deferred.is_empty() {
+            if existing.contains(TOOL_SEARCH_TOOL_NAME) {
+                warn!(
+                    deferred = deferred.len(),
+                    "a tool named {TOOL_SEARCH_TOOL_NAME} already exists; deferred MCP tools stay hidden"
+                );
+            } else {
+                arr.push(tool_search_definition(&deferred));
+            }
+        }
+    }
+
+    /// Rank deferred tools against `query` keywords (exact name first,
+    /// then name hits over description hits) and mark the top
+    /// `MAX_SEARCH_LOADS` loaded; their definitions join the next request.
+    pub fn search_tools(&self, query: &str) -> Result<String, String> {
+        let q = query.trim().to_lowercase();
+        let tokens: Vec<&str> = q
+            .split(|c: char| !c.is_alphanumeric())
+            .filter(|t| !t.is_empty())
+            .collect();
+        if tokens.is_empty() {
+            return Err(SEARCH_EMPTY_QUERY.into());
+        }
+        let idx = self.handle.index.load();
+        let mut matches: Vec<(bool, usize, &ToolDescriptor)> = idx
+            .descriptors
+            .iter()
+            .filter(|d| !d.always_load)
+            .filter_map(|d| {
+                let name = d.wire_name().to_lowercase();
+                let haystack = build_haystack(&d.definition);
+                // The catalog shows bare tool names, so exact match must
+                // accept both `server__tool` and `tool`.
+                let exact = name == q
+                    || d.qualified_name
+                        .split_once(SEPARATOR)
+                        .is_some_and(|(_, raw)| raw.eq_ignore_ascii_case(&q));
+                let score: usize = tokens
+                    .iter()
+                    .map(|t| {
+                        if name.contains(t) {
+                            NAME_HIT_SCORE
+                        } else if haystack.contains(t) {
+                            DESCRIPTION_HIT_SCORE
+                        } else {
+                            0
+                        }
+                    })
+                    .sum();
+                (exact || score > 0).then_some((exact, score, d))
+            })
+            .collect();
+        matches.sort_by(|a, b| {
+            (b.0, b.1)
+                .cmp(&(a.0, a.1))
+                .then_with(|| a.2.wire_name().cmp(b.2.wire_name()))
+        });
+        let mut loaded = self.lock_loaded();
+        let mut hits: Vec<&str> = Vec::new();
+        let mut overflow: Vec<&str> = Vec::new();
+        for (_, _, d) in &matches {
+            if hits.len() < MAX_SEARCH_LOADS {
+                loaded.insert(Arc::clone(&d.qualified_name));
+                hits.push(d.wire_name());
+            } else {
+                overflow.push(d.wire_name());
+            }
+        }
+        drop(loaded);
+        info!(query = %q, loaded = hits.len(), overflow = overflow.len(), "MCP tool search");
+        if hits.is_empty() {
+            return Ok(format!(
+                "{SEARCH_NO_MATCH} '{query}'. Try other keywords or an exact name from the catalog."
+            ));
+        }
+        let plural = if hits.len() == 1 { "tool" } else { "tools" };
+        let mut out = format!(
+            "Loaded {} {plural}, callable from your next message:",
+            hits.len()
+        );
+        for hit in &hits {
+            out.push_str(&format!("\n- `{hit}`"));
+        }
+        if !overflow.is_empty() {
+            let shown = overflow.len().min(MAX_OVERFLOW_NAMES);
+            let names: Vec<String> = overflow[..shown].iter().map(|n| format!("`{n}`")).collect();
+            out.push_str(&format!("\n{SEARCH_OVERFLOW_PREFIX}{}", names.join(", ")));
+            if overflow.len() > shown {
+                out.push_str(&format!(" and {} more", overflow.len() - shown));
+            }
+            out.push_str(". Search an exact tool name to load it.");
+        }
+        Ok(out)
+    }
+
+    /// Invoked on every MCP dispatch: a deferred tool the model calls by
+    /// catalog name gets its full definition on the next request.
+    pub fn mark_loaded(&self, qualified_name: &str) {
+        self.lock_loaded().insert(Arc::from(qualified_name));
+    }
+
+    fn lock_loaded(&self) -> std::sync::MutexGuard<'_, HashSet<Arc<str>>> {
+        self.loaded.lock().unwrap_or_else(|e| e.into_inner())
+    }
 }
 
 impl McpHandle {
@@ -305,12 +522,6 @@ impl McpHandle {
         transport::get_prompt(transport.as_ref(), &raw_name, arguments).await
     }
 
-    pub fn extend_tools(&self, tools: &mut Value) {
-        if let Some(arr) = tools.as_array_mut() {
-            arr.extend(self.index.load().descriptors.iter().cloned());
-        }
-    }
-
     pub async fn shutdown(&self) {
         let (ack_tx, ack_rx) = flume::bounded(1);
         self.send(McpCommand::Shutdown { ack: ack_tx });
@@ -345,6 +556,7 @@ pub async fn start_with_config(config: McpConfig) -> Option<McpHandle> {
         return None;
     }
 
+    let defer_tools = config.defer_tools.unwrap_or(DEFAULT_DEFER_TOOLS);
     let mut inner = parse_entries(config);
     start_enabled(&mut inner).await;
     inner.generation += 1;
@@ -358,6 +570,7 @@ pub async fn start_with_config(config: McpConfig) -> Option<McpHandle> {
         cmd_tx,
         index: Arc::clone(&index),
         snapshot: Arc::clone(&snapshot),
+        defer_tools,
     };
 
     info!(
@@ -572,6 +785,10 @@ fn parse_entries(config: McpConfig) -> McpManagerInner {
         });
     }
 
+    // Config maps are unordered; a stable order keeps the tool_search
+    // catalog and tools array byte-identical across runs (prompt cache).
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+
     McpManagerInner {
         entries,
         generation: 0,
@@ -618,7 +835,7 @@ fn apply_start_result(
 fn publish(inner: &McpManagerInner, index: &ArcSwap<ToolIndex>, snapshot: &ArcSwap<McpSnapshot>) {
     let mut tools = HashMap::new();
     let mut prompts = HashMap::new();
-    let mut descriptors: Vec<Value> = Vec::new();
+    let mut descriptors: Vec<ToolDescriptor> = Vec::new();
     let mut server_infos = Vec::with_capacity(inner.entries.len());
     let mut prompt_infos = Vec::new();
     let mut pids = Vec::new();
@@ -632,6 +849,7 @@ fn publish(inner: &McpManagerInner, index: &ArcSwap<ToolIndex>, snapshot: &ArcSw
         if let Some(ref transport) = entry.transport
             && entry.status != McpServerStatus::Disabled
         {
+            let always_load = entry.config.as_ref().is_some_and(|c| c.always_load);
             for t in &entry.tools {
                 tools.insert(
                     Arc::clone(&t.qualified_name),
@@ -640,11 +858,15 @@ fn publish(inner: &McpManagerInner, index: &ArcSwap<ToolIndex>, snapshot: &ArcSw
                         transport: Arc::clone(transport),
                     },
                 );
-                descriptors.push(json!({
-                    "name": wire_tool_name(&t.qualified_name),
-                    "description": t.description,
-                    "input_schema": t.input_schema,
-                }));
+                descriptors.push(ToolDescriptor {
+                    qualified_name: Arc::clone(&t.qualified_name),
+                    always_load,
+                    definition: json!({
+                        "name": wire_tool_name(&t.qualified_name),
+                        "description": t.description,
+                        "input_schema": t.input_schema,
+                    }),
+                });
             }
             for p in &entry.prompts {
                 prompts.insert(
@@ -681,6 +903,151 @@ fn publish(inner: &McpManagerInner, index: &ArcSwap<ToolIndex>, snapshot: &ArcSw
         pids,
         generation: inner.generation,
     }));
+}
+
+/// Session for dispatch-level tests outside this module, built through the
+/// real `publish` path so it can't drift from production index construction.
+#[cfg(test)]
+pub(crate) fn stub_session(tools: &[(&str, &str)]) -> McpSession {
+    let entry = ServerEntry {
+        name: "stub".into(),
+        config: None,
+        transport_kind: "stub",
+        origin: PathBuf::new(),
+        status: McpServerStatus::Running,
+        transport: Some(Arc::new(StubTransport(Arc::from("stub")))),
+        tools: tools
+            .iter()
+            .map(|(qualified, description)| McpToolDef {
+                qualified_name: Arc::from(*qualified),
+                raw_name: qualified
+                    .split_once(SEPARATOR)
+                    .map_or(*qualified, |(_, r)| r)
+                    .into(),
+                description: (*description).into(),
+                input_schema: json!({}),
+            })
+            .collect(),
+        prompts: Vec::new(),
+    };
+    let inner = McpManagerInner {
+        entries: vec![entry],
+        generation: 0,
+    };
+    let index = Arc::new(ArcSwap::from_pointee(ToolIndex::default()));
+    let snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot::default()));
+    publish(&inner, &index, &snapshot);
+    McpSession::new(
+        McpHandle {
+            cmd_tx: flume::unbounded().0,
+            index,
+            snapshot,
+            defer_tools: 0,
+        },
+        &[],
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn tool_names(tools: &Value) -> Vec<&str> {
+    tools
+        .as_array()
+        .expect("tools must be a JSON array")
+        .iter()
+        .filter_map(|t| t["name"].as_str())
+        .collect()
+}
+
+#[cfg(test)]
+struct StubTransport(Arc<str>);
+
+#[cfg(test)]
+impl McpTransport for StubTransport {
+    fn send_request<'a>(
+        &'a self,
+        method: &'a str,
+        _params: Option<Value>,
+    ) -> transport::BoxFuture<'a, Result<Value, McpError>> {
+        Box::pin(async move {
+            Err(McpError::UnknownTool {
+                name: method.into(),
+            })
+        })
+    }
+    fn send_notification<'a>(
+        &'a self,
+        _method: &'a str,
+        _params: Option<Value>,
+    ) -> transport::BoxFuture<'a, Result<(), McpError>> {
+        Box::pin(async { Ok(()) })
+    }
+    fn shutdown<'a>(&'a self) -> transport::BoxFuture<'a, ()> {
+        Box::pin(async {})
+    }
+    fn server_name(&self) -> &Arc<str> {
+        &self.0
+    }
+    fn transport_kind(&self) -> &'static str {
+        "stub"
+    }
+}
+
+fn build_haystack(definition: &Value) -> String {
+    let mut hay = definition["description"]
+        .as_str()
+        .unwrap_or_default()
+        .to_lowercase();
+    if let Some(props) = definition["input_schema"]["properties"].as_object() {
+        for key in props.keys() {
+            hay.push(' ');
+            hay.push_str(&key.to_lowercase());
+        }
+    }
+    hay
+}
+
+fn tool_search_definition(deferred: &[&ToolDescriptor]) -> Value {
+    // Grouping by server drops the repeated `server__` prefix, a few
+    // tokens per tool. Descriptors arrive grouped because entries are
+    // sorted and published per server.
+    let mut catalog = String::new();
+    let mut current_server = "";
+    for d in deferred {
+        let (server, raw) = d
+            .qualified_name
+            .split_once(SEPARATOR)
+            .unwrap_or((UNKNOWN_MCP, &d.qualified_name));
+        if server == current_server {
+            catalog.push_str(", ");
+        } else {
+            if !catalog.is_empty() {
+                catalog.push('\n');
+            }
+            catalog.push_str(server);
+            catalog.push_str(": ");
+            current_server = server;
+        }
+        catalog.push_str(raw);
+    }
+    json!({
+        "name": TOOL_SEARCH_TOOL_NAME,
+        "description": format!(
+            "Search and load deferred MCP tools; they are not callable until \
+             loaded, from your next message on. Keywords match tool names, \
+             descriptions, and parameter names; an exact tool name always wins.\n\
+             Deferred tools:\n{catalog}"
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Keywords or an exact tool name from the catalog"
+                }
+            },
+            "required": ["query"]
+        }
+    })
 }
 
 fn transport_url(transport: &Transport) -> Option<String> {
@@ -732,7 +1099,9 @@ mod tests {
     use super::*;
     use async_lock::Mutex as AsyncMutex;
     use config::{RawServerConfig, RawStdioFields, RawTransport};
+    use maki_providers::Role;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use test_case::test_case;
 
     const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 
@@ -740,6 +1109,7 @@ mod tests {
         RawServerConfig {
             enabled: true,
             timeout: DEFAULT_TIMEOUT_MS,
+            always_load: false,
             transport: RawTransport::Stdio(RawStdioFields {
                 command: cmd.iter().map(|s| s.to_string()).collect(),
                 environment: HashMap::new(),
@@ -754,7 +1124,11 @@ mod tests {
             origins.insert(name.to_string(), PathBuf::from("/test/config.toml"));
             mcp.insert(name.to_string(), cfg);
         }
-        McpConfig { mcp, origins }
+        McpConfig {
+            mcp,
+            origins,
+            ..Default::default()
+        }
     }
 
     const TOOL_NAME: &str = "srv.tool";
@@ -846,6 +1220,7 @@ mod tests {
         ServerConfig {
             name: name.into(),
             timeout: std::time::Duration::from_secs(1),
+            always_load: false,
             transport: Transport::Stdio {
                 program: "/nonexistent/definitely-not-here".into(),
                 args: vec![],
@@ -854,9 +1229,16 @@ mod tests {
         }
     }
 
-    /// Build `inner`, publish it into fresh `ArcSwap`s, and return a live `McpHandle` pointing
+    /// Build `inner`, publish it into fresh `ArcSwap`s, and return a live `McpSession` pointing
     /// at the same state so tests can hit both the mutation and the read path.
-    fn setup(entries: Vec<ServerEntry>) -> (McpManagerInner, McpHandle) {
+    fn setup(entries: Vec<ServerEntry>) -> (McpManagerInner, McpSession) {
+        setup_with_defer(entries, 0)
+    }
+
+    fn setup_with_defer(
+        entries: Vec<ServerEntry>,
+        defer_tools: usize,
+    ) -> (McpManagerInner, McpSession) {
         let inner = McpManagerInner {
             entries,
             generation: 0,
@@ -868,8 +1250,348 @@ mod tests {
             cmd_tx: flume::unbounded().0,
             index,
             snapshot,
+            defer_tools,
         };
-        (inner, handle)
+        (inner, McpSession::new(handle, &[]))
+    }
+
+    #[test]
+    fn parse_entries_sorts_servers_by_name() {
+        let config = make_config(vec![
+            ("zeta", stdio_raw(&["z"])),
+            ("alpha", stdio_raw(&["a"])),
+            ("mid", stdio_raw(&["m"])),
+        ]);
+        let inner = parse_entries(config);
+        let names: Vec<&str> = inner.entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "mid", "zeta"]);
+    }
+
+    fn always_load_entry(name: &str, transport: Arc<dyn McpTransport>) -> ServerEntry {
+        let mut raw = stdio_raw(&["echo"]);
+        raw.always_load = true;
+        let mut entry = fake_entry(name, transport);
+        entry.config = Some(parse_server(name.into(), raw).unwrap());
+        entry
+    }
+
+    #[test]
+    fn extend_tools_skips_deferral_at_or_below_threshold() {
+        let (_inner, handle) = setup_with_defer(vec![fake_entry("srv", FakeTransport::new())], 1);
+        let mut tools = json!([]);
+        handle.extend_tools(&mut tools);
+        assert_eq!(tool_names(&tools), vec![WIRE_TOOL_NAME]);
+    }
+
+    #[test]
+    fn defer_threshold_ignores_always_load_tools() {
+        let (_inner, handle) = setup_with_defer(
+            vec![
+                always_load_entry("eager", FakeTransport::new()),
+                fake_entry("lazy", FakeTransport::new()),
+            ],
+            1,
+        );
+        let mut tools = json!([]);
+        handle.extend_tools(&mut tools);
+        assert_eq!(tool_names(&tools), vec!["eager__tool", "lazy__tool"]);
+    }
+
+    #[test]
+    fn extend_tools_defers_behind_tool_search_by_default() {
+        let (_inner, handle) = setup(vec![fake_entry("srv", FakeTransport::new())]);
+        let mut tools = json!([]);
+        handle.extend_tools(&mut tools);
+        assert_eq!(tool_names(&tools), vec![TOOL_SEARCH_TOOL_NAME]);
+        let catalog = tools[0]["description"].as_str().unwrap();
+        assert!(catalog.contains("srv: tool"), "catalog groups by server");
+        assert!(handle.has_tool(TOOL_NAME), "deferred tools stay callable");
+    }
+
+    #[test]
+    fn extend_tools_includes_always_load_server_upfront() {
+        let (_inner, handle) = setup(vec![
+            always_load_entry("eager", FakeTransport::new()),
+            fake_entry("lazy", FakeTransport::new()),
+        ]);
+        let mut tools = json!([]);
+        handle.extend_tools(&mut tools);
+        let names = tool_names(&tools);
+        assert!(names.contains(&"eager__tool"));
+        assert!(names.contains(&TOOL_SEARCH_TOOL_NAME));
+        assert!(!names.contains(&"lazy__tool"));
+    }
+
+    #[test]
+    fn search_loads_tools_into_next_extend() {
+        let (_inner, handle) = setup(vec![fake_entry("srv", FakeTransport::new())]);
+        let result = handle.search_tools("TOOL").unwrap();
+        assert!(result.contains(WIRE_TOOL_NAME), "got: {result}");
+
+        let mut tools = json!([]);
+        handle.extend_tools(&mut tools);
+        assert_eq!(tool_names(&tools), vec![WIRE_TOOL_NAME]);
+    }
+
+    #[test]
+    fn search_reports_no_match_without_loading() {
+        let (_inner, handle) = setup(vec![fake_entry("srv", FakeTransport::new())]);
+        let result = handle.search_tools("nonexistent-capability").unwrap();
+        assert!(result.contains(SEARCH_NO_MATCH), "got: {result}");
+        let mut tools = json!([]);
+        handle.extend_tools(&mut tools);
+        assert_eq!(tool_names(&tools), vec![TOOL_SEARCH_TOOL_NAME]);
+    }
+
+    #[test]
+    fn search_caps_loads_and_reports_overflow() {
+        let transport: Arc<dyn McpTransport> = FakeTransport::new();
+        let mut entry = fake_entry("srv", Arc::clone(&transport));
+        entry.tools = (0..MAX_SEARCH_LOADS + 2)
+            .map(|i| McpToolDef {
+                qualified_name: intern(format!("srv{SEPARATOR}tool-{i}")),
+                raw_name: format!("tool-{i}"),
+                description: String::new(),
+                input_schema: json!({}),
+            })
+            .collect();
+        let (_inner, handle) = setup(vec![entry]);
+
+        let result = handle.search_tools("tool").unwrap();
+        let expected = format!(
+            "{SEARCH_OVERFLOW_PREFIX}`srv__tool-{}`, `srv__tool-{}`",
+            MAX_SEARCH_LOADS,
+            MAX_SEARCH_LOADS + 1
+        );
+        assert!(
+            result.contains(&expected),
+            "overflow must list names: {result}"
+        );
+        let mut tools = json!([]);
+        handle.extend_tools(&mut tools);
+        // Loaded cap plus the search tool for the remaining deferred ones.
+        assert_eq!(tools.as_array().unwrap().len(), MAX_SEARCH_LOADS + 1);
+    }
+
+    fn entry_with_tools(name: &str, tools: Vec<McpToolDef>) -> ServerEntry {
+        let mut entry = fake_entry(name, FakeTransport::new());
+        entry.tools = tools;
+        entry
+    }
+
+    fn tool_def(server: &str, raw: &str, description: &str, schema: Value) -> McpToolDef {
+        McpToolDef {
+            qualified_name: intern(format!("{server}{SEPARATOR}{raw}")),
+            raw_name: raw.into(),
+            description: description.into(),
+            input_schema: schema,
+        }
+    }
+
+    #[test_case("srv__tool-" ; "wire_name")]
+    #[test_case("tool-" ; "bare_name_as_shown_in_catalog")]
+    fn search_exact_name_outranks_keyword_matches(prefix: &str) {
+        let tools = (0..MAX_SEARCH_LOADS + 1)
+            .map(|i| tool_def("srv", &format!("tool-{i}"), "", json!({})))
+            .collect();
+        let (_inner, handle) = setup(vec![entry_with_tools("srv", tools)]);
+        // Alphabetical tie-break alone would leave the last tool in overflow.
+        let last = format!("{prefix}{MAX_SEARCH_LOADS}");
+        let result = handle.search_tools(&last).unwrap();
+        let overflow = result
+            .lines()
+            .find(|l| l.starts_with(SEARCH_OVERFLOW_PREFIX))
+            .expect("one match past the cap must overflow");
+        assert!(
+            result.contains(&format!("srv__tool-{MAX_SEARCH_LOADS}"))
+                && !overflow.contains(&format!("tool-{MAX_SEARCH_LOADS}")),
+            "exact name must be loaded, not overflowed: {result}"
+        );
+    }
+
+    #[test]
+    fn search_ranks_name_hits_above_description_hits() {
+        let tools = vec![
+            tool_def("srv", "add_comment", "Comment on an issue", json!({})),
+            tool_def("srv", "create_issue", "Open a ticket", json!({})),
+        ];
+        let (_inner, handle) = setup(vec![entry_with_tools("srv", tools)]);
+        let result = handle.search_tools("issue").unwrap();
+        let pos = |name: &str| {
+            result
+                .find(name)
+                .unwrap_or_else(|| panic!("{name} must match: {result}"))
+        };
+        assert!(
+            pos("srv__create_issue") < pos("srv__add_comment"),
+            "name hit must rank above description hit: {result}"
+        );
+    }
+
+    #[test]
+    fn search_multi_word_query_matches_any_keyword() {
+        let tools = vec![tool_def(
+            "srv",
+            "create_pr",
+            "Open a pull request",
+            json!({}),
+        )];
+        let (_inner, handle) = setup(vec![entry_with_tools("srv", tools)]);
+        let result = handle.search_tools("pull request").unwrap();
+        assert!(result.contains("srv__create_pr"), "got: {result}");
+    }
+
+    #[test]
+    fn search_matches_schema_parameter_names() {
+        let schema = json!({"type": "object", "properties": {"labels": {"type": "array"}}});
+        let tools = vec![tool_def("srv", "update", "Update a thing", schema)];
+        let (_inner, handle) = setup(vec![entry_with_tools("srv", tools)]);
+        let result = handle.search_tools("labels").unwrap();
+        assert!(result.contains("srv__update"), "got: {result}");
+    }
+
+    #[test]
+    fn extend_tools_never_duplicates_existing_names() {
+        let (_inner, handle) = setup(vec![always_load_entry("eager", FakeTransport::new())]);
+        let mut tools = json!([]);
+        handle.extend_tools(&mut tools);
+        handle.extend_tools(&mut tools);
+        assert_eq!(tool_names(&tools), vec!["eager__tool"]);
+    }
+
+    #[test]
+    fn new_seeds_loads_only_from_wire_names_in_history() {
+        let (_inner, session) = setup(vec![fake_entry("srv", FakeTransport::new())]);
+        let tool_use = |name: &str| ContentBlock::ToolUse {
+            id: "t".into(),
+            name: name.into(),
+            input: json!({}),
+        };
+        let history = vec![Message {
+            role: Role::Assistant,
+            content: vec![
+                tool_use(WIRE_TOOL_NAME),
+                tool_use("read"),
+                tool_use("gone__tool"),
+            ],
+            display_text: None,
+        }];
+        let restored = McpSession::new(session.handle.clone(), &history);
+        let mut tools = json!([]);
+        restored.extend_tools(&mut tools);
+        assert_eq!(
+            tool_names(&tools),
+            vec![WIRE_TOOL_NAME],
+            "only wire names still in the index may load"
+        );
+    }
+
+    #[test]
+    fn mid_session_loads_never_flip_remainder_into_context() {
+        let defs = vec![
+            tool_def("srv", "alpha", "", json!({})),
+            tool_def("srv", "beta", "", json!({})),
+            tool_def("srv", "gamma", "", json!({})),
+        ];
+        let (_inner, handle) = setup_with_defer(vec![entry_with_tools("srv", defs)], 2);
+        handle.mark_loaded("srv.alpha");
+        handle.mark_loaded("srv.beta");
+        let mut tools = json!([]);
+        handle.extend_tools(&mut tools);
+        let names = tool_names(&tools);
+        assert!(names.contains(&"srv__alpha") && names.contains(&"srv__beta"));
+        assert!(
+            !names.contains(&"srv__gamma"),
+            "threshold must compare the full index, not the remaining deferred count: {names:?}"
+        );
+        let catalog = tools
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|t| t["name"] == TOOL_SEARCH_TOOL_NAME)
+            .expect("tool_search must stay while any tool is deferred");
+        let description = catalog["description"].as_str().unwrap();
+        assert!(description.contains("srv: gamma"), "got: {description}");
+    }
+
+    #[test]
+    fn mark_loaded_declares_tool_and_drops_empty_catalog() {
+        let (_inner, handle) = setup(vec![fake_entry("srv", FakeTransport::new())]);
+        handle.mark_loaded(TOOL_NAME);
+        let mut tools = json!([]);
+        handle.extend_tools(&mut tools);
+        assert_eq!(
+            tool_names(&tools),
+            vec![WIRE_TOOL_NAME],
+            "loaded tool must be declared; an empty catalog must not be advertised"
+        );
+    }
+
+    #[test]
+    fn existing_wire_name_stays_out_of_catalog() {
+        let defs = vec![
+            tool_def("srv", "alpha", "", json!({})),
+            tool_def("srv", "beta", "", json!({})),
+        ];
+        let (_inner, handle) = setup(vec![entry_with_tools("srv", defs)]);
+        let mut tools = json!([{ "name": "srv__alpha" }]);
+        handle.extend_tools(&mut tools);
+        assert_eq!(
+            tool_names(&tools),
+            vec!["srv__alpha", TOOL_SEARCH_TOOL_NAME],
+            "colliding name must be skipped, not deferred or re-added"
+        );
+        let catalog = tools[1]["description"].as_str().unwrap();
+        assert!(catalog.contains("srv: beta"), "got: {catalog}");
+        assert!(!catalog.contains("alpha"), "got: {catalog}");
+    }
+
+    #[test]
+    fn history_seeding_handles_tool_names_with_double_underscores() {
+        let defs = vec![tool_def("srv", "do__thing", "", json!({}))];
+        let (_inner, session) = setup(vec![entry_with_tools("srv", defs)]);
+        let history = vec![Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::ToolUse {
+                id: "t".into(),
+                name: "srv__do__thing".into(),
+                input: json!({}),
+            }],
+            display_text: None,
+        }];
+        let restored = McpSession::new(session.handle.clone(), &history);
+        let mut tools = json!([]);
+        restored.extend_tools(&mut tools);
+        assert_eq!(
+            tool_names(&tools),
+            vec!["srv__do__thing"],
+            "only the first __ is the server separator"
+        );
+    }
+
+    #[test]
+    fn search_ignores_always_load_tools() {
+        let (_inner, handle) = setup(vec![always_load_entry("eager", FakeTransport::new())]);
+        let result = handle.search_tools("tool").unwrap();
+        assert!(
+            result.contains(SEARCH_NO_MATCH),
+            "always_load tools are already declared: {result}"
+        );
+    }
+
+    #[test]
+    fn search_loads_stay_scoped_to_their_session() {
+        let (_inner, session_a) = setup(vec![fake_entry("srv", FakeTransport::new())]);
+        let session_b = session_a.fresh();
+        session_a.search_tools("tool").unwrap();
+
+        let mut tools_a = json!([]);
+        session_a.extend_tools(&mut tools_a);
+        assert_eq!(tool_names(&tools_a), vec![WIRE_TOOL_NAME]);
+
+        let mut tools_b = json!([]);
+        session_b.extend_tools(&mut tools_b);
+        assert_eq!(tool_names(&tools_b), vec![TOOL_SEARCH_TOOL_NAME]);
     }
 
     #[test]
@@ -926,7 +1648,7 @@ mod tests {
             assert!(handle.has_tool(TOOL_NAME));
             let mut tools = json!([]);
             handle.extend_tools(&mut tools);
-            assert_eq!(tools[0]["name"], WIRE_TOOL_NAME);
+            assert_eq!(tools[0]["name"], TOOL_SEARCH_TOOL_NAME);
 
             handle_toggle(&mut inner, "srv", false).await;
             publish(&inner, &handle.index, &handle.snapshot);

--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -741,9 +741,25 @@ async fn start_server(config: &ServerConfig) -> Result<StartResult, McpError> {
             maki_storage::StateDir::resolve().ok(),
         )?),
     };
-    transport::initialize(transport.as_ref()).await?;
-    let tool_infos = transport::list_tools(transport.as_ref()).await?;
-    let prompt_infos = transport::list_prompts(transport.as_ref()).await?;
+    let capabilities = transport::initialize(transport.as_ref()).await?;
+    // Sloppy servers omit `capabilities` yet serve tools/list fine, so
+    // always ask; failure is only fatal when the server declared tools.
+    let tool_infos = match transport::list_tools(transport.as_ref()).await {
+        Ok(tools) => tools,
+        Err(e) if !capabilities.tools => {
+            warn!(server = config.name, error = %e, "tools/list failed; server declared no tools");
+            Vec::new()
+        }
+        Err(e) => return Err(e),
+    };
+    // Prompts are the opposite: ask only when declared. Servers without
+    // prompt support may answer with junk, and junk must not take down
+    // their tools.
+    let prompt_infos = if capabilities.prompts {
+        transport::list_prompts(transport.as_ref()).await?
+    } else {
+        Vec::new()
+    };
     info!(
         server = config.name,
         tool_count = tool_infos.len(),

--- a/maki-agent/src/mcp/transport.rs
+++ b/maki-agent/src/mcp/transport.rs
@@ -42,12 +42,21 @@ fn invalid_response(name: &Arc<str>, e: impl std::fmt::Display) -> McpError {
     }
 }
 
-pub async fn initialize(transport: &dyn McpTransport) -> Result<(), McpError> {
+pub struct ServerCapabilities {
+    pub tools: bool,
+    pub prompts: bool,
+}
+
+pub async fn initialize(transport: &dyn McpTransport) -> Result<ServerCapabilities, McpError> {
     let params = initialize_params();
-    transport.send_request("initialize", Some(params)).await?;
+    let result = transport.send_request("initialize", Some(params)).await?;
     transport
         .send_notification("notifications/initialized", None)
-        .await
+        .await?;
+    Ok(ServerCapabilities {
+        tools: result["capabilities"]["tools"].is_object(),
+        prompts: result["capabilities"]["prompts"].is_object(),
+    })
 }
 
 pub async fn list_tools(transport: &dyn McpTransport) -> Result<Vec<ToolInfo>, McpError> {
@@ -116,4 +125,49 @@ pub async fn call_tool(
         "MCP tools/call response"
     );
     Ok(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use test_case::test_case;
+
+    struct InitTransport(Value, Arc<str>);
+
+    impl McpTransport for InitTransport {
+        fn send_request<'a>(
+            &'a self,
+            _method: &'a str,
+            _params: Option<Value>,
+        ) -> BoxFuture<'a, Result<Value, McpError>> {
+            Box::pin(async { Ok(self.0.clone()) })
+        }
+        fn send_notification<'a>(
+            &'a self,
+            _method: &'a str,
+            _params: Option<Value>,
+        ) -> BoxFuture<'a, Result<(), McpError>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn shutdown<'a>(&'a self) -> BoxFuture<'a, ()> {
+            Box::pin(async {})
+        }
+        fn server_name(&self) -> &Arc<str> {
+            &self.1
+        }
+        fn transport_kind(&self) -> &'static str {
+            "stub"
+        }
+    }
+
+    #[test_case(json!({"capabilities": {"tools": {}, "prompts": {}}}), true, true ; "both")]
+    #[test_case(json!({"capabilities": {"tools": {"listChanged": false}}}), true, false ; "tools_only")]
+    #[test_case(json!({"capabilities": {"prompts": {}}}), false, true ; "prompts_only")]
+    #[test_case(json!({}), false, false ; "no_capabilities")]
+    fn initialize_parses_capabilities(result: Value, tools: bool, prompts: bool) {
+        let transport = InitTransport(result, Arc::from("srv"));
+        let caps = smol::block_on(initialize(&transport)).unwrap();
+        assert_eq!((caps.tools, caps.prompts), (tools, prompts));
+    }
 }

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -31,7 +31,7 @@ use serde_json::Value;
 
 use crate::agent::LoadedInstructions;
 use crate::cancel::{CancelMap, CancelToken};
-use crate::mcp::McpHandle;
+use crate::mcp::McpSession;
 use crate::permissions::PermissionManager;
 use crate::{AgentConfig, AgentMode, EventSender, SharedBuf};
 use maki_config::ToolOutputLines;
@@ -198,7 +198,7 @@ pub struct ToolContext {
     pub user_response_rx: Option<Arc<async_lock::Mutex<flume::Receiver<String>>>>,
     pub loaded_instructions: LoadedInstructions,
     pub cancel: CancelToken,
-    pub mcp: Option<McpHandle>,
+    pub mcp: Option<McpSession>,
     pub deadline: Deadline,
     pub config: AgentConfig,
     pub tool_output_lines: ToolOutputLines,

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -20,7 +20,7 @@ use maki_agent::tools::{
 };
 use maki_agent::{
     Agent, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, Envelope, EventSender,
-    History, SubagentInfo, ToolDoneEvent,
+    History, McpSession, SubagentInfo, ToolDoneEvent,
 };
 use maki_lua_macro::{lua_class, lua_fn, lua_table};
 use maki_providers::model::ModelTier;
@@ -190,7 +190,6 @@ async fn system_prompt(
 /// Optional fields:
 ///   `only` (string[]?) - include only these tool names.
 ///   `except` (string[]?) - exclude these tool names.
-///   `include_mcp` (boolean?) - include MCP tools. Default: `true`.
 ///   `workflow` (boolean?) - use workflow-mode descriptions. Default: `false`.
 ///   `spec` (string?) - evaluate capability exclusions against this model spec.
 /// @return (table?, string?) Array of tool definition tables, or `(nil, err)` on failure.
@@ -212,7 +211,6 @@ async fn tools(lua: Lua, ctx: mlua::UserDataRef<LuaCtx>, opts: Table) -> LuaResu
 
     let only: Option<Vec<String>> = opts.get("only")?;
     let except: Option<Vec<String>> = opts.get("except")?;
-    let include_mcp: bool = opts.get::<Option<bool>>("include_mcp")?.unwrap_or(true);
     let workflow: bool = opts.get::<Option<bool>>("workflow")?.unwrap_or(false);
     let spec_str: Option<String> = opts.get("spec")?;
 
@@ -242,12 +240,9 @@ async fn tools(lua: Lua, ctx: mlua::UserDataRef<LuaCtx>, opts: Table) -> LuaResu
         audience,
         workflow,
     };
-    let mut defs =
-        ToolRegistry::global().definitions(&vars, &ctx_desc, model.supports_tool_examples());
-
-    if include_mcp && let Some(ref mcp) = agent.mcp {
-        mcp.extend_tools(&mut defs);
-    }
+    // Base definitions only: the session injects MCP definitions per
+    // request, so baking them into a tools array would freeze the catalog.
+    let defs = ToolRegistry::global().definitions(&vars, &ctx_desc, model.supports_tool_examples());
 
     Ok((Some(json_to_lua(&lua, &defs)?), None))
 }
@@ -342,6 +337,10 @@ async fn call_tool(
 ///     `(string)` or `(nil, err)`.
 ///   `name` (string?) - display name for logs and UI.
 ///   `audience` (string?) - tool audience for capability gating. Default: `"general_sub"`.
+///   `mcp` (boolean?) - give the session access to MCP tools. Their
+///     definitions are injected automatically each turn (deferred behind
+///     `tool_search`), so don't put MCP definitions in `tools`. The session
+///     starts with no loaded tools of its own. Default: `true`.
 ///   `thinking` (string|integer?) - thinking mode: `"off"`, `"adaptive"`, an
 ///     effort level (`"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`,
 ///     `"max"`), or a budget integer (token count). Inherits parent setting
@@ -381,6 +380,7 @@ async fn session(
     let fast: bool = opts
         .get::<Option<bool>>("fast")?
         .unwrap_or(agent_ctx.opts.fast);
+    let mcp_enabled: bool = opts.get::<Option<bool>>("mcp")?.unwrap_or(true);
 
     let (model, provider): (Model, Arc<dyn provider::Provider>) = if let Some(ref spec) = model_spec
     {
@@ -526,7 +526,11 @@ async fn session(
         tools: tools_json,
         thinking,
         fast,
-        mcp: agent_ctx.mcp.clone(),
+        mcp: agent_ctx
+            .mcp
+            .as_ref()
+            .filter(|_| mcp_enabled)
+            .map(McpSession::fresh),
         history: History::new(Vec::new()),
         sub_event_tx,
         child_cancel,
@@ -646,7 +650,9 @@ struct SessionState {
     tools: JsonValue,
     thinking: ThinkingConfig,
     fast: bool,
-    mcp: Option<maki_agent::mcp::McpHandle>,
+    /// Fresh per session so `tool_search` loads never leak between a
+    /// subagent and its parent.
+    mcp: Option<McpSession>,
     history: History,
     sub_event_tx: EventSender,
     child_cancel: maki_agent::cancel::CancelToken,

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use maki_agent::agent;
-use maki_agent::mcp::McpHandle;
 use maki_agent::mcp::config::McpServerStatus;
+use maki_agent::mcp::{McpHandle, McpSession};
 use maki_agent::permissions::PermissionManager;
 use maki_agent::template;
 use maki_agent::template::Vars;
@@ -32,7 +32,7 @@ pub(super) struct AgentLoop {
     vars: Vars,
     instructions: Instructions,
     tools: Value,
-    mcp_handle: Option<McpHandle>,
+    mcp: Option<McpSession>,
     history: History,
     btw_system: Arc<ArcSwap<String>>,
     cancel_map: Arc<RunCancelMap>,
@@ -70,6 +70,7 @@ impl AgentLoop {
         lua_handle: Option<EventHandle>,
         subagent_cancels: Arc<CancelMap<String>>,
     ) -> Self {
+        let mcp = mcp_handle.map(|h| McpSession::new(h, &initial_history));
         Self {
             model_slot,
             config,
@@ -77,7 +78,7 @@ impl AgentLoop {
             vars: Vars::default(),
             instructions: Instructions::default(),
             tools: Value::Null,
-            mcp_handle,
+            mcp,
             history: History::restored(initial_history).with_mirror(shared_history),
             btw_system,
             cancel_map,
@@ -145,8 +146,7 @@ impl AgentLoop {
 
         let slot = self.model_slot.load();
         self.tools = self.build_tools(&slot.model, false);
-        if let Some(ref mcp) = self.mcp_handle {
-            mcp.extend_tools(&mut self.tools);
+        if let Some(ref mcp) = self.mcp {
             spawn_oauth_for_needs_auth(mcp);
         }
         !self.init_cancel.is_cancelled()
@@ -179,7 +179,7 @@ impl AgentLoop {
         }
 
         if let Some(ref prompt_ref) = input.prompt {
-            let Some(ref mcp) = self.mcp_handle else {
+            let Some(ref mcp) = self.mcp else {
                 return Err(AgentError::Tool {
                     tool: "mcp_prompt".into(),
                     message: "MCP not available".into(),
@@ -249,7 +249,7 @@ impl AgentLoop {
         .with_user_response_rx(Arc::clone(&self.answer_rx))
         .with_interrupt_source(Arc::clone(&self.queue) as Arc<dyn maki_agent::InterruptSource>)
         .with_cancel(cancel)
-        .with_mcp(self.mcp_handle.clone());
+        .with_mcp(self.mcp.clone());
 
         let result = agent.run(input).await;
         drop(agent);
@@ -263,12 +263,10 @@ impl AgentLoop {
         result
     }
 
+    /// Base tools only. MCP definitions are injected per request by
+    /// `Agent::request_tools`; baking them here would freeze the catalog.
     fn rebuild_tools(&mut self, model: &Model, workflow: bool) {
-        let mut tools = self.build_tools(model, workflow);
-        if let Some(ref mcp) = self.mcp_handle {
-            mcp.extend_tools(&mut tools);
-        }
-        self.tools = tools;
+        self.tools = self.build_tools(model, workflow);
     }
 
     fn build_tools(&self, model: &Model, workflow: bool) -> Value {

--- a/plugins/task/init.lua
+++ b/plugins/task/init.lua
@@ -123,7 +123,6 @@ local function handler(input, ctx)
   local tool_defs, tools_err = maki.agent.tools(ctx, {
     audience = audience,
     spec = model.spec,
-    include_mcp = true,
   })
   if tools_err then
     return { llm_output = tools_err, is_error = true }

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -705,7 +705,6 @@ available.
 
   - `only` (`string[]?`) include only these tool names.
   - `except` (`string[]?`) exclude these tool names.
-  - `include_mcp` (`boolean?`) include MCP tools. Default: `true`.
   - `workflow` (`boolean?`) use workflow-mode descriptions. Default: `false`.
   - `spec` (`string?`) evaluate capability exclusions against this model spec.
 
@@ -789,6 +788,10 @@ and tool set.
     `(string)` or `(nil, err)`.
   - `name` (`string?`) display name for logs and UI.
   - `audience` (`string?`) tool audience for capability gating. Default: `"general_sub"`.
+  - `mcp` (`boolean?`) give the session access to MCP tools. Their
+    definitions are injected automatically each turn (deferred behind
+    `tool_search`), so don't put MCP definitions in `tools`. The session
+    starts with no loaded tools of its own. Default: `true`.
   - `thinking` (`string|integer?`) thinking mode: `"off"`, `"adaptive"`, an
     effort level (`"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`,
     `"max"`), or a budget integer (token count). Inherits parent setting

--- a/site/docs/content/mcp/_index.md
+++ b/site/docs/content/mcp/_index.md
@@ -47,8 +47,44 @@ headers = { Authorization = "Bearer tok123" }
 | `headers` | map | | HTTP only |
 | `timeout` | u64 | 30000 | Milliseconds (1-300000) |
 | `enabled` | bool | true | |
+| `always_load` | bool | false | Skip tool search, load all tools upfront |
 
 Set `command` for stdio, `url` for HTTP. Pick one.
+
+One option lives at the top level of `mcp.toml`, outside any server:
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `defer_tools` | usize | 10 | Defer tools only when more than this many exist |
+
+## Tool search
+
+Every tool definition a server exposes costs context window space, on every request. Big servers like GitHub's ship dozens of tools when a task often needs three.
+
+So Maki, like Claude Code, defers MCP tools by default. The model sees one small `tool_search` tool that lists the deferred names, searches when it actually needs something, and the matches stay loaded for the rest of the session. Resume a session and the tools it was using come back. Subagents keep their own loads, so their searches don't bloat your main conversation.
+
+You don't configure anything for this. Add servers, and only the tools the model actually uses take up context.
+
+With 10 or fewer tools across all your servers there is no search step: at that size, searching costs more than it saves, so everything loads upfront. The top-level `defer_tools` key moves that line:
+
+```toml
+defer_tools = 30
+
+[mcp.github]
+url = "https://api.githubcopilot.com/mcp/"
+```
+
+Set it to 0 to always defer, or above your tool count to never defer.
+
+If one server should skip the search step entirely, opt it out:
+
+```toml
+[mcp.linear]
+command = ["linear-mcp-server"]
+always_load = true
+```
+
+Good for small servers you rely on every turn. On a big server it defeats the point: every definition is back in your context on every request.
 
 ## Naming and namespacing
 


### PR DESCRIPTION
A big MCP server ships dozens of tool definitions that eat context on every request, so MCP tools are now deferred by default: the model sees one small `tool_search` tool carrying the deferred names, searches when a task needs a capability, and matches stay loaded for the rest of the session. The whole thing is client-side like Claude Code's ToolSearch, so it works with any provider.

Search splits the query into keywords and ranks hits against tool names, descriptions, and parameter names: the best 5 load, an exact tool name always wins, and extra matches are listed by name so one more search grabs them. Definitions are re-extended every turn, so fresh loads and late-connecting servers join the next request, and loads are scoped per session so a subagent's searches never bloat the parent's context.

Servers you rely on every turn can skip the search step with `always_load = true` in `mcp.toml`.