### PR TITLE
docs(lua): drop stale live requirement from session.focus

### DIFF
--- a/maki-lua/src/api/session.rs
+++ b/maki-lua/src/api/session.rs
@@ -57,7 +57,7 @@ async fn current(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaRes
     roundtrip(lua, tx, SessionRequest::Current).await
 }
 
-/// Switches the UI to the session with {id}. The session must be live.
+/// Switches the UI to the session with {id}.
 ///
 /// @param id string Session id, as returned by `list()` or `live()`.
 /// @return (boolean|nil, string|nil) true on success, or nil and an error.

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -2589,7 +2589,7 @@ local id = maki.session.current()
 maki.session.focus({id})
 ```
 
-Switches the UI to the session with {id}. The session must be live.
+Switches the UI to the session with {id}.
 
 **Parameters:**
 


### PR DESCRIPTION
`maki.session.focus` is documented as "The session must be live", but it has not been true since the function gained its load-from-disk path.