### PR TITLE
fix(ui): use one clock format everywhere, configurable via ui.clock_format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2770,6 +2770,7 @@ dependencies = [
  "toml",
  "tracing",
  "unicode-width",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ futures-lite = "2"
 futures = "0.3"
 isahc = { version = "1.7", default-features = false, features = ["text-decoding", "static-curl", "static-ssl"] }
 libc = "0.2"
+windows-sys = { version = "0.61", features = ["Win32_Globalization"] }
 nucleo = "0.5"
 nucleo-matcher = "0.3"
 open = "5"

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -325,6 +325,7 @@ pub struct UiFileConfig {
     pub mouse_scroll_lines: Option<u32>,
     pub show_thinking: Option<bool>,
     pub theme: Option<String>,
+    pub clock_format: Option<ClockFormat>,
     pub tool_output_lines: Option<ToolOutputLinesFile>,
     pub max_input_lines: Option<u32>,
 }
@@ -341,6 +342,7 @@ impl UiFileConfig {
             mouse_scroll_lines,
             show_thinking,
             theme,
+            clock_format,
             max_input_lines
         );
         match (self.tool_output_lines.as_mut(), overlay.tool_output_lines) {
@@ -802,6 +804,17 @@ pub struct Config {
     pub plugins: PluginsConfig,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+pub enum ClockFormat {
+    #[serde(rename = "12h")]
+    Hour12,
+    #[serde(rename = "24h")]
+    Hour24,
+    #[default]
+    #[serde(rename = "system")]
+    System,
+}
+
 #[derive(Debug, Clone, ConfigSection)]
 #[config(section = "ui")]
 pub struct UiConfig {
@@ -829,6 +842,9 @@ pub struct UiConfig {
     )]
     pub show_thinking: bool,
 
+    #[config(default = ClockFormat::System, ty = "String", default_doc = "system", desc = "Clock format for timestamps: \"12h\", \"24h\", or \"system\" (follow the OS preference, 24h when unknown)")]
+    pub clock_format: ClockFormat,
+
     #[config(skip, default = "None")]
     pub theme: Option<String>,
 
@@ -852,6 +868,7 @@ impl UiConfig {
             mouse_scroll_lines: f.mouse_scroll_lines.unwrap_or(DEFAULT_MOUSE_SCROLL_LINES),
             max_input_lines: f.max_input_lines.unwrap_or(DEFAULT_MAX_INPUT_LINES),
             show_thinking: f.show_thinking.unwrap_or(true),
+            clock_format: f.clock_format.unwrap_or_default(),
             theme: f.theme,
             tool_output_lines: ToolOutputLines::from_file(f.tool_output_lines),
         }

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -1953,18 +1953,22 @@ fn unloading_plugin_kills_its_jobs() {
     );
     host.load_source("plugin_job", &src).unwrap();
 
+    // The shell creates the redirect target before printf writes to it,
+    // so poll until the file holds a parseable pid, not until it exists.
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    while !pid_path.exists() {
+    let pid = loop {
+        if let Ok(pid) = std::fs::read_to_string(&pid_path)
+            .unwrap_or_default()
+            .parse::<i32>()
+        {
+            break pid;
+        }
         assert!(
             std::time::Instant::now() < deadline,
             "plugin job did not publish its process id"
         );
         std::thread::sleep(Duration::from_millis(10));
-    }
-    let pid = std::fs::read_to_string(&pid_path)
-        .unwrap()
-        .parse::<i32>()
-        .unwrap();
+    };
     let pid = Pid::from_raw(pid).unwrap();
     assert!(test_kill_process_group(pid).is_ok());
 

--- a/maki-ui/Cargo.toml
+++ b/maki-ui/Cargo.toml
@@ -43,6 +43,9 @@ shell-words = { workspace = true }
 open = { workspace = true }
 
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true }
+
 [dev-dependencies]
 test-case = { workspace = true }
 tempfile = { workspace = true }

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -271,6 +271,7 @@ impl App {
                 model: &self.state.model,
                 fast: self.state.fast,
                 quota: quota.as_deref(),
+                clock_format: self.ui_config.clock_format,
             };
             let r = self.usage_modal.view(frame, full, &ctx);
             if r.width > 0 {

--- a/maki-ui/src/clock.rs
+++ b/maki-ui/src/clock.rs
@@ -1,0 +1,81 @@
+use std::sync::OnceLock;
+
+use maki_config::ClockFormat;
+
+pub fn hm(format: ClockFormat) -> &'static str {
+    if is_12h(format) { "%-I:%M %p" } else { "%H:%M" }
+}
+
+pub fn hms(format: ClockFormat) -> &'static str {
+    if is_12h(format) {
+        "%-I:%M:%S %p"
+    } else {
+        "%H:%M:%S"
+    }
+}
+
+fn is_12h(format: ClockFormat) -> bool {
+    static SYSTEM_12H: OnceLock<bool> = OnceLock::new();
+    match format {
+        ClockFormat::Hour12 => true,
+        ClockFormat::Hour24 => false,
+        ClockFormat::System => *SYSTEM_12H.get_or_init(system_uses_12h),
+    }
+}
+
+/// A POSIX `T_FMT` pattern is 12-hour when it renders a 12-hour field:
+/// hour (`%I`, `%l`), AM/PM marker (`%p`), or the whole time (`%r`).
+#[cfg(any(unix, test))]
+fn posix_fmt_is_12h(fmt: &[u8]) -> bool {
+    fmt.windows(2)
+        .any(|w| matches!(w, b"%I" | b"%l" | b"%p" | b"%r"))
+}
+
+#[cfg(unix)]
+fn system_uses_12h() -> bool {
+    use std::ffi::CStr;
+    unsafe {
+        let loc = libc::newlocale(libc::LC_TIME_MASK, c"".as_ptr(), std::ptr::null_mut());
+        if loc.is_null() {
+            return false;
+        }
+        let fmt = libc::nl_langinfo_l(libc::T_FMT, loc);
+        let uses_12h = !fmt.is_null() && posix_fmt_is_12h(CStr::from_ptr(fmt).to_bytes());
+        libc::freelocale(loc);
+        uses_12h
+    }
+}
+
+#[cfg(windows)]
+fn system_uses_12h() -> bool {
+    use windows_sys::Win32::Globalization::{GetLocaleInfoEx, LOCALE_STIMEFORMAT};
+    let mut buf = [0u16; 128];
+    let len = unsafe {
+        GetLocaleInfoEx(
+            std::ptr::null(),
+            LOCALE_STIMEFORMAT,
+            buf.as_mut_ptr(),
+            buf.len() as i32,
+        )
+    };
+    // `len` counts the terminating NUL. Windows patterns spell 24-hour
+    // hours as `H` and 12-hour ones as `h`, so no `H` means 12-hour.
+    len > 1 && !buf[..(len - 1) as usize].contains(&u16::from(b'H'))
+}
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    use super::posix_fmt_is_12h;
+
+    #[test_case(b"%r", true ; "twelve_hour_r")]
+    #[test_case(b"%I:%M:%S %p", true ; "twelve_hour_i_and_p")]
+    #[test_case(b"%l:%M %p", true ; "twelve_hour_l")]
+    #[test_case(b"%T", false ; "twenty_four_hour_t")]
+    #[test_case(b"%H:%M:%S", false ; "twenty_four_hour_h")]
+    #[test_case(b"", false ; "empty_defaults_to_24h")]
+    fn posix_fmt(fmt: &[u8], expected: bool) {
+        assert_eq!(posix_fmt_is_12h(fmt), expected);
+    }
+}

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -22,7 +22,7 @@ use crate::render_worker::RenderWorker;
 use crate::selection::Selection;
 use crate::splash::{ColorTransition, Splash};
 use crate::theme;
-use maki_config::{ToolOutputLines, UiConfig};
+use maki_config::{ClockFormat, ToolOutputLines, UiConfig};
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
@@ -81,6 +81,7 @@ pub struct MessagesPanel {
     restore_event_tx: Option<EventSender>,
     show_thinking: bool,
     thinking_collapsed: bool,
+    clock_format: ClockFormat,
     /// One re-bake per tool per generation; `snapshot_theme_gen`
     /// only bumps when colors actually land.
     rebake_requested: HashMap<String, u64>,
@@ -127,6 +128,7 @@ impl MessagesPanel {
             restore_event_tx: None,
             show_thinking: ui_config.show_thinking,
             thinking_collapsed: !ui_config.show_thinking,
+            clock_format: ui_config.clock_format,
             rebake_requested: HashMap::new(),
             prompt_progress: None,
         }
@@ -176,7 +178,7 @@ impl MessagesPanel {
             name: Arc::from(name),
         }));
         let mut msg = DisplayMessage::new(role, String::new());
-        msg.timestamp = Some(format_timestamp_now());
+        msg.timestamp = Some(format_timestamp_now(self.clock_format));
         self.messages.push(msg);
     }
 
@@ -208,7 +210,7 @@ impl MessagesPanel {
         msg.tool_output = event.output.map(Arc::new);
         msg.annotation = event.annotation;
         msg.render_header = event.render_header;
-        msg.timestamp = Some(format_timestamp_now());
+        msg.timestamp = Some(format_timestamp_now(self.clock_format));
         self.messages.push(msg);
     }
 

--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -5,7 +5,7 @@ use crate::animation::{spinner_frame, spinner_str};
 use crate::theme;
 use code_view::RenderLimits;
 use code_view::SectionFlags;
-use maki_config::ToolOutputLines;
+use maki_config::{ClockFormat, ToolOutputLines};
 
 use std::borrow::Cow;
 use std::fmt::Write;
@@ -160,9 +160,9 @@ impl ToolLines {
     }
 }
 
-pub fn format_timestamp_now() -> String {
+pub fn format_timestamp_now(format: ClockFormat) -> String {
     let zoned = Timestamp::now().to_zoned(TimeZone::system());
-    zoned.strftime("%H:%M:%S").to_string()
+    zoned.strftime(crate::clock::hms(format)).to_string()
 }
 
 pub fn append_right_info(

--- a/maki-ui/src/components/usage_modal.rs
+++ b/maki-ui/src/components/usage_modal.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use crossterm::event::{KeyCode, KeyEvent};
 use jiff::Timestamp;
 use jiff::tz::TimeZone;
+use maki_config::ClockFormat;
 use maki_providers::{Model, ModelPricing, ProviderUsage, TokenUsage, format_tokens};
 use maki_storage::sessions::StoredTokenUsage;
 use ratatui::Frame;
@@ -43,6 +44,7 @@ pub struct UsageModalContext<'a> {
     pub model: &'a Model,
     pub fast: bool,
     pub quota: Option<&'a UsageFetchState>,
+    pub clock_format: ClockFormat,
 }
 
 pub struct UsageModal {
@@ -159,7 +161,7 @@ fn build_lines(ctx: &UsageModalContext, theme: &crate::theme::Theme) -> Vec<Line
             format!("{PREFIX}{} quota", ctx.model.provider_display_name()),
             theme.keybind_section,
         )));
-        lines.extend(quota_lines(state, theme));
+        lines.extend(quota_lines(state, theme, ctx.clock_format));
     }
 
     if ctx.by_model.is_empty() {
@@ -287,7 +289,11 @@ impl crate::components::Overlay for UsageModal {
     }
 }
 
-fn quota_lines(state: &UsageFetchState, theme: &crate::theme::Theme) -> Vec<Line<'static>> {
+fn quota_lines(
+    state: &UsageFetchState,
+    theme: &crate::theme::Theme,
+    clock: ClockFormat,
+) -> Vec<Line<'static>> {
     let fg = Style::new().fg(theme.foreground);
     let dim = theme.status_dim;
     match state {
@@ -330,7 +336,7 @@ fn quota_lines(state: &UsageFetchState, theme: &crate::theme::Theme) -> Vec<Line
                 }
                 if let Some(ms) = limit.reset_at {
                     spans.push(Span::styled(
-                        format!("  Resets {}", format_reset(ms, &tz)),
+                        format!("  Resets {}", format_reset(ms, &tz, clock)),
                         dim,
                     ));
                 }
@@ -341,7 +347,7 @@ fn quota_lines(state: &UsageFetchState, theme: &crate::theme::Theme) -> Vec<Line
     }
 }
 
-fn format_reset(epoch_ms: u64, tz: &TimeZone) -> String {
+fn format_reset(epoch_ms: u64, tz: &TimeZone, clock: ClockFormat) -> String {
     let secs = (epoch_ms / 1000) as i64;
     let Ok(ts) = Timestamp::from_second(secs) else {
         return epoch_ms.to_string();
@@ -351,12 +357,13 @@ fn format_reset(epoch_ms: u64, tz: &TimeZone) -> String {
         return relative(delta);
     }
     let zoned = ts.to_zoned(tz.clone());
+    let clock = crate::clock::hm(clock);
     let fmt = if delta < WEEK {
-        "%a %-I:%M %p"
+        format!("%a {clock}")
     } else {
-        "%b %-d, %-I:%M %p"
+        format!("%b %-d, {clock}")
     };
-    zoned.strftime(fmt).to_string()
+    zoned.strftime(&fmt).to_string()
 }
 
 fn relative(seconds: i64) -> String {
@@ -428,7 +435,7 @@ mod tests {
                 },
             ],
         };
-        let lines = quota_lines(&UsageFetchState::Ready(usage), &theme);
+        let lines = quota_lines(&UsageFetchState::Ready(usage), &theme, ClockFormat::Hour24);
         assert_eq!(lines.len(), 3);
         assert!(
             lines[0]
@@ -462,8 +469,12 @@ mod tests {
     #[test]
     fn quota_non_terminal_states_render_single_line() {
         let theme = crate::theme::current();
-        assert_eq!(quota_lines(&UsageFetchState::Loading, &theme).len(), 1);
-        let unsupported = quota_lines(&UsageFetchState::Unsupported, &theme);
+        let clock = ClockFormat::Hour24;
+        assert_eq!(
+            quota_lines(&UsageFetchState::Loading, &theme, clock).len(),
+            1
+        );
+        let unsupported = quota_lines(&UsageFetchState::Unsupported, &theme, clock);
         assert_eq!(unsupported.len(), 1);
         assert!(
             unsupported[0]
@@ -471,7 +482,7 @@ mod tests {
                 .iter()
                 .any(|s| s.content.contains(NO_USAGE_ENDPOINT))
         );
-        let err = quota_lines(&UsageFetchState::Error("nope".into()), &theme);
+        let err = quota_lines(&UsageFetchState::Error("nope".into()), &theme, clock);
         assert_eq!(err.len(), 1);
         assert!(err[0].spans.iter().any(|s| s.content.contains("nope")));
     }

--- a/maki-ui/src/lib.rs
+++ b/maki-ui/src/lib.rs
@@ -7,6 +7,7 @@ pub mod animation;
 pub mod app;
 pub mod chat;
 mod clipboard;
+mod clock;
 mod color_compat;
 mod components;
 pub use components::command::{BUILTIN_COMMANDS, BuiltinCommand};

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -71,6 +71,7 @@ All fields are optional. Typos in field names cause an error right away.
 | `mouse_scroll_lines` | u32 | `3` | 1 | Lines per mouse wheel scroll |
 | `max_input_lines` | u32 | `20` | 1 | Maximum visible input lines |
 | `show_thinking` | bool | `true` | - | When true (default), show full model reasoning live and persisted. When false, hide reasoning behind an indicator (thinking> ...) with a click-to-expand hint, both while thinking and after it completes |
+| `clock_format` | String | `system` | - | Clock format for timestamps: "12h", "24h", or "system" (follow the OS preference, 24h when unknown) |
 
 ### `ui.theme`
 


### PR DESCRIPTION
The usage modal showed quota resets as 12-hour AM/PM while tool timestamps used 24-hour time, two hard-coded formats that could disagree with each other on the same screen.

Both now go through a small shared `clock` helper driven by the new `ui.clock_format` option (`12h`, `24h`, or `system`), so every user-facing timestamp follows the same clock.

The default is `system`: `nl_langinfo_l(T_FMT)` on Unix and `GetLocaleInfoEx(LOCALE_STIMEFORMAT)` on Windows tell whether the OS clock is 12-hour, falling back to 24h when detection fails.

On macOS this reads the POSIX locale rather than the System Settings toggle, so the explicit `12h`/`24h` overrides stay for anyone the heuristic misses.

Closes #729.