### PR TITLE
fix(agent): stop a stalled turn from bricking the session

### DIFF
--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -73,13 +73,7 @@ pub(super) async fn compact_history(
                         "compaction succeeded after truncating oldest rounds"
                     );
                 }
-                return Ok(finish_compact(
-                    response,
-                    history,
-                    event_tx,
-                    compact_start,
-                    model,
-                ));
+                return finish_compact(response, history, event_tx, compact_start, model);
             }
             Err(e) if e.is_context_overflow() && attempt < max_attempts - 1 => {
                 last_error = Some(e);
@@ -98,7 +92,7 @@ fn finish_compact(
     event_tx: &EventSender,
     compact_start: std::time::Instant,
     model: &Model,
-) -> TokenUsage {
+) -> Result<TokenUsage, AgentError> {
     let _ = event_tx.send(AgentEvent::TurnComplete(Box::new(TurnCompleteEvent {
         message: response.message.clone(),
         usage: response.usage,
@@ -106,6 +100,12 @@ fn finish_compact(
         cost: model.cost_of(&response.usage, false),
         context_size: Some(response.usage.output),
     })));
+
+    // Swapping the history for a summary the model never wrote would throw the
+    // session away for nothing.
+    if response.message.first_text_content().is_none() {
+        return Err(AgentError::EmptySummary);
+    }
 
     let new_history = vec![
         Message::user("What did we do so far?".into()),
@@ -118,7 +118,7 @@ fn finish_compact(
         "compaction completed"
     );
 
-    response.usage
+    Ok(response.usage)
 }
 
 pub async fn compact(
@@ -164,12 +164,7 @@ fn strip_images(messages: &mut [Message]) {
 
 fn strip_thinking(messages: &mut [Message]) {
     for msg in messages {
-        msg.content.retain(|block| {
-            !matches!(
-                block,
-                ContentBlock::Thinking { .. } | ContentBlock::RedactedThinking { .. }
-            )
-        });
+        msg.content.retain(|block| !block.is_thinking());
     }
 }
 
@@ -341,6 +336,39 @@ mod tests {
             assert_eq!(msgs.len(), 2);
             assert!(matches!(msgs[0].role, Role::User));
             assert!(matches!(msgs[1].role, Role::Assistant));
+        });
+    }
+
+    #[test_case(vec![] ; "no_content")]
+    #[test_case(vec![ContentBlock::Text { text: " \n".into() }] ; "blank_text")]
+    fn compact_keeps_history_when_summary_has_no_text(content: Vec<ContentBlock>) {
+        smol::block_on(async {
+            let provider = MockProvider::new(vec![Ok(StreamResponse {
+                message: Message {
+                    role: Role::Assistant,
+                    content,
+                    ..Default::default()
+                },
+                usage: TokenUsage::default(),
+                stop_reason: Some(StopReason::EndTurn),
+            })]);
+            const KEPT: &str = "first";
+            let mut history = History::new(vec![Message::user(KEPT.into())]);
+            let (raw_tx, _rx) = flume::unbounded();
+
+            let err = compact(
+                &provider,
+                &default_model(),
+                &mut history,
+                &EventSender::new(raw_tx, 0),
+                &AgentConfig::default(),
+            )
+            .await
+            .expect_err("empty summary must fail");
+
+            assert!(matches!(err, AgentError::EmptySummary));
+            assert_eq!(history.len(), 1);
+            assert_eq!(history.as_slice()[0].user_text(), Some(KEPT));
         });
     }
 

--- a/maki-agent/src/agent/mod.rs
+++ b/maki-agent/src/agent/mod.rs
@@ -14,6 +14,5 @@ pub use instructions::{
     is_instruction_file, load_instruction_text, load_instructions,
 };
 pub use run::{
-    Agent, AgentParams, AgentRunParams, EMPTY_RESPONSE_MARKER, estimate_message_tokens,
-    resolve_compaction_model,
+    Agent, AgentParams, AgentRunParams, estimate_message_tokens, resolve_compaction_model,
 };

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -6,7 +6,7 @@ use tracing::{error, info, warn};
 
 use maki_providers::provider::Provider;
 use maki_providers::{
-    ContentBlock, Message, Model, RequestOptions, Role, StopReason, StreamResponse, TokenUsage,
+    ContentBlock, Message, Model, RequestOptions, StopReason, StreamResponse, TokenUsage,
 };
 
 use super::compaction;
@@ -25,12 +25,11 @@ use crate::{
 use maki_config::{ModelPolicy, ToolOutputLines};
 use maki_storage::id::SessionRef;
 
-/// Stands in for the assistant turn the model left blank, so the nudge
-/// below has something to answer. Never a real response: readers that mine
-/// history for model text must skip it.
-pub const EMPTY_RESPONSE_MARKER: &str = "(empty)";
 const MAX_REAUTH_ATTEMPTS: u32 = 2;
 const NUDGE_PROMPT: &str = "You just executed tool calls but returned an empty response. Please process the tool results above and continue with the task.";
+/// A model that stalls once often stalls again on the retry, so it gets a
+/// second chance before the turn ends empty handed.
+const MAX_NUDGES: u32 = 2;
 
 pub fn resolve_compaction_model(
     provider: &Arc<dyn Provider>,
@@ -101,7 +100,7 @@ pub struct Agent<'h> {
     config: AgentConfig,
     tool_output_lines: ToolOutputLines,
     reauth_attempts: u32,
-    post_tool_empty_retried: bool,
+    nudges: u32,
     permissions: Arc<PermissionManager>,
     opts: RequestOptions,
     session_id: Option<SessionRef>,
@@ -143,7 +142,7 @@ impl<'h> Agent<'h> {
             rollback_len: 0,
             mcp: None,
             reauth_attempts: 0,
-            post_tool_empty_retried: false,
+            nudges: 0,
             opts: RequestOptions::default(),
             session_id: params.session_id,
             mailbox: params.mailbox,
@@ -330,25 +329,11 @@ impl<'h> Agent<'h> {
             self.context_size +=
                 estimate_message_tokens(&self.history.as_slice()[history_len_before..]);
         } else {
-            let has_text = response.message.first_text_content().is_some();
-
-            if !has_text && !self.post_tool_empty_retried && self.history.has_recent_tool_results(5)
-            {
-                self.post_tool_empty_retried = true;
-                warn!("empty response after tool calls, nudging model to continue");
-                self.event_tx.send(AgentEvent::Nudge)?;
-                self.history.push(Message {
-                    role: Role::Assistant,
-                    content: vec![ContentBlock::Text {
-                        text: EMPTY_RESPONSE_MARKER.into(),
-                    }],
-                    ..Default::default()
-                });
-                self.history.push(Message::synthetic(NUDGE_PROMPT.into()));
+            if response.message.first_text_content().is_some() {
+                self.history.push(response.message);
+            } else if self.recover_stalled_turn()? {
                 return Ok(TurnOutcome::Continue);
             }
-
-            self.history.push(response.message);
 
             if stop_reason == Some(StopReason::MaxTokens)
                 && self.num_turns <= self.config.max_continuation_turns
@@ -427,8 +412,28 @@ impl<'h> Agent<'h> {
         })
     }
 
+    /// The turn came back without text, so [`Message::empty_marker`] takes its
+    /// place in history. Returns true when the model was nudged to try again.
+    fn recover_stalled_turn(&mut self) -> Result<bool, AgentError> {
+        // Asked before the marker lands, since it shifts the recent window.
+        let nudge = self.nudges < MAX_NUDGES && self.history.has_recent_tool_results(5);
+        self.history.push(Message::empty_marker());
+        if !nudge {
+            return Ok(false);
+        }
+
+        self.nudges += 1;
+        warn!(
+            self.nudges,
+            "empty response after tool calls, nudging model to continue"
+        );
+        self.event_tx.send(AgentEvent::Nudge)?;
+        self.history.push(Message::synthetic(NUDGE_PROMPT.into()));
+        Ok(true)
+    }
+
     async fn process_tool_calls(&mut self, response: StreamResponse) -> Result<(), AgentError> {
-        self.post_tool_empty_retried = false;
+        self.nudges = 0;
         let ctx = self.tool_context();
         tool_dispatch::process_tool_calls(
             response,
@@ -656,10 +661,21 @@ mod tests {
     }
 
     fn empty_response() -> StreamResponse {
+        assistant_response(vec![])
+    }
+
+    fn thinking_response() -> StreamResponse {
+        assistant_response(vec![ContentBlock::Thinking {
+            thinking: "stalled".into(),
+            signature: None,
+        }])
+    }
+
+    fn assistant_response(content: Vec<ContentBlock>) -> StreamResponse {
         StreamResponse {
             message: Message {
                 role: Role::Assistant,
-                content: vec![],
+                content,
                 ..Default::default()
             },
             usage: TokenUsage::default(),
@@ -1130,15 +1146,25 @@ mod tests {
             empty_response(),
             text_response(StopReason::EndTurn),
         ],
-        3, true
+        3, 1
         ; "nudge_on_empty_after_tools"
+    )]
+    #[test_case(
+        vec![
+            tool_call_response("glob", "t1"),
+            thinking_response(),
+            empty_response(),
+            empty_response(),
+        ],
+        4, 2
+        ; "nudges_twice_then_gives_up"
     )]
     #[test_case(
         vec![
             tool_call_response("glob", "t1"),
             text_response(StopReason::EndTurn),
         ],
-        2, false
+        2, 0
         ; "no_nudge_when_text_after_tools"
     )]
     #[test_case(
@@ -1146,10 +1172,10 @@ mod tests {
             empty_response(),
             text_response(StopReason::EndTurn),
         ],
-        1, false
+        1, 0
         ; "no_nudge_without_recent_tools"
     )]
-    fn nudge_behavior(responses: Vec<StreamResponse>, expected_turns: u32, expect_nudge: bool) {
+    fn nudge_behavior(responses: Vec<StreamResponse>, expected_turns: u32, expected_nudges: usize) {
         smol::block_on(async {
             let mut history = History::new(Vec::new());
             let (mut agent, event_rx) = make_agent(MockProvider::new(responses), &mut history);
@@ -1157,10 +1183,12 @@ mod tests {
             drop(agent);
             let events = drain_events(&event_rx);
 
-            assert_eq!(
-                has_event(&events, |e| matches!(e, AgentEvent::Nudge)),
-                expect_nudge,
-            );
+            let nudges = events
+                .iter()
+                .filter(|e| matches!(e.event, AgentEvent::Nudge))
+                .count();
+            assert_eq!(nudges, expected_nudges);
+
             let done = events
                 .iter()
                 .find_map(|e| match &e.event {
@@ -1169,6 +1197,15 @@ mod tests {
                 })
                 .expect("expected Done event");
             assert_eq!(done, expected_turns);
+
+            assert!(
+                history
+                    .as_slice()
+                    .iter()
+                    .all(|m| m.content.iter().any(|b| !b.is_thinking())),
+                "history holds a message no provider will accept: {:?}",
+                history.as_slice()
+            );
         });
     }
 

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -14,9 +14,9 @@ pub use mcp::{
 };
 pub(crate) mod task_set;
 pub use agent::{
-    Agent, AgentParams, AgentRunParams, EMPTY_RESPONSE_MARKER, History, HistorySnapshot,
-    Instructions, LoadedInstructions, SharedMessages, UNAVAILABLE_RESULT,
-    close_dangling_tool_calls, find_subdirectory_instructions, is_instruction_file,
+    Agent, AgentParams, AgentRunParams, History, HistorySnapshot, Instructions, LoadedInstructions,
+    SharedMessages, UNAVAILABLE_RESULT, close_dangling_tool_calls, find_subdirectory_instructions,
+    is_instruction_file,
 };
 pub use cancel::{CancelMap, CancelToken, CancelTrigger};
 pub use mailbox::{MailboxError, SessionMailbox};
@@ -35,7 +35,7 @@ use std::path::{Path, PathBuf};
 
 pub use maki_providers::AgentError;
 use maki_providers::Message;
-pub use maki_providers::{ImageMediaType, ImageSource, ThinkingConfig};
+pub use maki_providers::{EMPTY_RESPONSE_MARKER, ImageMediaType, ImageSource, ThinkingConfig};
 pub use types::{
     AgentEvent, BufferSnapshot, DoneReason, Envelope, EventSender, GrepFileEntry, GrepLine,
     GrepMatchGroup, InstructionBlock, NO_FILES_FOUND, SharedBuf, SnapshotLine, SnapshotSpan,

--- a/maki-providers/src/error.rs
+++ b/maki-providers/src/error.rs
@@ -26,6 +26,8 @@ pub enum AgentError {
     Cancelled,
     #[error("stream timed out after {secs}s of inactivity")]
     Timeout { secs: u64 },
+    #[error("compaction returned no summary")]
+    EmptySummary,
 }
 
 impl AgentError {
@@ -41,6 +43,7 @@ impl AgentError {
             | Self::Channel
             | Self::Json(_)
             | Self::Cancelled
+            | Self::EmptySummary
             | Self::HttpRequest(_) => false,
         }
     }
@@ -108,6 +111,7 @@ impl AgentError {
             Self::Json(_) => "received an invalid response from the API".into(),
             Self::Channel => "internal error, try again".into(),
             Self::Cancelled => "cancelled".into(),
+            Self::EmptySummary => "compaction returned no summary, history kept as is".into(),
         }
     }
 

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -23,7 +23,7 @@ pub use providers::dynamic;
 pub use providers::openai::auth as openai_auth;
 pub use providers::xai::auth as xai_auth;
 pub use types::{
-    ContentBlock, Effort, EffortDialect, IMAGE_OMITTED_NOTE, ImageMediaType, ImageSource, Message,
-    MessageKind, ProviderEvent, ProviderUsage, RequestOptions, Role, StopReason, StreamResponse,
-    ThinkingConfig, UsageLimit, adapt_images_for_model, dialect,
+    ContentBlock, EMPTY_RESPONSE_MARKER, Effort, EffortDialect, IMAGE_OMITTED_NOTE, ImageMediaType,
+    ImageSource, Message, MessageKind, ProviderEvent, ProviderUsage, RequestOptions, Role,
+    StopReason, StreamResponse, ThinkingConfig, UsageLimit, adapt_images_for_model, dialect,
 };

--- a/maki-providers/src/providers/anthropic/mod.rs
+++ b/maki-providers/src/providers/anthropic/mod.rs
@@ -530,7 +530,7 @@ pub(crate) async fn parse_sse(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ContentBlock, ProviderEvent, Role, StopReason, TokenUsage};
+    use crate::{ContentBlock, EMPTY_RESPONSE_MARKER, ProviderEvent, Role, StopReason, TokenUsage};
     use serde_json::{Value, json};
     use shared::build_wire_messages;
     use std::time::Duration;
@@ -803,53 +803,88 @@ data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":5}}\n";
         })
     }
 
-    #[test]
-    fn cache_control_placement() {
-        let single = vec![Message::user("only".into())];
-        let wire = build_wire_messages(&single);
-        let json: Value = serde_json::to_value(&wire).unwrap();
-        assert_eq!(
-            json[0]["content"][0]["cache_control"],
-            json!({"type": "ephemeral"})
-        );
+    fn text_block(text: &str) -> ContentBlock {
+        ContentBlock::Text { text: text.into() }
+    }
 
-        let multi = vec![
+    fn thinking_block(thinking: &str) -> ContentBlock {
+        ContentBlock::Thinking {
+            thinking: thinking.into(),
+            signature: None,
+        }
+    }
+
+    fn message(role: Role, content: Vec<ContentBlock>) -> Message {
+        Message {
+            role,
+            content,
+            ..Default::default()
+        }
+    }
+
+    /// `expected` names the (message, block) pairs that should carry a breakpoint.
+    #[test_case(vec![Message::user("only".into())], &[(0, 0)] ; "single_message")]
+    #[test_case(
+        vec![
             Message::user("first".into()),
-            Message {
-                role: Role::Assistant,
-                content: vec![ContentBlock::Text {
-                    text: "reply".into(),
-                }],
-                ..Default::default()
-            },
-            Message {
-                role: Role::User,
-                content: vec![
-                    ContentBlock::ToolResult {
-                        tool_use_id: "t1".into(),
-                        content: "ok".into(),
-                        is_error: false,
-                    },
-                    ContentBlock::Text {
-                        text: "second".into(),
-                    },
-                ],
-                ..Default::default()
-            },
-        ];
-        let wire = build_wire_messages(&multi);
-        let json: Value = serde_json::to_value(&wire).unwrap();
+            message(Role::Assistant, vec![text_block("reply")]),
+            message(Role::User, vec![
+                ContentBlock::ToolResult {
+                    tool_use_id: "t1".into(),
+                    content: "ok".into(),
+                    is_error: false,
+                },
+                text_block("second"),
+            ]),
+        ],
+        &[(1, 0), (2, 1)]
+        ; "last_two_messages_only"
+    )]
+    #[test_case(
+        vec![
+            message(Role::Assistant, vec![
+                thinking_block("hmm"),
+                text_block("reply"),
+                thinking_block("more"),
+            ]),
+            message(Role::Assistant, vec![thinking_block("stalled")]),
+        ],
+        &[(0, 1)]
+        ; "skips_thinking_blocks"
+    )]
+    fn cache_control_placement(messages: Vec<Message>, expected: &[(usize, usize)]) {
+        let json: Value = serde_json::to_value(build_wire_messages(&messages)).unwrap();
 
-        assert!(json[0]["content"][0].get("cache_control").is_none());
-        assert_eq!(
-            json[1]["content"][0]["cache_control"],
-            json!({"type": "ephemeral"})
-        );
-        assert!(json[2]["content"][0].get("cache_control").is_none());
-        assert_eq!(
-            json[2]["content"][1]["cache_control"],
-            json!({"type": "ephemeral"})
-        );
+        let marked: Vec<(usize, usize)> = json
+            .as_array()
+            .unwrap()
+            .iter()
+            .enumerate()
+            .flat_map(|(msg_idx, msg)| {
+                msg["content"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, block)| block["cache_control"] == json!({"type": "ephemeral"}))
+                    .map(move |(block_idx, _)| (msg_idx, block_idx))
+            })
+            .collect();
+        assert_eq!(marked, expected);
+    }
+
+    #[test]
+    fn blank_text_blocks_never_reach_the_wire() {
+        let messages = vec![
+            message(Role::Assistant, vec![text_block(" \n"), text_block("kept")]),
+            message(Role::Assistant, vec![text_block("   ")]),
+        ];
+        let json: Value = serde_json::to_value(build_wire_messages(&messages)).unwrap();
+
+        assert_eq!(json[0]["content"].as_array().unwrap().len(), 1);
+        assert_eq!(json[0]["content"][0]["text"], "kept");
+        assert_eq!(json[1]["content"].as_array().unwrap().len(), 1);
+        assert_eq!(json[1]["content"][0]["text"], EMPTY_RESPONSE_MARKER);
     }
 
     #[test]

--- a/maki-providers/src/providers/anthropic/shared.rs
+++ b/maki-providers/src/providers/anthropic/shared.rs
@@ -1,4 +1,5 @@
 use std::ops::ControlFlow;
+use std::sync::LazyLock;
 
 use flume::Sender;
 use serde::{Deserialize, Serialize};
@@ -7,8 +8,8 @@ use tracing::{debug, warn};
 
 use crate::model::{FastPricing, Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::{
-    AgentError, ContentBlock, Message, ProviderEvent, Role, StopReason, StreamResponse,
-    ThinkingConfig, TokenUsage,
+    AgentError, ContentBlock, EMPTY_RESPONSE_MARKER, Message, ProviderEvent, Role, StopReason,
+    StreamResponse, ThinkingConfig, TokenUsage,
 };
 
 pub(super) const BETA_TOOL_EXAMPLES_BEDROCK: &str = "tool-examples-2025-10-29";
@@ -39,6 +40,10 @@ pub(crate) fn long_context_window(model_id: &str) -> Option<u32> {
 }
 
 pub(super) const MESSAGE_CACHE_BREAKPOINTS: usize = 2;
+
+static EMPTY_CONTENT: LazyLock<ContentBlock> = LazyLock::new(|| ContentBlock::Text {
+    text: EMPTY_RESPONSE_MARKER.into(),
+});
 
 #[derive(Serialize)]
 pub(crate) struct CacheControl {
@@ -153,6 +158,28 @@ pub(super) struct WireMessage<'a> {
     pub content: Vec<WireContentBlock<'a>>,
 }
 
+/// The API rejects blank text blocks, and messages with no block at all, so
+/// blanks go and a message left bare falls back to the marker.
+fn wire_content(msg: &Message) -> Vec<WireContentBlock<'_>> {
+    let mut content: Vec<WireContentBlock<'_>> = msg
+        .content
+        .iter()
+        .filter(|block| !matches!(block, ContentBlock::Text { text } if text.trim().is_empty()))
+        .map(|inner| WireContentBlock {
+            inner,
+            cache_control: None,
+        })
+        .collect();
+
+    if content.is_empty() {
+        content.push(WireContentBlock {
+            inner: &EMPTY_CONTENT,
+            cache_control: None,
+        });
+    }
+    content
+}
+
 pub(super) fn build_wire_messages(messages: &[Message]) -> Vec<WireMessage<'_>> {
     let len = messages.len();
 
@@ -160,23 +187,20 @@ pub(super) fn build_wire_messages(messages: &[Message]) -> Vec<WireMessage<'_>> 
         .iter()
         .enumerate()
         .map(|(msg_idx, msg)| {
-            let cache_last_block = msg_idx + MESSAGE_CACHE_BREAKPOINTS >= len;
+            let mut content = wire_content(msg);
+
+            // The API rejects `cache_control` on thinking blocks, so walk back to
+            // the last block that can carry it. All thinking means no breakpoint,
+            // which beats a fatal one.
+            if msg_idx + MESSAGE_CACHE_BREAKPOINTS >= len
+                && let Some(block) = content.iter_mut().rfind(|b| !b.inner.is_thinking())
+            {
+                block.cache_control = Some(EPHEMERAL);
+            }
 
             WireMessage {
                 role: &msg.role,
-                content: msg
-                    .content
-                    .iter()
-                    .enumerate()
-                    .map(|(block_idx, block)| WireContentBlock {
-                        inner: block,
-                        cache_control: if cache_last_block && block_idx + 1 == msg.content.len() {
-                            Some(EPHEMERAL)
-                        } else {
-                            None
-                        },
-                    })
-                    .collect(),
+                content,
             }
         })
         .collect()

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -89,6 +89,8 @@ impl ImageSource {
 
 pub const IMAGE_OMITTED_NOTE: &str =
     "[image omitted: the current model does not support image input]";
+/// See [`Message::empty_marker`].
+pub const EMPTY_RESPONSE_MARKER: &str = "(empty)";
 
 /// For models without vision, image blocks become a text note instead of a
 /// wire block the API would reject. History keeps the pixels, so switching
@@ -165,6 +167,12 @@ pub enum ContentBlock {
     },
 }
 
+impl ContentBlock {
+    pub fn is_thinking(&self) -> bool {
+        matches!(self, Self::Thinking { .. } | Self::RedactedThinking { .. })
+    }
+}
+
 /// Who a message came from, which `role` cannot say. Providers only
 /// accept user and assistant, so anything the host wants to report has to
 /// travel as a user message, and without this there is no way to tell it
@@ -211,6 +219,19 @@ pub struct Message {
 }
 
 impl Message {
+    /// Stands in for an assistant turn with no text, thinking alone or empty,
+    /// which providers reject as the trailing message. Never a real response:
+    /// readers mining history for model text must skip it.
+    pub fn empty_marker() -> Self {
+        Self {
+            role: Role::Assistant,
+            content: vec![ContentBlock::Text {
+                text: EMPTY_RESPONSE_MARKER.into(),
+            }],
+            ..Default::default()
+        }
+    }
+
     /// Something the host saw, reported to the model without pretending
     /// the user said it.
     pub fn observation(text: String) -> Self {
@@ -277,7 +298,7 @@ impl Message {
 
     pub fn first_text_content(&self) -> Option<&str> {
         self.content.iter().find_map(|b| match b {
-            ContentBlock::Text { text } if !text.is_empty() => Some(text.as_str()),
+            ContentBlock::Text { text } if !text.trim().is_empty() => Some(text.as_str()),
             _ => None,
         })
     }


### PR DESCRIPTION
A model that returns only a thinking block after tool calls gets nudged once, and if it stalls again the old one-shot flag had no nudge left, so the turn ended and the thinking-only message went into history.

That message was then the last one, and `build_wire_messages` stamps `cache_control` on the last block of the last two messages, which Anthropic refuses on thinking: every later prompt died with a 400 and the session was done for.

Now the breakpoint skips thinking blocks, a text-less turn is stored as the `(empty)` marker instead of raw (an empty one would 400 too), and the nudge gets two tries per tool cycle rather than one.