### PR TITLE
fix(providers): always get a warm model catalog for default model

### DIFF
--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -16,7 +16,7 @@ pub use providers::Timeouts;
 pub use providers::catalog::ProviderData;
 pub use providers::catalog::{
     catalog_provider, catalog_provider_if_available, catalog_providers,
-    catalog_providers_if_available, model_meta_if_available,
+    catalog_providers_if_available, model_meta_if_available, warm_catalog,
 };
 pub use providers::copilot::auth as copilot_auth;
 pub use providers::dynamic;

--- a/maki-providers/src/providers/catalog.rs
+++ b/maki-providers/src/providers/catalog.rs
@@ -424,6 +424,13 @@ pub(crate) fn init_shared_catalog_if_needed() -> &'static Mutex<CatalogData> {
     SHARED_CATALOG.get_or_init(|| Mutex::new(init_catalog_blocking(all_slugs, enable_free)))
 }
 
+/// Loads the models.dev catalog from the on-disk cache, fetching once if the
+/// cache is cold or stale. Blocks, so only call it from startup paths; every
+/// other lookup must stay on the `*_if_available` variants.
+pub fn warm_catalog() {
+    init_shared_catalog_if_needed();
+}
+
 /// Returns the list of all providers in alphabetical order.
 pub fn catalog_providers() -> Vec<ProviderData> {
     let guard = init_shared_catalog_if_needed().lock().unwrap();

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -4,7 +4,7 @@ use color_eyre::Result;
 use color_eyre::eyre::{Context, eyre};
 
 use maki_providers::manifest::ManifestRegistry;
-use maki_providers::model::{Model, ModelTier};
+use maki_providers::model::{Model, ModelError, ModelTier};
 use maki_storage::StateDir;
 use maki_storage::log::RotatingFileWriter;
 use maki_storage::model::read_model;
@@ -31,11 +31,11 @@ pub fn resolve_model(
                 "model {spec:?} is not allowed by provider model policy"
             ));
         }
-        return Model::from_spec(spec).context("invalid --model spec");
+        return from_spec_or_warm_catalog(spec).context("invalid --model spec");
     }
     if let Some(spec) = read_model(storage) {
         if policy.allows(&spec)
-            && let Ok(m) = Model::from_spec(&spec)
+            && let Ok(m) = from_spec_or_warm_catalog(&spec)
         {
             return Ok(m);
         }
@@ -50,7 +50,7 @@ pub fn resolve_model(
                 "default model {spec:?} is not allowed by provider model policy"
             ));
         }
-        return Model::from_spec(spec).context("invalid default_model in config");
+        return from_spec_or_warm_catalog(spec).context("invalid default_model in config");
     }
     auto_detect_model(policy).ok_or_else(|| {
         let policy_note = if policy.is_restrictive() {
@@ -62,6 +62,19 @@ pub fn resolve_model(
             "no provider available - set an API key (e.g. ANTHROPIC_API_KEY), run `maki auth login`, or use -m to specify a model{policy_note}\n\nSee https://maki.sh/docs/providers/ for setup instructions"
         )
     })
+}
+
+/// An unknown slug may just mean the models.dev catalog has not been loaded
+/// yet, so retry once with a warm catalog. `Model::from_spec` itself must stay
+/// non-blocking: the UI draws with it.
+fn from_spec_or_warm_catalog(spec: &str) -> Result<Model, ModelError> {
+    match Model::from_spec(spec) {
+        Err(ModelError::UnsupportedProvider(_)) => {
+            maki_providers::warm_catalog();
+            Model::from_spec(spec)
+        }
+        result => result,
+    }
 }
 
 fn auto_detect_model(policy: &maki_config::ModelPolicy) -> Option<Model> {


### PR DESCRIPTION
without this, models that aren't part of the default catalog outside of default providers can't be loaded and default to anthropic/claude-sonnet-4, requiring a change constantly as the model catalog is loaded async before this patch.


to repro, set `default_model` to e.g 0731 from umans (I already logged in to umans with an api key, it already works and I have functional sessions with it inside `maki`, so this is not a missing-auth issue)

```
$ cat ~/.config/maki/providers.toml
[provider]
default_model = "umans-ai/umans-deepseek-v4-flash-0731"
```

without this patch it goes to sonnet, with it it defaults to what I'd expect 