### PR TITLE
fix: instrument the exit tail and prioritize the Lua shutdown on quit

### DIFF
--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -131,8 +131,9 @@ impl Drop for PluginHost {
         let Some(handle) = self.inner.join.take() else {
             return;
         };
-        self.inner.shutdown.store(true, Ordering::Release);
-        let _ = self.inner.tx.send(Request::Shutdown);
+        // Start the shutdown first, or the join below waits for all
+        // queued bulk work to drain.
+        self.begin_shutdown();
         let (done_tx, done_rx) = flume::bounded(1);
         std::thread::spawn(move || {
             let _ = done_tx.send(handle.join().is_err());

--- a/maki-ui/src/lib.rs
+++ b/maki-ui/src/lib.rs
@@ -30,6 +30,8 @@ mod event_loop;
 mod input;
 mod terminal;
 
+use std::time::Instant;
+
 use color_eyre::Result;
 use maki_agent::ToolOutput;
 use maki_providers::Message;
@@ -66,13 +68,22 @@ pub fn run(params: EventLoopParams, initial_prompt: Option<String>) -> Result<Ru
             tabs: report.tabs,
             focused: report.focused,
         },
-        _ => RunOutcome::Exit {
-            session_id: report
+        exit => {
+            let session_id = report
                 .tabs
                 .get(report.focused)
                 .filter(|s| app::session_has_content(s))
-                .map(|s| s.id),
-            code: report.exit.code(),
-        },
+                .map(|s| s.id);
+            let started = Instant::now();
+            drop(report);
+            tracing::info!(
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "session buffers dropped"
+            );
+            RunOutcome::Exit {
+                session_id,
+                code: exit.code(),
+            }
+        }
     })
 }

--- a/maki-ui/src/terminal.rs
+++ b/maki-ui/src/terminal.rs
@@ -1,6 +1,7 @@
 use shell_words::split;
 use std::io::{Write, stdout};
 use std::path::Path;
+use std::time::Instant;
 
 use color_eyre::Result;
 use crossterm::Command;
@@ -65,8 +66,13 @@ impl TerminalGuard {
 
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
+        let started = Instant::now();
         pop_terminal_modes();
         ratatui::restore();
+        tracing::info!(
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "terminal restored"
+        );
     }
 }
 

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -3,6 +3,7 @@ use std::io::{self, IsTerminal, Read};
 use std::path::Path;
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
+use std::time::Instant;
 
 use color_eyre::Result;
 use color_eyre::eyre::Context;
@@ -349,8 +350,16 @@ pub fn run(mut cli: Cli) -> Result<()> {
                 if let Some(session_id) = session_id {
                     eprintln!("Resume session:\n\n  maki -s {session_id}");
                 }
+                let started = Instant::now();
+                drop(stack);
+                let stack_ms = started.elapsed().as_millis() as u64;
+                teardown.join();
+                tracing::info!(
+                    stack_ms,
+                    teardown_ms = started.elapsed().as_millis() as u64 - stack_ms,
+                    "plugin host and teardown joined"
+                );
                 if code != 0 {
-                    teardown.join();
                     std::process::exit(code);
                 }
                 return Ok(());
@@ -359,7 +368,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
                 tabs: reloaded,
                 focused: f,
             } => {
-                let started = std::time::Instant::now();
+                let started = Instant::now();
                 let last_good = (stack.config.clone(), stack.model.clone());
                 // Shut the old host down first so nothing can repopulate
                 // the registry after the clear: its senders disconnect, the


### PR DESCRIPTION
Exits after long sessions take seconds, yet every logged exit shows `ui shutdown phases` finishing in under 20ms, because the tail after that log was invisible: maki2 timed the terminal restore and the plugin host join, and the maki3 rewrite dropped those markers.

The tail is now measured again: `terminal restored` and `session buffers dropped` in `maki_ui::run`, and `plugin host and teardown joined` with `stack_ms`/`teardown_ms` around the `Stack` drop, whose `PluginHost::drop` joins the Lua thread with a 2s cap that logs nothing when it almost runs out.

The exit arm also calls `begin_shutdown()` before dropping the stack, same as `/reload`, so the shutdown request takes the priority lane instead of queueing behind bulk work, and non-zero exit codes go through the timed drop too.