### PR TITLE
feat(lua): emit session focus changes

### DIFF
--- a/maki-lua/src/api/autocmd.rs
+++ b/maki-lua/src/api/autocmd.rs
@@ -128,12 +128,13 @@ fn parse_string_or_seq(value: Value, what: &str) -> LuaResult<Vec<String>> {
 /// `del_autocmd` later to remove the listener.
 ///
 /// Built-in events fired by the host: `"TurnStart"`, `"TurnEnd"`,
-/// `"TurnError"`, `"SessionReset"`. Plugins can also fire their own
-/// events with `exec_autocmds`.
+/// `"TurnError"`, `"SessionReset"`, and `"SessionFocusChanged"`. Plugins can
+/// also fire their own events with `exec_autocmds`.
 ///
 /// Each host event carries `data.session_id`. For `"SessionReset"` that
-/// is the session being left behind, so a handler can drop what belonged
-/// to it; the other three name the session still running.
+/// is the session being left behind; the other events name the session now
+/// running or focused. `"SessionFocusChanged"` also carries
+/// `data.previous_session_id` except on initial startup.
 ///
 /// @param event string|string[] Event name or list of names.
 /// @param opts table Options:

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -203,6 +203,7 @@ pub(crate) struct EventLoop<'t> {
     terminal: &'t mut ratatui::DefaultTerminal,
     sessions: Vec<SessionRuntime>,
     focused: usize,
+    last_focused: Option<MakiId>,
     ctx: SpawnCtx,
     input: InputReader,
     warn_rx: flume::Receiver<String>,
@@ -394,6 +395,7 @@ impl<'t> EventLoop<'t> {
             terminal,
             sessions: runtimes,
             focused,
+            last_focused: None,
             ctx,
             input: InputReader::spawn(),
             warn_rx: bg.warn_rx,
@@ -544,6 +546,7 @@ impl<'t> EventLoop<'t> {
         }
         drop(slot_model);
 
+        self.emit_focus_change();
         self.emit_status_changes();
         Ok(())
     }
@@ -616,6 +619,21 @@ impl<'t> EventLoop<'t> {
                 }),
             );
         }
+    }
+
+    fn emit_focus_change(&mut self) {
+        let id = self.sessions[self.focused].id();
+        if self.last_focused == Some(id) {
+            return;
+        }
+        let mut data = json!({ "session_id": id });
+        if let Some(previous) = self.last_focused {
+            data["previous_session_id"] = json!(previous.to_string());
+        }
+        self.last_focused = Some(id);
+        self.ctx
+            .lua_event_handle
+            .fire_autocmd("SessionFocusChanged", data);
     }
 
     /// `List` replies from a background task (the scan can be slow); every

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -450,12 +450,13 @@ Listen for one or more events. Returns an id you can pass to
 `del_autocmd` later to remove the listener.
 
 Built-in events fired by the host: `"TurnStart"`, `"TurnEnd"`,
-`"TurnError"`, `"SessionReset"`. Plugins can also fire their own
-events with `exec_autocmds`.
+`"TurnError"`, `"SessionReset"`, and `"SessionFocusChanged"`. Plugins can
+also fire their own events with `exec_autocmds`.
 
 Each host event carries `data.session_id`. For `"SessionReset"` that
-is the session being left behind, so a handler can drop what belonged
-to it; the other three name the session still running.
+is the session being left behind; the other events name the session now
+running or focused. `"SessionFocusChanged"` also carries
+`data.previous_session_id` except on initial startup.
 
 **Parameters:**
 


### PR DESCRIPTION
## Summary

- detect focused-session changes once per event-loop cycle
- emit `SessionFocusChanged` for startup, tab switches, `/new` resets,
  in-place loads, and future focus paths
- include the focused session id and the previous id when one exists
- document the built-in event

## Why

Session-scoped Lua plugins can keep per-session data, but their UI hints are
host-global. Without a focus event, a plugin cannot restore or clear its UI
when the user changes sessions.

This is one of the generic Lua capabilities needed by the external goal plugin
discussed in #703. It contains no goal policy or plugin code.

## Validation

- `cargo fmt --all -- --check`
- `stylua --check plugins/`
- `cargo clippy --all --tests -- -D warnings`
- `cargo nextest run --workspace` (3,455 passed)
- `cargo test --workspace --doc`
- `just gen-docs-check`
- `cargo machete`

---

AI use, per CONTRIBUTING: implemented and reviewed with Codex at my direction.
