### PR TITLE
fix(ui): stop duplicate a failed tool's output below its collapsed view

### DIFF
--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -641,7 +641,7 @@ pub fn build_tool_lines(
             msg.tool_output.as_deref()
         },
     );
-    if let Some(ref snapshot) = msg.render_snapshot {
+    let show_output = if let Some(ref snapshot) = msg.render_snapshot {
         let search_text = msg
             .tool_output
             .as_ref()
@@ -653,24 +653,27 @@ pub fn build_tool_lines(
             })
             .or(body);
         b.push_snapshot(snapshot, search_text, rctx.started_at);
-        // With pre-permission previews, an error (say a denial) can land
-        // while only the script snapshot is on screen. Show the error below
-        // it, unless the handler already drew it into the body.
-        if matches!(status, ToolStatus::Error) {
+        // A denial can land while the snapshot still shows only the
+        // pre-permission script preview, so the error goes below it.
+        // But a collapsed snapshot keeps just a window of the output,
+        // so checking the full text would duplicate long outputs. The
+        // last line is a reliable probe: a tail-keep view always shows
+        // it, a bare script preview never does.
+        matches!(status, ToolStatus::Error) && {
             let err_text = msg.tool_output.as_deref().map(|o| o.as_text());
-            let shown = err_text.as_deref().or(body).map_or("", str::trim);
-            if !shown.is_empty() && !snapshot.text().contains(shown) {
-                let resolved = resolve_output(
-                    msg.tool_output.as_deref(),
-                    body,
-                    msg.live_output.as_deref(),
-                    msg.truncated_lines,
-                    b.limits,
-                );
-                b.push_resolved_output(&resolved);
-            }
+            let tail = err_text
+                .as_deref()
+                .or(body)
+                .map_or("", str::trim)
+                .lines()
+                .next_back()
+                .map_or("", str::trim);
+            !tail.is_empty() && !snapshot.text().contains(tail)
         }
     } else {
+        true
+    };
+    if show_output {
         let resolved = resolve_output(
             msg.tool_output.as_deref(),
             body,
@@ -1195,7 +1198,7 @@ mod tests {
 
     const DENIAL_MSG: &str = "Permission denied: user rejected";
 
-    fn error_snapshot_msg(snapshot_text: &str) -> DisplayMessage {
+    fn error_snapshot_msg(snapshot_lines: &[&str], output: &str) -> DisplayMessage {
         DisplayMessage {
             role: DisplayRole::Tool(Box::new(ToolRole {
                 id: "t1".into(),
@@ -1203,17 +1206,41 @@ mod tests {
                 name: "code_execution".into(),
             })),
             text: "2 lines".into(),
-            tool_output: Some(Arc::new(ToolOutput::Plain(DENIAL_MSG.into()))),
-            ..snapshot_msg(make_snapshot(vec![vec![SnapshotSpan {
-                text: snapshot_text.into(),
-                style: SpanStyle::Default,
-            }]]))
+            tool_output: Some(Arc::new(ToolOutput::Plain(output.into()))),
+            ..snapshot_msg(make_snapshot(
+                snapshot_lines
+                    .iter()
+                    .map(|t| {
+                        vec![SnapshotSpan {
+                            text: (*t).into(),
+                            style: SpanStyle::Default,
+                        }]
+                    })
+                    .collect(),
+            ))
         }
     }
 
-    #[test]
-    fn error_with_snapshot_renders_error_below() {
-        let msg = error_snapshot_msg("1 print('hi')");
+    #[test_case(
+        &["1 print('hi')"], DENIAL_MSG,
+        Some("1 print('hi')"), None
+        ; "denial_shown_below_script_preview")]
+    #[test_case(
+        &[DENIAL_MSG], DENIAL_MSG,
+        None, None
+        ; "denial_in_snapshot_not_duplicated")]
+    #[test_case(
+        &["... (15 lines) (click to expand)", "tail line", "Exit code: 2"],
+        "head line\ntail line\nExit code: 2",
+        None, Some("head line")
+        ; "collapsed_tail_view_not_duplicated")]
+    fn error_snapshot_output_renders_once(
+        snapshot: &[&str],
+        output: &str,
+        shown: Option<&str>,
+        hidden: Option<&str>,
+    ) {
+        let msg = error_snapshot_msg(snapshot, output);
         let tl = build_tool_lines(
             &msg,
             ToolStatus::Error,
@@ -1221,25 +1248,21 @@ mod tests {
             SectionFlags::default(),
         );
         let text = lines_text(&tl);
-        assert!(text.contains("print('hi')"), "snapshot stays: {text}");
-        assert!(text.contains(DENIAL_MSG), "denial must show: {text}");
-    }
-
-    #[test]
-    fn error_already_in_snapshot_is_not_duplicated() {
-        let msg = error_snapshot_msg(DENIAL_MSG);
-        let tl = build_tool_lines(
-            &msg,
-            ToolStatus::Error,
-            &test_rctx(80),
-            SectionFlags::default(),
-        );
-        let text = lines_text(&tl);
+        let tail = output.lines().next_back().unwrap();
         assert_eq!(
-            text.matches(DENIAL_MSG).count(),
+            text.matches(tail).count(),
             1,
-            "error must render exactly once: {text}"
+            "output tail must render exactly once: {text}"
         );
+        if let Some(shown) = shown {
+            assert!(text.contains(shown), "snapshot content must stay: {text}");
+        }
+        if let Some(hidden) = hidden {
+            assert!(
+                !text.contains(hidden),
+                "hidden lines must stay hidden: {text}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
When an errored tool has a render snapshot, the UI appends the raw output below it unless the snapshot already shows it, so a permission denial landing on a pre-permission script preview stays visible.

That check compared the full output text, but a collapsed `ToolView` snapshot only holds the visible window, so any failing bash command longer than the cap got rendered twice: the Lua tail view with `Exit code: N` in the middle, then the whole output again with a second truncation notice.

The check now probes for the last non-empty line of the error, which a tail-keep view always shows and a bare script preview never does, so the denial fallback keeps working.