### PR TITLE
providers: mistral: Add pricing for GLM-5.2 hosted by Mistral

### DIFF
--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -74,6 +74,22 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
             context_window: 262_144,
         },
         ModelEntry {
+            prefixes: &["glm-5-2", "zai-glm-5-2"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Glm,
+            vision: false,
+            default: false,
+            pricing: ModelPricing {
+                input: 1.40,
+                output: 4.40,
+                cache_write: 0.00,
+                cache_read: 0.14,
+                fast: None,
+            },
+            max_output_tokens: None,
+            context_window: 1_000_000,
+        },
+        ModelEntry {
             prefixes: &["mistral-small-latest", "mistral-small-2603"],
             tier: ModelTier::Medium,
             family: ModelFamily::Generic,

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -57,6 +57,7 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
             prefixes: &[
                 "mistral-medium-latest",
                 "mistral-medium-3.5",
+                "mistral-medium-3-5",
                 "mistral-medium-2604",
             ],
             tier: ModelTier::Strong,

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -159,7 +159,7 @@ Connects to any OpenAI-compatible `/v1` endpoint. Point `LLAMA_CPP_HOST` to your
 |------|--------|-------------------------------|---------|
 | Weak | **ministral-14b-latest, ministral-14b-2512** (default) | $0.20 / $0.20 | 262K ctx |
 | Medium | **mistral-small-latest, mistral-small-2603** (default) | $0.15 / $0.60 | 262K ctx |
-| Strong | **mistral-medium-latest, mistral-medium-3.5, mistral-medium-2604** (default) | $1.50 / $7.50 | 262K ctx |
+| Strong | **mistral-medium-latest, mistral-medium-3.5, mistral-medium-3-5, mistral-medium-2604** (default) | $1.50 / $7.50 | 262K ctx |
 | Strong | glm-5-2, zai-glm-5-2 | $1.40 / $4.40 | 1000K ctx |
 
 Defaults: mistral-medium-latest (strong), mistral-small-latest (medium), ministral-14b-latest (weak)

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -160,6 +160,7 @@ Connects to any OpenAI-compatible `/v1` endpoint. Point `LLAMA_CPP_HOST` to your
 | Weak | **ministral-14b-latest, ministral-14b-2512** (default) | $0.20 / $0.20 | 262K ctx |
 | Medium | **mistral-small-latest, mistral-small-2603** (default) | $0.15 / $0.60 | 262K ctx |
 | Strong | **mistral-medium-latest, mistral-medium-3.5, mistral-medium-2604** (default) | $1.50 / $7.50 | 262K ctx |
+| Strong | glm-5-2, zai-glm-5-2 | $1.40 / $4.40 | 1000K ctx |
 
 Defaults: mistral-medium-latest (strong), mistral-small-latest (medium), ministral-14b-latest (weak)
 


### PR DESCRIPTION
See https://docs.mistral.ai/models/zai-glm-5-2