### PR TITLE
fix(providers): floor thinking at minimal for models that require it

### DIFF
--- a/maki-config/src/providers.rs
+++ b/maki-config/src/providers.rs
@@ -41,6 +41,8 @@ pub struct ModelDef {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub supports_thinking: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requires_thinking: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub supports_vision: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pricing_input: Option<f64>,

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -206,6 +206,7 @@ supports_vision = false
 | `max_output_tokens` | u32 | protocol default | Max completion tokens |
 | `supports_tool_examples` | bool | protocol default | |
 | `supports_thinking` | bool | protocol default | |
+| `requires_thinking` | bool | false | For APIs that reject requests with thinking disabled. Implies `supports_thinking` and raises thinking to minimal effort when off (including compaction) |
 | `supports_vision` | bool | protocol default | When false, image input and `view_image` are off |
 | `pricing_input` / `pricing_output` | f64 | 0 | USD per 1M tokens |
 | `pricing_cache_write` / `pricing_cache_read` | f64 | 0 | USD per 1M tokens |
@@ -248,7 +249,7 @@ If your provider serves models not in the base catalog, add a `models` subcomman
 [{{"id": "my-model-v2", "tier": "strong", "context_window": 200000, "max_output_tokens": 16384}}]
 ```
 
-Only `id` is required. Optional fields: `tier` (default `medium`), `context_window` (128K), `max_output_tokens` (16K), `pricing` (`{{input, output, cache_write, cache_read}}`, all per 1M tokens), `supports_tool_examples` (defaults to the base provider's setting), `supports_thinking` (defaults to the base provider's setting), `supports_vision` (defaults to the base provider's setting; when false, image input and the `view_image` tool are disabled). The first model listed per tier is used for sub-agents. Without this subcommand, the base provider's models are used.
+Only `id` is required. Optional fields: `tier` (default `medium`), `context_window` (128K), `max_output_tokens` (16K), `pricing` (`{{input, output, cache_write, cache_read}}`, all per 1M tokens), `supports_tool_examples` (defaults to the base provider's setting), `supports_thinking` (defaults to the base provider's setting), `requires_thinking` (default false; for APIs that reject requests with thinking off, raises it to minimal effort and implies `supports_thinking`), `supports_vision` (defaults to the base provider's setting; when false, image input and the `view_image` tool are disabled). The first model listed per tier is used for sub-agents. Without this subcommand, the base provider's models are used.
 
 Dynamic provider models are namespaced as `{{slug}}/{{model_id}}` (e.g. `myproxy/claude-sonnet-4-6`).
 

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -10,7 +10,7 @@ pub(crate) mod types;
 pub use error::AgentError;
 pub use model::{
     FastPricing, Model, ModelEntry, ModelError, ModelFamily, ModelInfo, ModelPricing, ModelTier,
-    TokenUsage, add_cost, format_tokens,
+    ThinkingSupport, TokenUsage, add_cost, format_tokens,
 };
 pub use providers::Timeouts;
 pub use providers::catalog::ProviderData;

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -201,6 +201,28 @@ impl ModelFamily {
 
 const FAST_PROVIDER: &str = "anthropic";
 
+/// `Required` marks APIs that reject requests with thinking disabled;
+/// [`crate::RequestOptions::clamped`] raises `Off` to minimal effort for them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThinkingSupport {
+    No,
+    Yes,
+    Required,
+}
+
+impl ThinkingSupport {
+    /// `requires` wins: an API that rejects thinking-off requests
+    /// necessarily supports thinking.
+    pub fn from_flags(supports: Option<bool>, requires: bool) -> Option<Self> {
+        match (requires, supports) {
+            (true, _) => Some(Self::Required),
+            (false, Some(true)) => Some(Self::Yes),
+            (false, Some(false)) => Some(Self::No),
+            (false, None) => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Model {
     pub id: String,
@@ -208,7 +230,8 @@ pub struct Model {
     pub tier: ModelTier,
     pub family: ModelFamily,
     pub supports_tool_examples_override: Option<bool>,
-    pub supports_thinking_override: Option<bool>,
+    /// `None` falls back to discovery, then the provider manifest.
+    pub thinking_override: Option<ThinkingSupport>,
     pub supports_vision_override: Option<bool>,
     pub pricing: ModelPricing,
     /// `None` when unknown, see [`ProviderKind::fallback_max_output`].
@@ -248,7 +271,7 @@ impl Model {
             tier,
             family,
             supports_tool_examples_override: None,
-            supports_thinking_override: None,
+            thinking_override: None,
             supports_vision_override: None,
             pricing,
             max_output_tokens,
@@ -272,7 +295,7 @@ impl Model {
             tier: ModelTier::Medium,
             family: ModelFamily::Generic,
             supports_tool_examples_override: None,
-            supports_thinking_override: Some(meta.supports_thinking),
+            thinking_override: ThinkingSupport::from_flags(Some(meta.supports_thinking), false),
             supports_vision_override: Some(meta.supports_vision),
             pricing: ModelPricing {
                 input: meta.input_price,
@@ -287,8 +310,8 @@ impl Model {
     }
 
     pub fn supports_thinking(&self) -> bool {
-        if let Some(thinking) = self.supports_thinking_override {
-            return thinking;
+        if let Some(thinking) = self.thinking_override {
+            return thinking != ThinkingSupport::No;
         }
         // Discovery keys `known_models` by the builtin slug; resolve dynamic
         // and custom slugs through their base manifest before looking up.
@@ -301,6 +324,10 @@ impl Model {
             .discovered(manifest.slug, &self.id)
             .and_then(|d| d.supports_thinking)
             .unwrap_or(manifest.supports_thinking)
+    }
+
+    pub fn requires_thinking(&self) -> bool {
+        self.thinking_override == Some(ThinkingSupport::Required)
     }
 
     pub fn supports_vision(&self) -> bool {

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -12,7 +12,7 @@ use super::ResolvedAuth;
 use super::openai::responses;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use crate::manifest::ManifestRegistry;
-use crate::model::{FastPricing, Model, ModelPricing, ModelTier};
+use crate::model::{FastPricing, Model, ModelPricing, ModelTier, ThinkingSupport};
 use crate::provider::{BoxFuture, Provider, ProviderKind};
 use crate::providers::Timeouts;
 use crate::types::ThinkingConfig;
@@ -117,9 +117,12 @@ fn model_from_def(def: &ProviderDef, kind: ProviderKind, slug: &str, model_id: &
         .and_then(|m| m.context_window)
         .unwrap_or_else(|| kind.fallback_context_window());
     let supports_tool_examples_override = declared.and_then(|m| m.supports_tool_examples);
-    let supports_thinking_override = declared
-        .and_then(|m| m.supports_thinking)
-        .or_else(|| ManifestRegistry::get(&kind.to_string()).map(|m| m.supports_thinking));
+    let thinking_override = ThinkingSupport::from_flags(
+        declared
+            .and_then(|m| m.supports_thinking)
+            .or_else(|| ManifestRegistry::get(&kind.to_string()).map(|m| m.supports_thinking)),
+        declared.and_then(|m| m.requires_thinking).unwrap_or(false),
+    );
     let supports_vision_override = declared.and_then(|m| m.supports_vision);
     let pricing = declared
         .filter(|m| m.has_pricing())
@@ -142,7 +145,7 @@ fn model_from_def(def: &ProviderDef, kind: ProviderKind, slug: &str, model_id: &
         tier,
         family: kind.family(),
         supports_tool_examples_override,
-        supports_thinking_override,
+        thinking_override,
         supports_vision_override,
         pricing,
         max_output_tokens,

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -15,7 +15,7 @@ use strum::IntoEnumIterator;
 use tracing::{debug, warn};
 
 use crate::manifest::ManifestRegistry;
-use crate::model::{Model, ModelPricing, ModelTier};
+use crate::model::{Model, ModelPricing, ModelTier, ThinkingSupport};
 use crate::provider::{BoxFuture, Provider, ProviderKind};
 use crate::{AgentError, Message, ProviderEvent, ProviderUsage, RequestOptions, StreamResponse};
 
@@ -67,6 +67,8 @@ struct ScriptModel {
     #[serde(default)]
     supports_thinking: Option<bool>,
     #[serde(default)]
+    requires_thinking: bool,
+    #[serde(default)]
     supports_vision: Option<bool>,
     #[serde(default = "default_max_output_tokens")]
     max_output_tokens: u32,
@@ -84,7 +86,10 @@ impl ScriptModel {
             tier,
             family: base.family(),
             supports_tool_examples_override: self.supports_tool_examples,
-            supports_thinking_override: self.supports_thinking,
+            thinking_override: ThinkingSupport::from_flags(
+                self.supports_thinking,
+                self.requires_thinking,
+            ),
             supports_vision_override: self.supports_vision,
             pricing: self.pricing.clone().unwrap_or_default(),
             max_output_tokens: Some(self.max_output_tokens),

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -699,7 +699,7 @@ mod tests {
             family: ModelFamily::Gemini,
             supports_vision_override: Some(true),
             supports_tool_examples_override: None,
-            supports_thinking_override: None,
+            thinking_override: None,
             pricing: ModelPricing::default(),
             max_output_tokens: Some(8192),
             context_window: 1_048_576,

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -4,7 +4,7 @@ use flume::Sender;
 use maki_storage::id::SessionRef;
 use serde_json::{Value, json};
 
-use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
+use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier, ThinkingSupport};
 use crate::provider::{BoxFuture, Provider};
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
@@ -277,7 +277,7 @@ impl Provider for Mistral {
 
 fn adjust_model(model: &mut Model) {
     if model.id.starts_with("ministral-") {
-        model.supports_thinking_override = Some(false);
+        model.thinking_override = Some(ThinkingSupport::No);
     }
 }
 

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -321,7 +321,7 @@ mod tests {
             tier: crate::model::ModelTier::Medium,
             family: crate::model::ModelFamily::Generic,
             supports_tool_examples_override: None,
-            supports_thinking_override: None,
+            thinking_override: None,
             supports_vision_override: None,
             pricing: ModelPricing::default(),
             max_output_tokens: Some(8192),

--- a/maki-providers/src/providers/zai/mod.rs
+++ b/maki-providers/src/providers/zai/mod.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use tracing::warn;
 
-use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
+use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier, ThinkingSupport};
 use crate::provider::{BoxFuture, Provider};
 use crate::providers::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use crate::{
@@ -355,7 +355,7 @@ impl Provider for Zai {
 
 fn adjust_model(model: &mut Model) {
     if model.id.starts_with("glm-5.2") {
-        model.supports_thinking_override = Some(true);
+        model.thinking_override = Some(ThinkingSupport::Yes);
     }
 }
 

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -653,15 +653,18 @@ pub struct RequestOptions {
 }
 
 impl RequestOptions {
-    /// Strips options the model does not support. Called once before every
-    /// request so UI state, restored sessions, and subagent flags all go
-    /// through the same gate.
+    /// Reconciles options with the model's capabilities. Called once before
+    /// every request so UI state, restored sessions, and subagent flags all go
+    /// through the same gate. Despite the name, thinking clamps both ways:
+    /// down to `Off` when unsupported, up to minimal effort when required.
     pub fn clamped(self, model: &crate::model::Model) -> Self {
         Self {
-            thinking: if model.supports_thinking() {
-                self.thinking
-            } else {
+            thinking: if !model.supports_thinking() {
                 ThinkingConfig::Off
+            } else if model.requires_thinking() && !self.thinking.is_enabled() {
+                ThinkingConfig::Effort(Effort::Minimal)
+            } else {
+                self.thinking
             },
             fast: self.fast && model.supports_fast(),
         }
@@ -707,6 +710,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use crate::model::ThinkingSupport as Support;
     use test_case::test_case;
 
     #[test_case("end_turn", StopReason::EndTurn   ; "end_turn")]
@@ -976,7 +980,7 @@ mod tests {
             tier: crate::model::ModelTier::Medium,
             family: provider.family(),
             supports_tool_examples_override: None,
-            supports_thinking_override: None,
+            thinking_override: None,
             supports_vision_override: Some(provider.family().supports_vision()),
             pricing: crate::model::ModelPricing::default(),
             max_output_tokens: Some(8192),
@@ -984,15 +988,18 @@ mod tests {
         }
     }
 
-    #[test_case(None,        ThinkingConfig::Adaptive, ThinkingConfig::Adaptive ; "provider_default_keeps")]
-    #[test_case(Some(false), ThinkingConfig::Adaptive, ThinkingConfig::Off      ; "override_false_clamps")]
+    #[test_case(None,                    ThinkingConfig::Adaptive, ThinkingConfig::Adaptive        ; "provider_default_keeps")]
+    #[test_case(Some(Support::No),       ThinkingConfig::Adaptive, ThinkingConfig::Off             ; "unsupported_clamps_off")]
+    #[test_case(Some(Support::Yes),      ThinkingConfig::Off,      ThinkingConfig::Off             ; "supported_keeps_off")]
+    #[test_case(Some(Support::Required), ThinkingConfig::Off,      ThinkingConfig::Effort(Minimal) ; "required_raises_off_to_minimal")]
+    #[test_case(Some(Support::Required), ThinkingConfig::Adaptive, ThinkingConfig::Adaptive        ; "required_keeps_enabled")]
     fn request_options_clamped_thinking(
-        supports: Option<bool>,
+        thinking_override: Option<Support>,
         thinking: ThinkingConfig,
         expected: ThinkingConfig,
     ) {
         let mut model = clamp_test_model(crate::provider::ProviderKind::Anthropic);
-        model.supports_thinking_override = supports;
+        model.thinking_override = thinking_override;
         let opts = RequestOptions {
             thinking,
             fast: false,

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -3402,7 +3402,7 @@ fn thinking_explicit_args() {
 #[test]
 fn thinking_unsupported_model_flashes_error() {
     let mut app = test_app();
-    app.state.model.supports_thinking_override = Some(false);
+    app.state.model.thinking_override = Some(maki_providers::ThinkingSupport::No);
 
     app.execute_command(cmd("/thinking"));
     assert_eq!(app.state.thinking, ThinkingConfig::Off);

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -389,7 +389,7 @@ pub(crate) fn test_model() -> maki_providers::Model {
         tier: maki_providers::ModelTier::Medium,
         family: maki_providers::ModelFamily::Claude,
         supports_tool_examples_override: None,
-        supports_thinking_override: None,
+        thinking_override: None,
         supports_vision_override: Some(true),
         pricing: test_pricing(),
         max_output_tokens: Some(8192),

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -327,6 +327,7 @@ supports_vision = false
 | `max_output_tokens` | u32 | protocol default | Max completion tokens |
 | `supports_tool_examples` | bool | protocol default | |
 | `supports_thinking` | bool | protocol default | |
+| `requires_thinking` | bool | false | For APIs that reject requests with thinking disabled. Implies `supports_thinking` and raises thinking to minimal effort when off (including compaction) |
 | `supports_vision` | bool | protocol default | When false, image input and `view_image` are off |
 | `pricing_input` / `pricing_output` | f64 | 0 | USD per 1M tokens |
 | `pricing_cache_write` / `pricing_cache_read` | f64 | 0 | USD per 1M tokens |
@@ -382,7 +383,7 @@ If your provider serves models not in the base catalog, add a `models` subcomman
 [{"id": "my-model-v2", "tier": "strong", "context_window": 200000, "max_output_tokens": 16384}]
 ```
 
-Only `id` is required. Optional fields: `tier` (default `medium`), `context_window` (128K), `max_output_tokens` (16K), `pricing` (`{input, output, cache_write, cache_read}`, all per 1M tokens), `supports_tool_examples` (defaults to the base provider's setting), `supports_thinking` (defaults to the base provider's setting), `supports_vision` (defaults to the base provider's setting; when false, image input and the `view_image` tool are disabled). The first model listed per tier is used for sub-agents. Without this subcommand, the base provider's models are used.
+Only `id` is required. Optional fields: `tier` (default `medium`), `context_window` (128K), `max_output_tokens` (16K), `pricing` (`{input, output, cache_write, cache_read}`, all per 1M tokens), `supports_tool_examples` (defaults to the base provider's setting), `supports_thinking` (defaults to the base provider's setting), `requires_thinking` (default false; for APIs that reject requests with thinking off, raises it to minimal effort and implies `supports_thinking`), `supports_vision` (defaults to the base provider's setting; when false, image input and the `view_image` tool are disabled). The first model listed per tier is used for sub-agents. Without this subcommand, the base provider's models are used.
 
 Dynamic provider models are namespaced as `{slug}/{model_id}` (e.g. `myproxy/claude-sonnet-4-6`).
 


### PR DESCRIPTION
Meta AI Muse returns a 400 when a request arrives with thinking disabled, and compaction hardcodes `RequestOptions::default()`, so both auto-compact and `/compact` always failed there (#741).

Instead of patching compaction, teach `clamped()` to clamp both ways: it already lowers thinking to `Off` for models without it, now it also raises `Off` to minimal effort when the model declares the new `requires_thinking` flag.

Every request flows through that one gate, so compaction, subagents, and a manual `/thinking off` all get the floor with no per-call-site fixes.

Users set `requires_thinking = true` on a model in `providers.toml` (or a dynamic provider script), and each dialect snaps minimal to its lowest supported level, so the floor becomes whatever the API actually accepts.

Closes #741.