### PR TITLE
fix(lua): stop plugin.toml from failing silently

### DIFF
--- a/maki-lua-macro/src/lib.rs
+++ b/maki-lua-macro/src/lib.rs
@@ -278,6 +278,10 @@ fn expand_lua_fn(args: LuaFnArgs, func: &mut ItemFn) -> syn::Result<TokenStream2
         doc.params.iter().zip(&rendered).map(
             |((_, ty, d), name)| quote!(crate::docs::ParamDoc { name: #name, ty: #ty, desc: #d }),
         );
+    let guard_doc = match &args.guard {
+        Some(g) => quote!(Some(crate::plugin_permissions::Permission::#g.manifest_key())),
+        None => quote!(None),
+    };
     let doc_const = quote! {
         #[allow(non_upper_case_globals)]
         pub(crate) const #doc_ident: crate::docs::FnDoc = crate::docs::FnDoc {
@@ -287,6 +291,7 @@ fn expand_lua_fn(args: LuaFnArgs, func: &mut ItemFn) -> syn::Result<TokenStream2
             params: &[#(#param_docs),*],
             returns: #returns,
             example: #example,
+            guard: #guard_doc,
         };
     };
 

--- a/maki-lua/src/api/async.rs
+++ b/maki-lua/src/api/async.rs
@@ -239,6 +239,7 @@ const await__doc: FnDoc = FnDoc {
         },
     ],
     returns: "(...) Values passed by the caller to the injected callback.",
+    guard: None,
     example: "local result = maki.async.await(2, http.get, url)",
 };
 
@@ -260,6 +261,7 @@ const wrap__doc: FnDoc = FnDoc {
         },
     ],
     returns: "(function) Wrapped function you can call like a normal function.",
+    guard: None,
     example: "local get = maki.async.wrap(2, http.get)\nlocal body = get(url)",
 };
 
@@ -281,6 +283,7 @@ const join__doc: FnDoc = FnDoc {
         },
     ],
     returns: "",
+    guard: None,
     example: "maki.async.join(4, {\n  function() process(files[1]) end,\n  function() process(files[2]) end,\n  function() process(files[3]) end,\n})",
 };
 

--- a/maki-lua/src/api/fn.rs
+++ b/maki-lua/src/api/fn.rs
@@ -599,9 +599,6 @@ lua_table! {
     /// control. Use these to run shell commands, wait for output, and check
     /// whether programs are installed.
     ///
-    /// Job functions need the `run` permission. `executable` needs the `env`
-    /// permission.
-    ///
     /// ```lua
     /// local id = maki.fn.jobstart("git status", {
     ///   on_exit = function(code) print("done: " .. code) end,

--- a/maki-lua/src/api/interpreter.rs
+++ b/maki-lua/src/api/interpreter.rs
@@ -203,8 +203,7 @@ lua_table! {
     /// Run Python code in a memory-safe, time-limited sandbox.
     ///
     /// The sandbox uses the monty interpreter. Python code can call back into
-    /// Lua-defined tools, and stdout is streamed line by line. Requires the
-    /// `run` permission.
+    /// Lua-defined tools, and stdout is streamed line by line.
     ///
     /// ```lua
     /// local r, err = maki.interpreter.run("print('hello')", {

--- a/maki-lua/src/api/json.rs
+++ b/maki-lua/src/api/json.rs
@@ -22,6 +22,7 @@ human-readable error strings.",
             desc: "The Lua value to validate.",
         }],
         returns: "(table?) Array of error strings, or nil if valid.",
+        guard: None,
         example: "local errs = validator:validate({ name = 123 })\n\
 if errs then\n\
   for _, msg in ipairs(errs) do print(msg) end\n\

--- a/maki-lua/src/api/treesitter/query.rs
+++ b/maki-lua/src/api/treesitter/query.rs
@@ -40,6 +40,7 @@ const iter_captures__doc: FnDoc = FnDoc {
         },
     ],
     returns: "(function) Iterator yielding (integer, Node, table, table, integer).",
+    guard: None,
     example: "local q = maki.treesitter.query.parse(\"lua\", \"(identifier) @id\")\nfor idx, node, meta in q:iter_captures(root, source) do\n  print(idx, node:type())\nend",
 };
 
@@ -71,6 +72,7 @@ const iter_matches__doc: FnDoc = FnDoc {
         },
     ],
     returns: "(function) Iterator yielding (integer, table, table, integer).",
+    guard: None,
     example: "local q = maki.treesitter.query.parse(\"lua\", \"(function_declaration name: (identifier) @name)\"\n)\nfor pat, captures, meta in q:iter_matches(root, source) do\n  for cap_idx, nodes in pairs(captures) do\n    print(nodes[1]:type())\n  end\nend",
 };
 

--- a/maki-lua/src/api/ui/mod.rs
+++ b/maki-lua/src/api/ui/mod.rs
@@ -438,6 +438,7 @@ pub(crate) const set_status_hint__doc: FnDoc = FnDoc {
         desc: "Sequence of {key, label} pairs, e.g. `{{\"q\", \"quit\"}, {\"j\", \"down\"}}`. Pass nil to remove the plugin's hints.",
     }],
     returns: "",
+    guard: None,
     example: "maki.ui.set_status_hint({ {\"q\", \"quit\"}, {\"j\", \"down\"} })\n-- later, clear them:\nmaki.ui.set_status_hint(nil)",
 };
 

--- a/maki-lua/src/api/ui/win.rs
+++ b/maki-lua/src/api/ui/win.rs
@@ -109,6 +109,7 @@ const recv__doc: FnDoc = FnDoc {
         desc: "Max milliseconds to wait before a timeout event is returned.",
     }],
     returns: "(table|nil) Event table, or nil if the window has closed.",
+    guard: None,
     example: "while true do\n  local ev = win:recv()\n  if not ev or ev.key == \"q\" then break end\n  if ev.type == \"key\" and ev.key == \"j\" then\n    -- move cursor down\n  end\nend\nwin:close()",
 };
 

--- a/maki-lua/src/api/util/setup.rs
+++ b/maki-lua/src/api/util/setup.rs
@@ -27,6 +27,7 @@ accepts the same keys as the Configuration reference.",
                 desc: "Configuration table.",
             }],
             returns: "",
+            guard: None,
             example: "maki.setup({\n\
   model = \"opus\",\n\
   keymaps = false,\n\

--- a/maki-lua/src/docs.rs
+++ b/maki-lua/src/docs.rs
@@ -35,6 +35,10 @@ pub struct FnDoc {
     pub returns: &'static str,
     /// Lua snippet rendered as a fenced code block, or "" when absent.
     pub example: &'static str,
+    /// Manifest key of the plugin permission gating this function, from the
+    /// `guard =` attribute. Rendered into the docs so the reference can
+    /// never drift from the actual gate.
+    pub guard: Option<&'static str>,
 }
 
 pub struct ParamDoc {

--- a/maki-lua/src/docs_render.rs
+++ b/maki-lua/src/docs_render.rs
@@ -7,6 +7,7 @@ use mlua::{Lua, Table};
 
 use crate::docs::{DocKind, FnDoc, ModuleDoc, api_docs};
 use crate::loader::lib_dir;
+use crate::plugin_permissions::Permission;
 
 const SKILL_MODULE: &str = "plugin_dev";
 const REFERENCE_MODULE: &str = "plugin_dev_reference";
@@ -16,6 +17,46 @@ const DESCRIPTION: &str = "Write or modify maki plugins or init.lua config in Lu
 const REFERENCE_PLACEHOLDER: &str = "__MAKI_REFERENCE_PATH__";
 
 const EXAMPLE: &str = include_str!("../../plugins/glob/init.lua");
+
+const PERMISSIONS_ANCHOR: &str = "plugin-permissions";
+
+/// Generated from [`Permission::ALL`] so the reference can never drift from
+/// the real gate set. `anchored` adds the explicit heading id for the site;
+/// the skill copy stays plain markdown.
+fn permissions_section(anchored: bool) -> String {
+    const TEMPLATE: &str = r#"## Permissions and plugin.toml{ANCHOR}
+
+Sensitive APIs are gated per plugin file; every gated function's entry in
+this reference names the permission it needs. The permissions are: {NAMES}.
+A gated call without its permission raises
+`permission denied: '<name>' not granted for this plugin`.
+
+Grants come from a `plugin.toml` next to the Lua file (for
+`~/.config/maki/init.lua` that is `~/.config/maki/plugin.toml`):
+
+```toml
+[permissions]
+{KEYS}```
+
+The rules:
+
+- No `plugin.toml` at all: every permission is denied, and maki logs a
+  warning at load time.
+- `plugin.toml` exists: permissions default to granted; set a key to
+  `false` to revoke it. An empty file grants everything.
+- Invalid TOML: everything denied, with a warning in the log.
+"#;
+    let keys = Permission::ALL.map(Permission::manifest_key);
+    let anchor = if anchored {
+        format!(" {{#{PERMISSIONS_ANCHOR}}}")
+    } else {
+        String::new()
+    };
+    TEMPLATE
+        .replace("{ANCHOR}", &anchor)
+        .replace("{NAMES}", &keys.map(|k| format!("`{k}`")).join(", "))
+        .replace("{KEYS}", &keys.map(|k| format!("{k} = true\n")).concat())
+}
 
 const GUIDE: &str = r#"# Writing maki plugins
 
@@ -31,6 +72,8 @@ full API reference is at the end of this document.
 
 Either file can call `maki.setup({ ... })` for configuration and register
 tools or commands. There are no separate plugin directories yet.
+
+{PERMISSIONS}
 
 ## Development loop
 
@@ -102,6 +145,8 @@ end
 
 Lua errors are reserved for programmer mistakes, like passing a number where
 a string belongs.
+
+{PERMISSIONS}
 "#;
 
 const COMPACT_HEADER: &str = r#"# Lua API
@@ -126,7 +171,7 @@ const FULL_SOURCE_MAX_BYTES: usize = 1024;
 /// model reads only the sections it needs.
 fn skill_content(reference: &str) -> String {
     format!(
-        "{GUIDE}{EXAMPLE}```\n\n# Full API reference\n\n\
+        "{guide}{EXAMPLE}```\n\n# Full API reference\n\n\
          The complete Lua API reference - every function with parameters, return\n\
          values, and examples, plus shared helper module sources - is on disk at:\n\n\
          `{REFERENCE_PLACEHOLDER}`\n\n\
@@ -136,7 +181,8 @@ fn skill_content(reference: &str) -> String {
          signature or parameter table from the index alone.\n\n\
          Signatures use Neovim notation: `{{path}}` is required, `{{opts?}}` is\n\
          optional, `{{...}}` is variadic.\n{}",
-        reference_index(reference)
+        reference_index(reference),
+        guide = GUIDE.replace("{PERMISSIONS}", permissions_section(false).trim_end()),
     )
 }
 
@@ -435,6 +481,15 @@ fn push_fn(out: &mut String, module: &ModuleDoc, f: &FnDoc, classes: &ClassLinks
         out.push_str(f.desc);
         out.push_str("\n\n");
     }
+    if let Some(guard) = f.guard {
+        if compact {
+            out.push_str(&format!("Requires the `{guard}` plugin permission.\n\n"));
+        } else {
+            out.push_str(&format!(
+                "Requires the `{guard}` [plugin permission](#{PERMISSIONS_ANCHOR}).\n\n"
+            ));
+        }
+    }
     if !f.params.is_empty() {
         out.push_str("**Parameters:**\n\n");
         for p in f.params {
@@ -473,7 +528,11 @@ fn render(compact: bool) -> String {
     } else {
         class_links()
     };
-    let mut out = String::from(if compact { COMPACT_HEADER } else { HEADER });
+    let mut out = if compact {
+        String::from(COMPACT_HEADER)
+    } else {
+        HEADER.replace("{PERMISSIONS}", permissions_section(true).trim_end())
+    };
 
     if !compact {
         out.push_str("\n## Overview\n\n| Module | What it is for |\n| --- | --- |\n");

--- a/maki-lua/src/plugin_permissions.rs
+++ b/maki-lua/src/plugin_permissions.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::io;
 use std::path::Path;
 
 use mlua::{Error as LuaError, Function, IntoLuaMulti, Lua, Result as LuaResult};
@@ -16,7 +17,7 @@ pub enum Permission {
 }
 
 impl Permission {
-    const ALL: [Permission; 5] = [
+    pub(crate) const ALL: [Permission; 5] = [
         Permission::FsRead,
         Permission::FsWrite,
         Permission::Net,
@@ -24,7 +25,7 @@ impl Permission {
         Permission::Env,
     ];
 
-    fn manifest_key(self) -> &'static str {
+    pub(crate) const fn manifest_key(self) -> &'static str {
         match self {
             Permission::FsRead => "fs_read",
             Permission::FsWrite => "fs_write",
@@ -115,10 +116,11 @@ impl PluginPermissions {
 }
 
 fn denied_error(perm: Permission) -> LuaError {
-    LuaError::runtime(format!(
-        "permission denied: '{}' not granted for this plugin",
-        perm
-    ))
+    let msg = format!(
+        "permission denied: '{perm}' not granted for this plugin (grant it in {MANIFEST_FILE} next to the plugin file)"
+    );
+    warn!(permission = %perm, "{msg}");
+    LuaError::runtime(msg)
 }
 
 pub(crate) fn load_plugin_permissions(plugin_dir: Option<&Path>) -> PluginPermissions {
@@ -138,7 +140,22 @@ pub(crate) fn load_plugin_permissions(plugin_dir: Option<&Path>) -> PluginPermis
                 PluginPermissions::denied()
             }
         },
-        Err(_) => PluginPermissions::denied(),
+        Err(e) => {
+            if e.kind() == io::ErrorKind::NotFound {
+                warn!(
+                    dir = %dir.display(),
+                    "no {MANIFEST_FILE} next to plugin; all permissions denied. Create one \
+                     (even an empty file) next to it to grant permissions"
+                );
+            } else {
+                warn!(
+                    path = %manifest_path.display(),
+                    error = %e,
+                    "cannot read {MANIFEST_FILE}, denying all permissions"
+                );
+            }
+            PluginPermissions::denied()
+        }
     }
 }
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -50,6 +50,33 @@ end
 Lua errors are reserved for programmer mistakes, like passing a number where
 a string belongs.
 
+## Permissions and plugin.toml {#plugin-permissions}
+
+Sensitive APIs are gated per plugin file; every gated function's entry in
+this reference names the permission it needs. The permissions are: `fs_read`, `fs_write`, `net`, `run`, `env`.
+A gated call without its permission raises
+`permission denied: '<name>' not granted for this plugin`.
+
+Grants come from a `plugin.toml` next to the Lua file (for
+`~/.config/maki/init.lua` that is `~/.config/maki/plugin.toml`):
+
+```toml
+[permissions]
+fs_read = true
+fs_write = true
+net = true
+run = true
+env = true
+```
+
+The rules:
+
+- No `plugin.toml` at all: every permission is denied, and maki logs a
+  warning at load time.
+- `plugin.toml` exists: permissions default to granted; set a key to
+  `false` to revoke it. An empty file grants everything.
+- Invalid TOML: everything denied, with a warning in the log.
+
 ## Overview
 
 | Module | What it is for |
@@ -1318,6 +1345,8 @@ maki.env.state_dir()
 Return the directory where maki stores runtime state (sessions, auth tokens, etc.).
 Typically something like `~/.local/state/maki`.
 
+Requires the `env` [plugin permission](#plugin-permissions).
+
 **Returns:** (`string?`) State directory path, or nil if it cannot be determined.
 
 **Example:**
@@ -1336,6 +1365,8 @@ maki.env.config_dir()
 
 Return the directory where maki looks for user configuration files.
 Typically something like `~/.config/maki`.
+
+Requires the `env` [plugin permission](#plugin-permissions).
 
 **Returns:** (`string?`) Config directory path, or nil if it cannot be determined.
 
@@ -1356,6 +1387,8 @@ maki.env.logs_dir()
 Return the directory where maki writes its log files (`maki.log`).
 Typically something like `~/.local/logs/maki`.
 
+Requires the `env` [plugin permission](#plugin-permissions).
+
 **Returns:** (`string?`) Logs directory path, or nil if it cannot be determined.
 
 **Example:**
@@ -1375,6 +1408,8 @@ maki.env.legacy_dir()
 Return the legacy config path (`~/.maki`), if it exists on disk.
 Useful for migration logic. Returns nil when there is no legacy directory.
 
+Requires the `env` [plugin permission](#plugin-permissions).
+
 **Returns:** (`string?`) Legacy directory path, or nil if not present.
 
 
@@ -1383,9 +1418,6 @@ Useful for migration logic. Returns nil when there is no legacy directory.
 Process and environment helpers, modeled after Neovim's `vim.fn` job
 control. Use these to run shell commands, wait for output, and check
 whether programs are installed.
-
-Job functions need the `run` permission. `executable` needs the `env`
-permission.
 
 ```lua
 local id = maki.fn.jobstart("git status", {
@@ -1404,6 +1436,8 @@ maki.fn.jobstart({cmd}, {opts?})
 Run a shell command in the background. The command runs through
 `bash -c` on Unix or `cmd /C` on Windows. You get back a job id
 that you can pass to `jobstop` or `jobwait` to control the process.
+
+Requires the `run` [plugin permission](#plugin-permissions).
 
 **Parameters:**
 
@@ -1441,6 +1475,8 @@ maki.fn.jobstop({job_id})
 Kill a running job immediately (SIGKILL on Unix). Safe to call on
 jobs that already exited or on unknown ids.
 
+Requires the `run` [plugin permission](#plugin-permissions).
+
 **Parameters:**
 
 - `{job_id}` (`integer`) Job id returned by `jobstart`.
@@ -1466,6 +1502,8 @@ job does not finish before the timeout.
 While waiting, the job's `on_stdout`, `on_stderr`, and `on_exit`
 callbacks fire as events arrive (like Neovim), so you can stream
 output into a buffer while parked here.
+
+Requires the `run` [plugin permission](#plugin-permissions).
 
 **Parameters:**
 
@@ -1495,6 +1533,8 @@ maki.fn.executable({name})
 Check whether {name} can be found on `$PATH` or is an absolute path
 to a file. Returns 1 when found, 0 otherwise (matches Neovim's
 `vim.fn.executable`).
+
+Requires the `env` [plugin permission](#plugin-permissions).
 
 **Parameters:**
 
@@ -1589,6 +1629,8 @@ Read the entire file at {path} as a UTF-8 string.
 If the file contains bytes that are not valid UTF-8, this function throws.
 Use `read_bytes` for binary files.
 
+Requires the `fs_read` [plugin permission](#plugin-permissions).
+
 **Parameters:**
 
 - `{path}` (`string`) Absolute or relative file path. `~/` is expanded to the home directory.
@@ -1615,6 +1657,8 @@ maki.fs.read_bytes({path})
 
 Read the entire file at {path} as raw bytes, returned as a Luau buffer.
 Useful for binary files or when you need to pass the data to `maki.base64.encode`.
+
+Requires the `fs_read` [plugin permission](#plugin-permissions).
 
 **Parameters:**
 
@@ -1643,6 +1687,8 @@ Returns a table with `size` (integer), `is_file` (boolean), `is_dir` (boolean),
 and `mtime` (number, fractional seconds since the Unix epoch; absent when the
 filesystem does not report a modification time).
 If {path} does not exist, returns nil with no error.
+
+Requires the `fs_read` [plugin permission](#plugin-permissions).
 
 **Parameters:**
 
@@ -1807,6 +1853,8 @@ Walk upward from {source} looking for a directory that contains one of the
 {marker} files or directories. Like `vim.fs.root`. Useful for finding the
 project root.
 
+Requires the `fs_read` [plugin permission](#plugin-permissions).
+
 **Parameters:**
 
 - `{source}` (`string`) Starting file or directory path.
@@ -1879,6 +1927,8 @@ List the contents of the directory at {path}.
 Each entry is a two-element array `{name, type}` where type is one of
 `"file"`, `"directory"`, `"link"`, or `"unknown"`. Follows symlinks.
 
+Requires the `fs_read` [plugin permission](#plugin-permissions).
+
 **Parameters:**
 
 - `{path}` (`string`) Directory path.
@@ -1907,6 +1957,8 @@ maki.fs.write({path}, {content})
 Write {content} to the file at {path}, creating it if it does not exist
 or overwriting it if it does.
 
+Requires the `fs_write` [plugin permission](#plugin-permissions).
+
 **Parameters:**
 
 - `{path}` (`string`) Destination file path. `~/` is expanded.
@@ -1932,6 +1984,8 @@ maki.fs.atomic_write({path}, {content})
 Atomically replace {path} with {content}. The parent directory must exist.
 Readers observe either the old file or the complete new file.
 Existing file permissions are preserved. On Unix, new files use mode 0600.
+
+Requires the `fs_write` [plugin permission](#plugin-permissions).
 
 **Parameters:**
 
@@ -1960,6 +2014,8 @@ Pass `recursive = true` to remove a non-empty directory tree (like `rm -r`).
 Unlike `vim.fs.rm`, this also removes an empty directory without `recursive`.
 Symlinks are removed themselves, never followed.
 
+Requires the `fs_write` [plugin permission](#plugin-permissions).
+
 **Parameters:**
 
 - `{path}` (`string`) Path to the file or directory to remove.
@@ -1986,6 +2042,8 @@ maki.fs.mkdir({path}, {opts?})
 Create the directory at {path}. Set `parents = true` to create
 intermediate directories, like `mkdir -p`.
 
+Requires the `fs_write` [plugin permission](#plugin-permissions).
+
 **Parameters:**
 
 - `{path}` (`string`) Directory path to create.
@@ -2010,6 +2068,8 @@ maki.fs.glob({pattern}, {opts?})
 Find files matching one or more glob patterns.
 Respects `.gitignore` by default. Pass `sort = "mtime"` to get the most
 recently modified files first.
+
+Requires the `fs_read` [plugin permission](#plugin-permissions).
 
 **Parameters:**
 
@@ -2039,6 +2099,8 @@ grouped by file, similar to ripgrep output.
 
 Each result entry has a `path` and a list of `groups`. Each group contains
 `lines`, where every line has `line_nr`, `text`, and `is_match`.
+
+Requires the `fs_read` [plugin permission](#plugin-permissions).
 
 **Parameters:**
 
@@ -2217,8 +2279,7 @@ local bytes = img:encode("png")
 Run Python code in a memory-safe, time-limited sandbox.
 
 The sandbox uses the monty interpreter. Python code can call back into
-Lua-defined tools, and stdout is streamed line by line. Requires the
-`run` permission.
+Lua-defined tools, and stdout is streamed line by line.
 
 ```lua
 local r, err = maki.interpreter.run("print('hello')", {
@@ -2244,6 +2305,8 @@ functions you provide in {opts}.tools.
 The result table has optional fields: `stdout` (string, trimmed combined
 output) and `output` (string, the final expression value). On error, the
 table is empty and the second return value is the error message.
+
+Requires the `run` [plugin permission](#plugin-permissions).
 
 **Parameters:**
 
@@ -2586,6 +2649,8 @@ or metadata IP addresses are blocked for safety.
 
 The response table has three fields: `body` (string), `status`
 (integer), and `content_type` (string).
+
+Requires the `net` [plugin permission](#plugin-permissions).
 
 **Parameters:**
 
@@ -4815,6 +4880,8 @@ maki.uv.cwd()
 
 Return the current working directory as an absolute path. Like `vim.uv.cwd`.
 
+Requires the `env` [plugin permission](#plugin-permissions).
+
 **Returns:** (`string?`) Current working directory, or nil if it cannot be determined.
 
 **Example:**
@@ -4834,6 +4901,8 @@ maki.uv.os_homedir()
 
 Return the current user's home directory. Like `vim.uv.os_homedir`.
 
+Requires the `env` [plugin permission](#plugin-permissions).
+
 **Returns:** (`string?`) Home directory path, or nil if it cannot be determined.
 
 **Example:**
@@ -4852,6 +4921,8 @@ maki.uv.os_getenv({name})
 
 Look up the environment variable {name}. Like `vim.uv.os_getenv`.
 Returns nil when the variable is not set.
+
+Requires the `env` [plugin permission](#plugin-permissions).
 
 **Parameters:**
 

--- a/site/docs/content/permissions/_index.md
+++ b/site/docs/content/permissions/_index.md
@@ -195,6 +195,10 @@ Some constructs are too complex to analyze statically, so they always trigger a 
 
 Brace groups `{ ... }` and control flow (`if`, `for`, …) are segmented when possible; they do not by themselves force a prompt the way substitutions do.
 
+## Plugin Permissions
+
+Lua plugins have a separate, unrelated gate. A `plugin.toml` manifest next to the Lua file controls which gated `maki.*` APIs it may call. No manifest means every gated call is denied, including for your own `init.lua`. The [Lua API reference](/lua-api/#plugin-permissions) documents the manifest and lists every permission.
+
 ## Session Persistence
 
 When you save a session, its permission rules are saved too. Loading the session restores them.


### PR DESCRIPTION
A missing `plugin.toml` denies every plugin permission, but nothing said so: the docs never mentioned the file, and a plugin wrapping its work in `pcall` turned the denial into total silence. Debugging that took a log dive instead of ten seconds.

Now maki warns at load time when an `init.lua` has no manifest, warns again on each denied call so `pcall` cannot swallow it, and the Lua error names the fix.

The docs are generated so they cannot rot: the `guard =` attribute flows into `FnDoc`, every gated function gets a "Requires the `x` plugin permission" line, and the manifest section on the Lua API page is built from `Permission::ALL`.