### PR TITLE
ci: replace the dead Magic Nix Cache with cache-nix-action

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -36,12 +36,25 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v22
-      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - uses: nixbuild/nix-quick-install-action@v30
         with:
-          use-flakehub: false
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.*', '**/*.nix', 'Cargo.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 4G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-created: 0
+          purge-primary-key: never
       - name: Check hash drift
         run: nix build .#checks.x86_64-linux.git-dep-hashes
       - name: Check Nix formatting


### PR DESCRIPTION
The free tier of Magic Nix Cache was shut down in February 2025, so the `magic-nix-cache-action` step with `use-flakehub: false` has been a silent no-op and every run rebuilt the toolchain and all crane deps from scratch.

Cache the Nix store in the built-in GitHub Actions cache via `nix-quick-install-action` plus `cache-nix-action`, keyed on `flake.*`, `**/*.nix` and `Cargo.lock`.

Source-only changes hit the primary key and skip re-saving, dep or toolchain bumps prefix-restore the nearest cache, and the store is garbage collected to 4G before saving since the 10G repo budget is shared with `rust-cache` in the Rust workflow.