### PR TITLE
feat(lua): keep partial output when tools are cancelled or time out

### DIFF
--- a/maki-agent/src/agent/mod.rs
+++ b/maki-agent/src/agent/mod.rs
@@ -14,5 +14,6 @@ pub use instructions::{
     is_instruction_file, load_instruction_text, load_instructions,
 };
 pub use run::{
-    Agent, AgentParams, AgentRunParams, estimate_message_tokens, resolve_compaction_model,
+    Agent, AgentParams, AgentRunParams, EMPTY_RESPONSE_MARKER, estimate_message_tokens,
+    resolve_compaction_model,
 };

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -25,6 +25,10 @@ use crate::{
 use maki_config::{ModelPolicy, ToolOutputLines};
 use maki_storage::id::SessionRef;
 
+/// Stands in for the assistant turn the model left blank, so the nudge
+/// below has something to answer. Never a real response: readers that mine
+/// history for model text must skip it.
+pub const EMPTY_RESPONSE_MARKER: &str = "(empty)";
 const MAX_REAUTH_ATTEMPTS: u32 = 2;
 const NUDGE_PROMPT: &str = "You just executed tool calls but returned an empty response. Please process the tool results above and continue with the task.";
 
@@ -334,7 +338,7 @@ impl<'h> Agent<'h> {
                 self.history.push(Message {
                     role: Role::Assistant,
                     content: vec![ContentBlock::Text {
-                        text: "(empty)".into(),
+                        text: EMPTY_RESPONSE_MARKER.into(),
                     }],
                     ..Default::default()
                 });

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -14,9 +14,9 @@ pub use mcp::{
 };
 pub(crate) mod task_set;
 pub use agent::{
-    Agent, AgentParams, AgentRunParams, History, HistorySnapshot, Instructions, LoadedInstructions,
-    SharedMessages, UNAVAILABLE_RESULT, close_dangling_tool_calls, find_subdirectory_instructions,
-    is_instruction_file,
+    Agent, AgentParams, AgentRunParams, EMPTY_RESPONSE_MARKER, History, HistorySnapshot,
+    Instructions, LoadedInstructions, SharedMessages, UNAVAILABLE_RESULT,
+    close_dangling_tool_calls, find_subdirectory_instructions, is_instruction_file,
 };
 pub use cancel::{CancelMap, CancelToken, CancelTrigger};
 pub use mailbox::{MailboxError, SessionMailbox};

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -708,8 +708,11 @@ impl SharedBuf {
         Some(Arc::clone(&guard))
     }
 
+    /// A copy for a tool reply. Leaves the dirty flag alone: only the UI
+    /// clears it, and a reply can die on the way there (a cancelled run's
+    /// events are stale), which would strand the last repaint a tool made
+    /// on its way out. Re-reading the same lines once costs nothing.
     pub fn take(&self) -> BufferSnapshot {
-        self.dirty.store(false, Ordering::Release);
         let guard = self.committed.lock().unwrap_or_else(|e| e.into_inner());
         BufferSnapshot::from_arc(Arc::clone(&guard))
     }
@@ -1222,7 +1225,10 @@ mod tests {
 
         buf.append(line("l3"));
         let _ = buf.take();
-        assert!(buf.read_if_dirty().is_none(), "take clears dirty");
+        assert!(
+            buf.read_if_dirty().is_some(),
+            "take must leave the flag for the UI"
+        );
     }
 
     #[test]

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -18,8 +18,8 @@ use maki_agent::tools::{
     ToolContext, ToolFilter, ToolLive,
 };
 use maki_agent::{
-    Agent, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, Envelope, EventSender,
-    History, McpSession, SubagentInfo, ToolDoneEvent,
+    Agent, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, EMPTY_RESPONSE_MARKER,
+    Envelope, EventSender, History, McpSession, SubagentInfo, ToolDoneEvent,
 };
 use maki_lua_macro::{lua_class, lua_fn, lua_table};
 use maki_providers::model::ModelTier;
@@ -172,7 +172,10 @@ async fn system_prompt(
     ctx: mlua::UserDataRef<LuaCtx>,
     opts: Table,
 ) -> LuaResult<Pair<String>> {
-    let agent = try_pair!(dispatch_ctx(&ctx, "system_prompt"));
+    let slots = Arc::clone(&try_pair!(dispatch_ctx(&ctx, "system_prompt")).prompt_slots);
+    // Nothing may hold the ctx borrow across the wait: a cancel hook firing
+    // meanwhile needs `ctx:finish`, which takes it mutably.
+    drop(ctx);
     let prompt_id_str: String = opts.get("prompt_id")?;
     let prompt_id = match prompt_id_str.as_str() {
         "research" => maki_agent::prompt::PromptId::Research,
@@ -193,7 +196,7 @@ async fn system_prompt(
         _ => return Err(mlua::Error::runtime("instructions must be bool or string")),
     };
 
-    let assembled = maki_agent::prompt::assemble(prompt_id, &agent.prompt_slots, &instructions);
+    let assembled = maki_agent::prompt::assemble(prompt_id, &slots, &instructions);
     Ok((Some(vars.apply(&assembled).into_owned()), None))
 }
 
@@ -738,7 +741,9 @@ impl Drop for LuaSession {
 /// tools).
 ///
 /// @param message string User message to send.
-/// @return (table?, string?) Result table on success, or `(nil, err)` on failure.
+/// @return (table?, string?) Result table on success, or `(nil, err)` on
+/// failure. A run cut short after streaming some text hands you both: the
+/// error and a `{ text = <what it streamed> }` table.
 /// @example
 /// local r, err = sess:prompt("What files are in this project?")
 /// if err then error(err) end
@@ -794,8 +799,31 @@ async fn prompt(
     };
     let result = agent.run(input).await;
     drop(agent);
+    // Only this call's messages count: older turns may hold stale preamble
+    // text, and the agent loop's empty-response retry leaves a synthetic
+    // "(empty)" assistant marker that must not pass for a real response.
+    // Auto-compaction can shrink the history mid-run, so clamp the start:
+    // after a rewrite the tail is this call's output either way.
+    let turn = &s.history.as_slice()[history_len.min(s.history.len())..];
     if let Err(e) = result {
-        return Ok((None, Some(e.to_string())));
+        let partial = turn
+            .iter()
+            .filter(|m| matches!(m.role, Role::Assistant))
+            .flat_map(|m| m.content.iter())
+            .filter_map(|b| match b {
+                ContentBlock::Text { text } if text != EMPTY_RESPONSE_MARKER => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let tbl = if partial.is_empty() {
+            None
+        } else {
+            let tbl = lua.create_table()?;
+            tbl.set("text", partial)?;
+            Some(tbl)
+        };
+        return Ok((tbl, Some(e.to_string())));
     }
     // Waiting here doubles as an ordering barrier: the relay reaches `Done` only
     // after every `TurnComplete`, so all our `ToolLive::Usage` messages sit in the
@@ -808,12 +836,7 @@ async fn prompt(
         ),
     }
 
-    // Only this call's messages count: older turns may hold stale preamble
-    // text, and the agent loop's empty-response retry leaves a synthetic
-    // "(empty)" assistant marker that must not pass for a real response.
-    // Auto-compaction can shrink the history mid-run, so clamp the start:
-    // after a rewrite the tail is this call's output either way.
-    let text = s.history.as_slice()[history_len.min(s.history.len())..]
+    let text = turn
         .iter()
         .rfind(|m| matches!(m.role, Role::Assistant))
         .and_then(|m| {

--- a/maki-lua/src/api/async.rs
+++ b/maki-lua/src/api/async.rs
@@ -116,21 +116,27 @@ fn run(lua: &Lua, r#fn: Function, on_finish: Option<Function>) -> LuaResult<()> 
     Ok(())
 }
 
-/// Register {fn} to run as soon as the current task is cancelled, without
-/// waiting for whatever it is doing to finish. Use it to paint the
-/// cancelled state: a handler waiting on children (`gather`, `call_tool`)
-/// stays parked until they wind down, so anything after the wait is too
-/// late to reach the screen.
+/// Register {fn} to run as soon as the current task is cancelled or hits
+/// its deadline, without waiting for whatever it is doing to finish. Use
+/// it to paint the cancelled state: a handler waiting on children
+/// (`gather`, `call_tool`) stays parked until they wind down, so anything
+/// after the wait is too late to reach the screen.
+///
+/// The callback receives the reason (`"cancelled"` or `"timeout"`) and may
+/// still call `ctx:finish`; the host prefers that reply over the generic
+/// cancelled/timeout error. Mark it `is_error = true` and end it with a
+/// marker, so the model knows the output it gets is cut short.
 ///
 /// The callback runs outside your coroutine, so it must not yield. It
 /// fires at most once, immediately if the task is already cancelled. An
 /// error inside it is logged and never reaches your handler, and the
 /// other hooks still run.
 ///
-/// @param fn function Zero-argument function to run on cancel.
+/// @param fn function Function to run on cancel; receives the reason string.
 /// @example
-/// maki.async.on_cancel(function()
-///   view:append({ { "cancelled", "tool_error" } })
+/// maki.async.on_cancel(function(reason)
+///   view:append({ { reason, "tool_error" } })
+///   ctx:finish({ llm_output = partial .. "\n[cancelled; output is partial]", is_error = true })
 /// end)
 /// maki.async.gather(children)
 #[lua_fn]

--- a/maki-lua/src/api/interpreter.rs
+++ b/maki-lua/src/api/interpreter.rs
@@ -176,10 +176,12 @@ async fn interpreter_run(lua: Lua, code: String, opts: Table) -> LuaResult<Pair<
         Ok::<(), mlua::Error>(())
     };
 
-    let (result, cb) = cancel
-        .race(futures_lite::future::zip(run, recv_loop))
-        .await
-        .map_err(mlua::Error::runtime)?;
+    // A cancel comes back as a pair error, not a raise, so the caller can
+    // still report the lines it streamed before the cut.
+    let (result, cb) = match cancel.race(futures_lite::future::zip(run, recv_loop)).await {
+        Ok(v) => v,
+        Err(e) => return Ok((None, Some(e))),
+    };
     cb?;
 
     let tbl = lua.create_table()?;

--- a/maki-lua/src/api/util/ctx.rs
+++ b/maki-lua/src/api/util/ctx.rs
@@ -315,6 +315,7 @@ impl UserData for LuaCtx {
             cell.deadline_secs.set(Some(secs));
             cell.deadline
                 .set(Some(Instant::now() + Duration::from_secs(secs)));
+            cell.deadline_changed.notify(usize::MAX);
             Ok((Some(true), None))
         });
 
@@ -345,6 +346,10 @@ impl UserData for LuaCtx {
                 let Some(loaded) = this.loaded_instructions().cloned() else {
                     return Ok(this.cap_err_pair("find_instructions"));
                 };
+                // Nothing may hold the ctx borrow across the wait: a cancel
+                // hook firing meanwhile needs `ctx:finish`, which takes it
+                // mutably.
+                drop(this);
                 let results = smol::unblock(move || {
                     let cwd = std::env::current_dir().unwrap_or_default();
                     let abs = resolve_abs_with_cwd(dir_path, &cwd);

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -307,6 +307,9 @@ pub(crate) struct TaskCell {
     kill_at: Cell<Option<Instant>>,
     pub(crate) deadline: Cell<Option<Instant>>,
     pub(crate) deadline_secs: Cell<Option<u64>>,
+    /// Notified by `ctx:set_deadline`, so [`until_abandoned`] re-arms on the
+    /// new deadline instead of staying parked on the one it started with.
+    pub(crate) deadline_changed: Event,
     pub(crate) bufs: BufferStore,
     pub(crate) live: Option<LiveCtx>,
     /// The buf that owns click routing for this task: the last one passed
@@ -343,6 +346,7 @@ impl TaskCell {
             kill_at: Cell::new(None),
             deadline: Cell::new(deadline),
             deadline_secs: Cell::new(None),
+            deadline_changed: Event::new(),
             bufs: BufferStore::new(),
             live,
             root_buf: None,
@@ -352,6 +356,10 @@ impl TaskCell {
             bufs_claim: Weak::new(),
             owns_jobs: true,
         }
+    }
+
+    fn into_handle(self) -> TaskHandle {
+        Arc::new(Mutex::new(self))
     }
 
     /// Cancel outranks the deadline: once nobody waits for the reply,
@@ -432,17 +440,22 @@ pub(crate) fn register_cancel_hook(lua: &Lua, callback: Function) -> Result<(), 
         cell.cancel.is_cancelled()
     };
     if cancelled {
-        fire_cancel_hooks(lua, &handle);
+        fire_cancel_hooks(lua, &handle, KillReason::Cancelled);
     }
     Ok(())
 }
 
-fn fire_cancel_hooks(lua: &Lua, handle: &TaskHandle) {
+fn fire_cancel_hooks(lua: &Lua, handle: &TaskHandle, reason: KillReason) {
+    // Hooks word their partial-output marker from this string.
+    let reason = match reason {
+        KillReason::Cancelled => CANCELLED_MSG,
+        KillReason::Deadline => HANDLER_TIMEOUT_MSG,
+    };
     let hooks = std::mem::take(&mut lock_cell(handle).cancel_hooks);
     for key in hooks {
         if let Err(e) = lua
             .registry_value::<Function>(&key)
-            .and_then(|f| f.call::<()>(()))
+            .and_then(|f| f.call::<()>(reason))
         {
             tracing::warn!(error = %strip_traceback(&e), "cancel hook failed");
         }
@@ -885,7 +898,7 @@ impl<F: Future> Future for ScopedFuture<F> {
             && wait.as_mut().poll(cx).is_ready()
         {
             *this.cancel_wait = None;
-            fire_cancel_hooks(this.lua, this.handle);
+            fire_cancel_hooks(this.lua, this.handle, KillReason::Cancelled);
         }
         let result = this.inner.poll(cx);
         match prev {
@@ -1166,14 +1179,24 @@ impl SpawnQueue {
 /// finished in the same slice deserves to have its result reported.
 async fn until_abandoned(
     fut: impl Future<Output = Result<LuaValue, mlua::Error>>,
-    deadline: Option<Instant>,
-    cancel: &CancelToken,
+    handle: &TaskHandle,
 ) -> Result<LuaValue, mlua::Error> {
+    let cancel = lock_cell(handle).cancel.clone();
     let timed_out = async {
-        match deadline {
-            Some(dl) => smol::Timer::at(dl).await,
-            None => std::future::pending().await,
-        };
+        loop {
+            // Listen before reading: a `ctx:set_deadline` landing between the
+            // two wakes us instead of leaving us armed on the stale deadline.
+            let changed = lock_cell(handle).deadline_changed.listen();
+            // Bound before the match: the guard would outlive the await.
+            let deadline = lock_cell(handle).deadline.get();
+            match deadline {
+                Some(dl) if dl <= Instant::now() => break,
+                Some(dl) => {
+                    futures_lite::future::or(async { _ = smol::Timer::at(dl).await }, changed).await
+                }
+                None => changed.await,
+            }
+        }
         HANDLER_TIMEOUT_MSG
     };
     let cancelled = async {
@@ -1192,12 +1215,11 @@ async fn until_abandoned(
 async fn run_work_fn(
     lua: &Lua,
     work_fn: &RegistryKey,
-    deadline: Option<Instant>,
-    cancel: &CancelToken,
+    handle: &TaskHandle,
 ) -> Result<LuaValue, mlua::Error> {
     let func: Function = lua.registry_value(work_fn)?;
     let fut = lua.create_thread(func)?.into_async::<LuaValue>(())?;
-    until_abandoned(fut, deadline, cancel).await
+    until_abandoned(fut, handle).await
 }
 
 fn spawn_async_task(
@@ -1225,13 +1247,9 @@ fn spawn_async_task(
             &lua,
             TaskCell::new(task.cancel.clone(), task.deadline, task.live_ctx.clone()),
         );
+        let handle = Arc::clone(scope.handle());
         let result = scope
-            .scope_future(run_work_fn(
-                &lua,
-                &task.work_fn,
-                task.deadline,
-                &task.cancel,
-            ))
+            .scope_future(run_work_fn(&lua, &task.work_fn, &handle))
             .await;
         if let Err(e) = &result {
             let tool_id = task.live_ctx.as_ref().map(|l| l.tool_use_id.as_str());
@@ -2055,9 +2073,16 @@ async fn run_inline_tasks(lua: &Lua, scope: &TaskScope) {
         };
         for task in tasks {
             if !task.cancel.is_cancelled() {
-                let deadline = Some(Instant::now() + RESTORE_ASYNC_DEADLINE);
+                // Its own cell: the window is per task, not the restore
+                // scope's, and only `until_abandoned` reads it.
+                let handle = TaskCell::new(
+                    task.cancel.clone(),
+                    Some(Instant::now() + RESTORE_ASYNC_DEADLINE),
+                    None,
+                )
+                .into_handle();
                 if let Err(e) = scope
-                    .scope_future(run_work_fn(lua, &task.work_fn, deadline, &task.cancel))
+                    .scope_future(run_work_fn(lua, &task.work_fn, &handle))
                     .await
                 {
                     tracing::debug!(error = %e, "restore inline async task failed");
@@ -2129,6 +2154,19 @@ fn extract_restore_reply(ret: &LuaValue) -> Option<RestoreReply> {
     Some(RestoreReply { body, header })
 }
 
+/// The last slice a doomed handler gets: its cancel hooks run (firing twice
+/// is free, they drain once), and a reply they queue through `ctx:finish`
+/// wins, because it carries the output the user already watched stream by.
+fn cancel_hook_reply(
+    lua: &Lua,
+    handle: &TaskHandle,
+    finish_rx: &flume::Receiver<ToolCallReply>,
+    reason: KillReason,
+) -> Option<ToolCallReply> {
+    fire_cancel_hooks(lua, handle, reason);
+    finish_rx.try_recv().ok()
+}
+
 /// Handler returned nil, meaning it went async. Polls job events
 /// until `ctx:finish()`, all jobs die, or the deadline expires.
 async fn dispatch_async(
@@ -2155,10 +2193,14 @@ async fn dispatch_async(
         // frame left to unwind. Bound before the match so the guard drops
         // before `timeout_reply`, which locks the same cell.
         let kill = lock_cell(&handle).doomed(Instant::now());
-        match kill {
-            Some(KillReason::Cancelled) => return ToolCallReply::err(CANCELLED_MSG),
-            Some(KillReason::Deadline) => return timeout_reply(&handle, plugin, tool),
-            None => {}
+        if let Some(reason) = kill {
+            if let Some(reply) = cancel_hook_reply(lua, &handle, &finish_rx, reason) {
+                return reply;
+            }
+            return match reason {
+                KillReason::Cancelled => ToolCallReply::err(CANCELLED_MSG),
+                KillReason::Deadline => timeout_reply(&handle, plugin, tool),
+            };
         }
 
         match finish_rx.try_recv() {
@@ -2351,7 +2393,7 @@ async fn run_tool_call(
     }
 
     let call_future = scope.scope_future(async {
-        match until_abandoned(async_thread, deadline, &cancel).await {
+        match until_abandoned(async_thread, &handle).await {
             Ok(LuaValue::Nil) => {
                 let (live, sink) = {
                     let cell = lock_cell(&handle);
@@ -2376,7 +2418,13 @@ async fn run_tool_call(
                 }
                 ToolCallReply::from_lua_value(&lua, &val)
             }
-            Err(e) => ToolCallReply::err(strip_traceback(&e)),
+            // Bound before the `and_then` so the guard drops before the
+            // hooks run: they lock the same cell.
+            Err(e) => {
+                let kill = lock_cell(&handle).doomed(Instant::now());
+                kill.and_then(|reason| cancel_hook_reply(&lua, &handle, &finish_rx, reason))
+                    .unwrap_or_else(|| ToolCallReply::err(strip_traceback(&e)))
+            }
         }
     });
 
@@ -3329,6 +3377,10 @@ mod tests {
         assert!(cell.kill_at.get().is_none(), "healthy poke must disarm");
     }
 
+    fn task_handle(cancel: CancelToken, deadline: Option<Instant>) -> TaskHandle {
+        TaskCell::new(cancel, deadline, None).into_handle()
+    }
+
     /// The watchdog never reaches a handler parked in an await, so this
     /// race is what ends it - but not before its cleanup window, and never
     /// ahead of a result the handler already produced.
@@ -3338,8 +3390,7 @@ mod tests {
         smol::block_on(async {
             let early = futures_lite::future::poll_once(until_abandoned(
                 parked(),
-                None,
-                &cancelled_token(),
+                &task_handle(cancelled_token(), None),
             ))
             .await;
             assert!(
@@ -3347,18 +3398,46 @@ mod tests {
                 "a cancel must not abandon the handler before its window"
             );
 
-            let err = until_abandoned(parked(), Some(Instant::now()), &CancelToken::none())
-                .await
-                .expect_err("a lapsed deadline must end a parked handler");
+            let err = until_abandoned(
+                parked(),
+                &task_handle(CancelToken::none(), Some(Instant::now())),
+            )
+            .await
+            .expect_err("a lapsed deadline must end a parked handler");
             assert!(err.to_string().contains(HANDLER_TIMEOUT_MSG));
 
             until_abandoned(
                 std::future::ready(Ok(LuaValue::Boolean(true))),
-                Some(Instant::now()),
-                &cancelled_token(),
+                &task_handle(cancelled_token(), Some(Instant::now())),
             )
             .await
             .expect("a finished handler outranks a doom in the same slice");
+        });
+    }
+
+    /// `ctx:set_deadline` lands after the race is already armed, so the
+    /// arming must be revisited or a parked handler outlives its deadline.
+    #[test]
+    fn until_abandoned_re_arms_on_a_deadline_set_after_it_started() {
+        let handle = task_handle(CancelToken::none(), None);
+        let cell = Arc::clone(&handle);
+        smol::block_on(async {
+            let set = async {
+                smol::Timer::after(Duration::from_millis(1)).await;
+                let cell = lock_cell(&cell);
+                cell.deadline.set(Some(Instant::now()));
+                cell.deadline_changed.notify(usize::MAX);
+            };
+            let wait = until_abandoned(
+                std::future::pending::<Result<LuaValue, mlua::Error>>(),
+                &handle,
+            );
+            let (_, err) = futures_lite::future::zip(set, wait).await;
+            assert!(
+                err.expect_err("the new deadline must end the handler")
+                    .to_string()
+                    .contains(HANDLER_TIMEOUT_MSG)
+            );
         });
     }
 
@@ -3732,6 +3811,15 @@ mod tests {
     /// again: `timeout_reply` locks the very cell the loop inspects, so a
     /// regression there deadlocks and must fail rather than hang the suite.
     fn drive_dispatch(cell: TaskCell) -> (Result<String, String>, Duration) {
+        drive_dispatch_with(cell, |_, _| {})
+    }
+
+    /// `setup` runs on the dispatch thread, standing in for a handler that
+    /// armed cancel hooks.
+    fn drive_dispatch_with(
+        cell: TaskCell,
+        setup: impl FnOnce(&Lua, flume::Sender<ToolCallReply>) + Send + 'static,
+    ) -> (Result<String, String>, Duration) {
         let (tx, rx) = flume::bounded(1);
         thread::spawn(move || {
             let lua = Lua::new();
@@ -3741,7 +3829,8 @@ mod tests {
                 store.start(owner, DISPATCH_TEST_JOB, None, None, None, None, None)
             })
             .unwrap();
-            let (_finish_tx, finish_rx) = flume::bounded(1);
+            let (finish_tx, finish_rx) = flume::bounded(1);
+            setup(&lua, finish_tx);
 
             let start = Instant::now();
             let reply = smol::block_on(dispatch_async(
@@ -3788,6 +3877,46 @@ mod tests {
         assert!(
             elapsed < KILL_GRACE,
             "dispatch loop must not wait out a grace"
+        );
+    }
+
+    const PARTIAL_REPLY_OUTPUT: &str = "partial output";
+
+    /// A doomed handler's cancel hooks get the last word: the reply they
+    /// queue carries the output the user already saw, so it must beat the
+    /// generic cancelled/timeout error. The reason they are handed is what
+    /// lets a tool word its marker.
+    #[test_case(true, CANCELLED_MSG ; "cancelled")]
+    #[test_case(false, HANDLER_TIMEOUT_MSG ; "deadline")]
+    fn dispatch_async_prefers_the_reply_its_cancel_hooks_queued(
+        cancelled: bool,
+        expected_reason: &str,
+    ) {
+        let cell = if cancelled {
+            TaskCell::new(cancelled_token(), None, None)
+        } else {
+            let cell = TaskCell::new(CancelToken::none(), Some(Instant::now()), None);
+            cell.deadline_secs.set(Some(DISPATCH_TEST_DEADLINE_SECS));
+            cell
+        };
+
+        let (result, _) = drive_dispatch_with(cell, |lua, finish_tx| {
+            let hook = lua
+                .create_function(move |_, reason: String| {
+                    finish_tx
+                        .send(ToolCallReply::err(format!(
+                            "{PARTIAL_REPLY_OUTPUT}:{reason}"
+                        )))
+                        .ok();
+                    Ok(())
+                })
+                .unwrap();
+            register_cancel_hook(lua, hook).unwrap();
+        });
+
+        assert_eq!(
+            result,
+            Err(format!("{PARTIAL_REPLY_OUTPUT}:{expected_reason}"))
         );
     }
 

--- a/maki-lua/tests/batch_policy.rs
+++ b/maki-lua/tests/batch_policy.rs
@@ -35,6 +35,8 @@ const PARKJOB_HL_TOOL: &str = "parkjob_hl";
 const CMD_TOOL: &str = "cmd";
 const BOOM_TOOL: &str = "boom";
 const BOOM_ERR: &str = "stub tool exploded";
+const PARTIAL_TOOL: &str = "partial";
+const PARTIAL_ERR: &str = "half the output [cancelled by user; output above is partial]";
 const CHILD_USAGE: &str = "12.3k↑ 456↓ $0.123";
 /// Wildly generous vs the expected kill (one poll plus one
 /// [`KILL_GRACE`]); only a watchdog that never fires gets here.
@@ -94,6 +96,10 @@ maki.agent.call_tool = function(ctx, name, input, opts)
     -- one of them its own restore.
     maki.fn.jobwait(maki.fn.jobstart("sleep @PARK_SECS@"))
     return "parkjob_done"
+  elseif name == "partial" then
+    -- Parks past the sweep, then comes back with more than "cancelled".
+    maki.fn.jobwait(maki.fn.jobstart("sleep @PARK_SECS@"))
+    return nil, "@PARTIAL_ERR@"
   elseif name == "spin" then
     -- Never yields, so nothing but the watchdog can end it.
     while true do end
@@ -167,6 +173,7 @@ fn load_batch_host_with(child_src: &str) -> (Arc<ToolRegistry>, PluginHost) {
     let prelude = STUB_PRELUDE
         .replace("@BOOM_ERR@", BOOM_ERR)
         .replace("@CHILD_USAGE@", CHILD_USAGE)
+        .replace("@PARTIAL_ERR@", PARTIAL_ERR)
         .replace("@PARK_SECS@", &PARK_SECS.to_string());
     host.load_source(
         "batch_policy",
@@ -386,7 +393,9 @@ fn assert_indicators(buf: &maki_agent::SharedBuf, style: &str, want: usize, budg
 ///
 /// That sweep runs outside the coroutine, where a child restore that awaits
 /// raises, and one such body must not swallow the rest of the sweep. Children
-/// that already finished keep their own status and output.
+/// that already finished keep their own status and output, and a child whose
+/// own call lands after the sweep with more than "cancelled" trades the
+/// placeholder for it.
 #[test]
 fn cancel_mid_flight_repaints_parked_children_and_spares_finished_ones() {
     let batch = start_batch_with(
@@ -395,33 +404,35 @@ fn cancel_mid_flight_repaints_parked_children_and_spares_finished_ones() {
             { "tool": OK_TOOL, "parameters": { "tag": "a" } },
             { "tool": PARKJOB_TOOL, "parameters": {} },
             { "tool": PARKJOB_HL_TOOL, "parameters": {} },
+            { "tool": PARTIAL_TOOL, "parameters": {} },
             { "tool": BOOM_TOOL, "parameters": {} },
         ]),
     );
-    for (style, want) in [(SUCCESS_STYLE, 1), (ERROR_STYLE, 1), (SPINNER_STYLE, 2)] {
+    for (style, want) in [(SUCCESS_STYLE, 1), (ERROR_STYLE, 1), (SPINNER_STYLE, 3)] {
         assert_indicators(&batch.body, style, want, PAINT_TIMEOUT);
     }
 
     batch.trigger.cancel();
 
-    assert_indicators(&batch.body, ERROR_STYLE, 3, PAINT_TIMEOUT);
+    assert_indicators(&batch.body, ERROR_STYLE, 4, PAINT_TIMEOUT);
     assert_indicators(&batch.body, SPINNER_STYLE, 0, Duration::ZERO);
     assert_indicators(&batch.body, SUCCESS_STYLE, 1, Duration::ZERO);
 
     let cancelled = format!("{ERROR_PREFIX}{CANCELLED_ERROR}");
     let expected = format!(
-        "{}{}{}{}{}",
+        "{}{}{}{}{}{}",
         section(OK_TOOL, "ok:a"),
         section(PARKJOB_TOOL, &cancelled),
         section(PARKJOB_HL_TOOL, &cancelled),
+        section(PARTIAL_TOOL, &format!("{ERROR_PREFIX}{PARTIAL_ERR}")),
         section(BOOM_TOOL, &format!("{ERROR_PREFIX}{BOOM_ERR}")),
-        summary_mixed(1, 4, 3)
+        summary_mixed(1, 5, 4)
     );
     let settled = batch
         .result
         .recv_timeout(BATCH_RESULT_TIMEOUT)
         .expect("batch must settle instead of hanging on its cancelled children");
-    assert_eq!(settled, Ok(expected));
+    assert_eq!(settled, Err(expected));
 }
 
 /// Esc pressed before the batch is even dispatched: the handler still runs
@@ -439,7 +450,7 @@ fn cancelled_batch_dispatches_nothing_and_keeps_born_terminal_errors() {
             { "tool": OK_TOOL, "parameters": { "tag": "a" } },
         ]),
     )
-    .expect("the second sweep must not resettle an already cancelled child");
+    .expect_err("a cancelled batch is an error reply");
     let expected = format!(
         "{}{}{}",
         section(BATCH_TOOL, &format!("{ERROR_PREFIX}{NESTED_ERROR}")),

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -2706,6 +2706,107 @@ fn ctx_set_deadline_twice_errors() {
     assert!(err.contains(DEADLINE_ALREADY_SET_ERR), "got: {err}");
 }
 
+/// Generous: every wait below ends on an event, never on the clock, so only
+/// an already failing test pays this.
+const CANCEL_TEST_TIMEOUT: Duration = Duration::from_secs(30);
+const CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+fn poll_until<T>(what: &str, mut check: impl FnMut() -> Option<T>) -> T {
+    let deadline = std::time::Instant::now() + CANCEL_TEST_TIMEOUT;
+    loop {
+        if let Some(got) = check() {
+            return got;
+        }
+        assert!(std::time::Instant::now() < deadline, "{what}");
+        std::thread::sleep(CANCEL_POLL_INTERVAL);
+    }
+}
+
+const PARKED_DEADLINE_REPLY: &str = "partial: timeout";
+const PARKED_DEADLINE_PLUGIN: &str = r#"
+maki.api.register_tool({
+    name = "parked_deadline",
+    description = "parks past its deadline, finishing from its cancel hook",
+    schema = { type = "object", properties = {}, additionalProperties = false },
+    audiences = { "main" },
+    handler = function(input, ctx)
+        ctx:set_deadline(1)
+        maki.async.on_cancel(function(reason)
+            ctx:finish({ llm_output = "partial: " .. reason, is_error = true })
+        end)
+        maki.fn.jobwait(maki.fn.jobstart("sleep 30"))
+        return "unreachable"
+    end,
+})
+"#;
+
+/// A handler parked in an await runs no Lua when its deadline lapses, so the
+/// host is what ends it, by raising inside the await. Its cancel hooks still
+/// get that last slice, and the reply they finish with beats the generic
+/// timeout error. The handler that already returned nil takes a different
+/// road out, unit tested in `runtime.rs`.
+#[test]
+fn parked_handler_reports_its_hook_finish_reply_on_deadline() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source("parked_deadline_plugin", PARKED_DEADLINE_PLUGIN)
+        .unwrap();
+
+    let result = exec_tool(&reg, "parked_deadline", json!({}));
+
+    assert_eq!(result, Err(PARKED_DEADLINE_REPLY.to_owned()));
+    drop(host);
+}
+
+const BASH_CANCEL_ID: &str = "bash-cancel-1";
+/// Mirrors the cancelled marker in `plugins/lib/maki/partial.lua`.
+const BASH_PARTIAL_MARKER: &str = "[cancelled by user; output above is partial]";
+/// Assembled by printf so the probe never appears in the command header.
+const BASH_PARTIAL_PROBE: &str = "XY";
+const BASH_PARTIAL_CMD: &str = "printf '%s%s\\n' X Y && sleep 30";
+
+/// Esc mid-stream on a real bash run: the lines printed so far come back as
+/// an error reply ending in the marker, not a bare "cancelled".
+#[test]
+fn cancelled_bash_keeps_streamed_output_as_partial() {
+    let (tx, events) = flume::unbounded();
+    let event_tx = maki_agent::EventSender::new(tx, 0);
+    let (trigger, token) = maki_agent::CancelToken::new();
+    let (result_tx, result_rx) = flume::bounded(1);
+    std::thread::spawn(move || {
+        let (reg, host) = builtins_host();
+        let mut ctx = maki_agent::tools::test_support::stub_ctx_with(
+            &maki_agent::AgentMode::Build,
+            Some(&event_tx),
+            Some(BASH_CANCEL_ID),
+        );
+        ctx.cancel = token;
+        // The rtk probe costs up to two 2s job waits before the command even
+        // starts: pointless here, and a flake risk under load.
+        ctx.config.no_rtk = true;
+        let input = json!({ "command": BASH_PARTIAL_CMD });
+        result_tx
+            .send(exec_with_ctx(&reg, "bash", input, &ctx))
+            .ok();
+        drop(host);
+    });
+
+    let buf = poll_until("bash must publish its live buf", || {
+        recv_live_buf(&events, BASH_CANCEL_ID)
+    });
+    poll_until("bash output never reached the live buf", || {
+        buf.take().text().contains(BASH_PARTIAL_PROBE).then_some(())
+    });
+
+    trigger.cancel();
+
+    let err = result_rx
+        .recv_timeout(CANCEL_TEST_TIMEOUT)
+        .expect("cancelled bash must settle")
+        .expect_err("a partial reply is an error reply");
+    assert_eq!(err, format!("{BASH_PARTIAL_PROBE}\n{BASH_PARTIAL_MARKER}"));
+}
+
 #[test]
 fn restore_tool_async_ordering_and_delivery() {
     let (_reg, host) = builtins_host();

--- a/maki-lua/tests/task_policy.rs
+++ b/maki-lua/tests/task_policy.rs
@@ -33,6 +33,8 @@ const RECOVERED_TEXT: &str = "summary after nudge";
 const SUMMARY_NUDGE_FRAGMENT: &str = "concise summary";
 const PROMPT_ERR_MSG: &str = "model exploded";
 const RAISE_MSG: &str = "stub prompt kaboom";
+const PARTIAL_TEXT: &str = "half a transcript";
+const CANCELLED_ERR: &str = "cancelled";
 /// Mirrors the task plugin's `max_concurrent` default.
 const TASK_DEFAULT_MAX_CONCURRENT: u64 = 8;
 
@@ -42,6 +44,7 @@ const SCENARIO_INVALID_THEN_VALID: &str = "invalid_then_valid";
 const SCENARIO_NEVER_STRUCTURED: &str = "never_structured";
 const SCENARIO_INVALID_ONLY: &str = "invalid_only";
 const SCENARIO_PROMPT_ERROR: &str = "prompt_error";
+const SCENARIO_PARTIAL_ERROR: &str = "partial_error";
 const SCENARIO_RAISE: &str = "raise";
 const SCENARIO_NO_SUMMARY: &str = "no_summary";
 const SCENARIO_NO_SUMMARY_THEN_RECOVER: &str = "no_summary_then_recover";
@@ -117,6 +120,10 @@ behaviors.prompt_error = function(sess, msg)
   return nil, "@PROMPT_ERR@"
 end
 
+behaviors.partial_error = function(sess, msg)
+  return { text = "@PARTIAL_TEXT@" }, "@CANCELLED_ERR@"
+end
+
 behaviors.no_summary = function(sess, msg)
   return { text = "" }
 end
@@ -189,7 +196,9 @@ fn load_task_host_with_opts(
         .replace("@PLAIN_TEXT@", PLAIN_TEXT)
         .replace("@RECOVERED_TEXT@", RECOVERED_TEXT)
         .replace("@PROMPT_ERR@", PROMPT_ERR_MSG)
-        .replace("@RAISE_MSG@", RAISE_MSG);
+        .replace("@RAISE_MSG@", RAISE_MSG)
+        .replace("@PARTIAL_TEXT@", PARTIAL_TEXT)
+        .replace("@CANCELLED_ERR@", CANCELLED_ERR);
     host.load_source_with_opts(
         "task_policy",
         &format!("{prelude}\n{TASK_PLUGIN_SRC}"),
@@ -410,6 +419,19 @@ fn prompt_error_maps_to_sub_agent_error() {
     assert_eq!(err, format!("{SUB_AGENT_ERROR_PREFIX}{PROMPT_ERR_MSG}"));
     let snap = probe(&reg);
     assert_eq!(snap["closed"], json!(1));
+}
+
+/// Esc during a sub-agent run: the prompt hands back both an error and
+/// whatever the sub-agent managed to say, and half a transcript is worth
+/// more to the model than a bare "cancelled".
+#[test]
+fn interrupted_prompt_reports_the_partial_transcript() {
+    let (reg, _host) = load_task_host();
+    let err = exec_tool(&reg, TASK_TOOL, task_input(SCENARIO_PARTIAL_ERROR, None)).unwrap_err();
+    assert_eq!(
+        err,
+        format!("sub-agent interrupted ({CANCELLED_ERR}). Partial output:\n{PARTIAL_TEXT}")
+    );
 }
 
 #[test]

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -1298,6 +1298,10 @@ fn cancel_in_progress_retires_live_buf_to_watched() {
     assert!(panel.watching("t1"));
 
     buf.set_lines(vec![snap_line("after-cancel")]);
+    // The tool hands that same repaint to the host as its reply body, and the
+    // stale-run_id filter drops it. Taking a body must not cost the screen the
+    // last thing a cancelled tool painted.
+    let _dropped_reply = buf.take();
     panel.poll_live_bufs();
     let msg = panel.find_tool_msg_mut("t1").unwrap();
     assert_eq!(

--- a/plugins/bash/init.lua
+++ b/plugins/bash/init.lua
@@ -1,6 +1,7 @@
 local truncate = require("maki.truncate")
 local ToolView = require("maki.tool_view")
 local output_limits = require("maki.output_limits")
+local partial = require("maki.partial")
 
 local RTK_REWRITE_TIMEOUT_MS = 2000
 local RTK_UNSUPPORTED_FLAGS = {
@@ -353,8 +354,13 @@ maki.api.register_tool({
 
     local output_parts = {}
     local has_output = false
+    local finished = false
 
     local function finish(exit_code)
+      if finished then
+        return
+      end
+      finished = true
       local output = table.concat(output_parts)
       output = truncate(output, max_lines, max_bytes)
 
@@ -408,6 +414,17 @@ maki.api.register_tool({
         finish(code)
       end,
     })
+
+    -- Esc or deadline: hand back the lines streamed so far, so the model
+    -- keeps what the user just watched instead of a bare error.
+    maki.async.on_cancel(function(reason)
+      if finished then
+        return
+      end
+      finished = true
+      local out = truncate(table.concat(output_parts), max_lines, max_bytes)
+      ctx:finish(partial.cut(view, out, reason, timeout_secs))
+    end)
 
     return nil
   end,

--- a/plugins/batch/init.lua
+++ b/plugins/batch/init.lua
@@ -422,8 +422,10 @@ function Batch:annotate(c, ann)
   self:rerender()
 end
 
+-- A child the sweep settled may be settled once more, when its own call
+-- comes back with the partial output the sweep could not know about.
 function Batch:settle(c, status, output)
-  if TERMINAL[c.status] then
+  if TERMINAL[c.status] and c.output ~= CANCELLED_ERROR then
     error(string.format(RESETTLE_FMT, c.tool, c.status, status))
   end
   c.status = status
@@ -456,8 +458,13 @@ function Batch:run_child(c, ctx)
     end,
   })
   -- The sweep may have settled this child mid-call, and the call knows
-  -- nothing about that, so its result is moot.
+  -- nothing about that, so its result is moot. Unless it came back with
+  -- more than the sweep's bare "cancelled": that partial output is worth
+  -- keeping.
   if TERMINAL[c.status] then
+    if err and err ~= CANCELLED_ERROR and c.output == CANCELLED_ERROR then
+      self:settle(c, STATUS.ERROR, err)
+    end
     return
   end
   if err then
@@ -465,6 +472,15 @@ function Batch:run_child(c, ctx)
   else
     self:settle(c, STATUS.SUCCESS, text)
   end
+end
+
+function Batch:reply()
+  return {
+    llm_output = render_llm(self.children),
+    is_error = self.cancelled,
+    body = self.buf,
+    state = to_state(self.children),
+  }
 end
 
 -- Whatever is still non-terminal becomes a cancelled child, so none is
@@ -488,9 +504,13 @@ function Batch:run(ctx)
   end
   -- The cancel reaches neither `call_tool` nor `gather`, so a child parked
   -- in a request would stay drawn as running until the host gives up on
-  -- the whole handler, seconds later.
+  -- the whole handler, seconds later. The finish covers the case where the
+  -- host gives up on us anyway: the model still gets per-child results
+  -- rather than a bare "cancelled".
   maki.async.on_cancel(function()
+    self.cancelled = true
     self:sweep_cancelled()
+    ctx:finish(self:reply())
   end)
   maki.async.gather(funs)
   self:sweep_cancelled()
@@ -511,11 +531,7 @@ local function handler(input, ctx)
   ctx:live_buf(batch.buf)
   batch:run(ctx)
 
-  return {
-    llm_output = render_llm(children),
-    body = batch.buf,
-    state = to_state(children),
-  }
+  return batch:reply()
 end
 
 -- Last resort: no state, output isn't section-formatted.

--- a/plugins/code_execution/init.lua
+++ b/plugins/code_execution/init.lua
@@ -6,12 +6,15 @@
 local truncate = require("maki.truncate")
 local ToolView = require("maki.tool_view")
 local output_limits = require("maki.output_limits")
+local partial = require("maki.partial")
 
 local DEFAULT_MAX_OUTPUT_LINES = 2000
 local DEFAULT_MAX_OUTPUT_BYTES = 50 * 1024
 local MAX_SCRIPT_LINES = 2000
 local NO_OUTPUT = "(no output)"
 local SEPARATOR = "──────"
+local CANCELLED_ERR = "cancelled"
+local TIME_LIMIT_SUBSTR = "time limit exceeded"
 local PREAMBLE = "import re\nimport asyncio\nimport sys\nimport os\nimport json\n"
 local TOOLS_HEADER = "\n\nAvailable tools (called as Python functions with keyword arguments):\n"
 local WORKFLOW_TOOLS_NOTE =
@@ -226,13 +229,32 @@ local function handler(input, ctx)
   view:append({ { "Waiting for output...", "dim" } })
 
   local waiting = true
+  local output_parts = {}
   local function show(line)
     if waiting then
       waiting = false
       view:clear()
     end
+    output_parts[#output_parts + 1] = line
     view:append(line)
   end
+
+  local max_lines, max_bytes = output_limits.resolve(opts, ctx)
+
+  -- Memoized, because a cancel reaches us twice: once through the hook and
+  -- again as the interpreter's error, and the view is painted only once.
+  local cut_reply
+  local function cut(reason)
+    cut_reply = cut_reply
+      or partial.cut(view, truncate(table.concat(output_parts, "\n"), max_lines, max_bytes), reason, timeout)
+    return cut_reply
+  end
+
+  -- Only for a handler still parked when the host gives up on it: normally
+  -- the interpreter sees the cancel and we return the partial reply below.
+  maki.async.on_cancel(function(reason)
+    ctx:finish(cut(reason))
+  end)
 
   local tools = {}
   for _, t in ipairs(interpreter_tools(maki.api.get_tools({ config = config }), ctx:audience(), ctx:workflow())) do
@@ -251,6 +273,12 @@ local function handler(input, ctx)
   })
 
   if err then
+    if err == CANCELLED_ERR then
+      return cut("cancelled")
+    end
+    if err:find(TIME_LIMIT_SUBSTR, 1, true) then
+      return cut("timeout")
+    end
     if waiting then
       view:clear()
     end
@@ -270,7 +298,6 @@ local function handler(input, ctx)
     view:append({ { "No output", "dim" } })
   end
 
-  local max_lines, max_bytes = output_limits.resolve(opts, ctx)
   local llm_output = truncate(output, max_lines, max_bytes)
   view:finish()
 

--- a/plugins/lib/maki/partial.lua
+++ b/plugins/lib/maki/partial.lua
@@ -1,0 +1,34 @@
+-- When a tool is cut short, it still hands back what it printed. The marker
+-- tells the model that output is real but unfinished. One home for the
+-- wording and the painting, so every tool says it the same way.
+local M = {}
+
+local CANCELLED_FMT = "[cancelled by user; %s]"
+local TIMEOUT_FMT = "[timed out after %ds; %s]"
+-- Never claim output the model cannot see above the marker: it would go
+-- looking for it, or invent it.
+local SOME_OUTPUT = "output above is partial"
+local NO_OUTPUT = "no output before the cut"
+
+--- Close {view} on the marker and build the tool reply. {out} is everything
+--- the tool streamed, already truncated; empty means the view still shows a
+--- placeholder to drop. {reason} is a cancel-hook reason ("cancelled" |
+--- "timeout").
+function M.cut(view, out, reason, timeout_secs)
+  local tail = out ~= "" and SOME_OUTPUT or NO_OUTPUT
+  local marker = reason == "timeout" and TIMEOUT_FMT:format(timeout_secs, tail) or CANCELLED_FMT:format(tail)
+
+  if out == "" then
+    view:clear()
+  end
+  view:append({ { marker, "dim" } })
+  view:finish()
+
+  return {
+    llm_output = (out ~= "" and out .. "\n" or "") .. marker,
+    is_error = true,
+    body = view.buf,
+  }
+end
+
+return M

--- a/plugins/task/init.lua
+++ b/plugins/task/init.lua
@@ -208,6 +208,14 @@ local function handler(input, ctx)
     sess:close()
 
     if err then
+      -- A result alongside the error means the run was cut short after
+      -- streaming some text, and half a transcript beats a bare error.
+      if result then
+        return {
+          llm_output = "sub-agent interrupted (" .. err .. "). Partial output:\n" .. result.text,
+          is_error = true,
+        }
+      end
       return { llm_output = "sub-agent error: " .. err, is_error = true }
     end
     if validator and not captured then

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -867,7 +867,9 @@ tools).
 
 - `{message}` (`string`) User message to send.
 
-**Returns:** (`table?`, `string?`) Result table on success, or `(nil, err)` on failure.
+**Returns:** (`table?`, `string?`) Result table on success, or `(nil, err)` on
+failure. A run cut short after streaming some text hands you both: the
+error and a `{ text = <what it streamed> }` table.
 
 **Example:**
 
@@ -1074,11 +1076,16 @@ permit:release()
 maki.async.on_cancel({fn})
 ```
 
-Register {fn} to run as soon as the current task is cancelled, without
-waiting for whatever it is doing to finish. Use it to paint the
-cancelled state: a handler waiting on children (`gather`, `call_tool`)
-stays parked until they wind down, so anything after the wait is too
-late to reach the screen.
+Register {fn} to run as soon as the current task is cancelled or hits
+its deadline, without waiting for whatever it is doing to finish. Use
+it to paint the cancelled state: a handler waiting on children
+(`gather`, `call_tool`) stays parked until they wind down, so anything
+after the wait is too late to reach the screen.
+
+The callback receives the reason (`"cancelled"` or `"timeout"`) and may
+still call `ctx:finish`; the host prefers that reply over the generic
+cancelled/timeout error. Mark it `is_error = true` and end it with a
+marker, so the model knows the output it gets is cut short.
 
 The callback runs outside your coroutine, so it must not yield. It
 fires at most once, immediately if the task is already cancelled. An
@@ -1087,13 +1094,14 @@ other hooks still run.
 
 **Parameters:**
 
-- `{fn}` (`function`) Zero-argument function to run on cancel.
+- `{fn}` (`function`) Function to run on cancel; receives the reason string.
 
 **Example:**
 
 ```lua
-maki.async.on_cancel(function()
-  view:append({ { "cancelled", "tool_error" } })
+maki.async.on_cancel(function(reason)
+  view:append({ { reason, "tool_error" } })
+  ctx:finish({ llm_output = partial .. "\n[cancelled; output is partial]", is_error = true })
 end)
 maki.async.gather(children)
 ```
@@ -4934,6 +4942,20 @@ function M.resolve(opts, ctx)
 end
 
 return M
+```
+
+### `require("maki.partial")`
+
+```lua
+-- When a tool is cut short, it still hands back what it printed. The marker
+-- tells the model that output is real but unfinished. One home for the
+-- wording and the painting, so every tool says it the same way.
+
+--- Close {view} on the marker and build the tool reply. {out} is everything
+--- the tool streamed, already truncated; empty means the view still shows a
+--- placeholder to drop. {reason} is a cancel-hook reason ("cancelled" |
+--- "timeout").
+function M.cut(view, out, reason, timeout_secs)
 ```
 
 ### `require("maki.scroll")`

--- a/site/docs/content/token-economy/_index.md
+++ b/site/docs/content/token-economy/_index.md
@@ -44,6 +44,8 @@ one line stays              ~20k tokens never seen
 
 **Truncation everywhere.** Tool output is capped (`agent.max_output_bytes`, `agent.max_output_lines`), overlong grep lines are skipped, and every builtin tool description nags the model to read only what it needs. The nagging works.
 
+**Interrupted work is not wasted.** Press Esc on a long tool, or let its deadline hit, and whatever it printed so far still reaches the model, tagged as partial: bash keeps its streamed lines, `code_execution` the script output, a `task` subagent its half transcript. Otherwise the next turn starts from nothing and you pay to run it all again.
+
 ## Fewer round-trips
 
 Every round-trip re-sends the context, so round-trips are the other half of the bill.


### PR DESCRIPTION
Cancelled and timed-out tools replied with a bare `cancelled` or timeout error, so the model truthfully claimed it never saw the output the user just watched stream by.

The host now prefers a reply a cancel hook delivers through `ctx:finish` during the cleanup grace, and `maki.async.on_cancel` hooks get a `"cancelled"` or `"timeout"` reason and also fire on deadline.

`bash` and `code_execution` return the lines streamed so far with an explicit partial marker, `batch` upgrades a swept child when its call comes back with a richer error, and `sess:prompt` hands the subagent's partial transcript to `task` alongside the error.