### PR TITLE
fix(providers): honor providers.toml base_url for built-in providers

### DIFF
--- a/maki-config/src/providers.rs
+++ b/maki-config/src/providers.rs
@@ -11,6 +11,8 @@ use maki_storage::paths;
 
 const PROVIDERS_FILE: &str = "providers.toml";
 const BAD_CONFIG_EXIT_CODE: i32 = 2;
+/// The only built-in that reads `enable_free_models`.
+const OPENCODE_SLUG: &str = "opencode";
 
 /// Coarse capability classification used by maki-providers to dispatch tiered
 /// requests. Mirrors `maki_providers::ModelTier` shape but lives here so the
@@ -177,7 +179,7 @@ impl ProvidersConfig {
                 return Self::default();
             }
         };
-        match toml::from_str(&content) {
+        match toml::from_str::<ProvidersConfig>(&content) {
             Ok(config) => {
                 debug!(path = %path.display(), "loaded providers config");
                 config
@@ -255,27 +257,52 @@ pub fn base_url_override(slug: &str) -> Option<String> {
         .filter(|url| !url.is_empty())
 }
 
-pub fn resolve_base_url(slug: &str, def: Option<&ProviderDef>) -> Option<String> {
-    // Env override wins over config and built-in defaults.
+/// Env override then `providers.toml`, without the built-in default. Callers
+/// that already carry a default (the openai-compat layer, whose static default
+/// can be more specific than the inventory one) use this.
+pub fn configured_base_url(slug: &str, def: Option<&ProviderDef>) -> Option<String> {
     if let Some(url) = base_url_override(slug) {
         return Some(url);
     }
-    if let Some(d) = def {
-        if let Some(url) = &d.base_url {
-            return Some(url.clone());
-        }
-        if let Some(plan_name) = &d.plan
-            && let Some(builtin) = builtin_provider(slug)
-            && let Some(plans) = builtin.plans
-        {
-            for (key, plan) in plans {
-                if key == plan_name {
-                    return Some(plan.base_url.to_string());
-                }
-            }
-        }
+    let def = def?;
+    if let Some(url) = &def.base_url {
+        return Some(url.clone());
     }
-    builtin_provider(slug).map(|b| b.default_base_url.to_string())
+    let plan_name = def.plan.as_ref()?;
+    builtin_provider(slug)?
+        .plans?
+        .iter()
+        .find(|(key, _)| key == plan_name)
+        .map(|(_, plan)| plan.base_url.to_string())
+}
+
+pub fn resolve_base_url(slug: &str, def: Option<&ProviderDef>) -> Option<String> {
+    configured_base_url(slug, def)
+        .or_else(|| builtin_provider(slug).map(|b| b.default_base_url.to_string()))
+}
+
+/// Fields a `providers.toml` entry sets that a built-in slug ignores, because
+/// built-ins keep their compiled protocol, model catalog and auth wiring.
+/// Callers decide what counts as built-in (the inventory misses `openrouter`
+/// and `opencode`) and when to report it.
+pub fn ignored_builtin_fields(slug: &str, def: &ProviderDef) -> Vec<&'static str> {
+    let mut ignored = Vec::new();
+    if def.protocol.is_some() {
+        ignored.push("protocol");
+    }
+    if def.api_key_env.is_some() {
+        ignored.push("api_key_env");
+    }
+    if def.discover_models {
+        ignored.push("discover_models");
+    }
+    if !def.models.is_empty() {
+        ignored.push("models");
+    }
+    if def.enable_free_models.is_some() && slug != OPENCODE_SLUG {
+        ignored.push("enable_free_models");
+    }
+    ignored
 }
 
 pub fn resolve_protocol(slug: &str, def: Option<&ProviderDef>) -> Option<Protocol> {
@@ -413,6 +440,95 @@ tier = "{input}"
     #[test_case("my-custom", None => "MY_CUSTOM_API_KEY".to_string(); "custom_default")]
     fn resolve_api_key_env_tests(slug: &str, def: Option<&ProviderDef>) -> String {
         resolve_api_key_env(slug, def)
+    }
+
+    #[test]
+    fn resolve_base_url_prefers_def_over_none() {
+        // Unique slug: `openai` would pick up a real OPENAI_BASE_URL from the shell.
+        let slug = "maki-test-def-over-none-slug";
+        let def = ProviderDef {
+            base_url: Some("http://proxy.local/v1".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_base_url(slug, Some(&def)).as_deref(),
+            Some("http://proxy.local/v1")
+        );
+        assert_ne!(
+            resolve_base_url(slug, Some(&def)),
+            resolve_base_url(slug, None)
+        );
+    }
+
+    #[test]
+    fn resolve_base_url_empty_def_matches_none() {
+        let slug = "maki-test-empty-def-slug";
+        let def = ProviderDef::default();
+        assert_eq!(
+            resolve_base_url(slug, Some(&def)),
+            resolve_base_url(slug, None)
+        );
+    }
+
+    #[test]
+    fn resolve_base_url_custom_slug_uses_def() {
+        let slug = "maki-test-custom-base-url-slug";
+        let def = ProviderDef {
+            base_url: Some("http://xxxx:1234/v1".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_base_url(slug, Some(&def)).as_deref(),
+            Some("http://xxxx:1234/v1")
+        );
+        assert_eq!(resolve_base_url(slug, None), None);
+    }
+
+    #[test]
+    fn resolve_base_url_env_beats_def() {
+        let slug = "maki-test-env-base-url-slug";
+        let env_var = base_url_env_var(slug);
+        // SAFETY: unique test-only var; removed before the test returns.
+        unsafe {
+            std::env::set_var(&env_var, "http://env.local/v1");
+        }
+        let def = ProviderDef {
+            base_url: Some("http://toml.local/v1".into()),
+            ..Default::default()
+        };
+        let got = resolve_base_url(slug, Some(&def));
+        unsafe {
+            std::env::remove_var(&env_var);
+        }
+        assert_eq!(got.as_deref(), Some("http://env.local/v1"));
+    }
+
+    #[test]
+    fn ignored_builtin_fields_lists_custom_only_fields() {
+        let def = ProviderDef {
+            base_url: Some("http://proxy.local/v1".into()),
+            protocol: Some(Protocol::Openai),
+            api_key_env: Some("MY_KEY".into()),
+            discover_models: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            ignored_builtin_fields("anthropic", &def),
+            ["protocol", "api_key_env", "discover_models"]
+        );
+    }
+
+    #[test]
+    fn ignored_builtin_fields_keeps_opencode_free_models() {
+        let def = ProviderDef {
+            enable_free_models: Some(false),
+            ..Default::default()
+        };
+        assert!(ignored_builtin_fields(OPENCODE_SLUG, &def).is_empty());
+        assert_eq!(
+            ignored_builtin_fields("openrouter", &def),
+            ["enable_free_models"]
+        );
     }
 
     #[test_case("MyProvider", "myprovider"; "mixed_case")]

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -27,7 +27,16 @@ Every provider honors a `<SLUG>_BASE_URL` env var (`anthropic` -> `ANTHROPIC_BAS
 ANTHROPIC_BASE_URL=https://my-proxy.internal maki
 ```
 
-It wins over `providers.toml` and built-in defaults. `ANTHROPIC_BASE_URL` and `OPENAI_BASE_URL` are the same names the official SDKs use, so an existing proxy setup carries over as is. One exception: `OPENAI_BASE_URL` only redirects the platform API, never the ChatGPT Coding Plan backend."#;
+It wins over `providers.toml` and built-in defaults. `ANTHROPIC_BASE_URL` and `OPENAI_BASE_URL` are the same names the official SDKs use, so an existing proxy setup carries over as is. One exception: `OPENAI_BASE_URL` only redirects the platform API, never the ChatGPT Coding Plan backend.
+
+You can also set `base_url` for a built-in provider in `~/.config/maki/providers.toml`. It overrides the built-in default and loses to the env var above:
+
+```toml
+[openai]
+base_url = "http://xxxx:1234/v1"
+```
+
+The built-in provider still owns the slug, so `protocol`, `api_key_env`, `discover_models` and `models` are ignored with a warning. Use a custom slug if you need those."#;
 
 const LONG_CONTEXT_NOTE: &str = r#"Add `-1m` to any Claude model, like `claude-sonnet-4-6-1m`, to use the 1M token context window."#;
 

--- a/maki-providers/src/providers/anthropic/mod.rs
+++ b/maki-providers/src/providers/anthropic/mod.rs
@@ -216,26 +216,33 @@ fn origin(base_url: &str) -> &str {
 }
 
 /// True when `base_url` targets the real Anthropic API, directly or via the
-/// configured base-URL override (so quota stays visible behind a proxy).
-fn first_party(base_url: &str) -> bool {
+/// construction-time base-URL override (so quota stays visible behind a proxy).
+fn first_party(base_url: &str, configured_override: Option<&str>) -> bool {
     let target = origin(base_url);
     target.contains("api.anthropic.com")
-        || maki_config::providers::base_url_override("anthropic")
-            .is_some_and(|configured| origin(&configured) == target)
+        || configured_override.is_some_and(|configured| origin(configured) == target)
 }
 
 /// Subscription quota only exists for OAuth tokens against the real Anthropic
 /// API; API keys and anthropic-protocol third-party endpoints have none.
-fn usage_eligible(auth: &super::ResolvedAuth) -> bool {
+fn usage_eligible(auth: &super::ResolvedAuth, configured_override: Option<&str>) -> bool {
     auth.headers
         .iter()
         .any(|(k, _)| k.eq_ignore_ascii_case("authorization"))
-        && auth.base_url.as_deref().is_none_or(first_party)
+        && auth
+            .base_url
+            .as_deref()
+            .is_none_or(|url| first_party(url, configured_override))
 }
 
-fn resolve_auth_from_key(key: &str) -> super::ResolvedAuth {
+fn resolve_anthropic_base_url() -> Option<String> {
+    let config = maki_config::providers::ProvidersConfig::load();
+    maki_config::providers::resolve_base_url("anthropic", config.get("anthropic"))
+}
+
+fn resolve_auth_from_key(key: &str, base_url: Option<String>) -> super::ResolvedAuth {
     super::ResolvedAuth {
-        base_url: maki_config::providers::resolve_base_url("anthropic", None),
+        base_url,
         headers: vec![("x-api-key".into(), key.to_string())],
     }
 }
@@ -246,12 +253,16 @@ pub struct Anthropic {
     key_pool: Option<KeyPool>,
     system_prefix: Option<String>,
     stream_timeout: Duration,
+    /// Env / `providers.toml` / inventory default, resolved once at construction.
+    /// Reused by key rotation / reload so they do not re-parse providers.toml.
+    resolved_base_url: Option<String>,
 }
 
 impl Anthropic {
     pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
         let pool = KeyPool::resolve("anthropic", ENV_VAR)?;
-        let resolved = resolve_auth_from_key(pool.current());
+        let resolved_base_url = resolve_anthropic_base_url();
+        let resolved = resolve_auth_from_key(pool.current(), resolved_base_url.clone());
         debug!(keys = pool.len(), "using API key authentication");
         Ok(Self {
             client: super::http_client(timeouts),
@@ -259,6 +270,7 @@ impl Anthropic {
             key_pool: Some(pool),
             system_prefix: None,
             stream_timeout: timeouts.stream,
+            resolved_base_url,
         })
     }
 
@@ -272,6 +284,10 @@ impl Anthropic {
             key_pool: None,
             system_prefix: None,
             stream_timeout: timeouts.stream,
+            // Custom / dynamic callers own their base URL; treating it as the
+            // anthropic override would make every third-party endpoint look
+            // first party and poll `/api/oauth/usage` against it.
+            resolved_base_url: None,
         }
     }
 
@@ -423,7 +439,8 @@ impl Provider for Anthropic {
     fn reload_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
         Box::pin(async {
             let pool = KeyPool::resolve("anthropic", ENV_VAR)?;
-            *self.auth.lock().unwrap() = resolve_auth_from_key(pool.current());
+            *self.auth.lock().unwrap() =
+                resolve_auth_from_key(pool.current(), self.resolved_base_url.clone());
             debug!("reloaded Anthropic auth from env");
             Ok(())
         })
@@ -431,16 +448,21 @@ impl Provider for Anthropic {
 
     fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
         Box::pin(async {
-            Ok(self
-                .key_pool
-                .as_ref()
-                .is_some_and(|p| p.rotate_auth(&self.auth, resolve_auth_from_key)))
+            let base_url = self.resolved_base_url.clone();
+            Ok(self.key_pool.as_ref().is_some_and(|p| {
+                p.rotate_auth(&self.auth, |key| {
+                    resolve_auth_from_key(key, base_url.clone())
+                })
+            }))
         })
     }
 
     fn fetch_usage(&self) -> BoxFuture<'_, Result<Option<ProviderUsage>, AgentError>> {
         Box::pin(async move {
-            if !usage_eligible(&self.auth.lock().unwrap()) {
+            if !usage_eligible(
+                &self.auth.lock().unwrap(),
+                self.resolved_base_url.as_deref(),
+            ) {
                 return Ok(None);
             }
             let request = self
@@ -515,6 +537,7 @@ mod tests {
     use test_case::test_case;
 
     const TEST_STREAM_TIMEOUT: Duration = Duration::from_secs(300);
+    const THIRD_PARTY_BASE_URL: &str = "https://proxy.example.com/v1/messages";
 
     const USAGE_BODY: &str = r#"{
         "five_hour": {"utilization": 14.0, "resets_at": "2026-02-06T22:00:00+00:00"},
@@ -605,7 +628,35 @@ mod tests {
             base_url: base_url.map(String::from),
             headers: vec![(header.into(), "token".into())],
         };
-        assert_eq!(usage_eligible(&auth), expected);
+        assert_eq!(usage_eligible(&auth, None), expected);
+    }
+
+    #[test]
+    fn with_auth_keeps_third_party_endpoint_ineligible() {
+        let mut auth = crate::providers::ResolvedAuth::bearer("token");
+        auth.base_url = Some(THIRD_PARTY_BASE_URL.into());
+        let provider = Anthropic::with_auth(
+            Arc::new(Mutex::new(auth)),
+            crate::providers::Timeouts::default(),
+        );
+        assert!(provider.resolved_base_url.is_none());
+        assert!(!usage_eligible(
+            &provider.auth.lock().unwrap(),
+            provider.resolved_base_url.as_deref()
+        ));
+    }
+
+    #[test]
+    fn usage_eligible_when_url_matches_configured_override() {
+        let auth = crate::providers::ResolvedAuth {
+            base_url: Some(THIRD_PARTY_BASE_URL.into()),
+            headers: vec![("Authorization".into(), "token".into())],
+        };
+        assert!(usage_eligible(&auth, Some(THIRD_PARTY_BASE_URL)));
+        assert!(!usage_eligible(
+            &auth,
+            Some("https://other-proxy.example.com")
+        ));
     }
 
     #[test_case("https://api.anthropic.com/v1/messages", "https://api.anthropic.com" ; "strips_messages_path")]

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -99,9 +99,14 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
     ]
 }
 
-fn resolve_auth_from_key(key: &str) -> ResolvedAuth {
+fn resolve_google_base_url() -> Option<String> {
+    let config = maki_config::providers::ProvidersConfig::load();
+    maki_config::providers::resolve_base_url("google", config.get("google"))
+}
+
+fn resolve_auth_from_key(key: &str, base_url: Option<String>) -> ResolvedAuth {
     ResolvedAuth {
-        base_url: None,
+        base_url,
         headers: vec![("x-goog-api-key".into(), key.to_string())],
     }
 }
@@ -111,17 +116,21 @@ pub struct Google {
     auth: Arc<Mutex<ResolvedAuth>>,
     key_pool: Option<KeyPool>,
     stream_timeout: Duration,
+    /// Env / `providers.toml` / inventory default, resolved once at construction.
+    resolved_base_url: Option<String>,
 }
 
 impl Google {
     pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
         let pool = KeyPool::resolve("google", ENV_VAR)?;
-        let resolved = resolve_auth_from_key(pool.current());
+        let resolved_base_url = resolve_google_base_url();
+        let resolved = resolve_auth_from_key(pool.current(), resolved_base_url.clone());
         Ok(Self {
             client: http_client(timeouts),
             auth: Arc::new(Mutex::new(resolved)),
             key_pool: Some(pool),
             stream_timeout: timeouts.stream,
+            resolved_base_url,
         })
     }
 
@@ -129,11 +138,13 @@ impl Google {
         auth: Arc<Mutex<super::ResolvedAuth>>,
         timeouts: super::Timeouts,
     ) -> Self {
+        let resolved_base_url = auth.lock().unwrap().base_url.clone();
         Self {
             client: http_client(timeouts),
             auth,
             key_pool: None,
             stream_timeout: timeouts.stream,
+            resolved_base_url,
         }
     }
 
@@ -283,17 +294,20 @@ impl Provider for Google {
     fn reload_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
         Box::pin(async {
             let pool = KeyPool::resolve("google", ENV_VAR)?;
-            *self.auth.lock().unwrap() = resolve_auth_from_key(pool.current());
+            *self.auth.lock().unwrap() =
+                resolve_auth_from_key(pool.current(), self.resolved_base_url.clone());
             Ok(())
         })
     }
 
     fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
         Box::pin(async {
-            Ok(self
-                .key_pool
-                .as_ref()
-                .is_some_and(|p| p.rotate_auth(&self.auth, resolve_auth_from_key)))
+            let base_url = self.resolved_base_url.clone();
+            Ok(self.key_pool.as_ref().is_some_and(|p| {
+                p.rotate_auth(&self.auth, |key| {
+                    resolve_auth_from_key(key, base_url.clone())
+                })
+            }))
         })
     }
 }

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -65,6 +65,10 @@ pub struct OpenAi {
     auth: Arc<Mutex<ResolvedAuth>>,
     storage: Option<StateDir>,
     system_prefix: Option<String>,
+    /// Env / `providers.toml` override for the platform API, resolved once at
+    /// construction. Used by the Responses (codex) path only; ChatGPT Coding
+    /// Plan OAuth keeps its fixed backend URL.
+    resolved_base_url: Option<String>,
 }
 
 impl OpenAi {
@@ -73,6 +77,7 @@ impl OpenAi {
         let resolved = auth::resolve(&storage)?;
         let compat = OpenAiCompatProvider::new(&CONFIG, timeouts);
         Ok(Self {
+            resolved_base_url: resolve_openai_base_url(),
             compat,
             auth: Arc::new(Mutex::new(resolved)),
             storage: Some(storage),
@@ -85,6 +90,7 @@ impl OpenAi {
         timeouts: crate::providers::Timeouts,
     ) -> Self {
         Self {
+            resolved_base_url: resolve_openai_base_url(),
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
             auth,
             storage: None,
@@ -157,15 +163,23 @@ impl OpenAi {
         {
             return Ok(auth::build_coding_plan_resolved(&tokens));
         }
-        // Fall back to standard API key via the Responses API. `OPENAI_BASE_URL`
-        // overrides the platform API only, never the ChatGPT backend above.
+        // Fall back to standard API key via the Responses API. Env /
+        // providers.toml base_url overrides the platform API only, never the
+        // ChatGPT backend above.
         let mut auth = self.current_auth();
         if auth.base_url.is_none() {
-            auth.base_url = maki_config::providers::base_url_override("openai")
+            auth.base_url = self
+                .resolved_base_url
+                .clone()
                 .or_else(|| Some(CONFIG.base_url.into()));
         }
         Ok(auth)
     }
+}
+
+fn resolve_openai_base_url() -> Option<String> {
+    let config = maki_config::providers::ProvidersConfig::load();
+    maki_config::providers::configured_base_url("openai", config.get("openai"))
 }
 
 impl Provider for OpenAi {

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -27,14 +27,27 @@ pub(crate) struct OpenAiCompatProvider {
     client: HttpClient,
     config: &'static OpenAiCompatConfig,
     stream_timeout: Duration,
+    /// Env / `providers.toml` override, resolved once at construction. The
+    /// static compat default stays the last resort because it can be more
+    /// specific than the inventory one (`http://localhost:11434/v1` vs the
+    /// bare ollama host). Request-time `auth.base_url` still wins (custom,
+    /// local, dynamic).
+    resolved_base_url: Option<String>,
 }
 
 impl OpenAiCompatProvider {
     pub fn new(config: &'static OpenAiCompatConfig, timeouts: super::Timeouts) -> Self {
+        let resolved_base_url = if config.slug.is_empty() {
+            None
+        } else {
+            let providers = maki_config::providers::ProvidersConfig::load();
+            maki_config::providers::configured_base_url(config.slug, providers.get(config.slug))
+        };
         Self {
             client: super::http_client(timeouts),
             config,
             stream_timeout: timeouts.stream,
+            resolved_base_url,
         }
     }
 
@@ -122,12 +135,14 @@ impl OpenAiCompatProvider {
     }
 
     /// Effective base URL: an auth-supplied value (dynamic/custom providers)
-    /// wins, then the `<SLUG>_BASE_URL` env override, then the static default.
+    /// wins, then the construction-time env / `providers.toml` override, then
+    /// the static compat default.
     fn base_url(&self, auth: &ResolvedAuth) -> String {
         if let Some(explicit) = auth.base_url.as_deref() {
             return explicit.to_string();
         }
-        maki_config::providers::base_url_override(self.config.slug)
+        self.resolved_base_url
+            .clone()
             .unwrap_or_else(|| self.config.base_url.to_string())
     }
 

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -27,6 +27,15 @@ ANTHROPIC_BASE_URL=https://my-proxy.internal maki
 
 It wins over `providers.toml` and built-in defaults. `ANTHROPIC_BASE_URL` and `OPENAI_BASE_URL` are the same names the official SDKs use, so an existing proxy setup carries over as is. One exception: `OPENAI_BASE_URL` only redirects the platform API, never the ChatGPT Coding Plan backend.
 
+You can also set `base_url` for a built-in provider in `~/.config/maki/providers.toml`. It overrides the built-in default and loses to the env var above:
+
+```toml
+[openai]
+base_url = "http://xxxx:1234/v1"
+```
+
+The built-in provider still owns the slug, so `protocol`, `api_key_env`, `discover_models` and `models` are ignored with a warning. Use a custom slug if you need those.
+
 ## Built-in Providers
 
 ### Anthropic

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -50,6 +50,7 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
 
     setup::init_logging(&config.storage);
     setup::install_panic_log_hook();
+    setup::warn_ignored_provider_fields();
 
     let (mcp_handle, _mcp_config_errors) = smol::block_on(maki_agent::mcp::start(&cwd));
 

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -238,6 +238,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
 
     setup::init_logging(&stack.config.storage);
     setup::install_panic_log_hook();
+    setup::warn_ignored_provider_fields();
 
     if cli.is_sdk_mode() {
         let fast = stack.config.always_fast && stack.model.supports_fast();

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -3,6 +3,7 @@ use std::sync::Mutex;
 use color_eyre::Result;
 use color_eyre::eyre::Context;
 
+use maki_providers::manifest::ManifestRegistry;
 use maki_providers::model::{Model, ModelTier};
 use maki_storage::StateDir;
 use maki_storage::log::RotatingFileWriter;
@@ -54,6 +55,29 @@ fn auto_detect_model() -> Option<Model> {
         }
     }
     None
+}
+
+/// Built-in slugs keep their compiled protocol, model catalog and auth wiring,
+/// so a `providers.toml` entry setting those fields is only partly honored
+/// (#597). Call this after `init_logging`, otherwise the warning has no
+/// subscriber to reach.
+pub fn warn_ignored_provider_fields() {
+    for (slug, def) in &maki_config::providers::ProvidersConfig::load().providers {
+        if ManifestRegistry::get(slug).is_none() {
+            continue;
+        }
+        let ignored = maki_config::providers::ignored_builtin_fields(slug, def);
+        if ignored.is_empty() {
+            continue;
+        }
+        tracing::warn!(
+            slug,
+            fields = %ignored.join(", "),
+            "providers.toml entry for built-in provider ignores these fields \
+             (base_url/plan/api_key still apply), use a custom slug to set \
+             protocol or models"
+        );
+    }
 }
 
 pub fn install_panic_log_hook() {


### PR DESCRIPTION
## Summary
- Built-in providers only applied env `<SLUG>_BASE_URL` and ignored `base_url` from `providers.toml`, so an entry like `[openai] base_url = "http://proxy/v1"` still hit `api.openai.com`.
- Resolve base URLs through `ProvidersConfig` (same pattern as zai) for Anthropic, Google, OpenAI platform, and openai-compat providers.
- Document env > `providers.toml` > built-in precedence on the providers page.
- Add unit tests covering toml override, empty def fallback, and custom slug.

Fixes https://github.com/tontinton/maki/issues/597

## Test plan
- [x] `cargo test -p maki-config resolve_base_url`
- [x] `cargo test -p maki-config --lib`
- [x] Manual: set `[openai] base_url = "http://xxxx:1234/v1"` in `providers.toml`, capture traffic, confirm requests go to the proxy (and that `OPENAI_BASE_URL` still wins if set)
- [x] Manual: empty `[openai]` table still uses the built-in default URL