### PR TITLE
refactor(lua): one home for the `(value, err)` pair

### DIFF
--- a/maki-lua/src/api/AGENTS.md
+++ b/maki-lua/src/api/AGENTS.md
@@ -10,5 +10,7 @@ Our goal is to let plugin authors have as much freedom as possible, that's why d
 
 Fallible runtime operations return the pair (value, err) and never throw.
 Throwing is reserved for programmer errors, like passing a number where a string belongs.
+`util/pair.rs` is the single home for that shape: use `Pair<T>`, `err_pair`, `pair`, and `try_pair!` instead of writing a new helper.
+A call with nothing to return still answers `(true, nil)` on success, so `if not ok` always means failure.
 
 Tool handlers fail with `{ llm_output = msg, is_error = true }`; a plain string is always success (only `is_error` flags the result as an error to the provider).

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -34,6 +34,7 @@ use tracing::info;
 use crate::api::ui::buf::BufHandle;
 use crate::api::util::convert::{json_to_lua, lua_to_json, lua_tool_result};
 use crate::api::util::ctx::{AgentContext, LuaCtx};
+use crate::api::util::pair::{Pair, err_pair, try_pair};
 
 const SESSION_CLOSED_ERR: &str = "session closed";
 const DEFAULT_SESSION_AUDIENCE: ToolAudience = ToolAudience::GENERAL_SUB;
@@ -72,12 +73,6 @@ fn dispatch_ctx<'a>(ctx: &'a LuaCtx, method: &str) -> Result<&'a AgentContext, S
         .ok_or_else(|| ctx.cap_err(&format!("maki.agent.{method}")))
 }
 
-type Pair<T> = (Option<T>, Option<String>);
-
-fn err_pair<T>(err: impl ToString) -> Pair<T> {
-    (None, Some(err.to_string()))
-}
-
 /// Forwards subagent events to the parent, stamped with the subagent identity.
 /// Usage takes two paths: live on the tool header while the run goes on, and one
 /// total per run on `usage_tx`, which `prompt` waits for.
@@ -112,18 +107,6 @@ async fn relay_session_events(
         envelope.subagent = subagent_info.get().cloned();
         let _ = parent_tx.send_envelope(envelope);
     }
-}
-
-/// `maki.agent.*` convention: wrong argument types throw; every value or
-/// runtime failure (including a ctx without dispatch capability) returns
-/// `(nil, err)`.
-macro_rules! try_pair {
-    ($e:expr) => {
-        match $e {
-            Ok(v) => v,
-            Err(e) => return Ok(err_pair(e)),
-        }
-    };
 }
 
 /// Look up the model that the current agent is using, or pick a cheaper one.

--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -10,7 +10,8 @@ use maki_lua_macro::{lua_fn, lua_table};
 use mlua::{Function, Lua, RegistryKey, Result as LuaResult, Table, Value};
 
 use crate::api::fs::expand_tilde;
-use crate::api::util::command::{Pair, UiAction, err_pair, ui_roundtrip, ui_send};
+use crate::api::util::command::{UiAction, ui_roundtrip, ui_send};
+use crate::api::util::pair::{Pair, try_pair};
 use crate::plugin_permissions::PluginPermissions;
 use crate::runtime::with_task_jobs;
 
@@ -441,18 +442,18 @@ fn executable(_lua: &Lua, name: String) -> LuaResult<i32> {
 /// local view = maki.fn.winsaveview()
 /// maki.fn.winrestview({ topline = view.topline + 1 })
 #[lua_fn]
-async fn winsaveview(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaResult<Pair> {
-    let view = match ui_roundtrip(tx.as_ref(), |reply_tx| UiAction::WinSaveView { reply_tx }).await
-    {
-        Ok(view) => view,
-        Err(e) => return Ok(err_pair(e)),
-    };
+async fn winsaveview(
+    lua: Lua,
+    #[ctx] tx: Option<flume::Sender<UiAction>>,
+) -> LuaResult<Pair<Table>> {
+    let view =
+        try_pair!(ui_roundtrip(tx.as_ref(), |reply_tx| UiAction::WinSaveView { reply_tx }).await);
     let t = lua.create_table()?;
     t.set("topline", i64::from(view.scroll_top) + 1)?;
     t.set("line_count", view.line_count)?;
     t.set("height", view.height)?;
     t.set("auto_scroll", view.auto_scroll)?;
-    Ok((Value::Table(t), None))
+    Ok((Some(t), None))
 }
 
 /// Scroll the focused chat transcript so that the `topline` field of
@@ -472,13 +473,11 @@ fn winrestview(
     _lua: &Lua,
     #[ctx] tx: Option<flume::Sender<UiAction>>,
     view: Table,
-) -> LuaResult<Pair> {
+) -> LuaResult<Pair<bool>> {
     let topline = view.get::<Option<i64>>("topline")?.unwrap_or(1);
     let scroll_top = topline.saturating_sub(1).clamp(0, u16::MAX as i64) as u16;
-    match ui_send(tx.as_ref(), UiAction::WinRestView { scroll_top }) {
-        Ok(()) => Ok((Value::Boolean(true), None)),
-        Err(e) => Ok(err_pair(e)),
-    }
+    try_pair!(ui_send(tx.as_ref(), UiAction::WinRestView { scroll_top }));
+    Ok((Some(true), None))
 }
 
 lua_table! {
@@ -692,6 +691,10 @@ mod tests {
 
     #[test]
     fn winsaveview_reports_the_viewport_one_based() {
+        const SCROLL_TOP: u16 = 6;
+        const LINE_COUNT: u16 = 100;
+        const HEIGHT: u16 = 24;
+
         let (tx, rx) = flume::unbounded::<UiAction>();
         let lua = lua_with_view(Some(tx));
         std::thread::spawn(move || {
@@ -700,9 +703,9 @@ mod tests {
             };
             reply_tx
                 .send(WinView {
-                    scroll_top: 6,
-                    line_count: 100,
-                    height: 24,
+                    scroll_top: SCROLL_TOP,
+                    line_count: LINE_COUNT,
+                    height: HEIGHT,
                     auto_scroll: false,
                 })
                 .unwrap();
@@ -710,9 +713,9 @@ mod tests {
         let (view, err): (Table, Option<String>) =
             smol::block_on(lua.load("return f.winsaveview()").eval_async()).unwrap();
         assert_eq!(err, None);
-        assert_eq!(view.get::<u16>("topline").unwrap(), 7);
-        assert_eq!(view.get::<u16>("line_count").unwrap(), 100);
-        assert_eq!(view.get::<u16>("height").unwrap(), 24);
+        assert_eq!(view.get::<u16>("topline").unwrap(), SCROLL_TOP + 1);
+        assert_eq!(view.get::<u16>("line_count").unwrap(), LINE_COUNT);
+        assert_eq!(view.get::<u16>("height").unwrap(), HEIGHT);
         assert!(!view.get::<bool>("auto_scroll").unwrap());
     }
 

--- a/maki-lua/src/api/fs.rs
+++ b/maki-lua/src/api/fs.rs
@@ -6,9 +6,9 @@ use std::path::{Component, Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
 use maki_lua_macro::{lua_fn, lua_table};
-use mlua::{IntoLua, Lua, Result as LuaResult, Table, Value};
+use mlua::{Buffer, Lua, Result as LuaResult, Table, Value};
 
-use crate::api::util::convert::err_pair;
+use crate::api::util::pair::{Pair, err_pair, pair, try_pair};
 use crate::plugin_permissions::PluginPermissions;
 
 pub(crate) fn expand_tilde(path: &str) -> PathBuf {
@@ -92,19 +92,6 @@ fn collect_dir_entries(
     }
 }
 
-fn result_pair<T: mlua::IntoLua, E: std::fmt::Display>(
-    lua: &Lua,
-    result: Result<T, E>,
-) -> LuaResult<(mlua::Value, mlua::Value)> {
-    match result {
-        Ok(val) => Ok((val.into_lua(lua)?, mlua::Value::Nil)),
-        Err(e) => Ok((
-            mlua::Value::Nil,
-            mlua::Value::String(lua.create_string(e.to_string())?),
-        )),
-    }
-}
-
 /// Read the entire file at {path} as a UTF-8 string.
 /// If the file contains bytes that are not valid UTF-8, this function throws.
 /// Use `read_bytes` for binary files.
@@ -118,14 +105,14 @@ fn result_pair<T: mlua::IntoLua, E: std::fmt::Display>(
 ///   return
 /// end
 #[lua_fn(guard = FsRead)]
-async fn read(lua: Lua, path: String) -> LuaResult<(Value, Value)> {
+async fn read(_lua: Lua, path: String) -> LuaResult<Pair<String>> {
     let abs = make_absolute(&path)?;
     match smol::fs::read_to_string(&abs).await {
-        Ok(s) => Ok((s.into_lua(&lua)?, Value::Nil)),
+        Ok(s) => Ok((Some(s), None)),
         Err(e) if e.kind() == ErrorKind::InvalidData => {
             Err(mlua::Error::runtime("non-utf8 content; use read_bytes"))
         }
-        Err(e) => Ok((Value::Nil, Value::String(lua.create_string(e.to_string())?))),
+        Err(e) => Ok(err_pair(e)),
     }
 }
 
@@ -139,12 +126,10 @@ async fn read(lua: Lua, path: String) -> LuaResult<(Value, Value)> {
 /// if err then return end
 /// local encoded = maki.base64.encode(buf)
 #[lua_fn(guard = FsRead)]
-async fn read_bytes(lua: Lua, path: String) -> LuaResult<(Value, Value)> {
+async fn read_bytes(lua: Lua, path: String) -> LuaResult<Pair<Buffer>> {
     let abs = make_absolute(&path)?;
-    match smol::fs::read(&abs).await {
-        Ok(bytes) => Ok((lua.create_buffer(bytes)?.into_lua(&lua)?, Value::Nil)),
-        Err(e) => Ok((Value::Nil, Value::String(lua.create_string(e.to_string())?))),
-    }
+    let bytes = try_pair!(smol::fs::read(&abs).await);
+    Ok((Some(lua.create_buffer(bytes)?), None))
 }
 
 /// Get metadata for the file or directory at {path}.
@@ -161,7 +146,7 @@ async fn read_bytes(lua: Lua, path: String) -> LuaResult<(Value, Value)> {
 ///   print("size: " .. meta.size)
 /// end
 #[lua_fn(guard = FsRead)]
-async fn metadata(lua: Lua, path: String) -> LuaResult<(Value, Value)> {
+async fn metadata(lua: Lua, path: String) -> LuaResult<Pair<Table>> {
     let abs = make_absolute(&path)?;
     match smol::fs::metadata(&abs).await {
         Ok(meta) => {
@@ -174,10 +159,10 @@ async fn metadata(lua: Lua, path: String) -> LuaResult<(Value, Value)> {
             {
                 tbl.set("mtime", dur.as_secs_f64())?;
             }
-            Ok((Value::Table(tbl), Value::Nil))
+            Ok((Some(tbl), None))
         }
-        Err(e) if e.kind() == ErrorKind::NotFound => Ok((Value::Nil, Value::Nil)),
-        Err(e) => Ok((Value::Nil, Value::String(lua.create_string(e.to_string())?))),
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok((None, None)),
+        Err(e) => Ok(err_pair(e)),
     }
 }
 
@@ -393,7 +378,7 @@ fn ext(_lua: &Lua, path: String) -> LuaResult<Option<String>> {
 ///   print(e[1], e[2]) -- "main.rs"  "file"
 /// end
 #[lua_fn(guard = FsRead)]
-async fn dir(lua: Lua, path: String, opts: Option<Table>) -> LuaResult<(Value, Value)> {
+async fn dir(lua: Lua, path: String, opts: Option<Table>) -> LuaResult<Pair<Table>> {
     let abs = make_absolute(&path)?;
     let max_depth: u32 = match &opts {
         Some(t) => t.get::<u32>("depth").unwrap_or(1),
@@ -414,19 +399,15 @@ async fn dir(lua: Lua, path: String, opts: Option<Table>) -> LuaResult<(Value, V
     })
     .await;
 
-    match result {
-        Ok(entries) => {
-            let tbl = lua.create_table()?;
-            for (i, (name, typ)) in entries.iter().enumerate() {
-                let entry = lua.create_table()?;
-                entry.set(1, name.as_str())?;
-                entry.set(2, *typ)?;
-                tbl.set(i + 1, entry)?;
-            }
-            Ok((Value::Table(tbl), Value::Nil))
-        }
-        Err(e) => err_pair(&lua, e),
+    let entries = try_pair!(result);
+    let tbl = lua.create_table()?;
+    for (i, (name, typ)) in entries.iter().enumerate() {
+        let entry = lua.create_table()?;
+        entry.set(1, name.as_str())?;
+        entry.set(2, *typ)?;
+        tbl.set(i + 1, entry)?;
     }
+    Ok((Some(tbl), None))
 }
 
 /// Write {content} to the file at {path}, creating it if it does not exist
@@ -439,9 +420,9 @@ async fn dir(lua: Lua, path: String, opts: Option<Table>) -> LuaResult<(Value, V
 /// local ok, err = maki.fs.write("out.txt", "hello world")
 /// if err then print("write failed: " .. err) end
 #[lua_fn(guard = FsWrite)]
-async fn write(lua: Lua, path: String, content: String) -> LuaResult<(Value, Value)> {
+async fn write(_lua: Lua, path: String, content: String) -> LuaResult<Pair<bool>> {
     let abs = make_absolute(&path)?;
-    result_pair(&lua, smol::fs::write(&abs, content).await.map(|()| true))
+    Ok(pair(smol::fs::write(&abs, content).await.map(|()| true)))
 }
 
 /// Delete the file, symlink, or directory at {path}.
@@ -457,7 +438,7 @@ async fn write(lua: Lua, path: String, content: String) -> LuaResult<(Value, Val
 /// if err then print("rm failed: " .. err) end
 /// maki.fs.rm("stale_dir", { recursive = true, force = true })
 #[lua_fn(guard = FsWrite)]
-async fn rm(lua: Lua, path: String, opts: Option<Table>) -> LuaResult<(Value, Value)> {
+async fn rm(_lua: Lua, path: String, opts: Option<Table>) -> LuaResult<Pair<bool>> {
     let abs = make_absolute(&path)?;
     let recursive = opts
         .as_ref()
@@ -488,7 +469,7 @@ async fn rm(lua: Lua, path: String, opts: Option<Table>) -> LuaResult<(Value, Va
         }
     })
     .await;
-    result_pair(&lua, result.map(|()| true))
+    Ok(pair(result.map(|()| true)))
 }
 
 /// Create the directory at {path}. Set `parents = true` to create
@@ -500,7 +481,7 @@ async fn rm(lua: Lua, path: String, opts: Option<Table>) -> LuaResult<(Value, Va
 /// @example
 /// maki.fs.mkdir("a/b/c", { parents = true })
 #[lua_fn(guard = FsWrite)]
-async fn mkdir(lua: Lua, path: String, opts: Option<Table>) -> LuaResult<(Value, Value)> {
+async fn mkdir(_lua: Lua, path: String, opts: Option<Table>) -> LuaResult<Pair<bool>> {
     let abs = make_absolute(&path)?;
     let parents = opts
         .as_ref()
@@ -511,7 +492,7 @@ async fn mkdir(lua: Lua, path: String, opts: Option<Table>) -> LuaResult<(Value,
     } else {
         smol::fs::create_dir(&abs).await
     };
-    result_pair(&lua, result.map(|()| true))
+    Ok(pair(result.map(|()| true)))
 }
 
 /// Find files matching one or more glob patterns.
@@ -526,7 +507,7 @@ async fn mkdir(lua: Lua, path: String, opts: Option<Table>) -> LuaResult<(Value,
 /// if err then return end
 /// for _, f in ipairs(files) do print(f) end
 #[lua_fn(guard = FsRead)]
-async fn glob(lua: Lua, pattern: Value, opts: Option<Table>) -> LuaResult<(Value, Value)> {
+async fn glob(lua: Lua, pattern: Value, opts: Option<Table>) -> LuaResult<Pair<Table>> {
     let patterns: Vec<String> = match pattern {
         Value::String(s) => vec![s.to_str()?.to_owned()],
         Value::Table(t) => {
@@ -589,16 +570,12 @@ async fn glob(lua: Lua, pattern: Value, opts: Option<Table>) -> LuaResult<(Value
     })
     .await;
 
-    match result {
-        Ok(paths) => {
-            let tbl = lua.create_table()?;
-            for (i, path) in paths.iter().enumerate() {
-                tbl.set(i + 1, path.as_str())?;
-            }
-            Ok((Value::Table(tbl), Value::Nil))
-        }
-        Err(e) => err_pair(&lua, format_args!("glob: {e}")),
+    let paths = try_pair!(result.map_err(|e| format!("glob: {e}")));
+    let tbl = lua.create_table()?;
+    for (i, path) in paths.iter().enumerate() {
+        tbl.set(i + 1, path.as_str())?;
     }
+    Ok((Some(tbl), None))
 }
 
 /// Search file contents for a regex {pattern}. Returns structured matches
@@ -621,7 +598,7 @@ async fn glob(lua: Lua, pattern: Value, opts: Option<Table>) -> LuaResult<(Value
 ///   end
 /// end
 #[lua_fn(guard = FsRead)]
-async fn grep(lua: Lua, pattern: String, opts: Option<Table>) -> LuaResult<(Value, Value)> {
+async fn grep(lua: Lua, pattern: String, opts: Option<Table>) -> LuaResult<Pair<Table>> {
     let mut params = maki_agent::tools::grep::GrepParams::new(pattern);
     if let Some(ref opts) = opts {
         if let Ok(v) = opts.get::<String>("path") {
@@ -646,33 +623,29 @@ async fn grep(lua: Lua, pattern: String, opts: Option<Table>) -> LuaResult<(Valu
 
     let result = smol::unblock(move || maki_agent::tools::grep::grep_search(params)).await;
 
-    match result {
-        Ok((base, entries)) => {
-            let arr = lua.create_table()?;
-            for (i, entry) in entries.iter().enumerate() {
-                let etbl = lua.create_table()?;
-                etbl.set("path", base.join(&entry.path).to_string_lossy().as_ref())?;
-                let groups_tbl = lua.create_table()?;
-                for (gi, group) in entry.groups.iter().enumerate() {
-                    let gtbl = lua.create_table()?;
-                    let lines_tbl = lua.create_table()?;
-                    for (li, line) in group.lines.iter().enumerate() {
-                        let ltbl = lua.create_table()?;
-                        ltbl.set("line_nr", line.line_nr)?;
-                        ltbl.set("text", line.text.as_str())?;
-                        ltbl.set("is_match", line.is_match)?;
-                        lines_tbl.set(li + 1, ltbl)?;
-                    }
-                    gtbl.set("lines", lines_tbl)?;
-                    groups_tbl.set(gi + 1, gtbl)?;
-                }
-                etbl.set("groups", groups_tbl)?;
-                arr.set(i + 1, etbl)?;
+    let (base, entries) = try_pair!(result);
+    let arr = lua.create_table()?;
+    for (i, entry) in entries.iter().enumerate() {
+        let etbl = lua.create_table()?;
+        etbl.set("path", base.join(&entry.path).to_string_lossy().as_ref())?;
+        let groups_tbl = lua.create_table()?;
+        for (gi, group) in entry.groups.iter().enumerate() {
+            let gtbl = lua.create_table()?;
+            let lines_tbl = lua.create_table()?;
+            for (li, line) in group.lines.iter().enumerate() {
+                let ltbl = lua.create_table()?;
+                ltbl.set("line_nr", line.line_nr)?;
+                ltbl.set("text", line.text.as_str())?;
+                ltbl.set("is_match", line.is_match)?;
+                lines_tbl.set(li + 1, ltbl)?;
             }
-            Ok((Value::Table(arr), Value::Nil))
+            gtbl.set("lines", lines_tbl)?;
+            groups_tbl.set(gi + 1, gtbl)?;
         }
-        Err(e) => Ok((Value::Nil, Value::String(lua.create_string(e)?))),
+        etbl.set("groups", groups_tbl)?;
+        arr.set(i + 1, etbl)?;
     }
+    Ok((Some(arr), None))
 }
 
 lua_table! {

--- a/maki-lua/src/api/image.rs
+++ b/maki-lua/src/api/image.rs
@@ -8,9 +8,10 @@ use std::sync::Arc;
 
 use image::{DynamicImage, ImageFormat, ImageReader};
 use maki_lua_macro::{lua_class, lua_fn, lua_table};
-use mlua::{Lua, Result as LuaResult, Value as LuaValue};
+use mlua::{AnyUserData, Lua, Result as LuaResult, Table, Value as LuaValue};
 
 use super::base64::bytes_arg;
+use super::util::pair::{Pair, try_pair};
 
 /// Decode-bomb guard: a tiny file can declare huge dimensions and balloon
 /// into gigabytes of RGBA. Host-fixed so no plugin can disable it; 50MP
@@ -152,18 +153,14 @@ lua_class! {
 /// if err then error(err) end
 /// print(info.format, info.width, info.height)
 #[lua_fn]
-fn probe(lua: &Lua, data: LuaValue) -> LuaResult<(LuaValue, LuaValue)> {
+fn probe(lua: &Lua, data: LuaValue) -> LuaResult<Pair<Table>> {
     let bytes = bytes_arg(&data, "image.probe")?;
-    match probe_bytes(&bytes) {
-        Ok((format, width, height)) => {
-            let info = lua.create_table()?;
-            info.set("format", format_name(format))?;
-            info.set("width", width)?;
-            info.set("height", height)?;
-            Ok((LuaValue::Table(info), LuaValue::Nil))
-        }
-        Err(e) => Ok((LuaValue::Nil, LuaValue::String(lua.create_string(e)?))),
-    }
+    let (format, width, height) = try_pair!(probe_bytes(&bytes));
+    let info = lua.create_table()?;
+    info.set("format", format_name(format))?;
+    info.set("width", width)?;
+    info.set("height", height)?;
+    Ok((Some(info), None))
 }
 
 /// Decode raw image bytes into an Image handle you can resize and re-encode.
@@ -176,15 +173,10 @@ fn probe(lua: &Lua, data: LuaValue) -> LuaResult<(LuaValue, LuaValue)> {
 /// if err then error(err) end
 /// print(img:width() .. "x" .. img:height())
 #[lua_fn]
-async fn decode(lua: Lua, data: LuaValue) -> LuaResult<(LuaValue, LuaValue)> {
+async fn decode(lua: Lua, data: LuaValue) -> LuaResult<Pair<AnyUserData>> {
     let bytes = bytes_arg(&data, "image.decode")?;
-    match smol::unblock(move || decode_bytes(&bytes)).await {
-        Ok(img) => Ok((
-            LuaValue::UserData(lua.create_userdata(LuaImage(Arc::new(img)))?),
-            LuaValue::Nil,
-        )),
-        Err(e) => Ok((LuaValue::Nil, LuaValue::String(lua.create_string(e)?))),
-    }
+    let img = try_pair!(smol::unblock(move || decode_bytes(&bytes)).await);
+    Ok((Some(lua.create_userdata(LuaImage(Arc::new(img)))?), None))
 }
 
 lua_table! {

--- a/maki-lua/src/api/interpreter.rs
+++ b/maki-lua/src/api/interpreter.rs
@@ -17,6 +17,7 @@ use mlua::{Function, Lua, Result as LuaResult, Table};
 use serde_json::Value;
 
 use crate::api::util::convert::{json_to_lua, lua_tool_result};
+use crate::api::util::pair::Pair;
 use crate::plugin_permissions::PluginPermissions;
 use crate::runtime::{TaskHandle, lock_cell};
 
@@ -90,11 +91,7 @@ async fn call_lua_tool(lua: Lua, f: Option<Function>, pc: &PendingCall) -> Resul
 /// if err then error(err) end
 /// if result.stdout then print(result.stdout) end
 #[lua_fn(guard = Run, name = "run")]
-async fn interpreter_run(
-    lua: Lua,
-    code: String,
-    opts: Table,
-) -> LuaResult<(Table, Option<String>)> {
+async fn interpreter_run(lua: Lua, code: String, opts: Table) -> LuaResult<Pair<Table>> {
     let timeout_secs: u64 = required(&opts, "timeout")?;
     let max_memory_mb: usize = required(&opts, "max_memory_mb")?;
     let on_output: Function = required(&opts, "on_output")?;
@@ -194,9 +191,9 @@ async fn interpreter_run(
             if let Some(val) = ir.output {
                 tbl.set("output", val.to_string())?;
             }
-            Ok((tbl, None))
+            Ok((Some(tbl), None))
         }
-        Err(e) => Ok((tbl, Some(e))),
+        Err(e) => Ok((Some(tbl), Some(e))),
     }
 }
 

--- a/maki-lua/src/api/json.rs
+++ b/maki-lua/src/api/json.rs
@@ -1,7 +1,8 @@
 use maki_lua_macro::{lua_fn, lua_table};
-use mlua::{Lua, LuaSerdeExt, Result as LuaResult, UserData, UserDataMethods, Value};
+use mlua::{AnyUserData, Lua, LuaSerdeExt, Result as LuaResult, UserData, UserDataMethods, Value};
 
-use super::util::convert::{err_pair, json_to_lua, lua_to_json};
+use super::util::convert::{json_to_lua, lua_to_json};
+use super::util::pair::{Pair, pair, try_pair};
 
 pub(crate) const VALIDATOR_DOCS: crate::docs::ModuleDoc = crate::docs::ModuleDoc {
     name: "maki.json.SchemaValidator",
@@ -71,15 +72,9 @@ impl UserData for LuaSchemaValidator {
 /// local s, err = maki.json.encode({ name = "maki", version = 1 })
 /// print(s) -- {"name":"maki","version":1}
 #[lua_fn]
-fn encode(lua: &Lua, value: Value) -> LuaResult<(Value, Value)> {
-    let serde_val: serde_json::Value = match lua.from_value(value) {
-        Ok(v) => v,
-        Err(e) => return err_pair(lua, e),
-    };
-    match serde_json::to_string(&serde_val) {
-        Ok(s) => Ok((Value::String(lua.create_string(&s)?), Value::Nil)),
-        Err(e) => err_pair(lua, e),
-    }
+fn encode(lua: &Lua, value: Value) -> LuaResult<Pair<String>> {
+    let serde_val: serde_json::Value = try_pair!(lua.from_value(value));
+    Ok(pair(serde_json::to_string(&serde_val)))
 }
 
 /// Parse a JSON string into a Lua value. Objects become tables and
@@ -91,11 +86,9 @@ fn encode(lua: &Lua, value: Value) -> LuaResult<(Value, Value)> {
 /// local t, err = maki.json.decode('{"x": 42}')
 /// print(t.x) -- 42
 #[lua_fn]
-fn decode(lua: &Lua, str: String) -> LuaResult<(Value, Value)> {
-    match serde_json::from_str::<serde_json::Value>(&str) {
-        Ok(v) => Ok((json_to_lua(lua, &v)?, Value::Nil)),
-        Err(e) => err_pair(lua, e),
-    }
+fn decode(lua: &Lua, str: String) -> LuaResult<Pair<Value>> {
+    let value = try_pair!(serde_json::from_str::<serde_json::Value>(&str));
+    Ok((Some(json_to_lua(lua, &value)?), None))
 }
 
 /// Compile a JSON Schema into a reusable validator object. Supports
@@ -113,18 +106,13 @@ fn decode(lua: &Lua, str: String) -> LuaResult<(Value, Value)> {
 /// local errs = v:validate({ name = "maki" })
 /// assert(errs == nil)
 #[lua_fn]
-fn schema_validator(lua: &Lua, schema: Value) -> LuaResult<(Value, Value)> {
-    let schema_json = match lua_to_json(lua, &schema) {
-        Ok(v) => v,
-        Err(e) => return err_pair(lua, e),
-    };
-    match jsonschema::validator_for(&schema_json) {
-        Ok(validator) => Ok((
-            Value::UserData(lua.create_userdata(LuaSchemaValidator { validator })?),
-            Value::Nil,
-        )),
-        Err(e) => err_pair(lua, e),
-    }
+fn schema_validator(lua: &Lua, schema: Value) -> LuaResult<Pair<AnyUserData>> {
+    let schema_json = try_pair!(lua_to_json(lua, &schema));
+    let validator = try_pair!(jsonschema::validator_for(&schema_json));
+    Ok((
+        Some(lua.create_userdata(LuaSchemaValidator { validator })?),
+        None,
+    ))
 }
 
 lua_table! {

--- a/maki-lua/src/api/net.rs
+++ b/maki-lua/src/api/net.rs
@@ -5,7 +5,9 @@ use futures_lite::io::AsyncReadExt;
 use isahc::config::{Configurable, RedirectPolicy};
 use isahc::{AsyncBody, HttpClient, Request};
 use maki_lua_macro::{lua_fn, lua_table};
-use mlua::{Lua, Result as LuaResult, Table, Value};
+use mlua::{Lua, Result as LuaResult, Table};
+
+use crate::api::util::pair::{Pair, try_pair};
 
 use crate::plugin_permissions::PluginPermissions;
 
@@ -60,21 +62,14 @@ struct ResponseData {
 ///   print(res.status, res.body)
 /// end
 #[lua_fn(guard = Net)]
-async fn request(lua: Lua, url: String, opts: Option<Table>) -> LuaResult<(Value, Value)> {
-    let params = match extract_request_params(&url, opts.as_ref()) {
-        Ok(p) => p,
-        Err(e) => return Ok((Value::Nil, Value::String(lua.create_string(&e)?))),
-    };
-    match do_request(params).await {
-        Ok(resp) => {
-            let tbl = lua.create_table()?;
-            tbl.set("body", resp.body)?;
-            tbl.set("status", resp.status)?;
-            tbl.set("content_type", resp.content_type)?;
-            Ok((Value::Table(tbl), Value::Nil))
-        }
-        Err(e) => Ok((Value::Nil, Value::String(lua.create_string(&e)?))),
-    }
+async fn request(lua: Lua, url: String, opts: Option<Table>) -> LuaResult<Pair<Table>> {
+    let params = try_pair!(extract_request_params(&url, opts.as_ref()));
+    let resp = try_pair!(do_request(params).await);
+    let tbl = lua.create_table()?;
+    tbl.set("body", resp.body)?;
+    tbl.set("status", resp.status)?;
+    tbl.set("content_type", resp.content_type)?;
+    Ok((Some(tbl), None))
 }
 
 lua_table! {

--- a/maki-lua/src/api/session.rs
+++ b/maki-lua/src/api/session.rs
@@ -3,21 +3,21 @@
 //! the loop answers `list` from a background task so slow scans never block.
 
 use maki_lua_macro::{lua_fn, lua_table};
-use mlua::{Lua, Result as LuaResult, Table};
+use mlua::{Lua, Result as LuaResult, Table, Value};
 
-use crate::api::util::command::{Pair, SessionRequest, UiAction, err_pair, ui_roundtrip};
+use crate::api::util::command::{SessionRequest, UiAction, ui_roundtrip};
 use crate::api::util::convert::json_to_lua;
+use crate::api::util::pair::{Pair, try_pair};
 
 async fn roundtrip(
     lua: Lua,
     tx: Option<flume::Sender<UiAction>>,
     req: SessionRequest,
-) -> LuaResult<Pair> {
-    match ui_roundtrip(tx.as_ref(), |reply_tx| UiAction::Session { req, reply_tx }).await {
-        Ok(Ok(value)) => Ok((json_to_lua(&lua, &value)?, None)),
-        Ok(Err(e)) => Ok(err_pair(e)),
-        Err(e) => Ok(err_pair(e)),
-    }
+) -> LuaResult<Pair<Value>> {
+    let reply =
+        try_pair!(ui_roundtrip(tx.as_ref(), |reply_tx| UiAction::Session { req, reply_tx }).await);
+    let value = try_pair!(reply);
+    Ok((Some(json_to_lua(&lua, &value)?), None))
 }
 
 /// Lists sessions stored for the current project. Answered from a
@@ -27,7 +27,7 @@ async fn roundtrip(
 /// @example
 /// local stored, err = maki.session.list()
 #[lua_fn]
-async fn list(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaResult<Pair> {
+async fn list(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaResult<Pair<Value>> {
     roundtrip(lua, tx, SessionRequest::List).await
 }
 
@@ -38,7 +38,7 @@ async fn list(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaResult
 /// @example
 /// local live, err = maki.session.live()
 #[lua_fn]
-async fn live(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaResult<Pair> {
+async fn live(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaResult<Pair<Value>> {
     roundtrip(lua, tx, SessionRequest::Live).await
 }
 
@@ -48,7 +48,7 @@ async fn live(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaResult
 /// @example
 /// local id = maki.session.current()
 #[lua_fn]
-async fn current(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaResult<Pair> {
+async fn current(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaResult<Pair<Value>> {
     roundtrip(lua, tx, SessionRequest::Current).await
 }
 
@@ -63,7 +63,7 @@ async fn focus(
     lua: Lua,
     #[ctx] tx: Option<flume::Sender<UiAction>>,
     id: String,
-) -> LuaResult<Pair> {
+) -> LuaResult<Pair<Value>> {
     roundtrip(lua, tx, SessionRequest::Focus { id }).await
 }
 
@@ -79,7 +79,7 @@ async fn delete(
     lua: Lua,
     #[ctx] tx: Option<flume::Sender<UiAction>>,
     id: String,
-) -> LuaResult<Pair> {
+) -> LuaResult<Pair<Value>> {
     roundtrip(lua, tx, SessionRequest::Delete { id }).await
 }
 
@@ -95,7 +95,7 @@ async fn new(
     lua: Lua,
     #[ctx] tx: Option<flume::Sender<UiAction>>,
     opts: Option<Table>,
-) -> LuaResult<Pair> {
+) -> LuaResult<Pair<Value>> {
     let (prompt, focus) = match opts {
         Some(opts) => (opts.get("prompt")?, opts.get("focus").unwrap_or(false)),
         None => (None, false),
@@ -120,7 +120,7 @@ async fn prompt(
     #[ctx] tx: Option<flume::Sender<UiAction>>,
     text: String,
     opts: Option<Table>,
-) -> LuaResult<Pair> {
+) -> LuaResult<Pair<Value>> {
     let id = match opts {
         Some(opts) => opts.get("session")?,
         None => None,
@@ -140,7 +140,7 @@ async fn set_title(
     lua: Lua,
     #[ctx] tx: Option<flume::Sender<UiAction>>,
     opts: Table,
-) -> LuaResult<Pair> {
+) -> LuaResult<Pair<Value>> {
     let req = SessionRequest::SetTitle {
         id: opts.get("id")?,
         title: opts.get("title")?,

--- a/maki-lua/src/api/text.rs
+++ b/maki-lua/src/api/text.rs
@@ -1,5 +1,7 @@
 use maki_lua_macro::{lua_fn, lua_table};
-use mlua::{Lua, Result as LuaResult, Value};
+use mlua::{Lua, Result as LuaResult};
+
+use super::util::pair::{Pair, pair};
 
 /// Convert an HTML string to Markdown.
 /// Useful for cleaning up web content fetched with `maki.webfetch`.
@@ -11,14 +13,10 @@ use mlua::{Lua, Result as LuaResult, Value};
 /// if err then return end
 /// print(md) -- "# Hello\n\nworld"
 #[lua_fn]
-fn html_to_markdown(lua: &Lua, html: String) -> LuaResult<(Value, Value)> {
-    match htmd::convert(&html) {
-        Ok(md) => Ok((Value::String(lua.create_string(&md)?), Value::Nil)),
-        Err(e) => Ok((
-            Value::Nil,
-            Value::String(lua.create_string(format!("html_to_markdown: {e}"))?),
-        )),
-    }
+fn html_to_markdown(_lua: &Lua, html: String) -> LuaResult<Pair<String>> {
+    Ok(pair(
+        htmd::convert(&html).map_err(|e| format!("html_to_markdown: {e}")),
+    ))
 }
 
 lua_table! {

--- a/maki-lua/src/api/treesitter/mod.rs
+++ b/maki-lua/src/api/treesitter/mod.rs
@@ -7,29 +7,17 @@ pub(crate) mod tree;
 use maki_lua_macro::{lua_fn, lua_table};
 use mlua::{AnyUserData, Lua, Result as LuaResult, Table};
 
+use crate::api::util::pair::{Pair, err_pair};
 use crate::language::Language;
 use language_tree::LuaLanguageTree;
 use node::LuaNode;
 
-fn parse_impl(
-    lua: &Lua,
-    source: String,
-    lang_name: String,
-) -> LuaResult<(mlua::Value, mlua::Value)> {
+fn parse_impl(lua: &Lua, source: String, lang_name: String) -> LuaResult<Pair<AnyUserData>> {
     let Some(lang) = Language::from_name(&lang_name) else {
-        return Ok((
-            mlua::Value::Nil,
-            mlua::Value::String(lua.create_string(format!("no language registered: {lang_name}"))?),
-        ));
+        return Ok(err_pair(format!("no language registered: {lang_name}")));
     };
-    Ok((
-        mlua::Value::UserData(lua.create_userdata(LuaLanguageTree::new(
-            source.into(),
-            lang_name.into(),
-            lang,
-        ))?),
-        mlua::Value::Nil,
-    ))
+    let tree = LuaLanguageTree::new(source.into(), lang_name.into(), lang);
+    Ok((Some(lua.create_userdata(tree)?), None))
 }
 
 /// Creates a `LanguageTree` for {source} using the grammar named {lang}.
@@ -43,7 +31,7 @@ fn parse_impl(
 /// local parser, err = maki.treesitter.get_parser(src, "lua")
 /// if err then print("error: " .. err) end
 #[lua_fn]
-fn get_parser(lua: &Lua, source: String, lang: String) -> LuaResult<(mlua::Value, mlua::Value)> {
+fn get_parser(lua: &Lua, source: String, lang: String) -> LuaResult<Pair<AnyUserData>> {
     parse_impl(lua, source, lang)
 }
 
@@ -53,11 +41,7 @@ fn get_parser(lua: &Lua, source: String, lang: String) -> LuaResult<(mlua::Value
 /// @param lang string Language name.
 /// @return (LanguageTree|nil, string|nil) Parser, or nil and an error message.
 #[lua_fn]
-fn get_string_parser(
-    lua: &Lua,
-    source: String,
-    lang: String,
-) -> LuaResult<(mlua::Value, mlua::Value)> {
+fn get_string_parser(lua: &Lua, source: String, lang: String) -> LuaResult<Pair<AnyUserData>> {
     parse_impl(lua, source, lang)
 }
 

--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use arc_swap::ArcSwap;
 use maki_agent::SharedBuf;
-use mlua::{RegistryKey, Value};
+use mlua::RegistryKey;
 
 pub(crate) const NO_UI_ERR: &str = "no interactive UI attached";
 const UI_DROPPED_ERR: &str = "ui event loop dropped the request";
@@ -439,14 +439,6 @@ pub enum UiAction {
     WinRestView {
         scroll_top: u16,
     },
-}
-
-/// Lua's `(value, err)` convention: a failed UI call answers with nil and a
-/// message instead of raising.
-pub(crate) type Pair = (Value, Option<String>);
-
-pub(crate) fn err_pair(err: impl ToString) -> Pair {
-    (Value::Nil, Some(err.to_string()))
 }
 
 /// Hand an action to the UI event loop. A full or closed channel means the

--- a/maki-lua/src/api/util/convert.rs
+++ b/maki-lua/src/api/util/convert.rs
@@ -1,10 +1,6 @@
 use mlua::{Lua, LuaSerdeExt, Result as LuaResult, Value};
 use serde_json::Value as JsonValue;
 
-pub(crate) fn err_pair(lua: &Lua, e: impl std::fmt::Display) -> LuaResult<(Value, Value)> {
-    Ok((Value::Nil, Value::String(lua.create_string(e.to_string())?)))
-}
-
 pub(crate) const NIL_TOOL_RESULT_ERR: &str = "tool returned nil without an error message";
 
 pub(crate) fn lua_tool_result(values: mlua::MultiValue) -> Result<String, String> {

--- a/maki-lua/src/api/util/ctx.rs
+++ b/maki-lua/src/api/util/ctx.rs
@@ -15,6 +15,7 @@ use mlua::{LuaSerdeExt, MultiValue, UserData, UserDataMethods, Value as LuaValue
 use crate::api::tool::ToolCallReply;
 use crate::api::ui::buf::BufHandle;
 use crate::api::util::convert::json_to_lua;
+use crate::api::util::pair::Pair;
 use crate::runtime::{active_task, lock_cell};
 
 const DEADLINE_ALREADY_SET_MSG: &str = "ctx:set_deadline() already called";
@@ -224,8 +225,8 @@ impl LuaCtx {
         format!("{method} not available in {} ctx", self.kind())
     }
 
-    fn cap_err_pair(&self, method: &str) -> (LuaValue, Option<String>) {
-        (LuaValue::Nil, Some(self.cap_err(method)))
+    fn cap_err_pair<T>(&self, method: &str) -> Pair<T> {
+        (None, Some(self.cap_err(method)))
     }
 }
 
@@ -237,30 +238,28 @@ impl UserData for LuaCtx {
             let Some(workflow) = this.workflow() else {
                 return Ok(this.cap_err_pair("workflow"));
             };
-            Ok((LuaValue::Boolean(workflow), None))
+            Ok((Some(workflow), None))
         });
 
-        methods.add_method("audience", |lua, this, ()| {
+        methods.add_method("audience", |_, this, ()| {
             let Some(audience) = this.audience() else {
                 return Ok(this.cap_err_pair("audience"));
             };
-            let name = lua.create_string(audience.name().unwrap_or("main"))?;
-            Ok((LuaValue::String(name), None))
+            Ok((Some(audience.name().unwrap_or("main").to_string()), None))
         });
 
         // The session that called this tool, which under concurrent
         // sessions is not always the focused one `maki.session.current()`
         // reports. Nil without an error when the run has no session, as in
         // the `maki index` one-shot.
-        methods.add_method("session_id", |lua, this, ()| {
+        methods.add_method("session_id", |_, this, ()| {
             let Some(session_id) = this.session_id() else {
                 return Ok(this.cap_err_pair("session_id"));
             };
             let Some(session_id) = session_id else {
-                return Ok((LuaValue::Nil, None));
+                return Ok((None, None));
             };
-            let id = lua.create_string(session_id.id().to_string())?;
-            Ok((LuaValue::String(id), None))
+            Ok((Some(session_id.id().to_string()), None))
         });
 
         methods.add_method("live_buf", |lua, this, buf: mlua::AnyUserData| {
@@ -268,7 +267,7 @@ impl UserData for LuaCtx {
                 return Ok(this.cap_err_pair("live_buf"));
             }
             send_live_buf(lua, &buf)?;
-            Ok((LuaValue::Nil, None))
+            Ok((Some(true), None))
         });
 
         methods.add_method("config", |lua, this, args: MultiValue| {
@@ -277,7 +276,7 @@ impl UserData for LuaCtx {
             };
             let config_val = lua.to_value(config)?;
             if args.is_empty() {
-                return Ok((config_val, None));
+                return Ok((Some(config_val), None));
             }
             let key: String = lua.from_value(args[0].clone())?;
             let default = args.get(1).cloned().unwrap_or(LuaValue::Nil);
@@ -292,7 +291,7 @@ impl UserData for LuaCtx {
                 }
                 _ => default,
             };
-            Ok((val, None))
+            Ok((Some(val), None))
         });
 
         methods.add_method("tool_output_lines", |lua, this, ()| {
@@ -316,7 +315,7 @@ impl UserData for LuaCtx {
             cell.deadline_secs.set(Some(secs));
             cell.deadline
                 .set(Some(Instant::now() + Duration::from_secs(secs)));
-            Ok((LuaValue::Nil, None))
+            Ok((Some(true), None))
         });
 
         methods.add_method("record_read", |_, this, path: String| {
@@ -324,7 +323,7 @@ impl UserData for LuaCtx {
                 return Ok(this.cap_err_pair("record_read"));
             };
             tracker.record_read(Path::new(&path));
-            Ok((LuaValue::Nil, None))
+            Ok((Some(true), None))
         });
 
         methods.add_method("check_before_edit", |_, this, path: String| {
@@ -332,11 +331,11 @@ impl UserData for LuaCtx {
                 return Ok(this.cap_err_pair("check_before_edit"));
             };
             if !agent.config.stale_read_check {
-                return Ok((LuaValue::Boolean(true), None));
+                return Ok((Some(true), None));
             }
             match agent.file_tracker.check_before_edit(Path::new(&path)) {
-                Ok(()) => Ok((LuaValue::Boolean(true), None)),
-                Err(msg) => Ok((LuaValue::Boolean(false), Some(msg))),
+                Ok(()) => Ok((Some(true), None)),
+                Err(msg) => Ok((Some(false), Some(msg))),
             }
         });
 
@@ -359,7 +358,7 @@ impl UserData for LuaCtx {
                     entry.set("content", content)?;
                     tbl.set(i + 1, entry)?;
                 }
-                Ok((LuaValue::Table(tbl), None))
+                Ok((Some(tbl), None))
             },
         );
 
@@ -380,7 +379,7 @@ impl UserData for LuaCtx {
                 lock_cell(&active_task(lua)).root_buf = Some(buf);
             }
             let _ = tx.send(ToolCallReply::from_lua_value(lua, &val));
-            Ok((LuaValue::Nil, None))
+            Ok((Some(true), None))
         });
     }
 }

--- a/maki-lua/src/api/util/mod.rs
+++ b/maki-lua/src/api/util/mod.rs
@@ -2,4 +2,5 @@ pub(crate) mod command;
 pub(crate) mod convert;
 pub(crate) mod ctx;
 pub(crate) mod dispatch;
+pub(crate) mod pair;
 pub(crate) mod setup;

--- a/maki-lua/src/api/util/pair.rs
+++ b/maki-lua/src/api/util/pair.rs
@@ -1,0 +1,28 @@
+/// Lua's `(value, err)` convention: a failed call answers with nil and a
+/// message instead of raising. Both slots can be filled when a partial value is
+/// still useful to the caller.
+pub(crate) type Pair<T> = (Option<T>, Option<String>);
+
+pub(crate) fn err_pair<T>(err: impl ToString) -> Pair<T> {
+    (None, Some(err.to_string()))
+}
+
+pub(crate) fn pair<T, E: ToString>(result: Result<T, E>) -> Pair<T> {
+    match result {
+        Ok(value) => (Some(value), None),
+        Err(e) => err_pair(e),
+    }
+}
+
+/// Unwrap a `Result` inside a function returning `LuaResult<Pair<_>>`,
+/// answering with `(nil, err)` instead of throwing.
+macro_rules! try_pair {
+    ($e:expr) => {
+        match $e {
+            Ok(v) => v,
+            Err(e) => return Ok($crate::api::util::pair::err_pair(e)),
+        }
+    };
+}
+
+pub(crate) use try_pair;

--- a/maki-lua/src/api/yaml.rs
+++ b/maki-lua/src/api/yaml.rs
@@ -1,7 +1,7 @@
 use maki_lua_macro::{lua_fn, lua_table};
 use mlua::{Lua, LuaSerdeExt, Result as LuaResult, Value};
 
-use super::util::convert::err_pair;
+use super::util::pair::{Pair, pair, try_pair};
 
 /// Turn a Lua value into a YAML string. Most Lua types work, but
 /// circular references will return an error.
@@ -12,15 +12,9 @@ use super::util::convert::err_pair;
 /// local s, err = maki.yaml.encode({ name = "maki", tags = { "ai", "agent" } })
 /// print(s)
 #[lua_fn]
-fn encode(lua: &Lua, value: Value) -> LuaResult<(Value, Value)> {
-    let serde_val: serde_yaml::Value = match lua.from_value(value) {
-        Ok(v) => v,
-        Err(e) => return err_pair(lua, e),
-    };
-    match serde_yaml::to_string(&serde_val) {
-        Ok(s) => Ok((Value::String(lua.create_string(&s)?), Value::Nil)),
-        Err(e) => err_pair(lua, e),
-    }
+fn encode(lua: &Lua, value: Value) -> LuaResult<Pair<String>> {
+    let serde_val: serde_yaml::Value = try_pair!(lua.from_value(value));
+    Ok(pair(serde_yaml::to_string(&serde_val)))
 }
 
 /// Parse a YAML string into a Lua value. Mappings become tables and
@@ -32,11 +26,9 @@ fn encode(lua: &Lua, value: Value) -> LuaResult<(Value, Value)> {
 /// local t, err = maki.yaml.decode("name: maki\nversion: 1")
 /// print(t.name) -- maki
 #[lua_fn]
-fn decode(lua: &Lua, str: String) -> LuaResult<(Value, Value)> {
-    match serde_yaml::from_str::<serde_yaml::Value>(&str) {
-        Ok(v) => Ok((lua.to_value(&v)?, Value::Nil)),
-        Err(e) => err_pair(lua, e),
-    }
+fn decode(lua: &Lua, str: String) -> LuaResult<Pair<Value>> {
+    let value = try_pair!(serde_yaml::from_str::<serde_yaml::Value>(&str));
+    Ok((Some(lua.to_value(&value)?), None))
 }
 
 lua_table! {

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -873,9 +873,9 @@ impl MessagesPanel {
         self.scroll_top
     }
 
-    /// Backs `maki.fn.winsaveview`. The clamp earns its keep: a pinned or
-    /// restored `scroll_top` can sit past the end until the next `view`
-    /// resolves it against the current line count.
+    /// Backs `maki.fn.winsaveview`. The clamp matters: a pinned or restored
+    /// `scroll_top` can sit past the end until the next `view` resolves it
+    /// against the current line count.
     pub fn win_view(&self) -> WinView {
         WinView {
             scroll_top: self.scroll_top.min(self.max_scroll()),


### PR DESCRIPTION
Five helpers had grown for the same convention, plus a dozen sites that spelled out `(Value::Nil, Value::String(..))` by hand, so every new API picked whichever one it happened to see first.

`util/pair.rs` now holds the whole thing: `Pair<T>`, `err_pair`, `pair` and `try_pair!`. `Option<T>` pushes `Nil` when it is `None`, so Lua still gets exactly two values and nothing changes on that side, while the Rust side loses the `&Lua` argument, the `IntoLua` dance and most of the nested matches.