### PR TITLE
feat(ui): support user-defined themes

### DIFF
--- a/maki-docgen/src/gen_config.rs
+++ b/maki-docgen/src/gen_config.rs
@@ -121,6 +121,13 @@ fn write_theme_section(out: &mut String) {
     writeln!(out, "Available themes: {names}.\n").unwrap();
     writeln!(
         out,
+        "You can add your own themes too. Drop a `<name>.toml` file into \
+         `themes/` inside your Maki config directory, for example \
+         `~/.config/maki/themes/`. If it reuses a built-in name, yours wins.\n"
+    )
+    .unwrap();
+    writeln!(
+        out,
         "Themes use 24-bit colors, but not every terminal can show them. Maki \
          checks the environment, terminfo, and the terminal itself, and when \
          truecolor is missing it quietly falls back to the closest of the 256 \

--- a/maki-ui/src/components/theme_picker.rs
+++ b/maki-ui/src/components/theme_picker.rs
@@ -1,5 +1,5 @@
 use crate::components::Overlay;
-use crate::components::list_picker::{ListPicker, PickerAction, PickerItem};
+use crate::components::list_picker::{ListPicker, PickerAction};
 use crate::theme;
 
 use crossterm::event::KeyEvent;
@@ -14,18 +14,8 @@ pub enum ThemePickerAction {
     Closed,
 }
 
-struct ThemeEntry {
-    name: &'static str,
-}
-
-impl PickerItem for ThemeEntry {
-    fn label(&self) -> &str {
-        self.name
-    }
-}
-
 pub struct ThemePicker {
-    picker: ListPicker<ThemeEntry>,
+    picker: ListPicker<String>,
     original_theme_name: Option<String>,
 }
 
@@ -39,13 +29,10 @@ impl ThemePicker {
 
     pub fn open(&mut self) {
         let current_name = theme::current_theme_name();
-        let entries: Vec<ThemeEntry> = theme::BUNDLED_THEMES
-            .iter()
-            .map(|t| ThemeEntry { name: t.name })
-            .collect();
+        let entries = theme::all_theme_names();
         let current_idx = entries
             .iter()
-            .position(|e| e.name == current_name)
+            .position(|name| *name == current_name)
             .unwrap_or(0);
         self.original_theme_name = Some(current_name);
         self.picker.open(entries, TITLE);
@@ -67,8 +54,8 @@ impl ThemePicker {
                 self.apply_preview();
                 ThemePickerAction::Consumed
             }
-            PickerAction::Select(entry) => {
-                theme::persist_theme(entry.name);
+            PickerAction::Select(name) => {
+                theme::persist_theme(&name);
                 self.original_theme_name = None;
                 ThemePickerAction::Closed
             }
@@ -94,8 +81,8 @@ impl ThemePicker {
     }
 
     fn apply_preview(&self) {
-        if let Some(entry) = self.picker.selected_item()
-            && let Ok(t) = theme::load_by_name(entry.name)
+        if let Some(name) = self.picker.selected_item()
+            && let Ok(t) = theme::load_by_name(name)
         {
             theme::set(t);
         }

--- a/maki-ui/src/theme.rs
+++ b/maki-ui/src/theme.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 
@@ -270,11 +271,46 @@ pub fn generation() -> u64 {
 }
 
 pub fn load_by_name(name: &str) -> Result<Theme, String> {
+    if let Some(path) = user_themes_dir().map(|d| d.join(format!("{name}.toml")))
+        && let Ok(toml) = std::fs::read_to_string(&path)
+    {
+        return Theme::from_toml(&toml).map_err(|e| format!("{}: {e}", path.display()));
+    }
     BUNDLED_THEMES
         .iter()
         .find(|e| e.name == name)
         .map(|e| Theme::from_toml(e.toml))
         .unwrap_or_else(|| Err(format!("unknown theme: {name}")))
+}
+
+fn user_themes_dir() -> Option<PathBuf> {
+    maki_storage::paths::config_dir()
+        .ok()
+        .map(|d| d.join("themes"))
+}
+
+pub fn all_theme_names() -> Vec<String> {
+    let user_names = user_themes_dir()
+        .and_then(|dir| std::fs::read_dir(dir).ok())
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|e| {
+            let path = e.path();
+            if path.extension()? != "toml" {
+                return None;
+            }
+            Some(path.file_stem()?.to_str()?.to_owned())
+        });
+    merge_theme_names(user_names)
+}
+
+fn merge_theme_names(user_names: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut names: Vec<String> = BUNDLED_THEMES.iter().map(|e| e.name.to_owned()).collect();
+    names.extend(user_names);
+    names.sort_unstable();
+    names.dedup();
+    names
 }
 
 pub fn set_current_name(name: &str) {
@@ -1005,6 +1041,13 @@ mod tests {
     #[test]
     fn load_by_name_unknown() {
         assert!(load_by_name("nonexistent").is_err());
+    }
+
+    #[test]
+    fn merge_theme_names_dedups_user_override_and_sorts_in_custom() {
+        let names = merge_theme_names(["dracula".to_owned(), "aaa_custom".to_owned()]);
+        assert_eq!(names.iter().filter(|n| *n == "dracula").count(), 1);
+        assert_eq!(names.first().map(String::as_str), Some("aaa_custom"));
     }
 
     #[test]

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -78,6 +78,8 @@ Name of the color theme to load at startup, overriding the theme you last picked
 
 Available themes: `ayu_dark`, `ayu_light`, `ayu_mirage`, `carbonfox`, `catppuccin_frappe`, `catppuccin_latte`, `catppuccin_macchiato`, `catppuccin_mocha`, `dracula`, `everforest_dark`, `fleet_dark`, `github_dark`, `gruvbox`, `gruvbox_light`, `kanagawa`, `material_darker`, `monokai_pro`, `night_owl`, `nightfox`, `nord`, `onedark`, `rose_pine`, `rose_pine_dawn`, `rose_pine_moon`, `solarized_dark`, `solarized_light`, `tokyonight`, `vscode_dark_plus`, `zenburn`.
 
+You can add your own themes too. Drop a `<name>.toml` file into `themes/` inside your Maki config directory, for example `~/.config/maki/themes/`. If it reuses a built-in name, yours wins.
+
 Themes use 24-bit colors, but not every terminal can show them. Maki checks the environment, terminfo, and the terminal itself, and when truecolor is missing it quietly falls back to the closest of the 256 classic terminal colors. If detection gets it wrong, set `MAKI_TRUECOLOR=1` to force truecolor or `MAKI_TRUECOLOR=0` to force the fallback.
 
 ### `ui.tool_output_lines`


### PR DESCRIPTION
Closes #745, which asked for a way to use themes that are not bundled with maki.

Drop a `<name>.toml` file (Helix theme format) into `themes/` inside the maki config dir, e.g. `~/.config/maki/themes/`, and it appears in the theme picker like any built-in one.

`load_by_name` checks the user dir first, so a user theme can also override a bundled one by reusing its name.