### PR TITLE
fix(ui): stop tool spinner when the tool finishes

### DIFF
--- a/maki-ui/src/components/tool_display.rs
+++ b/maki-ui/src/components/tool_display.rs
@@ -205,6 +205,7 @@ pub fn append_right_info(
     }
 }
 
+#[derive(Clone, Copy)]
 enum Indicator {
     InProgress,
     Success,
@@ -306,10 +307,16 @@ struct ToolLineBuilder {
     truncation: SectionFlags,
     limits: RenderLimits,
     markdown: bool,
+    indicator: Indicator,
 }
 
 impl ToolLineBuilder {
-    fn new(width: u16, expanded: SectionFlags, max_output_lines: usize) -> Self {
+    fn new(
+        width: u16,
+        expanded: SectionFlags,
+        max_output_lines: usize,
+        indicator: Indicator,
+    ) -> Self {
         let limits = RenderLimits::new(expanded, max_output_lines);
         Self {
             lines: Vec::new(),
@@ -321,6 +328,7 @@ impl ToolLineBuilder {
             truncation: SectionFlags::default(),
             limits,
             markdown: false,
+            indicator,
         }
     }
 
@@ -345,9 +353,15 @@ impl ToolLineBuilder {
             if let Some(first_line) = snapshot.lines.first() {
                 let line_idx = self.lines.len();
                 let spinners = &mut self.spinner_lines;
-                bake_spans(&first_line.spans, &mut spans, spinner_str(0), |span_idx| {
-                    spinners.push((line_idx, span_idx));
-                });
+                bake_spans(
+                    &first_line.spans,
+                    &mut spans,
+                    spinner_str(0),
+                    self.indicator,
+                    |span_idx| {
+                        spinners.push((line_idx, span_idx));
+                    },
+                );
             }
         } else {
             spans.push(Span::styled(header.to_owned(), theme::current().tool));
@@ -371,24 +385,23 @@ impl ToolLineBuilder {
         self.search_text.push_str(text);
     }
 
-    fn prepend_indicator(&mut self, indicator: Indicator, started_at: Instant) {
+    fn prepend_indicator(&mut self, started_at: Instant) {
         if self.lines.is_empty() {
             return;
         }
-        let (text, style) = match indicator {
+        let (text, style) = match self.indicator {
             Indicator::InProgress => {
                 let ch = spinner_frame(started_at.elapsed().as_millis());
                 (format!("{ch} "), theme::current().spinner)
             }
-            Indicator::Success => (TOOL_INDICATOR.into(), theme::current().tool_success),
-            Indicator::Error => (TOOL_INDICATOR.into(), theme::current().tool_error),
+            finished => (TOOL_INDICATOR.into(), finished_style(finished)),
         };
         for (line, span) in &mut self.spinner_lines {
             if *line == 0 {
                 *span += 1;
             }
         }
-        if matches!(indicator, Indicator::InProgress) {
+        if matches!(self.indicator, Indicator::InProgress) {
             self.spinner_lines.push((0, 0));
         }
         self.lines[0].spans.insert(0, Span::styled(text, style));
@@ -477,7 +490,7 @@ impl ToolLineBuilder {
         let total = snapshot.lines.len();
         let frame = spinner_str(started_at.elapsed().as_millis());
         let (lines, spinners) =
-            snapshot_to_lines_range(snapshot, TOOL_BODY_INDENT, 0..total, frame);
+            snapshot_to_lines_range(snapshot, TOOL_BODY_INDENT, 0..total, frame, self.indicator);
         self.lines.extend(lines);
         self.spinner_lines
             .extend(spinners.into_iter().map(|(line, span)| (base + line, span)));
@@ -517,18 +530,26 @@ fn push_text_lines(lines: &mut Vec<Line<'static>>, text: &str, indent: &'static 
 }
 
 /// Bakes snapshot spans onto `out`. `"spinner"`-styled spans bake to the
-/// current frame, and `on_spinner` gets their span index in the same pass,
-/// so animation offsets can never drift from the baked spans.
+/// current frame while a tool is in progress, and `on_spinner` gets their
+/// span index in the same pass, so animation offsets can never drift from
+/// the baked spans. Finished tools bake a static dot instead and record no
+/// spinner position, so a stale `"spinner"` span can never keep animating.
 fn bake_spans(
     src: &[SnapshotSpan],
     out: &mut Vec<Span<'static>>,
     spinner_frame: &'static str,
+    indicator: Indicator,
     mut on_spinner: impl FnMut(usize),
 ) {
     for span in src {
         if matches!(&span.style, SpanStyle::Named(n) if n == SPINNER_STYLE_NAME) {
-            on_spinner(out.len());
-            out.push(Span::styled(spinner_frame, theme::current().spinner));
+            match indicator {
+                Indicator::InProgress => {
+                    on_spinner(out.len());
+                    out.push(Span::styled(spinner_frame, theme::current().spinner));
+                }
+                finished => out.push(Span::styled(TOOL_INDICATOR, finished_style(finished))),
+            }
         } else {
             out.push(Span::styled(
                 span.text.clone(),
@@ -538,11 +559,20 @@ fn bake_spans(
     }
 }
 
+fn finished_style(indicator: Indicator) -> Style {
+    if matches!(indicator, Indicator::Error) {
+        theme::current().tool_error
+    } else {
+        theme::current().tool_success
+    }
+}
+
 fn snapshot_to_lines_range(
     snapshot: &BufferSnapshot,
     indent: &str,
     range: std::ops::Range<usize>,
     spinner_frame: &'static str,
+    indicator: Indicator,
 ) -> (Vec<Line<'static>>, Vec<(usize, usize)>) {
     let mut spinners = Vec::new();
     let lines = snapshot.lines[range]
@@ -550,9 +580,15 @@ fn snapshot_to_lines_range(
         .enumerate()
         .map(|(i, sline)| {
             let mut spans = vec![Span::raw(indent.to_string())];
-            bake_spans(&sline.spans, &mut spans, spinner_frame, |span_idx| {
-                spinners.push((i, span_idx));
-            });
+            bake_spans(
+                &sline.spans,
+                &mut spans,
+                spinner_frame,
+                indicator,
+                |span_idx| {
+                    spinners.push((i, span_idx));
+                },
+            );
             Line::from(spans)
         })
         .collect();
@@ -606,7 +642,12 @@ pub fn build_tool_lines(
         None => (msg.text.as_str(), None),
     };
 
-    let mut b = ToolLineBuilder::new(rctx.width, expanded, rctx.tool_output_lines.get(tool_name));
+    let mut b = ToolLineBuilder::new(
+        rctx.width,
+        expanded,
+        rctx.tool_output_lines.get(tool_name),
+        status.into(),
+    );
     b.apply_output_format(msg.tool_output.as_deref());
     b.push_header(
         tool_name,
@@ -614,7 +655,7 @@ pub fn build_tool_lines(
         msg.annotation.as_deref(),
         msg.render_header.as_ref(),
     );
-    b.prepend_indicator(status.into(), rctx.started_at);
+    b.prepend_indicator(rctx.started_at);
     let has_snapshot = msg.render_snapshot.is_some();
     b.push_code_content(
         msg.tool_input.as_deref(),
@@ -701,9 +742,14 @@ pub fn build_instructions_lines(
         script: false,
         output: expanded,
     };
-    let mut b = ToolLineBuilder::new(width, exp, code_view::instruction_limit(expanded));
+    let mut b = ToolLineBuilder::new(
+        width,
+        exp,
+        code_view::instruction_limit(expanded),
+        Indicator::Success,
+    );
     b.push_header("load", header, annotation.as_deref(), None);
-    b.prepend_indicator(Indicator::Success, Instant::now());
+    b.prepend_indicator(Instant::now());
 
     let start = b.lines.len();
     let has_truncation =
@@ -1690,7 +1736,8 @@ mod tests {
             text: "content".into(),
             style: SpanStyle::Default,
         }]]);
-        let (lines, _) = snapshot_to_lines_range(&snapshot, ">>", 0..1, "⠋ ");
+        let (lines, _) =
+            snapshot_to_lines_range(&snapshot, ">>", 0..1, "⠋ ", Indicator::InProgress);
         assert_eq!(lines.len(), 1);
         let first_span = &lines[0].spans[0];
         assert_eq!(first_span.content.as_ref(), ">>");
@@ -1712,7 +1759,7 @@ mod tests {
                 style: SpanStyle::Default,
             },
         ]]);
-        let (lines, _) = snapshot_to_lines_range(&snapshot, "", 0..1, "⠋ ");
+        let (lines, _) = snapshot_to_lines_range(&snapshot, "", 0..1, "⠋ ", Indicator::InProgress);
         let texts: Vec<&str> = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(texts, vec!["", "aaa", "bbb", "ccc"]);
     }
@@ -1735,8 +1782,63 @@ mod tests {
                 },
             ],
         ]);
-        let (lines, spinners) = snapshot_to_lines_range(&snapshot, "", 0..2, "⠹ ");
+        let (lines, spinners) =
+            snapshot_to_lines_range(&snapshot, "", 0..2, "⠹ ", Indicator::InProgress);
         assert_eq!(spinners, vec![(1, 2)]);
         assert_eq!(lines[1].spans[2].content.as_ref(), "⠹ ");
+    }
+
+    #[test_case(ToolStatus::Success ; "success_bakes_dot")]
+    #[test_case(ToolStatus::Error ; "error_bakes_dot")]
+    fn done_snapshot_with_spinner_span_bakes_dot_and_records_no_spinner(status: ToolStatus) {
+        let snapshot = make_snapshot(vec![vec![
+            SnapshotSpan {
+                text: "child ".into(),
+                style: SpanStyle::Default,
+            },
+            SnapshotSpan {
+                text: "· ".into(),
+                style: SpanStyle::Named(SPINNER_STYLE_NAME.into()),
+            },
+        ]]);
+        let tl = build_tool_lines(
+            &snapshot_msg(snapshot),
+            status,
+            &test_rctx(80),
+            SectionFlags::default(),
+        );
+        assert_eq!(tl.spinner_lines, vec![]);
+        let body = tl.lines.get(1).expect("snapshot body line");
+        let dot = body.spans.last().expect("baked dot span");
+        assert_eq!(dot.content.as_ref(), TOOL_INDICATOR);
+    }
+
+    #[test]
+    fn done_header_with_spinner_span_bakes_dot_and_records_no_spinner() {
+        let header = make_snapshot(vec![vec![
+            SnapshotSpan {
+                text: "3 tools ".into(),
+                style: SpanStyle::Default,
+            },
+            SnapshotSpan {
+                text: "· ".into(),
+                style: SpanStyle::Named(SPINNER_STYLE_NAME.into()),
+            },
+        ]]);
+        let msg = DisplayMessage {
+            render_header: Some(header),
+            render_snapshot: None,
+            ..snapshot_msg(make_snapshot(vec![]))
+        };
+        let tl = build_tool_lines(
+            &msg,
+            ToolStatus::Success,
+            &test_rctx(80),
+            SectionFlags::default(),
+        );
+        assert_eq!(tl.spinner_lines, vec![]);
+        let header_line = tl.lines.first().expect("header line");
+        let dot = header_line.spans.last().expect("baked dot span");
+        assert_eq!(dot.content.as_ref(), TOOL_INDICATOR);
     }
 }


### PR DESCRIPTION
## Problem

When a `batch` child finishes, its spinner marker (`·`) kept animating instead of turning into a round dot (`●`).

The UI baked `"spinner"`-styled snapshot spans as animated frames and recorded their positions without checking the tool status. While any tool was still in progress, `update_spinners` re-animated those recorded positions, so a finished child could keep spinning.

## Fix

Make spinner baking status-aware in `maki-ui/src/components/tool_display.rs`:

- In progress: keep the animated frame and record the position.
- Success or error: bake a static `●` and do not record a spinner position.

## Tests

- Added `done_snapshot_with_spinner_span_bakes_dot_and_records_no_spinner` (success and error).
- Added `done_header_with_spinner_span_bakes_dot_and_records_no_spinner`.
- Updated existing spinner tests for the new `Indicator` parameter.