### PR TITLE
fix(providers/llama-cpp): enable vision detection in single-model mode

### DIFF
--- a/maki-providers/src/providers/local.rs
+++ b/maki-providers/src/providers/local.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
@@ -214,15 +213,6 @@ enum ServerMode {
 struct LlamaCppModelsResponse {
     #[serde(default)]
     data: Vec<LlamaCppModelData>,
-    #[serde(default)]
-    models: Vec<LlamaCppModelInfo>,
-}
-
-#[derive(Deserialize)]
-struct LlamaCppModelInfo {
-    name: String,
-    #[serde(default)]
-    capabilities: Vec<String>,
 }
 
 #[derive(Deserialize)]
@@ -295,11 +285,7 @@ impl LocalEndpoint {
             .and_then(|v| u32::try_from(v).ok())
             .unwrap_or(0);
 
-        let capabilities_map: HashMap<String, Vec<String>> = body
-            .models
-            .into_iter()
-            .map(|m| (m.name, m.capabilities))
-            .collect();
+        let props_vision = llamacpp_props_vision(&props, &mode);
 
         let mut models: Vec<crate::model::ModelInfo> = body
             .data
@@ -318,11 +304,7 @@ impl LocalEndpoint {
                 let context_window = llamacpp_extract_ctx_from_model(&m, &mode, props_n_ctx);
                 let supports_vision = arch
                     .map(|a| a.input_modalities.iter().any(|m| m == "image"))
-                    .or_else(|| {
-                        capabilities_map
-                            .get(&m.id)
-                            .map(|caps| caps.iter().any(|c| c == "multimodal"))
-                    });
+                    .or(props_vision);
                 Some(crate::model::ModelInfo {
                     id: m.id,
                     context_window: Some(context_window),
@@ -380,6 +362,16 @@ fn llamacpp_extract_ctx_from_model(
 fn llamacpp_extract_ctx_arg(args: &[String], flag: &str) -> Option<u32> {
     let idx = args.iter().position(|a| a == flag)?;
     args.get(idx + 1)?.parse().ok()
+}
+
+fn llamacpp_props_vision(props: &Value, mode: &ServerMode) -> Option<bool> {
+    match mode {
+        // router props describe the router, not the individual models it serves
+        ServerMode::Router => None,
+        ServerMode::Single | ServerMode::Legacy => {
+            props.pointer("/modalities/vision").and_then(Value::as_bool)
+        }
+    }
 }
 
 // Ollama model discovery via POST /api/show
@@ -907,6 +899,40 @@ mod tests {
                 "8".into(),
             ];
             assert_eq!(llamacpp_extract_ctx_arg(&args, "--ctx-size"), Some(16384));
+        }
+    }
+
+    mod llamacpp_props_vision {
+        use super::super::*;
+
+        #[test]
+        fn reads_vision_from_modalities() {
+            let props = json!({"modalities": {"vision": true, "audio": false}});
+            assert_eq!(
+                llamacpp_props_vision(&props, &ServerMode::Single),
+                Some(true)
+            );
+        }
+
+        #[test]
+        fn returns_false_when_vision_disabled() {
+            let props = json!({"modalities": {"vision": false, "audio": false}});
+            assert_eq!(
+                llamacpp_props_vision(&props, &ServerMode::Single),
+                Some(false)
+            );
+        }
+
+        #[test]
+        fn returns_none_without_modalities() {
+            let props = json!({"total_slots": 4});
+            assert_eq!(llamacpp_props_vision(&props, &ServerMode::Single), None);
+        }
+
+        #[test]
+        fn ignores_props_in_router_mode() {
+            let props = json!({"role": "router", "modalities": {"vision": true}});
+            assert_eq!(llamacpp_props_vision(&props, &ServerMode::Router), None);
         }
     }
 

--- a/maki-providers/src/providers/local.rs
+++ b/maki-providers/src/providers/local.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use flume::Sender;
@@ -213,6 +214,15 @@ enum ServerMode {
 struct LlamaCppModelsResponse {
     #[serde(default)]
     data: Vec<LlamaCppModelData>,
+    #[serde(default)]
+    models: Vec<LlamaCppModelInfo>,
+}
+
+#[derive(Deserialize)]
+struct LlamaCppModelInfo {
+    name: String,
+    #[serde(default)]
+    capabilities: Vec<String>,
 }
 
 #[derive(Deserialize)]
@@ -285,6 +295,12 @@ impl LocalEndpoint {
             .and_then(|v| u32::try_from(v).ok())
             .unwrap_or(0);
 
+        let capabilities_map: HashMap<String, Vec<String>> = body
+            .models
+            .into_iter()
+            .map(|m| (m.name, m.capabilities))
+            .collect();
+
         let mut models: Vec<crate::model::ModelInfo> = body
             .data
             .into_iter()
@@ -300,7 +316,13 @@ impl LocalEndpoint {
                     return None;
                 }
                 let context_window = llamacpp_extract_ctx_from_model(&m, &mode, props_n_ctx);
-                let supports_vision = arch.map(|a| a.input_modalities.iter().any(|m| m == "image"));
+                let supports_vision = arch
+                    .map(|a| a.input_modalities.iter().any(|m| m == "image"))
+                    .or_else(|| {
+                        capabilities_map
+                            .get(&m.id)
+                            .map(|caps| caps.iter().any(|c| c == "multimodal"))
+                    });
                 Some(crate::model::ModelInfo {
                     id: m.id,
                     context_window: Some(context_window),


### PR DESCRIPTION
When hosting a single model supporting vision with `llama-server -m <model.gguf> -mm <mmproj.gguf>`, maki didn't recognize that the model supported vision. This change allowed the local model to see the `view_image` tool and use it to read images successfully.