### PR TITLE
feat: add built-in codegraph tool for cross-file structural exploration

### DIFF
--- a/changelog.d/codegraph.added.md
+++ b/changelog.d/codegraph.added.md
@@ -1,0 +1,1 @@
+Built-in `codegraph` tool for cross-file structural exploration, call-path analysis, and blast-radius impact checks using a pre-indexed semantic codegraph (powered by [colbymchenry/codegraph](https://github.com/colbymchenry/codegraph)). Use `codegraph explore <query>` at the CLI or the built-in `codegraph` tool in agent sessions.

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -53,6 +53,7 @@ pub const DEFAULT_BUILTINS: &[&str] = &[
     "bash",
     "batch",
     "code_execution",
+    "codegraph",
     "edit",
     "glob",
     "grep",
@@ -351,6 +352,7 @@ pub struct ToolOutputLinesFile {
     pub code_execution: Option<usize>,
     pub task: Option<usize>,
     pub index: Option<usize>,
+    pub explore: Option<usize>,
     pub grep: Option<usize>,
     pub read: Option<usize>,
     pub write: Option<usize>,
@@ -367,6 +369,7 @@ impl ToolOutputLinesFile {
             code_execution,
             task,
             index,
+            explore,
             grep,
             read,
             write,
@@ -854,6 +857,7 @@ pub struct ToolOutputLines {
     pub code_execution: usize,
     pub task: usize,
     pub index: usize,
+    pub explore: usize,
     pub grep: usize,
     pub read: usize,
     pub write: usize,
@@ -867,6 +871,7 @@ impl ToolOutputLines {
         code_execution: 5,
         task: 5,
         index: 3,
+        explore: 3,
         grep: 3,
         read: 3,
         write: 7,
@@ -879,6 +884,7 @@ impl ToolOutputLines {
         ("code_execution", Self::DEFAULT.code_execution),
         ("task", Self::DEFAULT.task),
         ("index", Self::DEFAULT.index),
+        ("explore", Self::DEFAULT.explore),
         ("grep", Self::DEFAULT.grep),
         ("read", Self::DEFAULT.read),
         ("write", Self::DEFAULT.write),
@@ -894,6 +900,7 @@ impl ToolOutputLines {
             code_execution: f.code_execution.unwrap_or(d.code_execution),
             task: f.task.unwrap_or(d.task),
             index: f.index.unwrap_or(d.index),
+            explore: f.explore.unwrap_or(d.explore),
             grep: f.grep.unwrap_or(d.grep),
             read: f.read.unwrap_or(d.read),
             write: f.write.unwrap_or(d.write),
@@ -902,12 +909,13 @@ impl ToolOutputLines {
         }
     }
 
-    fn fields(&self) -> [(&'static str, usize); 9] {
+    fn fields(&self) -> [(&'static str, usize); 10] {
         [
             ("bash", self.bash),
             ("code_execution", self.code_execution),
             ("task", self.task),
             ("index", self.index),
+            ("explore", self.explore),
             ("grep", self.grep),
             ("read", self.read),
             ("write", self.write),
@@ -934,6 +942,7 @@ impl ToolOutputLines {
             "code_execution" => self.code_execution,
             "task" => self.task,
             "index" => self.index,
+            "codegraph" | "explore" => self.explore,
             "grep" | "glob" => self.grep,
             "read" => self.read,
             "memory" => self.write,

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -96,6 +96,10 @@ static BUNDLED_PLUGINS: &[BundledPlugin] = &[
         dir: include_dir!("$CARGO_MANIFEST_DIR/../plugins/code_execution"),
     },
     BundledPlugin {
+        name: "codegraph",
+        dir: include_dir!("$CARGO_MANIFEST_DIR/../plugins/codegraph"),
+    },
+    BundledPlugin {
         name: "view_image",
         dir: include_dir!("$CARGO_MANIFEST_DIR/../plugins/view_image"),
     },

--- a/plugins/codegraph/init.lua
+++ b/plugins/codegraph/init.lua
@@ -1,0 +1,136 @@
+local truncate = require("maki.truncate")
+local ToolView = require("maki.tool_view")
+local shorten_path = require("maki.shorten_path")
+local output_limits = require("maki.output_limits")
+
+local cwd = maki.uv.cwd() or "."
+local CG_TIMEOUT_SECS = 30
+local cg_available
+
+local function shell_quote(s)
+  return "'" .. s:gsub("'", "'\\''") .. "'"
+end
+
+local function check_codegraph()
+  if cg_available ~= nil then
+    return cg_available
+  end
+  local id = maki.fn.jobstart("codegraph --version")
+  local result = maki.fn.jobwait(id, 3000)
+  if result then
+    cg_available = (result.exit_code == 0)
+  else
+    maki.fn.jobstop(id)
+    cg_available = false
+  end
+  return cg_available
+end
+
+local function check_index(project_path)
+  local meta = maki.fs.metadata(project_path .. "/.codegraph")
+  return meta and meta.is_dir
+end
+
+maki.api.register_prompt_hint({
+  slot = "tool_usage",
+  content = "- Use **codegraph** for cross-file structural queries, call paths, and impact analysis before editing. Use **index** for single-file skeletons before read.",
+})
+
+local opts = maki.api.register_options(output_limits.extend({}))
+
+maki.api.register_tool({
+  name = "codegraph",
+  kind = "read",
+  description = [[Query a pre-indexed semantic codegraph for cross-file structural analysis. Returns verbatim source code grouped by file, plus a dependency impact "blast radius" summary with caller counts and test coverage info.
+
+Best for:
+- Understanding how a system works end-to-end ("how does X work")
+- Finding call paths ("what calls Y", "call path from A to B")
+- Checking blast radius before editing ("what depends on Z")
+- Cross-file symbol resolution
+
+Prefer **index** for single-file structure, then **read** for specific sections. codegraph excels at multi-file exploration and impact analysis.
+
+Requires the codegraph CLI and a .codegraph/ index in the project root.]],
+
+  schema = {
+    type = "object",
+    properties = {
+      query = {
+        type = "string",
+        description = "Natural language question or symbol/file names to explore (e.g. 'AuthService login', 'GraphTraverser BFS impact')",
+        required = true,
+      },
+      projectPath = { type = "string", description = "Absolute path to the project (defaults to current workspace)" },
+    },
+  },
+
+  header = function(input)
+    local buf = maki.ui.buf()
+    local spans = { { input.query or "", "tool" } }
+    if input.projectPath then
+      spans[#spans + 1] = { " in ", "dim" }
+      spans[#spans + 1] = { shorten_path(input.projectPath), "path" }
+    end
+    buf:line(spans)
+    return buf
+  end,
+
+  handler = function(input, ctx)
+    if not input.query then
+      return { llm_output = "error: query is required", is_error = true }
+    end
+
+    if not check_codegraph() then
+      return {
+        llm_output = "error: codegraph CLI not found. Install it from https://github.com/colbymchenry/codegraph",
+        is_error = true,
+      }
+    end
+
+    local project_path = input.projectPath or cwd
+
+    if not check_index(project_path) then
+      return {
+        llm_output = "error: no .codegraph/ index found in "
+          .. project_path
+          .. ". Run `codegraph init` first to index the project.",
+        is_error = true,
+      }
+    end
+
+    local max_lines, max_bytes = output_limits.resolve(opts, ctx)
+
+    local id = maki.fn.jobstart("codegraph explore " .. shell_quote(input.query) .. " " .. shell_quote(project_path))
+    local result = maki.fn.jobwait(id, CG_TIMEOUT_SECS * 1000)
+
+    if not result then
+      maki.fn.jobstop(id)
+      return { llm_output = "error: codegraph explore timed out after " .. CG_TIMEOUT_SECS .. "s", is_error = true }
+    end
+
+    if result.exit_code ~= 0 then
+      local err_msg = (result.stderr or ""):gsub("^%s*(.-)%s*$", "%1")
+      if err_msg == "" then
+        err_msg = (result.stdout or ""):gsub("^%s*(.-)%s*$", "%1")
+      end
+      if err_msg == "" then
+        err_msg = "exit code " .. result.exit_code
+      end
+      return { llm_output = "error: codegraph explore failed: " .. err_msg, is_error = true }
+    end
+
+    local output = (result.stdout or ""):gsub("\n+$", "")
+    local llm_output = truncate(output, max_lines, max_bytes)
+
+    local buf
+    if output ~= "" then
+      buf = maki.ui.buf()
+      local view = ToolView.new(buf, { max_lines = 5, keep = "head" })
+      view:append_text(output)
+      view:finish()
+    end
+
+    return { llm_output = llm_output, body = buf }
+  end,
+})


### PR DESCRIPTION
Registers a new Lua plugin wrapping the codegraph CLI (colbymchenry/codegraph) with a single `codegraph` tool that shells out to `codegraph explore <query> <projectPath>`. Returns verbatim source code grouped by file plus a blast-radius dependency impact summary.

Also adds `explore` field to `ToolOutputLines` and registers `codegraph` in `DEFAULT_BUILTINS` and `BUNDLED_PLUGINS`.