### PR TITLE
feat(task): allow full model spec for subagents

### DIFF
--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -660,6 +660,36 @@ fn agent_api_value_failures_return_err_pairs() {
     assert_eq!(out, "prompt_err tools_err model_err");
 }
 
+/// `spec` must win over `tier` when both are given, proving the task plugin's
+/// `model` field (forwarded as `spec`) takes precedence over `model_tier`.
+#[test]
+fn resolve_model_spec_takes_precedence_over_tier() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let src = format!(
+        r#"maki.api.register_tool({{
+            name = "spec_precedence_probe",
+            description = "t",
+            schema = {MINIMAL_SCHEMA},
+            audiences = {{ "main" }},
+            handler = function(input, ctx)
+                local m, err = maki.agent.resolve_model(ctx, {{
+                    tier = "weak",
+                    spec = "anthropic/claude-opus-4-8",
+                }})
+                if err then return "err:" .. err end
+                return m.spec
+            end
+        }})"#
+    );
+    host.load_source("spec_precedence_probe", &src).unwrap();
+    let out = exec_tool(&reg, "spec_precedence_probe", serde_json::json!({})).unwrap();
+    assert_eq!(
+        out, "anthropic/claude-opus-4-8",
+        "spec must override tier when both are set"
+    );
+}
+
 /// Restore used to lose anything drawn via `maki.async.run`: those tasks
 /// landed in the global spawn queue, which runs after the snapshot is
 /// taken. The runtime must run them inline, after the restore fn and after

--- a/maki-lua/tests/task_policy.rs
+++ b/maki-lua/tests/task_policy.rs
@@ -66,6 +66,7 @@ maki.async.semaphore = function(n)
 end
 
 maki.agent.resolve_model = function(ctx, opts)
+  recorder.resolve_opts = opts
   return { spec = "test/model" }
 end
 
@@ -147,6 +148,9 @@ maki.api.register_tool({
       released = recorder.released,
       sem_size = recorder.sem_size,
     }
+    if recorder.resolve_opts then
+      snap.resolve_opts = recorder.resolve_opts
+    end
     if #recorder.prompts > 0 then
       snap.prompts = recorder.prompts
     end
@@ -156,14 +160,24 @@ maki.api.register_tool({
 "#;
 
 fn load_task_host() -> (Arc<ToolRegistry>, PluginHost) {
+    load_task_host_with_opts(serde_json::Map::new())
+}
+
+fn load_task_host_with_opts(
+    opts: serde_json::Map<String, serde_json::Value>,
+) -> (Arc<ToolRegistry>, PluginHost) {
     let reg = Arc::new(ToolRegistry::new());
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
     let prelude = STUB_PRELUDE
         .replace("@PLAIN_TEXT@", PLAIN_TEXT)
         .replace("@PROMPT_ERR@", PROMPT_ERR_MSG)
         .replace("@RAISE_MSG@", RAISE_MSG);
-    host.load_source("task_policy", &format!("{prelude}\n{TASK_PLUGIN_SRC}"))
-        .unwrap();
+    host.load_source_with_opts(
+        "task_policy",
+        &format!("{prelude}\n{TASK_PLUGIN_SRC}"),
+        opts,
+    )
+    .unwrap();
     (reg, host)
 }
 
@@ -192,6 +206,47 @@ fn task_input(scenario: &str, output_schema: Option<Value>) -> Value {
         input["output_schema"] = schema;
     }
     input
+}
+
+const FULL_MODEL_SPEC: &str = "aperture/ollama/glm-5.2";
+
+#[test]
+fn model_spec_forwards_full_spec_to_resolve_model() {
+    let mut opts = serde_json::Map::new();
+    opts.insert("allow_model".into(), json!(true));
+    let (reg, _host) = load_task_host_with_opts(opts);
+    let mut input = task_input(SCENARIO_PLAIN, None);
+    input["model"] = json!(FULL_MODEL_SPEC);
+    let out = exec_tool(&reg, TASK_TOOL, input).expect("task with model spec failed");
+    assert_eq!(out, PLAIN_TEXT);
+
+    let snap = probe(&reg);
+    let opts = snap["resolve_opts"]
+        .as_object()
+        .expect("resolve_opts missing");
+    assert_eq!(opts["spec"], json!(FULL_MODEL_SPEC));
+    assert!(
+        opts.get("tier").is_none_or(Value::is_null),
+        "tier should be unset when only model spec is given"
+    );
+}
+
+#[test]
+fn model_spec_ignored_when_allow_model_off() {
+    let (reg, _host) = load_task_host();
+    let mut input = task_input(SCENARIO_PLAIN, None);
+    input["model"] = json!(FULL_MODEL_SPEC);
+    let out = exec_tool(&reg, TASK_TOOL, input).expect("task with model spec failed");
+    assert_eq!(out, PLAIN_TEXT);
+
+    let snap = probe(&reg);
+    let opts = snap["resolve_opts"]
+        .as_object()
+        .expect("resolve_opts missing");
+    assert!(
+        opts.get("spec").is_none_or(Value::is_null),
+        "spec should not be forwarded when allow_model is off"
+    );
 }
 
 fn answer_schema() -> Value {

--- a/plugins/task/init.lua
+++ b/plugins/task/init.lua
@@ -39,6 +39,14 @@ Notes:
 4. Tell it to return concise summaries with file:line refs, not full file contents.
 ]]
 
+local opts = maki.api.register_options({
+  max_concurrent = { default = 8, min = 1, desc = "Max concurrently running subagents." },
+  allow_model = {
+    default = false,
+    desc = "Expose a `model` input that overrides the subagent model. Only enable if you trust callers to pick an exact model themselves.",
+  },
+})
+
 local schema = {
   type = "object",
   required = { "description", "prompt" },
@@ -66,6 +74,15 @@ local schema = {
   },
 }
 
+-- Only advertise `model` when the plugin opts in: it costs tokens in every
+-- task schema, and an off-by-default flag keeps the common path lean.
+if opts.allow_model then
+  schema.properties.model = {
+    type = "string",
+    description = 'Exact model spec, e.g. "ollama/glm-5.2". You tell maki the model; maki will not guess. Overrides model_tier.',
+  }
+end
+
 local examples = {
   {
     description = "Find auth middleware",
@@ -73,10 +90,6 @@ local examples = {
     model_tier = "weak",
   },
 }
-
-local opts = maki.api.register_options({
-  max_concurrent = { default = 8, min = 1, desc = "Max concurrently running subagents." },
-})
 
 -- Process-wide cap on concurrent subagents.
 local semaphore = maki.async.semaphore(opts.max_concurrent)
@@ -110,6 +123,7 @@ local function handler(input, ctx)
 
   local model, model_err = maki.agent.resolve_model(ctx, {
     tier = input.model_tier,
+    spec = opts.allow_model and input.model or nil,
   })
   if model_err then
     return { llm_output = model_err, is_error = true }

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -205,6 +205,7 @@ maki.setup({
 
 | Field | Type | Default | Min | Description |
 |-------|------|---------|-----|-------------|
+| `allow_model` | boolean | `false` | - | Expose a `model` input that overrides the subagent model. Only enable if you trust callers to pick an exact model themselves. |
 | `max_concurrent` | integer | `8` | 1 | Max concurrently running subagents. |
 
 ### `plugins.webfetch`


### PR DESCRIPTION
Sometimes I really want to be able to specify exactly which model to use for a task, instead of only choosing by tier. Been using this code for a few days now and it seems to work nicely for me, figured maybe worth sharing.