### PR TITLE
plugins: edit: Change insert_lines to insert after instead of before

### DIFF
--- a/plugins/edit/edit_helpers.lua
+++ b/plugins/edit/edit_helpers.lua
@@ -45,4 +45,13 @@ function M.replace_lines(content, start_line, end_line, new_string)
   return trailing_nl and joined .. "\n" or joined
 end
 
+-- Insert `new_string` after line `after_line` and check arguments.
+function M.insert_after(content, after_line, new_string)
+  local lines = split_lines(content)
+  if after_line < 0 or after_line > #lines then
+    return nil, string.format("after line %d out of range (0-%d)", after_line, #lines)
+  end
+  return M.replace_lines(content, after_line + 1, nil, new_string)
+end
+
 return M

--- a/plugins/edit/init.lua
+++ b/plugins/edit/init.lua
@@ -2,6 +2,7 @@ local shorten_path = require("maki.shorten_path")
 local ToolView = require("maki.tool_view")
 local fuzzy_replace = require("maki.fuzzy_replace")
 local replace_lines = require("edit_helpers").replace_lines
+local insert_after = require("edit_helpers").insert_after
 
 local SNIPPET_MAX_CHARS = 32
 local FALLBACK_VIEW_LINES = 10
@@ -10,7 +11,7 @@ local EDIT_LINES_DESCRIPTION =
   [[Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new_string`. Use empty `new_string` to delete a range. Do not use with the batch tool.]]
 
 local INSERT_LINES_DESCRIPTION =
-  [[Insert lines before a given line number. Lines at `line` and below shift down. Existing lines are preserved. Do not use with the batch tool.]]
+  [[Insert `new_string` after line `line`, or at the top with 0. Only include new lines, never lines already in the file. Do not use with the batch tool.]]
 
 local EDIT_DESCRIPTION = [[Replace an exact string match in a file.
 
@@ -454,7 +455,7 @@ register_tool_if(opts.insert_lines, {
       },
       line = {
         type = "integer",
-        description = "Line number to insert before (1-indexed). Use 1 to insert at the top.",
+        description = "Line number to insert after (1-indexed). Use 0 to insert at the top.",
         required = true,
       },
       new_string = {
@@ -467,16 +468,16 @@ register_tool_if(opts.insert_lines, {
 
   header = edit_header,
   restore = diff_restore(function(input)
-    return { { new = input.new_string, nr = input.line } }
+    return { { new = input.new_string, nr = input.line + 1 } }
   end),
 
   handler = function(input, ctx)
     local result, err = apply_edit(input.path, ctx, function(content)
-      return replace_lines(content, input.line, nil, input.new_string)
+      return insert_after(content, input.line, input.new_string)
     end)
     if not result then
       return { llm_output = err, is_error = true }
     end
-    return diff_result(result, string.format("inserted at line %d in %s", input.line, shorten_path(result.path)))
+    return diff_result(result, string.format("inserted after line %d in %s", input.line, shorten_path(result.path)))
   end,
 })

--- a/plugins/edit/tests/spec.lua
+++ b/plugins/edit/tests/spec.lua
@@ -220,6 +220,7 @@ case("cjk_exact_match", function()
 end)
 
 local replace_lines = require("edit_helpers").replace_lines
+local insert_after = require("edit_helpers").insert_after
 
 case("replace_lines_range_replace_and_delete", function()
   local content = "aaa\nbbb\nccc\nddd\neee\n"
@@ -260,6 +261,24 @@ case("replace_lines_insert_mode", function()
 
   local r4 = replace_lines(content, 2, nil, "")
   eq(r4, "aaa\n\nbbb\nccc\n")
+end)
+
+case("insert_after_mode", function()
+  local content = "aaa\nbbb\nccc\n"
+
+  local r0 = insert_after(content, 0, "TOP")
+  eq(r0, "TOP\naaa\nbbb\nccc\n")
+
+  local r2 = insert_after(content, 2, "XXX\nYYY")
+  eq(r2, "aaa\nbbb\nXXX\nYYY\nccc\n")
+
+  local r3 = insert_after(content, 3, "END")
+  eq(r3, "aaa\nbbb\nccc\nEND\n")
+
+  local _, e1 = insert_after(content, -1, "x")
+  has(e1, "out of range")
+  local _, e2 = insert_after(content, 4, "x")
+  has(e2, "out of range")
 end)
 
 if #failures > 0 then

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -84,11 +84,11 @@ Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new
 
 ### `insert_lines` <span class="badge badge-optin">opt-in</span> {#insert_lines}
 
-Insert lines before a given line number. Lines at `line` and below shift down. Existing lines are preserved. Do not use with the batch tool.
+Insert `new_string` after line `line`, or at the top with 0. Only include new lines, never lines already in the file. Do not use with the batch tool.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `line` | integer | yes | Line number to insert before (1-indexed). Use 1 to insert at the top. |
+| `line` | integer | yes | Line number to insert after (1-indexed). Use 0 to insert at the top. |
 | `new_string` | string | yes | Text to insert |
 | `path` | string | yes | Absolute path to the file |
 


### PR DESCRIPTION
And be more clear that only the inserted lines should be specified and not any existing ones.

Previously with insert_lines the model often included the existing anchor line in the tool call, duplicating it.

----

I've noticed multiple times that models were confused by the current insert_lines tool that works the other way around and had to think about it a bit. Also relatively often they were duplicating the anchor line. This now seems to work reliably here without the model having to spend tokens and thinking how to call it correctly.

This is in edit_helpers mostly because of being able to test it.