### PR TITLE
fix(providers/google): preserve function_signature and Struct-shape tool results

### DIFF
--- a/maki-acp/src/translate.rs
+++ b/maki-acp/src/translate.rs
@@ -218,7 +218,9 @@ fn replay_assistant(msg: &Message, updates: &mut Vec<SessionUpdate>) {
         match block {
             MsgBlock::Text { text } => updates.push(text_delta(text)),
             MsgBlock::Thinking { thinking, .. } => updates.push(thinking_delta(thinking)),
-            MsgBlock::ToolUse { id, name, input } => {
+            MsgBlock::ToolUse {
+                id, name, input, ..
+            } => {
                 updates.push(replay_tool_call(id, name, input));
             }
             _ => {}
@@ -312,11 +314,7 @@ mod tests {
                 MsgBlock::Text {
                     text: "let me check".into(),
                 },
-                MsgBlock::ToolUse {
-                    id: "tu-1".into(),
-                    name: "bash".into(),
-                    input: serde_json::json!({"command": "ls"}),
-                },
+                MsgBlock::tool_use("tu-1", "bash", serde_json::json!({"command": "ls"})),
             ]),
             Message {
                 role: MsgRole::User,

--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -518,11 +518,7 @@ mod tests {
     fn tool_use(id: &str) -> Message {
         Message {
             role: Role::Assistant,
-            content: vec![ContentBlock::ToolUse {
-                id: id.into(),
-                name: "bash".into(),
-                input: serde_json::json!({}),
-            }],
+            content: vec![ContentBlock::tool_use(id, "bash", serde_json::json!({}))],
             ..Default::default()
         }
     }
@@ -679,11 +675,7 @@ mod tests {
         let mut messages = vec![
             Message {
                 role: Role::Assistant,
-                content: vec![ContentBlock::ToolUse {
-                    id: "t1".into(),
-                    name: "bash".into(),
-                    input: serde_json::json!({}),
-                }],
+                content: vec![ContentBlock::tool_use("t1", "bash", serde_json::json!({}))],
                 ..Default::default()
             },
             Message {
@@ -710,11 +702,7 @@ mod tests {
         let mut messages = vec![
             Message {
                 role: Role::Assistant,
-                content: vec![ContentBlock::ToolUse {
-                    id: "t1".into(),
-                    name: "bash".into(),
-                    input: serde_json::json!({}),
-                }],
+                content: vec![ContentBlock::tool_use("t1", "bash", serde_json::json!({}))],
                 ..Default::default()
             },
             Message::user("no tool result".into()),
@@ -769,11 +757,7 @@ mod tests {
             },
             Message {
                 role: Role::Assistant,
-                content: vec![ContentBlock::ToolUse {
-                    id: "t1".into(),
-                    name: "bash".into(),
-                    input: serde_json::json!({}),
-                }],
+                content: vec![ContentBlock::tool_use("t1", "bash", serde_json::json!({}))],
                 ..Default::default()
             },
             Message {

--- a/maki-agent/src/agent/history.rs
+++ b/maki-agent/src/agent/history.rs
@@ -215,11 +215,7 @@ mod tests {
             role: Role::Assistant,
             content: ids
                 .iter()
-                .map(|id| ContentBlock::ToolUse {
-                    id: id.to_string(),
-                    name: "read".into(),
-                    input: serde_json::json!({}),
-                })
+                .map(|id| ContentBlock::tool_use(*id, "read", serde_json::json!({})))
                 .collect(),
             ..Default::default()
         }

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -817,11 +817,11 @@ mod tests {
         StreamResponse {
             message: Message {
                 role: Role::Assistant,
-                content: vec![ContentBlock::ToolUse {
-                    id: tool_id.into(),
-                    name: tool_name.into(),
-                    input: serde_json::json!({"pattern": "*.nonexistent_test_xyz", "path": "/tmp"}),
-                }],
+                content: vec![ContentBlock::tool_use(
+                    tool_id,
+                    tool_name,
+                    serde_json::json!({"pattern": "*.nonexistent_test_xyz", "path": "/tmp"}),
+                )],
                 ..Default::default()
             },
             usage: TokenUsage::default(),
@@ -833,11 +833,7 @@ mod tests {
         StreamResponse {
             message: Message {
                 role: Role::Assistant,
-                content: vec![ContentBlock::ToolUse {
-                    id: "t1".into(),
-                    name: tool_name.into(),
-                    input,
-                }],
+                content: vec![ContentBlock::tool_use("t1", tool_name, input)],
                 ..Default::default()
             },
             usage: TokenUsage::default(),

--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -1573,11 +1573,7 @@ mod tests {
     #[test]
     fn new_seeds_loads_only_from_wire_names_in_history() {
         let (_inner, session) = setup(vec![fake_entry("srv", FakeTransport::new())]);
-        let tool_use = |name: &str| ContentBlock::ToolUse {
-            id: "t".into(),
-            name: name.into(),
-            input: json!({}),
-        };
+        let tool_use = |name: &str| ContentBlock::tool_use("t", name, json!({}));
         let history = vec![Message {
             role: Role::Assistant,
             content: vec![
@@ -1664,11 +1660,7 @@ mod tests {
         let (_inner, session) = setup(vec![entry_with_tools("srv", defs)]);
         let history = vec![Message {
             role: Role::Assistant,
-            content: vec![ContentBlock::ToolUse {
-                id: "t".into(),
-                name: "srv__do__thing".into(),
-                input: json!({}),
-            }],
+            content: vec![ContentBlock::tool_use("t", "srv__do__thing", json!({}))],
             display_text: None,
             ..Default::default()
         }];

--- a/maki-providers/src/providers/anthropic/shared.rs
+++ b/maki-providers/src/providers/anthropic/shared.rs
@@ -274,11 +274,8 @@ impl EventParser {
                                     name: name.clone(),
                                 })
                                 .await?;
-                            self.content_blocks.push(ContentBlock::ToolUse {
-                                id,
-                                name,
-                                input: Value::Null,
-                            });
+                            self.content_blocks
+                                .push(ContentBlock::tool_use(id, name, Value::Null));
                         }
                     }
                 }

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 use flume::Sender;
 use futures_lite::io::{AsyncBufReadExt, BufReader};
 use isahc::{AsyncReadResponseExt, HttpClient, Request};
-use maki_storage::id::SessionRef;
+use maki_storage::id::{MakiId, SessionRef};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use tracing::warn;
@@ -531,6 +531,43 @@ struct ApiModelInfo {
     supported_generation_methods: Vec<String>,
 }
 
+/// Append `text` to the last block when it is already a `Text`, else push a new
+/// `Text` block. Gemini streams a single assistant message as many small text
+/// parts across SSE chunks; coalescing keeps them as one content block so
+/// session restore renders one `maki>` block instead of one per delta.
+fn push_or_extend_text(blocks: &mut Vec<ContentBlock>, text: String) {
+    if let Some(ContentBlock::Text { text: prev }) = blocks.last_mut() {
+        prev.push_str(&text);
+    } else {
+        blocks.push(ContentBlock::Text { text });
+    }
+}
+
+/// Same as `push_or_extend_text` for thinking parts. The `thoughtSignature`
+/// arrives on the final thinking delta, so a later signature overwrites an
+/// earlier one; a `Some` on an earlier delta is preserved if the last is None.
+fn push_or_extend_thinking(
+    blocks: &mut Vec<ContentBlock>,
+    text: String,
+    signature: Option<String>,
+) {
+    if let Some(ContentBlock::Thinking {
+        thinking: prev,
+        signature: prev_sig,
+    }) = blocks.last_mut()
+    {
+        prev.push_str(&text);
+        if signature.is_some() {
+            *prev_sig = signature;
+        }
+    } else {
+        blocks.push(ContentBlock::Thinking {
+            thinking: text,
+            signature,
+        });
+    }
+}
+
 async fn parse_sse(
     response: isahc::Response<isahc::AsyncBody>,
     event_tx: &Sender<ProviderEvent>,
@@ -584,7 +621,7 @@ async fn parse_sse(
 
             for part in parts {
                 if let Some(func_call) = part.function_call {
-                    let id = format!("call_{}", func_call.name);
+                    let id = format!("call_{}_{}", func_call.name, MakiId::generate());
                     let input = func_call.args.unwrap_or_default();
                     let thought_signature = func_call.thought_signature.or(part.thought_signature);
                     event_tx
@@ -607,16 +644,13 @@ async fn parse_sse(
                                 .send_async(ProviderEvent::ThinkingDelta { text: text.clone() })
                                 .await?;
                         }
-                        content_blocks.push(ContentBlock::Thinking {
-                            thinking: text,
-                            signature: part.thought_signature,
-                        });
+                        push_or_extend_thinking(&mut content_blocks, text, part.thought_signature);
                     } else if !text.is_empty() {
                         // TODO: preserve part.thought_signature if ContentBlock::Text adds signature support.
                         event_tx
                             .send_async(ProviderEvent::TextDelta { text: text.clone() })
                             .await?;
-                        content_blocks.push(ContentBlock::Text { text });
+                        push_or_extend_text(&mut content_blocks, text);
                     }
                 }
             }
@@ -1037,6 +1071,78 @@ mod tests {
             &result.message.content[0],
             ContentBlock::Text { text } if text == "hello"
         ));
+    }
+
+    #[test]
+    fn parse_sse_coalesces_text_deltas_into_one_block() {
+        let event = |text: &str| {
+            format!(
+                "data: {{\"candidates\":[{{\"content\":{{\"parts\":[{{\"text\":\"{}\"}}]}}}}]}}\n\n",
+                text
+            )
+        };
+        let mut data = String::new();
+        data.push_str(&event("Hello, "));
+        data.push_str(&event("world."));
+        let response = mock_response(data.leak().as_bytes());
+        let (tx, _rx) = flume::unbounded();
+        let result = smol::block_on(parse_sse(response, &tx, Duration::from_secs(30))).unwrap();
+        assert_eq!(
+            result.message.content.len(),
+            1,
+            "expected one coalesced text block"
+        );
+        assert!(matches!(
+            &result.message.content[0],
+            ContentBlock::Text { text } if text == "Hello, world."
+        ));
+    }
+
+    #[test]
+    fn parse_sse_coalesces_thinking_deltas_keeps_last_signature() {
+        let event = |text: &str, sig: Option<&str>| match sig {
+            Some(s) => format!(
+                "data: {{\"candidates\":[{{\"content\":{{\"parts\":[{{\"text\":\"{}\",\"thought\":true,\"thoughtSignature\":\"{}\"}}]}}}}]}}\n\n",
+                text, s
+            ),
+            None => format!(
+                "data: {{\"candidates\":[{{\"content\":{{\"parts\":[{{\"text\":\"{}\",\"thought\":true}}]}}}}]}}\n\n",
+                text
+            ),
+        };
+        let mut data = String::new();
+        data.push_str(&event("reasoning... ", None));
+        data.push_str(&event("more.", Some("sig-final")));
+        let response = mock_response(data.leak().as_bytes());
+        let (tx, _rx) = flume::unbounded();
+        let result = smol::block_on(parse_sse(response, &tx, Duration::from_secs(30))).unwrap();
+        assert_eq!(result.message.content.len(), 1);
+        assert!(matches!(
+            &result.message.content[0],
+            ContentBlock::Thinking { thinking, signature }
+                if thinking == "reasoning... more." && signature.as_deref() == Some("sig-final")
+        ));
+    }
+
+    #[test]
+    fn parse_sse_parallel_same_name_tool_calls_get_unique_ids() {
+        let part = r#"{"functionCall":{"name":"bash","args":{"cmd":"ls"}}}"#;
+        let payload = format!(r#"{{"candidates":[{{"content":{{"parts":[{part},{part}]}}}}]}}"#,);
+        let data = format!("data: {payload}\n\n");
+        let response = mock_response(data.leak().as_bytes());
+        let (tx, _rx) = flume::unbounded();
+        let result = smol::block_on(parse_sse(response, &tx, Duration::from_secs(30))).unwrap();
+        let ids: Vec<&str> = result
+            .message
+            .content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::ToolUse { id, .. } => Some(id.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(ids.len(), 2, "expected two tool calls");
+        assert_ne!(ids[0], ids[1], "ids must be unique for parallel calls");
     }
 
     #[test]

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -356,21 +356,34 @@ fn convert_messages(messages: &[Message]) -> Vec<Value> {
                     parts.push(part);
                 }
                 ContentBlock::RedactedThinking { .. } => {}
-                ContentBlock::ToolUse { id: _, name, input } => {
-                    parts.push(json!({
+                ContentBlock::ToolUse {
+                    id: _,
+                    name,
+                    input,
+                    thought_signature,
+                } => {
+                    let mut part = json!({
                         "functionCall": {
                             "name": name,
                             "args": input,
                         }
-                    }));
+                    });
+                    if let Some(sig) = thought_signature {
+                        part["thoughtSignature"] = json!(sig);
+                    }
+                    parts.push(part);
                 }
                 ContentBlock::ToolResult {
                     tool_use_id,
                     content,
                     is_error,
                 } => {
-                    let mut response_val = serde_json::from_str(content)
-                        .unwrap_or_else(|_| json!({"result": content}));
+                    let parsed = serde_json::from_str::<Value>(content);
+                    let mut response_val = match parsed {
+                        Ok(Value::Object(map)) => Value::Object(map),
+                        Ok(other) => json!({"result": other}),
+                        Err(_) => json!({"result": content}),
+                    };
                     if *is_error {
                         response_val = json!({"error": response_val});
                     }
@@ -482,6 +495,8 @@ struct SsePart {
 struct SseFunctionCall {
     name: String,
     args: Option<Value>,
+    #[serde(default)]
+    thought_signature: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -571,6 +586,7 @@ async fn parse_sse(
                 if let Some(func_call) = part.function_call {
                     let id = format!("call_{}", func_call.name);
                     let input = func_call.args.unwrap_or_default();
+                    let thought_signature = func_call.thought_signature.or(part.thought_signature);
                     event_tx
                         .send_async(ProviderEvent::ToolUseStart {
                             id: id.clone(),
@@ -581,6 +597,7 @@ async fn parse_sse(
                         id,
                         name: func_call.name,
                         input,
+                        thought_signature,
                     });
                     stop_reason = Some(StopReason::ToolUse);
                 } else if let Some(text) = part.text {
@@ -595,6 +612,7 @@ async fn parse_sse(
                             signature: part.thought_signature,
                         });
                     } else if !text.is_empty() {
+                        // TODO: preserve part.thought_signature if ContentBlock::Text adds signature support.
                         event_tx
                             .send_async(ProviderEvent::TextDelta { text: text.clone() })
                             .await?;
@@ -760,11 +778,11 @@ mod tests {
         let messages = vec![
             Message {
                 role: Role::Assistant,
-                content: vec![ContentBlock::ToolUse {
-                    id: "call_1".into(),
-                    name: "read_file".into(),
-                    input: json!({"path": "/tmp/a"}),
-                }],
+                content: vec![ContentBlock::tool_use(
+                    "call_1",
+                    "read_file",
+                    json!({"path": "/tmp/a"}),
+                )],
                 ..Default::default()
             },
             Message {
@@ -782,6 +800,82 @@ mod tests {
         assert_eq!(
             result[1]["parts"][0]["functionResponse"]["name"],
             "read_file"
+        );
+    }
+
+    #[test_case("not json at all", json!({"result": "not json at all"}) ; "non_json_wraps_string")]
+    #[test_case(r#""a json string""#, json!({"result": "a json string"}) ; "json_scalar_wraps")]
+    #[test_case("42", json!({"result": 42}) ; "json_number_wraps")]
+    #[test_case(r#"{"out": "ok"}"#, json!({"out": "ok"}) ; "json_object_passes_through")]
+    fn convert_messages_tool_result_response_is_always_struct(content: &str, expected: Value) {
+        let messages = vec![
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::tool_use("call_1", "read", json!({}))],
+                ..Default::default()
+            },
+            Message {
+                role: Role::User,
+                content: vec![ContentBlock::ToolResult {
+                    tool_use_id: "call_1".into(),
+                    content: content.into(),
+                    is_error: false,
+                }],
+                ..Default::default()
+            },
+        ];
+        let result = convert_messages(&messages);
+        assert_eq!(
+            result[1]["parts"][0]["functionResponse"]["response"],
+            expected
+        );
+    }
+
+    #[test]
+    fn convert_messages_tool_result_error_wraps_response() {
+        let messages = vec![
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::tool_use("call_1", "read", json!({}))],
+                ..Default::default()
+            },
+            Message {
+                role: Role::User,
+                content: vec![ContentBlock::ToolResult {
+                    tool_use_id: "call_1".into(),
+                    content: "boom".into(),
+                    is_error: true,
+                }],
+                ..Default::default()
+            },
+        ];
+        let result = convert_messages(&messages);
+        assert_eq!(
+            result[1]["parts"][0]["functionResponse"]["response"],
+            json!({"error": {"result": "boom"}})
+        );
+    }
+
+    #[test]
+    fn convert_messages_tool_use_preserves_thought_signature() {
+        const SIG: &str = "sig-abc";
+        let messages = vec![Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::ToolUse {
+                id: "call_1".into(),
+                name: "read_file".into(),
+                input: json!({"path": "/tmp/a"}),
+                thought_signature: Some(SIG.into()),
+            }],
+            ..Default::default()
+        }];
+        let result = convert_messages(&messages);
+        assert_eq!(result[0]["parts"][0]["functionCall"]["name"], "read_file");
+        assert_eq!(result[0]["parts"][0]["thoughtSignature"], SIG);
+        assert!(
+            result[0]["parts"][0]["functionCall"]
+                .get("thoughtSignature")
+                .is_none()
         );
     }
 
@@ -971,6 +1065,29 @@ mod tests {
         assert!(matches!(
             &result.message.content[0],
             ContentBlock::ToolUse { name, .. } if name == "bash"
+        ));
+    }
+
+    #[test_case(
+        r#"{"functionCall":{"name":"bash","args":{"cmd":"ls"}},"thoughtSignature":"CvcQAdHtim/pKv/c0ClPFkYA=="}"#
+        ; "part_level"
+    )]
+    #[test_case(
+        r#"{"functionCall":{"name":"bash","args":{"cmd":"ls"},"thoughtSignature":"CvcQAdHtim/pKv/c0ClPFkYA=="}}"#
+        ; "nested_fallback"
+    )]
+    fn parse_sse_tool_call_captures_thought_signature(part_json: &str) {
+        const SIG: &str = "CvcQAdHtim/pKv/c0ClPFkYA==";
+        let payload = format!(
+            r#"{{"candidates":[{{"content":{{"parts":[{part_json}]}},"finishReason":"STOP"}}],"usageMetadata":{{"promptTokenCount":5,"candidatesTokenCount":15}}}}"#,
+        );
+        let data = format!("data: {payload}\n\n");
+        let response = mock_response(data.leak().as_bytes());
+        let (tx, _rx) = flume::unbounded();
+        let result = smol::block_on(parse_sse(response, &tx, Duration::from_secs(30))).unwrap();
+        assert!(matches!(
+            &result.message.content[0],
+            ContentBlock::ToolUse { thought_signature: Some(s), .. } if s == SIG
         ));
     }
 

--- a/maki-providers/src/providers/openai/responses.rs
+++ b/maki-providers/src/providers/openai/responses.rs
@@ -82,7 +82,9 @@ pub(crate) fn convert_input(messages: &[Message]) -> Value {
                 for block in &msg.content {
                     match block {
                         ContentBlock::Text { text } => text_parts.push(text.as_str()),
-                        ContentBlock::ToolUse { id, name, input } => {
+                        ContentBlock::ToolUse {
+                            id, name, input, ..
+                        } => {
                             tool_calls.push((id, name, input));
                         }
                         ContentBlock::ToolResult { .. }
@@ -505,11 +507,7 @@ pub(crate) async fn parse_sse(
                 Value::Object(Default::default())
             }
         };
-        content_blocks.push(ContentBlock::ToolUse {
-            id: acc.call_id,
-            name: acc.name,
-            input,
-        });
+        content_blocks.push(ContentBlock::tool_use(acc.call_id, acc.name, input));
     }
 
     Ok(StreamResponse {
@@ -699,11 +697,7 @@ data: {\"response\":{\"status\":\"incomplete\",\"usage\":{\"input_tokens\":10,\"
                     ContentBlock::Text {
                         text: "thinking...".to_string(),
                     },
-                    ContentBlock::ToolUse {
-                        id: "tc_1".to_string(),
-                        name: "bash".to_string(),
-                        input: json!({"command": "ls"}),
-                    },
+                    ContentBlock::tool_use("tc_1", "bash", json!({"command": "ls"})),
                 ],
                 ..Default::default()
             },

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -329,7 +329,9 @@ pub fn convert_messages(messages: &[Message], system: &str) -> Vec<Value> {
                         ContentBlock::Thinking { thinking, .. } => {
                             reasoning_text.push_str(thinking);
                         }
-                        ContentBlock::ToolUse { id, name, input } => {
+                        ContentBlock::ToolUse {
+                            id, name, input, ..
+                        } => {
                             tool_calls.push(json!({
                                 "id": id,
                                 "type": "function",
@@ -677,7 +679,7 @@ pub async fn parse_sse(
         } else {
             acc.name
         };
-        content_blocks.push(ContentBlock::ToolUse { id, name, input });
+        content_blocks.push(ContentBlock::tool_use(id, name, input));
     }
 
     Ok(StreamResponse {
@@ -804,11 +806,7 @@ data: [DONE]\n";
                     ContentBlock::Text {
                         text: "thinking...".to_string(),
                     },
-                    ContentBlock::ToolUse {
-                        id: "tc_1".to_string(),
-                        name: "bash".to_string(),
-                        input: json!({"command": "ls"}),
-                    },
+                    ContentBlock::tool_use("tc_1", "bash", json!({"command": "ls"})),
                 ],
                 ..Default::default()
             },
@@ -845,11 +843,11 @@ data: [DONE]\n";
             Message::user("list files".to_string()),
             Message {
                 role: Role::Assistant,
-                content: vec![ContentBlock::ToolUse {
-                    id: "tc_1".to_string(),
-                    name: "bash".to_string(),
-                    input: json!({"command": "ls"}),
-                }],
+                content: vec![ContentBlock::tool_use(
+                    "tc_1",
+                    "bash",
+                    json!({"command": "ls"}),
+                )],
                 ..Default::default()
             },
         ];

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -151,6 +151,8 @@ pub enum ContentBlock {
         id: String,
         name: String,
         input: Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        thought_signature: Option<String>,
     },
     ToolResult {
         tool_use_id: String,
@@ -182,6 +184,17 @@ pub enum MessageKind {
 impl MessageKind {
     fn is_turn(&self) -> bool {
         matches!(self, Self::Turn)
+    }
+}
+
+impl ContentBlock {
+    pub fn tool_use(id: impl Into<String>, name: impl Into<String>, input: Value) -> Self {
+        Self::ToolUse {
+            id: id.into(),
+            name: name.into(),
+            input,
+            thought_signature: None,
+        }
     }
 }
 
@@ -271,7 +284,9 @@ impl Message {
 
     pub fn tool_uses(&self) -> impl Iterator<Item = (&str, &str, &Value)> {
         self.content.iter().filter_map(|b| match b {
-            ContentBlock::ToolUse { id, name, input } => Some((id.as_str(), name.as_str(), input)),
+            ContentBlock::ToolUse {
+                id, name, input, ..
+            } => Some((id.as_str(), name.as_str(), input)),
             _ => None,
         })
     }

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -2210,11 +2210,7 @@ fn build_rewind_app() -> App {
                 ContentBlock::Text {
                     text: "response 1".into(),
                 },
-                ContentBlock::ToolUse {
-                    id: "tool-1".into(),
-                    name: "bash".into(),
-                    input: serde_json::json!({}),
-                },
+                ContentBlock::tool_use("tool-1", "bash", serde_json::json!({})),
             ],
             ..Default::default()
         },
@@ -3783,11 +3779,7 @@ const UNFINISHED_TASK_ID: &str = "task-unfinished";
 fn tool_use_msg(id: &str) -> Message {
     Message {
         role: Role::Assistant,
-        content: vec![ContentBlock::ToolUse {
-            id: id.into(),
-            name: "read".into(),
-            input: serde_json::json!({}),
-        }],
+        content: vec![ContentBlock::tool_use(id, "read", serde_json::json!({}))],
         ..Default::default()
     }
 }

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -417,7 +417,9 @@ pub fn history_to_display(
                             display
                                 .push(DisplayMessage::new(DisplayRole::Thinking, thinking.clone()));
                         }
-                        ContentBlock::ToolUse { id, name, input } => {
+                        ContentBlock::ToolUse {
+                            id, name, input, ..
+                        } => {
                             let static_name = name.as_str();
                             let reg = ToolRegistry::global();
                             let tool_call: Option<Box<dyn ToolInvocation>> =
@@ -772,11 +774,7 @@ mod tests {
         vec![
             Message {
                 role: Role::Assistant,
-                content: vec![ContentBlock::ToolUse {
-                    id: "t1".into(),
-                    name: tool.into(),
-                    input,
-                }],
+                content: vec![ContentBlock::tool_use("t1", tool, input)],
                 ..Default::default()
             },
             Message {
@@ -815,11 +813,7 @@ mod tests {
                     ContentBlock::Text {
                         text: "Sure, let me help.".into(),
                     },
-                    ContentBlock::ToolUse {
-                        id: "t1".into(),
-                        name: "bash".into(),
-                        input: serde_json::json!({"command": "echo hi"}),
-                    },
+                    ContentBlock::tool_use("t1", "bash", serde_json::json!({"command": "echo hi"})),
                 ],
                 ..Default::default()
             },


### PR DESCRIPTION
This PR fixes gemini-3.6-flash and gemini-3.1-pro-preview for interactive maki sessions for me. Before these changes, attempting to use Google models resulted in errors like:

```
{"timestamp":"2026-07-31T21:38:10.671754Z","level":"ERROR","fields":{"message":"stream_message failed","error":"API error (400): {\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Invalid value at 'contents[196].parts[0].function_response.response' (type.googleapis.com/google.protobuf.Struct), \\\"data: {\\\"candidates\\\":[{\\\"content\\\":{\\\"parts\\\":[{\\\"functionCall\\\":{\\\"name\\\":\\\"bash\\\",\\\"args\\\":{\\\"cmd\\\":\\\"ls\\\"},\\\"thoughtSignature\\\":\\\"CvcQAdHtim/pKv/c0ClPFkYA==\\\"}}]}},\\\"finishReason\\\":\\\"STOP\\\"}],\\\"usageMetadata\\\":{\\\"promptTokenCount\\\":5,\\\"candidatesTokenCount\\\":15}}\\n\\n\\\"\",\n    \"status\": \"INVALID_ARGUMENT\",\n    \"details\": [\n      {\n        \"@type\": \"type.googleapis.com/google.rpc.BadRequest\",\n        \"fieldViolations\": [\n          {\n            \"field\": \"contents[196].parts[0].function_response.response\",\n            \"description\": \"Invalid value at 'contents[196].parts[0].function_response.response' (type.googleapis.com/google.protobuf.Struct), \\\"data: {\\\"candidates\\\":[{\\\"content\\\":{\\\"parts\\\":[{\\\"functionCall\\\":{\\\"name\\\":\\\"bash\\\",\\\"args\\\":{\\\"cmd\\\":\\\"ls\\\"},\\\"thoughtSignature\\\":\\\"CvcQAdHtim/pKv/c0ClPFkYA==\\\"}}]}},\\\"finishReason\\\":\\\"STOP\\\"}],\\\"usageMetadata\\\":{\\\"promptTokenCount\\\":5,\\\"candidatesTokenCount\\\":15}}\\n\\n\\\"\"\n          }\n        ]\n      }\n    ]\n  }\n}\n","model":"gemini-flash-latest","self.num_turns":0},"target":"maki_agent::agent::run"}
```
and
```
{"timestamp":"2026-07-31T21:44:09.634621Z","level":"ERROR","fields":{"message":"stream_message failed","error":"API error (400): {\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Invalid JSON payload received. Unknown name \\\"thoughtSignature\\\" at 'contents[1].parts[0].function_call': Cannot find field.\",\n    \"status\": \"INVALID_ARGUMENT\",\n    \"details\": [\n      {\n        \"@type\": \"type.googleapis.com/google.rpc.BadRequest\",\n        \"fieldViolations\": [\n          {\n            \"field\": \"contents[1].parts[0].function_call\",\n            \"description\": \"Invalid JSON payload received. Unknown name \\\"thoughtSignature\\\" at 'contents[1].parts[0].function_call': Cannot find field.\"\n          }\n        ]\n      }\n    ]\n  }\n}\n","model":"gemini-flash-latest","self.num_turns":1},"target":"maki_agent::agent::run"}
```

Closes #698. Additionally, after testing the Gemini provider to ensure multi-turn sessions worked properly, I also tried loading a saved session from disk and discovered #718. Which I added a new commit to this PR to also fix.