### PR TITLE
feat(ui): add Ctrl+M binding to open model picker

### DIFF
--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -439,6 +439,7 @@ pub enum BuiltinAction {
     PopQueue,
     PrevChat,
     NextChat,
+    ModelPicker,
 }
 
 pub enum UiAction {

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -776,6 +776,10 @@ impl App {
             BuiltinAction::NextChat => {
                 self.active_chat = (self.active_chat + 1).min(self.chats.len() - 1);
             }
+            BuiltinAction::ModelPicker => {
+                self.model_picker.open(&self.state.model.spec());
+                return vec![Action::RefreshModels];
+            }
         }
         vec![]
     }
@@ -838,6 +842,9 @@ impl App {
     fn handle_main_chat_key(&mut self, key: KeyEvent) -> Vec<Action> {
         if key::EDIT_INPUT.matches(key) {
             return self.run_builtin(BuiltinAction::EditInput);
+        }
+        if key::MODEL_PICKER.matches(key) {
+            return self.run_builtin(BuiltinAction::ModelPicker);
         }
         if is_ctrl(&key) {
             if key::POP_QUEUE.matches(key) {

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -4541,3 +4541,24 @@ fn run_builtin_file_picker_opens_modal() {
     assert!(app.run_builtin(BuiltinAction::FilePicker).is_empty());
     assert!(app.file_picker.is_open());
 }
+
+#[test]
+fn run_builtin_model_picker_opens_and_refreshes() {
+    let mut app = test_app();
+    let actions = app.run_builtin(BuiltinAction::ModelPicker);
+    assert!(app.model_picker.is_open());
+    assert!(matches!(&actions[..], [Action::RefreshModels]));
+}
+
+#[test]
+fn alt_m_opens_model_picker() {
+    let mut app = test_app();
+    let key = KeyEvent {
+        code: KeyCode::Char('m'),
+        modifiers: KeyModifiers::CONTROL,
+        kind: crossterm::event::KeyEventKind::Press,
+        state: crossterm::event::KeyEventState::NONE,
+    };
+    app.update(Msg::Key(key));
+    assert!(app.model_picker.is_open());
+}

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -144,6 +144,7 @@ pub mod key {
     pub const OPEN_EDITOR: Bind = ctrl_bind!('o');
     pub const PLAN_TOGGLE: Bind = ctrl_bind!('t');
     pub const TASKS: Bind = ctrl_bind!('x');
+    pub const MODEL_PICKER: Bind = ctrl_bind!('m');
     pub const REFRESH: Bind = ctrl_bind!('r');
     pub const SUSPEND: Bind = ctrl_bind!('z');
     pub const DELETE: Bind = ctrl_bind!('d');
@@ -348,6 +349,12 @@ pub const KEYBINDS: &[Keybind] = &[
     Keybind {
         label: KeyLabel::Single(key::TASKS.label),
         description: "Open tasks",
+        context: KeybindContext::General,
+        platform: Platform::All,
+    },
+    Keybind {
+        label: KeyLabel::Single(key::MODEL_PICKER.label),
+        description: "Model picker",
         context: KeybindContext::General,
         platform: Platform::All,
     },

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -21,6 +21,7 @@ On macOS, some bindings use Option or Fn keys instead (run `/help` for exact key
 | `Ctrl+O` | Open plan in editor |
 | `Ctrl+T` | Toggle plan panel |
 | `Ctrl+X` | Open tasks |
+| `Ctrl+M` | Model picker |
 
 ## Editing
 


### PR DESCRIPTION
Ctrl+M opens the model picker from the main chat, same as /model. Wired through BuiltinAction so it is rebindable via maki.ui.action.