### PR TITLE
feat(lua): tell a tool which session called it

### DIFF
--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -413,6 +413,7 @@ impl<'h> Agent<'h> {
             model: Arc::clone(&self.model),
             event_tx: self.event_tx.clone(),
             mode: self.mode.clone(),
+            session_id: self.session_id.clone(),
             tool_use_id: None,
             user_response_rx: self.user_response_rx.clone(),
             loaded_instructions: self.loaded_instructions.clone(),
@@ -1047,5 +1048,20 @@ mod tests {
                 .expect("expected Done event");
             assert_eq!(done, expected_turns);
         });
+    }
+
+    /// Wiring this to `None` to make the struct literal compile would
+    /// silently reintroduce the bug the field exists to fix.
+    #[test]
+    fn tool_context_carries_the_session() {
+        let mut history = History::new(Vec::new());
+        let (mut agent, _event_rx) = make_agent(MockProvider::new(Vec::new()), &mut history);
+        assert_eq!(agent.tool_context().session_id, None);
+
+        let session: SessionRef = "01965087-4c71-7f00-8000-000000000000"
+            .parse()
+            .expect("valid session id");
+        agent.session_id = Some(session.clone());
+        assert_eq!(agent.tool_context().session_id, Some(session));
     }
 }

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -194,6 +194,10 @@ pub struct ToolContext {
     pub model: Arc<Model>,
     pub event_tx: EventSender,
     pub mode: AgentMode,
+    /// The session this run belongs to. A subagent inherits its parent's,
+    /// so a tool can always tell which conversation it is serving. `None`
+    /// when there is no session at all, like the `maki index` one-shot.
+    pub session_id: Option<SessionRef>,
     pub tool_use_id: Option<String>,
     pub user_response_rx: Option<Arc<async_lock::Mutex<flume::Receiver<String>>>>,
     pub loaded_instructions: LoadedInstructions,
@@ -415,6 +419,7 @@ pub fn interpreter_ctx(
         model: Arc::clone(&MODEL),
         event_tx: event_tx.clone(),
         mode: mode.clone(),
+        session_id: None,
         tool_use_id: None,
         user_response_rx,
         loaded_instructions: LoadedInstructions::new(),

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -497,7 +497,6 @@ async fn session(
         None => agent_ctx.opts.thinking,
     };
 
-    let session_id = MakiId::generate();
     let (sub_tx, sub_rx) = flume::unbounded::<Envelope>();
     let sub_event_tx = EventSender::new(sub_tx, agent_ctx.event_tx.run_id());
     let parent_tx = agent_ctx.event_tx.clone();
@@ -516,11 +515,13 @@ async fn session(
     .detach();
 
     // Register a cancel trigger so the child token does not fire on drop
-    // and kill the subagent at birth.
+    // and kill the subagent at birth. The fallback key gets its own id:
+    // it keys `subagent_cancels`, so sharing the session id would make two
+    // subagents running at once collide.
     let ui_id = agent_ctx
         .tool_use_id
         .clone()
-        .unwrap_or_else(|| format!("session-{session_id}"));
+        .unwrap_or_else(|| format!("session-{}", MakiId::generate()));
     let (child_trigger, child_cancel) = agent_ctx.cancel.child();
     agent_ctx
         .subagent_cancels
@@ -536,7 +537,7 @@ async fn session(
             config: agent_ctx.config.clone(),
             tool_output_lines: maki_config::ToolOutputLines::default(),
             permissions: Arc::clone(&agent_ctx.permissions),
-            session_id: Some(session_id.into()),
+            session_id: agent_ctx.session_id.clone(),
             timeouts: agent_ctx.timeouts,
             file_tracker: FileReadTracker::fresh(),
             prompt_slots: Arc::clone(&agent_ctx.prompt_slots),

--- a/maki-lua/src/api/util/ctx.rs
+++ b/maki-lua/src/api/util/ctx.rs
@@ -9,6 +9,7 @@ use maki_agent::tools::{
     Deadline, FileReadTracker, LocalTools, ToolAudience, ToolContext, ToolLive,
 };
 use maki_config::{AgentConfig, ToolOutputLines};
+use maki_storage::id::SessionRef;
 use mlua::{LuaSerdeExt, MultiValue, UserData, UserDataMethods, Value as LuaValue};
 
 use crate::api::tool::ToolCallReply;
@@ -97,6 +98,7 @@ enum Caps {
         config: AgentConfig,
         workflow: bool,
         audience: ToolAudience,
+        session_id: Option<SessionRef>,
     },
     Restore {
         state: Option<serde_json::Value>,
@@ -130,6 +132,7 @@ impl LuaCtx {
                 config: ctx.config.clone(),
                 workflow: ctx.workflow,
                 audience: ctx.audience,
+                session_id: ctx.session_id.clone(),
             },
         )
     }
@@ -174,6 +177,16 @@ impl LuaCtx {
         match &self.caps {
             Caps::Handler { agent, .. } => Some(agent.audience),
             Caps::Start { audience, .. } => Some(*audience),
+            Caps::Restore { .. } => None,
+        }
+    }
+
+    /// Outer `None` means the kind has no session at all, inner `None`
+    /// means this run has one but it is not tied to a session.
+    fn session_id(&self) -> Option<Option<&SessionRef>> {
+        match &self.caps {
+            Caps::Handler { agent, .. } => Some(agent.session_id.as_ref()),
+            Caps::Start { session_id, .. } => Some(session_id.as_ref()),
             Caps::Restore { .. } => None,
         }
     }
@@ -233,6 +246,21 @@ impl UserData for LuaCtx {
             };
             let name = lua.create_string(audience.name().unwrap_or("main"))?;
             Ok((LuaValue::String(name), None))
+        });
+
+        // The session that called this tool, which under concurrent
+        // sessions is not always the focused one `maki.session.current()`
+        // reports. Nil without an error when the run has no session, as in
+        // the `maki index` one-shot.
+        methods.add_method("session_id", |lua, this, ()| {
+            let Some(session_id) = this.session_id() else {
+                return Ok(this.cap_err_pair("session_id"));
+            };
+            let Some(session_id) = session_id else {
+                return Ok((LuaValue::Nil, None));
+            };
+            let id = lua.create_string(session_id.id().to_string())?;
+            Ok((LuaValue::String(id), None))
         });
 
         methods.add_method("live_buf", |lua, this, buf: mlua::AnyUserData| {
@@ -378,9 +406,16 @@ mod tests {
     const TOOL_USE_ID: &str = "tu-1";
     const INSTRUCTION_PATH: &str = "/tmp/nested/AGENTS.md";
     const LOCAL_TOOL_NAME: &str = "sess_tool";
+    /// Arbitrary ids are rejected: `SessionRef` parses base58 or a uuid.
+    const SESSION_ID: &str = "01965087-4c71-7f00-8000-000000000000";
+
+    fn session_ref() -> SessionRef {
+        SESSION_ID.parse().expect("valid session id")
+    }
 
     fn populated_ctx() -> ToolContext {
         let mut ctx = stub_ctx_with(&AgentMode::Build, None, Some(TOOL_USE_ID));
+        ctx.session_id = Some(session_ref());
         ctx.deadline = Deadline::after(Duration::from_secs(60));
         ctx.tool_output_lines = ToolOutputLines {
             bash: 999,
@@ -404,6 +439,11 @@ mod tests {
     fn agent_context_keeps_tool_use_id_and_resets_per_call_state() {
         let agent = AgentContext::from(&populated_ctx());
         assert_eq!(agent.tool_use_id.as_deref(), Some(TOOL_USE_ID));
+        assert_eq!(
+            agent.session_id,
+            Some(session_ref()),
+            "the session owns the whole run, so it is not per-call state"
+        );
         assert!(matches!(agent.deadline, Deadline::None));
         assert_eq!(agent.tool_output_lines, ToolOutputLines::default());
         assert!(agent.local_tools.is_empty());
@@ -426,6 +466,37 @@ mod tests {
         assert_eq!(inner.tool_use_id, None);
         assert!(inner.live_sink.is_none(), "sink must not be inherited");
         assert_eq!(agent.tool_use_id.as_deref(), Some(TOOL_USE_ID));
+        assert_eq!(
+            inner.session_id,
+            Some(session_ref()),
+            "a dispatched child runs in the same session, unlike tool_use_id"
+        );
+    }
+
+    #[test]
+    fn session_id_reaches_handler_and_start_but_not_restore() {
+        let ctx = populated_ctx();
+        assert_eq!(
+            LuaCtx::handler(&ctx).session_id(),
+            Some(Some(&session_ref()))
+        );
+        assert_eq!(LuaCtx::start(&ctx).session_id(), Some(Some(&session_ref())));
+        assert_eq!(
+            LuaCtx::restore(ToolOutputLines::default(), None).session_id(),
+            None,
+            "restore has no ToolContext to take a session from"
+        );
+    }
+
+    #[test]
+    fn session_id_absent_is_distinct_from_kind_lacking_it() {
+        let mut ctx = populated_ctx();
+        ctx.session_id = None;
+        assert_eq!(
+            LuaCtx::handler(&ctx).session_id(),
+            Some(None),
+            "a sessionless run still has the capability, so lua sees nil without an error"
+        );
     }
 
     #[test]

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -11,6 +11,7 @@ use maki_agent::tools::{
 };
 use maki_config::{AlwaysThinking, PluginsConfig, ToolOutputLines};
 use maki_lua::{PluginError, PluginHost, WARM_TOOL_CAP};
+use maki_storage::id::SessionRef;
 use serde_json::{Value, json};
 
 const NARGS_ERR: &str = r#"'nargs' must be 0, 1, "?", "*", or "+""#;
@@ -232,6 +233,79 @@ fn register_echo_tool() {
 
     let out = exec_tool(&reg, "echo_", serde_json::json!({"msg": "hello"})).unwrap();
     assert_eq!(out, "hello");
+}
+
+const SESSION_PLUGIN: &str = r#"
+maki.api.register_tool({
+    name = "whoami",
+    description = "reports the calling session",
+    schema = { type = "object", properties = {}, additionalProperties = false },
+    handler = function(_, ctx)
+        local id, err = ctx:session_id()
+        if err then
+            return "err:" .. err
+        end
+        return "id:" .. tostring(id)
+    end,
+})
+"#;
+
+fn exec_with_ctx(
+    reg: &ToolRegistry,
+    name: &str,
+    input: serde_json::Value,
+    ctx: &ToolContext,
+) -> Result<String, String> {
+    let entry = reg
+        .get(name)
+        .unwrap_or_else(|| panic!("tool {name} not registered"));
+    let inv = entry.tool.parse(&input).expect("parse failed");
+    smol::block_on(async { inv.execute(ctx).await })
+        .output
+        .map(|out| match out {
+            maki_agent::ToolOutput::Plain(s) => s.text,
+            other => panic!("unexpected output: {other:?}"),
+        })
+}
+
+/// The point of the whole thing: a handler learns who called it without
+/// asking `maki.session.current()`, which answers with whoever is focused.
+#[test]
+fn handler_reads_the_calling_session() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source("session_plugin", SESSION_PLUGIN).unwrap();
+
+    let session: SessionRef = "01965087-4c71-7f00-8000-000000000000"
+        .parse()
+        .expect("valid session id");
+    let mut ctx = maki_agent::tools::test_support::stub_ctx(&maki_agent::AgentMode::Build);
+    ctx.session_id = Some(session.clone());
+
+    let out = exec_with_ctx(&reg, "whoami", json!({}), &ctx).unwrap();
+    assert_eq!(
+        out,
+        format!("id:{}", session.id()),
+        "lua sees the canonical form, so it compares equal to maki.session.current()"
+    );
+    assert_ne!(
+        out,
+        format!("id:{}", session.as_str()),
+        "the verbatim form would not match ids from maki.session.live()"
+    );
+}
+
+#[test]
+fn handler_without_a_session_gets_nil_and_no_error() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source("session_plugin", SESSION_PLUGIN).unwrap();
+
+    let ctx = maki_agent::tools::test_support::stub_ctx(&maki_agent::AgentMode::Build);
+    assert_eq!(
+        exec_with_ctx(&reg, "whoami", json!({}), &ctx).unwrap(),
+        "id:nil"
+    );
 }
 
 #[test]


### PR DESCRIPTION
First of the four PRs from #676. Lands on its own because it is a bug today, not just groundwork for the monitor work.

## The problem

A tool handler had no way to know which session invoked it. The only thing to ask was `maki.session.current()`, which returns whichever session is **focused** (`maki-ui/src/event_loop.rs:672`). Once sessions run side by side (#546) the focused one is often not the caller, so a handler resolving "my session" that way acts on whatever the user happens to be looking at.

Latent in tree so far: the one `maki.session.current()` caller is `/rename` (`plugins/sessions/init.lua:581`), a command handler where focused is the right answer, and `maki.session.prompt()` has no callers yet. The mailbox in PR 3 is the first thing that would deliver to the wrong place.

## The change

`ToolContext` carries the session, and `ctx:session_id()` reads it back.

The id was already on `Agent`, but it was only ever read as a provider routing hint (`run.rs` -> `streaming.rs` -> `Provider::stream_message`; only mistral's `x-affinity` header and openrouter's body field consume it), and `maki.agent.session()` minted a throwaway `MakiId::generate()` for every subagent. Handing that straight to the ctx would have meant every tool under the `task` plugin reporting an id that is not in `maki.session.live()`, cannot be focused, and that `maki.session.prompt` rejects as not live.

Per the discussion on the issue, the fix is to the data rather than the name: the ui, sdk and acp entry points all pass a real session, so making the one caller that invents an id inherit its parent's makes the field mean the same thing everywhere. No rename, no change to the `Provider` trait. Parent and subagent now share one affinity key, which neither of us could find a case against.

Two details worth pointing at in review:

- The cancel key mints its own id now. `ui_id` falls back to `session-{id}` and keys `subagent_cancels`, later becoming a `tool_use_id` and a `parent_tool_use_id`, so sharing the session id would let two concurrent subagents clash.
- `ctx:session_id()` returns the canonical base58 form, not `SessionRef::as_str()`. Both parse back the same, but acp can hand us a legacy hyphenated string, and only the canonical form compares equal to what `maki.session.current()` and `live()` emit.

On `LuaCtx` it sits in `Caps` rather than as a flat field, so the three kinds stay distinguishable: handler and start return the id, restore returns `(nil, err)` because it has no `ToolContext` to take one from, and a run with genuinely no session (the `maki index` one-shot) returns a bare `nil` with no error, matching how `ctx:state()` and the `maki.env.*` family read.

## Testing

`just ci` green, 3400 tests. Five new: `tool_context()` carries the session (that function had no coverage, and wiring `None` there to make the literal compile is exactly this change's failure mode), the session surviving `AgentContext::from` and `to_tool_context` as the counter-assertion to the two fields those deliberately drop, and the Lua-visible handler path in both the present and absent cases.

**One gap, flagged rather than papered over:** subagent inheritance has no end-to-end test. Observing it needs a tool running *inside* a subagent, and `local_tools` handlers receive only their input table, not a ctx. maki-lua's suite has no provider mock and nothing drives a real subagent turn, and `maki.agent.session()` builds its provider from a model spec so one cannot be injected. Covering it means building that harness for a single field assignment. Happy to build it if you want it.

## Not in here

Review turned up a pre-existing bug next door: when one handler opens two sessions and `tool_use_id` is `Some`, both reuse it as `ui_id`, and `CancelMap::insert` drops the displaced trigger, so the second subagent cancels the first. It predates this change and this diff does not touch that path, so it is going out as its own PR.

Job ownership, the mailbox and message kind, and the monitor plugin are PRs 2 to 4.

---

AI use, per CONTRIBUTING: written with Claude Code at my direction. It did the codebase archaeology (tracing every consumer of the old field, which is what surfaced that it was an affinity key and not an identity), drafted the change and the tests, and ran a review pass with Codex over the diff. I directed the approach, took @tontinton's counter-proposal on the issue over my own, and reviewed everything that landed.
