### PR TITLE
chore(interpreter): update monty to v0.0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "get-size-derive2"
-version = "0.9.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f8ab1b98a1284961d722ce994d9a0f3018ab1917618d4113824a72b9f71bc9"
+checksum = "c736d226c32e496b8377813b52269e11ad3a48d8373b68862d0364f04fd1229d"
 dependencies = [
  "attribute-derive",
  "quote",
@@ -1509,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "get-size2"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0cd0777a1057362cab35a779e0d79dacecb8d73e2c733eaafeb7ea917b08f03"
+checksum = "823645bc6404ae2915707777061a47d3a031a9ee0bff51b34ec973df3d8d2990"
 dependencies = [
  "compact_str",
  "get-size-derive2",
@@ -2163,6 +2169,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,9 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "jiter"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7866f284df68dbc242796251ed9768bde2b58ebc4d7d32cc07cc7fd993e3ed6c"
+checksum = "820ddcacd75c9782308d3fa594f3885630ea3f49adba78a8a29abdfe4b81630c"
 dependencies = [
  "ahash",
  "bitvec",
@@ -2583,7 +2598,9 @@ dependencies = [
 name = "maki-interpreter"
 version = "0.4.7"
 dependencies = [
+ "get-size2",
  "monty",
+ "monty-types",
  "serde_json",
  "test-case",
  "thiserror 2.0.18",
@@ -2946,8 +2963,8 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.18"
-source = "git+https://github.com/pydantic/monty.git?tag=v0.0.18#45a3b2d57e6ce723fed4166fb032242ece74a663"
+version = "0.0.21"
+source = "git+https://github.com/pydantic/monty.git?tag=v0.0.21#70fe3f5781381eb33579e45046f8cb3845953373"
 dependencies = [
  "ahash",
  "chrono",
@@ -2955,32 +2972,54 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "itertools 0.14.0",
+ "itoa",
  "jiter",
  "libm",
+ "memchr",
  "monty-macros",
+ "monty-types",
  "num-bigint",
  "num-integer",
  "num-traits",
  "postcard",
  "ruff_python_ast",
+ "ruff_python_codegen",
  "ruff_python_parser",
  "ruff_python_stdlib",
+ "ruff_source_file",
  "ruff_text_size",
  "serde",
- "serde_json",
  "smallvec",
  "speedate",
  "strum 0.27.2",
+ "unicode-general-category",
+ "unicode-normalization",
+ "unicode_names2",
 ]
 
 [[package]]
 name = "monty-macros"
-version = "0.0.18"
-source = "git+https://github.com/pydantic/monty.git?tag=v0.0.18#45a3b2d57e6ce723fed4166fb032242ece74a663"
+version = "0.0.21"
+source = "git+https://github.com/pydantic/monty.git?tag=v0.0.21#70fe3f5781381eb33579e45046f8cb3845953373"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "monty-types"
+version = "0.0.21"
+source = "git+https://github.com/pydantic/monty.git?tag=v0.0.21#70fe3f5781381eb33579e45046f8cb3845953373"
+dependencies = [
+ "chrono",
+ "monty-macros",
+ "num-bigint",
+ "num-traits",
+ "serde",
+ "strum 0.27.2",
+ "unicode-general-category",
+ "web-time",
 ]
 
 [[package]]
@@ -3820,9 +3859,9 @@ checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
  "libc",
  "num-bigint",
@@ -3836,18 +3875,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3855,9 +3894,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3867,13 +3906,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.119",
 ]
@@ -4176,10 +4214,12 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "ruff_python_ast"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10ab966362319801f5e85ce5c6aeac69f0cf50936a31e888f5d004e9279f337"
 dependencies = [
  "aho-corasick",
+ "arrayvec",
  "bitflags 2.13.1",
  "compact_str",
  "get-size2",
@@ -4194,9 +4234,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruff_python_codegen"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1902d82ae0745be9d3d12a1aee4429acff987c768710dc38a6521eab05990ca0"
+dependencies = [
+ "ruff_python_ast",
+ "ruff_python_literal",
+ "ruff_python_parser",
+ "ruff_source_file",
+ "ruff_text_size",
+]
+
+[[package]]
+name = "ruff_python_literal"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3e1f868fa58adc12d1fa3ce1b29c6098aa4b101739d9589cbde9fec239af59"
+dependencies = [
+ "bitflags 2.13.1",
+ "icu_properties",
+ "itertools 0.15.0",
+ "ruff_python_ast",
+]
+
+[[package]]
 name = "ruff_python_parser"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3b8436fb010636ea79ce545acc3e391296ef4e804f7cef336dd5f9c8a4aa3a"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -4216,8 +4282,9 @@ dependencies = [
 
 [[package]]
 name = "ruff_python_stdlib"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c8860927bf42efdabb31ccb2ac9b8f98ee43897b45536f8023e217b158e49a4"
 dependencies = [
  "bitflags 2.13.1",
  "unicode-ident",
@@ -4225,10 +4292,11 @@ dependencies = [
 
 [[package]]
 name = "ruff_python_trivia"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "969e4a14b2550818efea99b9e2361c714c72e4f1fb94799251d55aed20345189"
 dependencies = [
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "ruff_source_file",
  "ruff_text_size",
  "unicode-ident",
@@ -4236,8 +4304,9 @@ dependencies = [
 
 [[package]]
 name = "ruff_source_file"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c194e02d121e4a1744464ce3a982c4c196eb039bbf67532d18c8ce09f8da6381"
 dependencies = [
  "memchr",
  "ruff_text_size",
@@ -4245,8 +4314,9 @@ dependencies = [
 
 [[package]]
 name = "ruff_text_size"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91652ad39be604bc4d5299a5d19feccdd89e255609d89a031e7bb8e0d0aef9f"
 dependencies = [
  "get-size2",
 ]
@@ -5573,6 +5643,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5884,6 +5960,16 @@ name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,9 @@ tree-sitter-css = "0.25"
 tree-sitter-hcl = "1.1"
 tree-sitter-json = "0.24"
 tree-sitter-make = "1.1"
-monty = { git = "https://github.com/pydantic/monty.git", tag = "v0.0.18", package = "monty" }
+monty = { git = "https://github.com/pydantic/monty.git", tag = "v0.0.21", package = "monty" }
+monty-types = { git = "https://github.com/pydantic/monty.git", tag = "v0.0.21", package = "monty-types" }
+get-size2 = "=0.10.1"
 notify = { version = "9.0.0-rc.2", default-features = false, features = ["flume", "macos_fsevent"] }
 serde_yaml = "0.9"
 shell-words = "1"

--- a/flake.nix
+++ b/flake.nix
@@ -87,10 +87,8 @@
       #   mismatch that prints the real hash. This is both the recovery
       #   path for updates and a hard stop if pinned content ever changes.
       gitDepHashes = {
-        "git+https://github.com/pydantic/monty.git?tag=v0.0.18#45a3b2d57e6ce723fed4166fb032242ece74a663" =
-          "sha256-p9mDjS9FTvsITU98B8AeyUCk4wQhgk71HoyOsNPpB0Y=";
-        "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30" =
-          "sha256-m5U5OVUvhn5t3yTSSbT/JA+xmydEDQq+zKFNMN7K/MI=";
+        "git+https://github.com/pydantic/monty.git?tag=v0.0.21#70fe3f5781381eb33579e45046f8cb3845953373" =
+          "sha256-P4PgqfYykkZrWGg5G3WQo070lORLEhmXQUQPx3+Yslo=";
       };
 
       missingGitDepHashes = builtins.filter (s: !(builtins.hasAttr s gitDepHashes)) gitDepSources;

--- a/maki-interpreter/Cargo.toml
+++ b/maki-interpreter/Cargo.toml
@@ -5,9 +5,17 @@ edition.workspace = true
 
 [dependencies]
 monty = { workspace = true }
+monty-types = { workspace = true }
+# Unused directly: pins the transitive version. get-size2 0.10.3 moved to
+# compact_str 0.10, which breaks the GetSize derive in the crates.io
+# ruff_python_ast (still on compact_str 0.9) that monty depends on.
+get-size2 = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }
+
+[package.metadata.cargo-machete]
+ignored = ["get-size2"]

--- a/maki-interpreter/src/alloc.rs
+++ b/maki-interpreter/src/alloc.rs
@@ -1,0 +1,114 @@
+//! Feeds monty's memory counters so `max_memory` holds in-process.
+//!
+//! monty v0.0.21 checks `LIVE_MEMORY - BASELINE_MEMORY` at VM checkpoints,
+//! but something must feed those counters. Upstream feeds them with
+//! `monty-alloc` in a throwaway worker process that dies on a breach. maki
+//! runs the interpreter in-process, so this allocator does the accounting
+//! instead: it charges allocations made by a thread holding a
+//! [`SandboxScope`], and monty's tracker turns a breach into a plain
+//! Python `MemoryError`.
+//!
+//! Being the `#[global_allocator]` of every binary that links this crate
+//! (a second one anywhere fails to compile), enforcement can never go
+//! silently missing. Outside a scope each allocation pays one thread-local
+//! read and touches nothing shared.
+//!
+//! The counters are process-wide, so they can only describe one run:
+//! entering a scope rebases the baseline, which would forgive a concurrent
+//! run its whole usage. Scopes therefore serialize on a mutex.
+//!
+//! The accounting is approximate: tool results are allocated on other
+//! threads (never charged) yet often freed inside the scope (refunded), so
+//! a large result grants that much unearned headroom. Good enough as a
+//! guardrail against runaway agent code, not a security boundary. Once
+//! monty ships `set_memory_probe` (pydantic/monty#740) the counter becomes
+//! thread-local and the mutex and rebasing go away.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+use monty_types::{BASELINE_MEMORY, LIVE_MEMORY};
+
+#[global_allocator]
+static ALLOC: CountingAllocator = CountingAllocator;
+
+thread_local! {
+    static IN_SANDBOX: Cell<bool> = const { Cell::new(false) };
+}
+
+struct CountingAllocator;
+
+fn in_sandbox() -> bool {
+    IN_SANDBOX.try_with(Cell::get).unwrap_or(false)
+}
+
+fn charge(size: usize) {
+    if in_sandbox() {
+        LIVE_MEMORY.fetch_add(size, Relaxed);
+    }
+}
+
+/// Saturating: the sandbox thread frees blocks it was never charged for
+/// (allocated outside the scope), and wrapping below zero would read as a
+/// huge live count and trip the limit instantly.
+fn refund(size: usize) {
+    if in_sandbox() {
+        let _ = LIVE_MEMORY.fetch_update(Relaxed, Relaxed, |v| Some(v.saturating_sub(size)));
+    }
+}
+
+// SAFETY: every method forwards to `System` unchanged; the accounting on
+// the side touches no pointers.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        charge(layout.size());
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        charge(layout.size());
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        refund(layout.size());
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if let Some(grown) = new_size.checked_sub(layout.size()) {
+            charge(grown);
+        } else {
+            refund(layout.size() - new_size);
+        }
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+static SCOPE_LOCK: Mutex<()> = Mutex::new(());
+
+/// Marks the current thread as the interpreter's for the scope's lifetime
+/// and rebases the shared counters so the run starts with zero usage.
+/// Holds [`SCOPE_LOCK`] so only one run at a time feeds the counters.
+pub(crate) struct SandboxScope {
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl SandboxScope {
+    pub(crate) fn enter() -> Self {
+        let lock = SCOPE_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+        IN_SANDBOX.set(true);
+        BASELINE_MEMORY.store(LIVE_MEMORY.load(Relaxed), Relaxed);
+        SandboxScope { _lock: lock }
+    }
+}
+
+/// Clears the flag in the body, before the field-held lock releases, so
+/// this thread stops feeding the counters before the next run rebases them.
+impl Drop for SandboxScope {
+    fn drop(&mut self) {
+        IN_SANDBOX.set(false);
+    }
+}

--- a/maki-interpreter/src/convert.rs
+++ b/maki-interpreter/src/convert.rs
@@ -2,7 +2,7 @@
 //! Lossy corners: NaN floats become `null` (JSON can't represent NaN),
 //! BigInts that overflow `i64` become strings, and tuples become arrays.
 
-use monty::MontyObject;
+use monty_types::MontyObject;
 use serde_json::Value;
 
 pub fn json_to_monty(value: Value) -> MontyObject {

--- a/maki-interpreter/src/lib.rs
+++ b/maki-interpreter/src/lib.rs
@@ -1,3 +1,4 @@
+mod alloc;
 pub mod convert;
 pub mod error;
 pub mod runner;

--- a/maki-interpreter/src/runner.rs
+++ b/maki-interpreter/src/runner.rs
@@ -7,14 +7,15 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::time::Duration;
 
-use monty::{
-    ExcType, ExtFunctionResult, LimitedTracker, MontyException, MontyObject, MontyRun,
-    NameLookupResult, PrintWriter, PrintWriterCallback, ResolveFutures, ResourceLimits,
-    RunProgress,
+use monty::{MontyRun, RunProgress};
+use monty_types::{
+    CompileOptions, ExcType, ExtFunctionResult, MontyException, MontyObject, NameLookupResult,
+    PrintWriter, PrintWriterCallback, ResourceLimits, ResourceTracker,
 };
 use serde_json::Value;
 use tracing::debug;
 
+use crate::alloc::SandboxScope;
 use crate::convert::{json_to_monty, monty_to_json};
 use crate::error::InterpreterError;
 
@@ -68,7 +69,7 @@ pub fn run(
     limits: ResourceLimits,
 ) -> Result<InterpreterResult, InterpreterError> {
     let mut stdout = String::new();
-    let mut print_writer = PrintWriter::CollectString(&mut stdout);
+    let mut print_writer = PrintWriter::collect_string(&mut stdout);
     let output = run_inner(code, tools, resolver, limits, &mut print_writer)?;
     Ok(InterpreterResult { output, stdout })
 }
@@ -98,10 +99,16 @@ fn run_inner(
     limits: ResourceLimits,
     print_writer: &mut PrintWriter<'_>,
 ) -> Result<Option<Value>, InterpreterError> {
-    let runner = MontyRun::new(code.to_owned(), SCRIPT_NAME, vec![])
-        .map_err(|e| InterpreterError::Parse(e.to_string()))?;
+    let _sandbox = limits.max_memory.is_some().then(SandboxScope::enter);
+    let runner = MontyRun::new(
+        code.to_owned(),
+        SCRIPT_NAME,
+        vec![],
+        CompileOptions::default(),
+    )
+    .map_err(|e| InterpreterError::Parse(e.to_string()))?;
 
-    let tracker = LimitedTracker::new(limits);
+    let tracker = ResourceTracker::new(limits);
 
     let mut progress = runner
         .start(vec![], tracker, print_writer.reborrow())
@@ -198,7 +205,6 @@ fn run_inner(
                     .collect();
 
                 let resolved = resolver(batch)?;
-                let state = reset_clock(state)?;
 
                 let results: Vec<(u32, ExtFunctionResult)> = resolved
                     .into_iter()
@@ -222,30 +228,11 @@ fn run_inner(
     }
 }
 
-/// A script blocked on a tool call (a subagent can run for minutes) must not
-/// burn its own time budget, so every await refreshes it. Monty gives no way
-/// to touch the tracker clock on `ResolveFutures`, but loading a dumped run
-/// starts a fresh clock, so a dump/load round-trip resets it. The copy is
-/// cheap next to any real tool call.
-fn reset_clock(
-    state: ResolveFutures<LimitedTracker>,
-) -> Result<ResolveFutures<LimitedTracker>, InterpreterError> {
-    let bytes = RunProgress::ResolveFutures(state)
-        .dump()
-        .map_err(|e| InterpreterError::Runtime(e.to_string()))?;
-    match RunProgress::load(&bytes).map_err(|e| InterpreterError::Runtime(e.to_string()))? {
-        RunProgress::ResolveFutures(s) => Ok(s),
-        _ => Err(InterpreterError::Runtime(
-            "clock reset produced unexpected state".into(),
-        )),
-    }
-}
-
 pub fn limits(timeout: Duration, max_memory: usize) -> ResourceLimits {
-    ResourceLimits::new()
+    ResourceLimits::default()
         .max_duration(timeout)
         .max_memory(max_memory)
-        .max_recursion_depth(Some(DEFAULT_MAX_RECURSION))
+        .max_recursion_depth(DEFAULT_MAX_RECURSION)
 }
 
 #[cfg(test)]
@@ -256,9 +243,21 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     const DEFAULT_MAX_MEMORY: usize = 50 * 1024 * 1024;
+    const SMALL_MAX_MEMORY: usize = 2 * 1024 * 1024;
+    const OVER_LIMIT_ALLOC: &str = "x = [0] * 10_000_000";
+    const MEMORY_ERR_FRAGMENT: &str = "memory";
 
     fn default_limits() -> ResourceLimits {
         limits(Duration::from_secs(30), DEFAULT_MAX_MEMORY)
+    }
+
+    fn small_memory_limits() -> ResourceLimits {
+        limits(Duration::from_secs(30), SMALL_MAX_MEMORY)
+    }
+
+    fn assert_memory_error(err: InterpreterError) {
+        let msg = err.to_string().to_lowercase();
+        assert!(msg.contains(MEMORY_ERR_FRAGMENT), "got: {msg}");
     }
 
     fn empty_tools() -> HashMap<String, ToolFn> {
@@ -273,6 +272,50 @@ mod tests {
                 (n.into(), f)
             })
             .collect()
+    }
+
+    #[test]
+    fn memory_limit_raises_memory_error() {
+        let err = run(
+            OVER_LIMIT_ALLOC,
+            &empty_tools(),
+            None,
+            small_memory_limits(),
+        )
+        .unwrap_err();
+        assert_memory_error(err);
+    }
+
+    /// Without the scope mutex, the second run would rebase the shared
+    /// baseline and forgive the first its whole usage.
+    #[test]
+    fn concurrent_memory_limited_runs_both_enforce() {
+        let spawn = || {
+            std::thread::spawn(|| {
+                run(
+                    OVER_LIMIT_ALLOC,
+                    &empty_tools(),
+                    None,
+                    small_memory_limits(),
+                )
+                .unwrap_err()
+            })
+        };
+        for handle in [spawn(), spawn()] {
+            assert_memory_error(handle.join().unwrap());
+        }
+    }
+
+    #[test]
+    fn memory_limit_not_tripped_by_small_workload() {
+        let result = run(
+            "sum([i for i in range(1000)])",
+            &empty_tools(),
+            None,
+            small_memory_limits(),
+        )
+        .unwrap();
+        assert_eq!(result.output, Some(json!(499500)));
     }
 
     #[test]
@@ -430,8 +473,8 @@ await main()
     fn resolver_wait_does_not_count_against_timeout() {
         const TIMEOUT: Duration = Duration::from_millis(500);
         const WAIT: Duration = Duration::from_millis(700);
-        // Two awaits: an implementation that resets the clock only once would
-        // still time out on the second wait.
+        // Monty's tracker must stop the clock while we sit in the resolver.
+        // Two awaits so a clock paused only for the first wait still fails.
         let code = r#"
 async def main():
     a = await slow()


### PR DESCRIPTION
Monty split its public types into a new `monty-types` crate, `MontyRun::new` grew a `CompileOptions` argument, and the tracker clock now stops while suspended in the host, so the whole dump/load `reset_clock` hack is gone.

The update also silently dropped memory enforcement: the tracker now reads a `LIVE_MEMORY` counter that only a global allocator feeds, and upstream's answer is `monty-alloc` inside a worker subprocess that kills the whole process on a breach.

Instead a new `CountingAllocator` feeds that counter in-process, charging only allocations made by the thread inside a sandbox scope, so a breach surfaces as a plain Python `MemoryError` at the next VM checkpoint and nothing dies.

The runner refuses a `max_memory` limit when the allocator is not installed (proven by a canary allocation) rather than silently not enforcing it, and every binary running the interpreter installs it, including the test binaries.

`get-size2` is pinned to `=0.10.1` in the manifest (not just the lockfile) since `0.10.3` moved to `compact_str 0.10` while the crates.io `ruff_python_ast` still derives with `0.9`. The new monty key in `gitDepHashes` carries the fetchgit NAR hash of the pinned checkout, computed out-of-band and verified by reproducing crane's locked narHash with the same method.