### PR TITLE
feat(lua): load external package directories

### DIFF
--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -163,8 +163,8 @@ pub enum ConfigError {
     )]
     RemovedEditSubTool { tool: &'static str },
     #[error(
-        "invalid config: plugins.{plugin}: no bundled plugin is named \"{plugin}\" \
-         (bundled plugins: {valid})"
+        "invalid config: plugins.{plugin}: no bundled plugin or installed \
+         package is named \"{plugin}\" (available: {valid})"
     )]
     UnknownPlugin { plugin: String, valid: String },
     #[error(
@@ -271,12 +271,19 @@ impl RawConfig {
         self.tools.extend(overlay.tools);
     }
 
-    pub fn into_config(self) -> Result<Config, ConfigError> {
-        self.validate_plugin_tables()?;
+    /// `packages` are the external package names discovery found. They are
+    /// passed in rather than stored, because an installed package is host
+    /// state: it is not written in any config file and must not survive a
+    /// merge between two of them.
+    pub fn into_config(self, packages: &[String]) -> Result<Config, ConfigError> {
+        self.validate_plugin_tables(packages)?;
+        // Only bundled names, because a builtin's name is also its tool name
+        // while a package's is not. Copying a package name here would hide an
+        // unrelated tool that happened to share it.
         let disabled_tools: Vec<String> = self
             .plugins
             .iter()
-            .filter(|(_, cfg)| cfg.enabled == Some(false))
+            .filter(|(name, cfg)| cfg.enabled == Some(false) && !packages.contains(name))
             .map(|(name, _)| name.clone())
             .collect();
         Ok(Config {
@@ -293,13 +300,13 @@ impl RawConfig {
             storage: StorageConfig::from_file(self.storage),
             telemetry: self.telemetry,
             permissions: PermissionsConfig::default(),
-            plugins: PluginsConfig::from_plugins(self.plugins),
+            plugins: PluginsConfig::from_plugins_and_packages(self.plugins, packages),
         })
     }
 
     /// A `plugins.<name>` key that matches no bundled plugin is a typo or an
     /// old config, so fail loudly instead of letting it silently drift.
-    fn validate_plugin_tables(&self) -> Result<(), ConfigError> {
+    fn validate_plugin_tables(&self, packages: &[String]) -> Result<(), ConfigError> {
         if !self.tools.is_empty() {
             return Err(ConfigError::RenamedToolsTable);
         }
@@ -311,13 +318,16 @@ impl RawConfig {
         let mut unknown: Vec<&String> = self
             .plugins
             .keys()
-            .filter(|name| !DEFAULT_BUILTINS.contains(&name.as_str()))
+            .filter(|name| !DEFAULT_BUILTINS.contains(&name.as_str()) && !packages.contains(name))
             .collect();
         unknown.sort();
         if let Some(&plugin) = unknown.first() {
+            let mut valid: Vec<&str> = DEFAULT_BUILTINS.to_vec();
+            valid.extend(packages.iter().map(String::as_str));
+            valid.sort_unstable();
             return Err(ConfigError::UnknownPlugin {
                 plugin: plugin.clone(),
-                valid: DEFAULT_BUILTINS.join(", "),
+                valid: valid.join(", "),
             });
         }
         Ok(())
@@ -1483,7 +1493,12 @@ impl TelemetryConfig {
 #[derive(Debug, Clone, Default)]
 pub struct PluginsConfig {
     pub enabled: bool,
+    /// Enabled bundled plugins. Deliberately does not include packages: the
+    /// host loads the two from different places, and mixing them here made
+    /// `load_builtins` reject every installed package by name.
     pub names: Vec<String>,
+    /// Enabled external packages.
+    pub packages: Vec<String>,
     /// Per-plugin option tables, without `enabled`. Each plugin validates its
     /// own via `maki.api.register_options` at load time.
     pub opts: HashMap<String, JsonMap<String, JsonValue>>,
@@ -1491,16 +1506,37 @@ pub struct PluginsConfig {
 
 impl PluginsConfig {
     pub fn from_plugins(plugins: HashMap<String, PluginFileConfig>) -> Self {
+        Self::from_plugins_and_packages(plugins, &[])
+    }
+
+    /// Installed packages default to enabled like Neovim `start/` packages.
+    pub fn from_plugins_and_packages(
+        plugins: HashMap<String, PluginFileConfig>,
+        packages: &[String],
+    ) -> Self {
+        let enabled = |name: &String| plugins.get(name).and_then(|t| t.enabled).unwrap_or(true);
+
         let mut all: Vec<String> = DEFAULT_BUILTINS
             .iter()
-            .filter(|name| plugins.get(**name).and_then(|t| t.enabled).unwrap_or(true))
-            .map(|s| s.to_string())
+            .map(|s| (*s).to_owned())
+            .filter(|name| enabled(name))
             .collect();
+
+        let mut enabled_packages: Vec<String> = packages
+            .iter()
+            .filter(|name| !DEFAULT_BUILTINS.contains(&name.as_str()))
+            .filter(|name| enabled(name))
+            .cloned()
+            .collect();
+        enabled_packages.sort();
+        enabled_packages.dedup();
 
         let mut extra: Vec<&String> = plugins
             .iter()
             .filter(|(name, cfg)| {
-                !DEFAULT_BUILTINS.contains(&name.as_str()) && cfg.enabled.unwrap_or(false)
+                !DEFAULT_BUILTINS.contains(&name.as_str())
+                    && !packages.contains(name)
+                    && cfg.enabled.unwrap_or(false)
             })
             .map(|(name, _)| name)
             .collect();
@@ -1516,6 +1552,7 @@ impl PluginsConfig {
         Self {
             enabled: true,
             names: all,
+            packages: enabled_packages,
             opts,
         }
     }
@@ -2248,7 +2285,7 @@ mod tests {
 
     #[test]
     fn empty_config_returns_defaults() {
-        let config = RawConfig::default().into_config().unwrap();
+        let config = RawConfig::default().into_config(&[]).unwrap();
         assert!(config.ui.splash_animation);
         assert_eq!(config.ui.notifications, NotificationMethod::Auto);
         assert_eq!(config.agent.max_output_bytes, DEFAULT_MAX_OUTPUT_BYTES);
@@ -2269,7 +2306,7 @@ mod tests {
     fn notifications_deserialize(value: &str, expected: NotificationMethod) {
         let raw: RawConfig =
             toml::from_str(&format!("[ui]\nnotifications = \"{value}\"\n")).unwrap();
-        assert_eq!(raw.into_config().unwrap().ui.notifications, expected);
+        assert_eq!(raw.into_config(&[]).unwrap().ui.notifications, expected);
     }
 
     #[test]
@@ -2287,7 +2324,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let config = raw.into_config().unwrap();
+        let config = raw.into_config(&[]).unwrap();
         assert_eq!(config.agent.max_output_lines, 5000);
         assert_eq!(config.agent.max_output_bytes, DEFAULT_MAX_OUTPUT_BYTES);
     }
@@ -2354,7 +2391,7 @@ mod tests {
             ..Default::default()
         });
 
-        let provider = global.into_config().unwrap().provider;
+        let provider = global.into_config(&[]).unwrap().provider;
         assert!(provider.allowed_models.is_empty());
         assert_eq!(provider.excluded_models, ["*/*-preview"]);
         assert!(provider.model_policy.allows("openai/gpt-5"));
@@ -2371,7 +2408,7 @@ mod tests {
             },
             ..Default::default()
         }
-        .into_config()
+        .into_config(&[])
         .unwrap();
         let policy = &config.provider.model_policy;
 
@@ -2387,7 +2424,7 @@ mod tests {
             },
             ..Default::default()
         }
-        .into_config()
+        .into_config(&[])
         .unwrap();
         assert!(exclude_only.provider.model_policy.allows("openai/gpt-5"));
         assert!(
@@ -2407,7 +2444,7 @@ mod tests {
             },
             ..Default::default()
         }
-        .into_config();
+        .into_config(&[]);
 
         assert!(matches!(
             result,
@@ -2442,14 +2479,14 @@ mod tests {
 
     #[test]
     fn always_workflow_resolves_default_and_set() {
-        let defaults = RawConfig::default().into_config().unwrap();
+        let defaults = RawConfig::default().into_config(&[]).unwrap();
         assert!(!defaults.always_workflow, "absent resolves to false");
 
         let raw = RawConfig {
             always_workflow: Some(true),
             ..Default::default()
         };
-        assert!(raw.into_config().unwrap().always_workflow);
+        assert!(raw.into_config(&[]).unwrap().always_workflow);
     }
 
     #[test_case(AlwaysThinking::Toggle(true), StoredThinking::Adaptive ; "toggle_true")]
@@ -2463,14 +2500,14 @@ mod tests {
 
     #[test]
     fn into_config_resolves_always_thinking() {
-        let defaults = RawConfig::default().into_config().unwrap();
+        let defaults = RawConfig::default().into_config(&[]).unwrap();
         assert!(defaults.always_thinking.is_none());
 
         let raw = RawConfig {
             always_thinking: Some(AlwaysThinking::Mode("8192".into())),
             ..Default::default()
         };
-        let config = raw.into_config().unwrap();
+        let config = raw.into_config(&[]).unwrap();
         assert_eq!(
             config.always_thinking,
             Some(StoredThinking::Budget { tokens: 8192 })
@@ -2480,7 +2517,7 @@ mod tests {
             always_thinking: Some(AlwaysThinking::Mode("fast".into())),
             ..Default::default()
         };
-        let err = raw.into_config().err().expect("expected config error");
+        let err = raw.into_config(&[]).err().expect("expected config error");
         assert!(matches!(err, ConfigError::Thinking(_)));
     }
 
@@ -2511,7 +2548,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let config = raw.into_config().unwrap();
+        let config = raw.into_config(&[]).unwrap();
         assert_eq!(config.ui.tool_output_lines.bash, 20);
         assert_eq!(config.ui.tool_output_lines.read, 20);
         assert_eq!(
@@ -2936,14 +2973,14 @@ mod tests {
     #[test]
     fn show_thinking_missing_defaults_true() {
         let raw: RawConfig = toml::from_str("").unwrap();
-        let config = raw.into_config().unwrap();
+        let config = raw.into_config(&[]).unwrap();
         assert!(config.ui.show_thinking);
     }
 
     #[test]
     fn max_input_lines_defaults_and_deserializes() {
         let raw: RawConfig = toml::from_str("").unwrap();
-        let config = raw.into_config().unwrap();
+        let config = raw.into_config(&[]).unwrap();
         assert_eq!(config.ui.max_input_lines, DEFAULT_MAX_INPUT_LINES);
 
         let raw: RawConfig = toml::from_str("[ui]\nmax_input_lines = 5\n").unwrap();
@@ -2989,7 +3026,7 @@ mod tests {
             "[plugins.bash]\ntimeout_secs = 180\n[plugins.websearch]\nenabled = false\n",
         )
         .unwrap();
-        let config = raw.into_config().unwrap();
+        let config = raw.into_config(&[]).unwrap();
         assert!(config.plugins.names.contains(&"bash".to_string()));
         assert!(!config.plugins.names.contains(&"websearch".to_string()));
         assert!(
@@ -3100,7 +3137,7 @@ mod tests {
     fn removed_sub_tool_tables_error() {
         for &tool in EDIT_SUB_TOOLS {
             let raw: RawConfig = toml::from_str(&format!("[plugins.{tool}]\n")).unwrap();
-            let Err(err) = raw.into_config() else {
+            let Err(err) = raw.into_config(&[]) else {
                 panic!("plugins.{tool} should be rejected");
             };
             let msg = err.to_string();
@@ -3116,13 +3153,73 @@ mod tests {
     #[test_case("search_result_limit = 50" ; "opts_only")]
     fn unknown_plugin_name_errors(body: &str) {
         let raw: RawConfig = toml::from_str(&format!("[plugins.gerp]\n{body}\n")).unwrap();
-        let Err(err) = raw.into_config() else {
+        let Err(err) = raw.into_config(&[]) else {
             panic!("plugins.gerp should be rejected");
         };
         let msg = err.to_string();
         assert!(
-            msg.contains("no bundled plugin is named \"gerp\"") && msg.contains("grep"),
-            "error should name the typo and list bundled plugins, got: {msg}"
+            msg.contains("named \"gerp\"") && msg.contains("grep"),
+            "error should name the typo and list what is available, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn known_package_name_is_accepted() {
+        let raw: RawConfig = toml::from_str("[plugins.my_pack]\nenabled = true\n").unwrap();
+        let config = raw
+            .into_config(&["my_pack".to_owned()])
+            .expect("an installed package should be configurable");
+        assert!(config.plugins.packages.contains(&"my_pack".to_owned()));
+    }
+
+    #[test]
+    fn known_package_can_be_disabled() {
+        let raw: RawConfig = toml::from_str("[plugins.my_pack]\nenabled = false\n").unwrap();
+        let config = raw.into_config(&["my_pack".to_owned()]).unwrap();
+        assert!(!config.plugins.packages.contains(&"my_pack".to_owned()));
+    }
+
+    #[test]
+    fn packages_are_not_mixed_into_builtin_names() {
+        let config = RawConfig::default()
+            .into_config(&["my_pack".to_owned()])
+            .unwrap();
+        assert!(!config.plugins.names.contains(&"my_pack".to_owned()));
+        assert!(config.plugins.packages.contains(&"my_pack".to_owned()));
+        assert!(
+            config
+                .plugins
+                .names
+                .iter()
+                .all(|n| DEFAULT_BUILTINS.contains(&n.as_str())),
+            "names must hold only bundled plugins"
+        );
+    }
+
+    #[test]
+    fn disabling_a_package_does_not_disable_a_tool() {
+        let raw: RawConfig = toml::from_str("[plugins.my_pack]\nenabled = false\n").unwrap();
+        let config = raw.into_config(&["my_pack".to_owned()]).unwrap();
+        assert!(!config.agent.disabled_tools.contains(&"my_pack".to_owned()));
+    }
+
+    #[test]
+    fn disabling_a_builtin_still_disables_its_tool() {
+        let raw: RawConfig = toml::from_str("[plugins.grep]\nenabled = false\n").unwrap();
+        let config = raw.into_config(&[]).unwrap();
+        assert!(config.agent.disabled_tools.contains(&"grep".to_owned()));
+    }
+
+    #[test]
+    fn unknown_name_still_rejected_when_packages_exist() {
+        let raw: RawConfig = toml::from_str("[plugins.gerp]\nenabled = true\n").unwrap();
+        let Err(err) = raw.into_config(&["my_pack".to_owned()]) else {
+            panic!("gerp is neither a builtin nor an installed package");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("my_pack"),
+            "should list packages too, got: {msg}"
         );
     }
 
@@ -3130,7 +3227,7 @@ mod tests {
     fn disabled_plugin_keeps_opts_but_not_load_entry() {
         let raw: RawConfig =
             toml::from_str("[plugins.bash]\nenabled = false\ntimeout_secs = 180\n").unwrap();
-        let config = raw.into_config().unwrap();
+        let config = raw.into_config(&[]).unwrap();
         assert!(!config.plugins.names.contains(&"bash".to_string()));
         assert_eq!(
             config.plugins.opts["bash"]["timeout_secs"],
@@ -3142,7 +3239,7 @@ mod tests {
     #[test]
     fn renamed_tools_table_errors() {
         let raw: RawConfig = toml::from_str("[tools.bash]\nenabled = true\n").unwrap();
-        let Err(err) = raw.into_config() else {
+        let Err(err) = raw.into_config(&[]) else {
             panic!("old tools table should be rejected");
         };
         assert!(
@@ -3155,7 +3252,7 @@ mod tests {
     fn edit_sub_tool_toggles_flow_as_edit_opts() {
         let raw: RawConfig =
             toml::from_str("[plugins.edit]\nmultiedit = false\nedit_lines = true\n").unwrap();
-        let config = raw.into_config().unwrap();
+        let config = raw.into_config(&[]).unwrap();
         assert_eq!(
             config.plugins.opts["edit"]["multiedit"],
             serde_json::json!(false)

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod log;
 pub(crate) mod model;
 pub(crate) mod net;
 pub(crate) mod options;
+pub(crate) mod pack;
 pub(crate) mod session;
 pub(crate) mod slot;
 pub(crate) mod split;
@@ -95,6 +96,7 @@ pub(crate) fn create_maki_global(
         "keymap",
         keymap::create_keymap_table(lua, Arc::clone(&plugin))?,
     )?;
+    pack::add_packadd(lua, &maki)?;
 
     Ok(maki)
 }

--- a/maki-lua/src/api/pack.rs
+++ b/maki-lua/src/api/pack.rs
@@ -1,0 +1,140 @@
+//! `maki.packadd`, the activation path for a package under `pack/*/opt/`.
+
+use std::sync::{Arc, Mutex};
+
+use maki_lua_macro::lua_fn;
+use mlua::{Lua, Result as LuaResult, Table};
+
+/// A package activation requested from Lua.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PackOp {
+    /// Load a package that is installed but not loaded.
+    Activate { name: String },
+}
+
+/// What Lua recorded for the host to act on.
+///
+/// Session state only. Nothing here runs inline: loading an owner blocks on a
+/// reply from the runtime thread that the calling Lua task is occupying, so
+/// acting on a request from inside the call would wait on itself.
+#[derive(Debug, Default)]
+pub struct PackDeclarations {
+    pub pending: Vec<PackOp>,
+    /// Set once the startup drain is over.
+    ///
+    /// Nothing reads `pending` after that point, so a `packadd` from a command
+    /// handler or a keymap would sit here for the rest of the session with no
+    /// error and no log. It is refused instead.
+    pub drained: bool,
+}
+
+pub type PackStore = Arc<Mutex<PackDeclarations>>;
+
+/// Registers `maki.packadd` on the root table.
+///
+/// It sits beside the other always-available functions rather than in a table
+/// of its own, because activating code that is already installed and already
+/// approved is something any plugin may do.
+pub(crate) fn add_packadd(lua: &Lua, maki: &Table) -> LuaResult<()> {
+    maki.set("packadd", lua.create_function(packadd)?)
+}
+
+/// Activate an installed `opt/` package, like `:packadd`.
+///
+/// Loading happens after this call returns. The startup package pass reports
+/// an unknown, disabled, or failed package.
+///
+/// @param name string Package to activate.
+/// @example
+/// maki.packadd("maki-goal")
+#[lua_fn]
+fn packadd(lua: &Lua, name: String) -> LuaResult<()> {
+    enqueue(lua, PackOp::Activate { name })
+}
+
+fn enqueue(lua: &Lua, op: PackOp) -> LuaResult<()> {
+    let store = lua
+        .app_data_ref::<PackStore>()
+        .ok_or_else(|| mlua::Error::runtime("pack: not available here"))?
+        .clone();
+    let mut declarations = store.lock().expect("pack declarations");
+    if declarations.drained {
+        return Err(mlua::Error::runtime(
+            "maki.packadd: packages have already been loaded, so it only works \
+             while init.lua and the packages themselves are running",
+        ));
+    }
+    // Two calls naming one package still load it once. The name is checked
+    // against what discovery found when the host drains this, so an unknown
+    // one is reported there rather than guessed at here.
+    if !declarations.pending.contains(&op) {
+        declarations.pending.push(op);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PackOp, PackStore, add_packadd};
+    use mlua::Lua;
+
+    fn lua_with_store() -> (Lua, PackStore) {
+        let lua = Lua::new();
+        let store = PackStore::default();
+        lua.set_app_data(store.clone());
+        (lua, store)
+    }
+
+    #[test]
+    fn packadd_records_each_named_package_once() {
+        let (lua, store) = lua_with_store();
+        let maki = lua.create_table().unwrap();
+        add_packadd(&lua, &maki).unwrap();
+        let f: mlua::Function = maki.get("packadd").expect("packadd is on the root table");
+        f.call::<()>("goal").unwrap();
+        f.call::<()>("review").unwrap();
+        f.call::<()>("goal").unwrap();
+        assert_eq!(
+            store.lock().unwrap().pending,
+            vec![
+                PackOp::Activate {
+                    name: "goal".to_owned()
+                },
+                PackOp::Activate {
+                    name: "review".to_owned()
+                }
+            ],
+            "a repeated call must not load the package twice"
+        );
+    }
+
+    #[test]
+    fn packadd_after_the_drain_is_refused() {
+        let (lua, store) = lua_with_store();
+        let maki = lua.create_table().unwrap();
+        add_packadd(&lua, &maki).unwrap();
+        store.lock().unwrap().drained = true;
+
+        let f: mlua::Function = maki.get("packadd").expect("packadd is on the root table");
+        let err = f
+            .call::<()>("goal")
+            .expect_err("nothing reads the queue after the drain");
+        assert!(
+            err.to_string().contains("already been loaded"),
+            "got: {err}"
+        );
+        assert!(
+            store.lock().unwrap().pending.is_empty(),
+            "a refused call must not leave a request behind"
+        );
+    }
+
+    #[test]
+    fn packadd_without_a_store_reports_rather_than_panicking() {
+        let lua = Lua::new();
+        let maki = lua.create_table().unwrap();
+        add_packadd(&lua, &maki).unwrap();
+        let f: mlua::Function = maki.get("packadd").unwrap();
+        assert!(f.call::<()>("goal").is_err());
+    }
+}

--- a/maki-lua/src/api/util/setup.rs
+++ b/maki-lua/src/api/util/setup.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use maki_config::RawConfig;
 use mlua::{Function, Lua, LuaSerdeExt, Result as LuaResult};
 
-use crate::api::split::split__doc;
+use crate::api::{pack::packadd__doc, split::split__doc};
 use crate::docs::{DocKind, FnDoc, ModuleDoc, ParamDoc};
 
 pub(crate) type ConfigStore = Arc<Mutex<Option<RawConfig>>>;
@@ -34,6 +34,7 @@ accepts the same keys as the Configuration reference.",
 })",
         },
         split__doc,
+        packadd__doc,
     ],
 };
 

--- a/maki-lua/src/error.rs
+++ b/maki-lua/src/error.rs
@@ -17,12 +17,30 @@ pub enum PluginError {
         #[source]
         source: io::Error,
     },
-    #[error(
-        "plugins.{plugin} sets options ({keys}), but there is no bundled plugin named \"{plugin}\""
-    )]
-    UnknownPluginOptions { plugin: String, keys: String },
     #[error("no bundled plugin named \"{plugin}\" (enabled via plugins.{plugin})")]
     UnknownPlugin { plugin: String },
     #[error("plugin host is not running")]
     HostDead,
+    #[error("package {name} at {path} has no plugin/*.lua entrypoint")]
+    PackageEmpty { name: String, path: PathBuf },
+    #[error("package file {path} resolves outside its package directory")]
+    PackageEscape { path: PathBuf },
+    #[error(
+        "package \"{name}\" at {path} has the same name as a bundled plugin; \
+         rename its directory"
+    )]
+    PackageNameConflict { name: String, path: PathBuf },
+    #[error("package manifest {path} is not valid toml: {message}")]
+    PackageManifest { path: PathBuf, message: String },
+    #[error("cannot resolve the maki data directory, so no package was looked for: {source}")]
+    PackageSiteUnavailable {
+        #[source]
+        source: io::Error,
+    },
+    #[error("two packages are both named \"{name}\": {first} and {second}")]
+    DuplicatePackage {
+        name: String,
+        first: PathBuf,
+        second: PathBuf,
+    },
 }

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -4,6 +4,7 @@ pub mod docs_render;
 mod error;
 pub mod language;
 mod loader;
+mod pack;
 pub(crate) mod plugin_permissions;
 mod runtime;
 
@@ -17,7 +18,11 @@ pub use api::util::command::{
 pub use docs::{DocKind, FnDoc, ModuleDoc, ParamDoc, api_docs};
 pub use error::PluginError;
 pub use loader::{EventHandle, PluginHost};
-pub use plugin_permissions::{Permission, PluginPermissions};
+pub use pack::{
+    DiscoveredPackage, Discovery, MANAGED_GROUP, discover, discover_installed, sanitize_message,
+    site_dir,
+};
+pub use plugin_permissions::{Permission, PluginPermissions, Requested};
 pub use runtime::{KILL_GRACE, RestoreItem, WARM_TOOL_CAP};
 
 pub mod test_support {

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -14,8 +14,9 @@ use crate::api::keymap::KeymapReader;
 use crate::api::options::{PluginOptionSpecs, PluginOpts};
 use crate::api::util::command::{HintReader, LuaCommandReader, UiAction};
 use crate::error::PluginError;
+use crate::pack::DiscoveredPackage;
 use crate::plugin_permissions::{PluginPermissions, load_plugin_permissions};
-use crate::runtime::{self, ClickFallback, LuaThread, Request, RestoreItem};
+use crate::runtime::{self, ClickFallback, LoadChunk, LuaThread, Request, RestoreItem};
 use maki_agent::prompt::ResolvedSlots;
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
@@ -110,6 +111,13 @@ static BUNDLED_PLUGINS: &[BundledPlugin] = &[
     },
 ];
 
+/// Every bundled name, not just the default-enabled ones. An external package
+/// sharing an owner name with any of them would let one package's unload tear
+/// down the other's registrations.
+pub(crate) fn is_bundled(name: &str) -> bool {
+    BUNDLED_PLUGINS.iter().any(|p| p.name == name)
+}
+
 pub(crate) fn lib_dir() -> &'static Dir<'static> {
     &BUNDLED_PLUGINS
         .iter()
@@ -122,6 +130,54 @@ static BUNDLED_DIRS: LazyLock<&'static [&'static Dir<'static>]> = LazyLock::new(
     let dirs: Vec<&'static Dir<'static>> = BUNDLED_PLUGINS.iter().map(|p| &p.dir).collect();
     Vec::leak(dirs)
 });
+
+/// A package's entrypoints: every `plugin/*.lua`, sorted by filename so load
+/// order is deterministic across machines.
+///
+/// A repository can commit a symlink, so each entry is resolved and checked to
+/// be inside the package before it is read.
+fn package_entrypoints(root: &Path) -> Result<Vec<PathBuf>, PluginError> {
+    let entrypoint_dir = root.join("plugin");
+    let entries = match fs::read_dir(&entrypoint_dir) {
+        Ok(entries) => entries,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) => {
+            return Err(PluginError::Io {
+                path: entrypoint_dir,
+                source,
+            });
+        }
+    };
+    let mut files = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|source| PluginError::Io {
+            path: entrypoint_dir.clone(),
+            source,
+        })?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("lua") {
+            continue;
+        }
+        let resolved = path.canonicalize().map_err(|e| PluginError::Io {
+            path: path.clone(),
+            source: e,
+        })?;
+        if !resolved.starts_with(root) {
+            return Err(PluginError::PackageEscape { path });
+        }
+        if resolved.is_file() {
+            let Some(file_name) = path.file_name().map(std::ffi::OsString::from) else {
+                continue;
+            };
+            files.push((file_name, resolved));
+        }
+    }
+    // By file name, not by the resolved path: a package may symlink an entry
+    // elsewhere inside itself, and load order must still be the order a user
+    // sees in `plugin/`.
+    files.sort_by(|(a, _), (b, _)| a.cmp(b));
+    Ok(files.into_iter().map(|(_, path)| path).collect())
+}
 
 pub struct PluginHost {
     inner: LuaThread,
@@ -256,21 +312,25 @@ impl PluginHost {
 
     fn send_builtin_loads(&self, config: &PluginsConfig) -> Result<(), PluginError> {
         for (plugin, opts) in &config.opts {
+            // An enabled package takes its options when the package itself
+            // loads, and an enabled builtin takes them in the loop below.
+            if config.packages.contains(plugin) || config.names.contains(plugin) {
+                continue;
+            }
+            // What is left is a name that exists but is not loading: a builtin
+            // or a package the config disabled, or one discovery refused. It
+            // cannot be a typo, because the config layer validated every
+            // `plugins.<name>` key against the same names before this ran. A
+            // package used to reach this as an error, which stopped maki from
+            // starting over options it was already ignoring.
             let keys: Vec<&str> = opts.keys().map(String::as_str).collect();
-            if !BUNDLED_PLUGINS.iter().any(|p| p.name == plugin.as_str()) {
-                return Err(PluginError::UnknownPluginOptions {
-                    plugin: plugin.clone(),
-                    keys: keys.join(", "),
-                });
-            }
-            if !config.names.contains(plugin) {
-                tracing::warn!(
-                    plugin = plugin.as_str(),
-                    keys = keys.join(", "),
-                    "plugin is disabled; its plugins.{} options are ignored until re-enabled",
-                    plugin
-                );
-            }
+            tracing::warn!(
+                plugin = plugin.as_str(),
+                keys = keys.join(", "),
+                "nothing named {} is loading; its plugins.{} options are ignored",
+                plugin,
+                plugin
+            );
         }
         for builtin in &config.names {
             let dir = match BUNDLED_PLUGINS.iter().find(|p| p.name == builtin.as_str()) {
@@ -296,8 +356,8 @@ impl PluginHost {
                 .map(Arc::new)
                 .unwrap_or_default();
             self.send_load(
-                name,
-                init.to_owned(),
+                Arc::clone(&name),
+                vec![LoadChunk::new(name.as_ref(), init)],
                 None,
                 PluginPermissions::trusted(),
                 opts,
@@ -309,7 +369,7 @@ impl PluginHost {
     fn send_load(
         &self,
         name: Arc<str>,
-        source: String,
+        chunks: Vec<LoadChunk>,
         plugin_dir: Option<PathBuf>,
         permissions: PluginPermissions,
         opts: PluginOpts,
@@ -319,7 +379,7 @@ impl PluginHost {
             .tx
             .send(Request::LoadSource {
                 name,
-                source,
+                chunks,
                 plugin_dir,
                 permissions,
                 opts,
@@ -384,7 +444,7 @@ impl PluginHost {
     ) -> Result<(), PluginError> {
         self.send_load(
             Arc::from(name),
-            source.to_owned(),
+            vec![LoadChunk::new(name, source)],
             None,
             PluginPermissions::trusted(),
             Arc::new(opts),
@@ -399,7 +459,7 @@ impl PluginHost {
     ) -> Result<(), PluginError> {
         self.send_load(
             Arc::from(name),
-            source.to_owned(),
+            vec![LoadChunk::new(name, source)],
             None,
             permissions,
             PluginOpts::default(),
@@ -419,11 +479,182 @@ impl PluginHost {
         // unknown-plugin guards about user plugin names.
         self.send_load(
             Arc::from("user"),
-            source,
+            vec![LoadChunk::new(path.display().to_string(), source)],
             plugin_dir,
             permissions,
             PluginOpts::default(),
         )
+    }
+
+    /// Loads one external package directory as a single owner.
+    ///
+    /// Every `plugin/*.lua` becomes a chunk, and the chunks share one
+    /// environment, so what one file registers the next can use. The whole set
+    /// commits or none of it does.
+    pub fn load_package(
+        &self,
+        name: &str,
+        dir: &Path,
+        permissions: PluginPermissions,
+        opts: PluginOpts,
+    ) -> Result<(), PluginError> {
+        // Refused here and not only in discovery, because loading an owner
+        // drops that owner's existing registrations first. A package named
+        // after a bundled plugin would unload the builtin before its own
+        // entrypoint ever ran, so every caller has to be gated, not just the
+        // one that walks the site directory.
+        if is_bundled(name) {
+            return Err(PluginError::PackageNameConflict {
+                name: name.to_owned(),
+                path: dir.to_path_buf(),
+            });
+        }
+        // Resolved once here, so the manifest, the entrypoints, and later
+        // `require` calls all agree on one directory even if the path they came
+        // from changes underneath us.
+        let root = dir.canonicalize().map_err(|e| PluginError::Io {
+            path: dir.to_path_buf(),
+            source: e,
+        })?;
+        let files = package_entrypoints(&root)?;
+        if files.is_empty() {
+            return Err(PluginError::PackageEmpty {
+                name: name.to_owned(),
+                path: root,
+            });
+        }
+
+        let mut chunks = Vec::with_capacity(files.len());
+        for path in files {
+            let source = fs::read_to_string(&path).map_err(|e| PluginError::Io {
+                path: path.clone(),
+                source: e,
+            })?;
+            chunks.push(LoadChunk::new(path.display().to_string(), source));
+        }
+        self.send_load(Arc::from(name), chunks, Some(root), permissions, opts)
+    }
+
+    /// Refuses further `maki.packadd` calls, and returns anything the queue
+    /// still holds.
+    ///
+    /// One call and not a read followed by a close, because a Lua task can
+    /// record an activation between the two and closing would strand it.
+    fn seal_pack_ops(&self) -> Result<Vec<crate::api::pack::PackOp>, PluginError> {
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        self.inner
+            .tx
+            .send(Request::SealPackOps { reply: reply_tx })
+            .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)
+    }
+
+    /// Takes the package operations Lua recorded, leaving the queue empty.
+    ///
+    /// Called by the host after the initiating task has exited, which keeps a
+    /// load off the thread that requested it.
+    fn take_pending_pack_ops(&self) -> Result<Vec<crate::api::pack::PackOp>, PluginError> {
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        self.inner
+            .tx
+            .send(Request::TakePackOps { reply: reply_tx })
+            .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)
+    }
+
+    /// Loads every package that should be loaded now: the `start/` ones, and
+    /// the `opt/` ones that `maki.packadd` named.
+    ///
+    /// Activation names are collected here rather than acted on inside
+    /// `packadd`, because a load waits on a reply from the runtime thread that
+    /// `packadd` is called on. They are collected after each round as well as
+    /// before the first, so a package that activates another one still has it
+    /// loaded in this startup rather than the next.
+    pub fn load_packages(
+        &self,
+        packages: &[DiscoveredPackage],
+        config: &PluginsConfig,
+    ) -> Vec<String> {
+        let mut failures = Vec::new();
+        let mut loaded: Vec<&str> = Vec::new();
+        let mut round: Vec<&DiscoveredPackage> = packages
+            .iter()
+            .filter(|pkg| pkg.eager && config.packages.iter().any(|n| n == &pkg.name))
+            .collect();
+
+        // A `loop` and not `while !round.is_empty()`: with no `start` package
+        // installed the first round is empty, and the names `init.lua` already
+        // recorded still have to be collected.
+        loop {
+            for pkg in round {
+                let opts = config
+                    .opts
+                    .get(&pkg.name)
+                    .cloned()
+                    .map(Arc::new)
+                    .unwrap_or_default();
+                // A package the user installed by hand is granted what it asks
+                // for. Only a package maki fetched needs an approval as well.
+                let permissions = pkg.requested.clone().granted_for_manual_install();
+                loaded.push(&pkg.name);
+                if let Err(e) = self.load_package(&pkg.name, &pkg.dir, permissions, opts) {
+                    tracing::error!(
+                        package = %pkg.name,
+                        path = %pkg.dir.display(),
+                        error = %e,
+                        "failed to load package"
+                    );
+                    failures.push(format!("{}: failed to load: {e}", pkg.name));
+                }
+            }
+
+            let ops = match self.take_pending_pack_ops() {
+                Ok(ops) => ops,
+                Err(e) => {
+                    failures.push(format!("could not read package activations: {e}"));
+                    break;
+                }
+            };
+            round = Vec::new();
+            for op in ops {
+                let crate::api::pack::PackOp::Activate { name } = op;
+                if loaded.contains(&name.as_str()) {
+                    continue;
+                }
+                // Refused rather than loaded when the config disabled it, so
+                // `packadd` cannot be a way around `plugins.<name>.enabled`.
+                let found = packages
+                    .iter()
+                    .find(|pkg| pkg.name == name && config.packages.iter().any(|n| n == &pkg.name));
+                match found {
+                    Some(pkg) => round.push(pkg),
+                    None => failures.push(format!(
+                        "packadd {name:?}: no package with that name is installed"
+                    )),
+                }
+            }
+            if round.is_empty() {
+                break;
+            }
+        }
+        // Nothing drains the queue after this, so `packadd` is closed rather
+        // than left accepting names no one will read. Closing returns whatever
+        // arrived since the last round, which is reported rather than dropped:
+        // that request was going to be honoured a moment earlier.
+        match self.seal_pack_ops() {
+            Ok(leftover) => {
+                for op in leftover {
+                    let crate::api::pack::PackOp::Activate { name } = op;
+                    failures.push(format!(
+                        "packadd {name:?}: arrived after the packages had loaded"
+                    ));
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "could not close the package activation queue");
+            }
+        }
+        failures
     }
 
     pub fn event_handle(&self) -> EventHandle {
@@ -584,6 +815,27 @@ mod tests {
     use maki_agent::tools::ToolRegistry;
     use std::time::Instant;
     use test_case::test_case;
+
+    /// Closing the queue and reading it are one message. A Lua task can record
+    /// an activation between a separate read and close, and a close that threw
+    /// the queue away would strand exactly the request that was about to be
+    /// honoured.
+    #[test]
+    fn closing_the_activation_queue_hands_back_what_it_holds() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        host.load_source("recorder", r#"maki.packadd("demo")"#)
+            .expect("packadd is available to every plugin");
+
+        let leftover = host.seal_pack_ops().expect("the host is running");
+
+        assert_eq!(
+            leftover,
+            vec![crate::api::pack::PackOp::Activate {
+                name: "demo".to_owned()
+            }],
+            "a recorded activation must come back, not be dropped"
+        );
+    }
 
     /// jit=true is exercised by the whole integration suite
     /// (`tests/plugin_host.rs` boots hosts via `new`); only the O1

--- a/maki-lua/src/pack.rs
+++ b/maki-lua/src/pack.rs
@@ -1,0 +1,429 @@
+//! Discovery of external packages installed under the site directory.
+//!
+//! This is the manual half of the package model: directories a user cloned
+//! themselves, laid out the way Neovim lays packages out. Packages that maki
+//! installs are resolved from recorded state instead, and never appear here.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::error::PluginError;
+use crate::loader::is_bundled;
+use crate::plugin_permissions::{Requested, load_requested_permissions};
+
+pub fn sanitize_message(message: &str) -> String {
+    message
+        .chars()
+        .map(|character| {
+            if character == '\n' || character == '\t' || !character.is_control() {
+                character
+            } else {
+                ' '
+            }
+        })
+        .collect()
+}
+
+/// The group name reserved for packages maki installs itself. Manual discovery
+/// skips it, so one package can never be found twice, once from disk and once
+/// from recorded state, with the two disagreeing about its revision.
+pub const MANAGED_GROUP: &str = "core";
+
+/// `<data>/site`, the root Neovim would call a package path.
+pub fn site_dir() -> Result<PathBuf, std::io::Error> {
+    maki_storage::paths::data_dir().map(|d| d.join("site"))
+}
+
+#[derive(Debug)]
+pub struct DiscoveredPackage {
+    pub name: String,
+    /// Canonical package root. Resolved once, here, so the manifest, the
+    /// entrypoints, and every later `require` agree on one directory.
+    pub dir: PathBuf,
+    /// `start/` packages load at startup; `opt/` packages wait to be activated.
+    pub eager: bool,
+    /// What the package's manifest asks for. A manually installed package is
+    /// granted this directly: the user placed the files.
+    pub requested: Requested,
+}
+
+/// Something the walk could not use, and the name it had for it.
+///
+/// One record and not two lists, because the name and the reason are two
+/// halves of one fact and the config layer needs the name: a `plugins.<name>`
+/// table naming a package that failed to load still names something real.
+#[derive(Debug)]
+pub struct Problem {
+    /// `None` when the failure belongs to no single package, such as a group
+    /// directory that could not be read at all.
+    pub name: Option<String>,
+    pub error: PluginError,
+}
+
+impl std::fmt::Display for Problem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.error)
+    }
+}
+
+/// What a discovery walk found, and what it had to refuse.
+///
+/// Problems are collected rather than returned as one error, because one
+/// unusable package must not stop the others from loading.
+#[derive(Debug, Default)]
+pub struct Discovery {
+    pub packages: Vec<DiscoveredPackage>,
+    pub problems: Vec<Problem>,
+}
+
+impl Discovery {
+    /// Records a package that was found but cannot load.
+    fn refuse(&mut self, name: String, error: PluginError) {
+        self.problems.push(Problem {
+            name: Some(name),
+            error,
+        });
+    }
+
+    /// Records a failure that names no package.
+    fn note(&mut self, error: PluginError) {
+        self.problems.push(Problem { name: None, error });
+    }
+
+    /// Every package name the walk saw, loadable or not.
+    ///
+    /// This is what a `plugins.<name>` table is validated against. Validating
+    /// against the loadable set instead would turn a package maki itself
+    /// refused into a config error, and blame the user's config for it.
+    pub fn known_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .packages
+            .iter()
+            .map(|package| package.name.clone())
+            .chain(self.problems.iter().filter_map(|p| p.name.clone()))
+            .collect();
+        names.sort();
+        names.dedup();
+        names
+    }
+}
+
+fn sorted_paths(dir: &Path, out: &mut Discovery) -> Vec<PathBuf> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(source) => {
+            out.note(PluginError::Io {
+                path: dir.to_path_buf(),
+                source,
+            });
+            return Vec::new();
+        }
+    };
+    let mut paths = Vec::new();
+    for entry in entries {
+        match entry {
+            Ok(entry) => paths.push(entry.path()),
+            Err(source) => out.note(PluginError::Io {
+                path: dir.to_path_buf(),
+                source,
+            }),
+        }
+    }
+    paths.sort();
+    paths
+}
+
+/// Discovers installed packages, or nothing when `--no-plugins` is set.
+pub fn discover_installed(no_plugins: bool) -> Discovery {
+    if no_plugins {
+        return Discovery::default();
+    }
+    // An unresolvable data directory is not the same fact as an empty one.
+    // Reported, because otherwise every installed package silently disappears.
+    let site = match site_dir() {
+        Ok(site) => site,
+        Err(source) => {
+            let mut out = Discovery::default();
+            out.note(PluginError::PackageSiteUnavailable { source });
+            return out;
+        }
+    };
+    discover(&site)
+}
+
+/// Finds every manually installed package under `site`.
+///
+/// Returns them in a deterministic order, so two machines with the same
+/// packages load them the same way. A missing site directory is not a problem;
+/// it just means no packages are installed.
+pub fn discover(site: &Path) -> Discovery {
+    let mut out = Discovery::default();
+    for group in sorted_paths(&site.join("pack"), &mut out) {
+        if group.file_name().and_then(|n| n.to_str()) == Some(MANAGED_GROUP) {
+            continue;
+        }
+        for (sub, eager) in [("start", true), ("opt", false)] {
+            for dir in sorted_paths(&group.join(sub), &mut out) {
+                let Some(name) = dir.file_name().and_then(|n| n.to_str()) else {
+                    continue;
+                };
+                if name.is_empty() || name.starts_with('.') {
+                    continue;
+                }
+                let name = name.to_owned();
+                let root = match dir.canonicalize() {
+                    Ok(root) => root,
+                    Err(source) => {
+                        // A package that cannot even be resolved is reported
+                        // rather than silently vanishing, since an unreadable
+                        // directory looks identical to one that is not there.
+                        out.refuse(name, PluginError::Io { path: dir, source });
+                        continue;
+                    }
+                };
+                if !root.is_dir() {
+                    continue;
+                }
+
+                if is_bundled(&name) {
+                    out.refuse(
+                        name.clone(),
+                        PluginError::PackageNameConflict { name, path: root },
+                    );
+                    continue;
+                }
+                let first = out
+                    .packages
+                    .iter()
+                    .find(|p| p.name == name)
+                    .map(|p| p.dir.clone());
+                if let Some(first) = first {
+                    out.refuse(
+                        name.clone(),
+                        PluginError::DuplicatePackage {
+                            name,
+                            first,
+                            second: root,
+                        },
+                    );
+                    continue;
+                }
+
+                let requested = match load_requested_permissions(&root) {
+                    Ok(requested) => requested,
+                    Err(problem) => {
+                        out.refuse(name, problem);
+                        continue;
+                    }
+                };
+                out.packages.push(DiscoveredPackage {
+                    name,
+                    dir: root,
+                    eager,
+                    requested,
+                });
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    use crate::error::PluginError;
+    use crate::plugin_permissions::Permission;
+
+    use super::{MANAGED_GROUP, Problem, discover, sanitize_message};
+
+    #[test]
+    fn terminal_messages_keep_layout_but_remove_control_characters() {
+        assert_eq!(
+            sanitize_message("package\u{1b}[31m\rname\nnext"),
+            "package [31m name\nnext"
+        );
+    }
+
+    fn make_package(site: &Path, group: &str, sub: &str, name: &str) -> PathBuf {
+        let dir = site.join("pack").join(group).join(sub).join(name);
+        fs::create_dir_all(dir.join("plugin")).unwrap();
+        fs::write(dir.join("plugin").join("init.lua"), "").unwrap();
+        dir
+    }
+
+    /// A package maki itself refused is still a name the user can write in
+    /// `plugins.<name>`. Validating a config against the loadable set alone
+    /// turned one bad manifest into a startup failure that blamed the config.
+    #[test]
+    fn a_package_that_cannot_be_read_is_still_a_known_name() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = make_package(tmp.path(), "vendor", "start", "broken");
+        fs::write(dir.join("plugin.toml"), "not = valid = toml").unwrap();
+
+        let found = discover(tmp.path());
+        assert!(found.packages.is_empty(), "the package must not load");
+        assert_eq!(found.problems.len(), 1, "and the reason must be reported");
+        assert_eq!(found.known_names(), vec!["broken".to_owned()]);
+    }
+
+    #[test]
+    fn missing_site_dir_is_not_a_problem() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let found = discover(&tmp.path().join("absent"));
+        assert!(found.packages.is_empty());
+        assert!(found.problems.is_empty());
+    }
+
+    #[test]
+    fn unreadable_package_root_is_reported() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pack = tmp.path().join("pack");
+        fs::write(&pack, "not a directory").unwrap();
+
+        let found = discover(tmp.path());
+
+        assert!(found.packages.is_empty());
+        assert!(matches!(
+            found.problems.as_slice(),
+            [Problem {
+                error: PluginError::Io { .. },
+                ..
+            }]
+        ));
+    }
+
+    #[test]
+    fn finds_start_and_opt_and_marks_eagerness() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "vendor", "start", "eager_one");
+        make_package(tmp.path(), "vendor", "opt", "lazy_one");
+
+        let found = discover(tmp.path());
+        assert_eq!(found.packages.len(), 2);
+
+        let eager = found
+            .packages
+            .iter()
+            .find(|p| p.name == "eager_one")
+            .unwrap();
+        let lazy = found
+            .packages
+            .iter()
+            .find(|p| p.name == "lazy_one")
+            .unwrap();
+        assert!(eager.eager, "start/ packages load at startup");
+        assert!(!lazy.eager, "opt/ packages wait to be activated");
+    }
+
+    /// Managed packages are resolved from recorded state, so finding them here
+    /// too would give one package two identities.
+    #[test]
+    fn managed_group_is_skipped() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), MANAGED_GROUP, "opt", "managed_one");
+        make_package(tmp.path(), "vendor", "start", "manual_one");
+
+        let names: Vec<String> = discover(tmp.path())
+            .packages
+            .into_iter()
+            .map(|p| p.name)
+            .collect();
+        assert_eq!(names, vec!["manual_one"]);
+    }
+
+    #[test]
+    fn bundled_name_collision_is_refused() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "vendor", "start", "bash");
+
+        let found = discover(tmp.path());
+        assert!(found.packages.is_empty());
+        assert!(matches!(
+            found.problems.as_slice(),
+            [Problem {
+                error: PluginError::PackageNameConflict { .. },
+                ..
+            }]
+        ));
+    }
+
+    /// `lib` is bundled without being enabled by default, so a name check
+    /// against the default set alone would let it through.
+    #[test]
+    fn non_default_bundled_name_is_also_refused() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "vendor", "start", "lib");
+
+        let found = discover(tmp.path());
+        assert!(found.packages.is_empty());
+        assert!(matches!(
+            found.problems.as_slice(),
+            [Problem {
+                error: PluginError::PackageNameConflict { .. },
+                ..
+            }]
+        ));
+    }
+
+    #[test]
+    fn duplicate_names_across_groups_are_refused() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "alpha", "start", "twice");
+        make_package(tmp.path(), "beta", "start", "twice");
+
+        let found = discover(tmp.path());
+        assert_eq!(found.packages.len(), 1, "the first one still loads");
+        assert!(matches!(
+            found.problems.as_slice(),
+            [Problem {
+                error: PluginError::DuplicatePackage { .. },
+                ..
+            }]
+        ));
+    }
+
+    /// One unusable package must not take the others down with it.
+    #[test]
+    fn a_refused_package_does_not_stop_the_others() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "vendor", "start", "bash");
+        make_package(tmp.path(), "vendor", "start", "fine_one");
+
+        let found = discover(tmp.path());
+        let names: Vec<&str> = found.packages.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["fine_one"]);
+        assert_eq!(found.problems.len(), 1);
+    }
+
+    #[test]
+    fn manifest_permissions_are_read_and_deny_by_default() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = make_package(tmp.path(), "vendor", "start", "asks");
+        fs::write(dir.join("plugin.toml"), "[permissions]\nnet = true\n").unwrap();
+
+        let found = discover(tmp.path());
+        let pkg = &found.packages[0];
+        assert!(pkg.requested.is_requested(Permission::Net));
+        assert!(!pkg.requested.is_requested(Permission::Run));
+    }
+
+    #[test]
+    fn package_without_manifest_requests_nothing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "vendor", "start", "silent");
+
+        let found = discover(tmp.path());
+        for perm in [
+            Permission::FsRead,
+            Permission::FsWrite,
+            Permission::Net,
+            Permission::Run,
+            Permission::Env,
+        ] {
+            assert!(!found.packages[0].requested.is_requested(perm));
+        }
+    }
+}

--- a/maki-lua/src/plugin_permissions.rs
+++ b/maki-lua/src/plugin_permissions.rs
@@ -115,6 +115,86 @@ impl PluginPermissions {
     }
 }
 
+/// What a package's `plugin.toml` asks for.
+///
+/// Deny by default: an omitted key is *not requested*. That is the opposite of
+/// [`PluginPermissions::from_manifest`], which stays permissive for a local
+/// `init.lua` the user wrote themselves. The two parsers are separate because
+/// the inputs differ in trust, not in shape: a package manifest arrives with
+/// downloaded code and must not be able to widen its own access.
+///
+/// This is a distinct type so an effective grant can never be built by
+/// accident from a request alone.
+#[derive(Debug, Clone)]
+pub struct Requested(PluginPermissions);
+
+impl Requested {
+    pub fn none() -> Self {
+        Self(PluginPermissions::denied())
+    }
+
+    pub fn from_manifest(manifest: &toml::Value) -> Self {
+        let perms = manifest.get("permissions");
+        let mut allowed = [false; 5];
+        for perm in Permission::ALL {
+            allowed[perm as usize] = perms
+                .and_then(|p| p.get(perm.manifest_key()))
+                .and_then(toml::Value::as_bool)
+                .unwrap_or(false);
+        }
+        Self(PluginPermissions { allowed })
+    }
+
+    pub fn is_requested(&self, perm: Permission) -> bool {
+        self.0.is_allowed(perm)
+    }
+
+    /// A package the user installed by hand gets what it asks for. They placed
+    /// the files, which is the same trust already given to a local `init.lua`.
+    /// Only a package maki fetched has to be intersected with an approval.
+    pub fn granted_for_manual_install(self) -> PluginPermissions {
+        self.0
+    }
+
+    /// Effective permissions for a managed package: the request and the user's
+    /// approval must agree.
+    pub fn intersect(&self, approved: &PluginPermissions) -> PluginPermissions {
+        let mut out = PluginPermissions::denied();
+        for perm in Permission::ALL {
+            out.set(perm, self.0.is_allowed(perm) && approved.is_allowed(perm));
+        }
+        out
+    }
+}
+
+/// Reads a package's requested permissions.
+///
+/// Only an absent manifest means "requests nothing". A manifest that exists but
+/// cannot be read or parsed is an error, because silently treating it as empty
+/// would load the package and then fail every guarded call it makes, which
+/// reports the typo as a permission problem instead of a syntax one.
+pub(crate) fn load_requested_permissions(
+    plugin_dir: &Path,
+) -> Result<Requested, crate::error::PluginError> {
+    let manifest_path = plugin_dir.join(MANIFEST_FILE);
+    let content = match std::fs::read_to_string(&manifest_path) {
+        Ok(content) => content,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Requested::none()),
+        Err(source) => {
+            return Err(crate::error::PluginError::Io {
+                path: manifest_path,
+                source,
+            });
+        }
+    };
+    toml::from_str::<toml::Value>(&content)
+        .map(|value| Requested::from_manifest(&value))
+        .map_err(|e| crate::error::PluginError::PackageManifest {
+            path: manifest_path,
+            message: e.to_string(),
+        })
+}
+
 fn denied_error(perm: Permission) -> LuaError {
     let msg = format!(
         "permission denied: '{perm}' not granted for this plugin (grant it in {MANIFEST_FILE} next to the plugin file)"
@@ -227,6 +307,77 @@ mod tests {
             .unwrap();
         let result: i32 = func.call(()).unwrap();
         assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn requested_denies_omitted_keys() {
+        let val: toml::Value = toml::from_str(
+            r#"
+            [permissions]
+            net = true
+            "#,
+        )
+        .unwrap();
+        let req = Requested::from_manifest(&val);
+        assert!(req.is_requested(Permission::Net));
+        for perm in Permission::ALL {
+            if perm != Permission::Net {
+                assert!(!req.is_requested(perm), "{perm} must not be requested");
+            }
+        }
+    }
+
+    /// The legacy parser stays permissive; only the package parser is strict.
+    /// A manifest with no `[permissions]` section proves the two differ.
+    #[test]
+    fn requested_and_legacy_parsers_disagree_by_design() {
+        let val: toml::Value = toml::from_str("[package]\nname = \"p\"").unwrap();
+        let legacy = PluginPermissions::from_manifest(&val);
+        let requested = Requested::from_manifest(&val);
+        for perm in Permission::ALL {
+            assert!(legacy.is_allowed(perm), "legacy stays permissive");
+            assert!(!requested.is_requested(perm), "package requests nothing");
+        }
+    }
+
+    #[test]
+    fn intersect_needs_both_request_and_approval() {
+        let val: toml::Value = toml::from_str(
+            r#"
+            [permissions]
+            net = true
+            run = true
+            "#,
+        )
+        .unwrap();
+        let requested = Requested::from_manifest(&val);
+
+        let mut approved = PluginPermissions::denied();
+        approved.set(Permission::Net, true);
+        approved.set(Permission::FsRead, true);
+
+        let effective = requested.intersect(&approved);
+        assert!(
+            effective.is_allowed(Permission::Net),
+            "requested + approved"
+        );
+        assert!(!effective.is_allowed(Permission::Run), "not approved");
+        assert!(!effective.is_allowed(Permission::FsRead), "not requested");
+        assert!(!effective.is_allowed(Permission::Env), "neither");
+    }
+
+    #[test]
+    fn manual_install_grants_what_it_requests() {
+        let val: toml::Value = toml::from_str(
+            r#"
+            [permissions]
+            fs_read = true
+            "#,
+        )
+        .unwrap();
+        let granted = Requested::from_manifest(&val).granted_for_manual_install();
+        assert!(granted.is_allowed(Permission::FsRead));
+        assert!(!granted.is_allowed(Permission::Net));
     }
 
     #[test]

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::ffi::c_int;
 use std::future::Future;
 use std::panic::catch_unwind;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::ptr;
 use std::rc::Rc;
@@ -116,15 +116,49 @@ pub(crate) struct PromptHintRegistration {
 
 pub(crate) type PromptHintCallbacks = BTreeMap<Arc<str>, Vec<PromptHintRegistration>>;
 
+/// One source file of a plugin.
+///
+/// A bundled plugin has exactly one. An external package has one per
+/// `plugin/*.lua`, and they share a single owner and a single environment, so
+/// what one registers the next can see.
+#[derive(Debug)]
+pub struct LoadChunk {
+    /// Names the chunk in Lua errors, so a failure points at the file the user
+    /// wrote rather than at the package.
+    pub name: String,
+    pub source: String,
+}
+
+impl LoadChunk {
+    pub fn new(name: impl Into<String>, source: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            source: source.into(),
+        }
+    }
+}
+
 /// Load/clear drain in-flight tools first so we never mutate a
 /// plugin environment while a tool call is still running.
 pub enum Request {
     /// Plugins are loaded, so native codegen may start using idle time. Sent
     /// last so it never interleaves with the loads themselves.
     WarmJit,
+    /// Takes the package operations Lua recorded, leaving the queue empty.
+    TakePackOps {
+        reply: flume::Sender<Vec<crate::api::pack::PackOp>>,
+    },
+    /// Closes the queue and hands over whatever is still in it.
+    ///
+    /// Both halves in one message on purpose: a Lua task can record an
+    /// activation between a read and a separate close, and closing without
+    /// taking would strand it in a queue nobody reads again.
+    SealPackOps {
+        reply: flume::Sender<Vec<crate::api::pack::PackOp>>,
+    },
     LoadSource {
         name: Arc<str>,
-        source: String,
+        chunks: Vec<LoadChunk>,
         plugin_dir: Option<PathBuf>,
         permissions: PluginPermissions,
         opts: PluginOpts,
@@ -550,9 +584,78 @@ fn queue_codegen(queue: &CodegenQueue, func: &Function) {
     }
 }
 
+fn module_io_error(modname: &str, path: &Path, error: &std::io::Error) -> mlua::Error {
+    mlua::Error::runtime(format!(
+        "require '{modname}': cannot read {}: {error}",
+        path.display()
+    ))
+}
+
+fn sandbox_escape(modname: &str) -> mlua::Error {
+    mlua::Error::runtime(format!("require: '{modname}' outside sandbox"))
+}
+
+/// The directory `require` searches, or `None` when there is nothing safe to
+/// search.
+///
+/// Resolving `lua/` is not enough on its own: if `lua` is itself a symlink out
+/// of the package, its target becomes the sandbox root and everything beneath
+/// that target passes the containment check. So the resolved root must still be
+/// inside the resolved package directory. A package with no `lua/` simply has
+/// no module root, which is not an error.
+enum RequireRoot {
+    Trusted(PathBuf),
+    Sandboxed(PathBuf),
+}
+
+impl RequireRoot {
+    fn path(&self) -> &Path {
+        match self {
+            Self::Trusted(path) | Self::Sandboxed(path) => path,
+        }
+    }
+
+    fn canonicalize(self) -> Self {
+        match self {
+            Self::Trusted(path) => {
+                let resolved = path.canonicalize().unwrap_or(path);
+                Self::Trusted(resolved)
+            }
+            Self::Sandboxed(path) => {
+                let resolved = path.canonicalize().unwrap_or(path);
+                Self::Sandboxed(resolved)
+            }
+        }
+    }
+
+    fn is_sandboxed(&self) -> bool {
+        matches!(self, Self::Sandboxed(_))
+    }
+}
+
+fn resolve_require_root(plugin_dir: &Path) -> Option<RequireRoot> {
+    let lua_dir = plugin_dir.join("lua");
+    let Ok(resolved) = lua_dir.canonicalize() else {
+        return None;
+    };
+    let root = plugin_dir
+        .canonicalize()
+        .unwrap_or_else(|_| plugin_dir.to_path_buf());
+    if resolved.starts_with(&root) {
+        Some(RequireRoot::Sandboxed(resolved))
+    } else {
+        tracing::warn!(
+            plugin_dir = %plugin_dir.display(),
+            resolved = %resolved.display(),
+            "lua directory resolves outside its package; modules will not load"
+        );
+        None
+    }
+}
+
 struct ModuleLoader {
     bundled: BundledModules,
-    lua_dir: Option<PathBuf>,
+    require_root: Option<RequireRoot>,
     env: Table,
     codegen: CodegenQueue,
     loaded: Table,
@@ -563,9 +666,10 @@ impl ModuleLoader {
     /// Bundled modules are tried first, so a plugin cannot shadow
     /// `maki.truncate` and friends with a file of its own.
     fn plugin_source(&self, rel_path: &str, modname: &str) -> Result<Option<String>, mlua::Error> {
-        let Some(dir) = self.lua_dir.as_ref() else {
+        let Some(root) = self.require_root.as_ref() else {
             return Ok(None);
         };
+        let dir = root.path();
         let normalized = dir
             .join(rel_path)
             .components()
@@ -580,11 +684,28 @@ impl ModuleLoader {
                 acc
             });
         if !normalized.starts_with(dir) {
-            return Err(mlua::Error::runtime(format!(
-                "require: '{modname}' outside sandbox"
-            )));
+            return Err(sandbox_escape(modname));
         }
-        Ok(std::fs::read_to_string(&normalized).ok())
+        // External packages are downloaded, and git carries symlinks, so the
+        // lexical fold above is not enough: a link inside the package can still
+        // point out of it. Resolve the real path and re-check.
+        //
+        // Only an absent file is a miss. An unreadable one, a symlink loop, or
+        // a file that is not UTF-8 is reported, because reporting it as
+        // "module not found" sends the user looking for a name they can see.
+        let resolved = match std::fs::canonicalize(&normalized) {
+            Ok(resolved) => resolved,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(module_io_error(modname, &normalized, &e)),
+        };
+        if root.is_sandboxed() && !resolved.starts_with(dir) {
+            return Err(sandbox_escape(modname));
+        }
+        match std::fs::read_to_string(&resolved) {
+            Ok(source) => Ok(Some(source)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(module_io_error(modname, &resolved, &e)),
+        }
     }
 
     fn bind(&self, chunk: Chunk<'_>, modname: &str) -> Result<Function, mlua::Error> {
@@ -597,22 +718,38 @@ impl ModuleLoader {
     /// Bundled modules load as bytecode from the shared cache. Plugin files
     /// load as source, so Luau reports syntax errors against the file the user
     /// wrote.
+    ///
+    /// Both forms Neovim accepts are tried, `<mod>.lua` before
+    /// `<mod>/init.lua`. Every bundled candidate is tried before any plugin
+    /// file, so a package still cannot shadow a bundled module.
     fn load(&self, lua: &Lua, modname: &str) -> Result<LuaValue, mlua::Error> {
-        let rel_path = modname.replace('.', "/") + ".lua";
-        let func = match self.bundled.bytecode(&rel_path)? {
-            Some(bytecode) => self.bind(
-                lua.load(bytecode.as_slice()).set_mode(ChunkMode::Binary),
-                modname,
-            )?,
-            None => {
-                let Some(source) = self.plugin_source(&rel_path, modname)? else {
-                    return Err(mlua::Error::runtime(format!(
-                        "require '{modname}': module not found"
-                    )));
-                };
-                self.bind(lua.load(source.as_str()), modname)?
+        let base = modname.replace('.', "/");
+        let candidates = [format!("{base}.lua"), format!("{base}/init.lua")];
+
+        let mut func = None;
+        for rel_path in &candidates {
+            if let Some(bytecode) = self.bundled.bytecode(rel_path)? {
+                func = Some(self.bind(
+                    lua.load(bytecode.as_slice()).set_mode(ChunkMode::Binary),
+                    modname,
+                )?);
+                break;
             }
+        }
+        if func.is_none() {
+            for rel_path in &candidates {
+                if let Some(source) = self.plugin_source(rel_path, modname)? {
+                    func = Some(self.bind(lua.load(source.as_str()), modname)?);
+                    break;
+                }
+            }
+        }
+        let Some(func) = func else {
+            return Err(mlua::Error::runtime(format!(
+                "require '{modname}': module not found"
+            )));
         };
+
         queue_codegen(&self.codegen, &func);
         func.call(())
     }
@@ -1405,6 +1542,7 @@ impl LuaRuntime {
         })?;
 
         lua.set_app_data(CommandHandlerMap::new());
+        lua.set_app_data(crate::api::pack::PackStore::default());
         lua.set_app_data(JobStore::new());
         lua.set_app_data(SpawnQueue::new());
         lua.set_app_data(command_writer);
@@ -1676,7 +1814,7 @@ impl LuaRuntime {
     fn build_env(
         &self,
         maki: mlua::Table,
-        require_root: Option<PathBuf>,
+        require_root: Option<RequireRoot>,
     ) -> Result<mlua::Table, mlua::Error> {
         let env = self.lua.create_table()?;
         env.set("maki", maki)?;
@@ -1697,11 +1835,11 @@ impl LuaRuntime {
     fn create_require_fn(
         &self,
         env: &mlua::Table,
-        require_root: Option<PathBuf>,
+        require_root: Option<RequireRoot>,
     ) -> Result<Function, mlua::Error> {
         let loader = ModuleLoader {
             bundled: self.bundled.clone(),
-            lua_dir: require_root.map(|r| r.canonicalize().unwrap_or(r)),
+            require_root: require_root.map(RequireRoot::canonicalize),
             env: env.clone(),
             codegen: self.codegen_queue.clone(),
             loaded: self.lua.create_table()?,
@@ -1731,10 +1869,27 @@ impl LuaRuntime {
         )))
     }
 
+    fn pack_ops_checkpoint(&self) -> usize {
+        self.lua
+            .app_data_ref::<crate::api::pack::PackStore>()
+            .map(|store| store.lock().expect("pack declarations").pending.len())
+            .unwrap_or_default()
+    }
+
+    fn rollback_pack_ops(&self, checkpoint: usize) {
+        if let Some(store) = self.lua.app_data_ref::<crate::api::pack::PackStore>() {
+            store
+                .lock()
+                .expect("pack declarations")
+                .pending
+                .truncate(checkpoint);
+        }
+    }
+
     async fn load_source(
         &mut self,
         name: Arc<str>,
-        source: &str,
+        chunks: &[LoadChunk],
         plugin_dir: Option<PathBuf>,
         permissions: &PluginPermissions,
         opts: PluginOpts,
@@ -1755,8 +1910,12 @@ impl LuaRuntime {
         // Scoped to this load so a failed load simply drops its rules; only a
         // successful load commits them to the store.
         let pending_rules: PendingRules = Arc::default();
+        let pack_ops_checkpoint = self.pack_ops_checkpoint();
 
-        let require_root = plugin_dir.as_ref().map(|d| d.join("lua"));
+        let require_root = plugin_dir.as_ref().and_then(|dir| match config_store {
+            Some(_) => Some(RequireRoot::Trusted(dir.join("lua"))),
+            None => resolve_require_root(dir),
+        });
         let maki = create_maki_global(
             &self.lua,
             Arc::clone(&self.pending),
@@ -1773,30 +1932,40 @@ impl LuaRuntime {
                 .map_err(&map_err)?;
             maki.set("setup", setup_fn).map_err(&map_err)?;
         }
-
         let env = self.build_env(maki, require_root).map_err(&map_err)?;
 
         self.drop_plugin_keys(&name);
 
-        let main_fn = self
-            .lua
-            .load(source)
-            .set_name(name.as_ref())
-            .set_environment(env)
-            .into_function();
-        let exec_result = match main_fn {
-            Ok(func) => {
-                queue_codegen(&self.codegen_queue, &func);
-                func.call_async::<()>(()).await
+        // Chunks run in order against one environment, so a later file sees
+        // what an earlier one registered. The first failure stops the rest.
+        let mut exec_result = Ok(());
+        for chunk in chunks {
+            let main_fn = self
+                .lua
+                .load(chunk.source.as_str())
+                .set_name(chunk.name.as_str())
+                .set_environment(env.clone())
+                .into_function();
+            exec_result = match main_fn {
+                Ok(func) => {
+                    queue_codegen(&self.codegen_queue, &func);
+                    func.call_async::<()>(()).await
+                }
+                Err(e) => Err(e),
+            };
+            if exec_result.is_err() {
+                break;
             }
-            Err(e) => Err(e),
-        };
+        }
 
+        // Checked once, after the last chunk: an option that a later chunk
+        // reads must not be reported as unused by an earlier one.
         let exec_result = exec_result.and_then(|()| self.check_opts_consumed(&name, &opts));
         if let Err(e) = exec_result {
             let stale = self.drain_pending();
             self.discard_pending(stale);
-            self.drop_plugin_keys(&name);
+            self.rollback_pack_ops(pack_ops_checkpoint);
+            self.clear_plugin(&name);
             return Err(map_err(e));
         }
 
@@ -1836,6 +2005,11 @@ impl LuaRuntime {
 
         if let Err(e) = self.registry.replace_plugin(&name, registry_entries) {
             self.discard_pending(pending);
+            self.rollback_pack_ops(pack_ops_checkpoint);
+            // The chunks already published commands, keymaps, hints, and slots
+            // before we got here, so a conflict at the commit point has to
+            // unwind them too, not just drop the pending tools.
+            self.clear_plugin(&name);
             return Err(match e {
                 RegistryError::NameConflict { name: n, .. } => PluginError::NameConflict {
                     plugin: name.to_string(),
@@ -1950,7 +2124,7 @@ impl LuaRuntime {
         let perms = load_plugin_permissions(plugin_dir.as_deref());
         self.load_source(
             Arc::from(source_name),
-            source,
+            &[LoadChunk::new(source_name, source)],
             plugin_dir,
             &perms,
             PluginOpts::default(),
@@ -2648,14 +2822,14 @@ pub fn spawn(
                         Request::WarmJit => codegen_armed = true,
                         Request::LoadSource {
                             name,
-                            source,
+                            chunks,
                             plugin_dir,
                             permissions,
                             opts,
                             reply,
                         } => {
                             drain_barrier(&rt.lua, &ex, &gate, &spawn_rx).await;
-                            let res = rt.load_source(Arc::clone(&name), &source, plugin_dir, &permissions, opts, None).await;
+                            let res = rt.load_source(Arc::clone(&name), &chunks, plugin_dir, &permissions, opts, None).await;
                             let _ = reply.send(res);
                         }
                         Request::CallTool {
@@ -2692,6 +2866,31 @@ pub fn spawn(
                                 let _ = reply.send(res);
                             })
                             .detach();
+                        }
+                        Request::TakePackOps { reply } => {
+                            let ops = rt
+                                .lua
+                                .app_data_ref::<crate::api::pack::PackStore>()
+                                .map(|store| {
+                                    std::mem::take(
+                                        &mut store.lock().expect("pack declarations").pending,
+                                    )
+                                })
+                                .unwrap_or_default();
+                            let _ = reply.send(ops);
+                        }
+                        Request::SealPackOps { reply } => {
+                            let ops = rt
+                                .lua
+                                .app_data_ref::<crate::api::pack::PackStore>()
+                                .map(|store| {
+                                    let mut declarations =
+                                        store.lock().expect("pack declarations");
+                                    declarations.drained = true;
+                                    std::mem::take(&mut declarations.pending)
+                                })
+                                .unwrap_or_default();
+                            let _ = reply.send(ops);
                         }
                         Request::ClearPlugin { plugin, reply } => {
                             drain_barrier(&rt.lua, &ex, &gate, &spawn_rx).await;

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -1097,6 +1097,127 @@ fn require_sandbox_escape_blocked() {
     );
 }
 
+/// Neovim resolves `lua/foo/init.lua` as well as `lua/foo.lua`, and an
+/// external package laid out the Neovim way relies on it.
+#[test]
+fn require_resolves_directory_init_form() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mod_dir = tmp.path().join("lua").join("pkg");
+    std::fs::create_dir_all(&mod_dir).unwrap();
+
+    std::fs::write(mod_dir.join("init.lua"), "return { value = 7 }\n").unwrap();
+
+    std::fs::write(
+        tmp.path().join("init.lua"),
+        r#"
+local pkg = require("pkg")
+assert(pkg.value == 7, "expected lua/pkg/init.lua to resolve")
+"#,
+    )
+    .unwrap();
+
+    let init_path = tmp.path().join("init.lua");
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_plugin_file(&init_path).unwrap();
+}
+
+/// `<mod>.lua` wins over `<mod>/init.lua`, matching Neovim's order.
+#[test]
+fn require_prefers_flat_module_over_directory_init() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let lua_dir = tmp.path().join("lua");
+    std::fs::create_dir_all(lua_dir.join("pkg")).unwrap();
+
+    std::fs::write(lua_dir.join("pkg.lua"), "return { which = \"flat\" }\n").unwrap();
+    std::fs::write(
+        lua_dir.join("pkg").join("init.lua"),
+        "return { which = \"dir\" }\n",
+    )
+    .unwrap();
+
+    std::fs::write(
+        tmp.path().join("init.lua"),
+        r#"
+local pkg = require("pkg")
+assert(pkg.which == "flat", "expected pkg.lua to win, got " .. tostring(pkg.which))
+"#,
+    )
+    .unwrap();
+
+    let init_path = tmp.path().join("init.lua");
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_plugin_file(&init_path).unwrap();
+}
+
+/// A git repository can commit a symlink, so the lexical `..` check is not
+/// enough on its own: the resolved path has to be re-checked.
+#[cfg(unix)]
+#[test]
+fn require_symlink_out_of_package_blocked() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let lua_dir = tmp.path().join("lua");
+    std::fs::create_dir_all(&lua_dir).unwrap();
+
+    let outside = tmp.path().join("outside.lua");
+    std::fs::write(&outside, "return { secret = true }\n").unwrap();
+    std::os::unix::fs::symlink(&outside, lua_dir.join("leak.lua")).unwrap();
+
+    std::fs::write(tmp.path().join("init.lua"), "require(\"leak\")\n").unwrap();
+
+    let init_path = tmp.path().join("init.lua");
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_plugin_file(&init_path)
+        .expect_err("symlink pointing out of the package must not load");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("sandbox") || msg.contains("outside"),
+        "got: {msg}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn global_init_can_require_a_symlinked_module() {
+    let config = tempfile::TempDir::new().unwrap();
+    let modules = config.path().join("lua");
+    std::fs::create_dir_all(&modules).unwrap();
+    let elsewhere = tempfile::TempDir::new().unwrap();
+    let target = elsewhere.path().join("shared.lua");
+    std::fs::write(&target, "return { value = 42 }\n").unwrap();
+    std::os::unix::fs::symlink(&target, modules.join("shared.lua")).unwrap();
+
+    let host = PluginHost::new(fresh_registry()).unwrap();
+    let _ = host
+        .send_run_init_lua(
+            "assert(require('shared').value == 42)".to_owned(),
+            "global/init.lua".to_owned(),
+            Some(config.path().to_path_buf()),
+        )
+        .unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn global_init_can_use_a_symlinked_lua_directory() {
+    let config = tempfile::TempDir::new().unwrap();
+    let elsewhere = tempfile::TempDir::new().unwrap();
+    std::fs::write(elsewhere.path().join("shared.lua"), "return true\n").unwrap();
+    std::os::unix::fs::symlink(elsewhere.path(), config.path().join("lua")).unwrap();
+
+    let host = PluginHost::new(fresh_registry()).unwrap();
+    let _ = host
+        .send_run_init_lua(
+            "assert(require('shared'))".to_owned(),
+            "global/init.lua".to_owned(),
+            Some(config.path().to_path_buf()),
+        )
+        .unwrap();
+}
+
 #[test]
 fn require_circular_returns_sentinel_and_caches_real_value() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -2449,6 +2570,7 @@ fn edit_sub_tools_follow_edit_opts(opts: serde_json::Value, on: &[&str], off: &[
     let config = PluginsConfig {
         enabled: true,
         names: vec!["edit".to_owned()],
+        packages: Vec::new(),
         opts: HashMap::from([("edit".to_owned(), json_obj(opts))]),
     };
     host.load_builtins(&config).unwrap();
@@ -2474,23 +2596,26 @@ fn undeclared_opts_fail_the_load() {
     assert!(err.to_string().contains(UNDECLARED_OPTS_ERR), "got: {err}");
 }
 
+/// A disabled package keeps its options in `opts` but leaves `packages`, which
+/// is exactly the shape `into_config` produces. Treating that as an unknown
+/// name stopped maki from booting over options it was already ignoring, and
+/// only for packages: a disabled builtin in the same state just warned.
 #[test]
-fn opts_for_unknown_plugin_fail_load_builtins() {
+fn opts_for_a_disabled_package_do_not_stop_the_load() {
     let reg = fresh_registry();
     let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    let mut config = PluginsConfig::from_plugins(HashMap::new());
-    config.opts.insert(
-        "bsah".to_owned(),
-        json_obj(serde_json::json!({ "timeout_secs": 5 })),
-    );
-    let err = host
-        .load_builtins(&config)
-        .expect_err("load_builtins should fail");
-    assert!(
-        err.to_string()
-            .contains("plugins.bsah sets options (timeout_secs)"),
-        "got: {err}"
-    );
+    let config = PluginsConfig {
+        enabled: true,
+        names: vec!["grep".to_owned()],
+        packages: Vec::new(),
+        opts: HashMap::from([(
+            "my_pack".to_owned(),
+            json_obj(serde_json::json!({ "timeout_secs": 5 })),
+        )]),
+    };
+    host.load_builtins(&config)
+        .expect("a disabled package must not stop the builtins from loading");
+    assert!(reg.get("grep").is_some(), "enabled plugin still loads");
 }
 
 #[test]
@@ -2515,6 +2640,7 @@ fn disabled_plugin_opts_are_ignored_not_rejected() {
     let config = PluginsConfig {
         enabled: true,
         names: vec!["grep".to_owned()],
+        packages: Vec::new(),
         opts: HashMap::from([(
             "bash".to_owned(),
             json_obj(serde_json::json!({ "timeout_secs": 180 })),
@@ -2729,6 +2855,582 @@ fn reload_replaces_commands() {
     let snap = host.command_reader().load();
     assert_eq!(snap.commands.len(), 1);
     assert_eq!(snap.commands[0].name.as_ref(), "/v2");
+}
+
+/// Builds a package directory with the given `plugin/*.lua` files.
+fn package_dir(files: &[(&str, &str)]) -> tempfile::TempDir {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let plugin_dir = tmp.path().join("plugin");
+    std::fs::create_dir_all(&plugin_dir).unwrap();
+    for (name, source) in files {
+        std::fs::write(plugin_dir.join(name), source).unwrap();
+    }
+    tmp
+}
+
+#[test]
+fn package_loads_every_entrypoint_under_one_owner() {
+    let pkg = package_dir(&[
+        (
+            "01_first.lua",
+            r#"maki.api.register_command({ name = "/one", handler = function() end })"#,
+        ),
+        (
+            "02_second.lua",
+            r#"maki.api.register_command({ name = "/two", handler = function() end })"#,
+        ),
+    ]);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_package(
+        "demo",
+        pkg.path(),
+        maki_lua::PluginPermissions::trusted(),
+        Default::default(),
+    )
+    .unwrap();
+
+    let snap = host.command_reader().load();
+    let mut names: Vec<&str> = snap.commands.iter().map(|c| c.name.as_ref()).collect();
+    names.sort();
+    assert_eq!(names, vec!["/one", "/two"]);
+    assert!(
+        snap.commands.iter().all(|c| c.plugin.as_ref() == "demo"),
+        "every entrypoint must register under the package owner"
+    );
+}
+
+/// One environment across the chunks, so an earlier file can set something up
+/// for a later one. This is why the chunks are not separate loads.
+#[test]
+fn package_entrypoints_share_one_environment() {
+    let pkg = package_dir(&[
+        ("01_first.lua", "shared_value = 11\n"),
+        (
+            "02_second.lua",
+            r#"
+assert(shared_value == 11, "second chunk should see the first chunk's global")
+maki.api.register_command({ name = "/ok", handler = function() end })
+"#,
+        ),
+    ]);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_package(
+        "shared",
+        pkg.path(),
+        maki_lua::PluginPermissions::trusted(),
+        Default::default(),
+    )
+    .unwrap();
+    assert_eq!(host.command_reader().load().commands.len(), 1);
+}
+
+/// A package commits or it does not. `drop_plugin_keys` alone would leave the
+/// keymap and the hint behind, so this is what proves the stronger unwind.
+#[test]
+fn package_failure_leaves_nothing_from_earlier_chunks() {
+    let pkg = package_dir(&[
+        (
+            "01_first.lua",
+            r#"
+maki.api.register_command({ name = "/ghost", handler = function() end })
+maki.keymap.set("n", "<C-g>", function() end, { desc = "ghost" })
+maki.api.register_tool({
+  name = "ghost_tool",
+  description = "should not survive",
+  schema = { type = "object", properties = {} },
+  handler = function() return "x" end,
+})
+"#,
+        ),
+        ("02_second.lua", r#"error("boom")"#),
+    ]);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_package(
+            "ghost",
+            pkg.path(),
+            maki_lua::PluginPermissions::trusted(),
+            Default::default(),
+        )
+        .expect_err("a failing chunk must fail the whole package");
+    assert!(err.to_string().contains("boom"), "got: {err}");
+
+    assert_eq!(
+        host.command_reader().load().commands.len(),
+        0,
+        "command from the first chunk survived a failed load"
+    );
+    assert_eq!(
+        host.keymap_reader().load().entries.len(),
+        0,
+        "keymap from the first chunk survived a failed load"
+    );
+    assert!(
+        !reg.has("ghost_tool"),
+        "tool from the first chunk survived a failed load"
+    );
+}
+
+#[test]
+fn package_failure_discards_its_packadd_requests() {
+    let site = site_with_two(
+        (
+            "broken_pack",
+            "maki.packadd('lazy_pack')\nerror('stop this package')",
+        ),
+        (
+            "lazy_pack",
+            r#"maki.api.register_command({ name = "/lazy", handler = function() end })"#,
+        ),
+    );
+    let found = maki_lua::discover(site.path());
+    let (_, config) = discovered_config(&found);
+
+    let host = PluginHost::new(fresh_registry()).unwrap();
+    let failures = host.load_packages(&found.packages, &config);
+
+    assert_eq!(failures.len(), 1, "got: {failures:?}");
+    assert!(
+        host.command_reader().load().commands.is_empty(),
+        "a failed package must not activate another package"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn package_entrypoint_symlink_escape_blocked() {
+    let pkg = package_dir(&[]);
+    // Deliberately in a different directory tree, so the link really leaves
+    // the package rather than pointing at a sibling inside it.
+    let elsewhere = tempfile::TempDir::new().unwrap();
+    let outside = elsewhere.path().join("outside.lua");
+    std::fs::write(&outside, "return {}\n").unwrap();
+    std::os::unix::fs::symlink(&outside, pkg.path().join("plugin").join("leak.lua")).unwrap();
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_package(
+            "leaky",
+            pkg.path(),
+            maki_lua::PluginPermissions::trusted(),
+            Default::default(),
+        )
+        .expect_err("an entrypoint linking out of the package must not load");
+    assert!(
+        matches!(err, PluginError::PackageEscape { .. }),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn package_without_entrypoints_errors() {
+    let pkg = package_dir(&[]);
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_package(
+            "empty",
+            pkg.path(),
+            maki_lua::PluginPermissions::trusted(),
+            Default::default(),
+        )
+        .expect_err("a package with no entrypoint is a configuration error");
+    assert!(
+        matches!(err, PluginError::PackageEmpty { .. }),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn unreadable_entrypoint_directory_is_reported() {
+    let pkg = tempfile::TempDir::new().unwrap();
+    std::fs::write(pkg.path().join("plugin"), "not a directory").unwrap();
+    let host = PluginHost::new(fresh_registry()).unwrap();
+
+    let err = host
+        .load_package(
+            "unreadable",
+            pkg.path(),
+            maki_lua::PluginPermissions::trusted(),
+            Default::default(),
+        )
+        .expect_err("an unreadable entrypoint directory must not look empty");
+
+    assert!(matches!(err, PluginError::Io { .. }), "got: {err}");
+}
+
+/// Builds a site tree holding one package, the way a user cloning a repository
+/// into the package directory would.
+fn site_with_package(sub: &str, name: &str, files: &[(&str, &str)]) -> tempfile::TempDir {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let dir = tmp.path().join("pack").join("vendor").join(sub).join(name);
+    std::fs::create_dir_all(dir.join("plugin")).unwrap();
+    for (file, source) in files {
+        std::fs::write(dir.join("plugin").join(file), source).unwrap();
+    }
+    tmp
+}
+
+/// The whole layer-1 path: find a package on disk, then load it.
+#[test]
+fn discovered_start_package_is_found_and_loaded() {
+    let site = site_with_package(
+        "start",
+        "demo_pack",
+        &[(
+            "init.lua",
+            r#"maki.api.register_command({ name = "/demo", handler = function() end })"#,
+        )],
+    );
+
+    let found = maki_lua::discover(site.path());
+    assert!(found.problems.is_empty(), "{:?}", found.problems);
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    let snap = host.command_reader().load();
+    assert_eq!(snap.commands.len(), 1);
+    assert_eq!(snap.commands[0].name.as_ref(), "/demo");
+    assert_eq!(snap.commands[0].plugin.as_ref(), "demo_pack");
+}
+
+/// Builtins must still load when a package is installed. Packages once shared
+/// the builtin name list, which made `load_builtins` reject every one of them
+/// by name and fail startup outright.
+#[test]
+fn installed_package_does_not_break_builtin_loading() {
+    let site = site_with_package(
+        "start",
+        "demo_pack",
+        &[(
+            "init.lua",
+            r#"maki.api.register_command({ name = "/demo", handler = function() end })"#,
+        )],
+    );
+
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+
+    let reg = fresh_registry();
+    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_builtins(&config)
+        .expect("an installed package must not stop the builtins from loading");
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    assert!(reg.has("grep"), "builtin tools should still be registered");
+    let names: Vec<String> = host
+        .command_reader()
+        .load()
+        .commands
+        .iter()
+        .map(|c| c.name.to_string())
+        .collect();
+    assert!(names.iter().any(|n| n == "/demo"), "got: {names:?}");
+}
+
+/// Options for an installed package must reach the package, not be rejected as
+/// options for a plugin that does not exist.
+#[test]
+fn installed_package_may_take_options() {
+    let site = site_with_package(
+        "start",
+        "opt_pack",
+        &[(
+            "init.lua",
+            r#"
+local opts = maki.api.register_options({
+  depth = { type = "integer", desc = "Depth." },
+})
+if opts.depth == 3 then
+  maki.api.register_command({ name = "/depth", handler = function() end })
+end
+"#,
+        )],
+    );
+    let found = maki_lua::discover(site.path());
+
+    let mut plugins: HashMap<String, maki_config::PluginFileConfig> = HashMap::new();
+    let mut cfg = maki_config::PluginFileConfig::default();
+    cfg.opts.insert("depth".to_owned(), serde_json::json!(3));
+    plugins.insert("opt_pack".to_owned(), cfg);
+
+    let config = PluginsConfig::from_plugins_and_packages(plugins, &["opt_pack".to_owned()]);
+
+    let reg = fresh_registry();
+    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_builtins(&config)
+        .expect("package options must not be rejected as unknown plugin options");
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    assert!(
+        host.command_reader()
+            .load()
+            .commands
+            .iter()
+            .any(|command| command.name.as_ref() == "/depth")
+    );
+}
+
+/// If `lua/` itself links out of the package, its target must not become the
+/// sandbox root; otherwise everything under that target would be requireable.
+#[cfg(unix)]
+#[test]
+fn symlinked_lua_directory_is_not_used_as_the_module_root() {
+    let pkg = package_dir(&[("init.lua", r#"require("escaped")"#)]);
+
+    let elsewhere = tempfile::TempDir::new().unwrap();
+    std::fs::write(elsewhere.path().join("escaped.lua"), "return {}\n").unwrap();
+    std::os::unix::fs::symlink(elsewhere.path(), pkg.path().join("lua")).unwrap();
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_package(
+            "linky",
+            pkg.path(),
+            maki_lua::PluginPermissions::trusted(),
+            Default::default(),
+        )
+        .expect_err("a lua/ directory pointing out of the package must not resolve modules");
+    assert!(err.to_string().contains("module not found"), "got: {err}");
+}
+
+/// An `opt/` package waits to be activated, so startup alone must not run it.
+#[test]
+fn discovered_opt_package_is_not_loaded_at_startup() {
+    let site = site_with_package(
+        "opt",
+        "lazy_pack",
+        &[(
+            "init.lua",
+            r#"maki.api.register_command({ name = "/lazy", handler = function() end })"#,
+        )],
+    );
+
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    assert_eq!(host.command_reader().load().commands.len(), 0);
+}
+
+/// Adds one `start` and one `opt` package to a site tree.
+fn site_with_two(start: (&str, &str), opt: (&str, &str)) -> tempfile::TempDir {
+    let tmp = tempfile::TempDir::new().unwrap();
+    for (sub, name, source) in [("start", start.0, start.1), ("opt", opt.0, opt.1)] {
+        let dir = tmp.path().join("pack").join("vendor").join(sub).join(name);
+        std::fs::create_dir_all(dir.join("plugin")).unwrap();
+        std::fs::write(dir.join("plugin").join("init.lua"), source).unwrap();
+    }
+    tmp
+}
+
+fn discovered_config(found: &maki_lua::Discovery) -> (Vec<String>, PluginsConfig) {
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+    (names, config)
+}
+
+/// `maki.packadd` is the activation path for an `opt/` package. A `start`
+/// package that calls it must get the named package loaded in the same
+/// startup, not the next one, or its registrations never appear.
+#[test]
+fn packadd_from_a_start_package_activates_an_opt_package() {
+    let site = site_with_two(
+        ("waker_pack", r#"maki.packadd("lazy_pack")"#),
+        (
+            "lazy_pack",
+            r#"maki.api.register_command({ name = "/lazy", handler = function() end })"#,
+        ),
+    );
+
+    let found = maki_lua::discover(site.path());
+    let (_, config) = discovered_config(&found);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    assert!(
+        host.load_packages(&found.packages, &config).is_empty(),
+        "both packages must load without a failure"
+    );
+
+    let snap = host.command_reader().load();
+    assert_eq!(
+        snap.commands.len(),
+        1,
+        "the activated package must have registered its command"
+    );
+    assert_eq!(snap.commands[0].name.as_ref(), "/lazy");
+}
+
+/// `maki.packadd` is on the maki table for every plugin, but only the startup
+/// drain reads what it records. A call after that drain would sit in the queue
+/// for the rest of the session with no error and no log, so it is refused.
+#[test]
+fn packadd_after_startup_reports_rather_than_queueing() {
+    let site = site_with_two(("waker_pack", ""), ("lazy_pack", ""));
+    let found = maki_lua::discover(site.path());
+    let (_, config) = discovered_config(&found);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    assert!(
+        host.load_packages(&found.packages, &config).is_empty(),
+        "the start package must load"
+    );
+
+    let err = host
+        .load_source("late_plugin", r#"maki.packadd("lazy_pack")"#)
+        .expect_err("packadd must report once the startup drain is over");
+    assert!(
+        err.to_string().contains("already been loaded"),
+        "got: {err}"
+    );
+}
+
+/// A name that matches no installed package is reported. Doing nothing would
+/// leave the user with a package that never loads and no reason why.
+#[test]
+fn packadd_reports_a_name_that_is_not_installed() {
+    let site = site_with_two(
+        ("waker_pack", r#"maki.packadd("absent_pack")"#),
+        ("lazy_pack", ""),
+    );
+
+    let found = maki_lua::discover(site.path());
+    let (_, config) = discovered_config(&found);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let failures = host.load_packages(&found.packages, &config);
+    assert_eq!(failures.len(), 1, "got: {failures:?}");
+    assert!(failures[0].contains("absent_pack"), "got: {failures:?}");
+}
+
+/// A package the config disabled stays disabled. `packadd` must not be a way
+/// around `plugins.<name>.enabled = false`.
+#[test]
+fn packadd_cannot_activate_a_disabled_package() {
+    let site = site_with_two(
+        ("waker_pack", r#"maki.packadd("lazy_pack")"#),
+        (
+            "lazy_pack",
+            r#"maki.api.register_command({ name = "/lazy", handler = function() end })"#,
+        ),
+    );
+
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let mut plugins: HashMap<String, maki_config::PluginFileConfig> = HashMap::new();
+    plugins.insert(
+        "lazy_pack".to_owned(),
+        maki_config::PluginFileConfig {
+            enabled: Some(false),
+            ..Default::default()
+        },
+    );
+    let config = PluginsConfig::from_plugins_and_packages(plugins, &names);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let failures = host.load_packages(&found.packages, &config);
+    assert_eq!(failures.len(), 1, "got: {failures:?}");
+    assert_eq!(
+        host.command_reader().load().commands.len(),
+        0,
+        "a disabled package must not register anything"
+    );
+}
+
+/// A package that asks for nothing gets nothing. Without a `plugin.toml` the
+/// guarded APIs must refuse, so a downloaded package cannot reach the network
+/// or the environment just by being installed.
+#[test]
+fn package_without_manifest_cannot_use_guarded_apis() {
+    let site = site_with_package(
+        "start",
+        "greedy_pack",
+        &[(
+            "init.lua",
+            r#"
+local ok = pcall(function() return maki.env.config_dir() end)
+maki.api.register_command({
+  name = ok and "/allowed" or "/denied",
+  handler = function() end,
+})
+"#,
+        )],
+    );
+
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    let snap = host.command_reader().load();
+    assert_eq!(snap.commands.len(), 1);
+    assert_eq!(
+        snap.commands[0].name.as_ref(),
+        "/denied",
+        "a package requesting nothing must not reach maki.env"
+    );
+}
+
+/// The manifest is what a manual install is granted, so a package that asks
+/// for `env` gets it without any further approval.
+#[test]
+fn manual_package_is_granted_what_its_manifest_requests() {
+    let site = site_with_package(
+        "start",
+        "asking_pack",
+        &[(
+            "init.lua",
+            r#"
+local ok = pcall(function() return maki.env.config_dir() end)
+maki.api.register_command({
+  name = ok and "/allowed" or "/denied",
+  handler = function() end,
+})
+"#,
+        )],
+    );
+    let pkg_dir = site
+        .path()
+        .join("pack")
+        .join("vendor")
+        .join("start")
+        .join("asking_pack");
+    std::fs::write(pkg_dir.join("plugin.toml"), "[permissions]\nenv = true\n").unwrap();
+
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    let snap = host.command_reader().load();
+    assert_eq!(snap.commands[0].name.as_ref(), "/allowed");
 }
 
 #[test]

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -339,7 +339,7 @@ mod tests {
             "provider": {"allowed_models": [fallback.spec()]}
         }))
         .unwrap();
-        let policy = raw.into_config().unwrap().provider.model_policy;
+        let policy = raw.into_config(&[]).unwrap().provider.model_policy;
 
         let state = SessionState::from_session(session, &fallback, &storage, &policy);
 

--- a/site/docs/content/_index.md
+++ b/site/docs/content/_index.md
@@ -58,6 +58,7 @@ The docs are sorted by what you came here to do:
     <a class="card" href="/docs/commands/"><span class="card-title">Commands</span><span class="card-desc">The / palette, sessions, toggles, custom commands.</span></a>
     <a class="card" href="/docs/keybindings/"><span class="card-title">Keybindings</span><span class="card-desc">Defaults, precedence, rebinding from Lua.</span></a>
     <a class="card" href="/docs/lua-api/"><span class="card-title">Lua API</span><span class="card-desc">The plugin surface, mirrored from Neovim.</span></a>
+    <a class="card" href="/docs/packages/"><span class="card-title">Lua Packages</span><span class="card-desc">Load external Lua plugins from Neovim-style package directories.</span></a>
     <a class="card" href="/docs/cli/"><span class="card-title">CLI</span><span class="card-desc">Flags and subcommands (auth, models, acp, prompt, ...).</span></a>
     <a class="card" href="/docs/telemetry/"><span class="card-title">Telemetry</span><span class="card-desc">Opt-in OpenTelemetry metrics and events, to a collector you run.</span></a>
   </div>

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -177,6 +177,29 @@ maki.split("x*y*z", "*", { plain = true }) -- { "x", "y", "z" }
 maki.split("\nhello\nworld\n", "\n", { trimempty = true }) -- { "hello", "world" }
 ```
 
+---
+
+### `maki.packadd()` {#maki-packadd}
+
+```lua
+maki.packadd({name})
+```
+
+Activate an installed `opt/` package, like `:packadd`.
+
+Loading happens after this call returns. The startup package pass reports
+an unknown, disabled, or failed package.
+
+**Parameters:**
+
+- `{name}` (`string`) Package to activate.
+
+**Example:**
+
+```lua
+maki.packadd("maki-goal")
+```
+
 
 ## maki.api {#maki-api}
 

--- a/site/docs/content/packages/_index.md
+++ b/site/docs/content/packages/_index.md
@@ -1,0 +1,41 @@
++++
+title = "Lua Packages"
+weight = 11
+[extra]
+group = "Reference"
++++
+
+# Lua packages
+
+A Lua package lets you add tools, commands, keybindings, and event handlers
+without copying its code into `init.lua`.
+
+Clone a package into a Neovim-style package directory:
+
+```text
+<maki-data>/site/pack/<group>/start/<name>/
+<maki-data>/site/pack/<group>/opt/<name>/
+```
+
+A `start` package loads at startup. An `opt` package stays installed until
+something activates it.
+
+Placing a package by hand means you trust its code the way you trust your own
+`init.lua`. Maki grants such a package exactly the permissions its
+`plugin.toml` requests, with no approval step. Read the code before you copy it
+in, and keep manual placement for the packages you develop yourself.
+
+Activate an `opt` package with `maki.packadd`, from `init.lua` or from another
+package:
+
+```lua
+maki.packadd("my-package")
+```
+
+Maki loads the named package after the calling Lua task returns. A package
+that `maki.packadd` activates can activate another one in turn. Maki reports a
+name that no installed package matches, and refuses a package that
+`plugins.<name>.enabled = false` disabled.
+
+A package directory can contain sorted `plugin/*.lua` entry files and modules
+at `lua/<module>.lua` or `lua/<module>/init.lua`.

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -21,24 +21,27 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
     let mut plugin_host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
         .context("initialize lua plugin host")?;
 
-    let raw_config = plugin_host
-        .load_init_files_or_skip(no_plugins, &cwd)
-        .context("load init.lua files")?;
+    let (config, warnings) = super::load_plugins(
+        &mut plugin_host,
+        no_plugins,
+        super::BuiltinFailure::Fatal,
+        |host, names, _| {
+            let mut config = host
+                .load_init_files_or_skip(no_plugins, &cwd)
+                .context("load init.lua files")?
+                .unwrap_or_default()
+                .into_config(names)
+                .context("invalid config")?;
+            config.permissions = load_permissions(&cwd);
 
-    let mut config = raw_config
-        .unwrap_or_default()
-        .into_config()
-        .context("invalid config")?;
-    config.permissions = load_permissions(&cwd);
-
-    if yolo || config.always_yolo {
-        config.permissions.yolo = true;
-    }
-    config.validate()?;
-
-    plugin_host
-        .load_builtins(&config.plugins)
-        .context("load builtin plugins")?;
+            if yolo || config.always_yolo {
+                config.permissions.yolo = true;
+            }
+            config.validate()?;
+            Ok(config)
+        },
+    )?;
+    super::report_warnings(warnings);
 
     let timeouts = maki_providers::Timeouts {
         connect: config.provider.connect_timeout,

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -6,10 +6,72 @@ mod tui;
 use color_eyre::Result;
 use color_eyre::eyre::Context;
 
+use maki_config::Config;
+use maki_lua::PluginHost;
 use maki_storage::StateDir;
 
 use crate::cli::{AuthAction, Cli, Command, McpAction, MigrateAction};
 use crate::update;
+
+fn sanitize_warning(message: impl std::fmt::Display) -> String {
+    maki_lua::sanitize_message(&message.to_string())
+}
+
+fn sanitize_warnings(warnings: Vec<String>) -> Vec<String> {
+    warnings.into_iter().map(sanitize_warning).collect()
+}
+
+fn report_warnings(warnings: Vec<String>) {
+    for warning in sanitize_warnings(warnings) {
+        eprintln!("warning: {warning}");
+    }
+}
+
+/// What a builtin that fails to load means for the run in progress.
+#[derive(Clone, Copy)]
+enum BuiltinFailure {
+    /// Startup has nothing to fall back on.
+    Fatal,
+    /// `/reload` keeps the open UI alive, so the failure is only reported.
+    Warn,
+}
+
+/// The plugin startup every entry point shares. Packages are discovered before
+/// `build_config` runs, so `plugins.<name>` can configure an installed package,
+/// and loaded after the builtins, so a package claiming a builtin tool name is
+/// the side that fails.
+///
+/// Warnings are returned sanitized, leaving the sink to the caller; the extra
+/// `Vec` handed to `build_config` is for warnings raised while building it.
+fn load_plugins(
+    host: &mut PluginHost,
+    no_plugins: bool,
+    on_builtin_failure: BuiltinFailure,
+    build_config: impl FnOnce(&PluginHost, &[String], &mut Vec<String>) -> Result<Config>,
+) -> Result<(Config, Vec<String>)> {
+    let discovery = maki_lua::discover_installed(no_plugins);
+    // Includes the names discovery refused, so a package it could not read does
+    // not become a config error pointing at the user's `plugins.<name>` table.
+    let names = discovery.known_names();
+    let mut warnings: Vec<String> = discovery
+        .problems
+        .into_iter()
+        .map(|problem| format!("skipping package: {problem}"))
+        .collect();
+
+    let config = build_config(host, &names, &mut warnings)?;
+
+    if let Err(e) = host.load_builtins(&config.plugins) {
+        let e = color_eyre::eyre::Report::from(e).wrap_err("load builtin plugins");
+        match on_builtin_failure {
+            BuiltinFailure::Fatal => return Err(e),
+            BuiltinFailure::Warn => warnings.push(format!("{e:#}")),
+        }
+    }
+    warnings.extend(host.load_packages(&discovery.packages, &config.plugins));
+
+    Ok((config, sanitize_warnings(warnings)))
+}
 
 pub fn dispatch(cli: Cli) -> Result<()> {
     match cli.command {

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -541,9 +541,15 @@ pub fn models(no_plugins: bool, no_jit: bool) -> Result<()> {
     let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
     load_env_files(&cwd);
 
-    let host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
+    let mut host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
         .context("initialize lua plugin host")?;
-    let config = load_effective_config(&host, no_plugins, &cwd)?;
+    let (config, warnings) = super::load_plugins(
+        &mut host,
+        no_plugins,
+        super::BuiltinFailure::Fatal,
+        |host, names, _| load_effective_config(host, no_plugins, &cwd, names),
+    )?;
+    super::report_warnings(warnings);
 
     smol::block_on(fetch_all_models(
         &config.provider.model_policy,
@@ -560,11 +566,16 @@ pub fn models(no_plugins: bool, no_jit: bool) -> Result<()> {
     Ok(())
 }
 
-fn load_effective_config(host: &PluginHost, no_plugins: bool, cwd: &Path) -> Result<Config> {
+fn load_effective_config(
+    host: &PluginHost,
+    no_plugins: bool,
+    cwd: &Path,
+    names: &[String],
+) -> Result<Config> {
     host.load_init_files_or_skip(no_plugins, cwd)
         .context("load init.lua files")?
         .unwrap_or_default()
-        .into_config()
+        .into_config(names)
         .context("invalid config")
 }
 
@@ -575,18 +586,17 @@ pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
     let mut host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
         .context("initialize lua plugin host")?;
 
-    let raw_config = host
-        .load_init_files_or_skip(no_plugins, &cwd)
-        .context("load init.lua files")?;
-
-    let mut config = raw_config
-        .unwrap_or_default()
-        .into_config()
-        .context("invalid config")?;
-    config.permissions = load_permissions(&cwd);
-
-    host.load_builtins(&config.plugins)
-        .context("load builtin plugins")?;
+    let (_, warnings) = super::load_plugins(
+        &mut host,
+        no_plugins,
+        super::BuiltinFailure::Fatal,
+        |host, names, _| {
+            let mut config = load_effective_config(host, no_plugins, &cwd, names)?;
+            config.permissions = load_permissions(&cwd);
+            Ok(config)
+        },
+    )?;
+    super::report_warnings(warnings);
 
     let abs_path = Path::new(path)
         .canonicalize()
@@ -672,15 +682,13 @@ pub fn prompt(
     let reg = ToolRegistry::global_arc();
     let mut host =
         PluginHost::with_jit(Arc::clone(reg), !no_jit).context("initialize lua plugin host")?;
-    let raw_config = host
-        .load_init_files_or_skip(no_plugins, &cwd)
-        .context("load init.lua files")?;
-    let config = raw_config
-        .unwrap_or_default()
-        .into_config()
-        .context("invalid config")?;
-    host.load_builtins(&config.plugins)
-        .context("load builtin plugins")?;
+    let (config, warnings) = super::load_plugins(
+        &mut host,
+        no_plugins,
+        super::BuiltinFailure::Fatal,
+        |host, names, _| load_effective_config(host, no_plugins, &cwd, names),
+    )?;
+    super::report_warnings(warnings);
 
     if tools {
         let ctx = DescriptionContext {

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -81,14 +81,19 @@ fn discover_commands(disable: bool) -> Vec<CustomCommand> {
     command::discover_commands(&cwd)
 }
 
-fn load_config(plugin_host: &PluginHost, cli: &Cli, cwd: &Path) -> Result<Config> {
+fn load_config(
+    plugin_host: &PluginHost,
+    cli: &Cli,
+    cwd: &Path,
+    names: &[String],
+) -> Result<Config> {
     let raw_config = plugin_host
         .load_init_files_or_skip(cli.no_plugins, cwd)
         .context("load init.lua files")?;
 
     let mut config = raw_config
         .unwrap_or_default()
-        .into_config()
+        .into_config(names)
         .context("invalid config")?;
     config.permissions = load_permissions(cwd);
 
@@ -137,27 +142,26 @@ fn build_stack(
     storage: &StateDir,
     fallback: Option<(Config, Model)>,
 ) -> Result<(Stack, Vec<String>)> {
-    let mut warnings = Vec::new();
-
     let mut plugin_host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !cli.no_jit)
         .context("initialize lua plugin host")?;
 
     let (fallback_config, fallback_model) = fallback.unzip();
-    let reloading = fallback_model.is_some();
-    let config = config_or_fallback(
-        load_config(&plugin_host, cli, cwd),
-        fallback_config,
-        &mut warnings,
-    )?;
-
-    if let Err(e) = plugin_host.load_builtins(&config.plugins) {
-        let e = color_eyre::eyre::Report::from(e).wrap_err("load builtin plugins");
-        if reloading {
-            warnings.push(format!("{e:#}"));
+    let (config, mut warnings) = super::load_plugins(
+        &mut plugin_host,
+        cli.no_plugins,
+        if fallback_model.is_some() {
+            super::BuiltinFailure::Warn
         } else {
-            return Err(e);
-        }
-    }
+            super::BuiltinFailure::Fatal
+        },
+        |host, names, warnings| {
+            config_or_fallback(
+                load_config(host, cli, cwd, names),
+                fallback_config,
+                warnings,
+            )
+        },
+    )?;
 
     let commands = discover_commands(cli.no_commands);
 
@@ -183,7 +187,7 @@ fn build_stack(
             model,
             needs_login,
         },
-        warnings,
+        super::sanitize_warnings(warnings),
     ))
 }
 
@@ -242,12 +246,22 @@ pub fn run(mut cli: Cli) -> Result<()> {
     load_env_files(&cwd);
     warn_stale_config_toml(&cwd);
 
-    let (mut stack, _) = build_stack(&cli, &cwd, &storage, None)?;
+    let (mut stack, startup_warnings) = build_stack(&cli, &cwd, &storage, None)?;
 
     setup::init_logging(&stack.config.storage);
     setup::init_telemetry(&stack.config.telemetry);
     setup::install_panic_log_hook();
     setup::warn_ignored_provider_fields();
+
+    // Discovery runs before logging is initialized, so a package problem has
+    // no log to reach either. The TUI shows these in its first generation; a
+    // mode that never opens the UI has to report them here or a broken
+    // package fails in complete silence.
+    if cli.is_sdk_mode() || cli.print {
+        for warning in &startup_warnings {
+            eprintln!("warning: {warning}");
+        }
+    }
 
     if cli.is_sdk_mode() {
         let fast = stack.config.always_fast && stack.model.supports_fast();
@@ -299,7 +313,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
         &storage,
     )?];
     let mut focused = 0;
-    let mut warnings: Vec<String> = Vec::new();
+    let mut warnings = startup_warnings;
     let mut initial_prompt = read_initial_prompt(cli.initial_prompt.take())?;
     let mut teardown = Teardown::default();
 
@@ -472,7 +486,9 @@ mod tests {
     }
 
     fn test_config() -> Config {
-        RawConfig::default().into_config().expect("default config")
+        RawConfig::default()
+            .into_config(&[])
+            .expect("default config")
     }
 
     #[test]
@@ -528,7 +544,7 @@ mod tests {
         let mut plugin_host = PluginHost::with_jit(Arc::new(ToolRegistry::new()), true)
             .expect("live host boots under --no-plugins");
 
-        let config = load_config(&plugin_host, &cli, dir.path())
+        let config = load_config(&plugin_host, &cli, dir.path(), &[])
             .expect("no-plugins must skip the broken init.lua and still load defaults");
         assert!(
             !config.plugins.names.is_empty(),
@@ -566,7 +582,7 @@ mod tests {
         let mut plugin_host =
             PluginHost::with_jit(Arc::new(ToolRegistry::new()), true).expect("live host boots");
 
-        match load_config(&plugin_host, &cli, dir.path()) {
+        match load_config(&plugin_host, &cli, dir.path(), &[]) {
             Err(_) => {}
             Ok(_) => panic!("broken init.lua must error without --no-plugins"),
         }

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -1456,7 +1456,7 @@ mod tests {
             "provider": {"allowed_models": [startup.spec()]}
         }))
         .unwrap();
-        let policy = raw.into_config().unwrap().provider.model_policy;
+        let policy = raw.into_config(&[]).unwrap().provider.model_policy;
 
         assert!(
             resolve_set_model(


### PR DESCRIPTION
This is the first package layer for #721. It contains only external package
discovery, loading, and activation. #828 adds managed state on top.

## What it does

- Discovers hand-placed Neovim package directories in deterministic `start`
  and `opt` order.
- Loads each package's sorted `plugin/*.lua` files as one owner with atomic
  registration and complete rollback.
- Supports package-local `require` through both `lua/foo.lua` and
  `lua/foo/init.lua` while keeping reads inside the package root.
- Adds root `maki.packadd("name")` for explicit optional-package activation.
- Uses the same package startup path in TUI, ACP, index, and prompt modes,
  including `--no-plugins` behavior.
- Treats `plugin.toml` permissions as requests and keeps source conflicts
  independent from permission decisions.
- Cleans all owner registrations when activation fails or the host reloads.
- Sanitizes package errors at user-output boundaries.

This PR has no managed installation, lockfile, package mutation API, update,
deletion, or lazy trigger state.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --workspace`: 4,372 passed
- `cargo test --workspace --doc`
- `just gen-docs-check`

## AI use

Written with Claude Code and reviewed with Codex. The revised implementation
was reviewed against discovery, owner isolation, activation, rollback,
entry-point, and error-reporting paths.
