### PR TITLE
fix(ui): drain nucleo before reading palette matches

### DIFF
--- a/maki-ui/src/components/command.rs
+++ b/maki-ui/src/components/command.rs
@@ -15,6 +15,8 @@ use ratatui::widgets::{Clear, Paragraph};
 
 use crate::theme;
 
+const TICK_TIMEOUT_MS: u64 = 10;
+
 pub struct BuiltinCommand {
     pub name: &'static str,
     pub description: &'static str,
@@ -330,14 +332,18 @@ impl CommandPalette {
             false,
         );
 
-        // Tick to get matches
         self.tick();
     }
 
     fn tick(&mut self) {
-        let status = self.nucleo.tick(100);
-        if status.changed {
-            self.refresh_matches();
+        loop {
+            let status = self.nucleo.tick(TICK_TIMEOUT_MS);
+            if status.changed {
+                self.refresh_matches();
+            }
+            if !status.running {
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
`CommandPalette::sync` ticked nucleo once, but matching runs on a worker thread, so under load `tick` could return `running: true` and leave `filtered` with stale results, which made `sync_filters_on_first_word_only` flaky.

Now `tick` loops until the worker settles, which takes microseconds for a few dozen commands, so callers always see the final match set.