### PR TITLE
feat: add model allow and exclude policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,6 +2473,7 @@ dependencies = [
  "color-eyre",
  "flume 0.11.1",
  "maki-agent",
+ "maki-config",
  "maki-providers",
  "maki-storage",
  "serde",
@@ -2529,6 +2530,7 @@ name = "maki-config"
 version = "0.4.5"
 dependencies = [
  "dotenvy",
+ "globset",
  "inventory",
  "maki-config-macro",
  "maki-storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ strum = { version = "0.27", features = ["derive"] }
 htmd = "0.5"
 tempfile = "3"
 regex = { version = "1", default-features = false, features = ["std", "perf", "unicode-perl"] }
+globset = "0.4"
 grep-regex = "0.1"
 grep-searcher = "0.1"
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }

--- a/maki-acp/Cargo.toml
+++ b/maki-acp/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 maki-agent = { workspace = true }
+maki-config = { workspace = true }
 maki-providers = { workspace = true }
 maki-storage = { workspace = true }
 agent-client-protocol-schema = { workspace = true }

--- a/maki-acp/src/lib.rs
+++ b/maki-acp/src/lib.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use maki_agent::prompt::ResolvedSlots;
 use maki_agent::{AgentConfig, PermissionsConfig};
+use maki_config::ModelPolicy;
 use maki_providers::Timeouts;
 use maki_providers::model::Model;
 
@@ -20,6 +21,7 @@ pub struct AcpParams {
     pub mcp_handle: Option<maki_agent::McpHandle>,
     pub prompt_slots: Arc<ResolvedSlots>,
     pub yolo: bool,
+    pub model_policy: Arc<ModelPolicy>,
 }
 
 pub fn run(params: AcpParams) -> color_eyre::Result<()> {

--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -41,6 +41,7 @@ struct SessionState {
 struct Server {
     out_tx: Sender<Value>,
     model_specs: Vec<String>,
+    model_policy: Arc<maki_config::ModelPolicy>,
     session: Option<SessionState>,
 }
 
@@ -66,7 +67,8 @@ pub async fn serve(params: AcpParams) -> color_eyre::Result<()> {
 
     let mut server = Server {
         out_tx,
-        model_specs: available_model_specs(),
+        model_specs: available_model_specs(&params.model_policy),
+        model_policy: Arc::clone(&params.model_policy),
         session: None,
     };
 
@@ -180,6 +182,7 @@ fn spawn_session(
         system_prompt_override: None,
         append_system_prompt: None,
         workflow: false,
+        model_policy: Arc::clone(&params.model_policy),
     })
 }
 
@@ -272,6 +275,9 @@ fn handle_set_config(srv: &mut Server, raw: &Value) -> Result<AgentResponse, Acp
     }
 
     let spec = req.value.0.to_string();
+    if !srv.model_policy.allows(&spec) {
+        return Err(AcpError::invalid_params().data(json_str(&"model is not allowed by policy")));
+    }
     let model =
         Model::from_spec(&spec).map_err(|e| AcpError::invalid_params().data(json_str(&e)))?;
 

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -22,7 +22,7 @@ use crate::{
     AgentConfig, AgentError, AgentEvent, AgentInput, AgentMode, EventSender, ExtractedCommand,
     InterruptSource, SessionMailbox, TurnCompleteEvent,
 };
-use maki_config::ToolOutputLines;
+use maki_config::{ModelPolicy, ToolOutputLines};
 use maki_storage::id::SessionRef;
 
 const MAX_REAUTH_ATTEMPTS: u32 = 2;
@@ -32,11 +32,13 @@ pub fn resolve_compaction_model(
     provider: &Arc<dyn Provider>,
     model: &Model,
     timeouts: maki_providers::Timeouts,
+    model_policy: &ModelPolicy,
 ) -> (Arc<dyn Provider>, Model) {
     if let Some(spec) = maki_providers::model_registry::model_registry()
         .read()
         .unwrap()
         .spec_for_tier_any(maki_providers::ModelTier::Compaction)
+        && model_policy.allows(&spec)
         && let Ok(mut m) = Model::from_spec(&spec)
         && let Ok(p) = maki_providers::provider::from_model(&mut m, timeouts)
     {
@@ -65,6 +67,7 @@ pub struct AgentParams {
     pub subagent_cancels: Arc<CancelMap<String>>,
     pub registry: Arc<crate::tools::ToolRegistry>,
     pub audience: ToolAudience,
+    pub model_policy: Arc<ModelPolicy>,
 }
 
 pub struct AgentRunParams<'h> {
@@ -109,6 +112,7 @@ pub struct Agent<'h> {
     audience: ToolAudience,
     workflow: bool,
     local_tools: LocalTools,
+    model_policy: Arc<ModelPolicy>,
 }
 
 impl<'h> Agent<'h> {
@@ -148,6 +152,7 @@ impl<'h> Agent<'h> {
             audience: params.audience,
             workflow: false,
             local_tools: LocalTools::default(),
+            model_policy: params.model_policy,
         }
     }
 
@@ -457,6 +462,7 @@ impl<'h> Agent<'h> {
             audience: self.audience,
             local_tools: Arc::clone(&self.local_tools),
             live_sink: None,
+            model_policy: Arc::clone(&self.model_policy),
         }
     }
 
@@ -480,8 +486,12 @@ impl<'h> Agent<'h> {
     }
 
     async fn do_compact(&mut self) -> Result<(), AgentError> {
-        let (compact_provider, compact_model) =
-            resolve_compaction_model(&self.provider, &self.model, self.timeouts);
+        let (compact_provider, compact_model) = resolve_compaction_model(
+            &self.provider,
+            &self.model,
+            self.timeouts,
+            &self.model_policy,
+        );
         self.total_usage += compaction::compact_history(
             &*compact_provider,
             &compact_model,
@@ -679,6 +689,7 @@ mod tests {
                 subagent_cancels: Arc::new(crate::cancel::CancelMap::new()),
                 registry: Arc::new(crate::tools::ToolRegistry::new()),
                 audience: ToolAudience::MAIN,
+                model_policy: Arc::new(ModelPolicy::default()),
             },
             AgentRunParams {
                 history,
@@ -1080,6 +1091,7 @@ mod tests {
                     subagent_cancels: Arc::new(crate::cancel::CancelMap::new()),
                     registry: Arc::new(crate::tools::ToolRegistry::new()),
                     audience: ToolAudience::MAIN,
+                    model_policy: Arc::new(ModelPolicy::default()),
                 },
                 AgentRunParams {
                     history: &mut history,

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use async_lock::Mutex;
 use flume::Receiver;
+use maki_config::ModelPolicy;
 use maki_providers::Message;
 use maki_providers::Timeouts;
 use maki_providers::TokenUsage;
@@ -81,6 +82,7 @@ pub struct HeadlessParams {
     pub initial_wd: PathBuf,
     pub fast: bool,
     pub workflow: bool,
+    pub model_policy: Arc<ModelPolicy>,
 }
 
 pub struct HeadlessHandle {
@@ -220,6 +222,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
                     subagent_cancels: Arc::new(CancelMap::new()),
                     registry: Arc::clone(ToolRegistry::global_arc()),
                     audience: ToolAudience::MAIN,
+                    model_policy: Arc::clone(&params.model_policy),
                 },
                 AgentRunParams {
                     history: &mut history,
@@ -282,6 +285,7 @@ pub struct InteractiveParams {
     pub system_prompt_override: Option<String>,
     pub append_system_prompt: Option<String>,
     pub workflow: bool,
+    pub model_policy: Arc<ModelPolicy>,
 }
 
 pub struct InteractiveHandle {
@@ -366,7 +370,10 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                 let event_tx = EventSender::new(raw_tx.clone(), run_id);
                 let error_tx = event_tx.clone();
 
-                if let Some(mut new_model) = model_rx.try_iter().last()
+                if let Some(mut new_model) = model_rx
+                    .try_iter()
+                    .last()
+                    .filter(|candidate| params.model_policy.allows(&candidate.spec()))
                     && new_model.spec() != model.spec()
                 {
                     match provider::from_model_async(&mut new_model, params.timeouts).await {
@@ -434,6 +441,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                         subagent_cancels: Arc::new(CancelMap::new()),
                         registry: Arc::clone(ToolRegistry::global_arc()),
                         audience: ToolAudience::MAIN,
+                        model_policy: Arc::clone(&params.model_policy),
                     },
                     AgentRunParams {
                         history: &mut history,

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -34,7 +34,7 @@ use crate::cancel::{CancelMap, CancelToken};
 use crate::mcp::McpSession;
 use crate::permissions::PermissionManager;
 use crate::{AgentConfig, AgentMode, EventSender, SharedBuf};
-use maki_config::ToolOutputLines;
+use maki_config::{ModelPolicy, ToolOutputLines};
 use maki_providers::Model;
 use maki_providers::RequestOptions;
 use maki_providers::provider::Provider;
@@ -221,6 +221,7 @@ pub struct ToolContext {
     /// Never inherited: `to_tool_context` clears it, and each caller sets
     /// it for its own call only.
     pub live_sink: Option<flume::Sender<ToolLive>>,
+    pub model_policy: Arc<ModelPolicy>,
 }
 
 /// Live progress of a dispatched child tool, streamed while it runs.
@@ -439,6 +440,7 @@ pub fn interpreter_ctx(
         audience: ToolAudience::MAIN,
         local_tools: LocalTools::default(),
         live_sink: None,
+        model_policy: Arc::new(ModelPolicy::default()),
     }
 }
 

--- a/maki-config/Cargo.toml
+++ b/maki-config/Cargo.toml
@@ -14,6 +14,7 @@ toml_edit = { workspace = true }
 tracing = { workspace = true }
 dotenvy = { workspace = true }
 inventory = { workspace = true }
+globset = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use maki_config_macro::ConfigSection;
 use maki_storage::paths;
 use maki_storage::sessions::{StoredThinking, ThinkingParseError};
@@ -167,6 +168,13 @@ pub enum ConfigError {
          A .bak backup is left next to the file."
     )]
     RenamedToolsTable,
+    #[error("invalid config: provider.{field} contains invalid glob pattern `{pattern}`: {source}")]
+    InvalidModelPattern {
+        field: &'static str,
+        pattern: String,
+        #[source]
+        source: globset::Error,
+    },
 }
 
 fn check(
@@ -271,7 +279,7 @@ impl RawConfig {
                 .transpose()?,
             ui: UiConfig::from_file(self.ui),
             agent: AgentConfig::from_file(self.agent, no_rtk, disabled_tools),
-            provider: ProviderConfig::from_file(self.provider),
+            provider: ProviderConfig::from_file(self.provider)?,
             storage: StorageConfig::from_file(self.storage),
             permissions: PermissionsConfig::default(),
             plugins: PluginsConfig::from_plugins(self.plugins),
@@ -483,6 +491,8 @@ impl AgentFileConfig {
 #[serde(default, deny_unknown_fields)]
 pub struct ProviderFileConfig {
     pub default_model: Option<String>,
+    pub allowed_models: Option<Vec<String>>,
+    pub excluded_models: Option<Vec<String>>,
     pub connect_timeout_secs: Option<u64>,
     pub low_speed_timeout_secs: Option<u64>,
     pub stream_timeout_secs: Option<u64>,
@@ -494,6 +504,8 @@ impl ProviderFileConfig {
             self,
             overlay,
             default_model,
+            allowed_models,
+            excluded_models,
             connect_timeout_secs,
             low_speed_timeout_secs,
             stream_timeout_secs
@@ -1048,6 +1060,23 @@ pub struct ProviderConfig {
     )]
     pub default_model: Option<String>,
 
+    #[config(
+        ty = "string[]",
+        default_doc = "[]",
+        desc = "Glob patterns for permitted qualified model specs; empty permits all models"
+    )]
+    pub allowed_models: Vec<String>,
+
+    #[config(
+        ty = "string[]",
+        default_doc = "[]",
+        desc = "Glob patterns for excluded qualified model specs; exclusions take precedence"
+    )]
+    pub excluded_models: Vec<String>,
+
+    #[config(skip)]
+    pub model_policy: ModelPolicy,
+
     #[config(key = "connect_timeout_secs", ty = "u64", default = DEFAULT_CONNECT_TIMEOUT_SECS,
              min = MIN_CONNECT_TIMEOUT_SECS, val = "self.connect_timeout.as_secs()",
              desc = "HTTP connect timeout (seconds)")]
@@ -1068,6 +1097,9 @@ impl Default for ProviderConfig {
     fn default() -> Self {
         Self {
             default_model: None,
+            allowed_models: Vec::new(),
+            excluded_models: Vec::new(),
+            model_policy: ModelPolicy::allow_all(),
             connect_timeout: Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS),
             low_speed_timeout: Duration::from_secs(DEFAULT_LOW_SPEED_TIMEOUT_SECS),
             stream_timeout: Duration::from_secs(DEFAULT_STREAM_TIMEOUT_SECS),
@@ -1076,9 +1108,15 @@ impl Default for ProviderConfig {
 }
 
 impl ProviderConfig {
-    fn from_file(f: ProviderFileConfig) -> Self {
-        Self {
+    fn from_file(f: ProviderFileConfig) -> Result<Self, ConfigError> {
+        let allowed_models = f.allowed_models.unwrap_or_default();
+        let excluded_models = f.excluded_models.unwrap_or_default();
+        let model_policy = ModelPolicy::new(&allowed_models, &excluded_models)?;
+        Ok(Self {
             default_model: f.default_model,
+            allowed_models,
+            excluded_models,
+            model_policy,
             connect_timeout: Duration::from_secs(
                 f.connect_timeout_secs
                     .unwrap_or(DEFAULT_CONNECT_TIMEOUT_SECS),
@@ -1090,7 +1128,60 @@ impl ProviderConfig {
             stream_timeout: Duration::from_secs(
                 f.stream_timeout_secs.unwrap_or(DEFAULT_STREAM_TIMEOUT_SECS),
             ),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ModelPolicy {
+    allowed: GlobSet,
+    excluded: GlobSet,
+    has_allowed_models: bool,
+}
+
+impl Default for ModelPolicy {
+    fn default() -> Self {
+        Self::allow_all()
+    }
+}
+
+impl ModelPolicy {
+    fn allow_all() -> Self {
+        Self::new(&[], &[]).expect("empty model policy is valid")
+    }
+
+    pub fn new(allowed_models: &[String], excluded_models: &[String]) -> Result<Self, ConfigError> {
+        Ok(Self {
+            allowed: Self::compile("allowed_models", allowed_models)?,
+            excluded: Self::compile("excluded_models", excluded_models)?,
+            has_allowed_models: !allowed_models.is_empty(),
+        })
+    }
+
+    fn compile(field: &'static str, patterns: &[String]) -> Result<GlobSet, ConfigError> {
+        let mut globset = GlobSetBuilder::new();
+        for pattern in patterns {
+            let glob = GlobBuilder::new(pattern)
+                .literal_separator(false)
+                .build()
+                .map_err(|source| ConfigError::InvalidModelPattern {
+                    field,
+                    pattern: pattern.clone(),
+                    source,
+                })?;
+            globset.add(glob);
         }
+        globset
+            .build()
+            .map_err(|source| ConfigError::InvalidModelPattern {
+                field,
+                pattern: String::new(),
+                source,
+            })
+    }
+
+    pub fn allows(&self, spec: &str) -> bool {
+        (!self.has_allowed_models || self.allowed.is_match(spec)) && !self.excluded.is_match(spec)
     }
 }
 
@@ -1957,6 +2048,86 @@ mod tests {
         assert_eq!(base.agent.max_output_bytes, Some(80_000), "base preserved");
         assert_eq!(base.ui.splash_animation, Some(false), "base preserved");
         assert_eq!(base.ui.flash_duration_ms, Some(2000), "base preserved");
+    }
+
+    #[test]
+    fn provider_model_lists_inherit_replace_and_clear() {
+        let mut global = RawConfig {
+            provider: ProviderFileConfig {
+                allowed_models: Some(vec!["anthropic/*".into()]),
+                excluded_models: Some(vec!["*/*-preview".into()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        global.merge(RawConfig {
+            provider: ProviderFileConfig {
+                allowed_models: Some(Vec::new()),
+                excluded_models: None,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let provider = global.into_config(false).unwrap().provider;
+        assert!(provider.allowed_models.is_empty());
+        assert_eq!(provider.excluded_models, ["*/*-preview"]);
+        assert!(provider.model_policy.allows("openai/gpt-5"));
+        assert!(!provider.model_policy.allows("openai/gpt-5-preview"));
+    }
+
+    #[test]
+    fn model_policy_matches_qualified_specs() {
+        let config = RawConfig {
+            provider: ProviderFileConfig {
+                allowed_models: Some(vec!["openai/gpt-5".into(), "opencode/*".into()]),
+                excluded_models: Some(vec!["*/*-preview".into()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+        .into_config(false)
+        .unwrap();
+        let policy = &config.provider.model_policy;
+
+        assert!(policy.allows("openai/gpt-5"));
+        assert!(policy.allows("opencode/nvidia/openai/gpt-oss-120b"));
+        assert!(!policy.allows("anthropic/claude-sonnet-4-6"));
+        assert!(!policy.allows("opencode/gpt-5-preview"));
+
+        let exclude_only = RawConfig {
+            provider: ProviderFileConfig {
+                excluded_models: Some(vec!["anthropic/*".into()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+        .into_config(false)
+        .unwrap();
+        assert!(exclude_only.provider.model_policy.allows("openai/gpt-5"));
+        assert!(
+            !exclude_only
+                .provider
+                .model_policy
+                .allows("anthropic/claude-sonnet-4-6")
+        );
+    }
+
+    #[test]
+    fn invalid_model_pattern_is_a_config_error() {
+        let result = RawConfig {
+            provider: ProviderFileConfig {
+                allowed_models: Some(vec!["[".into()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+        .into_config(false);
+
+        assert!(matches!(
+            result,
+            Err(ConfigError::InvalidModelPattern { field: "allowed_models", pattern, .. }) if pattern == "["
+        ));
     }
 
     #[test]

--- a/maki-docgen/src/gen_config.rs
+++ b/maki-docgen/src/gen_config.rs
@@ -196,7 +196,10 @@ maki.setup({{
     }},
     provider = {{
         default_model = \"anthropic/claude-sonnet-4-6\",
+        allowed_models = {{ \"anthropic/*\", \"openai/gpt-5\" }},
+        excluded_models = {{ \"*/*-preview\" }},
     }},
+
     storage = {{
         max_log_files = {max_log_files},
     }},
@@ -208,6 +211,8 @@ maki.setup({{
 ```
 
 All fields are optional. Typos in field names cause an error right away.
+
+`provider.allowed_models` is a list of glob patterns for qualified `provider/model-id` specs. `*` also matches `/`, so `opencode/*` includes nested model IDs. When the list is empty or omitted, every model is allowed. `provider.excluded_models` removes matching models after that, so exclusions always win. A project list replaces the matching global list; omit it to inherit or use `{{}}` to clear it. The policy applies to selectors, CLI and API model changes, delegation, and `maki models`.
 
 `maki.setup()` can only be called once per init.lua.
 

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -54,9 +54,13 @@ fn resolve_model_from_ctx(ctx: &AgentContext, tier: Option<&str>) -> Result<Mode
         .unwrap();
     map.spec_for_tier(slug, effective)
         .or_else(|| map.spec_for_tier_any(effective))
+        .filter(|spec| ctx.model_policy.allows(spec))
         .and_then(|s| Model::from_spec(&s).ok())
         .map(Ok)
-        .unwrap_or_else(|| Model::from_tier_dynamic(slug, effective).map_err(|e| e.to_string()))
+        .unwrap_or_else(|| {
+            Model::from_tier_with_policy(slug, effective, &ctx.model_policy)
+                .map_err(|e| e.to_string())
+        })
 }
 
 fn model_to_lua_table(lua: &Lua, model: &Model) -> LuaResult<Table> {
@@ -141,7 +145,7 @@ async fn resolve_model(
         .and_then(|t| t.get::<Option<String>>("spec").ok().flatten());
 
     let model = match spec_str {
-        Some(ref spec) => try_pair!(Model::from_spec(spec)),
+        Some(ref spec) => try_pair!(Model::from_spec_with_policy(spec, &agent.model_policy)),
         None => try_pair!(resolve_model_from_ctx(agent, tier_str.as_deref())),
     };
     Ok((Some(model_to_lua_table(&lua, &model)?), None))
@@ -233,7 +237,7 @@ async fn tools(lua: Lua, ctx: mlua::UserDataRef<LuaCtx>, opts: Table) -> LuaResu
 
     let parsed = spec_str
         .as_deref()
-        .and_then(|spec| Model::from_spec(spec).ok());
+        .and_then(|spec| Model::from_spec_with_policy(spec, &agent.model_policy).ok());
     let model = parsed.as_ref().unwrap_or(&agent.model);
 
     let base = match (only, except) {
@@ -405,7 +409,7 @@ async fn session(
 
     let (model, provider): (Model, Arc<dyn provider::Provider>) = if let Some(ref spec) = model_spec
     {
-        let mut m = try_pair!(Model::from_spec(spec));
+        let mut m = try_pair!(Model::from_spec_with_policy(spec, &agent_ctx.model_policy));
         let p = try_pair!(provider::from_model_async(&mut m, agent_ctx.timeouts).await);
         (m, Arc::from(p))
     } else {
@@ -529,6 +533,7 @@ async fn session(
             subagent_cancels: Arc::new(CancelMap::new()),
             registry: Arc::clone(maki_agent::tools::ToolRegistry::global_arc()),
             audience,
+            model_policy: Arc::clone(&agent_ctx.model_policy),
         },
         system: system.unwrap_or_default(),
         tools: tools_json,

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -2063,6 +2063,11 @@ fn setup_compaction_buffer(lua_src: &str, expected: maki_config::CompactionBuffe
     UNKNOWN_FIELD_ERR
     ; "moved_plugin_option"
 )]
+#[test_case::test_case(
+    r#"maki.setup({ provider = { allowed_models = "anthropic/*" } })"#,
+    ""
+    ; "model_policy_wrong_type"
+)]
 fn setup_rejects_bad_input(lua_src: &str, expected_substr: &str) {
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
@@ -2073,6 +2078,32 @@ fn setup_rejects_bad_input(lua_src: &str, expected_substr: &str) {
     if !expected_substr.is_empty() {
         assert!(err.to_string().contains(expected_substr), "got: {err}");
     }
+}
+
+#[test]
+fn setup_model_policy_lists() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let raw = host
+        .send_run_init_lua(
+            r#"maki.setup({ provider = {
+                allowed_models = { "anthropic/*", "openai/gpt-5" },
+                excluded_models = { "*/*-preview" },
+            } })"#
+                .to_owned(),
+            "test_init.lua".to_owned(),
+            None,
+        )
+        .unwrap()
+        .expect("expected Some(RawConfig)");
+    assert_eq!(
+        raw.provider.allowed_models,
+        Some(vec!["anthropic/*".into(), "openai/gpt-5".into()])
+    );
+    assert_eq!(
+        raw.provider.excluded_models,
+        Some(vec!["*/*-preview".into()])
+    );
 }
 
 #[test]

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -9,6 +9,7 @@ use std::ops::AddAssign;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use maki_config::ModelPolicy;
 use maki_storage::sessions::{MIN_THINKING_BUDGET, StoredTokenUsage};
 use serde::{Deserialize, Serialize};
 
@@ -28,8 +29,12 @@ pub enum ModelError {
     UnknownModel(String),
     #[error("invalid model tier '{0}' (expected: strong, medium, weak)")]
     InvalidTier(String),
+    #[error("no allowed model for {0}/{1}")]
+    NoAllowedModel(String, ModelTier),
     #[error("no default model for {0}/{1}")]
     NoDefault(String, ModelTier),
+    #[error("model '{0}' is not allowed by provider model policy")]
+    NotAllowed(String),
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -372,6 +377,32 @@ impl Model {
         Self::from_spec(&format!("{slug}/{model_id}"))
     }
 
+    pub fn from_tier_with_policy(
+        slug: &str,
+        tier: ModelTier,
+        policy: &ModelPolicy,
+    ) -> Result<Self, ModelError> {
+        if let Ok(model) = Self::from_tier_dynamic(slug, tier)
+            && policy.allows(&model.spec())
+        {
+            return Ok(model);
+        }
+
+        let Some(manifest) = ManifestRegistry::for_slug(slug) else {
+            return Err(ModelError::NoAllowedModel(slug.to_string(), tier));
+        };
+        manifest
+            .models
+            .iter()
+            .filter(|entry| entry.tier == tier)
+            .flat_map(|entry| entry.prefixes)
+            .map(|model_id| format!("{slug}/{model_id}"))
+            .find(|spec| policy.allows(spec))
+            .map(|spec| Self::from_spec(&spec))
+            .transpose()?
+            .ok_or_else(|| ModelError::NoAllowedModel(slug.to_string(), tier))
+    }
+
     pub fn from_tier_dynamic(slug: &str, tier: ModelTier) -> Result<Self, ModelError> {
         if let Some(model) = dynamic::find_model_for_tier(slug, tier) {
             return Ok(model);
@@ -400,6 +431,13 @@ impl Model {
             return Self::from_tier(slug, tier);
         }
         Err(ModelError::UnsupportedProvider(slug.to_string()))
+    }
+
+    pub fn from_spec_with_policy(spec: &str, policy: &ModelPolicy) -> Result<Self, ModelError> {
+        if !policy.allows(spec) {
+            return Err(ModelError::NotAllowed(spec.to_string()));
+        }
+        Self::from_spec(spec)
     }
 
     pub fn from_spec(spec: &str) -> Result<Self, ModelError> {
@@ -563,6 +601,20 @@ mod tests {
     use super::*;
     use test_case::test_case;
 
+    fn policy(allowed: &[&str], excluded: &[&str]) -> ModelPolicy {
+        ModelPolicy::new(
+            &allowed
+                .iter()
+                .map(|pattern| (*pattern).into())
+                .collect::<Vec<_>>(),
+            &excluded
+                .iter()
+                .map(|pattern| (*pattern).into())
+                .collect::<Vec<_>>(),
+        )
+        .unwrap()
+    }
+
     const TIERS: [ModelTier; 4] = [
         ModelTier::Weak,
         ModelTier::Medium,
@@ -605,6 +657,47 @@ mod tests {
             std::mem::discriminant(&err),
             std::mem::discriminant(&expected)
         );
+    }
+
+    #[test]
+    fn from_spec_with_policy_rejects_disallowed_exact_spec() {
+        let policy = policy(&["anthropic/*"], &[]);
+        let spec = "openai/gpt-5.6-sol";
+
+        let error = Model::from_spec_with_policy(spec, &policy).unwrap_err();
+
+        assert!(matches!(error, ModelError::NotAllowed(disallowed) if disallowed == spec));
+    }
+
+    #[test]
+    fn from_spec_with_policy_resolves_allowed_exact_spec() {
+        let policy = policy(&["openai/gpt-5.6-sol"], &[]);
+
+        let model = Model::from_spec_with_policy("openai/gpt-5.6-sol", &policy).unwrap();
+
+        assert_eq!(model.spec(), "openai/gpt-5.6-sol");
+    }
+
+    #[test]
+    fn tier_with_policy_uses_allowed_alternative() {
+        let policy = policy(&["openai/gpt-5.4-nano"], &[]);
+
+        let model = Model::from_tier_with_policy("openai", ModelTier::Weak, &policy).unwrap();
+
+        assert_eq!(model.spec(), "openai/gpt-5.4-nano");
+        assert_eq!(model.tier, ModelTier::Weak);
+    }
+
+    #[test]
+    fn tier_with_policy_errors_without_allowed_candidate() {
+        let policy = policy(&["anthropic/*"], &[]);
+
+        let error = Model::from_tier_with_policy("openai", ModelTier::Weak, &policy).unwrap_err();
+
+        assert!(matches!(
+            error,
+            ModelError::NoAllowedModel(provider, ModelTier::Weak) if provider == "openai"
+        ));
     }
 
     #[test]

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 use strum::{Display, EnumIter, EnumString};
 use tracing::{debug, warn};
 
+use maki_config::ModelPolicy;
 use maki_storage::id::SessionRef;
 
 use crate::model::{Model, ModelFamily, ModelInfo};
@@ -365,7 +366,7 @@ pub struct ModelBatch {
 /// and configured dynamic providers. See [`fetch_all_models`] for live lookups.
 /// Never blocks on catalog download; catalog-backed providers appear only once
 /// the catalog has warmed in the background.
-pub fn available_model_specs() -> Vec<String> {
+pub fn available_model_specs(policy: &ModelPolicy) -> Vec<String> {
     let mut specs: Vec<String> = crate::manifest::ManifestRegistry::builtins()
         .iter()
         .filter(|m| provider_available_offline(m.slug))
@@ -404,10 +405,12 @@ pub fn available_model_specs() -> Vec<String> {
             }
         }
     }
+    specs.retain(|spec| policy.allows(spec));
     specs
 }
 
 pub async fn fetch_all_models(
+    policy: &ModelPolicy,
     mut on_ready: impl FnMut(ModelBatch),
     on_done: Option<Box<dyn FnOnce() + Send>>,
 ) {
@@ -550,7 +553,8 @@ pub async fn fetch_all_models(
 
     drop(tx);
 
-    while let Ok(batch) = rx.recv_async().await {
+    while let Ok(mut batch) = rx.recv_async().await {
+        batch.models.retain(|spec| policy.allows(spec));
         on_ready(batch);
     }
     if let Some(done) = on_done {
@@ -561,6 +565,33 @@ pub async fn fetch_all_models(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn policy(allowed: &[&str], excluded: &[&str]) -> ModelPolicy {
+        ModelPolicy::new(
+            &allowed
+                .iter()
+                .map(|pattern| (*pattern).into())
+                .collect::<Vec<_>>(),
+            &excluded
+                .iter()
+                .map(|pattern| (*pattern).into())
+                .collect::<Vec<_>>(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn available_specs_apply_model_policy() {
+        unsafe { std::env::set_var("OPENAI_API_KEY", "sk-test-model-policy") };
+        let policy = policy(&["openai/*"], &["*/gpt-5.6-terra"]);
+
+        let specs = available_model_specs(&policy);
+        unsafe { std::env::remove_var("OPENAI_API_KEY") };
+
+        assert!(!specs.is_empty());
+        assert!(specs.iter().all(|spec| spec.starts_with("openai/")));
+        assert!(!specs.iter().any(|spec| spec == "openai/gpt-5.6-terra"));
+    }
 
     #[test]
     fn provider_for_slug_unknown_returns_error() {

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -15,6 +15,7 @@ use maki_agent::{
     CancelToken, CancelTrigger, Envelope, EventSender, History, Instructions, McpCommand,
     PromptRole, SessionMailbox, SharedMessages, ToolOutputLines,
 };
+use maki_config::ModelPolicy;
 use maki_lua::EventHandle;
 use maki_providers::{AgentError, Message, Model, TokenUsage};
 use maki_storage::id::SessionRef;
@@ -48,6 +49,7 @@ pub(super) struct AgentLoop {
     timeouts: maki_providers::Timeouts,
     lua_handle: EventHandle,
     subagent_cancels: Arc<CancelMap<String>>,
+    model_policy: Arc<ModelPolicy>,
 }
 
 impl AgentLoop {
@@ -71,6 +73,7 @@ impl AgentLoop {
         timeouts: maki_providers::Timeouts,
         lua_handle: EventHandle,
         subagent_cancels: Arc<CancelMap<String>>,
+        model_policy: Arc<ModelPolicy>,
     ) -> Self {
         let mcp = mcp_handle.map(|h| McpSession::new(h, &initial_history));
         Self {
@@ -96,6 +99,7 @@ impl AgentLoop {
             timeouts,
             lua_handle,
             subagent_cancels,
+            model_policy,
         }
     }
 
@@ -162,8 +166,12 @@ impl AgentLoop {
 
     async fn do_compact(&mut self, event_tx: &EventSender) -> Result<(), AgentError> {
         let slot = self.model_slot.load();
-        let (provider, model) =
-            agent::resolve_compaction_model(&slot.provider, &slot.model, self.timeouts);
+        let (provider, model) = agent::resolve_compaction_model(
+            &slot.provider,
+            &slot.model,
+            self.timeouts,
+            &self.model_policy,
+        );
         agent::compact(
             &*provider,
             &model,
@@ -246,6 +254,7 @@ impl AgentLoop {
                 subagent_cancels: Arc::clone(&self.subagent_cancels),
                 registry: Arc::clone(maki_agent::tools::ToolRegistry::global_arc()),
                 audience: ToolAudience::MAIN,
+                model_policy: Arc::clone(&self.model_policy),
             },
             AgentRunParams {
                 history: &mut self.history,

--- a/maki-ui/src/agent/mod.rs
+++ b/maki-ui/src/agent/mod.rs
@@ -13,6 +13,7 @@ use maki_agent::{
     AgentConfig, CancelMap, CancelToken, Envelope, HistorySnapshot, McpCommand, McpConfigErrors,
     McpHandle, McpSnapshotReader, SessionMailbox, SharedMessages, ToolOutputLines,
 };
+use maki_config::ModelPolicy;
 use maki_lua::EventHandle;
 use maki_storage::id::SessionRef;
 
@@ -54,6 +55,7 @@ pub(crate) struct AgentHandles {
     pub(crate) mcp_config_errors: McpConfigErrors,
     pub(crate) queue: QueueSender,
     pub(crate) timeouts: maki_providers::Timeouts,
+    model_policy: Arc<ModelPolicy>,
     mailbox: Option<SessionMailbox>,
     task: smol::Task<()>,
 }
@@ -73,6 +75,7 @@ impl AgentHandles {
         lua_handle: EventHandle,
         mcp_handle: Option<McpHandle>,
         mcp_config_errors: McpConfigErrors,
+        model_policy: Arc<ModelPolicy>,
     ) -> Self {
         spawn_agent_internal(
             flume::unbounded(),
@@ -86,6 +89,7 @@ impl AgentHandles {
             session_id,
             timeouts,
             lua_handle,
+            model_policy,
         )
     }
 
@@ -158,6 +162,7 @@ impl AgentHandles {
             Some(SessionRef::from(app.state.session.id)),
             self.timeouts,
             lua_handle,
+            Arc::clone(&self.model_policy),
         );
         let old = mem::replace(self, new);
         // Repoint the app at the new queue before dropping `old`, otherwise the app keeps
@@ -215,6 +220,7 @@ fn spawn_agent_internal(
     session_id: Option<SessionRef>,
     timeouts: maki_providers::Timeouts,
     lua_handle: EventHandle,
+    model_policy: Arc<ModelPolicy>,
 ) -> AgentHandles {
     let (cmd_tx, cmd_rx) = flume::unbounded::<AgentCommand>();
     let (answer_tx, answer_rx) = flume::unbounded::<String>();
@@ -257,6 +263,7 @@ fn spawn_agent_internal(
         timeouts,
         lua_handle,
         subagent_cancels,
+        Arc::clone(&model_policy),
     );
 
     let task = smol::spawn(agent_loop.run());
@@ -272,6 +279,7 @@ fn spawn_agent_internal(
         mcp_config_errors,
         queue: queue_tx,
         timeouts,
+        model_policy,
         mailbox,
         task,
     }
@@ -350,6 +358,7 @@ mod tests {
             EventHandle::disconnected_for_test(),
             None,
             McpConfigErrors::new(PathBuf::new()),
+            Arc::new(ModelPolicy::default()),
         );
         (handles, model_slot, permissions)
     }

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -57,7 +57,7 @@ use maki_agent::{
     AgentEvent, Envelope, ImageSource, McpConfigErrors, McpPromptInfo, McpSnapshotReader,
     SharedMessages, SubagentInfo,
 };
-use maki_config::UiConfig;
+use maki_config::{ModelPolicy, UiConfig};
 use maki_lua::{EventHandle, HintReader, KeymapReader, LuaCommandReader, WinView};
 use maki_providers::{Model, ThinkingConfig, add_cost};
 use maki_storage::StateDir;
@@ -180,6 +180,7 @@ pub struct App {
     pub(crate) shell: shell::ShellState,
     pub(crate) ui_config: UiConfig,
     pub(crate) permissions: Arc<PermissionManager>,
+    pub(crate) model_policy: Arc<ModelPolicy>,
     pub(crate) lua_event_handle: EventHandle,
     pub(super) keymap_reader: KeymapReader,
     pub(super) hint_reader: HintReader,
@@ -206,9 +207,10 @@ impl App {
         permissions: Arc<PermissionManager>,
         custom_commands: Arc<[maki_agent::command::CustomCommand]>,
         lua_event_handle: EventHandle,
+        model_policy: Arc<ModelPolicy>,
     ) -> Self {
         scrollbar::set_enabled(ui_config.scrollbar);
-        let state = SessionState::from_session(session, model, &storage);
+        let state = SessionState::from_session(session, model, &storage, &model_policy);
         let typewriter = ui_config.typewriter_ms_per_char;
         let flash = ui_config.flash_duration();
         let input_box = InputBox::new(
@@ -270,6 +272,7 @@ impl App {
             shell: shell::ShellState::default(),
             ui_config,
             permissions,
+            model_policy: Arc::clone(&model_policy),
             lua_event_handle,
             keymap_reader,
             hint_reader,
@@ -277,8 +280,12 @@ impl App {
             restoring: Arc::new(AtomicBool::new(false)),
             subagent_answers: HashMap::new(),
         };
-        app.model_picker
-            .set_recents(maki_storage::model::read_recents(&app.storage));
+        app.model_picker.set_recents(
+            maki_storage::model::read_recents(&app.storage)
+                .into_iter()
+                .filter(|spec| model_policy.allows(spec))
+                .collect(),
+        );
         app
     }
 
@@ -300,7 +307,10 @@ impl App {
     }
 
     pub(crate) fn record_recent_model(&mut self, spec: &str) {
-        let recents = maki_storage::model::push_recent(&self.storage, spec);
+        let recents = maki_storage::model::push_recent(&self.storage, spec)
+            .into_iter()
+            .filter(|spec| self.model_policy.allows(spec))
+            .collect();
         self.model_picker.set_recents(recents);
     }
 

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -339,7 +339,8 @@ impl App {
         self.checkpoint_now();
         self.permissions
             .load_session_rules(stored_to_rules(&session.meta.session_rules));
-        self.state = SessionState::from_session(session, fallback_model, &self.storage);
+        self.state =
+            SessionState::from_session(session, fallback_model, &self.storage, &self.model_policy);
         for w in self.state.warnings.drain(..) {
             self.status_bar.flash(w);
         }

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use maki_config::Effect;
+use maki_config::{Effect, ModelPolicy};
 use maki_providers::{Model, ThinkingConfig, TokenUsage};
 use maki_storage::StateDir;
 use maki_storage::sessions::{StoredEffect, StoredMode, StoredRule};
@@ -31,11 +31,18 @@ impl SessionState {
         mut session: AppSession,
         fallback_model: &Model,
         storage: &StateDir,
+        model_policy: &ModelPolicy,
     ) -> Self {
-        let model = Model::from_spec(&session.model).unwrap_or_else(|_| {
-            session.model = fallback_model.spec();
-            fallback_model.clone()
-        });
+        let model = model_policy
+            .allows(&session.model)
+            .then(|| Model::from_spec(&session.model))
+            .transpose()
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| {
+                session.model = fallback_model.spec();
+                fallback_model.clone()
+            });
 
         let mode = match session.meta.mode {
             Some(StoredMode::Plan) => Mode::Plan,
@@ -200,7 +207,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let storage = StateDir::from_path(tmp.path().to_path_buf());
         let session = make_plan_session(Some(StoredMode::Plan), None);
-        let state = SessionState::from_session(session, &test_model(), &storage);
+        let state =
+            SessionState::from_session(session, &test_model(), &storage, &ModelPolicy::default());
         assert_eq!(state.mode, Mode::Plan);
         assert!(state.plan.path().is_some(), "plan path should be allocated");
     }
@@ -211,7 +219,8 @@ mod tests {
         let storage = StateDir::from_path(tmp.path().to_path_buf());
         let session =
             make_plan_session(Some(StoredMode::Plan), Some("/nonexistent/plan.md".into()));
-        let state = SessionState::from_session(session, &test_model(), &storage);
+        let state =
+            SessionState::from_session(session, &test_model(), &storage, &ModelPolicy::default());
         assert_eq!(state.mode, Mode::Plan);
         let path = state.plan.path().expect("plan path should be allocated");
         assert_ne!(path, Path::new("/nonexistent/plan.md"));
@@ -229,9 +238,29 @@ mod tests {
             Some(StoredMode::Plan),
             Some(plan_file.to_string_lossy().into_owned()),
         );
-        let state = SessionState::from_session(session, &test_model(), &storage);
+        let state =
+            SessionState::from_session(session, &test_model(), &storage, &ModelPolicy::default());
         assert_eq!(state.mode, Mode::Plan);
         assert_eq!(state.plan.path(), Some(plan_file.as_path()));
+    }
+
+    #[test]
+    fn disallowed_restored_model_uses_fallback() {
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = StateDir::from_path(tmp.path().to_path_buf());
+        let fallback = test_model();
+        let mut session = make_plan_session(Some(StoredMode::Build), None);
+        session.model = "openai/gpt-5".into();
+        let raw: maki_config::RawConfig = serde_json::from_value(serde_json::json!({
+            "provider": {"allowed_models": [fallback.spec()]}
+        }))
+        .unwrap();
+        let policy = raw.into_config(false).unwrap().provider.model_policy;
+
+        let state = SessionState::from_session(session, &fallback, &storage, &policy);
+
+        assert_eq!(state.model.spec(), fallback.spec());
+        assert_eq!(state.session.model, fallback.spec());
     }
 
     #[test]
@@ -239,7 +268,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let storage = StateDir::from_path(tmp.path().to_path_buf());
         let session = make_plan_session(Some(StoredMode::Build), None);
-        let state = SessionState::from_session(session, &test_model(), &storage);
+        let state =
+            SessionState::from_session(session, &test_model(), &storage, &ModelPolicy::default());
         assert_eq!(state.mode, Mode::Build);
         assert!(state.plan.path().is_none());
     }

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -62,6 +62,7 @@ fn build_app_with_lua(
         )),
         Arc::from([]),
         maki_lua::EventHandle::disconnected_for_test(),
+        Arc::new(maki_config::ModelPolicy::default()),
     )
 }
 
@@ -3417,7 +3418,12 @@ fn thinking_restored_from_session_meta() {
     let mut session = AppSession::new("test-model", "/tmp/test");
     session.meta.thinking = Some(StoredThinking::Budget { tokens: 4096 });
 
-    let state = SessionState::from_session(session, &test_model(), &storage);
+    let state = SessionState::from_session(
+        session,
+        &test_model(),
+        &storage,
+        &maki_config::ModelPolicy::default(),
+    );
     assert_eq!(state.thinking, ThinkingConfig::Budget(4096));
 }
 
@@ -3502,7 +3508,12 @@ fn fast_restored_from_session_meta() {
     let mut session = AppSession::new("anthropic/claude-opus-4-8", "/tmp/test");
     session.meta.fast = true;
 
-    let state = SessionState::from_session(session, &test_model(), &storage);
+    let state = SessionState::from_session(
+        session,
+        &test_model(),
+        &storage,
+        &maki_config::ModelPolicy::default(),
+    );
     assert!(state.fast);
 }
 
@@ -3515,7 +3526,12 @@ fn fast_normalized_off_when_restored_onto_ineligible_model() {
     let mut session = AppSession::new("anthropic/claude-sonnet-4-5", "/tmp/test");
     session.meta.fast = true;
 
-    let state = SessionState::from_session(session, &test_model(), &storage);
+    let state = SessionState::from_session(
+        session,
+        &test_model(),
+        &storage,
+        &maki_config::ModelPolicy::default(),
+    );
     assert!(!state.fast);
 }
 

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -20,7 +20,7 @@ use crossterm::event::{
 use maki_agent::command::CustomCommand;
 use maki_agent::permissions::PermissionManager;
 use maki_agent::{AgentConfig, CancelToken, McpCommand, McpConfigErrors, McpHandle, mcp};
-use maki_config::UiConfig;
+use maki_config::{ModelPolicy, UiConfig};
 use maki_lua::{
     EventHandle, HintReader, KeymapReader, LuaCommandReader, SessionReply, SessionRequest, UiAction,
 };
@@ -82,6 +82,7 @@ pub struct EventLoopParams {
     pub hint_reader: HintReader,
     pub ui_action_rx: flume::Receiver<UiAction>,
     pub lua_event_handle: EventHandle,
+    pub model_policy: Arc<ModelPolicy>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -165,6 +166,7 @@ struct SpawnCtx {
     model_slot: Arc<ArcSwap<ModelSlot>>,
     available_models: Arc<ArcSwapOption<Vec<String>>>,
     storage_writer: Arc<StorageWriter>,
+    model_policy: Arc<ModelPolicy>,
 }
 
 impl SpawnCtx {
@@ -182,6 +184,7 @@ impl SpawnCtx {
             self.lua_event_handle.clone(),
             self.mcp_handle.clone(),
             self.mcp_config_errors.clone(),
+            Arc::clone(&self.model_policy),
         );
         let mut app = App::new(
             &self.model_slot.load().model,
@@ -199,6 +202,7 @@ impl SpawnCtx {
             permissions,
             Arc::clone(&self.custom_commands),
             self.lua_event_handle.clone(),
+            Arc::clone(&self.model_policy),
         );
         handles.apply_to_app(&mut app);
         if resumed {
@@ -266,7 +270,11 @@ fn merge_batch(
     available.store(Some(Arc::new(merged)));
 }
 
-fn spawn_model_fetch(model_slot: &Arc<ArcSwap<ModelSlot>>, timeouts: Timeouts) -> BackgroundModels {
+fn spawn_model_fetch(
+    model_slot: &Arc<ArcSwap<ModelSlot>>,
+    timeouts: Timeouts,
+    policy: Arc<ModelPolicy>,
+) -> BackgroundModels {
     let available: Arc<ArcSwapOption<Vec<String>>> = Arc::new(ArcSwapOption::empty());
     let bg = Arc::clone(&available);
     let (warn_tx, warn_rx) = flume::unbounded::<String>();
@@ -295,7 +303,12 @@ fn spawn_model_fetch(model_slot: &Arc<ArcSwap<ModelSlot>>, timeouts: Timeouts) -
                 provider: Arc::from(provider),
             }));
         });
-        fetch_all_models(|batch| merge_batch(&bg, batch, &warn_tx), Some(done)).await;
+        fetch_all_models(
+            &policy,
+            |batch| merge_batch(&bg, batch, &warn_tx),
+            Some(done),
+        )
+        .await;
     });
     BackgroundModels {
         available,
@@ -329,6 +342,7 @@ impl<'t> EventLoop<'t> {
             hint_reader,
             ui_action_rx,
             lua_event_handle,
+            model_policy,
         } = params;
 
         // Apply the config theme before the warmup thread spawns, or warmup
@@ -364,7 +378,7 @@ impl<'t> EventLoop<'t> {
             model: model.clone(),
             provider,
         }));
-        let bg = spawn_model_fetch(&model_slot, timeouts);
+        let bg = spawn_model_fetch(&model_slot, timeouts, Arc::clone(&model_policy));
         let storage_writer = Arc::new(StorageWriter::new(storage.clone(), bg.warn_tx.clone()));
 
         let ctx = SpawnCtx {
@@ -384,6 +398,7 @@ impl<'t> EventLoop<'t> {
             model_slot,
             available_models: bg.available,
             storage_writer,
+            model_policy,
         };
 
         let mut runtimes: Vec<SessionRuntime> = sessions
@@ -991,6 +1006,7 @@ impl<'t> EventLoop<'t> {
             Action::LoadSession(loaded) => {
                 let loaded = *loaded;
                 if loaded.model_spec != self.ctx.model_slot.load().model.spec()
+                    && self.ctx.model_policy.allows(&loaded.model_spec)
                     && let Ok(mut new_model) = Model::from_spec(&loaded.model_spec)
                     && let Ok(new_provider) = from_model(&mut new_model, self.ctx.timeouts)
                 {
@@ -1070,6 +1086,11 @@ impl<'t> EventLoop<'t> {
     }
 
     fn change_model(&mut self, spec: String) {
+        if !self.ctx.model_policy.allows(&spec) {
+            self.focused_app()
+                .flash(format!("Model is not allowed by policy: {spec}"));
+            return;
+        }
         match Model::from_spec(&spec) {
             Ok(mut new_model) => match from_model(&mut new_model, self.ctx.timeouts) {
                 Ok(new_provider) => {
@@ -1093,9 +1114,15 @@ impl<'t> EventLoop<'t> {
     fn refresh_models(&self) {
         let available = Arc::clone(&self.ctx.available_models);
         let warn_tx = self.warn_tx.clone();
+        let policy = Arc::clone(&self.ctx.model_policy);
         available.store(None);
         smol::spawn(async move {
-            fetch_all_models(|batch| merge_batch(&available, batch, &warn_tx), None).await;
+            fetch_all_models(
+                &policy,
+                |batch| merge_batch(&available, batch, &warn_tx),
+                None,
+            )
+            .await;
         })
         .detach();
     }

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -34,7 +34,10 @@ maki.setup({
     },
     provider = {
         default_model = "anthropic/claude-sonnet-4-6",
+        allowed_models = { "anthropic/*", "openai/gpt-5" },
+        excluded_models = { "*/*-preview" },
     },
+
     storage = {
         max_log_files = 5,
     },
@@ -46,6 +49,8 @@ maki.setup({
 ```
 
 All fields are optional. Typos in field names cause an error right away.
+
+`provider.allowed_models` is a list of glob patterns for qualified `provider/model-id` specs. `*` also matches `/`, so `opencode/*` includes nested model IDs. When the list is empty or omitted, every model is allowed. `provider.excluded_models` removes matching models after that, so exclusions always win. A project list replaces the matching global list; omit it to inherit or use `{}` to clear it. The policy applies to selectors, CLI and API model changes, delegation, and `maki models`.
 
 `maki.setup()` can only be called once per init.lua.
 
@@ -115,6 +120,8 @@ How many lines of output to show per tool in the UI. All values are `usize` with
 | Field | Type | Default | Min | Description |
 |-------|------|---------|-----|-------------|
 | `default_model` | String | `none` | - | Default model identifier (e.g. `anthropic/claude-sonnet-4-6`) |
+| `allowed_models` | string[] | `[]` | - | Glob patterns for permitted qualified model specs; empty permits all models |
+| `excluded_models` | string[] | `[]` | - | Glob patterns for excluded qualified model specs; exclusions take precedence |
 | `connect_timeout_secs` | u64 | `10` | 1 | HTTP connect timeout (seconds) |
 | `low_speed_timeout_secs` | u64 | `120` | 1 | Low speed timeout (seconds with less than 1 byte received) |
 | `stream_timeout_secs` | u64 | `300` | 10 | Streaming response timeout (seconds) |

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -65,5 +65,6 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
         mcp_handle,
         prompt_slots: Arc::new(prompt_slots),
         yolo,
+        model_policy: Arc::new(config.provider.model_policy.clone()),
     })
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -26,9 +26,7 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         Some(Command::Index { path }) => {
             subcmd::index(&path, cli.no_plugins, cli.no_jit)?;
         }
-        Some(Command::Models) => {
-            subcmd::models();
-        }
+        Some(Command::Models) => subcmd::models(cli.no_plugins, cli.no_jit)?,
         Some(Command::Mcp { action }) => {
             let storage = StateDir::resolve().context("resolve data directory")?;
             match action {

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -12,7 +12,7 @@ use maki_config::providers::{
     ProviderDef, ProvidersConfig, all_builtins, builtin_provider, resolve_api_key_env,
     resolve_base_url, resolve_default_model, resolve_display_name, resolve_login_url, slugify,
 };
-use maki_config::{load_env_files, load_permissions};
+use maki_config::{Config, load_env_files, load_permissions};
 use maki_lua::PluginHost;
 use maki_providers::provider::fetch_all_models;
 use maki_providers::{ProviderData, catalog_providers};
@@ -533,8 +533,16 @@ pub fn auth_status(storage: &StateDir) -> Result<()> {
     Ok(())
 }
 
-pub fn models() {
+pub fn models(no_plugins: bool, no_jit: bool) -> Result<()> {
+    let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
+    load_env_files(&cwd);
+
+    let host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
+        .context("initialize lua plugin host")?;
+    let config = load_effective_config(&host, no_plugins, &cwd)?;
+
     smol::block_on(fetch_all_models(
+        &config.provider.model_policy,
         |batch| {
             for model in batch.models {
                 println!("{model}");
@@ -545,6 +553,15 @@ pub fn models() {
         },
         None,
     ));
+    Ok(())
+}
+
+fn load_effective_config(host: &PluginHost, no_plugins: bool, cwd: &Path) -> Result<Config> {
+    host.load_init_files_or_skip(no_plugins, cwd)
+        .context("load init.lua files")?
+        .unwrap_or_default()
+        .into_config(false)
+        .context("invalid config")
 }
 
 pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -253,6 +253,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
             prompt_slots,
             fast,
             workflow: stack.config.always_workflow,
+            model_policy: Arc::new(stack.config.provider.model_policy.clone()),
         })
         .context("run sdk mode")?;
         return Ok(());
@@ -272,6 +273,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
             stack.plugin_host.event_handle(),
             fast,
             stack.config.always_workflow,
+            Arc::new(stack.config.provider.model_policy.clone()),
         )
         .context("run print mode")?;
         return Ok(());
@@ -301,7 +303,13 @@ pub fn run(mut cli: Cli) -> Result<()> {
             }
         }
         let focused_tab = &tabs[focused];
-        let model = if focused_tab.messages().is_empty() {
+        let model = if focused_tab.messages().is_empty()
+            || !stack
+                .config
+                .provider
+                .model_policy
+                .allows(&focused_tab.model)
+        {
             stack.model.clone()
         } else {
             Model::from_spec(&focused_tab.model).unwrap_or_else(|_| stack.model.clone())
@@ -330,6 +338,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
                 hint_reader: stack.plugin_host.hint_reader(),
                 ui_action_rx: stack.plugin_host.ui_action_rx(),
                 lua_event_handle: stack.plugin_host.event_handle(),
+                model_policy: Arc::new(stack.config.provider.model_policy.clone()),
             },
             initial_prompt.take(),
         )

--- a/src/print.rs
+++ b/src/print.rs
@@ -9,6 +9,7 @@
 
 use std::io::{self, Read};
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use clap::ValueEnum;
@@ -17,6 +18,7 @@ use color_eyre::eyre::{Context, eyre};
 use maki_agent::headless::{HeadlessHandle, HeadlessParams};
 use maki_agent::tools::QUESTION_TOOL_NAME;
 use maki_agent::{AgentConfig, AgentEvent, Envelope, ImageSource, PermissionsConfig};
+use maki_config::ModelPolicy;
 use maki_lua::EventHandle;
 use maki_providers::model::Model;
 use maki_providers::{StopReason, TokenUsage};
@@ -146,6 +148,7 @@ pub fn run(
     lua_handle: EventHandle,
     fast: bool,
     workflow: bool,
+    model_policy: Arc<ModelPolicy>,
 ) -> Result<()> {
     let prompt = match prompt_arg {
         Some(p) => p,
@@ -179,6 +182,7 @@ pub fn run(
         initial_wd: cwd,
         fast,
         workflow,
+        model_policy,
     });
 
     let HeadlessHandle {

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -25,6 +25,7 @@ use maki_agent::tools::QUESTION_TOOL_NAME;
 use maki_agent::{
     AgentConfig, AgentEvent, AgentInput, AgentMode, Envelope, PermissionsConfig, ToolOutput,
 };
+use maki_config::ModelPolicy;
 use maki_providers::model::Model;
 use maki_providers::{ImageSource, Message, StopReason, Timeouts, TokenUsage};
 use maki_storage::StateDir;
@@ -447,6 +448,7 @@ pub struct SdkParams {
     pub prompt_slots: ResolvedSlots,
     pub fast: bool,
     pub workflow: bool,
+    pub model_policy: Arc<ModelPolicy>,
 }
 
 struct Shared {
@@ -466,6 +468,7 @@ pub fn run(params: SdkParams) -> Result<()> {
         prompt_slots,
         fast,
         workflow,
+        model_policy,
     } = params;
     cli.warn_ignored_flags();
     if let Some(max) = cli.max_turns {
@@ -498,6 +501,7 @@ pub fn run(params: SdkParams) -> Result<()> {
         system_prompt_override: cli.system_prompt.clone().filter(|s| !s.is_empty()),
         append_system_prompt: cli.append_system_prompt.clone().filter(|s| !s.is_empty()),
         workflow,
+        model_policy: Arc::clone(&model_policy),
     });
 
     let (out_tx, out_rx) = flume::unbounded::<String>();
@@ -600,7 +604,14 @@ pub fn run(params: SdkParams) -> Result<()> {
                 else {
                     continue;
                 };
-                handle_control_request(&cr, &writer, &handle, &shared, &startup_model)?;
+                handle_control_request(
+                    &cr,
+                    &writer,
+                    &handle,
+                    &shared,
+                    &startup_model,
+                    &model_policy,
+                )?;
             }
             "control_response" => {
                 let Some(cr) =
@@ -726,6 +737,7 @@ fn handle_control_request(
     handle: &InteractiveHandle,
     shared: &Mutex<Shared>,
     startup_model: &Model,
+    model_policy: &ModelPolicy,
 ) -> Result<()> {
     let ok = Some(Value::Object(Default::default()));
     match cr.request.subtype.as_str() {
@@ -763,11 +775,18 @@ fn handle_control_request(
             }
         }
         "set_model" => {
-            if let Some(model) = resolve_set_model(cr.request.extra.get("model"), startup_model) {
-                let _ = handle.model_tx.send(model.clone());
-                shared.lock().unwrap().model = model;
+            match resolve_set_model(cr.request.extra.get("model"), startup_model, model_policy) {
+                Some(model) => {
+                    let _ = handle.model_tx.send(model.clone());
+                    shared.lock().unwrap().model = model;
+                    writer.emit_control_response(&cr.request_id, ok, None)
+                }
+                None => writer.emit_control_response(
+                    &cr.request_id,
+                    None,
+                    Some("invalid or disallowed model".into()),
+                ),
             }
-            writer.emit_control_response(&cr.request_id, ok, None)
         }
         other => writer.emit_control_response(
             &cr.request_id,
@@ -777,18 +796,27 @@ fn handle_control_request(
     }
 }
 
-fn resolve_set_model(model_val: Option<&Value>, startup_model: &Model) -> Option<Model> {
+fn resolve_set_model(
+    model_val: Option<&Value>,
+    startup_model: &Model,
+    model_policy: &ModelPolicy,
+) -> Option<Model> {
     match model_val? {
         Value::Null => Some(startup_model.clone()),
-        Value::String(model_str) => match Model::from_spec(&resolve_model_spec(model_str)) {
-            Ok(m) => Some(m),
-            Err(e) => {
-                eprintln!(
-                    "warning: failed to resolve model '{model_str}': {e}, keeping current model"
-                );
-                None
+        Value::String(model_str) => {
+            let spec = resolve_model_spec(model_str);
+            if !model_policy.allows(&spec) {
+                warn!(model = %spec, "ignoring model disallowed by policy");
+                return None;
             }
-        },
+            match Model::from_spec(&spec) {
+                Ok(m) => Some(m),
+                Err(e) => {
+                    warn!(model = %model_str, error = %e, "ignoring invalid model");
+                    None
+                }
+            }
+        }
         _ => None,
     }
 }
@@ -1396,8 +1424,32 @@ mod tests {
     #[test]
     fn resolve_set_model_null_returns_startup() {
         let startup = Model::from_spec("anthropic/claude-sonnet-4-20250514").unwrap();
-        let result = resolve_set_model(Some(&Value::Null), &startup).unwrap();
+        let result = resolve_set_model(
+            Some(&Value::Null),
+            &startup,
+            &maki_config::ModelPolicy::default(),
+        )
+        .unwrap();
         assert_eq!(result.id, startup.id);
+    }
+
+    #[test]
+    fn resolve_set_model_rejects_disallowed_exact_spec() {
+        let startup = Model::from_spec("anthropic/claude-sonnet-4-20250514").unwrap();
+        let raw: maki_config::RawConfig = serde_json::from_value(serde_json::json!({
+            "provider": {"allowed_models": [startup.spec()]}
+        }))
+        .unwrap();
+        let policy = raw.into_config(false).unwrap().provider.model_policy;
+
+        assert!(
+            resolve_set_model(
+                Some(&Value::String("openai/gpt-5".into())),
+                &startup,
+                &policy
+            )
+            .is_none()
+        );
     }
 
     #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,7 +1,7 @@
 use std::sync::Mutex;
 
 use color_eyre::Result;
-use color_eyre::eyre::Context;
+use color_eyre::eyre::{Context, eyre};
 
 use maki_providers::manifest::ManifestRegistry;
 use maki_providers::model::{Model, ModelTier};
@@ -24,31 +24,47 @@ pub fn resolve_model(
     provider_config: &maki_config::ProviderConfig,
     storage: &StateDir,
 ) -> Result<Model> {
+    let policy = &provider_config.model_policy;
     if let Some(spec) = explicit {
-        let model = Model::from_spec(spec).context("invalid --model spec")?;
-        return Ok(model);
+        if !policy.allows(spec) {
+            return Err(eyre!(
+                "model {spec:?} is not allowed by provider model policy"
+            ));
+        }
+        return Model::from_spec(spec).context("invalid --model spec");
     }
     if let Some(spec) = read_model(storage) {
-        if let Ok(m) = Model::from_spec(&spec) {
+        if policy.allows(&spec)
+            && let Ok(m) = Model::from_spec(&spec)
+        {
             return Ok(m);
         }
-        tracing::warn!(spec, "saved model no longer valid, falling back to default");
+        tracing::warn!(
+            spec,
+            "saved model unavailable or disallowed, falling back to default"
+        );
     }
     if let Some(spec) = provider_config.default_model.as_deref() {
+        if !policy.allows(spec) {
+            return Err(eyre!(
+                "default model {spec:?} is not allowed by provider model policy"
+            ));
+        }
         return Model::from_spec(spec).context("invalid default_model in config");
     }
-    auto_detect_model().ok_or_else(|| {
+    auto_detect_model(policy).ok_or_else(|| {
         color_eyre::eyre::eyre!(
             "no provider available - set an API key (e.g. ANTHROPIC_API_KEY), run `maki auth login`, or use -m to specify a model\n\nSee https://maki.sh/docs/providers/ for setup instructions"
         )
     })
 }
 
-fn auto_detect_model() -> Option<Model> {
+fn auto_detect_model(policy: &maki_config::ModelPolicy) -> Option<Model> {
     for tier in [ModelTier::Strong, ModelTier::Medium] {
         for &slug in PROVIDER_PRIORITY {
             if maki_providers::provider::provider_available(slug)
                 && let Ok(model) = Model::from_tier(slug, tier)
+                && policy.allows(&model.spec())
             {
                 return Some(model);
             }


### PR DESCRIPTION
## Introduction

Providers backed by large catalogs, such as OpenAI and OpenCode Go, can expose many models. Showing every discovered model makes the selector noisy and also means delegated tasks may resolve to models that the user did not intend to use.

Maki previously had no single policy governing model availability. Hiding entries only in the picker would not be sufficient because models can also be selected through startup configuration, CLI flags, restored sessions, ACP, SDK control messages, Lua plugins, tier-based delegation, and compaction overrides.

## Change

* Add `provider.allowed_models` and `provider.excluded_models` to `maki.setup()`.
* Support the setting in both global and project `init.lua` configuration.
* Match glob patterns against complete qualified `provider/model-id` specs.
* Apply allow rules first and exclusions second, so exclusions always win.
* Filter model discovery from built-in, dynamic, catalog, and custom providers.
* Enforce the same policy for direct model resolution, not only model listings.
* Constrain delegated task models and internal tier-based model selection.
* Document the settings in the generated configuration reference.

## Configuration

```lua
maki.setup({
    provider = {
        allowed_models = {
            "anthropic/*",
            "openai/gpt-5*",
        },
        excluded_models = {
            "*/*-preview",
        },
    },
})
```

Patterns match the full qualified spec. `*` can span `/`, so a pattern such as `opencode/*` also matches nested IDs like `opencode/nvidia/openai/gpt-oss-120b`.

An empty or omitted allowlist permits every model. The exclusion list is then subtracted from that result. At project scope, each configured list replaces the corresponding global list. Omitting a project list inherits the global value, while `{}` explicitly clears it.

## How

### Configuration and matching

`ProviderFileConfig` keeps both lists optional until global and project configuration have been merged. This preserves the distinction between an omitted field and an explicitly empty list.

The resolved `ProviderConfig` owns a compiled `ModelPolicy`. Patterns are compiled once with `globset` while configuration is resolved, rather than being reparsed at every model lookup. Invalid patterns fail configuration loading with the field and pattern included in the error.

### Discovery

Both offline model enumeration and asynchronous provider discovery accept the effective policy. Every emitted model batch is filtered before it reaches consumers, covering static manifests, live provider responses, dynamic providers, catalog providers, and declared or discovered custom models.

This keeps the TUI selector, ACP model options, and `maki models` consistent. Recent models are filtered separately because they are loaded from storage rather than discovery.

### Resolution and enforcement

Policy-aware model helpers reject blocked exact specs and find an allowed candidate for tier-based selection. The effective policy is threaded through runtime parameters and agent tool contexts so it reaches all model-selection boundaries:

* startup `--model`, saved models, configured defaults, and auto-detection;
* TUI changes and restored sessions;
* SDK and ACP model changes;
* Lua `maki.agent.resolve_model` and child sessions;
* built-in task delegation, including exact model selection when enabled;
* registry-backed tier selection and compaction overrides.

A blocked saved or restored model falls back to the permitted startup model. Explicit blocked selections return an actionable error. Compaction retains the current model when its configured override is blocked.

## Why

A centralized policy avoids a mismatch where a model disappears from the picker but remains usable through another interface. This matters especially for delegation: model tiers and exact model specs are resolved below the UI, so selector-only filtering would not limit what a subagent can use.

Compiling and carrying one policy also keeps matching behavior identical across interfaces while avoiding repeated parsing or provider-specific filtering logic.

## Validation

```text
cargo check --workspace
cargo clippy --all --tests -- -D warnings
cargo test -p maki-config -p maki-providers
cargo nextest run -p maki-lua -E 'test(setup_model_policy_lists) | test(model_policy_wrong_type) | binary(task_policy)'
cargo nextest run -p maki-ui -E 'test(disallowed_restored_model_uses_fallback)'
cargo run -p maki-docgen -- --check
git diff --check
```

The configuration and provider suites passed with 106 and 501 tests respectively. The focused Lua policy suite passed 16 tests, the restored-session policy test passed, and workspace Clippy completed without warnings.

## AI use

The code change was implemented by an AI agent. I fully reviewed and tested the change myself.