### PR TITLE
fix(ui): name the ended session in SessionReset

### DIFF
--- a/maki-lua/src/api/autocmd.rs
+++ b/maki-lua/src/api/autocmd.rs
@@ -131,6 +131,10 @@ fn parse_string_or_seq(value: Value, what: &str) -> LuaResult<Vec<String>> {
 /// `"TurnError"`, `"SessionReset"`. Plugins can also fire their own
 /// events with `exec_autocmds`.
 ///
+/// Each host event carries `data.session_id`. For `"SessionReset"` that
+/// is the session being left behind, so a handler can drop what belonged
+/// to it; the other three name the session still running.
+///
 /// @param event string|string[] Event name or list of names.
 /// @param opts table Options:
 ///   `callback` (function) called with an ev table `{ id, event, match, data }`.

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -56,6 +56,17 @@ pub mod test_support {
                 _ => ("other", Vec::new()),
             })
         }
+
+        /// Next fired autocmd as `(event, data)`, skipping other requests.
+        pub fn try_recv_autocmd(&self) -> Option<(String, serde_json::Value)> {
+            use crate::runtime::Request;
+            while let Ok(req) = self.0.try_recv() {
+                if let Request::FireAutocmd { event, data } = req {
+                    return Some((event, data));
+                }
+            }
+            None
+        }
     }
 
     pub fn probed_event_handle() -> (crate::EventHandle, RequestProbe) {

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -197,8 +197,11 @@ impl App {
         if self.state.mode == Mode::Plan {
             self.enter_plan();
         }
-        self.state.session = AppSession::new(&self.state.session.model, &self.state.session.cwd);
+        // Fire before the swap. A handler cleaning up after the session
+        // that just ended needs its id, and the stamp always reads
+        // whichever session is current.
         self.fire_session_autocmd("SessionReset", serde_json::json!({}));
+        self.state.session = AppSession::new(&self.state.session.model, &self.state.session.cwd);
         vec![Action::NewSession]
     }
 

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -537,6 +537,27 @@ fn ctrl_c_closes_palette() {
     assert!(!app.command_palette.is_active());
 }
 
+/// The event exists so plugins can drop what belonged to the session that
+/// ended. Naming its replacement makes every such handler a no-op.
+#[test]
+fn session_reset_names_the_session_that_ended() {
+    let mut app = test_app();
+    let (handle, probe) = maki_lua::test_support::probed_event_handle();
+    app.lua_event_handle = handle;
+    let ended = app.state.session.id.to_string();
+
+    app.reset_session();
+
+    let (event, data) = probe.try_recv_autocmd().expect("SessionReset fired");
+    assert_eq!(event, "SessionReset");
+    assert_eq!(data["session_id"], serde_json::json!(ended));
+    assert_ne!(
+        app.state.session.id.to_string(),
+        ended,
+        "reset must have installed a different session, or this proves nothing"
+    );
+}
+
 #[test]
 fn reset_session_clears_plan() {
     let mut app = test_app();

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -453,6 +453,10 @@ Built-in events fired by the host: `"TurnStart"`, `"TurnEnd"`,
 `"TurnError"`, `"SessionReset"`. Plugins can also fire their own
 events with `exec_autocmds`.
 
+Each host event carries `data.session_id`. For `"SessionReset"` that
+is the session being left behind, so a handler can drop what belonged
+to it; the other three name the session still running.
+
 **Parameters:**
 
 - `{event}` (`string|string[]`) Event name or list of names.


### PR DESCRIPTION
Found while working on #676. Independent of it, so it goes on its own.

## The bug

`reset_session` installs the replacement session and then fires the autocmd:

```rust
self.state.session = AppSession::new(...);
self.fire_session_autocmd("SessionReset", json!({}));
```

`fire_session_autocmd` stamps `self.state.session.id`, which by then is the new session. So `SessionReset` announces the id of the session that just *started*, never the one that ended.

A plugin dropping what belonged to the old session keys on an id that was never associated with it. Nothing errors, the cleanup simply does not match anything. `plugins/todo_write` is the only in-tree listener and it ignores the payload, so this is latent today, but it is exactly the hook #676's watcher work needs to release session-owned resources, and it would have silently done nothing.

## The fix

Fire before the swap, so the stamp still reads the outgoing session. Three lines.

I considered carrying both ids instead. It does not seem worth it: the event is named for the reset and its only plausible use is cleanup, while a handler wanting to set things up for the new session already has `TurnStart`. Happy to add a second field if you disagree.

`autocmd`'s doc comment now states which session each host event names, since that contract was never written down and is the whole point of the fix. Regenerated with `just gen-docs`.

## Testing

`just ci` green. One test, and I checked it has teeth: with the old ordering restored it fails with the replacement's id against the ended one, which is the exact symptom.

It needed a small `try_recv_autocmd` on the existing test probe, since the probe collapsed every non-click request into `("other", vec![])` and could not see the payload.

---

AI use, per CONTRIBUTING: written with Claude Code at my direction. It found this while mapping session teardown for the #676 work, wrote the fix and the test, and ran a review pass with Codex. I reviewed what landed.
