### PR TITLE
feat(providers): per-model thinking config and body overrides for dynamic providers

### DIFF
--- a/maki-config/src/providers.rs
+++ b/maki-config/src/providers.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process;
 
+use maki_storage::sessions::{BodyOverride, EffortDialectId, ThinkingFieldConfig};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use tracing::debug;
@@ -54,6 +55,19 @@ pub struct ModelDef {
     pub pricing_fast_input: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pricing_fast_output: Option<f64>,
+    /// Override the effort dialect for this model. When `None`, the base
+    /// provider's default dialect is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking_dialect: Option<EffortDialectId>,
+    /// Override where thinking values go in the body. When `None`, the base
+    /// provider's hardcoded field layout is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking_fields: Option<ThinkingFieldConfig>,
+    /// Per-model body overrides: `defaults` fills absent keys, `replace`
+    /// overwrites, `filter` strips. Each provider guards its conversation
+    /// field from all three.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body_override: Option<BodyOverride>,
 }
 
 impl ModelDef {
@@ -420,6 +434,28 @@ tier = "mediums"
     fn model_def_tier_defaults_to_medium() {
         let m: ModelDef = toml::from_str(r#"id = "x""#).unwrap();
         assert_eq!(m.tier, Tier::Medium);
+    }
+
+    #[test]
+    fn model_def_body_override_roundtrip() {
+        let toml_str = r#"
+id = "my-model"
+tier = "strong"
+thinking_dialect = "glm"
+body_override = { defaults = { generationConfig = { temperature = 0.1 } }, filter = ["poison", "red"] }
+"#;
+        let m: ModelDef = toml::from_str(toml_str).unwrap();
+        assert_eq!(m.id, "my-model");
+        assert_eq!(m.thinking_dialect, Some(EffortDialectId::Glm));
+        let ov = m.body_override.expect("body_override parsed");
+        let defaults = ov.defaults.expect("defaults parsed");
+        assert_eq!(defaults["generationConfig"]["temperature"], 0.1);
+        assert_eq!(ov.filter, vec!["poison".to_string(), "red".to_string()]);
+
+        let minimal: ModelDef = toml::from_str(r#"id = "x""#).unwrap();
+        assert!(minimal.thinking_dialect.is_none());
+        assert!(minimal.thinking_fields.is_none());
+        assert!(minimal.body_override.is_none());
     }
 
     #[test_case("weak", Tier::Weak ; "weak")]

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -239,7 +239,15 @@ If your provider serves models not in the base catalog, add a `models` subcomman
 [{{"id": "my-model-v2", "tier": "strong", "context_window": 200000, "max_output_tokens": 16384}}]
 ```
 
-Only `id` is required. Optional fields: `tier` (default `medium`), `context_window` (128K), `max_output_tokens` (16K), `pricing` (`{{input, output, cache_write, cache_read}}`, all per 1M tokens), `supports_tool_examples` (defaults to the base provider's setting), `supports_thinking` (defaults to the base provider's setting), `supports_vision` (defaults to the base provider's setting; when false, image input and the `view_image` tool are disabled). The first model listed per tier is used for sub-agents. Without this subcommand, the base provider's models are used.
+Only `id` is required. Optional fields: `tier` (default `medium`), `context_window` (128K), `max_output_tokens` (16K), `pricing` (`{{input, output, cache_write, cache_read}}`, all per 1M tokens), `supports_tool_examples` (defaults to the base provider's setting), `supports_thinking` (defaults to the base provider's setting), `supports_vision` (defaults to the base provider's setting; when false, image input and the `view_image` tool are disabled), `thinking_dialect` (overrides the base provider's effort level mapping; one of `standard`, `prefer-high`, `high-only`, `glm`, `deep-seek`, `anthropic-adaptive`, `tensor-x`), `thinking_fields` (overrides where thinking values go in the body; see below), `body_override` (per-model body manipulation with three operations: `defaults` fills absent keys, `replace` overwrites existing keys, `filter` strips keys). The first model listed per tier is used for selecting that tier at runtime.
+
+`body_override` is the escape hatch when a model needs a field the base provider does not set, or needs to remove one the base provider always sets. All three operations run after the typed thinking setup, and each provider guards its conversation field (`messages`, `input`, or `contents`) from all three. Example:
+
+```json
+[{{"id": "my-model", "tier": "strong", "body_override": {{"defaults": {{"chat_template_kwargs": {{"enable_thinking": true}}}}, "filter": ["some_base_key"]}}}}]
+```
+
+`thinking_fields` lets you control where effort strings, toggles, and budgets go in the body. It has `effort_path` (dot-path for the effort string), `budget_path` (dot-path for a budget integer), `budget_max` (cap), and `toggles` (a list of toggle objects, each with `path`, `on`, `off`, `adaptive`, and `budget_key`). This lets you handle providers like DeepSeek (toggle + effort), Google (budget + thoughts flag), OpenRouter (nested `reasoning.effort`), and exotic setups like ElectronHub (multiple toggle objects + effort in a nested object).
 
 Dynamic provider models are namespaced as `{{slug}}/{{model_id}}` (e.g. `myproxy/claude-sonnet-4-6`).
 

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -20,7 +20,8 @@ pub use providers::opencode::{
     ProviderData, catalog_provider, catalog_providers, catalog_providers_if_available,
 };
 pub use types::{
-    ContentBlock, Effort, EffortDialect, IMAGE_OMITTED_NOTE, ImageMediaType, ImageSource, Message,
-    ProviderEvent, ProviderUsage, RequestOptions, Role, StopReason, StreamResponse, ThinkingConfig,
-    UsageLimit, adapt_images_for_model, dialect,
+    BodyOverride, ContentBlock, Effort, EffortDialect, EffortDialectId, IMAGE_OMITTED_NOTE,
+    ImageMediaType, ImageSource, Message, ProviderEvent, ProviderUsage, RequestOptions, Role,
+    StopReason, StreamResponse, ThinkingConfig, ThinkingFieldConfig, ToggleEntry, UsageLimit,
+    adapt_images_for_model, dialect, effort_dialect_for,
 };

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -9,12 +9,15 @@ use std::ops::AddAssign;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use maki_storage::sessions::{MIN_THINKING_BUDGET, StoredTokenUsage};
+use maki_storage::sessions::{
+    BodyOverride, EffortDialectId, MIN_THINKING_BUDGET, StoredTokenUsage, ThinkingFieldConfig,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::manifest::{ManifestRegistry, ProviderManifest};
 use crate::model_registry::model_registry;
 use crate::providers::{anthropic, custom, dynamic};
+use crate::types::{EffortDialect, effort_dialect_for};
 
 const PER_MILLION: f64 = 1_000_000.0;
 
@@ -214,6 +217,16 @@ pub struct Model {
     /// `None` when unknown, see [`ProviderKind::fallback_max_output`].
     pub max_output_tokens: Option<u32>,
     pub context_window: u32,
+    /// Override the effort dialect for this model. When `None`, the base
+    /// provider's hardcoded dialect is used.
+    pub thinking_dialect: Option<EffortDialectId>,
+    /// Override where thinking values go in the body. When `None`, the base
+    /// provider's hardcoded field layout is used.
+    pub thinking_fields: Option<ThinkingFieldConfig>,
+    /// Per-model body overrides applied after all typed thinking setup.
+    /// `defaults` fills absent keys, `replace` overwrites, `filter` strips.
+    /// Each provider guards its conversation field from all three.
+    pub body_override: Option<BodyOverride>,
 }
 
 impl Model {
@@ -253,6 +266,9 @@ impl Model {
             pricing,
             max_output_tokens,
             context_window,
+            thinking_dialect: None,
+            thinking_fields: None,
+            body_override: None,
         }
     }
 
@@ -271,6 +287,14 @@ impl Model {
             .discovered(manifest.slug, &self.id)
             .and_then(|d| d.supports_thinking)
             .unwrap_or(manifest.supports_thinking)
+    }
+
+    /// The effort dialect for this model. Uses the model's override if set,
+    /// otherwise falls back to the provider's default.
+    pub fn effort_dialect<'a>(&self, default: &'a EffortDialect<'a>) -> &'a EffortDialect<'a> {
+        self.thinking_dialect
+            .map(effort_dialect_for)
+            .unwrap_or(default)
     }
 
     pub fn supports_vision(&self) -> bool {
@@ -351,7 +375,7 @@ impl Model {
         // protocol default under the custom slug, keeping its tier and pricing),
         // or no such provider.
         match custom::resolve_tier(slug, tier) {
-            custom::TierLookup::Model(model) => return Ok(model),
+            custom::TierLookup::Model(model) => return Ok(*model),
             custom::TierLookup::NoModelForTier(base) => {
                 let manifest = ManifestRegistry::get(&base.to_string())
                     .ok_or_else(|| ModelError::NoDefault(slug.to_string(), tier))?;

--- a/maki-providers/src/providers/anthropic/shared.rs
+++ b/maki-providers/src/providers/anthropic/shared.rs
@@ -211,6 +211,7 @@ pub(crate) fn build_request_body_with_system(
     });
 
     thinking.apply_to_body(&mut body, model);
+    super::super::apply_body_overrides(&mut body, model, &["messages"]);
     body
 }
 
@@ -593,9 +594,14 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
 mod tests {
     use test_case::test_case;
 
+    use super::build_request_body_with_system;
     use super::{
         LONG_CONTEXT_SUFFIX, LONG_CONTEXT_WINDOW, long_context_window, strip_long_context,
     };
+    use crate::model::{Model, ModelFamily, ModelPricing, ModelTier};
+    use crate::types::{BodyOverride, ThinkingConfig};
+    use serde_json::json;
+    use std::sync::Arc;
 
     #[test_case("claude-opus-4-8-1m", "claude-opus-4-8" ; "strips_suffix")]
     #[test_case("claude-opus-4-8", "claude-opus-4-8" ; "leaves_plain_id")]
@@ -608,5 +614,57 @@ mod tests {
     fn long_context_window_follows_suffix(model_id: &str, expected: Option<u32>) {
         assert_eq!(long_context_window(model_id), expected);
         assert!(LONG_CONTEXT_SUFFIX.ends_with("1m"));
+    }
+
+    fn model_with_body_override(override_config: Option<BodyOverride>) -> Model {
+        Model {
+            id: "claude-opus-4-8".into(),
+            provider: Arc::from("anthropic"),
+            tier: ModelTier::Strong,
+            family: ModelFamily::Claude,
+            supports_tool_examples_override: None,
+            supports_thinking_override: None,
+            supports_vision_override: None,
+            pricing: ModelPricing::default(),
+            max_output_tokens: Some(8192),
+            context_window: 200_000,
+            thinking_dialect: None,
+            thinking_fields: None,
+            body_override: override_config,
+        }
+    }
+
+    #[test]
+    fn defaults_do_not_overwrite_standard_thinking() {
+        let model = model_with_body_override(Some(BodyOverride {
+            defaults: Some(json!({"thinking": {"type": "enabled", "budget_tokens": 2048}})),
+            replace: None,
+            filter: vec![],
+        }));
+        let body =
+            build_request_body_with_system(&model, &[], &[], &json!([]), ThinkingConfig::Adaptive);
+        assert_eq!(body["thinking"]["type"], "adaptive");
+        assert_eq!(body["max_tokens"], 8192);
+    }
+
+    #[test]
+    fn filter_strips_thinking_set_by_apply_to_body() {
+        let model = model_with_body_override(Some(BodyOverride {
+            defaults: Some(json!({"thinking": {"type": "enabled", "budget_tokens": 2048}})),
+            replace: None,
+            filter: vec!["thinking".into()],
+        }));
+        let body =
+            build_request_body_with_system(&model, &[], &[], &json!([]), ThinkingConfig::Adaptive);
+        assert!(body.get("thinking").is_none());
+        assert_eq!(body["max_tokens"], 8192);
+    }
+
+    #[test]
+    fn no_overrides_keeps_standard_body() {
+        let model = model_with_body_override(None);
+        let body =
+            build_request_body_with_system(&model, &[], &[], &json!([]), ThinkingConfig::Adaptive);
+        assert_eq!(body["thinking"]["type"], "adaptive");
     }
 }

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -230,6 +230,7 @@ impl Copilot {
         if wire_tools.as_array().is_some_and(|tools| !tools.is_empty()) {
             body["tools"] = wire_tools;
         }
+        super::apply_body_overrides(&mut body, model, &["messages"]);
 
         let request = self
             .build_post(
@@ -314,6 +315,7 @@ impl Copilot {
             "stream": true,
         });
         thinking.apply_to_body(&mut body, model);
+        super::apply_body_overrides(&mut body, model, &["messages"]);
 
         let request = self
             .build_post(&auth, MESSAGES_PATH, Some("conversation-agent"), &body)?

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -15,8 +15,15 @@ use crate::manifest::ManifestRegistry;
 use crate::model::{FastPricing, Model, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider, ProviderKind};
 use crate::providers::Timeouts;
-use crate::types::ThinkingConfig;
-use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
+use crate::types::ThinkingFieldConfig;
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
+
+fn custom_openai_fields() -> ThinkingFieldConfig {
+    ThinkingFieldConfig {
+        effort_path: Some("reasoning_effort".into()),
+        ..Default::default()
+    }
+}
 
 static CUSTOM_OPENAI_CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     // Custom providers resolve their own base URL (including any override) from
@@ -147,6 +154,9 @@ fn model_from_def(def: &ProviderDef, kind: ProviderKind, slug: &str, model_id: &
         pricing,
         max_output_tokens,
         context_window,
+        thinking_dialect: declared.and_then(|m| m.thinking_dialect),
+        thinking_fields: declared.and_then(|m| m.thinking_fields.clone()),
+        body_override: declared.and_then(|m| m.body_override.clone()),
     }
 }
 
@@ -173,7 +183,7 @@ fn declared_specs_from(config: &ProvidersConfig) -> Vec<String> {
 
 /// Outcome of resolving a tier against `providers.toml` in a single read.
 pub enum TierLookup {
-    Model(Model),
+    Model(Box<Model>),
     /// Provider exists but declares no model at this tier; carries the base kind
     /// so the caller can inherit the base protocol's default.
     NoModelForTier(ProviderKind),
@@ -195,7 +205,9 @@ pub fn resolve_tier(slug: &str, tier: ModelTier) -> TierLookup {
     };
     let kind = protocol_kind(protocol);
     match def.models.iter().find(|m| ModelTier::from(m.tier) == tier) {
-        Some(declared) => TierLookup::Model(model_from_def(def, kind, slug, &declared.id)),
+        Some(declared) => {
+            TierLookup::Model(Box::new(model_from_def(def, kind, slug, &declared.id)))
+        }
         None => TierLookup::NoModelForTier(kind),
     }
 }
@@ -275,9 +287,13 @@ impl Provider for CustomOpenAiProvider {
             }
 
             let mut body = self.compat.build_body(model, messages, system, tools);
-            if matches!(opts.thinking, ThinkingConfig::Off) {
-                body["thinking"] = serde_json::json!({"type": "disabled"});
-            }
+            opts.thinking.apply_thinking(
+                &mut body,
+                model,
+                &dialect::PREFER_HIGH,
+                &custom_openai_fields(),
+            );
+            super::apply_body_overrides(&mut body, model, &["messages"]);
             self.compat
                 .do_stream(model, &[], &body, event_tx, &auth)
                 .await

--- a/maki-providers/src/providers/deepseek.rs
+++ b/maki-providers/src/providers/deepseek.rs
@@ -8,7 +8,7 @@ use tracing::warn;
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
-use crate::types::{ProviderUsage, UsageLimit};
+use crate::types::{ProviderUsage, ThinkingFieldConfig, UsageLimit};
 use crate::{
     AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, ThinkingConfig, dialect,
 };
@@ -28,6 +28,19 @@ static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     include_stream_usage: true,
     provider_name: "DeepSeek",
 };
+
+fn deepseek_fields() -> ThinkingFieldConfig {
+    ThinkingFieldConfig {
+        effort_path: Some("reasoning_effort".into()),
+        toggles: vec![crate::types::ToggleEntry {
+            path: "thinking".into(),
+            on: Some(serde_json::json!({"type": "enabled"})),
+            off: Some(serde_json::json!({"type": "disabled"})),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
 
 inventory::submit!(maki_config::providers::BuiltInProvider {
     slug: "deepseek",
@@ -173,18 +186,16 @@ impl Provider for DeepSeek {
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
 
+            opts.thinking
+                .apply_thinking(&mut body, model, &dialect::DEEPSEEK, &deepseek_fields());
             if opts.thinking.is_enabled() {
-                body["thinking"] = serde_json::json!({"type": "enabled"});
-                opts.thinking
-                    .apply_reasoning_effort(&mut body, &dialect::DEEPSEEK, model);
                 if matches!(opts.thinking, ThinkingConfig::Budget(_)) {
                     warn!("DeepSeek reasoning does not support token budgets");
                 }
                 pad_reasoning_content(&model.id, &mut body);
-            } else {
-                body["thinking"] = serde_json::json!({"type": "disabled"});
             }
 
+            super::apply_body_overrides(&mut body, model, &["messages"]);
             self.compat
                 .do_stream(model, &[], &body, event_tx, &auth)
                 .await

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -9,12 +9,12 @@ use flume::Sender;
 use maki_config::providers::ProvidersConfig;
 use maki_storage::StateDir;
 use maki_storage::id::SessionRef;
+use maki_storage::sessions::{BodyOverride, EffortDialectId, ThinkingFieldConfig};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use strum::IntoEnumIterator;
 use tracing::{debug, warn};
 
-use crate::manifest::ManifestRegistry;
 use crate::model::{Model, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider, ProviderKind};
 use crate::{AgentError, Message, ProviderEvent, ProviderUsage, RequestOptions, StreamResponse};
@@ -46,18 +46,35 @@ struct DynamicProviderMeta {
     has_auth: bool,
     script_path: PathBuf,
     models: Vec<ScriptModel>,
+    model_filters: Vec<ScriptModelFilter>,
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ScriptInfo {
     display_name: String,
     base: String,
     #[serde(default)]
     system_prefix: Option<String>,
     has_auth: bool,
+    /// Provider-wide, glob-matched body shaping rules. Each entry contributes
+    /// its `body_override` to every model id whose id matches its `match` glob.
+    /// Per-model entries in [`ScriptModel`] take precedence when both apply.
+    #[serde(default)]
+    model_filters: Vec<ScriptModelFilter>,
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ScriptModelFilter {
+    #[serde(rename = "match")]
+    match_pattern: String,
+    #[serde(default)]
+    body_override: Option<BodyOverride>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ScriptModel {
     id: String,
     #[serde(default = "default_tier")]
@@ -68,16 +85,31 @@ struct ScriptModel {
     supports_thinking: Option<bool>,
     #[serde(default)]
     supports_vision: Option<bool>,
-    #[serde(default = "default_max_output_tokens")]
-    max_output_tokens: u32,
+    #[serde(default)]
+    max_output_tokens: Option<u32>,
     #[serde(default = "default_context_window")]
     context_window: u32,
     #[serde(default)]
     pricing: Option<ModelPricing>,
+    #[serde(default)]
+    thinking_dialect: Option<EffortDialectId>,
+    #[serde(default)]
+    thinking_fields: Option<ThinkingFieldConfig>,
+    #[serde(default)]
+    body_override: Option<BodyOverride>,
 }
 
 impl ScriptModel {
-    fn to_model(&self, slug: &str, base: ProviderKind, id: String, tier: ModelTier) -> Model {
+    fn to_model(
+        &self,
+        slug: &str,
+        base: ProviderKind,
+        id_matcher: &str,
+        id: String,
+        tier: ModelTier,
+        model_filters: &[ScriptModelFilter],
+    ) -> Model {
+        let body_override = resolve_overrides(id_matcher, model_filters, &self.body_override);
         Model {
             id,
             provider: Arc::from(slug),
@@ -87,8 +119,11 @@ impl ScriptModel {
             supports_thinking_override: self.supports_thinking,
             supports_vision_override: self.supports_vision,
             pricing: self.pricing.clone().unwrap_or_default(),
-            max_output_tokens: Some(self.max_output_tokens),
+            max_output_tokens: self.max_output_tokens,
             context_window: self.context_window,
+            thinking_dialect: self.thinking_dialect,
+            thinking_fields: self.thinking_fields.clone(),
+            body_override,
         }
     }
 }
@@ -97,15 +132,12 @@ fn default_tier() -> ModelTier {
     ModelTier::Medium
 }
 
-fn default_max_output_tokens() -> u32 {
-    16384
-}
-
 fn default_context_window() -> u32 {
     128_000
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ScriptResolvedAuth {
     base_url: Option<String>,
     headers: HashMap<String, String>,
@@ -125,6 +157,97 @@ fn is_valid_slug(s: &str) -> bool {
         && s.as_bytes()[0].is_ascii_alphanumeric()
         && s.bytes()
             .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+}
+
+/// Full shell-style glob match: `*` matches any run (including empty), `?` matches
+/// a single char, both over the whole byte sequence (slashes included). Model ids
+/// in maki are short, so we don't need to anchor the pattern globally — the
+/// caller decides whether to match exactly or as a substring.
+fn glob_match(pattern: &str, text: &str) -> bool {
+    glob_match_inner(pattern.as_bytes(), text.as_bytes())
+}
+
+fn glob_match_inner(pat: &[u8], text: &[u8]) -> bool {
+    let mut pi = 0;
+    let mut ti = 0;
+    let mut star_pi: Option<usize> = None;
+    let mut star_ti: usize = 0;
+    while ti < text.len() {
+        if pi < pat.len() && pat[pi] == b'*' {
+            star_pi = Some(pi);
+            star_ti = ti;
+            pi += 1;
+        } else if pi < pat.len() && (pat[pi] == b'?' || pat[pi] == text[ti]) {
+            pi += 1;
+            ti += 1;
+        } else if let Some(sp) = star_pi {
+            pi = sp + 1;
+            star_ti += 1;
+            ti = star_ti;
+        } else {
+            return false;
+        }
+    }
+    while pi < pat.len() && pat[pi] == b'*' {
+        pi += 1;
+    }
+    pi == pat.len()
+}
+
+/// Resolve the effective `body_override` for one model id. Per-model
+/// value applies first; matching `model_filters` entries then accumulate
+/// in declaration order. `defaults` and `replace` deep-merge later-wins;
+/// `filter` unions with first-seen preserved.
+fn resolve_overrides(
+    model_id: &str,
+    filters: &[ScriptModelFilter],
+    per_model: &Option<BodyOverride>,
+) -> Option<BodyOverride> {
+    let mut result = per_model.clone();
+    for entry in filters {
+        if !glob_match(&entry.match_pattern, model_id) {
+            continue;
+        }
+        if let Some(entry_ov) = &entry.body_override {
+            let merged = result.get_or_insert_with(BodyOverride::default);
+            if let Some(entry_defaults) = &entry_ov.defaults {
+                let target = merged
+                    .defaults
+                    .get_or_insert_with(|| Value::Object(Default::default()));
+                merge_value_late_wins(target, entry_defaults);
+            }
+            if let Some(entry_replace) = &entry_ov.replace {
+                let target = merged
+                    .replace
+                    .get_or_insert_with(|| Value::Object(Default::default()));
+                merge_value_late_wins(target, entry_replace);
+            }
+            for k in &entry_ov.filter {
+                if !merged.filter.contains(k) {
+                    merged.filter.push(k.clone());
+                }
+            }
+        }
+    }
+    result
+}
+
+/// Two-object deep merge, later-wins. Used to fold multiple `BodyOverride`
+/// contributions (per-model, then each matching glob in order) into one shape.
+fn merge_value_late_wins(target: &mut Value, src: &Value) {
+    let (Some(t), Some(s)) = (target.as_object_mut(), src.as_object()) else {
+        return;
+    };
+    for (k, v) in s {
+        match t.get_mut(k) {
+            Some(existing) if existing.is_object() && v.is_object() => {
+                merge_value_late_wins(existing, v);
+            }
+            _ => {
+                t.insert(k.clone(), v.clone());
+            }
+        }
+    }
 }
 
 fn builtin_slugs() -> Vec<String> {
@@ -294,7 +417,11 @@ fn build_meta(
     let info: ScriptInfo = match serde_json::from_str(&described.info) {
         Ok(i) => i,
         Err(e) => {
-            warn!(slug, error = %e, "invalid info JSON, skipping");
+            warn!(
+                slug,
+                error = %e,
+                "invalid info JSON, dynamic provider skipped; fix the script's `info` output"
+            );
             return None;
         }
     };
@@ -308,10 +435,19 @@ fn build_meta(
     };
 
     let models = match &described.models {
-        Some(json) => serde_json::from_str(json).unwrap_or_else(|e| {
-            warn!(slug, error = %e, "invalid models JSON, falling back to base models");
-            Vec::new()
-        }),
+        Some(json) => match serde_json::from_str::<Vec<ScriptModel>>(json) {
+            Ok(m) => m,
+            Err(e) => {
+                let snippet: String = json.chars().take(120).collect();
+                warn!(
+                    slug,
+                    error = %e,
+                    snippet = %snippet,
+                    "invalid models JSON: dynamic provider has no models; fix the script's `models` output"
+                );
+                Vec::new()
+            }
+        },
         None => Vec::new(),
     };
 
@@ -323,6 +459,7 @@ fn build_meta(
         has_auth: info.has_auth,
         script_path,
         models,
+        model_filters: info.model_filters,
     })
 }
 
@@ -551,21 +688,10 @@ pub fn dynamic_model_specs_for(slug: &str) -> Vec<String> {
     let Some(meta) = find_meta(slug) else {
         return Vec::new();
     };
-    if meta.models.is_empty() {
-        let base_slug = meta.base.to_string();
-        ManifestRegistry::get(&base_slug)
-            .map(|m| m.models)
-            .unwrap_or(&[])
-            .iter()
-            .flat_map(|entry| entry.prefixes.iter())
-            .map(|prefix| format!("{slug}/{prefix}"))
-            .collect()
-    } else {
-        meta.models
-            .iter()
-            .map(|m| format!("{slug}/{}", m.id))
-            .collect()
-    }
+    meta.models
+        .iter()
+        .map(|m| format!("{slug}/{}", m.id))
+        .collect()
 }
 
 pub fn discovered_slugs() -> Vec<&'static str> {
@@ -583,13 +709,27 @@ pub fn lookup_model(slug: &str, model_id: &str) -> Option<Model> {
         .iter()
         .filter(|m| model_id.starts_with(&m.id))
         .max_by_key(|m| m.id.len())?;
-    Some(script_model.to_model(slug, meta.base, model_id.to_string(), script_model.tier))
+    Some(script_model.to_model(
+        slug,
+        meta.base,
+        model_id,
+        model_id.to_string(),
+        script_model.tier,
+        &meta.model_filters,
+    ))
 }
 
 pub fn find_model_for_tier(slug: &str, tier: ModelTier) -> Option<Model> {
     let meta = find_meta(slug)?;
     let script_model = meta.models.iter().find(|m| m.tier == tier)?;
-    Some(script_model.to_model(slug, meta.base, script_model.id.clone(), tier))
+    Some(script_model.to_model(
+        slug,
+        meta.base,
+        &script_model.id,
+        script_model.id.clone(),
+        tier,
+        &meta.model_filters,
+    ))
 }
 
 struct DynamicProvider {
@@ -637,9 +777,6 @@ impl Provider for DynamicProvider {
     }
 
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
-        if self.models.is_empty() {
-            return self.inner.list_models();
-        }
         Box::pin(async {
             Ok(self
                 .models
@@ -647,7 +784,7 @@ impl Provider for DynamicProvider {
                 .map(|m| crate::model::ModelInfo {
                     id: m.id.clone(),
                     context_window: Some(m.context_window),
-                    max_output_tokens: Some(m.max_output_tokens),
+                    max_output_tokens: m.max_output_tokens,
                     pricing: m.pricing.clone(),
                     supports_thinking: None,
                     supports_vision: m.supports_vision,
@@ -730,19 +867,27 @@ mod tests {
 
     #[test]
     fn script_model_deserialization() {
-        let full = r#"{"id": "my-model", "tier": "strong", "supports_tool_examples": true, "max_output_tokens": 32000, "context_window": 200000, "pricing": {"input": 3.0, "output": 15.0, "cache_write": 3.75, "cache_read": 0.30}}"#;
+        let full = r#"{"id": "my-model", "tier": "strong", "supports_tool_examples": true, "max_output_tokens": 32000, "context_window": 200000, "pricing": {"input": 3.0, "output": 15.0, "cache_write": 3.75, "cache_read": 0.30}, "thinking_dialect": "glm", "body_override": {"defaults": {"generationConfig": {"temperature": 0.1}}, "filter": ["poison"]}}"#;
         let model: ScriptModel = serde_json::from_str(full).unwrap();
         assert_eq!(model.id, "my-model");
         assert_eq!(model.tier, ModelTier::Strong);
         assert_eq!(model.supports_tool_examples, Some(true));
         assert!(model.pricing.is_some());
+        assert_eq!(model.thinking_dialect, Some(EffortDialectId::Glm));
+        let ov = model.body_override.as_ref().expect("body_override parsed");
+        let defaults = ov.defaults.as_ref().expect("defaults parsed");
+        assert_eq!(defaults["generationConfig"]["temperature"], 0.1);
+        assert_eq!(ov.filter, vec!["poison".to_string()]);
 
         let minimal: ScriptModel = serde_json::from_str(r#"{"id": "custom-v1"}"#).unwrap();
         assert_eq!(minimal.tier, ModelTier::Medium);
         assert_eq!(minimal.supports_tool_examples, None);
-        assert_eq!(minimal.max_output_tokens, 16384);
+        assert!(minimal.max_output_tokens.is_none());
         assert_eq!(minimal.context_window, 128_000);
         assert!(minimal.pricing.is_none());
+        assert!(minimal.thinking_dialect.is_none());
+        assert!(minimal.thinking_fields.is_none());
+        assert!(minimal.body_override.is_none());
     }
 
     #[cfg(unix)]
@@ -810,6 +955,106 @@ esac
         assert_eq!(providers[0].models.len(), 1);
         assert_eq!(providers[0].models[0].id, "custom-v1");
         assert_eq!(providers[0].models[0].tier, ModelTier::Strong);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_overrides_applies_filters_in_declaration_order() {
+        let filters = vec![
+            ScriptModelFilter {
+                match_pattern: "hint*".into(),
+                body_override: Some(BodyOverride {
+                    defaults: Some(
+                        serde_json::json!({"chat_template_kwargs": {"enable_thinking": true}}),
+                    ),
+                    replace: None,
+                    filter: vec!["min_tokens".into(), "red".into()],
+                }),
+            },
+            ScriptModelFilter {
+                match_pattern: "unrelated-*".into(),
+                body_override: Some(BodyOverride {
+                    defaults: Some(serde_json::json!({"poison": true})),
+                    replace: None,
+                    filter: vec!["poison_field".into()],
+                }),
+            },
+        ];
+        let per_model = Some(BodyOverride {
+            defaults: Some(serde_json::json!({"temperature": 0.1, "trace_id": "abc"})),
+            replace: None,
+            filter: vec!["always_strip".into()],
+        });
+
+        let resolved = resolve_overrides("hint-mod-3", &filters, &per_model).unwrap();
+
+        let defaults = resolved.defaults.as_ref().unwrap();
+        assert_eq!(defaults["temperature"], 0.1);
+        assert_eq!(defaults["trace_id"], "abc");
+        assert_eq!(defaults["chat_template_kwargs"]["enable_thinking"], true);
+        assert!(defaults.get("poison").is_none());
+
+        assert_eq!(resolved.filter, vec!["always_strip", "min_tokens", "red"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_overrides_no_filters_no_overrides_returns_neutrals() {
+        let result = resolve_overrides("model-x", &[], &None);
+        assert!(result.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discover_resolves_overrides_for_matching_model() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("ovr-llm");
+        let script = r#"#!/bin/sh
+case "$1" in
+  info) echo '{
+    "display_name": "OvR",
+    "base": "openai",
+    "has_auth": false,
+    "model_filters": [
+      {"match": "hint*", "body_override": {"defaults": {"chat_template_kwargs": {"enable_thinking": true}}, "filter": ["min_tokens"]}}
+    ]
+  }' ;;
+  models) echo '[
+    {"id": "hint-mod", "tier": "strong", "max_output_tokens": 32000, "context_window": 200000, "body_override": {"defaults": {"temperature": 0.1}, "filter": ["always_strip"]}},
+    {"id": "plain-mod", "tier": "medium", "max_output_tokens": 16000, "context_window": 128000}
+  ]' ;;
+  resolve) echo '{"headers": {"authorization": "Bearer test"}}' ;;
+  *) exit 1 ;;
+esac
+"#;
+        let mut file = File::create(&path).unwrap();
+        file.write_all(script.as_bytes()).unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let metas = discover_in(tmp.path());
+        assert_eq!(metas.len(), 1);
+        let meta = &metas[0];
+        assert_eq!(meta.model_filters.len(), 1);
+        assert_eq!(meta.model_filters[0].match_pattern, "hint*");
+        assert_eq!(meta.models.len(), 2);
+
+        let m = meta.models.iter().find(|m| m.id == "hint-mod").unwrap();
+        let resolved =
+            resolve_overrides("hint-mod-large", &meta.model_filters, &m.body_override).unwrap();
+        let defaults = resolved.defaults.as_ref().unwrap();
+        assert_eq!(defaults["temperature"], 0.1);
+        assert_eq!(defaults["chat_template_kwargs"]["enable_thinking"], true);
+        assert_eq!(
+            resolved.filter,
+            vec!["always_strip".to_string(), "min_tokens".to_string()]
+        );
+
+        let plain = meta.models.iter().find(|m| m.id == "plain-mod").unwrap();
+        assert!(plain.body_override.is_none());
+        let result = resolve_overrides("plain-mod", &meta.model_filters, &plain.body_override);
+        assert!(result.is_none());
     }
 
     #[cfg(unix)]

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -11,9 +11,10 @@ use tracing::warn;
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
+use crate::types::{ThinkingFieldConfig, ToggleEntry};
 use crate::{
     AgentError, ContentBlock, Message, ProviderEvent, RequestOptions, Role, StopReason,
-    StreamResponse, ThinkingConfig, TokenUsage,
+    StreamResponse, ThinkingConfig, TokenUsage, dialect,
 };
 
 use super::{KeyPool, ResolvedAuth, http_client, next_sse_line};
@@ -25,13 +26,22 @@ const PRO_MAX_THINKING: u32 = 32_768;
 
 /// The generic per-model max, capped by Google's documented `thinkingBudget`
 /// hard limits per family.
-fn max_thinking(model: &Model) -> u32 {
+fn google_fields(model: &Model) -> ThinkingFieldConfig {
     let cap = if model.id.contains("flash") {
         FLASH_MAX_THINKING
     } else {
         PRO_MAX_THINKING
     };
-    model.max_thinking_budget().map_or(cap, |m| m.min(cap))
+    ThinkingFieldConfig {
+        budget_path: Some("generationConfig.thinkingConfig.thinkingBudget".into()),
+        budget_max: Some(cap),
+        toggles: vec![ToggleEntry {
+            path: "generationConfig.thinkingConfig.includeThoughts".into(),
+            adaptive: Some(json!(true)),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
 }
 
 inventory::submit!(maki_config::providers::BuiltInProvider {
@@ -201,7 +211,7 @@ impl Google {
             body["systemInstruction"] = json!({"parts": [{"text": system}]});
         }
 
-        thinking.apply_google_thinking(&mut body, max_thinking(model));
+        thinking.apply_thinking(&mut body, model, &dialect::STANDARD, &google_fields(model));
 
         if let Some(max_output) = model.max_output_tokens {
             body["generationConfig"]["maxOutputTokens"] = json!(max_output);
@@ -212,6 +222,7 @@ impl Google {
             body["tools"] = json!([{"functionDeclarations": tool_decls}]);
         }
 
+        super::apply_body_overrides(&mut body, model, &["contents"]);
         body
     }
 
@@ -651,6 +662,9 @@ mod tests {
             pricing: ModelPricing::default(),
             max_output_tokens: Some(8192),
             context_window: 1_048_576,
+            thinking_dialect: None,
+            thinking_fields: None,
+            body_override: None,
         }
     }
 

--- a/maki-providers/src/providers/local.rs
+++ b/maki-providers/src/providers/local.rs
@@ -11,7 +11,8 @@ use maki_config::providers::Protocol;
 
 use crate::model::Model;
 use crate::provider::{BoxFuture, Provider};
-use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
+use crate::types::{ThinkingFieldConfig, ToggleEntry};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
 use super::openai::responses;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
@@ -35,6 +36,19 @@ fn resolve_protocol_for_local(slug: &str) -> Option<Protocol> {
         slug,
         maki_config::providers::ProvidersConfig::load().get(slug),
     )
+}
+
+fn local_fields() -> ThinkingFieldConfig {
+    ThinkingFieldConfig {
+        budget_path: Some("thinking_budget_tokens".into()),
+        toggles: vec![ToggleEntry {
+            path: "thinking_budget_tokens".into(),
+            off: Some(json!(0)),
+            adaptive: Some(json!(-1)),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
 }
 
 pub(crate) struct LocalEndpoint {
@@ -162,9 +176,11 @@ impl Provider for LocalEndpoint {
             let mut body = self.compat.build_body(model, messages, system, tools);
 
             if self.thinking_budget_field {
-                opts.thinking.apply_local_thinking(&mut body, model);
+                opts.thinking
+                    .apply_thinking(&mut body, model, &dialect::STANDARD, &local_fields());
             }
 
+            super::apply_body_overrides(&mut body, model, &["messages"]);
             self.compat
                 .do_stream(model, &[], &body, event_tx, &auth)
                 .await

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -6,6 +6,7 @@ use serde_json::{Value, json};
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
+use crate::types::ThinkingFieldConfig;
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
@@ -19,6 +20,13 @@ static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     include_stream_usage: true,
     provider_name: "Mistral",
 };
+
+fn mistral_fields() -> ThinkingFieldConfig {
+    ThinkingFieldConfig {
+        effort_path: Some("reasoning_effort".into()),
+        ..Default::default()
+    }
+}
 
 inventory::submit!(maki_config::providers::BuiltInProvider {
     slug: "mistral",
@@ -200,10 +208,11 @@ impl Provider for Mistral {
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
             opts.thinking
-                .apply_reasoning_effort(&mut body, &dialect::HIGH_ONLY, model);
+                .apply_thinking(&mut body, model, &dialect::HIGH_ONLY, &mistral_fields());
             // Convert assistant messages to Mistral's expected format with thinking content
             convert_assistant_messages_in_place(body.get_mut("messages").unwrap());
 
+            super::apply_body_overrides(&mut body, model, &["messages"]);
             let mut extra_headers = vec![];
             if let Some(session_id) = session_id {
                 extra_headers.push(("x-affinity", session_id.as_str()));

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -7,9 +7,11 @@ use futures_lite::io::AsyncBufRead;
 use isahc::config::Configurable;
 use isahc::http::request::Builder;
 use serde::Deserialize;
+use serde_json::Value;
 use tracing::debug;
 
 use crate::AgentError;
+use crate::model::Model;
 
 pub(crate) mod anthropic;
 pub(crate) mod copilot;
@@ -107,6 +109,78 @@ pub(crate) fn urlenc(s: &str) -> String {
         }
     }
     out
+}
+
+/// Apply per-model body overrides after all typed thinking setup. Three
+/// operations run in order: `defaults` (additive, only fills absent keys),
+/// `replace` (deep-merge, overwrites existing), `filter` (strips keys).
+/// `protected` is the conversation field for this provider's protocol
+/// (`messages`, `input`, or `contents`); none of the three can touch it.
+///
+/// Nothing happens when `body_override` is `None`, so the no-override path
+/// stays zero-cost.
+pub(crate) fn apply_body_overrides(body: &mut Value, model: &Model, protected: &[&str]) {
+    let Some(ov) = model.body_override.as_ref() else {
+        return;
+    };
+    if let Some(defaults) = &ov.defaults {
+        shallow_inject(body, defaults, protected);
+    }
+    if let Some(replace) = &ov.replace {
+        deep_merge(body, replace, protected);
+    }
+    if !ov.filter.is_empty() {
+        filter_body(body, &ov.filter, protected);
+    }
+}
+
+fn shallow_inject(body: &mut Value, defaults: &Value, protected: &[&str]) {
+    let (Some(body_obj), Some(defaults_obj)) = (body.as_object_mut(), defaults.as_object()) else {
+        return;
+    };
+    for (k, v) in defaults_obj {
+        if protected.contains(&k.as_str()) {
+            continue;
+        }
+        if !body_obj.contains_key(k) {
+            body_obj.insert(k.clone(), v.clone());
+        }
+    }
+}
+
+fn deep_merge(body: &mut Value, replace: &Value, protected: &[&str]) {
+    let (Some(body_obj), Some(replace_obj)) = (body.as_object_mut(), replace.as_object()) else {
+        return;
+    };
+    for (k, v) in replace_obj {
+        if protected.contains(&k.as_str()) {
+            continue;
+        }
+        match body_obj.get_mut(k) {
+            Some(existing) if existing.is_object() && v.is_object() => {
+                if let (Some(e), Some(r)) = (existing.as_object_mut(), v.as_object()) {
+                    for (rk, rv) in r {
+                        e.insert(rk.clone(), rv.clone());
+                    }
+                }
+            }
+            _ => {
+                body_obj.insert(k.clone(), v.clone());
+            }
+        }
+    }
+}
+
+fn filter_body(body: &mut Value, filter: &[String], protected: &[&str]) {
+    let Some(obj) = body.as_object_mut() else {
+        return;
+    };
+    for k in filter {
+        if protected.contains(&k.as_str()) {
+            continue;
+        }
+        obj.remove(k);
+    }
 }
 
 #[derive(Deserialize)]
@@ -386,5 +460,171 @@ mod tests {
         assert!(result.is_err());
         let msg = format!("{result:?}");
         assert!(msg.contains(&env_var) || msg.contains(&slug));
+    }
+
+    #[test]
+    fn shallow_inject_fills_absent_keys_only() {
+        let mut body = serde_json::json!({"temperature": 0.1, "messages": []});
+        let defaults = serde_json::json!({"temperature": 0.7, "max_tokens": 8192});
+        shallow_inject(&mut body, &defaults, &["messages"]);
+        assert_eq!(body["temperature"], 0.1);
+        assert_eq!(body["max_tokens"], 8192);
+    }
+
+    #[test]
+    fn shallow_inject_empty_is_noop() {
+        let mut body = serde_json::json!({"x": 1});
+        shallow_inject(&mut body, &serde_json::json!({}), &[]);
+        assert_eq!(body, serde_json::json!({"x": 1}));
+    }
+
+    #[test]
+    fn shallow_inject_nested_value_lands_whole() {
+        let mut absent = serde_json::json!({"a": 1});
+        shallow_inject(
+            &mut absent,
+            &serde_json::json!({"chat_template_kwargs": {"x": 1}}),
+            &[],
+        );
+        assert_eq!(absent["chat_template_kwargs"]["x"], 1);
+
+        let mut present = serde_json::json!({"chat_template_kwargs": {"y": 1}});
+        shallow_inject(
+            &mut present,
+            &serde_json::json!({"chat_template_kwargs": {"x": 999}}),
+            &[],
+        );
+        assert_eq!(present["chat_template_kwargs"]["y"], 1);
+        assert!(present["chat_template_kwargs"].get("x").is_none());
+    }
+
+    #[test]
+    fn filter_body_removes_listed_keys() {
+        let mut body = serde_json::json!({
+            "context_management": {"x": 1},
+            "keep": true,
+            "also_drop": null
+        });
+        filter_body(
+            &mut body,
+            &["context_management".into(), "also_drop".into()],
+            &[],
+        );
+        assert_eq!(body, serde_json::json!({"keep": true}));
+    }
+
+    #[test]
+    fn filter_body_missing_key_is_noop() {
+        let mut body = serde_json::json!({"keep": true});
+        filter_body(&mut body, &["context_management".into()], &[]);
+        assert_eq!(body, serde_json::json!({"keep": true}));
+    }
+
+    #[test]
+    fn apply_body_overrides_defaults_then_replace_then_filter() {
+        let model = Model {
+            id: "test-model".into(),
+            provider: Arc::from("anthropic"),
+            tier: crate::model::ModelTier::Medium,
+            family: crate::model::ModelFamily::Claude,
+            supports_tool_examples_override: None,
+            supports_thinking_override: None,
+            supports_vision_override: None,
+            pricing: Default::default(),
+            max_output_tokens: Some(8192),
+            context_window: 200_000,
+            thinking_dialect: None,
+            thinking_fields: None,
+            body_override: Some(crate::types::BodyOverride {
+                defaults: Some(serde_json::json!({"temperature": 0.7, "poison": "bad"})),
+                replace: Some(serde_json::json!({"temperature": 0.1})),
+                filter: vec!["poison".into()],
+            }),
+        };
+        let mut body = serde_json::json!({"messages": [], "temperature": 0.5});
+        apply_body_overrides(&mut body, &model, &["messages"]);
+        // Replace overwrites the existing temperature (not the defaults value).
+        assert_eq!(body["temperature"], 0.1);
+        assert_eq!(body["messages"], serde_json::json!([]));
+        assert!(body.get("poison").is_none());
+    }
+
+    #[test]
+    fn apply_body_overrides_no_override_is_noop() {
+        let model = Model {
+            id: "test-model".into(),
+            provider: Arc::from("anthropic"),
+            tier: crate::model::ModelTier::Medium,
+            family: crate::model::ModelFamily::Claude,
+            supports_tool_examples_override: None,
+            supports_thinking_override: None,
+            supports_vision_override: None,
+            pricing: Default::default(),
+            max_output_tokens: Some(8192),
+            context_window: 200_000,
+            thinking_dialect: None,
+            thinking_fields: None,
+            body_override: None,
+        };
+        let mut body = serde_json::json!({"messages": [], "temperature": 0.5});
+        apply_body_overrides(&mut body, &model, &["messages"]);
+        assert_eq!(
+            body,
+            serde_json::json!({"messages": [], "temperature": 0.5})
+        );
+    }
+
+    #[test]
+    fn apply_body_overrides_protected_key_survives_filter() {
+        let model = Model {
+            id: "test-model".into(),
+            provider: Arc::from("anthropic"),
+            tier: crate::model::ModelTier::Medium,
+            family: crate::model::ModelFamily::Claude,
+            supports_tool_examples_override: None,
+            supports_thinking_override: None,
+            supports_vision_override: None,
+            pricing: Default::default(),
+            max_output_tokens: Some(8192),
+            context_window: 200_000,
+            thinking_dialect: None,
+            thinking_fields: None,
+            body_override: Some(crate::types::BodyOverride {
+                defaults: None,
+                replace: None,
+                filter: vec!["messages".into()],
+            }),
+        };
+        let mut body = serde_json::json!({"messages": [{"role": "user"}]});
+        apply_body_overrides(&mut body, &model, &["messages"]);
+        assert_eq!(body["messages"], serde_json::json!([{"role": "user"}]));
+    }
+
+    #[test]
+    fn apply_body_overrides_replace_deep_merges_nested() {
+        let model = Model {
+            id: "test-model".into(),
+            provider: Arc::from("anthropic"),
+            tier: crate::model::ModelTier::Medium,
+            family: crate::model::ModelFamily::Claude,
+            supports_tool_examples_override: None,
+            supports_thinking_override: None,
+            supports_vision_override: None,
+            pricing: Default::default(),
+            max_output_tokens: Some(8192),
+            context_window: 200_000,
+            thinking_dialect: None,
+            thinking_fields: None,
+            body_override: Some(crate::types::BodyOverride {
+                defaults: None,
+                replace: Some(serde_json::json!({"generationConfig": {"thinkingBudget": 8192}})),
+                filter: vec![],
+            }),
+        };
+        let mut body =
+            serde_json::json!({"messages": [], "generationConfig": {"includeThoughts": true}});
+        apply_body_overrides(&mut body, &model, &["messages"]);
+        assert_eq!(body["generationConfig"]["thinkingBudget"], 8192);
+        assert_eq!(body["generationConfig"]["includeThoughts"], true);
     }
 }

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -8,6 +8,7 @@ use tracing::{debug, warn};
 
 use crate::model::Model;
 use crate::provider::{BoxFuture, Provider};
+use crate::types::ThinkingFieldConfig;
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
 use super::auth;
@@ -35,6 +36,13 @@ pub(crate) const PLAN_MODELS: &[&str] = &[
     "gpt-5.4-mini",
     "gpt-5.2",
 ];
+
+fn standard_fields() -> ThinkingFieldConfig {
+    ThinkingFieldConfig {
+        effort_path: Some("reasoning_effort".into()),
+        ..Default::default()
+    }
+}
 
 const CODEX_PLAN_CONTEXT_WINDOW: u32 = 272_000;
 const GPT_5_6_PLAN_CONTEXT_WINDOW: u32 = 372_000;
@@ -218,7 +226,8 @@ impl Provider for OpenAi {
 
             let mut body = self.compat.build_body(model, messages, system, tools);
             opts.thinking
-                .apply_reasoning_effort(&mut body, &dialect::STANDARD, model);
+                .apply_thinking(&mut body, model, &dialect::STANDARD, &standard_fields());
+            super::super::apply_body_overrides(&mut body, model, &["messages"]);
             self.with_oauth_retry(|| async {
                 let auth = self.current_auth();
                 self.compat

--- a/maki-providers/src/providers/openai/responses.rs
+++ b/maki-providers/src/providers/openai/responses.rs
@@ -33,6 +33,7 @@ pub(crate) fn build_body(
     if wire_tools.as_array().is_some_and(|a| !a.is_empty()) {
         body["tools"] = wire_tools;
     }
+    super::super::apply_body_overrides(&mut body, model, &["input"]);
     body
 }
 

--- a/maki-providers/src/providers/opencode.rs
+++ b/maki-providers/src/providers/opencode.rs
@@ -19,6 +19,7 @@ use maki_storage::auth::load_provider_credentials;
 use crate::model::{Model, ModelInfo, ModelPricing};
 use crate::provider::{BoxFuture, Provider};
 use crate::providers::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+use crate::types::ThinkingFieldConfig;
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
 use super::{ResolvedAuth, http_client};
@@ -413,6 +414,13 @@ impl CatalogData {
     }
 }
 
+fn opencode_compat_fields() -> ThinkingFieldConfig {
+    ThinkingFieldConfig {
+        effort_path: Some("reasoning_effort".into()),
+        ..Default::default()
+    }
+}
+
 static CATALOG_CHAT_CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     slug: "opencode",
     api_key_env: "",
@@ -477,8 +485,13 @@ impl Opencode {
         opts: &RequestOptions,
     ) -> Result<StreamResponse, AgentError> {
         let mut body = self.chat_compat.build_body(model, messages, system, tools);
-        opts.thinking
-            .apply_reasoning_effort(&mut body, &dialect::PREFER_HIGH, model);
+        opts.thinking.apply_thinking(
+            &mut body,
+            model,
+            &dialect::PREFER_HIGH,
+            &opencode_compat_fields(),
+        );
+        super::apply_body_overrides(&mut body, model, &["messages"]);
         self.chat_compat
             .do_stream(model, &[], &body, event_tx, auth)
             .await

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -8,7 +8,7 @@ use crate::model::{Model, ModelEntry, ModelInfo, ModelPricing};
 use crate::provider::{BoxFuture, Provider};
 use crate::{
     AgentError, Effort, EffortDialect, Message, ProviderEvent, RequestOptions, StreamResponse,
-    dialect,
+    ThinkingFieldConfig, dialect,
 };
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
@@ -198,16 +198,20 @@ impl Provider for OpenRouter {
             };
 
             let effort_dialect = effort_dialect(reasoning_info.as_deref());
-            if model.supports_thinking()
-                && let Some(effort) = opts.thinking.effort_str(&effort_dialect, model)
-            {
-                body["reasoning"] = json!({"effort": effort});
+            if model.supports_thinking() {
+                let fields = ThinkingFieldConfig {
+                    effort_path: Some("reasoning.effort".into()),
+                    ..Default::default()
+                };
+                opts.thinking
+                    .apply_thinking(&mut body, model, &effort_dialect, &fields);
             }
 
             if let Some(sid) = session_id {
                 body["session_id"] = json!(sid.to_string());
             }
 
+            super::apply_body_overrides(&mut body, model, &["messages"]);
             let extra_headers = [("HTTP-Referer", REFERER), ("X-OpenRouter-Title", APP_TITLE)];
             self.compat
                 .do_stream(model, &extra_headers, &body, event_tx, &auth)
@@ -314,6 +318,9 @@ mod tests {
             pricing: ModelPricing::default(),
             max_output_tokens: Some(8192),
             context_window: 200_000,
+            thinking_dialect: None,
+            thinking_fields: None,
+            body_override: None,
         };
         (effort_dialect(info), model)
     }

--- a/maki-providers/src/providers/synthetic.rs
+++ b/maki-providers/src/providers/synthetic.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
+use crate::types::ThinkingFieldConfig;
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
@@ -19,6 +20,13 @@ static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     include_stream_usage: false,
     provider_name: "Synthetic",
 };
+
+fn synthetic_fields() -> ThinkingFieldConfig {
+    ThinkingFieldConfig {
+        effort_path: Some("reasoning_effort".into()),
+        ..Default::default()
+    }
+}
 
 inventory::submit!(maki_config::providers::BuiltInProvider {
     slug: "synthetic",
@@ -135,7 +143,8 @@ impl Provider for Synthetic {
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
             opts.thinking
-                .apply_reasoning_effort(&mut body, &dialect::STANDARD, model);
+                .apply_thinking(&mut body, model, &dialect::STANDARD, &synthetic_fields());
+            super::apply_body_overrides(&mut body, model, &["messages"]);
             self.compat
                 .do_stream(model, &[], &body, event_tx, &auth)
                 .await

--- a/maki-providers/src/providers/tensorx.rs
+++ b/maki-providers/src/providers/tensorx.rs
@@ -6,6 +6,7 @@ use serde_json::{Value, json};
 
 use crate::model::{Model, ModelEntry, ModelInfo, ModelPricing};
 use crate::provider::{BoxFuture, Provider};
+use crate::types::{ThinkingFieldConfig, ToggleEntry};
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
@@ -109,21 +110,47 @@ impl Provider for TensorX {
                 }
             };
 
-            if has_thinking {
-                body["thinking"] = json!(opts.thinking.is_enabled());
-            }
-            if has_reasoning_effort {
-                opts.thinking
-                    .apply_reasoning_effort(&mut body, &dialect::TENSORX, model);
-            }
+            let fields = if has_thinking && has_reasoning_effort {
+                ThinkingFieldConfig {
+                    effort_path: Some("reasoning_effort".into()),
+                    toggles: vec![ToggleEntry {
+                        path: "thinking".into(),
+                        on: Some(json!(true)),
+                        off: Some(json!(false)),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }
+            } else if has_thinking {
+                ThinkingFieldConfig {
+                    toggles: vec![ToggleEntry {
+                        path: "thinking".into(),
+                        on: Some(json!(true)),
+                        off: Some(json!(false)),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }
+            } else if has_reasoning_effort {
+                ThinkingFieldConfig {
+                    effort_path: Some("reasoning_effort".into()),
+                    ..Default::default()
+                }
+            } else {
+                ThinkingFieldConfig::default()
+            };
+            opts.thinking
+                .apply_thinking(&mut body, model, &dialect::TENSORX, &fields);
             // Fallback for deepseek models that use chat_template_kwargs
-            else if !has_thinking
+            if !has_thinking
+                && !has_reasoning_effort
                 && opts.thinking.is_enabled()
                 && model.id.starts_with("deepseek/deepseek-v4")
             {
                 body["chat_template_kwargs"] = json!({"thinking": true});
             }
 
+            super::apply_body_overrides(&mut body, model, &["messages"]);
             self.compat
                 .do_stream(model, &[], &body, event_tx, &auth)
                 .await

--- a/maki-providers/src/providers/zai/mod.rs
+++ b/maki-providers/src/providers/zai/mod.rs
@@ -10,6 +10,7 @@ use tracing::warn;
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
 use crate::providers::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+use crate::types::ThinkingFieldConfig;
 use crate::{
     AgentError, Message, ProviderEvent, ProviderUsage, RequestOptions, StreamResponse, UsageLimit,
     dialect,
@@ -25,6 +26,13 @@ static CONFIG_STANDARD: OpenAiCompatConfig = OpenAiCompatConfig {
     include_stream_usage: false,
     provider_name: "Z.AI",
 };
+
+fn zai_fields() -> ThinkingFieldConfig {
+    ThinkingFieldConfig {
+        effort_path: Some("reasoning_effort".into()),
+        ..Default::default()
+    }
+}
 
 const QUOTA_LIMIT_URL: &str = "https://api.z.ai/api/monitor/usage/quota/limit";
 
@@ -301,8 +309,9 @@ impl Provider for Zai {
             let mut body = self.compat.build_body(model, messages, system, tools);
             if model.supports_thinking() {
                 opts.thinking
-                    .apply_reasoning_effort(&mut body, &dialect::GLM, model);
+                    .apply_thinking(&mut body, model, &dialect::GLM, &zai_fields());
             }
+            super::apply_body_overrides(&mut body, model, &["messages"]);
             match self
                 .compat
                 .do_stream(model, &[], &body, event_tx, &auth)

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -7,6 +7,7 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 pub use maki_storage::sessions::Effort;
+pub use maki_storage::sessions::{BodyOverride, EffortDialectId, ThinkingFieldConfig, ToggleEntry};
 use maki_storage::sessions::{MIN_THINKING_BUDGET, StoredThinking, TitleSource};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -403,6 +404,21 @@ pub mod dialect {
     };
 }
 
+/// Map a config-level dialect ID to the static `EffortDialect` it represents.
+/// Lives here (not on the enum in maki-storage) because the dialect consts
+/// are defined in this crate.
+pub fn effort_dialect_for(id: EffortDialectId) -> &'static EffortDialect<'static> {
+    match id {
+        EffortDialectId::Standard => &dialect::STANDARD,
+        EffortDialectId::PreferHigh => &dialect::PREFER_HIGH,
+        EffortDialectId::HighOnly => &dialect::HIGH_ONLY,
+        EffortDialectId::Glm => &dialect::GLM,
+        EffortDialectId::DeepSeek => &dialect::DEEPSEEK,
+        EffortDialectId::AnthropicAdaptive => &dialect::ANTHROPIC_ADAPTIVE,
+        EffortDialectId::TensorX => &dialect::TENSORX,
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum ThinkingConfig {
     #[default]
@@ -418,6 +434,47 @@ enum Budgeted {
     Off,
     Adaptive,
     Tokens(u32),
+}
+
+/// Write `value` at a dot-separated path in `body`, creating intermediate
+/// objects as needed. `"reasoning.effort"` navigates `body["reasoning"]`
+/// (creating it if absent) then sets `["effort"]`.
+fn set_by_path(body: &mut Value, path: &str, value: Value) {
+    let segments: Vec<&str> = path.split('.').collect();
+    let mut current = body;
+    for segment in &segments[..segments.len() - 1] {
+        let entry = &mut current[*segment];
+        if !entry.is_object() {
+            *entry = Value::Object(Default::default());
+        }
+        current = entry;
+    }
+    current[*segments.last().unwrap()] = value;
+}
+
+/// Same navigation as [`set_by_path`] but shallow-merges objects at the leaf
+/// instead of overwriting. Lets a toggle's static fields coexist with dynamic
+/// effort/budget values written to the same object by a later step.
+fn merge_by_path(body: &mut Value, path: &str, value: Value) {
+    let segments: Vec<&str> = path.split('.').collect();
+    let mut current = body;
+    for segment in &segments[..segments.len() - 1] {
+        let entry = &mut current[*segment];
+        if !entry.is_object() {
+            *entry = Value::Object(Default::default());
+        }
+        current = entry;
+    }
+    let target = &mut current[*segments.last().unwrap()];
+    if target.is_object() && value.is_object() {
+        if let (Some(t), Some(v)) = (target.as_object_mut(), value.as_object()) {
+            for (k, val) in v {
+                t.insert(k.clone(), val.clone());
+            }
+        }
+    } else {
+        *target = value;
+    }
 }
 
 impl ThinkingConfig {
@@ -463,8 +520,14 @@ impl ThinkingConfig {
 
     /// Anthropic messages API body. Adaptive-thinking models get the native
     /// adaptive knob plus `output_config.effort`; legacy models get a plain
-    /// token budget.
+    /// token budget. When `model.thinking_fields` is set (dynamic or custom
+    /// provider override), the model takes full control of the wire format
+    /// and the version check is skipped.
     pub fn apply_to_body(self, body: &mut Value, model: &Model) {
+        if let Some(fields) = &model.thinking_fields {
+            self.apply_thinking(body, model, &dialect::ANTHROPIC_ADAPTIVE, fields);
+            return;
+        }
         if Self::requires_adaptive(&model.id) {
             match self {
                 Self::Off => {}
@@ -526,6 +589,100 @@ impl ThinkingConfig {
             Budgeted::Tokens(n) => i64::from(n),
         };
         body["thinking_budget_tokens"] = json!(budget);
+    }
+
+    /// Serialize thinking to `body` using a declarative field config. When
+    /// `model.thinking_fields` fields are set they override `default_fields`;
+    /// fields that are `None`/empty fall back to the provider default.
+    /// `model.thinking_dialect` overrides `default_dialect` when set.
+    ///
+    /// Pipeline: toggles (set for Off, deep-merge for enabled states)
+    /// then budget (at `budget_path`, or nested in the first toggle with
+    /// `budget_key`) then effort string (at `effort_path`).
+    pub fn apply_thinking(
+        self,
+        body: &mut Value,
+        model: &Model,
+        default_dialect: &EffortDialect,
+        default_fields: &ThinkingFieldConfig,
+    ) {
+        let dialect = model.effort_dialect(default_dialect);
+
+        // Partial merge: model fields take priority when set, otherwise we
+        // fall back to the provider default. A script that only sets a
+        // toggle (like BlazeAPI's enable_thinking) still gets the base
+        // provider's effort_path and budget_path for free.
+        let effort_path = model
+            .thinking_fields
+            .as_ref()
+            .and_then(|f| f.effort_path.as_deref())
+            .or(default_fields.effort_path.as_deref());
+        let budget_path = model
+            .thinking_fields
+            .as_ref()
+            .and_then(|f| f.budget_path.as_deref())
+            .or(default_fields.budget_path.as_deref());
+        let budget_max = model
+            .thinking_fields
+            .as_ref()
+            .and_then(|f| f.budget_max)
+            .or(default_fields.budget_max);
+        let toggles = model
+            .thinking_fields
+            .as_ref()
+            .filter(|f| !f.toggles.is_empty())
+            .map(|f| &f.toggles)
+            .unwrap_or(&default_fields.toggles);
+
+        let max = budget_max
+            .map(|cap| {
+                model
+                    .max_thinking_budget()
+                    .map(|m| m.min(cap))
+                    .or(Some(cap))
+            })
+            .unwrap_or_else(|| model.max_thinking_budget());
+
+        for toggle in toggles {
+            match self {
+                Self::Off => {
+                    if let Some(v) = &toggle.off {
+                        set_by_path(body, &toggle.path, v.clone());
+                    }
+                }
+                Self::Adaptive => {
+                    let val = toggle.adaptive.as_ref().or(toggle.on.as_ref());
+                    if let Some(v) = val {
+                        merge_by_path(body, &toggle.path, v.clone());
+                    }
+                }
+                _ => {
+                    if let Some(v) = &toggle.on {
+                        merge_by_path(body, &toggle.path, v.clone());
+                    }
+                }
+            }
+        }
+
+        if let Budgeted::Tokens(n) = self.budget(max) {
+            if let Some(bp) = budget_path {
+                set_by_path(body, bp, json!(n));
+            } else {
+                for toggle in toggles {
+                    if let Some(key) = &toggle.budget_key {
+                        let path = format!("{}.{}", toggle.path, key);
+                        set_by_path(body, &path, json!(n));
+                        break;
+                    }
+                }
+            }
+        }
+
+        if let Some(ep) = effort_path
+            && let Some(effort) = self.effort_str(dialect, model)
+        {
+            set_by_path(body, ep, json!(effort));
+        }
     }
 
     pub fn parse(input: &str, current: Self) -> Result<Self, &'static str> {
@@ -902,6 +1059,9 @@ mod tests {
             pricing: crate::model::ModelPricing::default(),
             max_output_tokens: Some(8192),
             context_window: 200_000,
+            thinking_dialect: None,
+            thinking_fields: None,
+            body_override: None,
         }
     }
 

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -23,6 +23,7 @@ use tracing::warn;
 use crate::id::{MakiId, MakiIdParseError};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::{StateDir, StorageError, atomic_write, now_epoch};
 
@@ -340,6 +341,72 @@ impl FromStr for Effort {
             .find(|e| e.as_str() == s)
             .ok_or_else(|| ThinkingParseError::Unknown(s.to_string()))
     }
+}
+
+/// Serializable identifier for a built-in effort dialect. Resolved to
+/// the actual `EffortDialect` by `maki_providers::effort_dialect_for`.
+/// Lives here so both `maki-config` (TOML) and `maki-providers` (JSON
+/// dynamic scripts) can deserialize it without a cross-dependency.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum EffortDialectId {
+    Standard,
+    PreferHigh,
+    HighOnly,
+    Glm,
+    DeepSeek,
+    AnthropicAdaptive,
+    TensorX,
+}
+
+/// One toggle object written to the body based on the thinking state.
+/// `on` is deep-merged for Effort/Budget, `adaptive` for Adaptive (falls
+/// back to `on`), `off` is set for Off. `budget_key` nests the computed
+/// budget inside this toggle's object.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ToggleEntry {
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub off: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub adaptive: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget_key: Option<String>,
+}
+
+/// Where thinking values go in the request body. When set on a model it
+/// overrides the base provider's hardcoded thinking layout. Supports
+/// multiple toggle objects (ElectronHub writes both `thinking` and
+/// `reasoning`), nested paths (OpenRouter's `reasoning.effort`), budgets
+/// nested inside toggles (Anthropic's `budget_tokens`), and budget caps
+/// (Google's family-specific limits).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ThinkingFieldConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget_max: Option<u32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub toggles: Vec<ToggleEntry>,
+}
+
+/// Unified body manipulation for per-model overrides. Three operations
+/// run in order: `defaults` (additive, only fills absent keys), `replace`
+/// (deep-merge, overwrites existing), `filter` (strips keys). Each
+/// provider guards its conversation field so none of the three can touch
+/// `messages`, `input`, or `contents`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct BodyOverride {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub defaults: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replace: Option<Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub filter: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1512,9 +1579,13 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::BodyOverride;
     use super::Effort;
+    use super::EffortDialectId;
     use super::StoredThinking;
+    use super::ThinkingFieldConfig;
     use super::ThinkingParseError;
+    use super::ToggleEntry;
     use super::{
         CWD_INDEX_FILE, DEFAULT_TITLE, LOG_BLOATED, MAX_APPENDS, MAX_TITLE_LEN, SESSION_VERSION,
         StoredSubagent, TAIL_BUF, generate_title, json_path, jsonl_path, load_cwd_index,
@@ -2982,5 +3053,64 @@ mod tests {
 
         let loaded = TestSession::load_from(session.id, dir).unwrap();
         assert_same_session(&loaded, &session);
+    }
+
+    #[test_case(EffortDialectId::Standard ; "standard")]
+    #[test_case(EffortDialectId::PreferHigh ; "prefer_high")]
+    #[test_case(EffortDialectId::HighOnly ; "high_only")]
+    #[test_case(EffortDialectId::Glm ; "glm")]
+    #[test_case(EffortDialectId::DeepSeek ; "deep_seek")]
+    #[test_case(EffortDialectId::AnthropicAdaptive ; "anthropic_adaptive")]
+    #[test_case(EffortDialectId::TensorX ; "tensor_x")]
+    fn effort_dialect_id_serde_round_trip(id: EffortDialectId) {
+        let json = serde_json::to_string(&id).unwrap();
+        let parsed: EffortDialectId = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, id);
+    }
+
+    #[test]
+    fn thinking_field_config_empty_round_trip() {
+        let config = ThinkingFieldConfig::default();
+        let json = serde_json::to_string(&config).unwrap();
+        assert_eq!(json, "{}");
+        let parsed: ThinkingFieldConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, config);
+    }
+
+    #[test]
+    fn thinking_field_config_with_toggles_round_trip() {
+        let config = ThinkingFieldConfig {
+            effort_path: Some("reasoning_effort".into()),
+            toggles: vec![ToggleEntry {
+                path: "thinking".into(),
+                on: Some(serde_json::json!({"type": "enabled"})),
+                off: Some(serde_json::json!({"type": "disabled"})),
+                adaptive: Some(serde_json::json!({"type": "adaptive"})),
+                budget_key: Some("budget_tokens".into()),
+            }],
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: ThinkingFieldConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, config);
+    }
+
+    #[test]
+    fn body_override_round_trip() {
+        let ov = BodyOverride {
+            defaults: Some(serde_json::json!({"temperature": 0.1})),
+            replace: Some(serde_json::json!({"max_tokens": 8192})),
+            filter: vec!["poison".into()],
+        };
+        let json = serde_json::to_string(&ov).unwrap();
+        let parsed: BodyOverride = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, ov);
+    }
+
+    #[test]
+    fn body_override_empty_serializes_to_empty_object() {
+        let ov = BodyOverride::default();
+        let json = serde_json::to_string(&ov).unwrap();
+        assert_eq!(json, "{}");
     }
 }

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -394,6 +394,9 @@ pub(crate) fn test_model() -> maki_providers::Model {
         pricing: test_pricing(),
         max_output_tokens: Some(8192),
         context_window: TEST_CONTEXT_WINDOW,
+        thinking_dialect: None,
+        thinking_fields: None,
+        body_override: None,
     }
 }
 

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -373,7 +373,15 @@ If your provider serves models not in the base catalog, add a `models` subcomman
 [{"id": "my-model-v2", "tier": "strong", "context_window": 200000, "max_output_tokens": 16384}]
 ```
 
-Only `id` is required. Optional fields: `tier` (default `medium`), `context_window` (128K), `max_output_tokens` (16K), `pricing` (`{input, output, cache_write, cache_read}`, all per 1M tokens), `supports_tool_examples` (defaults to the base provider's setting), `supports_thinking` (defaults to the base provider's setting), `supports_vision` (defaults to the base provider's setting; when false, image input and the `view_image` tool are disabled). The first model listed per tier is used for sub-agents. Without this subcommand, the base provider's models are used.
+Only `id` is required. Optional fields: `tier` (default `medium`), `context_window` (128K), `max_output_tokens` (16K), `pricing` (`{input, output, cache_write, cache_read}`, all per 1M tokens), `supports_tool_examples` (defaults to the base provider's setting), `supports_thinking` (defaults to the base provider's setting), `supports_vision` (defaults to the base provider's setting; when false, image input and the `view_image` tool are disabled), `thinking_dialect` (overrides the base provider's effort level mapping; one of `standard`, `prefer-high`, `high-only`, `glm`, `deep-seek`, `anthropic-adaptive`, `tensor-x`), `thinking_fields` (overrides where thinking values go in the body; see below), `body_override` (per-model body manipulation with three operations: `defaults` fills absent keys, `replace` overwrites existing keys, `filter` strips keys). The first model listed per tier is used for selecting that tier at runtime.
+
+`body_override` is the escape hatch when a model needs a field the base provider does not set, or needs to remove one the base provider always sets. All three operations run after the typed thinking setup, and each provider guards its conversation field (`messages`, `input`, or `contents`) from all three. Example:
+
+```json
+[{"id": "my-model", "tier": "strong", "body_override": {"defaults": {"chat_template_kwargs": {"enable_thinking": true}}, "filter": ["some_base_key"]}}]
+```
+
+`thinking_fields` lets you control where effort strings, toggles, and budgets go in the body. It has `effort_path` (dot-path for the effort string), `budget_path` (dot-path for a budget integer), `budget_max` (cap), and `toggles` (a list of toggle objects, each with `path`, `on`, `off`, `adaptive`, and `budget_key`). This lets you handle providers like DeepSeek (toggle + effort), Google (budget + thoughts flag), OpenRouter (nested `reasoning.effort`), and exotic setups like ElectronHub (multiple toggle objects + effort in a nested object).
 
 Dynamic provider models are namespaced as `{slug}/{model_id}` (e.g. `myproxy/claude-sonnet-4-6`).
 


### PR DESCRIPTION
Some models behind dynamic and custom providers need different effort levels, toggle fields, or budget paths than the base provider hardcodes. A GLM model routed through openai_compat was stuck with prefer-high levels and no way to get xhigh. Now the script or TOML can set thinking_dialect to pick the right level mapping and thinking_fields to point effort strings, toggles, and budgets at whatever fields the API expects, including nested paths and multiple toggle objects. The old inject_params and filter_params become body_override with three operations (defaults, replace, filter) that run after all thinking setup, and each provider guards its conversation field so nobody accidentally strips the messages.