### PR TITLE
fix(task): nudge subagents that finish without a summary

### DIFF
--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -731,7 +731,9 @@ impl Drop for LuaSession {
 /// kept across calls, so you can have a multi-turn conversation.
 ///
 /// The returned table has fields: `text` (string), `duration_ms` (integer),
-/// `input_tokens` (integer), `output_tokens` (integer).
+/// `input_tokens` (integer), `output_tokens` (integer). `text` is an empty
+/// string when the subagent produced no text block (e.g. it only called
+/// tools).
 ///
 /// @param message string User message to send.
 /// @return (table?, string?) Result table on success, or `(nil, err)` on failure.
@@ -763,6 +765,7 @@ async fn prompt(
         });
     }
 
+    let history_len = s.history.len();
     let mut agent = Agent::new(
         s.params.clone(),
         AgentRunParams {
@@ -803,19 +806,19 @@ async fn prompt(
         ),
     }
 
-    let text = s
-        .history
-        .as_slice()
+    // Only this call's messages count: older turns may hold stale preamble
+    // text, and the agent loop's empty-response retry leaves a synthetic
+    // "(empty)" assistant marker that must not pass for a real response.
+    let text = s.history.as_slice()[history_len..]
         .iter()
-        .rev()
-        .filter(|m| matches!(m.role, Role::Assistant))
-        .flat_map(|m| m.content.iter())
-        .find_map(|b| match b {
-            ContentBlock::Text { text } => Some(text.as_str()),
-            _ => None,
-        })
-        .unwrap_or("(no response)")
-        .to_owned();
+        .rfind(|m| matches!(m.role, Role::Assistant))
+        .and_then(|m| {
+            m.content.iter().find_map(|b| match b {
+                ContentBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+        });
+    let text = text.map_or_else(String::new, str::to_owned);
 
     let tbl = lua.create_table()?;
     tbl.set("text", text)?;

--- a/maki-lua/tests/task_policy.rs
+++ b/maki-lua/tests/task_policy.rs
@@ -20,6 +20,7 @@ const SCHEMA_COMPILE_ERROR: &str = "invalid output_schema";
 const SCHEMA_ROOT_ERROR: &str = "output_schema must have type object";
 const STRUCTURED_MISSING_ERROR: &str = "subagent finished without calling structured_output";
 const STRUCTURED_INVALID_ERROR: &str = "subagent result does not match output_schema";
+const SUMMARY_MISSING_ERROR: &str = "subagent finished without providing a summary";
 const UNKNOWN_SUBAGENT_ERR: &str = "unknown subagent type: bogus";
 const SUB_AGENT_ERROR_PREFIX: &str = "sub-agent error: ";
 
@@ -27,6 +28,9 @@ const TASK_TOOL: &str = "task";
 const PROBE_TOOL: &str = "probe";
 const TASK_PROMPT: &str = "do the thing";
 const PLAIN_TEXT: &str = "plain text result";
+const RECOVERED_TEXT: &str = "summary after nudge";
+/// Mirrors the task plugin's `NUDGE_SUMMARY` wording.
+const SUMMARY_NUDGE_FRAGMENT: &str = "concise summary";
 const PROMPT_ERR_MSG: &str = "model exploded";
 const RAISE_MSG: &str = "stub prompt kaboom";
 /// Mirrors the task plugin's `max_concurrent` default.
@@ -39,6 +43,8 @@ const SCENARIO_NEVER_STRUCTURED: &str = "never_structured";
 const SCENARIO_INVALID_ONLY: &str = "invalid_only";
 const SCENARIO_PROMPT_ERROR: &str = "prompt_error";
 const SCENARIO_RAISE: &str = "raise";
+const SCENARIO_NO_SUMMARY: &str = "no_summary";
+const SCENARIO_NO_SUMMARY_THEN_RECOVER: &str = "no_summary_then_recover";
 
 /// Stubs keyed by `opts.name` (the task's `description`). `maki.json` and
 /// `maki.async` stay real so schema validation and semaphore behavior are tested.
@@ -111,6 +117,17 @@ behaviors.prompt_error = function(sess, msg)
   return nil, "@PROMPT_ERR@"
 end
 
+behaviors.no_summary = function(sess, msg)
+  return { text = "" }
+end
+
+behaviors.no_summary_then_recover = function(sess, msg)
+  if #recorder.prompts == 1 then
+    return { text = "" }
+  end
+  return { text = "@RECOVERED_TEXT@" }
+end
+
 behaviors.raise = function(sess, msg)
   error("@RAISE_MSG@")
 end
@@ -170,6 +187,7 @@ fn load_task_host_with_opts(
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
     let prelude = STUB_PRELUDE
         .replace("@PLAIN_TEXT@", PLAIN_TEXT)
+        .replace("@RECOVERED_TEXT@", RECOVERED_TEXT)
         .replace("@PROMPT_ERR@", PROMPT_ERR_MSG)
         .replace("@RAISE_MSG@", RAISE_MSG);
     host.load_source_with_opts(
@@ -404,6 +422,35 @@ fn plain_path_returns_text_without_local_tools() {
     assert_eq!(snap["has_local_tools"], json!(false));
     assert_eq!(snap["prompt_count"], json!(1));
     assert_eq!(snap["prompts"][0], json!(TASK_PROMPT));
+    assert_eq!(snap["closed"], json!(1));
+}
+
+#[test]
+fn no_summary_nudges_then_recovers() {
+    let (reg, _host) = load_task_host();
+    let out = exec_tool(
+        &reg,
+        TASK_TOOL,
+        task_input(SCENARIO_NO_SUMMARY_THEN_RECOVER, None),
+    )
+    .unwrap();
+    assert_eq!(out, RECOVERED_TEXT);
+
+    let snap = probe(&reg);
+    assert_eq!(snap["prompt_count"], json!(2));
+    let nudge = snap["prompts"][1].as_str().expect("nudge prompt missing");
+    assert!(nudge.contains(SUMMARY_NUDGE_FRAGMENT), "got: {nudge}");
+    assert_eq!(snap["closed"], json!(1));
+}
+
+#[test]
+fn no_summary_errors_after_nudges() {
+    let (reg, _host) = load_task_host();
+    let err = exec_tool(&reg, TASK_TOOL, task_input(SCENARIO_NO_SUMMARY, None)).unwrap_err();
+    assert_eq!(err, SUMMARY_MISSING_ERROR);
+
+    let snap = probe(&reg);
+    assert_eq!(snap["prompt_count"], json!(1 + MAX_STRUCTURED_RETRIES));
     assert_eq!(snap["closed"], json!(1));
 }
 

--- a/plugins/task/init.lua
+++ b/plugins/task/init.lua
@@ -12,14 +12,17 @@ local STRUCTURED_OUTPUT_NAME = "structured_output"
 local STRUCTURED_OUTPUT_DESCRIPTION = "Report your final result. Call it exactly once when your task is complete."
 local STRUCTURED_OUTPUT_ACK = "Output recorded."
 local STRUCTURED_OUTPUT_PROMPT_SUFFIX = "\n\nWhen finished, call the structured_output tool with your final result."
-local MAX_STRUCTURED_RETRIES = 2
+local MAX_NUDGES = 2
 local MAX_SCHEMA_ERRORS = 3
 local SCHEMA_COMPILE_ERROR = "invalid output_schema"
 local SCHEMA_ROOT_ERROR = "output_schema must have type object"
 local STRUCTURED_MISSING_ERROR = "subagent finished without calling structured_output"
 local STRUCTURED_INVALID_ERROR = "subagent result does not match output_schema"
+local SUMMARY_MISSING_ERROR = "subagent finished without providing a summary"
 local NUDGE_MISSING =
   "You did not call the structured_output tool. Call it now with your final result matching its input schema."
+local NUDGE_SUMMARY =
+  "You finished your work but did not provide a summary. Reply with a concise summary of what you did and found."
 local INVALID_INPUT_PREFIX =
   "Input does not match the required schema. Fix the errors and call structured_output again:\n"
 local BODY_INDENT_COLS = 4
@@ -190,9 +193,16 @@ local function handler(input, ctx)
 
     local result, err = sess:prompt(message)
     local retries = 0
-    while not err and validator and not captured and retries < MAX_STRUCTURED_RETRIES do
-      retries = retries + 1
-      result, err = sess:prompt(NUDGE_MISSING)
+    while not err and retries < MAX_NUDGES do
+      if validator and not captured then
+        retries = retries + 1
+        result, err = sess:prompt(NUDGE_MISSING)
+      elseif not validator and result.text == "" then
+        retries = retries + 1
+        result, err = sess:prompt(NUDGE_SUMMARY)
+      else
+        break
+      end
     end
 
     sess:close()
@@ -203,6 +213,9 @@ local function handler(input, ctx)
     if validator and not captured then
       local msg = last_errors and (STRUCTURED_INVALID_ERROR .. ":\n" .. last_errors) or STRUCTURED_MISSING_ERROR
       return { llm_output = msg, is_error = true }
+    end
+    if not validator and result.text == "" then
+      return { llm_output = SUMMARY_MISSING_ERROR, is_error = true }
     end
     return { llm_output = captured and maki.json.encode(captured) or result.text, format = "markdown" }
   end)

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -859,7 +859,9 @@ loop runs to completion, calling tools as needed. Conversation history is
 kept across calls, so you can have a multi-turn conversation.
 
 The returned table has fields: `text` (string), `duration_ms` (integer),
-`input_tokens` (integer), `output_tokens` (integer).
+`input_tokens` (integer), `output_tokens` (integer). `text` is an empty
+string when the subagent produced no text block (e.g. it only called
+tools).
 
 **Parameters:**
 


### PR DESCRIPTION
I've had a couple cases where a task's model has reported "DONE!" and exited cleanly but failed to provide the actual summary to the main session. I've been using this fix and it seems to work nicely so far.