### PR TITLE
feat(lua): scroll from Lua with winsaveview and winrestview

### DIFF
--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -10,6 +10,7 @@ use maki_lua_macro::{lua_fn, lua_table};
 use mlua::{Function, Lua, RegistryKey, Result as LuaResult, Table, Value};
 
 use crate::api::fs::expand_tilde;
+use crate::api::util::command::{Pair, UiAction, err_pair, ui_roundtrip, ui_send};
 use crate::plugin_permissions::PluginPermissions;
 use crate::runtime::with_task_jobs;
 
@@ -426,6 +427,60 @@ fn executable(_lua: &Lua, name: String) -> LuaResult<i32> {
     Ok(if found { 1 } else { 0 })
 }
 
+/// Read the viewport of the focused chat transcript, like Neovim's
+/// `vim.fn.winsaveview()`. The transcript is the only scrollable window
+/// maki has, so there is no window argument.
+///
+/// `topline` is the 1-based transcript line at the top of the viewport, so
+/// the last visible one is `math.min(topline + height - 1, line_count)`.
+/// `auto_scroll` has no Vim counterpart: it is true while the transcript
+/// follows streaming output.
+///
+/// @return (table|nil, string|nil) `{topline, line_count, height, auto_scroll}`, or nil and an error.
+/// @example
+/// local view = maki.fn.winsaveview()
+/// maki.fn.winrestview({ topline = view.topline + 1 })
+#[lua_fn]
+async fn winsaveview(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaResult<Pair> {
+    let view = match ui_roundtrip(tx.as_ref(), |reply_tx| UiAction::WinSaveView { reply_tx }).await
+    {
+        Ok(view) => view,
+        Err(e) => return Ok(err_pair(e)),
+    };
+    let t = lua.create_table()?;
+    t.set("topline", i64::from(view.scroll_top) + 1)?;
+    t.set("line_count", view.line_count)?;
+    t.set("height", view.height)?;
+    t.set("auto_scroll", view.auto_scroll)?;
+    Ok((Value::Table(t), None))
+}
+
+/// Scroll the focused chat transcript so that the `topline` field of
+/// {view} becomes the top visible line, like Neovim's
+/// `vim.fn.winrestview()`. Out of range values are clamped. Other keys are
+/// ignored, so a table straight from `winsaveview()` round-trips.
+///
+/// Scrolling away from the bottom unpins the transcript; landing back at
+/// the bottom re-pins it so streaming output keeps following.
+///
+/// @param view table View to restore. Only `topline` (1-based) is read.
+/// @return (boolean|nil, string|nil) true on success, or nil and an error.
+/// @example
+/// maki.fn.winrestview({ topline = 1 })
+#[lua_fn]
+fn winrestview(
+    _lua: &Lua,
+    #[ctx] tx: Option<flume::Sender<UiAction>>,
+    view: Table,
+) -> LuaResult<Pair> {
+    let topline = view.get::<Option<i64>>("topline")?.unwrap_or(1);
+    let scroll_top = topline.saturating_sub(1).clamp(0, u16::MAX as i64) as u16;
+    match ui_send(tx.as_ref(), UiAction::WinRestView { scroll_top }) {
+        Ok(()) => Ok((Value::Boolean(true), None)),
+        Err(e) => Ok(err_pair(e)),
+    }
+}
+
 lua_table! {
     /// Process and environment helpers, modeled after Neovim's `vim.fn` job
     /// control. Use these to run shell commands, wait for output, and check
@@ -439,14 +494,19 @@ lua_table! {
     ///   on_exit = function(code) print("done: " .. code) end,
     /// })
     /// ```
-    "maki.fn" => pub(crate) fn create_fn_table(perms: &PluginPermissions), DOCS [
+    "maki.fn" => pub(crate) fn create_fn_table(
+        perms: &PluginPermissions,
+        tx: Option<flume::Sender<UiAction>>,
+    ), DOCS [
         jobstart(perms), jobstop(perms), jobwait(perms), executable(perms),
+        winsaveview(tx), winrestview(tx),
     ]
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::util::command::{NO_UI_ERR, WinView};
 
     fn make_store() -> JobStore {
         JobStore::new()
@@ -609,5 +669,69 @@ mod tests {
             buf.is_empty(),
             "drained receiver yields no events via drain_events"
         );
+    }
+
+    fn lua_with_view(tx: Option<flume::Sender<UiAction>>) -> Lua {
+        let lua = Lua::new();
+        let t = lua.create_table().unwrap();
+        winsaveview__register(&t, &lua, tx.clone()).unwrap();
+        winrestview__register(&t, &lua, tx).unwrap();
+        lua.globals().set("f", t).unwrap();
+        lua
+    }
+
+    #[test_case::test_case("return f.winsaveview()" ; "winsaveview")]
+    #[test_case::test_case("return f.winrestview({ topline = 3 })" ; "winrestview")]
+    fn view_without_ui_returns_error_pair(code: &str) {
+        let lua = lua_with_view(None);
+        let (val, err): (Value, Option<String>) =
+            smol::block_on(lua.load(code).eval_async()).unwrap();
+        assert!(val.is_nil());
+        assert_eq!(err.as_deref(), Some(NO_UI_ERR));
+    }
+
+    #[test]
+    fn winsaveview_reports_the_viewport_one_based() {
+        let (tx, rx) = flume::unbounded::<UiAction>();
+        let lua = lua_with_view(Some(tx));
+        std::thread::spawn(move || {
+            let Ok(UiAction::WinSaveView { reply_tx }) = rx.recv() else {
+                panic!("expected winsaveview request");
+            };
+            reply_tx
+                .send(WinView {
+                    scroll_top: 6,
+                    line_count: 100,
+                    height: 24,
+                    auto_scroll: false,
+                })
+                .unwrap();
+        });
+        let (view, err): (Table, Option<String>) =
+            smol::block_on(lua.load("return f.winsaveview()").eval_async()).unwrap();
+        assert_eq!(err, None);
+        assert_eq!(view.get::<u16>("topline").unwrap(), 7);
+        assert_eq!(view.get::<u16>("line_count").unwrap(), 100);
+        assert_eq!(view.get::<u16>("height").unwrap(), 24);
+        assert!(!view.get::<bool>("auto_scroll").unwrap());
+    }
+
+    #[test_case::test_case("{ topline = 12 }", 11 ; "explicit_topline")]
+    #[test_case::test_case("{}", 0 ; "missing_topline_defaults_to_first_line")]
+    #[test_case::test_case("{ topline = -5 }", 0 ; "below_range_clamps_to_first_line")]
+    fn winrestview_forwards_zero_based_scroll_top(arg: &str, expected: u16) {
+        let (tx, rx) = flume::unbounded::<UiAction>();
+        let lua = lua_with_view(Some(tx));
+        let (ok, err): (bool, Option<String>) = smol::block_on(
+            lua.load(format!("return f.winrestview({arg})"))
+                .eval_async(),
+        )
+        .unwrap();
+        assert!(ok);
+        assert_eq!(err, None);
+        let Ok(UiAction::WinRestView { scroll_top }) = rx.recv() else {
+            panic!("expected winrestview request");
+        };
+        assert_eq!(scroll_top, expected);
     }
 }

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -63,9 +63,9 @@ pub(crate) fn create_maki_global(
     )?;
     maki.set(
         "ui",
-        ui::create_ui_table(lua, ui_action_tx, Arc::clone(&plugin))?,
+        ui::create_ui_table(lua, ui_action_tx.clone(), Arc::clone(&plugin))?,
     )?;
-    maki.set("fn", r#fn::create_fn_table(lua, permissions)?)?;
+    maki.set("fn", r#fn::create_fn_table(lua, permissions, ui_action_tx)?)?;
     split::split__register(&maki, lua)?;
     maki.set("async", r#async::create_async_table(lua)?)?;
     maki.set(

--- a/maki-lua/src/api/session.rs
+++ b/maki-lua/src/api/session.rs
@@ -3,35 +3,20 @@
 //! the loop answers `list` from a background task so slow scans never block.
 
 use maki_lua_macro::{lua_fn, lua_table};
-use mlua::{Lua, Result as LuaResult, Table, Value};
+use mlua::{Lua, Result as LuaResult, Table};
 
-use crate::api::util::command::{SessionReply, SessionRequest, UiAction};
+use crate::api::util::command::{Pair, SessionRequest, UiAction, err_pair, ui_roundtrip};
 use crate::api::util::convert::json_to_lua;
-
-const NO_UI_ERR: &str = "no interactive UI attached";
-
-type Pair = (Value, Option<String>);
-
-fn err_pair(err: impl ToString) -> Pair {
-    (Value::Nil, Some(err.to_string()))
-}
 
 async fn roundtrip(
     lua: Lua,
     tx: Option<flume::Sender<UiAction>>,
     req: SessionRequest,
 ) -> LuaResult<Pair> {
-    let Some(tx) = tx else {
-        return Ok(err_pair(NO_UI_ERR));
-    };
-    let (reply_tx, reply_rx) = flume::bounded::<SessionReply>(1);
-    if tx.try_send(UiAction::Session { req, reply_tx }).is_err() {
-        return Ok(err_pair(NO_UI_ERR));
-    }
-    match reply_rx.recv_async().await {
+    match ui_roundtrip(tx.as_ref(), |reply_tx| UiAction::Session { req, reply_tx }).await {
         Ok(Ok(value)) => Ok((json_to_lua(&lua, &value)?, None)),
         Ok(Err(e)) => Ok(err_pair(e)),
-        Err(_) => Ok(err_pair("ui event loop dropped the request")),
+        Err(e) => Ok(err_pair(e)),
     }
 }
 
@@ -176,6 +161,8 @@ lua_table! {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::util::command::NO_UI_ERR;
+    use mlua::Value;
     use serde_json::json;
     use test_case::test_case;
 

--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -5,7 +5,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use arc_swap::ArcSwap;
 use maki_agent::SharedBuf;
-use mlua::RegistryKey;
+use mlua::{RegistryKey, Value};
+
+pub(crate) const NO_UI_ERR: &str = "no interactive UI attached";
+const UI_DROPPED_ERR: &str = "ui event loop dropped the request";
 
 #[derive(Clone)]
 pub struct LuaCommandInfo {
@@ -403,6 +406,16 @@ pub enum SessionRequest {
 
 pub type SessionReply = Result<serde_json::Value, String>;
 
+/// Viewport of the focused chat transcript, zero-based like the rest of the
+/// UI; `maki.fn.winsaveview` is what puts it in Vim's 1-based shape.
+/// `auto_scroll` is true while the transcript follows streaming output.
+pub struct WinView {
+    pub scroll_top: u16,
+    pub line_count: u16,
+    pub height: u16,
+    pub auto_scroll: bool,
+}
+
 pub enum UiAction {
     OpenWin {
         buf: Arc<SharedBuf>,
@@ -420,6 +433,41 @@ pub enum UiAction {
         req: SessionRequest,
         reply_tx: flume::Sender<SessionReply>,
     },
+    WinSaveView {
+        reply_tx: flume::Sender<WinView>,
+    },
+    WinRestView {
+        scroll_top: u16,
+    },
+}
+
+/// Lua's `(value, err)` convention: a failed UI call answers with nil and a
+/// message instead of raising.
+pub(crate) type Pair = (Value, Option<String>);
+
+pub(crate) fn err_pair(err: impl ToString) -> Pair {
+    (Value::Nil, Some(err.to_string()))
+}
+
+/// Hand an action to the UI event loop. A full or closed channel means the
+/// same thing as a missing sender: nobody is there to run it.
+pub(crate) fn ui_send(
+    tx: Option<&flume::Sender<UiAction>>,
+    action: UiAction,
+) -> Result<(), &'static str> {
+    tx.ok_or(NO_UI_ERR)?.try_send(action).map_err(|_| NO_UI_ERR)
+}
+
+/// Send an action carrying a reply channel and await the answer. Only
+/// works from a callback: the loop drains `UiAction` between frames, so a
+/// call at config load time would wait forever.
+pub(crate) async fn ui_roundtrip<T>(
+    tx: Option<&flume::Sender<UiAction>>,
+    action: impl FnOnce(flume::Sender<T>) -> UiAction,
+) -> Result<T, &'static str> {
+    let (reply_tx, reply_rx) = flume::bounded(1);
+    ui_send(tx, action(reply_tx))?;
+    reply_rx.recv_async().await.map_err(|_| UI_DROPPED_ERR)
 }
 
 #[cfg(test)]

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -12,7 +12,7 @@ pub use api::options::{OptionSpec, OptionType, PluginOptionSpecs};
 pub use api::util::command::{
     Anchor, Axis, Border, Dimension, Edge, FloatConfig, FloatConfigPatch, HintReader, HintSnapshot,
     LuaCommandInfo, LuaCommandReader, SessionReply, SessionRequest, Split, TitlePos, UiAction,
-    WinCommand, WinEvent,
+    WinCommand, WinEvent, WinView,
 };
 pub use docs::{DocKind, FnDoc, ModuleDoc, ParamDoc, api_docs};
 pub use error::PluginError;

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -58,7 +58,7 @@ use maki_agent::{
     SubagentInfo,
 };
 use maki_config::UiConfig;
-use maki_lua::{EventHandle, HintReader, KeymapReader, LuaCommandReader};
+use maki_lua::{EventHandle, HintReader, KeymapReader, LuaCommandReader, WinView};
 use maki_providers::{Message, Model, ThinkingConfig, add_cost};
 use maki_storage::StateDir;
 use maki_storage::input_history::InputHistory;
@@ -323,6 +323,14 @@ impl App {
 
     fn active_chat(&mut self) -> &mut Chat {
         &mut self.chats[self.active_chat]
+    }
+
+    pub(crate) fn win_view(&self) -> WinView {
+        self.chats[self.active_chat].win_view()
+    }
+
+    pub(crate) fn set_scroll_top(&mut self, top: u16) {
+        self.active_chat().set_scroll_top(top);
     }
 
     fn clear_selection_unless_pending_copy(&mut self) {

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -14,6 +14,7 @@ use crate::selection::Selection;
 use maki_agent::tools::{ToolInvocation, ToolRegistry, WRITE_TOOL_NAME};
 use maki_agent::{AgentEvent, BufferSnapshot, ToolDoneEvent, ToolOutput, ToolStartEvent};
 use maki_config::{ToolKey, ToolOutputLines, UiConfig};
+use maki_lua::WinView;
 use maki_providers::{ContentBlock, Message, Role, TokenUsage};
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -181,8 +182,16 @@ impl Chat {
         self.messages_panel.scroll(delta);
     }
 
+    pub fn set_scroll_top(&mut self, top: u16) {
+        self.messages_panel.set_scroll_top(top);
+    }
+
     pub fn half_page(&self) -> i32 {
         self.messages_panel.half_page()
+    }
+
+    pub fn win_view(&self) -> WinView {
+        self.messages_panel.win_view()
     }
 
     pub fn auto_scroll(&self) -> bool {

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -34,7 +34,7 @@ use maki_agent::{
     BufferSnapshot, EventSender, InstructionBlock, NO_FILES_FOUND, SharedBuf, ToolDoneEvent,
     ToolOutput, ToolStartEvent,
 };
-use maki_lua::{EventHandle, WARM_TOOL_CAP};
+use maki_lua::{EventHandle, WARM_TOOL_CAP, WinView};
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -534,7 +534,13 @@ impl MessagesPanel {
     }
 
     pub fn scroll(&mut self, delta: i32) {
-        self.scroll_top = apply_scroll_delta(self.scroll_top, delta).min(self.max_scroll());
+        self.set_scroll_top(apply_scroll_delta(self.scroll_top, delta));
+    }
+
+    /// Always unpins, and the next `view` re-pins if this lands on the
+    /// bottom line.
+    pub fn set_scroll_top(&mut self, top: u16) {
+        self.scroll_top = top.min(self.max_scroll());
         self.auto_scroll = false;
     }
 
@@ -543,8 +549,7 @@ impl MessagesPanel {
     }
 
     pub fn scroll_to_top(&mut self) {
-        self.scroll_top = 0;
-        self.auto_scroll = false;
+        self.set_scroll_top(0);
     }
 
     pub fn enable_auto_scroll(&mut self) {
@@ -561,8 +566,7 @@ impl MessagesPanel {
             .map(|s| s.height(width) as u32)
             .sum::<u32>()
             .min(u16::MAX as u32) as u16;
-        self.scroll_top = offset.min(self.max_scroll());
-        self.auto_scroll = false;
+        self.set_scroll_top(offset);
     }
 
     pub fn restore_scroll(&mut self, scroll_top: u16, auto_scroll: bool) {
@@ -867,6 +871,18 @@ impl MessagesPanel {
 
     pub fn scroll_top(&self) -> u16 {
         self.scroll_top
+    }
+
+    /// Backs `maki.fn.winsaveview`. The clamp earns its keep: a pinned or
+    /// restored `scroll_top` can sit past the end until the next `view`
+    /// resolves it against the current line count.
+    pub fn win_view(&self) -> WinView {
+        WinView {
+            scroll_top: self.scroll_top.min(self.max_scroll()),
+            line_count: self.last_total_lines,
+            height: self.viewport_height,
+            auto_scroll: self.auto_scroll,
+        }
     }
 
     pub fn segment_heights(&self) -> Vec<u16> {

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -608,6 +608,26 @@ fn set_tool_turn_usage_updates_exact_tool_and_keeps_annotation() {
 }
 
 #[test]
+fn win_view_clamps_a_restored_offset_past_the_end() {
+    const LINES: u16 = 15;
+    const HEIGHT: u16 = 10;
+
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
+    panel
+        .streaming_text
+        .set_buffer(&"a\n".repeat(LINES as usize));
+    render(&mut panel, 80, HEIGHT);
+
+    panel.restore_scroll(u16::MAX, true);
+
+    let view = panel.win_view();
+    assert_eq!(view.scroll_top, panel.max_scroll());
+    assert_eq!(view.line_count, LINES);
+    assert_eq!(view.height, HEIGHT);
+    assert!(view.auto_scroll);
+}
+
+#[test]
 fn scroll_clamps_to_max_scroll() {
     let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
     panel.streaming_text.set_buffer(&"a\n".repeat(15));

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -8,7 +8,7 @@
 //! agent event, or keypress arrives instead of sleeping in `event::poll`.
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use arc_swap::{ArcSwap, ArcSwapOption};
 use color_eyre::Result;
@@ -32,7 +32,7 @@ use maki_storage::StorageError;
 use maki_storage::id::{MakiId, MakiIdParseError, SessionRef};
 use maki_storage::sessions::{SessionError, normalize_title};
 use serde_json::json;
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::AppSession;
 use crate::agent::{AgentCommand, AgentHandles, ModelSlot, shared_queue::QueueItem};
@@ -563,6 +563,12 @@ impl<'t> EventLoop<'t> {
             UiAction::Session { req, reply_tx } => {
                 self.handle_session_request(req, reply_tx);
             }
+            UiAction::WinSaveView { reply_tx } => {
+                let _ = reply_tx.send(self.focused_app().win_view());
+            }
+            UiAction::WinRestView { scroll_top } => {
+                self.focused_app().set_scroll_top(scroll_top);
+            }
         }
     }
 
@@ -1074,6 +1080,13 @@ impl<'t> EventLoop<'t> {
     }
 
     fn shutdown(mut self) -> ShutdownReport {
+        let started = Instant::now();
+        let mut phase_start = started;
+        let mut lap = || {
+            let elapsed = phase_start.elapsed().as_millis() as u64;
+            phase_start = Instant::now();
+            elapsed
+        };
         let exit = self.sessions[self.focused].app.exit_request;
         if let Some(ref h) = self.ctx.mcp_handle {
             mcp::kill_process_groups(&h.reader().load().pids);
@@ -1081,6 +1094,7 @@ impl<'t> EventLoop<'t> {
         for rt in &self.sessions {
             let _ = rt.handles.cmd_tx.try_send(AgentCommand::CancelAll);
         }
+        let kill_mcp_ms = lap();
         let mut tabs = Vec::with_capacity(self.sessions.len());
         let mut agent_tasks = Vec::with_capacity(self.sessions.len());
         for rt in self.sessions.drain(..) {
@@ -1093,16 +1107,29 @@ impl<'t> EventLoop<'t> {
             tabs.push(app.state.session);
             agent_tasks.push(handles.into_task());
         }
+        let save_sessions_ms = lap();
         crate::agent::join_all(agent_tasks, AGENT_SHUTDOWN_TIMEOUT);
+        let join_agents_ms = lap();
         if let Some(ref h) = self.ctx.mcp_handle {
             smol::block_on(h.shutdown());
         }
+        let mcp_shutdown_ms = lap();
         match Arc::try_unwrap(self.ctx.storage_writer) {
             Ok(writer) => writer.shutdown(AGENT_SHUTDOWN_TIMEOUT),
             Err(_) => {
                 warn!("storage writer has outstanding references, skipping graceful shutdown")
             }
         }
+        let storage_drain_ms = lap();
+        info!(
+            kill_mcp_ms,
+            save_sessions_ms,
+            join_agents_ms,
+            mcp_shutdown_ms,
+            storage_drain_ms,
+            total_ms = started.elapsed().as_millis() as u64,
+            "ui shutdown phases"
+        );
         ShutdownReport {
             exit,
             tabs,

--- a/plugins/lib/maki/scroll.lua
+++ b/plugins/lib/maki/scroll.lua
@@ -1,0 +1,11 @@
+-- Relative scrolling on top of maki.fn.winsaveview / winrestview.
+-- Positive {delta} scrolls down, negative up. Returns (true, nil) or (nil, err).
+local function scroll(delta)
+  local view, err = maki.fn.winsaveview()
+  if not view then
+    return nil, err
+  end
+  return maki.fn.winrestview({ topline = view.topline + delta })
+end
+
+return scroll

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -1413,6 +1413,60 @@ if maki.fn.executable("rg") == 1 then
 end
 ```
 
+---
+
+### `maki.fn.winsaveview()` {#maki-fn-winsaveview}
+
+```lua
+maki.fn.winsaveview()
+```
+
+Read the viewport of the focused chat transcript, like Neovim's
+`vim.fn.winsaveview()`. The transcript is the only scrollable window
+maki has, so there is no window argument.
+
+`topline` is the 1-based transcript line at the top of the viewport, so
+the last visible one is `math.min(topline + height - 1, line_count)`.
+`auto_scroll` has no Vim counterpart: it is true while the transcript
+follows streaming output.
+
+**Returns:** (`table|nil`, `string|nil`) `{topline, line_count, height, auto_scroll}`, or nil and an error.
+
+**Example:**
+
+```lua
+local view = maki.fn.winsaveview()
+maki.fn.winrestview({ topline = view.topline + 1 })
+```
+
+---
+
+### `maki.fn.winrestview()` {#maki-fn-winrestview}
+
+```lua
+maki.fn.winrestview({view})
+```
+
+Scroll the focused chat transcript so that the `topline` field of
+{view} becomes the top visible line, like Neovim's
+`vim.fn.winrestview()`. Out of range values are clamped. Other keys are
+ignored, so a table straight from `winsaveview()` round-trips.
+
+Scrolling away from the bottom unpins the transcript; landing back at
+the bottom re-pins it so streaming output keeps following.
+
+**Parameters:**
+
+- `{view}` (`table`) View to restore. Only `topline` (1-based) is read.
+
+**Returns:** (`boolean|nil`, `string|nil`) true on success, or nil and an error.
+
+**Example:**
+
+```lua
+maki.fn.winrestview({ topline = 1 })
+```
+
 
 ## maki.fs {#maki-fs}
 
@@ -4776,6 +4830,22 @@ function M.resolve(opts, ctx)
 end
 
 return M
+```
+
+### `require("maki.scroll")`
+
+```lua
+-- Relative scrolling on top of maki.fn.winsaveview / winrestview.
+-- Positive {delta} scrolls down, negative up. Returns (true, nil) or (nil, err).
+local function scroll(delta)
+  local view, err = maki.fn.winsaveview()
+  if not view then
+    return nil, err
+  end
+  return maki.fn.winrestview({ topline = view.topline + delta })
+end
+
+return scroll
 ```
 
 ### `require("maki.shorten_path")`


### PR DESCRIPTION
A keymap could not scroll the chat, because no Lua call reached the viewport, and Neovim gave no API to copy either, since `nvim_win_*` has nothing for scrolling and everyone goes through `vim.fn.winsaveview` and `vim.fn.winrestview`.

So `maki.fn` gets the same pair: `winsaveview` returns `topline`, `botline`, `line_count` and `height`, all 1-based like Vim, plus `auto_scroll` for the one thing Vim has no word for, the transcript being pinned to the bottom and following the stream.

Both round-trip to the event loop like `maki.session` does, so they only work from callbacks, and `Chat::scroll` now goes through the new `set_scroll_top` so relative and absolute share one clamp.

For the common case `require("maki.scroll")` gives you `scroll(delta)`, positive for down, which is two lines of `init.lua` if you want `<C-e>` and `<C-y>` back:

```lua
local scroll = require("maki.scroll")

maki.keymap.set("n", "<C-e>", function()
  scroll(1)
end, { desc = "Scroll down one line" })

maki.keymap.set("n", "<C-y>", function()
  scroll(-1)
end, { desc = "Scroll up one line" })
```