### PR TITLE
fix: token-savings bug fixes (sessions open/scan_headers, task done tool)

### DIFF
--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -11,7 +11,53 @@ use super::streaming::stream_with_retry;
 use crate::cancel::CancelToken;
 use crate::{AgentError, AgentEvent, EventSender, TurnCompleteEvent};
 
-pub(super) const CONTINUE_AFTER_COMPACT: &str = "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed. If the summary contains a todo list, restore it with todo_write and keep it updated. If you learned important project context during this session, consider saving it to memory before it's lost.";
+pub(super) const CONTINUE_AFTER_COMPACT: &str = "Continue if you have next steps, or stop and ask for clarification if unsure. Restore todo lists with todo_write. Save important context to memory before it's lost.";
+
+const MINIMAL_CONTEXT_RATIO: f64 = 0.2;
+const AGGRESSIVE_CONTEXT_RATIO: f64 = 0.4;
+const NORMAL_BUDGET_RATIO: f64 = 0.15;
+const AGGRESSIVE_BUDGET_RATIO: f64 = 0.10;
+const MINIMAL_BUDGET_RATIO: f64 = 0.05;
+const MIN_COMPACTION_BUDGET: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompactionTier {
+    Normal,
+    Aggressive,
+    Minimal,
+}
+
+impl CompactionTier {
+    #[must_use]
+    pub fn from_remaining_context(remaining: u32, context_window: u32) -> Self {
+        if context_window == 0 {
+            return Self::Normal;
+        }
+        let ratio = f64::from(remaining) / f64::from(context_window);
+        if ratio < MINIMAL_CONTEXT_RATIO {
+            Self::Minimal
+        } else if ratio < AGGRESSIVE_CONTEXT_RATIO {
+            Self::Aggressive
+        } else {
+            Self::Normal
+        }
+    }
+
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    pub fn token_budget(self, context_window: u32) -> u32 {
+        if context_window == 0 {
+            return 0;
+        }
+        let ratio = match self {
+            Self::Normal => NORMAL_BUDGET_RATIO,
+            Self::Aggressive => AGGRESSIVE_BUDGET_RATIO,
+            Self::Minimal => MINIMAL_BUDGET_RATIO,
+        };
+        ((f64::from(context_window) * ratio) as u32).max(MIN_COMPACTION_BUDGET)
+    }
+}
+
 const IMAGE_PLACEHOLDER: &str = "[image]";
 
 pub(super) async fn compact_history(
@@ -26,7 +72,22 @@ pub(super) async fn compact_history(
     strip_images(&mut compaction_history);
     strip_thinking(&mut compaction_history);
     strip_old_tool_results(&mut compaction_history);
-    compaction_history.push(Message::user(crate::prompt::COMPACTION_USER.to_string()));
+
+    let context_window = model.context_window;
+    let current_usage = crate::agent::run::estimate_message_tokens(&compaction_history);
+    let remaining = context_window.saturating_sub(current_usage);
+    let tier = CompactionTier::from_remaining_context(remaining, context_window);
+    let budget = tier.token_budget(context_window);
+
+    let user_prompt = format!(
+        "{}\n\nToken budget: {} tokens (tier: {:?}, remaining: {}/{} context)",
+        crate::prompt::COMPACTION_USER,
+        budget,
+        tier,
+        remaining,
+        context_window
+    );
+    compaction_history.push(Message::user(user_prompt));
 
     let empty_tools = serde_json::json!([]);
     let max_attempts = 3;
@@ -277,6 +338,44 @@ mod tests {
         let mut model = default_model();
         model.context_window = context_window;
         model
+    }
+
+    #[test_case(0,     0, CompactionTier::Normal    ; "zero_context_window_defaults_normal")]
+    #[test_case(0,   100, CompactionTier::Minimal    ; "empty_remaining_is_minimal")]
+    #[test_case(10,  100, CompactionTier::Minimal    ; "low_ratio_minimal")]
+    #[test_case(19,  100, CompactionTier::Minimal    ; "just_below_0_2")]
+    #[test_case(20,  100, CompactionTier::Aggressive ; "at_0_2_boundary")]
+    #[test_case(30,  100, CompactionTier::Aggressive ; "mid_ratio_aggressive")]
+    #[test_case(39,  100, CompactionTier::Aggressive ; "just_below_0_4")]
+    #[test_case(40,  100, CompactionTier::Normal     ; "at_0_4_boundary")]
+    #[test_case(50,  100, CompactionTier::Normal     ; "high_ratio_normal")]
+    #[test_case(199, 1000, CompactionTier::Minimal    ; "just_below_0_2_at_1000")]
+    #[test_case(200, 1000, CompactionTier::Aggressive ; "at_0_2_boundary_1000")]
+    #[test_case(399, 1000, CompactionTier::Aggressive ; "just_below_0_4_at_1000")]
+    #[test_case(400, 1000, CompactionTier::Normal     ; "at_0_4_boundary_1000")]
+    #[test_case(1999, 10000, CompactionTier::Minimal    ; "just_below_0_2_at_10000")]
+    #[test_case(2000, 10000, CompactionTier::Aggressive ; "at_0_2_boundary_10000")]
+    #[test_case(3999, 10000, CompactionTier::Aggressive ; "just_below_0_4_at_10000")]
+    #[test_case(4000, 10000, CompactionTier::Normal     ; "at_0_4_boundary_10000")]
+    fn compaction_tier_from_remaining(
+        remaining: u32,
+        context_window: u32,
+        expected: CompactionTier,
+    ) {
+        assert_eq!(
+            CompactionTier::from_remaining_context(remaining, context_window),
+            expected
+        );
+    }
+
+    #[test_case(CompactionTier::Normal,     100, 15 ; "normal_budget")]
+    #[test_case(CompactionTier::Aggressive, 100, 10 ; "aggressive_budget")]
+    #[test_case(CompactionTier::Minimal,    100,  5 ; "minimal_budget")]
+    #[test_case(CompactionTier::Minimal,      1,  1 ; "tiny_window_minimum_budget")]
+    #[test_case(CompactionTier::Minimal,      2,  1 ; "small_window_still_minimum")]
+    #[test_case(CompactionTier::Normal,       0,  0 ; "zero_window_zero_budget")]
+    fn compaction_tier_budget(tier: CompactionTier, context_window: u32, expected: u32) {
+        assert_eq!(tier.token_budget(context_window), expected);
     }
 
     fn text_response(stop_reason: StopReason) -> StreamResponse {
@@ -586,5 +685,45 @@ mod tests {
         truncate_oldest_round(&mut messages);
         assert!(!messages.is_empty());
         assert!(matches!(messages[0].role, Role::User));
+    }
+
+    #[test]
+    fn compact_produces_user_assistant_pair() {
+        smol::block_on(async {
+            let provider: std::sync::Arc<dyn Provider> =
+                std::sync::Arc::new(MockProvider::new(vec![text_response(StopReason::EndTurn)]));
+            let model = default_model();
+            let (raw_tx, _rx) = flume::unbounded();
+            let mut history = History::new(vec![
+                Message::user("first".into()),
+                Message {
+                    role: Role::Assistant,
+                    content: vec![ContentBlock::Text {
+                        text: "reply".into(),
+                    }],
+                    ..Default::default()
+                },
+            ]);
+
+            compact(
+                &*provider,
+                &model,
+                &mut history,
+                &EventSender::new(raw_tx, 0),
+            )
+            .await
+            .unwrap();
+
+            let msgs = history.as_slice();
+            assert_eq!(msgs.len(), 2);
+            assert!(matches!(msgs[0].role, Role::User));
+            assert!(matches!(msgs[1].role, Role::Assistant));
+            assert!(
+                msgs[0]
+                    .first_text_content()
+                    .unwrap()
+                    .contains("What did we do so far?")
+            );
+        });
     }
 }

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -278,8 +278,9 @@ impl<'h> Agent<'h> {
         if has_tools {
             let history_len_before = self.history.len();
             self.process_tool_calls(response).await?;
-            self.context_size +=
-                estimate_message_tokens(&self.history.as_slice()[history_len_before..]);
+            self.context_size = self.context_size.saturating_add(estimate_message_tokens(
+                &self.history.as_slice()[history_len_before..],
+            ));
         } else {
             let has_text = response.message.first_text_content().is_some();
 
@@ -500,7 +501,17 @@ pub fn estimate_message_tokens(messages: &[Message]) -> u32 {
             _ => None,
         })
         .sum();
-    (total_bytes.max(CHARS_PER_TOKEN) / CHARS_PER_TOKEN) as u32
+    let count = total_bytes.max(CHARS_PER_TOKEN) / CHARS_PER_TOKEN;
+    match u32::try_from(count) {
+        Ok(n) => n,
+        Err(_) => {
+            warn!(
+                count,
+                "estimated token count exceeded u32 range; saturating"
+            );
+            u32::MAX
+        }
+    }
 }
 
 #[cfg(test)]
@@ -980,5 +991,34 @@ mod tests {
                 .expect("expected Done event");
             assert_eq!(done, expected_turns);
         });
+    }
+
+    #[test]
+    fn estimate_message_tokens_empty_is_zero() {
+        assert_eq!(estimate_message_tokens(&[]), 0);
+    }
+
+    #[test]
+    fn estimate_message_tokens_counts_bytes_per_four() {
+        let messages = vec![
+            Message::user("hello world".into()),
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::Text {
+                    text: "response".into(),
+                }],
+                ..Default::default()
+            },
+        ];
+        let count = estimate_message_tokens(&messages);
+        assert_eq!(count, 4, "expected 4 tokens for 19 bytes at 4 bytes/token");
+    }
+
+    #[test]
+    fn context_size_addition_uses_saturating_add() {
+        let context_size: u32 = u32::MAX - 100;
+        let addition: u32 = 200;
+        let result = context_size.saturating_add(addition);
+        assert_eq!(result, u32::MAX);
     }
 }

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -423,6 +423,7 @@ pub(super) async fn process_tool_calls(
 
     let mut all_results = results;
     all_results.extend(immediate_errors);
+
     let tool_msg = crate::types::tool_results(all_results);
     event_tx.send(AgentEvent::ToolResultsSubmitted {
         message: Box::new(tool_msg.clone()),
@@ -780,6 +781,46 @@ mod tests {
                 !executed.load(Ordering::SeqCst),
                 "execute must not run after denial"
             );
+        });
+    }
+
+    #[test]
+    fn local_tool_progress_keywords_returned_unchanged() {
+        smol::block_on(async {
+            const PROGRESS_TEXT: &str = "Building project... 100% complete ==> Done";
+            let ctx = local_ctx("progress", |_| Ok(PROGRESS_TEXT.to_string()));
+            let done = run(
+                ToolRegistry::global(),
+                None,
+                "t1".into(),
+                "progress",
+                &serde_json::json!({}),
+                &ctx,
+                Emit::Silent,
+            )
+            .await;
+            assert!(!done.is_error);
+            assert_eq!(done.output.as_text(), PROGRESS_TEXT);
+        });
+    }
+
+    #[test]
+    fn local_tool_error_preserves_message_unchanged() {
+        smol::block_on(async {
+            const ERROR_MSG: &str = "100% failed";
+            let ctx = local_ctx("fail", |_| Err(ERROR_MSG.to_string()));
+            let done = run(
+                ToolRegistry::global(),
+                None,
+                "t1".into(),
+                "fail",
+                &serde_json::json!({}),
+                &ctx,
+                Emit::Silent,
+            )
+            .await;
+            assert!(done.is_error);
+            assert_eq!(done.output.as_text(), ERROR_MSG);
         });
     }
 }

--- a/maki-agent/src/prompt.rs
+++ b/maki-agent/src/prompt.rs
@@ -51,6 +51,7 @@ pub enum SlotKind {
 pub enum Slot {
     Identity,
     Tone,
+    Environment,
     ToolUsage,
     EfficientTools,
     Conventions,
@@ -62,6 +63,7 @@ impl Slot {
         match self {
             Slot::Identity => "{{identity}}",
             Slot::Tone => "{{tone}}",
+            Slot::Environment => "{{environment}}",
             Slot::ToolUsage => "{{tool_usage}}",
             Slot::EfficientTools => "{{efficient_tools}}",
             Slot::Conventions => "{{conventions}}",
@@ -71,7 +73,7 @@ impl Slot {
 
     pub fn kind(self) -> SlotKind {
         match self {
-            Slot::Identity | Slot::Tone => SlotKind::Singleton,
+            Slot::Identity | Slot::Tone | Slot::Environment => SlotKind::Singleton,
             Slot::ToolUsage
             | Slot::EfficientTools
             | Slot::Conventions
@@ -465,5 +467,56 @@ mod tests {
         let out = assemble(PromptId::System, &s, "");
         assert!(out.contains("Never assume a library is available"));
         assert!(out.contains("- Extra rule"));
+    }
+
+    #[test]
+    fn assemble_system_without_environment_has_no_heading_or_marker() {
+        let out = assemble(PromptId::System, &ResolvedSlots::default(), "");
+        assert!(!out.contains("# Environment"));
+        assert!(!out.contains("{{environment}}"));
+    }
+
+    #[test]
+    fn assemble_system_with_environment_shows_heading_and_content() {
+        const ENV_CONTENT: &str = "# Environment\nCurrent date: 2026-07-21";
+        let mut s = ResolvedSlots::default();
+        s.insert(
+            PromptId::System,
+            Slot::Environment,
+            SlotEntry {
+                plugin: Arc::from("test"),
+                content: ENV_CONTENT.into(),
+            },
+        );
+        let out = assemble(PromptId::System, &s, "");
+        assert!(out.contains("# Environment"));
+        assert!(out.contains("Current date: 2026-07-21"));
+        assert!(!out.contains("{{environment}}"));
+    }
+
+    #[test]
+    fn environment_section_placed_between_objectivity_and_tool_usage() {
+        const ENV_CONTENT: &str = "# Environment\nCurrent date: 2026-07-21";
+        let mut s = ResolvedSlots::default();
+        s.insert(
+            PromptId::System,
+            Slot::Environment,
+            SlotEntry {
+                plugin: Arc::from("test"),
+                content: ENV_CONTENT.into(),
+            },
+        );
+        let out = assemble(PromptId::System, &s, "");
+        let obj_idx = out.find("# Professional objectivity").unwrap();
+        let env_idx = out.find("# Environment").unwrap();
+        let tool_idx = out.find("# Tool usage").unwrap();
+        assert!(
+            obj_idx < env_idx,
+            "Environment should be after Professional objectivity"
+        );
+        assert!(
+            env_idx < tool_idx,
+            "Environment should be before Tool usage"
+        );
     }
 }

--- a/maki-agent/src/prompts/compaction.md
+++ b/maki-agent/src/prompts/compaction.md
@@ -1,14 +1,1 @@
-You are a helpful AI assistant tasked with summarizing conversations.
-
-When asked to summarize, provide a detailed but concise summary of the conversation.
-Focus on information that would be helpful for continuing the conversation, including:
-- What was done
-- What is currently being worked on
-- Which files are being modified
-- What needs to be done next
-- Key user requests, constraints, or preferences that should persist
-- Important technical decisions and why they were made
-
-Your summary should be comprehensive enough to provide context but concise enough to be quickly understood.
-
-Do not respond to any questions in the conversation, only output the summary.
+Summarize the conversation concisely for continuation. Cover: what was done, what's in progress, which files are affected, what's next, key user constraints, and important technical decisions. Output only the summary.

--- a/maki-agent/src/prompts/compaction_user.md
+++ b/maki-agent/src/prompts/compaction_user.md
@@ -1,24 +1,27 @@
-Provide a detailed summary for continuing our conversation above.
-Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next.
+Summarize the conversation above concisely. Focus on:
 
-Stick to this template:
+- Goal and current progress
+- Files being modified
+- Key user constraints
+- Next steps
+
+Use this template:
 ---
 ## Goal
-[What goal(s) is the user trying to accomplish?]
+[What is the user trying to accomplish?]
 
-## Instructions
-- [Important instructions the user gave that are relevant]
-- [If there is a plan or spec, include information about it]
+## Progress
+[What was done, what is in progress, what remains]
 
-## Discoveries
-[Notable things learned during this conversation]
+## Files
+[Relevant files read/edited/created]
 
-## Accomplished
-[What work has been completed, what is still in progress, what is left?]
-
-## Relevant files / directories
-[Structured list of relevant files that have been read, edited, or created]
+## Constraints
+[Key user instructions or preferences]
 
 ## Todo list
-[If a todo list was in use, repeat it here verbatim with each item's current status; it must be kept up to date with todo_write after continuing. Otherwise omit this section]
+[All open todo items, if any, so they can be restored with todo_write]
+
+## Next
+[What to do next]
 ---

--- a/maki-agent/src/prompts/system.md
+++ b/maki-agent/src/prompts/system.md
@@ -6,6 +6,7 @@
 # Professional objectivity
 Prioritize technical accuracy over validating the user's beliefs. Provide direct, objective technical info without unnecessary praise or emotional validation. Disagree when necessary. Objective guidance and respectful correction are more valuable than false agreement.
 
+{{environment}}
 # Tool usage
 - Every tool result grows your context. Minimize use of verbose tool calls, prefer compact results.
 - Use **batch** for parallel calls, **code_execution** for chained/filtered calls, **task** for delegation.
@@ -13,6 +14,12 @@ Prioritize technical accuracy over validating the user's beliefs. Provide direct
 - Read files before editing them. Match surrounding context, conventions, and imports.
 - Prefer edits over full file writes.
 {{tool_usage}}
+
+# Least-privilege tool selection
+Prefer lower-privilege tools when possible:
+- Use **read**/**glob** before **bash** for file inspection
+- Use targeted queries before broad searches
+- Use **code_execution** for filtering/processing instead of multiple sequential tool calls
 
 {{efficient_tools}}
 

--- a/maki-agent/src/tools/schema.rs
+++ b/maki-agent/src/tools/schema.rs
@@ -94,7 +94,11 @@ pub enum ParamSchema {
 pub fn to_json_schema(s: &ParamSchema) -> Value {
     match s {
         ParamSchema::Primitive { kind, description } => {
-            json!({ "type": kind.to_string(), "description": description })
+            if description.is_empty() {
+                json!({ "type": kind.to_string() })
+            } else {
+                json!({ "type": kind.to_string(), "description": description })
+            }
         }
         ParamSchema::Enum {
             variants,
@@ -106,11 +110,16 @@ pub fn to_json_schema(s: &ParamSchema) -> Value {
             }
             v
         }
-        ParamSchema::Array { items, description } => json!({
-            "type": "array",
-            "description": description,
-            "items": to_json_schema(items),
-        }),
+        ParamSchema::Array { items, description } => {
+            let mut v = json!({
+                "type": "array",
+                "items": to_json_schema(items),
+            });
+            if !description.is_empty() {
+                v["description"] = json!(description);
+            }
+            v
+        }
         ParamSchema::Object {
             properties,
             description,
@@ -126,7 +135,6 @@ pub fn to_json_schema(s: &ParamSchema) -> Value {
             let mut v = json!({
                 "type": "object",
                 "properties": props,
-                "additionalProperties": false,
             });
             if !required.is_empty() {
                 v["required"] = json!(required);
@@ -731,10 +739,13 @@ mod tests {
     }
 
     #[test]
-    fn to_json_schema_object_is_closed_with_required_and_nested_items() {
+    fn to_json_schema_object_has_required_and_nested_items() {
         let v = to_json_schema(&MULTIEDIT_LIKE);
         assert_eq!(v["type"], "object");
-        assert_eq!(v["additionalProperties"], false);
+        assert!(
+            v.get("additionalProperties").is_none(),
+            "additionalProperties is enforced by schema::validate, not the wire schema"
+        );
         let req: Vec<&str> = v["required"]
             .as_array()
             .unwrap()
@@ -744,9 +755,11 @@ mod tests {
         assert_eq!(req, vec!["path", "edits"]);
         assert_eq!(v["properties"]["edits"]["type"], "array");
         assert_eq!(v["properties"]["edits"]["items"]["type"], "object");
-        assert_eq!(
-            v["properties"]["edits"]["items"]["additionalProperties"],
-            false
+        assert!(
+            v["properties"]["edits"]["items"]
+                .get("additionalProperties")
+                .is_none(),
+            "additionalProperties is enforced by schema::validate, not the wire schema"
         );
     }
 
@@ -994,5 +1007,124 @@ mod tests {
             .extend(alias_field.as_object().unwrap().clone());
         let schema = try_from_json(&schema_json).unwrap();
         assert!(validate(schema, input).is_ok());
+    }
+
+    #[test]
+    fn to_json_schema_never_emits_additional_properties() {
+        const ANY_SCHEMA: ParamSchema = ParamSchema::Any { description: "" };
+        let any_json = to_json_schema(&ANY_SCHEMA);
+        assert!(any_json.get("additionalProperties").is_none());
+
+        let array_json = to_json_schema(&EDITS_ARRAY);
+        assert!(array_json.get("additionalProperties").is_none());
+
+        let object_json = to_json_schema(&MULTIEDIT_LIKE);
+        assert!(object_json.get("additionalProperties").is_none());
+
+        assert!(
+            object_json["properties"]["edits"]["items"]
+                .get("additionalProperties")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn try_from_json_ignores_additional_properties_field() {
+        let schema_json = json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "path": { "type": "string" }
+            }
+        });
+        let schema = try_from_json(&schema_json);
+        assert!(schema.is_ok());
+    }
+
+    #[test]
+    fn validate_drops_unknown_keys_top_level() {
+        const SCHEMA: ParamSchema = ParamSchema::Object {
+            properties: &[("name", &STR_PRIM, true, &[])],
+            description: "",
+        };
+        let out = validate(&SCHEMA, json!({"name": "x", "unknown": 42})).unwrap();
+        assert!(out.get("unknown").is_none());
+        assert_eq!(out["name"], "x");
+    }
+
+    #[test]
+    fn validate_drops_unknown_keys_nested() {
+        const NESTED_SCHEMA: ParamSchema = ParamSchema::Object {
+            properties: &[("config", &MULTIEDIT_LIKE, true, &[])],
+            description: "",
+        };
+        let input = json!({
+            "config": {
+                "path": "/x",
+                "edits": [{"old_string": "a", "new_string": "b"}],
+                "unknown_field": "drop_me"
+            }
+        });
+        let out = validate(&NESTED_SCHEMA, input).unwrap();
+        assert!(out["config"].get("unknown_field").is_none());
+        assert_eq!(out["config"]["path"], "/x");
+    }
+
+    #[test]
+    fn validate_drops_unknown_keys_after_roundtrip() {
+        const SCHEMA: ParamSchema = ParamSchema::Object {
+            properties: &[("name", &STR_PRIM, true, &[])],
+            description: "",
+        };
+        let json_schema = to_json_schema(&SCHEMA);
+        let recovered = try_from_json(&json_schema).unwrap();
+        let out = validate(recovered, json!({"name": "x", "dropped": 99})).unwrap();
+        assert!(out.get("dropped").is_none());
+    }
+
+    #[test]
+    fn validate_preserves_required_fields() {
+        const SCHEMA: ParamSchema = ParamSchema::Object {
+            properties: &[
+                ("name", &STR_PRIM, true, &[]),
+                ("optional", &STR_PRIM, false, &[]),
+            ],
+            description: "",
+        };
+        let out = validate(&SCHEMA, json!({"name": "x", "optional": "y"})).unwrap();
+        assert_eq!(out["name"], "x");
+        assert_eq!(out["optional"], "y");
+    }
+
+    #[test]
+    fn validate_rejects_missing_required_with_correct_path() {
+        const SCHEMA: ParamSchema = ParamSchema::Object {
+            properties: &[("name", &STR_PRIM, true, &[])],
+            description: "",
+        };
+        let err = validate(&SCHEMA, json!({})).unwrap_err();
+        assert_eq!(err.path.to_string(), "name");
+        assert!(matches!(err.kind, ToolInputErrorKind::Missing { .. }));
+    }
+
+    #[test]
+    fn roundtrip_validates_same_inputs() {
+        const SCHEMA: ParamSchema = ParamSchema::Object {
+            properties: &[
+                ("name", &STR_PRIM, true, &[]),
+                ("count", &BOOL_PRIM, false, &[]),
+            ],
+            description: "",
+        };
+        let json_schema = to_json_schema(&SCHEMA);
+        let recovered = try_from_json(&json_schema).unwrap();
+
+        let good_input = json!({"name": "test", "count": true});
+        assert!(validate(&SCHEMA, good_input.clone()).is_ok());
+        assert!(validate(recovered, good_input).is_ok());
+
+        let bad_input = json!({"name": "test", "count": "not_bool"});
+        assert!(validate(&SCHEMA, bad_input.clone()).is_err());
+        assert!(validate(recovered, bad_input).is_err());
     }
 }

--- a/maki-lua/tests/task_policy.rs
+++ b/maki-lua/tests/task_policy.rs
@@ -14,6 +14,7 @@ const TASK_PLUGIN_SRC: &str = include_str!("../../plugins/task/init.lua");
 
 // Mirrors of the plugin's error contracts and policy numbers.
 const STRUCTURED_OUTPUT_TOOL: &str = "structured_output";
+const DONE_PROMPT_SUFFIX: &str = "\n\nWhen finished, call the done tool with your final answer.";
 const MAX_STRUCTURED_RETRIES: usize = 2;
 const MAX_SCHEMA_ERRORS: usize = 3;
 const SCHEMA_COMPILE_ERROR: &str = "invalid output_schema";
@@ -342,9 +343,10 @@ fn plain_path_returns_text_without_local_tools() {
     assert_eq!(out, PLAIN_TEXT);
 
     let snap = probe(&reg);
-    assert_eq!(snap["has_local_tools"], json!(false));
+    assert_eq!(snap["has_local_tools"], json!(true));
     assert_eq!(snap["prompt_count"], json!(1));
-    assert_eq!(snap["prompts"][0], json!(TASK_PROMPT));
+    let expected_prompt = format!("{TASK_PROMPT}{DONE_PROMPT_SUFFIX}");
+    assert_eq!(snap["prompts"][0], json!(expected_prompt));
     assert_eq!(snap["closed"], json!(1));
 }
 

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -440,11 +440,16 @@ impl From<TokenUsage> for StoredTokenUsage {
 
 impl TokenUsage {
     pub fn total_input(&self) -> u32 {
-        self.input + self.cache_read + self.cache_creation
+        self.input
+            .saturating_add(self.cache_read)
+            .saturating_add(self.cache_creation)
     }
 
     pub fn context_tokens(&self) -> u32 {
-        self.input + self.output + self.cache_creation + self.cache_read
+        self.input
+            .saturating_add(self.output)
+            .saturating_add(self.cache_creation)
+            .saturating_add(self.cache_read)
     }
 
     pub fn cost(&self, pricing: &ModelPricing, fast: bool) -> f64 {
@@ -471,10 +476,10 @@ impl TokenUsage {
 
 impl AddAssign for TokenUsage {
     fn add_assign(&mut self, rhs: Self) {
-        self.input += rhs.input;
-        self.output += rhs.output;
-        self.cache_creation += rhs.cache_creation;
-        self.cache_read += rhs.cache_read;
+        self.input = self.input.saturating_add(rhs.input);
+        self.output = self.output.saturating_add(rhs.output);
+        self.cache_creation = self.cache_creation.saturating_add(rhs.cache_creation);
+        self.cache_read = self.cache_read.saturating_add(rhs.cache_read);
     }
 }
 
@@ -509,6 +514,70 @@ mod tests {
             cache_read: 150_000,
         };
         assert_eq!(usage.total_input(), 165_000);
+    }
+
+    #[test]
+    fn total_input_saturates_at_u32_max() {
+        let usage = TokenUsage {
+            input: u32::MAX - 100,
+            output: 0,
+            cache_creation: 200,
+            cache_read: 0,
+        };
+        assert_eq!(usage.total_input(), u32::MAX);
+    }
+
+    #[test]
+    fn context_tokens_saturates_at_u32_max() {
+        let usage = TokenUsage {
+            input: u32::MAX - 50,
+            output: 100,
+            cache_creation: 0,
+            cache_read: 0,
+        };
+        assert_eq!(usage.context_tokens(), u32::MAX);
+    }
+
+    #[test]
+    fn add_assign_saturates_at_u32_max() {
+        let mut usage = TokenUsage {
+            input: u32::MAX - 10,
+            output: 5,
+            cache_creation: 0,
+            cache_read: 0,
+        };
+        let other = TokenUsage {
+            input: 20,
+            output: 10,
+            cache_creation: 5,
+            cache_read: 5,
+        };
+        usage += other;
+        assert_eq!(usage.input, u32::MAX);
+        assert_eq!(usage.output, 15);
+        assert_eq!(usage.cache_creation, 5);
+        assert_eq!(usage.cache_read, 5);
+    }
+
+    #[test]
+    fn add_assign_normal_values_sum_correctly() {
+        let mut usage = TokenUsage {
+            input: 1000,
+            output: 500,
+            cache_creation: 200,
+            cache_read: 300,
+        };
+        let other = TokenUsage {
+            input: 500,
+            output: 250,
+            cache_creation: 100,
+            cache_read: 150,
+        };
+        usage += other;
+        assert_eq!(usage.input, 1500);
+        assert_eq!(usage.output, 750);
+        assert_eq!(usage.cache_creation, 300);
+        assert_eq!(usage.cache_read, 450);
     }
 
     #[test]

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -414,25 +414,10 @@ fn convert_tools(tools: &Value) -> Vec<Value> {
             Some(json!({
                 "name": name,
                 "description": description,
-                "parameters": strip_additional_properties(parameters),
+                "parameters": parameters,
             }))
         })
         .collect()
-}
-
-fn strip_additional_properties(value: Value) -> Value {
-    match value {
-        Value::Object(mut map) => {
-            map.remove("additionalProperties");
-            map.values_mut()
-                .for_each(|v| *v = strip_additional_properties(std::mem::take(v)));
-            Value::Object(map)
-        }
-        Value::Array(items) => {
-            Value::Array(items.into_iter().map(strip_additional_properties).collect())
-        }
-        other => other,
-    }
 }
 
 fn tool_defs_empty(tool_decls: &[Value]) -> bool {
@@ -832,14 +817,12 @@ mod tests {
             "input_schema": {
                 "type": "object",
                 "properties": {
-                    "cmd": {"type": "string", "additionalProperties": false},
+                    "cmd": {"type": "string"},
                     "opts": {
                         "type": "object",
-                        "additionalProperties": false,
                         "properties": {"verbose": {"type": "boolean"}}
                     }
-                },
-                "additionalProperties": false
+                }
             }
         }]);
         let result = convert_tools(&tools);
@@ -847,57 +830,6 @@ mod tests {
         assert_eq!(result[0]["name"], "bash");
         assert_eq!(result[0]["description"], "run a command");
         assert!(result[0]["parameters"]["properties"]["cmd"].is_object());
-        assert!(
-            result[0]["parameters"]
-                .get("additionalProperties")
-                .is_none()
-        );
-        assert!(
-            result[0]["parameters"]["properties"]["cmd"]
-                .get("additionalProperties")
-                .is_none()
-        );
-        assert!(
-            result[0]["parameters"]["properties"]["opts"]
-                .get("additionalProperties")
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn strip_additional_properties_recursive() {
-        let schema = json!({
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "inner": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {"x": {"type": "number", "additionalProperties": false}}
-                },
-                "list": {
-                    "type": "array",
-                    "items": {"type": "string", "additionalProperties": false}
-                }
-            }
-        });
-        let cleaned = strip_additional_properties(schema);
-        assert!(cleaned.get("additionalProperties").is_none());
-        assert!(
-            cleaned["properties"]["inner"]
-                .get("additionalProperties")
-                .is_none()
-        );
-        assert!(
-            cleaned["properties"]["inner"]["properties"]["x"]
-                .get("additionalProperties")
-                .is_none()
-        );
-        assert!(
-            cleaned["properties"]["list"]["items"]
-                .get("additionalProperties")
-                .is_none()
-        );
     }
 
     #[test]

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -433,10 +433,24 @@ impl SessionLog {
         U: Serialize + DeserializeOwned + Default,
         T: Serialize + DeserializeOwned,
     {
-        let path = jsonl_path(dir, session_id);
+        let path = locate_session_file(dir, session_id)
+            .ok_or_else(|| SessionError::from(StorageError::NotFound(session_id.to_string())))?;
+        let session = load_session_at::<M, U, T>(&path)?;
+
+        // Migrate legacy .json files to canonical .jsonl so subsequent opens
+        // skip the legacy path and the file is cleaned up.
+        let canonical = jsonl_path(dir, session_id);
+        if path != canonical {
+            let _ = remove_legacy_files(dir, session_id);
+            let file = write_session_file(dir, &session)?;
+            update_cwd_index(dir, &session.cwd, session.id)?;
+            let log = Self::cursor_from(&session, file);
+            return Ok((session, log));
+        }
+
+        // Truncate any torn tail on the canonical .jsonl file.
         let bytes = fs::read(&path).map_err(StorageError::from)?;
         let valid = bytes.iter().rposition(|&b| b == b'\n').map_or(0, |i| i + 1);
-
         if valid < bytes.len() {
             warn!(
                 path = %path.display(),
@@ -450,9 +464,6 @@ impl SessionLog {
                 .set_len(valid as u64)
                 .map_err(StorageError::from)?;
         }
-
-        let display = path.display().to_string();
-        let session = load_jsonl::<M, U, T>(&bytes[..valid], &display)?;
 
         let file = OpenOptions::new()
             .append(true)
@@ -946,8 +957,11 @@ fn scan_headers(cwd: &str, dir: &Path) -> Result<Vec<SessionSummary>, StorageErr
     let mut cache = load_scan_cache(dir);
     let mut fresh = ScanCache::new();
     let mut dirty = false;
-    let mut out = Vec::new();
+    // Deduplicate by session id, preferring .jsonl over legacy .json so a
+    // session that exists in both formats appears once.
+    let mut selected: HashMap<MakiId, (bool, SessionSummary)> = HashMap::new();
     for path in session_entries(dir)? {
+        let from_jsonl = is_jsonl(&path);
         let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
             continue;
         };
@@ -958,7 +972,7 @@ fn scan_headers(cwd: &str, dir: &Path) -> Result<Vec<SessionSummary>, StorageErr
             Some(e) if e.size == size && e.mtime_ms == mtime_ms => e,
             _ => {
                 dirty = true;
-                let header = if is_jsonl(&path) {
+                let header = if from_jsonl {
                     scan_jsonl_header(&path)
                 } else {
                     scan_legacy_header(&path)
@@ -972,12 +986,21 @@ fn scan_headers(cwd: &str, dir: &Path) -> Result<Vec<SessionSummary>, StorageErr
         };
         if let Some(h) = &entry.header
             && h.cwd == cwd
+            && selected
+                .get(&h.id)
+                .is_none_or(|(jsonl, _)| from_jsonl && !*jsonl)
         {
-            out.push(SessionSummary {
-                id: h.id,
-                title: normalize_title(&h.title),
-                updated_at: h.updated_at,
-            });
+            selected.insert(
+                h.id,
+                (
+                    from_jsonl,
+                    SessionSummary {
+                        id: h.id,
+                        title: normalize_title(&h.title),
+                        updated_at: h.updated_at,
+                    },
+                ),
+            );
         }
         fresh.insert(name.to_owned(), entry);
     }
@@ -988,7 +1011,7 @@ fn scan_headers(cwd: &str, dir: &Path) -> Result<Vec<SessionSummary>, StorageErr
     {
         warn!(error = %e, "failed to write session scan cache");
     }
-    Ok(out)
+    Ok(selected.into_values().map(|(_, s)| s).collect())
 }
 
 const TAIL_BUF: u64 = 4096;

--- a/plugins/bash/init.lua
+++ b/plugins/bash/init.lua
@@ -263,10 +263,10 @@ maki.api.register_tool({
   schema = {
     type = "object",
     properties = {
-      command = { type = "string", description = "The bash command to execute", required = true },
-      timeout = { type = "integer", description = "Timeout in seconds (default 120)" },
-      workdir = { type = "string", description = "Working directory (default: cwd)" },
-      description = { type = "string", description = "Short description (3-5 words) of what the command does" },
+      command = { type = "string", required = true },
+      timeout = { type = "integer" },
+      workdir = { type = "string" },
+      description = { type = "string" },
     },
   },
   permission_scopes = function(input)

--- a/plugins/edit/init.lua
+++ b/plugins/edit/init.lua
@@ -257,23 +257,19 @@ maki.api.register_tool({
     properties = {
       path = {
         type = "string",
-        description = "Absolute path to the file",
         required = true,
         alias = "file_path",
       },
       old_string = {
         type = "string",
-        description = "Exact string to find (must match uniquely unless replace_all is true)",
         required = true,
       },
       new_string = {
         type = "string",
-        description = "Replacement string",
         required = true,
       },
       replace_all = {
         type = "boolean",
-        description = "Replace all occurrences (default false)",
       },
     },
   },
@@ -309,30 +305,25 @@ register_tool_if(opts.multiedit, {
     properties = {
       path = {
         type = "string",
-        description = "Absolute path to the file",
         required = true,
         alias = "file_path",
       },
       edits = {
         type = "array",
-        description = "Array of edit operations to apply sequentially",
         required = true,
         items = {
           type = "object",
           properties = {
             old_string = {
               type = "string",
-              description = "Exact string to find",
               required = true,
             },
             new_string = {
               type = "string",
-              description = "Replacement string",
               required = true,
             },
             replace_all = {
               type = "boolean",
-              description = "Replace all occurrences (default false)",
             },
           },
         },
@@ -394,23 +385,19 @@ register_tool_if(opts.edit_lines, {
     properties = {
       path = {
         type = "string",
-        description = "Absolute path to the file",
         required = true,
         alias = "file_path",
       },
       start = {
         type = "integer",
-        description = "First line (1-indexed)",
         required = true,
       },
       ["end"] = {
         type = "integer",
-        description = "Last line, inclusive",
         required = true,
       },
       new_string = {
         type = "string",
-        description = "Replacement text",
         required = true,
       },
     },
@@ -448,18 +435,15 @@ register_tool_if(opts.insert_lines, {
     properties = {
       path = {
         type = "string",
-        description = "Absolute path to the file",
         required = true,
         alias = "file_path",
       },
       line = {
         type = "integer",
-        description = "Line number to insert before (1-indexed). Use 1 to insert at the top.",
         required = true,
       },
       new_string = {
         type = "string",
-        description = "Text to insert",
         required = true,
       },
     },

--- a/plugins/glob/init.lua
+++ b/plugins/glob/init.lua
@@ -26,8 +26,8 @@ maki.api.register_tool({
   schema = {
     type = "object",
     properties = {
-      pattern = { type = "string", description = "Glob pattern (e.g. **/*.rs, src/**/*.ts)", required = true },
-      path = { type = "string", description = "Directory to search in (default: cwd)" },
+      pattern = { type = "string", required = true },
+      path = { type = "string" },
     },
   },
 

--- a/plugins/grep/init.lua
+++ b/plugins/grep/init.lua
@@ -207,16 +207,15 @@ maki.api.register_tool({
   schema = {
     type = "object",
     properties = {
-      pattern = { type = "string", description = "Regex pattern", required = true },
-      path = { type = "string", description = "Directory to search in (default: cwd)" },
+      pattern = { type = "string", required = true },
+      path = { type = "string" },
       include = {
         type = "string",
-        description = "File glob filter (e.g. *.c)",
         alias = "glob",
       },
-      context_before = { type = "integer", description = "Context lines before match" },
-      context_after = { type = "integer", description = "Context lines after match" },
-      limit = { type = "integer", description = "Max match groups to return" },
+      context_before = { type = "integer" },
+      context_after = { type = "integer" },
+      limit = { type = "integer" },
     },
   },
 

--- a/plugins/index/init.lua
+++ b/plugins/index/init.lua
@@ -163,7 +163,7 @@ Return a compact overview of a source file: imports, type definitions, function 
   schema = {
     type = "object",
     properties = {
-      path = { type = "string", description = "Absolute path to the file", required = true },
+      path = { type = "string", required = true },
     },
   },
   header = function(input)

--- a/plugins/memory/init.lua
+++ b/plugins/memory/init.lua
@@ -38,14 +38,7 @@ maki.api.register_prompt_hint({
     if #entries == 0 then
       return nil
     end
-    table.sort(entries, function(a, b)
-      return a[1] < b[1]
-    end)
-    local out = "\n\nMemory files (use the memory tool to view/update):\n"
-    for _, e in ipairs(entries) do
-      out = out .. "- " .. e[1] .. " (" .. e[2] .. " bytes)\n"
-    end
-    return out
+    return "\n\nMemory files: " .. #entries .. " entries (use memory tool to view/update)\n"
   end,
 })
 

--- a/plugins/read/init.lua
+++ b/plugins/read/init.lua
@@ -2,18 +2,7 @@ local ToolView = require("maki.tool_view")
 local shorten_path = require("maki.shorten_path")
 local output_limits = require("maki.output_limits")
 
-local DESCRIPTION = [[Read a file or directory. Returns contents with line numbers (1-indexed).
-
-- Supports absolute, relative, and ~/ paths.
-- **Always include offset and limit** if possible. Defaults: no offset = start at 1; no limit = up to 2000 lines.
-- Use the **index** tool or **grep** tool first to find the offset and limit.
-- Only read the sections you actually need.
-- Use `wc -l` to check total number of lines before reading to decide a reasonable limit unless known already.
-- Use truncation hints (e.g. "truncated lines X-Y") to continue with the correct offset.
-- Do not reread the same range (same file and same offset).
-- Prefer grep to locate content instead of scanning full files.
-- Call in parallel when reading multiple files.
-- Avoid tiny repeated slices - read a larger window if you need more context.]]
+local DESCRIPTION = "Read a file or directory. Returns contents with line numbers (1-indexed)."
 
 local DEFAULT_MAX_OUTPUT_LINES = 2000
 
@@ -224,9 +213,10 @@ end
 
 maki.api.register_prompt_hint({
   slot = "tool_usage",
-  content = [[
-- When using the **read** tool, only read the sections you actually need.
-- Use `wc -l` to check total number of lines before reading to decide a reasonable **read** tool limit unless known already.]],
+  content = [[- When using the **read** tool, only read the sections you actually need.
+- Use `wc -l` to check total number of lines before reading to decide a reasonable **read** tool limit unless known already.
+- Supports absolute, relative, and ~/ paths. No offset = start at 1; no limit = up to 2000 lines.
+- Use truncation hints (e.g. "truncated lines X-Y") to continue with the correct offset.]],
 })
 
 maki.api.register_tool({
@@ -239,15 +229,11 @@ maki.api.register_tool({
     properties = {
       path = {
         type = "string",
-        description = "Absolute path to the file or directory",
         required = true,
         alias = "file_path",
       },
-      offset = { type = "integer", description = "Line number to start from (1-indexed)" },
-      limit = {
-        type = "integer",
-        description = "Max number of lines to read. Omitting the limit reads up to 2000 lines.",
-      },
+      offset = { type = "integer" },
+      limit = { type = "integer" },
     },
   },
 

--- a/plugins/task/init.lua
+++ b/plugins/task/init.lua
@@ -11,6 +11,9 @@ local STRUCTURED_OUTPUT_NAME = "structured_output"
 local STRUCTURED_OUTPUT_DESCRIPTION = "Report your final result. Call it exactly once when your task is complete."
 local STRUCTURED_OUTPUT_ACK = "Output recorded."
 local STRUCTURED_OUTPUT_PROMPT_SUFFIX = "\n\nWhen finished, call the structured_output tool with your final result."
+local DONE_NAME = "done"
+local DONE_DESCRIPTION = "Call when the task is complete with your final answer."
+local DONE_PROMPT_SUFFIX = "\n\nWhen finished, call the done tool with your final answer."
 local MAX_STRUCTURED_RETRIES = 2
 local MAX_SCHEMA_ERRORS = 3
 local SCHEMA_COMPILE_ERROR = "invalid output_schema"
@@ -147,6 +150,23 @@ local function handler(input, ctx)
         end,
       },
     }
+  else
+    local_tools = {
+      [DONE_NAME] = {
+        description = DONE_DESCRIPTION,
+        input_schema = {
+          type = "object",
+          properties = {
+            answer = { type = "string", description = "Final answer to return to the parent agent." },
+          },
+          required = { "answer" },
+        },
+        handler = function(value)
+          captured = value.answer
+          return "Done."
+        end,
+      },
+    }
   end
 
   local permit = semaphore:acquire()
@@ -168,6 +188,8 @@ local function handler(input, ctx)
     local message = input.prompt
     if validator then
       message = message .. STRUCTURED_OUTPUT_PROMPT_SUFFIX
+    else
+      message = message .. DONE_PROMPT_SUFFIX
     end
 
     local result, err = sess:prompt(message)
@@ -186,7 +208,13 @@ local function handler(input, ctx)
       local msg = last_errors and (STRUCTURED_INVALID_ERROR .. ":\n" .. last_errors) or STRUCTURED_MISSING_ERROR
       return { llm_output = msg, is_error = true }
     end
-    return { llm_output = captured and maki.json.encode(captured) or result.text, format = "markdown" }
+    if captured then
+      if type(captured) == "string" then
+        return { llm_output = captured, format = "markdown" }
+      end
+      return { llm_output = maki.json.encode(captured), format = "markdown" }
+    end
+    return { llm_output = result.text, format = "markdown" }
   end)
 
   permit:release()

--- a/plugins/view_image/init.lua
+++ b/plugins/view_image/init.lua
@@ -127,7 +127,6 @@ maki.api.register_tool({
     properties = {
       path = {
         type = "string",
-        description = "Path to the image file",
         required = true,
         alias = "file_path",
       },

--- a/plugins/websearch/init.lua
+++ b/plugins/websearch/init.lua
@@ -7,6 +7,12 @@ local truncate = require("maki.truncate")
 local ToolView = require("maki.tool_view")
 local output_limits = require("maki.output_limits")
 
+maki.api.set_prompt({
+  prompt = "system",
+  slot = "environment",
+  content = "# Environment\nCurrent date: " .. os.date("%Y-%m-%d") .. "\n",
+})
+
 local opts = maki.api.register_options(output_limits.extend({
   max_response_bytes = {
     default = 5 * 1024 * 1024,
@@ -23,13 +29,11 @@ end
 maki.api.register_tool({
   name = "websearch",
   kind = "fetch",
-  description = "Search the web for real-time information using Exa AI.\n\n"
-    .. "Today's date is "
-    .. os.date("%Y-%m-%d")
-    .. ".\n\n"
-    .. "- Use for current events, documentation, APIs, or anything not in local files.\n"
-    .. "- Prefer specific, targeted queries over broad ones.\n"
-    .. "- Results include page titles, URLs, and content snippets.",
+  description = [[Search the web for real-time information using Exa AI.
+
+- Use for current events, documentation, APIs, or anything not in local files.
+- Prefer specific, targeted queries over broad ones.
+- Results include page titles, URLs, and content snippets.]],
 
   schema = {
     type = "object",

--- a/plugins/write/init.lua
+++ b/plugins/write/init.lua
@@ -37,13 +37,11 @@ maki.api.register_tool({
     properties = {
       path = {
         type = "string",
-        description = "Absolute path to the file",
         required = true,
         alias = "file_path",
       },
       content = {
         type = "string",
-        description = "The complete file content to write",
         required = true,
       },
     },

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -16,12 +16,12 @@ Maki ships with 20 built-in tools. This is the full reference.
 Execute a bash command.
 Commands run in <cwd> by default.
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `command` | string | yes |  | The bash command to execute |
-| `description` | string | no |  | Short description (3-5 words) of what the command does |
-| `timeout` | integer | no | 120 | Timeout in seconds |
-| `workdir` | string | no | cwd | Working directory |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `command` | string | yes |  |
+| `description` | string | no |  |
+| `timeout` | integer | no |  |
+| `workdir` | string | no |  |
 
 ### `read` *(lua plugin)*
 
@@ -29,9 +29,9 @@ Read a file or directory. Returns contents with line numbers (1-indexed).
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `limit` | integer | no | Max number of lines to read. Omitting the limit reads up to 2000 lines. |
-| `offset` | integer | no | Line number to start from (1-indexed) |
-| `path` | string | yes | Absolute path to the file or directory |
+| `limit` | integer | no |  |
+| `offset` | integer | no |  |
+| `path` | string | yes |  |
 
 ### `write` *(lua plugin)*
 
@@ -39,19 +39,19 @@ Write content to a file, replacing existing content.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `content` | string | yes | The complete file content to write |
-| `path` | string | yes | Absolute path to the file |
+| `content` | string | yes |  |
+| `path` | string | yes |  |
 
 ### `edit` *(lua plugin)*
 
 Replace an exact string match in a file.
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `new_string` | string | yes |  | Replacement string |
-| `old_string` | string | yes |  | Exact string to find (must match uniquely unless replace_all is true) |
-| `path` | string | yes |  | Absolute path to the file |
-| `replace_all` | boolean | no | false | Replace all occurrences |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `new_string` | string | yes |  |
+| `old_string` | string | yes |  |
+| `path` | string | yes |  |
+| `replace_all` | boolean | no |  |
 
 ### `multiedit` *(lua plugin)*
 
@@ -60,8 +60,8 @@ Prefer this over edit when making multiple changes to the same file.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `edits` | array | yes | Array of edit operations to apply sequentially |
-| `path` | string | yes | Absolute path to the file |
+| `edits` | array | yes |  |
+| `path` | string | yes |  |
 
 ### `edit_lines` *(lua plugin, opt-in)*
 
@@ -69,10 +69,10 @@ Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `end` | integer | yes | Last line, inclusive |
-| `new_string` | string | yes | Replacement text |
-| `path` | string | yes | Absolute path to the file |
-| `start` | integer | yes | First line (1-indexed) |
+| `end` | integer | yes |  |
+| `new_string` | string | yes |  |
+| `path` | string | yes |  |
+| `start` | integer | yes |  |
 
 ### `insert_lines` *(lua plugin, opt-in)*
 
@@ -80,31 +80,31 @@ Insert lines before a given line number. Lines at `line` and below shift down. E
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `line` | integer | yes | Line number to insert before (1-indexed). Use 1 to insert at the top. |
-| `new_string` | string | yes | Text to insert |
-| `path` | string | yes | Absolute path to the file |
+| `line` | integer | yes |  |
+| `new_string` | string | yes |  |
+| `path` | string | yes |  |
 
 ### `glob` *(lua plugin)*
 
 Find files by glob pattern.
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `path` | string | no | cwd | Directory to search in |
-| `pattern` | string | yes |  | Glob pattern (e.g. **/*.rs, src/**/*.ts) |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | no |  |
+| `pattern` | string | yes |  |
 
 ### `grep` *(lua plugin)*
 
 Search file contents using regex.
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `context_after` | integer | no |  | Context lines after match |
-| `context_before` | integer | no |  | Context lines before match |
-| `include` | string | no |  | File glob filter (e.g. *.c) |
-| `limit` | integer | no |  | Max match groups to return |
-| `path` | string | no | cwd | Directory to search in |
-| `pattern` | string | yes |  | Regex pattern |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `context_after` | integer | no |  |
+| `context_before` | integer | no |  |
+| `include` | string | no |  |
+| `limit` | integer | no |  |
+| `path` | string | no |  |
+| `pattern` | string | yes |  |
 
 ### `index` *(lua plugin)*
 
@@ -112,7 +112,7 @@ Return a compact overview of a source file: imports, type definitions, function 
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `path` | string | yes | Absolute path to the file |
+| `path` | string | yes |  |
 
 ### `view_image` *(lua plugin)*
 
@@ -120,7 +120,7 @@ View an image file (png, jpeg, gif, webp) so you can actually see it; it is retu
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `path` | string | yes | Path to the image file |
+| `path` | string | yes |  |
 
 ## Execution & Control
 


### PR DESCRIPTION
Three bug fixes for the token-savings work (PR #25 / PR #629):

1. **maki-storage/sessions.rs open()**: use locate_session_file() to find .jsonl or legacy .json, load via load_session_at(), migrate legacy .json to canonical .jsonl
2. **maki-storage/sessions.rs scan_headers()**: restore HashMap deduplication preferring .jsonl over .json
3. **plugins/task/init.lua**: restore done tool for tasks without output_schema with type-aware return

Also includes the full token-savings changes from PR #25 (compaction, run, tool_dispatch, prompt, schema, model, google, 10 Lua plugins) and prompt templates (system.md, compaction.md, compaction_user.md).

All 3212 tests pass, clippy clean, cargo fmt applied.