### PR TITLE
build(nix): add cargo-machete to the devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -207,6 +207,7 @@
         {
           default = craneLib.devShell {
             packages = with pkgs; [
+              cargo-machete
               cargo-nextest
               git
               just


### PR DESCRIPTION
`machete` was recently added to the justfile/ci.

Makes `cargo-machete` available in the nix devShell.