### PR TITLE
feat(ui): audit logs for the tool body snapshot pipeline

### DIFF
--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -444,10 +444,15 @@ impl ToolInvocation for LuaToolInvocation {
                 Some(Ok(reply)) => {
                     if let Some(ref id) = ctx.tool_use_id {
                         if let Some(live_buf) = reply.live_buf {
-                            let _ = ctx.event_tx.send(AgentEvent::LiveToolBuf {
-                                id: id.clone(),
-                                body: live_buf,
-                            });
+                            crate::runtime::send_render_event(
+                                &ctx.event_tx,
+                                id,
+                                "live_buf",
+                                AgentEvent::LiveToolBuf {
+                                    id: id.clone(),
+                                    body: live_buf,
+                                },
+                            );
                         }
                         crate::runtime::RestoreReply {
                             body: reply.snapshot,

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -217,6 +217,19 @@ pub(crate) struct RestoreReply {
     pub header: Option<BufferSnapshot>,
 }
 
+/// The UI restores tool bodies from these events; a send can only fail when
+/// the receiver is gone, but that still loses the snapshot, so it gets a log.
+pub(crate) fn send_render_event(
+    event_tx: &maki_agent::EventSender,
+    tool_id: &str,
+    what: &str,
+    event: maki_agent::AgentEvent,
+) {
+    if event_tx.send(event).is_err() {
+        tracing::warn!(tool_id, what, "tool render event dropped: channel closed");
+    }
+}
+
 impl RestoreReply {
     pub(crate) fn emit(
         self,
@@ -225,18 +238,28 @@ impl RestoreReply {
         event_tx: &maki_agent::EventSender,
     ) {
         if let Some(snapshot) = self.body {
-            let _ = event_tx.send(maki_agent::AgentEvent::ToolSnapshot {
-                id: tool_use_id.to_owned(),
-                snapshot,
-                theme_gen,
-            });
+            send_render_event(
+                event_tx,
+                tool_use_id,
+                "body_snapshot",
+                maki_agent::AgentEvent::ToolSnapshot {
+                    id: tool_use_id.to_owned(),
+                    snapshot,
+                    theme_gen,
+                },
+            );
         }
         if let Some(snapshot) = self.header {
-            let _ = event_tx.send(maki_agent::AgentEvent::ToolHeaderSnapshot {
-                id: tool_use_id.to_owned(),
-                snapshot,
-                theme_gen,
-            });
+            send_render_event(
+                event_tx,
+                tool_use_id,
+                "header_snapshot",
+                maki_agent::AgentEvent::ToolHeaderSnapshot {
+                    id: tool_use_id.to_owned(),
+                    snapshot,
+                    theme_gen,
+                },
+            );
         }
     }
 }
@@ -827,6 +850,10 @@ fn spawn_async_task(
     task: PendingAsyncTask,
 ) {
     if task.cancel.is_cancelled() {
+        tracing::debug!(
+            tool_id = task.live_ctx.as_ref().map(|l| l.tool_use_id.as_str()),
+            "async.run: cancelled before spawn"
+        );
         lua.remove_registry_value(task.work_fn).ok();
         return;
     }
@@ -845,7 +872,8 @@ fn spawn_async_task(
             .scope_future(run_work_fn(&lua, &task.work_fn, task.deadline))
             .await;
         if let Err(e) = &result {
-            tracing::debug!(error = %e, "async.run: task failed");
+            let tool_id = task.live_ctx.as_ref().map(|l| l.tool_use_id.as_str());
+            tracing::debug!(error = %e, tool_id, "async.run: task failed");
         }
 
         if let Some(ref live) = task.live_ctx
@@ -854,11 +882,16 @@ fn spawn_async_task(
             // Always `read`, not `read_if_dirty`: the dirty flag is
             // consume-once and the UI polls each frame, so the flag
             // races. Re-emitting identical content is harmless.
-            let _ = live.event_tx.send(maki_agent::AgentEvent::ToolSnapshot {
-                id: live.tool_use_id.clone(),
-                snapshot: maki_agent::BufferSnapshot::from_arc(buf.read()),
-                theme_gen: None,
-            });
+            send_render_event(
+                &live.event_tx,
+                &live.tool_use_id,
+                "async_snapshot",
+                maki_agent::AgentEvent::ToolSnapshot {
+                    id: live.tool_use_id.clone(),
+                    snapshot: maki_agent::BufferSnapshot::from_arc(buf.read()),
+                    theme_gen: None,
+                },
+            );
         }
 
         drop(scope);

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -948,6 +948,18 @@ impl App {
             ) {
                 self.save_session();
             }
+            // A snapshot dropped here degrades the tool body to llm_output.
+            if let AgentEvent::ToolSnapshot { id, .. }
+            | AgentEvent::ToolHeaderSnapshot { id, .. }
+            | AgentEvent::LiveToolBuf { id, .. } = &envelope.event
+            {
+                tracing::debug!(
+                    tool_id = %id,
+                    event_run_id = envelope.run_id,
+                    current_run_id = self.run_id,
+                    "tool render event dropped: stale run_id"
+                );
+            }
             return vec![];
         }
 

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -40,6 +40,7 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
+use tracing::warn;
 
 const THINKING_HIDDEN_HEADER: &str = "thinking> ...";
 
@@ -235,7 +236,7 @@ impl MessagesPanel {
     }
 
     pub fn tool_done(&mut self, event: ToolDoneEvent) {
-        self.retire_live_buf(&event.id);
+        let had_live_buf = self.retire_live_buf(&event.id);
         let Some(msg) = self
             .messages
             .iter_mut()
@@ -264,6 +265,16 @@ impl MessagesPanel {
             ToolOutput::Plain(text) | ToolOutput::Markdown(text) | ToolOutput::ReadDir(text)
                 if msg.render_snapshot.is_none() =>
             {
+                if had_live_buf {
+                    // The plugin streamed a body buf but no snapshot ever
+                    // landed: this is the raw llm_output glitch users report.
+                    warn!(
+                        tool_id = %event.id,
+                        tool = %event.tool,
+                        is_error = event.is_error,
+                        "live buf had no snapshot at tool_done; falling back to llm_output"
+                    );
+                }
                 let tr = truncate_output(&text.text, self.tool_output_lines.get(&event.tool));
                 msg.truncated_lines = tr.skipped;
                 if !tr.kept.is_empty() {
@@ -889,9 +900,10 @@ impl MessagesPanel {
     /// Moves a finished tool's live buf to the watched set, flushing any
     /// last dirty lines. Called on completion and on cancellation, so
     /// `live_bufs` never leaks entries that keep `is_animating` true.
-    fn retire_live_buf(&mut self, id: &str) {
+    /// Returns whether a live buf existed for this id.
+    fn retire_live_buf(&mut self, id: &str) -> bool {
         let Some(buf) = self.live_bufs.remove(id) else {
-            return;
+            return false;
         };
         if let Some(lines) = buf.read_if_dirty() {
             self.store_snapshot(id, BufferSnapshot::from_arc(lines), false, None);
@@ -900,6 +912,7 @@ impl MessagesPanel {
         if self.watched_bufs.len() > WARM_TOOL_CAP {
             self.watched_bufs.pop_front();
         }
+        true
     }
 
     fn has_snapshot(&self, tool_id: &str) -> bool {
@@ -1000,6 +1013,11 @@ impl MessagesPanel {
             }
             msg.snapshot_theme_gen = applied_gen;
             self.rebuild_tool_segment(tool_id);
+        } else {
+            warn!(
+                tool_id,
+                is_header, "snapshot dropped: no tool message with this id"
+            );
         }
     }
 


### PR DESCRIPTION
Sometimes a finished tool shows its raw `llm_output` instead of the rich body its plugin streamed, and every way this can happen was silent: `let _ =` on event sends, a no-op when a snapshot finds no matching tool message, and the stale `run_id` filter dropping render events without a trace.

Now the moment `tool_done` falls back to `llm_output` while a live buf existed it logs a warn with the tool id, and each drop point along the way (closed channels, unknown ids, stale runs, cancelled `async.run` tasks) leaves its own entry.

Next time the glitch appears, `maki.log` tells which leg lost the snapshot.