### PR TITLE
feat(lua): add maki.api.run_command to run slash commands by name 🤖🤖🤖

### DIFF
--- a/maki-docgen/src/gen_commands.rs
+++ b/maki-docgen/src/gen_commands.rs
@@ -4,6 +4,33 @@ use maki_ui::BUILTIN_COMMANDS;
 
 use crate::lua_util;
 
+const ALIASING: &str = r#"## Aliasing commands
+
+Prefer a different name for a command? `maki.api.run_command` runs any slash command exactly as typing it would, so an alias is a one-line handler in your `init.lua` instead of a reimplementation.
+
+```lua
+-- ~/.config/maki/init.lua
+local aliases = {
+    { name = "/clear", target = "/new", description = "Alias for /new" },
+    { name = "/resume", target = "/sessions", description = "Alias for /sessions" },
+}
+
+for _, alias in ipairs(aliases) do
+    maki.api.register_command({
+        name = alias.name,
+        description = alias.description,
+        handler = function()
+            local ok, err = maki.api.run_command(alias.target)
+            if not ok then
+                maki.ui.flash("could not run " .. alias.target .. ": " .. err)
+            end
+        end,
+    })
+end
+```
+
+Both names stay in the palette: aliasing adds a name, it does not rename or hide the original. It works for any command listed above, plus plugin commands and MCP prompts. See [`maki.api.run_command`](/docs/lua-api/#maki-api-run_command) for matching and error handling, or [`maki.ui.action`](/docs/lua-api/#maki-ui-action) to bind a key instead of a name."#;
+
 fn write_row(out: &mut String, name: &str, description: &str) {
     writeln!(out, "| `{name}` | {} |", description.replace('|', "\\|")).unwrap();
 }
@@ -163,6 +190,9 @@ pub fn generate() -> String {
         "For example, `/project:review main.rs` replaces `$ARGUMENTS` with `main.rs`."
     )
     .unwrap();
+    writeln!(out).unwrap();
+    writeln!(out, "{ALIASING}").unwrap();
+
     writeln!(out).unwrap();
     writeln!(
         out,

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -42,7 +42,13 @@ pub(crate) fn create_maki_global(
 ) -> LuaResult<Table> {
     let maki = lua.create_table()?;
 
-    let api = tool::create_api_table(lua, pending, Arc::clone(&plugin), opts)?;
+    let api = tool::create_api_table(
+        lua,
+        pending,
+        Arc::clone(&plugin),
+        opts,
+        ui_action_tx.clone(),
+    )?;
     autocmd::add_autocmd_methods(&api, lua, Arc::clone(&plugin))?;
     slot::add_slot_methods(&api, lua, Arc::clone(&plugin))?;
     maki.set("api", api)?;

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -31,11 +31,15 @@ use serde_json::{Value, json};
 use crate::api::options::{PluginOpts, register_options__doc, register_options__register};
 use crate::api::ui::buf::{BufHandle, line_to_lua};
 use crate::api::util::command::{
-    CommandEntry, CommandHandlerMap, LuaCommandWriter, publish_command_snapshot,
+    CommandEntry, CommandHandlerMap, LuaCommandWriter, UiAction, publish_command_snapshot,
+    ui_roundtrip,
 };
 use crate::api::util::convert::{json_to_lua, lua_to_json};
 use crate::api::util::ctx::LuaCtx;
-use crate::runtime::{HintContent, LiveCtx, PromptHintCallbacks, PromptHintRegistration, Request};
+use crate::api::util::pair::{Pair, try_pair};
+use crate::runtime::{
+    HintContent, LiveCtx, PromptHintCallbacks, PromptHintRegistration, Request, command_depth,
+};
 
 const TOOL_NAME_MAX: usize = 64;
 const TOOL_HANDLER_RETURN_ERR: &str =
@@ -681,6 +685,56 @@ fn register_command(lua: &Lua, #[ctx] plugin: Arc<str>, spec: Table) -> LuaResul
     register_command_from_lua(lua, &spec, plugin)
 }
 
+/// Runs a slash command by name, exactly as typing it in the input would.
+/// Works for built-ins, custom `/project:` and `/user:` commands, MCP
+/// prompts, and commands other plugins registered.
+///
+/// Use it to alias a command you like under a name you prefer, instead of
+/// reimplementing what it does. See `maki.ui.action` for the same idea
+/// applied to keybound UI actions.
+///
+/// Pass the whole command line, arguments included: `"/cd ~/src"`. The
+/// leading slash is optional. Names match exactly apart from case, so a typo
+/// reports an error instead of running the closest command, and a cycle of
+/// aliases stops with one too.
+///
+/// This returns as soon as the command has been dispatched, not when it
+/// finishes, so aliasing something long-running like `/compact` does not
+/// block your handler.
+///
+/// @param cmdline string Command line, e.g. `"/new"` or `"/cd ~/src"`.
+/// @return (boolean|nil, string|nil) `true` once dispatched, or nil and an error message for an unknown command.
+/// @example
+/// -- /resume as an alias for the built-in session picker:
+/// maki.api.register_command({
+///   name = "/resume",
+///   description = "Alias for /sessions",
+///   handler = function()
+///     local ok, err = maki.api.run_command("/sessions")
+///     if not ok then
+///       maki.ui.flash("could not run /sessions: " .. err)
+///     end
+///   end,
+/// })
+#[lua_fn]
+async fn run_command(
+    lua: Lua,
+    #[ctx] tx: Option<flume::Sender<UiAction>>,
+    cmdline: String,
+) -> LuaResult<Pair<bool>> {
+    let depth = command_depth(&lua).saturating_add(1);
+    let reply = try_pair!(
+        ui_roundtrip(tx.as_ref(), |reply_tx| UiAction::RunCommand {
+            cmdline,
+            depth,
+            reply_tx,
+        })
+        .await
+    );
+    try_pair!(reply);
+    Ok((Some(true), None))
+}
+
 /// Add a piece of text to an aggregate prompt slot. Multiple plugins can each
 /// contribute to the same slot, and all contributions are concatenated.
 ///
@@ -856,6 +910,7 @@ lua_table! {
     extend "maki.api" => pub(crate) fn add_tool_fns(pending: PendingTools, plugin: Arc<str>, opts: PluginOpts), DOCS [
         register_tool(pending), register_command(plugin), register_prompt_hint(plugin),
         register_options(plugin, opts), set_prompt(plugin), get_tools, get_tool,
+        manual run_command,
     ]
 }
 
@@ -864,9 +919,11 @@ pub(crate) fn create_api_table(
     pending: PendingTools,
     plugin: Arc<str>,
     opts: PluginOpts,
+    ui_action_tx: Option<flume::Sender<UiAction>>,
 ) -> LuaResult<Table> {
     let t = lua.create_table()?;
     add_tool_fns(&t, lua, pending, plugin, opts)?;
+    run_command__register(&t, lua, ui_action_tx)?;
     Ok(t)
 }
 

--- a/maki-lua/src/api/ui/mod.rs
+++ b/maki-lua/src/api/ui/mod.rs
@@ -258,6 +258,9 @@ fn flash(_lua: &Lua, #[ctx] tx: flume::Sender<UiAction>, msg: String) -> LuaResu
 /// `"plan_toggle"`, `"plan_editor"`, `"edit_input"`, `"pop_queue"`,
 /// `"prev_chat"`, `"next_chat"`.
 ///
+/// For slash commands rather than keybound actions, see
+/// `maki.api.run_command`.
+///
 /// @param name string Action name, e.g. `"file_picker"`.
 /// @return (boolean|nil, string|nil) `true` on success, or nil and an error message for an unknown name.
 /// @example

--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -462,6 +462,14 @@ pub enum UiAction {
         scroll_top: u16,
     },
     Builtin(BuiltinAction),
+    /// `reply_tx` answers whether {cmdline} resolved to a known command, not
+    /// how the command itself went: `/compact` streams for a minute, and the
+    /// Lua caller must not park for that long.
+    RunCommand {
+        cmdline: String,
+        depth: u8,
+        reply_tx: flume::Sender<Result<(), String>>,
+    },
 }
 
 /// Hand an action to the UI event loop. A full or closed channel means the

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -57,6 +57,24 @@ pub mod test_support {
             })
         }
 
+        /// Next dispatched slash command as `(command, args, depth)`, skipping
+        /// other requests.
+        pub fn try_recv_command(&self) -> Option<(String, String, u8)> {
+            use crate::runtime::Request;
+            while let Ok(req) = self.0.try_recv() {
+                if let Request::RunCommand {
+                    command,
+                    args,
+                    depth,
+                    ..
+                } = req
+                {
+                    return Some((command.to_string(), args, depth));
+                }
+            }
+            None
+        }
+
         /// Next fired autocmd as `(event, data)`, skipping other requests.
         pub fn try_recv_autocmd(&self) -> Option<(String, serde_json::Value)> {
             use crate::runtime::Request;

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -477,11 +477,12 @@ impl EventHandle {
         }
     }
 
-    pub fn run_command(&self, plugin: Arc<str>, command: Arc<str>, args: String) {
+    pub fn run_command(&self, plugin: Arc<str>, command: Arc<str>, args: String, depth: u8) {
         let _ = self.prio_tx.try_send(Request::RunCommand {
             plugin,
             command,
             args,
+            depth,
         });
     }
 
@@ -678,17 +679,24 @@ mod tests {
         let (prio_tx, prio_rx) = flume::bounded(8);
         let (tx, _rx) = flume::bounded(8);
         let handle = EventHandle { tx, prio_tx };
-        handle.run_command(Arc::from("myplugin"), Arc::from("/greet"), "world".into());
+        handle.run_command(
+            Arc::from("myplugin"),
+            Arc::from("/greet"),
+            "world".into(),
+            2,
+        );
         let req = prio_rx.try_recv().unwrap();
         match req {
             Request::RunCommand {
                 plugin,
                 command,
                 args,
+                depth,
             } => {
                 assert_eq!(plugin.as_ref(), "myplugin");
                 assert_eq!(command.as_ref(), "/greet");
                 assert_eq!(args, "world");
+                assert_eq!(depth, 2);
             }
             _ => panic!("expected RunCommand"),
         }

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -159,6 +159,9 @@ pub enum Request {
         plugin: Arc<str>,
         command: Arc<str>,
         args: String,
+        /// How many `maki.api.run_command` hops led here; seeds the handler's
+        /// [`TaskCell::command_depth`] so an alias cycle terminates.
+        depth: u8,
     },
     CollectPromptSlots {
         reply: flume::Sender<ResolvedSlots>,
@@ -332,6 +335,10 @@ pub(crate) struct TaskCell {
     /// Set by [`TaskScope::new`]; `enqueue_async_task` upgrades it so queued
     /// tasks share ownership of `bufs`. See [`BufsClaim`].
     bufs_claim: Weak<BufsClaim>,
+    /// Slash-command hops that led to this task, so `maki.api.run_command`
+    /// can refuse to extend a chain that never ends. Inherited by
+    /// `maki.async.run` tasks, or a cycle could hop through one and reset it.
+    pub(crate) command_depth: u8,
 }
 
 impl TaskCell {
@@ -355,6 +362,7 @@ impl TaskCell {
             cancel_hooks: Vec::new(),
             bufs_claim: Weak::new(),
             owns_jobs: true,
+            command_depth: 0,
         }
     }
 
@@ -815,7 +823,18 @@ impl TaskScope {
 ///
 /// [detached]: TaskScope::detached
 pub(crate) async fn run_detached<F: Future>(lua: &Lua, fut: F) -> F::Output {
+    run_scoped(lua, TaskScope::detached(lua), fut).await
+}
+
+/// [`run_detached`] for a slash-command handler, seeding the hop count that
+/// `maki.api.run_command` checks before extending the chain.
+pub(crate) async fn run_command_scoped<F: Future>(lua: &Lua, depth: u8, fut: F) -> F::Output {
     let scope = TaskScope::detached(lua);
+    lock_cell(scope.handle()).command_depth = depth;
+    run_scoped(lua, scope, fut).await
+}
+
+async fn run_scoped<F: Future>(lua: &Lua, scope: TaskScope, fut: F) -> F::Output {
     let handle = Arc::clone(scope.handle());
     let pump = async {
         let mut event_buf = Vec::new();
@@ -934,6 +953,13 @@ pub(crate) fn active_task_id(lua: &Lua) -> Option<u64> {
     Some(lock_cell(&handle).id)
 }
 
+/// Slash-command hops that led to the running task; 0 outside a command
+/// handler, so a keybind or tool calling `maki.api.run_command` starts fresh.
+pub(crate) fn command_depth(lua: &Lua) -> u8 {
+    lua.app_data_ref::<TaskHandle>()
+        .map_or(0, |handle| lock_cell(&handle).command_depth)
+}
+
 /// Task id for job ownership; `None` under a delivery scope.
 pub(crate) fn job_task_id(lua: &Lua) -> Option<u64> {
     let handle = lua.app_data_ref::<TaskHandle>()?;
@@ -968,12 +994,12 @@ pub(crate) fn with_live_ctx<R>(lua: &Lua, f: impl FnOnce(&LiveCtx) -> R) -> Opti
 
 pub(crate) fn enqueue_async_task(lua: &Lua, work_fn: RegistryKey) -> Result<(), mlua::Error> {
     let handle = lua.app_data_ref::<TaskHandle>();
-    let (cancel, live_ctx) = match &handle {
+    let (cancel, live_ctx, command_depth) = match &handle {
         Some(h) => {
             let cell = lock_cell(h);
-            (cell.cancel.clone(), cell.live.clone())
+            (cell.cancel.clone(), cell.live.clone(), cell.command_depth)
         }
-        None => (CancelToken::none(), None),
+        None => (CancelToken::none(), None, 0),
     };
 
     let mut task = PendingAsyncTask {
@@ -982,6 +1008,7 @@ pub(crate) fn enqueue_async_task(lua: &Lua, work_fn: RegistryKey) -> Result<(), 
         deadline: Some(Instant::now() + ASYNC_RUN_DEFAULT_DEADLINE),
         live_ctx,
         owner: None,
+        command_depth,
     };
 
     if let Some(h) = &handle {
@@ -1136,6 +1163,7 @@ pub(crate) struct PendingAsyncTask {
     pub deadline: Option<Instant>,
     pub live_ctx: Option<LiveCtx>,
     pub owner: Option<Arc<BufsClaim>>,
+    pub command_depth: u8,
 }
 
 /// Shared ownership of a task's `bufs`: the scope holds one clone, each
@@ -1243,10 +1271,9 @@ fn spawn_async_task(
     ex.spawn(async move {
         let _gate_guard = g.acquire().await;
 
-        let scope = TaskScope::new(
-            &lua,
-            TaskCell::new(task.cancel.clone(), task.deadline, task.live_ctx.clone()),
-        );
+        let mut cell = TaskCell::new(task.cancel.clone(), task.deadline, task.live_ctx.clone());
+        cell.command_depth = task.command_depth;
+        let scope = TaskScope::new(&lua, cell);
         let handle = Arc::clone(scope.handle());
         let result = scope
             .scope_future(run_work_fn(&lua, &task.work_fn, &handle))
@@ -2656,6 +2683,7 @@ pub fn spawn(
                             plugin,
                             command,
                             args,
+                            depth,
                         } => {
                             let handler_fn =
                                 rt.lua.app_data_ref::<CommandHandlerMap>().and_then(|m| {
@@ -2675,7 +2703,7 @@ pub fn spawn(
                                         let thread = lua.create_thread(func)?;
                                         thread.into_async::<()>(opts)?.await
                                     };
-                                    if let Err(e) = run_detached(&lua, run).await {
+                                    if let Err(e) = run_command_scoped(&lua, depth, run).await {
                                         tracing::warn!(plugin = %plugin, command = %command, error = %e, "command handler failed");
                                     }
                                 })
@@ -3189,6 +3217,20 @@ mod tests {
         );
     }
 
+    /// Without this a `run_command` cycle could hop through `maki.async.run`
+    /// and start over at depth 0, so the cap would never trip.
+    #[test]
+    fn enqueue_async_task_inherits_command_depth() {
+        let lua = enqueue_test_lua();
+        let mut cell = TaskCell::new(CancelToken::none(), None, None);
+        cell.command_depth = 3;
+        let _h = set_active(&lua, cell);
+        enqueue_async_task(&lua, enqueue_dummy(&lua)).unwrap();
+
+        let queue = lua.app_data_ref::<SpawnQueue>().unwrap();
+        assert_eq!(queue.rx.try_recv().unwrap().command_depth, 3);
+    }
+
     #[test]
     fn enqueue_async_task_uses_fresh_deadline_regardless_of_parent() {
         let lua = enqueue_test_lua();
@@ -3256,6 +3298,7 @@ mod tests {
             deadline,
             live_ctx: None,
             owner: None,
+            command_depth: 0,
         }
     }
 
@@ -3786,6 +3829,7 @@ mod tests {
             deadline: None,
             live_ctx: None,
             owner: None,
+            command_depth: 0,
         };
 
         let ex = Rc::new(smol::LocalExecutor::new());

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -2551,7 +2551,7 @@ fn command_handler_receives_args_and_fargs(args: &str, expected_flash: &str) {
     .unwrap();
     let rx = host.ui_action_rx();
     host.event_handle()
-        .run_command(Arc::from("p"), Arc::from("/echo"), args.into());
+        .run_command(Arc::from("p"), Arc::from("/echo"), args.into(), 0);
 
     let action = rx
         .recv_timeout(Duration::from_secs(5))
@@ -2559,6 +2559,51 @@ fn command_handler_receives_args_and_fargs(args: &str, expected_flash: &str) {
     assert!(matches!(action, maki_lua::UiAction::Flash(msg) if msg == expected_flash));
 }
 
+const RUN_COMMAND_NO_ACTION: &str = "run_command did not reach the UI";
+
+/// `/go` asks for `/cd ~/src` and flashes the `ok, err` pair it gets back. The
+/// command line travels untouched, since the UI is the side that parses it, and
+/// a handler reached at depth 0 asks for depth 1 so a chain of aliases keeps
+/// counting toward the cap.
+#[test_case::test_case(Ok(()), "true|nil" ; "dispatched")]
+#[test_case::test_case(Err("unknown command".into()), "nil|unknown command" ; "rejected")]
+fn run_command_round_trips_through_ui(reply: Result<(), String>, expected_flash: &str) {
+    let host = PluginHost::new(fresh_registry()).unwrap();
+    host.load_source(
+        "p",
+        r#"
+        maki.api.register_command({
+            name = "/go",
+            handler = function()
+                local ok, err = maki.api.run_command("/cd ~/src")
+                maki.ui.flash(tostring(ok) .. "|" .. tostring(err))
+            end,
+        })
+        "#,
+    )
+    .unwrap();
+    let rx = host.ui_action_rx();
+    host.event_handle()
+        .run_command(Arc::from("p"), Arc::from("/go"), String::new(), 0);
+
+    let maki_lua::UiAction::RunCommand {
+        cmdline,
+        depth,
+        reply_tx,
+    } = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect(RUN_COMMAND_NO_ACTION)
+    else {
+        panic!("{RUN_COMMAND_NO_ACTION}");
+    };
+    assert_eq!((cmdline.as_str(), depth), ("/cd ~/src", 1));
+    reply_tx.send(reply).unwrap();
+
+    let action = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect(RUN_COMMAND_NO_ACTION);
+    assert!(matches!(action, maki_lua::UiAction::Flash(msg) if msg == expected_flash));
+}
 #[test_case::test_case(
     r#"maki.api.register_command({ name = "", handler = function() end })"#,
     "non-empty" ; "empty_name"
@@ -3812,7 +3857,7 @@ fn async_run_from_parked_command_handler_runs_promptly() {
     .unwrap();
     let rx = host.ui_action_rx();
     let handle = host.event_handle();
-    handle.run_command(Arc::from("p"), Arc::from("/park"), String::new());
+    handle.run_command(Arc::from("p"), Arc::from("/park"), String::new(), 0);
 
     let action = rx
         .recv_timeout(Duration::from_secs(5))
@@ -3843,7 +3888,7 @@ fn job_callbacks_fire_while_command_handler_parked() {
     .unwrap();
     let rx = host.ui_action_rx();
     let handle = host.event_handle();
-    handle.run_command(Arc::from("p"), Arc::from("/stream"), String::new());
+    handle.run_command(Arc::from("p"), Arc::from("/stream"), String::new(), 0);
 
     let action = rx
         .recv_timeout(Duration::from_secs(5))

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -96,6 +96,12 @@ const IMPLEMENT_PARALLEL_HINT: &str = "Use batch+task to parallelize, assign eac
 const TASK_DONE_DETAIL: &str = "✓ ";
 const MISSING_TOOL_COMPLETION: &str = "Tool did not report completion before the turn ended";
 
+/// Depth budget for `maki.api.run_command` chains. Aliases nest a level or two
+/// in practice; the cap only exists so a command aliasing itself reports an
+/// error instead of ping-ponging with the Lua thread forever.
+pub(crate) const MAX_COMMAND_DEPTH: u8 = 8;
+pub(crate) const COMMAND_DEPTH_MSG: &str = "slash command nested too deeply (alias cycle?)";
+
 #[derive(Clone)]
 pub(super) struct TaskEntry {
     name: String,
@@ -848,7 +854,10 @@ impl App {
             .handle_key(key, &self.input_box.buffer.value())
         {
             CommandAction::Consumed => return vec![],
-            CommandAction::Execute(cmd) => return self.execute_command(cmd),
+            CommandAction::Execute(cmd) => {
+                self.input_box.discard();
+                return self.execute_command(cmd, 0);
+            }
             CommandAction::Complete(text) => {
                 self.command_palette.sync(&text);
                 self.input_box.set_input(text);
@@ -1238,8 +1247,33 @@ impl App {
         idx
     }
 
-    fn execute_command(&mut self, cmd: ParsedCommand) -> Vec<Action> {
-        self.input_box.discard();
+    /// Entry point for `maki.api.run_command`: splits a command line into the
+    /// name and args the input bar would hand over, leading slash optional.
+    /// `Err` means nothing ran at all, so the Lua caller can say why.
+    pub(crate) fn run_cmdline(&mut self, cmdline: &str, depth: u8) -> Result<Vec<Action>, String> {
+        if depth > MAX_COMMAND_DEPTH {
+            return Err(COMMAND_DEPTH_MSG.to_string());
+        }
+        let trimmed = cmdline.trim();
+        let (name, args) = trimmed
+            .split_once(char::is_whitespace)
+            .unwrap_or((trimmed, ""));
+        let resolved = self
+            .command_palette
+            .resolve(&format!("/{}", name.trim_start_matches('/')))
+            .ok_or_else(|| format!("unknown command '{name}'"))?;
+        Ok(self.execute_command(
+            ParsedCommand {
+                name: resolved,
+                args: args.trim().to_string(),
+            },
+            depth,
+        ))
+    }
+
+    /// {depth} is the `maki.api.run_command` hop count, forwarded to a Lua
+    /// handler so an alias cycle keeps counting. 0 when the user typed it.
+    fn execute_command(&mut self, cmd: ParsedCommand, depth: u8) -> Vec<Action> {
         match cmd.name.as_str() {
             "/tasks" => {
                 self.open_tasks();
@@ -1357,14 +1391,14 @@ impl App {
                 self.execute_mcp_prompt(name, &cmd.args)
             }
             name if self.command_palette.find_lua_command(name).is_some() => {
-                self.run_lua_command(name, cmd.args);
+                self.run_lua_command(name, cmd.args, depth);
                 vec![]
             }
             _ => vec![],
         }
     }
 
-    fn run_lua_command(&self, name: &str, args: String) {
+    fn run_lua_command(&self, name: &str, args: String, depth: u8) {
         let Some(lua_cmd) = self.command_palette.find_lua_command(name) else {
             return;
         };
@@ -1372,6 +1406,7 @@ impl App {
             Arc::clone(&lua_cmd.plugin),
             Arc::clone(&lua_cmd.name),
             args,
+            depth,
         );
     }
 

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -1253,7 +1253,7 @@ fn overlay_blocks_ctrl_shortcuts(setup: fn(&mut App)) {
 #[test]
 fn compact_command_sets_streaming() {
     let mut app = test_app();
-    let actions = app.execute_command(cmd("/compact"));
+    let actions = app.execute_command(cmd("/compact"), 0);
     assert!(matches!(&actions[0], Action::Compact));
     assert_eq!(app.status, Status::Streaming);
 }
@@ -1264,7 +1264,7 @@ fn compact_during_streaming_queues_item() {
     app.status = Status::Streaming;
     app.run_id = 1;
 
-    let actions = app.execute_command(cmd("/compact"));
+    let actions = app.execute_command(cmd("/compact"), 0);
     assert!(actions.is_empty());
     assert_eq!(app.queue.len(), 1);
     assert_eq!(app.queue.panel_entries()[0].text, "/compact");
@@ -1727,7 +1727,7 @@ fn queue_command_sets_focus(has_queue: bool) {
     } else {
         test_app()
     };
-    app.execute_command(cmd("/queue"));
+    app.execute_command(cmd("/queue"), 0);
     assert_eq!(app.queue.focus().is_some(), has_queue);
 }
 
@@ -1896,7 +1896,7 @@ fn help_toggles_modal() {
     assert!(!app.help_modal.is_open());
     app.update(Msg::Key(kb::HELP.to_key_event()));
     assert!(app.help_modal.is_open());
-    app.execute_command(cmd("/help"));
+    app.execute_command(cmd("/help"), 0);
     assert!(!app.help_modal.is_open());
 }
 
@@ -2065,7 +2065,7 @@ fn reload_persists_session_with_content_to_disk() {
     app.state
         .session_mut()
         .push_message(Message::user("hello".into()));
-    let actions = app.execute_command(cmd("/reload"));
+    let actions = app.execute_command(cmd("/reload"), 0);
     assert_eq!(app.exit_request, ExitRequest::Reload);
     assert!(actions.is_empty());
     app.checkpoint();
@@ -2078,7 +2078,7 @@ fn reload_persists_session_with_content_to_disk() {
 #[test]
 fn reload_leaves_empty_session_unpersisted_on_disk() {
     let (tmp, _dir, writer, mut app) = tempdir_app();
-    app.execute_command(cmd("/reload"));
+    app.execute_command(cmd("/reload"), 0);
     drain_writer(app, writer);
 
     let sessions_dir = tmp.path().join(maki_storage::sessions::SESSIONS_DIR);
@@ -2118,11 +2118,11 @@ fn apply_loaded_session_defers_queued_messages_until_respawn() {
 fn yolo_toggle() {
     let mut app = test_app();
     assert!(!app.permissions.is_yolo());
-    app.execute_command(cmd("/yolo"));
+    app.execute_command(cmd("/yolo"), 0);
     assert!(app.permissions.is_yolo());
     let flash = app.status_bar.flash_text().unwrap();
     assert!(flash.contains("enabled"), "flash={flash:?}");
-    app.execute_command(cmd("/yolo"));
+    app.execute_command(cmd("/yolo"), 0);
     assert!(!app.permissions.is_yolo());
     let flash = app.status_bar.flash_text().unwrap();
     assert!(flash.contains("disabled"), "flash={flash:?}");
@@ -2132,7 +2132,7 @@ fn yolo_toggle() {
 fn usage_command_toggles_modal() {
     let mut app = test_app();
     assert!(!app.usage_modal.is_open());
-    let open_actions = app.execute_command(cmd("/usage"));
+    let open_actions = app.execute_command(cmd("/usage"), 0);
     assert!(app.usage_modal.is_open());
     assert!(
         open_actions
@@ -2140,7 +2140,7 @@ fn usage_command_toggles_modal() {
             .any(|a| matches!(a, Action::RefreshUsage)),
         "opening should request a quota refresh"
     );
-    let close_actions = app.execute_command(cmd("/usage"));
+    let close_actions = app.execute_command(cmd("/usage"), 0);
     assert!(!app.usage_modal.is_open());
     assert!(
         !close_actions
@@ -2153,7 +2153,7 @@ fn usage_command_toggles_modal() {
 #[test]
 fn ctrl_r_refreshes_usage_while_modal_open() {
     let mut app = test_app();
-    app.execute_command(cmd("/usage"));
+    app.execute_command(cmd("/usage"), 0);
     assert!(app.usage_modal.is_open());
 
     let actions = app.update(Msg::Key(kb::REFRESH.to_key_event()));
@@ -2167,10 +2167,13 @@ fn ctrl_r_refreshes_usage_while_modal_open() {
 #[test]
 fn cd_command_behavior() {
     let mut app = test_app();
-    app.execute_command(ParsedCommand {
-        name: "/cd".into(),
-        args: "/tmp".into(),
-    });
+    app.execute_command(
+        ParsedCommand {
+            name: "/cd".into(),
+            args: "/tmp".into(),
+        },
+        0,
+    );
     let flash = app.status_bar.flash_text().unwrap();
     assert!(flash.starts_with("cd /tmp"), "flash={flash:?}");
     // Use `canonicalize_clean` (resolves symlinks like the OS does) rather
@@ -2180,10 +2183,13 @@ fn cd_command_behavior() {
     let resolved = maki_storage::paths::canonicalize_clean(Path::new("/tmp"));
     assert_eq!(app.state.session.cwd, resolved.to_string_lossy());
 
-    app.execute_command(ParsedCommand {
-        name: "/cd".into(),
-        args: "/nonexistent_path_12345".into(),
-    });
+    app.execute_command(
+        ParsedCommand {
+            name: "/cd".into(),
+            args: "/nonexistent_path_12345".into(),
+        },
+        0,
+    );
     let flash = app.status_bar.flash_text().unwrap();
     assert!(flash.starts_with("cd: "), "error flash={flash:?}");
 }
@@ -2222,6 +2228,98 @@ fn typed_lua_command_with_args_executes() {
 
     assert!(actions.is_empty(), "{LUA_COMMAND_NOT_SENT}");
     assert!(probe.try_recv().is_some(), "{LUA_COMMAND_RAN}");
+}
+
+const RUN_CMDLINE_REJECTED: &str = "a rejected cmdline must not run anything";
+
+#[test_case("/new" ; "plain")]
+#[test_case("/NEW" ; "uppercase")]
+#[test_case("  /new  " ; "surrounding_whitespace")]
+#[test_case("new" ; "missing_slash")]
+fn run_cmdline_executes_builtin(cmdline: &str) {
+    let mut app = test_app();
+
+    let actions = app.run_cmdline(cmdline, 0).unwrap();
+
+    assert!(matches!(&actions[..], [Action::NewSession]));
+}
+
+#[test]
+fn run_cmdline_splits_args_off_the_name() {
+    let mut app = test_app();
+
+    let actions = app.run_cmdline("/btw what is rust?", 0).unwrap();
+
+    assert!(matches!(&actions[..], [Action::Btw(q)] if q == "what is rust?"));
+}
+
+/// Only the typed path clears the input, so a keybind or autocmd reaching for
+/// `run_command` cannot eat a half-written message.
+#[test]
+fn run_cmdline_keeps_typed_input() {
+    let mut app = test_app();
+    app.input_box.set_input("half written".into());
+
+    app.run_cmdline("/usage", 0).unwrap();
+
+    assert_eq!(app.input_box.buffer.value(), "half written");
+}
+
+#[test]
+fn run_cmdline_unknown_name_errors_without_dispatching() {
+    let mut app = test_app();
+    let (handle, probe) = maki_lua::test_support::probed_event_handle();
+    app.lua_event_handle = handle;
+
+    let Err(err) = app.run_cmdline("/nope", 0) else {
+        panic!("{RUN_CMDLINE_REJECTED}");
+    };
+
+    assert!(err.contains("/nope"), "err={err:?}");
+    assert!(probe.try_recv_command().is_none(), "{RUN_CMDLINE_REJECTED}");
+}
+
+#[test]
+fn run_cmdline_rejects_past_max_depth() {
+    let mut app = test_app();
+
+    let Err(err) = app.run_cmdline("/new", crate::app::MAX_COMMAND_DEPTH + 1) else {
+        panic!("{RUN_CMDLINE_REJECTED}");
+    };
+
+    assert_eq!(err, crate::app::COMMAND_DEPTH_MSG);
+    assert!(
+        app.run_cmdline("/new", crate::app::MAX_COMMAND_DEPTH)
+            .is_ok(),
+        "the cap itself must still run"
+    );
+}
+
+/// A Lua command reached through an alias carries the hop count onward, or a
+/// cycle of Lua aliases would never trip the cap. It goes out spelled as
+/// registered, since only that spelling dispatches.
+#[test]
+fn run_cmdline_forwards_depth_to_lua_command() {
+    let dir = StateDir::from_path(env::temp_dir());
+    let mut app = build_app_with_lua(
+        dir.clone(),
+        Arc::new(test_writer(dir)),
+        LuaCommandReader::from_commands(vec![LuaCommandInfo {
+            name: "/Sessions".into(),
+            description: "Browse sessions".into(),
+            plugin: "sessions".into(),
+            max_args: 0,
+        }]),
+    );
+    let (handle, probe) = maki_lua::test_support::probed_event_handle();
+    app.lua_event_handle = handle;
+
+    app.run_cmdline("/sessions", 3).unwrap();
+
+    assert_eq!(
+        probe.try_recv_command(),
+        Some(("/Sessions".to_string(), String::new(), 3))
+    );
 }
 
 #[test]
@@ -2513,7 +2611,7 @@ fn search_escape_restores_scroll(scroll_top: u16, auto_scroll: bool) {
 #[test]
 fn mcp_command_opens_picker() {
     let mut app = test_app();
-    app.execute_command(cmd("/mcp"));
+    app.execute_command(cmd("/mcp"), 0);
     assert!(app.mcp_picker.is_open());
 }
 
@@ -2538,7 +2636,7 @@ fn mcp_toggle_dispatches_action() {
         }),
         McpConfigErrors::new(PathBuf::new()),
     );
-    app.execute_command(cmd("/mcp"));
+    app.execute_command(cmd("/mcp"), 0);
 
     let actions = app.update(Msg::Key(key(KeyCode::Enter)));
     assert!(matches!(
@@ -2604,10 +2702,13 @@ fn alt_o_opens_editor_for_input() {
 #[test]
 fn btw_empty_flashes_error() {
     let mut app = test_app();
-    let actions = app.execute_command(ParsedCommand {
-        name: "/btw".into(),
-        args: String::new(),
-    });
+    let actions = app.execute_command(
+        ParsedCommand {
+            name: "/btw".into(),
+            args: String::new(),
+        },
+        0,
+    );
     assert!(actions.is_empty());
     assert_eq!(
         app.status_bar.flash_text().unwrap(),
@@ -2618,10 +2719,13 @@ fn btw_empty_flashes_error() {
 #[test]
 fn btw_with_question_returns_action() {
     let mut app = test_app();
-    let actions = app.execute_command(ParsedCommand {
-        name: "/btw".into(),
-        args: "what is rust?".into(),
-    });
+    let actions = app.execute_command(
+        ParsedCommand {
+            name: "/btw".into(),
+            args: "what is rust?".into(),
+        },
+        0,
+    );
     assert!(matches!(&actions[..], [Action::Btw(q)] if q == "what is rust?"));
 }
 
@@ -3364,10 +3468,10 @@ fn thinking_toggle_cycles_off_adaptive() {
     let mut app = test_app();
     assert_eq!(app.state.thinking, ThinkingConfig::Off);
 
-    app.execute_command(cmd("/thinking"));
+    app.execute_command(cmd("/thinking"), 0);
     assert_eq!(app.state.thinking, ThinkingConfig::Adaptive);
 
-    app.execute_command(cmd("/thinking"));
+    app.execute_command(cmd("/thinking"), 0);
     assert_eq!(app.state.thinking, ThinkingConfig::Off);
 }
 
@@ -3375,16 +3479,22 @@ fn thinking_toggle_cycles_off_adaptive() {
 fn thinking_explicit_args() {
     let mut app = test_app();
 
-    app.execute_command(ParsedCommand {
-        name: "/thinking".into(),
-        args: "8192".into(),
-    });
+    app.execute_command(
+        ParsedCommand {
+            name: "/thinking".into(),
+            args: "8192".into(),
+        },
+        0,
+    );
     assert_eq!(app.state.thinking, ThinkingConfig::Budget(8192));
 
-    app.execute_command(ParsedCommand {
-        name: "/thinking".into(),
-        args: "high".into(),
-    });
+    app.execute_command(
+        ParsedCommand {
+            name: "/thinking".into(),
+            args: "high".into(),
+        },
+        0,
+    );
     assert_eq!(app.state.thinking, ThinkingConfig::Effort(Effort::High));
 }
 
@@ -3393,7 +3503,7 @@ fn thinking_unsupported_model_flashes_error() {
     let mut app = test_app();
     app.state.model.thinking_override = Some(maki_providers::ThinkingSupport::No);
 
-    app.execute_command(cmd("/thinking"));
+    app.execute_command(cmd("/thinking"), 0);
     assert_eq!(app.state.thinking, ThinkingConfig::Off);
     assert!(app.status_bar.flash_text().is_some());
 }
@@ -3424,11 +3534,11 @@ fn fast_toggle_on_off_on_opus() {
     set_opus_model(&mut app);
     assert!(!app.state.fast);
 
-    app.execute_command(cmd("/fast"));
+    app.execute_command(cmd("/fast"), 0);
     assert!(app.state.fast);
     assert_eq!(app.status_bar.flash_text(), Some(FAST_ON_MSG));
 
-    app.execute_command(cmd("/fast"));
+    app.execute_command(cmd("/fast"), 0);
     assert!(!app.state.fast);
     assert_eq!(app.status_bar.flash_text(), Some(FAST_OFF_MSG));
 }
@@ -3442,11 +3552,11 @@ fn workflow_toggle_flows_into_agent_input() {
     };
     assert!(!app.build_agent_input(&msg).workflow);
 
-    app.execute_command(cmd("/workflow"));
+    app.execute_command(cmd("/workflow"), 0);
     assert!(app.build_agent_input(&msg).workflow);
     assert_eq!(app.status_bar.flash_text(), Some(WORKFLOW_ON_MSG));
 
-    app.execute_command(cmd("/workflow"));
+    app.execute_command(cmd("/workflow"), 0);
     assert!(!app.build_agent_input(&msg).workflow);
     assert_eq!(app.status_bar.flash_text(), Some(WORKFLOW_OFF_MSG));
 }
@@ -3483,7 +3593,7 @@ fn fast_flashes_error_on_ineligible_model(spec: &str) {
     let mut app = test_app();
     app.state.model = maki_providers::Model::from_spec(spec).unwrap();
 
-    app.execute_command(cmd("/fast"));
+    app.execute_command(cmd("/fast"), 0);
     assert!(!app.state.fast);
     assert_eq!(app.status_bar.flash_text(), Some(FAST_UNSUPPORTED_MSG));
 }

--- a/maki-ui/src/components/command.rs
+++ b/maki-ui/src/components/command.rs
@@ -193,6 +193,43 @@ impl CommandPalette {
         }
     }
 
+    /// Every command the palette knows, in display order. The one place that
+    /// enumerates the four sources: matching and name lookup both read it.
+    fn items<'a>(
+        custom_commands: &'a [CustomCommand],
+        mcp_prompts: &'a [McpPromptInfo],
+        lua_commands: &'a [LuaCommandInfo],
+    ) -> impl Iterator<Item = CommandItem> + 'a {
+        let builtins = BUILTIN_COMMANDS.iter().map(|cmd| CommandItem {
+            name: cmd.name.to_string(),
+            max_args: cmd.max_args,
+            command_type: CommandType::Builtin(cmd),
+        });
+        let custom = custom_commands
+            .iter()
+            .enumerate()
+            .map(|(i, cmd)| CommandItem {
+                name: cmd.display_name(),
+                max_args: if cmd.has_args() { usize::MAX } else { 0 },
+                command_type: CommandType::Custom(i),
+            });
+        let prompts = mcp_prompts.iter().enumerate().map(|(i, p)| CommandItem {
+            name: format!("/{}", p.display_name),
+            max_args: if p.arguments.is_empty() {
+                0
+            } else {
+                usize::MAX
+            },
+            command_type: CommandType::McpPrompt(i),
+        });
+        let lua = lua_commands.iter().enumerate().map(|(i, cmd)| CommandItem {
+            name: cmd.name.to_string(),
+            max_args: cmd.max_args,
+            command_type: CommandType::Lua(i),
+        });
+        builtins.chain(custom).chain(prompts).chain(lua)
+    }
+
     fn build_nucleo(
         custom_commands: &[CustomCommand],
         mcp_prompts: &[McpPromptInfo],
@@ -201,49 +238,7 @@ impl CommandPalette {
         let nucleo = Nucleo::new(Config::DEFAULT, Arc::new(|| {}), None, 1);
         let injector = nucleo.injector();
 
-        for cmd in BUILTIN_COMMANDS.iter() {
-            let item = CommandItem {
-                name: cmd.name.to_string(),
-                max_args: cmd.max_args,
-                command_type: CommandType::Builtin(cmd),
-            };
-            injector.push(item, |item, cols| {
-                cols[0] = Utf32String::from(item.name.as_str());
-            });
-        }
-
-        for (i, cmd) in custom_commands.iter().enumerate() {
-            let item = CommandItem {
-                name: cmd.display_name(),
-                max_args: if cmd.has_args() { usize::MAX } else { 0 },
-                command_type: CommandType::Custom(i),
-            };
-            injector.push(item, |item, cols| {
-                cols[0] = Utf32String::from(item.name.as_str());
-            });
-        }
-
-        for (i, prompt) in mcp_prompts.iter().enumerate() {
-            let item = CommandItem {
-                name: format!("/{}", prompt.display_name),
-                max_args: if prompt.arguments.is_empty() {
-                    0
-                } else {
-                    usize::MAX
-                },
-                command_type: CommandType::McpPrompt(i),
-            };
-            injector.push(item, |item, cols| {
-                cols[0] = Utf32String::from(item.name.as_str());
-            });
-        }
-
-        for (i, cmd) in lua_commands.iter().enumerate() {
-            let item = CommandItem {
-                name: cmd.name.to_string(),
-                max_args: cmd.max_args,
-                command_type: CommandType::Lua(i),
-            };
+        for item in Self::items(custom_commands, mcp_prompts, lua_commands) {
             injector.push(item, |item, cols| {
                 cols[0] = Utf32String::from(item.name.as_str());
             });
@@ -449,6 +444,16 @@ impl CommandPalette {
             name,
             args: args.to_string(),
         })
+    }
+
+    /// Name lookup for `maki.api.run_command`, returning the registered
+    /// spelling that [`crate::app::App`] dispatches on. Case-insensitive like
+    /// typing, but never fuzzy: an alias names one command on purpose, and a
+    /// typo should report itself instead of running the closest neighbor.
+    pub fn resolve(&self, name: &str) -> Option<String> {
+        Self::items(&self.custom, &self.mcp_prompts, &self.lua_commands)
+            .map(|item| item.name)
+            .find(|n| n.eq_ignore_ascii_case(name))
     }
 
     pub fn find_custom_command(&self, display_name: &str) -> Option<&CustomCommand> {

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -618,6 +618,23 @@ impl<'t> EventLoop<'t> {
                 let actions = self.focused_app().run_builtin(action);
                 self.dispatch(self.focused, actions);
             }
+            UiAction::RunCommand {
+                cmdline,
+                depth,
+                reply_tx,
+            } => {
+                // Answer before dispatching: the caller only waits on the name
+                // resolving, and dispatch may take a while (or exit the app).
+                match self.focused_app().run_cmdline(&cmdline, depth) {
+                    Ok(actions) => {
+                        let _ = reply_tx.send(Ok(()));
+                        self.dispatch(self.focused, actions);
+                    }
+                    Err(e) => {
+                        let _ = reply_tx.send(Err(e));
+                    }
+                }
+            }
         }
     }
 

--- a/site/docs/content/commands/_index.md
+++ b/site/docs/content/commands/_index.md
@@ -84,4 +84,31 @@ Use `$ARGUMENTS` in the command body. It gets replaced with whatever you type af
 
 For example, `/project:review main.rs` replaces `$ARGUMENTS` with `main.rs`.
 
+## Aliasing commands
+
+Prefer a different name for a command? `maki.api.run_command` runs any slash command exactly as typing it would, so an alias is a one-line handler in your `init.lua` instead of a reimplementation.
+
+```lua
+-- ~/.config/maki/init.lua
+local aliases = {
+    { name = "/clear", target = "/new", description = "Alias for /new" },
+    { name = "/resume", target = "/sessions", description = "Alias for /sessions" },
+}
+
+for _, alias in ipairs(aliases) do
+    maki.api.register_command({
+        name = alias.name,
+        description = alias.description,
+        handler = function()
+            local ok, err = maki.api.run_command(alias.target)
+            if not ok then
+                maki.ui.flash("could not run " .. alias.target .. ": " .. err)
+            end
+        end,
+    })
+end
+```
+
+Both names stay in the palette: aliasing adds a name, it does not rename or hide the original. It works for any command listed above, plus plugin commands and MCP prompts. See [`maki.api.run_command`](/docs/lua-api/#maki-api-run_command) for matching and error handling, or [`maki.ui.action`](/docs/lua-api/#maki-ui-action) to bind a key instead of a name.
+
 Related: [CLI](/docs/cli/) for shell flags and subcommands, [Skills](/docs/skills/) for on-demand playbooks.

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -440,6 +440,53 @@ end
 
 ---
 
+### `maki.api.run_command()` {#maki-api-run_command}
+
+```lua
+maki.api.run_command({cmdline})
+```
+
+Runs a slash command by name, exactly as typing it in the input would.
+Works for built-ins, custom `/project:` and `/user:` commands, MCP
+prompts, and commands other plugins registered.
+
+Use it to alias a command you like under a name you prefer, instead of
+reimplementing what it does. See `maki.ui.action` for the same idea
+applied to keybound UI actions.
+
+Pass the whole command line, arguments included: `"/cd ~/src"`. The
+leading slash is optional. Names match exactly apart from case, so a typo
+reports an error instead of running the closest command, and a cycle of
+aliases stops with one too.
+
+This returns as soon as the command has been dispatched, not when it
+finishes, so aliasing something long-running like `/compact` does not
+block your handler.
+
+**Parameters:**
+
+- `{cmdline}` (`string`) Command line, e.g. `"/new"` or `"/cd ~/src"`.
+
+**Returns:** (`boolean|nil`, `string|nil`) `true` once dispatched, or nil and an error message for an unknown command.
+
+**Example:**
+
+```lua
+-- /resume as an alias for the built-in session picker:
+maki.api.register_command({
+  name = "/resume",
+  description = "Alias for /sessions",
+  handler = function()
+    local ok, err = maki.api.run_command("/sessions")
+    if not ok then
+      maki.ui.flash("could not run /sessions: " .. err)
+    end
+  end,
+})
+```
+
+---
+
 ### `maki.api.create_autocmd()` {#maki-api-create_autocmd}
 
 ```lua
@@ -4171,6 +4218,9 @@ and call this from it.
 Valid names: `"file_picker"`, `"search"`, `"tasks"`, `"help"`,
 `"plan_toggle"`, `"plan_editor"`, `"edit_input"`, `"pop_queue"`,
 `"prev_chat"`, `"next_chat"`.
+
+For slash commands rather than keybound actions, see
+`maki.api.run_command`.
 
 **Parameters:**
 


### PR DESCRIPTION
Closes #776.

Runs any slash command by name, so an alias is one line instead of a copy of the original:

```lua
maki.api.register_command({
  name = "/resume",
  description = "Alias for /sessions",
  handler = function()
    maki.api.run_command("/sessions")
  end,
})
```

This is the slash command version of `maki.ui.action` (#752). It calls the same code the input bar calls, so an alias always does what the real command does.

The name must match exactly, so `/pct` does not turn into `/compact`. The call returns once the command starts, not once it ends, so an alias for `/compact` does not block your handler. If aliases point at each other in a loop, it stops with an error. The hop count is sent along with the request, because handlers run on their own and the caller is already gone by then.

Docs: new "Aliasing commands" section on the Commands page.

`just ci` passes, except `stylua`, `ruff`, `ty` and `machete`, which are not installed on my machine. No Lua or Python files changed. Two tests in `maki-providers` fail, but they also fail without my changes.

AI use: I used Claude (Opus 4.6) as an agent in the repo. It wrote the code and tests, and I checked each step. After a review pass it moved `depth` out of `ParsedCommand` and made it an argument. It also wanted to move the loop check into the Lua binding, which I said no to, because the UI runs the commands so it should hold the limit.