### PR TITLE
fix(agent): stop a second subagent cancelling the first

### DIFF
--- a/maki-agent/src/cancel.rs
+++ b/maki-agent/src/cancel.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 use std::future::Future;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use event_listener::Event;
@@ -96,13 +96,25 @@ impl Drop for CancelTrigger {
     }
 }
 
-enum Entry {
-    Live(#[allow(dead_code)] CancelTrigger),
-    PreCancelled,
+/// Names one registration inside a key's list so its owner can retire it
+/// without disturbing the others registered under the same key.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct CancelSlot(u64);
+
+struct Slotted {
+    slot: CancelSlot,
+    trigger: Option<CancelTrigger>,
+}
+
+#[derive(Default)]
+struct Entry {
+    registrations: Vec<Slotted>,
+    cancelled: bool,
 }
 
 pub struct CancelMap<K> {
     entries: Mutex<HashMap<K, Entry>>,
+    next_slot: AtomicU64,
 }
 
 impl<K: Eq + std::hash::Hash> Default for CancelMap<K> {
@@ -115,26 +127,49 @@ impl<K: Eq + std::hash::Hash> CancelMap<K> {
     pub fn new() -> Self {
         Self {
             entries: Mutex::new(HashMap::new()),
+            next_slot: AtomicU64::new(0),
         }
     }
 
-    pub fn insert(&self, id: K, trigger: CancelTrigger) {
+    /// Registers {trigger} under {id}, alongside any already there, and
+    /// returns the slot to hand back to [`retire`](Self::retire).
+    pub fn insert(&self, id: K, trigger: CancelTrigger) -> CancelSlot {
         let mut map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
-        match map.remove(&id) {
-            Some(Entry::PreCancelled) => drop(trigger),
-            _ => {
-                map.insert(id, Entry::Live(trigger));
-            }
+        let slot = CancelSlot(self.next_slot.fetch_add(1, Ordering::Relaxed));
+        let entry = map.entry(id).or_default();
+        let trigger = if entry.cancelled {
+            drop(trigger);
+            None
+        } else {
+            Some(trigger)
+        };
+        entry.registrations.push(Slotted { slot, trigger });
+        slot
+    }
+
+    /// Retires one registration, dropping its trigger when it is still
+    /// active and leaving its siblings alone.
+    pub fn retire(&self, id: &K, slot: CancelSlot) {
+        let mut map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(entry) = map.get_mut(id) else {
+            return;
+        };
+        entry
+            .registrations
+            .retain(|registration| registration.slot != slot);
+        if entry.registrations.is_empty() {
+            map.remove(id);
         }
     }
 
+    /// Cancels everything under {id} and marks later siblings cancelled.
+    /// The entry stays until every registered sibling retires.
     pub fn cancel_or_precancel(&self, id: K) {
         let mut map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
-        match map.remove(&id) {
-            Some(Entry::Live(_)) => {} // trigger dropped, fires cancel
-            _ => {
-                map.insert(id, Entry::PreCancelled);
-            }
+        let entry = map.entry(id).or_default();
+        entry.cancelled = true;
+        for registration in &mut entry.registrations {
+            drop(registration.trigger.take());
         }
     }
 
@@ -143,6 +178,14 @@ impl<K: Eq + std::hash::Hash> CancelMap<K> {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .remove(id);
+    }
+
+    #[cfg(test)]
+    fn has_key(&self, id: &K) -> bool {
+        self.entries
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains_key(id)
     }
 
     pub fn cancel_all(&self) {
@@ -250,13 +293,13 @@ mod tests {
     }
 
     #[test]
-    fn cancel_map_remove_clears_precancelled() {
+    fn cancel_map_remove_clears_cancelled() {
         let map: CancelMap<String> = CancelMap::new();
         map.cancel_or_precancel("t1".to_owned());
         map.remove(&"t1".to_owned());
         let (trigger, token) = CancelToken::new();
         map.insert("t1".to_owned(), trigger);
-        assert!(!token.is_cancelled(), "remove should clear PreCancelled");
+        assert!(!token.is_cancelled(), "remove should clear cancellation");
     }
 
     #[test]
@@ -272,7 +315,7 @@ mod tests {
     }
 
     #[test]
-    fn cancel_map_cancel_all_clears_precancelled() {
+    fn cancel_map_cancel_all_clears_cancelled() {
         let map: CancelMap<String> = CancelMap::new();
         map.cancel_or_precancel("t1".to_owned());
         map.cancel_all();
@@ -280,23 +323,114 @@ mod tests {
         map.insert("t1".to_owned(), trigger);
         assert!(
             !token.is_cancelled(),
-            "cancel_all should clear PreCancelled entries"
+            "cancel_all should clear cancelled entries"
         );
     }
 
+    /// One tool call can open several subagents. They used to evict each
+    /// other, so the first died the moment the second registered.
     #[test]
-    fn cancel_map_insert_overwrites_live() {
+    fn cancel_map_keeps_siblings_under_one_key() {
         let map = CancelMap::new();
         let (t1, tok1) = CancelToken::new();
         let (t2, tok2) = CancelToken::new();
         map.insert("x".to_owned(), t1);
         map.insert("x".to_owned(), t2);
-        assert!(
-            tok1.is_cancelled(),
-            "first trigger should be dropped on overwrite"
-        );
-        assert!(!tok2.is_cancelled(), "second trigger should remain live");
+        assert!(!tok1.is_cancelled(), "a sibling must not evict the first");
+        assert!(!tok2.is_cancelled());
+
+        map.cancel_or_precancel("x".to_owned());
+        assert!(tok1.is_cancelled(), "cancelling the key stops them all");
+        assert!(tok2.is_cancelled());
+    }
+
+    #[test]
+    fn cancel_map_retire_leaves_siblings_running() {
+        let map = CancelMap::new();
+        let (t1, tok1) = CancelToken::new();
+        let (t2, tok2) = CancelToken::new();
+        let slot1 = map.insert("x".to_owned(), t1);
+        map.insert("x".to_owned(), t2);
+
+        map.retire(&"x".to_owned(), slot1);
+        assert!(tok1.is_cancelled(), "retiring drops that trigger");
+        assert!(!tok2.is_cancelled(), "the sibling keeps running");
+
         map.cancel_or_precancel("x".to_owned());
         assert!(tok2.is_cancelled());
+    }
+
+    /// The last one out clears the key so it can be reused.
+    #[test]
+    fn cancel_map_retiring_the_last_registration_clears_the_key() {
+        let map = CancelMap::new();
+        let (t1, _tok1) = CancelToken::new();
+        let slot = map.insert("x".to_owned(), t1);
+        assert!(map.has_key(&"x".to_owned()));
+
+        map.retire(&"x".to_owned(), slot);
+        assert!(!map.has_key(&"x".to_owned()), "empty key must be dropped");
+    }
+
+    /// Cancelling before anything registers has to catch every session the
+    /// tool call goes on to open, not just the first one through the door.
+    #[test]
+    fn cancel_map_precancel_catches_every_later_sibling() {
+        let map: CancelMap<String> = CancelMap::new();
+        map.cancel_or_precancel("x".to_owned());
+
+        let (t1, tok1) = CancelToken::new();
+        let (t2, tok2) = CancelToken::new();
+        let slot1 = map.insert("x".to_owned(), t1);
+        let slot2 = map.insert("x".to_owned(), t2);
+        assert!(tok1.is_cancelled());
+        assert!(
+            tok2.is_cancelled(),
+            "the mark must outlive the first insert"
+        );
+
+        map.retire(&"x".to_owned(), slot1);
+        assert!(map.has_key(&"x".to_owned()));
+        map.retire(&"x".to_owned(), slot2);
+        assert!(!map.has_key(&"x".to_owned()));
+    }
+
+    /// Pressing esc while a fan-out is running must also stop the sibling
+    /// that starts a moment later.
+    #[test]
+    fn cancel_map_cancel_catches_a_sibling_registered_after() {
+        let map = CancelMap::new();
+        let (t1, tok1) = CancelToken::new();
+        let slot1 = map.insert("x".to_owned(), t1);
+
+        map.cancel_or_precancel("x".to_owned());
+        assert!(tok1.is_cancelled());
+
+        let (t2, tok2) = CancelToken::new();
+        let slot2 = map.insert("x".to_owned(), t2);
+        assert!(tok2.is_cancelled(), "cancel left no mark for the sibling");
+
+        map.retire(&"x".to_owned(), slot1);
+        assert!(map.has_key(&"x".to_owned()));
+        map.retire(&"x".to_owned(), slot2);
+        assert!(!map.has_key(&"x".to_owned()));
+
+        let (t3, tok3) = CancelToken::new();
+        map.insert("x".to_owned(), t3);
+        assert!(
+            !tok3.is_cancelled(),
+            "the completed call must not poison a reused tool id"
+        );
+    }
+
+    #[test]
+    fn cancel_map_insert_into_cancelled_returns_retirement_slot() {
+        let map = CancelMap::new();
+        map.cancel_or_precancel("x".to_owned());
+        let (trigger, token) = CancelToken::new();
+        let slot = map.insert("x".to_owned(), trigger);
+        assert!(token.is_cancelled());
+        map.retire(&"x".to_owned(), slot);
+        assert!(!map.has_key(&"x".to_owned()));
     }
 }

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use async_lock::Mutex as AsyncMutex;
 use futures::future::{Either, select};
 use maki_agent::agent::tool_dispatch::{self, Emit};
-use maki_agent::cancel::CancelMap;
+use maki_agent::cancel::{CancelMap, CancelSlot};
 use maki_agent::tools::interpreter_bridge;
 use maki_agent::tools::registry::ToolRegistry;
 use maki_agent::tools::schema::sanitize_tool_input_schema;
@@ -523,7 +523,9 @@ async fn session(
         .clone()
         .unwrap_or_else(|| format!("session-{}", MakiId::generate()));
     let (child_trigger, child_cancel) = agent_ctx.cancel.child();
-    agent_ctx
+    // Several sessions can share one `ui_id`, so keep the slot and retire
+    // only ours on close instead of clearing the whole key.
+    let cancel_slot = agent_ctx
         .subagent_cancels
         .insert(ui_id.clone(), child_trigger);
 
@@ -561,6 +563,7 @@ async fn session(
         answer_tx: Some(answer_tx),
         parent_cancels: Arc::clone(&agent_ctx.subagent_cancels),
         ui_id,
+        cancel_slot,
         parent_event_tx: parent_tx,
         subagent_info,
         local_tools: Arc::new(local_map),
@@ -686,7 +689,10 @@ struct SessionState {
     parent_cancels: Arc<CancelMap<String>>,
     /// Stable identity for UI, cancel, and history. Falls back to a synthetic
     /// id for workflow-mode sessions (no model-issued tool call exists).
+    /// Shared with any sibling session the same tool call opened.
     ui_id: String,
+    /// Which registration under [`ui_id`](Self::ui_id) is ours.
+    cancel_slot: CancelSlot,
     parent_event_tx: EventSender,
     subagent_info: Arc<OnceLock<SubagentInfo>>,
     local_tools: LocalTools,
@@ -703,7 +709,7 @@ impl SessionState {
             return;
         }
         self.closed = true;
-        self.parent_cancels.remove(&self.ui_id);
+        self.parent_cancels.retire(&self.ui_id, self.cancel_slot);
         let messages = std::mem::replace(&mut self.history, History::new(Vec::new())).into_vec();
         let _ = self.parent_event_tx.send(AgentEvent::SubagentHistory {
             tool_use_id: self.ui_id.clone(),

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -302,7 +302,9 @@ impl AgentLoop {
     }
 
     fn set_cancel_trigger(&self, run_id: u64, trigger: CancelTrigger) {
-        self.cancel_map.insert(run_id, trigger);
+        // One trigger per run, and `clear_cancel_trigger` drops the whole
+        // key, so the slot is not worth carrying around.
+        let _ = self.cancel_map.insert(run_id, trigger);
     }
 
     fn clear_cancel_trigger(&self, run_id: u64) {

--- a/maki-ui/src/agent/cancel_map.rs
+++ b/maki-ui/src/agent/cancel_map.rs
@@ -4,6 +4,8 @@ pub(super) type RunCancelMap = CancelMap<u64>;
 
 pub(super) fn new_run_cancel_map(run_id: u64, trigger: CancelTrigger) -> RunCancelMap {
     let map = RunCancelMap::new();
-    map.insert(run_id, trigger);
+    // A run holds one trigger and clears the whole key when it ends, so
+    // there is no sibling to tell apart and no slot to keep.
+    let _ = map.insert(run_id, trigger);
     map
 }


### PR DESCRIPTION
Found while working on #676. Independent of that work.

## The bug

Subagent cancellation is keyed by the parent tool-use id, but one tool call can open several subagent sessions. The old `CancelMap` stored one trigger per key, so registering a second session dropped and cancelled the first.

Making the key unique would hide the collision but break escape-key cancellation, which correctly targets every subagent spawned by the tool call.

## What changed

A key now owns several slotted registrations. `insert` returns a `CancelSlot`, and each session retires only its own slot when it closes.

Cancelling a key cancels every current registration and marks later siblings cancelled. That cancelled state remains only while registrations from the tool call still exist; retiring the last slot removes the key, so a provider reusing a tool id in a later turn is not poisoned by an old cancellation.

The top-level run map still uses the same API with one registration per run.

## Validation

Focused tests cover sibling registration, cancel-before-register, mid-fan-out cancellation, independent retirement, last-slot cleanup, and key reuse. Formatting, workspace clippy, the full test suite, and the complete Rust and Nix CI matrices are green.

---

AI use, per CONTRIBUTING: implemented and reviewed with Codex and Claude Code at my direction.
