### PR TITLE
providers: Don't send max_output_tokens if disabled by the provider

### DIFF
--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -132,8 +132,10 @@ fn format_pricing(entry: &ModelEntry) -> String {
 
 fn format_context(entry: &ModelEntry) -> String {
     let ctx_k = entry.context_window / 1_000;
-    let out_k = entry.max_output_tokens / 1_000;
-    format!("{ctx_k}K ctx / {out_k}K out")
+    match entry.max_output_tokens {
+        Some(out) => format!("{ctx_k}K ctx / {}K out", out / 1_000),
+        None => format!("{ctx_k}K ctx"),
+    }
 }
 
 struct ProviderSection {

--- a/maki-providers/src/manifest.rs
+++ b/maki-providers/src/manifest.rs
@@ -88,7 +88,7 @@ const MISTRAL: ProviderManifest = ProviderManifest {
     family: ModelFamily::Generic,
     supports_thinking: true,
     accepts_arbitrary_models: true,
-    fallback_max_output: Some(32_000),
+    fallback_max_output: None,
     fallback_context_window: 128_000,
     models: mistral::models(),
 };

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -167,7 +167,7 @@ pub struct ModelEntry {
     pub vision: bool,
     pub default: bool,
     pub pricing: ModelPricing,
-    pub max_output_tokens: u32,
+    pub max_output_tokens: Option<u32>,
     pub context_window: u32,
 }
 
@@ -234,7 +234,7 @@ impl Model {
             .unwrap_or_default();
         let max_output_tokens = discovered
             .and_then(|info| info.max_output_tokens)
-            .or_else(|| static_entry.map(|entry| entry.max_output_tokens))
+            .or_else(|| static_entry.and_then(|entry| entry.max_output_tokens))
             .or(manifest.fallback_max_output);
         let context_window = discovered
             .and_then(|info| info.context_window)

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -167,7 +167,7 @@ impl ProviderKind {
             Self::Copilot => Some(100_000),
             Self::Ollama => Some(16_384),
             Self::LlamaCpp => None,
-            Self::Mistral => Some(32_000),
+            Self::Mistral => None,
             Self::Zai => Some(16_000),
             Self::DeepSeek => Some(384_000),
             Self::OpenRouter => Some(128_000),

--- a/maki-providers/src/providers/anthropic/shared.rs
+++ b/maki-providers/src/providers/anthropic/shared.rs
@@ -397,7 +397,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.10,
                 fast: None,
             },
-            max_output_tokens: 64000,
+            max_output_tokens: Some(64000),
             context_window: 200_000,
         },
         ModelEntry {
@@ -413,7 +413,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.30,
                 fast: None,
             },
-            max_output_tokens: 64000,
+            max_output_tokens: Some(64000),
             context_window: 200_000,
         },
         ModelEntry {
@@ -429,7 +429,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.30,
                 fast: None,
             },
-            max_output_tokens: 64000,
+            max_output_tokens: Some(64000),
             context_window: 200_000,
         },
         ModelEntry {
@@ -446,7 +446,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.20,
                 fast: None,
             },
-            max_output_tokens: 128000,
+            max_output_tokens: Some(128000),
             context_window: 200_000,
         },
         ModelEntry {
@@ -462,7 +462,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.30,
                 fast: None,
             },
-            max_output_tokens: 64000,
+            max_output_tokens: Some(64000),
             context_window: 200_000,
         },
         ModelEntry {
@@ -478,7 +478,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.50,
                 fast: None,
             },
-            max_output_tokens: 64000,
+            max_output_tokens: Some(64000),
             context_window: 200_000,
         },
         ModelEntry {
@@ -495,7 +495,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 // Fast mode withdrawn on 2026-06-29.
                 fast: None,
             },
-            max_output_tokens: 128000,
+            max_output_tokens: Some(128000),
             context_window: 200_000,
         },
         ModelEntry {
@@ -512,7 +512,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 // Fast mode withdrawn on 2026-07-24.
                 fast: None,
             },
-            max_output_tokens: 128000,
+            max_output_tokens: Some(128000),
             context_window: 200_000,
         },
         ModelEntry {
@@ -531,7 +531,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                     output: 50.00,
                 }),
             },
-            max_output_tokens: 128000,
+            max_output_tokens: Some(128000),
             context_window: 200_000,
         },
         ModelEntry {
@@ -550,7 +550,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                     output: 50.00,
                 }),
             },
-            max_output_tokens: 128000,
+            max_output_tokens: Some(128000),
             context_window: 200_000,
         },
         ModelEntry {
@@ -566,7 +566,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 1.00,
                 fast: None,
             },
-            max_output_tokens: 128000,
+            max_output_tokens: Some(128000),
             context_window: 200_000,
         },
         ModelEntry {
@@ -582,7 +582,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 1.50,
                 fast: None,
             },
-            max_output_tokens: 32000,
+            max_output_tokens: Some(32000),
             context_window: 200_000,
         },
     ];

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -52,7 +52,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
             vision: true,
             default: true,
             pricing: ModelPricing::ZERO,
-            max_output_tokens: 100_000,
+            max_output_tokens: Some(100_000),
             context_window: 200_000,
         },
         ModelEntry {
@@ -62,7 +62,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
             vision: true,
             default: true,
             pricing: ModelPricing::ZERO,
-            max_output_tokens: 100_000,
+            max_output_tokens: Some(100_000),
             context_window: 200_000,
         },
         ModelEntry {
@@ -77,7 +77,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
             vision: true,
             default: true,
             pricing: ModelPricing::ZERO,
-            max_output_tokens: 100_000,
+            max_output_tokens: Some(100_000),
             context_window: 200_000,
         },
         ModelEntry {
@@ -87,7 +87,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
             vision: true,
             default: false,
             pricing: ModelPricing::ZERO,
-            max_output_tokens: 64_000,
+            max_output_tokens: Some(64_000),
             context_window: 264_000,
         },
     ]

--- a/maki-providers/src/providers/deepseek.rs
+++ b/maki-providers/src/providers/deepseek.rs
@@ -56,7 +56,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.0028,
                 fast: None,
             },
-            max_output_tokens: 384_000,
+            max_output_tokens: Some(384_000),
             context_window: 1_000_000,
         },
         ModelEntry {
@@ -72,7 +72,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.003625,
                 fast: None,
             },
-            max_output_tokens: 384_000,
+            max_output_tokens: Some(384_000),
             context_window: 1_000_000,
         },
     ]

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -61,7 +61,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.31,
                 fast: None,
             },
-            max_output_tokens: 65_536,
+            max_output_tokens: Some(65_536),
             context_window: 1_048_576,
         },
         ModelEntry {
@@ -77,7 +77,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.04,
                 fast: None,
             },
-            max_output_tokens: 65_536,
+            max_output_tokens: Some(65_536),
             context_window: 1_048_576,
         },
         ModelEntry {
@@ -93,7 +93,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.01,
                 fast: None,
             },
-            max_output_tokens: 65_536,
+            max_output_tokens: Some(65_536),
             context_window: 1_048_576,
         },
     ]
@@ -920,8 +920,8 @@ mod tests {
         assert!(!models.is_empty());
         for entry in models {
             assert!(!entry.prefixes.is_empty());
-            assert!(entry.max_output_tokens > 0);
-            assert!(entry.context_window >= entry.max_output_tokens);
+            assert!(entry.max_output_tokens.is_some_and(|t| t > 0));
+            assert!(entry.context_window >= entry.max_output_tokens.unwrap());
         }
     }
 

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -70,7 +70,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.00,
                 fast: None,
             },
-            max_output_tokens: 262_144,
+            max_output_tokens: None,
             context_window: 262_144,
         },
         ModelEntry {
@@ -86,7 +86,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.00,
                 fast: None,
             },
-            max_output_tokens: 262_144,
+            max_output_tokens: None,
             context_window: 262_144,
         },
         ModelEntry {
@@ -102,7 +102,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.00,
                 fast: None,
             },
-            max_output_tokens: 262_144,
+            max_output_tokens: None,
             context_window: 262_144,
         },
     ]

--- a/maki-providers/src/providers/openai/mod.rs
+++ b/maki-providers/src/providers/openai/mod.rs
@@ -36,7 +36,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.10,
                 fast: None,
             },
-            max_output_tokens: GPT_5_6_MAX_OUTPUT_TOKENS,
+            max_output_tokens: Some(GPT_5_6_MAX_OUTPUT_TOKENS),
             context_window: GPT_5_6_CONTEXT_WINDOW,
         },
         ModelEntry {
@@ -52,7 +52,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.25,
                 fast: None,
             },
-            max_output_tokens: GPT_5_6_MAX_OUTPUT_TOKENS,
+            max_output_tokens: Some(GPT_5_6_MAX_OUTPUT_TOKENS),
             context_window: GPT_5_6_CONTEXT_WINDOW,
         },
         ModelEntry {
@@ -68,7 +68,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.50,
                 fast: None,
             },
-            max_output_tokens: GPT_5_6_MAX_OUTPUT_TOKENS,
+            max_output_tokens: Some(GPT_5_6_MAX_OUTPUT_TOKENS),
             context_window: GPT_5_6_CONTEXT_WINDOW,
         },
         ModelEntry {
@@ -84,7 +84,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.02,
                 fast: None,
             },
-            max_output_tokens: 128_000,
+            max_output_tokens: Some(128_000),
             context_window: 400_000,
         },
         ModelEntry {
@@ -100,7 +100,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.075,
                 fast: None,
             },
-            max_output_tokens: 128_000,
+            max_output_tokens: Some(128_000),
             context_window: 400_000,
         },
         ModelEntry {
@@ -116,7 +116,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.025,
                 fast: None,
             },
-            max_output_tokens: 32_768,
+            max_output_tokens: Some(32_768),
             context_window: 1_047_576,
         },
         ModelEntry {
@@ -132,7 +132,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.10,
                 fast: None,
             },
-            max_output_tokens: 32_768,
+            max_output_tokens: Some(32_768),
             context_window: 1_047_576,
         },
         ModelEntry {
@@ -148,7 +148,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.50,
                 fast: None,
             },
-            max_output_tokens: 32_768,
+            max_output_tokens: Some(32_768),
             context_window: 1_047_576,
         },
         ModelEntry {
@@ -164,7 +164,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.275,
                 fast: None,
             },
-            max_output_tokens: 100_000,
+            max_output_tokens: Some(100_000),
             context_window: 200_000,
         },
         ModelEntry {
@@ -180,7 +180,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.50,
                 fast: None,
             },
-            max_output_tokens: 128_000,
+            max_output_tokens: Some(128_000),
             context_window: 1_050_000,
         },
         ModelEntry {
@@ -196,7 +196,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.25,
                 fast: None,
             },
-            max_output_tokens: 128_000,
+            max_output_tokens: Some(128_000),
             context_window: 1_050_000,
         },
         ModelEntry {
@@ -212,7 +212,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 1.00,
                 fast: None,
             },
-            max_output_tokens: 100_000,
+            max_output_tokens: Some(100_000),
             context_window: 200_000,
         },
         ModelEntry {
@@ -228,7 +228,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.175,
                 fast: None,
             },
-            max_output_tokens: 128_000,
+            max_output_tokens: Some(128_000),
             context_window: 400_000,
         },
         ModelEntry {
@@ -244,7 +244,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.175,
                 fast: None,
             },
-            max_output_tokens: 128_000,
+            max_output_tokens: Some(128_000),
             context_window: 400_000,
         },
         ModelEntry {
@@ -260,7 +260,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.025,
                 fast: None,
             },
-            max_output_tokens: 128_000,
+            max_output_tokens: Some(128_000),
             context_window: 400_000,
         },
         ModelEntry {
@@ -276,7 +276,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.125,
                 fast: None,
             },
-            max_output_tokens: 128_000,
+            max_output_tokens: Some(128_000),
             context_window: 400_000,
         },
         ModelEntry {
@@ -292,7 +292,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.125,
                 fast: None,
             },
-            max_output_tokens: 128_000,
+            max_output_tokens: Some(128_000),
             context_window: 400_000,
         },
     ]

--- a/maki-providers/src/providers/synthetic.rs
+++ b/maki-providers/src/providers/synthetic.rs
@@ -47,7 +47,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.00,
                 fast: None,
             },
-            max_output_tokens: 131072,
+            max_output_tokens: Some(131072),
             context_window: 200_000,
         },
         ModelEntry {
@@ -63,7 +63,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.00,
                 fast: None,
             },
-            max_output_tokens: 131072,
+            max_output_tokens: Some(131072),
             context_window: 200_000,
         },
         ModelEntry {
@@ -79,7 +79,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.00,
                 fast: None,
             },
-            max_output_tokens: 131072,
+            max_output_tokens: Some(131072),
             context_window: 200_000,
         },
     ]

--- a/maki-providers/src/providers/zai/mod.rs
+++ b/maki-providers/src/providers/zai/mod.rs
@@ -125,7 +125,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.30,
                 fast: None,
             },
-            max_output_tokens: 131072,
+            max_output_tokens: Some(131072),
             context_window: 200_000,
         },
         ModelEntry {
@@ -141,7 +141,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.20,
                 fast: None,
             },
-            max_output_tokens: 131072,
+            max_output_tokens: Some(131072),
             context_window: 1_000_000,
         },
         ModelEntry {
@@ -157,7 +157,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.20,
                 fast: None,
             },
-            max_output_tokens: 131072,
+            max_output_tokens: Some(131072),
             context_window: 200_000,
         },
         ModelEntry {
@@ -173,7 +173,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.00,
                 fast: None,
             },
-            max_output_tokens: 131072,
+            max_output_tokens: Some(131072),
             context_window: 200_000,
         },
         ModelEntry {
@@ -189,7 +189,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.11,
                 fast: None,
             },
-            max_output_tokens: 131072,
+            max_output_tokens: Some(131072),
             context_window: 200_000,
         },
         ModelEntry {
@@ -205,7 +205,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.00,
                 fast: None,
             },
-            max_output_tokens: 98304,
+            max_output_tokens: Some(98304),
             context_window: 131_072,
         },
         ModelEntry {
@@ -221,7 +221,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.03,
                 fast: None,
             },
-            max_output_tokens: 98304,
+            max_output_tokens: Some(98304),
             context_window: 131_072,
         },
         ModelEntry {
@@ -237,7 +237,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 cache_read: 0.11,
                 fast: None,
             },
-            max_output_tokens: 98304,
+            max_output_tokens: Some(98304),
             context_window: 131_072,
         },
     ]

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -157,9 +157,9 @@ Connects to any OpenAI-compatible `/v1` endpoint. Point `LLAMA_CPP_HOST` to your
 
 | Tier | Models | Pricing (in/out per 1M tokens) | Context |
 |------|--------|-------------------------------|---------|
-| Weak | **ministral-14b-latest, ministral-14b-2512** (default) | $0.20 / $0.20 | 262K ctx / 262K out |
-| Medium | **mistral-small-latest, mistral-small-2603** (default) | $0.15 / $0.60 | 262K ctx / 262K out |
-| Strong | **mistral-medium-latest, mistral-medium-3.5, mistral-medium-2604** (default) | $1.50 / $7.50 | 262K ctx / 262K out |
+| Weak | **ministral-14b-latest, ministral-14b-2512** (default) | $0.20 / $0.20 | 262K ctx |
+| Medium | **mistral-small-latest, mistral-small-2603** (default) | $0.15 / $0.60 | 262K ctx |
+| Strong | **mistral-medium-latest, mistral-medium-3.5, mistral-medium-2604** (default) | $1.50 / $7.50 | 262K ctx |
 
 Defaults: mistral-medium-latest (strong), mistral-small-latest (medium), ministral-14b-latest (weak)
 


### PR DESCRIPTION
Even max_tokens=0 has specific meaning for various providers and can lead to trouble.

----

Specifically, I had 0 set for all the Mistral models for quite some time (it's equal to the max context size anyway) and sending either the max or 0 can cause all kinds of error conditions. Not sending it at all works better.