### PR TITLE
feat(lua): emit tool lifecycle events 🤖🤖🤖

### DIFF
--- a/maki-lua/src/api/autocmd.rs
+++ b/maki-lua/src/api/autocmd.rs
@@ -128,13 +128,15 @@ fn parse_string_or_seq(value: Value, what: &str) -> LuaResult<Vec<String>> {
 /// `del_autocmd` later to remove the listener.
 ///
 /// Built-in events fired by the host: `"TurnStart"`, `"TurnEnd"`,
-/// `"TurnError"`, `"SessionReset"`, and `"SessionFocusChanged"`. Plugins can
-/// also fire their own events with `exec_autocmds`.
+/// `"TurnError"`, `"ToolStart"`, `"ToolDone"`, `"SessionReset"`, and
+/// `"SessionFocusChanged"`. Plugins can also fire their own events with
+/// `exec_autocmds`.
 ///
 /// Each host event carries `data.session_id`. For `"SessionReset"` that
 /// is the session being left behind; the other events name the session now
-/// running or focused. `"SessionFocusChanged"` also carries
-/// `data.previous_session_id` except on initial startup.
+/// running or focused. Tool events also carry `data.tool_id` and `data.tool`.
+/// `"SessionFocusChanged"` also carries `data.previous_session_id` except on
+/// initial startup.
 ///
 /// @param event string|string[] Event name or list of names.
 /// @param opts table Options:

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -1005,6 +1005,24 @@ impl App {
             return vec![];
         }
 
+        match &envelope.event {
+            AgentEvent::ToolStart(event) => self.fire_session_autocmd(
+                "ToolStart",
+                serde_json::json!({
+                    "tool_id": event.id,
+                    "tool": event.tool,
+                }),
+            ),
+            AgentEvent::ToolDone(event) => self.fire_session_autocmd(
+                "ToolDone",
+                serde_json::json!({
+                    "tool_id": event.id,
+                    "tool": event.tool,
+                }),
+            ),
+            _ => {}
+        }
+
         let subagent_id = envelope
             .subagent
             .as_ref()

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -645,6 +645,41 @@ fn load_session_clears_plan() {
 }
 
 #[test]
+fn tool_lifecycle_events_name_the_session_and_tool() {
+    let mut app = streaming_app();
+    let (handle, probe) = maki_lua::test_support::probed_event_handle();
+    app.lua_event_handle = handle;
+    let session_id = app.state.session.id.to_string();
+
+    app.update(agent_msg(tool_start("tool-1", "bash")));
+
+    let (event, data) = probe.try_recv_autocmd().expect("ToolStart fired");
+    assert_eq!(event, "ToolStart");
+    assert_eq!(data["session_id"], serde_json::json!(session_id));
+    assert_eq!(data["tool_id"], "tool-1");
+    assert_eq!(data["tool"], "bash");
+
+    app.update(agent_msg(AgentEvent::ToolDone(Box::new(ToolDoneEvent {
+        id: "tool-1".into(),
+        tool: "bash".into(),
+        output: ToolOutput::Plain("done".into()),
+        is_error: false,
+        annotation: None,
+        written_path: None,
+    }))));
+
+    let (event, data) = probe.try_recv_autocmd().expect("ToolDone fired");
+    assert_eq!(event, "ToolDone");
+    assert_eq!(data["session_id"], serde_json::json!(session_id));
+    assert_eq!(data["tool_id"], "tool-1");
+    assert_eq!(data["tool"], "bash");
+
+    app.run_id += 1;
+    app.update(agent_msg_with_run_id(tool_start("stale", "read"), 1));
+    assert!(probe.try_recv_autocmd().is_none());
+}
+
+#[test]
 fn tab_in_palette_completes_command() {
     let mut app = test_app();
     type_slash(&mut app);

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -450,13 +450,15 @@ Listen for one or more events. Returns an id you can pass to
 `del_autocmd` later to remove the listener.
 
 Built-in events fired by the host: `"TurnStart"`, `"TurnEnd"`,
-`"TurnError"`, `"SessionReset"`, and `"SessionFocusChanged"`. Plugins can
-also fire their own events with `exec_autocmds`.
+`"TurnError"`, `"ToolStart"`, `"ToolDone"`, `"SessionReset"`, and
+`"SessionFocusChanged"`. Plugins can also fire their own events with
+`exec_autocmds`.
 
 Each host event carries `data.session_id`. For `"SessionReset"` that
 is the session being left behind; the other events name the session now
-running or focused. `"SessionFocusChanged"` also carries
-`data.previous_session_id` except on initial startup.
+running or focused. Tool events also carry `data.tool_id` and `data.tool`.
+`"SessionFocusChanged"` also carries `data.previous_session_id` except on
+initial startup.
 
 **Parameters:**
 


### PR DESCRIPTION
## Why this belongs in core

In #703, the direction was to keep goal policy in an external plugin and add
only the Lua APIs that such plugins need. Lua can observe turn and session
boundaries today, but it cannot observe tool activity during a turn.

The external goal plugin uses those boundaries to refresh its session status
while an agent works through a long multi-tool turn. Without a host event, the
plugin must either show stale state until the whole turn ends or poll a
lifecycle that Rust already owns. This is also a general boundary for status,
workflow, and telemetry plugins. It does not add goal-specific behavior.

## What changes

- emit `ToolStart` and `ToolDone` through the existing autocmd path
- include only `session_id`, `tool_id`, and `tool`
- document both events in the generated Lua API reference
- test both payloads and prove that stale-run events are not forwarded

The dispatch is after the existing `run_id` guard. Restore and stale events
keep their current early-return behavior. The change adds no state, queue,
configuration, dependency, or parallel lifecycle path.

## Validation

- `cargo fmt --all -- --check`
- `stylua --check plugins/`
- `cargo clippy --all --tests -- -D warnings`
- `cargo nextest run --workspace` (3,510 passed)
- `cargo test --workspace --doc`
- `just gen-docs-check`
- `cargo machete`

`just ci` reaches the repository's existing nine Ruff findings in unchanged
`scripts/` files after the Rust and Lua checks pass.

## AI use

Implemented and reviewed with Codex under my direction. I used it to trace the
existing event and stale-run paths, challenge whether this belongs in core,
add the regression assertion, and run the validation above.
