### PR TITLE
Add missing providers to README and site provider list

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ An AI coding agent optimized for minimal use of context tokens, while providing 
 * DeepSeek - `DEEPSEEK_API_KEY`.
 * OpenRouter - `OPENROUTER_API_KEY`.
 * Synthetic - `SYNTHETIC_API_KEY`.
+* TensorX - `TENSORX_API_KEY`.
 * OpenCode Zen - `OPENCODE_API_KEY`, or the free `public` key for zero-cost models. Models from the models.dev catalog.
 * OpenCode Go - `OPENCODE_API_KEY`. Models from the models.dev catalog.
 * Aperture - `APERTURE_HOST` (e.g. `https://your-host.tailnet.ts.net`). No API key needed, Tailscale handles auth.

--- a/site/index.html
+++ b/site/index.html
@@ -1650,6 +1650,7 @@ imports = <span class="fn">set</span>()
       <div class="provider-grid">
         <a href="/docs/providers/#anthropic" class="provider-chip">Anthropic</a>
         <a href="/docs/providers/#openai" class="provider-chip">OpenAI</a>
+        <a href="/docs/providers/#xai" class="provider-chip">xAI</a>
         <a href="/docs/providers/#google" class="provider-chip">Google</a>
         <a href="/docs/providers/#copilot" class="provider-chip">Copilot</a>
         <a href="/docs/providers/#ollama" class="provider-chip">Ollama</a>
@@ -1659,6 +1660,10 @@ imports = <span class="fn">set</span>()
         <a href="/docs/providers/#deepseek" class="provider-chip">DeepSeek</a>
         <a href="/docs/providers/#openrouter" class="provider-chip">OpenRouter</a>
         <a href="/docs/providers/#synthetic" class="provider-chip">Synthetic</a>
+        <a href="/docs/providers/#tensorx" class="provider-chip">TensorX</a>
+        <a href="/docs/providers/#opencode-zen" class="provider-chip">OpenCode Zen</a>
+        <a href="/docs/providers/#opencode-go" class="provider-chip">OpenCode Go</a>
+        <a href="/docs/providers/#aperture" class="provider-chip">Aperture</a>
       </div>
       <p class="provider-plus reveal reveal-d3">Anything that speaks the OpenAI or Anthropic API works too. Write a short <a href="https://github.com/tontinton/maki/tree/main/scripts/providers" target="_blank" rel="noopener">provider script</a>. OpenAI oauth example included.</p>
     </div>


### PR DESCRIPTION
Add TensorX to the README's supported providers, and add xAI,
TensorX, OpenCode Zen, OpenCode Go, and Aperture chips to the
site's provider grid to match the built-in provider docs.