### PR TITLE
fix(providers copilot): auth and pricing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "agent-client-protocol-schema"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +144,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b350bfd03649e07aa05c0a81b3e15934374e585c98204a57e20b9d49f49bb9a"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +198,18 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "async-channel"
@@ -273,6 +307,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "async-signal"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +340,17 @@ name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "atomic"
@@ -456,6 +512,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +617,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +688,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -735,6 +819,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1117,6 +1211,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
 dependencies = [
  "encoding_rs",
+]
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1733,6 +1854,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2044,6 +2174,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2290,6 +2430,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "4.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72585bb6cc9bc370d1d545b7e23fcce71dfd4461c5e15275e3cf51bdfd9a980a"
+dependencies = [
+ "apple-native-keyring-store",
+ "keyring-core",
+ "windows-native-keyring-store",
+ "zbus-secret-service-keyring-store",
+]
+
+[[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2525,7 +2686,7 @@ dependencies = [
  "test-case",
  "thiserror 2.0.18",
  "toml",
- "toml_edit",
+ "toml_edit 0.22.27",
  "tracing",
  "url",
 ]
@@ -2545,7 +2706,7 @@ dependencies = [
  "test-case",
  "thiserror 2.0.18",
  "toml",
- "toml_edit",
+ "toml_edit 0.22.27",
  "tracing",
 ]
 
@@ -2706,6 +2867,7 @@ dependencies = [
  "inventory",
  "isahc",
  "jiff",
+ "keyring",
  "maki-config",
  "maki-storage",
  "open",
@@ -3387,6 +3549,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "ordermap"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3802,6 +3974,15 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.13+spec-1.1.0",
+]
 
 [[package]]
 name = "proc-macro-error-attr2"
@@ -4423,6 +4604,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secret-service"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hkdf",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4491,6 +4714,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4825,6 +5059,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5152,8 +5397,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -5166,6 +5411,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5174,9 +5428,30 @@ dependencies = [
  "indexmap 2.14.0",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5637,6 +5912,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5747,6 +6033,7 @@ dependencies = [
  "atomic",
  "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -6132,6 +6419,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6242,6 +6542,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6346,6 +6655,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74801d001b9e7729adb4f1825b67b398185fed424749aa3d8bacf70417137d9a"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6385,6 +6775,12 @@ dependencies = [
  "syn 2.0.119",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -6438,4 +6834,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.4",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.3",
+ "winnow 1.0.4",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ similar = { version = "2", features = ["inline", "unicode"] }
 jsonrepair = { version = "0.1", default-features = false, features = ["serde"] }
 jsonschema = { version = "0.33", default-features = false }
 jiff = { version = "0.2", default-features = false, features = ["std", "tz-system"] }
+keyring = "4"
 arboard = { version = "3", default-features = false, features = ["image-data", "wayland-data-control"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 flume = { version = "0.11", default-features = false, features = ["async", "select"] }

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -410,7 +410,7 @@ fn build_sections() -> Vec<ProviderSection> {
                     kind,
                     name: kind.display_name(),
                     auth_line: format!(
-                        "{} (or run `maki auth login copilot` to import a token from gh)",
+                        "{} (or run `maki auth login copilot` to import a token from gh CLI, the Copilot client, or the system keyring)",
                         format_auth(kind)
                     ),
                     urls: vec![kind.base_url()],

--- a/maki-providers/Cargo.toml
+++ b/maki-providers/Cargo.toml
@@ -26,6 +26,7 @@ inventory = { workspace = true }
 jiff = { workspace = true }
 getrandom = { workspace = true }
 open = { workspace = true }
+keyring = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/maki-providers/src/model_registry.rs
+++ b/maki-providers/src/model_registry.rs
@@ -409,7 +409,7 @@ mod tests {
         );
     }
 
-    #[test_case(&[("gpt-5.4", ModelTier::Strong), ("claude-opus-4.7", ModelTier::Strong)], "copilot/gpt-5.4"; "curated default beats discovered tier")]
+    #[test_case(&[("gpt-5.4", ModelTier::Strong), ("claude-opus-4.7", ModelTier::Strong)], "copilot/claude-opus-4.7"; "curated default beats discovered tier")]
     #[test_case(&[("claude-opus-4.6", ModelTier::Strong), ("alpha", ModelTier::Strong)], "copilot/claude-opus-4.6"; "later curated prefix when first is unavailable")]
     #[test_case(&[("zeta", ModelTier::Strong), ("alpha", ModelTier::Strong)], "copilot/alpha"; "lowest id when no curated default is entitled")]
     fn spec_for_tier_prefers_entitled_curated_default(

--- a/maki-providers/src/providers/copilot/auth.rs
+++ b/maki-providers/src/providers/copilot/auth.rs
@@ -2,6 +2,8 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
+use base64::Engine;
+use keyring::Entry;
 use maki_storage::StateDir;
 use maki_storage::auth::{
     ProviderCredentials, delete_provider_credentials, load_provider_credentials,
@@ -9,13 +11,16 @@ use maki_storage::auth::{
 };
 use serde_json::Value as JsonValue;
 use serde_yaml::Value as YamlValue;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::AgentError;
 
 const TOKEN_ENV_VARS: &[&str] = &["GH_COPILOT_TOKEN", "COPILOT_GITHUB_TOKEN"];
 const DEFAULT_HOST: &str = "github.com";
 const PROVIDER: &str = "copilot";
+const KEYRING_SERVICE_PREFIX: &str = "gh:";
+const GO_KEYRING_B64_PREFIX: &str = "go-keyring-base64:";
+const KEYRING_LOCKED_MESSAGE: &str = "is unreadable; is the store locked?";
 
 pub(crate) fn graphql_url(host: &str) -> String {
     if host == DEFAULT_HOST {
@@ -49,7 +54,7 @@ pub(crate) fn load_token() -> Result<ProviderCredentials, AgentError> {
     })
 }
 
-fn discover_token() -> Result<ProviderCredentials, AgentError> {
+fn discover_token(hints: &mut Vec<String>) -> Result<ProviderCredentials, AgentError> {
     for path in copilot_config_paths() {
         if let Ok(contents) = fs::read_to_string(path)
             && let Some((token, host)) = extract_oauth_token_json(&contents)
@@ -72,11 +77,133 @@ fn discover_token() -> Result<ProviderCredentials, AgentError> {
         }
     }
 
+    if let Some((token, host)) = discover_keyring_token(hints) {
+        return Ok(ProviderCredentials {
+            api_key: token,
+            host: (host != DEFAULT_HOST).then_some(host),
+        });
+    }
+
     Err(AgentError::Config {
         message: "Copilot token not found. Run `gh auth login --web`, sign in with the Copilot \
             client, or set GH_COPILOT_TOKEN."
             .into(),
     })
+}
+
+fn discover_keyring_token(hints: &mut Vec<String>) -> Option<(String, String)> {
+    let files = readable_config_files();
+    for host in keyring_hosts(&files) {
+        for account in keyring_accounts(&files, &host) {
+            let Ok(entry) = Entry::new(&format!("{KEYRING_SERVICE_PREFIX}{host}"), &account) else {
+                debug!(host, account, "gh keyring account rejected");
+                continue;
+            };
+            match entry.get_password() {
+                Ok(raw) => return Some((decode_go_keyring(&raw), host)),
+                Err(keyring::Error::NoEntry) => {}
+                Err(err) => {
+                    warn!(
+                        error = %err, host, account,
+                        "gh keyring entry {}", KEYRING_LOCKED_MESSAGE
+                    );
+                    hints.push(locked_keyring_hint(&host, &account, err));
+                }
+            }
+        }
+    }
+    None
+}
+
+fn locked_keyring_hint(host: &str, account: &str, error: impl std::fmt::Display) -> String {
+    format!("gh keyring entry for {host}/{account} {KEYRING_LOCKED_MESSAGE} ({error})")
+}
+
+fn keyring_accounts(files: &[String], host: &str) -> Vec<String> {
+    let mut accounts = Vec::new();
+    for contents in files {
+        for user in config_usernames(contents, host) {
+            if !accounts.contains(&user) {
+                accounts.push(user);
+            }
+        }
+    }
+    push_unique(&mut accounts, "");
+    accounts
+}
+
+fn push_unique(list: &mut Vec<String>, value: &str) {
+    if !list.iter().any(|item| item == value) {
+        list.push(value.to_owned());
+    }
+}
+
+// YAML 1.2 is a superset of JSON, so one serde_yaml parse covers both the JSON copilot config and
+// the YAML gh config.
+fn config_usernames(contents: &str, host: &str) -> Vec<String> {
+    let mut usernames = Vec::new();
+    if let Ok(value) = serde_yaml::from_str::<YamlValue>(contents)
+        && let Some(cfg) = value.get(host).and_then(YamlValue::as_mapping)
+    {
+        if let Some(user) = cfg.get("user").and_then(YamlValue::as_str) {
+            push_unique(&mut usernames, user);
+        }
+        if let Some(users) = cfg.get("users").and_then(YamlValue::as_mapping) {
+            for key in users.keys().filter_map(|key| key.as_str()) {
+                push_unique(&mut usernames, key);
+            }
+        }
+    }
+    usernames
+}
+
+fn keyring_hosts(files: &[String]) -> Vec<String> {
+    let mut hosts = vec![DEFAULT_HOST.to_owned()];
+    for contents in files {
+        for host in config_file_hosts(contents) {
+            if is_github_host(&host) && !hosts.contains(&host) {
+                hosts.push(host);
+            }
+        }
+    }
+    hosts
+}
+
+fn readable_config_files() -> Vec<String> {
+    copilot_config_paths()
+        .into_iter()
+        .chain(gh_config_paths())
+        .filter_map(|path| fs::read_to_string(path).ok())
+        .collect()
+}
+
+// YAML 1.2 is a superset of JSON; also parses the JSON copilot config.
+fn config_file_hosts(contents: &str) -> Vec<String> {
+    let Ok(value) = serde_yaml::from_str::<YamlValue>(contents) else {
+        return Vec::new();
+    };
+    value
+        .as_mapping()
+        .map(|m| {
+            m.keys()
+                .filter_map(|k| k.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Reverses the encoding written by the `go-keyring` library (used by the gh CLI,
+/// which is written in Go): it base64-encodes the token bytes and prefixes them
+/// with `go-keyring-base64:`. Plain (un-prefixed) tokens are returned as-is.
+fn decode_go_keyring(raw: &str) -> String {
+    raw.strip_prefix(GO_KEYRING_B64_PREFIX)
+        .and_then(|encoded| {
+            base64::engine::general_purpose::STANDARD
+                .decode(encoded)
+                .ok()
+        })
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+        .unwrap_or_else(|| raw.to_owned())
 }
 
 pub fn login(dir: &StateDir) -> Result<(), AgentError> {
@@ -85,9 +212,18 @@ pub fn login(dir: &StateDir) -> Result<(), AgentError> {
         return Ok(());
     }
 
-    let creds = discover_token()?;
+    let mut hints = Vec::new();
+    let creds = match discover_token(&mut hints) {
+        Ok(creds) => creds,
+        Err(err) => {
+            for hint in hints {
+                eprintln!("{hint}");
+            }
+            return Err(err);
+        }
+    };
     let host = creds.host.as_deref().unwrap_or(DEFAULT_HOST);
-    println!("Copilot token imported from gh CLI / Copilot client config ({host}).");
+    println!("Copilot token imported from gh CLI / Copilot client / system keyring ({host}).");
     save_provider_credentials(dir, PROVIDER, &creds)?;
     Ok(())
 }
@@ -156,6 +292,15 @@ mod tests {
     use super::*;
     use test_case::test_case;
 
+    #[test]
+    fn locked_keyring_hint_includes_host_account_and_error() {
+        let hint = locked_keyring_hint("github.com", "janedoe", "access denied");
+        assert!(hint.contains("github.com"));
+        assert!(hint.contains("janedoe"));
+        assert!(hint.contains(KEYRING_LOCKED_MESSAGE));
+        assert!(hint.ends_with("(access denied)"));
+    }
+
     #[test_case(
         r#"{"github.com": {"oauth_token": "token-1"}}"# => Some(("token-1".to_string(), "github.com".to_string())); "json_matching_domain"
     )]
@@ -194,5 +339,56 @@ mod tests {
     #[test_case("myco.ghe.com" => "https://myco.ghe.com/api/graphql"; "graphql_ghe")]
     fn test_graphql_url(host: &str) -> String {
         graphql_url(host)
+    }
+
+    #[test_case("go-keyring-base64:Z2hvX3Rva2Vu" => "gho_token".to_owned(); "go_keyring_prefixed")]
+    #[test_case("gho_token" => "gho_token".to_owned(); "plain_token")]
+    #[test_case("go-keyring-base64:!!!not-base64" => "go-keyring-base64:!!!not-base64".to_owned(); "invalid_base64_kept_raw")]
+    fn test_decode_go_keyring(raw: &str) -> String {
+        decode_go_keyring(raw)
+    }
+
+    #[test_case(
+        r#"{"github.com": {"oauth_token": "t"}}"# => vec!["github.com".to_owned()]; "json_hosts"
+    )]
+    #[test_case(
+        "github.com:\n  oauth_token: t\nmyco.ghe.com:\n  oauth_token: t\n" =>
+        vec!["github.com".to_owned(), "myco.ghe.com".to_owned()]; "yaml_hosts"
+    )]
+    #[test_case("[unclosed" => Vec::<String>::new(); "unparsable")]
+    fn test_config_file_hosts(contents: &str) -> Vec<String> {
+        config_file_hosts(contents)
+    }
+
+    #[test_case(
+        r#"{"github.com": {"user": "janedoe", "oauth_token": "t"}}"#, "github.com" =>
+        vec!["janedoe".to_owned()]; "json_user"
+    )]
+    #[test_case(
+        "github.com:\n  user: janedoe\n  users:\n    janedoe:\n    janesmith_second:\n",
+        "github.com" =>
+        vec!["janedoe".to_owned(), "janesmith_second".to_owned()]; "yaml_user_and_users"
+    )]
+    #[test_case(
+        r#"{"github.com": {"user": "janedoe", "users": {"janedoe": {}, "janesmith": {}}}}"#,
+        "github.com" =>
+        vec!["janedoe".to_owned(), "janesmith".to_owned()]; "json_user_and_users"
+    )]
+    #[test_case(
+        "github.com:\n  user: janedoe\n", "myco.ghe.com" =>
+        Vec::<String>::new(); "missing_host"
+    )]
+    fn test_config_usernames(contents: &str, host: &str) -> Vec<String> {
+        config_usernames(contents, host)
+    }
+
+    #[test_case(
+        vec![r#"{"github.com": {"oauth_token": "t"}}"#.to_owned()], "github.com" =>
+        vec!["".to_owned()]; "host_without_username_gets_empty_account")]
+    #[test_case(
+        vec!["github.com:\n  user: janedoe\n".to_owned()], "github.com" =>
+        vec!["janedoe".to_owned(), "".to_owned()]; "usernames_then_empty_account_last")]
+    fn test_keyring_accounts(files: Vec<String>, host: &str) -> Vec<String> {
+        keyring_accounts(&files, host)
     }
 }

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -13,7 +13,9 @@ use tracing::{debug, warn};
 use super::anthropic::shared;
 use super::openai::responses;
 use super::openai_compat;
-use crate::model::{Model, ModelEntry, ModelFamily, ModelInfo, ModelPricing, ModelTier};
+use crate::model::{
+    Model, ModelEntry, ModelFamily, ModelInfo, ModelPricing, ModelTier, lookup_entry,
+};
 use crate::provider::{BoxFuture, Provider};
 use crate::{
     AgentError, Effort, EffortDialect, Message, ProviderEvent, RequestOptions, StreamResponse,
@@ -30,7 +32,7 @@ inventory::submit!(maki_config::providers::BuiltInProvider {
     protocol: maki_config::providers::Protocol::Openai,
     default_base_url: DEFAULT_API_ENDPOINT,
     default_api_key_env: "GH_COPILOT_TOKEN",
-    default_model: "copilot/gpt-5.2",
+    default_model: "copilot/gpt-5.6-terra",
     plans: None,
     login_url: Some("https://github.com/settings/copilot"),
     needs_url: false,
@@ -43,52 +45,389 @@ const RESPONSES_PATH: &str = "/responses";
 const MESSAGES_PATH: &str = "/v1/messages";
 const MODELS_PATH: &str = "/models";
 
+/// Scales `/models` AI-credit prices (1 credit = $0.01) to USD per 1M tokens.
+const AIC_TO_USD_PER_MILLION: f64 = 10_000.0;
+
+/// Fallback pricing used until `/models` reports `billing.token_prices` (or
+/// for offline runs). The API wins via discovered metadata; these mirror
+/// GitHub's published rates (usage-based billing since June 2026,
+/// docs.github.com/copilot/reference/copilot-billing/models-and-pricing), at
+/// the default context tier.
 pub(crate) const fn models() -> &'static [ModelEntry] {
     &[
         ModelEntry {
-            prefixes: &["gpt-5-mini", "gpt-5 mini", "claude-haiku-4.5"],
+            prefixes: &["gpt-5-mini"],
             tier: ModelTier::Weak,
             family: ModelFamily::Generic,
             vision: true,
-            default: true,
-            pricing: ModelPricing::ZERO,
+            default: false,
+            pricing: ModelPricing {
+                input: 0.25,
+                output: 2.00,
+                cache_write: 0.00,
+                cache_read: 0.025,
+                fast: None,
+            },
             max_output_tokens: Some(100_000),
             context_window: 200_000,
         },
         ModelEntry {
-            prefixes: &["gpt-5.2", "gpt-4.1", "claude-sonnet-4.5"],
+            prefixes: &["gpt-5.4-mini"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 0.75,
+                output: 4.50,
+                cache_write: 0.00,
+                cache_read: 0.075,
+                fast: None,
+            },
+            max_output_tokens: Some(100_000),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.4-nano"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 0.20,
+                output: 1.25,
+                cache_write: 0.00,
+                cache_read: 0.02,
+                fast: None,
+            },
+            max_output_tokens: Some(100_000),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["claude-haiku-4.5"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 1.00,
+                output: 5.00,
+                cache_write: 1.25,
+                cache_read: 0.10,
+                fast: None,
+            },
+            max_output_tokens: Some(64_000),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["gemini-3.5-flash"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 1.50,
+                output: 9.00,
+                cache_write: 0.00,
+                cache_read: 0.15,
+                fast: None,
+            },
+            max_output_tokens: Some(65_536),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["gemini-3.6-flash"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 0.75,
+                output: 3.75,
+                cache_write: 0.00,
+                cache_read: 0.075,
+                fast: None,
+            },
+            max_output_tokens: Some(65_536),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["gemini-3.7-flash"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 0.75,
+                output: 3.75,
+                cache_write: 0.00,
+                cache_read: 0.075,
+                fast: None,
+            },
+            max_output_tokens: Some(65_536),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["mai-code-1-flash-picker"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 0.75,
+                output: 4.50,
+                cache_write: 0.00,
+                cache_read: 0.075,
+                fast: None,
+            },
+            max_output_tokens: Some(100_000),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["claude-sonnet-4.5", "claude-sonnet-4.6"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 3.00,
+                output: 15.00,
+                cache_write: 3.75,
+                cache_read: 0.30,
+                fast: None,
+            },
+            max_output_tokens: Some(64_000),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["claude-sonnet-5"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 2.00,
+                output: 10.00,
+                cache_write: 2.50,
+                cache_read: 0.20,
+                fast: None,
+            },
+            max_output_tokens: Some(100_000),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.5"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 5.00,
+                output: 30.00,
+                cache_write: 0.00,
+                cache_read: 0.50,
+                fast: None,
+            },
+            max_output_tokens: Some(100_000),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["kimi-k2.7-code"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 0.95,
+                output: 4.00,
+                cache_write: 0.00,
+                cache_read: 0.19,
+                fast: None,
+            },
+            max_output_tokens: Some(100_000),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["kimi-k3"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 3.00,
+                output: 15.00,
+                cache_write: 0.00,
+                cache_read: 0.30,
+                fast: None,
+            },
+            max_output_tokens: Some(100_000),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["gemini-3.1-pro-preview"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 2.00,
+                output: 12.00,
+                cache_write: 0.00,
+                cache_read: 0.20,
+                fast: None,
+            },
+            max_output_tokens: Some(65_536),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.6-luna"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: true,
+            pricing: ModelPricing {
+                input: 0.20,
+                output: 1.20,
+                cache_write: 0.25,
+                cache_read: 0.02,
+                fast: None,
+            },
+            max_output_tokens: Some(100_000),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.4"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 2.50,
+                output: 15.00,
+                cache_write: 0.00,
+                cache_read: 0.25,
+                fast: None,
+            },
+            max_output_tokens: Some(100_000),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.6-sol"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 5.00,
+                output: 30.00,
+                cache_write: 6.25,
+                cache_read: 0.50,
+                fast: None,
+            },
+            max_output_tokens: Some(100_000),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.6-terra"],
             tier: ModelTier::Medium,
             family: ModelFamily::Generic,
             vision: true,
             default: true,
-            pricing: ModelPricing::ZERO,
+            pricing: ModelPricing {
+                input: 2.00,
+                output: 12.00,
+                cache_write: 2.50,
+                cache_read: 0.20,
+                fast: None,
+            },
+            max_output_tokens: Some(100_000),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["gpt-5.3-codex"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 1.75,
+                output: 14.00,
+                cache_write: 0.00,
+                cache_read: 0.175,
+                fast: None,
+            },
             max_output_tokens: Some(100_000),
             context_window: 200_000,
         },
         ModelEntry {
             prefixes: &[
-                "gpt-5.4",
-                "gpt-5.3-codex",
+                "claude-opus-5",
+                "claude-opus-4.8",
+                "claude-opus-4.7",
                 "claude-opus-4.6",
-                "grok-code-fast-1",
+                "claude-opus-4.5",
             ],
             tier: ModelTier::Strong,
             family: ModelFamily::Generic,
             vision: true,
             default: true,
-            pricing: ModelPricing::ZERO,
-            max_output_tokens: Some(100_000),
+            pricing: ModelPricing {
+                input: 5.00,
+                output: 25.00,
+                cache_write: 6.25,
+                cache_read: 0.50,
+                fast: None,
+            },
+            max_output_tokens: Some(64_000),
             context_window: 200_000,
         },
         ModelEntry {
-            prefixes: &["claude-opus-4.7"],
+            prefixes: &["claude-opus-4.8-fast", "claude-fable-5"],
             tier: ModelTier::Strong,
             family: ModelFamily::Generic,
             vision: true,
             default: false,
-            pricing: ModelPricing::ZERO,
-            max_output_tokens: Some(64_000),
-            context_window: 264_000,
+            pricing: ModelPricing {
+                input: 10.00,
+                output: 50.00,
+                cache_write: 12.50,
+                cache_read: 1.00,
+                fast: None,
+            },
+            max_output_tokens: Some(100_000),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["grok-4.5"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 2.00,
+                output: 6.00,
+                cache_write: 0.00,
+                cache_read: 0.50,
+                fast: None,
+            },
+            max_output_tokens: Some(100_000),
+            context_window: 200_000,
+        },
+        ModelEntry {
+            prefixes: &["grok-4.6"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 2.00,
+                output: 6.00,
+                cache_write: 0.00,
+                cache_read: 0.50,
+                fast: None,
+            },
+            max_output_tokens: Some(100_000),
+            context_window: 200_000,
         },
     ]
 }
@@ -367,6 +706,8 @@ struct CopilotModel {
     #[serde(default)]
     capabilities: CopilotModelCapabilities,
     #[serde(default)]
+    billing: CopilotModelBilling,
+    #[serde(default)]
     is_chat_default: bool,
     #[serde(default)]
     model_picker_enabled: bool,
@@ -374,6 +715,30 @@ struct CopilotModel {
     model_picker_category: Option<CopilotModelCategory>,
     #[serde(default)]
     supported_endpoints: Vec<String>,
+}
+
+#[derive(Clone, Default, Deserialize)]
+struct CopilotModelBilling {
+    #[serde(default)]
+    token_prices: Option<CopilotTokenPrices>,
+}
+
+#[derive(Clone, Default, Deserialize)]
+struct CopilotTokenPrices {
+    #[serde(default)]
+    batch_size: u32,
+    #[serde(default)]
+    default: Option<CopilotTokenPriceTier>,
+}
+
+#[derive(Clone, Default, Deserialize)]
+struct CopilotTokenPriceTier {
+    #[serde(default)]
+    input_price: f64,
+    #[serde(default)]
+    output_price: f64,
+    #[serde(default)]
+    cache_price: f64,
 }
 
 impl CopilotModel {
@@ -392,7 +757,7 @@ impl CopilotModel {
             id: self.id.clone(),
             context_window: self.capabilities.limits.max_context_window_tokens,
             max_output_tokens: self.capabilities.limits.max_output_tokens,
-            pricing: None,
+            pricing: self.pricing(),
             supports_thinking: Some(self.supports_thinking()),
             supports_vision: Some(self.capabilities.supports.vision),
             tier: self
@@ -433,6 +798,30 @@ impl CopilotModel {
             reasoning_efforts,
             adaptive_thinking: self.capabilities.supports.adaptive_thinking,
         }
+    }
+
+    /// `/models` reports prices in AI credits per billing batch (1 credit =
+    /// $0.01), scaled to USD per 1M tokens for [`ModelPricing`]. The endpoint
+    /// exposes only the default context tier and cached-input reads; cache
+    /// writes are inherited from the static manifest by id prefix so cost
+    /// accounting matches the offline path.
+    fn pricing(&self) -> Option<ModelPricing> {
+        let token_prices = self.billing.token_prices.as_ref()?;
+        let default = token_prices.default.as_ref()?;
+        let batch_size = f64::from(token_prices.batch_size);
+        if batch_size == 0.0 {
+            return None;
+        }
+        let usd_per_million = AIC_TO_USD_PER_MILLION / batch_size;
+        let manifest_cache_write =
+            lookup_entry(models(), &self.id).map_or(0.0, |entry| entry.pricing.cache_write);
+        Some(ModelPricing {
+            input: default.input_price * usd_per_million,
+            output: default.output_price * usd_per_million,
+            cache_read: default.cache_price * usd_per_million,
+            cache_write: manifest_cache_write,
+            fast: None,
+        })
     }
 
     fn endpoint(&self) -> Endpoint {
@@ -745,7 +1134,11 @@ impl Provider for Copilot {
 
 #[cfg(test)]
 mod tests {
+    const OPUS_CACHE_WRITE: f64 = 6.25;
+
     use super::*;
+    use crate::TokenUsage;
+    use crate::manifest::ManifestRegistry;
     use test_case::test_case;
 
     #[test]
@@ -757,6 +1150,7 @@ mod tests {
                 model_type: "chat".into(),
                 ..Default::default()
             },
+            billing: CopilotModelBilling::default(),
             is_chat_default: false,
             model_picker_enabled: true,
             model_picker_category: None,
@@ -845,6 +1239,94 @@ mod tests {
         assert_eq!(model.model_info().supports_thinking, Some(expected));
     }
 
+    #[test_case(ModelTier::Weak, "gpt-5.6-luna"; "weak defaults to luna")]
+    #[test_case(ModelTier::Medium, "gpt-5.6-terra"; "medium defaults to terra")]
+    #[test_case(ModelTier::Strong, "claude-opus-5"; "strong defaults to opus")]
+    fn manifest_has_exactly_one_default_per_tier(tier: ModelTier, expected_prefix: &str) {
+        let defaults: Vec<_> = models()
+            .iter()
+            .filter(|entry| entry.default && entry.tier == tier)
+            .collect();
+        assert_eq!(defaults.len(), 1);
+        assert_eq!(defaults[0].prefixes[0], expected_prefix);
+        assert_eq!(
+            ManifestRegistry::find_default_for_tier("copilot", tier)
+                .unwrap()
+                .prefixes[0],
+            expected_prefix
+        );
+    }
+
+    #[test_case("copilot/gpt-5.6-luna", 1_000_000, 1_000_000, 0.20 + 1.20; "luna default rates")]
+    #[test_case("copilot/gpt-5.4-mini", 100_000, 100_000, 0.075 + 0.45; "gpt-5.4-mini beats gpt-5.4 prefix")]
+    #[test_case("copilot/claude-opus-4.8-fast", 100_000, 100_000, 1.00 + 5.00; "opus 4.8 fast beats opus prefix")]
+    fn manifest_models_report_cost(spec: &str, input: u32, output: u32, expected: f64) {
+        let usage = TokenUsage {
+            input,
+            output,
+            cache_creation: 0,
+            cache_read: 0,
+        };
+        let cost = Model::from_spec(spec)
+            .unwrap()
+            .cost_of(&usage, false)
+            .unwrap();
+        assert!((cost - expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn token_prices_convert_aic_per_batch_to_usd_per_million() {
+        let model: CopilotModel = serde_json::from_value(json!({
+            "id": "gpt-5",
+            "billing": {
+                "token_prices": {
+                    "batch_size": 500_000,
+                    "default": {"input_price": 500.0, "output_price": 3000.0, "cache_price": 50.0}
+                }
+            }
+        }))
+        .unwrap();
+
+        let pricing = model.pricing().unwrap();
+        assert_eq!(pricing.input, 10.0);
+        assert_eq!(pricing.output, 60.0);
+        assert_eq!(pricing.cache_read, 1.0);
+        assert!(pricing.fast.is_none());
+    }
+
+    #[test]
+    fn pricing_inherits_cache_write_from_manifest_by_prefix() {
+        let billing = |id: &str| {
+            json!({
+                "id": id,
+                "billing": {
+                    "token_prices": {
+                        "batch_size": 500_000,
+                        "default": {"input_price": 250.0, "output_price": 1250.0, "cache_price": 25.0}
+                    }
+                }
+            })
+        };
+
+        let opus: CopilotModel = serde_json::from_value(billing("claude-opus-5")).unwrap();
+        let pricing = opus.pricing().unwrap();
+        assert_eq!(pricing.input, 5.0);
+        assert_eq!(pricing.output, 25.0);
+        assert_eq!(pricing.cache_read, 0.5);
+        assert_eq!(pricing.cache_write, OPUS_CACHE_WRITE);
+
+        let unmatched: CopilotModel = serde_json::from_value(billing("gpt-5")).unwrap();
+        assert_eq!(unmatched.pricing().unwrap().cache_write, 0.0);
+    }
+
+    #[test_case(json!({"id": "gpt-5"}) ; "no billing")]
+    #[test_case(json!({"id": "gpt-5", "billing": {"token_prices": {"batch_size": 0, "default": {"input_price": 1.0, "output_price": 1.0, "cache_price": 0.1}}}}) ; "zero batch size")]
+    fn pricing_falls_back_when_billing_unusable(billing: Value) {
+        let model: CopilotModel = serde_json::from_value(billing).unwrap();
+        assert!(model.pricing().is_none());
+        assert!(model.model_info().pricing.is_none());
+    }
+
     #[test]
     fn responses_reasoning_uses_effort_object_and_explicit_none() {
         let model = Model::from_spec("copilot/gpt-5.4").unwrap();
@@ -881,6 +1363,7 @@ mod tests {
                 model_type: "chat".into(),
                 ..Default::default()
             },
+            billing: CopilotModelBilling::default(),
             is_chat_default: false,
             model_picker_enabled: true,
             model_picker_category: None,

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -121,18 +121,37 @@ Defaults: gemini-2.5-pro (strong), gemini-2.5-flash (medium), gemini-2.0-flash-l
 
 ### Copilot
 
-- **Env var**: `GH_COPILOT_TOKEN` (or run `maki auth login copilot` to import a token from gh)
+- **Env var**: `GH_COPILOT_TOKEN` (or run `maki auth login copilot` to import a token from gh CLI, the Copilot client, or the system keyring)
 - **API**: `https://api.githubcopilot.com (or GraphQL-discovered Copilot API endpoint)`
 - **Features**: Native Copilot Chat HTTP API with model endpoint discovery
 
 | Tier | Models | Pricing (in/out per 1M tokens) | Context |
 |------|--------|-------------------------------|---------|
-| Weak | **gpt-5-mini, gpt-5 mini, claude-haiku-4.5** (default) | $0.00 / $0.00 | 200K ctx / 100K out |
-| Medium | **gpt-5.2, gpt-4.1, claude-sonnet-4.5** (default) | $0.00 / $0.00 | 200K ctx / 100K out |
-| Strong | **gpt-5.4, gpt-5.3-codex, claude-opus-4.6, grok-code-fast-1** (default) | $0.00 / $0.00 | 200K ctx / 100K out |
-| Strong | claude-opus-4.7 | $0.00 / $0.00 | 264K ctx / 64K out |
+| Weak | gpt-5-mini | $0.25 / $2.00 | 200K ctx / 100K out |
+| Weak | gpt-5.4-mini | $0.75 / $4.50 | 200K ctx / 100K out |
+| Weak | gpt-5.4-nano | $0.20 / $1.25 | 200K ctx / 100K out |
+| Weak | claude-haiku-4.5 | $1.00 / $5.00 | 200K ctx / 64K out |
+| Weak | gemini-3.5-flash | $1.50 / $9.00 | 200K ctx / 65K out |
+| Weak | mai-code-1-flash-picker | $0.75 / $4.50 | 200K ctx / 100K out |
+| Weak | **gpt-5.6-luna** (default) | $0.20 / $1.20 | 200K ctx / 100K out |
+| Medium | gemini-3.6-flash | $0.75 / $3.75 | 200K ctx / 65K out |
+| Medium | gemini-3.7-flash | $0.75 / $3.75 | 200K ctx / 65K out |
+| Medium | claude-sonnet-4.5, claude-sonnet-4.6 | $3.00 / $15.00 | 200K ctx / 64K out |
+| Medium | claude-sonnet-5 | $2.00 / $10.00 | 200K ctx / 100K out |
+| Medium | kimi-k2.7-code | $0.95 / $4.00 | 200K ctx / 100K out |
+| Medium | gemini-3.1-pro-preview | $2.00 / $12.00 | 200K ctx / 65K out |
+| Medium | **gpt-5.6-terra** (default) | $2.00 / $12.00 | 200K ctx / 100K out |
+| Medium | grok-4.5 | $2.00 / $6.00 | 200K ctx / 100K out |
+| Medium | grok-4.6 | $2.00 / $6.00 | 200K ctx / 100K out |
+| Strong | gpt-5.5 | $5.00 / $30.00 | 200K ctx / 100K out |
+| Strong | kimi-k3 | $3.00 / $15.00 | 200K ctx / 100K out |
+| Strong | gpt-5.4 | $2.50 / $15.00 | 200K ctx / 100K out |
+| Strong | gpt-5.6-sol | $5.00 / $30.00 | 200K ctx / 100K out |
+| Strong | gpt-5.3-codex | $1.75 / $14.00 | 200K ctx / 100K out |
+| Strong | **claude-opus-5, claude-opus-4.8, claude-opus-4.7, claude-opus-4.6, claude-opus-4.5** (default) | $5.00 / $25.00 | 200K ctx / 64K out |
+| Strong | claude-opus-4.8-fast, claude-fable-5 | $10.00 / $50.00 | 200K ctx / 100K out |
 
-Defaults: gpt-5-mini (weak), gpt-5.2 (medium), gpt-5.4 (strong)
+Defaults: gpt-5.6-luna (weak), gpt-5.6-terra (medium), claude-opus-5 (strong)
 
 ### Ollama
 


### PR DESCRIPTION
Resolves #749

The copilot provider takes the auth token from the config/state of either the `gh` or `copilot-cli` cli tools. When using `gh`, maki previously only looked for the token in the `~/.config/gh/hosts.yaml` file, but `gh` defaults to storing the token in the system keyring where available. This leads to maki not being able to find the token when stored via the `gh` default.

Additionally, copilot switched to usage-based pricing, so treating models served from copilot as unpriced was misleading.

- Checks the system keyring for copilot auth token
    - This depends on the `keyring` crate as a new dependency
- Adds pricing to models from the copilot provider
- Updates the hardcoded model fallbacks for copilot to reflect the current state as of August 2026
   - Switches default model from `gpt-5.2` (no longer available) to `get-5.6-luna`