### PR TITLE
feat(ui): bind Ctrl+P to the session picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ An AI coding agent optimized for minimal use of context tokens, while providing 
 * Extend with neovim like Lua plugins - [Builtin plugins](https://github.com/tontinton/maki/tree/main/plugins), [User made plugins showcase](https://github.com/tontinton/maki/discussions/452), [Lua API reference](https://maki.sh/docs/lua-api/).
 * Philosophy of not hiding anything - while other coding agents hide information as models improve (e.g. not showing number of lines read), maki leaves you in control.
 * UI fits everything well on my small screen laptop.
-* Full visibility of subagents - each subagent gets their own "chat window" you can easily navigate between using `/tasks` (Ctrl-X), or Ctrl-N/P.
+* Full visibility of subagents - each subagent gets their own "chat window" you can easily navigate between using `/tasks` (Ctrl-X).
 * Sensible permission system - when the agent runs `git diff && rm -rf /`, what do you think will happen in your current coding agent? It will treat it as `git *`. Maki uses tree-sitter to parse the bash command and figure out the permissions requested are `git *` and `rm *`. Disable using `--yolo`.
 * SSRF protection on `webfetch` calls.
 * A `memory` tool to keep long term context, just tell maki to remember something (sometimes it uses it automatically). Managed via `/memory` (view / edit / delete memories).

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -88,6 +88,7 @@ const FLASH_REWIND: &str = "Press esc again to rewind...";
 const AUTH_EXPIRED_MSG: &str =
     "Token expired. Run `maki auth login` in another terminal, then press Enter to retry.";
 const FLASH_NO_PLAN: &str = "No plan file";
+const SESSIONS_COMMAND: &str = "/sessions";
 const FAST_UNSUPPORTED_MSG: &str = "Fast mode requires an Anthropic Opus 4.6+ model (API only)";
 const FAST_ON_MSG: &str = "Fast mode: on";
 const FAST_OFF_MSG: &str = "Fast mode: off";
@@ -513,11 +514,9 @@ impl App {
         if key::TASKS.matches(key) {
             return Some(self.run_builtin(BuiltinAction::Tasks));
         }
-        if key::PREV_CHAT.matches(key) {
-            return Some(self.run_builtin(BuiltinAction::PrevChat));
-        }
-        if key::NEXT_CHAT.matches(key) {
-            return Some(self.run_builtin(BuiltinAction::NextChat));
+        if key::SESSIONS.matches(key) {
+            self.run_lua_command(SESSIONS_COMMAND, String::new(), 0);
+            return Some(vec![]);
         }
         if key::SCROLL_HALF_UP.matches(key) {
             let half = self.chats[self.active_chat].half_page();

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -750,7 +750,7 @@ fn tab_in_palette_completes_command() {
 }
 
 #[test]
-fn ctrl_p_n_navigation() {
+fn chat_navigation_actions() {
     let mut app = test_app();
     app.status = Status::Streaming;
     app.run_id = 1;
@@ -762,16 +762,16 @@ fn ctrl_p_n_navigation() {
     assert_eq!(app.chats.len(), 2);
     assert_eq!(app.active_chat, 0);
 
-    app.update(Msg::Key(kb::NEXT_CHAT.to_key_event()));
+    app.run_builtin(BuiltinAction::NextChat);
     assert_eq!(app.active_chat, 1);
 
-    app.update(Msg::Key(kb::NEXT_CHAT.to_key_event()));
+    app.run_builtin(BuiltinAction::NextChat);
     assert_eq!(app.active_chat, 1);
 
-    app.update(Msg::Key(kb::PREV_CHAT.to_key_event()));
+    app.run_builtin(BuiltinAction::PrevChat);
     assert_eq!(app.active_chat, 0);
 
-    app.update(Msg::Key(kb::PREV_CHAT.to_key_event()));
+    app.run_builtin(BuiltinAction::PrevChat);
     assert_eq!(app.active_chat, 0);
 }
 
@@ -1249,8 +1249,7 @@ fn picker_enter_stays_at_navigated() {
 }
 
 const OVERLAY_BLOCKED_KEYS: &[KeyEvent] = &[
-    kb::NEXT_CHAT.to_key_event(),
-    kb::PREV_CHAT.to_key_event(),
+    kb::SESSIONS.to_key_event(),
     kb::SCROLL_HALF_UP.to_key_event(),
     kb::SCROLL_HALF_DOWN.to_key_event(),
     kb::HELP.to_key_event(),
@@ -4067,7 +4066,7 @@ fn permission_prompt_takes_bottom_precedence_over_below_split() {
 
 fn app_with_active_subagent() -> App {
     let mut app = app_with_subagent();
-    app.update(Msg::Key(kb::NEXT_CHAT.to_key_event()));
+    app.run_builtin(BuiltinAction::NextChat);
     assert_eq!(app.active_chat, 1);
     app
 }
@@ -4114,7 +4113,7 @@ fn esc_in_main_chat_with_active_subagent_no_cancel() {
 fn cancel_subagent_removes_answer_sender() {
     let (mut app, _sub_rx, _main_rx) = app_with_subagent_tx(TASK_ID);
     assert!(!app.subagent_answers.is_empty());
-    app.update(Msg::Key(kb::NEXT_CHAT.to_key_event()));
+    app.run_builtin(BuiltinAction::NextChat);
     assert_eq!(app.active_chat, 1);
     app.last_esc = Some(Instant::now());
     app.update(Msg::Key(key(KeyCode::Esc)));
@@ -4161,7 +4160,7 @@ fn subagent_cancel_then_navigate_back_main_unaffected() {
     app.update(Msg::Key(key(KeyCode::Esc)));
     assert!(app.chats[1].is_finished());
 
-    app.update(Msg::Key(kb::PREV_CHAT.to_key_event()));
+    app.run_builtin(BuiltinAction::PrevChat);
     assert_eq!(app.active_chat, 0);
     assert_eq!(app.status, Status::Streaming);
     assert!(!app.chats[0].is_finished());

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -129,8 +129,7 @@ pub mod key {
 
     pub const QUIT: Bind = ctrl_bind!('c');
     pub const HELP: Bind = ctrl_bind!('h');
-    pub const PREV_CHAT: Bind = ctrl_bind!('p');
-    pub const NEXT_CHAT: Bind = ctrl_bind!('n');
+    pub const SESSIONS: Bind = ctrl_bind!('p');
     pub const SCROLL_HALF_UP: Bind = ctrl_bind!('u');
     pub const SCROLL_HALF_DOWN: Bind = ctrl_bind!('d');
     pub const SCROLL_LINE_UP: Bind = ctrl_bind!('y');
@@ -317,8 +316,8 @@ pub const KEYBINDS: &[Keybind] = &[
         platform: Platform::All,
     },
     Keybind {
-        label: KeyLabel::Alt(key::NEXT_CHAT.label, key::PREV_CHAT.label),
-        description: "Next / previous task chat",
+        label: KeyLabel::Single(key::SESSIONS.label),
+        description: "Browse sessions",
         context: KeybindContext::General,
         platform: Platform::All,
     },

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -15,7 +15,7 @@ On macOS, some bindings use Option or Fn keys instead (run `/help` for exact key
 |-----|--------|
 | `Ctrl+C` | Quit / clear input |
 | `Ctrl+H` | Show keybindings |
-| `Ctrl+N` / `Ctrl+P` | Next / previous task chat |
+| `Ctrl+P` | Browse sessions |
 | `Ctrl+F` | Search messages |
 | `Ctrl+S` | File picker |
 | `Ctrl+O` | Open plan in editor |

--- a/site/index.html
+++ b/site/index.html
@@ -1403,7 +1403,7 @@
         <div class="pip pip-lavender"></div>
         <div>
           <strong>Full visibility</strong>
-          <p>Philosophy: don't hide anything. Token count, cost, and model are always in the status bar. Each subagent gets its own chat window you can flip through with Ctrl-N/P. Ctrl-F for fuzzy search. <code>/btw</code> runs a side query without touching the current session. <code>!</code> runs shell commands, <code>!!</code> runs them silently.</p>
+          <p>Philosophy: don't hide anything. Token count, cost, and model are always in the status bar. Each subagent gets its own chat window you can flip through with <code>/tasks</code> (Ctrl-X). Ctrl-F for fuzzy search. <code>/btw</code> runs a side query without touching the current session. <code>!</code> runs shell commands, <code>!!</code> runs them silently.</p>
         </div>
       </div>
       <div class="pitch-item">


### PR DESCRIPTION
Ctrl+N and Ctrl+P used to flip between subagent chats, but `/tasks` (Ctrl+X) already does that better, and jumping between sessions had no key at all.

Ctrl+P now runs the `/sessions` command and Ctrl+N is free again, while `prev_chat` and `next_chat` stay available as builtin actions for anyone who wants them back from Lua.