### PR TITLE
fix(providers): store and use discovered model metadata for custom providers

### DIFF
--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -12,7 +12,7 @@ use super::ResolvedAuth;
 use super::openai::responses;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use crate::manifest::ManifestRegistry;
-use crate::model::{FastPricing, Model, ModelPricing, ModelTier, ThinkingSupport};
+use crate::model::{FastPricing, Model, ModelInfo, ModelPricing, ModelTier, ThinkingSupport};
 use crate::provider::{BoxFuture, Provider, ProviderKind};
 use crate::providers::Timeouts;
 use crate::types::ThinkingConfig;
@@ -110,12 +110,20 @@ fn model_from_def(def: &ProviderDef, kind: ProviderKind, slug: &str, model_id: &
     let tier = declared
         .map(|m| ModelTier::from(m.tier))
         .unwrap_or(ModelTier::Medium);
+    // TODO: callers holding the registry read guard (e.g. Model::from_spec in
+    // lua agent / run paths) make this a recursive read lock; drop the guard in
+    // the callers as a follow-up, same issue as Model::from_base.
+    let reg = crate::model_registry::model_registry().read().unwrap();
+    let discovered = reg.discovered(slug, model_id);
     let max_output_tokens = declared
         .and_then(|m| m.max_output_tokens)
+        .or_else(|| discovered.and_then(|d| d.max_output_tokens))
         .or_else(|| kind.fallback_max_output());
     let context_window = declared
         .and_then(|m| m.context_window)
+        .or_else(|| discovered.and_then(|d| d.context_window))
         .unwrap_or_else(|| kind.fallback_context_window());
+    drop(reg);
     let supports_tool_examples_override = declared.and_then(|m| m.supports_tool_examples);
     let thinking_override = ThinkingSupport::from_flags(
         declared
@@ -225,7 +233,13 @@ pub fn discover_models(timeouts: Timeouts) -> Vec<String> {
                 let slug_c = slug.clone();
                 let result = smol::block_on(provider.list_models());
                 match result {
-                    Ok(models) => {
+                    Ok(mut models) => {
+                        overlay_declared_tiers(def, &mut models);
+                        let slug_arc: Arc<str> = Arc::from(slug_c.as_str());
+                        crate::model_registry::model_registry()
+                            .write()
+                            .unwrap()
+                            .set_known_models(&slug_arc, models.clone());
                         for m in models {
                             all_specs.push(format!("{slug_c}/{}", m.id));
                         }
@@ -241,6 +255,18 @@ pub fn discover_models(timeouts: Timeouts) -> Vec<String> {
         }
     }
     all_specs
+}
+
+/// Discovery via the openai compat layer never reports tiers, so stored models
+/// would only resolve positionally in `spec_for_tier`, shadowing tiers declared
+/// in `providers.toml`. Copying declared tiers onto the discovered entries lets
+/// the metadata candidate win and keeps declared config authoritative.
+fn overlay_declared_tiers(def: &ProviderDef, models: &mut [ModelInfo]) {
+    for model in models {
+        if let Some(declared) = def.models.iter().find(|m| m.id == model.id) {
+            model.tier = Some(ModelTier::from(declared.tier));
+        }
+    }
 }
 
 struct CustomOpenAiProvider {
@@ -324,5 +350,46 @@ mod tests {
         // Resolution owns the builtin slug regardless of the providers.toml entry.
         let model = Model::from_spec("opencode/shadow-model").unwrap();
         assert_eq!(model.provider.as_ref(), "opencode");
+    }
+
+    // The exact regression this fixes: discovery parsed context_window but
+    // never stored it, so custom models always got the protocol fallback.
+    #[test]
+    fn discovered_metadata_flows_into_custom_model_from_def() {
+        let slug = "custom-discovery-metadata-test";
+        let model_id = "vllm-model";
+        let expected_window: u32 = 131_072;
+        let expected_output: u32 = 8_192;
+
+        {
+            let mut info = ModelInfo::id_only(model_id.to_string());
+            info.context_window = Some(expected_window);
+            info.max_output_tokens = Some(expected_output);
+            crate::model_registry::model_registry()
+                .write()
+                .unwrap()
+                .set_known_models(&Arc::<str>::from(slug), vec![info]);
+        }
+
+        let def = openai_def(model_id);
+        let model = model_from_def(&def, ProviderKind::OpenAi, slug, model_id);
+        assert_eq!(model.context_window, expected_window);
+        assert_eq!(model.max_output_tokens, Some(expected_output));
+    }
+
+    #[test]
+    fn overlay_declared_tiers_sets_tier_for_declared_models_only() {
+        let def: ProviderDef = serde_json::from_str(
+            r#"{"protocol":"openai","models":[{"id":"declared","tier":"strong"}]}"#,
+        )
+        .unwrap();
+        let mut models = vec![
+            ModelInfo::id_only("declared".to_string()),
+            ModelInfo::id_only("undeclared".to_string()),
+        ];
+
+        overlay_declared_tiers(&def, &mut models);
+        assert_eq!(models[0].tier, Some(ModelTier::Strong));
+        assert_eq!(models[1].tier, None);
     }
 }


### PR DESCRIPTION
Custom providers parsed context_window from /v1/models but never stored it, so resolution always fell back to the provider-kind default (200k). Now set_known_models is called during discovery and model_from_def consults discovered metadata as an intermediate fallback.

Fixes context size discovery with vLLM endpoints.

AI disclosure: maki + qwen 3.6 27b