### PR TITLE
feat(index): add Astro, Svelte, and Vue language support

### DIFF
--- a/plugins/index/indexer.lua
+++ b/plugins/index/indexer.lua
@@ -52,6 +52,9 @@ local EXT_TO_LANG = {
   yaml = "yaml",
   yml = "yaml",
   sql = "sql",
+  astro = "astro",
+  svelte = "svelte",
+  vue = "vue",
 }
 
 local FILENAME_TO_LANG = {

--- a/plugins/index/lang/astro.lua
+++ b/plugins/index/lang/astro.lua
@@ -1,0 +1,11 @@
+return function(U)
+  return require("lang.simple_outline")(U, {
+    header = "components",
+    nodes = {
+      frontmatter = { label = "frontmatter: " },
+      script_element = { label = "script: " },
+      style_element = { label = "style: " },
+      element = { label = "markup: " },
+    },
+  })
+end

--- a/plugins/index/lang/simple_outline.lua
+++ b/plugins/index/lang/simple_outline.lua
@@ -1,0 +1,43 @@
+return function(U, config)
+  local compact_ws = U.compact_ws
+  local format_range = U.format_range
+  local get_text = U.get_text
+  local line_end = U.line_end
+  local line_start = U.line_start
+  local truncate = U.truncate
+
+  local function render(node, source, descriptor)
+    local text = compact_ws(get_text(node, source))
+    local label
+    if type(descriptor.label) == "function" then
+      label = descriptor.label(text)
+    else
+      label = descriptor.label .. truncate(text, config.max_length or 100)
+    end
+    return "  " .. label .. " " .. format_range(line_start(node), line_end(node))
+  end
+
+  local function walk(node, source, out)
+    local descriptor = config.nodes[node:type()]
+    if descriptor then
+      out[#out + 1] = render(node, source, descriptor)
+      if not descriptor.recurse then
+        return
+      end
+    end
+    for _, child in ipairs(node:children()) do
+      walk(child, source, out)
+    end
+  end
+
+  return {
+    extract = function(source, root)
+      local out = {}
+      walk(root, source, out)
+      if #out == 0 then
+        return ""
+      end
+      return (config.header or "outline") .. ":\n" .. table.concat(out, "\n") .. "\n"
+    end,
+  }
+end

--- a/plugins/index/lang/svelte.lua
+++ b/plugins/index/lang/svelte.lua
@@ -1,0 +1,11 @@
+return function(U)
+  return require("lang.simple_outline")(U, {
+    header = "components",
+    nodes = {
+      script_element = { label = "script: " },
+      style_element = { label = "style: " },
+      element = { label = "markup: " },
+      snippet_statement = { label = "snippet: " },
+    },
+  })
+end

--- a/plugins/index/lang/vue.lua
+++ b/plugins/index/lang/vue.lua
@@ -1,0 +1,10 @@
+return function(U)
+  return require("lang.simple_outline")(U, {
+    header = "components",
+    nodes = {
+      script_element = { label = "script: " },
+      style_element = { label = "style: " },
+      template_element = { label = "template: " },
+    },
+  })
+end

--- a/plugins/index/tests/lang/astro_svelte_vue.lua
+++ b/plugins/index/tests/lang/astro_svelte_vue.lua
@@ -1,0 +1,26 @@
+local helpers = require("tests.helpers")
+local case = helpers.case
+local has = helpers.has
+local idx = helpers.idx
+local indexer = require("indexer")
+
+case("astro_indexes_common_structure", function()
+  local source = "---\nconst title = 'Hello'\n---\n<main id=\"page\"><h1>{title}</h1></main>"
+  has(idx(source, "astro"), { "components:", "frontmatter:", "markup:" })
+end)
+
+case("svelte_indexes_common_structure", function()
+  local source = "<script>let count = 0;</script>\n<main>{count}</main>\n<style>main { color: red; }</style>"
+  has(idx(source, "svelte"), { "components:", "script:", "markup:", "style:" })
+end)
+
+case("vue_indexes_common_structure", function()
+  local source = "<template><main>{{ title }}</main></template>\n<script setup>const title = 'Hi'</script>"
+  has(idx(source, "vue"), { "components:", "template:", "script:" })
+end)
+
+case("astro_svelte_vue_map_extensions", function()
+  assert(indexer.EXT_TO_LANG.astro == "astro")
+  assert(indexer.EXT_TO_LANG.svelte == "svelte")
+  assert(indexer.EXT_TO_LANG.vue == "vue")
+end)

--- a/plugins/index/tests/spec.lua
+++ b/plugins/index/tests/spec.lua
@@ -6,6 +6,7 @@
 -- alphabetized. Each spec uses the shared `case` helper from tests/helpers.lua,
 -- which collects failures so a single broken case does not abort the suite.
 require("tests.indexer_core")
+require("tests.lang.astro_svelte_vue")
 require("tests.lang.bash")
 require("tests.lang.bazel")
 require("tests.lang.c")


### PR DESCRIPTION
Add indexing support for Astro, Svelte, and Vue single-file components. Each language uses the shared simple_outline helper to extract component structure (frontmatter, script, style, template, markup) with line ranges.

- Add lang/astro.lua, lang/svelte.lua, lang/vue.lua
- Add lang/simple_outline.lua shared helper for outline-based languages
- Register astro, svelte, vue extensions in EXT_TO_LANG
- Add tests/lang/astro_svelte_vue.lua with structure and mapping tests