### PR TITLE
feat(memory): make notes editable with the plain `edit` tool

### DIFF
--- a/maki-acp/src/lib.rs
+++ b/maki-acp/src/lib.rs
@@ -6,6 +6,7 @@ pub mod translate;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use maki_agent::permissions::PluginRuleStore;
 use maki_agent::prompt::ResolvedSlots;
 use maki_agent::{AgentConfig, PermissionsConfig};
 use maki_config::ModelPolicy;
@@ -21,6 +22,7 @@ pub struct AcpParams {
     pub prompt_slots: Arc<ResolvedSlots>,
     pub yolo: bool,
     pub model_policy: Arc<ModelPolicy>,
+    pub plugin_rules: Arc<PluginRuleStore>,
 }
 
 pub fn run(params: AcpParams) -> color_eyre::Result<()> {

--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -229,6 +229,7 @@ fn spawn_session(
         append_system_prompt: None,
         workflow: false,
         model_policy: Arc::clone(&params.model_policy),
+        plugin_rules: Arc::clone(&params.plugin_rules),
     })
 }
 
@@ -663,6 +664,7 @@ mod tests {
             permissions: Arc::new(PermissionManager::new(
                 maki_config::PermissionsConfig::default(),
                 PathBuf::from("/project"),
+                Arc::default(),
             )),
             task: smol::spawn(async {}),
         };

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -701,6 +701,7 @@ mod tests {
                         ..Default::default()
                     },
                     std::path::PathBuf::from("/tmp"),
+                    Arc::default(),
                 )),
                 session_id: None,
                 mailbox: None,

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -711,7 +711,11 @@ mod tests {
                 ..Default::default()
             };
             let dir = TempDir::new().unwrap();
-            let permissions = Arc::new(PermissionManager::new(deny_cfg, dir.path().to_path_buf()));
+            let permissions = Arc::new(PermissionManager::new(
+                deny_cfg,
+                dir.path().to_path_buf(),
+                Arc::default(),
+            ));
             let mut ctx = crate::tools::test_support::stub_ctx_with_permissions(
                 &AgentMode::Build,
                 permissions,
@@ -829,7 +833,11 @@ mod tests {
                 ..Default::default()
             };
             let dir = TempDir::new().unwrap();
-            let permissions = Arc::new(PermissionManager::new(deny_cfg, dir.path().to_path_buf()));
+            let permissions = Arc::new(PermissionManager::new(
+                deny_cfg,
+                dir.path().to_path_buf(),
+                Arc::default(),
+            ));
             let ctx = crate::tools::test_support::stub_ctx_with_permissions(
                 &AgentMode::Build,
                 permissions,
@@ -937,7 +945,11 @@ mod tests {
                 ..Default::default()
             };
             let dir = TempDir::new().unwrap();
-            let permissions = Arc::new(PermissionManager::new(deny_cfg, dir.path().to_path_buf()));
+            let permissions = Arc::new(PermissionManager::new(
+                deny_cfg,
+                dir.path().to_path_buf(),
+                Arc::default(),
+            ));
             let ctx = crate::tools::test_support::stub_ctx_with_permissions(
                 &AgentMode::Build,
                 permissions,

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -17,7 +17,7 @@ use tracing::{error, warn};
 
 use crate::agent::{self, History};
 use crate::cancel::{CancelMap, CancelToken};
-use crate::permissions::PermissionManager;
+use crate::permissions::{PermissionManager, PluginRuleStore};
 use crate::prompt::ResolvedSlots;
 use crate::template;
 use crate::tools::{DescriptionContext, FileReadTracker, ToolAudience, ToolFilter, ToolRegistry};
@@ -83,6 +83,7 @@ pub struct HeadlessParams {
     pub fast: bool,
     pub workflow: bool,
     pub model_policy: Arc<ModelPolicy>,
+    pub plugin_rules: Arc<PluginRuleStore>,
 }
 
 pub struct HeadlessHandle {
@@ -213,6 +214,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
                     permissions: Arc::new(PermissionManager::new(
                         params.permissions_config,
                         working_dir_path,
+                        params.plugin_rules,
                     )),
                     session_id: Some(session_ref_clone.clone()),
                     mailbox: Some(mailbox.clone()),
@@ -286,6 +288,7 @@ pub struct InteractiveParams {
     pub append_system_prompt: Option<String>,
     pub workflow: bool,
     pub model_policy: Arc<ModelPolicy>,
+    pub plugin_rules: Arc<PluginRuleStore>,
 }
 
 pub struct InteractiveHandle {
@@ -337,6 +340,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
     let permissions = Arc::new(PermissionManager::new(
         params.permissions_config,
         params.initial_wd,
+        Arc::clone(&params.plugin_rules),
     ));
     if params.yolo {
         permissions.toggle_yolo();

--- a/maki-agent/src/permissions.rs
+++ b/maki-agent/src/permissions.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 use maki_config::{
     DefaultEffect, Effect, FILE_WRITE_TOOLS, PermissionRule, PermissionTarget, PermissionsConfig,
@@ -151,6 +151,41 @@ impl PermissionAnswer {
     }
 }
 
+/// Permission rules declared by Lua plugins via
+/// `maki.api.register_permission_rule`, keyed by plugin name. Shared between
+/// the Lua runtime (writer, on plugin load/unload) and every
+/// [`PermissionManager`] (reader).
+#[derive(Default)]
+pub struct PluginRuleStore(Mutex<HashMap<Arc<str>, Vec<PermissionRule>>>);
+
+impl PluginRuleStore {
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<Arc<str>, Vec<PermissionRule>>> {
+        self.0.lock().unwrap_or_else(|e| {
+            warn!("plugin rule mutex was poisoned, recovering");
+            e.into_inner()
+        })
+    }
+
+    /// An empty `rules` removes the entry, so a reload that registers
+    /// nothing clears the stale rules.
+    pub fn replace(&self, plugin: &str, rules: Vec<PermissionRule>) {
+        let mut map = self.lock();
+        if rules.is_empty() {
+            map.remove(plugin);
+        } else {
+            map.insert(Arc::from(plugin), rules);
+        }
+    }
+
+    pub fn remove(&self, plugin: &str) {
+        self.lock().remove(plugin);
+    }
+
+    pub fn snapshot(&self) -> Vec<PermissionRule> {
+        self.lock().values().flatten().cloned().collect()
+    }
+}
+
 pub struct PermissionManager {
     session_rules: Mutex<Vec<PermissionRule>>,
     config_rules: Vec<PermissionRule>,
@@ -159,10 +194,15 @@ pub struct PermissionManager {
     default: DefaultEffect,
     tool_defaults: HashMap<ToolKey, DefaultEffect>,
     cwd: PathBuf,
+    plugin_rules: Arc<PluginRuleStore>,
 }
 
 impl PermissionManager {
-    pub fn new(config: PermissionsConfig, cwd: PathBuf) -> Self {
+    pub fn new(
+        config: PermissionsConfig,
+        cwd: PathBuf,
+        plugin_rules: Arc<PluginRuleStore>,
+    ) -> Self {
         let config_rules = config.rules;
         let builtin_rules = builtin_rules(&cwd);
 
@@ -197,6 +237,7 @@ impl PermissionManager {
             default: config.default,
             tool_defaults: config.tool_defaults,
             cwd,
+            plugin_rules,
         }
     }
 
@@ -212,6 +253,7 @@ impl PermissionManager {
             default: self.default,
             tool_defaults: self.tool_defaults.clone(),
             cwd: self.cwd.clone(),
+            plugin_rules: Arc::clone(&self.plugin_rules),
         }
     }
 
@@ -230,6 +272,7 @@ impl PermissionManager {
         plan_path: Option<&Path>,
     ) -> PermissionCheck {
         let session = self.session_rules();
+        let plugin = self.plugin_rules.snapshot();
 
         // Any matching deny wins. No specificity hierarchy — a Wildcard
         // deny blocks everything, a tool-specific deny blocks that tool.
@@ -245,6 +288,7 @@ impl PermissionManager {
                 .iter()
                 .chain(&self.config_rules)
                 .chain(&self.builtin_rules)
+                .chain(&plugin)
             {
                 if !matches_rule(&r.tool, tool) || !rule_matches_scope(r, scope) {
                     continue;
@@ -665,8 +709,20 @@ mod tests {
         }
     }
 
+    fn mgr_with(config: PermissionsConfig, cwd: PathBuf) -> PermissionManager {
+        PermissionManager::new(config, cwd, Arc::default())
+    }
+
     fn default_mgr() -> PermissionManager {
-        PermissionManager::new(PermissionsConfig::default(), PathBuf::from("/tmp"))
+        mgr_with(PermissionsConfig::default(), PathBuf::from("/tmp"))
+    }
+
+    fn plugin_edit_rule(scope: &str, effect: Effect) -> PermissionRule {
+        PermissionRule {
+            tool: ToolKey::native("edit"),
+            scope: Some(scope.into()),
+            effect,
+        }
     }
 
     #[test_case("*", "anything" => true ; "star")]
@@ -687,7 +743,7 @@ mod tests {
     #[test_case(vec!["cd /tmp", "cargo test"], vec!["cd *", "cargo *"], true ; "all_allowed")]
     #[test_case(vec!["cd /tmp", "cargo test"], vec!["cargo *"], false ; "missing_rule")]
     fn compound_check(scopes: Vec<&str>, rules: Vec<&str>, expect_allowed: bool) {
-        let mgr = PermissionManager::new(
+        let mgr = mgr_with(
             make_config(rules.into_iter().map(allow_rule).collect()),
             PathBuf::from("/tmp"),
         );
@@ -697,7 +753,7 @@ mod tests {
 
     #[test]
     fn compound_denied_if_any_segment_denied() {
-        let mgr = PermissionManager::new(
+        let mgr = mgr_with(
             make_config(vec![
                 allow_rule("cd *"),
                 allow_rule("cargo *"),
@@ -718,7 +774,7 @@ mod tests {
 
     #[test]
     fn complex_constructs_force_prompt_even_with_allow_star() {
-        let mgr = PermissionManager::new(make_config(vec![allow_rule("*")]), PathBuf::from("/tmp"));
+        let mgr = mgr_with(make_config(vec![allow_rule("*")]), PathBuf::from("/tmp"));
         assert!(matches!(
             mgr.check_multi(&ToolKey::native("bash"), &["echo $(whoami)"], true, None),
             PermissionCheck::NeedsPrompt { .. }
@@ -809,7 +865,7 @@ mod tests {
 
     #[test]
     fn session_rule_overrides_config() {
-        let mgr = PermissionManager::new(
+        let mgr = mgr_with(
             make_config(vec![allow_rule("cargo *")]),
             PathBuf::from("/tmp"),
         );
@@ -822,7 +878,7 @@ mod tests {
 
     #[test]
     fn deny_overrides_default_allow() {
-        let mgr = PermissionManager::new(
+        let mgr = mgr_with(
             PermissionsConfig {
                 default: DefaultEffect::Allow,
                 rules: vec![deny_rule("rm *")],
@@ -873,7 +929,7 @@ mod tests {
     #[test]
     fn boundary_inside_proceeds() {
         let tmp = std::env::temp_dir();
-        let mgr = PermissionManager::new(PermissionsConfig::default(), tmp.clone());
+        let mgr = mgr_with(PermissionsConfig::default(), tmp.clone());
         assert!(
             mgr.boundary_block_reason(&tmp.join("some_file.txt"))
                 .is_none()
@@ -883,7 +939,7 @@ mod tests {
     #[test]
     fn boundary_outside_proceeds_via_prompt() {
         let tmp = std::env::temp_dir();
-        let mgr = PermissionManager::new(PermissionsConfig::default(), tmp);
+        let mgr = mgr_with(PermissionsConfig::default(), tmp);
         #[cfg(unix)]
         let outside = Path::new("/etc/hosts");
         #[cfg(windows)]
@@ -912,7 +968,7 @@ mod tests {
             .join("..")
             .join("Windows")
             .join("System32");
-        let mgr = PermissionManager::new(PermissionsConfig::default(), sub.clone());
+        let mgr = mgr_with(PermissionsConfig::default(), sub.clone());
         assert!(
             mgr.boundary_block_reason(&attack).is_none(),
             "outside-cwd dotdot path should prompt, not hard-block: {}",
@@ -935,7 +991,7 @@ mod tests {
         let _ = std::os::unix::fs::symlink(&tmp, &link);
 
         let attack = link.join("..").join("escape_target");
-        let mgr = PermissionManager::new(PermissionsConfig::default(), project.clone());
+        let mgr = mgr_with(PermissionsConfig::default(), project.clone());
         assert!(
             mgr.boundary_block_reason(&attack).is_none(),
             "outside-boundary edits are gated by the prompt, not hard-blocked: {}",
@@ -948,7 +1004,7 @@ mod tests {
     fn boundary_nonexistent_cwd_proceeds_via_lexical_tail() {
         let missing = std::env::temp_dir().join("__maki_test_absent_cwd_xyz");
         let _ = std::fs::remove_dir_all(&missing);
-        let mgr = PermissionManager::new(PermissionsConfig::default(), missing.clone());
+        let mgr = mgr_with(PermissionsConfig::default(), missing.clone());
         assert!(
             mgr.boundary_block_reason(&missing.join("file.txt"))
                 .is_none()
@@ -970,7 +1026,7 @@ mod tests {
 
     #[test]
     fn check_multi_force_prompt_skips_allow_rules() {
-        let mgr = PermissionManager::new(
+        let mgr = mgr_with(
             make_config(vec![allow_rule("cargo *"), allow_rule("git *")]),
             PathBuf::from("/tmp"),
         );
@@ -1003,8 +1059,7 @@ mod tests {
 
     #[test]
     fn check_multi_deny_wins_over_force_prompt() {
-        let mgr =
-            PermissionManager::new(make_config(vec![deny_rule("rm *")]), PathBuf::from("/tmp"));
+        let mgr = mgr_with(make_config(vec![deny_rule("rm *")]), PathBuf::from("/tmp"));
         assert!(matches!(
             mgr.check_multi(&ToolKey::native("bash"), &["rm -rf /"], true, None),
             PermissionCheck::Denied
@@ -1013,7 +1068,7 @@ mod tests {
 
     #[test]
     fn check_multi_partial_coverage_prompts_uncovered() {
-        let mgr = PermissionManager::new(
+        let mgr = mgr_with(
             make_config(vec![allow_rule("cargo *")]),
             PathBuf::from("/tmp"),
         );
@@ -1145,7 +1200,7 @@ mod tests {
 
     #[test]
     fn deny_rule_with_none_scope_blocks_everything() {
-        let mgr = PermissionManager::new(
+        let mgr = mgr_with(
             make_config(vec![PermissionRule {
                 tool: ToolKey::native("bash"),
                 scope: None,
@@ -1161,7 +1216,7 @@ mod tests {
 
     #[test]
     fn wildcard_deny_blocks_all_tools() {
-        let mgr = PermissionManager::new(
+        let mgr = mgr_with(
             make_config(vec![PermissionRule {
                 tool: ToolKey::Wildcard,
                 scope: None,
@@ -1182,7 +1237,7 @@ mod tests {
 
     #[test]
     fn mcp_deny_always_blocks_all_arguments() {
-        let mgr = PermissionManager::new(make_config(vec![]), PathBuf::from("/tmp"));
+        let mgr = mgr_with(make_config(vec![]), PathBuf::from("/tmp"));
         let tool = ToolKey::McpTool {
             server: "deepwiki".into(),
             tool: "search".into(),
@@ -1207,8 +1262,7 @@ mod tests {
 
     #[test]
     fn yolo_mode_allows_but_deny_still_blocks() {
-        let mgr =
-            PermissionManager::new(make_config(vec![deny_rule("rm *")]), PathBuf::from("/tmp"));
+        let mgr = mgr_with(make_config(vec![deny_rule("rm *")]), PathBuf::from("/tmp"));
         mgr.toggle_yolo();
         assert!(mgr.is_yolo());
         assert!(matches!(
@@ -1241,7 +1295,7 @@ mod tests {
 
     #[test]
     fn default_deny_blocks_unmatched() {
-        let mgr = PermissionManager::new(
+        let mgr = mgr_with(
             PermissionsConfig {
                 default: DefaultEffect::Deny,
                 ..Default::default()
@@ -1256,7 +1310,7 @@ mod tests {
 
     #[test]
     fn default_deny_with_allow_rules() {
-        let mgr = PermissionManager::new(
+        let mgr = mgr_with(
             PermissionsConfig {
                 default: DefaultEffect::Deny,
                 rules: vec![allow_rule("cargo *")],
@@ -1276,7 +1330,7 @@ mod tests {
 
     #[test]
     fn default_allow_allows_unmatched() {
-        let mgr = PermissionManager::new(
+        let mgr = mgr_with(
             PermissionsConfig {
                 default: DefaultEffect::Allow,
                 ..Default::default()
@@ -1291,7 +1345,7 @@ mod tests {
 
     #[test]
     fn default_prompt_is_default_behavior() {
-        let mgr = PermissionManager::new(PermissionsConfig::default(), PathBuf::from("/tmp"));
+        let mgr = mgr_with(PermissionsConfig::default(), PathBuf::from("/tmp"));
         assert!(matches!(
             mgr.check(&ToolKey::native("bash"), "cargo test", None),
             PermissionCheck::NeedsPrompt { .. }
@@ -1300,7 +1354,7 @@ mod tests {
 
     #[test]
     fn mcp_server_wildcard_matches_all_server_tools() {
-        let mgr = PermissionManager::new(
+        let mgr = mgr_with(
             make_config(vec![PermissionRule {
                 tool: ToolKey::McpServer {
                     server: "deepwiki".into(),
@@ -1336,7 +1390,7 @@ mod tests {
 
     #[test]
     fn mcp_server_wildcard_does_not_match_other_server() {
-        let mgr = PermissionManager::new(
+        let mgr = mgr_with(
             make_config(vec![PermissionRule {
                 tool: ToolKey::McpServer {
                     server: "deepwiki".into(),
@@ -1361,7 +1415,7 @@ mod tests {
 
     #[test]
     fn per_tool_default_overrides_global() {
-        let mgr = PermissionManager::new(
+        let mgr = mgr_with(
             PermissionsConfig {
                 default: DefaultEffect::Deny,
                 tool_defaults: HashMap::from([(ToolKey::native("bash"), DefaultEffect::Allow)]),
@@ -1394,6 +1448,39 @@ mod tests {
             ),
             expect_allowed,
         );
+    }
+
+    #[test]
+    fn plugin_rules_apply_to_manager_and_forks() {
+        let store = Arc::new(PluginRuleStore::default());
+        let mgr = PermissionManager::new(
+            PermissionsConfig::default(),
+            PathBuf::from("/tmp"),
+            Arc::clone(&store),
+        );
+        let fork = mgr.fork();
+        store.replace("memory", vec![plugin_edit_rule("/x/**", Effect::Allow)]);
+        for m in [&mgr, &fork] {
+            assert!(matches!(
+                m.check(&ToolKey::native("edit"), "/x/f", None),
+                PermissionCheck::Allowed
+            ));
+        }
+    }
+
+    #[test]
+    fn config_deny_beats_plugin_allow() {
+        let store = Arc::new(PluginRuleStore::default());
+        store.replace("memory", vec![plugin_edit_rule("/x/**", Effect::Allow)]);
+        let mgr = PermissionManager::new(
+            make_config(vec![plugin_edit_rule("/x/**", Effect::Deny)]),
+            PathBuf::from("/tmp"),
+            store,
+        );
+        assert!(matches!(
+            mgr.check(&ToolKey::native("edit"), "/x/f", None),
+            PermissionCheck::Denied
+        ));
     }
 
     #[test]

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -460,6 +460,7 @@ pub fn cli_tool_ctx() -> ToolContext {
                 ..Default::default()
             },
             std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+            Arc::default(),
         )),
         Arc::new(FileReadTracker::new()),
         None,
@@ -522,6 +523,7 @@ pub mod test_support {
                 ..Default::default()
             },
             std::path::PathBuf::from("/tmp"),
+            Arc::default(),
         ))
     });
 

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -28,13 +28,14 @@ use std::sync::Arc;
 use mlua::{Lua, Result as LuaResult, Table};
 
 use crate::api::options::PluginOpts;
-use crate::api::tool::PendingTools;
+use crate::api::tool::{PendingRules, PendingTools};
 use crate::api::util::command::UiAction;
 use crate::plugin_permissions::PluginPermissions;
 
 pub(crate) fn create_maki_global(
     lua: &Lua,
     pending: PendingTools,
+    pending_rules: PendingRules,
     plugin: Arc<str>,
     ui_action_tx: Option<flume::Sender<UiAction>>,
     permissions: &PluginPermissions,
@@ -45,6 +46,7 @@ pub(crate) fn create_maki_global(
     let api = tool::create_api_table(
         lua,
         pending,
+        pending_rules,
         Arc::clone(&plugin),
         opts,
         ui_action_tx.clone(),

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -20,7 +20,7 @@ use maki_agent::{
     AgentEvent, BufferSnapshot, ImageMediaType, ImageSource, InstructionBlock, SharedBuf,
     TextOutput, ToolOutput,
 };
-use maki_config::ToolOutputLines;
+use maki_config::{Effect, PermissionRule, ToolKey, ToolOutputLines};
 use maki_lua_macro::{lua_fn, lua_table};
 use mlua::{
     Function, Lua, LuaSerdeExt, MultiValue, RegistryKey, Result as LuaResult, Table,
@@ -46,6 +46,7 @@ const TOOL_HANDLER_RETURN_ERR: &str =
     "tool handler must return string or {output=string, is_error?=bool}";
 const TIMEOUT_PARSE_ERR: &str = "register_tool: 'timeout' must be a positive number, 0, or false";
 const NARGS_ERR: &str = r#"register_command: 'nargs' must be 0, 1, "?", "*", or "+""#;
+const PERMISSION_RULE_KEYS: &[&str] = &["tool", "scope", "effect"];
 const MAX_HINT_CONTENT_SIZE: usize = 1024 * 1024;
 const DESCRIBE_TIMEOUT: Duration = Duration::from_secs(3);
 const PLAIN_HEADER_STYLE: &str = "tool";
@@ -139,6 +140,8 @@ pub(crate) struct PendingTool {
 }
 
 pub(crate) type PendingTools = Arc<Mutex<Vec<PendingTool>>>;
+
+pub(crate) type PendingRules = Arc<Mutex<Vec<PermissionRule>>>;
 
 pub(crate) struct LuaTool {
     pub(crate) name: Arc<str>,
@@ -648,6 +651,93 @@ fn register_tool(lua: &Lua, #[ctx] pending: PendingTools, spec: Table) -> LuaRes
     register_tool_from_lua(lua, &spec, pending)
 }
 
+/// Declare an agent permission rule for a native tool. Use it to pre-allow
+/// (or pre-deny) tool calls on paths your plugin owns, like a storage
+/// directory outside the working dir, so the user is not prompted for them.
+///
+/// Rules live as long as the plugin is loaded: a reload replaces them, and a
+/// reload that registers none clears the old ones. User config and session
+/// deny rules always win over a plugin allow.
+///
+/// @param spec table Rule specification:
+///   tool   (string) Required. Native tool name (e.g. "edit", "write").
+///                   MCP tools and the "*" wildcard are not allowed.
+///   scope  (string) Required. Scope pattern the rule applies to, e.g.
+///                   "/abs/dir/**" for a directory subtree.
+///   effect (string) Optional. "allow" (default) or "deny".
+/// @return
+/// @example
+/// maki.api.register_permission_rule({
+///   tool = "write",
+///   scope = notes_dir .. "/**",
+/// })
+#[lua_fn]
+fn register_permission_rule(
+    _lua: &Lua,
+    #[ctx] pending_rules: PendingRules,
+    spec: Table,
+) -> LuaResult<()> {
+    for entry in spec.pairs::<String, LuaValue>() {
+        let (key, _) = entry.map_err(|_| {
+            mlua::Error::runtime("register_permission_rule: spec keys must be strings")
+        })?;
+        if !PERMISSION_RULE_KEYS.contains(&key.as_str()) {
+            return Err(mlua::Error::runtime(format!(
+                "register_permission_rule: unknown key '{key}' (valid: tool, scope, effect)"
+            )));
+        }
+    }
+
+    let tool: String = spec.get("tool").map_err(|_| {
+        mlua::Error::runtime("register_permission_rule: 'tool' must be a native tool name string")
+    })?;
+    let tool = match ToolKey::parse(&tool) {
+        Ok(key @ ToolKey::Native(_)) => key,
+        Ok(_) => {
+            return Err(mlua::Error::runtime(
+                "register_permission_rule: only native tools are allowed (no wildcard or MCP)",
+            ));
+        }
+        Err(e) => {
+            return Err(mlua::Error::runtime(format!(
+                "register_permission_rule: {e}"
+            )));
+        }
+    };
+
+    let scope: String = spec
+        .get("scope")
+        .map_err(|_| mlua::Error::runtime("register_permission_rule: 'scope' must be a string"))?;
+    if scope.is_empty() {
+        return Err(mlua::Error::runtime(
+            "register_permission_rule: 'scope' must be non-empty",
+        ));
+    }
+
+    let effect = spec
+        .get::<Option<String>>("effect")
+        .map_err(|_| mlua::Error::runtime("register_permission_rule: 'effect' must be a string"))?;
+    let effect = match effect.as_deref() {
+        None | Some("allow") => Effect::Allow,
+        Some("deny") => Effect::Deny,
+        Some(other) => {
+            return Err(mlua::Error::runtime(format!(
+                "register_permission_rule: invalid effect '{other}' (expected \"allow\" or \"deny\")"
+            )));
+        }
+    };
+
+    pending_rules
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .push(PermissionRule {
+            tool,
+            scope: Some(scope),
+            effect,
+        });
+    Ok(())
+}
+
 /// Register a slash-command that appears in the user input bar.
 ///
 /// Slash commands let the user trigger plugin actions by typing `/name` in the
@@ -907,9 +997,10 @@ lua_table! {
     /// maki.api.register_tool({ name = "greet", ... })
     /// maki.api.register_prompt_hint({ slot = "tool_usage", content = "..." })
     /// ```
-    extend "maki.api" => pub(crate) fn add_tool_fns(pending: PendingTools, plugin: Arc<str>, opts: PluginOpts), DOCS [
-        register_tool(pending), register_command(plugin), register_prompt_hint(plugin),
-        register_options(plugin, opts), set_prompt(plugin), get_tools, get_tool,
+    extend "maki.api" => pub(crate) fn add_tool_fns(pending: PendingTools, pending_rules: PendingRules, plugin: Arc<str>, opts: PluginOpts), DOCS [
+        register_tool(pending), register_permission_rule(pending_rules), register_command(plugin),
+        register_prompt_hint(plugin), register_options(plugin, opts), set_prompt(plugin),
+        get_tools, get_tool,
         manual run_command,
     ]
 }
@@ -917,12 +1008,13 @@ lua_table! {
 pub(crate) fn create_api_table(
     lua: &Lua,
     pending: PendingTools,
+    pending_rules: PendingRules,
     plugin: Arc<str>,
     opts: PluginOpts,
     ui_action_tx: Option<flume::Sender<UiAction>>,
 ) -> LuaResult<Table> {
     let t = lua.create_table()?;
-    add_tool_fns(&t, lua, pending, plugin, opts)?;
+    add_tool_fns(&t, lua, pending, pending_rules, plugin, opts)?;
     run_command__register(&t, lua, ui_action_tx)?;
     Ok(t)
 }

--- a/maki-lua/src/docs.rs
+++ b/maki-lua/src/docs.rs
@@ -123,6 +123,7 @@ mod tests {
         let maki = create_maki_global(
             &lua,
             Arc::default(),
+            Arc::default(),
             Arc::from("docs-test"),
             Some(ui_tx),
             &PluginPermissions::trusted(),

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 use include_dir::{Dir, include_dir};
+use maki_agent::permissions::PluginRuleStore;
 use maki_agent::tools::ToolRegistry;
 use maki_config::{PluginsConfig, RawConfig};
 
@@ -124,6 +125,7 @@ static BUNDLED_DIRS: LazyLock<&'static [&'static Dir<'static>]> = LazyLock::new(
 
 pub struct PluginHost {
     inner: LuaThread,
+    plugin_rules: Arc<PluginRuleStore>,
 }
 
 impl Drop for PluginHost {
@@ -155,8 +157,19 @@ impl PluginHost {
     /// interpreter with full debug info. Applied at VM creation, so
     /// every chunk gets it, init.lua files included.
     pub fn with_jit(registry: Arc<ToolRegistry>, jit: bool) -> Result<Self, PluginError> {
-        let lua = runtime::spawn(registry, *BUNDLED_DIRS, jit)?;
-        Ok(Self { inner: lua })
+        let plugin_rules = Arc::new(PluginRuleStore::default());
+        let lua = runtime::spawn(registry, *BUNDLED_DIRS, jit, Arc::clone(&plugin_rules))?;
+        Ok(Self {
+            inner: lua,
+            plugin_rules,
+        })
+    }
+
+    /// The store that `maki.api.register_permission_rule` writes into. Hand
+    /// it to every [`maki_agent::permissions::PermissionManager`] so plugin
+    /// rules apply to all sessions.
+    pub fn plugin_rules(&self) -> Arc<PluginRuleStore> {
+        Arc::clone(&self.plugin_rules)
     }
 
     /// Stop the Lua thread from taking new work without joining it, so the

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -16,6 +16,7 @@ use event_listener::Event;
 
 use include_dir::Dir;
 use maki_agent::cancel::CancelToken;
+use maki_agent::permissions::PluginRuleStore;
 use maki_agent::prompt::{PromptId, ResolvedSlots, Slot, SlotEntry};
 use maki_agent::tools::{
     HeaderResult, PermissionScopes, RegistryError, Tool, ToolLive, ToolRegistry, ToolSource,
@@ -33,7 +34,9 @@ use crate::api::keymap::KeymapReader;
 use crate::api::keymap::{KeymapStore, KeymapWriter};
 use crate::api::options::{PluginOptionSpecs, PluginOpts, collect_plugin_options};
 use crate::api::slot::SlotStore;
-use crate::api::tool::{LuaTool, PendingTool, PendingTools, PermissionScopeSpec, ToolCallReply};
+use crate::api::tool::{
+    LuaTool, PendingRules, PendingTool, PendingTools, PermissionScopeSpec, ToolCallReply,
+};
 use crate::api::ui::HintStore;
 use crate::api::ui::buf::{BufHandle, BufferStore};
 use crate::api::util::command::{CommandHandlerMap, HintWriter, publish_command_snapshot};
@@ -1349,6 +1352,7 @@ struct LuaRuntime {
     _watchdog: Watchdog,
     lua: Lua,
     pending: PendingTools,
+    plugin_rules: Arc<PluginRuleStore>,
     plugins: PluginMap,
     live_tasks: LiveTasks,
     warm_tools: WarmTools,
@@ -1372,6 +1376,7 @@ impl LuaRuntime {
         keymap_writer: KeymapWriter,
         hint_writer: HintWriter,
         jit: bool,
+        plugin_rules: Arc<PluginRuleStore>,
     ) -> Result<Self, PluginError> {
         let lua = Lua::new();
         let compiler = install_compiler(&lua, jit);
@@ -1438,6 +1443,7 @@ impl LuaRuntime {
             _watchdog: watchdog,
             lua,
             pending,
+            plugin_rules,
             plugins,
             live_tasks: Rc::new(RefCell::new(HashMap::new())),
             warm_tools: Rc::new(RefCell::new(VecDeque::new())),
@@ -1746,10 +1752,15 @@ impl LuaRuntime {
         );
         self.discard_pending(stale);
 
+        // Scoped to this load so a failed load simply drops its rules; only a
+        // successful load commits them to the store.
+        let pending_rules: PendingRules = Arc::default();
+
         let require_root = plugin_dir.as_ref().map(|d| d.join("lua"));
         let maki = create_maki_global(
             &self.lua,
             Arc::clone(&self.pending),
+            Arc::clone(&pending_rules),
             Arc::clone(&name),
             self.ui_action_tx.clone(),
             permissions,
@@ -1852,6 +1863,8 @@ impl LuaRuntime {
                 )
             })
             .collect();
+        let rules = std::mem::take(&mut *pending_rules.lock().unwrap_or_else(|e| e.into_inner()));
+        self.plugin_rules.replace(&name, rules);
         self.plugins.borrow_mut().insert(name, keys);
 
         Ok(())
@@ -1859,6 +1872,7 @@ impl LuaRuntime {
 
     fn clear_plugin(&mut self, plugin: &str) {
         self.registry.clear_plugin(plugin);
+        self.plugin_rules.remove(plugin);
         self.drop_plugin_keys(plugin);
         if let Some(mut store) = self.lua.app_data_mut::<KeymapStore>() {
             let keys = store.clear_plugin(plugin);
@@ -2513,6 +2527,7 @@ pub fn spawn(
     registry: Arc<ToolRegistry>,
     bundled_dirs: &'static [&'static Dir<'static>],
     jit: bool,
+    plugin_rules: Arc<PluginRuleStore>,
 ) -> Result<LuaThread, PluginError> {
     let (tx, rx) = flume::unbounded::<Request>();
     let (prio_tx, prio_rx) = flume::unbounded::<Request>();
@@ -2538,6 +2553,7 @@ pub fn spawn(
                 keymap_writer,
                 hint_writer,
                 jit,
+                plugin_rules,
             ) {
                 Ok(r) => {
                     let _ = init_tx.send(Ok(()));

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -9,7 +9,7 @@ use maki_agent::tools::{
     DescriptionContext, ExecFuture, HeaderFuture, HeaderResult, ParseError, Tool, ToolContext,
     ToolExecResult, ToolInvocation, ToolLive, ToolRegistry, ToolSource, timeout_annotation,
 };
-use maki_config::{AlwaysThinking, PluginsConfig, ToolOutputLines};
+use maki_config::{AlwaysThinking, Effect, PluginsConfig, ToolKey, ToolOutputLines};
 use maki_lua::{PluginError, PluginHost, WARM_TOOL_CAP};
 use maki_storage::id::SessionRef;
 #[cfg(unix)]
@@ -320,6 +320,82 @@ fn unload_round_trip() {
 
     host.unload("unload_test").unwrap();
     assert!(!reg.has("echo_"));
+}
+
+const PERMISSION_RULE_SRC: &str =
+    r#"maki.api.register_permission_rule({ tool = "edit", scope = "/tmp/x/**" })"#;
+const NO_RULE_SRC: &str = "local _ = 1";
+
+#[test]
+fn permission_rule_lands_in_store_and_unload_clears() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+
+    host.load_source("perm_plugin", PERMISSION_RULE_SRC)
+        .unwrap();
+    let rules = host.plugin_rules().snapshot();
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].tool, ToolKey::native("edit"));
+    assert_eq!(rules[0].scope.as_deref(), Some("/tmp/x/**"));
+    assert_eq!(rules[0].effect, Effect::Allow);
+
+    host.unload("perm_plugin").unwrap();
+    assert!(host.plugin_rules().snapshot().is_empty());
+}
+
+#[test]
+fn permission_rule_failed_load_leaves_store_empty() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+
+    let src = format!("{PERMISSION_RULE_SRC}\nerror('boom after rule')");
+    let err = host
+        .load_source("perm_broken", &src)
+        .expect_err("expected lua error");
+    assert!(matches!(err, PluginError::Lua { .. }));
+    assert!(host.plugin_rules().snapshot().is_empty());
+}
+
+#[test]
+fn reload_clears_stale_rules_of_that_plugin_only() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+
+    host.load_source("perm_a", PERMISSION_RULE_SRC).unwrap();
+    host.load_source(
+        "perm_b",
+        r#"maki.api.register_permission_rule({ tool = "write", scope = "/tmp/y/**", effect = "deny" })"#,
+    )
+    .unwrap();
+    assert_eq!(host.plugin_rules().snapshot().len(), 2);
+
+    host.load_source("perm_a", NO_RULE_SRC).unwrap();
+    let rules = host.plugin_rules().snapshot();
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].tool, ToolKey::native("write"));
+    assert_eq!(rules[0].scope.as_deref(), Some("/tmp/y/**"));
+    assert_eq!(rules[0].effect, Effect::Deny);
+}
+
+#[test_case::test_case(r#"{ tool = "srv.tool", scope = "/x/**" }"#, "only native tools are allowed" ; "mcp_tool")]
+#[test_case::test_case(r#"{ tool = "mcp:srv", scope = "/x/**" }"#, "invalid tool name" ; "invalid_tool_chars")]
+#[test_case::test_case(r#"{ tool = "*", scope = "/x/**" }"#, "only native tools are allowed" ; "wildcard_tool")]
+#[test_case::test_case(r#"{ scope = "/x/**" }"#, "'tool' must be a native tool name string" ; "missing_tool")]
+#[test_case::test_case(r#"{ tool = "edit" }"#, "'scope' must be a string" ; "missing_scope")]
+#[test_case::test_case(r#"{ tool = "edit", scope = "" }"#, "'scope' must be non-empty" ; "empty_scope")]
+#[test_case::test_case(r#"{ tool = "edit", scope = "/x/**", effect = "maybe" }"#, "invalid effect 'maybe'" ; "bad_effect")]
+#[test_case::test_case(r#"{ tool = "edit", scope = "/x/**", bogus = 1 }"#, "unknown key 'bogus'" ; "unknown_key")]
+fn permission_rule_validation_rejects(spec: &str, expected_err: &str) {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_source(
+            "perm_invalid",
+            &format!("maki.api.register_permission_rule({spec})"),
+        )
+        .expect_err("expected validation error");
+    assert!(matches!(err, PluginError::Lua { .. }));
+    assert!(err.to_string().contains(expected_err), "got: {err}");
 }
 
 #[test_case::test_case(BAD_NAME_SRC, MINIMAL_SCHEMA, "invalid name" ; "invalid_tool_name")]

--- a/maki-ui/src/agent/mod.rs
+++ b/maki-ui/src/agent/mod.rs
@@ -346,6 +346,7 @@ mod tests {
         let permissions = Arc::new(PermissionManager::new(
             PermissionsConfig::default(),
             PathBuf::from("/tmp"),
+            Arc::default(),
         ));
         let handles = AgentHandles::spawn(
             &model_slot,

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -73,6 +73,7 @@ fn build_app_with_lua(
                 ..Default::default()
             },
             PathBuf::from("/tmp"),
+            Arc::default(),
         )),
         Arc::from([]),
         maki_lua::EventHandle::disconnected_for_test(),

--- a/plugins/memory/init.lua
+++ b/plugins/memory/init.lua
@@ -2,28 +2,57 @@ local ToolView = require("maki.tool_view")
 local helpers = require("memory_helpers")
 local ListPicker = require("maki.list_picker")
 
+local WRITE_TOOLS = { "write", "edit", "multiedit", "edit_lines", "insert_lines" }
+
 local function memories_path_suffix()
   local cwd = maki.uv.cwd()
   local root = maki.fs.root(cwd, ".git") or cwd
   return "projects/" .. helpers.project_id(root) .. "/memories"
 end
 
+local function legacy_dir_if_exists(suffix)
+  local legacy = maki.env.legacy_dir()
+  if not legacy then
+    return nil
+  end
+  local dir = maki.fs.joinpath(legacy, suffix)
+  local meta = maki.fs.metadata(dir)
+  if meta and meta.is_dir then
+    return dir
+  end
+end
+
+-- Notes live outside cwd, where file-write tools normally prompt; pre-allow
+-- them here so the agent can edit notes directly. Reads may come from the
+-- legacy dir while writes go to the state dir, so cover both.
+local function register_write_rules()
+  local suffix = memories_path_suffix()
+  local dirs = { legacy_dir_if_exists(suffix) }
+  local state = maki.env.state_dir()
+  if state then
+    dirs[#dirs + 1] = maki.fs.joinpath(state, suffix)
+  end
+  for _, dir in ipairs(dirs) do
+    for _, tool in ipairs(WRITE_TOOLS) do
+      maki.api.register_permission_rule({ tool = tool, scope = dir .. "/**" })
+    end
+  end
+end
+register_write_rules()
+
 local function resolve_dir(check_legacy)
+  local suffix = memories_path_suffix()
   if check_legacy then
-    local legacy = maki.env.legacy_dir()
-    if legacy then
-      local dir = maki.fs.joinpath(legacy, memories_path_suffix())
-      local meta = maki.fs.metadata(dir)
-      if meta and meta.is_dir then
-        return dir
-      end
+    local dir = legacy_dir_if_exists(suffix)
+    if dir then
+      return dir
     end
   end
   local state = maki.env.state_dir()
   if not state then
     return nil, "cannot resolve state dir"
   end
-  return maki.fs.joinpath(state, memories_path_suffix())
+  return maki.fs.joinpath(state, suffix)
 end
 
 maki.api.register_prompt_hint({
@@ -129,12 +158,22 @@ local function cmd_delete(path, dir)
   return "deleted " .. path
 end
 
+local function with_dir(res, dir)
+  local prefix = "dir: " .. dir .. "\n\n"
+  if type(res) == "string" then
+    return prefix .. res
+  end
+  res.llm_output = prefix .. res.llm_output
+  return res
+end
+
 maki.api.register_tool({
   name = "memory",
   description = "Persistent, project-scoped scratchpad for learnings, patterns, decisions, and gotchas across sessions.\n\n"
     .. "- Notes are retrieved by tag; reuse the tags from your system prompt when they fit.\n"
     .. "- Save important context before compaction or to build up project knowledge.\n"
-    .. "- Keep entries concise and current. Delete outdated information.",
+    .. "- Keep entries concise and current. Delete outdated information.\n"
+    .. "- Notes are plain files; `list` and `read` report the dir, so use the edit tool on `<dir>/<name>` for targeted changes.",
 
   schema = {
     type = "object",
@@ -206,6 +245,9 @@ maki.api.register_tool({
     end
     if err then
       return { llm_output = "error: " .. err, is_error = true }
+    end
+    if cmd == "list" or cmd == "read" then
+      return with_dir(result, dir)
     end
     return result
   end,

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -235,6 +235,40 @@ maki.api.register_tool({
 
 ---
 
+### `maki.api.register_permission_rule()` {#maki-api-register_permission_rule}
+
+```lua
+maki.api.register_permission_rule({spec})
+```
+
+Declare an agent permission rule for a native tool. Use it to pre-allow
+(or pre-deny) tool calls on paths your plugin owns, like a storage
+directory outside the working dir, so the user is not prompted for them.
+
+Rules live as long as the plugin is loaded: a reload replaces them, and a
+reload that registers none clears the old ones. User config and session
+deny rules always win over a plugin allow.
+
+**Parameters:**
+
+- `{spec}` (`table`) Rule specification:
+  - `tool` (`string`) Required. Native tool name (e.g. "edit", "write").
+    MCP tools and the "*" wildcard are not allowed.
+  - `scope` (`string`) Required. Scope pattern the rule applies to, e.g.
+    "/abs/dir/**" for a directory subtree.
+  - `effect` (`string`) Optional. "allow" (default) or "deny".
+
+**Example:**
+
+```lua
+maki.api.register_permission_rule({
+  tool = "write",
+  scope = notes_dir .. "/**",
+})
+```
+
+---
+
 ### `maki.api.register_command()` {#maki-api-register_command}
 
 ```lua

--- a/site/docs/content/permissions/_index.md
+++ b/site/docs/content/permissions/_index.md
@@ -9,13 +9,14 @@ group = "Reference"
 
 Maki uses a permission system to decide what each tool is allowed to do and when to ask you first.
 
-Rules come from three layers, combined for resolution:
+Rules come from four layers, combined for resolution:
 
 1. **Session rules**, set during the current session (in-memory only)
 2. **Config rules**, loaded from TOML permission files
 3. **Builtin rules**, the hardcoded defaults
+4. **Plugin rules**, declared by plugins via [`maki.api.register_permission_rule`](/lua-api/#maki-api-register_permission_rule)
 
-Any matching deny blocks the tool. No exceptions.
+Any matching deny blocks the tool. No exceptions, so a config deny always beats a plugin allow.
 
 ## Check Flow
 
@@ -36,7 +37,7 @@ plan file write?    ── yes ──►  runs
 default: prompt / allow / deny
 ```
 
-Deny rules are checked across all three layers before anything else, so a deny cannot be bypassed by YOLO or the plan-file auto-allow. In plan mode, writes to any path other than the plan file are rejected before this flow, and MCP tools are blocked entirely. `default` resolves per-tool first, then global; the built-in default is `"prompt"`.
+Deny rules are checked across all layers before anything else, so a deny cannot be bypassed by YOLO or the plan-file auto-allow. In plan mode, writes to any path other than the plan file are rejected before this flow, and MCP tools are blocked entirely. `default` resolves per-tool first, then global; the built-in default is `"prompt"`.
 
 ## Builtin Defaults
 
@@ -50,6 +51,8 @@ File-write tools are pre-allowed inside the project working directory (cwd at se
 | `edit_lines` | `<cwd>/**` | Same, when the opt-in tool is enabled |
 | `insert_lines` | `<cwd>/**` | Same, when the opt-in tool is enabled |
 | `task` | `*` | Subagent spawning always allowed |
+
+The memory plugin uses a plugin rule to pre-allow the file-write tools inside its notes directory (under maki's state dir), so the agent can edit memory notes directly without a prompt.
 
 These tools have no builtin allow rule, so they prompt (or follow your `default`) every time unless you add rules:
 

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -63,5 +63,6 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
         prompt_slots: Arc::new(prompt_slots),
         yolo,
         model_policy: Arc::new(config.provider.model_policy.clone()),
+        plugin_rules: plugin_host.plugin_rules(),
     })
 }

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -255,6 +255,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
             fast,
             workflow: stack.config.always_workflow,
             model_policy: Arc::new(stack.config.provider.model_policy.clone()),
+            plugin_rules: stack.plugin_host.plugin_rules(),
         })
         .context("run sdk mode")?;
         return Ok(());
@@ -275,6 +276,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
             fast,
             stack.config.always_workflow,
             Arc::new(stack.config.provider.model_policy.clone()),
+            stack.plugin_host.plugin_rules(),
         )
         .context("run print mode")?;
         return Ok(());
@@ -331,6 +333,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
                 permissions: Arc::new(maki_agent::permissions::PermissionManager::new(
                     stack.config.permissions.clone(),
                     cwd.clone(),
+                    stack.plugin_host.plugin_rules(),
                 )),
                 timeouts: stack.timeouts(),
                 exit_on_done: cli.exit_on_done,

--- a/src/print.rs
+++ b/src/print.rs
@@ -16,6 +16,7 @@ use clap::ValueEnum;
 use color_eyre::Result;
 use color_eyre::eyre::{Context, eyre};
 use maki_agent::headless::{HeadlessHandle, HeadlessParams};
+use maki_agent::permissions::PluginRuleStore;
 use maki_agent::tools::QUESTION_TOOL_NAME;
 use maki_agent::{AgentConfig, AgentEvent, DoneReason, Envelope, ImageSource, PermissionsConfig};
 use maki_config::ModelPolicy;
@@ -149,6 +150,7 @@ pub fn run(
     fast: bool,
     workflow: bool,
     model_policy: Arc<ModelPolicy>,
+    plugin_rules: Arc<PluginRuleStore>,
 ) -> Result<()> {
     let prompt = match prompt_arg {
         Some(p) => p,
@@ -183,6 +185,7 @@ pub fn run(
         fast,
         workflow,
         model_policy,
+        plugin_rules,
     });
 
     let HeadlessHandle {

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -19,7 +19,7 @@ use color_eyre::eyre::{Context, eyre};
 use flume::{Receiver, Sender};
 use maki_agent::headless::{self, InteractiveHandle, InteractiveParams};
 use maki_agent::mcp;
-use maki_agent::permissions::PermissionAnswer;
+use maki_agent::permissions::{PermissionAnswer, PluginRuleStore};
 use maki_agent::prompt::ResolvedSlots;
 use maki_agent::tools::QUESTION_TOOL_NAME;
 use maki_agent::{
@@ -450,6 +450,7 @@ pub struct SdkParams {
     pub fast: bool,
     pub workflow: bool,
     pub model_policy: Arc<ModelPolicy>,
+    pub plugin_rules: Arc<PluginRuleStore>,
 }
 
 struct Shared {
@@ -470,6 +471,7 @@ pub fn run(params: SdkParams) -> Result<()> {
         fast,
         workflow,
         model_policy,
+        plugin_rules,
     } = params;
     cli.warn_ignored_flags();
     if let Some(max) = cli.max_turns {
@@ -503,6 +505,7 @@ pub fn run(params: SdkParams) -> Result<()> {
         append_system_prompt: cli.append_system_prompt.clone().filter(|s| !s.is_empty()),
         workflow,
         model_policy: Arc::clone(&model_policy),
+        plugin_rules,
     });
 
     let (out_tx, out_rx) = flume::unbounded::<String>();


### PR DESCRIPTION
Fixing one line in a memory note meant rewriting the whole file, and a dedicated edit command would hang `old_string`, `new_string` and `replace_all` on the memory schema, paid on every request of every session.

So `list` and `read` now print a `dir:` line and the tool description points the agent at the regular `edit` tool, which already speaks absolute paths.

Notes live outside cwd where file-write tools prompt, and core should not know a plugin's storage layout, so plugins can now declare agent permission rules via `maki.api.register_permission_rule`: a fourth rule layer at builtin precedence that a config deny still beats, committed on successful plugin load, replaced on reload, cleared on unload.

The memory plugin uses it to pre-allow the file-write tools on its notes dir; the generic edit path skips the 20KB cap and tag validation, which we accept since the stem-tag fallback covers untagged files.