### PR TITLE
fix(code_execution): no timeout on subagents inside the sandbox

### DIFF
--- a/maki-interpreter/src/runner.rs
+++ b/maki-interpreter/src/runner.rs
@@ -9,7 +9,8 @@ use std::time::Duration;
 
 use monty::{
     ExcType, ExtFunctionResult, LimitedTracker, MontyException, MontyObject, MontyRun,
-    NameLookupResult, PrintWriter, PrintWriterCallback, ResourceLimits, RunProgress,
+    NameLookupResult, PrintWriter, PrintWriterCallback, ResolveFutures, ResourceLimits,
+    RunProgress,
 };
 use serde_json::Value;
 use tracing::debug;
@@ -17,8 +18,6 @@ use tracing::debug;
 use crate::convert::{json_to_monty, monty_to_json};
 use crate::error::InterpreterError;
 
-const DEFAULT_TIMEOUT_SECS: u64 = 30;
-const DEFAULT_MAX_MEMORY: usize = 50 * 1024 * 1024;
 const DEFAULT_MAX_RECURSION: usize = 100;
 const SCRIPT_NAME: &str = "agent.py";
 
@@ -199,6 +198,7 @@ fn run_inner(
                     .collect();
 
                 let resolved = resolver(batch)?;
+                let state = reset_clock(state)?;
 
                 let results: Vec<(u32, ExtFunctionResult)> = resolved
                     .into_iter()
@@ -222,15 +222,23 @@ fn run_inner(
     }
 }
 
-pub fn default_limits() -> ResourceLimits {
-    limits_with_timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
-}
-
-pub fn limits_with_timeout(timeout: Duration) -> ResourceLimits {
-    ResourceLimits::new()
-        .max_duration(timeout)
-        .max_memory(DEFAULT_MAX_MEMORY)
-        .max_recursion_depth(Some(DEFAULT_MAX_RECURSION))
+/// A script blocked on a tool call (a subagent can run for minutes) must not
+/// burn its own time budget, so every await refreshes it. Monty gives no way
+/// to touch the tracker clock on `ResolveFutures`, but loading a dumped run
+/// starts a fresh clock, so a dump/load round-trip resets it. The copy is
+/// cheap next to any real tool call.
+fn reset_clock(
+    state: ResolveFutures<LimitedTracker>,
+) -> Result<ResolveFutures<LimitedTracker>, InterpreterError> {
+    let bytes = RunProgress::ResolveFutures(state)
+        .dump()
+        .map_err(|e| InterpreterError::Runtime(e.to_string()))?;
+    match RunProgress::load(&bytes).map_err(|e| InterpreterError::Runtime(e.to_string()))? {
+        RunProgress::ResolveFutures(s) => Ok(s),
+        _ => Err(InterpreterError::Runtime(
+            "clock reset produced unexpected state".into(),
+        )),
+    }
 }
 
 pub fn limits(timeout: Duration, max_memory: usize) -> ResourceLimits {
@@ -246,6 +254,12 @@ mod tests {
     use serde_json::json;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    const DEFAULT_MAX_MEMORY: usize = 50 * 1024 * 1024;
+
+    fn default_limits() -> ResourceLimits {
+        limits(Duration::from_secs(30), DEFAULT_MAX_MEMORY)
+    }
 
     fn empty_tools() -> HashMap<String, ToolFn> {
         HashMap::new()
@@ -410,6 +424,33 @@ await main()
             call_count.load(Ordering::SeqCst) >= 2,
             "resolver should be called at least twice for sequential awaits"
         );
+    }
+
+    #[test]
+    fn resolver_wait_does_not_count_against_timeout() {
+        const TIMEOUT: Duration = Duration::from_millis(500);
+        const WAIT: Duration = Duration::from_millis(700);
+        // Two awaits: an implementation that resets the clock only once would
+        // still time out on the second wait.
+        let code = r#"
+async def main():
+    a = await slow()
+    b = await slow()
+    return a + b
+await main()
+"#;
+        let tools = stub_tools(&["slow"]);
+        let resolver: AsyncResolver = Box::new(|pending: Vec<PendingCall>| {
+            std::thread::sleep(WAIT);
+            Ok(pending
+                .into_iter()
+                .map(|pc| (pc.call_id, Ok(json!("done"))))
+                .collect())
+        });
+
+        let lims = limits(TIMEOUT, DEFAULT_MAX_MEMORY);
+        let result = run(code, &tools, Some(&resolver), lims).unwrap();
+        assert_eq!(result.output, Some(json!("donedone")));
     }
 
     #[test]

--- a/plugins/code_execution/init.lua
+++ b/plugins/code_execution/init.lua
@@ -15,14 +15,14 @@ local SEPARATOR = "──────"
 local PREAMBLE = "import re\nimport asyncio\nimport sys\nimport os\nimport json\n"
 local TOOLS_HEADER = "\n\nAvailable tools (called as Python functions with keyword arguments):\n"
 local WORKFLOW_TOOLS_NOTE =
-  "\nWorkflow mode: orchestrate subagents from this script. Await every `task(...)` call and use `asyncio.gather` for parallel fan-out. Pass `output_schema` to task for machine-readable results (a JSON string, parse with `json.loads`). Raise this tool's `timeout` param: subagents outlive the default code_execution timeout.\n"
+  "\nWorkflow mode: orchestrate subagents from this script. Await every `task(...)` call and use `asyncio.gather` for parallel fan-out. Pass `output_schema` to task for machine-readable results (a JSON string, parse with `json.loads`).\n"
 local PY_TYPES = { string = "str", integer = "int", boolean = "bool", array = "list" }
 
 local opts = maki.api.register_options(output_limits.extend({
   timeout_secs = {
     default = 30,
     min = 5,
-    desc = "Stop the script after this many seconds. A call's `timeout` param overrides it.",
+    desc = "Script execution time budget in seconds; waiting on tool calls does not count. A call's `timeout` param overrides it.",
   },
   max_memory_mb = { default = 50, min = 10, desc = "Memory limit for the Python sandbox (MB)." },
 }))
@@ -88,7 +88,7 @@ Use for chained/dependent tool calls and filtering/processing results, e.g. filt
 - Use `asyncio.gather()` for concurrency within one execution.
 - Available libs: re, asyncio, sys, os, json. No other imports, no classes, no filesystem/network access.
 - Fresh sandbox each run: no state persists between executions.
-- 30 second timeout (configurable via `timeout` parameter).
+- 30s script timeout (`timeout` param); time awaiting tool calls doesn't count.
 - Skip it when a single tool call needs no transformation.
 - NOT a thinking scratchpad. Reason in your response text.
 ]]
@@ -104,7 +104,7 @@ local schema = {
     },
     timeout = {
       type = "integer",
-      description = "Timeout in seconds (default 30, max 300)",
+      description = "Script execution timeout in seconds (default 30)",
     },
   },
 }
@@ -223,8 +223,6 @@ local function handler(input, ctx)
   ctx:live_buf(buf)
   maki.async.run(highlight)
 
-  ctx:set_deadline(timeout)
-
   view:append({ { "Waiting for output...", "dim" } })
 
   local waiting = true
@@ -239,8 +237,9 @@ local function handler(input, ctx)
   local tools = {}
   for _, t in ipairs(interpreter_tools(maki.api.get_tools({ config = config }), ctx:audience(), ctx:workflow())) do
     local name = t.name
+    local call_opts = t.workflow_only and {} or { timeout = timeout }
     tools[name] = function(tool_input)
-      return maki.agent.call_tool(ctx, name, tool_input, { timeout = timeout })
+      return maki.agent.call_tool(ctx, name, tool_input, call_opts)
     end
   end
 

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -151,7 +151,7 @@ maki.setup({
 | `max_memory_mb` | integer | `50` | 10 | Memory limit for the Python sandbox (MB). |
 | `max_output_bytes` | integer | - | - | Override `agent.max_output_bytes` for this tool. |
 | `max_output_lines` | integer | - | - | Override `agent.max_output_lines` for this tool. |
-| `timeout_secs` | integer | `30` | 5 | Stop the script after this many seconds. A call's `timeout` param overrides it. |
+| `timeout_secs` | integer | `30` | 5 | Script execution time budget in seconds; waiting on tool calls does not count. A call's `timeout` param overrides it. |
 
 ### `plugins.edit`
 

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -139,7 +139,7 @@ Execute Python code in a sandboxed interpreter with tools as callable functions.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `code` | string | yes |  | Python code to execute. Tools are async functions that return strings (not objects). You MUST await every call: `result = await read(path='/file')`. Use `await asyncio.gather(...)` for concurrency. |
-| `timeout` | integer | no | 30, max 300 | Timeout in seconds |
+| `timeout` | integer | no | 30 | Script execution timeout in seconds |
 
 ### `question` *(lua plugin)*
 


### PR DESCRIPTION
Awaiting `task(...)` from a script died at the sandbox limit: the nested `call_tool` deadline, the `ctx:set_deadline` wall clock, and monty's `max_duration` all counted the wait.

Now workflow-only tools get no `timeout` in `call_tool` and the handler sets no deadline, so subagents run as long as they need, same as a regular `task` call.

Monty has no tracker access on `ResolveFutures`, but its clock restarts on deserialization by design, so after a resolver wait over 500ms a `dump()`/`load()` round-trip grants the resumed script a fresh time budget.

The `timeout` param now only bounds actual script execution, keeping runaway-loop protection.