### PR TITLE
feat(providers): add Claude Opus 5 and Sonnet 5

### DIFF
--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -215,41 +215,24 @@ fn write_model_table(out: &mut String, entries: &[ModelEntry]) {
         "|------|--------|-------------------------------|---------|"
     );
 
+    // A row per model, not per tier: prices and context sizes differ inside a
+    // tier, so one merged row would quote a single model's numbers for all.
     for tier in [ModelTier::Weak, ModelTier::Medium, ModelTier::Strong] {
-        let tier_entries: Vec<_> = entries.iter().filter(|e| e.tier == tier).collect();
-        if tier_entries.is_empty() {
-            continue;
-        }
-
-        let models: Vec<String> = tier_entries
-            .iter()
-            .map(|e| {
-                let names = e.prefixes.join(", ");
-                if e.default {
+        for entry in entries.iter().filter(|e| e.tier == tier) {
+            let names = entry.prefixes.join(", ");
+            let _ = writeln!(
+                out,
+                "| {} | {} | {} | {} |",
+                tier_label(tier),
+                if entry.default {
                     format!("**{names}** (default)")
                 } else {
                     names
-                }
-            })
-            .collect();
-
-        let pricing = tier_entries
-            .first()
-            .map(|e| format_pricing(e))
-            .unwrap_or_default();
-        let context = tier_entries
-            .first()
-            .map(|e| format_context(e))
-            .unwrap_or_default();
-
-        let _ = writeln!(
-            out,
-            "| {} | {} | {} | {} |",
-            tier_label(tier),
-            models.join(", "),
-            pricing,
-            context,
-        );
+                },
+                format_pricing(entry),
+                format_context(entry),
+            );
+        }
     }
 
     let defaults: Vec<String> = entries

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -38,9 +38,9 @@ pub struct ModelPricing {
     pub output: f64,
     pub cache_write: f64,
     pub cache_read: f64,
-    /// Anthropic fast mode charges a premium that differs per model (6x on Opus
-    /// 4.6/4.7, 2x on Opus 4.8). `None` means the model has no fast tier, so asking
-    /// for fast mode quietly falls back to standard rates instead of overcharging.
+    /// Anthropic fast mode charges a premium that differs per model. `None`
+    /// means the model has no fast tier, so asking for fast mode quietly falls
+    /// back to standard rates instead of overcharging.
     #[serde(default)]
     pub fast: Option<FastPricing>,
 }
@@ -736,38 +736,18 @@ mod tests {
         assert_eq!(Model::from_spec(spec).unwrap().supports_vision(), expected);
     }
 
-    #[test_case("claude-opus-4-6" ; "opus_4_6")]
-    #[test_case("claude-opus-4-7" ; "opus_4_7")]
-    #[test_case("claude-opus-4-8" ; "opus_4_8")]
-    fn supports_fast_true_for_anthropic_opus(model_id: &str) {
+    #[test_case("claude-opus-5",    true  ; "entry_with_fast_pricing")]
+    #[test_case("claude-opus-5-1m", true  ; "long_context_suffix_still_matches_prefix")]
+    #[test_case("claude-opus-4-7",  false ; "fast_withdrawn_from_the_table")]
+    #[test_case("claude-sonnet-5",  false ; "entry_without_fast_pricing")]
+    #[test_case("claude-opus-99",   false ; "no_entry_at_all")]
+    fn supports_fast_follows_anthropic_table(model_id: &str, expected: bool) {
         let model = Model::from_base(
             ManifestRegistry::get("anthropic").unwrap(),
             "anthropic",
             model_id,
         );
-        assert!(model.supports_fast());
-    }
-
-    #[test_case("claude-sonnet-4-5" ; "sonnet")]
-    #[test_case("claude-haiku-4-5" ; "haiku")]
-    #[test_case("claude-opus-4-5" ; "opus_4_5")]
-    fn supports_fast_false_for_other_anthropic_models(model_id: &str) {
-        let model = Model::from_base(
-            ManifestRegistry::get("anthropic").unwrap(),
-            "anthropic",
-            model_id,
-        );
-        assert!(!model.supports_fast());
-    }
-
-    #[test]
-    fn supports_fast_false_for_unknown_anthropic_model() {
-        let model = Model::from_base(
-            ManifestRegistry::get("anthropic").unwrap(),
-            "anthropic",
-            "claude-opus-99",
-        );
-        assert!(!model.supports_fast());
+        assert_eq!(model.supports_fast(), expected);
     }
 
     #[test]

--- a/maki-providers/src/providers/anthropic/shared.rs
+++ b/maki-providers/src/providers/anthropic/shared.rs
@@ -421,7 +421,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
             tier: ModelTier::Medium,
             family: ModelFamily::Claude,
             vision: true,
-            default: true,
+            default: false,
             pricing: ModelPricing {
                 input: 3.00,
                 output: 15.00,
@@ -430,6 +430,23 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 fast: None,
             },
             max_output_tokens: 64000,
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["claude-sonnet-5"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Claude,
+            vision: true,
+            default: true,
+            // Introductory rates until 2026-09-01, then 3.00 / 15.00 / 3.75 / 0.30.
+            pricing: ModelPricing {
+                input: 2.00,
+                output: 10.00,
+                cache_write: 2.50,
+                cache_read: 0.20,
+                fast: None,
+            },
+            max_output_tokens: 128000,
             context_window: 200_000,
         },
         ModelEntry {
@@ -475,10 +492,8 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 output: 25.00,
                 cache_write: 6.25,
                 cache_read: 0.50,
-                fast: Some(FastPricing {
-                    input: 30.00,
-                    output: 150.00,
-                }),
+                // Fast mode withdrawn on 2026-06-29.
+                fast: None,
             },
             max_output_tokens: 128000,
             context_window: 200_000,
@@ -494,16 +509,33 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 output: 25.00,
                 cache_write: 6.25,
                 cache_read: 0.50,
-                fast: Some(FastPricing {
-                    input: 30.00,
-                    output: 150.00,
-                }),
+                // Fast mode withdrawn on 2026-07-24.
+                fast: None,
             },
             max_output_tokens: 128000,
             context_window: 200_000,
         },
         ModelEntry {
             prefixes: &["claude-opus-4-8"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Claude,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 5.00,
+                output: 25.00,
+                cache_write: 6.25,
+                cache_read: 0.50,
+                fast: Some(FastPricing {
+                    input: 10.00,
+                    output: 50.00,
+                }),
+            },
+            max_output_tokens: 128000,
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["claude-opus-5"],
             tier: ModelTier::Strong,
             family: ModelFamily::Claude,
             vision: true,

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -314,6 +314,24 @@ const THINKING_USAGE: &str =
 /// caps. Explicit user budgets never go through this.
 const FALLBACK_MAX_THINKING_BUDGET: u32 = 32_768;
 
+/// First Claude version that speaks adaptive thinking. Opus got there a
+/// generation early, at 4.7; the other families joined at 5.
+const ADAPTIVE_SINCE: (u32, u32) = (5, 0);
+const ADAPTIVE_SINCE_OPUS: (u32, u32) = (4, 7);
+const OPUS: &str = "opus";
+
+/// `claude-opus-4.7` -> `("opus", (4, 7))`, `claude-opus-5-1m` -> `("opus", (5, 0))`.
+/// Copilot writes the version with a dot, hence the two separators. Legacy ids
+/// put the version first (`claude-3-5-sonnet-20241022`), so a numeric family
+/// tells us there is no modern version to read here.
+fn claude_version(model_id: &str) -> Option<(&str, (u32, u32))> {
+    let mut parts = model_id.strip_prefix("claude-")?.split(['-', '.']);
+    let family = parts.next().filter(|f| f.parse::<u32>().is_err())?;
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+    Some((family, (major, minor)))
+}
+
 /// How a provider's effort knob speaks: which levels its API accepts, what
 /// `adaptive` means there, and whether "off" needs an explicit string.
 /// New providers add a const in [`dialect`]; providers with dynamic model
@@ -469,21 +487,18 @@ impl ThinkingConfig {
         }
     }
 
-    /// Version check, not an allowlist, so future Opus releases work
-    /// automatically. Splits on `-` and `.` since Copilot uses dotted ids
-    /// (`claude-opus-4.7`).
+    /// Models from [`ADAPTIVE_SINCE`] on reject `type: "enabled"` with a 400. A
+    /// version check, not an allowlist, so future releases and new families
+    /// work automatically.
     fn requires_adaptive(model_id: &str) -> bool {
-        let Some(version) = model_id.strip_prefix("claude-opus-") else {
-            return false;
-        };
-        let mut parts = version.split(['-', '.']);
-        let (Some(Ok(major)), Some(Ok(minor))) = (
-            parts.next().map(str::parse::<u32>),
-            parts.next().map(str::parse::<u32>),
-        ) else {
-            return false;
-        };
-        (major, minor) >= (4, 7)
+        claude_version(model_id).is_some_and(|(family, version)| {
+            version
+                >= if family == OPUS {
+                    ADAPTIVE_SINCE_OPUS
+                } else {
+                    ADAPTIVE_SINCE
+                }
+        })
     }
 
     pub fn apply_reasoning_effort(self, body: &mut Value, dialect: &EffortDialect, model: &Model) {
@@ -790,9 +805,10 @@ mod tests {
     #[test_case(ThinkingConfig::Budget(10000), "claude-opus-4-7", json!({"thinking": {"type": "adaptive"}, "output_config": {"effort": "high"}}) ; "budget_adaptive_opus_4_7")]
     #[test_case(ThinkingConfig::Effort(Low), "claude-opus-4-7", json!({"thinking": {"type": "adaptive"}, "output_config": {"effort": "low"}}) ; "effort_low_passthrough")]
     #[test_case(ThinkingConfig::Budget(10000), "claude-opus-4-8-1m", json!({"thinking": {"type": "adaptive"}, "output_config": {"effort": "high"}}) ; "budget_adaptive_opus_4_8_long_context")]
-    #[test_case(ThinkingConfig::Budget(10000), "claude-opus-5-0", json!({"thinking": {"type": "adaptive"}, "output_config": {"effort": "high"}}) ; "budget_adaptive_future_opus_5")]
+    #[test_case(ThinkingConfig::Budget(10000), "claude-opus-5-1m", json!({"thinking": {"type": "adaptive"}, "output_config": {"effort": "high"}}) ; "budget_adaptive_opus_5_unparsable_minor")]
     #[test_case(ThinkingConfig::Budget(10000), "claude-opus-4.7", json!({"thinking": {"type": "adaptive"}, "output_config": {"effort": "high"}}) ; "budget_adaptive_copilot_dotted_id")]
-    #[test_case(ThinkingConfig::Budget(10000), "claude-opus-4.6", json!({"thinking": {"type": "enabled", "budget_tokens": 4096}}) ; "budget_legacy_copilot_dotted_4_6")]
+    #[test_case(ThinkingConfig::Budget(10000), "claude-sonnet-5", json!({"thinking": {"type": "adaptive"}, "output_config": {"effort": "high"}}) ; "budget_adaptive_sonnet_5")]
+    #[test_case(ThinkingConfig::Budget(10000), "claude-3-5-sonnet-20241022", json!({"thinking": {"type": "enabled", "budget_tokens": 4096}}) ; "budget_legacy_dated_id")]
     fn thinking_apply_to_body(config: ThinkingConfig, model_id: &str, expected: Value) {
         let mut body = json!({});
         config.apply_to_body(&mut body, &thinking_model(model_id));

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -38,10 +38,19 @@ It wins over `providers.toml` and built-in defaults. `ANTHROPIC_BASE_URL` and `O
 | Tier | Models | Pricing (in/out per 1M tokens) | Context |
 |------|--------|-------------------------------|---------|
 | Weak | **claude-haiku-4-5** (default) | $1.00 / $5.00 | 200K ctx / 64K out |
-| Medium | claude-sonnet-4-5, **claude-sonnet-4-6** (default), claude-sonnet-4 | $3.00 / $15.00 | 200K ctx / 64K out |
-| Strong | claude-opus-4-5, claude-opus-4-6, claude-opus-4-7, **claude-opus-4-8** (default), claude-fable-5, claude-opus-4-0, claude-opus-4-1 | $5.00 / $25.00 | 200K ctx / 64K out |
+| Medium | claude-sonnet-4-5 | $3.00 / $15.00 | 200K ctx / 64K out |
+| Medium | claude-sonnet-4-6 | $3.00 / $15.00 | 200K ctx / 64K out |
+| Medium | **claude-sonnet-5** (default) | $2.00 / $10.00 | 200K ctx / 128K out |
+| Medium | claude-sonnet-4 | $3.00 / $15.00 | 200K ctx / 64K out |
+| Strong | claude-opus-4-5 | $5.00 / $25.00 | 200K ctx / 64K out |
+| Strong | claude-opus-4-6 | $5.00 / $25.00 | 200K ctx / 128K out |
+| Strong | claude-opus-4-7 | $5.00 / $25.00 | 200K ctx / 128K out |
+| Strong | claude-opus-4-8 | $5.00 / $25.00 | 200K ctx / 128K out |
+| Strong | **claude-opus-5** (default) | $5.00 / $25.00 | 200K ctx / 128K out |
+| Strong | claude-fable-5 | $10.00 / $50.00 | 200K ctx / 128K out |
+| Strong | claude-opus-4-0, claude-opus-4-1 | $15.00 / $75.00 | 200K ctx / 32K out |
 
-Defaults: claude-haiku-4-5 (weak), claude-sonnet-4-6 (medium), claude-opus-4-8 (strong)
+Defaults: claude-haiku-4-5 (weak), claude-sonnet-5 (medium), claude-opus-5 (strong)
 
 Add `-1m` to any Claude model, like `claude-sonnet-4-6-1m`, to use the 1M token context window.
 
@@ -67,9 +76,23 @@ You can override the model with `ANTHROPIC_MODEL` and the endpoint with `ANTHROP
 
 | Tier | Models | Pricing (in/out per 1M tokens) | Context |
 |------|--------|-------------------------------|---------|
-| Weak | **gpt-5.6-luna** (default), gpt-5.4-nano, gpt-5.4-mini, gpt-4.1-nano | $1.00 / $6.00 | 372K ctx / 128K out |
-| Medium | **gpt-5.6-terra** (default), gpt-4.1-mini, gpt-4.1, o4-mini, gpt-5.1-codex-mini | $2.50 / $15.00 | 372K ctx / 128K out |
-| Strong | **gpt-5.6-sol** (default), gpt-5.5, gpt-5.4, o3, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-max, gpt-5.1-codex | $5.00 / $30.00 | 372K ctx / 128K out |
+| Weak | **gpt-5.6-luna** (default) | $1.00 / $6.00 | 372K ctx / 128K out |
+| Weak | gpt-5.4-nano | $0.20 / $1.25 | 400K ctx / 128K out |
+| Weak | gpt-5.4-mini | $0.75 / $4.50 | 400K ctx / 128K out |
+| Weak | gpt-4.1-nano | $0.10 / $0.40 | 1047K ctx / 32K out |
+| Medium | **gpt-5.6-terra** (default) | $2.50 / $15.00 | 372K ctx / 128K out |
+| Medium | gpt-4.1-mini | $0.40 / $1.60 | 1047K ctx / 32K out |
+| Medium | gpt-4.1 | $2.00 / $8.00 | 1047K ctx / 32K out |
+| Medium | o4-mini | $1.10 / $4.40 | 200K ctx / 100K out |
+| Medium | gpt-5.1-codex-mini | $0.25 / $2.00 | 400K ctx / 128K out |
+| Strong | **gpt-5.6-sol** (default) | $5.00 / $30.00 | 372K ctx / 128K out |
+| Strong | gpt-5.5 | $5.00 / $30.00 | 1050K ctx / 128K out |
+| Strong | gpt-5.4 | $2.50 / $15.00 | 1050K ctx / 128K out |
+| Strong | o3 | $2.00 / $8.00 | 200K ctx / 100K out |
+| Strong | gpt-5.3-codex | $1.75 / $14.00 | 400K ctx / 128K out |
+| Strong | gpt-5.2-codex | $1.75 / $14.00 | 400K ctx / 128K out |
+| Strong | gpt-5.1-codex-max | $1.25 / $10.00 | 400K ctx / 128K out |
+| Strong | gpt-5.1-codex | $1.25 / $10.00 | 400K ctx / 128K out |
 
 Defaults: gpt-5.6-luna (weak), gpt-5.6-terra (medium), gpt-5.6-sol (strong)
 
@@ -97,7 +120,8 @@ Defaults: gemini-2.5-pro (strong), gemini-2.5-flash (medium), gemini-2.0-flash-l
 |------|--------|-------------------------------|---------|
 | Weak | **gpt-5-mini, gpt-5 mini, claude-haiku-4.5** (default) | $0.00 / $0.00 | 200K ctx / 100K out |
 | Medium | **gpt-5.2, gpt-4.1, claude-sonnet-4.5** (default) | $0.00 / $0.00 | 200K ctx / 100K out |
-| Strong | **gpt-5.4, gpt-5.3-codex, claude-opus-4.6, grok-code-fast-1** (default), claude-opus-4.7 | $0.00 / $0.00 | 200K ctx / 100K out |
+| Strong | **gpt-5.4, gpt-5.3-codex, claude-opus-4.6, grok-code-fast-1** (default) | $0.00 / $0.00 | 200K ctx / 100K out |
+| Strong | claude-opus-4.7 | $0.00 / $0.00 | 264K ctx / 64K out |
 
 Defaults: gpt-5-mini (weak), gpt-5.2 (medium), gpt-5.4 (strong)
 
@@ -139,9 +163,14 @@ Defaults: mistral-medium-latest (strong), mistral-small-latest (medium), ministr
 
 | Tier | Models | Pricing (in/out per 1M tokens) | Context |
 |------|--------|-------------------------------|---------|
-| Weak | **glm-4.7-flash** (default), glm-4.5-flash, glm-4.5-air | $0.00 / $0.00 | 200K ctx / 131K out |
-| Medium | **glm-4.7, glm-4.6** (default), glm-4.5 | $0.60 / $2.20 | 200K ctx / 131K out |
-| Strong | **glm-5-code** (default), glm-5.2, glm-5.1, glm-5 | $1.20 / $5.00 | 200K ctx / 131K out |
+| Weak | **glm-4.7-flash** (default) | $0.00 / $0.00 | 200K ctx / 131K out |
+| Weak | glm-4.5-flash | $0.00 / $0.00 | 131K ctx / 98K out |
+| Weak | glm-4.5-air | $0.20 / $1.10 | 131K ctx / 98K out |
+| Medium | **glm-4.7, glm-4.6** (default) | $0.60 / $2.20 | 200K ctx / 131K out |
+| Medium | glm-4.5 | $0.60 / $2.20 | 131K ctx / 98K out |
+| Strong | **glm-5-code** (default) | $1.20 / $5.00 | 200K ctx / 131K out |
+| Strong | glm-5.2 | $1.00 / $3.20 | 1000K ctx / 131K out |
+| Strong | glm-5.1, glm-5 | $1.00 / $3.20 | 200K ctx / 131K out |
 
 Defaults: glm-5-code (strong), glm-4.7-flash (weak), glm-4.7 (medium)
 


### PR DESCRIPTION
Opus 5 was missing from the Anthropic table, so it fell through to the unknown model path with zero pricing and a tier guessed from its position in `/models`.

It now sits there as the strong default at $5 / $25 with 2x fast mode, next to Sonnet 5 as the medium default at its introductory $2 / $10, which rises to $3 / $15 on September 1.

Fast mode is gone from Opus 4.6 and 4.7, withdrawn in June and retired today, so the toggle no longer promises speed it cannot deliver at six times the real price.

The adaptive thinking check only looked at Opus, which would have sent `thinking.type: "enabled"` to Sonnet 5 and to Fable 5 and earned a 400 back; it now covers everything from the 5 generation on, while a guard on numeric families keeps old ids like `claude-3-5-sonnet-20241022` on the budget path.