### PR TITLE
feat(lua): add maki.ui.action to run built-in UI actions by name

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,7 +62,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-      - uses: extractions/setup-just@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
       - run: just lint
 
   test:
@@ -73,10 +75,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-      - uses: extractions/setup-just@v2
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-nextest
+          tool: just,cargo-nextest
       - run: sudo apt-get -o Acquire::Retries=5 install -y ripgrep
       - run: just test
 
@@ -100,7 +101,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-      - uses: extractions/setup-just@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
       - run: just gen-docs-check
 
   build:
@@ -111,7 +114,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-      - uses: extractions/setup-just@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
       - run: just build
 
   lint-windows:
@@ -122,7 +127,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-      - uses: extractions/setup-just@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
       - run: just lint
 
   build-windows:
@@ -133,7 +140,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-      - uses: extractions/setup-just@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
       - run: just build
 
   ci-pass:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,6 +2624,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "smol",
+ "strum 0.27.2",
  "tempfile",
  "test-case",
  "thiserror 2.0.18",

--- a/maki-lua/Cargo.toml
+++ b/maki-lua/Cargo.toml
@@ -26,6 +26,7 @@ serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 smol = { workspace = true }
+strum = { workspace = true }
 event-listener = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }

--- a/maki-lua/src/api/ui/mod.rs
+++ b/maki-lua/src/api/ui/mod.rs
@@ -6,11 +6,13 @@ use std::time::Duration;
 use humantime::format_duration;
 use maki_lua_macro::{lua_fn, lua_table};
 use mlua::{Lua, Result as LuaResult, Table};
+use strum::VariantNames;
 
 use crate::api::util::command::{
-    Anchor, Border, Dimension, FloatConfig, HintEntries, HintWriter, Split, TitlePos, UiAction,
-    WinCommand, WinEvent,
+    Anchor, Border, BuiltinAction, Dimension, FloatConfig, HintEntries, HintWriter, Split,
+    TitlePos, UiAction, WinCommand, WinEvent, ui_send,
 };
+use crate::api::util::pair::{Pair, try_pair};
 use crate::docs::{FnDoc, ParamDoc};
 pub(crate) mod blit;
 pub(crate) mod buf;
@@ -247,6 +249,32 @@ fn flash(_lua: &Lua, #[ctx] tx: flume::Sender<UiAction>, msg: String) -> LuaResu
     Ok(())
 }
 
+/// Runs a built-in UI action by name, exactly as its default keybinding
+/// would. Handy when a default key never reaches maki because tmux or
+/// your terminal grabs it first: bind a new key with `maki.keymap.set`
+/// and call this from it.
+///
+/// Valid names: `"file_picker"`, `"search"`, `"tasks"`, `"help"`,
+/// `"plan_toggle"`, `"plan_editor"`, `"edit_input"`, `"pop_queue"`,
+/// `"prev_chat"`, `"next_chat"`.
+///
+/// @param name string Action name, e.g. `"file_picker"`.
+/// @return (boolean|nil, string|nil) `true` on success, or nil and an error message for an unknown name.
+/// @example
+/// -- Open the built-in file picker with Ctrl+Q instead of Ctrl+S:
+/// maki.keymap.set("n", "<C-q>", function()
+///   maki.ui.action("file_picker")
+/// end)
+#[lua_fn]
+fn action(_lua: &Lua, #[ctx] tx: flume::Sender<UiAction>, name: String) -> LuaResult<Pair<bool>> {
+    let builtin = try_pair!(name.parse::<BuiltinAction>().map_err(|_| format!(
+        "unknown action '{name}' (valid: {})",
+        BuiltinAction::VARIANTS.join(", ")
+    )));
+    try_pair!(ui_send(Some(&tx), UiAction::Builtin(builtin)));
+    Ok((Some(true), None))
+}
+
 /// Opens {path} in the user's `$EDITOR` (e.g. vim, nano) and waits for
 /// it to close. This suspends the TUI while the editor is running.
 /// Returns the editor's exit code so you can check if the user saved.
@@ -423,7 +451,7 @@ lua_table! {
     extend "maki.ui" => pub(crate) fn add_ui_fns(), DOCS [
         buf, theme_color, highlight, markdown, humantime, terminal_size,
         display_width, truncate_text,
-        manual flash, manual open_editor, manual open_win, manual set_status_hint,
+        manual flash, manual action, manual open_editor, manual open_win, manual set_status_hint,
     ]
 }
 
@@ -437,6 +465,7 @@ pub(crate) fn create_ui_table(
 
     if let Some(tx) = ui_action_tx {
         flash__register(&t, lua, tx.clone())?;
+        action__register(&t, lua, tx.clone())?;
         open_editor__register(&t, lua, tx.clone())?;
         open_win__register(&t, lua, tx)?;
     }

--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use arc_swap::ArcSwap;
 use maki_agent::SharedBuf;
 use mlua::RegistryKey;
+use strum::{EnumString, VariantNames};
 
 pub(crate) const NO_UI_ERR: &str = "no interactive UI attached";
 const UI_DROPPED_ERR: &str = "ui event loop dropped the request";
@@ -420,6 +421,23 @@ pub struct WinView {
     pub auto_scroll: bool,
 }
 
+/// Lua sees these through `maki.ui.action` as the snake_case variant
+/// names, so renaming a variant breaks user configs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString, VariantNames)]
+#[strum(serialize_all = "snake_case")]
+pub enum BuiltinAction {
+    FilePicker,
+    Search,
+    Tasks,
+    Help,
+    PlanToggle,
+    PlanEditor,
+    EditInput,
+    PopQueue,
+    PrevChat,
+    NextChat,
+}
+
 pub enum UiAction {
     OpenWin {
         buf: Arc<SharedBuf>,
@@ -443,6 +461,7 @@ pub enum UiAction {
     WinRestView {
         scroll_top: u16,
     },
+    Builtin(BuiltinAction),
 }
 
 /// Hand an action to the UI event loop. A full or closed channel means the
@@ -514,6 +533,16 @@ mod tests {
             .filter(|c| c.plugin.as_ref() == "plugA")
             .collect();
         assert_eq!(plug_a_cmds.len(), 2);
+    }
+
+    #[test]
+    fn builtin_action_names_are_snake_case() {
+        for name in BuiltinAction::VARIANTS {
+            assert!(
+                name.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+                "lua-facing action name '{name}' is not snake_case"
+            );
+        }
     }
 
     #[test]

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -10,9 +10,9 @@ mod runtime;
 pub use api::keymap::{KeymapEntry, KeymapReader, KeymapSnapshot};
 pub use api::options::{OptionSpec, OptionType, PluginOptionSpecs};
 pub use api::util::command::{
-    Anchor, Axis, Border, Dimension, Edge, FloatConfig, FloatConfigPatch, HintReader, HintSnapshot,
-    LuaCommandInfo, LuaCommandReader, SessionReply, SessionRequest, Split, TitlePos, UiAction,
-    WinCommand, WinEvent, WinView,
+    Anchor, Axis, Border, BuiltinAction, Dimension, Edge, FloatConfig, FloatConfigPatch,
+    HintReader, HintSnapshot, LuaCommandInfo, LuaCommandReader, SessionReply, SessionRequest,
+    Split, TitlePos, UiAction, WinCommand, WinEvent, WinView,
 };
 pub use docs::{DocKind, FnDoc, ModuleDoc, ParamDoc, api_docs};
 pub use error::PluginError;

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -58,7 +58,7 @@ use maki_agent::{
     SharedMessages, SubagentInfo,
 };
 use maki_config::{ModelPolicy, UiConfig};
-use maki_lua::{EventHandle, HintReader, KeymapReader, LuaCommandReader, WinView};
+use maki_lua::{BuiltinAction, EventHandle, HintReader, KeymapReader, LuaCommandReader, WinView};
 use maki_providers::{Model, ThinkingConfig, add_cost};
 use maki_storage::StateDir;
 use maki_storage::input_history::InputHistory;
@@ -495,20 +495,16 @@ impl App {
             });
         }
         if key::HELP.matches(key) {
-            self.help_modal.toggle();
-            return Some(vec![]);
+            return Some(self.run_builtin(BuiltinAction::Help));
         }
         if key::TASKS.matches(key) {
-            self.open_tasks();
-            return Some(vec![]);
+            return Some(self.run_builtin(BuiltinAction::Tasks));
         }
         if key::PREV_CHAT.matches(key) {
-            self.active_chat = self.active_chat.saturating_sub(1);
-            return Some(vec![]);
+            return Some(self.run_builtin(BuiltinAction::PrevChat));
         }
         if key::NEXT_CHAT.matches(key) {
-            self.active_chat = (self.active_chat + 1).min(self.chats.len() - 1);
-            return Some(vec![]);
+            return Some(self.run_builtin(BuiltinAction::NextChat));
         }
         if key::SCROLL_HALF_UP.matches(key) {
             let half = self.chats[self.active_chat].half_page();
@@ -713,15 +709,62 @@ impl App {
             });
         }
 
-        if key::PLAN_TOGGLE.matches(key)
-            && self.state.mode == Mode::Plan
-            && self.state.plan.is_ready()
-        {
-            self.plan_form.toggle();
-            return Some(vec![]);
+        if key::PLAN_TOGGLE.matches(key) && self.plan_toggle_ready() {
+            return Some(self.run_builtin(BuiltinAction::PlanToggle));
         }
 
         None
+    }
+
+    fn plan_toggle_ready(&self) -> bool {
+        self.state.mode == Mode::Plan && self.state.plan.is_ready()
+    }
+
+    /// Single implementation behind both the default keybindings and
+    /// `maki.ui.action`, so a Lua rebind can never drift from the
+    /// original key's behavior.
+    pub(crate) fn run_builtin(&mut self, action: BuiltinAction) -> Vec<Action> {
+        match action {
+            BuiltinAction::FilePicker => {
+                self.file_picker.open(&self.state.session.cwd);
+            }
+            BuiltinAction::Search => {
+                let top = self.chats[self.active_chat].scroll_top();
+                let auto = self.chats[self.active_chat].auto_scroll();
+                self.search_modal.open(top, auto);
+            }
+            BuiltinAction::Tasks => {
+                if self.task_picker.is_open() {
+                    self.task_picker.close();
+                } else {
+                    self.open_tasks();
+                }
+            }
+            BuiltinAction::Help => self.help_modal.toggle(),
+            BuiltinAction::PlanToggle => {
+                if self.plan_toggle_ready() {
+                    self.plan_form.toggle();
+                }
+            }
+            BuiltinAction::PlanEditor => {
+                return match self.state.plan.path() {
+                    Some(p) => vec![Action::OpenEditor(p.to_path_buf())],
+                    None => {
+                        self.flash(FLASH_NO_PLAN.into());
+                        vec![]
+                    }
+                };
+            }
+            BuiltinAction::EditInput => return vec![Action::EditInputInEditor],
+            BuiltinAction::PopQueue => {
+                self.queue.remove(0);
+            }
+            BuiltinAction::PrevChat => self.active_chat = self.active_chat.saturating_sub(1),
+            BuiltinAction::NextChat => {
+                self.active_chat = (self.active_chat + 1).min(self.chats.len() - 1);
+            }
+        }
+        vec![]
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> Vec<Action> {
@@ -781,25 +824,17 @@ impl App {
 
     fn handle_main_chat_key(&mut self, key: KeyEvent) -> Vec<Action> {
         if key::EDIT_INPUT.matches(key) {
-            return vec![Action::EditInputInEditor];
+            return self.run_builtin(BuiltinAction::EditInput);
         }
         if is_ctrl(&key) {
             if key::POP_QUEUE.matches(key) {
-                self.queue.remove(0);
+                return self.run_builtin(BuiltinAction::PopQueue);
             } else if key::OPEN_EDITOR.matches(key) {
-                return match self.state.plan.path() {
-                    Some(p) => vec![Action::OpenEditor(p.to_path_buf())],
-                    None => {
-                        self.flash(FLASH_NO_PLAN.into());
-                        vec![]
-                    }
-                };
+                return self.run_builtin(BuiltinAction::PlanEditor);
             } else if key::SEARCH.matches(key) {
-                let top = self.chats[self.active_chat].scroll_top();
-                let auto = self.chats[self.active_chat].auto_scroll();
-                self.search_modal.open(top, auto);
+                return self.run_builtin(BuiltinAction::Search);
             } else if key::FILE_PICKER.matches(key) {
-                self.file_picker.open(&self.state.session.cwd);
+                return self.run_builtin(BuiltinAction::FilePicker);
             } else if key.code == KeyCode::Char('v') && self.image_paste_rx.is_empty() {
                 self.start_image_paste();
             } else if let InputAction::PaletteSync(val) = self.input_box.handle_key(key) {

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -13,7 +13,7 @@ use maki_agent::{
     McpSnapshotReader, ToolDoneEvent, ToolOutput, ToolStartEvent, TurnCompleteEvent,
 };
 use maki_config::{PermissionsConfig, UiConfig};
-use maki_lua::{HintReader, KeymapReader, LuaCommandInfo, LuaCommandReader};
+use maki_lua::{BuiltinAction, HintReader, KeymapReader, LuaCommandInfo, LuaCommandReader};
 use maki_providers::{ContentBlock, Effort, Message, Role, TokenUsage};
 use maki_storage::sessions::{StoredMode, StoredThinking};
 use ratatui::layout::Rect;
@@ -4197,4 +4197,11 @@ fn turn_end_keeps_only_the_subagents_that_finished() {
         .map(|sa| sa.tool_use_id.as_str())
         .collect();
     assert_eq!(ids, [FINISHED_TASK_ID]);
+}
+
+#[test]
+fn run_builtin_file_picker_opens_modal() {
+    let mut app = test_app();
+    assert!(app.run_builtin(BuiltinAction::FilePicker).is_empty());
+    assert!(app.file_picker.is_open());
 }

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -614,6 +614,10 @@ impl<'t> EventLoop<'t> {
             UiAction::WinRestView { scroll_top } => {
                 self.focused_app().set_scroll_top(scroll_top);
             }
+            UiAction::Builtin(action) => {
+                let actions = self.focused_app().run_builtin(action);
+                self.dispatch(self.focused, actions);
+            }
         }
     }
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -4149,6 +4149,38 @@ maki.ui.flash("Copied to clipboard!")
 
 ---
 
+### `maki.ui.action()` {#maki-ui-action}
+
+```lua
+maki.ui.action({name})
+```
+
+Runs a built-in UI action by name, exactly as its default keybinding
+would. Handy when a default key never reaches maki because tmux or
+your terminal grabs it first: bind a new key with `maki.keymap.set`
+and call this from it.
+
+Valid names: `"file_picker"`, `"search"`, `"tasks"`, `"help"`,
+`"plan_toggle"`, `"plan_editor"`, `"edit_input"`, `"pop_queue"`,
+`"prev_chat"`, `"next_chat"`.
+
+**Parameters:**
+
+- `{name}` (`string`) Action name, e.g. `"file_picker"`.
+
+**Returns:** (`boolean|nil`, `string|nil`) `true` on success, or nil and an error message for an unknown name.
+
+**Example:**
+
+```lua
+-- Open the built-in file picker with Ctrl+Q instead of Ctrl+S:
+maki.keymap.set("n", "<C-q>", function()
+  maki.ui.action("file_picker")
+end)
+```
+
+---
+
 ### `maki.ui.open_editor()` {#maki-ui-open_editor}
 
 ```lua


### PR DESCRIPTION
Default keybindings like `Ctrl+S` for the file picker were baked in, so anyone whose terminal or tmux already eats the key had to reimplement the feature in Lua from scratch (#752).

`maki.ui.action("file_picker")` now triggers the built-in behavior directly, and since Lua keymaps already run before the defaults, `maki.keymap.set` on any key is a full rebind.

The default key branches and the new `App::run_builtin` share one implementation, so both paths stay identical.

Closes #752.