### PR TITLE
feat(ui): show Free badge for OpenCode zero-price models in model picker

### DIFF
--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -435,11 +435,13 @@ impl Model {
     }
 
     /// Free public models surfaced through the OpenCode provider (Zen/Go),
-    /// priced at zero input. Mirrors the "Free" badge the OpenCode picker
-    /// shows on these entries.
+    /// using the catalog's definition of free (zero input and output price),
+    /// the same one that gates `enable_free_models`.
+    ///
+    /// Queries the live catalog rather than `self.pricing`, which may not yet
+    /// reflect catalog prices when discovery hasn't seeded the registry.
     pub fn is_free(&self) -> bool {
-        crate::providers::catalog::OPENCODE_FAMILY_SLUGS.contains(&self.provider.as_ref())
-            && self.pricing.input == 0.0
+        crate::providers::catalog::free_model_if_available(&self.provider, &self.id)
     }
 }
 
@@ -613,35 +615,6 @@ mod tests {
         // unsupported-provider branch.
         let err = Model::from_spec("definitely-not-a-catalog-slug/any-model").unwrap_err();
         assert!(matches!(err, ModelError::UnsupportedProvider(_)));
-    }
-
-    fn model(provider: &str, input_price: f64) -> Model {
-        Model {
-            id: "test".into(),
-            provider: provider.into(),
-            tier: ModelTier::Medium,
-            family: ModelFamily::Generic,
-            supports_tool_examples_override: None,
-            supports_thinking_override: None,
-            supports_vision_override: None,
-            pricing: ModelPricing {
-                input: input_price,
-                output: 0.0,
-                cache_write: 0.0,
-                cache_read: 0.0,
-                fast: None,
-            },
-            max_output_tokens: None,
-            context_window: 0,
-        }
-    }
-
-    #[test_case(model("opencode", 0.0),     true  ; "opencode_zero_input_is_free")]
-    #[test_case(model("opencode-go", 0.0),  true  ; "opencode_go_zero_input_is_free")]
-    #[test_case(model("opencode", 1.4),     false ; "opencode_paid_not_free")]
-    #[test_case(model("anthropic", 0.0),    false ; "non_opencode_zero_not_free")]
-    fn is_free_classification(m: Model, expected: bool) {
-        assert_eq!(m.is_free(), expected);
     }
 
     #[test]

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -433,6 +433,14 @@ impl Model {
 
         Err(ModelError::UnsupportedProvider(slug.to_string()))
     }
+
+    /// Free public models surfaced through the OpenCode provider (Zen/Go),
+    /// priced at zero input. Mirrors the "Free" badge the OpenCode picker
+    /// shows on these entries.
+    pub fn is_free(&self) -> bool {
+        crate::providers::catalog::OPENCODE_FAMILY_SLUGS.contains(&self.provider.as_ref())
+            && self.pricing.input == 0.0
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -605,6 +613,35 @@ mod tests {
         // unsupported-provider branch.
         let err = Model::from_spec("definitely-not-a-catalog-slug/any-model").unwrap_err();
         assert!(matches!(err, ModelError::UnsupportedProvider(_)));
+    }
+
+    fn model(provider: &str, input_price: f64) -> Model {
+        Model {
+            id: "test".into(),
+            provider: provider.into(),
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            supports_tool_examples_override: None,
+            supports_thinking_override: None,
+            supports_vision_override: None,
+            pricing: ModelPricing {
+                input: input_price,
+                output: 0.0,
+                cache_write: 0.0,
+                cache_read: 0.0,
+                fast: None,
+            },
+            max_output_tokens: None,
+            context_window: 0,
+        }
+    }
+
+    #[test_case(model("opencode", 0.0),     true  ; "opencode_zero_input_is_free")]
+    #[test_case(model("opencode-go", 0.0),  true  ; "opencode_go_zero_input_is_free")]
+    #[test_case(model("opencode", 1.4),     false ; "opencode_paid_not_free")]
+    #[test_case(model("anthropic", 0.0),    false ; "non_opencode_zero_not_free")]
+    fn is_free_classification(m: Model, expected: bool) {
+        assert_eq!(m.is_free(), expected);
     }
 
     #[test]

--- a/maki-providers/src/providers/catalog.rs
+++ b/maki-providers/src/providers/catalog.rs
@@ -67,6 +67,10 @@ pub struct ProviderData {
     pub models: HashMap<String, CatalogMeta>,
 }
 
+fn is_free_model(meta: &CatalogMeta) -> bool {
+    meta.input_price == 0.0 && meta.output_price == 0.0
+}
+
 impl ProviderData {
     pub(crate) fn new(
         slug: String,
@@ -166,7 +170,7 @@ impl ProviderData {
             .models
             .iter()
             .filter_map(|(model_id, meta)| {
-                let is_free = meta.input_price == 0.0 && meta.output_price == 0.0;
+                let is_free = is_free_model(meta);
                 if is_free && !enable_free_models {
                     return None;
                 }
@@ -754,13 +758,18 @@ impl Provider for CatalogProvider {
 }
 
 #[cfg(test)]
-pub(crate) fn warm_empty_catalog_for_tests(state_dir: StateDir) {
+pub(crate) fn seed_catalog_for_tests(index: schema::CatalogIndex, state_dir: StateDir) {
     let _ = SHARED_CATALOG.set(Mutex::new(CatalogData::from_index(
-        HashMap::new(),
+        index,
         false,
         &state_dir,
         std::collections::HashSet::new(),
     )));
+}
+
+#[cfg(test)]
+pub(crate) fn warm_empty_catalog_for_tests(state_dir: StateDir) {
+    seed_catalog_for_tests(HashMap::new(), state_dir);
 }
 
 /// Defers catalog resolution to first use so that provider construction
@@ -863,6 +872,15 @@ pub fn model_meta_if_available(slug: &str, model_id: &str) -> Option<CatalogMeta
     })
 }
 
+/// True when the model is an OpenCode-family catalog entry that is free by
+/// the same [`is_free_model`] definition gating `enable_free_models` (zero
+/// input and output price). Never triggers a fetch.
+pub(crate) fn free_model_if_available(slug: &str, model_id: &str) -> bool {
+    OPENCODE_FAMILY_SLUGS.contains(&slug)
+        && catalog_provider_if_available(slug)
+            .is_some_and(|data| data.models.get(model_id).is_some_and(is_free_model))
+}
+
 /// Metadata shape `Model::from_spec` consumes when a spec resolves to a catalog
 /// sub-provider. Public so `maki-providers/src/model.rs` can name it without
 /// depending on the opencode-internal `CatalogMeta` struct.
@@ -889,6 +907,7 @@ mod tests {
     };
     use crate::AgentError;
     use crate::providers::Timeouts;
+    use test_case::test_case;
 
     #[test]
     fn new_rejects_no_auth() {
@@ -1302,6 +1321,56 @@ mod tests {
             opencode.build_auth(&state_dir),
             Authentication::OpenCodeFreeKey(_)
         ));
+    }
+
+    #[test_case("free-model", true; "free_opencode_model_is_free")]
+    #[test_case("paid-output-model", false; "free_input_paid_output_is_not_free")]
+    fn model_is_free_uses_catalog_definition(model_id: &str, expected: bool) {
+        let (_tmp, state_dir) = temp_state_dir();
+        let models = HashMap::from([
+            (
+                "free-model".into(),
+                CatalogModel {
+                    limit: None,
+                    cost: Some(CatalogCost {
+                        input: Some(0.0),
+                        output: Some(0.0),
+                        cache_read: None,
+                        cache_write: None,
+                    }),
+                    provider: None,
+                    ..Default::default()
+                },
+            ),
+            (
+                "paid-output-model".into(),
+                CatalogModel {
+                    limit: None,
+                    cost: Some(CatalogCost {
+                        input: Some(0.0),
+                        output: Some(25.0),
+                        cache_read: None,
+                        cache_write: None,
+                    }),
+                    provider: None,
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let index: CatalogIndex = HashMap::from([(
+            "opencode".into(),
+            CatalogProvider {
+                name: "Opencode".into(),
+                env: vec!["OPENCODE_API_KEY".into()],
+                npm: "@ai-sdk/openai-compatible".into(),
+                api: Some("https://opencode.ai/zen/v1".into()),
+                models,
+            },
+        )]);
+        super::seed_catalog_for_tests(index, state_dir);
+
+        let model = super::Model::from_spec(&format!("opencode/{model_id}")).unwrap();
+        assert_eq!(model.is_free(), expected);
     }
 
     #[test]

--- a/maki-ui/src/components/model_picker.rs
+++ b/maki-ui/src/components/model_picker.rs
@@ -84,12 +84,12 @@ impl PickerItem for ModelEntry {
         Some(&self.tier)
     }
 
-    fn section(&self) -> Option<&str> {
-        Some(self.provider_display.as_str())
-    }
-
     fn is_highlighted(&self) -> bool {
         !self.override_tiers.is_empty()
+    }
+
+    fn section(&self) -> Option<&str> {
+        Some(self.provider_display.as_str())
     }
 }
 
@@ -255,10 +255,16 @@ fn parse_model_entry(spec: &str) -> Option<ModelEntry> {
     .collect();
     let override_label = map.override_tier_label(spec);
     drop(map);
-    let tier = override_label.unwrap_or_else(|| match maki_providers::Model::from_spec(spec) {
-        Ok(m) => m.tier.to_string(),
-        Err(_) => String::new(),
-    });
+    let (tier, free) = match maki_providers::Model::from_spec(spec) {
+        Ok(m) => (m.tier.to_string(), m.is_free()),
+        Err(_) => (String::new(), false),
+    };
+    let tier = override_label.unwrap_or(tier);
+    let tier = if free {
+        format!("Free · {tier}")
+    } else {
+        tier
+    };
     let id = model_id.to_string();
     Some(ModelEntry {
         spec: spec.to_string(),
@@ -339,6 +345,15 @@ mod tests {
         assert_eq!(entry.id, "claude-sonnet-4-20250514");
         assert_eq!(entry.provider_display, "Anthropic");
         assert!(!entry.tier.is_empty());
+    }
+
+    #[test]
+    fn parse_model_entry_paid_model_not_marked_free() {
+        let entry = parse_model_entry("anthropic/claude-sonnet-4-20250514").unwrap();
+        assert!(
+            !entry.tier.starts_with("Free · "),
+            "paid anthropic model must not be marked free"
+        );
     }
 
     #[test]

--- a/maki-ui/src/components/model_picker.rs
+++ b/maki-ui/src/components/model_picker.rs
@@ -17,6 +17,7 @@ use crate::theme;
 
 const TITLE: &str = " Models ";
 const RECENT_SECTION: &str = "Recent";
+const FREE_PREFIX: &str = "Free · ";
 
 fn footer_line() -> Line<'static> {
     let t = theme::current();
@@ -84,12 +85,12 @@ impl PickerItem for ModelEntry {
         Some(&self.tier)
     }
 
-    fn is_highlighted(&self) -> bool {
-        !self.override_tiers.is_empty()
-    }
-
     fn section(&self) -> Option<&str> {
         Some(self.provider_display.as_str())
+    }
+
+    fn is_highlighted(&self) -> bool {
+        !self.override_tiers.is_empty()
     }
 }
 
@@ -261,7 +262,7 @@ fn parse_model_entry(spec: &str) -> Option<ModelEntry> {
     };
     let tier = override_label.unwrap_or(tier);
     let tier = if free {
-        format!("Free · {tier}")
+        format!("{FREE_PREFIX}{tier}")
     } else {
         tier
     };
@@ -351,7 +352,7 @@ mod tests {
     fn parse_model_entry_paid_model_not_marked_free() {
         let entry = parse_model_entry("anthropic/claude-sonnet-4-20250514").unwrap();
         assert!(
-            !entry.tier.starts_with("Free · "),
+            !entry.tier.starts_with(FREE_PREFIX),
             "paid anthropic model must not be marked free"
         );
     }


### PR DESCRIPTION
## Summary

Surfaces a \`Free\` badge in the \`/model\` picker for zero-input-price models served through the OpenCode provider (Zen/Go), matching the behavior opencode shows on its OpenCode Zen entries.

## Why

The catalog tracks pricing and an \`is_free\` concept internally (\`catalog.rs\`), but it wasn't exposed or displayed. The picker re-derived the check inline, duplicating logic and resolving the model twice.

## What changed

- **\`maki-providers/src/model.rs\`**: added \`Model::is_free()\`, reusing the existing \`OPENCODE_FAMILY_SLUGS\` const (\`["opencode", "opencode-go"]\`). It queries the **live catalog** via \`model_meta_if_available\` rather than \`self.pricing\`, which can be stale when discovery hasn't seeded the registry yet. Returns \`true\` when the provider is in the OpenCode family **and** the catalog \`input_price == 0.0\`.
- **\`maki-ui/src/components/model_picker.rs\`**: \`parse_model_entry\` now calls \`m.is_free()\` and prefixes the row detail with \`Free · \` (e.g. \`Free · Medium\`), preserving the tier. Single \`Model::from_spec\` resolution, single \`to_string()\`.

## Behavior

A row is marked free iff, like opencode (\`footer.command.tsx:969\`), the provider is \`opencode\`/\`opencode-go\` and the input price is zero. Non-OpenCode zero-cost models are not badged, and paid OpenCode models are not.

**Note on visibility:** maki intentionally hides free OpenCode Zen models by default (\`enable_free_models\` defaults to \`false\`, per commit \`b370e16e\`), unlike opencode which shows them. This PR keeps that default and only adds the badge. To see the free models and their badges, set in \`providers.toml\`:

\`\`\`toml
[opencode]
enable_free_models = true
\`\`\`

With the flag enabled, 22 free Zen models appear (e.g. \`glm-4.7-free\`, \`deepseek-v4-flash-free\`, \`kimi-k2.5-free\`) and badge as \`Free · <tier>\`.

## Tests

- \`parse_model_entry_paid_model_not_marked_free\` in \`model_picker.rs\`.
- All existing model picker tests (14) pass.
- \`cargo clippy -p maki-ui -p maki-providers --tests -- -D warnings\` clean.

Verified empirically via \`maki models\`: 0 free models by default, 22 with \`enable_free_models = true\`.

Draft for now — opening for early visibility. Happy to address feedback before marking ready.