### PR TITLE
fix(plugins): scope the todo panel to the session that wrote it

### DIFF
--- a/plugins/todo_write/init.lua
+++ b/plugins/todo_write/init.lua
@@ -1,7 +1,7 @@
-local items = {}
-local buf = nil
-local win = nil
-local seen_first = false
+local todos = {}
+local popped = {}
+local focused = nil
+local buf, win
 
 local STATUS_MARKERS = {
   completed = { "[✓]", "todo_completed" },
@@ -18,7 +18,15 @@ local DESCRIPTION = [[Create or update a structured todo list to track tasks.
 - Use ONLY for multi-step work (3+ steps).
 - Skip for trivial tasks.]]
 
-local function count_done()
+local function items_of(sid)
+  return todos[sid or ""] or {}
+end
+
+local function is_focused(sid)
+  return not focused or sid == focused
+end
+
+local function count_done(items)
   local n = 0
   for _, item in ipairs(items) do
     if item.status == "completed" then
@@ -28,13 +36,9 @@ local function count_done()
   return n
 end
 
-local function update_hint()
-  if #items == 0 then
-    maki.ui.set_status_hint(nil)
-    return
-  end
+local function update_hint(items)
   maki.ui.set_status_hint({
-    { string.format(" %d/%d ", count_done(), #items), "foreground" },
+    { string.format(" %d/%d ", count_done(items), #items), "foreground" },
     { "Ctrl+T", "keybind_key" },
     { " ", "" },
   })
@@ -59,7 +63,7 @@ local function ensure_win(visible)
   })
 end
 
-local function build_lines()
+local function build_lines(items)
   local lines = {}
   for _, item in ipairs(items) do
     local marker = STATUS_MARKERS[item.status] or STATUS_MARKERS.pending
@@ -70,14 +74,29 @@ local function build_lines()
   return lines
 end
 
-local function render_panel(visible)
+local function render_panel(items, visible)
   ensure_win(visible)
-  buf:set_lines(build_lines())
+  buf:set_lines(build_lines(items))
   win:set_config({ height = #items + 2 })
   if win:is_visible() then
     maki.ui.set_status_hint(nil)
   else
-    update_hint()
+    update_hint(items)
+  end
+end
+
+local function hide_panel()
+  if win and win:is_open() then
+    win:hide()
+  end
+  maki.ui.set_status_hint(nil)
+end
+
+local function sync_panel(items, pop)
+  if #items == 0 then
+    hide_panel()
+  else
+    render_panel(items, pop)
   end
 end
 
@@ -121,56 +140,63 @@ maki.api.register_tool({
   end,
 
   restore = function(input)
-    items = input.todos or {}
+    local items = input.todos or {}
+    todos[focused or ""] = items
     if #items == 0 then
       return nil
     end
-    render_panel(false)
+    render_panel(items, false)
     local body = maki.ui.buf()
-    body:set_lines(build_lines())
+    body:set_lines(build_lines(items))
     return body
   end,
 
-  handler = function(input)
-    items = input.todos or {}
-    if #items == 0 then
-      if win and win:is_open() then
-        win:hide()
-      end
-      maki.ui.set_status_hint(nil)
-      return "Todos cleared"
+  handler = function(input, ctx)
+    local sid = ctx:session_id() or ""
+    local items = input.todos or {}
+    todos[sid] = items
+    local pop = #items > 0 and not popped[sid]
+    if pop then
+      popped[sid] = true
     end
-    local first = not seen_first
-    seen_first = true
-    render_panel(first)
-    return ""
+    if is_focused(sid) then
+      sync_panel(items, pop)
+    end
+    return #items == 0 and "Todos cleared" or ""
   end,
 })
 
 local function toggle()
+  local items = items_of(focused)
   if not win or #items == 0 then
     return
   end
   if win:is_visible() then
     win:hide()
-    update_hint()
+    update_hint(items)
   elseif win:is_open() then
     win:show()
     maki.ui.set_status_hint(nil)
   else
-    render_panel(true)
+    render_panel(items, true)
   end
 end
 
 maki.keymap.set("n", "<C-t>", toggle, { desc = "Toggle todo panel" })
 
-local function clear_todos()
-  items = {}
-  seen_first = false
-  if win and win:is_open() then
-    win:hide()
-  end
-  maki.ui.set_status_hint(nil)
-end
+maki.api.create_autocmd({ "TurnEnd", "SessionReset" }, {
+  callback = function(ev)
+    local sid = ev.data and ev.data.session_id or ""
+    todos[sid], popped[sid] = nil, nil
+    if is_focused(sid) then
+      hide_panel()
+    end
+  end,
+})
 
-maki.api.create_autocmd({ "TurnEnd", "SessionReset" }, { callback = clear_todos })
+maki.api.create_autocmd("SessionFocusChanged", {
+  callback = function(ev)
+    focused = ev.data and ev.data.session_id
+    sync_panel(items_of(focused), false)
+  end,
+})


### PR DESCRIPTION
One Lua runtime serves every session, so `todo_write` from a background session (or its subagent) opened the shared Todos panel on top of whatever session the user was looking at, and a background `TurnEnd` could hide the foreground panel.

Todos now live in a table keyed by `ctx:session_id()`, and the panel only renders when the writing session is focused.

The focused id comes from the `SessionFocusChanged` autocmd instead of `maki.session.current()`, since that event fires on startup, focus switches, and after reset, and it spares async UI roundtrips in sync callbacks.

Switching focus re-renders the panel from the new session's todos, and `TurnEnd`/`SessionReset` cleanup is filtered by the event's `session_id`.