### PR TITLE
feat(agent): custom compaction instructions

### DIFF
--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use maki_config::CompactionBuffer;
+use maki_config::{AgentConfig, CompactionBuffer};
 use maki_providers::{
     ContentBlock, Message, Model, RequestOptions, Role, StreamResponse, TokenUsage,
 };
@@ -11,8 +11,19 @@ use super::streaming::stream_with_retry;
 use crate::cancel::CancelToken;
 use crate::{AgentError, AgentEvent, EventSender, TurnCompleteEvent};
 
-pub(super) const CONTINUE_AFTER_COMPACT: &str = "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed. If the summary contains a todo list, restore it with todo_write and keep it updated. If you learned important project context during this session, consider saving it to memory before it's lost.";
+const CONTINUE_AFTER_COMPACT: &str = "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed. If the summary contains a todo list, restore it with todo_write and keep it updated. If you learned important project context during this session, consider saving it to memory before it's lost.";
 const IMAGE_PLACEHOLDER: &str = "[image]";
+
+fn normalize(text: &Option<String>) -> Option<&str> {
+    text.as_deref().map(str::trim).filter(|t| !t.is_empty())
+}
+
+pub(super) fn continue_message(config: &AgentConfig) -> String {
+    match normalize(&config.post_compaction_instructions) {
+        Some(extra) => format!("{CONTINUE_AFTER_COMPACT}\n\n{extra}"),
+        None => CONTINUE_AFTER_COMPACT.to_string(),
+    }
+}
 
 pub(super) async fn compact_history(
     provider: &dyn maki_providers::provider::Provider,
@@ -20,6 +31,7 @@ pub(super) async fn compact_history(
     history: &mut History,
     event_tx: &EventSender,
     cancel: &CancelToken,
+    config: &AgentConfig,
 ) -> Result<TokenUsage, AgentError> {
     let compact_start = std::time::Instant::now();
     let mut compaction_history: Vec<Message> = history.as_slice().to_vec();
@@ -27,7 +39,14 @@ pub(super) async fn compact_history(
     strip_images(&mut compaction_history);
     strip_thinking(&mut compaction_history);
     strip_old_tool_results(&mut compaction_history);
-    compaction_history.push(Message::user(crate::prompt::COMPACTION_USER.to_string()));
+    let summary_prompt = match normalize(&config.compaction_instructions) {
+        Some(extra) => format!(
+            "{}\n\nAdditional instructions:\n{extra}",
+            crate::prompt::COMPACTION_USER
+        ),
+        None => crate::prompt::COMPACTION_USER.to_string(),
+    };
+    compaction_history.push(Message::user(summary_prompt));
 
     let empty_tools = serde_json::json!([]);
     let max_attempts = 3;
@@ -107,9 +126,13 @@ pub async fn compact(
     model: &Model,
     history: &mut History,
     event_tx: &EventSender,
+    config: &AgentConfig,
 ) -> Result<(), AgentError> {
     let cancel = CancelToken::none();
-    let usage = compact_history(provider, model, history, event_tx, &cancel).await?;
+    let usage = compact_history(provider, model, history, event_tx, &cancel, config).await?;
+    if let Some(post) = normalize(&config.post_compaction_instructions) {
+        history.push(Message::synthetic(post.to_string()));
+    }
 
     event_tx.send(AgentEvent::Done {
         usage,
@@ -309,6 +332,7 @@ mod tests {
                 &model,
                 &mut history,
                 &EventSender::new(raw_tx, 0),
+                &AgentConfig::default(),
             )
             .await
             .unwrap();
@@ -318,6 +342,51 @@ mod tests {
             assert!(matches!(msgs[0].role, Role::User));
             assert!(matches!(msgs[1].role, Role::Assistant));
         });
+    }
+
+    #[test]
+    fn compact_applies_custom_instructions() {
+        smol::block_on(async {
+            const EXTRA: &str = "Record anything that belongs in plan.md";
+            const POST: &str = "Re-read plan.md and agent.md";
+
+            let provider = MockProvider::new(vec![Ok(text_response(StopReason::EndTurn))]);
+            let mut history = History::new(vec![Message::user("work".into())]);
+            let (raw_tx, _rx) = flume::unbounded();
+            let config = AgentConfig {
+                compaction_instructions: Some(EXTRA.into()),
+                post_compaction_instructions: Some(POST.into()),
+                ..Default::default()
+            };
+
+            compact(
+                &provider,
+                &default_model(),
+                &mut history,
+                &EventSender::new(raw_tx, 0),
+                &config,
+            )
+            .await
+            .unwrap();
+
+            let requests = provider.requests.lock().unwrap();
+            let summary_prompt = requests[0].last().unwrap();
+            assert!(matches!(
+                &summary_prompt.content[0],
+                ContentBlock::Text { text }
+                    if text.starts_with(crate::prompt::COMPACTION_USER) && text.ends_with(EXTRA)
+            ));
+            assert!(matches!(
+                &history.as_slice().last().unwrap().content[0],
+                ContentBlock::Text { text } if text == POST
+            ));
+        });
+    }
+
+    #[test_case(Some("  \n ".into()), None ; "whitespace_only_is_none")]
+    #[test_case(Some("  keep plan.md ".into()), Some("keep plan.md") ; "trimmed")]
+    fn normalize_instructions(raw: Option<String>, expected: Option<&str>) {
+        assert_eq!(normalize(&raw), expected);
     }
 
     #[test]
@@ -353,6 +422,7 @@ mod tests {
                 &mut history,
                 &EventSender::new(raw_tx, 0),
                 &CancelToken::none(),
+                &AgentConfig::default(),
             )
             .await
             .unwrap();
@@ -579,6 +649,7 @@ mod tests {
                 &mut history,
                 &EventSender::new(raw_tx, 0),
                 &CancelToken::none(),
+                &AgentConfig::default(),
             )
             .await
             .unwrap();
@@ -620,6 +691,7 @@ mod tests {
                 &mut history,
                 &EventSender::new(raw_tx, 0),
                 &CancelToken::none(),
+                &AgentConfig::default(),
             )
             .await
             .unwrap();

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -9,7 +9,7 @@ use maki_providers::{
     ContentBlock, Message, Model, RequestOptions, Role, StopReason, StreamResponse, TokenUsage,
 };
 
-use super::compaction::{self, CONTINUE_AFTER_COMPACT};
+use super::compaction;
 use super::history::{History, sanitize_cancelled_history};
 use super::instructions::LoadedInstructions;
 use super::streaming::stream_with_retry;
@@ -488,12 +488,15 @@ impl<'h> Agent<'h> {
             self.history,
             &self.event_tx,
             &self.cancel,
+            &self.config,
         )
         .await?;
         self.rollback_len = self.history.len();
         self.event_tx.send(AgentEvent::CompactionDone)?;
         self.history
-            .push(Message::synthetic(CONTINUE_AFTER_COMPACT.into()));
+            .push(Message::synthetic(compaction::continue_message(
+                &self.config,
+            )));
         Ok(())
     }
 
@@ -998,6 +1001,27 @@ mod tests {
                 )),
                 expected,
             );
+        });
+    }
+
+    #[test]
+    fn do_compact_appends_post_instructions_to_continue_message() {
+        smol::block_on(async {
+            const POST: &str = "Re-read plan.md";
+            let mut history = History::new(vec![Message::user("go".into())]);
+            let (mut agent, _event_rx) = make_agent(
+                MockProvider::new(vec![text_response(StopReason::EndTurn)]),
+                &mut history,
+            );
+            agent.config.post_compaction_instructions = Some(POST.into());
+            agent.do_compact().await.unwrap();
+            drop(agent);
+
+            let last = history.as_slice().last().unwrap();
+            assert!(matches!(
+                &last.content[0],
+                ContentBlock::Text { text } if text.ends_with(POST) && text != POST
+            ));
         });
     }
 

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -458,6 +458,8 @@ pub struct AgentFileConfig {
     pub max_output_lines: Option<usize>,
     pub max_continuation_turns: Option<u32>,
     pub compaction_buffer: Option<CompactionBuffer>,
+    pub compaction_instructions: Option<String>,
+    pub post_compaction_instructions: Option<String>,
     pub stale_read_check: Option<bool>,
 }
 
@@ -470,6 +472,8 @@ impl AgentFileConfig {
             max_output_lines,
             max_continuation_turns,
             compaction_buffer,
+            compaction_instructions,
+            post_compaction_instructions,
             stale_read_check
         );
     }
@@ -983,6 +987,20 @@ pub struct AgentConfig {
     pub compaction_buffer: CompactionBuffer,
 
     #[config(
+        ty = "String",
+        default = "None",
+        desc = "Extra instructions appended to the compaction summary prompt"
+    )]
+    pub compaction_instructions: Option<String>,
+
+    #[config(
+        ty = "String",
+        default = "None",
+        desc = "Extra instructions the agent receives after any compaction (e.g. re-read plan.md)"
+    )]
+    pub post_compaction_instructions: Option<String>,
+
+    #[config(
         default = true,
         desc = "Require re-reading a file that changed on disk before editing it"
     )]
@@ -1011,6 +1029,8 @@ impl AgentConfig {
                 .max_continuation_turns
                 .unwrap_or(DEFAULT_MAX_CONTINUATION_TURNS),
             compaction_buffer: file.compaction_buffer.unwrap_or(DEFAULT_COMPACTION_BUFFER),
+            compaction_instructions: file.compaction_instructions,
+            post_compaction_instructions: file.post_compaction_instructions,
             stale_read_check: file.stale_read_check.unwrap_or(true),
             max_turns: None,
             allowed_tools: Vec::new(),

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -2114,7 +2114,11 @@ fn setup_all_sections_at_once() {
                 always_fast = true,
                 always_thinking = "adaptive",
                 ui = { splash_animation = false, mouse_scroll_lines = 5 },
-                agent = { max_output_lines = 9000 },
+                agent = {
+                    max_output_lines = 9000,
+                    compaction_instructions = "Note plan.md",
+                    post_compaction_instructions = "Re-read plan.md",
+                },
                 provider = { default_model = "anthropic/claude-opus-4-6" },
                 storage = { max_log_files = 3 },
                 plugins = { bash = { enabled = true, timeout_secs = 180 }, websearch = { enabled = false } },
@@ -2134,6 +2138,14 @@ fn setup_all_sections_at_once() {
     assert_eq!(raw.ui.splash_animation, Some(false));
     assert_eq!(raw.ui.mouse_scroll_lines, Some(5));
     assert_eq!(raw.agent.max_output_lines, Some(9000));
+    assert_eq!(
+        raw.agent.compaction_instructions.as_deref(),
+        Some("Note plan.md")
+    );
+    assert_eq!(
+        raw.agent.post_compaction_instructions.as_deref(),
+        Some("Re-read plan.md")
+    );
     assert_eq!(
         raw.provider.default_model.as_deref(),
         Some("anthropic/claude-opus-4-6")

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -164,7 +164,14 @@ impl AgentLoop {
         let slot = self.model_slot.load();
         let (provider, model) =
             agent::resolve_compaction_model(&slot.provider, &slot.model, self.timeouts);
-        agent::compact(&*provider, &model, &mut self.history, event_tx).await
+        agent::compact(
+            &*provider,
+            &model,
+            &mut self.history,
+            event_tx,
+            &self.config,
+        )
+        .await
     }
 
     async fn do_agent_run(

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -104,6 +104,8 @@ How many lines of output to show per tool in the UI. All values are `usize` with
 | `max_output_lines` | usize | `2000` | 10 | Max tool output lines |
 | `max_continuation_turns` | u32 | `3` | 1 | Max automatic continuation turns |
 | `compaction_buffer` | u32 \| string | `20%` | - | Context reserved for compaction: token count or percent of the context window (e.g. "20%") |
+| `compaction_instructions` | String | `none` | - | Extra instructions appended to the compaction summary prompt |
+| `post_compaction_instructions` | String | `none` | - | Extra instructions the agent receives after any compaction (e.g. re-read plan.md) |
 | `stale_read_check` | bool | `true` | - | Require re-reading a file that changed on disk before editing it |
 
 ### `provider`


### PR DESCRIPTION
Compaction could silently drop context that users keep in files like `plan.md`, and after auto-compact the agent resumed without reloading them.

New `agent.compaction_instructions` gets appended to the summary prompt, so the summary captures what should be persisted.

New `agent.post_compaction_instructions` gets appended to the resume message, where the agent has tools again and can save and re-read project files.

Both merge across global and project config and work through `maki.setup`.

Closes #747.