### PR TITLE
fix(ui): reconcile stale task state and preserve shell on agent errors

### DIFF
--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -94,11 +94,13 @@ const IMPLEMENT_MSG_PREFIX: &str = "Implement the plan";
 const IMPLEMENT_PARALLEL_HINT: &str = "Use batch+task to parallelize, assign each subagent a separate module and restrict its tests to that module to avoid interference.";
 
 const TASK_DONE_DETAIL: &str = "✓ ";
+const MISSING_TOOL_COMPLETION: &str = "Tool did not report completion before the turn ended";
 
 #[derive(Clone)]
 pub(super) struct TaskEntry {
     name: String,
     finished: Option<bool>,
+    chat_index: usize,
 }
 
 impl PickerItem for TaskEntry {
@@ -157,6 +159,7 @@ pub struct App {
     pub exit_request: ExitRequest,
     pub(crate) exit_on_done: bool,
     pub(crate) queue: MessageQueue,
+    recoverable_queue: Vec<String>,
     pub answer_tx: Option<flume::Sender<String>>,
     pub(crate) cmd_tx: Option<flume::Sender<super::AgentCommand>>,
     pub(super) pending_input: PendingInput,
@@ -246,6 +249,7 @@ impl App {
             exit_request: ExitRequest::None,
             exit_on_done: false,
             queue: MessageQueue::default(),
+            recoverable_queue: Vec::new(),
             answer_tx: None,
             cmd_tx: None,
             pending_input: PendingInput::None,
@@ -422,19 +426,37 @@ impl App {
         }
     }
 
-    fn open_tasks(&mut self) {
-        let entries: Vec<TaskEntry> = self
-            .chats
+    fn task_entries(&self) -> Vec<TaskEntry> {
+        self.chats
             .iter()
             .enumerate()
-            .map(|(i, c)| TaskEntry {
-                name: c.name.clone(),
-                finished: (i > 0).then_some(c.is_finished()),
+            .map(|(chat_index, chat)| TaskEntry {
+                name: chat.name.clone(),
+                finished: (chat_index > 0).then_some(chat.is_finished()),
+                chat_index,
             })
-            .collect();
+            .collect()
+    }
+
+    fn open_tasks(&mut self) {
         self.task_picker_original = Some(self.active_chat);
-        self.task_picker.open(entries, " Tasks ");
+        self.task_picker.open(self.task_entries(), " Tasks ");
         self.task_picker.select(self.active_chat);
+    }
+
+    fn sync_task_picker(&mut self) {
+        if !self.task_picker.is_open() {
+            return;
+        }
+        let selected = self
+            .task_picker
+            .selected_item()
+            .map(|entry| entry.chat_index);
+        self.task_picker.replace_items(self.task_entries());
+        if let Some(chat_index) = selected {
+            self.task_picker
+                .select_item_by(|entry| entry.chat_index == chat_index);
+        }
     }
 
     fn handle_ctrl(&mut self, key: KeyEvent) -> Option<Vec<Action>> {
@@ -603,9 +625,9 @@ impl App {
             }
             return Some(match self.task_picker.handle_key(key) {
                 PickerAction::Consumed | PickerAction::Toggle(..) => vec![],
-                PickerAction::Select(idx, _) => {
+                PickerAction::Select(entry) => {
                     self.task_picker_original = None;
-                    self.active_chat = idx;
+                    self.active_chat = entry.chat_index;
                     vec![]
                 }
                 PickerAction::Close => {
@@ -863,7 +885,7 @@ impl App {
             if cmd == "cd" || cmd.starts_with("cd ") {
                 self.flash("Only /cd can change the working directory".into());
             }
-            let id = self.shell.next_id();
+            let id = self.shell.reserve_id();
             let sigil = if prefix.visible { "!" } else { "!!" };
             let display = format!("{sigil} {}", prefix.command);
             self.main_chat().show_user_message(display);
@@ -892,6 +914,7 @@ impl App {
         self.main_chat()
             .push(DisplayMessage::new(DisplayRole::Error, CANCEL_MSG.into()));
         self.queue.clear();
+        self.recoverable_queue.clear();
         self.status = Status::Idle;
         vec![Action::CancelAgent {
             run_id: cancelled_run,
@@ -975,6 +998,7 @@ impl App {
             if let Some(&sub_idx) = self.chat_index.get(tool_use_id.as_str()) {
                 self.chats[sub_idx].mark_finished(DisplayRole::Done, DONE_TEXT);
             }
+            self.sync_task_picker();
             self.state
                 .session
                 .subagent_messages
@@ -1010,6 +1034,7 @@ impl App {
                 };
                 self.chats[sub_idx].mark_finished(role, text);
             }
+            self.sync_task_picker();
         }
 
         if let AgentEvent::Retry {
@@ -1091,6 +1116,7 @@ impl App {
             match result {
                 ChatEventResult::Done => {
                     self.status_bar.clear_flash();
+                    self.terminalize_turn(MISSING_TOOL_COMPLETION);
                     self.save_session();
                     self.chat_index.clear();
                     self.subagent_answers.clear();
@@ -1103,13 +1129,12 @@ impl App {
                 ChatEventResult::Error(message) => {
                     self.status = Status::error(message.clone());
                     self.status_bar.clear_flash();
+                    self.subagent_answers.clear();
+                    self.terminalize_turn(&message);
+                    self.recoverable_queue = self.queue.text_messages();
                     self.save_session();
                     self.queue.clear();
-                    self.subagent_answers.clear();
-                    self.finish_subagents(DisplayRole::Error, ERROR_TEXT);
-                    for chat in &mut self.chats {
-                        chat.fail_in_progress_with_message(message.clone());
-                    }
+                    self.chat_index.clear();
                     self.fire_session_autocmd(
                         "TurnError",
                         serde_json::json!({ "message": message }),
@@ -1152,6 +1177,7 @@ impl App {
             chat.push_user_message(prompt);
         }
         self.chats.push(chat);
+        self.sync_task_picker();
         idx
     }
 
@@ -1462,10 +1488,33 @@ impl App {
     }
 
     fn finish_subagents(&mut self, role: DisplayRole, text: &str) {
-        for &sub_idx in self.chat_index.values() {
-            self.chats[sub_idx].mark_finished(role.clone(), text);
-        }
+        self.retain_resolved_subagents(role, text);
         self.chat_index.clear();
+    }
+
+    /// Terminalizes every tool left in progress when a turn ends, sparing
+    /// shell commands that outlive the agent.
+    fn terminalize_turn(&mut self, message: &str) {
+        self.retain_resolved_subagents(DisplayRole::Error, ERROR_TEXT);
+        self.chats[0].fail_in_progress_except(message.into(), self.shell.active_ids());
+        for chat in self.chats.iter_mut().skip(1) {
+            chat.fail_in_progress_with_message(message.into());
+        }
+        self.sync_task_picker();
+    }
+
+    /// Marks unfinished subagent chats as ended and drops them from
+    /// `chat_index`, which is what makes a `save_session` afterwards persist
+    /// only the children that really completed.
+    fn retain_resolved_subagents(&mut self, role: DisplayRole, text: &str) {
+        self.chat_index.retain(|_, &mut sub_idx| {
+            if self.chats[sub_idx].is_finished() {
+                true
+            } else {
+                self.chats[sub_idx].mark_finished(role.clone(), text);
+                false
+            }
+        });
     }
 
     pub fn flush_all_chats(&mut self) {

--- a/maki-ui/src/app/queue.rs
+++ b/maki-ui/src/app/queue.rs
@@ -170,6 +170,9 @@ impl App {
     /// load/rewind the display is restored before `respawn` swaps the shared
     /// queue, so pushing earlier would fill a queue that is about to die.
     pub(crate) fn flush_restored_queue(&mut self) {
+        // The live queue owns the text from here on, so the recovery
+        // snapshot must stop overriding it on save.
+        self.recoverable_queue.clear();
         for text in std::mem::take(&mut self.state.session.meta.queued_messages) {
             self.queue_and_notify(QueuedMessage {
                 text,
@@ -210,6 +213,8 @@ impl App {
     /// once per run.
     pub(super) fn start_run(&mut self, input: AgentInput, display: String) -> Vec<Action> {
         self.run_id += 1;
+        // New work supersedes text held for recovery after an agent error.
+        self.recoverable_queue.clear();
         self.status = Status::Streaming;
         self.fire_session_autocmd("TurnStart", serde_json::json!({}));
         self.main_chat().show_user_message(display);

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -44,18 +44,24 @@ impl App {
         let draft = self.input_box.buffer.value();
         self.state.session.meta.input_draft = if draft.is_empty() { None } else { Some(draft) };
 
-        self.state.session.meta.queued_messages = self.queue.text_messages();
+        self.state.session.meta.queued_messages = if self.recoverable_queue.is_empty() {
+            self.queue.text_messages()
+        } else {
+            self.recoverable_queue.clone()
+        };
 
-        self.state.session.meta.subagents = self
-            .chats
-            .iter()
-            .skip(1)
-            .zip(self.chat_index.iter())
-            .map(|(chat, (tool_id, _))| StoredSubagent {
-                tool_use_id: tool_id.clone(),
-                name: chat.name.clone(),
-                prompt: None,
-                model: chat.model_id.clone(),
+        let mut subagents: Vec<_> = self.chat_index.iter().collect();
+        subagents.sort_by_key(|&(_, chat_index)| chat_index);
+        self.state.session.meta.subagents = subagents
+            .into_iter()
+            .map(|(tool_id, &chat_index)| {
+                let chat = &self.chats[chat_index];
+                StoredSubagent {
+                    tool_use_id: tool_id.clone(),
+                    name: chat.name.clone(),
+                    prompt: None,
+                    model: chat.model_id.clone(),
+                }
             })
             .collect();
     }
@@ -84,6 +90,7 @@ impl App {
         self.chat_index.clear();
         self.status = super::Status::Idle;
         self.queue.clear();
+        self.recoverable_queue.clear();
         self.close_all_overlays();
         self.pending_input = PendingInput::None;
         self.status_bar.clear_flash();

--- a/maki-ui/src/app/shell.rs
+++ b/maki-ui/src/app/shell.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::process::Command as StdCommand;
 use std::time::{Duration, Instant};
 
@@ -72,12 +73,23 @@ pub(crate) struct ShellState {
     cancel_triggers: Vec<CancelTrigger>,
     pending_results: Vec<Message>,
     id_counter: u64,
+    active_ids: HashSet<String>,
 }
 
 impl ShellState {
-    pub fn next_id(&mut self) -> String {
+    pub fn reserve_id(&mut self) -> String {
         self.id_counter += 1;
-        format!("shell-{}", self.id_counter)
+        let id = format!("shell-{}", self.id_counter);
+        self.active_ids.insert(id.clone());
+        id
+    }
+
+    pub fn active_ids(&self) -> &HashSet<String> {
+        &self.active_ids
+    }
+
+    pub fn release_id(&mut self, id: &str) {
+        self.active_ids.remove(id);
     }
 
     pub fn add_trigger(&mut self, trigger: CancelTrigger) {
@@ -136,7 +148,7 @@ impl App {
                     None
                 };
                 self.main_chat().shell_tool_done(ToolDoneEvent {
-                    id,
+                    id: id.clone(),
                     tool: "bash".into(),
                     output: ToolOutput::Plain(output.into()),
                     is_error,
@@ -146,6 +158,7 @@ impl App {
                 if let Some(msg) = result_msg {
                     self.shell.push_result(msg);
                 }
+                self.shell.release_id(&id);
             }
         }
     }

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -527,6 +527,7 @@ fn reset_session_clears_plan() {
     assert_eq!(app.state.mode, Mode::Build);
     assert_eq!(app.state.plan, PlanState::None);
     assert!(app.queue.is_empty());
+    assert!(app.recoverable_queue.is_empty());
     assert_eq!(app.chats.len(), 1);
     assert_eq!(app.chats[0].name, "Main");
     assert_eq!(app.active_chat, 0);
@@ -742,6 +743,7 @@ fn turn_complete_accumulates_usage_by_model() {
 #[test]
 fn cancel_resets_all_chats_and_indices() {
     let mut app = app_with_subagent();
+    open_tasks_picker(&mut app);
     app.update(subagent_msg(
         AgentEvent::ToolStart(Box::new(ToolStartEvent {
             id: "sub_t1".into(),
@@ -756,11 +758,24 @@ fn cancel_resets_all_chats_and_indices() {
         "task1",
         None,
     ));
+    let buf = Arc::new(maki_agent::SharedBuf::new());
+    app.update(subagent_msg(
+        AgentEvent::LiveToolBuf {
+            id: "sub_t1".into(),
+            body: buf,
+        },
+        "task1",
+        None,
+    ));
 
-    cancel_app(&mut app);
+    let actions = app.handle_cancel();
+    assert!(matches!(actions.as_slice(), [Action::CancelAgent { .. }]));
+    assert!(!app.task_picker.is_open());
     assert_eq!(app.chats[0].in_progress_count(), 0);
     assert_eq!(app.chats[1].in_progress_count(), 0);
+    assert!(app.chats[1].is_finished());
     assert!(app.chat_index.is_empty());
+    assert!(!app.is_animating());
 }
 
 fn finish_subagent(app: &mut App, id: &str, is_error: bool) {
@@ -850,6 +865,104 @@ fn app_with_subagent_id(id: &str) -> App {
 
 fn app_with_subagent() -> App {
     app_with_subagent_id("task1")
+}
+
+#[test]
+fn open_task_picker_refreshes_after_tool_done() {
+    let mut app = app_with_subagent();
+    open_tasks_picker(&mut app);
+    assert!(
+        app.task_picker
+            .selected_item()
+            .is_some_and(|entry| entry.chat_index == 0)
+    );
+
+    finish_subagent_task(&mut app, false);
+
+    assert!(app.task_picker.is_open());
+    assert_eq!(app.task_picker.item(1).unwrap().finished, Some(true));
+}
+
+#[test]
+fn open_task_picker_inserts_new_child_without_changing_selection() {
+    let mut app = app_with_subagent();
+    open_tasks_picker(&mut app);
+    app.update(Msg::Key(key(KeyCode::Down)));
+
+    app.update(subagent_msg(
+        AgentEvent::TextDelta { text: "new".into() },
+        "task2",
+        Some("build"),
+    ));
+
+    assert_eq!(app.task_picker.item(2).unwrap().name, "build");
+    assert_eq!(app.task_picker.selected_item().unwrap().chat_index, 1);
+}
+
+#[test]
+fn filtered_task_picker_enter_selects_entry_chat() {
+    let mut app = app_with_subagent_id("task1");
+    app.update(subagent_msg(
+        AgentEvent::TextDelta { text: "y".into() },
+        "task2",
+        Some("build"),
+    ));
+    open_tasks_picker(&mut app);
+    app.update(Msg::Key(key(KeyCode::Char('b'))));
+
+    assert_eq!(app.task_picker.selected_item().unwrap().chat_index, 2);
+    app.update(Msg::Key(key(KeyCode::Enter)));
+
+    assert!(!app.task_picker.is_open());
+    assert_eq!(app.active_chat, 2);
+}
+
+#[test]
+fn filtered_task_picker_refresh_preserves_selected_chat_identity() {
+    let mut app = app_with_subagent_id("task1");
+    app.update(subagent_msg(
+        AgentEvent::TextDelta { text: "y".into() },
+        "task2",
+        Some("build"),
+    ));
+    open_tasks_picker(&mut app);
+    app.update(Msg::Key(key(KeyCode::Char('b'))));
+    assert_eq!(app.task_picker.selected_item().unwrap().chat_index, 2);
+
+    app.update(subagent_msg(
+        AgentEvent::TextDelta { text: "z".into() },
+        "task3",
+        Some("benchmark"),
+    ));
+
+    assert!(app.task_picker.is_open());
+    assert_eq!(app.task_picker.selected_item().unwrap().chat_index, 2);
+}
+
+#[test]
+fn open_task_picker_refreshes_after_subagent_history() {
+    let mut app = app_with_subagent_id("session-abc");
+    open_tasks_picker(&mut app);
+
+    app.update(agent_msg(AgentEvent::SubagentHistory {
+        tool_use_id: "session-abc".into(),
+        messages: vec![],
+    }));
+
+    assert!(app.task_picker.is_open());
+    assert_eq!(app.task_picker.item(1).unwrap().finished, Some(true));
+}
+
+#[test]
+fn closed_task_picker_stays_closed_after_lifecycle_events() {
+    let mut app = app_with_subagent();
+    finish_subagent_task(&mut app, false);
+    app.update(subagent_msg(
+        AgentEvent::TextDelta { text: "new".into() },
+        "task2",
+        Some("build"),
+    ));
+    assert!(!app.task_picker.is_open());
 }
 
 #[test]
@@ -2318,12 +2431,258 @@ fn stale_non_terminal_event_does_not_save_session() {
 }
 
 #[test]
-fn error_event_matching_run_id_saves_session() {
+fn parent_done_reconciles_unresolved_children_and_tools() {
     let mut app = streaming_app_with_history();
+    app.update(agent_msg(AgentEvent::ToolStart(Box::new(ToolStartEvent {
+        id: "task1".into(),
+        tool: "task".into(),
+        summary: "research".into(),
+        annotation: None,
+        input: None,
+        raw_input: None,
+        output: None,
+        render_header: None,
+    }))));
+    app.update(subagent_msg(
+        AgentEvent::ToolStart(Box::new(ToolStartEvent {
+            id: "child-tool".into(),
+            tool: "read".into(),
+            summary: "reading".into(),
+            annotation: None,
+            input: None,
+            raw_input: None,
+            output: None,
+            render_header: None,
+        })),
+        "task1",
+        Some("research"),
+    ));
+    let buf = Arc::new(maki_agent::SharedBuf::new());
+    app.update(subagent_msg(
+        AgentEvent::LiveToolBuf {
+            id: "child-tool".into(),
+            body: buf,
+        },
+        "task1",
+        None,
+    ));
+
+    app.update(done_event());
+
+    assert!(app.chats[1].is_finished());
+    assert_eq!(app.chats[0].in_progress_count(), 0);
+    assert_eq!(app.chats[1].in_progress_count(), 0);
+    assert!(
+        app.chats[0]
+            .last_message_text()
+            .contains(MISSING_TOOL_COMPLETION)
+    );
+    assert!(app.state.session.meta.subagents.is_empty());
+    assert_eq!(app.state.session.messages.len(), 2);
+    assert!(app.state.session.tool_outputs.is_empty());
+    assert!(!app.is_animating());
+}
+
+#[test]
+fn parent_error_refreshes_picker_and_persists_only_completed_children() {
+    let mut app = streaming_app_with_history();
+    app.update(subagent_msg_with_model(
+        AgentEvent::TextDelta { text: "one".into() },
+        "task1",
+        "first",
+        "model-a",
+    ));
+    finish_subagent(&mut app, "task1", false);
+    app.update(subagent_msg_with_model(
+        AgentEvent::TextDelta { text: "two".into() },
+        "task2",
+        "second",
+        "model-b",
+    ));
+    app.update(subagent_msg_with_model(
+        AgentEvent::TextDelta {
+            text: "three".into(),
+        },
+        "task3",
+        "third",
+        "model-c",
+    ));
+    finish_subagent(&mut app, "task3", false);
+    open_tasks_picker(&mut app);
+
     app.update(agent_msg(AgentEvent::Error {
         message: "boom".into(),
     }));
+
+    assert!(app.task_picker.is_open());
+    assert_eq!(app.task_picker.item(2).unwrap().finished, Some(true));
+    let saved: Vec<_> = app
+        .state
+        .session
+        .meta
+        .subagents
+        .iter()
+        .map(|subagent| {
+            (
+                subagent.tool_use_id.as_str(),
+                subagent.name.as_str(),
+                subagent.model.as_deref(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        saved,
+        vec![
+            ("task1", "first", Some("model-a")),
+            ("task3", "third", Some("model-c")),
+        ]
+    );
+}
+
+#[test]
+fn reserved_shell_survives_parent_done_until_shell_done() {
+    let mut app = streaming_app_with_history();
+    let id = app.shell.reserve_id();
+
+    app.update(done_event());
+    assert!(app.shell.active_ids().contains(&id));
+
+    app.handle_shell_event(shell::ShellEvent::Start {
+        id: id.clone(),
+        command: "true".into(),
+    });
+    assert_eq!(app.chats[0].in_progress_count(), 1);
+    app.handle_shell_event(shell::ShellEvent::Done {
+        id: id.clone(),
+        command: "true".into(),
+        output: String::new(),
+        is_error: false,
+        visible: false,
+    });
+    assert_eq!(app.chats[0].in_progress_count(), 0);
+    assert!(!app.shell.active_ids().contains(&id));
+}
+
+#[test]
+fn active_shell_survives_agent_error_while_agent_and_child_tools_fail() {
+    let mut app = streaming_app_with_history();
+    let shell_id = app.shell.reserve_id();
+    app.handle_shell_event(shell::ShellEvent::Start {
+        id: shell_id.clone(),
+        command: "true".into(),
+    });
+    app.update(agent_msg(AgentEvent::ToolStart(Box::new(ToolStartEvent {
+        id: "agent-tool".into(),
+        tool: "read".into(),
+        summary: "reading".into(),
+        annotation: None,
+        input: None,
+        raw_input: None,
+        output: None,
+        render_header: None,
+    }))));
+    app.update(subagent_msg(
+        AgentEvent::ToolStart(Box::new(ToolStartEvent {
+            id: "child-tool".into(),
+            tool: "read".into(),
+            summary: "reading".into(),
+            annotation: None,
+            input: None,
+            raw_input: None,
+            output: None,
+            render_header: None,
+        })),
+        "task1",
+        Some("research"),
+    ));
+
+    app.update(agent_msg(AgentEvent::Error {
+        message: "provider overloaded".into(),
+    }));
+
+    assert_eq!(app.chats[0].in_progress_count(), 1);
+    assert_eq!(app.chats[1].in_progress_count(), 0);
+    assert!(app.chats[1].is_finished());
+
+    app.handle_shell_event(shell::ShellEvent::Done {
+        id: shell_id.clone(),
+        command: "true".into(),
+        output: String::new(),
+        is_error: false,
+        visible: false,
+    });
+    assert_eq!(app.chats[0].in_progress_count(), 0);
+    assert!(!app.shell.active_ids().contains(&shell_id));
+}
+
+#[test]
+fn main_shell_exclusion_does_not_protect_same_id_in_child_chat() {
+    let mut app = streaming_app_with_history();
+    let id = app.shell.reserve_id();
+    app.handle_shell_event(shell::ShellEvent::Start {
+        id: id.clone(),
+        command: "true".into(),
+    });
+    app.update(subagent_msg(
+        AgentEvent::ToolStart(Box::new(ToolStartEvent {
+            id: id.clone(),
+            tool: "read".into(),
+            summary: "reading".into(),
+            annotation: None,
+            input: None,
+            raw_input: None,
+            output: None,
+            render_header: None,
+        })),
+        "task1",
+        Some("research"),
+    ));
+
+    app.update(done_event());
+
+    assert_eq!(app.chats[0].in_progress_count(), 1);
+    assert_eq!(app.chats[1].in_progress_count(), 0);
+    assert!(app.chats[1].is_finished());
+}
+
+#[test]
+fn error_event_matching_run_id_saves_session_and_queued_messages() {
+    let mut app = streaming_app_with_history();
+    app.queue_and_notify(queued_msg("next"));
+
+    app.update(agent_msg(AgentEvent::Error {
+        message: "boom".into(),
+    }));
+
     assert_eq!(app.state.session.messages.len(), 2);
+    assert_eq!(app.state.session.meta.queued_messages, ["next"]);
+    assert!(app.queue.is_empty());
+
+    app.save_session();
+    assert_eq!(app.state.session.meta.queued_messages, ["next"]);
+
+    type_and_submit(&mut app, "replacement");
+    app.save_session();
+    assert!(app.state.session.meta.queued_messages.is_empty());
+}
+
+#[test]
+fn flush_restored_queue_drops_recovery_snapshot() {
+    let mut app = streaming_app_with_history();
+    app.queue_and_notify(queued_msg("next"));
+    app.update(agent_msg(AgentEvent::Error {
+        message: "boom".into(),
+    }));
+    assert_eq!(app.state.session.meta.queued_messages, ["next"]);
+
+    app.flush_restored_queue();
+    app.save_session();
+    assert_eq!(app.state.session.meta.queued_messages, ["next"]);
+    assert!(app.recoverable_queue.is_empty());
+
+    app.queue.clear();
+    app.save_session();
+    assert!(app.state.session.meta.queued_messages.is_empty());
 }
 
 // --- Plan form integration tests ---

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -1,7 +1,7 @@
 //! Rebuilds display messages from stored sessions. Tool outputs get syntax
 //! highlighted, missing outputs fall back to plain text from `ToolResult`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -273,6 +273,11 @@ impl Chat {
 
     pub fn fail_in_progress_with_message(&mut self, message: String) {
         self.messages_panel.fail_in_progress_with_message(message);
+    }
+
+    pub fn fail_in_progress_except(&mut self, message: String, excluded: &HashSet<String>) {
+        self.messages_panel
+            .fail_in_progress_except(message, excluded);
     }
 
     pub fn push(&mut self, msg: DisplayMessage) {

--- a/maki-ui/src/components/list_picker.rs
+++ b/maki-ui/src/components/list_picker.rs
@@ -53,7 +53,7 @@ impl PickerItem for String {
 
 pub enum PickerAction<T> {
     Consumed,
-    Select(usize, T),
+    Select(T),
     Toggle(usize, bool),
     Close,
 }
@@ -269,6 +269,22 @@ impl<T: PickerItem> ListPicker<T> {
         }
     }
 
+    pub fn select_item_by(&mut self, predicate: impl Fn(&T) -> bool) -> bool {
+        let Some(s) = self.state.as_mut() else {
+            return false;
+        };
+        let Some(selected) = s
+            .filtered
+            .iter()
+            .position(|&item_idx| predicate(&s.items[item_idx]))
+        else {
+            return false;
+        };
+        s.selected = selected;
+        s.ensure_visible();
+        true
+    }
+
     pub fn set_error_text(&mut self, text: Option<String>) {
         self.error_text = text;
     }
@@ -362,7 +378,7 @@ impl<T: PickerItem> ListPicker<T> {
                 match idx {
                     Some(idx) => {
                         let mut state = self.state.take().unwrap();
-                        PickerAction::Select(idx, state.items.swap_remove(idx))
+                        PickerAction::Select(state.items.swap_remove(idx))
                     }
                     None => PickerAction::Consumed,
                 }
@@ -821,6 +837,20 @@ mod tests {
     }
 
     #[test]
+    fn select_item_by_uses_visible_row_and_preserves_filter() {
+        let mut p = ListPicker::new();
+        p.open(entries(&["Alpha", "Beta", "Alpine"]), " Test ");
+        p.handle_key(key(KeyCode::Char('a')));
+        p.handle_key(key(KeyCode::Char('l')));
+
+        assert!(p.select_item_by(|entry| entry.label == "Alpine"));
+        assert_eq!(p.selected_item().unwrap().label, "Alpine");
+        assert_eq!(ready_state(&p).search.value(), "al");
+        assert!(!p.select_item_by(|entry| entry.label == "Beta"));
+        assert_eq!(p.selected_item().unwrap().label, "Alpine");
+    }
+
+    #[test]
     fn navigation_wraps_around() {
         let mut p = ListPicker::new();
         p.open(entries(&["A", "B", "C"]), " Test ");
@@ -926,7 +956,7 @@ mod tests {
         p.handle_key(key(KeyCode::Down));
 
         let action = p.handle_key(key(KeyCode::Enter));
-        assert!(matches!(action, PickerAction::Select(1, ref e) if e.label == "B"));
+        assert!(matches!(action, PickerAction::Select(ref e) if e.label == "B"));
         assert!(!p.is_open());
     }
 

--- a/maki-ui/src/components/login_picker.rs
+++ b/maki-ui/src/components/login_picker.rs
@@ -278,7 +278,7 @@ impl LoginPicker {
         let action = match &mut self.step {
             Step::Closed => return LoginPickerAction::Consumed,
             Step::PickProvider(picker) => match picker.handle_key(key) {
-                PickerAction::Select(_, item) => {
+                PickerAction::Select(item) => {
                     if item.slug == CATALOG_UNAVAILABLE_SLUG {
                         StepAction::None
                     } else if item.slug == "custom" {
@@ -322,7 +322,7 @@ impl LoginPicker {
                 }
             },
             Step::PickPlan { picker, slug } => match picker.handle_key(key) {
-                PickerAction::Select(_, item) => {
+                PickerAction::Select(item) => {
                     let config = providers::ProvidersConfig::load();
                     StepAction::GoEnterKey {
                         slug: slug.clone(),
@@ -354,7 +354,7 @@ impl LoginPicker {
                 }
             },
             Step::CustomProtocol { picker, slug } => match picker.handle_key(key) {
-                PickerAction::Select(_, item) => StepAction::GoCustomUrl {
+                PickerAction::Select(item) => StepAction::GoCustomUrl {
                     slug: slug.clone(),
                     protocol: item.0.to_string(),
                 },

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -24,7 +24,7 @@ use crate::splash::{ColorTransition, Splash};
 use crate::theme;
 use maki_config::{ToolOutputLines, UiConfig};
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -374,12 +374,17 @@ impl MessagesPanel {
     }
 
     pub fn fail_in_progress_with_message(&mut self, message: String) {
+        self.fail_in_progress_except(message, &HashSet::new());
+    }
+
+    pub fn fail_in_progress_except(&mut self, message: String, excluded: &HashSet<String>) {
         let ids: Vec<(String, Arc<str>)> = self
             .messages
             .iter()
             .filter_map(|m| {
                 if let DisplayRole::Tool(t) = &m.role
                     && t.status == ToolStatus::InProgress
+                    && !excluded.contains(&t.id)
                 {
                     Some((t.id.clone(), Arc::clone(&t.name)))
                 } else {

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -7,6 +7,7 @@ use maki_agent::{
     GrepFileEntry, GrepMatchGroup, SnapshotLine, SnapshotSpan, SpanStyle, ToolInput, ToolOutput,
 };
 use ratatui::backend::TestBackend;
+use std::collections::HashSet;
 use test_case::test_case;
 
 fn snap_line(text: &str) -> SnapshotLine {
@@ -258,6 +259,19 @@ fn unknown_tool_id_is_noop() {
         written_path: None,
     });
     assert!(panel.messages.is_empty());
+}
+
+#[test]
+fn fail_in_progress_except_preserves_excluded_tool() {
+    let mut panel = panel_with_tools(&[("agent", "task"), ("shell", "bash")]);
+    let excluded = HashSet::from(["shell".to_string()]);
+
+    panel.fail_in_progress_except("missing completion".into(), &excluded);
+
+    assert_eq!(panel.in_progress_count(), 1);
+    assert_eq!(msg_status(&panel, "agent"), ToolStatus::Error);
+    assert_eq!(msg_status(&panel, "shell"), ToolStatus::InProgress);
+    assert!(panel.messages[0].text.contains("missing completion"));
 }
 
 #[test]

--- a/maki-ui/src/components/model_picker.rs
+++ b/maki-ui/src/components/model_picker.rs
@@ -199,7 +199,7 @@ impl ModelPicker {
         }
         match self.picker.handle_key(key) {
             PickerAction::Consumed => ModelPickerAction::Consumed,
-            PickerAction::Select(_, entry) => ModelPickerAction::Select(entry.spec),
+            PickerAction::Select(entry) => ModelPickerAction::Select(entry.spec),
             PickerAction::Close => ModelPickerAction::Close,
             PickerAction::Toggle(..) => ModelPickerAction::Consumed,
         }

--- a/maki-ui/src/components/rewind_picker.rs
+++ b/maki-ui/src/components/rewind_picker.rs
@@ -96,7 +96,7 @@ impl RewindPicker {
     pub fn handle_key(&mut self, key: KeyEvent) -> RewindPickerAction {
         match self.picker.handle_key(key) {
             PickerAction::Consumed => RewindPickerAction::Consumed,
-            PickerAction::Select(_, entry) => RewindPickerAction::Select(entry),
+            PickerAction::Select(entry) => RewindPickerAction::Select(entry),
             PickerAction::Close => RewindPickerAction::Close,
             PickerAction::Toggle(..) => RewindPickerAction::Consumed,
         }

--- a/maki-ui/src/components/theme_picker.rs
+++ b/maki-ui/src/components/theme_picker.rs
@@ -67,7 +67,7 @@ impl ThemePicker {
                 self.apply_preview();
                 ThemePickerAction::Consumed
             }
-            PickerAction::Select(_, entry) => {
+            PickerAction::Select(entry) => {
                 theme::persist_theme(entry.name);
                 self.original_theme_name = None;
                 ThemePickerAction::Closed


### PR DESCRIPTION
Original work by @laudney, from #646. This supersedes and replaces that PR, squashed into one commit with their authorship kept.

Why a new PR: their fork is org-owned, so pushing the review fixes to their branch is rejected with a 403.

### what it fixes

- The task picker kept showing children as still running after they finished. `sync_task_picker` now refreshes the rows from the live chats when a child starts or ends.
- Opening a row from a filtered task list took you to the wrong chat. `PickerAction::Select` now carries the selected item instead of a list position, so rows no longer have to line up with chat indices.
- An agent error marked a live `!` shell as failed. Turn cleanup now skips the shell ids that are still running.
- An agent error dropped messages queued before it. The queue is copied into `recoverable_queue` and kept in the saved session until new work or a reset supersedes it.
- Persisted subagent names and models were paired with the wrong tool ids, because `sync_ephemeral_state` zipped `chats.skip(1)` with hashmap iteration order. It now walks `chat_index` and reads each child by its own index.
- Tools left in progress at the end of a turn are terminalized instead of hanging around as stale spinners.

### review fixes applied on top

- Pulled the duplicated turn-end cleanup out of the `Done` and `Error` arms into `terminalize_turn`, so the two paths cannot drift.
- Renamed `finish_unresolved_subagents` to `retain_resolved_subagents`, since the `retain` on `chat_index` is what makes the following `save_session` persist only the finished children. The name now says it.
- `flush_restored_queue` clears `recoverable_queue`. Once the live queue owns the text the snapshot is not the authority anymore, so a restored message can no longer keep getting written back and replay on every launch.

All changes are UI only (`maki-ui`).