### PR TITLE
feat: let a watcher report to a session without spending a turn

### DIFF
--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -477,6 +477,7 @@ mod tests {
                     text: "done".into(),
                 }],
                 display_text: None,
+                ..Default::default()
             },
         ];
         let mut session: Session<Message, TokenUsage, maki_agent::ToolOutput> =

--- a/maki-acp/src/translate.rs
+++ b/maki-acp/src/translate.rs
@@ -185,6 +185,9 @@ pub fn replay_history(messages: &[Message]) -> Vec<SessionUpdate> {
 }
 
 fn replay_user(msg: &Message, updates: &mut Vec<SessionUpdate>) {
+    if msg.is_observation() {
+        return;
+    }
     if let Some(text) = msg.user_text() {
         updates.push(SessionUpdate::UserMessageChunk(ContentChunk::new(
             ContentBlock::Text(TextContent::new(text.to_string())),
@@ -286,6 +289,7 @@ mod tests {
             role: MsgRole::Assistant,
             content,
             display_text: None,
+            ..Default::default()
         }
     }
 
@@ -322,6 +326,7 @@ mod tests {
                     is_error: false,
                 }],
                 display_text: None,
+                ..Default::default()
             },
             assistant(vec![MsgBlock::Text {
                 text: "done".into(),
@@ -365,6 +370,12 @@ mod tests {
     }
 
     #[test]
+    fn replay_never_speaks_an_observation_as_the_user() {
+        let obs = Message::observation("[monitor] build failed".into());
+        assert!(updates_json(&[obs]).is_empty());
+    }
+
+    #[test]
     fn replay_failed_tool_result_maps_to_failed_status() {
         let msg = Message {
             role: MsgRole::User,
@@ -374,6 +385,7 @@ mod tests {
                 is_error: true,
             }],
             display_text: None,
+            ..Default::default()
         };
         let json = updates_json(&[msg]);
         assert_eq!(json[0]["sessionUpdate"], "tool_call_update");

--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -603,6 +603,38 @@ mod tests {
     }
 
     #[test]
+    fn compaction_keeps_observation_before_dependent_reply() {
+        smol::block_on(async {
+            let provider = MockProvider::new(vec![Ok(text_response(StopReason::EndTurn))]);
+            let mut history = History::new(vec![
+                Message::observation("[monitor] build failed".into()),
+                Message {
+                    role: Role::Assistant,
+                    content: vec![ContentBlock::Text {
+                        text: "I will fix it".into(),
+                    }],
+                    ..Default::default()
+                },
+            ]);
+            let (raw_tx, _rx) = flume::unbounded();
+
+            compact_history(
+                &provider,
+                &default_model(),
+                &mut history,
+                &EventSender::new(raw_tx, 0),
+                &CancelToken::none(),
+            )
+            .await
+            .unwrap();
+
+            let requests = provider.requests.lock().unwrap();
+            assert!(requests[0][0].is_observation());
+            assert!(matches!(requests[0][1].role, Role::Assistant));
+        });
+    }
+
+    #[test]
     fn truncate_oldest_round_preserves_text_beside_orphan() {
         let mut messages = vec![
             Message::user("request".into()),

--- a/maki-agent/src/agent/history.rs
+++ b/maki-agent/src/agent/history.rs
@@ -178,6 +178,7 @@ pub fn close_dangling_tool_calls(messages: &mut Vec<Message>, note: &str) {
         role: Role::User,
         content: error_results,
         display_text: Some(String::new()),
+        ..Default::default()
     });
 }
 
@@ -236,6 +237,7 @@ mod tests {
                 })
                 .collect(),
             display_text: Some(String::new()),
+            ..Default::default()
         }
     }
 

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -20,7 +20,7 @@ use crate::permissions::PermissionManager;
 use crate::tools::{Deadline, FileReadTracker, LocalTools, ToolAudience, ToolContext};
 use crate::{
     AgentConfig, AgentError, AgentEvent, AgentInput, AgentMode, EventSender, ExtractedCommand,
-    InterruptSource, TurnCompleteEvent,
+    InterruptSource, SessionMailbox, TurnCompleteEvent,
 };
 use maki_config::ToolOutputLines;
 use maki_storage::id::SessionRef;
@@ -58,6 +58,7 @@ pub struct AgentParams {
     pub tool_output_lines: ToolOutputLines,
     pub permissions: Arc<PermissionManager>,
     pub session_id: Option<SessionRef>,
+    pub mailbox: Option<SessionMailbox>,
     pub timeouts: maki_providers::Timeouts,
     pub file_tracker: Arc<FileReadTracker>,
     pub prompt_slots: Arc<crate::prompt::ResolvedSlots>,
@@ -99,6 +100,7 @@ pub struct Agent<'h> {
     permissions: Arc<PermissionManager>,
     opts: RequestOptions,
     session_id: Option<SessionRef>,
+    mailbox: Option<SessionMailbox>,
     timeouts: maki_providers::Timeouts,
     file_tracker: Arc<FileReadTracker>,
     prompt_slots: Arc<crate::prompt::ResolvedSlots>,
@@ -138,6 +140,7 @@ impl<'h> Agent<'h> {
             post_tool_empty_retried: false,
             opts: RequestOptions::default(),
             session_id: params.session_id,
+            mailbox: params.mailbox,
             file_tracker: params.file_tracker,
             prompt_slots: params.prompt_slots,
             subagent_cancels: params.subagent_cancels,
@@ -182,20 +185,30 @@ impl<'h> Agent<'h> {
     }
 
     pub async fn run(&mut self, input: AgentInput) -> Result<(), AgentError> {
+        let AgentInput {
+            message,
+            mode,
+            images,
+            preamble,
+            thinking,
+            fast,
+            workflow,
+            prompt: _,
+        } = input;
         self.rollback_len = self.history.len();
-        let msg = Message::user_with_images(input.message.clone(), input.images);
-        self.history.push(msg);
-        self.mode = input.mode;
-        self.workflow = input.workflow;
-        self.opts = RequestOptions {
-            thinking: input.thinking,
-            fast: input.fast,
-        };
+        self.push_input_context(preamble);
+        if !message.trim().is_empty() || !images.is_empty() {
+            self.history
+                .push(Message::user_with_images(message.clone(), images));
+        }
+        self.mode = mode;
+        self.workflow = workflow;
+        self.opts = RequestOptions { thinking, fast };
 
         info!(
             model = %self.model.id,
             mode = ?self.mode,
-            message_len = input.message.len(),
+            message_len = message.len(),
             "agent run started"
         );
 
@@ -206,6 +219,17 @@ impl<'h> Agent<'h> {
         }
 
         result
+    }
+
+    fn push_input_context(&mut self, preamble: Vec<Message>) {
+        for message in preamble {
+            self.history.push(message);
+        }
+        if let Some(mailbox) = &self.mailbox {
+            for message in mailbox.drain() {
+                self.history.push(message);
+            }
+        }
     }
 
     async fn run_loop(&mut self) -> Result<(), AgentError> {
@@ -486,9 +510,7 @@ impl<'h> Agent<'h> {
                     text: input.message.clone(),
                     image_count: input.images.len(),
                 })?;
-                for msg in std::mem::take(&mut input.preamble) {
-                    self.history.push(msg);
-                }
+                self.push_input_context(std::mem::take(&mut input.preamble));
                 self.mode = input.mode.clone();
                 let display = input.message.clone();
                 let wrapped = format!(
@@ -647,6 +669,7 @@ mod tests {
                     std::path::PathBuf::from("/tmp"),
                 )),
                 session_id: None,
+                mailbox: None,
                 timeouts: maki_providers::Timeouts::default(),
                 file_tracker: FileReadTracker::fresh(),
                 prompt_slots: Arc::new(crate::prompt::ResolvedSlots::default()),
@@ -675,6 +698,82 @@ mod tests {
             workflow: false,
             prompt: None,
         }
+    }
+
+    #[test]
+    fn run_ingests_preamble_then_mailbox_then_user_message() {
+        smol::block_on(async {
+            let id = maki_storage::id::MakiId::generate();
+            let mailbox = SessionMailbox::register(id);
+            SessionMailbox::notify(id, "mailbox".into(), false).unwrap();
+            let mut history = History::new(Vec::new());
+            let (mut agent, _event_rx) = make_agent(
+                MockProvider::new(vec![text_response(StopReason::EndTurn)]),
+                &mut history,
+            );
+            agent.mailbox = Some(mailbox);
+            let mut input = default_input();
+            input.preamble = vec![Message::observation("preamble".into())];
+
+            agent.run(input).await.unwrap();
+            drop(agent);
+
+            assert_eq!(history.as_slice()[0].user_text(), Some("preamble"));
+            assert_eq!(history.as_slice()[1].user_text(), Some("mailbox"));
+            assert_eq!(history.as_slice()[2].user_text(), Some("hello"));
+        });
+    }
+
+    #[test]
+    fn queued_input_drains_preamble_and_mailbox() {
+        smol::block_on(async {
+            let id = maki_storage::id::MakiId::generate();
+            let mailbox = SessionMailbox::register(id);
+            SessionMailbox::notify(id, "mailbox".into(), false).unwrap();
+            let mut input = default_input();
+            input.preamble = vec![Message::observation("preamble".into())];
+            let source = MockInterruptSource::new(vec![ExtractedCommand::Interrupt(input, 0)]);
+            let mut history = History::new(Vec::new());
+            let (mut agent, _event_rx) = make_agent(MockProvider::new(Vec::new()), &mut history);
+            agent.mailbox = Some(mailbox);
+            let mut agent = agent.with_interrupt_source(source);
+
+            assert!(agent.handle_queued_command().await.unwrap());
+            drop(agent);
+
+            let text = history
+                .as_slice()
+                .iter()
+                .map(Message::user_text)
+                .collect::<Vec<_>>();
+            assert_eq!(text, [Some("preamble"), Some("mailbox"), Some("hello")]);
+            assert!(history.as_slice()[0].is_observation());
+            assert!(history.as_slice()[1].is_observation());
+        });
+    }
+
+    #[test]
+    fn wake_only_run_does_not_insert_an_empty_user_turn() {
+        smol::block_on(async {
+            let id = maki_storage::id::MakiId::generate();
+            let mailbox = SessionMailbox::register(id);
+            SessionMailbox::notify(id, "failed".into(), true).unwrap();
+            let mut history = History::new(Vec::new());
+            let (mut agent, _event_rx) = make_agent(
+                MockProvider::new(vec![text_response(StopReason::EndTurn)]),
+                &mut history,
+            );
+            agent.mailbox = Some(mailbox);
+            let mut input = default_input();
+            input.message.clear();
+
+            agent.run(input).await.unwrap();
+            drop(agent);
+
+            assert_eq!(history.as_slice().len(), 2);
+            assert!(history.as_slice()[0].is_observation());
+            assert!(matches!(history.as_slice()[1].role, Role::Assistant));
+        });
     }
 
     fn drain_events(rx: &flume::Receiver<Envelope>) -> Vec<Envelope> {
@@ -954,6 +1053,7 @@ mod tests {
                         std::path::PathBuf::from("/tmp"),
                     )),
                     session_id: None,
+                    mailbox: None,
                     timeouts: maki_providers::Timeouts::default(),
                     file_tracker: FileReadTracker::fresh(),
                     prompt_slots: Arc::new(crate::prompt::ResolvedSlots::default()),

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -22,7 +22,7 @@ use crate::template;
 use crate::tools::{DescriptionContext, FileReadTracker, ToolAudience, ToolFilter, ToolRegistry};
 use crate::{
     Agent, AgentConfig, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, Envelope,
-    EventSender, ImageSource, McpHandle, McpSession, PermissionsConfig, ToolOutput,
+    EventSender, ImageSource, McpHandle, McpSession, PermissionsConfig, SessionMailbox, ToolOutput,
     ToolOutputLines,
 };
 
@@ -180,6 +180,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
     let session_id = MakiId::generate();
     let session_ref = SessionRef::from(session_id);
     let session_ref_clone = session_ref.clone();
+    let mailbox = SessionMailbox::register(session_id);
     let fast = params.fast;
     let workflow = params.workflow;
     let task = smol::spawn({
@@ -212,6 +213,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
                         working_dir_path,
                     )),
                     session_id: Some(session_ref_clone.clone()),
+                    mailbox: Some(mailbox.clone()),
                     timeouts: params.timeouts,
                     file_tracker: FileReadTracker::fresh(),
                     prompt_slots: Arc::new(params.prompt_slots),
@@ -325,6 +327,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
             (id, SessionRef::from(id))
         }
     };
+    let mailbox = SessionMailbox::register(session_id);
 
     let working_dir = params.initial_wd.to_string_lossy().into_owned();
     let permissions = Arc::new(PermissionManager::new(
@@ -424,6 +427,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                         tool_output_lines: ToolOutputLines::default(),
                         permissions: Arc::clone(&permissions),
                         session_id: Some(session_ref_clone.clone()),
+                        mailbox: Some(mailbox.clone()),
                         timeouts: params.timeouts,
                         file_tracker: Arc::clone(&file_tracker),
                         prompt_slots: Arc::clone(&params.prompt_slots),
@@ -539,6 +543,23 @@ mod tests {
         let loaded = load(&tmp);
         assert_eq!(loaded.messages().len(), 1);
         assert_eq!(loaded.title, generate_title(&messages));
+    }
+
+    #[test]
+    fn record_turn_persists_observations() {
+        let tmp = TempDir::new().unwrap();
+        let mut store = store_in(&tmp);
+        store.record_turn(
+            &[
+                Message::user("fix the login bug".into()),
+                Message::observation("build failed".into()),
+            ],
+            MODEL_SPEC.into(),
+        );
+
+        let loaded = load(&tmp);
+        assert_eq!(loaded.messages().len(), 2);
+        assert!(loaded.messages()[1].is_observation());
     }
 
     #[test]

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -5,6 +5,7 @@ pub mod cancel;
 pub mod child_guard;
 pub use child_guard::ChildGuard;
 pub mod headless;
+pub mod mailbox;
 pub mod mcp;
 pub use mcp::config::{McpConfigError, McpConfigErrors, McpServerInfo, McpServerStatus};
 pub use mcp::protocol::PromptRole;
@@ -18,6 +19,7 @@ pub use agent::{
     is_instruction_file,
 };
 pub use cancel::{CancelMap, CancelToken, CancelTrigger};
+pub use mailbox::{MailboxError, SessionMailbox};
 pub use maki_config::{AgentConfig, PermissionsConfig, ToolOutputLines};
 pub mod command;
 pub mod diff;

--- a/maki-agent/src/mailbox.rs
+++ b/maki-agent/src/mailbox.rs
@@ -1,0 +1,217 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, LazyLock, Mutex, MutexGuard, PoisonError, Weak};
+
+use maki_providers::Message;
+use maki_storage::id::MakiId;
+use thiserror::Error;
+
+const MAILBOX_CAPACITY: usize = 100;
+
+static MAILBOXES: LazyLock<Mutex<HashMap<MakiId, Weak<Mutex<State>>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+#[derive(Default)]
+struct State {
+    pending: VecDeque<Message>,
+    wake: bool,
+}
+
+#[derive(Debug, Error)]
+#[error("session not live: {0}")]
+pub struct MailboxError(MakiId);
+
+#[derive(Clone)]
+pub struct SessionMailbox {
+    session_id: MakiId,
+    state: Arc<Mutex<State>>,
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+impl SessionMailbox {
+    pub fn register(session_id: MakiId) -> Self {
+        let mut mailboxes = lock(&MAILBOXES);
+        if let Some(state) = mailboxes.get(&session_id).and_then(Weak::upgrade) {
+            return Self { session_id, state };
+        }
+
+        let state = Arc::new(Mutex::new(State::default()));
+        mailboxes.insert(session_id, Arc::downgrade(&state));
+        Self { session_id, state }
+    }
+
+    pub fn notify(session_id: MakiId, text: String, wake: bool) -> Result<(), MailboxError> {
+        let mailbox = {
+            let mut mailboxes = lock(&MAILBOXES);
+            let Some(state) = mailboxes.get(&session_id).and_then(Weak::upgrade) else {
+                mailboxes.remove(&session_id);
+                return Err(MailboxError(session_id));
+            };
+            Self { session_id, state }
+        };
+        let mut state = lock(&mailbox.state);
+        if state.pending.len() == MAILBOX_CAPACITY {
+            state.pending.pop_front();
+        }
+        state.pending.push_back(Message::observation(text));
+        state.wake |= wake;
+        Ok(())
+    }
+
+    pub fn drain(&self) -> Vec<Message> {
+        let mut state = lock(&self.state);
+        state.wake = false;
+        state.pending.drain(..).collect()
+    }
+
+    pub fn claim_wake(&self) -> Vec<Message> {
+        let mut state = lock(&self.state);
+        if !state.wake {
+            return Vec::new();
+        }
+        state.wake = false;
+        state.pending.drain(..).collect()
+    }
+}
+
+impl Drop for SessionMailbox {
+    fn drop(&mut self) {
+        if Arc::strong_count(&self.state) != 1 {
+            return;
+        }
+        let weak = Arc::downgrade(&self.state);
+        let mut mailboxes = lock(&MAILBOXES);
+        if Arc::strong_count(&self.state) == 1
+            && mailboxes
+                .get(&self.session_id)
+                .is_some_and(|registered| registered.ptr_eq(&weak))
+        {
+            mailboxes.remove(&self.session_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text(message: &Message) -> &str {
+        message.user_text().unwrap()
+    }
+
+    #[test]
+    fn notifications_drain_in_order_and_clear_wake() {
+        let id = MakiId::generate();
+        let mailbox = SessionMailbox::register(id);
+        SessionMailbox::notify(id, "first".into(), true).unwrap();
+        SessionMailbox::notify(id, "second".into(), true).unwrap();
+
+        let messages = mailbox.drain();
+        assert_eq!(
+            messages.iter().map(text).collect::<Vec<_>>(),
+            ["first", "second"]
+        );
+        assert!(messages.iter().all(Message::is_observation));
+        assert!(mailbox.claim_wake().is_empty());
+    }
+
+    #[test]
+    fn quiet_notifications_do_not_claim_a_wake() {
+        let id = MakiId::generate();
+        let mailbox = SessionMailbox::register(id);
+        SessionMailbox::notify(id, "built".into(), false).unwrap();
+
+        assert!(mailbox.claim_wake().is_empty());
+        assert_eq!(mailbox.drain().len(), 1);
+    }
+
+    #[test]
+    fn waking_notification_claims_all_pending_messages() {
+        let id = MakiId::generate();
+        let mailbox = SessionMailbox::register(id);
+        SessionMailbox::notify(id, "quiet".into(), false).unwrap();
+        SessionMailbox::notify(id, "wake".into(), true).unwrap();
+
+        let messages = mailbox.claim_wake();
+        assert_eq!(
+            messages.iter().map(text).collect::<Vec<_>>(),
+            ["quiet", "wake"]
+        );
+        assert!(mailbox.drain().is_empty());
+    }
+
+    #[test]
+    fn notifications_drop_the_oldest_message_at_capacity() {
+        let id = MakiId::generate();
+        let mailbox = SessionMailbox::register(id);
+        for index in 0..=MAILBOX_CAPACITY {
+            SessionMailbox::notify(id, index.to_string(), false).unwrap();
+        }
+
+        let messages = mailbox.drain();
+        assert_eq!(messages.len(), MAILBOX_CAPACITY);
+        assert_eq!(text(&messages[0]), "1");
+        assert_eq!(text(messages.last().unwrap()), MAILBOX_CAPACITY.to_string());
+    }
+
+    #[test]
+    fn registrations_for_the_same_id_share_state() {
+        let id = MakiId::generate();
+        let first = SessionMailbox::register(id);
+        let second = SessionMailbox::register(id);
+        SessionMailbox::notify(id, "built".into(), false).unwrap();
+
+        assert_eq!(second.drain().len(), 1);
+        assert!(first.drain().is_empty());
+    }
+
+    #[test]
+    fn dropping_the_last_registration_closes_the_mailbox() {
+        let id = MakiId::generate();
+        drop(SessionMailbox::register(id));
+
+        assert!(!lock(&MAILBOXES).contains_key(&id));
+        assert!(SessionMailbox::notify(id, "late".into(), false).is_err());
+    }
+
+    #[test]
+    fn dropping_one_registration_keeps_the_shared_mailbox() {
+        let id = MakiId::generate();
+        let first = SessionMailbox::register(id);
+        let second = SessionMailbox::register(id);
+
+        drop(first);
+
+        assert!(lock(&MAILBOXES).contains_key(&id));
+        SessionMailbox::notify(id, "built".into(), false).unwrap();
+        assert_eq!(second.drain().len(), 1);
+    }
+
+    #[test]
+    fn stale_drop_does_not_remove_a_replacement() {
+        let id = MakiId::generate();
+        let stale = SessionMailbox::register(id);
+        let replacement = SessionMailbox {
+            session_id: id,
+            state: Arc::new(Mutex::new(State::default())),
+        };
+        lock(&MAILBOXES).insert(id, Arc::downgrade(&replacement.state));
+
+        drop(stale);
+        SessionMailbox::notify(id, "built".into(), false).unwrap();
+
+        assert_eq!(replacement.drain().len(), 1);
+    }
+
+    #[test]
+    fn legacy_and_canonical_ids_address_the_same_mailbox() {
+        let legacy: MakiId = "01965087-4c71-7f00-8000-000000000001".parse().unwrap();
+        let canonical: MakiId = legacy.to_string().parse().unwrap();
+        let mailbox = SessionMailbox::register(legacy);
+        SessionMailbox::notify(canonical, "built".into(), false).unwrap();
+
+        assert_eq!(mailbox.drain().len(), 1);
+    }
+}

--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -1586,6 +1586,7 @@ mod tests {
                 tool_use("gone__tool"),
             ],
             display_text: None,
+            ..Default::default()
         }];
         let restored = McpSession::new(session.handle.clone(), &history);
         let mut tools = json!([]);
@@ -1669,6 +1670,7 @@ mod tests {
                 input: json!({}),
             }],
             display_text: None,
+            ..Default::default()
         }];
         let restored = McpSession::new(session.handle.clone(), &history);
         let mut tools = json!([]);

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -522,6 +522,7 @@ async fn session(
             tool_output_lines: maki_config::ToolOutputLines::default(),
             permissions: Arc::clone(&agent_ctx.permissions),
             session_id: agent_ctx.session_id.clone(),
+            mailbox: None,
             timeouts: agent_ctx.timeouts,
             file_tracker: FileReadTracker::fresh(),
             prompt_slots: Arc::clone(&agent_ctx.prompt_slots),

--- a/maki-lua/src/api/session.rs
+++ b/maki-lua/src/api/session.rs
@@ -1,13 +1,18 @@
-//! `maki.session`: host session primitives. Every call round-trips to the UI
-//! event loop, which owns the live session runtimes and the session store;
-//! the loop answers `list` from a background task so slow scans never block.
+//! `maki.session`: host session primitives. Session management round-trips to
+//! the UI event loop, which owns live runtimes and storage. `notify` posts
+//! directly to the agent mailbox so synchronous callbacks can use it.
 
+use maki_agent::SessionMailbox;
 use maki_lua_macro::{lua_fn, lua_table};
+use maki_storage::id::MakiId;
 use mlua::{Lua, Result as LuaResult, Table, Value};
 
 use crate::api::util::command::{SessionRequest, UiAction, ui_roundtrip};
 use crate::api::util::convert::json_to_lua;
-use crate::api::util::pair::{Pair, try_pair};
+use crate::api::util::pair::{Pair, err_pair, try_pair};
+
+const BLANK_NOTIFY_ERR: &str = "text must not be blank";
+const SESSION_REQUIRED_ERR: &str = "session is required";
 
 async fn roundtrip(
     lua: Lua,
@@ -128,6 +133,38 @@ async fn prompt(
     roundtrip(lua, tx, SessionRequest::Prompt { id, text }).await
 }
 
+/// Reports {text} to a live session without creating a user turn. The
+/// observation waits for the session's next agent run.
+///
+/// @param text string What to report. Must not be blank.
+/// @param opts table Options:
+///   `session` (string) id of a live session.
+///   `wake` (boolean) start a TUI turn when it next becomes idle (default false).
+/// @return (boolean|nil, string|nil) true, or nil and an error.
+/// @example
+/// maki.session.notify("[monitor] deploy failed", { session = id, wake = true })
+#[lua_fn]
+fn notify(_lua: &Lua, text: String, opts: Option<Table>) -> LuaResult<Pair<bool>> {
+    if text.trim().is_empty() {
+        return Ok(err_pair(BLANK_NOTIFY_ERR));
+    }
+    let Some(opts) = opts else {
+        return Ok(err_pair(SESSION_REQUIRED_ERR));
+    };
+    let Some(raw_id) = opts.get::<Option<String>>("session")? else {
+        return Ok(err_pair(SESSION_REQUIRED_ERR));
+    };
+    let session_id: MakiId = match raw_id.parse() {
+        Ok(id) => id,
+        Err(error) => return Ok(err_pair(error)),
+    };
+    let wake = opts.get("wake").unwrap_or(false);
+    if let Err(error) = SessionMailbox::notify(session_id, text, wake) {
+        return Ok(err_pair(error));
+    }
+    Ok((Some(true), None))
+}
+
 /// Renames a session, live or stored.
 ///
 /// @param opts table Required fields: id (string) session to rename;
@@ -151,11 +188,11 @@ async fn set_title(
 lua_table! {
     /// Host session primitives. The interactive UI can run several sessions
     /// at once; these functions let plugins list, create, focus, rename, and
-    /// delete them. Every call round-trips to the UI event loop and returns
-    /// the pair `(value, err)`. Without an interactive UI attached, every
-    /// call returns `nil, "no interactive UI attached"`.
+    /// delete them. Session management returns `nil, "no interactive UI
+    /// attached"` without a UI. `notify` instead targets a live agent mailbox
+    /// directly, so it also works under ACP and SDK frontends.
     "maki.session" => pub(crate) fn create_session_table(tx: Option<flume::Sender<UiAction>>),
-    DOCS [list(tx), live(tx), current(tx), focus(tx), delete(tx), new(tx), prompt(tx), set_title(tx)]
+    DOCS [list(tx), live(tx), current(tx), focus(tx), delete(tx), new(tx), prompt(tx), notify(), set_title(tx)]
 }
 
 #[cfg(test)]
@@ -225,6 +262,77 @@ mod tests {
         checker.join().unwrap();
         assert_eq!(err, None);
         assert_eq!(val, "queued");
+    }
+
+    #[test]
+    fn notify_is_synchronous_and_queues_an_observation() {
+        let id = MakiId::generate();
+        let mailbox = SessionMailbox::register(id);
+        let (tx, rx) = flume::unbounded::<UiAction>();
+        let lua = lua_with_session(Some(tx));
+        lua.globals().set("session_id", id.to_string()).unwrap();
+
+        let (value, error): (bool, Option<String>) = lua
+            .load("return session.notify('built', { session = session_id })")
+            .eval()
+            .unwrap();
+
+        assert!(value);
+        assert_eq!(error, None);
+        let messages = mailbox.drain();
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].is_observation());
+        assert_eq!(messages[0].user_text(), Some("built"));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn waking_notify_sets_the_mailbox_wake_flag() {
+        let id = MakiId::generate();
+        let mailbox = SessionMailbox::register(id);
+        let lua = lua_with_session(None);
+        lua.globals().set("session_id", id.to_string()).unwrap();
+
+        let (value, error): (bool, Option<String>) = lua
+            .load("return session.notify('failed', { session = session_id, wake = true })")
+            .eval()
+            .unwrap();
+
+        assert!(value);
+        assert_eq!(error, None);
+        assert_eq!(mailbox.claim_wake().len(), 1);
+    }
+
+    #[test]
+    fn notify_rejects_missing_and_non_live_sessions() {
+        let lua = lua_with_session(None);
+        let (_, missing): (Value, Option<String>) =
+            lua.load("return session.notify('built')").eval().unwrap();
+        assert_eq!(missing.as_deref(), Some(SESSION_REQUIRED_ERR));
+
+        let id = MakiId::generate();
+        lua.globals().set("session_id", id.to_string()).unwrap();
+        let (_, not_live): (Value, Option<String>) = lua
+            .load("return session.notify('built', { session = session_id })")
+            .eval()
+            .unwrap();
+        assert_eq!(not_live, Some(format!("session not live: {id}")));
+    }
+
+    #[test]
+    fn notify_rejects_blank_text_and_invalid_session_ids() {
+        let lua = lua_with_session(None);
+        let (_, blank): (Value, Option<String>) = lua
+            .load("return session.notify(' ', { session = 'invalid' })")
+            .eval()
+            .unwrap();
+        assert_eq!(blank.as_deref(), Some(BLANK_NOTIFY_ERR));
+
+        let (_, invalid): (Value, Option<String>) = lua
+            .load("return session.notify('built', { session = 'invalid' })")
+            .eval()
+            .unwrap();
+        assert!(invalid.is_some_and(|error| error.contains("invalid base58")));
     }
 
     #[test]

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -21,6 +21,6 @@ pub use providers::opencode::{
 };
 pub use types::{
     ContentBlock, Effort, EffortDialect, IMAGE_OMITTED_NOTE, ImageMediaType, ImageSource, Message,
-    ProviderEvent, ProviderUsage, RequestOptions, Role, StopReason, StreamResponse, ThinkingConfig,
-    UsageLimit, adapt_images_for_model, dialect,
+    MessageKind, ProviderEvent, ProviderUsage, RequestOptions, Role, StopReason, StreamResponse,
+    ThinkingConfig, UsageLimit, adapt_images_for_model, dialect,
 };

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -2,6 +2,9 @@
 //! `Message.display_text`: `Some("")` marks a message as synthetic (sent to the API but hidden
 //! from the UI). `user_text()` returns `None` for these, so system-injected messages
 //! (cancel markers, compaction prompts) stay invisible without a separate type.
+//! `Message.kind` answers a different question. Synthetic text is ours and
+//! trusted, it is just not worth showing. An observation comes from outside,
+//! belongs in model context, and must never be mistaken for the user talking.
 
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -160,15 +163,56 @@ pub enum ContentBlock {
     },
 }
 
+/// Who a message came from, which `role` cannot say. Providers only
+/// accept user and assistant, so anything the host wants to report has to
+/// travel as a user message, and without this there is no way to tell it
+/// apart from the user actually typing. A prefix in the text would not do:
+/// a log line can print one.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageKind {
+    /// Someone said this, the user or the model.
+    #[default]
+    Turn,
+    /// The host noticed it and passed it to the model. It stays in session
+    /// history for conversation order but is hidden from user-facing views.
+    Observation,
+}
+
+impl MessageKind {
+    fn is_turn(&self) -> bool {
+        matches!(self, Self::Turn)
+    }
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Message {
     pub role: Role,
     pub content: Vec<ContentBlock>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_text: Option<String>,
+    /// Skipped when it is `Turn`, so sessions written before this existed
+    /// load unchanged.
+    #[serde(default, skip_serializing_if = "MessageKind::is_turn")]
+    pub kind: MessageKind,
 }
 
 impl Message {
+    /// Something the host saw, reported to the model without pretending
+    /// the user said it.
+    pub fn observation(text: String) -> Self {
+        Self {
+            role: Role::User,
+            content: vec![ContentBlock::Text { text }],
+            kind: MessageKind::Observation,
+            ..Default::default()
+        }
+    }
+
+    pub fn is_observation(&self) -> bool {
+        self.kind == MessageKind::Observation
+    }
+
     pub fn user(text: String) -> Self {
         Self {
             role: Role::User,
@@ -182,6 +226,7 @@ impl Message {
             role: Role::User,
             content: vec![ContentBlock::Text { text: ai_text }],
             display_text: Some(display),
+            ..Default::default()
         }
     }
 
@@ -205,6 +250,7 @@ impl Message {
             role: Role::User,
             content: vec![ContentBlock::Text { text }],
             display_text: Some(String::new()),
+            ..Default::default()
         }
     }
 
@@ -239,7 +285,7 @@ impl Message {
 
 impl TitleSource for Message {
     fn first_user_text(&self) -> Option<&str> {
-        if !self.role.is_user() {
+        if !self.role.is_user() || self.is_observation() {
             return None;
         }
         self.user_text()
@@ -679,6 +725,24 @@ mod tests {
         let msg = Message::user_with_images(String::new(), vec![source]);
         assert_eq!(msg.content.len(), 1);
         assert!(matches!(&msg.content[0], ContentBlock::Image { .. }));
+    }
+
+    #[test]
+    fn message_kind_is_backward_compatible() {
+        let old: Message = serde_json::from_value(json!({
+            "role": "user",
+            "content": [{ "type": "text", "text": "hello" }]
+        }))
+        .unwrap();
+        assert_eq!(old.kind, MessageKind::Turn);
+
+        let turn = serde_json::to_value(Message::user("hello".into())).unwrap();
+        assert!(turn.get("kind").is_none());
+
+        let observation = Message::observation("built".into());
+        assert_eq!(observation.first_user_text(), None);
+        let observation = serde_json::to_value(observation).unwrap();
+        assert_eq!(observation["kind"], "observation");
     }
 
     #[test_case(ImageMediaType::Png,  "image/png"  ; "png")]

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -13,7 +13,7 @@ use maki_agent::tools::{
 use maki_agent::{
     Agent, AgentConfig, AgentEvent, AgentInput, AgentParams, AgentRunParams, CancelMap,
     CancelToken, CancelTrigger, Envelope, EventSender, History, Instructions, McpCommand,
-    PromptRole, SharedMessages, ToolOutputLines,
+    PromptRole, SessionMailbox, SharedMessages, ToolOutputLines,
 };
 use maki_lua::EventHandle;
 use maki_providers::{AgentError, Message, Model, TokenUsage};
@@ -44,6 +44,7 @@ pub(super) struct AgentLoop {
     answer_rx: Arc<async_lock::Mutex<flume::Receiver<String>>>,
     queue: Arc<QueueReceiver>,
     session_id: Option<SessionRef>,
+    mailbox: Option<SessionMailbox>,
     timeouts: maki_providers::Timeouts,
     lua_handle: EventHandle,
     subagent_cancels: Arc<CancelMap<String>>,
@@ -66,6 +67,7 @@ impl AgentLoop {
         cancel_map: Arc<RunCancelMap>,
         init_cancel: CancelToken,
         session_id: Option<SessionRef>,
+        mailbox: Option<SessionMailbox>,
         timeouts: maki_providers::Timeouts,
         lua_handle: EventHandle,
         subagent_cancels: Arc<CancelMap<String>>,
@@ -90,6 +92,7 @@ impl AgentLoop {
             answer_rx: Arc::new(async_lock::Mutex::new(answer_rx)),
             queue,
             session_id,
+            mailbox,
             timeouts,
             lua_handle,
             subagent_cancels,
@@ -179,10 +182,6 @@ impl AgentLoop {
         }
         self.rebuild_tools(&slot.model, input.workflow);
 
-        for msg in std::mem::take(&mut input.preamble) {
-            self.history.push(msg);
-        }
-
         if let Some(ref prompt_ref) = input.prompt {
             let Some(ref mcp) = self.mcp else {
                 return Err(AgentError::Tool {
@@ -207,7 +206,7 @@ impl AgentLoop {
                     },
                     PromptRole::User => Message::user(text),
                 };
-                self.history.push(msg);
+                input.preamble.push(msg);
             }
         }
 
@@ -233,6 +232,7 @@ impl AgentLoop {
                 tool_output_lines: self.tool_output_lines,
                 permissions: Arc::clone(&self.permissions),
                 session_id: self.session_id.clone(),
+                mailbox: self.mailbox.clone(),
                 timeouts: self.timeouts,
                 file_tracker: Arc::clone(&self.file_tracker),
                 prompt_slots: Arc::new(prompt_slots),

--- a/maki-ui/src/agent/mod.rs
+++ b/maki-ui/src/agent/mod.rs
@@ -11,7 +11,7 @@ use arc_swap::ArcSwap;
 use maki_agent::permissions::PermissionManager;
 use maki_agent::{
     AgentConfig, CancelMap, CancelToken, Envelope, HistorySnapshot, McpCommand, McpConfigErrors,
-    McpHandle, McpSnapshotReader, SharedMessages, ToolOutputLines,
+    McpHandle, McpSnapshotReader, SessionMailbox, SharedMessages, ToolOutputLines,
 };
 use maki_lua::EventHandle;
 use maki_storage::id::SessionRef;
@@ -54,6 +54,7 @@ pub(crate) struct AgentHandles {
     pub(crate) mcp_config_errors: McpConfigErrors,
     pub(crate) queue: QueueSender,
     pub(crate) timeouts: maki_providers::Timeouts,
+    mailbox: Option<SessionMailbox>,
     task: smol::Task<()>,
 }
 
@@ -117,6 +118,13 @@ impl AgentHandles {
         if let Some(ref h) = self.mcp_handle {
             h.send(cmd);
         }
+    }
+
+    pub(crate) fn claim_mailbox_wake(&self) -> Vec<Message> {
+        self.mailbox
+            .as_ref()
+            .map(SessionMailbox::claim_wake)
+            .unwrap_or_default()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -220,6 +228,9 @@ fn spawn_agent_internal(
     let (init_trigger, init_cancel) = CancelToken::new();
     let cancel_map = Arc::new(new_run_cancel_map(0, init_trigger));
     let subagent_cancels: Arc<CancelMap<String>> = Arc::new(CancelMap::new());
+    let mailbox = session_id
+        .as_ref()
+        .map(|session_id| SessionMailbox::register(session_id.id()));
 
     spawn_command_router(
         cmd_rx,
@@ -242,6 +253,7 @@ fn spawn_agent_internal(
         cancel_map,
         init_cancel,
         session_id,
+        mailbox.clone(),
         timeouts,
         lua_handle,
         subagent_cancels,
@@ -260,6 +272,7 @@ fn spawn_agent_internal(
         mcp_config_errors,
         queue: queue_tx,
         timeouts,
+        mailbox,
         task,
     }
 }

--- a/maki-ui/src/app/queue.rs
+++ b/maki-ui/src/app/queue.rs
@@ -210,6 +210,18 @@ impl App {
         self.start_run(input, display)
     }
 
+    pub(crate) fn start_mailbox_run(
+        &mut self,
+        preamble: Vec<maki_providers::Message>,
+    ) -> Vec<Action> {
+        let mut input = self.build_agent_input(&QueuedMessage {
+            text: String::new(),
+            images: Vec::new(),
+        });
+        input.preamble = preamble;
+        self.start_run(input, String::new())
+    }
+
     /// The one place a fresh run starts: every path that emits
     /// `Action::SendMessage` must go through here so `run_id` bumps exactly
     /// once per run.
@@ -219,7 +231,9 @@ impl App {
         self.recoverable_queue.clear();
         self.status = Status::Streaming;
         self.fire_session_autocmd("TurnStart", serde_json::json!({}));
-        self.main_chat().show_user_message(display);
+        if !display.is_empty() {
+            self.main_chat().show_user_message(display);
+        }
         vec![Action::SendMessage(Box::new(input))]
     }
 }

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -213,6 +213,22 @@ fn typing_and_submit() {
     assert_eq!(app.main_chat().last_message_text(), "hi");
 }
 
+#[test]
+fn mailbox_wake_starts_without_an_empty_user_bubble() {
+    let mut app = test_app();
+    let actions = app.start_mailbox_run(vec![Message::observation("failed".into())]);
+
+    assert!(matches!(
+        &actions[..],
+        [Action::SendMessage(input)]
+            if input.message.is_empty()
+                && input.preamble.len() == 1
+                && input.preamble[0].is_observation()
+    ));
+    assert_eq!(app.status, Status::Streaming);
+    assert!(app.main_chat().segment_search_texts().is_empty());
+}
+
 fn with_text(app: &mut App) {
     app.update(Msg::Key(key(KeyCode::Char('h'))));
     app.update(Msg::Key(key(KeyCode::Char('i'))));
@@ -1975,6 +1991,31 @@ fn checkpoint_syncs_ephemeral_content_into_meta() {
     assert_eq!(session.meta.mode, Some(StoredMode::Build));
     assert_eq!(session.meta.queued_messages, vec!["queued".to_string()]);
     assert!(session_has_content(session));
+}
+
+#[test]
+fn checkpoint_persists_observations_without_using_them_as_title() {
+    let mut app = test_app();
+    let initial_title = app.state.session.title.clone();
+    let _history = attach_live_history(
+        &mut app,
+        vec![
+            Message::observation("build failed".into()),
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::Text {
+                    text: "I will fix it".into(),
+                }],
+                ..Default::default()
+            },
+        ],
+    );
+
+    app.checkpoint();
+
+    assert_eq!(app.state.session.messages().len(), 2);
+    assert!(app.state.session.messages()[0].is_observation());
+    assert_eq!(app.state.session.title, initial_title);
 }
 
 fn drain_writer(app: App, writer: Arc<StorageWriter>) {
@@ -3760,6 +3801,7 @@ fn tool_result_msg(id: &str, text: &str) -> Message {
             is_error: false,
         }],
         display_text: Some(String::new()),
+        ..Default::default()
     }
 }
 

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -398,6 +398,9 @@ pub fn history_to_display(
     let mut display = Vec::new();
     let mut restore_items: Vec<maki_lua::RestoreItem> = Vec::new();
     for msg in messages {
+        if msg.is_observation() {
+            continue;
+        }
         match msg.role {
             Role::User => {
                 if let Some(text) = msg.user_text() {
@@ -569,7 +572,7 @@ fn build_loaded_tool(
 fn build_tool_results_map(messages: &[Message]) -> HashMap<&str, (bool, &str)> {
     let mut map = HashMap::new();
     for msg in messages {
-        if !matches!(msg.role, Role::User) {
+        if !matches!(msg.role, Role::User) || msg.is_observation() {
             continue;
         }
         for block in &msg.content {
@@ -740,6 +743,24 @@ mod tests {
                 .0
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn history_hides_observations_but_keeps_the_reply() {
+        let msgs = vec![
+            Message::observation("build failed".into()),
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::Text {
+                    text: "I will fix it".into(),
+                }],
+                ..Default::default()
+            },
+        ];
+        let display = history_to_display(&msgs, &empty_outputs(), &ToolOutputLines::default()).0;
+        assert_eq!(display.len(), 1);
+        assert_eq!(display[0].role, DisplayRole::Assistant);
+        assert_eq!(display[0].text, "I will fix it");
     }
 
     fn tool_use_pair(

--- a/maki-ui/src/components/rewind_picker.rs
+++ b/maki-ui/src/components/rewind_picker.rs
@@ -43,7 +43,7 @@ impl RewindPicker {
         let mut turn_num = 0usize;
         let mut entries: Vec<RewindEntry> = Vec::new();
         for (msg_idx, msg) in messages.iter().enumerate() {
-            if !matches!(msg.role, Role::User) {
+            if !matches!(msg.role, Role::User) || msg.is_observation() {
                 continue;
             }
             let Some(full_text) = msg.user_text() else {
@@ -193,9 +193,10 @@ mod tests {
     }
 
     #[test]
-    fn synthetic_messages_are_excluded() {
+    fn synthetic_messages_and_observations_are_excluded() {
         let mut picker = RewindPicker::new();
         let msgs = vec![
+            Message::observation("build failed".into()),
             user_msg("real prompt"),
             assistant_msg(),
             Message::synthetic("[Cancelled by user]".into()),
@@ -203,7 +204,7 @@ mod tests {
         picker.open(&msgs).unwrap();
         let item = picker.picker.selected_item().unwrap();
         assert!(item.label().contains("real prompt"));
-        assert_eq!(item.turn_index, 0);
+        assert_eq!(item.turn_index, 1);
     }
 
     #[test]

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -111,6 +111,22 @@ impl SessionStatus {
     }
 }
 
+fn claim_idle_wake(
+    status: SessionStatus,
+    claim: impl FnOnce() -> Vec<Message>,
+) -> Option<Vec<Message>> {
+    if status != SessionStatus::Idle {
+        return None;
+    }
+    let preamble = claim();
+    (!preamble.is_empty()).then_some(preamble)
+}
+
+fn prepend_preamble(preamble: &mut Vec<Message>, mut leading: Vec<Message>) {
+    leading.append(preamble);
+    *preamble = leading;
+}
+
 fn parse_session_id(id: &str) -> Result<MakiId, String> {
     id.parse().map_err(|e: MakiIdParseError| e.to_string())
 }
@@ -548,6 +564,7 @@ impl<'t> EventLoop<'t> {
 
         self.emit_focus_change();
         self.emit_status_changes();
+        self.start_mailbox_runs();
         Ok(())
     }
 
@@ -634,6 +651,25 @@ impl<'t> EventLoop<'t> {
         self.ctx
             .lua_event_handle
             .fire_autocmd("SessionFocusChanged", data);
+    }
+
+    fn start_mailbox_runs(&mut self) {
+        let ready: Vec<_> = self
+            .sessions
+            .iter()
+            .enumerate()
+            .filter_map(|(index, runtime)| {
+                claim_idle_wake(SessionStatus::of(&runtime.app), || {
+                    runtime.handles.claim_mailbox_wake()
+                })
+                .map(|preamble| (index, preamble))
+            })
+            .collect();
+
+        for (index, preamble) in ready {
+            let actions = self.sessions[index].app.start_mailbox_run(preamble);
+            self.dispatch(index, actions);
+        }
     }
 
     /// `List` replies from a background task (the scan can be slow); every
@@ -927,7 +963,7 @@ impl<'t> EventLoop<'t> {
             Action::SendMessage(input) => {
                 let rt = &mut self.sessions[idx];
                 let mut input = *input;
-                input.preamble = rt.app.shell.drain_results();
+                prepend_preamble(&mut input.preamble, rt.app.shell.drain_results());
                 let run_id = rt.app.run_id;
                 rt.handles.queue.push(QueueItem::Message {
                     text: input.message.clone(),
@@ -1160,5 +1196,67 @@ fn scroll_delta(kind: MouseEventKind, lines: u32) -> i32 {
         lines as i32
     } else {
         -(lines as i32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+
+    const OBSERVATION: &str = "failed";
+    const SHELL_RESULT: &str = "command finished";
+
+    #[test]
+    fn idle_wake_claims_a_non_empty_preamble() {
+        let preamble = claim_idle_wake(SessionStatus::Idle, || {
+            vec![Message::observation(OBSERVATION.into())]
+        })
+        .unwrap();
+
+        assert_eq!(preamble.len(), 1);
+        assert_eq!(preamble[0].user_text(), Some(OBSERVATION));
+    }
+
+    #[test]
+    fn idle_without_messages_and_non_idle_sessions_do_not_start() {
+        assert!(claim_idle_wake(SessionStatus::Idle, Vec::new).is_none());
+
+        for status in [SessionStatus::Working, SessionStatus::NeedsInput] {
+            let called = Cell::new(false);
+            let preamble = claim_idle_wake(status, || {
+                called.set(true);
+                vec![Message::observation(OBSERVATION.into())]
+            });
+
+            assert!(preamble.is_none());
+            assert!(!called.get());
+        }
+    }
+
+    #[test]
+    fn wake_arriving_while_working_runs_when_idle() {
+        let id = maki_storage::id::MakiId::generate();
+        let mailbox = maki_agent::SessionMailbox::register(id);
+        maki_agent::SessionMailbox::notify(id, OBSERVATION.into(), true).unwrap();
+
+        assert!(claim_idle_wake(SessionStatus::Working, || mailbox.claim_wake()).is_none());
+        let preamble = claim_idle_wake(SessionStatus::Idle, || mailbox.claim_wake()).unwrap();
+        assert_eq!(preamble.len(), 1);
+        assert_eq!(preamble[0].user_text(), Some(OBSERVATION));
+    }
+
+    #[test]
+    fn shell_results_do_not_replace_existing_preamble() {
+        let mut preamble = vec![Message::observation(OBSERVATION.into())];
+
+        prepend_preamble(
+            &mut preamble,
+            vec![Message::observation(SHELL_RESULT.into())],
+        );
+
+        let text = preamble.iter().map(Message::user_text).collect::<Vec<_>>();
+        assert_eq!(text, [Some(SHELL_RESULT), Some(OBSERVATION)]);
     }
 }

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -2514,9 +2514,9 @@ end
 
 Host session primitives. The interactive UI can run several sessions
 at once; these functions let plugins list, create, focus, rename, and
-delete them. Every call round-trips to the UI event loop and returns
-the pair `(value, err)`. Without an interactive UI attached, every
-call returns `nil, "no interactive UI attached"`.
+delete them. Session management returns `nil, "no interactive UI
+attached"` without a UI. `notify` instead targets a live agent mailbox
+directly, so it also works under ACP and SDK frontends.
 
 ---
 
@@ -2671,6 +2671,32 @@ the prompt is queued and picked up when the agent reaches it.
 
 ```lua
 local state, err = maki.session.prompt("run the tests", { session = id })
+```
+
+---
+
+### `maki.session.notify()` {#maki-session-notify}
+
+```lua
+maki.session.notify({text}, {opts?})
+```
+
+Reports {text} to a live session without creating a user turn. The
+observation waits for the session's next agent run.
+
+**Parameters:**
+
+- `{text}` (`string`) What to report. Must not be blank.
+- `{opts?}` (`table`) Options:
+  - `session` (`string`) id of a live session.
+  - `wake` (`boolean`) start a TUI turn when it next becomes idle (default false).
+
+**Returns:** (`boolean|nil`, `string|nil`) true, or nil and an error.
+
+**Example:**
+
+```lua
+maki.session.notify("[monitor] deploy failed", { session = id, wake = true })
 ```
 
 ---


### PR DESCRIPTION
Part of #676.

## What changed

- `MessageKind::Observation` distinguishes host-reported output from a user turn without relying on a spoofable prefix.
- A process-local, bounded `SessionMailbox` lives in `maki-agent` beside shared `AgentInput` ingestion. It keeps the newest 100 observations.
- TUI, headless, SDK, ACP, and subagent paths all use that boundary, including queued input.
- `maki.session.notify(text, opts)` is synchronous, so job callbacks can post without yielding.
- Quiet observations ride with the next ordinary run. `wake = true` starts one TUI run only after the session becomes idle, including when the notification arrived mid-stream.
- Observations remain in stored and compaction history for provider-valid conversation order. They stay hidden from TUI history, ACP replay, rewind entries, and generated titles.

The TUI does not render an empty user bubble for wake-only runs. Non-TUI frontends do not synthesize runs; their next input drains the mailbox.

## Validation

Formatting, strict clippy, 3,482 workspace tests, doctests, generated docs, dependency analysis, coverage, and focused mailbox mutation tests pass locally. `just ci` reaches only nine existing Python lint findings in unchanged `scripts/`.

The monitor itself is intentionally not bundled. It lives at https://github.com/laudney/maki-monitor.

---

AI use, per CONTRIBUTING: implemented and reviewed with Codex and Claude Code at my direction.
