### PR TITLE
plugins: index: Actually list the directory when calling it on directories

### DIFF
--- a/maki-lua/tests/real_plugins_restore.rs
+++ b/maki-lua/tests/real_plugins_restore.rs
@@ -16,8 +16,21 @@ const BATCH_SRC: &str = include_str!("../../plugins/batch/init.lua");
 
 /// Only the real ToolView emits this when collapsed.
 const EXPAND_HINT: &str = "click to expand";
-/// Fixed cap so truncation tests don't depend on the product default.
+/// Fixed caps so truncation tests don't depend on the product defaults. The
+/// index and read caps differ so a body rendered through the wrong view is
+/// visibly different.
 const VIEW_CAP: usize = 3;
+const INDEX_VIEW_CAP: usize = 2;
+const READ_VIEW_CAP: usize = 5;
+
+fn view_lines() -> ToolOutputLines {
+    ToolOutputLines {
+        other: VIEW_CAP,
+        index: INDEX_VIEW_CAP,
+        read: READ_VIEW_CAP,
+        ..ToolOutputLines::DEFAULT
+    }
+}
 
 const GREP_OUT: &str =
     "src/a.rs:\n  1: fn main() {}\n  2: fn helper() {}\n\nsrc/b.rs:\n  10: fn other() {}";
@@ -65,10 +78,7 @@ fn restore(
             output: output.to_owned(),
             input,
             is_error: false,
-            tool_output_lines: ToolOutputLines {
-                other: VIEW_CAP,
-                ..ToolOutputLines::DEFAULT
-            },
+            tool_output_lines: view_lines(),
             theme_gen: None,
             clicks,
             state,
@@ -245,5 +255,92 @@ fn multiedit_batch_child_shows_full_numbered_diff() {
     assert!(
         !text.contains("3 + n1"),
         "added lines get a blank gutter: {text}"
+    );
+}
+
+const INDEX_TOOL: &str = "index";
+const LIVE_TOOL_USE_ID: &str = "live_id";
+/// More than the index view cap, exactly the read view cap, so a listing
+/// rendered through the index view is visibly truncated.
+const DIR_ENTRIES: [&str; READ_VIEW_CAP] = ["a.txt", "b.txt", "c.txt", "d.txt", "e.txt"];
+const ENTRIES_SUFFIX: &str = " entries";
+
+struct Live {
+    body: String,
+    output: String,
+    annotation: Option<String>,
+}
+
+fn exec_live(host: &PluginHost, reg: &ToolRegistry, tool: &str, input: Value) -> Live {
+    let (tx, rx) = flume::unbounded();
+    let event_tx = maki_agent::EventSender::new(tx, 0);
+    let mut ctx = maki_agent::tools::test_support::stub_ctx_with(
+        &maki_agent::AgentMode::Build,
+        Some(&event_tx),
+        Some(LIVE_TOOL_USE_ID),
+    );
+    ctx.tool_output_lines = view_lines();
+    let inv = reg
+        .get(tool)
+        .unwrap_or_else(|| panic!("tool {tool} not registered"))
+        .tool
+        .parse(&input)
+        .expect("parse failed");
+    let result = smol::block_on(async { inv.execute(&ctx).await });
+    host.load_source("live_barrier", "").unwrap();
+    let mut body = String::new();
+    for env in rx.drain() {
+        if let AgentEvent::ToolSnapshot { snapshot, .. } = env.event {
+            body = snapshot.text();
+        }
+    }
+    let output = match result.output.expect("tool failed") {
+        maki_agent::ToolOutput::Plain(s) | maki_agent::ToolOutput::Markdown(s) => s.text,
+        other => panic!("unexpected output: {other:?}"),
+    };
+    Live {
+        body,
+        output,
+        annotation: result.annotation,
+    }
+}
+
+/// A directory has no skeleton, so index shows the plain listing. Restore must
+/// rebuild that same listing view instead of the index skeleton view, which
+/// would truncate to the index cap and highlight the entries as code.
+#[test]
+fn index_dir_renders_identically_live_and_restored() {
+    let dir = tempfile::tempdir().unwrap();
+    for name in DIR_ENTRIES {
+        std::fs::write(dir.path().join(name), "").unwrap();
+    }
+    let reg = Arc::new(ToolRegistry::new());
+    let host = PluginHost::with_all_builtins(Arc::clone(&reg)).unwrap();
+    let input = json!({ "path": dir.path().to_str().unwrap() });
+
+    let live = exec_live(&host, &reg, INDEX_TOOL, input.clone());
+    let restored = restore(&host, INDEX_TOOL, input, &live.output, None, Vec::new());
+
+    let expected_annotation = format!("{}{ENTRIES_SUFFIX}", DIR_ENTRIES.len());
+    assert_eq!(
+        live.annotation.as_deref(),
+        Some(expected_annotation.as_str()),
+        "live dir listing is annotated like read's"
+    );
+    for name in DIR_ENTRIES {
+        assert!(
+            live.body.contains(name),
+            "entry {name} missing: {}",
+            live.body
+        );
+    }
+    assert!(
+        !live.body.contains(EXPAND_HINT),
+        "listing fits the read view cap: {}",
+        live.body
+    );
+    assert_eq!(
+        restored.body, live.body,
+        "restored dir listing must match the live one"
     );
 }

--- a/plugins/index/init.lua
+++ b/plugins/index/init.lua
@@ -1,3 +1,4 @@
+local dir_listing = require("maki.dir_listing")
 local indexer = require("indexer")
 local ToolView = require("maki.tool_view")
 local shorten_path = require("maki.shorten_path")
@@ -170,6 +171,10 @@ Return a compact overview of a source file: imports, type definitions, function 
     return render_header(input.path)
   end,
   restore = function(input, output, _is_error, ctx)
+    local meta = input.path and maki.fs.metadata(input.path)
+    if meta and meta.is_dir then
+      return { body = dir_listing.view(output, ctx) }
+    end
     local ext = input.path:match("%.([^%.]+)$") or ""
     local buf, header = render_index(output, input.path, ctx, ext)
     return { body = buf, header = header }
@@ -181,11 +186,23 @@ Return a compact overview of a source file: imports, type definitions, function 
     end
 
     local meta = maki.fs.metadata(path)
-    if meta and meta.is_dir then
-      return {
-        llm_output = "Path is a directory. Use index on files or use the read or glob tool to list directories.",
-        is_error = true,
+    if not meta then
+      return { llm_output = "error: path not found: " .. path, is_error = true }
+    end
+    if meta.is_dir then
+      local listing, err = dir_listing.list(path, ctx)
+      if not listing then
+        return { llm_output = "error: " .. tostring(err), is_error = true }
+      end
+      local output = {
+        llm_output = listing.text,
+        body = dir_listing.view(listing.text, ctx),
+        annotation = listing.count .. " entries",
       }
+      if listing.instructions then
+        output.instructions = listing.instructions
+      end
+      return output
     end
 
     local filename = path:match("([^/]+)$")

--- a/plugins/index/tests/helpers.lua
+++ b/plugins/index/tests/helpers.lua
@@ -1,22 +1,11 @@
--- Shared helpers for the index plugin spec.
+-- Index-specific test helpers.
 --
--- Per-language spec files in tests/lang/<lang>.lua require this module to get
--- a consistent test vocabulary. `case` wraps each block in pcall so a single
--- failure does not abort the rest of the suite; failures are collected here
--- and surfaced by `report()` from tests/spec.lua at the end.
+-- Per-language spec files in tests/lang/<lang>.lua require this module for
+-- indexer-specific assertions (`idx`, `has`, `lacks`, etc.).
 
 local indexer = require("indexer")
 
 local M = {}
-
-local failures = {}
-
-function M.case(name, fn)
-  local ok, err = pcall(fn)
-  if not ok then
-    table.insert(failures, name .. ": " .. tostring(err))
-  end
-end
 
 function M.idx(source, lang)
   local result, err = indexer.index_source(source, lang)
@@ -97,12 +86,6 @@ function M.assert_fields_no_ranged_meta(text, meta, struct_needle, field_needles
     end
   end
   assert(struct_found, struct_needle .. " not found in output")
-end
-
-function M.report()
-  if #failures > 0 then
-    error(#failures .. " case(s) failed:\n\n" .. table.concat(failures, "\n\n"))
-  end
 end
 
 return M

--- a/plugins/index/tests/indexer_core.lua
+++ b/plugins/index/tests/indexer_core.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx_with_meta = helpers.idx_with_meta
 
 local function meta_count(meta)

--- a/plugins/index/tests/lang/bash.lua
+++ b/plugins/index/tests/lang/bash.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local has = helpers.has
 

--- a/plugins/index/tests/lang/bazel.lua
+++ b/plugins/index/tests/lang/bazel.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has

--- a/plugins/index/tests/lang/c.lua
+++ b/plugins/index/tests/lang/c.lua
@@ -2,8 +2,9 @@
 -- C-header constructs (typedefs, enums, includes, guards) work the same way
 -- under both `c` and `cpp`. C++-specific syntax lives in cpp.lua.
 
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has

--- a/plugins/index/tests/lang/c_sharp.lua
+++ b/plugins/index/tests/lang/c_sharp.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local has = helpers.has
 

--- a/plugins/index/tests/lang/cpp.lua
+++ b/plugins/index/tests/lang/cpp.lua
@@ -1,7 +1,8 @@
 -- C++ tests. C-header cases shared between `c` and `cpp` live in c.lua.
 
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local has = helpers.has
 

--- a/plugins/index/tests/lang/dart.lua
+++ b/plugins/index/tests/lang/dart.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has

--- a/plugins/index/tests/lang/elixir.lua
+++ b/plugins/index/tests/lang/elixir.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has

--- a/plugins/index/tests/lang/gleam.lua
+++ b/plugins/index/tests/lang/gleam.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local has = helpers.has
 

--- a/plugins/index/tests/lang/go.lua
+++ b/plugins/index/tests/lang/go.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has

--- a/plugins/index/tests/lang/html.lua
+++ b/plugins/index/tests/lang/html.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local has = helpers.has
 local lacks = helpers.lacks

--- a/plugins/index/tests/lang/java.lua
+++ b/plugins/index/tests/lang/java.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local has = helpers.has
 

--- a/plugins/index/tests/lang/kotlin.lua
+++ b/plugins/index/tests/lang/kotlin.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has

--- a/plugins/index/tests/lang/lua_lang.lua
+++ b/plugins/index/tests/lang/lua_lang.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local has = helpers.has
 

--- a/plugins/index/tests/lang/markdown.lua
+++ b/plugins/index/tests/lang/markdown.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local has = helpers.has
 local lacks = helpers.lacks

--- a/plugins/index/tests/lang/nix.lua
+++ b/plugins/index/tests/lang/nix.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local has = helpers.has
 local lacks = helpers.lacks

--- a/plugins/index/tests/lang/php.lua
+++ b/plugins/index/tests/lang/php.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local has = helpers.has
 

--- a/plugins/index/tests/lang/python.lua
+++ b/plugins/index/tests/lang/python.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has

--- a/plugins/index/tests/lang/ruby.lua
+++ b/plugins/index/tests/lang/ruby.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has

--- a/plugins/index/tests/lang/rust.lua
+++ b/plugins/index/tests/lang/rust.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has

--- a/plugins/index/tests/lang/scala.lua
+++ b/plugins/index/tests/lang/scala.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local has = helpers.has
 

--- a/plugins/index/tests/lang/sql.lua
+++ b/plugins/index/tests/lang/sql.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local has = helpers.has
 local lacks = helpers.lacks

--- a/plugins/index/tests/lang/swift.lua
+++ b/plugins/index/tests/lang/swift.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has

--- a/plugins/index/tests/lang/toml.lua
+++ b/plugins/index/tests/lang/toml.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has

--- a/plugins/index/tests/lang/typescript.lua
+++ b/plugins/index/tests/lang/typescript.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has

--- a/plugins/index/tests/lang/yaml.lua
+++ b/plugins/index/tests/lang/yaml.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local has = helpers.has
 local lacks = helpers.lacks

--- a/plugins/index/tests/lang/zig.lua
+++ b/plugins/index/tests/lang/zig.lua
@@ -1,5 +1,6 @@
+local th = require("maki.test_helpers")
 local helpers = require("tests.helpers")
-local case = helpers.case
+local case = th.case
 local idx = helpers.idx
 local idx_with_meta = helpers.idx_with_meta
 local has = helpers.has

--- a/plugins/index/tests/spec.lua
+++ b/plugins/index/tests/spec.lua
@@ -3,8 +3,55 @@
 -- Per-language cases live in tests/lang/<lang>.lua and run as side effects of
 -- require. Add a new language by creating tests/lang/<lang>.lua (use any
 -- existing file as a template) and adding a require line below — keep them
--- alphabetized. Each spec uses the shared `case` helper from tests/helpers.lua,
--- which collects failures so a single broken case does not abort the suite.
+-- alphabetized.
+
+local th = require("maki.test_helpers")
+local case = th.case
+local eq = th.eq
+local mktmpdir = function()
+  return th.mktmpdir("index_spec")
+end
+local rmtree = th.rmtree
+
+local dir_listing = require("maki.dir_listing")
+
+local function mock_ctx(path)
+  return {
+    is_instruction_file = function(self, name)
+      local set = { ["AGENTS.md"] = true, ["CLAUDE.md"] = true, ["COPILOT.md"] = true }
+      return set[name] or false
+    end,
+    find_instructions = function()
+      return {}
+    end,
+  }
+end
+
+-- integration: directory listing via real filesystem
+
+case("dir_listing_sort_and_filter", function()
+  local tmpdir = mktmpdir()
+  maki.fs.write(maki.fs.joinpath(tmpdir, "c.txt"), "")
+  maki.fs.write(maki.fs.joinpath(tmpdir, "a.txt"), "")
+  maki.fs.write(maki.fs.joinpath(tmpdir, "AGENTS.md"), "instructions")
+  maki.fs.write(maki.fs.joinpath(tmpdir, "b.txt"), "")
+  maki.fs.write(maki.fs.joinpath(tmpdir, "m.txt"), "")
+  maki.fs.mkdir(maki.fs.joinpath(tmpdir, "zdir"))
+  maki.fs.mkdir(maki.fs.joinpath(tmpdir, "adir"))
+  maki.fs.mkdir(maki.fs.joinpath(tmpdir, "idir"))
+
+  local listing, err = dir_listing.list(tmpdir, mock_ctx(tmpdir))
+  assert(err == nil, "dir listing should succeed: " .. tostring(err))
+  eq(#listing.names, 7)
+  eq(listing.names[1], "adir/")
+  eq(listing.names[2], "idir/")
+  eq(listing.names[3], "zdir/")
+  eq(listing.names[4], "a.txt")
+  eq(listing.names[5], "b.txt")
+  eq(listing.names[6], "c.txt")
+  eq(listing.names[7], "m.txt")
+  rmtree(tmpdir)
+end)
 require("tests.indexer_core")
 require("tests.lang.bash")
 require("tests.lang.bazel")
@@ -33,4 +80,4 @@ require("tests.lang.typescript")
 require("tests.lang.yaml")
 require("tests.lang.zig")
 
-require("tests.helpers").report()
+th.report()

--- a/plugins/lib/maki/dir_listing.lua
+++ b/plugins/lib/maki/dir_listing.lua
@@ -1,0 +1,58 @@
+-- Shared directory listing for index and read plugins.
+-- Lists entries, filters instruction files, sorts dirs before files, and
+-- renders the listing so every caller shows a directory the same way.
+
+local ToolView = require("maki.tool_view")
+
+local DEFAULT_MAX_LINES = 10
+
+local M = {}
+
+function M.list(path, ctx)
+  local entries, err = maki.fs.dir(path)
+  if not entries then
+    return nil, err
+  end
+
+  local dirs = {}
+  local files = {}
+  for _, entry in ipairs(entries) do
+    local name, typ = entry[1], entry[2]
+    if typ == "directory" then
+      dirs[#dirs + 1] = name .. "/"
+    elseif not ctx:is_instruction_file(name) then
+      files[#files + 1] = name
+    end
+  end
+  table.sort(dirs)
+  table.sort(files)
+  for _, f in ipairs(files) do
+    dirs[#dirs + 1] = f
+  end
+
+  local instructions = ctx:find_instructions(path)
+
+  local result = {
+    names = dirs,
+    text = table.concat(dirs, "\n"),
+    count = #dirs,
+  }
+  if #instructions > 0 then
+    result.instructions = instructions
+  end
+  return result
+end
+
+function M.view(text, ctx)
+  local tol = ctx:tool_output_lines()
+  local buf = maki.ui.buf()
+  local view = ToolView.new(buf, { max_lines = (tol and tol.read) or DEFAULT_MAX_LINES, keep = "head" })
+  view:append_text(text)
+  view:finish()
+  buf:on("click", function()
+    view:toggle()
+  end)
+  return buf
+end
+
+return M

--- a/plugins/lib/maki/test_helpers.lua
+++ b/plugins/lib/maki/test_helpers.lua
@@ -1,0 +1,48 @@
+-- Shared test helpers for Lua plugin specs.
+--
+-- Provides a lightweight test harness: `case` wraps each block in pcall so a
+-- single failure does not abort the rest of the suite. Failures are collected
+-- and surfaced by `report()` at the end.
+
+local M = {}
+
+local failures = {}
+
+function M.case(name, fn)
+  local ok, err = pcall(fn)
+  if not ok then
+    table.insert(failures, name .. ": " .. tostring(err))
+  end
+end
+
+function M.eq(actual, expected, msg)
+  if actual ~= expected then
+    error((msg or "") .. "\nexpected: " .. tostring(expected) .. "\n  actual: " .. tostring(actual))
+  end
+end
+
+local _tmpdir_counter = 0
+
+function M.mktmpdir(prefix)
+  _tmpdir_counter = _tmpdir_counter + 1
+  local name = "/tmp/maki_"
+    .. (prefix or "test")
+    .. "_"
+    .. tostring(os.clock()):gsub("%.", "")
+    .. "_"
+    .. _tmpdir_counter
+  maki.fs.mkdir(name)
+  return name
+end
+
+function M.rmtree(dir)
+  maki.fs.rm(dir, { recursive = true })
+end
+
+function M.report()
+  if #failures > 0 then
+    error(#failures .. " case(s) failed:\n\n" .. table.concat(failures, "\n\n"))
+  end
+end
+
+return M

--- a/plugins/read/init.lua
+++ b/plugins/read/init.lua
@@ -1,3 +1,4 @@
+local dir_listing = require("maki.dir_listing")
 local ToolView = require("maki.tool_view")
 local shorten_path = require("maki.shorten_path")
 local output_limits = require("maki.output_limits")
@@ -98,17 +99,6 @@ local function build_file_view(lines, start_line, total_lines, path, ctx, prefix
   return buf
 end
 
-local function build_dir_view(text, ctx)
-  local buf = maki.ui.buf()
-  local view = ToolView.new(buf, read_view_opts(ctx))
-  view:append_text(text)
-  view:finish()
-  buf:on("click", function()
-    view:toggle()
-  end)
-  return buf
-end
-
 local function read_file(path, offset, limit, ctx)
   local content, err = maki.fs.read(path)
   if not content then
@@ -183,41 +173,18 @@ local function read_file(path, offset, limit, ctx)
 end
 
 local function list_dir(path, ctx)
-  local entries, err = maki.fs.dir(path)
-  if not entries then
+  local listing, err = dir_listing.list(path, ctx)
+  if not listing then
     return { llm_output = "read error: " .. tostring(err), is_error = true }
   end
 
-  local sorted = {}
-  for _, entry in ipairs(entries) do
-    local name, typ = entry[1], entry[2]
-    if typ == "directory" then
-      sorted[#sorted + 1] = { name .. "/", true }
-    elseif not ctx:is_instruction_file(name) then
-      sorted[#sorted + 1] = { name, false }
-    end
-  end
-  table.sort(sorted, function(a, b)
-    if a[2] ~= b[2] then
-      return a[2]
-    end
-    return a[1] < b[1]
-  end)
-
-  local names = {}
-  for _, e in ipairs(sorted) do
-    names[#names + 1] = e[1]
-  end
-  local text = table.concat(names, "\n")
-
-  local instructions = ctx:find_instructions(path)
   local result = {
-    llm_output = text,
-    body = build_dir_view(text, ctx),
-    annotation = #sorted .. " entries",
+    llm_output = listing.text,
+    body = dir_listing.view(listing.text, ctx),
+    annotation = listing.count .. " entries",
   }
-  if #instructions > 0 then
-    result.instructions = instructions
+  if listing.instructions then
+    result.instructions = listing.instructions
   end
   return result
 end

--- a/plugins/read/tests/spec.lua
+++ b/plugins/read/tests/spec.lua
@@ -35,55 +35,15 @@ local function split_lines(content)
   return lines
 end
 
-local function sort_dir_entries(entries, is_instruction_file)
-  local sorted = {}
-  for _, entry in ipairs(entries) do
-    local name, typ = entry[1], entry[2]
-    if typ == "directory" then
-      sorted[#sorted + 1] = { name .. "/", true }
-    elseif not is_instruction_file(name) then
-      sorted[#sorted + 1] = { name, false }
-    end
-  end
-  table.sort(sorted, function(a, b)
-    if a[2] ~= b[2] then
-      return a[2]
-    end
-    return a[1] < b[1]
-  end)
-  local names = {}
-  for _, e in ipairs(sorted) do
-    names[#names + 1] = e[1]
-  end
-  return names
-end
+local dir_listing = require("maki.dir_listing")
+local th = require("maki.test_helpers")
 
-local failures = {}
-
-local function case(name, fn)
-  local ok, err = pcall(fn)
-  if not ok then
-    table.insert(failures, name .. ": " .. tostring(err))
-  end
+local case = th.case
+local eq = th.eq
+local mktmpdir = function()
+  return th.mktmpdir("read_spec")
 end
-
-local function eq(actual, expected, msg)
-  if actual ~= expected then
-    error((msg or "") .. "\nexpected: " .. tostring(expected) .. "\n  actual: " .. tostring(actual))
-  end
-end
-
-local _tmpdir_counter = 0
-local function mktmpdir()
-  _tmpdir_counter = _tmpdir_counter + 1
-  local name = "/tmp/maki_read_spec_" .. tostring(os.clock()):gsub("%.", "") .. "_" .. _tmpdir_counter
-  maki.fs.mkdir(name)
-  return name
-end
-
-local function rmtree(dir)
-  maki.fs.rm(dir, { recursive = true })
-end
+local rmtree = th.rmtree
 
 -- line_nr_fmt: table-driven across all boundaries + alignment
 
@@ -161,41 +121,6 @@ case("split_lines", function()
   end
 end)
 
--- sort_dir_entries
-
-local function mock_is_instruction(name)
-  local set = { ["AGENTS.md"] = true, ["CLAUDE.md"] = true, ["COPILOT.md"] = true }
-  return set[name] or false
-end
-
-case("sort_dirs_first_alpha_within_group", function()
-  local entries = {
-    { "z", "directory" },
-    { "a", "directory" },
-    { "m.txt", "file" },
-    { "b.txt", "file" },
-  }
-  local names = sort_dir_entries(entries, mock_is_instruction)
-  eq(names[1], "a/")
-  eq(names[2], "z/")
-  eq(names[3], "b.txt")
-  eq(names[4], "m.txt")
-end)
-
-case("sort_hides_instruction_files_not_dirs", function()
-  local entries = {
-    { "AGENTS.md", "file" },
-    { "CLAUDE.md", "file" },
-    { "COPILOT.md", "file" },
-    { "AGENTS.md", "directory" },
-    { "main.rs", "file" },
-  }
-  local names = sort_dir_entries(entries, mock_is_instruction)
-  eq(#names, 2)
-  eq(names[1], "AGENTS.md/")
-  eq(names[2], "main.rs")
-end)
-
 -- integration: directory listing via real filesystem
 
 case("dir_listing_sort_and_filter", function()
@@ -203,20 +128,32 @@ case("dir_listing_sort_and_filter", function()
   maki.fs.write(maki.fs.joinpath(tmpdir, "c.txt"), "")
   maki.fs.write(maki.fs.joinpath(tmpdir, "a.txt"), "")
   maki.fs.write(maki.fs.joinpath(tmpdir, "AGENTS.md"), "instructions")
+  maki.fs.write(maki.fs.joinpath(tmpdir, "b.txt"), "")
+  maki.fs.write(maki.fs.joinpath(tmpdir, "m.txt"), "")
   maki.fs.mkdir(maki.fs.joinpath(tmpdir, "zdir"))
   maki.fs.mkdir(maki.fs.joinpath(tmpdir, "adir"))
+  maki.fs.mkdir(maki.fs.joinpath(tmpdir, "idir"))
 
-  local entries, err = maki.fs.dir(tmpdir)
+  local ctx = {
+    is_instruction_file = function(self, name)
+      local set = { ["AGENTS.md"] = true, ["CLAUDE.md"] = true, ["COPILOT.md"] = true }
+      return set[name] or false
+    end,
+    find_instructions = function()
+      return {}
+    end,
+  }
+  local listing, err = dir_listing.list(tmpdir, ctx)
   assert(err == nil, "dir listing should succeed: " .. tostring(err))
-  local names = sort_dir_entries(entries, mock_is_instruction)
-  eq(#names, 4)
-  eq(names[1], "adir/")
-  eq(names[2], "zdir/")
-  eq(names[3], "a.txt")
-  eq(names[4], "c.txt")
+  eq(#listing.names, 7)
+  eq(listing.names[1], "adir/")
+  eq(listing.names[2], "idir/")
+  eq(listing.names[3], "zdir/")
+  eq(listing.names[4], "a.txt")
+  eq(listing.names[5], "b.txt")
+  eq(listing.names[6], "c.txt")
+  eq(listing.names[7], "m.txt")
   rmtree(tmpdir)
 end)
 
-if #failures > 0 then
-  error(#failures .. " case(s) failed:\n\n" .. table.concat(failures, "\n\n"))
-end
+th.report()

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -4771,6 +4771,16 @@ end
 return M
 ```
 
+### `require("maki.dir_listing")`
+
+```lua
+-- Shared directory listing for index and read plugins.
+-- Lists entries, filters instruction files, sorts dirs before files, and
+-- renders the listing so every caller shows a directory the same way.
+function M.list(path, ctx)
+function M.view(text, ctx)
+```
+
 ### `require("maki.fuzzy_replace")`
 
 ```lua
@@ -4877,6 +4887,21 @@ local function shorten_path(path)
 end
 
 return shorten_path
+```
+
+### `require("maki.test_helpers")`
+
+```lua
+-- Shared test helpers for Lua plugin specs.
+--
+-- Provides a lightweight test harness: `case` wraps each block in pcall so a
+-- single failure does not abort the rest of the suite. Failures are collected
+-- and surfaced by `report()` at the end.
+function M.case(name, fn)
+function M.eq(actual, expected, msg)
+function M.mktmpdir(prefix)
+function M.rmtree(dir)
+function M.report()
 ```
 
 ### `require("maki.text_input")`


### PR DESCRIPTION
Behaves the same as the read tool now, and doesn't "cost" anything but avoids a round trip if a model is confused.