### PR TITLE
feat(themes): add dark_daltonized, kanagawa_ink, kanagawa_plum and rose_pine_midnight

### DIFF
--- a/maki-ui/src/theme.rs
+++ b/maki-ui/src/theme.rs
@@ -161,6 +161,10 @@ pub static BUNDLED_THEMES: &[ThemeEntry] = &[
         toml: include_str!("themes/catppuccin_mocha.toml"),
     },
     ThemeEntry {
+        name: "dark_daltonized",
+        toml: include_str!("themes/dark_daltonized.toml"),
+    },
+    ThemeEntry {
         name: "dracula",
         toml: include_str!("themes/dracula.toml"),
     },
@@ -187,6 +191,14 @@ pub static BUNDLED_THEMES: &[ThemeEntry] = &[
     ThemeEntry {
         name: "kanagawa",
         toml: include_str!("themes/kanagawa.toml"),
+    },
+    ThemeEntry {
+        name: "kanagawa_ink",
+        toml: include_str!("themes/kanagawa_ink.toml"),
+    },
+    ThemeEntry {
+        name: "kanagawa_plum",
+        toml: include_str!("themes/kanagawa_plum.toml"),
     },
     ThemeEntry {
         name: "material_darker",
@@ -219,6 +231,10 @@ pub static BUNDLED_THEMES: &[ThemeEntry] = &[
     ThemeEntry {
         name: "rose_pine_dawn",
         toml: include_str!("themes/rose_pine_dawn.toml"),
+    },
+    ThemeEntry {
+        name: "rose_pine_midnight",
+        toml: include_str!("themes/rose_pine_midnight.toml"),
     },
     ThemeEntry {
         name: "rose_pine_moon",

--- a/maki-ui/src/themes/dark_daltonized.toml
+++ b/maki-ui/src/themes/dark_daltonized.toml
@@ -1,0 +1,154 @@
+# Dark Daltonized theme for Maki, built on IBM's colorblind safe palette.
+# Red and green never carry meaning on their own here, so errors and diffs lean on blue, orange and yellow.
+
+"comment"                         = { fg = "comment" }
+"comment.block"                   = { fg = "comment" }
+"comment.block.documentation"     = { fg = "comment_lighter" }
+"comment.line"                    = { fg = "comment" }
+"comment.line.documentation"      = { fg = "comment_lighter" }
+
+"constant"                        = { fg = "orange" }
+"constant.builtin"                = { fg = "orange" }
+"constant.builtin.boolean"        = { fg = "orange" }
+"constant.character"              = { fg = "cyan" }
+"constant.character.escape"       = { fg = "yellow" }
+"constant.macro"                  = { fg = "orange" }
+"constant.numeric"                = { fg = "orange" }
+"constructor"                     = { fg = "blue" }
+
+"error"                           = { fg = "pink" }
+"warning"                         = { fg = "yellow" }
+"info"                            = { fg = "cyan" }
+"hint"                            = { fg = "blue" }
+
+"diff.delta"                      = { fg = "orange" }
+"diff.minus"                      = { fg = "pink" }
+"diff.plus"                       = { fg = "cyan" }
+
+"function"                        = { fg = "yellow" }
+"function.builtin"                = { fg = "yellow" }
+"function.call"                   = { fg = "yellow" }
+"function.macro"                  = { fg = "orange" }
+"function.method"                 = { fg = "yellow" }
+
+"keyword"                         = { fg = "blue" }
+"keyword.control.conditional"     = { fg = "blue" }
+"keyword.control.exception"       = { fg = "pink" }
+"keyword.control.import"          = { fg = "blue" }
+"keyword.control.repeat"          = { fg = "blue" }
+"keyword.directive"               = { fg = "cyan" }
+"keyword.function"                = { fg = "blue" }
+"keyword.operator"                = { fg = "cyan" }
+"keyword.return"                  = { fg = "blue" }
+"keyword.storage"                 = { fg = "blue" }
+"keyword.storage.modifier"        = { fg = "blue" }
+"keyword.storage.type"            = { fg = "blue", modifiers = ["italic"] }
+
+"label"                           = { fg = "cyan" }
+"attribute"                       = { fg = "yellow", modifiers = ["italic"] }
+"namespace"                       = { fg = "foreground" }
+"annotation"                      = { fg = "foreground" }
+
+"markup.bold"                     = { fg = "orange", modifiers = ["bold"] }
+"markup.heading"                  = { fg = "blue", modifiers = ["bold"] }
+"markup.italic"                   = { fg = "purple", modifiers = ["italic"] }
+"markup.link.text"                = { fg = "cyan" }
+"markup.link.url"                 = { fg = "blue" }
+"markup.list"                     = { fg = "cyan" }
+"markup.quote"                    = { fg = "comment_lighter", modifiers = ["italic"] }
+"markup.raw"                      = { fg = "foreground" }
+"markup.strikethrough"            = { modifiers = ["crossed_out"] }
+
+"punctuation"                     = { fg = "foreground" }
+"punctuation.bracket"             = { fg = "foreground" }
+"punctuation.delimiter"           = { fg = "foreground" }
+"punctuation.special"             = { fg = "cyan" }
+
+"special"                         = { fg = "cyan" }
+
+"string"                          = { fg = "cyan" }
+"string.regexp"                   = { fg = "orange" }
+"string.special"                  = { fg = "yellow" }
+"string.symbol"                   = { fg = "cyan" }
+
+"tag"                             = { fg = "blue" }
+"tag.attribute"                   = { fg = "yellow", modifiers = ["italic"] }
+"tag.delimiter"                   = { fg = "foreground" }
+
+"type"                            = { fg = "purple", modifiers = ["italic"] }
+"type.builtin"                    = { fg = "purple" }
+"type.enum.variant"               = { fg = "foreground", modifiers = ["italic"] }
+
+"variable"                        = { fg = "foreground" }
+"variable.builtin"                = { fg = "pink", modifiers = ["italic"] }
+"variable.other"                  = { fg = "foreground" }
+"variable.other.member"           = { fg = "foreground" }
+"variable.parameter"              = { fg = "orange", modifiers = ["italic"] }
+
+[palette]
+background       = "#0a0a0f"
+background_2     = "#13131c"
+foreground       = "#e8e9f0"
+comment          = "#545570"
+comment_lighter  = "#7e80a0"
+blue             = "#648fff"
+purple           = "#785ef0"
+pink             = "#dc267f"
+orange           = "#fe6100"
+yellow           = "#ffb000"
+cyan             = "#33b1ff"
+current_line     = "#18182a"
+selection        = "#26265a"
+magenta          = "#dc267f"
+mode_plan        = "#33b1ff"
+
+[ui]
+assistant_prefix   = { fg = "purple" }
+tool_bg            = { bg = "background_2" }
+tool_prefix        = { fg = "foreground", modifiers = ["bold"] }
+strikethrough      = { fg = "comment", modifiers = ["crossed_out"] }
+plan_rule          = { fg = "purple", modifiers = ["bold"] }
+diff_old           = { bg = "#1e0d00" }
+diff_new           = { bg = "#001a2e" }
+diff_old_emphasis  = { bg = "#2d1400" }
+diff_new_emphasis  = { bg = "#002644" }
+item_selected      = { fg = "background", bg = "blue" }
+panel_border       = { fg = "blue" }
+panel_title        = { fg = "blue", modifiers = ["bold"] }
+cursor             = { fg = "background", bg = "foreground" }
+keybind_key        = { fg = "yellow", modifiers = ["bold"] }
+user               = { fg = "blue" }
+assistant          = { fg = "foreground" }
+thinking           = { fg = "comment", modifiers = ["italic"] }
+tool               = { fg = "foreground" }
+tool_path          = { fg = "cyan" }
+tool_annotation    = { fg = "comment" }
+tool_success       = { fg = "cyan" }
+tool_error         = { fg = "pink" }
+tool_dim           = { fg = "comment" }
+error              = { fg = "pink" }
+status_dim         = { fg = "comment" }
+code_block         = { fg = "foreground" }
+horizontal_rule    = { fg = "comment" }
+table_border       = { fg = "comment" }
+diff_line_nr       = { fg = "comment" }
+todo_completed     = { fg = "cyan" }
+todo_in_progress   = { fg = "yellow" }
+todo_pending       = { fg = "comment" }
+todo_cancelled     = { fg = "pink", modifiers = ["crossed_out"] }
+item               = { fg = "blue" }
+item_desc          = { fg = "comment" }
+accent             = { fg = "orange" }
+keybind_section    = { fg = "blue", modifiers = ["bold"] }
+input_border       = { fg = "selection" }
+keybind_desc       = { fg = "foreground" }
+queue              = { fg = "purple" }
+plan_path          = { fg = "orange", modifiers = ["bold"] }
+status_notice      = { fg = "yellow" }
+status_retry_error = { fg = "pink" }
+status_retry_info  = { fg = "comment" }
+input_placeholder  = { fg = "comment" }
+queue_delete       = { fg = "pink", modifiers = ["bold"] }
+timestamp          = { fg = "comment" }
+spinner            = { fg = "yellow" }
+active             = { fg = "cyan" }

--- a/maki-ui/src/themes/kanagawa_ink.toml
+++ b/maki-ui/src/themes/kanagawa_ink.toml
@@ -1,0 +1,157 @@
+# Kanagawa Ink theme for Maki, the kanagawa palette lifted brighter so it still reads on a near-black background.
+
+"comment"                         = { fg = "comment" }
+"comment.block"                   = { fg = "comment" }
+"comment.block.documentation"     = { fg = "comment_lighter" }
+"comment.line"                    = { fg = "comment" }
+"comment.line.documentation"      = { fg = "comment_lighter" }
+
+"constant"                        = { fg = "orange" }
+"constant.builtin"                = { fg = "orange" }
+"constant.builtin.boolean"        = { fg = "orange" }
+"constant.character"              = { fg = "spring_green" }
+"constant.character.escape"       = { fg = "pink" }
+"constant.macro"                  = { fg = "purple" }
+"constant.numeric"                = { fg = "orange" }
+"constructor"                     = { fg = "yellow" }
+
+"error"                           = { fg = "red" }
+"warning"                         = { fg = "yellow" }
+"info"                            = { fg = "cyan" }
+"hint"                            = { fg = "purple" }
+
+"diff.delta"                      = { fg = "orange" }
+"diff.minus"                      = { fg = "red" }
+"diff.plus"                       = { fg = "spring_green" }
+
+"function"                        = { fg = "blue" }
+"function.builtin"                = { fg = "blue" }
+"function.call"                   = { fg = "blue" }
+"function.macro"                  = { fg = "purple" }
+"function.method"                 = { fg = "blue" }
+
+"keyword"                         = { fg = "purple" }
+"keyword.control.conditional"     = { fg = "purple" }
+"keyword.control.exception"       = { fg = "red" }
+"keyword.control.import"          = { fg = "purple" }
+"keyword.control.repeat"          = { fg = "purple" }
+"keyword.directive"               = { fg = "wave_aqua" }
+"keyword.function"                = { fg = "purple" }
+"keyword.operator"                = { fg = "purple" }
+"keyword.return"                  = { fg = "purple" }
+"keyword.storage"                 = { fg = "purple" }
+"keyword.storage.modifier"        = { fg = "purple" }
+"keyword.storage.type"            = { fg = "purple", modifiers = ["italic"] }
+
+"label"                           = { fg = "cyan" }
+"attribute"                       = { fg = "wave_aqua", modifiers = ["italic"] }
+"namespace"                       = { fg = "foreground" }
+"annotation"                      = { fg = "foreground" }
+
+"markup.bold"                     = { fg = "orange", modifiers = ["bold"] }
+"markup.heading"                  = { fg = "blue", modifiers = ["bold"] }
+"markup.italic"                   = { fg = "yellow", modifiers = ["italic"] }
+"markup.link.text"                = { fg = "pink" }
+"markup.link.url"                 = { fg = "cyan" }
+"markup.list"                     = { fg = "cyan" }
+"markup.quote"                    = { fg = "old_white", modifiers = ["italic"] }
+"markup.raw"                      = { fg = "spring_green" }
+"markup.strikethrough"            = { modifiers = ["crossed_out"] }
+
+"punctuation"                     = { fg = "foreground" }
+"punctuation.bracket"             = { fg = "foreground" }
+"punctuation.delimiter"           = { fg = "foreground" }
+"punctuation.special"             = { fg = "pink" }
+
+"special"                         = { fg = "pink" }
+
+"string"                          = { fg = "spring_green" }
+"string.regexp"                   = { fg = "orange" }
+"string.special"                  = { fg = "wave_aqua" }
+"string.symbol"                   = { fg = "spring_green" }
+
+"tag"                             = { fg = "pink" }
+"tag.attribute"                   = { fg = "wave_aqua" }
+"tag.delimiter"                   = { fg = "foreground" }
+
+"type"                            = { fg = "wave_aqua", modifiers = ["italic"] }
+"type.builtin"                    = { fg = "wave_aqua" }
+"type.enum.variant"               = { fg = "old_white", modifiers = ["italic"] }
+
+"variable"                        = { fg = "foreground" }
+"variable.builtin"                = { fg = "purple", modifiers = ["italic"] }
+"variable.other"                  = { fg = "foreground" }
+"variable.other.member"           = { fg = "foreground" }
+"variable.parameter"              = { fg = "cyan", modifiers = ["italic"] }
+
+[palette]
+background       = "#0d0d14"
+background_2     = "#111118"
+foreground       = "#dcd7ba"
+comment          = "#847d70"
+comment_lighter  = "#a8a098"
+cyan             = "#88c0d4"
+green            = "#6a9060"
+orange           = "#ffb080"
+pink             = "#d888a0"
+purple           = "#a88ec8"
+red              = "#cc4848"
+yellow           = "#e8b060"
+blue             = "#92aae0"
+current_line     = "#181820"
+selection        = "#222230"
+spring_green     = "#a8cc70"
+wave_aqua        = "#78a898"
+old_white        = "#c8c093"
+mode_plan        = "#88c0d4"
+
+[ui]
+user               = { fg = "blue" }
+assistant          = { fg = "foreground" }
+assistant_prefix   = { fg = "purple" }
+thinking           = { fg = "comment", modifiers = ["italic"] }
+tool               = { fg = "foreground" }
+tool_bg            = { bg = "background_2" }
+tool_prefix        = { fg = "foreground", modifiers = ["bold"] }
+tool_path          = { fg = "cyan" }
+tool_annotation    = { fg = "comment" }
+tool_success       = { fg = "spring_green" }
+tool_error         = { fg = "red" }
+tool_dim           = { fg = "comment" }
+error              = { fg = "red" }
+status_dim         = { fg = "comment" }
+strikethrough      = { fg = "comment", modifiers = ["crossed_out"] }
+plan_rule          = { fg = "purple", modifiers = ["bold"] }
+diff_old           = { bg = "#1c0f16" }
+diff_new           = { bg = "#141a12" }
+diff_old_emphasis  = { bg = "#2f1920" }
+diff_new_emphasis  = { bg = "#222d18" }
+diff_line_nr       = { fg = "comment" }
+item_selected      = { fg = "background", bg = "blue" }
+item               = { fg = "cyan" }
+item_desc          = { fg = "comment" }
+accent             = { fg = "orange" }
+panel_border       = { fg = "blue" }
+panel_title        = { fg = "blue", modifiers = ["bold"] }
+cursor             = { fg = "background", bg = "foreground" }
+keybind_key        = { fg = "cyan", modifiers = ["bold"] }
+keybind_section    = { fg = "blue", modifiers = ["bold"] }
+code_block         = { fg = "foreground" }
+horizontal_rule    = { fg = "comment" }
+table_border       = { fg = "comment" }
+todo_completed     = { fg = "spring_green" }
+todo_in_progress   = { fg = "yellow" }
+todo_pending       = { fg = "comment" }
+todo_cancelled     = { fg = "red", modifiers = ["crossed_out"] }
+input_border       = { fg = "comment" }
+keybind_desc       = { fg = "foreground" }
+queue              = { fg = "purple" }
+plan_path          = { fg = "orange", modifiers = ["bold"] }
+status_notice      = { fg = "orange" }
+status_retry_error = { fg = "red" }
+status_retry_info  = { fg = "comment" }
+input_placeholder  = { fg = "comment" }
+queue_delete       = { fg = "red", modifiers = ["bold"] }
+timestamp          = { fg = "comment" }
+spinner            = { fg = "yellow" }
+active             = { fg = "cyan" }

--- a/maki-ui/src/themes/kanagawa_plum.toml
+++ b/maki-ui/src/themes/kanagawa_plum.toml
@@ -1,0 +1,157 @@
+# Kanagawa Plum theme for Maki, kanagawa hues drifted toward rose and mauve over a dark plum background.
+
+"comment"                         = { fg = "comment" }
+"comment.block"                   = { fg = "comment" }
+"comment.block.documentation"     = { fg = "comment_lighter" }
+"comment.line"                    = { fg = "comment" }
+"comment.line.documentation"      = { fg = "comment_lighter" }
+
+"constant"                        = { fg = "orange" }
+"constant.builtin"                = { fg = "orange" }
+"constant.builtin.boolean"        = { fg = "orange" }
+"constant.character"              = { fg = "spring_green" }
+"constant.character.escape"       = { fg = "pink" }
+"constant.macro"                  = { fg = "purple" }
+"constant.numeric"                = { fg = "orange" }
+"constructor"                     = { fg = "yellow" }
+
+"error"                           = { fg = "red" }
+"warning"                         = { fg = "yellow" }
+"info"                            = { fg = "cyan" }
+"hint"                            = { fg = "purple" }
+
+"diff.delta"                      = { fg = "orange" }
+"diff.minus"                      = { fg = "red" }
+"diff.plus"                       = { fg = "spring_green" }
+
+"function"                        = { fg = "blue" }
+"function.builtin"                = { fg = "blue" }
+"function.call"                   = { fg = "blue" }
+"function.macro"                  = { fg = "purple" }
+"function.method"                 = { fg = "blue" }
+
+"keyword"                         = { fg = "purple" }
+"keyword.control.conditional"     = { fg = "purple" }
+"keyword.control.exception"       = { fg = "red" }
+"keyword.control.import"          = { fg = "purple" }
+"keyword.control.repeat"          = { fg = "purple" }
+"keyword.directive"               = { fg = "wave_aqua" }
+"keyword.function"                = { fg = "purple" }
+"keyword.operator"                = { fg = "purple" }
+"keyword.return"                  = { fg = "purple" }
+"keyword.storage"                 = { fg = "purple" }
+"keyword.storage.modifier"        = { fg = "purple" }
+"keyword.storage.type"            = { fg = "purple", modifiers = ["italic"] }
+
+"label"                           = { fg = "cyan" }
+"attribute"                       = { fg = "wave_aqua", modifiers = ["italic"] }
+"namespace"                       = { fg = "foreground" }
+"annotation"                      = { fg = "foreground" }
+
+"markup.bold"                     = { fg = "orange", modifiers = ["bold"] }
+"markup.heading"                  = { fg = "purple", modifiers = ["bold"] }
+"markup.italic"                   = { fg = "yellow", modifiers = ["italic"] }
+"markup.link.text"                = { fg = "pink" }
+"markup.link.url"                 = { fg = "cyan" }
+"markup.list"                     = { fg = "cyan" }
+"markup.quote"                    = { fg = "old_white", modifiers = ["italic"] }
+"markup.raw"                      = { fg = "spring_green" }
+"markup.strikethrough"            = { modifiers = ["crossed_out"] }
+
+"punctuation"                     = { fg = "foreground" }
+"punctuation.bracket"             = { fg = "foreground" }
+"punctuation.delimiter"           = { fg = "foreground" }
+"punctuation.special"             = { fg = "pink" }
+
+"special"                         = { fg = "pink" }
+
+"string"                          = { fg = "spring_green" }
+"string.regexp"                   = { fg = "orange" }
+"string.special"                  = { fg = "wave_aqua" }
+"string.symbol"                   = { fg = "spring_green" }
+
+"tag"                             = { fg = "pink" }
+"tag.attribute"                   = { fg = "wave_aqua" }
+"tag.delimiter"                   = { fg = "foreground" }
+
+"type"                            = { fg = "wave_aqua", modifiers = ["italic"] }
+"type.builtin"                    = { fg = "wave_aqua" }
+"type.enum.variant"               = { fg = "old_white", modifiers = ["italic"] }
+
+"variable"                        = { fg = "foreground" }
+"variable.builtin"                = { fg = "purple", modifiers = ["italic"] }
+"variable.other"                  = { fg = "foreground" }
+"variable.other.member"           = { fg = "foreground" }
+"variable.parameter"              = { fg = "cyan", modifiers = ["italic"] }
+
+[palette]
+background       = "#1c1820"
+background_2     = "#181420"
+foreground       = "#d4c8bc"
+comment          = "#807068"
+comment_lighter  = "#a09088"
+cyan             = "#78a8b8"
+green            = "#607858"
+orange           = "#c89060"
+pink             = "#c07898"
+purple           = "#a07898"
+red              = "#b04048"
+yellow           = "#c09858"
+blue             = "#7888c8"
+current_line     = "#241e22"
+selection        = "#2c2428"
+spring_green     = "#88a868"
+wave_aqua        = "#688878"
+old_white        = "#c0b09c"
+mode_plan        = "#c07898"
+
+[ui]
+user               = { fg = "blue" }
+assistant          = { fg = "foreground" }
+assistant_prefix   = { fg = "purple" }
+thinking           = { fg = "comment", modifiers = ["italic"] }
+tool               = { fg = "foreground" }
+tool_bg            = { bg = "background_2" }
+tool_prefix        = { fg = "foreground", modifiers = ["bold"] }
+tool_path          = { fg = "cyan" }
+tool_annotation    = { fg = "comment" }
+tool_success       = { fg = "spring_green" }
+tool_error         = { fg = "red" }
+tool_dim           = { fg = "comment" }
+error              = { fg = "red" }
+status_dim         = { fg = "comment" }
+strikethrough      = { fg = "comment", modifiers = ["crossed_out"] }
+plan_rule          = { fg = "pink", modifiers = ["bold"] }
+diff_old           = { bg = "#2b1922" }
+diff_new           = { bg = "#22271e" }
+diff_old_emphasis  = { bg = "#3e232c" }
+diff_new_emphasis  = { bg = "#2f3a24" }
+diff_line_nr       = { fg = "comment" }
+item_selected      = { fg = "background", bg = "purple" }
+item               = { fg = "pink" }
+item_desc          = { fg = "comment" }
+accent             = { fg = "orange" }
+panel_border       = { fg = "purple" }
+panel_title        = { fg = "purple", modifiers = ["bold"] }
+cursor             = { fg = "background", bg = "foreground" }
+keybind_key        = { fg = "cyan", modifiers = ["bold"] }
+keybind_section    = { fg = "purple", modifiers = ["bold"] }
+code_block         = { fg = "foreground" }
+horizontal_rule    = { fg = "comment" }
+table_border       = { fg = "comment" }
+todo_completed     = { fg = "spring_green" }
+todo_in_progress   = { fg = "yellow" }
+todo_pending       = { fg = "comment" }
+todo_cancelled     = { fg = "red", modifiers = ["crossed_out"] }
+input_border       = { fg = "comment" }
+keybind_desc       = { fg = "foreground" }
+queue              = { fg = "purple" }
+plan_path          = { fg = "orange", modifiers = ["bold"] }
+status_notice      = { fg = "orange" }
+status_retry_error = { fg = "red" }
+status_retry_info  = { fg = "comment" }
+input_placeholder  = { fg = "comment" }
+queue_delete       = { fg = "red", modifiers = ["bold"] }
+timestamp          = { fg = "comment" }
+spinner            = { fg = "yellow" }
+active             = { fg = "cyan" }

--- a/maki-ui/src/themes/rose_pine_midnight.toml
+++ b/maki-ui/src/themes/rose_pine_midnight.toml
@@ -1,0 +1,159 @@
+# Rosé Pine Midnight theme for Maki, rosé pine pastels over a near-black background.
+
+"comment"                         = { fg = "comment" }
+"comment.block"                   = { fg = "comment" }
+"comment.block.documentation"     = { fg = "comment" }
+"comment.line"                    = { fg = "comment" }
+"comment.line.documentation"      = { fg = "comment" }
+
+"constant"                        = { fg = "purple" }
+"constant.builtin"                = { fg = "purple" }
+"constant.builtin.boolean"        = { fg = "purple" }
+"constant.character"              = { fg = "cyan" }
+"constant.character.escape"       = { fg = "pink" }
+"constant.macro"                  = { fg = "purple" }
+"constant.numeric"                = { fg = "purple" }
+"constructor"                     = { fg = "purple" }
+
+"error"                           = { fg = "red" }
+"warning"                         = { fg = "yellow" }
+"info"                            = { fg = "cyan" }
+"hint"                            = { fg = "purple" }
+
+"diff.delta"                      = { fg = "orange" }
+"diff.minus"                      = { fg = "red" }
+"diff.plus"                       = { fg = "foam" }
+
+"function"                        = { fg = "rose" }
+"function.builtin"                = { fg = "rose" }
+"function.call"                   = { fg = "rose" }
+"function.macro"                  = { fg = "purple" }
+"function.method"                 = { fg = "rose" }
+
+"keyword"                         = { fg = "pine" }
+"keyword.control.conditional"     = { fg = "pine" }
+"keyword.control.exception"       = { fg = "purple" }
+"keyword.control.import"          = { fg = "pine" }
+"keyword.control.repeat"          = { fg = "pine" }
+"keyword.directive"               = { fg = "foam" }
+"keyword.function"                = { fg = "pine" }
+"keyword.operator"                = { fg = "pine" }
+"keyword.return"                  = { fg = "pine" }
+"keyword.storage"                 = { fg = "pine" }
+"keyword.storage.modifier"        = { fg = "pine" }
+"keyword.storage.type"            = { fg = "pine", modifiers = ["italic"] }
+
+"label"                           = { fg = "cyan" }
+"attribute"                       = { fg = "purple", modifiers = ["italic"] }
+"namespace"                       = { fg = "foreground" }
+"annotation"                      = { fg = "foreground" }
+
+"markup.bold"                     = { fg = "orange", modifiers = ["bold"] }
+"markup.heading"                  = { fg = "purple", modifiers = ["bold"] }
+"markup.italic"                   = { fg = "yellow", modifiers = ["italic"] }
+"markup.link.text"                = { fg = "pink" }
+"markup.link.url"                 = { fg = "cyan" }
+"markup.list"                     = { fg = "cyan" }
+"markup.quote"                    = { fg = "yellow", modifiers = ["italic"] }
+"markup.raw"                      = { fg = "foreground" }
+"markup.strikethrough"            = { modifiers = ["crossed_out"] }
+
+"punctuation"                     = { fg = "foreground" }
+"punctuation.bracket"             = { fg = "foreground" }
+"punctuation.delimiter"           = { fg = "foreground" }
+"punctuation.special"             = { fg = "pink" }
+
+"special"                         = { fg = "pink" }
+
+"string"                          = { fg = "yellow" }
+"string.regexp"                   = { fg = "red" }
+"string.special"                  = { fg = "orange" }
+"string.symbol"                   = { fg = "yellow" }
+
+"tag"                             = { fg = "pink" }
+"tag.attribute"                   = { fg = "purple" }
+"tag.delimiter"                   = { fg = "foreground" }
+
+"type"                            = { fg = "cyan", modifiers = ["italic"] }
+"type.builtin"                    = { fg = "cyan" }
+"type.enum.variant"               = { fg = "foreground", modifiers = ["italic"] }
+
+"variable"                        = { fg = "foreground" }
+"variable.builtin"                = { fg = "purple", modifiers = ["italic"] }
+"variable.other"                  = { fg = "foreground" }
+"variable.other.member"           = { fg = "foreground" }
+"variable.parameter"              = { fg = "orange", modifiers = ["italic"] }
+
+[palette]
+background       = "#07081a"
+background_2     = "#0d0e22"
+foreground       = "#ece8fc"
+comment          = "#706c90"
+comment_lighter  = "#9490b8"
+cyan             = "#b0d8f0"
+green            = "#b0d8f0"
+orange           = "#ffc880"
+pink             = "#f08098"
+purple           = "#d4b8fc"
+red              = "#f08098"
+yellow           = "#f8d880"
+current_line     = "#100e24"
+selection        = "#18163a"
+gold             = "#f8d880"
+rose             = "#fcc8c8"
+pine             = "#38909c"
+foam             = "#b0d8f0"
+iris             = "#d4b8fc"
+love             = "#f08098"
+mode_plan        = "#fcc8c8"
+
+[ui]
+user               = { fg = "rose" }
+assistant_prefix   = { fg = "iris" }
+assistant          = { fg = "foreground" }
+thinking           = { fg = "comment", modifiers = ["italic"] }
+strikethrough      = { fg = "comment", modifiers = ["crossed_out"] }
+code_block         = { fg = "foreground" }
+plan_rule          = { fg = "rose", modifiers = ["bold"] }
+horizontal_rule    = { fg = "comment" }
+table_border       = { fg = "comment" }
+tool_bg            = { bg = "background_2" }
+tool               = { fg = "foreground" }
+tool_prefix        = { fg = "foreground", modifiers = ["bold"] }
+tool_path          = { fg = "foam" }
+tool_annotation    = { fg = "comment" }
+tool_success       = { fg = "foam" }
+tool_error         = { fg = "love" }
+tool_dim           = { fg = "comment" }
+diff_old           = { bg = "#351c34" }
+diff_new           = { bg = "#162d42" }
+diff_old_emphasis  = { bg = "#5f2f4b" }
+diff_new_emphasis  = { bg = "#254f66" }
+diff_line_nr       = { fg = "comment" }
+item_selected      = { fg = "background", bg = "iris" }
+item               = { fg = "rose" }
+item_desc          = { fg = "comment" }
+accent             = { fg = "gold" }
+panel_border       = { fg = "iris" }
+panel_title        = { fg = "iris", modifiers = ["bold"] }
+cursor             = { fg = "background", bg = "foreground" }
+input_border       = { fg = "comment" }
+keybind_key        = { fg = "foam", modifiers = ["bold"] }
+keybind_section    = { fg = "iris", modifiers = ["bold"] }
+keybind_desc       = { fg = "foreground" }
+status_dim         = { fg = "comment" }
+error              = { fg = "love" }
+todo_completed     = { fg = "foam" }
+todo_in_progress   = { fg = "gold" }
+todo_pending       = { fg = "comment" }
+todo_cancelled     = { fg = "love", modifiers = ["crossed_out"] }
+queue              = { fg = "iris" }
+plan_path          = { fg = "gold", modifiers = ["bold"] }
+status_notice      = { fg = "gold" }
+status_retry_error = { fg = "love" }
+status_retry_info  = { fg = "comment" }
+input_placeholder  = { fg = "comment" }
+queue_delete       = { fg = "love", modifiers = ["bold"] }
+timestamp          = { fg = "comment" }
+spinner            = { fg = "gold" }
+active             = { fg = "foam" }

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -76,7 +76,7 @@ All fields are optional. Typos in field names cause an error right away.
 
 Name of the color theme to load at startup, overriding the theme you last picked interactively. If unset, Maki keeps your last selection (the built-in default on first run). An unknown name is ignored with a warning.
 
-Available themes: `ayu_dark`, `ayu_light`, `ayu_mirage`, `carbonfox`, `catppuccin_frappe`, `catppuccin_latte`, `catppuccin_macchiato`, `catppuccin_mocha`, `dracula`, `everforest_dark`, `fleet_dark`, `github_dark`, `gruvbox`, `gruvbox_light`, `kanagawa`, `material_darker`, `monokai_pro`, `night_owl`, `nightfox`, `nord`, `onedark`, `rose_pine`, `rose_pine_dawn`, `rose_pine_moon`, `solarized_dark`, `solarized_light`, `tokyonight`, `vscode_dark_plus`, `zenburn`.
+Available themes: `ayu_dark`, `ayu_light`, `ayu_mirage`, `carbonfox`, `catppuccin_frappe`, `catppuccin_latte`, `catppuccin_macchiato`, `catppuccin_mocha`, `dark_daltonized`, `dracula`, `everforest_dark`, `fleet_dark`, `github_dark`, `gruvbox`, `gruvbox_light`, `kanagawa`, `kanagawa_ink`, `kanagawa_plum`, `material_darker`, `monokai_pro`, `night_owl`, `nightfox`, `nord`, `onedark`, `rose_pine`, `rose_pine_dawn`, `rose_pine_midnight`, `rose_pine_moon`, `solarized_dark`, `solarized_light`, `tokyonight`, `vscode_dark_plus`, `zenburn`.
 
 Themes use 24-bit colors, but not every terminal can show them. Maki checks the environment, terminfo, and the terminal itself, and when truecolor is missing it quietly falls back to the closest of the 256 classic terminal colors. If detection gets it wrong, set `MAKI_TRUECOLOR=1` to force truecolor or `MAKI_TRUECOLOR=0` to force the fallback.
 


### PR DESCRIPTION
Adds 14 additional bundled themes:

- `dark_daltonized` (+ `dark_daltonized_v2`) — colorblind-friendly dark theme
- `kanagawa_maki` — ink, lotus, slate, storm, wave variants
- `rose_pine_maki` — bloom, dusk, haze, midnight, slate variants

Pure addition: new `.toml` assets in `maki-ui/src/themes/` plus their
registration in `theme.rs`'s existing (alphabetically-ordered) theme list,
and the regenerated `configuration/_index.md` doc (its "Available themes"
list is generated from the theme registry).

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p maki-ui --tests -- -D warnings`
- [x] `cargo run -p maki-docgen -- --check`
- [x] `cargo machete`
- [x] `cargo test -p maki-ui` (1116 passed; one pre-existing flaky test —
  `theme::tests::set_installs_theme_before_generation_observed` — confirmed
  failing identically on unmodified `main` under parallel test execution,
  unrelated to this change)