### PR TITLE
fix(providers): stop exposing the model registry lock guard

### DIFF
--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -34,10 +34,8 @@ pub fn resolve_compaction_model(
     timeouts: maki_providers::Timeouts,
     model_policy: &ModelPolicy,
 ) -> (Arc<dyn Provider>, Model) {
-    if let Some(spec) = maki_providers::model_registry::model_registry()
-        .read()
-        .unwrap()
-        .spec_for_tier_any(maki_providers::ModelTier::Compaction)
+    if let Some(spec) =
+        maki_providers::model_registry::spec_for_tier_any(maki_providers::ModelTier::Compaction)
         && model_policy.allows(&spec)
         && let Ok(mut m) = Model::from_spec(&spec)
         && let Ok(p) = maki_providers::provider::from_model(&mut m, timeouts)

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -49,11 +49,8 @@ fn resolve_model_from_ctx(ctx: &AgentContext, tier: Option<&str>) -> Result<Mode
         return Ok(Model::clone(&ctx.model));
     }
     let slug = &ctx.model.provider;
-    let map = maki_providers::model_registry::model_registry()
-        .read()
-        .unwrap();
-    map.spec_for_tier(slug, effective)
-        .or_else(|| map.spec_for_tier_any(effective))
+    maki_providers::model_registry::spec_for_tier(slug, effective)
+        .or_else(|| maki_providers::model_registry::spec_for_tier_any(effective))
         .filter(|spec| ctx.model_policy.allows(spec))
         .and_then(|s| Model::from_spec(&s).ok())
         .map(Ok)

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -14,7 +14,7 @@ use maki_storage::sessions::{MIN_THINKING_BUDGET, StoredTokenUsage};
 use serde::{Deserialize, Serialize};
 
 use crate::manifest::{ManifestRegistry, ProviderManifest};
-use crate::model_registry::model_registry;
+use crate::model_registry;
 use crate::providers::{anthropic, custom, dynamic};
 
 const PER_MILLION: f64 = 1_000_000.0;
@@ -252,9 +252,9 @@ impl Model {
         let spec = format!("{slug}/{model_id}");
         // Discovery keys `known_models` by the builtin slug, so a dynamic or
         // custom slug reads positional tiers and metadata through its base.
-        let guard = model_registry().read().unwrap();
-        let discovered = guard.discovered(manifest.slug, model_id);
-        let tier = guard.tier_for(&spec, manifest.slug, static_entry.map(|e| e.tier));
+        let discovered = model_registry::discovered(manifest.slug, model_id);
+        let discovered = discovered.as_ref();
+        let tier = model_registry::tier_for(&spec, manifest.slug, static_entry.map(|e| e.tier));
         let family = static_entry.map_or(manifest.family, |entry| entry.family);
         let pricing = discovered
             .and_then(|info| info.pricing.clone())
@@ -269,7 +269,6 @@ impl Model {
             .or_else(|| anthropic::shared::long_context_window(model_id))
             .or_else(|| static_entry.map(|entry| entry.context_window))
             .unwrap_or(manifest.fallback_context_window);
-        drop(guard);
         Self {
             id: model_id.to_string(),
             provider: Arc::from(slug),
@@ -323,10 +322,7 @@ impl Model {
         let Some(manifest) = ManifestRegistry::for_slug(&self.provider) else {
             return false;
         };
-        model_registry()
-            .read()
-            .unwrap()
-            .discovered(manifest.slug, &self.id)
+        model_registry::discovered(manifest.slug, &self.id)
             .and_then(|d| d.supports_thinking)
             .unwrap_or(manifest.supports_thinking)
     }
@@ -342,11 +338,7 @@ impl Model {
         let manifest = ManifestRegistry::for_slug(&self.provider);
         manifest
             .and_then(|m| {
-                model_registry()
-                    .read()
-                    .unwrap()
-                    .discovered(m.slug, &self.id)
-                    .and_then(|d| d.supports_vision)
+                model_registry::discovered(m.slug, &self.id).and_then(|d| d.supports_vision)
             })
             .or_else(|| {
                 manifest
@@ -395,7 +387,7 @@ impl Model {
     }
 
     pub fn from_tier(slug: &str, tier: ModelTier) -> Result<Self, ModelError> {
-        if let Some(spec) = model_registry().read().unwrap().spec_for_tier(slug, tier) {
+        if let Some(spec) = model_registry::spec_for_tier(slug, tier) {
             return Self::from_spec(&spec);
         }
         let entry = ManifestRegistry::find_default_for_tier(slug, tier)
@@ -1005,34 +997,19 @@ mod tests {
     fn discovered_context_window_flows_into_from_base_for_unknown_model() {
         use crate::model::ModelInfo;
 
-        let slug: Arc<str> = Arc::from("ollama");
         let model_id = "test-discovered-context-window-model";
         let expected_window: u32 = 131_072;
 
-        // Seed discovered metadata into the global registry
-        {
-            let mut reg = model_registry().write().unwrap();
-            reg.set_known_models(
-                &slug,
-                vec![ModelInfo {
-                    id: model_id.to_string(),
-                    context_window: Some(expected_window),
-                    max_output_tokens: None,
-                    pricing: None,
-                    supports_thinking: None,
-                    supports_vision: None,
-                    tier: None,
-                    provider_info: None,
-                }],
-            );
-        }
+        model_registry::set_known_models(
+            "ollama",
+            vec![ModelInfo {
+                context_window: Some(expected_window),
+                ..ModelInfo::id_only(model_id.to_string())
+            }],
+        );
 
-        // from_base for this unknown model should pick up the discovered context_window
         let model = Model::from_base(ManifestRegistry::get("ollama").unwrap(), "ollama", model_id);
-        assert_eq!(model.id, model_id);
         assert_eq!(model.context_window, expected_window);
-        // max_output_tokens falls back to provider default since not discovered
-        assert_eq!(model.max_output_tokens, Some(16_384));
 
         // A dynamic/custom slug shares its base provider's discovery.
         let wrapped = Model::from_base(

--- a/maki-providers/src/model_registry.rs
+++ b/maki-providers/src/model_registry.rs
@@ -7,13 +7,15 @@
 //! Discovered metadata (context windows, pricing) from `/models` endpoints is
 //! stored in `known_models` and consulted by [`crate::model::Model::from_base`].
 //!
-//! All reads and writes go through [`model_registry`]. The module owns
+//! The global lock never escapes this module: accessors lock internally and
+//! return owned data, so a caller can never hold a read guard across model
+//! construction (recursive read + queued writer = deadlock). The module owns
 //! persistence: [`load_from_storage`] at startup, [`set_and_persist`] on user
 //! edits. Callers never touch the on-disk format directly.
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::{Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use maki_storage::{StateDir, atomic_write};
 use tracing::warn;
@@ -24,89 +26,123 @@ const TIERS_FILE: &str = "model-tiers";
 
 static REGISTRY: OnceLock<RwLock<ModelRegistry>> = OnceLock::new();
 
-pub fn model_registry() -> &'static RwLock<ModelRegistry> {
+fn read() -> RwLockReadGuard<'static, ModelRegistry> {
+    registry().read().unwrap()
+}
+
+fn write() -> RwLockWriteGuard<'static, ModelRegistry> {
+    registry().write().unwrap()
+}
+
+fn registry() -> &'static RwLock<ModelRegistry> {
     REGISTRY.get_or_init(|| RwLock::new(ModelRegistry::default()))
+}
+
+pub fn spec_for_tier(provider: &str, tier: ModelTier) -> Option<String> {
+    read().spec_for_tier(provider, tier)
+}
+
+pub fn spec_for_tier_any(tier: ModelTier) -> Option<String> {
+    read().spec_for_tier_any(tier)
+}
+
+pub fn discovered(provider: &str, model_id: &str) -> Option<ModelInfo> {
+    read().discovered(provider, model_id).cloned()
+}
+
+/// Typed `provider_info` for a discovered model. Key by the builtin slug, not
+/// `model.provider`: a dynamic wrap's model carries its own slug.
+pub fn provider_info<T: Send + Sync + 'static>(provider: &str, model_id: &str) -> Option<Arc<T>> {
+    let info = read()
+        .discovered(provider, model_id)?
+        .provider_info
+        .clone()?;
+    Arc::downcast(info).ok()
+}
+
+pub fn tier_for(spec: &str, provider: &str, static_tier: Option<ModelTier>) -> ModelTier {
+    read().tier_for(spec, provider, static_tier)
+}
+
+pub fn set_known_models(provider: &str, models: Vec<ModelInfo>) {
+    write().set_known_models(provider, models);
+}
+
+/// Tiers whose override points at `spec`, in descending tier order.
+pub fn override_tiers(spec: &str) -> Vec<ModelTier> {
+    read().override_tiers(spec)
 }
 
 pub fn load_from_storage(dir: &StateDir) {
     let overrides = read_overrides(dir.path().join(TIERS_FILE).as_path());
-    model_registry().write().unwrap().set_overrides(overrides);
+    write().set_overrides(overrides);
 }
 
 pub fn set_and_persist(spec: String, tier: ModelTier, dir: &StateDir) {
-    let snapshot = {
-        let mut reg = model_registry().write().unwrap();
-        reg.set(spec, tier);
-        reg.overrides.clone()
-    };
-    write_overrides(dir.path().join(TIERS_FILE).as_path(), &snapshot);
+    update_and_persist(dir, |reg| reg.set(spec, tier));
 }
 
 pub fn unset_and_persist(spec: &str, tier: ModelTier, dir: &StateDir) {
+    update_and_persist(dir, |reg| reg.unset(spec, tier));
+}
+
+/// Snapshot under the lock, persist outside it: file IO must never run while
+/// holding the registry lock.
+fn update_and_persist(dir: &StateDir, update: impl FnOnce(&mut ModelRegistry)) {
     let snapshot = {
-        let mut reg = model_registry().write().unwrap();
-        reg.unset(spec, tier);
+        let mut reg = write();
+        update(&mut reg);
         reg.overrides.clone()
     };
     write_overrides(dir.path().join(TIERS_FILE).as_path(), &snapshot);
 }
 
 #[derive(Debug, Default)]
-pub struct ModelRegistry {
+struct ModelRegistry {
     /// Keyed by tier (not spec) so inserting a model automatically evicts the
     /// previous holder. Persisted to disk.
     overrides: BTreeMap<ModelTier, String>,
     /// Ordered model info per provider, populated from `list_models()`.
     /// Not persisted - rebuilt every session. Used for auto-tier assignment
     /// and discovered metadata lookup.
-    known_models: HashMap<Arc<str>, Vec<ModelInfo>>,
+    known_models: HashMap<String, Vec<ModelInfo>>,
 }
 
 impl ModelRegistry {
-    pub fn set_overrides(&mut self, overrides: BTreeMap<ModelTier, String>) {
+    fn set_overrides(&mut self, overrides: BTreeMap<ModelTier, String>) {
         self.overrides = overrides;
     }
 
-    pub fn set_known_models(&mut self, provider: &Arc<str>, models: Vec<ModelInfo>) {
-        self.known_models.insert(Arc::clone(provider), models);
+    fn set_known_models(&mut self, provider: &str, models: Vec<ModelInfo>) {
+        self.known_models.insert(provider.to_string(), models);
     }
 
-    pub fn set(&mut self, spec: String, tier: ModelTier) {
+    fn set(&mut self, spec: String, tier: ModelTier) {
         self.overrides.insert(tier, spec);
     }
 
-    pub fn unset(&mut self, spec: &str, tier: ModelTier) {
-        if self.overrides.get(&tier).map(String::as_str) == Some(spec) {
+    fn unset(&mut self, spec: &str, tier: ModelTier) {
+        if self.has_override(spec, tier) {
             self.overrides.remove(&tier);
         }
     }
 
-    pub fn has_override(&self, spec: &str, tier: ModelTier) -> bool {
+    fn has_override(&self, spec: &str, tier: ModelTier) -> bool {
         self.overrides.get(&tier).map(String::as_str) == Some(spec)
     }
 
     /// Lookup discovered metadata for a model by ID.
-    pub fn discovered(&self, provider: &str, model_id: &str) -> Option<&ModelInfo> {
+    fn discovered(&self, provider: &str, model_id: &str) -> Option<&ModelInfo> {
         self.known_models
             .get(provider)?
             .iter()
             .find(|m| m.id == model_id)
     }
 
-    pub fn tier_for(
-        &self,
-        spec: &str,
-        provider: &str,
-        static_tier: Option<ModelTier>,
-    ) -> ModelTier {
+    fn tier_for(&self, spec: &str, provider: &str, static_tier: Option<ModelTier>) -> ModelTier {
         // A spec may hold several tiers; prefer the strongest agent tier,
         // falling back to Compaction only when it is the sole assignment.
-        let mut tiers = self
-            .overrides
-            .iter()
-            .rev()
-            .filter(|(_, s)| s.as_str() == spec)
-            .map(|(&t, _)| t);
+        let mut tiers = self.override_tiers(spec).into_iter();
         if let Some(first) = tiers.next() {
             return match first {
                 ModelTier::Compaction => tiers.next().unwrap_or(first),
@@ -132,7 +168,7 @@ impl ModelRegistry {
         ModelTier::Medium
     }
 
-    pub fn spec_for_tier(&self, provider: &str, tier: ModelTier) -> Option<String> {
+    fn spec_for_tier(&self, provider: &str, tier: ModelTier) -> Option<String> {
         let prefix = format!("{provider}/");
         if let Some(spec) = self.overrides.get(&tier)
             && spec.starts_with(&prefix)
@@ -186,7 +222,7 @@ impl ModelRegistry {
         self.overrides.iter().any(|(&t, s)| s == spec && t != tier)
     }
 
-    pub fn spec_for_tier_any(&self, tier: ModelTier) -> Option<String> {
+    fn spec_for_tier_any(&self, tier: ModelTier) -> Option<String> {
         if let Some(spec) = self.overrides.get(&tier) {
             return Some(spec.clone());
         }
@@ -198,15 +234,13 @@ impl ModelRegistry {
         None
     }
 
-    pub fn override_tier_label(&self, spec: &str) -> Option<String> {
-        let tiers: Vec<_> = self
-            .overrides
+    fn override_tiers(&self, spec: &str) -> Vec<ModelTier> {
+        self.overrides
             .iter()
             .rev()
             .filter(|(_, s)| s.as_str() == spec)
-            .map(|(t, _)| t.to_string())
-            .collect();
-        (!tiers.is_empty()).then(|| tiers.join("/"))
+            .map(|(&t, _)| t)
+            .collect()
     }
 }
 
@@ -277,7 +311,7 @@ mod tests {
         reg.set_overrides(overrides.iter().map(|(t, s)| (*t, s.to_string())).collect());
         if !models.is_empty() {
             reg.set_known_models(
-                &Arc::<str>::from("ollama"),
+                "ollama",
                 models
                     .iter()
                     .map(|s| ModelInfo::id_only(s.to_string()))
@@ -305,7 +339,7 @@ mod tests {
     fn make_tiered(models: &[(&str, ModelTier)]) -> ModelRegistry {
         let mut reg = ModelRegistry::default();
         reg.set_known_models(
-            &Arc::<str>::from("copilot"),
+            "copilot",
             models
                 .iter()
                 .map(|&(id, tier)| ModelInfo {
@@ -433,33 +467,17 @@ mod tests {
     fn discovered_looks_up_by_id() {
         let mut reg = ModelRegistry::default();
         reg.set_known_models(
-            &Arc::<str>::from("llama-cpp"),
+            "llama-cpp",
             vec![
+                ModelInfo::id_only("model-a".into()),
                 ModelInfo {
-                    id: "model-a".into(),
-                    context_window: Some(32_000),
-                    max_output_tokens: None,
-                    pricing: None,
-                    supports_thinking: None,
-                    supports_vision: None,
-                    tier: None,
-                    provider_info: None,
-                },
-                ModelInfo {
-                    id: "model-b".into(),
                     context_window: Some(128_000),
-                    max_output_tokens: None,
-                    pricing: None,
-                    supports_thinking: None,
-                    supports_vision: None,
-                    tier: None,
-                    provider_info: None,
+                    ..ModelInfo::id_only("model-b".into())
                 },
             ],
         );
-        let info = reg.discovered("llama-cpp", "model-a").unwrap();
-        assert_eq!(info.id, "model-a");
-        assert_eq!(info.context_window, Some(32_000));
+        let info = reg.discovered("llama-cpp", "model-b").unwrap();
+        assert_eq!(info.context_window, Some(128_000));
         assert!(reg.discovered("llama-cpp", "model-x").is_none());
         assert!(reg.discovered("ollama", "model-a").is_none());
     }

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -429,11 +429,7 @@ pub async fn fetch_all_models(
             let batch = match provider.list_models().await {
                 Ok(models) => {
                     if manifest.accepts_arbitrary_models {
-                        let slug: Arc<str> = Arc::from(slug);
-                        crate::model_registry::model_registry()
-                            .write()
-                            .unwrap()
-                            .set_known_models(&slug, models.clone());
+                        crate::model_registry::set_known_models(slug, models.clone());
                     }
                     let mut specs: Vec<String> =
                         models.iter().map(|m| format!("{slug}/{}", m.id)).collect();

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -263,20 +263,17 @@ impl Copilot {
     ) -> Result<StreamResponse, AgentError> {
         let auth = self.auth().await?;
         let mut body = responses::build_body(model, messages, system, tools);
-        let reasoning_info = crate::model_registry::model_registry()
-            .read()
-            .unwrap()
-            .discovered("copilot", &model.id)
-            .and_then(|info| info.provider_info.clone())
-            .and_then(|info| Arc::downcast::<CopilotModelInfo>(info).ok())
-            .or_else(|| {
-                self.models
-                    .lock()
-                    .unwrap()
-                    .get(&model.id)
-                    .map(CopilotModel::reasoning_info)
-                    .map(Arc::new)
-            });
+        let reasoning_info = crate::model_registry::provider_info::<CopilotModelInfo>(
+            "copilot", &model.id,
+        )
+        .or_else(|| {
+            self.models
+                .lock()
+                .unwrap()
+                .get(&model.id)
+                .map(CopilotModel::reasoning_info)
+                .map(Arc::new)
+        });
         if let Some(info) = reasoning_info {
             apply_responses_reasoning(&mut body, thinking, model, &effort_dialect(&info));
         }

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -110,11 +110,8 @@ fn model_from_def(def: &ProviderDef, kind: ProviderKind, slug: &str, model_id: &
     let tier = declared
         .map(|m| ModelTier::from(m.tier))
         .unwrap_or(ModelTier::Medium);
-    // TODO: callers holding the registry read guard (e.g. Model::from_spec in
-    // lua agent / run paths) make this a recursive read lock; drop the guard in
-    // the callers as a follow-up, same issue as Model::from_base.
-    let reg = crate::model_registry::model_registry().read().unwrap();
-    let discovered = reg.discovered(slug, model_id);
+    let discovered = crate::model_registry::discovered(slug, model_id);
+    let discovered = discovered.as_ref();
     let max_output_tokens = declared
         .and_then(|m| m.max_output_tokens)
         .or_else(|| discovered.and_then(|d| d.max_output_tokens))
@@ -123,7 +120,6 @@ fn model_from_def(def: &ProviderDef, kind: ProviderKind, slug: &str, model_id: &
         .and_then(|m| m.context_window)
         .or_else(|| discovered.and_then(|d| d.context_window))
         .unwrap_or_else(|| kind.fallback_context_window());
-    drop(reg);
     let supports_tool_examples_override = declared.and_then(|m| m.supports_tool_examples);
     let thinking_override = ThinkingSupport::from_flags(
         declared
@@ -235,11 +231,7 @@ pub fn discover_models(timeouts: Timeouts) -> Vec<String> {
                 match result {
                     Ok(mut models) => {
                         overlay_declared_tiers(def, &mut models);
-                        let slug_arc: Arc<str> = Arc::from(slug_c.as_str());
-                        crate::model_registry::model_registry()
-                            .write()
-                            .unwrap()
-                            .set_known_models(&slug_arc, models.clone());
+                        crate::model_registry::set_known_models(&slug_c, models.clone());
                         for m in models {
                             all_specs.push(format!("{slug_c}/{}", m.id));
                         }
@@ -361,15 +353,14 @@ mod tests {
         let expected_window: u32 = 131_072;
         let expected_output: u32 = 8_192;
 
-        {
-            let mut info = ModelInfo::id_only(model_id.to_string());
-            info.context_window = Some(expected_window);
-            info.max_output_tokens = Some(expected_output);
-            crate::model_registry::model_registry()
-                .write()
-                .unwrap()
-                .set_known_models(&Arc::<str>::from(slug), vec![info]);
-        }
+        crate::model_registry::set_known_models(
+            slug,
+            vec![ModelInfo {
+                context_window: Some(expected_window),
+                max_output_tokens: Some(expected_output),
+                ..ModelInfo::id_only(model_id.to_string())
+            }],
+        );
 
         let def = openai_def(model_id);
         let model = model_from_def(&def, ProviderKind::OpenAi, slug, model_id);

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -197,17 +197,10 @@ impl Provider for OpenRouter {
 
             body["cache_control"] = json!({"type": "ephemeral"});
 
-            let reasoning_info: Option<Arc<OpenRouterModelInfo>> = {
-                let guard = crate::model_registry::model_registry().read().unwrap();
-                // Discovery keys by the builtin slug; a dynamic wrap's model
-                // carries its own slug, so don't key by model.provider.
-                guard
-                    .discovered("openrouter", &model.id)
-                    .and_then(|d| d.provider_info.clone())
-                    .map(|arc| {
-                        Arc::downcast::<OpenRouterModelInfo>(arc).expect("wrong provider info type")
-                    })
-            };
+            let reasoning_info = crate::model_registry::provider_info::<OpenRouterModelInfo>(
+                "openrouter",
+                &model.id,
+            );
 
             let effort_dialect = effort_dialect(reasoning_info.as_deref());
             if model.supports_thinking()

--- a/maki-providers/src/providers/tensorx.rs
+++ b/maki-providers/src/providers/tensorx.rs
@@ -92,22 +92,11 @@ impl Provider for TensorX {
             let system = super::with_prefix(&self.system_prefix, system, &mut buf);
             let mut body = self.compat.build_body(model, messages, system, tools);
 
-            let (has_thinking, has_reasoning_effort) = {
-                let guard = crate::model_registry::model_registry().read().unwrap();
-                // Discovery keys by the builtin slug; a dynamic wrap's model
-                // carries its own slug, so don't key by model.provider.
-                let info = guard
-                    .discovered("tensorx", &model.id)
-                    .and_then(|d| d.provider_info.clone())
-                    .map(|arc| {
-                        Arc::downcast::<TensorXModelInfo>(arc).expect("wrong provider info type")
+            let (has_thinking, has_reasoning_effort) =
+                crate::model_registry::provider_info::<TensorXModelInfo>("tensorx", &model.id)
+                    .map_or((false, false), |info| {
+                        (info.has_thinking, info.has_reasoning_effort)
                     });
-                if let Some(info) = info {
-                    (info.has_thinking, info.has_reasoning_effort)
-                } else {
-                    (false, false)
-                }
-            };
 
             if has_thinking {
                 body["thinking"] = json!(opts.thinking.is_enabled());

--- a/maki-ui/src/components/model_picker.rs
+++ b/maki-ui/src/components/model_picker.rs
@@ -278,23 +278,20 @@ fn parse_model_entry(spec: &str) -> Option<ModelEntry> {
         maki_config::providers::resolve_display_name(provider_str, config.get(provider_str))
     };
 
-    let map = model_registry::model_registry().read().unwrap();
-    let override_tiers: Vec<ModelTier> = [
-        ModelTier::Strong,
-        ModelTier::Medium,
-        ModelTier::Weak,
-        ModelTier::Compaction,
-    ]
-    .into_iter()
-    .filter(|&t| map.has_override(spec, t))
-    .collect();
-    let override_label = map.override_tier_label(spec);
-    drop(map);
+    let override_tiers = model_registry::override_tiers(spec);
     let (tier, free) = match maki_providers::Model::from_spec(spec) {
         Ok(m) => (m.tier.to_string(), m.is_free()),
         Err(_) => (String::new(), false),
     };
-    let tier = override_label.unwrap_or(tier);
+    let tier = if override_tiers.is_empty() {
+        tier
+    } else {
+        override_tiers
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("/")
+    };
     let tier = if free {
         format!("{FREE_PREFIX}{tier}")
     } else {


### PR DESCRIPTION
Callers held the registry read guard while building models, and the construction path (`Model::from_base`, `model_from_def`) takes the same lock again on the same thread.

`std::sync::RwLock` deadlocks on that recursive read once a writer like background discovery or a tier edit queues between the two reads.

The lock is now private to `model_registry`: accessors like `spec_for_tier` and `discovered` lock internally and return owned data, so no caller can hold a guard while re-entering.

Fixes #757.