### PR TITLE
feat(ui): add terminal attention notifications 🤖🤖🤖

### DIFF
--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -577,6 +577,7 @@ pub enum AgentEvent {
         text: String,
         image_count: usize,
     },
+    QueueDrained,
     Done {
         usage: TokenUsage,
         num_turns: u32,

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -331,6 +331,7 @@ pub struct PluginFileConfig {
 pub struct UiFileConfig {
     pub splash_animation: Option<bool>,
     pub scrollbar: Option<bool>,
+    pub notifications: Option<NotificationMethod>,
     pub flash_duration_ms: Option<u64>,
     pub typewriter_ms_per_char: Option<u64>,
     pub mouse_scroll_lines: Option<u32>,
@@ -348,6 +349,7 @@ impl UiFileConfig {
             overlay,
             splash_animation,
             scrollbar,
+            notifications,
             flash_duration_ms,
             typewriter_ms_per_char,
             mouse_scroll_lines,
@@ -362,6 +364,16 @@ impl UiFileConfig {
             _ => {}
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NotificationMethod {
+    #[default]
+    Auto,
+    Osc9,
+    Bell,
+    Off,
 }
 
 #[derive(Deserialize, Default, Debug)]
@@ -843,6 +855,14 @@ pub struct UiConfig {
     #[config(default = true, desc = "Show vertical scrollbar in scrollable areas")]
     pub scrollbar: bool,
 
+    #[config(
+        default = NotificationMethod::Auto,
+        ty = "string",
+        default_doc = "auto",
+        desc = "Terminal notification method: auto, osc9, bell, or off"
+    )]
+    pub notifications: NotificationMethod,
+
     #[config(default = DEFAULT_FLASH_DURATION_MS, desc = "Duration of flash messages (ms)")]
     pub flash_duration_ms: u64,
 
@@ -880,6 +900,7 @@ impl UiConfig {
         Self {
             splash_animation: f.splash_animation.unwrap_or(true),
             scrollbar: f.scrollbar.unwrap_or(true),
+            notifications: f.notifications.unwrap_or_default(),
             flash_duration_ms: f.flash_duration_ms.unwrap_or(DEFAULT_FLASH_DURATION_MS),
             typewriter_ms_per_char: f
                 .typewriter_ms_per_char
@@ -2016,6 +2037,7 @@ mod tests {
     fn empty_config_returns_defaults() {
         let config = RawConfig::default().into_config(false).unwrap();
         assert!(config.ui.splash_animation);
+        assert_eq!(config.ui.notifications, NotificationMethod::Auto);
         assert_eq!(config.agent.max_output_bytes, DEFAULT_MAX_OUTPUT_BYTES);
         assert_eq!(
             config.provider.connect_timeout,
@@ -2025,6 +2047,22 @@ mod tests {
             config.storage.max_log_bytes,
             DEFAULT_MAX_LOG_BYTES_MB * 1024 * 1024
         );
+    }
+
+    #[test_case("auto", NotificationMethod::Auto ; "auto")]
+    #[test_case("osc9", NotificationMethod::Osc9 ; "osc9")]
+    #[test_case("bell", NotificationMethod::Bell ; "bell")]
+    #[test_case("off", NotificationMethod::Off ; "off")]
+    fn notifications_deserialize(value: &str, expected: NotificationMethod) {
+        let raw: RawConfig =
+            toml::from_str(&format!("[ui]\nnotifications = \"{value}\"\n")).unwrap();
+        assert_eq!(raw.into_config(false).unwrap().ui.notifications, expected);
+    }
+
+    #[test]
+    fn notifications_reject_unknown_value() {
+        let result: Result<RawConfig, _> = toml::from_str("[ui]\nnotifications = \"desktop\"\n");
+        assert!(result.is_err());
     }
 
     #[test]
@@ -2047,6 +2085,7 @@ mod tests {
             always_yolo: Some(false),
             ui: UiFileConfig {
                 splash_animation: Some(false),
+                notifications: Some(NotificationMethod::Bell),
                 flash_duration_ms: Some(2000),
                 ..Default::default()
             },
@@ -2059,6 +2098,10 @@ mod tests {
         };
         let overlay = RawConfig {
             always_yolo: Some(true),
+            ui: UiFileConfig {
+                notifications: Some(NotificationMethod::Off),
+                ..Default::default()
+            },
             agent: AgentFileConfig {
                 max_output_lines: Some(5000),
                 ..Default::default()
@@ -2071,6 +2114,11 @@ mod tests {
         assert_eq!(base.agent.max_output_lines, Some(5000), "overlay wins");
         assert_eq!(base.agent.max_output_bytes, Some(80_000), "base preserved");
         assert_eq!(base.ui.splash_animation, Some(false), "base preserved");
+        assert_eq!(
+            base.ui.notifications,
+            Some(NotificationMethod::Off),
+            "overlay wins"
+        );
         assert_eq!(base.ui.flash_duration_ms, Some(2000), "base preserved");
     }
 

--- a/maki-lua/src/api/session.rs
+++ b/maki-lua/src/api/session.rs
@@ -37,7 +37,8 @@ async fn list(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaResult
 }
 
 /// Lists the sessions currently running in this UI. Status is "working",
-/// "needs_input", or "idle".
+/// "needs_input", or "idle". A mailbox follow-up stays "working" without an
+/// intermediate "idle" status.
 ///
 /// @return (table|nil, string|nil) Array of `{id, title, status, updated_at, focused}`, or nil and an error.
 /// @example

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -26,6 +26,18 @@ use super::ModelSlot;
 use super::cancel_map::RunCancelMap;
 use super::shared_queue::{QueueItem, QueueReceiver};
 
+fn publish_queue_drained(
+    queue: &QueueReceiver,
+    agent_tx: &flume::Sender<Envelope>,
+    run_id: Option<u64>,
+) -> bool {
+    let Some(run_id) = run_id else {
+        return false;
+    };
+    let event_tx = EventSender::new(agent_tx.clone(), run_id);
+    queue.publish_if_empty(|| event_tx.try_send(AgentEvent::QueueDrained))
+}
+
 pub(super) struct AgentLoop {
     model_slot: Arc<ArcSwap<ModelSlot>>,
     config: AgentConfig,
@@ -109,12 +121,15 @@ impl AgentLoop {
         }
 
         while let Ok(()) = self.queue.recv_notify().await {
+            let mut last_run_id = None;
             while let Some(entry) = self.queue.pop() {
                 if entry.run_id() < self.min_run_id {
                     continue;
                 }
+                last_run_id = Some(entry.run_id());
                 self.process_entry(entry).await;
             }
+            publish_queue_drained(&self.queue, &self.agent_tx, last_run_id);
         }
     }
 
@@ -377,5 +392,24 @@ fn spawn_oauth_for_needs_auth(handle: &McpHandle) {
             tracing::info!(server = %server_name, "MCP server authenticated via OAuth");
         })
         .detach();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::shared_queue;
+
+    #[test]
+    fn queue_drain_uses_last_run_id() {
+        let (_queue_tx, queue_rx) = shared_queue::queue();
+        let (event_tx, event_rx) = flume::unbounded();
+
+        assert!(publish_queue_drained(&queue_rx, &event_tx, Some(7)));
+        let envelope = event_rx.try_recv().unwrap();
+        assert!(matches!(envelope.event, AgentEvent::QueueDrained));
+        assert_eq!(envelope.run_id, 7);
+        assert!(!publish_queue_drained(&queue_rx, &event_tx, None));
+        assert!(event_rx.is_empty());
     }
 }

--- a/maki-ui/src/agent/mod.rs
+++ b/maki-ui/src/agent/mod.rs
@@ -176,6 +176,10 @@ impl AgentHandles {
     /// wind down. The caller sends `CancelAll` first and then awaits all
     /// tabs at once via [`join_all`] instead of paying a serial timeout
     /// per tab.
+    pub(crate) fn is_finished(&self) -> bool {
+        self.task.is_finished()
+    }
+
     pub(crate) fn into_task(self) -> smol::Task<()> {
         self.task
     }

--- a/maki-ui/src/agent/shared_queue.rs
+++ b/maki-ui/src/agent/shared_queue.rs
@@ -174,6 +174,15 @@ impl QueueReceiver {
         lock(&self.items).pop_front()
     }
 
+    pub(crate) fn publish_if_empty(&self, publish: impl FnOnce()) -> bool {
+        let items = lock(&self.items);
+        if !items.is_empty() {
+            return false;
+        }
+        publish();
+        true
+    }
+
     pub(crate) async fn recv_notify(&self) -> Result<(), flume::RecvError> {
         self.notify_rx.recv_async().await
     }
@@ -187,6 +196,10 @@ impl InterruptSource for QueueReceiver {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+    use std::sync::Barrier;
+    use std::thread;
+
     use super::*;
     use test_case::test_case;
 
@@ -218,5 +231,37 @@ mod tests {
         let expected = usize::from(visible);
         assert_eq!(tx.panel_len(), expected);
         assert_eq!(tx.panel_entries().len(), expected);
+    }
+
+    #[test]
+    fn nonempty_queue_does_not_publish_drain() {
+        let (tx, rx) = queue();
+        tx.push(msg(false));
+        let called = Cell::new(false);
+
+        assert!(!rx.publish_if_empty(|| called.set(true)));
+        assert!(!called.get());
+    }
+
+    #[test]
+    fn drain_publication_is_serialized_with_push() {
+        let (tx, rx) = queue();
+        let barrier = Arc::new(Barrier::new(2));
+        let order = Arc::new(Mutex::new(Vec::new()));
+        let worker_barrier = Arc::clone(&barrier);
+        let worker_order = Arc::clone(&order);
+        let worker = thread::spawn(move || {
+            worker_barrier.wait();
+            tx.push(msg(false));
+            lock(&worker_order).push("push");
+        });
+
+        assert!(rx.publish_if_empty(|| {
+            barrier.wait();
+            lock(&order).push("drain");
+        }));
+        worker.join().unwrap();
+
+        assert_eq!(*lock(&order), ["drain", "push"]);
     }
 }

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -62,7 +62,7 @@ use maki_config::{ModelPolicy, UiConfig};
 use maki_lua::{
     BuiltinAction, EventHandle, HintReader, HintSnapshot, KeymapReader, LuaCommandReader, WinView,
 };
-use maki_providers::{Model, ThinkingConfig, add_cost};
+use maki_providers::{ContentBlock, Message, Model, ThinkingConfig, add_cost};
 use maki_storage::StateDir;
 use maki_storage::input_history::InputHistory;
 use maki_storage::model::persist_model;
@@ -98,6 +98,7 @@ const IMPLEMENT_PARALLEL_HINT: &str = "Use batch+task to parallelize, assign eac
 
 const TASK_DONE_DETAIL: &str = "✓ ";
 const MISSING_TOOL_COMPLETION: &str = "Tool did not report completion before the turn ended";
+const NOTIFICATION_PREVIEW_CHARS: usize = 200;
 
 /// Depth budget for `maki.api.run_command` chains. Aliases nest a level or two
 /// in practice; the cap only exists so a command aliasing itself reports an
@@ -122,6 +123,99 @@ impl PickerItem for TaskEntry {
     fn is_spinning(&self) -> bool {
         matches!(self.finished, Some(false))
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Notification {
+    TurnComplete { response: Option<String> },
+    PermissionRequested { tool: Option<String> },
+    AuthenticationRequired,
+    QuestionRequested,
+    PlanReady,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
+pub(crate) enum NotificationPriority {
+    Low,
+    High,
+}
+
+impl Notification {
+    pub(crate) fn priority(&self) -> NotificationPriority {
+        match self {
+            Self::TurnComplete { .. } => NotificationPriority::Low,
+            Self::PermissionRequested { .. }
+            | Self::AuthenticationRequired
+            | Self::QuestionRequested
+            | Self::PlanReady => NotificationPriority::High,
+        }
+    }
+
+    pub(crate) fn message(&self) -> String {
+        match self {
+            Self::TurnComplete { response } => response
+                .clone()
+                .unwrap_or_else(|| "Agent turn complete".into()),
+            Self::PermissionRequested { tool: Some(tool) } => {
+                format!("Permission requested: {tool}")
+            }
+            Self::PermissionRequested { tool: None } => "Permission requested".into(),
+            Self::AuthenticationRequired => "Authentication required".into(),
+            Self::QuestionRequested => "Question requested".into(),
+            Self::PlanReady => "Plan ready".into(),
+        }
+    }
+
+    pub(crate) fn error_completion() -> Self {
+        Self::TurnComplete {
+            response: Some("Agent stopped with an error".into()),
+        }
+    }
+}
+
+fn notification_preview<'a>(chunks: impl Iterator<Item = &'a str>) -> Option<String> {
+    let mut preview = String::new();
+    let mut characters = 0;
+    let mut pending_space = false;
+    for chunk in chunks {
+        pending_space |= !preview.is_empty();
+        for character in chunk.chars() {
+            if character.is_whitespace() {
+                pending_space = !preview.is_empty();
+                continue;
+            }
+            if pending_space {
+                preview.push(' ');
+                characters += 1;
+                if characters == NOTIFICATION_PREVIEW_CHARS {
+                    preview.pop();
+                    return Some(preview);
+                }
+            }
+            pending_space = false;
+            preview.push(character);
+            characters += 1;
+            if characters == NOTIFICATION_PREVIEW_CHARS {
+                return Some(preview);
+            }
+        }
+    }
+    (!preview.is_empty()).then_some(preview)
+}
+
+fn normalize_preview(text: &str) -> Option<String> {
+    notification_preview(std::iter::once(text))
+}
+
+pub(crate) fn turn_response(message: &Message) -> Option<String> {
+    if message.has_tool_calls() {
+        return None;
+    }
+
+    notification_preview(message.content.iter().filter_map(|block| match block {
+        ContentBlock::Text { text } => Some(text.as_str()),
+        _ => None,
+    }))
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -931,7 +1025,11 @@ impl App {
     fn quit_with(&mut self, req: ExitRequest) -> Vec<Action> {
         self.save_input_history();
         self.exit_request = req;
-        vec![]
+        vec![Action::ManualExit]
+    }
+
+    pub(crate) fn clear_exit_request(&mut self) {
+        self.exit_request = ExitRequest::None;
     }
 
     pub(crate) fn handle_submit(&mut self, sub: Submission) -> Vec<Action> {
@@ -1573,6 +1671,24 @@ impl App {
     /// error; a background run would wipe it (`start_run` clears the queue).
     pub(crate) fn holds_recovery_text(&self) -> bool {
         !self.recoverable_queue.is_empty()
+    }
+
+    pub(crate) fn attention(&self) -> Option<Notification> {
+        if let Some(tool) = self.permission_prompt.tool() {
+            let tool = (!matches!(tool, maki_config::ToolKey::Wildcard))
+                .then(|| normalize_preview(&tool.to_string()))
+                .flatten();
+            return Some(Notification::PermissionRequested { tool });
+        }
+        if matches!(self.pending_input, PendingInput::AuthRetry { .. }) {
+            return Some(Notification::AuthenticationRequired);
+        }
+        if self.status != Status::Streaming && self.plan_form_active() {
+            return Some(Notification::PlanReady);
+        }
+        self.float_mgr
+            .needs_input()
+            .then_some(Notification::QuestionRequested)
     }
 
     pub fn has_modal_overlay(&self) -> bool {

--- a/maki-ui/src/app/queue.rs
+++ b/maki-ui/src/app/queue.rs
@@ -227,6 +227,7 @@ impl App {
     /// once per run.
     pub(super) fn start_run(&mut self, input: AgentInput, display: String) -> Vec<Action> {
         self.run_id += 1;
+        self.clear_exit_request();
         // New work supersedes text held for recovery after an agent error.
         self.recoverable_queue.clear();
         self.status = Status::Streaming;

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -171,6 +171,7 @@ impl App {
         self.active_chat = 0;
         self.chat_index.clear();
         self.status = super::Status::Idle;
+        self.clear_exit_request();
         self.queue.clear();
         self.recoverable_queue.clear();
         self.close_all_overlays();

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -315,7 +315,7 @@ fn ctrl_c_quits_when_input_empty() {
     app.status = Status::Idle;
     let actions = app.update(Msg::Key(kb::QUIT.to_key_event()));
     assert_eq!(app.exit_request, ExitRequest::Success);
-    assert!(actions.is_empty());
+    assert!(matches!(actions.as_slice(), [Action::ManualExit]));
 }
 
 #[test_case(done(), ExitRequest::Success ; "done_exits_success")]
@@ -325,8 +325,26 @@ fn exit_on_done_flag_triggers_exit(event: AgentEvent, expected: ExitRequest) {
     app.exit_on_done = true;
     app.status = Status::Streaming;
     app.run_id = 1;
-    app.update(agent_msg(event));
+    let actions = app.update(agent_msg(event));
     assert_eq!(app.exit_request, expected);
+    assert!(actions.is_empty());
+}
+
+#[test]
+fn reset_session_clears_exit_request_source() {
+    let mut app = test_app();
+    app.exit_on_done = true;
+    app.status = Status::Streaming;
+    app.run_id = 1;
+    app.update(agent_msg(AgentEvent::Done {
+        usage: TokenUsage::default(),
+        num_turns: 1,
+        reason: DoneReason::EndTurn,
+    }));
+
+    app.reset_session();
+
+    assert_eq!(app.exit_request, ExitRequest::None);
 }
 
 #[test]
@@ -2205,7 +2223,7 @@ fn submit_exit_quits() {
         images: vec![],
     });
     assert_eq!(app.exit_request, ExitRequest::Success);
-    assert!(actions.is_empty());
+    assert!(matches!(actions.as_slice(), [Action::ManualExit]));
 }
 
 #[test]
@@ -2300,7 +2318,7 @@ fn reload_persists_session_with_content_to_disk() {
         .push_message(Message::user("hello".into()));
     let actions = app.execute_command(cmd("/reload"), 0);
     assert_eq!(app.exit_request, ExitRequest::Reload);
-    assert!(actions.is_empty());
+    assert!(matches!(actions.as_slice(), [Action::ManualExit]));
     app.checkpoint();
     let id = app.state.session.id;
     drain_writer(app, writer);
@@ -3965,10 +3983,23 @@ fn attention_float_marks_app_as_awaiting_input_until_close() {
 
     app.float_mgr.open(buf, config, true, event_tx, cmd_rx);
     assert!(app.awaiting_input());
+    assert_eq!(app.attention(), Some(Notification::QuestionRequested));
+
+    cmd_tx
+        .send(maki_lua::WinCommand::SetVisible(false))
+        .unwrap();
+    let _ = app.float_mgr.tick();
+    assert!(!app.awaiting_input());
+    assert_eq!(app.attention(), None);
+
+    cmd_tx.send(maki_lua::WinCommand::SetVisible(true)).unwrap();
+    let _ = app.float_mgr.tick();
+    assert_eq!(app.attention(), Some(Notification::QuestionRequested));
 
     cmd_tx.send(maki_lua::WinCommand::Close).unwrap();
     let _ = app.float_mgr.tick();
     assert!(!app.awaiting_input());
+    assert_eq!(app.attention(), None);
 }
 
 #[test]
@@ -4182,6 +4213,134 @@ const BUMP_TITLE: &str = "title bump ";
 const TOOL_IDS: [&str; 2] = ["tool-a", "tool-b"];
 const FINISHED_TASK_ID: &str = "task-finished";
 const UNFINISHED_TASK_ID: &str = "task-unfinished";
+
+#[test]
+fn turn_response_normalizes_text_and_truncates_unicode() {
+    let long = "界".repeat(201);
+    let message = Message {
+        role: Role::Assistant,
+        content: vec![
+            ContentBlock::Text {
+                text: "  first\n\tsecond ".into(),
+            },
+            ContentBlock::Thinking {
+                thinking: "ignored".into(),
+                signature: None,
+            },
+            ContentBlock::Text { text: long },
+        ],
+        ..Default::default()
+    };
+    let response = turn_response(&message).unwrap();
+    assert_eq!(response.chars().count(), 200);
+    assert!(response.starts_with("first second 界"));
+    assert_eq!(turn_response(&Message::default()), None);
+}
+
+#[test]
+fn turn_response_stops_after_bounded_large_input() {
+    let message = Message {
+        role: Role::Assistant,
+        content: vec![
+            ContentBlock::Text {
+                text: format!("first {}", "x".repeat(1_000_000)),
+            },
+            ContentBlock::Text {
+                text: "not reached".into(),
+            },
+        ],
+        ..Default::default()
+    };
+
+    let response = turn_response(&message).unwrap();
+
+    assert_eq!(response.chars().count(), 200);
+    assert!(response.starts_with("first "));
+    assert!(!response.contains("not reached"));
+}
+
+#[test]
+fn tool_call_is_not_a_turn_response() {
+    assert_eq!(turn_response(&tool_use_msg("tool")), None);
+}
+
+#[test_case(Notification::TurnComplete { response: Some("answer".into()) }, "answer", NotificationPriority::Low ; "turn_response")]
+#[test_case(Notification::TurnComplete { response: None }, "Agent turn complete", NotificationPriority::Low ; "turn_fallback")]
+#[test_case(Notification::PermissionRequested { tool: Some("bash".into()) }, "Permission requested: bash", NotificationPriority::High ; "permission_tool")]
+#[test_case(Notification::PermissionRequested { tool: None }, "Permission requested", NotificationPriority::High ; "permission_fallback")]
+#[test_case(Notification::AuthenticationRequired, "Authentication required", NotificationPriority::High ; "authentication")]
+#[test_case(Notification::QuestionRequested, "Question requested", NotificationPriority::High ; "question")]
+#[test_case(Notification::PlanReady, "Plan ready", NotificationPriority::High ; "plan")]
+fn notification_message_and_priority(
+    notification: Notification,
+    expected_message: &str,
+    expected_priority: NotificationPriority,
+) {
+    assert_eq!(notification.message(), expected_message);
+    assert_eq!(notification.priority(), expected_priority);
+}
+
+#[test]
+fn error_completion_has_safe_message() {
+    assert_eq!(
+        Notification::error_completion().message(),
+        "Agent stopped with an error"
+    );
+}
+
+#[test]
+fn attention_prioritizes_permission_and_normalizes_tool() {
+    let mut app = test_app();
+    app.pending_input = PendingInput::AuthRetry { subagent_id: None };
+    app.state.mode = Mode::Plan;
+    app.state.plan = PlanState::Ready(PathBuf::from("plan.md"));
+    app.plan_form.on_plan_ready();
+    app.permission_prompt.open(
+        "id".into(),
+        maki_config::ToolKey::native("bash"),
+        vec!["execute".into()],
+        None,
+    );
+    assert_eq!(
+        app.attention(),
+        Some(Notification::PermissionRequested {
+            tool: Some("bash".into())
+        })
+    );
+
+    app.permission_prompt
+        .open("id".into(), maki_config::ToolKey::Wildcard, vec![], None);
+    assert_eq!(
+        app.attention(),
+        Some(Notification::PermissionRequested { tool: None })
+    );
+}
+
+#[test]
+fn attention_classifies_auth_and_ready_plan() {
+    let mut app = test_app();
+    app.pending_input = PendingInput::AuthRetry { subagent_id: None };
+    assert_eq!(app.attention(), Some(Notification::AuthenticationRequired));
+
+    app.pending_input = PendingInput::None;
+    app.state.mode = Mode::Plan;
+    app.state.plan = PlanState::Ready(PathBuf::from("plan.md"));
+    app.plan_form.on_plan_ready();
+    app.status = Status::Streaming;
+    assert_eq!(app.attention(), None);
+    app.status = Status::Idle;
+    assert_eq!(app.attention(), Some(Notification::PlanReady));
+    assert!(!app.awaiting_input());
+
+    app.plan_form.hide();
+    assert_eq!(app.attention(), None);
+    app.plan_form.on_plan_ready();
+    app.state.plan = PlanState::Drafting(PathBuf::from("plan.md"));
+    assert_eq!(app.attention(), None);
+    app.state.plan = PlanState::Ready(PathBuf::from("plan.md"));
+    app.state.mode = Mode::Build;
+    assert_eq!(app.attention(), None);
+}
 
 fn tool_use_msg(id: &str) -> Message {
     Message {

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -121,6 +121,7 @@ impl Chat {
             AgentEvent::QueueItemConsumed { text, image_count } => {
                 return ChatEventResult::QueueItemConsumed { text, image_count };
             }
+            AgentEvent::QueueDrained => {}
             AgentEvent::Retry { .. } => unreachable!("handled before handle_event"),
             AgentEvent::Done { .. } => {
                 self.messages_panel.flush();

--- a/maki-ui/src/components/lua_float.rs
+++ b/maki-ui/src/components/lua_float.rs
@@ -268,7 +268,9 @@ impl FloatManager {
     }
 
     pub fn needs_input(&self) -> bool {
-        self.windows.iter().any(|win| win.config.needs_input)
+        self.windows
+            .iter()
+            .any(|win| win.visible && win.config.needs_input)
     }
 
     pub fn handle_key(&mut self, key_event: KeyEvent) -> bool {
@@ -731,6 +733,20 @@ mod tests {
         let buf = make_buf(lines);
         mgr.open(buf, make_config(), true, event_tx, cmd_rx);
         (event_rx, cmd_tx)
+    }
+
+    #[test_case(true, true ; "visible")]
+    #[test_case(false, false ; "hidden")]
+    fn needs_input_requires_visibility(visible: bool, expected: bool) {
+        let mut mgr = FloatManager::new();
+        let (event_tx, cmd_rx, _, _) = make_channels();
+        let config = FloatConfig {
+            visible,
+            needs_input: true,
+            ..FloatConfig::default()
+        };
+        mgr.open(make_buf(&[]), config, false, event_tx, cmd_rx);
+        assert_eq!(mgr.needs_input(), expected);
     }
 
     #[test]

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -185,6 +185,7 @@ use std::path::PathBuf;
 
 pub enum Action {
     SendMessage(Box<AgentInput>),
+    ManualExit,
     ShellCommand {
         id: String,
         command: String,

--- a/maki-ui/src/components/permission_prompt.rs
+++ b/maki-ui/src/components/permission_prompt.rs
@@ -148,6 +148,13 @@ impl PermissionPrompt {
         };
     }
 
+    pub(crate) fn tool(&self) -> Option<&ToolKey> {
+        match self {
+            Self::Open { tool, .. } => Some(tool),
+            Self::Closed => None,
+        }
+    }
+
     pub fn subagent_id(&self) -> Option<&str> {
         match self {
             Self::Open { subagent_id, .. } => subagent_id.as_deref(),

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -19,7 +19,9 @@ use crossterm::event::{
 };
 use maki_agent::command::CustomCommand;
 use maki_agent::permissions::PermissionManager;
-use maki_agent::{AgentConfig, CancelToken, McpCommand, McpConfigErrors, McpHandle, mcp};
+use maki_agent::{
+    AgentConfig, AgentEvent, CancelToken, Envelope, McpCommand, McpConfigErrors, McpHandle, mcp,
+};
 use maki_config::{ModelPolicy, UiConfig};
 use maki_lua::{
     EventHandle, HintReader, KeymapReader, LuaCommandReader, SessionReply, SessionRequest, UiAction,
@@ -37,7 +39,7 @@ use tracing::{info, warn};
 use crate::AppSession;
 use crate::agent::{AgentCommand, AgentHandles, ModelSlot, shared_queue::QueueItem};
 use crate::app::shell::{ShellEvent, spawn_shell};
-use crate::app::{App, Msg, QueuedMessage, SubmitOutcome};
+use crate::app::{App, Msg, Notification, QueuedMessage, SubmitOutcome, turn_response};
 use crate::color_compat;
 use crate::components::input::Submission;
 use crate::components::usage_modal::UsageFetchState;
@@ -91,6 +93,104 @@ enum SessionStatus {
     Idle,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum PendingCompletion {
+    WaitingForQueueDrain(Notification),
+    Due(Notification),
+}
+
+#[derive(Default)]
+struct RunNotificationState {
+    response_candidate: Option<String>,
+    pending_completion: Option<PendingCompletion>,
+    last_attention: Option<Notification>,
+    exit_pending_drain: bool,
+}
+
+impl RunNotificationState {
+    fn on_run_start(&mut self) {
+        *self = Self::default();
+    }
+
+    fn on_cancel(&mut self) {
+        self.on_run_start();
+    }
+
+    fn on_queue_item_consumed(&mut self) {
+        self.response_candidate = None;
+        self.pending_completion = None;
+    }
+
+    fn on_turn_complete(&mut self, message: &Message) {
+        self.response_candidate = turn_response(message);
+    }
+
+    fn on_done(&mut self, event: &AgentEvent, exit_on_done: bool) {
+        let notification = match event {
+            AgentEvent::Done { .. } => Notification::TurnComplete {
+                response: self.response_candidate.take(),
+            },
+            AgentEvent::Error { .. } => {
+                self.response_candidate = None;
+                Notification::error_completion()
+            }
+            _ => return,
+        };
+        self.pending_completion = Some(PendingCompletion::WaitingForQueueDrain(notification));
+        self.exit_pending_drain = exit_on_done;
+    }
+
+    fn on_drain(&mut self) {
+        match self.pending_completion.take() {
+            Some(PendingCompletion::WaitingForQueueDrain(notification)) => {
+                self.pending_completion = Some(PendingCompletion::Due(notification));
+                self.exit_pending_drain = false;
+            }
+            pending => self.pending_completion = pending,
+        }
+    }
+
+    fn on_manual_exit(&mut self) {
+        self.exit_pending_drain = false;
+    }
+
+    fn reconcile(
+        &mut self,
+        attention: Option<Notification>,
+        status: SessionStatus,
+        queue_empty: bool,
+        terminal_focused: bool,
+    ) -> Option<Notification> {
+        let prompt = (attention != self.last_attention)
+            .then(|| attention.clone())
+            .flatten();
+        self.last_attention = attention.clone();
+
+        let completion = match self.pending_completion.take() {
+            Some(PendingCompletion::WaitingForQueueDrain(notification)) => {
+                self.pending_completion =
+                    Some(PendingCompletion::WaitingForQueueDrain(notification));
+                None
+            }
+            Some(PendingCompletion::Due(notification))
+                if attention.is_none() && status == SessionStatus::Idle && queue_empty =>
+            {
+                Some(notification)
+            }
+            _ => None,
+        };
+        (!terminal_focused).then(|| prompt.or(completion)).flatten()
+    }
+
+    fn waiting_for_exit_drain(&self) -> bool {
+        self.exit_pending_drain
+    }
+
+    fn agent_stopped_before_drain(&self, agent_finished: bool, agent_rx_empty: bool) -> bool {
+        self.exit_pending_drain && agent_finished && agent_rx_empty
+    }
+}
+
 impl SessionStatus {
     fn of(app: &App) -> Self {
         if app.awaiting_input() {
@@ -116,6 +216,65 @@ fn prepend_preamble(preamble: &mut Vec<Message>, mut leading: Vec<Message>) {
     *preamble = leading;
 }
 
+fn is_current_top_level(current_run_id: u64, envelope: &Envelope) -> bool {
+    envelope.run_id == current_run_id && envelope.subagent.is_none()
+}
+
+fn select_notification(
+    selected: Option<Notification>,
+    candidate: Option<Notification>,
+) -> Option<Notification> {
+    match (selected, candidate) {
+        (Some(current), Some(candidate)) if candidate.priority() > current.priority() => {
+            Some(candidate)
+        }
+        (selected @ Some(_), _) => selected,
+        (None, candidate) => candidate,
+    }
+}
+
+fn select_exit_runtime<'a>(
+    runtimes: impl IntoIterator<Item = (usize, &'a ExitRequest, &'a RunNotificationState)>,
+) -> Option<usize> {
+    runtimes.into_iter().find_map(|(index, request, state)| {
+        (*request != ExitRequest::None && !state.waiting_for_exit_drain()).then_some(index)
+    })
+}
+
+fn queue_drain_matches(current_run_id: u64, envelope: &Envelope) -> bool {
+    envelope.run_id == current_run_id
+        && envelope.subagent.is_none()
+        && matches!(envelope.event, AgentEvent::QueueDrained)
+}
+
+#[cfg(not(windows))]
+fn terminal_focus_event(event: &Event) -> Option<bool> {
+    match event {
+        Event::FocusGained => Some(true),
+        Event::FocusLost => Some(false),
+        _ => None,
+    }
+}
+
+#[cfg(windows)]
+fn terminal_focus_event(_event: &Event) -> Option<bool> {
+    None
+}
+
+#[cfg(not(windows))]
+fn terminal_input_proves_focus(event: &Event) -> bool {
+    match event {
+        Event::Key(key) => key.kind == KeyEventKind::Press,
+        Event::Paste(_) | Event::Mouse(_) => true,
+        _ => false,
+    }
+}
+
+#[cfg(windows)]
+fn terminal_input_proves_focus(_event: &Event) -> bool {
+    false
+}
+
 fn parse_session_id(id: &str) -> Result<MakiId, String> {
     id.parse().map_err(|e: MakiIdParseError| e.to_string())
 }
@@ -126,6 +285,7 @@ struct SessionRuntime {
     shell_tx: flume::Sender<ShellEvent>,
     shell_rx: flume::Receiver<ShellEvent>,
     last_status: SessionStatus,
+    notifications: RunNotificationState,
 }
 
 impl SessionRuntime {
@@ -214,6 +374,7 @@ impl SpawnCtx {
             shell_tx,
             shell_rx,
             last_status: SessionStatus::Idle,
+            notifications: RunNotificationState::default(),
         }
     }
 }
@@ -223,6 +384,8 @@ pub(crate) struct EventLoop<'t> {
     sessions: Vec<SessionRuntime>,
     focused: usize,
     last_focused: Option<MakiId>,
+    terminal_focused: bool,
+    notifier: Option<terminal::TerminalNotifier>,
     ctx: SpawnCtx,
     input: InputReader,
     warn_rx: flume::Receiver<String>,
@@ -380,6 +543,7 @@ impl<'t> EventLoop<'t> {
         let bg = spawn_model_fetch(&model_slot, timeouts, Arc::clone(&model_policy));
         let storage_writer = Arc::new(StorageWriter::new(storage.clone(), bg.warn_tx.clone()));
 
+        let notifier = terminal::TerminalNotifier::new(ui_config.notifications);
         let ctx = SpawnCtx {
             storage,
             config,
@@ -426,6 +590,8 @@ impl<'t> EventLoop<'t> {
             sessions: runtimes,
             focused,
             last_focused: None,
+            terminal_focused: false,
+            notifier,
             ctx,
             input: InputReader::spawn(),
             warn_rx: bg.warn_rx,
@@ -468,14 +634,13 @@ impl<'t> EventLoop<'t> {
                 }
             }
 
-            if let Some(i) = self
-                .sessions
-                .iter()
-                .position(|rt| rt.app.exit_request != ExitRequest::None)
+            if let Some(i) =
+                select_exit_runtime(self.sessions.iter().enumerate().map(|(index, runtime)| {
+                    (index, &runtime.app.exit_request, &runtime.notifications)
+                }))
             {
-                // A backgrounded session can finish an `exit_on_done` turn;
-                // focus it so shutdown reports its exit code and id.
                 self.focused = i;
+                self.emit_notifications();
                 break Ok(());
             }
 
@@ -567,6 +732,35 @@ impl<'t> EventLoop<'t> {
     }
 
     fn handle_agent(&mut self, idx: usize, envelope: Box<maki_agent::Envelope>) {
+        let notifications_enabled = self.notifier.is_some();
+        let current = is_current_top_level(self.sessions[idx].app.run_id, &envelope);
+        if matches!(&envelope.event, AgentEvent::QueueDrained) {
+            if queue_drain_matches(self.sessions[idx].app.run_id, &envelope) {
+                self.sessions[idx].notifications.on_drain();
+            }
+            return;
+        }
+
+        if current && matches!(&envelope.event, AgentEvent::QueueItemConsumed { .. }) {
+            let runtime = &mut self.sessions[idx];
+            runtime.notifications.on_queue_item_consumed();
+            if runtime.app.exit_on_done {
+                runtime.app.clear_exit_request();
+            }
+        } else if notifications_enabled
+            && current
+            && let AgentEvent::TurnComplete(turn) = &envelope.event
+        {
+            self.sessions[idx]
+                .notifications
+                .on_turn_complete(&turn.message);
+        }
+        if current {
+            let exit_on_done = self.sessions[idx].app.exit_on_done;
+            self.sessions[idx]
+                .notifications
+                .on_done(&envelope.event, exit_on_done);
+        }
         let actions = self.sessions[idx].app.update(Msg::Agent(envelope));
         self.dispatch(idx, actions);
     }
@@ -599,8 +793,21 @@ impl<'t> EventLoop<'t> {
         // These two only fire Lua autocmds. Anything a handler does comes back
         // as a `UiAction` on the next wake, which repaints then.
         self.emit_focus_change();
+        dirty |= self.start_mailbox_runs();
         self.emit_status_changes();
-        Ok(dirty | self.start_mailbox_runs())
+        self.emit_notifications();
+        if let Some(runtime) = self.sessions.iter().find(|runtime| {
+            runtime.notifications.agent_stopped_before_drain(
+                runtime.handles.is_finished(),
+                runtime.handles.agent_rx.is_empty(),
+            )
+        }) {
+            return Err(eyre!(
+                "agent for session {} stopped before queue drain",
+                runtime.id()
+            ));
+        }
+        Ok(dirty)
     }
 
     fn handle_ui_action(&mut self, action: UiAction) {
@@ -665,6 +872,7 @@ impl<'t> EventLoop<'t> {
             let _pause = self.input.pause();
             terminal::open_in_editor(path, self.terminal)
         };
+        self.terminal_focused = false;
         match result {
             Ok(code) => code,
             Err(e) => {
@@ -691,6 +899,34 @@ impl<'t> EventLoop<'t> {
                     "focused": i == self.focused,
                 }),
             );
+        }
+    }
+
+    fn emit_notifications(&mut self) {
+        if self.notifier.is_none() {
+            return;
+        }
+        let mut selected = None;
+        for runtime in &mut self.sessions {
+            let candidate = runtime.notifications.reconcile(
+                runtime.app.attention(),
+                runtime.last_status,
+                matches!(runtime.handles.queue.len(), 0),
+                self.terminal_focused,
+            );
+            selected = select_notification(selected, candidate);
+        }
+
+        let Some(notification) = selected else {
+            return;
+        };
+        let Some(notifier) = self.notifier.as_ref() else {
+            return;
+        };
+        let resolved = notifier.notifier();
+        if let Err(error) = notifier.notify(&notification.message()) {
+            self.notifier = None;
+            warn!(?resolved, %error, "terminal notifications disabled after write failure");
         }
     }
 
@@ -923,6 +1159,19 @@ impl<'t> EventLoop<'t> {
     }
 
     fn translate(&mut self, raw: Event) -> (Option<Msg>, Option<Event>) {
+        let supports_focus_reporting = self
+            .notifier
+            .as_ref()
+            .is_some_and(terminal::TerminalNotifier::supports_focus_reporting);
+        if let Some(focused) = terminal_focus_event(&raw) {
+            if supports_focus_reporting {
+                self.terminal_focused = focused;
+            }
+            return (None, None);
+        }
+        if supports_focus_reporting && terminal_input_proves_focus(&raw) {
+            self.terminal_focused = true;
+        }
         match raw {
             Event::Key(key) if key.kind == KeyEventKind::Press => (Some(Msg::Key(key)), None),
             Event::Key(_) => (None, None),
@@ -1004,6 +1253,8 @@ impl<'t> EventLoop<'t> {
 
     fn respawn_agent(&mut self, idx: usize, history: Vec<Message>) {
         let rt = &mut self.sessions[idx];
+        rt.notifications.on_run_start();
+        rt.app.clear_exit_request();
         let lua_handle = rt.app.lua_event_handle.clone();
         let permissions = Arc::clone(&rt.app.permissions);
         rt.handles.respawn(
@@ -1021,6 +1272,11 @@ impl<'t> EventLoop<'t> {
         match action {
             Action::SendMessage(input) => {
                 let rt = &mut self.sessions[idx];
+                let cancel_pending_exit = rt.notifications.waiting_for_exit_drain();
+                rt.notifications.on_run_start();
+                if cancel_pending_exit {
+                    rt.app.clear_exit_request();
+                }
                 let mut input = *input;
                 prepend_preamble(&mut input.preamble, rt.app.shell.drain_results());
                 let run_id = rt.app.run_id;
@@ -1033,7 +1289,9 @@ impl<'t> EventLoop<'t> {
                 });
             }
             Action::CancelAgent { run_id } => {
-                let _ = self.sessions[idx]
+                let runtime = &mut self.sessions[idx];
+                runtime.notifications.on_cancel();
+                let _ = runtime
                     .handles
                     .cmd_tx
                     .try_send(AgentCommand::Cancel { run_id });
@@ -1072,6 +1330,8 @@ impl<'t> EventLoop<'t> {
             }
             Action::Compact => {
                 let rt = &mut self.sessions[idx];
+                rt.notifications.on_run_start();
+                rt.app.clear_exit_request();
                 let run_id = rt.app.run_id;
                 rt.handles.queue.push(QueueItem::Compact { run_id });
             }
@@ -1107,6 +1367,7 @@ impl<'t> EventLoop<'t> {
                     let _pause = self.input.pause();
                     terminal::edit_temp_content(&current_text, self.terminal)
                 };
+                self.terminal_focused = false;
                 match result {
                     Ok(edited) => self.sessions[idx].app.input_box.set_input(edited),
                     Err(e) => self.sessions[idx].app.flash(e),
@@ -1123,9 +1384,11 @@ impl<'t> EventLoop<'t> {
             Action::Suspend => {
                 let _pause = self.input.pause();
                 terminal::suspend(self.terminal);
+                self.terminal_focused = false;
             }
             Action::RefreshModels => self.refresh_models(),
             Action::RefreshUsage => self.refresh_usage(),
+            Action::ManualExit => self.sessions[idx].notifications.on_manual_exit(),
         }
     }
 
@@ -1273,10 +1536,242 @@ fn scroll_delta(kind: MouseEventKind, lines: u32) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use maki_agent::{DoneReason, SubagentInfo};
+    use maki_providers::TokenUsage;
 
     const OBSERVATION: &str = "failed";
     const SHELL_RESULT: &str = "command finished";
 
+    fn envelope(event: AgentEvent, run_id: u64, subagent: bool) -> Envelope {
+        Envelope {
+            event,
+            subagent: subagent.then(|| SubagentInfo {
+                parent_tool_use_id: "tool".into(),
+                name: "agent".into(),
+                prompt: None,
+                model: None,
+                answer_tx: None,
+            }),
+            run_id,
+        }
+    }
+
+    fn done(run_id: u64, subagent: bool) -> Envelope {
+        envelope(
+            AgentEvent::Done {
+                usage: TokenUsage::default(),
+                num_turns: 1,
+                reason: DoneReason::EndTurn,
+            },
+            run_id,
+            subagent,
+        )
+    }
+
+    #[test]
+    fn only_current_top_level_events_are_eligible() {
+        assert!(is_current_top_level(4, &done(4, false)));
+        assert!(!is_current_top_level(5, &done(4, false)));
+        assert!(!is_current_top_level(4, &done(4, true)));
+    }
+
+    #[test]
+    fn completion_waits_for_queue_drain() {
+        let mut state = RunNotificationState {
+            response_candidate: Some("done".into()),
+            ..RunNotificationState::default()
+        };
+
+        state.on_done(&done(4, false).event, true);
+        assert_eq!(
+            state.pending_completion,
+            Some(PendingCompletion::WaitingForQueueDrain(
+                Notification::TurnComplete {
+                    response: Some("done".into())
+                }
+            ))
+        );
+        assert!(state.waiting_for_exit_drain());
+
+        state.on_drain();
+
+        assert_eq!(
+            state.pending_completion,
+            Some(PendingCompletion::Due(Notification::TurnComplete {
+                response: Some("done".into())
+            }))
+        );
+        assert!(!state.waiting_for_exit_drain());
+
+        state.on_drain();
+
+        assert_eq!(
+            state.pending_completion,
+            Some(PendingCompletion::Due(Notification::TurnComplete {
+                response: Some("done".into())
+            }))
+        );
+    }
+
+    #[test]
+    fn focused_notification_is_consumed() {
+        let notification = Notification::TurnComplete { response: None };
+        let mut state = RunNotificationState {
+            pending_completion: Some(PendingCompletion::Due(notification)),
+            ..RunNotificationState::default()
+        };
+
+        let selected = state.reconcile(None, SessionStatus::Idle, true, true);
+
+        assert_eq!(selected, None);
+        assert_eq!(state.pending_completion, None);
+    }
+
+    #[test]
+    fn completion_notification_is_one_shot() {
+        let notification = Notification::TurnComplete { response: None };
+        let mut state = RunNotificationState {
+            pending_completion: Some(PendingCompletion::Due(notification.clone())),
+            ..RunNotificationState::default()
+        };
+
+        assert_eq!(
+            state.reconcile(None, SessionStatus::Idle, true, false),
+            Some(notification)
+        );
+        assert_eq!(
+            state.reconcile(None, SessionStatus::Idle, true, false),
+            None
+        );
+    }
+
+    #[test]
+    fn prompt_wins_over_completion_and_is_not_repeated_unchanged() {
+        let prompt = Notification::QuestionRequested;
+        let mut state = RunNotificationState {
+            pending_completion: Some(PendingCompletion::Due(Notification::TurnComplete {
+                response: None,
+            })),
+            ..RunNotificationState::default()
+        };
+
+        assert_eq!(
+            state.reconcile(Some(prompt.clone()), SessionStatus::Idle, true, false),
+            Some(prompt.clone())
+        );
+        assert_eq!(state.pending_completion, None);
+        assert_eq!(
+            state.reconcile(Some(prompt), SessionStatus::NeedsInput, true, false),
+            None
+        );
+    }
+
+    #[test]
+    fn notification_selection_prefers_priority_then_session_order() {
+        let completion = Notification::TurnComplete { response: None };
+        let first_prompt = Notification::QuestionRequested;
+        let second_prompt = Notification::AuthenticationRequired;
+
+        let selected = select_notification(None, Some(completion));
+        let selected = select_notification(selected, Some(first_prompt.clone()));
+        let selected = select_notification(selected, Some(second_prompt));
+
+        assert_eq!(selected, Some(first_prompt));
+    }
+
+    #[test]
+    fn nonempty_queue_suppresses_completion() {
+        let mut state = RunNotificationState {
+            pending_completion: Some(PendingCompletion::Due(Notification::TurnComplete {
+                response: None,
+            })),
+            ..RunNotificationState::default()
+        };
+
+        assert_eq!(
+            state.reconcile(None, SessionStatus::Idle, false, false),
+            None
+        );
+        assert_eq!(state.pending_completion, None);
+    }
+
+    #[test]
+    fn waiting_completion_is_not_consumed() {
+        let notification = Notification::TurnComplete { response: None };
+        let mut state = RunNotificationState {
+            pending_completion: Some(PendingCompletion::WaitingForQueueDrain(
+                notification.clone(),
+            )),
+            ..RunNotificationState::default()
+        };
+
+        assert_eq!(
+            state.reconcile(None, SessionStatus::Idle, true, false),
+            None
+        );
+        assert_eq!(
+            state.pending_completion,
+            Some(PendingCompletion::WaitingForQueueDrain(notification))
+        );
+    }
+
+    #[test]
+    fn stale_queue_drain_does_not_match_current_run() {
+        let current = envelope(AgentEvent::QueueDrained, 8, false);
+        let stale = envelope(AgentEvent::QueueDrained, 7, false);
+        let subagent = envelope(AgentEvent::QueueDrained, 8, true);
+
+        assert!(queue_drain_matches(8, &current));
+        assert!(!queue_drain_matches(8, &stale));
+        assert!(!queue_drain_matches(8, &subagent));
+    }
+
+    #[test]
+    fn exit_scan_skips_runtime_waiting_for_queue_drain() {
+        let success = ExitRequest::Success;
+        let none = ExitRequest::None;
+        let mut waiting = RunNotificationState::default();
+        waiting.on_done(&done(4, false).event, true);
+        let ready = RunNotificationState::default();
+
+        assert_eq!(
+            select_exit_runtime([(0, &success, &waiting), (1, &none, &ready)]),
+            None
+        );
+
+        waiting.on_drain();
+
+        assert_eq!(
+            select_exit_runtime([(0, &success, &waiting), (1, &none, &ready)]),
+            Some(0)
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn focus_events_map_to_terminal_focus_state() {
+        assert_eq!(terminal_focus_event(&Event::FocusGained), Some(true));
+        assert_eq!(terminal_focus_event(&Event::FocusLost), Some(false));
+        assert_eq!(terminal_focus_event(&Event::Resize(80, 24)), None);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn interactive_input_proves_terminal_focus() {
+        let release = crossterm::event::KeyEvent {
+            code: crossterm::event::KeyCode::Enter,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+            kind: KeyEventKind::Release,
+            state: crossterm::event::KeyEventState::NONE,
+        };
+
+        assert!(terminal_input_proves_focus(&Event::Key(
+            crate::components::key(crossterm::event::KeyCode::Enter)
+        )));
+        assert!(terminal_input_proves_focus(&Event::Paste("text".into())));
+        assert!(!terminal_input_proves_focus(&Event::Key(release)));
+        assert!(!terminal_input_proves_focus(&Event::Resize(80, 24)));
+    }
     #[test]
     fn shell_results_do_not_replace_existing_preamble() {
         let mut preamble = vec![Message::observation(OBSERVATION.into())];

--- a/maki-ui/src/terminal.rs
+++ b/maki-ui/src/terminal.rs
@@ -1,6 +1,7 @@
 use shell_words::split;
 use std::io::{Write, stdout};
 use std::path::Path;
+use std::process::Command as ProcessCommand;
 use std::time::Instant;
 
 use color_eyre::Result;
@@ -11,15 +12,205 @@ use crossterm::event::{
     DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
     KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
+#[cfg(not(windows))]
+use crossterm::event::{DisableFocusChange, EnableFocusChange};
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
+use maki_config::NotificationMethod;
+
+const FALLBACK_NOTIFICATION_MESSAGE: &str = "Maki needs attention";
+const BELL_SEQUENCE: &str = "\u{7}";
 
 pub(crate) struct TerminalGuard;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TerminalMux {
     Zellij,
     Tmux,
     Screen,
     None,
+}
+
+#[derive(Default)]
+struct TerminalEnvironment<'a> {
+    term_program: Option<&'a str>,
+    wezterm: bool,
+    iterm: bool,
+    kitty: bool,
+    term: Option<&'a str>,
+}
+
+#[derive(Default)]
+struct TmuxClient<'a> {
+    term_type: Option<&'a str>,
+    term_name: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResolvedNotifier {
+    Osc9,
+    Bell,
+}
+
+pub(crate) struct TerminalNotifier {
+    notifier: ResolvedNotifier,
+    mux: TerminalMux,
+}
+
+impl TerminalNotifier {
+    pub(crate) fn new(configured: NotificationMethod) -> Option<Self> {
+        let notifier = resolve_notifier(configured, || {
+            let term_program = std::env::var("TERM_PROGRAM").ok();
+            let term = std::env::var("TERM").ok();
+            let env = TerminalEnvironment {
+                term_program: term_program.as_deref(),
+                wezterm: std::env::var_os("WEZTERM_VERSION").is_some(),
+                iterm: std::env::var_os("ITERM_SESSION_ID").is_some()
+                    || std::env::var_os("ITERM_PROFILE").is_some()
+                    || std::env::var_os("ITERM_PROFILE_NAME").is_some(),
+                kitty: std::env::var_os("KITTY_WINDOW_ID").is_some(),
+                term: term.as_deref(),
+            };
+            let tmux_values = env
+                .term_program
+                .filter(|value| normalize_terminal_id(value) == "tmux")
+                .and_then(|_| query_tmux_client());
+            let tmux = tmux_values
+                .as_ref()
+                .map(|(term_type, term_name)| TmuxClient {
+                    term_type: non_empty(term_type),
+                    term_name: non_empty(term_name),
+                });
+            auto_supports_osc9(&env, tmux.as_ref())
+        })?;
+        Some(Self {
+            notifier,
+            mux: TerminalMux::detect(),
+        })
+    }
+
+    pub(crate) fn notifier(&self) -> ResolvedNotifier {
+        self.notifier
+    }
+
+    pub(crate) fn supports_focus_reporting(&self) -> bool {
+        self.mux != TerminalMux::Screen
+    }
+
+    pub(crate) fn notify(&self, message: &str) -> std::io::Result<()> {
+        let sequence = notification_sequence(self.notifier, self.mux, message);
+        let mut stdout = stdout().lock();
+        stdout
+            .write_all(sequence.as_bytes())
+            .and_then(|()| stdout.flush())
+    }
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    let value = value.trim();
+    (!value.is_empty()).then_some(value)
+}
+
+fn normalize_terminal_id(value: &str) -> String {
+    value
+        .trim()
+        .chars()
+        .filter(|c| !matches!(c, ' ' | '-' | '_' | '.'))
+        .collect::<String>()
+        .to_ascii_lowercase()
+}
+
+fn supports_osc9(value: &str) -> bool {
+    matches!(
+        normalize_terminal_id(value).as_str(),
+        "ghostty"
+            | "iterm"
+            | "iterm2"
+            | "itermapp"
+            | "kitty"
+            | "warp"
+            | "warpterminal"
+            | "wezterm"
+            | "xtermghostty"
+            | "xtermkitty"
+    )
+}
+
+fn resolve_notifier(
+    configured: NotificationMethod,
+    auto_supports_osc9: impl FnOnce() -> bool,
+) -> Option<ResolvedNotifier> {
+    match configured {
+        NotificationMethod::Off => None,
+        NotificationMethod::Osc9 => Some(ResolvedNotifier::Osc9),
+        NotificationMethod::Bell => Some(ResolvedNotifier::Bell),
+        NotificationMethod::Auto => Some(if auto_supports_osc9() {
+            ResolvedNotifier::Osc9
+        } else {
+            ResolvedNotifier::Bell
+        }),
+    }
+}
+
+fn auto_supports_osc9(env: &TerminalEnvironment<'_>, tmux: Option<&TmuxClient<'_>>) -> bool {
+    if let Some(term_program) = env.term_program.filter(|value| !value.trim().is_empty()) {
+        if normalize_terminal_id(term_program) == "tmux" {
+            return tmux.is_some_and(|client| {
+                client
+                    .term_type
+                    .and_then(|value| value.split_whitespace().next())
+                    .is_some_and(supports_osc9)
+                    || client.term_name.is_some_and(supports_osc9)
+            });
+        }
+        return supports_osc9(term_program);
+    }
+    env.wezterm || env.iterm || env.kitty || env.term.is_some_and(supports_osc9)
+}
+
+fn query_tmux_client() -> Option<(String, String)> {
+    let output = ProcessCommand::new("tmux")
+        .args([
+            "display-message",
+            "-p",
+            "#{client_termtype}\t#{client_termname}",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let output = String::from_utf8(output.stdout).ok()?;
+    let (term_type, term_name) = output.trim_end().split_once('\t')?;
+    Some((term_type.to_string(), term_name.to_string()))
+}
+
+fn sanitize_notification_message(message: &str) -> String {
+    let sanitized = message
+        .chars()
+        .map(|character| {
+            if character.is_control() || character == '\u{7f}' {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>();
+    let normalized = sanitized.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.is_empty() {
+        FALLBACK_NOTIFICATION_MESSAGE.to_string()
+    } else {
+        normalized
+    }
+}
+
+fn notification_sequence(notifier: ResolvedNotifier, mux: TerminalMux, message: &str) -> String {
+    match notifier {
+        ResolvedNotifier::Osc9 => {
+            let message = sanitize_notification_message(message);
+            mux.wrap_for_mux(format!("\u{1b}]9;{message}\u{7}"))
+        }
+        ResolvedNotifier::Bell => BELL_SEQUENCE.to_string(),
+    }
 }
 
 impl TerminalMux {
@@ -59,6 +250,7 @@ impl TerminalGuard {
         let terminal = ratatui::init();
         stdout().execute(EnableBracketedPaste)?;
         stdout().execute(EnableMouseCapture)?;
+        enable_focus_change();
         push_keyboard_enhancement();
         Ok((Self, terminal))
     }
@@ -95,6 +287,7 @@ fn teardown() {
 fn pop_terminal_modes() {
     stdout().execute(crossterm::cursor::Show).ok();
     stdout().execute(PopKeyboardEnhancementFlags).ok();
+    disable_focus_change();
     stdout().execute(DisableMouseCapture).ok();
     stdout().execute(DisableBracketedPaste).ok();
 }
@@ -103,10 +296,27 @@ fn resume(terminal: &mut ratatui::DefaultTerminal) {
     stdout().execute(EnterAlternateScreen).ok();
     stdout().execute(EnableBracketedPaste).ok();
     stdout().execute(EnableMouseCapture).ok();
+    enable_focus_change();
     terminal::enable_raw_mode().ok();
     push_keyboard_enhancement();
     let _ = terminal.clear();
 }
+
+#[cfg(not(windows))]
+fn enable_focus_change() {
+    stdout().execute(EnableFocusChange).ok();
+}
+
+#[cfg(windows)]
+fn enable_focus_change() {}
+
+#[cfg(not(windows))]
+fn disable_focus_change() {
+    stdout().execute(DisableFocusChange).ok();
+}
+
+#[cfg(windows)]
+fn disable_focus_change() {}
 
 fn push_keyboard_enhancement() {
     if let Err(e) = stdout().execute(PushKeyboardEnhancementFlags(
@@ -184,6 +394,13 @@ pub(crate) fn copy_to_clipboard(text: &str) -> Result<(), String> {
 mod tests {
     use super::*;
 
+    fn env<'a>(term_program: Option<&'a str>) -> TerminalEnvironment<'a> {
+        TerminalEnvironment {
+            term_program,
+            ..TerminalEnvironment::default()
+        }
+    }
+
     // Simulates DCS-passthrough parsing: `ESC ESC` becomes one ESC,
     // `ESC \` ends the DCS. Panics on bad input so tests fail loudly.
     fn parse_dcs_passthrough(wrapped: &str, prefix: &str) -> String {
@@ -224,6 +441,156 @@ mod tests {
     // Uses the ST terminator that crossterm emits, which puts ESC bytes
     // at the start and in the middle of the payload.
     const OSC52_WITH_ST: &str = "\u{1b}]52;c;SGVsbG8=\u{1b}\\";
+
+    #[test]
+    fn configured_notification_method_resolves_once() {
+        assert_eq!(
+            resolve_notifier(NotificationMethod::Osc9, || panic!("auto detection ran")),
+            Some(ResolvedNotifier::Osc9)
+        );
+        assert_eq!(
+            resolve_notifier(NotificationMethod::Bell, || panic!("auto detection ran")),
+            Some(ResolvedNotifier::Bell)
+        );
+        assert_eq!(
+            resolve_notifier(NotificationMethod::Off, || panic!("auto detection ran")),
+            None
+        );
+        assert_eq!(
+            resolve_notifier(NotificationMethod::Auto, || true),
+            Some(ResolvedNotifier::Osc9)
+        );
+        assert_eq!(
+            resolve_notifier(NotificationMethod::Auto, || false),
+            Some(ResolvedNotifier::Bell)
+        );
+    }
+
+    #[test]
+    fn screen_is_the_only_mux_without_focus_reporting() {
+        let notifier = |mux| TerminalNotifier {
+            notifier: ResolvedNotifier::Osc9,
+            mux,
+        };
+
+        assert!(!notifier(TerminalMux::Screen).supports_focus_reporting());
+        for mux in [TerminalMux::None, TerminalMux::Tmux, TerminalMux::Zellij] {
+            assert!(notifier(mux).supports_focus_reporting());
+        }
+    }
+
+    #[test]
+    fn auto_supports_codex_terminal_programs() {
+        for value in ["Ghostty", "iTerm.app", "kitty", "WarpTerminal", "WezTerm"] {
+            assert!(
+                auto_supports_osc9(&env(Some(value)), None),
+                "terminal: {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn term_program_precedes_terminal_specific_variables() {
+        let terminal = TerminalEnvironment {
+            term_program: Some("Alacritty"),
+            wezterm: true,
+            ..TerminalEnvironment::default()
+        };
+        assert!(!auto_supports_osc9(&terminal, None));
+    }
+
+    #[test]
+    fn auto_uses_specific_variables_and_term_fallbacks() {
+        for terminal in [
+            TerminalEnvironment {
+                wezterm: true,
+                ..TerminalEnvironment::default()
+            },
+            TerminalEnvironment {
+                iterm: true,
+                ..TerminalEnvironment::default()
+            },
+            TerminalEnvironment {
+                kitty: true,
+                ..TerminalEnvironment::default()
+            },
+            TerminalEnvironment {
+                term: Some("xterm-kitty"),
+                ..TerminalEnvironment::default()
+            },
+            TerminalEnvironment {
+                term: Some("xterm-ghostty"),
+                ..TerminalEnvironment::default()
+            },
+        ] {
+            assert!(auto_supports_osc9(&terminal, None));
+        }
+        let terminal = TerminalEnvironment {
+            term: Some("xterm-256color"),
+            ..TerminalEnvironment::default()
+        };
+        assert!(!auto_supports_osc9(&terminal, None));
+    }
+
+    #[test]
+    fn auto_uses_tmux_client_type_and_falls_back_to_bell() {
+        let terminal = env(Some("tmux"));
+        let ghostty = TmuxClient {
+            term_type: Some("ghostty 1.2.3"),
+            term_name: Some("xterm-256color"),
+        };
+        assert!(auto_supports_osc9(&terminal, Some(&ghostty)));
+        let ghostty_name = TmuxClient {
+            term_type: Some("xterm-256color"),
+            term_name: Some("xterm-ghostty"),
+        };
+        assert!(auto_supports_osc9(&terminal, Some(&ghostty_name)));
+        assert!(!auto_supports_osc9(&terminal, None));
+    }
+
+    #[test]
+    fn notification_sequences_encode_message_and_keep_bell_raw() {
+        const MESSAGE: &str = "Task complete";
+        const OSC9_SEQUENCE: &str = "\u{1b}]9;Task complete\u{7}";
+
+        assert_eq!(
+            notification_sequence(ResolvedNotifier::Osc9, TerminalMux::None, MESSAGE),
+            OSC9_SEQUENCE
+        );
+        assert_eq!(
+            notification_sequence(ResolvedNotifier::Bell, TerminalMux::Tmux, MESSAGE),
+            BELL_SEQUENCE
+        );
+    }
+
+    #[test]
+    fn notification_message_sanitization_removes_terminal_controls_and_normalizes_whitespace() {
+        const MESSAGE: &str = "\0Task\t\u{7f}complete\u{85}\nnow\u{2003}";
+        const EXPECTED_MESSAGE: &str = "Task complete now";
+
+        assert_eq!(sanitize_notification_message(MESSAGE), EXPECTED_MESSAGE);
+    }
+
+    #[test]
+    fn empty_sanitized_notification_message_uses_fallback() {
+        const MESSAGE: &str = "\0\t\u{7f}\u{85}\n\u{2003}";
+
+        assert_eq!(
+            sanitize_notification_message(MESSAGE),
+            FALLBACK_NOTIFICATION_MESSAGE
+        );
+    }
+
+    #[test]
+    fn osc9_roundtrips_mux_passthrough() {
+        const MESSAGE: &str = "Task complete";
+        const OSC9_SEQUENCE: &str = "\u{1b}]9;Task complete\u{7}";
+
+        let tmux = notification_sequence(ResolvedNotifier::Osc9, TerminalMux::Tmux, MESSAGE);
+        let screen = notification_sequence(ResolvedNotifier::Osc9, TerminalMux::Screen, MESSAGE);
+        assert_eq!(parse_dcs_passthrough(&tmux, "\u{1b}Ptmux;"), OSC9_SEQUENCE);
+        assert_eq!(parse_dcs_passthrough(&screen, "\u{1b}P"), OSC9_SEQUENCE);
+    }
 
     #[test]
     fn none_is_identity() {

--- a/site/docs/content/_index.md
+++ b/site/docs/content/_index.md
@@ -52,6 +52,7 @@ The docs are sorted by what you came here to do:
     <a class="card" href="/docs/tools/"><span class="card-title">Tools</span><span class="card-desc">Every built-in tool and its parameters.</span></a>
     <a class="card" href="/docs/providers/"><span class="card-title">Providers</span><span class="card-desc">Model catalogs, env vars, providers.toml, model tiers.</span></a>
     <a class="card" href="/docs/permissions/"><span class="card-title">Permissions</span><span class="card-desc">What runs freely, what asks first, TOML rules.</span></a>
+    <a class="card" href="/docs/notifications/"><span class="card-title">Notifications</span><span class="card-desc">Know when a session finishes or needs your input.</span></a>
     <a class="card" href="/docs/mcp/"><span class="card-title">MCP</span><span class="card-desc">External tool servers over stdio or HTTP.</span></a>
     <a class="card" href="/docs/commands/"><span class="card-title">Commands</span><span class="card-desc">The / palette, sessions, toggles, custom commands.</span></a>
     <a class="card" href="/docs/keybindings/"><span class="card-title">Keybindings</span><span class="card-desc">Defaults, precedence, rebinding from Lua.</span></a>

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -71,6 +71,7 @@ All fields are optional. Typos in field names cause an error right away.
 |-------|------|---------|-----|-------------|
 | `splash_animation` | bool | `true` | - | Show splash animation on startup |
 | `scrollbar` | bool | `true` | - | Show vertical scrollbar in scrollable areas |
+| `notifications` | string | `auto` | - | Terminal notification method: auto, osc9, bell, or off |
 | `flash_duration_ms` | u64 | `1500` | - | Duration of flash messages (ms) |
 | `typewriter_ms_per_char` | u64 | `4` | - | Typewriter effect speed (ms/char) |
 | `mouse_scroll_lines` | u32 | `3` | 1 | Lines per mouse wheel scroll |

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -2608,7 +2608,8 @@ maki.session.live()
 ```
 
 Lists the sessions currently running in this UI. Status is "working",
-"needs_input", or "idle".
+"needs_input", or "idle". A mailbox follow-up stays "working" without an
+intermediate "idle" status.
 
 **Returns:** (`table|nil`, `string|nil`) Array of `{id, title, status, updated_at, focused}`, or nil and an error.
 

--- a/site/docs/content/notifications/_index.md
+++ b/site/docs/content/notifications/_index.md
@@ -1,0 +1,82 @@
++++
+title = "Notifications"
+weight = 9
+[extra]
+group = "Reference"
++++
+
+# Notifications
+
+Maki can tell you when a session finishes or needs your input. This is useful
+when you move to another terminal while Maki works.
+
+Notifications are enabled by default. Maki does not notify while it knows
+that its terminal has focus.
+
+Maki uses these messages:
+
+- `Agent turn complete` or a preview of the response, up to 200 characters.
+- `Permission requested: <tool>` for a permission prompt.
+- `Authentication required` when authentication needs attention.
+- `Question requested` for a question prompt.
+- `Plan ready` when a plan is ready.
+
+Response previews can appear in your operating system's notification history.
+Maki does not include tool arguments, permission scopes, question bodies, plan
+content, or error details. Use `bell` for a message-free alert, or use `off`
+to disable notifications if response text should not reach notification
+history.
+
+## Configuration
+
+Set `ui.notifications` in `~/.config/maki/init.lua`:
+
+```lua
+maki.setup({
+  ui = {
+    notifications = "auto",
+  },
+})
+```
+
+| Value | Behavior |
+| --- | --- |
+| `auto` | Use OSC 9 in a supported terminal. Use BEL otherwise. |
+| `osc9` | Always send an OSC 9 notification. |
+| `bell` | Always send the terminal bell. |
+| `off` | Do not send notifications. |
+
+`auto` supports Ghostty, iTerm2, Kitty, Warp, and WezTerm. An unknown terminal
+uses BEL. Your terminal settings decide whether BEL makes a sound or shows a
+visual alert.
+
+Maki also recognizes `xterm-ghostty` and `xterm-kitty` from `TERM`. This lets
+OSC 9 work when an SSH connection does not preserve `TERM_PROGRAM`.
+
+## tmux
+
+tmux needs both of these settings:
+
+```tmux
+set -g focus-events on
+set -g allow-passthrough all
+```
+
+Use `allow-passthrough all`, not `allow-passthrough on`. The `on` value permits
+passthrough only while the Maki pane is visible. tmux drops the notification
+after you change to another tmux window.
+
+Add the settings to `~/.tmux.conf`, then reload the file or restart tmux.
+
+## Other terminal multiplexers
+
+Maki wraps OSC 9 for GNU screen. GNU screen does not pass terminal focus
+events to Maki, so Maki does not suppress notifications there. A notification
+can appear while the GNU screen window has focus.
+
+Maki sends OSC 9 directly through Zellij.
+
+## Focus on Windows
+
+This terminal focus protocol is not available on Windows. Maki treats the
+terminal as unfocused so an explicit `bell` or `osc9` setting still works.

--- a/src/print.rs
+++ b/src/print.rs
@@ -237,6 +237,7 @@ pub fn run(
             | AgentEvent::ToolOutput { .. }
             | AgentEvent::ToolDone(_)
             | AgentEvent::QueueItemConsumed { .. }
+            | AgentEvent::QueueDrained
             | AgentEvent::AutoCompacting
             | AgentEvent::CompactionDone
             | AgentEvent::AuthRequired

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -960,6 +960,7 @@ impl EventPump {
             | AgentEvent::ToolOutput { .. }
             | AgentEvent::ToolDone(_)
             | AgentEvent::QueueItemConsumed { .. }
+            | AgentEvent::QueueDrained
             | AgentEvent::AutoCompacting
             | AgentEvent::CompactionDone
             | AgentEvent::AuthRequired


### PR DESCRIPTION
## Summary

- add `auto`, `osc9`, `bell`, and `off` notification settings
- emit OSC 9 in known terminals and BEL in unknown terminals
- suppress notifications while the terminal reports focus
- wait for an ordered per-session queue-drain event before completion alerts
- flush `--exit-on-done` alerts and keep busy sessions independent
- document SSH, Windows, GNU screen, Zellij, and the required tmux settings

This implements the second step for #709. Its prerequisite, #733, is merged.
The branch is rebased onto current `main` at `18465acf` (v0.4.8) and contains
one feature commit.

`auto` follows Codex and uses BEL when the terminal is unknown. Response
previews are bounded, normalized, and sanitized before they enter an OSC
sequence. Tool arguments, permission scopes, question bodies, plan content,
and error details are not included.

## Correctness boundaries

A completion waits for `QueueDrained`, which is published while the queue lock
still protects the empty check. Stale runs and subagents cannot complete the
current top-level run. New work, cancellation, session reset, and manual exit
clear the related state through `RunNotificationState` intent methods.

GNU screen does not report focus, so Maki skips focus suppression there.
Windows stays conservatively unfocused because this focus protocol is not
available there.

The rebased diff had three complete review passes. The first pass found and
fixed upstream `DoneReason` and repaint API adaptations. Later passes found no
P1 or P2 correctness issue and removed two weak test assertions.

## Checks

- `just ci`
  - Rust and Lua formatting
  - Clippy with warnings denied
  - Ruff and ty
  - 3,783 workspace tests
  - generated documentation check
  - unused dependency check
- `cargo test --workspace --doc`
- `git diff --check upstream/main..HEAD`

I did not perform manual Ghostty, tmux, GNU screen, or Windows UI tests during
this rebase.

## AI use

I used Codex to research terminal behavior, trace lifecycle and concurrency
paths, implement the feature, address review feedback, rebase the branch,
review the complete rebased diff, and run the checks. My direction was to use
the ordered queue-drain design, keep BEL as the unknown-terminal fallback,
follow Tony's feedback, and keep one clean feature commit.
