### PR TITLE
fix(providers): detect vision and real limits for synthetic models

### DIFF
--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -994,6 +994,26 @@ mod tests {
     }
 
     #[test]
+    fn discovered_vision_flows_into_curated_provider_model() {
+        use crate::model::ModelInfo;
+
+        model_registry::set_known_models(
+            "synthetic",
+            vec![
+                ModelInfo {
+                    supports_vision: Some(true),
+                    ..ModelInfo::id_only("syn:test-vision".into())
+                },
+                ModelInfo::id_only("syn:test-blind".into()),
+            ],
+        );
+
+        let vision = |id| Model::from_spec(id).unwrap().supports_vision();
+        assert!(vision("synthetic/syn:test-vision"));
+        assert!(!vision("synthetic/syn:test-blind"));
+    }
+
+    #[test]
     fn discovered_context_window_flows_into_from_base_for_unknown_model() {
         use crate::model::ModelInfo;
 

--- a/maki-providers/src/model_registry.rs
+++ b/maki-providers/src/model_registry.rs
@@ -20,6 +20,7 @@ use std::sync::{Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use maki_storage::{StateDir, atomic_write};
 use tracing::warn;
 
+use crate::manifest::ManifestRegistry;
 use crate::model::{ModelInfo, ModelTier};
 
 const TIERS_FILE: &str = "model-tiers";
@@ -149,16 +150,15 @@ impl ModelRegistry {
                 t => t,
             };
         }
-        if let Some((_, model_id)) = spec.split_once('/')
+        if tiers_from_discovery(provider)
+            && let Some((_, model_id)) = spec.split_once('/')
             && let Some(models) = self.known_models.get(provider)
-            && let Some(model) = models.iter().find(|model| model.id == model_id)
+            && let Some(pos) = models.iter().position(|model| model.id == model_id)
         {
-            if let Some(tier) = model.tier {
+            if let Some(tier) = models[pos].tier {
                 return tier;
             }
-            if static_tier.is_none()
-                && let Some(pos) = models.iter().position(|candidate| candidate.id == model_id)
-            {
+            if static_tier.is_none() {
                 return tier_for_position(pos);
             }
         }
@@ -176,11 +176,14 @@ impl ModelRegistry {
             return Some(spec.clone());
         }
 
-        let candidate = self
-            .discovered_static_candidate(provider, tier)
-            .or_else(|| self.metadata_candidate(provider, tier))
-            .or_else(|| static_candidate(provider, tier))
-            .or_else(|| self.positional_candidate(provider, tier))?;
+        let candidate = if tiers_from_discovery(provider) {
+            self.discovered_static_candidate(provider, tier)
+                .or_else(|| self.metadata_candidate(provider, tier))
+                .or_else(|| static_candidate(provider, tier))
+                .or_else(|| self.positional_candidate(provider, tier))
+        } else {
+            static_candidate(provider, tier)
+        }?;
 
         (!self.claimed_elsewhere(&candidate, tier)).then_some(candidate)
     }
@@ -244,6 +247,14 @@ impl ModelRegistry {
     }
 }
 
+/// Discovery metadata (context window, pricing, vision) is stored for every
+/// provider, but only providers that accept arbitrary models may use the
+/// discovered list for tier auto-assignment; curated providers keep their
+/// static tier tables.
+fn tiers_from_discovery(provider: &str) -> bool {
+    ManifestRegistry::get(provider).is_none_or(|m| m.accepts_arbitrary_models)
+}
+
 fn static_candidate(provider: &str, tier: ModelTier) -> Option<String> {
     static_prefixes(provider, tier)
         .next()
@@ -251,7 +262,7 @@ fn static_candidate(provider: &str, tier: ModelTier) -> Option<String> {
 }
 
 fn static_prefixes(provider: &str, tier: ModelTier) -> impl Iterator<Item = &'static str> {
-    crate::manifest::ManifestRegistry::get(provider)
+    ManifestRegistry::get(provider)
         .into_iter()
         .flat_map(|manifest| manifest.models)
         .filter(move |entry| entry.default && entry.tier == tier)
@@ -334,6 +345,27 @@ mod tests {
         assert_eq!(t("ollama/pos1", None), ModelTier::Weak);
         assert_eq!(t("ollama/pos2", None), ModelTier::Weak);
         assert_eq!(t("ollama/unknown", None), ModelTier::Medium);
+    }
+
+    #[test]
+    fn curated_provider_ignores_discovered_tiers() {
+        let mut reg = ModelRegistry::default();
+        reg.set_known_models(
+            "synthetic",
+            vec![ModelInfo {
+                tier: Some(ModelTier::Strong),
+                ..ModelInfo::id_only("syn:large:vision".into())
+            }],
+        );
+
+        assert_ne!(
+            reg.tier_for("synthetic/syn:large:vision", "synthetic", None),
+            ModelTier::Strong
+        );
+        assert_ne!(
+            reg.spec_for_tier("synthetic", ModelTier::Strong),
+            Some("synthetic/syn:large:vision".into())
+        );
     }
 
     fn make_tiered(models: &[(&str, ModelTier)]) -> ModelRegistry {

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -428,11 +428,9 @@ pub async fn fetch_all_models(
         smol::spawn(async move {
             let batch = match provider.list_models().await {
                 Ok(models) => {
-                    if manifest.accepts_arbitrary_models {
-                        crate::model_registry::set_known_models(slug, models.clone());
-                    }
                     let mut specs: Vec<String> =
                         models.iter().map(|m| format!("{slug}/{}", m.id)).collect();
+                    crate::model_registry::set_known_models(slug, models);
                     for entry in manifest.models {
                         for prefix in entry.prefixes {
                             let spec = format!("{slug}/{prefix}");

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -225,36 +225,39 @@ impl OpenAiCompatProvider {
             .or_else(|| m["max_model_len"].as_u64())
             .or_else(|| m["max_context_length"].as_u64())
             .and_then(|v| u32::try_from(v).ok());
-        let max_output_tokens = m["max_tokens"].as_u64().and_then(|v| u32::try_from(v).ok());
-        let pricing = m["pricing"]
-            .as_object()
-            .and_then(|p| {
-                Some(crate::model::ModelPricing {
-                    input: p.get("prompt")?.as_str()?.parse().ok()?,
-                    output: p.get("completion")?.as_str()?.parse().ok()?,
-                    cache_write: p
-                        .get("cache_creation")?
-                        .as_str()?
-                        .parse::<f64>()
-                        .ok()
-                        .unwrap_or(0.0),
-                    cache_read: p
-                        .get("cache_read")?
-                        .as_str()?
-                        .parse::<f64>()
-                        .ok()
-                        .unwrap_or(0.0),
-                    fast: None,
-                })
+        let max_output_tokens = m["max_tokens"]
+            .as_u64()
+            .or_else(|| m["max_output_length"].as_u64())
+            .and_then(|v| u32::try_from(v).ok());
+        let supports_vision = m["input_modalities"]
+            .as_array()
+            .map(|mods| mods.iter().any(|v| v.as_str() == Some("image")));
+        let pricing = m["pricing"].as_object().and_then(|p| {
+            Some(crate::model::ModelPricing {
+                input: p.get("prompt")?.as_str()?.parse().ok()?,
+                output: p.get("completion")?.as_str()?.parse().ok()?,
+                cache_write: p
+                    .get("cache_creation")?
+                    .as_str()?
+                    .parse::<f64>()
+                    .ok()
+                    .unwrap_or(0.0),
+                cache_read: p
+                    .get("cache_read")?
+                    .as_str()?
+                    .parse::<f64>()
+                    .ok()
+                    .unwrap_or(0.0),
+                fast: None,
             })
-            .unwrap_or_default();
+        });
         Some(crate::model::ModelInfo {
             id: id.to_string(),
             context_window,
             max_output_tokens,
-            pricing: Some(pricing),
+            pricing,
             supports_thinking: None,
-            supports_vision: None,
+            supports_vision,
             tier: None,
             provider_info: None,
         })
@@ -704,6 +707,28 @@ mod tests {
     use test_case::test_case;
 
     const TEST_STREAM_TIMEOUT: Duration = Duration::from_secs(300);
+
+    #[test]
+    fn default_model_parser_reads_context_and_output_length() {
+        let m = json!({"id": "m", "context_length": 524_288, "max_output_length": 65_536});
+        let info = OpenAiCompatProvider::default_model_parser(&m).unwrap();
+        assert_eq!(info.context_window, Some(524_288));
+        assert_eq!(info.max_output_tokens, Some(65_536));
+    }
+
+    #[test]
+    fn default_model_parser_missing_pricing_stays_none() {
+        let info = OpenAiCompatProvider::default_model_parser(&json!({"id": "m"})).unwrap();
+        assert!(info.pricing.is_none());
+    }
+
+    #[test_case(json!({"id": "m", "input_modalities": ["text", "image"]}), Some(true) ; "image_modality_enables_vision")]
+    #[test_case(json!({"id": "m", "input_modalities": ["text"]}), Some(false) ; "text_only_disables_vision")]
+    #[test_case(json!({"id": "m"}), None ; "missing_modalities_stays_unknown")]
+    fn default_model_parser_vision_flag(m: Value, expected: Option<bool>) {
+        let info = OpenAiCompatProvider::default_model_parser(&m).unwrap();
+        assert_eq!(info.supports_vision, expected);
+    }
 
     #[test]
     fn parse_sse_text_and_usage() {


### PR DESCRIPTION
The generic openai_compat parser hardcoded `supports_vision: None` and only read `max_tokens`, so synthetic models like `syn:large:vision` stayed text-only and kept fallback limits.  The parser now reads `input_modalities` and `max_output_length`, matching what the synthetic API reports.

Discovery metadata also never reached the registry because `fetch_all_models` only stored it for providers with `accepts_arbitrary_models`.  It is now stored for everyone, while curated providers keep their static tier tables through a new `tiers_from_discovery` gate so auto-tiering stays protected.

Fixes #763