### PR TITLE
fix(ui): persist sessions every frame instead of once per turn

### DIFF
--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -216,7 +216,7 @@ fn load_history_from(
     > = maki_storage::sessions::Session::load(session_id, storage).map_err(|e| {
         AcpError::resource_not_found(Some(format!("session/{session_id}"))).data(json_str(&e))
     })?;
-    Ok(session.messages)
+    Ok(session.take_messages())
 }
 
 fn handle_prompt(srv: &mut Server, raw: &Value, id: &RequestId) -> Result<(), AcpError> {
@@ -481,7 +481,7 @@ mod tests {
         ];
         let mut session: Session<Message, TokenUsage, maki_agent::ToolOutput> =
             Session::new("anthropic/test-model", "/project");
-        session.messages = messages.clone();
+        session.replace_messages(messages.clone());
         session.save(&dir).unwrap();
 
         let id: MakiId = session.id;

--- a/maki-agent/src/agent/history.rs
+++ b/maki-agent/src/agent/history.rs
@@ -2,32 +2,33 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use maki_providers::{ContentBlock, Message, Role};
+use maki_storage::sessions::next_epoch;
 use tracing::warn;
 
 const CANCEL_MARKER: &str = "[Cancelled by user]";
-const UNAVAILABLE_RESULT: &str = "[Tool result not available]";
+pub const UNAVAILABLE_RESULT: &str = "[Tool result not available]";
 
-pub type SharedMessages = Arc<ArcSwap<Vec<Message>>>;
+pub type HistorySnapshot = maki_storage::sessions::HistorySnapshot<Message>;
+pub type SharedMessages = Arc<ArcSwap<HistorySnapshot>>;
 
 pub struct History {
-    messages: Vec<Message>,
+    /// The value the mirror publishes, held whole so the two can never
+    /// disagree and so a new run can never inherit the last one's epoch.
+    snapshot: HistorySnapshot,
     mirror: Option<SharedMessages>,
 }
 
 impl History {
     pub fn new(messages: Vec<Message>) -> Self {
         Self {
-            messages,
+            snapshot: HistorySnapshot::new(messages),
             mirror: None,
         }
     }
 
     pub fn restored(mut messages: Vec<Message>) -> Self {
         sanitize_restored(&mut messages);
-        Self {
-            messages,
-            mirror: None,
-        }
+        Self::new(messages)
     }
 
     pub fn with_mirror(mut self, mirror: SharedMessages) -> Self {
@@ -37,7 +38,7 @@ impl History {
     }
 
     pub fn as_slice(&self) -> &[Message] {
-        &self.messages
+        &self.snapshot.messages
     }
 
     pub fn push(&mut self, msg: Message) {
@@ -45,11 +46,11 @@ impl History {
     }
 
     pub fn len(&self) -> usize {
-        self.messages.len()
+        self.snapshot.messages.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.messages.is_empty()
+        self.snapshot.messages.is_empty()
     }
 
     pub fn has_recent_tool_results(&self, depth: usize) -> bool {
@@ -63,27 +64,36 @@ impl History {
     }
 
     pub fn replace(&mut self, messages: Vec<Message>) {
-        self.edit(|msgs| *msgs = messages);
+        self.rewrite(|msgs| *msgs = messages);
     }
 
     pub fn truncate(&mut self, len: usize) {
-        self.edit(|msgs| msgs.truncate(len));
+        self.rewrite(|msgs| msgs.truncate(len));
     }
 
     pub fn into_vec(self) -> Vec<Message> {
-        self.messages
+        Arc::unwrap_or_clone(self.snapshot.messages)
     }
 
+    /// An append: whatever a consumer already holds of the list stays good.
     fn edit(&mut self, f: impl FnOnce(&mut Vec<Message>)) {
-        f(&mut self.messages);
+        f(Arc::make_mut(&mut self.snapshot.messages));
         self.publish();
     }
 
+    /// Any other change, so a consumer has to start the list over.
+    fn rewrite(&mut self, f: impl FnOnce(&mut Vec<Message>)) {
+        self.snapshot.epoch = next_epoch();
+        self.edit(f);
+    }
+
+    /// The mirror gets the messages as they are. Closing dangling tool calls
+    /// here used to make the snapshot as long as the real results that came
+    /// next, so the log never saw them. Callers that need an API-valid list
+    /// close the dangling calls on their own copy.
     fn publish(&self) {
         let Some(mirror) = &self.mirror else { return };
-        let mut snapshot = self.messages.clone();
-        close_dangling_tool_calls(&mut snapshot, UNAVAILABLE_RESULT);
-        mirror.store(Arc::new(snapshot));
+        mirror.store(Arc::new(self.snapshot.clone()));
     }
 }
 
@@ -151,7 +161,7 @@ fn sanitize_restored(messages: &mut Vec<Message>) {
     }
 }
 
-fn close_dangling_tool_calls(messages: &mut Vec<Message>, note: &str) {
+pub fn close_dangling_tool_calls(messages: &mut Vec<Message>, note: &str) {
     let Some(last) = messages.last() else { return };
     if !matches!(last.role, Role::Assistant) || !last.has_tool_calls() {
         return;
@@ -187,6 +197,10 @@ mod tests {
     use test_case::test_case;
 
     use super::*;
+
+    const FIRST: &str = "first";
+    const SECOND: &str = "second";
+    const GO: &str = "go";
 
     #[track_caller]
     fn assert_ends_with_cancel_marker(history: &History) {
@@ -226,7 +240,7 @@ mod tests {
     }
 
     fn make_mirror() -> SharedMessages {
-        Arc::new(ArcSwap::from_pointee(Vec::new()))
+        Arc::new(ArcSwap::from_pointee(HistorySnapshot::default()))
     }
 
     #[track_caller]
@@ -295,99 +309,90 @@ mod tests {
     }
 
     #[test]
-    fn mirror_sequential_mutations_always_consistent() {
+    fn mirror_is_verbatim_and_epoch_tracks_appends() {
         let mirror = make_mirror();
         let mut history = History::new(Vec::new()).with_mirror(Arc::clone(&mirror));
+        let append_epoch = mirror.load().epoch;
 
         for i in 0..10 {
             history.push(Message::user(format!("msg-{i}")));
-            assert_eq!(mirror.load().len(), i + 1);
+            assert_eq!(mirror.load().messages.len(), i + 1);
+            assert_eq!(mirror.load().epoch, append_epoch, "push is an append");
         }
 
         history.truncate(3);
-        assert_eq!(mirror.load().len(), 3);
-
-        history.replace(vec![Message::user("fresh".into())]);
-        assert_eq!(mirror.load().len(), 1);
+        assert_eq!(mirror.load().messages.len(), 3);
+        assert_ne!(
+            mirror.load().epoch,
+            append_epoch,
+            "truncate is not an append"
+        );
 
         history.push(make_tool_use_msg(&["t_final"]));
-        assert_eq!(history.len(), 2, "history has 2");
-        assert_eq!(mirror.load().len(), 3, "mirror has 3 (dangling closed)");
+        assert_eq!(history.len(), 4);
+        assert_eq!(
+            mirror.load().messages.len(),
+            4,
+            "dangling tool_use is mirrored verbatim"
+        );
     }
 
     #[test]
-    fn snapshot_closes_dangling_tool_uses_without_mutating_history() {
-        let mirror = make_mirror();
-        let history = History::new(vec![
-            Message::user("go".into()),
-            make_tool_use_msg(&["t1", "t2"]),
-        ])
-        .with_mirror(Arc::clone(&mirror));
+    fn close_dangling_tool_uses_appends_error_results() {
+        let mut messages = vec![Message::user("go".into()), make_tool_use_msg(&["t1", "t2"])];
+        close_dangling_tool_calls(&mut messages, UNAVAILABLE_RESULT);
 
-        assert_eq!(history.len(), 2, "history itself unchanged");
-
-        let snap = mirror.load();
-        assert_eq!(snap.len(), 3, "snapshot has extra closing message");
-
-        let closing = &snap[2];
+        assert_eq!(messages.len(), 3);
+        let closing = &messages[2];
         assert!(matches!(closing.role, Role::User));
         assert_eq!(extract_error_ids(closing), ["t1", "t2"]);
         assert_eq!(closing.display_text.as_deref(), Some(""));
     }
 
     #[test]
-    fn snapshot_not_dangling_when_tool_result_already_present() {
-        let mirror = make_mirror();
-        let mut history =
-            History::new(vec![Message::user("go".into()), make_tool_use_msg(&["t1"])])
-                .with_mirror(Arc::clone(&mirror));
-
-        assert_eq!(mirror.load().len(), 3, "dangling before result");
-
-        history.push(Message {
-            role: Role::User,
-            content: vec![ContentBlock::ToolResult {
-                tool_use_id: "t1".into(),
-                content: "file contents".into(),
-                is_error: false,
-            }],
-            ..Default::default()
-        });
-
-        let snap = mirror.load();
-        assert_eq!(snap.len(), 3, "no extra closing after real result");
+    fn close_dangling_is_noop_when_tool_result_already_present() {
+        let mut messages = vec![
+            Message::user("go".into()),
+            make_tool_use_msg(&["t1"]),
+            make_tool_result_msg(&["t1"]),
+        ];
+        close_dangling_tool_calls(&mut messages, UNAVAILABLE_RESULT);
+        assert_eq!(messages.len(), 3, "no extra closing after real result");
     }
 
     #[test]
-    fn into_vec_returns_inner_not_snapshot() {
+    fn into_vec_returns_inner_messages() {
         let mirror = make_mirror();
         let history = History::new(vec![Message::user("go".into()), make_tool_use_msg(&["t1"])])
             .with_mirror(Arc::clone(&mirror));
 
-        assert_eq!(mirror.load().len(), 3, "snapshot has closing message");
-        assert_eq!(history.into_vec().len(), 2, "into_vec returns raw messages");
+        assert_eq!(mirror.load().messages.len(), 2);
+        assert_eq!(history.into_vec().len(), 2);
     }
 
+    /// Cancelling closes the open tool calls and marks the turn, all onto the
+    /// end of the list, so the log can keep appending instead of rewriting.
     #[test]
-    fn sanitize_cancelled_on_mirrored_history() {
+    fn sanitize_cancelled_history_appends_onto_the_mirror() {
         let mirror = make_mirror();
-        let mut history =
-            History::new(vec![Message::user("go".into()), make_tool_use_msg(&["t1"])])
-                .with_mirror(Arc::clone(&mirror));
+        let mut history = History::new(vec![Message::user(GO.into()), make_tool_use_msg(&["t1"])])
+            .with_mirror(Arc::clone(&mirror));
+        let epoch = mirror.load().epoch;
 
         sanitize_cancelled_history(&mut history, 0);
 
         let snap = mirror.load();
-        assert_eq!(snap.len(), history.len(), "mirror matches history length");
-
-        let last = snap.last().unwrap();
-        assert!(matches!(&last.content[0], ContentBlock::Text { text } if text == CANCEL_MARKER));
-
-        let tool_result_msg = &snap[snap.len() - 2];
-        assert!(tool_result_msg.content.iter().any(|b| matches!(
+        assert_eq!(snap.epoch, epoch, "cancel cleanup is a pure append");
+        assert_eq!(snap.messages.len(), history.len(), "mirror is verbatim");
+        assert_eq!(extract_error_ids(&snap.messages[2]), ["t1"]);
+        assert!(snap.messages[2].content.iter().any(|b| matches!(
             b,
-            ContentBlock::ToolResult { content, is_error: true, .. } if content == CANCEL_MARKER
+            ContentBlock::ToolResult { content, .. } if content == CANCEL_MARKER
         )));
+        assert!(matches!(
+            &snap.messages[3].content[0],
+            ContentBlock::Text { text } if text == CANCEL_MARKER
+        ));
     }
 
     fn text_msg(role: Role, text: &str) -> Message {
@@ -548,5 +553,98 @@ mod tests {
             history.has_recent_tool_results(depth)
         };
         assert_eq!(result, depth > 0);
+    }
+
+    /// The writer thread serializes a snapshot while the user keeps typing, so
+    /// a published snapshot must never move under it.
+    #[test]
+    fn published_snapshot_is_frozen_against_later_mutations() {
+        let mirror = make_mirror();
+        let mut history =
+            History::new(vec![Message::user(FIRST.into())]).with_mirror(Arc::clone(&mirror));
+
+        let after_new = mirror.load_full();
+        history.push(Message::user(SECOND.into()));
+        assert_eq!(after_new.messages.len(), 1);
+        assert_eq!(after_new.messages[0].user_text(), Some(FIRST));
+        assert!(!Arc::ptr_eq(&after_new.messages, &mirror.load().messages));
+
+        let after_push = mirror.load_full();
+        history.truncate(1);
+        assert_eq!(after_push.messages.len(), 2);
+        assert_eq!(after_push.messages[1].user_text(), Some(SECOND));
+        assert!(!Arc::ptr_eq(&after_push.messages, &mirror.load().messages));
+    }
+
+    /// After a respawn the old run's messages must be gone from the mirror
+    /// right away, not only once the new run pushes something.
+    #[test]
+    fn with_mirror_overwrites_previous_run_snapshot_immediately() {
+        let mirror = make_mirror();
+        let run1 = History::new(vec![Message::user(FIRST.into())]).with_mirror(Arc::clone(&mirror));
+        let run1_epoch = mirror.load().epoch;
+        drop(run1);
+
+        let _run2 = History::new(vec![Message::user(SECOND.into()), Message::user(GO.into())])
+            .with_mirror(Arc::clone(&mirror));
+
+        let snap = mirror.load();
+        assert_eq!(snap.messages.len(), 2);
+        assert_eq!(snap.messages[0].user_text(), Some(SECOND));
+        assert_ne!(snap.epoch, run1_epoch, "run 2 is not an append onto run 1");
+    }
+
+    #[test]
+    fn restored_mints_fresh_epoch_and_mirrors_sanitized_messages() {
+        let mirror = make_mirror();
+        let seed_epoch = mirror.load().epoch;
+
+        let history = History::restored(vec![
+            Message::user(GO.into()),
+            make_tool_use_msg(&["t1"]),
+            make_tool_result_msg(&["orphan"]),
+        ])
+        .with_mirror(Arc::clone(&mirror));
+
+        let snap = mirror.load();
+        assert_ne!(snap.epoch, seed_epoch);
+        assert!(
+            Arc::ptr_eq(&snap.messages, &history.snapshot.messages),
+            "mirror shares the sanitized buffer verbatim"
+        );
+        assert_eq!(snap.messages.len(), 3);
+        assert_eq!(extract_error_ids(&snap.messages[2]), ["t1"]);
+    }
+
+    #[test]
+    fn sanitize_cancelled_history_noop_publishes_nothing() {
+        let mirror = make_mirror();
+        let mut history =
+            History::new(vec![Message::user(GO.into())]).with_mirror(Arc::clone(&mirror));
+        let before = mirror.load_full();
+        let rollback_len = history.len();
+
+        sanitize_cancelled_history(&mut history, rollback_len);
+
+        let after = mirror.load_full();
+        assert_eq!(before.epoch, after.epoch);
+        assert!(Arc::ptr_eq(&before.messages, &after.messages));
+    }
+
+    /// Compaction can swap the whole list for one of the same length, which a
+    /// length-only check would miss and quietly corrupt the log.
+    #[test]
+    fn replace_mints_new_epoch_even_when_length_is_unchanged() {
+        let mirror = make_mirror();
+        let mut history =
+            History::new(vec![Message::user(FIRST.into())]).with_mirror(Arc::clone(&mirror));
+        let epoch = mirror.load().epoch;
+
+        history.replace(vec![Message::user(SECOND.into())]);
+
+        let snap = mirror.load();
+        assert_ne!(snap.epoch, epoch);
+        assert_eq!(snap.messages.len(), 1);
+        assert_eq!(snap.messages[0].user_text(), Some(SECOND));
     }
 }

--- a/maki-agent/src/agent/mod.rs
+++ b/maki-agent/src/agent/mod.rs
@@ -6,7 +6,9 @@ mod streaming;
 pub mod tool_dispatch;
 
 pub use compaction::compact;
-pub use history::{History, SharedMessages};
+pub use history::{
+    History, HistorySnapshot, SharedMessages, UNAVAILABLE_RESULT, close_dangling_tool_calls,
+};
 pub use instructions::{
     Instructions, LoadedInstructions, build_system_prompt, find_subdirectory_instructions,
     is_instruction_file, load_instruction_text, load_instructions,

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -61,8 +61,8 @@ impl SessionStore {
     }
 
     fn record_turn(&mut self, messages: &[Message], model_spec: String) {
-        self.session.messages = messages.to_vec();
-        self.session.model = model_spec;
+        self.session.replace_messages(messages.to_vec());
+        self.session.set_model(model_spec);
         self.session.update_title_if_default();
         self.save();
     }
@@ -526,7 +526,7 @@ mod tests {
         assert_eq!(loaded.id, session_id());
         assert_eq!(loaded.cwd, CWD);
         assert_eq!(loaded.model, MODEL_SPEC);
-        assert!(loaded.messages.is_empty());
+        assert!(loaded.messages().is_empty());
     }
 
     #[test]
@@ -537,7 +537,7 @@ mod tests {
         store.record_turn(&messages, MODEL_SPEC.into());
 
         let loaded = load(&tmp);
-        assert_eq!(loaded.messages.len(), 1);
+        assert_eq!(loaded.messages().len(), 1);
         assert_eq!(loaded.title, generate_title(&messages));
     }
 
@@ -549,7 +549,7 @@ mod tests {
         drop(store);
 
         let mut store = store_in(&tmp);
-        assert_eq!(store.session.messages.len(), 1);
+        assert_eq!(store.session.messages().len(), 1);
 
         let messages = vec![
             Message::user("first prompt".into()),
@@ -558,7 +558,7 @@ mod tests {
         store.record_turn(&messages, "other/model".into());
 
         let loaded = load(&tmp);
-        assert_eq!(loaded.messages.len(), 2);
+        assert_eq!(loaded.messages().len(), 2);
         assert_eq!(loaded.model, "other/model");
     }
 

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -13,8 +13,9 @@ pub use mcp::{
 };
 pub(crate) mod task_set;
 pub use agent::{
-    Agent, AgentParams, AgentRunParams, History, Instructions, LoadedInstructions, SharedMessages,
-    find_subdirectory_instructions, is_instruction_file,
+    Agent, AgentParams, AgentRunParams, History, HistorySnapshot, Instructions, LoadedInstructions,
+    SharedMessages, UNAVAILABLE_RESULT, close_dangling_tool_calls, find_subdirectory_instructions,
+    is_instruction_file,
 };
 pub use cancel::{CancelMap, CancelToken, CancelTrigger};
 pub use maki_config::{AgentConfig, PermissionsConfig, ToolOutputLines};

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -14,6 +14,8 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::UNIX_EPOCH;
 
 use tracing::warn;
@@ -34,6 +36,21 @@ const SCAN_CACHE_STEM: &str = "scan_cache";
 const NON_SESSION_STEMS: [&str; 2] = [CWD_INDEX_STEM, SCAN_CACHE_STEM];
 const DEFAULT_TITLE: &str = "New session";
 const MAX_TITLE_LEN: usize = 60;
+const EPOCH_CHANGED: &str = "messages were rewritten";
+const FILE_CHANGED_UNDERNEATH: &str = "file changed underneath";
+const CURSOR_AHEAD: &str = "cursor ahead of session";
+const LOG_BLOATED: &str = "too many stale meta records";
+/// Every append leaves a whole meta record behind and only the last one is ever
+/// read. Past this many, the log is rewritten and they all go away at once.
+const MAX_APPENDS: usize = 512;
+
+/// Hands out the token that tags one append-only run of a message list.
+/// Process wide, so two runs never pick the same number.
+static EPOCH: AtomicU64 = AtomicU64::new(1);
+
+pub fn next_epoch() -> u64 {
+    EPOCH.fetch_add(1, Ordering::Relaxed)
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum SessionError {
@@ -49,8 +66,8 @@ pub enum SessionError {
         raw_id: String,
         source: MakiIdParseError,
     },
-    #[error("cursor ahead of session (log has {saved}, session has {actual}); compact required")]
-    CursorAhead { saved: usize, actual: usize },
+    #[error("session log diverged ({reason}); rewrite required")]
+    LogDiverged { reason: &'static str },
 }
 
 /// Per-model token breakdown entry. Mirrors the four usage counters tracked by
@@ -89,7 +106,7 @@ impl std::ops::AddAssign for StoredTokenUsage {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct SessionMeta {
     #[serde(default)]
     pub mode: Option<StoredMode>,
@@ -105,18 +122,49 @@ pub struct SessionMeta {
     pub input_draft: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub queued_messages: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub subagents: Vec<StoredSubagent>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thinking: Option<StoredThinking>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub fast: bool,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub workflow: bool,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub usage_by_model: HashMap<String, StoredTokenUsage>,
 }
 
+/// Messages plus the token of the run they belong to. Comparing tokens tells
+/// an append from a rewrite, with no need to diff the lists.
+#[derive(Clone)]
+pub struct HistorySnapshot<M> {
+    pub epoch: u64,
+    pub messages: Arc<Vec<M>>,
+}
+
+impl<M> HistorySnapshot<M> {
+    pub fn new(messages: Vec<M>) -> Self {
+        Self {
+            epoch: next_epoch(),
+            messages: Arc::new(messages),
+        }
+    }
+}
+
+impl<M> Default for HistorySnapshot<M> {
+    fn default() -> Self {
+        Self::new(Vec::new())
+    }
+}
+
+/// The conversation collections are private so every change goes through a
+/// mutator that classifies itself: `revision` says "this needs writing",
+/// `epoch` says "append cursors into the log are void". The other fields stay
+/// public because the meta record is rewritten in full on every append, so
+/// they hold no cursor to spoil. `cwd` and `model` are the exception: they
+/// live in the header record, which only a rewrite touches, so changes must
+/// go through their setters.
+///
+/// [`SessionMeta`] is the part the owner mirrors from its own live state and
+/// hands over whole on every checkpoint. Whatever the session maintains itself
+/// gets a field of its own instead, so a checkpoint never copies it out and
+/// back in only to compare it against itself.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session<M, U, T> {
     pub version: u32,
@@ -124,16 +172,34 @@ pub struct Session<M, U, T> {
     pub title: String,
     pub cwd: String,
     pub model: String,
-    pub messages: Vec<M>,
+    messages: Arc<Vec<M>>,
     pub token_usage: U,
     #[serde(default = "HashMap::new")]
-    pub tool_outputs: HashMap<String, T>,
+    tool_outputs: HashMap<String, Arc<T>>,
     #[serde(default = "HashMap::new", skip_serializing_if = "HashMap::is_empty")]
-    pub subagent_messages: HashMap<String, Vec<M>>,
+    subagent_messages: HashMap<String, Arc<Vec<M>>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    subagents: Vec<StoredSubagent>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    usage_by_model: HashMap<String, StoredTokenUsage>,
     #[serde(flatten)]
     pub meta: SessionMeta,
     pub created_at: u64,
     pub updated_at: u64,
+    /// Bumped by every mutation, so a checkpoint knows if there is anything
+    /// to write.
+    #[serde(skip)]
+    revision: u64,
+    /// Bumped by every mutation except `meta`, so a checkpoint can tell a tool
+    /// result, which has to reach disk now, from a keystroke in the draft,
+    /// which can wait for the keystrokes behind it.
+    #[serde(skip)]
+    content_revision: u64,
+    /// The append-only run `messages` belongs to, adopted from the producer's
+    /// snapshot or minted fresh when this session rewrites them itself. Once
+    /// it changes, every append cursor into the log is void.
+    #[serde(skip, default = "next_epoch")]
+    epoch: u64,
 }
 
 #[derive(Serialize)]
@@ -157,7 +223,7 @@ pub enum StoredMode {
     Plan,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StoredRule {
     pub tool: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -306,12 +372,10 @@ impl StoredThinking {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StoredSubagent {
     pub tool_use_id: String,
     pub name: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub prompt: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
 }
@@ -379,6 +443,10 @@ enum LogRecord<M, U, T> {
         title: String,
         token_usage: U,
         updated_at: u64,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        subagents: Vec<StoredSubagent>,
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        usage_by_model: HashMap<String, StoredTokenUsage>,
         #[serde(flatten)]
         meta: SessionMeta,
     },
@@ -389,7 +457,14 @@ enum LogRecord<M, U, T> {
 pub struct SessionLog {
     session_id: MakiId,
     file: File,
+    /// The session's `epoch` at the last write. Appending is sound only while
+    /// it stays the same.
+    saved_epoch: u64,
+    /// Length of the file after the last write. Anything else means someone
+    /// truncated, deleted or wrote it, and an append would corrupt it.
+    saved_len: u64,
     saved_msg_count: usize,
+    appends: usize,
     saved_tool_ids: HashSet<String>,
     saved_sub_msg_counts: HashMap<String, usize>,
     /// Serialized trailing meta record; lets `append` persist meta-only
@@ -397,22 +472,29 @@ pub struct SessionLog {
     saved_meta: Vec<u8>,
 }
 
-fn sub_msg_snapshot<M>(map: &HashMap<String, Vec<M>>) -> HashMap<String, usize> {
+fn sub_msg_snapshot<M>(map: &HashMap<String, Arc<Vec<M>>>) -> HashMap<String, usize> {
     map.iter().map(|(k, v)| (k.clone(), v.len())).collect()
 }
 
 impl SessionLog {
-    pub fn create<M, U, T>(dir: &Path, session: &Session<M, U, T>) -> Result<Self, SessionError>
+    /// Starts the file over: writes the whole log through a rename, so a crash
+    /// mid-write leaves the old one intact, then claims the cwd index and
+    /// sweeps pre-jsonl leftovers. The only way to get a usable cursor onto a
+    /// file this process did not write: a cursor read back from disk describes
+    /// the session that was loaded, never the live one.
+    pub fn rewrite<M, U, T>(dir: &Path, session: &Session<M, U, T>) -> Result<Self, SessionError>
     where
         M: Serialize,
         U: Serialize,
         T: Serialize,
     {
-        let file = write_session_file(dir, session)?;
+        let log = Self::write_canonical(dir, session)?;
         update_cwd_index(dir, &session.cwd, session.id)?;
-        Ok(Self::cursor_from(session, file))
+        Ok(log)
     }
 
+    /// [`Self::rewrite`] without claiming the cwd index: migrating a legacy
+    /// file on load must not make that session the cwd's latest.
     fn write_canonical<M, U, T>(
         dir: &Path,
         session: &Session<M, U, T>,
@@ -422,47 +504,23 @@ impl SessionLog {
         U: Serialize,
         T: Serialize,
     {
-        let file = write_session_file(dir, session)?;
-        Ok(Self::cursor_from(session, file))
-    }
+        fs::create_dir_all(dir).map_err(StorageError::from)?;
+        let path = jsonl_path(dir, session.id);
+        let tmp = path.with_extension("jsonl.tmp");
 
-    pub fn open<M, U, T>(
-        dir: &Path,
-        session_id: MakiId,
-    ) -> Result<(Session<M, U, T>, Self), SessionError>
-    where
-        M: Serialize + DeserializeOwned,
-        U: Serialize + DeserializeOwned + Default,
-        T: Serialize + DeserializeOwned,
-    {
-        let path = jsonl_path(dir, session_id);
-        let bytes = fs::read(&path).map_err(StorageError::from)?;
-        let valid = bytes.iter().rposition(|&b| b == b'\n').map_or(0, |i| i + 1);
+        let mut tmp_file = File::create(&tmp).map_err(StorageError::from)?;
+        write_full_session(&mut tmp_file, session)?;
+        tmp_file.sync_data().map_err(StorageError::from)?;
+        fs::rename(&tmp, &path).map_err(StorageError::from)?;
 
-        if valid < bytes.len() {
-            warn!(
-                path = %path.display(),
-                bytes = bytes.len() - valid,
-                "truncating torn session log tail",
-            );
-            OpenOptions::new()
-                .write(true)
-                .open(&path)
-                .map_err(StorageError::from)?
-                .set_len(valid as u64)
-                .map_err(StorageError::from)?;
+        if let Err(e) = remove_legacy_files(dir, session.id) {
+            warn!(error = %e, "legacy session files remain after rewrite");
         }
-
-        let display = path.display().to_string();
-        let session = load_jsonl::<M, U, T>(&bytes[..valid], &display)?;
-
         let file = OpenOptions::new()
             .append(true)
             .open(&path)
             .map_err(StorageError::from)?;
-
-        let log = Self::cursor_from(&session, file);
-        Ok((session, log))
+        Ok(Self::cursor_from(session, file))
     }
 
     pub fn session_id(&self) -> MakiId {
@@ -476,13 +534,7 @@ impl SessionLog {
         T: Serialize,
     {
         self.require_same_id(session)?;
-
-        if self.cursor_ahead(session) {
-            return Err(SessionError::CursorAhead {
-                saved: self.saved_msg_count,
-                actual: session.messages.len(),
-            });
-        }
+        self.ensure_appendable(session)?;
 
         let mut buf = Vec::new();
         let mut new_msg_count = self.saved_msg_count;
@@ -529,7 +581,6 @@ impl SessionLog {
         }
         buf.extend_from_slice(&meta);
 
-        let start = self.file.metadata().map_err(StorageError::from)?.len();
         if let Err(e) = self
             .file
             .write_all(&buf)
@@ -538,10 +589,12 @@ impl SessionLog {
             // A failed write can leave partial bytes; roll back to the last
             // record boundary so the file matches the unadvanced cursors and
             // a retry appends cleanly instead of duplicating records.
-            let _ = self.file.set_len(start);
+            let _ = self.file.set_len(self.saved_len);
             return Err(StorageError::from(e).into());
         }
 
+        self.saved_len += buf.len() as u64;
+        self.appends += 1;
         self.saved_msg_count = new_msg_count;
         self.saved_tool_ids.extend(new_tool_ids);
         for (sub_id, count) in new_sub_counts {
@@ -552,46 +605,20 @@ impl SessionLog {
         Ok(())
     }
 
-    pub fn compact<M, U, T>(
-        &mut self,
-        dir: &Path,
-        session: &Session<M, U, T>,
-    ) -> Result<(), SessionError>
-    where
-        M: Serialize,
-        U: Serialize,
-        T: Serialize,
-    {
-        self.require_same_id(session)?;
-
-        let path = jsonl_path(dir, session.id);
-        let tmp = path.with_extension("jsonl.tmp");
-
-        let mut tmp_file = File::create(&tmp).map_err(StorageError::from)?;
-        write_full_session(&mut tmp_file, session)?;
-        tmp_file.sync_data().map_err(StorageError::from)?;
-
-        fs::rename(&tmp, &path).map_err(StorageError::from)?;
-
-        let file = OpenOptions::new()
-            .append(true)
-            .open(&path)
-            .map_err(StorageError::from)?;
-        *self = Self::cursor_from(session, file);
-
-        Ok(())
-    }
-
     fn cursor_from<M, U, T>(session: &Session<M, U, T>, file: File) -> Self
     where
         M: Serialize,
         U: Serialize,
         T: Serialize,
     {
+        let saved_len = file.metadata().map(|m| m.len()).unwrap_or_default();
         Self {
             session_id: session.id,
             file,
+            saved_epoch: session.epoch,
+            saved_len,
             saved_msg_count: session.messages.len(),
+            appends: 0,
             saved_tool_ids: session.tool_outputs.keys().cloned().collect(),
             saved_sub_msg_counts: sub_msg_snapshot(&session.subagent_messages),
             saved_meta: meta_record(session).unwrap_or_default(),
@@ -606,6 +633,27 @@ impl SessionLog {
             });
         }
         Ok(())
+    }
+
+    /// Ok only while every cursor still describes the file, which is what makes
+    /// `saved_len` the file length and the rest of the cursors its content, and
+    /// while appending is still cheaper than starting the file over.
+    fn ensure_appendable<M, U, T>(&self, session: &Session<M, U, T>) -> Result<(), SessionError> {
+        let reason = if session.epoch != self.saved_epoch {
+            EPOCH_CHANGED
+        } else if self.file.metadata().map_err(StorageError::from)?.len() != self.saved_len {
+            FILE_CHANGED_UNDERNEATH
+        } else if self.appends >= MAX_APPENDS {
+            LOG_BLOATED
+        } else if self.cursor_ahead(session) {
+            // Nothing shrinks a session without minting a new epoch, so this
+            // should never fire. It stays because the slices in `append` would
+            // panic instead of corrupting if it ever does.
+            CURSOR_AHEAD
+        } else {
+            return Ok(());
+        };
+        Err(SessionError::LogDiverged { reason })
     }
 
     fn cursor_ahead<M, U, T>(&self, session: &Session<M, U, T>) -> bool {
@@ -636,24 +684,12 @@ where
             title: session.title.clone(),
             token_usage: &session.token_usage,
             updated_at: session.updated_at,
+            subagents: session.subagents.clone(),
+            usage_by_model: session.usage_by_model.clone(),
             meta: session.meta.clone(),
         },
     )?;
     Ok(buf)
-}
-
-fn write_session_file<M, U, T>(dir: &Path, session: &Session<M, U, T>) -> Result<File, SessionError>
-where
-    M: Serialize,
-    U: Serialize,
-    T: Serialize,
-{
-    fs::create_dir_all(dir).map_err(StorageError::from)?;
-    let path = jsonl_path(dir, session.id);
-    let mut file = File::create(&path).map_err(StorageError::from)?;
-    write_full_session(&mut file, session)?;
-    file.sync_data().map_err(StorageError::from)?;
-    Ok(file)
 }
 
 fn write_full_session<M, U, T>(
@@ -676,7 +712,7 @@ where
             created_at: session.created_at,
         },
     )?;
-    for msg in &session.messages {
+    for msg in session.messages.iter() {
         append_record(&mut buf, &LogRecord::<&M, &U, &T>::Msg { d: msg })?;
     }
     for (id, output) in &session.tool_outputs {
@@ -689,7 +725,7 @@ where
         )?;
     }
     for (sub_id, msgs) in &session.subagent_messages {
-        for msg in msgs {
+        for msg in msgs.iter() {
             append_record(
                 &mut buf,
                 &LogRecord::<&M, &U, &T>::SubMsg {
@@ -734,12 +770,14 @@ where
     let mut model = String::new();
     let mut cwd = String::new();
     let mut created_at = 0u64;
-    let mut messages = Vec::new();
+    let mut messages: Vec<M> = Vec::new();
     let mut tool_outputs = HashMap::new();
     let mut subagent_messages: HashMap<String, Vec<M>> = HashMap::new();
     let mut title = DEFAULT_TITLE.to_string();
     let mut token_usage = U::default();
     let mut updated_at = 0u64;
+    let mut subagents = Vec::new();
+    let mut usage_by_model = HashMap::new();
     let mut meta = SessionMeta::default();
     let mut got_header = false;
 
@@ -792,7 +830,7 @@ where
             }
             LogRecord::Msg { d } => messages.push(d),
             LogRecord::Out { id: out_id, d } => {
-                tool_outputs.insert(out_id, d);
+                tool_outputs.insert(out_id, Arc::new(d));
             }
             LogRecord::SubMsg { sub, d } => {
                 subagent_messages.entry(sub).or_default().push(d);
@@ -801,11 +839,15 @@ where
                 title: m_title,
                 token_usage: m_usage,
                 updated_at: m_updated,
+                subagents: m_subagents,
+                usage_by_model: m_usage_by_model,
                 meta: m_meta,
             } => {
                 title = m_title;
                 token_usage = m_usage;
                 updated_at = m_updated;
+                subagents = m_subagents;
+                usage_by_model = m_usage_by_model;
                 meta = m_meta;
             }
         }
@@ -819,13 +861,21 @@ where
         title,
         cwd,
         model,
-        messages,
+        messages: Arc::new(messages),
         token_usage,
         tool_outputs,
-        subagent_messages,
+        subagent_messages: subagent_messages
+            .into_iter()
+            .map(|(id, msgs)| (id, Arc::new(msgs)))
+            .collect(),
+        subagents,
+        usage_by_model,
         meta,
         created_at,
         updated_at,
+        revision: 0,
+        content_revision: 0,
+        epoch: next_epoch(),
     })
 }
 
@@ -1128,7 +1178,7 @@ where
 
 impl<M, U, T> Session<M, U, T>
 where
-    M: Serialize + DeserializeOwned + TitleSource,
+    M: Serialize + DeserializeOwned + TitleSource + Clone,
     U: Serialize + DeserializeOwned + Default,
     T: Serialize + DeserializeOwned,
 {
@@ -1140,17 +1190,210 @@ where
             title: DEFAULT_TITLE.into(),
             cwd: cwd.into(),
             model: model.into(),
-            messages: Vec::new(),
+            messages: Arc::default(),
             token_usage: U::default(),
             tool_outputs: HashMap::new(),
             subagent_messages: HashMap::new(),
+            subagents: Vec::new(),
+            usage_by_model: HashMap::new(),
             meta: SessionMeta {
                 mode: Some(StoredMode::Build),
                 ..Default::default()
             },
             created_at: now,
             updated_at: now,
+            revision: 0,
+            content_revision: 0,
+            epoch: next_epoch(),
         }
+    }
+
+    pub fn messages(&self) -> &[M] {
+        &self.messages
+    }
+
+    pub fn take_messages(self) -> Vec<M> {
+        Arc::unwrap_or_clone(self.messages)
+    }
+
+    pub fn tool_outputs(&self) -> &HashMap<String, Arc<T>> {
+        &self.tool_outputs
+    }
+
+    pub fn subagent_messages(&self) -> &HashMap<String, Arc<Vec<M>>> {
+        &self.subagent_messages
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub fn content_revision(&self) -> u64 {
+        self.content_revision
+    }
+
+    fn touch(&mut self) {
+        self.content_revision += 1;
+        self.touch_soft();
+    }
+
+    /// Only UI state moved, so the write can wait for company. Everything a
+    /// crash would lose for good goes through `touch`, which is the default a
+    /// new mutator gets by not thinking about it.
+    fn touch_soft(&mut self) {
+        self.updated_at = now_epoch();
+        self.revision += 1;
+    }
+
+    /// Every append cursor into the log is void from here on.
+    fn rewrite(&mut self) {
+        self.epoch = next_epoch();
+        self.touch();
+    }
+
+    pub fn push_message(&mut self, msg: M) {
+        Arc::make_mut(&mut self.messages).push(msg);
+        self.touch();
+    }
+
+    pub fn replace_messages(&mut self, messages: Vec<M>) {
+        self.messages = Arc::new(messages);
+        self.rewrite();
+    }
+
+    pub fn truncate_messages(&mut self, len: usize) {
+        if len >= self.messages.len() {
+            return;
+        }
+        Arc::make_mut(&mut self.messages).truncate(len);
+        self.rewrite();
+    }
+
+    /// Adopting a producer's snapshot inherits its run token, so the log's
+    /// cursors survive exactly when the snapshot was an append.
+    fn set_history(&mut self, snapshot: &HistorySnapshot<M>) {
+        self.messages = Arc::clone(&snapshot.messages);
+        self.epoch = snapshot.epoch;
+        self.touch();
+    }
+
+    /// Applies everything the owner mirrors from live state. It takes an `Arc`
+    /// and checks for a real change first because `Arc::make_mut` deep-copies
+    /// the whole session while the writer still holds the last snapshot, and an
+    /// idle session should not pay for that every frame.
+    pub fn checkpoint(
+        this: &mut Arc<Self>,
+        history: Option<&HistorySnapshot<M>>,
+        meta: SessionMeta,
+        token_usage: U,
+    ) where
+        M: Clone,
+        U: PartialEq + Clone,
+        T: Clone,
+    {
+        let history = history.filter(|h| !Arc::ptr_eq(&this.messages, &h.messages));
+        if history.is_none() && this.meta == meta && this.token_usage == token_usage {
+            return;
+        }
+        let session = Arc::make_mut(this);
+        if let Some(snapshot) = history {
+            session.set_history(snapshot);
+            // The title comes from the messages, so it goes stale exactly when
+            // they move.
+            session.update_title_if_default();
+        }
+        session.set_meta(meta);
+        session.set_token_usage(token_usage);
+    }
+
+    /// A change under an existing id is not expressible as an append, so it
+    /// voids the cursors; a new id is a pure append.
+    pub fn insert_tool_output(&mut self, id: String, output: T) {
+        if self.tool_outputs.insert(id, Arc::new(output)).is_some() {
+            self.rewrite();
+        } else {
+            self.touch();
+        }
+    }
+
+    pub fn set_subagent_messages(&mut self, id: String, msgs: Vec<M>) {
+        let shrank = self
+            .subagent_messages
+            .get(&id)
+            .is_some_and(|old| msgs.len() < old.len());
+        self.subagent_messages.insert(id, Arc::new(msgs));
+        if shrank {
+            self.rewrite();
+        } else {
+            self.touch();
+        }
+    }
+
+    fn set_token_usage(&mut self, usage: U)
+    where
+        U: PartialEq,
+    {
+        if self.token_usage == usage {
+            return;
+        }
+        self.token_usage = usage;
+        self.touch();
+    }
+
+    fn set_meta(&mut self, meta: SessionMeta) {
+        if self.meta == meta {
+            return;
+        }
+        self.meta = meta;
+        self.touch_soft();
+    }
+
+    pub fn subagents(&self) -> &[StoredSubagent] {
+        &self.subagents
+    }
+
+    pub fn set_subagents(&mut self, subagents: Vec<StoredSubagent>) {
+        if self.subagents == subagents {
+            return;
+        }
+        self.subagents = subagents;
+        self.touch();
+    }
+
+    pub fn usage_by_model(&self) -> &HashMap<String, StoredTokenUsage> {
+        &self.usage_by_model
+    }
+
+    pub fn set_title(&mut self, title: String) {
+        if self.title == title {
+            return;
+        }
+        self.title = title;
+        self.touch();
+    }
+
+    /// Header field: appends never rewrite the header, so the change voids
+    /// the cursors to force a full rewrite.
+    pub fn set_cwd(&mut self, cwd: String) {
+        if self.cwd == cwd {
+            return;
+        }
+        self.cwd = cwd;
+        self.rewrite();
+    }
+
+    /// Header field, see [`Self::set_cwd`].
+    pub fn set_model(&mut self, model: String) {
+        if self.model == model {
+            return;
+        }
+        self.model = model;
+        self.rewrite();
+    }
+
+    pub fn add_model_usage(&mut self, model: &str, usage: StoredTokenUsage) {
+        *self.usage_by_model.entry(model.to_owned()).or_default() += usage;
+        self.touch();
     }
 
     /// After `messages` is truncated (rewind), state keyed by tool_use_id can
@@ -1162,18 +1405,18 @@ where
     pub fn prune_orphans(&mut self, tool_ids: impl Fn(&M) -> Vec<String>) {
         let main_ids: HashSet<String> = self.messages.iter().flat_map(&tool_ids).collect();
         self.subagent_messages.retain(|id, _| main_ids.contains(id));
-        self.meta
-            .subagents
+        self.subagents
             .retain(|sa| main_ids.contains(&sa.tool_use_id));
 
         let live: HashSet<String> = self
             .subagent_messages
             .values()
-            .flatten()
+            .flat_map(|msgs| msgs.iter())
             .flat_map(&tool_ids)
             .chain(main_ids)
             .collect();
         self.tool_outputs.retain(|id, _| live.contains(id));
+        self.rewrite();
     }
 
     pub fn save(&mut self, dir: &StateDir) -> Result<(), SessionError> {
@@ -1183,8 +1426,7 @@ where
 
     pub fn save_to(&mut self, dir: &Path) -> Result<(), SessionError> {
         self.updated_at = now_epoch();
-        write_session_file(dir, self)?;
-        update_cwd_index(dir, &self.cwd, self.id)?;
+        SessionLog::rewrite(dir, self)?;
         Ok(())
     }
 
@@ -1198,13 +1440,10 @@ where
             return Err(StorageError::NotFound(id.to_string()).into());
         };
         let session = load_session_at::<M, U, T>(&path)?;
-        let canonical = jsonl_path(dir, id);
-        if path != canonical {
-            if let Err(e) = SessionLog::write_canonical(dir, &session) {
-                warn!(error = %e, "failed migrate to canonical jsonl; keeping legacy file");
-            } else if let Err(e) = remove_legacy_files(dir, id) {
-                warn!(error = %e, "legacy files remain after migration");
-            }
+        if path != jsonl_path(dir, id)
+            && let Err(e) = SessionLog::write_canonical(dir, &session)
+        {
+            warn!(error = %e, "failed migrate to canonical jsonl; keeping legacy file");
         }
         Ok(session)
     }
@@ -1251,7 +1490,7 @@ where
 
     pub fn update_title_if_default(&mut self) {
         if self.title == DEFAULT_TITLE {
-            self.title = generate_title(&self.messages);
+            self.set_title(generate_title(&self.messages));
         }
     }
 
@@ -1269,12 +1508,6 @@ where
         remove_from_cwd_index(dir, id)?;
         Ok(())
     }
-
-    pub fn migrate_to_jsonl(dir: &Path, session: &Self) -> Result<SessionLog, SessionError> {
-        let log = SessionLog::create(dir, session)?;
-        remove_legacy_files(dir, session.id)?;
-        Ok(log)
-    }
 }
 
 #[cfg(test)]
@@ -1283,17 +1516,21 @@ mod tests {
     use super::StoredThinking;
     use super::ThinkingParseError;
     use super::{
-        CWD_INDEX_FILE, DEFAULT_TITLE, MAX_TITLE_LEN, SESSION_VERSION, StoredSubagent, TAIL_BUF,
-        generate_title, json_path, jsonl_path, load_cwd_index, update_cwd_index,
-        write_full_session,
+        CWD_INDEX_FILE, DEFAULT_TITLE, LOG_BLOATED, MAX_APPENDS, MAX_TITLE_LEN, SESSION_VERSION,
+        StoredSubagent, TAIL_BUF, generate_title, json_path, jsonl_path, load_cwd_index,
+        update_cwd_index, write_full_session,
     };
-    use super::{SCAN_CACHE_FILE, Session, SessionError, SessionLog, StorageError, TitleSource};
+    use super::{
+        HistorySnapshot, SCAN_CACHE_FILE, Session, SessionError, SessionLog, SessionMeta,
+        StorageError, TitleSource,
+    };
     use crate::id::MakiId;
     use serde_json::Value;
     use std::collections::HashMap;
     use std::fs::{self, OpenOptions};
     use std::io::Write;
     use std::path::Path;
+    use std::sync::Arc;
     use tempfile::TempDir;
     use test_case::test_case;
 
@@ -1301,6 +1538,7 @@ mod tests {
 
     const LEGACY_HEX_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
     const TAMPERED_TITLE: &str = "tampered cached title";
+    const PENDING_DRAFT: &str = "half typed thought";
 
     impl TitleSource for Value {
         fn first_user_text(&self) -> Option<&str> {
@@ -1354,38 +1592,36 @@ mod tests {
             StoredSubagent {
                 tool_use_id: id.into(),
                 name: "sub".into(),
-                prompt: None,
                 model: None,
             }
         }
 
         let mut session: TestSession = Session::new("model", "/p");
-        session.messages.push("task-live".into());
+        session.push_message("task-live".into());
         session
             .subagent_messages
-            .insert("task-live".into(), vec!["sub-tool".into()]);
+            .insert("task-live".into(), Arc::new(vec!["sub-tool".into()]));
         session
             .subagent_messages
-            .insert("task-stale".into(), vec!["stale-sub-tool".into()]);
-        session.meta.subagents = vec![subagent("task-live"), subagent("task-stale")];
+            .insert("task-stale".into(), Arc::new(vec!["stale-sub-tool".into()]));
+        session.set_subagents(vec![subagent("task-live"), subagent("task-stale")]);
         for id in ["task-live", "sub-tool", "stale-sub-tool", "orphan"] {
-            session.tool_outputs.insert(id.into(), Value::Null);
+            session.insert_tool_output(id.into(), Value::Null);
         }
 
         session.prune_orphans(ids);
 
         assert_eq!(
-            session.subagent_messages.keys().collect::<Vec<_>>(),
+            session.subagent_messages().keys().collect::<Vec<_>>(),
             ["task-live"]
         );
         let subagent_ids: Vec<_> = session
-            .meta
-            .subagents
+            .subagents()
             .iter()
             .map(|sa| sa.tool_use_id.as_str())
             .collect();
         assert_eq!(subagent_ids, ["task-live"]);
-        let mut outputs: Vec<_> = session.tool_outputs.keys().cloned().collect();
+        let mut outputs: Vec<_> = session.tool_outputs().keys().cloned().collect();
         outputs.sort();
         assert_eq!(outputs, ["sub-tool", "task-live"]);
     }
@@ -1396,8 +1632,8 @@ mod tests {
         let dir = tmp.path();
         let mut session: TestSession =
             Session::new("anthropic/claude-sonnet-4", "/home/test/project");
-        session.messages.push(user_message("hello"));
-        session.subagent_messages.insert(
+        session.push_message(user_message("hello"));
+        session.set_subagent_messages(
             "tool-1".into(),
             vec![user_message("sub-prompt"), assistant_message("sub-reply")],
         );
@@ -1407,7 +1643,7 @@ mod tests {
         assert_eq!(loaded.id, session.id);
         assert_eq!(loaded.model, "anthropic/claude-sonnet-4");
         assert_eq!(loaded.cwd, "/home/test/project");
-        assert_eq!(loaded.messages.len(), 1);
+        assert_eq!(loaded.messages().len(), 1);
         assert_eq!(loaded.version, SESSION_VERSION);
         assert_eq!(loaded.subagent_messages["tool-1"].len(), 2);
     }
@@ -1417,8 +1653,8 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let mut session: TestSession = Session::new("anthropic/claude-sonnet-4", "/project");
-        session.meta.usage_by_model.insert(
-            "claude-sonnet-4".into(),
+        session.add_model_usage(
+            "claude-sonnet-4",
             super::StoredTokenUsage {
                 input: 100,
                 output: 20,
@@ -1426,8 +1662,8 @@ mod tests {
                 cache_read: 40,
             },
         );
-        session.meta.usage_by_model.insert(
-            "claude-haiku-4".into(),
+        session.add_model_usage(
+            "claude-haiku-4",
             super::StoredTokenUsage {
                 input: 30,
                 output: 10,
@@ -1437,12 +1673,12 @@ mod tests {
         session.save_to(dir).unwrap();
 
         let loaded = TestSession::load_from(session.id, dir).unwrap();
-        let sonnet = &loaded.meta.usage_by_model["claude-sonnet-4"];
+        let sonnet = &loaded.usage_by_model()["claude-sonnet-4"];
         assert_eq!(sonnet.input, 100);
         assert_eq!(sonnet.output, 20);
         assert_eq!(sonnet.cache_read, 40);
         assert_eq!(sonnet.total_input(), 145);
-        assert_eq!(loaded.meta.usage_by_model["claude-haiku-4"].total(), 40);
+        assert_eq!(loaded.usage_by_model()["claude-haiku-4"].total(), 40);
     }
 
     #[test]
@@ -1456,7 +1692,39 @@ mod tests {
         let path = tmp.path().join(format!("{LEGACY_HEX_ID}.jsonl"));
         fs::write(&path, json).unwrap();
         let loaded = TestSession::load_from(id, tmp.path()).unwrap();
-        assert!(loaded.meta.usage_by_model.is_empty());
+        assert!(loaded.usage_by_model().is_empty());
+    }
+
+    /// `subagents` and `usage_by_model` moved off `SessionMeta` onto the
+    /// session, which must not move them in the file: they were flattened into
+    /// the meta record and they still sit there.
+    #[test]
+    fn session_owned_fields_keep_their_place_in_the_meta_record() {
+        let id: MakiId = LEGACY_HEX_ID.parse().unwrap();
+        let meta_line = concat!(
+            r#"{"t":"meta","title":"t","token_usage":null,"updated_at":0,"fast":true,"#,
+            r#""subagents":[{"tool_use_id":"t1","name":"child"}],"#,
+            r#""usage_by_model":{"m":{"input":7,"output":3}}}"#,
+        );
+        let json = format!(
+            r#"{{"t":"header","v":2,"id":"{LEGACY_HEX_ID}","model":"m","cwd":"/","created_at":0}}
+{meta_line}"#
+        );
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(format!("{LEGACY_HEX_ID}.jsonl")), json).unwrap();
+
+        let mut loaded = TestSession::load_from(id, tmp.path()).unwrap();
+        assert_eq!(loaded.subagents()[0].name, "child");
+        assert_eq!(loaded.usage_by_model()["m"].total(), 10);
+        assert!(loaded.meta.fast, "flattened meta still parses alongside");
+
+        let dir = tmp.path().join("rewritten");
+        fs::create_dir(&dir).unwrap();
+        loaded.save_to(&dir).unwrap();
+        let reloaded = TestSession::load_from(id, &dir).unwrap();
+        assert_same_session(&reloaded, &loaded);
+        assert_eq!(reloaded.subagents(), loaded.subagents());
+        assert_eq!(reloaded.usage_by_model(), loaded.usage_by_model());
     }
 
     #[test]
@@ -1464,36 +1732,82 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let mut session: TestSession = Session::new("m", "/project");
-        session.messages.push(user_message("first"));
+        session.push_message(user_message("first"));
 
-        let mut log = SessionLog::create(dir, &session).unwrap();
+        let mut log = SessionLog::rewrite(dir, &session).unwrap();
 
-        session.messages.push(assistant_message("reply"));
-        session.messages.push(user_message("second"));
-        session
-            .tool_outputs
-            .insert("tool-1".into(), serde_json::json!({"result": "ok"}));
+        session.push_message(assistant_message("reply"));
+        session.push_message(user_message("second"));
+        session.tool_outputs.insert(
+            "tool-1".into(),
+            Arc::new(serde_json::json!({"result": "ok"})),
+        );
         session
             .subagent_messages
-            .insert("sub-1".into(), vec![user_message("sub-prompt")]);
+            .insert("sub-1".into(), Arc::new(vec![user_message("sub-prompt")]));
         log.append(&session).unwrap();
 
-        session
-            .subagent_messages
-            .get_mut("sub-1")
-            .unwrap()
+        Arc::make_mut(session.subagent_messages.get_mut("sub-1").unwrap())
             .push(assistant_message("sub-reply"));
         session
             .subagent_messages
-            .insert("sub-2".into(), vec![user_message("sub-2-prompt")]);
+            .insert("sub-2".into(), Arc::new(vec![user_message("sub-2-prompt")]));
         log.append(&session).unwrap();
 
         let loaded = TestSession::load_from(session.id, dir).unwrap();
-        assert_eq!(loaded.messages.len(), 3);
-        assert_eq!(loaded.tool_outputs.len(), 1);
-        assert!(loaded.tool_outputs.contains_key("tool-1"));
+        assert_eq!(loaded.messages().len(), 3);
+        assert_eq!(loaded.tool_outputs().len(), 1);
+        assert!(loaded.tool_outputs().contains_key("tool-1"));
         assert_eq!(loaded.subagent_messages["sub-1"].len(), 2);
         assert_eq!(loaded.subagent_messages["sub-2"].len(), 1);
+    }
+
+    #[test]
+    fn log_asks_for_a_rewrite_once_appends_pile_up() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let mut session: TestSession = Session::new("m", "/project");
+        let mut log = SessionLog::rewrite(dir, &session).unwrap();
+
+        for i in 0..MAX_APPENDS {
+            session.push_message(user_message(&format!("m{i}")));
+            log.append(&session).unwrap();
+        }
+        session.push_message(user_message("one too many"));
+
+        assert!(matches!(
+            log.append(&session),
+            Err(SessionError::LogDiverged {
+                reason: LOG_BLOATED
+            })
+        ));
+    }
+
+    /// `cwd` and `model` live in the header record, so changing them must
+    /// diverge the log into a rewrite, which also refreshes the cwd index.
+    #[test]
+    fn cwd_and_model_changes_survive_reload_through_a_rewrite() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let mut session: TestSession = Session::new("m", "/old");
+        session.push_message(user_message("hi"));
+        let mut log = SessionLog::rewrite(dir, &session).unwrap();
+
+        session.set_model("m2".into());
+        session.set_cwd("/new".into());
+        assert!(matches!(
+            log.append(&session),
+            Err(SessionError::LogDiverged { .. })
+        ));
+        drop(SessionLog::rewrite(dir, &session).unwrap());
+
+        let loaded = TestSession::load_from(session.id, dir).unwrap();
+        assert_eq!(loaded.model, "m2");
+        assert_eq!(loaded.cwd, "/new");
+        assert_eq!(
+            load_cwd_index(dir).get("/new"),
+            Some(&session.id.to_string())
+        );
     }
 
     #[test]
@@ -1502,7 +1816,7 @@ mod tests {
         let dir = tmp.path();
         let session_a: TestSession = Session::new("m", "/project");
         let session_b: TestSession = Session::new("m", "/project");
-        let mut log = SessionLog::create(dir, &session_a).unwrap();
+        let mut log = SessionLog::rewrite(dir, &session_a).unwrap();
 
         let err = log.append(&session_b).unwrap_err();
         assert!(matches!(err, SessionError::IdMismatch { .. }));
@@ -1513,7 +1827,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let mut session: TestSession = Session::new("m", "/project");
-        session.messages.push(user_message("survives"));
+        session.push_message(user_message("survives"));
         session.save_to(dir).unwrap();
 
         let path = jsonl_path(dir, session.id);
@@ -1521,7 +1835,7 @@ mod tests {
         file.write_all(b"{\"t\":\"msg\",\"d\":{\"trun").unwrap();
 
         let loaded = TestSession::load_from(session.id, dir).unwrap();
-        assert_eq!(loaded.messages.len(), 1);
+        assert_eq!(loaded.messages().len(), 1);
     }
 
     #[test]
@@ -1530,27 +1844,27 @@ mod tests {
         let dir = tmp.path();
         let mut session: TestSession = Session::new("m", "/project");
         for i in 0..10 {
-            session.messages.push(user_message(&format!("msg-{i}")));
+            session.push_message(user_message(&format!("msg-{i}")));
         }
-        session.subagent_messages.insert(
+        session.set_subagent_messages(
             "sub-1".into(),
             vec![user_message("sub-prompt"), assistant_message("sub-reply")],
         );
-        let mut log = SessionLog::create(dir, &session).unwrap();
+        drop(SessionLog::rewrite(dir, &session).unwrap());
 
-        session.messages.truncate(5);
+        session.truncate_messages(5);
         session.tool_outputs.clear();
         session.subagent_messages.remove("sub-1");
-        log.compact(dir, &session).unwrap();
+        let mut log = SessionLog::rewrite(dir, &session).unwrap();
 
-        session.messages.push(user_message("after-compact-1"));
-        session.messages.push(user_message("after-compact-2"));
-        session.messages.push(user_message("after-compact-3"));
+        session.push_message(user_message("after-compact-1"));
+        session.push_message(user_message("after-compact-2"));
+        session.push_message(user_message("after-compact-3"));
         log.append(&session).unwrap();
 
         let loaded = TestSession::load_from(session.id, dir).unwrap();
-        assert_eq!(loaded.messages.len(), 8);
-        assert!(loaded.subagent_messages.is_empty());
+        assert_eq!(loaded.messages().len(), 8);
+        assert!(loaded.subagent_messages().is_empty());
     }
 
     /// A rename with no new messages must survive restart, while a no-op
@@ -1560,8 +1874,8 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let mut session: TestSession = Session::new("m", "/project");
-        session.messages.push(user_message("hi"));
-        let mut log = SessionLog::create(dir, &session).unwrap();
+        session.push_message(user_message("hi"));
+        let mut log = SessionLog::rewrite(dir, &session).unwrap();
 
         let path = jsonl_path(dir, session.id);
         let size_before = fs::metadata(&path).unwrap().len();
@@ -1582,22 +1896,22 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let mut session: TestSession = Session::new("m", "/project");
-        session.messages.push(user_message("legacy"));
+        session.push_message(user_message("legacy"));
 
         let json_path = json_path(dir, session.id);
         fs::write(&json_path, serde_json::to_vec(&session).unwrap()).unwrap();
         update_cwd_index(dir, &session.cwd, session.id).unwrap();
 
         let loaded = TestSession::load_from(session.id, dir).unwrap();
-        assert_eq!(loaded.messages.len(), 1);
+        assert_eq!(loaded.messages().len(), 1);
 
-        let _log = TestSession::migrate_to_jsonl(dir, &loaded).unwrap();
+        let _log = SessionLog::rewrite(dir, &loaded).unwrap();
 
         assert!(!json_path.exists());
         assert!(jsonl_path(dir, session.id).exists());
 
         let reloaded = TestSession::load_from(session.id, dir).unwrap();
-        assert_eq!(reloaded.messages.len(), 1);
+        assert_eq!(reloaded.messages().len(), 1);
         assert_eq!(reloaded.model, "m");
     }
 
@@ -1621,13 +1935,13 @@ mod tests {
         let id: MakiId = legacy.parse().unwrap();
         let mut session: TestSession = Session::new("m", "/project");
         session.id = id;
-        session.messages.push(user_message("legacy"));
+        session.push_message(user_message("legacy"));
         let legacy_path = dir.join(format!("{legacy}.jsonl"));
         write_legacy_jsonl(&legacy_path, &session);
 
         let loaded = TestSession::load_from(id, dir).unwrap();
         assert_eq!(loaded.id, id);
-        assert_eq!(loaded.messages.len(), 1);
+        assert_eq!(loaded.messages().len(), 1);
 
         assert!(!legacy_path.exists());
         let canonical = jsonl_path(dir, id);
@@ -1690,10 +2004,10 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let mut s1: TestSession = Session::new("m", "/project");
-        s1.messages.push(user_message("hi"));
-        let mut log = SessionLog::create(dir, &s1).unwrap();
+        s1.push_message(user_message("hi"));
+        let mut log = SessionLog::rewrite(dir, &s1).unwrap();
         let s2: TestSession = Session::new("m", "/project");
-        SessionLog::create(dir, &s2).unwrap();
+        SessionLog::rewrite(dir, &s2).unwrap();
         TestSession::list_in("/project", dir).unwrap();
 
         s1.title = "renamed".into();
@@ -1714,8 +2028,8 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let mut s: TestSession = Session::new("m", "/project");
-        s.messages.push(user_message("hi"));
-        let mut log = SessionLog::create(dir, &s).unwrap();
+        s.push_message(user_message("hi"));
+        let mut log = SessionLog::rewrite(dir, &s).unwrap();
         s.title = "line one\n\n\tline two".into();
         log.append(&s).unwrap();
 
@@ -1742,7 +2056,7 @@ mod tests {
 
     fn save_with_time(session: &mut TestSession, dir: &Path, time: u64) {
         session.updated_at = time;
-        SessionLog::create(dir, session).unwrap();
+        SessionLog::rewrite(dir, session).unwrap();
         update_cwd_index(dir, &session.cwd, session.id).unwrap();
     }
 
@@ -1833,7 +2147,7 @@ mod tests {
         let id: MakiId = legacy.parse().unwrap();
         let mut session: TestSession = Session::new("m", "/project");
         session.id = id;
-        session.messages.push(user_message("legacy"));
+        session.push_message(user_message("legacy"));
         let legacy_path = dir.join(format!("{legacy}.jsonl"));
         write_legacy_jsonl(&legacy_path, &session);
 
@@ -1848,7 +2162,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let mut session: TestSession = Session::new("m", "/project");
-        session.messages.push(user_message("hi"));
+        session.push_message(user_message("hi"));
 
         let jsonl_file = jsonl_path(dir, session.id);
         write_legacy_jsonl(&jsonl_file, &session);
@@ -1868,20 +2182,20 @@ mod tests {
         let id: MakiId = LEGACY_HEX_ID.parse().unwrap();
         let mut jsonl_session: TestSession = Session::new("m", "/project");
         jsonl_session.id = id;
-        jsonl_session.messages.push(user_message("newer"));
+        jsonl_session.push_message(user_message("newer"));
 
         let legacy_jsonl = dir.join(format!("{LEGACY_HEX_ID}.jsonl"));
         write_legacy_jsonl(&legacy_jsonl, &jsonl_session);
 
         let mut json_session: TestSession = Session::new("m", "/project");
         json_session.id = id;
-        json_session.messages.push(user_message("older"));
+        json_session.push_message(user_message("older"));
         let legacy_json = dir.join(format!("{LEGACY_HEX_ID}.json"));
         fs::write(&legacy_json, serde_json::to_vec(&json_session).unwrap()).unwrap();
 
         let loaded = TestSession::load_from(id, dir).unwrap();
-        assert_eq!(loaded.messages.len(), 1);
-        assert_eq!(loaded.messages[0], user_message("newer"));
+        assert_eq!(loaded.messages().len(), 1);
+        assert_eq!(loaded.messages()[0], user_message("newer"));
     }
 
     #[test]
@@ -1892,13 +2206,13 @@ mod tests {
         let id: MakiId = LEGACY_HEX_ID.parse().unwrap();
         let mut jsonl_session: TestSession = Session::new("m", "/project");
         jsonl_session.id = id;
-        jsonl_session.messages.push(user_message("newer"));
+        jsonl_session.push_message(user_message("newer"));
         let legacy_jsonl = dir.join(format!("{LEGACY_HEX_ID}.jsonl"));
         write_legacy_jsonl(&legacy_jsonl, &jsonl_session);
 
         let mut json_session: TestSession = Session::new("m", "/project");
         json_session.id = id;
-        json_session.messages.push(user_message("older"));
+        json_session.push_message(user_message("older"));
         let legacy_json = dir.join(format!("{LEGACY_HEX_ID}.json"));
         fs::write(&legacy_json, serde_json::to_vec(&json_session).unwrap()).unwrap();
 
@@ -1921,7 +2235,7 @@ mod tests {
         let id: MakiId = LEGACY_HEX_ID.parse().unwrap();
         let mut session: TestSession = Session::new("m", "/project");
         session.id = id;
-        session.messages.push(user_message("legacy"));
+        session.push_message(user_message("legacy"));
 
         let legacy_jsonl = dir.join(format!("{LEGACY_HEX_ID}.jsonl"));
         write_legacy_jsonl(&legacy_jsonl, &session);
@@ -1935,14 +2249,14 @@ mod tests {
     }
 
     #[test]
-    fn migrate_to_jsonl_removes_legacy_named_files() {
+    fn rewrite_removes_legacy_named_files() {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
 
         let id: MakiId = LEGACY_HEX_ID.parse().unwrap();
         let mut session: TestSession = Session::new("m", "/project");
         session.id = id;
-        session.messages.push(user_message("legacy"));
+        session.push_message(user_message("legacy"));
 
         let legacy_jsonl = dir.join(format!("{LEGACY_HEX_ID}.jsonl"));
         write_legacy_jsonl(&legacy_jsonl, &session);
@@ -1950,7 +2264,7 @@ mod tests {
         let legacy_json = dir.join(format!("{LEGACY_HEX_ID}.json"));
         fs::write(&legacy_json, serde_json::to_vec(&session).unwrap()).unwrap();
 
-        let _log = TestSession::migrate_to_jsonl(dir, &session).unwrap();
+        let _log = SessionLog::rewrite(dir, &session).unwrap();
 
         assert!(!legacy_jsonl.exists());
         assert!(!legacy_json.exists());
@@ -2068,51 +2382,30 @@ mod tests {
         ));
     }
 
+    /// A torn tail is what a crash mid-append leaves behind, and the file is
+    /// the only thing standing between the user and their conversation, so the
+    /// cursor `rewrite` hands back must describe the file it just wrote.
     #[test]
-    fn open_roundtrip_resumes_append() {
+    fn rewrite_replaces_a_torn_file_and_keeps_appending() {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let mut session: TestSession = Session::new("m", "/project");
-        session.messages.push(user_message("first"));
-
-        let mut log = SessionLog::create(dir, &session).unwrap();
-        session.messages.push(assistant_message("reply"));
-        log.append(&session).unwrap();
-        drop(log);
-
-        let (loaded, mut log) = SessionLog::open::<Value, Value, Value>(dir, session.id).unwrap();
-        assert_eq!(loaded.messages.len(), 2);
-
-        session.messages.push(user_message("second"));
-        log.append(&session).unwrap();
-        drop(log);
-
-        let reloaded = TestSession::load_from(session.id, dir).unwrap();
-        assert_eq!(reloaded.messages.len(), 3);
-    }
-
-    #[test]
-    fn open_repairs_torn_tail_so_next_append_survives_reload() {
-        let tmp = TempDir::new().unwrap();
-        let dir = tmp.path();
-        let mut session: TestSession = Session::new("m", "/project");
-        session.messages.push(user_message("first"));
-        drop(SessionLog::create(dir, &session).unwrap());
+        session.push_message(user_message("first"));
+        drop(SessionLog::rewrite(dir, &session).unwrap());
 
         let path = jsonl_path(dir, session.id);
         let mut file = OpenOptions::new().append(true).open(&path).unwrap();
         file.write_all(b"{\"t\":\"msg\",\"d\":{\"trun").unwrap();
         drop(file);
 
-        let (mut loaded, mut log) =
-            SessionLog::open::<Value, Value, Value>(dir, session.id).unwrap();
-        assert_eq!(loaded.messages.len(), 1);
-        loaded.messages.push(user_message("second"));
-        log.append(&loaded).unwrap();
+        session.push_message(assistant_message("reply"));
+        let mut log = SessionLog::rewrite(dir, &session).unwrap();
+        session.push_message(user_message("second"));
+        log.append(&session).unwrap();
         drop(log);
 
         let reloaded = TestSession::load_from(session.id, dir).unwrap();
-        assert_eq!(reloaded.messages.len(), 2);
+        assert_same_session(&reloaded, &session);
     }
 
     #[test]
@@ -2249,11 +2542,11 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let mut session: TestSession = Session::new("m", "/project");
-        session.messages.push(user_message("first"));
+        session.push_message(user_message("first"));
         session
             .tool_outputs
-            .insert("t1".into(), serde_json::json!({"result": "ok"}));
-        let mut log = SessionLog::create(dir, &session).unwrap();
+            .insert("t1".into(), Arc::new(serde_json::json!({"result": "ok"})));
+        let mut log = SessionLog::rewrite(dir, &session).unwrap();
         log.append(&session).unwrap();
 
         let path = jsonl_path(dir, session.id);
@@ -2263,8 +2556,8 @@ mod tests {
         append_raw_msg(&path, user_message("second"));
 
         let loaded = TestSession::load_from(session.id, dir).unwrap();
-        assert_eq!(loaded.messages.len(), 2);
-        assert!(loaded.tool_outputs.contains_key("t1"));
+        assert_eq!(loaded.messages().len(), 2);
+        assert!(loaded.tool_outputs().contains_key("t1"));
     }
 
     #[test]
@@ -2287,7 +2580,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let mut session: TestSession = Session::new("m", "/project");
-        session.messages.push(user_message("msg"));
+        session.push_message(user_message("msg"));
         session.save_to(dir).unwrap();
 
         let path = jsonl_path(dir, session.id);
@@ -2297,7 +2590,7 @@ mod tests {
         append_raw_msg(&path, user_message("after"));
 
         let loaded = TestSession::load_from(session.id, dir).unwrap();
-        assert_eq!(loaded.messages.len(), 2);
+        assert_eq!(loaded.messages().len(), 2);
     }
 
     #[test]
@@ -2305,7 +2598,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let mut session: TestSession = Session::new("m", "/project");
-        session.messages.push(user_message("first"));
+        session.push_message(user_message("first"));
         session.save_to(dir).unwrap();
 
         let path = jsonl_path(dir, session.id);
@@ -2316,7 +2609,7 @@ mod tests {
         append_raw_msg(&path, user_message("second"));
 
         let loaded = TestSession::load_from(session.id, dir).unwrap();
-        assert_eq!(loaded.messages.len(), 2);
+        assert_eq!(loaded.messages().len(), 2);
     }
 
     #[test]
@@ -2324,15 +2617,15 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let mut session: TestSession = Session::new("m", "/project");
-        session.messages.push(user_message("first"));
-        let mut log = SessionLog::create(dir, &session).unwrap();
+        session.push_message(user_message("first"));
+        let mut log = SessionLog::rewrite(dir, &session).unwrap();
 
         session.title = "v1".into();
-        session.messages.push(assistant_message("reply"));
+        session.push_message(assistant_message("reply"));
         log.append(&session).unwrap();
 
         session.title = "v2".into();
-        session.messages.push(user_message("second"));
+        session.push_message(user_message("second"));
         log.append(&session).unwrap();
 
         let list = TestSession::list_in("/project", dir).unwrap();
@@ -2359,16 +2652,335 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let mut session: TestSession = Session::new("m", "/project");
-        session.messages.push(user_message("msg"));
-        let mut log = SessionLog::create(dir, &session).unwrap();
+        session.push_message(user_message("msg"));
+        let mut log = SessionLog::rewrite(dir, &session).unwrap();
 
         session.title = "big-meta".into();
         session.meta.input_draft = Some("x".repeat(TAIL_BUF as usize * 2));
-        session.messages.push(assistant_message("reply"));
+        session.push_message(assistant_message("reply"));
         log.append(&session).unwrap();
 
         let list = TestSession::list_in("/project", dir).unwrap();
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].title, "big-meta");
+    }
+
+    // -- The log never guesses --
+
+    const PROPERTY_SEED: u64 = 0x2545_F491_4F6C_DD1D;
+    const PROPERTY_STEPS: usize = 500;
+    const MUTATION_KINDS: u64 = 8;
+    const EXTERNAL_TRUNCATION: u64 = 12;
+
+    /// Deterministic xorshift so a failure is always the same failure.
+    struct Rng(u64);
+
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            self.0 ^= self.0 << 13;
+            self.0 ^= self.0 >> 7;
+            self.0 ^= self.0 << 17;
+            self.0
+        }
+
+        fn below(&mut self, n: u64) -> u64 {
+            self.next() % n
+        }
+    }
+
+    fn tool_message(id: &str) -> Value {
+        serde_json::json!({ "role": "assistant", "tool": id })
+    }
+
+    fn tool_ids(m: &Value) -> Vec<String> {
+        m.get("tool")
+            .and_then(Value::as_str)
+            .map(|s| vec![s.to_owned()])
+            .unwrap_or_default()
+    }
+
+    /// What the storage writer does: append while the epoch holds, rewrite the
+    /// whole file otherwise.
+    fn write_through(log: &mut SessionLog, dir: &Path, session: &TestSession) {
+        match log.append(session) {
+            Err(SessionError::LogDiverged { .. }) => {
+                *log = SessionLog::rewrite(dir, session).unwrap()
+            }
+            other => other.unwrap(),
+        }
+    }
+
+    #[track_caller]
+    fn assert_same_session(loaded: &TestSession, expected: &TestSession) {
+        assert_eq!(loaded.messages(), expected.messages(), "messages");
+        assert_eq!(loaded.tool_outputs(), expected.tool_outputs(), "outputs");
+        assert_eq!(
+            loaded.subagent_messages(),
+            expected.subagent_messages(),
+            "subagent messages",
+        );
+        assert_eq!(loaded.title, expected.title, "title");
+        assert_eq!(loaded.meta, expected.meta, "meta");
+        assert_eq!(loaded.updated_at, expected.updated_at, "updated_at");
+    }
+
+    fn mutate(session: &mut TestSession, rng: &mut Rng, step: usize) {
+        let slot = format!("t{}", rng.below(4));
+        match rng.below(MUTATION_KINDS) {
+            0 => session.push_message(user_message(&format!("msg-{step}"))),
+            1 => {
+                session.push_message(tool_message(&slot));
+                session.push_message(assistant_message("reply"));
+            }
+            2 => session.insert_tool_output(slot, Value::from(format!("out-{step}"))),
+            3 => {
+                let len = rng.below(4) as usize;
+                let msgs = (0..len)
+                    .map(|i| user_message(&format!("sub-{i}")))
+                    .collect();
+                session.set_subagent_messages(slot, msgs);
+            }
+            4 => {
+                let len = session.messages().len();
+                session.truncate_messages(len.saturating_sub(1 + rng.below(3) as usize));
+            }
+            5 => session.replace_messages(vec![user_message(&format!("fresh-{step}"))]),
+            6 => session.prune_orphans(tool_ids),
+            _ => {
+                session.set_title(format!("title-{step}"));
+                session.set_meta(SessionMeta {
+                    input_draft: Some(format!("draft-{step}")),
+                    ..session.meta.clone()
+                });
+            }
+        }
+    }
+
+    /// Every mutation kind in random order, snapshots dropped here and there
+    /// like the writer coalescing them, and the file clobbered now and then.
+    /// Whatever the script, reloading must give back the live session.
+    #[test]
+    fn random_mutation_script_round_trips_through_the_log() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let mut session: TestSession = Session::new("m", "/project");
+        let mut log = SessionLog::rewrite(dir, &session).unwrap();
+        let mut rng = Rng(PROPERTY_SEED);
+
+        for step in 0..PROPERTY_STEPS {
+            mutate(&mut session, &mut rng, step);
+            // Dropping a snapshot is what coalescing does, and the next write
+            // must still land on a file that matches.
+            if rng.below(3) == 0 {
+                continue;
+            }
+            if rng.below(EXTERNAL_TRUNCATION) == 0 {
+                let path = jsonl_path(dir, session.id);
+                let len = std::fs::metadata(&path).unwrap().len();
+                OpenOptions::new()
+                    .write(true)
+                    .open(&path)
+                    .unwrap()
+                    .set_len(len / 2)
+                    .unwrap();
+            }
+            write_through(&mut log, dir, &session);
+        }
+        write_through(&mut log, dir, &session);
+
+        let loaded = TestSession::load_from(session.id, dir).unwrap();
+        assert_same_session(&loaded, &session);
+    }
+
+    #[test]
+    fn externally_truncated_log_is_rewritten_not_appended() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let mut session: TestSession = Session::new("m", "/project");
+        session.push_message(user_message("hello"));
+        let mut log = SessionLog::rewrite(dir, &session).unwrap();
+
+        let path = jsonl_path(dir, session.id);
+        OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_len(0)
+            .unwrap();
+
+        session.push_message(assistant_message("reply"));
+        assert!(matches!(
+            log.append(&session),
+            Err(SessionError::LogDiverged { .. }),
+        ));
+        drop(SessionLog::rewrite(dir, &session).unwrap());
+
+        let loaded = TestSession::load_from(session.id, dir).unwrap();
+        assert_same_session(&loaded, &session);
+    }
+
+    /// `Arc::make_mut` deep-copies the session while the writer holds the last
+    /// snapshot, and a checkpoint that changes nothing must not pay for it.
+    #[test]
+    fn unchanged_checkpoint_does_not_clone_the_session() {
+        let mut session: TestSession = Session::new("m", "/project");
+        session.push_message(user_message("hello"));
+        let snapshot = HistorySnapshot::new(session.messages().to_vec());
+        let mut session = Arc::new(session);
+        let meta = session.meta.clone();
+        Session::checkpoint(&mut session, Some(&snapshot), meta.clone(), Value::Null);
+
+        let held = Arc::clone(&session);
+        Session::checkpoint(&mut session, Some(&snapshot), meta.clone(), Value::Null);
+        assert!(Arc::ptr_eq(&held, &session), "no change, no clone");
+
+        Session::checkpoint(
+            &mut session,
+            Some(&snapshot),
+            SessionMeta {
+                input_draft: Some("draft".into()),
+                ..meta
+            },
+            Value::Null,
+        );
+        assert!(!Arc::ptr_eq(&held, &session));
+        assert_eq!(session.meta.input_draft.as_deref(), Some("draft"));
+        assert!(session.revision() > held.revision());
+    }
+
+    /// What the owner types sits in `meta`, so `content_revision` is what tells
+    /// a keystroke, which can wait for the ones behind it, from a tool result,
+    /// which has to be on disk before the next crash.
+    #[test]
+    fn a_meta_only_change_leaves_content_revision_alone() {
+        let mut session: TestSession = Session::new("m", "/project");
+        let (revision, content) = (session.revision(), session.content_revision());
+
+        session.set_meta(SessionMeta {
+            input_draft: Some(PENDING_DRAFT.into()),
+            ..session.meta.clone()
+        });
+        assert!(session.revision() > revision, "still needs writing");
+        assert_eq!(session.content_revision(), content, "but it can wait");
+
+        session.push_message(user_message("hello"));
+        assert!(session.content_revision() > content);
+    }
+
+    /// A mutator called with the value already there is not a change, and a
+    /// truncate that cuts nothing must leave the epoch alone or every open
+    /// cursor into the log dies for nothing.
+    #[test]
+    fn no_op_mutators_leave_the_session_and_its_cursors_alone() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let mut session: TestSession = Session::new("m", "/project");
+        session.push_message(user_message("a"));
+        session.push_message(assistant_message("b"));
+        let mut log = SessionLog::rewrite(dir, &session).unwrap();
+        let (revision, updated_at, epoch) = (session.revision(), session.updated_at, session.epoch);
+
+        session.set_title(session.title.clone());
+        session.set_meta(session.meta.clone());
+        session.truncate_messages(session.messages().len());
+        session.truncate_messages(session.messages().len() + 1);
+
+        assert_eq!(session.revision(), revision);
+        assert_eq!(session.updated_at, updated_at);
+        assert_eq!(session.epoch, epoch);
+
+        session.push_message(user_message("c"));
+        log.append(&session).unwrap();
+        let loaded = TestSession::load_from(session.id, dir).unwrap();
+        assert_same_session(&loaded, &session);
+    }
+
+    /// Every frame checkpoints, so a checkpoint that only grew the message list
+    /// must stay a small append instead of rewriting the whole file.
+    #[test]
+    fn successive_checkpoints_from_one_run_stay_appendable() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let mut produced = HistorySnapshot::new(vec![user_message("a")]);
+        let mut session: Arc<TestSession> = Arc::new(Session::new("m", "/project"));
+        let meta = session.meta.clone();
+        Session::checkpoint(&mut session, Some(&produced), meta.clone(), Value::Null);
+
+        let mut log = SessionLog::rewrite(dir, &session).unwrap();
+        for step in 0..3 {
+            Arc::make_mut(&mut produced.messages).push(assistant_message(&format!("reply-{step}")));
+            Session::checkpoint(&mut session, Some(&produced), meta.clone(), Value::Null);
+            log.append(&session).unwrap();
+        }
+
+        let loaded = TestSession::load_from(session.id, dir).unwrap();
+        assert_same_session(&loaded, &session);
+    }
+
+    /// The writer keeps the previous snapshot alive, so the UI ends up mutating
+    /// a deep copy from `Arc::make_mut`. The copy inherits the run token, so the
+    /// cursors the writer holds still describe it.
+    #[test]
+    fn append_cursor_survives_the_clone_arc_make_mut_hands_the_ui() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let mut base: TestSession = Session::new("m", "/project");
+        base.push_message(user_message("a"));
+        let mut log = SessionLog::rewrite(dir, &base).unwrap();
+
+        let mut session = Arc::new(base);
+        let held = Arc::clone(&session);
+        let live = Arc::make_mut(&mut session);
+        live.push_message(assistant_message("b"));
+        live.insert_tool_output("t1".into(), Value::from("out"));
+        live.set_subagent_messages("s1".into(), vec![user_message("sub")]);
+
+        log.append(&session).unwrap();
+
+        assert_eq!(held.messages().len(), 1, "the writer's snapshot is frozen");
+        let loaded = TestSession::load_from(session.id, dir).unwrap();
+        assert_same_session(&loaded, &session);
+    }
+
+    /// The corruption the epoch exists for. A rewind mints a new run, so a
+    /// snapshot still in flight carries the pre-rewind messages: longer than
+    /// the rewritten log, yet sharing only its head. Going by length alone
+    /// would splice its tail on and leave disk holding `[a, d, c]` while the
+    /// session holds `[a, b, c]`.
+    #[test]
+    fn stale_snapshot_after_a_rewind_is_rewritten_not_spliced() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let produced = HistorySnapshot::new(vec![
+            user_message("a"),
+            assistant_message("b"),
+            user_message("c"),
+        ]);
+        let mut session: Arc<TestSession> = Arc::new(Session::new("m", "/project"));
+        let meta = session.meta.clone();
+        Session::checkpoint(&mut session, Some(&produced), meta.clone(), Value::Null);
+        let mut log = SessionLog::rewrite(dir, &session).unwrap();
+
+        let live = Arc::make_mut(&mut session);
+        live.truncate_messages(1);
+        live.push_message(user_message("d"));
+        write_through(&mut log, dir, &session);
+
+        Session::checkpoint(&mut session, Some(&produced), meta, Value::Null);
+        let path = jsonl_path(dir, session.id);
+        let size_before = fs::metadata(&path).unwrap().len();
+        assert!(matches!(
+            log.append(&session),
+            Err(SessionError::LogDiverged { .. }),
+        ));
+        assert_eq!(
+            fs::metadata(&path).unwrap().len(),
+            size_before,
+            "a refused append must not have written half of itself"
+        );
+        drop(SessionLog::rewrite(dir, &session).unwrap());
+
+        let loaded = TestSession::load_from(session.id, dir).unwrap();
+        assert_same_session(&loaded, &session);
     }
 }

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -13,7 +13,7 @@ use maki_agent::tools::{
 use maki_agent::{
     Agent, AgentConfig, AgentEvent, AgentInput, AgentParams, AgentRunParams, CancelMap,
     CancelToken, CancelTrigger, Envelope, EventSender, History, Instructions, McpCommand,
-    PromptRole, ToolOutputLines,
+    PromptRole, SharedMessages, ToolOutputLines,
 };
 use maki_lua::EventHandle;
 use maki_providers::{AgentError, Message, Model, TokenUsage};
@@ -56,7 +56,7 @@ impl AgentLoop {
         config: AgentConfig,
         tool_output_lines: ToolOutputLines,
         initial_history: Vec<Message>,
-        shared_history: Arc<ArcSwap<Vec<Message>>>,
+        shared_history: SharedMessages,
         btw_system: Arc<ArcSwap<String>>,
         mcp_handle: Option<McpHandle>,
         permissions: Arc<PermissionManager>,

--- a/maki-ui/src/agent/mod.rs
+++ b/maki-ui/src/agent/mod.rs
@@ -10,8 +10,8 @@ use std::time::Duration;
 use arc_swap::ArcSwap;
 use maki_agent::permissions::PermissionManager;
 use maki_agent::{
-    AgentConfig, CancelMap, CancelToken, Envelope, McpCommand, McpConfigErrors, McpHandle,
-    McpSnapshotReader, ToolOutputLines,
+    AgentConfig, CancelMap, CancelToken, Envelope, HistorySnapshot, McpCommand, McpConfigErrors,
+    McpHandle, McpSnapshotReader, SharedMessages, ToolOutputLines,
 };
 use maki_lua::EventHandle;
 use maki_storage::id::SessionRef;
@@ -48,7 +48,7 @@ pub(crate) struct AgentHandles {
     pub(crate) agent_rx: flume::Receiver<Envelope>,
     pub(crate) agent_tx: flume::Sender<Envelope>,
     pub(crate) answer_tx: flume::Sender<String>,
-    pub(crate) history: Arc<ArcSwap<Vec<Message>>>,
+    pub(crate) history: SharedMessages,
     pub(crate) btw_system: Arc<ArcSwap<String>>,
     pub(crate) mcp_handle: Option<McpHandle>,
     pub(crate) mcp_config_errors: McpConfigErrors,
@@ -212,8 +212,10 @@ fn spawn_agent_internal(
     let (answer_tx, answer_rx) = flume::unbounded::<String>();
     let (queue_tx, queue_rx) = shared_queue::queue();
     let queue_rx = Arc::new(queue_rx);
-    let shared_history: Arc<ArcSwap<Vec<Message>>> =
-        Arc::new(ArcSwap::from_pointee(initial_history.clone()));
+    // Seeded empty because `AgentLoop::new` below publishes the real snapshot
+    // synchronously, before any handle escapes.
+    let shared_history: SharedMessages =
+        Arc::new(ArcSwap::from_pointee(HistorySnapshot::default()));
     let btw_system: Arc<ArcSwap<String>> = Arc::new(ArcSwap::from_pointee(String::new()));
     let (init_trigger, init_cancel) = CancelToken::new();
     let cancel_map = Arc::new(new_run_cancel_map(0, init_trigger));
@@ -278,6 +280,7 @@ mod tests {
     const SHORT_TIMEOUT: Duration = Duration::from_millis(50);
     const PROBE_TEXT: &str = "probe-through-old-sender";
     const RESTORED_TEXT: &str = "restored-queued-message";
+    const RESUMED_HISTORY_TEXT: &str = "resumed-conversation";
 
     struct StubProvider;
 
@@ -305,6 +308,16 @@ mod tests {
         Arc<ArcSwap<ModelSlot>>,
         Arc<PermissionManager>,
     ) {
+        stub_spawn_with(Vec::new())
+    }
+
+    fn stub_spawn_with(
+        initial_history: Vec<Message>,
+    ) -> (
+        AgentHandles,
+        Arc<ArcSwap<ModelSlot>>,
+        Arc<PermissionManager>,
+    ) {
         let model_slot = Arc::new(ArcSwap::from_pointee(ModelSlot {
             model: crate::components::test_model(),
             provider: Arc::new(StubProvider),
@@ -315,7 +328,7 @@ mod tests {
         ));
         let handles = AgentHandles::spawn(
             &model_slot,
-            Vec::new(),
+            initial_history,
             AgentConfig::default(),
             ToolOutputLines::default(),
             &permissions,
@@ -359,14 +372,18 @@ mod tests {
         respawn(&mut handles, &model_slot, &permissions, &mut app);
         assert_eq!(app.run_id, run_id_before + 1);
 
-        app.state.session.meta.queued_messages = vec![RESTORED_TEXT.into()];
+        app.state.session_mut().meta.queued_messages = vec![RESTORED_TEXT.into()];
         respawn(&mut handles, &model_slot, &permissions, &mut app);
         assert_eq!(
             app.run_id,
             run_id_before + 2,
             "each respawn must bump run_id exactly once"
         );
-        assert!(app.state.session.meta.queued_messages.is_empty());
+        assert_eq!(
+            app.queue.text_messages(),
+            [RESTORED_TEXT],
+            "the restored item lands in the new queue exactly once"
+        );
 
         pre_gen1_sender
             .send(AgentEvent::TextDelta {
@@ -391,6 +408,48 @@ mod tests {
                 _ => {}
             }
         }
+    }
+
+    /// If the seeded empty snapshot ever outlived `spawn`, the next checkpoint
+    /// would adopt it and wipe a resumed conversation from disk.
+    #[test]
+    fn spawn_publishes_the_resumed_history_before_the_handles_escape() {
+        let (handles, _model_slot, _permissions) =
+            stub_spawn_with(vec![Message::user(RESUMED_HISTORY_TEXT.into())]);
+        let snapshot = handles.history.load();
+        assert_eq!(
+            snapshot.messages.len(),
+            1,
+            "the seeded empty snapshot must be replaced synchronously"
+        );
+        assert_eq!(snapshot.messages[0].user_text(), Some(RESUMED_HISTORY_TEXT));
+    }
+
+    #[test]
+    fn respawn_publishes_the_new_history_into_the_app_mirror() {
+        let (mut handles, model_slot, permissions) = stub_spawn();
+        let mut app = crate::app::tests::test_app();
+        handles.respawn(
+            vec![Message::user(RESUMED_HISTORY_TEXT.into())],
+            &model_slot,
+            AgentConfig::default(),
+            ToolOutputLines::default(),
+            &permissions,
+            &mut app,
+            EventHandle::disconnected_for_test(),
+        );
+
+        let mirror = app
+            .shared_history
+            .as_ref()
+            .expect("respawn wires the live mirror into the app");
+        let snapshot = mirror.load();
+        assert_eq!(
+            snapshot.messages.len(),
+            1,
+            "a checkpoint right after respawn must not see the seeded empty snapshot"
+        );
+        assert_eq!(snapshot.messages[0].user_text(), Some(RESUMED_HISTORY_TEXT));
     }
 
     #[test]

--- a/maki-ui/src/app/btw.rs
+++ b/maki-ui/src/app/btw.rs
@@ -32,11 +32,14 @@ impl App {
         provider: Arc<dyn Provider>,
         model: Model,
     ) {
+        // The mirror is verbatim, so mid-turn it can end on an open tool call.
+        // Providers reject that, so close them off on our own copy.
         let mut messages = self
             .shared_history
             .as_ref()
-            .map(|h| Vec::clone(&h.load()))
+            .map(|h| Vec::clone(&h.load().messages))
             .unwrap_or_default();
+        maki_agent::close_dangling_tool_calls(&mut messages, maki_agent::UNAVAILABLE_RESULT);
         let system = self
             .btw_system
             .as_ref()

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -55,11 +55,11 @@ use crossterm::event::{KeyCode, KeyEvent, MouseEvent};
 use maki_agent::permissions::PermissionManager;
 use maki_agent::{
     AgentEvent, Envelope, ImageSource, McpConfigErrors, McpPromptInfo, McpSnapshotReader,
-    SubagentInfo,
+    SharedMessages, SubagentInfo,
 };
 use maki_config::UiConfig;
 use maki_lua::{EventHandle, HintReader, KeymapReader, LuaCommandReader, WinView};
-use maki_providers::{Message, Model, ThinkingConfig, add_cost};
+use maki_providers::{Model, ThinkingConfig, add_cost};
 use maki_storage::StateDir;
 use maki_storage::input_history::InputHistory;
 use maki_storage::model::persist_model;
@@ -72,6 +72,7 @@ pub(crate) use mode::{Mode, PlanState, PlanTrigger};
 #[cfg(test)]
 use mouse::EDGE_SCROLL_LINES;
 pub(crate) use queue::{MessageQueue, SubmitOutcome};
+use session::Sent;
 pub(crate) use session::session_has_content;
 use session_state::SessionState;
 
@@ -171,10 +172,11 @@ pub struct App {
 
     pub(crate) storage: StateDir,
     pub(crate) usage_slot: Arc<ArcSwapOption<UsageFetchState>>,
-    pub(crate) shared_history: Option<Arc<ArcSwap<Vec<Message>>>>,
+    pub(crate) shared_history: Option<SharedMessages>,
     pub(crate) btw_system: Option<Arc<ArcSwap<String>>>,
     pub(crate) image_paste_rx: Vec<flume::Receiver<Result<ImageSource, String>>>,
     storage_writer: Arc<StorageWriter>,
+    last_sent: Option<Sent>,
     pub(crate) shell: shell::ShellState,
     pub(crate) ui_config: UiConfig,
     pub(crate) permissions: Arc<PermissionManager>,
@@ -264,6 +266,7 @@ impl App {
             btw_system: None,
             image_paste_rx: vec![],
             storage_writer,
+            last_sent: None,
             shell: shell::ShellState::default(),
             ui_config,
             permissions,
@@ -865,7 +868,6 @@ impl App {
     }
 
     fn quit_with(&mut self, req: ExitRequest) -> Vec<Action> {
-        self.save_session();
         self.save_input_history();
         self.exit_request = req;
         vec![]
@@ -971,14 +973,6 @@ impl App {
             return vec![];
         }
         if envelope.run_id != self.run_id {
-            // Stale run_id after cancel: agent updates shared_history before sending
-            // Done/Error, so this is the first moment the full conversation is available.
-            if matches!(
-                envelope.event,
-                AgentEvent::Done { .. } | AgentEvent::Error { .. }
-            ) {
-                self.save_session();
-            }
             // A snapshot dropped here degrades the tool body to llm_output.
             if let AgentEvent::ToolSnapshot { id, .. }
             | AgentEvent::ToolHeaderSnapshot { id, .. }
@@ -1006,9 +1000,8 @@ impl App {
             }
             self.sync_task_picker();
             self.state
-                .session
-                .subagent_messages
-                .insert(tool_use_id, messages);
+                .session_mut()
+                .set_subagent_messages(tool_use_id, messages);
             return vec![];
         }
 
@@ -1029,9 +1022,8 @@ impl App {
                 self.transition_plan(PlanTrigger::WriteDone);
             }
             self.state
-                .session
-                .tool_outputs
-                .insert(e.id.clone(), e.output.clone());
+                .session_mut()
+                .insert_tool_output(e.id.clone(), e.output.clone());
             if let Some(&sub_idx) = self.chat_index.get(&e.id) {
                 let (role, text) = if e.is_error {
                     (DisplayRole::Error, ERROR_TEXT)
@@ -1062,23 +1054,13 @@ impl App {
 
         self.retry_info = None;
 
-        let plan_path = if self.state.mode == Mode::Plan {
-            self.state.plan.path()
-        } else {
-            None
-        };
-
         if let AgentEvent::TurnComplete(ref tc) = envelope.event {
             self.state.token_usage += tc.usage;
             self.chats[chat_idx].token_usage += tc.usage;
             add_cost(&mut self.chats[chat_idx].cost, tc.cost);
-            *self
-                .state
-                .session
-                .meta
-                .usage_by_model
-                .entry(tc.model.clone())
-                .or_default() += tc.usage.into();
+            self.state
+                .session_mut()
+                .add_model_usage(&tc.model, tc.usage.into());
             let ctx_size = tc.context_size.unwrap_or_else(|| tc.usage.context_tokens());
             self.chats[chat_idx].context_size = ctx_size;
             if chat_idx == 0 {
@@ -1092,6 +1074,11 @@ impl App {
             }
         }
 
+        let plan_path = if self.state.mode == Mode::Plan {
+            self.state.plan.path()
+        } else {
+            None
+        };
         let result = self.chats[chat_idx].handle_event(envelope.event, plan_path);
 
         if let ChatEventResult::QueueItemConsumed { text, image_count } = result {
@@ -1127,7 +1114,6 @@ impl App {
                 ChatEventResult::Done => {
                     self.status_bar.clear_flash();
                     self.terminalize_turn(MISSING_TOOL_COMPLETION);
-                    self.save_session();
                     self.chat_index.clear();
                     self.subagent_answers.clear();
                     self.status = Status::Idle;
@@ -1142,7 +1128,6 @@ impl App {
                     self.subagent_answers.clear();
                     self.terminalize_turn(&message);
                     self.recoverable_queue = self.queue.text_messages();
-                    self.save_session();
                     self.queue.clear();
                     self.chat_index.clear();
                     self.fire_session_autocmd(
@@ -1188,6 +1173,7 @@ impl App {
         }
         self.chats.push(chat);
         self.sync_task_picker();
+        self.sync_subagents();
         idx
     }
 
@@ -1420,7 +1406,9 @@ impl App {
         match std::env::set_current_dir(&path) {
             Ok(()) => {
                 if let Ok(canonical) = std::env::current_dir() {
-                    self.state.session.cwd = canonical.to_string_lossy().into_owned();
+                    self.state
+                        .session_mut()
+                        .set_cwd(canonical.to_string_lossy().into_owned());
                 }
                 self.status_bar.refresh_cwd();
                 self.flash(format!("cd {}", path.display()))
@@ -1514,8 +1502,8 @@ impl App {
     }
 
     /// Marks unfinished subagent chats as ended and drops them from
-    /// `chat_index`, which is what makes a `save_session` afterwards persist
-    /// only the children that really completed.
+    /// `chat_index`, so the session records only the children that really
+    /// completed.
     fn retain_resolved_subagents(&mut self, role: DisplayRole, text: &str) {
         self.chat_index.retain(|_, &mut sub_idx| {
             if self.chats[sub_idx].is_finished() {
@@ -1525,6 +1513,7 @@ impl App {
                 false
             }
         });
+        self.sync_subagents();
     }
 
     pub fn flush_all_chats(&mut self) {

--- a/maki-ui/src/app/queue.rs
+++ b/maki-ui/src/app/queue.rs
@@ -173,7 +173,9 @@ impl App {
         // The live queue owns the text from here on, so the recovery
         // snapshot must stop overriding it on save.
         self.recoverable_queue.clear();
-        for text in std::mem::take(&mut self.state.session.meta.queued_messages) {
+        // Read, not taken: the live queue is what the next checkpoint mirrors
+        // back into the session, so emptying it here changes nothing on disk.
+        for text in self.state.session.meta.queued_messages.clone() {
             self.queue_and_notify(QueuedMessage {
                 text,
                 images: Vec::new(),

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::time::{Duration, Instant};
 
 use crate::chat::{Chat, DONE_TEXT, history_to_display};
 use crate::components::DisplayRole;
@@ -7,19 +8,33 @@ use crate::components::rewind_picker::RewindEntry;
 use crate::components::{Action, LoadedSession};
 use maki_providers::{Model, TokenUsage};
 use maki_storage::id::MakiId;
-use maki_storage::sessions::StoredSubagent;
+use maki_storage::sessions::{SessionMeta, StoredSubagent};
 
 use crate::AppSession;
 
-use super::session_state::{SessionState, stored_to_rules};
-use super::{App, Mode, PendingInput, PlanState};
+use super::session_state::{SessionState, rules_to_stored, stored_to_rules};
+use super::{App, Mode, PendingInput, PlanState, Status};
 
-/// The single content predicate: `App::save_session` persists a session
-/// iff this holds, and the shutdown path reuses it to tell which tabs were
-/// saved, so the report and the disk can never disagree. Sync the session
-/// first (`save_session` does).
+/// The shortest gap between two writes that carry only UI state.
+const SOFT_SAVE_DELAY: Duration = Duration::from_millis(1000);
+
+/// What `App::checkpoint` last handed to the writer: which session, how far
+/// along it was, and when. The id is part of it because a session swapped into
+/// the tab starts its revisions back at zero and would otherwise look older
+/// than the stamp left by the one it replaced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Sent {
+    pub id: MakiId,
+    pub revision: u64,
+    pub content_revision: u64,
+    pub at: Instant,
+}
+
+/// The one content check: `App::checkpoint` saves a session only when this
+/// holds, and the shutdown report reuses it to say which tabs were saved, so
+/// the report and the disk can never disagree.
 pub(crate) fn session_has_content(session: &AppSession) -> bool {
-    !session.messages.is_empty()
+    !session.messages().is_empty()
         || session.meta.input_draft.is_some()
         || !session.meta.queued_messages.is_empty()
         || session.meta.mode != Some(maki_storage::sessions::StoredMode::Build)
@@ -30,51 +45,118 @@ impl App {
         session_has_content(&self.state.session)
     }
 
-    pub(crate) fn save_session(&mut self) {
-        self.state
-            .sync_session(&self.shared_history, &self.permissions);
-        self.sync_ephemeral_state();
-        if !self.has_content() {
-            return;
-        }
-        self.enqueue_save();
+    /// The event loop runs this once per frame per session. It syncs whatever
+    /// the session mirrors from live state, then writes only if a mutator
+    /// really changed something. No dirty flags and no per-event save calls,
+    /// so there is nothing left to forget.
+    pub(crate) fn checkpoint(&mut self) {
+        self.checkpoint_with(SOFT_SAVE_DELAY);
     }
 
-    fn sync_ephemeral_state(&mut self) {
-        let draft = self.input_box.buffer.value();
-        self.state.session.meta.input_draft = if draft.is_empty() { None } else { Some(draft) };
+    /// A checkpoint for the paths that get no later frame, so a draft typed a
+    /// keystroke ago still reaches disk: shutdown, and swapping the session out
+    /// from under the tab.
+    pub(crate) fn checkpoint_now(&mut self) {
+        self.checkpoint_with(Duration::ZERO);
+    }
 
-        self.state.session.meta.queued_messages = if self.recoverable_queue.is_empty() {
-            self.queue.text_messages()
-        } else {
-            self.recoverable_queue.clone()
+    pub(super) fn checkpoint_with(&mut self, soft_delay: Duration) {
+        let snapshot = self.shared_history.as_ref().map(|h| h.load_full());
+        let meta = self.build_meta();
+        AppSession::checkpoint(
+            &mut self.state.session,
+            snapshot.as_deref(),
+            meta,
+            self.state.token_usage,
+        );
+
+        if !self.has_content() {
+            // A draft typed and then deleted is already on disk, and a file with
+            // nothing in it is a session the picker still offers to resume. Idle
+            // only: submitting empties the draft a frame before the agent mirrors
+            // the prompt back, and that gap is not an abandoned session.
+            let id = self.state.session.id;
+            if self.status == Status::Idle && self.last_sent.take_if(|last| last.id == id).is_some()
+            {
+                self.storage_writer.delete(id, |_| {});
+            }
+            return;
+        }
+        let session = &self.state.session;
+        let sent = Sent {
+            id: session.id,
+            revision: session.revision(),
+            content_revision: session.content_revision(),
+            at: Instant::now(),
         };
+        if let Some(last) = &self.last_sent
+            && last.id == sent.id
+        {
+            if last.revision == sent.revision {
+                return;
+            }
+            // Only UI state moved: a keystroke in the draft, the queue or a
+            // session rule. Each one costs a meta record plus an fsync, so they
+            // land at most once per `soft_delay`, which bounds what a crash
+            // takes with it. Anything the agent produced skips the wait.
+            if last.content_revision == sent.content_revision && last.at.elapsed() < soft_delay {
+                return;
+            }
+        }
 
-        let mut subagents: Vec<_> = self.chat_index.iter().collect();
-        subagents.sort_by_key(|&(_, chat_index)| chat_index);
-        self.state.session.meta.subagents = subagents
+        self.storage_writer.send(Arc::clone(&self.state.session));
+        self.last_sent = Some(sent);
+    }
+
+    /// Everything the session mirrors from live state, built field by field so
+    /// a new `SessionMeta` field forces a decision here. Every frame calls it,
+    /// so it stays cheap: an idle UI has an empty draft, queue and rule list,
+    /// and an empty `Vec` does not allocate.
+    fn build_meta(&self) -> SessionMeta {
+        let state = &self.state;
+        let draft = self.input_box.buffer.value();
+        SessionMeta {
+            mode: Some(state.mode.into()),
+            plan_path: state.plan.path().map(|p| p.to_string_lossy().into_owned()),
+            plan_written: state.plan.is_ready(),
+            session_rules: rules_to_stored(&self.permissions.session_rules_snapshot()),
+            context_size: state.context_size,
+            input_draft: (!draft.is_empty()).then_some(draft),
+            queued_messages: if self.recoverable_queue.is_empty() {
+                self.queue.text_messages()
+            } else {
+                self.recoverable_queue.clone()
+            },
+            thinking: Some(state.thinking.into()),
+            fast: state.fast,
+            workflow: state.workflow,
+        }
+    }
+
+    /// Called where the set of subagent tabs changes, not at checkpoint time:
+    /// the turn-end path clears `chat_index` right after pruning it, so a later
+    /// rebuild would only ever find an empty map.
+    pub(super) fn sync_subagents(&mut self) {
+        let mut ordered: Vec<_> = self.chat_index.iter().collect();
+        ordered.sort_by_key(|&(_, chat_index)| chat_index);
+        let subagents = ordered
             .into_iter()
             .map(|(tool_id, &chat_index)| {
                 let chat = &self.chats[chat_index];
                 StoredSubagent {
                     tool_use_id: tool_id.clone(),
                     name: chat.name.clone(),
-                    prompt: None,
                     model: chat.model_id.clone(),
                 }
             })
             .collect();
+        self.state.session_mut().set_subagents(subagents);
     }
 
     pub(super) fn save_input_history(&self) {
         if let Err(e) = self.input_box.history().save(&self.storage) {
             tracing::warn!(error = %e, "input history save failed");
         }
-    }
-
-    pub(super) fn enqueue_save(&self) {
-        self.storage_writer
-            .send(Box::new(self.state.session.clone()));
     }
 
     pub(super) fn reset_ui_chrome(&mut self) {
@@ -105,8 +187,8 @@ impl App {
         self.restoring = restoring.clone();
 
         let (display_msgs, restore_items) = history_to_display(
-            &self.state.session.messages,
-            &self.state.session.tool_outputs,
+            self.state.session.messages(),
+            self.state.session.tool_outputs(),
             &self.ui_config.tool_output_lines,
         );
         self.main_chat().load_messages(display_msgs);
@@ -118,14 +200,17 @@ impl App {
         main.token_usage = usage;
         main.cost = cost;
         main.context_size = context_size;
-        if let Some(draft) = self.state.session.meta.input_draft.take() {
+        if let Some(draft) = self.state.session.meta.input_draft.clone() {
             self.input_box.set_input(draft);
             self.input_box.buffer.move_to_end();
         }
 
         self.fire_restore_items(restore_items);
 
-        for sa in std::mem::take(&mut self.state.session.meta.subagents) {
+        // Read, not taken: the live chats below are the source `sync_subagents`
+        // mirrors back, so emptying the session here would only make the next
+        // checkpoint write the same list again.
+        for sa in self.state.session.subagents().to_vec() {
             let idx = self.chats.len();
             self.chat_index.insert(sa.tool_use_id.clone(), idx);
             let mut chat = Chat::new(
@@ -135,10 +220,10 @@ impl App {
             );
             chat.set_restore_channel(self.restore_event_tx.clone());
             chat.model_id = sa.model;
-            if let Some(messages) = self.state.session.subagent_messages.get(&sa.tool_use_id) {
+            if let Some(messages) = self.state.session.subagent_messages().get(&sa.tool_use_id) {
                 let (display, items) = history_to_display(
                     messages,
-                    &self.state.session.tool_outputs,
+                    self.state.session.tool_outputs(),
                     &self.ui_config.tool_output_lines,
                 );
                 chat.load_messages(display);
@@ -147,6 +232,8 @@ impl App {
             }
             self.chats.push(chat);
         }
+
+        self.sync_subagents();
 
         let eh = &self.lua_event_handle;
         if eh.is_disconnected() {
@@ -182,14 +269,20 @@ impl App {
         }
     }
 
-    fn loaded_session_snapshot(&self) -> LoadedSession {
+    /// The one funnel for handing a history over. When the UI installs one the
+    /// agent did not give it (rewind, load, new session), the mirror handle
+    /// goes away in the same breath, so no later checkpoint can bring the
+    /// agent's stale copy back. Only `respawn_agent` hands a live mirror in.
+    fn install_local_history(&mut self) -> LoadedSession {
+        self.shared_history = None;
         LoadedSession {
-            messages: self.state.session.messages.clone(),
+            messages: self.state.session.messages().to_vec(),
             model_spec: self.state.session.model.clone(),
         }
     }
 
     pub(super) fn reset_session(&mut self) -> Vec<Action> {
+        self.checkpoint_now();
         self.reset_ui_chrome();
         self.state.token_usage = TokenUsage::default();
         self.state.context_size = 0;
@@ -201,13 +294,16 @@ impl App {
         // that just ended needs its id, and the stamp always reads
         // whichever session is current.
         self.fire_session_autocmd("SessionReset", serde_json::json!({}));
-        self.state.session = AppSession::new(&self.state.session.model, &self.state.session.cwd);
+        self.state.session = Arc::new(AppSession::new(
+            &self.state.session.model,
+            &self.state.session.cwd,
+        ));
+        self.install_local_history();
         vec![Action::NewSession]
     }
 
     pub(super) fn open_rewind_picker(&mut self) -> Vec<Action> {
-        self.save_session();
-        match self.rewind_picker.open(&self.state.session.messages) {
+        match self.rewind_picker.open(self.state.session.messages()) {
             Ok(()) => vec![],
             Err(msg) => {
                 self.status_bar.flash(msg);
@@ -217,12 +313,12 @@ impl App {
     }
 
     pub(super) fn rewind_to(&mut self, entry: RewindEntry) -> Vec<Action> {
-        self.state.session.messages.truncate(entry.turn_index);
-        self.state
-            .session
-            .prune_orphans(|m| m.tool_uses().map(|(id, _, _)| id.to_owned()).collect());
+        let session = self.state.session_mut();
+        session.truncate_messages(entry.turn_index);
+        session.prune_orphans(|m| m.tool_uses().map(|(id, _, _)| id.to_owned()).collect());
+        session.update_title_if_default();
         self.state.context_size =
-            maki_agent::agent::estimate_message_tokens(&self.state.session.messages);
+            maki_agent::agent::estimate_message_tokens(self.state.session.messages());
 
         self.reset_ui_chrome();
         self.restore_display();
@@ -230,12 +326,7 @@ impl App {
         self.input_box.set_input(entry.prompt_text);
         self.input_box.buffer.move_to_end();
 
-        self.state.session.update_title_if_default();
-        self.enqueue_save();
-
-        vec![Action::LoadSession(Box::new(
-            self.loaded_session_snapshot(),
-        ))]
+        vec![Action::LoadSession(Box::new(self.install_local_history()))]
     }
 
     pub(crate) fn apply_loaded_session(
@@ -243,6 +334,7 @@ impl App {
         session: AppSession,
         fallback_model: &Model,
     ) -> LoadedSession {
+        self.checkpoint_now();
         self.permissions
             .load_session_rules(stored_to_rules(&session.meta.session_rules));
         self.state = SessionState::from_session(session, fallback_model, &self.storage);
@@ -252,8 +344,7 @@ impl App {
         self.reset_ui_chrome();
         self.restore_display();
 
-        self.enqueue_save();
-        self.loaded_session_snapshot()
+        self.install_local_history()
     }
 
     pub(crate) fn load_session(&mut self, session_id: MakiId) -> Vec<Action> {
@@ -265,7 +356,6 @@ impl App {
                 return vec![];
             }
         };
-        self.save_session();
         let loaded = self.apply_loaded_session(session, &self.state.model.clone());
         vec![Action::LoadSession(Box::new(loaded))]
     }

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -1,10 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use arc_swap::ArcSwap;
-use maki_agent::permissions::PermissionManager;
 use maki_config::Effect;
-use maki_providers::{Message, Model, ThinkingConfig, TokenUsage};
+use maki_providers::{Model, ThinkingConfig, TokenUsage};
 use maki_storage::StateDir;
 use maki_storage::sessions::{StoredEffect, StoredMode, StoredRule};
 
@@ -13,7 +11,8 @@ use crate::AppSession;
 use super::mode::{Mode, PlanState};
 
 pub(crate) struct SessionState {
-    pub session: AppSession,
+    /// Shared with the writer thread, so a checkpoint is just a refcount bump.
+    pub session: Arc<AppSession>,
     pub model: Model,
     pub token_usage: TokenUsage,
     pub context_size: u32,
@@ -78,7 +77,7 @@ impl SessionState {
                 .unwrap_or_default(),
             fast: session.meta.fast && model.supports_fast(),
             workflow: session.meta.workflow,
-            session,
+            session: Arc::new(session),
             model,
             token_usage,
             context_size,
@@ -88,25 +87,8 @@ impl SessionState {
         }
     }
 
-    pub fn sync_session(
-        &mut self,
-        shared_history: &Option<Arc<ArcSwap<Vec<Message>>>>,
-        permissions: &Arc<PermissionManager>,
-    ) {
-        if let Some(history) = shared_history {
-            self.session.messages = Vec::clone(&history.load());
-        }
-        self.session.token_usage = self.token_usage;
-        self.session.meta.context_size = self.context_size;
-        self.session.meta.mode = Some(self.mode.into());
-        self.session.meta.plan_path = self.plan.path().map(|p| p.to_string_lossy().into_owned());
-        self.session.meta.plan_written = self.plan.is_ready();
-        self.session.meta.session_rules = rules_to_stored(&permissions.session_rules_snapshot());
-        self.session.meta.thinking = Some(self.thinking.into());
-        self.session.meta.fast = self.fast;
-        self.session.meta.workflow = self.workflow;
-        self.session.updated_at = maki_storage::now_epoch();
-        self.session.update_title_if_default();
+    pub fn session_mut(&mut self) -> &mut AppSession {
+        Arc::make_mut(&mut self.session)
     }
 
     pub fn update_model(&mut self, model: &Model) {
@@ -116,7 +98,7 @@ impl SessionState {
         if !model.supports_fast() {
             self.fast = false;
         }
-        self.session.model = model.spec();
+        self.session_mut().set_model(model.spec());
         self.model = model.clone();
     }
 }

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -14,7 +14,7 @@ use maki_agent::{
 };
 use maki_config::{PermissionsConfig, UiConfig};
 use maki_lua::{HintReader, KeymapReader, LuaCommandInfo, LuaCommandReader};
-use maki_providers::{ContentBlock, Effort, Role, TokenUsage};
+use maki_providers::{ContentBlock, Effort, Message, Role, TokenUsage};
 use maki_storage::sessions::{StoredMode, StoredThinking};
 use ratatui::layout::Rect;
 use std::env;
@@ -65,9 +65,13 @@ fn build_app_with_lua(
     )
 }
 
+fn test_writer(dir: StateDir) -> StorageWriter {
+    StorageWriter::new(dir, flume::unbounded().0)
+}
+
 pub(crate) fn test_app() -> App {
     let dir = StateDir::from_path(env::temp_dir());
-    let mut app = build_app(dir.clone(), Arc::new(StorageWriter::new(dir)));
+    let mut app = build_app(dir.clone(), Arc::new(test_writer(dir)));
     let (shared_queue, _rx) = shared_queue::queue();
     app.queue.set_shared(shared_queue);
     app
@@ -76,7 +80,7 @@ pub(crate) fn test_app() -> App {
 fn tempdir_app() -> (TempDir, StateDir, Arc<StorageWriter>, App) {
     let tmp = TempDir::new().unwrap();
     let dir = StateDir::from_path(tmp.path().to_path_buf());
-    let writer = Arc::new(StorageWriter::new(dir.clone()));
+    let writer = Arc::new(test_writer(dir.clone()));
     let app = build_app(dir.clone(), Arc::clone(&writer));
     (tmp, dir, writer, app)
 }
@@ -457,7 +461,7 @@ fn submit_prompt_rejects(mk: fn() -> App, text: &str, expected: &str) {
 
 fn streaming_app_without_queue() -> App {
     let dir = StateDir::from_path(env::temp_dir());
-    let mut app = build_app(dir.clone(), Arc::new(StorageWriter::new(dir)));
+    let mut app = build_app(dir.clone(), Arc::new(test_writer(dir)));
     app.status = Status::Streaming;
     app
 }
@@ -613,10 +617,9 @@ fn reset_session_clears_drafting_plan_in_build_mode() {
 fn load_session_clears_plan() {
     let (_tmp, _dir, _writer, mut app) = tempdir_app();
     app.state
-        .session
-        .messages
-        .push(Message::user("test".into()));
-    app.state.session.save(&app.storage).unwrap();
+        .session_mut()
+        .push_message(Message::user("test".into()));
+    app.state.session_mut().save(&app.storage).unwrap();
     let id = app.state.session.id;
     app.state.mode = Mode::Build;
     app.state.plan = PlanState::Ready(PathBuf::from("old-plan.md"));
@@ -865,7 +868,7 @@ fn turn_complete_accumulates_usage_by_model() {
         None,
     ));
 
-    let by_model = &app.state.session.meta.usage_by_model;
+    let by_model = app.state.session.usage_by_model();
     assert_eq!(by_model.len(), 2);
     let main = &by_model["main-model"];
     assert_eq!(main.input, 100);
@@ -1363,9 +1366,8 @@ fn double_esc_idle_opens_rewind_picker() {
     app.status = Status::Idle;
     app.run_id = 1;
     app.state
-        .session
-        .messages
-        .push(Message::user("hello".into()));
+        .session_mut()
+        .push_message(Message::user("hello".into()));
 
     app.last_esc = Some(Instant::now());
     app.update(Msg::Key(key(KeyCode::Esc)));
@@ -1890,7 +1892,7 @@ fn help_modal_consumes_keys_and_esc_closes() {
 )]
 #[test_case(
     |app: &mut App| {
-        app.state.session.messages.push(Message::user("test".into()));
+        app.state.session_mut().push_message(Message::user("test".into()));
         app.open_rewind_picker();
     },
     &[KeybindContext::RewindPicker],
@@ -1937,34 +1939,34 @@ fn session_has_content_covers_each_branch() {
     assert!(session_has_content(&session));
     session.meta.mode = Some(StoredMode::Build);
 
-    session.messages.push(Message::user("hello".into()));
+    session.push_message(Message::user("hello".into()));
     assert!(session_has_content(&session));
 }
 
 #[test]
-fn save_session_syncs_ephemeral_content_into_meta() {
+fn checkpoint_syncs_ephemeral_content_into_meta() {
     let mut app = test_app();
-    app.save_session();
+    app.checkpoint();
     assert!(!session_has_content(&app.state.session));
 
     app.update(Msg::Key(key(KeyCode::Char('x'))));
-    app.save_session();
+    app.checkpoint();
     assert!(session_has_content(&app.state.session));
 
     app.update(Msg::Key(key(KeyCode::Backspace)));
-    app.save_session();
+    app.checkpoint();
     assert!(app.state.session.meta.input_draft.is_none());
     assert!(!session_has_content(&app.state.session));
 
     app.update(Msg::Key(key(KeyCode::Tab)));
-    app.save_session();
+    app.checkpoint();
     assert_eq!(app.state.session.meta.mode, Some(StoredMode::Plan));
     assert!(session_has_content(&app.state.session));
 
     let mut queued = app_with_queued_message();
-    queued.save_session();
+    queued.checkpoint();
     let session = &queued.state.session;
-    assert!(session.messages.is_empty());
+    assert!(session.messages().is_empty());
     assert!(session.meta.input_draft.is_none());
     assert_eq!(session.meta.mode, Some(StoredMode::Build));
     assert_eq!(session.meta.queued_messages, vec!["queued".to_string()]);
@@ -1983,16 +1985,16 @@ fn drain_writer(app: App, writer: Arc<StorageWriter>) {
 fn reload_persists_session_with_content_to_disk() {
     let (_tmp, dir, writer, mut app) = tempdir_app();
     app.state
-        .session
-        .messages
-        .push(Message::user("hello".into()));
+        .session_mut()
+        .push_message(Message::user("hello".into()));
     let actions = app.execute_command(cmd("/reload"));
     assert_eq!(app.exit_request, ExitRequest::Reload);
     assert!(actions.is_empty());
+    app.checkpoint();
     let id = app.state.session.id;
     drain_writer(app, writer);
 
-    assert_eq!(AppSession::load(id, &dir).unwrap().messages.len(), 1);
+    assert_eq!(AppSession::load(id, &dir).unwrap().messages().len(), 1);
 }
 
 #[test]
@@ -2008,48 +2010,15 @@ fn reload_leaves_empty_session_unpersisted_on_disk() {
     assert_eq!(entries, 0);
 }
 
-/// `state.session.tool_outputs` is the only store, so a `ToolDone` write
-/// must reach disk or restored sessions lose their tool call widgets.
-#[test]
-fn tool_done_output_persists_to_disk() {
-    let (_tmp, dir, writer, mut app) = tempdir_app();
-    app.state
-        .session
-        .messages
-        .push(Message::user("prompt".into()));
-    app.status = Status::Streaming;
-    app.run_id = 1;
-
-    app.update(agent_msg(AgentEvent::ToolDone(Box::new(ToolDoneEvent {
-        id: "tool-live".into(),
-        tool: "bash".into(),
-        output: ToolOutput::Plain("live output".into()),
-        is_error: false,
-        annotation: None,
-        written_path: None,
-    }))));
-
-    app.save_session();
-    let id = app.state.session.id;
-    drain_writer(app, writer);
-
-    let loaded = AppSession::load(id, &dir).unwrap();
-    assert!(matches!(
-        loaded.tool_outputs.get("tool-live"),
-        Some(ToolOutput::Plain(s)) if s.text == "live output"
-    ));
-}
-
 #[test]
 fn restore_resumed_session_flushes_queued_messages_and_round_trips() {
     let mut app = test_app();
-    app.state.session.meta.queued_messages = vec!["q1".into(), "q2".into()];
+    app.state.session_mut().meta.queued_messages = vec!["q1".into(), "q2".into()];
 
     app.restore_resumed_session();
-    assert!(app.state.session.meta.queued_messages.is_empty());
     assert_eq!(app.queue.text_messages(), ["q1", "q2"]);
 
-    app.save_session();
+    app.checkpoint();
     assert_eq!(app.state.session.meta.queued_messages, ["q1", "q2"]);
 }
 
@@ -2058,7 +2027,7 @@ fn apply_loaded_session_defers_queued_messages_until_respawn() {
     let mut app = test_app();
     let mut session = AppSession::new("test-model", "/tmp/test");
     session.meta.queued_messages = vec!["deferred".into()];
-    session.messages.push(Message::user("hello".into()));
+    session.push_message(Message::user("hello".into()));
 
     let model = app.state.model.clone();
     app.apply_loaded_session(session, &model);
@@ -2160,7 +2129,7 @@ fn typed_lua_command_with_args_executes() {
     let dir = StateDir::from_path(env::temp_dir());
     let mut app = build_app_with_lua(
         dir.clone(),
-        Arc::new(StorageWriter::new(dir)),
+        Arc::new(test_writer(dir)),
         LuaCommandReader::from_commands(vec![LuaCommandInfo {
             name: "/rename".into(),
             description: "Rename the current session".into(),
@@ -2188,7 +2157,7 @@ fn slash_noncommand_sends_as_prompt() {
 fn build_rewind_app() -> App {
     let mut app = test_app();
 
-    app.state.session.messages = vec![
+    app.state.session_mut().replace_messages(vec![
         Message::user("first prompt".into()),
         Message {
             role: Role::Assistant,
@@ -2213,11 +2182,10 @@ fn build_rewind_app() -> App {
             ..Default::default()
         },
         Message::user("third prompt".into()),
-    ];
+    ]);
     app.state
-        .session
-        .tool_outputs
-        .insert("tool-1".into(), ToolOutput::Plain("output".into()));
+        .session_mut()
+        .insert_tool_output("tool-1".into(), ToolOutput::Plain("output".into()));
     app
 }
 
@@ -2233,11 +2201,11 @@ fn rewind_to_middle_truncates_and_populates_input() {
     };
     let actions = app.rewind_to(entry);
 
-    assert_eq!(app.state.session.messages.len(), 2);
-    assert!(app.state.session.tool_outputs.contains_key("tool-1"));
+    assert_eq!(app.state.session.messages().len(), 2);
+    assert!(app.state.session.tool_outputs().contains_key("tool-1"));
     assert_eq!(app.input_box.buffer.value(), "second prompt");
     assert_eq!(app.run_id, old_run_id);
-    let expected_ctx = maki_agent::agent::estimate_message_tokens(&app.state.session.messages);
+    let expected_ctx = maki_agent::agent::estimate_message_tokens(app.state.session.messages());
     assert_eq!(app.state.context_size, expected_ctx);
     assert_eq!(app.chats[0].context_size, expected_ctx);
 
@@ -2260,8 +2228,8 @@ fn rewind_to_first_turn_clears_everything() {
     };
     let actions = app.rewind_to(entry);
 
-    assert!(app.state.session.messages.is_empty());
-    assert!(!app.state.session.tool_outputs.contains_key("tool-1"));
+    assert!(app.state.session.messages().is_empty());
+    assert!(!app.state.session.tool_outputs().contains_key("tool-1"));
     assert_eq!(app.state.token_usage.input, 500);
     assert_eq!(app.state.token_usage.output, 200);
     assert_eq!(app.state.context_size, 0);
@@ -2632,38 +2600,30 @@ fn streaming_app_with_history() -> App {
             ..Default::default()
         },
     ];
-    app.shared_history = Some(Arc::new(ArcSwap::from_pointee(history)));
+    app.shared_history = Some(Arc::new(ArcSwap::from_pointee(
+        maki_agent::HistorySnapshot::new(history),
+    )));
     app
 }
 
+/// The stale event is dropped, yet the cancelled turn still reaches disk: the
+/// next frame's checkpoint syncs the mirror whatever event arrived.
 #[test_case(
-    AgentEvent::Done { usage: TokenUsage::default(), num_turns: 1, stop_reason: None } ; "stale_done_saves_session"
+    AgentEvent::Done { usage: TokenUsage::default(), num_turns: 1, stop_reason: None } ; "stale_done"
 )]
 #[test_case(
-    AgentEvent::Error { message: "timeout".into() } ; "stale_error_saves_session"
+    AgentEvent::Error { message: "timeout".into() } ; "stale_error"
 )]
-fn stale_terminal_event_after_cancel_saves_session(event: AgentEvent) {
+fn checkpoint_after_cancel_persists_the_cancelled_turn(event: AgentEvent) {
     let mut app = streaming_app_with_history();
     let old_run_id = app.run_id;
     cancel_app(&mut app);
     assert_ne!(app.run_id, old_run_id);
-    assert!(app.state.session.messages.is_empty());
+    assert!(app.state.session.messages().is_empty());
 
     app.update(agent_msg_with_run_id(event, old_run_id));
-    assert_eq!(app.state.session.messages.len(), 2);
-}
-
-#[test]
-fn stale_non_terminal_event_does_not_save_session() {
-    let mut app = streaming_app_with_history();
-    let old_run_id = app.run_id;
-    cancel_app(&mut app);
-
-    app.update(agent_msg_with_run_id(
-        turn_complete(TokenUsage::default(), "mock", None),
-        old_run_id,
-    ));
-    assert!(app.state.session.messages.is_empty());
+    app.checkpoint();
+    assert_eq!(app.state.session.messages().len(), 2);
 }
 
 #[test]
@@ -2713,9 +2673,10 @@ fn parent_done_reconciles_unresolved_children_and_tools() {
             .last_message_text()
             .contains(MISSING_TOOL_COMPLETION)
     );
-    assert!(app.state.session.meta.subagents.is_empty());
-    assert_eq!(app.state.session.messages.len(), 2);
-    assert!(app.state.session.tool_outputs.is_empty());
+    app.checkpoint();
+    assert!(app.state.session.subagents().is_empty());
+    assert_eq!(app.state.session.messages().len(), 2);
+    assert!(app.state.session.tool_outputs().is_empty());
     assert!(!app.is_animating());
 }
 
@@ -2752,11 +2713,11 @@ fn parent_error_refreshes_picker_and_persists_only_completed_children() {
 
     assert!(app.task_picker.is_open());
     assert_eq!(app.task_picker.item(2).unwrap().finished, Some(true));
+    app.checkpoint();
     let saved: Vec<_> = app
         .state
         .session
-        .meta
-        .subagents
+        .subagents()
         .iter()
         .map(|subagent| {
             (
@@ -2889,16 +2850,16 @@ fn error_event_matching_run_id_saves_session_and_queued_messages() {
     app.update(agent_msg(AgentEvent::Error {
         message: "boom".into(),
     }));
+    app.checkpoint();
 
-    assert_eq!(app.state.session.messages.len(), 2);
+    assert_eq!(app.state.session.messages().len(), 2);
     assert_eq!(app.state.session.meta.queued_messages, ["next"]);
     assert!(app.queue.is_empty());
 
-    app.save_session();
     assert_eq!(app.state.session.meta.queued_messages, ["next"]);
 
     type_and_submit(&mut app, "replacement");
-    app.save_session();
+    app.checkpoint();
     assert!(app.state.session.meta.queued_messages.is_empty());
 }
 
@@ -2909,15 +2870,16 @@ fn flush_restored_queue_drops_recovery_snapshot() {
     app.update(agent_msg(AgentEvent::Error {
         message: "boom".into(),
     }));
+    app.checkpoint();
     assert_eq!(app.state.session.meta.queued_messages, ["next"]);
 
     app.flush_restored_queue();
-    app.save_session();
+    app.checkpoint();
     assert_eq!(app.state.session.meta.queued_messages, ["next"]);
     assert!(app.recoverable_queue.is_empty());
 
     app.queue.clear();
-    app.save_session();
+    app.checkpoint();
     assert!(app.state.session.meta.queued_messages.is_empty());
 }
 
@@ -3755,4 +3717,375 @@ fn subagent_cancel_then_navigate_back_main_unaffected() {
     assert_eq!(app.active_chat, 0);
     assert_eq!(app.status, Status::Streaming);
     assert!(!app.chats[0].is_finished());
+}
+
+// -- Every frame checkpoints: one way in for a history, one trigger to save --
+
+/// Long enough that a waiting change is still waiting when the assert runs, on
+/// any machine, so none of these tests depend on the wall clock.
+const SOFT_DELAY_HELD: Duration = Duration::from_secs(3600);
+const MID_BATCH_RESULT: &str = "file contents";
+const TYPED_DRAFT: &str = "hi";
+const UNSENT_DRAFT: &str = "half typed thought";
+const LIVE_AGENT_TEXT: &str = "live agent turn";
+const STORED_SESSION_TEXT: &str = "other session talk";
+const SWITCHED_DRAFT: &str = "draft typed after switching";
+const BUMP_TITLE: &str = "title bump ";
+const TOOL_IDS: [&str; 2] = ["tool-a", "tool-b"];
+const FINISHED_TASK_ID: &str = "task-finished";
+const UNFINISHED_TASK_ID: &str = "task-unfinished";
+
+fn tool_use_msg(id: &str) -> Message {
+    Message {
+        role: Role::Assistant,
+        content: vec![ContentBlock::ToolUse {
+            id: id.into(),
+            name: "read".into(),
+            input: serde_json::json!({}),
+        }],
+        ..Default::default()
+    }
+}
+
+fn tool_result_msg(id: &str, text: &str) -> Message {
+    Message {
+        role: Role::User,
+        content: vec![ContentBlock::ToolResult {
+            tool_use_id: id.into(),
+            content: text.into(),
+            is_error: false,
+        }],
+        display_text: Some(String::new()),
+    }
+}
+
+fn tool_text(id: &str) -> String {
+    format!("output of {id}")
+}
+
+fn attach_live_history(app: &mut App, messages: Vec<Message>) -> maki_agent::History {
+    let mirror: maki_agent::SharedMessages =
+        Arc::new(ArcSwap::from_pointee(maki_agent::HistorySnapshot::default()));
+    let history = maki_agent::History::new(messages).with_mirror(Arc::clone(&mirror));
+    app.shared_history = Some(mirror);
+    history
+}
+
+/// Types [`TYPED_DRAFT`] one key per frame and hands back the stamp of the
+/// write the first key caused. The soft delay never elapses, so every key after
+/// the first is still waiting when the caller looks.
+fn type_draft_leaving_last_key_waiting(app: &mut App) -> Sent {
+    let mut keys = TYPED_DRAFT.chars();
+    app.update(Msg::Key(key(KeyCode::Char(keys.next().unwrap()))));
+    app.checkpoint();
+    let first = app
+        .last_sent
+        .clone()
+        .expect("the first keystroke puts the session on disk");
+
+    for c in keys {
+        app.update(Msg::Key(key(KeyCode::Char(c))));
+        app.checkpoint_with(SOFT_DELAY_HELD);
+    }
+    first
+}
+
+/// Checkpointing mid-batch used to freeze the tools as failed forever. The
+/// synthetic closing message made the snapshot as long as the real results that
+/// followed, so the append cursor never saw them.
+#[test]
+fn mid_batch_checkpoint_does_not_shadow_the_real_tool_results() {
+    let (_tmp, dir, writer, mut app) = tempdir_app();
+    let mut history = attach_live_history(
+        &mut app,
+        vec![Message::user("go".into()), tool_use_msg("t1")],
+    );
+    app.checkpoint();
+
+    history.push(tool_result_msg("t1", MID_BATCH_RESULT));
+    app.checkpoint();
+
+    let id = app.state.session.id;
+    drain_writer(app, writer);
+
+    let loaded = AppSession::load(id, &dir).unwrap();
+    assert_eq!(loaded.messages().len(), 3);
+    let [
+        ContentBlock::ToolResult {
+            content, is_error, ..
+        },
+    ] = &loaded.messages()[2].content[..]
+    else {
+        panic!("expected one real tool result: {:?}", loaded.messages()[2]);
+    };
+    assert_eq!((content.as_str(), *is_error), (MID_BATCH_RESULT, false));
+}
+
+/// In the window between a rewind and the agent respawn, syncing from the
+/// mirror would bring back the messages that were just dropped.
+#[test]
+fn checkpoint_after_rewind_persists_the_truncated_history() {
+    let (_tmp, dir, writer, mut app) = tempdir_app();
+    let _live = attach_live_history(
+        &mut app,
+        vec![
+            Message::user("first prompt".into()),
+            Message::user("second prompt".into()),
+        ],
+    );
+    app.checkpoint();
+
+    let entry = crate::components::rewind_picker::RewindEntry {
+        turn_index: 1,
+        prompt_preview: "2: second".into(),
+        prompt_text: "second prompt".into(),
+    };
+    app.rewind_to(entry);
+    assert!(app.shared_history.is_none(), "mirror handle is dropped");
+    app.checkpoint();
+
+    let id = app.state.session.id;
+    drain_writer(app, writer);
+    assert_eq!(AppSession::load(id, &dir).unwrap().messages().len(), 1);
+}
+
+#[test]
+fn reset_session_never_writes_the_old_conversation_under_the_new_id() {
+    let (_tmp, dir, writer, mut app) = tempdir_app();
+    let _live = attach_live_history(&mut app, vec![Message::user("old talk".into())]);
+    app.checkpoint();
+    let old_id = app.state.session.id;
+
+    app.reset_session();
+    app.checkpoint();
+    let new_id = app.state.session.id;
+    assert_ne!(new_id, old_id);
+
+    drain_writer(app, writer);
+    assert_eq!(AppSession::load(old_id, &dir).unwrap().messages().len(), 1);
+    assert!(
+        AppSession::load(new_id, &dir).is_err(),
+        "an empty session has no content to persist",
+    );
+}
+
+/// Two traps in one switch. `install_local_history` has to drop the mirror
+/// handle, or the old agent's messages land under the freshly loaded id. And
+/// `revision` is `#[serde(skip)]`, so the loaded session starts back at zero and
+/// can collide with the revision already sent for the one it replaced, which
+/// only keying `last_sent` by id survives.
+#[test]
+fn load_session_persists_the_new_session_and_leaks_no_history_into_it() {
+    let (_tmp, dir, writer, mut app) = tempdir_app();
+    let mut stored = AppSession::new("test-model", "/tmp/test");
+    stored.push_message(Message::user(STORED_SESSION_TEXT.into()));
+    stored.save(&dir).unwrap();
+
+    let _live = attach_live_history(&mut app, vec![Message::user(LIVE_AGENT_TEXT.into())]);
+    app.input_box.set_input(UNSENT_DRAFT.into());
+    app.checkpoint();
+    let (live_id, sent_revision) = (app.state.session.id, app.state.session.revision());
+
+    app.load_session(stored.id);
+    assert_eq!(app.state.session.id, stored.id);
+    // Walk the loaded session up to the revision already sent for the live one,
+    // so the checkpoint below lands on the exact collision.
+    let session = app.state.session_mut();
+    while session.revision() + 1 < sent_revision {
+        session.set_title(format!("{BUMP_TITLE}{}", session.revision()));
+    }
+    app.input_box.set_input(SWITCHED_DRAFT.into());
+    app.checkpoint();
+    assert_eq!(
+        app.state.session.revision(),
+        sent_revision,
+        "both sessions must sit at the same revision for this to test anything"
+    );
+
+    drain_writer(app, writer);
+    let loaded = AppSession::load(stored.id, &dir).unwrap();
+    assert_eq!(loaded.meta.input_draft.as_deref(), Some(SWITCHED_DRAFT));
+    assert_eq!(loaded.messages().len(), 1);
+    assert_eq!(loaded.messages()[0].user_text(), Some(STORED_SESSION_TEXT));
+    let previous = AppSession::load(live_id, &dir).unwrap();
+    assert_eq!(previous.messages()[0].user_text(), Some(LIVE_AGENT_TEXT));
+}
+
+#[test]
+fn idle_checkpoint_changes_nothing() {
+    let mut app = test_app();
+    app.state
+        .session_mut()
+        .push_message(Message::user("hello".into()));
+    app.checkpoint();
+    let (revision, updated_at) = (app.state.session.revision(), app.state.session.updated_at);
+
+    app.checkpoint();
+    app.checkpoint();
+
+    assert_eq!(app.state.session.revision(), revision);
+    assert_eq!(app.state.session.updated_at, updated_at);
+}
+
+/// Issue #675: a crash between a keystroke and submit threw the draft away,
+/// because nothing was written until the turn ended. The first key lands within
+/// a frame now, and the keys behind it ride along on a later write rather than
+/// each costing an `fsync`.
+#[test]
+fn first_draft_keystroke_lands_and_the_rest_coalesce() {
+    let (_tmp, dir, writer, mut app) = tempdir_app();
+    let first = type_draft_leaving_last_key_waiting(&mut app);
+    assert_eq!(
+        app.last_sent.as_ref(),
+        Some(&first),
+        "a keystroke on its own waits instead of costing a write",
+    );
+
+    app.checkpoint_with(Duration::ZERO);
+    assert_ne!(
+        app.last_sent.as_ref(),
+        Some(&first),
+        "and lands once the delay is up"
+    );
+
+    let id = app.state.session.id;
+    drain_writer(app, writer);
+    let saved = AppSession::load(id, &dir).unwrap();
+    assert_eq!(saved.meta.input_draft.as_deref(), Some(TYPED_DRAFT));
+    assert!(saved.messages().is_empty());
+}
+
+#[test]
+fn a_content_change_writes_the_waiting_draft_with_it() {
+    let (_tmp, dir, writer, mut app) = tempdir_app();
+    type_draft_leaving_last_key_waiting(&mut app);
+
+    app.state
+        .session_mut()
+        .push_message(Message::user(LIVE_AGENT_TEXT.into()));
+    app.checkpoint_with(SOFT_DELAY_HELD);
+
+    let id = app.state.session.id;
+    drain_writer(app, writer);
+    let saved = AppSession::load(id, &dir).unwrap();
+    assert_eq!(saved.messages().len(), 1, "content never waits");
+    assert_eq!(saved.meta.input_draft.as_deref(), Some(TYPED_DRAFT));
+}
+
+#[test]
+fn shutdown_writes_a_draft_that_is_still_waiting() {
+    let (_tmp, dir, writer, mut app) = tempdir_app();
+    type_draft_leaving_last_key_waiting(&mut app);
+
+    app.checkpoint_now();
+
+    let id = app.state.session.id;
+    drain_writer(app, writer);
+    let saved = AppSession::load(id, &dir).unwrap();
+    assert_eq!(saved.meta.input_draft.as_deref(), Some(TYPED_DRAFT));
+}
+
+/// Submitting empties the draft a frame before the agent mirrors the prompt
+/// back. Delete the session in that gap and the user loses the one they were
+/// just starting.
+#[test]
+fn submitting_the_draft_keeps_the_session_on_disk() {
+    let (_tmp, dir, writer, mut app) = tempdir_app();
+    type_draft_leaving_last_key_waiting(&mut app);
+    let id = app.state.session.id;
+
+    app.update(Msg::Key(key(KeyCode::Enter)));
+    app.checkpoint();
+    assert!(!app.has_content(), "the submit window is what this covers");
+
+    drain_writer(app, writer);
+    assert!(AppSession::load(id, &dir).is_ok());
+}
+
+/// The draft put the session on disk, and deleting it leaves nothing worth
+/// keeping. Without the delete the file survives with the abandoned draft in
+/// it, and the picker offers an empty session to resume.
+#[test]
+fn deleting_the_draft_takes_the_session_off_disk() {
+    let (_tmp, dir, writer, mut app) = tempdir_app();
+    type_draft_leaving_last_key_waiting(&mut app);
+    let id = app.state.session.id;
+
+    for _ in TYPED_DRAFT.chars() {
+        app.update(Msg::Key(key(KeyCode::Backspace)));
+    }
+    app.checkpoint();
+    assert!(app.last_sent.is_none(), "nothing is on disk to stamp");
+
+    drain_writer(app, writer);
+    assert!(AppSession::load(id, &dir).is_err());
+}
+
+/// The second result goes through the append cursor the first one opened, so a
+/// stale cursor would quietly drop or duplicate it.
+#[test]
+fn two_tool_results_checkpointed_separately_both_reach_disk() {
+    let (_tmp, dir, writer, mut app) = tempdir_app();
+    app.state
+        .session_mut()
+        .push_message(Message::user("prompt".into()));
+    app.status = Status::Streaming;
+    app.run_id = 1;
+
+    for tool_id in TOOL_IDS {
+        app.update(agent_msg(AgentEvent::ToolDone(Box::new(ToolDoneEvent {
+            id: tool_id.into(),
+            tool: "bash".into(),
+            output: ToolOutput::Plain(tool_text(tool_id).into()),
+            is_error: false,
+            annotation: None,
+            written_path: None,
+        }))));
+        app.checkpoint();
+    }
+
+    let id = app.state.session.id;
+    drain_writer(app, writer);
+    let loaded = AppSession::load(id, &dir).unwrap();
+    for tool_id in TOOL_IDS {
+        match loaded.tool_outputs().get(tool_id).map(Arc::as_ref) {
+            Some(ToolOutput::Plain(out)) => assert_eq!(out.text, tool_text(tool_id)),
+            other => panic!("missing plain output for {tool_id}: {other:?}"),
+        }
+    }
+}
+
+/// The `Done` path clears `chat_index` right after pruning it, so nothing can
+/// rebuild the tabs later. Only the `sync_subagents` call inside
+/// `retain_resolved_subagents` carries the survivors over.
+#[test]
+fn turn_end_keeps_only_the_subagents_that_finished() {
+    let mut app = test_app();
+    app.status = Status::Streaming;
+    app.run_id = 1;
+    for (task_id, name) in [
+        (FINISHED_TASK_ID, "finished child"),
+        (UNFINISHED_TASK_ID, "open child"),
+    ] {
+        app.update(subagent_msg(
+            AgentEvent::TextDelta { text: "x".into() },
+            task_id,
+            Some(name),
+        ));
+    }
+    finish_subagent(&mut app, FINISHED_TASK_ID, false);
+    assert_eq!(app.state.session.subagents().len(), 2);
+
+    app.update(done_event());
+    assert!(app.chat_index.is_empty());
+    app.checkpoint();
+
+    let ids: Vec<_> = app
+        .state
+        .session
+        .subagents()
+        .iter()
+        .map(|sa| sa.tool_use_id.as_str())
+        .collect();
+    assert_eq!(ids, [FINISHED_TASK_ID]);
 }

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -267,7 +267,7 @@ impl App {
             let quota = self.usage_slot.load();
             let ctx = UsageModalContext {
                 total: &self.state.token_usage,
-                by_model: &self.state.session.meta.usage_by_model,
+                by_model: self.state.session.usage_by_model(),
                 model: &self.state.model,
                 fast: self.state.fast,
                 quota: quota.as_deref(),

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -393,7 +393,7 @@ impl Chat {
 
 pub fn history_to_display(
     messages: &[Message],
-    tool_outputs: &HashMap<String, ToolOutput>,
+    tool_outputs: &HashMap<String, Arc<ToolOutput>>,
     tool_output_lines: &ToolOutputLines,
 ) -> (Vec<DisplayMessage>, Vec<maki_lua::RestoreItem>) {
     let results = build_tool_results_map(messages);
@@ -433,7 +433,7 @@ pub fn history_to_display(
                                     (s, Some(&**text))
                                 })
                                 .unwrap_or((ToolStatus::Success, None));
-                            let stored = tool_outputs.get(id.as_str());
+                            let stored = tool_outputs.get(id.as_str()).map(Arc::as_ref);
                             let (text, truncated_lines, tool_output, mut annotation) =
                                 build_loaded_tool(
                                     static_name,
@@ -644,7 +644,7 @@ mod tests {
         }
     }
 
-    fn empty_outputs() -> HashMap<String, ToolOutput> {
+    fn empty_outputs() -> HashMap<String, Arc<ToolOutput>> {
         HashMap::new()
     }
 
@@ -868,7 +868,7 @@ mod tests {
         for (tool_name, input_json, output) in variants {
             let discriminant = std::mem::discriminant(&output);
             let msgs = tool_use_pair(tool_name, input_json, "ok", false);
-            let outputs = HashMap::from([("t1".into(), output)]);
+            let outputs = HashMap::from([("t1".into(), Arc::new(output))]);
             let display = history_to_display(&msgs, &outputs, &ToolOutputLines::default()).0;
             assert_eq!(
                 std::mem::discriminant(display[0].tool_output.as_deref().unwrap()),
@@ -891,7 +891,7 @@ mod tests {
             "wrote 12 bytes",
             false,
         );
-        let outputs = HashMap::from([("t1".into(), write_output)]);
+        let outputs = HashMap::from([("t1".into(), Arc::new(write_output))]);
         let display = history_to_display(&msgs, &outputs, &ToolOutputLines::default()).0;
         assert!(display[0].annotation.is_some());
     }
@@ -994,7 +994,7 @@ mod tests {
             "edited a",
             false,
         );
-        let outputs = HashMap::from([("t1".to_owned(), edit_output("a"))]);
+        let outputs = HashMap::from([("t1".to_owned(), Arc::new(edit_output("a")))]);
         let (_, items) = history_to_display(&msgs, &outputs, &ToolOutputLines::default());
         assert!(items.is_empty(), "Rust owns Diff rendering on restore");
 

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -153,11 +153,11 @@ struct SpawnCtx {
 
 impl SpawnCtx {
     fn spawn_runtime(&self, session: AppSession) -> SessionRuntime {
-        let resumed = !session.messages.is_empty();
+        let resumed = !session.messages().is_empty();
         let permissions = Arc::new(self.permissions.fork());
         let handles = AgentHandles::spawn(
             &self.model_slot,
-            session.messages.clone(),
+            session.messages().to_vec(),
             self.config.clone(),
             self.ui_config.tool_output_lines,
             &permissions,
@@ -333,7 +333,6 @@ impl<'t> EventLoop<'t> {
             crate::update::spawn_check();
         });
 
-        let storage_writer = Arc::new(StorageWriter::new(storage.clone()));
         let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
         let (mcp_handle, mcp_config_errors) = smol::block_on(mcp::start(&cwd));
 
@@ -349,6 +348,7 @@ impl<'t> EventLoop<'t> {
             provider,
         }));
         let bg = spawn_model_fetch(&model_slot, timeouts);
+        let storage_writer = Arc::new(StorageWriter::new(storage.clone(), bg.warn_tx.clone()));
 
         let ctx = SpawnCtx {
             storage,
@@ -421,6 +421,7 @@ impl<'t> EventLoop<'t> {
             if let Err(e) = self.drain_channels() {
                 break Err(e);
             }
+            self.checkpoint_all();
             let app = &mut self.sessions[self.focused].app;
             if let Err(e) = self.terminal.draw(|f| {
                 app.view(f);
@@ -492,6 +493,15 @@ impl<'t> EventLoop<'t> {
             Wake::Warn(warning) => self.focused_app().flash(warning),
         }
         Ok(())
+    }
+
+    /// The one save trigger. A checkpoint writes only on a real change, so
+    /// every tool result reaches disk within a frame while an idle session
+    /// writes nothing.
+    fn checkpoint_all(&mut self) {
+        for rt in &mut self.sessions {
+            rt.app.checkpoint();
+        }
     }
 
     fn tick(&mut self) {
@@ -689,7 +699,7 @@ impl<'t> EventLoop<'t> {
                     let _ = self.submit_text(idx, prompt);
                 }
                 if focus {
-                    self.set_focus(idx);
+                    self.focused = idx;
                 }
                 let _ = reply_tx.send(Ok(json!(id)));
             }
@@ -714,15 +724,12 @@ impl<'t> EventLoop<'t> {
                 let reply = (|| {
                     let id = parse_session_id(&id)?;
                     if let Some(i) = self.position(id) {
-                        let app = &mut self.sessions[i].app;
-                        app.state.session.title = title;
-                        app.save_session();
+                        self.sessions[i].app.state.session_mut().set_title(title);
                     } else {
                         let mut session =
                             AppSession::load(id, &self.ctx.storage).map_err(|e| e.to_string())?;
-                        session.title = title;
-                        session.updated_at = maki_storage::now_epoch();
-                        self.ctx.storage_writer.send(Box::new(session));
+                        session.set_title(title);
+                        self.ctx.storage_writer.send(Arc::new(session));
                     }
                     Ok(json!(true))
                 })();
@@ -767,20 +774,12 @@ impl<'t> EventLoop<'t> {
         self.sessions.len() - 1
     }
 
-    fn set_focus(&mut self, idx: usize) {
-        if idx == self.focused {
-            return;
-        }
-        self.sessions[self.focused].app.save_session();
-        self.focused = idx;
-    }
-
     /// Focus a live session, or bring a stored one up: in place when the
     /// focused session is a blank idle one (nothing worth keeping), otherwise
     /// as a new runtime so the session you came from stays live.
     fn focus_session(&mut self, id: MakiId) -> Result<(), String> {
         if let Some(i) = self.position(id) {
-            self.set_focus(i);
+            self.focused = i;
             return Ok(());
         }
         let focused = &mut self.sessions[self.focused];
@@ -792,7 +791,7 @@ impl<'t> EventLoop<'t> {
         let session = AppSession::load(id, &self.ctx.storage)
             .map_err(|e| format!("Failed to load session: {e}"))?;
         let idx = self.push_runtime(self.ctx.spawn_runtime(session));
-        self.set_focus(idx);
+        self.focused = idx;
         Ok(())
     }
 
@@ -1101,10 +1100,10 @@ impl<'t> EventLoop<'t> {
             let SessionRuntime {
                 mut app, handles, ..
             } = rt;
-            app.save_session();
+            app.checkpoint_now();
             // `app` drops at the end of this iteration, closing the
             // channels the agent loop waits on, so `join_all` can finish.
-            tabs.push(app.state.session);
+            tabs.push(Arc::unwrap_or_clone(app.state.session));
             agent_tasks.push(handles.into_task());
         }
         let save_sessions_ms = lap();

--- a/maki-ui/src/storage_writer.rs
+++ b/maki-ui/src/storage_writer.rs
@@ -2,183 +2,193 @@
 //!
 //! Apps post session snapshots keyed by session id; the writer thread drains
 //! the newest snapshot of every session per wake and performs O(delta)
-//! appends. Deletes run on the same thread, so an append and a delete of the
-//! same session can never race: a queued save cannot resurrect deleted files.
+//! appends. Deletes travel through the same per-session slot as saves, so
+//! whichever the app asked for last is what reaches disk.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::mem;
-use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use maki_storage::StateDir;
 use maki_storage::id::MakiId;
 use maki_storage::sessions::{SESSIONS_DIR, SessionError, SessionLog};
+use maki_storage::{StateDir, StorageError};
 use tracing::warn;
 
 use crate::AppSession;
 
-type Pending = Arc<Mutex<HashMap<MakiId, Box<AppSession>>>>;
+const SAVE_FAILED_PREFIX: &str = "Session save failed";
+const SAVE_RECOVERED: &str = "Session save recovered";
+
+type Pending = Arc<Mutex<HashMap<MakiId, Entry>>>;
 
 type DeleteCallback = Box<dyn FnOnce(Result<(), SessionError>) + Send>;
 
-enum Op {
-    Flush,
-    Delete { id: MakiId, done: DeleteCallback },
+/// One slot per session, holding whatever the app asked for last. Deletes
+/// used to ride a side channel, where a flush queued before a delete could
+/// drain a save enqueued after it, so the delete unlinked a session the app
+/// had just saved.
+enum Entry {
+    Save(Arc<AppSession>),
+    Delete(DeleteCallback),
 }
 
 pub struct StorageWriter {
     pending: Pending,
-    ops: flume::Sender<Op>,
+    wake: flume::Sender<()>,
     done_rx: flume::Receiver<()>,
 }
 
 impl StorageWriter {
-    pub fn new(dir: StateDir) -> Self {
+    pub fn new(dir: StateDir, warn_tx: flume::Sender<String>) -> Self {
         let pending: Pending = Arc::default();
         let writer_pending = Arc::clone(&pending);
-        let (ops, ops_rx) = flume::unbounded::<Op>();
+        let (wake, wake_rx) = flume::unbounded::<()>();
         let (done_tx, done_rx) = flume::bounded::<()>(1);
 
         std::thread::Builder::new()
             .name("storage-writer".into())
             .spawn(move || {
-                let mut logs: HashMap<MakiId, SessionLog> = HashMap::new();
-                while let Ok(op) = ops_rx.recv() {
-                    match op {
-                        Op::Flush => flush(&writer_pending, &mut logs, &dir),
-                        Op::Delete { id, done } => {
-                            lock(&writer_pending).remove(&id);
-                            logs.remove(&id);
-                            done(AppSession::delete(id, &dir));
-                        }
-                    }
+                let mut writer = Writer {
+                    dir,
+                    warn_tx,
+                    logs: HashMap::new(),
+                    failing: HashSet::new(),
+                };
+                while wake_rx.recv().is_ok() {
+                    writer.flush(&writer_pending);
                 }
-                flush(&writer_pending, &mut logs, &dir);
+                writer.flush(&writer_pending);
                 let _ = done_tx.send(());
             })
             .expect("failed to spawn storage writer thread");
 
         Self {
             pending,
-            ops,
+            wake,
             done_rx,
         }
     }
 
-    pub fn send(&self, session: Box<AppSession>) {
-        let mut pending = lock(&self.pending);
-        let was_empty = pending.is_empty();
-        pending.insert(session.id, session);
-        drop(pending);
-        if was_empty {
-            let _ = self.ops.send(Op::Flush);
-        }
+    pub fn send(&self, session: Arc<AppSession>) {
+        self.enqueue(session.id, Entry::Save(session));
     }
 
-    /// Delete a session's files on the writer thread, discarding any pending
-    /// snapshot first. Runs after already-queued flushes; `done` fires on the
-    /// writer thread, so callers never block on disk.
+    /// Delete a session's files on the writer thread; `done` fires there, so
+    /// callers never block on disk. Deleting a session that was never written
+    /// reports success, and a save enqueued afterwards supersedes the delete.
     pub fn delete(&self, id: MakiId, done: impl FnOnce(Result<(), SessionError>) + Send + 'static) {
-        let op = Op::Delete {
-            id,
-            done: Box::new(done),
-        };
-        if let Err(flume::SendError(Op::Delete { done, .. })) = self.ops.send(op) {
+        self.enqueue(id, Entry::Delete(Box::new(done)));
+    }
+
+    fn enqueue(&self, id: MakiId, entry: Entry) {
+        lock(&self.pending).insert(id, entry);
+        if self.wake.send(()).is_err()
+            && let Some(Entry::Delete(done)) = lock(&self.pending).remove(&id)
+        {
             done(Err(writer_gone()));
         }
     }
 
     pub fn shutdown(self, timeout: Duration) {
-        drop(self.ops);
+        drop(self.wake);
         if self.done_rx.recv_timeout(timeout).is_err() {
             warn!("storage writer did not drain within {timeout:?}");
         }
     }
 }
 
-fn lock(pending: &Pending) -> std::sync::MutexGuard<'_, HashMap<MakiId, Box<AppSession>>> {
+fn lock(pending: &Pending) -> std::sync::MutexGuard<'_, HashMap<MakiId, Entry>> {
     pending.lock().unwrap_or_else(|e| e.into_inner())
 }
 
 fn writer_gone() -> SessionError {
-    maki_storage::StorageError::Io(io::Error::other("storage writer unavailable")).into()
+    StorageError::Io(io::Error::other("storage writer unavailable")).into()
 }
 
-fn flush(pending: &Pending, logs: &mut HashMap<MakiId, SessionLog>, dir: &StateDir) {
-    let batch = mem::take(&mut *lock(pending));
-    if batch.is_empty() {
-        return;
-    }
-    let sessions_dir = match dir.ensure_subdir(SESSIONS_DIR) {
-        Ok(d) => d,
-        Err(e) => {
-            warn!(error = %e, "failed to ensure sessions dir");
-            return;
-        }
-    };
-    for session in batch.into_values() {
-        write_session(&sessions_dir, logs, &session);
-    }
+/// Everything the writer thread owns. It never leaves that thread, so nothing
+/// here needs a lock.
+struct Writer {
+    dir: StateDir,
+    warn_tx: flume::Sender<String>,
+    /// Only cursors that still describe their file.
+    logs: HashMap<MakiId, SessionLog>,
+    /// Sessions whose last write failed, so a sick disk warns once instead of
+    /// once per frame.
+    failing: HashSet<MakiId>,
 }
 
-fn write_session(
-    sessions_dir: &Path,
-    logs: &mut HashMap<MakiId, SessionLog>,
-    session: &AppSession,
-) {
-    if let Some(log) = logs.get_mut(&session.id) {
-        if !append_or_compact(log, sessions_dir, session) {
-            logs.remove(&session.id);
-        }
-        return;
+impl Writer {
+    fn forget(&mut self, id: MakiId) {
+        self.logs.remove(&id);
+        self.failing.remove(&id);
     }
-    let mut log = match open_or_create_log(sessions_dir, session) {
-        Ok(l) => l,
-        Err(e) => {
-            warn!(error = %e, id = %session.id, "session log open failed");
-            return;
-        }
-    };
-    if append_or_compact(&mut log, sessions_dir, session) {
-        logs.insert(session.id, log);
-    }
-}
 
-/// False means the log's cursors are unusable and it must not stay cached.
-fn append_or_compact(log: &mut SessionLog, sessions_dir: &Path, session: &AppSession) -> bool {
-    match log.append(session) {
-        Ok(()) => true,
-        Err(SessionError::CursorAhead { .. }) => match log.compact(sessions_dir, session) {
-            Ok(()) => true,
-            Err(e) => {
-                warn!(error = %e, id = %session.id, "compact fallback failed");
-                false
+    fn flush(&mut self, pending: &Pending) {
+        // Bound first: a `for` head temporary lives for the whole loop, so
+        // iterating the guard directly would deadlock the re-insert below.
+        let batch = mem::take(&mut *lock(pending));
+        for (id, entry) in batch {
+            match entry {
+                Entry::Save(session) => {
+                    let result = self.write(&session);
+                    if result.is_err() {
+                        // `checkpoint` never resends an unchanged revision, so
+                        // a dropped snapshot would miss disk for good.
+                        // `or_insert` lets a newer op win; the shutdown flush
+                        // is the last retry.
+                        lock(pending).entry(id).or_insert(Entry::Save(session));
+                    }
+                    self.report(id, result);
+                }
+                Entry::Delete(done) => {
+                    self.forget(id);
+                    done(match AppSession::delete(id, &self.dir) {
+                        Err(SessionError::Storage(StorageError::NotFound(_))) => Ok(()),
+                        result => result,
+                    });
+                }
             }
-        },
-        Err(e) => {
-            warn!(error = %e, id = %session.id, "append failed");
-            true
         }
     }
-}
 
-fn open_or_create_log(
-    sessions_dir: &Path,
-    session: &AppSession,
-) -> Result<SessionLog, maki_storage::sessions::SessionError> {
-    let jsonl_path = sessions_dir.join(format!("{}.jsonl", session.id));
-    if jsonl_path.exists() {
-        let id = session.id;
-        let (_loaded, log) = SessionLog::open::<
-            maki_providers::Message,
-            maki_providers::TokenUsage,
-            maki_agent::ToolOutput,
-        >(sessions_dir, id)?;
-        Ok(log)
-    } else {
-        AppSession::migrate_to_jsonl(sessions_dir, session)
+    fn write(&mut self, session: &AppSession) -> Result<(), SessionError> {
+        let sessions_dir = self.dir.ensure_subdir(SESSIONS_DIR)?;
+        if let Some(mut log) = self.logs.remove(&session.id) {
+            // A failed `append` rolls the file back to the last record boundary,
+            // so the cursor still fits and is worth keeping: rebuilding it costs
+            // a second full write, the last thing a failing disk needs.
+            // Divergence is the one answer a cursor cannot survive.
+            let appended = log.append(session);
+            if !matches!(appended, Err(SessionError::LogDiverged { .. })) {
+                self.logs.insert(session.id, log);
+                return appended;
+            }
+        }
+        // No usable cursor, whether because this thread never wrote the file
+        // or because the log diverged, so the file starts over. Reading the
+        // old file back gains nothing: a cursor recovered from disk describes
+        // the session that was stored, never the live one.
+        self.logs
+            .insert(session.id, SessionLog::rewrite(&sessions_dir, session)?);
+        Ok(())
+    }
+
+    fn report(&mut self, id: MakiId, result: Result<(), impl std::fmt::Display>) {
+        match result {
+            Ok(()) => {
+                if self.failing.remove(&id) {
+                    let _ = self.warn_tx.send(SAVE_RECOVERED.to_string());
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, %id, "session write failed");
+                if self.failing.insert(id) {
+                    let _ = self.warn_tx.send(format!("{SAVE_FAILED_PREFIX}: {e}"));
+                }
+            }
+        }
     }
 }
 
@@ -188,6 +198,13 @@ mod tests {
     use tempfile::TempDir;
 
     const DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+    const MODEL: &str = "test-model";
+    const CWD: &str = "/tmp/writer";
+    const MSG_PREFIX: &str = "msg-";
+    const RESUMED_MSG: &str = "resumed";
+    const TOOL_ID: &str = "tool-1";
+    const TOOL_TEXT: &str = "tool output";
+    const TITLE: &str = "renamed after reload";
 
     fn state_dir() -> (TempDir, StateDir) {
         let tmp = TempDir::new().unwrap();
@@ -195,19 +212,46 @@ mod tests {
         (tmp, dir)
     }
 
+    fn writer(dir: &StateDir) -> (StorageWriter, flume::Receiver<String>) {
+        let (warn_tx, warn_rx) = flume::unbounded();
+        (StorageWriter::new(dir.clone(), warn_tx), warn_rx)
+    }
+
+    fn message_texts(session: &AppSession) -> Vec<String> {
+        session
+            .messages()
+            .iter()
+            .map(|m| m.user_text().unwrap_or_default().to_string())
+            .collect()
+    }
+
+    fn msg_text(n: usize) -> String {
+        format!("{MSG_PREFIX}{n}")
+    }
+
+    fn user_message(n: usize) -> maki_providers::Message {
+        maki_providers::Message::user(msg_text(n))
+    }
+
+    /// A plain file where the sessions dir should be. `create_dir_all` cannot
+    /// turn that into a directory, so every flush fails until it is removed.
+    fn block_sessions_dir(dir: &StateDir) {
+        std::fs::write(dir.path().join(SESSIONS_DIR), "").unwrap();
+    }
+
     /// Snapshots must coalesce per session id, not into one `latest` slot:
     /// two racing sessions used to silently drop one.
     #[test]
     fn shutdown_drains_newest_snapshot_of_every_session() {
         let (_tmp, dir) = state_dir();
-        let writer = StorageWriter::new(dir.clone());
+        let (writer, _warn_rx) = writer(&dir);
         let a = AppSession::new("test-model", "/tmp/a");
         let mut b = AppSession::new("test-model", "/tmp/b");
         let (a_id, b_id) = (a.id, b.id);
-        writer.send(Box::new(a));
-        writer.send(Box::new(b.clone()));
-        b.title = "renamed".into();
-        writer.send(Box::new(b));
+        writer.send(Arc::new(a));
+        writer.send(Arc::new(b.clone()));
+        b.set_title("renamed".into());
+        writer.send(Arc::new(b));
         writer.shutdown(DRAIN_TIMEOUT);
 
         assert!(AppSession::load(a_id, &dir).is_ok());
@@ -217,10 +261,10 @@ mod tests {
     #[test]
     fn delete_discards_pending_snapshot() {
         let (_tmp, dir) = state_dir();
-        let writer = StorageWriter::new(dir.clone());
+        let (writer, _warn_rx) = writer(&dir);
         let session = AppSession::new("test-model", "/tmp/c");
         let id = session.id;
-        writer.send(Box::new(session));
+        writer.send(Arc::new(session));
         let (done_tx, done_rx) = flume::bounded(1);
         writer.delete(id, move |res| {
             let _ = done_tx.send(res);
@@ -229,5 +273,158 @@ mod tests {
 
         assert!(done_rx.recv().unwrap().is_ok());
         assert!(AppSession::load(id, &dir).is_err());
+    }
+
+    /// A fresh writer over an existing file has no cursor, so it re-opens the
+    /// log and gets cursors for the loaded session, not the live one. The first
+    /// append must diverge into a full rewrite instead of landing on stale
+    /// offsets.
+    #[test]
+    fn reopened_log_rewrites_diverged_file_instead_of_appending() {
+        let (_tmp, dir) = state_dir();
+        let mut session = AppSession::new(MODEL, CWD);
+        let id = session.id;
+        for i in 0..5 {
+            session.push_message(user_message(i));
+        }
+        let (first, _first_warn_rx) = writer(&dir);
+        first.send(Arc::new(session.clone()));
+        first.shutdown(DRAIN_TIMEOUT);
+
+        session.truncate_messages(2);
+        session.push_message(maki_providers::Message::user(RESUMED_MSG.into()));
+        session.insert_tool_output(
+            TOOL_ID.into(),
+            maki_agent::ToolOutput::Plain(TOOL_TEXT.to_string().into()),
+        );
+        session.set_title(TITLE.into());
+
+        let (second, second_warn_rx) = writer(&dir);
+        second.send(Arc::new(session.clone()));
+        second.shutdown(DRAIN_TIMEOUT);
+
+        let loaded = AppSession::load(id, &dir).unwrap();
+        assert_eq!(
+            message_texts(&loaded),
+            [msg_text(0), msg_text(1), RESUMED_MSG.to_string()]
+        );
+        assert_eq!(loaded.title, TITLE);
+        match loaded.tool_outputs().get(TOOL_ID).map(Arc::as_ref) {
+            Some(maki_agent::ToolOutput::Plain(out)) => assert_eq!(out.text, TOOL_TEXT),
+            other => panic!("tool output lost: {other:?}"),
+        }
+        assert!(second_warn_rx.is_empty());
+    }
+
+    /// A disk that keeps failing warns once, not once per frame, and says so
+    /// exactly once when writes start working again.
+    #[test]
+    fn failing_flush_warns_once_and_reports_recovery() {
+        let (_tmp, dir) = state_dir();
+        block_sessions_dir(&dir);
+        let (writer, warn_rx) = writer(&dir);
+        let session = Arc::new(AppSession::new(MODEL, CWD));
+        let id = session.id;
+
+        writer.send(Arc::clone(&session));
+        let warning = warn_rx.recv_timeout(DRAIN_TIMEOUT).unwrap();
+        assert!(warning.starts_with(SAVE_FAILED_PREFIX), "{warning}");
+
+        // The save is enqueued before the delete, so the flush that runs the
+        // delete has already drained it; a repeat failure must stay silent.
+        writer.send(Arc::clone(&session));
+        let (done_tx, done_rx) = flume::bounded(1);
+        writer.delete(MakiId::generate(), move |res| {
+            let _ = done_tx.send(res);
+        });
+        assert!(done_rx.recv_timeout(DRAIN_TIMEOUT).unwrap().is_err());
+        assert!(warn_rx.is_empty(), "second failure warned again");
+
+        std::fs::remove_file(dir.path().join(SESSIONS_DIR)).unwrap();
+        writer.send(session);
+        let recovered = warn_rx.recv_timeout(DRAIN_TIMEOUT).unwrap();
+        assert_eq!(recovered, SAVE_RECOVERED);
+        writer.shutdown(DRAIN_TIMEOUT);
+
+        assert!(warn_rx.is_empty());
+        assert!(AppSession::load(id, &dir).is_ok());
+    }
+
+    /// A save enqueued after a delete must win: clear a draft and retype it
+    /// fast enough, and the queued delete used to unlink the file the retype
+    /// had just saved.
+    #[test]
+    fn save_enqueued_after_delete_survives() {
+        let (_tmp, dir) = state_dir();
+        let (writer, warn_rx) = writer(&dir);
+        let mut session = AppSession::new(MODEL, CWD);
+        let id = session.id;
+        session.push_message(user_message(0));
+        writer.send(Arc::new(session.clone()));
+        writer.delete(id, |_| {});
+        session.push_message(maki_providers::Message::user(RESUMED_MSG.into()));
+        writer.send(Arc::new(session));
+        writer.shutdown(DRAIN_TIMEOUT);
+
+        let loaded = AppSession::load(id, &dir).unwrap();
+        assert_eq!(
+            message_texts(&loaded),
+            [msg_text(0), RESUMED_MSG.to_string()]
+        );
+        assert!(warn_rx.is_empty());
+    }
+
+    /// A failed write stays queued: `checkpoint` never resends an unchanged
+    /// revision, so the writer owns the retry, and the shutdown flush is the
+    /// last one.
+    #[test]
+    fn failed_write_is_retried_by_a_later_flush() {
+        let (_tmp, dir) = state_dir();
+        block_sessions_dir(&dir);
+        let (writer, warn_rx) = writer(&dir);
+        let session = Arc::new(AppSession::new(MODEL, CWD));
+        let id = session.id;
+
+        writer.send(session);
+        let warning = warn_rx.recv_timeout(DRAIN_TIMEOUT).unwrap();
+        assert!(warning.starts_with(SAVE_FAILED_PREFIX), "{warning}");
+
+        std::fs::remove_file(dir.path().join(SESSIONS_DIR)).unwrap();
+        writer.shutdown(DRAIN_TIMEOUT);
+
+        assert!(AppSession::load(id, &dir).is_ok());
+        assert_eq!(warn_rx.recv_timeout(DRAIN_TIMEOUT).unwrap(), SAVE_RECOVERED);
+    }
+
+    /// After a delete the cursor still holds an open handle to the unlinked
+    /// file, which still looks unchanged, so an append would write the session
+    /// into nothing. Forgetting the cursor makes the next snapshot write a
+    /// whole file.
+    #[test]
+    fn session_recreated_after_delete_is_written_in_full() {
+        let (_tmp, dir) = state_dir();
+        let (writer, warn_rx) = writer(&dir);
+        let mut session = AppSession::new(MODEL, CWD);
+        let id = session.id;
+        session.push_message(user_message(0));
+        writer.send(Arc::new(session.clone()));
+
+        let (done_tx, done_rx) = flume::bounded(1);
+        writer.delete(id, move |res| {
+            let _ = done_tx.send(res);
+        });
+        done_rx.recv_timeout(DRAIN_TIMEOUT).unwrap().unwrap();
+        assert!(AppSession::load(id, &dir).is_err());
+
+        session.push_message(maki_providers::Message::user(RESUMED_MSG.into()));
+        writer.send(Arc::new(session));
+        writer.shutdown(DRAIN_TIMEOUT);
+
+        let loaded = AppSession::load(id, &dir).unwrap();
+        assert_eq!(
+            message_texts(&loaded),
+            [msg_text(0), RESUMED_MSG.to_string()]
+        );
+        assert!(warn_rx.is_empty());
     }
 }

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -292,7 +292,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
 
     loop {
         for session in &mut tabs {
-            if session.messages.is_empty() {
+            if session.messages().is_empty() {
                 session.meta.fast |= stack.config.always_fast;
                 session.meta.workflow |= stack.config.always_workflow;
                 if let Some(thinking) = stack.config.always_thinking {
@@ -301,7 +301,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
             }
         }
         let focused_tab = &tabs[focused];
-        let model = if focused_tab.messages.is_empty() {
+        let model = if focused_tab.messages().is_empty() {
             stack.model.clone()
         } else {
             Model::from_spec(&focused_tab.model).unwrap_or_else(|_| stack.model.clone())

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -654,11 +654,11 @@ fn resolve_session(cli: &Cli, cwd: &str) -> Result<(Option<SessionRef>, Vec<Mess
         let session = StoredSession::load(session_ref.id(), &storage)
             .map_err(|e| eyre!("load session {id}: {e}"))?;
         let resumed = (!cli.fork_session).then_some(session_ref);
-        (resumed, session.messages)
+        (resumed, session.take_messages())
     } else if cli.continue_session {
         let storage = StateDir::resolve().context("resolve state dir")?;
         match StoredSession::latest(cwd, &storage) {
-            Ok(Some(session)) => (Some(SessionRef::from(session.id)), session.messages),
+            Ok(Some(session)) => (Some(SessionRef::from(session.id)), session.take_messages()),
             _ => (None, Vec::new()),
         }
     } else {


### PR DESCRIPTION
A crash used to throw away a whole turn plus the input draft, because saving was a side effect scattered across eight call sites that only fired at turn boundaries (#675).

The event loop now checkpoints every session once per frame and writes only when a mutator really changed something, so a tool result reaches disk within a frame, an idle session writes nothing, and a draft waits up to a second because a keystroke is not worth an `fsync`.

Writing that often needs `Session` to classify its own changes: `revision` says it needs writing, `content_revision` says it can wait, and `epoch` says the log must be rewritten instead of appended.

`History` in `maki-agent` is now the single producer of messages and its mirror is a verbatim copy, so a mid-batch snapshot no longer carries a synthetic `[Tool result not available]` that shadowed the real results forever.

A session that loses its last draft is deleted again, or the picker would offer one with nothing in it, and a log this process did not write is replaced outright, since a cursor read back from disk never fits the live session.

Closes #675