### PR TITLE
docs: redesign the site UI with terminal chrome and a search modal

### DIFF
--- a/maki-docgen/src/gen_tools.rs
+++ b/maki-docgen/src/gen_tools.rs
@@ -135,13 +135,6 @@ fn write_param_table(out: &mut String, params: &[Param]) {
     }
 }
 
-fn source_label(source: &ToolSource) -> &'static str {
-    match source {
-        ToolSource::Lua { .. } => "lua plugin",
-        ToolSource::Mcp { .. } => "mcp",
-    }
-}
-
 fn write_tool_entry(out: &mut String, name: &str, info: &ToolInfo, opt_in: &HashSet<String>) {
     let description = info
         .def
@@ -153,11 +146,14 @@ fn write_tool_entry(out: &mut String, name: &str, info: &ToolInfo, opt_in: &Hash
     let summary = first_paragraph(description);
 
     writeln!(out).unwrap();
-    let mut badge_text = source_label(&info.source).to_string();
-    if opt_in.contains(name) {
-        badge_text.push_str(", opt-in");
+    let mut badges = String::new();
+    if matches!(info.source, ToolSource::Mcp { .. }) {
+        badges.push_str(" <span class=\"badge\">mcp</span>");
     }
-    writeln!(out, "### `{name}` *({badge_text})*").unwrap();
+    if opt_in.contains(name) {
+        badges.push_str(" <span class=\"badge badge-optin\">opt-in</span>");
+    }
+    writeln!(out, "### `{name}`{badges} {{#{name}}}").unwrap();
     writeln!(out).unwrap();
     writeln!(out, "{summary}").unwrap();
     writeln!(out).unwrap();

--- a/site/build.sh
+++ b/site/build.sh
@@ -4,7 +4,7 @@ set -e
 # Cloudflare Pages build script
 # Assembles the static landing page + Zola docs into a single output dir.
 
-ZOLA_VERSION="${ZOLA_VERSION:-0.19.2}"
+ZOLA_VERSION="${ZOLA_VERSION:-0.22.1}"
 
 if ! command -v zola >/dev/null 2>&1; then
   echo "Installing zola ${ZOLA_VERSION}..."

--- a/site/build.sh
+++ b/site/build.sh
@@ -97,4 +97,32 @@ summary=$(first_paragraph docs/content/_index.md)
   done
 } > "$OUT/llms-full.txt"
 
+# 4. Search index (lazy-loaded by the docs search modal)
+python3 - "$OUT/docs/search.json" docs/content <<'EOF'
+import json, os, re, sys
+
+out, root = sys.argv[1], sys.argv[2]
+docs = []
+for slug in os.listdir(root):
+    path = os.path.join(root, slug, "_index.md")
+    if not os.path.isfile(path):
+        continue
+    raw = open(path, encoding="utf-8").read()
+    m = re.match(r"\+\+\+\n(.*?)\n\+\+\+\n", raw, re.S)
+    fm, body = m.group(1), raw[m.end():]
+    title = re.search(r'^title = "(.*)"$', fm, re.M).group(1)
+    weight = re.search(r"^weight = (\d+)$", fm, re.M)
+    body = re.sub(r"^```.*$", "", body, flags=re.M)
+    body = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", body)
+    body = re.sub(r"<[^>]+>", " ", body)
+    body = re.sub(r"[#*`|]", " ", body)
+    body = re.sub(r"-{3,}", " ", body)
+    body = re.sub(r"\s+", " ", body).strip()
+    docs.append((int(weight.group(1)) if weight else 999,
+                 {"title": title, "href": f"/docs/{slug}/", "body": body}))
+docs.sort(key=lambda d: d[0])
+with open(out, "w", encoding="utf-8") as f:
+    json.dump([d for _, d in docs], f, ensure_ascii=False)
+EOF
+
 cp "$OUT/llms.txt" "$OUT/llms-full.txt" "$OUT/docs/"

--- a/site/docs/config.toml
+++ b/site/docs/config.toml
@@ -6,5 +6,6 @@ build_search_index = false
 [markdown.highlighting]
 enabled = true
 style = "inline"
-light_theme = "catppuccin-latte"
-dark_theme = "catppuccin-mocha"
+light_theme = "maki-light"
+dark_theme = "maki-dark"
+extra_themes = ["extra/maki-light.json", "extra/maki-dark.json"]

--- a/site/docs/content/_index.md
+++ b/site/docs/content/_index.md
@@ -9,42 +9,55 @@ Maki is a terminal coding agent written in Rust, built bottom up to spend as few
 
 The docs are sorted by what you came here to do:
 
-```
-new to maki          ─►  Quick Start, Configuration
-getting things done  ─►  Guides: Skills, Headless Mode, ACP
-looking something up ─►  Reference: Tools, Providers, Permissions, ...
-wondering why        ─►  Concepts: Token Economy, Context
-```
+<div class="doc-group">
+  <div class="doc-group-head">
+    <span class="eyebrow">Getting Started</span>
+    <span class="tagline">new to maki</span>
+  </div>
+  <div class="card-grid">
+    <a class="card" href="/docs/quick-start/"><span class="card-title">Quick Start</span><span class="card-desc">Install, connect a provider, first session.</span></a>
+    <a class="card" href="/docs/configuration/"><span class="card-title">Configuration</span><span class="card-desc">init.lua, the small Lua script where all settings live.</span></a>
+  </div>
+</div>
 
-## Getting started
+<div class="doc-group">
+  <div class="doc-group-head">
+    <span class="eyebrow">Guides</span>
+    <span class="tagline">getting things done</span>
+  </div>
+  <div class="card-grid">
+    <a class="card" href="/docs/skills/"><span class="card-title">Skills</span><span class="card-desc">Write Markdown playbooks the agent loads on demand.</span></a>
+    <a class="card" href="/docs/headless/"><span class="card-title">Headless Mode</span><span class="card-desc">--print for scripts and CI. Drop-in Claude Code compatible.</span></a>
+    <a class="card" href="/docs/acp/"><span class="card-title">ACP</span><span class="card-desc">Drive Maki from your editor, like Zed, over the Agent Client Protocol.</span></a>
+  </div>
+</div>
 
-- [Quick Start](/docs/quick-start/): install, connect a provider, first session.
-- [Configuration](/docs/configuration/): `init.lua`, the small Lua script where all settings live.
+<div class="doc-group">
+  <div class="doc-group-head">
+    <span class="eyebrow">Concepts</span>
+    <span class="tagline">wondering why</span>
+  </div>
+  <div class="card-grid">
+    <a class="card" href="/docs/token-economy/"><span class="card-title">Token Economy</span><span class="card-desc">Where tokens go in an agent loop, and every trick Maki uses to spend fewer of them.</span></a>
+    <a class="card" href="/docs/context/"><span class="card-title">Context</span><span class="card-desc">What enters the model's context and when, and where to put project knowledge.</span></a>
+  </div>
+</div>
 
-## Guides
-
-- [Skills](/docs/skills/): write Markdown playbooks the agent loads on demand.
-- [Headless Mode](/docs/headless/): `--print` for scripts and CI. Drop-in Claude Code compatible.
-- [ACP](/docs/acp/): drive Maki from your editor, like [Zed](https://zed.dev/), over the Agent Client Protocol.
-
-## Concepts
-
-How Maki thinks, worth one read:
-
-- [Token Economy](/docs/token-economy/): where tokens go in an agent loop, and every trick Maki uses to spend fewer of them.
-- [Context](/docs/context/): what enters the model's context and when, and where to put project knowledge (`AGENTS.md`, skills, memory, commands).
-
-## Reference
-
-Look-up material, most of it generated straight from source so it cannot drift:
-
-- [Tools](/docs/tools/): every built-in tool and its parameters.
-- [Providers](/docs/providers/): model catalogs, env vars, `providers.toml`, model tiers.
-- [Permissions](/docs/permissions/): what runs freely, what asks first, TOML rules.
-- [MCP](/docs/mcp/): external tool servers over stdio or HTTP.
-- [Commands](/docs/commands/): the `/` palette, sessions, toggles, custom commands.
-- [Keybindings](/docs/keybindings/): defaults, precedence, rebinding from Lua.
-- [Lua API](/docs/lua-api/): the plugin surface, mirrored from Neovim.
-- [CLI](/docs/cli/): flags and subcommands (`auth`, `models`, `acp`, `prompt`, ...).
+<div class="doc-group">
+  <div class="doc-group-head">
+    <span class="eyebrow">Reference</span>
+    <span class="tagline">looking something up</span>
+  </div>
+  <div class="card-grid">
+    <a class="card" href="/docs/tools/"><span class="card-title">Tools</span><span class="card-desc">Every built-in tool and its parameters.</span></a>
+    <a class="card" href="/docs/providers/"><span class="card-title">Providers</span><span class="card-desc">Model catalogs, env vars, providers.toml, model tiers.</span></a>
+    <a class="card" href="/docs/permissions/"><span class="card-title">Permissions</span><span class="card-desc">What runs freely, what asks first, TOML rules.</span></a>
+    <a class="card" href="/docs/mcp/"><span class="card-title">MCP</span><span class="card-desc">External tool servers over stdio or HTTP.</span></a>
+    <a class="card" href="/docs/commands/"><span class="card-title">Commands</span><span class="card-desc">The / palette, sessions, toggles, custom commands.</span></a>
+    <a class="card" href="/docs/keybindings/"><span class="card-title">Keybindings</span><span class="card-desc">Defaults, precedence, rebinding from Lua.</span></a>
+    <a class="card" href="/docs/lua-api/"><span class="card-title">Lua API</span><span class="card-desc">The plugin surface, mirrored from Neovim.</span></a>
+    <a class="card" href="/docs/cli/"><span class="card-title">CLI</span><span class="card-desc">Flags and subcommands (auth, models, acp, prompt, ...).</span></a>
+  </div>
+</div>
 
 Something missing or wrong? Open an issue on [GitHub](https://github.com/tontinton/maki).

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -11,7 +11,7 @@ Maki ships with 21 built-in tools in this reference (19 on by default, 2 opt-in 
 
 ## File Operations
 
-### `bash` *(lua plugin)*
+### `bash` {#bash}
 
 Execute a bash command.
 Commands run in <cwd> by default.
@@ -23,7 +23,7 @@ Commands run in <cwd> by default.
 | `timeout` | integer | no | 120 | Timeout in seconds |
 | `workdir` | string | no | cwd | Working directory |
 
-### `list` *(lua plugin)*
+### `list` {#list}
 
 List directory contents. Returns entry names sorted alphabetically, directories first with a trailing /.
 
@@ -31,7 +31,7 @@ List directory contents. Returns entry names sorted alphabetically, directories 
 |-----------|------|----------|-------------|
 | `path` | string | yes | Absolute path to the directory |
 
-### `read` *(lua plugin)*
+### `read` {#read}
 
 Read a file. Returns contents with line numbers (1-indexed).
 
@@ -41,7 +41,7 @@ Read a file. Returns contents with line numbers (1-indexed).
 | `offset` | integer | yes | Line number to start from (1-indexed). Use 1 for the first line. |
 | `path` | string | yes | Absolute path to the file |
 
-### `write` *(lua plugin)*
+### `write` {#write}
 
 Write content to a file, replacing existing content.
 
@@ -50,7 +50,7 @@ Write content to a file, replacing existing content.
 | `content` | string | yes | The complete file content to write |
 | `path` | string | yes | Absolute path to the file |
 
-### `edit` *(lua plugin)*
+### `edit` {#edit}
 
 Replace an exact string match in a file.
 
@@ -61,7 +61,7 @@ Replace an exact string match in a file.
 | `path` | string | yes |  | Absolute path to the file |
 | `replace_all` | boolean | no | false | Replace all occurrences |
 
-### `multiedit` *(lua plugin)*
+### `multiedit` {#multiedit}
 
 Make multiple find-and-replace edits to a single file atomically.
 Prefer this over edit when making multiple changes to the same file.
@@ -71,7 +71,7 @@ Prefer this over edit when making multiple changes to the same file.
 | `edits` | array | yes | Array of edit operations to apply sequentially |
 | `path` | string | yes | Absolute path to the file |
 
-### `edit_lines` *(lua plugin, opt-in)*
+### `edit_lines` <span class="badge badge-optin">opt-in</span> {#edit_lines}
 
 Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new_string`. Use empty `new_string` to delete a range. Do not use with the batch tool.
 
@@ -82,7 +82,7 @@ Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new
 | `path` | string | yes | Absolute path to the file |
 | `start` | integer | yes | First line (1-indexed) |
 
-### `insert_lines` *(lua plugin, opt-in)*
+### `insert_lines` <span class="badge badge-optin">opt-in</span> {#insert_lines}
 
 Insert lines before a given line number. Lines at `line` and below shift down. Existing lines are preserved. Do not use with the batch tool.
 
@@ -92,7 +92,7 @@ Insert lines before a given line number. Lines at `line` and below shift down. E
 | `new_string` | string | yes | Text to insert |
 | `path` | string | yes | Absolute path to the file |
 
-### `glob` *(lua plugin)*
+### `glob` {#glob}
 
 Find files by glob pattern.
 
@@ -101,7 +101,7 @@ Find files by glob pattern.
 | `path` | string | no | cwd | Directory to search in |
 | `pattern` | string | yes |  | Glob pattern (e.g. **/*.rs, src/**/*.ts) |
 
-### `grep` *(lua plugin)*
+### `grep` {#grep}
 
 Search file contents using regex.
 
@@ -114,7 +114,7 @@ Search file contents using regex.
 | `path` | string | no | cwd | Directory to search in |
 | `pattern` | string | yes |  | Regex pattern |
 
-### `index` *(lua plugin)*
+### `index` {#index}
 
 Return a compact overview of a source file: imports, type definitions, function signatures, and structure with their line numbers surrounded by []. ~70-90% more efficient than reading the full file.
 
@@ -122,7 +122,7 @@ Return a compact overview of a source file: imports, type definitions, function 
 |-----------|------|----------|-------------|
 | `path` | string | yes | Absolute path to the file |
 
-### `view_image` *(lua plugin)*
+### `view_image` {#view_image}
 
 View an image file (png, jpeg, gif, webp) so you can actually see it; it is returned as vision input alongside the tool result. Use instead of `read` for images.
 
@@ -132,7 +132,7 @@ View an image file (png, jpeg, gif, webp) so you can actually see it; it is retu
 
 ## Execution & Control
 
-### `batch` *(lua plugin)*
+### `batch` {#batch}
 
 Executes multiple independent tool calls concurrently to reduce round-trips.
 
@@ -140,7 +140,7 @@ Executes multiple independent tool calls concurrently to reduce round-trips.
 |-----------|------|----------|-------------|
 | `tool_calls` | array | yes | Array of tool calls to execute in parallel |
 
-### `code_execution` *(lua plugin)*
+### `code_execution` {#code_execution}
 
 Execute Python code in a sandboxed interpreter with tools as callable functions.
 
@@ -149,7 +149,7 @@ Execute Python code in a sandboxed interpreter with tools as callable functions.
 | `code` | string | yes |  | Python code to execute. Tools are async functions that return strings (not objects). You MUST await every call: `result = await read(path='/file', offset=1, limit=0)`. Use `await asyncio.gather(...)` for concurrency. |
 | `timeout` | integer | no | 30 | Script execution timeout in seconds |
 
-### `question` *(lua plugin)*
+### `question` {#question}
 
 Use this tool when you need to ask the user questions during execution. This allows you to:
 - Gather user preferences or requirements
@@ -163,7 +163,7 @@ Use this tool when you need to ask the user questions during execution. This all
 
 ## Agent & Knowledge
 
-### `task` *(lua plugin)*
+### `task` {#task}
 
 Launch an autonomous subagent to perform tasks independently. Best combined with batch.
 
@@ -175,7 +175,7 @@ Launch an autonomous subagent to perform tasks independently. Best combined with
 | `prompt` | string | yes | Detailed task prompt for the agent |
 | `subagent_type` | string | no | Subagent type: "research" (read-only, default) or "general" (can modify files) |
 
-### `todo_write` *(lua plugin)*
+### `todo_write` {#todo_write}
 
 Create or update a structured todo list to track tasks.
 
@@ -183,7 +183,7 @@ Create or update a structured todo list to track tasks.
 |-----------|------|----------|-------------|
 | `todos` | array | yes | The updated todo list |
 
-### `memory` *(lua plugin)*
+### `memory` {#memory}
 
 Persistent, project-scoped scratchpad for learnings, patterns, decisions, and gotchas across sessions.
 
@@ -194,7 +194,7 @@ Persistent, project-scoped scratchpad for learnings, patterns, decisions, and go
 | `path` | string | no | Relative path, e.g. 'architecture.md'. |
 | `tags` | array | no | snake_case tags. Filter for list/read; assigned on write (defaults to filename stem). |
 
-### `skill` *(lua plugin)*
+### `skill` {#skill}
 
 Load a skill that provides instructions and workflows for specific tasks.
 
@@ -204,7 +204,7 @@ Load a skill that provides instructions and workflows for specific tasks.
 
 ## Web
 
-### `webfetch` *(lua plugin)*
+### `webfetch` {#webfetch}
 
 Fetch a URL and return its contents.
 
@@ -214,7 +214,7 @@ Fetch a URL and return its contents.
 | `timeout` | integer | no | 30, max 120 | Timeout in seconds |
 | `url` | string | yes |  | URL to fetch (http:// or https://) |
 
-### `websearch` *(lua plugin)*
+### `websearch` {#websearch}
 
 Search the web for real-time information using Exa AI.
 

--- a/site/docs/extra/maki-dark.json
+++ b/site/docs/extra/maki-dark.json
@@ -1,0 +1,179 @@
+{
+  "name": "maki-dark",
+  "type": "dark",
+  "colors": {
+    "editor.background": "#141624",
+    "editor.foreground": "#D1D4DE"
+  },
+  "tokenColors": [
+    {
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
+      "settings": {
+        "foreground": "#6E738A"
+      }
+    },
+    {
+      "scope": [
+        "string",
+        "punctuation.definition.string"
+      ],
+      "settings": {
+        "foreground": "#94CF9F"
+      }
+    },
+    {
+      "scope": [
+        "string.unquoted"
+      ],
+      "settings": {
+        "foreground": "#D1D4DE"
+      }
+    },
+    {
+      "scope": [
+        "constant.character.escape",
+        "string constant.other.placeholder"
+      ],
+      "settings": {
+        "foreground": "#F6A88D"
+      }
+    },
+    {
+      "scope": [
+        "constant.numeric",
+        "constant.language",
+        "constant.character",
+        "constant.other.option"
+      ],
+      "settings": {
+        "foreground": "#E7A3C3"
+      }
+    },
+    {
+      "scope": [
+        "keyword",
+        "storage.type",
+        "storage.modifier"
+      ],
+      "settings": {
+        "foreground": "#A1ABF0"
+      }
+    },
+    {
+      "scope": [
+        "keyword.operator"
+      ],
+      "settings": {
+        "foreground": "#818599"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.function",
+        "support.function",
+        "meta.function-call.generic"
+      ],
+      "settings": {
+        "foreground": "#F09C7E"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.type",
+        "entity.name.class",
+        "support.type",
+        "support.class",
+        "entity.other.inherited-class"
+      ],
+      "settings": {
+        "foreground": "#84C2D7"
+      }
+    },
+    {
+      "scope": [
+        "support.type.property-name",
+        "variable.key",
+        "entity.name.tag.yaml"
+      ],
+      "settings": {
+        "foreground": "#A1ABF0"
+      }
+    },
+    {
+      "scope": [
+        "variable.language"
+      ],
+      "settings": {
+        "foreground": "#D5ADDE"
+      }
+    },
+    {
+      "scope": [
+        "variable.other.normal",
+        "variable.other.special",
+        "punctuation.definition.variable"
+      ],
+      "settings": {
+        "foreground": "#E7A3C3"
+      }
+    },
+    {
+      "scope": [
+        "punctuation",
+        "meta.brace",
+        "punctuation.separator",
+        "punctuation.terminator"
+      ],
+      "settings": {
+        "foreground": "#818599"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.tag"
+      ],
+      "settings": {
+        "foreground": "#A1ABF0"
+      }
+    },
+    {
+      "scope": [
+        "entity.other.attribute-name"
+      ],
+      "settings": {
+        "foreground": "#F09C7E"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.section",
+        "markup.heading"
+      ],
+      "settings": {
+        "foreground": "#F09C7E"
+      }
+    },
+    {
+      "scope": [
+        "markup.inline.raw",
+        "markup.raw"
+      ],
+      "settings": {
+        "foreground": "#94CF9F"
+      }
+    },
+    {
+      "scope": [
+        "markup.underline.link",
+        "string.other.link",
+        "constant.other.reference.link"
+      ],
+      "settings": {
+        "foreground": "#84C2D7"
+      }
+    }
+  ]
+}

--- a/site/docs/extra/maki-light.json
+++ b/site/docs/extra/maki-light.json
@@ -1,0 +1,179 @@
+{
+  "name": "maki-light",
+  "type": "light",
+  "colors": {
+    "editor.background": "#F1EDDE",
+    "editor.foreground": "#282D40"
+  },
+  "tokenColors": [
+    {
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
+      "settings": {
+        "foreground": "#8A7966"
+      }
+    },
+    {
+      "scope": [
+        "string",
+        "punctuation.definition.string"
+      ],
+      "settings": {
+        "foreground": "#3C673E"
+      }
+    },
+    {
+      "scope": [
+        "string.unquoted"
+      ],
+      "settings": {
+        "foreground": "#282D40"
+      }
+    },
+    {
+      "scope": [
+        "constant.character.escape",
+        "string constant.other.placeholder"
+      ],
+      "settings": {
+        "foreground": "#924D35"
+      }
+    },
+    {
+      "scope": [
+        "constant.numeric",
+        "constant.language",
+        "constant.character",
+        "constant.other.option"
+      ],
+      "settings": {
+        "foreground": "#84446A"
+      }
+    },
+    {
+      "scope": [
+        "keyword",
+        "storage.type",
+        "storage.modifier"
+      ],
+      "settings": {
+        "foreground": "#8B3722"
+      }
+    },
+    {
+      "scope": [
+        "keyword.operator"
+      ],
+      "settings": {
+        "foreground": "#5D6375"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.function",
+        "support.function",
+        "meta.function-call.generic"
+      ],
+      "settings": {
+        "foreground": "#836412"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.type",
+        "entity.name.class",
+        "support.type",
+        "support.class",
+        "entity.other.inherited-class"
+      ],
+      "settings": {
+        "foreground": "#2D6359"
+      }
+    },
+    {
+      "scope": [
+        "support.type.property-name",
+        "variable.key",
+        "entity.name.tag.yaml"
+      ],
+      "settings": {
+        "foreground": "#836412"
+      }
+    },
+    {
+      "scope": [
+        "variable.language"
+      ],
+      "settings": {
+        "foreground": "#6B4474"
+      }
+    },
+    {
+      "scope": [
+        "variable.other.normal",
+        "variable.other.special",
+        "punctuation.definition.variable"
+      ],
+      "settings": {
+        "foreground": "#84446A"
+      }
+    },
+    {
+      "scope": [
+        "punctuation",
+        "meta.brace",
+        "punctuation.separator",
+        "punctuation.terminator"
+      ],
+      "settings": {
+        "foreground": "#5D6375"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.tag"
+      ],
+      "settings": {
+        "foreground": "#8B3722"
+      }
+    },
+    {
+      "scope": [
+        "entity.other.attribute-name"
+      ],
+      "settings": {
+        "foreground": "#836412"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.section",
+        "markup.heading"
+      ],
+      "settings": {
+        "foreground": "#8B3722"
+      }
+    },
+    {
+      "scope": [
+        "markup.inline.raw",
+        "markup.raw"
+      ],
+      "settings": {
+        "foreground": "#3C673E"
+      }
+    },
+    {
+      "scope": [
+        "markup.underline.link",
+        "string.other.link",
+        "constant.other.reference.link"
+      ],
+      "settings": {
+        "foreground": "#2D6359"
+      }
+    }
+  ]
+}

--- a/site/docs/templates/base.html
+++ b/site/docs/templates/base.html
@@ -24,33 +24,35 @@
   </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Nunito:wght@400;700;800&family=Fraunces:opsz,wght@9..144,700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;700&,wght@0,400;0,700;1,400&family=Nunito:wght@400;700;800&family=Fraunces:opsz,wght@9..144,700&display=swap" rel="stylesheet">
   <style>
     *,*::before,*::after { margin: 0; padding: 0; box-sizing: border-box; }
 
     :root {
       color-scheme: light;
-      --lavender: oklch(85% 0.06 280);
-      --periwinkle: oklch(78% 0.08 275);
+      --lavender: oklch(86% 0.05 85);
+      --periwinkle: oklch(76% 0.08 80);
       --soft-pink: oklch(82% 0.06 350);
       --salmon: oklch(62% 0.14 40);
       --cream: oklch(97% 0.015 90);
-      --deep-navy: oklch(22% 0.04 270);
-      --text-primary: oklch(22% 0.04 270);
-      --text-secondary: oklch(40% 0.03 270);
-      --text-muted: oklch(52% 0.03 270);
-      --sidebar-bg: oklch(95.5% 0.025 278 / 0.6);
-      --border-subtle: oklch(88% 0.04 278);
-      --border-light: oklch(91% 0.03 280);
-      --accent: oklch(48% 0.14 275);
-      --accent-soft: oklch(92% 0.05 275);
-      --accent-hover: oklch(42% 0.16 275);
-      --code-bg: oklch(94% 0.03 278);
-      --code-block-bg: #1E1E2E;
-
-      --code-block-fg: oklch(86% 0.02 270);
-      --surface-card: oklch(99% 0.008 280 / 0.75);
-      --card-border: oklch(89% 0.035 278);
+      --deep-navy: oklch(25% 0.03 60);
+      --text-primary: oklch(25% 0.03 60);
+      --text-secondary: oklch(41% 0.025 65);
+      --text-muted: oklch(52% 0.025 70);
+      --sidebar-bg: oklch(95.5% 0.02 90 / 0.6);
+      --border-subtle: oklch(88% 0.03 85);
+      --border-light: oklch(91% 0.025 88);
+      --accent: oklch(47% 0.11 50);
+      --accent-soft: oklch(92% 0.045 80);
+      --accent-hover: oklch(41% 0.13 45);
+      --code-bg: oklch(93.5% 0.025 92);
+      --code-paper: oklch(94.5% 0.02 92);
+      --code-border: oklch(87% 0.03 92);
+      --code-caption: oklch(56% 0.035 75);
+      --code-selection: oklch(87% 0.06 85 / 0.5);
+      --code-scrollbar: oklch(80% 0.035 90);
+      --surface-card: oklch(99% 0.008 90 / 0.75);
+      --card-border: oklch(89% 0.03 88);
       --sidebar-w: 240px;
       --toc-w: 250px;
       --content-max: 740px;
@@ -59,51 +61,50 @@
       --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
 
       --sky-wash:
-        radial-gradient(55% 80% at 82% -12%, oklch(88% 0.055 350 / 0.35), transparent 62%),
-        linear-gradient(180deg, oklch(92% 0.05 276 / 0.65), oklch(94% 0.03 278 / 0.25) 55%, transparent 85%);
+        radial-gradient(55% 80% at 82% -12%, oklch(89% 0.05 45 / 0.35), transparent 62%),
+        linear-gradient(180deg, oklch(93% 0.04 85 / 0.65), oklch(95% 0.025 88 / 0.25) 55%, transparent 85%);
       --topnav-bg: oklch(97% 0.015 90 / 0.97);
-      --topnav-border: oklch(88% 0.04 280 / 0.35);
-      --topnav-shadow: oklch(70% 0.06 280 / 0.06);
-      --topnav-shadow-deep: oklch(70% 0.06 280 / 0.08);
-      --topnav-scrolled-border: oklch(88% 0.04 280 / 0.5);
-      --sidebar-sep: oklch(78% 0.04 280 / 0.3);
-      --sidebar-border: oklch(88% 0.04 280 / 0.3);
-      --sidebar-label-color: oklch(62% 0.04 275);
-      --sidebar-hover-bg: oklch(92% 0.04 278 / 0.5);
-      --sidebar-active-bg: oklch(92% 0.05 275 / 0.5);
-      --sidebar-scrollbar: oklch(80% 0.04 278);
-      --inline-code-color: oklch(38% 0.10 275);
-      --inline-code-border: oklch(89% 0.03 278);
-      --code-block-border: oklch(28% 0.03 275);
-      --table-head-bg: oklch(94% 0.03 278);
-      --table-border: oklch(88% 0.04 278);
-      --table-row-border: oklch(92% 0.02 280);
-      --table-th-color: oklch(42% 0.05 275);
-      --table-hover-bg: oklch(96% 0.02 278);
-      --blockquote-bg: oklch(94.5% 0.03 278 / 0.5);
+      --topnav-border: oklch(88% 0.03 85 / 0.35);
+      --topnav-shadow: oklch(70% 0.05 80 / 0.06);
+      --topnav-shadow-deep: oklch(70% 0.05 80 / 0.08);
+      --topnav-scrolled-border: oklch(88% 0.03 85 / 0.5);
+      --sidebar-sep: oklch(78% 0.035 85 / 0.3);
+      --sidebar-border: oklch(88% 0.03 85 / 0.3);
+      --sidebar-label-color: oklch(60% 0.04 75);
+      --sidebar-hover-bg: oklch(92% 0.035 85 / 0.5);
+      --sidebar-active-bg: oklch(91% 0.05 80 / 0.5);
+      --sidebar-scrollbar: oklch(80% 0.035 85);
+      --inline-code-color: oklch(40% 0.06 60);
+      --inline-code-border: oklch(86.5% 0.035 90);
+      --table-head-bg: oklch(93.5% 0.025 90);
+      --table-border: oklch(88% 0.03 85);
+      --table-row-border: oklch(92% 0.02 88);
+      --table-th-color: oklch(44% 0.05 60);
+      --table-hover-bg: oklch(96% 0.02 90);
+      --blockquote-bg: oklch(94.5% 0.025 88 / 0.5);
       --tip-accent: oklch(60% 0.11 155);
       --tip-bg: oklch(94% 0.03 155 / 0.4);
       --warn-accent: oklch(65% 0.13 45);
       --warn-bg: oklch(95% 0.03 60 / 0.5);
-      --marker-color: oklch(68% 0.06 275);
-      --hr-color: oklch(88% 0.04 280);
-      --link-underline: oklch(55% 0.12 275 / 0.25);
-      --h2-rule: oklch(88% 0.04 278 / 0.7);
-      --h3-code-border: oklch(88% 0.05 275);
-      --search-input-border: oklch(86% 0.04 278);
-      --search-input-bg: oklch(98% 0.01 280 / 0.7);
-      --search-placeholder: oklch(68% 0.03 275);
-      --search-hint-color: oklch(65% 0.03 275);
-      --search-hint-bg: oklch(94% 0.03 278);
-      --search-hint-border: oklch(88% 0.04 278);
-      --search-results-bg: oklch(98% 0.01 280);
-      --search-results-border: oklch(88% 0.04 278);
-      --search-results-shadow: oklch(60% 0.04 280 / 0.14);
-      --search-result-border: oklch(92% 0.02 280);
-      --search-result-hover: oklch(94% 0.04 278);
-      --overlay-bg: oklch(20% 0.02 270 / 0.3);
-      --mobile-sidebar-shadow: oklch(20% 0.02 270 / 0.1);
-      --kbd-shadow: oklch(80% 0.04 278);
+      --marker-color: oklch(66% 0.06 70);
+      --hr-color: oklch(88% 0.03 85);
+      --link-underline: oklch(52% 0.10 50 / 0.3);
+      --h2-rule: oklch(88% 0.03 85 / 0.7);
+      --h3-code-border: oklch(87% 0.045 80);
+      --search-input-border: oklch(86% 0.035 85);
+      --search-input-bg: oklch(98% 0.01 90 / 0.7);
+      --search-placeholder: oklch(66% 0.03 75);
+      --search-hint-color: oklch(63% 0.03 75);
+      --search-hint-bg: oklch(94% 0.025 88);
+      --search-hint-border: oklch(88% 0.03 85);
+      --search-results-bg: oklch(98% 0.01 90);
+      --search-results-border: oklch(88% 0.03 85);
+      --search-results-shadow: oklch(60% 0.04 80 / 0.14);
+      --search-result-border: oklch(92% 0.02 88);
+      --search-result-hover: oklch(93% 0.03 85);
+      --overlay-bg: oklch(25% 0.02 60 / 0.3);
+      --mobile-sidebar-shadow: oklch(25% 0.02 60 / 0.1);
+      --kbd-shadow: oklch(82% 0.03 85);
     }
 
     [data-theme="dark"] {
@@ -123,9 +124,11 @@
       --accent-soft: oklch(25% 0.05 275);
       --accent-hover: oklch(78% 0.13 275);
       --code-bg: oklch(22% 0.025 275);
-      --code-block-bg: #1E1E2E;
-
-      --code-block-fg: oklch(82% 0.02 270);
+      --code-paper: oklch(20.5% 0.028 277);
+      --code-border: oklch(27% 0.03 276);
+      --code-caption: oklch(58% 0.025 275);
+      --code-selection: oklch(45% 0.08 275 / 0.5);
+      --code-scrollbar: oklch(35% 0.03 275);
       --surface-card: oklch(19.5% 0.025 273 / 0.7);
       --card-border: oklch(27% 0.03 275);
 
@@ -157,7 +160,6 @@
       --sidebar-scrollbar: oklch(35% 0.03 275);
       --inline-code-color: oklch(72% 0.08 275);
       --inline-code-border: oklch(28% 0.03 275);
-      --code-block-border: oklch(26% 0.03 275);
       --table-head-bg: oklch(20% 0.025 275);
       --table-border: oklch(26% 0.03 275);
       --table-row-border: oklch(22% 0.02 275);
@@ -346,7 +348,7 @@
     .search-btn .search-hint {
       margin-left: auto;
       font-size: 0.68rem;
-      font-family: 'JetBrains Mono', monospace;
+      font-family: 'IBM Plex Mono', monospace;
       color: var(--search-hint-color);
       background: var(--search-hint-bg);
       padding: 0.1rem 0.4rem;
@@ -384,7 +386,7 @@
       display: inline-flex;
       align-items: center;
       gap: 0.35rem;
-      font-family: 'JetBrains Mono', monospace;
+      font-family: 'IBM Plex Mono', monospace;
       font-size: 0.68rem;
       font-weight: 400;
       color: var(--text-muted);
@@ -451,7 +453,7 @@
     .badge {
       display: inline-block;
       vertical-align: 0.15em;
-      font-family: 'JetBrains Mono', monospace;
+      font-family: 'IBM Plex Mono', monospace;
       font-size: 0.6rem;
       font-weight: 700;
       text-transform: uppercase;
@@ -466,7 +468,7 @@
 
     .h-anchor {
       margin-left: 0.4rem;
-      font-family: 'JetBrains Mono', monospace;
+      font-family: 'IBM Plex Mono', monospace;
       font-weight: 400;
       color: var(--accent);
       text-decoration: none;
@@ -502,7 +504,7 @@
 
     /* ── INLINE CODE ── */
     code {
-      font-family: 'JetBrains Mono', 'Fira Code', monospace;
+      font-family: 'IBM Plex Mono', 'Fira Code', monospace;
       font-size: 0.84em;
       background: var(--code-bg);
       color: var(--inline-code-color);
@@ -513,43 +515,48 @@
     /* ── CODE BLOCKS ── */
     pre {
       position: relative;
-      background: var(--code-block-bg) !important;
-      color: var(--code-block-fg) !important;
-      color-scheme: dark !important;
-      padding: 1.25rem 1.5rem;
+      background: var(--code-paper);
+      border: 1px solid var(--code-border);
+      color-scheme: light !important;
+      padding: 1.05rem 1.25rem;
       overflow-x: auto;
-      margin-bottom: 1.5rem;
-      border: 1px solid var(--code-block-border);
+      margin-bottom: 1.75rem;
+      scrollbar-width: thin;
+      scrollbar-color: var(--code-scrollbar) transparent;
     }
-    .copy-btn {
-      position: absolute;
-      top: 0.5rem;
-      right: 0.5rem;
-      display: grid;
-      place-items: center;
-      width: 1.7rem;
-      height: 1.7rem;
-      padding: 0;
-      border: 1px solid oklch(40% 0.03 275 / 0.6);
-      background: oklch(25% 0.03 275 / 0.9);
-      color: oklch(70% 0.02 270);
-      cursor: pointer;
-      opacity: 0;
-      transition: opacity 0.15s, color 0.15s, background 0.15s;
-    }
-    pre:hover .copy-btn, .copy-btn:focus-visible { opacity: 1; }
-    .copy-btn:hover { background: oklch(32% 0.03 275); color: oklch(90% 0.02 270); }
-    .copy-btn.copied { color: oklch(78% 0.14 150); opacity: 1; }
-    .copy-btn.copied svg:first-child, .copy-btn:not(.copied) svg:last-child { display: none; }
-    @media (hover: none) { .copy-btn { opacity: 0.7; } }
+    [data-theme="dark"] pre { color-scheme: dark !important; }
+    pre ::selection { background: var(--code-selection); }
     pre code {
+      display: block;
       background: none;
       border: none;
       padding: 0;
-      color: var(--code-block-fg);
-      font-size: 0.87rem;
-      line-height: 1.65;
+      color: inherit;
+      font-size: 0.85rem;
+      line-height: 1.7;
+      font-feature-settings: 'zero';
     }
+    .copy-btn {
+      position: absolute;
+      top: 0.55rem;
+      right: 0.75rem;
+      padding: 0.2rem 0.3rem;
+      border: none;
+      background: var(--code-paper);
+      font: 0.62rem 'IBM Plex Mono', monospace;
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      color: var(--code-caption);
+      cursor: pointer;
+      opacity: 0;
+      transition: opacity 0.15s, color 0.15s;
+    }
+    .copy-btn::after { content: 'copy'; }
+    .copy-btn.copied::after { content: 'copied!'; }
+    pre:hover .copy-btn, .copy-btn:focus-visible { opacity: 1; }
+    .copy-btn:hover { color: var(--accent); }
+    .copy-btn.copied { color: var(--tip-accent); opacity: 1; }
+    @media (hover: none) { .copy-btn { opacity: 0.7; } }
 
     /* ── SYNTAX HIGHLIGHTING ── */
     .giallo-l { display: inline-block; min-height: 1lh; width: 100%; }
@@ -623,7 +630,7 @@
     }
     .doc-group-head .eyebrow { font-size: 0.76rem; }
     .doc-group-head .tagline {
-      font-family: 'JetBrains Mono', monospace;
+      font-family: 'IBM Plex Mono', monospace;
       font-size: 0.72rem;
       color: var(--text-muted);
     }
@@ -653,7 +660,7 @@
     }
     .card-title::before {
       content: '❯ ';
-      font-family: 'JetBrains Mono', monospace;
+      font-family: 'IBM Plex Mono', monospace;
       font-size: 0.78rem;
       color: var(--accent);
     }
@@ -736,7 +743,7 @@
     .toc .toc-h3 {
       padding-left: 1.6rem;
       font-weight: 400;
-      font-family: 'JetBrains Mono', monospace;
+      font-family: 'IBM Plex Mono', monospace;
       font-size: 0.72rem;
     }
     .toc .toc-sub { display: none; margin-bottom: 0.2rem; }
@@ -786,7 +793,7 @@
     }
     .search-row input::placeholder { color: var(--search-placeholder); }
     .search-row kbd {
-      font-family: 'JetBrains Mono', monospace;
+      font-family: 'IBM Plex Mono', monospace;
       font-size: 0.62rem;
       color: var(--search-hint-color);
       background: var(--search-hint-bg);
@@ -1060,8 +1067,6 @@
     btn.className = 'copy-btn';
     btn.type = 'button';
     btn.setAttribute('aria-label', 'Copy code');
-    btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>'
-      + '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
     let timer;
     btn.addEventListener('click', async () => {
       await navigator.clipboard.writeText(code.innerText.replace(/\n$/, ''));

--- a/site/docs/templates/base.html
+++ b/site/docs/templates/base.html
@@ -21,13 +21,7 @@
         document.documentElement.style.background = 'oklch(97% 0.015 90)';
       }
     })();
-  document.querySelectorAll('.content-inner table').forEach(t => {
-    const wrap = document.createElement('div');
-    wrap.className = 'table-wrap';
-    t.parentNode.insertBefore(wrap, t);
-    wrap.appendChild(t);
-  });
-</script>
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Nunito:wght@400;700;800&family=Fraunces:opsz,wght@9..144,700&display=swap" rel="stylesheet">
@@ -39,17 +33,13 @@
       --lavender: oklch(85% 0.06 280);
       --periwinkle: oklch(78% 0.08 275);
       --soft-pink: oklch(82% 0.06 350);
-      --salmon: oklch(75% 0.12 40);
+      --salmon: oklch(62% 0.14 40);
       --cream: oklch(97% 0.015 90);
       --deep-navy: oklch(22% 0.04 270);
-      --navy-light: oklch(32% 0.04 270);
       --text-primary: oklch(22% 0.04 270);
       --text-secondary: oklch(40% 0.03 270);
       --text-muted: oklch(52% 0.03 270);
-      --surface-glow: oklch(90% 0.05 280);
-      --sky-start: oklch(94% 0.03 275);
-      --sky-end: oklch(90% 0.05 280);
-      --sidebar-bg: oklch(95.5% 0.025 278);
+      --sidebar-bg: oklch(95.5% 0.025 278 / 0.6);
       --border-subtle: oklch(88% 0.04 278);
       --border-light: oklch(91% 0.03 280);
       --accent: oklch(48% 0.14 275);
@@ -57,7 +47,10 @@
       --accent-hover: oklch(42% 0.16 275);
       --code-bg: oklch(94% 0.03 278);
       --code-block-bg: #1E1E2E;
+
       --code-block-fg: oklch(86% 0.02 270);
+      --surface-card: oklch(99% 0.008 280 / 0.75);
+      --card-border: oklch(89% 0.035 278);
       --sidebar-w: 240px;
       --toc-w: 250px;
       --content-max: 740px;
@@ -65,7 +58,10 @@
       --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
       --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
 
-      --topnav-bg: oklch(97% 0.015 90 / 0.8);
+      --sky-wash:
+        radial-gradient(55% 80% at 82% -12%, oklch(88% 0.055 350 / 0.35), transparent 62%),
+        linear-gradient(180deg, oklch(92% 0.05 276 / 0.65), oklch(94% 0.03 278 / 0.25) 55%, transparent 85%);
+      --topnav-bg: oklch(97% 0.015 90 / 0.97);
       --topnav-border: oklch(88% 0.04 280 / 0.35);
       --topnav-shadow: oklch(70% 0.06 280 / 0.06);
       --topnav-shadow-deep: oklch(70% 0.06 280 / 0.08);
@@ -85,52 +81,70 @@
       --table-th-color: oklch(42% 0.05 275);
       --table-hover-bg: oklch(96% 0.02 278);
       --blockquote-bg: oklch(94.5% 0.03 278 / 0.5);
+      --tip-accent: oklch(60% 0.11 155);
+      --tip-bg: oklch(94% 0.03 155 / 0.4);
+      --warn-accent: oklch(65% 0.13 45);
+      --warn-bg: oklch(95% 0.03 60 / 0.5);
       --marker-color: oklch(68% 0.06 275);
       --hr-color: oklch(88% 0.04 280);
       --link-underline: oklch(55% 0.12 275 / 0.25);
-      --h2-rule: oklch(88% 0.04 278);
+      --h2-rule: oklch(88% 0.04 278 / 0.7);
       --h3-code-border: oklch(88% 0.05 275);
       --search-input-border: oklch(86% 0.04 278);
       --search-input-bg: oklch(98% 0.01 280 / 0.7);
       --search-placeholder: oklch(68% 0.03 275);
-      --search-focus-border: oklch(72% 0.08 275);
-      --search-focus-ring: oklch(78% 0.08 275 / 0.15);
-      --search-focus-bg: oklch(99% 0.005 280);
-      --search-icon-color: oklch(62% 0.03 275);
-      --search-results-bg: oklch(98% 0.01 280);
-      --search-results-border: oklch(88% 0.04 278);
-      --search-results-shadow: oklch(60% 0.04 280 / 0.1);
-      --search-results-shadow-deep: oklch(60% 0.04 280 / 0.08);
-      --search-result-border: oklch(92% 0.02 280);
-      --search-result-hover: oklch(94% 0.04 278);
       --search-hint-color: oklch(65% 0.03 275);
       --search-hint-bg: oklch(94% 0.03 278);
       --search-hint-border: oklch(88% 0.04 278);
-      --overlay-bg: oklch(20% 0.02 270 / 0.25);
+      --search-results-bg: oklch(98% 0.01 280);
+      --search-results-border: oklch(88% 0.04 278);
+      --search-results-shadow: oklch(60% 0.04 280 / 0.14);
+      --search-result-border: oklch(92% 0.02 280);
+      --search-result-hover: oklch(94% 0.04 278);
+      --overlay-bg: oklch(20% 0.02 270 / 0.3);
       --mobile-sidebar-shadow: oklch(20% 0.02 270 / 0.1);
+      --kbd-shadow: oklch(80% 0.04 278);
     }
 
     [data-theme="dark"] {
       color-scheme: dark;
       --cream: oklch(16% 0.02 270);
       --deep-navy: oklch(92% 0.02 275);
-      --navy-light: oklch(80% 0.03 275);
       --text-primary: oklch(90% 0.02 275);
       --text-secondary: oklch(72% 0.025 275);
       --text-muted: oklch(58% 0.025 275);
       --lavender: oklch(45% 0.06 280);
       --periwinkle: oklch(55% 0.08 275);
-      --sidebar-bg: oklch(18% 0.02 272);
+      --salmon: oklch(72% 0.13 40);
+      --sidebar-bg: oklch(18% 0.02 272 / 0.55);
       --border-subtle: oklch(28% 0.03 275);
       --border-light: oklch(25% 0.02 275);
-      --accent: oklch(68% 0.12 275);
+      --accent: oklch(70% 0.11 275);
       --accent-soft: oklch(25% 0.05 275);
-      --accent-hover: oklch(75% 0.14 275);
+      --accent-hover: oklch(78% 0.13 275);
       --code-bg: oklch(22% 0.025 275);
       --code-block-bg: #1E1E2E;
+
       --code-block-fg: oklch(82% 0.02 270);
-      --surface-glow: oklch(22% 0.04 280);
-      --topnav-bg: oklch(16% 0.02 270 / 0.85);
+      --surface-card: oklch(19.5% 0.025 273 / 0.7);
+      --card-border: oklch(27% 0.03 275);
+
+      --sky-wash:
+        radial-gradient(1.5px 1.5px at 11% 48px, oklch(90% 0.02 275 / 0.9) 45%, transparent 55%),
+        radial-gradient(1px 1px at 27% 130px, oklch(90% 0.02 275 / 0.7) 45%, transparent 55%),
+        radial-gradient(2px 2px at 38% 34px, oklch(92% 0.03 300 / 0.8) 45%, transparent 55%),
+        radial-gradient(1px 1px at 49% 180px, oklch(90% 0.02 275 / 0.55) 45%, transparent 55%),
+        radial-gradient(1.5px 1.5px at 57% 76px, oklch(90% 0.02 275 / 0.85) 45%, transparent 55%),
+        radial-gradient(1px 1px at 66% 210px, oklch(90% 0.02 275 / 0.5) 45%, transparent 55%),
+        radial-gradient(2px 2px at 74% 40px, oklch(92% 0.03 300 / 0.9) 45%, transparent 55%),
+        radial-gradient(1px 1px at 82% 150px, oklch(90% 0.02 275 / 0.6) 45%, transparent 55%),
+        radial-gradient(1.5px 1.5px at 90% 90px, oklch(90% 0.02 275 / 0.8) 45%, transparent 55%),
+        radial-gradient(1px 1px at 96% 24px, oklch(90% 0.02 275 / 0.7) 45%, transparent 55%),
+        radial-gradient(1px 1px at 19% 240px, oklch(90% 0.02 275 / 0.4) 45%, transparent 55%),
+        radial-gradient(1.5px 1.5px at 88% 260px, oklch(90% 0.02 275 / 0.45) 45%, transparent 55%),
+        radial-gradient(55% 85% at 80% -15%, oklch(32% 0.07 290 / 0.55), transparent 65%),
+        linear-gradient(180deg, oklch(21% 0.045 278 / 0.85), oklch(19% 0.03 275 / 0.4) 55%, transparent 85%);
+      --topnav-bg: oklch(17% 0.022 271 / 0.97);
       --topnav-border: oklch(28% 0.03 275 / 0.5);
       --topnav-shadow: oklch(5% 0.02 270 / 0.2);
       --topnav-shadow-deep: oklch(5% 0.02 270 / 0.3);
@@ -143,39 +157,45 @@
       --sidebar-scrollbar: oklch(35% 0.03 275);
       --inline-code-color: oklch(72% 0.08 275);
       --inline-code-border: oklch(28% 0.03 275);
-      --code-block-border: oklch(24% 0.03 275);
+      --code-block-border: oklch(26% 0.03 275);
       --table-head-bg: oklch(20% 0.025 275);
       --table-border: oklch(26% 0.03 275);
       --table-row-border: oklch(22% 0.02 275);
       --table-th-color: oklch(62% 0.04 275);
       --table-hover-bg: oklch(20% 0.025 275);
       --blockquote-bg: oklch(20% 0.03 278 / 0.5);
+      --tip-accent: oklch(68% 0.11 155);
+      --tip-bg: oklch(22% 0.03 160 / 0.4);
+      --warn-accent: oklch(70% 0.12 45);
+      --warn-bg: oklch(23% 0.03 55 / 0.45);
       --marker-color: oklch(50% 0.06 275);
       --hr-color: oklch(28% 0.03 275);
       --link-underline: oklch(60% 0.10 275 / 0.3);
-      --h2-rule: oklch(28% 0.03 275);
+      --h2-rule: oklch(28% 0.03 275 / 0.8);
       --h3-code-border: oklch(30% 0.05 275);
       --search-input-border: oklch(30% 0.03 275);
       --search-input-bg: oklch(20% 0.02 275 / 0.7);
       --search-placeholder: oklch(48% 0.03 275);
-      --search-focus-border: oklch(50% 0.08 275);
-      --search-focus-ring: oklch(50% 0.08 275 / 0.2);
-      --search-focus-bg: oklch(18% 0.02 275);
-      --search-icon-color: oklch(48% 0.03 275);
-      --search-results-bg: oklch(20% 0.02 275);
-      --search-results-border: oklch(28% 0.03 275);
-      --search-results-shadow: oklch(5% 0.02 270 / 0.3);
-      --search-results-shadow-deep: oklch(5% 0.02 270 / 0.25);
-      --search-result-border: oklch(24% 0.02 275);
-      --search-result-hover: oklch(24% 0.04 278);
       --search-hint-color: oklch(50% 0.03 275);
       --search-hint-bg: oklch(22% 0.025 275);
       --search-hint-border: oklch(30% 0.03 275);
-      --overlay-bg: oklch(5% 0.01 270 / 0.5);
+      --search-results-bg: oklch(20% 0.02 275);
+      --search-results-border: oklch(30% 0.03 275);
+      --search-results-shadow: oklch(5% 0.02 270 / 0.45);
+      --search-result-border: oklch(24% 0.02 275);
+      --search-result-hover: oklch(24% 0.04 278);
+      --overlay-bg: oklch(5% 0.01 270 / 0.55);
       --mobile-sidebar-shadow: oklch(5% 0.02 270 / 0.3);
+      --kbd-shadow: oklch(30% 0.03 275);
+    }
+
+    @view-transition { navigation: auto; }
+    @media (prefers-reduced-motion: no-preference) {
+      ::view-transition-old(root), ::view-transition-new(root) { animation-duration: 0.14s; }
     }
 
     html {
+      background: var(--cream);
       scroll-behavior: smooth;
       scroll-padding-top: calc(var(--nav-h) + 2rem);
       -webkit-font-smoothing: antialiased;
@@ -185,17 +205,23 @@
     body {
       font-family: 'Nunito', system-ui, sans-serif;
       color: var(--text-primary);
-      background: var(--cream);
       line-height: 1.72;
       font-size: 17px;
+    }
+    body::before {
+      content: '';
+      position: absolute;
+      top: 0; left: 0; right: 0;
+      height: 480px;
+      z-index: -1;
+      pointer-events: none;
+      background: var(--sky-wash);
     }
 
     /* ── TOP NAV ── */
     .topnav {
       position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
+      top: 0; left: 0; right: 0;
       z-index: 100;
       height: var(--nav-h);
       display: flex;
@@ -203,10 +229,8 @@
       justify-content: space-between;
       padding: 0 1.75rem;
       background: var(--topnav-bg);
-      backdrop-filter: blur(20px) saturate(1.2);
-      -webkit-backdrop-filter: blur(20px) saturate(1.2);
       border-bottom: 1px solid var(--topnav-border);
-      transition: box-shadow 0.4s var(--ease-smooth), border-color 0.4s var(--ease-smooth);
+      transition: box-shadow 0.3s var(--ease-smooth), border-color 0.3s var(--ease-smooth);
     }
     .topnav.scrolled {
       box-shadow: 0 1px 3px var(--topnav-shadow), 0 6px 24px var(--topnav-shadow-deep);
@@ -219,14 +243,10 @@
       color: var(--deep-navy);
       text-decoration: none;
       letter-spacing: -0.03em;
-      transition: opacity 0.2s;
+      transition: opacity 0.15s;
     }
     .topnav-logo:hover { opacity: 0.7; }
-    .topnav-sep {
-      width: 1px;
-      height: 18px;
-      background: var(--sidebar-sep);
-    }
+    .topnav-sep { width: 1px; height: 18px; background: var(--sidebar-sep); }
     .topnav-section {
       font-size: 0.85rem;
       font-weight: 700;
@@ -240,14 +260,10 @@
       font-weight: 700;
       color: var(--text-muted);
       text-decoration: none;
-      transition: color 0.2s;
+      transition: color 0.15s;
     }
     .topnav-right a:hover { color: var(--deep-navy); }
-    .topnav-github {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.35rem;
-    }
+    .topnav-github { display: inline-flex; align-items: center; gap: 0.35rem; }
     .topnav-github svg { vertical-align: middle; }
 
     .sidebar-toggle {
@@ -272,8 +288,7 @@
     .sidebar {
       position: fixed;
       top: var(--nav-h);
-      left: 0;
-      bottom: 0;
+      left: 0; bottom: 0;
       width: var(--sidebar-w);
       padding: 1.25rem 1rem 2rem 1.5rem;
       overflow-y: auto;
@@ -282,7 +297,6 @@
       z-index: 50;
     }
     .sidebar::-webkit-scrollbar { width: 3px; }
-    .sidebar::-webkit-scrollbar-thumb { background: var(--sidebar-scrollbar); border-radius: 3px; }
     .sidebar::-webkit-scrollbar-track { background: transparent; }
 
     .sidebar-group { margin-bottom: 0.5rem; }
@@ -300,20 +314,43 @@
       font-weight: 700;
       color: var(--text-secondary);
       text-decoration: none;
-      border-radius: 6px;
-      transition: background 0.2s var(--ease-smooth), color 0.2s var(--ease-smooth), transform 0.15s var(--ease-out);
+      transition: background 0.15s var(--ease-smooth), color 0.15s var(--ease-smooth);
       line-height: 1.5;
       border-left: 2px solid transparent;
     }
-    .sidebar a:hover {
-      background: var(--sidebar-hover-bg);
-      color: var(--accent);
-    }
-    .sidebar a:active { transform: scale(0.98); }
+    .sidebar a:hover { background: var(--sidebar-hover-bg); color: var(--accent); }
     .sidebar a.active {
       background: var(--sidebar-active-bg);
       color: var(--accent);
       border-left-color: var(--accent);
+    }
+
+    /* ── SEARCH BUTTON (sidebar) ── */
+    .search-btn {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      width: 100%;
+      margin-bottom: 1.25rem;
+      padding: 0.5rem 0.65rem;
+      font-family: 'Nunito', sans-serif;
+      font-size: 0.84rem;
+      font-weight: 700;
+      color: var(--search-placeholder);
+      border: 1px solid var(--search-input-border);
+      background: var(--search-input-bg);
+      cursor: pointer;
+      transition: border-color 0.15s, color 0.15s;
+    }
+    .search-btn:hover { border-color: var(--accent); color: var(--text-secondary); }
+    .search-btn .search-hint {
+      margin-left: auto;
+      font-size: 0.68rem;
+      font-family: 'JetBrains Mono', monospace;
+      color: var(--search-hint-color);
+      background: var(--search-hint-bg);
+      padding: 0.1rem 0.4rem;
+      border: 1px solid var(--search-hint-border);
     }
 
     /* ── MAIN CONTENT ── */
@@ -324,10 +361,42 @@
       padding: 2.75rem clamp(2rem, 5vw, 3.5rem) 5rem;
       max-width: calc(var(--content-max) + var(--sidebar-w) + 7rem);
     }
-    .main-content > .content-inner {
-      max-width: var(--content-max);
-      overflow-x: auto;
+    .main-content > .content-inner { max-width: var(--content-max); }
+
+    /* ── PAGE HEAD ── */
+    .page-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-bottom: 0.5rem;
+      min-height: 1.5rem;
     }
+    .eyebrow {
+      font-size: 0.72rem;
+      font-weight: 800;
+      text-transform: uppercase;
+      letter-spacing: 0.14em;
+      color: var(--accent);
+    }
+    .page-actions { display: flex; gap: 0.5rem; }
+    .page-actions button, .page-actions a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.68rem;
+      font-weight: 400;
+      color: var(--text-muted);
+      background: var(--surface-card);
+      border: 1px solid var(--card-border);
+      padding: 0.25rem 0.55rem;
+      cursor: pointer;
+      text-decoration: none;
+      transition: color 0.15s, border-color 0.15s;
+      white-space: nowrap;
+    }
+    .page-actions button:hover, .page-actions a:hover { color: var(--accent); border-color: var(--accent); }
 
     /* ── TYPOGRAPHY ── */
     h1 {
@@ -337,44 +406,36 @@
       letter-spacing: -0.025em;
       line-height: 1.15;
       color: var(--deep-navy);
-      margin-bottom: 2rem;
-      position: relative;
+      margin-bottom: 1.75rem;
     }
     h1::after {
       content: '';
       display: block;
       width: 48px;
       height: 3px;
-      background: linear-gradient(90deg, var(--accent), var(--periwinkle));
-      border-radius: 2px;
+      background: var(--accent);
       margin-top: 0.75rem;
     }
+    .page-home h1 { font-size: clamp(2.1rem, 4vw, 2.7rem); }
 
     h2 {
       font-family: 'Fraunces', 'Georgia', serif;
       font-weight: 700;
-      font-size: clamp(1.5rem, 3vw, 1.85rem);
+      font-size: clamp(1.45rem, 3vw, 1.75rem);
       letter-spacing: -0.02em;
       line-height: 1.25;
       color: var(--deep-navy);
       margin-top: 3rem;
       margin-bottom: 1rem;
-    }
-    h2::before {
-      content: '';
-      display: block;
-      width: 100%;
-      height: 1.5px;
-      border-radius: 2px;
-      background: linear-gradient(90deg, var(--accent), var(--periwinkle) 45%, transparent 85%);
-      margin-bottom: 1.25rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid var(--h2-rule);
     }
 
     h3 {
       font-weight: 800;
       font-size: 1.05rem;
       color: var(--deep-navy);
-      margin-top: 2rem;
+      margin-top: 2.4rem;
       margin-bottom: 0.6rem;
       letter-spacing: -0.01em;
     }
@@ -384,9 +445,36 @@
       color: var(--accent);
       background: var(--accent-soft);
       padding: 0.15rem 0.5rem;
-      border-radius: 5px;
       border: 1px solid var(--h3-code-border);
     }
+
+    .badge {
+      display: inline-block;
+      vertical-align: 0.15em;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.6rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      background: var(--surface-card);
+      border: 1px solid var(--card-border);
+      padding: 0.08rem 0.5rem;
+      margin-left: 0.4rem;
+    }
+    .badge-optin { color: var(--salmon); border-color: currentcolor; }
+
+    .h-anchor {
+      margin-left: 0.4rem;
+      font-family: 'JetBrains Mono', monospace;
+      font-weight: 400;
+      color: var(--accent);
+      text-decoration: none;
+      opacity: 0;
+      transition: opacity 0.12s;
+    }
+    h2:hover .h-anchor, h3:hover .h-anchor, .h-anchor:focus-visible { opacity: 0.7; }
+    .h-anchor:hover { opacity: 1; }
 
     p, ul, ol { margin-bottom: 1.1rem; }
     ul, ol { padding-left: 1.5rem; }
@@ -408,7 +496,7 @@
     hr {
       border: none;
       height: 1px;
-      background: linear-gradient(90deg, var(--hr-color), transparent);
+      background: var(--hr-color);
       margin: 2.5rem 0;
     }
 
@@ -419,7 +507,6 @@
       background: var(--code-bg);
       color: var(--inline-code-color);
       padding: 0.15rem 0.4rem;
-      border-radius: 4px;
       border: 1px solid var(--inline-code-border);
     }
 
@@ -429,7 +516,6 @@
       background: var(--code-block-bg) !important;
       color: var(--code-block-fg) !important;
       color-scheme: dark !important;
-      border-radius: 10px;
       padding: 1.25rem 1.5rem;
       overflow-x: auto;
       margin-bottom: 1.5rem;
@@ -441,16 +527,15 @@
       right: 0.5rem;
       display: grid;
       place-items: center;
-      width: 2rem;
-      height: 2rem;
+      width: 1.7rem;
+      height: 1.7rem;
       padding: 0;
       border: 1px solid oklch(40% 0.03 275 / 0.6);
-      border-radius: 6px;
-      background: oklch(25% 0.03 275 / 0.85);
-      color: oklch(72% 0.02 270);
+      background: oklch(25% 0.03 275 / 0.9);
+      color: oklch(70% 0.02 270);
       cursor: pointer;
       opacity: 0;
-      transition: 0.15s;
+      transition: opacity 0.15s, color 0.15s, background 0.15s;
     }
     pre:hover .copy-btn, .copy-btn:focus-visible { opacity: 1; }
     .copy-btn:hover { background: oklch(32% 0.03 275); color: oklch(90% 0.02 270); }
@@ -473,19 +558,16 @@
     .table-wrap {
       overflow-x: auto;
       margin-bottom: 1.5rem;
-      border-radius: 10px;
       border: 1px solid var(--table-border);
+      background: var(--surface-card);
     }
     table {
       width: 100%;
       border-collapse: separate;
       border-spacing: 0;
       font-size: 0.87rem;
-      overflow: hidden;
     }
-    thead {
-      background: var(--table-head-bg);
-    }
+    thead { background: var(--table-head-bg); }
     th {
       padding: 0.65rem 0.85rem;
       text-align: left;
@@ -501,42 +583,127 @@
       border-bottom: 1px solid var(--table-row-border);
       color: var(--text-secondary);
     }
-    td code {
-      font-size: 0.82rem;
-      white-space: nowrap;
-    }
+    td code { font-size: 0.82rem; white-space: nowrap; }
     tr:last-child td { border-bottom: none; }
-    tbody tr {
-      transition: background 0.15s var(--ease-smooth);
-    }
     tbody tr:hover { background: var(--table-hover-bg); }
 
-    /* ── BLOCKQUOTE ── */
+    /* ── KBD (keybindings) ── */
+    .page-keybindings td:first-child code {
+      background: var(--surface-card);
+      border: 1px solid var(--inline-code-border);
+      box-shadow: 0 2px 0 var(--kbd-shadow);
+      padding: 0.12rem 0.5rem;
+      color: var(--text-secondary);
+      font-size: 0.78rem;
+    }
+
+    /* ── BLOCKQUOTE / CALLOUTS ── */
     blockquote {
       border-left: 3px solid var(--periwinkle);
       padding: 0.85rem 1.25rem;
       margin-bottom: 1.25rem;
       background: var(--blockquote-bg);
-      border-radius: 0 8px 8px 0;
       color: var(--text-secondary);
       font-size: 0.94rem;
     }
     blockquote p:last-child { margin-bottom: 0; }
+    blockquote.callout-tip { border-left-color: var(--tip-accent); background: var(--tip-bg); }
+    blockquote.callout-tip strong:first-child { color: var(--tip-accent); }
+    blockquote.callout-warning { border-left-color: var(--warn-accent); background: var(--warn-bg); }
+    blockquote.callout-warning strong:first-child { color: var(--warn-accent); }
+    blockquote.callout-note strong:first-child { color: var(--accent); }
+
+    /* ── CARDS (docs index) ── */
+    .doc-group { margin-top: 2.25rem; }
+    .doc-group-head {
+      display: flex;
+      align-items: baseline;
+      gap: 0.75rem;
+      margin-bottom: 0.8rem;
+    }
+    .doc-group-head .eyebrow { font-size: 0.76rem; }
+    .doc-group-head .tagline {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.72rem;
+      color: var(--text-muted);
+    }
+    .card-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 0.8rem;
+    }
+    a.card {
+      display: block;
+      padding: 0.9rem 1.05rem;
+      background: var(--surface-card);
+      border: 1px solid var(--card-border);
+      text-decoration: none;
+      transition: border-color 0.15s, background 0.15s;
+    }
+    a.card:hover {
+      border-color: var(--accent);
+      background: var(--search-results-bg);
+    }
+    .card-title {
+      display: block;
+      font-weight: 800;
+      font-size: 0.95rem;
+      color: var(--deep-navy);
+      line-height: 1.4;
+    }
+    .card-title::before {
+      content: '❯ ';
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.78rem;
+      color: var(--accent);
+    }
+    .card-desc {
+      display: block;
+      margin-top: 0.15rem;
+      font-size: 0.82rem;
+      line-height: 1.5;
+      color: var(--text-muted);
+    }
+
+    /* ── PREV / NEXT ── */
+    .page-nav {
+      display: flex;
+      gap: 0.9rem;
+      margin-top: 4rem;
+    }
+    .page-nav a {
+      flex: 1;
+      display: block;
+      padding: 0.85rem 1.1rem;
+      background: var(--surface-card);
+      border: 1px solid var(--card-border);
+      text-decoration: none;
+      transition: border-color 0.15s;
+    }
+    .page-nav a:hover { border-color: var(--accent); }
+    .page-nav a.pn-next { text-align: right; }
+    .page-nav .pn-dir {
+      display: block;
+      font-size: 0.68rem;
+      font-weight: 800;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--text-muted);
+    }
+    .page-nav .pn-title { font-weight: 800; font-size: 0.95rem; color: var(--accent); }
 
     /* ── RIGHT TOC ── */
     .toc {
       display: none;
       position: fixed;
       top: var(--nav-h);
-      right: 0;
-      bottom: 0;
+      right: 0; bottom: 0;
       width: var(--toc-w);
       overflow-y: auto;
       padding: 1.75rem 1.25rem 2.5rem 0.5rem;
       scrollbar-width: thin;
     }
     .toc::-webkit-scrollbar { width: 3px; }
-    .toc::-webkit-scrollbar-thumb { background: var(--sidebar-scrollbar); border-radius: 3px; }
     .toc-label {
       font-size: 0.68rem;
       font-weight: 800;
@@ -554,7 +721,6 @@
       color: var(--text-muted);
       text-decoration: none;
       border-left: 2px solid transparent;
-      border-radius: 0 6px 6px 0;
       line-height: 1.45;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -573,83 +739,78 @@
       font-family: 'JetBrains Mono', monospace;
       font-size: 0.72rem;
     }
-    .toc .toc-sub {
-      display: none;
-      margin-bottom: 0.2rem;
-    }
+    .toc .toc-sub { display: none; margin-bottom: 0.2rem; }
     .toc .toc-group.open .toc-sub { display: block; }
     @media (min-width: 1400px) {
       .toc { display: block; }
-      body.has-toc .main-content {
-        margin-right: var(--toc-w);
-        max-width: none;
-      }
+      body.has-toc .main-content { margin-right: var(--toc-w); max-width: none; }
       body.has-toc .content-inner { margin: 0 auto; }
     }
 
-    /* ── SEARCH ── */
-    .search-box {
+    /* ── SEARCH MODAL ── */
+    .search-modal { position: fixed; inset: 0; z-index: 300; }
+    .search-modal[hidden] { display: none; }
+    .search-backdrop { position: absolute; inset: 0; background: var(--overlay-bg); }
+    .search-panel {
       position: relative;
-      margin-bottom: 1.25rem;
-    }
-    .search-box input {
-      width: 100%;
-      padding: 0.5rem 0.75rem 0.5rem 2.1rem;
-      font-family: 'Nunito', sans-serif;
-      font-size: 0.84rem;
-      border: 1px solid var(--search-input-border);
-      border-radius: 8px;
-      background: var(--search-input-bg);
-      color: var(--text-primary);
-      outline: none;
-      transition: border-color 0.2s var(--ease-smooth), box-shadow 0.2s var(--ease-smooth), background 0.2s;
-    }
-    .search-box input::placeholder { color: var(--search-placeholder); }
-    .search-box input:focus {
-      border-color: var(--search-focus-border);
-      box-shadow: 0 0 0 3px var(--search-focus-ring);
-      background: var(--search-focus-bg);
-    }
-    .search-box svg {
-      position: absolute;
-      left: 0.65rem;
-      top: 50%;
-      transform: translateY(-50%);
-      color: var(--search-icon-color);
-      pointer-events: none;
-    }
-    .search-results {
-      position: absolute;
-      top: calc(100% + 4px);
-      left: 0;
-      right: 0;
+      margin: 11vh auto 0;
+      width: min(580px, calc(100vw - 2rem));
       background: var(--search-results-bg);
       border: 1px solid var(--search-results-border);
-      border-radius: 8px;
-      box-shadow: 0 4px 16px var(--search-results-shadow), 0 12px 40px var(--search-results-shadow-deep);
-      z-index: 200;
-      max-height: 400px;
-      overflow-y: auto;
-      display: none;
+      box-shadow: 0 16px 60px var(--search-results-shadow);
+      overflow: hidden;
     }
-    .search-results.open { display: block; }
+    @media (prefers-reduced-motion: no-preference) {
+      .search-panel { animation: search-pop 0.13s var(--ease-out); }
+    }
+    @keyframes search-pop {
+      from { opacity: 0; transform: translateY(-8px) scale(0.985); }
+    }
+    .search-row {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--search-result-border);
+      color: var(--search-placeholder);
+    }
+    .search-row input {
+      flex: 1;
+      border: none;
+      background: none;
+      outline: none;
+      font-family: 'Nunito', sans-serif;
+      font-size: 0.95rem;
+      font-weight: 700;
+      color: var(--text-primary);
+    }
+    .search-row input::placeholder { color: var(--search-placeholder); }
+    .search-row kbd {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.62rem;
+      color: var(--search-hint-color);
+      background: var(--search-hint-bg);
+      border: 1px solid var(--search-hint-border);
+      padding: 0.1rem 0.4rem;
+    }
+    .search-results { max-height: 55vh; overflow-y: auto; }
     .search-results a {
       display: block;
-      padding: 0.55rem 0.85rem;
+      padding: 0.55rem 1rem;
       font-size: 0.84rem;
       color: var(--text-secondary);
       text-decoration: none;
       border-bottom: 1px solid var(--search-result-border);
-      transition: background 0.15s, color 0.15s;
     }
     .search-results a:last-child { border-bottom: none; }
-    .search-results a:hover { background: var(--search-result-hover); }
+    .search-results a:hover, .search-results a.selected { background: var(--search-result-hover); }
+    .search-results a.selected .search-result-title,
     .search-results a:hover .search-result-title { color: var(--accent); }
     .search-result-title {
       font-weight: 700;
       color: var(--text-primary);
-      margin-bottom: 0.15rem;
-      transition: color 0.15s;
+      margin-bottom: 0.1rem;
+      transition: color 0.12s;
     }
     .search-result-snippet {
       font-size: 0.78rem;
@@ -660,21 +821,14 @@
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
     }
-    .search-result-snippet mark {
+    .search-result-snippet mark, .search-highlight {
       background: var(--accent);
-      color: var(--bg-primary);
-      border-radius: 2px;
+      color: var(--cream);
       padding: 0 0.12rem;
     }
-    .search-highlight {
-      background: var(--accent);
-      color: var(--bg-primary);
-      border-radius: 2px;
-      padding: 0.05rem 0.15rem;
-      animation: highlight-fade 1s ease-out forwards;
-    }
+    .search-highlight { animation: highlight-fade 1s ease-out forwards; }
     @keyframes highlight-fade {
-      0%, 40% { background: var(--accent); color: var(--bg-primary); }
+      0%, 40% { background: var(--accent); color: var(--cream); }
       100% { background: transparent; color: inherit; }
     }
     .search-results .no-results {
@@ -684,33 +838,14 @@
       text-align: center;
     }
 
-
-
-    /* ── KEYBOARD SHORTCUT HINT ── */
-    .search-hint {
-      position: absolute;
-      right: 0.55rem;
-      top: 50%;
-      transform: translateY(-50%);
-      font-size: 0.68rem;
-      font-family: 'JetBrains Mono', monospace;
-      color: var(--search-hint-color);
-      background: var(--search-hint-bg);
-      padding: 0.1rem 0.4rem;
-      border-radius: 4px;
-      border: 1px solid var(--search-hint-border);
-      pointer-events: none;
-      transition: opacity 0.2s;
-    }
-    .search-box input:focus ~ .search-hint { opacity: 0; }
-
     /* ── MOBILE ── */
     @media (max-width: 768px) {
       .sidebar-toggle { display: block; }
       .sidebar {
         transform: translateX(-100%);
-        transition: transform 0.3s var(--ease-out);
+        transition: transform 0.25s var(--ease-out);
         box-shadow: none;
+        background: var(--cream);
       }
       .sidebar.open {
         transform: translateX(0);
@@ -721,17 +856,14 @@
         position: fixed;
         inset: 0;
         background: var(--overlay-bg);
-        backdrop-filter: blur(2px);
         z-index: 40;
-        transition: opacity 0.3s var(--ease-smooth);
       }
       .sidebar-overlay.open { display: block; }
-      .main-content {
-        margin-left: 0;
-        padding: 2rem 1.25rem 4rem;
-      }
+      .main-content { margin-left: 0; padding: 2rem 1.25rem 4rem; }
       .topnav { padding: 0 1rem; }
       .topnav-right a:not(.topnav-github) { display: none; }
+      .page-nav { flex-direction: column; }
+      .page-actions .action-label { display: none; }
     }
 
     /* ── THEME TRANSITION ── */
@@ -739,26 +871,24 @@
     html.theme-transition *,
     html.theme-transition *::before,
     html.theme-transition *::after {
-      transition: background 0.35s var(--ease-smooth),
-                  background-color 0.35s var(--ease-smooth),
-                  color 0.25s var(--ease-smooth),
-                  border-color 0.35s var(--ease-smooth),
-                  box-shadow 0.35s var(--ease-smooth),
-                  fill 0.25s var(--ease-smooth) !important;
+      transition: background 0.3s var(--ease-smooth),
+                  background-color 0.3s var(--ease-smooth),
+                  color 0.2s var(--ease-smooth),
+                  border-color 0.3s var(--ease-smooth),
+                  fill 0.2s var(--ease-smooth) !important;
     }
 
     /* ── THEME TOGGLE ── */
     .theme-toggle {
       background: none;
       border: 1px solid var(--border-subtle);
-      border-radius: 8px;
       cursor: pointer;
       padding: 0.3rem;
       display: inline-flex;
       align-items: center;
       justify-content: center;
       color: var(--text-muted);
-      transition: color 0.2s, border-color 0.2s, background 0.2s;
+      transition: color 0.15s, border-color 0.15s, background 0.15s;
       width: 32px;
       height: 32px;
     }
@@ -767,17 +897,18 @@
       border-color: var(--accent);
       background: var(--accent-soft);
     }
-    .theme-toggle svg {
-      width: 16px;
-      height: 16px;
-      transition: transform 0.35s var(--ease-out), opacity 0.2s;
-    }
-    .theme-toggle:hover svg {
-      transform: rotate(15deg);
-    }
+    .theme-toggle svg { width: 16px; height: 16px; transition: transform 0.3s var(--ease-out); }
+    .theme-toggle:hover svg { transform: rotate(15deg); }
     .theme-toggle .icon-moon { display: none; }
     [data-theme="dark"] .theme-toggle .icon-sun { display: none; }
     [data-theme="dark"] .theme-toggle .icon-moon { display: block; }
+
+    /* ── FOCUS ── */
+    :focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+    .search-row input:focus-visible { outline: none; }
 
     /* ── REDUCED MOTION ── */
     @media (prefers-reduced-motion: reduce) {
@@ -790,7 +921,7 @@
     }
   </style>
 </head>
-<body>
+<body class="{% block bodyclass %}{% endblock %}">
 
 <header class="topnav" id="topnav">
   <div class="topnav-left">
@@ -817,12 +948,11 @@
 <div class="page-layout">
   <div class="sidebar-overlay" id="sidebar-overlay"></div>
   <nav class="sidebar" id="sidebar">
-    <div class="search-box">
+    <button class="search-btn" id="search-open" aria-label="Search docs">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-      <input type="text" id="search-input" placeholder="Search docs..." autocomplete="off">
+      Search docs...
       <span class="search-hint">/</span>
-      <div class="search-results" id="search-results"></div>
-    </div>
+    </button>
 {%- set root = get_section(path="_index.md") -%}
     {%- set sections = [] -%}
     {%- for sub in root.subsections -%}
@@ -850,13 +980,25 @@
   {% block toc %}{% endblock %}
 </div>
 
+<div class="search-modal" id="search-modal" hidden>
+  <div class="search-backdrop" id="search-backdrop"></div>
+  <div class="search-panel" role="dialog" aria-label="Search docs">
+    <div class="search-row">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="search-input" placeholder="Search docs..." autocomplete="off">
+      <kbd>esc</kbd>
+    </div>
+    <div class="search-results" id="search-results"></div>
+  </div>
+</div>
+
 <script>
   // theme toggle
   const themeToggle = document.getElementById('theme-toggle');
   function setTheme(dark, animate) {
     if (animate) {
       document.documentElement.classList.add('theme-transition');
-      setTimeout(() => document.documentElement.classList.remove('theme-transition'), 400);
+      setTimeout(() => document.documentElement.classList.remove('theme-transition'), 350);
     }
     document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
     document.documentElement.style.colorScheme = dark ? 'dark' : 'light';
@@ -864,18 +1006,41 @@
     localStorage.setItem('theme', dark ? 'dark' : 'light');
   }
   themeToggle.addEventListener('click', () => {
-    const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-    setTheme(!isDark, true);
+    setTheme(document.documentElement.getAttribute('data-theme') !== 'dark', true);
   });
   window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
     if (!localStorage.getItem('theme')) setTheme(e.matches, true);
   });
 
-  const nav = document.getElementById('topnav');
-  window.addEventListener('scroll', () => {
-    nav.classList.toggle('scrolled', window.scrollY > 10);
-  }, { passive: true });
+  const contentRoot = document.querySelector('.content-inner');
 
+  // wrap tables for horizontal overflow
+  contentRoot.querySelectorAll('table').forEach(t => {
+    const wrap = document.createElement('div');
+    wrap.className = 'table-wrap';
+    t.parentNode.insertBefore(wrap, t);
+    wrap.appendChild(t);
+  });
+
+  // heading anchor links
+  contentRoot.querySelectorAll('h2[id], h3[id]').forEach(h => {
+    const a = document.createElement('a');
+    a.className = 'h-anchor';
+    a.href = '#' + h.id;
+    a.textContent = '#';
+    a.setAttribute('aria-label', 'Link to this section');
+    h.appendChild(a);
+  });
+
+  // callouts
+  contentRoot.querySelectorAll('blockquote').forEach(b => {
+    const s = b.querySelector('p:first-child strong:first-child');
+    if (!s) return;
+    const kind = s.textContent.replace(/:$/, '').toLowerCase();
+    if (['note', 'tip', 'warning'].includes(kind)) b.classList.add('callout-' + kind);
+  });
+
+  // sidebar (mobile)
   const toggle = document.getElementById('sidebar-toggle');
   const sidebar = document.getElementById('sidebar');
   const overlay = document.getElementById('sidebar-overlay');
@@ -888,7 +1053,7 @@
     overlay.classList.remove('open');
   });
 
-  // copy buttons
+  // copy buttons + terminal lang labels
   document.querySelectorAll('main pre').forEach(pre => {
     const code = pre.querySelector('code') || pre;
     const btn = document.createElement('button');
@@ -907,22 +1072,62 @@
     pre.appendChild(btn);
   });
 
+  // active sidebar link
   const path = window.location.pathname.replace(/\/$/, '');
   document.querySelectorAll('.sidebar a').forEach(a => {
     const href = a.getAttribute('href').replace(/\/$/, '');
-    if (path === href || path.endsWith(href)) a.classList.add('active');
+    if (path === href || (href && path.endsWith(href))) a.classList.add('active');
   });
 
-  // search
+  // copy page as markdown
+  const mdBtn = document.getElementById('copy-md');
+  if (mdBtn) {
+    const label = mdBtn.querySelector('.action-label');
+    const original = label.textContent;
+    let mdTimer;
+    mdBtn.addEventListener('click', async () => {
+      try {
+        const r = await fetch('index.md');
+        if (!r.ok) throw new Error();
+        await navigator.clipboard.writeText(await r.text());
+        label.textContent = 'Copied';
+      } catch {
+        label.textContent = 'Unavailable';
+      }
+      clearTimeout(mdTimer);
+      mdTimer = setTimeout(() => { label.textContent = original; }, 1500);
+    });
+  }
+
+  // ── search modal (index lazy-loaded once, shared across pages via HTTP cache) ──
+  const searchModal = document.getElementById('search-modal');
   const searchInput = document.getElementById('search-input');
   const searchResults = document.getElementById('search-results');
-  {%- set root = get_section(path="_index.md") -%}
-  const searchDocs = [
-    {%- for sub in root.subsections -%}
-      {%- set s = get_section(path=sub) -%}
-      {title:{{ s.title | json_encode | safe }}, href:{{ s.permalink | json_encode | safe }}, body:{{ s.content | replace(from="</td>", to=" ") | replace(from="</th>", to=" ") | replace(from="</li>", to=" ") | replace(from="<br>", to=" ") | replace(from="<br/>", to=" ") | replace(from="<br />", to=" ") | replace(from="</p>", to=" ") | replace(from="</h1>", to=". ") | replace(from="</h2>", to=". ") | replace(from="</h3>", to=". ") | replace(from="</h4>", to=". ") | striptags | json_encode | safe }}},
-    {%- endfor -%}
-  ];
+  let searchDocs = null;
+  let selectedIdx = -1;
+
+  async function loadSearchDocs() {
+    if (searchDocs) return;
+    try {
+      const r = await fetch('{{ config.base_url | safe }}/search.json');
+      searchDocs = r.ok ? await r.json() : [];
+    } catch {
+      searchDocs = [];
+    }
+  }
+
+  function openSearch() {
+    searchModal.hidden = false;
+    searchInput.focus();
+    searchInput.select();
+    loadSearchDocs();
+  }
+  function closeSearch() {
+    searchModal.hidden = true;
+    selectedIdx = -1;
+  }
+  document.getElementById('search-open').addEventListener('click', openSearch);
+  document.getElementById('search-backdrop').addEventListener('click', closeSearch);
 
   function getSnippet(body, terms) {
     const lower = body.toLowerCase();
@@ -939,9 +1144,9 @@
         bestSentence = s;
       }
     }
+    const pattern = terms.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
     if (bestScore > 0 && bestSentence.length <= 200) {
-      const esc = bestSentence.trim().replace(/&/g,'&amp;').replace(/</g,'&lt;');
-      const pattern = terms.map(t => t.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')).join('|');
+      const esc = bestSentence.trim().replace(/&/g, '&amp;').replace(/</g, '&lt;');
       return esc.replace(new RegExp(`(${pattern})`, 'gi'), '<mark>$1</mark>');
     }
     let bestIdx = 0;
@@ -963,14 +1168,14 @@
     let raw = body.slice(start, end).trim();
     if (start > 0) raw = '...' + raw;
     if (end < body.length) raw += '...';
-    const esc = raw.replace(/&/g,'&amp;').replace(/</g,'&lt;');
-    const pattern = terms.map(t => t.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')).join('|');
+    const esc = raw.replace(/&/g, '&amp;').replace(/</g, '&lt;');
     return esc.replace(new RegExp(`(${pattern})`, 'gi'), '<mark>$1</mark>');
   }
 
-  searchInput.addEventListener('input', () => {
+  function renderSearch() {
     const q = searchInput.value.trim().toLowerCase();
-    if (!q) { searchResults.classList.remove('open'); return; }
+    selectedIdx = -1;
+    if (!q || !searchDocs) { searchResults.innerHTML = ''; return; }
     const terms = q.split(/\s+/).filter(Boolean);
     const hits = searchDocs.filter(d => {
       const hay = (d.title + ' ' + d.body).toLowerCase();
@@ -978,30 +1183,55 @@
     }).slice(0, 8);
     if (hits.length === 0) {
       searchResults.innerHTML = '<div class="no-results">No results</div>';
-    } else {
-      searchResults.innerHTML = hits.map(d => {
-        const snippet = getSnippet(d.body, terms);
-        return `<a href="${d.href}?q=${encodeURIComponent(searchInput.value.trim())}"><div class="search-result-title">${d.title}</div><div class="search-result-snippet">${snippet}</div></a>`;
-      }).join('');
+      return;
     }
-    searchResults.classList.add('open');
+    searchResults.innerHTML = hits.map(d => {
+      const snippet = getSnippet(d.body, terms);
+      return `<a href="${d.href}?q=${encodeURIComponent(searchInput.value.trim())}"><div class="search-result-title">${d.title}</div><div class="search-result-snippet">${snippet}</div></a>`;
+    }).join('');
+  }
+
+  searchInput.addEventListener('input', async () => {
+    await loadSearchDocs();
+    renderSearch();
   });
-  document.addEventListener('click', (e) => {
-    if (!e.target.closest('.search-box')) searchResults.classList.remove('open');
+
+  function moveSelection(delta) {
+    const links = searchResults.querySelectorAll('a');
+    if (!links.length) return;
+    if (selectedIdx >= 0) links[selectedIdx].classList.remove('selected');
+    selectedIdx = (selectedIdx + delta + links.length) % links.length;
+    links[selectedIdx].classList.add('selected');
+    links[selectedIdx].scrollIntoView({ block: 'nearest' });
+  }
+
+  document.addEventListener('keydown', (e) => {
+    const open = !searchModal.hidden;
+    if (open) {
+      if (e.key === 'Escape') { closeSearch(); return; }
+      if (e.key === 'ArrowDown') { e.preventDefault(); moveSelection(1); return; }
+      if (e.key === 'ArrowUp') { e.preventDefault(); moveSelection(-1); return; }
+      if (e.key === 'Enter' && selectedIdx >= 0) {
+        e.preventDefault();
+        searchResults.querySelectorAll('a')[selectedIdx].click();
+      }
+      return;
+    }
+    const tag = document.activeElement.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+    if (e.key === '/' && !e.ctrlKey && !e.metaKey) { e.preventDefault(); openSearch(); }
+    if (e.key === 'k' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); openSearch(); }
   });
 
   // highlight + scroll on ?q= param
   const urlQ = new URLSearchParams(window.location.search).get('q');
   if (urlQ) {
     const terms = urlQ.trim().toLowerCase().split(/\s+/).filter(Boolean);
-    const walker = document.createTreeWalker(
-      document.querySelector('.main-content'),
-      NodeFilter.SHOW_TEXT
-    );
+    const walker = document.createTreeWalker(document.querySelector('.main-content'), NodeFilter.SHOW_TEXT);
     let firstMark = null;
     const nodes = [];
     while (walker.nextNode()) nodes.push(walker.currentNode);
-    const pattern = new RegExp(`(${terms.map(t => t.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')).join('|')})`, 'gi');
+    const pattern = new RegExp(`(${terms.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})`, 'gi');
     for (const node of nodes) {
       if (!pattern.test(node.textContent)) continue;
       pattern.lastIndex = 0;
@@ -1020,30 +1250,33 @@
       if (last < node.textContent.length) frag.appendChild(document.createTextNode(node.textContent.slice(last)));
       node.parentNode.replaceChild(frag, node);
     }
-    if (firstMark) {
-      firstMark.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }
+    if (firstMark) firstMark.scrollIntoView({ behavior: 'smooth', block: 'center' });
     history.replaceState(null, '', window.location.pathname);
   }
 
-  // right-hand toc: shorten labels, scrollspy, accordion
+  // right-hand toc: labels, scrollspy, accordion
+  const nav = document.getElementById('topnav');
   const toc = document.getElementById('toc');
+  let updateToc = null;
   if (toc) {
     document.body.classList.add('has-toc');
+    const tocLinks = new Map();
+    toc.querySelectorAll('a').forEach(a => tocLinks.set(decodeURIComponent(a.hash.slice(1)), a));
+    const headings = [...contentRoot.querySelectorAll('h2[id], h3[id]')].filter(h => tocLinks.has(h.id));
+    headings.forEach(h => {
+      const a = tocLinks.get(h.id);
+      const c = h.querySelector('code');
+      if (c && a.classList.contains('toc-h3')) a.textContent = c.textContent;
+    });
     toc.querySelectorAll('.toc-group').forEach(group => {
       const h2Text = group.querySelector('.toc-h2').textContent.trim();
       group.querySelectorAll('.toc-h3').forEach(a => {
         const t = a.textContent.trim();
-        if (t.startsWith(h2Text + '.')) a.textContent = t.slice(h2Text.length + 1);
-        else a.textContent = t;
+        a.textContent = t.startsWith(h2Text + '.') ? t.slice(h2Text.length + 1) : t;
       });
     });
-    const tocLinks = new Map();
-    toc.querySelectorAll('a').forEach(a => tocLinks.set(decodeURIComponent(a.hash.slice(1)), a));
-    const headings = [...document.querySelectorAll('.content-inner h2[id], .content-inner h3[id]')]
-      .filter(h => tocLinks.has(h.id));
     let activeLink = null;
-    function updateToc() {
+    updateToc = function() {
       const offset = window.scrollY + 100;
       let current = null;
       for (const h of headings) {
@@ -1060,22 +1293,38 @@
       link.closest('.toc-group').classList.add('open');
       const r = link.getBoundingClientRect();
       const tr = toc.getBoundingClientRect();
-      if (r.top < tr.top + 40 || r.bottom > tr.bottom - 40) {
-        link.scrollIntoView({ block: 'center' });
-      }
-    }
-    window.addEventListener('scroll', updateToc, { passive: true });
+      if (r.top < tr.top + 40 || r.bottom > tr.bottom - 40) link.scrollIntoView({ block: 'nearest' });
+    };
     window.addEventListener('hashchange', updateToc);
     updateToc();
   }
 
-  // "/" keyboard shortcut for search
-  document.addEventListener('keydown', (e) => {
-    if (e.key === '/' && !e.ctrlKey && !e.metaKey && document.activeElement !== searchInput) {
-      e.preventDefault();
-      searchInput.focus();
-    }
-  });
+  // single rAF-throttled scroll handler
+  let scrollTick = false;
+  window.addEventListener('scroll', () => {
+    if (scrollTick) return;
+    scrollTick = true;
+    requestAnimationFrame(() => {
+      nav.classList.toggle('scrolled', window.scrollY > 10);
+      if (updateToc) updateToc();
+      scrollTick = false;
+    });
+  }, { passive: true });
+  nav.classList.toggle('scrolled', window.scrollY > 10);
+
+  // hover prefetch for internal links
+  const prefetched = new Set([location.pathname]);
+  document.addEventListener('mouseover', (e) => {
+    const a = e.target.closest('a[href^="{{ config.base_url | safe }}"], a[href^="/docs/"]');
+    if (!a) return;
+    const url = new URL(a.href, location.href);
+    if (url.origin !== location.origin || prefetched.has(url.pathname)) return;
+    prefetched.add(url.pathname);
+    const l = document.createElement('link');
+    l.rel = 'prefetch';
+    l.href = url.pathname;
+    document.head.appendChild(l);
+  }, { passive: true });
 </script>
 
 </body>

--- a/site/docs/templates/index.html
+++ b/site/docs/templates/index.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block bodyclass %}page-home{% endblock %}
+
 {% block content %}
 {{ section.content | safe }}
 {% endblock %}

--- a/site/docs/templates/section.html
+++ b/site/docs/templates/section.html
@@ -2,8 +2,55 @@
 
 {% block title %}{{ section.title }} | {{ config.title }}{% endblock %}
 
+{% block bodyclass %}page-{{ section.path | trim_start_matches(pat="/") | trim_end_matches(pat="/") }}{% endblock %}
+
 {% block content %}
+{%- set root = get_section(path="_index.md") -%}
+{%- set ordered = [] -%}
+{%- for group in ["Getting Started", "Guides", "Concepts", "Reference"] -%}
+  {%- for sub in root.subsections -%}
+    {%- set s = get_section(path=sub) -%}
+    {%- if s.extra.group == group -%}
+      {%- set_global ordered = ordered | concat(with=[s]) -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endfor -%}
+{%- set prev = false -%}
+{%- set next = false -%}
+{%- set found = false -%}
+{%- for s in ordered -%}
+  {%- if s.permalink == section.permalink -%}
+    {%- set_global found = true -%}
+  {%- elif not found -%}
+    {%- set_global prev = s -%}
+  {%- elif not next -%}
+    {%- set_global next = s -%}
+  {%- endif -%}
+{%- endfor -%}
+<div class="page-head">
+  <span class="eyebrow">{{ section.extra.group }}</span>
+  <div class="page-actions">
+    <button id="copy-md" type="button" title="Copy this page as Markdown for an LLM">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+      <span class="action-label">Copy as Markdown</span>
+    </button>
+  </div>
+</div>
 {{ section.content | safe }}
+<nav class="page-nav">
+  {%- if prev %}
+  <a href="{{ prev.permalink }}" class="pn-prev">
+    <span class="pn-dir">← Previous</span>
+    <span class="pn-title">{{ prev.title }}</span>
+  </a>
+  {%- endif %}
+  {%- if next %}
+  <a href="{{ next.permalink }}" class="pn-next">
+    <span class="pn-dir">Next →</span>
+    <span class="pn-title">{{ next.title }}</span>
+  </a>
+  {%- endif %}
+</nav>
 {% endblock %}
 
 {% block toc %}


### PR DESCRIPTION
The docs shared the landing page palette but none of its personality, so the sky gradient and dark-mode starfield now carry over, code blocks render as small terminal windows with macOS dots and a language label, and the index page swaps its bullet lists for grouped card grids.

Every page gets a group eyebrow, heading anchor links, prev/next footer cards, and a "Copy as Markdown" button that reuses the per-page `index.md` mirrors `build.sh` already generates.

The biggest page-load win: every page used to inline the entire docs corpus as a JS search array (252KB for the tools page, now 68KB), so `build.sh` now emits one shared `search.json` that the new `Cmd+K` modal fetches lazily.

`gen_tools.rs` drops the `(lua plugin)` badge repeated on all 21 tools, keeping `opt-in` as a pill and emitting explicit `{#name}` heading ids, so anchors become `#bash` instead of `#bash-lua-plugin`.

Animations stick to transform and opacity behind a single rAF scroll handler, internal links prefetch on hover, and a bug where the table-wrap script ran in `<head>` before the DOM existed is fixed.