### PR TITLE
perf(build): stop linking debug info nobody reads

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,6 +63,10 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    env:
+      # The runner ships libssl-dev, so skip the two minute vendored OpenSSL
+      # build on a cache miss. Windows has none and keeps vendoring.
+      OPENSSL_NO_VENDOR: 1
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
@@ -76,6 +80,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    env:
+      OPENSSL_NO_VENDOR: 1
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
@@ -104,6 +110,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    env:
+      OPENSSL_NO_VENDOR: 1
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,6 +84,8 @@ jobs:
           tool: just,cargo-nextest
       - run: sudo apt-get -o Acquire::Retries=5 install -y ripgrep
       - run: just test
+      # Lives here to reuse the warm target dir instead of building the graph twice.
+      - run: just gen-docs-check
 
   machete:
     name: Unused deps
@@ -96,19 +98,6 @@ jobs:
         with:
           tool: cargo-machete
       - run: cargo machete
-
-  docs:
-    name: Docs
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: just
-      - run: just gen-docs-check
 
   build:
     name: Build
@@ -123,8 +112,8 @@ jobs:
           tool: just
       - run: just build
 
-  lint-windows:
-    name: Lint (Windows)
+  windows:
+    name: Lint + Build (Windows)
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: windows-latest
@@ -135,24 +124,12 @@ jobs:
         with:
           tool: just
       - run: just lint
-
-  build-windows:
-    name: Build (Windows)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: just
       - run: just build
 
   ci-pass:
     name: CI
     if: always()
-    needs: [fmt, fmt-lua, lint, test, machete, docs, build, lint-windows, build-windows]
+    needs: [fmt, fmt-lua, lint, test, machete, build, windows]
     runs-on: ubuntu-latest
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,10 +44,7 @@ Dev builds skip debug info for deps and vendored C (our crates keep it); to debu
 
 ## Nix
 
-- `nix build` — build the project in a sandboxed environment
-- `nix develop` — enter the dev shell (Rust toolchain, formatters, CLI tools)
-- `nix fmt` — format all `.nix` files with `nixfmt`
-- `nix flake check` — run all flake checks (including git-dep-hashes drift detection)
+`nix develop` (dev shell; exports `OPENSSL_NO_VENDOR`, saves ~80s cold build - export it yourself outside the shell if you have libssl-dev), `nix build`, `nix fmt` (nixfmt), `nix flake check` (includes git-dep-hashes drift).
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,10 +32,15 @@ Maki is an AI coding agent (like Claude Code and opencode), that is built bottom
 
 ## Testing
 
-- cargo clippy --all --tests -- -D warnings
-- cargo nextest run --workspace
+Cheapest first, and scope to the crate you touched while iterating:
+
+- `just check` (or `cargo check -p <crate> --tests`)
+- `just lint` - `cargo clippy --all --tests -- -D warnings`
+- `just test` - `cargo nextest run --workspace`
 
 Read `justfile` for more.
+
+Dev builds skip debug info for deps and vendored C (our crates keep it); to debug into a dep set `[profile.dev.package.<name>] debug = true`.
 
 ## Nix
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ Regarding AI use in PRs, describe how you used AI, even include the prompts if u
 
 Useful commands are in the `justfile` file, most useful probably is `just ci` that runs locally basically everything we run in the CI automatically to block PRs.
 
+Rebuilds are slow mostly because of the linker, so dev builds skip debug info for the dependencies and for the C we build from source (`profile.dev.build-override` is where `cc` picks up `-g`). Our own crates keep theirs, so debugging maki feels the same as always, and if you ever want to step into a dependency, add `[profile.dev.package.<name>] debug = true`, or comment out `[profile.dev.package."*"]` in `Cargo.toml` to get all of them back.
+
 My most useful prompts:
 
 ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,3 +191,15 @@ inventory = "0.3"
 
 [profile.bench]
 debug = true
+
+# Dev rebuilds are linker bound, and debug info is most of what the linker
+# chews through. Our crates keep theirs so a debugger still works, the 600
+# dependencies do not need any.
+[profile.dev.package."*"]
+debug = false
+
+# `cc` reads DEBUG from here and passes -g when it is on, which covers the C
+# and C++ we build from source: OpenSSL, curl, Luau and 30 tree-sitter
+# grammars. Those static archives held the bulk of the bytes.
+[profile.dev.build-override]
+debug = false

--- a/flake.nix
+++ b/flake.nix
@@ -221,6 +221,12 @@
 
             SSL_CERT_FILE = certs;
             NIX_SSL_CERT_FILE = certs;
+
+            # isahc's `static-ssl` makes openssl-sys build OpenSSL from source,
+            # two minutes of a cold build. This shell already has one below, so
+            # use it. Release builds run in Alpine and still vendor.
+            OPENSSL_NO_VENDOR = "1";
+
             LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
               pkgs.openssl
               pkgs.stdenv.cc.cc.lib

--- a/justfile
+++ b/justfile
@@ -4,6 +4,10 @@ default:
 build *ARGS:
     cargo build {{ARGS}}
 
+# Types only, no codegen, no lints. Add `-p <crate>` to make it cheaper still.
+check *ARGS:
+    cargo check --workspace --tests {{ARGS}}
+
 run *ARGS:
     cargo run {{ARGS}}
 


### PR DESCRIPTION
Dev rebuilds spent most of their time in the linker, and almost all of that on debug info, on a target dir that had grown to 14G.

The 600 dependencies now build without any, and our own crates keep theirs, so a debugger still steps through maki as usual.

The knob that mattered most is `build-override`, since `cc` reads `DEBUG` from it, so `-g` is gone from OpenSSL, curl, Luau and the 30 tree-sitter grammars we build from source, and those static archives held the bulk of the bytes.

CI also stops building the graph twice, and `just check` is there for the tightest loop.