### PR TITLE
plugins: read: Make offset/limit mandatory parameters

### DIFF
--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -3576,3 +3576,179 @@ fn job_callbacks_fire_while_command_handler_parked() {
         .expect("job callbacks starved while command handler was parked");
     assert!(matches!(action, maki_lua::UiAction::Flash(msg) if msg == "job:hi"));
 }
+
+/// read tool requires offset and limit; missing fields should fail schema validation.
+mod read_tool_required_params {
+    use super::*;
+
+    const MISSING_OFFSET_ERR: &str = "invalid parameter 'offset': required";
+    const MISSING_LIMIT_ERR: &str = "invalid parameter 'limit': required";
+    const MAX_OUTPUT_LINES: i32 = 2000;
+
+    #[test]
+    fn missing_offset_fails_parse() {
+        let (reg, _host) = builtins_host();
+        let entry = reg.get("read").expect("read registered");
+        let err = entry
+            .tool
+            .parse(&serde_json::json!({ "path": "/tmp/foo.txt", "limit": 10 }))
+            .err()
+            .expect("missing offset should fail");
+        assert!(err.to_string().contains(MISSING_OFFSET_ERR), "got: {err}");
+    }
+
+    #[test]
+    fn missing_limit_fails_parse() {
+        let (reg, _host) = builtins_host();
+        let entry = reg.get("read").expect("read registered");
+        let err = entry
+            .tool
+            .parse(&serde_json::json!({ "path": "/tmp/foo.txt", "offset": 1 }))
+            .err()
+            .expect("missing limit should fail");
+        assert!(err.to_string().contains(MISSING_LIMIT_ERR), "got: {err}");
+    }
+
+    #[test]
+    fn both_offset_and_limit_present_parses() {
+        let (reg, _host) = builtins_host();
+        let entry = reg.get("read").expect("read registered");
+        let result = entry.tool.parse(&serde_json::json!({
+            "path": "/tmp/foo.txt",
+            "offset": 1,
+            "limit": 10
+        }));
+        assert!(result.is_ok(), "valid input should parse");
+    }
+
+    #[test]
+    fn limit_zero_parses_and_reads_to_cap() {
+        let (reg, _host) = builtins_host();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("big.txt");
+        // Write 100 lines
+        let content = (1..=100i32)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(&path, &content).unwrap();
+
+        let out = exec_tool(
+            &reg,
+            "read",
+            serde_json::json!({
+                "path": path.to_str().unwrap(),
+                "offset": 1,
+                "limit": 0
+            }),
+        );
+        let out = out.expect("read should succeed");
+        // limit=0 means read to end (capped at 2000). 100 lines < 2000, so all should be read.
+        assert!(
+            out.contains("1: line 1"),
+            "should start at line 1, got: {out}"
+        );
+        assert!(
+            out.contains("100: line 100"),
+            "should include last line, got: {out}"
+        );
+    }
+
+    #[test]
+    fn limit_zero_respects_2000_cap() {
+        let (reg, _host) = builtins_host();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("huge.txt");
+        // Write 2500 lines
+        let content = (1..=2500i32)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(&path, &content).unwrap();
+
+        let out = exec_tool(
+            &reg,
+            "read",
+            serde_json::json!({
+                "path": path.to_str().unwrap(),
+                "offset": 1,
+                "limit": 0
+            }),
+        );
+        let out = out.expect("read should succeed");
+        // limit=0 capped at 2000, so should have lines 1-2000
+        assert!(out.contains("1: line 1"), "should start at line 1");
+        assert!(
+            out.contains("2000: line 2000"),
+            "should include line 2000, got last lines: {}",
+            out.split('\n').rev().take(5).collect::<Vec<_>>().join("\n")
+        );
+        assert!(
+            !out.contains("2001: line 2001"),
+            "should not include line 2001"
+        );
+        // Should have truncation hint
+        assert!(
+            out.contains("Truncated"),
+            "should mention truncation, got: {out}"
+        );
+    }
+
+    #[test]
+    fn explicit_limit_above_cap_is_clamped() {
+        let (reg, _host) = builtins_host();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("huge.txt");
+        let content = (1..=MAX_OUTPUT_LINES + 500)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(&path, &content).unwrap();
+
+        let out = exec_tool(
+            &reg,
+            "read",
+            serde_json::json!({
+                "path": path.to_str().unwrap(),
+                "offset": 1,
+                "limit": MAX_OUTPUT_LINES + 500
+            }),
+        );
+        let out = out.expect("read should succeed");
+        assert!(
+            out.contains(&format!("{MAX_OUTPUT_LINES}: line {MAX_OUTPUT_LINES}")),
+            "should include the last line within the cap, got: {out}"
+        );
+        assert!(
+            !out.contains(&format!(
+                "{}: line {}",
+                MAX_OUTPUT_LINES + 1,
+                MAX_OUTPUT_LINES + 1
+            )),
+            "explicit limit must be clamped to the cap, got: {out}"
+        );
+    }
+
+    #[test]
+    fn offset_beyond_file_returns_empty() {
+        let (reg, _host) = builtins_host();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("small.txt");
+        std::fs::write(&path, "just one line\n").unwrap();
+
+        let out = exec_tool(
+            &reg,
+            "read",
+            serde_json::json!({
+                "path": path.to_str().unwrap(),
+                "offset": 100,
+                "limit": 10
+            }),
+        );
+        let out = out.expect("read should succeed");
+        assert!(
+            out.is_empty(),
+            "offset beyond file should return empty, got: {out}"
+        );
+    }
+}

--- a/plugins/code_execution/init.lua
+++ b/plugins/code_execution/init.lua
@@ -84,7 +84,7 @@ local description = [[Execute Python code in a sandboxed interpreter with tools 
 
 Use for chained/dependent tool calls and filtering/processing results, e.g. filtering web tool output. **DRAMATICALLY** faster than sequential tool calls!
 
-- All tools are async and return strings: `result = await read(path='file.txt')`. Parse output yourself.
+- All tools are async and return strings: `result = await read(path='file.txt', offset=1, limit=0)`. Parse output yourself.
 - Use `asyncio.gather()` for concurrency within one execution.
 - Available libs: re, asyncio, sys, os, json. No other imports, no classes, no filesystem/network access.
 - Fresh sandbox each run: no state persists between executions.
@@ -100,7 +100,7 @@ local schema = {
   properties = {
     code = {
       type = "string",
-      description = "Python code to execute. Tools are async functions that return strings (not objects). You MUST await every call: `result = await read(path='/file')`. Use `await asyncio.gather(...)` for concurrency.",
+      description = "Python code to execute. Tools are async functions that return strings (not objects). You MUST await every call: `result = await read(path='/file', offset=1, limit=0)`. Use `await asyncio.gather(...)` for concurrency.",
     },
     timeout = {
       type = "integer",
@@ -112,7 +112,7 @@ local schema = {
 local examples = {
   {
     code = [[files = (await glob(pattern='**/*.rs')).strip().split('\n')
-results = await asyncio.gather(*[read(path=f) for f in files if f.strip()])
+results = await asyncio.gather(*[read(path=f, offset=1, limit=0) for f in files if f.strip()])
 for f, c in zip(files, results):
     if 'fn main' in c: print(f)]],
   },

--- a/plugins/read/init.lua
+++ b/plugins/read/init.lua
@@ -5,10 +5,11 @@ local output_limits = require("maki.output_limits")
 local DESCRIPTION = [[Read a file or directory. Returns contents with line numbers (1-indexed).
 
 - Supports absolute, relative, and ~/ paths.
-- **Always include offset and limit** if possible. Defaults: no offset = start at 1; no limit = up to 2000 lines.
+- **offset** and **limit** are required. Use offset=1 to read from the first line.
+- Use limit=0 to read until the end of file (capped at 2000 lines).
 - Use the **index** tool or **grep** tool first to find the offset and limit.
 - Only read the sections you actually need.
-- Use `wc -l` to check total number of lines before reading to decide a reasonable limit unless known already.
+- Use `wc -l` to check total number of lines before reading to decide a reasonable limit.
 - Use truncation hints (e.g. "truncated lines X-Y") to continue with the correct offset.
 - Do not reread the same range (same file and same offset).
 - Prefer grep to locate content instead of scanning full files.
@@ -125,8 +126,9 @@ local function read_file(path, offset, limit, ctx)
   end
   local total_lines = #all_lines
 
-  local start = math.max(offset or 1, 1)
-  local max_lines = limit or opts.max_output_lines or ctx:config("max_output_lines", DEFAULT_MAX_OUTPUT_LINES)
+  local start = math.max(offset, 1)
+  local default_max = opts.max_output_lines or ctx:config("max_output_lines", DEFAULT_MAX_OUTPUT_LINES)
+  local max_lines = limit == 0 and default_max or math.min(limit, default_max)
   local max_line_bytes = opts.max_line_bytes
 
   local lines = {}
@@ -226,7 +228,7 @@ maki.api.register_prompt_hint({
   slot = "tool_usage",
   content = [[
 - When using the **read** tool, only read the sections you actually need.
-- Use `wc -l` to check total number of lines before reading to decide a reasonable **read** tool limit unless known already.]],
+- Use `wc -l` to check total number of lines before reading to decide a reasonable **read** tool limit.]],
 })
 
 maki.api.register_tool({
@@ -243,10 +245,15 @@ maki.api.register_tool({
         required = true,
         alias = "file_path",
       },
-      offset = { type = "integer", description = "Line number to start from (1-indexed)" },
+      offset = {
+        type = "integer",
+        description = "Line number to start from (1-indexed). Use 1 for the first line.",
+        required = true,
+      },
       limit = {
         type = "integer",
-        description = "Max number of lines to read. Omitting the limit reads up to 2000 lines.",
+        description = "Max number of lines to read. Use 0 to read until end of file (capped at 2000 lines).",
+        required = true,
       },
     },
   },
@@ -255,9 +262,9 @@ maki.api.register_tool({
     local buf = maki.ui.buf()
     local s = shorten_path(input.path or "")
     local start = input.offset or 1
-    if input.limit then
+    if input.limit and input.limit > 0 then
       s = s .. ":" .. start .. "-" .. (start + input.limit - 1)
-    elseif input.offset then
+    else
       s = s .. ":" .. start
     end
     buf:line({ { s, "path" } })

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -29,8 +29,8 @@ Read a file or directory. Returns contents with line numbers (1-indexed).
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `limit` | integer | no | Max number of lines to read. Omitting the limit reads up to 2000 lines. |
-| `offset` | integer | no | Line number to start from (1-indexed) |
+| `limit` | integer | yes | Max number of lines to read. Use 0 to read until end of file (capped at 2000 lines). |
+| `offset` | integer | yes | Line number to start from (1-indexed). Use 1 for the first line. |
 | `path` | string | yes | Absolute path to the file or directory |
 
 ### `write` *(lua plugin)*
@@ -138,7 +138,7 @@ Execute Python code in a sandboxed interpreter with tools as callable functions.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `code` | string | yes |  | Python code to execute. Tools are async functions that return strings (not objects). You MUST await every call: `result = await read(path='/file')`. Use `await asyncio.gather(...)` for concurrency. |
+| `code` | string | yes |  | Python code to execute. Tools are async functions that return strings (not objects). You MUST await every call: `result = await read(path='/file', offset=1, limit=0)`. Use `await asyncio.gather(...)` for concurrency. |
 | `timeout` | integer | no | 30 | Script execution timeout in seconds |
 
 ### `question` *(lua plugin)*


### PR DESCRIPTION
Optional parameters regularly confuse at least smaller models: I've seen Qwen 3.6 27B explicitly state that it's trying to read lines X-Y and then it's calling read without the parameters. 3 times in a row until the repeated-tool-call trigger happens, the context is a lot more full, and it tries to use `sed` to get the lines it wants.

Also observed with Qwen 3.6 35B-A3B regularly, and Mistral Medium 3.5 sometimes.

This avoids filling the context unnecessarily on big files at very little cost.

CC @g4bwy in case he also saw that