### PR TITLE
fix(update): fall back to system curl when TLS verification fails

### DIFF
--- a/maki-storage/src/version.rs
+++ b/maki-storage/src/version.rs
@@ -1,3 +1,5 @@
+use std::io;
+use std::process::Command;
 use std::time::Duration;
 
 use isahc::config::Configurable;
@@ -59,12 +61,37 @@ fn parse_tag(bytes: &[u8]) -> Result<String, VersionError> {
     Ok(tag.strip_prefix('v').unwrap_or(tag).to_owned())
 }
 
+/// Fallback for TLS-inspecting proxies (e.g. Cloudflare WARP): system `curl`
+/// trusts the OS certificate store, which our statically linked OpenSSL
+/// cannot read. Callers keep their original error when this also fails,
+/// since the TLS error is the useful one to show.
+pub fn curl_fetch(url: &str) -> io::Result<Vec<u8>> {
+    let max_time = CONNECT_TIMEOUT + REQUEST_TIMEOUT;
+    let out = Command::new("curl")
+        .args(["-fsSL", "-A", "maki", "--max-time"])
+        .arg(max_time.as_secs().to_string())
+        .arg(url)
+        .output()?;
+    if !out.status.success() {
+        return Err(io::Error::other(format!(
+            "curl failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(out.stdout)
+}
+
 pub fn fetch_latest() -> Result<String, VersionError> {
+    let bytes = fetch_bytes().or_else(|e| curl_fetch(RELEASES_URL).map_err(|_| e))?;
+    parse_tag(&bytes)
+}
+
+fn fetch_bytes() -> Result<Vec<u8>, VersionError> {
     let mut resp = client()?.send(request()?)?;
     if !resp.status().is_success() {
         return Err(VersionError::Status(resp.status().as_u16()));
     }
-    parse_tag(&resp.bytes()?)
+    Ok(resp.bytes()?)
 }
 
 pub async fn fetch_latest_async() -> Result<String, VersionError> {

--- a/src/update.rs
+++ b/src/update.rs
@@ -57,14 +57,17 @@ pub enum UpdateError {
 
 fn fetch_script() -> Result<String, UpdateError> {
     use isahc::ReadResponseExt;
-    let mut response = isahc::get(INSTALL_SCRIPT_URL).map_err(|e| UpdateError::Fetch {
-        url: INSTALL_SCRIPT_URL,
-        source: e,
-    })?;
-    response.text().map_err(|e| UpdateError::Fetch {
-        url: INSTALL_SCRIPT_URL,
-        source: e.into(),
-    })
+    isahc::get(INSTALL_SCRIPT_URL)
+        .and_then(|mut r| r.text().map_err(Into::into))
+        .map_err(|source| UpdateError::Fetch {
+            url: INSTALL_SCRIPT_URL,
+            source,
+        })
+        .or_else(|e| {
+            version::curl_fetch(INSTALL_SCRIPT_URL)
+                .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+                .map_err(|_| e)
+        })
 }
 
 fn backup_binary(exe_path: &Path, storage: &StateDir) -> Result<PathBuf, UpdateError> {


### PR DESCRIPTION
`maki update` dies on a certificate error behind TLS-inspecting proxies like Cloudflare WARP, because our statically linked OpenSSL only trusts CA bundles it can read from files, and on macOS the proxy's root CA lives in the Keychain where no file bundle can see it.

Windows was never affected since `curl-sys` uses schannel there, and Linux works once the CA lands in `/etc/ssl/certs`, so macOS was the broken case.

Now when the `isahc` fetch of the release tag or the install script fails, we retry with the system `curl`, which trusts the OS store natively, and surface the original error if that fails too.

The update path already requires `curl` anyway, since `install.sh` starts with `need_cmd curl`.