### PR TITLE
feat(mcp): support static OAuth client credentials for servers without DCR

### DIFF
--- a/maki-agent/src/mcp/config.rs
+++ b/maki-agent/src/mcp/config.rs
@@ -121,6 +121,7 @@ pub struct McpServerInfo {
     pub status: McpServerStatus,
     pub config_path: PathBuf,
     pub url: Option<String>,
+    pub oauth: Option<OauthClientConfig>,
 }
 
 #[derive(Deserialize, Default)]
@@ -167,6 +168,8 @@ pub struct RawHttpFields {
     pub url: String,
     #[serde(default)]
     pub headers: HashMap<String, String>,
+    #[serde(default)]
+    pub oauth: Option<OauthClientConfig>,
 }
 
 #[derive(Clone, Debug)]
@@ -179,6 +182,23 @@ pub struct ServerConfig {
     pub transport: Transport,
 }
 
+/// Static OAuth client used when the server has no registration endpoint.
+#[derive(Deserialize, Clone, Debug)]
+pub struct OauthClientConfig {
+    pub client_id: String,
+    #[serde(default)]
+    pub client_secret: Option<String>,
+    /// Fixed loopback port so the redirect URI can be pre-registered.
+    #[serde(default)]
+    pub callback_port: Option<u16>,
+    /// Loopback path of the redirect URI (defaults to `/mcp/oauth/callback`).
+    #[serde(default)]
+    pub callback_path: Option<String>,
+    /// Loopback hostname of the redirect URI (defaults to `127.0.0.1`).
+    #[serde(default)]
+    pub callback_hostname: Option<String>,
+}
+
 #[derive(Clone, Debug)]
 pub enum Transport {
     Stdio {
@@ -189,6 +209,7 @@ pub enum Transport {
     Http {
         url: String,
         headers: HashMap<String, String>,
+        oauth: Option<OauthClientConfig>,
     },
 }
 
@@ -217,6 +238,10 @@ impl McpConfig {
                     config_path: self.origins.get(name).cloned().unwrap_or_default(),
                     url: match &raw.transport {
                         RawTransport::Http(h) => Some(h.url.clone()),
+                        _ => None,
+                    },
+                    oauth: match &raw.transport {
+                        RawTransport::Http(h) => h.oauth.clone(),
                         _ => None,
                     },
                 }
@@ -259,9 +284,17 @@ pub fn parse_server(name: String, server: RawServerConfig) -> Result<ServerConfi
                     "server '{name}' url must start with http:// or https://"
                 )));
             }
+            if let Some(path) = &cfg.oauth.as_ref().and_then(|o| o.callback_path.as_ref())
+                && (path.is_empty() || !path.starts_with('/'))
+            {
+                return Err(McpError::Config(format!(
+                    "server '{name}' oauth.callback_path must start with '/'"
+                )));
+            }
             Transport::Http {
                 url: cfg.url,
                 headers: cfg.headers,
+                oauth: cfg.oauth,
             }
         }
     };
@@ -407,6 +440,7 @@ mod tests {
             transport: RawTransport::Http(RawHttpFields {
                 url: url.to_string(),
                 headers: HashMap::new(),
+                oauth: None,
             }),
         }
     }
@@ -505,6 +539,56 @@ headers = { Authorization = "Bearer tok123" }
             }
             _ => panic!("expected Http"),
         }
+    }
+
+    #[test]
+    fn oauth_client_config_deserializes() {
+        let toml_str = r#"
+[mcp.acme]
+url = "https://mcp.acme.example.com/mcp"
+oauth = { client_id = "acme-client", client_secret = "s3cret", callback_port = 3118, callback_path = "/callback" }
+"#;
+        let config: McpConfig = toml::from_str(toml_str).unwrap();
+        let parsed = parse_server("acme".into(), config.mcp["acme"].clone()).unwrap();
+        match parsed.transport {
+            Transport::Http { url, oauth, .. } => {
+                assert_eq!(url, "https://mcp.acme.example.com/mcp");
+                let oauth = oauth.unwrap();
+                assert_eq!(oauth.client_id, "acme-client");
+                assert_eq!(oauth.client_secret.as_deref(), Some("s3cret"));
+                assert_eq!(oauth.callback_port, Some(3118));
+                assert_eq!(oauth.callback_path.as_deref(), Some("/callback"));
+            }
+            _ => panic!("expected Http"),
+        }
+    }
+
+    #[test]
+    fn oauth_client_secret_and_port_optional() {
+        let config: McpConfig = toml::from_str(
+            "[mcp.acme]\nurl = \"https://mcp.acme.example.com/mcp\"\noauth = { client_id = \"acme-client\" }\n",
+        )
+        .unwrap();
+        let parsed = parse_server("acme".into(), config.mcp["acme"].clone()).unwrap();
+        match parsed.transport {
+            Transport::Http { oauth, .. } => {
+                let oauth = oauth.unwrap();
+                assert_eq!(oauth.client_secret, None);
+                assert_eq!(oauth.callback_port, None);
+                assert_eq!(oauth.callback_path, None);
+            }
+            _ => panic!("expected Http"),
+        }
+    }
+
+    #[test]
+    fn oauth_callback_path_must_start_with_slash() {
+        let config: McpConfig = toml::from_str(
+            "[mcp.acme]\nurl = \"https://mcp.acme.example.com/mcp\"\noauth = { client_id = \"acme-client\", callback_path = \"callback\" }\n",
+        )
+        .unwrap();
+        let err = parse_server("acme".into(), config.mcp["acme"].clone()).unwrap_err();
+        assert!(err.to_string().contains("callback_path"));
     }
 
     #[test]

--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -35,8 +35,8 @@ use serde_json::{Value, json};
 use tracing::{info, warn};
 
 use self::config::{
-    McpConfig, McpConfigErrors, McpServerInfo, McpServerStatus, ServerConfig, Transport,
-    load_config, parse_server, transport_kind,
+    McpConfig, McpConfigErrors, McpServerInfo, McpServerStatus, OauthClientConfig, ServerConfig,
+    Transport, load_config, parse_server, transport_kind,
 };
 use self::error::McpError;
 use self::http::HttpTransport;
@@ -818,7 +818,7 @@ async fn start_server(config: &ServerConfig) -> Result<StartResult, McpError> {
             environment,
             config.timeout,
         )?),
-        Transport::Http { url, headers } => Arc::new(HttpTransport::new(
+        Transport::Http { url, headers, .. } => Arc::new(HttpTransport::new(
             &config.name,
             url,
             headers,
@@ -950,6 +950,10 @@ fn publish(inner: &McpManagerInner, index: &ArcSwap<ToolIndex>, snapshot: &ArcSw
             .config
             .as_ref()
             .and_then(|c| transport_url(&c.transport));
+        let oauth = entry
+            .config
+            .as_ref()
+            .and_then(|c| transport_oauth(&c.transport));
 
         if let Some(ref transport) = entry.transport
             && entry.status != McpServerStatus::Disabled
@@ -995,6 +999,7 @@ fn publish(inner: &McpManagerInner, index: &ArcSwap<ToolIndex>, snapshot: &ArcSw
             status: entry.status.clone(),
             config_path: entry.origin.clone(),
             url,
+            oauth,
         });
     }
 
@@ -1161,6 +1166,13 @@ fn transport_url(transport: &Transport) -> Option<String> {
     match transport {
         Transport::Http { url, .. } => Some(url.clone()),
         Transport::Stdio { .. } => None,
+    }
+}
+
+fn transport_oauth(transport: &Transport) -> Option<OauthClientConfig> {
+    match transport {
+        Transport::Http { oauth, .. } => oauth.clone(),
+        _ => None,
     }
 }
 

--- a/maki-agent/src/mcp/oauth/callback.rs
+++ b/maki-agent/src/mcp/oauth/callback.rs
@@ -13,25 +13,47 @@ pub struct CallbackResult {
     pub code: String,
 }
 
+const DEFAULT_HOSTNAME: &str = "127.0.0.1";
+
 pub struct CallbackServer {
     pub port: u16,
+    hostname: String,
+    path: String,
     listener: TcpListener,
 }
 
 impl CallbackServer {
-    pub async fn bind() -> Result<Self, String> {
-        let listener = match TcpListener::bind(("127.0.0.1", PREFERRED_PORT)).await {
+    /// `port` pins the loopback listener so the redirect URI can be
+    /// pre-registered with the authorization server. Without it, fall back to
+    /// `PREFERRED_PORT`, then to any free port. `path`/`hostname` override the
+    /// advertised redirect URI; binding stays on 127.0.0.1, which `localhost`
+    /// (and 127.0.0.1 itself) resolves to.
+    pub async fn bind(
+        port: Option<u16>,
+        path: Option<&str>,
+        hostname: Option<&str>,
+    ) -> Result<Self, String> {
+        let requested = port.unwrap_or(PREFERRED_PORT);
+        let listener = match TcpListener::bind(("127.0.0.1", requested)).await {
             Ok(l) => l,
-            Err(_) => TcpListener::bind("127.0.0.1:0")
+            Err(_) if port.is_none() => TcpListener::bind("127.0.0.1:0")
                 .await
                 .map_err(|e| format!("failed to bind callback server: {e}"))?,
+            Err(e) => return Err(format!("failed to bind callback port {requested}: {e}")),
         };
         let port = listener.local_addr().map_err(|e| e.to_string())?.port();
-        Ok(Self { port, listener })
+        let path = path.unwrap_or(CALLBACK_PATH).to_string();
+        let hostname = hostname.unwrap_or(DEFAULT_HOSTNAME).to_string();
+        Ok(Self {
+            port,
+            hostname,
+            path,
+            listener,
+        })
     }
 
     pub fn redirect_uri(&self) -> String {
-        format!("http://127.0.0.1:{}{CALLBACK_PATH}", self.port)
+        format!("http://{}:{}{}", self.hostname, self.port, self.path)
     }
 
     pub async fn wait_for_callback(self, expected_state: &str) -> Result<CallbackResult, String> {
@@ -63,7 +85,7 @@ impl CallbackServer {
                 None => continue,
             };
 
-            if !path.starts_with(CALLBACK_PATH) {
+            if !path.starts_with(self.path.as_str()) {
                 let _ = respond(&mut stream, 404, "Not Found").await;
                 continue;
             }
@@ -184,7 +206,7 @@ mod tests {
     #[test]
     fn callback_receives_code() {
         smol::block_on(async {
-            let server = CallbackServer::bind().await.unwrap();
+            let server = CallbackServer::bind(None, None, None).await.unwrap();
             let port = server.port;
 
             let handle = smol::spawn(async move { server.wait_for_callback("test-state").await });
@@ -199,6 +221,88 @@ mod tests {
 
             let result = handle.await.unwrap();
             assert_eq!(result.code, "auth-code");
+        });
+    }
+
+    #[test]
+    fn callback_receives_code_on_custom_path() {
+        smol::block_on(async {
+            let server = CallbackServer::bind(None, Some("/callback"), None)
+                .await
+                .unwrap();
+            let port = server.port;
+
+            let handle = smol::spawn(async move { server.wait_for_callback("test-state").await });
+
+            let mut stream = smol::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+                .await
+                .unwrap();
+            let req =
+                "GET /callback?code=auth-code&state=test-state HTTP/1.1\r\nHost: localhost\r\n\r\n";
+            stream.write_all(req.as_bytes()).await.unwrap();
+
+            let result = handle.await.unwrap();
+            assert_eq!(result.code, "auth-code");
+        });
+    }
+
+    #[test]
+    fn bind_pins_requested_port() {
+        smol::block_on(async {
+            let probe = smol::net::TcpListener::bind(("127.0.0.1", 0))
+                .await
+                .unwrap();
+            let port = probe.local_addr().unwrap().port();
+            drop(probe);
+
+            let server = CallbackServer::bind(Some(port), Some("/callback"), None)
+                .await
+                .unwrap();
+            assert_eq!(server.port, port);
+            assert_eq!(
+                server.redirect_uri(),
+                format!("http://127.0.0.1:{port}/callback")
+            );
+        });
+    }
+
+    #[test]
+    fn bind_advertises_custom_hostname() {
+        smol::block_on(async {
+            let server = CallbackServer::bind(None, None, Some("localhost"))
+                .await
+                .unwrap();
+            assert_eq!(
+                server.redirect_uri(),
+                format!("http://localhost:{}{CALLBACK_PATH}", server.port)
+            );
+        });
+    }
+
+    #[test]
+    fn bind_defaults_to_stock_path() {
+        smol::block_on(async {
+            let server = CallbackServer::bind(None, None, None).await.unwrap();
+            assert_eq!(
+                server.redirect_uri(),
+                format!("http://127.0.0.1:{}{CALLBACK_PATH}", server.port)
+            );
+        });
+    }
+
+    #[test]
+    fn bind_pinned_port_in_use_is_error() {
+        smol::block_on(async {
+            let listener = smol::net::TcpListener::bind(("127.0.0.1", 0))
+                .await
+                .unwrap();
+            let port = listener.local_addr().unwrap().port();
+
+            let err = CallbackServer::bind(Some(port), None, None)
+                .await
+                .err()
+                .unwrap();
+            assert!(err.contains("failed to bind callback port"));
         });
     }
 }

--- a/maki-agent/src/mcp/oauth/mod.rs
+++ b/maki-agent/src/mcp/oauth/mod.rs
@@ -18,6 +18,7 @@ use tracing::{info, warn};
 
 use self::callback::{CallbackResult, CallbackServer};
 use self::discovery::parse_www_authenticate;
+use super::config::OauthClientConfig;
 use super::error::McpError;
 
 const AUTH_TIMEOUT: Duration = Duration::from_secs(600);
@@ -50,6 +51,7 @@ pub async fn authenticate(
     www_authenticate: Option<&str>,
     storage: &StateDir,
     interaction: Interaction,
+    static_client: Option<OauthClientConfig>,
 ) -> Result<McpAuthData, McpError> {
     let wrap = |e: OAuthError| McpError::OAuthFailed {
         server: server_name.into(),
@@ -101,12 +103,26 @@ pub async fn authenticate(
         )));
     }
 
-    let callback = CallbackServer::bind()
-        .await
-        .map_err(|e| wrap(OAuthError::Other(e)))?;
+    let callback = CallbackServer::bind(
+        static_client.as_ref().and_then(|c| c.callback_port),
+        static_client
+            .as_ref()
+            .and_then(|c| c.callback_path.as_deref()),
+        static_client
+            .as_ref()
+            .and_then(|c| c.callback_hostname.as_deref()),
+    )
+    .await
+    .map_err(|e| wrap(OAuthError::Other(e)))?;
     let redirect_uri = callback.redirect_uri();
 
-    let reg = if let Some(existing) = load_mcp_auth(storage, server_name, server_url)
+    let reg = if let Some(c) = static_client {
+        registration::ClientRegistration {
+            client_id: c.client_id,
+            client_secret: c.client_secret,
+            client_secret_expires_at: None,
+        }
+    } else if let Some(existing) = load_mcp_auth(storage, server_name, server_url)
         && existing.redirect_uri.as_deref() == Some(&redirect_uri)
     {
         registration::ClientRegistration {
@@ -160,7 +176,7 @@ pub async fn authenticate(
                 warn!(server = server_name, error = %e, "failed to open browser");
             }
 
-            eprintln!("Waiting for callback on 127.0.0.1:{}...", callback.port);
+            eprintln!("Waiting for callback on {redirect_uri}...");
             eprintln!("If this machine has no browser, log in on another device and paste");
             eprintln!("the full redirect URL ({redirect_uri}?...) here:");
 

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -344,6 +344,7 @@ fn spawn_oauth_for_needs_auth(handle: &McpHandle) {
         let server_name = info.name.clone();
         let server_url = server_url.clone();
         let www_auth = url.clone();
+        let oauth = info.oauth.clone();
         smol::spawn(async move {
             let storage = match maki_storage::StateDir::resolve() {
                 Ok(s) => s,
@@ -358,6 +359,7 @@ fn spawn_oauth_for_needs_auth(handle: &McpHandle) {
                 www_auth.as_deref(),
                 &storage,
                 maki_agent::mcp::oauth::Interaction::Background,
+                oauth,
             )
             .await
             {

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -2497,6 +2497,7 @@ fn mcp_toggle_dispatches_action() {
                 status: McpServerStatus::Running,
                 config_path: PathBuf::from("/tmp/config.toml"),
                 url: None,
+                oauth: None,
             }],
             prompts: vec![],
             pids: vec![],

--- a/maki-ui/src/components/mcp_picker.rs
+++ b/maki-ui/src/components/mcp_picker.rs
@@ -173,6 +173,7 @@ mod tests {
                     status: McpServerStatus::Running,
                     config_path: PathBuf::from("/home/.config/maki/config.toml"),
                     url: None,
+                    oauth: None,
                 },
                 McpServerInfo {
                     name: "github".into(),
@@ -182,6 +183,7 @@ mod tests {
                     status: McpServerStatus::Disabled,
                     config_path: PathBuf::from("/project/.maki/config.toml"),
                     url: None,
+                    oauth: None,
                 },
             ],
             prompts: vec![],

--- a/site/docs/content/mcp/_index.md
+++ b/site/docs/content/mcp/_index.md
@@ -37,6 +37,14 @@ url = "https://mcp.example.com/mcp"
 headers = { Authorization = "Bearer tok123" }
 ```
 
+Some HTTP servers need OAuth but have no dynamic client registration. For those, give Maki a static client:
+
+```toml
+[mcp.acme]
+url = "https://mcp.acme.example.com/mcp"
+oauth = { client_id = "acme-client", client_secret = "s3cret", callback_port = 3118, callback_path = "/callback", callback_hostname = "localhost" }
+```
+
 ### All options
 
 | Field | Type | Default | Notes |
@@ -45,6 +53,7 @@ headers = { Authorization = "Bearer tok123" }
 | `url` | string | | HTTP: server URL |
 | `environment` | map | | Stdio only |
 | `headers` | map | | HTTP only |
+| `oauth` | table | | HTTP only: static client (`client_id`, optional `client_secret`, optional `callback_port`, optional `callback_path`, optional `callback_hostname`) |
 | `timeout` | u64 | 30000 | Milliseconds (1-300000) |
 | `enabled` | bool | true | |
 | `always_load` | bool | false | Skip tool search, load all tools upfront |
@@ -123,6 +132,18 @@ Some HTTP servers need auth. When that happens, Maki opens your browser to log i
 maki mcp auth <server-name>     # manually trigger auth
 maki mcp logout <server-name>   # remove stored tokens
 ```
+
+Servers without dynamic client registration need a client you registered yourself (e.g. your own app on their platform). Add it to the server config so the auth flow uses it instead of trying to register:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `client_id` | string | Client id of your registered app |
+| `client_secret` | string | Optional, for confidential clients |
+| `callback_port` | u16 | Optional, pins the loopback port so the redirect URI can be pre-registered |
+| `callback_path` | string | Optional, loopback path of the redirect URI (default `/mcp/oauth/callback`) |
+| `callback_hostname` | string | Optional, loopback hostname of the redirect URI (default `127.0.0.1`) |
+
+Set `callback_port` when the server only accepts exact redirect URIs. Otherwise Maki falls back to its default port, then to any free port, so the redirect URI changes between runs. Set `callback_path` when the server registered a different path (e.g. `/callback`). Set `callback_hostname` to `localhost` when the server registered the name form instead of the IP (the listener still binds to 127.0.0.1).
 
 ### Headless machines
 

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -596,11 +596,20 @@ pub fn mcp_auth(server: &str, storage: &StateDir) -> Result<()> {
             .mcp
             .get(server)
             .ok_or_else(|| color_eyre::eyre::eyre!("unknown MCP server: {server}"))?;
-        let url = match mcp_config::parse_server(server.to_owned(), raw.clone())?.transport {
-            mcp_config::Transport::Http { url, .. } => url,
+        let (url, oauth) = match mcp_config::parse_server(server.to_owned(), raw.clone())?.transport
+        {
+            mcp_config::Transport::Http { url, oauth, .. } => (url, oauth),
             _ => color_eyre::eyre::bail!("server '{server}' is not an HTTP transport"),
         };
-        mcp_oauth::authenticate(server, &url, None, storage, mcp_oauth::Interaction::Cli).await?;
+        mcp_oauth::authenticate(
+            server,
+            &url,
+            None,
+            storage,
+            mcp_oauth::Interaction::Cli,
+            oauth,
+        )
+        .await?;
         eprintln!("Successfully authenticated with MCP server '{server}'");
         Ok(())
     })


### PR DESCRIPTION
## What

Support static OAuth client credentials for HTTP MCP servers that do not offer Dynamic Client Registration (RFC 7591).

New optional `oauth` block on HTTP server configs:

```toml
[mcp.acme]
url = "https://mcp.acme.example.com/mcp"
oauth = { client_id = "acme-client", client_secret = "s3cret", callback_port = 3118, callback_path = "/callback", callback_hostname = "localhost" }
```

- `client_id`: required. Client id of an app you registered on the server's platform.
- `client_secret`: optional. For confidential clients, sent as `client_secret` form param on token exchange and refresh.
- `callback_port`: optional. Pins the loopback port so the redirect URI can be pre-registered. Without it, Maki falls back to its default port, then to any free port (existing behavior).
- `callback_path`: optional. Loopback path of the redirect URI (default `/mcp/oauth/callback`). Needed when the server pre-registered a different path, e.g. `/callback`.
- `callback_hostname`: optional. Loopback hostname of the redirect URI (default `127.0.0.1`, unchanged). Set to `localhost` when the server registered the name form.

## Why

The MCP Authorization spec (2025-06-18) makes DCR optional and requires clients to support servers without it, either by hardcoding a client id or by letting users enter one. Maki currently only tries DCR and fails with "no stored client and server has no registration endpoint" on such servers.

Real-world example: Slack's hosted MCP endpoint (`https://mcp.slack.com/mcp`) has no registration endpoint; its partner clients use a shared client id with a pre-registered `http://localhost:3118/callback` redirect URI. This change implements the hardcoded-client option: the user configures the client and Maki uses it.

The flow prefers configured credentials over DCR, keeps stored tokens working (early return on valid stored tokens, silent refresh), and reuses the stored client when the redirect URI is unchanged.

Complements #726 (fall back to root OAuth metadata): together they make Slack's hosted MCP endpoint work out of the box. No shared files, mergeable in any order.

## AI use

The code change was implemented by an AI agent. I fully reviewed and tested the change myself.