### PR TITLE
feat(lua): add list mode to maki.fn.jobstart

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -94,9 +94,71 @@ function Install-Maki([string]$Tag) {
 
         Write-Host "$Binary $Tag installed to $dest"
         Add-ToUserPath -Dir $InstallDir
+
+        if (-not (Test-BashAvailable)) {
+            Write-Host ""
+            Write-Host "warning: bash not found on Windows. The bash tool requires Git for Windows or WSL."
+            if (Test-WinGetAvailable) {
+                $response = Read-Host "Install Git for Windows via winget? (y/N)"
+                if ($response -eq 'y' -or $response -eq 'Y') {
+                    Write-Host "Installing Git for Windows..."
+                    winget install --id Git.Git -e --source winget
+                    Write-Host "Git for Windows installed. Restart your terminal to use bash."
+                } else {
+                    Write-Host "To install manually:"
+                    Write-Host "  winget install --id Git.Git -e --source winget"
+                    Write-Host "  or download from https://git-scm.com/download/win"
+                    Write-Host ""
+                    Write-Host "Alternatively, enable WSL: https://learn.microsoft.com/en-us/windows/wsl/install"
+                }
+            } else {
+                Write-Host "To install Git for Windows:"
+                Write-Host "  Download from https://git-scm.com/download/win"
+                Write-Host ""
+                Write-Host "Alternatively, enable WSL: https://learn.microsoft.com/en-us/windows/wsl/install"
+            }
+        }
     } finally {
         Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction SilentlyContinue
     }
+}
+
+function Test-BashAvailable {
+    $paths = $env:Path -split ';'
+    foreach ($dir in $paths) {
+        $bashPath = Join-Path $dir.Trim('"') "bash.exe"
+        if (Test-Path -LiteralPath $bashPath -PathType Leaf) {
+            return $true
+        }
+    }
+    $candidates = @(
+        "C:\Program Files\Git\bin\bash.exe",
+        "C:\Program Files\Git\usr\bin\bash.exe",
+        "C:\Program Files (x86)\Git\bin\bash.exe",
+        "C:\cygwin64\bin\bash.exe",
+        "C:\cygwin\bin\bash.exe",
+        "C:\msys64\usr\bin\bash.exe",
+        "C:\msys32\usr\bin\bash.exe"
+    )
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            return $true
+        }
+    }
+    foreach ($dir in $paths) {
+        $wslPath = Join-Path $dir.Trim('"') "wsl.exe"
+        if (Test-Path -LiteralPath $wslPath -PathType Leaf) {
+            return $true
+        }
+    }
+    if (Test-Path -LiteralPath "C:\Windows\System32\wsl.exe" -PathType Leaf) {
+        return $true
+    }
+    return $false
+}
+
+function Test-WinGetAvailable {
+    return $null -ne (Get-Command winget -ErrorAction Ignore)
 }
 
 function Add-ToUserPath([string]$Dir) {

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::Duration;
 
 use maki_config_macro::ConfigSection;
@@ -1512,6 +1513,90 @@ fn collect_env_vars(path: &Path, vars: &mut HashMap<String, String>) {
 
 pub fn load_env_files(cwd: &Path) {
     load_env_files_with_global(cwd, global_dir().as_deref());
+}
+
+/// Error message shown when no Bash-compatible runtime is found on Windows.
+#[cfg(windows)]
+const BASH_NOT_FOUND_ERROR: &str = "bash not found on Windows. Install Git for Windows:\n  \
+     winget install --id Git.Git -e --source winget\n  \
+     or download from https://git-scm.com/download/win\n\n  \
+     Alternatively, enable WSL: \
+     https://learn.microsoft.com/en-us/windows/wsl/install";
+
+/// Search PATH and common install paths for a Bash executable.
+#[cfg(windows)]
+fn find_bash_on_path() -> Option<PathBuf> {
+    std::env::var_os("PATH")
+        .and_then(|paths| {
+            std::env::split_paths(&paths).find_map(|dir| {
+                let bash = dir.join("bash.exe");
+                if bash.is_file() { Some(bash) } else { None }
+            })
+        })
+        .or_else(|| {
+            let candidates = [
+                // Git for Windows
+                r"C:\Program Files\Git\bin\bash.exe",
+                r"C:\Program Files\Git\usr\bin\bash.exe",
+                r"C:\Program Files (x86)\Git\bin\bash.exe",
+                // Cygwin
+                r"C:\cygwin64\bin\bash.exe",
+                r"C:\cygwin\bin\bash.exe",
+                // MSYS2
+                r"C:\msys64\usr\bin\bash.exe",
+                r"C:\msys32\usr\bin\bash.exe",
+            ];
+            candidates.iter().find_map(|p| {
+                let path = PathBuf::from(p);
+                path.is_file().then_some(path)
+            })
+        })
+}
+
+/// Search PATH and System32 for `wsl.exe`.
+#[cfg(windows)]
+fn find_wsl() -> Option<PathBuf> {
+    std::env::var_os("PATH")
+        .and_then(|paths| {
+            std::env::split_paths(&paths).find_map(|dir| {
+                let wsl = dir.join("wsl.exe");
+                if wsl.is_file() { Some(wsl) } else { None }
+            })
+        })
+        .or_else(|| {
+            let path = PathBuf::from(r"C:\Windows\System32\wsl.exe");
+            path.is_file().then_some(path)
+        })
+}
+
+/// Build a `bash -c` command for the given shell string.
+///
+/// Mirrors Neovim's list-form `jobstart(['bash', '-c', ...])`: the command
+/// string is passed as a single argv element, so quoting is preserved by the
+/// C runtime / libuv argument parser instead of being reinterpreted by
+/// cmd.exe. On Windows, searches PATH and known install locations for Git
+/// Bash, Cygwin, MSYS2 and falls back to WSL's `wsl.exe -e bash -c`.
+pub fn bash_command(cmd: &str) -> Result<Command, String> {
+    #[cfg(unix)]
+    {
+        let mut c = Command::new("bash");
+        c.arg("-c").arg(cmd);
+        Ok(c)
+    }
+    #[cfg(windows)]
+    {
+        if let Some(bash) = find_bash_on_path() {
+            let mut c = Command::new(bash);
+            c.arg("-c").arg(cmd);
+            return Ok(c);
+        }
+        if let Some(wsl) = find_wsl() {
+            let mut c = Command::new(wsl);
+            c.arg("-e").arg("bash").arg("-c").arg(cmd);
+            return Ok(c);
+        }
+        Err(BASH_NOT_FOUND_ERROR.to_string())
+    }
 }
 
 pub fn load_permissions(cwd: &Path) -> PermissionsConfig {

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -1523,50 +1523,67 @@ const BASH_NOT_FOUND_ERROR: &str = "bash not found on Windows. Install Git for W
      Alternatively, enable WSL: \
      https://learn.microsoft.com/en-us/windows/wsl/install";
 
-/// Search PATH and common install paths for a Bash executable.
+/// Search common install paths for a Bash executable, then scan PATH.
+///
+/// Known install locations (Git for Windows, Cygwin, MSYS2) are checked
+/// first so that `C:\Windows\System32\bash.exe` (the legacy WSL launcher
+/// that appears on any machine with WSL enabled) is never preferred over
+/// a real Git Bash. PATH entries under `%SystemRoot%` are skipped for the
+/// same reason.
 #[cfg(windows)]
 fn find_bash_on_path() -> Option<PathBuf> {
-    std::env::var_os("PATH")
-        .and_then(|paths| {
-            std::env::split_paths(&paths).find_map(|dir| {
-                let bash = dir.join("bash.exe");
-                if bash.is_file() { Some(bash) } else { None }
-            })
+    let candidates = [
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files\Git\usr\bin\bash.exe",
+        r"C:\Program Files (x86)\Git\bin\bash.exe",
+        r"C:\cygwin64\bin\bash.exe",
+        r"C:\cygwin\bin\bash.exe",
+        r"C:\msys64\usr\bin\bash.exe",
+        r"C:\msys32\usr\bin\bash.exe",
+    ];
+    for p in &candidates {
+        let path = PathBuf::from(p);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    let system_root = std::env::var_os("SystemRoot").unwrap_or_else(|| "C:\\Windows".into());
+    std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths).find_map(|dir| {
+            if dir.as_os_str() == system_root {
+                return None;
+            }
+            let bash = dir.join("bash.exe");
+            bash.is_file().then_some(bash)
         })
-        .or_else(|| {
-            let candidates = [
-                // Git for Windows
-                r"C:\Program Files\Git\bin\bash.exe",
-                r"C:\Program Files\Git\usr\bin\bash.exe",
-                r"C:\Program Files (x86)\Git\bin\bash.exe",
-                // Cygwin
-                r"C:\cygwin64\bin\bash.exe",
-                r"C:\cygwin\bin\bash.exe",
-                // MSYS2
-                r"C:\msys64\usr\bin\bash.exe",
-                r"C:\msys32\usr\bin\bash.exe",
-            ];
-            candidates.iter().find_map(|p| {
-                let path = PathBuf::from(p);
-                path.is_file().then_some(path)
-            })
-        })
+    })
 }
 
-/// Search PATH and System32 for `wsl.exe`.
+/// Search PATH and System32 for `wsl.exe`, then verify a distro is
+/// actually installed by running `wsl.exe -e true`. `wsl.exe` ships in
+/// System32 on stock Windows 10/11 even when no distro is installed, so
+/// blindly trusting its presence leads to garbled UTF-16 "no installed
+/// distributions" output instead of our nice error message.
 #[cfg(windows)]
 fn find_wsl() -> Option<PathBuf> {
-    std::env::var_os("PATH")
-        .and_then(|paths| {
-            std::env::split_paths(&paths).find_map(|dir| {
-                let wsl = dir.join("wsl.exe");
-                if wsl.is_file() { Some(wsl) } else { None }
-            })
+    let wsl = std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths).find_map(|dir| {
+            let wsl = dir.join("wsl.exe");
+            wsl.is_file().then_some(wsl)
         })
-        .or_else(|| {
-            let path = PathBuf::from(r"C:\Windows\System32\wsl.exe");
-            path.is_file().then_some(path)
-        })
+    })
+    .or_else(|| {
+        let path = PathBuf::from(r"C:\Windows\System32\wsl.exe");
+        path.is_file().then_some(path)
+    })?;
+    let ok = std::process::Command::new(&wsl)
+        .arg("-e")
+        .arg("true")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success());
+    if ok { Some(wsl) } else { None }
 }
 
 /// Build a `bash -c` command for the given shell string.
@@ -1576,7 +1593,13 @@ fn find_wsl() -> Option<PathBuf> {
 /// C runtime / libuv argument parser instead of being reinterpreted by
 /// cmd.exe. On Windows, searches PATH and known install locations for Git
 /// Bash, Cygwin, MSYS2 and falls back to WSL's `wsl.exe -e bash -c`.
-pub fn bash_command(cmd: &str) -> Result<Command, String> {
+///
+/// When `env` is provided and the WSL fallback is used, the variable names are
+/// appended to `WSLENV` so they cross the Windows/Linux boundary (otherwise
+/// `.env(...)` only sets them on the `wsl.exe` process and they are silently
+/// dropped inside the Linux shell).
+#[cfg_attr(unix, allow(unused_variables))]
+pub fn bash_command(cmd: &str, env: Option<&HashMap<String, String>>) -> Result<Command, String> {
     #[cfg(unix)]
     {
         let mut c = Command::new("bash");
@@ -1593,6 +1616,15 @@ pub fn bash_command(cmd: &str) -> Result<Command, String> {
         if let Some(wsl) = find_wsl() {
             let mut c = Command::new(wsl);
             c.arg("-e").arg("bash").arg("-c").arg(cmd);
+            if let Some(env_map) = env {
+                let wsl_env: Vec<String> = env_map
+                    .keys()
+                    .map(|k| format!("{k}/p"))
+                    .collect();
+                if !wsl_env.is_empty() {
+                    c.env("WSLENV", wsl_env.join(":"));
+                }
+            }
             return Ok(c);
         }
         Err(BASH_NOT_FOUND_ERROR.to_string())

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -1566,16 +1566,17 @@ fn find_bash_on_path() -> Option<PathBuf> {
 /// distributions" output instead of our nice error message.
 #[cfg(windows)]
 fn find_wsl() -> Option<PathBuf> {
-    let wsl = std::env::var_os("PATH").and_then(|paths| {
-        std::env::split_paths(&paths).find_map(|dir| {
-            let wsl = dir.join("wsl.exe");
-            wsl.is_file().then_some(wsl)
+    let wsl = std::env::var_os("PATH")
+        .and_then(|paths| {
+            std::env::split_paths(&paths).find_map(|dir| {
+                let wsl = dir.join("wsl.exe");
+                wsl.is_file().then_some(wsl)
+            })
         })
-    })
-    .or_else(|| {
-        let path = PathBuf::from(r"C:\Windows\System32\wsl.exe");
-        path.is_file().then_some(path)
-    })?;
+        .or_else(|| {
+            let path = PathBuf::from(r"C:\Windows\System32\wsl.exe");
+            path.is_file().then_some(path)
+        })?;
     let ok = std::process::Command::new(&wsl)
         .arg("-e")
         .arg("true")
@@ -1617,10 +1618,7 @@ pub fn bash_command(cmd: &str, env: Option<&HashMap<String, String>>) -> Result<
             let mut c = Command::new(wsl);
             c.arg("-e").arg("bash").arg("-c").arg(cmd);
             if let Some(env_map) = env {
-                let wsl_env: Vec<String> = env_map
-                    .keys()
-                    .map(|k| format!("{k}/p"))
-                    .collect();
+                let wsl_env: Vec<String> = env_map.keys().map(|k| format!("{k}/p")).collect();
                 if !wsl_env.is_empty() {
                     c.env("WSLENV", wsl_env.join(":"));
                 }

--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -568,7 +568,7 @@ mod tests {
     fn dropping_the_store_kills_its_jobs() {
         let mut store = make_store();
         let id = store
-            .start("sleep 30", None, None, None, None, None)
+            .start(JobSpec::Shell("sleep 30".into()), None, None, None, None, None)
             .expect("job started");
         let pid = store.jobs[&id].pid;
         assert!(group_alive(pid), "job should be running before the drop");

--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -55,7 +55,7 @@ impl JobStore {
         on_stderr: Option<RegistryKey>,
         on_exit: Option<RegistryKey>,
     ) -> Result<u32, String> {
-        let mut command = maki_config::bash_command(cmd)?;
+        let mut command = maki_config::bash_command(cmd, env.as_ref())?;
         command
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::env;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 use std::thread;
 use std::time::Duration;
 
@@ -55,7 +55,7 @@ impl JobStore {
         on_stderr: Option<RegistryKey>,
         on_exit: Option<RegistryKey>,
     ) -> Result<u32, String> {
-        let mut command = shell_command(cmd);
+        let mut command = maki_config::bash_command(cmd)?;
         command
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -224,21 +224,6 @@ impl JobStore {
 impl Drop for JobStore {
     fn drop(&mut self) {
         self.kill_all();
-    }
-}
-
-fn shell_command(cmd: &str) -> Command {
-    #[cfg(unix)]
-    {
-        let mut c = Command::new("bash");
-        c.arg("-c").arg(cmd);
-        c
-    }
-    #[cfg(windows)]
-    {
-        let mut c = Command::new("cmd.exe");
-        c.arg("/C").arg(cmd);
-        c
     }
 }
 

--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::env;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
-use std::process::Stdio;
+use std::process::{Command, Stdio};
 use std::thread;
 use std::time::Duration;
 
@@ -16,6 +16,12 @@ use crate::plugin_permissions::PluginPermissions;
 use crate::runtime::with_task_jobs;
 
 const READER_BUF_SIZE: usize = 8 * 1024;
+
+#[derive(Clone)]
+pub(crate) enum JobSpec {
+    Shell(String),
+    Program { program: String, args: Vec<String> },
+}
 
 #[derive(Clone)]
 pub(crate) enum JobEvent {
@@ -48,14 +54,21 @@ impl JobStore {
 
     pub fn start(
         &mut self,
-        cmd: &str,
+        spec: JobSpec,
         cwd: Option<String>,
         env: Option<HashMap<String, String>>,
         on_stdout: Option<RegistryKey>,
         on_stderr: Option<RegistryKey>,
         on_exit: Option<RegistryKey>,
     ) -> Result<u32, String> {
-        let mut command = maki_config::bash_command(cmd, env.as_ref())?;
+        let mut command = match spec {
+            JobSpec::Shell(cmd) => maki_config::bash_command(&cmd, env.as_ref())?,
+            JobSpec::Program { program, args } => {
+                let mut c = Command::new(&program);
+                c.args(&args);
+                c
+            }
+        };
         command
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -255,7 +268,11 @@ fn kill_job(meta: &mut JobMeta) {
 /// `bash -c` on Unix or `cmd /C` on Windows. You get back a job id
 /// that you can pass to `jobstop` or `jobwait` to control the process.
 ///
-/// @param cmd string Shell command to run.
+/// For commands that don't need shell features (pipes, redirection, globs),
+/// pass an array to run the program directly with preserved argument quoting:
+/// `maki.fn.jobstart({ "git", "commit", "-m", "feat: msg" })`
+///
+/// @param cmd string|table Shell command string, or array of program + args.
 /// @param opts table? Optional settings:
 ///   `cwd` (string?) working directory (tilde is expanded).
 ///   `env` (table?) extra environment variables, `{ VAR = "value" }`.
@@ -270,7 +287,39 @@ fn kill_job(meta: &mut JobMeta) {
 ///   on_exit = function(_, code) print("exit: " .. code) end,
 /// })
 #[lua_fn(guard = Run)]
-fn jobstart(lua: &Lua, cmd: String, opts: Option<Table>) -> LuaResult<u32> {
+fn jobstart(lua: &Lua, cmd: Value, opts: Option<Table>) -> LuaResult<u32> {
+    let spec = match cmd {
+        Value::String(s) => JobSpec::Shell(s.to_str()?.to_owned()),
+        Value::Table(tbl) => {
+            // Treat tables as arrays (list mode): first element is program, rest are args
+            let len = tbl.len().unwrap_or(0);
+            if len == 0 {
+                return Err(mlua::Error::runtime(
+                    "jobstart array must have at least a program",
+                ));
+            }
+            let program: String = tbl
+                .get::<String>(1)
+                .map_err(|e| mlua::Error::runtime(format!("jobstart program must be a string: {e}")))?;
+            if program.is_empty() {
+                return Err(mlua::Error::runtime(
+                    "jobstart program cannot be empty string",
+                ));
+            }
+            // Collect remaining args, filtering out empty strings
+            let args: Vec<String> = (2..=len)
+                .filter_map(|i| tbl.get::<String>(i).ok())
+                .filter(|s| !s.is_empty())
+                .collect();
+            JobSpec::Program { program, args }
+        }
+        _ => {
+            return Err(mlua::Error::runtime(
+                "jobstart expects a string or array",
+            ))
+        }
+    };
+
     let (cwd, env, on_stdout, on_stderr, on_exit) = match opts {
         Some(ref opts) => {
             let cwd: Option<String> = opts.get("cwd").ok();
@@ -299,7 +348,7 @@ fn jobstart(lua: &Lua, cmd: String, opts: Option<Table>) -> LuaResult<u32> {
     };
 
     with_task_jobs(lua, |store| {
-        store.start(&cmd, cwd, env, on_stdout, on_stderr, on_exit)
+        store.start(spec, cwd, env, on_stdout, on_stderr, on_exit)
     })
     .map_err(mlua::Error::runtime)
 }
@@ -499,7 +548,7 @@ mod tests {
 
     fn start_echo(store: &mut JobStore) -> u32 {
         store
-            .start("echo hello", None, None, None, None, None)
+            .start(JobSpec::Shell("echo hello".into()), None, None, None, None, None)
             .unwrap()
     }
 
@@ -537,7 +586,7 @@ mod tests {
     fn start_invalid_cwd_returns_error() {
         let mut store = make_store();
         let result = store.start(
-            "echo hello",
+            JobSpec::Shell("echo hello".into()),
             Some("/nonexistent_dir_abc_xyz_123".into()),
             None,
             None,

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -2749,6 +2749,7 @@ pub fn spawn(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::r#fn::JobSpec;
     use crate::api::tool::ToolCallReply;
     use futures_lite::future::poll_once;
     use maki_agent::cancel::CancelTrigger;
@@ -3649,7 +3650,7 @@ mod tests {
             let scope = TaskScope::new(&lua, cell);
             lock_cell(scope.handle())
                 .jobs
-                .start(DISPATCH_TEST_JOB, None, None, None, None, None)
+                .start(JobSpec::Shell(DISPATCH_TEST_JOB.into()), None, None, None, None, None)
                 .unwrap();
             let (_finish_tx, finish_rx) = flume::bounded(1);
 

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -3781,4 +3781,101 @@ mod read_tool_required_params {
             "offset beyond file should return empty, got: {out}"
         );
     }
+/// List mode runs the program directly without shell interpretation.
+/// This preserves argument quoting (the core fix for #602).
+#[test]
+fn jobstart_list_mode_preserve_arg_quoting() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "job_list",
+            description = "runs program directly via list mode",
+            schema = {MINIMAL_SCHEMA},
+            audiences = {{ "main" }},
+            handler = function(input, ctx)
+                maki.fn.jobstart({{"echo", "hello world"}}, {{
+                    on_exit = function(_, code)
+                        ctx:finish("exit=" .. tostring(code))
+                    end
+                }})
+            end
+        }})"#
+    );
+    host.load_source("job_list", &src).unwrap();
+    let out = exec_tool(&reg, "job_list", serde_json::json!({})).unwrap();
+    assert_eq!(out, "exit=0");
+}
+
+/// List mode with multiple args works correctly.
+#[test]
+fn jobstart_list_mode_multiple_args() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "job_multi",
+            description = "tests multiple args in list mode",
+            schema = {MINIMAL_SCHEMA},
+            audiences = {{ "main" }},
+            handler = function(input, ctx)
+                local seen = {{}}
+                local exit_code
+                maki.fn.jobstart({{"echo", "-n", "a", "b", "c"}}, {{
+                    on_stdout = function(_, line) seen[#seen + 1] = line end
+                }})
+                local res = maki.fn.jobwait(1)
+                return table.concat(seen, ",")
+            end
+        }})"#
+    );
+    host.load_source("job_multi", &src).unwrap();
+    let out = exec_tool(&reg, "job_multi", serde_json::json!({})).unwrap();
+    // echo -n a b c should output "a b c" without trailing newline
+    assert_eq!(out, "a b c");
+}
+
+/// Empty table for list mode errors appropriately.
+#[test]
+fn jobstart_list_mode_empty_table_errors() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "job_empty",
+            description = "empty array errors",
+            schema = {MINIMAL_SCHEMA},
+            audiences = {{ "main" }},
+            handler = function(input, ctx)
+                local _, err = pcall(maki.fn.jobstart, {{}})
+                return tostring(err)
+            end
+        }})"#
+    );
+    host.load_source("job_empty", &src).unwrap();
+    let out = exec_tool(&reg, "job_empty", serde_json::json!({})).unwrap();
+    assert!(out.contains("must have at least a program"), "got: {out}");
+}
+
+/// Non-string in array errors appropriately.
+#[test]
+fn jobstart_list_mode_non_string_arg_errors() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "job_nonstr",
+            description = "non-string arg errors",
+            schema = {MINIMAL_SCHEMA},
+            audiences = {{ "main" }},
+            handler = function(input, ctx)
+                local _, err = pcall(maki.fn.jobstart, {{123, "echo"}})
+                return tostring(err)
+            end
+        }})"#
+    );
+    host.load_source("job_nonstr", &src).unwrap();
+    let out = exec_tool(&reg, "job_nonstr", serde_json::json!({})).unwrap();
+    // When a non-string is in the array, mlua's get::<String> will error
+    assert!(!out.is_empty(), "got empty error string");
 }

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -3781,6 +3781,8 @@ mod read_tool_required_params {
             "offset beyond file should return empty, got: {out}"
         );
     }
+}
+
 /// List mode runs the program directly without shell interpretation.
 /// This preserves argument quoting (the core fix for #602).
 #[test]

--- a/maki-ui/src/app/shell.rs
+++ b/maki-ui/src/app/shell.rs
@@ -13,7 +13,7 @@ use maki_agent::{
 };
 use maki_providers::Message;
 
-use maki_config;
+use maki_config::bash_command;
 
 use super::App;
 
@@ -214,7 +214,7 @@ async fn run_command(
     max_output_lines: usize,
     max_output_bytes: usize,
 ) -> Result<String, String> {
-    let mut std_cmd: StdCommand = maki_config::bash_command(command)?;
+    let mut std_cmd: StdCommand = bash_command(command, None)?;
     std_cmd.env("GIT_TERMINAL_PROMPT", "0");
     #[cfg(unix)]
     unsafe {

--- a/maki-ui/src/app/shell.rs
+++ b/maki-ui/src/app/shell.rs
@@ -13,6 +13,8 @@ use maki_agent::{
 };
 use maki_providers::Message;
 
+use maki_config;
+
 use super::App;
 
 const STREAM_FLUSH_INTERVAL: Duration = Duration::from_millis(100);
@@ -212,12 +214,8 @@ async fn run_command(
     max_output_lines: usize,
     max_output_bytes: usize,
 ) -> Result<String, String> {
-    let mut std_cmd = StdCommand::new("bash");
-    std_cmd
-        .arg("-c")
-        .arg(command)
-        .env("GIT_TERMINAL_PROMPT", "0");
-
+    let mut std_cmd: StdCommand = maki_config::bash_command(command)?;
+    std_cmd.env("GIT_TERMINAL_PROMPT", "0");
     #[cfg(unix)]
     unsafe {
         std_cmd.pre_exec(|| {

--- a/maki-ui/src/app/shell.rs
+++ b/maki-ui/src/app/shell.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::process::Command as StdCommand;
 use std::time::{Duration, Instant};
 
@@ -214,8 +214,10 @@ async fn run_command(
     max_output_lines: usize,
     max_output_bytes: usize,
 ) -> Result<String, String> {
-    let mut std_cmd: StdCommand = bash_command(command, None)?;
-    std_cmd.env("GIT_TERMINAL_PROMPT", "0");
+    let mut env = HashMap::new();
+    env.insert("GIT_TERMINAL_PROMPT".to_string(), "0".to_string());
+    let mut std_cmd: StdCommand = bash_command(command, Some(&env))?;
+    std_cmd.envs(&env);
     #[cfg(unix)]
     unsafe {
         std_cmd.pre_exec(|| {

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -1308,13 +1308,17 @@ local id = maki.fn.jobstart("git status", {
 maki.fn.jobstart({cmd}, {opts?})
 ```
 
-Run a shell command in the background. The command runs through
-`bash -c` on Unix or `cmd /C` on Windows. You get back a job id
-that you can pass to `jobstop` or `jobwait` to control the process.
+Run a command in the background.
+
+**String mode** runs through `bash -c` on all platforms. On Windows, you need Git Bash or WSL installed. Use this when you need shell features like pipes, redirection, or variable expansion.
+
+**List mode** runs the program directly with preserved argument quoting. Pass an array where the first element is the program and the rest are arguments. This is the safer choice for commands with spaces or special characters in arguments.
+
+You get back a job id that you can pass to `jobstop` or `jobwait` to control the process.
 
 **Parameters:**
 
-- `{cmd}` (`string`) Shell command to run.
+- `{cmd}` (`string|table`) Shell command string, or array of `[program, arg1, arg2, ...]`.
 - `{opts?}` (`table?`) Optional settings:
   - `cwd` (`string?`) working directory (tilde is expanded).
   - `env` (`table?`) extra environment variables, `{ VAR = "value" }`.
@@ -1324,12 +1328,18 @@ that you can pass to `jobstop` or `jobwait` to control the process.
 
 **Returns:** (`integer`) Job id.
 
-**Example:**
+**Examples:**
 
 ```lua
+-- String mode (shell features available)
 local id = maki.fn.jobstart("ls -la", {
   cwd = "~/projects",
   on_stdout = function(_, line) print(line) end,
+  on_exit = function(_, code) print("exit: " .. code) end,
+})
+
+-- List mode (preserves argument quoting)
+local id = maki.fn.jobstart({ "git", "commit", "-m", "feat: preserve spaces" }, {
   on_exit = function(_, code) print("exit: " .. code) end,
 })
 ```

--- a/site/docs/content/quick-start/_index.md
+++ b/site/docs/content/quick-start/_index.md
@@ -53,6 +53,8 @@ curl -fsSL https://maki.sh/install.sh | sh
 
 Both install to `%LOCALAPPDATA%\maki` and add it to your user PATH. Override with `MAKI_INSTALL_DIR` / `$env:MAKI_INSTALL_DIR`.
 
+The bash tool requires Git for Windows or WSL. The installer will detect missing bash and offer to install Git for Windows via winget.
+
 ### Living on the edge (main branch)
 
 ```sh


### PR DESCRIPTION
> **Stacked on #617** — merge that PR first so this diff only shows the list-mode changes.

## Summary

Adds list mode to `maki.fn.jobstart()`, matching Neovim's `jobstart()` API pattern. This gives plugins a way to spawn processes with preserved argument quoting, avoiding shell parsing issues.

## Background

Issue #602 identified that the `bash` tool mangles quoted arguments because it runs through `cmd.exe /C` on Windows. The related PR #617 fixes the immediate Windows issue by resolving a real `bash.exe`, but the underlying Lua API only accepted shell strings.

This PR adds a **list mode** to `jobstart()` as the cleaner long-term primitive: plugins can pass `[program, arg1, arg2, ...]` directly, bypassing the shell entirely.

## Changes

- `JobStore::start` now accepts a `JobSpec` enum (`Shell` or `Program`)
- `maki.fn.jobstart()` Lua API accepts:
  - **string** -> shell mode (`bash -c`, etc.)
  - **table** -> list mode (direct exec, preserved quoting)
- Added tests for list mode behavior
- Updated Lua API docs

## Example

```lua
-- String mode (shell features available)
local id = maki.fn.jobstart("ls -la", opts)

-- List mode (preserves argument quoting)
local id = maki.fn.jobstart({ "git", "commit", "-m", "feat: preserve spaces" }, opts)
```

Signed-off-by: w0wl0lxd <w0wl0lxd@tuta.com>
