### PR TITLE
feat(providers/llama-cpp): configure native thinking fields

### DIFF
--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -1,3 +1,4 @@
+use maki_providers::Effort;
 use maki_providers::manifest::ManifestRegistry;
 use maki_providers::model::{ModelEntry, ModelTier};
 use maki_providers::provider::ProviderKind;
@@ -229,6 +230,7 @@ You can also create a custom provider interactively with `maki auth login` and c
 
 fn dynamic_providers_section() -> String {
     let valid_values: Vec<String> = ProviderKind::iter().map(|k| format!("`{k}`")).collect();
+    let efforts: Vec<String> = Effort::ALL.iter().map(|e| format!("`{e}`")).collect();
 
     format!(
         r#"## Dynamic Providers
@@ -256,6 +258,35 @@ If your provider serves models not in the base catalog, add a `models` subcomman
 
 Only `id` is required. Optional fields: `tier` (default `medium`), `context_window` (128K), `max_output_tokens` (16K), `pricing` (`{{input, output, cache_write, cache_read}}`, all per 1M tokens), `supports_tool_examples` (defaults to the base provider's setting), `supports_thinking` (defaults to the base provider's setting), `requires_thinking` (default false; for APIs that reject requests with thinking off, raises it to minimal effort and implies `supports_thinking`), `supports_vision` (defaults to the base provider's setting; when false, image input and the `view_image` tool are disabled). The first model listed per tier is used for sub-agents. Without this subcommand, the base provider's models are used.
 
+A `llama-cpp` model can replace Maki's token-budget mapping with its native thinking fields. Each thinking mode maps to a JSON fragment merged into the request body:
+
+```json
+[{{
+  "id": "reasoning-model",
+  "supports_thinking": true,
+  "thinking_fields": {{
+    "off": {{"reasoning_effort": "none"}},
+    "adaptive": {{"reasoning_effort": "medium"}},
+    "low": {{"reasoning_effort": "low"}},
+    "medium": {{"reasoning_effort": "medium"}},
+    "xhigh": {{"reasoning_effort": "xhigh"}}
+  }}
+}}]
+```
+
+`off` is used when thinking is off, `adaptive` when thinking is on without a chosen level. Any other key is an effort level, one of {}. The levels you declare are the ones the model accepts: whatever you ask for snaps into them, downwards first, so a level the model never advertised is never sent. Every part is optional.
+
+Fragments are merged into the body, so nesting works too. A template toggle is just a fragment:
+
+```json
+"thinking_fields": {{
+  "off": {{"chat_template_kwargs": {{"enable_thinking": false}}}},
+  "adaptive": {{"chat_template_kwargs": {{"enable_thinking": true}}}}
+}}
+```
+
+Named modes send only these fields, no token budget. An explicit `/thinking <budget>` snaps into the levels you declared; a model that declares none gets the `adaptive` fragment plus `thinking_budget_tokens`. Any mode you left undeclared falls back to the usual `thinking_budget_tokens` mapping, so no request ever ends up saying nothing. Models without `thinking_fields` keep the existing llama.cpp behavior.
+
 Dynamic provider models are namespaced as `{{slug}}/{{model_id}}` (e.g. `myproxy/claude-sonnet-4-6`).
 
 ### Script Name Rules
@@ -265,6 +296,7 @@ Dynamic provider models are namespaced as `{{slug}}/{{model_id}}` (e.g. `myproxy
 - Can't reuse a built-in provider's slug
 - Must be executable"#,
         valid_values.join(", "),
+        efforts.join(", "),
     )
 }
 

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use crate::manifest::{ManifestRegistry, ProviderManifest};
 use crate::model_registry;
 use crate::providers::{anthropic, custom, dynamic};
+use crate::types::ThinkingFields;
 
 const PER_MILLION: f64 = 1_000_000.0;
 
@@ -242,6 +243,7 @@ pub struct Model {
     /// `None` when unknown, see [`ProviderKind::fallback_max_output`].
     pub max_output_tokens: Option<u32>,
     pub context_window: u32,
+    pub thinking_fields: Option<Box<ThinkingFields>>,
 }
 
 impl Model {
@@ -280,6 +282,7 @@ impl Model {
             pricing,
             max_output_tokens,
             context_window,
+            thinking_fields: None,
         }
     }
 
@@ -310,6 +313,7 @@ impl Model {
             },
             max_output_tokens: Some(meta.output),
             context_window: meta.context,
+            thinking_fields: None,
         }
     }
 

--- a/maki-providers/src/providers/catalog.rs
+++ b/maki-providers/src/providers/catalog.rs
@@ -1027,6 +1027,7 @@ mod tests {
             pricing: ModelPricing::default(),
             max_output_tokens: None,
             context_window: 0,
+            thinking_fields: None,
         };
         let (tx, _rx) = flume::unbounded();
         let result = smol::block_on(provider.stream_message(

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -154,6 +154,7 @@ fn model_from_def(def: &ProviderDef, kind: ProviderKind, slug: &str, model_id: &
         pricing,
         max_output_tokens,
         context_window,
+        thinking_fields: None,
     }
 }
 

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -17,6 +17,7 @@ use tracing::{debug, warn};
 use crate::manifest::ManifestRegistry;
 use crate::model::{Model, ModelPricing, ModelTier, ThinkingSupport};
 use crate::provider::{BoxFuture, Provider, ProviderKind};
+use crate::types::ThinkingFields;
 use crate::{AgentError, Message, ProviderEvent, ProviderUsage, RequestOptions, StreamResponse};
 
 use super::ResolvedAuth;
@@ -38,6 +39,7 @@ const INFO_TIMEOUT: Duration = Duration::from_secs(5);
 const SCRIPT_TIMEOUT: Duration = Duration::from_secs(30);
 const PROVIDERS_DIR: &str = "providers";
 const SCRIPT_CACHE_FILE: &str = "provider-scripts.json";
+const THINKING_FIELDS_KEY: &str = "thinking_fields";
 
 struct DynamicProviderMeta {
     slug: String,
@@ -77,6 +79,8 @@ struct ScriptModel {
     context_window: u32,
     #[serde(default)]
     pricing: Option<ModelPricing>,
+    #[serde(default)]
+    thinking_fields: Option<ThinkingFields>,
 }
 
 impl ScriptModel {
@@ -95,6 +99,7 @@ impl ScriptModel {
             pricing: self.pricing.clone().unwrap_or_default(),
             max_output_tokens: Some(self.max_output_tokens),
             context_window: self.context_window,
+            thinking_fields: self.thinking_fields.clone().map(Box::new),
         }
     }
 }
@@ -313,13 +318,52 @@ fn build_meta(
         }
     };
 
-    let models = match &described.models {
-        Some(json) => serde_json::from_str(json).unwrap_or_else(|e| {
-            warn!(slug, error = %e, "invalid models JSON, falling back to base models");
-            Vec::new()
-        }),
+    // Entry by entry, so one bad model never costs the whole list.
+    let models: Vec<ScriptModel> = match &described.models {
+        Some(json) => serde_json::from_str::<Vec<Value>>(json)
+            .unwrap_or_else(|e| {
+                warn!(slug, error = %e, "invalid models JSON, falling back to base models");
+                Vec::new()
+            })
+            .into_iter()
+            .filter_map(|mut entry| {
+                let error = match serde_json::from_value::<ScriptModel>(entry.clone()) {
+                    Ok(model) => return Some(model),
+                    Err(e) => e,
+                };
+                // Malformed thinking fields cost the field, not the model.
+                let without_fields = entry
+                    .as_object_mut()
+                    .is_some_and(|o| o.remove(THINKING_FIELDS_KEY).is_some())
+                    .then(|| serde_json::from_value::<ScriptModel>(entry).ok())
+                    .flatten();
+                match without_fields {
+                    Some(model) => {
+                        warn!(slug, error = %error, model = model.id, "invalid thinking_fields, dropping them");
+                        Some(model)
+                    }
+                    None => {
+                        warn!(slug, error = %error, "invalid model entry, skipping");
+                        None
+                    }
+                }
+            })
+            .collect(),
         None => Vec::new(),
     };
+
+    // Only the llama.cpp request path reads these, so anywhere else they would
+    // vanish without a trace.
+    if !matches!(base, ProviderKind::LlamaCpp)
+        && let Some(model) = models.iter().find(|m| m.thinking_fields.is_some())
+    {
+        warn!(
+            slug,
+            base = %info.base,
+            model = model.id,
+            "thinking_fields only applies to llama-cpp models, ignoring"
+        );
+    }
 
     Some(DynamicProviderMeta {
         slug,
@@ -739,12 +783,21 @@ mod tests {
 
     #[test]
     fn script_model_deserialization() {
-        let full = r#"{"id": "my-model", "tier": "strong", "supports_tool_examples": true, "max_output_tokens": 32000, "context_window": 200000, "pricing": {"input": 3.0, "output": 15.0, "cache_write": 3.75, "cache_read": 0.30}}"#;
+        let full = r#"{"id": "my-model", "tier": "strong", "supports_tool_examples": true, "max_output_tokens": 32000, "context_window": 200000, "pricing": {"input": 3.0, "output": 15.0, "cache_write": 3.75, "cache_read": 0.30}, "thinking_fields": {"adaptive": {"reasoning_effort": "medium"}, "low": {"reasoning_effort": "low"}}}"#;
         let model: ScriptModel = serde_json::from_str(full).unwrap();
         assert_eq!(model.id, "my-model");
         assert_eq!(model.tier, ModelTier::Strong);
         assert_eq!(model.supports_tool_examples, Some(true));
         assert!(model.pricing.is_some());
+        let resolved = model.to_model(
+            "dynamic",
+            ProviderKind::LlamaCpp,
+            model.id.clone(),
+            model.tier,
+        );
+        let mut body = serde_json::json!({});
+        crate::ThinkingConfig::Adaptive.apply_local_thinking(&mut body, &resolved);
+        assert_eq!(body, serde_json::json!({"reasoning_effort": "medium"}));
 
         let minimal: ScriptModel = serde_json::from_str(r#"{"id": "custom-v1"}"#).unwrap();
         assert_eq!(minimal.tier, ModelTier::Medium);
@@ -752,6 +805,26 @@ mod tests {
         assert_eq!(minimal.max_output_tokens, 16384);
         assert_eq!(minimal.context_window, 128_000);
         assert!(minimal.pricing.is_none());
+        assert!(minimal.thinking_fields.is_none());
+    }
+
+    #[test]
+    fn bad_thinking_fields_keeps_the_model() {
+        let described = ScriptDescription {
+            modified_ns: 0,
+            size: 0,
+            info: r#"{"display_name": "T", "base": "llama-cpp", "has_auth": false}"#.into(),
+            models: Some(
+                r#"[{"id": "typo", "thinking_fields": {"hight": {"reasoning_effort": "high"}}},
+                    {"id": "broken", "tier": 7},
+                    {"id": "good"}]"#
+                    .into(),
+            ),
+        };
+        let meta = build_meta("t".into(), PathBuf::new(), &described).unwrap();
+        let ids: Vec<&str> = meta.models.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(ids, ["typo", "good"]);
+        assert!(meta.models[0].thinking_fields.is_none());
     }
 
     #[cfg(unix)]

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -703,6 +703,7 @@ mod tests {
             pricing: ModelPricing::default(),
             max_output_tokens: Some(8192),
             context_window: 1_048_576,
+            thinking_fields: None,
         }
     }
 

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -319,6 +319,7 @@ mod tests {
             pricing: ModelPricing::default(),
             max_output_tokens: Some(8192),
             context_window: 200_000,
+            thinking_fields: None,
         };
         (effort_dialect(info), model)
     }

--- a/maki-providers/src/providers/xai/platform.rs
+++ b/maki-providers/src/providers/xai/platform.rs
@@ -312,6 +312,7 @@ mod tests {
             pricing: ModelPricing::ZERO,
             max_output_tokens: Some(131_072),
             context_window: 500_000,
+            thinking_fields: None,
         }
     }
 

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -7,17 +7,20 @@
 //! belongs in model context, and must never be mistaken for the user talking.
 
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 pub use maki_storage::sessions::Effort;
 use maki_storage::sessions::{MIN_THINKING_BUDGET, StoredThinking, TitleSource};
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 use strum::{Display, IntoStaticStr};
 use tracing::warn;
 
 use crate::TokenUsage;
 use crate::model::Model;
+
+const LOCAL_BUDGET_FIELD: &str = "thinking_budget_tokens";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ImageMediaType {
@@ -408,6 +411,60 @@ pub struct EffortDialect<'a> {
     pub off: Option<&'static str>,
 }
 
+/// How a local model spells thinking on the wire, in place of a token budget.
+/// Each mode carries the JSON fragment merged into the request body, so any
+/// shape a chat template needs works without a schema per provider.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct ThinkingFields {
+    #[serde(default)]
+    off: Option<Map<String, Value>>,
+    #[serde(default)]
+    adaptive: Option<Map<String, Value>>,
+    /// Keyed by [`Effort`]; the declared keys are the levels the model accepts.
+    #[serde(flatten)]
+    levels: BTreeMap<Effort, Map<String, Value>>,
+}
+
+impl ThinkingFields {
+    /// Levels snap to the declared ones, so a level the model never advertised
+    /// is never sent. A token budget picks the level it corresponds to; models
+    /// that declare no levels fall back to `adaptive` and keep the count
+    /// (the returned flag tells the caller to still send the budget field).
+    fn fragment(
+        &self,
+        thinking: ThinkingConfig,
+        max: Option<u32>,
+    ) -> Option<(&Map<String, Value>, bool)> {
+        let level = match thinking {
+            ThinkingConfig::Off => return self.off.as_ref().map(|f| (f, false)),
+            ThinkingConfig::Adaptive => return self.adaptive.as_ref().map(|f| (f, false)),
+            ThinkingConfig::Effort(level) => level,
+            ThinkingConfig::Budget(n) => {
+                if self.levels.is_empty() {
+                    return self.adaptive.as_ref().map(|f| (f, true));
+                }
+                Effort::from_budget(n, max.unwrap_or(FALLBACK_MAX_THINKING_BUDGET))
+            }
+        };
+        let declared: Vec<Effort> = self.levels.keys().copied().collect();
+        self.levels
+            .get(&level.snap(&declared))
+            .or(self.adaptive.as_ref())
+            .map(|f| (f, false))
+    }
+}
+
+fn merge_body(body: &mut Map<String, Value>, fragment: &Map<String, Value>) {
+    for (key, value) in fragment {
+        match (body.get_mut(key), value.as_object()) {
+            (Some(Value::Object(target)), Some(source)) => merge_body(target, source),
+            _ => {
+                body.insert(key.clone(), value.clone());
+            }
+        }
+    }
+}
+
 pub mod dialect {
     use super::EffortDialect;
     use maki_storage::sessions::Effort::{High, Low, Max, Medium, Minimal, XHigh};
@@ -588,12 +645,25 @@ impl ThinkingConfig {
     }
 
     pub fn apply_local_thinking(self, body: &mut Value, model: &Model) {
-        let budget = match self.budget(model.max_thinking_budget()) {
+        let max = model.max_thinking_budget();
+        if let Some(fields) = &model.thinking_fields
+            && let Some((fragment, keep_budget)) = fields.fragment(self, max)
+            && let Some(object) = body.as_object_mut()
+        {
+            merge_body(object, fragment);
+            if keep_budget && let Budgeted::Tokens(budget) = self.budget(max) {
+                body[LOCAL_BUDGET_FIELD] = json!(budget);
+            }
+            return;
+        }
+        // No fragment means the model has no way to spell this mode, so the
+        // budget field takes over: a request must never end up saying nothing.
+        let budget = match self.budget(max) {
             Budgeted::Off => 0,
             Budgeted::Adaptive => -1,
             Budgeted::Tokens(n) => i64::from(n),
         };
-        body["thinking_budget_tokens"] = json!(budget);
+        body[LOCAL_BUDGET_FIELD] = json!(budget);
     }
 
     pub fn parse(input: &str, current: Self) -> Result<Self, &'static str> {
@@ -862,6 +932,25 @@ mod tests {
         }
     }
 
+    fn native_thinking_model(id: &str, fields: Value) -> crate::model::Model {
+        let mut model = thinking_model(id);
+        model.thinking_fields = Some(Box::new(serde_json::from_value(fields).unwrap()));
+        model
+    }
+
+    fn native_effort_model() -> crate::model::Model {
+        native_thinking_model(
+            "local-model",
+            json!({
+                "off": {"reasoning_effort": "none"},
+                "adaptive": {"reasoning_effort": "medium"},
+                "low": {"reasoning_effort": "low"},
+                "medium": {"reasoning_effort": "medium"},
+                "xhigh": {"reasoning_effort": "xhigh"}
+            }),
+        )
+    }
+
     #[test]
     fn dialects_have_non_empty_ascending_supported() {
         let all = [
@@ -970,6 +1059,67 @@ mod tests {
         assert_eq!(body["thinking_budget_tokens"], expected);
     }
 
+    #[test_case(ThinkingConfig::Off,           json!({"reasoning_effort": "none"})   ; "off")]
+    #[test_case(ThinkingConfig::Adaptive,      json!({"reasoning_effort": "medium"}) ; "adaptive")]
+    #[test_case(ThinkingConfig::Effort(Low),   json!({"reasoning_effort": "low"})    ; "low")]
+    #[test_case(ThinkingConfig::Effort(High),  json!({"reasoning_effort": "medium"}) ; "undeclared_high_snaps_down")]
+    #[test_case(ThinkingConfig::Effort(XHigh), json!({"reasoning_effort": "xhigh"})  ; "xhigh")]
+    #[test_case(ThinkingConfig::Budget(4096),  json!({"reasoning_effort": "xhigh"})  ; "numeric_budget_maps_to_declared_level")]
+    fn local_native_effort_uses_declared_levels(config: ThinkingConfig, expected: Value) {
+        let mut body = json!({});
+        config.apply_local_thinking(&mut body, &native_effort_model());
+        assert_eq!(body, expected);
+    }
+
+    #[test]
+    fn local_required_thinking_maps_off_to_lowest_native_effort() {
+        let mut model = native_effort_model();
+        model.thinking_override = Some(Support::Required);
+        let thinking = RequestOptions {
+            thinking: ThinkingConfig::Off,
+            fast: false,
+        }
+        .clamped(&model)
+        .thinking;
+        let mut body = json!({});
+        thinking.apply_local_thinking(&mut body, &model);
+        assert_eq!(body, json!({"reasoning_effort": "low"}));
+    }
+
+    #[test_case(ThinkingConfig::Off,          json!({"chat_template_kwargs": {"enable_thinking": false, "keep": 1}}) ; "off")]
+    #[test_case(ThinkingConfig::Adaptive,     json!({"chat_template_kwargs": {"enable_thinking": true, "keep": 1}})  ; "adaptive")]
+    #[test_case(ThinkingConfig::Effort(High), json!({"chat_template_kwargs": {"enable_thinking": true, "keep": 1}})  ; "effort_without_levels_uses_adaptive")]
+    #[test_case(ThinkingConfig::Budget(2048), json!({"chat_template_kwargs": {"enable_thinking": true, "keep": 1}, "thinking_budget_tokens": 2048}) ; "numeric_budget")]
+    fn local_native_toggle_merges_into_nested_object(config: ThinkingConfig, expected: Value) {
+        let model = native_thinking_model(
+            "local-toggle-model",
+            json!({
+                "off": {"chat_template_kwargs": {"enable_thinking": false}},
+                "adaptive": {"chat_template_kwargs": {"enable_thinking": true}}
+            }),
+        );
+        let mut body = json!({"chat_template_kwargs": {"keep": 1}});
+        config.apply_local_thinking(&mut body, &model);
+        assert_eq!(body, expected);
+    }
+
+    /// A mode the model has no fragment for must still reach the server, so
+    /// the budget field takes over instead of the request saying nothing.
+    #[test_case(json!({"low": {"reasoning_effort": "low"}}), ThinkingConfig::Off, 0 ; "off_without_off")]
+    #[test_case(json!({"adaptive": {"enable_thinking": true}}), ThinkingConfig::Off, 0 ; "toggle_without_off")]
+    #[test_case(json!({"off": {"reasoning_effort": "none"}}), ThinkingConfig::Adaptive, -1 ; "adaptive_without_adaptive")]
+    #[test_case(json!({"off": {"reasoning_effort": "none"}}), ThinkingConfig::Budget(4096), 4096 ; "budget_without_levels")]
+    fn local_native_missing_fragment_falls_back_to_budget(
+        fields: Value,
+        config: ThinkingConfig,
+        expected: i64,
+    ) {
+        let model = native_thinking_model("local-partial", fields);
+        let mut body = json!({});
+        config.apply_local_thinking(&mut body, &model);
+        assert_eq!(body, json!({ "thinking_budget_tokens": expected }));
+    }
+
     /// llama.cpp models have no known output window; the budget the user
     /// asked for must reach the server untouched.
     #[test]
@@ -993,6 +1143,7 @@ mod tests {
             pricing: crate::model::ModelPricing::default(),
             max_output_tokens: Some(8192),
             context_window: 200_000,
+            thinking_fields: None,
         }
     }
 

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -400,6 +400,7 @@ pub(crate) fn test_model() -> maki_providers::Model {
         pricing: test_pricing(),
         max_output_tokens: Some(8192),
         context_window: TEST_CONTEXT_WINDOW,
+        thinking_fields: None,
     }
 }
 

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -407,6 +407,35 @@ If your provider serves models not in the base catalog, add a `models` subcomman
 
 Only `id` is required. Optional fields: `tier` (default `medium`), `context_window` (128K), `max_output_tokens` (16K), `pricing` (`{input, output, cache_write, cache_read}`, all per 1M tokens), `supports_tool_examples` (defaults to the base provider's setting), `supports_thinking` (defaults to the base provider's setting), `requires_thinking` (default false; for APIs that reject requests with thinking off, raises it to minimal effort and implies `supports_thinking`), `supports_vision` (defaults to the base provider's setting; when false, image input and the `view_image` tool are disabled). The first model listed per tier is used for sub-agents. Without this subcommand, the base provider's models are used.
 
+A `llama-cpp` model can replace Maki's token-budget mapping with its native thinking fields. Each thinking mode maps to a JSON fragment merged into the request body:
+
+```json
+[{
+  "id": "reasoning-model",
+  "supports_thinking": true,
+  "thinking_fields": {
+    "off": {"reasoning_effort": "none"},
+    "adaptive": {"reasoning_effort": "medium"},
+    "low": {"reasoning_effort": "low"},
+    "medium": {"reasoning_effort": "medium"},
+    "xhigh": {"reasoning_effort": "xhigh"}
+  }
+}]
+```
+
+`off` is used when thinking is off, `adaptive` when thinking is on without a chosen level. Any other key is an effort level, one of `minimal`, `low`, `medium`, `high`, `xhigh`, `max`. The levels you declare are the ones the model accepts: whatever you ask for snaps into them, downwards first, so a level the model never advertised is never sent. Every part is optional.
+
+Fragments are merged into the body, so nesting works too. A template toggle is just a fragment:
+
+```json
+"thinking_fields": {
+  "off": {"chat_template_kwargs": {"enable_thinking": false}},
+  "adaptive": {"chat_template_kwargs": {"enable_thinking": true}}
+}
+```
+
+Named modes send only these fields, no token budget. An explicit `/thinking <budget>` snaps into the levels you declared; a model that declares none gets the `adaptive` fragment plus `thinking_budget_tokens`. Any mode you left undeclared falls back to the usual `thinking_budget_tokens` mapping, so no request ever ends up saying nothing. Models without `thinking_fields` keep the existing llama.cpp behavior.
+
 Dynamic provider models are namespaced as `{slug}/{model_id}` (e.g. `myproxy/claude-sonnet-4-6`).
 
 ### Script Name Rules


### PR DESCRIPTION
Hey, I ran into this while running Qwen3.8 27B locally. Its chat template supplies a different system prompt based on the selected thinking level, so merely sending a token budget is not enough. While looking for existing work I found PR #717 and figured I could follow up with the smaller thinking-focused part of it.

This adds optional per-model `thinking_dialect` and `thinking_fields` metadata for dynamic llama.cpp providers. Named modes use the model's native effort field or template toggle, while explicit numeric budgets still send `thinking_budget_tokens`. Models without this metadata keep the existing behavior.

Tested at runtime against my local llama-cpp deployment with bunch of permutations of Qwen 3.8, Qwen 3.6 and Muse 30B.
