### PR TITLE
fix(lua): kill jobs when the store goes, not just the scope

### DIFF
--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -214,6 +214,16 @@ impl JobStore {
     }
 }
 
+/// Every job is its own process group, so one we forget keeps running
+/// after maki is gone. `TaskScope::drop` handles the usual path; this
+/// catches the rest, like the warm click cell that is dropped without a
+/// scope, and a panic unwinding past the cleanup.
+impl Drop for JobStore {
+    fn drop(&mut self) {
+        self.kill_all();
+    }
+}
+
 fn shell_command(cmd: &str) -> Command {
     #[cfg(unix)]
     {
@@ -446,6 +456,32 @@ mod tests {
         store
             .start("echo hello", None, None, None, None, None)
             .unwrap()
+    }
+
+    #[cfg(unix)]
+    fn group_alive(pid: u32) -> bool {
+        unsafe { libc::killpg(pid as libc::pid_t, 0) == 0 }
+    }
+
+    /// The warm click cell is dropped without ever going through
+    /// `TaskScope`, so without this the process outlives maki.
+    #[cfg(unix)]
+    #[test]
+    fn dropping_the_store_kills_its_jobs() {
+        let mut store = make_store();
+        let id = store
+            .start("sleep 30", None, None, None, None, None)
+            .expect("job started");
+        let pid = store.jobs[&id].pid;
+        assert!(group_alive(pid), "job should be running before the drop");
+
+        drop(store);
+
+        let gone = (0..500).any(|_| {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            !group_alive(pid)
+        });
+        assert!(gone, "dropping the store must not orphan the process group");
     }
 
     #[test]


### PR DESCRIPTION
Found while mapping job lifetime for #676. Independent of that work.

## The leak

Jobs are spawned with `setsid`, so each one is its own process group. The only thing that ever reclaims one is `TaskScope::drop`, which calls `kill_all` then `clear`.

The warm click cell never goes through a scope. It is built by hand as a bare `TaskCell` when a tool finishes, and click handlers run under `ScopedFuture::new` directly, with no `TaskScope` anywhere. When the entry is evicted the cell is just dropped, and neither `TaskCell` nor `JobStore` had a `Drop`. So a job started from a click handler is never killed, and the process group outlives maki.

Nothing in tree starts a job from a click handler today, so it is latent, but it is a spawned process that nobody can stop, and the same hole swallows a panic that unwinds past the cleanup.

## The change

```rust
impl Drop for JobStore {
    fn drop(&mut self) { self.kill_all(); }
}
```

Killing needs no `&Lua`, only `clear` does, so this is free and covers every path rather than the ones we remembered. It does not double kill: `TaskScope::drop` still calls `kill_all` then `clear`, and `clear` drains the map, so the later `Drop` finds nothing.

The test starts `sleep 30`, drops the store and polls `killpg(pid, 0)`. I checked it has teeth: without the `Drop` it fails after the full budget with the group still alive.

## One thing I want your call on

`kill_all` signals on `meta.alive`, and `alive` only falls when an `Exit` event is *delivered* to Lua. The warm path never pumps events, so a job that finished on its own can stay `alive` long after the waiter reaped it, and `killpg` then targets a pid the kernel is free to have reused.

That hazard is not new, `TaskScope::drop` has always signalled on the same flag, and this change does not widen the race so much as add another caller of it. Worth saying out loud though, because the paths this newly covers are exactly the ones where `alive` is most likely to be stale.

I tried gating the kill on a flag the waiter sets when it reaps the child, and it was wrong: a reaped leader does not mean an empty group. `bash -c 'sleep 30 &'` returns immediately, the leader is reaped, and `sleep` keeps running in the same group, so the gate skipped exactly the jobs this exists to reclaim. I backed it out.

The real fix is a handle rather than a number, `pidfd_open` plus `pidfd_send_signal` on linux and a job object on windows, which closes it properly instead of narrowing it. Happy to do that as its own PR if you want it, or to leave this as is.

---

AI use, per CONTRIBUTING: written with Claude Code at my direction. It found the leak while mapping job lifetime for #676, wrote the fix and the test, and ran two review passes with Codex. The second pass is what caught that the reaped-leader gate was wrong, with a repro. I made the call to back it out and to raise the stale-pid question here rather than paper over it.
