### PR TITLE
fix(providers): register OpenRouter in the builtin inventory 🤖🤖🤖

### DIFF
--- a/maki-config/src/providers.rs
+++ b/maki-config/src/providers.rs
@@ -283,8 +283,8 @@ pub fn resolve_base_url(slug: &str, def: Option<&ProviderDef>) -> Option<String>
 
 /// Fields a `providers.toml` entry sets that a built-in slug ignores, because
 /// built-ins keep their compiled protocol, model catalog and auth wiring.
-/// Callers decide what counts as built-in (the inventory misses `openrouter`
-/// and `opencode`) and when to report it.
+/// Callers decide what counts as built-in (the inventory misses the `opencode`
+/// slugs) and when to report it.
 pub fn ignored_builtin_fields(slug: &str, def: &ProviderDef) -> Vec<&'static str> {
     let mut ignored = Vec::new();
     if def.protocol.is_some() {

--- a/maki-providers/src/manifest.rs
+++ b/maki-providers/src/manifest.rs
@@ -284,6 +284,28 @@ mod tests {
         }
     }
 
+    /// Opencode Zen and Opencode Go come from the fetched catalog and stay
+    /// hidden until the user is authed, so they never join the inventory.
+    const CATALOG_ONLY_SLUGS: &[&str] = &["opencode", "opencode-go"];
+
+    /// The picker lists the inventory, so a manifest without an entry is a
+    /// provider the user cannot reach. OpenRouter shipped that way for months.
+    #[test]
+    fn every_builtin_manifest_has_inventory_entry() {
+        for manifest in BUILTINS {
+            if CATALOG_ONLY_SLUGS.contains(&manifest.slug) {
+                continue;
+            }
+            assert!(
+                inventory::iter::<BuiltInProvider>()
+                    .into_iter()
+                    .any(|b| b.slug == manifest.slug),
+                "manifest {:?} has no BuiltInProvider entry, so it never shows in the picker",
+                manifest.slug,
+            );
+        }
+    }
+
     #[test]
     fn every_builtin_provider_inventory_entry_has_matching_manifest() {
         for builtin in inventory::iter::<BuiltInProvider>() {

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -38,8 +38,8 @@ fn protocol_kind(protocol: Protocol) -> ProviderKind {
 }
 
 /// Builtins win their slug in `from_spec`/`create`, so every custom path skips
-/// them. Key off the manifest (all 13 builtins), not `builtin_provider`, which
-/// omits `openrouter`/`opencode` and would let them shadow the builtin.
+/// them. Key off the manifest (every builtin), not `builtin_provider`, which
+/// omits the `opencode` slugs and would let them shadow the builtin.
 fn is_builtin_slug(slug: &str) -> bool {
     ManifestRegistry::get(slug).is_some()
 }
@@ -301,25 +301,25 @@ mod tests {
         .unwrap()
     }
 
-    // `openrouter` is a builtin whose slug is absent from the `builtin_provider`
+    // `opencode` is a builtin whose slug is absent from the `builtin_provider`
     // inventory; the old guard leaked it into the picker, where it then resolved
     // as the builtin and silently dropped the custom model. Listing must skip
     // every builtin slug so a providers.toml entry can never shadow one.
     #[test]
     fn declared_specs_skip_builtin_named_entries_but_keep_custom() {
         let mut config = ProvidersConfig::default();
-        config.upsert("openrouter".to_string(), openai_def("shadow-model"));
+        config.upsert("opencode".to_string(), openai_def("shadow-model"));
         config.upsert("my-custom".to_string(), openai_def("real-model"));
 
         let specs = declared_specs_from(&config);
         assert!(
-            !specs.iter().any(|s| s.starts_with("openrouter/")),
+            !specs.iter().any(|s| s.starts_with("opencode/")),
             "builtin slug must be skipped in custom listing: {specs:?}"
         );
         assert!(specs.contains(&"my-custom/real-model".to_string()));
 
         // Resolution owns the builtin slug regardless of the providers.toml entry.
-        let model = Model::from_spec("openrouter/shadow-model").unwrap();
-        assert_eq!(model.provider.as_ref(), "openrouter");
+        let model = Model::from_spec("opencode/shadow-model").unwrap();
+        assert_eq!(model.provider.as_ref(), "opencode");
     }
 }

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -27,6 +27,18 @@ static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
     provider_name: "OpenRouter",
 };
 
+inventory::submit!(maki_config::providers::BuiltInProvider {
+    slug: "openrouter",
+    display_name: "OpenRouter",
+    protocol: maki_config::providers::Protocol::Openai,
+    default_base_url: "https://openrouter.ai/api/v1",
+    default_api_key_env: "OPENROUTER_API_KEY",
+    default_model: "openrouter/openai/gpt-5.5",
+    plans: None,
+    login_url: Some("https://openrouter.ai/keys"),
+    needs_url: false,
+});
+
 pub(crate) const fn models() -> &'static [ModelEntry] {
     &[]
 }

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -59,7 +59,7 @@ pub struct OpenRouter {
 
 impl OpenRouter {
     pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
-        let pool = KeyPool::from_env(CONFIG.api_key_env)?;
+        let pool = KeyPool::resolve(CONFIG.slug, CONFIG.api_key_env)?;
         Ok(Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
             auth: Arc::new(Mutex::new(ResolvedAuth::bearer(pool.current()))),


### PR DESCRIPTION
I installed maki and there was no OpenRouter in the provider list, which was confusing given #287 added it. Digging in, OpenRouter had been skipped by two separate wiring passes.

**It never joined the builtin inventory.** No `inventory::submit!(BuiltInProvider)` entry, unlike every other builtin, and the login picker lists exactly that inventory. So OpenRouter was unreachable from the UI. #334 hit the same wall.

**It read its key from the env var only.** It was the last caller of `KeyPool::from_env` rather than `KeyPool::resolve`, so `maki auth login openrouter` stored a key the provider never read, and unsetting `OPENROUTER_API_KEY` failed with a bare "not set" instead of pointing at the login command. Commit 1d1d245 wired every other provider onto `KeyPool` and missed this one.

Both are one-liners. I also added a test that every manifest has an inventory entry, so the next provider cannot ship half-wired. The opencode slugs stay exempt since they come from the catalog and stay hidden until authed. Two comments and one test used openrouter as their example of a manifest without an inventory entry, so they now point at opencode, the only remaining case.

`default_model` is `openrouter/openai/gpt-5.5`, taken from the 4d71723 commit message and checked against the live `/v1/models`. Happy to move it to 5.6 if you prefer.

One thing left out: a bare `OPENROUTER_API_KEY` still will not auto-detect a model, because `from_tier` needs a static model table and OpenRouter discovers through `/v1/models` instead. That is a wider change touching the other catalog providers, so I kept it separate. Say the word if you want it here.

No test on the `KeyPool::resolve` switch: covering it means faking the state dir through `XDG_STATE_HOME` and mutating process-global env, which races under parallel tests. `resolve`'s precedence is already covered in `mod.rs`. Glad to add one if you want it anyway.

AI use: written with Claude Code from my bug report. It traced both causes, wrote the fixes and test, and ran fmt/clippy/tests/docgen. I reviewed the diff and confirmed the picker fix against a local build.
