### PR TITLE
plugins: Add dedicated `list` plugin and remove directory listing support from `read` plugin

### DIFF
--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -60,6 +60,7 @@ pub const DEFAULT_BUILTINS: &[&str] = &[
     "glob",
     "grep",
     "index",
+    "list",
     "memory",
     "question",
     "read",

--- a/maki-docgen/src/gen_tools.rs
+++ b/maki-docgen/src/gen_tools.rs
@@ -16,6 +16,7 @@ const SECTIONS: &[(&str, &[&str])] = &[
         "File Operations",
         &[
             "bash",
+            "list",
             "read",
             "write",
             "edit",

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -103,6 +103,10 @@ static BUNDLED_PLUGINS: &[BundledPlugin] = &[
         name: "lib",
         dir: include_dir!("$CARGO_MANIFEST_DIR/../plugins/lib"),
     },
+    BundledPlugin {
+        name: "list",
+        dir: include_dir!("$CARGO_MANIFEST_DIR/../plugins/list"),
+    },
 ];
 
 pub(crate) fn lib_dir() -> &'static Dir<'static> {

--- a/maki-lua/tests/real_plugins_restore.rs
+++ b/maki-lua/tests/real_plugins_restore.rs
@@ -325,7 +325,7 @@ fn index_dir_renders_identically_live_and_restored() {
     assert_eq!(
         live.annotation.as_deref(),
         Some(expected_annotation.as_str()),
-        "live dir listing is annotated like read's"
+        "live dir listing is annotated with entry count"
     );
     for name in DIR_ENTRIES {
         assert!(

--- a/maki-lua/tests/spec.rs
+++ b/maki-lua/tests/spec.rs
@@ -7,6 +7,7 @@ use test_case::test_case;
 #[test_case("edit", include_str!("../../plugins/edit/tests/spec.lua") ; "edit_plugin_spec")]
 #[test_case("index", include_str!("../../plugins/index/tests/spec.lua") ; "index_plugin_spec")]
 #[test_case("lib", include_str!("../../plugins/lib/tests/spec.lua") ; "lib_spec")]
+#[test_case("list", include_str!("../../plugins/list/tests/spec.lua") ; "list_plugin_spec")]
 #[test_case("memory", include_str!("../../plugins/memory/tests/spec.lua") ; "memory_plugin_spec")]
 #[test_case("question", include_str!("../../plugins/question/tests/spec.lua") ; "question_plugin_spec")]
 #[test_case("read", include_str!("../../plugins/read/tests/spec.lua") ; "read_plugin_spec")]

--- a/plugins/lib/maki/dir_listing.lua
+++ b/plugins/lib/maki/dir_listing.lua
@@ -1,4 +1,4 @@
--- Shared directory listing for index and read plugins.
+-- Shared directory listing for index and list plugins.
 -- Lists entries, filters instruction files, sorts dirs before files, and
 -- renders the listing so every caller shows a directory the same way.
 

--- a/plugins/list/init.lua
+++ b/plugins/list/init.lua
@@ -1,0 +1,49 @@
+local dir_listing = require("maki.dir_listing")
+local list_helpers = require("list_helpers")
+local shorten_path = require("maki.shorten_path")
+
+local DESCRIPTION =
+  [[List directory contents. Returns entry names sorted alphabetically, directories first with a trailing /.
+
+- Filters out instruction files (AGENTS.md, CLAUDE.md, COPILOT.md).]]
+
+maki.api.register_prompt_hint({
+  slot = "tool_usage",
+  content = [[
+- Use the **list** tool to see what a directory contains.]],
+})
+
+maki.api.register_tool({
+  name = "list",
+  kind = "read",
+  description = DESCRIPTION,
+
+  schema = {
+    type = "object",
+    properties = {
+      path = {
+        type = "string",
+        description = "Absolute path to the directory",
+        required = true,
+      },
+    },
+  },
+
+  header = function(input)
+    local buf = maki.ui.buf()
+    buf:line({ { shorten_path(input.path or ""), "path" } })
+    return buf
+  end,
+
+  restore = function(_input, output, _is_error, ctx)
+    return dir_listing.view(output, ctx)
+  end,
+
+  handler = function(input, ctx)
+    local result = list_helpers.handler(input, ctx)
+    if not result.is_error then
+      result.body = dir_listing.view(result.llm_output, ctx)
+    end
+    return result
+  end,
+})

--- a/plugins/list/list_helpers.lua
+++ b/plugins/list/list_helpers.lua
@@ -1,0 +1,36 @@
+local dir_listing = require("maki.dir_listing")
+
+local M = {}
+
+-- Pure result building; init.lua attaches the body view, which needs a task scope.
+
+function M.handler(input, ctx)
+  local raw = input.path
+  if not raw then
+    return { llm_output = "error: path is required", is_error = true }
+  end
+  local path = maki.fs.abspath(raw)
+  local meta = maki.fs.metadata(path)
+  if not meta then
+    return { llm_output = "error: path not found: " .. path, is_error = true }
+  end
+  if not meta.is_dir then
+    return { llm_output = "error: path is not a directory: " .. path, is_error = true }
+  end
+
+  local listing, err = dir_listing.list(path, ctx)
+  if not listing then
+    return { llm_output = "error: " .. tostring(err), is_error = true }
+  end
+
+  local result = {
+    llm_output = listing.text,
+    annotation = listing.count .. " entries",
+  }
+  if listing.instructions then
+    result.instructions = listing.instructions
+  end
+  return result
+end
+
+return M

--- a/plugins/list/tests/spec.lua
+++ b/plugins/list/tests/spec.lua
@@ -1,0 +1,76 @@
+local list_helpers = require("list_helpers")
+local th = require("maki.test_helpers")
+
+local case = th.case
+local eq = th.eq
+local mktmpdir = function()
+  return th.mktmpdir("list_spec")
+end
+local rmtree = th.rmtree
+
+local PATH_REQUIRED_MSG = "error: path is required"
+
+local function mock_ctx(instructions)
+  return {
+    is_instruction_file = function(_self, name)
+      local set = { ["AGENTS.md"] = true, ["CLAUDE.md"] = true, ["COPILOT.md"] = true }
+      return set[name] or false
+    end,
+    find_instructions = function()
+      return instructions or {}
+    end,
+  }
+end
+
+case("handler_requires_path", function()
+  local result = list_helpers.handler({}, mock_ctx())
+  eq(result.is_error, true)
+  eq(result.llm_output, PATH_REQUIRED_MSG)
+end)
+
+case("handler_errors_on_missing_path", function()
+  local tmpdir = mktmpdir()
+  local missing = maki.fs.joinpath(tmpdir, "missing")
+  local result = list_helpers.handler({ path = missing }, mock_ctx())
+  eq(result.is_error, true)
+  eq(result.llm_output, "error: path not found: " .. missing)
+  rmtree(tmpdir)
+end)
+
+case("handler_errors_on_file_path", function()
+  local tmpdir = mktmpdir()
+  local file = maki.fs.joinpath(tmpdir, "file.txt")
+  maki.fs.write(file, "content")
+  local result = list_helpers.handler({ path = file }, mock_ctx())
+  eq(result.is_error, true)
+  eq(result.llm_output, "error: path is not a directory: " .. file)
+  rmtree(tmpdir)
+end)
+
+case("handler_lists_sorted_and_filtered", function()
+  local tmpdir = mktmpdir()
+  maki.fs.write(maki.fs.joinpath(tmpdir, "b.txt"), "")
+  maki.fs.write(maki.fs.joinpath(tmpdir, "a.txt"), "")
+  maki.fs.write(maki.fs.joinpath(tmpdir, "AGENTS.md"), "instructions")
+  maki.fs.mkdir(maki.fs.joinpath(tmpdir, "zdir"))
+  maki.fs.mkdir(maki.fs.joinpath(tmpdir, "adir"))
+
+  local result = list_helpers.handler({ path = tmpdir }, mock_ctx())
+  eq(result.is_error, nil)
+  eq(result.llm_output, "adir/\nzdir/\na.txt\nb.txt")
+  eq(result.annotation, "4 entries")
+  eq(result.instructions, nil)
+  rmtree(tmpdir)
+end)
+
+case("handler_propagates_instructions", function()
+  local tmpdir = mktmpdir()
+  maki.fs.write(maki.fs.joinpath(tmpdir, "a.txt"), "")
+  local instructions = { maki.fs.joinpath(tmpdir, "AGENTS.md") }
+  local result = list_helpers.handler({ path = tmpdir }, mock_ctx(instructions))
+  eq(result.is_error, nil)
+  eq(result.instructions, instructions)
+  rmtree(tmpdir)
+end)
+
+th.report()

--- a/plugins/read/init.lua
+++ b/plugins/read/init.lua
@@ -1,9 +1,8 @@
-local dir_listing = require("maki.dir_listing")
 local ToolView = require("maki.tool_view")
 local shorten_path = require("maki.shorten_path")
 local output_limits = require("maki.output_limits")
 
-local DESCRIPTION = [[Read a file or directory. Returns contents with line numbers (1-indexed).
+local DESCRIPTION = [[Read a file. Returns contents with line numbers (1-indexed).
 
 - Supports absolute, relative, and ~/ paths.
 - **offset** and **limit** are required. Use offset=1 to read from the first line.
@@ -174,23 +173,6 @@ local function read_file(path, offset, limit, ctx)
   }
 end
 
-local function list_dir(path, ctx)
-  local listing, err = dir_listing.list(path, ctx)
-  if not listing then
-    return { llm_output = "read error: " .. tostring(err), is_error = true }
-  end
-
-  local result = {
-    llm_output = listing.text,
-    body = dir_listing.view(listing.text, ctx),
-    annotation = listing.count .. " entries",
-  }
-  if listing.instructions then
-    result.instructions = listing.instructions
-  end
-  return result
-end
-
 maki.api.register_prompt_hint({
   slot = "tool_usage",
   content = [[
@@ -208,7 +190,7 @@ maki.api.register_tool({
     properties = {
       path = {
         type = "string",
-        description = "Absolute path to the file or directory",
+        description = "Absolute path to the file",
         required = true,
         alias = "file_path",
       },
@@ -271,7 +253,7 @@ maki.api.register_tool({
       return { llm_output = "error: path not found: " .. path, is_error = true }
     end
     if meta.is_dir then
-      return list_dir(path, ctx)
+      return { llm_output = "error: path is a directory, use the list tool instead", is_error = true }
     end
     return read_file(path, input.offset, input.limit, ctx)
   end,

--- a/plugins/read/tests/spec.lua
+++ b/plugins/read/tests/spec.lua
@@ -35,7 +35,6 @@ local function split_lines(content)
   return lines
 end
 
-local dir_listing = require("maki.dir_listing")
 local th = require("maki.test_helpers")
 
 local case = th.case
@@ -119,41 +118,6 @@ case("split_lines", function()
       eq(lines[i], expected, "line " .. i .. " for " .. ("%q"):format(v[1]))
     end
   end
-end)
-
--- integration: directory listing via real filesystem
-
-case("dir_listing_sort_and_filter", function()
-  local tmpdir = mktmpdir()
-  maki.fs.write(maki.fs.joinpath(tmpdir, "c.txt"), "")
-  maki.fs.write(maki.fs.joinpath(tmpdir, "a.txt"), "")
-  maki.fs.write(maki.fs.joinpath(tmpdir, "AGENTS.md"), "instructions")
-  maki.fs.write(maki.fs.joinpath(tmpdir, "b.txt"), "")
-  maki.fs.write(maki.fs.joinpath(tmpdir, "m.txt"), "")
-  maki.fs.mkdir(maki.fs.joinpath(tmpdir, "zdir"))
-  maki.fs.mkdir(maki.fs.joinpath(tmpdir, "adir"))
-  maki.fs.mkdir(maki.fs.joinpath(tmpdir, "idir"))
-
-  local ctx = {
-    is_instruction_file = function(self, name)
-      local set = { ["AGENTS.md"] = true, ["CLAUDE.md"] = true, ["COPILOT.md"] = true }
-      return set[name] or false
-    end,
-    find_instructions = function()
-      return {}
-    end,
-  }
-  local listing, err = dir_listing.list(tmpdir, ctx)
-  assert(err == nil, "dir listing should succeed: " .. tostring(err))
-  eq(#listing.names, 7)
-  eq(listing.names[1], "adir/")
-  eq(listing.names[2], "idir/")
-  eq(listing.names[3], "zdir/")
-  eq(listing.names[4], "a.txt")
-  eq(listing.names[5], "b.txt")
-  eq(listing.names[6], "c.txt")
-  eq(listing.names[7], "m.txt")
-  rmtree(tmpdir)
 end)
 
 th.report()

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -4832,7 +4832,7 @@ return M
 ### `require("maki.dir_listing")`
 
 ```lua
--- Shared directory listing for index and read plugins.
+-- Shared directory listing for index and list plugins.
 -- Lists entries, filters instruction files, sorts dirs before files, and
 -- renders the listing so every caller shows a directory the same way.
 function M.list(path, ctx)

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -7,7 +7,7 @@ group = "Reference"
 
 # Tools
 
-Maki ships with 20 built-in tools in this reference (18 on by default, 2 opt-in via plugin options). Tools marked **opt-in** are off until you enable them under `plugins` in [Configuration](/docs/configuration/).
+Maki ships with 21 built-in tools in this reference (19 on by default, 2 opt-in via plugin options). Tools marked **opt-in** are off until you enable them under `plugins` in [Configuration](/docs/configuration/).
 
 ## File Operations
 
@@ -23,15 +23,23 @@ Commands run in <cwd> by default.
 | `timeout` | integer | no | 120 | Timeout in seconds |
 | `workdir` | string | no | cwd | Working directory |
 
+### `list` *(lua plugin)*
+
+List directory contents. Returns entry names sorted alphabetically, directories first with a trailing /.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | yes | Absolute path to the directory |
+
 ### `read` *(lua plugin)*
 
-Read a file or directory. Returns contents with line numbers (1-indexed).
+Read a file. Returns contents with line numbers (1-indexed).
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `limit` | integer | yes | Max number of lines to read. Use 0 to read until end of file (capped at 2000 lines). |
 | `offset` | integer | yes | Line number to start from (1-indexed). Use 1 for the first line. |
-| `path` | string | yes | Absolute path to the file or directory |
+| `path` | string | yes | Absolute path to the file |
 
 ### `write` *(lua plugin)*
 


### PR DESCRIPTION
I've never seen a model make use of the directory listing via the `read` tool and always fall back to using `bash` with `ls`. This now adds a minimal `list` tool, which I actually saw used quite often.