### PR TITLE
fix(index): improve test helper error messages with output context

### DIFF
--- a/plugins/index/tests/helpers.lua
+++ b/plugins/index/tests/helpers.lua
@@ -32,7 +32,7 @@ end
 
 function M.has(output, needles)
   for _, n in ipairs(needles) do
-    assert(output:find(n, 1, true), "missing '" .. n .. "'")
+    assert(output:find(n, 1, true), "missing '" .. n .. "' in output:\n" .. output)
   end
 end
 


### PR DESCRIPTION
Update the has() assertion in plugins/index/tests/helpers.lua to include output context in error messages, making it easier to debug test failures.