### PR TITLE
feat(acp): report session usage updates

### DIFF
--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -24,9 +24,9 @@ use maki_agent::tools::{LocalToolFn, LocalTools, QUESTION_TOOL_NAME, local_tool}
 use maki_agent::types::AgentEvent;
 use maki_agent::{AgentInput, AgentMode, Envelope, ImageMediaType, ImageSource};
 use maki_config::MAX_SERVER_NAME_LEN;
-use maki_providers::Message;
 use maki_providers::model::Model;
 use maki_providers::provider::available_model_specs;
+use maki_providers::{Message, TokenUsage, add_cost};
 use maki_storage::id::{MakiId, SessionRef};
 use serde::Serialize;
 use serde_json::Value;
@@ -190,7 +190,7 @@ async fn new_session(
     let spec = params.model.spec();
     let resp = methods::new_session_response(handle.session_id.as_str())
         .config_options(vec![methods::model_config_option(&spec, &srv.model_specs)]);
-    install_session(srv, handle, mcp, spec, pending, cwd);
+    install_session(srv, handle, mcp, spec, pending, cwd, None);
     Ok(AgentResponse::NewSessionResponse(resp))
 }
 
@@ -205,7 +205,7 @@ async fn load_session(
         .0
         .parse()
         .map_err(|_| AcpError::resource_not_found(Some(req.session_id.0.to_string())))?;
-    let (history, recorded_cwd) = load_history(session_ref.id())?;
+    let (history, recorded_cwd, restored_usage) = load_history(session_ref.id())?;
     close_session(srv).await;
     let mcp = start_mcp(&req.cwd, &req.mcp_servers).await;
     let sid = SessionId::from(session_ref.to_string());
@@ -226,7 +226,10 @@ async fn load_session(
     let spec = params.model.spec();
     let resp = methods::load_session_response()
         .config_options(vec![methods::model_config_option(&spec, &srv.model_specs)]);
-    install_session(srv, handle, mcp, spec, pending, cwd);
+    // The restored total predates any per-turn cost, so price it once with the
+    // current model; later turns add their own exact cost.
+    let restored_cost = params.model.cost_of(&restored_usage, false);
+    install_session(srv, handle, mcp, spec, pending, cwd, restored_cost);
     Ok(AgentResponse::LoadSessionResponse(resp))
 }
 
@@ -417,6 +420,7 @@ fn install_session(
     current_model: String,
     pending: PendingState,
     cwd: PathBuf,
+    initial_cost: Option<f64>,
 ) {
     start_event_pump(
         handle.event_rx.clone(),
@@ -425,6 +429,7 @@ fn install_session(
         Arc::clone(&pending),
         cwd,
         maki_storage::paths::home(),
+        initial_cost,
     );
     srv.session = Some(SessionState {
         handle,
@@ -435,7 +440,9 @@ fn install_session(
     });
 }
 
-fn load_history(session_id: MakiId) -> Result<(Vec<Message>, Option<PathBuf>), AcpError> {
+fn load_history(
+    session_id: MakiId,
+) -> Result<(Vec<Message>, Option<PathBuf>, TokenUsage), AcpError> {
     let storage = maki_storage::StateDir::resolve()
         .map_err(|e| AcpError::internal_error().data(json_str(&e)))?;
     load_history_from(&storage, session_id)
@@ -447,7 +454,7 @@ fn load_history(session_id: MakiId) -> Result<(Vec<Message>, Option<PathBuf>), A
 fn load_history_from(
     storage: &maki_storage::StateDir,
     session_id: MakiId,
-) -> Result<(Vec<Message>, Option<PathBuf>), AcpError> {
+) -> Result<(Vec<Message>, Option<PathBuf>, TokenUsage), AcpError> {
     let session: maki_storage::sessions::Session<
         Message,
         maki_providers::TokenUsage,
@@ -460,7 +467,8 @@ fn load_history_from(
     } else {
         None
     };
-    Ok((session.take_messages(), recorded))
+    let usage = session.token_usage;
+    Ok((session.take_messages(), recorded, usage))
 }
 
 fn handle_prompt(srv: &mut Server, raw: &Value, id: &RequestId) -> Result<(), AcpError> {
@@ -641,14 +649,21 @@ fn start_event_pump(
     pending: PendingState,
     cwd: PathBuf,
     home: Option<PathBuf>,
+    initial_cost: Option<f64>,
 ) {
     smol::spawn(async move {
         let sid = SessionId::from(session_id.to_string());
+        let mut cost_total = initial_cost;
 
         while let Ok(Envelope {
             event, subagent, ..
         }) = event_rx.recv_async().await
         {
+            // Subagent stream events stay out of the transcript, but their
+            // turns still spend session money.
+            if let AgentEvent::TurnComplete(tc) = &event {
+                add_cost(&mut cost_total, tc.cost);
+            }
             if subagent.is_some() {
                 continue;
             }
@@ -662,6 +677,7 @@ fn start_event_pump(
                 }
                 AgentEvent::ToolOutput { id, content } => translate::tool_output(&id, &content),
                 AgentEvent::ToolDone(event) => translate::tool_done(&event, &cwd, home.as_deref()),
+                AgentEvent::TurnComplete(event) => translate::usage_update(&event, cost_total),
                 AgentEvent::PermissionRequest { id, tool, scopes } => {
                     let fields =
                         ToolCallUpdateFields::new().title(format!("{tool}: {}", scopes.join(", ")));
@@ -862,15 +878,21 @@ mod tests {
         let mut session: Session<Message, TokenUsage, maki_agent::ToolOutput> =
             Session::new("anthropic/test-model", "/project");
         session.replace_messages(messages.clone());
+        session.token_usage = TokenUsage {
+            input: 1_000,
+            output: 200,
+            ..Default::default()
+        };
         session.save(&dir).unwrap();
 
         let id: MakiId = session.id;
-        let (history, recorded) = load_history_from(&dir, id).unwrap();
+        let (history, recorded, usage) = load_history_from(&dir, id).unwrap();
         assert_eq!(
             serde_json::to_value(&history).unwrap(),
             serde_json::to_value(&messages).unwrap()
         );
         assert_eq!(recorded, Some(PathBuf::from("/project")));
+        assert_eq!(usage, session.token_usage);
     }
 
     #[test]
@@ -880,7 +902,7 @@ mod tests {
         let mut session: Session<Message, TokenUsage, maki_agent::ToolOutput> =
             Session::new("anthropic/test-model", "relative/project");
         session.save(&dir).unwrap();
-        let (_, recorded) = load_history_from(&dir, session.id).unwrap();
+        let (_, recorded, _) = load_history_from(&dir, session.id).unwrap();
         assert_eq!(recorded, None);
     }
 

--- a/maki-acp/src/translate.rs
+++ b/maki-acp/src/translate.rs
@@ -1,16 +1,18 @@
 use std::path::{Path, PathBuf};
 
 use agent_client_protocol_schema::{
-    Content, ContentBlock, ContentChunk, Diff, ImageContent, SessionUpdate, StopReason,
+    Content, ContentBlock, ContentChunk, Cost, Diff, ImageContent, SessionUpdate, StopReason,
     TextContent, ToolCall, ToolCallContent, ToolCallId, ToolCallLocation, ToolCallStatus,
-    ToolCallUpdate, ToolCallUpdateFields, ToolKind,
+    ToolCallUpdate, ToolCallUpdateFields, ToolKind, UsageUpdate,
 };
 use maki_agent::DoneReason;
 use maki_agent::tools::ToolRegistry;
-use maki_agent::types::{ToolDoneEvent, ToolOutput, ToolStartEvent};
+use maki_agent::types::{ToolDoneEvent, ToolOutput, ToolStartEvent, TurnCompleteEvent};
 use maki_providers::{ContentBlock as MsgBlock, ImageMediaType, Message, Role as MsgRole};
 
 const MIN_FENCE_LEN: usize = 3;
+/// Model pricing is quoted in US dollars, so that is the reported currency.
+const CURRENCY: &str = "USD";
 
 /// File-level tools report a location so the client can follow along. Directory
 /// scoped tools (glob, grep, list) and commands (bash) target no single file.
@@ -272,6 +274,20 @@ pub fn map_done_reason(reason: DoneReason) -> StopReason {
         DoneReason::MaxTurns => StopReason::MaxTurnRequests,
         DoneReason::Cancelled => StopReason::Cancelled,
     }
+}
+
+/// Per ACP "Session Usage Updates": the current context gauge plus the
+/// session's cumulative cost. Each turn's event only carries its own turn's
+/// share, so the caller tracks the running total across turns.
+pub fn usage_update(event: &TurnCompleteEvent, cost_total: Option<f64>) -> SessionUpdate {
+    let used = event
+        .context_size
+        .unwrap_or_else(|| event.usage.context_tokens()) as u64;
+    let mut update = UsageUpdate::new(used, u64::from(event.context_window));
+    if let Some(cost) = cost_total {
+        update = update.cost(Cost::new(cost, CURRENCY));
+    }
+    SessionUpdate::UsageUpdate(update)
 }
 
 pub fn replay_history(messages: &[Message], cwd: &Path, home: Option<&Path>) -> Vec<SessionUpdate> {
@@ -713,5 +729,52 @@ mod tests {
         )]);
         let json = updates_json(&[msg]);
         assert!(json[0].get("locations").is_none(), "{:?}", json[0]);
+    }
+
+    fn turn_event(
+        context_size: Option<u32>,
+        context_window: u32,
+        cost: Option<f64>,
+    ) -> TurnCompleteEvent {
+        TurnCompleteEvent {
+            message: Message::default(),
+            usage: maki_providers::TokenUsage {
+                input: 1_000,
+                output: 200,
+                cache_creation: 0,
+                cache_read: 50_000,
+            },
+            model: "test-model".into(),
+            cost,
+            context_size,
+            context_window,
+        }
+    }
+
+    #[test]
+    fn usage_update_reports_gauge_and_cumulative_cost() {
+        let event = turn_event(Some(60_000), 200_000, Some(0.05));
+        let json = serde_json::to_value(usage_update(&event, Some(0.125))).unwrap();
+        assert_eq!(json["sessionUpdate"], "usage_update");
+        assert_eq!(json["used"], 60_000);
+        assert_eq!(json["size"], 200_000);
+        assert_eq!(json["cost"]["amount"], 0.125);
+        assert_eq!(json["cost"]["currency"], CURRENCY);
+    }
+
+    #[test]
+    fn usage_update_without_cost_omits_cost() {
+        let event = turn_event(Some(60_000), 200_000, None);
+        let json = serde_json::to_value(usage_update(&event, None)).unwrap();
+        assert_eq!(json["used"], 60_000);
+        assert_eq!(json["size"], 200_000);
+        assert!(json.get("cost").is_none(), "{json}");
+    }
+
+    #[test]
+    fn usage_update_falls_back_to_usage_when_context_size_missing() {
+        let event = turn_event(None, 200_000, None);
+        let json = serde_json::to_value(usage_update(&event, None)).unwrap();
+        assert_eq!(json["used"], 51_200);
     }
 }

--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -99,6 +99,7 @@ fn finish_compact(
         model: model.id.clone(),
         cost: model.cost_of(&response.usage, false),
         context_size: Some(response.usage.output),
+        context_window: model.context_window,
     })));
 
     // Swapping the history for a summary the model never wrote would throw the

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -394,6 +394,7 @@ impl<'h> Agent<'h> {
                     .model
                     .cost_of(&response.usage, self.opts.clamped(&self.model).fast),
                 context_size: Some(response.usage.context_tokens()),
+                context_window: self.model.context_window,
             })))
     }
 

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -849,6 +849,9 @@ pub struct TurnCompleteEvent {
     pub cost: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context_size: Option<u32>,
+    /// The model's context window, so consumers can gauge `context_size`
+    /// against the ceiling without resolving the model.
+    pub context_window: u32,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -966,6 +966,7 @@ mod tests {
             model: "test-model".into(),
             cost: Some(cost),
             context_size: None,
+            context_window: 0,
         }))
     }
 

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -246,6 +246,7 @@ fn turn_complete(usage: TokenUsage, model: &str, cost: Option<f64>) -> AgentEven
         model: model.into(),
         cost,
         context_size: None,
+        context_window: 0,
     }))
 }
 


### PR DESCRIPTION
I wanted to see my remaining context for the session when using `maki acp` with Zed.

Code implemented by maki with Qwen3.8-27B, tested and confirmed working by me.

Note the hover tooltip in my Zed UI now: <img width="720" height="666" alt="image" src="https://github.com/user-attachments/assets/786f9dfa-84e7-42fe-8d46-bd0a1612bd8c" />
