### PR TITLE
feat(lua): add managed package state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,6 +1503,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2796,6 +2806,7 @@ dependencies = [
  "maki-interpreter",
  "maki-lua-macro",
  "maki-markdown",
+ "maki-pack",
  "maki-providers",
  "maki-storage",
  "mlua",
@@ -2880,6 +2891,20 @@ dependencies = [
  "maki-config",
  "serde_json",
  "smol",
+ "test-case",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "maki-pack"
+version = "0.4.12"
+dependencies = [
+ "fs4",
+ "serde",
+ "serde_json",
+ "smol",
+ "tempfile",
  "test-case",
  "thiserror 2.0.18",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
   "maki-lua",
   "maki-markdown",
   "maki-otel",
+  "maki-pack",
   "maki-providers",
   "maki-storage",
   "maki-config-macro",
@@ -85,6 +86,7 @@ maki-lua-macro = { path = "maki-lua-macro" }
 maki-highlight = { path = "maki-highlight" }
 maki-markdown = { path = "maki-markdown" }
 maki-otel = { path = "maki-otel" }
+maki-pack = { path = "maki-pack" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 bs58 = "0.5"
@@ -124,6 +126,7 @@ keyring = "4"
 arboard = { version = "3", default-features = false, features = ["image-data", "wayland-data-control"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 flume = { version = "0.11", default-features = false, features = ["async", "select"] }
+fs4 = "1"
 pin-project-lite = "0.2"
 rustix = { version = "1", default-features = false, features = ["process"] }
 humantime = "2"

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -163,8 +163,8 @@ pub enum ConfigError {
     )]
     RemovedEditSubTool { tool: &'static str },
     #[error(
-        "invalid config: plugins.{plugin}: no bundled plugin is named \"{plugin}\" \
-         (bundled plugins: {valid})"
+        "invalid config: plugins.{plugin}: no bundled plugin or installed \
+         package is named \"{plugin}\" (available: {valid})"
     )]
     UnknownPlugin { plugin: String, valid: String },
     #[error(
@@ -271,12 +271,19 @@ impl RawConfig {
         self.tools.extend(overlay.tools);
     }
 
-    pub fn into_config(self) -> Result<Config, ConfigError> {
-        self.validate_plugin_tables()?;
+    /// `packages` are the external package names discovery found. They are
+    /// passed in rather than stored, because an installed package is host
+    /// state: it is not written in any config file and must not survive a
+    /// merge between two of them.
+    pub fn into_config(self, packages: &[String]) -> Result<Config, ConfigError> {
+        self.validate_plugin_tables(packages)?;
+        // Only bundled names, because a builtin's name is also its tool name
+        // while a package's is not. Copying a package name here would hide an
+        // unrelated tool that happened to share it.
         let disabled_tools: Vec<String> = self
             .plugins
             .iter()
-            .filter(|(_, cfg)| cfg.enabled == Some(false))
+            .filter(|(name, cfg)| cfg.enabled == Some(false) && !packages.contains(name))
             .map(|(name, _)| name.clone())
             .collect();
         Ok(Config {
@@ -293,13 +300,13 @@ impl RawConfig {
             storage: StorageConfig::from_file(self.storage),
             telemetry: self.telemetry,
             permissions: PermissionsConfig::default(),
-            plugins: PluginsConfig::from_plugins(self.plugins),
+            plugins: PluginsConfig::from_plugins_and_packages(self.plugins, packages),
         })
     }
 
     /// A `plugins.<name>` key that matches no bundled plugin is a typo or an
     /// old config, so fail loudly instead of letting it silently drift.
-    fn validate_plugin_tables(&self) -> Result<(), ConfigError> {
+    fn validate_plugin_tables(&self, packages: &[String]) -> Result<(), ConfigError> {
         if !self.tools.is_empty() {
             return Err(ConfigError::RenamedToolsTable);
         }
@@ -311,13 +318,16 @@ impl RawConfig {
         let mut unknown: Vec<&String> = self
             .plugins
             .keys()
-            .filter(|name| !DEFAULT_BUILTINS.contains(&name.as_str()))
+            .filter(|name| !DEFAULT_BUILTINS.contains(&name.as_str()) && !packages.contains(name))
             .collect();
         unknown.sort();
         if let Some(&plugin) = unknown.first() {
+            let mut valid: Vec<&str> = DEFAULT_BUILTINS.to_vec();
+            valid.extend(packages.iter().map(String::as_str));
+            valid.sort_unstable();
             return Err(ConfigError::UnknownPlugin {
                 plugin: plugin.clone(),
-                valid: DEFAULT_BUILTINS.join(", "),
+                valid: valid.join(", "),
             });
         }
         Ok(())
@@ -1483,7 +1493,12 @@ impl TelemetryConfig {
 #[derive(Debug, Clone, Default)]
 pub struct PluginsConfig {
     pub enabled: bool,
+    /// Enabled bundled plugins. Deliberately does not include packages: the
+    /// host loads the two from different places, and mixing them here made
+    /// `load_builtins` reject every installed package by name.
     pub names: Vec<String>,
+    /// Enabled external packages.
+    pub packages: Vec<String>,
     /// Per-plugin option tables, without `enabled`. Each plugin validates its
     /// own via `maki.api.register_options` at load time.
     pub opts: HashMap<String, JsonMap<String, JsonValue>>,
@@ -1491,16 +1506,37 @@ pub struct PluginsConfig {
 
 impl PluginsConfig {
     pub fn from_plugins(plugins: HashMap<String, PluginFileConfig>) -> Self {
+        Self::from_plugins_and_packages(plugins, &[])
+    }
+
+    /// Installed packages default to enabled like Neovim `start/` packages.
+    pub fn from_plugins_and_packages(
+        plugins: HashMap<String, PluginFileConfig>,
+        packages: &[String],
+    ) -> Self {
+        let enabled = |name: &String| plugins.get(name).and_then(|t| t.enabled).unwrap_or(true);
+
         let mut all: Vec<String> = DEFAULT_BUILTINS
             .iter()
-            .filter(|name| plugins.get(**name).and_then(|t| t.enabled).unwrap_or(true))
-            .map(|s| s.to_string())
+            .map(|s| (*s).to_owned())
+            .filter(|name| enabled(name))
             .collect();
+
+        let mut enabled_packages: Vec<String> = packages
+            .iter()
+            .filter(|name| !DEFAULT_BUILTINS.contains(&name.as_str()))
+            .filter(|name| enabled(name))
+            .cloned()
+            .collect();
+        enabled_packages.sort();
+        enabled_packages.dedup();
 
         let mut extra: Vec<&String> = plugins
             .iter()
             .filter(|(name, cfg)| {
-                !DEFAULT_BUILTINS.contains(&name.as_str()) && cfg.enabled.unwrap_or(false)
+                !DEFAULT_BUILTINS.contains(&name.as_str())
+                    && !packages.contains(name)
+                    && cfg.enabled.unwrap_or(false)
             })
             .map(|(name, _)| name)
             .collect();
@@ -1516,6 +1552,7 @@ impl PluginsConfig {
         Self {
             enabled: true,
             names: all,
+            packages: enabled_packages,
             opts,
         }
     }
@@ -2248,7 +2285,7 @@ mod tests {
 
     #[test]
     fn empty_config_returns_defaults() {
-        let config = RawConfig::default().into_config().unwrap();
+        let config = RawConfig::default().into_config(&[]).unwrap();
         assert!(config.ui.splash_animation);
         assert_eq!(config.ui.notifications, NotificationMethod::Auto);
         assert_eq!(config.agent.max_output_bytes, DEFAULT_MAX_OUTPUT_BYTES);
@@ -2269,7 +2306,7 @@ mod tests {
     fn notifications_deserialize(value: &str, expected: NotificationMethod) {
         let raw: RawConfig =
             toml::from_str(&format!("[ui]\nnotifications = \"{value}\"\n")).unwrap();
-        assert_eq!(raw.into_config().unwrap().ui.notifications, expected);
+        assert_eq!(raw.into_config(&[]).unwrap().ui.notifications, expected);
     }
 
     #[test]
@@ -2287,7 +2324,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let config = raw.into_config().unwrap();
+        let config = raw.into_config(&[]).unwrap();
         assert_eq!(config.agent.max_output_lines, 5000);
         assert_eq!(config.agent.max_output_bytes, DEFAULT_MAX_OUTPUT_BYTES);
     }
@@ -2354,7 +2391,7 @@ mod tests {
             ..Default::default()
         });
 
-        let provider = global.into_config().unwrap().provider;
+        let provider = global.into_config(&[]).unwrap().provider;
         assert!(provider.allowed_models.is_empty());
         assert_eq!(provider.excluded_models, ["*/*-preview"]);
         assert!(provider.model_policy.allows("openai/gpt-5"));
@@ -2371,7 +2408,7 @@ mod tests {
             },
             ..Default::default()
         }
-        .into_config()
+        .into_config(&[])
         .unwrap();
         let policy = &config.provider.model_policy;
 
@@ -2387,7 +2424,7 @@ mod tests {
             },
             ..Default::default()
         }
-        .into_config()
+        .into_config(&[])
         .unwrap();
         assert!(exclude_only.provider.model_policy.allows("openai/gpt-5"));
         assert!(
@@ -2407,7 +2444,7 @@ mod tests {
             },
             ..Default::default()
         }
-        .into_config();
+        .into_config(&[]);
 
         assert!(matches!(
             result,
@@ -2442,14 +2479,14 @@ mod tests {
 
     #[test]
     fn always_workflow_resolves_default_and_set() {
-        let defaults = RawConfig::default().into_config().unwrap();
+        let defaults = RawConfig::default().into_config(&[]).unwrap();
         assert!(!defaults.always_workflow, "absent resolves to false");
 
         let raw = RawConfig {
             always_workflow: Some(true),
             ..Default::default()
         };
-        assert!(raw.into_config().unwrap().always_workflow);
+        assert!(raw.into_config(&[]).unwrap().always_workflow);
     }
 
     #[test_case(AlwaysThinking::Toggle(true), StoredThinking::Adaptive ; "toggle_true")]
@@ -2463,14 +2500,14 @@ mod tests {
 
     #[test]
     fn into_config_resolves_always_thinking() {
-        let defaults = RawConfig::default().into_config().unwrap();
+        let defaults = RawConfig::default().into_config(&[]).unwrap();
         assert!(defaults.always_thinking.is_none());
 
         let raw = RawConfig {
             always_thinking: Some(AlwaysThinking::Mode("8192".into())),
             ..Default::default()
         };
-        let config = raw.into_config().unwrap();
+        let config = raw.into_config(&[]).unwrap();
         assert_eq!(
             config.always_thinking,
             Some(StoredThinking::Budget { tokens: 8192 })
@@ -2480,7 +2517,7 @@ mod tests {
             always_thinking: Some(AlwaysThinking::Mode("fast".into())),
             ..Default::default()
         };
-        let err = raw.into_config().err().expect("expected config error");
+        let err = raw.into_config(&[]).err().expect("expected config error");
         assert!(matches!(err, ConfigError::Thinking(_)));
     }
 
@@ -2511,7 +2548,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let config = raw.into_config().unwrap();
+        let config = raw.into_config(&[]).unwrap();
         assert_eq!(config.ui.tool_output_lines.bash, 20);
         assert_eq!(config.ui.tool_output_lines.read, 20);
         assert_eq!(
@@ -2936,14 +2973,14 @@ mod tests {
     #[test]
     fn show_thinking_missing_defaults_true() {
         let raw: RawConfig = toml::from_str("").unwrap();
-        let config = raw.into_config().unwrap();
+        let config = raw.into_config(&[]).unwrap();
         assert!(config.ui.show_thinking);
     }
 
     #[test]
     fn max_input_lines_defaults_and_deserializes() {
         let raw: RawConfig = toml::from_str("").unwrap();
-        let config = raw.into_config().unwrap();
+        let config = raw.into_config(&[]).unwrap();
         assert_eq!(config.ui.max_input_lines, DEFAULT_MAX_INPUT_LINES);
 
         let raw: RawConfig = toml::from_str("[ui]\nmax_input_lines = 5\n").unwrap();
@@ -2989,7 +3026,7 @@ mod tests {
             "[plugins.bash]\ntimeout_secs = 180\n[plugins.websearch]\nenabled = false\n",
         )
         .unwrap();
-        let config = raw.into_config().unwrap();
+        let config = raw.into_config(&[]).unwrap();
         assert!(config.plugins.names.contains(&"bash".to_string()));
         assert!(!config.plugins.names.contains(&"websearch".to_string()));
         assert!(
@@ -3100,7 +3137,7 @@ mod tests {
     fn removed_sub_tool_tables_error() {
         for &tool in EDIT_SUB_TOOLS {
             let raw: RawConfig = toml::from_str(&format!("[plugins.{tool}]\n")).unwrap();
-            let Err(err) = raw.into_config() else {
+            let Err(err) = raw.into_config(&[]) else {
                 panic!("plugins.{tool} should be rejected");
             };
             let msg = err.to_string();
@@ -3116,13 +3153,73 @@ mod tests {
     #[test_case("search_result_limit = 50" ; "opts_only")]
     fn unknown_plugin_name_errors(body: &str) {
         let raw: RawConfig = toml::from_str(&format!("[plugins.gerp]\n{body}\n")).unwrap();
-        let Err(err) = raw.into_config() else {
+        let Err(err) = raw.into_config(&[]) else {
             panic!("plugins.gerp should be rejected");
         };
         let msg = err.to_string();
         assert!(
-            msg.contains("no bundled plugin is named \"gerp\"") && msg.contains("grep"),
-            "error should name the typo and list bundled plugins, got: {msg}"
+            msg.contains("named \"gerp\"") && msg.contains("grep"),
+            "error should name the typo and list what is available, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn known_package_name_is_accepted() {
+        let raw: RawConfig = toml::from_str("[plugins.my_pack]\nenabled = true\n").unwrap();
+        let config = raw
+            .into_config(&["my_pack".to_owned()])
+            .expect("an installed package should be configurable");
+        assert!(config.plugins.packages.contains(&"my_pack".to_owned()));
+    }
+
+    #[test]
+    fn known_package_can_be_disabled() {
+        let raw: RawConfig = toml::from_str("[plugins.my_pack]\nenabled = false\n").unwrap();
+        let config = raw.into_config(&["my_pack".to_owned()]).unwrap();
+        assert!(!config.plugins.packages.contains(&"my_pack".to_owned()));
+    }
+
+    #[test]
+    fn packages_are_not_mixed_into_builtin_names() {
+        let config = RawConfig::default()
+            .into_config(&["my_pack".to_owned()])
+            .unwrap();
+        assert!(!config.plugins.names.contains(&"my_pack".to_owned()));
+        assert!(config.plugins.packages.contains(&"my_pack".to_owned()));
+        assert!(
+            config
+                .plugins
+                .names
+                .iter()
+                .all(|n| DEFAULT_BUILTINS.contains(&n.as_str())),
+            "names must hold only bundled plugins"
+        );
+    }
+
+    #[test]
+    fn disabling_a_package_does_not_disable_a_tool() {
+        let raw: RawConfig = toml::from_str("[plugins.my_pack]\nenabled = false\n").unwrap();
+        let config = raw.into_config(&["my_pack".to_owned()]).unwrap();
+        assert!(!config.agent.disabled_tools.contains(&"my_pack".to_owned()));
+    }
+
+    #[test]
+    fn disabling_a_builtin_still_disables_its_tool() {
+        let raw: RawConfig = toml::from_str("[plugins.grep]\nenabled = false\n").unwrap();
+        let config = raw.into_config(&[]).unwrap();
+        assert!(config.agent.disabled_tools.contains(&"grep".to_owned()));
+    }
+
+    #[test]
+    fn unknown_name_still_rejected_when_packages_exist() {
+        let raw: RawConfig = toml::from_str("[plugins.gerp]\nenabled = true\n").unwrap();
+        let Err(err) = raw.into_config(&["my_pack".to_owned()]) else {
+            panic!("gerp is neither a builtin nor an installed package");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("my_pack"),
+            "should list packages too, got: {msg}"
         );
     }
 
@@ -3130,7 +3227,7 @@ mod tests {
     fn disabled_plugin_keeps_opts_but_not_load_entry() {
         let raw: RawConfig =
             toml::from_str("[plugins.bash]\nenabled = false\ntimeout_secs = 180\n").unwrap();
-        let config = raw.into_config().unwrap();
+        let config = raw.into_config(&[]).unwrap();
         assert!(!config.plugins.names.contains(&"bash".to_string()));
         assert_eq!(
             config.plugins.opts["bash"]["timeout_secs"],
@@ -3142,7 +3239,7 @@ mod tests {
     #[test]
     fn renamed_tools_table_errors() {
         let raw: RawConfig = toml::from_str("[tools.bash]\nenabled = true\n").unwrap();
-        let Err(err) = raw.into_config() else {
+        let Err(err) = raw.into_config(&[]) else {
             panic!("old tools table should be rejected");
         };
         assert!(
@@ -3155,7 +3252,7 @@ mod tests {
     fn edit_sub_tool_toggles_flow_as_edit_opts() {
         let raw: RawConfig =
             toml::from_str("[plugins.edit]\nmultiedit = false\nedit_lines = true\n").unwrap();
-        let config = raw.into_config().unwrap();
+        let config = raw.into_config(&[]).unwrap();
         assert_eq!(
             config.plugins.opts["edit"]["multiedit"],
             serde_json::json!(false)

--- a/maki-lua/Cargo.toml
+++ b/maki-lua/Cargo.toml
@@ -19,6 +19,7 @@ maki-highlight = { workspace = true }
 maki-interpreter = { workspace = true }
 maki-lua-macro = { workspace = true }
 maki-markdown = { workspace = true }
+maki-pack = { workspace = true }
 maki-providers = { workspace = true }
 mlua = { workspace = true }
 serde_json = { workspace = true }

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod log;
 pub(crate) mod model;
 pub(crate) mod net;
 pub(crate) mod options;
+pub(crate) mod pack;
 pub(crate) mod session;
 pub(crate) mod slot;
 pub(crate) mod split;
@@ -95,6 +96,7 @@ pub(crate) fn create_maki_global(
         "keymap",
         keymap::create_keymap_table(lua, Arc::clone(&plugin))?,
     )?;
+    pack::add_packadd(lua, &maki)?;
 
     Ok(maki)
 }

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -97,6 +97,7 @@ pub(crate) fn create_maki_global(
         keymap::create_keymap_table(lua, Arc::clone(&plugin))?,
     )?;
     pack::add_packadd(lua, &maki)?;
+    maki.set("pack", pack::create_pack_read_table(lua)?)?;
 
     Ok(maki)
 }

--- a/maki-lua/src/api/pack.rs
+++ b/maki-lua/src/api/pack.rs
@@ -1,0 +1,140 @@
+//! `maki.packadd`, the activation path for a package under `pack/*/opt/`.
+
+use std::sync::{Arc, Mutex};
+
+use maki_lua_macro::lua_fn;
+use mlua::{Lua, Result as LuaResult, Table};
+
+/// A package activation requested from Lua.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PackOp {
+    /// Load a package that is installed but not loaded.
+    Activate { name: String },
+}
+
+/// What Lua recorded for the host to act on.
+///
+/// Session state only. Nothing here runs inline: loading an owner blocks on a
+/// reply from the runtime thread that the calling Lua task is occupying, so
+/// acting on a request from inside the call would wait on itself.
+#[derive(Debug, Default)]
+pub struct PackDeclarations {
+    pub pending: Vec<PackOp>,
+    /// Set once the startup drain is over.
+    ///
+    /// Nothing reads `pending` after that point, so a `packadd` from a command
+    /// handler or a keymap would sit here for the rest of the session with no
+    /// error and no log. It is refused instead.
+    pub drained: bool,
+}
+
+pub type PackStore = Arc<Mutex<PackDeclarations>>;
+
+/// Registers `maki.packadd` on the root table.
+///
+/// It sits beside the other always-available functions rather than in a table
+/// of its own, because activating code that is already installed and already
+/// approved is something any plugin may do.
+pub(crate) fn add_packadd(lua: &Lua, maki: &Table) -> LuaResult<()> {
+    maki.set("packadd", lua.create_function(packadd)?)
+}
+
+/// Activate an installed `opt/` package, like `:packadd`.
+///
+/// Loading happens after this call returns. The startup package pass reports
+/// an unknown, disabled, or failed package.
+///
+/// @param name string Package to activate.
+/// @example
+/// maki.packadd("maki-goal")
+#[lua_fn]
+fn packadd(lua: &Lua, name: String) -> LuaResult<()> {
+    enqueue(lua, PackOp::Activate { name })
+}
+
+fn enqueue(lua: &Lua, op: PackOp) -> LuaResult<()> {
+    let store = lua
+        .app_data_ref::<PackStore>()
+        .ok_or_else(|| mlua::Error::runtime("pack: not available here"))?
+        .clone();
+    let mut declarations = store.lock().expect("pack declarations");
+    if declarations.drained {
+        return Err(mlua::Error::runtime(
+            "maki.packadd: packages have already been loaded, so it only works \
+             while init.lua and the packages themselves are running",
+        ));
+    }
+    // Two calls naming one package still load it once. The name is checked
+    // against what discovery found when the host drains this, so an unknown
+    // one is reported there rather than guessed at here.
+    if !declarations.pending.contains(&op) {
+        declarations.pending.push(op);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PackOp, PackStore, add_packadd};
+    use mlua::Lua;
+
+    fn lua_with_store() -> (Lua, PackStore) {
+        let lua = Lua::new();
+        let store = PackStore::default();
+        lua.set_app_data(store.clone());
+        (lua, store)
+    }
+
+    #[test]
+    fn packadd_records_each_named_package_once() {
+        let (lua, store) = lua_with_store();
+        let maki = lua.create_table().unwrap();
+        add_packadd(&lua, &maki).unwrap();
+        let f: mlua::Function = maki.get("packadd").expect("packadd is on the root table");
+        f.call::<()>("goal").unwrap();
+        f.call::<()>("review").unwrap();
+        f.call::<()>("goal").unwrap();
+        assert_eq!(
+            store.lock().unwrap().pending,
+            vec![
+                PackOp::Activate {
+                    name: "goal".to_owned()
+                },
+                PackOp::Activate {
+                    name: "review".to_owned()
+                }
+            ],
+            "a repeated call must not load the package twice"
+        );
+    }
+
+    #[test]
+    fn packadd_after_the_drain_is_refused() {
+        let (lua, store) = lua_with_store();
+        let maki = lua.create_table().unwrap();
+        add_packadd(&lua, &maki).unwrap();
+        store.lock().unwrap().drained = true;
+
+        let f: mlua::Function = maki.get("packadd").expect("packadd is on the root table");
+        let err = f
+            .call::<()>("goal")
+            .expect_err("nothing reads the queue after the drain");
+        assert!(
+            err.to_string().contains("already been loaded"),
+            "got: {err}"
+        );
+        assert!(
+            store.lock().unwrap().pending.is_empty(),
+            "a refused call must not leave a request behind"
+        );
+    }
+
+    #[test]
+    fn packadd_without_a_store_reports_rather_than_panicking() {
+        let lua = Lua::new();
+        let maki = lua.create_table().unwrap();
+        add_packadd(&lua, &maki).unwrap();
+        let f: mlua::Function = maki.get("packadd").unwrap();
+        assert!(f.call::<()>("goal").is_err());
+    }
+}

--- a/maki-lua/src/api/pack.rs
+++ b/maki-lua/src/api/pack.rs
@@ -1,140 +1,670 @@
-//! `maki.packadd`, the activation path for a package under `pack/*/opt/`.
+//! Global package declarations and read-only package state.
 
+use std::collections::BTreeSet;
 use std::sync::{Arc, Mutex};
 
-use maki_lua_macro::lua_fn;
-use mlua::{Lua, Result as LuaResult, Table};
+use maki_lua_macro::{lua_fn, lua_table};
+use maki_pack::Spec;
+use mlua::{Lua, MultiValue, RegistryKey, Result as LuaResult, Table, Value as LuaValue};
 
-/// A package activation requested from Lua.
-#[derive(Debug, PartialEq, Eq)]
-pub enum PackOp {
-    /// Load a package that is installed but not loaded.
-    Activate { name: String },
+/// What `pack.add` and `packadd` refuse once startup has loaded the declared
+/// set: nothing reads either list again, so a late call has to say so rather
+/// than record something that will never happen.
+const AFTER_LOAD: &str = "packages have already been loaded";
+/// A name is one package. Two sources under it are a mistake in `init.lua`,
+/// not a preference to resolve silently.
+const ALREADY_DECLARED: &str = "is already declared";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LoadMode {
+    Eager,
+    Dormant,
+    Custom(Arc<RegistryKey>),
 }
 
-/// What Lua recorded for the host to act on.
-///
-/// Session state only. Nothing here runs inline: loading an owner blocks on a
-/// reply from the runtime thread that the calling Lua task is occupying, so
-/// acting on a request from inside the call would wait on itself.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone)]
+pub struct Declared {
+    pub spec: Spec,
+    pub load: LoadMode,
+    pub confirm: bool,
+    pub data: Option<Arc<RegistryKey>>,
+}
+
+#[derive(Debug, Default, Clone)]
 pub struct PackDeclarations {
+    pub specs: Vec<Declared>,
+    pub active: BTreeSet<String>,
     pub pending: Vec<PackOp>,
-    /// Set once the startup drain is over.
-    ///
-    /// Nothing reads `pending` after that point, so a `packadd` from a command
-    /// handler or a keymap would sit here for the rest of the session with no
-    /// error and no log. It is refused instead.
     pub drained: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PackOp {
+    Activate { name: String },
 }
 
 pub type PackStore = Arc<Mutex<PackDeclarations>>;
 
-/// Registers `maki.packadd` on the root table.
-///
-/// It sits beside the other always-available functions rather than in a table
-/// of its own, because activating code that is already installed and already
-/// approved is something any plugin may do.
-pub(crate) fn add_packadd(lua: &Lua, maki: &Table) -> LuaResult<()> {
-    maki.set("packadd", lua.create_function(packadd)?)
+fn reject_unknown_fields(table: &Table, allowed: &[&str], context: &str) -> LuaResult<()> {
+    for pair in table.clone().pairs::<LuaValue, LuaValue>() {
+        let (key, _) = pair?;
+        let LuaValue::String(key) = key else {
+            return Err(mlua::Error::runtime(format!(
+                "{context}: field names must be strings"
+            )));
+        };
+        let key = key.to_str()?;
+        if !allowed.contains(&key.as_ref()) {
+            return Err(mlua::Error::runtime(format!(
+                "{context}: unknown field {key:?}"
+            )));
+        }
+    }
+    Ok(())
 }
 
-/// Activate an installed `opt/` package, like `:packadd`.
+fn finish(spec: Spec) -> LuaResult<Spec> {
+    if maki_pack::git::http_source_has_userinfo(&spec.src) {
+        let source = crate::pack::sanitize_message(&maki_pack::git::redact(&spec.src));
+        return Err(mlua::Error::runtime(format!(
+            "pack.add: source {source:?} contains HTTP credentials; use a Git credential helper instead"
+        )));
+    }
+    if !maki_pack::name_is_safe(&spec.name) {
+        let source = crate::pack::sanitize_message(&maki_pack::git::redact(&spec.src));
+        return Err(mlua::Error::runtime(format!(
+            "pack.add: {:?} is not a usable package name for {source:?}; set 'name' explicitly",
+            spec.name
+        )));
+    }
+    if crate::loader::is_bundled(&spec.name) {
+        return Err(mlua::Error::runtime(format!(
+            "pack.add: {:?} is the name of a builtin plugin; set 'name' to something else",
+            spec.name
+        )));
+    }
+    Ok(spec)
+}
+
+fn parse_spec(lua: &Lua, value: LuaValue) -> LuaResult<(Spec, Option<Arc<RegistryKey>>)> {
+    let table = match value {
+        LuaValue::String(source) => {
+            return finish(Spec::new(source.to_str()?.to_owned())).map(|spec| (spec, None));
+        }
+        LuaValue::Table(table) => table,
+        other => {
+            return Err(mlua::Error::runtime(format!(
+                "pack.add: each spec must be a string or a table, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    reject_unknown_fields(&table, &["src", "name", "version", "data"], "pack.add spec")?;
+
+    let source = match table.get::<LuaValue>("src")? {
+        LuaValue::String(source) => source.to_str()?.to_owned(),
+        LuaValue::Nil => return Err(mlua::Error::runtime("pack.add: spec is missing 'src'")),
+        other => {
+            return Err(mlua::Error::runtime(format!(
+                "pack.add: 'src' must be a string, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    if source.trim().is_empty() {
+        return Err(mlua::Error::runtime("pack.add: 'src' must not be empty"));
+    }
+
+    let mut spec = Spec::new(source);
+    match table.get::<LuaValue>("name")? {
+        LuaValue::Nil => {}
+        LuaValue::String(name) => {
+            let name = name.to_str()?.to_owned();
+            if name.is_empty() {
+                return Err(mlua::Error::runtime("pack.add: 'name' must not be empty"));
+            }
+            spec = spec.with_name(name);
+        }
+        other => {
+            return Err(mlua::Error::runtime(format!(
+                "pack.add: 'name' must be a string, got {}",
+                other.type_name()
+            )));
+        }
+    }
+    match table.get::<LuaValue>("version")? {
+        LuaValue::Nil => {}
+        LuaValue::String(version) => {
+            let version = version.to_str()?.to_owned();
+            if version.trim().is_empty() {
+                return Err(mlua::Error::runtime(
+                    "pack.add: 'version' must not be empty",
+                ));
+            }
+            spec = spec.with_version(version);
+        }
+        other => {
+            return Err(mlua::Error::runtime(format!(
+                "pack.add: 'version' must be a string, got {}",
+                other.type_name()
+            )));
+        }
+    }
+    let data = match table.get::<LuaValue>("data")? {
+        LuaValue::Nil => None,
+        value => Some(Arc::new(lua.create_registry_value(value)?)),
+    };
+    finish(spec).map(|spec| (spec, data))
+}
+
+/// Declare global packages after the global `init.lua` finishes.
 ///
-/// Loading happens after this call returns. The startup package pass reports
-/// an unknown, disabled, or failed package.
-///
-/// @param name string Package to activate.
+/// @param specs table Sources or tables with `src`, `name`, `version`, and `data`.
+/// @param opts table? `confirm` controls source confirmation. `load` is a
+///   boolean or a custom loader function.
 /// @example
-/// maki.packadd("maki-goal")
+/// maki.pack.add({
+///   { src = "https://github.com/user/maki-goal", version = "main" },
+/// })
 #[lua_fn]
-fn packadd(lua: &Lua, name: String) -> LuaResult<()> {
-    enqueue(lua, PackOp::Activate { name })
+fn add(lua: &Lua, specs: Table, opts: Option<Table>) -> LuaResult<()> {
+    let store = lua
+        .app_data_ref::<PackStore>()
+        .ok_or_else(|| mlua::Error::runtime("pack.add: not available here"))?
+        .clone();
+    let (load, confirm) = parse_options(lua, opts)?;
+    let mut parsed = Vec::new();
+    for entry in specs.sequence_values::<LuaValue>() {
+        let (spec, data) = parse_spec(lua, entry?)?;
+        parsed.push(Declared {
+            spec,
+            load: load.clone(),
+            confirm,
+            data,
+        });
+    }
+
+    let mut declarations = store.lock().expect("pack declarations");
+    if declarations.drained {
+        return Err(mlua::Error::runtime(format!("pack.add: {AFTER_LOAD}")));
+    }
+    for declared in parsed {
+        let existing = declarations
+            .specs
+            .iter()
+            .find(|existing| existing.spec.name == declared.spec.name);
+        match existing {
+            Some(existing) if existing.spec != declared.spec => {
+                let source =
+                    crate::pack::sanitize_message(&maki_pack::git::redact(&existing.spec.src));
+                return Err(mlua::Error::runtime(format!(
+                    "pack.add: {:?} {ALREADY_DECLARED} for {source:?}",
+                    declared.spec.name
+                )));
+            }
+            Some(_) => {}
+            None => declarations.specs.push(declared),
+        }
+    }
+    Ok(())
 }
 
-fn enqueue(lua: &Lua, op: PackOp) -> LuaResult<()> {
+fn parse_options(lua: &Lua, opts: Option<Table>) -> LuaResult<(LoadMode, bool)> {
+    let Some(opts) = opts else {
+        return Ok((LoadMode::Eager, true));
+    };
+    reject_unknown_fields(&opts, &["confirm", "load"], "pack.add")?;
+    let confirm = match opts.get::<LuaValue>("confirm")? {
+        LuaValue::Nil => true,
+        LuaValue::Boolean(confirm) => confirm,
+        other => {
+            return Err(mlua::Error::runtime(format!(
+                "pack.add: 'confirm' must be a boolean, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    let load = match opts.get::<LuaValue>("load")? {
+        LuaValue::Nil | LuaValue::Boolean(true) => LoadMode::Eager,
+        LuaValue::Boolean(false) => LoadMode::Dormant,
+        LuaValue::Function(function) => {
+            LoadMode::Custom(Arc::new(lua.create_registry_value(function)?))
+        }
+        other => {
+            return Err(mlua::Error::runtime(format!(
+                "pack.add: 'load' must be a boolean or function, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    Ok((load, confirm))
+}
+
+fn enqueue(lua: &Lua, name: String) -> LuaResult<()> {
+    if !maki_pack::name_is_safe(&name) {
+        return Err(mlua::Error::runtime(format!(
+            "pack: {name:?} is not a usable package name"
+        )));
+    }
     let store = lua
         .app_data_ref::<PackStore>()
         .ok_or_else(|| mlua::Error::runtime("pack: not available here"))?
         .clone();
     let mut declarations = store.lock().expect("pack declarations");
     if declarations.drained {
-        return Err(mlua::Error::runtime(
-            "maki.packadd: packages have already been loaded, so it only works \
-             while init.lua and the packages themselves are running",
-        ));
+        return Err(mlua::Error::runtime(format!("maki.packadd: {AFTER_LOAD}")));
     }
-    // Two calls naming one package still load it once. The name is checked
-    // against what discovery found when the host drains this, so an unknown
-    // one is reported there rather than guessed at here.
-    if !declarations.pending.contains(&op) {
-        declarations.pending.push(op);
+    let operation = PackOp::Activate { name };
+    if !declarations.pending.contains(&operation) {
+        declarations.pending.push(operation);
     }
     Ok(())
 }
 
+/// Load an installed package that is not active.
+///
+/// @param name string Package name.
+#[lua_fn]
+fn packadd(lua: &Lua, name: String) -> LuaResult<()> {
+    enqueue(lua, name)
+}
+
+pub(crate) fn add_packadd(lua: &Lua, maki: &Table) -> LuaResult<()> {
+    maki.set("packadd", lua.create_function(packadd)?)
+}
+
+/// Get package state without changing the installed set.
+///
+/// @param names table? Package names. Omit for all managed packages.
+/// @param opts table? Reserved. Omit it.
+/// @return (table) Package records with `spec`, `path`, `rev`, and `active`.
+#[lua_fn]
+fn get(lua: &Lua, names: Option<Table>, opts: Option<Table>) -> LuaResult<Table> {
+    if let Some(opts) = opts {
+        reject_unknown_fields(&opts, &[], "pack.get")?;
+    }
+    let requested: Option<Vec<String>> = names
+        .map(|table| table.sequence_values::<String>().collect())
+        .transpose()?;
+    let store = lua
+        .app_data_ref::<PackStore>()
+        .ok_or_else(|| mlua::Error::runtime("pack.get: not available here"))?
+        .clone();
+    let declarations = store.lock().expect("pack declarations").clone();
+    let lock = crate::pack::read_lockfile(crate::pack::lockfile_path().as_deref())
+        .ok_or_else(|| mlua::Error::runtime("pack.get: pack lockfile is unreadable"))?;
+    let site = crate::pack::site_dir().ok();
+    package_state_table(lua, requested, &declarations, &lock, site.as_deref())
+}
+
+fn package_state_table(
+    lua: &Lua,
+    requested: Option<Vec<String>>,
+    declarations: &PackDeclarations,
+    lock: &maki_pack::lockfile::Lockfile,
+    site: Option<&std::path::Path>,
+) -> LuaResult<Table> {
+    let names = requested.unwrap_or_else(|| {
+        let mut names: Vec<String> = declarations
+            .specs
+            .iter()
+            .map(|declared| declared.spec.name.clone())
+            .collect();
+        let extras: Vec<String> = lock
+            .install_order()
+            .filter(|name| !names.iter().any(|known| known == *name))
+            .map(str::to_owned)
+            .collect();
+        names.extend(extras);
+        names
+    });
+    let manager = site.map(maki_pack::manager::Manager::new);
+    let result = lua.create_table()?;
+    for (index, name) in names.into_iter().enumerate() {
+        let declared = declarations
+            .specs
+            .iter()
+            .find(|declared| declared.spec.name == name);
+        let locked = lock
+            .get(&name)
+            .filter(|entry| declared.is_none_or(|declared| declared.spec.src == entry.src));
+        if declared.is_none() && locked.is_none() {
+            return Err(mlua::Error::runtime(format!(
+                "pack.get: package {name:?} is not installed"
+            )));
+        }
+        let fallback;
+        let spec = match declared {
+            Some(declared) => &declared.spec,
+            None => {
+                let entry = locked.expect("checked above");
+                fallback = Spec::new(entry.src.clone()).with_name(name.clone());
+                &fallback
+            }
+        };
+        let item = lua.create_table()?;
+        item.set(
+            "spec",
+            spec_to_lua(
+                lua,
+                spec,
+                declared.and_then(|declared| declared.data.as_ref()),
+            )?,
+        )?;
+        item.set(
+            "path",
+            manager
+                .as_ref()
+                .and_then(|manager| locked.and_then(|_| manager.resolve(lock, &name)))
+                .map(|path| path.display().to_string()),
+        )?;
+        item.set("rev", locked.map(|entry| entry.rev.as_str()))?;
+        item.set("active", declarations.active.contains(&name))?;
+        result.set(index + 1, item)?;
+    }
+    Ok(result)
+}
+
+pub(crate) fn spec_to_lua(
+    lua: &Lua,
+    spec: &Spec,
+    data: Option<&Arc<RegistryKey>>,
+) -> LuaResult<Table> {
+    let table = lua.create_table()?;
+    table.set("src", maki_pack::git::redact(&spec.src))?;
+    table.set("name", spec.name.as_str())?;
+    if let Some(version) = &spec.version {
+        table.set("version", version.as_str())?;
+    }
+    if let Some(data) = data {
+        table.set("data", lua.registry_value::<LuaValue>(data.as_ref())?)?;
+    }
+    Ok(table)
+}
+
+pub(crate) fn create_pack_read_table(lua: &Lua) -> LuaResult<Table> {
+    let table = lua.create_table()?;
+    table.set(
+        "add",
+        lua.create_function(|_, _: MultiValue| -> LuaResult<()> {
+            Err(mlua::Error::runtime(
+                "maki.pack.add is only available in the global init.lua",
+            ))
+        })?,
+    )?;
+    table.set(
+        "get",
+        lua.create_function(|lua, (names, opts): (Option<Table>, Option<Table>)| {
+            get(lua, names, opts)
+        })?,
+    )?;
+    Ok(table)
+}
+
+lua_table! {
+    /// Declare global packages and inspect package state.
+    ///
+    /// `add` is available only in the global `init.lua`. `get` is read-only
+    /// and is available in project config and packages.
+    "maki.pack" => pub(crate) fn create_pack_table(), DOCS [
+        add, get,
+    ]
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{PackOp, PackStore, add_packadd};
-    use mlua::Lua;
+    use super::*;
+    use test_case::test_case;
+
+    const TEST_REV: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
     fn lua_with_store() -> (Lua, PackStore) {
         let lua = Lua::new();
-        let store = PackStore::default();
+        let store: PackStore = Arc::default();
         lua.set_app_data(store.clone());
         (lua, store)
     }
 
+    fn add_fn(lua: &Lua) -> mlua::Function {
+        create_pack_table(lua).unwrap().get("add").unwrap()
+    }
+
     #[test]
-    fn packadd_records_each_named_package_once() {
+    fn a_table_spec_carries_name_version_and_data() {
         let (lua, store) = lua_with_store();
-        let maki = lua.create_table().unwrap();
-        add_packadd(&lua, &maki).unwrap();
-        let f: mlua::Function = maki.get("packadd").expect("packadd is on the root table");
-        f.call::<()>("goal").unwrap();
-        f.call::<()>("review").unwrap();
-        f.call::<()>("goal").unwrap();
-        assert_eq!(
-            store.lock().unwrap().pending,
-            vec![
-                PackOp::Activate {
-                    name: "goal".to_owned()
-                },
-                PackOp::Activate {
-                    name: "review".to_owned()
-                }
-            ],
-            "a repeated call must not load the package twice"
+        let data = lua.create_table().unwrap();
+        data.set("number", 7).unwrap();
+        let spec = lua.create_table().unwrap();
+        spec.set("src", "https://github.com/user/repo").unwrap();
+        spec.set("name", "custom").unwrap();
+        spec.set("version", "v1.2.3").unwrap();
+        spec.set("data", data).unwrap();
+        add_fn(&lua)
+            .call::<()>(lua.create_sequence_from([spec]).unwrap())
+            .unwrap();
+
+        let declared = store.lock().unwrap().specs[0].clone();
+        assert_eq!(declared.spec.name, "custom");
+        assert_eq!(declared.spec.version.as_deref(), Some("v1.2.3"));
+        let output = spec_to_lua(&lua, &declared.spec, declared.data.as_ref()).unwrap();
+        let output_data: Table = output.get("data").unwrap();
+        assert_eq!(output_data.get::<i64>("number").unwrap(), 7);
+    }
+
+    #[test]
+    fn a_version_table_is_rejected() {
+        let (lua, _) = lua_with_store();
+        let spec = lua.create_table().unwrap();
+        spec.set("src", "https://github.com/user/repo").unwrap();
+        spec.set("version", lua.create_table().unwrap()).unwrap();
+
+        assert!(
+            add_fn(&lua)
+                .call::<()>(lua.create_sequence_from([spec]).unwrap())
+                .is_err()
         );
     }
 
     #[test]
-    fn packadd_after_the_drain_is_refused() {
+    fn custom_loader_is_retained_in_the_registry() {
         let (lua, store) = lua_with_store();
-        let maki = lua.create_table().unwrap();
-        add_packadd(&lua, &maki).unwrap();
+        let specs = lua
+            .create_sequence_from(["https://github.com/user/repo"])
+            .unwrap();
+        let opts = lua.create_table().unwrap();
+        opts.set("load", lua.create_function(|_, ()| Ok(())).unwrap())
+            .unwrap();
+        add_fn(&lua).call::<()>((specs, opts)).unwrap();
+
+        assert!(matches!(
+            store.lock().unwrap().specs[0].load,
+            LoadMode::Custom(_)
+        ));
+    }
+
+    /// Re-running the same declaration is how a shared `init.lua` snippet
+    /// behaves, so it stays a no-op rather than an error.
+    #[test]
+    fn an_identical_second_declaration_of_a_name_wins() {
+        let (lua, store) = lua_with_store();
+        let source = "https://example.com/one/repo";
+        for _ in 0..2 {
+            add_fn(&lua)
+                .call::<()>(lua.create_sequence_from([source]).unwrap())
+                .unwrap();
+        }
+
+        let declarations = store.lock().unwrap();
+        assert_eq!(declarations.specs.len(), 1);
+        assert_eq!(declarations.specs[0].spec.src, source);
+    }
+
+    #[test_case("https://example.com/two/repo", None ; "another_source")]
+    #[test_case("https://example.com/one/repo", Some("v2") ; "another_version")]
+    fn a_contradicting_declaration_of_a_name_is_refused(source: &str, version: Option<&str>) {
+        let (lua, store) = lua_with_store();
+        add_fn(&lua)
+            .call::<()>(
+                lua.create_sequence_from(["https://example.com/one/repo"])
+                    .unwrap(),
+            )
+            .unwrap();
+
+        let spec = lua.create_table().unwrap();
+        spec.set("src", source).unwrap();
+        if let Some(version) = version {
+            spec.set("version", version).unwrap();
+        }
+        let error = add_fn(&lua)
+            .call::<()>(lua.create_sequence_from([spec]).unwrap())
+            .expect_err("a second source for one name must be refused")
+            .to_string();
+
+        assert!(
+            error.contains(ALREADY_DECLARED),
+            "unexpected error: {error}"
+        );
+        assert_eq!(store.lock().unwrap().specs.len(), 1);
+    }
+
+    /// Nothing reads the declared set after startup, so a late `pack.add` has
+    /// to fail the way `packadd` does instead of recording a dead entry.
+    #[test]
+    fn adding_after_the_declared_set_was_loaded_is_refused() {
+        let (lua, store) = lua_with_store();
         store.lock().unwrap().drained = true;
 
-        let f: mlua::Function = maki.get("packadd").expect("packadd is on the root table");
-        let err = f
-            .call::<()>("goal")
-            .expect_err("nothing reads the queue after the drain");
-        assert!(
-            err.to_string().contains("already been loaded"),
-            "got: {err}"
-        );
-        assert!(
-            store.lock().unwrap().pending.is_empty(),
-            "a refused call must not leave a request behind"
+        let error = add_fn(&lua)
+            .call::<()>(
+                lua.create_sequence_from(["https://example.com/one/repo"])
+                    .unwrap(),
+            )
+            .expect_err("a declaration after the load must be refused")
+            .to_string();
+
+        assert!(error.contains(AFTER_LOAD), "unexpected error: {error}");
+        assert!(store.lock().unwrap().specs.is_empty());
+    }
+
+    #[test]
+    fn packadd_queues_one_activation() {
+        let (lua, store) = lua_with_store();
+        let maki = lua.create_table().unwrap();
+        add_packadd(&lua, &maki).unwrap();
+        let packadd: mlua::Function = maki.get("packadd").unwrap();
+
+        packadd.call::<()>("demo").unwrap();
+        packadd.call::<()>("demo").unwrap();
+
+        assert_eq!(
+            store.lock().unwrap().pending,
+            vec![PackOp::Activate {
+                name: "demo".to_owned()
+            }]
         );
     }
 
     #[test]
-    fn packadd_without_a_store_reports_rather_than_panicking() {
-        let lua = Lua::new();
-        let maki = lua.create_table().unwrap();
-        add_packadd(&lua, &maki).unwrap();
-        let f: mlua::Function = maki.get("packadd").unwrap();
-        assert!(f.call::<()>("goal").is_err());
+    fn get_preserves_order_and_reports_exact_state() {
+        let (lua, store) = lua_with_store();
+        let zeta = lua.create_table().unwrap();
+        zeta.set("src", "https://example.com/zeta").unwrap();
+        zeta.set("data", "kept").unwrap();
+        let alpha = lua.create_table().unwrap();
+        alpha.set("src", "https://example.com/alpha").unwrap();
+        add_fn(&lua)
+            .call::<()>(lua.create_sequence_from([zeta, alpha]).unwrap())
+            .unwrap();
+        store.lock().unwrap().active.insert("alpha".to_owned());
+
+        let site = tempfile::TempDir::new().unwrap();
+        let mut lock = maki_pack::lockfile::Lockfile::default();
+        lock.record("alpha", "https://example.com/alpha", TEST_REV);
+        lock.record("legacy", "https://example.com/legacy", TEST_REV);
+        for name in ["alpha", "legacy"] {
+            std::fs::create_dir_all(maki_pack::paths::revision_dir(site.path(), name, TEST_REV))
+                .unwrap();
+        }
+        let declarations = store.lock().unwrap().clone();
+
+        let all = package_state_table(&lua, None, &declarations, &lock, Some(site.path())).unwrap();
+        assert_eq!(all.raw_len(), 3);
+        assert_eq!(
+            all.get::<Table>(1)
+                .unwrap()
+                .get::<Table>("spec")
+                .unwrap()
+                .get::<String>("name")
+                .unwrap(),
+            "zeta"
+        );
+        assert_eq!(
+            all.get::<Table>(3)
+                .unwrap()
+                .get::<Table>("spec")
+                .unwrap()
+                .get::<String>("name")
+                .unwrap(),
+            "legacy"
+        );
+
+        let filtered = package_state_table(
+            &lua,
+            Some(vec!["alpha".to_owned(), "zeta".to_owned()]),
+            &declarations,
+            &lock,
+            Some(site.path()),
+        )
+        .unwrap();
+        let alpha: Table = filtered.get(1).unwrap();
+        assert!(alpha.get::<bool>("active").unwrap());
+        assert_eq!(alpha.get::<String>("rev").unwrap(), TEST_REV);
+        assert_eq!(
+            alpha.get::<String>("path").unwrap(),
+            maki_pack::paths::revision_dir(site.path(), "alpha", TEST_REV)
+                .display()
+                .to_string()
+        );
+        let zeta: Table = filtered.get(2).unwrap();
+        let zeta_spec: Table = zeta.get("spec").unwrap();
+        assert_eq!(zeta_spec.get::<String>("data").unwrap(), "kept");
+        assert!(zeta.get::<Option<String>>("rev").unwrap().is_none());
+        assert!(!zeta.get::<bool>("active").unwrap());
+    }
+
+    #[test]
+    fn get_rejects_missing_names_and_hides_replaced_source_state() {
+        let (lua, store) = lua_with_store();
+        add_fn(&lua)
+            .call::<()>(
+                lua.create_sequence_from(["https://example.com/new/demo"])
+                    .unwrap(),
+            )
+            .unwrap();
+        let declarations = store.lock().unwrap().clone();
+        let mut lock = maki_pack::lockfile::Lockfile::default();
+        lock.record("demo", "https://example.com/old/demo", TEST_REV);
+
+        let replaced = package_state_table(
+            &lua,
+            Some(vec!["demo".to_owned()]),
+            &declarations,
+            &lock,
+            None,
+        )
+        .unwrap();
+        let item: Table = replaced.get(1).unwrap();
+        assert!(item.get::<Option<String>>("path").unwrap().is_none());
+        assert!(item.get::<Option<String>>("rev").unwrap().is_none());
+
+        let error = package_state_table(
+            &lua,
+            Some(vec!["missing".to_owned()]),
+            &declarations,
+            &lock,
+            None,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("not installed"), "{error}");
     }
 }

--- a/maki-lua/src/api/util/setup.rs
+++ b/maki-lua/src/api/util/setup.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use maki_config::RawConfig;
 use mlua::{Function, Lua, LuaSerdeExt, Result as LuaResult};
 
-use crate::api::split::split__doc;
+use crate::api::{pack::packadd__doc, split::split__doc};
 use crate::docs::{DocKind, FnDoc, ModuleDoc, ParamDoc};
 
 pub(crate) type ConfigStore = Arc<Mutex<Option<RawConfig>>>;
@@ -34,6 +34,7 @@ accepts the same keys as the Configuration reference.",
 })",
         },
         split__doc,
+        packadd__doc,
     ],
 };
 

--- a/maki-lua/src/docs.rs
+++ b/maki-lua/src/docs.rs
@@ -53,6 +53,7 @@ pub fn api_docs() -> Vec<&'static ModuleDoc> {
     use crate::api;
     vec![
         &api::util::setup::DOCS,
+        &api::pack::DOCS,
         &api::tool::DOCS,
         &api::autocmd::DOCS,
         &api::slot::DOCS,
@@ -157,11 +158,23 @@ mod tests {
                 .insert(key);
         }
 
+        // Documented here but attached by the runtime rather than by
+        // `create_maki_global`, so the table built for this test has none of
+        // it. `setup` is attached only when a config store is present.
+        const RUNTIME_ATTACHED: [&str; 1] = ["setup"];
+
         for (name, mut expected) in documented {
+            if RUNTIME_ATTACHED
+                .iter()
+                .any(|only| name == format!("maki.{only}"))
+            {
+                continue;
+            }
             let actual = table_keys(&resolve_table(&maki, name));
             if name == "maki" {
-                // Documented here, but injected later by the runtime.
-                expected.remove("setup");
+                for only in RUNTIME_ATTACHED {
+                    expected.remove(only);
+                }
             }
             let expected: BTreeSet<String> = expected.iter().map(|s| s.to_string()).collect();
             assert_eq!(

--- a/maki-lua/src/error.rs
+++ b/maki-lua/src/error.rs
@@ -17,12 +17,30 @@ pub enum PluginError {
         #[source]
         source: io::Error,
     },
-    #[error(
-        "plugins.{plugin} sets options ({keys}), but there is no bundled plugin named \"{plugin}\""
-    )]
-    UnknownPluginOptions { plugin: String, keys: String },
     #[error("no bundled plugin named \"{plugin}\" (enabled via plugins.{plugin})")]
     UnknownPlugin { plugin: String },
     #[error("plugin host is not running")]
     HostDead,
+    #[error("package {name} at {path} has no plugin/*.lua entrypoint")]
+    PackageEmpty { name: String, path: PathBuf },
+    #[error("package file {path} resolves outside its package directory")]
+    PackageEscape { path: PathBuf },
+    #[error(
+        "package \"{name}\" at {path} has the same name as a bundled plugin; \
+         rename its directory"
+    )]
+    PackageNameConflict { name: String, path: PathBuf },
+    #[error("package manifest {path} is not valid toml: {message}")]
+    PackageManifest { path: PathBuf, message: String },
+    #[error("cannot resolve the maki data directory, so no package was looked for: {source}")]
+    PackageSiteUnavailable {
+        #[source]
+        source: io::Error,
+    },
+    #[error("two packages are both named \"{name}\": {first} and {second}")]
+    DuplicatePackage {
+        name: String,
+        first: PathBuf,
+        second: PathBuf,
+    },
 }

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -10,6 +10,7 @@ mod runtime;
 
 pub use api::keymap::{KeymapEntry, KeymapReader, KeymapSnapshot};
 pub use api::options::{OptionSpec, OptionType, PluginOptionSpecs};
+pub use api::pack::{Declared, PackOp};
 pub use api::util::command::{
     Anchor, Axis, Border, BuiltinAction, Dimension, Edge, FloatConfig, FloatConfigPatch,
     HintReader, HintSnapshot, LuaCommandInfo, LuaCommandReader, ModelRequest, SessionRequest,
@@ -19,8 +20,8 @@ pub use docs::{DocKind, FnDoc, ModuleDoc, ParamDoc, api_docs};
 pub use error::PluginError;
 pub use loader::{EventHandle, PluginHost};
 pub use pack::{
-    DiscoveredPackage, Discovery, MANAGED_GROUP, discover, discover_installed, sanitize_message,
-    site_dir,
+    DiscoveredPackage, Discovery, InstallReport, Interaction, MANAGED_GROUP, Origin, discover,
+    discover_installed, install_declared, lockfile_path, sanitize_message, site_dir,
 };
 pub use plugin_permissions::{Permission, PluginPermissions, Requested};
 pub use runtime::{KILL_GRACE, RestoreItem, WARM_TOOL_CAP};

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -4,6 +4,7 @@ pub mod docs_render;
 mod error;
 pub mod language;
 mod loader;
+mod pack;
 pub(crate) mod plugin_permissions;
 mod runtime;
 
@@ -17,7 +18,11 @@ pub use api::util::command::{
 pub use docs::{DocKind, FnDoc, ModuleDoc, ParamDoc, api_docs};
 pub use error::PluginError;
 pub use loader::{EventHandle, PluginHost};
-pub use plugin_permissions::{Permission, PluginPermissions};
+pub use pack::{
+    DiscoveredPackage, Discovery, MANAGED_GROUP, discover, discover_installed, sanitize_message,
+    site_dir,
+};
+pub use plugin_permissions::{Permission, PluginPermissions, Requested};
 pub use runtime::{KILL_GRACE, RestoreItem, WARM_TOOL_CAP};
 
 pub mod test_support {

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -14,8 +14,9 @@ use crate::api::keymap::KeymapReader;
 use crate::api::options::{PluginOptionSpecs, PluginOpts};
 use crate::api::util::command::{HintReader, LuaCommandReader, UiAction};
 use crate::error::PluginError;
+use crate::pack::DiscoveredPackage;
 use crate::plugin_permissions::{PluginPermissions, load_plugin_permissions};
-use crate::runtime::{self, ClickFallback, LuaThread, Request, RestoreItem};
+use crate::runtime::{self, ClickFallback, LoadChunk, LuaThread, Request, RestoreItem};
 use maki_agent::prompt::ResolvedSlots;
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
@@ -110,6 +111,13 @@ static BUNDLED_PLUGINS: &[BundledPlugin] = &[
     },
 ];
 
+/// Every bundled name, not just the default-enabled ones. An external package
+/// sharing an owner name with any of them would let one package's unload tear
+/// down the other's registrations.
+pub(crate) fn is_bundled(name: &str) -> bool {
+    BUNDLED_PLUGINS.iter().any(|p| p.name == name)
+}
+
 pub(crate) fn lib_dir() -> &'static Dir<'static> {
     &BUNDLED_PLUGINS
         .iter()
@@ -122,6 +130,54 @@ static BUNDLED_DIRS: LazyLock<&'static [&'static Dir<'static>]> = LazyLock::new(
     let dirs: Vec<&'static Dir<'static>> = BUNDLED_PLUGINS.iter().map(|p| &p.dir).collect();
     Vec::leak(dirs)
 });
+
+/// A package's entrypoints: every `plugin/*.lua`, sorted by filename so load
+/// order is deterministic across machines.
+///
+/// A repository can commit a symlink, so each entry is resolved and checked to
+/// be inside the package before it is read.
+fn package_entrypoints(root: &Path) -> Result<Vec<PathBuf>, PluginError> {
+    let entrypoint_dir = root.join("plugin");
+    let entries = match fs::read_dir(&entrypoint_dir) {
+        Ok(entries) => entries,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) => {
+            return Err(PluginError::Io {
+                path: entrypoint_dir,
+                source,
+            });
+        }
+    };
+    let mut files = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|source| PluginError::Io {
+            path: entrypoint_dir.clone(),
+            source,
+        })?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("lua") {
+            continue;
+        }
+        let resolved = path.canonicalize().map_err(|e| PluginError::Io {
+            path: path.clone(),
+            source: e,
+        })?;
+        if !resolved.starts_with(root) {
+            return Err(PluginError::PackageEscape { path });
+        }
+        if resolved.is_file() {
+            let Some(file_name) = path.file_name().map(std::ffi::OsString::from) else {
+                continue;
+            };
+            files.push((file_name, resolved));
+        }
+    }
+    // By file name, not by the resolved path: a package may symlink an entry
+    // elsewhere inside itself, and load order must still be the order a user
+    // sees in `plugin/`.
+    files.sort_by(|(a, _), (b, _)| a.cmp(b));
+    Ok(files.into_iter().map(|(_, path)| path).collect())
+}
 
 pub struct PluginHost {
     inner: LuaThread,
@@ -256,21 +312,25 @@ impl PluginHost {
 
     fn send_builtin_loads(&self, config: &PluginsConfig) -> Result<(), PluginError> {
         for (plugin, opts) in &config.opts {
+            // An enabled package takes its options when the package itself
+            // loads, and an enabled builtin takes them in the loop below.
+            if config.packages.contains(plugin) || config.names.contains(plugin) {
+                continue;
+            }
+            // What is left is a name that exists but is not loading: a builtin
+            // or a package the config disabled, or one discovery refused. It
+            // cannot be a typo, because the config layer validated every
+            // `plugins.<name>` key against the same names before this ran. A
+            // package used to reach this as an error, which stopped maki from
+            // starting over options it was already ignoring.
             let keys: Vec<&str> = opts.keys().map(String::as_str).collect();
-            if !BUNDLED_PLUGINS.iter().any(|p| p.name == plugin.as_str()) {
-                return Err(PluginError::UnknownPluginOptions {
-                    plugin: plugin.clone(),
-                    keys: keys.join(", "),
-                });
-            }
-            if !config.names.contains(plugin) {
-                tracing::warn!(
-                    plugin = plugin.as_str(),
-                    keys = keys.join(", "),
-                    "plugin is disabled; its plugins.{} options are ignored until re-enabled",
-                    plugin
-                );
-            }
+            tracing::warn!(
+                plugin = plugin.as_str(),
+                keys = keys.join(", "),
+                "nothing named {} is loading; its plugins.{} options are ignored",
+                plugin,
+                plugin
+            );
         }
         for builtin in &config.names {
             let dir = match BUNDLED_PLUGINS.iter().find(|p| p.name == builtin.as_str()) {
@@ -296,8 +356,8 @@ impl PluginHost {
                 .map(Arc::new)
                 .unwrap_or_default();
             self.send_load(
-                name,
-                init.to_owned(),
+                Arc::clone(&name),
+                vec![LoadChunk::new(name.as_ref(), init)],
                 None,
                 PluginPermissions::trusted(),
                 opts,
@@ -309,7 +369,7 @@ impl PluginHost {
     fn send_load(
         &self,
         name: Arc<str>,
-        source: String,
+        chunks: Vec<LoadChunk>,
         plugin_dir: Option<PathBuf>,
         permissions: PluginPermissions,
         opts: PluginOpts,
@@ -319,7 +379,7 @@ impl PluginHost {
             .tx
             .send(Request::LoadSource {
                 name,
-                source,
+                chunks,
                 plugin_dir,
                 permissions,
                 opts,
@@ -384,7 +444,7 @@ impl PluginHost {
     ) -> Result<(), PluginError> {
         self.send_load(
             Arc::from(name),
-            source.to_owned(),
+            vec![LoadChunk::new(name, source)],
             None,
             PluginPermissions::trusted(),
             Arc::new(opts),
@@ -399,7 +459,7 @@ impl PluginHost {
     ) -> Result<(), PluginError> {
         self.send_load(
             Arc::from(name),
-            source.to_owned(),
+            vec![LoadChunk::new(name, source)],
             None,
             permissions,
             PluginOpts::default(),
@@ -419,11 +479,182 @@ impl PluginHost {
         // unknown-plugin guards about user plugin names.
         self.send_load(
             Arc::from("user"),
-            source,
+            vec![LoadChunk::new(path.display().to_string(), source)],
             plugin_dir,
             permissions,
             PluginOpts::default(),
         )
+    }
+
+    /// Loads one external package directory as a single owner.
+    ///
+    /// Every `plugin/*.lua` becomes a chunk, and the chunks share one
+    /// environment, so what one file registers the next can use. The whole set
+    /// commits or none of it does.
+    pub fn load_package(
+        &self,
+        name: &str,
+        dir: &Path,
+        permissions: PluginPermissions,
+        opts: PluginOpts,
+    ) -> Result<(), PluginError> {
+        // Refused here and not only in discovery, because loading an owner
+        // drops that owner's existing registrations first. A package named
+        // after a bundled plugin would unload the builtin before its own
+        // entrypoint ever ran, so every caller has to be gated, not just the
+        // one that walks the site directory.
+        if is_bundled(name) {
+            return Err(PluginError::PackageNameConflict {
+                name: name.to_owned(),
+                path: dir.to_path_buf(),
+            });
+        }
+        // Resolved once here, so the manifest, the entrypoints, and later
+        // `require` calls all agree on one directory even if the path they came
+        // from changes underneath us.
+        let root = dir.canonicalize().map_err(|e| PluginError::Io {
+            path: dir.to_path_buf(),
+            source: e,
+        })?;
+        let files = package_entrypoints(&root)?;
+        if files.is_empty() {
+            return Err(PluginError::PackageEmpty {
+                name: name.to_owned(),
+                path: root,
+            });
+        }
+
+        let mut chunks = Vec::with_capacity(files.len());
+        for path in files {
+            let source = fs::read_to_string(&path).map_err(|e| PluginError::Io {
+                path: path.clone(),
+                source: e,
+            })?;
+            chunks.push(LoadChunk::new(path.display().to_string(), source));
+        }
+        self.send_load(Arc::from(name), chunks, Some(root), permissions, opts)
+    }
+
+    /// Refuses further `maki.packadd` calls, and returns anything the queue
+    /// still holds.
+    ///
+    /// One call and not a read followed by a close, because a Lua task can
+    /// record an activation between the two and closing would strand it.
+    fn seal_pack_ops(&self) -> Result<Vec<crate::api::pack::PackOp>, PluginError> {
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        self.inner
+            .tx
+            .send(Request::SealPackOps { reply: reply_tx })
+            .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)
+    }
+
+    /// Takes the package operations Lua recorded, leaving the queue empty.
+    ///
+    /// Called by the host after the initiating task has exited, which keeps a
+    /// load off the thread that requested it.
+    fn take_pending_pack_ops(&self) -> Result<Vec<crate::api::pack::PackOp>, PluginError> {
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        self.inner
+            .tx
+            .send(Request::TakePackOps { reply: reply_tx })
+            .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)
+    }
+
+    /// Loads every package that should be loaded now: the `start/` ones, and
+    /// the `opt/` ones that `maki.packadd` named.
+    ///
+    /// Activation names are collected here rather than acted on inside
+    /// `packadd`, because a load waits on a reply from the runtime thread that
+    /// `packadd` is called on. They are collected after each round as well as
+    /// before the first, so a package that activates another one still has it
+    /// loaded in this startup rather than the next.
+    pub fn load_packages(
+        &self,
+        packages: &[DiscoveredPackage],
+        config: &PluginsConfig,
+    ) -> Vec<String> {
+        let mut failures = Vec::new();
+        let mut loaded: Vec<&str> = Vec::new();
+        let mut round: Vec<&DiscoveredPackage> = packages
+            .iter()
+            .filter(|pkg| pkg.eager && config.packages.iter().any(|n| n == &pkg.name))
+            .collect();
+
+        // A `loop` and not `while !round.is_empty()`: with no `start` package
+        // installed the first round is empty, and the names `init.lua` already
+        // recorded still have to be collected.
+        loop {
+            for pkg in round {
+                let opts = config
+                    .opts
+                    .get(&pkg.name)
+                    .cloned()
+                    .map(Arc::new)
+                    .unwrap_or_default();
+                // A package the user installed by hand is granted what it asks
+                // for. Only a package maki fetched needs an approval as well.
+                let permissions = pkg.requested.clone().granted_for_manual_install();
+                loaded.push(&pkg.name);
+                if let Err(e) = self.load_package(&pkg.name, &pkg.dir, permissions, opts) {
+                    tracing::error!(
+                        package = %pkg.name,
+                        path = %pkg.dir.display(),
+                        error = %e,
+                        "failed to load package"
+                    );
+                    failures.push(format!("{}: failed to load: {e}", pkg.name));
+                }
+            }
+
+            let ops = match self.take_pending_pack_ops() {
+                Ok(ops) => ops,
+                Err(e) => {
+                    failures.push(format!("could not read package activations: {e}"));
+                    break;
+                }
+            };
+            round = Vec::new();
+            for op in ops {
+                let crate::api::pack::PackOp::Activate { name } = op;
+                if loaded.contains(&name.as_str()) {
+                    continue;
+                }
+                // Refused rather than loaded when the config disabled it, so
+                // `packadd` cannot be a way around `plugins.<name>.enabled`.
+                let found = packages
+                    .iter()
+                    .find(|pkg| pkg.name == name && config.packages.iter().any(|n| n == &pkg.name));
+                match found {
+                    Some(pkg) => round.push(pkg),
+                    None => failures.push(format!(
+                        "packadd {name:?}: no package with that name is installed"
+                    )),
+                }
+            }
+            if round.is_empty() {
+                break;
+            }
+        }
+        // Nothing drains the queue after this, so `packadd` is closed rather
+        // than left accepting names no one will read. Closing returns whatever
+        // arrived since the last round, which is reported rather than dropped:
+        // that request was going to be honoured a moment earlier.
+        match self.seal_pack_ops() {
+            Ok(leftover) => {
+                for op in leftover {
+                    let crate::api::pack::PackOp::Activate { name } = op;
+                    failures.push(format!(
+                        "packadd {name:?}: arrived after the packages had loaded"
+                    ));
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "could not close the package activation queue");
+            }
+        }
+        failures
     }
 
     pub fn event_handle(&self) -> EventHandle {
@@ -584,6 +815,27 @@ mod tests {
     use maki_agent::tools::ToolRegistry;
     use std::time::Instant;
     use test_case::test_case;
+
+    /// Closing the queue and reading it are one message. A Lua task can record
+    /// an activation between a separate read and close, and a close that threw
+    /// the queue away would strand exactly the request that was about to be
+    /// honoured.
+    #[test]
+    fn closing_the_activation_queue_hands_back_what_it_holds() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        host.load_source("recorder", r#"maki.packadd("demo")"#)
+            .expect("packadd is available to every plugin");
+
+        let leftover = host.seal_pack_ops().expect("the host is running");
+
+        assert_eq!(
+            leftover,
+            vec![crate::api::pack::PackOp::Activate {
+                name: "demo".to_owned()
+            }],
+            "a recorded activation must come back, not be dropped"
+        );
+    }
 
     /// jit=true is exercised by the whole integration suite
     /// (`tests/plugin_host.rs` boots hosts via `new`); only the O1

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -16,7 +16,9 @@ use crate::api::util::command::{HintReader, LuaCommandReader, UiAction};
 use crate::error::PluginError;
 use crate::pack::DiscoveredPackage;
 use crate::plugin_permissions::{PluginPermissions, load_plugin_permissions};
-use crate::runtime::{self, ClickFallback, LoadChunk, LuaThread, Request, RestoreItem};
+use crate::runtime::{
+    self, ClickFallback, ConfigScope, LoadChunk, LuaThread, Request, RestoreItem,
+};
 use maki_agent::prompt::ResolvedSlots;
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
@@ -255,12 +257,20 @@ impl PluginHost {
         let mut merged: Option<RawConfig> = None;
 
         for global_dir in maki_config::global_config_dirs() {
-            self.run_init_file(&global_dir.join("init.lua"), "global/init.lua", &mut merged)?;
+            self.run_init_file(
+                &global_dir.join("init.lua"),
+                ConfigScope::Global,
+                &mut merged,
+            )?;
             if merged.is_some() {
                 break;
             }
         }
-        self.run_init_file(&cwd.join(".maki/init.lua"), "project/init.lua", &mut merged)?;
+        self.run_init_file(
+            &cwd.join(".maki/init.lua"),
+            ConfigScope::Project,
+            &mut merged,
+        )?;
 
         Ok(merged)
     }
@@ -282,7 +292,7 @@ impl PluginHost {
     fn run_init_file(
         &self,
         path: &Path,
-        label: &str,
+        scope: ConfigScope,
         merged: &mut Option<RawConfig>,
     ) -> Result<(), PluginError> {
         if !path.is_file() {
@@ -293,7 +303,7 @@ impl PluginHost {
             source: e,
         })?;
         let plugin_dir = path.parent().map(Path::to_path_buf);
-        if let Some(raw) = self.send_run_init_lua(source, label.to_owned(), plugin_dir)? {
+        if let Some(raw) = self.send_config_lua(source, scope, plugin_dir)? {
             match merged {
                 Some(existing) => existing.merge(raw),
                 None => *merged = Some(raw),
@@ -361,11 +371,14 @@ impl PluginHost {
                 None,
                 PluginPermissions::trusted(),
                 opts,
+                None,
+                false,
             )?;
         }
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn send_load(
         &self,
         name: Arc<str>,
@@ -373,6 +386,8 @@ impl PluginHost {
         plugin_dir: Option<PathBuf>,
         permissions: PluginPermissions,
         opts: PluginOpts,
+        revision_guard: Option<Arc<maki_pack::lock::Lock>>,
+        package: bool,
     ) -> Result<(), PluginError> {
         let (reply_tx, reply_rx) = flume::bounded(1);
         self.inner
@@ -383,6 +398,8 @@ impl PluginHost {
                 plugin_dir,
                 permissions,
                 opts,
+                revision_guard,
+                package,
                 reply: reply_tx,
             })
             .map_err(|_| PluginError::HostDead)?;
@@ -406,12 +423,21 @@ impl PluginHost {
         source_name: String,
         plugin_dir: Option<PathBuf>,
     ) -> Result<Option<RawConfig>, PluginError> {
+        self.send_config_lua(source, ConfigScope::named(source_name), plugin_dir)
+    }
+
+    fn send_config_lua(
+        &self,
+        source: String,
+        scope: ConfigScope,
+        plugin_dir: Option<PathBuf>,
+    ) -> Result<Option<RawConfig>, PluginError> {
         let (reply_tx, reply_rx) = flume::bounded(1);
         self.inner
             .tx
             .send(Request::RunInitLua {
                 source,
-                source_name,
+                scope,
                 plugin_dir,
                 reply: reply_tx,
             })
@@ -448,6 +474,8 @@ impl PluginHost {
             None,
             PluginPermissions::trusted(),
             Arc::new(opts),
+            None,
+            false,
         )
     }
 
@@ -463,6 +491,8 @@ impl PluginHost {
             None,
             permissions,
             PluginOpts::default(),
+            None,
+            false,
         )
     }
 
@@ -483,7 +513,44 @@ impl PluginHost {
             plugin_dir,
             permissions,
             PluginOpts::default(),
+            None,
+            false,
         )
+    }
+
+    /// Packages declared by `maki.pack.add` in `init.lua`.
+    ///
+    /// Read after the init files have run, which is when the declared set is
+    /// complete and before anything is installed.
+    pub fn declared_packages(&self) -> Result<Vec<crate::api::pack::Declared>, PluginError> {
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        self.inner
+            .tx
+            .send(Request::CollectPackages { reply: reply_tx })
+            .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)
+    }
+
+    fn run_pack_loader(
+        &self,
+        declared: crate::api::pack::Declared,
+        package: &DiscoveredPackage,
+        permissions: PluginPermissions,
+        opts: PluginOpts,
+    ) -> Result<(), PluginError> {
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        self.inner
+            .tx
+            .send(Request::RunPackLoader {
+                declared,
+                path: package.dir.clone(),
+                permissions,
+                opts,
+                revision_guard: package.revision_guard.clone(),
+                reply: reply_tx,
+            })
+            .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)?
     }
 
     /// Loads one external package directory as a single owner.
@@ -497,6 +564,17 @@ impl PluginHost {
         dir: &Path,
         permissions: PluginPermissions,
         opts: PluginOpts,
+    ) -> Result<(), PluginError> {
+        self.load_package_with_guard(name, dir, permissions, opts, None)
+    }
+
+    fn load_package_with_guard(
+        &self,
+        name: &str,
+        dir: &Path,
+        permissions: PluginPermissions,
+        opts: PluginOpts,
+        revision_guard: Option<Arc<maki_pack::lock::Lock>>,
     ) -> Result<(), PluginError> {
         // Refused here and not only in discovery, because loading an owner
         // drops that owner's existing registrations first. A package named
@@ -532,15 +610,22 @@ impl PluginHost {
             })?;
             chunks.push(LoadChunk::new(path.display().to_string(), source));
         }
-        self.send_load(Arc::from(name), chunks, Some(root), permissions, opts)
+        self.send_load(
+            Arc::from(name),
+            chunks,
+            Some(root),
+            permissions,
+            opts,
+            revision_guard,
+            true,
+        )
     }
-
     /// Refuses further `maki.packadd` calls, and returns anything the queue
     /// still holds.
     ///
     /// One call and not a read followed by a close, because a Lua task can
     /// record an activation between the two and closing would strand it.
-    fn seal_pack_ops(&self) -> Result<Vec<crate::api::pack::PackOp>, PluginError> {
+    pub fn seal_pack_ops(&self) -> Result<Vec<crate::api::pack::PackOp>, PluginError> {
         let (reply_tx, reply_rx) = flume::bounded(1);
         self.inner
             .tx
@@ -575,6 +660,24 @@ impl PluginHost {
         packages: &[DiscoveredPackage],
         config: &PluginsConfig,
     ) -> Vec<String> {
+        self.load_packages_inner(packages, &[], config)
+    }
+
+    pub fn load_declared_packages(
+        &self,
+        packages: &[DiscoveredPackage],
+        declared: &[crate::api::pack::Declared],
+        config: &PluginsConfig,
+    ) -> Vec<String> {
+        self.load_packages_inner(packages, declared, config)
+    }
+
+    fn load_packages_inner(
+        &self,
+        packages: &[DiscoveredPackage],
+        declared: &[crate::api::pack::Declared],
+        config: &PluginsConfig,
+    ) -> Vec<String> {
         let mut failures = Vec::new();
         let mut loaded: Vec<&str> = Vec::new();
         let mut round: Vec<&DiscoveredPackage> = packages
@@ -593,11 +696,32 @@ impl PluginHost {
                     .cloned()
                     .map(Arc::new)
                     .unwrap_or_default();
-                // A package the user installed by hand is granted what it asks
-                // for. Only a package maki fetched needs an approval as well.
-                let permissions = pkg.requested.clone().granted_for_manual_install();
+                let permissions = crate::pack::effective_permissions(pkg);
                 loaded.push(&pkg.name);
-                if let Err(e) = self.load_package(&pkg.name, &pkg.dir, permissions, opts) {
+                let custom = declared
+                    .iter()
+                    .find(|declaration| declaration.spec.name == pkg.name)
+                    .filter(|declaration| {
+                        matches!(declaration.load, crate::api::pack::LoadMode::Custom(_))
+                            && matches!(
+                                &pkg.origin,
+                                crate::pack::Origin::Fetched { src }
+                                    if src == &declaration.spec.src
+                            )
+                    });
+                let result = match custom {
+                    Some(declaration) => {
+                        self.run_pack_loader(declaration.clone(), pkg, permissions, opts)
+                    }
+                    None => self.load_package_with_guard(
+                        &pkg.name,
+                        &pkg.dir,
+                        permissions,
+                        opts,
+                        pkg.revision_guard.clone(),
+                    ),
+                };
+                if let Err(e) = result {
                     tracing::error!(
                         package = %pkg.name,
                         path = %pkg.dir.display(),

--- a/maki-lua/src/pack.rs
+++ b/maki-lua/src/pack.rs
@@ -1,0 +1,429 @@
+//! Discovery of external packages installed under the site directory.
+//!
+//! This is the manual half of the package model: directories a user cloned
+//! themselves, laid out the way Neovim lays packages out. Packages that maki
+//! installs are resolved from recorded state instead, and never appear here.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::error::PluginError;
+use crate::loader::is_bundled;
+use crate::plugin_permissions::{Requested, load_requested_permissions};
+
+pub fn sanitize_message(message: &str) -> String {
+    message
+        .chars()
+        .map(|character| {
+            if character == '\n' || character == '\t' || !character.is_control() {
+                character
+            } else {
+                ' '
+            }
+        })
+        .collect()
+}
+
+/// The group name reserved for packages maki installs itself. Manual discovery
+/// skips it, so one package can never be found twice, once from disk and once
+/// from recorded state, with the two disagreeing about its revision.
+pub const MANAGED_GROUP: &str = "core";
+
+/// `<data>/site`, the root Neovim would call a package path.
+pub fn site_dir() -> Result<PathBuf, std::io::Error> {
+    maki_storage::paths::data_dir().map(|d| d.join("site"))
+}
+
+#[derive(Debug)]
+pub struct DiscoveredPackage {
+    pub name: String,
+    /// Canonical package root. Resolved once, here, so the manifest, the
+    /// entrypoints, and every later `require` agree on one directory.
+    pub dir: PathBuf,
+    /// `start/` packages load at startup; `opt/` packages wait to be activated.
+    pub eager: bool,
+    /// What the package's manifest asks for. A manually installed package is
+    /// granted this directly: the user placed the files.
+    pub requested: Requested,
+}
+
+/// Something the walk could not use, and the name it had for it.
+///
+/// One record and not two lists, because the name and the reason are two
+/// halves of one fact and the config layer needs the name: a `plugins.<name>`
+/// table naming a package that failed to load still names something real.
+#[derive(Debug)]
+pub struct Problem {
+    /// `None` when the failure belongs to no single package, such as a group
+    /// directory that could not be read at all.
+    pub name: Option<String>,
+    pub error: PluginError,
+}
+
+impl std::fmt::Display for Problem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.error)
+    }
+}
+
+/// What a discovery walk found, and what it had to refuse.
+///
+/// Problems are collected rather than returned as one error, because one
+/// unusable package must not stop the others from loading.
+#[derive(Debug, Default)]
+pub struct Discovery {
+    pub packages: Vec<DiscoveredPackage>,
+    pub problems: Vec<Problem>,
+}
+
+impl Discovery {
+    /// Records a package that was found but cannot load.
+    fn refuse(&mut self, name: String, error: PluginError) {
+        self.problems.push(Problem {
+            name: Some(name),
+            error,
+        });
+    }
+
+    /// Records a failure that names no package.
+    fn note(&mut self, error: PluginError) {
+        self.problems.push(Problem { name: None, error });
+    }
+
+    /// Every package name the walk saw, loadable or not.
+    ///
+    /// This is what a `plugins.<name>` table is validated against. Validating
+    /// against the loadable set instead would turn a package maki itself
+    /// refused into a config error, and blame the user's config for it.
+    pub fn known_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .packages
+            .iter()
+            .map(|package| package.name.clone())
+            .chain(self.problems.iter().filter_map(|p| p.name.clone()))
+            .collect();
+        names.sort();
+        names.dedup();
+        names
+    }
+}
+
+fn sorted_paths(dir: &Path, out: &mut Discovery) -> Vec<PathBuf> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(source) => {
+            out.note(PluginError::Io {
+                path: dir.to_path_buf(),
+                source,
+            });
+            return Vec::new();
+        }
+    };
+    let mut paths = Vec::new();
+    for entry in entries {
+        match entry {
+            Ok(entry) => paths.push(entry.path()),
+            Err(source) => out.note(PluginError::Io {
+                path: dir.to_path_buf(),
+                source,
+            }),
+        }
+    }
+    paths.sort();
+    paths
+}
+
+/// Discovers installed packages, or nothing when `--no-plugins` is set.
+pub fn discover_installed(no_plugins: bool) -> Discovery {
+    if no_plugins {
+        return Discovery::default();
+    }
+    // An unresolvable data directory is not the same fact as an empty one.
+    // Reported, because otherwise every installed package silently disappears.
+    let site = match site_dir() {
+        Ok(site) => site,
+        Err(source) => {
+            let mut out = Discovery::default();
+            out.note(PluginError::PackageSiteUnavailable { source });
+            return out;
+        }
+    };
+    discover(&site)
+}
+
+/// Finds every manually installed package under `site`.
+///
+/// Returns them in a deterministic order, so two machines with the same
+/// packages load them the same way. A missing site directory is not a problem;
+/// it just means no packages are installed.
+pub fn discover(site: &Path) -> Discovery {
+    let mut out = Discovery::default();
+    for group in sorted_paths(&site.join("pack"), &mut out) {
+        if group.file_name().and_then(|n| n.to_str()) == Some(MANAGED_GROUP) {
+            continue;
+        }
+        for (sub, eager) in [("start", true), ("opt", false)] {
+            for dir in sorted_paths(&group.join(sub), &mut out) {
+                let Some(name) = dir.file_name().and_then(|n| n.to_str()) else {
+                    continue;
+                };
+                if name.is_empty() || name.starts_with('.') {
+                    continue;
+                }
+                let name = name.to_owned();
+                let root = match dir.canonicalize() {
+                    Ok(root) => root,
+                    Err(source) => {
+                        // A package that cannot even be resolved is reported
+                        // rather than silently vanishing, since an unreadable
+                        // directory looks identical to one that is not there.
+                        out.refuse(name, PluginError::Io { path: dir, source });
+                        continue;
+                    }
+                };
+                if !root.is_dir() {
+                    continue;
+                }
+
+                if is_bundled(&name) {
+                    out.refuse(
+                        name.clone(),
+                        PluginError::PackageNameConflict { name, path: root },
+                    );
+                    continue;
+                }
+                let first = out
+                    .packages
+                    .iter()
+                    .find(|p| p.name == name)
+                    .map(|p| p.dir.clone());
+                if let Some(first) = first {
+                    out.refuse(
+                        name.clone(),
+                        PluginError::DuplicatePackage {
+                            name,
+                            first,
+                            second: root,
+                        },
+                    );
+                    continue;
+                }
+
+                let requested = match load_requested_permissions(&root) {
+                    Ok(requested) => requested,
+                    Err(problem) => {
+                        out.refuse(name, problem);
+                        continue;
+                    }
+                };
+                out.packages.push(DiscoveredPackage {
+                    name,
+                    dir: root,
+                    eager,
+                    requested,
+                });
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    use crate::error::PluginError;
+    use crate::plugin_permissions::Permission;
+
+    use super::{MANAGED_GROUP, Problem, discover, sanitize_message};
+
+    #[test]
+    fn terminal_messages_keep_layout_but_remove_control_characters() {
+        assert_eq!(
+            sanitize_message("package\u{1b}[31m\rname\nnext"),
+            "package [31m name\nnext"
+        );
+    }
+
+    fn make_package(site: &Path, group: &str, sub: &str, name: &str) -> PathBuf {
+        let dir = site.join("pack").join(group).join(sub).join(name);
+        fs::create_dir_all(dir.join("plugin")).unwrap();
+        fs::write(dir.join("plugin").join("init.lua"), "").unwrap();
+        dir
+    }
+
+    /// A package maki itself refused is still a name the user can write in
+    /// `plugins.<name>`. Validating a config against the loadable set alone
+    /// turned one bad manifest into a startup failure that blamed the config.
+    #[test]
+    fn a_package_that_cannot_be_read_is_still_a_known_name() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = make_package(tmp.path(), "vendor", "start", "broken");
+        fs::write(dir.join("plugin.toml"), "not = valid = toml").unwrap();
+
+        let found = discover(tmp.path());
+        assert!(found.packages.is_empty(), "the package must not load");
+        assert_eq!(found.problems.len(), 1, "and the reason must be reported");
+        assert_eq!(found.known_names(), vec!["broken".to_owned()]);
+    }
+
+    #[test]
+    fn missing_site_dir_is_not_a_problem() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let found = discover(&tmp.path().join("absent"));
+        assert!(found.packages.is_empty());
+        assert!(found.problems.is_empty());
+    }
+
+    #[test]
+    fn unreadable_package_root_is_reported() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pack = tmp.path().join("pack");
+        fs::write(&pack, "not a directory").unwrap();
+
+        let found = discover(tmp.path());
+
+        assert!(found.packages.is_empty());
+        assert!(matches!(
+            found.problems.as_slice(),
+            [Problem {
+                error: PluginError::Io { .. },
+                ..
+            }]
+        ));
+    }
+
+    #[test]
+    fn finds_start_and_opt_and_marks_eagerness() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "vendor", "start", "eager_one");
+        make_package(tmp.path(), "vendor", "opt", "lazy_one");
+
+        let found = discover(tmp.path());
+        assert_eq!(found.packages.len(), 2);
+
+        let eager = found
+            .packages
+            .iter()
+            .find(|p| p.name == "eager_one")
+            .unwrap();
+        let lazy = found
+            .packages
+            .iter()
+            .find(|p| p.name == "lazy_one")
+            .unwrap();
+        assert!(eager.eager, "start/ packages load at startup");
+        assert!(!lazy.eager, "opt/ packages wait to be activated");
+    }
+
+    /// Managed packages are resolved from recorded state, so finding them here
+    /// too would give one package two identities.
+    #[test]
+    fn managed_group_is_skipped() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), MANAGED_GROUP, "opt", "managed_one");
+        make_package(tmp.path(), "vendor", "start", "manual_one");
+
+        let names: Vec<String> = discover(tmp.path())
+            .packages
+            .into_iter()
+            .map(|p| p.name)
+            .collect();
+        assert_eq!(names, vec!["manual_one"]);
+    }
+
+    #[test]
+    fn bundled_name_collision_is_refused() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "vendor", "start", "bash");
+
+        let found = discover(tmp.path());
+        assert!(found.packages.is_empty());
+        assert!(matches!(
+            found.problems.as_slice(),
+            [Problem {
+                error: PluginError::PackageNameConflict { .. },
+                ..
+            }]
+        ));
+    }
+
+    /// `lib` is bundled without being enabled by default, so a name check
+    /// against the default set alone would let it through.
+    #[test]
+    fn non_default_bundled_name_is_also_refused() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "vendor", "start", "lib");
+
+        let found = discover(tmp.path());
+        assert!(found.packages.is_empty());
+        assert!(matches!(
+            found.problems.as_slice(),
+            [Problem {
+                error: PluginError::PackageNameConflict { .. },
+                ..
+            }]
+        ));
+    }
+
+    #[test]
+    fn duplicate_names_across_groups_are_refused() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "alpha", "start", "twice");
+        make_package(tmp.path(), "beta", "start", "twice");
+
+        let found = discover(tmp.path());
+        assert_eq!(found.packages.len(), 1, "the first one still loads");
+        assert!(matches!(
+            found.problems.as_slice(),
+            [Problem {
+                error: PluginError::DuplicatePackage { .. },
+                ..
+            }]
+        ));
+    }
+
+    /// One unusable package must not take the others down with it.
+    #[test]
+    fn a_refused_package_does_not_stop_the_others() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "vendor", "start", "bash");
+        make_package(tmp.path(), "vendor", "start", "fine_one");
+
+        let found = discover(tmp.path());
+        let names: Vec<&str> = found.packages.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["fine_one"]);
+        assert_eq!(found.problems.len(), 1);
+    }
+
+    #[test]
+    fn manifest_permissions_are_read_and_deny_by_default() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = make_package(tmp.path(), "vendor", "start", "asks");
+        fs::write(dir.join("plugin.toml"), "[permissions]\nnet = true\n").unwrap();
+
+        let found = discover(tmp.path());
+        let pkg = &found.packages[0];
+        assert!(pkg.requested.is_requested(Permission::Net));
+        assert!(!pkg.requested.is_requested(Permission::Run));
+    }
+
+    #[test]
+    fn package_without_manifest_requests_nothing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "vendor", "start", "silent");
+
+        let found = discover(tmp.path());
+        for perm in [
+            Permission::FsRead,
+            Permission::FsWrite,
+            Permission::Net,
+            Permission::Run,
+            Permission::Env,
+        ] {
+            assert!(!found.packages[0].requested.is_requested(perm));
+        }
+    }
+}

--- a/maki-lua/src/pack.rs
+++ b/maki-lua/src/pack.rs
@@ -5,7 +5,9 @@
 //! installs are resolved from recorded state instead, and never appear here.
 
 use std::fs;
+use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use crate::error::PluginError;
 use crate::loader::is_bundled;
@@ -27,14 +29,36 @@ pub fn sanitize_message(message: &str) -> String {
 /// The group name reserved for packages maki installs itself. Manual discovery
 /// skips it, so one package can never be found twice, once from disk and once
 /// from recorded state, with the two disagreeing about its revision.
-pub const MANAGED_GROUP: &str = "core";
+///
+/// Re-exported rather than repeated: `maki-pack` decides where it puts a
+/// checkout, and a second copy here that drifted would stop discovery skipping
+/// the directory it writes.
+pub use maki_pack::paths::MANAGED_GROUP;
 
 /// `<data>/site`, the root Neovim would call a package path.
 pub fn site_dir() -> Result<PathBuf, std::io::Error> {
     maki_storage::paths::data_dir().map(|d| d.join("site"))
 }
 
-#[derive(Debug)]
+/// How a package reached the disk, which is what decides whose word grants its
+/// permissions.
+///
+/// This is a distinction the code needs and did not have. A manifest is written
+/// by whoever wrote the package. For a package the user placed by hand that is
+/// effectively the user, so the manifest is their own statement of intent. For
+/// a package maki fetched it is a stranger, and letting the manifest grant
+/// itself permissions would make the request self-certifying: a later revision
+/// could add `run = true` and start subprocesses without anyone agreeing to it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Origin {
+    /// The user put the files under `pack/<group>/`. Trusted like `init.lua`.
+    Manual,
+    /// Maki cloned it from this source. The source is part of the approval key,
+    /// so re-pointing a name at another repository does not inherit its grants.
+    Fetched { src: String },
+}
+
+#[derive(Debug, Clone)]
 pub struct DiscoveredPackage {
     pub name: String,
     /// Canonical package root. Resolved once, here, so the manifest, the
@@ -42,9 +66,603 @@ pub struct DiscoveredPackage {
     pub dir: PathBuf,
     /// `start/` packages load at startup; `opt/` packages wait to be activated.
     pub eager: bool,
-    /// What the package's manifest asks for. A manually installed package is
-    /// granted this directly: the user placed the files.
+    /// What the package's manifest asks for. Never a grant on its own for a
+    /// fetched package; see `Origin`.
     pub requested: Requested,
+    pub origin: Origin,
+    pub revision_guard: Option<Arc<maki_pack::lock::Lock>>,
+}
+
+/// `pack-lock.json`, beside the user's configuration so it can be committed.
+///
+/// `global_config_dirs` returns several candidates in the order `init.lua` is
+/// searched for, so the first that exists is the one whose `maki.pack.add`
+/// declared these packages, and a custom config directory keeps its lockfile
+/// rather than leaving it behind in XDG. With none of them created yet there is
+/// nothing to sit beside, and the last candidate is the one
+/// `append_permission_rule` already treats as writable.
+pub fn lockfile_path() -> Option<PathBuf> {
+    let dirs = maki_config::global_config_dirs();
+    dirs.iter()
+        .find(|dir| dir.is_dir())
+        .cloned()
+        .or_else(|| dirs.into_iter().next_back())
+        .map(|dir| dir.join("pack-lock.json"))
+}
+
+/// `pack-approvals.json`, in the state directory beside the checkouts.
+///
+/// Deliberately not beside the lockfile. A lockfile is meant to be committed,
+/// so a package set reproduces on another machine. An approval is the opposite
+/// kind of fact: one person's decision to trust one repository on one machine,
+/// which must not travel with a repository into someone else's checkout.
+pub fn approvals_path() -> Option<PathBuf> {
+    site_dir().ok().map(|dir| dir.join("pack-approvals.json"))
+}
+
+/// Reads the approval store.
+///
+/// An unreadable store yields no approvals rather than a default-open one. The
+/// failure mode is then a package that loads with nothing granted, which is
+/// visible and recoverable, instead of one that loads with everything granted.
+pub fn read_approvals() -> maki_pack::approvals::Approvals {
+    let Some(path) = approvals_path() else {
+        return maki_pack::approvals::Approvals::default();
+    };
+    read_approvals_file(&path).unwrap_or_default()
+}
+
+fn read_approvals_file(path: &Path) -> Option<maki_pack::approvals::Approvals> {
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Some(maki_pack::approvals::Approvals::default());
+        }
+        Err(error) => {
+            tracing::error!(
+                path = %path.display(),
+                %error,
+                "pack approval store could not be read; granting nothing"
+            );
+            return None;
+        }
+    };
+    match serde_json::from_str(&text) {
+        Ok(approvals) => Some(approvals),
+        Err(e) => {
+            tracing::error!(
+                path = %path.display(),
+                error = %e,
+                "pack approval store is unreadable; granting nothing"
+            );
+            None
+        }
+    }
+}
+
+fn read_approvals_for_write() -> Option<maki_pack::approvals::Approvals> {
+    approvals_path()
+        .map(|path| read_approvals_file(&path))
+        .unwrap_or_else(|| Some(maki_pack::approvals::Approvals::default()))
+}
+
+/// Effective permissions for a package about to load.
+///
+/// The whole point of `Origin`: a fetched package's own manifest is a request,
+/// and a request is not a grant.
+pub fn effective_permissions(
+    pkg: &DiscoveredPackage,
+) -> crate::plugin_permissions::PluginPermissions {
+    granted(pkg, &read_approvals())
+}
+
+/// The rule itself, with the store passed in.
+///
+/// Separated from the disk read so it can be tested against a store built in
+/// the test rather than against whatever the person running the tests happens
+/// to have approved.
+pub fn granted(
+    pkg: &DiscoveredPackage,
+    approvals: &maki_pack::approvals::Approvals,
+) -> crate::plugin_permissions::PluginPermissions {
+    match &pkg.origin {
+        Origin::Manual => pkg.requested.clone().granted_for_manual_install(),
+        Origin::Fetched { src } => {
+            let key = maki_pack::approvals::ApprovalKey::new(pkg.name.clone(), src);
+            let approved = crate::plugin_permissions::PluginPermissions::from_approved(
+                approvals
+                    .get(&key)
+                    .unwrap_or(&[])
+                    .iter()
+                    .map(String::as_str),
+            );
+            pkg.requested.intersect(&approved)
+        }
+    }
+}
+
+/// Whether this entry point can ask the user a question.
+///
+/// An install runs downloaded code, so it is a trust decision. A run with no
+/// terminal cannot take one, and must refuse rather than assume consent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Interaction {
+    Tty,
+    None,
+}
+
+impl Interaction {
+    fn confirm(self, prompt: &str) -> bool {
+        if self != Self::Tty || !io::stdin().is_terminal() {
+            return false;
+        }
+        eprint!("{} [y/N] ", sanitize_message(prompt));
+        let _ = io::stderr().flush();
+        let mut input = String::new();
+        io::stdin().read_line(&mut input).is_ok() && input.trim().eq_ignore_ascii_case("y")
+    }
+}
+
+/// What an install pass produced, and what it could not.
+///
+/// Failures are returned rather than only logged: installation runs before
+/// logging is set up, so a message written there reaches nobody.
+#[derive(Debug, Default)]
+pub struct InstallReport {
+    pub packages: Vec<DiscoveredPackage>,
+    pub failures: Vec<String>,
+}
+
+/// Whether a declared package is already installed from the source it names.
+///
+/// Both halves matter. A recorded revision only describes the source it was
+/// recorded for, so a name pointed at a different repository is neither
+/// installed nor covered by the decision that trusted the old one.
+fn installed_from_declared_source(
+    declared: &crate::api::pack::Declared,
+    lock: &maki_pack::lockfile::Lockfile,
+    manager: &maki_pack::manager::Manager,
+) -> bool {
+    let spec = &declared.spec;
+    lock.get(&spec.name)
+        .is_some_and(|entry| entry.src == spec.src)
+        && manager.resolve(lock, &spec.name).is_some()
+}
+
+/// The declared packages that are already installed at the source and revision
+/// the lockfile records.
+///
+/// Reads only: no git, no lock, no network. This is what a session still has
+/// when it cannot install, so one held lock does not take away the packages
+/// the user already had.
+fn resolved_on_disk(
+    specs: &[crate::api::pack::Declared],
+    site: &Path,
+    lock: &maki_pack::lockfile::Lockfile,
+    failures: &mut Vec<String>,
+) -> Vec<DiscoveredPackage> {
+    let manager = maki_pack::manager::Manager::new(site);
+    let approvals = read_approvals();
+    let mut found = Vec::new();
+    for declared in specs {
+        let spec = &declared.spec;
+        if !installed_from_declared_source(declared, lock, &manager) {
+            continue;
+        }
+        let Some(dir) = manager.resolve(lock, &spec.name) else {
+            continue;
+        };
+        let revision = lock
+            .get(&spec.name)
+            .expect("resolved lock entry")
+            .rev
+            .as_str();
+        let revision_guard = match maki_pack::lock::Lock::acquire_shared(
+            &maki_pack::paths::revision_lock(site, &spec.name, revision),
+        ) {
+            Ok(guard) => Arc::new(guard),
+            Err(error) => {
+                failures.push(format!("{}: {}", spec.name, redact_error(&error)));
+                continue;
+            }
+        };
+        let requested = match load_requested_permissions(&dir) {
+            Ok(requested) => requested,
+            Err(problem) => {
+                // Named here, because the caller only reports why installing
+                // stopped. Dropping this would make the package vanish with
+                // the lock error as the only clue.
+                failures.push(format!("{}: {problem}", spec.name));
+                continue;
+            }
+        };
+        let key = maki_pack::approvals::ApprovalKey::new(spec.name.clone(), &spec.src);
+        let missing = missing_permissions(&requested, approvals.get(&key).unwrap_or(&[]));
+        if !missing.is_empty() {
+            failures.push(format!(
+                "{}: permission approval is required for {}",
+                spec.name,
+                missing.join(", ")
+            ));
+            continue;
+        }
+        found.push(DiscoveredPackage {
+            name: spec.name.clone(),
+            requested,
+            origin: Origin::Fetched {
+                src: spec.src.clone(),
+            },
+            dir,
+            eager: matches!(
+                declared.load,
+                crate::api::pack::LoadMode::Eager | crate::api::pack::LoadMode::Custom(_)
+            ),
+            revision_guard: Some(revision_guard),
+        });
+    }
+    found
+}
+
+fn missing_permissions(requested: &Requested, approved: &[String]) -> Vec<String> {
+    requested
+        .names()
+        .into_iter()
+        .filter(|name| !approved.iter().any(|approved| approved == name))
+        .collect()
+}
+
+fn runnable_declarations<'a>(
+    specs: &'a [crate::api::pack::Declared],
+    manual: &Discovery,
+    report: &mut InstallReport,
+) -> Vec<&'a crate::api::pack::Declared> {
+    let manual_names = manual.known_names();
+    specs
+        .iter()
+        .filter(|declared| {
+            let name = &declared.spec.name;
+            if let Some(error) = owner_conflict(name) {
+                report.failures.push(error);
+                return false;
+            }
+            if manual_names.iter().any(|manual| manual == name) {
+                let path = manual
+                    .packages
+                    .iter()
+                    .find(|package| package.name == *name)
+                    .map(|package| format!(" at {}", package.dir.display()))
+                    .unwrap_or_default();
+                report.failures.push(format!(
+                    "{name}: managed package name conflicts with manual package{path}"
+                ));
+                return false;
+            }
+            true
+        })
+        .collect()
+}
+
+fn grant_installed(
+    specs: &[&crate::api::pack::Declared],
+    site: &Path,
+    manager: &maki_pack::manager::Manager,
+    lock: &maki_pack::lockfile::Lockfile,
+    interaction: Interaction,
+    report: &mut InstallReport,
+) {
+    let Some(mut approvals) = read_approvals_for_write() else {
+        report
+            .failures
+            .push("the package approval store is unreadable, so no package was loaded".to_owned());
+        return;
+    };
+    let mut approvals_changed = false;
+    let mut newly_approved = std::collections::BTreeSet::new();
+
+    for declared in specs.iter().copied() {
+        let spec = &declared.spec;
+        if lock
+            .get(&spec.name)
+            .is_none_or(|entry| entry.src != spec.src)
+        {
+            continue;
+        }
+        let Some(dir) = manager.resolve(lock, &spec.name) else {
+            continue;
+        };
+        let revision = lock
+            .get(&spec.name)
+            .expect("resolved lock entry")
+            .rev
+            .as_str();
+        let revision_guard = match maki_pack::lock::Lock::acquire_shared(
+            &maki_pack::paths::revision_lock(site, &spec.name, revision),
+        ) {
+            Ok(guard) => Arc::new(guard),
+            Err(error) => {
+                report
+                    .failures
+                    .push(format!("{}: {}", spec.name, redact_error(&error)));
+                continue;
+            }
+        };
+        let requested = match load_requested_permissions(&dir) {
+            Ok(requested) => requested,
+            Err(problem) => {
+                report.failures.push(format!("{}: {problem}", spec.name));
+                continue;
+            }
+        };
+        let key = maki_pack::approvals::ApprovalKey::new(spec.name.clone(), &spec.src);
+        let requested_names = requested.names();
+        let missing = missing_permissions(&requested, approvals.get(&key).unwrap_or(&[]));
+
+        if approvals.get(&key).is_none() {
+            approvals_changed |= approvals.revoke(&spec.name);
+        }
+        if !missing.is_empty() {
+            if !interaction.confirm(&format!(
+                "Allow package {} these permissions: {}?",
+                spec.name,
+                missing.join(", ")
+            )) {
+                report.failures.push(format!(
+                    "{}: permission approval is required for {}",
+                    spec.name,
+                    missing.join(", ")
+                ));
+                continue;
+            }
+            approvals.approve(&key, requested_names);
+            approvals_changed = true;
+            newly_approved.insert(spec.name.clone());
+        }
+        report.packages.push(DiscoveredPackage {
+            name: spec.name.clone(),
+            requested,
+            origin: Origin::Fetched {
+                src: spec.src.clone(),
+            },
+            dir,
+            eager: matches!(
+                declared.load,
+                crate::api::pack::LoadMode::Eager | crate::api::pack::LoadMode::Custom(_)
+            ),
+            revision_guard: Some(revision_guard),
+        });
+    }
+
+    if approvals_changed && !write_approvals(&approvals) {
+        let packages = std::mem::take(&mut report.packages);
+        for package in packages {
+            if newly_approved.contains(&package.name) {
+                report.failures.push(format!(
+                    "{}: permission approval could not be saved",
+                    package.name
+                ));
+            } else {
+                report.packages.push(package);
+            }
+        }
+    }
+}
+
+/// Installs the packages the global `init.lua` declared and reports where each
+/// one landed.
+///
+/// Runs on the caller's thread, never the Lua thread: installing clones, and
+/// loading blocks on a reply from the runtime, so doing either from inside a
+/// Lua call would wait on a message that cannot be processed until it returns.
+/// One unreachable repository is reported and skipped so a network problem
+/// does not stop Maki from starting.
+pub fn install_declared(
+    specs: &[crate::api::pack::Declared],
+    interaction: Interaction,
+) -> InstallReport {
+    let mut report = InstallReport::default();
+    let site = match site_dir() {
+        Ok(site) => site,
+        Err(error) => {
+            report.failures.push(format!(
+                "no data directory, so no package was installed: {error}"
+            ));
+            return report;
+        }
+    };
+
+    let lock_path = lockfile_path();
+
+    // Held across the whole read, install, and write. Atomic rename gives
+    // durability but not isolation: without this, two processes could each read
+    // the same lockfile and the second write would discard the first's entries.
+    let _guard = match lock_path.as_deref().map(maki_pack::paths::sidecar_lock) {
+        Some(path) => match maki_pack::lock::Lock::acquire(&path) {
+            Ok(guard) => Some(guard),
+            Err(e) => {
+                // The kernel releases the lock when its process exits,
+                // including after a crash.
+                tracing::error!(error = %e, "could not take the package lock");
+                report.failures.push(redact_error(&e));
+                // Installing needs the lock; reading what is already there
+                // does not. Returning nothing would tell the session it has
+                // no managed packages at all, because discovery skips the
+                // managed group, so a second maki started during a clone
+                // would come up with every package the user has missing.
+                if let Some(lock) = read_lockfile(lock_path.as_deref()) {
+                    report.packages = resolved_on_disk(specs, &site, &lock, &mut report.failures);
+                }
+                return report;
+            }
+        },
+        None => None,
+    };
+
+    let mut lock = match read_lockfile(lock_path.as_deref()) {
+        Some(lock) => lock,
+        None => {
+            report
+                .failures
+                .push("the pack lockfile is unreadable, so no package was installed".to_owned());
+            return report;
+        }
+    };
+
+    let manager = maki_pack::manager::Manager::new(&site);
+    for error in manager.prune(&lock) {
+        tracing::warn!(error = %error, "could not prune a stale package revision");
+        report.failures.push(redact_error(&error));
+    }
+    if specs.is_empty() {
+        return report;
+    }
+    let manual = discover(&site);
+    let runnable = runnable_declarations(specs, &manual, &mut report);
+    let mut changed = false;
+
+    // Asked once for the whole batch, before anything is cloned. A package
+    // already recorded at the revision it asks for is not a new trust
+    // decision, so only a fresh source prompts. Credentials are redacted,
+    // because the prompt is the one place a source is shown in full.
+    let new_sources: Vec<String> = runnable
+        .iter()
+        .copied()
+        .filter(|declared| {
+            declared.confirm && !installed_from_declared_source(declared, &lock, &manager)
+        })
+        .map(|declared| {
+            format!(
+                "{} from {}",
+                declared.spec.name,
+                maki_pack::git::redact(&declared.spec.src)
+            )
+        })
+        .collect();
+    let confirmed = new_sources.is_empty()
+        || interaction.confirm(&format!(
+            "Install these packages?\n  {}",
+            new_sources.join("\n  ")
+        ));
+
+    for declared in runnable.iter().copied() {
+        let spec = &declared.spec;
+        if declared.confirm
+            && !installed_from_declared_source(declared, &lock, &manager)
+            && !confirmed
+        {
+            report.failures.push(format!(
+                "{}: installation requires confirmation; set confirm = false for a non-interactive install",
+                spec.name
+            ));
+            continue;
+        }
+        let result = match smol::block_on(manager.ensure_installed(spec, &mut lock)) {
+            Ok(result) => result,
+            Err(e) => {
+                let message = redact_error(&e);
+                tracing::error!(package = %spec.name, error = %message, "failed to install package");
+                report
+                    .failures
+                    .push(format!("{}: failed to install: {message}", spec.name));
+                continue;
+            }
+        };
+        changed |= result.changed;
+    }
+
+    // Written once, after the installs, and only when something moved.
+    if changed {
+        let recorded = match lock_path {
+            Some(path) => write_lockfile(&path, &lock),
+            None => false,
+        };
+        if !recorded {
+            // The packages are on disk but nothing records where. The next
+            // start reads the old lockfile and would not find them, so they
+            // must not be reported as installed either.
+            report.packages.clear();
+            report
+                .failures
+                .push("the pack lockfile could not be written, so no package was used".to_owned());
+            return report;
+        }
+    }
+
+    grant_installed(&runnable, &site, &manager, &lock, interaction, &mut report);
+    report
+}
+
+fn owner_conflict(name: &str) -> Option<String> {
+    is_bundled(name)
+        .then(|| format!("{name}: managed package name conflicts with a builtin plugin"))
+}
+
+fn redact_error(error: &impl std::fmt::Display) -> String {
+    sanitize_message(&maki_pack::git::redact(&error.to_string()))
+}
+
+pub(crate) fn read_lockfile(path: Option<&Path>) -> Option<maki_pack::lockfile::Lockfile> {
+    let Some(path) = path else {
+        return Some(maki_pack::lockfile::Lockfile::default());
+    };
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Some(maki_pack::lockfile::Lockfile::default());
+        }
+        Err(error) => {
+            tracing::error!(path = %path.display(), %error, "pack lockfile could not be read");
+            return None;
+        }
+    };
+    match maki_pack::lockfile::Lockfile::from_json(&text) {
+        Ok(lock) => Some(lock),
+        Err(e) => {
+            tracing::error!(error = %e, "pack lockfile is unreadable; refusing to change packages");
+            None
+        }
+    }
+}
+
+fn write_approvals(approvals: &maki_pack::approvals::Approvals) -> bool {
+    let Some(path) = approvals_path() else {
+        return false;
+    };
+    match serde_json::to_string_pretty(approvals) {
+        Ok(text) => match write_atomically(&path, &text) {
+            Ok(()) => true,
+            Err(error) => {
+                tracing::error!(path = %path.display(), %error, "failed to write pack approvals");
+                false
+            }
+        },
+        Err(error) => {
+            tracing::error!(%error, "failed to serialize pack approvals");
+            false
+        }
+    }
+}
+
+fn write_lockfile(path: &Path, lock: &maki_pack::lockfile::Lockfile) -> bool {
+    match lock.to_json() {
+        Ok(text) => match write_atomically(path, &text) {
+            Ok(()) => true,
+            Err(e) => {
+                tracing::error!(path = %path.display(), error = %e, "failed to write pack lockfile");
+                false
+            }
+        },
+        Err(e) => {
+            tracing::error!(error = %e, "failed to serialize pack lockfile");
+            false
+        }
+    }
+}
+
+fn write_atomically(path: &Path, text: &str) -> Result<(), maki_storage::StorageError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    maki_storage::atomic_write(path, text.as_bytes())
 }
 
 /// Something the walk could not use, and the name it had for it.
@@ -222,6 +840,11 @@ pub fn discover(site: &Path) -> Discovery {
                     dir: root,
                     eager,
                     requested,
+                    // Found by walking `pack/<group>/`, which is where a user
+                    // puts files by hand. Maki's own checkouts are resolved
+                    // through the lockfile, never discovered this way.
+                    origin: Origin::Manual,
+                    revision_guard: None,
                 });
             }
         }
@@ -235,9 +858,15 @@ mod tests {
     use std::path::{Path, PathBuf};
 
     use crate::error::PluginError;
-    use crate::plugin_permissions::Permission;
+    use crate::plugin_permissions::{Permission, Requested};
 
-    use super::{MANAGED_GROUP, Problem, discover, sanitize_message};
+    use super::{
+        DiscoveredPackage, MANAGED_GROUP, Origin, Problem, discover, granted,
+        installed_from_declared_source, missing_permissions, read_approvals_file, read_lockfile,
+        resolved_on_disk, sanitize_message,
+    };
+
+    const TEST_REV: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
     #[test]
     fn terminal_messages_keep_layout_but_remove_control_characters() {
@@ -247,11 +876,237 @@ mod tests {
         );
     }
 
+    #[test]
+    fn a_lockfile_read_error_is_not_treated_as_a_missing_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        assert!(read_lockfile(Some(dir.path())).is_none());
+    }
+
+    #[test]
+    fn a_missing_lockfile_reads_as_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("missing.json");
+
+        assert!(read_lockfile(Some(&path)).unwrap().is_empty());
+    }
+
+    #[test]
+    fn a_malformed_approval_store_is_not_treated_as_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("approvals.json");
+        fs::write(&path, "not json").unwrap();
+
+        assert!(read_approvals_file(&path).is_none());
+    }
+
+    #[test]
+    fn a_missing_approval_store_reads_as_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("approvals.json");
+
+        assert!(read_approvals_file(&path).unwrap().is_empty());
+    }
+
     fn make_package(site: &Path, group: &str, sub: &str, name: &str) -> PathBuf {
         let dir = site.join("pack").join(group).join(sub).join(name);
         fs::create_dir_all(dir.join("plugin")).unwrap();
         fs::write(dir.join("plugin").join("init.lua"), "").unwrap();
         dir
+    }
+
+    /// Builds a package whose manifest asks for everything, which is the
+    /// interesting case: the question is never what it asked for, but whose
+    /// word turns the request into a grant.
+    fn greedy(name: &str, origin: Origin) -> DiscoveredPackage {
+        let manifest = toml::from_str::<toml::Value>(
+            "[permissions]\nfs_read = true\nfs_write = true\nnet = true\nrun = true\nenv = true\n",
+        )
+        .unwrap();
+        DiscoveredPackage {
+            name: name.to_owned(),
+            dir: PathBuf::from("/nowhere"),
+            eager: true,
+            requested: Requested::from_manifest(&manifest),
+            origin,
+            revision_guard: None,
+        }
+    }
+
+    /// A package the user placed by hand is trusted like `init.lua`: they put
+    /// the files there, so its manifest is their own statement.
+    #[test]
+    fn a_manual_package_is_granted_what_its_manifest_asks_for() {
+        let pkg = greedy("demo", Origin::Manual);
+        let effective = granted(&pkg, &maki_pack::approvals::Approvals::default());
+
+        for perm in Permission::ALL {
+            assert!(
+                effective.is_allowed(perm),
+                "{perm} should be granted to a manually installed package"
+            );
+        }
+    }
+
+    /// The negative half of the pair above, and the defect this exists to
+    /// prevent: downloaded code must not be able to certify its own
+    /// permissions by writing them into the manifest it ships.
+    #[test]
+    fn a_fetched_package_is_granted_nothing_without_an_approval() {
+        let pkg = greedy(
+            "demo",
+            Origin::Fetched {
+                src: "https://example.com/demo".to_owned(),
+            },
+        );
+        let effective = granted(&pkg, &maki_pack::approvals::Approvals::default());
+
+        for perm in Permission::ALL {
+            assert!(
+                !effective.is_allowed(perm),
+                "{perm} must not be granted to fetched code with no approval"
+            );
+        }
+    }
+
+    /// An approval grants only what it names, and only where the package also
+    /// asked for it. Both halves have to agree.
+    #[test]
+    fn a_fetched_package_is_granted_the_intersection_of_request_and_approval() {
+        let src = "https://example.com/demo";
+        let pkg = greedy(
+            "demo",
+            Origin::Fetched {
+                src: src.to_owned(),
+            },
+        );
+
+        let mut approvals = maki_pack::approvals::Approvals::default();
+        approvals.approve(
+            &maki_pack::approvals::ApprovalKey::new("demo", src),
+            vec!["run".to_owned()],
+        );
+        let effective = granted(&pkg, &approvals);
+
+        assert!(effective.is_allowed(Permission::Run), "run was approved");
+        assert!(
+            !effective.is_allowed(Permission::Net),
+            "net was requested but never approved"
+        );
+    }
+
+    /// The reason an approval is keyed by source as well as name. Pointing a
+    /// name at another repository is a new trust decision, so the grants
+    /// recorded for the old one must not carry over.
+    #[test]
+    fn an_approval_does_not_survive_a_changed_source() {
+        let mut approvals = maki_pack::approvals::Approvals::default();
+        approvals.approve(
+            &maki_pack::approvals::ApprovalKey::new("demo", "https://example.com/demo"),
+            vec!["run".to_owned()],
+        );
+
+        let moved = greedy(
+            "demo",
+            Origin::Fetched {
+                src: "https://elsewhere.example/demo".to_owned(),
+            },
+        );
+        assert!(
+            !granted(&moved, &approvals).is_allowed(Permission::Run),
+            "an approval for one repository must not grant another"
+        );
+    }
+
+    #[test]
+    fn missing_permissions_reports_each_unapproved_request() {
+        let manifest = toml::from_str::<toml::Value>(
+            "[permissions]\nfs_read = true\nnet = true\nrun = true\n",
+        )
+        .unwrap();
+        let requested = Requested::from_manifest(&manifest);
+
+        assert_eq!(
+            missing_permissions(&requested, &["net".to_owned()]),
+            ["fs_read".to_owned(), "run".to_owned()]
+        );
+    }
+
+    fn declared_pack(name: &str, src: &str) -> crate::api::pack::Declared {
+        crate::api::pack::Declared {
+            spec: maki_pack::Spec::new(src).with_name(name),
+            load: crate::api::pack::LoadMode::Eager,
+            confirm: true,
+            data: None,
+        }
+    }
+
+    /// Sets up a site where `name` is installed from `src` at one revision.
+    fn installed_site(name: &str, src: &str) -> (tempfile::TempDir, maki_pack::lockfile::Lockfile) {
+        let site = tempfile::TempDir::new().unwrap();
+        let mut lock = maki_pack::lockfile::Lockfile::default();
+        lock.record(name, src, TEST_REV);
+        fs::create_dir_all(maki_pack::paths::revision_dir(site.path(), name, TEST_REV)).unwrap();
+        (site, lock)
+    }
+
+    /// The rule that decides whether installing is a fresh trust decision.
+    /// `.maki/init.lua` is project local, so a repository maki opens can point
+    /// a name the user already trusts somewhere else: matching on the name
+    /// alone skipped the prompt and cloned the new source on the strength of
+    /// the old decision.
+    #[test]
+    fn a_package_is_only_installed_when_the_recorded_source_matches() {
+        let src = "https://example.com/demo";
+        let (site, lock) = installed_site("demo", src);
+        let manager = maki_pack::manager::Manager::new(site.path());
+
+        assert!(
+            installed_from_declared_source(&declared_pack("demo", src), &lock, &manager),
+            "same name, same source, and on disk"
+        );
+        assert!(
+            !installed_from_declared_source(
+                &declared_pack("demo", "https://elsewhere.example/demo"),
+                &lock,
+                &manager
+            ),
+            "a name pointed at another repository is a new trust decision"
+        );
+    }
+
+    /// A held lock stops an install, but it does not make the packages already
+    /// on disk disappear. Discovery skips the managed group, so reporting none
+    /// left the session with every managed package missing.
+    #[test]
+    fn packages_already_on_disk_resolve_without_git_or_a_lock() {
+        let src = "https://example.com/demo";
+        let (site, lock) = installed_site("demo", src);
+
+        let mut failures = Vec::new();
+        let found = resolved_on_disk(
+            &[declared_pack("demo", src)],
+            site.path(),
+            &lock,
+            &mut failures,
+        );
+        assert_eq!(found.len(), 1, "the installed package is still usable");
+        assert_eq!(found[0].name, "demo");
+        assert_eq!(
+            found[0].dir,
+            maki_pack::paths::revision_dir(site.path(), "demo", TEST_REV)
+        );
+
+        let moved = resolved_on_disk(
+            &[declared_pack("demo", "https://elsewhere.example/demo")],
+            site.path(),
+            &lock,
+            &mut failures,
+        );
+        assert!(
+            moved.is_empty(),
+            "the recorded revision describes the old source only"
+        );
     }
 
     /// A package maki itself refused is still a name the user can write in

--- a/maki-lua/src/plugin_permissions.rs
+++ b/maki-lua/src/plugin_permissions.rs
@@ -25,6 +25,17 @@ impl Permission {
         Permission::Env,
     ];
 
+    /// Parses the name used in `plugin.toml` and in the approval store.
+    ///
+    /// Both use one spelling on purpose. If an approval were recorded under a
+    /// different name from the request, `intersect` would silently never
+    /// match, and every managed package would run with nothing granted.
+    pub fn from_key(key: &str) -> Option<Self> {
+        Permission::ALL
+            .into_iter()
+            .find(|p| p.manifest_key() == key)
+    }
+
     pub(crate) const fn manifest_key(self) -> &'static str {
         match self {
             Permission::FsRead => "fs_read",
@@ -56,6 +67,21 @@ impl PluginPermissions {
         Self {
             allowed: [false; 5],
         }
+    }
+
+    /// Builds a set from the names an approval records.
+    ///
+    /// A name this build does not know is ignored rather than treated as a
+    /// grant, so an approval file written by a newer maki cannot widen what an
+    /// older one allows.
+    pub fn from_approved<'a>(names: impl IntoIterator<Item = &'a str>) -> Self {
+        let mut out = Self::denied();
+        for name in names {
+            if let Some(perm) = Permission::from_key(name) {
+                out.set(perm, true);
+            }
+        }
+        out
     }
 
     pub fn is_allowed(&self, perm: Permission) -> bool {
@@ -147,6 +173,14 @@ impl Requested {
 
     pub fn is_requested(&self, perm: Permission) -> bool {
         self.0.is_allowed(perm)
+    }
+
+    pub fn names(&self) -> Vec<String> {
+        Permission::ALL
+            .into_iter()
+            .filter(|permission| self.is_requested(*permission))
+            .map(|permission| permission.to_string())
+            .collect()
     }
 
     /// A package the user installed by hand gets what it asks for. They placed
@@ -325,6 +359,23 @@ mod tests {
                 assert!(!req.is_requested(perm), "{perm} must not be requested");
             }
         }
+    }
+
+    #[test]
+    fn requested_names_are_the_approval_keys() {
+        let value: toml::Value = toml::from_str(
+            r#"
+            [permissions]
+            fs_read = true
+            run = true
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            Requested::from_manifest(&value).names(),
+            ["fs_read".to_owned(), "run".to_owned()]
+        );
     }
 
     /// The legacy parser stays permissive; only the package parser is strict.

--- a/maki-lua/src/plugin_permissions.rs
+++ b/maki-lua/src/plugin_permissions.rs
@@ -115,6 +115,86 @@ impl PluginPermissions {
     }
 }
 
+/// What a package's `plugin.toml` asks for.
+///
+/// Deny by default: an omitted key is *not requested*. That is the opposite of
+/// [`PluginPermissions::from_manifest`], which stays permissive for a local
+/// `init.lua` the user wrote themselves. The two parsers are separate because
+/// the inputs differ in trust, not in shape: a package manifest arrives with
+/// downloaded code and must not be able to widen its own access.
+///
+/// This is a distinct type so an effective grant can never be built by
+/// accident from a request alone.
+#[derive(Debug, Clone)]
+pub struct Requested(PluginPermissions);
+
+impl Requested {
+    pub fn none() -> Self {
+        Self(PluginPermissions::denied())
+    }
+
+    pub fn from_manifest(manifest: &toml::Value) -> Self {
+        let perms = manifest.get("permissions");
+        let mut allowed = [false; 5];
+        for perm in Permission::ALL {
+            allowed[perm as usize] = perms
+                .and_then(|p| p.get(perm.manifest_key()))
+                .and_then(toml::Value::as_bool)
+                .unwrap_or(false);
+        }
+        Self(PluginPermissions { allowed })
+    }
+
+    pub fn is_requested(&self, perm: Permission) -> bool {
+        self.0.is_allowed(perm)
+    }
+
+    /// A package the user installed by hand gets what it asks for. They placed
+    /// the files, which is the same trust already given to a local `init.lua`.
+    /// Only a package maki fetched has to be intersected with an approval.
+    pub fn granted_for_manual_install(self) -> PluginPermissions {
+        self.0
+    }
+
+    /// Effective permissions for a managed package: the request and the user's
+    /// approval must agree.
+    pub fn intersect(&self, approved: &PluginPermissions) -> PluginPermissions {
+        let mut out = PluginPermissions::denied();
+        for perm in Permission::ALL {
+            out.set(perm, self.0.is_allowed(perm) && approved.is_allowed(perm));
+        }
+        out
+    }
+}
+
+/// Reads a package's requested permissions.
+///
+/// Only an absent manifest means "requests nothing". A manifest that exists but
+/// cannot be read or parsed is an error, because silently treating it as empty
+/// would load the package and then fail every guarded call it makes, which
+/// reports the typo as a permission problem instead of a syntax one.
+pub(crate) fn load_requested_permissions(
+    plugin_dir: &Path,
+) -> Result<Requested, crate::error::PluginError> {
+    let manifest_path = plugin_dir.join(MANIFEST_FILE);
+    let content = match std::fs::read_to_string(&manifest_path) {
+        Ok(content) => content,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Requested::none()),
+        Err(source) => {
+            return Err(crate::error::PluginError::Io {
+                path: manifest_path,
+                source,
+            });
+        }
+    };
+    toml::from_str::<toml::Value>(&content)
+        .map(|value| Requested::from_manifest(&value))
+        .map_err(|e| crate::error::PluginError::PackageManifest {
+            path: manifest_path,
+            message: e.to_string(),
+        })
+}
+
 fn denied_error(perm: Permission) -> LuaError {
     let msg = format!(
         "permission denied: '{perm}' not granted for this plugin (grant it in {MANIFEST_FILE} next to the plugin file)"
@@ -227,6 +307,77 @@ mod tests {
             .unwrap();
         let result: i32 = func.call(()).unwrap();
         assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn requested_denies_omitted_keys() {
+        let val: toml::Value = toml::from_str(
+            r#"
+            [permissions]
+            net = true
+            "#,
+        )
+        .unwrap();
+        let req = Requested::from_manifest(&val);
+        assert!(req.is_requested(Permission::Net));
+        for perm in Permission::ALL {
+            if perm != Permission::Net {
+                assert!(!req.is_requested(perm), "{perm} must not be requested");
+            }
+        }
+    }
+
+    /// The legacy parser stays permissive; only the package parser is strict.
+    /// A manifest with no `[permissions]` section proves the two differ.
+    #[test]
+    fn requested_and_legacy_parsers_disagree_by_design() {
+        let val: toml::Value = toml::from_str("[package]\nname = \"p\"").unwrap();
+        let legacy = PluginPermissions::from_manifest(&val);
+        let requested = Requested::from_manifest(&val);
+        for perm in Permission::ALL {
+            assert!(legacy.is_allowed(perm), "legacy stays permissive");
+            assert!(!requested.is_requested(perm), "package requests nothing");
+        }
+    }
+
+    #[test]
+    fn intersect_needs_both_request_and_approval() {
+        let val: toml::Value = toml::from_str(
+            r#"
+            [permissions]
+            net = true
+            run = true
+            "#,
+        )
+        .unwrap();
+        let requested = Requested::from_manifest(&val);
+
+        let mut approved = PluginPermissions::denied();
+        approved.set(Permission::Net, true);
+        approved.set(Permission::FsRead, true);
+
+        let effective = requested.intersect(&approved);
+        assert!(
+            effective.is_allowed(Permission::Net),
+            "requested + approved"
+        );
+        assert!(!effective.is_allowed(Permission::Run), "not approved");
+        assert!(!effective.is_allowed(Permission::FsRead), "not requested");
+        assert!(!effective.is_allowed(Permission::Env), "neither");
+    }
+
+    #[test]
+    fn manual_install_grants_what_it_requests() {
+        let val: toml::Value = toml::from_str(
+            r#"
+            [permissions]
+            fs_read = true
+            "#,
+        )
+        .unwrap();
+        let granted = Requested::from_manifest(&val).granted_for_manual_install();
+        assert!(granted.is_allowed(Permission::FsRead));
+        assert!(!granted.is_allowed(Permission::Net));
     }
 
     #[test]

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::ffi::c_int;
 use std::future::Future;
 use std::panic::catch_unwind;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::ptr;
 use std::rc::Rc;
@@ -116,15 +116,49 @@ pub(crate) struct PromptHintRegistration {
 
 pub(crate) type PromptHintCallbacks = BTreeMap<Arc<str>, Vec<PromptHintRegistration>>;
 
+/// One source file of a plugin.
+///
+/// A bundled plugin has exactly one. An external package has one per
+/// `plugin/*.lua`, and they share a single owner and a single environment, so
+/// what one registers the next can see.
+#[derive(Debug)]
+pub struct LoadChunk {
+    /// Names the chunk in Lua errors, so a failure points at the file the user
+    /// wrote rather than at the package.
+    pub name: String,
+    pub source: String,
+}
+
+impl LoadChunk {
+    pub fn new(name: impl Into<String>, source: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            source: source.into(),
+        }
+    }
+}
+
 /// Load/clear drain in-flight tools first so we never mutate a
 /// plugin environment while a tool call is still running.
 pub enum Request {
     /// Plugins are loaded, so native codegen may start using idle time. Sent
     /// last so it never interleaves with the loads themselves.
     WarmJit,
+    /// Takes the package operations Lua recorded, leaving the queue empty.
+    TakePackOps {
+        reply: flume::Sender<Vec<crate::api::pack::PackOp>>,
+    },
+    /// Closes the queue and hands over whatever is still in it.
+    ///
+    /// Both halves in one message on purpose: a Lua task can record an
+    /// activation between a read and a separate close, and closing without
+    /// taking would strand it in a queue nobody reads again.
+    SealPackOps {
+        reply: flume::Sender<Vec<crate::api::pack::PackOp>>,
+    },
     LoadSource {
         name: Arc<str>,
-        source: String,
+        chunks: Vec<LoadChunk>,
         plugin_dir: Option<PathBuf>,
         permissions: PluginPermissions,
         opts: PluginOpts,
@@ -550,9 +584,78 @@ fn queue_codegen(queue: &CodegenQueue, func: &Function) {
     }
 }
 
+fn module_io_error(modname: &str, path: &Path, error: &std::io::Error) -> mlua::Error {
+    mlua::Error::runtime(format!(
+        "require '{modname}': cannot read {}: {error}",
+        path.display()
+    ))
+}
+
+fn sandbox_escape(modname: &str) -> mlua::Error {
+    mlua::Error::runtime(format!("require: '{modname}' outside sandbox"))
+}
+
+/// The directory `require` searches, or `None` when there is nothing safe to
+/// search.
+///
+/// Resolving `lua/` is not enough on its own: if `lua` is itself a symlink out
+/// of the package, its target becomes the sandbox root and everything beneath
+/// that target passes the containment check. So the resolved root must still be
+/// inside the resolved package directory. A package with no `lua/` simply has
+/// no module root, which is not an error.
+enum RequireRoot {
+    Trusted(PathBuf),
+    Sandboxed(PathBuf),
+}
+
+impl RequireRoot {
+    fn path(&self) -> &Path {
+        match self {
+            Self::Trusted(path) | Self::Sandboxed(path) => path,
+        }
+    }
+
+    fn canonicalize(self) -> Self {
+        match self {
+            Self::Trusted(path) => {
+                let resolved = path.canonicalize().unwrap_or(path);
+                Self::Trusted(resolved)
+            }
+            Self::Sandboxed(path) => {
+                let resolved = path.canonicalize().unwrap_or(path);
+                Self::Sandboxed(resolved)
+            }
+        }
+    }
+
+    fn is_sandboxed(&self) -> bool {
+        matches!(self, Self::Sandboxed(_))
+    }
+}
+
+fn resolve_require_root(plugin_dir: &Path) -> Option<RequireRoot> {
+    let lua_dir = plugin_dir.join("lua");
+    let Ok(resolved) = lua_dir.canonicalize() else {
+        return None;
+    };
+    let root = plugin_dir
+        .canonicalize()
+        .unwrap_or_else(|_| plugin_dir.to_path_buf());
+    if resolved.starts_with(&root) {
+        Some(RequireRoot::Sandboxed(resolved))
+    } else {
+        tracing::warn!(
+            plugin_dir = %plugin_dir.display(),
+            resolved = %resolved.display(),
+            "lua directory resolves outside its package; modules will not load"
+        );
+        None
+    }
+}
+
 struct ModuleLoader {
     bundled: BundledModules,
-    lua_dir: Option<PathBuf>,
+    require_root: Option<RequireRoot>,
     env: Table,
     codegen: CodegenQueue,
     loaded: Table,
@@ -563,9 +666,10 @@ impl ModuleLoader {
     /// Bundled modules are tried first, so a plugin cannot shadow
     /// `maki.truncate` and friends with a file of its own.
     fn plugin_source(&self, rel_path: &str, modname: &str) -> Result<Option<String>, mlua::Error> {
-        let Some(dir) = self.lua_dir.as_ref() else {
+        let Some(root) = self.require_root.as_ref() else {
             return Ok(None);
         };
+        let dir = root.path();
         let normalized = dir
             .join(rel_path)
             .components()
@@ -580,11 +684,28 @@ impl ModuleLoader {
                 acc
             });
         if !normalized.starts_with(dir) {
-            return Err(mlua::Error::runtime(format!(
-                "require: '{modname}' outside sandbox"
-            )));
+            return Err(sandbox_escape(modname));
         }
-        Ok(std::fs::read_to_string(&normalized).ok())
+        // External packages are downloaded, and git carries symlinks, so the
+        // lexical fold above is not enough: a link inside the package can still
+        // point out of it. Resolve the real path and re-check.
+        //
+        // Only an absent file is a miss. An unreadable one, a symlink loop, or
+        // a file that is not UTF-8 is reported, because reporting it as
+        // "module not found" sends the user looking for a name they can see.
+        let resolved = match std::fs::canonicalize(&normalized) {
+            Ok(resolved) => resolved,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(module_io_error(modname, &normalized, &e)),
+        };
+        if root.is_sandboxed() && !resolved.starts_with(dir) {
+            return Err(sandbox_escape(modname));
+        }
+        match std::fs::read_to_string(&resolved) {
+            Ok(source) => Ok(Some(source)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(module_io_error(modname, &resolved, &e)),
+        }
     }
 
     fn bind(&self, chunk: Chunk<'_>, modname: &str) -> Result<Function, mlua::Error> {
@@ -597,22 +718,38 @@ impl ModuleLoader {
     /// Bundled modules load as bytecode from the shared cache. Plugin files
     /// load as source, so Luau reports syntax errors against the file the user
     /// wrote.
+    ///
+    /// Both forms Neovim accepts are tried, `<mod>.lua` before
+    /// `<mod>/init.lua`. Every bundled candidate is tried before any plugin
+    /// file, so a package still cannot shadow a bundled module.
     fn load(&self, lua: &Lua, modname: &str) -> Result<LuaValue, mlua::Error> {
-        let rel_path = modname.replace('.', "/") + ".lua";
-        let func = match self.bundled.bytecode(&rel_path)? {
-            Some(bytecode) => self.bind(
-                lua.load(bytecode.as_slice()).set_mode(ChunkMode::Binary),
-                modname,
-            )?,
-            None => {
-                let Some(source) = self.plugin_source(&rel_path, modname)? else {
-                    return Err(mlua::Error::runtime(format!(
-                        "require '{modname}': module not found"
-                    )));
-                };
-                self.bind(lua.load(source.as_str()), modname)?
+        let base = modname.replace('.', "/");
+        let candidates = [format!("{base}.lua"), format!("{base}/init.lua")];
+
+        let mut func = None;
+        for rel_path in &candidates {
+            if let Some(bytecode) = self.bundled.bytecode(rel_path)? {
+                func = Some(self.bind(
+                    lua.load(bytecode.as_slice()).set_mode(ChunkMode::Binary),
+                    modname,
+                )?);
+                break;
             }
+        }
+        if func.is_none() {
+            for rel_path in &candidates {
+                if let Some(source) = self.plugin_source(rel_path, modname)? {
+                    func = Some(self.bind(lua.load(source.as_str()), modname)?);
+                    break;
+                }
+            }
+        }
+        let Some(func) = func else {
+            return Err(mlua::Error::runtime(format!(
+                "require '{modname}': module not found"
+            )));
         };
+
         queue_codegen(&self.codegen, &func);
         func.call(())
     }
@@ -1405,6 +1542,7 @@ impl LuaRuntime {
         })?;
 
         lua.set_app_data(CommandHandlerMap::new());
+        lua.set_app_data(crate::api::pack::PackStore::default());
         lua.set_app_data(JobStore::new());
         lua.set_app_data(SpawnQueue::new());
         lua.set_app_data(command_writer);
@@ -1676,7 +1814,7 @@ impl LuaRuntime {
     fn build_env(
         &self,
         maki: mlua::Table,
-        require_root: Option<PathBuf>,
+        require_root: Option<RequireRoot>,
     ) -> Result<mlua::Table, mlua::Error> {
         let env = self.lua.create_table()?;
         env.set("maki", maki)?;
@@ -1697,11 +1835,11 @@ impl LuaRuntime {
     fn create_require_fn(
         &self,
         env: &mlua::Table,
-        require_root: Option<PathBuf>,
+        require_root: Option<RequireRoot>,
     ) -> Result<Function, mlua::Error> {
         let loader = ModuleLoader {
             bundled: self.bundled.clone(),
-            lua_dir: require_root.map(|r| r.canonicalize().unwrap_or(r)),
+            require_root: require_root.map(RequireRoot::canonicalize),
             env: env.clone(),
             codegen: self.codegen_queue.clone(),
             loaded: self.lua.create_table()?,
@@ -1731,10 +1869,27 @@ impl LuaRuntime {
         )))
     }
 
+    fn pack_ops_checkpoint(&self) -> usize {
+        self.lua
+            .app_data_ref::<crate::api::pack::PackStore>()
+            .map(|store| store.lock().expect("pack declarations").pending.len())
+            .unwrap_or_default()
+    }
+
+    fn rollback_pack_ops(&self, checkpoint: usize) {
+        if let Some(store) = self.lua.app_data_ref::<crate::api::pack::PackStore>() {
+            store
+                .lock()
+                .expect("pack declarations")
+                .pending
+                .truncate(checkpoint);
+        }
+    }
+
     async fn load_source(
         &mut self,
         name: Arc<str>,
-        source: &str,
+        chunks: &[LoadChunk],
         plugin_dir: Option<PathBuf>,
         permissions: &PluginPermissions,
         opts: PluginOpts,
@@ -1755,8 +1910,12 @@ impl LuaRuntime {
         // Scoped to this load so a failed load simply drops its rules; only a
         // successful load commits them to the store.
         let pending_rules: PendingRules = Arc::default();
+        let pack_ops_checkpoint = self.pack_ops_checkpoint();
 
-        let require_root = plugin_dir.as_ref().map(|d| d.join("lua"));
+        let require_root = plugin_dir.as_ref().and_then(|dir| match config_store {
+            Some(_) => Some(RequireRoot::Trusted(dir.join("lua"))),
+            None => resolve_require_root(dir),
+        });
         let maki = create_maki_global(
             &self.lua,
             Arc::clone(&self.pending),
@@ -1773,30 +1932,40 @@ impl LuaRuntime {
                 .map_err(&map_err)?;
             maki.set("setup", setup_fn).map_err(&map_err)?;
         }
-
         let env = self.build_env(maki, require_root).map_err(&map_err)?;
 
         self.drop_plugin_keys(&name);
 
-        let main_fn = self
-            .lua
-            .load(source)
-            .set_name(name.as_ref())
-            .set_environment(env)
-            .into_function();
-        let exec_result = match main_fn {
-            Ok(func) => {
-                queue_codegen(&self.codegen_queue, &func);
-                func.call_async::<()>(()).await
+        // Chunks run in order against one environment, so a later file sees
+        // what an earlier one registered. The first failure stops the rest.
+        let mut exec_result = Ok(());
+        for chunk in chunks {
+            let main_fn = self
+                .lua
+                .load(chunk.source.as_str())
+                .set_name(chunk.name.as_str())
+                .set_environment(env.clone())
+                .into_function();
+            exec_result = match main_fn {
+                Ok(func) => {
+                    queue_codegen(&self.codegen_queue, &func);
+                    func.call_async::<()>(()).await
+                }
+                Err(e) => Err(e),
+            };
+            if exec_result.is_err() {
+                break;
             }
-            Err(e) => Err(e),
-        };
+        }
 
+        // Checked once, after the last chunk: an option that a later chunk
+        // reads must not be reported as unused by an earlier one.
         let exec_result = exec_result.and_then(|()| self.check_opts_consumed(&name, &opts));
         if let Err(e) = exec_result {
             let stale = self.drain_pending();
             self.discard_pending(stale);
-            self.drop_plugin_keys(&name);
+            self.rollback_pack_ops(pack_ops_checkpoint);
+            self.clear_plugin(&name);
             return Err(map_err(e));
         }
 
@@ -1836,6 +2005,11 @@ impl LuaRuntime {
 
         if let Err(e) = self.registry.replace_plugin(&name, registry_entries) {
             self.discard_pending(pending);
+            self.rollback_pack_ops(pack_ops_checkpoint);
+            // The chunks already published commands, keymaps, hints, and slots
+            // before we got here, so a conflict at the commit point has to
+            // unwind them too, not just drop the pending tools.
+            self.clear_plugin(&name);
             return Err(match e {
                 RegistryError::NameConflict { name: n, .. } => PluginError::NameConflict {
                     plugin: name.to_string(),
@@ -1950,7 +2124,7 @@ impl LuaRuntime {
         let perms = load_plugin_permissions(plugin_dir.as_deref());
         self.load_source(
             Arc::from(source_name),
-            source,
+            &[LoadChunk::new(source_name, source)],
             plugin_dir,
             &perms,
             PluginOpts::default(),
@@ -2648,14 +2822,14 @@ pub fn spawn(
                         Request::WarmJit => codegen_armed = true,
                         Request::LoadSource {
                             name,
-                            source,
+                            chunks,
                             plugin_dir,
                             permissions,
                             opts,
                             reply,
                         } => {
                             drain_barrier(&rt.lua, &ex, &gate, &spawn_rx).await;
-                            let res = rt.load_source(Arc::clone(&name), &source, plugin_dir, &permissions, opts, None).await;
+                            let res = rt.load_source(Arc::clone(&name), &chunks, plugin_dir, &permissions, opts, None).await;
                             let _ = reply.send(res);
                         }
                         Request::CallTool {
@@ -2692,6 +2866,31 @@ pub fn spawn(
                                 let _ = reply.send(res);
                             })
                             .detach();
+                        }
+                        Request::TakePackOps { reply } => {
+                            let ops = rt
+                                .lua
+                                .app_data_ref::<crate::api::pack::PackStore>()
+                                .map(|store| {
+                                    std::mem::take(
+                                        &mut store.lock().expect("pack declarations").pending,
+                                    )
+                                })
+                                .unwrap_or_default();
+                            let _ = reply.send(ops);
+                        }
+                        Request::SealPackOps { reply } => {
+                            let ops = rt
+                                .lua
+                                .app_data_ref::<crate::api::pack::PackStore>()
+                                .map(|store| {
+                                    let mut declarations =
+                                        store.lock().expect("pack declarations");
+                                    declarations.drained = true;
+                                    std::mem::take(&mut declarations.pending)
+                                })
+                                .unwrap_or_default();
+                            let _ = reply.send(ops);
                         }
                         Request::ClearPlugin { plugin, reply } => {
                             drain_barrier(&rt.lua, &ex, &gate, &spawn_rx).await;

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -138,6 +138,42 @@ impl LoadChunk {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ConfigScope {
+    Global,
+    Project,
+    Named(String),
+}
+
+impl ConfigScope {
+    fn label(&self) -> &str {
+        match self {
+            Self::Global => "global/init.lua",
+            Self::Project => "project/init.lua",
+            Self::Named(name) => name,
+        }
+    }
+
+    pub(crate) fn named(name: String) -> Self {
+        match name.as_str() {
+            "global/init.lua" => Self::Global,
+            "project/init.lua" => Self::Project,
+            _ => Self::Named(name),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ConfigLoad<'a> {
+    store: &'a ConfigStore,
+    scope: &'a ConfigScope,
+}
+
+enum PluginLoad<'a> {
+    Chunks(&'a [LoadChunk]),
+    Function { function: Function, argument: Table },
+}
+
 /// Load/clear drain in-flight tools first so we never mutate a
 /// plugin environment while a tool call is still running.
 pub enum Request {
@@ -162,6 +198,8 @@ pub enum Request {
         plugin_dir: Option<PathBuf>,
         permissions: PluginPermissions,
         opts: PluginOpts,
+        revision_guard: Option<Arc<maki_pack::lock::Lock>>,
+        package: bool,
         reply: flume::Sender<LoadResult>,
     },
     CallTool {
@@ -191,7 +229,7 @@ pub enum Request {
     },
     RunInitLua {
         source: String,
-        source_name: String,
+        scope: ConfigScope,
         plugin_dir: Option<PathBuf>,
         reply: flume::Sender<Result<Option<RawConfig>, PluginError>>,
     },
@@ -208,6 +246,19 @@ pub enum Request {
     },
     CollectPluginOptions {
         reply: flume::Sender<PluginOptionSpecs>,
+    },
+    /// Packages `init.lua` declared. Read after the init files have run, since
+    /// that is when the declared set is complete.
+    CollectPackages {
+        reply: flume::Sender<Vec<crate::api::pack::Declared>>,
+    },
+    RunPackLoader {
+        declared: crate::api::pack::Declared,
+        path: PathBuf,
+        permissions: PluginPermissions,
+        opts: PluginOpts,
+        revision_guard: Option<Arc<maki_pack::lock::Lock>>,
+        reply: flume::Sender<LoadResult>,
     },
     Shutdown,
     RestoreToolAsync {
@@ -1481,7 +1532,12 @@ struct ToolKeys {
     describe: Option<RegistryKey>,
 }
 
-type PluginMap = Rc<RefCell<HashMap<Arc<str>, HashMap<Arc<str>, ToolKeys>>>>;
+struct PluginOwner {
+    tools: HashMap<Arc<str>, ToolKeys>,
+    revision_guard: Option<Arc<maki_pack::lock::Lock>>,
+}
+
+type PluginMap = Rc<RefCell<HashMap<Arc<str>, PluginOwner>>>;
 
 struct LuaRuntime {
     /// Held for its Drop (joins the poker thread). Field order doesn't
@@ -1542,12 +1598,12 @@ impl LuaRuntime {
         })?;
 
         lua.set_app_data(CommandHandlerMap::new());
-        lua.set_app_data(crate::api::pack::PackStore::default());
         lua.set_app_data(JobStore::new());
         lua.set_app_data(SpawnQueue::new());
         lua.set_app_data(command_writer);
         lua.set_app_data(PromptHintCallbacks::default());
         lua.set_app_data(PluginOptionSpecs::default());
+        lua.set_app_data(crate::api::pack::PackStore::default());
         lua.set_app_data(AutocmdStore::default());
         lua.set_app_data(SlotStore::default());
         lua.set_app_data(KeymapStore::new());
@@ -1569,7 +1625,7 @@ impl LuaRuntime {
             let plugins = Rc::clone(&plugins);
             crate::api::tool::set_local_tool_handles(move |tool| {
                 let plugins = plugins.borrow();
-                let tk = plugins.values().find_map(|tools| tools.get(tool))?;
+                let tk = plugins.values().find_map(|owner| owner.tools.get(tool))?;
                 let to_fn = |key: Option<&RegistryKey>| {
                     key.and_then(|k| lua.registry_value::<Function>(k).ok())
                 };
@@ -1617,7 +1673,7 @@ impl LuaRuntime {
         true
     }
 
-    fn drop_plugin_keys(&mut self, name: &str) {
+    fn drop_plugin_keys(&mut self, name: &str) -> Option<Arc<maki_pack::lock::Lock>> {
         self.warm_tools.borrow_mut().clear();
         with_jobs(&self.lua, |store| {
             store.kill_owner(&self.lua, &JobOwner::Plugin(Arc::from(name)));
@@ -1631,8 +1687,10 @@ impl LuaRuntime {
         if let Some(mut store) = self.lua.app_data_mut::<SlotStore>() {
             store.clear_plugin(name);
         }
-        if let Some(keys) = self.plugins.borrow_mut().remove(name) {
-            for (_, tk) in keys {
+        let mut revision_guard = None;
+        if let Some(owner) = self.plugins.borrow_mut().remove(name) {
+            revision_guard = owner.revision_guard;
+            for (_, tk) in owner.tools {
                 if let Err(e) = self.lua.remove_registry_value(tk.handler) {
                     tracing::warn!(plugin = name, error = %e, "failed to drop lua handler key");
                 }
@@ -1685,6 +1743,7 @@ impl LuaRuntime {
                 }
             }
         }
+        revision_guard
     }
 
     async fn run_hint_callback(&self, plugin: &str, func: Function) -> Option<String> {
@@ -1886,14 +1945,17 @@ impl LuaRuntime {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn load_source(
         &mut self,
         name: Arc<str>,
-        chunks: &[LoadChunk],
+        load: PluginLoad<'_>,
         plugin_dir: Option<PathBuf>,
         permissions: &PluginPermissions,
         opts: PluginOpts,
-        config_store: Option<&ConfigStore>,
+        config: Option<ConfigLoad<'_>>,
+        revision_guard: Option<Arc<maki_pack::lock::Lock>>,
+        package: bool,
     ) -> LoadResult {
         let map_err = |e: mlua::Error| PluginError::Lua {
             plugin: name.to_string(),
@@ -1912,7 +1974,7 @@ impl LuaRuntime {
         let pending_rules: PendingRules = Arc::default();
         let pack_ops_checkpoint = self.pack_ops_checkpoint();
 
-        let require_root = plugin_dir.as_ref().and_then(|dir| match config_store {
+        let require_root = plugin_dir.as_ref().and_then(|dir| match config {
             Some(_) => Some(RequireRoot::Trusted(dir.join("lua"))),
             None => resolve_require_root(dir),
         });
@@ -1927,36 +1989,54 @@ impl LuaRuntime {
         )
         .map_err(&map_err)?;
 
-        if let Some(cs) = config_store {
-            let setup_fn = crate::api::util::setup::create_setup_fn(&self.lua, Arc::clone(cs))
-                .map_err(&map_err)?;
+        if let Some(config) = config {
+            let setup_fn =
+                crate::api::util::setup::create_setup_fn(&self.lua, Arc::clone(config.store))
+                    .map_err(&map_err)?;
             maki.set("setup", setup_fn).map_err(&map_err)?;
+
+            let pack = match config.scope {
+                ConfigScope::Global => crate::api::pack::create_pack_table(&self.lua),
+                _ => crate::api::pack::create_pack_read_table(&self.lua),
+            }
+            .map_err(&map_err)?;
+            maki.set("pack", pack).map_err(&map_err)?;
         }
         let env = self.build_env(maki, require_root).map_err(&map_err)?;
 
-        self.drop_plugin_keys(&name);
+        drop(self.drop_plugin_keys(&name));
 
         // Chunks run in order against one environment, so a later file sees
         // what an earlier one registered. The first failure stops the rest.
-        let mut exec_result = Ok(());
-        for chunk in chunks {
-            let main_fn = self
-                .lua
-                .load(chunk.source.as_str())
-                .set_name(chunk.name.as_str())
-                .set_environment(env.clone())
-                .into_function();
-            exec_result = match main_fn {
-                Ok(func) => {
-                    queue_codegen(&self.codegen_queue, &func);
-                    func.call_async::<()>(()).await
+        let exec_result = match load {
+            PluginLoad::Chunks(chunks) => {
+                let mut result = Ok(());
+                for chunk in chunks {
+                    let main_fn = self
+                        .lua
+                        .load(chunk.source.as_str())
+                        .set_name(chunk.name.as_str())
+                        .set_environment(env.clone())
+                        .into_function();
+                    result = match main_fn {
+                        Ok(function) => {
+                            queue_codegen(&self.codegen_queue, &function);
+                            function.call_async::<()>(()).await
+                        }
+                        Err(error) => Err(error),
+                    };
+                    if result.is_err() {
+                        break;
+                    }
                 }
-                Err(e) => Err(e),
-            };
-            if exec_result.is_err() {
-                break;
+                result
             }
-        }
+            PluginLoad::Function { function, argument } => {
+                function.set_environment(env).map_err(&map_err)?;
+                queue_codegen(&self.codegen_queue, &function);
+                function.call_async::<()>(argument).await
+            }
+        };
 
         // Checked once, after the last chunk: an option that a later chunk
         // reads must not be reported as unused by an earlier one.
@@ -2039,7 +2119,20 @@ impl LuaRuntime {
             .collect();
         let rules = std::mem::take(&mut *pending_rules.lock().unwrap_or_else(|e| e.into_inner()));
         self.plugin_rules.replace(&name, rules);
-        self.plugins.borrow_mut().insert(name, keys);
+        self.plugins.borrow_mut().insert(
+            Arc::clone(&name),
+            PluginOwner {
+                tools: keys,
+                revision_guard,
+            },
+        );
+        if package && let Some(store) = self.lua.app_data_ref::<crate::api::pack::PackStore>() {
+            store
+                .lock()
+                .expect("pack declarations")
+                .active
+                .insert(name.to_string());
+        }
 
         Ok(())
     }
@@ -2047,7 +2140,14 @@ impl LuaRuntime {
     fn clear_plugin(&mut self, plugin: &str) {
         self.registry.clear_plugin(plugin);
         self.plugin_rules.remove(plugin);
-        self.drop_plugin_keys(plugin);
+        let revision_guard = self.drop_plugin_keys(plugin);
+        if let Some(store) = self.lua.app_data_ref::<crate::api::pack::PackStore>() {
+            store
+                .lock()
+                .expect("pack declarations")
+                .active
+                .remove(plugin);
+        }
         if let Some(mut store) = self.lua.app_data_mut::<KeymapStore>() {
             let keys = store.clear_plugin(plugin);
             let entries = store.snapshot_entries();
@@ -2067,6 +2167,7 @@ impl LuaRuntime {
                 writer.publish(entries);
             }
         }
+        drop(revision_guard);
     }
 
     fn evict_warm(&self, tool_use_id: &str) {
@@ -2117,18 +2218,23 @@ impl LuaRuntime {
     async fn run_init_lua(
         &mut self,
         source: &str,
-        source_name: &str,
+        scope: ConfigScope,
         plugin_dir: Option<PathBuf>,
     ) -> Result<Option<RawConfig>, PluginError> {
         let config_store: ConfigStore = Arc::new(Mutex::new(None));
         let perms = load_plugin_permissions(plugin_dir.as_deref());
         self.load_source(
-            Arc::from(source_name),
-            &[LoadChunk::new(source_name, source)],
+            Arc::from(scope.label()),
+            PluginLoad::Chunks(&[LoadChunk::new(scope.label(), source)]),
             plugin_dir,
             &perms,
             PluginOpts::default(),
-            Some(&config_store),
+            Some(ConfigLoad {
+                store: &config_store,
+                scope: &scope,
+            }),
+            None,
+            false,
         )
         .await?;
         Ok(config_store.lock().unwrap().take())
@@ -2148,7 +2254,7 @@ fn plugin_fn(
 ) -> Option<(Function, LuaValue)> {
     let func = {
         let plugins = plugins.borrow();
-        let key = key(plugins.get(plugin)?.get(tool)?)?;
+        let key = key(plugins.get(plugin)?.tools.get(tool)?)?;
         match lua.registry_value::<Function>(key) {
             Ok(f) => f,
             Err(e) => {
@@ -2209,9 +2315,12 @@ async fn compute_header(
 async fn restore_item(lua: &Lua, plugins: &PluginMap, item: RestoreItem) -> Option<RestoreReply> {
     let (func, plugin_name) = {
         let plugins = plugins.borrow();
-        let (pname, tk) = plugins
-            .iter()
-            .find_map(|(pname, tools)| tools.get(&*item.tool).map(|tk| (pname.clone(), tk)))?;
+        let (pname, tk) = plugins.iter().find_map(|(pname, owner)| {
+            owner
+                .tools
+                .get(&*item.tool)
+                .map(|keys| (pname.clone(), keys))
+        })?;
         let key = tk.restore.as_ref()?;
         (lua.registry_value::<Function>(key).ok()?, pname)
     };
@@ -2500,7 +2609,12 @@ fn run_describe(
 ) -> Option<String> {
     let func: Function = {
         let plugins_ref = plugins.borrow();
-        let key = plugins_ref.get(plugin)?.get(tool)?.describe.as_ref()?;
+        let key = plugins_ref
+            .get(plugin)?
+            .tools
+            .get(tool)?
+            .describe
+            .as_ref()?;
         lua.registry_value(key).ok()?
     };
     let arg = match json_to_lua(lua, dctx) {
@@ -2563,10 +2677,10 @@ async fn run_tool_call(
 ) -> ToolCallReply {
     let handler: Function = {
         let plugins_ref = plugins.borrow();
-        let Some(keys) = plugins_ref.get(&*plugin) else {
+        let Some(owner) = plugins_ref.get(&*plugin) else {
             return ToolCallReply::err(format!("plugin not loaded: {plugin}"));
         };
-        let Some(tool_keys) = keys.get(&*tool) else {
+        let Some(tool_keys) = owner.tools.get(&*tool) else {
             return ToolCallReply::err(format!("tool not found: {tool}"));
         };
         match lua.registry_value(&tool_keys.handler) {
@@ -2826,10 +2940,23 @@ pub fn spawn(
                             plugin_dir,
                             permissions,
                             opts,
+                            revision_guard,
+                            package,
                             reply,
                         } => {
                             drain_barrier(&rt.lua, &ex, &gate, &spawn_rx).await;
-                            let res = rt.load_source(Arc::clone(&name), &chunks, plugin_dir, &permissions, opts, None).await;
+                            let res = rt
+                                .load_source(
+                                    Arc::clone(&name),
+                                    PluginLoad::Chunks(&chunks),
+                                    plugin_dir,
+                                    &permissions,
+                                    opts,
+                                    None,
+                                    revision_guard,
+                                    package,
+                                )
+                                .await;
                             let _ = reply.send(res);
                         }
                         Request::CallTool {
@@ -2949,12 +3076,12 @@ pub fn spawn(
                         }
                         Request::RunInitLua {
                             source,
-                            source_name,
+                            scope,
                             plugin_dir,
                             reply,
                         } => {
                             drain_barrier(&rt.lua, &ex, &gate, &spawn_rx).await;
-                            let res = rt.run_init_lua(&source, &source_name, plugin_dir).await;
+                            let res = rt.run_init_lua(&source, scope, plugin_dir).await;
                             let _ = reply.send(res);
                         }
                         Request::CollectPromptSlots { reply } => {
@@ -2963,6 +3090,67 @@ pub fn spawn(
                         }
                         Request::CollectPluginOptions { reply } => {
                             let _ = reply.send(collect_plugin_options(&rt.lua));
+                        }
+                        Request::CollectPackages { reply } => {
+                            let declared = rt
+                                .lua
+                                .app_data_ref::<crate::api::pack::PackStore>()
+                                .map(|store| store.lock().expect("pack declarations").specs.clone())
+                                .unwrap_or_default();
+                            let _ = reply.send(declared);
+                        }
+                        Request::RunPackLoader {
+                            declared,
+                            path,
+                            permissions,
+                            opts,
+                            revision_guard,
+                            reply,
+                        } => {
+                            drain_barrier(&rt.lua, &ex, &gate, &spawn_rx).await;
+                            let name = declared.spec.name.clone();
+                            let input = (|| {
+                                let crate::api::pack::LoadMode::Custom(loader) = &declared.load
+                                else {
+                                    return Err(mlua::Error::runtime(
+                                        "run_pack_loader: not a custom load",
+                                    ));
+                                };
+                                let function =
+                                    rt.lua.registry_value::<Function>(loader.as_ref())?;
+                                let argument = rt.lua.create_table()?;
+                                argument.set(
+                                    "spec",
+                                    crate::api::pack::spec_to_lua(
+                                        &rt.lua,
+                                        &declared.spec,
+                                        declared.data.as_ref(),
+                                    )?,
+                                )?;
+                                argument.set("path", path.display().to_string())?;
+                                Ok::<_, mlua::Error>((function, argument))
+                            })()
+                            .map_err(|source| PluginError::Lua {
+                                plugin: name.clone(),
+                                source,
+                            });
+                            let result = match input {
+                                Ok((function, argument)) => {
+                                    rt.load_source(
+                                        Arc::from(name.as_str()),
+                                        PluginLoad::Function { function, argument },
+                                        Some(path),
+                                        &permissions,
+                                        opts,
+                                        None,
+                                        revision_guard,
+                                        true,
+                                    )
+                                    .await
+                                }
+                                Err(error) => Err(error),
+                            };
+                            let _ = reply.send(result);
                         }
                         Request::RestoreToolAsync { item, event_tx } => {
                             spawn_restore(&ex, &gate, &restores, &rt, item, event_tx);
@@ -3051,7 +3239,7 @@ pub fn spawn(
                                 let plugins = rt.plugins.borrow();
                                 plugins
                                     .get(&*plugin)
-                                    .and_then(|p| p.get(&*tool))
+                                    .and_then(|owner| owner.tools.get(&*tool))
                                     .and_then(|tk| tk.start.as_ref())
                                     .and_then(|key| rt.lua.registry_value::<Function>(key).ok())
                             };

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -18,6 +18,7 @@ use serde_json::{Value, json};
 
 const BUILTIN_COMMANDS: &[&str] = &["/sessions", "/rename", "/tasks"];
 const NARGS_ERR: &str = r#"'nargs' must be 0, 1, "?", "*", or "+""#;
+const GLOBAL_PACK_ONLY_ERR: &str = "only available in the global init.lua";
 const USAGE_TOOL_NAME: &str = "usage_child";
 const USAGE_VALUE: &str = "12.3k↑ 456↓ $0.123";
 const USAGE_OUTPUT: &str = "usage_done";
@@ -2230,6 +2231,79 @@ fn setup_happy_path() {
     assert_eq!(raw.agent.max_output_lines, Some(3000));
 }
 
+#[test]
+fn project_init_cannot_declare_global_packages() {
+    let host = PluginHost::new(fresh_registry()).unwrap();
+
+    let error = host
+        .send_run_init_lua(
+            r#"maki.pack.add({ "https://example.com/demo" })"#.to_owned(),
+            "project/init.lua".to_owned(),
+            None,
+        )
+        .expect_err("project config must not change global packages");
+
+    assert!(
+        error.to_string().contains(GLOBAL_PACK_ONLY_ERR),
+        "got: {error}"
+    );
+}
+
+#[test]
+fn a_named_config_cannot_change_global_packages() {
+    let host = PluginHost::new(fresh_registry()).unwrap();
+
+    let error = host
+        .send_run_init_lua(
+            r#"maki.pack.add({ "https://example.com/demo" })"#.to_owned(),
+            "test_init.lua".to_owned(),
+            None,
+        )
+        .expect_err("only the global config may change packages");
+
+    assert!(
+        error.to_string().contains(GLOBAL_PACK_ONLY_ERR),
+        "got: {error}"
+    );
+}
+
+#[test]
+fn global_init_can_declare_managed_packages() {
+    let host = PluginHost::new(fresh_registry()).unwrap();
+
+    let _ = host
+        .send_run_init_lua(
+            r#"maki.pack.add({ "https://example.com/demo" })"#.to_owned(),
+            "global/init.lua".to_owned(),
+            None,
+        )
+        .unwrap();
+
+    let declared = host.declared_packages().unwrap();
+    assert_eq!(declared.len(), 1);
+    assert_eq!(declared[0].spec.name, "demo");
+}
+
+#[test]
+fn project_init_can_activate_an_installed_global_package() {
+    let host = PluginHost::new(fresh_registry()).unwrap();
+
+    let _ = host
+        .send_run_init_lua(
+            r#"maki.packadd("demo")"#.to_owned(),
+            "project/init.lua".to_owned(),
+            None,
+        )
+        .unwrap();
+
+    assert_eq!(
+        host.seal_pack_ops().unwrap(),
+        [maki_lua::PackOp::Activate {
+            name: "demo".to_owned()
+        }]
+    );
+}
+
 #[test_case::test_case(
     r#"maki.setup({ agent = { compaction_buffer = 10000 } })"#,
     maki_config::CompactionBuffer::Tokens(10_000)
@@ -3105,6 +3179,192 @@ fn discovered_start_package_is_found_and_loaded() {
     assert_eq!(snap.commands[0].plugin.as_ref(), "demo_pack");
 }
 
+#[test]
+fn custom_loader_runs_as_the_package_owner_with_spec_data() {
+    let package = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(package.path().join("lua")).unwrap();
+    std::fs::write(
+        package.path().join("lua").join("entry.lua"),
+        r#"
+return {
+  setup = function(command)
+    maki.api.register_command({ name = command, handler = function() end })
+    maki.api.register_tool({
+      name = "custom_state",
+      description = "Package state.",
+      schema = { type = "object", properties = {} },
+      audiences = { "main" },
+      handler = function()
+        return tostring(maki.pack.get({ "custom" })[1].active)
+      end,
+    })
+  end,
+}
+"#,
+    )
+    .unwrap();
+
+    let registry = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&registry)).unwrap();
+    host.send_run_init_lua(
+        r#"
+maki.pack.add({
+  {
+    src = "https://example.com/custom",
+    name = "custom",
+    data = { module = "entry", command = "/custom" },
+  },
+}, {
+  load = function(package)
+    require(package.spec.data.module).setup(package.spec.data.command)
+  end,
+})
+"#
+        .to_owned(),
+        "global/init.lua".to_owned(),
+        None,
+    )
+    .unwrap();
+    let declared = host.declared_packages().unwrap();
+    let packages = vec![maki_lua::DiscoveredPackage {
+        name: "custom".to_owned(),
+        dir: package.path().to_path_buf(),
+        eager: true,
+        requested: maki_lua::Requested::none(),
+        origin: maki_lua::Origin::Fetched {
+            src: "https://example.com/custom".to_owned(),
+        },
+        revision_guard: None,
+    }];
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &["custom".into()]);
+
+    let failures = host.load_declared_packages(&packages, &declared, &config);
+    assert!(failures.is_empty(), "got: {failures:?}");
+
+    let commands = host.command_reader().load();
+    assert_eq!(commands.commands.len(), 1);
+    assert_eq!(commands.commands[0].name.as_ref(), "/custom");
+    assert_eq!(commands.commands[0].plugin.as_ref(), "custom");
+    assert_eq!(
+        exec_tool(&registry, "custom_state", serde_json::json!({})).unwrap(),
+        "true"
+    );
+}
+
+#[test]
+fn managed_custom_loader_does_not_capture_a_manual_name_conflict() {
+    let site = site_with_package(
+        "start",
+        "manual",
+        &[(
+            "init.lua",
+            r#"maki.api.register_command({ name = "/manual", handler = function() end })"#,
+        )],
+    );
+    let packages = maki_lua::discover(site.path()).packages;
+    let host = PluginHost::new(fresh_registry()).unwrap();
+    host.send_run_init_lua(
+        r#"
+maki.pack.add({
+  { src = "https://example.com/manual", name = "manual" },
+}, {
+  load = function() error("managed custom loader ran") end,
+})
+"#
+        .to_owned(),
+        "global/init.lua".to_owned(),
+        None,
+    )
+    .unwrap();
+    let declared = host.declared_packages().unwrap();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &["manual".into()]);
+
+    let failures = host.load_declared_packages(&packages, &declared, &config);
+
+    assert!(failures.is_empty(), "got: {failures:?}");
+    let commands = host.command_reader().load();
+    assert_eq!(commands.commands.len(), 1);
+    assert_eq!(commands.commands[0].name.as_ref(), "/manual");
+}
+
+#[test]
+fn loaded_revision_lock_protects_modules_read_after_startup() {
+    const CURRENT: &str = "1111111111111111111111111111111111111111";
+    const STALE: &str = "2222222222222222222222222222222222222222";
+
+    let site = tempfile::TempDir::new().unwrap();
+    let stale_dir = maki_pack::paths::revision_dir(site.path(), "late_pack", STALE);
+    std::fs::create_dir_all(stale_dir.join("plugin")).unwrap();
+    std::fs::create_dir_all(stale_dir.join("lua")).unwrap();
+    std::fs::write(
+        stale_dir.join("plugin").join("init.lua"),
+        format!(
+            r#"
+maki.api.register_tool({{
+  name = "late_pack",
+  description = "Late module read.",
+  schema = {MINIMAL_SCHEMA},
+  audiences = {{ "main" }},
+  handler = function() return require("late").value end,
+}})
+"#
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        stale_dir.join("lua").join("late.lua"),
+        "return { value = 'late ok' }\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(maki_pack::paths::revision_dir(
+        site.path(),
+        "late_pack",
+        CURRENT,
+    ))
+    .unwrap();
+    let mut lockfile = maki_pack::lockfile::Lockfile::default();
+    lockfile.record("late_pack", "https://example.com/late", CURRENT);
+    let revision_guard = Arc::new(
+        maki_pack::lock::Lock::acquire_shared(&maki_pack::paths::revision_lock(
+            site.path(),
+            "late_pack",
+            STALE,
+        ))
+        .unwrap(),
+    );
+    let packages = vec![maki_lua::DiscoveredPackage {
+        name: "late_pack".to_owned(),
+        dir: stale_dir.clone(),
+        eager: true,
+        requested: maki_lua::Requested::none(),
+        origin: maki_lua::Origin::Fetched {
+            src: "https://example.com/late".to_owned(),
+        },
+        revision_guard: Some(revision_guard),
+    }];
+    let config =
+        PluginsConfig::from_plugins_and_packages(Default::default(), &["late_pack".into()]);
+    let registry = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&registry)).unwrap();
+
+    assert!(host.load_packages(&packages, &config).is_empty());
+    drop(packages);
+    let manager = maki_pack::manager::Manager::new(site.path());
+    assert!(manager.prune(&lockfile).is_empty());
+    assert!(stale_dir.is_dir(), "a loaded revision must not be pruned");
+    assert_eq!(
+        exec_tool(&registry, "late_pack", serde_json::json!({})).unwrap(),
+        "late ok"
+    );
+
+    host.unload("late_pack").unwrap();
+    assert!(manager.prune(&lockfile).is_empty());
+    assert!(
+        !stale_dir.exists(),
+        "an unloaded stale revision can be pruned"
+    );
+}
+
 /// Builtins must still load when a package is installed. Packages once shared
 /// the builtin name list, which made `load_builtins` reject every one of them
 /// by name and fail startup outright.
@@ -3247,6 +3507,16 @@ fn discovered_config(found: &maki_lua::Discovery) -> (Vec<String>, PluginsConfig
     (names, config)
 }
 
+/// The whole startup order: load what starts eagerly, then apply whatever
+/// those loads recorded. `maki.packadd` only takes effect at the second step.
+fn activate_all(
+    host: &PluginHost,
+    found: &maki_lua::Discovery,
+    config: &PluginsConfig,
+) -> Vec<String> {
+    host.load_packages(&found.packages, config)
+}
+
 /// `maki.packadd` is the activation path for an `opt/` package. A `start`
 /// package that calls it must get the named package loaded in the same
 /// startup, not the next one, or its registrations never appear.
@@ -3265,10 +3535,8 @@ fn packadd_from_a_start_package_activates_an_opt_package() {
 
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    assert!(
-        host.load_packages(&found.packages, &config).is_empty(),
-        "both packages must load without a failure"
-    );
+    let failures = activate_all(&host, &found, &config);
+    assert!(failures.is_empty(), "got: {failures:?}");
 
     let snap = host.command_reader().load();
     assert_eq!(
@@ -3318,7 +3586,7 @@ fn packadd_reports_a_name_that_is_not_installed() {
 
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    let failures = host.load_packages(&found.packages, &config);
+    let failures = activate_all(&host, &found, &config);
     assert_eq!(failures.len(), 1, "got: {failures:?}");
     assert!(failures[0].contains("absent_pack"), "got: {failures:?}");
 }
@@ -3349,7 +3617,7 @@ fn packadd_cannot_activate_a_disabled_package() {
 
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    let failures = host.load_packages(&found.packages, &config);
+    let failures = activate_all(&host, &found, &config);
     assert_eq!(failures.len(), 1, "got: {failures:?}");
     assert_eq!(
         host.command_reader().load().commands.len(),

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -1097,6 +1097,127 @@ fn require_sandbox_escape_blocked() {
     );
 }
 
+/// Neovim resolves `lua/foo/init.lua` as well as `lua/foo.lua`, and an
+/// external package laid out the Neovim way relies on it.
+#[test]
+fn require_resolves_directory_init_form() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mod_dir = tmp.path().join("lua").join("pkg");
+    std::fs::create_dir_all(&mod_dir).unwrap();
+
+    std::fs::write(mod_dir.join("init.lua"), "return { value = 7 }\n").unwrap();
+
+    std::fs::write(
+        tmp.path().join("init.lua"),
+        r#"
+local pkg = require("pkg")
+assert(pkg.value == 7, "expected lua/pkg/init.lua to resolve")
+"#,
+    )
+    .unwrap();
+
+    let init_path = tmp.path().join("init.lua");
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_plugin_file(&init_path).unwrap();
+}
+
+/// `<mod>.lua` wins over `<mod>/init.lua`, matching Neovim's order.
+#[test]
+fn require_prefers_flat_module_over_directory_init() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let lua_dir = tmp.path().join("lua");
+    std::fs::create_dir_all(lua_dir.join("pkg")).unwrap();
+
+    std::fs::write(lua_dir.join("pkg.lua"), "return { which = \"flat\" }\n").unwrap();
+    std::fs::write(
+        lua_dir.join("pkg").join("init.lua"),
+        "return { which = \"dir\" }\n",
+    )
+    .unwrap();
+
+    std::fs::write(
+        tmp.path().join("init.lua"),
+        r#"
+local pkg = require("pkg")
+assert(pkg.which == "flat", "expected pkg.lua to win, got " .. tostring(pkg.which))
+"#,
+    )
+    .unwrap();
+
+    let init_path = tmp.path().join("init.lua");
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_plugin_file(&init_path).unwrap();
+}
+
+/// A git repository can commit a symlink, so the lexical `..` check is not
+/// enough on its own: the resolved path has to be re-checked.
+#[cfg(unix)]
+#[test]
+fn require_symlink_out_of_package_blocked() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let lua_dir = tmp.path().join("lua");
+    std::fs::create_dir_all(&lua_dir).unwrap();
+
+    let outside = tmp.path().join("outside.lua");
+    std::fs::write(&outside, "return { secret = true }\n").unwrap();
+    std::os::unix::fs::symlink(&outside, lua_dir.join("leak.lua")).unwrap();
+
+    std::fs::write(tmp.path().join("init.lua"), "require(\"leak\")\n").unwrap();
+
+    let init_path = tmp.path().join("init.lua");
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_plugin_file(&init_path)
+        .expect_err("symlink pointing out of the package must not load");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("sandbox") || msg.contains("outside"),
+        "got: {msg}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn global_init_can_require_a_symlinked_module() {
+    let config = tempfile::TempDir::new().unwrap();
+    let modules = config.path().join("lua");
+    std::fs::create_dir_all(&modules).unwrap();
+    let elsewhere = tempfile::TempDir::new().unwrap();
+    let target = elsewhere.path().join("shared.lua");
+    std::fs::write(&target, "return { value = 42 }\n").unwrap();
+    std::os::unix::fs::symlink(&target, modules.join("shared.lua")).unwrap();
+
+    let host = PluginHost::new(fresh_registry()).unwrap();
+    let _ = host
+        .send_run_init_lua(
+            "assert(require('shared').value == 42)".to_owned(),
+            "global/init.lua".to_owned(),
+            Some(config.path().to_path_buf()),
+        )
+        .unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn global_init_can_use_a_symlinked_lua_directory() {
+    let config = tempfile::TempDir::new().unwrap();
+    let elsewhere = tempfile::TempDir::new().unwrap();
+    std::fs::write(elsewhere.path().join("shared.lua"), "return true\n").unwrap();
+    std::os::unix::fs::symlink(elsewhere.path(), config.path().join("lua")).unwrap();
+
+    let host = PluginHost::new(fresh_registry()).unwrap();
+    let _ = host
+        .send_run_init_lua(
+            "assert(require('shared'))".to_owned(),
+            "global/init.lua".to_owned(),
+            Some(config.path().to_path_buf()),
+        )
+        .unwrap();
+}
+
 #[test]
 fn require_circular_returns_sentinel_and_caches_real_value() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -2449,6 +2570,7 @@ fn edit_sub_tools_follow_edit_opts(opts: serde_json::Value, on: &[&str], off: &[
     let config = PluginsConfig {
         enabled: true,
         names: vec!["edit".to_owned()],
+        packages: Vec::new(),
         opts: HashMap::from([("edit".to_owned(), json_obj(opts))]),
     };
     host.load_builtins(&config).unwrap();
@@ -2474,23 +2596,26 @@ fn undeclared_opts_fail_the_load() {
     assert!(err.to_string().contains(UNDECLARED_OPTS_ERR), "got: {err}");
 }
 
+/// A disabled package keeps its options in `opts` but leaves `packages`, which
+/// is exactly the shape `into_config` produces. Treating that as an unknown
+/// name stopped maki from booting over options it was already ignoring, and
+/// only for packages: a disabled builtin in the same state just warned.
 #[test]
-fn opts_for_unknown_plugin_fail_load_builtins() {
+fn opts_for_a_disabled_package_do_not_stop_the_load() {
     let reg = fresh_registry();
     let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    let mut config = PluginsConfig::from_plugins(HashMap::new());
-    config.opts.insert(
-        "bsah".to_owned(),
-        json_obj(serde_json::json!({ "timeout_secs": 5 })),
-    );
-    let err = host
-        .load_builtins(&config)
-        .expect_err("load_builtins should fail");
-    assert!(
-        err.to_string()
-            .contains("plugins.bsah sets options (timeout_secs)"),
-        "got: {err}"
-    );
+    let config = PluginsConfig {
+        enabled: true,
+        names: vec!["grep".to_owned()],
+        packages: Vec::new(),
+        opts: HashMap::from([(
+            "my_pack".to_owned(),
+            json_obj(serde_json::json!({ "timeout_secs": 5 })),
+        )]),
+    };
+    host.load_builtins(&config)
+        .expect("a disabled package must not stop the builtins from loading");
+    assert!(reg.get("grep").is_some(), "enabled plugin still loads");
 }
 
 #[test]
@@ -2515,6 +2640,7 @@ fn disabled_plugin_opts_are_ignored_not_rejected() {
     let config = PluginsConfig {
         enabled: true,
         names: vec!["grep".to_owned()],
+        packages: Vec::new(),
         opts: HashMap::from([(
             "bash".to_owned(),
             json_obj(serde_json::json!({ "timeout_secs": 180 })),
@@ -2729,6 +2855,582 @@ fn reload_replaces_commands() {
     let snap = host.command_reader().load();
     assert_eq!(snap.commands.len(), 1);
     assert_eq!(snap.commands[0].name.as_ref(), "/v2");
+}
+
+/// Builds a package directory with the given `plugin/*.lua` files.
+fn package_dir(files: &[(&str, &str)]) -> tempfile::TempDir {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let plugin_dir = tmp.path().join("plugin");
+    std::fs::create_dir_all(&plugin_dir).unwrap();
+    for (name, source) in files {
+        std::fs::write(plugin_dir.join(name), source).unwrap();
+    }
+    tmp
+}
+
+#[test]
+fn package_loads_every_entrypoint_under_one_owner() {
+    let pkg = package_dir(&[
+        (
+            "01_first.lua",
+            r#"maki.api.register_command({ name = "/one", handler = function() end })"#,
+        ),
+        (
+            "02_second.lua",
+            r#"maki.api.register_command({ name = "/two", handler = function() end })"#,
+        ),
+    ]);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_package(
+        "demo",
+        pkg.path(),
+        maki_lua::PluginPermissions::trusted(),
+        Default::default(),
+    )
+    .unwrap();
+
+    let snap = host.command_reader().load();
+    let mut names: Vec<&str> = snap.commands.iter().map(|c| c.name.as_ref()).collect();
+    names.sort();
+    assert_eq!(names, vec!["/one", "/two"]);
+    assert!(
+        snap.commands.iter().all(|c| c.plugin.as_ref() == "demo"),
+        "every entrypoint must register under the package owner"
+    );
+}
+
+/// One environment across the chunks, so an earlier file can set something up
+/// for a later one. This is why the chunks are not separate loads.
+#[test]
+fn package_entrypoints_share_one_environment() {
+    let pkg = package_dir(&[
+        ("01_first.lua", "shared_value = 11\n"),
+        (
+            "02_second.lua",
+            r#"
+assert(shared_value == 11, "second chunk should see the first chunk's global")
+maki.api.register_command({ name = "/ok", handler = function() end })
+"#,
+        ),
+    ]);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_package(
+        "shared",
+        pkg.path(),
+        maki_lua::PluginPermissions::trusted(),
+        Default::default(),
+    )
+    .unwrap();
+    assert_eq!(host.command_reader().load().commands.len(), 1);
+}
+
+/// A package commits or it does not. `drop_plugin_keys` alone would leave the
+/// keymap and the hint behind, so this is what proves the stronger unwind.
+#[test]
+fn package_failure_leaves_nothing_from_earlier_chunks() {
+    let pkg = package_dir(&[
+        (
+            "01_first.lua",
+            r#"
+maki.api.register_command({ name = "/ghost", handler = function() end })
+maki.keymap.set("n", "<C-g>", function() end, { desc = "ghost" })
+maki.api.register_tool({
+  name = "ghost_tool",
+  description = "should not survive",
+  schema = { type = "object", properties = {} },
+  handler = function() return "x" end,
+})
+"#,
+        ),
+        ("02_second.lua", r#"error("boom")"#),
+    ]);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_package(
+            "ghost",
+            pkg.path(),
+            maki_lua::PluginPermissions::trusted(),
+            Default::default(),
+        )
+        .expect_err("a failing chunk must fail the whole package");
+    assert!(err.to_string().contains("boom"), "got: {err}");
+
+    assert_eq!(
+        host.command_reader().load().commands.len(),
+        0,
+        "command from the first chunk survived a failed load"
+    );
+    assert_eq!(
+        host.keymap_reader().load().entries.len(),
+        0,
+        "keymap from the first chunk survived a failed load"
+    );
+    assert!(
+        !reg.has("ghost_tool"),
+        "tool from the first chunk survived a failed load"
+    );
+}
+
+#[test]
+fn package_failure_discards_its_packadd_requests() {
+    let site = site_with_two(
+        (
+            "broken_pack",
+            "maki.packadd('lazy_pack')\nerror('stop this package')",
+        ),
+        (
+            "lazy_pack",
+            r#"maki.api.register_command({ name = "/lazy", handler = function() end })"#,
+        ),
+    );
+    let found = maki_lua::discover(site.path());
+    let (_, config) = discovered_config(&found);
+
+    let host = PluginHost::new(fresh_registry()).unwrap();
+    let failures = host.load_packages(&found.packages, &config);
+
+    assert_eq!(failures.len(), 1, "got: {failures:?}");
+    assert!(
+        host.command_reader().load().commands.is_empty(),
+        "a failed package must not activate another package"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn package_entrypoint_symlink_escape_blocked() {
+    let pkg = package_dir(&[]);
+    // Deliberately in a different directory tree, so the link really leaves
+    // the package rather than pointing at a sibling inside it.
+    let elsewhere = tempfile::TempDir::new().unwrap();
+    let outside = elsewhere.path().join("outside.lua");
+    std::fs::write(&outside, "return {}\n").unwrap();
+    std::os::unix::fs::symlink(&outside, pkg.path().join("plugin").join("leak.lua")).unwrap();
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_package(
+            "leaky",
+            pkg.path(),
+            maki_lua::PluginPermissions::trusted(),
+            Default::default(),
+        )
+        .expect_err("an entrypoint linking out of the package must not load");
+    assert!(
+        matches!(err, PluginError::PackageEscape { .. }),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn package_without_entrypoints_errors() {
+    let pkg = package_dir(&[]);
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_package(
+            "empty",
+            pkg.path(),
+            maki_lua::PluginPermissions::trusted(),
+            Default::default(),
+        )
+        .expect_err("a package with no entrypoint is a configuration error");
+    assert!(
+        matches!(err, PluginError::PackageEmpty { .. }),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn unreadable_entrypoint_directory_is_reported() {
+    let pkg = tempfile::TempDir::new().unwrap();
+    std::fs::write(pkg.path().join("plugin"), "not a directory").unwrap();
+    let host = PluginHost::new(fresh_registry()).unwrap();
+
+    let err = host
+        .load_package(
+            "unreadable",
+            pkg.path(),
+            maki_lua::PluginPermissions::trusted(),
+            Default::default(),
+        )
+        .expect_err("an unreadable entrypoint directory must not look empty");
+
+    assert!(matches!(err, PluginError::Io { .. }), "got: {err}");
+}
+
+/// Builds a site tree holding one package, the way a user cloning a repository
+/// into the package directory would.
+fn site_with_package(sub: &str, name: &str, files: &[(&str, &str)]) -> tempfile::TempDir {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let dir = tmp.path().join("pack").join("vendor").join(sub).join(name);
+    std::fs::create_dir_all(dir.join("plugin")).unwrap();
+    for (file, source) in files {
+        std::fs::write(dir.join("plugin").join(file), source).unwrap();
+    }
+    tmp
+}
+
+/// The whole layer-1 path: find a package on disk, then load it.
+#[test]
+fn discovered_start_package_is_found_and_loaded() {
+    let site = site_with_package(
+        "start",
+        "demo_pack",
+        &[(
+            "init.lua",
+            r#"maki.api.register_command({ name = "/demo", handler = function() end })"#,
+        )],
+    );
+
+    let found = maki_lua::discover(site.path());
+    assert!(found.problems.is_empty(), "{:?}", found.problems);
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    let snap = host.command_reader().load();
+    assert_eq!(snap.commands.len(), 1);
+    assert_eq!(snap.commands[0].name.as_ref(), "/demo");
+    assert_eq!(snap.commands[0].plugin.as_ref(), "demo_pack");
+}
+
+/// Builtins must still load when a package is installed. Packages once shared
+/// the builtin name list, which made `load_builtins` reject every one of them
+/// by name and fail startup outright.
+#[test]
+fn installed_package_does_not_break_builtin_loading() {
+    let site = site_with_package(
+        "start",
+        "demo_pack",
+        &[(
+            "init.lua",
+            r#"maki.api.register_command({ name = "/demo", handler = function() end })"#,
+        )],
+    );
+
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+
+    let reg = fresh_registry();
+    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_builtins(&config)
+        .expect("an installed package must not stop the builtins from loading");
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    assert!(reg.has("grep"), "builtin tools should still be registered");
+    let names: Vec<String> = host
+        .command_reader()
+        .load()
+        .commands
+        .iter()
+        .map(|c| c.name.to_string())
+        .collect();
+    assert!(names.iter().any(|n| n == "/demo"), "got: {names:?}");
+}
+
+/// Options for an installed package must reach the package, not be rejected as
+/// options for a plugin that does not exist.
+#[test]
+fn installed_package_may_take_options() {
+    let site = site_with_package(
+        "start",
+        "opt_pack",
+        &[(
+            "init.lua",
+            r#"
+local opts = maki.api.register_options({
+  depth = { type = "integer", desc = "Depth." },
+})
+if opts.depth == 3 then
+  maki.api.register_command({ name = "/depth", handler = function() end })
+end
+"#,
+        )],
+    );
+    let found = maki_lua::discover(site.path());
+
+    let mut plugins: HashMap<String, maki_config::PluginFileConfig> = HashMap::new();
+    let mut cfg = maki_config::PluginFileConfig::default();
+    cfg.opts.insert("depth".to_owned(), serde_json::json!(3));
+    plugins.insert("opt_pack".to_owned(), cfg);
+
+    let config = PluginsConfig::from_plugins_and_packages(plugins, &["opt_pack".to_owned()]);
+
+    let reg = fresh_registry();
+    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_builtins(&config)
+        .expect("package options must not be rejected as unknown plugin options");
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    assert!(
+        host.command_reader()
+            .load()
+            .commands
+            .iter()
+            .any(|command| command.name.as_ref() == "/depth")
+    );
+}
+
+/// If `lua/` itself links out of the package, its target must not become the
+/// sandbox root; otherwise everything under that target would be requireable.
+#[cfg(unix)]
+#[test]
+fn symlinked_lua_directory_is_not_used_as_the_module_root() {
+    let pkg = package_dir(&[("init.lua", r#"require("escaped")"#)]);
+
+    let elsewhere = tempfile::TempDir::new().unwrap();
+    std::fs::write(elsewhere.path().join("escaped.lua"), "return {}\n").unwrap();
+    std::os::unix::fs::symlink(elsewhere.path(), pkg.path().join("lua")).unwrap();
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_package(
+            "linky",
+            pkg.path(),
+            maki_lua::PluginPermissions::trusted(),
+            Default::default(),
+        )
+        .expect_err("a lua/ directory pointing out of the package must not resolve modules");
+    assert!(err.to_string().contains("module not found"), "got: {err}");
+}
+
+/// An `opt/` package waits to be activated, so startup alone must not run it.
+#[test]
+fn discovered_opt_package_is_not_loaded_at_startup() {
+    let site = site_with_package(
+        "opt",
+        "lazy_pack",
+        &[(
+            "init.lua",
+            r#"maki.api.register_command({ name = "/lazy", handler = function() end })"#,
+        )],
+    );
+
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    assert_eq!(host.command_reader().load().commands.len(), 0);
+}
+
+/// Adds one `start` and one `opt` package to a site tree.
+fn site_with_two(start: (&str, &str), opt: (&str, &str)) -> tempfile::TempDir {
+    let tmp = tempfile::TempDir::new().unwrap();
+    for (sub, name, source) in [("start", start.0, start.1), ("opt", opt.0, opt.1)] {
+        let dir = tmp.path().join("pack").join("vendor").join(sub).join(name);
+        std::fs::create_dir_all(dir.join("plugin")).unwrap();
+        std::fs::write(dir.join("plugin").join("init.lua"), source).unwrap();
+    }
+    tmp
+}
+
+fn discovered_config(found: &maki_lua::Discovery) -> (Vec<String>, PluginsConfig) {
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+    (names, config)
+}
+
+/// `maki.packadd` is the activation path for an `opt/` package. A `start`
+/// package that calls it must get the named package loaded in the same
+/// startup, not the next one, or its registrations never appear.
+#[test]
+fn packadd_from_a_start_package_activates_an_opt_package() {
+    let site = site_with_two(
+        ("waker_pack", r#"maki.packadd("lazy_pack")"#),
+        (
+            "lazy_pack",
+            r#"maki.api.register_command({ name = "/lazy", handler = function() end })"#,
+        ),
+    );
+
+    let found = maki_lua::discover(site.path());
+    let (_, config) = discovered_config(&found);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    assert!(
+        host.load_packages(&found.packages, &config).is_empty(),
+        "both packages must load without a failure"
+    );
+
+    let snap = host.command_reader().load();
+    assert_eq!(
+        snap.commands.len(),
+        1,
+        "the activated package must have registered its command"
+    );
+    assert_eq!(snap.commands[0].name.as_ref(), "/lazy");
+}
+
+/// `maki.packadd` is on the maki table for every plugin, but only the startup
+/// drain reads what it records. A call after that drain would sit in the queue
+/// for the rest of the session with no error and no log, so it is refused.
+#[test]
+fn packadd_after_startup_reports_rather_than_queueing() {
+    let site = site_with_two(("waker_pack", ""), ("lazy_pack", ""));
+    let found = maki_lua::discover(site.path());
+    let (_, config) = discovered_config(&found);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    assert!(
+        host.load_packages(&found.packages, &config).is_empty(),
+        "the start package must load"
+    );
+
+    let err = host
+        .load_source("late_plugin", r#"maki.packadd("lazy_pack")"#)
+        .expect_err("packadd must report once the startup drain is over");
+    assert!(
+        err.to_string().contains("already been loaded"),
+        "got: {err}"
+    );
+}
+
+/// A name that matches no installed package is reported. Doing nothing would
+/// leave the user with a package that never loads and no reason why.
+#[test]
+fn packadd_reports_a_name_that_is_not_installed() {
+    let site = site_with_two(
+        ("waker_pack", r#"maki.packadd("absent_pack")"#),
+        ("lazy_pack", ""),
+    );
+
+    let found = maki_lua::discover(site.path());
+    let (_, config) = discovered_config(&found);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let failures = host.load_packages(&found.packages, &config);
+    assert_eq!(failures.len(), 1, "got: {failures:?}");
+    assert!(failures[0].contains("absent_pack"), "got: {failures:?}");
+}
+
+/// A package the config disabled stays disabled. `packadd` must not be a way
+/// around `plugins.<name>.enabled = false`.
+#[test]
+fn packadd_cannot_activate_a_disabled_package() {
+    let site = site_with_two(
+        ("waker_pack", r#"maki.packadd("lazy_pack")"#),
+        (
+            "lazy_pack",
+            r#"maki.api.register_command({ name = "/lazy", handler = function() end })"#,
+        ),
+    );
+
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let mut plugins: HashMap<String, maki_config::PluginFileConfig> = HashMap::new();
+    plugins.insert(
+        "lazy_pack".to_owned(),
+        maki_config::PluginFileConfig {
+            enabled: Some(false),
+            ..Default::default()
+        },
+    );
+    let config = PluginsConfig::from_plugins_and_packages(plugins, &names);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let failures = host.load_packages(&found.packages, &config);
+    assert_eq!(failures.len(), 1, "got: {failures:?}");
+    assert_eq!(
+        host.command_reader().load().commands.len(),
+        0,
+        "a disabled package must not register anything"
+    );
+}
+
+/// A package that asks for nothing gets nothing. Without a `plugin.toml` the
+/// guarded APIs must refuse, so a downloaded package cannot reach the network
+/// or the environment just by being installed.
+#[test]
+fn package_without_manifest_cannot_use_guarded_apis() {
+    let site = site_with_package(
+        "start",
+        "greedy_pack",
+        &[(
+            "init.lua",
+            r#"
+local ok = pcall(function() return maki.env.config_dir() end)
+maki.api.register_command({
+  name = ok and "/allowed" or "/denied",
+  handler = function() end,
+})
+"#,
+        )],
+    );
+
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    let snap = host.command_reader().load();
+    assert_eq!(snap.commands.len(), 1);
+    assert_eq!(
+        snap.commands[0].name.as_ref(),
+        "/denied",
+        "a package requesting nothing must not reach maki.env"
+    );
+}
+
+/// The manifest is what a manual install is granted, so a package that asks
+/// for `env` gets it without any further approval.
+#[test]
+fn manual_package_is_granted_what_its_manifest_requests() {
+    let site = site_with_package(
+        "start",
+        "asking_pack",
+        &[(
+            "init.lua",
+            r#"
+local ok = pcall(function() return maki.env.config_dir() end)
+maki.api.register_command({
+  name = ok and "/allowed" or "/denied",
+  handler = function() end,
+})
+"#,
+        )],
+    );
+    let pkg_dir = site
+        .path()
+        .join("pack")
+        .join("vendor")
+        .join("start")
+        .join("asking_pack");
+    std::fs::write(pkg_dir.join("plugin.toml"), "[permissions]\nenv = true\n").unwrap();
+
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    let snap = host.command_reader().load();
+    assert_eq!(snap.commands[0].name.as_ref(), "/allowed");
 }
 
 #[test]

--- a/maki-pack/Cargo.toml
+++ b/maki-pack/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "maki-pack"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+fs4 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+smol = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+test-case = { workspace = true }

--- a/maki-pack/src/approvals.rs
+++ b/maki-pack/src/approvals.rs
@@ -1,0 +1,162 @@
+//! Which permissions the user approved, for which package, from which source.
+//!
+//! Approvals live outside every checkout. A downloaded `plugin.toml` states
+//! what a package *wants*; this file states what it may have. The manifest is
+//! never authority over itself.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// An approval is bound to the source as well as the name.
+///
+/// Without the source in the key, deleting a package and adding an unrelated
+/// repository under the same name would silently inherit the old grants. A
+/// changed `src` is a new trust decision, so it must not match.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApprovalKey {
+    pub name: String,
+    pub src: String,
+}
+
+impl ApprovalKey {
+    pub fn new(name: impl Into<String>, src: &str) -> Self {
+        Self {
+            name: name.into(),
+            src: normalize_src(src),
+        }
+    }
+}
+
+/// Canonical form of a source, for keying an approval.
+///
+/// This deliberately does almost nothing. An earlier version folded a `.git`
+/// suffix, a trailing slash, and scheme and host case, on the theory that those
+/// name the same repository. They do not always: `/x/repo` and `/x/repo.git`
+/// can both exist as separate local repositories, and lowercasing an authority
+/// also lowercases any user information in an ssh URL. Every one of those
+/// collisions hands a different repository someone else's permission grants.
+///
+/// Being too strict only costs a second prompt when a user writes the same URL
+/// two ways. Being too loose grants access that was never approved, so this
+/// errs strict and trims whitespace alone.
+fn normalize_src(src: &str) -> String {
+    src.trim().to_owned()
+}
+
+/// The approval store, as written to disk.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Approvals {
+    #[serde(default)]
+    entries: BTreeMap<String, Entry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Entry {
+    src: String,
+    #[serde(default)]
+    permissions: Vec<String>,
+}
+
+impl Approvals {
+    /// Permissions approved for this exact package and source. A package whose
+    /// source changed has no approval, which is the point.
+    pub fn get(&self, key: &ApprovalKey) -> Option<&[String]> {
+        let entry = self.entries.get(&key.name)?;
+        (entry.src == key.src).then_some(entry.permissions.as_slice())
+    }
+
+    pub fn approve(&mut self, key: &ApprovalKey, permissions: Vec<String>) {
+        self.entries.insert(
+            key.name.clone(),
+            Entry {
+                src: key.src.clone(),
+                permissions,
+            },
+        );
+    }
+
+    /// Drops a package's approval, so reinstalling it asks again.
+    pub fn revoke(&mut self, name: &str) -> bool {
+        self.entries.remove(name).is_some()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    const SRC: &str = "https://github.com/user/repo";
+
+    fn approved(store: &Approvals, name: &str, src: &str) -> Option<Vec<String>> {
+        store
+            .get(&ApprovalKey::new(name, src))
+            .map(<[String]>::to_vec)
+    }
+
+    /// The defect this key shape exists to prevent: reusing a name must not
+    /// inherit the previous repository's grants.
+    #[test]
+    fn approval_does_not_carry_over_to_a_different_source() {
+        let mut store = Approvals::default();
+        store.approve(&ApprovalKey::new("pkg", SRC), vec!["run".to_owned()]);
+        assert_eq!(
+            approved(&store, "pkg", "https://github.com/attacker/repo"),
+            None,
+            "a different repository must not inherit the approval"
+        );
+    }
+
+    /// Only surrounding whitespace is ignored. Anything else is a different
+    /// source and must be approved again.
+    #[test]
+    fn whitespace_around_the_same_source_keeps_the_approval() {
+        let mut store = Approvals::default();
+        store.approve(&ApprovalKey::new("pkg", SRC), vec!["net".to_owned()]);
+        let padded = format!("  {SRC}\n");
+        assert!(approved(&store, "pkg", &padded).is_some());
+    }
+
+    /// These all look like harmless spellings, and an earlier version folded
+    /// them together. Each can name a genuinely different repository, and
+    /// folding them lets one inherit another's grants.
+    #[test_case("https://github.com/user/repo.git" ; "git_suffix_may_be_a_separate_repo")]
+    #[test_case("https://github.com/user/repo/" ; "trailing_slash")]
+    #[test_case("HTTPS://GitHub.com/user/repo" ; "authority_case")]
+    #[test_case("https://github.com/USER/repo" ; "path_case")]
+    #[test_case("ssh://User@github.com/user/repo" ; "ssh_user_case")]
+    fn a_differently_spelled_source_is_not_approved(variant: &str) {
+        let mut store = Approvals::default();
+        store.approve(&ApprovalKey::new("pkg", SRC), vec!["net".to_owned()]);
+        assert!(
+            approved(&store, "pkg", variant).is_none(),
+            "{variant} must be a fresh trust decision"
+        );
+    }
+
+    /// Two local repositories that really can both exist side by side.
+    #[test]
+    fn a_local_path_and_its_git_suffix_are_distinct() {
+        let mut store = Approvals::default();
+        store.approve(
+            &ApprovalKey::new("pkg", "/srv/repo"),
+            vec!["run".to_owned()],
+        );
+        assert!(approved(&store, "pkg", "/srv/repo.git").is_none());
+    }
+
+    #[test]
+    fn round_trips_through_json() {
+        let mut store = Approvals::default();
+        store.approve(&ApprovalKey::new("pkg", SRC), vec!["net".to_owned()]);
+
+        let text = serde_json::to_string(&store).unwrap();
+        let back: Approvals = serde_json::from_str(&text).unwrap();
+        assert_eq!(approved(&back, "pkg", SRC), Some(vec!["net".to_owned()]));
+    }
+}

--- a/maki-pack/src/git.rs
+++ b/maki-pack/src/git.rs
@@ -1,0 +1,327 @@
+//! Every git invocation maki makes.
+//!
+//! Commands are built by the functions here and run by one runner, so no call
+//! site can forget the hardening flags. Neovim shells out to `git` too, which
+//! keeps credential helpers, SSH agents, and proxy settings working without
+//! maki owning any of that.
+
+use std::path::{Path, PathBuf};
+
+/// Peels whatever a ref names down to a commit.
+const COMMIT_PEEL: &str = "^{commit}";
+
+/// Flags every invocation carries, whatever it is doing.
+///
+/// `core.hooksPath` points at a directory maki keeps empty, so a repository
+/// cannot run code during a clone, a fetch, or a checkout. Cloning does not
+/// import hooks from a remote, so this is defence in depth for the case that
+/// matters more: a checkout directory on this machine whose `.git/hooks`
+/// something else has written.
+pub fn hardening_args(empty_hooks_dir: &Path) -> Vec<String> {
+    vec![
+        "-c".to_owned(),
+        format!("core.hooksPath={}", empty_hooks_dir.display()),
+    ]
+}
+
+/// Clone arguments. `partial` asks the server for a blobless clone, which is
+/// much smaller; a server that refuses it makes the command fail, and the
+/// caller retries without it.
+/// `--` closes the option list, so a source beginning with `-` is treated as a
+/// repository rather than as a git option. There is no shell here, so this is
+/// argument injection, not command injection, but `--upload-pack=` alone is
+/// enough to run a program.
+pub fn clone_args(empty_hooks_dir: &Path, src: &str, dest: &Path, partial: bool) -> Vec<String> {
+    let mut args = hardening_args(empty_hooks_dir);
+    args.push("clone".to_owned());
+    if partial {
+        args.push("--filter=blob:none".to_owned());
+    }
+    args.push("--".to_owned());
+    args.push(src.to_owned());
+    args.push(dest.display().to_string());
+    args
+}
+
+/// Whether a revision can be passed to git as a positional argument.
+///
+/// `git rev-parse --not-a-flag` would be read as an option, and revisions come
+/// from a package specification, so they are checked rather than trusted.
+pub fn revision_is_safe(rev: &str) -> bool {
+    !rev.is_empty() && !rev.starts_with('-')
+}
+
+/// Whether an HTTP source embeds user information that Git would persist.
+///
+/// Tokens in clone URLs are commonly written as a username, a password, or
+/// both. Git records the URL in `.git/config`, and maki also records the source
+/// in its lockfile. Reject that form and let Git's credential helper provide
+/// credentials without putting them on disk as part of the repository URL.
+pub fn http_source_has_userinfo(src: &str) -> bool {
+    let Some((scheme, rest)) = src.trim().split_once("://") else {
+        return false;
+    };
+    if !scheme.eq_ignore_ascii_case("http") && !scheme.eq_ignore_ascii_case("https") {
+        return false;
+    }
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+    authority.contains('@')
+}
+
+pub fn checkout_args(empty_hooks_dir: &Path, rev: &str) -> Vec<String> {
+    let mut args = hardening_args(empty_hooks_dir);
+    args.extend(["checkout".to_owned(), "--detach".to_owned(), rev.to_owned()]);
+    args
+}
+
+/// Resolves a ref to a commit id. An annotated tag is an object of its own, so
+/// a bare `rev-parse` would record the tag's id in the lockfile rather than the
+/// commit that lockfile is supposed to reproduce.
+pub fn rev_parse_args(empty_hooks_dir: &Path, rev: &str) -> Vec<String> {
+    let mut args = hardening_args(empty_hooks_dir);
+    args.extend(["rev-parse".to_owned(), format!("{rev}{COMMIT_PEEL}")]);
+    args
+}
+
+/// Environment every invocation runs with. Disabling the terminal prompt makes
+/// a credential request fail immediately instead of hanging a startup on a
+/// prompt nobody is watching.
+pub fn hardening_env() -> [(&'static str, &'static str); 2] {
+    [("GIT_TERMINAL_PROMPT", "0"), ("GIT_ASKPASS", "")]
+}
+
+/// What one git invocation produced.
+#[derive(Debug, Clone)]
+pub struct GitOutput {
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GitError {
+    #[error("git is not installed or not on PATH")]
+    Missing,
+    #[error("git {args} failed with status {status}: {stderr}")]
+    Failed {
+        args: String,
+        status: String,
+        stderr: String,
+    },
+}
+
+/// Hides credentials embedded in a URL, so an error message can be shown or
+/// logged without leaking a token that was only ever meant for git.
+pub fn redact(text: &str) -> String {
+    text.split_inclusive(char::is_whitespace)
+        .map(|part| {
+            let word = part.trim_end_matches(char::is_whitespace);
+            let whitespace = &part[word.len()..];
+            let redacted = match word.split_once("://") {
+                Some((scheme, rest)) => match rest.rsplit_once('@') {
+                    Some((_creds, host)) => format!("{scheme}://***@{host}"),
+                    None => word.to_owned(),
+                },
+                None => word.to_owned(),
+            };
+            redacted + whitespace
+        })
+        .collect()
+}
+
+/// Runs git off the calling thread.
+///
+/// `maki.pack.add` runs while `init.lua` is being sourced, and `init.lua`
+/// executes on the single Lua thread inside an async call. A blocking
+/// `Command::output` there would stall the whole VM, the watchdog included, so
+/// every invocation goes through `smol::unblock` and the caller awaits it. On a
+/// first start a clone can take seconds, which is exactly when this matters.
+pub async fn run(args: Vec<String>, cwd: Option<PathBuf>) -> Result<GitOutput, GitError> {
+    let display = redact(&args.join(" "));
+    let output = smol::unblock(move || {
+        let mut cmd = std::process::Command::new("git");
+        cmd.args(&args);
+        if let Some(dir) = cwd {
+            cmd.current_dir(dir);
+        }
+        for (key, value) in hardening_env() {
+            cmd.env(key, value);
+        }
+        cmd.output()
+    })
+    .await;
+
+    let output = match output {
+        Ok(output) => output,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Err(GitError::Missing),
+        Err(e) => {
+            return Err(GitError::Failed {
+                args: display,
+                status: "not started".to_owned(),
+                stderr: e.to_string(),
+            });
+        }
+    };
+
+    if output.status.success() {
+        Ok(GitOutput {
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        })
+    } else {
+        Err(GitError::Failed {
+            args: display,
+            status: output.status.to_string(),
+            stderr: redact(String::from_utf8_lossy(&output.stderr).trim()),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use test_case::test_case;
+
+    fn hooks() -> PathBuf {
+        PathBuf::from("/data/site/.nohooks")
+    }
+
+    fn hooks_flag_present(args: &[String]) -> bool {
+        args.windows(2)
+            .any(|w| w[0] == "-c" && w[1].starts_with("core.hooksPath="))
+    }
+
+    #[test]
+    fn git_cannot_open_an_interactive_credential_prompt() {
+        assert_eq!(
+            hardening_env(),
+            [("GIT_TERMINAL_PROMPT", "0"), ("GIT_ASKPASS", "")]
+        );
+    }
+
+    /// The hardening is the point of routing every command through here, so
+    /// each builder is checked rather than only the shared helper.
+    #[test]
+    fn every_command_disables_hooks() {
+        assert!(hooks_flag_present(&clone_args(
+            &hooks(),
+            "src",
+            Path::new("/dest"),
+            true
+        )));
+        assert!(hooks_flag_present(&checkout_args(&hooks(), "main")));
+        assert!(hooks_flag_present(&rev_parse_args(&hooks(), "HEAD")));
+    }
+
+    /// The flags have to come before the subcommand, or git treats them as
+    /// arguments to it and the hardening silently does nothing.
+    #[test]
+    fn hardening_precedes_the_subcommand() {
+        let args = clone_args(&hooks(), "src", Path::new("/dest"), false);
+        let subcommand = args.iter().position(|a| a == "clone").unwrap();
+        let config = args.iter().position(|a| a == "-c").unwrap();
+        assert!(config < subcommand);
+    }
+
+    #[test]
+    fn partial_clone_is_opt_in_so_it_can_be_retried_without_it() {
+        let partial = clone_args(&hooks(), "src", Path::new("/dest"), true);
+        let full = clone_args(&hooks(), "src", Path::new("/dest"), false);
+        assert!(partial.iter().any(|a| a == "--filter=blob:none"));
+        assert!(!full.iter().any(|a| a == "--filter=blob:none"));
+    }
+
+    #[test]
+    fn checkout_detaches_so_no_branch_tracks_the_revision() {
+        let args = checkout_args(&hooks(), "abc123");
+        assert!(args.iter().any(|a| a == "--detach"));
+        assert_eq!(args.last().unwrap(), "abc123");
+    }
+
+    /// A source is a positional argument, so it must sit after `--`. Without
+    /// it, a src of `--upload-pack=...` is an option git will act on.
+    #[test]
+    fn clone_puts_the_source_after_an_option_terminator() {
+        let args = clone_args(&hooks(), "--upload-pack=evil", Path::new("/dest"), true);
+        let terminator = args.iter().position(|a| a == "--").expect("`--` required");
+        let src = args
+            .iter()
+            .position(|a| a == "--upload-pack=evil")
+            .expect("src present");
+        assert!(
+            terminator < src,
+            "a source that looks like an option must follow `--`: {args:?}"
+        );
+    }
+
+    /// A clone URL can carry a token. Errors are shown and logged, so the
+    /// credential must not travel with them.
+    #[test]
+    fn credentials_in_a_url_are_redacted() {
+        let out = redact("clone -- https://user:tok3n@github.com/u/r /dest");
+        assert!(!out.contains("tok3n"), "token leaked: {out}");
+        assert!(!out.contains("user:"), "user leaked: {out}");
+        assert!(out.contains("github.com/u/r"), "host should survive: {out}");
+        assert!(out.contains("/dest"));
+    }
+
+    #[test_case("https://token@example.com/repo", true ; "username_token")]
+    #[test_case("https://user:token@example.com/repo", true ; "password_token")]
+    #[test_case("HTTP://user@example.com/repo", true ; "scheme_case")]
+    #[test_case("https://example.com/user@repo", false ; "at_in_path")]
+    #[test_case("ssh://git@example.com/repo", false ; "ssh_username")]
+    #[test_case("git@example.com:user/repo", false ; "scp_style")]
+    fn detects_http_user_information(src: &str, expected: bool) {
+        assert_eq!(http_source_has_userinfo(src), expected);
+    }
+
+    #[test]
+    fn redaction_leaves_ordinary_urls_alone() {
+        let plain = "clone -- https://github.com/u/r /dest";
+        assert_eq!(redact(plain), plain);
+    }
+
+    #[test]
+    fn redaction_preserves_whitespace() {
+        let source = "/a path/with spaces\nand a second line";
+        assert_eq!(redact(source), source);
+    }
+
+    #[test]
+    fn revisions_that_look_like_options_are_rejected() {
+        assert!(revision_is_safe("main"));
+        assert!(revision_is_safe("v1.2.3"));
+        assert!(revision_is_safe("abc123"));
+        assert!(!revision_is_safe("--upload-pack=evil"));
+        assert!(!revision_is_safe("-x"));
+        assert!(!revision_is_safe(""));
+    }
+
+    /// A failure has to name the command, the status, and git's own message,
+    /// or a user cannot tell a network problem from a bad revision.
+    #[test]
+    fn failure_reports_command_status_and_stderr() {
+        let err = GitError::Failed {
+            args: "clone x y".to_owned(),
+            status: "exit status: 128".to_owned(),
+            stderr: "repository not found".to_owned(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("clone x y"));
+        assert!(msg.contains("128"));
+        assert!(msg.contains("repository not found"));
+    }
+
+    #[test]
+    fn a_failing_command_reports_rather_than_panicking() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let hooks = dir.path().join("nohooks");
+        std::fs::create_dir_all(&hooks).unwrap();
+
+        let result = smol::block_on(run(
+            rev_parse_args(&hooks, "definitely-not-a-ref"),
+            Some(dir.path().to_path_buf()),
+        ));
+        assert!(result.is_err(), "an unknown revision must be an error");
+    }
+}

--- a/maki-pack/src/lib.rs
+++ b/maki-pack/src/lib.rs
@@ -1,0 +1,16 @@
+//! Durable state for packages maki installs itself.
+//!
+//! This crate owns what is installed, at which commit, from which source, and
+//! what the user approved. It deliberately knows nothing about Lua: the runtime
+//! owns which packages a session has loaded, and the two never hold a second
+//! opinion about each other's facts.
+
+pub mod approvals;
+pub mod git;
+pub mod lock;
+pub mod lockfile;
+pub mod manager;
+pub mod paths;
+mod spec;
+
+pub use spec::{Spec, derive_name, name_is_safe};

--- a/maki-pack/src/lock.rs
+++ b/maki-pack/src/lock.rs
@@ -1,0 +1,149 @@
+//! Advisory locks between maki processes.
+//!
+//! Several maki processes share one checkout directory, one lockfile, and one
+//! approval store. Without a lock, two starting at the same moment would race
+//! the same clone, and two writing the lockfile would lose one another's
+//! entries.
+//!
+//! The kernel owns the lock and releases it when the process dies. Holding it
+//! across a whole read-modify-write is what makes concurrent updates to
+//! different packages compose: atomic rename alone gives durability, not
+//! isolation.
+
+use std::fs::{self, File, OpenOptions};
+use std::path::{Path, PathBuf};
+
+use fs4::{FileExt, TryLockError};
+
+/// Held for as long as the operation runs. Dropping it releases the lock.
+#[derive(Debug)]
+pub struct Lock {
+    _file: File,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LockError {
+    #[error("{path} is locked by another Maki process")]
+    Held { path: PathBuf },
+    #[error("cannot lock {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+impl Lock {
+    /// Takes the lock without waiting.
+    ///
+    /// This never waits. A caller that cannot proceed tells the user which
+    /// operation is in the way, which is more useful than a startup that hangs
+    /// on a lock nobody is watching.
+    pub fn acquire(path: &Path) -> Result<Self, LockError> {
+        Self::open_and_lock(path, FileExt::try_lock)
+    }
+
+    pub fn acquire_shared(path: &Path) -> Result<Self, LockError> {
+        Self::open_and_lock(path, FileExt::try_lock_shared)
+    }
+
+    fn open_and_lock(
+        path: &Path,
+        lock: fn(&File) -> Result<(), TryLockError>,
+    ) -> Result<Self, LockError> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|source| LockError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        }
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)
+            .map_err(|source| LockError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        match lock(&file) {
+            Ok(()) => Ok(Self { _file: file }),
+            Err(TryLockError::WouldBlock) => Err(LockError::Held {
+                path: path.to_path_buf(),
+            }),
+            Err(TryLockError::Error(source)) => Err(LockError::Io {
+                path: path.to_path_buf(),
+                source,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lock_path(dir: &tempfile::TempDir) -> PathBuf {
+        dir.path().join("pack.lock")
+    }
+
+    #[test]
+    fn a_second_acquire_reports_the_holder_instead_of_waiting() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = lock_path(&dir);
+
+        let _held = Lock::acquire(&path).unwrap();
+        let err = Lock::acquire(&path).expect_err("a held lock must not be taken twice");
+        assert!(matches!(err, LockError::Held { .. }), "got: {err}");
+    }
+
+    #[test]
+    fn releasing_lets_the_next_caller_take_it() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = lock_path(&dir);
+
+        drop(Lock::acquire(&path).unwrap());
+        Lock::acquire(&path).expect("a released lock should be free");
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn shared_holders_block_exclusive_cleanup() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = lock_path(&dir);
+
+        let _first = Lock::acquire_shared(&path).unwrap();
+        let _second = Lock::acquire_shared(&path).unwrap();
+        assert!(matches!(Lock::acquire(&path), Err(LockError::Held { .. })));
+    }
+
+    #[test]
+    fn exclusive_cleanup_blocks_a_new_shared_reader() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = lock_path(&dir);
+
+        let _exclusive = Lock::acquire(&path).unwrap();
+        assert!(matches!(
+            Lock::acquire_shared(&path),
+            Err(LockError::Held { .. })
+        ));
+    }
+
+    #[test]
+    fn an_existing_unlocked_file_can_be_locked() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = lock_path(&dir);
+
+        fs::write(&path, "left by an earlier process").unwrap();
+        Lock::acquire(&path).expect("file existence does not mean the lock is held");
+    }
+
+    #[test]
+    fn missing_parent_directory_is_created() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("nested").join("deep").join("pack.lock");
+        let _lock = Lock::acquire(&path).expect("the lock directory should be created");
+        assert!(path.exists());
+    }
+}

--- a/maki-pack/src/lockfile.rs
+++ b/maki-pack/src/lockfile.rs
@@ -1,0 +1,115 @@
+//! The exact commit of every managed package.
+//!
+//! Committing this file and running an install reproduces a package set on
+//! another machine, which is the whole reason it records commits rather than
+//! the `version` that produced them.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// One recorded package. The source is stored alongside the revision so a
+/// lockfile entry describes where its commit came from, not just what it was.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockEntry {
+    pub src: String,
+    pub rev: String,
+}
+
+/// A `BTreeMap` rather than a hash map, so the file serializes in a stable
+/// order and committing it does not produce noisy diffs.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Lockfile {
+    #[serde(default)]
+    packages: BTreeMap<String, LockEntry>,
+}
+
+impl Lockfile {
+    pub fn get(&self, name: &str) -> Option<&LockEntry> {
+        self.packages.get(name)
+    }
+
+    /// Records a package at a revision. Called only after the change on disk
+    /// succeeded, so a failed fetch never moves a recorded revision.
+    pub fn record(
+        &mut self,
+        name: impl Into<String>,
+        src: impl Into<String>,
+        rev: impl Into<String>,
+    ) {
+        self.packages.insert(
+            name.into(),
+            LockEntry {
+                src: src.into(),
+                rev: rev.into(),
+            },
+        );
+    }
+
+    /// Every recorded name, alphabetically. Pruning and `pack.get` walk the
+    /// lockfile this way, so neither depends on insertion order.
+    pub fn install_order(&self) -> impl Iterator<Item = &str> {
+        self.packages.keys().map(String::as_str)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.packages.is_empty()
+    }
+
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+
+    pub fn from_json(text: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn filled() -> Lockfile {
+        let mut lock = Lockfile::default();
+        lock.record("zebra", "https://x/zebra", "ccc");
+        lock.record("alpha", "https://x/alpha", "aaa");
+        lock.record("mid", "https://x/mid", "bbb");
+        lock
+    }
+
+    /// Alphabetical, so what a walk of the lockfile reports is the same on
+    /// every machine that shares it.
+    #[test]
+    fn install_order_is_alphabetical_not_insertion_order() {
+        assert_eq!(
+            filled().install_order().collect::<Vec<_>>(),
+            ["alpha", "mid", "zebra"]
+        );
+    }
+
+    #[test]
+    fn round_trips_through_json() {
+        let lock = filled();
+        let back = Lockfile::from_json(&lock.to_json().unwrap()).unwrap();
+        assert_eq!(back, lock);
+    }
+
+    /// The file is meant to be committed, so the same content must serialize
+    /// identically however it was built.
+    #[test]
+    fn serialization_is_stable_regardless_of_insertion_order() {
+        let mut other = Lockfile::default();
+        other.record("alpha", "https://x/alpha", "aaa");
+        other.record("mid", "https://x/mid", "bbb");
+        other.record("zebra", "https://x/zebra", "ccc");
+        assert_eq!(other.to_json().unwrap(), filled().to_json().unwrap());
+    }
+
+    #[test]
+    fn missing_packages_key_reads_as_empty() {
+        assert_eq!(
+            Lockfile::from_json("{}").unwrap().install_order().count(),
+            0
+        );
+    }
+}

--- a/maki-pack/src/manager.rs
+++ b/maki-pack/src/manager.rs
@@ -1,0 +1,1020 @@
+//! Installing and pruning managed packages.
+//!
+//! The lockfile is the single source of truth for which revision of a package
+//! is active. Nothing else records it, so nothing else can disagree with it,
+//! and a package resolves straight to `core/<name>/<sha>` without the tree
+//! having to be searched.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::git::{self, GitError};
+use crate::lock::{Lock, LockError};
+use crate::lockfile::Lockfile;
+use crate::paths;
+use crate::spec::Spec;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ManagerError {
+    #[error(transparent)]
+    Git(#[from] GitError),
+    #[error(transparent)]
+    Lock(#[from] LockError),
+    #[error("package name {name:?} (from {src:?}) is not a usable directory name")]
+    UnsafeName { name: String, src: String },
+    #[error("revision {rev:?} would be read by git as an option")]
+    UnsafeRevision { rev: String },
+    #[error(
+        "package source {src:?} contains HTTP credentials; use a Git credential helper instead"
+    )]
+    UnsafeSource { src: String },
+    #[error("io error on {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// A package that is on disk and ready to load.
+#[derive(Debug, Clone)]
+pub struct Installed {
+    pub rev: String,
+    /// Absolute path of the revision directory this session should load.
+    pub dir: PathBuf,
+    /// True when this call installed or moved the package.
+    pub changed: bool,
+}
+
+/// Where a clone keeps the refs that `git fetch` actually moves.
+const REMOTE_PREFIX: &str = "refs/remotes/origin/";
+/// What the default branch resolves against. See `resolve_revision`.
+const REMOTE_HEAD: &str = "refs/remotes/origin/HEAD";
+
+pub struct Manager {
+    site: PathBuf,
+}
+
+impl Manager {
+    pub fn new(site: impl Into<PathBuf>) -> Self {
+        Self { site: site.into() }
+    }
+
+    /// Where a package's revision lives, without touching the network.
+    ///
+    /// Startup uses this: a package already recorded in the lockfile resolves
+    /// to a directory with no git call at all, which is what keeps a steady
+    /// state start offline.
+    pub fn resolve(&self, lock: &Lockfile, name: &str) -> Option<PathBuf> {
+        // The lockfile is a file on disk that a user edits and commits, so its
+        // contents are input, not fact. Both halves become path components, and
+        // an absolute or traversing value would point this outside the site
+        // directory entirely.
+        if !crate::spec::name_is_safe(name) {
+            return None;
+        }
+        let entry = lock.get(name)?;
+        if !revision_is_safe_component(&entry.rev) {
+            return None;
+        }
+        let dir = paths::revision_dir(&self.site, name, &entry.rev);
+        dir.is_dir().then_some(dir)
+    }
+
+    /// Deletes stale immutable revisions that no running process is reading.
+    pub fn prune(&self, lock: &Lockfile) -> Vec<ManagerError> {
+        let mut failures = Vec::new();
+        for name in lock.install_order() {
+            if !crate::spec::name_is_safe(name) {
+                continue;
+            }
+            let Some(current) = lock.get(name).map(|entry| entry.rev.as_str()) else {
+                continue;
+            };
+            if !revision_is_prunable(current) {
+                continue;
+            }
+            let root = paths::package_root(&self.site, name);
+            let entries = match fs::read_dir(&root) {
+                Ok(entries) => entries,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(source) => {
+                    failures.push(ManagerError::Io { path: root, source });
+                    continue;
+                }
+            };
+            for entry in entries {
+                let entry = match entry {
+                    Ok(entry) => entry,
+                    Err(source) => {
+                        failures.push(ManagerError::Io {
+                            path: root.clone(),
+                            source,
+                        });
+                        continue;
+                    }
+                };
+                let revision = entry.file_name().to_string_lossy().into_owned();
+                let file_type = match entry.file_type() {
+                    Ok(file_type) => file_type,
+                    Err(source) => {
+                        failures.push(ManagerError::Io {
+                            path: entry.path(),
+                            source,
+                        });
+                        continue;
+                    }
+                };
+                if !file_type.is_dir() || revision == current || !revision_is_prunable(&revision) {
+                    continue;
+                }
+                let guard = match Lock::acquire(&paths::revision_lock(&self.site, name, &revision))
+                {
+                    Ok(guard) => guard,
+                    Err(LockError::Held { .. }) => {
+                        tracing::debug!(package = name, %revision, "stale package revision is in use");
+                        continue;
+                    }
+                    Err(error) => {
+                        failures.push(error.into());
+                        continue;
+                    }
+                };
+                if let Err(source) = fs::remove_dir_all(entry.path()) {
+                    failures.push(ManagerError::Io {
+                        path: entry.path(),
+                        source,
+                    });
+                }
+                drop(guard);
+            }
+        }
+        failures
+    }
+
+    /// Makes sure a package is on disk, cloning and checking out if needed.
+    ///
+    /// When the lockfile already records a revision, that revision is used and
+    /// `version` is not consulted. That is what makes a committed lockfile
+    /// reproduce a package set rather than re-resolving to something newer.
+    pub async fn ensure_installed(
+        &self,
+        spec: &Spec,
+        lock: &mut Lockfile,
+    ) -> Result<Installed, ManagerError> {
+        if git::http_source_has_userinfo(&spec.src) {
+            return Err(ManagerError::UnsafeSource {
+                src: git::redact(&spec.src),
+            });
+        }
+        self.check_name(&spec.name, &spec.src)?;
+
+        // The recorded source must match before an installed directory counts.
+        // Pointing a name at a different repository has to fetch that
+        // repository, not keep serving whatever was installed under the name.
+        let source_matches = lock
+            .get(&spec.name)
+            .is_some_and(|entry| entry.src == spec.src);
+
+        if source_matches && let Some(dir) = self.resolve(lock, &spec.name) {
+            let rev = lock
+                .get(&spec.name)
+                .expect("resolved from this entry")
+                .rev
+                .clone();
+            return Ok(Installed {
+                rev,
+                dir,
+                changed: false,
+            });
+        }
+
+        let _guard = Lock::acquire(&paths::package_lock(&self.site, &spec.name))?;
+        let hooks = self.hooks_dir()?;
+        let work = self.work_dir(&spec.name);
+
+        // A cached working copy is only reusable if it is a copy of the source
+        // being asked for. Reusing one by name alone would materialize the old
+        // repository's code while recording the new source.
+        if work.join(".git").is_dir() && !self.work_matches_source(&work, &spec.src).await {
+            fs::remove_dir_all(&work).map_err(|source| ManagerError::Io {
+                path: work.clone(),
+                source,
+            })?;
+        }
+        if !work.join(".git").is_dir() {
+            self.clone_into(&hooks, &spec.src, &work).await?;
+        }
+
+        // A recorded revision wins over `version`, even when nothing is on disk
+        // yet. That is the case a lockfile exists for: a fresh machine must get
+        // the commit that was committed, not whatever `version` resolves to
+        // today. Only a matching source counts, since a changed source makes
+        // the old revision meaningless.
+        let recorded = lock
+            .get(&spec.name)
+            .filter(|entry| entry.src == spec.src)
+            .map(|entry| {
+                if revision_is_safe_component(&entry.rev) {
+                    Ok(entry.rev.clone())
+                } else {
+                    Err(ManagerError::UnsafeRevision {
+                        rev: entry.rev.clone(),
+                    })
+                }
+            })
+            .transpose()?;
+
+        let rev = match recorded {
+            Some(rev) => rev,
+            None => self.resolve_revision(&hooks, &work, spec).await?,
+        };
+        let dest = paths::revision_dir(&self.site, &spec.name, &rev);
+        if !dest.is_dir() {
+            self.materialize(&hooks, &work, &rev, &dest).await?;
+        }
+
+        lock.record(&spec.name, &spec.src, &rev);
+        Ok(Installed {
+            rev,
+            dir: dest,
+            changed: true,
+        })
+    }
+
+    /// Rejects a name that would not stay inside the package root.
+    ///
+    /// Every path this type builds is `<site>/pack/core/<name>/...`, and an
+    /// absolute or traversing name escapes that entirely, so this is checked
+    /// before any directory is created or removed.
+    fn check_name(&self, name: &str, src: &str) -> Result<(), ManagerError> {
+        if crate::spec::name_is_safe(name) {
+            Ok(())
+        } else {
+            Err(ManagerError::UnsafeName {
+                name: name.to_owned(),
+                src: git::redact(src),
+            })
+        }
+    }
+
+    /// Whether a cached working copy points at the source being asked for.
+    ///
+    /// A copy whose remote cannot be read is treated as not matching, so the
+    /// safe outcome is a fresh clone rather than code from an unknown origin.
+    async fn work_matches_source(&self, work: &Path, src: &str) -> bool {
+        let args = vec![
+            "remote".to_owned(),
+            "get-url".to_owned(),
+            "origin".to_owned(),
+        ];
+        match git::run(args, Some(work.to_path_buf())).await {
+            Ok(out) => out.stdout.trim() == src.trim(),
+            Err(_) => false,
+        }
+    }
+
+    /// The bare working copy git operates on. Revisions are copied out of it,
+    /// so no session ever reads a directory git is mutating.
+    fn work_dir(&self, name: &str) -> PathBuf {
+        paths::package_root(&self.site, name).join(".work")
+    }
+
+    fn hooks_dir(&self) -> Result<PathBuf, ManagerError> {
+        let dir = paths::empty_hooks_dir(&self.site);
+        fs::create_dir_all(&dir).map_err(|source| ManagerError::Io {
+            path: dir.clone(),
+            source,
+        })?;
+        Ok(dir)
+    }
+
+    async fn clone_into(&self, hooks: &Path, src: &str, work: &Path) -> Result<(), ManagerError> {
+        if let Some(parent) = work.parent() {
+            fs::create_dir_all(parent).map_err(|source| ManagerError::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        // A blobless clone is much smaller, but an older server refuses the
+        // filter outright, so fall back to a full clone rather than failing.
+        match git::run(git::clone_args(hooks, src, work, true), None).await {
+            Ok(_) => Ok(()),
+            Err(_) => {
+                let _ = fs::remove_dir_all(work);
+                git::run(git::clone_args(hooks, src, work, false), None).await?;
+                Ok(())
+            }
+        }
+    }
+
+    async fn resolve_revision(
+        &self,
+        hooks: &Path,
+        work: &Path,
+        spec: &Spec,
+    ) -> Result<String, ManagerError> {
+        // Tried in order, first one that resolves wins.
+        //
+        // A branch name has the same problem the default branch has: `git
+        // fetch` moves `refs/remotes/origin/<branch>` and leaves the local
+        // branch where it was, so `version = "main"` would pin the commit that
+        // was current at clone time for ever. A tag or a commit is not a
+        // remote-tracking ref, and falls through to the literal name.
+        let candidates: Vec<String> = match spec.version.as_deref() {
+            // A clone with no `origin/HEAD` is unusual but legal, and then the
+            // local head is the only answer there is.
+            None => vec![REMOTE_HEAD.to_owned(), "HEAD".to_owned()],
+            Some(revision) => remote_branch_ref(revision)
+                .into_iter()
+                .chain(std::iter::once(revision.to_owned()))
+                .collect(),
+        };
+
+        let mut last = None;
+        for candidate in &candidates {
+            if !git::revision_is_safe(candidate) {
+                return Err(ManagerError::UnsafeRevision {
+                    rev: candidate.clone(),
+                });
+            }
+            match git::run(
+                git::rev_parse_args(hooks, candidate),
+                Some(work.to_path_buf()),
+            )
+            .await
+            {
+                Ok(out) => return Ok(out.stdout.trim().to_owned()),
+                Err(e) => last = Some(e),
+            }
+        }
+        Err(last.expect("at least one candidate is always tried").into())
+    }
+
+    /// Builds the revision directory. It is written under a temporary name and
+    /// renamed, so a session never sees a half-populated revision.
+    async fn materialize(
+        &self,
+        hooks: &Path,
+        work: &Path,
+        rev: &str,
+        dest: &Path,
+    ) -> Result<(), ManagerError> {
+        git::run(git::checkout_args(hooks, rev), Some(work.to_path_buf())).await?;
+
+        let staging = dest.with_extension("incoming");
+        let _ = fs::remove_dir_all(&staging);
+        copy_tree(work, &staging).map_err(|source| ManagerError::Io {
+            path: staging.clone(),
+            source,
+        })?;
+        fs::rename(&staging, dest).map_err(|source| ManagerError::Io {
+            path: dest.to_path_buf(),
+            source,
+        })?;
+        Ok(())
+    }
+}
+
+fn remote_branch_ref(rev: &str) -> Option<String> {
+    if let Some(name) = rev.strip_prefix("refs/heads/") {
+        return Some(format!("{REMOTE_PREFIX}{name}"));
+    }
+    (!rev.starts_with("refs/") && rev != "HEAD").then(|| format!("{REMOTE_PREFIX}{rev}"))
+}
+
+/// A revision directory name. Revisions are recorded from `git rev-parse`, so a
+/// real one is a hex object id; anything else came from a hand-edited lockfile.
+fn revision_is_safe_component(rev: &str) -> bool {
+    matches!(rev.len(), 40 | 64) && rev.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn revision_is_prunable(rev: &str) -> bool {
+    revision_is_safe_component(rev)
+}
+
+/// Copies a checkout without its `.git` directory, so a revision holds only the
+/// package's files and nothing that git would later mutate.
+fn copy_tree(from: &Path, to: &Path) -> std::io::Result<()> {
+    let root = from.canonicalize()?;
+    copy_tree_with_root(from, to, &root)
+}
+
+fn copy_tree_with_root(from: &Path, to: &Path, root: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        if name == ".git" {
+            continue;
+        }
+        let src = entry.path();
+        let dst = to.join(&name);
+        let meta = fs::symlink_metadata(&src)?;
+        if meta.file_type().is_symlink() {
+            let target = fs::read_link(&src)?;
+            let Some(parent) = src.parent() else {
+                continue;
+            };
+            let Ok(resolved) = parent.join(&target).canonicalize() else {
+                continue;
+            };
+            if target.is_absolute() || !resolved.starts_with(root) {
+                // Dropped, not followed: a link out of the checkout would make
+                // the package read or shadow a file the user never installed.
+                // Reported, because a package silently missing a file is far
+                // harder to diagnose than one that says what it left behind.
+                tracing::warn!(
+                    link = %src.display(),
+                    target = %target.display(),
+                    "package symlink leaves the package; it was not copied"
+                );
+                continue;
+            }
+            copy_symlink(&target, &dst, resolved.is_dir())?;
+            continue;
+        }
+        if meta.is_dir() {
+            copy_tree_with_root(&src, &dst, root)?;
+        } else {
+            fs::copy(&src, &dst)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn copy_symlink(target: &Path, dest: &Path, _is_dir: bool) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, dest)
+}
+
+#[cfg(windows)]
+fn copy_symlink(target: &Path, dest: &Path, is_dir: bool) -> std::io::Result<()> {
+    if is_dir {
+        std::os::windows::fs::symlink_dir(target, dest)
+    } else {
+        std::os::windows::fs::symlink_file(target, dest)
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn copy_symlink(_target: &Path, _dest: &Path, _is_dir: bool) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "copying symbolic links is unsupported",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    const TEST_REV: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const OTHER_REV: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    fn site() -> tempfile::TempDir {
+        tempfile::TempDir::new().unwrap()
+    }
+
+    #[test]
+    fn unnamed_source_is_rejected_rather_than_guessed() {
+        let dir = site();
+        let mgr = Manager::new(dir.path());
+        let spec = Spec::new("").with_name("");
+        let mut lock = Lockfile::default();
+
+        let err = smol::block_on(mgr.ensure_installed(&spec, &mut lock))
+            .expect_err("a package with no name cannot be installed");
+        assert!(matches!(err, ManagerError::UnsafeName { .. }), "got: {err}");
+    }
+
+    #[test]
+    fn http_credentials_are_rejected_before_clone() {
+        let dir = site();
+        let mgr = Manager::new(dir.path());
+        let spec = Spec::new("https://user:secret@example.com/repo");
+        let mut lock = Lockfile::default();
+
+        let error = smol::block_on(mgr.ensure_installed(&spec, &mut lock))
+            .expect_err("credentials must not reach Git or the lockfile");
+
+        assert!(matches!(error, ManagerError::UnsafeSource { .. }));
+        assert!(
+            !error.to_string().contains("secret"),
+            "credential leaked: {error}"
+        );
+        assert!(lock.get(&spec.name).is_none());
+    }
+
+    /// Every path is built as `<site>/pack/core/<name>/...`, and `Path::join`
+    /// replaces the base when the name is absolute, so an unchecked name puts
+    /// `remove_dir_all` anywhere on the filesystem.
+    #[test_case("/etc" ; "absolute")]
+    #[test_case("../../etc" ; "traversal")]
+    #[test_case(".." ; "parent")]
+    #[test_case("a/b" ; "separator")]
+    #[test_case(".hidden" ; "leading_dot_collides_with_work_dir")]
+    #[test_case("" ; "empty")]
+    fn unsafe_package_names_are_refused(name: &str) {
+        let dir = site();
+        let mgr = Manager::new(dir.path());
+        let mut lock = Lockfile::default();
+        let spec = Spec::new("https://x/demo").with_name(name);
+
+        assert!(
+            matches!(
+                smol::block_on(mgr.ensure_installed(&spec, &mut lock)),
+                Err(ManagerError::UnsafeName { .. })
+            ),
+            "{name:?} must not become a package directory"
+        );
+    }
+
+    /// The name check has to run before anything is created or deleted, so a
+    /// refused name leaves no trace outside the site directory.
+    #[test]
+    fn a_refused_name_creates_nothing() {
+        let dir = site();
+        let outside = dir.path().join("outside");
+        fs::create_dir_all(&outside).unwrap();
+
+        let site_dir = dir.path().join("site");
+        let mgr = Manager::new(&site_dir);
+        let mut lock = Lockfile::default();
+        let spec = Spec::new("https://x/demo").with_name("../outside");
+
+        let _ = smol::block_on(mgr.ensure_installed(&spec, &mut lock));
+        assert!(outside.is_dir(), "a refused name must not touch anything");
+    }
+
+    #[test]
+    fn a_revision_that_looks_like_an_option_is_refused() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), None);
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(origin.display().to_string())
+            .with_name("demo")
+            .with_version("--upload-pack=evil");
+
+        let err = smol::block_on(mgr.ensure_installed(&spec, &mut lock))
+            .expect_err("a revision starting with a dash must not reach git");
+        assert!(
+            matches!(err, ManagerError::UnsafeRevision { .. }),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn an_invalid_recorded_revision_is_not_re_resolved() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), None);
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let src = origin.display().to_string();
+        lock.record("demo", &src, "../invalid");
+        let spec = Spec::new(src).with_name("demo");
+
+        let err = smol::block_on(mgr.ensure_installed(&spec, &mut lock))
+            .expect_err("an invalid lock revision must not resolve a replacement");
+
+        assert!(matches!(err, ManagerError::UnsafeRevision { .. }));
+        assert_eq!(lock.get("demo").unwrap().rev, "../invalid");
+    }
+
+    /// A recorded revision that exists on disk resolves with no git call, which
+    /// is what keeps a steady state start offline.
+    #[test]
+    fn resolve_finds_a_recorded_revision_without_touching_git() {
+        let dir = site();
+        let mgr = Manager::new(dir.path());
+        let mut lock = Lockfile::default();
+        lock.record("demo", "https://x/demo", TEST_REV);
+
+        assert!(mgr.resolve(&lock, "demo").is_none(), "not on disk yet");
+
+        fs::create_dir_all(paths::revision_dir(dir.path(), "demo", TEST_REV)).unwrap();
+        assert_eq!(
+            mgr.resolve(&lock, "demo").unwrap(),
+            paths::revision_dir(dir.path(), "demo", TEST_REV)
+        );
+    }
+
+    #[test]
+    fn an_already_installed_package_reports_no_change() {
+        let dir = site();
+        let mgr = Manager::new(dir.path());
+        let mut lock = Lockfile::default();
+        lock.record("demo", "https://x/demo", TEST_REV);
+        fs::create_dir_all(paths::revision_dir(dir.path(), "demo", TEST_REV)).unwrap();
+
+        let spec = Spec::new("https://x/demo").with_name("demo");
+        let installed = smol::block_on(mgr.ensure_installed(&spec, &mut lock)).unwrap();
+        assert!(!installed.changed);
+        assert_eq!(installed.rev, TEST_REV);
+    }
+
+    /// Builds a real repository to install from, so the whole path runs
+    /// without the network.
+    ///
+    /// Failures panic rather than skipping. git is a hard requirement of this
+    /// feature and the repository under test is itself a git checkout, so a
+    /// missing git is a broken environment, not a reason to pass silently.
+    fn origin_repo(dir: &Path, tag: Option<&str>) -> PathBuf {
+        let repo = dir.join("origin");
+        fs::create_dir_all(repo.join("plugin")).unwrap();
+        fs::write(repo.join("plugin").join("init.lua"), "-- demo\n").unwrap();
+
+        let run = |args: Vec<&str>| {
+            smol::block_on(git::run(
+                args.iter().map(|a| (*a).to_owned()).collect(),
+                Some(repo.clone()),
+            ))
+            .unwrap_or_else(|e| panic!("git {args:?} failed while building the fixture: {e}"))
+        };
+        run(vec!["init", "--quiet"]);
+        run(vec!["config", "user.email", "t@example.com"]);
+        run(vec!["config", "user.name", "test"]);
+        run(vec!["add", "."]);
+        run(vec!["commit", "--quiet", "-m", "initial"]);
+        if let Some(tag) = tag {
+            run(vec!["tag", tag]);
+        }
+        repo
+    }
+
+    #[test]
+    fn installs_a_package_from_a_local_repository() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), None);
+
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(origin.display().to_string()).with_name("demo");
+
+        let installed = smol::block_on(mgr.ensure_installed(&spec, &mut lock))
+            .expect("a local repository should install");
+
+        assert!(installed.changed);
+        assert!(
+            installed.dir.join("plugin").join("init.lua").is_file(),
+            "the package files should be in the revision directory"
+        );
+        assert!(
+            !installed.dir.join(".git").exists(),
+            "a revision must not carry a git directory"
+        );
+        assert_eq!(
+            lock.get("demo").map(|e| e.rev.as_str()),
+            Some(installed.rev.as_str()),
+            "the installed revision is recorded"
+        );
+        assert!(
+            installed.dir.ends_with(&installed.rev),
+            "the directory is named for its revision"
+        );
+    }
+
+    /// A second call must not re-clone or move the package, which is what
+    /// makes a steady state start free.
+    #[test]
+    fn installing_twice_is_idempotent() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), None);
+
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(origin.display().to_string()).with_name("demo");
+
+        let first = smol::block_on(mgr.ensure_installed(&spec, &mut lock)).unwrap();
+        let second = smol::block_on(mgr.ensure_installed(&spec, &mut lock)).unwrap();
+
+        assert!(!second.changed, "the second call changes nothing");
+        assert_eq!(first.dir, second.dir);
+        assert_eq!(first.rev, second.rev);
+    }
+
+    /// A tag is not a remote-tracking ref, so it has to resolve literally
+    /// rather than being lost to the branch lookup that runs first.
+    #[test]
+    fn an_explicit_tag_still_resolves() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), Some("v1.0.0"));
+
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(origin.display().to_string())
+            .with_name("demo")
+            .with_version("v1.0.0");
+
+        smol::block_on(mgr.ensure_installed(&spec, &mut lock)).expect("a tag should install");
+    }
+
+    /// An annotated tag is its own object. Recording that object id would put
+    /// something in the lockfile that is not a commit, and `resolve` would then
+    /// look for a revision directory no checkout ever produces.
+    #[test]
+    fn an_annotated_tag_records_the_commit_it_points_at() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), None);
+        let git = |args: Vec<&str>| {
+            smol::block_on(git::run(
+                args.iter().map(|a| (*a).to_owned()).collect(),
+                Some(origin.clone()),
+            ))
+            .unwrap()
+        };
+        git(vec!["tag", "-a", "v2.0.0", "-m", "release"]);
+        let commit = git(vec!["rev-parse", "HEAD"]).stdout.trim().to_owned();
+        let tag_object = git(vec!["rev-parse", "v2.0.0"]).stdout.trim().to_owned();
+        assert_ne!(tag_object, commit, "the fixture tag must be annotated");
+
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(origin.display().to_string())
+            .with_name("demo")
+            .with_version("v2.0.0");
+
+        let installed = smol::block_on(mgr.ensure_installed(&spec, &mut lock))
+            .expect("an annotated tag should install");
+        assert_eq!(installed.rev, commit);
+    }
+
+    /// The point of committing a lockfile: another machine, with nothing
+    /// installed, gets the recorded commit rather than re-resolving `version`.
+    #[test]
+    fn a_committed_lockfile_reproduces_the_recorded_commit_on_a_fresh_machine() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), Some("v1.0.0"));
+        let src = origin.display().to_string();
+
+        // Machine one installs and records a commit.
+        let first_site = dir.path().join("site-one");
+        let mgr = Manager::new(&first_site);
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(src.clone()).with_name("demo");
+        let first = smol::block_on(mgr.ensure_installed(&spec, &mut lock)).unwrap();
+
+        // A later commit lands upstream, so `version` would now resolve higher.
+        fs::write(origin.join("plugin").join("extra.lua"), "-- later\n").unwrap();
+        for args in [vec!["add", "."], vec!["commit", "--quiet", "-m", "later"]] {
+            smol::block_on(git::run(
+                args.iter().map(|a| (*a).to_owned()).collect(),
+                Some(origin.clone()),
+            ))
+            .unwrap();
+        }
+
+        // Machine two starts empty but carries the committed lockfile.
+        let second_site = dir.path().join("site-two");
+        let mgr2 = Manager::new(&second_site);
+        let second = smol::block_on(mgr2.ensure_installed(&spec, &mut lock)).unwrap();
+
+        assert_eq!(
+            second.rev, first.rev,
+            "a committed lockfile must reproduce its recorded commit"
+        );
+        assert!(
+            !second.dir.join("plugin").join("extra.lua").exists(),
+            "the later commit must not be installed"
+        );
+    }
+
+    /// A changed source makes the old revision meaningless, so it must not be
+    /// reused for a different repository.
+    #[test]
+    fn a_changed_source_ignores_the_recorded_revision() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), None);
+        let mgr = Manager::new(dir.path().join("site"));
+
+        let mut lock = Lockfile::default();
+        lock.record("demo", "https://elsewhere/other", OTHER_REV);
+
+        let spec = Spec::new(origin.display().to_string()).with_name("demo");
+        let installed = smol::block_on(mgr.ensure_installed(&spec, &mut lock))
+            .expect("a new source should resolve afresh");
+        assert_ne!(installed.rev, OTHER_REV);
+        assert_eq!(lock.get("demo").unwrap().src, spec.src);
+    }
+
+    /// Repointing a name at a different repository must install that
+    /// repository. Reusing the cached checkout would serve the old code while
+    /// recording the new source.
+    #[test]
+    fn repointing_a_name_at_another_repository_installs_the_new_one() {
+        let dir = site();
+        let first = origin_repo(dir.path(), None);
+
+        let site_dir = dir.path().join("site");
+        let mgr = Manager::new(&site_dir);
+        let mut lock = Lockfile::default();
+
+        let spec = Spec::new(first.display().to_string()).with_name("demo");
+        smol::block_on(mgr.ensure_installed(&spec, &mut lock)).unwrap();
+
+        // A second, genuinely different repository under the same name.
+        let second_root = dir.path().join("second");
+        fs::create_dir_all(&second_root).unwrap();
+        let second = origin_repo(&second_root, None);
+        fs::write(second.join("plugin").join("only_here.lua"), "-- new\n").unwrap();
+        for args in [vec!["add", "."], vec!["commit", "--quiet", "-m", "second"]] {
+            smol::block_on(git::run(
+                args.iter().map(|a| (*a).to_owned()).collect(),
+                Some(second.clone()),
+            ))
+            .unwrap();
+        }
+
+        let respec = Spec::new(second.display().to_string()).with_name("demo");
+        let installed = smol::block_on(mgr.ensure_installed(&respec, &mut lock))
+            .expect("a new source should install");
+
+        assert!(
+            installed.dir.join("plugin").join("only_here.lua").is_file(),
+            "the new repository's code must be installed"
+        );
+        assert_eq!(lock.get("demo").unwrap().src, respec.src);
+    }
+
+    /// The lockfile wins over `version`, which is what makes a committed
+    /// lockfile reproduce a package set instead of resolving something newer.
+    #[test]
+    fn a_recorded_revision_is_used_instead_of_resolving_version() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), Some("v1.2.0"));
+
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(origin.display().to_string()).with_name("demo");
+        let first = smol::block_on(mgr.ensure_installed(&spec, &mut lock)).unwrap();
+
+        let pinned = Spec::new(origin.display().to_string())
+            .with_name("demo")
+            .with_version("v1.2.0");
+        let second = smol::block_on(mgr.ensure_installed(&pinned, &mut lock)).unwrap();
+
+        assert_eq!(second.rev, first.rev, "the recorded revision must win");
+        assert!(!second.changed);
+    }
+
+    /// The lockfile is committed and hand-edited, so its values are input. Both
+    /// halves become path components and must not escape the site directory.
+    #[test_case("/tmp/evil" ; "absolute_revision")]
+    #[test_case("../../evil" ; "traversing_revision")]
+    #[test_case("has/slash" ; "revision_with_separator")]
+    #[test_case("abc123" ; "abbreviated_revision")]
+    fn a_crafted_lockfile_revision_does_not_resolve(rev: &str) {
+        let dir = site();
+        let mgr = Manager::new(dir.path());
+        let mut lock = Lockfile::default();
+        lock.record("demo", "https://x/demo", rev);
+
+        // Make the escaped target exist, so only the guard can reject it.
+        let escaped = paths::revision_dir(dir.path(), "demo", rev);
+        let _ = fs::create_dir_all(&escaped);
+
+        assert!(
+            mgr.resolve(&lock, "demo").is_none(),
+            "revision {rev:?} must not resolve to a directory outside the package"
+        );
+    }
+
+    #[test]
+    fn a_crafted_lockfile_package_name_does_not_resolve() {
+        let dir = site();
+        let mgr = Manager::new(dir.path());
+        let mut lock = Lockfile::default();
+        lock.record("../escape", "https://x/demo", TEST_REV);
+        assert!(mgr.resolve(&lock, "../escape").is_none());
+    }
+
+    /// A repository can commit a symlink to any host file. `fs::copy` follows
+    /// one, which would copy that file's contents into the installed package
+    /// where the package's own Lua can read it.
+    #[cfg(unix)]
+    #[test]
+    fn copy_tree_does_not_follow_symlinks_out_of_the_tree() {
+        let dir = site();
+        let secret = dir.path().join("secret.txt");
+        fs::write(&secret, "sensitive").unwrap();
+
+        let from = dir.path().join("from");
+        fs::create_dir_all(&from).unwrap();
+        fs::write(from.join("real.lua"), "-- ok").unwrap();
+        std::os::unix::fs::symlink(&secret, from.join("leak.txt")).unwrap();
+
+        let to = dir.path().join("to");
+        copy_tree(&from, &to).unwrap();
+
+        assert!(to.join("real.lua").is_file(), "real files still copy");
+        assert!(
+            !to.join("leak.txt").exists(),
+            "a symlink must not be followed into the installed revision"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_tree_preserves_relative_symlinks_inside_the_tree() {
+        let dir = site();
+        let from = dir.path().join("from");
+        fs::create_dir_all(&from).unwrap();
+        fs::write(from.join("real.lua"), "-- ok").unwrap();
+        std::os::unix::fs::symlink("real.lua", from.join("linked.lua")).unwrap();
+
+        let to = dir.path().join("to");
+        copy_tree(&from, &to).unwrap();
+
+        assert_eq!(
+            fs::read_link(to.join("linked.lua")).unwrap(),
+            Path::new("real.lua")
+        );
+        assert_eq!(fs::read_to_string(to.join("linked.lua")).unwrap(), "-- ok");
+    }
+
+    #[test]
+    fn copy_tree_omits_the_git_directory() {
+        let dir = site();
+        let from = dir.path().join("from");
+        fs::create_dir_all(from.join(".git")).unwrap();
+        fs::create_dir_all(from.join("plugin")).unwrap();
+        fs::write(from.join(".git").join("HEAD"), "ref").unwrap();
+        fs::write(from.join("plugin").join("init.lua"), "-- x").unwrap();
+
+        let to = dir.path().join("to");
+        copy_tree(&from, &to).unwrap();
+
+        assert!(to.join("plugin").join("init.lua").is_file());
+        assert!(!to.join(".git").exists(), "a revision must not carry .git");
+    }
+
+    #[test]
+    fn prune_removes_only_unlocked_stale_revisions() {
+        const CURRENT: &str = "1111111111111111111111111111111111111111";
+        const STALE: &str = "2222222222222222222222222222222222222222";
+        const HELD: &str = "3333333333333333333333333333333333333333";
+
+        let dir = site();
+        let manager = Manager::new(dir.path());
+        let mut lock = Lockfile::default();
+        lock.record("demo", "https://x/demo", CURRENT);
+        for revision in [CURRENT, STALE, HELD] {
+            fs::create_dir_all(paths::revision_dir(dir.path(), "demo", revision)).unwrap();
+        }
+        fs::create_dir_all(paths::package_root(dir.path(), "demo").join(".work")).unwrap();
+        let _held = Lock::acquire_shared(&paths::revision_lock(dir.path(), "demo", HELD)).unwrap();
+
+        assert!(manager.prune(&lock).is_empty());
+
+        assert!(paths::revision_dir(dir.path(), "demo", CURRENT).is_dir());
+        assert!(!paths::revision_dir(dir.path(), "demo", STALE).exists());
+        assert!(paths::revision_dir(dir.path(), "demo", HELD).is_dir());
+        assert!(
+            paths::package_root(dir.path(), "demo")
+                .join(".work")
+                .is_dir()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prune_ignores_symlinks_and_packages_without_a_lockfile_owner() {
+        const CURRENT: &str = "1111111111111111111111111111111111111111";
+        const STALE: &str = "2222222222222222222222222222222222222222";
+
+        let dir = site();
+        let manager = Manager::new(dir.path());
+        let mut lock = Lockfile::default();
+        lock.record("owned", "https://x/owned", CURRENT);
+        fs::create_dir_all(paths::revision_dir(dir.path(), "owned", CURRENT)).unwrap();
+        let target = dir.path().join("target");
+        fs::create_dir_all(&target).unwrap();
+        std::os::unix::fs::symlink(&target, paths::revision_dir(dir.path(), "owned", STALE))
+            .unwrap();
+        let unknown = paths::revision_dir(dir.path(), "unknown", STALE);
+        fs::create_dir_all(&unknown).unwrap();
+
+        assert!(manager.prune(&lock).is_empty());
+
+        assert!(target.is_dir());
+        assert!(paths::revision_dir(dir.path(), "owned", STALE).is_symlink());
+        assert!(unknown.is_dir());
+    }
+
+    #[test]
+    fn prune_does_not_mutate_a_package_with_an_invalid_current_revision() {
+        const RECOVERABLE: &str = "2222222222222222222222222222222222222222";
+
+        let dir = site();
+        let manager = Manager::new(dir.path());
+        let mut lock = Lockfile::default();
+        lock.record("demo", "https://x/demo", "../invalid");
+        let recoverable = paths::revision_dir(dir.path(), "demo", RECOVERABLE);
+        fs::create_dir_all(&recoverable).unwrap();
+
+        assert!(manager.prune(&lock).is_empty());
+        assert!(recoverable.is_dir());
+    }
+}

--- a/maki-pack/src/paths.rs
+++ b/maki-pack/src/paths.rs
@@ -1,0 +1,99 @@
+//! Where managed packages live on disk.
+//!
+//! Every revision gets its own directory and is never rewritten, so a session
+//! that resolved one revision keeps reading it even while an update installs
+//! another. There is no symlink to swap, which also means no Windows junction
+//! or privilege question: the layout is identical on every platform.
+
+use std::path::{Path, PathBuf};
+
+/// Group name reserved for packages maki installs. Manual discovery skips it,
+/// so a managed package is never also found by walking the tree.
+pub const MANAGED_GROUP: &str = "core";
+
+/// `<site>/pack/core/<name>`, holding one directory per installed revision.
+pub fn package_root(site: &Path, name: &str) -> PathBuf {
+    site.join("pack").join(MANAGED_GROUP).join(name)
+}
+
+/// `<site>/pack/core/<name>/<sha>`, the directory a session actually loads.
+pub fn revision_dir(site: &Path, name: &str, sha: &str) -> PathBuf {
+    package_root(site, name).join(sha)
+}
+
+/// An empty directory pointed at by `core.hooksPath`, so no repository hook can
+/// run during a clone, a fetch, or a checkout.
+pub fn empty_hooks_dir(site: &Path) -> PathBuf {
+    site.join(".nohooks")
+}
+
+/// Lock covering one package's checkouts.
+pub fn package_lock(site: &Path, name: &str) -> PathBuf {
+    site.join("pack")
+        .join(MANAGED_GROUP)
+        .join(format!("{name}.lock"))
+}
+
+/// Stable sidecar lock for one immutable revision directory.
+pub fn revision_lock(site: &Path, name: &str, revision: &str) -> PathBuf {
+    site.join("pack")
+        .join(MANAGED_GROUP)
+        .join(".locks")
+        .join(name)
+        .join(format!("{revision}.lock"))
+}
+
+/// Sidecar lock for a shared file, held across its whole read-modify-write.
+pub fn sidecar_lock(file: &Path) -> PathBuf {
+    let mut name = file.file_name().unwrap_or_default().to_os_string();
+    name.push(".lock");
+    file.with_file_name(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn site() -> PathBuf {
+        PathBuf::from("/data/site")
+    }
+
+    #[test]
+    fn revisions_are_siblings_under_one_package_root() {
+        let a = revision_dir(&site(), "demo", "aaa");
+        let b = revision_dir(&site(), "demo", "bbb");
+        assert_eq!(a.parent(), b.parent());
+        assert_eq!(a.parent().unwrap(), package_root(&site(), "demo"));
+        assert_ne!(a, b, "two revisions must not share a directory");
+    }
+
+    /// Managed packages live under the reserved group, which manual discovery
+    /// skips. If this ever changed, one package could get two identities.
+    #[test]
+    fn managed_packages_live_under_the_reserved_group() {
+        let root = package_root(&site(), "demo");
+        assert!(root.starts_with(site().join("pack").join(MANAGED_GROUP)));
+    }
+
+    #[test]
+    fn sidecar_lock_sits_beside_its_file() {
+        let lock = sidecar_lock(Path::new("/cfg/pack-lock.json"));
+        assert_eq!(lock, PathBuf::from("/cfg/pack-lock.json.lock"));
+    }
+
+    #[test]
+    fn package_lock_is_not_inside_the_package_root() {
+        let name = "demo";
+        let lock = package_lock(&site(), name);
+        assert!(
+            !lock.starts_with(package_root(&site(), name)),
+            "a lock inside the directory it guards would be removed with it"
+        );
+    }
+
+    #[test]
+    fn revision_lock_survives_revision_removal() {
+        let lock = revision_lock(&site(), "demo", "abc");
+        assert!(!lock.starts_with(revision_dir(&site(), "demo", "abc")));
+    }
+}

--- a/maki-pack/src/spec.rs
+++ b/maki-pack/src/spec.rs
@@ -1,0 +1,142 @@
+//! What a user declares when they add a package.
+
+/// One package, as declared by `maki.pack.add`.
+///
+/// Field names and defaults follow Neovim's `vim.pack.Spec`, so a user moving
+/// from a Neovim plugin list does not have to translate anything.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Spec {
+    /// Any URI `git clone` accepts.
+    pub src: String,
+    /// Directory and owner name. Derived from `src` when not given.
+    pub name: String,
+    /// Branch, tag, or commit to resolve. `None` follows the default branch.
+    pub version: Option<String>,
+}
+
+impl Spec {
+    pub fn new(src: impl Into<String>) -> Self {
+        let src = src.into();
+        let name = derive_name(&src);
+        Self {
+            src,
+            name,
+            version: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    #[must_use]
+    pub fn with_version(mut self, version: impl Into<String>) -> Self {
+        self.version = Some(version.into());
+        self
+    }
+}
+
+/// Whether a name is safe to use as a directory under the package root.
+///
+/// This is a security boundary, not a tidiness rule. A name becomes a path
+/// component, and `Path::join` *replaces* the base when given an absolute path,
+/// so a package called `/etc` would make the package root `/etc` and a removal
+/// would delete it. A name containing `..` escapes upward the same way.
+pub fn name_is_safe(name: &str) -> bool {
+    !name.is_empty()
+        && name != ".."
+        && !name.starts_with('.')
+        && !name.contains('/')
+        && !name.contains('\\')
+        && !name.contains('\0')
+        // A Windows drive prefix would also escape, and names are shared
+        // across platforms, so reject it everywhere rather than only there.
+        && !name.contains(':')
+        // Keep names usable as unambiguous command arguments.
+        && !name.starts_with('-')
+        && !name.starts_with('+')
+        && !name
+            .chars()
+            .any(|character| character.is_whitespace() || character.is_control())
+}
+
+/// The repository name in a git URI.
+///
+/// Handles the forms git itself accepts: https URLs, scp-style `host:path`, and
+/// plain paths, with or without a `.git` suffix or a trailing slash. An
+/// unusable `src` yields an empty name, which the caller rejects rather than
+/// guessing.
+pub fn derive_name(src: &str) -> String {
+    let trimmed = src.trim().trim_end_matches('/');
+    let last = trimmed
+        .rsplit(['/', ':'])
+        .find(|part| !part.is_empty())
+        .unwrap_or("");
+    last.strip_suffix(".git").unwrap_or(last).to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    #[test_case("https://github.com/user/repo", "repo" ; "https")]
+    #[test_case("https://github.com/user/repo.git", "repo" ; "https_with_git_suffix")]
+    #[test_case("https://github.com/user/repo/", "repo" ; "trailing_slash")]
+    #[test_case("https://github.com/user/repo.git/", "repo" ; "git_suffix_and_slash")]
+    #[test_case("git@github.com:user/repo.git", "repo" ; "scp_style")]
+    #[test_case("ssh://git@host/user/repo.git", "repo" ; "ssh_url")]
+    #[test_case("/srv/git/repo.git", "repo" ; "local_path")]
+    #[test_case("repo", "repo" ; "bare_name")]
+    #[test_case("https://example.com/a.b/my-plugin.nvim", "my-plugin.nvim" ; "dots_kept_when_not_git_suffix")]
+    fn derives_name_from_src(src: &str, expected: &str) {
+        assert_eq!(derive_name(src), expected);
+    }
+
+    #[test_case("repo", true ; "plain")]
+    #[test_case("my-plugin.nvim", true ; "dots_inside")]
+    #[test_case("under_score", true ; "underscore")]
+    #[test_case("", false ; "empty")]
+    #[test_case("..", false ; "parent")]
+    #[test_case("../escape", false ; "traversal")]
+    #[test_case("/etc", false ; "absolute")]
+    #[test_case("a/b", false ; "separator")]
+    #[test_case("a\\b", false ; "backslash")]
+    #[test_case("C:evil", false ; "drive_prefix")]
+    #[test_case(".hidden", false ; "leading_dot")]
+    #[test_case("-option", false ; "command_option")]
+    #[test_case("++flag", false ; "command_flag")]
+    #[test_case("two words", false ; "command_separator")]
+    #[test_case("escape\u{1b}sequence", false ; "control_character")]
+    fn name_safety(name: &str, expected: bool) {
+        assert_eq!(name_is_safe(name), expected, "{name:?}");
+    }
+
+    /// Names derived from ordinary sources must survive the safety check, or
+    /// the guard would reject real packages.
+    #[test]
+    fn derived_names_from_real_sources_are_safe() {
+        for src in [
+            "https://github.com/user/repo.git",
+            "git@github.com:user/repo.git",
+            "ssh://git@host/user/my-plugin.nvim",
+        ] {
+            assert!(name_is_safe(&derive_name(src)), "{src}");
+        }
+    }
+
+    #[test]
+    fn unusable_src_yields_an_empty_name() {
+        assert_eq!(derive_name(""), "");
+        assert_eq!(derive_name("///"), "");
+    }
+
+    #[test]
+    fn explicit_name_overrides_the_derived_one() {
+        let spec = Spec::new("https://github.com/user/repo").with_name("other");
+        assert_eq!(spec.name, "other");
+        assert_eq!(spec.src, "https://github.com/user/repo");
+    }
+}

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -339,7 +339,7 @@ mod tests {
             "provider": {"allowed_models": [fallback.spec()]}
         }))
         .unwrap();
-        let policy = raw.into_config().unwrap().provider.model_policy;
+        let policy = raw.into_config(&[]).unwrap().provider.model_policy;
 
         let state = SessionState::from_session(session, &fallback, &storage, &policy);
 

--- a/site/docs/content/_index.md
+++ b/site/docs/content/_index.md
@@ -58,6 +58,7 @@ The docs are sorted by what you came here to do:
     <a class="card" href="/docs/commands/"><span class="card-title">Commands</span><span class="card-desc">The / palette, sessions, toggles, custom commands.</span></a>
     <a class="card" href="/docs/keybindings/"><span class="card-title">Keybindings</span><span class="card-desc">Defaults, precedence, rebinding from Lua.</span></a>
     <a class="card" href="/docs/lua-api/"><span class="card-title">Lua API</span><span class="card-desc">The plugin surface, mirrored from Neovim.</span></a>
+    <a class="card" href="/docs/packages/"><span class="card-title">Lua Packages</span><span class="card-desc">Load external Lua plugins from Neovim-style package directories.</span></a>
     <a class="card" href="/docs/cli/"><span class="card-title">CLI</span><span class="card-desc">Flags and subcommands (auth, models, acp, prompt, ...).</span></a>
     <a class="card" href="/docs/telemetry/"><span class="card-title">Telemetry</span><span class="card-desc">Opt-in OpenTelemetry metrics and events, to a collector you run.</span></a>
   </div>

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -84,6 +84,7 @@ The rules:
 | Module | What it is for |
 | --- | --- |
 | [`maki`](#maki) | The global entry point. |
+| [`maki.pack`](#maki-pack) | Declare global packages and inspect package state. |
 | [`maki.api`](#maki-api) | Plugin registration. |
 | [`maki.agent`](#maki-agent) | Subagent primitives for plugins that need to talk to an LLM. |
 | [`maki.agent.Session`](#maki-agent-Session) | A subagent session with its own conversation history. |
@@ -185,20 +186,62 @@ maki.split("\nhello\nworld\n", "\n", { trimempty = true }) -- { "hello", "world"
 maki.packadd({name})
 ```
 
-Activate an installed `opt/` package, like `:packadd`.
-
-Loading happens after this call returns. The startup package pass reports
-an unknown, disabled, or failed package.
+Load an installed package that is not active.
 
 **Parameters:**
 
-- `{name}` (`string`) Package to activate.
+- `{name}` (`string`) Package name.
+
+
+## maki.pack {#maki-pack}
+
+Declare global packages and inspect package state.
+
+`add` is available only in the global `init.lua`. `get` is read-only
+and is available in project config and packages.
+
+---
+
+### `maki.pack.add()` {#maki-pack-add}
+
+```lua
+maki.pack.add({specs}, {opts?})
+```
+
+Declare global packages after the global `init.lua` finishes.
+
+**Parameters:**
+
+- `{specs}` (`table`) Sources or tables with `src`, `name`, `version`, and `data`.
+- `{opts?}` (`table?`) `confirm` controls source confirmation. `load` is a
+
+  boolean or a custom loader function.
+
 
 **Example:**
 
 ```lua
-maki.packadd("maki-goal")
+maki.pack.add({
+  { src = "https://github.com/user/maki-goal", version = "main" },
+})
 ```
+
+---
+
+### `maki.pack.get()` {#maki-pack-get}
+
+```lua
+maki.pack.get({names?}, {opts?})
+```
+
+Get package state without changing the installed set.
+
+**Parameters:**
+
+- `{names?}` (`table?`) Package names. Omit for all managed packages.
+- `{opts?}` (`table?`) Reserved. Omit it.
+
+**Returns:** (`table`) Package records with `spec`, `path`, `rev`, and `active`.
 
 
 ## maki.api {#maki-api}

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -177,6 +177,29 @@ maki.split("x*y*z", "*", { plain = true }) -- { "x", "y", "z" }
 maki.split("\nhello\nworld\n", "\n", { trimempty = true }) -- { "hello", "world" }
 ```
 
+---
+
+### `maki.packadd()` {#maki-packadd}
+
+```lua
+maki.packadd({name})
+```
+
+Activate an installed `opt/` package, like `:packadd`.
+
+Loading happens after this call returns. The startup package pass reports
+an unknown, disabled, or failed package.
+
+**Parameters:**
+
+- `{name}` (`string`) Package to activate.
+
+**Example:**
+
+```lua
+maki.packadd("maki-goal")
+```
+
 
 ## maki.api {#maki-api}
 

--- a/site/docs/content/packages/_index.md
+++ b/site/docs/content/packages/_index.md
@@ -1,0 +1,41 @@
++++
+title = "Lua Packages"
+weight = 11
+[extra]
+group = "Reference"
++++
+
+# Lua packages
+
+A Lua package lets you add tools, commands, keybindings, and event handlers
+without copying its code into `init.lua`.
+
+Clone a package into a Neovim-style package directory:
+
+```text
+<maki-data>/site/pack/<group>/start/<name>/
+<maki-data>/site/pack/<group>/opt/<name>/
+```
+
+A `start` package loads at startup. An `opt` package stays installed until
+something activates it.
+
+Placing a package by hand means you trust its code the way you trust your own
+`init.lua`. Maki grants such a package exactly the permissions its
+`plugin.toml` requests, with no approval step. Read the code before you copy it
+in, and keep manual placement for the packages you develop yourself.
+
+Activate an `opt` package with `maki.packadd`, from `init.lua` or from another
+package:
+
+```lua
+maki.packadd("my-package")
+```
+
+Maki loads the named package after the calling Lua task returns. A package
+that `maki.packadd` activates can activate another one in turn. Maki reports a
+name that no installed package matches, and refuses a package that
+`plugins.<name>.enabled = false` disabled.
+
+A package directory can contain sorted `plugin/*.lua` entry files and modules
+at `lua/<module>.lua` or `lua/<module>/init.lua`.

--- a/site/docs/content/packages/_index.md
+++ b/site/docs/content/packages/_index.md
@@ -8,7 +8,92 @@ group = "Reference"
 # Lua packages
 
 A Lua package lets you add tools, commands, keybindings, and event handlers
-without copying its code into `init.lua`.
+without copying its code into `init.lua`. Maki can load a package that you put
+on disk, or it can install one from a Git repository and lock it to one commit.
+
+## Install from Git
+
+Declare managed packages in the global `init.lua`, normally
+`~/.config/maki/init.lua`:
+
+```lua
+maki.pack.add({
+  "https://github.com/example/maki-goal",
+  {
+    src = "https://github.com/example/maki-review",
+    version = "v1.2.0",
+  },
+})
+```
+
+Maki shows all new packages in one install prompt. It writes the selected Git
+commit to `pack-lock.json` in your config directory. Commit this file if you
+want another machine to install the same revisions.
+
+Package installation is global. A project `.maki/init.lua` cannot add packages
+because all projects share the same lockfile and package directory. Project
+config and packages can inspect installed state with `maki.pack.get` and can
+activate an installed package with `maki.packadd`.
+
+Maki restores a missing checkout only when the global config still declares
+the package and its source matches the lockfile entry. Package and approval
+changes use one process lock. The kernel releases this lock when the process
+exits, including after a crash or forced termination.
+
+Set `confirm = false` only when the package source is already trusted and Maki
+must run without a terminal:
+
+```lua
+maki.pack.add({ "https://github.com/example/maki-goal" }, {
+  confirm = false,
+})
+```
+
+This option skips the install prompt. It does not approve package permissions.
+Maki rejects an HTTP source that contains a username, password, or token because
+Git and the lockfile would store it. Use a Git credential helper or an SSH agent
+instead.
+
+Set `load = false` to install a package without loading it at startup. Set
+`load` to a function when the package needs a custom entry point:
+
+```lua
+maki.pack.add({
+  {
+    src = "https://github.com/example/maki-review",
+    data = { module = "review" },
+  },
+}, {
+  load = function(package)
+    require(package.spec.data.module).setup()
+  end,
+})
+```
+
+The function runs as the package owner. It receives the package `spec` and its
+installed `path`. The `data` field can contain any Lua value.
+
+## Package permissions
+
+A managed package can ask for guarded APIs in `plugin.toml`:
+
+```toml
+[permissions]
+fs_read = true
+fs_write = true
+net = true
+run = true
+env = true
+```
+
+The file is a request, not an approval. Maki asks about new permissions in a
+separate prompt. An approval applies only to the same package name and source.
+Maki keeps approvals in `<maki-data>/site/pack-approvals.json`. They describe
+trust on this machine and must not be committed with `pack-lock.json`.
+Non-interactive modes report the package as unavailable until the install and
+permission decisions are made in an interactive terminal.
+
+## Install by hand
 
 Clone a package into a Neovim-style package directory:
 
@@ -22,8 +107,10 @@ something activates it.
 
 Placing a package by hand means you trust its code the way you trust your own
 `init.lua`. Maki grants such a package exactly the permissions its
-`plugin.toml` requests, with no approval step. Read the code before you copy it
-in, and keep manual placement for the packages you develop yourself.
+`plugin.toml` requests, with no approval step. A managed install is the
+opposite: Maki asks before it clones a source and again before it grants the
+permissions. Read the code before you copy it in, and keep manual placement for
+the packages you develop yourself.
 
 Activate an `opt` package with `maki.packadd`, from `init.lua` or from another
 package:
@@ -39,3 +126,9 @@ name that no installed package matches, and refuses a package that
 
 A package directory can contain sorted `plugin/*.lua` entry files and modules
 at `lua/<module>.lua` or `lua/<module>/init.lua`.
+
+Managed packages use immutable revision directories under
+`<maki-data>/site/pack/core/<name>/<commit>/`. A new revision creates a new
+directory. A running package holds a shared lock on its revision. At startup,
+Maki removes each stale revision only when it can take the matching exclusive
+lock. Revisions used by another Maki process stay on disk.

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -21,24 +21,27 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
     let mut plugin_host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
         .context("initialize lua plugin host")?;
 
-    let raw_config = plugin_host
-        .load_init_files_or_skip(no_plugins, &cwd)
-        .context("load init.lua files")?;
+    let (config, warnings) = super::load_plugins(
+        &mut plugin_host,
+        no_plugins,
+        super::BuiltinFailure::Fatal,
+        |host, names, _| {
+            let mut config = host
+                .load_init_files_or_skip(no_plugins, &cwd)
+                .context("load init.lua files")?
+                .unwrap_or_default()
+                .into_config(names)
+                .context("invalid config")?;
+            config.permissions = load_permissions(&cwd);
 
-    let mut config = raw_config
-        .unwrap_or_default()
-        .into_config()
-        .context("invalid config")?;
-    config.permissions = load_permissions(&cwd);
-
-    if yolo || config.always_yolo {
-        config.permissions.yolo = true;
-    }
-    config.validate()?;
-
-    plugin_host
-        .load_builtins(&config.plugins)
-        .context("load builtin plugins")?;
+            if yolo || config.always_yolo {
+                config.permissions.yolo = true;
+            }
+            config.validate()?;
+            Ok(config)
+        },
+    )?;
+    super::report_warnings(warnings);
 
     let timeouts = maki_providers::Timeouts {
         connect: config.provider.connect_timeout,

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -25,12 +25,13 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
         &mut plugin_host,
         no_plugins,
         super::BuiltinFailure::Fatal,
+        maki_lua::Interaction::None,
         |host, names, _| {
             let mut config = host
                 .load_init_files_or_skip(no_plugins, &cwd)
                 .context("load init.lua files")?
                 .unwrap_or_default()
-                .into_config(names)
+                .into_config(&names(host)?)
                 .context("invalid config")?;
             config.permissions = load_permissions(&cwd);
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -6,10 +6,72 @@ mod tui;
 use color_eyre::Result;
 use color_eyre::eyre::Context;
 
+use maki_config::Config;
+use maki_lua::PluginHost;
 use maki_storage::StateDir;
 
 use crate::cli::{AuthAction, Cli, Command, McpAction, MigrateAction};
 use crate::update;
+
+fn sanitize_warning(message: impl std::fmt::Display) -> String {
+    maki_lua::sanitize_message(&message.to_string())
+}
+
+fn sanitize_warnings(warnings: Vec<String>) -> Vec<String> {
+    warnings.into_iter().map(sanitize_warning).collect()
+}
+
+fn report_warnings(warnings: Vec<String>) {
+    for warning in sanitize_warnings(warnings) {
+        eprintln!("warning: {warning}");
+    }
+}
+
+/// What a builtin that fails to load means for the run in progress.
+#[derive(Clone, Copy)]
+enum BuiltinFailure {
+    /// Startup has nothing to fall back on.
+    Fatal,
+    /// `/reload` keeps the open UI alive, so the failure is only reported.
+    Warn,
+}
+
+/// The plugin startup every entry point shares. Packages are discovered before
+/// `build_config` runs, so `plugins.<name>` can configure an installed package,
+/// and loaded after the builtins, so a package claiming a builtin tool name is
+/// the side that fails.
+///
+/// Warnings are returned sanitized, leaving the sink to the caller; the extra
+/// `Vec` handed to `build_config` is for warnings raised while building it.
+fn load_plugins(
+    host: &mut PluginHost,
+    no_plugins: bool,
+    on_builtin_failure: BuiltinFailure,
+    build_config: impl FnOnce(&PluginHost, &[String], &mut Vec<String>) -> Result<Config>,
+) -> Result<(Config, Vec<String>)> {
+    let discovery = maki_lua::discover_installed(no_plugins);
+    // Includes the names discovery refused, so a package it could not read does
+    // not become a config error pointing at the user's `plugins.<name>` table.
+    let names = discovery.known_names();
+    let mut warnings: Vec<String> = discovery
+        .problems
+        .into_iter()
+        .map(|problem| format!("skipping package: {problem}"))
+        .collect();
+
+    let config = build_config(host, &names, &mut warnings)?;
+
+    if let Err(e) = host.load_builtins(&config.plugins) {
+        let e = color_eyre::eyre::Report::from(e).wrap_err("load builtin plugins");
+        match on_builtin_failure {
+            BuiltinFailure::Fatal => return Err(e),
+            BuiltinFailure::Warn => warnings.push(format!("{e:#}")),
+        }
+    }
+    warnings.extend(host.load_packages(&discovery.packages, &config.plugins));
+
+    Ok((config, sanitize_warnings(warnings)))
+}
 
 pub fn dispatch(cli: Cli) -> Result<()> {
     match cli.command {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -7,7 +7,7 @@ use color_eyre::Result;
 use color_eyre::eyre::Context;
 
 use maki_config::Config;
-use maki_lua::PluginHost;
+use maki_lua::{DiscoveredPackage, Interaction, PluginHost};
 use maki_storage::StateDir;
 
 use crate::cli::{AuthAction, Cli, Command, McpAction, MigrateAction};
@@ -36,10 +36,20 @@ enum BuiltinFailure {
     Warn,
 }
 
+/// Discovered package names plus the ones `init.lua` declared with
+/// `maki.pack.add`. Resolved by `build_config` instead of handed to it, because
+/// the declared set is only complete once the init files have run, and
+/// validation would otherwise reject a `plugins.<name>` for a package the user
+/// just declared.
+type KnownNames<'a> = dyn Fn(&PluginHost) -> Result<Vec<String>> + 'a;
+
 /// The plugin startup every entry point shares. Packages are discovered before
 /// `build_config` runs, so `plugins.<name>` can configure an installed package,
-/// and loaded after the builtins, so a package claiming a builtin tool name is
-/// the side that fails.
+/// declared ones are installed after it, and everything is loaded after the
+/// builtins, so a package claiming a builtin tool name is the side that fails.
+///
+/// `interaction` decides whether an install that needs the user's confirmation
+/// may ask for it or has to fail; only the interactive UI can answer.
 ///
 /// Warnings are returned sanitized, leaving the sink to the caller; the extra
 /// `Vec` handed to `build_config` is for warnings raised while building it.
@@ -47,19 +57,30 @@ fn load_plugins(
     host: &mut PluginHost,
     no_plugins: bool,
     on_builtin_failure: BuiltinFailure,
-    build_config: impl FnOnce(&PluginHost, &[String], &mut Vec<String>) -> Result<Config>,
+    interaction: Interaction,
+    build_config: impl FnOnce(&PluginHost, &KnownNames<'_>, &mut Vec<String>) -> Result<Config>,
 ) -> Result<(Config, Vec<String>)> {
     let discovery = maki_lua::discover_installed(no_plugins);
     // Includes the names discovery refused, so a package it could not read does
     // not become a config error pointing at the user's `plugins.<name>` table.
-    let names = discovery.known_names();
+    let discovered_names = discovery.known_names();
     let mut warnings: Vec<String> = discovery
         .problems
         .into_iter()
         .map(|problem| format!("skipping package: {problem}"))
         .collect();
 
-    let config = build_config(host, &names, &mut warnings)?;
+    let config = build_config(
+        host,
+        &|host: &PluginHost| {
+            let mut names = discovered_names.clone();
+            names.extend(declared_packages(host)?.into_iter().map(|d| d.spec.name));
+            names.sort();
+            names.dedup();
+            Ok(names)
+        },
+        &mut warnings,
+    )?;
 
     if let Err(e) = host.load_builtins(&config.plugins) {
         let e = color_eyre::eyre::Report::from(e).wrap_err("load builtin plugins");
@@ -68,9 +89,24 @@ fn load_plugins(
             BuiltinFailure::Warn => warnings.push(format!("{e:#}")),
         }
     }
-    warnings.extend(host.load_packages(&discovery.packages, &config.plugins));
+
+    // Installing here rather than inside `maki.pack.add` keeps a clone off the
+    // Lua thread, and is the phase Neovim's own `load` default defers to.
+    let declared = declared_packages(host)?;
+    let installed = maki_lua::install_declared(&declared, interaction);
+    warnings.extend(installed.failures);
+    let available: Vec<DiscoveredPackage> = discovery
+        .packages
+        .into_iter()
+        .chain(installed.packages)
+        .collect();
+    warnings.extend(host.load_declared_packages(&available, &declared, &config.plugins));
 
     Ok((config, sanitize_warnings(warnings)))
+}
+
+fn declared_packages(host: &PluginHost) -> Result<Vec<maki_lua::Declared>> {
+    host.declared_packages().context("read declared packages")
 }
 
 pub fn dispatch(cli: Cli) -> Result<()> {

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -547,6 +547,7 @@ pub fn models(no_plugins: bool, no_jit: bool) -> Result<()> {
         &mut host,
         no_plugins,
         super::BuiltinFailure::Fatal,
+        maki_lua::Interaction::None,
         |host, names, _| load_effective_config(host, no_plugins, &cwd, names),
     )?;
     super::report_warnings(warnings);
@@ -570,12 +571,14 @@ fn load_effective_config(
     host: &PluginHost,
     no_plugins: bool,
     cwd: &Path,
-    names: &[String],
+    names: &super::KnownNames<'_>,
 ) -> Result<Config> {
-    host.load_init_files_or_skip(no_plugins, cwd)
-        .context("load init.lua files")?
+    let raw_config = host
+        .load_init_files_or_skip(no_plugins, cwd)
+        .context("load init.lua files")?;
+    raw_config
         .unwrap_or_default()
-        .into_config(names)
+        .into_config(&names(host)?)
         .context("invalid config")
 }
 
@@ -590,6 +593,7 @@ pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
         &mut host,
         no_plugins,
         super::BuiltinFailure::Fatal,
+        maki_lua::Interaction::None,
         |host, names, _| {
             let mut config = load_effective_config(host, no_plugins, &cwd, names)?;
             config.permissions = load_permissions(&cwd);
@@ -686,6 +690,7 @@ pub fn prompt(
         &mut host,
         no_plugins,
         super::BuiltinFailure::Fatal,
+        maki_lua::Interaction::None,
         |host, names, _| load_effective_config(host, no_plugins, &cwd, names),
     )?;
     super::report_warnings(warnings);

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -541,9 +541,15 @@ pub fn models(no_plugins: bool, no_jit: bool) -> Result<()> {
     let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
     load_env_files(&cwd);
 
-    let host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
+    let mut host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
         .context("initialize lua plugin host")?;
-    let config = load_effective_config(&host, no_plugins, &cwd)?;
+    let (config, warnings) = super::load_plugins(
+        &mut host,
+        no_plugins,
+        super::BuiltinFailure::Fatal,
+        |host, names, _| load_effective_config(host, no_plugins, &cwd, names),
+    )?;
+    super::report_warnings(warnings);
 
     smol::block_on(fetch_all_models(
         &config.provider.model_policy,
@@ -560,11 +566,16 @@ pub fn models(no_plugins: bool, no_jit: bool) -> Result<()> {
     Ok(())
 }
 
-fn load_effective_config(host: &PluginHost, no_plugins: bool, cwd: &Path) -> Result<Config> {
+fn load_effective_config(
+    host: &PluginHost,
+    no_plugins: bool,
+    cwd: &Path,
+    names: &[String],
+) -> Result<Config> {
     host.load_init_files_or_skip(no_plugins, cwd)
         .context("load init.lua files")?
         .unwrap_or_default()
-        .into_config()
+        .into_config(names)
         .context("invalid config")
 }
 
@@ -575,18 +586,17 @@ pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
     let mut host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
         .context("initialize lua plugin host")?;
 
-    let raw_config = host
-        .load_init_files_or_skip(no_plugins, &cwd)
-        .context("load init.lua files")?;
-
-    let mut config = raw_config
-        .unwrap_or_default()
-        .into_config()
-        .context("invalid config")?;
-    config.permissions = load_permissions(&cwd);
-
-    host.load_builtins(&config.plugins)
-        .context("load builtin plugins")?;
+    let (_, warnings) = super::load_plugins(
+        &mut host,
+        no_plugins,
+        super::BuiltinFailure::Fatal,
+        |host, names, _| {
+            let mut config = load_effective_config(host, no_plugins, &cwd, names)?;
+            config.permissions = load_permissions(&cwd);
+            Ok(config)
+        },
+    )?;
+    super::report_warnings(warnings);
 
     let abs_path = Path::new(path)
         .canonicalize()
@@ -672,15 +682,13 @@ pub fn prompt(
     let reg = ToolRegistry::global_arc();
     let mut host =
         PluginHost::with_jit(Arc::clone(reg), !no_jit).context("initialize lua plugin host")?;
-    let raw_config = host
-        .load_init_files_or_skip(no_plugins, &cwd)
-        .context("load init.lua files")?;
-    let config = raw_config
-        .unwrap_or_default()
-        .into_config()
-        .context("invalid config")?;
-    host.load_builtins(&config.plugins)
-        .context("load builtin plugins")?;
+    let (config, warnings) = super::load_plugins(
+        &mut host,
+        no_plugins,
+        super::BuiltinFailure::Fatal,
+        |host, names, _| load_effective_config(host, no_plugins, &cwd, names),
+    )?;
+    super::report_warnings(warnings);
 
     if tools {
         let ctx = DescriptionContext {

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -11,7 +11,7 @@ use color_eyre::eyre::Context;
 use maki_agent::command::{self, CustomCommand};
 use maki_agent::tools::ToolRegistry;
 use maki_config::{Config, load_env_files, load_permissions};
-use maki_lua::PluginHost;
+use maki_lua::{Interaction, PluginHost};
 use maki_providers::model::Model;
 use maki_storage::StateDir;
 use maki_storage::id::MakiId;
@@ -85,7 +85,7 @@ fn load_config(
     plugin_host: &PluginHost,
     cli: &Cli,
     cwd: &Path,
-    names: &[String],
+    names: &super::KnownNames<'_>,
 ) -> Result<Config> {
     let raw_config = plugin_host
         .load_init_files_or_skip(cli.no_plugins, cwd)
@@ -93,8 +93,9 @@ fn load_config(
 
     let mut config = raw_config
         .unwrap_or_default()
-        .into_config(names)
+        .into_config(&names(plugin_host)?)
         .context("invalid config")?;
+    config.permissions = load_permissions(cwd);
     config.permissions = load_permissions(cwd);
 
     if cli.yolo || config.always_yolo {
@@ -132,7 +133,6 @@ fn config_or_fallback(
         (Err(e), None) => Err(e),
     }
 }
-
 /// The one construction path for a generation: first startup passes
 /// `fallback: None` (fail-fast); `/reload` passes the last-good config and
 /// model so a broken config reopens the UI with a warning instead of exiting.
@@ -140,6 +140,7 @@ fn build_stack(
     cli: &Cli,
     cwd: &Path,
     storage: &StateDir,
+    interaction: Interaction,
     fallback: Option<(Config, Model)>,
 ) -> Result<(Stack, Vec<String>)> {
     let mut plugin_host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !cli.no_jit)
@@ -154,6 +155,7 @@ fn build_stack(
         } else {
             super::BuiltinFailure::Fatal
         },
+        interaction,
         |host, names, warnings| {
             config_or_fallback(
                 load_config(host, cli, cwd, names),
@@ -246,7 +248,14 @@ pub fn run(mut cli: Cli) -> Result<()> {
     load_env_files(&cwd);
     warn_stale_config_toml(&cwd);
 
-    let (mut stack, startup_warnings) = build_stack(&cli, &cwd, &storage, None)?;
+    // Only the interactive UI can answer an install confirmation, so the other
+    // modes refuse the install with its reason even when a terminal is attached.
+    let interaction = if cli.print || cli.is_sdk_mode() {
+        Interaction::None
+    } else {
+        Interaction::Tty
+    };
+    let (mut stack, startup_warnings) = build_stack(&cli, &cwd, &storage, interaction, None)?;
 
     setup::init_logging(&stack.config.storage);
     setup::init_telemetry(&stack.config.telemetry);
@@ -405,7 +414,8 @@ pub fn run(mut cli: Cli) -> Result<()> {
                 stack.plugin_host.begin_shutdown();
                 ToolRegistry::global().clear_lua();
                 teardown.defer(move || drop(stack));
-                let (new_stack, new_warnings) = build_stack(&cli, &cwd, &storage, Some(last_good))?;
+                let (new_stack, new_warnings) =
+                    build_stack(&cli, &cwd, &storage, interaction, Some(last_good))?;
                 tabs = reloaded;
                 if tabs.is_empty() {
                     let session = AppSession::new(&new_stack.model.spec(), &cwd_str);
@@ -448,6 +458,10 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicBool, Ordering};
+
+    fn no_names(_: &PluginHost) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
 
     /// `second_saw_first` requires both joins: `defer` joining the first
     /// closure before spawning the second, and `Drop` joining the second
@@ -544,7 +558,7 @@ mod tests {
         let mut plugin_host = PluginHost::with_jit(Arc::new(ToolRegistry::new()), true)
             .expect("live host boots under --no-plugins");
 
-        let config = load_config(&plugin_host, &cli, dir.path(), &[])
+        let config = load_config(&plugin_host, &cli, dir.path(), &no_names)
             .expect("no-plugins must skip the broken init.lua and still load defaults");
         assert!(
             !config.plugins.names.is_empty(),
@@ -582,7 +596,7 @@ mod tests {
         let mut plugin_host =
             PluginHost::with_jit(Arc::new(ToolRegistry::new()), true).expect("live host boots");
 
-        match load_config(&plugin_host, &cli, dir.path(), &[]) {
+        match load_config(&plugin_host, &cli, dir.path(), &no_names) {
             Err(_) => {}
             Ok(_) => panic!("broken init.lua must error without --no-plugins"),
         }

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -81,14 +81,19 @@ fn discover_commands(disable: bool) -> Vec<CustomCommand> {
     command::discover_commands(&cwd)
 }
 
-fn load_config(plugin_host: &PluginHost, cli: &Cli, cwd: &Path) -> Result<Config> {
+fn load_config(
+    plugin_host: &PluginHost,
+    cli: &Cli,
+    cwd: &Path,
+    names: &[String],
+) -> Result<Config> {
     let raw_config = plugin_host
         .load_init_files_or_skip(cli.no_plugins, cwd)
         .context("load init.lua files")?;
 
     let mut config = raw_config
         .unwrap_or_default()
-        .into_config()
+        .into_config(names)
         .context("invalid config")?;
     config.permissions = load_permissions(cwd);
 
@@ -137,27 +142,26 @@ fn build_stack(
     storage: &StateDir,
     fallback: Option<(Config, Model)>,
 ) -> Result<(Stack, Vec<String>)> {
-    let mut warnings = Vec::new();
-
     let mut plugin_host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !cli.no_jit)
         .context("initialize lua plugin host")?;
 
     let (fallback_config, fallback_model) = fallback.unzip();
-    let reloading = fallback_model.is_some();
-    let config = config_or_fallback(
-        load_config(&plugin_host, cli, cwd),
-        fallback_config,
-        &mut warnings,
-    )?;
-
-    if let Err(e) = plugin_host.load_builtins(&config.plugins) {
-        let e = color_eyre::eyre::Report::from(e).wrap_err("load builtin plugins");
-        if reloading {
-            warnings.push(format!("{e:#}"));
+    let (config, mut warnings) = super::load_plugins(
+        &mut plugin_host,
+        cli.no_plugins,
+        if fallback_model.is_some() {
+            super::BuiltinFailure::Warn
         } else {
-            return Err(e);
-        }
-    }
+            super::BuiltinFailure::Fatal
+        },
+        |host, names, warnings| {
+            config_or_fallback(
+                load_config(host, cli, cwd, names),
+                fallback_config,
+                warnings,
+            )
+        },
+    )?;
 
     let commands = discover_commands(cli.no_commands);
 
@@ -183,7 +187,7 @@ fn build_stack(
             model,
             needs_login,
         },
-        warnings,
+        super::sanitize_warnings(warnings),
     ))
 }
 
@@ -242,12 +246,22 @@ pub fn run(mut cli: Cli) -> Result<()> {
     load_env_files(&cwd);
     warn_stale_config_toml(&cwd);
 
-    let (mut stack, _) = build_stack(&cli, &cwd, &storage, None)?;
+    let (mut stack, startup_warnings) = build_stack(&cli, &cwd, &storage, None)?;
 
     setup::init_logging(&stack.config.storage);
     setup::init_telemetry(&stack.config.telemetry);
     setup::install_panic_log_hook();
     setup::warn_ignored_provider_fields();
+
+    // Discovery runs before logging is initialized, so a package problem has
+    // no log to reach either. The TUI shows these in its first generation; a
+    // mode that never opens the UI has to report them here or a broken
+    // package fails in complete silence.
+    if cli.is_sdk_mode() || cli.print {
+        for warning in &startup_warnings {
+            eprintln!("warning: {warning}");
+        }
+    }
 
     if cli.is_sdk_mode() {
         let fast = stack.config.always_fast && stack.model.supports_fast();
@@ -299,7 +313,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
         &storage,
     )?];
     let mut focused = 0;
-    let mut warnings: Vec<String> = Vec::new();
+    let mut warnings = startup_warnings;
     let mut initial_prompt = read_initial_prompt(cli.initial_prompt.take())?;
     let mut teardown = Teardown::default();
 
@@ -472,7 +486,9 @@ mod tests {
     }
 
     fn test_config() -> Config {
-        RawConfig::default().into_config().expect("default config")
+        RawConfig::default()
+            .into_config(&[])
+            .expect("default config")
     }
 
     #[test]
@@ -528,7 +544,7 @@ mod tests {
         let mut plugin_host = PluginHost::with_jit(Arc::new(ToolRegistry::new()), true)
             .expect("live host boots under --no-plugins");
 
-        let config = load_config(&plugin_host, &cli, dir.path())
+        let config = load_config(&plugin_host, &cli, dir.path(), &[])
             .expect("no-plugins must skip the broken init.lua and still load defaults");
         assert!(
             !config.plugins.names.is_empty(),
@@ -566,7 +582,7 @@ mod tests {
         let mut plugin_host =
             PluginHost::with_jit(Arc::new(ToolRegistry::new()), true).expect("live host boots");
 
-        match load_config(&plugin_host, &cli, dir.path()) {
+        match load_config(&plugin_host, &cli, dir.path(), &[]) {
             Err(_) => {}
             Ok(_) => panic!("broken init.lua must error without --no-plugins"),
         }

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -1456,7 +1456,7 @@ mod tests {
             "provider": {"allowed_models": [startup.spec()]}
         }))
         .unwrap();
-        let policy = raw.into_config().unwrap().provider.model_policy;
+        let policy = raw.into_config(&[]).unwrap().provider.model_policy;
 
         assert!(
             resolve_set_model(


### PR DESCRIPTION
Depends on #827.

GitHub cannot stack pull requests across forks, so this branch contains the
reviewed #827 commit first. The new commit for this PR is `d91dbbff`.

## What this adds

- Adds global `maki.pack.add` and read-only `maki.pack.get`.
- Accepts a branch, tag, commit, or no version as a string. There is no
  `maki.version.range` API or semver dependency.
- Keeps package installation global. Project config and packages can inspect
  state and use `maki.packadd`, but cannot change the installed set.
- Stores managed packages as immutable revisions under
  `site/pack/core/<name>/<commit>` and records exact revisions in
  `pack-lock.json`.
- Supports `load = true`, `load = false`, and a custom load function with
  arbitrary spec `data`.
- Keeps source confirmation separate from package permission approval.
  Approvals are machine-local and bound to the package name and source.
- Takes a shared per-revision lock before reading a fetched manifest or Lua
  file. The Lua owner retains it through late uncached `require()` reads.
- Prunes stale revision directories at startup with the existing lock type.
  Pruning keeps the recorded revision, skips a revision held by another
  process, never waits, and reports other failures without stopping startup.
- Keeps the accepted source, Git-hook, symlink, path, owner-conflict, and
  credential-redaction checks.

## Scope after the maintainer review

This PR has no updates, deletion, offline mode, change events, lazy triggers,
or trigger dispatch state. #829 will own update review, `/packupdate!`, Lua
`force`, deletion, and change events only if the events stay a cheap wrapper.
The trigger-based #830 work is parked.

Folder trust is in #880. Minimum Maki version support is in #881.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --workspace`: 4,495 passed
- `cargo test --workspace --doc`
- `cargo hack check --workspace --each-feature`
- `just gen-docs-check`
- `cargo machete`: no unused dependencies
- `cargo audit`: only the existing `quick-xml` advisories and existing warnings

## AI use

Written with Claude Code and reviewed with Codex. The revised implementation
was reviewed twice against install, approval, lock, pruning, late module-read,
and entry-point failure paths.
