### PR TITLE
fix(ui): keep the agent output and queue alive across respawns

### DIFF
--- a/maki-ui/src/agent/mod.rs
+++ b/maki-ui/src/agent/mod.rs
@@ -3,16 +3,15 @@ mod cancel_map;
 mod command_router;
 pub(crate) mod shared_queue;
 
-use std::collections::HashMap;
 use std::mem;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use arc_swap::ArcSwap;
 use maki_agent::permissions::PermissionManager;
 use maki_agent::{
     AgentConfig, CancelMap, CancelToken, Envelope, McpCommand, McpConfigErrors, McpHandle,
-    McpSnapshotReader, ToolOutput, ToolOutputLines,
+    McpSnapshotReader, ToolOutputLines,
 };
 use maki_lua::EventHandle;
 use maki_storage::id::SessionRef;
@@ -39,6 +38,11 @@ pub(crate) enum AgentCommand {
     CancelSubagent { tool_use_id: String },
 }
 
+/// Input channels (`cmd_tx`, `answer_tx`, `queue`) are per-agent, so an old
+/// loop can never steal new input. The output channel (`agent_tx`/`agent_rx`)
+/// is per-tab: `respawn` reuses it, so anyone still holding a sender (a Lua
+/// restore reply, a click, an old agent winding down) can always deliver.
+/// Stale events are filtered by `run_id`, not by killing the channel.
 pub(crate) struct AgentHandles {
     pub(crate) cmd_tx: flume::Sender<AgentCommand>,
     pub(crate) agent_rx: flume::Receiver<Envelope>,
@@ -46,7 +50,6 @@ pub(crate) struct AgentHandles {
     pub(crate) answer_tx: flume::Sender<String>,
     pub(crate) history: Arc<ArcSwap<Vec<Message>>>,
     pub(crate) btw_system: Arc<ArcSwap<String>>,
-    pub(crate) tool_outputs: Arc<Mutex<HashMap<String, ToolOutput>>>,
     pub(crate) mcp_handle: Option<McpHandle>,
     pub(crate) mcp_config_errors: McpConfigErrors,
     pub(crate) queue: QueueSender,
@@ -71,6 +74,7 @@ impl AgentHandles {
         mcp_config_errors: McpConfigErrors,
     ) -> Self {
         spawn_agent_internal(
+            flume::unbounded(),
             model_slot,
             initial_history,
             config,
@@ -96,7 +100,6 @@ impl AgentHandles {
         app.cmd_tx = Some(self.cmd_tx.clone());
         app.shared_history = Some(Arc::clone(&self.history));
         app.btw_system = Some(Arc::clone(&self.btw_system));
-        app.shared_tool_outputs = Some(Arc::clone(&self.tool_outputs));
         app.queue.set_shared(self.queue.clone());
         let restore_tx =
             maki_agent::EventSender::new(self.agent_tx.clone(), crate::app::RESTORE_RUN_ID);
@@ -127,11 +130,16 @@ impl AgentHandles {
         app: &mut App,
         lua_handle: Option<EventHandle>,
     ) {
+        // The output channel survives the respawn, so this bump is the only
+        // thing that makes the old loop's in-flight envelopes stale. It lives
+        // here so no caller can respawn without it.
+        app.run_id += 1;
         let slot = model_slot.load();
         if let Err(e) = smol::block_on(slot.provider.reload_auth()) {
             warn!(error = %e, "failed to reload auth, continuing with existing credentials");
         }
         let new = spawn_agent_internal(
+            (self.agent_tx.clone(), self.agent_rx.clone()),
             model_slot,
             history,
             config,
@@ -147,6 +155,7 @@ impl AgentHandles {
         // Repoint the app at the new queue before dropping `old`, otherwise the app keeps
         // the last old `QueueSender` alive and the old loop parks in `recv_notify` forever.
         self.apply_to_app(app);
+        app.flush_restored_queue();
         old.cancel();
     }
 
@@ -187,6 +196,7 @@ pub(crate) fn join_all(tasks: Vec<smol::Task<()>>, timeout: Duration) {
 
 #[allow(clippy::too_many_arguments)]
 fn spawn_agent_internal(
+    (agent_tx, agent_rx): (flume::Sender<Envelope>, flume::Receiver<Envelope>),
     model_slot: &Arc<ArcSwap<ModelSlot>>,
     initial_history: Vec<Message>,
     config: AgentConfig,
@@ -198,8 +208,6 @@ fn spawn_agent_internal(
     timeouts: maki_providers::Timeouts,
     lua_handle: Option<EventHandle>,
 ) -> AgentHandles {
-    let (agent_tx, agent_rx) = flume::unbounded::<Envelope>();
-    let agent_tx_clone = agent_tx.clone();
     let (cmd_tx, cmd_rx) = flume::unbounded::<AgentCommand>();
     let (answer_tx, answer_rx) = flume::unbounded::<String>();
     let (queue_tx, queue_rx) = shared_queue::queue();
@@ -207,8 +215,6 @@ fn spawn_agent_internal(
     let shared_history: Arc<ArcSwap<Vec<Message>>> =
         Arc::new(ArcSwap::from_pointee(initial_history.clone()));
     let btw_system: Arc<ArcSwap<String>> = Arc::new(ArcSwap::from_pointee(String::new()));
-    let shared_tool_outputs: Arc<Mutex<HashMap<String, ToolOutput>>> =
-        Arc::new(Mutex::new(HashMap::new()));
     let (init_trigger, init_cancel) = CancelToken::new();
     let cancel_map = Arc::new(new_run_cancel_map(0, init_trigger));
     let subagent_cancels: Arc<CancelMap<String>> = Arc::new(CancelMap::new());
@@ -228,7 +234,7 @@ fn spawn_agent_internal(
         Arc::clone(&btw_system),
         mcp_handle.clone(),
         Arc::clone(permissions),
-        agent_tx,
+        agent_tx.clone(),
         answer_rx,
         queue_rx,
         cancel_map,
@@ -244,11 +250,10 @@ fn spawn_agent_internal(
     AgentHandles {
         cmd_tx,
         agent_rx,
-        agent_tx: agent_tx_clone,
+        agent_tx,
         answer_tx,
         history: shared_history,
         btw_system,
-        tool_outputs: shared_tool_outputs,
         mcp_handle,
         mcp_config_errors,
         queue: queue_tx,
@@ -259,12 +264,134 @@ fn spawn_agent_internal(
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
     use std::time::Instant;
+
+    use maki_agent::AgentEvent;
+    use maki_config::PermissionsConfig;
+    use maki_providers::provider::BoxFuture;
+    use maki_providers::{AgentError, ModelInfo, ProviderEvent, RequestOptions, StreamResponse};
 
     use super::*;
 
     const LONG_TIMEOUT: Duration = Duration::from_secs(60);
     const SHORT_TIMEOUT: Duration = Duration::from_millis(50);
+    const PROBE_TEXT: &str = "probe-through-old-sender";
+    const RESTORED_TEXT: &str = "restored-queued-message";
+
+    struct StubProvider;
+
+    impl Provider for StubProvider {
+        fn stream_message<'a>(
+            &'a self,
+            _model: &'a Model,
+            _messages: &'a [Message],
+            _system: &'a str,
+            _tools: &'a serde_json::Value,
+            _event_tx: &'a flume::Sender<ProviderEvent>,
+            _opts: RequestOptions,
+            _session_id: Option<&'a SessionRef>,
+        ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
+            Box::pin(std::future::pending())
+        }
+
+        fn list_models(&self) -> BoxFuture<'_, Result<Vec<ModelInfo>, AgentError>> {
+            Box::pin(async { Ok(Vec::new()) })
+        }
+    }
+
+    fn stub_spawn() -> (
+        AgentHandles,
+        Arc<ArcSwap<ModelSlot>>,
+        Arc<PermissionManager>,
+    ) {
+        let model_slot = Arc::new(ArcSwap::from_pointee(ModelSlot {
+            model: crate::components::test_model(),
+            provider: Arc::new(StubProvider),
+        }));
+        let permissions = Arc::new(PermissionManager::new(
+            PermissionsConfig::default(),
+            PathBuf::from("/tmp"),
+        ));
+        let handles = AgentHandles::spawn(
+            &model_slot,
+            Vec::new(),
+            AgentConfig::default(),
+            ToolOutputLines::default(),
+            &permissions,
+            None,
+            maki_providers::Timeouts::default(),
+            None,
+            None,
+            McpConfigErrors::new(PathBuf::new()),
+        );
+        (handles, model_slot, permissions)
+    }
+
+    fn respawn(
+        handles: &mut AgentHandles,
+        model_slot: &Arc<ArcSwap<ModelSlot>>,
+        permissions: &Arc<PermissionManager>,
+        app: &mut App,
+    ) {
+        handles.respawn(
+            Vec::new(),
+            model_slot,
+            AgentConfig::default(),
+            ToolOutputLines::default(),
+            permissions,
+            app,
+            None,
+        );
+    }
+
+    /// Senders captured before any respawn (Lua restore replies, clicks) must
+    /// still reach the live receiver, and restored queue items must land in
+    /// the freshly wired queue, not the one that just died.
+    #[test]
+    fn respawn_twice_keeps_channel_and_delivers_restored_queue() {
+        let (mut handles, model_slot, permissions) = stub_spawn();
+        let pre_gen1_sender =
+            maki_agent::EventSender::new(handles.agent_tx.clone(), crate::app::RESTORE_RUN_ID);
+
+        let mut app = crate::app::tests::test_app();
+        let run_id_before = app.run_id;
+        respawn(&mut handles, &model_slot, &permissions, &mut app);
+        assert_eq!(app.run_id, run_id_before + 1);
+
+        app.state.session.meta.queued_messages = vec![RESTORED_TEXT.into()];
+        respawn(&mut handles, &model_slot, &permissions, &mut app);
+        assert_eq!(
+            app.run_id,
+            run_id_before + 2,
+            "each respawn must bump run_id exactly once"
+        );
+        assert!(app.state.session.meta.queued_messages.is_empty());
+
+        pre_gen1_sender
+            .send(AgentEvent::TextDelta {
+                text: PROBE_TEXT.into(),
+            })
+            .expect("pre-generation-1 sender must still deliver after two respawns");
+
+        let mut probe_seen = false;
+        let mut consumed_seen = false;
+        while !(probe_seen && consumed_seen) {
+            let envelope = handles
+                .agent_rx
+                .recv_timeout(LONG_TIMEOUT)
+                .expect("probe or restored queue item never reached the tab channel");
+            match envelope.event {
+                AgentEvent::TextDelta { ref text } if text == PROBE_TEXT => probe_seen = true,
+                AgentEvent::QueueItemConsumed { ref text, .. } => {
+                    assert_eq!(text, RESTORED_TEXT);
+                    assert_eq!(envelope.run_id, app.run_id);
+                    consumed_seen = true;
+                }
+                _ => {}
+            }
+        }
+    }
 
     #[test]
     fn join_all_returns_when_all_tasks_complete() {

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -1,6 +1,8 @@
 //! Elm-style `update(Msg) -> Vec<Action>`; side effects are dispatched by the caller.
 //! Double-esc: first esc flashes a hint, second within `flash_duration` cancels/rewinds.
-//! `run_id` increments each run so stale events from previous agent runs are ignored.
+//! `run_id` invalidates in-flight agent events. It bumps in exactly three
+//! places, one per transition: `start_run`, `handle_cancel`, and
+//! `AgentHandles::respawn`. Everything else only reads it.
 
 mod btw;
 mod image_paste;
@@ -11,13 +13,13 @@ mod session;
 pub(crate) mod session_state;
 pub(crate) mod shell;
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;
 pub(crate) mod view;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use crate::AppSession;
@@ -54,7 +56,7 @@ use crossterm::event::{KeyCode, KeyEvent, MouseEvent};
 use maki_agent::permissions::PermissionManager;
 use maki_agent::{
     AgentEvent, Envelope, ImageSource, McpConfigErrors, McpPromptInfo, McpSnapshotReader,
-    SubagentInfo, ToolOutput,
+    SubagentInfo,
 };
 use maki_config::UiConfig;
 use maki_lua::{EventHandle, HintReader, KeymapReader, LuaCommandReader};
@@ -169,7 +171,6 @@ pub struct App {
     pub(crate) usage_slot: Arc<ArcSwapOption<UsageFetchState>>,
     pub(crate) shared_history: Option<Arc<ArcSwap<Vec<Message>>>>,
     pub(crate) btw_system: Option<Arc<ArcSwap<String>>>,
-    pub(crate) shared_tool_outputs: Option<Arc<Mutex<HashMap<String, ToolOutput>>>>,
     pub(crate) image_paste_rx: Vec<flume::Receiver<Result<ImageSource, String>>>,
     storage_writer: Arc<StorageWriter>,
     pub(crate) shell: shell::ShellState,
@@ -253,7 +254,6 @@ impl App {
             usage_slot: Arc::new(ArcSwapOption::empty()),
             shared_history: None,
             btw_system: None,
-            shared_tool_outputs: None,
             image_paste_rx: vec![],
             storage_writer,
             shell: shell::ShellState::default(),
@@ -996,12 +996,10 @@ impl App {
             {
                 self.transition_plan(PlanTrigger::WriteDone);
             }
-            if let Some(ref outputs) = self.shared_tool_outputs {
-                outputs
-                    .lock()
-                    .unwrap()
-                    .insert(e.id.clone(), e.output.clone());
-            }
+            self.state
+                .session
+                .tool_outputs
+                .insert(e.id.clone(), e.output.clone());
             if let Some(&sub_idx) = self.chat_index.get(&e.id) {
                 let (role, text) = if e.is_error {
                     (DisplayRole::Error, ERROR_TEXT)
@@ -1321,10 +1319,7 @@ impl App {
             self.flash("Agent is busy, try again later".into());
             vec![]
         } else {
-            self.run_id += 1;
-            self.status = Status::Streaming;
-            self.main_chat().show_user_message(display_text);
-            vec![Action::SendMessage(Box::new(input))]
+            self.start_run(input, display_text)
         }
     }
 
@@ -1562,7 +1557,6 @@ impl App {
         } else {
             format!("{}.", IMPLEMENT_MSG_PREFIX)
         };
-        self.run_id += 1;
         let msg = QueuedMessage {
             text,
             images: vec![],

--- a/maki-ui/src/app/queue.rs
+++ b/maki-ui/src/app/queue.rs
@@ -1,5 +1,7 @@
 //! Queue for messages typed while the agent is busy.
 
+use maki_agent::AgentInput;
+
 use super::{Action, App, Status, format_with_images};
 
 use crate::agent::shared_queue::{QueueItem, QueueSender};
@@ -129,7 +131,6 @@ impl App {
                 SubmitOutcome::Rejected(NO_QUEUE_ERR)
             }
         } else {
-            self.run_id += 1;
             SubmitOutcome::Started(self.start_from_queue(&msg))
         }
     }
@@ -165,6 +166,18 @@ impl App {
         true
     }
 
+    /// Push restored queue items only here, never in `restore_display`: on
+    /// load/rewind the display is restored before `respawn` swaps the shared
+    /// queue, so pushing earlier would fill a queue that is about to die.
+    pub(crate) fn flush_restored_queue(&mut self) {
+        for text in std::mem::take(&mut self.state.session.meta.queued_messages) {
+            self.queue_and_notify(QueuedMessage {
+                text,
+                images: Vec::new(),
+            });
+        }
+    }
+
     pub(super) fn queue_compact(&mut self) {
         let Some(ref shared) = self.queue.shared else {
             return;
@@ -174,9 +187,12 @@ impl App {
         });
     }
 
-    /// Agent reached a deferred message: time to draw the bubble.
-    /// Immediate-dispatch items skip this event, so no dedup needed.
+    /// Agent reached a deferred message: time to draw the bubble. Restored
+    /// queue items start runs without `start_run`, so this is where the app
+    /// learns the agent is busy. Immediate-dispatch items skip this event,
+    /// so no dedup needed.
     pub(super) fn on_queue_item_consumed(&mut self, text: &str, image_count: usize) {
+        self.status = Status::Streaming;
         self.main_chat()
             .show_user_message(format_with_images(text, image_count));
     }
@@ -184,10 +200,19 @@ impl App {
     /// Immediate path: kick off the agent and draw the bubble in the same
     /// frame, so the user sees their message land where it will stay.
     pub(super) fn start_from_queue(&mut self, msg: &QueuedMessage) -> Vec<Action> {
+        let display = format_with_images(&msg.text, msg.images.len());
+        let input = self.build_agent_input(msg);
+        self.start_run(input, display)
+    }
+
+    /// The one place a fresh run starts: every path that emits
+    /// `Action::SendMessage` must go through here so `run_id` bumps exactly
+    /// once per run.
+    pub(super) fn start_run(&mut self, input: AgentInput, display: String) -> Vec<Action> {
+        self.run_id += 1;
         self.status = Status::Streaming;
         self.fire_session_autocmd("TurnStart", serde_json::json!({}));
-        self.main_chat()
-            .show_user_message(format_with_images(&msg.text, msg.images.len()));
-        vec![Action::SendMessage(Box::new(self.build_agent_input(msg)))]
+        self.main_chat().show_user_message(display);
+        vec![Action::SendMessage(Box::new(input))]
     }
 }

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -13,7 +13,6 @@ use crate::AppSession;
 
 use super::session_state::{SessionState, stored_to_rules};
 use super::{App, Mode, PendingInput, PlanState};
-use crate::agent::QueuedMessage;
 
 /// The single content predicate: `App::save_session` persists a session
 /// iff this holds, and the shutdown path reuses it to tell which tabs were
@@ -32,11 +31,8 @@ impl App {
     }
 
     pub(crate) fn save_session(&mut self) {
-        self.state.sync_session(
-            &self.shared_history,
-            &self.shared_tool_outputs,
-            &self.permissions,
-        );
+        self.state
+            .sync_session(&self.shared_history, &self.permissions);
         self.sync_ephemeral_state();
         if !self.has_content() {
             return;
@@ -110,14 +106,6 @@ impl App {
             self.input_box.buffer.move_to_end();
         }
 
-        for text in std::mem::take(&mut self.state.session.meta.queued_messages) {
-            let msg = QueuedMessage {
-                text,
-                images: Vec::new(),
-            };
-            self.queue_and_notify(msg);
-        }
-
         self.fire_restore_items(restore_items);
 
         for sa in std::mem::take(&mut self.state.session.meta.subagents) {
@@ -158,10 +146,22 @@ impl App {
         }
     }
 
+    /// Resume at process start: the agent was already spawned with this
+    /// history, so no respawn follows and the restored queue must be
+    /// flushed here.
+    pub(crate) fn restore_resumed_session(&mut self) {
+        self.permissions
+            .load_session_rules(stored_to_rules(&self.state.session.meta.session_rules));
+        self.restore_display();
+        self.flush_restored_queue();
+        for w in self.state.warnings.drain(..) {
+            self.status_bar.flash(w);
+        }
+    }
+
     fn loaded_session_snapshot(&self) -> LoadedSession {
         LoadedSession {
             messages: self.state.session.messages.clone(),
-            tool_outputs: self.state.session.tool_outputs.clone(),
             model_spec: self.state.session.model.clone(),
         }
     }
@@ -191,8 +191,6 @@ impl App {
     }
 
     pub(super) fn rewind_to(&mut self, entry: RewindEntry) -> Vec<Action> {
-        self.run_id += 1;
-
         self.state.session.messages.truncate(entry.turn_index);
         self.state
             .session

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -1,9 +1,7 @@
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use arc_swap::ArcSwap;
-use maki_agent::ToolOutput;
 use maki_agent::permissions::PermissionManager;
 use maki_config::Effect;
 use maki_providers::{Message, Model, ThinkingConfig, TokenUsage};
@@ -93,14 +91,10 @@ impl SessionState {
     pub fn sync_session(
         &mut self,
         shared_history: &Option<Arc<ArcSwap<Vec<Message>>>>,
-        shared_tool_outputs: &Option<Arc<Mutex<HashMap<String, ToolOutput>>>>,
         permissions: &Arc<PermissionManager>,
     ) {
         if let Some(history) = shared_history {
             self.session.messages = Vec::clone(&history.load());
-        }
-        if let Some(outputs) = shared_tool_outputs {
-            self.session.tool_outputs = outputs.lock().unwrap_or_else(|e| e.into_inner()).clone();
         }
         self.session.token_usage = self.token_usage;
         self.session.meta.context_size = self.context_size;

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -55,7 +55,7 @@ fn build_app(dir: StateDir, writer: Arc<StorageWriter>) -> App {
     )
 }
 
-fn test_app() -> App {
+pub(crate) fn test_app() -> App {
     let dir = StateDir::from_path(env::temp_dir());
     let mut app = build_app(dir.clone(), Arc::new(StorageWriter::new(dir)));
     let (shared_queue, _rx) = shared_queue::queue();
@@ -353,6 +353,25 @@ fn queue_item_consumed_pushes_deferred_user_message() {
         app.main_chat().last_message_role(),
         Some(&DisplayRole::User),
     );
+}
+
+/// Restored queue items start runs without `start_run`, so the consumed
+/// event is the only signal that the agent went busy: it must flip status
+/// or the busy-guard and esc-to-cancel stay off during the whole run.
+#[test]
+fn queue_item_consumed_marks_agent_streaming() {
+    let mut app = test_app();
+    assert_eq!(app.status, Status::Idle);
+
+    app.update(agent_msg_with_run_id(
+        AgentEvent::QueueItemConsumed {
+            text: "restored".into(),
+            image_count: 0,
+        },
+        app.run_id,
+    ));
+
+    assert_eq!(app.status, Status::Streaming);
 }
 
 #[test_case(error_app as fn(&mut App) ; "error")]
@@ -1626,6 +1645,65 @@ fn reload_leaves_empty_session_unpersisted_on_disk() {
     assert_eq!(entries, 0);
 }
 
+/// `state.session.tool_outputs` is the only store, so a `ToolDone` write
+/// must reach disk or restored sessions lose their tool call widgets.
+#[test]
+fn tool_done_output_persists_to_disk() {
+    let (_tmp, dir, writer, mut app) = tempdir_app();
+    app.state
+        .session
+        .messages
+        .push(Message::user("prompt".into()));
+    app.status = Status::Streaming;
+    app.run_id = 1;
+
+    app.update(agent_msg(AgentEvent::ToolDone(Box::new(ToolDoneEvent {
+        id: "tool-live".into(),
+        tool: "bash".into(),
+        output: ToolOutput::Plain("live output".into()),
+        is_error: false,
+        annotation: None,
+        written_path: None,
+    }))));
+
+    app.save_session();
+    let id = app.state.session.id;
+    drain_writer(app, writer);
+
+    let loaded = AppSession::load(id, &dir).unwrap();
+    assert!(matches!(
+        loaded.tool_outputs.get("tool-live"),
+        Some(ToolOutput::Plain(s)) if s.text == "live output"
+    ));
+}
+
+#[test]
+fn restore_resumed_session_flushes_queued_messages_and_round_trips() {
+    let mut app = test_app();
+    app.state.session.meta.queued_messages = vec!["q1".into(), "q2".into()];
+
+    app.restore_resumed_session();
+    assert!(app.state.session.meta.queued_messages.is_empty());
+    assert_eq!(app.queue.text_messages(), ["q1", "q2"]);
+
+    app.save_session();
+    assert_eq!(app.state.session.meta.queued_messages, ["q1", "q2"]);
+}
+
+#[test]
+fn apply_loaded_session_defers_queued_messages_until_respawn() {
+    let mut app = test_app();
+    let mut session = AppSession::new("test-model", "/tmp/test");
+    session.meta.queued_messages = vec!["deferred".into()];
+    session.messages.push(Message::user("hello".into()));
+
+    let model = app.state.model.clone();
+    app.apply_loaded_session(session, &model);
+
+    assert!(app.queue.is_empty());
+    assert_eq!(app.state.session.meta.queued_messages, ["deferred"]);
+}
+
 #[test]
 fn yolo_toggle() {
     let mut app = test_app();
@@ -1767,7 +1845,7 @@ fn rewind_to_middle_truncates_and_populates_input() {
     assert_eq!(app.state.session.messages.len(), 2);
     assert!(app.state.session.tool_outputs.contains_key("tool-1"));
     assert_eq!(app.input_box.buffer.value(), "second prompt");
-    assert_eq!(app.run_id, old_run_id + 1);
+    assert_eq!(app.run_id, old_run_id);
     let expected_ctx = maki_agent::agent::estimate_message_tokens(&app.state.session.messages);
     assert_eq!(app.state.context_size, expected_ctx);
     assert_eq!(app.chats[0].context_size, expected_ctx);
@@ -1776,7 +1854,6 @@ fn rewind_to_middle_truncates_and_populates_input() {
         panic!("expected LoadSession");
     };
     assert_eq!(loaded.messages.len(), 2);
-    assert!(loaded.tool_outputs.contains_key("tool-1"));
 }
 
 #[test]

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -27,7 +27,6 @@ pub(crate) mod theme_picker;
 pub(crate) mod tool_display;
 pub(crate) mod usage_modal;
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -173,7 +172,6 @@ impl ModalScroll {
 
 pub struct LoadedSession {
     pub messages: Vec<Message>,
-    pub tool_outputs: HashMap<String, ToolOutput>,
     pub model_spec: String,
 }
 

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -186,7 +186,7 @@ impl SpawnCtx {
         app.lua_event_handle = self.lua_event_handle.clone();
         handles.apply_to_app(&mut app);
         if resumed {
-            restore_session(&mut app, &handles);
+            app.restore_resumed_session();
         }
         let (shell_tx, shell_rx) = flume::unbounded::<ShellEvent>();
         SessionRuntime {
@@ -285,21 +285,6 @@ fn spawn_model_fetch(model_slot: &Arc<ArcSwap<ModelSlot>>, timeouts: Timeouts) -
         warn_rx,
         warn_tx,
         task,
-    }
-}
-
-fn restore_session(app: &mut App, handles: &AgentHandles) {
-    app.permissions
-        .load_session_rules(crate::app::session_state::stored_to_rules(
-            &app.state.session.meta.session_rules,
-        ));
-    *handles
-        .tool_outputs
-        .lock()
-        .unwrap_or_else(|e| e.into_inner()) = app.state.session.tool_outputs.clone();
-    app.restore_display();
-    for w in app.state.warnings.drain(..) {
-        app.status_bar.flash(w);
     }
 }
 
@@ -539,12 +524,6 @@ impl<'t> EventLoop<'t> {
             match self.next_wake(Duration::ZERO) {
                 Some(wake) => self.handle_wake(wake)?,
                 None => break,
-            }
-        }
-
-        for rt in &mut self.sessions {
-            if rt.app.status == Status::Streaming && rt.handles.agent_rx.is_disconnected() {
-                rt.app.status = Status::error("agent stopped unexpectedly".into());
             }
         }
 
@@ -969,11 +948,6 @@ impl<'t> EventLoop<'t> {
                     }));
                 }
                 self.respawn_agent(idx, loaded.messages);
-                *self.sessions[idx]
-                    .handles
-                    .tool_outputs
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner()) = loaded.tool_outputs;
             }
             Action::ChangeModel(spec) => self.change_model(spec),
             Action::RefreshProvider { slug } => self.refresh_provider(slug),


### PR DESCRIPTION
Rewinding a session lost tool call widgets: `rewind_to` fired Lua `RestoreItem`s at the current channel, then `Action::LoadSession` respawned the agent with a fresh one, so the async `ToolSnapshot` replies landed on a dead receiver.

Now the `Envelope` channel belongs to the tab, not the agent: `respawn` passes the existing pair into the new loop, so anything holding a sender (restore replies, clicks, theme rebakes) can always deliver, and staleness is guaranteed by bumping `run_id` in exactly one place, `respawn`.

Restored queued messages had the same lifetime bug on the input side: `restore_display` pushed them into the old agent's queue moments before `respawn` replaced it, so a load or rewind silently dropped them; now `flush_restored_queue` pushes them only once the final queue is wired.

The UI-only mirror of tool outputs is gone too: `state.session.tool_outputs` is now the single store, written directly on `ToolDone`, which removes the seeding that every respawn and session load had to remember.