### PR TITLE
feat(acp): report tool call file locations for follow-along

### DIFF
--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -172,11 +172,12 @@ async fn new_session(
     let req: NewSessionRequest = parse_params(raw)?;
     close_session(srv).await;
     let mcp = start_mcp(&req.cwd, &req.mcp_servers).await;
+    let cwd = req.cwd.clone();
     let handle = spawn_session(params, req.cwd, None, Vec::new(), mcp.clone());
     let spec = params.model.spec();
     let resp = methods::new_session_response(handle.session_id.as_str())
         .config_options(vec![methods::model_config_option(&spec, &srv.model_specs)]);
-    install_session(srv, handle, mcp, spec);
+    install_session(srv, handle, mcp, spec, cwd);
     Ok(AgentResponse::NewSessionResponse(resp))
 }
 
@@ -191,18 +192,21 @@ async fn load_session(
         .0
         .parse()
         .map_err(|_| AcpError::resource_not_found(Some(req.session_id.0.to_string())))?;
-    let history = load_history(session_ref.id())?;
+    let (history, recorded_cwd) = load_history(session_ref.id())?;
     close_session(srv).await;
     let mcp = start_mcp(&req.cwd, &req.mcp_servers).await;
     let sid = SessionId::from(session_ref.to_string());
-    for update in translate::replay_history(&history) {
+    let home = maki_storage::paths::home();
+    let replay_cwd = recorded_cwd.as_deref().unwrap_or(&req.cwd);
+    for update in translate::replay_history(&history, replay_cwd, home.as_deref()) {
         session_update(&srv.out_tx, &sid, update);
     }
+    let cwd = req.cwd.clone();
     let handle = spawn_session(params, req.cwd, Some(session_ref), history, mcp.clone());
     let spec = params.model.spec();
     let resp = methods::load_session_response()
         .config_options(vec![methods::model_config_option(&spec, &srv.model_specs)]);
-    install_session(srv, handle, mcp, spec);
+    install_session(srv, handle, mcp, spec, cwd);
     Ok(AgentResponse::LoadSessionResponse(resp))
 }
 
@@ -318,6 +322,7 @@ fn install_session(
     handle: InteractiveHandle,
     mcp: Option<McpHandle>,
     current_model: String,
+    cwd: PathBuf,
 ) {
     let pending = PendingState::default();
     start_event_pump(
@@ -325,6 +330,8 @@ fn install_session(
         handle.session_id.clone(),
         srv.out_tx.clone(),
         Arc::clone(&pending),
+        cwd,
+        maki_storage::paths::home(),
     );
     srv.session = Some(SessionState {
         handle,
@@ -335,16 +342,19 @@ fn install_session(
     });
 }
 
-fn load_history(session_id: MakiId) -> Result<Vec<Message>, AcpError> {
+fn load_history(session_id: MakiId) -> Result<(Vec<Message>, Option<PathBuf>), AcpError> {
     let storage = maki_storage::StateDir::resolve()
         .map_err(|e| AcpError::internal_error().data(json_str(&e)))?;
     load_history_from(&storage, session_id)
 }
 
+/// History plus the absolute cwd the session recorded in its header. Tool
+/// inputs from a past run resolve against that cwd, not the client's current
+/// one; a non-absolute recording falls back to the caller's cwd.
 fn load_history_from(
     storage: &maki_storage::StateDir,
     session_id: MakiId,
-) -> Result<Vec<Message>, AcpError> {
+) -> Result<(Vec<Message>, Option<PathBuf>), AcpError> {
     let session: maki_storage::sessions::Session<
         Message,
         maki_providers::TokenUsage,
@@ -352,7 +362,12 @@ fn load_history_from(
     > = maki_storage::sessions::Session::load(session_id, storage).map_err(|e| {
         AcpError::resource_not_found(Some(format!("session/{session_id}"))).data(json_str(&e))
     })?;
-    Ok(session.take_messages())
+    let recorded = if Path::new(&session.cwd).is_absolute() {
+        Some(PathBuf::from(&session.cwd))
+    } else {
+        None
+    };
+    Ok((session.take_messages(), recorded))
 }
 
 fn handle_prompt(srv: &mut Server, raw: &Value, id: &RequestId) -> Result<(), AcpError> {
@@ -525,6 +540,8 @@ fn start_event_pump(
     session_id: SessionRef,
     out_tx: Sender<Value>,
     pending: PendingState,
+    cwd: PathBuf,
+    home: Option<PathBuf>,
 ) {
     smol::spawn(async move {
         let sid = SessionId::from(session_id.to_string());
@@ -541,9 +558,11 @@ fn start_event_pump(
                 AgentEvent::TextDelta { text } => translate::text_delta(&text),
                 AgentEvent::ThinkingDelta { text } => translate::thinking_delta(&text),
                 AgentEvent::ToolPending { id, name } => translate::tool_pending(&id, &name),
-                AgentEvent::ToolStart(event) => translate::tool_start(&event),
+                AgentEvent::ToolStart(event) => {
+                    translate::tool_start(&event, &cwd, home.as_deref())
+                }
                 AgentEvent::ToolOutput { id, content } => translate::tool_output(&id, &content),
-                AgentEvent::ToolDone(event) => translate::tool_done(&event),
+                AgentEvent::ToolDone(event) => translate::tool_done(&event, &cwd, home.as_deref()),
                 AgentEvent::PermissionRequest { id, tool, scopes } => {
                     let fields =
                         ToolCallUpdateFields::new().title(format!("{tool}: {}", scopes.join(", ")));
@@ -734,11 +753,23 @@ mod tests {
         session.save(&dir).unwrap();
 
         let id: MakiId = session.id;
-        let history = load_history_from(&dir, id).unwrap();
+        let (history, recorded) = load_history_from(&dir, id).unwrap();
         assert_eq!(
             serde_json::to_value(&history).unwrap(),
             serde_json::to_value(&messages).unwrap()
         );
+        assert_eq!(recorded, Some(PathBuf::from("/project")));
+    }
+
+    #[test]
+    fn load_history_records_absolute_cwd_only() {
+        let tmp = TempDir::new().unwrap();
+        let dir = StateDir::from_path(tmp.path().to_path_buf());
+        let mut session: Session<Message, TokenUsage, maki_agent::ToolOutput> =
+            Session::new("anthropic/test-model", "relative/project");
+        session.save(&dir).unwrap();
+        let (_, recorded) = load_history_from(&dir, session.id).unwrap();
+        assert_eq!(recorded, None);
     }
 
     #[test]

--- a/maki-acp/src/translate.rs
+++ b/maki-acp/src/translate.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 use agent_client_protocol_schema::{
     Content, ContentBlock, ContentChunk, Diff, ImageContent, SessionUpdate, StopReason,
     TextContent, ToolCall, ToolCallContent, ToolCallId, ToolCallLocation, ToolCallStatus,
@@ -9,6 +11,19 @@ use maki_agent::types::{ToolDoneEvent, ToolOutput, ToolStartEvent};
 use maki_providers::{ContentBlock as MsgBlock, ImageMediaType, Message, Role as MsgRole};
 
 const MIN_FENCE_LEN: usize = 3;
+
+/// File-level tools report a location so the client can follow along. Directory
+/// scoped tools (glob, grep, list) and commands (bash) target no single file.
+const FILE_TOOLS: &[&str] = &[
+    "read",
+    "write",
+    "edit",
+    "multiedit",
+    "edit_lines",
+    "insert_lines",
+    "index",
+    "view_image",
+];
 
 /// Zed renders tool output as markdown, so bare text loses its newlines.
 /// We wrap it in a backtick fence (longer than any run inside the text)
@@ -71,7 +86,7 @@ pub fn tool_pending(id: &str, name: &str) -> SessionUpdate {
     )
 }
 
-pub fn tool_start(event: &ToolStartEvent) -> SessionUpdate {
+pub fn tool_start(event: &ToolStartEvent, cwd: &Path, home: Option<&Path>) -> SessionUpdate {
     let mut fields = ToolCallUpdateFields::new()
         .status(ToolCallStatus::InProgress)
         .title(event.summary.clone());
@@ -80,12 +95,7 @@ pub fn tool_start(event: &ToolStartEvent) -> SessionUpdate {
         fields = fields.raw_input(raw.clone());
     }
 
-    let mut locations = Vec::new();
-    if event.input.is_some()
-        && let Some(path) = input_path(event.raw_input.as_ref())
-    {
-        locations.push(ToolCallLocation::new(path));
-    }
+    let locations = tool_locations(&event.tool, event.raw_input.as_ref(), cwd, home);
     if !locations.is_empty() {
         fields = fields.locations(locations);
     }
@@ -96,11 +106,103 @@ pub fn tool_start(event: &ToolStartEvent) -> SessionUpdate {
     ))
 }
 
-fn input_path(raw_input: Option<&serde_json::Value>) -> Option<std::path::PathBuf> {
+/// File locations the tool call touches, per ACP "Following the Agent". The
+/// client expects absolute paths, so `~` and relative paths are resolved
+/// against the session's home and cwd.
+fn tool_locations(
+    tool: &str,
+    raw_input: Option<&serde_json::Value>,
+    cwd: &Path,
+    home: Option<&Path>,
+) -> Vec<ToolCallLocation> {
+    if !FILE_TOOLS.contains(&tool) {
+        return Vec::new();
+    }
+    let Some(raw) = raw_input else {
+        return Vec::new();
+    };
+    let Some(path) = input_path(raw) else {
+        return Vec::new();
+    };
+    let Some(resolved) = resolve_path(path, cwd, home) else {
+        return Vec::new();
+    };
+    vec![location(resolved, input_line(tool, raw))]
+}
+
+/// The target file: `path`, or its schema alias `file_path` when the model
+/// used that spelling.
+fn input_path(raw_input: &serde_json::Value) -> Option<&str> {
     raw_input
-        .and_then(|v| v.get("path"))
-        .and_then(|v| v.as_str())
-        .map(std::path::PathBuf::from)
+        .get("path")
+        .or_else(|| raw_input.get("file_path"))?
+        .as_str()
+        .filter(|s| !s.is_empty())
+}
+
+/// `~`, `~/x`, and relative paths become absolute; other `~` spellings
+/// (`~user`) have no expansion. ACP clients require absolute paths in
+/// locations, so anything unresolvable yields None instead of a bogus path.
+fn resolve_path(raw: &str, cwd: &Path, home: Option<&Path>) -> Option<PathBuf> {
+    if raw.starts_with('~') {
+        if raw == "~" {
+            return home.map(Path::to_path_buf);
+        }
+        let rest = raw.strip_prefix("~/")?;
+        return home.map(|h| h.join(rest));
+    }
+    let p = Path::new(raw);
+    Some(if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        cwd.join(p)
+    })
+}
+
+/// The line a tool call focuses on, when its input says so. ACP `line` is
+/// 0-based (Zed uses it as a buffer row), but tool inputs are 1-based.
+fn input_line(tool: &str, raw_input: &serde_json::Value) -> Option<u32> {
+    let key = match tool {
+        "read" => "offset",
+        "edit_lines" => "start",
+        "insert_lines" => "line",
+        _ => return None,
+    };
+    raw_input.get(key).and_then(as_line).map(|l| l - 1)
+}
+
+/// raw_input is pre-validation, so models sometimes send numbers as strings.
+fn as_line(v: &serde_json::Value) -> Option<u32> {
+    let n = v
+        .as_u64()
+        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))?;
+    u32::try_from(n).ok().filter(|&l| l >= 1)
+}
+
+fn location(path: PathBuf, line: Option<u32>) -> ToolCallLocation {
+    let mut loc = ToolCallLocation::new(path);
+    if let Some(l) = line {
+        loc = loc.line(l);
+    }
+    loc
+}
+
+/// A finished call's location comes from what it wrote. File tools already
+/// reported that path at start, sometimes with a line, and an update replaces
+/// locations instead of merging them, so re-reporting would drop the line the
+/// client is following. Paths are already absolute (the plugins abspath them),
+/// so resolve_path is a no-op here; it only guards against a relative slip.
+fn done_locations(event: &ToolDoneEvent, cwd: &Path, home: Option<&Path>) -> Vec<ToolCallLocation> {
+    if event.is_error || FILE_TOOLS.contains(&&*event.tool) {
+        return Vec::new();
+    }
+    let Some(path) = event.written_path() else {
+        return Vec::new();
+    };
+    let Some(resolved) = resolve_path(path, cwd, home) else {
+        return Vec::new();
+    };
+    vec![location(resolved, None)]
 }
 
 pub fn tool_output(id: &str, content: &str) -> SessionUpdate {
@@ -113,7 +215,7 @@ pub fn tool_output(id: &str, content: &str) -> SessionUpdate {
     ))
 }
 
-pub fn tool_done(event: &ToolDoneEvent) -> SessionUpdate {
+pub fn tool_done(event: &ToolDoneEvent, cwd: &Path, home: Option<&Path>) -> SessionUpdate {
     let status = if event.is_error {
         ToolCallStatus::Failed
     } else {
@@ -152,6 +254,11 @@ pub fn tool_done(event: &ToolDoneEvent) -> SessionUpdate {
         fields = fields.raw_output(serde_json::Value::String(raw_text));
     }
 
+    let locations = done_locations(event, cwd, home);
+    if !locations.is_empty() {
+        fields = fields.locations(locations);
+    }
+
     SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
         ToolCallId::from(event.id.clone()),
         fields,
@@ -167,12 +274,12 @@ pub fn map_done_reason(reason: DoneReason) -> StopReason {
     }
 }
 
-pub fn replay_history(messages: &[Message]) -> Vec<SessionUpdate> {
+pub fn replay_history(messages: &[Message], cwd: &Path, home: Option<&Path>) -> Vec<SessionUpdate> {
     let mut updates = Vec::new();
     for msg in messages {
         match msg.role {
             MsgRole::User => replay_user(msg, &mut updates),
-            MsgRole::Assistant => replay_assistant(msg, &mut updates),
+            MsgRole::Assistant => replay_assistant(msg, &mut updates, cwd, home),
         }
     }
     updates
@@ -207,7 +314,12 @@ fn replay_user(msg: &Message, updates: &mut Vec<SessionUpdate>) {
     }
 }
 
-fn replay_assistant(msg: &Message, updates: &mut Vec<SessionUpdate>) {
+fn replay_assistant(
+    msg: &Message,
+    updates: &mut Vec<SessionUpdate>,
+    cwd: &Path,
+    home: Option<&Path>,
+) {
     for block in &msg.content {
         match block {
             MsgBlock::Text { text } => updates.push(text_delta(text)),
@@ -215,20 +327,26 @@ fn replay_assistant(msg: &Message, updates: &mut Vec<SessionUpdate>) {
             MsgBlock::ToolUse {
                 id, name, input, ..
             } => {
-                updates.push(replay_tool_call(id, name, input));
+                updates.push(replay_tool_call(id, name, input, cwd, home));
             }
             _ => {}
         }
     }
 }
 
-fn replay_tool_call(id: &str, name: &str, input: &serde_json::Value) -> SessionUpdate {
-    SessionUpdate::ToolCall(
-        ToolCall::new(ToolCallId::from(id.to_string()), name.to_string())
-            .kind(tool_kind(name))
-            .status(ToolCallStatus::Pending)
-            .raw_input(input.clone()),
-    )
+fn replay_tool_call(
+    id: &str,
+    name: &str,
+    input: &serde_json::Value,
+    cwd: &Path,
+    home: Option<&Path>,
+) -> SessionUpdate {
+    let call = ToolCall::new(ToolCallId::from(id.to_string()), name.to_string())
+        .kind(tool_kind(name))
+        .status(ToolCallStatus::Pending)
+        .raw_input(input.clone())
+        .locations(tool_locations(name, Some(input), cwd, home));
+    SessionUpdate::ToolCall(call)
 }
 
 fn replay_tool_result(id: &str, content: &str, is_error: bool) -> SessionUpdate {
@@ -260,10 +378,16 @@ fn mime_type(media: &ImageMediaType) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use maki_providers::ImageSource;
+    use serde_json::json;
     use test_case::test_case;
 
     use super::*;
+
+    const CWD: &str = "/home/user/project";
+    const HOME: &str = "/home/user";
 
     #[test_case("1: mod render\n2: mod segment", "```\n1: mod render\n2: mod segment\n```" ; "plain_text_gets_default_fence")]
     #[test_case("has ```rust\ncode\n``` inside", "````\nhas ```rust\ncode\n``` inside\n````" ; "fence_longer_than_inner_backticks")]
@@ -291,7 +415,7 @@ mod tests {
     }
 
     fn updates_json(messages: &[Message]) -> Vec<serde_json::Value> {
-        replay_history(messages)
+        replay_history(messages, Path::new(CWD), Some(Path::new(HOME)))
             .iter()
             .map(|u| serde_json::to_value(u).unwrap())
             .collect()
@@ -420,5 +544,174 @@ mod tests {
     #[test_case("nonexistent_plugin_tool", ToolKind::Other ; "unknown_tool_is_other")]
     fn tool_kind_from_registry(name: &str, expected: ToolKind) {
         assert_eq!(tool_kind(name), expected);
+    }
+
+    fn start_event(tool: &str, raw_input: Option<serde_json::Value>) -> ToolStartEvent {
+        ToolStartEvent {
+            id: "t-1".into(),
+            tool: Arc::from(tool),
+            summary: String::new(),
+            render_header: None,
+            annotation: None,
+            input: None,
+            raw_input,
+            output: None,
+        }
+    }
+
+    fn start_locations(
+        tool: &str,
+        raw_input: Option<serde_json::Value>,
+    ) -> Option<serde_json::Value> {
+        let update = tool_start(
+            &start_event(tool, raw_input),
+            Path::new(CWD),
+            Some(Path::new(HOME)),
+        );
+        serde_json::to_value(update)
+            .unwrap()
+            .get("locations")
+            .cloned()
+    }
+
+    #[test_case("read", Some(json!({"path": "/a/b.rs", "offset": 42, "limit": 5})), Some(json!([{"path": "/a/b.rs", "line": 41}])) ; "read_absolute_with_offset")]
+    #[test_case("read", Some(json!({"path": "/a/b.rs", "offset": 1, "limit": 5})), Some(json!([{"path": "/a/b.rs", "line": 0}])) ; "offset_one_reports_line_zero")]
+    #[test_case("read", Some(json!({"path": "src/lib.rs", "offset": 1, "limit": 0})), Some(json!([{"path": "/home/user/project/src/lib.rs", "line": 0}])) ; "read_relative_resolved_against_cwd")]
+    #[test_case("read", Some(json!({"path": "~/notes.md", "offset": 1, "limit": 0})), Some(json!([{"path": "/home/user/notes.md", "line": 0}])) ; "read_tilde_expanded")]
+    #[test_case("read", Some(json!({"path": "~", "offset": 1, "limit": 0})), Some(json!([{"path": "/home/user", "line": 0}])) ; "read_bare_tilde_expands_to_home")]
+    #[test_case("read", Some(json!({"path": "~other/x", "offset": 1, "limit": 0})), None ; "read_tilde_user_prefix_unresolvable")]
+    #[test_case("read", Some(json!({"file_path": "/a/b.rs", "offset": 7, "limit": 5})), Some(json!([{"path": "/a/b.rs", "line": 6}])) ; "read_file_path_alias")]
+    #[test_case("read", Some(json!({"path": "/a/b.rs", "offset": "42", "limit": 5})), Some(json!([{"path": "/a/b.rs", "line": 41}])) ; "read_string_offset_coerced")]
+    #[test_case("write", Some(json!({"path": "/a/b.rs", "content": "x"})), Some(json!([{"path": "/a/b.rs"}])) ; "write_no_line")]
+    #[test_case("edit", Some(json!({"path": "c.rs", "old_string": "a", "new_string": "b"})), Some(json!([{"path": "/home/user/project/c.rs"}])) ; "edit_relative_no_line")]
+    #[test_case("multiedit", Some(json!({"path": "c.rs", "edits": []})), Some(json!([{"path": "/home/user/project/c.rs"}])) ; "multiedit_relative_no_line")]
+    #[test_case("edit_lines", Some(json!({"path": "/a", "start": 3, "end": 9, "new_string": "n"})), Some(json!([{"path": "/a", "line": 2}])) ; "edit_lines_start_becomes_line")]
+    #[test_case("insert_lines", Some(json!({"path": "/a", "line": 5, "new_string": "n"})), Some(json!([{"path": "/a", "line": 4}])) ; "insert_lines_line")]
+    #[test_case("index", Some(json!({"path": "/a/b.rs"})), Some(json!([{"path": "/a/b.rs"}])) ; "index_file_path")]
+    #[test_case("view_image", Some(json!({"path": "img.png"})), Some(json!([{"path": "/home/user/project/img.png"}])) ; "view_image_relative")]
+    #[test_case("glob", Some(json!({"pattern": "*.rs", "path": "src"})), None ; "glob_directory_path_ignored")]
+    #[test_case("grep", Some(json!({"pattern": "x", "path": "src"})), None ; "grep_directory_path_ignored")]
+    #[test_case("bash", Some(json!({"command": "ls", "workdir": "/tmp"})), None ; "bash_workdir_ignored")]
+    #[test_case("read", None, None ; "missing_input_no_locations")]
+    #[test_case("read", Some(json!({"offset": 1, "limit": 0})), None ; "missing_path_no_locations")]
+    #[test_case("read", Some(json!({"path": "", "offset": 1, "limit": 0})), None ; "empty_path_no_locations")]
+    fn tool_start_locations(
+        tool: &str,
+        input: Option<serde_json::Value>,
+        expected: Option<serde_json::Value>,
+    ) {
+        assert_eq!(start_locations(tool, input), expected);
+    }
+
+    #[test]
+    fn tool_start_with_no_raw_input_has_no_locations_field() {
+        let update = tool_start(
+            &start_event("read", None),
+            Path::new(CWD),
+            Some(Path::new(HOME)),
+        );
+        let json = serde_json::to_value(update).unwrap();
+        assert!(
+            json.get("locations").is_none(),
+            "empty locations must be omitted: {json}"
+        );
+    }
+
+    fn done_event(
+        tool: &str,
+        output: ToolOutput,
+        is_error: bool,
+        written: Option<&str>,
+    ) -> ToolDoneEvent {
+        ToolDoneEvent {
+            id: "t-1".into(),
+            tool: Arc::from(tool),
+            output,
+            is_error,
+            annotation: None,
+            written_path: written.map(str::to_owned),
+        }
+    }
+
+    fn done_locations_of(event: &ToolDoneEvent) -> Option<serde_json::Value> {
+        let update = tool_done(event, Path::new(CWD), Some(Path::new(HOME)));
+        serde_json::to_value(update)
+            .unwrap()
+            .get("locations")
+            .cloned()
+    }
+
+    #[test]
+    fn done_written_path_reports_location_without_line() {
+        let event = done_event(
+            "memory",
+            ToolOutput::Plain("wrote 3 bytes".into()),
+            false,
+            Some("/home/user/project/a.rs"),
+        );
+        assert_eq!(
+            done_locations_of(&event),
+            Some(json!([{"path": "/home/user/project/a.rs"}]))
+        );
+    }
+
+    /// A file tool's start event already reported the path, with the line the
+    /// client is following. Re-reporting it here would replace that line.
+    #[test_case("edit_lines" ; "edit_lines_keeps_start_line")]
+    #[test_case("insert_lines" ; "insert_lines_keeps_start_line")]
+    #[test_case("write" ; "write_keeps_start_location")]
+    fn done_file_tool_omits_written_path_location(tool: &str) {
+        let event = done_event(
+            tool,
+            ToolOutput::Plain("wrote 3 bytes".into()),
+            false,
+            Some("/home/user/project/a.rs"),
+        );
+        assert_eq!(done_locations_of(&event), None);
+    }
+
+    #[test]
+    fn done_error_suppresses_written_path_location() {
+        let event = done_event(
+            "memory",
+            ToolOutput::Plain("write error: permission denied".into()),
+            true,
+            Some("/home/user/project/a.rs"),
+        );
+        assert_eq!(done_locations_of(&event), None);
+    }
+
+    #[test]
+    fn done_without_file_output_has_no_locations() {
+        let event = done_event("memory", ToolOutput::Plain("done".into()), false, None);
+        assert_eq!(done_locations_of(&event), None);
+    }
+
+    #[test]
+    fn replay_tool_use_reports_locations() {
+        let msg = assistant(vec![MsgBlock::tool_use(
+            "tu-1",
+            "read",
+            json!({"path": "src/lib.rs", "offset": 10, "limit": 0}),
+        )]);
+        let json = updates_json(&[msg]);
+        assert_eq!(json.len(), 1);
+        assert_eq!(json[0]["sessionUpdate"], "tool_call");
+        assert_eq!(json[0]["toolCallId"], "tu-1");
+        assert_eq!(
+            json[0]["locations"],
+            json!([{"path": "/home/user/project/src/lib.rs", "line": 9}])
+        );
+    }
+
+    #[test]
+    fn replay_non_file_tool_has_no_locations() {
+        let msg = assistant(vec![MsgBlock::tool_use(
+            "tu-1",
+            "bash",
+            json!({"command": "ls"}),
+        )]);
+        let json = updates_json(&[msg]);
+        assert!(json[0].get("locations").is_none(), "{:?}", json[0]);
     }
 }


### PR DESCRIPTION
I was wondering why enabling the "Follow" feature in Zed didn't seem to work, and it looks like a bunch of this was wired up but nonfunctional? So I hooked more of it up. In testing with Zed locally, it opens files as the agent reads them, but it doesn't seem quite like it always follows specific lines. Needs more testing and feedback.

Implemented in maki by qwen3.8-27B, tested by me with Zed.