### PR TITLE
feat(ui): show subtask token usage

### DIFF
--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -84,6 +84,7 @@ fn finish_compact(
         message: response.message.clone(),
         usage: response.usage,
         model: model.id.clone(),
+        cost: (!model.pricing.is_zero()).then(|| response.usage.cost(&model.pricing, false)),
         context_size: Some(response.usage.output),
     })));
 

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -372,6 +372,11 @@ impl<'h> Agent<'h> {
                 message: response.message.clone(),
                 usage: response.usage,
                 model: self.model.id.clone(),
+                cost: (!self.model.pricing.is_zero()).then(|| {
+                    response
+                        .usage
+                        .cost(&self.model.pricing, self.opts.clamped(&self.model).fast)
+                }),
                 context_size: Some(response.usage.context_tokens()),
             })))
     }

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -35,9 +35,9 @@ use maki_providers::Message;
 pub use maki_providers::{ImageMediaType, ImageSource, ThinkingConfig};
 pub use types::{
     AgentEvent, BufferSnapshot, Envelope, EventSender, GrepFileEntry, GrepLine, GrepMatchGroup,
-    InstructionBlock, NO_FILES_FOUND, SharedBuf, SnapshotLine, SnapshotSpan, SpanStyle,
-    SubagentInfo, TextOutput, ToolDoneEvent, ToolInput, ToolOutput, ToolStartEvent,
-    TurnCompleteEvent,
+    InstructionBlock, NO_FILES_FOUND, RIGHT_TIMESTAMP_STYLE, RIGHT_USAGE_STYLE, SharedBuf,
+    SnapshotLine, SnapshotSpan, SpanStyle, SubagentInfo, TextOutput, ToolDoneEvent, ToolInput,
+    ToolOutput, ToolStartEvent, TurnCompleteEvent,
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -223,6 +223,7 @@ pub struct ToolContext {
 pub enum ToolLive {
     Buf(Arc<SharedBuf>),
     Annotation(String),
+    Usage(String),
 }
 
 pub(crate) fn resolve_path(path: &str) -> Result<String, String> {

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -11,6 +11,10 @@ use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 
 pub const NO_FILES_FOUND: &str = "No files found";
+/// Span styles a plugin puts on the last two spans of a snapshot line to have
+/// the UI strip them off and re-render them flush right on that line.
+pub const RIGHT_USAGE_STYLE: &str = "__maki_right_usage";
+pub const RIGHT_TIMESTAMP_STYLE: &str = "__maki_right_timestamp";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GrepFileEntry {
@@ -818,6 +822,8 @@ pub struct TurnCompleteEvent {
     pub usage: TokenUsage,
     pub model: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub context_size: Option<u32>,
 }
 
@@ -888,6 +894,7 @@ pub struct Envelope {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::Value;
     use test_case::test_case;
 
     #[test_case(ToolOutput::Plain("ok".into()),                      Some("1 lines")     ; "plain_short_annotates")]
@@ -1324,6 +1331,29 @@ mod tests {
         let json_without = r#"{"id":"t1"}"#;
         let parsed: ToolSnapshotFields = serde_json::from_str(json_without).unwrap();
         assert_eq!(parsed.theme_gen, None, "{COMPAT_MSG}");
+    }
+
+    #[test_case(Some(1.25), Some(1.25) ; "cost_present")]
+    #[test_case(None, None ; "cost_absent")]
+    fn turn_complete_event_serializes_cost(cost: Option<f64>, expected: Option<f64>) {
+        const COST_FIELD: &str = "cost";
+        const MODEL: &str = "test-model";
+        const MSG: &str = "serialized turn cost must survive session persistence";
+
+        let event = AgentEvent::TurnComplete(Box::new(TurnCompleteEvent {
+            message: Message::default(),
+            usage: TokenUsage::default(),
+            model: MODEL.into(),
+            cost,
+            context_size: None,
+        }));
+
+        let value = serde_json::to_value(event).unwrap();
+        assert_eq!(
+            value.get(COST_FIELD).and_then(Value::as_f64),
+            expected,
+            "{MSG}"
+        );
     }
 
     #[test]

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -3,9 +3,7 @@
 
 use std::collections::HashMap;
 use std::pin::pin;
-use std::sync::Arc;
-use std::sync::OnceLock;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use async_lock::Mutex as AsyncMutex;
@@ -26,7 +24,7 @@ use maki_agent::{
 use maki_lua_macro::{lua_class, lua_fn, lua_table};
 use maki_providers::model::ModelTier;
 use maki_providers::provider;
-use maki_providers::{ContentBlock, Model, ModelError, Role, ThinkingConfig};
+use maki_providers::{ContentBlock, Model, ModelError, Role, ThinkingConfig, TokenUsage};
 use maki_storage::id::MakiId;
 use maki_storage::sessions::StoredThinking;
 use mlua::{Function, IntoLuaMulti, Lua, Result as LuaResult, Table, Value as LuaValue};
@@ -78,6 +76,46 @@ type Pair<T> = (Option<T>, Option<String>);
 
 fn err_pair<T>(err: impl ToString) -> Pair<T> {
     (None, Some(err.to_string()))
+}
+
+async fn relay_session_events(
+    sub_rx: flume::Receiver<Envelope>,
+    parent_tx: EventSender,
+    subagent_info: Arc<OnceLock<SubagentInfo>>,
+    usage: Arc<Mutex<(TokenUsage, Option<f64>)>>,
+    usage_sync_tx: flume::Sender<()>,
+    live_sink: Option<flume::Sender<ToolLive>>,
+) {
+    while let Ok(mut envelope) = sub_rx.recv_async().await {
+        match &envelope.event {
+            AgentEvent::TurnComplete(turn) => {
+                let formatted = {
+                    let mut cumulative = usage.lock().unwrap_or_else(|e| e.into_inner());
+                    cumulative.0 += turn.usage;
+                    if let Some(turn_cost) = turn.cost {
+                        cumulative.1 = Some(cumulative.1.unwrap_or_default() + turn_cost);
+                    }
+                    subagent_info
+                        .get()
+                        .map(|_| cumulative.0.format(cumulative.1))
+                };
+                if let (Some(sink), Some(formatted)) = (&live_sink, formatted) {
+                    let _ = sink.send(ToolLive::Usage(formatted));
+                }
+            }
+            AgentEvent::Done { .. } => {
+                let _ = usage_sync_tx.send(());
+                continue;
+            }
+            AgentEvent::Error { .. }
+            | AgentEvent::ToolOutput { .. }
+            | AgentEvent::ToolPending { .. }
+            | AgentEvent::SubagentHistory { .. } => continue,
+            _ => {}
+        }
+        envelope.subagent = subagent_info.get().cloned();
+        let _ = parent_tx.send_envelope(envelope);
+    }
 }
 
 /// `maki.agent.*` convention: wrong argument types throw; every value or
@@ -251,8 +289,8 @@ async fn tools(lua: Lua, ctx: mlua::UserDataRef<LuaCtx>, opts: Table) -> LuaResu
 /// Run a tool by name and wait for the result. This is how you call built-in
 /// tools (like `read`, `bash`, `glob`) from Lua without going through the LLM.
 ///
-/// Live events (streaming output, annotations) are delivered through optional
-/// callbacks while the tool runs.
+/// Live events (streaming output, annotations, cumulative usage) are delivered
+/// through optional callbacks while the tool runs.
 ///
 /// @param ctx LuaCtx Agent context.
 /// @param name string Tool name, e.g. `"bash"`, `"read"`.
@@ -263,6 +301,8 @@ async fn tools(lua: Lua, ctx: mlua::UserDataRef<LuaCtx>, opts: Table) -> LuaResu
 ///     the tool publishes. Must not yield.
 ///   `on_annotation` (function?) - called with an annotation string for each
 ///     annotation event. Must not yield.
+///   `on_usage` (function?) - called with a formatted cumulative token usage
+///     string. Must not yield.
 /// @return (string?, string?) Tool output text, or `(nil, err)` on failure.
 /// @example
 /// local out, err = maki.agent.call_tool(ctx, "bash", {
@@ -282,14 +322,15 @@ async fn call_tool(
     let input_json = lua_to_json(&lua, &input)?;
     let agent = try_pair!(dispatch_ctx(&ctx, "call_tool"));
     let mut tctx = agent.to_tool_context();
-    let (mut on_buf, mut on_ann, mut rx) = (None, None, None);
+    let (mut on_buf, mut on_ann, mut on_usage, mut rx) = (None, None, None, None);
     if let Some(o) = opts {
         if let Some(secs) = o.get::<Option<u64>>("timeout")? {
             tctx.deadline = Deadline::after(Duration::from_secs(secs));
         }
         on_buf = o.get::<Option<Function>>("on_live_buf")?;
         on_ann = o.get::<Option<Function>>("on_annotation")?;
-        if on_buf.is_some() || on_ann.is_some() {
+        on_usage = o.get::<Option<Function>>("on_usage")?;
+        if on_buf.is_some() || on_ann.is_some() || on_usage.is_some() {
             let (tx, r) = flume::unbounded();
             tctx.live_sink = Some(tx);
             rx = Some(r);
@@ -303,6 +344,7 @@ async fn call_tool(
         tool: &name,
         on_buf,
         on_ann,
+        on_usage,
     };
     let done = dispatch_racing_live(&tctx, &name, &input_json, rx, &cbs).await;
     // Same fallback the UI applies on tool completion, so a batch child's
@@ -466,34 +508,19 @@ async fn session(
     let (answer_tx, answer_rx) = flume::unbounded::<String>();
 
     let subagent_info: Arc<OnceLock<SubagentInfo>> = Arc::new(OnceLock::new());
-    let total_input = Arc::new(AtomicU32::new(0));
-    let total_output = Arc::new(AtomicU32::new(0));
+    let usage = Arc::new(Mutex::new((TokenUsage::default(), None)));
+    let (usage_sync_tx, usage_sync_rx) = flume::unbounded();
+    let live_sink = agent_ctx.live_sink.clone();
 
-    {
-        let info = Arc::clone(&subagent_info);
-        let ti = Arc::clone(&total_input);
-        let to = Arc::clone(&total_output);
-        let parent_tx = parent_tx.clone();
-        smol::spawn(async move {
-            while let Ok(mut envelope) = sub_rx.recv_async().await {
-                match &envelope.event {
-                    AgentEvent::Done { usage, .. } => {
-                        ti.fetch_add(usage.total_input(), Ordering::Relaxed);
-                        to.fetch_add(usage.output, Ordering::Relaxed);
-                        continue;
-                    }
-                    AgentEvent::Error { .. }
-                    | AgentEvent::ToolOutput { .. }
-                    | AgentEvent::ToolPending { .. }
-                    | AgentEvent::SubagentHistory { .. } => continue,
-                    _ => {}
-                }
-                envelope.subagent = info.get().cloned();
-                let _ = parent_tx.send_envelope(envelope);
-            }
-        })
-        .detach();
-    }
+    smol::spawn(relay_session_events(
+        sub_rx,
+        parent_tx.clone(),
+        Arc::clone(&subagent_info),
+        Arc::clone(&usage),
+        usage_sync_tx,
+        live_sink,
+    ))
+    .detach();
 
     // Register a cancel trigger so the child token does not fire on drop
     // and kill the subagent at birth.
@@ -544,8 +571,8 @@ async fn session(
         subagent_info,
         local_tools: Arc::new(local_map),
         name,
-        total_input,
-        total_output,
+        usage,
+        usage_sync_rx,
         start: Instant::now(),
         closed: false,
     };
@@ -587,6 +614,7 @@ struct LiveCallbacks<'a> {
     tool: &'a str,
     on_buf: Option<Function>,
     on_ann: Option<Function>,
+    on_usage: Option<Function>,
 }
 
 impl LiveCallbacks<'_> {
@@ -594,6 +622,7 @@ impl LiveCallbacks<'_> {
         let res = match ev {
             ToolLive::Buf(buf) => call_opt(&self.on_buf, BufHandle::foreign(buf)).await,
             ToolLive::Annotation(ann) => call_opt(&self.on_ann, ann).await,
+            ToolLive::Usage(usage) => call_opt(&self.on_usage, usage).await,
         };
         if let Some(Err(e)) = res {
             tracing::warn!(tool = self.tool, error = %e, "call_tool callback failed");
@@ -668,8 +697,8 @@ struct SessionState {
     subagent_info: Arc<OnceLock<SubagentInfo>>,
     local_tools: LocalTools,
     name: String,
-    total_input: Arc<AtomicU32>,
-    total_output: Arc<AtomicU32>,
+    usage: Arc<Mutex<(TokenUsage, Option<f64>)>>,
+    usage_sync_rx: flume::Receiver<()>,
     start: Instant,
     closed: bool,
 }
@@ -686,11 +715,12 @@ impl SessionState {
             tool_use_id: self.ui_id.clone(),
             messages,
         });
+        let usage = self.usage.lock().unwrap_or_else(|e| e.into_inner());
         info!(
             name = %self.name,
             duration_ms = self.start.elapsed().as_millis() as u64,
-            input_tokens = self.total_input.load(Ordering::Relaxed),
-            output_tokens = self.total_output.load(Ordering::Relaxed),
+            input_tokens = usage.0.total_input(),
+            output_tokens = usage.0.output,
             "subagent session closed",
         );
     }
@@ -780,6 +810,9 @@ async fn prompt(
     if let Err(e) = result {
         return Ok((None, Some(e.to_string())));
     }
+    if s.usage_sync_rx.recv_async().await.is_err() {
+        tracing::warn!(name = %s.name, "subagent usage tracker stopped, token counts may lag");
+    }
 
     let text = s
         .history
@@ -798,8 +831,9 @@ async fn prompt(
     let tbl = lua.create_table()?;
     tbl.set("text", text)?;
     tbl.set("duration_ms", s.start.elapsed().as_millis() as u64)?;
-    tbl.set("input_tokens", s.total_input.load(Ordering::Relaxed))?;
-    tbl.set("output_tokens", s.total_output.load(Ordering::Relaxed))?;
+    let usage = s.usage.lock().unwrap_or_else(|e| e.into_inner());
+    tbl.set("input_tokens", usage.0.total_input())?;
+    tbl.set("output_tokens", usage.0.output)?;
     Ok((Some(tbl), None))
 }
 
@@ -841,6 +875,8 @@ fn call_local_tool(
 
 #[cfg(test)]
 mod tests {
+    use maki_agent::TurnCompleteEvent;
+    use maki_providers::Message;
     use serde_json::json;
 
     use super::*;
@@ -870,5 +906,130 @@ mod tests {
         assert!(raised.contains("boom"), "got: {raised}");
         let wrong = call("function() return 42 end", input).unwrap_err();
         assert!(wrong.contains("expected string"), "got: {wrong}");
+    }
+
+    #[test]
+    fn relay_session_events_accumulates_usage_before_done() {
+        const MODEL: &str = "test-model";
+        const PARENT_ID: &str = "task-1";
+        const NAME: &str = "research";
+        const IGNORED_ERROR: &str = "handled by the session caller";
+        const EXPECTED_LIVE: &[&str] = &["100↑ 20↓ $0.250", "150↑ 30↓ $0.750"];
+
+        let (sub_tx, sub_rx) = flume::unbounded();
+        let (parent_raw_tx, parent_rx) = flume::unbounded();
+        let parent_tx = EventSender::new(parent_raw_tx, 7);
+        let subagent_info = Arc::new(OnceLock::new());
+        subagent_info
+            .set(SubagentInfo {
+                parent_tool_use_id: PARENT_ID.into(),
+                name: NAME.into(),
+                prompt: None,
+                model: Some(MODEL.into()),
+                answer_tx: None,
+            })
+            .unwrap();
+        let cumulative = Arc::new(Mutex::new((TokenUsage::default(), None)));
+        let (sync_tx, sync_rx) = flume::unbounded();
+        let (live_tx, live_rx) = flume::unbounded();
+
+        for (usage, cost) in [
+            (
+                TokenUsage {
+                    input: 100,
+                    output: 20,
+                    ..Default::default()
+                },
+                0.25,
+            ),
+            (
+                TokenUsage {
+                    input: 50,
+                    output: 10,
+                    ..Default::default()
+                },
+                0.5,
+            ),
+        ] {
+            sub_tx
+                .send(Envelope {
+                    event: AgentEvent::TurnComplete(Box::new(TurnCompleteEvent {
+                        message: Message::default(),
+                        usage,
+                        model: MODEL.into(),
+                        cost: Some(cost),
+                        context_size: None,
+                    })),
+                    subagent: None,
+                    run_id: 7,
+                })
+                .unwrap();
+        }
+        sub_tx
+            .send(Envelope {
+                event: AgentEvent::Error {
+                    message: IGNORED_ERROR.into(),
+                },
+                subagent: None,
+                run_id: 7,
+            })
+            .unwrap();
+        sub_tx
+            .send(Envelope {
+                event: AgentEvent::Done {
+                    usage: TokenUsage::default(),
+                    num_turns: 2,
+                    stop_reason: None,
+                },
+                subagent: None,
+                run_id: 7,
+            })
+            .unwrap();
+        drop(sub_tx);
+
+        smol::block_on(relay_session_events(
+            sub_rx,
+            parent_tx,
+            Arc::clone(&subagent_info),
+            Arc::clone(&cumulative),
+            sync_tx,
+            Some(live_tx),
+        ));
+
+        assert_eq!(
+            *cumulative.lock().unwrap(),
+            (
+                TokenUsage {
+                    input: 150,
+                    output: 30,
+                    ..Default::default()
+                },
+                Some(0.75)
+            )
+        );
+        let live = live_rx
+            .drain()
+            .filter_map(|event| match event {
+                ToolLive::Usage(usage) => Some(usage),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(live, EXPECTED_LIVE);
+        assert_eq!(sync_rx.try_recv(), Ok(()));
+        assert!(sync_rx.try_recv().is_err());
+
+        let forwarded = parent_rx.drain().collect::<Vec<_>>();
+        assert_eq!(forwarded.len(), 2);
+        assert!(
+            forwarded
+                .iter()
+                .all(|envelope| matches!(envelope.event, AgentEvent::TurnComplete(_)))
+        );
+        assert!(forwarded.iter().all(|envelope| {
+            envelope
+                .subagent
+                .as_ref()
+                .is_some_and(|info| info.parent_tool_use_id == PARENT_ID)
+        }));
     }
 }

--- a/maki-lua/src/api/ui/mod.rs
+++ b/maki-lua/src/api/ui/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use humantime::format_duration;
+use maki_agent::{RIGHT_TIMESTAMP_STYLE, RIGHT_USAGE_STYLE};
 use maki_lua_macro::{lua_fn, lua_table};
 use mlua::{Lua, Result as LuaResult, Table};
 
@@ -233,6 +234,25 @@ fn truncate_text(lua: &Lua, text: String, max_width: usize) -> LuaResult<Table> 
     Ok(tbl)
 }
 
+/// Builds the two trailing spans of a tool header line: token usage and a
+/// timestamp. Append them, in this order, as the last spans of the line and
+/// the UI re-renders them flush right instead of inline.
+///
+/// @param usage string Formatted token usage, e.g. `"12.3k↑ 456↓ $0.123"`.
+/// @param timestamp string Wall-clock time, e.g. `"12:34:56"`.
+/// @return (table, table) Usage span and timestamp span.
+/// @example
+/// local usage, timestamp = maki.ui.right_info("12.3k↑ 456↓", os.date("%H:%M:%S"))
+/// spans[#spans + 1] = usage
+/// spans[#spans + 1] = timestamp
+#[lua_fn]
+fn right_info(lua: &Lua, usage: String, timestamp: String) -> LuaResult<(Table, Table)> {
+    Ok((
+        lua.create_sequence_from([usage, RIGHT_USAGE_STYLE.to_owned()])?,
+        lua.create_sequence_from([timestamp, RIGHT_TIMESTAMP_STYLE.to_owned()])?,
+    ))
+}
+
 /// Shows a brief message in the status bar. The message disappears
 /// after a short time. Good for confirming an action like "copied!"
 /// or showing a transient warning.
@@ -419,7 +439,7 @@ lua_table! {
     /// ```
     extend "maki.ui" => pub(crate) fn add_ui_fns(), DOCS [
         buf, theme_color, highlight, markdown, humantime, terminal_size,
-        display_width, truncate_text,
+        display_width, truncate_text, right_info,
         manual flash, manual open_editor, manual open_win, manual set_status_hint,
     ]
 }

--- a/maki-lua/tests/batch_policy.rs
+++ b/maki-lua/tests/batch_policy.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 
 use maki_agent::tools::ToolRegistry;
 use maki_agent::tools::test_support::{stub_ctx, stub_ctx_with};
-use maki_agent::{AgentEvent, AgentMode, BufferSnapshot, EventSender, SpanStyle, ToolOutput};
+use maki_agent::{
+    AgentEvent, AgentMode, BufferSnapshot, EventSender, RIGHT_TIMESTAMP_STYLE, RIGHT_USAGE_STYLE,
+    SpanStyle, ToolOutput,
+};
 use maki_config::ToolOutputLines;
 use maki_lua::PluginHost;
 use serde_json::{Value, json};
@@ -42,6 +45,14 @@ maki.agent.call_tool = function(ctx, name, input, opts)
       opts.on_annotation("5 lines")
     end
     return "annotated_done"
+  elseif name == "used" then
+    if opts and opts.on_annotation then
+      opts.on_annotation("model-x")
+    end
+    if opts and opts.on_usage then
+      opts.on_usage("12.3k↑ 456↓ $0.123")
+    end
+    return "used_done"
   elseif name == "park" then
     -- Deadlocks unless a sibling runs concurrently and releases.
     local p = sem:acquire()
@@ -484,6 +495,80 @@ fn restore_child_body_equals_child_restore_view() {
 /// A child can annotate more than once (a task child streams its model,
 /// then its completion note arrives on the same channel); batch joins
 /// them on the child header in order.
+#[test]
+fn usage_and_timestamp_markers_are_on_matching_child() {
+    let (reg, host) = load_batch_host();
+    let input = json!({ "tool_calls": [
+        { "tool": "used", "parameters": {} },
+        { "tool": "ok", "parameters": { "tag": "b" } }
+    ] });
+    let (tx, rx) = flume::unbounded();
+    let event_tx = EventSender::new(tx, 0);
+    let mut ctx = stub_ctx_with(&AgentMode::Build, Some(&event_tx), Some(BATCH_ID));
+    ctx.registry = Arc::clone(&reg);
+    let entry = reg.get(BATCH_TOOL).unwrap();
+    let inv = entry.tool.parse(&input).unwrap();
+    let done = smol::block_on(async { inv.execute(&ctx).await });
+    assert!(done.output.is_ok(), "batch failed: {:?}", done.output);
+    let state = done.output.as_ref().unwrap().state().cloned().unwrap();
+    assert_eq!(state["children"][0]["usage"], "12.3k↑ 456↓ $0.123");
+    assert!(state["children"][0]["usage_timestamp"].is_string());
+    host.load_source("usage_barrier", "").unwrap();
+    let lines = rx
+        .drain()
+        .filter_map(|env| match env.event {
+            AgentEvent::ToolSnapshot { snapshot, .. } => Some(snapshot),
+            _ => None,
+        })
+        .last()
+        .expect("usage snapshot")
+        .lines
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| (span.text.clone(), span.style.clone()))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let first = lines[0]
+        .iter()
+        .map(|(text, _)| text.as_str())
+        .collect::<String>();
+    assert!(
+        first.contains("model-x"),
+        "model annotation missing: {first}"
+    );
+    let usage = lines[0]
+        .iter()
+        .find(|(_, style)| *style == SpanStyle::Named(RIGHT_USAGE_STYLE.to_owned()));
+    assert_eq!(
+        usage.map(|(text, _)| text.as_str()),
+        Some("12.3k↑ 456↓ $0.123")
+    );
+    let timestamp = lines[0]
+        .iter()
+        .find(|(_, style)| *style == SpanStyle::Named(RIGHT_TIMESTAMP_STYLE.to_owned()))
+        .map(|(text, _)| text.as_str());
+    assert!(
+        timestamp.is_some_and(|timestamp| {
+            timestamp.len() == 8
+                && timestamp.chars().enumerate().all(|(i, c)| {
+                    matches!(i, 2 | 5) && c == ':' || !matches!(i, 2 | 5) && c.is_ascii_digit()
+                })
+        }),
+        "timestamp must be HH:MM:SS and rightmost: {first}"
+    );
+    let second = lines[4]
+        .iter()
+        .map(|(text, _)| text.as_str())
+        .collect::<String>();
+    assert!(
+        !second.contains("12.3k↑"),
+        "usage leaked to sibling: {second}"
+    );
+}
+
 #[test]
 fn annotations_append_on_child_in_order() {
     let (reg, _host) = load_batch_host();

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -1,13 +1,58 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use maki_agent::tools::{ToolRegistry, ToolSource, timeout_annotation};
+use maki_agent::ToolOutput;
+use maki_agent::tools::{
+    DescriptionContext, ExecFuture, HeaderFuture, HeaderResult, ParseError, Tool, ToolContext,
+    ToolExecResult, ToolInvocation, ToolLive, ToolRegistry, ToolSource, timeout_annotation,
+};
 use maki_config::{AlwaysThinking, PluginsConfig, ToolOutputLines};
 use maki_lua::{PluginError, PluginHost, WARM_TOOL_CAP};
-use std::path::Path;
+use serde_json::{Value, json};
 
 const NARGS_ERR: &str = r#"'nargs' must be 0, 1, "?", "*", or "+""#;
+const USAGE_TOOL_NAME: &str = "usage_child";
+const USAGE_VALUE: &str = "12.3k↑ 456↓ $0.123";
+
+struct UsageTool;
+
+struct UsageInvocation;
+
+impl ToolInvocation for UsageInvocation {
+    fn start_header(&self) -> HeaderFuture {
+        HeaderFuture::Ready(HeaderResult::plain(USAGE_TOOL_NAME.into()))
+    }
+
+    fn execute<'a>(self: Box<Self>, ctx: &'a ToolContext) -> ExecFuture<'a> {
+        Box::pin(async move {
+            if let Some(sink) = &ctx.live_sink {
+                let _ = sink.send(ToolLive::Usage(USAGE_VALUE.into()));
+            }
+            ToolExecResult::from(Ok::<_, String>(ToolOutput::Plain("usage_done".into())))
+        })
+    }
+}
+
+impl Tool for UsageTool {
+    fn name(&self) -> &str {
+        USAGE_TOOL_NAME
+    }
+
+    fn description(&self, _ctx: &DescriptionContext) -> Cow<'_, str> {
+        "emits usage".into()
+    }
+
+    fn schema(&self) -> Value {
+        json!({"type": "object", "properties": {}, "additionalProperties": false})
+    }
+
+    fn parse(&self, _input: &Value) -> Result<Box<dyn ToolInvocation>, ParseError> {
+        Ok(Box::new(UsageInvocation))
+    }
+}
 
 fn fresh_registry() -> Arc<ToolRegistry> {
     Arc::new(ToolRegistry::new())
@@ -1617,6 +1662,13 @@ fn warm_click_survives_post_completion_cancel() {
 #[test]
 fn call_tool_streams_live_buf_and_annotations() {
     let reg = fresh_registry();
+    reg.register(
+        Arc::new(UsageTool),
+        ToolSource::Lua {
+            plugin: Arc::from("usage_fixture"),
+        },
+    )
+    .unwrap();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
     let src = format!(
         r#"
@@ -1661,20 +1713,23 @@ maki.api.register_tool({{
             on_annotation = function(a) ann = a end,
         }})
         local live_text = "none"
-        local ann2 = "nil"
         local text2 = maki.agent.call_tool(ctx, "streaming_child", {{}}, {{
             on_live_buf = function(b)
                 local lines = b:get_lines()
                 live_text = lines[1] and lines[1][1] and lines[1][1][1] or "empty"
             end,
-            on_annotation = function(a) ann2 = a end,
+        }})
+        local usage = "nil"
+        local text3 = maki.agent.call_tool(ctx, "{USAGE_TOOL_NAME}", {{}}, {{
+            on_usage = function(value) usage = value end,
         }})
         local ann3 = "nil"
         local _, err3 = maki.agent.call_tool(ctx, "failing_child", {{}}, {{
             on_annotation = function(a) ann3 = a end,
         }})
         return tostring(text) .. "/" .. ann
-            .. " " .. tostring(text2) .. "/" .. live_text .. "/" .. ann2
+            .. " " .. tostring(text2) .. "/" .. live_text
+            .. " " .. tostring(text3) .. "/" .. usage
             .. " " .. tostring(err3) .. "/" .. ann3
     end
 }})
@@ -1690,7 +1745,8 @@ maki.api.register_tool({{
     .expect("driver ok");
     assert_eq!(
         out,
-        "child_done/5 items stream_done/streamed line/1 lines boom/nil"
+        "child_done/5 items stream_done/streamed line \
+         usage_done/12.3k↑ 456↓ $0.123 boom/nil"
     );
 }
 

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -10,7 +10,7 @@ pub(crate) mod types;
 pub use error::AgentError;
 pub use model::{
     FastPricing, Model, ModelEntry, ModelError, ModelFamily, ModelInfo, ModelPricing, ModelTier,
-    TokenUsage,
+    TokenUsage, format_tokens,
 };
 pub use providers::Timeouts;
 pub use providers::copilot::auth as copilot_auth;

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -431,11 +431,25 @@ impl From<TokenUsage> for StoredTokenUsage {
 
 impl TokenUsage {
     pub fn total_input(&self) -> u32 {
-        self.input + self.cache_read + self.cache_creation
+        self.input
+            .saturating_add(self.cache_read)
+            .saturating_add(self.cache_creation)
     }
 
     pub fn context_tokens(&self) -> u32 {
-        self.input + self.output + self.cache_creation + self.cache_read
+        self.total_input().saturating_add(self.output)
+    }
+
+    pub fn format(&self, cost: Option<f64>) -> String {
+        let tokens = format!(
+            "{}↑ {}↓",
+            format_tokens(self.total_input()),
+            format_tokens(self.output)
+        );
+        match cost {
+            Some(cost) => format!("{tokens} ${cost:.3}"),
+            None => tokens,
+        }
     }
 
     pub fn cost(&self, pricing: &ModelPricing, fast: bool) -> f64 {
@@ -460,12 +474,20 @@ impl TokenUsage {
     }
 }
 
+pub fn format_tokens(tokens: u32) -> String {
+    match tokens {
+        0..1_000 => tokens.to_string(),
+        1_000..1_000_000 => format!("{:.1}k", f64::from(tokens) / 1_000.0),
+        _ => format!("{:.1}m", f64::from(tokens) / 1_000_000.0),
+    }
+}
+
 impl AddAssign for TokenUsage {
     fn add_assign(&mut self, rhs: Self) {
-        self.input += rhs.input;
-        self.output += rhs.output;
-        self.cache_creation += rhs.cache_creation;
-        self.cache_read += rhs.cache_read;
+        self.input = self.input.saturating_add(rhs.input);
+        self.output = self.output.saturating_add(rhs.output);
+        self.cache_creation = self.cache_creation.saturating_add(rhs.cache_creation);
+        self.cache_read = self.cache_read.saturating_add(rhs.cache_read);
     }
 }
 
@@ -480,6 +502,23 @@ mod tests {
         ModelTier::Strong,
         ModelTier::Compaction,
     ];
+
+    #[test_case(999, "999"             ; "under_thousand")]
+    #[test_case(1_000, "1.0k"          ; "thousand")]
+    #[test_case(12_345, "12.3k"        ; "thousands")]
+    #[test_case(999_999, "1000.0k"     ; "just_under_million")]
+    #[test_case(1_000_000, "1.0m"      ; "million")]
+    #[test_case(1_500_000, "1.5m"      ; "millions")]
+    fn format_tokens_display(tokens: u32, expected: &str) {
+        assert_eq!(format_tokens(tokens), expected);
+    }
+
+    #[test_case(TokenUsage { input: 12_000, output: 456, cache_creation: 200, cache_read: 100 }, None, "12.3k↑ 456↓" ; "without_cost")]
+    #[test_case(TokenUsage { input: 1_000_000, output: 100_000, cache_creation: 200_000, cache_read: 500_000 }, Some(5.4), "1.7m↑ 100.0k↓ $5.400" ; "with_cost")]
+    #[test_case(TokenUsage { input: u32::MAX, output: 1, cache_creation: 1, cache_read: 1 }, None, "4295.0m↑ 1↓" ; "input_saturates")]
+    fn usage_formatting(usage: TokenUsage, cost: Option<f64>, expected: &str) {
+        assert_eq!(usage.format(cost), expected);
+    }
 
     #[test_case("no-slash-here", ModelError::InvalidFormat ; "invalid_format")]
     #[test_case("foobar/gpt-4", ModelError::UnsupportedProvider("foobar".into()) ; "unsupported_provider")]

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -70,20 +70,22 @@ pub struct StoredTokenUsage {
 
 impl StoredTokenUsage {
     pub fn total_input(&self) -> u32 {
-        self.input + self.cache_read + self.cache_creation
+        self.input
+            .saturating_add(self.cache_read)
+            .saturating_add(self.cache_creation)
     }
 
     pub fn total(&self) -> u32 {
-        self.input + self.output + self.cache_creation + self.cache_read
+        self.total_input().saturating_add(self.output)
     }
 }
 
 impl std::ops::AddAssign for StoredTokenUsage {
     fn add_assign(&mut self, rhs: Self) {
-        self.input += rhs.input;
-        self.output += rhs.output;
-        self.cache_creation += rhs.cache_creation;
-        self.cache_read += rhs.cache_read;
+        self.input = self.input.saturating_add(rhs.input);
+        self.output = self.output.saturating_add(rhs.output);
+        self.cache_creation = self.cache_creation.saturating_add(rhs.cache_creation);
+        self.cache_read = self.cache_read.saturating_add(rhs.cache_read);
     }
 }
 
@@ -1281,9 +1283,9 @@ mod tests {
     use super::StoredThinking;
     use super::ThinkingParseError;
     use super::{
-        CWD_INDEX_FILE, DEFAULT_TITLE, MAX_TITLE_LEN, SESSION_VERSION, StoredSubagent, TAIL_BUF,
-        generate_title, json_path, jsonl_path, load_cwd_index, update_cwd_index,
-        write_full_session,
+        CWD_INDEX_FILE, DEFAULT_TITLE, MAX_TITLE_LEN, SESSION_VERSION, StoredSubagent,
+        StoredTokenUsage, TAIL_BUF, generate_title, json_path, jsonl_path, load_cwd_index,
+        update_cwd_index, write_full_session,
     };
     use super::{SCAN_CACHE_FILE, Session, SessionError, SessionLog, StorageError, TitleSource};
     use crate::id::MakiId;
@@ -1294,6 +1296,29 @@ mod tests {
     use std::path::Path;
     use tempfile::TempDir;
     use test_case::test_case;
+
+    #[test]
+    fn stored_token_usage_saturates() {
+        let mut usage = StoredTokenUsage {
+            input: u32::MAX,
+            output: u32::MAX,
+            cache_creation: 1,
+            cache_read: 1,
+        };
+        usage += StoredTokenUsage {
+            input: 1,
+            output: 1,
+            cache_creation: u32::MAX,
+            cache_read: u32::MAX,
+        };
+
+        assert_eq!(usage.total_input(), u32::MAX);
+        assert_eq!(usage.total(), u32::MAX);
+        assert_eq!(usage.input, u32::MAX);
+        assert_eq!(usage.output, u32::MAX);
+        assert_eq!(usage.cache_creation, u32::MAX);
+        assert_eq!(usage.cache_read, u32::MAX);
+    }
 
     type TestSession = Session<Value, Value, Value>;
 

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -44,7 +44,6 @@ use crate::components::scrollbar;
 use crate::components::search_modal::{SearchAction, SearchModal};
 use crate::components::status_bar::StatusBar;
 use crate::components::theme_picker::{ThemePicker, ThemePickerAction};
-use crate::components::tool_display::format_turn_usage;
 use crate::components::usage_modal::{UsageFetchState, UsageModal};
 use crate::components::{
     Action, DisplayMessage, DisplayRole, ExitRequest, Overlay, RetryInfo, Status, is_ctrl,
@@ -986,7 +985,6 @@ impl App {
             .subagent
             .as_ref()
             .map(|s| s.parent_tool_use_id.clone());
-
         let chat_idx = match envelope.subagent {
             Some(ref subagent) => self.resolve_or_create_chat(subagent),
             None => 0,
@@ -1040,6 +1038,10 @@ impl App {
         if let AgentEvent::TurnComplete(ref tc) = envelope.event {
             self.state.token_usage += tc.usage;
             self.chats[chat_idx].token_usage += tc.usage;
+            if let Some(turn_cost) = tc.cost {
+                let cost = &mut self.chats[chat_idx].cost;
+                *cost = Some(cost.unwrap_or_default() + turn_cost);
+            }
             *self
                 .state
                 .session
@@ -1052,9 +1054,13 @@ impl App {
             if chat_idx == 0 {
                 self.state.context_size = ctx_size;
             }
-            let formatted =
-                format_turn_usage(&tc.usage, &self.state.model.pricing, self.state.fast);
-            self.chats[chat_idx].set_pending_turn_usage(formatted);
+            if let Some(tool_id) = &subagent_id {
+                let chat = &self.chats[chat_idx];
+                let formatted = chat.token_usage.format(chat.cost);
+                self.chats[0].set_tool_turn_usage(tool_id, formatted);
+            } else {
+                self.chats[chat_idx].set_pending_turn_usage(tc.usage.format(tc.cost));
+            }
         }
 
         let result = self.chats[chat_idx].handle_event(envelope.event, plan_path);

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -668,6 +668,7 @@ fn turn_complete_tracks_usage_and_context_per_chat() {
             message: Default::default(),
             usage: main_usage,
             model: "test".into(),
+            cost: None,
             context_size: None,
         },
     ))));
@@ -682,6 +683,7 @@ fn turn_complete_tracks_usage_and_context_per_chat() {
             message: Default::default(),
             usage: sub_usage,
             model: "test".into(),
+            cost: None,
             context_size: None,
         })),
         "task1",
@@ -694,6 +696,51 @@ fn turn_complete_tracks_usage_and_context_per_chat() {
     assert_eq!(app.chats[1].token_usage.input, 200);
     assert_eq!(app.chats[0].context_size, main_usage.context_tokens());
     assert_eq!(app.chats[1].context_size, sub_usage.context_tokens());
+}
+
+#[test]
+fn subagent_turn_complete_updates_matching_parent_header_cumulatively() {
+    let mut app = test_app();
+    app.status = Status::Streaming;
+    app.run_id = 1;
+    for id in ["task1", "task2"] {
+        app.update(agent_msg(AgentEvent::ToolStart(Box::new(ToolStartEvent {
+            id: id.into(),
+            tool: "task".into(),
+            summary: id.into(),
+            annotation: None,
+            input: None,
+            raw_input: None,
+            output: None,
+            render_header: None,
+        }))));
+    }
+
+    let usage = TokenUsage {
+        input: 1_000,
+        output: 200,
+        cache_creation: 300,
+        cache_read: 400,
+    };
+    for _ in 0..2 {
+        app.update(subagent_msg(
+            AgentEvent::TurnComplete(Box::new(TurnCompleteEvent {
+                message: Default::default(),
+                usage,
+                model: "child-model".into(),
+                cost: Some(0.007),
+                context_size: None,
+            })),
+            "task1",
+            Some("research"),
+        ));
+    }
+
+    assert_eq!(
+        app.chats[0].tool_turn_usage("task1"),
+        Some("3.4k↑ 400↓ $0.014")
+    );
+    assert_eq!(app.chats[0].tool_turn_usage("task2"), None);
 }
 
 #[test]
@@ -710,6 +757,7 @@ fn turn_complete_accumulates_usage_by_model() {
                 ..Default::default()
             },
             model: "main-model".into(),
+            cost: None,
             context_size: None,
         },
     ))));
@@ -722,6 +770,7 @@ fn turn_complete_accumulates_usage_by_model() {
                 ..Default::default()
             },
             model: "sub-model".into(),
+            cost: None,
             context_size: None,
         })),
         "task1",
@@ -2310,6 +2359,7 @@ fn stale_non_terminal_event_does_not_save_session() {
             message: Message::user(String::new()),
             usage: TokenUsage::default(),
             model: "mock".into(),
+            cost: None,
             context_size: None,
         })),
         old_run_id,

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -42,6 +42,7 @@ pub enum ChatEventResult {
 pub struct Chat {
     pub name: String,
     pub token_usage: TokenUsage,
+    pub cost: Option<f64>,
     pub context_size: u32,
     pub model_id: Option<String>,
     pending_turn_usage: Option<String>,
@@ -54,6 +55,7 @@ impl Chat {
         Self {
             name,
             token_usage: TokenUsage::default(),
+            cost: None,
             context_size: 0,
             model_id: None,
             pending_turn_usage: None,
@@ -301,6 +303,10 @@ impl Chat {
         self.messages_panel.update_tool_model(tool_id, model);
     }
 
+    pub fn set_tool_turn_usage(&mut self, tool_id: &str, usage: String) {
+        self.messages_panel.set_tool_turn_usage(tool_id, usage);
+    }
+
     pub fn load_messages(&mut self, msgs: Vec<DisplayMessage>) {
         self.messages_panel.load_messages(msgs);
     }
@@ -363,6 +369,11 @@ impl Chat {
     #[cfg(test)]
     pub fn streaming_thinking_is_empty(&self) -> bool {
         self.messages_panel.streaming_thinking_is_empty()
+    }
+
+    #[cfg(test)]
+    pub fn tool_turn_usage(&self, tool_id: &str) -> Option<&str> {
+        self.messages_panel.tool_turn_usage(tool_id)
     }
 }
 

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -313,19 +313,21 @@ impl MessagesPanel {
     }
 
     pub fn set_turn_usage_on_last_tool(&mut self, usage: String) {
-        let Some(idx) = self
-            .messages
-            .iter()
-            .rposition(|m| matches!(m.role, DisplayRole::Tool(_)))
-        else {
+        let Some(id) = self.messages.iter().rev().find_map(|msg| match &msg.role {
+            DisplayRole::Tool(tool) => Some(tool.id.clone()),
+            _ => None,
+        }) else {
             return;
         };
-        self.messages[idx].turn_usage = Some(usage);
-        let DisplayRole::Tool(t) = &self.messages[idx].role else {
-            unreachable!()
-        };
-        let id = t.id.clone();
-        self.rebuild_tool_segment(&id);
+        self.set_tool_turn_usage(&id, usage);
+    }
+
+    pub fn set_tool_turn_usage(&mut self, tool_id: &str, usage: String) {
+        let timestamp = format_timestamp_now();
+        self.update_tool(tool_id, |msg| {
+            msg.turn_usage = Some(usage);
+            msg.timestamp = Some(timestamp);
+        });
     }
 
     fn upsert_instruction_segment(
@@ -497,6 +499,19 @@ impl MessagesPanel {
     #[cfg(test)]
     pub fn streaming_thinking_is_empty(&self) -> bool {
         self.streaming_thinking.is_empty()
+    }
+
+    #[cfg(test)]
+    pub fn tool_turn_usage(&self, tool_id: &str) -> Option<&str> {
+        self.messages.iter().rev().find_map(|msg| match &msg.role {
+            DisplayRole::Tool(tool) if tool.id == tool_id => msg.turn_usage.as_deref(),
+            _ => None,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn set_tool_timestamp(&mut self, tool_id: &str, timestamp: &str) {
+        self.update_tool(tool_id, |msg| msg.timestamp = Some(timestamp.to_owned()));
     }
 
     pub fn set_prompt_progress(&mut self, progress: Option<PromptProgress>) {

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -579,6 +579,25 @@ fn update_tool_model_sets_annotation() {
 }
 
 #[test]
+fn set_tool_turn_usage_updates_exact_tool_and_preserves_annotation() {
+    let mut panel = panel_with_tools(&[("t1", "task"), ("t2", "task")]);
+    panel.update_tool_model("t1", "anthropic/claude-sonnet-4-20250514");
+    panel.set_tool_timestamp("t1", "invalid");
+    panel.set_tool_timestamp("t2", "sibling");
+
+    panel.set_tool_turn_usage("t1", "1.2k↑ 345↓ $0.010".into());
+
+    assert_eq!(panel.tool_turn_usage("t1"), Some("1.2k↑ 345↓ $0.010"));
+    assert_ne!(panel.messages[0].timestamp.as_deref(), Some("invalid"));
+    assert_eq!(panel.tool_turn_usage("t2"), None);
+    assert_eq!(panel.messages[1].timestamp.as_deref(), Some("sibling"));
+    assert_eq!(
+        panel.messages[0].annotation.as_deref(),
+        Some("anthropic/claude-sonnet-4-20250514")
+    );
+}
+
+#[test]
 fn scroll_clamps_to_max_scroll() {
     let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.streaming_text.set_buffer(&"a\n".repeat(15));

--- a/maki-ui/src/components/status_bar.rs
+++ b/maki-ui/src/components/status_bar.rs
@@ -8,7 +8,7 @@ use super::{RetryInfo, Status};
 use crate::animation::spinner_frame;
 use crate::theme;
 
-use maki_providers::{ModelPricing, TokenUsage};
+use maki_providers::{ModelPricing, TokenUsage, format_tokens};
 use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::Style;
@@ -17,14 +17,6 @@ use ratatui::widgets::Paragraph;
 
 const FAST_LABEL: &str = " [fast]";
 const WORKFLOW_LABEL: &str = " [workflow]";
-
-pub(crate) fn format_tokens(n: u32) -> String {
-    match n {
-        0..1_000 => n.to_string(),
-        1_000..1_000_000 => format!("{:.1}k", n as f64 / 1_000.0),
-        _ => format!("{:.1}m", n as f64 / 1_000_000.0),
-    }
-}
 
 pub struct UsageStats<'a> {
     pub usage: &'a TokenUsage,
@@ -315,16 +307,6 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
     use test_case::test_case;
-
-    #[test_case(999, "999")]
-    #[test_case(1_000, "1.0k")]
-    #[test_case(12_345, "12.3k")]
-    #[test_case(999_999, "1000.0k")]
-    #[test_case(1_000_000, "1.0m")]
-    #[test_case(1_500_000, "1.5m")]
-    fn format_tokens_display(input: u32, expected: &str) {
-        assert_eq!(format_tokens(input), expected);
-    }
 
     #[test_case("/home/user/projects/app", "/home/user", "~/projects/app" ; "inside_home")]
     #[test_case("/tmp/other", "/home/user", "/tmp/other"                  ; "outside_home")]

--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -1,4 +1,3 @@
-use super::status_bar::format_tokens;
 use super::{DisplayMessage, ToolStatus};
 
 use super::code_view;
@@ -15,14 +14,13 @@ use std::time::Instant;
 
 use unicode_width::UnicodeWidthStr;
 
-use maki_providers::{ModelPricing, TokenUsage};
-
 use jiff::Timestamp;
 use jiff::tz::TimeZone;
 
 use crate::markdown::{should_truncate, text_to_lines, truncate_output, truncation_notice};
 use maki_agent::{
-    BufferSnapshot, InstructionBlock, SnapshotSpan, SpanStyle, ToolInput, ToolOutput,
+    BufferSnapshot, InstructionBlock, RIGHT_TIMESTAMP_STYLE, RIGHT_USAGE_STYLE, SnapshotSpan,
+    SpanStyle, ToolInput, ToolOutput,
 };
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
@@ -166,20 +164,6 @@ impl ToolLines {
 pub fn format_timestamp_now() -> String {
     let zoned = Timestamp::now().to_zoned(TimeZone::system());
     zoned.strftime("%H:%M:%S").to_string()
-}
-
-pub fn format_turn_usage(usage: &TokenUsage, pricing: &ModelPricing, fast: bool) -> String {
-    let tokens = format!(
-        "{}↑ {}↓",
-        format_tokens(usage.total_input()),
-        format_tokens(usage.output),
-    );
-    if pricing.is_zero() {
-        tokens
-    } else {
-        let cost = usage.cost(pricing, fast);
-        format!("{tokens} ${cost:.3}")
-    }
 }
 
 pub fn append_right_info(
@@ -494,7 +478,7 @@ impl ToolLineBuilder {
         let total = snapshot.lines.len();
         let frame = spinner_str(started_at.elapsed().as_millis());
         let (lines, spinners) =
-            snapshot_to_lines_range(snapshot, TOOL_BODY_INDENT, 0..total, frame);
+            snapshot_to_lines_range(snapshot, TOOL_BODY_INDENT, 0..total, frame, self.width);
         self.lines.extend(lines);
         self.spinner_lines
             .extend(spinners.into_iter().map(|(line, span)| (base + line, span)));
@@ -560,6 +544,7 @@ fn snapshot_to_lines_range(
     indent: &str,
     range: std::ops::Range<usize>,
     spinner_frame: &'static str,
+    width: u16,
 ) -> (Vec<Line<'static>>, Vec<(usize, usize)>) {
     let mut spinners = Vec::new();
     let lines = snapshot.lines[range]
@@ -567,10 +552,25 @@ fn snapshot_to_lines_range(
         .enumerate()
         .map(|(i, sline)| {
             let mut spans = vec![Span::raw(indent.to_string())];
-            bake_spans(&sline.spans, &mut spans, spinner_frame, |span_idx| {
+            let right_info = sline.spans.split_last().and_then(|(timestamp, rest)| {
+                let (usage, content) = rest.split_last()?;
+                matches!(&usage.style, SpanStyle::Named(name) if name == RIGHT_USAGE_STYLE)
+                    .then_some(())?;
+                matches!(&timestamp.style, SpanStyle::Named(name) if name == RIGHT_TIMESTAMP_STYLE)
+                    .then_some((content, usage.text.as_str(), timestamp.text.as_str()))
+            });
+            let (content, usage, timestamp) = right_info.map_or(
+                (sline.spans.as_slice(), None, None),
+                |(content, usage, timestamp)| (content, Some(usage), Some(timestamp)),
+            );
+            bake_spans(content, &mut spans, spinner_frame, |span_idx| {
                 spinners.push((i, span_idx));
             });
-            Line::from(spans)
+            let mut line = Line::from(spans);
+            if usage.is_some() || timestamp.is_some() {
+                append_right_info(&mut line, usage, timestamp, width);
+            }
+            line
         })
         .collect();
     (lines, spinners)
@@ -1707,7 +1707,7 @@ mod tests {
             text: "content".into(),
             style: SpanStyle::Default,
         }]]);
-        let (lines, _) = snapshot_to_lines_range(&snapshot, ">>", 0..1, "⠋ ");
+        let (lines, _) = snapshot_to_lines_range(&snapshot, ">>", 0..1, "⠋ ", 80);
         assert_eq!(lines.len(), 1);
         let first_span = &lines[0].spans[0];
         assert_eq!(first_span.content.as_ref(), ">>");
@@ -1729,9 +1729,49 @@ mod tests {
                 style: SpanStyle::Default,
             },
         ]]);
-        let (lines, _) = snapshot_to_lines_range(&snapshot, "", 0..1, "⠋ ");
+        let (lines, _) = snapshot_to_lines_range(&snapshot, "", 0..1, "⠋ ", 80);
         let texts: Vec<&str> = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(texts, vec!["", "aaa", "bbb", "ccc"]);
+    }
+
+    #[test_case(80, true  ; "shown_when_width_sufficient")]
+    #[test_case(30, false ; "hidden_when_too_narrow")]
+    fn snapshot_right_info_uses_tool_header_renderer(width: u16, visible: bool) {
+        let snapshot = make_snapshot(vec![vec![
+            SnapshotSpan {
+                text: "● task> Research".into(),
+                style: SpanStyle::Default,
+            },
+            SnapshotSpan {
+                text: "12.3k↑ 456↓ $0.123".into(),
+                style: SpanStyle::Named(RIGHT_USAGE_STYLE.into()),
+            },
+            SnapshotSpan {
+                text: "12:34:56".into(),
+                style: SpanStyle::Named(RIGHT_TIMESTAMP_STYLE.into()),
+            },
+        ]]);
+
+        let (lines, _) = snapshot_to_lines_range(&snapshot, TOOL_BODY_INDENT, 0..1, "⠋ ", width);
+        let line = &lines[0];
+        let text = line
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+
+        assert_eq!(text.ends_with("12.3k↑ 456↓ $0.123  12:34:56"), visible);
+        if visible {
+            assert_eq!(
+                UnicodeWidthStr::width(text.as_str()),
+                usize::from(width) - 1
+            );
+            assert_eq!(
+                line.spans[line.spans.len() - 3].style,
+                theme::current().tool_dim
+            );
+            assert_eq!(line.spans.last().unwrap().style, theme::current().timestamp);
+        }
     }
 
     #[test]
@@ -1752,7 +1792,7 @@ mod tests {
                 },
             ],
         ]);
-        let (lines, spinners) = snapshot_to_lines_range(&snapshot, "", 0..2, "⠹ ");
+        let (lines, spinners) = snapshot_to_lines_range(&snapshot, "", 0..2, "⠹ ", 80);
         assert_eq!(spinners, vec![(1, 2)]);
         assert_eq!(lines[1].spans[2].content.as_ref(), "⠹ ");
     }

--- a/maki-ui/src/components/usage_modal.rs
+++ b/maki-ui/src/components/usage_modal.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crossterm::event::{KeyCode, KeyEvent};
 use jiff::Timestamp;
 use jiff::tz::TimeZone;
-use maki_providers::{Model, ModelPricing, ProviderUsage, TokenUsage};
+use maki_providers::{Model, ModelPricing, ProviderUsage, TokenUsage, format_tokens};
 use maki_storage::sessions::StoredTokenUsage;
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -16,7 +16,6 @@ use crate::components::ModalScroll;
 use crate::components::keybindings::key;
 use crate::components::modal::Modal;
 use crate::components::scrollbar::render_vertical_scrollbar;
-use crate::components::status_bar::format_tokens;
 use crate::theme;
 
 const TITLE: &str = " Token usage ";

--- a/plugins/batch/init.lua
+++ b/plugins/batch/init.lua
@@ -201,6 +201,11 @@ local function child_header_line(c)
   if c.annotation then
     spans[#spans + 1] = { " (" .. c.annotation .. ")", "tool_annotation" }
   end
+  if c.usage then
+    local usage, timestamp = maki.ui.right_info(c.usage, c.usage_timestamp)
+    spans[#spans + 1] = usage
+    spans[#spans + 1] = timestamp
+  end
   return spans
 end
 
@@ -265,7 +270,14 @@ end
 local function to_state(children)
   local out = {}
   for i, c in ipairs(children) do
-    out[i] = { tool = c.tool, status = c.status, output = c.output, annotation = c.annotation }
+    out[i] = {
+      tool = c.tool,
+      status = c.status,
+      output = c.output,
+      annotation = c.annotation,
+      usage = c.usage,
+      usage_timestamp = c.usage_timestamp,
+    }
   end
   return { children = out }
 end
@@ -403,6 +415,12 @@ function Batch:annotate(c, ann)
   self:rerender()
 end
 
+function Batch:set_usage(c, usage)
+  c.usage = usage
+  c.usage_timestamp = os.date("%H:%M:%S")
+  self:rerender()
+end
+
 function Batch:settle(c, status, output)
   if TERMINAL[c.status] then
     error(string.format(RESETTLE_FMT, c.tool, c.status, status))
@@ -425,6 +443,9 @@ function Batch:run_child(c, ctx)
     end,
     on_annotation = function(a)
       self:annotate(c, a)
+    end,
+    on_usage = function(usage)
+      self:set_usage(c, usage)
     end,
   })
   if err then
@@ -508,6 +529,7 @@ local function restore(input, output, _is_error, rctx)
       local c = children[i]
       c.status = TERMINAL[sc.status] and sc.status or STATUS.ERROR
       c.output, c.annotation = sc.output, sc.annotation
+      c.usage, c.usage_timestamp = sc.usage, sc.usage_timestamp
     end
     return Batch.new(children, tol).buf
   end

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -745,8 +745,8 @@ maki.agent.call_tool({ctx}, {name}, {input}, {opts?})
 Run a tool by name and wait for the result. This is how you call built-in
 tools (like `read`, `bash`, `glob`) from Lua without going through the LLM.
 
-Live events (streaming output, annotations) are delivered through optional
-callbacks while the tool runs.
+Live events (streaming output, annotations, cumulative usage) are delivered
+through optional callbacks while the tool runs.
 
 **Parameters:**
 
@@ -759,6 +759,8 @@ callbacks while the tool runs.
     the tool publishes. Must not yield.
   - `on_annotation` (`function?`) called with an annotation string for each
     annotation event. Must not yield.
+  - `on_usage` (`function?`) called with a formatted cumulative token usage
+    string. Must not yield.
 
 **Returns:** (`string?`, `string?`) Tool output text, or `(nil, err)` on failure.
 
@@ -3971,6 +3973,33 @@ Splits a string at a display-cell boundary.
 ```lua
 local t = maki.ui.truncate_text("hello world", 5)
 -- t.head == "hello", t.tail == " world"
+```
+
+---
+
+### `maki.ui.right_info()` {#maki-ui-right_info}
+
+```lua
+maki.ui.right_info({usage}, {timestamp})
+```
+
+Builds the two trailing spans of a tool header line: token usage and a
+timestamp. Append them, in this order, as the last spans of the line and
+the UI re-renders them flush right instead of inline.
+
+**Parameters:**
+
+- `{usage}` (`string`) Formatted token usage, e.g. `"12.3k↑ 456↓ $0.123"`.
+- `{timestamp}` (`string`) Wall-clock time, e.g. `"12:34:56"`.
+
+**Returns:** (`table`, `table`) Usage span and timestamp span.
+
+**Example:**
+
+```lua
+local usage, timestamp = maki.ui.right_info("12.3k↑ 456↓", os.date("%H:%M:%S"))
+spans[#spans + 1] = usage
+spans[#spans + 1] = timestamp
 ```
 
 ---


### PR DESCRIPTION
## Summary

- stream cumulative subagent input, output, and cost usage into task headers
- refresh the task timestamp with every usage update
- render standalone and batched task metadata through the same right-aligned UI path
- preserve batch child usage across restore and saturate token counters

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all --tests -- -D warnings`
- `cargo nextest run --workspace` (3178 passed)
