### PR TITLE
feat(lua): pass args as a split table to command handlers

### DIFF
--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -657,11 +657,12 @@ fn register_tool(lua: &Lua, #[ctx] pending: PendingTools, spec: Table) -> LuaRes
 ///                          Defaults to 0 (no arguments). Set to -1 for
 ///                          unlimited. An "argument" is a whitespace-separated
 ///                          word, so max_args = 1 breaks on the first space.
-///                          Handler receives the raw arg string, not a list.
 ///                          If the user types more arguments than max_args, the
 ///                          command silently stops matching and the input is sent
 ///                          to the model as a normal message instead.
-///   handler     (function) Required. Called when the user runs the command.
+///   handler     (function) Required. Called with a 1-indexed table of
+///                          whitespace-separated argument strings when the user
+///                          runs the command.
 /// @return
 /// @example
 /// maki.api.register_command({

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -2277,8 +2277,12 @@ pub fn spawn(
                                 let lua = rt.lua.clone();
                                 ex.spawn(async move {
                                     let run = async {
+                                        let args_table = lua.create_table()?;
+                                        for (i, word) in args.split_whitespace().enumerate() {
+                                            args_table.raw_set(i + 1, word)?;
+                                        }
                                         let thread = lua.create_thread(func)?;
-                                        thread.into_async::<()>(args)?.await
+                                        thread.into_async::<()>(args_table)?.await
                                     };
                                     if let Err(e) = run_detached(&lua, run).await {
                                         tracing::warn!(plugin = %plugin, command = %command, error = %e, "command handler failed");

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -257,11 +257,12 @@ browsing memory files or toggling settings.
     Defaults to 0 (no arguments). Set to -1 for
     unlimited. An "argument" is a whitespace-separated
     word, so max_args = 1 breaks on the first space.
-    Handler receives the raw arg string, not a list.
     If the user types more arguments than max_args, the
     command silently stops matching and the input is sent
     to the model as a normal message instead.
-  - `handler` (`function`) Required. Called when the user runs the command.
+  - `handler` (`function`) Required. Called with a 1-indexed table of
+    whitespace-separated argument strings when the user
+    runs the command.
 
 **Example:**
 


### PR DESCRIPTION
as a follow-up to #632, pass arguments as a list to lua handlers instead of a raw string

AI: maki + qwen3.6-27b