### PR TITLE
fix(agent): preserve tool pairs during compaction

### DIFF
--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -6,7 +6,7 @@ use maki_providers::{
 };
 use tracing::info;
 
-use super::history::History;
+use super::history::{History, remove_orphaned_tool_results};
 use super::streaming::stream_with_retry;
 use crate::cancel::CancelToken;
 use crate::{AgentError, AgentEvent, EventSender, TurnCompleteEvent};
@@ -23,6 +23,7 @@ pub(super) async fn compact_history(
 ) -> Result<TokenUsage, AgentError> {
     let compact_start = std::time::Instant::now();
     let mut compaction_history: Vec<Message> = history.as_slice().to_vec();
+    remove_orphaned_tool_results(&mut compaction_history);
     strip_images(&mut compaction_history);
     strip_thinking(&mut compaction_history);
     strip_old_tool_results(&mut compaction_history);
@@ -176,39 +177,26 @@ fn truncate_oldest_round(messages: &mut Vec<Message>) {
         return;
     }
 
-    let mut remove_count = 1;
-
-    if matches!(messages.first().map(|m| &m.role), Some(Role::Assistant)) {
-        let has_tool_calls = messages[0].has_tool_calls();
-        if has_tool_calls {
-            let next_has_tool_results = messages.get(1).is_some_and(|m| {
-                matches!(m.role, Role::User)
-                    && m.content
-                        .iter()
-                        .any(|b| matches!(b, ContentBlock::ToolResult { .. }))
-            });
-            if next_has_tool_results {
-                remove_count = 2;
-            }
-        }
-    } else if matches!(messages.first().map(|m| &m.role), Some(Role::User))
-        && matches!(messages.get(1).map(|m| &m.role), Some(Role::Assistant))
+    let removed_user = matches!(messages.remove(0).role, Role::User);
+    if removed_user
+        && messages.len() > 1
+        && matches!(
+            messages.first().map(|message| &message.role),
+            Some(Role::Assistant)
+        )
     {
-        // Dropping a lone user message would leave assistant-first, which some providers reject.
-        // Remove the assistant too to keep the conversation well-formed.
-        remove_count = 2;
+        messages.remove(0);
     }
+    remove_orphaned_tool_results(messages);
 
-    messages.drain(..remove_count);
-
-    // After draining, the first message might still be an assistant (e.g. consecutive
-    // assistant messages). Keep draining until the first message is user or we're empty.
-    while messages.len() > 1 && matches!(messages.first().map(|m| &m.role), Some(Role::Assistant)) {
-        let mut drop = 1;
-        if matches!(messages.get(1).map(|m| &m.role), Some(Role::User)) {
-            drop = 2;
-        }
-        messages.drain(..drop);
+    while messages.len() > 1
+        && matches!(
+            messages.first().map(|message| &message.role),
+            Some(Role::Assistant)
+        )
+    {
+        messages.remove(0);
+        remove_orphaned_tool_results(messages);
     }
 }
 
@@ -235,13 +223,15 @@ mod tests {
     use crate::AgentConfig;
 
     struct MockProvider {
-        responses: Mutex<Vec<StreamResponse>>,
+        responses: Mutex<Vec<Result<StreamResponse, AgentError>>>,
+        requests: Mutex<Vec<Vec<Message>>>,
     }
 
     impl MockProvider {
-        fn new(responses: Vec<StreamResponse>) -> Self {
+        fn new(responses: Vec<Result<StreamResponse, AgentError>>) -> Self {
             Self {
                 responses: Mutex::new(responses),
+                requests: Mutex::new(Vec::new()),
             }
         }
     }
@@ -250,7 +240,7 @@ mod tests {
         fn stream_message<'a>(
             &'a self,
             _: &'a Model,
-            _: &'a [Message],
+            messages: &'a [Message],
             _: &'a str,
             _: &'a Value,
             _: &'a flume::Sender<ProviderEvent>,
@@ -258,9 +248,10 @@ mod tests {
             _: Option<&'a SessionRef>,
         ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
             Box::pin(async {
+                self.requests.lock().unwrap().push(messages.to_vec());
                 let mut responses = self.responses.lock().unwrap();
                 assert!(!responses.is_empty(), "MockProvider: no more responses");
-                Ok(responses.remove(0))
+                responses.remove(0)
             })
         }
 
@@ -296,8 +287,9 @@ mod tests {
     #[test]
     fn compact_replaces_history_with_summary() {
         smol::block_on(async {
-            let provider: std::sync::Arc<dyn Provider> =
-                std::sync::Arc::new(MockProvider::new(vec![text_response(StopReason::EndTurn)]));
+            let provider: std::sync::Arc<dyn Provider> = std::sync::Arc::new(MockProvider::new(
+                vec![Ok(text_response(StopReason::EndTurn))],
+            ));
             let model = default_model();
             let (raw_tx, _rx) = flume::unbounded();
             let mut history = History::new(vec![
@@ -324,6 +316,65 @@ mod tests {
             assert_eq!(msgs.len(), 2);
             assert!(matches!(msgs[0].role, Role::User));
             assert!(matches!(msgs[1].role, Role::Assistant));
+        });
+    }
+
+    #[test]
+    fn compact_preparation_removes_orphan_result_and_tool_image() {
+        use std::sync::Arc;
+
+        use maki_providers::{ImageMediaType, ImageSource};
+
+        smol::block_on(async {
+            let provider = MockProvider::new(vec![Ok(text_response(StopReason::EndTurn))]);
+            let image = ContentBlock::Image {
+                source: ImageSource::new(ImageMediaType::Png, Arc::from("aGVsbG8=")),
+            };
+            let mut orphan = Message {
+                role: Role::User,
+                content: vec![tool_result("orphan"), image.clone()],
+                ..Default::default()
+            };
+            orphan.content.push(ContentBlock::Text {
+                text: "keep text".into(),
+            });
+            let chat_image = Message {
+                role: Role::User,
+                content: vec![image],
+                ..Default::default()
+            };
+            let mut history = History::new(vec![orphan, chat_image]);
+            let (raw_tx, _rx) = flume::unbounded();
+
+            compact_history(
+                &provider,
+                &default_model(),
+                &mut history,
+                &EventSender::new(raw_tx, 0),
+                &CancelToken::none(),
+            )
+            .await
+            .unwrap();
+
+            let requests = provider.requests.lock().unwrap();
+            let request = &requests[0];
+            assert!(
+                !request
+                    .iter()
+                    .flat_map(|message| &message.content)
+                    .any(|block| matches!(
+                        block,
+                        ContentBlock::ToolResult { .. } | ContentBlock::Image { .. }
+                    ))
+            );
+            assert!(
+                request.iter().flat_map(|message| &message.content).any(
+                    |block| matches!(block, ContentBlock::Text { text } if text == "keep text")
+                )
+            );
+            assert!(request.iter().flat_map(|message| &message.content).any(
+                |block| matches!(block, ContentBlock::Text { text } if text == IMAGE_PLACEHOLDER)
+            ));
         });
     }
 
@@ -463,6 +514,121 @@ mod tests {
         );
     }
 
+    fn tool_use(id: &str) -> Message {
+        Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::ToolUse {
+                id: id.into(),
+                name: "bash".into(),
+                input: serde_json::json!({}),
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn tool_result(id: &str) -> ContentBlock {
+        ContentBlock::ToolResult {
+            tool_use_id: id.into(),
+            content: "output".into(),
+            is_error: false,
+        }
+    }
+
+    #[track_caller]
+    fn assert_tool_results_have_calls(messages: &[Message]) {
+        for (index, message) in messages.iter().enumerate() {
+            for block in &message.content {
+                let ContentBlock::ToolResult { tool_use_id, .. } = block else {
+                    continue;
+                };
+                assert!(matches!(message.role, Role::User));
+                assert!(index > 0);
+                assert!(
+                    messages[index - 1]
+                        .tool_uses()
+                        .any(|(id, _, _)| id == tool_use_id)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn compact_history_retries_without_reproduced_orphan() {
+        smol::block_on(async {
+            const TOOL_USE_ID: &str = "call_dMZDTpEfz2JxMvFbqFHua1Zy";
+
+            let provider = MockProvider::new(vec![
+                Err(AgentError::Api {
+                    status: 413,
+                    message: "prompt is too long".into(),
+                }),
+                Ok(text_response(StopReason::EndTurn)),
+            ]);
+            let mut history = History::new(vec![
+                Message::user("request".into()),
+                tool_use(TOOL_USE_ID),
+                Message {
+                    role: Role::User,
+                    content: vec![tool_result(TOOL_USE_ID)],
+                    ..Default::default()
+                },
+                Message::user("prompt".into()),
+            ]);
+            let (raw_tx, _rx) = flume::unbounded();
+
+            compact_history(
+                &provider,
+                &default_model(),
+                &mut history,
+                &EventSender::new(raw_tx, 0),
+                &CancelToken::none(),
+            )
+            .await
+            .unwrap();
+
+            let requests = provider.requests.lock().unwrap();
+            assert_eq!(requests.len(), 2);
+            assert!(requests[0]
+                .iter()
+                .flat_map(|message| &message.content)
+                .any(|block| matches!(block, ContentBlock::ToolResult { tool_use_id, .. } if tool_use_id == TOOL_USE_ID)));
+            assert!(
+                !requests[1]
+                    .iter()
+                    .flat_map(|message| &message.content)
+                    .any(|block| matches!(block, ContentBlock::ToolResult { .. }))
+            );
+        });
+    }
+
+    #[test]
+    fn truncate_oldest_round_preserves_text_beside_orphan() {
+        let mut messages = vec![
+            Message::user("request".into()),
+            tool_use("expected"),
+            Message {
+                role: Role::User,
+                content: vec![
+                    tool_result("mismatched"),
+                    ContentBlock::Text {
+                        text: "keep me".into(),
+                    },
+                ],
+                ..Default::default()
+            },
+            Message::user("prompt".into()),
+        ];
+
+        truncate_oldest_round(&mut messages);
+        assert_tool_results_have_calls(&messages);
+
+        assert_eq!(messages.len(), 2);
+        assert!(
+            matches!(&messages[0].content[..], [ContentBlock::Text { text }] if text == "keep me")
+        );
+        assert_tool_results_have_calls(&messages);
+    }
+
     #[test]
     fn truncate_oldest_round_removes_single_user_message() {
         let mut messages = vec![
@@ -470,6 +636,7 @@ mod tests {
             Message::user("second".into()),
         ];
         truncate_oldest_round(&mut messages);
+        assert_tool_results_have_calls(&messages);
         assert_eq!(messages.len(), 1);
         assert!(matches!(&messages[0].content[0], ContentBlock::Text { text } if text == "second"));
     }
@@ -498,6 +665,7 @@ mod tests {
             Message::user("keep me".into()),
         ];
         truncate_oldest_round(&mut messages);
+        assert_tool_results_have_calls(&messages);
         assert_eq!(messages.len(), 1);
         assert!(
             matches!(&messages[0].content[0], ContentBlock::Text { text } if text == "keep me")
@@ -519,6 +687,7 @@ mod tests {
             Message::user("no tool result".into()),
         ];
         truncate_oldest_round(&mut messages);
+        assert_tool_results_have_calls(&messages);
         assert_eq!(messages.len(), 1);
         assert!(
             matches!(&messages[0].content[0], ContentBlock::Text { text } if text == "no tool result")
@@ -529,6 +698,7 @@ mod tests {
     fn truncate_oldest_round_noop_on_single_message() {
         let mut messages = vec![Message::user("only".into())];
         truncate_oldest_round(&mut messages);
+        assert_tool_results_have_calls(&messages);
         assert_eq!(messages.len(), 1);
     }
 
@@ -545,6 +715,7 @@ mod tests {
             Message::user("keep me".into()),
         ];
         truncate_oldest_round(&mut messages);
+        assert_tool_results_have_calls(&messages);
         assert_eq!(messages.len(), 1);
         assert!(
             matches!(&messages[0].content[0], ContentBlock::Text { text } if text == "keep me")
@@ -584,7 +755,10 @@ mod tests {
             Message::user("keep me".into()),
         ];
         truncate_oldest_round(&mut messages);
-        assert!(!messages.is_empty());
-        assert!(matches!(messages[0].role, Role::User));
+        assert_tool_results_have_calls(&messages);
+        assert_eq!(messages.len(), 1);
+        assert!(
+            matches!(&messages[0].content[..], [ContentBlock::Text { text }] if text == "keep me")
+        );
     }
 }

--- a/maki-agent/src/agent/history.rs
+++ b/maki-agent/src/agent/history.rs
@@ -87,10 +87,8 @@ impl History {
     }
 }
 
-/// Restored sessions can have orphaned tool_results or unclosed tool_uses
-/// (e.g. the process was killed mid-turn). The API returns 400 if it sees those.
-fn sanitize_restored(messages: &mut Vec<Message>) {
-    let len_before = messages.len();
+pub(super) fn remove_orphaned_tool_results(messages: &mut Vec<Message>) -> bool {
+    let mut changed = false;
     let mut i = 0;
     while i < messages.len() {
         if !matches!(messages[i].role, Role::User) {
@@ -107,6 +105,7 @@ fn sanitize_restored(messages: &mut Vec<Message>) {
             Vec::new()
         };
 
+        let content_len = messages[i].content.len();
         let (mut had_results, mut kept_results) = (false, false);
         messages[i].content.retain(|b| match b {
             ContentBlock::ToolResult { tool_use_id, .. } => {
@@ -117,25 +116,33 @@ fn sanitize_restored(messages: &mut Vec<Message>) {
             }
             _ => true,
         });
-        // A tool-returned image whose results were all orphaned would float
-        // with no context, so it goes too. Chat-pasted images live in
-        // messages without tool results and stay untouched.
         if had_results && !kept_results {
             messages[i]
                 .content
                 .retain(|b| !matches!(b, ContentBlock::Image { .. }));
         }
+        changed |= messages[i].content.len() != content_len;
 
         if messages[i].content.is_empty() {
             messages.remove(i);
+            changed = true;
         } else {
             i += 1;
         }
     }
 
-    close_dangling_tool_calls(messages, UNAVAILABLE_RESULT);
+    changed
+}
 
-    if messages.len() != len_before {
+/// Restored sessions can have orphaned tool_results or unclosed tool_uses
+/// (e.g. the process was killed mid-turn). The API returns 400 if it sees those.
+fn sanitize_restored(messages: &mut Vec<Message>) {
+    let len_before = messages.len();
+    let mut changed = remove_orphaned_tool_results(messages);
+    close_dangling_tool_calls(messages, UNAVAILABLE_RESULT);
+    changed |= messages.len() != len_before;
+
+    if changed {
         warn!(
             before = len_before,
             after = messages.len(),
@@ -471,6 +478,23 @@ mod tests {
             ContentBlock::ToolResult { tool_use_id, .. } if tool_use_id == "t1"
         ));
         assert!(matches!(content[1], ContentBlock::Image { .. }));
+    }
+
+    #[test]
+    fn remove_orphaned_tool_results_reports_content_change() {
+        let mut result = make_tool_result_msg(&["orphan"]);
+        result.content.push(ContentBlock::Text {
+            text: "keep me".into(),
+        });
+        let mut messages = vec![result];
+
+        assert!(remove_orphaned_tool_results(&mut messages));
+        assert_eq!(messages.len(), 1);
+        assert!(matches!(
+            &messages[0].content[..],
+            [ContentBlock::Text { text }] if text == "keep me"
+        ));
+        assert!(!remove_orphaned_tool_results(&mut messages));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- remove orphaned tool results before sending compaction requests
- revalidate tool-result IDs after truncating old history rounds
- preserve unrelated text and chat-pasted images while removing contextless tool output
- add regression coverage for context-overflow retries

## Root cause

When a compaction request overflowed the context window, retry truncation could remove an assistant tool call while retaining its following tool result. Strict providers then rejected the orphaned `function_call_output` because its `call_id` no longer existed in the request.

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --all --tests -- -D warnings`
- `cargo nextest run --workspace` (3173 passed)
