### PR TITLE
fix: make live model lists authoritative for mistral and zai

### DIFF
--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -32,6 +32,10 @@ use crate::providers::tensorx::TensorX;
 use crate::providers::zai::Zai;
 use crate::{AgentError, Message, ProviderEvent, ProviderUsage, RequestOptions, StreamResponse};
 
+/// Providers whose live model lists are authoritative and must not be merged
+/// with static tables (stale entries and ID-style conflicts surface as dupes).
+const LIVE_LIST_ONLY: &[&str] = &["mistral", "zai"];
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumString, EnumIter)]
 #[strum(serialize_all = "kebab-case")]
 pub enum ProviderKind {
@@ -431,11 +435,13 @@ pub async fn fetch_all_models(
                     let mut specs: Vec<String> =
                         models.iter().map(|m| format!("{slug}/{}", m.id)).collect();
                     crate::model_registry::set_known_models(slug, models);
-                    for entry in manifest.models {
-                        for prefix in entry.prefixes {
-                            let spec = format!("{slug}/{prefix}");
-                            if !specs.contains(&spec) {
-                                specs.push(spec);
+                    if !LIVE_LIST_ONLY.contains(&slug) {
+                        for entry in manifest.models {
+                            for prefix in entry.prefixes {
+                                let spec = format!("{slug}/{prefix}");
+                                if !specs.contains(&spec) {
+                                    specs.push(spec);
+                                }
                             }
                         }
                     }

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -209,6 +209,12 @@ impl OpenAiCompatProvider {
         let url = format!("{base}/models");
         let body_text = self.get_text(auth, &url).await?;
         let body: Value = serde_json::from_str(&body_text)?;
+        debug!(
+            provider = self.config.provider_name,
+            base_url = %base,
+            response = %serde_json::to_string_pretty(&body).unwrap_or_else(|_| body_text.clone()),
+            "live /models response"
+        );
 
         let mut models: Vec<crate::model::ModelInfo> = body["data"]
             .as_array()

--- a/maki-providers/src/providers/opencode.rs
+++ b/maki-providers/src/providers/opencode.rs
@@ -65,10 +65,15 @@ impl Opencode {
     }
 
     async fn do_list_models(&self) -> Result<Vec<ModelInfo>, AgentError> {
-        Ok(
+        let models =
             smol::unblock(move || init_shared_catalog_if_needed().lock().unwrap().all_models())
-                .await,
-        )
+                .await;
+        debug!(
+            source = "shared catalog",
+            count = models.len(),
+            "opencode models listed from local catalog"
+        );
+        Ok(models)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -537,6 +537,16 @@ pub fn models(no_plugins: bool, no_jit: bool) -> Result<()> {
     let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
     load_env_files(&cwd);
 
+    if std::env::var_os("RUST_LOG").is_some() {
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+            )
+            .with_writer(io::stderr)
+            .init();
+    }
+
     let host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
         .context("initialize lua plugin host")?;
     let config = load_effective_config(&host, no_plugins, &cwd)?;


### PR DESCRIPTION
## Problem

Model discovery for `mistral` and `zai` merged stale static manifest tables into live `/models` responses:

- `zai/glm-5-code`, `zai/glm-4.7-flash`, `zai/glm-4.5-flash` — no longer on the live API
- `mistral/glm-5-2` / `zai-glm-5-2` — duplicated ID-style confusion (hyphenated vs dotted) between static tables and the live API

## Fix

Skip the static manifest merge for `mistral` and `zai` in `fetch_all_models` — their live lists are authoritative. The static fallback on listing failure is unchanged.

Also adds observability for provider discovery:
- `debug!` of the live `/models` response body (openai_compat)
- `debug!` of opencode's local catalog listing
- `RUST_LOG` tracing init in `maki models`

## Testing

- Verified with `maki models`: `zai/*` now shows only the 8 live models (dotted IDs), no more stale `glm-5-code` / `glm-4.7-flash` / `glm-4.5-flash`
- `mistral/*` glm entries remain only because Mistral's live API genuinely returns them (confirmed via curl)
- `cargo test -p maki-providers`, `cargo clippy --all --tests -- -D warnings` clean