### PR TITLE
fix(openrouter): prefer billing costs provided in responses

### DIFF
--- a/maki-acp/src/translate.rs
+++ b/maki-acp/src/translate.rs
@@ -750,6 +750,7 @@ mod tests {
                 output: 200,
                 cache_creation: 0,
                 cache_read: 50_000,
+                ..Default::default()
             },
             model: "test-model".into(),
             cost,

--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -500,6 +500,7 @@ mod tests {
             output,
             cache_read,
             cache_creation,
+            ..Default::default()
         };
         assert_eq!(
             is_overflow(&usage, &model, AgentConfig::default().compaction_buffer),

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -999,6 +999,7 @@ mod tests {
             output,
             cache_creation: 0,
             cache_read: 0,
+            cost: None,
         }
     }
 

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -107,6 +107,20 @@ impl ModelPricing {
     /// Cache multipliers Anthropic applies on top of the base input rate.
     const CACHE_WRITE_MULTIPLIER: f64 = 1.25;
     const CACHE_READ_MULTIPLIER: f64 = 0.10;
+
+    /// Fast mode only ever quotes two rates, so its cache rates come off its own
+    /// input rate rather than the standard one they no longer relate to.
+    fn rates(&self, fast: bool) -> (f64, f64, f64, f64) {
+        match &self.fast {
+            Some(f) if fast => (
+                f.input,
+                f.output,
+                f.input * Self::CACHE_WRITE_MULTIPLIER,
+                f.input * Self::CACHE_READ_MULTIPLIER,
+            ),
+            _ => (self.input, self.output, self.cache_write, self.cache_read),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -396,10 +410,19 @@ impl Model {
     ///
     /// `None` on an unpriced model (oauth, local), so callers can hide the cost
     /// instead of showing a misleading "$0.000".
+    ///
+    /// A bill the provider sent us is the whole answer, so it skips both the
+    /// table and the surcharge: it is already the price at this hour, and we
+    /// have one even for a model nothing ever quoted a rate for. Except a bill
+    /// of zero, which is all a free model ever sends, and free has always shown
+    /// no cost rather than "$0.000".
     pub fn billed_cost(&self, usage: &TokenUsage, fast: bool) -> Option<f64> {
-        let cost = self.list_cost(usage, fast)?;
-        let schedule = ManifestRegistry::for_slug(&self.provider).and_then(|m| m.pricing_schedule);
-        Some(schedule.map_or(cost, |s| cost * s.multiplier_at(Timestamp::now())))
+        usage.cost.filter(|bill| *bill > 0.0).or_else(|| {
+            let cost = self.list_cost(usage, fast)?;
+            let schedule =
+                ManifestRegistry::for_slug(&self.provider).and_then(|m| m.pricing_schedule);
+            Some(schedule.map_or(cost, |s| cost * s.multiplier_at(Timestamp::now())))
+        })
     }
 
     /// The quoted rates, with no wall-clock surcharge. Deterministic, which is
@@ -407,7 +430,7 @@ impl Model {
     /// what they paid: the rate back then is unknown, and the table price is
     /// the honest guess.
     pub fn list_cost(&self, usage: &TokenUsage, fast: bool) -> Option<f64> {
-        (!self.pricing.is_zero()).then(|| usage.cost(&self.pricing, fast))
+        (!self.pricing.is_zero()).then(|| usage.estimate(&self.pricing, fast))
     }
 
     pub fn provider_display_name(&self) -> &'static str {
@@ -544,6 +567,15 @@ pub struct TokenUsage {
     pub cache_creation: u32,
     #[serde(rename = "cache_read_input_tokens")]
     pub cache_read: u32,
+    /// What this one response cost, straight from the provider, when it bothers
+    /// to say (OpenRouter's `usage.cost`). Worth preferring on a router, where
+    /// our table prices the model we asked for and the router bills for
+    /// whichever upstream it picked.
+    ///
+    /// One response only, so it is neither summed nor stored. Sessions add up
+    /// their bill a turn at a time in [`StoredTokenUsage::cost`].
+    #[serde(skip)]
+    pub cost: Option<f64>,
 }
 
 impl From<StoredTokenUsage> for TokenUsage {
@@ -553,6 +585,9 @@ impl From<StoredTokenUsage> for TokenUsage {
             output: s.output,
             cache_creation: s.cache_creation,
             cache_read: s.cache_read,
+            // A stored cost belongs to a whole session and this field to one
+            // response, so there is nothing honest to carry across.
+            cost: None,
         }
     }
 }
@@ -603,22 +638,9 @@ impl TokenUsage {
     }
 
     /// Crate-private on purpose: pricing outside [`Model`] skips the provider's
-    /// schedule.
-    pub(crate) fn cost(&self, pricing: &ModelPricing, fast: bool) -> f64 {
-        let (input, output, cache_write, cache_read) = match &pricing.fast {
-            Some(f) if fast => (
-                f.input,
-                f.output,
-                f.input * ModelPricing::CACHE_WRITE_MULTIPLIER,
-                f.input * ModelPricing::CACHE_READ_MULTIPLIER,
-            ),
-            _ => (
-                pricing.input,
-                pricing.output,
-                pricing.cache_write,
-                pricing.cache_read,
-            ),
-        };
+    /// schedule, and the bill it may have sent us.
+    pub(crate) fn estimate(&self, pricing: &ModelPricing, fast: bool) -> f64 {
+        let (input, output, cache_write, cache_read) = pricing.rates(fast);
         self.input as f64 * input / PER_MILLION
             + self.output as f64 * output / PER_MILLION
             + self.cache_creation as f64 * cache_write / PER_MILLION
@@ -640,6 +662,9 @@ impl AddAssign for TokenUsage {
         self.output = self.output.saturating_add(rhs.output);
         self.cache_creation = self.cache_creation.saturating_add(rhs.cache_creation);
         self.cache_read = self.cache_read.saturating_add(rhs.cache_read);
+        // Only some responses arrive with a bill, so a running total of them is
+        // part paid and part missing while looking like the lot.
+        self.cost = None;
     }
 }
 
@@ -680,6 +705,7 @@ mod tests {
         output: 0,
         cache_creation: 0,
         cache_read: 0,
+        cost: None,
     };
     /// Four counters that cannot be confused with each other.
     const COUNTERS: TokenUsage = TokenUsage {
@@ -687,9 +713,12 @@ mod tests {
         output: 22,
         cache_creation: 33,
         cache_read: 44,
+        cost: None,
     };
     const RECORDED_COST: f64 = 0.25;
     const FREE_MEANS_A_KNOWN_ZERO: &str = "only a price discovery reported as zero means free";
+    const TABLE_MUST_NOT_AGREE_BY_LUCK: &str =
+        "the table has to disagree, or preferring the bill proves nothing";
     const PAID_PRICING: ModelPricing = ModelPricing {
         input: 3.0,
         output: 15.0,
@@ -706,9 +735,9 @@ mod tests {
         assert_eq!(format_tokens(tokens), expected);
     }
 
-    #[test_case(TokenUsage { input: 12_000, output: 456, cache_creation: 200, cache_read: 100 }, None, "12.3k↑ 456↓" ; "without_cost")]
-    #[test_case(TokenUsage { input: 1_000_000, output: 100_000, cache_creation: 200_000, cache_read: 500_000 }, Some(5.4), "1.7m↑ 100.0k↓ $5.400" ; "with_cost")]
-    #[test_case(TokenUsage { input: u32::MAX, output: 1, cache_creation: 1, cache_read: 1 }, None, "4295.0m↑ 1↓" ; "input_saturates")]
+    #[test_case(TokenUsage { input: 12_000, output: 456, cache_creation: 200, cache_read: 100, cost: None }, None, "12.3k↑ 456↓" ; "without_cost")]
+    #[test_case(TokenUsage { input: 1_000_000, output: 100_000, cache_creation: 200_000, cache_read: 500_000, cost: None }, Some(5.4), "1.7m↑ 100.0k↓ $5.400" ; "with_cost")]
+    #[test_case(TokenUsage { input: u32::MAX, output: 1, cache_creation: 1, cache_read: 1, cost: None }, None, "4295.0m↑ 1↓" ; "input_saturates")]
     fn usage_formatting(usage: TokenUsage, cost: Option<f64>, expected: &str) {
         assert_eq!(usage.format(cost), expected);
     }
@@ -720,6 +749,7 @@ mod tests {
             output: 456,
             cache_creation: 200,
             cache_read: 100,
+            ..Default::default()
         };
         assert_eq!(usage.format_sum_cost(Some(1.5)), "12.3k↑ 456↓ Σ$1.500");
         assert_eq!(usage.format_sum_cost(None), usage.format(None));
@@ -793,12 +823,13 @@ mod tests {
             output: 1_000,
             cache_creation: 10_000,
             cache_read: 150_000,
+            ..Default::default()
         };
         assert_eq!(usage.total_input(), 165_000);
     }
 
     #[test]
-    fn cost_computes_all_token_types() {
+    fn estimate_computes_all_token_types() {
         let pricing = ModelPricing {
             input: 3.00,
             output: 15.00,
@@ -811,10 +842,46 @@ mod tests {
             output: 100_000,
             cache_creation: 200_000,
             cache_read: 500_000,
+            ..Default::default()
         };
-        let cost = usage.cost(&pricing, false);
+        let cost = usage.estimate(&pricing, false);
         let expected = 3.0 + 1.5 + 0.75 + 0.15;
         assert!((cost - expected).abs() < 1e-10);
+    }
+
+    /// A bill wins outright, and the two ways it used to get lost are the two
+    /// cases here: DeepSeek would have scaled it by the hour on top, and an
+    /// unpriced model would have thrown it away for having no rate to quote.
+    #[test_case(DEEPSEEK_SPEC ; "priced_and_scheduled")]
+    #[test_case(UNPRICED_DEEPSEEK_SPEC ; "unpriced")]
+    fn a_reported_cost_is_the_whole_answer(spec: &str) {
+        let model = Model::from_spec(spec).unwrap();
+        let billed = TokenUsage {
+            cost: Some(RECORDED_COST),
+            ..INPUT_ONLY
+        };
+        assert_ne!(
+            model.billed_cost(&INPUT_ONLY, false),
+            Some(RECORDED_COST),
+            "{TABLE_MUST_NOT_AGREE_BY_LUCK}"
+        );
+        assert_eq!(model.billed_cost(&billed, false), Some(RECORDED_COST));
+    }
+
+    /// Only some responses arrive with a bill, so a total of them would be part
+    /// paid and part missing while looking like the whole session.
+    #[test]
+    fn adding_usage_sums_counters_and_drops_the_bill() {
+        let mut total = TokenUsage {
+            cost: Some(RECORDED_COST),
+            ..COUNTERS
+        };
+        total += TokenUsage {
+            cost: Some(RECORDED_COST),
+            ..COUNTERS
+        };
+        assert_eq!(total.input, COUNTERS.input * 2);
+        assert_eq!(total.cost, None);
     }
 
     #[test]
@@ -834,11 +901,12 @@ mod tests {
             output: 1_000_000,
             cache_creation: 1_000_000,
             cache_read: 1_000_000,
+            ..Default::default()
         };
-        let fast = usage.cost(&pricing, true);
+        let fast = usage.estimate(&pricing, true);
         let expected = 30.0 + 150.0 + 37.5 + 3.0;
         assert!((fast - expected).abs() < 1e-10);
-        assert!(fast > usage.cost(&pricing, false));
+        assert!(fast > usage.estimate(&pricing, false));
     }
 
     #[test]
@@ -855,8 +923,12 @@ mod tests {
             output: 1_000_000,
             cache_creation: 0,
             cache_read: 0,
+            ..Default::default()
         };
-        assert_eq!(usage.cost(&pricing, true), usage.cost(&pricing, false));
+        assert_eq!(
+            usage.estimate(&pricing, true),
+            usage.estimate(&pricing, false)
+        );
     }
 
     #[test]
@@ -1161,13 +1233,19 @@ mod tests {
     }
 
     /// A schedule must not turn "no price" into "$0.000". Callers hide `None`,
-    /// and any multiple of nothing is still nothing.
+    /// and any multiple of nothing is still nothing. A free model billing us
+    /// zero lands in the same place, which is where it has always been.
     #[test]
     fn unpriced_models_stay_unpriced_under_a_schedule() {
         let model = Model::from_spec(UNPRICED_DEEPSEEK_SPEC).unwrap();
+        let free = TokenUsage {
+            cost: Some(0.0),
+            ..INPUT_ONLY
+        };
         assert!(model.pricing.is_zero());
         assert_eq!(model.list_cost(&INPUT_ONLY, false), None);
         assert_eq!(model.billed_cost(&INPUT_ONLY, false), None);
+        assert_eq!(model.billed_cost(&free, false), None);
     }
 
     /// Every later total is rebuilt from what was stored, so storing a turn must

--- a/maki-providers/src/providers/anthropic/mod.rs
+++ b/maki-providers/src/providers/anthropic/mod.rs
@@ -709,7 +709,8 @@ data: {\"type\":\"message_stop\"}\n";
                     input: 42,
                     output: 10,
                     cache_creation: 5,
-                    cache_read: 8
+                    cache_read: 8,
+                    cost: None,
                 }
             );
             assert!(

--- a/maki-providers/src/providers/anthropic/shared.rs
+++ b/maki-providers/src/providers/anthropic/shared.rs
@@ -73,6 +73,7 @@ impl From<Usage> for TokenUsage {
             output: u.output_tokens,
             cache_creation: u.cache_creation_input_tokens,
             cache_read: u.cache_read_input_tokens,
+            ..Default::default()
         }
     }
 }

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -1260,6 +1260,7 @@ mod tests {
             output,
             cache_creation: 0,
             cache_read: 0,
+            cost: None,
         };
         let cost = Model::from_spec(spec)
             .unwrap()

--- a/maki-providers/src/providers/openai/responses.rs
+++ b/maki-providers/src/providers/openai/responses.rs
@@ -548,6 +548,7 @@ fn parse_usage(u: &Value) -> TokenUsage {
         output: output_tokens,
         cache_read: cached,
         cache_creation: 0,
+        cost: None,
     }
 }
 

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use flume::Sender;
 use futures_lite::io::{AsyncBufRead, AsyncBufReadExt, BufReader};
 use isahc::{AsyncReadResponseExt, HttpClient, Request};
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use serde_json::{Value, json};
 use tracing::{debug, warn};
 
@@ -469,6 +469,21 @@ struct ChunkUsage {
     /// DeepSeek reports cache hits here instead of `prompt_tokens_details`.
     #[serde(default)]
     prompt_cache_hit_tokens: u32,
+    /// What the request billed, which routers like OpenRouter attach to usage.
+    #[serde(default, deserialize_with = "lenient_cost")]
+    cost: Option<f64>,
+}
+
+/// No standard covers `cost`, so a gateway may quote it as a string or in a
+/// shape we have never seen. A chunk we cannot parse is dropped whole, and this
+/// is the chunk carrying the turn's token counts, so reading the price has to
+/// be allowed to fail on its own.
+fn lenient_cost<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<f64>, D::Error> {
+    Ok(match Option::<Value>::deserialize(deserializer)? {
+        Some(Value::Number(n)) => n.as_f64(),
+        Some(Value::String(s)) => s.parse().ok(),
+        _ => None,
+    })
 }
 
 #[derive(Deserialize)]
@@ -534,6 +549,7 @@ pub async fn parse_sse(
                 output: u.completion_tokens,
                 cache_read: cached,
                 cache_creation: 0,
+                cost: u.cost,
             };
         }
 
@@ -717,6 +733,8 @@ mod tests {
     use test_case::test_case;
 
     const TEST_STREAM_TIMEOUT: Duration = Duration::from_secs(300);
+    const COUNTS_SURVIVE_A_BAD_COST: &str =
+        "a price we cannot read must not take the token counts down with it";
 
     #[test]
     fn default_model_parser_reads_context_and_output_length() {
@@ -792,6 +810,32 @@ data: [DONE]\n";
             assert_eq!(resp.usage.input, 20);
             assert_eq!(resp.usage.cache_read, 80);
             assert_eq!(resp.usage.output, 10);
+        })
+    }
+
+    /// OpenRouter quotes the bill on the same chunk as the token counts, so the
+    /// counts have to come through whatever it says the price is.
+    #[test_case(json!(0.00045), Some(0.00045)   ; "number")]
+    #[test_case(json!("0.00045"), Some(0.00045) ; "quoted_number")]
+    #[test_case(json!("free"), None             ; "unparsable_string")]
+    #[test_case(json!({"usd": 0.00045}), None   ; "unknown_shape")]
+    #[test_case(json!(null), None               ; "null")]
+    fn parse_sse_cost_from_usage(cost: Value, expected: Option<f64>) {
+        smol::block_on(async {
+            let chunk = json!({
+                "choices": [{"finish_reason": "stop", "delta": {}}],
+                "usage": {"prompt_tokens": 100, "completion_tokens": 10, "cost": cost},
+            });
+            let sse = format!("data: {chunk}\n\ndata: [DONE]\n");
+
+            let (tx, _rx) = flume::unbounded();
+            let resp = parse_sse(Cursor::new(sse.as_bytes()), &tx, TEST_STREAM_TIMEOUT)
+                .await
+                .unwrap();
+
+            assert_eq!(resp.usage.input, 100, "{COUNTS_SURVIVE_A_BAD_COST}");
+            assert_eq!(resp.usage.output, 10, "{COUNTS_SURVIVE_A_BAD_COST}");
+            assert_eq!(resp.usage.cost, expected);
         })
     }
 

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -219,6 +219,7 @@ mod tests {
         output: 0,
         cache_creation: 0,
         cache_read: 0,
+        cost: None,
     };
     /// [`MILLION_INPUT`] at `test_pricing`'s standard input rate.
     const LIST_PRICE: f64 = 3.0;

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -965,6 +965,7 @@ const SUB_TOKENS: TokenUsage = TokenUsage {
     output: 200,
     cache_creation: 300,
     cache_read: 400,
+    cost: None,
 };
 const SUB_COST: Option<f64> = Some(0.007);
 const MAIN_TOKENS: TokenUsage = TokenUsage {
@@ -972,6 +973,7 @@ const MAIN_TOKENS: TokenUsage = TokenUsage {
     output: 100,
     cache_creation: 0,
     cache_read: 0,
+    cost: None,
 };
 const MAIN_COST: Option<f64> = Some(0.002);
 const MAIN_MODEL: &str = "main-model";
@@ -1023,6 +1025,7 @@ const RESTORED_TOKENS: TokenUsage = TokenUsage {
     output: 0,
     cache_creation: 0,
     cache_read: 0,
+    cost: None,
 };
 const RESTORED_MODEL: &str = "model-that-ran-before";
 const SIGMA_MISSING: &str = "the status bar must draw the session total";


### PR DESCRIPTION
Problem: when using models through openrouter, maki doesn't take into account the pricing from the actual provider openrouter selects, and blindly calculates costs based on standard input/output pricing, leading to inaccurate cost metrics

AI usage: maki w/ `openrouter/deepseek/deepseek-v4-flash-0731` to fully vibecode the patch. largely the prompts were along the line of "openrouter is reporting significantly lower costs than maki, see how to get the actual prices openrouter is billing at". i apologize if the resulting rust code is a bit ugly.

Solution: (selected from v4 flash's ideas) in the token usage struct, keep two separate fields - native_cost reports the sum of costs from the api responses for a given model (currently only looks for usage.cost as found in openrouter responses), otherwise other responses are assumed to be billed at standard token pricing and are summed into estimated_cost (names seem a bit sketchy to me, maybe api_reported_cost/standard_token_cost instead?)

i was going to add a cost breakdown to /usage to show how much of the cost is from which (hence the outdated branch name), but it seemed a bit noisy after vibecoding an initial implementation, and contributing.md mentions you're planning to move more plugins to lua too so i figure it's best to not add here.

there are certainly other routers with differing ways of reporting cost but openrouter is (afaik) the most popular so i figure keeping this openrouter-only hack is fine for now.