### PR TITLE
feat(lua): give every job an owner and one store to live in

### DIFF
--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::{Command, Stdio};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
@@ -13,7 +14,7 @@ use crate::api::fs::expand_tilde;
 use crate::api::util::command::{UiAction, ui_roundtrip, ui_send};
 use crate::api::util::pair::{Pair, try_pair};
 use crate::plugin_permissions::PluginPermissions;
-use crate::runtime::with_task_jobs;
+use crate::runtime::{active_task_id, with_jobs};
 
 const READER_BUF_SIZE: usize = 8 * 1024;
 
@@ -24,9 +25,15 @@ pub(crate) enum JobEvent {
     Exit(i32),
 }
 
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) enum JobOwner {
+    Task(u64),
+    Plugin(Arc<str>),
+}
+
 struct JobMeta {
+    owner: JobOwner,
     pid: u32,
-    alive: bool,
     on_stdout: Option<RegistryKey>,
     on_stderr: Option<RegistryKey>,
     on_exit: Option<RegistryKey>,
@@ -38,6 +45,12 @@ pub(crate) struct JobStore {
     next_id: u32,
 }
 
+struct CheckedOutReceiver {
+    lua: Lua,
+    job_id: u32,
+    receiver: Option<flume::Receiver<JobEvent>>,
+}
+
 impl JobStore {
     pub fn new() -> Self {
         Self {
@@ -46,8 +59,10 @@ impl JobStore {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn start(
         &mut self,
+        owner: JobOwner,
         cmd: &str,
         cwd: Option<String>,
         env: Option<HashMap<String, String>>,
@@ -138,8 +153,8 @@ impl JobStore {
         self.jobs.insert(
             id,
             JobMeta {
+                owner,
                 pid,
-                alive: true,
                 on_stdout,
                 on_stderr,
                 on_exit,
@@ -150,12 +165,8 @@ impl JobStore {
         Ok(id)
     }
 
-    pub fn has_alive_jobs(&self) -> bool {
-        self.jobs.values().any(|j| j.alive)
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.jobs.is_empty()
+    pub fn is_empty(&self, owner: &JobOwner) -> bool {
+        !self.jobs.values().any(|job| job.owner == *owner)
     }
 
     pub fn callback_key(&self, job_id: u32, event: &JobEvent) -> Option<&RegistryKey> {
@@ -167,15 +178,29 @@ impl JobStore {
         }
     }
 
-    pub fn take_receiver(&mut self, job_id: u32) -> Option<flume::Receiver<JobEvent>> {
-        let meta = self.jobs.get_mut(&job_id)?;
-        meta.event_rx.take()
+    pub fn take_receiver(
+        &mut self,
+        job_id: u32,
+        task_id: Option<u64>,
+        plugin: &str,
+    ) -> Option<flume::Receiver<JobEvent>> {
+        let job = self.jobs.get_mut(&job_id)?;
+        job.can_access(task_id, plugin)
+            .then(|| job.event_rx.take())?
     }
 
-    pub fn drain_events(&self, buf: &mut Vec<(u32, JobEvent)>) {
+    pub fn restore_receiver(&mut self, job_id: u32, receiver: flume::Receiver<JobEvent>) {
+        if let Some(job) = self.jobs.get_mut(&job_id)
+            && job.event_rx.is_none()
+        {
+            job.event_rx = Some(receiver);
+        }
+    }
+
+    pub fn drain_events(&self, owner: &JobOwner, buf: &mut Vec<(u32, JobEvent)>) {
         buf.clear();
-        for (&id, meta) in &self.jobs {
-            if let Some(ref rx) = meta.event_rx {
+        for (&id, job) in self.jobs.iter().filter(|(_, job)| job.owner == *owner) {
+            if let Some(ref rx) = job.event_rx {
                 while let Ok(event) = rx.try_recv() {
                     buf.push((id, event));
                 }
@@ -183,31 +208,50 @@ impl JobStore {
         }
     }
 
-    pub fn mark_dead(&mut self, job_id: u32) {
-        if let Some(meta) = self.jobs.get_mut(&job_id) {
-            meta.alive = false;
-        }
-    }
-
-    pub fn kill(&mut self, job_id: u32) {
-        if let Some(meta) = self.jobs.get_mut(&job_id)
-            && meta.alive
+    pub fn drain_plugin_events(&self, buf: &mut Vec<(u32, JobEvent)>) {
+        buf.clear();
+        for (&id, job) in self
+            .jobs
+            .iter()
+            .filter(|(_, job)| matches!(job.owner, JobOwner::Plugin(_)))
         {
-            kill_job(meta);
-        }
-    }
-
-    pub fn kill_all(&mut self) {
-        for meta in self.jobs.values_mut() {
-            if meta.alive {
-                kill_job(meta);
+            if let Some(ref rx) = job.event_rx {
+                while let Ok(event) = rx.try_recv() {
+                    buf.push((id, event));
+                }
             }
         }
     }
 
-    pub fn clear(&mut self, lua: &Lua) {
-        for (_, meta) in self.jobs.drain() {
-            for key in [meta.on_stdout, meta.on_stderr, meta.on_exit]
+    pub fn kill(&mut self, job_id: u32, task_id: Option<u64>, plugin: &str) {
+        if let Some(job) = self.jobs.get_mut(&job_id)
+            && job.can_access(task_id, plugin)
+        {
+            kill_job(job);
+        }
+    }
+
+    pub fn kill_owner(&mut self, lua: &Lua, owner: &JobOwner) {
+        let ids = self
+            .jobs
+            .iter()
+            .filter_map(|(&id, job)| (job.owner == *owner).then_some(id))
+            .collect::<Vec<_>>();
+        for id in ids {
+            self.remove(lua, id, true);
+        }
+    }
+
+    pub fn finish(&mut self, lua: &Lua, job_id: u32) {
+        self.remove(lua, job_id, false);
+    }
+
+    fn remove(&mut self, lua: &Lua, job_id: u32, kill: bool) {
+        if let Some(mut job) = self.jobs.remove(&job_id) {
+            if kill {
+                kill_job(&mut job);
+            }
+            for key in [job.on_stdout, job.on_stderr, job.on_exit]
                 .into_iter()
                 .flatten()
             {
@@ -215,15 +259,50 @@ impl JobStore {
             }
         }
     }
+
+    fn kill_all(&mut self) {
+        for job in self.jobs.values_mut() {
+            kill_job(job);
+        }
+    }
 }
 
-/// Every job is its own process group, so one we forget keeps running
-/// after maki is gone. `TaskScope::drop` handles the usual path; this
-/// catches the rest, like the warm click cell that is dropped without a
-/// scope, and a panic unwinding past the cleanup.
 impl Drop for JobStore {
     fn drop(&mut self) {
         self.kill_all();
+    }
+}
+
+impl CheckedOutReceiver {
+    fn new(lua: &Lua, job_id: u32, receiver: flume::Receiver<JobEvent>) -> Self {
+        Self {
+            lua: lua.clone(),
+            job_id,
+            receiver: Some(receiver),
+        }
+    }
+
+    fn get(&self) -> &flume::Receiver<JobEvent> {
+        self.receiver.as_ref().expect("receiver is checked out")
+    }
+}
+
+impl Drop for CheckedOutReceiver {
+    fn drop(&mut self) {
+        if let Some(receiver) = self.receiver.take() {
+            with_jobs(&self.lua, |store| {
+                store.restore_receiver(self.job_id, receiver);
+            });
+        }
+    }
+}
+
+impl JobMeta {
+    fn can_access(&self, task_id: Option<u64>, plugin: &str) -> bool {
+        match &self.owner {
+            JobOwner::Task(owner_id) => task_id == Some(*owner_id),
+            JobOwner::Plugin(owner_plugin) => owner_plugin.as_ref() == plugin,
+        }
     }
 }
 
@@ -277,6 +356,9 @@ fn kill_job(meta: &mut JobMeta) {
 ///   `on_stdout` (function?) called with `(job_id, line)` for each stdout line.
 ///   `on_stderr` (function?) called with `(job_id, line)` for each stderr line.
 ///   `on_exit` (function?) called with `(job_id, code)` when the process finishes.
+///   `owner` (string?) job lifetime. `"task"` (default) ends the job with
+///     the current call. `"plugin"` keeps it alive until the plugin unloads
+///     or reloads.
 /// @return (integer) Job id.
 /// @example
 /// local id = maki.fn.jobstart("ls -la", {
@@ -285,7 +367,29 @@ fn kill_job(meta: &mut JobMeta) {
 ///   on_exit = function(_, code) print("exit: " .. code) end,
 /// })
 #[lua_fn(guard = Run)]
-fn jobstart(lua: &Lua, cmd: String, opts: Option<Table>) -> LuaResult<u32> {
+fn jobstart(
+    lua: &Lua,
+    #[ctx] plugin: Arc<str>,
+    cmd: String,
+    opts: Option<Table>,
+) -> LuaResult<u32> {
+    let owner_name: Option<String> = opts
+        .as_ref()
+        .map(|opts| opts.get("owner"))
+        .transpose()?
+        .flatten();
+    let owner = match owner_name.as_deref() {
+        None | Some("task") => active_task_id(lua).map(JobOwner::Task).ok_or_else(|| {
+            mlua::Error::runtime("jobstart: no active task; use owner = \"plugin\"")
+        })?,
+        Some("plugin") => JobOwner::Plugin(Arc::clone(&plugin)),
+        Some(other) => {
+            return Err(mlua::Error::runtime(format!(
+                "jobstart: unknown owner {other:?}; expected \"task\" or \"plugin\""
+            )));
+        }
+    };
+
     let (cwd, env, on_stdout, on_stderr, on_exit) = match opts {
         Some(ref opts) => {
             let cwd: Option<String> = opts.get("cwd").ok();
@@ -313,8 +417,8 @@ fn jobstart(lua: &Lua, cmd: String, opts: Option<Table>) -> LuaResult<u32> {
         None => (None, None, None, None, None),
     };
 
-    with_task_jobs(lua, |store| {
-        store.start(&cmd, cwd, env, on_stdout, on_stderr, on_exit)
+    with_jobs(lua, |store| {
+        store.start(owner, &cmd, cwd, env, on_stdout, on_stderr, on_exit)
     })
     .map_err(mlua::Error::runtime)
 }
@@ -327,8 +431,9 @@ fn jobstart(lua: &Lua, cmd: String, opts: Option<Table>) -> LuaResult<u32> {
 /// @example
 /// maki.fn.jobstop(id)
 #[lua_fn(guard = Run)]
-fn jobstop(lua: &Lua, job_id: u32) -> LuaResult<()> {
-    with_task_jobs(lua, |store| store.kill(job_id));
+fn jobstop(lua: &Lua, #[ctx] plugin: Arc<str>, job_id: u32) -> LuaResult<()> {
+    let task_id = active_task_id(lua);
+    with_jobs(lua, |store| store.kill(job_id, task_id, &plugin));
     Ok(())
 }
 
@@ -350,9 +455,16 @@ fn jobstop(lua: &Lua, job_id: u32) -> LuaResult<()> {
 ///   print(result.stdout)
 /// end
 #[lua_fn(guard = Run)]
-async fn jobwait(lua: Lua, job_id: u32, timeout_ms: Option<u64>) -> LuaResult<Value> {
-    let rx = with_task_jobs(&lua, |store| store.take_receiver(job_id))
+async fn jobwait(
+    lua: Lua,
+    #[ctx] plugin: Arc<str>,
+    job_id: u32,
+    timeout_ms: Option<u64>,
+) -> LuaResult<Value> {
+    let task_id = active_task_id(&lua);
+    let receiver = with_jobs(&lua, |store| store.take_receiver(job_id, task_id, &plugin))
         .ok_or_else(|| mlua::Error::runtime("unknown job id or already waited"))?;
+    let receiver = CheckedOutReceiver::new(&lua, job_id, receiver);
 
     let timeout = Duration::from_millis(timeout_ms.unwrap_or(30_000));
     let deadline = smol::Timer::after(timeout);
@@ -362,11 +474,12 @@ async fn jobwait(lua: Lua, job_id: u32, timeout_ms: Option<u64>) -> LuaResult<Va
     let mut stderr_lines = Vec::new();
 
     let exit_code = loop {
-        let event = futures_lite::future::or(async { rx.recv_async().await.ok() }, async {
-            (&mut deadline).await;
-            None
-        })
-        .await;
+        let event =
+            futures_lite::future::or(async { receiver.get().recv_async().await.ok() }, async {
+                (&mut deadline).await;
+                None
+            })
+            .await;
 
         let Some(event) = event else {
             return Ok(mlua::Value::Nil);
@@ -390,11 +503,14 @@ async fn jobwait(lua: Lua, job_id: u32, timeout_ms: Option<u64>) -> LuaResult<Va
 /// dead on exit. Shared by `jobwait` and the async dispatch loop so
 /// both deliver events identically.
 pub(crate) fn deliver_job_event(lua: &Lua, job_id: u32, event: &JobEvent) -> LuaResult<()> {
-    let callback = with_task_jobs(lua, |store| {
+    let callback = with_jobs(lua, |store| {
         store
             .callback_key(job_id, event)
             .and_then(|key| lua.registry_value::<Function>(key).ok())
     });
+    if let JobEvent::Exit(_) = event {
+        with_jobs(lua, |store| store.finish(lua, job_id));
+    }
     if let Some(callback) = callback {
         let arg = match event {
             JobEvent::Stdout(line) | JobEvent::Stderr(line) => {
@@ -403,9 +519,6 @@ pub(crate) fn deliver_job_event(lua: &Lua, job_id: u32, event: &JobEvent) -> Lua
             JobEvent::Exit(code) => Value::Integer(*code as i64),
         };
         callback.call::<()>((job_id, arg))?;
-    }
-    if let JobEvent::Exit(_) = event {
-        with_task_jobs(lua, |store| store.mark_dead(job_id));
     }
     Ok(())
 }
@@ -495,10 +608,11 @@ lua_table! {
     /// })
     /// ```
     "maki.fn" => pub(crate) fn create_fn_table(
+        plugin: Arc<str>,
         perms: &PluginPermissions,
         tx: Option<flume::Sender<UiAction>>,
     ), DOCS [
-        jobstart(perms), jobstop(perms), jobwait(perms), executable(perms),
+        jobstart(perms, plugin), jobstop(perms, plugin), jobwait(perms, plugin), executable(perms),
         winsaveview(tx), winrestview(tx),
     ]
 }
@@ -508,13 +622,23 @@ mod tests {
     use super::*;
     use crate::api::util::command::{NO_UI_ERR, WinView};
 
+    const TEST_PLUGIN: &str = "test-plugin";
+
     fn make_store() -> JobStore {
         JobStore::new()
     }
 
+    fn task_owner(id: u64) -> JobOwner {
+        JobOwner::Task(id)
+    }
+
+    fn plugin_owner() -> JobOwner {
+        JobOwner::Plugin(Arc::from(TEST_PLUGIN))
+    }
+
     fn start_echo(store: &mut JobStore) -> u32 {
         store
-            .start("echo hello", None, None, None, None, None)
+            .start(task_owner(1), "echo hello", None, None, None, None, None)
             .unwrap()
     }
 
@@ -527,31 +651,37 @@ mod tests {
             .is_some_and(|pid| test_kill_process_group(pid).is_ok())
     }
 
-    /// The warm click cell is dropped without ever going through
-    /// `TaskScope`, so without this the process outlives maki.
+    #[cfg(unix)]
+    fn wait_for_group_exit(pid: u32) -> bool {
+        (0..500).any(|_| {
+            thread::sleep(Duration::from_millis(10));
+            !group_alive(pid)
+        })
+    }
+
     #[cfg(unix)]
     #[test]
     fn dropping_the_store_kills_its_jobs() {
         let mut store = make_store();
         let id = store
-            .start("sleep 30", None, None, None, None, None)
+            .start(task_owner(1), "sleep 30", None, None, None, None, None)
             .expect("job started");
         let pid = store.jobs[&id].pid;
         assert!(group_alive(pid), "job should be running before the drop");
 
         drop(store);
 
-        let gone = (0..500).any(|_| {
-            std::thread::sleep(std::time::Duration::from_millis(10));
-            !group_alive(pid)
-        });
-        assert!(gone, "dropping the store must not orphan the process group");
+        assert!(
+            wait_for_group_exit(pid),
+            "dropping the store must not orphan the process group"
+        );
     }
 
     #[test]
     fn start_invalid_cwd_returns_error() {
         let mut store = make_store();
         let result = store.start(
+            task_owner(1),
             "echo hello",
             Some("/nonexistent_dir_abc_xyz_123".into()),
             None,
@@ -563,41 +693,102 @@ mod tests {
     }
 
     #[test]
-    fn has_alive_jobs_tracks_state() {
+    fn finishing_a_job_removes_it() {
+        let lua = Lua::new();
         let mut store = make_store();
-        assert!(!store.has_alive_jobs());
+        let owner = task_owner(1);
+        assert!(store.is_empty(&owner));
 
         let id = start_echo(&mut store);
-        assert!(store.has_alive_jobs());
+        assert!(!store.is_empty(&owner));
+        let receiver = store.take_receiver(id, Some(1), TEST_PLUGIN).unwrap();
+        while !matches!(
+            receiver.recv_timeout(Duration::from_secs(5)).unwrap(),
+            JobEvent::Exit(_)
+        ) {}
 
-        store.mark_dead(id);
-        assert!(!store.has_alive_jobs());
+        store.finish(&lua, id);
+        assert!(store.is_empty(&owner));
     }
 
     #[test]
-    fn noop_on_nonexistent_or_dead_jobs() {
+    fn unknown_job_operations_are_noops() {
         let mut store = make_store();
-        store.mark_dead(999);
-        store.kill(999);
-
-        let id = start_echo(&mut store);
-        store.mark_dead(id);
-        store.kill(id);
-
+        store.kill(999, Some(1), TEST_PLUGIN);
+        assert!(store.take_receiver(999, Some(1), TEST_PLUGIN).is_none());
         assert!(store.callback_key(999, &JobEvent::Exit(0)).is_none());
     }
 
     #[test]
     fn take_receiver_lifecycle() {
         let mut store = make_store();
-        assert!(store.take_receiver(999).is_none());
+        assert!(store.take_receiver(999, Some(1), TEST_PLUGIN).is_none());
 
         let id = start_echo(&mut store);
-        assert!(store.take_receiver(id).is_some());
         assert!(
-            store.take_receiver(id).is_none(),
+            store.take_receiver(id, Some(2), TEST_PLUGIN).is_none(),
+            "another task must not access the job"
+        );
+        assert!(store.take_receiver(id, Some(1), TEST_PLUGIN).is_some());
+        assert!(
+            store.take_receiver(id, Some(1), TEST_PLUGIN).is_none(),
             "second take should fail (receiver already moved)"
         );
+    }
+
+    #[test]
+    fn plugin_owner_can_be_accessed_only_by_its_plugin() {
+        let mut store = make_store();
+        let id = store
+            .start(plugin_owner(), "echo hello", None, None, None, None, None)
+            .unwrap();
+
+        assert!(store.take_receiver(id, Some(1), "other-plugin").is_none());
+        assert!(store.take_receiver(id, None, TEST_PLUGIN).is_some());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn kill_requires_owner_access() {
+        let lua = Lua::new();
+        let mut store = make_store();
+        let id = store
+            .start(task_owner(1), "sleep 30", None, None, None, None, None)
+            .unwrap();
+        let pid = store.jobs[&id].pid;
+
+        store.kill(id, Some(2), TEST_PLUGIN);
+        assert!(group_alive(pid));
+
+        store.kill(id, Some(1), TEST_PLUGIN);
+        assert!(wait_for_group_exit(pid));
+        store.finish(&lua, id);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owner_cleanup_is_isolated() {
+        let lua = Lua::new();
+        let mut store = make_store();
+        let task = task_owner(1);
+        let plugin = plugin_owner();
+        let task_id = store
+            .start(task.clone(), "sleep 30", None, None, None, None, None)
+            .unwrap();
+        let plugin_id = store
+            .start(plugin.clone(), "sleep 30", None, None, None, None, None)
+            .unwrap();
+        let task_pid = store.jobs[&task_id].pid;
+        let plugin_pid = store.jobs[&plugin_id].pid;
+
+        store.kill_owner(&lua, &task);
+
+        assert!(store.is_empty(&task));
+        assert!(!store.is_empty(&plugin));
+        assert!(wait_for_group_exit(task_pid));
+        assert!(group_alive(plugin_pid));
+        store.kill_owner(&lua, &plugin);
+        assert!(wait_for_group_exit(plugin_pid));
     }
 
     #[test]
@@ -621,7 +812,7 @@ mod tests {
     fn take_receiver_delivers_events() {
         let mut store = make_store();
         let id = start_echo(&mut store);
-        let rx = store.take_receiver(id).unwrap();
+        let rx = store.take_receiver(id, Some(1), TEST_PLUGIN).unwrap();
 
         let mut got_exit = false;
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
@@ -640,14 +831,17 @@ mod tests {
     }
 
     #[test]
-    fn drain_events_collects_from_all_jobs() {
+    fn drain_events_filters_by_owner() {
         let mut store = make_store();
         let id = start_echo(&mut store);
+        let plugin_id = store
+            .start(plugin_owner(), "echo plugin", None, None, None, None, None)
+            .unwrap();
 
         let mut buf = Vec::new();
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         loop {
-            store.drain_events(&mut buf);
+            store.drain_events(&task_owner(1), &mut buf);
             if buf
                 .iter()
                 .any(|(jid, e)| *jid == id && matches!(e, JobEvent::Exit(_)))
@@ -659,16 +853,33 @@ mod tests {
             }
             std::thread::sleep(Duration::from_millis(50));
         }
+        assert!(buf.iter().all(|(job_id, _)| *job_id != plugin_id));
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            store.drain_plugin_events(&mut buf);
+            if buf
+                .iter()
+                .any(|(job_id, event)| *job_id == plugin_id && matches!(event, JobEvent::Exit(_)))
+            {
+                break;
+            }
+            if std::time::Instant::now() > deadline {
+                panic!("should receive plugin job exit event");
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+        assert!(buf.iter().all(|(job_id, _)| *job_id != id));
     }
 
     #[test]
     fn drain_events_empty_after_take() {
         let mut store = make_store();
         let id = start_echo(&mut store);
-        let _rx = store.take_receiver(id).unwrap();
+        let _rx = store.take_receiver(id, Some(1), TEST_PLUGIN).unwrap();
 
         let mut buf = Vec::new();
-        store.drain_events(&mut buf);
+        store.drain_events(&task_owner(1), &mut buf);
         assert!(
             buf.is_empty(),
             "drained receiver yields no events via drain_events"
@@ -741,5 +952,63 @@ mod tests {
             panic!("expected winrestview request");
         };
         assert_eq!(scroll_top, expected);
+    }
+
+    #[test]
+    fn exit_cleanup_runs_before_a_failing_callback() {
+        let lua = Lua::new();
+        lua.set_app_data(JobStore::new());
+        let callback = lua
+            .create_function(|_, ()| Err::<(), _>(mlua::Error::runtime("callback failed")))
+            .unwrap();
+        let callback_key = lua.create_registry_value(callback).unwrap();
+        with_jobs(&lua, |store| {
+            store.jobs.insert(
+                1,
+                JobMeta {
+                    owner: task_owner(1),
+                    pid: 0,
+                    on_stdout: None,
+                    on_stderr: None,
+                    on_exit: Some(callback_key),
+                    event_rx: None,
+                },
+            );
+        });
+
+        assert!(deliver_job_event(&lua, 1, &JobEvent::Exit(0)).is_err());
+        assert!(with_jobs(&lua, |store| store.is_empty(&task_owner(1))));
+    }
+
+    #[test]
+    fn finish_releases_callback_registry_values() {
+        let lua = Lua::new();
+        let capture = Arc::new(());
+        let callback_capture = Arc::clone(&capture);
+        let callback = lua
+            .create_function(move |_, ()| {
+                let _ = &callback_capture;
+                Ok(())
+            })
+            .unwrap();
+        let callback_key = lua.create_registry_value(callback).unwrap();
+        let mut store = make_store();
+        store.jobs.insert(
+            1,
+            JobMeta {
+                owner: task_owner(1),
+                pid: 0,
+                on_stdout: Some(callback_key),
+                on_stderr: None,
+                on_exit: None,
+                event_rx: None,
+            },
+        );
+        assert_eq!(Arc::strong_count(&capture), 2);
+
+        store.finish(&lua, 1);
+        lua.gc_collect().unwrap();
+
+        assert_eq!(Arc::strong_count(&capture), 1);
     }
 }

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -65,7 +65,10 @@ pub(crate) fn create_maki_global(
         "ui",
         ui::create_ui_table(lua, ui_action_tx.clone(), Arc::clone(&plugin))?,
     )?;
-    maki.set("fn", r#fn::create_fn_table(lua, permissions, ui_action_tx)?)?;
+    maki.set(
+        "fn",
+        r#fn::create_fn_table(lua, Arc::clone(&plugin), permissions, ui_action_tx)?,
+    )?;
     split::split__register(&maki, lua)?;
     maki.set("async", r#async::create_async_table(lua)?)?;
     maki.set(

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::ptr;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
@@ -28,7 +28,7 @@ use maki_config::RawConfig;
 
 use crate::api::autocmd::AutocmdStore;
 use crate::api::create_maki_global;
-use crate::api::r#fn::{JobStore, deliver_job_event};
+use crate::api::r#fn::{JobOwner, JobStore, deliver_job_event};
 use crate::api::keymap::KeymapReader;
 use crate::api::keymap::{KeymapStore, KeymapWriter};
 use crate::api::options::{PluginOptionSpecs, PluginOpts, collect_plugin_options};
@@ -83,6 +83,7 @@ const ASYNC_RUN_DEFAULT_DEADLINE: Duration = Duration::from_secs(60);
 const RESTORE_SPAWN_ROUNDS: usize = 8;
 /// Keeps a buggy plugin's restore task from freezing the lua loop.
 const RESTORE_ASYNC_DEADLINE: Duration = Duration::from_secs(10);
+static NEXT_TASK_ID: AtomicU64 = AtomicU64::new(1);
 /// Hard cap on one whole restore item. The watchdog interrupt only lands
 /// while Lua runs, so a restore parked on a never-resolving await would otherwise
 /// hold its gate slot forever and deadlock `gate.drain()` in the dispatcher.
@@ -299,13 +300,13 @@ enum KillReason {
 /// Lua is single-threaded so this Mutex never contends, but
 /// `Lua::app_data` requires `Send + Sync` with the `send` feature.
 pub(crate) struct TaskCell {
+    pub(crate) id: u64,
     pub(crate) cancel: CancelToken,
     /// End of the current [`KILL_GRACE`], armed by the first watchdog poke
     /// that sees a doomed task and cleared at every yield.
     kill_at: Cell<Option<Instant>>,
     pub(crate) deadline: Cell<Option<Instant>>,
     pub(crate) deadline_secs: Cell<Option<u64>>,
-    pub(crate) jobs: JobStore,
     pub(crate) bufs: BufferStore,
     pub(crate) live: Option<LiveCtx>,
     /// The buf that owns click routing for this task: the last one passed
@@ -334,11 +335,11 @@ impl TaskCell {
         live: Option<LiveCtx>,
     ) -> Self {
         Self {
+            id: NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed),
             cancel,
             kill_at: Cell::new(None),
             deadline: Cell::new(deadline),
             deadline_secs: Cell::new(None),
-            jobs: JobStore::new(),
             bufs: BufferStore::new(),
             live,
             root_buf: None,
@@ -792,7 +793,8 @@ pub(crate) async fn run_detached<F: Future>(lua: &Lua, fut: F) -> F::Output {
     let pump = async {
         let mut event_buf = Vec::new();
         loop {
-            lock_cell(&handle).jobs.drain_events(&mut event_buf);
+            let owner = JobOwner::Task(lock_cell(&handle).id);
+            with_jobs(lua, |store| store.drain_events(&owner, &mut event_buf));
             for (job_id, event) in event_buf.drain(..) {
                 if let Err(e) = deliver_job_event(lua, job_id, &event) {
                     tracing::warn!(error = %strip_traceback(&e), "detached job callback failed");
@@ -808,12 +810,14 @@ pub(crate) async fn run_detached<F: Future>(lua: &Lua, fut: F) -> F::Output {
 
 impl Drop for TaskScope {
     fn drop(&mut self) {
-        {
+        let task_id = {
             let mut cell = lock_cell(&self.handle);
-            cell.jobs.kill_all();
-            cell.jobs.clear(&self.lua);
             cell.clear_cancel_hooks(&self.lua);
-        }
+            cell.id
+        };
+        with_jobs(&self.lua, |store| {
+            store.kill_owner(&self.lua, &JobOwner::Task(task_id));
+        });
         match self.prev.take() {
             Some(p) => {
                 self.lua.set_app_data(p);
@@ -888,8 +892,19 @@ pub(crate) fn active_task(lua: &Lua) -> TaskHandle {
         .expect("task accessor called outside a task scope")
 }
 
-pub(crate) fn with_task_jobs<R>(lua: &Lua, f: impl FnOnce(&mut JobStore) -> R) -> R {
-    f(&mut lock_cell(&active_task(lua)).jobs)
+pub(crate) fn with_jobs<R>(lua: &Lua, f: impl FnOnce(&mut JobStore) -> R) -> R {
+    if lua.app_data_ref::<JobStore>().is_none() {
+        lua.set_app_data(JobStore::new());
+    }
+    let mut store = lua
+        .app_data_mut::<JobStore>()
+        .expect("job store was just installed");
+    f(&mut store)
+}
+
+pub(crate) fn active_task_id(lua: &Lua) -> Option<u64> {
+    let handle = lua.app_data_ref::<TaskHandle>()?;
+    Some(lock_cell(&handle).id)
 }
 
 pub(crate) fn with_task_bufs<R>(lua: &Lua, f: impl FnOnce(&mut BufferStore) -> R) -> R {
@@ -1316,6 +1331,7 @@ impl LuaRuntime {
         })?;
 
         lua.set_app_data(CommandHandlerMap::new());
+        lua.set_app_data(JobStore::new());
         lua.set_app_data(SpawnQueue::new());
         lua.set_app_data(command_writer);
         lua.set_app_data(PromptHintCallbacks::default());
@@ -1390,6 +1406,9 @@ impl LuaRuntime {
 
     fn drop_plugin_keys(&mut self, name: &str) {
         self.warm_tools.borrow_mut().clear();
+        with_jobs(&self.lua, |store| {
+            store.kill_owner(&self.lua, &JobOwner::Plugin(Arc::from(name)));
+        });
         if let Some(mut store) = self.lua.app_data_mut::<PluginOptionSpecs>() {
             store.remove(name);
         }
@@ -2098,7 +2117,8 @@ async fn dispatch_async(
     tool: &str,
     finish_rx: flume::Receiver<ToolCallReply>,
 ) -> ToolCallReply {
-    if lock_cell(&handle).jobs.is_empty() {
+    let owner = JobOwner::Task(lock_cell(&handle).id);
+    if with_jobs(lua, |store| store.is_empty(&owner)) {
         lua.gc_collect().ok();
         smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
         return match finish_rx.try_recv() {
@@ -2128,11 +2148,10 @@ async fn dispatch_async(
             Err(flume::TryRecvError::Empty) => {}
         }
 
-        lock_cell(&handle).jobs.drain_events(&mut event_buf);
+        with_jobs(lua, |store| store.drain_events(&owner, &mut event_buf));
 
         if event_buf.is_empty() {
-            let has_alive = lock_cell(&handle).jobs.has_alive_jobs();
-            if !has_alive {
+            if with_jobs(lua, |store| store.is_empty(&owner)) {
                 smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
                 return match finish_rx.try_recv() {
                     Ok(reply) => reply,
@@ -2423,6 +2442,31 @@ pub fn spawn(
             };
 
             let ex = Rc::new(smol::LocalExecutor::new());
+            {
+                let lua = rt.lua.clone();
+                ex.spawn(async move {
+                    let mut event_buf = Vec::new();
+                    loop {
+                        with_jobs(&lua, |store| {
+                            store.drain_plugin_events(&mut event_buf);
+                        });
+                        if !event_buf.is_empty() {
+                            let scope = TaskScope::detached(&lua);
+                            for (job_id, event) in event_buf.drain(..) {
+                                if let Err(e) = deliver_job_event(&lua, job_id, &event) {
+                                    tracing::warn!(
+                                        error = %strip_traceback(&e),
+                                        "plugin job callback failed"
+                                    );
+                                }
+                            }
+                            drop(scope);
+                        }
+                        smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
+                    }
+                })
+                .detach();
+            }
             let gate = Rc::new(InflightGate::new(rt.lua.clone()));
             let restores = Rc::new(RestoreTracker::default());
             let spawn_rx = rt
@@ -2810,7 +2854,7 @@ mod tests {
     }
 
     #[test]
-    fn task_scope_clears_jobs_and_bufs_on_drop() {
+    fn task_scope_clears_bufs_on_drop() {
         let lua = Lua::new();
         let scope = TaskScope::new(&lua, task_cell(None));
         let handle = Arc::clone(scope.handle());
@@ -2818,6 +2862,30 @@ mod tests {
         assert!(lock_cell(&handle).bufs.live_buf().is_some());
         drop(scope);
         assert!(lock_cell(&handle).bufs.live_buf().is_none());
+    }
+
+    #[test]
+    fn task_scope_clears_only_its_jobs_on_drop() {
+        let lua = Lua::new();
+        let scope = TaskScope::new(&lua, task_cell(None));
+        let task_owner = JobOwner::Task(lock_cell(scope.handle()).id);
+        let plugin_owner = JobOwner::Plugin(Arc::from("test-plugin"));
+        with_jobs(&lua, |store| {
+            store
+                .start(task_owner.clone(), "exit 0", None, None, None, None, None)
+                .unwrap();
+            store
+                .start(plugin_owner.clone(), "exit 0", None, None, None, None, None)
+                .unwrap();
+        });
+
+        drop(scope);
+
+        with_jobs(&lua, |store| {
+            assert!(store.is_empty(&task_owner));
+            assert!(!store.is_empty(&plugin_owner));
+            store.kill_owner(&lua, &plugin_owner);
+        });
     }
 
     #[test]
@@ -3647,10 +3715,11 @@ mod tests {
         thread::spawn(move || {
             let lua = Lua::new();
             let scope = TaskScope::new(&lua, cell);
-            lock_cell(scope.handle())
-                .jobs
-                .start(DISPATCH_TEST_JOB, None, None, None, None, None)
-                .unwrap();
+            let owner = JobOwner::Task(lock_cell(scope.handle()).id);
+            with_jobs(&lua, |store| {
+                store.start(owner, DISPATCH_TEST_JOB, None, None, None, None, None)
+            })
+            .unwrap();
             let (_finish_tx, finish_rx) = flume::bounded(1);
 
             let start = Instant::now();

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -12,6 +12,8 @@ use maki_agent::tools::{
 use maki_config::{AlwaysThinking, PluginsConfig, ToolOutputLines};
 use maki_lua::{PluginError, PluginHost, WARM_TOOL_CAP};
 use maki_storage::id::SessionRef;
+#[cfg(unix)]
+use rustix::process::{Pid, test_kill_process_group};
 use serde_json::{Value, json};
 
 const NARGS_ERR: &str = r#"'nargs' must be 0, 1, "?", "*", or "+""#;
@@ -1852,6 +1854,100 @@ fn jobstop_kills_running_job() {
     host.load_source("job_stop", &src).unwrap();
     let out = exec_tool(&reg, "job_stop", serde_json::json!({})).unwrap();
     assert_eq!(out, "killed=true");
+}
+
+#[test]
+fn plugin_owned_job_outlives_its_starting_tool() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let src = format!(
+        r#"
+local output = "pending"
+local exit_code = "pending"
+maki.api.register_tool({{
+    name = "start_plugin_job",
+    description = "starts a plugin-owned job",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        local id = maki.fn.jobstart("sleep 0.1; printf plugin-output; exit 7", {{
+            owner = "plugin",
+            on_stdout = function(_, line) output = line end,
+            on_exit = function(_, code) exit_code = tostring(code) end,
+        }})
+        return maki.fn.jobwait(id, 1) == nil and "started" or "did not time out"
+    end,
+}})
+maki.api.register_tool({{
+    name = "plugin_job_state",
+    description = "reports plugin-owned job callbacks",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        return output .. "/" .. exit_code
+    end,
+}})
+"#
+    );
+    host.load_source("plugin_job", &src).unwrap();
+    assert_eq!(
+        exec_tool(&reg, "start_plugin_job", json!({})).unwrap(),
+        "started"
+    );
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let state = exec_tool(&reg, "plugin_job_state", json!({})).unwrap();
+        if state == "plugin-output/7" {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "plugin-owned callbacks did not run: {state}"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn unloading_plugin_kills_its_jobs() {
+    let host = PluginHost::new(fresh_registry()).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let pid_path = dir.path().join("job.pid");
+    let src = format!(
+        r#"maki.fn.jobstart("printf %s $$ > '{}'; exec sleep 30", {{
+            owner = "plugin",
+        }})"#,
+        pid_path.display()
+    );
+    host.load_source("plugin_job", &src).unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !pid_path.exists() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "plugin job did not publish its process id"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let pid = std::fs::read_to_string(&pid_path)
+        .unwrap()
+        .parse::<i32>()
+        .unwrap();
+    let pid = Pid::from_raw(pid).unwrap();
+    assert!(test_kill_process_group(pid).is_ok());
+
+    host.unload("plugin_job").unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while test_kill_process_group(pid).is_ok() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "plugin process group survived unload"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
 }
 
 #[test]

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -1321,6 +1321,9 @@ that you can pass to `jobstop` or `jobwait` to control the process.
   - `on_stdout` (`function?`) called with `(job_id, line)` for each stdout line.
   - `on_stderr` (`function?`) called with `(job_id, line)` for each stderr line.
   - `on_exit` (`function?`) called with `(job_id, code)` when the process finishes.
+  - `owner` (`string?`) job lifetime. `"task"` (default) ends the job with
+    the current call. `"plugin"` keeps it alive until the plugin unloads
+    or reloads.
 
 **Returns:** (`integer`) Job id.
 


### PR DESCRIPTION
Part of #676.

## What changed

Jobs now share one Lua-owned store and carry an explicit lifetime owner:

```lua
maki.fn.jobstart(cmd, { owner = "plugin" })
```

Task ownership remains the default. Plugin ownership lets a watcher outlive the tool call that started it, while plugin unload or reload removes the job through `drop_plugin_keys`.

The persistent executor pump delivers callbacks for plugin-owned jobs even after the starting scope ends. Access checks keep task jobs scoped to their task and plugin jobs scoped to their plugin. Exit, timeout handoff, unload, and store drop all release callback keys and stop processes at the correct boundary.

## Validation

Formatting, workspace clippy, the full workspace test suite, doctests, generated docs, dependency analysis, and focused mutation tests pass locally. The full Rust and Nix CI matrices are green.

The external monitor consuming this API lives at https://github.com/laudney/maki-monitor.

---

AI use, per CONTRIBUTING: implemented and reviewed with Codex and Claude Code at my direction.
