### PR TITLE
feat(config): allow skipping the stale read check before edits

### DIFF
--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -458,6 +458,7 @@ pub struct AgentFileConfig {
     pub max_output_lines: Option<usize>,
     pub max_continuation_turns: Option<u32>,
     pub compaction_buffer: Option<CompactionBuffer>,
+    pub stale_read_check: Option<bool>,
 }
 
 impl AgentFileConfig {
@@ -468,7 +469,8 @@ impl AgentFileConfig {
             max_output_bytes,
             max_output_lines,
             max_continuation_turns,
-            compaction_buffer
+            compaction_buffer,
+            stale_read_check
         );
     }
 }
@@ -980,6 +982,12 @@ pub struct AgentConfig {
     #[config(default = DEFAULT_COMPACTION_BUFFER, ty = "u32 | string", default_doc = "20%", desc = "Context reserved for compaction: token count or percent of the context window (e.g. \"20%\")")]
     pub compaction_buffer: CompactionBuffer,
 
+    #[config(
+        default = true,
+        desc = "Require re-reading a file that changed on disk before editing it"
+    )]
+    pub stale_read_check: bool,
+
     #[config(skip, default = false)]
     pub no_rtk: bool,
 
@@ -1003,6 +1011,7 @@ impl AgentConfig {
                 .max_continuation_turns
                 .unwrap_or(DEFAULT_MAX_CONTINUATION_TURNS),
             compaction_buffer: file.compaction_buffer.unwrap_or(DEFAULT_COMPACTION_BUFFER),
+            stale_read_check: file.stale_read_check.unwrap_or(true),
             max_turns: None,
             allowed_tools: Vec::new(),
             disabled_tools,

--- a/maki-lua/src/api/util/ctx.rs
+++ b/maki-lua/src/api/util/ctx.rs
@@ -300,10 +300,13 @@ impl UserData for LuaCtx {
         });
 
         methods.add_method("check_before_edit", |_, this, path: String| {
-            let Some(tracker) = this.file_tracker() else {
+            let Some(agent) = this.agent() else {
                 return Ok(this.cap_err_pair("check_before_edit"));
             };
-            match tracker.check_before_edit(Path::new(&path)) {
+            if !agent.config.stale_read_check {
+                return Ok((LuaValue::Boolean(true), None));
+            }
+            match agent.file_tracker.check_before_edit(Path::new(&path)) {
                 Ok(()) => Ok((LuaValue::Boolean(true), None)),
                 Err(msg) => Ok((LuaValue::Boolean(false), Some(msg))),
             }

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -104,6 +104,7 @@ How many lines of output to show per tool in the UI. All values are `usize` with
 | `max_output_lines` | usize | `2000` | 10 | Max tool output lines |
 | `max_continuation_turns` | u32 | `3` | 1 | Max automatic continuation turns |
 | `compaction_buffer` | u32 \| string | `20%` | - | Context reserved for compaction: token count or percent of the context window (e.g. "20%") |
+| `stale_read_check` | bool | `true` | - | Require re-reading a file that changed on disk before editing it |
 
 ### `provider`
 


### PR DESCRIPTION
Editing a file that changed on disk since the last read is refused, which is right most of the time but gets in the way when another tool or a formatter keeps touching your files.

The new `agent.stale_read_check` option turns that guard off, and since the check lives in `ctx:check_before_edit`, one flag covers `write`, `edit`, `multiedit` and any plugin using the same API.

The default stays `true`, so nothing changes unless you ask for it.