### PR TITLE
feat(lua): session-owned jobs so a monitor can be a plugin

### DIFF
--- a/maki-acp/src/lib.rs
+++ b/maki-acp/src/lib.rs
@@ -14,6 +14,9 @@ use maki_config::ModelPolicy;
 use maki_providers::Timeouts;
 use maki_providers::model::Model;
 use maki_storage::id::MakiId;
+use smol::future::Boxed;
+
+pub type SessionEndHook = Arc<dyn Fn(MakiId) -> Boxed<()> + Send + Sync>;
 
 pub struct AcpParams {
     pub model: Model,
@@ -25,8 +28,10 @@ pub struct AcpParams {
     pub yolo: bool,
     pub model_policy: Arc<ModelPolicy>,
     pub plugin_rules: Arc<PluginRuleStore>,
-    /// Called when an ACP session is replaced or the server exits.
-    pub on_session_end: Option<Arc<dyn Fn(MakiId) + Send + Sync>>,
+    /// Called when an ACP session is replaced or the server exits. The hook
+    /// answers with a future so its wait rides the executor instead of
+    /// holding stdin for the whole `SessionEnd` grace period.
+    pub on_session_end: Option<SessionEndHook>,
 }
 
 pub fn run(params: AcpParams) -> color_eyre::Result<()> {

--- a/maki-acp/src/lib.rs
+++ b/maki-acp/src/lib.rs
@@ -13,6 +13,7 @@ use maki_agent::{AgentConfig, PermissionsConfig};
 use maki_config::ModelPolicy;
 use maki_providers::Timeouts;
 use maki_providers::model::Model;
+use maki_storage::id::MakiId;
 
 pub struct AcpParams {
     pub model: Model,
@@ -25,7 +26,7 @@ pub struct AcpParams {
     pub model_policy: Arc<ModelPolicy>,
     pub plugin_rules: Arc<PluginRuleStore>,
     /// Called when an ACP session is replaced or the server exits.
-    pub on_session_end: Option<Arc<dyn Fn(maki_storage::id::MakiId) + Send + Sync>>,
+    pub on_session_end: Option<Arc<dyn Fn(MakiId) + Send + Sync>>,
 }
 
 pub fn run(params: AcpParams) -> color_eyre::Result<()> {

--- a/maki-acp/src/lib.rs
+++ b/maki-acp/src/lib.rs
@@ -24,6 +24,8 @@ pub struct AcpParams {
     pub yolo: bool,
     pub model_policy: Arc<ModelPolicy>,
     pub plugin_rules: Arc<PluginRuleStore>,
+    /// Called when an ACP session is replaced or the server exits.
+    pub on_session_end: Option<Arc<dyn Fn(maki_storage::id::MakiId) + Send + Sync>>,
 }
 
 pub fn run(params: AcpParams) -> color_eyre::Result<()> {

--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -35,7 +35,7 @@ use serde_json::Value;
 use smol::io::AsyncBufReadExt;
 use tracing::{debug, warn};
 
-use crate::{AcpParams, elicitation, methods, permissions, translate};
+use crate::{AcpParams, SessionEndHook, elicitation, methods, permissions, translate};
 
 const FIRST_OUTGOING_REQUEST_ID: i64 = 1000;
 /// ACP has no fast-mode toggle, so a restored total is priced at standard rates.
@@ -75,7 +75,7 @@ struct Server {
     model_policy: Arc<ModelPolicy>,
     client_elicits_form: bool,
     session: Option<SessionState>,
-    on_session_end: Option<Arc<dyn Fn(MakiId) + Send + Sync>>,
+    on_session_end: Option<SessionEndHook>,
 }
 
 impl Server {
@@ -124,12 +124,7 @@ pub async fn serve(params: AcpParams) -> color_eyre::Result<()> {
         }
     }
 
-    if let Some(session) = server.session.take() {
-        if let Some(cb) = &server.on_session_end {
-            cb(session.handle.session_id.id());
-        }
-        drop(session);
-    }
+    close_session(&mut server).await;
     drop(server);
     writer_task.await;
     reader_task.await.context("read stdin")?;
@@ -498,7 +493,7 @@ async fn close_session(srv: &mut Server) {
         return;
     };
     if let Some(cb) = &srv.on_session_end {
-        cb(state.handle.session_id.id());
+        cb(state.handle.session_id.id()).await;
     }
     // The event pump dies with the session, so the prompt it owed an answer to
     // has to be answered here or the client waits on it forever.
@@ -934,6 +929,24 @@ mod tests {
             }),
         };
         (server, answer_rx, out_rx)
+    }
+
+    #[test]
+    fn close_session_awaits_the_session_end_hook() {
+        let (mut srv, ..) = server_with_ask(AskKind::Permission);
+        let ended = srv.session.as_ref().unwrap().handle.session_id.id();
+        let (ended_tx, ended_rx) = flume::bounded(1);
+        srv.on_session_end = Some(Arc::new(move |id| {
+            let ended_tx = ended_tx.clone();
+            Box::pin(async move {
+                let _ = ended_tx.send(id);
+            })
+        }));
+
+        smol::block_on(close_session(&mut srv));
+
+        assert_eq!(ended_rx.try_recv().ok(), Some(ended));
+        assert!(srv.session.is_none(), "close must take the session");
     }
 
     #[test]

--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -75,6 +75,7 @@ struct Server {
     model_policy: Arc<ModelPolicy>,
     client_elicits_form: bool,
     session: Option<SessionState>,
+    on_session_end: Option<Arc<dyn Fn(maki_storage::id::MakiId) + Send + Sync>>,
 }
 
 impl Server {
@@ -108,6 +109,7 @@ pub async fn serve(params: AcpParams) -> color_eyre::Result<()> {
         model_policy: Arc::clone(&params.model_policy),
         client_elicits_form: false,
         session: None,
+        on_session_end: params.on_session_end.clone(),
     };
 
     let (in_tx, in_rx) = flume::unbounded::<Incoming>();
@@ -122,6 +124,12 @@ pub async fn serve(params: AcpParams) -> color_eyre::Result<()> {
         }
     }
 
+    if let Some(session) = server.session.take() {
+        if let Some(cb) = &server.on_session_end {
+            cb(session.handle.session_id.id());
+        }
+        drop(session);
+    }
     drop(server);
     writer_task.await;
     reader_task.await.context("read stdin")?;
@@ -489,6 +497,9 @@ async fn close_session(srv: &mut Server) {
     let Some(state) = srv.session.take() else {
         return;
     };
+    if let Some(cb) = &srv.on_session_end {
+        cb(state.handle.session_id.id());
+    }
     // The event pump dies with the session, so the prompt it owed an answer to
     // has to be answered here or the client waits on it forever.
     if let Some(id) = state.pending.lock().unwrap().prompt.take() {
@@ -910,6 +921,7 @@ mod tests {
             model_specs: Vec::new(),
             model_policy: Arc::new(ModelPolicy::default()),
             client_elicits_form: false,
+            on_session_end: None,
             session: Some(SessionState {
                 handle,
                 mcp: None,

--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -75,7 +75,7 @@ struct Server {
     model_policy: Arc<ModelPolicy>,
     client_elicits_form: bool,
     session: Option<SessionState>,
-    on_session_end: Option<Arc<dyn Fn(maki_storage::id::MakiId) + Send + Sync>>,
+    on_session_end: Option<Arc<dyn Fn(MakiId) + Send + Sync>>,
 }
 
 impl Server {

--- a/maki-lua/src/api/autocmd.rs
+++ b/maki-lua/src/api/autocmd.rs
@@ -5,7 +5,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use maki_lua_macro::{lua_fn, lua_table};
 use mlua::{Function, Lua, Result as LuaResult, Table, Value};
 
-use crate::api::util::dispatch::{DepthGuard, call_isolated};
+use crate::api::util::dispatch::DepthGuard;
+use crate::runtime::{run_detached, strip_traceback};
 
 static NEXT_AUTOCMD_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -55,6 +56,12 @@ fn pattern_matches(patterns: Option<&[String]>, fired: Option<&str>) -> bool {
 }
 
 /// One dispatch path for host-fired and plugin-fired events. Never throws.
+/// Each callback runs in its own coroutine under its own detached task
+/// scope, so it may suspend (the `maki.fs.*` helpers park on
+/// `smol::unblock`); an inline resume would die with "attempt to yield
+/// across metamethod / C-call boundary". The per-callback scope also means
+/// task-owned jobs a handler starts die with that handler instead of
+/// outliving it to the end of the batch.
 ///
 /// The snapshot below looks racy but is not: all Lua runs on the runtime
 /// thread and plugin unloads arrive through the request channel, so nothing
@@ -63,8 +70,8 @@ fn pattern_matches(patterns: Option<&[String]>, fired: Option<&str>) -> bool {
 /// `data` is shared across callbacks (nvim does the same), but each callback
 /// gets its own `ev` table, so one plugin's mutation cannot leak into the
 /// next.
-pub(crate) fn dispatch(lua: &Lua, event: &str, pattern: Option<&str>, data: Value) {
-    let Ok(_guard) = DepthGuard::enter(lua, "autocmd", event) else {
+pub(crate) async fn dispatch(lua: Lua, event: String, pattern: Option<String>, data: Value) {
+    let Ok(_guard) = DepthGuard::enter(&lua, "autocmd", &event) else {
         tracing::warn!(event, "autocmd dispatch exceeded max depth, skipping");
         return;
     };
@@ -72,14 +79,14 @@ pub(crate) fn dispatch(lua: &Lua, event: &str, pattern: Option<&str>, data: Valu
         let Some(mut store) = lua.app_data_mut::<AutocmdStore>() else {
             return;
         };
-        let Some(entries) = store.listeners.get_mut(event) else {
+        let Some(entries) = store.listeners.get_mut(&event) else {
             return;
         };
         let mut snapshot = Vec::new();
         // Drop `once` entries now, at snapshot time: if a callback refires
         // the same event they are already gone, so they stay exactly-once.
         entries.retain(|e| {
-            let fires = pattern_matches(e.patterns.as_deref(), pattern);
+            let fires = pattern_matches(e.patterns.as_deref(), pattern.as_deref());
             if fires {
                 snapshot.push((e.id, Arc::clone(&e.plugin), e.callback.clone()));
             }
@@ -88,14 +95,26 @@ pub(crate) fn dispatch(lua: &Lua, event: &str, pattern: Option<&str>, data: Valu
         snapshot
     };
     for (id, plugin, callback) in snapshot {
-        let ev = match make_ev_table(lua, id, event, pattern, &data) {
+        let ev = match make_ev_table(&lua, id, &event, pattern.as_deref(), &data) {
             Ok(ev) => ev,
             Err(e) => {
                 tracing::warn!(event, error = %e, "failed to build autocmd ev table");
                 return;
             }
         };
-        call_isolated::<()>(lua, &callback, ev, event, &plugin);
+        if let Err(e) = run_detached(&lua, async {
+            let thread = lua.create_thread(callback)?;
+            thread.into_async::<()>(ev)?.await
+        })
+        .await
+        {
+            tracing::warn!(
+                event,
+                plugin = &*plugin,
+                error = %strip_traceback(&e),
+                "plugin callback failed"
+            );
+        }
     }
 }
 
@@ -148,6 +167,13 @@ fn parse_string_or_seq(value: Value, what: &str) -> LuaResult<Vec<String>> {
 /// asked for it; it carries `data.model` in the shape `maki.model.get`
 /// returns, plus `data.previous_spec`. Picking the model already in use stays
 /// quiet, and so does startup.
+///
+/// On the exit paths (UI shutdown, ACP EOF, headless completion) the host is
+/// already tearing down, so handlers get a short grace period and must not
+/// depend on `maki.fn` UI roundtrips; write state out with `maki.fs` instead.
+///
+/// Jobs started inside a callback die with the dispatch unless you await
+/// them there (`jobwait`) or hand them to a session (`owner = "session"`).
 ///
 /// @param event string|string[] Event name or list of names.
 /// @param opts table Options:
@@ -205,7 +231,7 @@ fn del_autocmd(lua: &Lua, id: u64) -> LuaResult<()> {
 }
 
 /// Fire one or more events manually. Every matching autocmd callback
-/// runs synchronously before this function returns.
+/// runs to completion before this function returns.
 ///
 /// @param event string|string[] Event name or list of names to fire.
 /// @param opts table? Options:
@@ -218,7 +244,7 @@ fn del_autocmd(lua: &Lua, id: u64) -> LuaResult<()> {
 ///   data = { msg = "hello" },
 /// })
 #[lua_fn]
-fn exec_autocmds(lua: &Lua, event: Value, opts: Option<Table>) -> LuaResult<()> {
+async fn exec_autocmds(lua: Lua, event: Value, opts: Option<Table>) -> LuaResult<()> {
     let events = parse_string_or_seq(event, "event")?;
     let (pattern, data) = match opts {
         Some(opts) => {
@@ -232,7 +258,7 @@ fn exec_autocmds(lua: &Lua, event: Value, opts: Option<Table>) -> LuaResult<()> 
         None => (None, Value::Nil),
     };
     for event in events {
-        dispatch(lua, &event, pattern.as_deref(), data.clone());
+        dispatch(lua.clone(), event, pattern.clone(), data.clone()).await;
     }
     Ok(())
 }

--- a/maki-lua/src/api/autocmd.rs
+++ b/maki-lua/src/api/autocmd.rs
@@ -181,7 +181,8 @@ fn parse_string_or_seq(value: Value, what: &str) -> LuaResult<Vec<String>> {
 /// `maki.fs` instead.
 ///
 /// Jobs started inside a callback die with the dispatch unless you await
-/// them there (`jobwait`) or hand them to a session (`owner = "session"`).
+/// them there (`jobwait`) or hand them to a session
+/// (`scope = { session = ... }`).
 ///
 /// @param event string|string[] Event name or list of names.
 /// @param opts table Options:

--- a/maki-lua/src/api/autocmd.rs
+++ b/maki-lua/src/api/autocmd.rs
@@ -148,17 +148,18 @@ fn parse_string_or_seq(value: Value, what: &str) -> LuaResult<Vec<String>> {
 ///
 /// Built-in events fired by the host: `"TurnStart"`, `"TurnEnd"`,
 /// `"TurnError"`, `"ToolStart"`, `"ToolDone"`, `"SessionReset"`,
-/// `"SessionFocusChanged"`, `"SessionStatusChanged"`, `"TaskStatusChanged"`,
-/// and `"ModelChanged"`. Plugins can also fire their own events with
-/// `exec_autocmds`.
+/// `"SessionEnd"`, `"SessionFocusChanged"`, `"SessionStatusChanged"`,
+/// `"TaskStatusChanged"`, and `"ModelChanged"`. Plugins can also fire their
+/// own events with `exec_autocmds`.
 ///
-/// Each host event carries `data.session_id`. For `"SessionReset"` that
-/// is the session being left behind; the other events name the session now
-/// running or focused. Tool events also carry `data.tool_id` and `data.tool`.
-/// `"SessionFocusChanged"` also carries `data.previous_session_id` except on
-/// initial startup. `"SessionStatusChanged"` fires whenever a session moves
-/// between `"working"`, `"needs_input"`, and `"idle"`; it carries
-/// `data.status`, `data.title`, and `data.focused` (boolean).
+/// Each host event carries `data.session_id`. For `"SessionReset"` and
+/// `"SessionEnd"` that is the session being left behind; the other events
+/// name the session now running or focused. Tool events also carry
+/// `data.tool_id` and `data.tool`. `"SessionFocusChanged"` also carries
+/// `data.previous_session_id` except on initial startup.
+/// `"SessionStatusChanged"` fires whenever a session moves between
+/// `"working"`, `"needs_input"`, and `"idle"`; it carries `data.status`,
+/// `data.title`, and `data.focused` (boolean).
 /// `"TaskStatusChanged"` fires when a subagent starts, or when one moves
 /// between `"working"`, `"done"`, and `"error"`; it carries `data.id` and
 /// `data.name` alongside `data.status`. A task that comes back from disk
@@ -168,9 +169,16 @@ fn parse_string_or_seq(value: Value, what: &str) -> LuaResult<Vec<String>> {
 /// returns, plus `data.previous_spec`. Picking the model already in use stays
 /// quiet, and so does startup.
 ///
+/// `"SessionEnd"` is the teardown signal: it fires first so handlers can
+/// still inspect or stop the session's jobs, then session-owned jobs are
+/// reaped. It is sent on TUI `/new`, tab delete, session load, UI shutdown,
+/// ACP session replace/EOF, and headless completion.
+/// `"SessionReset"` stays TUI-only (`/new`).
+///
 /// On the exit paths (UI shutdown, ACP EOF, headless completion) the host is
-/// already tearing down, so handlers get a short grace period and must not
-/// depend on `maki.fn` UI roundtrips; write state out with `maki.fs` instead.
+/// already tearing down, so handlers get a short grace period and the UI is
+/// gone: `maki.fn` roundtrips fail right away. Write state out with
+/// `maki.fs` instead.
 ///
 /// Jobs started inside a callback die with the dispatch unless you await
 /// them there (`jobwait`) or hand them to a session (`owner = "session"`).

--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -1,20 +1,24 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::env;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use maki_lua_macro::{lua_fn, lua_table};
 use mlua::{Function, Lua, RegistryKey, Result as LuaResult, Table, Value};
 
 use crate::api::fs::expand_tilde;
 use crate::api::util::command::{UiAction, ui_roundtrip, ui_send};
-use crate::api::util::pair::{Pair, try_pair};
+use crate::api::util::pair::{Pair, err_pair, try_pair};
 use crate::plugin_permissions::PluginPermissions;
 use crate::runtime::{active_task_id, job_task_id, with_jobs};
+
+const DEFAULT_TAIL: usize = 20;
+const MAX_TAIL_LINES: usize = 1024;
+const DEFAULT_WAIT_MS: u64 = 30_000;
 
 const READER_BUF_SIZE: usize = 8 * 1024;
 
@@ -33,11 +37,34 @@ pub(crate) enum JobOwner {
 
 struct JobMeta {
     owner: JobOwner,
+    command: String,
     pid: u32,
+    started: Instant,
     on_stdout: Option<RegistryKey>,
     on_stderr: Option<RegistryKey>,
     on_exit: Option<RegistryKey>,
     event_rx: Option<flume::Receiver<JobEvent>>,
+    stdout_tail: VecDeque<String>,
+    stderr_tail: VecDeque<String>,
+    tail_cap: usize,
+    exit_code: Option<i32>,
+}
+
+impl JobMeta {
+    fn record_line(&mut self, stdout: bool, line: &str) {
+        if self.tail_cap == 0 {
+            return;
+        }
+        let tail = if stdout {
+            &mut self.stdout_tail
+        } else {
+            &mut self.stderr_tail
+        };
+        if tail.len() >= self.tail_cap {
+            tail.pop_front();
+        }
+        tail.push_back(line.to_string());
+    }
 }
 
 pub(crate) struct JobStore {
@@ -154,15 +181,30 @@ impl JobStore {
             id,
             JobMeta {
                 owner,
+                command: cmd.to_string(),
                 pid,
+                started: Instant::now(),
                 on_stdout,
                 on_stderr,
                 on_exit,
                 event_rx: Some(event_rx),
+                stdout_tail: VecDeque::new(),
+                stderr_tail: VecDeque::new(),
+                tail_cap: DEFAULT_TAIL,
+                exit_code: None,
             },
         );
 
         Ok(id)
+    }
+
+    fn configure(&mut self, id: u32, tail: Option<usize>) {
+        let Some(job) = self.jobs.get_mut(&id) else {
+            return;
+        };
+        if let Some(cap) = tail {
+            job.tail_cap = cap.min(MAX_TAIL_LINES);
+        }
     }
 
     pub fn is_empty(&self, owner: &JobOwner) -> bool {
@@ -221,6 +263,47 @@ impl JobStore {
                 }
             }
         }
+    }
+
+    pub fn record_event(&mut self, job_id: u32, event: &JobEvent) {
+        let Some(job) = self.jobs.get_mut(&job_id) else {
+            return;
+        };
+        match event {
+            JobEvent::Stdout(line) => job.record_line(true, line),
+            JobEvent::Stderr(line) => job.record_line(false, line),
+            JobEvent::Exit(code) => job.exit_code = Some(*code),
+        }
+    }
+
+    pub fn snapshot(&self, job_id: u32, task_id: Option<u64>, plugin: &str) -> Option<JobSnapshot> {
+        let job = self.jobs.get(&job_id)?;
+        job.can_access(task_id, plugin).then(|| JobSnapshot {
+            id: job_id,
+            command: job.command.clone(),
+            pid: job.pid,
+            elapsed_secs: job.started.elapsed().as_secs(),
+            exit_code: job.exit_code,
+            stdout_lines: job.stdout_tail.iter().cloned().collect(),
+            stderr_lines: job.stderr_tail.iter().cloned().collect(),
+        })
+    }
+
+    pub fn list(&self, task_id: Option<u64>, plugin: &str) -> Vec<JobSnapshot> {
+        self.jobs
+            .iter()
+            .filter(|(_, job)| job.can_access(task_id, plugin))
+            .filter(|(_, job)| job.exit_code.is_none())
+            .map(|(&id, job)| JobSnapshot {
+                id,
+                command: job.command.clone(),
+                pid: job.pid,
+                elapsed_secs: job.started.elapsed().as_secs(),
+                exit_code: None,
+                stdout_lines: Vec::new(),
+                stderr_lines: Vec::new(),
+            })
+            .collect()
     }
 
     pub fn kill(&mut self, job_id: u32, task_id: Option<u64>, plugin: &str) {
@@ -297,6 +380,16 @@ impl Drop for CheckedOutReceiver {
     }
 }
 
+pub(crate) struct JobSnapshot {
+    pub id: u32,
+    pub command: String,
+    pub pid: u32,
+    pub elapsed_secs: u64,
+    pub exit_code: Option<i32>,
+    pub stdout_lines: Vec<String>,
+    pub stderr_lines: Vec<String>,
+}
+
 impl JobMeta {
     fn can_access(&self, task_id: Option<u64>, plugin: &str) -> bool {
         match &self.owner {
@@ -359,6 +452,8 @@ fn kill_job(meta: &mut JobMeta) {
 ///   `owner` (string?) job lifetime. `"task"` (default) ends the job with
 ///     the current call. `"plugin"` keeps it alive until the plugin unloads
 ///     or reloads.
+///   `tail` (integer?) trailing lines per stream kept for `jobinfo`
+///     (default 20, 0 disables, max 1024).
 /// @return (integer) Job id.
 /// @example
 /// local id = maki.fn.jobstart("ls -la", {
@@ -390,7 +485,7 @@ fn jobstart(
         }
     };
 
-    let (cwd, env, on_stdout, on_stderr, on_exit) = match opts {
+    let (cwd, env, on_stdout, on_stderr, on_exit, tail) = match opts {
         Some(ref opts) => {
             let cwd: Option<String> = opts.get("cwd").ok();
             let env: Option<HashMap<String, String>> = opts
@@ -412,15 +507,89 @@ fn jobstart(
                 .ok()
                 .map(|f| lua.create_registry_value(f))
                 .transpose()?;
-            (cwd, env, on_stdout, on_stderr, on_exit)
+            let tail: Option<usize> = opts.get("tail").ok();
+            if let Some(n) = tail
+                && n > MAX_TAIL_LINES
+            {
+                return Err(mlua::Error::runtime(format!(
+                    "jobstart: tail must be in 0..={MAX_TAIL_LINES}"
+                )));
+            }
+            (cwd, env, on_stdout, on_stderr, on_exit, tail)
         }
-        None => (None, None, None, None, None),
+        None => (None, None, None, None, None, None),
     };
 
     with_jobs(lua, |store| {
-        store.start(owner, &cmd, cwd, env, on_stdout, on_stderr, on_exit)
+        let id = store.start(owner, &cmd, cwd, env, on_stdout, on_stderr, on_exit)?;
+        store.configure(id, tail);
+        Ok::<u32, String>(id)
     })
     .map_err(mlua::Error::runtime)
+}
+
+/// Snapshot a job this plugin can see. Live jobs report tails collected
+/// so far. Task and plugin jobs are gone after they exit, so this is
+/// a live view today.
+///
+/// @param job_id integer Job id returned by `jobstart`.
+/// @return (table|nil, string|nil) `{ id, command, pid, status,
+///   exit_code, elapsed_secs, stdout_lines, stderr_lines }`, or nil and
+///   an error. `status` is `"running"` or `"exited"`.
+/// @example
+/// local info = maki.fn.jobinfo(id)
+#[lua_fn(guard = Run)]
+fn jobinfo(lua: &Lua, #[ctx] plugin: Arc<str>, job_id: u32) -> LuaResult<Pair<Value>> {
+    let task_id = active_task_id(lua);
+    match with_jobs(lua, |store| store.snapshot(job_id, task_id, &plugin)) {
+        Some(snap) => Ok((Some(Value::Table(snapshot_table(lua, &snap)?)), None)),
+        None => Ok(err_pair("job: not found")),
+    }
+}
+
+/// List live jobs this plugin can see: the current task's jobs plus
+/// this plugin's plugin-owned jobs.
+///
+/// @return (table) array of `{ id, command, pid, elapsed_secs }`.
+/// @example
+/// local jobs = maki.fn.joblist()
+#[lua_fn(guard = Run)]
+fn joblist(lua: &Lua, #[ctx] plugin: Arc<str>) -> LuaResult<Pair<Value>> {
+    let task_id = active_task_id(lua);
+    let snaps = with_jobs(lua, |store| store.list(task_id, &plugin));
+    let result = lua.create_table()?;
+    for (i, snap) in snaps.iter().enumerate() {
+        result.set(i + 1, snapshot_table(lua, snap)?)?;
+    }
+    Ok((Some(Value::Table(result)), None))
+}
+
+fn snapshot_table(lua: &Lua, snap: &JobSnapshot) -> LuaResult<Table> {
+    let row = lua.create_table()?;
+    row.set("id", snap.id)?;
+    row.set("command", snap.command.as_str())?;
+    row.set("pid", snap.pid)?;
+    row.set("elapsed_secs", snap.elapsed_secs)?;
+    row.set(
+        "status",
+        if snap.exit_code.is_some() {
+            "exited"
+        } else {
+            "running"
+        },
+    )?;
+    row.set("exit_code", snap.exit_code)?;
+    let stdout = lua.create_table()?;
+    for (i, line) in snap.stdout_lines.iter().enumerate() {
+        stdout.set(i + 1, line.as_str())?;
+    }
+    row.set("stdout_lines", stdout)?;
+    let stderr = lua.create_table()?;
+    for (i, line) in snap.stderr_lines.iter().enumerate() {
+        stderr.set(i + 1, line.as_str())?;
+    }
+    row.set("stderr_lines", stderr)?;
+    Ok(row)
 }
 
 /// Kill a running job immediately (SIGKILL on Unix). Safe to call on
@@ -466,7 +635,7 @@ async fn jobwait(
         .ok_or_else(|| mlua::Error::runtime("unknown job id or already waited"))?;
     let receiver = CheckedOutReceiver::new(&lua, job_id, receiver);
 
-    let timeout = Duration::from_millis(timeout_ms.unwrap_or(30_000));
+    let timeout = Duration::from_millis(timeout_ms.unwrap_or(DEFAULT_WAIT_MS));
     let deadline = smol::Timer::after(timeout);
     futures_lite::pin!(deadline);
 
@@ -504,6 +673,7 @@ async fn jobwait(
 /// both deliver events identically.
 pub(crate) fn deliver_job_event(lua: &Lua, job_id: u32, event: &JobEvent) -> LuaResult<()> {
     let callback = with_jobs(lua, |store| {
+        store.record_event(job_id, event);
         store
             .callback_key(job_id, event)
             .and_then(|key| lua.registry_value::<Function>(key).ok())
@@ -609,7 +779,8 @@ lua_table! {
         perms: &PluginPermissions,
         tx: Option<flume::Sender<UiAction>>,
     ), DOCS [
-        jobstart(perms, plugin), jobstop(perms, plugin), jobwait(perms, plugin), executable(perms),
+        jobstart(perms, plugin), jobstop(perms, plugin), jobwait(perms, plugin),
+        jobinfo(perms, plugin), joblist(perms, plugin), executable(perms),
         winsaveview(tx), winrestview(tx),
     ]
 }
@@ -631,6 +802,27 @@ mod tests {
 
     fn plugin_owner() -> JobOwner {
         JobOwner::Plugin(Arc::from(TEST_PLUGIN))
+    }
+
+    fn stub_job(
+        owner: JobOwner,
+        on_stdout: Option<RegistryKey>,
+        on_exit: Option<RegistryKey>,
+    ) -> JobMeta {
+        JobMeta {
+            owner,
+            command: String::new(),
+            pid: 0,
+            started: Instant::now(),
+            on_stdout,
+            on_stderr: None,
+            on_exit,
+            event_rx: None,
+            stdout_tail: VecDeque::new(),
+            stderr_tail: VecDeque::new(),
+            tail_cap: DEFAULT_TAIL,
+            exit_code: None,
+        }
     }
 
     fn start_echo(store: &mut JobStore) -> u32 {
@@ -960,17 +1152,9 @@ mod tests {
             .unwrap();
         let callback_key = lua.create_registry_value(callback).unwrap();
         with_jobs(&lua, |store| {
-            store.jobs.insert(
-                1,
-                JobMeta {
-                    owner: task_owner(1),
-                    pid: 0,
-                    on_stdout: None,
-                    on_stderr: None,
-                    on_exit: Some(callback_key),
-                    event_rx: None,
-                },
-            );
+            store
+                .jobs
+                .insert(1, stub_job(task_owner(1), None, Some(callback_key)));
         });
 
         assert!(deliver_job_event(&lua, 1, &JobEvent::Exit(0)).is_err());
@@ -990,22 +1174,77 @@ mod tests {
             .unwrap();
         let callback_key = lua.create_registry_value(callback).unwrap();
         let mut store = make_store();
-        store.jobs.insert(
-            1,
-            JobMeta {
-                owner: task_owner(1),
-                pid: 0,
-                on_stdout: Some(callback_key),
-                on_stderr: None,
-                on_exit: None,
-                event_rx: None,
-            },
-        );
+        store
+            .jobs
+            .insert(1, stub_job(task_owner(1), Some(callback_key), None));
         assert_eq!(Arc::strong_count(&capture), 2);
 
         store.finish(&lua, 1);
         lua.gc_collect().unwrap();
 
         assert_eq!(Arc::strong_count(&capture), 1);
+    }
+
+    #[test]
+    fn snapshot_reports_live_tails_and_hides_inaccessible_jobs() {
+        let mut store = make_store();
+        let id = start_echo(&mut store);
+        store.record_event(id, &JobEvent::Stdout("hello".into()));
+        store.record_event(id, &JobEvent::Stderr("warn".into()));
+
+        let snap = store.snapshot(id, Some(1), TEST_PLUGIN).unwrap();
+        assert_eq!(snap.command, "echo hello");
+        assert_eq!(snap.stdout_lines, ["hello"]);
+        assert_eq!(snap.stderr_lines, ["warn"]);
+        assert!(snap.exit_code.is_none());
+        assert!(store.snapshot(id, Some(2), TEST_PLUGIN).is_none());
+        assert!(store.snapshot(999, Some(1), TEST_PLUGIN).is_none());
+    }
+
+    #[test]
+    fn tail_cap_drops_oldest_lines() {
+        let mut store = make_store();
+        let id = start_echo(&mut store);
+        store.configure(id, Some(2));
+        store.record_event(id, &JobEvent::Stdout("a".into()));
+        store.record_event(id, &JobEvent::Stdout("b".into()));
+        store.record_event(id, &JobEvent::Stdout("c".into()));
+        let snap = store.snapshot(id, Some(1), TEST_PLUGIN).unwrap();
+        assert_eq!(snap.stdout_lines, ["b", "c"]);
+    }
+
+    #[test]
+    fn list_is_live_and_access_scoped() {
+        let lua = Lua::new();
+        let mut store = make_store();
+        let task = start_echo(&mut store);
+        let plugin = store
+            .start(plugin_owner(), "echo plugin", None, None, None, None, None)
+            .unwrap();
+
+        let from_task: Vec<u32> = store
+            .list(Some(1), TEST_PLUGIN)
+            .iter()
+            .map(|s| s.id)
+            .collect();
+        assert!(from_task.contains(&task));
+        assert!(from_task.contains(&plugin));
+
+        let from_other: Vec<u32> = store
+            .list(Some(2), "other-plugin")
+            .iter()
+            .map(|s| s.id)
+            .collect();
+        assert!(from_other.is_empty());
+
+        store.record_event(task, &JobEvent::Exit(0));
+        store.finish(&lua, task);
+        let live: Vec<u32> = store
+            .list(Some(1), TEST_PLUGIN)
+            .iter()
+            .map(|s| s.id)
+            .collect();
+        assert_eq!(live, [plugin]);
+        assert!(store.snapshot(task, Some(1), TEST_PLUGIN).is_none());
     }
 }

--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -764,8 +764,8 @@ fn jobinfo(lua: &Lua, #[ctx] plugin: Arc<str>, job_id: u32) -> LuaResult<Pair<Va
 
 /// List jobs this plugin can see, including exited session-owned jobs (so an
 /// id started before a reload stays findable). Rows identify the job; call
-/// `jobinfo` for tails. Pass a session id to restrict session-owned jobs to
-/// that session.
+/// `jobinfo` for tails. Pass a session id to list only session-owned jobs
+/// for that session; plugin and task jobs are omitted.
 ///
 /// @param session string? Session id filter.
 /// @return (table) array of `{ id, command, pid, session, status, exit_code,
@@ -858,8 +858,10 @@ fn jobforget(lua: &Lua, #[ctx] plugin: Arc<str>, job_id: u32) -> LuaResult<()> {
 ///
 /// While waiting, the job's `on_stdout`, `on_stderr`, and `on_exit`
 /// callbacks fire as events arrive (like Neovim), so you can stream
-/// output into a buffer while parked here. A job that already exited
-/// answers from its snapshot instead and fires no callbacks.
+/// output into a buffer while parked here. An already-exited
+/// session-owned job answers from its snapshot and fires no callbacks.
+/// Task and plugin jobs leave the store on exit, so waiting after that
+/// is an error.
 ///
 /// @param job_id integer Job id returned by `jobstart`.
 /// @param timeout_ms integer? Maximum wait in milliseconds (default 30000).
@@ -1041,7 +1043,7 @@ lua_table! {
     ///
     /// ```lua
     /// local id = maki.fn.jobstart("git status", {
-    ///   on_exit = function(code) print("done: " .. code) end,
+    ///   on_exit = function(_, code) print("done: " .. code) end,
     /// })
     /// ```
     "maki.fn" => pub(crate) fn create_fn_table(

--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use maki_agent::SessionMailbox;
 use maki_lua_macro::{lua_fn, lua_table};
 use maki_storage::id::MakiId;
 use mlua::{Function, Lua, RegistryKey, Result as LuaResult, Table, Value};
@@ -24,6 +23,11 @@ const MAX_COMPLETED_SESSION_JOBS: usize = 256;
 const DEFAULT_WAIT_MS: u64 = 30_000;
 
 const READER_BUF_SIZE: usize = 8 * 1024;
+
+const NO_TASK_SCOPE_ERR: &str =
+    "jobstart: no active task; use scope = \"plugin\" or { session = ... }";
+const TABLE_SCOPE_ERR: &str = "jobstart: table scope must be { session = <id> }";
+const SCOPE_TYPE_ERR: &str = "jobstart: scope must be \"task\", \"plugin\", or { session = <id> }";
 
 #[derive(Clone)]
 pub(crate) enum JobEvent {
@@ -44,13 +48,6 @@ pub(crate) enum JobOwner {
     },
 }
 
-#[derive(Clone)]
-struct JobNotify {
-    session: MakiId,
-    wake: bool,
-    on_success: bool,
-}
-
 struct JobMeta {
     owner: JobOwner,
     command: String,
@@ -63,7 +60,6 @@ struct JobMeta {
     stdout_tail: VecDeque<String>,
     stderr_tail: VecDeque<String>,
     tail_cap: usize,
-    notify: Option<JobNotify>,
     exit_code: Option<i32>,
     /// Recorded at exit so elapsed time stops counting once the process is gone.
     elapsed_secs: Option<u64>,
@@ -223,7 +219,6 @@ impl JobStore {
                 stdout_tail: VecDeque::new(),
                 stderr_tail: VecDeque::new(),
                 tail_cap: DEFAULT_TAIL,
-                notify: None,
                 exit_code: None,
                 elapsed_secs: None,
             },
@@ -232,14 +227,12 @@ impl JobStore {
         Ok(id)
     }
 
-    fn configure(&mut self, id: u32, notify: Option<JobNotify>, tail: Option<usize>) {
-        let Some(job) = self.jobs.get_mut(&id) else {
-            return;
-        };
-        if let Some(cap) = tail {
+    fn set_tail(&mut self, id: u32, tail: Option<usize>) {
+        if let Some(job) = self.jobs.get_mut(&id)
+            && let Some(cap) = tail
+        {
             job.tail_cap = cap.min(MAX_TAIL_LINES);
         }
-        job.notify = notify;
     }
 
     pub fn is_empty(&self, owner: &JobOwner) -> bool {
@@ -332,14 +325,6 @@ impl JobStore {
             job.elapsed_secs = Some(job.started.elapsed().as_secs());
         }
         job.exit_code = Some(code);
-        if let Some(notify) = job.notify.clone()
-            && (code != 0 || notify.on_success)
-        {
-            let message = format!("[job {job_id}] \"{}\" exited with code {code}", job.command);
-            if let Err(e) = SessionMailbox::notify(notify.session, message, notify.wake) {
-                tracing::warn!(error = %e, job_id, "session job notify failed");
-            }
-        }
         if matches!(job.owner, JobOwner::Session { .. }) {
             drop_callbacks(lua, job);
             self.completed_order.push_back(job_id);
@@ -610,15 +595,10 @@ fn kill_job(meta: &mut JobMeta) {
 ///   `on_stdout` (function?) called with `(job_id, line)` for each stdout line.
 ///   `on_stderr` (function?) called with `(job_id, line)` for each stderr line.
 ///   `on_exit` (function?) called with `(job_id, code)` when the process finishes.
-///   `owner` (string?) job lifetime. `"task"` (default) ends the job with
-///     the current call. `"plugin"` keeps it alive until the plugin unloads
-///     or reloads. `"session"` keeps it alive until that session ends, and
-///     survives plugin reload; requires `session`.
-///   `session` (string?) session id. Required when `owner = "session"`.
-///   `notify` (boolean|table?) when the process exits, post a mailbox
-///     observation to `session`. `true` uses `{ wake = true, on_success = true }`.
-///     A table accepts `wake` (boolean, default true) and `on_success`
-///     (boolean, default true). Only valid with `owner = "session"`.
+///   `scope` (string|table?) job lifetime. `"task"` (default) ends the job
+///     with the current call. `"plugin"` keeps it alive until the plugin
+///     unloads or reloads. `{ session = "<id>" }` keeps it alive until that
+///     session ends, and survives plugin reload.
 ///   `tail` (integer?) trailing lines per stream kept for `jobinfo`
 ///     (default 20, 0 disables, max 1024).
 /// @return (integer) Job id.
@@ -635,41 +615,14 @@ fn jobstart(
     cmd: String,
     opts: Option<Table>,
 ) -> LuaResult<u32> {
-    let owner_name: Option<String> = opts
+    let scope = opts
         .as_ref()
-        .map(|opts| opts.get("owner"))
+        .map(|opts| opts.get::<Value>("scope"))
         .transpose()?
-        .flatten();
-    let session = opts
-        .as_ref()
-        .and_then(|opts| opts.get::<Option<String>>("session").ok().flatten());
-    let owner = match owner_name.as_deref() {
-        None | Some("task") => job_task_id(lua).map(JobOwner::Task).ok_or_else(|| {
-            mlua::Error::runtime("jobstart: no active task; use owner = \"plugin\" or \"session\"")
-        })?,
-        Some("plugin") => JobOwner::Plugin(Arc::clone(&plugin)),
-        Some("session") => {
-            let raw = session.as_deref().ok_or_else(|| {
-                mlua::Error::runtime("jobstart: owner = \"session\" requires session")
-            })?;
-            let session: MakiId =
-                raw.parse()
-                    .map_err(|e: maki_storage::id::MakiIdParseError| {
-                        mlua::Error::runtime(e.to_string())
-                    })?;
-            JobOwner::Session {
-                session,
-                plugin: Arc::clone(&plugin),
-            }
-        }
-        Some(other) => {
-            return Err(mlua::Error::runtime(format!(
-                "jobstart: unknown owner {other:?}; expected \"task\", \"plugin\", or \"session\""
-            )));
-        }
-    };
+        .unwrap_or(Value::Nil);
+    let owner = parse_scope(lua, &plugin, scope)?;
 
-    let (cwd, env, on_stdout, on_stderr, on_exit, notify, tail) = match opts {
+    let (cwd, env, on_stdout, on_stderr, on_exit, tail) = match opts {
         Some(ref opts) => {
             let cwd: Option<String> = opts.get("cwd").ok();
             let env: Option<HashMap<String, String>> = opts
@@ -691,7 +644,6 @@ fn jobstart(
                 .ok()
                 .map(|f| lua.create_registry_value(f))
                 .transpose()?;
-            let notify = parse_notify(opts, &owner)?;
             let tail: Option<usize> = opts.get("tail").ok();
             if let Some(n) = tail
                 && n > MAX_TAIL_LINES
@@ -700,47 +652,50 @@ fn jobstart(
                     "jobstart: tail must be in 0..={MAX_TAIL_LINES}"
                 )));
             }
-            (cwd, env, on_stdout, on_stderr, on_exit, notify, tail)
+            (cwd, env, on_stdout, on_stderr, on_exit, tail)
         }
-        None => (None, None, None, None, None, None, None),
+        None => (None, None, None, None, None, None),
     };
 
     with_jobs(lua, |store| {
         let id = store.start(owner, &cmd, cwd, env, on_stdout, on_stderr, on_exit)?;
-        store.configure(id, notify, tail);
+        store.set_tail(id, tail);
         Ok::<u32, String>(id)
     })
     .map_err(mlua::Error::runtime)
 }
 
-fn parse_notify(opts: &Table, owner: &JobOwner) -> LuaResult<Option<JobNotify>> {
-    let session = match owner {
-        JobOwner::Session { session, .. } => *session,
-        _ => {
-            if opts.contains_key("notify")? {
-                return Err(mlua::Error::runtime(
-                    "jobstart: notify requires owner = \"session\"",
-                ));
-            }
-            return Ok(None);
-        }
+fn parse_scope(lua: &Lua, plugin: &Arc<str>, scope: Value) -> LuaResult<JobOwner> {
+    let task_scope = || {
+        job_task_id(lua)
+            .map(JobOwner::Task)
+            .ok_or_else(|| mlua::Error::runtime(NO_TASK_SCOPE_ERR))
     };
-    match opts.get::<Value>("notify")? {
-        Value::Nil => Ok(None),
-        Value::Boolean(false) => Ok(None),
-        Value::Boolean(true) => Ok(Some(JobNotify {
-            session,
-            wake: true,
-            on_success: true,
-        })),
-        Value::Table(t) => Ok(Some(JobNotify {
-            session,
-            wake: t.get("wake").unwrap_or(true),
-            on_success: t.get("on_success").unwrap_or(true),
-        })),
-        _ => Err(mlua::Error::runtime(
-            "jobstart: notify must be a boolean or table",
-        )),
+    match scope {
+        Value::Nil => task_scope(),
+        Value::String(name) => match &*name.to_str()? {
+            "task" => task_scope(),
+            "plugin" => Ok(JobOwner::Plugin(Arc::clone(plugin))),
+            other => Err(mlua::Error::runtime(format!(
+                "jobstart: unknown scope {other:?}; expected \"task\", \"plugin\", or {{ session = ... }}"
+            ))),
+        },
+        Value::Table(scope) => {
+            let Value::String(raw) = scope.get::<Value>("session")? else {
+                return Err(mlua::Error::runtime(TABLE_SCOPE_ERR));
+            };
+            let session: MakiId =
+                raw.to_str()?
+                    .parse()
+                    .map_err(|e: maki_storage::id::MakiIdParseError| {
+                        mlua::Error::runtime(e.to_string())
+                    })?;
+            Ok(JobOwner::Session {
+                session,
+                plugin: Arc::clone(plugin),
+            })
+        }
+        _ => Err(mlua::Error::runtime(SCOPE_TYPE_ERR)),
     }
 }
 
@@ -1120,7 +1075,6 @@ mod tests {
             stdout_tail: VecDeque::new(),
             stderr_tail: VecDeque::new(),
             tail_cap: DEFAULT_TAIL,
-            notify: None,
             exit_code: None,
             elapsed_secs: None,
         }
@@ -1498,7 +1452,7 @@ mod tests {
     fn tail_cap_drops_oldest_lines() {
         let mut store = make_store();
         let id = start_echo(&mut store);
-        store.configure(id, None, Some(2));
+        store.set_tail(id, Some(2));
         store.record_event(id, &JobEvent::Stdout("a".into()));
         store.record_event(id, &JobEvent::Stdout("b".into()));
         store.record_event(id, &JobEvent::Stdout("c".into()));
@@ -1546,7 +1500,6 @@ mod tests {
     fn session_job_survives_plugin_detach_and_answers_after_exit() {
         let lua = Lua::new();
         let session = MakiId::generate();
-        let mailbox = SessionMailbox::register(session);
         let owner = JobOwner::Session {
             session,
             plugin: Arc::from(TEST_PLUGIN),
@@ -1563,15 +1516,7 @@ mod tests {
                 None,
             )
             .unwrap();
-        store.configure(
-            id,
-            Some(JobNotify {
-                session,
-                wake: false,
-                on_success: true,
-            }),
-            Some(5),
-        );
+        store.set_tail(id, Some(5));
 
         store.detach_plugin_callbacks(&lua, TEST_PLUGIN);
         assert!(store.jobs.contains_key(&id), "detach must keep the job");
@@ -1594,13 +1539,6 @@ mod tests {
             snap.stderr_lines.iter().any(|l| l.contains("err")),
             "stderr tail: {:?}",
             snap.stderr_lines
-        );
-        let notes = mailbox.drain();
-        assert!(
-            notes.iter().any(|m| m
-                .user_text()
-                .is_some_and(|t| t.contains("exited with code 3"))),
-            "expected exit notify"
         );
 
         store.kill_session(&lua, session);

--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::env;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
@@ -7,7 +7,9 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use maki_agent::SessionMailbox;
 use maki_lua_macro::{lua_fn, lua_table};
+use maki_storage::id::MakiId;
 use mlua::{Function, Lua, RegistryKey, Result as LuaResult, Table, Value};
 
 use crate::api::fs::expand_tilde;
@@ -18,6 +20,7 @@ use crate::runtime::{active_task_id, job_task_id, with_jobs};
 
 const DEFAULT_TAIL: usize = 20;
 const MAX_TAIL_LINES: usize = 1024;
+const MAX_COMPLETED_SESSION_JOBS: usize = 256;
 const DEFAULT_WAIT_MS: u64 = 30_000;
 
 const READER_BUF_SIZE: usize = 8 * 1024;
@@ -33,6 +36,19 @@ pub(crate) enum JobEvent {
 pub(crate) enum JobOwner {
     Task(u64),
     Plugin(Arc<str>),
+    /// Lives until the session ends (or the host process exits). Survives
+    /// plugin reload: the starting plugin can still inspect and stop it.
+    Session {
+        session: MakiId,
+        plugin: Arc<str>,
+    },
+}
+
+#[derive(Clone)]
+struct JobNotify {
+    session: MakiId,
+    wake: bool,
+    on_success: bool,
 }
 
 struct JobMeta {
@@ -47,10 +63,20 @@ struct JobMeta {
     stdout_tail: VecDeque<String>,
     stderr_tail: VecDeque<String>,
     tail_cap: usize,
+    notify: Option<JobNotify>,
     exit_code: Option<i32>,
+    /// Recorded at exit so elapsed time stops counting once the process is gone.
+    elapsed_secs: Option<u64>,
 }
 
 impl JobMeta {
+    fn session(&self) -> Option<MakiId> {
+        match self.owner {
+            JobOwner::Session { session, .. } => Some(session),
+            _ => None,
+        }
+    }
+
     fn record_line(&mut self, stdout: bool, line: &str) {
         if self.tail_cap == 0 {
             return;
@@ -70,6 +96,7 @@ impl JobMeta {
 pub(crate) struct JobStore {
     jobs: HashMap<u32, JobMeta>,
     next_id: u32,
+    completed_order: VecDeque<u32>,
 }
 
 struct CheckedOutReceiver {
@@ -83,6 +110,7 @@ impl JobStore {
         Self {
             jobs: HashMap::new(),
             next_id: 1,
+            completed_order: VecDeque::new(),
         }
     }
 
@@ -191,20 +219,23 @@ impl JobStore {
                 stdout_tail: VecDeque::new(),
                 stderr_tail: VecDeque::new(),
                 tail_cap: DEFAULT_TAIL,
+                notify: None,
                 exit_code: None,
+                elapsed_secs: None,
             },
         );
 
         Ok(id)
     }
 
-    fn configure(&mut self, id: u32, tail: Option<usize>) {
+    fn configure(&mut self, id: u32, notify: Option<JobNotify>, tail: Option<usize>) {
         let Some(job) = self.jobs.get_mut(&id) else {
             return;
         };
         if let Some(cap) = tail {
             job.tail_cap = cap.min(MAX_TAIL_LINES);
         }
+        job.notify = notify;
     }
 
     pub fn is_empty(&self, owner: &JobOwner) -> bool {
@@ -255,7 +286,7 @@ impl JobStore {
         for (&id, job) in self
             .jobs
             .iter()
-            .filter(|(_, job)| matches!(job.owner, JobOwner::Plugin(_)))
+            .filter(|(_, job)| matches!(job.owner, JobOwner::Plugin(_) | JobOwner::Session { .. }))
         {
             if let Some(ref rx) = job.event_rx {
                 while let Ok(event) = rx.try_recv() {
@@ -272,7 +303,72 @@ impl JobStore {
         match event {
             JobEvent::Stdout(line) => job.record_line(true, line),
             JobEvent::Stderr(line) => job.record_line(false, line),
-            JobEvent::Exit(code) => job.exit_code = Some(*code),
+            JobEvent::Exit(code) => {
+                job.exit_code = Some(*code);
+                job.elapsed_secs = Some(job.started.elapsed().as_secs());
+            }
+        }
+    }
+
+    /// Session-owned jobs stay inspectable after exit. Task/plugin jobs are
+    /// removed the way they always were.
+    pub fn complete(&mut self, lua: &Lua, job_id: u32, code: i32) {
+        let Some(job) = self.jobs.get_mut(&job_id) else {
+            return;
+        };
+        job.exit_code = Some(code);
+        if let Some(notify) = job.notify.clone()
+            && (code != 0 || notify.on_success)
+        {
+            let message = format!("[job {job_id}] \"{}\" exited with code {code}", job.command);
+            if let Err(e) = SessionMailbox::notify(notify.session, message, notify.wake) {
+                tracing::warn!(error = %e, job_id, "session job notify failed");
+            }
+        }
+        if matches!(job.owner, JobOwner::Session { .. }) {
+            drop_callbacks(lua, job);
+            self.completed_order.push_back(job_id);
+            while self.completed_order.len() > MAX_COMPLETED_SESSION_JOBS {
+                let oldest = self.completed_order.pop_front().unwrap();
+                if self
+                    .jobs
+                    .get(&oldest)
+                    .is_some_and(|j| j.exit_code.is_some())
+                {
+                    self.remove(lua, oldest, false);
+                }
+            }
+            return;
+        }
+        self.finish(lua, job_id);
+    }
+
+    pub fn kill_session(&mut self, lua: &Lua, session: MakiId) {
+        let ids: Vec<u32> = self
+            .jobs
+            .iter()
+            .filter(|(_, job)| job.session() == Some(session))
+            .map(|(&id, _)| id)
+            .collect();
+        for id in ids {
+            self.remove(lua, id, true);
+        }
+        let remaining: HashSet<u32> = self.jobs.keys().copied().collect();
+        self.completed_order.retain(|id| remaining.contains(id));
+    }
+
+    /// Drop Lua callbacks for session jobs started by {plugin} without
+    /// killing the process. Used on plugin unload/reload.
+    pub fn detach_plugin_callbacks(&mut self, lua: &Lua, plugin: &str) {
+        for job in self.jobs.values_mut() {
+            if let JobOwner::Session {
+                plugin: owner_plugin,
+                ..
+            } = &job.owner
+                && owner_plugin.as_ref() == plugin
+            {
+                drop_callbacks(lua, job);
+            }
         }
     }
 
@@ -281,27 +377,41 @@ impl JobStore {
         job.can_access(task_id, plugin).then(|| JobSnapshot {
             id: job_id,
             command: job.command.clone(),
+            session: job.session(),
             pid: job.pid,
-            elapsed_secs: job.started.elapsed().as_secs(),
+            elapsed_secs: job
+                .elapsed_secs
+                .unwrap_or_else(|| job.started.elapsed().as_secs()),
             exit_code: job.exit_code,
             stdout_lines: job.stdout_tail.iter().cloned().collect(),
             stderr_lines: job.stderr_tail.iter().cloned().collect(),
         })
     }
 
-    pub fn list(&self, task_id: Option<u64>, plugin: &str) -> Vec<JobSnapshot> {
+    /// List jobs this plugin can see. Task and plugin jobs leave the map on
+    /// exit; session-owned jobs stay, so exited ones show up here with their
+    /// final tail and exit code.
+    pub fn list(
+        &self,
+        session: Option<MakiId>,
+        task_id: Option<u64>,
+        plugin: &str,
+    ) -> Vec<JobSnapshot> {
         self.jobs
             .iter()
             .filter(|(_, job)| job.can_access(task_id, plugin))
-            .filter(|(_, job)| job.exit_code.is_none())
+            .filter(|(_, job)| session.is_none_or(|s| job.session() == Some(s)))
             .map(|(&id, job)| JobSnapshot {
                 id,
                 command: job.command.clone(),
+                session: job.session(),
                 pid: job.pid,
-                elapsed_secs: job.started.elapsed().as_secs(),
-                exit_code: None,
-                stdout_lines: Vec::new(),
-                stderr_lines: Vec::new(),
+                elapsed_secs: job
+                    .elapsed_secs
+                    .unwrap_or_else(|| job.started.elapsed().as_secs()),
+                exit_code: job.exit_code,
+                stdout_lines: job.stdout_tail.iter().cloned().collect(),
+                stderr_lines: job.stderr_tail.iter().cloned().collect(),
             })
             .collect()
     }
@@ -383,6 +493,7 @@ impl Drop for CheckedOutReceiver {
 pub(crate) struct JobSnapshot {
     pub id: u32,
     pub command: String,
+    pub session: Option<MakiId>,
     pub pid: u32,
     pub elapsed_secs: u64,
     pub exit_code: Option<i32>,
@@ -395,7 +506,20 @@ impl JobMeta {
         match &self.owner {
             JobOwner::Task(owner_id) => task_id == Some(*owner_id),
             JobOwner::Plugin(owner_plugin) => owner_plugin.as_ref() == plugin,
+            JobOwner::Session {
+                plugin: owner_plugin,
+                ..
+            } => owner_plugin.as_ref() == plugin,
         }
+    }
+}
+
+fn drop_callbacks(lua: &Lua, job: &mut JobMeta) {
+    for key in [&mut job.on_stdout, &mut job.on_stderr, &mut job.on_exit]
+        .into_iter()
+        .filter_map(Option::take)
+    {
+        lua.remove_registry_value(key).ok();
     }
 }
 
@@ -415,6 +539,11 @@ fn shell_command(cmd: &str) -> Command {
 }
 
 fn kill_job(meta: &mut JobMeta) {
+    // The wait thread already reaped the process, so its pid may have been
+    // recycled. Only signal jobs we know are still alive.
+    if meta.exit_code.is_some() {
+        return;
+    }
     let pid = meta.pid;
     #[cfg(unix)]
     {
@@ -451,7 +580,13 @@ fn kill_job(meta: &mut JobMeta) {
 ///   `on_exit` (function?) called with `(job_id, code)` when the process finishes.
 ///   `owner` (string?) job lifetime. `"task"` (default) ends the job with
 ///     the current call. `"plugin"` keeps it alive until the plugin unloads
-///     or reloads.
+///     or reloads. `"session"` keeps it alive until that session ends, and
+///     survives plugin reload; requires `session`.
+///   `session` (string?) session id. Required when `owner = "session"`.
+///   `notify` (boolean|table?) when the process exits, post a mailbox
+///     observation to `session`. `true` uses `{ wake = true, on_success = true }`.
+///     A table accepts `wake` (boolean, default true) and `on_success`
+///     (boolean, default true). Only valid with `owner = "session"`.
 ///   `tail` (integer?) trailing lines per stream kept for `jobinfo`
 ///     (default 20, 0 disables, max 1024).
 /// @return (integer) Job id.
@@ -473,19 +608,36 @@ fn jobstart(
         .map(|opts| opts.get("owner"))
         .transpose()?
         .flatten();
+    let session = opts
+        .as_ref()
+        .and_then(|opts| opts.get::<Option<String>>("session").ok().flatten());
     let owner = match owner_name.as_deref() {
         None | Some("task") => job_task_id(lua).map(JobOwner::Task).ok_or_else(|| {
-            mlua::Error::runtime("jobstart: no active task; use owner = \"plugin\"")
+            mlua::Error::runtime("jobstart: no active task; use owner = \"plugin\" or \"session\"")
         })?,
         Some("plugin") => JobOwner::Plugin(Arc::clone(&plugin)),
+        Some("session") => {
+            let raw = session.as_deref().ok_or_else(|| {
+                mlua::Error::runtime("jobstart: owner = \"session\" requires session")
+            })?;
+            let session: MakiId =
+                raw.parse()
+                    .map_err(|e: maki_storage::id::MakiIdParseError| {
+                        mlua::Error::runtime(e.to_string())
+                    })?;
+            JobOwner::Session {
+                session,
+                plugin: Arc::clone(&plugin),
+            }
+        }
         Some(other) => {
             return Err(mlua::Error::runtime(format!(
-                "jobstart: unknown owner {other:?}; expected \"task\" or \"plugin\""
+                "jobstart: unknown owner {other:?}; expected \"task\", \"plugin\", or \"session\""
             )));
         }
     };
 
-    let (cwd, env, on_stdout, on_stderr, on_exit, tail) = match opts {
+    let (cwd, env, on_stdout, on_stderr, on_exit, notify, tail) = match opts {
         Some(ref opts) => {
             let cwd: Option<String> = opts.get("cwd").ok();
             let env: Option<HashMap<String, String>> = opts
@@ -507,6 +659,7 @@ fn jobstart(
                 .ok()
                 .map(|f| lua.create_registry_value(f))
                 .transpose()?;
+            let notify = parse_notify(opts, &owner)?;
             let tail: Option<usize> = opts.get("tail").ok();
             if let Some(n) = tail
                 && n > MAX_TAIL_LINES
@@ -515,25 +668,55 @@ fn jobstart(
                     "jobstart: tail must be in 0..={MAX_TAIL_LINES}"
                 )));
             }
-            (cwd, env, on_stdout, on_stderr, on_exit, tail)
+            (cwd, env, on_stdout, on_stderr, on_exit, notify, tail)
         }
-        None => (None, None, None, None, None, None),
+        None => (None, None, None, None, None, None, None),
     };
 
     with_jobs(lua, |store| {
         let id = store.start(owner, &cmd, cwd, env, on_stdout, on_stderr, on_exit)?;
-        store.configure(id, tail);
+        store.configure(id, notify, tail);
         Ok::<u32, String>(id)
     })
     .map_err(mlua::Error::runtime)
 }
 
+fn parse_notify(opts: &Table, owner: &JobOwner) -> LuaResult<Option<JobNotify>> {
+    let session = match owner {
+        JobOwner::Session { session, .. } => *session,
+        _ => {
+            if opts.contains_key("notify")? {
+                return Err(mlua::Error::runtime(
+                    "jobstart: notify requires owner = \"session\"",
+                ));
+            }
+            return Ok(None);
+        }
+    };
+    match opts.get::<Value>("notify")? {
+        Value::Nil => Ok(None),
+        Value::Boolean(false) => Ok(None),
+        Value::Boolean(true) => Ok(Some(JobNotify {
+            session,
+            wake: true,
+            on_success: true,
+        })),
+        Value::Table(t) => Ok(Some(JobNotify {
+            session,
+            wake: t.get("wake").unwrap_or(true),
+            on_success: t.get("on_success").unwrap_or(true),
+        })),
+        _ => Err(mlua::Error::runtime(
+            "jobstart: notify must be a boolean or table",
+        )),
+    }
+}
+
 /// Snapshot a job this plugin can see. Live jobs report tails collected
-/// so far. Task and plugin jobs are gone after they exit, so this is
-/// a live view today.
+/// so far; session-owned jobs still answer after they exit.
 ///
 /// @param job_id integer Job id returned by `jobstart`.
-/// @return (table|nil, string|nil) `{ id, command, pid, status,
+/// @return (table|nil, string|nil) `{ id, command, pid, session, status,
 ///   exit_code, elapsed_secs, stdout_lines, stderr_lines }`, or nil and
 ///   an error. `status` is `"running"` or `"exited"`.
 /// @example
@@ -547,16 +730,26 @@ fn jobinfo(lua: &Lua, #[ctx] plugin: Arc<str>, job_id: u32) -> LuaResult<Pair<Va
     }
 }
 
-/// List live jobs this plugin can see: the current task's jobs plus
-/// this plugin's plugin-owned jobs.
+/// List jobs this plugin can see, including exited session-owned jobs (so an
+/// id started before a reload stays findable). Pass a session id to restrict
+/// session-owned jobs to that session.
 ///
-/// @return (table) array of `{ id, command, pid, elapsed_secs }`.
+/// @param session string? Session id filter.
+/// @return (table) array of `{ id, command, pid, session, status, exit_code,
+///   elapsed_secs, stdout_lines, stderr_lines }`.
 /// @example
-/// local jobs = maki.fn.joblist()
+/// local jobs = maki.fn.joblist(maki.session.current())
 #[lua_fn(guard = Run)]
-fn joblist(lua: &Lua, #[ctx] plugin: Arc<str>) -> LuaResult<Pair<Value>> {
+fn joblist(lua: &Lua, #[ctx] plugin: Arc<str>, session: Option<String>) -> LuaResult<Pair<Value>> {
+    let filter = match session {
+        Some(raw) => match raw.parse::<MakiId>() {
+            Ok(id) => Some(id),
+            Err(e) => return Ok(err_pair(e.to_string())),
+        },
+        None => None,
+    };
     let task_id = active_task_id(lua);
-    let snaps = with_jobs(lua, |store| store.list(task_id, &plugin));
+    let snaps = with_jobs(lua, |store| store.list(filter, task_id, &plugin));
     let result = lua.create_table()?;
     for (i, snap) in snaps.iter().enumerate() {
         result.set(i + 1, snapshot_table(lua, snap)?)?;
@@ -569,6 +762,7 @@ fn snapshot_table(lua: &Lua, snap: &JobSnapshot) -> LuaResult<Table> {
     row.set("id", snap.id)?;
     row.set("command", snap.command.as_str())?;
     row.set("pid", snap.pid)?;
+    row.set("session", snap.session.map(|s| s.to_string()))?;
     row.set("elapsed_secs", snap.elapsed_secs)?;
     row.set(
         "status",
@@ -607,8 +801,11 @@ fn jobstop(lua: &Lua, #[ctx] plugin: Arc<str>, job_id: u32) -> LuaResult<()> {
 }
 
 /// Wait for a job to finish and collect its output. Returns a result
-/// table with `stdout`, `stderr`, and `exit_code`. Returns `nil` if the
-/// job does not finish before the timeout.
+/// table with `stdout`, `stderr`, `exit_code`, and `truncated`. `truncated`
+/// is false when the collected lines are the full output; a job that already
+/// exited answers from its captured tail, so `truncated` is true and the
+/// output may be missing lines. Returns `nil` if the job does not finish
+/// before the timeout.
 ///
 /// While waiting, the job's `on_stdout`, `on_stderr`, and `on_exit`
 /// callbacks fire as events arrive (like Neovim), so you can stream
@@ -616,7 +813,7 @@ fn jobstop(lua: &Lua, #[ctx] plugin: Arc<str>, job_id: u32) -> LuaResult<()> {
 ///
 /// @param job_id integer Job id returned by `jobstart`.
 /// @param timeout_ms integer? Maximum wait in milliseconds (default 30000).
-/// @return (table?) `{ stdout, stderr, exit_code }`, or nil on timeout.
+/// @return (table?) `{ stdout, stderr, exit_code, truncated }`, or nil on timeout.
 /// @example
 /// local id = maki.fn.jobstart("echo hello")
 /// local result = maki.fn.jobwait(id, 5000)
@@ -631,6 +828,16 @@ async fn jobwait(
     timeout_ms: Option<u64>,
 ) -> LuaResult<Value> {
     let task_id = active_task_id(&lua);
+    if let Some(snap) = with_jobs(&lua, |store| store.snapshot(job_id, task_id, &plugin))
+        && let Some(code) = snap.exit_code
+    {
+        let result = lua.create_table()?;
+        result.set("stdout", snap.stdout_lines.join("\n"))?;
+        result.set("stderr", snap.stderr_lines.join("\n"))?;
+        result.set("exit_code", code)?;
+        result.set("truncated", true)?;
+        return Ok(mlua::Value::Table(result));
+    }
     let receiver = with_jobs(&lua, |store| store.take_receiver(job_id, task_id, &plugin))
         .ok_or_else(|| mlua::Error::runtime("unknown job id or already waited"))?;
     let receiver = CheckedOutReceiver::new(&lua, job_id, receiver);
@@ -665,6 +872,7 @@ async fn jobwait(
     result.set("stdout", stdout_lines.join("\n"))?;
     result.set("stderr", stderr_lines.join("\n"))?;
     result.set("exit_code", exit_code)?;
+    result.set("truncated", false)?;
     Ok(mlua::Value::Table(result))
 }
 
@@ -678,8 +886,8 @@ pub(crate) fn deliver_job_event(lua: &Lua, job_id: u32, event: &JobEvent) -> Lua
             .callback_key(job_id, event)
             .and_then(|key| lua.registry_value::<Function>(key).ok())
     });
-    if let JobEvent::Exit(_) = event {
-        with_jobs(lua, |store| store.finish(lua, job_id));
+    if let JobEvent::Exit(code) = event {
+        with_jobs(lua, |store| store.complete(lua, job_id, *code));
     }
     if let Some(callback) = callback {
         let arg = match event {
@@ -821,7 +1029,9 @@ mod tests {
             stdout_tail: VecDeque::new(),
             stderr_tail: VecDeque::new(),
             tail_cap: DEFAULT_TAIL,
+            notify: None,
             exit_code: None,
+            elapsed_secs: None,
         }
     }
 
@@ -1205,7 +1415,7 @@ mod tests {
     fn tail_cap_drops_oldest_lines() {
         let mut store = make_store();
         let id = start_echo(&mut store);
-        store.configure(id, Some(2));
+        store.configure(id, None, Some(2));
         store.record_event(id, &JobEvent::Stdout("a".into()));
         store.record_event(id, &JobEvent::Stdout("b".into()));
         store.record_event(id, &JobEvent::Stdout("c".into()));
@@ -1223,7 +1433,7 @@ mod tests {
             .unwrap();
 
         let from_task: Vec<u32> = store
-            .list(Some(1), TEST_PLUGIN)
+            .list(None, Some(1), TEST_PLUGIN)
             .iter()
             .map(|s| s.id)
             .collect();
@@ -1231,7 +1441,7 @@ mod tests {
         assert!(from_task.contains(&plugin));
 
         let from_other: Vec<u32> = store
-            .list(Some(2), "other-plugin")
+            .list(None, Some(2), "other-plugin")
             .iter()
             .map(|s| s.id)
             .collect();
@@ -1240,11 +1450,227 @@ mod tests {
         store.record_event(task, &JobEvent::Exit(0));
         store.finish(&lua, task);
         let live: Vec<u32> = store
-            .list(Some(1), TEST_PLUGIN)
+            .list(None, Some(1), TEST_PLUGIN)
             .iter()
             .map(|s| s.id)
             .collect();
         assert_eq!(live, [plugin]);
         assert!(store.snapshot(task, Some(1), TEST_PLUGIN).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn session_job_survives_plugin_detach_and_answers_after_exit() {
+        let lua = Lua::new();
+        let session = MakiId::generate();
+        let mailbox = SessionMailbox::register(session);
+        let owner = JobOwner::Session {
+            session,
+            plugin: Arc::from(TEST_PLUGIN),
+        };
+        let mut store = make_store();
+        let id = store
+            .start(
+                owner.clone(),
+                "echo hi; echo err >&2; exit 3",
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        store.configure(
+            id,
+            Some(JobNotify {
+                session,
+                wake: false,
+                on_success: true,
+            }),
+            Some(5),
+        );
+
+        store.detach_plugin_callbacks(&lua, TEST_PLUGIN);
+        assert!(store.jobs.contains_key(&id), "detach must keep the job");
+
+        let mut buf = Vec::new();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            store.drain_plugin_events(&mut buf);
+            for (_, event) in &buf {
+                store.record_event(id, event);
+            }
+            if buf
+                .iter()
+                .any(|(jid, e)| *jid == id && matches!(e, JobEvent::Exit(_)))
+            {
+                break;
+            }
+            assert!(Instant::now() < deadline, "session job never exited");
+            thread::sleep(Duration::from_millis(20));
+        }
+        store.complete(&lua, id, 3);
+
+        let snap = store
+            .snapshot(id, None, TEST_PLUGIN)
+            .expect("peek after exit");
+        assert_eq!(snap.exit_code, Some(3));
+        assert!(
+            snap.stdout_lines.iter().any(|l| l.contains("hi")),
+            "stdout tail: {:?}",
+            snap.stdout_lines
+        );
+        assert!(
+            snap.stderr_lines.iter().any(|l| l.contains("err")),
+            "stderr tail: {:?}",
+            snap.stderr_lines
+        );
+        let notes = mailbox.drain();
+        assert!(
+            notes.iter().any(|m| m
+                .user_text()
+                .is_some_and(|t| t.contains("exited with code 3"))),
+            "expected exit notify"
+        );
+
+        store.kill_session(&lua, session);
+        assert!(store.snapshot(id, None, TEST_PLUGIN).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn kill_session_does_not_touch_other_sessions() {
+        let lua = Lua::new();
+        let a = MakiId::generate();
+        let b = MakiId::generate();
+        let mut store = make_store();
+        let first = store
+            .start(
+                JobOwner::Session {
+                    session: a,
+                    plugin: Arc::from(TEST_PLUGIN),
+                },
+                "sleep 30",
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        let second = store
+            .start(
+                JobOwner::Session {
+                    session: b,
+                    plugin: Arc::from(TEST_PLUGIN),
+                },
+                "sleep 30",
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        store.kill_session(&lua, a);
+        assert!(store.snapshot(first, None, TEST_PLUGIN).is_none());
+        assert!(store.snapshot(second, None, TEST_PLUGIN).is_some());
+        store.kill_session(&lua, b);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exited_session_job_freezes_elapsed_at_exit() {
+        let lua = Lua::new();
+        let session = MakiId::generate();
+        let mut store = make_store();
+        let id = store
+            .start(
+                JobOwner::Session {
+                    session,
+                    plugin: Arc::from(TEST_PLUGIN),
+                },
+                "sleep 0.1",
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        let mut buf = Vec::new();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            store.drain_plugin_events(&mut buf);
+            for (_, event) in &buf {
+                store.record_event(id, event);
+            }
+            if buf
+                .iter()
+                .any(|(job_id, event)| *job_id == id && matches!(event, JobEvent::Exit(_)))
+            {
+                break;
+            }
+            assert!(Instant::now() < deadline, "session job never exited");
+            thread::sleep(Duration::from_millis(10));
+        }
+        store.complete(&lua, id, 0);
+        let at_exit = store.snapshot(id, None, TEST_PLUGIN).unwrap().elapsed_secs;
+        thread::sleep(Duration::from_millis(200));
+        let later = store.snapshot(id, None, TEST_PLUGIN).unwrap().elapsed_secs;
+        assert_eq!(at_exit, later, "elapsed must freeze once the job exits");
+        store.kill_session(&lua, session);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exited_session_job_stays_listed_and_kill_is_a_noop() {
+        let lua = Lua::new();
+        let session = MakiId::generate();
+        let mut store = make_store();
+        let id = store
+            .start(
+                JobOwner::Session {
+                    session,
+                    plugin: Arc::from(TEST_PLUGIN),
+                },
+                "sleep 0.1",
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        let mut buf = Vec::new();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            store.drain_plugin_events(&mut buf);
+            for (_, event) in &buf {
+                store.record_event(id, event);
+            }
+            if buf
+                .iter()
+                .any(|(job_id, event)| *job_id == id && matches!(event, JobEvent::Exit(_)))
+            {
+                break;
+            }
+            assert!(Instant::now() < deadline, "session job never exited");
+            thread::sleep(Duration::from_millis(10));
+        }
+        store.complete(&lua, id, 0);
+        store.kill(id, None, TEST_PLUGIN);
+        let snap = store
+            .snapshot(id, None, TEST_PLUGIN)
+            .expect("exited session job must stay inspectable");
+        assert_eq!(snap.exit_code, Some(0));
+        assert!(
+            store
+                .list(Some(session), None, TEST_PLUGIN)
+                .iter()
+                .any(|listed| listed.id == id && listed.exit_code == Some(0)),
+            "exited session job must stay listed"
+        );
+        store.kill_session(&lua, session);
     }
 }

--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -16,7 +16,7 @@ use crate::api::fs::expand_tilde;
 use crate::api::util::command::{UiAction, ui_roundtrip, ui_send};
 use crate::api::util::pair::{Pair, err_pair, try_pair};
 use crate::plugin_permissions::PluginPermissions;
-use crate::runtime::{active_task_id, job_task_id, with_jobs};
+use crate::runtime::{active_task_id, job_task_id, strip_traceback, with_jobs};
 
 const DEFAULT_TAIL: usize = 20;
 const MAX_TAIL_LINES: usize = 1024;
@@ -97,6 +97,9 @@ pub(crate) struct JobStore {
     jobs: HashMap<u32, JobMeta>,
     next_id: u32,
     completed_order: VecDeque<u32>,
+    /// Id served by the last [`JobStore::next_matching`], so the next scan
+    /// starts past it.
+    scan_cursor: u32,
 }
 
 struct CheckedOutReceiver {
@@ -111,6 +114,7 @@ impl JobStore {
             jobs: HashMap::new(),
             next_id: 1,
             completed_order: VecDeque::new(),
+            scan_cursor: 0,
         }
     }
 
@@ -270,30 +274,38 @@ impl JobStore {
         }
     }
 
-    pub fn drain_events(&self, owner: &JobOwner, buf: &mut Vec<(u32, JobEvent)>) {
-        buf.clear();
-        for (&id, job) in self.jobs.iter().filter(|(_, job)| job.owner == *owner) {
-            if let Some(ref rx) = job.event_rx {
-                while let Ok(event) = rx.try_recv() {
-                    buf.push((id, event));
-                }
-            }
-        }
+    /// Pop one queued event. Deliberately one at a time: a batch pulled into
+    /// a caller-owned buffer is lost if that caller is dropped mid-delivery,
+    /// and with it the tail and exit code the event carries.
+    pub fn next_event(&mut self, owner: &JobOwner) -> Option<(u32, JobEvent)> {
+        self.next_matching(|job| job.owner == *owner)
     }
 
-    pub fn drain_plugin_events(&self, buf: &mut Vec<(u32, JobEvent)>) {
-        buf.clear();
-        for (&id, job) in self
-            .jobs
-            .iter()
-            .filter(|(_, job)| matches!(job.owner, JobOwner::Plugin(_) | JobOwner::Session { .. }))
-        {
-            if let Some(ref rx) = job.event_rx {
-                while let Ok(event) = rx.try_recv() {
-                    buf.push((id, event));
-                }
+    /// [`Self::next_event`] for the jobs the host pumps: plugin-owned ones and
+    /// session-owned ones, which outlive the task that started them.
+    pub fn next_plugin_event(&mut self) -> Option<(u32, JobEvent)> {
+        self.next_matching(|job| {
+            matches!(job.owner, JobOwner::Plugin(_) | JobOwner::Session { .. })
+        })
+    }
+
+    /// Round-robins over the jobs holding events: taking the first match every
+    /// time would let a job printing faster than we deliver starve the rest.
+    fn next_matching(&mut self, pred: impl Fn(&JobMeta) -> bool) -> Option<(u32, JobEvent)> {
+        let mut past_cursor = None;
+        let mut lowest = None;
+        for (&id, job) in &self.jobs {
+            if !pred(job) || !job.event_rx.as_ref().is_some_and(|rx| !rx.is_empty()) {
+                continue;
             }
+            if id > self.scan_cursor {
+                past_cursor = Some(past_cursor.map_or(id, |seen: u32| seen.min(id)));
+            }
+            lowest = Some(lowest.map_or(id, |seen: u32| seen.min(id)));
         }
+        let id = past_cursor.or(lowest)?;
+        self.scan_cursor = id;
+        Some((id, self.jobs.get(&id)?.event_rx.as_ref()?.try_recv().ok()?))
     }
 
     pub fn record_event(&mut self, job_id: u32, event: &JobEvent) {
@@ -316,6 +328,9 @@ impl JobStore {
         let Some(job) = self.jobs.get_mut(&job_id) else {
             return;
         };
+        if job.elapsed_secs.is_none() {
+            job.elapsed_secs = Some(job.started.elapsed().as_secs());
+        }
         job.exit_code = Some(code);
         if let Some(notify) = job.notify.clone()
             && (code != 0 || notify.on_success)
@@ -374,23 +389,13 @@ impl JobStore {
 
     pub fn snapshot(&self, job_id: u32, task_id: Option<u64>, plugin: &str) -> Option<JobSnapshot> {
         let job = self.jobs.get(&job_id)?;
-        job.can_access(task_id, plugin).then(|| JobSnapshot {
-            id: job_id,
-            command: job.command.clone(),
-            session: job.session(),
-            pid: job.pid,
-            elapsed_secs: job
-                .elapsed_secs
-                .unwrap_or_else(|| job.started.elapsed().as_secs()),
-            exit_code: job.exit_code,
-            stdout_lines: job.stdout_tail.iter().cloned().collect(),
-            stderr_lines: job.stderr_tail.iter().cloned().collect(),
-        })
+        job.can_access(task_id, plugin)
+            .then(|| JobSnapshot::from_job(job_id, job, true))
     }
 
     /// List jobs this plugin can see. Task and plugin jobs leave the map on
-    /// exit; session-owned jobs stay, so exited ones show up here with their
-    /// final tail and exit code.
+    /// exit; session-owned jobs stay so exited ids stay findable. Tails live
+    /// on `snapshot` / `jobinfo`.
     pub fn list(
         &self,
         session: Option<MakiId>,
@@ -401,19 +406,20 @@ impl JobStore {
             .iter()
             .filter(|(_, job)| job.can_access(task_id, plugin))
             .filter(|(_, job)| session.is_none_or(|s| job.session() == Some(s)))
-            .map(|(&id, job)| JobSnapshot {
-                id,
-                command: job.command.clone(),
-                session: job.session(),
-                pid: job.pid,
-                elapsed_secs: job
-                    .elapsed_secs
-                    .unwrap_or_else(|| job.started.elapsed().as_secs()),
-                exit_code: job.exit_code,
-                stdout_lines: job.stdout_tail.iter().cloned().collect(),
-                stderr_lines: job.stderr_tail.iter().cloned().collect(),
-            })
+            .map(|(&id, job)| JobSnapshot::from_job(id, job, false))
             .collect()
+    }
+
+    /// Drop an exited job this plugin can see. Running jobs are left alone.
+    pub fn forget(&mut self, lua: &Lua, job_id: u32, task_id: Option<u64>, plugin: &str) {
+        let Some(job) = self.jobs.get(&job_id) else {
+            return;
+        };
+        if !job.can_access(task_id, plugin) || job.exit_code.is_none() {
+            return;
+        }
+        self.remove(lua, job_id, false);
+        self.completed_order.retain(|&id| id != job_id);
     }
 
     pub fn kill(&mut self, job_id: u32, task_id: Option<u64>, plugin: &str) {
@@ -424,15 +430,16 @@ impl JobStore {
         }
     }
 
-    pub fn kill_owner(&mut self, lua: &Lua, owner: &JobOwner) {
+    pub fn kill_owner(&mut self, lua: &Lua, owner: &JobOwner) -> Vec<u32> {
         let ids = self
             .jobs
             .iter()
             .filter_map(|(&id, job)| (job.owner == *owner).then_some(id))
             .collect::<Vec<_>>();
-        for id in ids {
-            self.remove(lua, id, true);
+        for id in &ids {
+            self.remove(lua, *id, true);
         }
+        ids
     }
 
     pub fn finish(&mut self, lua: &Lua, job_id: u32) {
@@ -499,6 +506,31 @@ pub(crate) struct JobSnapshot {
     pub exit_code: Option<i32>,
     pub stdout_lines: Vec<String>,
     pub stderr_lines: Vec<String>,
+}
+
+impl JobSnapshot {
+    fn from_job(id: u32, job: &JobMeta, tails: bool) -> Self {
+        Self {
+            id,
+            command: job.command.clone(),
+            session: job.session(),
+            pid: job.pid,
+            elapsed_secs: job
+                .elapsed_secs
+                .unwrap_or_else(|| job.started.elapsed().as_secs()),
+            exit_code: job.exit_code,
+            stdout_lines: if tails {
+                job.stdout_tail.iter().cloned().collect()
+            } else {
+                Vec::new()
+            },
+            stderr_lines: if tails {
+                job.stderr_tail.iter().cloned().collect()
+            } else {
+                Vec::new()
+            },
+        }
+    }
 }
 
 impl JobMeta {
@@ -725,18 +757,19 @@ fn parse_notify(opts: &Table, owner: &JobOwner) -> LuaResult<Option<JobNotify>> 
 fn jobinfo(lua: &Lua, #[ctx] plugin: Arc<str>, job_id: u32) -> LuaResult<Pair<Value>> {
     let task_id = active_task_id(lua);
     match with_jobs(lua, |store| store.snapshot(job_id, task_id, &plugin)) {
-        Some(snap) => Ok((Some(Value::Table(snapshot_table(lua, &snap)?)), None)),
+        Some(snap) => Ok((Some(Value::Table(snapshot_table(lua, &snap, true)?)), None)),
         None => Ok(err_pair("job: not found")),
     }
 }
 
 /// List jobs this plugin can see, including exited session-owned jobs (so an
-/// id started before a reload stays findable). Pass a session id to restrict
-/// session-owned jobs to that session.
+/// id started before a reload stays findable). Rows identify the job; call
+/// `jobinfo` for tails. Pass a session id to restrict session-owned jobs to
+/// that session.
 ///
 /// @param session string? Session id filter.
 /// @return (table) array of `{ id, command, pid, session, status, exit_code,
-///   elapsed_secs, stdout_lines, stderr_lines }`.
+///   elapsed_secs }`.
 /// @example
 /// local jobs = maki.fn.joblist(maki.session.current())
 #[lua_fn(guard = Run)]
@@ -752,12 +785,12 @@ fn joblist(lua: &Lua, #[ctx] plugin: Arc<str>, session: Option<String>) -> LuaRe
     let snaps = with_jobs(lua, |store| store.list(filter, task_id, &plugin));
     let result = lua.create_table()?;
     for (i, snap) in snaps.iter().enumerate() {
-        result.set(i + 1, snapshot_table(lua, snap)?)?;
+        result.set(i + 1, snapshot_table(lua, snap, false)?)?;
     }
     Ok((Some(Value::Table(result)), None))
 }
 
-fn snapshot_table(lua: &Lua, snap: &JobSnapshot) -> LuaResult<Table> {
+fn snapshot_table(lua: &Lua, snap: &JobSnapshot, tails: bool) -> LuaResult<Table> {
     let row = lua.create_table()?;
     row.set("id", snap.id)?;
     row.set("command", snap.command.as_str())?;
@@ -773,16 +806,18 @@ fn snapshot_table(lua: &Lua, snap: &JobSnapshot) -> LuaResult<Table> {
         },
     )?;
     row.set("exit_code", snap.exit_code)?;
-    let stdout = lua.create_table()?;
-    for (i, line) in snap.stdout_lines.iter().enumerate() {
-        stdout.set(i + 1, line.as_str())?;
+    if tails {
+        let stdout = lua.create_table()?;
+        for (i, line) in snap.stdout_lines.iter().enumerate() {
+            stdout.set(i + 1, line.as_str())?;
+        }
+        row.set("stdout_lines", stdout)?;
+        let stderr = lua.create_table()?;
+        for (i, line) in snap.stderr_lines.iter().enumerate() {
+            stderr.set(i + 1, line.as_str())?;
+        }
+        row.set("stderr_lines", stderr)?;
     }
-    row.set("stdout_lines", stdout)?;
-    let stderr = lua.create_table()?;
-    for (i, line) in snap.stderr_lines.iter().enumerate() {
-        stderr.set(i + 1, line.as_str())?;
-    }
-    row.set("stderr_lines", stderr)?;
     Ok(row)
 }
 
@@ -800,6 +835,20 @@ fn jobstop(lua: &Lua, #[ctx] plugin: Arc<str>, job_id: u32) -> LuaResult<()> {
     Ok(())
 }
 
+/// Drop an exited session-owned job from the store. Running jobs are left
+/// alone; use `jobstop` to kill those. Unknown ids are a no-op.
+///
+/// @param job_id integer Job id returned by `jobstart`.
+/// @return
+/// @example
+/// maki.fn.jobforget(id)
+#[lua_fn(guard = Run)]
+fn jobforget(lua: &Lua, #[ctx] plugin: Arc<str>, job_id: u32) -> LuaResult<()> {
+    let task_id = active_task_id(lua);
+    with_jobs(lua, |store| store.forget(lua, job_id, task_id, &plugin));
+    Ok(())
+}
+
 /// Wait for a job to finish and collect its output. Returns a result
 /// table with `stdout`, `stderr`, `exit_code`, and `truncated`. `truncated`
 /// is false when the collected lines are the full output; a job that already
@@ -809,7 +858,8 @@ fn jobstop(lua: &Lua, #[ctx] plugin: Arc<str>, job_id: u32) -> LuaResult<()> {
 ///
 /// While waiting, the job's `on_stdout`, `on_stderr`, and `on_exit`
 /// callbacks fire as events arrive (like Neovim), so you can stream
-/// output into a buffer while parked here.
+/// output into a buffer while parked here. A job that already exited
+/// answers from its snapshot instead and fires no callbacks.
 ///
 /// @param job_id integer Job id returned by `jobstart`.
 /// @param timeout_ms integer? Maximum wait in milliseconds (default 30000).
@@ -860,7 +910,12 @@ async fn jobwait(
         let Some(event) = event else {
             return Ok(mlua::Value::Nil);
         };
-        deliver_job_event(&lua, job_id, &event)?;
+        // A failing callback must not abort the wait: the event is already
+        // recorded and the exit still needs collecting. Same policy as the
+        // detached dispatch pump.
+        if let Err(e) = deliver_job_event(&lua, job_id, &event).await {
+            tracing::warn!(job_id, error = %strip_traceback(&e), "jobwait callback failed");
+        }
         match event {
             JobEvent::Stdout(line) => stdout_lines.push(line),
             JobEvent::Stderr(line) => stderr_lines.push(line),
@@ -879,7 +934,12 @@ async fn jobwait(
 /// Fire the job's Lua callback for {event} (if any) and mark the job
 /// dead on exit. Shared by `jobwait` and the async dispatch loop so
 /// both deliver events identically.
-pub(crate) fn deliver_job_event(lua: &Lua, job_id: u32, event: &JobEvent) -> LuaResult<()> {
+///
+/// The callback runs in a fresh coroutine so it may suspend (the
+/// `maki.fs.*` helpers park on `smol::unblock`); resumed inline from a
+/// poll loop it would die with "attempt to yield across metamethod /
+/// C-call boundary" on its first suspension.
+pub(crate) async fn deliver_job_event(lua: &Lua, job_id: u32, event: &JobEvent) -> LuaResult<()> {
     let callback = with_jobs(lua, |store| {
         store.record_event(job_id, event);
         store
@@ -896,7 +956,9 @@ pub(crate) fn deliver_job_event(lua: &Lua, job_id: u32, event: &JobEvent) -> Lua
             }
             JobEvent::Exit(code) => Value::Integer(*code as i64),
         };
-        callback.call::<()>((job_id, arg))?;
+        lua.create_thread(callback)?
+            .into_async::<()>((job_id, arg))?
+            .await?;
     }
     Ok(())
 }
@@ -987,8 +1049,9 @@ lua_table! {
         perms: &PluginPermissions,
         tx: Option<flume::Sender<UiAction>>,
     ), DOCS [
-        jobstart(perms, plugin), jobstop(perms, plugin), jobwait(perms, plugin),
-        jobinfo(perms, plugin), joblist(perms, plugin), executable(perms),
+        jobstart(perms, plugin), jobstop(perms, plugin), jobforget(perms, plugin),
+        jobwait(perms, plugin), jobinfo(perms, plugin), joblist(perms, plugin),
+        executable(perms),
         winsaveview(tx), winrestview(tx),
     ]
 }
@@ -999,6 +1062,32 @@ mod tests {
     use crate::api::util::command::{NO_UI_ERR, WinView};
 
     const TEST_PLUGIN: &str = "test-plugin";
+    const JOB_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+    const JOB_POLL_INTERVAL: Duration = Duration::from_millis(10);
+    const NEVER_EXITED: &str = "job never reported its exit";
+
+    /// Pull events until {id} reports its exit, so assertions run against a
+    /// job that is certainly done.
+    fn collect_until_exit(
+        id: u32,
+        mut next: impl FnMut() -> Option<(u32, JobEvent)>,
+    ) -> Vec<(u32, JobEvent)> {
+        let deadline = Instant::now() + JOB_EXIT_TIMEOUT;
+        let mut events = Vec::new();
+        loop {
+            while let Some(event) = next() {
+                events.push(event);
+            }
+            if events
+                .iter()
+                .any(|(job_id, event)| *job_id == id && matches!(event, JobEvent::Exit(_)))
+            {
+                return events;
+            }
+            assert!(Instant::now() < deadline, "{NEVER_EXITED}");
+            thread::sleep(JOB_POLL_INTERVAL);
+        }
+    }
 
     fn make_store() -> JobStore {
         JobStore::new()
@@ -1230,59 +1319,51 @@ mod tests {
     }
 
     #[test]
-    fn drain_events_filters_by_owner() {
+    fn next_event_filters_by_owner() {
         let mut store = make_store();
         let id = start_echo(&mut store);
         let plugin_id = store
             .start(plugin_owner(), "echo plugin", None, None, None, None, None)
             .unwrap();
 
-        let mut buf = Vec::new();
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
-        loop {
-            store.drain_events(&task_owner(1), &mut buf);
-            if buf
-                .iter()
-                .any(|(jid, e)| *jid == id && matches!(e, JobEvent::Exit(_)))
-            {
-                break;
-            }
-            if std::time::Instant::now() > deadline {
-                panic!("should receive exit event for completed job");
-            }
-            std::thread::sleep(Duration::from_millis(50));
-        }
-        assert!(buf.iter().all(|(job_id, _)| *job_id != plugin_id));
+        let task_events = collect_until_exit(id, || store.next_event(&task_owner(1)));
+        assert!(task_events.iter().all(|(job_id, _)| *job_id != plugin_id));
 
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
-        loop {
-            store.drain_plugin_events(&mut buf);
-            if buf
-                .iter()
-                .any(|(job_id, event)| *job_id == plugin_id && matches!(event, JobEvent::Exit(_)))
-            {
-                break;
-            }
-            if std::time::Instant::now() > deadline {
-                panic!("should receive plugin job exit event");
-            }
-            thread::sleep(Duration::from_millis(50));
-        }
-        assert!(buf.iter().all(|(job_id, _)| *job_id != id));
+        let plugin_events = collect_until_exit(plugin_id, || store.next_plugin_event());
+        assert!(plugin_events.iter().all(|(job_id, _)| *job_id != id));
     }
 
     #[test]
-    fn drain_events_empty_after_take() {
+    fn next_event_is_empty_after_take() {
         let mut store = make_store();
         let id = start_echo(&mut store);
         let _rx = store.take_receiver(id, Some(1), TEST_PLUGIN).unwrap();
 
-        let mut buf = Vec::new();
-        store.drain_events(&task_owner(1), &mut buf);
         assert!(
-            buf.is_empty(),
-            "drained receiver yields no events via drain_events"
+            store.next_event(&task_owner(1)).is_none(),
+            "a checked out receiver yields no events to the pump"
         );
+    }
+
+    #[test]
+    fn next_event_round_robins_so_a_chatty_job_cannot_starve_its_sibling() {
+        const QUEUED_PER_JOB: usize = 2;
+        let mut store = make_store();
+        for id in [1, 2] {
+            let (tx, rx) = flume::unbounded();
+            for _ in 0..QUEUED_PER_JOB {
+                tx.send(JobEvent::Stdout("spam".into())).unwrap();
+            }
+            let mut job = stub_job(task_owner(1), None, None);
+            job.event_rx = Some(rx);
+            store.jobs.insert(id, job);
+        }
+
+        let served: Vec<u32> = std::iter::from_fn(|| store.next_event(&task_owner(1)))
+            .map(|(id, _)| id)
+            .collect();
+
+        assert_eq!(served, [1, 2, 1, 2]);
     }
 
     fn lua_with_view(tx: Option<flume::Sender<UiAction>>) -> Lua {
@@ -1367,7 +1448,7 @@ mod tests {
                 .insert(1, stub_job(task_owner(1), None, Some(callback_key)));
         });
 
-        assert!(deliver_job_event(&lua, 1, &JobEvent::Exit(0)).is_err());
+        assert!(smol::block_on(deliver_job_event(&lua, 1, &JobEvent::Exit(0))).is_err());
         assert!(with_jobs(&lua, |store| store.is_empty(&task_owner(1))));
     }
 
@@ -1493,21 +1574,8 @@ mod tests {
         store.detach_plugin_callbacks(&lua, TEST_PLUGIN);
         assert!(store.jobs.contains_key(&id), "detach must keep the job");
 
-        let mut buf = Vec::new();
-        let deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            store.drain_plugin_events(&mut buf);
-            for (_, event) in &buf {
-                store.record_event(id, event);
-            }
-            if buf
-                .iter()
-                .any(|(jid, e)| *jid == id && matches!(e, JobEvent::Exit(_)))
-            {
-                break;
-            }
-            assert!(Instant::now() < deadline, "session job never exited");
-            thread::sleep(Duration::from_millis(20));
+        for (_, event) in collect_until_exit(id, || store.next_plugin_event()) {
+            store.record_event(id, &event);
         }
         store.complete(&lua, id, 3);
 
@@ -1578,48 +1646,98 @@ mod tests {
         store.kill_session(&lua, b);
     }
 
-    #[cfg(unix)]
     #[test]
-    fn exited_session_job_freezes_elapsed_at_exit() {
+    fn snapshot_elapsed_freezes_at_recorded_exit() {
+        const PAST_SECS: u64 = 45;
+        let session = MakiId::generate();
+        let mut store = make_store();
+        let mut job = stub_job(
+            JobOwner::Session {
+                session,
+                plugin: Arc::from(TEST_PLUGIN),
+            },
+            None,
+            None,
+        );
+        job.started = Instant::now()
+            .checked_sub(Duration::from_secs(PAST_SECS))
+            .expect("clock has enough history");
+        store.jobs.insert(1, job);
+
+        store.record_event(1, &JobEvent::Exit(0));
+        let at_exit = store.snapshot(1, None, TEST_PLUGIN).unwrap().elapsed_secs;
+        assert!(
+            at_exit >= PAST_SECS,
+            "elapsed at exit should reflect the backdated start, got {at_exit}"
+        );
+
+        store.jobs.get_mut(&1).unwrap().started = Instant::now();
+        let later = store.snapshot(1, None, TEST_PLUGIN).unwrap().elapsed_secs;
+        assert_eq!(later, at_exit, "elapsed must freeze once the job exits");
+    }
+
+    #[test]
+    fn list_omits_tails() {
+        let mut store = make_store();
+        let id = start_echo(&mut store);
+        store.record_event(id, &JobEvent::Stdout("hello".into()));
+        let listed = store.list(None, Some(1), TEST_PLUGIN);
+        assert!(
+            listed
+                .iter()
+                .any(|s| s.id == id && s.stdout_lines.is_empty() && s.stderr_lines.is_empty()),
+            "joblist must not clone tails"
+        );
+        assert_eq!(
+            store
+                .snapshot(id, Some(1), TEST_PLUGIN)
+                .unwrap()
+                .stdout_lines,
+            ["hello"]
+        );
+    }
+
+    #[test]
+    fn forget_drops_exited_session_jobs_only() {
         let lua = Lua::new();
         let session = MakiId::generate();
         let mut store = make_store();
-        let id = store
-            .start(
+        store.jobs.insert(
+            1,
+            stub_job(
                 JobOwner::Session {
                     session,
                     plugin: Arc::from(TEST_PLUGIN),
                 },
-                "sleep 0.1",
                 None,
                 None,
-                None,
-                None,
-                None,
-            )
-            .unwrap();
-        let mut buf = Vec::new();
-        let deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            store.drain_plugin_events(&mut buf);
-            for (_, event) in &buf {
-                store.record_event(id, event);
-            }
-            if buf
+            ),
+        );
+
+        store.forget(&lua, 1, None, TEST_PLUGIN);
+        assert!(
+            store.snapshot(1, None, TEST_PLUGIN).is_some(),
+            "running job must stay"
+        );
+
+        store.record_event(1, &JobEvent::Exit(0));
+        store.complete(&lua, 1, 0);
+        assert!(
+            store
+                .list(Some(session), None, TEST_PLUGIN)
                 .iter()
-                .any(|(job_id, event)| *job_id == id && matches!(event, JobEvent::Exit(_)))
-            {
-                break;
-            }
-            assert!(Instant::now() < deadline, "session job never exited");
-            thread::sleep(Duration::from_millis(10));
-        }
-        store.complete(&lua, id, 0);
-        let at_exit = store.snapshot(id, None, TEST_PLUGIN).unwrap().elapsed_secs;
-        thread::sleep(Duration::from_millis(200));
-        let later = store.snapshot(id, None, TEST_PLUGIN).unwrap().elapsed_secs;
-        assert_eq!(at_exit, later, "elapsed must freeze once the job exits");
-        store.kill_session(&lua, session);
+                .any(|s| s.id == 1)
+        );
+
+        store.forget(&lua, 1, None, "other-plugin");
+        assert!(
+            store.snapshot(1, None, TEST_PLUGIN).is_some(),
+            "other plugin cannot forget"
+        );
+
+        store.forget(&lua, 1, None, TEST_PLUGIN);
+        assert!(store.snapshot(1, None, TEST_PLUGIN).is_none());
+        assert!(store.list(Some(session), None, TEST_PLUGIN).is_empty());
     }
 
     #[cfg(unix)]
@@ -1642,21 +1760,8 @@ mod tests {
                 None,
             )
             .unwrap();
-        let mut buf = Vec::new();
-        let deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            store.drain_plugin_events(&mut buf);
-            for (_, event) in &buf {
-                store.record_event(id, event);
-            }
-            if buf
-                .iter()
-                .any(|(job_id, event)| *job_id == id && matches!(event, JobEvent::Exit(_)))
-            {
-                break;
-            }
-            assert!(Instant::now() < deadline, "session job never exited");
-            thread::sleep(Duration::from_millis(10));
+        for (_, event) in collect_until_exit(id, || store.next_plugin_event()) {
+            store.record_event(id, &event);
         }
         store.complete(&lua, id, 0);
         store.kill(id, None, TEST_PLUGIN);

--- a/maki-lua/src/api/fs.rs
+++ b/maki-lua/src/api/fs.rs
@@ -425,6 +425,32 @@ async fn write(_lua: Lua, path: String, content: String) -> LuaResult<Pair<bool>
     Ok(pair(smol::fs::write(&abs, content).await.map(|()| true)))
 }
 
+/// Append {content} to the file at {path}, creating it (but not its parent
+/// directory) if it does not exist.
+///
+/// @param path string Destination file path. `~/` is expanded.
+/// @param content string Text to append.
+/// @return (true?, string?) `true` on success, or nil plus an error message.
+/// @example
+/// local ok, err = maki.fs.append("out.log", "line\n")
+/// if err then print("append failed: " .. err) end
+#[lua_fn(guard = FsWrite)]
+async fn append(_lua: Lua, path: String, content: String) -> LuaResult<Pair<bool>> {
+    let abs = make_absolute(&path)?;
+    // `smol::fs::File` writes through a background task and answers before
+    // the bytes reach the file, so a plain `unblock` keeps append ordered.
+    let result = smol::unblock(move || {
+        use std::io::Write;
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&abs)
+            .and_then(|mut f| f.write_all(content.as_bytes()))
+    })
+    .await;
+    Ok(pair(result.map(|()| true)))
+}
+
 /// Atomically replace {path} with {content}. The parent directory must exist.
 /// Readers observe either the old file or the complete new file.
 /// Existing file permissions are preserved. On Unix, new files use mode 0600.
@@ -678,7 +704,7 @@ lua_table! {
     "maki.fs" => pub(crate) fn create_fs_table(perms: &PluginPermissions), DOCS [
         read(perms), read_bytes(perms), metadata(perms), dirname, basename,
         joinpath, normalize, abspath, parents, root(perms), relpath, ext,
-        dir(perms), write(perms), atomic_write(perms), rm(perms), mkdir(perms),
+        dir(perms), write(perms), append(perms), atomic_write(perms), rm(perms), mkdir(perms),
         glob(perms), grep(perms),
     ]
 }
@@ -989,6 +1015,64 @@ mod tests {
 
         let error = smol::block_on(
             atomic_write.call_async::<(Value, Value)>((file.to_str().unwrap(), FIRST_CONTENT)),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains(FS_WRITE_PERMISSION));
+        assert!(!file.exists());
+    }
+
+    #[test]
+    fn append_creates_then_appends_to_file() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("out.log");
+        let lua = Lua::new();
+        let table = create_fs_table(&lua, &PluginPermissions::trusted()).unwrap();
+        let append: mlua::Function = table.get("append").unwrap();
+
+        let (ok, err): (Value, Value) =
+            smol::block_on(append.call_async((file.to_str().unwrap(), FIRST_CONTENT))).unwrap();
+        assert_eq!(ok, Value::Boolean(true));
+        assert_eq!(err, Value::Nil);
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), FIRST_CONTENT);
+
+        let (ok, err): (Value, Value) =
+            smol::block_on(append.call_async((file.to_str().unwrap(), REPLACEMENT_CONTENT)))
+                .unwrap();
+        assert_eq!(ok, Value::Boolean(true));
+        assert_eq!(err, Value::Nil);
+        assert_eq!(
+            std::fs::read_to_string(&file).unwrap(),
+            format!("{FIRST_CONTENT}{REPLACEMENT_CONTENT}")
+        );
+    }
+
+    #[test]
+    fn append_returns_error_when_parent_is_missing() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("missing/out.log");
+        let lua = Lua::new();
+        let table = create_fs_table(&lua, &PluginPermissions::trusted()).unwrap();
+        let append: mlua::Function = table.get("append").unwrap();
+
+        let (ok, err): (Value, Value) =
+            smol::block_on(append.call_async((file.to_str().unwrap(), FIRST_CONTENT))).unwrap();
+
+        assert_eq!(ok, Value::Nil);
+        assert!(matches!(err, Value::String(_)));
+        assert!(!file.exists());
+    }
+
+    #[test]
+    fn append_requires_fs_write_permission() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("out.log");
+        let lua = Lua::new();
+        let table = create_fs_table(&lua, &PluginPermissions::denied()).unwrap();
+        let append: mlua::Function = table.get("append").unwrap();
+
+        let error = smol::block_on(
+            append.call_async::<(Value, Value)>((file.to_str().unwrap(), FIRST_CONTENT)),
         )
         .unwrap_err();
 

--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -514,6 +514,10 @@ pub(crate) fn ui_send(
 /// Send an action carrying a reply channel and await the answer. Only
 /// works from a callback: the loop drains `UiAction` between frames, so a
 /// call at config load time would wait forever.
+///
+/// No deadline on purpose: the loop legitimately stops answering for a long
+/// time (`open_editor` holds it for as long as the editor is up). Teardown
+/// drops the receiver instead, which fails the send outright.
 pub(crate) async fn ui_roundtrip<T>(
     tx: Option<&flume::Sender<UiAction>>,
     action: impl FnOnce(flume::Sender<T>) -> UiAction,
@@ -603,6 +607,16 @@ mod tests {
         assert_eq!(reader.load().generation, 1);
         writer.publish(vec![]);
         assert_eq!(reader.load().generation, 2);
+    }
+
+    #[test]
+    fn ui_roundtrip_fails_once_the_loop_drops_its_receiver() {
+        let (tx, rx) = flume::unbounded();
+        drop(rx);
+        let result = smol::block_on(ui_roundtrip(Some(&tx), |reply_tx| UiAction::WinSaveView {
+            reply_tx,
+        }));
+        assert_eq!(result.err(), Some(NO_UI_ERR));
     }
 
     #[test_case(Dimension::Abs(42), 200 => 42 ; "abs_ignores_total")]

--- a/maki-lua/src/api/util/dispatch.rs
+++ b/maki-lua/src/api/util/dispatch.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use mlua::{FromLuaMulti, Function, IntoLuaMulti, Lua};
 
-use crate::runtime::TaskScope;
+use crate::runtime::{TaskScope, strip_traceback};
 
 pub(crate) const MAX_HOOK_DEPTH: u8 = 8;
 
@@ -70,7 +70,7 @@ pub(crate) fn call_isolated<R: FromLuaMulti>(
     match func.call::<R>(args) {
         Ok(r) => Some(r),
         Err(e) => {
-            tracing::warn!(seam, plugin, error = %e, "plugin callback failed");
+            tracing::warn!(seam, plugin, error = %strip_traceback(&e), "plugin callback failed");
             None
         }
     }

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -33,6 +33,7 @@ pub mod test_support {
     use crate::api::util::command::{
         HintEntries, HintReader, HintWriter, LuaCommandInfo, LuaCommandReader, LuaCommandWriter,
     };
+    use maki_storage::id::MakiId;
 
     pub struct LuaCommandWriterHandle(LuaCommandWriter);
 
@@ -110,10 +111,10 @@ pub mod test_support {
         }
 
         /// Next `SessionEnd` request as the session being left behind.
-        pub fn try_recv_end_session(&self) -> Option<maki_storage::id::MakiId> {
+        pub fn try_recv_end_session(&self) -> Option<MakiId> {
             use crate::runtime::Request;
             while let Ok(req) = self.0.try_recv() {
-                if let Request::EndSession { session } = req {
+                if let Request::EndSession { session, .. } = req {
                     return Some(session);
                 }
             }

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -108,6 +108,17 @@ pub mod test_support {
             }
             None
         }
+
+        /// Next `SessionEnd` request as the session being left behind.
+        pub fn try_recv_end_session(&self) -> Option<maki_storage::id::MakiId> {
+            use crate::runtime::Request;
+            while let Ok(req) = self.0.try_recv() {
+                if let Request::EndSession { session } = req {
+                    return Some(session);
+                }
+            }
+            None
+        }
     }
 
     pub fn probed_event_handle() -> (crate::EventHandle, RequestProbe) {

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -952,6 +952,12 @@ impl EventHandle {
         });
     }
 
+    /// Fire `SessionEnd` for a session that is going away. Call from every
+    /// session-end path (reset, load, delete, shutdown, ACP, headless).
+    pub fn end_session(&self, session: maki_storage::id::MakiId) {
+        let _ = self.tx.try_send(Request::EndSession { session });
+    }
+
     pub fn run_keybind_callback(&self, id: u64) -> bool {
         self.prio_tx
             .try_send(Request::RunKeybindCallback { id })

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -952,8 +952,8 @@ impl EventHandle {
         });
     }
 
-    /// Fire `SessionEnd` for a session that is going away. Call from every
-    /// session-end path (reset, load, delete, shutdown, ACP, headless).
+    /// Kill session-owned jobs and fire `SessionEnd`. Call from every
+    /// session-end path so a Lua monitor can stay a plugin.
     pub fn end_session(&self, session: maki_storage::id::MakiId) {
         let _ = self.tx.try_send(Request::EndSession { session });
     }

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use include_dir::{Dir, include_dir};
 use maki_agent::permissions::PluginRuleStore;
@@ -22,6 +22,7 @@ use crate::runtime::{
     self, ClickFallback, ConfigScope, LoadChunk, LoadContext, LuaThread, Request, RestoreItem,
 };
 use maki_agent::prompt::ResolvedSlots;
+use maki_storage::id::MakiId;
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 const USER_PLUGIN: &str = "user";
@@ -952,10 +953,48 @@ impl EventHandle {
         });
     }
 
-    /// Kill session-owned jobs and fire `SessionEnd`. Call from every
-    /// session-end path so a Lua monitor can stay a plugin.
-    pub fn end_session(&self, session: maki_storage::id::MakiId) {
-        let _ = self.tx.try_send(Request::EndSession { session });
+    /// Queue the kill of session-owned jobs and the `SessionEnd` dispatch,
+    /// then return. Call from every session-end path so a Lua monitor can
+    /// stay a plugin. Process exit wants [`Self::end_sessions_blocking`].
+    pub fn end_session(&self, session: MakiId) {
+        let _ = self.tx.try_send(Request::EndSession {
+            session,
+            reply: None,
+        });
+    }
+
+    /// [`Self::end_session`] for process exit: block until the handlers ran
+    /// and the jobs were reaped, so the `Shutdown` that follows on the
+    /// priority lane cannot skip ahead of them.
+    ///
+    /// Every session is queued first and the deadline is shared, so quitting
+    /// with many tabs open costs one `SHUTDOWN_TIMEOUT`, not one per tab.
+    pub fn end_sessions_blocking(&self, sessions: impl IntoIterator<Item = MakiId>) {
+        let waits: Vec<_> = sessions
+            .into_iter()
+            .filter_map(|session| Some((session, self.send_end_session(session)?)))
+            .collect();
+        let deadline = Instant::now() + SHUTDOWN_TIMEOUT;
+        for (session, reply_rx) in waits {
+            let left = deadline.saturating_duration_since(Instant::now());
+            if reply_rx.recv_timeout(left).is_err() {
+                tracing::warn!(
+                    session = %session,
+                    "SessionEnd did not finish within timeout, continuing teardown"
+                );
+            }
+        }
+    }
+
+    fn send_end_session(&self, session: MakiId) -> Option<flume::Receiver<()>> {
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        self.tx
+            .send(Request::EndSession {
+                session,
+                reply: Some(reply_tx),
+            })
+            .ok()?;
+        Some(reply_rx)
     }
 
     pub fn run_keybind_callback(&self, id: u64) -> bool {

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -986,6 +986,14 @@ impl EventHandle {
         }
     }
 
+    /// [`Self::end_sessions_blocking`] parked on a spare thread. ACP calls
+    /// this from its executor, where blocking would freeze stdin for the
+    /// whole grace period.
+    pub async fn end_session_async(&self, session: MakiId) {
+        let handle = self.clone();
+        smol::unblock(move || handle.end_sessions_blocking([session])).await;
+    }
+
     fn send_end_session(&self, session: MakiId) -> Option<flume::Receiver<()>> {
         let (reply_tx, reply_rx) = flume::bounded(1);
         self.tx

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -289,6 +289,9 @@ pub enum Request {
         event: String,
         data: Value,
     },
+    EndSession {
+        session: maki_storage::id::MakiId,
+    },
     ClickTool {
         tool_use_id: String,
         /// 1-based line in the tool's live buffer; 0 means the click landed
@@ -3190,6 +3193,14 @@ pub fn spawn(
                             if event == TURN_END_EVENT {
                                 rt.lua.gc_collect().ok();
                             }
+                        }
+                        Request::EndSession { session } => {
+                            let data = json_to_lua(
+                                &rt.lua,
+                                &serde_json::json!({ "session_id": session.to_string() }),
+                            )
+                            .unwrap_or(LuaValue::Nil);
+                            crate::api::autocmd::dispatch(&rt.lua, "SessionEnd", None, data);
                         }
                         Request::Describe {
                             plugin,

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -289,6 +289,7 @@ pub enum Request {
         event: String,
         data: Value,
     },
+    /// Reap session-owned jobs and fire `SessionEnd`.
     EndSession {
         session: maki_storage::id::MakiId,
     },
@@ -1702,6 +1703,7 @@ impl LuaRuntime {
         self.warm_tools.borrow_mut().clear();
         with_jobs(&self.lua, |store| {
             store.kill_owner(&self.lua, &JobOwner::Plugin(Arc::from(name)));
+            store.detach_plugin_callbacks(&self.lua, name);
         });
         if let Some(mut store) = self.lua.app_data_mut::<PluginOptionSpecs>() {
             store.remove(name);
@@ -3195,12 +3197,17 @@ pub fn spawn(
                             }
                         }
                         Request::EndSession { session } => {
+                            // Handlers may still inspect or stop the jobs, so
+                            // the event fires before the reap.
                             let data = json_to_lua(
                                 &rt.lua,
                                 &serde_json::json!({ "session_id": session.to_string() }),
                             )
                             .unwrap_or(LuaValue::Nil);
                             crate::api::autocmd::dispatch(&rt.lua, "SessionEnd", None, data);
+                            with_jobs(&rt.lua, |store| {
+                                store.kill_session(&rt.lua, session);
+                            });
                         }
                         Request::Describe {
                             plugin,

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -26,10 +26,11 @@ use mlua::{Chunk, ChunkMode, Compiler, Function, Lua, RegistryKey, Table, Value 
 use serde_json::Value;
 
 use maki_config::RawConfig;
+use maki_storage::id::MakiId;
 
 use crate::api::autocmd::AutocmdStore;
 use crate::api::create_maki_global;
-use crate::api::r#fn::{JobOwner, JobStore, deliver_job_event};
+use crate::api::r#fn::{JobEvent, JobOwner, JobStore, deliver_job_event};
 use crate::api::keymap::KeymapReader;
 use crate::api::keymap::{KeymapStore, KeymapWriter};
 use crate::api::options::{PluginOptionSpecs, PluginOpts, collect_plugin_options};
@@ -98,6 +99,11 @@ static NEXT_TASK_ID: AtomicU64 = AtomicU64::new(1);
 /// tool's rendered output.
 const RESTORE_ITEM_TIMEOUT: Duration = Duration::from_secs(60);
 const TURN_END_EVENT: &str = "TurnEnd";
+/// Cap on the last delivery pass a scope makes before it reaps its jobs. A job
+/// printing faster than we deliver always has another event queued, so an
+/// unbounded pass would never reach the reap.
+const FINAL_DRAIN_BUDGET: usize = 256;
+const SESSION_END_EVENT: &str = "SessionEnd";
 /// Without a cap, a runaway plugin OOM-kills the whole process.
 /// With one, it hits a catchable Lua error instead.
 const LUA_MEMORY_LIMIT: usize = 512 * 1024 * 1024;
@@ -291,7 +297,8 @@ pub enum Request {
     },
     /// Reap session-owned jobs and fire `SessionEnd`.
     EndSession {
-        session: maki_storage::id::MakiId,
+        session: MakiId,
+        reply: Option<flume::Sender<()>>,
     },
     ClickTool {
         tool_use_id: String,
@@ -322,6 +329,21 @@ pub enum Request {
         live: LiveCtx,
         ctx: Box<LuaCtx>,
         reply: flume::Sender<()>,
+    },
+}
+
+/// Host-fired hooks, taken off the request loop. Their handlers can suspend
+/// (job and `maki.fs` awaits), and awaiting one inline would stop the loop
+/// from serving anything else, including the priority lane. One consumer
+/// keeps them in the order the host fired them.
+enum HostHook {
+    Autocmd {
+        event: String,
+        data: Value,
+    },
+    EndSession {
+        session: MakiId,
+        reply: Option<flume::Sender<()>>,
     },
 }
 
@@ -1056,22 +1078,79 @@ pub(crate) async fn run_command_scoped<F: Future>(lua: &Lua, depth: u8, fut: F) 
 
 async fn run_scoped<F: Future>(lua: &Lua, scope: TaskScope, fut: F) -> F::Output {
     let handle = Arc::clone(scope.handle());
+    let owner = JobOwner::Task(lock_cell(&handle).id);
     let pump = async {
-        let mut event_buf = Vec::new();
         loop {
-            let owner = JobOwner::Task(lock_cell(&handle).id);
-            with_jobs(lua, |store| store.drain_events(&owner, &mut event_buf));
-            for (job_id, event) in event_buf.drain(..) {
-                if let Err(e) = deliver_job_event(lua, job_id, &event) {
-                    tracing::warn!(error = %strip_traceback(&e), "detached job callback failed");
-                }
-            }
+            deliver_pending(lua, usize::MAX, || {
+                with_jobs(lua, |store| store.next_event(&owner))
+            })
+            .await;
             smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
         }
     };
     let out = scope.scope_future(smol::future::or(fut, pump)).await;
+    // `or` drops the pump the moment {fut} wins, so one last pass under the
+    // same scope delivers whatever arrived in between; the scope teardown
+    // right after reaps any task job. Only a callback caught mid-suspend at
+    // that instant is lost, never a whole event: `deliver_pending` leaves
+    // events in the channel until the delivery that records them starts.
+    scope
+        .scope_future(deliver_pending(lua, FINAL_DRAIN_BUDGET, || {
+            with_jobs(lua, |store| store.next_event(&owner))
+        }))
+        .await;
     drop(scope);
     out
+}
+
+async fn run_host_hook(lua: &Lua, hook: HostHook) {
+    match hook {
+        HostHook::Autocmd { event, data } => {
+            let data = json_to_lua(lua, &data).unwrap_or(LuaValue::Nil);
+            let is_turn_end = event == TURN_END_EVENT;
+            crate::api::autocmd::dispatch(lua.clone(), event, None, data).await;
+            if is_turn_end {
+                lua.gc_collect().ok();
+            }
+        }
+        HostHook::EndSession { session, reply } => {
+            // Handlers may still inspect or stop the jobs, so the event fires
+            // before the reap.
+            let data = json_to_lua(
+                lua,
+                &serde_json::json!({ "session_id": session.to_string() }),
+            )
+            .unwrap_or(LuaValue::Nil);
+            crate::api::autocmd::dispatch(lua.clone(), SESSION_END_EVENT.to_owned(), None, data)
+                .await;
+            with_jobs(lua, |store| store.kill_session(lua, session));
+            if let Some(reply) = reply {
+                let _ = reply.send(());
+            }
+        }
+    }
+}
+
+/// Fire job callbacks for up to {budget} queued events, one at a time so a
+/// dropped caller cannot strand a batch. Failures are logged and the drain
+/// continues: the event is already recorded and the next one still needs
+/// delivering.
+async fn deliver_pending(
+    lua: &Lua,
+    budget: usize,
+    mut next: impl FnMut() -> Option<(u32, JobEvent)>,
+) {
+    for _ in 0..budget {
+        let Some((job_id, event)) = next() else {
+            return;
+        };
+        if let Err(e) = deliver_job_event(lua, job_id, &event).await {
+            tracing::warn!(job_id, error = %strip_traceback(&e), "job callback failed");
+        }
+        // A callback with nothing to await never yields, so a job printing
+        // faster than we deliver would hold the executor here forever.
+        smol::future::yield_now().await;
+    }
 }
 
 impl Drop for TaskScope {
@@ -1082,7 +1161,14 @@ impl Drop for TaskScope {
             cell.id
         };
         with_jobs(&self.lua, |store| {
-            store.kill_owner(&self.lua, &JobOwner::Task(task_id));
+            let leftovers = store.kill_owner(&self.lua, &JobOwner::Task(task_id));
+            if !leftovers.is_empty() {
+                tracing::warn!(
+                    task = task_id,
+                    jobs = ?leftovers,
+                    "scope finished with live jobs; they were killed"
+                );
+            }
         });
         match self.prev.take() {
             Some(p) => {
@@ -1105,7 +1191,9 @@ pin_project_lite::pin_project! {
         // fired. Without it nothing would poll us while the handler sits parked
         // in an await, and the hooks would wait on a child event that may
         // never come. Already `Box::pin`ned, so no structural pinning needed.
-        cancel_wait: Option<Pin<Box<dyn Future<Output = ()>>>>,
+        // `+ Send` keeps every ScopedFuture usable under mlua's `send` feature,
+        // including ones awaited inside `create_async_function` bodies.
+        cancel_wait: Option<Pin<Box<dyn Future<Output = ()> + Send>>>,
         #[pin]
         inner: F,
     }
@@ -2515,8 +2603,6 @@ async fn dispatch_async(
         };
     }
 
-    let mut event_buf = Vec::new();
-
     loop {
         // No grace here: the handler already returned, so there is no Lua
         // frame left to unwind. Bound before the match so the guard drops
@@ -2540,29 +2626,26 @@ async fn dispatch_async(
             Err(flume::TryRecvError::Empty) => {}
         }
 
-        with_jobs(lua, |store| store.drain_events(&owner, &mut event_buf));
-
-        if event_buf.is_empty() {
-            if with_jobs(lua, |store| store.is_empty(&owner)) {
-                smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
-                return match finish_rx.try_recv() {
-                    Ok(reply) => reply,
-                    _ => ToolCallReply::err(NIL_WITHOUT_FINISH_MSG),
-                };
+        if let Some((job_id, event)) = with_jobs(lua, |store| store.next_event(&owner)) {
+            if let Err(e) = deliver_job_event(lua, job_id, &event).await {
+                return ToolCallReply::err(format!("job callback error: {}", strip_traceback(&e)));
             }
-            smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
+            smol::future::yield_now().await;
             continue;
         }
 
-        for (job_id, event) in event_buf.drain(..) {
-            if let Err(e) = deliver_job_event(lua, job_id, &event) {
-                return ToolCallReply::err(format!("job callback error: {}", strip_traceback(&e)));
-            }
+        if with_jobs(lua, |store| store.is_empty(&owner)) {
+            smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
+            return match finish_rx.try_recv() {
+                Ok(reply) => reply,
+                _ => ToolCallReply::err(NIL_WITHOUT_FINISH_MSG),
+            };
         }
+        smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
     }
 }
 
-fn strip_traceback(err: &mlua::Error) -> String {
+pub(crate) fn strip_traceback(err: &mlua::Error) -> String {
     match err {
         mlua::Error::CallbackError { cause, .. } => {
             let mut inner = cause;
@@ -2859,21 +2942,22 @@ pub fn spawn(
             {
                 let lua = rt.lua.clone();
                 ex.spawn(async move {
-                    let mut event_buf = Vec::new();
                     loop {
-                        with_jobs(&lua, |store| {
-                            store.drain_plugin_events(&mut event_buf);
-                        });
-                        if !event_buf.is_empty() {
+                        // Pop before building the scope so an idle pump costs
+                        // nothing. The delivery scope republishes the task
+                        // handle across callback yields: an unscoped resume
+                        // would run under whatever task the executor
+                        // interleaved, misrouting jobs and watchdog state.
+                        if let Some(first) = with_jobs(&lua, |store| store.next_plugin_event()) {
+                            let mut first = Some(first);
                             let scope = TaskScope::delivery(&lua);
-                            for (job_id, event) in event_buf.drain(..) {
-                                if let Err(e) = deliver_job_event(&lua, job_id, &event) {
-                                    tracing::warn!(
-                                        error = %strip_traceback(&e),
-                                        "plugin job callback failed"
-                                    );
-                                }
-                            }
+                            scope
+                                .scope_future(deliver_pending(&lua, usize::MAX, || {
+                                    first
+                                        .take()
+                                        .or_else(|| with_jobs(&lua, |s| s.next_plugin_event()))
+                                }))
+                                .await;
                             drop(scope);
                         }
                         smol::Timer::after(DISPATCH_POLL_INTERVAL).await;
@@ -2883,6 +2967,20 @@ pub fn spawn(
             }
             let gate = Rc::new(InflightGate::new(rt.lua.clone()));
             let restores = Rc::new(RestoreTracker::default());
+            let (hook_tx, hook_rx) = flume::unbounded::<HostHook>();
+            {
+                let lua = rt.lua.clone();
+                let gate = Rc::clone(&gate);
+                ex.spawn(async move {
+                    while let Ok(hook) = hook_rx.recv_async().await {
+                        // Counted as in-flight so a plugin reload waiting on
+                        // `drain_barrier` cannot land mid-handler.
+                        let _guard = GateGuard::new(&gate);
+                        run_host_hook(&lua, hook).await;
+                    }
+                })
+                .detach();
+            }
             let spawn_rx = rt
                 .lua
                 .app_data_ref::<SpawnQueue>()
@@ -3190,24 +3288,10 @@ pub fn spawn(
                             .detach();
                         }
                         Request::FireAutocmd { event, data } => {
-                            let data = json_to_lua(&rt.lua, &data).unwrap_or(LuaValue::Nil);
-                            crate::api::autocmd::dispatch(&rt.lua, &event, None, data);
-                            if event == TURN_END_EVENT {
-                                rt.lua.gc_collect().ok();
-                            }
+                            let _ = hook_tx.send(HostHook::Autocmd { event, data });
                         }
-                        Request::EndSession { session } => {
-                            // Handlers may still inspect or stop the jobs, so
-                            // the event fires before the reap.
-                            let data = json_to_lua(
-                                &rt.lua,
-                                &serde_json::json!({ "session_id": session.to_string() }),
-                            )
-                            .unwrap_or(LuaValue::Nil);
-                            crate::api::autocmd::dispatch(&rt.lua, "SessionEnd", None, data);
-                            with_jobs(&rt.lua, |store| {
-                                store.kill_session(&rt.lua, session);
-                            });
+                        Request::EndSession { session, reply } => {
+                            let _ = hook_tx.send(HostHook::EndSession { session, reply });
                         }
                         Request::Describe {
                             plugin,
@@ -3318,6 +3402,19 @@ mod tests {
         let lua = Lua::new();
         lua.set_app_data(BufferStore::new());
         lua
+    }
+
+    /// A job printing faster than we deliver never runs its channel dry, so the
+    /// last pass a scope makes before reaping it has to stop on its own.
+    #[test]
+    fn the_bounded_drain_stops_on_an_endless_stream() {
+        let lua = test_lua();
+        let mut offered = 0usize;
+        smol::block_on(deliver_pending(&lua, FINAL_DRAIN_BUDGET, || {
+            offered += 1;
+            (offered <= FINAL_DRAIN_BUDGET * 2).then(|| (1, JobEvent::Stdout("spam".into())))
+        }));
+        assert_eq!(offered, FINAL_DRAIN_BUDGET);
     }
 
     #[test]

--- a/maki-lua/tests/events_slots.rs
+++ b/maki-lua/tests/events_slots.rs
@@ -233,6 +233,28 @@ end }})
 }
 
 #[test]
+fn host_end_session_fires_session_end() {
+    let (reg, host) = host();
+    let listener = format!(
+        r#"
+local log = {{}}
+maki.api.create_autocmd("SessionEnd", {{ callback = function(ev)
+    log[#log + 1] = string.format("%s|%s", ev.event, tostring(ev.data and ev.data.session_id))
+end }})
+{}
+"#,
+        probe_tool("probe_session_end", "return table.concat(log, \";\")")
+    );
+    load(&host, "listener", &listener);
+    let session = maki_storage::id::MakiId::generate();
+    host.event_handle().end_session(session);
+    assert_eq!(
+        exec_tool(&reg, "probe_session_end"),
+        format!("SessionEnd|{session}")
+    );
+}
+
+#[test]
 fn unload_clears_autocmds_but_keeps_others() {
     let (reg, host) = host();
     let listener = |tool: &str| {

--- a/maki-lua/tests/events_slots.rs
+++ b/maki-lua/tests/events_slots.rs
@@ -247,7 +247,7 @@ end }})
     );
     load(&host, "listener", &listener);
     let session = maki_storage::id::MakiId::generate();
-    host.event_handle().end_session(session);
+    host.event_handle().end_sessions_blocking([session]);
     assert_eq!(
         exec_tool(&reg, "probe_session_end"),
         format!("SessionEnd|{session}")

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -2366,7 +2366,7 @@ maki.api.register_tool({{
         "reloaded plugin should see the live session job, got {state}"
     );
 
-    host.event_handle().end_session(session);
+    host.event_handle().end_sessions_blocking([session]);
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
     while test_kill_process_group(pid).is_ok() {
         assert!(
@@ -2447,20 +2447,11 @@ local seen
     let pid = Pid::from_raw(pid).unwrap();
     assert!(test_kill_process_group(pid).is_ok());
 
-    host.event_handle().end_session(session);
+    host.event_handle().end_sessions_blocking([session]);
 
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    let seen = loop {
-        let seen = exec_tool(&reg, "probe_order_job", json!({})).unwrap();
-        if !seen.starts_with("not-yet") {
-            break seen;
-        }
-        assert!(
-            std::time::Instant::now() < deadline,
-            "SessionEnd handler never ran"
-        );
-        std::thread::sleep(Duration::from_millis(10));
-    };
+    // `wait = true` answers only after handlers dispatched and jobs reaped,
+    // so what the handler saw is settled.
+    let seen = exec_tool(&reg, "probe_order_job", json!({})).unwrap();
     assert!(
         seen.starts_with("running:"),
         "SessionEnd handler should see the live job, got {seen}"
@@ -2474,6 +2465,165 @@ local seen
         );
         std::thread::sleep(Duration::from_millis(10));
     }
+}
+
+#[test]
+fn autocmd_task_jobs_die_with_their_own_callback() {
+    let (reg, host) = builtins_host();
+    const GONE: &str = "gone";
+    let src = format!(
+        r#"
+local job
+seen = "unset"
+maki.api.create_autocmd("ProbeIsolation", {{
+    callback = function()
+        job = maki.fn.jobstart("sleep 30")
+    end,
+}})
+maki.api.create_autocmd("ProbeIsolation", {{
+    callback = function()
+        local info = job and maki.fn.jobinfo(job) or nil
+        seen = info and ("alive:" .. info.status) or "{GONE}"
+    end,
+}})
+maki.api.register_tool({{
+    name = "probe_isolation",
+    description = "reports what the second handler saw",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        return seen
+    end,
+}})
+"#
+    );
+    host.load_source("isolation_probe", &src).unwrap();
+
+    host.event_handle()
+        .fire_autocmd("ProbeIsolation", json!({}));
+
+    // FireAutocmd and CallTool queue on the same channel and dispatch is
+    // awaited in order, so the second handler has already run here. A shared
+    // batch scope would report the first handler's job as alive.
+    assert_eq!(exec_tool(&reg, "probe_isolation", json!({})).unwrap(), GONE);
+}
+
+#[cfg(unix)]
+#[test]
+fn session_end_autocmds_may_suspend() {
+    let (reg, host) = builtins_host();
+
+    let dir = std::env::temp_dir().join(format!("maki-sessionend-suspend-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let marker = dir.join("marker.txt");
+    std::fs::write(&marker, "x").unwrap();
+
+    const RM_FAILED: &str = "err:";
+    let src = format!(
+        r#"
+local rm_result
+maki.api.create_autocmd("SessionEnd", {{
+    callback = function(ev)
+        local ok, res = pcall(maki.fs.rm, ev.data.dir, {{ recursive = true, force = true }})
+        rm_result = ok and "ok" or "{RM_FAILED}" .. tostring(res)
+    end,
+}})
+maki.api.register_tool({{
+    name = "rm_probe",
+    description = "reports what the SessionEnd handler saw",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        return rm_result or "unset"
+    end,
+}})
+"#,
+    );
+    host.load_source("sessionend_suspend", &src).unwrap();
+
+    host.event_handle()
+        .fire_autocmd("SessionEnd", json!({ "dir": dir.display().to_string() }));
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let seen = loop {
+        match exec_tool(&reg, "rm_probe", json!({})) {
+            Ok(seen) if seen != "unset" => break seen,
+            _ if std::time::Instant::now() < deadline => {}
+            other => panic!("SessionEnd probe never settled: {other:?}"),
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    assert_eq!(seen, "ok", "fs.rm must not die on a yield boundary");
+    assert!(!marker.exists(), "fs.rm should have removed the tree");
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn jobwait_streams_events_to_suspending_callbacks() {
+    let (reg, host) = builtins_host();
+
+    let dir = std::env::temp_dir().join(format!("maki-jobwait-suspend-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let meta = dir.join("meta.json");
+
+    let session = maki_storage::id::MakiId::generate();
+    // The process must still run when wait_suspending_job calls jobwait:
+    // an already-exited job answers from its snapshot without delivering
+    // on_exit, which would make the assertion below race the event pump.
+    const EXIT_CB_FAILED: &str = "exit_cb_failed";
+    let src = format!(
+        r#"
+local job_id
+local exit_cb_result
+maki.api.register_tool({{
+    name = "start_suspending_job",
+    description = "starts a session-owned job whose on_exit writes a file",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        job_id = maki.fn.jobstart("sleep 2", {{
+            owner = "session",
+            session = "{session}",
+            on_exit = function(_, code)
+                local ok, res = pcall(maki.fs.atomic_write, "{}", tostring(code))
+                exit_cb_result = ok and "ok" or "{EXIT_CB_FAILED}:" .. tostring(res)
+            end,
+        }})
+        return tostring(job_id)
+    end,
+}})
+maki.api.register_tool({{
+    name = "wait_suspending_job",
+    description = "waits like monitor_wait does",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        local ok, res = pcall(maki.fn.jobwait, job_id, 10000)
+        if not ok then
+            return {{ llm_output = "error: " .. tostring(res), is_error = true }}
+        end
+        return "exit:" .. tostring(res and res.exit_code) .. "|exit_cb:" .. tostring(exit_cb_result)
+    end,
+}})
+"#,
+        meta.display(),
+    );
+    host.load_source("jobwait_suspend", &src).unwrap();
+
+    exec_tool(&reg, "start_suspending_job", json!({})).unwrap();
+    let waited = exec_tool(&reg, "wait_suspending_job", json!({})).unwrap();
+    assert_eq!(
+        waited, "exit:0|exit_cb:ok",
+        "jobwait must report the exit and on_exit must survive suspending fs calls"
+    );
+    assert!(
+        std::path::Path::new(&meta).exists(),
+        "on_exit should have written the meta file"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
 }
 
 #[test]
@@ -5468,4 +5618,179 @@ mod read_tool_required_params {
             "offset beyond file should return empty, got: {out}"
         );
     }
+}
+
+#[test]
+fn jobwait_reentrant_self_wait_in_on_exit() {
+    let (reg, host) = builtins_host();
+    let session = maki_storage::id::MakiId::generate();
+    let src = format!(
+        r#"
+local job_id
+maki.api.register_tool({{
+    name = "start_self_wait_job",
+    description = "session job whose on_exit reenters jobwait on itself",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        job_id = maki.fn.jobstart("sleep 1", {{
+            owner = "session",
+            session = "{session}",
+            on_exit = function(id, code)
+                local ok, res = pcall(maki.fn.jobwait, id, 2000)
+                if not ok then
+                    error("self-wait errored: " .. tostring(res))
+                end
+                if res == nil then
+                    error("self-wait timed out")
+                end
+                if res.exit_code ~= code then
+                    error("self-wait code mismatch")
+                end
+            end,
+        }})
+        return tostring(job_id)
+    end,
+}})
+maki.api.register_tool({{
+    name = "wait_self_wait_job",
+    description = "outer wait like monitor_wait",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        local ok, res = pcall(maki.fn.jobwait, job_id, 10000)
+        if not ok then
+            return {{ llm_output = "error: " .. tostring(res), is_error = true }}
+        end
+        if res == nil then
+            return {{ llm_output = "error: outer wait timed out", is_error = true }}
+        end
+        return "exit:" .. tostring(res.exit_code)
+    end,
+}})
+"#
+    );
+    host.load_source("selfwait", &src).unwrap();
+
+    exec_tool(&reg, "start_self_wait_job", json!({})).unwrap();
+    let out = exec_tool(&reg, "wait_self_wait_job", json!({})).unwrap();
+    assert_eq!(
+        out, "exit:0",
+        "reentrant self-wait must not poison the outer wait"
+    );
+    let after = exec_tool(&reg, "wait_self_wait_job", json!({})).unwrap();
+    assert!(
+        after.starts_with("exit:"),
+        "VM must stay usable, got: {after}"
+    );
+}
+
+#[test]
+fn jobwait_returns_after_session_end_kill() {
+    let (reg, host) = builtins_host();
+    let session = maki_storage::id::MakiId::generate();
+    let src = format!(
+        r#"
+local job_id
+maki.api.register_tool({{
+    name = "start_long_job",
+    description = "session job that outlives the wait",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        job_id = maki.fn.jobstart("sleep 30", {{
+            owner = "session",
+            session = "{session}",
+        }})
+        return tostring(job_id)
+    end,
+}})
+maki.api.register_tool({{
+    name = "wait_long_job",
+    description = "parks in jobwait until killed or timeout",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        local ok, res = pcall(maki.fn.jobwait, job_id, 25000)
+        if not ok then
+            return {{ llm_output = "error: " .. tostring(res), is_error = true }}
+        end
+        if res == nil then
+            return "timeout"
+        end
+        return "exit:" .. tostring(res.exit_code)
+    end,
+}})
+"#
+    );
+    host.load_source("endkill", &src).unwrap();
+    exec_tool(&reg, "start_long_job", json!({})).unwrap();
+
+    let reg2 = Arc::clone(&reg);
+    let wait_handle =
+        std::thread::spawn(move || exec_tool(&reg2, "wait_long_job", json!({})).unwrap());
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    host.event_handle().end_sessions_blocking([session]);
+    let out = wait_handle.join().expect("wait thread must not panic");
+    assert!(
+        out.starts_with("exit:") || out == "timeout",
+        "parked jobwait must return after session end, got: {out}"
+    );
+}
+
+#[test]
+fn jobwait_callback_error_still_delivers_exit() {
+    let (reg, host) = builtins_host();
+    let session = maki_storage::id::MakiId::generate();
+    let src = format!(
+        r#"
+local job_id
+maki.api.register_tool({{
+    name = "start_boom_job",
+    description = "job whose on_stdout raises",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        job_id = maki.fn.jobstart("echo one; echo two; echo three", {{
+            owner = "session",
+            session = "{session}",
+            on_stdout = function(_, line)
+                if line == "two" then
+                    error("boom on stdout")
+                end
+            end,
+        }})
+        return tostring(job_id)
+    end,
+}})
+maki.api.register_tool({{
+    name = "wait_boom_job",
+    description = "waits past the failing callback",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        local ok, res = pcall(maki.fn.jobwait, job_id, 10000)
+        if not ok then
+            return {{ llm_output = "error: " .. tostring(res), is_error = true }}
+        end
+        if res == nil then
+            return {{ llm_output = "error: timed out", is_error = true }}
+        end
+                return "exit:" .. tostring(res.exit_code) .. "|stdout:" .. tostring(res.stdout)
+    end,
+}})
+"#
+    );
+    host.load_source("boomjob", &src).unwrap();
+    exec_tool(&reg, "start_boom_job", json!({})).unwrap();
+    let out = exec_tool(&reg, "wait_boom_job", json!({})).unwrap();
+    assert!(
+        out.starts_with("exit:0"),
+        "a failing on_stdout must not swallow the exit, got: {out}"
+    );
+    let again = exec_tool(&reg, "wait_boom_job", json!({})).unwrap();
+    assert!(
+        again.starts_with("exit:"),
+        "VM must stay usable, got: {again}"
+    );
 }

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -2131,7 +2131,7 @@ maki.api.register_tool({{
     audiences = {{ "main" }},
     handler = function()
         local id = maki.fn.jobstart("sleep 0.1; printf plugin-output; exit 7", {{
-            owner = "plugin",
+            scope = "plugin",
             on_stdout = function(_, line) output = line end,
             on_exit = function(_, code) exit_code = tostring(code) end,
         }})
@@ -2177,7 +2177,7 @@ fn unloading_plugin_kills_its_jobs() {
     let pid_path = dir.path().join("job.pid");
     let src = format!(
         r#"maki.fn.jobstart("printf %s $$ > '{}'; exec sleep 30", {{
-            owner = "plugin",
+            scope = "plugin",
         }})"#,
         pid_path.display()
     );
@@ -2228,7 +2228,7 @@ maki.api.register_tool({{
     audiences = {{ "main" }},
     handler = function()
         job_id = maki.fn.jobstart("printf 'hello-tail\n'; exec sleep 30", {{
-            owner = "plugin",
+            scope = "plugin",
             tail = 8,
         }})
         return tostring(job_id)
@@ -2308,8 +2308,7 @@ maki.api.register_tool({{
     audiences = {{ "main" }},
     handler = function()
         local id = maki.fn.jobstart("printf %s $$ > '{pid}'; exec sleep 30", {{
-            owner = "session",
-            session = "{sid}",
+            scope = {{ session = "{sid}" }},
         }})
         return tostring(id)
     end,
@@ -2396,8 +2395,7 @@ maki.api.register_tool({{
     audiences = {{ "main" }},
     handler = function()
         job_id = maki.fn.jobstart("printf %s $$ > '{pid}'; exec sleep 30", {{
-            owner = "session",
-            session = "{sid}",
+            scope = {{ session = "{sid}" }},
         }})
         return tostring(job_id)
     end,
@@ -2584,8 +2582,7 @@ maki.api.register_tool({{
     audiences = {{ "main" }},
     handler = function()
         job_id = maki.fn.jobstart("sleep 2", {{
-            owner = "session",
-            session = "{session}",
+            scope = {{ session = "{session}" }},
             on_exit = function(_, code)
                 local ok, res = pcall(maki.fs.atomic_write, "{}", tostring(code))
                 exit_cb_result = ok and "ok" or "{EXIT_CB_FAILED}:" .. tostring(res)
@@ -5634,8 +5631,7 @@ maki.api.register_tool({{
     audiences = {{ "main" }},
     handler = function()
         job_id = maki.fn.jobstart("sleep 1", {{
-            owner = "session",
-            session = "{session}",
+            scope = {{ session = "{session}" }},
             on_exit = function(id, code)
                 local ok, res = pcall(maki.fn.jobwait, id, 2000)
                 if not ok then
@@ -5703,8 +5699,7 @@ maki.api.register_tool({{
         -- a parked jobwait can run this callback. The marker is proof the
         -- wait is really parked, where a sleep would just be a guess.
         local id = maki.fn.jobstart("echo parked; exec sleep 30", {{
-            owner = "session",
-            session = "{session}",
+            scope = {{ session = "{session}" }},
             on_stdout = function() maki.fs.write("{parked}", "parked") end,
         }})
         local ok, res = pcall(maki.fn.jobwait, id, 25000)
@@ -5750,8 +5745,7 @@ maki.api.register_tool({{
     audiences = {{ "main" }},
     handler = function()
         job_id = maki.fn.jobstart("echo one; echo two; echo three", {{
-            owner = "session",
-            session = "{session}",
+            scope = {{ session = "{session}" }},
             on_stdout = function(_, line)
                 if line == "two" then
                     error("boom on stdout")

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -2215,6 +2215,81 @@ fn unloading_plugin_kills_its_jobs() {
 }
 
 #[test]
+fn jobinfo_and_joblist_see_live_plugin_jobs() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let src = format!(
+        r#"
+local job_id
+maki.api.register_tool({{
+    name = "start_listed_job",
+    description = "starts a plugin job for inspect",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        job_id = maki.fn.jobstart("printf 'hello-tail\n'; exec sleep 30", {{
+            owner = "plugin",
+            tail = 8,
+        }})
+        return tostring(job_id)
+    end,
+}})
+maki.api.register_tool({{
+    name = "inspect_listed_job",
+    description = "jobinfo and joblist for the live job",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        local info = maki.fn.jobinfo(job_id)
+        if not info then return "missing" end
+        local listed = false
+        for _, row in ipairs(maki.fn.joblist()) do
+            if row.id == job_id then listed = true end
+        end
+        return table.concat({{
+            info.status,
+            info.command,
+            tostring(listed),
+            table.concat(info.stdout_lines, ","),
+        }}, "|")
+    end,
+}})
+maki.api.register_tool({{
+    name = "stop_listed_job",
+    description = "stop the inspect job",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        maki.fn.jobstop(job_id)
+        return "stopped"
+    end,
+}})
+"#
+    );
+    host.load_source("job_inspect", &src).unwrap();
+    let _id = exec_tool(&reg, "start_listed_job", json!({})).unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let state = loop {
+        let state = exec_tool(&reg, "inspect_listed_job", json!({})).unwrap();
+        if state.starts_with("running|") && state.contains("hello-tail") {
+            break state;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "jobinfo never saw the live job: {state}"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    };
+    assert!(
+        state.contains("|true|"),
+        "joblist should include the live job, got {state}"
+    );
+
+    exec_tool(&reg, "stop_listed_job", json!({})).unwrap();
+}
+
+#[test]
 fn vm_recovers_after_async_job_tool() {
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -2449,8 +2449,8 @@ local seen
 
     host.event_handle().end_sessions_blocking([session]);
 
-    // `wait = true` answers only after handlers dispatched and jobs reaped,
-    // so what the handler saw is settled.
+    // `end_sessions_blocking` only answers once the handlers ran and the jobs
+    // were reaped, so what the handler saw is settled by now.
     let seen = exec_tool(&reg, "probe_order_job", json!({})).unwrap();
     assert!(
         seen.starts_with("running:"),
@@ -5689,52 +5689,50 @@ maki.api.register_tool({{
 fn jobwait_returns_after_session_end_kill() {
     let (reg, host) = builtins_host();
     let session = maki_storage::id::MakiId::generate();
+    let dir = tempfile::tempdir().unwrap();
+    let parked_path = dir.path().join("parked");
     let src = format!(
         r#"
-local job_id
-maki.api.register_tool({{
-    name = "start_long_job",
-    description = "session job that outlives the wait",
-    schema = {MINIMAL_SCHEMA},
-    audiences = {{ "main" }},
-    handler = function()
-        job_id = maki.fn.jobstart("sleep 30", {{
-            owner = "session",
-            session = "{session}",
-        }})
-        return tostring(job_id)
-    end,
-}})
 maki.api.register_tool({{
     name = "wait_long_job",
-    description = "parks in jobwait until killed or timeout",
+    description = "parks in jobwait until the session ends",
     schema = {MINIMAL_SCHEMA},
     audiences = {{ "main" }},
     handler = function()
-        local ok, res = pcall(maki.fn.jobwait, job_id, 25000)
+        -- jobwait checks the job's output channel out of the store, so only
+        -- a parked jobwait can run this callback. The marker is proof the
+        -- wait is really parked, where a sleep would just be a guess.
+        local id = maki.fn.jobstart("echo parked; exec sleep 30", {{
+            owner = "session",
+            session = "{session}",
+            on_stdout = function() maki.fs.write("{parked}", "parked") end,
+        }})
+        local ok, res = pcall(maki.fn.jobwait, id, 25000)
         if not ok then
             return {{ llm_output = "error: " .. tostring(res), is_error = true }}
         end
         if res == nil then
-            return "timeout"
+            return {{ llm_output = "error: jobwait timed out", is_error = true }}
         end
         return "exit:" .. tostring(res.exit_code)
     end,
 }})
-"#
+"#,
+        parked = parked_path.display(),
     );
     host.load_source("endkill", &src).unwrap();
-    exec_tool(&reg, "start_long_job", json!({})).unwrap();
 
     let reg2 = Arc::clone(&reg);
     let wait_handle =
         std::thread::spawn(move || exec_tool(&reg2, "wait_long_job", json!({})).unwrap());
-    std::thread::sleep(std::time::Duration::from_millis(500));
+    poll_until("jobwait never parked", || {
+        parked_path.exists().then_some(())
+    });
     host.event_handle().end_sessions_blocking([session]);
     let out = wait_handle.join().expect("wait thread must not panic");
     assert!(
-        out.starts_with("exit:") || out == "timeout",
-        "parked jobwait must return after session end, got: {out}"
+        out.starts_with("exit:"),
+        "parked jobwait must collect the exit of the killed job, got: {out}"
     );
 }
 

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -2289,6 +2289,193 @@ maki.api.register_tool({{
     exec_tool(&reg, "stop_listed_job", json!({})).unwrap();
 }
 
+#[cfg(unix)]
+#[test]
+fn session_owned_job_survives_plugin_reload() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let session = maki_storage::id::MakiId::generate();
+    let _mailbox = maki_agent::SessionMailbox::register(session);
+    let sid = session.to_string();
+    let dir = tempfile::tempdir().unwrap();
+    let pid_path = dir.path().join("job.pid");
+    let src = format!(
+        r#"
+maki.api.register_tool({{
+    name = "start_session_job",
+    description = "starts a session-owned job",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        local id = maki.fn.jobstart("printf %s $$ > '{pid}'; exec sleep 30", {{
+            owner = "session",
+            session = "{sid}",
+        }})
+        return tostring(id)
+    end,
+}})
+"#,
+        pid = pid_path.display(),
+        sid = sid,
+    );
+    host.load_source("session_job", &src).unwrap();
+    let id = exec_tool(&reg, "start_session_job", json!({})).unwrap();
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let pid = loop {
+        if let Ok(pid) = std::fs::read_to_string(&pid_path)
+            .unwrap_or_default()
+            .parse::<i32>()
+        {
+            break pid;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "session job did not publish its process id"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    };
+    let pid = Pid::from_raw(pid).unwrap();
+    assert!(test_kill_process_group(pid).is_ok());
+
+    host.unload("session_job").unwrap();
+    std::thread::sleep(Duration::from_millis(50));
+    assert!(
+        test_kill_process_group(pid).is_ok(),
+        "session-owned job must survive plugin unload"
+    );
+
+    let inspect = format!(
+        r#"
+maki.api.register_tool({{
+    name = "inspect_session_job",
+    description = "lists session jobs after reload",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        local info = maki.fn.jobinfo({id})
+        if not info then return "missing" end
+        return info.status .. ":" .. tostring(info.pid)
+    end,
+}})
+"#
+    );
+    host.load_source("session_job", &inspect).unwrap();
+    let state = exec_tool(&reg, "inspect_session_job", json!({})).unwrap();
+    assert!(
+        state.starts_with("running:"),
+        "reloaded plugin should see the live session job, got {state}"
+    );
+
+    host.event_handle().end_session(session);
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while test_kill_process_group(pid).is_ok() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "end_session must kill the session job"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn session_end_handler_sees_jobs_before_they_are_reaped() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let session = maki_storage::id::MakiId::generate();
+    let _mailbox = maki_agent::SessionMailbox::register(session);
+    let sid = session.to_string();
+    let dir = tempfile::tempdir().unwrap();
+    let pid_path = dir.path().join("job.pid");
+    let src = format!(
+        r#"
+maki.api.register_tool({{
+    name = "start_order_job",
+    description = "starts a session-owned job",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        job_id = maki.fn.jobstart("printf %s $$ > '{pid}'; exec sleep 30", {{
+            owner = "session",
+            session = "{sid}",
+        }})
+        return tostring(job_id)
+    end,
+}})
+maki.api.register_tool({{
+    name = "probe_order_job",
+    description = "reports what the SessionEnd handler saw",
+    schema = {MINIMAL_SCHEMA},
+    audiences = {{ "main" }},
+    handler = function()
+        return seen or "not-yet"
+    end,
+}})
+maki.api.create_autocmd("SessionEnd", {{
+    callback = function(ev)
+        if tostring(ev.data and ev.data.session_id) ~= "{sid}" then return end
+        local ok, info = pcall(maki.fn.jobinfo, job_id)
+        if not ok then
+            seen = "err:" .. tostring(info)
+            return
+        end
+        seen = info and (info.status .. ":" .. tostring(info.pid)) or "missing"
+    end,
+}})
+local seen
+"#,
+        pid = pid_path.display(),
+        sid = sid,
+    );
+    host.load_source("order_probe", &src).unwrap();
+    exec_tool(&reg, "start_order_job", json!({})).unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let pid = loop {
+        if let Ok(pid) = std::fs::read_to_string(&pid_path)
+            .unwrap_or_default()
+            .parse::<i32>()
+        {
+            break pid;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "session job did not publish its process id"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    };
+    let pid = Pid::from_raw(pid).unwrap();
+    assert!(test_kill_process_group(pid).is_ok());
+
+    host.event_handle().end_session(session);
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let seen = loop {
+        let seen = exec_tool(&reg, "probe_order_job", json!({})).unwrap();
+        if !seen.starts_with("not-yet") {
+            break seen;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "SessionEnd handler never ran"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    };
+    assert!(
+        seen.starts_with("running:"),
+        "SessionEnd handler should see the live job, got {seen}"
+    );
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while test_kill_process_group(pid).is_ok() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "end_session must reap the job after dispatching SessionEnd"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
 #[test]
 fn vm_recovers_after_async_job_tool() {
     let reg = fresh_registry();

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -336,6 +336,7 @@ impl App {
         // that just ended needs its id, and the stamp always reads
         // whichever session is current.
         self.fire_session_autocmd("SessionReset", serde_json::json!({}));
+        self.lua_event_handle.end_session(self.state.session.id);
         let session = self.blank_session();
         self.apply_stored_permissions(&session.meta);
         self.state.session = Arc::new(session);
@@ -388,10 +389,14 @@ impl App {
         session: AppSession,
         fallback_model: &Model,
     ) -> LoadedSession {
+        let previous = self.state.session.id;
         self.checkpoint_now();
         self.apply_stored_permissions(&session.meta);
         self.state =
             SessionState::from_session(session, fallback_model, &self.storage, &self.model_policy);
+        if previous != self.state.session.id {
+            self.lua_event_handle.end_session(previous);
+        }
         for w in self.state.warnings.drain(..) {
             self.status_bar.flash(w);
         }

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -675,6 +675,8 @@ fn session_reset_names_the_session_that_ended() {
     let (event, data) = probe.try_recv_autocmd().expect("SessionReset fired");
     assert_eq!(event, "SessionReset");
     assert_eq!(data["session_id"], serde_json::json!(ended));
+    let ended_id = probe.try_recv_end_session().expect("SessionEnd queued");
+    assert_eq!(ended_id.to_string(), ended);
     assert_ne!(
         app.state.session.id.to_string(),
         ended,

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -1565,6 +1565,10 @@ impl<'t> EventLoop<'t> {
             elapsed
         };
         let exit = self.sessions[self.focused].app.exit_request;
+        // The loop already stopped draining `UiAction`. Drop the receiver
+        // before the handlers run, or one that touches the UI parks forever
+        // and only the teardown deadline gets us out of it.
+        drop(self.ui_action_rx);
         self.ctx
             .lua_event_handle
             .end_sessions_blocking(self.sessions.iter().map(SessionRuntime::id));

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -1565,9 +1565,10 @@ impl<'t> EventLoop<'t> {
             elapsed
         };
         let exit = self.sessions[self.focused].app.exit_request;
-        for rt in &self.sessions {
-            self.ctx.lua_event_handle.end_session(rt.id());
-        }
+        self.ctx
+            .lua_event_handle
+            .end_sessions_blocking(self.sessions.iter().map(SessionRuntime::id));
+        let session_end_ms = lap();
         if let Some(ref h) = self.ctx.mcp_handle {
             mcp::kill_process_groups(&h.reader().load().pids);
         }
@@ -1602,6 +1603,7 @@ impl<'t> EventLoop<'t> {
         }
         let storage_drain_ms = lap();
         info!(
+            session_end_ms,
             kill_mcp_ms,
             save_sessions_ms,
             join_agents_ms,

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -1061,6 +1061,7 @@ impl<'t> EventLoop<'t> {
                         return;
                     }
                     let rt = self.remove_runtime(i);
+                    self.ctx.lua_event_handle.end_session(rt.id());
                     rt.handles.cancel();
                 }
                 self.ctx.storage_writer.delete(id, move |res| {
@@ -1564,6 +1565,9 @@ impl<'t> EventLoop<'t> {
             elapsed
         };
         let exit = self.sessions[self.focused].app.exit_request;
+        for rt in &self.sessions {
+            self.ctx.lua_event_handle.end_session(rt.id());
+        }
         if let Some(ref h) = self.ctx.mcp_handle {
             mcp::kill_process_groups(&h.reader().load().pids);
         }

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -657,6 +657,13 @@ asked for it; it carries `data.model` in the shape `maki.model.get`
 returns, plus `data.previous_spec`. Picking the model already in use stays
 quiet, and so does startup.
 
+On the exit paths (UI shutdown, ACP EOF, headless completion) the host is
+already tearing down, so handlers get a short grace period and must not
+depend on `maki.fn` UI roundtrips; write state out with `maki.fs` instead.
+
+Jobs started inside a callback die with the dispatch unless you await
+them there (`jobwait`) or hand them to a session (`owner = "session"`).
+
 **Parameters:**
 
 - `{event}` (`string|string[]`) Event name or list of names.
@@ -707,7 +714,7 @@ maki.api.exec_autocmds({event}, {opts?})
 ```
 
 Fire one or more events manually. Every matching autocmd callback
-runs synchronously before this function returns.
+runs to completion before this function returns.
 
 **Parameters:**
 
@@ -1633,6 +1640,29 @@ maki.fn.jobstop(id)
 
 ---
 
+### `maki.fn.jobforget()` {#maki-fn-jobforget}
+
+```lua
+maki.fn.jobforget({job_id})
+```
+
+Drop an exited session-owned job from the store. Running jobs are left
+alone; use `jobstop` to kill those. Unknown ids are a no-op.
+
+Requires the `run` [plugin permission](#plugin-permissions).
+
+**Parameters:**
+
+- `{job_id}` (`integer`) Job id returned by `jobstart`.
+
+**Example:**
+
+```lua
+maki.fn.jobforget(id)
+```
+
+---
+
 ### `maki.fn.jobwait()` {#maki-fn-jobwait}
 
 ```lua
@@ -1648,7 +1678,8 @@ before the timeout.
 
 While waiting, the job's `on_stdout`, `on_stderr`, and `on_exit`
 callbacks fire as events arrive (like Neovim), so you can stream
-output into a buffer while parked here.
+output into a buffer while parked here. A job that already exited
+answers from its snapshot instead and fires no callbacks.
 
 Requires the `run` [plugin permission](#plugin-permissions).
 
@@ -1705,8 +1736,9 @@ maki.fn.joblist({session?})
 ```
 
 List jobs this plugin can see, including exited session-owned jobs (so an
-id started before a reload stays findable). Pass a session id to restrict
-session-owned jobs to that session.
+id started before a reload stays findable). Rows identify the job; call
+`jobinfo` for tails. Pass a session id to restrict session-owned jobs to
+that session.
 
 Requires the `run` [plugin permission](#plugin-permissions).
 
@@ -1715,7 +1747,7 @@ Requires the `run` [plugin permission](#plugin-permissions).
 - `{session?}` (`string?`) Session id filter.
 
 **Returns:** (`table`) array of `{ id, command, pid, session, status, exit_code,
-  elapsed_secs, stdout_lines, stderr_lines }`.
+  elapsed_secs }`.
 
 **Example:**
 
@@ -2172,6 +2204,33 @@ Requires the `fs_write` [plugin permission](#plugin-permissions).
 ```lua
 local ok, err = maki.fs.write("out.txt", "hello world")
 if err then print("write failed: " .. err) end
+```
+
+---
+
+### `maki.fs.append()` {#maki-fs-append}
+
+```lua
+maki.fs.append({path}, {content})
+```
+
+Append {content} to the file at {path}, creating it (but not its parent
+directory) if it does not exist.
+
+Requires the `fs_write` [plugin permission](#plugin-permissions).
+
+**Parameters:**
+
+- `{path}` (`string`) Destination file path. `~/` is expanded.
+- `{content}` (`string`) Text to append.
+
+**Returns:** (`true?`, `string?`) `true` on success, or nil plus an error message.
+
+**Example:**
+
+```lua
+local ok, err = maki.fs.append("out.log", "line\n")
+if err then print("append failed: " .. err) end
 ```
 
 ---

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -1587,6 +1587,8 @@ Requires the `run` [plugin permission](#plugin-permissions).
   - `owner` (`string?`) job lifetime. `"task"` (default) ends the job with
     the current call. `"plugin"` keeps it alive until the plugin unloads
     or reloads.
+  - `tail` (`integer?`) trailing lines per stream kept for `jobinfo`
+    (default 20, 0 disables, max 1024).
 
 **Returns:** (`integer`) Job id.
 
@@ -1656,6 +1658,51 @@ local result = maki.fn.jobwait(id, 5000)
 if result then
   print(result.stdout)
 end
+```
+
+---
+
+### `maki.fn.jobinfo()` {#maki-fn-jobinfo}
+
+```lua
+maki.fn.jobinfo({job_id})
+```
+
+Snapshot a job this plugin can see. Live jobs report tails collected
+so far. Task and plugin jobs are gone after they exit, so this is
+a live view today.
+
+**Parameters:**
+
+- `{job_id}` (`integer`) Job id returned by `jobstart`.
+
+**Returns:** (`table|nil`, `string|nil`) `{ id, command, pid, status,
+  exit_code, elapsed_secs, stdout_lines, stderr_lines }`, or nil and
+  an error. `status` is `"running"` or `"exited"`.
+
+**Example:**
+
+```lua
+local info = maki.fn.jobinfo(id)
+```
+
+---
+
+### `maki.fn.joblist()` {#maki-fn-joblist}
+
+```lua
+maki.fn.joblist()
+```
+
+List live jobs this plugin can see: the current task's jobs plus
+this plugin's plugin-owned jobs.
+
+**Returns:** (`table`) array of `{ id, command, pid, elapsed_secs }`.
+
+**Example:**
+
+```lua
+local jobs = maki.fn.joblist()
 ```
 
 ---

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -637,17 +637,18 @@ Listen for one or more events. Returns an id you can pass to
 
 Built-in events fired by the host: `"TurnStart"`, `"TurnEnd"`,
 `"TurnError"`, `"ToolStart"`, `"ToolDone"`, `"SessionReset"`,
-`"SessionFocusChanged"`, `"SessionStatusChanged"`, `"TaskStatusChanged"`,
-and `"ModelChanged"`. Plugins can also fire their own events with
-`exec_autocmds`.
+`"SessionEnd"`, `"SessionFocusChanged"`, `"SessionStatusChanged"`,
+`"TaskStatusChanged"`, and `"ModelChanged"`. Plugins can also fire their
+own events with `exec_autocmds`.
 
-Each host event carries `data.session_id`. For `"SessionReset"` that
-is the session being left behind; the other events name the session now
-running or focused. Tool events also carry `data.tool_id` and `data.tool`.
-`"SessionFocusChanged"` also carries `data.previous_session_id` except on
-initial startup. `"SessionStatusChanged"` fires whenever a session moves
-between `"working"`, `"needs_input"`, and `"idle"`; it carries
-`data.status`, `data.title`, and `data.focused` (boolean).
+Each host event carries `data.session_id`. For `"SessionReset"` and
+`"SessionEnd"` that is the session being left behind; the other events
+name the session now running or focused. Tool events also carry
+`data.tool_id` and `data.tool`. `"SessionFocusChanged"` also carries
+`data.previous_session_id` except on initial startup.
+`"SessionStatusChanged"` fires whenever a session moves between
+`"working"`, `"needs_input"`, and `"idle"`; it carries `data.status`,
+`data.title`, and `data.focused` (boolean).
 `"TaskStatusChanged"` fires when a subagent starts, or when one moves
 between `"working"`, `"done"`, and `"error"`; it carries `data.id` and
 `data.name` alongside `data.status`. A task that comes back from disk
@@ -657,9 +658,16 @@ asked for it; it carries `data.model` in the shape `maki.model.get`
 returns, plus `data.previous_spec`. Picking the model already in use stays
 quiet, and so does startup.
 
+`"SessionEnd"` is the teardown signal: it fires first so handlers can
+still inspect or stop the session's jobs, then session-owned jobs are
+reaped. It is sent on TUI `/new`, tab delete, session load, UI shutdown,
+ACP session replace/EOF, and headless completion.
+`"SessionReset"` stays TUI-only (`/new`).
+
 On the exit paths (UI shutdown, ACP EOF, headless completion) the host is
-already tearing down, so handlers get a short grace period and must not
-depend on `maki.fn` UI roundtrips; write state out with `maki.fs` instead.
+already tearing down, so handlers get a short grace period and the UI is
+gone: `maki.fn` roundtrips fail right away. Write state out with
+`maki.fs` instead.
 
 Jobs started inside a callback die with the dispatch unless you await
 them there (`jobwait`) or hand them to a session (`owner = "session"`).
@@ -1564,7 +1572,7 @@ whether programs are installed.
 
 ```lua
 local id = maki.fn.jobstart("git status", {
-  on_exit = function(code) print("done: " .. code) end,
+  on_exit = function(_, code) print("done: " .. code) end,
 })
 ```
 
@@ -1678,8 +1686,10 @@ before the timeout.
 
 While waiting, the job's `on_stdout`, `on_stderr`, and `on_exit`
 callbacks fire as events arrive (like Neovim), so you can stream
-output into a buffer while parked here. A job that already exited
-answers from its snapshot instead and fires no callbacks.
+output into a buffer while parked here. An already-exited
+session-owned job answers from its snapshot and fires no callbacks.
+Task and plugin jobs leave the store on exit, so waiting after that
+is an error.
 
 Requires the `run` [plugin permission](#plugin-permissions).
 
@@ -1737,8 +1747,8 @@ maki.fn.joblist({session?})
 
 List jobs this plugin can see, including exited session-owned jobs (so an
 id started before a reload stays findable). Rows identify the job; call
-`jobinfo` for tails. Pass a session id to restrict session-owned jobs to
-that session.
+`jobinfo` for tails. Pass a session id to list only session-owned jobs
+for that session; plugin and task jobs are omitted.
 
 Requires the `run` [plugin permission](#plugin-permissions).
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -670,7 +670,8 @@ gone: `maki.fn` roundtrips fail right away. Write state out with
 `maki.fs` instead.
 
 Jobs started inside a callback die with the dispatch unless you await
-them there (`jobwait`) or hand them to a session (`owner = "session"`).
+them there (`jobwait`) or hand them to a session
+(`scope = { session = ... }`).
 
 **Parameters:**
 
@@ -1599,15 +1600,10 @@ Requires the `run` [plugin permission](#plugin-permissions).
   - `on_stdout` (`function?`) called with `(job_id, line)` for each stdout line.
   - `on_stderr` (`function?`) called with `(job_id, line)` for each stderr line.
   - `on_exit` (`function?`) called with `(job_id, code)` when the process finishes.
-  - `owner` (`string?`) job lifetime. `"task"` (default) ends the job with
-    the current call. `"plugin"` keeps it alive until the plugin unloads
-    or reloads. `"session"` keeps it alive until that session ends, and
-    survives plugin reload; requires `session`.
-  - `session` (`string?`) session id. Required when `owner = "session"`.
-  - `notify` (`boolean|table?`) when the process exits, post a mailbox
-    observation to `session`. `true` uses `{ wake = true, on_success = true }`.
-    A table accepts `wake` (boolean, default true) and `on_success`
-    (boolean, default true). Only valid with `owner = "session"`.
+  - `scope` (`string|table?`) job lifetime. `"task"` (default) ends the job
+    with the current call. `"plugin"` keeps it alive until the plugin
+    unloads or reloads. `{ session = "<id>" }` keeps it alive until that
+    session ends, and survives plugin reload.
   - `tail` (`integer?`) trailing lines per stream kept for `jobinfo`
     (default 20, 0 disables, max 1024).
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -1586,7 +1586,13 @@ Requires the `run` [plugin permission](#plugin-permissions).
   - `on_exit` (`function?`) called with `(job_id, code)` when the process finishes.
   - `owner` (`string?`) job lifetime. `"task"` (default) ends the job with
     the current call. `"plugin"` keeps it alive until the plugin unloads
-    or reloads.
+    or reloads. `"session"` keeps it alive until that session ends, and
+    survives plugin reload; requires `session`.
+  - `session` (`string?`) session id. Required when `owner = "session"`.
+  - `notify` (`boolean|table?`) when the process exits, post a mailbox
+    observation to `session`. `true` uses `{ wake = true, on_success = true }`.
+    A table accepts `wake` (boolean, default true) and `on_success`
+    (boolean, default true). Only valid with `owner = "session"`.
   - `tail` (`integer?`) trailing lines per stream kept for `jobinfo`
     (default 20, 0 disables, max 1024).
 
@@ -1634,8 +1640,11 @@ maki.fn.jobwait({job_id}, {timeout_ms?})
 ```
 
 Wait for a job to finish and collect its output. Returns a result
-table with `stdout`, `stderr`, and `exit_code`. Returns `nil` if the
-job does not finish before the timeout.
+table with `stdout`, `stderr`, `exit_code`, and `truncated`. `truncated`
+is false when the collected lines are the full output; a job that already
+exited answers from its captured tail, so `truncated` is true and the
+output may be missing lines. Returns `nil` if the job does not finish
+before the timeout.
 
 While waiting, the job's `on_stdout`, `on_stderr`, and `on_exit`
 callbacks fire as events arrive (like Neovim), so you can stream
@@ -1648,7 +1657,7 @@ Requires the `run` [plugin permission](#plugin-permissions).
 - `{job_id}` (`integer`) Job id returned by `jobstart`.
 - `{timeout_ms?}` (`integer?`) Maximum wait in milliseconds (default 30000).
 
-**Returns:** (`table?`) `{ stdout, stderr, exit_code }`, or nil on timeout.
+**Returns:** (`table?`) `{ stdout, stderr, exit_code, truncated }`, or nil on timeout.
 
 **Example:**
 
@@ -1669,14 +1678,15 @@ maki.fn.jobinfo({job_id})
 ```
 
 Snapshot a job this plugin can see. Live jobs report tails collected
-so far. Task and plugin jobs are gone after they exit, so this is
-a live view today.
+so far; session-owned jobs still answer after they exit.
+
+Requires the `run` [plugin permission](#plugin-permissions).
 
 **Parameters:**
 
 - `{job_id}` (`integer`) Job id returned by `jobstart`.
 
-**Returns:** (`table|nil`, `string|nil`) `{ id, command, pid, status,
+**Returns:** (`table|nil`, `string|nil`) `{ id, command, pid, session, status,
   exit_code, elapsed_secs, stdout_lines, stderr_lines }`, or nil and
   an error. `status` is `"running"` or `"exited"`.
 
@@ -1691,18 +1701,26 @@ local info = maki.fn.jobinfo(id)
 ### `maki.fn.joblist()` {#maki-fn-joblist}
 
 ```lua
-maki.fn.joblist()
+maki.fn.joblist({session?})
 ```
 
-List live jobs this plugin can see: the current task's jobs plus
-this plugin's plugin-owned jobs.
+List jobs this plugin can see, including exited session-owned jobs (so an
+id started before a reload stays findable). Pass a session id to restrict
+session-owned jobs to that session.
 
-**Returns:** (`table`) array of `{ id, command, pid, elapsed_secs }`.
+Requires the `run` [plugin permission](#plugin-permissions).
+
+**Parameters:**
+
+- `{session?}` (`string?`) Session id filter.
+
+**Returns:** (`table`) array of `{ id, command, pid, session, status, exit_code,
+  elapsed_secs, stdout_lines, stderr_lines }`.
 
 **Example:**
 
 ```lua
-local jobs = maki.fn.joblist()
+local jobs = maki.fn.joblist(maki.session.current())
 ```
 
 ---

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -70,6 +70,9 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
         yolo,
         model_policy: Arc::new(config.provider.model_policy.clone()),
         plugin_rules: plugin_host.plugin_rules(),
-        on_session_end: Some(Arc::new(move |id| event_handle.end_sessions_blocking([id]))),
+        on_session_end: Some(Arc::new(move |id| {
+            let handle = event_handle.clone();
+            Box::pin(async move { handle.end_session_async(id).await })
+        })),
     })
 }

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -70,6 +70,6 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
         yolo,
         model_policy: Arc::new(config.provider.model_policy.clone()),
         plugin_rules: plugin_host.plugin_rules(),
-        on_session_end: Some(Arc::new(move |id| event_handle.end_session(id))),
+        on_session_end: Some(Arc::new(move |id| event_handle.end_sessions_blocking([id]))),
     })
 }

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -59,6 +59,7 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
 
     let prompt_slots = plugin_host.event_handle().collect_prompt_slots();
 
+    let event_handle = plugin_host.event_handle();
     maki_acp::run(maki_acp::AcpParams {
         model,
         config: config.agent,
@@ -69,5 +70,6 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
         yolo,
         model_policy: Arc::new(config.provider.model_policy.clone()),
         plugin_rules: plugin_host.plugin_rules(),
+        on_session_end: Some(Arc::new(move |id| event_handle.end_session(id))),
     })
 }

--- a/src/print.rs
+++ b/src/print.rs
@@ -325,6 +325,7 @@ pub fn run(
         })
         .await;
     });
+    lua_handle.end_session(session_id.id());
 
     let duration_ms = start.elapsed().as_millis();
     // Zero on an unpriced model, which is what its turns reported too.

--- a/src/print.rs
+++ b/src/print.rs
@@ -325,7 +325,7 @@ pub fn run(
         })
         .await;
     });
-    lua_handle.end_session(session_id.id());
+    lua_handle.end_sessions_blocking([session_id.id()]);
 
     let duration_ms = start.elapsed().as_millis();
     // Zero on an unpriced model, which is what its turns reported too.


### PR DESCRIPTION
Follow-up to #774. Tony asked whether monitor can live as a standalone Lua plugin. Not yet: plugin jobs die on `/reload`, and Lua only sees TUI `/new` via `SessionReset`. This branch adds the missing host hooks so a later rewrite can drop the native supervisor.

Rebased onto current `main` and split into five commits. Review-fix rounds are folded into the commit they belong to; the last commit is the leftover hang-on-quit / ACP wait.

1. **SessionEnd** — teardown hook on every session-end path (TUI reset/load/delete/shutdown, ACP replace/EOF, headless completion). `SessionReset` stays TUI-only.
2. **jobinfo / joblist** — live inspect plus `jobstart tail=N`. Task and plugin jobs still disappear on exit, so this is a live view.
3. **`owner = "session"`** — survives plugin reload; the same plugin can still inspect and stop it. `notify` posts a mailbox observation from the host. `SessionEnd` fires first so handlers can inspect or stop those jobs, then the host reaps them. Folds the first review round (stale-pid kill, truncated `jobwait`, frozen `elapsed_secs`, exited jobs in `joblist`).
4. **suspending callbacks + `maki.fs.append`** — job and autocmd callbacks run in their own coroutine so they can await `maki.fs`. SessionEnd wait is bounded on process-exit paths. `append` grows a log file without replacing it. Folds later review (per-callback scopes, delivery-scope pinning, async `append`, `jobwait` surviving a failing callback).
5. **UI roundtrip timeout + async ACP SessionEnd** — `ui_roundtrip` times out if the event loop has stopped draining, so a SessionEnd handler that touches `winsaveview` on quit cannot deadlock teardown. ACP polls `end_session_async` instead of blocking the executor over stdin.

Commit 3 is the one to discuss. The first two stand on their own. Commits 4 and 5 are the plumbing a Lua monitor needs in order to write logs from those callbacks without hanging quit.

## Test plan

- [x] `cargo clippy` on `maki-lua`, `maki-ui`, `maki-acp` (`-D warnings`)
- [x] `cargo nextest run -p maki-lua -p maki-ui -p maki-acp`
- [x] `just gen-docs` / `cargo fmt --all -- --check`