### PR TITLE
fix: canonicalize `functions.` tool names once at the provider boundary

### DIFF
--- a/maki-agent/src/agent/streaming.rs
+++ b/maki-agent/src/agent/streaming.rs
@@ -1,6 +1,6 @@
 use maki_providers::provider::Provider;
 use maki_providers::retry::{MAX_TIMEOUT_RETRIES, RetryState};
-use maki_providers::{Message, Model, ProviderEvent, RequestOptions, StreamResponse};
+use maki_providers::{ContentBlock, Message, Model, ProviderEvent, RequestOptions, StreamResponse};
 use maki_storage::id::SessionRef;
 use serde_json::Value;
 use tracing::warn;
@@ -8,12 +8,32 @@ use tracing::warn;
 use crate::cancel::CancelToken;
 use crate::{AgentError, AgentEvent, EventSender};
 
+const FUNCTIONS_PREFIX: &str = "functions.";
+
+/// GPT models sometimes emit `functions.<name>`, a Codex training habit.
+/// Stripped here at the provider boundary so no raw name enters the agent;
+/// the batch plugin mirrors the rule in Lua.
+pub(crate) fn canonical_tool_name(name: &str) -> &str {
+    name.strip_prefix(FUNCTIONS_PREFIX).unwrap_or(name)
+}
+
+fn canonicalize_tool_names(message: &mut Message) {
+    for block in &mut message.content {
+        if let ContentBlock::ToolUse { name, .. } = block {
+            *name = canonical_tool_name(name).to_owned();
+        }
+    }
+}
+
 async fn forward_provider_events(prx: flume::Receiver<ProviderEvent>, event_tx: &EventSender) {
     while let Ok(pe) = prx.recv_async().await {
         let ae = match pe {
             ProviderEvent::TextDelta { text } => AgentEvent::TextDelta { text },
             ProviderEvent::ThinkingDelta { text } => AgentEvent::ThinkingDelta { text },
-            ProviderEvent::ToolUseStart { id, name } => AgentEvent::ToolPending { id, name },
+            ProviderEvent::ToolUseStart { id, name } => AgentEvent::ToolPending {
+                id,
+                name: canonical_tool_name(&name).to_owned(),
+            },
             ProviderEvent::PromptProgress {
                 processed,
                 total,
@@ -63,7 +83,10 @@ pub(crate) async fn stream_with_retry(
         drop(ptx);
         let _ = forwarder.await;
         match result {
-            Ok(r) => return Ok(r),
+            Ok(mut r) => {
+                canonicalize_tool_names(&mut r.message);
+                return Ok(r);
+            }
             Err(AgentError::Cancelled) => return Err(AgentError::Cancelled),
             Err(e) if e.is_retryable() => {
                 if e.should_rotate_key()
@@ -95,5 +118,30 @@ pub(crate) async fn stream_with_retry(
             }
             Err(e) => return Err(e),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use maki_providers::Role;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn tool_use_names_canonicalized() {
+        let mut message = Message {
+            role: Role::Assistant,
+            content: vec![
+                ContentBlock::Text { text: "hi".into() },
+                ContentBlock::tool_use("t1", "functions.bash", json!({})),
+                ContentBlock::tool_use("t2", "read", json!({})),
+                ContentBlock::tool_use("t3", "my_functions.x", json!({})),
+            ],
+            ..Default::default()
+        };
+        canonicalize_tool_names(&mut message);
+        let names: Vec<&str> = message.tool_uses().map(|(_, name, _)| name).collect();
+        assert_eq!(names, ["bash", "read", "my_functions.x"]);
     }
 }

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -68,8 +68,9 @@ pub async fn run(
     ctx: &ToolContext,
     emit: Emit,
 ) -> ToolDoneEvent {
-    // GPT-5.6 was likely trained on Codex sessions where tools are `functions.<name>`
-    let name = name.strip_prefix("functions.").unwrap_or(name);
+    // Covers names re-entering from model JSON (batch children, `call_tool`,
+    // the interpreter bridge); streamed names are canonicalized in streaming.rs.
+    let name = super::streaming::canonical_tool_name(name);
     if let Some(local) = ctx.local_tools.get(name) {
         return run_local_tool(local, id, name, input, ctx, emit);
     }
@@ -565,6 +566,25 @@ mod tests {
             .await;
             assert!(done.is_error);
             assert_eq!(done.output.as_text(), "nope");
+        });
+    }
+
+    #[test]
+    fn functions_prefixed_name_dispatches_to_canonical_tool() {
+        smol::block_on(async {
+            let ctx = local_ctx("ok", |_| Ok("ran".into()));
+            let done = run(
+                ToolRegistry::global(),
+                None,
+                "t1".into(),
+                "functions.ok",
+                &serde_json::json!({}),
+                &ctx,
+                Emit::Silent,
+            )
+            .await;
+            assert!(!done.is_error);
+            assert_eq!(done.output.as_text(), "ran");
         });
     }
 

--- a/maki-lua/tests/batch_policy.rs
+++ b/maki-lua/tests/batch_policy.rs
@@ -474,6 +474,31 @@ fn flat_nested_and_merged_params_normalize_identically() {
     assert_eq!(calls[2]["params"], json!({ "tag": "nested", "n": 1 }));
 }
 
+/// The batch plugin strips GPT's `functions.` prefix in Lua so child
+/// lookups and the nested-batch guard key on the canonical name.
+#[test]
+fn functions_prefix_stripped_from_child_tool_names() {
+    let (reg, _host) = load_batch_host();
+    let out = run_batch(
+        &reg,
+        json!([
+            { "tool": "functions.ok", "parameters": { "tag": "a" } },
+            { "tool": "functions.batch", "parameters": { "tool_calls": [] } },
+        ]),
+    )
+    .expect("batch failed");
+    let expected = format!(
+        "{}{}{}",
+        section("ok", "ok:a"),
+        section("batch", &format!("{ERROR_PREFIX}{NESTED_ERROR}")),
+        summary_mixed(1, 2, 1)
+    );
+    assert_eq!(out, expected);
+    let calls = recorded_calls(&reg);
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0]["tool"], json!("ok"));
+}
+
 #[test_case::test_case(json!([]), EMPTY_ERROR ; "empty_list")]
 #[test_case::test_case(json!([{ "tool": "ok", "parameters": { "tag": "x" }, "tag": "y" }]), "duplicate parameter 'tag'" ; "duplicate_key")]
 fn invalid_input_errors_without_dispatch(tool_calls: Value, expected_err: &str) {

--- a/plugins/batch/init.lua
+++ b/plugins/batch/init.lua
@@ -97,6 +97,9 @@ local function normalize_entry(entry)
   if type(tool) ~= "string" then
     return nil, "batch entry missing 'tool'"
   end
+  -- Lua twin of `canonical_tool_name` (streaming.rs): strip GPT's
+  -- `functions.` prefix so headers and the nested-batch guard match.
+  tool = tool:match("^functions%.(.+)") or tool
   local rest = {}
   local has_rest = false
   for k, v in pairs(entry) do


### PR DESCRIPTION
GPT models sometimes call tools as `functions.bash`, a habit from Codex training, and we handled it by stripping the prefix at each consumer: once in `tool_dispatch.rs`, and again in the batch plugin after the raw name broke `get_tool` lookups, `## functions.bash` llm sections, and the nested-batch guard.

Every other consumer was still exposed: the pending spinner and ACP showed the raw name through `ToolPending`, and history kept it too, so it leaked into persisted sessions, restored tool views, doom-loop keys, and every replayed turn.

The rule now lives in one place, `canonical_tool_name` in `streaming.rs`, applied at the provider boundary (`stream_with_retry` and the event forwarder), so no raw name ever enters the agent; `tool_dispatch::run` reuses it for names arriving out of model JSON (batch children, `call_tool`, the interpreter bridge), and the batch plugin keeps a Lua twin for its own headers and guards.