### PR TITLE
feat: promote index and add tooned passthrough with global stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -263,7 +263,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -278,7 +278,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -525,6 +525,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +700,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm 0.29.0",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +849,22 @@ checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.13.1",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
@@ -829,7 +876,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1213,6 +1260,17 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
@@ -1513,7 +1571,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0cd0777a1057362cab35a779e0d79dacecb8d73e2c733eaafeb7ea917b08f03"
 dependencies = [
- "compact_str",
+ "compact_str 0.9.1",
  "get-size-derive2",
  "hashbrown 0.17.1",
  "ordermap",
@@ -1527,7 +1585,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-link",
 ]
 
@@ -1537,7 +1595,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1674,6 +1732,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2146,6 +2206,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2368,6 +2437,12 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2398,6 +2473,15 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru"
@@ -2451,6 +2535,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror 2.0.18",
+ "toon-format",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2587,7 +2672,7 @@ dependencies = [
  "async-lock",
  "base64",
  "criterion",
- "crossterm",
+ "crossterm 0.29.0",
  "event-listener",
  "flume 0.11.1",
  "futures",
@@ -2609,6 +2694,7 @@ dependencies = [
  "maki-storage",
  "mlua",
  "regex",
+ "serde",
  "serde_json",
  "serde_yaml",
  "smol",
@@ -2616,6 +2702,7 @@ dependencies = [
  "test-case",
  "thiserror 2.0.18",
  "toml",
+ "toon-format",
  "tracing",
  "tree-sitter",
  "tree-sitter-bash",
@@ -2645,7 +2732,7 @@ dependencies = [
  "tree-sitter-typescript",
  "tree-sitter-yaml",
  "tree-sitter-zig",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2664,7 +2751,7 @@ dependencies = [
  "fastrand",
  "maki-highlight",
  "test-case",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2723,7 +2810,7 @@ dependencies = [
  "base64",
  "color-eyre",
  "criterion",
- "crossterm",
+ "crossterm 0.29.0",
  "flume 0.11.1",
  "futures-lite",
  "getrandom 0.3.4",
@@ -2742,7 +2829,7 @@ dependencies = [
  "nucleo",
  "nucleo-matcher",
  "open",
- "ratatui",
+ "ratatui 0.30.2",
  "serde",
  "serde_json",
  "shell-words",
@@ -2753,7 +2840,7 @@ dependencies = [
  "test-case",
  "toml",
  "tracing",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2890,7 +2977,7 @@ dependencies = [
  "mlua_derive",
  "num-traits",
  "parking_lot",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustversion",
  "serde",
  "serde-value",
@@ -3272,6 +3359,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3416,6 +3525,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -3688,7 +3803,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3963,6 +4078,27 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.13.1",
+ "cassowary",
+ "compact_str 0.8.2",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru 0.12.5",
+ "paste",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate 1.1.0",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "ratatui"
 version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
@@ -3984,19 +4120,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
  "bitflags 2.13.1",
- "compact_str",
+ "compact_str 0.9.1",
  "critical-section",
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru",
+ "lru 0.18.1",
  "palette",
  "serde",
  "strum 0.28.0",
  "thiserror 2.0.18",
  "unicode-segmentation",
- "unicode-truncate",
- "unicode-width",
+ "unicode-truncate 2.0.1",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -4006,7 +4142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
 dependencies = [
  "cfg-if",
- "crossterm",
+ "crossterm 0.29.0",
  "instability",
  "ratatui-core",
 ]
@@ -4059,7 +4195,7 @@ dependencies = [
  "strum 0.28.0",
  "time",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -4161,14 +4297,14 @@ source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df141495
 dependencies = [
  "aho-corasick",
  "bitflags 2.13.1",
- "compact_str",
+ "compact_str 0.9.1",
  "get-size2",
  "is-macro",
  "memchr",
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "thin-vec",
  "thiserror 2.0.18",
 ]
@@ -4180,13 +4316,13 @@ source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df141495
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
- "compact_str",
+ "compact_str 0.9.1",
  "get-size2",
  "memchr",
  "ruff_python_ast",
  "ruff_python_trivia",
  "ruff_text_size",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "static_assertions",
  "thin-vec",
  "unicode-ident",
@@ -4239,6 +4375,12 @@ checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
@@ -4254,6 +4396,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -4261,7 +4416,7 @@ dependencies = [
  "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4672,6 +4827,15 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
@@ -4686,6 +4850,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4762,6 +4939,7 @@ dependencies = [
  "flate2",
  "fnv",
  "once_cell",
+ "onig",
  "plist",
  "regex-syntax",
  "serde",
@@ -4793,7 +4971,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4814,7 +4992,7 @@ checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
 dependencies = [
  "bitflags 2.13.1",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "windows-sys 0.61.2",
 ]
@@ -4985,6 +5163,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiktoken-rs"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bstr",
+ "fancy-regex 0.13.0",
+ "lazy_static",
+ "regex",
+ "rustc-hash 1.1.0",
+]
+
+[[package]]
 name = "time"
 version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5091,6 +5284,29 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toon-format"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f89570c1a68d73941f728cca32a4345b2ffca36667ad921af336c60309a3e7e"
+dependencies = [
+ "anyhow",
+ "arboard",
+ "chrono",
+ "clap",
+ "comfy-table",
+ "crossterm 0.28.1",
+ "indexmap 2.14.0",
+ "ratatui 0.29.0",
+ "serde",
+ "serde_json",
+ "syntect",
+ "thiserror 2.0.18",
+ "tiktoken-rs",
+ "tui-textarea",
+ "unicode-width 0.2.0",
+]
 
 [[package]]
 name = "tracing"
@@ -5465,6 +5681,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tui-textarea"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
+dependencies = [
+ "crossterm 0.28.1",
+ "ratatui 0.29.0",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "two-face"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5516,20 +5743,37 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-truncate"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.2.2"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -5738,7 +5982,7 @@ checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 1.1.4",
  "smallvec",
  "wayland-sys",
 ]
@@ -5750,7 +5994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.13.1",
- "rustix",
+ "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -5992,11 +6236,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -6010,20 +6263,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -6033,9 +6308,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6045,9 +6332,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6057,15 +6356,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6097,7 +6414,7 @@ dependencies = [
  "libc",
  "log",
  "os_pipe",
- "rustix",
+ "rustix 1.1.4",
  "thiserror 2.0.18",
  "tree_magic_mini",
  "wayland-backend",
@@ -6128,7 +6445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ clap = { workspace = true }
 color-eyre = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+toon-format = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 smol = { workspace = true }
@@ -117,6 +118,7 @@ jiff = { version = "0.2", default-features = false, features = ["std", "tz-syste
 arboard = { version = "3", default-features = false, features = ["image-data", "wayland-data-control"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 flume = { version = "0.11", default-features = false, features = ["async", "select"] }
+toon-format = "0.5"
 humantime = "2"
 toml = "0.8"
 toml_edit = "0.22"

--- a/maki-agent/src/prompt.rs
+++ b/maki-agent/src/prompt.rs
@@ -29,7 +29,7 @@ pub const DEFAULT_TONE: &str = r#"- Be concise. Your output is displayed on a CL
 - Output text to communicate with the user; all text you output outside of tool use is displayed to the user. Only use tools to complete tasks. NEVER use bash echo or other command-line tools to communicate thoughts, explanations, diagrams, or instructions to the user. Output all communication directly in your response text instead.
 - NEVER create files unless absolutely necessary. ALWAYS prefer editing existing files."#;
 
-const NATIVE_EFFICIENT_TOOLS: &[&str] = &["batch", "code_execution", "task"];
+const NATIVE_EFFICIENT_TOOLS: &[&str] = &["batch", "code_execution", "index", "task"];
 const INSTRUCTIONS_MARKER: &str = "{{instructions}}";
 
 /// Singleton: alphabetically last plugin wins, discarding all prior content
@@ -219,7 +219,7 @@ mod tests {
     use super::*;
     use test_case::test_case;
 
-    const NATIVE_EFFICIENT_LINE: &str = "Most efficient tools: batch, code_execution, task";
+    const NATIVE_EFFICIENT_LINE: &str = "Most efficient tools: batch, code_execution, index, task";
 
     fn slots(prompt: PromptId, entries: &[(Slot, &str)]) -> ResolvedSlots {
         let mut slots = ResolvedSlots::default();
@@ -297,12 +297,12 @@ mod tests {
         let s = slots(
             PromptId::System,
             &[
-                (Slot::EfficientTools, "index"),
                 (Slot::EfficientTools, "foo"),
+                (Slot::EfficientTools, "bar"),
             ],
         );
         let out = assemble(PromptId::System, &s, "");
-        assert!(out.contains(&format!("{NATIVE_EFFICIENT_LINE}, index, foo.")));
+        assert!(out.contains(&format!("{NATIVE_EFFICIENT_LINE}, foo, bar.")));
     }
 
     #[test]

--- a/maki-agent/src/prompts/general.md
+++ b/maki-agent/src/prompts/general.md
@@ -14,10 +14,12 @@ You must NEVER generate or guess URLs unless they are for helping the user with 
 
 # Tool usage
 - Every tool result grows your context. Minimize use of verbose tool calls, prefer compact results.
+- **Use index** before read to get a compact file skeleton and line numbers, then read only the section you need with offset/limit.
 - **Use batch** for 2+ independent parallel calls, **code_execution** for dependent/chained calls or filtering/processing results.
 - Read files before editing them. Look at surrounding context and imports to match conventions.
 - Prefer edit/multiedit over write; targeted edits use far fewer tokens.
 - NEVER create files unless absolutely necessary. Prefer editing existing files.
+- Prefer `maki.json.tooned` (lossless JSON/TOON passthrough) over plain JSON when passing structured data between tools or scripts.
 {{tool_usage}}
 
 {{efficient_tools}}

--- a/maki-agent/src/prompts/research.md
+++ b/maki-agent/src/prompts/research.md
@@ -17,8 +17,10 @@ You must NEVER generate or guess URLs unless they are for helping the user with 
 
 # Tool usage
 - Every tool result grows your context. Minimize use of verbose tool calls, prefer compact results.
+- **Use index** before read to get a compact file skeleton and line numbers, then read only the specific section with offset/limit.
 - **Use batch** for 2+ independent reads, greps, or globs. Never call them one at a time sequentially.
 - **Use code_execution** for dependent/chained calls (e.g. glob then read matches) or filtering large tool outputs.
+- Prefer `maki.json.tooned` (lossless JSON/TOON passthrough) over plain JSON when passing structured data between tools or scripts.
 {{tool_usage}}
 
 {{efficient_tools}}

--- a/maki-agent/src/prompts/system.md
+++ b/maki-agent/src/prompts/system.md
@@ -8,10 +8,12 @@ Prioritize technical accuracy over validating the user's beliefs. Provide direct
 
 # Tool usage
 - Every tool result grows your context. Minimize use of verbose tool calls, prefer compact results.
+- **Use index** first on source files to get a compact skeleton and line numbers, then use **read** with offset/limit for the specific section.
 - Use **batch** for parallel calls, **code_execution** for chained/filtered calls, **task** for delegation.
 - Combine **batch** and **task**: launch multiple tasks in a batch to parallelize research or implementation.
 - Read files before editing them. Match surrounding context, conventions, and imports.
 - Prefer edits over full file writes.
+- Prefer `maki.json.tooned` (lossless JSON/TOON passthrough) over plain JSON when passing structured data between tools or scripts.
 {{tool_usage}}
 
 {{efficient_tools}}

--- a/maki-lua/Cargo.toml
+++ b/maki-lua/Cargo.toml
@@ -21,8 +21,10 @@ maki-lua-macro = { workspace = true }
 maki-markdown = { workspace = true }
 maki-providers = { workspace = true }
 mlua = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+toon-format = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 smol = { workspace = true }

--- a/maki-lua/src/api/json.rs
+++ b/maki-lua/src/api/json.rs
@@ -1,5 +1,9 @@
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
 use maki_lua_macro::{lua_fn, lua_table};
 use mlua::{Lua, LuaSerdeExt, Result as LuaResult, UserData, UserDataMethods, Value};
+use serde::{Deserialize, Serialize};
 
 use super::util::convert::{err_pair, json_to_lua, lua_to_json};
 
@@ -127,17 +131,148 @@ fn schema_validator(lua: &Lua, schema: Value) -> LuaResult<(Value, Value)> {
     }
 }
 
+/// Encode a Lua value as TOON (Token-Oriented Object Notation), a token-efficient
+/// alternative to JSON for LLM context (~30-60% fewer tokens on uniform arrays of
+/// objects). Opt-in: pair with `from_toon` only when the consumer is a model.
+///
+/// @param value any Lua value to encode.
+/// @return (string?, string?) TOON string, or nil plus an error.
+/// @example
+/// local s, err = maki.json.to_toon({ users = { { id = 1, name = "Alice" } } })
+#[lua_fn]
+fn to_toon(lua: &Lua, value: Value) -> LuaResult<(Value, Value)> {
+    let serde_val: serde_json::Value = match lua.from_value(value) {
+        Ok(v) => v,
+        Err(e) => return err_pair(lua, e),
+    };
+    match toon_format::encode_default(&serde_val) {
+        Ok(s) => Ok((Value::String(lua.create_string(&s)?), Value::Nil)),
+        Err(e) => err_pair(lua, e),
+    }
+}
+
+/// Decode a TOON string back into a Lua value. Inverse of `to_toon`.
+///
+/// @param str string TOON string to decode.
+/// @return (any?, string?) Decoded value, or nil plus an error.
+/// @example
+/// local t, err = maki.json.from_toon(s)
+#[lua_fn]
+fn from_toon(lua: &Lua, str: String) -> LuaResult<(Value, Value)> {
+    match toon_format::decode_default::<serde_json::Value>(&str) {
+        Ok(v) => Ok((json_to_lua(lua, &v)?, Value::Nil)),
+        Err(e) => err_pair(lua, e),
+    }
+}
+
+#[derive(Default, Serialize, Deserialize, Debug, Clone)]
+struct ToonStats {
+    calls: u64,
+    json_bytes: u64,
+    toon_bytes: u64,
+    toon_wins: u64,
+    saved_bytes: u64,
+}
+
+fn toon_stats_path() -> Option<PathBuf> {
+    maki_storage::paths::data_dir()
+        .ok()
+        .map(|dir| dir.join("toon_stats.json"))
+}
+
+fn load_toon_stats() -> ToonStats {
+    if let Some(path) = toon_stats_path()
+        && let Ok(text) = std::fs::read_to_string(&path)
+        && let Ok(stats) = serde_json::from_str::<ToonStats>(&text)
+    {
+        return stats;
+    }
+    ToonStats::default()
+}
+
+fn record_toon_stats(json_len: usize, toon_len: usize, used_toon: bool) {
+    static STATS: OnceLock<Mutex<ToonStats>> = OnceLock::new();
+    let guard = STATS.get_or_init(|| Mutex::new(load_toon_stats()));
+    if let Ok(mut stats) = guard.lock() {
+        stats.calls += 1;
+        stats.json_bytes += json_len as u64;
+        stats.toon_bytes += toon_len as u64;
+        if used_toon {
+            stats.toon_wins += 1;
+            stats.saved_bytes += json_len.saturating_sub(toon_len) as u64;
+        }
+        if let Some(path) = toon_stats_path()
+            && let Ok(bytes) = serde_json::to_vec(&*stats)
+        {
+            let _ = maki_storage::atomic_write(&path, &bytes);
+        }
+    }
+}
+
+/// Lossless JSON/TOON passthrough. Encodes the value as JSON and TOON and
+/// returns whichever representation is smaller. If TOON does not shrink the
+/// payload, the original JSON string is returned unchanged.
+///
+/// @param value any Lua value to encode.
+/// @return (string?, string?) Encoded string (JSON or TOON) and its format ("json" or "toon"), or nil plus an error.
+/// @example
+/// local s, fmt = maki.json.tooned({ users = { { id = 1, name = "Alice" } } })
+#[lua_fn]
+fn tooned(lua: &Lua, value: Value) -> LuaResult<(Value, Value)> {
+    let serde_val: serde_json::Value = match lua.from_value(value) {
+        Ok(v) => v,
+        Err(e) => return err_pair(lua, e),
+    };
+    let json = match serde_json::to_string(&serde_val) {
+        Ok(s) => s,
+        Err(e) => return err_pair(lua, e),
+    };
+    let toon = match toon_format::encode_default(&serde_val) {
+        Ok(s) => s,
+        Err(e) => return err_pair(lua, e),
+    };
+    let use_toon = toon.len() < json.len()
+        && toon_format::decode_default::<serde_json::Value>(&toon)
+            .ok()
+            .and_then(|decoded| serde_json::to_value(&decoded).ok())
+            .is_some_and(|decoded| decoded == serde_val);
+    record_toon_stats(json.len(), toon.len(), use_toon);
+    if use_toon {
+        Ok((Value::String(lua.create_string(&toon)?), Value::String(lua.create_string("toon")?)))
+    } else {
+        Ok((Value::String(lua.create_string(&json)?), Value::String(lua.create_string("json")?)))
+    }
+}
+
+/// Return historical TOON passthrough statistics.
+///
+/// @return (table?, string?) Stats table with calls, json_bytes, toon_bytes, toon_wins, saved_bytes, or nil plus an error.
+/// @example
+/// local stats, err = maki.json.toon_stats()
+#[lua_fn]
+fn toon_stats(lua: &Lua) -> LuaResult<(Value, Value)> {
+    let stats = load_toon_stats();
+    let tbl = lua.create_table()?;
+    tbl.set("calls", stats.calls)?;
+    tbl.set("json_bytes", stats.json_bytes)?;
+    tbl.set("toon_bytes", stats.toon_bytes)?;
+    tbl.set("toon_wins", stats.toon_wins)?;
+    tbl.set("saved_bytes", stats.saved_bytes)?;
+    Ok((Value::Table(tbl), Value::Nil))
+}
+
 lua_table! {
-    /// JSON encoding, decoding, and schema validation. Encode Lua
-    /// tables to JSON strings, decode JSON back into tables, and
-    /// optionally validate data against a JSON Schema.
+    /// JSON encoding, decoding, schema validation, and TOON round-trip.
+    /// Encode Lua tables to JSON strings, decode JSON back into tables,
+    /// validate against a JSON Schema, or convert to/from TOON for
+    /// token-efficient context blocks.
     ///
     /// ```lua
     /// local s = maki.json.encode({ ok = true })
     /// local t = maki.json.decode(s)
     /// ```
     "maki.json" => pub(crate) fn create_json_table(), DOCS [
-        encode, decode, schema_validator,
+        encode, decode, schema_validator, to_toon, from_toon, tooned, toon_stats,
     ]
 }
 

--- a/plugins/index/init.lua
+++ b/plugins/index/init.lua
@@ -145,11 +145,6 @@ maki.api.register_prompt_hint({
   content = "- Use the **index** tool first on individual files to get their skeleton, then use the **read** tool with offset/limit for the specific section you need.",
 })
 
-maki.api.register_prompt_hint({
-  slot = "efficient_tools",
-  content = "index",
-})
-
 maki.api.register_tool({
   name = "index",
   kind = "read",


### PR DESCRIPTION
- Add index to native efficient tools and emphasize it in system/research/general prompts.
- Add maki.json.tooned: lossless JSON/TOON passthrough that only returns TOON when it is smaller.
- Record global toon_stats.json with call counts, bytes, wins, and savings.
- Remove duplicate efficient_tools hint from index plugin.