### PR TITLE
feat(lua): nvim-style command handler opts (args, fargs) and nargs

### DIFF
--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -41,6 +41,7 @@ const TOOL_NAME_MAX: usize = 64;
 const TOOL_HANDLER_RETURN_ERR: &str =
     "tool handler must return string or {output=string, is_error?=bool}";
 const TIMEOUT_PARSE_ERR: &str = "register_tool: 'timeout' must be a positive number, 0, or false";
+const NARGS_ERR: &str = r#"register_command: 'nargs' must be 0, 1, "?", "*", or "+""#;
 const MAX_HINT_CONTENT_SIZE: usize = 1024 * 1024;
 const DESCRIBE_TIMEOUT: Duration = Duration::from_secs(3);
 const PLAIN_HEADER_STYLE: &str = "tool";
@@ -653,15 +654,19 @@ fn register_tool(lua: &Lua, #[ctx] pending: PendingTools, spec: Table) -> LuaRes
 ///   name        (string)   Required. The command name (e.g. "/hello"; a leading
 ///                            slash is added when missing).
 ///   description (string)   Optional. Short description shown in the command palette.
-///   max_args    (integer)  Optional. Maximum number of arguments accepted.
-///                          Defaults to 0 (no arguments). Set to -1 for
-///                          unlimited. An "argument" is a whitespace-separated
-///                          word, so max_args = 1 breaks on the first space.
-///                          Handler receives the raw arg string, not a list.
-///                          If the user types more arguments than max_args, the
-///                          command silently stops matching and the input is sent
-///                          to the model as a normal message instead.
-///   handler     (function) Required. Called when the user runs the command.
+///   nargs       (integer|string) Optional. How many arguments the command
+///                          takes, spelled like nvim's nargs: 0 (default),
+///                          1, "?" (zero or one), "*" (any number), or "+"
+///                          (one or more). An argument is a whitespace
+///                          separated word. Type more than allowed and the
+///                          command quietly stops matching: the input goes
+///                          to the model as a normal message. Only the upper
+///                          bound is checked, so with "+" you still need to
+///                          handle an empty `opts.args` yourself.
+///   handler     (function) Required. Called when the user runs the command,
+///                          with one opts table: `opts.args` is the raw
+///                          argument string (whitespace kept, may be empty)
+///                          and `opts.fargs` is the same split into words.
 /// @return
 /// @example
 /// maki.api.register_command({
@@ -1190,6 +1195,21 @@ fn register_tool_from_lua(lua: &Lua, spec: &Table, pending: PendingTools) -> Lua
     Ok(())
 }
 
+/// Matching only needs an upper bound, so "+" and "*" both become MAX;
+/// minimums ("+" vs "*") are left for handlers to enforce.
+fn parse_nargs(spec: &Table) -> LuaResult<usize> {
+    match spec.get::<LuaValue>("nargs")? {
+        LuaValue::Nil | LuaValue::Integer(0) | LuaValue::Number(0.0) => Ok(0),
+        LuaValue::Integer(1) | LuaValue::Number(1.0) => Ok(1),
+        LuaValue::String(s) => match s.to_string_lossy().as_ref() {
+            "?" => Ok(1),
+            "*" | "+" => Ok(usize::MAX),
+            _ => Err(mlua::Error::runtime(NARGS_ERR)),
+        },
+        _ => Err(mlua::Error::runtime(NARGS_ERR)),
+    }
+}
+
 fn register_command_from_lua(lua: &Lua, spec: &Table, plugin: Arc<str>) -> LuaResult<()> {
     let mut name: String = spec
         .get("name")
@@ -1203,21 +1223,7 @@ fn register_command_from_lua(lua: &Lua, spec: &Table, plugin: Arc<str>) -> LuaRe
         name.insert(0, '/');
     }
     let description: String = spec.get("description").unwrap_or_default();
-    let max_args: i64 = spec
-        .get::<Option<i64>>("max_args")
-        .map_err(|_| mlua::Error::runtime("register_command: 'max_args' must be an integer"))?
-        .unwrap_or(0);
-    let max_args: usize = match max_args {
-        -1 => usize::MAX,
-        n if n >= 0 => n
-            .try_into()
-            .map_err(|_| mlua::Error::runtime("register_command: 'max_args' is too large"))?,
-        _ => {
-            return Err(mlua::Error::runtime(
-                "register_command: 'max_args' must be non-negative or -1 for unlimited",
-            ));
-        }
-    };
+    let max_args = parse_nargs(spec)?;
     let handler: Function = spec
         .get("handler")
         .map_err(|_| mlua::Error::runtime("register_command: missing 'handler'"))?;

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -2277,8 +2277,14 @@ pub fn spawn(
                                 let lua = rt.lua.clone();
                                 ex.spawn(async move {
                                     let run = async {
+                                        let opts = lua.create_table()?;
+                                        opts.set(
+                                            "fargs",
+                                            lua.create_sequence_from(args.split_whitespace())?,
+                                        )?;
+                                        opts.set("args", args)?;
                                         let thread = lua.create_thread(func)?;
-                                        thread.into_async::<()>(args)?.await
+                                        thread.into_async::<()>(opts)?.await
                                     };
                                     if let Err(e) = run_detached(&lua, run).await {
                                         tracing::warn!(plugin = %plugin, command = %command, error = %e, "command handler failed");

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -7,6 +7,8 @@ use maki_config::{AlwaysThinking, PluginsConfig, ToolOutputLines};
 use maki_lua::{PluginError, PluginHost, WARM_TOOL_CAP};
 use std::path::Path;
 
+const NARGS_ERR: &str = r#"'nargs' must be 0, 1, "?", "*", or "+""#;
+
 fn fresh_registry() -> Arc<ToolRegistry> {
     Arc::new(ToolRegistry::new())
 }
@@ -2188,7 +2190,7 @@ fn register_command_happy_path() {
         maki.api.register_command({
             name = "/hello",
             description = "says hello",
-            handler = function(args) end,
+            handler = function(opts) end,
         })
         "#,
     )
@@ -2200,68 +2202,54 @@ fn register_command_happy_path() {
     assert_eq!(snap.commands[0].name.as_ref(), "/hello");
     assert_eq!(snap.commands[0].description.as_ref(), "says hello");
     assert_eq!(snap.commands[0].plugin.as_ref(), "cmd_plugin");
-    assert_eq!(snap.commands[0].max_args, 0);
 }
 
-#[test]
-fn register_command_max_args_custom() {
+#[test_case::test_case("" => 0 ; "default_zero")]
+#[test_case::test_case("nargs = 0," => 0 ; "zero")]
+#[test_case::test_case("nargs = 1," => 1 ; "one")]
+#[test_case::test_case(r#"nargs = "?","# => 1 ; "zero_or_one")]
+#[test_case::test_case(r#"nargs = "*","# => usize::MAX ; "any")]
+#[test_case::test_case(r#"nargs = "+","# => usize::MAX ; "one_or_more")]
+fn register_command_nargs_values(nargs_field: &str) -> usize {
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
     host.load_source(
-        "cmd_max",
+        "cmd_nargs",
+        &format!(
+            r#"maki.api.register_command({{ name = "/test", {nargs_field} handler = function() end }})"#
+        ),
+    )
+    .unwrap();
+
+    host.command_reader().load().commands[0].max_args
+}
+
+#[test_case::test_case("a  b c", "a  b c|a,b,c" ; "raw_text_and_split_list")]
+#[test_case::test_case("", "|" ; "empty_args")]
+fn command_handler_receives_args_and_fargs(args: &str, expected_flash: &str) {
+    let host = PluginHost::new(fresh_registry()).unwrap();
+    host.load_source(
+        "p",
         r#"
         maki.api.register_command({
-            name = "/onearg",
-            description = "takes one arg",
-            max_args = 1,
-            handler = function(args) end,
-        })
-        maki.api.register_command({
-            name = "/noargs",
-            description = "takes no args",
-            max_args = 0,
-            handler = function() end,
+            name = "/echo",
+            nargs = "*",
+            handler = function(opts)
+                maki.ui.flash(opts.args .. "|" .. table.concat(opts.fargs, ","))
+            end,
         })
         "#,
     )
     .unwrap();
+    let rx = host.ui_action_rx().unwrap();
+    host.event_handle()
+        .unwrap()
+        .run_command(Arc::from("p"), Arc::from("/echo"), args.into());
 
-    let snap = host.command_reader().load();
-    assert_eq!(snap.commands.len(), 2);
-    let one_arg = snap
-        .commands
-        .iter()
-        .find(|c| c.name.as_ref() == "/onearg")
-        .unwrap();
-    assert_eq!(one_arg.max_args, 1);
-    let no_args = snap
-        .commands
-        .iter()
-        .find(|c| c.name.as_ref() == "/noargs")
-        .unwrap();
-    assert_eq!(no_args.max_args, 0);
-}
-
-#[test]
-fn register_command_max_args_unlimited() {
-    let reg = fresh_registry();
-    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    host.load_source(
-        "cmd_unlimited",
-        r#"
-        maki.api.register_command({
-            name = "/unlimited",
-            description = "takes unlimited args",
-            max_args = -1,
-            handler = function(args) end,
-        })
-        "#,
-    )
-    .unwrap();
-
-    let snap = host.command_reader().load();
-    assert_eq!(snap.commands.len(), 1);
-    assert_eq!(snap.commands[0].max_args, usize::MAX);
+    let action = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("command handler did not run");
+    assert!(matches!(action, maki_lua::UiAction::Flash(msg) if msg == expected_flash));
 }
 
 #[test_case::test_case(
@@ -2273,16 +2261,16 @@ fn register_command_max_args_unlimited() {
     "handler" ; "missing_handler"
 )]
 #[test_case::test_case(
-    r#"maki.api.register_command({ name = "/test", max_args = -2, handler = function() end })"#,
-    "non-negative or -1" ; "negative_max_args"
+    r#"maki.api.register_command({ name = "/test", nargs = -1, handler = function() end })"#,
+    NARGS_ERR ; "negative_nargs"
 )]
 #[test_case::test_case(
-    r#"maki.api.register_command({ name = "/test", max_args = "one", handler = function() end })"#,
-    "must be an integer" ; "string_max_args"
+    r#"maki.api.register_command({ name = "/test", nargs = 2, handler = function() end })"#,
+    NARGS_ERR ; "nargs_two"
 )]
 #[test_case::test_case(
-    r#"maki.api.register_command({ name = "/test", max_args = math.huge, handler = function() end })"#,
-    "must be an integer" ; "infinite_max_args"
+    r#"maki.api.register_command({ name = "/test", nargs = "!", handler = function() end })"#,
+    NARGS_ERR ; "unknown_string_nargs"
 )]
 fn register_command_validation_rejects(src: &str, expected_err: &str) {
     let reg = fresh_registry();

--- a/maki-ui/src/components/command.rs
+++ b/maki-ui/src/components/command.rs
@@ -682,7 +682,7 @@ mod tests {
     #[test_case("/cd  ~/foo", true  ; "one_arg_cmd_double_space")]
     #[test_case("/cd ~/foo ", false ; "one_arg_cmd_second_space")]
     #[test_case("/btw hello world", true ; "btw_stays_active_with_many_args")]
-    fn sync_respects_max_args(input: &str, expect_active: bool) {
+    fn sync_respects_nargs(input: &str, expect_active: bool) {
         let p = synced(input);
         assert_eq!(p.is_active(), expect_active);
     }

--- a/plugins/sessions/init.lua
+++ b/plugins/sessions/init.lua
@@ -571,8 +571,9 @@ maki.api.register_command({
 maki.api.register_command({
   name = "/rename",
   description = "Rename the current session",
-  handler = function(args)
-    local title = (args or ""):match("^%s*(.-)%s*$")
+  nargs = "+",
+  handler = function(opts)
+    local title = opts.args:match("^%s*(.-)%s*$")
     if title == "" then
       maki.ui.flash(RENAME_USAGE)
       return

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -253,15 +253,19 @@ browsing memory files or toggling settings.
   - `name` (`string`) Required. The command name (e.g. "/hello"; a leading
     slash is added when missing).
   - `description` (`string`) Optional. Short description shown in the command palette.
-  - `max_args` (`integer`) Optional. Maximum number of arguments accepted.
-    Defaults to 0 (no arguments). Set to -1 for
-    unlimited. An "argument" is a whitespace-separated
-    word, so max_args = 1 breaks on the first space.
-    Handler receives the raw arg string, not a list.
-    If the user types more arguments than max_args, the
-    command silently stops matching and the input is sent
-    to the model as a normal message instead.
-  - `handler` (`function`) Required. Called when the user runs the command.
+  - `nargs` (`integer|string`) Optional. How many arguments the command
+    takes, spelled like nvim's nargs: 0 (default),
+    1, "?" (zero or one), "*" (any number), or "+"
+    (one or more). An argument is a whitespace
+    separated word. Type more than allowed and the
+    command quietly stops matching: the input goes
+    to the model as a normal message. Only the upper
+    bound is checked, so with "+" you still need to
+    handle an empty `opts.args` yourself.
+  - `handler` (`function`) Required. Called when the user runs the command,
+    with one opts table: `opts.args` is the raw
+    argument string (whitespace kept, may be empty)
+    and `opts.fargs` is the same split into words.
 
 **Example:**
 


### PR DESCRIPTION
command handlers now receive one table, like nvim's `nvim_create_user_command`:

- `opts.args`: the raw argument string, whitespace preserved
- `opts.fargs`: the whitespace-split list

`max_args` is gone, replaced by nvim's `nargs`: `0` (default), `1`, `"?"`, `"*"`, `"+"`. invalid values error at registration. the palette still counts args to decide when a command stops matching, now driven by `nargs`.

in-repo plugins migrated, `/rename` keeps its free-text behavior via raw `opts.args` with `nargs = "+"`. docs regenerated.

supersedes #643, reworks #632's `max_args` into `nargs` for nvim compatibility.