### PR TITLE
fix(acp): answer the question tool through elicitation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ get-size2 = "=0.10.1"
 notify = { version = "9.0.0-rc.2", default-features = false, features = ["flume", "macos_fsevent"] }
 serde_yaml = "0.9"
 shell-words = "1"
-agent-client-protocol-schema = "0.13"
+agent-client-protocol-schema = { version = "0.13", features = ["unstable_elicitation"] }
 
 wait-timeout = "0.2"
 inventory = "0.3"

--- a/maki-acp/src/elicitation.rs
+++ b/maki-acp/src/elicitation.rs
@@ -1,0 +1,254 @@
+//! Maps the `question` tool onto ACP form elicitation (`elicitation/create`).
+//! The tool keeps its Lua-advertised schema; only execution is rerouted here,
+//! so Zed and friends render native forms instead of a spinner nobody can answer.
+
+use std::collections::BTreeMap;
+
+use agent_client_protocol_schema::{
+    ClientCapabilities, CreateElicitationRequest, CreateElicitationResponse, ElicitationAction,
+    ElicitationContentValue, ElicitationFormMode, ElicitationPropertySchema, ElicitationSchema,
+    ElicitationSessionScope, EnumOption, MultiSelectPropertySchema, SessionId,
+    StringPropertySchema, ToolCallId,
+};
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Mirrors the Lua question tool's dismiss output so the model sees the same
+/// text regardless of frontend.
+pub const DISMISSED: &str = "(question dismissed by user)";
+const NO_ANSWER: &str = "(no answer)";
+
+#[derive(Deserialize)]
+struct Question {
+    question: String,
+    #[serde(default)]
+    header: String,
+    #[serde(default)]
+    options: Vec<QuestionOption>,
+    #[serde(default, rename = "multiSelect", alias = "multiple")]
+    multi_select: bool,
+}
+
+#[derive(Deserialize)]
+struct QuestionOption {
+    label: String,
+    #[serde(default)]
+    description: String,
+}
+
+pub fn supports_form(caps: &ClientCapabilities) -> bool {
+    caps.elicitation.as_ref().is_some_and(|e| e.form.is_some())
+}
+
+fn parse_questions(input: &Value) -> Result<Vec<Question>, String> {
+    let questions = input.get("questions").cloned().unwrap_or(Value::Null);
+    serde_json::from_value(questions).map_err(|e| format!("invalid questions: {e}"))
+}
+
+fn enum_options(options: &[QuestionOption]) -> Vec<EnumOption> {
+    options
+        .iter()
+        .map(|opt| {
+            let title = if opt.description.is_empty() {
+                opt.label.clone()
+            } else {
+                format!("{} - {}", opt.label, opt.description)
+            };
+            EnumOption::new(opt.label.clone(), title)
+        })
+        .collect()
+}
+
+fn property(q: &Question) -> ElicitationPropertySchema {
+    let title = q.question.clone();
+    if q.options.is_empty() {
+        ElicitationPropertySchema::String(StringPropertySchema::new().title(title))
+    } else if q.multi_select {
+        ElicitationPropertySchema::Array(
+            MultiSelectPropertySchema::titled(enum_options(&q.options)).title(title),
+        )
+    } else {
+        ElicitationPropertySchema::String(
+            StringPropertySchema::new()
+                .title(title)
+                .one_of(enum_options(&q.options)),
+        )
+    }
+}
+
+/// Property keys are positional (`q1`, `q2`, ...) so answers map back to
+/// questions even when headers repeat or are missing.
+fn key(index: usize) -> String {
+    format!("q{}", index + 1)
+}
+
+pub fn form_request(
+    session_id: &str,
+    tool_call_id: Option<String>,
+    input: &Value,
+) -> Result<CreateElicitationRequest, String> {
+    let questions = parse_questions(input)?;
+    if questions.is_empty() {
+        return Err("at least one question is required".to_owned());
+    }
+
+    let mut schema = ElicitationSchema::new();
+    schema.properties = questions
+        .iter()
+        .enumerate()
+        .map(|(i, q)| (key(i), property(q)))
+        .collect();
+
+    let scope = ElicitationSessionScope::new(SessionId::from(session_id.to_owned()))
+        .tool_call_id(tool_call_id.map(ToolCallId::from));
+    let message = match questions.as_slice() {
+        [only] => only.question.clone(),
+        many => format!("{} questions", many.len()),
+    };
+    Ok(CreateElicitationRequest::new(
+        ElicitationFormMode::new(scope, schema),
+        message,
+    ))
+}
+
+fn answer_text(value: Option<&ElicitationContentValue>) -> Option<String> {
+    match value? {
+        ElicitationContentValue::String(s) if !s.is_empty() => Some(s.clone()),
+        ElicitationContentValue::StringArray(items) if !items.is_empty() => Some(items.join(", ")),
+        ElicitationContentValue::Integer(n) => Some(n.to_string()),
+        ElicitationContentValue::Number(n) => Some(n.to_string()),
+        ElicitationContentValue::Boolean(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+/// Turns the client's `elicitation/create` result into the same markdown the
+/// Lua tool feeds the model: one `header: labels` line per question.
+pub fn format_response(input: &Value, raw_result: &str) -> String {
+    let Ok(response) = serde_json::from_str::<CreateElicitationResponse>(raw_result) else {
+        return DISMISSED.to_owned();
+    };
+    let ElicitationAction::Accept(accept) = response.action else {
+        return DISMISSED.to_owned();
+    };
+    let content: BTreeMap<String, ElicitationContentValue> = accept.content.unwrap_or_default();
+    let questions = parse_questions(input).unwrap_or_default();
+
+    questions
+        .iter()
+        .enumerate()
+        .map(|(i, q)| {
+            let label = if q.header.is_empty() {
+                format!("Q{}", i + 1)
+            } else {
+                q.header.clone()
+            };
+            let answer = answer_text(content.get(&key(i))).unwrap_or_else(|| NO_ANSWER.to_owned());
+            format!("{label}: {answer}")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use agent_client_protocol_schema::ElicitationScope;
+    use test_case::test_case;
+
+    use super::*;
+
+    fn questions_input() -> Value {
+        serde_json::json!({
+            "questions": [
+                {
+                    "question": "Pick a framework",
+                    "header": "Framework",
+                    "options": [
+                        { "label": "axum", "description": "tokio based" },
+                        { "label": "actix" }
+                    ]
+                },
+                {
+                    "question": "Which features?",
+                    "header": "Features",
+                    "multiSelect": true,
+                    "options": [{ "label": "auth" }, { "label": "uploads" }]
+                },
+                { "question": "Anything else?" }
+            ]
+        })
+    }
+
+    #[test]
+    fn form_request_maps_questions_to_schema() {
+        let req = form_request("sess_1", Some("tool_1".to_owned()), &questions_input()).unwrap();
+        assert_eq!(req.message, "3 questions");
+
+        let ElicitationScope::Session(scope) = req.scope() else {
+            panic!("expected session scope");
+        };
+        assert_eq!(scope.session_id.0.as_ref(), "sess_1");
+        assert_eq!(
+            scope.tool_call_id.as_ref().map(|t| t.0.as_ref()),
+            Some("tool_1")
+        );
+
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["mode"], "form");
+        let props = &json["requestedSchema"]["properties"];
+        assert_eq!(props["q1"]["type"], "string");
+        assert_eq!(props["q1"]["oneOf"][0]["const"], "axum");
+        assert_eq!(props["q2"]["type"], "array");
+        assert_eq!(props["q3"]["type"], "string");
+        assert!(props["q3"].get("oneOf").is_none());
+    }
+
+    #[test]
+    fn single_question_is_the_message() {
+        let input = serde_json::json!({ "questions": [{ "question": "Proceed?" }] });
+        let req = form_request("sess_1", None, &input).unwrap();
+        assert_eq!(req.message, "Proceed?");
+    }
+
+    #[test_case(serde_json::json!({}) ; "missing_questions")]
+    #[test_case(serde_json::json!({ "questions": [] }) ; "empty_questions")]
+    fn form_request_rejects_bad_input(input: Value) {
+        assert!(form_request("sess_1", None, &input).is_err());
+    }
+
+    #[test]
+    fn accept_response_formats_answers() {
+        let raw = serde_json::json!({
+            "action": "accept",
+            "content": { "q1": "axum", "q2": ["auth", "uploads"] }
+        })
+        .to_string();
+        assert_eq!(
+            format_response(&questions_input(), &raw),
+            "Framework: axum\nFeatures: auth, uploads\nQ3: (no answer)"
+        );
+    }
+
+    #[test_case(r#"{"action":"decline"}"# ; "decline")]
+    #[test_case(r#"{"action":"cancel"}"# ; "cancel")]
+    #[test_case("not json" ; "unparsable")]
+    #[test_case("null" ; "jsonrpc_error_forwarded_as_null")]
+    fn non_accept_is_dismissed(raw: &str) {
+        assert_eq!(format_response(&questions_input(), raw), DISMISSED);
+    }
+
+    #[test]
+    fn supports_form_requires_form_capability() {
+        assert!(!supports_form(&ClientCapabilities::default()));
+        let caps: ClientCapabilities = serde_json::from_value(serde_json::json!({
+            "elicitation": { "form": {} }
+        }))
+        .unwrap();
+        assert!(supports_form(&caps));
+        let url_only: ClientCapabilities = serde_json::from_value(serde_json::json!({
+            "elicitation": { "url": {} }
+        }))
+        .unwrap();
+        assert!(!supports_form(&url_only));
+    }
+}

--- a/maki-acp/src/lib.rs
+++ b/maki-acp/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod elicitation;
 pub mod methods;
 pub mod permissions;
 pub mod server;

--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -7,10 +7,10 @@ use std::sync::{Arc, Mutex};
 
 use agent_client_protocol_schema::{
     AgentNotification, AgentRequest, AgentResponse, ContentBlock, CurrentModeUpdate,
-    EmbeddedResourceResource, Error as AcpError, ImageContent, JsonRpcMessage, LoadSessionRequest,
-    McpServer, NewSessionRequest, Notification, PromptRequest, PromptResponse, Request, RequestId,
-    RequestPermissionRequest, RequestPermissionResponse, Response, SessionId, SessionModeId,
-    SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
+    EmbeddedResourceResource, Error as AcpError, ImageContent, InitializeRequest, JsonRpcMessage,
+    LoadSessionRequest, McpServer, NewSessionRequest, Notification, PromptRequest, PromptResponse,
+    Request, RequestId, RequestPermissionRequest, RequestPermissionResponse, Response, SessionId,
+    SessionModeId, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
     SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModeResponse, StopReason,
     TextContent, ToolCallId, ToolCallUpdate, ToolCallUpdateFields,
 };
@@ -20,6 +20,7 @@ use maki_agent::headless::{self, InteractiveHandle, InteractiveParams};
 use maki_agent::mcp::config::{RawHttpFields, RawStdioFields, RawTransport};
 use maki_agent::mcp::{self, McpHandle};
 use maki_agent::permissions::PermissionAnswer;
+use maki_agent::tools::{LocalToolFn, LocalTools, QUESTION_TOOL_NAME, local_tool};
 use maki_agent::types::AgentEvent;
 use maki_agent::{AgentInput, AgentMode, Envelope, ImageMediaType, ImageSource};
 use maki_config::MAX_SERVER_NAME_LEN;
@@ -32,7 +33,7 @@ use serde_json::Value;
 use smol::io::AsyncBufReadExt;
 use tracing::{debug, warn};
 
-use crate::{AcpParams, methods, permissions, translate};
+use crate::{AcpParams, elicitation, methods, permissions, translate};
 
 const FIRST_OUTGOING_REQUEST_ID: i64 = 1000;
 
@@ -40,12 +41,18 @@ const FIRST_OUTGOING_REQUEST_ID: i64 = 1000;
 /// session cannot match a request of the session that replaced it.
 static NEXT_OUTGOING_REQUEST_ID: AtomicI64 = AtomicI64::new(FIRST_OUTGOING_REQUEST_ID);
 
-/// What the client still owes us. Only one permission can be outstanding: the
-/// agent holds the answer channel while it waits for one.
+/// What the client still owes us. `ask` is the one outstanding request that
+/// blocks a tool (permission or elicitation): there can only be one, because
+/// both wait on the agent's single answer channel.
 #[derive(Default)]
 struct Pending {
     prompt: Option<RequestId>,
-    permission: Option<i64>,
+    ask: Option<(i64, AskKind)>,
+}
+
+enum AskKind {
+    Permission,
+    Elicitation,
 }
 
 type PendingState = Arc<Mutex<Pending>>;
@@ -62,6 +69,7 @@ struct Server {
     out_tx: Sender<Value>,
     model_specs: Vec<String>,
     model_policy: Arc<maki_config::ModelPolicy>,
+    client_elicits_form: bool,
     session: Option<SessionState>,
 }
 
@@ -89,6 +97,7 @@ pub async fn serve(params: AcpParams) -> color_eyre::Result<()> {
         out_tx,
         model_specs: available_model_specs(&params.model_policy),
         model_policy: Arc::clone(&params.model_policy),
+        client_elicits_form: false,
         session: None,
     };
 
@@ -148,9 +157,13 @@ async fn handle_request(
     params: &AcpParams,
 ) {
     let result = match method {
-        "initialize" => Ok(AgentResponse::InitializeResponse(
-            methods::initialize_response(),
-        )),
+        "initialize" => {
+            srv.client_elicits_form = parse_params::<InitializeRequest>(raw)
+                .is_ok_and(|req| elicitation::supports_form(&req.client_capabilities));
+            Ok(AgentResponse::InitializeResponse(
+                methods::initialize_response(),
+            ))
+        }
         "session/new" => new_session(srv, raw, params).await,
         "session/load" => load_session(srv, raw, params).await,
         "session/prompt" => match handle_prompt(srv, raw, &id) {
@@ -173,11 +186,11 @@ async fn new_session(
     close_session(srv).await;
     let mcp = start_mcp(&req.cwd, &req.mcp_servers).await;
     let cwd = req.cwd.clone();
-    let handle = spawn_session(params, req.cwd, None, Vec::new(), mcp.clone());
+    let (handle, pending) = spawn_session(srv, params, req.cwd, None, Vec::new(), mcp.clone());
     let spec = params.model.spec();
     let resp = methods::new_session_response(handle.session_id.as_str())
         .config_options(vec![methods::model_config_option(&spec, &srv.model_specs)]);
-    install_session(srv, handle, mcp, spec, cwd);
+    install_session(srv, handle, mcp, spec, pending, cwd);
     Ok(AgentResponse::NewSessionResponse(resp))
 }
 
@@ -202,28 +215,47 @@ async fn load_session(
         session_update(&srv.out_tx, &sid, update);
     }
     let cwd = req.cwd.clone();
-    let handle = spawn_session(params, req.cwd, Some(session_ref), history, mcp.clone());
+    let (handle, pending) = spawn_session(
+        srv,
+        params,
+        req.cwd,
+        Some(session_ref),
+        history,
+        mcp.clone(),
+    );
     let spec = params.model.spec();
     let resp = methods::load_session_response()
         .config_options(vec![methods::model_config_option(&spec, &srv.model_specs)]);
-    install_session(srv, handle, mcp, spec, cwd);
+    install_session(srv, handle, mcp, spec, pending, cwd);
     Ok(AgentResponse::LoadSessionResponse(resp))
 }
 
 fn spawn_session(
+    srv: &Server,
     params: &AcpParams,
     cwd: PathBuf,
     session_id: Option<SessionRef>,
     history: Vec<Message>,
     mcp_handle: Option<McpHandle>,
-) -> InteractiveHandle {
-    headless::spawn_interactive(InteractiveParams {
+) -> (InteractiveHandle, PendingState) {
+    let pending = PendingState::default();
+    // Without form elicitation the question tool would spin forever waiting
+    // for a TUI that does not exist, so it is dropped and the model asks in
+    // plain text instead.
+    let (excluded_tools, local_tools) = if srv.client_elicits_form {
+        let tool = question_tool(srv.out_tx.clone(), Arc::clone(&pending));
+        let map: LocalTools = Arc::new(HashMap::from([(QUESTION_TOOL_NAME.to_owned(), tool)]));
+        (Vec::new(), map)
+    } else {
+        (vec![QUESTION_TOOL_NAME], LocalTools::default())
+    };
+    let handle = headless::spawn_interactive(InteractiveParams {
         model: params.model.clone(),
         config: params.config.clone(),
         permissions_config: params.permissions_config.clone(),
         timeouts: params.timeouts,
         prompt_slots: Arc::clone(&params.prompt_slots),
-        excluded_tools: Vec::new(),
+        excluded_tools,
         mcp_handle,
         initial_wd: cwd,
         session_id,
@@ -234,6 +266,66 @@ fn spawn_session(
         workflow: false,
         model_policy: Arc::clone(&params.model_policy),
         plugin_rules: Arc::clone(&params.plugin_rules),
+        local_tools,
+    });
+    (handle, pending)
+}
+
+/// Sends a request the client must answer and records it as the outstanding
+/// ask, registered before sending so the response can never race past us.
+fn ask_client(
+    out_tx: &Sender<Value>,
+    pending: &PendingState,
+    kind: AskKind,
+    request: AgentRequest,
+) -> i64 {
+    let id = NEXT_OUTGOING_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
+    pending.lock().unwrap().ask = Some((id, kind));
+    send(
+        out_tx,
+        Request {
+            id: RequestId::Number(id),
+            method: Arc::from(request.method()),
+            params: Some(request),
+        },
+    );
+    id
+}
+
+/// Shadows the Lua `question` tool: sends `elicitation/create` to the client
+/// and blocks the tool call until the form comes back. Serializes on the same
+/// answer channel as permissions, so at most one ask is in flight.
+fn question_tool(out_tx: Sender<Value>, pending: PendingState) -> LocalToolFn {
+    local_tool(move |input, ctx| {
+        let out_tx = out_tx.clone();
+        let pending = Arc::clone(&pending);
+        Box::pin(async move {
+            let session_id = ctx
+                .session_id
+                .as_ref()
+                .map(ToString::to_string)
+                .ok_or("no session")?;
+            let request = elicitation::form_request(&session_id, ctx.tool_use_id, &input)?;
+            let rx = ctx.user_response_rx.as_ref().ok_or("no answer channel")?;
+
+            let guard = rx.lock().await;
+            let request = AgentRequest::CreateElicitationRequest(request);
+            let id = ask_client(&out_tx, &pending, AskKind::Elicitation, request);
+            let response = ctx.cancel.race(guard.recv_async()).await;
+            // Cleared while still holding the channel, so a stale id cannot
+            // clobber whatever ask comes next.
+            let _ = pending
+                .lock()
+                .unwrap()
+                .ask
+                .take_if(|(ask_id, _)| *ask_id == id);
+            drop(guard);
+
+            Ok(match response {
+                Ok(Ok(raw)) => elicitation::format_response(&input, &raw),
+                _ => elicitation::DISMISSED.to_owned(),
+            })
+        })
     })
 }
 
@@ -323,9 +415,9 @@ fn install_session(
     handle: InteractiveHandle,
     mcp: Option<McpHandle>,
     current_model: String,
+    pending: PendingState,
     cwd: PathBuf,
 ) {
-    let pending = PendingState::default();
     start_event_pump(
         handle.event_rx.clone(),
         handle.session_id.clone(),
@@ -452,7 +544,7 @@ fn handle_notification(srv: &Server, method: &str) {
             if let Some(session) = &srv.session {
                 // Any answer still in flight belongs to the cancelled turn, so
                 // forget its id and let it be dropped on arrival.
-                session.pending.lock().unwrap().permission = None;
+                session.pending.lock().unwrap().ask = None;
                 let _ = session.handle.cancel_tx.try_send(());
             }
         }
@@ -465,21 +557,27 @@ fn handle_incoming_response(srv: &Server, raw: &Value) {
     let Some(id) = raw.get("id").and_then(Value::as_i64) else {
         return;
     };
-    if session
+    let ask = session
         .pending
         .lock()
         .unwrap()
-        .permission
-        .take_if(|pending| *pending == id)
-        .is_none()
-    {
+        .ask
+        .take_if(|(ask_id, _)| *ask_id == id);
+    let Some((_, kind)) = ask else {
         warn!(id, "response for an unknown request id");
         return;
-    }
-    let _ = session
-        .handle
-        .answer_tx
-        .send(permission_answer(raw).encode());
+    };
+    let answer = match kind {
+        AskKind::Permission => permission_answer(raw).encode(),
+        // The waiting question tool parses this; an error response decodes to
+        // nothing and counts as a dismissal.
+        AskKind::Elicitation => raw
+            .get("result")
+            .cloned()
+            .unwrap_or(Value::Null)
+            .to_string(),
+    };
+    let _ = session.handle.answer_tx.send(answer);
 }
 
 /// A response we cannot read still has to answer the agent, or the tool waits
@@ -573,16 +671,7 @@ fn start_event_pump(
                             ToolCallUpdate::new(ToolCallId::from(id), fields),
                             permissions::permission_options(),
                         ));
-                    let request_id = NEXT_OUTGOING_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
-                    pending.lock().unwrap().permission = Some(request_id);
-                    send(
-                        &out_tx,
-                        Request {
-                            id: RequestId::Number(request_id),
-                            method: Arc::from(request.method()),
-                            params: Some(request),
-                        },
-                    );
+                    ask_client(&out_tx, &pending, AskKind::Permission, request);
                     continue;
                 }
                 AgentEvent::Done { reason, .. } => {
@@ -671,6 +760,10 @@ mod tests {
     }
 
     fn server_awaiting_answer() -> (Server, Receiver<String>) {
+        server_with_ask(AskKind::Permission)
+    }
+
+    fn server_with_ask(kind: AskKind) -> (Server, Receiver<String>) {
         let (answer_tx, answer_rx) = flume::unbounded();
         let handle = InteractiveHandle {
             event_rx: flume::unbounded().1,
@@ -691,14 +784,15 @@ mod tests {
             out_tx: flume::unbounded().0,
             model_specs: Vec::new(),
             model_policy: Arc::new(maki_config::ModelPolicy::default()),
+            client_elicits_form: false,
             session: Some(SessionState {
                 handle,
                 mcp: None,
                 current_mode: AgentMode::Build,
                 current_model: String::new(),
                 pending: Arc::new(Mutex::new(Pending {
-                    permission: Some(ANSWERED_ID),
-                    ..Default::default()
+                    prompt: None,
+                    ask: Some((ANSWERED_ID, kind)),
                 })),
             }),
         };
@@ -732,6 +826,22 @@ mod tests {
 
         handle_incoming_response(&srv, &allow_once(ANSWERED_ID));
         assert!(answer_rx.is_empty(), "the cancelled turn owns that answer");
+    }
+
+    #[test]
+    fn elicitation_response_forwards_the_raw_result() {
+        let (srv, answer_rx) = server_with_ask(AskKind::Elicitation);
+        let raw = serde_json::json!({
+            "id": ANSWERED_ID,
+            "result": { "action": "accept", "content": { "q1": "axum" } },
+        });
+
+        handle_incoming_response(&srv, &raw);
+        let forwarded = answer_rx.try_recv().unwrap();
+        assert_eq!(
+            serde_json::from_str::<Value>(&forwarded).unwrap(),
+            raw["result"]
+        );
     }
 
     #[test]

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -73,7 +73,7 @@ pub async fn run(
     // the interpreter bridge); streamed names are canonicalized in streaming.rs.
     let name = super::streaming::canonical_tool_name(name);
     if let Some(local) = ctx.local_tools.get(name) {
-        return run_local_tool(local, id, name, input, ctx, emit);
+        return run_local_tool(local, id, name, input, ctx, emit).await;
     }
     let entry = registry.get(name);
     // LLM providers send tool names in wire format (server__tool) but our
@@ -257,7 +257,7 @@ fn run_tool_search(
     }
 }
 
-fn run_local_tool(
+async fn run_local_tool(
     local: &LocalToolFn,
     id: String,
     name: &str,
@@ -267,7 +267,11 @@ fn run_local_tool(
 ) -> ToolDoneEvent {
     let tool_id: Arc<str> = Arc::from(name);
     emit_raw_start(ctx, emit, &id, &tool_id, name.to_owned(), input);
-    let (output, is_error) = match local(input) {
+    let tool_ctx = ToolContext {
+        tool_use_id: Some(id.clone()),
+        ..ctx.clone()
+    };
+    let (output, is_error) = match local(input.clone(), tool_ctx).await {
         Ok(output) => (output, false),
         Err(e) => {
             warn!(tool = %name, error = %e, "local tool failed");
@@ -525,7 +529,13 @@ mod tests {
     ) -> ToolContext {
         let mut ctx = crate::tools::test_support::stub_ctx(&AgentMode::Build);
         let mut map = std::collections::HashMap::new();
-        map.insert(name.to_owned(), Arc::new(f) as LocalToolFn);
+        map.insert(
+            name.to_owned(),
+            crate::tools::local_tool(move |input, _ctx| {
+                let result = f(&input);
+                Box::pin(async move { result })
+            }),
+        );
         ctx.local_tools = Arc::new(map);
         ctx
     }
@@ -592,7 +602,10 @@ mod tests {
             let mut map = std::collections::HashMap::new();
             map.insert(
                 "local_echo".to_owned(),
-                Arc::new(|input: &Value| Ok(input.to_string())) as LocalToolFn,
+                crate::tools::local_tool(|input, _ctx| {
+                    let out = input.to_string();
+                    Box::pin(async move { Ok(out) })
+                }),
             );
             ctx.local_tools = Arc::new(map);
 

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -20,7 +20,9 @@ use crate::cancel::{CancelMap, CancelToken};
 use crate::permissions::{PermissionManager, PluginRuleStore};
 use crate::prompt::ResolvedSlots;
 use crate::template;
-use crate::tools::{DescriptionContext, FileReadTracker, ToolAudience, ToolFilter, ToolRegistry};
+use crate::tools::{
+    DescriptionContext, FileReadTracker, LocalTools, ToolAudience, ToolFilter, ToolRegistry,
+};
 use crate::{
     Agent, AgentConfig, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, Envelope,
     EventSender, ImageSource, McpHandle, McpSession, PermissionsConfig, SessionMailbox, ToolOutput,
@@ -289,6 +291,9 @@ pub struct InteractiveParams {
     pub workflow: bool,
     pub model_policy: Arc<ModelPolicy>,
     pub plugin_rules: Arc<PluginRuleStore>,
+    /// Host-side overrides that shadow a registered tool's execution while
+    /// keeping its advertised schema (e.g. ACP answers `question` via elicitation).
+    pub local_tools: LocalTools,
 }
 
 pub struct InteractiveHandle {
@@ -464,6 +469,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                 .with_loaded_instructions(instructions.loaded.clone())
                 .with_user_response_rx(Arc::clone(&answer_rx))
                 .with_cancel(cancel)
+                .with_local_tools(Arc::clone(&params.local_tools))
                 .with_mcp(mcp.clone());
 
                 let result = agent.run(input).await;

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -185,8 +185,18 @@ pub fn timeout_annotation(secs: u64) -> String {
     format!("{formatted} timeout")
 }
 
-pub type LocalToolFn = Arc<dyn Fn(&Value) -> Result<String, String> + Send + Sync>;
+pub type LocalToolResult = BoxFuture<'static, Result<String, String>>;
+pub type LocalToolFn = Arc<dyn Fn(Value, ToolContext) -> LocalToolResult + Send + Sync>;
 pub type LocalTools = Arc<HashMap<String, LocalToolFn>>;
+
+/// Coerces a closure into a [`LocalToolFn`]; the bound gives the boxed
+/// future a coercion target that `Arc::new` alone does not.
+pub fn local_tool<F>(f: F) -> LocalToolFn
+where
+    F: Fn(Value, ToolContext) -> LocalToolResult + Send + Sync + 'static,
+{
+    Arc::new(f)
+}
 
 #[derive(Clone)]
 pub struct ToolContext {

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -459,8 +459,10 @@ async fn session(
             let weak = lua.weak();
             local_map.insert(
                 name,
-                Arc::new(move |input: &JsonValue| call_local_tool(&weak, &handler, input))
-                    as LocalToolFn,
+                maki_agent::tools::local_tool(move |input, _ctx| {
+                    let result = call_local_tool(&weak, &handler, &input);
+                    Box::pin(async move { result })
+                }),
             );
         }
     }

--- a/maki-lua/src/api/util/ctx.rs
+++ b/maki-lua/src/api/util/ctx.rs
@@ -432,7 +432,7 @@ mod tests {
         let mut tools: HashMap<String, LocalToolFn> = HashMap::new();
         tools.insert(
             LOCAL_TOOL_NAME.into(),
-            Arc::new(|_: &serde_json::Value| Ok(String::new())) as LocalToolFn,
+            maki_agent::tools::local_tool(|_, _| Box::pin(async { Ok(String::new()) })),
         );
         ctx.local_tools = Arc::new(tools);
         ctx.live_sink = Some(flume::unbounded().0);

--- a/site/docs/content/acp/_index.md
+++ b/site/docs/content/acp/_index.md
@@ -39,6 +39,7 @@ The `model` value is a `provider/model-id` spec, same format as `maki --model`.
 - **Model switching.** Pick a model from the editor's dropdown, mid-session. All configured providers show up.
 - **Modes.** Switch between build (full access) and plan (plan-file writes only) from the editor.
 - **Permissions.** Tool permission prompts appear in the editor: allow or reject, once or always.
+- **Questions.** The `question` tool becomes a native form in the editor (ACP elicitation). If the client does not support elicitation, the tool is dropped and the model asks in plain text.
 - **Live tool calls.** Tool progress streams as it happens, including sub-agents and batched calls.
 - **Images and context.** Prompts can include images and editor-attached files.
 

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -506,6 +506,7 @@ pub fn run(params: SdkParams) -> Result<()> {
         workflow,
         model_policy: Arc::clone(&model_policy),
         plugin_rules,
+        local_tools: Default::default(),
     });
 
     let (out_tx, out_rx) = flume::unbounded::<String>();


### PR DESCRIPTION
<img width="796" height="633" alt="image" src="https://github.com/user-attachments/assets/9c256da4-0db6-4ce5-858a-f701e33d8aa0" />


In Zed the question tool spun forever, because its Lua handler opens a TUI window and nothing in ACP mode drains the UI channel, so `win:recv()` waited on events that could never come (#812).

ACP has since stabilized `elicitation/create` and Zed ships it on by default, so when the client advertises the form capability the tool now becomes a native form: options map to `oneOf` enums, `multiSelect` to a titled multi-select, and the accepted content is formatted into the same `Header: labels` lines the Lua tool feeds the model.

Execution is rerouted through `local_tools`, which shadows a registered tool while the Lua registry keeps advertising its schema, so `LocalToolFn` grew async plus a `ToolContext`, and the response rides the same answer channel and pending-id routing as permissions.

Clients without the capability just lose the tool, like `--print` and SDK mode already do, and the model asks in plain text instead of hanging.

Free-text answers and per-option descriptions degrade over forms, since an enum field cannot also take custom input.

Closes #812