### PR TITLE
feat(lua): expose needs-input window state

### DIFF
--- a/maki-lua/src/api/ui/mod.rs
+++ b/maki-lua/src/api/ui/mod.rs
@@ -300,6 +300,7 @@ async fn open_editor(
 ///   - order (integer): paint order among split windows at the same edge. Default 50.
 ///   - focus (boolean): whether the window takes keyboard focus on open. Default true.
 ///   - visible (boolean): whether the window is initially visible. Default true.
+///   - needs_input (boolean): whether the window means the session needs user input. Default false.
 /// @return (Win) Window handle.
 /// @example
 /// local buf = maki.ui.buf()
@@ -341,6 +342,7 @@ fn open_win(
     let split = parse_split(&opts);
     let order: u16 = opts.get("order").unwrap_or(50);
     let visible: bool = opts.get("visible").unwrap_or(true);
+    let needs_input: bool = opts.get("needs_input").unwrap_or(false);
 
     let config = FloatConfig {
         width,
@@ -359,6 +361,7 @@ fn open_win(
         split,
         order,
         visible,
+        needs_input,
     };
 
     let (term_cols, term_rows) = crossterm::terminal::size().unwrap_or((80, 24));

--- a/maki-lua/src/api/ui/win.rs
+++ b/maki-lua/src/api/ui/win.rs
@@ -178,6 +178,7 @@ fn win_extra<M: mlua::UserDataMethods<WinHandle>>(methods: &mut M) {
 ///   - reserved_top (integer): rows reserved at the top of the content area.
 ///   - split (string): edge docking, "above", "below", "left", "right", "panel", or "".
 ///   - order (integer): paint order among split windows.
+///   - needs_input (boolean): whether the window means the session needs user input.
 /// @return
 /// @example
 /// win:set_config({ title = "Updated!", width = "80%" })
@@ -207,7 +208,7 @@ fn set_config(_lua: &Lua, this: &WinHandle, opts: Table) -> LuaResult<()> {
     if let Ok(z) = opts.get::<u16>("zindex") {
         patch.zindex = Some(z);
     }
-    if let Ok(cl) = opts.get::<bool>("cursor_line") {
+    if let Ok(Some(cl)) = opts.get::<Option<bool>>("cursor_line") {
         patch.cursor_line = Some(cl);
     }
     if let Ok(rt) = opts.get::<usize>("reserved_top") {
@@ -218,6 +219,9 @@ fn set_config(_lua: &Lua, this: &WinHandle, opts: Table) -> LuaResult<()> {
     }
     if let Ok(o) = opts.get::<u16>("order") {
         patch.order = Some(o);
+    }
+    if let Ok(Some(ni)) = opts.get::<Option<bool>>("needs_input") {
+        patch.needs_input = Some(ni);
     }
     patch.width = try_parse_dimension(&opts, "width");
     patch.height = try_parse_dimension(&opts, "height");
@@ -342,6 +346,7 @@ lua_class! {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::util::command::FloatConfig;
 
     fn make_channels() -> (
         flume::Sender<WinEvent>,
@@ -450,6 +455,43 @@ mod tests {
             assert_eq!(recv_task.await.unwrap(), "key");
         }));
         assert!(matches!(cmd_rx.try_recv(), Ok(WinCommand::SetCursor(2))));
+    }
+
+    #[test]
+    fn set_config_without_needs_input_keeps_flag() {
+        let lua = mlua::Lua::new();
+        let (_event_tx, cmd_rx, handle) = make_channels();
+        lua.globals().set("win", handle).unwrap();
+        lua.load("win:set_config({ title = \"t\" })")
+            .exec()
+            .unwrap();
+        let Ok(WinCommand::SetConfig(patch)) = cmd_rx.try_recv() else {
+            panic!("expected SetConfig command");
+        };
+        assert_eq!(
+            patch.needs_input, None,
+            "absent key must not touch the flag"
+        );
+        let mut cfg = FloatConfig {
+            needs_input: true,
+            ..FloatConfig::default()
+        };
+        cfg.apply_patch(patch);
+        assert!(cfg.needs_input, "patch without the key must keep the flag");
+    }
+
+    #[test]
+    fn set_config_with_needs_input_false_clears_flag() {
+        let lua = mlua::Lua::new();
+        let (_event_tx, cmd_rx, handle) = make_channels();
+        lua.globals().set("win", handle).unwrap();
+        lua.load("win:set_config({ needs_input = false })")
+            .exec()
+            .unwrap();
+        let Ok(WinCommand::SetConfig(patch)) = cmd_rx.try_recv() else {
+            panic!("expected SetConfig command");
+        };
+        assert_eq!(patch.needs_input, Some(false));
     }
 
     #[test]

--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -303,6 +303,7 @@ pub struct FloatConfig {
     pub split: Split,
     pub order: u16,
     pub visible: bool,
+    pub needs_input: bool,
 }
 
 impl Default for FloatConfig {
@@ -324,6 +325,7 @@ impl Default for FloatConfig {
             split: Split::None,
             order: 50,
             visible: true,
+            needs_input: false,
         }
     }
 }
@@ -354,7 +356,8 @@ impl FloatConfig {
             reserved_top,
             split,
             order,
-            visible
+            visible,
+            needs_input
         );
     }
 }
@@ -377,6 +380,7 @@ pub struct FloatConfigPatch {
     pub split: Option<Split>,
     pub order: Option<u16>,
     pub visible: Option<bool>,
+    pub needs_input: Option<bool>,
 }
 
 pub enum WinEvent {

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -1474,10 +1474,12 @@ impl App {
         self.overlays().iter().any(|o| o.is_open())
     }
 
-    /// True when the agent is parked on user input: a permission prompt or an
-    /// auth retry. Drives the `needs_input` session status.
+    /// True when the agent is parked on user input. Drives the `needs_input`
+    /// session status.
     pub(crate) fn awaiting_input(&self) -> bool {
-        self.permission_prompt.is_open() || self.pending_input != PendingInput::None
+        self.permission_prompt.is_open()
+            || self.pending_input != PendingInput::None
+            || self.float_mgr.needs_input()
     }
 
     pub fn has_modal_overlay(&self) -> bool {

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -3600,6 +3600,25 @@ fn open_split_window(app: &mut App, dir: maki_lua::Split) {
 }
 
 #[test]
+fn attention_float_marks_app_as_awaiting_input_until_close() {
+    let mut app = test_app();
+    let buf = Arc::new(maki_agent::SharedBuf::new());
+    let config = maki_lua::FloatConfig {
+        needs_input: true,
+        ..maki_lua::FloatConfig::default()
+    };
+    let (event_tx, _event_rx) = flume::bounded::<maki_lua::WinEvent>(8);
+    let (cmd_tx, cmd_rx) = flume::bounded::<maki_lua::WinCommand>(8);
+
+    app.float_mgr.open(buf, config, true, event_tx, cmd_rx);
+    assert!(app.awaiting_input());
+
+    cmd_tx.send(maki_lua::WinCommand::Close).unwrap();
+    app.float_mgr.tick();
+    assert!(!app.awaiting_input());
+}
+
+#[test]
 fn below_split_reserves_bottom_and_suppresses_input() {
     let mut app = test_app();
     let (msg_before, _b, _s, input_before, splits_before) = app.layout_geometry(TEST_AREA);

--- a/maki-ui/src/components/lua_float.rs
+++ b/maki-ui/src/components/lua_float.rs
@@ -253,6 +253,10 @@ impl FloatManager {
         }
     }
 
+    pub fn needs_input(&self) -> bool {
+        self.windows.iter().any(|win| win.config.needs_input)
+    }
+
     pub fn handle_key(&mut self, key_event: KeyEvent) -> bool {
         let Some(fid) = self.focused_id else {
             return false;
@@ -986,6 +990,28 @@ mod tests {
 
         assert_eq!(mgr.windows[0].config.title, "Updated");
         assert_eq!(mgr.windows[0].config.zindex, 99);
+    }
+
+    #[test]
+    fn needs_input_tracks_window_lifecycle_and_config() {
+        let mut mgr = FloatManager::new();
+        assert!(!mgr.needs_input());
+
+        let (_event_rx, cmd_tx) = open_with_lines(&mut mgr, &["a"]);
+        assert!(!mgr.needs_input());
+
+        cmd_tx
+            .send(WinCommand::SetConfig(FloatConfigPatch {
+                needs_input: Some(true),
+                ..FloatConfigPatch::default()
+            }))
+            .unwrap();
+        mgr.tick();
+        assert!(mgr.needs_input());
+
+        cmd_tx.send(WinCommand::Close).unwrap();
+        mgr.tick();
+        assert!(!mgr.needs_input());
     }
 
     #[test]

--- a/plugins/question/question_form.lua
+++ b/plugins/question/question_form.lua
@@ -607,6 +607,7 @@ function QuestionForm.open(questions)
     border = "rounded",
     reserved_bottom = 1,
     focus = true,
+    needs_input = true,
     split = "below",
   })
 

--- a/plugins/question/tests/spec.lua
+++ b/plugins/question/tests/spec.lua
@@ -682,6 +682,7 @@ case("open_requests_bottom_split", function()
   assert(ok, "open must not error: " .. tostring(err))
   assert(captured, "open_win must be called")
   eq(captured.split, "below", "form must request a bottom split")
+  eq(captured.needs_input, true, "form must mark the session as needing input")
 end)
 
 local function find_span_containing(lines, text)

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -4205,6 +4205,7 @@ and close the window when you are done.
   - `order` (`integer`) paint order among split windows at the same edge. Default 50.
   - `focus` (`boolean`) whether the window takes keyboard focus on open. Default true.
   - `visible` (`boolean`) whether the window is initially visible. Default true.
+  - `needs_input` (`boolean`) whether the window means the session needs user input. Default false.
 
 **Returns:** ([`Win`](#maki-ui-Win)) Window handle.
 
@@ -4325,6 +4326,7 @@ Updates the window layout on the fly. Only the fields you include in
   - `reserved_top` (`integer`) rows reserved at the top of the content area.
   - `split` (`string`) edge docking, "above", "below", "left", "right", "panel", or "".
   - `order` (`integer`) paint order among split windows.
+  - `needs_input` (`boolean`) whether the window means the session needs user input.
 
 **Example:**
 


### PR DESCRIPTION
## Summary

- add `needs_input` to Lua window configuration and updates
- include flagged windows in the live session `needs_input` status
- mark the bundled question form as waiting for user input
- document the new Lua window field

This is the independently useful first step for #709. It corrects live
session status for question windows without adding notification policy.

## Checks

- `cargo fmt --all -- --check`
- `stylua --check plugins/`
- `just gen-docs-check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --workspace`: 3,525 passed
- `cargo test --workspace --doc`

`just ci` reaches the Python lint step and stops on nine existing Ruff
findings in unchanged `scripts/` files.

## AI use

I used Codex to trace the Lua window and session-status flow, implement the
change, review the complete diff, and run the checks. My prompt direction was
to split `needs_input` from terminal notifications so this change stays
independently useful and small.
