### PR TITLE
fix(lua): add the leading slash to command names when missing

### DIFF
--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -645,7 +645,8 @@ fn register_tool(lua: &Lua, #[ctx] pending: PendingTools, spec: Table) -> LuaRes
 /// browsing memory files or toggling settings.
 ///
 /// @param spec table Command specification:
-///   name        (string)   Required. The command name (without the leading slash).
+///   name        (string)   Required. The command name (e.g. "/hello"; a leading
+///                            slash is added when missing).
 ///   description (string)   Optional. Short description shown in the command palette.
 ///   handler     (function) Required. Called when the user runs the command.
 /// @return
@@ -1177,13 +1178,16 @@ fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> Lua
 }
 
 fn register_command_from_lua(lua: &Lua, spec: &Table, plugin: Arc<str>) -> LuaResult<()> {
-    let name: String = spec
+    let mut name: String = spec
         .get("name")
         .map_err(|_| mlua::Error::runtime("register_command: missing 'name'"))?;
     if name.is_empty() {
         return Err(mlua::Error::runtime(
             "register_command: name must be non-empty",
         ));
+    }
+    if !name.starts_with('/') {
+        name.insert(0, '/');
     }
     let description: String = spec.get("description").unwrap_or_default();
     let handler: Function = spec

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -731,6 +731,26 @@ mod tests {
     }
 
     #[test]
+    fn register_command_adds_missing_leading_slash() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        host.load_source(
+            "noslash",
+            r#"
+            maki.api.register_command({
+                name = "hello",
+                description = "no slash",
+                handler = function() end,
+            })
+            "#,
+        )
+        .unwrap();
+
+        let snap = host.command_reader().load();
+        assert_eq!(snap.commands.len(), 1);
+        assert_eq!(snap.commands[0].name.as_ref(), "/hello");
+    }
+
+    #[test]
     fn command_reader_generation_increments_on_publish() {
         let (writer, reader) = LuaCommandWriter::new();
         assert_eq!(reader.load().generation, 0);

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -250,7 +250,8 @@ browsing memory files or toggling settings.
 **Parameters:**
 
 - `{spec}` (`table`) Command specification:
-  - `name` (`string`) Required. The command name (without the leading slash).
+  - `name` (`string`) Required. The command name (e.g. "/hello"; a leading
+    slash is added when missing).
   - `description` (`string`) Optional. Short description shown in the command palette.
   - `handler` (`function`) Required. Called when the user runs the command.
 


### PR DESCRIPTION
The command palette matches Lua commands by their full name including the slash, so a plugin registering `name = "hello"` instead of `"/hello"` silently never matched what the user typed.

Now `register_command` prepends the `/` itself when it is missing, and the docs no longer claim the name goes without a slash while every example shows one.