### PR TITLE
fix(ui): show last turn usage on task rows, not a sum over turns

### DIFF
--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -74,8 +74,9 @@ fn dispatch_ctx<'a>(ctx: &'a LuaCtx, method: &str) -> Result<&'a AgentContext, S
 }
 
 /// Forwards subagent events to the parent, stamped with the subagent identity.
-/// Usage takes two paths: live on the tool header while the run goes on, and one
-/// total per run on `usage_tx`, which `prompt` waits for.
+/// Usage takes two paths: live on the tool header while the run goes on (last
+/// turn's tokens plus the run's summed cost), and one total per run on
+/// `usage_tx`, which `prompt` waits for.
 async fn relay_session_events(
     sub_rx: flume::Receiver<Envelope>,
     parent_tx: EventSender,
@@ -83,15 +84,13 @@ async fn relay_session_events(
     usage_tx: flume::Sender<TokenUsage>,
     live_sink: Option<flume::Sender<ToolLive>>,
 ) {
-    let mut cumulative = TokenUsage::default();
     let mut cost = None;
     while let Ok(mut envelope) = sub_rx.recv_async().await {
         match &envelope.event {
             AgentEvent::TurnComplete(turn) => {
-                cumulative += turn.usage;
                 add_cost(&mut cost, turn.cost);
                 if let Some(sink) = &live_sink {
-                    let _ = sink.send(ToolLive::Usage(cumulative.format(cost)));
+                    let _ = sink.send(ToolLive::Usage(turn.usage.format_sum_cost(cost)));
                 }
             }
             AgentEvent::Done { usage, .. } => {
@@ -899,7 +898,6 @@ mod tests {
     const RUN_ID: u64 = 7;
     const PARENT_ID: &str = "task-1";
     const IGNORED_ERROR: &str = "handled by the session caller";
-    const EXPECTED_LIVE: &[&str] = &["100↑ 20↓ $0.250", "150↑ 30↓ $0.750"];
     const DONE_USAGE: TokenUsage = tokens(150, 30);
 
     const fn tokens(input: u32, output: u32) -> TokenUsage {
@@ -977,11 +975,15 @@ mod tests {
                 _ => panic!("relay must only publish usage"),
             })
             .collect::<Vec<_>>();
-        assert_eq!(live, EXPECTED_LIVE);
+        let expected = [
+            tokens(100, 20).format_sum_cost(Some(0.25)),
+            tokens(50, 10).format_sum_cost(Some(0.75)),
+        ];
+        assert_eq!(live, expected);
         assert_eq!(usage_rx.try_recv(), Ok(DONE_USAGE));
 
         let forwarded = parent_rx.drain().collect::<Vec<_>>();
-        assert_eq!(forwarded.len(), EXPECTED_LIVE.len());
+        assert_eq!(forwarded.len(), expected.len());
         assert!(forwarded.iter().all(|envelope| {
             matches!(envelope.event, AgentEvent::TurnComplete(_))
                 && envelope

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -447,13 +447,22 @@ impl TokenUsage {
     }
 
     pub fn format(&self, cost: Option<f64>) -> String {
+        self.format_cost(cost, "")
+    }
+
+    /// Like [`format`](Self::format), but marks the cost as a running total.
+    pub fn format_sum_cost(&self, cost: Option<f64>) -> String {
+        self.format_cost(cost, "Σ")
+    }
+
+    fn format_cost(&self, cost: Option<f64>, prefix: &str) -> String {
         let tokens = format!(
             "{}↑ {}↓",
             format_tokens(self.total_input()),
             format_tokens(self.output)
         );
         match cost {
-            Some(cost) => format!("{tokens} ${cost:.3}"),
+            Some(cost) => format!("{tokens} {prefix}${cost:.3}"),
             None => tokens,
         }
     }
@@ -529,6 +538,18 @@ mod tests {
     #[test_case(TokenUsage { input: u32::MAX, output: 1, cache_creation: 1, cache_read: 1 }, None, "4295.0m↑ 1↓" ; "input_saturates")]
     fn usage_formatting(usage: TokenUsage, cost: Option<f64>, expected: &str) {
         assert_eq!(usage.format(cost), expected);
+    }
+
+    #[test]
+    fn sum_marker_applies_only_to_the_cost() {
+        let usage = TokenUsage {
+            input: 12_000,
+            output: 456,
+            cache_creation: 200,
+            cache_read: 100,
+        };
+        assert_eq!(usage.format_sum_cost(Some(1.5)), "12.3k↑ 456↓ Σ$1.500");
+        assert_eq!(usage.format_sum_cost(None), usage.format(None));
     }
 
     #[test_case("no-slash-here", ModelError::InvalidFormat ; "invalid_format")]

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -1056,7 +1056,6 @@ impl App {
 
         if let AgentEvent::TurnComplete(ref tc) = envelope.event {
             self.state.token_usage += tc.usage;
-            self.chats[chat_idx].token_usage += tc.usage;
             add_cost(&mut self.chats[chat_idx].cost, tc.cost);
             self.state
                 .session_mut()
@@ -1068,8 +1067,7 @@ impl App {
             }
             self.chats[chat_idx].set_pending_turn_usage(tc.usage.format(tc.cost));
             if let Some(tool_id) = &subagent_id {
-                let chat = &self.chats[chat_idx];
-                let formatted = chat.token_usage.format(chat.cost);
+                let formatted = tc.usage.format_sum_cost(self.chats[chat_idx].cost);
                 self.chats[0].set_tool_turn_usage(tool_id, formatted);
             }
         }

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -194,10 +194,12 @@ impl App {
         self.main_chat().load_messages(display_msgs);
         // The restored total predates any per-turn cost, so price it once with the
         // selected model. Later turns add their own exact cost.
-        let (usage, context_size) = (self.state.token_usage, self.state.context_size);
-        let cost = self.state.model.cost_of(&usage, self.state.fast);
+        let cost = self
+            .state
+            .model
+            .cost_of(&self.state.token_usage, self.state.fast);
+        let context_size = self.state.context_size;
         let main = self.main_chat();
-        main.token_usage = usage;
         main.cost = cost;
         main.context_size = context_size;
         if let Some(draft) = self.state.session.meta.input_draft.clone() {

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -733,8 +733,6 @@ fn turn_complete_tracks_usage_and_context_per_chat() {
 
     assert_eq!(app.state.token_usage.input, 300);
     assert_eq!(app.state.token_usage.output, 125);
-    assert_eq!(app.chats[0].token_usage.input, 100);
-    assert_eq!(app.chats[1].token_usage.input, 200);
     assert_eq!(app.chats[0].context_size, main_usage.context_tokens());
     assert_eq!(app.chats[1].context_size, sub_usage.context_tokens());
 }
@@ -763,28 +761,34 @@ fn sub_turn_complete() -> Msg {
     )
 }
 
-/// Uses the same formatter as the header: these tests pin which tool gets the
+/// Built with the header's own formatter: these tests pin which tool gets the
 /// usage, not how it is spelled (maki-providers covers the spelling).
-fn sub_usage_text(turns: u32) -> String {
-    let mut total = TokenUsage::default();
-    for _ in 0..turns {
-        total += SUB_TOKENS;
-    }
-    total.format(SUB_COST.map(|cost| cost * f64::from(turns)))
+fn sub_usage_text() -> String {
+    SUB_TOKENS.format_sum_cost(SUB_COST)
 }
 
 #[test]
-fn subagent_turn_complete_updates_matching_parent_header_cumulatively() {
+fn subagent_turn_complete_updates_matching_parent_header_with_last_turn() {
     let mut app = streaming_app();
     app.update(agent_msg(tool_start(TASK_ID, "task")));
     app.update(agent_msg(tool_start("task2", "task")));
 
     app.update(sub_turn_complete());
-    app.update(sub_turn_complete());
+    // The second turn's tokens differ, so a sum or a stale first turn would fail.
+    let last = TokenUsage {
+        input: 42,
+        ..SUB_TOKENS
+    };
+    app.update(subagent_msg(
+        turn_complete(last, "child-model", SUB_COST),
+        TASK_ID,
+        Some(SUBAGENT_NAME),
+    ));
 
+    let expected = last.format_sum_cost(SUB_COST.map(|cost| cost * 2.0));
     assert_eq!(
         app.chats[0].tool_turn_usage(TASK_ID),
-        Some(sub_usage_text(2).as_str())
+        Some(expected.as_str())
     );
     assert_eq!(app.chats[0].tool_turn_usage("task2"), None);
 }
@@ -806,7 +810,7 @@ fn parent_turn_flush_stamps_the_last_unstamped_tool(subagent_ran: bool) {
     app.update(agent_msg(tool_results_submitted()));
 
     let expected = if subagent_ran {
-        sub_usage_text(1)
+        sub_usage_text()
     } else {
         MAIN_TOKENS.format(MAIN_COST)
     };
@@ -836,7 +840,7 @@ fn tool_inside_subagent_chat_gets_its_turn_usage() {
 
     assert_eq!(
         app.chats[1].tool_turn_usage(TOOL_ID),
-        Some(sub_usage_text(1).as_str())
+        Some(SUB_TOKENS.format(SUB_COST).as_str())
     );
 }
 

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -15,7 +15,7 @@ use maki_agent::tools::{ToolInvocation, ToolRegistry, WRITE_TOOL_NAME};
 use maki_agent::{AgentEvent, BufferSnapshot, ToolDoneEvent, ToolOutput, ToolStartEvent};
 use maki_config::{ToolKey, ToolOutputLines, UiConfig};
 use maki_lua::WinView;
-use maki_providers::{ContentBlock, Message, Role, TokenUsage};
+use maki_providers::{ContentBlock, Message, Role};
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::Color;
@@ -42,7 +42,6 @@ pub enum ChatEventResult {
 
 pub struct Chat {
     pub name: String,
-    pub token_usage: TokenUsage,
     pub cost: Option<f64>,
     pub context_size: u32,
     pub model_id: Option<String>,
@@ -55,7 +54,6 @@ impl Chat {
     pub fn new(name: String, ui_config: UiConfig, lua_event_handle: maki_lua::EventHandle) -> Self {
         Self {
             name,
-            token_usage: TokenUsage::default(),
             cost: None,
             context_size: 0,
             model_id: None,


### PR DESCRIPTION
A task row summed every subagent turn, and since each turn resends the whole context, a long run showed something like `405.5k↑ 14.0k↓` that read as one giant request.

The header now shows the last turn only, so `↑` is the subagent's current context and `↓` its latest output, matching what regular tool rows mean.

Cost stays a running total because that is the number you actually care about, and `format_sum_cost` marks it `Σ$` so nobody mistakes it for one turn again.