### PR TITLE
feat(pack): add lazy package activation (4/4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,6 +1503,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2889,6 +2899,7 @@ dependencies = [
 name = "maki-pack"
 version = "0.4.12"
 dependencies = [
+ "fs4",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,6 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror 2.0.18",
- "toml",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2796,6 +2796,7 @@ dependencies = [
  "maki-interpreter",
  "maki-lua-macro",
  "maki-markdown",
+ "maki-pack",
  "maki-providers",
  "maki-storage",
  "mlua",
@@ -2881,6 +2882,21 @@ dependencies = [
  "smol",
  "test-case",
  "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "maki-pack"
+version = "0.4.12"
+dependencies = [
+ "semver",
+ "serde",
+ "serde_json",
+ "smol",
+ "tempfile",
+ "test-case",
+ "thiserror 2.0.18",
+ "toml",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
   "maki-lua",
   "maki-markdown",
   "maki-otel",
+  "maki-pack",
   "maki-providers",
   "maki-storage",
   "maki-config-macro",
@@ -85,6 +86,7 @@ maki-lua-macro = { path = "maki-lua-macro" }
 maki-highlight = { path = "maki-highlight" }
 maki-markdown = { path = "maki-markdown" }
 maki-otel = { path = "maki-otel" }
+maki-pack = { path = "maki-pack" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 bs58 = "0.5"
@@ -94,6 +96,7 @@ crossterm = { version = "0.29", features = ["osc52"] }
 color-eyre = { version = "0.6", default-features = false, features = ["track-caller"] }
 termini = "1"
 thiserror = "2"
+semver = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["std", "fmt", "env-filter", "json"] }
 clap = { version = "4", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ keyring = "4"
 arboard = { version = "3", default-features = false, features = ["image-data", "wayland-data-control"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 flume = { version = "0.11", default-features = false, features = ["async", "select"] }
+fs4 = "1"
 pin-project-lite = "0.2"
 rustix = { version = "1", default-features = false, features = ["process"] }
 humantime = "2"

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -163,7 +163,7 @@ pub enum ConfigError {
     )]
     RemovedEditSubTool { tool: &'static str },
     #[error(
-        "invalid config: plugins.{plugin}: no bundled plugin or installed \
+        "invalid config: plugins.{plugin}: no bundled plugin or known \
          package is named \"{plugin}\" (available: {valid})"
     )]
     UnknownPlugin { plugin: String, valid: String },
@@ -271,10 +271,10 @@ impl RawConfig {
         self.tools.extend(overlay.tools);
     }
 
-    /// `packages` are the external package names discovery found. They are
-    /// passed in rather than stored, because an installed package is host
-    /// state: it is not written in any config file and must not survive a
-    /// merge between two of them.
+    /// `packages` are the external package names the host discovered or the
+    /// init files declared. They are passed in rather than stored, because an
+    /// installed package is host state: no config file writes it, and it must
+    /// not survive a merge between two of them.
     pub fn into_config(self, no_rtk: bool, packages: &[String]) -> Result<Config, ConfigError> {
         self.validate_plugin_tables(packages)?;
         // Only bundled names, because a builtin's name is also its tool name
@@ -325,6 +325,7 @@ impl RawConfig {
             let mut valid: Vec<&str> = DEFAULT_BUILTINS.to_vec();
             valid.extend(packages.iter().map(String::as_str));
             valid.sort_unstable();
+            valid.dedup();
             return Err(ConfigError::UnknownPlugin {
                 plugin: plugin.clone(),
                 valid: valid.join(", "),

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -163,8 +163,8 @@ pub enum ConfigError {
     )]
     RemovedEditSubTool { tool: &'static str },
     #[error(
-        "invalid config: plugins.{plugin}: no bundled plugin is named \"{plugin}\" \
-         (bundled plugins: {valid})"
+        "invalid config: plugins.{plugin}: no bundled plugin or installed \
+         package is named \"{plugin}\" (available: {valid})"
     )]
     UnknownPlugin { plugin: String, valid: String },
     #[error(
@@ -271,12 +271,19 @@ impl RawConfig {
         self.tools.extend(overlay.tools);
     }
 
-    pub fn into_config(self, no_rtk: bool) -> Result<Config, ConfigError> {
-        self.validate_plugin_tables()?;
+    /// `packages` are the external package names discovery found. They are
+    /// passed in rather than stored, because an installed package is host
+    /// state: it is not written in any config file and must not survive a
+    /// merge between two of them.
+    pub fn into_config(self, no_rtk: bool, packages: &[String]) -> Result<Config, ConfigError> {
+        self.validate_plugin_tables(packages)?;
+        // Only bundled names, because a builtin's name is also its tool name
+        // while a package's is not. Copying a package name here would hide an
+        // unrelated tool that happened to share it.
         let disabled_tools: Vec<String> = self
             .plugins
             .iter()
-            .filter(|(_, cfg)| cfg.enabled == Some(false))
+            .filter(|(name, cfg)| cfg.enabled == Some(false) && !packages.contains(name))
             .map(|(name, _)| name.clone())
             .collect();
         Ok(Config {
@@ -293,13 +300,13 @@ impl RawConfig {
             storage: StorageConfig::from_file(self.storage),
             telemetry: self.telemetry,
             permissions: PermissionsConfig::default(),
-            plugins: PluginsConfig::from_plugins(self.plugins),
+            plugins: PluginsConfig::from_plugins_and_packages(self.plugins, packages),
         })
     }
 
     /// A `plugins.<name>` key that matches no bundled plugin is a typo or an
     /// old config, so fail loudly instead of letting it silently drift.
-    fn validate_plugin_tables(&self) -> Result<(), ConfigError> {
+    fn validate_plugin_tables(&self, packages: &[String]) -> Result<(), ConfigError> {
         if !self.tools.is_empty() {
             return Err(ConfigError::RenamedToolsTable);
         }
@@ -311,13 +318,16 @@ impl RawConfig {
         let mut unknown: Vec<&String> = self
             .plugins
             .keys()
-            .filter(|name| !DEFAULT_BUILTINS.contains(&name.as_str()))
+            .filter(|name| !DEFAULT_BUILTINS.contains(&name.as_str()) && !packages.contains(name))
             .collect();
         unknown.sort();
         if let Some(&plugin) = unknown.first() {
+            let mut valid: Vec<&str> = DEFAULT_BUILTINS.to_vec();
+            valid.extend(packages.iter().map(String::as_str));
+            valid.sort_unstable();
             return Err(ConfigError::UnknownPlugin {
                 plugin: plugin.clone(),
-                valid: DEFAULT_BUILTINS.join(", "),
+                valid: valid.join(", "),
             });
         }
         Ok(())
@@ -1478,7 +1488,12 @@ impl TelemetryConfig {
 #[derive(Debug, Clone, Default)]
 pub struct PluginsConfig {
     pub enabled: bool,
+    /// Enabled bundled plugins. Deliberately does not include packages: the
+    /// host loads the two from different places, and mixing them here made
+    /// `load_builtins` reject every installed package by name.
     pub names: Vec<String>,
+    /// Enabled external packages.
+    pub packages: Vec<String>,
     /// Per-plugin option tables, without `enabled`. Each plugin validates its
     /// own via `maki.api.register_options` at load time.
     pub opts: HashMap<String, JsonMap<String, JsonValue>>,
@@ -1486,16 +1501,37 @@ pub struct PluginsConfig {
 
 impl PluginsConfig {
     pub fn from_plugins(plugins: HashMap<String, PluginFileConfig>) -> Self {
+        Self::from_plugins_and_packages(plugins, &[])
+    }
+
+    /// Installed packages default to enabled like Neovim `start/` packages.
+    pub fn from_plugins_and_packages(
+        plugins: HashMap<String, PluginFileConfig>,
+        packages: &[String],
+    ) -> Self {
+        let enabled = |name: &String| plugins.get(name).and_then(|t| t.enabled).unwrap_or(true);
+
         let mut all: Vec<String> = DEFAULT_BUILTINS
             .iter()
-            .filter(|name| plugins.get(**name).and_then(|t| t.enabled).unwrap_or(true))
-            .map(|s| s.to_string())
+            .map(|s| (*s).to_owned())
+            .filter(|name| enabled(name))
             .collect();
+
+        let mut enabled_packages: Vec<String> = packages
+            .iter()
+            .filter(|name| !DEFAULT_BUILTINS.contains(&name.as_str()))
+            .filter(|name| enabled(name))
+            .cloned()
+            .collect();
+        enabled_packages.sort();
+        enabled_packages.dedup();
 
         let mut extra: Vec<&String> = plugins
             .iter()
             .filter(|(name, cfg)| {
-                !DEFAULT_BUILTINS.contains(&name.as_str()) && cfg.enabled.unwrap_or(false)
+                !DEFAULT_BUILTINS.contains(&name.as_str())
+                    && !packages.contains(name)
+                    && cfg.enabled.unwrap_or(false)
             })
             .map(|(name, _)| name)
             .collect();
@@ -1511,6 +1547,7 @@ impl PluginsConfig {
         Self {
             enabled: true,
             names: all,
+            packages: enabled_packages,
             opts,
         }
     }
@@ -2243,7 +2280,7 @@ mod tests {
 
     #[test]
     fn empty_config_returns_defaults() {
-        let config = RawConfig::default().into_config(false).unwrap();
+        let config = RawConfig::default().into_config(false, &[]).unwrap();
         assert!(config.ui.splash_animation);
         assert_eq!(config.ui.notifications, NotificationMethod::Auto);
         assert_eq!(config.agent.max_output_bytes, DEFAULT_MAX_OUTPUT_BYTES);
@@ -2264,7 +2301,10 @@ mod tests {
     fn notifications_deserialize(value: &str, expected: NotificationMethod) {
         let raw: RawConfig =
             toml::from_str(&format!("[ui]\nnotifications = \"{value}\"\n")).unwrap();
-        assert_eq!(raw.into_config(false).unwrap().ui.notifications, expected);
+        assert_eq!(
+            raw.into_config(false, &[]).unwrap().ui.notifications,
+            expected
+        );
     }
 
     #[test]
@@ -2282,7 +2322,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let config = raw.into_config(false).unwrap();
+        let config = raw.into_config(false, &[]).unwrap();
         assert_eq!(config.agent.max_output_lines, 5000);
         assert_eq!(config.agent.max_output_bytes, DEFAULT_MAX_OUTPUT_BYTES);
     }
@@ -2349,7 +2389,7 @@ mod tests {
             ..Default::default()
         });
 
-        let provider = global.into_config(false).unwrap().provider;
+        let provider = global.into_config(false, &[]).unwrap().provider;
         assert!(provider.allowed_models.is_empty());
         assert_eq!(provider.excluded_models, ["*/*-preview"]);
         assert!(provider.model_policy.allows("openai/gpt-5"));
@@ -2366,7 +2406,7 @@ mod tests {
             },
             ..Default::default()
         }
-        .into_config(false)
+        .into_config(false, &[])
         .unwrap();
         let policy = &config.provider.model_policy;
 
@@ -2382,7 +2422,7 @@ mod tests {
             },
             ..Default::default()
         }
-        .into_config(false)
+        .into_config(false, &[])
         .unwrap();
         assert!(exclude_only.provider.model_policy.allows("openai/gpt-5"));
         assert!(
@@ -2402,7 +2442,7 @@ mod tests {
             },
             ..Default::default()
         }
-        .into_config(false);
+        .into_config(false, &[]);
 
         assert!(matches!(
             result,
@@ -2437,14 +2477,14 @@ mod tests {
 
     #[test]
     fn always_workflow_resolves_default_and_set() {
-        let defaults = RawConfig::default().into_config(false).unwrap();
+        let defaults = RawConfig::default().into_config(false, &[]).unwrap();
         assert!(!defaults.always_workflow, "absent resolves to false");
 
         let raw = RawConfig {
             always_workflow: Some(true),
             ..Default::default()
         };
-        assert!(raw.into_config(false).unwrap().always_workflow);
+        assert!(raw.into_config(false, &[]).unwrap().always_workflow);
     }
 
     #[test_case(AlwaysThinking::Toggle(true), StoredThinking::Adaptive ; "toggle_true")]
@@ -2458,14 +2498,14 @@ mod tests {
 
     #[test]
     fn into_config_resolves_always_thinking() {
-        let defaults = RawConfig::default().into_config(false).unwrap();
+        let defaults = RawConfig::default().into_config(false, &[]).unwrap();
         assert!(defaults.always_thinking.is_none());
 
         let raw = RawConfig {
             always_thinking: Some(AlwaysThinking::Mode("8192".into())),
             ..Default::default()
         };
-        let config = raw.into_config(false).unwrap();
+        let config = raw.into_config(false, &[]).unwrap();
         assert_eq!(
             config.always_thinking,
             Some(StoredThinking::Budget { tokens: 8192 })
@@ -2475,7 +2515,10 @@ mod tests {
             always_thinking: Some(AlwaysThinking::Mode("fast".into())),
             ..Default::default()
         };
-        let err = raw.into_config(false).err().expect("expected config error");
+        let err = raw
+            .into_config(false, &[])
+            .err()
+            .expect("expected config error");
         assert!(matches!(err, ConfigError::Thinking(_)));
     }
 
@@ -2506,7 +2549,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let config = raw.into_config(false).unwrap();
+        let config = raw.into_config(false, &[]).unwrap();
         assert_eq!(config.ui.tool_output_lines.bash, 20);
         assert_eq!(config.ui.tool_output_lines.read, 20);
         assert_eq!(
@@ -2931,14 +2974,14 @@ mod tests {
     #[test]
     fn show_thinking_missing_defaults_true() {
         let raw: RawConfig = toml::from_str("").unwrap();
-        let config = raw.into_config(false).unwrap();
+        let config = raw.into_config(false, &[]).unwrap();
         assert!(config.ui.show_thinking);
     }
 
     #[test]
     fn max_input_lines_defaults_and_deserializes() {
         let raw: RawConfig = toml::from_str("").unwrap();
-        let config = raw.into_config(false).unwrap();
+        let config = raw.into_config(false, &[]).unwrap();
         assert_eq!(config.ui.max_input_lines, DEFAULT_MAX_INPUT_LINES);
 
         let raw: RawConfig = toml::from_str("[ui]\nmax_input_lines = 5\n").unwrap();
@@ -2984,7 +3027,7 @@ mod tests {
             "[plugins.bash]\ntimeout_secs = 180\n[plugins.websearch]\nenabled = false\n",
         )
         .unwrap();
-        let config = raw.into_config(false).unwrap();
+        let config = raw.into_config(false, &[]).unwrap();
         assert!(config.plugins.names.contains(&"bash".to_string()));
         assert!(!config.plugins.names.contains(&"websearch".to_string()));
         assert!(
@@ -3095,7 +3138,7 @@ mod tests {
     fn removed_sub_tool_tables_error() {
         for &tool in EDIT_SUB_TOOLS {
             let raw: RawConfig = toml::from_str(&format!("[plugins.{tool}]\n")).unwrap();
-            let Err(err) = raw.into_config(false) else {
+            let Err(err) = raw.into_config(false, &[]) else {
                 panic!("plugins.{tool} should be rejected");
             };
             let msg = err.to_string();
@@ -3111,13 +3154,73 @@ mod tests {
     #[test_case("search_result_limit = 50" ; "opts_only")]
     fn unknown_plugin_name_errors(body: &str) {
         let raw: RawConfig = toml::from_str(&format!("[plugins.gerp]\n{body}\n")).unwrap();
-        let Err(err) = raw.into_config(false) else {
+        let Err(err) = raw.into_config(false, &[]) else {
             panic!("plugins.gerp should be rejected");
         };
         let msg = err.to_string();
         assert!(
-            msg.contains("no bundled plugin is named \"gerp\"") && msg.contains("grep"),
-            "error should name the typo and list bundled plugins, got: {msg}"
+            msg.contains("named \"gerp\"") && msg.contains("grep"),
+            "error should name the typo and list what is available, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn known_package_name_is_accepted() {
+        let raw: RawConfig = toml::from_str("[plugins.my_pack]\nenabled = true\n").unwrap();
+        let config = raw
+            .into_config(false, &["my_pack".to_owned()])
+            .expect("an installed package should be configurable");
+        assert!(config.plugins.packages.contains(&"my_pack".to_owned()));
+    }
+
+    #[test]
+    fn known_package_can_be_disabled() {
+        let raw: RawConfig = toml::from_str("[plugins.my_pack]\nenabled = false\n").unwrap();
+        let config = raw.into_config(false, &["my_pack".to_owned()]).unwrap();
+        assert!(!config.plugins.packages.contains(&"my_pack".to_owned()));
+    }
+
+    #[test]
+    fn packages_are_not_mixed_into_builtin_names() {
+        let config = RawConfig::default()
+            .into_config(false, &["my_pack".to_owned()])
+            .unwrap();
+        assert!(!config.plugins.names.contains(&"my_pack".to_owned()));
+        assert!(config.plugins.packages.contains(&"my_pack".to_owned()));
+        assert!(
+            config
+                .plugins
+                .names
+                .iter()
+                .all(|n| DEFAULT_BUILTINS.contains(&n.as_str())),
+            "names must hold only bundled plugins"
+        );
+    }
+
+    #[test]
+    fn disabling_a_package_does_not_disable_a_tool() {
+        let raw: RawConfig = toml::from_str("[plugins.my_pack]\nenabled = false\n").unwrap();
+        let config = raw.into_config(false, &["my_pack".to_owned()]).unwrap();
+        assert!(!config.agent.disabled_tools.contains(&"my_pack".to_owned()));
+    }
+
+    #[test]
+    fn disabling_a_builtin_still_disables_its_tool() {
+        let raw: RawConfig = toml::from_str("[plugins.grep]\nenabled = false\n").unwrap();
+        let config = raw.into_config(false, &[]).unwrap();
+        assert!(config.agent.disabled_tools.contains(&"grep".to_owned()));
+    }
+
+    #[test]
+    fn unknown_name_still_rejected_when_packages_exist() {
+        let raw: RawConfig = toml::from_str("[plugins.gerp]\nenabled = true\n").unwrap();
+        let Err(err) = raw.into_config(false, &["my_pack".to_owned()]) else {
+            panic!("gerp is neither a builtin nor an installed package");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("my_pack"),
+            "should list packages too, got: {msg}"
         );
     }
 
@@ -3125,7 +3228,7 @@ mod tests {
     fn disabled_plugin_keeps_opts_but_not_load_entry() {
         let raw: RawConfig =
             toml::from_str("[plugins.bash]\nenabled = false\ntimeout_secs = 180\n").unwrap();
-        let config = raw.into_config(false).unwrap();
+        let config = raw.into_config(false, &[]).unwrap();
         assert!(!config.plugins.names.contains(&"bash".to_string()));
         assert_eq!(
             config.plugins.opts["bash"]["timeout_secs"],
@@ -3137,7 +3240,7 @@ mod tests {
     #[test]
     fn renamed_tools_table_errors() {
         let raw: RawConfig = toml::from_str("[tools.bash]\nenabled = true\n").unwrap();
-        let Err(err) = raw.into_config(false) else {
+        let Err(err) = raw.into_config(false, &[]) else {
             panic!("old tools table should be rejected");
         };
         assert!(
@@ -3150,7 +3253,7 @@ mod tests {
     fn edit_sub_tool_toggles_flow_as_edit_opts() {
         let raw: RawConfig =
             toml::from_str("[plugins.edit]\nmultiedit = false\nedit_lines = true\n").unwrap();
-        let config = raw.into_config(false).unwrap();
+        let config = raw.into_config(false, &[]).unwrap();
         assert_eq!(
             config.plugins.opts["edit"]["multiedit"],
             serde_json::json!(false)

--- a/maki-lua/Cargo.toml
+++ b/maki-lua/Cargo.toml
@@ -19,6 +19,7 @@ maki-highlight = { workspace = true }
 maki-interpreter = { workspace = true }
 maki-lua-macro = { workspace = true }
 maki-markdown = { workspace = true }
+maki-pack = { workspace = true }
 maki-providers = { workspace = true }
 mlua = { workspace = true }
 serde_json = { workspace = true }

--- a/maki-lua/src/api/autocmd.rs
+++ b/maki-lua/src/api/autocmd.rs
@@ -10,6 +10,17 @@ use crate::api::util::dispatch::{DepthGuard, call_isolated};
 static NEXT_AUTOCMD_ID: AtomicU64 = AtomicU64::new(1);
 
 const WILDCARD_PATTERN: &str = "*";
+pub(crate) const LAZY_EVENTS: &[&str] = &[
+    "TurnStart",
+    "TurnEnd",
+    "TurnError",
+    "ToolStart",
+    "ToolDone",
+    "SessionReset",
+    "SessionFocusChanged",
+    "SessionStatusChanged",
+    "TaskStatusChanged",
+];
 
 pub(crate) struct AutocmdEntry {
     pub id: u64,
@@ -131,7 +142,8 @@ fn parse_string_or_seq(value: Value, what: &str) -> LuaResult<Vec<String>> {
 /// `"TurnError"`, `"ToolStart"`, `"ToolDone"`, `"SessionReset"`,
 /// `"SessionFocusChanged"`, `"SessionStatusChanged"`, and
 /// `"TaskStatusChanged"`. Plugins can also fire their own events with
-/// `exec_autocmds`.
+/// `exec_autocmds`. Package operations fire `"PackChangedPre"` and
+/// `"PackChanged"`.
 ///
 /// Each host event carries `data.session_id`. For `"SessionReset"` that
 /// is the session being left behind; the other events name the session now

--- a/maki-lua/src/api/keymap.rs
+++ b/maki-lua/src/api/keymap.rs
@@ -90,7 +90,13 @@ impl KeymapStore {
         plugin: Arc<str>,
         desc: String,
     ) -> (u64, Option<RegistryKey>) {
-        let id = NEXT_KEYMAP_ID.fetch_add(1, Ordering::Relaxed);
+        // Skipping the sentinel keeps `PENDING_KEYMAP_ID` meaning exactly one
+        // thing. The counter would have to wrap for this to matter, but the
+        // invariant is cheap to hold and expensive to debug once broken.
+        let mut id = NEXT_KEYMAP_ID.fetch_add(1, Ordering::Relaxed);
+        if id == PENDING_KEYMAP_ID {
+            id = NEXT_KEYMAP_ID.fetch_add(1, Ordering::Relaxed);
+        }
         let old = self
             .bindings
             .iter()
@@ -140,6 +146,58 @@ impl KeymapStore {
             .collect()
     }
 
+    /// Adds the keys of packages that have not loaded yet.
+    ///
+    /// A key trigger only works if the UI knows to send the press here, and it
+    /// reads this snapshot to decide. `PENDING_KEYMAP_ID` marks an entry no
+    /// binding owns; the runtime fails that id and then resolves by key, which
+    /// is what survives the load.
+    fn with_dormant(
+        mut entries: Vec<KeymapEntry>,
+        dormant: &[crate::api::pack::Dormant],
+    ) -> Vec<KeymapEntry> {
+        for pkg in dormant.iter().filter(|d| d.is_startable()) {
+            for notation in &pkg.triggers.keys {
+                let Ok((key, modifiers)) = parse_key_notation(notation) else {
+                    continue;
+                };
+                // A real binding wins. Publishing both would let the pending
+                // entry shadow a key a loaded plugin already answers.
+                if entries
+                    .iter()
+                    .any(|e| e.key == key && e.modifiers == modifiers)
+                {
+                    continue;
+                }
+                entries.push(KeymapEntry {
+                    key,
+                    modifiers,
+                    desc: format!("loads {}", pkg.name),
+                    plugin: Arc::from(pkg.name.as_str()),
+                    id: PENDING_KEYMAP_ID,
+                });
+            }
+        }
+        entries
+    }
+
+    /// Resolves by key rather than by id.
+    ///
+    /// Activation needs this. A dormant package's pending entry carries an id
+    /// that no real binding has, and the binding the package registers when it
+    /// loads gets a fresh id, so the id the UI sent cannot be carried across
+    /// the load. The key and modifiers can.
+    pub(crate) fn callback_for_key(
+        &self,
+        key: KeyCode,
+        modifiers: KeyModifiers,
+    ) -> Option<&RegistryKey> {
+        self.bindings
+            .iter()
+            .find(|b| b.key == key && b.modifiers == modifiers)
+            .map(|b| &b.callback)
+    }
+
     pub fn callback_for_id(&self, id: u64) -> Option<&RegistryKey> {
         self.bindings
             .iter()
@@ -147,6 +205,11 @@ impl KeymapStore {
             .map(|b| &b.callback)
     }
 }
+
+/// The id published for a key that only a dormant package answers.
+///
+/// No real binding can hold it because `KeymapStore::set` skips this value.
+pub(crate) const PENDING_KEYMAP_ID: u64 = u64::MAX;
 
 pub fn parse_key_notation(input: &str) -> Result<(KeyCode, KeyModifiers), String> {
     let s = input.trim();
@@ -244,9 +307,18 @@ fn parse_key_name(name: &str) -> Result<KeyCode, String> {
     }
 }
 
-fn publish_keymap_snapshot(lua: &Lua) {
+/// The one place a keymap snapshot is published.
+///
+/// Dormant keys are added here rather than by the callers, so no later
+/// `keymap.set` can publish a snapshot that quietly drops them and leaves a
+/// package with a trigger the UI no longer sends.
+pub(crate) fn publish_keymap_snapshot(lua: &Lua) {
     if let Some(store) = lua.app_data_ref::<KeymapStore>() {
-        let entries = store.snapshot_entries();
+        let dormant = lua
+            .app_data_ref::<crate::api::pack::PackStore>()
+            .and_then(|s| s.lock().expect("pack declarations").dormant.clone())
+            .unwrap_or_default();
+        let entries = KeymapStore::with_dormant(store.snapshot_entries(), &dormant);
         if let Some(writer) = lua.app_data_ref::<KeymapWriter>() {
             writer.publish(entries);
         }

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -98,6 +98,7 @@ pub(crate) fn create_maki_global(
         keymap::create_keymap_table(lua, Arc::clone(&plugin))?,
     )?;
     maki.set("pack", pack::create_pack_read_table(lua)?)?;
+    pack::add_packadd(lua, &maki)?;
 
     Ok(maki)
 }

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod log;
 pub(crate) mod model;
 pub(crate) mod net;
 pub(crate) mod options;
+pub(crate) mod pack;
 pub(crate) mod session;
 pub(crate) mod slot;
 pub(crate) mod split;

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -97,6 +97,7 @@ pub(crate) fn create_maki_global(
         "keymap",
         keymap::create_keymap_table(lua, Arc::clone(&plugin))?,
     )?;
+    maki.set("pack", pack::create_pack_read_table(lua)?)?;
 
     Ok(maki)
 }

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod treesitter;
 pub(crate) mod ui;
 pub(crate) mod util;
 pub(crate) mod uv;
+pub(crate) mod version;
 pub(crate) mod yaml;
 
 use std::sync::Arc;

--- a/maki-lua/src/api/pack.rs
+++ b/maki-lua/src/api/pack.rs
@@ -110,6 +110,13 @@ pub struct PackDeclarations {
     /// `maki.packadd` must record a host operation. `Some` means the runtime
     /// owns activation, including when the catalog is empty.
     pub dormant: Option<Vec<Dormant>>,
+    /// Set once the drain point has taken the pending operations.
+    ///
+    /// Arming the catalog can fail, and then `dormant` stays `None` for the
+    /// rest of the session and every `maki.packadd` records an operation that
+    /// nothing will ever read. This says the queue is closed, whatever the
+    /// catalog did.
+    pub drained: bool,
 }
 
 /// One installed, unloaded package and the triggers that activate it.
@@ -562,6 +569,15 @@ fn enqueue(lua: &Lua, op: PackOp, name: &str) -> LuaResult<()> {
         .ok_or_else(|| mlua::Error::runtime("pack: not available here"))?
         .clone();
     let mut declarations = store.lock().expect("pack declarations");
+    if declarations.drained {
+        return Err(mlua::Error::runtime(
+            "maki.packadd: packages have already been loaded, so it only works \
+             while init.lua and the packages themselves are running",
+        ));
+    }
+    // Two calls naming one package still load it once. The name is checked
+    // against what discovery found when the host drains this, so an unknown
+    // one is reported there rather than guessed at here.
     if !declarations.pending.contains(&op) {
         declarations.pending.push(op);
     }
@@ -890,6 +906,12 @@ pub(crate) fn add_packadd(
                 let state = {
                     let mut declarations = store.lock().expect("pack declarations");
                     let Some(dormant) = declarations.dormant.as_ref() else {
+                        if declarations.drained {
+                            return Err(mlua::Error::runtime(format!(
+                                "packadd: package {name:?} cannot be activated, because \
+                                 startup could not build the activation catalog"
+                            )));
+                        }
                         let operation = PackOp::Activate { name };
                         if !declarations.pending.contains(&operation) {
                             declarations.pending.push(operation);
@@ -1338,6 +1360,30 @@ mod tests {
         function.call::<()>("demo").unwrap();
 
         assert_eq!(store.lock().unwrap().pending.len(), 1);
+    }
+
+    /// The recording path is only read by the startup drain. Arming the
+    /// activation catalog can fail, and then every later `packadd` lands here,
+    /// so it has to report rather than queue where nothing will look.
+    #[test]
+    fn packadd_after_the_drain_is_refused() {
+        let (lua, store) = lua_with_store();
+        let maki = lua.create_table().unwrap();
+        add_packadd(&lua, &maki, None).unwrap();
+        store.lock().unwrap().drained = true;
+
+        let f: mlua::Function = maki.get("packadd").expect("packadd should be registered");
+        let err = f
+            .call::<()>("demo")
+            .expect_err("nothing reads the queue after the drain");
+        assert!(
+            err.to_string().contains("already been loaded"),
+            "got: {err}"
+        );
+        assert!(
+            store.lock().unwrap().pending.is_empty(),
+            "a refused call must not leave a request behind"
+        );
     }
 
     #[test]

--- a/maki-lua/src/api/pack.rs
+++ b/maki-lua/src/api/pack.rs
@@ -1,0 +1,96 @@
+//! `maki.packadd`, the activation path for a package under `pack/*/opt/`.
+
+use std::sync::{Arc, Mutex};
+
+use mlua::{Lua, Result as LuaResult, Table};
+
+/// A change to the installed set, requested from Lua.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PackOp {
+    /// Load a package that is installed but not loaded.
+    Activate { name: String },
+}
+
+/// What Lua recorded for the host to act on.
+///
+/// Session state only. Nothing here runs inline: loading an owner blocks on a
+/// reply from the runtime thread that the calling Lua task is occupying, so
+/// acting on a request from inside the call would wait on itself.
+#[derive(Debug, Default, Clone)]
+pub struct PackDeclarations {
+    pub pending: Vec<PackOp>,
+}
+
+pub type PackStore = Arc<Mutex<PackDeclarations>>;
+
+/// Registers `maki.packadd` on the root table.
+///
+/// It sits beside the other always-available functions rather than in a table
+/// of its own, because activating code that is already installed and already
+/// approved is something any plugin may do.
+pub(crate) fn add_packadd(lua: &Lua, maki: &Table) -> LuaResult<()> {
+    maki.set("packadd", lua.create_function(packadd)?)
+}
+
+fn packadd(lua: &Lua, name: String) -> LuaResult<()> {
+    enqueue(lua, PackOp::Activate { name })
+}
+
+fn enqueue(lua: &Lua, op: PackOp) -> LuaResult<()> {
+    let store = lua
+        .app_data_ref::<PackStore>()
+        .ok_or_else(|| mlua::Error::runtime("pack: not available here"))?
+        .clone();
+    let mut declarations = store.lock().expect("pack declarations");
+    // Two calls naming one package still load it once. The name is checked
+    // against what discovery found when the host drains this, so an unknown
+    // one is reported there rather than guessed at here.
+    if !declarations.pending.contains(&op) {
+        declarations.pending.push(op);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lua_with_store() -> (Lua, PackStore) {
+        let lua = Lua::new();
+        let store = PackStore::default();
+        lua.set_app_data(store.clone());
+        (lua, store)
+    }
+
+    #[test]
+    fn packadd_records_each_named_package_once() {
+        let (lua, store) = lua_with_store();
+        let maki = lua.create_table().unwrap();
+        add_packadd(&lua, &maki).unwrap();
+        let f: mlua::Function = maki.get("packadd").expect("packadd is on the root table");
+        f.call::<()>("goal").unwrap();
+        f.call::<()>("review").unwrap();
+        f.call::<()>("goal").unwrap();
+        assert_eq!(
+            store.lock().unwrap().pending,
+            vec![
+                PackOp::Activate {
+                    name: "goal".to_owned()
+                },
+                PackOp::Activate {
+                    name: "review".to_owned()
+                }
+            ],
+            "a repeated call must not load the package twice"
+        );
+    }
+
+    #[test]
+    fn packadd_without_a_store_reports_rather_than_panicking() {
+        let lua = Lua::new();
+        let maki = lua.create_table().unwrap();
+        add_packadd(&lua, &maki).unwrap();
+        let f: mlua::Function = maki.get("packadd").unwrap();
+        assert!(f.call::<()>("goal").is_err());
+    }
+}

--- a/maki-lua/src/api/pack.rs
+++ b/maki-lua/src/api/pack.rs
@@ -1,96 +1,986 @@
-//! `maki.packadd`, the activation path for a package under `pack/*/opt/`.
+//! `maki.pack`, modelled after Neovim's `vim.pack`.
+//!
+//! Declaring a package records it and returns. Nothing is cloned or loaded from
+//! inside the call, because `add` runs while `init.lua` is being sourced and
+//! every load path blocks on a reply from the same runtime thread the caller is
+//! occupying. The host installs and loads the recorded set afterwards, which is
+//! also the phase Neovim defers to.
 
 use std::sync::{Arc, Mutex};
 
-use mlua::{Lua, Result as LuaResult, Table};
+use maki_lua_macro::{lua_fn, lua_table};
+use maki_pack::{Spec, Version};
+use mlua::{Lua, Result as LuaResult, Table, Value as LuaValue};
+
+/// When a declared package should load.
+///
+/// The default follows Neovim: `false` while `init.lua` is being sourced, and
+/// `true` afterwards. Maki's startup has a phase after the init files that
+/// corresponds to the one Neovim defers to, so a package declared with no
+/// `load` still loads, just at that phase rather than inside the `add` call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LoadMode {
+    /// Load in the startup package phase.
+    Eager,
+    /// Installed and recorded, but not loaded until something activates it.
+    ///
+    /// Maki diverges from Neovim here on purpose. There, `load = false` means
+    /// `:packadd!`, and startup sources the package anyway, so the value barely
+    /// differs from `true`. A lazy trigger needs a state to delay, and Neovim
+    /// has no lazy loading, so it never needed one.
+    Dormant,
+    /// Dormant until one of these fires, then loaded once.
+    Triggered(Triggers),
+}
+
+/// What wakes a dormant package.
+///
+/// Event, command, and keymap are the lazy.nvim concepts that map onto maki.
+/// There is deliberately no module trigger: `require` resolves against the
+/// calling plugin's own root and binds the chunk to the caller's environment,
+/// so activating another package on a module miss would run downloaded code
+/// under whichever owner happened to require it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Triggers {
+    /// Host-fired event names. A plugin-fired `exec_autocmds` does not
+    /// activate a package, because that dispatch is synchronous and loading is
+    /// not.
+    pub event: Vec<String>,
+    /// Slash command names, with or without the leading slash.
+    pub cmd: Vec<String>,
+    /// Keys in Vim notation.
+    pub keys: Vec<String>,
+}
+
+impl Triggers {
+    pub fn is_empty(&self) -> bool {
+        self.event.is_empty() && self.cmd.is_empty() && self.keys.is_empty()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Declared {
+    pub spec: Spec,
+    pub load: LoadMode,
+    /// Ask before cloning this source. Cleared with `confirm = false`, which
+    /// is a statement that the source is already trusted, and never an
+    /// approval of the permissions the package asks for.
+    pub confirm: bool,
+}
+
+/// Everything `init.lua` declared, in declaration order.
+///
+/// Session state only. What is installed, and at which revision, lives in the
+/// lockfile, and this never holds a second opinion about it.
+#[derive(Debug, Default, Clone)]
+pub struct PackDeclarations {
+    pub specs: Vec<Declared>,
+    /// Operations recorded by Lua for the host to perform after the calling
+    /// task has exited. Nothing here runs inline: `update` and `del` unload an
+    /// owner, and unloading blocks on a reply from the runtime thread the
+    /// caller is occupying.
+    pub pending: Vec<PackOp>,
+}
+
+/// Where an update should move a package to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UpdateTarget {
+    /// Resolve `version` again and take what it points at now.
+    #[default]
+    Version,
+    /// Go back to the revision the lockfile records. This is the undo for an
+    /// update that moved to something broken.
+    Lockfile,
+}
+
+/// How an update should behave. One type, shared by `maki.pack.update` and by
+/// `/packupdate`, so a flag cannot mean one thing from Lua and another from
+/// the command line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct UpdateOptions {
+    pub target: UpdateTarget,
+    /// Do not contact the remote. Resolves against refs already on disk.
+    pub offline: bool,
+}
+
+impl UpdateOptions {
+    /// Narrows a remote policy to what `offline` allows. Offline always wins,
+    /// so no combination of options can reach the network against the user's
+    /// explicit instruction.
+    pub fn remote(&self, wanted: maki_pack::manager::Refresh) -> maki_pack::manager::Refresh {
+        if self.offline {
+            maki_pack::manager::Refresh::Never
+        } else {
+            wanted
+        }
+    }
+}
 
 /// A change to the installed set, requested from Lua.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PackOp {
-    /// Load a package that is installed but not loaded.
+    /// Fetch and move a package to what its version now resolves to.
+    Update {
+        name: String,
+        options: UpdateOptions,
+    },
+    /// Remove a package and its lockfile entry.
+    Delete { name: String },
+    /// Load a package that is installed but dormant.
     Activate { name: String },
-}
-
-/// What Lua recorded for the host to act on.
-///
-/// Session state only. Nothing here runs inline: loading an owner blocks on a
-/// reply from the runtime thread that the calling Lua task is occupying, so
-/// acting on a request from inside the call would wait on itself.
-#[derive(Debug, Default, Clone)]
-pub struct PackDeclarations {
-    pub pending: Vec<PackOp>,
 }
 
 pub type PackStore = Arc<Mutex<PackDeclarations>>;
 
-/// Registers `maki.packadd` on the root table.
+fn reject_unknown_fields(table: &Table, allowed: &[&str], context: &str) -> LuaResult<()> {
+    for pair in table.clone().pairs::<LuaValue, LuaValue>() {
+        let (key, _) = pair?;
+        let LuaValue::String(key) = key else {
+            return Err(mlua::Error::runtime(format!(
+                "{context}: field names must be strings"
+            )));
+        };
+        let key = key.to_str()?;
+        if !allowed.contains(&key.as_ref()) {
+            return Err(mlua::Error::runtime(format!(
+                "{context}: unknown field {key:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// The one place a spec's name is accepted, whichever form it arrived in.
 ///
-/// It sits beside the other always-available functions rather than in a table
-/// of its own, because activating code that is already installed and already
-/// approved is something any plugin may do.
-pub(crate) fn add_packadd(lua: &Lua, maki: &Table) -> LuaResult<()> {
-    maki.set("packadd", lua.create_function(packadd)?)
+/// The name becomes a directory under the package root, so it is refused here
+/// rather than reaching the filesystem.
+fn finish(spec: Spec) -> LuaResult<Spec> {
+    if maki_pack::git::http_source_has_userinfo(&spec.src) {
+        let source = crate::pack::sanitize_message(&maki_pack::git::redact(&spec.src));
+        return Err(mlua::Error::runtime(format!(
+            "pack.add: source {:?} contains HTTP credentials; use a Git credential helper instead",
+            source
+        )));
+    }
+    if !maki_pack::name_is_safe(&spec.name) {
+        let source = crate::pack::sanitize_message(&maki_pack::git::redact(&spec.src));
+        return Err(mlua::Error::runtime(format!(
+            "pack.add: {:?} is not a usable package name for {:?}; set 'name' explicitly",
+            spec.name, source
+        )));
+    }
+    if crate::loader::is_bundled(&spec.name) {
+        return Err(mlua::Error::runtime(format!(
+            "pack.add: {:?} is the name of a builtin plugin; set 'name' to something else",
+            spec.name
+        )));
+    }
+    Ok(spec)
 }
 
-fn packadd(lua: &Lua, name: String) -> LuaResult<()> {
-    enqueue(lua, PackOp::Activate { name })
+/// Reads a spec entry, which is either a string source or a table.
+fn parse_spec(value: LuaValue) -> LuaResult<Spec> {
+    let table = match value {
+        // Neovim accepts a bare string and treats it as `src`. It still goes
+        // through the name check below: a source whose name cannot be derived
+        // is no safer for having been written as a string.
+        LuaValue::String(s) => return finish(Spec::new(s.to_str()?.to_owned())),
+        LuaValue::Table(t) => t,
+        other => {
+            return Err(mlua::Error::runtime(format!(
+                "pack.add: each spec must be a string or a table, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    reject_unknown_fields(&table, &["src", "name", "version"], "pack.add spec")?;
+
+    let src = match table.get::<LuaValue>("src")? {
+        LuaValue::String(src) => src.to_str()?.to_owned(),
+        LuaValue::Nil => return Err(mlua::Error::runtime("pack.add: spec is missing 'src'")),
+        other => {
+            return Err(mlua::Error::runtime(format!(
+                "pack.add: 'src' must be a string, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    if src.trim().is_empty() {
+        return Err(mlua::Error::runtime("pack.add: 'src' must not be empty"));
+    }
+
+    let mut spec = Spec::new(src);
+    match table.get::<LuaValue>("name")? {
+        LuaValue::Nil => {}
+        LuaValue::String(name) => {
+            let name = name.to_str()?.to_owned();
+            if name.is_empty() {
+                return Err(mlua::Error::runtime("pack.add: 'name' must not be empty"));
+            }
+            spec = spec.with_name(name);
+        }
+        other => {
+            return Err(mlua::Error::runtime(format!(
+                "pack.add: 'name' must be a string, got {}",
+                other.type_name()
+            )));
+        }
+    }
+    spec =
+        match table.get::<LuaValue>("version")? {
+            LuaValue::Nil => spec,
+            LuaValue::String(s) => {
+                let revision = s.to_str()?.to_owned();
+                if revision.trim().is_empty() {
+                    return Err(mlua::Error::runtime(
+                        "pack.add: 'version' must not be empty",
+                    ));
+                }
+                spec.with_version(Version::Rev(revision))
+            }
+            LuaValue::Table(t) => {
+                let raw: String = t.get(super::version::RANGE_MARKER).map_err(|_| {
+                    mlua::Error::runtime(
+                        "pack.add: 'version' table must come from maki.version.range()",
+                    )
+                })?;
+                spec.with_version(Version::range(&raw).map_err(|e| {
+                    mlua::Error::runtime(format!("pack.add: bad version range: {e}"))
+                })?)
+            }
+            other => {
+                return Err(mlua::Error::runtime(format!(
+                    "pack.add: 'version' must be a string or maki.version.range(), got {}",
+                    other.type_name()
+                )));
+            }
+        };
+
+    finish(spec)
 }
 
-fn enqueue(lua: &Lua, op: PackOp) -> LuaResult<()> {
+/// Declare packages to install and load, like `vim.pack.add`.
+///
+/// Recording is all this does. The host installs and loads the declared set
+/// after `init.lua` finishes, so a slow clone never blocks the call and a
+/// package failure never stops maki from starting.
+///
+/// Only available inside `init.lua`. Declaring a package fetches code, so it is
+/// configuration rather than something a downloaded plugin may do.
+///
+/// @param specs table List of specs. Each is a source string, or a table with
+///   `src` (string, required), `name` (string), and `version` (string or
+///   `maki.version.range()`).
+/// @param opts table? Options: `load` (boolean|table) `false` installs the
+///   package without loading it, leaving it for `maki.packadd`; a table of
+///   `event`, `cmd`, and `keys` loads it the first time one of those fires.
+///   `confirm` (boolean) `false` clones a new source without asking, which
+///   states that the source is trusted and never approves its permissions.
+/// @example
+/// maki.pack.add({
+///   { src = "https://github.com/user/maki-goal", version = "main" },
+/// })
+#[lua_fn]
+fn add(lua: &Lua, specs: Table, opts: Option<Table>) -> LuaResult<()> {
+    let store = lua
+        .app_data_ref::<PackStore>()
+        .ok_or_else(|| mlua::Error::runtime("pack.add: not available here"))?
+        .clone();
+
+    let (load, confirm) = parse_options(opts)?;
+
+    let mut parsed = Vec::new();
+    for entry in specs.sequence_values::<LuaValue>() {
+        parsed.push(Declared {
+            spec: parse_spec(entry?)?,
+            load: load.clone(),
+            confirm,
+        });
+    }
+
+    let mut declarations = store.lock().expect("pack declarations");
+    for declared in parsed {
+        // Neovim keeps the first declaration of a name for the session.
+        if !declarations
+            .specs
+            .iter()
+            .any(|existing| existing.spec.name == declared.spec.name)
+        {
+            declarations.specs.push(declared);
+        }
+    }
+    Ok(())
+}
+
+/// Reads `opts.load`.
+///
+/// `nil` means the default, which is to load in the startup phase. `false`
+/// leaves the package dormant until something activates it.
+fn parse_options(opts: Option<Table>) -> LuaResult<(LoadMode, bool)> {
+    let Some(opts) = opts else {
+        return Ok((LoadMode::Eager, true));
+    };
+    reject_unknown_fields(&opts, &["load", "confirm"], "pack.add")?;
+    let confirm = match opts.get::<LuaValue>("confirm")? {
+        LuaValue::Nil => true,
+        LuaValue::Boolean(confirm) => confirm,
+        other => {
+            return Err(mlua::Error::runtime(format!(
+                "pack.add: 'confirm' must be a boolean, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    let load = match opts.get::<LuaValue>("load")? {
+        LuaValue::Nil => LoadMode::Eager,
+        LuaValue::Boolean(true) => LoadMode::Eager,
+        LuaValue::Boolean(false) => LoadMode::Dormant,
+        LuaValue::Table(t) => parse_triggers(&t)?,
+        other => {
+            return Err(mlua::Error::runtime(format!(
+                "pack.add: 'load' must be a boolean or a trigger table, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    Ok((load, confirm))
+}
+
+fn parse_triggers(table: &Table) -> LuaResult<LoadMode> {
+    reject_unknown_fields(table, &["event", "cmd", "keys"], "pack.add load")?;
+    let mut triggers = Triggers::default();
+    for (key, target) in [
+        ("event", &mut triggers.event),
+        ("cmd", &mut triggers.cmd),
+        ("keys", &mut triggers.keys),
+    ] {
+        match table.get::<LuaValue>(key)? {
+            LuaValue::Nil => {}
+            // Checked for the bare string too, not only for the list form.
+            // An empty name counts towards "some trigger was named" while
+            // matching nothing, which would leave the package dormant with
+            // nothing able to wake it.
+            LuaValue::String(s) => {
+                let entry = s.to_str()?.to_owned();
+                if entry.trim().is_empty() {
+                    return Err(mlua::Error::runtime(format!(
+                        "pack.add: '{key}' must not be empty"
+                    )));
+                }
+                target.push(entry);
+            }
+            LuaValue::Table(list) => {
+                for entry in list.sequence_values::<String>() {
+                    let entry = entry?;
+                    if entry.trim().is_empty() {
+                        return Err(mlua::Error::runtime(format!(
+                            "pack.add: empty {key} trigger"
+                        )));
+                    }
+                    target.push(entry);
+                }
+            }
+            other => {
+                return Err(mlua::Error::runtime(format!(
+                    "pack.add: '{key}' must be a string or a list, got {}",
+                    other.type_name()
+                )));
+            }
+        }
+    }
+    // An empty table would leave the package dormant with nothing able to wake
+    // it, which is almost certainly a typo rather than an intent.
+    if triggers.is_empty() {
+        return Err(mlua::Error::runtime(
+            "pack.add: 'load' table names no trigger; use event, cmd, or keys",
+        ));
+    }
+    Ok(LoadMode::Triggered(triggers))
+}
+
+/// Records an operation for the host, rejecting an unusable name first.
+fn enqueue(lua: &Lua, op: PackOp, name: &str) -> LuaResult<()> {
+    if !maki_pack::name_is_safe(name) {
+        return Err(mlua::Error::runtime(format!(
+            "pack: {name:?} is not a usable package name"
+        )));
+    }
     let store = lua
         .app_data_ref::<PackStore>()
         .ok_or_else(|| mlua::Error::runtime("pack: not available here"))?
         .clone();
     let mut declarations = store.lock().expect("pack declarations");
-    // Two calls naming one package still load it once. The name is checked
-    // against what discovery found when the host drains this, so an unknown
-    // one is reported there rather than guessed at here.
     if !declarations.pending.contains(&op) {
         declarations.pending.push(op);
     }
     Ok(())
 }
 
+/// Update packages to what their version now resolves to, like
+/// `vim.pack.update`.
+///
+/// The work happens after this call returns, because updating unloads and
+/// reloads the package and unloading waits on the runtime this call occupies.
+///
+/// @param names table? Package names. Omit for every declared package.
+/// @param opts table? `offline` to work without the network, and `target` of
+///   `"version"` (the default) to take what version now resolves to, or
+///   `"lockfile"` to go back to the recorded revision.
+/// @example
+/// maki.pack.update({ "maki-goal" })
+/// maki.pack.update(nil, { target = "lockfile" })
+#[lua_fn]
+fn update(lua: &Lua, names: Option<Table>, opts: Option<Table>) -> LuaResult<()> {
+    let options = parse_update_options(opts)?;
+    let names = names_arg(names)?;
+    // Omitting the argument means every declared package, which is what the
+    // documentation has always said. Enumerating them here rather than at the
+    // point of application keeps one meaning of "which packages" and lets a
+    // name be validated the same way whether it was typed or implied.
+    let names = if names.is_empty() {
+        declared_names(lua)?
+    } else {
+        names
+    };
+    for name in names {
+        enqueue(
+            lua,
+            PackOp::Update {
+                name: name.clone(),
+                options,
+            },
+            &name,
+        )?;
+    }
+    Ok(())
+}
+
+/// Every package name `maki.pack.add` declared, in declaration order.
+fn declared_names(lua: &Lua) -> LuaResult<Vec<String>> {
+    let store = lua
+        .app_data_ref::<PackStore>()
+        .ok_or_else(|| mlua::Error::runtime("pack: not available here"))?
+        .clone();
+    let declarations = store.lock().expect("pack declarations");
+    Ok(declarations
+        .specs
+        .iter()
+        .map(|d| d.spec.name.clone())
+        .collect())
+}
+
+/// Reads the option table shared by `maki.pack.update` and `/packupdate`.
+fn parse_update_options(opts: Option<Table>) -> LuaResult<UpdateOptions> {
+    let Some(opts) = opts else {
+        return Ok(UpdateOptions::default());
+    };
+    let offline = match opts.get::<LuaValue>("offline")? {
+        LuaValue::Nil => false,
+        LuaValue::Boolean(b) => b,
+        other => {
+            return Err(mlua::Error::runtime(format!(
+                "pack.update: 'offline' must be a boolean, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    let target = match opts.get::<LuaValue>("target")? {
+        LuaValue::Nil => UpdateTarget::Version,
+        LuaValue::String(s) => match s.to_str()?.as_ref() {
+            "version" => UpdateTarget::Version,
+            "lockfile" => UpdateTarget::Lockfile,
+            other => {
+                return Err(mlua::Error::runtime(format!(
+                    "pack.update: 'target' must be \"version\" or \"lockfile\", got {other:?}"
+                )));
+            }
+        },
+        other => {
+            return Err(mlua::Error::runtime(format!(
+                "pack.update: 'target' must be a string, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    Ok(UpdateOptions { target, offline })
+}
+
+/// Remove packages, like `vim.pack.del`.
+///
+/// Runs after this call returns, for the same reason as `update`.
+///
+/// @param names table Package names to remove.
+/// @example
+/// maki.pack.del({ "maki-goal" })
+#[lua_fn]
+fn del(lua: &Lua, names: Table) -> LuaResult<()> {
+    let names = names_arg(Some(names))?;
+    if names.is_empty() {
+        return Err(mlua::Error::runtime("pack.del: name a package to remove"));
+    }
+    for name in names {
+        enqueue(lua, PackOp::Delete { name: name.clone() }, &name)?;
+    }
+    Ok(())
+}
+
+/// Activate an installed package that is not loaded, like `:packadd`.
+///
+/// This is how an `opt/` package, or one declared with no automatic load, is
+/// brought in. It is available to any plugin, unlike `add`, `update`, and
+/// `del`: activating code that is already installed and already approved is a
+/// much weaker act than fetching new code.
+///
+/// Loading happens after this call returns, for the same reason as `update`.
+///
+/// @param name string Package to activate.
+/// @example
+/// maki.packadd("maki-goal")
+#[lua_fn]
+fn packadd(lua: &Lua, name: String) -> LuaResult<()> {
+    enqueue(lua, PackOp::Activate { name: name.clone() }, &name)
+}
+
+/// Registers `maki.packadd` on the root table.
+///
+/// It sits beside the other always-available functions rather than inside
+/// `maki.pack`, because that table exists only for `init.lua` while activation
+/// is something any plugin may do.
+pub(crate) fn add_packadd(lua: &Lua, maki: &Table) -> LuaResult<()> {
+    maki.set("packadd", lua.create_function(packadd_raw)?)
+}
+
+fn packadd_raw(lua: &Lua, name: String) -> LuaResult<()> {
+    packadd(lua, name)
+}
+
+fn names_arg(names: Option<Table>) -> LuaResult<Vec<String>> {
+    let Some(table) = names else {
+        return Ok(Vec::new());
+    };
+    table.sequence_values::<String>().collect()
+}
+
+lua_table! {
+    /// Declaring external packages, modelled after `vim.pack`.
+    ///
+    /// Available only inside `init.lua`, because installing a package fetches
+    /// code and that is a configuration decision rather than something a
+    /// plugin may do for itself.
+    ///
+    /// ```lua
+    /// maki.pack.add({ "https://github.com/user/maki-goal" })
+    /// ```
+    "maki.pack" => pub(crate) fn create_pack_table(), DOCS [
+        add, update, del,
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::version::create_version_table;
 
     fn lua_with_store() -> (Lua, PackStore) {
         let lua = Lua::new();
-        let store = PackStore::default();
+        let store: PackStore = Arc::default();
         lua.set_app_data(store.clone());
         (lua, store)
     }
 
+    fn add_fn(lua: &Lua) -> mlua::Function {
+        create_pack_table(lua).unwrap().get("add").unwrap()
+    }
+
     #[test]
-    fn packadd_records_each_named_package_once() {
+    fn a_bare_string_is_treated_as_a_source() {
         let (lua, store) = lua_with_store();
-        let maki = lua.create_table().unwrap();
-        add_packadd(&lua, &maki).unwrap();
-        let f: mlua::Function = maki.get("packadd").expect("packadd is on the root table");
-        f.call::<()>("goal").unwrap();
-        f.call::<()>("review").unwrap();
-        f.call::<()>("goal").unwrap();
+        let specs = lua
+            .create_sequence_from(["https://github.com/user/repo"])
+            .unwrap();
+        add_fn(&lua).call::<()>(specs).unwrap();
+
+        let declared = store.lock().unwrap();
+        assert_eq!(declared.specs.len(), 1);
+        assert_eq!(declared.specs[0].spec.src, "https://github.com/user/repo");
+        assert_eq!(declared.specs[0].spec.name, "repo", "name derived from src");
+    }
+
+    #[test]
+    fn a_table_spec_carries_name_and_version() {
+        let (lua, store) = lua_with_store();
+        let spec = lua.create_table().unwrap();
+        spec.set("src", "https://github.com/user/repo").unwrap();
+        spec.set("name", "custom").unwrap();
+        spec.set("version", "v1.2.3").unwrap();
+        let specs = lua.create_sequence_from([spec]).unwrap();
+        add_fn(&lua).call::<()>(specs).unwrap();
+
+        let declared = store.lock().unwrap();
+        assert_eq!(declared.specs[0].spec.name, "custom");
         assert_eq!(
-            store.lock().unwrap().pending,
-            vec![
-                PackOp::Activate {
-                    name: "goal".to_owned()
-                },
-                PackOp::Activate {
-                    name: "review".to_owned()
-                }
-            ],
-            "a repeated call must not load the package twice"
+            declared.specs[0].spec.version,
+            Version::Rev("v1.2.3".to_owned())
         );
     }
 
     #[test]
-    fn packadd_without_a_store_reports_rather_than_panicking() {
-        let lua = Lua::new();
+    fn a_range_from_version_range_is_accepted() {
+        let (lua, store) = lua_with_store();
+        let range_fn: mlua::Function = create_version_table(&lua).unwrap().get("range").unwrap();
+        let range: Table = range_fn.call("^1.2").unwrap();
+
+        let spec = lua.create_table().unwrap();
+        spec.set("src", "https://github.com/user/repo").unwrap();
+        spec.set("version", range).unwrap();
+        let specs = lua.create_sequence_from([spec]).unwrap();
+        add_fn(&lua).call::<()>(specs).unwrap();
+
+        assert!(matches!(
+            store.lock().unwrap().specs[0].spec.version,
+            Version::Range(_)
+        ));
+    }
+
+    /// An arbitrary table is not a constraint, so it must not be mistaken for
+    /// one and silently ignored.
+    #[test]
+    fn a_plain_table_version_is_rejected() {
+        let (lua, _store) = lua_with_store();
+        let spec = lua.create_table().unwrap();
+        spec.set("src", "https://github.com/user/repo").unwrap();
+        spec.set("version", lua.create_table().unwrap()).unwrap();
+        let specs = lua.create_sequence_from([spec]).unwrap();
+        assert!(add_fn(&lua).call::<()>(specs).is_err());
+    }
+
+    #[test]
+    fn a_spec_without_src_is_rejected() {
+        let (lua, _store) = lua_with_store();
+        let spec = lua.create_table().unwrap();
+        spec.set("name", "orphan").unwrap();
+        let specs = lua.create_sequence_from([spec]).unwrap();
+        assert!(add_fn(&lua).call::<()>(specs).is_err());
+    }
+
+    /// The name becomes a directory, so an unsafe one is refused here rather
+    /// than reaching the filesystem.
+    #[test]
+    fn an_unsafe_name_is_refused() {
+        let (lua, _store) = lua_with_store();
+        for bad in ["../escape", "/etc", "a/b"] {
+            let spec = lua.create_table().unwrap();
+            spec.set("src", "https://github.com/user/repo").unwrap();
+            spec.set("name", bad).unwrap();
+            let specs = lua.create_sequence_from([spec]).unwrap();
+            assert!(add_fn(&lua).call::<()>(specs).is_err(), "{bad} allowed");
+        }
+    }
+
+    #[test]
+    fn an_unsafe_name_error_redacts_source_credentials() {
+        let (lua, _store) = lua_with_store();
+        let spec = lua.create_table().unwrap();
+        spec.set("src", "https://secret@example.com/repo").unwrap();
+        spec.set("name", "../escape").unwrap();
+        let specs = lua.create_sequence_from([spec]).unwrap();
+
+        let error = add_fn(&lua).call::<()>(specs).unwrap_err().to_string();
+
+        assert!(!error.contains("secret"));
+        assert!(error.contains("https://***@example.com/repo"));
+    }
+
+    #[test]
+    fn http_credentials_are_rejected_before_installation() {
+        let (lua, store) = lua_with_store();
+        let specs = lua
+            .create_sequence_from(["https://user:secret@example.com/repo"])
+            .unwrap();
+
+        let error = add_fn(&lua).call::<()>(specs).unwrap_err().to_string();
+
+        assert!(!error.contains("secret"), "credential leaked: {error}");
+        assert!(error.contains("Git credential helper"));
+        assert!(store.lock().unwrap().specs.is_empty());
+    }
+
+    #[test]
+    fn a_non_string_name_is_rejected() {
+        let (lua, _store) = lua_with_store();
+        let spec = lua.create_table().unwrap();
+        spec.set("src", "https://github.com/user/repo").unwrap();
+        spec.set("name", 7).unwrap();
+        let specs = lua.create_sequence_from([spec]).unwrap();
+
+        assert!(add_fn(&lua).call::<()>(specs).is_err());
+    }
+
+    #[test]
+    fn an_empty_name_is_rejected() {
+        let (lua, store) = lua_with_store();
+        let spec = lua.create_table().unwrap();
+        spec.set("src", "https://github.com/user/repo").unwrap();
+        spec.set("name", "").unwrap();
+        let specs = lua.create_sequence_from([spec]).unwrap();
+
+        assert!(add_fn(&lua).call::<()>(specs).is_err());
+        assert!(store.lock().unwrap().specs.is_empty());
+    }
+
+    #[test]
+    fn unknown_spec_and_option_fields_are_rejected() {
+        let (lua, store) = lua_with_store();
+        let spec = lua.create_table().unwrap();
+        spec.set("src", "https://github.com/user/repo").unwrap();
+        spec.set("typo", true).unwrap();
+        let specs = lua.create_sequence_from([spec]).unwrap();
+        assert!(add_fn(&lua).call::<()>(specs).is_err());
+
+        let specs = lua
+            .create_sequence_from(["https://github.com/user/repo"])
+            .unwrap();
+        let opts = lua.create_table().unwrap();
+        opts.set("typo", true).unwrap();
+        assert!(add_fn(&lua).call::<()>((specs, opts)).is_err());
+        assert!(store.lock().unwrap().specs.is_empty());
+    }
+
+    #[test]
+    fn a_builtin_owner_name_is_rejected() {
+        let (lua, _store) = lua_with_store();
+        let spec = lua.create_table().unwrap();
+        spec.set("src", "https://github.com/user/repo").unwrap();
+        spec.set("name", "bash").unwrap();
+        let specs = lua.create_sequence_from([spec]).unwrap();
+
+        let error = add_fn(&lua).call::<()>(specs).unwrap_err().to_string();
+
+        assert!(error.contains("builtin plugin"));
+    }
+
+    /// A source whose name cannot be derived has to be named explicitly rather
+    /// than installed under an empty directory name.
+    #[test]
+    fn a_source_with_no_derivable_name_is_refused() {
+        let (lua, _store) = lua_with_store();
+        let specs = lua.create_sequence_from(["///"]).unwrap();
+        assert!(add_fn(&lua).call::<()>(specs).is_err());
+    }
+
+    #[test]
+    fn the_first_declaration_of_a_name_wins() {
+        let (lua, store) = lua_with_store();
+        let first = lua.create_table().unwrap();
+        first.set("src", "https://github.com/user/a").unwrap();
+        first.set("name", "pkg").unwrap();
+        let second = lua.create_table().unwrap();
+        second.set("src", "https://github.com/user/b").unwrap();
+        second.set("name", "pkg").unwrap();
+
+        add_fn(&lua)
+            .call::<()>(lua.create_sequence_from([first]).unwrap())
+            .unwrap();
+        add_fn(&lua)
+            .call::<()>(lua.create_sequence_from([second]).unwrap())
+            .unwrap();
+
+        let declared = store.lock().unwrap();
+        assert_eq!(declared.specs.len(), 1);
+        assert_eq!(declared.specs[0].spec.src, "https://github.com/user/a");
+    }
+
+    fn call(lua: &Lua, name: &str, arg: Table) -> mlua::Result<()> {
+        let f: mlua::Function = create_pack_table(lua).unwrap().get(name).unwrap();
+        f.call(arg)
+    }
+
+    /// Mutating calls record work and return. Doing it inline would unload an
+    /// owner, and unloading waits on the runtime thread the call occupies.
+    #[test]
+    fn update_and_del_record_work_rather_than_doing_it() {
+        let (lua, store) = lua_with_store();
+        call(&lua, "update", lua.create_sequence_from(["a"]).unwrap()).unwrap();
+        call(&lua, "del", lua.create_sequence_from(["b"]).unwrap()).unwrap();
+
+        let pending = store.lock().unwrap().pending.clone();
+        assert_eq!(
+            pending,
+            vec![
+                PackOp::Update {
+                    name: "a".to_owned(),
+                    options: UpdateOptions::default(),
+                },
+                PackOp::Delete {
+                    name: "b".to_owned()
+                },
+            ]
+        );
+    }
+
+    /// `packadd` is what makes an `opt/` package reachable at all, so it must
+    /// register on the root table and queue an activation.
+    #[test]
+    fn packadd_registers_on_the_root_table_and_queues_activation() {
+        let (lua, store) = lua_with_store();
+        let maki = lua.create_table().unwrap();
+        add_packadd(&lua, &maki).unwrap();
+
+        let f: mlua::Function = maki.get("packadd").expect("packadd should be registered");
+        f.call::<()>("demo").unwrap();
+
+        assert_eq!(
+            store.lock().unwrap().pending,
+            vec![PackOp::Activate {
+                name: "demo".to_owned()
+            }]
+        );
+    }
+
+    #[test]
+    fn packadd_refuses_an_unsafe_name() {
+        let (lua, store) = lua_with_store();
         let maki = lua.create_table().unwrap();
         add_packadd(&lua, &maki).unwrap();
         let f: mlua::Function = maki.get("packadd").unwrap();
-        assert!(f.call::<()>("goal").is_err());
+
+        assert!(f.call::<()>("../escape").is_err());
+        assert!(store.lock().unwrap().pending.is_empty());
+    }
+
+    /// Omitting `load` still loads the package, at the startup phase rather
+    /// than inside the call, which is what Neovim's default defers to.
+    #[test]
+    fn a_declaration_without_load_is_eager() {
+        let (lua, store) = lua_with_store();
+        let specs = lua
+            .create_sequence_from(["https://github.com/user/repo"])
+            .unwrap();
+        add_fn(&lua).call::<()>(specs).unwrap();
+        assert_eq!(store.lock().unwrap().specs[0].load, LoadMode::Eager);
+    }
+
+    /// `load = false` is what a lazy trigger will later delay, so it has to be
+    /// a real dormant state rather than a synonym for `true`.
+    #[test]
+    fn load_false_leaves_the_package_dormant() {
+        let (lua, store) = lua_with_store();
+        let specs = lua
+            .create_sequence_from(["https://github.com/user/repo"])
+            .unwrap();
+        let opts = lua.create_table().unwrap();
+        opts.set("load", false).unwrap();
+
+        let f: mlua::Function = create_pack_table(&lua).unwrap().get("add").unwrap();
+        f.call::<()>((specs, opts)).unwrap();
+        assert_eq!(store.lock().unwrap().specs[0].load, LoadMode::Dormant);
+    }
+
+    #[test]
+    fn a_trigger_table_records_its_triggers() {
+        let (lua, store) = lua_with_store();
+        let specs = lua
+            .create_sequence_from(["https://github.com/user/repo"])
+            .unwrap();
+        let load = lua.create_table().unwrap();
+        load.set("event", lua.create_sequence_from(["TurnStart"]).unwrap())
+            .unwrap();
+        load.set("cmd", "/demo").unwrap();
+        let opts = lua.create_table().unwrap();
+        opts.set("load", load).unwrap();
+
+        let f: mlua::Function = create_pack_table(&lua).unwrap().get("add").unwrap();
+        f.call::<()>((specs, opts)).unwrap();
+
+        let declared = store.lock().unwrap();
+        let LoadMode::Triggered(triggers) = &declared.specs[0].load else {
+            panic!(
+                "expected a triggered load, got {:?}",
+                declared.specs[0].load
+            );
+        };
+        assert_eq!(triggers.event, vec!["TurnStart".to_owned()]);
+        assert_eq!(
+            triggers.cmd,
+            vec!["/demo".to_owned()],
+            "a bare string counts"
+        );
+        assert!(triggers.keys.is_empty());
+    }
+
+    /// A table naming no trigger leaves the package dormant with nothing able
+    /// to wake it, which is a typo rather than an intent.
+    #[test]
+    fn an_empty_trigger_table_is_rejected() {
+        let (lua, _store) = lua_with_store();
+        let specs = lua
+            .create_sequence_from(["https://github.com/user/repo"])
+            .unwrap();
+        let opts = lua.create_table().unwrap();
+        opts.set("load", lua.create_table().unwrap()).unwrap();
+
+        let f: mlua::Function = create_pack_table(&lua).unwrap().get("add").unwrap();
+        assert!(f.call::<()>((specs, opts)).is_err());
+    }
+
+    #[test]
+    fn a_non_boolean_load_is_rejected() {
+        let (lua, _store) = lua_with_store();
+        let specs = lua
+            .create_sequence_from(["https://github.com/user/repo"])
+            .unwrap();
+        let opts = lua.create_table().unwrap();
+        opts.set("load", 7).unwrap();
+
+        let f: mlua::Function = create_pack_table(&lua).unwrap().get("add").unwrap();
+        assert!(f.call::<()>((specs, opts)).is_err());
+    }
+
+    #[test]
+    fn the_same_operation_is_not_queued_twice() {
+        let (lua, store) = lua_with_store();
+        for _ in 0..3 {
+            call(&lua, "update", lua.create_sequence_from(["a"]).unwrap()).unwrap();
+        }
+        assert_eq!(store.lock().unwrap().pending.len(), 1);
+    }
+
+    /// A name reaches the filesystem, so it is refused here rather than later.
+    #[test]
+    fn an_unsafe_name_is_refused_by_update_and_del() {
+        let (lua, store) = lua_with_store();
+        for bad in ["../escape", "/etc"] {
+            assert!(call(&lua, "update", lua.create_sequence_from([bad]).unwrap()).is_err());
+            assert!(call(&lua, "del", lua.create_sequence_from([bad]).unwrap()).is_err());
+        }
+        assert!(store.lock().unwrap().pending.is_empty());
+    }
+
+    /// Deleting nothing is a mistake worth reporting, unlike updating
+    /// everything, which is what Neovim's omitted names mean.
+    #[test]
+    fn del_requires_a_name() {
+        let (lua, _store) = lua_with_store();
+        assert!(call(&lua, "del", lua.create_table().unwrap()).is_err());
+    }
+
+    #[test]
+    fn declaration_order_is_preserved() {
+        let (lua, store) = lua_with_store();
+        let specs = lua
+            .create_sequence_from([
+                "https://github.com/user/first",
+                "https://github.com/user/second",
+            ])
+            .unwrap();
+        add_fn(&lua).call::<()>(specs).unwrap();
+
+        let declared = store.lock().unwrap();
+        let names: Vec<&str> = declared
+            .specs
+            .iter()
+            .map(|d| d.spec.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["first", "second"]);
     }
 }

--- a/maki-lua/src/api/pack.rs
+++ b/maki-lua/src/api/pack.rs
@@ -7,11 +7,15 @@
 //! also the phase Neovim defers to.
 
 use std::collections::BTreeSet;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use maki_lua_macro::{lua_fn, lua_table};
+
+use crate::api::options::PluginOpts;
+use crate::plugin_permissions::PluginPermissions;
 use maki_pack::{Spec, Version};
-use mlua::{Lua, Result as LuaResult, Table, Value as LuaValue};
+use mlua::{Lua, RegistryKey, Result as LuaResult, Table, Value as LuaValue};
 
 /// When a declared package should load.
 ///
@@ -32,6 +36,12 @@ pub enum LoadMode {
     Dormant,
     /// Dormant until one of these fires, then loaded once.
     Triggered(Triggers),
+    /// The function supplied by `opts.load` is fully responsible for loading.
+    ///
+    /// It carries the function rather than sitting beside an `Option` field,
+    /// so "custom with no loader" cannot be built and no caller has to handle
+    /// a case that has no meaning.
+    Custom(Arc<RegistryKey>),
 }
 
 /// What wakes a dormant package.
@@ -47,7 +57,8 @@ pub struct Triggers {
     /// activate a package, because that dispatch is synchronous and loading is
     /// not.
     pub event: Vec<String>,
-    /// Slash command names, with or without the leading slash.
+    /// Slash command names, always stored with the leading slash so they match
+    /// what `register_command` records.
     pub cmd: Vec<String>,
     /// Keys in Vim notation.
     pub keys: Vec<String>,
@@ -63,19 +74,17 @@ impl Triggers {
 pub struct Declared {
     pub spec: Spec,
     pub load: LoadMode,
-    /// Ask before cloning this source. Cleared with `confirm = false`, which
-    /// is a statement that the source is already trusted, and never an
-    /// approval of the permissions the package asks for.
     pub confirm: bool,
+    /// Opaque Lua data retained in the runtime registry.
+    pub data: Option<Arc<RegistryKey>>,
 }
 
 impl Declared {
-    /// Whether this package loads in the startup phase.
-    ///
-    /// Asked by callers outside this crate too, so it is one method rather
-    /// than a `LoadMode` match repeated in each of them.
-    pub fn is_eager(&self) -> bool {
-        matches!(self.load, LoadMode::Eager)
+    /// Whether this entry point must load the package during startup.
+    pub fn loads_at_start(&self, delivers_agent_events: bool) -> bool {
+        matches!(self.load, LoadMode::Eager | LoadMode::Custom(_))
+            || (!delivers_agent_events
+                && matches!(&self.load, LoadMode::Triggered(t) if !t.event.is_empty()))
     }
 }
 
@@ -86,6 +95,8 @@ impl Declared {
 #[derive(Debug, Default, Clone)]
 pub struct PackDeclarations {
     pub specs: Vec<Declared>,
+    /// `confirm` from the first `add` call, including an empty call.
+    pub lock_confirm: Option<bool>,
     /// Package owners that loaded successfully in this runtime.
     pub active: BTreeSet<String>,
     /// Operations recorded by Lua for the host to perform after the calling
@@ -93,6 +104,49 @@ pub struct PackDeclarations {
     /// owner, and unloading blocks on a reply from the runtime thread the
     /// caller is occupying.
     pub pending: Vec<PackOp>,
+    /// Packages installed but not loaded, with what should wake them.
+    ///
+    /// `None` means startup has not built the activation catalog yet, so
+    /// `maki.packadd` must record a host operation. `Some` means the runtime
+    /// owns activation, including when the catalog is empty.
+    pub dormant: Option<Vec<Dormant>>,
+}
+
+/// One installed, unloaded package and the triggers that activate it.
+#[derive(Debug, Clone)]
+pub struct Dormant {
+    pub name: String,
+    /// Where the package was installed. The runtime reads its entrypoints from
+    /// here when a trigger fires.
+    pub dir: PathBuf,
+    /// Already narrowed by origin and approval. Stored rather than recomputed,
+    /// so activation cannot accidentally grant more than a startup load would.
+    pub permissions: PluginPermissions,
+    pub opts: PluginOpts,
+    pub triggers: Triggers,
+    pub state: PackState,
+}
+
+/// Whether activation may still be attempted for a dormant package.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum PackState {
+    #[default]
+    Inactive,
+    /// A load that failed is not retried. Retrying on every keystroke would
+    /// run a broken package's top level over and over.
+    Failed(String),
+}
+
+impl Dormant {
+    /// Whether this package answers to a command name.
+    pub fn handles_command(&self, command: &str) -> bool {
+        self.triggers.cmd.iter().any(|c| c == command)
+    }
+
+    /// Whether a trigger may still start a load.
+    pub fn is_startable(&self) -> bool {
+        matches!(self.state, PackState::Inactive)
+    }
 }
 
 /// Where an update should move a package to.
@@ -114,6 +168,8 @@ pub struct UpdateOptions {
     pub target: UpdateTarget,
     /// Do not contact the remote. Resolves against refs already on disk.
     pub offline: bool,
+    /// Skip update review. Permission approval remains separate.
+    pub force: bool,
 }
 
 impl UpdateOptions {
@@ -138,9 +194,34 @@ pub enum PackOp {
         options: UpdateOptions,
     },
     /// Remove a package and its lockfile entry.
-    Delete { name: String },
+    Delete { name: String, force: bool },
     /// Load a package that is installed but dormant.
     Activate { name: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackChangeKind {
+    Install,
+    Update,
+    Delete,
+}
+
+impl PackChangeKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Install => "install",
+            Self::Update => "update",
+            Self::Delete => "delete",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PackChange {
+    pub declared: Declared,
+    pub active: bool,
+    pub kind: PackChangeKind,
+    pub path: PathBuf,
 }
 
 pub type PackStore = Arc<Mutex<PackDeclarations>>;
@@ -182,6 +263,11 @@ fn finish(spec: Spec) -> LuaResult<Spec> {
             spec.name, source
         )));
     }
+    // A package name is an owner name, and an owner name is what unloading
+    // takes. Letting a package be called `bash` would make `pack.del("bash")`
+    // tear down the bundled bash tool, its keymaps, and its hints, so the name
+    // is refused here rather than at the point of damage. Manual discovery
+    // already refuses the same names.
     if crate::loader::is_bundled(&spec.name) {
         return Err(mlua::Error::runtime(format!(
             "pack.add: {:?} is the name of a builtin plugin; set 'name' to something else",
@@ -192,12 +278,14 @@ fn finish(spec: Spec) -> LuaResult<Spec> {
 }
 
 /// Reads a spec entry, which is either a string source or a table.
-fn parse_spec(value: LuaValue) -> LuaResult<Spec> {
+fn parse_spec(lua: &Lua, value: LuaValue) -> LuaResult<(Spec, Option<Arc<RegistryKey>>)> {
     let table = match value {
         // Neovim accepts a bare string and treats it as `src`. It still goes
         // through the name check below: a source whose name cannot be derived
         // is no safer for having been written as a string.
-        LuaValue::String(s) => return finish(Spec::new(s.to_str()?.to_owned())),
+        LuaValue::String(s) => {
+            return finish(Spec::new(s.to_str()?.to_owned())).map(|spec| (spec, None));
+        }
         LuaValue::Table(t) => t,
         other => {
             return Err(mlua::Error::runtime(format!(
@@ -206,11 +294,13 @@ fn parse_spec(value: LuaValue) -> LuaResult<Spec> {
             )));
         }
     };
-    reject_unknown_fields(&table, &["src", "name", "version"], "pack.add spec")?;
+    reject_unknown_fields(&table, &["src", "name", "version", "data"], "pack.add spec")?;
 
     let src = match table.get::<LuaValue>("src")? {
+        LuaValue::Nil => {
+            return Err(mlua::Error::runtime("pack.add: spec is missing 'src'"));
+        }
         LuaValue::String(src) => src.to_str()?.to_owned(),
-        LuaValue::Nil => return Err(mlua::Error::runtime("pack.add: spec is missing 'src'")),
         other => {
             return Err(mlua::Error::runtime(format!(
                 "pack.add: 'src' must be a string, got {}",
@@ -242,14 +332,14 @@ fn parse_spec(value: LuaValue) -> LuaResult<Spec> {
     spec =
         match table.get::<LuaValue>("version")? {
             LuaValue::Nil => spec,
-            LuaValue::String(s) => {
-                let revision = s.to_str()?.to_owned();
-                if revision.trim().is_empty() {
+            LuaValue::String(version) => {
+                let version = version.to_str()?.to_owned();
+                if version.trim().is_empty() {
                     return Err(mlua::Error::runtime(
                         "pack.add: 'version' must not be empty",
                     ));
                 }
-                spec.with_version(Version::Rev(revision))
+                spec.with_version(Version::Rev(version))
             }
             LuaValue::Table(t) => {
                 let raw: String = t.get(super::version::RANGE_MARKER).map_err(|_| {
@@ -269,7 +359,12 @@ fn parse_spec(value: LuaValue) -> LuaResult<Spec> {
             }
         };
 
-    finish(spec)
+    let data = match table.get::<LuaValue>("data")? {
+        LuaValue::Nil => None,
+        value => Some(Arc::new(lua.create_registry_value(value)?)),
+    };
+
+    finish(spec).map(|spec| (spec, data))
 }
 
 /// Declare packages to install and load, like `vim.pack.add`.
@@ -277,20 +372,24 @@ fn parse_spec(value: LuaValue) -> LuaResult<Spec> {
 /// Recording is all this does. The host installs and loads the declared set
 /// after `init.lua` finishes, so a slow clone never blocks the call and a
 /// package failure never stops maki from starting.
+/// The first declaration of a package name wins for the current session.
 ///
 /// Only available inside `init.lua`. Declaring a package fetches code, so it is
 /// configuration rather than something a downloaded plugin may do.
 ///
 /// @param specs table List of specs. Each is a source string, or a table with
-///   `src` (string, required), `name` (string), and `version` (string or
-///   `maki.version.range()`).
-/// @param opts table? Options: `load` (boolean|table) `false` installs the
-///   package without loading it, leaving it for `maki.packadd`; a table of
-///   `event`, `cmd`, and `keys` names what should wake it. Trigger tables are
-///   recorded and checked but not dispatched yet, so a package that declares
-///   one installs and stays dormant until `maki.packadd` activates it.
-///   `confirm` (boolean) `false` clones a new source without asking, which
-///   states that the source is trusted and never approves its permissions.
+///   `src` (string, required), `name` (string), `version` (string or
+///   `maki.version.range()`), and arbitrary `data` passed to `get`, change
+///   events, and a custom loader.
+/// @param opts table? Options: `confirm` (boolean, default true) asks before
+///   installation. `load` (boolean|table|function) controls loading. `false`
+///   leaves the package for `maki.packadd`. A table of `event`, `cmd`, and
+///   `keys` names what wakes it. A function runs as the package owner with
+///   `{ spec, path }` and is fully responsible for loading it. Credentials in
+///   `spec.src` are redacted. The first
+///   trigger loads the package and is then delivered to it. `event` accepts
+///   only the host events that `create_autocmd` documents.
+///   HTTP sources with credentials are rejected; use a Git credential helper.
 /// @example
 /// maki.pack.add({
 ///   { src = "https://github.com/user/maki-goal", version = "main" },
@@ -302,31 +401,22 @@ fn add(lua: &Lua, specs: Table, opts: Option<Table>) -> LuaResult<()> {
         .ok_or_else(|| mlua::Error::runtime("pack.add: not available here"))?
         .clone();
 
-    let (load, confirm) = parse_options(opts)?;
+    let (load, confirm) = parse_options(lua, opts)?;
 
     let mut parsed = Vec::new();
     for entry in specs.sequence_values::<LuaValue>() {
+        let (spec, data) = parse_spec(lua, entry?)?;
         parsed.push(Declared {
-            spec: parse_spec(entry?)?,
+            spec,
             load: load.clone(),
             confirm,
+            data,
         });
     }
 
     let mut declarations = store.lock().expect("pack declarations");
+    declarations.lock_confirm.get_or_insert(confirm);
     for declared in parsed {
-        // Said plainly rather than left to be discovered. The triggers are
-        // recorded and validated, but nothing dispatches on them yet, so the
-        // package installs and waits. Staying dormant is the safe half of the
-        // feature; silently never waking would not be.
-        if let LoadMode::Triggered(_) = &declared.load {
-            tracing::warn!(
-                package = %declared.spec.name,
-                "lazy triggers are recorded but not dispatched yet; \
-                 the package stays dormant until maki.packadd activates it"
-            );
-        }
-        // Neovim keeps the first declaration of a name for the session.
         if !declarations
             .specs
             .iter()
@@ -342,11 +432,11 @@ fn add(lua: &Lua, specs: Table, opts: Option<Table>) -> LuaResult<()> {
 ///
 /// `nil` means the default, which is to load in the startup phase. `false`
 /// leaves the package dormant until something activates it.
-fn parse_options(opts: Option<Table>) -> LuaResult<(LoadMode, bool)> {
+fn parse_options(lua: &Lua, opts: Option<Table>) -> LuaResult<(LoadMode, bool)> {
     let Some(opts) = opts else {
         return Ok((LoadMode::Eager, true));
     };
-    reject_unknown_fields(&opts, &["load", "confirm"], "pack.add")?;
+    reject_unknown_fields(&opts, &["confirm", "load"], "pack.add")?;
     let confirm = match opts.get::<LuaValue>("confirm")? {
         LuaValue::Nil => true,
         LuaValue::Boolean(confirm) => confirm,
@@ -358,18 +448,40 @@ fn parse_options(opts: Option<Table>) -> LuaResult<(LoadMode, bool)> {
         }
     };
     let load = match opts.get::<LuaValue>("load")? {
-        LuaValue::Nil => LoadMode::Eager,
-        LuaValue::Boolean(true) => LoadMode::Eager,
+        LuaValue::Nil | LuaValue::Boolean(true) => LoadMode::Eager,
         LuaValue::Boolean(false) => LoadMode::Dormant,
         LuaValue::Table(t) => parse_triggers(&t)?,
+        LuaValue::Function(function) => {
+            LoadMode::Custom(Arc::new(lua.create_registry_value(function)?))
+        }
         other => {
             return Err(mlua::Error::runtime(format!(
-                "pack.add: 'load' must be a boolean or a trigger table, got {}",
+                "pack.add: 'load' must be a boolean, trigger table, or function, got {}",
                 other.type_name()
             )));
         }
     };
     Ok((load, confirm))
+}
+
+/// Command names are stored the way `register_command` stores them.
+///
+/// That call adds a leading slash if the name has none. A trigger recorded
+/// without one would publish `foo`, load the package, and then look for a
+/// handler registered as `/foo`, so the command that woke the package would
+/// not run.
+fn normalize_command(name: &str) -> LuaResult<String> {
+    let bare = name.strip_prefix('/').unwrap_or(name);
+    if bare.is_empty() || name.chars().any(char::is_whitespace) || name.ends_with('!') {
+        return Err(mlua::Error::runtime(format!(
+            "pack.add: invalid command trigger {name:?}"
+        )));
+    }
+    if name.starts_with('/') {
+        Ok(name.to_owned())
+    } else {
+        Ok(format!("/{name}"))
+    }
 }
 
 fn parse_triggers(table: &Table) -> LuaResult<LoadMode> {
@@ -414,8 +526,22 @@ fn parse_triggers(table: &Table) -> LuaResult<LoadMode> {
             }
         }
     }
-    // An empty table would leave the package dormant with nothing able to wake
-    // it, which is almost certainly a typo rather than an intent.
+    for cmd in &mut triggers.cmd {
+        *cmd = normalize_command(cmd)?;
+    }
+    for event in &triggers.event {
+        if !crate::api::autocmd::LAZY_EVENTS.contains(&event.as_str()) {
+            return Err(mlua::Error::runtime(format!(
+                "pack.add: {event:?} is not an event fired by the host"
+            )));
+        }
+    }
+    for key in &triggers.keys {
+        crate::api::keymap::parse_key_notation(key).map_err(|error| {
+            mlua::Error::runtime(format!("pack.add: invalid key trigger {key:?}: {error}"))
+        })?;
+    }
+    // An empty table would leave the package dormant with no way to wake it.
     if triggers.is_empty() {
         return Err(mlua::Error::runtime(
             "pack.add: 'load' table names no trigger; use event, cmd, or keys",
@@ -442,6 +568,132 @@ fn enqueue(lua: &Lua, op: PackOp, name: &str) -> LuaResult<()> {
     Ok(())
 }
 
+/// Gets managed package information, optionally filtered by name.
+///
+/// This is the read-only part of `maki.pack`, so packages may call it too.
+/// Information comes from the current declarations and lockfile and does not
+/// contact a remote.
+///
+/// @param names table? Package names. Omit for all managed packages.
+/// @param opts table? Reserved for future compatibility. Omit it.
+/// @return (table) Package records with `spec`, `path`, `rev`, and `active`.
+/// @example
+/// local packages = maki.pack.get({ "maki-goal" })
+#[lua_fn]
+fn get(lua: &Lua, names: Option<Table>, opts: Option<Table>) -> LuaResult<Table> {
+    validate_get_options(opts)?;
+    let names = names
+        .map(|table| table.sequence_values::<String>().collect())
+        .transpose()?;
+    let store = lua
+        .app_data_ref::<PackStore>()
+        .ok_or_else(|| mlua::Error::runtime("pack.get: not available here"))?
+        .clone();
+    let declarations = store.lock().expect("pack declarations").clone();
+    let lock = crate::pack::read_lockfile(crate::pack::lockfile_path().as_deref())
+        .ok_or_else(|| mlua::Error::runtime("pack.get: pack lockfile is unreadable"))?;
+
+    let order = match names {
+        Some(names) => names,
+        None => {
+            let mut names: Vec<String> = declarations
+                .specs
+                .iter()
+                .map(|declared| declared.spec.name.clone())
+                .collect();
+            let extras: Vec<String> = lock
+                .install_order()
+                .filter(|name| !names.iter().any(|known| known == name))
+                .map(str::to_owned)
+                .collect();
+            names.extend(extras);
+            names
+        }
+    };
+
+    // A missing data directory only means no path can be reported for a
+    // record, which `path = nil` already says, so this reads as absence here.
+    let site = crate::pack::site_dir().ok();
+    let manager = site.as_ref().map(maki_pack::manager::Manager::new);
+    let result = lua.create_table()?;
+    for (index, name) in order.into_iter().enumerate() {
+        let declared = declarations
+            .specs
+            .iter()
+            .find(|declared| declared.spec.name == name);
+        let locked = lock.get(&name);
+        if declared.is_none() && locked.is_none() {
+            return Err(mlua::Error::runtime(format!(
+                "pack.get: package {name:?} is not installed"
+            )));
+        }
+
+        let fallback;
+        let spec = match declared {
+            Some(declared) => &declared.spec,
+            None => {
+                let entry = locked.expect("checked above");
+                fallback = Spec::new(entry.src.clone()).with_name(name.clone());
+                &fallback
+            }
+        };
+        let path = manager
+            .as_ref()
+            .and_then(|manager| manager.resolve(&lock, &name));
+        let item = lua.create_table()?;
+        item.set(
+            "spec",
+            spec_to_lua(lua, spec, declared.and_then(|d| d.data.as_ref()))?,
+        )?;
+        item.set("path", path.map(|path| path.display().to_string()))?;
+        item.set("rev", locked.map(|entry| entry.rev.as_str()))?;
+        item.set("active", declarations.active.contains(&name))?;
+        result.set(index + 1, item)?;
+    }
+    Ok(result)
+}
+
+fn validate_get_options(opts: Option<Table>) -> LuaResult<()> {
+    let Some(opts) = opts else {
+        return Ok(());
+    };
+    reject_unknown_fields(&opts, &[], "pack.get")
+}
+
+pub(crate) fn spec_to_lua(
+    lua: &Lua,
+    spec: &Spec,
+    data: Option<&Arc<RegistryKey>>,
+) -> LuaResult<Table> {
+    let table = lua.create_table()?;
+    table.set("src", maki_pack::git::redact(&spec.src))?;
+    table.set("name", spec.name.as_str())?;
+    match &spec.version {
+        Version::DefaultBranch => {}
+        Version::Rev(version) => table.set("version", version.as_str())?,
+        Version::Range(range) => {
+            let version = lua.create_table()?;
+            version.set(super::version::RANGE_MARKER, range.to_string())?;
+            table.set("version", version)?;
+        }
+    }
+    if let Some(data) = data {
+        table.set("data", lua.registry_value::<LuaValue>(data.as_ref())?)?;
+    }
+    Ok(table)
+}
+
+pub(crate) fn create_pack_read_table(lua: &Lua) -> LuaResult<Table> {
+    let table = lua.create_table()?;
+    table.set(
+        "get",
+        lua.create_function(|lua, (names, opts): (Option<Table>, Option<Table>)| {
+            get(lua, names, opts)
+        })?,
+    )?;
+    Ok(table)
+}
+
 /// Update packages to what their version now resolves to, like
 /// `vim.pack.update`.
 ///
@@ -449,9 +701,10 @@ fn enqueue(lua: &Lua, op: PackOp, name: &str) -> LuaResult<()> {
 /// reloads the package and unloading waits on the runtime this call occupies.
 ///
 /// @param names table? Package names. Omit for every declared package.
-/// @param opts table? `offline` to work without the network, and `target` of
+/// @param opts table? `offline` works without the network. `target` is
 ///   `"version"` (the default) to take what version now resolves to, or
-///   `"lockfile"` to go back to the recorded revision.
+///   `"lockfile"` to go back to the recorded revision. `force` skips the
+///   update review, but not a new permission approval.
 /// @example
 /// maki.pack.update({ "maki-goal" })
 /// maki.pack.update(nil, { target = "lockfile" })
@@ -499,13 +752,23 @@ fn parse_update_options(opts: Option<Table>) -> LuaResult<UpdateOptions> {
     let Some(opts) = opts else {
         return Ok(UpdateOptions::default());
     };
-    reject_unknown_fields(&opts, &["offline", "target"], "pack.update")?;
+    reject_unknown_fields(&opts, &["offline", "force", "target"], "pack.update")?;
     let offline = match opts.get::<LuaValue>("offline")? {
         LuaValue::Nil => false,
         LuaValue::Boolean(b) => b,
         other => {
             return Err(mlua::Error::runtime(format!(
                 "pack.update: 'offline' must be a boolean, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    let force = match opts.get::<LuaValue>("force")? {
+        LuaValue::Nil => false,
+        LuaValue::Boolean(force) => force,
+        other => {
+            return Err(mlua::Error::runtime(format!(
+                "pack.update: 'force' must be a boolean, got {}",
                 other.type_name()
             )));
         }
@@ -528,7 +791,11 @@ fn parse_update_options(opts: Option<Table>) -> LuaResult<UpdateOptions> {
             )));
         }
     };
-    Ok(UpdateOptions { target, offline })
+    Ok(UpdateOptions {
+        target,
+        offline,
+        force,
+    })
 }
 
 /// Remove packages, like `vim.pack.del`.
@@ -536,16 +803,44 @@ fn parse_update_options(opts: Option<Table>) -> LuaResult<UpdateOptions> {
 /// Runs after this call returns, for the same reason as `update`.
 ///
 /// @param names table Package names to remove.
+/// @param opts table? `force` allows removal of an active package.
 /// @example
 /// maki.pack.del({ "maki-goal" })
 #[lua_fn]
-fn del(lua: &Lua, names: Table) -> LuaResult<()> {
-    let names = names_arg(Some(names))?;
+fn del(lua: &Lua, names: Table, opts: Option<Table>) -> LuaResult<()> {
+    let names: Vec<String> = names
+        .sequence_values::<String>()
+        .collect::<LuaResult<_>>()?;
     if names.is_empty() {
         return Err(mlua::Error::runtime("pack.del: name a package to remove"));
     }
+    if let Some(opts) = &opts {
+        reject_unknown_fields(opts, &["force"], "pack.del")?;
+    }
+    let force = match opts
+        .as_ref()
+        .map(|opts| opts.get::<LuaValue>("force"))
+        .transpose()?
+        .unwrap_or(LuaValue::Nil)
+    {
+        LuaValue::Nil => false,
+        LuaValue::Boolean(force) => force,
+        other => {
+            return Err(mlua::Error::runtime(format!(
+                "pack.del: 'force' must be a boolean, got {}",
+                other.type_name()
+            )));
+        }
+    };
     for name in names {
-        enqueue(lua, PackOp::Delete { name: name.clone() }, &name)?;
+        enqueue(
+            lua,
+            PackOp::Delete {
+                name: name.clone(),
+                force,
+            },
+            &name,
+        )?;
     }
     Ok(())
 }
@@ -558,6 +853,9 @@ fn del(lua: &Lua, names: Table) -> LuaResult<()> {
 /// much weaker act than fetching new code.
 ///
 /// Loading happens after this call returns, for the same reason as `update`.
+/// A runtime call reports an unknown, disabled, or previously failed package
+/// immediately. During `init.lua`, the host reports the result after startup
+/// has installed and cataloged packages.
 ///
 /// @param name string Package to activate.
 /// @example
@@ -572,19 +870,60 @@ fn packadd(lua: &Lua, name: String) -> LuaResult<()> {
 /// It sits beside the other always-available functions rather than inside
 /// `maki.pack`, because that table exists only for `init.lua` while activation
 /// is something any plugin may do.
-pub(crate) fn add_packadd(lua: &Lua, maki: &Table) -> LuaResult<()> {
-    maki.set("packadd", lua.create_function(packadd_raw)?)
-}
-
-fn packadd_raw(lua: &Lua, name: String) -> LuaResult<()> {
-    packadd(lua, name)
-}
-
-fn names_arg(names: Option<Table>) -> LuaResult<Vec<String>> {
-    let Some(table) = names else {
-        return Ok(Vec::new());
+pub(crate) fn add_packadd(
+    lua: &Lua,
+    maki: &Table,
+    runtime_tx: Option<flume::Sender<crate::runtime::Request>>,
+) -> LuaResult<()> {
+    let function = match runtime_tx {
+        Some(tx) => {
+            let store = lua
+                .app_data_ref::<PackStore>()
+                .ok_or_else(|| mlua::Error::runtime("packadd: not available here"))?
+                .clone();
+            lua.create_function(move |_, name: String| {
+                if !maki_pack::name_is_safe(&name) {
+                    return Err(mlua::Error::runtime(format!(
+                        "pack: {name:?} is not a usable package name"
+                    )));
+                }
+                let state = {
+                    let mut declarations = store.lock().expect("pack declarations");
+                    let Some(dormant) = declarations.dormant.as_ref() else {
+                        let operation = PackOp::Activate { name };
+                        if !declarations.pending.contains(&operation) {
+                            declarations.pending.push(operation);
+                        }
+                        return Ok(());
+                    };
+                    if declarations.active.contains(&name) {
+                        return Ok(());
+                    }
+                    dormant
+                        .iter()
+                        .find(|package| package.name == name)
+                        .map(|package| package.state.clone())
+                };
+                match state {
+                    Some(PackState::Inactive) => {}
+                    Some(PackState::Failed(error)) => {
+                        return Err(mlua::Error::runtime(format!(
+                            "packadd: package {name:?} already failed to load: {error}"
+                        )));
+                    }
+                    None => {
+                        return Err(mlua::Error::runtime(format!(
+                            "packadd: package {name:?} is not installed or is disabled"
+                        )));
+                    }
+                }
+                tx.send(crate::runtime::Request::ActivatePackage { name })
+                    .map_err(|_| mlua::Error::runtime("packadd: plugin host is not running"))
+            })?
+        }
+        None => lua.create_function(packadd)?,
     };
-    table.sequence_values::<String>().collect()
+    maki.set("packadd", function)
 }
 
 lua_table! {
@@ -598,7 +937,7 @@ lua_table! {
     /// maki.pack.add({ "https://github.com/user/maki-goal" })
     /// ```
     "maki.pack" => pub(crate) fn create_pack_table(), DOCS [
-        add, update, del,
+        add, get, update, del,
     ]
 }
 
@@ -612,6 +951,17 @@ mod tests {
         let store: PackStore = Arc::default();
         lua.set_app_data(store.clone());
         (lua, store)
+    }
+
+    #[test]
+    fn get_rejects_options_that_it_does_not_implement() {
+        let lua = Lua::new();
+        let opts = lua.create_table().unwrap();
+        opts.set("offline", true).unwrap();
+
+        let error = validate_get_options(Some(opts)).unwrap_err();
+
+        assert!(error.to_string().contains("unknown field"), "{error}");
     }
 
     fn add_fn(lua: &Lua) -> mlua::Function {
@@ -648,6 +998,65 @@ mod tests {
             declared.specs[0].spec.version,
             Version::Rev("v1.2.3".to_owned())
         );
+    }
+
+    #[test]
+    fn arbitrary_data_round_trips_without_serialization() {
+        let (lua, store) = lua_with_store();
+        let data = lua.create_table().unwrap();
+        data.set("number", 7).unwrap();
+        data.set("call", lua.create_function(|_, ()| Ok("ok")).unwrap())
+            .unwrap();
+        let spec = lua.create_table().unwrap();
+        spec.set("src", "https://github.com/user/repo").unwrap();
+        spec.set("data", data).unwrap();
+        add_fn(&lua)
+            .call::<()>(lua.create_sequence_from([spec]).unwrap())
+            .unwrap();
+
+        let declared = store.lock().unwrap().specs[0].clone();
+        let output = spec_to_lua(&lua, &declared.spec, declared.data.as_ref()).unwrap();
+        let output_data: Table = output.get("data").unwrap();
+        let call: mlua::Function = output_data.get("call").unwrap();
+        assert_eq!(output_data.get::<i64>("number").unwrap(), 7);
+        assert_eq!(call.call::<String>(()).unwrap(), "ok");
+    }
+
+    #[test]
+    fn http_credentials_are_rejected_without_exposing_them() {
+        let (lua, _store) = lua_with_store();
+        let specs = lua
+            .create_sequence_from(["https://user:secret@example.com/repo\u{1b}"])
+            .unwrap();
+
+        let error = add_fn(&lua).call::<()>(specs).unwrap_err().to_string();
+
+        assert!(error.contains("credential helper"), "got: {error}");
+        assert!(!error.contains("secret"), "credential leaked: {error}");
+        assert!(
+            !error.contains('\u{1b}'),
+            "control character leaked: {error}"
+        );
+    }
+
+    #[test]
+    fn the_first_add_call_sets_lockfile_confirmation_even_when_empty() {
+        let (lua, store) = lua_with_store();
+        let opts = lua.create_table().unwrap();
+        opts.set("confirm", false).unwrap();
+        add_fn(&lua)
+            .call::<()>((lua.create_table().unwrap(), opts))
+            .unwrap();
+        add_fn(&lua)
+            .call::<()>(
+                lua.create_sequence_from(["https://github.com/user/repo"])
+                    .unwrap(),
+            )
+            .unwrap();
+
+        let declarations = store.lock().unwrap();
+        assert_eq!(declarations.lock_confirm, Some(false));
+        assert!(declarations.specs[0].confirm);
     }
 
     #[test]
@@ -689,8 +1098,58 @@ mod tests {
         assert!(add_fn(&lua).call::<()>(specs).is_err());
     }
 
-    /// The name becomes a directory, so an unsafe one is refused here rather
-    /// than reaching the filesystem.
+    #[test]
+    fn a_non_string_source_reports_its_type() {
+        let (lua, _store) = lua_with_store();
+        let spec = lua.create_table().unwrap();
+        spec.set("src", 7).unwrap();
+        let specs = lua.create_sequence_from([spec]).unwrap();
+
+        let error = add_fn(&lua).call::<()>(specs).unwrap_err();
+
+        assert!(error.to_string().contains("must be a string"), "{error}");
+    }
+
+    #[test]
+    fn a_misspelled_spec_field_is_rejected() {
+        let (lua, _store) = lua_with_store();
+        let spec = lua.create_table().unwrap();
+        spec.set("src", "https://github.com/user/repo").unwrap();
+        spec.set("verison", "v1").unwrap();
+        let specs = lua.create_sequence_from([spec]).unwrap();
+
+        let error = add_fn(&lua).call::<()>(specs).unwrap_err();
+
+        assert!(error.to_string().contains("verison"), "{error}");
+    }
+
+    #[test]
+    fn an_empty_version_is_rejected() {
+        let (lua, _store) = lua_with_store();
+        let spec = lua.create_table().unwrap();
+        spec.set("src", "https://github.com/user/repo").unwrap();
+        spec.set("version", " ").unwrap();
+        let specs = lua.create_sequence_from([spec]).unwrap();
+
+        assert!(add_fn(&lua).call::<()>(specs).is_err());
+    }
+
+    #[test]
+    fn an_empty_or_non_string_explicit_name_is_rejected() {
+        let (lua, _store) = lua_with_store();
+        for name in [
+            LuaValue::String(lua.create_string("").unwrap()),
+            LuaValue::Integer(7),
+        ] {
+            let spec = lua.create_table().unwrap();
+            spec.set("src", "https://github.com/user/repo").unwrap();
+            spec.set("name", name).unwrap();
+            let specs = lua.create_sequence_from([spec]).unwrap();
+
+            assert!(add_fn(&lua).call::<()>(specs).is_err());
+        }
+    }
+
     /// A package name is an owner name. If a package could be called `bash`,
     /// removing it would unload the bundled bash tool rather than the package.
     #[test]
@@ -706,6 +1165,7 @@ mod tests {
         assert!(err.to_string().contains("builtin"), "{err}");
     }
 
+    /// The name becomes a directory, so reject it before filesystem access.
     #[test]
     fn an_unsafe_name_is_refused() {
         let (lua, _store) = lua_with_store();
@@ -718,88 +1178,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn an_unsafe_name_error_redacts_source_credentials() {
-        let (lua, _store) = lua_with_store();
-        let spec = lua.create_table().unwrap();
-        spec.set("src", "https://secret@example.com/repo").unwrap();
-        spec.set("name", "../escape").unwrap();
-        let specs = lua.create_sequence_from([spec]).unwrap();
-
-        let error = add_fn(&lua).call::<()>(specs).unwrap_err().to_string();
-
-        assert!(!error.contains("secret"));
-        assert!(error.contains("https://***@example.com/repo"));
-    }
-
-    #[test]
-    fn http_credentials_are_rejected_before_installation() {
-        let (lua, store) = lua_with_store();
-        let specs = lua
-            .create_sequence_from(["https://user:secret@example.com/repo"])
-            .unwrap();
-
-        let error = add_fn(&lua).call::<()>(specs).unwrap_err().to_string();
-
-        assert!(!error.contains("secret"), "credential leaked: {error}");
-        assert!(error.contains("Git credential helper"));
-        assert!(store.lock().unwrap().specs.is_empty());
-    }
-
-    #[test]
-    fn a_non_string_name_is_rejected() {
-        let (lua, _store) = lua_with_store();
-        let spec = lua.create_table().unwrap();
-        spec.set("src", "https://github.com/user/repo").unwrap();
-        spec.set("name", 7).unwrap();
-        let specs = lua.create_sequence_from([spec]).unwrap();
-
-        assert!(add_fn(&lua).call::<()>(specs).is_err());
-    }
-
-    #[test]
-    fn an_empty_name_is_rejected() {
-        let (lua, store) = lua_with_store();
-        let spec = lua.create_table().unwrap();
-        spec.set("src", "https://github.com/user/repo").unwrap();
-        spec.set("name", "").unwrap();
-        let specs = lua.create_sequence_from([spec]).unwrap();
-
-        assert!(add_fn(&lua).call::<()>(specs).is_err());
-        assert!(store.lock().unwrap().specs.is_empty());
-    }
-
-    #[test]
-    fn unknown_spec_and_option_fields_are_rejected() {
-        let (lua, store) = lua_with_store();
-        let spec = lua.create_table().unwrap();
-        spec.set("src", "https://github.com/user/repo").unwrap();
-        spec.set("typo", true).unwrap();
-        let specs = lua.create_sequence_from([spec]).unwrap();
-        assert!(add_fn(&lua).call::<()>(specs).is_err());
-
-        let specs = lua
-            .create_sequence_from(["https://github.com/user/repo"])
-            .unwrap();
-        let opts = lua.create_table().unwrap();
-        opts.set("typo", true).unwrap();
-        assert!(add_fn(&lua).call::<()>((specs, opts)).is_err());
-        assert!(store.lock().unwrap().specs.is_empty());
-    }
-
-    #[test]
-    fn a_builtin_owner_name_is_rejected() {
-        let (lua, _store) = lua_with_store();
-        let spec = lua.create_table().unwrap();
-        spec.set("src", "https://github.com/user/repo").unwrap();
-        spec.set("name", "bash").unwrap();
-        let specs = lua.create_sequence_from([spec]).unwrap();
-
-        let error = add_fn(&lua).call::<()>(specs).unwrap_err().to_string();
-
-        assert!(error.contains("builtin plugin"));
-    }
-
     /// A source whose name cannot be derived has to be named explicitly rather
     /// than installed under an empty directory name.
     #[test]
@@ -810,7 +1188,7 @@ mod tests {
     }
 
     #[test]
-    fn the_first_declaration_of_a_name_wins() {
+    fn the_first_declaration_of_a_package_wins() {
         let (lua, store) = lua_with_store();
         let first = lua.create_table().unwrap();
         first.set("src", "https://github.com/user/a").unwrap();
@@ -853,10 +1231,67 @@ mod tests {
                     options: UpdateOptions::default(),
                 },
                 PackOp::Delete {
-                    name: "b".to_owned()
+                    name: "b".to_owned(),
+                    force: false,
                 },
             ]
         );
+    }
+
+    #[test]
+    fn an_explicit_empty_update_list_does_not_update_everything() {
+        let (lua, store) = lua_with_store();
+        let specs = lua
+            .create_sequence_from(["https://github.com/user/a"])
+            .unwrap();
+        add_fn(&lua).call::<()>(specs).unwrap();
+
+        call(&lua, "update", lua.create_table().unwrap()).unwrap();
+
+        assert!(store.lock().unwrap().pending.is_empty());
+    }
+
+    #[test]
+    fn update_and_delete_force_options_reach_the_pending_operations() {
+        let (lua, store) = lua_with_store();
+        let options = lua.create_table().unwrap();
+        options.set("force", true).unwrap();
+        let update: mlua::Function = create_pack_table(&lua).unwrap().get("update").unwrap();
+        update
+            .call::<()>((lua.create_sequence_from(["a"]).unwrap(), options.clone()))
+            .unwrap();
+        let delete: mlua::Function = create_pack_table(&lua).unwrap().get("del").unwrap();
+        delete
+            .call::<()>((lua.create_sequence_from(["b"]).unwrap(), options))
+            .unwrap();
+
+        assert!(matches!(
+            &store.lock().unwrap().pending[..],
+            [
+                PackOp::Update {
+                    options: UpdateOptions { force: true, .. },
+                    ..
+                },
+                PackOp::Delete { force: true, .. }
+            ]
+        ));
+    }
+
+    #[test]
+    fn update_and_delete_reject_unknown_options() {
+        let (lua, store) = lua_with_store();
+        for name in ["update", "del"] {
+            let options = lua.create_table().unwrap();
+            options.set("focre", true).unwrap();
+            let function: mlua::Function = create_pack_table(&lua).unwrap().get(name).unwrap();
+
+            let error = function
+                .call::<()>((lua.create_sequence_from(["a"]).unwrap(), options))
+                .unwrap_err();
+
+            assert!(error.to_string().contains("focre"), "{error}");
+        }
+        assert!(store.lock().unwrap().pending.is_empty());
     }
 
     /// `packadd` is what makes an `opt/` package reachable at all, so it must
@@ -865,7 +1300,7 @@ mod tests {
     fn packadd_registers_on_the_root_table_and_queues_activation() {
         let (lua, store) = lua_with_store();
         let maki = lua.create_table().unwrap();
-        add_packadd(&lua, &maki).unwrap();
+        add_packadd(&lua, &maki, None).unwrap();
 
         let f: mlua::Function = maki.get("packadd").expect("packadd should be registered");
         f.call::<()>("demo").unwrap();
@@ -879,10 +1314,37 @@ mod tests {
     }
 
     #[test]
+    fn startup_packadd_queues_one_activation_per_package() {
+        let (lua, store) = lua_with_store();
+        let maki = lua.create_table().unwrap();
+        add_packadd(&lua, &maki, None).unwrap();
+        let function: mlua::Function = maki.get("packadd").unwrap();
+
+        function.call::<()>("demo").unwrap();
+        function.call::<()>("demo").unwrap();
+
+        assert_eq!(store.lock().unwrap().pending.len(), 1);
+    }
+
+    #[test]
+    fn runtime_packadd_queues_once_before_the_catalog_is_ready() {
+        let (lua, store) = lua_with_store();
+        let maki = lua.create_table().unwrap();
+        let (tx, _rx) = flume::unbounded();
+        add_packadd(&lua, &maki, Some(tx)).unwrap();
+        let function: mlua::Function = maki.get("packadd").unwrap();
+
+        function.call::<()>("demo").unwrap();
+        function.call::<()>("demo").unwrap();
+
+        assert_eq!(store.lock().unwrap().pending.len(), 1);
+    }
+
+    #[test]
     fn packadd_refuses_an_unsafe_name() {
         let (lua, store) = lua_with_store();
         let maki = lua.create_table().unwrap();
-        add_packadd(&lua, &maki).unwrap();
+        add_packadd(&lua, &maki, None).unwrap();
         let f: mlua::Function = maki.get("packadd").unwrap();
 
         assert!(f.call::<()>("../escape").is_err());
@@ -918,6 +1380,37 @@ mod tests {
     }
 
     #[test]
+    fn misspelled_load_fields_are_rejected() {
+        let (lua, _store) = lua_with_store();
+        let specs = lua
+            .create_sequence_from(["https://github.com/user/repo"])
+            .unwrap();
+        let opts = lua.create_table().unwrap();
+        opts.set("lod", false).unwrap();
+
+        let error = add_fn(&lua).call::<()>((specs, opts)).unwrap_err();
+
+        assert!(error.to_string().contains("lod"), "{error}");
+    }
+
+    #[test]
+    fn a_custom_loader_is_retained_and_runs_at_start() {
+        let (lua, store) = lua_with_store();
+        let specs = lua
+            .create_sequence_from(["https://github.com/user/repo"])
+            .unwrap();
+        let opts = lua.create_table().unwrap();
+        opts.set("load", lua.create_function(|_, ()| Ok(())).unwrap())
+            .unwrap();
+
+        add_fn(&lua).call::<()>((specs, opts)).unwrap();
+
+        let declared = store.lock().unwrap().specs[0].clone();
+        assert!(matches!(declared.load, LoadMode::Custom(_)));
+        assert!(declared.loads_at_start(true));
+    }
+
+    #[test]
     fn a_trigger_table_records_its_triggers() {
         let (lua, store) = lua_with_store();
         let specs = lua
@@ -949,6 +1442,98 @@ mod tests {
         assert!(triggers.keys.is_empty());
     }
 
+    #[test]
+    fn a_misspelled_trigger_field_is_rejected() {
+        let (lua, _store) = lua_with_store();
+        let specs = lua
+            .create_sequence_from(["https://github.com/user/repo"])
+            .unwrap();
+        let load = lua.create_table().unwrap();
+        load.set("comand", "/demo").unwrap();
+        let opts = lua.create_table().unwrap();
+        opts.set("load", load).unwrap();
+
+        let error = add_fn(&lua).call::<()>((specs, opts)).unwrap_err();
+
+        assert!(error.to_string().contains("comand"), "{error}");
+    }
+
+    #[test]
+    fn headless_start_promotes_event_triggers_but_not_command_triggers() {
+        let event = Declared {
+            spec: Spec::new("https://example.com/event"),
+            load: LoadMode::Triggered(Triggers {
+                event: vec!["TurnStart".to_owned()],
+                ..Triggers::default()
+            }),
+            confirm: true,
+            data: None,
+        };
+        let command = Declared {
+            spec: Spec::new("https://example.com/command"),
+            load: LoadMode::Triggered(Triggers {
+                cmd: vec!["/demo".to_owned()],
+                ..Triggers::default()
+            }),
+            confirm: true,
+            data: None,
+        };
+
+        assert!(!event.loads_at_start(true));
+        assert!(event.loads_at_start(false));
+        assert!(!command.loads_at_start(false));
+    }
+
+    #[test]
+    fn read_only_pack_table_exposes_only_get() {
+        let lua = Lua::new();
+        let table = create_pack_read_table(&lua).unwrap();
+        assert!(table.contains_key("get").unwrap());
+        assert!(!table.contains_key("add").unwrap());
+        assert!(!table.contains_key("update").unwrap());
+        assert!(!table.contains_key("del").unwrap());
+    }
+
+    /// `register_command` stores a leading slash whether or not the package
+    /// wrote one, so a trigger recorded without one would wake the package and
+    /// then fail to find the very command that woke it.
+    #[test]
+    fn a_command_trigger_is_stored_with_a_leading_slash() {
+        let (lua, store) = lua_with_store();
+        let opts = lua.create_table().unwrap();
+        let load = lua.create_table().unwrap();
+        load.set("cmd", "bare").unwrap();
+        opts.set("load", load).unwrap();
+
+        let specs = lua
+            .create_sequence_from(["https://example.com/demo"])
+            .unwrap();
+        let f: mlua::Function = create_pack_table(&lua).unwrap().get("add").unwrap();
+        f.call::<()>((specs, opts)).unwrap();
+
+        let declared = store.lock().unwrap().specs[0].clone();
+        match declared.load {
+            LoadMode::Triggered(t) => assert_eq!(t.cmd, vec!["/bare".to_owned()]),
+            other => panic!("expected a trigger, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn command_triggers_must_be_dispatchable_words() {
+        for command in ["/", "two words", "/forced!"] {
+            let (lua, _store) = lua_with_store();
+            let opts = lua.create_table().unwrap();
+            let load = lua.create_table().unwrap();
+            load.set("cmd", command).unwrap();
+            opts.set("load", load).unwrap();
+            let specs = lua
+                .create_sequence_from(["https://example.com/demo"])
+                .unwrap();
+
+            assert!(add_fn(&lua).call::<()>((specs, opts)).is_err(), "{command}");
+        }
+    }
+
     /// A table naming no trigger leaves the package dormant with nothing able
     /// to wake it, which is a typo rather than an intent.
     #[test]
@@ -962,6 +1547,36 @@ mod tests {
 
         let f: mlua::Function = create_pack_table(&lua).unwrap().get("add").unwrap();
         assert!(f.call::<()>((specs, opts)).is_err());
+    }
+
+    #[test]
+    fn events_without_an_activation_path_are_rejected() {
+        for event in ["PluginOnly", "PackChanged"] {
+            let (lua, _store) = lua_with_store();
+            let specs = lua
+                .create_sequence_from(["https://github.com/user/repo"])
+                .unwrap();
+            let load = lua.create_table().unwrap();
+            load.set("event", event).unwrap();
+            let opts = lua.create_table().unwrap();
+            opts.set("load", load).unwrap();
+
+            assert!(add_fn(&lua).call::<()>((specs, opts)).is_err(), "{event}");
+        }
+    }
+
+    #[test]
+    fn an_invalid_key_trigger_is_rejected() {
+        let (lua, _store) = lua_with_store();
+        let specs = lua
+            .create_sequence_from(["https://github.com/user/repo"])
+            .unwrap();
+        let load = lua.create_table().unwrap();
+        load.set("keys", "<Not-A-Key>").unwrap();
+        let opts = lua.create_table().unwrap();
+        opts.set("load", load).unwrap();
+
+        assert!(add_fn(&lua).call::<()>((specs, opts)).is_err());
     }
 
     #[test]
@@ -984,37 +1599,6 @@ mod tests {
             call(&lua, "update", lua.create_sequence_from(["a"]).unwrap()).unwrap();
         }
         assert_eq!(store.lock().unwrap().pending.len(), 1);
-    }
-
-    #[test]
-    fn an_explicit_empty_update_list_does_not_update_every_package() {
-        let (lua, store) = lua_with_store();
-        let declared = lua
-            .create_sequence_from(["https://github.com/user/repo"])
-            .unwrap();
-        add_fn(&lua).call::<()>(declared).unwrap();
-        let update: mlua::Function = create_pack_table(&lua).unwrap().get("update").unwrap();
-
-        update
-            .call::<()>(lua.create_table().unwrap())
-            .expect("an empty selection is valid");
-
-        assert!(store.lock().unwrap().pending.is_empty());
-    }
-
-    #[test]
-    fn update_rejects_unknown_options() {
-        let (lua, store) = lua_with_store();
-        let opts = lua.create_table().unwrap();
-        opts.set("ofline", true).unwrap();
-        let update: mlua::Function = create_pack_table(&lua).unwrap().get("update").unwrap();
-
-        assert!(
-            update
-                .call::<()>((lua.create_table().unwrap(), opts))
-                .is_err()
-        );
-        assert!(store.lock().unwrap().pending.is_empty());
     }
 
     /// A name reaches the filesystem, so it is refused here rather than later.

--- a/maki-lua/src/api/pack.rs
+++ b/maki-lua/src/api/pack.rs
@@ -1478,8 +1478,12 @@ mod tests {
             .create_sequence_from(["https://github.com/user/repo"])
             .unwrap();
         let load = lua.create_table().unwrap();
-        load.set("event", lua.create_sequence_from(["TurnStart"]).unwrap())
-            .unwrap();
+        load.set(
+            "event",
+            lua.create_sequence_from(["TurnStart", "TaskStatusChanged"])
+                .unwrap(),
+        )
+        .unwrap();
         load.set("cmd", "/demo").unwrap();
         let opts = lua.create_table().unwrap();
         opts.set("load", load).unwrap();
@@ -1494,7 +1498,10 @@ mod tests {
                 declared.specs[0].load
             );
         };
-        assert_eq!(triggers.event, vec!["TurnStart".to_owned()]);
+        assert_eq!(
+            triggers.event,
+            vec!["TurnStart".to_owned(), "TaskStatusChanged".to_owned()]
+        );
         assert_eq!(
             triggers.cmd,
             vec!["/demo".to_owned()],

--- a/maki-lua/src/api/pack.rs
+++ b/maki-lua/src/api/pack.rs
@@ -15,7 +15,7 @@ use maki_lua_macro::{lua_fn, lua_table};
 use crate::api::options::PluginOpts;
 use crate::plugin_permissions::PluginPermissions;
 use maki_pack::{Spec, Version};
-use mlua::{Lua, RegistryKey, Result as LuaResult, Table, Value as LuaValue};
+use mlua::{Lua, MultiValue, RegistryKey, Result as LuaResult, Table, Value as LuaValue};
 
 /// When a declared package should load.
 ///
@@ -95,8 +95,6 @@ impl Declared {
 #[derive(Debug, Default, Clone)]
 pub struct PackDeclarations {
     pub specs: Vec<Declared>,
-    /// `confirm` from the first `add` call, including an empty call.
-    pub lock_confirm: Option<bool>,
     /// Package owners that loaded successfully in this runtime.
     pub active: BTreeSet<String>,
     /// Operations recorded by Lua for the host to perform after the calling
@@ -232,6 +230,9 @@ pub struct PackChange {
 }
 
 pub type PackStore = Arc<Mutex<PackDeclarations>>;
+
+#[derive(Clone)]
+pub(crate) struct PackRuntimeTx(pub flume::Sender<crate::runtime::Request>);
 
 fn reject_unknown_fields(table: &Table, allowed: &[&str], context: &str) -> LuaResult<()> {
     for pair in table.clone().pairs::<LuaValue, LuaValue>() {
@@ -381,8 +382,8 @@ fn parse_spec(lua: &Lua, value: LuaValue) -> LuaResult<(Spec, Option<Arc<Registr
 /// package failure never stops maki from starting.
 /// The first declaration of a package name wins for the current session.
 ///
-/// Only available inside `init.lua`. Declaring a package fetches code, so it is
-/// configuration rather than something a downloaded plugin may do.
+/// Only available inside the global `init.lua`. Declaring a package fetches
+/// code and changes state shared by every project.
 ///
 /// @param specs table List of specs. Each is a source string, or a table with
 ///   `src` (string, required), `name` (string), `version` (string or
@@ -422,7 +423,6 @@ fn add(lua: &Lua, specs: Table, opts: Option<Table>) -> LuaResult<()> {
     }
 
     let mut declarations = store.lock().expect("pack declarations");
-    declarations.lock_confirm.get_or_insert(confirm);
     for declared in parsed {
         if !declarations
             .specs
@@ -710,11 +710,26 @@ pub(crate) fn create_pack_read_table(lua: &Lua) -> LuaResult<Table> {
     Ok(table)
 }
 
+pub(crate) fn restrict_management(lua: &Lua, table: &Table) -> LuaResult<()> {
+    for method in ["add", "update", "del"] {
+        table.set(
+            method,
+            lua.create_function(move |_, _: MultiValue| -> LuaResult<()> {
+                Err(mlua::Error::runtime(format!(
+                    "maki.pack.{method} is only available in the global init.lua"
+                )))
+            })?,
+        )?;
+    }
+    Ok(())
+}
+
 /// Update packages to what their version now resolves to, like
 /// `vim.pack.update`.
 ///
 /// The work happens after this call returns, because updating unloads and
 /// reloads the package and unloading waits on the runtime this call occupies.
+/// Only available inside the global `init.lua`.
 ///
 /// @param names table? Package names. Omit for every declared package.
 /// @param opts table? `offline` works without the network. `target` is
@@ -817,6 +832,7 @@ fn parse_update_options(opts: Option<Table>) -> LuaResult<UpdateOptions> {
 /// Remove packages, like `vim.pack.del`.
 ///
 /// Runs after this call returns, for the same reason as `update`.
+/// Only available inside the global `init.lua`.
 ///
 /// @param names table Package names to remove.
 /// @param opts table? `force` allows removal of an active package.
@@ -886,11 +902,10 @@ fn packadd(lua: &Lua, name: String) -> LuaResult<()> {
 /// It sits beside the other always-available functions rather than inside
 /// `maki.pack`, because that table exists only for `init.lua` while activation
 /// is something any plugin may do.
-pub(crate) fn add_packadd(
-    lua: &Lua,
-    maki: &Table,
-    runtime_tx: Option<flume::Sender<crate::runtime::Request>>,
-) -> LuaResult<()> {
+pub(crate) fn add_packadd(lua: &Lua, maki: &Table) -> LuaResult<()> {
+    let runtime_tx = lua
+        .app_data_ref::<PackRuntimeTx>()
+        .map(|runtime| runtime.0.clone());
     let function = match runtime_tx {
         Some(tx) => {
             let store = lua
@@ -949,11 +964,11 @@ pub(crate) fn add_packadd(
 }
 
 lua_table! {
-    /// Declaring external packages, modelled after `vim.pack`.
+    /// Manage global external packages, modelled after `vim.pack`.
     ///
-    /// Available only inside `init.lua`, because installing a package fetches
-    /// code and that is a configuration decision rather than something a
-    /// plugin may do for itself.
+    /// `get` is read-only and available to project config and plugins.
+    /// `add`, `update`, and `del` are available only inside the global
+    /// `init.lua`, because they change state shared by every project.
     ///
     /// ```lua
     /// maki.pack.add({ "https://github.com/user/maki-goal" })
@@ -1062,7 +1077,7 @@ mod tests {
     }
 
     #[test]
-    fn the_first_add_call_sets_lockfile_confirmation_even_when_empty() {
+    fn an_empty_add_does_not_change_later_confirmation() {
         let (lua, store) = lua_with_store();
         let opts = lua.create_table().unwrap();
         opts.set("confirm", false).unwrap();
@@ -1077,7 +1092,6 @@ mod tests {
             .unwrap();
 
         let declarations = store.lock().unwrap();
-        assert_eq!(declarations.lock_confirm, Some(false));
         assert!(declarations.specs[0].confirm);
     }
 
@@ -1322,7 +1336,7 @@ mod tests {
     fn packadd_registers_on_the_root_table_and_queues_activation() {
         let (lua, store) = lua_with_store();
         let maki = lua.create_table().unwrap();
-        add_packadd(&lua, &maki, None).unwrap();
+        add_packadd(&lua, &maki).unwrap();
 
         let f: mlua::Function = maki.get("packadd").expect("packadd should be registered");
         f.call::<()>("demo").unwrap();
@@ -1339,7 +1353,7 @@ mod tests {
     fn startup_packadd_queues_one_activation_per_package() {
         let (lua, store) = lua_with_store();
         let maki = lua.create_table().unwrap();
-        add_packadd(&lua, &maki, None).unwrap();
+        add_packadd(&lua, &maki).unwrap();
         let function: mlua::Function = maki.get("packadd").unwrap();
 
         function.call::<()>("demo").unwrap();
@@ -1353,7 +1367,8 @@ mod tests {
         let (lua, store) = lua_with_store();
         let maki = lua.create_table().unwrap();
         let (tx, _rx) = flume::unbounded();
-        add_packadd(&lua, &maki, Some(tx)).unwrap();
+        lua.set_app_data(PackRuntimeTx(tx));
+        add_packadd(&lua, &maki).unwrap();
         let function: mlua::Function = maki.get("packadd").unwrap();
 
         function.call::<()>("demo").unwrap();
@@ -1369,7 +1384,7 @@ mod tests {
     fn packadd_after_the_drain_is_refused() {
         let (lua, store) = lua_with_store();
         let maki = lua.create_table().unwrap();
-        add_packadd(&lua, &maki, None).unwrap();
+        add_packadd(&lua, &maki).unwrap();
         store.lock().unwrap().drained = true;
 
         let f: mlua::Function = maki.get("packadd").expect("packadd should be registered");
@@ -1390,7 +1405,7 @@ mod tests {
     fn packadd_refuses_an_unsafe_name() {
         let (lua, store) = lua_with_store();
         let maki = lua.create_table().unwrap();
-        add_packadd(&lua, &maki, None).unwrap();
+        add_packadd(&lua, &maki).unwrap();
         let f: mlua::Function = maki.get("packadd").unwrap();
 
         assert!(f.call::<()>("../escape").is_err());

--- a/maki-lua/src/api/pack.rs
+++ b/maki-lua/src/api/pack.rs
@@ -6,6 +6,7 @@
 //! occupying. The host installs and loads the recorded set afterwards, which is
 //! also the phase Neovim defers to.
 
+use std::collections::BTreeSet;
 use std::sync::{Arc, Mutex};
 
 use maki_lua_macro::{lua_fn, lua_table};
@@ -68,6 +69,16 @@ pub struct Declared {
     pub confirm: bool,
 }
 
+impl Declared {
+    /// Whether this package loads in the startup phase.
+    ///
+    /// Asked by callers outside this crate too, so it is one method rather
+    /// than a `LoadMode` match repeated in each of them.
+    pub fn is_eager(&self) -> bool {
+        matches!(self.load, LoadMode::Eager)
+    }
+}
+
 /// Everything `init.lua` declared, in declaration order.
 ///
 /// Session state only. What is installed, and at which revision, lives in the
@@ -75,6 +86,8 @@ pub struct Declared {
 #[derive(Debug, Default, Clone)]
 pub struct PackDeclarations {
     pub specs: Vec<Declared>,
+    /// Package owners that loaded successfully in this runtime.
+    pub active: BTreeSet<String>,
     /// Operations recorded by Lua for the host to perform after the calling
     /// task has exited. Nothing here runs inline: `update` and `del` unload an
     /// owner, and unloading blocks on a reply from the runtime thread the
@@ -273,7 +286,9 @@ fn parse_spec(value: LuaValue) -> LuaResult<Spec> {
 ///   `maki.version.range()`).
 /// @param opts table? Options: `load` (boolean|table) `false` installs the
 ///   package without loading it, leaving it for `maki.packadd`; a table of
-///   `event`, `cmd`, and `keys` loads it the first time one of those fires.
+///   `event`, `cmd`, and `keys` names what should wake it. Trigger tables are
+///   recorded and checked but not dispatched yet, so a package that declares
+///   one installs and stays dormant until `maki.packadd` activates it.
 ///   `confirm` (boolean) `false` clones a new source without asking, which
 ///   states that the source is trusted and never approves its permissions.
 /// @example
@@ -300,6 +315,17 @@ fn add(lua: &Lua, specs: Table, opts: Option<Table>) -> LuaResult<()> {
 
     let mut declarations = store.lock().expect("pack declarations");
     for declared in parsed {
+        // Said plainly rather than left to be discovered. The triggers are
+        // recorded and validated, but nothing dispatches on them yet, so the
+        // package installs and waits. Staying dormant is the safe half of the
+        // feature; silently never waking would not be.
+        if let LoadMode::Triggered(_) = &declared.load {
+            tracing::warn!(
+                package = %declared.spec.name,
+                "lazy triggers are recorded but not dispatched yet; \
+                 the package stays dormant until maki.packadd activates it"
+            );
+        }
         // Neovim keeps the first declaration of a name for the session.
         if !declarations
             .specs
@@ -432,15 +458,14 @@ fn enqueue(lua: &Lua, op: PackOp, name: &str) -> LuaResult<()> {
 #[lua_fn]
 fn update(lua: &Lua, names: Option<Table>, opts: Option<Table>) -> LuaResult<()> {
     let options = parse_update_options(opts)?;
-    let names = names_arg(names)?;
-    // Omitting the argument means every declared package, which is what the
-    // documentation has always said. Enumerating them here rather than at the
-    // point of application keeps one meaning of "which packages" and lets a
-    // name be validated the same way whether it was typed or implied.
-    let names = if names.is_empty() {
-        declared_names(lua)?
-    } else {
-        names
+    // Only an omitted argument means every package. An explicit empty list is
+    // useful when callers compute a selection and must not become a bulk
+    // update by accident.
+    let names = match names {
+        Some(names) => names
+            .sequence_values::<String>()
+            .collect::<LuaResult<_>>()?,
+        None => declared_names(lua)?,
     };
     for name in names {
         enqueue(
@@ -474,6 +499,7 @@ fn parse_update_options(opts: Option<Table>) -> LuaResult<UpdateOptions> {
     let Some(opts) = opts else {
         return Ok(UpdateOptions::default());
     };
+    reject_unknown_fields(&opts, &["offline", "target"], "pack.update")?;
     let offline = match opts.get::<LuaValue>("offline")? {
         LuaValue::Nil => false,
         LuaValue::Boolean(b) => b,
@@ -665,6 +691,21 @@ mod tests {
 
     /// The name becomes a directory, so an unsafe one is refused here rather
     /// than reaching the filesystem.
+    /// A package name is an owner name. If a package could be called `bash`,
+    /// removing it would unload the bundled bash tool rather than the package.
+    #[test]
+    fn a_builtin_name_is_refused() {
+        let lua = Lua::new();
+        lua.set_app_data(PackStore::default());
+        let spec = lua.create_table().unwrap();
+        spec.set("src", "https://example.com/x").unwrap();
+        spec.set("name", "bash").unwrap();
+        let specs = lua.create_sequence_from([spec]).unwrap();
+
+        let err = call(&lua, "add", specs).expect_err("a builtin name is not available");
+        assert!(err.to_string().contains("builtin"), "{err}");
+    }
+
     #[test]
     fn an_unsafe_name_is_refused() {
         let (lua, _store) = lua_with_store();
@@ -943,6 +984,37 @@ mod tests {
             call(&lua, "update", lua.create_sequence_from(["a"]).unwrap()).unwrap();
         }
         assert_eq!(store.lock().unwrap().pending.len(), 1);
+    }
+
+    #[test]
+    fn an_explicit_empty_update_list_does_not_update_every_package() {
+        let (lua, store) = lua_with_store();
+        let declared = lua
+            .create_sequence_from(["https://github.com/user/repo"])
+            .unwrap();
+        add_fn(&lua).call::<()>(declared).unwrap();
+        let update: mlua::Function = create_pack_table(&lua).unwrap().get("update").unwrap();
+
+        update
+            .call::<()>(lua.create_table().unwrap())
+            .expect("an empty selection is valid");
+
+        assert!(store.lock().unwrap().pending.is_empty());
+    }
+
+    #[test]
+    fn update_rejects_unknown_options() {
+        let (lua, store) = lua_with_store();
+        let opts = lua.create_table().unwrap();
+        opts.set("ofline", true).unwrap();
+        let update: mlua::Function = create_pack_table(&lua).unwrap().get("update").unwrap();
+
+        assert!(
+            update
+                .call::<()>((lua.create_table().unwrap(), opts))
+                .is_err()
+        );
+        assert!(store.lock().unwrap().pending.is_empty());
     }
 
     /// A name reaches the filesystem, so it is refused here rather than later.

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -31,8 +31,7 @@ use serde_json::{Value, json};
 use crate::api::options::{PluginOpts, register_options__doc, register_options__register};
 use crate::api::ui::buf::{BufHandle, line_to_lua};
 use crate::api::util::command::{
-    CommandEntry, CommandHandlerMap, LuaCommandWriter, UiAction, publish_command_snapshot,
-    ui_roundtrip,
+    CommandEntry, CommandHandlerMap, UiAction, publish_command_snapshot, ui_roundtrip,
 };
 use crate::api::util::convert::{json_to_lua, lua_to_json};
 use crate::api::util::ctx::LuaCtx;
@@ -1395,13 +1394,7 @@ fn register_command_from_lua(lua: &Lua, spec: &Table, plugin: Arc<str>) -> LuaRe
         );
     }
 
-    let map = lua
-        .app_data_ref::<CommandHandlerMap>()
-        .ok_or_else(|| mlua::Error::runtime("register_command: not initialized"))?;
-    let writer = lua
-        .app_data_ref::<LuaCommandWriter>()
-        .ok_or_else(|| mlua::Error::runtime("register_command: not initialized"))?;
-    publish_command_snapshot(&map, &writer);
+    publish_command_snapshot(lua)?;
 
     Ok(())
 }

--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -134,8 +134,25 @@ pub(crate) struct CommandEntry {
 
 pub(crate) type CommandHandlerMap = HashMap<Arc<str>, HashMap<Arc<str>, CommandEntry>>;
 
-pub(crate) fn publish_command_snapshot(map: &CommandHandlerMap, writer: &LuaCommandWriter) {
-    let commands = map
+/// Publishes the commands the palette can offer.
+///
+/// `dormant` carries the packages that are installed but not loaded. Their
+/// commands are published too, because a lazy trigger that cannot be found is
+/// not a trigger: the user has to be able to type the command that wakes the
+/// package. Running one activates the package first and then dispatches, so a
+/// published pending command behaves like any other.
+pub(crate) fn publish_command_snapshot(lua: &Lua) -> Result<(), mlua::Error> {
+    let map = lua
+        .app_data_ref::<CommandHandlerMap>()
+        .ok_or_else(|| mlua::Error::runtime("command store not initialized"))?;
+    let writer = lua
+        .app_data_ref::<LuaCommandWriter>()
+        .ok_or_else(|| mlua::Error::runtime("command writer not initialized"))?;
+    let dormant = lua
+        .app_data_ref::<crate::api::pack::PackStore>()
+        .and_then(|store| store.lock().expect("pack declarations").dormant.clone())
+        .unwrap_or_default();
+    let mut commands: Vec<LuaCommandInfo> = map
         .iter()
         .flat_map(|(plugin, cmds)| {
             cmds.iter().map(move |(name, entry)| LuaCommandInfo {
@@ -146,7 +163,27 @@ pub(crate) fn publish_command_snapshot(map: &CommandHandlerMap, writer: &LuaComm
             })
         })
         .collect();
+
+    for pkg in dormant.iter().filter(|d| d.is_startable()) {
+        for cmd in &pkg.triggers.cmd {
+            // A real registration always wins. Once the package has loaded, it
+            // owns the name, and listing the pending entry as well would show
+            // the command twice.
+            if commands.iter().any(|c| c.name.as_ref() == cmd.as_str()) {
+                continue;
+            }
+            commands.push(LuaCommandInfo {
+                name: Arc::from(cmd.as_str()),
+                description: Arc::from(format!("{} (loads {})", cmd, pkg.name)),
+                plugin: Arc::from(pkg.name.as_str()),
+                // Unknown until the package registers the command, and too few
+                // would stop the palette matching once arguments are typed.
+                max_args: usize::MAX,
+            });
+        }
+    }
     writer.publish(commands);
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -567,7 +604,9 @@ mod tests {
             .insert(Arc::from("/cmd3"), make_entry(&lua, "desc3"));
 
         let (writer, reader) = LuaCommandWriter::new();
-        publish_command_snapshot(&map, &writer);
+        lua.set_app_data(map);
+        lua.set_app_data(writer);
+        publish_command_snapshot(&lua).unwrap();
 
         let snap = reader.load();
         assert_eq!(snap.commands.len(), 3);

--- a/maki-lua/src/api/util/setup.rs
+++ b/maki-lua/src/api/util/setup.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 use maki_config::RawConfig;
 use mlua::{Function, Lua, LuaSerdeExt, Result as LuaResult};
 
+use crate::api::pack::packadd__doc;
 use crate::api::split::split__doc;
 use crate::docs::{DocKind, FnDoc, ModuleDoc, ParamDoc};
 
@@ -34,6 +35,7 @@ accepts the same keys as the Configuration reference.",
 })",
         },
         split__doc,
+        packadd__doc,
     ],
 };
 

--- a/maki-lua/src/api/version.rs
+++ b/maki-lua/src/api/version.rs
@@ -1,0 +1,63 @@
+//! `maki.version`, modelled after Neovim's `vim.version`.
+
+use maki_lua_macro::{lua_fn, lua_table};
+use maki_pack::Version;
+use mlua::{Lua, Result as LuaResult, Table};
+
+/// Marks a table as the result of `maki.version.range`, so `pack.add` can tell
+/// a constraint from an ordinary string version.
+pub(crate) const RANGE_MARKER: &str = "__maki_version_range";
+
+/// Build a semver constraint, like `vim.version.range`.
+///
+/// A package given a range installs the greatest tag the constraint admits.
+///
+/// @param spec string Constraint, for example `"^1.2"` or `">=1.0, <2.0"`.
+/// @return (table) Value to pass as a spec's `version`.
+/// @example
+/// maki.pack.add({
+///   { src = "https://github.com/user/plugin", version = maki.version.range("^1") },
+/// })
+#[lua_fn]
+fn range(lua: &Lua, spec: String) -> LuaResult<Table> {
+    // Parsed here so a bad constraint is reported where it was written, not
+    // later when a package tries to install.
+    Version::range(&spec)
+        .map_err(|e| mlua::Error::runtime(format!("version.range: {spec:?} is not valid: {e}")))?;
+    let table = lua.create_table()?;
+    table.set(RANGE_MARKER, spec)?;
+    Ok(table)
+}
+
+lua_table! {
+    /// Version constraints, modelled after `vim.version`.
+    ///
+    /// ```lua
+    /// local v = maki.version.range("^1.2")
+    /// ```
+    "maki.version" => pub(crate) fn create_version_table(), DOCS [
+        range,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A bad constraint is reported where it was written, not later when the
+    /// package tries to install.
+    #[test]
+    fn an_invalid_range_fails_at_the_call_site() {
+        let lua = Lua::new();
+        let range_fn: mlua::Function = create_version_table(&lua).unwrap().get("range").unwrap();
+        assert!(range_fn.call::<Table>("not a range").is_err());
+    }
+
+    #[test]
+    fn a_valid_range_is_marked_so_pack_add_can_recognize_it() {
+        let lua = Lua::new();
+        let range_fn: mlua::Function = create_version_table(&lua).unwrap().get("range").unwrap();
+        let t: Table = range_fn.call("^1.2").unwrap();
+        assert_eq!(t.get::<String>(RANGE_MARKER).unwrap(), "^1.2");
+    }
+}

--- a/maki-lua/src/docs.rs
+++ b/maki-lua/src/docs.rs
@@ -159,13 +159,10 @@ mod tests {
                 .insert(key);
         }
 
-        // Documented here but attached by the runtime rather than by
-        // `create_maki_global`, so the table built for this test has none of
-        // them. `setup` and `version` are attached only when a config store is
-        // present, which is what limits them to `init.lua`; `packadd` is
-        // attached for every plugin, just later. The global `pack` table has
-        // only its read API until the runtime replaces it for `init.lua`.
-        const RUNTIME_ATTACHED: [&str; 3] = ["setup", "version", "packadd"];
+        // `setup` and `version` are attached only when a config store is
+        // present, which is what limits them to `init.lua`. The global `pack`
+        // table has only its read API until the runtime replaces it there.
+        const RUNTIME_ATTACHED: [&str; 2] = ["setup", "version"];
 
         for (name, mut expected) in documented {
             if RUNTIME_ATTACHED

--- a/maki-lua/src/docs.rs
+++ b/maki-lua/src/docs.rs
@@ -53,6 +53,8 @@ pub fn api_docs() -> Vec<&'static ModuleDoc> {
     use crate::api;
     vec![
         &api::util::setup::DOCS,
+        &api::pack::DOCS,
+        &api::version::DOCS,
         &api::tool::DOCS,
         &api::autocmd::DOCS,
         &api::slot::DOCS,
@@ -157,11 +159,25 @@ mod tests {
                 .insert(key);
         }
 
+        // Documented here but attached by the runtime rather than by
+        // `create_maki_global`, so the table built for this test has none of
+        // them. `setup`, `pack`, and `version` are attached only when a config
+        // store is present, which is what limits them to `init.lua`;
+        // `packadd` is attached for every plugin, just later.
+        const RUNTIME_ATTACHED: [&str; 4] = ["setup", "pack", "version", "packadd"];
+
         for (name, mut expected) in documented {
+            if RUNTIME_ATTACHED
+                .iter()
+                .any(|only| name == format!("maki.{only}"))
+            {
+                continue;
+            }
             let actual = table_keys(&resolve_table(&maki, name));
             if name == "maki" {
-                // Documented here, but injected later by the runtime.
-                expected.remove("setup");
+                for only in RUNTIME_ATTACHED {
+                    expected.remove(only);
+                }
             }
             let expected: BTreeSet<String> = expected.iter().map(|s| s.to_string()).collect();
             assert_eq!(

--- a/maki-lua/src/docs.rs
+++ b/maki-lua/src/docs.rs
@@ -161,10 +161,11 @@ mod tests {
 
         // Documented here but attached by the runtime rather than by
         // `create_maki_global`, so the table built for this test has none of
-        // them. `setup`, `pack`, and `version` are attached only when a config
-        // store is present, which is what limits them to `init.lua`;
-        // `packadd` is attached for every plugin, just later.
-        const RUNTIME_ATTACHED: [&str; 4] = ["setup", "pack", "version", "packadd"];
+        // them. `setup` and `version` are attached only when a config store is
+        // present, which is what limits them to `init.lua`; `packadd` is
+        // attached for every plugin, just later. The global `pack` table has
+        // only its read API until the runtime replaces it for `init.lua`.
+        const RUNTIME_ATTACHED: [&str; 3] = ["setup", "version", "packadd"];
 
         for (name, mut expected) in documented {
             if RUNTIME_ATTACHED
@@ -174,6 +175,9 @@ mod tests {
                 continue;
             }
             let actual = table_keys(&resolve_table(&maki, name));
+            if name == "maki.pack" {
+                expected.retain(|function| *function == "get");
+            }
             if name == "maki" {
                 for only in RUNTIME_ATTACHED {
                     expected.remove(only);

--- a/maki-lua/src/error.rs
+++ b/maki-lua/src/error.rs
@@ -17,14 +17,14 @@ pub enum PluginError {
         #[source]
         source: io::Error,
     },
-    #[error(
-        "plugins.{plugin} sets options ({keys}), but there is no bundled plugin named \"{plugin}\""
-    )]
-    UnknownPluginOptions { plugin: String, keys: String },
     #[error("no bundled plugin named \"{plugin}\" (enabled via plugins.{plugin})")]
     UnknownPlugin { plugin: String },
     #[error("plugin host is not running")]
     HostDead,
+    #[error(
+        "the plugin host is still running background work, so \"{owner}\" could not be loaded or unloaded in time"
+    )]
+    HostBusy { owner: String },
     #[error("package {name} at {path} has no plugin/*.lua entrypoint")]
     PackageEmpty { name: String, path: PathBuf },
     #[error("package file {path} resolves outside its package directory")]

--- a/maki-lua/src/error.rs
+++ b/maki-lua/src/error.rs
@@ -25,4 +25,26 @@ pub enum PluginError {
     UnknownPlugin { plugin: String },
     #[error("plugin host is not running")]
     HostDead,
+    #[error("package {name} at {path} has no plugin/*.lua entrypoint")]
+    PackageEmpty { name: String, path: PathBuf },
+    #[error("package file {path} resolves outside its package directory")]
+    PackageEscape { path: PathBuf },
+    #[error(
+        "package \"{name}\" at {path} has the same name as a bundled plugin; \
+         rename its directory"
+    )]
+    PackageNameConflict { name: String, path: PathBuf },
+    #[error("package manifest {path} is not valid toml: {message}")]
+    PackageManifest { path: PathBuf, message: String },
+    #[error("cannot resolve the maki data directory, so no package was looked for: {source}")]
+    PackageSiteUnavailable {
+        #[source]
+        source: io::Error,
+    },
+    #[error("two packages are both named \"{name}\": {first} and {second}")]
+    DuplicatePackage {
+        name: String,
+        first: PathBuf,
+        second: PathBuf,
+    },
 }

--- a/maki-lua/src/error.rs
+++ b/maki-lua/src/error.rs
@@ -29,6 +29,8 @@ pub enum PluginError {
     PackageEmpty { name: String, path: PathBuf },
     #[error("package file {path} resolves outside its package directory")]
     PackageEscape { path: PathBuf },
+    #[error("{plugin} did not finish loading within {milliseconds}ms")]
+    LoadTimeout { plugin: String, milliseconds: u128 },
     #[error(
         "package \"{name}\" at {path} has the same name as a bundled plugin; \
          rename its directory"

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -10,7 +10,7 @@ mod runtime;
 
 pub use api::keymap::{KeymapEntry, KeymapReader, KeymapSnapshot};
 pub use api::options::{OptionSpec, OptionType, PluginOptionSpecs};
-pub use api::pack::{Declared, PackOp};
+pub use api::pack::{Declared, Dormant, PackChange, PackChangeKind, PackOp, PackState, Triggers};
 pub use api::util::command::{
     Anchor, Axis, Border, BuiltinAction, Dimension, Edge, FloatConfig, FloatConfigPatch,
     HintReader, HintSnapshot, LuaCommandInfo, LuaCommandReader, ModelRequest, SessionRequest,
@@ -20,9 +20,9 @@ pub use docs::{DocKind, FnDoc, ModuleDoc, ParamDoc, api_docs};
 pub use error::PluginError;
 pub use loader::{EventHandle, PluginHost};
 pub use pack::{
-    DiscoveredPackage, Discovery, InstallReport, Interaction, MANAGED_GROUP, Origin, PackCommand,
-    PackReport, apply_pack_ops, discover, discover_installed, drain_pack_ops, install_declared,
-    installed_names, lockfile_path, plan_command, site_dir,
+    DiscoveredPackage, Discovery, InstallReport, Interaction, PackCommand, PackReport,
+    apply_pack_ops, arm_packages, discover, discover_installed, drain_pack_ops, install_declared,
+    installed_names, installed_package, plan_command, sanitize_message,
 };
 pub use plugin_permissions::{Permission, PluginPermissions, Requested};
 pub use runtime::{KILL_GRACE, RestoreItem, WARM_TOOL_CAP};

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -20,9 +20,9 @@ pub use docs::{DocKind, FnDoc, ModuleDoc, ParamDoc, api_docs};
 pub use error::PluginError;
 pub use loader::{EventHandle, PluginHost};
 pub use pack::{
-    DiscoveredPackage, Discovery, InstallReport, Interaction, MANAGED_GROUP, Origin, PackReport,
-    apply_pack_ops, discover, discover_installed, drain_pack_ops, install_declared, lockfile_path,
-    site_dir,
+    DiscoveredPackage, Discovery, InstallReport, Interaction, MANAGED_GROUP, Origin, PackCommand,
+    PackReport, apply_pack_ops, discover, discover_installed, drain_pack_ops, install_declared,
+    installed_names, lockfile_path, plan_command, site_dir,
 };
 pub use plugin_permissions::{Permission, PluginPermissions, Requested};
 pub use runtime::{KILL_GRACE, RestoreItem, WARM_TOOL_CAP};

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -22,7 +22,7 @@ pub use loader::{EventHandle, PluginHost};
 pub use pack::{
     DiscoveredPackage, Discovery, InstallReport, Interaction, PackCommand, PackReport,
     apply_pack_ops, arm_packages, discover, discover_installed, drain_pack_ops, install_declared,
-    installed_names, installed_package, plan_command, sanitize_message,
+    installed_names, installed_package, plan_command, resolve_declared_on_disk, sanitize_message,
 };
 pub use plugin_permissions::{Permission, PluginPermissions, Requested};
 pub use runtime::{KILL_GRACE, RestoreItem, WARM_TOOL_CAP};

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -10,6 +10,7 @@ mod runtime;
 
 pub use api::keymap::{KeymapEntry, KeymapReader, KeymapSnapshot};
 pub use api::options::{OptionSpec, OptionType, PluginOptionSpecs};
+pub use api::pack::{Declared, PackOp};
 pub use api::util::command::{
     Anchor, Axis, Border, BuiltinAction, Dimension, Edge, FloatConfig, FloatConfigPatch,
     HintReader, HintSnapshot, LuaCommandInfo, LuaCommandReader, ModelRequest, SessionRequest,
@@ -19,7 +20,9 @@ pub use docs::{DocKind, FnDoc, ModuleDoc, ParamDoc, api_docs};
 pub use error::PluginError;
 pub use loader::{EventHandle, PluginHost};
 pub use pack::{
-    DiscoveredPackage, Discovery, MANAGED_GROUP, discover, discover_installed, site_dir,
+    DiscoveredPackage, Discovery, InstallReport, Interaction, MANAGED_GROUP, Origin, PackReport,
+    apply_pack_ops, discover, discover_installed, drain_pack_ops, install_declared, lockfile_path,
+    site_dir,
 };
 pub use plugin_permissions::{Permission, PluginPermissions, Requested};
 pub use runtime::{KILL_GRACE, RestoreItem, WARM_TOOL_CAP};

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -4,6 +4,7 @@ pub mod docs_render;
 mod error;
 pub mod language;
 mod loader;
+mod pack;
 pub(crate) mod plugin_permissions;
 mod runtime;
 
@@ -17,7 +18,10 @@ pub use api::util::command::{
 pub use docs::{DocKind, FnDoc, ModuleDoc, ParamDoc, api_docs};
 pub use error::PluginError;
 pub use loader::{EventHandle, PluginHost};
-pub use plugin_permissions::{Permission, PluginPermissions};
+pub use pack::{
+    DiscoveredPackage, Discovery, MANAGED_GROUP, discover, discover_installed, site_dir,
+};
+pub use plugin_permissions::{Permission, PluginPermissions, Requested};
 pub use runtime::{KILL_GRACE, RestoreItem, WARM_TOOL_CAP};
 
 pub mod test_support {

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -21,6 +21,34 @@ use maki_agent::prompt::ResolvedSlots;
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// How long a load or an unload waits for the runtime to answer.
+///
+/// Both handlers first wait for in-flight Lua tasks to reach zero, and a plain
+/// `maki.async.run` loop has no deadline and no cancel token, so that wait can
+/// never end. `/packupdate` unloads and reloads an owner after the terminal has
+/// been restored, which turned that into a process hung with no UI and no
+/// message.
+///
+/// Derived from the runtime's own load budget rather than picked: a shorter
+/// deadline would report a load that is still legitimately running as stuck,
+/// and that load would then commit its registrations after its caller had
+/// already treated it as failed.
+const HOST_REPLY_TIMEOUT: Duration = Duration::from_secs(crate::runtime::LOAD_TIMEOUT_SECS + 5);
+
+/// A reply that has not come yet, told apart from one that never can.
+///
+/// A host that is still working is a different fact from a host that has gone,
+/// and reporting the second as the first would send the user looking for a
+/// plugin to stop when there is no host left to stop it in.
+fn reply_failure(error: flume::RecvTimeoutError, owner: &str) -> PluginError {
+    match error {
+        flume::RecvTimeoutError::Timeout => PluginError::HostBusy {
+            owner: owner.to_owned(),
+        },
+        flume::RecvTimeoutError::Disconnected => PluginError::HostDead,
+    }
+}
+
 struct BundledPlugin {
     name: &'static str,
     dir: Dir<'static>,
@@ -360,26 +388,25 @@ impl PluginHost {
 
     fn send_builtin_loads(&self, config: &PluginsConfig) -> Result<(), PluginError> {
         for (plugin, opts) in &config.opts {
-            let keys: Vec<&str> = opts.keys().map(String::as_str).collect();
-            // An installed package may take options too, and its options are
-            // passed when the package itself loads, not here.
-            if config.packages.contains(plugin) {
+            // An enabled package takes its options when the package itself
+            // loads, and an enabled builtin takes them in the loop below.
+            if config.packages.contains(plugin) || config.names.contains(plugin) {
                 continue;
             }
-            if !BUNDLED_PLUGINS.iter().any(|p| p.name == plugin.as_str()) {
-                return Err(PluginError::UnknownPluginOptions {
-                    plugin: plugin.clone(),
-                    keys: keys.join(", "),
-                });
-            }
-            if !config.names.contains(plugin) {
-                tracing::warn!(
-                    plugin = plugin.as_str(),
-                    keys = keys.join(", "),
-                    "plugin is disabled; its plugins.{} options are ignored until re-enabled",
-                    plugin
-                );
-            }
+            // What is left is a name that exists but is not loading: a builtin
+            // or a package the config disabled, or one discovery refused. It
+            // cannot be a typo, because the config layer validated every
+            // `plugins.<name>` key against the same names before this ran. A
+            // package used to reach this as an error, which stopped maki from
+            // starting over options it was already ignoring.
+            let keys: Vec<&str> = opts.keys().map(String::as_str).collect();
+            tracing::warn!(
+                plugin = plugin.as_str(),
+                keys = keys.join(", "),
+                "nothing named {} is loading; its plugins.{} options are ignored",
+                plugin,
+                plugin
+            );
         }
         for builtin in &config.names {
             let dir = match BUNDLED_PLUGINS.iter().find(|p| p.name == builtin.as_str()) {
@@ -426,6 +453,7 @@ impl PluginHost {
         mark_package_active: bool,
     ) -> Result<(), PluginError> {
         let (reply_tx, reply_rx) = flume::bounded(1);
+        let owner = name.to_string();
         self.inner
             .tx
             .send(Request::LoadSource {
@@ -438,7 +466,9 @@ impl PluginHost {
                 reply: reply_tx,
             })
             .map_err(|_| PluginError::HostDead)?;
-        reply_rx.recv().map_err(|_| PluginError::HostDead)?
+        reply_rx
+            .recv_timeout(HOST_REPLY_TIMEOUT)
+            .map_err(|e| reply_failure(e, &owner))?
     }
 
     /// Option specs declared by loaded plugins via `maki.api.register_options`,
@@ -480,7 +510,9 @@ impl PluginHost {
                 reply: reply_tx,
             })
             .map_err(|_| PluginError::HostDead)?;
-        reply_rx.recv().map_err(|_| PluginError::HostDead)?;
+        reply_rx
+            .recv_timeout(HOST_REPLY_TIMEOUT)
+            .map_err(|e| reply_failure(e, plugin))?;
         Ok(())
     }
 
@@ -569,7 +601,9 @@ impl PluginHost {
             .tx
             .send(Request::CollectActivePackages { reply: reply_tx })
             .map_err(|_| PluginError::HostDead)?;
-        reply_rx.recv().map_err(|_| PluginError::HostDead)
+        reply_rx
+            .recv_timeout(HOST_REPLY_TIMEOUT)
+            .map_err(|e| reply_failure(e, "packages"))
     }
 
     #[cfg(test)]
@@ -650,11 +684,16 @@ impl PluginHost {
     ///
     /// Called by the host after the initiating task has exited, which keeps an
     /// unload off the thread that requested it.
-    pub fn take_pending_pack_ops(&self) -> Result<Vec<crate::api::pack::PackOp>, PluginError> {
+    /// Refuses further `maki.packadd` calls, and returns anything the queue
+    /// still holds.
+    ///
+    /// One call and not a read followed by a close, because a Lua task can
+    /// record an activation between the two and closing would strand it.
+    pub fn seal_pack_ops(&self) -> Result<Vec<crate::api::pack::PackOp>, PluginError> {
         let (reply_tx, reply_rx) = flume::bounded(1);
         self.inner
             .tx
-            .send(Request::TakePackOps { reply: reply_tx })
+            .send(Request::SealPackOps { reply: reply_tx })
             .map_err(|_| PluginError::HostDead)?;
         reply_rx.recv().map_err(|_| PluginError::HostDead)
     }
@@ -1039,6 +1078,23 @@ mod tests {
             PluginOpts::default(),
         )
         .expect("an active package must not run twice");
+    }
+
+    /// `/packupdate` unloads and loads an owner after the terminal has been
+    /// restored, and the runtime waits there for in-flight Lua tasks to reach
+    /// zero. A `maki.async.run` loop never lets that happen, so the reply has
+    /// a deadline; a host that is merely busy must say so, because reporting a
+    /// dead host would point the user at the wrong thing entirely.
+    #[test]
+    fn a_slow_reply_and_a_gone_host_are_different_failures() {
+        assert!(matches!(
+            reply_failure(flume::RecvTimeoutError::Timeout, "demo"),
+            PluginError::HostBusy { owner } if owner == "demo"
+        ));
+        assert!(matches!(
+            reply_failure(flume::RecvTimeoutError::Disconnected, "demo"),
+            PluginError::HostDead
+        ));
     }
 
     /// jit=true is exercised by the whole integration suite

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -131,6 +131,54 @@ static BUNDLED_DIRS: LazyLock<&'static [&'static Dir<'static>]> = LazyLock::new(
     Vec::leak(dirs)
 });
 
+/// Reads a package off disk into the chunks a load needs.
+///
+/// Deliberately separate from sending the load. Everything here is file I/O
+/// and nothing touches the Lua state, so the runtime thread can call it too.
+/// That is what makes a lazy trigger possible: `PluginHost::load_package`
+/// waits on a reply from the runtime, so the runtime cannot use it, but the
+/// runtime can read the package itself and then call `load_source` directly.
+pub(crate) fn read_package(
+    name: &str,
+    dir: &Path,
+) -> Result<(PathBuf, Vec<LoadChunk>), PluginError> {
+    // Refused here and not only in discovery, because loading an owner drops
+    // that owner's existing registrations first. A package named after a
+    // bundled plugin would unload the builtin before its own entrypoint ever
+    // ran, so every path that reaches a load has to be gated, not just the one
+    // that walks the site directory.
+    if is_bundled(name) {
+        return Err(PluginError::PackageNameConflict {
+            name: name.to_owned(),
+            path: dir.to_path_buf(),
+        });
+    }
+    // Resolved once here, so the manifest, the entrypoints, and later
+    // `require` calls all agree on one directory even if the path they came
+    // from changes underneath us.
+    let root = dir.canonicalize().map_err(|e| PluginError::Io {
+        path: dir.to_path_buf(),
+        source: e,
+    })?;
+    let files = package_entrypoints(&root)?;
+    if files.is_empty() {
+        return Err(PluginError::PackageEmpty {
+            name: name.to_owned(),
+            path: root,
+        });
+    }
+
+    let mut chunks = Vec::with_capacity(files.len());
+    for path in files {
+        let source = fs::read_to_string(&path).map_err(|e| PluginError::Io {
+            path: path.clone(),
+            source: e,
+        })?;
+        chunks.push(LoadChunk::new(path.display().to_string(), source));
+    }
+    Ok((root, chunks))
+}
+
 /// A package's entrypoints: every `plugin/*.lua`, sorted by filename so load
 /// order is deterministic across machines.
 ///
@@ -506,6 +554,15 @@ impl PluginHost {
         reply_rx.recv().map_err(|_| PluginError::HostDead)
     }
 
+    pub fn pack_lock_confirm(&self) -> Result<Option<bool>, PluginError> {
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        self.inner
+            .tx
+            .send(Request::CollectPackConfirm { reply: reply_tx })
+            .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)
+    }
+
     pub fn active_packages(&self) -> Result<std::collections::BTreeSet<String>, PluginError> {
         let (reply_tx, reply_rx) = flume::bounded(1);
         self.inner
@@ -513,6 +570,80 @@ impl PluginHost {
             .send(Request::CollectActivePackages { reply: reply_tx })
             .map_err(|_| PluginError::HostDead)?;
         reply_rx.recv().map_err(|_| PluginError::HostDead)
+    }
+
+    #[cfg(test)]
+    fn set_load_timeout(&self, timeout: Duration) -> Result<(), PluginError> {
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        self.inner
+            .tx
+            .send(Request::SetLoadTimeout {
+                timeout,
+                reply: reply_tx,
+            })
+            .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)
+    }
+
+    pub fn run_pack_loader(
+        &self,
+        declared: crate::api::pack::Declared,
+        path: &Path,
+        permissions: PluginPermissions,
+        opts: PluginOpts,
+    ) -> Result<(), PluginError> {
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        self.inner
+            .tx
+            .send(Request::RunPackLoader {
+                declared,
+                path: path.to_path_buf(),
+                permissions,
+                opts,
+                reply: reply_tx,
+            })
+            .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)?
+    }
+
+    pub fn fire_pack_changed(
+        &self,
+        event: &'static str,
+        change: crate::api::pack::PackChange,
+    ) -> Result<(), PluginError> {
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        self.inner
+            .tx
+            .send(Request::FirePackChanged {
+                event,
+                change,
+                reply: reply_tx,
+            })
+            .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)
+    }
+
+    /// Tells the runtime which packages are installed but not loaded, so a
+    /// trigger can activate one.
+    ///
+    /// Sent from the host because only the host knows where each package
+    /// landed and what its approval narrowed the permissions to. The runtime
+    /// then owns the activation itself, which is the only way it can happen:
+    /// `load_package` waits on a reply from the runtime thread.
+    pub fn set_dormant_packages(
+        &self,
+        packages: Vec<crate::api::pack::Dormant>,
+    ) -> Result<(), PluginError> {
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        self.inner
+            .tx
+            .send(Request::SetDormantPackages {
+                packages,
+                reply: reply_tx,
+            })
+            .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)?;
+        Ok(())
     }
 
     /// Takes the package operations Lua recorded, leaving the queue empty.
@@ -528,50 +659,6 @@ impl PluginHost {
         reply_rx.recv().map_err(|_| PluginError::HostDead)
     }
 
-    /// Loads every `start/` package, and every managed package the caller
-    /// installed.
-    ///
-    /// Activation is not handled here. `maki.packadd` records an operation,
-    /// and every recorded operation is applied at one drain point once all of
-    /// this has run, so a package activated by another one still loads in this
-    /// startup.
-    pub fn load_packages(
-        &self,
-        packages: &[DiscoveredPackage],
-        config: &PluginsConfig,
-    ) -> Vec<String> {
-        let mut failures = Vec::new();
-        for pkg in packages
-            .iter()
-            .filter(|pkg| pkg.eager && config.packages.iter().any(|n| n == &pkg.name))
-        {
-            let opts = config
-                .opts
-                .get(&pkg.name)
-                .cloned()
-                .map(Arc::new)
-                .unwrap_or_default();
-            // A package the user installed by hand is granted what it asks
-            // for. A package maki fetched is granted only where the request
-            // and a recorded approval agree, so a manifest cannot certify
-            // itself.
-            let permissions = crate::pack::effective_permissions(pkg);
-            if let Err(e) = self.load_package(&pkg.name, &pkg.dir, permissions, opts) {
-                tracing::error!(
-                    package = %pkg.name,
-                    path = %pkg.dir.display(),
-                    error = %e,
-                    "failed to load package"
-                );
-                failures.push(crate::pack::sanitize_message(&format!(
-                    "{}: failed to load: {e}",
-                    pkg.name
-                )));
-            }
-        }
-        failures
-    }
-
     /// Loads one external package directory as a single owner.
     ///
     /// Every `plugin/*.lua` becomes a chunk, and the chunks share one
@@ -584,31 +671,96 @@ impl PluginHost {
         permissions: PluginPermissions,
         opts: PluginOpts,
     ) -> Result<(), PluginError> {
-        // Resolved once here, so the manifest, the entrypoints, and later
-        // `require` calls all agree on one directory even if the path they came
-        // from changes underneath us.
-        let root = dir.canonicalize().map_err(|e| PluginError::Io {
-            path: dir.to_path_buf(),
-            source: e,
-        })?;
-        let files = package_entrypoints(&root)?;
-        if files.is_empty() {
-            return Err(PluginError::PackageEmpty {
-                name: name.to_owned(),
-                path: root,
-            });
-        }
-
-        let mut chunks = Vec::with_capacity(files.len());
-        for path in files {
-            let source = fs::read_to_string(&path).map_err(|e| PluginError::Io {
-                path: path.clone(),
-                source: e,
-            })?;
-            chunks.push(LoadChunk::new(path.display().to_string(), source));
-        }
+        let (root, chunks) = read_package(name, dir)?;
         self.send_load(Arc::from(name), chunks, Some(root), permissions, opts, true)
     }
+
+    /// Loads the manually installed packages that load at startup.
+    ///
+    /// A broken package must not stop maki from starting, so each failure is
+    /// reported and the remaining packages still load. Packages the config
+    /// disabled are skipped, as are `opt/` packages, which wait to be
+    /// activated.
+    pub fn load_packages(
+        &self,
+        packages: &[DiscoveredPackage],
+        config: &PluginsConfig,
+    ) -> Vec<String> {
+        let mut failures = Vec::new();
+        for pkg in packages.iter().filter(|p| p.eager) {
+            if !config.packages.iter().any(|n| n == &pkg.name) {
+                continue;
+            }
+            let opts = config
+                .opts
+                .get(&pkg.name)
+                .cloned()
+                .map(Arc::new)
+                .unwrap_or_default();
+            // A package the user installed by hand is granted what it asks
+            // for. A package maki fetched is granted only where the request
+            // and a recorded approval agree, so a manifest cannot certify
+            // itself.
+            let permissions = crate::pack::effective_permissions(pkg);
+            if let Err(e) = self.load_package(&pkg.name, &pkg.dir, permissions, opts) {
+                let message = crate::pack::redact_error(&e);
+                tracing::error!(
+                    package = %pkg.name,
+                    path = %pkg.dir.display(),
+                    error = %message,
+                    "failed to load package"
+                );
+                failures.push(format!("{}: failed to load: {message}", pkg.name));
+            }
+        }
+        failures
+    }
+
+    pub fn load_declared_packages(
+        &self,
+        packages: &[DiscoveredPackage],
+        declared: &[crate::api::pack::Declared],
+        config: &PluginsConfig,
+    ) -> Vec<String> {
+        let mut failures = Vec::new();
+        for package in packages.iter().filter(|package| package.eager) {
+            if !config.packages.iter().any(|name| name == &package.name) {
+                continue;
+            }
+            let Some(declaration) = declared
+                .iter()
+                .find(|declaration| declaration.spec.name == package.name)
+            else {
+                failures.extend(self.load_packages(std::slice::from_ref(package), config));
+                continue;
+            };
+            if !matches!(declaration.load, crate::api::pack::LoadMode::Custom(_)) {
+                failures.extend(self.load_packages(std::slice::from_ref(package), config));
+                continue;
+            }
+            let permissions = crate::pack::effective_permissions(package);
+            let opts = config
+                .opts
+                .get(&package.name)
+                .cloned()
+                .map(Arc::new)
+                .unwrap_or_default();
+            if let Err(error) =
+                self.run_pack_loader(declaration.clone(), &package.dir, permissions, opts)
+            {
+                let message = crate::pack::redact_error(&error);
+                tracing::error!(
+                    package = %package.name,
+                    path = %package.dir.display(),
+                    error = %message,
+                    "custom package loader failed"
+                );
+                failures.push(format!("{}: custom loader failed: {message}", package.name));
+            }
+        }
+        failures
+    }
+
     pub fn event_handle(&self) -> EventHandle {
         EventHandle {
             tx: self.inner.tx.clone(),
@@ -752,9 +904,14 @@ impl EventHandle {
         });
     }
 
-    pub fn run_keybind_callback(&self, id: u64) -> bool {
+    pub fn run_keybind_callback(
+        &self,
+        id: u64,
+        key: crossterm::event::KeyCode,
+        modifiers: crossterm::event::KeyModifiers,
+    ) -> bool {
         self.prio_tx
-            .try_send(Request::RunKeybindCallback { id })
+            .try_send(Request::RunKeybindCallback { id, key, modifiers })
             .is_ok()
     }
 }
@@ -767,6 +924,122 @@ mod tests {
     use maki_agent::tools::ToolRegistry;
     use std::time::Instant;
     use test_case::test_case;
+
+    fn package_with_source(source: &str) -> tempfile::TempDir {
+        let package = tempfile::TempDir::new().unwrap();
+        let plugin_dir = package.path().join("plugin");
+        std::fs::create_dir(&plugin_dir).unwrap();
+        std::fs::write(plugin_dir.join("init.lua"), source).unwrap();
+        package
+    }
+
+    #[test]
+    fn spinning_package_load_times_out() {
+        let package = package_with_source("while true do end");
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        host.set_load_timeout(Duration::from_millis(300)).unwrap();
+
+        let started = Instant::now();
+        let error = host
+            .load_package(
+                "spinner",
+                package.path(),
+                PluginPermissions::trusted(),
+                PluginOpts::default(),
+            )
+            .expect_err("the watchdog must stop the load");
+
+        assert!(
+            matches!(error, PluginError::LoadTimeout { .. }),
+            "got: {error:?}"
+        );
+        assert!(started.elapsed() < Duration::from_secs(20), "{error}");
+    }
+
+    #[test]
+    fn parked_package_load_times_out_and_rolls_back() {
+        let package = package_with_source(
+            r#"
+            maki.api.register_command({ name = "/parked", handler = function() end })
+            maki.async.run(function()
+              maki.api.register_command({ name = "/late", handler = function() end })
+            end)
+            maki.async.await(1, function(_callback) end)
+            "#,
+        );
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        host.set_load_timeout(Duration::from_millis(300)).unwrap();
+
+        let error = host
+            .load_package(
+                "parked",
+                package.path(),
+                PluginPermissions::trusted(),
+                PluginOpts::default(),
+            )
+            .expect_err("the wall-clock timer must stop the load");
+
+        assert!(matches!(error, PluginError::LoadTimeout { .. }));
+        assert!(
+            host.command_reader()
+                .load()
+                .commands
+                .iter()
+                .all(|command| !matches!(command.name.as_ref(), "/parked" | "/late"))
+        );
+        host.load_source("after_timeout", "").unwrap();
+    }
+
+    #[test]
+    fn failed_package_discards_queued_async_work() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+
+        host.load_source(
+            "failed",
+            r#"
+            maki.async.run(function()
+              maki.api.register_command({ name = "/late", handler = function() end })
+            end)
+            error("stop")
+            "#,
+        )
+        .expect_err("the package must fail");
+        host.load_source("fence", "").unwrap();
+
+        assert!(
+            host.command_reader()
+                .load()
+                .commands
+                .iter()
+                .all(|command| command.name.as_ref() != "/late")
+        );
+    }
+
+    #[test]
+    fn loading_an_active_package_does_not_run_it_again() {
+        let package = package_with_source("");
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        host.load_package(
+            "once",
+            package.path(),
+            PluginPermissions::trusted(),
+            PluginOpts::default(),
+        )
+        .unwrap();
+        std::fs::write(
+            package.path().join("plugin/init.lua"),
+            "error('loaded twice')",
+        )
+        .unwrap();
+
+        host.load_package(
+            "once",
+            package.path(),
+            PluginPermissions::trusted(),
+            PluginOpts::default(),
+        )
+        .expect("an active package must not run twice");
+    }
 
     /// jit=true is exercised by the whole integration suite
     /// (`tests/plugin_host.rs` boots hosts via `new`); only the O1
@@ -993,7 +1266,7 @@ mod tests {
         );
 
         let handle = host.event_handle();
-        handle.run_keybind_callback(entry.id);
+        handle.run_keybind_callback(entry.id, entry.key, entry.modifiers);
 
         let deadline = Instant::now() + Duration::from_secs(2);
         loop {

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -16,10 +16,13 @@ use crate::api::util::command::{HintReader, LuaCommandReader, UiAction};
 use crate::error::PluginError;
 use crate::pack::DiscoveredPackage;
 use crate::plugin_permissions::{PluginPermissions, load_plugin_permissions};
-use crate::runtime::{self, ClickFallback, LoadChunk, LuaThread, Request, RestoreItem};
+use crate::runtime::{
+    self, ClickFallback, ConfigScope, LoadChunk, LuaThread, Request, RestoreItem,
+};
 use maki_agent::prompt::ResolvedSlots;
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+const HOST_REPLY_BACKSTOP: Duration = Duration::from_secs(5);
 
 /// How long a load or an unload waits for the runtime to answer.
 ///
@@ -29,11 +32,11 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 /// been restored, which turned that into a process hung with no UI and no
 /// message.
 ///
-/// Derived from the runtime's own load budget rather than picked: a shorter
-/// deadline would report a load that is still legitimately running as stuck,
-/// and that load would then commit its registrations after its caller had
-/// already treated it as failed.
-const HOST_REPLY_TIMEOUT: Duration = Duration::from_secs(crate::runtime::LOAD_TIMEOUT_SECS + 5);
+/// The default async task deadline is the useful lower bound for the drain.
+/// A task can set a longer deadline, so this remains a backstop rather than a
+/// proof that the queued request has stopped.
+const HOST_REPLY_TIMEOUT: Duration =
+    crate::runtime::ASYNC_RUN_DEFAULT_DEADLINE.saturating_add(HOST_REPLY_BACKSTOP);
 
 /// A reply that has not come yet, told apart from one that never can.
 ///
@@ -331,12 +334,20 @@ impl PluginHost {
         let mut merged: Option<RawConfig> = None;
 
         for global_dir in maki_config::global_config_dirs() {
-            self.run_init_file(&global_dir.join("init.lua"), "global/init.lua", &mut merged)?;
+            self.run_init_file(
+                &global_dir.join("init.lua"),
+                ConfigScope::Global,
+                &mut merged,
+            )?;
             if merged.is_some() {
                 break;
             }
         }
-        self.run_init_file(&cwd.join(".maki/init.lua"), "project/init.lua", &mut merged)?;
+        self.run_init_file(
+            &cwd.join(".maki/init.lua"),
+            ConfigScope::Project,
+            &mut merged,
+        )?;
 
         Ok(merged)
     }
@@ -358,7 +369,7 @@ impl PluginHost {
     fn run_init_file(
         &self,
         path: &Path,
-        label: &str,
+        scope: ConfigScope,
         merged: &mut Option<RawConfig>,
     ) -> Result<(), PluginError> {
         if !path.is_file() {
@@ -369,7 +380,7 @@ impl PluginHost {
             source: e,
         })?;
         let plugin_dir = path.parent().map(Path::to_path_buf);
-        if let Some(raw) = self.send_run_init_lua(source, label.to_owned(), plugin_dir)? {
+        if let Some(raw) = self.send_config_lua(source, scope, plugin_dir)? {
             match merged {
                 Some(existing) => existing.merge(raw),
                 None => *merged = Some(raw),
@@ -488,12 +499,21 @@ impl PluginHost {
         source_name: String,
         plugin_dir: Option<PathBuf>,
     ) -> Result<Option<RawConfig>, PluginError> {
+        self.send_config_lua(source, ConfigScope::named(source_name), plugin_dir)
+    }
+
+    fn send_config_lua(
+        &self,
+        source: String,
+        scope: ConfigScope,
+        plugin_dir: Option<PathBuf>,
+    ) -> Result<Option<RawConfig>, PluginError> {
         let (reply_tx, reply_rx) = flume::bounded(1);
         self.inner
             .tx
             .send(Request::RunInitLua {
                 source,
-                source_name,
+                scope,
                 plugin_dir,
                 reply: reply_tx,
             })
@@ -582,15 +602,6 @@ impl PluginHost {
         self.inner
             .tx
             .send(Request::CollectPackages { reply: reply_tx })
-            .map_err(|_| PluginError::HostDead)?;
-        reply_rx.recv().map_err(|_| PluginError::HostDead)
-    }
-
-    pub fn pack_lock_confirm(&self) -> Result<Option<bool>, PluginError> {
-        let (reply_tx, reply_rx) = flume::bounded(1);
-        self.inner
-            .tx
-            .send(Request::CollectPackConfirm { reply: reply_tx })
             .map_err(|_| PluginError::HostDead)?;
         reply_rx.recv().map_err(|_| PluginError::HostDead)
     }
@@ -964,6 +975,8 @@ mod tests {
     use std::time::Instant;
     use test_case::test_case;
 
+    const NON_CUSTOM_LOADER_ERROR: &str = "run_pack_loader: not a custom load";
+
     fn package_with_source(source: &str) -> tempfile::TempDir {
         let package = tempfile::TempDir::new().unwrap();
         let plugin_dir = package.path().join("plugin");
@@ -1078,6 +1091,31 @@ mod tests {
             PluginOpts::default(),
         )
         .expect("an active package must not run twice");
+    }
+
+    #[test]
+    fn public_pack_loader_rejects_a_non_custom_declaration() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        let declared = crate::api::pack::Declared {
+            spec: maki_pack::Spec::new("https://example.com/demo.git"),
+            load: crate::api::pack::LoadMode::Eager,
+            confirm: true,
+            data: None,
+        };
+
+        let error = host
+            .run_pack_loader(
+                declared,
+                Path::new("."),
+                PluginPermissions::trusted(),
+                PluginOpts::default(),
+            )
+            .expect_err("a non-custom declaration must return an error");
+
+        assert!(
+            error.to_string().contains(NON_CUSTOM_LOADER_ERROR),
+            "{error}"
+        );
     }
 
     /// `/packupdate` unloads and loads an owner after the terminal has been

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -487,6 +487,76 @@ impl PluginHost {
         )
     }
 
+    /// Packages declared by `maki.pack.add` in `init.lua`.
+    ///
+    /// Read after the init files have run, which is when the declared set is
+    /// complete and before anything is installed.
+    pub fn declared_packages(&self) -> Result<Vec<crate::api::pack::Declared>, PluginError> {
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        self.inner
+            .tx
+            .send(Request::CollectPackages { reply: reply_tx })
+            .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)
+    }
+
+    /// Takes the package operations Lua recorded, leaving the queue empty.
+    ///
+    /// Called by the host after the initiating task has exited, which keeps an
+    /// unload off the thread that requested it.
+    pub fn take_pending_pack_ops(&self) -> Result<Vec<crate::api::pack::PackOp>, PluginError> {
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        self.inner
+            .tx
+            .send(Request::TakePackOps { reply: reply_tx })
+            .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)
+    }
+
+    /// Loads every `start/` package, and every managed package the caller
+    /// installed.
+    ///
+    /// Activation is not handled here. `maki.packadd` records an operation,
+    /// and every recorded operation is applied at one drain point once all of
+    /// this has run, so a package activated by another one still loads in this
+    /// startup.
+    pub fn load_packages(
+        &self,
+        packages: &[DiscoveredPackage],
+        config: &PluginsConfig,
+    ) -> Vec<String> {
+        let mut failures = Vec::new();
+        for pkg in packages
+            .iter()
+            .filter(|pkg| pkg.eager && config.packages.iter().any(|n| n == &pkg.name))
+        {
+            let opts = config
+                .opts
+                .get(&pkg.name)
+                .cloned()
+                .map(Arc::new)
+                .unwrap_or_default();
+            // A package the user installed by hand is granted what it asks
+            // for. A package maki fetched is granted only where the request
+            // and a recorded approval agree, so a manifest cannot certify
+            // itself.
+            let permissions = crate::pack::effective_permissions(pkg);
+            if let Err(e) = self.load_package(&pkg.name, &pkg.dir, permissions, opts) {
+                tracing::error!(
+                    package = %pkg.name,
+                    path = %pkg.dir.display(),
+                    error = %e,
+                    "failed to load package"
+                );
+                failures.push(crate::pack::sanitize_message(&format!(
+                    "{}: failed to load: {e}",
+                    pkg.name
+                )));
+            }
+        }
+        failures
+    }
+
     /// Loads one external package directory as a single owner.
     ///
     /// Every `plugin/*.lua` becomes a chunk, and the chunks share one
@@ -499,17 +569,6 @@ impl PluginHost {
         permissions: PluginPermissions,
         opts: PluginOpts,
     ) -> Result<(), PluginError> {
-        // Refused here and not only in discovery, because loading an owner
-        // drops that owner's existing registrations first. A package named
-        // after a bundled plugin would unload the builtin before its own
-        // entrypoint ever ran, so every caller has to be gated, not just the
-        // one that walks the site directory.
-        if is_bundled(name) {
-            return Err(PluginError::PackageNameConflict {
-                name: name.to_owned(),
-                path: dir.to_path_buf(),
-            });
-        }
         // Resolved once here, so the manifest, the entrypoints, and later
         // `require` calls all agree on one directory even if the path they came
         // from changes underneath us.
@@ -535,107 +594,6 @@ impl PluginHost {
         }
         self.send_load(Arc::from(name), chunks, Some(root), permissions, opts)
     }
-
-    /// Loads the manually installed packages that load at startup.
-    ///
-    /// A broken package must not stop maki from starting, so each failure is
-    /// reported and the remaining packages still load. Packages the config
-    /// disabled are skipped, as are `opt/` packages, which wait to be
-    /// activated.
-    /// Takes the package operations Lua recorded, leaving the queue empty.
-    ///
-    /// Called by the host after the initiating task has exited, which keeps a
-    /// load off the thread that requested it.
-    fn take_pending_pack_ops(&self) -> Result<Vec<crate::api::pack::PackOp>, PluginError> {
-        let (reply_tx, reply_rx) = flume::bounded(1);
-        self.inner
-            .tx
-            .send(Request::TakePackOps { reply: reply_tx })
-            .map_err(|_| PluginError::HostDead)?;
-        reply_rx.recv().map_err(|_| PluginError::HostDead)
-    }
-
-    /// Loads every package that should be loaded now: the `start/` ones, and
-    /// the `opt/` ones that `maki.packadd` named.
-    ///
-    /// Activation names are collected here rather than acted on inside
-    /// `packadd`, because a load waits on a reply from the runtime thread that
-    /// `packadd` is called on. They are collected after each round as well as
-    /// before the first, so a package that activates another one still has it
-    /// loaded in this startup rather than the next.
-    pub fn load_packages(
-        &self,
-        packages: &[DiscoveredPackage],
-        config: &PluginsConfig,
-    ) -> Vec<String> {
-        let mut failures = Vec::new();
-        let mut loaded: Vec<&str> = Vec::new();
-        let mut round: Vec<&DiscoveredPackage> = packages
-            .iter()
-            .filter(|pkg| pkg.eager && config.packages.iter().any(|n| n == &pkg.name))
-            .collect();
-
-        // A `loop` and not `while !round.is_empty()`: with no `start` package
-        // installed the first round is empty, and the names `init.lua` already
-        // recorded still have to be collected.
-        loop {
-            for pkg in round {
-                let opts = config
-                    .opts
-                    .get(&pkg.name)
-                    .cloned()
-                    .map(Arc::new)
-                    .unwrap_or_default();
-                // A package the user installed by hand is granted what it asks
-                // for. Only a package maki fetched needs an approval as well.
-                let permissions = pkg.requested.clone().granted_for_manual_install();
-                loaded.push(&pkg.name);
-                if let Err(e) = self.load_package(&pkg.name, &pkg.dir, permissions, opts) {
-                    tracing::error!(
-                        package = %pkg.name,
-                        path = %pkg.dir.display(),
-                        error = %e,
-                        "failed to load package"
-                    );
-                    failures.push(crate::pack::sanitize_message(&format!(
-                        "{}: failed to load: {e}",
-                        pkg.name
-                    )));
-                }
-            }
-
-            let ops = match self.take_pending_pack_ops() {
-                Ok(ops) => ops,
-                Err(e) => {
-                    failures.push(format!("could not read package activations: {e}"));
-                    break;
-                }
-            };
-            round = Vec::new();
-            for op in ops {
-                let crate::api::pack::PackOp::Activate { name } = op;
-                if loaded.contains(&name.as_str()) {
-                    continue;
-                }
-                // Refused rather than loaded when the config disabled it, so
-                // `packadd` cannot be a way around `plugins.<name>.enabled`.
-                let found = packages
-                    .iter()
-                    .find(|pkg| pkg.name == name && config.packages.iter().any(|n| n == &pkg.name));
-                match found {
-                    Some(pkg) => round.push(pkg),
-                    None => failures.push(crate::pack::sanitize_message(&format!(
-                        "packadd {name:?}: no package with that name is installed"
-                    ))),
-                }
-            }
-            if round.is_empty() {
-                break;
-            }
-        }
-        failures
-    }
-
     pub fn event_handle(&self) -> EventHandle {
         EventHandle {
             tx: self.inner.tx.clone(),

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -362,6 +362,7 @@ impl PluginHost {
                 None,
                 PluginPermissions::trusted(),
                 opts,
+                false,
             )?;
         }
         Ok(())
@@ -374,6 +375,7 @@ impl PluginHost {
         plugin_dir: Option<PathBuf>,
         permissions: PluginPermissions,
         opts: PluginOpts,
+        mark_package_active: bool,
     ) -> Result<(), PluginError> {
         let (reply_tx, reply_rx) = flume::bounded(1);
         self.inner
@@ -384,6 +386,7 @@ impl PluginHost {
                 plugin_dir,
                 permissions,
                 opts,
+                mark_package_active,
                 reply: reply_tx,
             })
             .map_err(|_| PluginError::HostDead)?;
@@ -449,6 +452,7 @@ impl PluginHost {
             None,
             PluginPermissions::trusted(),
             Arc::new(opts),
+            false,
         )
     }
 
@@ -464,6 +468,7 @@ impl PluginHost {
             None,
             permissions,
             PluginOpts::default(),
+            false,
         )
     }
 
@@ -484,6 +489,7 @@ impl PluginHost {
             plugin_dir,
             permissions,
             PluginOpts::default(),
+            false,
         )
     }
 
@@ -496,6 +502,15 @@ impl PluginHost {
         self.inner
             .tx
             .send(Request::CollectPackages { reply: reply_tx })
+            .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)
+    }
+
+    pub fn active_packages(&self) -> Result<std::collections::BTreeSet<String>, PluginError> {
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        self.inner
+            .tx
+            .send(Request::CollectActivePackages { reply: reply_tx })
             .map_err(|_| PluginError::HostDead)?;
         reply_rx.recv().map_err(|_| PluginError::HostDead)
     }
@@ -592,7 +607,7 @@ impl PluginHost {
             })?;
             chunks.push(LoadChunk::new(path.display().to_string(), source));
         }
-        self.send_load(Arc::from(name), chunks, Some(root), permissions, opts)
+        self.send_load(Arc::from(name), chunks, Some(root), permissions, opts, true)
     }
     pub fn event_handle(&self) -> EventHandle {
         EventHandle {

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -14,8 +14,9 @@ use crate::api::keymap::KeymapReader;
 use crate::api::options::{PluginOptionSpecs, PluginOpts};
 use crate::api::util::command::{HintReader, LuaCommandReader, UiAction};
 use crate::error::PluginError;
+use crate::pack::DiscoveredPackage;
 use crate::plugin_permissions::{PluginPermissions, load_plugin_permissions};
-use crate::runtime::{self, ClickFallback, LuaThread, Request, RestoreItem};
+use crate::runtime::{self, ClickFallback, LoadChunk, LuaThread, Request, RestoreItem};
 use maki_agent::prompt::ResolvedSlots;
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
@@ -110,6 +111,13 @@ static BUNDLED_PLUGINS: &[BundledPlugin] = &[
     },
 ];
 
+/// Every bundled name, not just the default-enabled ones. An external package
+/// sharing an owner name with any of them would let one package's unload tear
+/// down the other's registrations.
+pub(crate) fn is_bundled(name: &str) -> bool {
+    BUNDLED_PLUGINS.iter().any(|p| p.name == name)
+}
+
 pub(crate) fn lib_dir() -> &'static Dir<'static> {
     &BUNDLED_PLUGINS
         .iter()
@@ -122,6 +130,54 @@ static BUNDLED_DIRS: LazyLock<&'static [&'static Dir<'static>]> = LazyLock::new(
     let dirs: Vec<&'static Dir<'static>> = BUNDLED_PLUGINS.iter().map(|p| &p.dir).collect();
     Vec::leak(dirs)
 });
+
+/// A package's entrypoints: every `plugin/*.lua`, sorted by filename so load
+/// order is deterministic across machines.
+///
+/// A repository can commit a symlink, so each entry is resolved and checked to
+/// be inside the package before it is read.
+fn package_entrypoints(root: &Path) -> Result<Vec<PathBuf>, PluginError> {
+    let entrypoint_dir = root.join("plugin");
+    let entries = match fs::read_dir(&entrypoint_dir) {
+        Ok(entries) => entries,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) => {
+            return Err(PluginError::Io {
+                path: entrypoint_dir,
+                source,
+            });
+        }
+    };
+    let mut files = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|source| PluginError::Io {
+            path: entrypoint_dir.clone(),
+            source,
+        })?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("lua") {
+            continue;
+        }
+        let resolved = path.canonicalize().map_err(|e| PluginError::Io {
+            path: path.clone(),
+            source: e,
+        })?;
+        if !resolved.starts_with(root) {
+            return Err(PluginError::PackageEscape { path });
+        }
+        if resolved.is_file() {
+            let Some(file_name) = path.file_name().map(std::ffi::OsString::from) else {
+                continue;
+            };
+            files.push((file_name, resolved));
+        }
+    }
+    // By file name, not by the resolved path: a package may symlink an entry
+    // elsewhere inside itself, and load order must still be the order a user
+    // sees in `plugin/`.
+    files.sort_by(|(a, _), (b, _)| a.cmp(b));
+    Ok(files.into_iter().map(|(_, path)| path).collect())
+}
 
 pub struct PluginHost {
     inner: LuaThread,
@@ -257,6 +313,11 @@ impl PluginHost {
     fn send_builtin_loads(&self, config: &PluginsConfig) -> Result<(), PluginError> {
         for (plugin, opts) in &config.opts {
             let keys: Vec<&str> = opts.keys().map(String::as_str).collect();
+            // An installed package may take options too, and its options are
+            // passed when the package itself loads, not here.
+            if config.packages.contains(plugin) {
+                continue;
+            }
             if !BUNDLED_PLUGINS.iter().any(|p| p.name == plugin.as_str()) {
                 return Err(PluginError::UnknownPluginOptions {
                     plugin: plugin.clone(),
@@ -296,8 +357,8 @@ impl PluginHost {
                 .map(Arc::new)
                 .unwrap_or_default();
             self.send_load(
-                name,
-                init.to_owned(),
+                Arc::clone(&name),
+                vec![LoadChunk::new(name.as_ref(), init)],
                 None,
                 PluginPermissions::trusted(),
                 opts,
@@ -309,7 +370,7 @@ impl PluginHost {
     fn send_load(
         &self,
         name: Arc<str>,
-        source: String,
+        chunks: Vec<LoadChunk>,
         plugin_dir: Option<PathBuf>,
         permissions: PluginPermissions,
         opts: PluginOpts,
@@ -319,7 +380,7 @@ impl PluginHost {
             .tx
             .send(Request::LoadSource {
                 name,
-                source,
+                chunks,
                 plugin_dir,
                 permissions,
                 opts,
@@ -384,7 +445,7 @@ impl PluginHost {
     ) -> Result<(), PluginError> {
         self.send_load(
             Arc::from(name),
-            source.to_owned(),
+            vec![LoadChunk::new(name, source)],
             None,
             PluginPermissions::trusted(),
             Arc::new(opts),
@@ -399,7 +460,7 @@ impl PluginHost {
     ) -> Result<(), PluginError> {
         self.send_load(
             Arc::from(name),
-            source.to_owned(),
+            vec![LoadChunk::new(name, source)],
             None,
             permissions,
             PluginOpts::default(),
@@ -419,11 +480,160 @@ impl PluginHost {
         // unknown-plugin guards about user plugin names.
         self.send_load(
             Arc::from("user"),
-            source,
+            vec![LoadChunk::new(path.display().to_string(), source)],
             plugin_dir,
             permissions,
             PluginOpts::default(),
         )
+    }
+
+    /// Loads one external package directory as a single owner.
+    ///
+    /// Every `plugin/*.lua` becomes a chunk, and the chunks share one
+    /// environment, so what one file registers the next can use. The whole set
+    /// commits or none of it does.
+    pub fn load_package(
+        &self,
+        name: &str,
+        dir: &Path,
+        permissions: PluginPermissions,
+        opts: PluginOpts,
+    ) -> Result<(), PluginError> {
+        // Refused here and not only in discovery, because loading an owner
+        // drops that owner's existing registrations first. A package named
+        // after a bundled plugin would unload the builtin before its own
+        // entrypoint ever ran, so every caller has to be gated, not just the
+        // one that walks the site directory.
+        if is_bundled(name) {
+            return Err(PluginError::PackageNameConflict {
+                name: name.to_owned(),
+                path: dir.to_path_buf(),
+            });
+        }
+        // Resolved once here, so the manifest, the entrypoints, and later
+        // `require` calls all agree on one directory even if the path they came
+        // from changes underneath us.
+        let root = dir.canonicalize().map_err(|e| PluginError::Io {
+            path: dir.to_path_buf(),
+            source: e,
+        })?;
+        let files = package_entrypoints(&root)?;
+        if files.is_empty() {
+            return Err(PluginError::PackageEmpty {
+                name: name.to_owned(),
+                path: root,
+            });
+        }
+
+        let mut chunks = Vec::with_capacity(files.len());
+        for path in files {
+            let source = fs::read_to_string(&path).map_err(|e| PluginError::Io {
+                path: path.clone(),
+                source: e,
+            })?;
+            chunks.push(LoadChunk::new(path.display().to_string(), source));
+        }
+        self.send_load(Arc::from(name), chunks, Some(root), permissions, opts)
+    }
+
+    /// Loads the manually installed packages that load at startup.
+    ///
+    /// A broken package must not stop maki from starting, so each failure is
+    /// reported and the remaining packages still load. Packages the config
+    /// disabled are skipped, as are `opt/` packages, which wait to be
+    /// activated.
+    /// Takes the package operations Lua recorded, leaving the queue empty.
+    ///
+    /// Called by the host after the initiating task has exited, which keeps a
+    /// load off the thread that requested it.
+    fn take_pending_pack_ops(&self) -> Result<Vec<crate::api::pack::PackOp>, PluginError> {
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        self.inner
+            .tx
+            .send(Request::TakePackOps { reply: reply_tx })
+            .map_err(|_| PluginError::HostDead)?;
+        reply_rx.recv().map_err(|_| PluginError::HostDead)
+    }
+
+    /// Loads every package that should be loaded now: the `start/` ones, and
+    /// the `opt/` ones that `maki.packadd` named.
+    ///
+    /// Activation names are collected here rather than acted on inside
+    /// `packadd`, because a load waits on a reply from the runtime thread that
+    /// `packadd` is called on. They are collected after each round as well as
+    /// before the first, so a package that activates another one still has it
+    /// loaded in this startup rather than the next.
+    pub fn load_packages(
+        &self,
+        packages: &[DiscoveredPackage],
+        config: &PluginsConfig,
+    ) -> Vec<String> {
+        let mut failures = Vec::new();
+        let mut loaded: Vec<&str> = Vec::new();
+        let mut round: Vec<&DiscoveredPackage> = packages
+            .iter()
+            .filter(|pkg| pkg.eager && config.packages.iter().any(|n| n == &pkg.name))
+            .collect();
+
+        // A `loop` and not `while !round.is_empty()`: with no `start` package
+        // installed the first round is empty, and the names `init.lua` already
+        // recorded still have to be collected.
+        loop {
+            for pkg in round {
+                let opts = config
+                    .opts
+                    .get(&pkg.name)
+                    .cloned()
+                    .map(Arc::new)
+                    .unwrap_or_default();
+                // A package the user installed by hand is granted what it asks
+                // for. Only a package maki fetched needs an approval as well.
+                let permissions = pkg.requested.clone().granted_for_manual_install();
+                loaded.push(&pkg.name);
+                if let Err(e) = self.load_package(&pkg.name, &pkg.dir, permissions, opts) {
+                    tracing::error!(
+                        package = %pkg.name,
+                        path = %pkg.dir.display(),
+                        error = %e,
+                        "failed to load package"
+                    );
+                    failures.push(crate::pack::sanitize_message(&format!(
+                        "{}: failed to load: {e}",
+                        pkg.name
+                    )));
+                }
+            }
+
+            let ops = match self.take_pending_pack_ops() {
+                Ok(ops) => ops,
+                Err(e) => {
+                    failures.push(format!("could not read package activations: {e}"));
+                    break;
+                }
+            };
+            round = Vec::new();
+            for op in ops {
+                let crate::api::pack::PackOp::Activate { name } = op;
+                if loaded.contains(&name.as_str()) {
+                    continue;
+                }
+                // Refused rather than loaded when the config disabled it, so
+                // `packadd` cannot be a way around `plugins.<name>.enabled`.
+                let found = packages
+                    .iter()
+                    .find(|pkg| pkg.name == name && config.packages.iter().any(|n| n == &pkg.name));
+                match found {
+                    Some(pkg) => round.push(pkg),
+                    None => failures.push(crate::pack::sanitize_message(&format!(
+                        "packadd {name:?}: no package with that name is installed"
+                    ))),
+                }
+            }
+            if round.is_empty() {
+                break;
+            }
+        }
+        failures
     }
 
     pub fn event_handle(&self) -> EventHandle {

--- a/maki-lua/src/pack.rs
+++ b/maki-lua/src/pack.rs
@@ -5,6 +5,7 @@
 //! installs are resolved from recorded state instead, and never appear here.
 
 use std::fs;
+use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
 use crate::error::PluginError;
@@ -27,11 +28,34 @@ pub(crate) fn sanitize_message(message: &str) -> String {
 /// The group name reserved for packages maki installs itself. Manual discovery
 /// skips it, so one package can never be found twice, once from disk and once
 /// from recorded state, with the two disagreeing about its revision.
-pub const MANAGED_GROUP: &str = "core";
+///
+/// Re-exported rather than repeated: `maki-pack` decides where it puts a
+/// checkout, and a second copy here that drifted would stop discovery skipping
+/// the directory it writes.
+pub use maki_pack::paths::MANAGED_GROUP;
 
 /// `<data>/site`, the root Neovim would call a package path.
 pub fn site_dir() -> Result<PathBuf, std::io::Error> {
     maki_storage::paths::data_dir().map(|d| d.join("site"))
+}
+
+/// How a package reached the disk, which is what decides whose word grants its
+/// permissions.
+///
+/// This is a distinction the code needs and did not have. A manifest is written
+/// by whoever wrote the package. For a package the user placed by hand that is
+/// effectively the user, so the manifest is their own statement of intent. For
+/// a package maki fetched it is a stranger, and letting the manifest grant
+/// itself permissions would make the request self-certifying: an update could
+/// add `run = true` and gain the ability to start subprocesses without anyone
+/// agreeing to it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Origin {
+    /// The user put the files under `pack/<group>/`. Trusted like `init.lua`.
+    Manual,
+    /// Maki cloned it from this source. The source is part of the approval key,
+    /// so re-pointing a name at another repository does not inherit its grants.
+    Fetched { src: String },
 }
 
 #[derive(Debug, Clone)]
@@ -42,9 +66,744 @@ pub struct DiscoveredPackage {
     pub dir: PathBuf,
     /// `start/` packages load at startup; `opt/` packages wait to be activated.
     pub eager: bool,
-    /// What the package's manifest asks for. A manually installed package is
-    /// granted this directly: the user placed the files.
+    /// What the package's manifest asks for. Never a grant on its own for a
+    /// fetched package; see `Origin`.
     pub requested: Requested,
+    pub origin: Origin,
+}
+
+/// `pack-lock.json`, beside the user's configuration so it can be committed.
+///
+/// `global_config_dirs` returns several candidates; the last is the one
+/// `append_permission_rule` already treats as writable, so the lockfile uses
+/// the same directory rather than inventing its own rule.
+pub fn lockfile_path() -> Option<PathBuf> {
+    maki_config::global_config_dirs()
+        .into_iter()
+        .next_back()
+        .map(|dir| dir.join("pack-lock.json"))
+}
+
+/// `pack-approvals.json`, in the state directory beside the checkouts.
+///
+/// Deliberately not beside the lockfile. A lockfile is meant to be committed,
+/// so a package set reproduces on another machine. An approval is the opposite
+/// kind of fact: one person's decision to trust one repository on one machine,
+/// which must not travel with a repository into someone else's checkout.
+pub fn approvals_path() -> Option<PathBuf> {
+    site_dir().ok().map(|dir| dir.join("pack-approvals.json"))
+}
+
+/// Reads the approval store.
+///
+/// An unreadable store yields no approvals rather than a default-open one. The
+/// failure mode is then a package that loads with nothing granted, which is
+/// visible and recoverable, instead of one that loads with everything granted.
+pub fn read_approvals() -> maki_pack::approvals::Approvals {
+    let Some(path) = approvals_path() else {
+        return maki_pack::approvals::Approvals::default();
+    };
+    let text = match fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return maki_pack::approvals::Approvals::default();
+        }
+        Err(error) => {
+            tracing::error!(
+                path = %path.display(),
+                %error,
+                "pack approval store could not be read; granting nothing"
+            );
+            return maki_pack::approvals::Approvals::default();
+        }
+    };
+    match serde_json::from_str(&text) {
+        Ok(approvals) => approvals,
+        Err(e) => {
+            tracing::error!(
+                path = %path.display(),
+                error = %e,
+                "pack approval store is unreadable; granting nothing"
+            );
+            maki_pack::approvals::Approvals::default()
+        }
+    }
+}
+
+/// Effective permissions for a package about to load.
+///
+/// The whole point of `Origin`: a fetched package's own manifest is a request,
+/// and a request is not a grant.
+pub fn effective_permissions(
+    pkg: &DiscoveredPackage,
+) -> crate::plugin_permissions::PluginPermissions {
+    granted(pkg, &read_approvals())
+}
+
+/// The rule itself, with the store passed in.
+///
+/// Separated from the disk read so it can be tested against a store built in
+/// the test rather than against whatever the person running the tests happens
+/// to have approved.
+pub fn granted(
+    pkg: &DiscoveredPackage,
+    approvals: &maki_pack::approvals::Approvals,
+) -> crate::plugin_permissions::PluginPermissions {
+    match &pkg.origin {
+        Origin::Manual => pkg.requested.clone().granted_for_manual_install(),
+        Origin::Fetched { src } => {
+            let key = maki_pack::approvals::ApprovalKey::new(pkg.name.clone(), src);
+            let approved = crate::plugin_permissions::PluginPermissions::from_approved(
+                approvals
+                    .get(&key)
+                    .unwrap_or(&[])
+                    .iter()
+                    .map(String::as_str),
+            );
+            pkg.requested.intersect(&approved)
+        }
+    }
+}
+
+/// Whether this entry point can ask the user a question.
+///
+/// An install runs downloaded code, so it is a trust decision. A run with no
+/// terminal cannot take one, and must refuse rather than assume consent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Interaction {
+    Tty,
+    None,
+}
+
+impl Interaction {
+    fn confirm(self, prompt: &str) -> bool {
+        if self != Self::Tty || !io::stdin().is_terminal() {
+            return false;
+        }
+        eprint!("{} [y/N] ", sanitize_message(prompt));
+        let _ = io::stderr().flush();
+        let mut input = String::new();
+        io::stdin().read_line(&mut input).is_ok() && input.trim().eq_ignore_ascii_case("y")
+    }
+}
+
+/// What an install pass produced, and what it could not.
+///
+/// Failures are returned rather than only logged: installation runs before
+/// logging is set up, so a message written there reaches nobody.
+#[derive(Debug, Default)]
+pub struct InstallReport {
+    pub packages: Vec<DiscoveredPackage>,
+    pub failures: Vec<String>,
+}
+
+/// Installs the packages `init.lua` declared, and reports where each one
+/// landed.
+///
+/// Runs on the caller's thread, never the Lua thread: installing clones, and
+/// loading blocks on a reply from the runtime, so doing either from inside a
+/// Lua call would wait on a message that cannot be processed until it returns.
+///
+/// A package that fails to install is reported and skipped. One unreachable
+/// repository must not stop maki from starting, or a network problem would
+/// make the editor unusable.
+pub fn install_declared(
+    specs: &[crate::api::pack::Declared],
+    interaction: Interaction,
+) -> InstallReport {
+    let mut report = InstallReport::default();
+    if specs.is_empty() {
+        return report;
+    }
+    let site = match site_dir() {
+        Ok(site) => site,
+        Err(error) => {
+            report.failures.push(format!(
+                "no data directory, so no package was installed: {error}"
+            ));
+            return report;
+        }
+    };
+
+    let lock_path = lockfile_path();
+
+    // Held across the whole read, install, and write. Atomic rename gives
+    // durability but not isolation: without this, two processes could each read
+    // the same lockfile and the second write would discard the first's entries.
+    let _guard = match lock_path.as_deref().map(maki_pack::paths::sidecar_lock) {
+        Some(path) => match maki_pack::lock::Lock::acquire(&path) {
+            Ok(guard) => Some(guard),
+            Err(e) => {
+                // The error names the lock file and the process holding it,
+                // and says to delete it if that process is gone. Reporting a
+                // bare "another process" would be wrong after a crash.
+                tracing::error!(error = %e, "could not take the package lock");
+                report.failures.push(sanitize_message(&e.to_string()));
+                return report;
+            }
+        },
+        None => None,
+    };
+
+    let mut lock = match read_lockfile(lock_path.as_deref()) {
+        Some(lock) => lock,
+        None => {
+            report
+                .failures
+                .push("the pack lockfile is unreadable, so no package was installed".to_owned());
+            return report;
+        }
+    };
+
+    let manager = maki_pack::manager::Manager::new(&site);
+    let manual = discover(&site).packages;
+    let mut changed = false;
+
+    // Asked once for the whole batch, before anything is cloned. A package
+    // already recorded at the revision it asks for is not a new trust
+    // decision, so only a fresh source prompts. Credentials are redacted,
+    // because the prompt is the one place a source is shown in full.
+    let new_sources: Vec<String> = specs
+        .iter()
+        .filter(|declared| {
+            declared.confirm && manager.resolve(&lock, &declared.spec.name).is_none()
+        })
+        .map(|declared| {
+            format!(
+                "{} from {}",
+                declared.spec.name,
+                maki_pack::git::redact(&declared.spec.src)
+            )
+        })
+        .collect();
+    if !new_sources.is_empty()
+        && !interaction.confirm(&format!(
+            "Install these packages?\n  {}",
+            new_sources.join("\n  ")
+        ))
+    {
+        report.failures.push(format!(
+            "installation was not confirmed, so {} package(s) were not installed",
+            new_sources.len()
+        ));
+        return report;
+    }
+
+    for declared in specs {
+        let spec = &declared.spec;
+        if let Some(error) = owner_conflict(&spec.name) {
+            report.failures.push(sanitize_message(&error));
+            continue;
+        }
+        if let Some(package) = manual.iter().find(|package| package.name == spec.name) {
+            report.failures.push(sanitize_message(&format!(
+                "{}: a manual package at {} already has this name",
+                spec.name,
+                package.dir.display()
+            )));
+            continue;
+        }
+        let result = match smol::block_on(manager.ensure_installed(spec, &mut lock)) {
+            Ok(result) => result,
+            Err(e) => {
+                let message = redact_error(&e);
+                tracing::error!(package = %spec.name, error = %message, "failed to install package");
+                report
+                    .failures
+                    .push(format!("{}: failed to install: {message}", spec.name));
+                continue;
+            }
+        };
+        // A manifest that exists but cannot be parsed is not the same fact as
+        // one that is absent, so it stops this package rather than loading it
+        // with a request nobody wrote.
+        let requested = match load_requested_permissions(&result.dir) {
+            Ok(requested) => requested,
+            Err(problem) => {
+                report
+                    .failures
+                    .push(sanitize_message(&format!("{}: {problem}", spec.name)));
+                continue;
+            }
+        };
+        changed |= result.changed;
+        report.packages.push(DiscoveredPackage {
+            name: spec.name.clone(),
+            requested,
+            origin: Origin::Fetched {
+                src: spec.src.clone(),
+            },
+            dir: result.dir,
+            // `load = false` installs the package and leaves it for
+            // `maki.packadd`, which is the state a lazy trigger delays.
+            eager: matches!(declared.load, crate::api::pack::LoadMode::Eager),
+        });
+    }
+
+    // Written once, after the installs, and only when something moved.
+    if changed {
+        let recorded = match lock_path {
+            Some(path) => write_lockfile(&path, &lock),
+            None => false,
+        };
+        if !recorded {
+            // The packages are on disk but nothing records where. The next
+            // start reads the old lockfile and would not find them, so they
+            // must not be reported as installed either.
+            report.packages.clear();
+            report
+                .failures
+                .push("the pack lockfile could not be written, so no package was used".to_owned());
+        }
+    }
+
+    report
+}
+
+/// Applies the package operations Lua recorded.
+///
+/// Called by the host once the requesting task has exited. Nothing here may run
+/// inside a Lua call: unloading an owner blocks on a reply from the runtime
+/// thread, so a Lua handler that waited for its own package to be removed would
+/// wait on a message that cannot be processed until it returns.
+///
+/// Each operation is independent, so one failure is reported and the rest still
+/// run.
+pub fn apply_pack_ops(
+    host: &crate::loader::PluginHost,
+    ops: &[crate::api::pack::PackOp],
+    declared: &[crate::api::pack::Declared],
+    packages: &[DiscoveredPackage],
+    active: &std::collections::BTreeSet<String>,
+    config: &maki_config::PluginsConfig,
+) -> PackReport {
+    use crate::api::pack::{PackOp, UpdateTarget};
+
+    let mut report = PackReport::default();
+    if ops.is_empty() {
+        return report;
+    }
+    let site = match site_dir() {
+        Ok(site) => site,
+        Err(error) => {
+            report.failures.push(format!(
+                "no data directory, so packages cannot be changed: {error}"
+            ));
+            return report;
+        }
+    };
+    let manager = maki_pack::manager::Manager::new(&site);
+
+    // An activation loads code that is already installed at a revision the
+    // lockfile already records, so it changes no shared state. Taking the
+    // cross-process lock for it would block a real install for no reason.
+    let changes_state = ops
+        .iter()
+        .any(|op| !matches!(op, crate::api::pack::PackOp::Activate { .. }));
+    let lock_path = lockfile_path();
+    let _guard = match lock_path
+        .as_deref()
+        .filter(|_| changes_state)
+        .map(maki_pack::paths::sidecar_lock)
+    {
+        Some(path) => match maki_pack::lock::Lock::acquire(&path) {
+            Ok(guard) => Some(guard),
+            Err(e) => {
+                // The error names the lock file and the process holding it,
+                // and says to delete it if that process is gone. Reporting a
+                // bare "another process" would be wrong after a crash.
+                tracing::error!(error = %e, "could not take the package lock");
+                report.failures.push(sanitize_message(&e.to_string()));
+                return report;
+            }
+        },
+        None => None,
+    };
+    let mut lock = match read_lockfile(lock_path.as_deref()) {
+        Some(lock) => lock,
+        None => {
+            report
+                .failures
+                .push("the pack lockfile is unreadable, so nothing was changed".to_owned());
+            return report;
+        }
+    };
+
+    let mut changed = false;
+    let manual = discover(&site).packages;
+    for op in ops {
+        let name = match op {
+            PackOp::Update { name, .. } | PackOp::Delete { name } | PackOp::Activate { name } => {
+                name
+            }
+        };
+        if let Some(error) = owner_conflict(name) {
+            report.failures.push(error);
+            continue;
+        }
+        if manual.iter().any(|package| package.name == *name) && lock.get(name).is_some() {
+            report.failures.push(format!(
+                "{name}: managed package name conflicts with a manual package"
+            ));
+            continue;
+        }
+        match op {
+            PackOp::Delete { name } => {
+                // Checked before anything is unloaded. `unload` takes an owner
+                // name, and every plugin is an owner, so deleting a name that
+                // is not a managed package would tear down whatever else
+                // answers to it: `del("bash")` would unregister the bundled
+                // bash tool, its keymaps, and its hints.
+                if lock.get(name).is_none() {
+                    tracing::error!(package = %name, "not a managed package; refusing to remove");
+                    report.failures.push(format!(
+                        "{name}: not a managed package, so it was not removed"
+                    ));
+                    continue;
+                }
+                // Unloaded before the files go, so nothing keeps running from a
+                // directory that no longer exists.
+                if let Err(e) = host.unload(name) {
+                    tracing::error!(package = %name, error = %e, "failed to unload package");
+                    report.failures.push(format!(
+                        "{name}: owner cleanup failed, so it was not removed: {e}"
+                    ));
+                    continue;
+                }
+                report.unloaded.push(name.clone());
+                match manager.remove(name, &mut lock) {
+                    Ok(()) => {
+                        changed = true;
+                        report.removed.push(name.clone());
+                    }
+                    Err(e) => {
+                        let msg = redact_error(&e);
+                        tracing::error!(package = %name, error = %msg, "failed to remove");
+                        report.failures.push(format!("{name}: {msg}"));
+                    }
+                }
+            }
+            PackOp::Update { name, options } => {
+                let Some(spec) = declared
+                    .iter()
+                    .find(|d| &d.spec.name == name)
+                    .map(|d| &d.spec)
+                else {
+                    tracing::error!(package = %name, "not a declared package; cannot update");
+                    report.failures.push(format!(
+                        "{name}: not declared with maki.pack.add, so it cannot be updated"
+                    ));
+                    continue;
+                };
+                // Kept so a failure can put it back. Dropping the pin is what
+                // makes `version` be resolved again, but a failed update must
+                // not leave the package unpinned: a later successful operation
+                // writes the lockfile, and the pin would be gone from it.
+                let previous = lock.get(name).cloned();
+                let was_active = active.contains(name);
+                let refresh = match options.target {
+                    UpdateTarget::Version => {
+                        lock.remove(name);
+                        options.remote(maki_pack::manager::Refresh::Always)
+                    }
+                    // Restoring the recorded revision needs no fetch: either it
+                    // is already materialized, or it has to be obtained, and
+                    // `IfMissing` covers both.
+                    UpdateTarget::Lockfile => {
+                        options.remote(maki_pack::manager::Refresh::IfMissing)
+                    }
+                };
+                match smol::block_on(manager.install(spec, &mut lock, refresh)) {
+                    Ok(result) => {
+                        if was_active {
+                            if let Err(e) = host.unload(name) {
+                                tracing::error!(package = %name, error = %e, "failed to unload");
+                                report.failures.push(format!("{name}: {e}"));
+                                match previous {
+                                    Some(entry) => lock.restore(name, entry),
+                                    None => lock.remove(name),
+                                }
+                                continue;
+                            }
+                            report.unloaded.push(name.clone());
+                            // Only reload what was running. Updating a package
+                            // that was dormant, or waiting on a lazy trigger,
+                            // must not be the thing that starts it.
+                            match load_one(
+                                host,
+                                name,
+                                &result.dir,
+                                Origin::Fetched {
+                                    src: spec.src.clone(),
+                                },
+                                config,
+                            ) {
+                                Ok(()) => report.loaded.push(name.clone()),
+                                Err(message) => report
+                                    .failures
+                                    .push(format!("{name}: updated but failed to load: {message}")),
+                            }
+                        }
+                        changed |= result.changed;
+                        report.updated.push((name.clone(), result.rev));
+                    }
+                    Err(e) => {
+                        let msg = redact_error(&e);
+                        tracing::error!(package = %name, error = %msg, "failed to update");
+                        if let Some(entry) = previous {
+                            lock.restore(name, entry);
+                        }
+                        report.failures.push(format!("{name}: {msg}"));
+                    }
+                }
+            }
+            PackOp::Activate { name } => {
+                if !config.packages.iter().any(|package| package == name) {
+                    report.failures.push(format!(
+                        "{name}: package is disabled, so it was not activated"
+                    ));
+                    continue;
+                }
+                // Already loaded is success, not an error. Loading again would
+                // run the package's top level a second time under an owner that
+                // is already registered.
+                if active.contains(name) {
+                    continue;
+                }
+                // The caller's set is tried first. It already holds every
+                // package this startup discovered or installed, so the common
+                // case needs no managed state at all.
+                let found = packages
+                    .iter()
+                    .find(|package| package.name == *name)
+                    .map(|package| (package.dir.clone(), package.origin.clone()))
+                    .or_else(|| resolve_for_activation(&manager, &lock, &site, name));
+                match found {
+                    Some((dir, origin)) => match load_one(host, name, &dir, origin, config) {
+                        Ok(()) => {
+                            report.activated.push(name.clone());
+                            report.loaded.push(name.clone());
+                        }
+                        Err(message) => report
+                            .failures
+                            .push(format!("{name}: failed to activate: {message}")),
+                    },
+                    None => {
+                        tracing::error!(package = %name, "not installed; cannot activate");
+                        report
+                            .failures
+                            .push(format!("{name}: not installed, so it cannot be activated"));
+                    }
+                }
+            }
+        }
+    }
+
+    if changed
+        && let Some(path) = lock_path
+        && !write_lockfile(&path, &lock)
+    {
+        report
+            .failures
+            .push("packages changed but the lockfile could not be written".to_owned());
+    }
+    report
+}
+
+fn owner_conflict(name: &str) -> Option<String> {
+    is_bundled(name)
+        .then(|| format!("{name}: managed package name conflicts with a builtin plugin"))
+}
+
+/// Applies whatever `init.lua` asked for, once everything it could refer to is
+/// loaded.
+///
+/// This is the only drain point, and it is deliberately here rather than
+/// somewhere inside the running UI. `maki.pack.update` and `del` are attached
+/// only where a config store is, which is the `init.lua` context, so the
+/// pending queue is filled during startup and nowhere else. Draining on the
+/// startup thread, after the packages are loaded, means the work happens off
+/// the Lua thread (so unloading cannot wait on itself) and before the terminal
+/// is taken over (so a clone cannot freeze a redraw).
+///
+/// `active` is the set of package owners currently loaded. It is updated in
+/// place, because whether a package was running decides whether an update
+/// reloads it.
+pub fn drain_pack_ops(
+    host: &crate::loader::PluginHost,
+    declared: &[crate::api::pack::Declared],
+    packages: &[DiscoveredPackage],
+    active: &mut std::collections::BTreeSet<String>,
+    config: &maki_config::PluginsConfig,
+) -> PackReport {
+    let ops = match host.take_pending_pack_ops() {
+        Ok(ops) => ops,
+        Err(e) => {
+            tracing::error!(error = %e, "could not read pending package operations");
+            return PackReport::default();
+        }
+    };
+    let report = apply_pack_ops(host, &ops, declared, packages, active, config);
+    for name in &report.unloaded {
+        active.remove(name);
+    }
+    for name in &report.loaded {
+        active.insert(name.clone());
+    }
+    report
+}
+
+/// What a batch of package operations did.
+///
+/// Returned rather than only logged, because `/packupdate` has to tell the user
+/// what moved, and "check the log" is not an answer for a command they just
+/// typed. Every string here is already redacted.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PackReport {
+    /// Package name, and the revision it now sits at.
+    pub updated: Vec<(String, String)>,
+    pub removed: Vec<String>,
+    pub activated: Vec<String>,
+    /// Names that are now loaded, or no longer loaded, so the caller can keep
+    /// its active set in step without asking the runtime.
+    pub loaded: Vec<String>,
+    pub unloaded: Vec<String>,
+    pub failures: Vec<String>,
+}
+
+impl PackReport {
+    /// One line summarising the batch, for the status area.
+    pub fn summary(&self) -> String {
+        let mut parts = Vec::new();
+        if !self.updated.is_empty() {
+            parts.push(format!("{} updated", self.updated.len()));
+        }
+        if !self.removed.is_empty() {
+            parts.push(format!("{} removed", self.removed.len()));
+        }
+        if !self.activated.is_empty() {
+            parts.push(format!("{} activated", self.activated.len()));
+        }
+        if !self.failures.is_empty() {
+            parts.push(format!("{} failed", self.failures.len()));
+        }
+        if parts.is_empty() {
+            return "no package changed".to_owned();
+        }
+        format!("packages: {}", parts.join(", "))
+    }
+}
+
+/// Strips credentials out of an error before it is logged.
+///
+/// `ManagerError` embeds the source URI in several variants, and a source may
+/// carry a password. The git runner redacts its own output, but an error built
+/// outside it (an unsatisfied version range, for one) never passed through
+/// that, so the redaction is applied at the point of logging instead.
+fn redact_error(e: &impl std::fmt::Display) -> String {
+    sanitize_message(&maki_pack::git::redact(&e.to_string()))
+}
+
+/// Finds where an activatable package lives, and how far to trust it.
+///
+/// A managed package resolves through the lockfile. A package the user placed
+/// under `pack/<group>/opt/` by hand has no lock entry, and refusing it here
+/// would contradict the documented behaviour of `maki.packadd`.
+fn resolve_for_activation(
+    manager: &maki_pack::manager::Manager,
+    lock: &maki_pack::lockfile::Lockfile,
+    site: &Path,
+    name: &str,
+) -> Option<(PathBuf, Origin)> {
+    if let Some(dir) = manager.resolve(lock, name) {
+        let src = lock.get(name).map(|e| e.src.clone()).unwrap_or_default();
+        return Some((dir, Origin::Fetched { src }));
+    }
+    discover(site)
+        .packages
+        .into_iter()
+        .find(|p| p.name == name)
+        .map(|p| (p.dir, p.origin))
+}
+
+fn load_one(
+    host: &crate::loader::PluginHost,
+    name: &str,
+    dir: &Path,
+    origin: Origin,
+    config: &maki_config::PluginsConfig,
+) -> Result<(), String> {
+    let package = DiscoveredPackage {
+        name: name.to_owned(),
+        requested: load_requested_permissions(dir).map_err(|e| redact_error(&e))?,
+        dir: dir.to_path_buf(),
+        eager: true,
+        origin,
+    };
+    let opts = config
+        .opts
+        .get(name)
+        .cloned()
+        .map(std::sync::Arc::new)
+        .unwrap_or_default();
+    host.load_package(name, dir, effective_permissions(&package), opts)
+        .map_err(|error| redact_error(&error))
+}
+
+pub(crate) fn read_lockfile(path: Option<&Path>) -> Option<maki_pack::lockfile::Lockfile> {
+    let Some(path) = path else {
+        return Some(maki_pack::lockfile::Lockfile::default());
+    };
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Some(maki_pack::lockfile::Lockfile::default());
+        }
+        Err(error) => {
+            tracing::error!(path = %path.display(), %error, "pack lockfile could not be read");
+            return None;
+        }
+    };
+    match maki_pack::lockfile::Lockfile::from_json(&text) {
+        Ok(lock) => Some(lock),
+        Err(e) => {
+            tracing::error!(error = %e, "pack lockfile is unreadable; refusing to change packages");
+            None
+        }
+    }
+}
+
+fn write_lockfile(path: &Path, lock: &maki_pack::lockfile::Lockfile) -> bool {
+    match lock.to_json() {
+        Ok(text) => match write_atomically(path, &text) {
+            Ok(()) => true,
+            Err(e) => {
+                tracing::error!(path = %path.display(), error = %e, "failed to write pack lockfile");
+                false
+            }
+        },
+        Err(e) => {
+            tracing::error!(error = %e, "failed to serialize pack lockfile");
+            false
+        }
+    }
+}
+
+/// Writes through a temporary file and renames, so a crash mid-write cannot
+/// truncate a lockfile that a user has committed.
+fn write_atomically(path: &Path, text: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("json.incoming");
+    // Flushed before the rename. Without this the rename can reach the disk
+    // first, so a crash leaves the real name pointing at a file whose contents
+    // never got there, and the lockfile reads as truncated on the next start.
+    let mut file = fs::File::create(&tmp)?;
+    file.write_all(text.as_bytes())?;
+    file.sync_all()?;
+    drop(file);
+    fs::rename(&tmp, path)
 }
 
 /// What a discovery walk found, and what it had to refuse.
@@ -162,6 +921,10 @@ pub fn discover(site: &Path) -> Discovery {
                     dir: root,
                     eager,
                     requested,
+                    // Found by walking `pack/<group>/`, which is where a user
+                    // puts files by hand. Maki's own checkouts are resolved
+                    // through the lockfile, never discovered this way.
+                    origin: Origin::Manual,
                 });
             }
         }
@@ -182,11 +945,128 @@ mod tests {
         );
     }
 
+    #[test]
+    fn a_lockfile_read_error_is_not_treated_as_a_missing_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        assert!(read_lockfile(Some(dir.path())).is_none());
+    }
+
+    #[test]
+    fn a_missing_lockfile_reads_as_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("missing.json");
+
+        assert!(read_lockfile(Some(&path)).unwrap().is_empty());
+    }
+
     fn make_package(site: &Path, group: &str, sub: &str, name: &str) -> PathBuf {
         let dir = site.join("pack").join(group).join(sub).join(name);
         fs::create_dir_all(dir.join("plugin")).unwrap();
         fs::write(dir.join("plugin").join("init.lua"), "").unwrap();
         dir
+    }
+
+    /// Builds a package whose manifest asks for everything, which is the
+    /// interesting case: the question is never what it asked for, but whose
+    /// word turns the request into a grant.
+    fn greedy(name: &str, origin: Origin) -> DiscoveredPackage {
+        let manifest = toml::from_str::<toml::Value>(
+            "[permissions]\nfs_read = true\nfs_write = true\nnet = true\nrun = true\nenv = true\n",
+        )
+        .unwrap();
+        DiscoveredPackage {
+            name: name.to_owned(),
+            dir: PathBuf::from("/nowhere"),
+            eager: true,
+            requested: Requested::from_manifest(&manifest),
+            origin,
+        }
+    }
+
+    /// A package the user placed by hand is trusted like `init.lua`: they put
+    /// the files there, so its manifest is their own statement.
+    #[test]
+    fn a_manual_package_is_granted_what_its_manifest_asks_for() {
+        let pkg = greedy("demo", Origin::Manual);
+        let effective = granted(&pkg, &maki_pack::approvals::Approvals::default());
+
+        for perm in Permission::ALL {
+            assert!(
+                effective.is_allowed(perm),
+                "{perm} should be granted to a manually installed package"
+            );
+        }
+    }
+
+    /// The negative half of the pair above, and the defect this exists to
+    /// prevent: downloaded code must not be able to certify its own
+    /// permissions by writing them into the manifest it ships.
+    #[test]
+    fn a_fetched_package_is_granted_nothing_without_an_approval() {
+        let pkg = greedy(
+            "demo",
+            Origin::Fetched {
+                src: "https://example.com/demo".to_owned(),
+            },
+        );
+        let effective = granted(&pkg, &maki_pack::approvals::Approvals::default());
+
+        for perm in Permission::ALL {
+            assert!(
+                !effective.is_allowed(perm),
+                "{perm} must not be granted to fetched code with no approval"
+            );
+        }
+    }
+
+    /// An approval grants only what it names, and only where the package also
+    /// asked for it. Both halves have to agree.
+    #[test]
+    fn a_fetched_package_is_granted_the_intersection_of_request_and_approval() {
+        let src = "https://example.com/demo";
+        let pkg = greedy(
+            "demo",
+            Origin::Fetched {
+                src: src.to_owned(),
+            },
+        );
+
+        let mut approvals = maki_pack::approvals::Approvals::default();
+        approvals.approve(
+            &maki_pack::approvals::ApprovalKey::new("demo", src),
+            vec!["run".to_owned()],
+        );
+        let effective = granted(&pkg, &approvals);
+
+        assert!(effective.is_allowed(Permission::Run), "run was approved");
+        assert!(
+            !effective.is_allowed(Permission::Net),
+            "net was requested but never approved"
+        );
+    }
+
+    /// The reason an approval is keyed by source as well as name. Pointing a
+    /// name at another repository is a new trust decision, so the grants
+    /// recorded for the old one must not carry over.
+    #[test]
+    fn an_approval_does_not_survive_a_changed_source() {
+        let mut approvals = maki_pack::approvals::Approvals::default();
+        approvals.approve(
+            &maki_pack::approvals::ApprovalKey::new("demo", "https://example.com/demo"),
+            vec!["run".to_owned()],
+        );
+
+        let moved = greedy(
+            "demo",
+            Origin::Fetched {
+                src: "https://elsewhere.example/demo".to_owned(),
+            },
+        );
+        assert!(
+            !granted(&moved, &approvals).is_allowed(Permission::Run),
+            "an approval for one repository must not grant another"
+        );
     }
 
     #[test]

--- a/maki-lua/src/pack.rs
+++ b/maki-lua/src/pack.rs
@@ -1,0 +1,337 @@
+//! Discovery of external packages installed under the site directory.
+//!
+//! This is the manual half of the package model: directories a user cloned
+//! themselves, laid out the way Neovim lays packages out. Packages that maki
+//! installs are resolved from recorded state instead, and never appear here.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::error::PluginError;
+use crate::loader::is_bundled;
+use crate::plugin_permissions::{Requested, load_requested_permissions};
+
+pub(crate) fn sanitize_message(message: &str) -> String {
+    message
+        .chars()
+        .map(|character| {
+            if character == '\n' || character == '\t' || !character.is_control() {
+                character
+            } else {
+                ' '
+            }
+        })
+        .collect()
+}
+
+/// The group name reserved for packages maki installs itself. Manual discovery
+/// skips it, so one package can never be found twice, once from disk and once
+/// from recorded state, with the two disagreeing about its revision.
+pub const MANAGED_GROUP: &str = "core";
+
+/// `<data>/site`, the root Neovim would call a package path.
+pub fn site_dir() -> Result<PathBuf, std::io::Error> {
+    maki_storage::paths::data_dir().map(|d| d.join("site"))
+}
+
+#[derive(Debug, Clone)]
+pub struct DiscoveredPackage {
+    pub name: String,
+    /// Canonical package root. Resolved once, here, so the manifest, the
+    /// entrypoints, and every later `require` agree on one directory.
+    pub dir: PathBuf,
+    /// `start/` packages load at startup; `opt/` packages wait to be activated.
+    pub eager: bool,
+    /// What the package's manifest asks for. A manually installed package is
+    /// granted this directly: the user placed the files.
+    pub requested: Requested,
+}
+
+/// What a discovery walk found, and what it had to refuse.
+///
+/// Problems are collected rather than returned as one error, because one
+/// unusable package must not stop the others from loading.
+#[derive(Debug, Default)]
+pub struct Discovery {
+    pub packages: Vec<DiscoveredPackage>,
+    pub problems: Vec<PluginError>,
+}
+
+fn sorted_paths(dir: &Path, problems: &mut Vec<PluginError>) -> Vec<PathBuf> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(source) => {
+            problems.push(PluginError::Io {
+                path: dir.to_path_buf(),
+                source,
+            });
+            return Vec::new();
+        }
+    };
+    let mut paths = Vec::new();
+    for entry in entries {
+        match entry {
+            Ok(entry) => paths.push(entry.path()),
+            Err(source) => problems.push(PluginError::Io {
+                path: dir.to_path_buf(),
+                source,
+            }),
+        }
+    }
+    paths.sort();
+    paths
+}
+
+/// Discovers installed packages, or nothing when `--no-plugins` is set.
+pub fn discover_installed(no_plugins: bool) -> Discovery {
+    if no_plugins {
+        return Discovery::default();
+    }
+    // An unresolvable data directory is not the same fact as an empty one.
+    // Reported, because otherwise every installed package silently disappears.
+    let site = match site_dir() {
+        Ok(site) => site,
+        Err(source) => {
+            return Discovery {
+                packages: Vec::new(),
+                problems: vec![PluginError::PackageSiteUnavailable { source }],
+            };
+        }
+    };
+    discover(&site)
+}
+
+/// Finds every manually installed package under `site`.
+///
+/// Returns them in a deterministic order, so two machines with the same
+/// packages load them the same way. A missing site directory is not a problem;
+/// it just means no packages are installed.
+pub fn discover(site: &Path) -> Discovery {
+    let mut out = Discovery::default();
+    for group in sorted_paths(&site.join("pack"), &mut out.problems) {
+        if group.file_name().and_then(|n| n.to_str()) == Some(MANAGED_GROUP) {
+            continue;
+        }
+        for (sub, eager) in [("start", true), ("opt", false)] {
+            for dir in sorted_paths(&group.join(sub), &mut out.problems) {
+                let Some(name) = dir.file_name().and_then(|n| n.to_str()) else {
+                    continue;
+                };
+                if name.is_empty() || name.starts_with('.') {
+                    continue;
+                }
+                let name = name.to_owned();
+                let root = match dir.canonicalize() {
+                    Ok(root) => root,
+                    Err(source) => {
+                        // A package that cannot even be resolved is reported
+                        // rather than silently vanishing, since an unreadable
+                        // directory looks identical to one that is not there.
+                        out.problems.push(PluginError::Io { path: dir, source });
+                        continue;
+                    }
+                };
+                if !root.is_dir() {
+                    continue;
+                }
+
+                if is_bundled(&name) {
+                    out.problems
+                        .push(PluginError::PackageNameConflict { name, path: root });
+                    continue;
+                }
+                if let Some(prev) = out.packages.iter().find(|p| p.name == name) {
+                    out.problems.push(PluginError::DuplicatePackage {
+                        name,
+                        first: prev.dir.clone(),
+                        second: root,
+                    });
+                    continue;
+                }
+
+                let requested = match load_requested_permissions(&root) {
+                    Ok(requested) => requested,
+                    Err(problem) => {
+                        out.problems.push(problem);
+                        continue;
+                    }
+                };
+                out.packages.push(DiscoveredPackage {
+                    name,
+                    dir: root,
+                    eager,
+                    requested,
+                });
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin_permissions::Permission;
+
+    #[test]
+    fn terminal_messages_keep_layout_but_remove_control_characters() {
+        assert_eq!(
+            sanitize_message("package\u{1b}[31m\rname\nnext"),
+            "package [31m name\nnext"
+        );
+    }
+
+    fn make_package(site: &Path, group: &str, sub: &str, name: &str) -> PathBuf {
+        let dir = site.join("pack").join(group).join(sub).join(name);
+        fs::create_dir_all(dir.join("plugin")).unwrap();
+        fs::write(dir.join("plugin").join("init.lua"), "").unwrap();
+        dir
+    }
+
+    #[test]
+    fn missing_site_dir_is_not_a_problem() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let found = discover(&tmp.path().join("absent"));
+        assert!(found.packages.is_empty());
+        assert!(found.problems.is_empty());
+    }
+
+    #[test]
+    fn unreadable_package_root_is_reported() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pack = tmp.path().join("pack");
+        fs::write(&pack, "not a directory").unwrap();
+
+        let found = discover(tmp.path());
+
+        assert!(found.packages.is_empty());
+        assert!(matches!(
+            found.problems.as_slice(),
+            [PluginError::Io { .. }]
+        ));
+    }
+
+    #[test]
+    fn finds_start_and_opt_and_marks_eagerness() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "vendor", "start", "eager_one");
+        make_package(tmp.path(), "vendor", "opt", "lazy_one");
+
+        let found = discover(tmp.path());
+        assert_eq!(found.packages.len(), 2);
+
+        let eager = found
+            .packages
+            .iter()
+            .find(|p| p.name == "eager_one")
+            .unwrap();
+        let lazy = found
+            .packages
+            .iter()
+            .find(|p| p.name == "lazy_one")
+            .unwrap();
+        assert!(eager.eager, "start/ packages load at startup");
+        assert!(!lazy.eager, "opt/ packages wait to be activated");
+    }
+
+    /// Managed packages are resolved from recorded state, so finding them here
+    /// too would give one package two identities.
+    #[test]
+    fn managed_group_is_skipped() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), MANAGED_GROUP, "opt", "managed_one");
+        make_package(tmp.path(), "vendor", "start", "manual_one");
+
+        let names: Vec<String> = discover(tmp.path())
+            .packages
+            .into_iter()
+            .map(|p| p.name)
+            .collect();
+        assert_eq!(names, vec!["manual_one"]);
+    }
+
+    #[test]
+    fn bundled_name_collision_is_refused() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "vendor", "start", "bash");
+
+        let found = discover(tmp.path());
+        assert!(found.packages.is_empty());
+        assert!(matches!(
+            found.problems.as_slice(),
+            [PluginError::PackageNameConflict { .. }]
+        ));
+    }
+
+    /// `lib` is bundled without being enabled by default, so a name check
+    /// against the default set alone would let it through.
+    #[test]
+    fn non_default_bundled_name_is_also_refused() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "vendor", "start", "lib");
+
+        let found = discover(tmp.path());
+        assert!(found.packages.is_empty());
+        assert!(matches!(
+            found.problems.as_slice(),
+            [PluginError::PackageNameConflict { .. }]
+        ));
+    }
+
+    #[test]
+    fn duplicate_names_across_groups_are_refused() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "alpha", "start", "twice");
+        make_package(tmp.path(), "beta", "start", "twice");
+
+        let found = discover(tmp.path());
+        assert_eq!(found.packages.len(), 1, "the first one still loads");
+        assert!(matches!(
+            found.problems.as_slice(),
+            [PluginError::DuplicatePackage { .. }]
+        ));
+    }
+
+    /// One unusable package must not take the others down with it.
+    #[test]
+    fn a_refused_package_does_not_stop_the_others() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "vendor", "start", "bash");
+        make_package(tmp.path(), "vendor", "start", "fine_one");
+
+        let found = discover(tmp.path());
+        let names: Vec<&str> = found.packages.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["fine_one"]);
+        assert_eq!(found.problems.len(), 1);
+    }
+
+    #[test]
+    fn manifest_permissions_are_read_and_deny_by_default() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = make_package(tmp.path(), "vendor", "start", "asks");
+        fs::write(dir.join("plugin.toml"), "[permissions]\nnet = true\n").unwrap();
+
+        let found = discover(tmp.path());
+        let pkg = &found.packages[0];
+        assert!(pkg.requested.is_requested(Permission::Net));
+        assert!(!pkg.requested.is_requested(Permission::Run));
+    }
+
+    #[test]
+    fn package_without_manifest_requests_nothing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "vendor", "start", "silent");
+
+        let found = discover(tmp.path());
+        for perm in [
+            Permission::FsRead,
+            Permission::FsWrite,
+            Permission::Net,
+            Permission::Run,
+            Permission::Env,
+        ] {
+            assert!(!found.packages[0].requested.is_requested(perm));
+        }
+    }
+}

--- a/maki-lua/src/pack.rs
+++ b/maki-lua/src/pack.rs
@@ -8,53 +8,25 @@ use std::fs;
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
+use crossterm::event::{KeyCode, KeyModifiers};
+
+use crate::api::pack::{Dormant, PackState};
 use crate::error::PluginError;
 use crate::loader::is_bundled;
 use crate::plugin_permissions::{Requested, load_requested_permissions};
+use maki_pack::Spec;
 
-pub(crate) fn sanitize_message(message: &str) -> String {
-    message
-        .chars()
-        .map(|character| {
-            if character == '\n' || character == '\t' || !character.is_control() {
-                character
-            } else {
-                ' '
-            }
-        })
-        .collect()
-}
-
-/// The group name reserved for packages maki installs itself. Manual discovery
-/// skips it, so one package can never be found twice, once from disk and once
-/// from recorded state, with the two disagreeing about its revision.
-///
-/// Re-exported rather than repeated: `maki-pack` decides where it puts a
-/// checkout, and a second copy here that drifted would stop discovery skipping
-/// the directory it writes.
-pub use maki_pack::paths::MANAGED_GROUP;
+use maki_pack::paths::MANAGED_GROUP;
 
 /// `<data>/site`, the root Neovim would call a package path.
-pub fn site_dir() -> Result<PathBuf, std::io::Error> {
+pub(crate) fn site_dir() -> Result<PathBuf, std::io::Error> {
     maki_storage::paths::data_dir().map(|d| d.join("site"))
 }
 
-/// How a package reached the disk, which is what decides whose word grants its
-/// permissions.
-///
-/// This is a distinction the code needs and did not have. A manifest is written
-/// by whoever wrote the package. For a package the user placed by hand that is
-/// effectively the user, so the manifest is their own statement of intent. For
-/// a package maki fetched it is a stranger, and letting the manifest grant
-/// itself permissions would make the request self-certifying: an update could
-/// add `run = true` and gain the ability to start subprocesses without anyone
-/// agreeing to it.
+/// How a package reached the disk, which decides how permissions are granted.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Origin {
-    /// The user put the files under `pack/<group>/`. Trusted like `init.lua`.
+enum Origin {
     Manual,
-    /// Maki cloned it from this source. The source is part of the approval key,
-    /// so re-pointing a name at another repository does not inherit its grants.
     Fetched { src: String },
 }
 
@@ -63,13 +35,13 @@ pub struct DiscoveredPackage {
     pub name: String,
     /// Canonical package root. Resolved once, here, so the manifest, the
     /// entrypoints, and every later `require` agree on one directory.
-    pub dir: PathBuf,
+    pub(crate) dir: PathBuf,
     /// `start/` packages load at startup; `opt/` packages wait to be activated.
-    pub eager: bool,
+    pub(crate) eager: bool,
     /// What the package's manifest asks for. Never a grant on its own for a
     /// fetched package; see `Origin`.
-    pub requested: Requested,
-    pub origin: Origin,
+    pub(crate) requested: Requested,
+    origin: Origin,
 }
 
 /// `pack-lock.json`, beside the user's configuration so it can be committed.
@@ -77,7 +49,7 @@ pub struct DiscoveredPackage {
 /// `global_config_dirs` returns several candidates; the last is the one
 /// `append_permission_rule` already treats as writable, so the lockfile uses
 /// the same directory rather than inventing its own rule.
-pub fn lockfile_path() -> Option<PathBuf> {
+pub(crate) fn lockfile_path() -> Option<PathBuf> {
     maki_config::global_config_dirs()
         .into_iter()
         .next_back()
@@ -90,8 +62,102 @@ pub fn lockfile_path() -> Option<PathBuf> {
 /// so a package set reproduces on another machine. An approval is the opposite
 /// kind of fact: one person's decision to trust one repository on one machine,
 /// which must not travel with a repository into someone else's checkout.
-pub fn approvals_path() -> Option<PathBuf> {
+fn approvals_path() -> Option<PathBuf> {
     site_dir().ok().map(|dir| dir.join("pack-approvals.json"))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Interaction {
+    Tty,
+    None,
+}
+
+impl Interaction {
+    fn confirm(self, prompt: &str) -> bool {
+        if self != Self::Tty || !io::stdin().is_terminal() {
+            return false;
+        }
+        eprint!("{} [y/N] ", sanitize_message(prompt));
+        let _ = io::stderr().flush();
+        let mut input = String::new();
+        io::stdin().read_line(&mut input).is_ok() && input.trim().eq_ignore_ascii_case("y")
+    }
+}
+
+pub fn sanitize_message(message: &str) -> String {
+    message
+        .chars()
+        .map(|character| {
+            if character == '\n' || character == '\t' || !character.is_control() {
+                character
+            } else {
+                ' '
+            }
+        })
+        .collect()
+}
+
+#[derive(Debug, Default)]
+pub struct InstallReport {
+    pub packages: Vec<DiscoveredPackage>,
+    pub failures: Vec<String>,
+}
+
+struct InstallCandidate {
+    declared: crate::api::pack::Declared,
+    spec: Spec,
+    confirm: bool,
+    source_changed: bool,
+}
+
+fn install_candidates(
+    specs: &[crate::api::pack::Declared],
+    lock: &maki_pack::lockfile::Lockfile,
+    manager: &maki_pack::manager::Manager,
+    lock_confirm: Option<bool>,
+) -> Vec<InstallCandidate> {
+    let mut candidates = Vec::new();
+    for name in lock.install_order() {
+        if manager.resolve(lock, name).is_some() {
+            continue;
+        }
+        let Some(entry) = lock.get(name) else {
+            continue;
+        };
+        let current = specs.iter().find(|declared| declared.spec.name == name);
+        if current.is_some_and(|declared| declared.spec.src != entry.src) {
+            continue;
+        }
+        let spec = Spec::new(entry.src.clone()).with_name(name.to_owned());
+        let declared = current
+            .cloned()
+            .map(|mut declared| {
+                declared.spec = spec.clone();
+                declared
+            })
+            .unwrap_or_else(|| synthetic_declared(spec.clone()));
+        candidates.push(InstallCandidate {
+            declared,
+            spec,
+            confirm: lock_confirm.unwrap_or(true),
+            source_changed: false,
+        });
+    }
+    for declared in specs {
+        let source_changed = lock
+            .get(&declared.spec.name)
+            .is_some_and(|entry| entry.src != declared.spec.src);
+        let needs_install = source_changed || lock.get(&declared.spec.name).is_none();
+        if needs_install {
+            candidates.push(InstallCandidate {
+                declared: declared.clone(),
+                spec: declared.spec.clone(),
+                confirm: declared.confirm,
+                source_changed,
+            });
+        }
+    }
+    candidates
 }
 
 /// Reads the approval store.
@@ -134,11 +200,17 @@ fn read_approvals_file(path: &Path) -> Option<maki_pack::approvals::Approvals> {
     }
 }
 
+fn read_approvals_for_write() -> Option<maki_pack::approvals::Approvals> {
+    approvals_path()
+        .map(|path| read_approvals_file(&path))
+        .unwrap_or_else(|| Some(maki_pack::approvals::Approvals::default()))
+}
+
 /// Effective permissions for a package about to load.
 ///
 /// The whole point of `Origin`: a fetched package's own manifest is a request,
 /// and a request is not a grant.
-pub fn effective_permissions(
+pub(crate) fn effective_permissions(
     pkg: &DiscoveredPackage,
 ) -> crate::plugin_permissions::PluginPermissions {
     granted(pkg, &read_approvals())
@@ -149,7 +221,7 @@ pub fn effective_permissions(
 /// Separated from the disk read so it can be tested against a store built in
 /// the test rather than against whatever the person running the tests happens
 /// to have approved.
-pub fn granted(
+fn granted(
     pkg: &DiscoveredPackage,
     approvals: &maki_pack::approvals::Approvals,
 ) -> crate::plugin_permissions::PluginPermissions {
@@ -169,38 +241,6 @@ pub fn granted(
     }
 }
 
-/// Whether this entry point can ask the user a question.
-///
-/// An install runs downloaded code, so it is a trust decision. A run with no
-/// terminal cannot take one, and must refuse rather than assume consent.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Interaction {
-    Tty,
-    None,
-}
-
-impl Interaction {
-    fn confirm(self, prompt: &str) -> bool {
-        if self != Self::Tty || !io::stdin().is_terminal() {
-            return false;
-        }
-        eprint!("{} [y/N] ", sanitize_message(prompt));
-        let _ = io::stderr().flush();
-        let mut input = String::new();
-        io::stdin().read_line(&mut input).is_ok() && input.trim().eq_ignore_ascii_case("y")
-    }
-}
-
-/// What an install pass produced, and what it could not.
-///
-/// Failures are returned rather than only logged: installation runs before
-/// logging is set up, so a message written there reaches nobody.
-#[derive(Debug, Default)]
-pub struct InstallReport {
-    pub packages: Vec<DiscoveredPackage>,
-    pub failures: Vec<String>,
-}
-
 /// Installs the packages `init.lua` declared, and reports where each one
 /// landed.
 ///
@@ -211,19 +251,176 @@ pub struct InstallReport {
 /// A package that fails to install is reported and skipped. One unreachable
 /// repository must not stop maki from starting, or a network problem would
 /// make the editor unusable.
-pub fn install_declared(
-    specs: &[crate::api::pack::Declared],
+/// What the approval pass reads while it decides what each package may have.
+struct Grant<'a> {
+    manager: &'a maki_pack::manager::Manager,
+    manual: &'a [DiscoveredPackage],
+    lock: &'a maki_pack::lockfile::Lockfile,
     interaction: Interaction,
+    delivers_agent_events: bool,
+    source_changes: &'a std::collections::BTreeSet<String>,
+}
+
+/// Narrows each installed package to what its request and a stored approval
+/// agree on, asking about anything new.
+///
+/// Kept apart from installing, because a manifest arrives with the code it
+/// describes. Deciding what a package may have has to be a separate step from
+/// putting it on disk, or the download would be deciding its own access.
+fn grant_installed(
+    specs: &[crate::api::pack::Declared],
+    ctx: &Grant<'_>,
+    report: &mut InstallReport,
+) {
+    let Grant {
+        manager,
+        manual,
+        lock,
+        interaction,
+        delivers_agent_events,
+        source_changes,
+    } = ctx;
+    let interaction = *interaction;
+    let delivers_agent_events = *delivers_agent_events;
+
+    let Some(mut approvals) = read_approvals_for_write() else {
+        report
+            .failures
+            .push("the package approval store is unreadable, so no package was loaded".to_owned());
+        return;
+    };
+    let mut approvals_changed = false;
+    let mut revoked_sources = std::collections::BTreeSet::new();
+    let mut newly_approved = std::collections::BTreeSet::new();
+    for name in source_changes.iter() {
+        let declared = specs
+            .iter()
+            .find(|declared| declared.spec.name == *name)
+            .expect("source changes come from declarations");
+        if revoke_mismatched_approval(&mut approvals, name, &declared.spec.src) {
+            approvals_changed = true;
+            revoked_sources.insert(name.clone());
+        }
+    }
+    for declared in specs {
+        if let Some(error) = owner_conflict(&declared.spec.name) {
+            if !report
+                .failures
+                .iter()
+                .any(|failure| failure.starts_with(&format!("{}:", declared.spec.name)))
+            {
+                report.failures.push(error);
+            }
+            continue;
+        }
+        if let Some(manual) = manual.iter().find(|p| p.name == declared.spec.name) {
+            if !report
+                .failures
+                .iter()
+                .any(|failure| failure.starts_with(&format!("{}:", declared.spec.name)))
+            {
+                report.failures.push(format!(
+                    "{}: managed package name conflicts with manual package at {}",
+                    declared.spec.name,
+                    manual.dir.display()
+                ));
+            }
+            continue;
+        }
+        let Some(dir) = manager.resolve(lock, &declared.spec.name) else {
+            continue;
+        };
+        if lock
+            .get(&declared.spec.name)
+            .is_none_or(|entry| entry.src != declared.spec.src)
+        {
+            continue;
+        }
+        // A manifest that exists but cannot be read is not the same fact as
+        // an absent one, so it stops this package rather than approving an
+        // empty request nobody wrote.
+        let requested = match load_requested_permissions(&dir) {
+            Ok(requested) => requested,
+            Err(problem) => {
+                report.failures.push(sanitize_message(&format!(
+                    "{}: {problem}",
+                    declared.spec.name
+                )));
+                continue;
+            }
+        };
+        let names = requested.names();
+        let key =
+            maki_pack::approvals::ApprovalKey::new(declared.spec.name.clone(), &declared.spec.src);
+        let approved = approvals.get(&key).unwrap_or(&[]);
+        let missing: Vec<&str> = names
+            .iter()
+            .map(String::as_str)
+            .filter(|name| !approved.iter().any(|approved| approved == name))
+            .collect();
+        if !missing.is_empty() {
+            let accepted = interaction.confirm(&format!(
+                "Allow package {} these permissions: {}?",
+                declared.spec.name,
+                missing.join(", ")
+            ));
+            if !accepted {
+                report.failures.push(format!(
+                    "{}: permission approval is required for {}",
+                    declared.spec.name,
+                    missing.join(", ")
+                ));
+                continue;
+            }
+            approvals.approve(&key, names);
+            approvals_changed = true;
+            newly_approved.insert(declared.spec.name.clone());
+        }
+        report.packages.push(DiscoveredPackage {
+            name: declared.spec.name.clone(),
+            requested,
+            origin: Origin::Fetched {
+                src: declared.spec.src.clone(),
+            },
+            dir,
+            eager: declared.loads_at_start(delivers_agent_events),
+        });
+    }
+    if approvals_changed && !write_approvals(&approvals) {
+        for package in std::mem::take(&mut report.packages) {
+            if newly_approved.contains(&package.name) {
+                report.failures.push(format!(
+                    "{}: permission approval could not be saved",
+                    package.name
+                ));
+            } else {
+                report.packages.push(package);
+            }
+        }
+        for name in revoked_sources {
+            report.failures.push(format!(
+                "{name}: the old source permission approval could not be revoked"
+            ));
+        }
+    }
+}
+
+pub fn install_declared(
+    host: &crate::loader::PluginHost,
+    specs: &[crate::api::pack::Declared],
+    lock_confirm: Option<bool>,
+    interaction: Interaction,
+    delivers_agent_events: bool,
 ) -> InstallReport {
     let mut report = InstallReport::default();
-    if specs.is_empty() {
+    if specs.is_empty() && lock_confirm.is_none() {
         return report;
     }
     let site = match site_dir() {
         Ok(site) => site,
         Err(error) => {
             report.failures.push(format!(
-                "no data directory, so no package was installed: {error}"
+                "no data directory, so packages cannot be installed: {error}"
             ));
             return report;
         }
@@ -254,114 +451,156 @@ pub fn install_declared(
         None => {
             report
                 .failures
-                .push("the pack lockfile is unreadable, so no package was installed".to_owned());
+                .push("pack lockfile is unreadable; no package was installed".to_owned());
             return report;
         }
     };
-
+    let original_lock = lock.clone();
     let manager = maki_pack::manager::Manager::new(&site);
     let manual = discover(&site).packages;
-    let mut changed = false;
+    let collides = |name: &str| manual.iter().find(|package| package.name == name);
+    let mut source_changes = std::collections::BTreeSet::new();
+    let candidates = install_candidates(specs, &lock, &manager, lock_confirm);
 
-    // Asked once for the whole batch, before anything is cloned. A package
-    // already recorded at the revision it asks for is not a new trust
-    // decision, so only a fresh source prompts. Credentials are redacted,
-    // because the prompt is the one place a source is shown in full.
-    let new_sources: Vec<String> = specs
+    let requiring_confirmation: Vec<String> = candidates
         .iter()
-        .filter(|declared| {
-            declared.confirm && manager.resolve(&lock, &declared.spec.name).is_none()
-        })
-        .map(|declared| {
+        .filter(|candidate| candidate.confirm)
+        .map(|candidate| {
             format!(
                 "{} from {}",
-                declared.spec.name,
-                maki_pack::git::redact(&declared.spec.src)
+                candidate.spec.name,
+                maki_pack::git::redact(&candidate.spec.src)
             )
         })
         .collect();
-    if !new_sources.is_empty()
-        && !interaction.confirm(&format!(
+    let confirmed = requiring_confirmation.is_empty()
+        || interaction.confirm(&format!(
             "Install these packages?\n  {}",
-            new_sources.join("\n  ")
-        ))
-    {
-        report.failures.push(format!(
-            "installation was not confirmed, so {} package(s) were not installed",
-            new_sources.len()
+            requiring_confirmation.join("\n  ")
         ));
-        return report;
+    let mut accepted = Vec::new();
+    for candidate in candidates {
+        if let Some(error) = owner_conflict(&candidate.spec.name) {
+            report.failures.push(error);
+            continue;
+        }
+        if let Some(manual) = collides(&candidate.spec.name) {
+            report.failures.push(format!(
+                "{}: managed package name conflicts with manual package at {}",
+                candidate.spec.name,
+                manual.dir.display()
+            ));
+            continue;
+        }
+        if candidate.confirm && !confirmed {
+            report.failures.push(format!(
+                "{}: installation requires confirmation; set confirm = false for a non-interactive install",
+                candidate.spec.name
+            ));
+            continue;
+        }
+        accepted.push(candidate);
     }
 
-    for declared in specs {
-        let spec = &declared.spec;
-        if let Some(error) = owner_conflict(&spec.name) {
-            report.failures.push(sanitize_message(&error));
-            continue;
-        }
-        if let Some(package) = manual.iter().find(|package| package.name == spec.name) {
-            report.failures.push(sanitize_message(&format!(
-                "{}: a manual package at {} already has this name",
-                spec.name,
-                package.dir.display()
-            )));
-            continue;
-        }
-        let result = match smol::block_on(manager.ensure_installed(spec, &mut lock)) {
-            Ok(result) => result,
+    for candidate in &accepted {
+        let change = crate::api::pack::PackChange {
+            declared: candidate.declared.clone(),
+            active: false,
+            kind: crate::api::pack::PackChangeKind::Install,
+            path: maki_pack::paths::package_root(&site, &candidate.spec.name),
+        };
+        let _ = host.fire_pack_changed("PackChangedPre", change);
+    }
+
+    let mut installed_changes = Vec::new();
+    for candidate in accepted {
+        let InstallCandidate {
+            declared,
+            spec,
+            source_changed,
+            ..
+        } = candidate;
+        match smol::block_on(manager.ensure_installed(&spec, &mut lock)) {
+            Ok(result) => {
+                if result.changed {
+                    if source_changed {
+                        source_changes.insert(spec.name.clone());
+                    }
+                    installed_changes.push((declared, result.dir));
+                }
+            }
             Err(e) => {
                 let message = redact_error(&e);
-                tracing::error!(package = %spec.name, error = %message, "failed to install package");
-                report
-                    .failures
-                    .push(format!("{}: failed to install: {message}", spec.name));
-                continue;
+                tracing::error!(
+                    package = %spec.name,
+                    error = %message,
+                    "failed to install package"
+                );
+                report.failures.push(format!("{}: {message}", spec.name));
             }
-        };
-        // A manifest that exists but cannot be parsed is not the same fact as
-        // one that is absent, so it stops this package rather than loading it
-        // with a request nobody wrote.
-        let requested = match load_requested_permissions(&result.dir) {
-            Ok(requested) => requested,
-            Err(problem) => {
-                report
-                    .failures
-                    .push(sanitize_message(&format!("{}: {problem}", spec.name)));
-                continue;
-            }
-        };
-        changed |= result.changed;
-        report.packages.push(DiscoveredPackage {
-            name: spec.name.clone(),
-            requested,
-            origin: Origin::Fetched {
-                src: spec.src.clone(),
-            },
-            dir: result.dir,
-            // `load = false` installs the package and leaves it for
-            // `maki.packadd`, which is the state a lazy trigger delays.
-            eager: matches!(declared.load, crate::api::pack::LoadMode::Eager),
-        });
-    }
-
-    // Written once, after the installs, and only when something moved.
-    if changed {
-        let recorded = match lock_path {
-            Some(path) => write_lockfile(&path, &lock),
-            None => false,
-        };
-        if !recorded {
-            // The packages are on disk but nothing records where. The next
-            // start reads the old lockfile and would not find them, so they
-            // must not be reported as installed either.
-            report.packages.clear();
-            report
-                .failures
-                .push("the pack lockfile could not be written, so no package was used".to_owned());
         }
     }
 
+    if lock != original_lock {
+        let Some(path) = lock_path.as_deref() else {
+            report
+                .failures
+                .push("packages changed but no lockfile path is available".to_owned());
+            return report;
+        };
+        if !write_lockfile(path, &lock) {
+            report
+                .failures
+                .push("packages changed but the lockfile could not be written".to_owned());
+            return report;
+        }
+    }
+    for (declared, path) in installed_changes {
+        let _ = host.fire_pack_changed(
+            "PackChanged",
+            crate::api::pack::PackChange {
+                declared,
+                active: false,
+                kind: crate::api::pack::PackChangeKind::Install,
+                path,
+            },
+        );
+    }
+
+    grant_installed(
+        specs,
+        &Grant {
+            manager: &manager,
+            manual: &manual,
+            lock: &lock,
+            interaction,
+            delivers_agent_events,
+            source_changes: &source_changes,
+        },
+        &mut report,
+    );
     report
+}
+
+fn synthetic_declared(spec: Spec) -> crate::api::pack::Declared {
+    crate::api::pack::Declared {
+        spec,
+        load: crate::api::pack::LoadMode::Dormant,
+        confirm: true,
+        data: None,
+    }
+}
+
+fn owner_conflict(name: &str) -> Option<String> {
+    is_bundled(name)
+        .then(|| format!("{name}: managed package name conflicts with a builtin plugin"))
+}
+
+fn activation_refusal(name: &str, config: &maki_config::PluginsConfig) -> Option<String> {
+    owner_conflict(name).or_else(|| {
+        (!config.packages.iter().any(|package| package == name))
+            .then(|| format!("{name}: package is disabled, so it was not activated"))
+    })
 }
 
 /// Applies the package operations Lua recorded.
@@ -373,14 +612,389 @@ pub fn install_declared(
 ///
 /// Each operation is independent, so one failure is reported and the rest still
 /// run.
+/// An update that resolved to a revision, waiting on review and approval.
+struct PreparedUpdate {
+    declared: crate::api::pack::Declared,
+    installed: maki_pack::manager::Installed,
+    was_active: bool,
+    force: bool,
+    source_changed: bool,
+    review: String,
+}
+
+/// What `commit_batch` needs to record a batch, or to undo it.
+struct CommitBatch<'a> {
+    host: &'a crate::loader::PluginHost,
+    config: &'a maki_config::PluginsConfig,
+    manager: &'a maki_pack::manager::Manager,
+    lock: &'a maki_pack::lockfile::Lockfile,
+    lock_path: Option<&'a Path>,
+    original_lock: &'a maki_pack::lockfile::Lockfile,
+    approvals_before: Option<&'a maki_pack::approvals::Approvals>,
+    approvals_changed: bool,
+    completed_changes: Vec<crate::api::pack::PackChange>,
+}
+
+/// Records what the batch did, or puts back what it can when it cannot.
+///
+/// The lockfile is the only durable record of where a checkout went. If it
+/// cannot be written the packages have still moved on disk, so every change
+/// has to be undone and no operation may be reported as done: the next start
+/// reads the old lockfile and would not find the new revisions.
+fn commit_batch(batch: CommitBatch<'_>, report: &mut PackReport) {
+    let CommitBatch {
+        host,
+        config,
+        manager,
+        lock,
+        lock_path,
+        original_lock,
+        approvals_before,
+        approvals_changed,
+        completed_changes,
+    } = batch;
+
+    // The lockfile is the durable record, so it decides whether anything moved.
+    // A flag carried beside it could only ever disagree with it.
+    let changed = lock != original_lock;
+    let lock_written = !changed || lock_path.is_some_and(|path| write_lockfile(path, lock));
+    if !lock_written {
+        if approvals_changed
+            && approvals_before
+                .as_ref()
+                .is_none_or(|approvals| !write_approvals(approvals))
+        {
+            report.failures.push(
+                    "the previous package approvals could not be restored after the lockfile write failed"
+                        .to_owned(),
+                );
+        }
+        for change in &completed_changes {
+            let name = &change.declared.spec.name;
+            let Some(previous) = original_lock.get(name) else {
+                continue;
+            };
+            let restored = match change.kind {
+                crate::api::pack::PackChangeKind::Update => {
+                    if change.active
+                        && let Err(error) = host.unload(name)
+                    {
+                        report.failures.push(format!(
+                            "{name}: the unrecorded revision could not be unloaded: {error}"
+                        ));
+                        continue;
+                    }
+                    manager.resolve(original_lock, name)
+                }
+                crate::api::pack::PackChangeKind::Delete => {
+                    let spec = Spec::new(previous.src.clone()).with_name(name.clone());
+                    let mut restore_lock = original_lock.clone();
+                    match smol::block_on(manager.ensure_installed(&spec, &mut restore_lock)) {
+                        Ok(installed) => Some(installed.dir),
+                        Err(error) => {
+                            let message = redact_error(&error);
+                            report.failures.push(format!(
+                                "{name}: the removed checkout could not be restored: {message}"
+                            ));
+                            None
+                        }
+                    }
+                }
+                crate::api::pack::PackChangeKind::Install => None,
+            };
+            if change.active
+                && let Some(path) = restored
+                && let Err(error) =
+                    load_declared_one(host, &change.declared, &path, &previous.src, config)
+            {
+                report.failures.push(format!(
+                    "{name}: the previous revision failed to reload: {error}"
+                ));
+            }
+        }
+        // The packages moved on disk but nothing recorded where. The next
+        // catalog reads the old lockfile, so an unrecorded revision must not
+        // remain active or be counted as done.
+        for (name, _) in report.updated.drain(..) {
+            report.failures.push(format!(
+                "{name}: the new revision could not be recorded, so the old one \
+                     comes back on the next start"
+            ));
+        }
+        for name in report.removed.drain(..) {
+            report.failures.push(format!(
+                    "{name}: the removal could not be recorded, so the package comes back on the next start"
+                ));
+        }
+        report
+            .failures
+            .push("packages changed but the lockfile could not be written".to_owned());
+    } else {
+        for name in &report.removed {
+            if !revoke_approval(name) {
+                report.failures.push(format!(
+                    "{name}: removed, but its approval could not be revoked; \
+                        reinstalling the same source restores the old grants"
+                ));
+            }
+        }
+        for change in completed_changes {
+            let _ = host.fire_pack_changed("PackChanged", change);
+        }
+    }
+}
+
+/// The operations in a batch that may run, in request order.
+///
+/// A name given more than one operation in one batch is refused outright:
+/// which of them won would depend on the order the passes below happen to run
+/// in. A name that belongs to a builtin owner is refused for the same reason
+/// deleting one is refused, because every plugin is an owner.
+fn runnable_ops<'a>(
+    ops: &'a [crate::api::pack::PackOp],
+    report: &mut PackReport,
+) -> Vec<&'a crate::api::pack::PackOp> {
+    use crate::api::pack::PackOp;
+
+    let name_of = |op: &'a PackOp| match op {
+        PackOp::Update { name, .. } | PackOp::Delete { name, .. } | PackOp::Activate { name } => {
+            name.as_str()
+        }
+    };
+
+    let mut seen = std::collections::BTreeSet::new();
+    let mut conflicted = std::collections::BTreeSet::new();
+    for op in ops {
+        let name = name_of(op);
+        if !seen.insert(name) {
+            conflicted.insert(name);
+        }
+    }
+    for name in &conflicted {
+        report.failures.push(format!(
+            "{name}: several package operations were requested; nothing was changed for it"
+        ));
+    }
+
+    ops.iter()
+        .filter(|op| {
+            let name = name_of(op);
+            if conflicted.contains(name) {
+                return false;
+            }
+            match owner_conflict(name) {
+                Some(error) => {
+                    report.failures.push(error);
+                    false
+                }
+                None => true,
+            }
+        })
+        .collect()
+}
+
+/// What the update pass reads while it resolves each requested revision.
+struct Prepare<'a> {
+    declared: &'a [crate::api::pack::Declared],
+    manual: &'a [DiscoveredPackage],
+    manager: &'a maki_pack::manager::Manager,
+    active: &'a std::collections::BTreeSet<String>,
+}
+
+/// Resolves every requested update to a revision, without moving anything.
+///
+/// Separate from applying them, because Neovim shows the whole set for review
+/// before the first checkout moves, and a declined review must leave the
+/// lockfile exactly as it was.
+fn prepare_updates(
+    runnable: &[&crate::api::pack::PackOp],
+    ctx: &Prepare<'_>,
+    lock: &mut maki_pack::lockfile::Lockfile,
+    report: &mut PackReport,
+) -> Vec<PreparedUpdate> {
+    use crate::api::pack::{PackOp, UpdateTarget};
+
+    let Prepare {
+        declared,
+        manual,
+        manager,
+        active,
+    } = ctx;
+    let mut prepared = Vec::new();
+    for op in runnable {
+        let PackOp::Update { name, options } = op else {
+            continue;
+        };
+        let Some(declaration) = declared
+            .iter()
+            .find(|declaration| declaration.spec.name == *name)
+        else {
+            report.failures.push(format!(
+                "{name}: not declared with maki.pack.add, so it cannot be updated"
+            ));
+            continue;
+        };
+        let Some(previous) = lock.get(name).cloned() else {
+            report
+                .failures
+                .push(format!("{name}: not installed, so it cannot be updated"));
+            continue;
+        };
+        if let Some(package) = manual.iter().find(|package| package.name == *name) {
+            report.failures.push(format!(
+                "{name}: managed package name conflicts with manual package at {}",
+                package.dir.display()
+            ));
+            continue;
+        }
+
+        let existed = manager.resolve(lock, name).is_some();
+        let mut preview = lock.clone();
+        let refresh = match options.target {
+            UpdateTarget::Version => {
+                preview.remove(name);
+                options.remote(maki_pack::manager::Refresh::Always)
+            }
+            UpdateTarget::Lockfile => options.remote(maki_pack::manager::Refresh::IfMissing),
+        };
+        let installed =
+            match smol::block_on(manager.install(&declaration.spec, &mut preview, refresh)) {
+                Ok(installed) => installed,
+                Err(error) => {
+                    let message = redact_error(&error);
+                    tracing::error!(package = %name, error = %message, "failed to prepare update");
+                    report.failures.push(format!("{name}: {message}"));
+                    continue;
+                }
+            };
+        if existed && previous.src == declaration.spec.src && previous.rev == installed.rev {
+            continue;
+        }
+        let subjects = if previous.src == declaration.spec.src {
+            match smol::block_on(manager.revision_log(name, &previous.rev, &installed.rev)) {
+                Ok(subjects) => subjects,
+                Err(error) => {
+                    let message = redact_error(&error);
+                    tracing::error!(package = %name, error = %message, "failed to review update");
+                    report
+                        .failures
+                        .push(format!("{name}: could not review update: {message}"));
+                    continue;
+                }
+            }
+        } else {
+            Vec::new()
+        };
+        let mut review = format!("{name}: {} -> {}", previous.rev, installed.rev);
+        for subject in subjects {
+            review.push_str("\n    ");
+            review.push_str(&subject);
+        }
+        prepared.push(PreparedUpdate {
+            declared: declaration.clone(),
+            installed,
+            was_active: active.contains(name),
+            force: options.force,
+            source_changed: previous.src != declaration.spec.src,
+            review,
+        });
+    }
+    prepared
+}
+
+/// What the delete pass reads while it decides what may be removed.
+struct Remove<'a> {
+    declared: &'a [crate::api::pack::Declared],
+    site: &'a Path,
+    manager: &'a maki_pack::manager::Manager,
+    lock: &'a maki_pack::lockfile::Lockfile,
+    active: &'a std::collections::BTreeSet<String>,
+}
+
+/// Works out which removals may go ahead, without removing anything.
+///
+/// Separate from applying them for the same reason updates are: every
+/// pre-event fires before the first file moves, so the whole batch has to be
+/// known first.
+fn prepare_deletes(
+    runnable: &[&crate::api::pack::PackOp],
+    ctx: &Remove<'_>,
+    report: &mut PackReport,
+) -> std::collections::BTreeMap<String, crate::api::pack::PackChange> {
+    use crate::api::pack::PackOp;
+
+    let Remove {
+        declared,
+        site,
+        manager,
+        lock,
+        active,
+    } = ctx;
+    let mut prepared_deletes = std::collections::BTreeMap::new();
+    for op in runnable {
+        let PackOp::Delete { name, force } = op else {
+            continue;
+        };
+        // `/packdel` refuses a package that is still declared, because the
+        // next start would install it again. `maki.pack.del` reaches this
+        // point without that check, so it is made here as well and both
+        // callers get the same rule.
+        if declared.iter().any(|d| d.spec.name == *name) {
+            report.failures.push(format!(
+                "{name}: still declared with maki.pack.add, so it would be \
+                 installed again; remove the declaration first"
+            ));
+            continue;
+        }
+        // Checked before anything is unloaded. `unload` takes an owner name,
+        // and every plugin is an owner, so a crafted lock entry must not make
+        // deleting a package clear a builtin with the same name.
+        let Some(entry) = lock.get(name) else {
+            tracing::error!(package = %name, "not a managed package; refusing to remove");
+            report.failures.push(format!(
+                "{name}: not a managed package, so it was not removed"
+            ));
+            continue;
+        };
+        let was_active = active.contains(name);
+        if was_active && !force {
+            report
+                .failures
+                .push(format!("{name}: package is active; use force to remove it"));
+            continue;
+        }
+        let declaration = declared
+            .iter()
+            .find(|declaration| declaration.spec.name == *name)
+            .cloned()
+            .unwrap_or_else(|| {
+                synthetic_declared(Spec::new(entry.src.clone()).with_name(name.clone()))
+            });
+        let path = manager
+            .resolve(lock, name)
+            .unwrap_or_else(|| maki_pack::paths::package_root(site, name));
+        prepared_deletes.insert(
+            name.clone(),
+            crate::api::pack::PackChange {
+                declared: declaration,
+                active: was_active,
+                kind: crate::api::pack::PackChangeKind::Delete,
+                path,
+            },
+        );
+    }
+    prepared_deletes
+}
+
 pub fn apply_pack_ops(
     host: &crate::loader::PluginHost,
     ops: &[crate::api::pack::PackOp],
     declared: &[crate::api::pack::Declared],
     packages: &[DiscoveredPackage],
     config: &maki_config::PluginsConfig,
+    interaction: Interaction,
 ) -> PackReport {
-    use crate::api::pack::{PackOp, UpdateTarget};
+    use crate::api::pack::PackOp;
 
     let mut report = PackReport::default();
     if ops.is_empty() {
@@ -431,9 +1045,7 @@ pub fn apply_pack_ops(
             return report;
         }
     };
-    // Updated as the batch proceeds. Read once and left alone, a delete
-    // followed by an activate in the same batch would skip the activate as
-    // "already loaded" for a package the delete had just unloaded.
+    let original_lock = lock.clone();
     let mut active = match host.active_packages() {
         Ok(active) => active,
         Err(error) => {
@@ -443,157 +1055,257 @@ pub fn apply_pack_ops(
             return report;
         }
     };
+    // Decided once. Four later passes walk this batch, and each repeating the
+    // same two guards is how one of them ends up disagreeing with the others
+    // about whether an operation may run.
+    let runnable = runnable_ops(ops, &mut report);
 
-    let mut changed = false;
     let manual = discover(&site).packages;
-    for op in ops {
-        let name = match op {
-            PackOp::Update { name, .. } | PackOp::Delete { name } | PackOp::Activate { name } => {
-                name
-            }
-        };
-        if let Some(error) = owner_conflict(name) {
-            report.failures.push(error);
-            continue;
-        }
-        if manual.iter().any(|package| package.name == *name) && lock.get(name).is_some() {
+    let prepared = prepare_updates(
+        &runnable,
+        &Prepare {
+            declared,
+            manual: &manual,
+            manager: &manager,
+            active: &active,
+        },
+        &mut lock,
+        &mut report,
+    );
+
+    let review_items: Vec<&str> = prepared
+        .iter()
+        .filter(|update| !update.force)
+        .map(|update| update.review.as_str())
+        .collect();
+    let review_accepted = review_items.is_empty()
+        || interaction.confirm(&format!(
+            "Apply these package updates?\n  {}",
+            review_items.join("\n  ")
+        ));
+    let mut approvals = read_approvals_for_write();
+    let approvals_before = approvals.clone();
+    let mut approvals_changed = false;
+    let mut revoked_sources = std::collections::BTreeSet::new();
+    let mut approved = Vec::new();
+    for update in prepared {
+        let name = &update.declared.spec.name;
+        let Some(approvals) = approvals.as_mut() else {
             report.failures.push(format!(
-                "{name}: managed package name conflicts with a manual package"
+                "{name}: the package approval store is unreadable, so it was not updated"
+            ));
+            continue;
+        };
+        if !update.force && !review_accepted {
+            report.failures.push(format!(
+                "{name}: update requires confirmation; use force for a non-interactive update"
             ));
             continue;
         }
+        match approve_permissions(
+            interaction,
+            name,
+            &update.declared.spec.src,
+            &update.installed.dir,
+            approvals,
+        ) {
+            Ok(changed) => {
+                let revoked = update.source_changed
+                    && !changed
+                    && revoke_mismatched_approval(approvals, name, &update.declared.spec.src);
+                if revoked {
+                    revoked_sources.insert(name.clone());
+                }
+                approvals_changed |= changed || revoked;
+                approved.push((update, changed));
+            }
+            Err(message) => report.failures.push(message),
+        }
+    }
+    if approvals_changed
+        && approvals
+            .as_ref()
+            .is_none_or(|approvals| !write_approvals(approvals))
+    {
+        approved.retain(|(update, newly_approved)| {
+            if *newly_approved {
+                report.failures.push(format!(
+                    "{}: permission approval could not be saved",
+                    update.declared.spec.name
+                ));
+                false
+            } else {
+                true
+            }
+        });
+        for name in revoked_sources {
+            report.failures.push(format!(
+                "{name}: the old source permission approval could not be revoked"
+            ));
+        }
+    }
+
+    let mut approved: std::collections::BTreeMap<String, PreparedUpdate> = approved
+        .into_iter()
+        .map(|(update, _)| (update.declared.spec.name.clone(), update))
+        .collect();
+    let mut prepared_deletes = prepare_deletes(
+        &runnable,
+        &Remove {
+            declared,
+            site: &site,
+            manager: &manager,
+            lock: &lock,
+            active: &active,
+        },
+        &mut report,
+    );
+
+    // Neovim sends every pre-event in request order before it applies any
+    // change. A dependency observer can therefore see the complete batch
+    // before the first checkout moves.
+    for op in &runnable {
+        let change = match op {
+            PackOp::Delete { name, .. } => prepared_deletes.get(name).cloned(),
+            PackOp::Update { name, .. } => {
+                approved
+                    .get(name)
+                    .map(|update| crate::api::pack::PackChange {
+                        declared: update.declared.clone(),
+                        active: update.was_active,
+                        kind: crate::api::pack::PackChangeKind::Update,
+                        path: update.installed.dir.clone(),
+                    })
+            }
+            PackOp::Activate { .. } => None,
+        };
+        if let Some(change) = change {
+            let _ = host.fire_pack_changed("PackChangedPre", change);
+        }
+    }
+
+    active = match host.active_packages() {
+        Ok(active) => active,
+        Err(error) => {
+            report.failures.push(format!(
+                "package state changed during PackChangedPre, but could not be read: {error}"
+            ));
+            return report;
+        }
+    };
+    for (name, update) in &mut approved {
+        update.was_active = active.contains(name);
+    }
+    for (name, change) in &mut prepared_deletes {
+        change.active = active.contains(name);
+    }
+    for operation in &runnable {
+        let PackOp::Delete { name, force: false } = operation else {
+            continue;
+        };
+        if prepared_deletes
+            .get(name)
+            .is_some_and(|change| change.active)
+        {
+            prepared_deletes.remove(name);
+            report.failures.push(format!(
+                "{name}: package became active during PackChangedPre; use force to remove it"
+            ));
+        }
+    }
+
+    let mut completed_changes = Vec::new();
+    for op in &runnable {
         match op {
-            PackOp::Delete { name } => {
-                // Checked before anything is unloaded. `unload` takes an owner
-                // name, and every plugin is an owner, so deleting a name that
-                // is not a managed package would tear down whatever else
-                // answers to it: `del("bash")` would unregister the bundled
-                // bash tool, its keymaps, and its hints.
-                if lock.get(name).is_none() {
-                    tracing::error!(package = %name, "not a managed package; refusing to remove");
+            PackOp::Delete { name, .. } => {
+                let Some(change) = prepared_deletes.remove(name) else {
+                    continue;
+                };
+                if let Err(error) = host.unload(name) {
+                    tracing::error!(package = %name, %error, "failed to unload package");
                     report.failures.push(format!(
-                        "{name}: not a managed package, so it was not removed"
+                        "{name}: owner cleanup failed, so it was not removed: {error}"
                     ));
                     continue;
                 }
-                // Unloaded before the files go, so nothing keeps running from a
-                // directory that no longer exists.
-                if let Err(e) = host.unload(name) {
-                    tracing::error!(package = %name, error = %e, "failed to unload package");
-                    report.failures.push(format!(
-                        "{name}: owner cleanup failed, so it was not removed: {e}"
-                    ));
-                    continue;
+                if change.active {
+                    active.remove(name);
                 }
-                active.remove(name);
                 match manager.remove(name, &mut lock) {
                     Ok(()) => {
-                        changed = true;
                         report.removed.push(name.clone());
-                        // Last, so a step that fails earlier leaves the
-                        // approval exactly as it was. Revoking first would
-                        // strip the grant from a package that is still
-                        // installed, and every guarded call it makes would
-                        // then report a permission problem instead of the
-                        // removal that actually failed.
-                        if !revoke_approval(name) {
-                            report.failures.push(format!(
-                                "{name}: removed, but its approval could not be revoked; \
-                                 reinstalling the same source would not ask again"
-                            ));
-                        }
+                        completed_changes.push(change);
                     }
                     Err(e) => {
                         let msg = redact_error(&e);
                         tracing::error!(package = %name, error = %msg, "failed to remove");
                         report.failures.push(format!("{name}: {msg}"));
-                    }
-                }
-            }
-            PackOp::Update { name, options } => {
-                let Some(spec) = declared
-                    .iter()
-                    .find(|d| &d.spec.name == name)
-                    .map(|d| &d.spec)
-                else {
-                    tracing::error!(package = %name, "not a declared package; cannot update");
-                    report.failures.push(format!(
-                        "{name}: not declared with maki.pack.add, so it cannot be updated"
-                    ));
-                    continue;
-                };
-                // Kept so a failure can put it back. Dropping the pin is what
-                // makes `version` be resolved again, but a failed update must
-                // not leave the package unpinned: a later successful operation
-                // writes the lockfile, and the pin would be gone from it.
-                let previous = lock.get(name).cloned();
-                let was_active = active.contains(name);
-                let refresh = match options.target {
-                    UpdateTarget::Version => {
-                        lock.remove(name);
-                        options.remote(maki_pack::manager::Refresh::Always)
-                    }
-                    // Restoring the recorded revision needs no fetch: either it
-                    // is already materialized, or it has to be obtained, and
-                    // `IfMissing` covers both.
-                    UpdateTarget::Lockfile => {
-                        options.remote(maki_pack::manager::Refresh::IfMissing)
-                    }
-                };
-                match smol::block_on(manager.install(spec, &mut lock, refresh)) {
-                    Ok(result) => {
-                        if was_active {
-                            if let Err(e) = host.unload(name) {
-                                tracing::error!(package = %name, error = %e, "failed to unload");
-                                report.failures.push(format!("{name}: {e}"));
-                                match previous {
-                                    Some(entry) => lock.restore(name, entry),
-                                    None => lock.remove(name),
-                                }
-                                continue;
-                            }
-                            // Only reload what was running. Updating a package
-                            // that was dormant, or waiting on a lazy trigger,
-                            // must not be the thing that starts it.
-                            active.remove(name);
-                            match load_one(
+                        if change.active {
+                            match load_declared_one(
                                 host,
-                                name,
-                                &result.dir,
-                                Origin::Fetched {
-                                    src: spec.src.clone(),
-                                },
+                                &change.declared,
+                                &change.path,
+                                &change.declared.spec.src,
                                 config,
                             ) {
                                 Ok(()) => {
                                     active.insert(name.clone());
                                 }
-                                // The old owner is already gone, so this is a
-                                // package that is now installed and not
-                                // running. Saying so beats reporting success.
-                                Err(msg) => report
-                                    .failures
-                                    .push(format!("{name}: updated but failed to load: {msg}")),
+                                Err(error) => report.failures.push(format!(
+                                    "{name}: the old package also failed to reload: {error}"
+                                )),
                             }
                         }
-                        changed |= result.changed;
-                        report.updated.push((name.clone(), result.rev));
-                    }
-                    Err(e) => {
-                        let msg = redact_error(&e);
-                        tracing::error!(package = %name, error = %msg, "failed to update");
-                        if let Some(entry) = previous {
-                            lock.restore(name, entry);
-                        }
-                        report.failures.push(format!("{name}: {msg}"));
                     }
                 }
             }
-            PackOp::Activate { name } => {
-                if !config.packages.iter().any(|package| package == name) {
+            PackOp::Update { name, .. } => {
+                let Some(update) = approved.remove(name) else {
+                    continue;
+                };
+                if update.was_active
+                    && let Err(error) = host.unload(name)
+                {
+                    tracing::error!(package = %name, %error, "failed to unload package");
                     report.failures.push(format!(
-                        "{name}: package is disabled, so it was not activated"
+                        "{name}: owner cleanup failed, so it was not updated: {error}"
                     ));
+                    continue;
+                }
+                if update.was_active {
+                    active.remove(name);
+                }
+                lock.record(name, &update.declared.spec.src, &update.installed.rev);
+                report
+                    .updated
+                    .push((name.clone(), update.installed.rev.clone()));
+                if update.was_active {
+                    let loaded = load_declared_one(
+                        host,
+                        &update.declared,
+                        &update.installed.dir,
+                        &update.declared.spec.src,
+                        config,
+                    );
+                    match loaded {
+                        Ok(()) => {
+                            active.insert(name.clone());
+                        }
+                        Err(message) => report
+                            .failures
+                            .push(format!("{name}: updated but failed to load: {message}")),
+                    }
+                }
+                completed_changes.push(crate::api::pack::PackChange {
+                    declared: update.declared,
+                    active: update.was_active,
+                    kind: crate::api::pack::PackChangeKind::Update,
+                    path: update.installed.dir,
+                });
+            }
+            PackOp::Activate { name } => {
+                if let Some(error) = activation_refusal(name, config) {
+                    report.failures.push(error);
                     continue;
                 }
                 // Already loaded is success, not an error. Loading again would
@@ -604,7 +1316,7 @@ pub fn apply_pack_ops(
                 }
                 // The caller's set is tried first. It already holds every
                 // package this startup discovered or installed, so the common
-                // case needs no managed state at all.
+                // case reads no managed state at all.
                 let found = packages
                     .iter()
                     .find(|package| package.name == *name)
@@ -613,12 +1325,10 @@ pub fn apply_pack_ops(
                 match found {
                     Some((dir, origin)) => match load_one(host, name, &dir, origin, config) {
                         Ok(()) => {
-                            active.insert(name.clone());
                             report.activated.push(name.clone());
+                            active.insert(name.clone());
                         }
-                        Err(message) => report
-                            .failures
-                            .push(format!("{name}: failed to activate: {message}")),
+                        Err(msg) => report.failures.push(format!("{name}: {msg}")),
                     },
                     None => {
                         tracing::error!(package = %name, "not installed; cannot activate");
@@ -631,29 +1341,66 @@ pub fn apply_pack_ops(
         }
     }
 
-    if changed
-        && let Some(path) = lock_path
-        && !write_lockfile(&path, &lock)
-    {
-        // The packages moved on disk but nothing recorded where. The next
-        // start reads the old lockfile and loads the old revisions, so these
-        // updates did not stick and must not be counted as done.
-        for (name, _) in report.updated.drain(..) {
-            report.failures.push(format!(
-                "{name}: the new revision could not be recorded, so the old one \
-                comes back on the next start"
-            ));
-        }
-        report
-            .failures
-            .push("packages changed but the lockfile could not be written".to_owned());
-    }
+    commit_batch(
+        CommitBatch {
+            host,
+            config,
+            manager: &manager,
+            lock: &lock,
+            lock_path: lock_path.as_deref(),
+            original_lock: &original_lock,
+            approvals_before: approvals_before.as_ref(),
+            approvals_changed,
+            completed_changes,
+        },
+        &mut report,
+    );
     report
 }
 
-fn owner_conflict(name: &str) -> Option<String> {
-    is_bundled(name)
-        .then(|| format!("{name}: managed package name conflicts with a builtin plugin"))
+fn approve_permissions(
+    interaction: Interaction,
+    name: &str,
+    src: &str,
+    dir: &Path,
+    approvals: &mut maki_pack::approvals::Approvals,
+) -> Result<bool, String> {
+    let requested = load_requested_permissions(dir)
+        .map_err(|e| redact_error(&e))?
+        .names();
+    let key = maki_pack::approvals::ApprovalKey::new(name, src);
+    let approved = approvals.get(&key).unwrap_or(&[]);
+    let missing: Vec<&str> = requested
+        .iter()
+        .map(String::as_str)
+        .filter(|permission| !approved.iter().any(|item| item == permission))
+        .collect();
+    if missing.is_empty() {
+        return Ok(false);
+    }
+    if !interaction.confirm(&format!(
+        "Allow package {name} these permissions: {}?",
+        missing.join(", ")
+    )) {
+        return Err(format!(
+            "{name}: permission approval is required for {}",
+            missing.join(", ")
+        ));
+    }
+    approvals.approve(&key, requested);
+    Ok(true)
+}
+
+fn revoke_mismatched_approval(
+    approvals: &mut maki_pack::approvals::Approvals,
+    name: &str,
+    src: &str,
+) -> bool {
+    let key = maki_pack::approvals::ApprovalKey::new(name, src);
+    if approvals.get(&key).is_some() {
+        return false;
+    }
+    approvals.revoke(name)
 }
 
 /// Every package name the lockfile records, whether or not `init.lua` still
@@ -665,6 +1412,22 @@ fn owner_conflict(name: &str) -> Option<String> {
 pub fn installed_names() -> Option<Vec<String>> {
     let lock = read_lockfile(lockfile_path().as_deref())?;
     Some(lock.install_order().map(str::to_owned).collect())
+}
+
+/// Where one installed package lives, if the lockfile records it.
+pub fn installed_package(name: &str) -> Option<DiscoveredPackage> {
+    let site = site_dir().ok()?;
+    let lock = read_lockfile(lockfile_path().as_deref())?;
+    let manager = maki_pack::manager::Manager::new(&site);
+    let dir = manager.resolve(&lock, name)?;
+    let src = lock.get(name)?.src.clone();
+    Some(DiscoveredPackage {
+        name: name.to_owned(),
+        requested: load_requested_permissions(&dir).ok()?,
+        dir,
+        eager: true,
+        origin: Origin::Fetched { src },
+    })
 }
 
 /// What `/packupdate` or `/packdel` asked for.
@@ -680,13 +1443,15 @@ pub enum PackCommand {
     },
     Delete {
         names: Vec<String>,
-        /// `++all`. Without a bang, active packages are kept.
         all: bool,
+        force: bool,
     },
 }
 
 impl PackCommand {
-    pub fn parse(name: &str, args: &str) -> Result<Self, String> {
+    /// Reads one command line. `bang` is the trailing `!`, which the palette
+    /// has already taken off the name.
+    pub fn parse(name: &str, args: &str, bang: bool) -> Result<Self, String> {
         use crate::api::pack::{UpdateOptions, UpdateTarget};
 
         let mut names = Vec::new();
@@ -703,7 +1468,8 @@ impl PackCommand {
                 flag if flag.starts_with('+') || flag.starts_with('-') => {
                     return Err(format!("{name}: unknown option {flag:?}"));
                 }
-                other => names.push(other.to_owned()),
+                other if !names.iter().any(|name| name == other) => names.push(other.to_owned()),
+                _ => {}
             }
         }
 
@@ -712,6 +1478,7 @@ impl PackCommand {
                 if all {
                     return Err("/packupdate: ++all is not an option; omit the name instead".into());
                 }
+                options.force = bang;
                 Ok(PackCommand::Update { names, options })
             }
             "/packdel" => {
@@ -721,7 +1488,11 @@ impl PackCommand {
                 if all != names.is_empty() {
                     return Err("/packdel: name a package, or pass ++all".into());
                 }
-                Ok(PackCommand::Delete { names, all })
+                Ok(PackCommand::Delete {
+                    names,
+                    all,
+                    force: bang,
+                })
             }
             other => Err(format!("{other}: not a package command")),
         }
@@ -735,7 +1506,6 @@ impl PackCommand {
 /// read here, so this stays a pure decision that a test can drive.
 pub fn plan_command(
     cmd: &PackCommand,
-    bang: bool,
     declared: &[crate::api::pack::Declared],
     installed: &[String],
     active: &std::collections::BTreeSet<String>,
@@ -767,7 +1537,7 @@ pub fn plan_command(
                 })
                 .collect())
         }
-        PackCommand::Delete { names, all } => {
+        PackCommand::Delete { names, all, force } => {
             // Deletion asks what is installed, not what is declared. Removing
             // the `maki.pack.add` line and then removing the files is the
             // normal way to get rid of a package, and it is the only way that
@@ -779,7 +1549,7 @@ pub fn plan_command(
                 installed
                     .iter()
                     .filter(|name| !known.contains(&name.as_str()))
-                    .filter(|name| bang || !active.contains(*name))
+                    .filter(|name| *force || !active.contains(*name))
                     .cloned()
                     .collect()
             } else {
@@ -792,7 +1562,7 @@ pub fn plan_command(
                             "{name}: package is still declared; remove it from maki.pack.add first"
                         ));
                     }
-                    if active.contains(name) && !bang {
+                    if active.contains(name) && !force {
                         return Err(format!(
                             "{name}: package is active; use /packdel! to remove it"
                         ));
@@ -805,8 +1575,217 @@ pub fn plan_command(
             }
             Ok(names
                 .into_iter()
-                .map(|name| PackOp::Delete { name })
+                .map(|name| PackOp::Delete {
+                    name,
+                    force: *force,
+                })
                 .collect())
+        }
+    }
+}
+
+/// Hands the runtime every installed package that can be activated later.
+///
+/// This includes manual `opt/` packages, managed packages declared with
+/// `load = false`, and packages with lazy triggers. The same runtime table
+/// therefore serves explicit `maki.packadd` calls and automatic activation.
+///
+/// `reserved` carries the names the caller resolves *before* Lua commands:
+/// builtins and discovered custom commands. A trigger on one of those could
+/// never fire, because the palette would dispatch the other one first, so it
+/// is refused rather than left as a command that silently does nothing.
+pub fn arm_packages(
+    host: &crate::loader::PluginHost,
+    packages: &[DiscoveredPackage],
+    declared: &[crate::api::pack::Declared],
+    reserved: &[String],
+    active: &std::collections::BTreeSet<String>,
+    config: &maki_config::PluginsConfig,
+) -> Result<(), PluginError> {
+    let mut names = std::collections::BTreeSet::new();
+    let mut dormant = Vec::new();
+    for package in packages {
+        if owner_conflict(&package.name).is_some() {
+            continue;
+        }
+        if !names.insert(package.name.clone()) {
+            continue;
+        }
+        let Some(triggers) = activation_triggers(package, declared) else {
+            continue;
+        };
+        // A package the config disabled stays disabled. Waking it on a
+        // trigger would be a way around `plugins.<name>.enabled = false`.
+        if !config.packages.iter().any(|name| name == &package.name) {
+            continue;
+        }
+        // Already loaded, because an eager load or `maki.packadd` named it.
+        // Cataloging it again would let a later trigger run its top level a
+        // second time under an owner that is already registered.
+        if active.contains(&package.name) {
+            continue;
+        }
+        let package = match &package.origin {
+            // Re-resolve managed packages from the lockfile. An update or
+            // deletion may have changed the path since installation returned.
+            Origin::Fetched { .. } => match installed_package(&package.name) {
+                Some(package) => package,
+                None => continue,
+            },
+            Origin::Manual => package.clone(),
+        };
+        let permissions = effective_permissions(&package);
+        if !package.requested.is_granted_by(&permissions) {
+            continue;
+        }
+        dormant.push(Dormant {
+            // Narrowed here, once, by the same rule a startup load uses.
+            // Activation must not be a way to get more than the package
+            // would have been granted at startup.
+            permissions,
+            name: package.name.clone(),
+            dir: package.dir,
+            opts: config
+                .opts
+                .get(&package.name)
+                .cloned()
+                .map(std::sync::Arc::new)
+                .unwrap_or_default(),
+            triggers,
+            state: PackState::Inactive,
+        });
+    }
+
+    let dormant = filter_trigger_collisions(host, dormant, reserved);
+
+    host.set_dormant_packages(dormant)
+}
+
+fn filter_trigger_collisions(
+    host: &crate::loader::PluginHost,
+    dormant: Vec<Dormant>,
+    reserved: &[String],
+) -> Vec<Dormant> {
+    // A trigger that claims a name something already answers to would shadow
+    // it until the package loads, and then lose the name anyway once the real
+    // registration wins. Refusing the trigger keeps the working command
+    // working; the package can still be woken with `maki.packadd`.
+    //
+    // The published snapshot mixes real registrations with the pending entries
+    // a previous arming put there for these same packages. Startup arms twice,
+    // once before loading and once after, so without this the second pass
+    // would see its own pending entries and drop every trigger it had just
+    // published.
+    let arming: std::collections::BTreeSet<&str> =
+        dormant.iter().map(|pkg| pkg.name.as_str()).collect();
+    let mut taken: Vec<String> = host
+        .command_reader()
+        .load()
+        .commands
+        .iter()
+        .filter(|command| !arming.contains(command.plugin.as_ref()))
+        .map(|command| command.name.to_string())
+        .collect();
+    taken.extend(reserved.iter().cloned());
+    let mut seen: Vec<String> = Vec::new();
+    let mut seen_keys: Vec<(KeyCode, KeyModifiers)> = Vec::new();
+    // Keys a loaded plugin already answers. The snapshot suppresses a pending
+    // entry for one of these, so arming it would leave a package with a
+    // trigger that can never fire and no warning saying why.
+    let bound: Vec<(KeyCode, KeyModifiers)> = host
+        .keymap_reader()
+        .load()
+        .entries
+        .iter()
+        .filter(|e| !arming.contains(e.plugin.as_ref()))
+        .map(|e| (e.key, e.modifiers))
+        .collect();
+    dormant
+        .into_iter()
+        .map(|mut pkg| {
+            pkg.triggers.cmd.retain(|cmd| {
+                if taken.iter().any(|t| t == cmd) {
+                    tracing::warn!(
+                        package = %pkg.name,
+                        command = %cmd,
+                        "a command with this name already exists; the trigger is ignored"
+                    );
+                    return false;
+                }
+                // Two packages claiming one command would race, and which one
+                // won would depend on declaration order.
+                if seen.iter().any(|t| t == cmd) {
+                    tracing::warn!(
+                        package = %pkg.name,
+                        command = %cmd,
+                        "another package already claims this command; the trigger is ignored"
+                    );
+                    return false;
+                }
+                seen.push(cmd.clone());
+                true
+            });
+            // Keys need the same rule. `with_dormant` already refuses a key a
+            // loaded plugin holds, but nothing there stops two dormant
+            // packages claiming one key, and which of them a press woke would
+            // then depend on declaration order.
+            pkg.triggers.keys.retain(|notation| {
+                // Parsed once, before either test. Parsing inside the bound
+                // check ran it again for every key a plugin already holds, and
+                // reported an unusable notation as "already bound" whenever
+                // some other binding happened to exist.
+                let Ok(parsed) = crate::api::keymap::parse_key_notation(notation) else {
+                    tracing::warn!(
+                        package = %pkg.name,
+                        key = %notation,
+                        "not a usable key notation; the trigger is ignored"
+                    );
+                    return false;
+                };
+                if bound.contains(&parsed) {
+                    tracing::warn!(
+                        package = %pkg.name,
+                        key = %notation,
+                        "a plugin already binds this key; the trigger is ignored"
+                    );
+                    return false;
+                }
+                if seen_keys.contains(&parsed) {
+                    tracing::warn!(
+                        package = %pkg.name,
+                        key = %notation,
+                        "another package already claims this key; the trigger is ignored"
+                    );
+                    return false;
+                }
+                seen_keys.push(parsed);
+                true
+            });
+            pkg
+        })
+        .collect()
+}
+
+/// Automatic triggers for one package, or an empty set when only an explicit
+/// `maki.packadd` may activate it.
+fn activation_triggers(
+    package: &DiscoveredPackage,
+    declared: &[crate::api::pack::Declared],
+) -> Option<crate::api::pack::Triggers> {
+    use crate::api::pack::LoadMode;
+
+    match &package.origin {
+        Origin::Manual if !package.eager => Some(crate::api::pack::Triggers::default()),
+        Origin::Manual => None,
+        Origin::Fetched { .. } => {
+            let declaration = declared
+                .iter()
+                .find(|declaration| declaration.spec.name == package.name)?;
+            match &declaration.load {
+                LoadMode::Dormant => Some(crate::api::pack::Triggers::default()),
+                LoadMode::Triggered(triggers) => Some(triggers.clone()),
+                LoadMode::Eager | LoadMode::Custom(_) => None,
+            }
         }
     }
 }
@@ -821,11 +1800,13 @@ pub fn plan_command(
 /// startup thread, after the packages are loaded, means the work happens off
 /// the Lua thread (so unloading cannot wait on itself) and before the terminal
 /// is taken over (so a clone cannot freeze a redraw).
+///
 pub fn drain_pack_ops(
     host: &crate::loader::PluginHost,
     declared: &[crate::api::pack::Declared],
     packages: &[DiscoveredPackage],
     config: &maki_config::PluginsConfig,
+    interaction: Interaction,
 ) -> PackReport {
     let ops = match host.take_pending_pack_ops() {
         Ok(ops) => ops,
@@ -834,7 +1815,7 @@ pub fn drain_pack_ops(
             return PackReport::default();
         }
     };
-    apply_pack_ops(host, &ops, declared, packages, config)
+    apply_pack_ops(host, &ops, declared, packages, config, interaction)
 }
 
 /// What a batch of package operations did.
@@ -896,7 +1877,7 @@ fn resolve_for_activation(
     name: &str,
 ) -> Option<(PathBuf, Origin)> {
     if let Some(dir) = manager.resolve(lock, name) {
-        let src = lock.get(name).map(|e| e.src.clone()).unwrap_or_default();
+        let src = lock.get(name)?.src.clone();
         return Some((dir, Origin::Fetched { src }));
     }
     discover(site)
@@ -904,6 +1885,38 @@ fn resolve_for_activation(
         .into_iter()
         .find(|p| p.name == name)
         .map(|p| (p.dir, p.origin))
+}
+
+/// What one package load should be given.
+///
+/// Both load paths go through this, so a change to how a grant is narrowed or
+/// where options come from cannot reach one of them and miss the other.
+fn load_inputs(
+    name: &str,
+    dir: &Path,
+    origin: Origin,
+    config: &maki_config::PluginsConfig,
+) -> Result<
+    (
+        crate::plugin_permissions::PluginPermissions,
+        crate::api::options::PluginOpts,
+    ),
+    String,
+> {
+    let package = DiscoveredPackage {
+        name: name.to_owned(),
+        requested: load_requested_permissions(dir).map_err(|e| redact_error(&e))?,
+        dir: dir.to_path_buf(),
+        eager: true,
+        origin,
+    };
+    let opts = config
+        .opts
+        .get(name)
+        .cloned()
+        .map(std::sync::Arc::new)
+        .unwrap_or_default();
+    Ok((effective_permissions(&package), opts))
 }
 
 /// Loads one package and says whether it worked.
@@ -918,20 +1931,28 @@ fn load_one(
     origin: Origin,
     config: &maki_config::PluginsConfig,
 ) -> Result<(), String> {
-    let package = DiscoveredPackage {
-        name: name.to_owned(),
-        requested: load_requested_permissions(dir).map_err(|e| redact_error(&e))?,
-        dir: dir.to_path_buf(),
-        eager: true,
-        origin,
+    let (permissions, opts) = load_inputs(name, dir, origin, config)?;
+    host.load_package(name, dir, permissions, opts)
+        .map_err(|error| redact_error(&error))
+}
+
+fn load_declared_one(
+    host: &crate::loader::PluginHost,
+    declared: &crate::api::pack::Declared,
+    dir: &Path,
+    src: &str,
+    config: &maki_config::PluginsConfig,
+) -> Result<(), String> {
+    let origin = Origin::Fetched {
+        src: src.to_owned(),
     };
-    let opts = config
-        .opts
-        .get(name)
-        .cloned()
-        .map(std::sync::Arc::new)
-        .unwrap_or_default();
-    host.load_package(name, dir, effective_permissions(&package), opts)
+    if !matches!(declared.load, crate::api::pack::LoadMode::Custom(_)) {
+        return load_one(host, &declared.spec.name, dir, origin, config);
+    }
+    let (permissions, opts) = load_inputs(&declared.spec.name, dir, origin, config)?;
+    let mut declared = declared.clone();
+    declared.spec.src = src.to_owned();
+    host.run_pack_loader(declared, dir, permissions, opts)
         .map_err(|error| redact_error(&error))
 }
 
@@ -958,6 +1979,25 @@ pub(crate) fn read_lockfile(path: Option<&Path>) -> Option<maki_pack::lockfile::
     }
 }
 
+fn write_approvals(approvals: &maki_pack::approvals::Approvals) -> bool {
+    let Some(path) = approvals_path() else {
+        return false;
+    };
+    match serde_json::to_string_pretty(approvals) {
+        Ok(text) => match write_atomically(&path, &text) {
+            Ok(()) => true,
+            Err(error) => {
+                tracing::error!(path = %path.display(), %error, "failed to write pack approvals");
+                false
+            }
+        },
+        Err(error) => {
+            tracing::error!(%error, "failed to serialize pack approvals");
+            false
+        }
+    }
+}
+
 /// Writes the lockfile, and says whether it landed.
 fn write_lockfile(path: &Path, lock: &maki_pack::lockfile::Lockfile) -> bool {
     match lock.to_json() {
@@ -977,8 +2017,9 @@ fn write_lockfile(path: &Path, lock: &maki_pack::lockfile::Lockfile) -> bool {
 
 /// Drops a package's recorded approval.
 ///
-/// Removal stops when this fails, so a deleted package never leaves a grant
-/// that can silently return with a later install.
+/// A best-effort write: failing to revoke leaves a stale grant that only takes
+/// effect if the same name and source are installed again, so it is logged
+/// rather than allowed to abort the removal that already happened.
 fn revoke_approval(name: &str) -> bool {
     let Some(path) = approvals_path() else {
         return true;
@@ -987,24 +2028,7 @@ fn revoke_approval(name: &str) -> bool {
         return false;
     };
     approvals.revoke(name);
-    let text = if approvals.is_empty() {
-        "{}".to_owned()
-    } else {
-        match serde_json::to_string_pretty(&approvals) {
-            Ok(text) => text,
-            Err(e) => {
-                tracing::error!(error = %e, "failed to serialize pack approvals");
-                return false;
-            }
-        }
-    };
-    match write_atomically(&path, &text) {
-        Ok(()) => true,
-        Err(e) => {
-            tracing::error!(path = %path.display(), error = %e, "failed to write pack approvals");
-            false
-        }
-    }
+    write_approvals(&approvals)
 }
 
 /// Writes through a temporary file and renames, so a crash mid-write cannot
@@ -1013,15 +2037,7 @@ fn write_atomically(path: &Path, text: &str) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let tmp = path.with_extension("json.incoming");
-    // Flushed before the rename. Without this the rename can reach the disk
-    // first, so a crash leaves the real name pointing at a file whose contents
-    // never got there, and the lockfile reads as truncated on the next start.
-    let mut file = fs::File::create(&tmp)?;
-    file.write_all(text.as_bytes())?;
-    file.sync_all()?;
-    drop(file);
-    fs::rename(&tmp, path)
+    maki_storage::atomic_write(path, text.as_bytes()).map_err(std::io::Error::other)
 }
 
 /// What a discovery walk found, and what it had to refuse.
@@ -1152,48 +2168,16 @@ pub fn discover(site: &Path) -> Discovery {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
-    use crate::plugin_permissions::Permission;
+    use crate::loader::PluginHost;
+    use crate::plugin_permissions::{Permission, PluginPermissions};
+    use maki_agent::tools::ToolRegistry;
 
-    #[test]
-    fn terminal_messages_keep_layout_but_remove_control_characters() {
-        assert_eq!(
-            sanitize_message("package\u{1b}[31m\rname\nnext"),
-            "package [31m name\nnext"
-        );
-    }
-
-    #[test]
-    fn a_lockfile_read_error_is_not_treated_as_a_missing_file() {
-        let dir = tempfile::TempDir::new().unwrap();
-
-        assert!(read_lockfile(Some(dir.path())).is_none());
-    }
-
-    #[test]
-    fn a_missing_lockfile_reads_as_empty() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("missing.json");
-
-        assert!(read_lockfile(Some(&path)).unwrap().is_empty());
-    }
-
-    #[test]
-    fn an_invalid_approval_store_is_not_safe_to_overwrite() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("approvals.json");
-        fs::write(&path, "not json").unwrap();
-
-        assert!(read_approvals_file(&path).is_none());
-    }
-
-    #[test]
-    fn a_missing_approval_store_reads_as_empty() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("missing.json");
-
-        assert!(read_approvals_file(&path).unwrap().is_empty());
-    }
+    const EMPTY_PACK_SUMMARY: &str = "no package changed";
+    const FULL_PACK_SUMMARY: &str = "packages: 1 updated, 2 removed, 1 activated, 2 failed";
+    const SAFE_PROMPT: &str = "update [31m name\nnext";
 
     fn make_package(site: &Path, group: &str, sub: &str, name: &str) -> PathBuf {
         let dir = site.join("pack").join(group).join(sub).join(name);
@@ -1311,6 +2295,7 @@ mod tests {
                 spec: maki_pack::Spec::new(format!("https://example.com/{n}")).with_name(*n),
                 load: crate::api::pack::LoadMode::Eager,
                 confirm: true,
+                data: None,
             })
             .collect()
     }
@@ -1320,10 +2305,365 @@ mod tests {
     }
 
     #[test]
+    fn only_manual_opt_packages_are_explicit_activation_targets() {
+        let mut package = greedy("demo", Origin::Manual);
+        package.eager = false;
+        assert!(activation_triggers(&package, &[]).is_some());
+
+        package.eager = true;
+        assert!(activation_triggers(&package, &[]).is_none());
+    }
+
+    #[test]
+    fn managed_activation_uses_the_declaration_with_the_same_name() {
+        let package = greedy(
+            "demo",
+            Origin::Fetched {
+                src: "https://example.com/demo".to_owned(),
+            },
+        );
+        let mut declared = declared_named(&["other", "demo"]);
+        declared[1].load = crate::api::pack::LoadMode::Triggered(crate::api::pack::Triggers {
+            cmd: vec!["/demo".to_owned()],
+            ..Default::default()
+        });
+
+        let triggers = activation_triggers(&package, &declared).expect("demo is activatable");
+
+        assert_eq!(triggers.cmd, ["/demo"]);
+    }
+
+    #[test]
+    fn builtin_owners_and_disabled_packages_cannot_be_activated() {
+        let config = maki_config::PluginsConfig::from_plugins_and_packages(
+            Default::default(),
+            &["bash".to_owned(), "demo".to_owned()],
+        );
+
+        assert!(owner_conflict("bash").is_some());
+        assert!(activation_refusal("bash", &config).is_some());
+        assert!(activation_refusal("disabled", &config).is_some());
+        assert!(activation_refusal("demo", &config).is_none());
+
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        let mut package = greedy("bash", Origin::Manual);
+        package.eager = false;
+        arm_packages(&host, &[package], &[], &[], &Default::default(), &config).unwrap();
+
+        let error = host
+            .load_source("caller", r#"maki.packadd("bash")"#)
+            .expect_err("a catalog refresh must not reintroduce a builtin owner");
+        assert!(error.to_string().contains("not installed"), "got: {error}");
+    }
+
+    #[test]
+    fn trigger_collisions_keep_only_unclaimed_commands_and_keys() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        host.load_source(
+            "loaded",
+            r#"
+            maki.api.register_command({ name = "/taken", handler = function() end })
+            maki.keymap.set("n", "<C-g>", function() end)
+            "#,
+        )
+        .unwrap();
+        let package = |name: &str, commands: &[&str], keys: &[&str]| Dormant {
+            name: name.to_owned(),
+            dir: PathBuf::from("/nowhere"),
+            permissions: PluginPermissions::denied(),
+            opts: Default::default(),
+            triggers: crate::api::pack::Triggers {
+                cmd: commands
+                    .iter()
+                    .map(|command| (*command).to_owned())
+                    .collect(),
+                keys: keys.iter().map(|key| (*key).to_owned()).collect(),
+                ..Default::default()
+            },
+            state: PackState::Inactive,
+        };
+        let dormant = vec![
+            package(
+                "first",
+                &["/taken", "/reserved", "/shared"],
+                &["<C-g>", "<C-x>"],
+            ),
+            package("second", &["/shared", "/second"], &["<C-x>", "<C-y>"]),
+        ];
+
+        let filtered = filter_trigger_collisions(&host, dormant, &["/reserved".to_owned()]);
+
+        assert_eq!(filtered[0].triggers.cmd, ["/shared"]);
+        assert_eq!(filtered[0].triggers.keys, ["<C-x>"]);
+        assert_eq!(filtered[1].triggers.cmd, ["/second"]);
+        assert_eq!(filtered[1].triggers.keys, ["<C-y>"]);
+    }
+
+    /// Startup arms twice: once before the packages load, and once after. The
+    /// first pass publishes a pending palette entry for each trigger so the
+    /// user can type the command that wakes the package. The second pass must
+    /// not read those entries as names that are already taken, or every
+    /// trigger it just published would be dropped and no lazy package could
+    /// ever be woken by its command or key.
+    #[test]
+    fn a_second_arming_keeps_the_triggers_the_first_published() {
+        let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
+        let package = || Dormant {
+            name: "lazy".to_owned(),
+            dir: PathBuf::from("/nowhere"),
+            permissions: PluginPermissions::denied(),
+            opts: Default::default(),
+            triggers: crate::api::pack::Triggers {
+                cmd: vec!["/lazy".to_owned()],
+                keys: vec!["<C-l>".to_owned()],
+                ..Default::default()
+            },
+            state: PackState::Inactive,
+        };
+
+        let first = filter_trigger_collisions(&host, vec![package()], &[]);
+        assert_eq!(first[0].triggers.cmd, ["/lazy"]);
+        host.set_dormant_packages(first).unwrap();
+
+        let second = filter_trigger_collisions(&host, vec![package()], &[]);
+
+        assert_eq!(
+            second[0].triggers.cmd,
+            ["/lazy"],
+            "the pending entry the first arming published is not a collision"
+        );
+        assert_eq!(second[0].triggers.keys, ["<C-l>"]);
+    }
+
+    #[test]
+    fn terminal_prompts_keep_layout_but_remove_control_characters() {
+        assert_eq!(
+            sanitize_message("update\u{1b}[31m\rname\nnext"),
+            SAFE_PROMPT
+        );
+    }
+
+    #[test]
+    fn a_changed_source_does_not_fetch_the_old_lock_entry() {
+        let site = tempfile::TempDir::new().unwrap();
+        let manager = maki_pack::manager::Manager::new(site.path());
+        let mut lock = maki_pack::lockfile::Lockfile::default();
+        lock.record("demo", "https://example.com/old", "abc123");
+        let mut declared = declared_named(&["demo"]);
+        declared[0].spec.src = "https://example.com/new".to_owned();
+
+        let candidates = install_candidates(&declared, &lock, &manager, Some(false));
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].spec.src, "https://example.com/new");
+        assert!(candidates[0].confirm);
+        assert!(candidates[0].source_changed);
+    }
+
+    #[test]
+    fn an_installed_revision_does_not_block_a_source_change() {
+        let site = tempfile::TempDir::new().unwrap();
+        let manager = maki_pack::manager::Manager::new(site.path());
+        let mut lock = maki_pack::lockfile::Lockfile::default();
+        lock.record("demo", "https://example.com/old", "abc123");
+        fs::create_dir_all(maki_pack::paths::revision_dir(
+            site.path(),
+            "demo",
+            "abc123",
+        ))
+        .unwrap();
+        let mut declared = declared_named(&["demo"]);
+        declared[0].spec.src = "https://example.com/new".to_owned();
+
+        let candidates = install_candidates(&declared, &lock, &manager, Some(true));
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].spec.src, "https://example.com/new");
+        assert!(candidates[0].source_changed);
+    }
+
+    #[test]
+    fn an_installed_matching_revision_needs_no_install() {
+        let site = tempfile::TempDir::new().unwrap();
+        let manager = maki_pack::manager::Manager::new(site.path());
+        let mut lock = maki_pack::lockfile::Lockfile::default();
+        lock.record("demo", "https://example.com/demo", "abc123");
+        fs::create_dir_all(maki_pack::paths::revision_dir(
+            site.path(),
+            "demo",
+            "abc123",
+        ))
+        .unwrap();
+        let declared = declared_named(&["demo"]);
+
+        assert!(install_candidates(&declared, &lock, &manager, Some(true)).is_empty());
+    }
+
+    #[test]
+    fn a_missing_matching_lock_entry_is_planned_once() {
+        let site = tempfile::TempDir::new().unwrap();
+        let manager = maki_pack::manager::Manager::new(site.path());
+        let mut lock = maki_pack::lockfile::Lockfile::default();
+        lock.record("demo", "https://example.com/demo", "abc123");
+        let declared = declared_named(&["demo"]);
+
+        let candidates = install_candidates(&declared, &lock, &manager, Some(true));
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(
+            candidates[0].declared.load,
+            crate::api::pack::LoadMode::Eager
+        );
+    }
+
+    #[test]
+    fn permission_check_accepts_no_request_and_rejects_an_unapproved_request() {
+        let package = tempfile::TempDir::new().unwrap();
+        let mut approvals = maki_pack::approvals::Approvals::default();
+        assert_eq!(
+            approve_permissions(
+                Interaction::None,
+                "demo",
+                "https://example.com/demo",
+                package.path(),
+                &mut approvals,
+            ),
+            Ok(false)
+        );
+
+        fs::write(
+            package.path().join("plugin.toml"),
+            "[permissions]\nrun = true\n",
+        )
+        .unwrap();
+        let error = approve_permissions(
+            Interaction::None,
+            "demo",
+            "https://example.com/demo",
+            package.path(),
+            &mut approvals,
+        )
+        .expect_err("an unapproved request must not pass in headless mode");
+        assert!(error.contains("run"), "{error}");
+    }
+
+    #[test]
+    fn permission_check_reuses_an_exact_approval() {
+        let package = tempfile::TempDir::new().unwrap();
+        fs::write(
+            package.path().join("plugin.toml"),
+            "[permissions]\nrun = true\n",
+        )
+        .unwrap();
+        let src = "https://example.com/demo";
+        let mut approvals = maki_pack::approvals::Approvals::default();
+        approvals.approve(
+            &maki_pack::approvals::ApprovalKey::new("demo", src),
+            vec!["run".to_owned()],
+        );
+
+        assert_eq!(
+            approve_permissions(
+                Interaction::None,
+                "demo",
+                src,
+                package.path(),
+                &mut approvals,
+            ),
+            Ok(false)
+        );
+    }
+
+    #[test]
+    fn a_lockfile_read_error_is_not_treated_as_a_missing_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        assert!(read_lockfile(Some(dir.path())).is_none());
+    }
+
+    #[test]
+    fn a_missing_lockfile_reads_as_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("missing.json");
+
+        assert_eq!(
+            read_lockfile(Some(&path)).unwrap().install_order().count(),
+            0
+        );
+    }
+
+    #[test]
+    fn an_invalid_approval_store_is_not_safe_to_overwrite() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("approvals.json");
+        fs::write(&path, "not json").unwrap();
+
+        assert!(read_approvals_file(&path).is_none());
+    }
+
+    #[test]
+    fn a_missing_approval_store_reads_as_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("missing.json");
+
+        assert!(read_approvals_file(&path).unwrap().is_empty());
+    }
+
+    #[test]
+    fn atomic_writes_replace_an_existing_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("pack-lock.json");
+        fs::write(&path, "old").unwrap();
+
+        write_atomically(&path, "new").unwrap();
+
+        assert_eq!(fs::read_to_string(path).unwrap(), "new");
+    }
+
+    #[test]
+    fn a_source_change_keeps_an_approval_for_the_new_source() {
+        let name = "demo";
+        let old_src = "https://example.com/old";
+        let new_src = "https://example.com/new";
+        let mut approvals = maki_pack::approvals::Approvals::default();
+        approvals.approve(
+            &maki_pack::approvals::ApprovalKey::new(name, new_src),
+            vec!["run".to_owned()],
+        );
+
+        assert!(!revoke_mismatched_approval(&mut approvals, name, new_src));
+        assert!(
+            approvals
+                .get(&maki_pack::approvals::ApprovalKey::new(name, new_src))
+                .is_some()
+        );
+
+        approvals.approve(
+            &maki_pack::approvals::ApprovalKey::new(name, old_src),
+            vec!["run".to_owned()],
+        );
+        assert!(revoke_mismatched_approval(&mut approvals, name, new_src));
+        assert!(approvals.is_empty());
+    }
+
+    #[test]
+    fn pack_report_summary_lists_each_result_count() {
+        assert_eq!(PackReport::default().summary(), EMPTY_PACK_SUMMARY);
+        let report = PackReport {
+            updated: vec![("updated".to_owned(), "revision".to_owned())],
+            removed: vec!["removed-one".to_owned(), "removed-two".to_owned()],
+            activated: vec!["activated".to_owned()],
+            failures: vec!["failed-one".to_owned(), "failed-two".to_owned()],
+        };
+
+        assert_eq!(report.summary(), FULL_PACK_SUMMARY);
+    }
+
+    #[test]
     fn packupdate_flags_map_onto_the_same_options_lua_uses() {
         use crate::api::pack::{UpdateOptions, UpdateTarget};
 
-        let cmd = PackCommand::parse("/packupdate", "++offline ++lockfile").unwrap();
+        let cmd = PackCommand::parse("/packupdate", "++offline ++lockfile", false).unwrap();
         assert_eq!(
             cmd,
             PackCommand::Update {
@@ -1331,16 +2671,27 @@ mod tests {
                 options: UpdateOptions {
                     target: UpdateTarget::Lockfile,
                     offline: true,
+                    force: false,
                 },
             }
         );
+    }
+
+    #[test]
+    fn packupdate_bang_sets_force() {
+        let PackCommand::Update { options, .. } =
+            PackCommand::parse("/packupdate", "", true).unwrap()
+        else {
+            panic!("expected update command");
+        };
+        assert!(options.force);
     }
 
     /// A mistyped flag must not become a package name, or the error would name
     /// the wrong problem.
     #[test]
     fn an_unknown_flag_is_refused_rather_than_read_as_a_name() {
-        let err = PackCommand::parse("/packupdate", "++ofline")
+        let err = PackCommand::parse("/packupdate", "++ofline", false)
             .expect_err("a misspelled flag is not a package");
         assert!(err.contains("++ofline"), "{err}");
     }
@@ -1350,16 +2701,16 @@ mod tests {
     #[test]
     fn packupdate_without_a_name_plans_every_declared_package() {
         let declared = declared_named(&["alpha", "beta"]);
-        let cmd = PackCommand::parse("/packupdate", "").unwrap();
-        let ops = plan_command(&cmd, false, &declared, &[], &active_set(&[])).unwrap();
+        let cmd = PackCommand::parse("/packupdate", "", false).unwrap();
+        let ops = plan_command(&cmd, &declared, &[], &active_set(&[])).unwrap();
         assert_eq!(ops.len(), 2);
     }
 
     #[test]
     fn packupdate_refuses_a_package_that_was_never_declared() {
         let declared = declared_named(&["alpha"]);
-        let cmd = PackCommand::parse("/packupdate", "ghost").unwrap();
-        let err = plan_command(&cmd, false, &declared, &[], &active_set(&[]))
+        let cmd = PackCommand::parse("/packupdate", "ghost", false).unwrap();
+        let err = plan_command(&cmd, &declared, &[], &active_set(&[]))
             .expect_err("an undeclared package cannot be updated");
         assert!(err.contains("ghost"), "{err}");
     }
@@ -1369,22 +2720,29 @@ mod tests {
     /// for: the destructive half has to be asked for explicitly.
     #[test]
     fn packdel_all_skips_loaded_packages_unless_the_bang_is_given() {
-        let declared = Vec::new();
         let installed = vec!["alpha".to_owned(), "beta".to_owned()];
         let active = active_set(&["alpha"]);
-        let cmd = PackCommand::parse("/packdel", "++all").unwrap();
+        let cmd = PackCommand::parse("/packdel", "++all", false).unwrap();
 
-        let ops = plan_command(&cmd, false, &declared, &installed, &active).unwrap();
+        let ops = plan_command(&cmd, &[], &installed, &active).unwrap();
         assert_eq!(
             ops,
             vec![crate::api::pack::PackOp::Delete {
-                name: "beta".to_owned()
+                name: "beta".to_owned(),
+                force: false,
             }],
             "without the bang, the loaded package stays"
         );
 
-        let forced = plan_command(&cmd, true, &declared, &installed, &active).unwrap();
+        let cmd = PackCommand::parse("/packdel", "++all", true).unwrap();
+        let forced = plan_command(&cmd, &[], &installed, &active).unwrap();
         assert_eq!(forced.len(), 2, "the bang removes the loaded one too");
+        assert!(forced.into_iter().all(|operation| {
+            matches!(
+                operation,
+                crate::api::pack::PackOp::Delete { force: true, .. }
+            )
+        }));
     }
 
     /// Deleting a package is how you get rid of one you no longer declare, so
@@ -1395,14 +2753,15 @@ mod tests {
     #[test]
     fn packdel_removes_an_installed_package_that_is_no_longer_declared() {
         let installed = vec!["orphan".to_owned()];
-        let cmd = PackCommand::parse("/packdel", "orphan").unwrap();
+        let cmd = PackCommand::parse("/packdel", "orphan", false).unwrap();
 
-        let ops = plan_command(&cmd, false, &[], &installed, &active_set(&[]))
+        let ops = plan_command(&cmd, &[], &installed, &active_set(&[]))
             .expect("an installed package can be removed without a declaration");
         assert_eq!(
             ops,
             vec![crate::api::pack::PackOp::Delete {
-                name: "orphan".to_owned()
+                name: "orphan".to_owned(),
+                force: false,
             }]
         );
     }
@@ -1411,9 +2770,9 @@ mod tests {
     fn packdel_refuses_a_package_that_startup_would_reinstall() {
         let declared = declared_named(&["alpha"]);
         let installed = vec!["alpha".to_owned()];
-        let cmd = PackCommand::parse("/packdel", "alpha").unwrap();
+        let cmd = PackCommand::parse("/packdel", "alpha", true).unwrap();
 
-        let error = plan_command(&cmd, true, &declared, &installed, &active_set(&[]))
+        let error = plan_command(&cmd, &declared, &installed, &active_set(&[]))
             .expect_err("a declared package would be reinstalled during the reload");
 
         assert!(error.contains("remove it from maki.pack.add"), "{error}");
@@ -1423,60 +2782,46 @@ mod tests {
     fn packdel_requires_bang_for_an_active_named_package() {
         let installed = vec!["alpha".to_owned()];
         let active = active_set(&["alpha"]);
-        let cmd = PackCommand::parse("/packdel", "alpha").unwrap();
+        let cmd = PackCommand::parse("/packdel", "alpha", false).unwrap();
 
-        assert!(plan_command(&cmd, false, &[], &installed, &active).is_err());
+        assert!(plan_command(&cmd, &[], &installed, &active).is_err());
+        let cmd = PackCommand::parse("/packdel", "alpha", true).unwrap();
         assert_eq!(
-            plan_command(&cmd, true, &[], &installed, &active).unwrap(),
+            plan_command(&cmd, &[], &installed, &active).unwrap(),
             vec![crate::api::pack::PackOp::Delete {
-                name: "alpha".to_owned()
+                name: "alpha".to_owned(),
+                force: true,
             }]
         );
     }
 
     #[test]
     fn packdel_refuses_a_package_that_is_not_installed() {
-        let cmd = PackCommand::parse("/packdel", "ghost").unwrap();
-        let err = plan_command(&cmd, false, &[], &[], &active_set(&[]))
+        let cmd = PackCommand::parse("/packdel", "ghost", false).unwrap();
+        let err = plan_command(&cmd, &[], &[], &active_set(&[]))
             .expect_err("nothing to remove is an error, not a silent success");
         assert!(err.contains("ghost"), "{err}");
     }
 
     #[test]
     fn packdel_needs_either_a_name_or_all_but_not_both() {
-        assert!(PackCommand::parse("/packdel", "").is_err());
-        assert!(PackCommand::parse("/packdel", "++all alpha").is_err());
-        assert!(PackCommand::parse("/packdel", "alpha").is_ok());
+        assert!(PackCommand::parse("/packdel", "", false).is_err());
+        assert!(PackCommand::parse("/packdel", "++all alpha", false).is_err());
+        assert!(PackCommand::parse("/packdel", "alpha", false).is_ok());
     }
 
     /// The update flags mean nothing to a delete, so accepting them silently
     /// would let a user believe an offline delete did something different.
     #[test]
     fn packdel_refuses_the_update_flags() {
-        assert!(PackCommand::parse("/packdel", "++all ++offline").is_err());
+        assert!(PackCommand::parse("/packdel", "++all ++offline", false).is_err());
     }
 
     #[test]
     fn missing_site_dir_is_not_a_problem() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let found = discover(&tmp.path().join("absent"));
+        let found = discover(&PathBuf::from("/definitely/not/here"));
         assert!(found.packages.is_empty());
         assert!(found.problems.is_empty());
-    }
-
-    #[test]
-    fn unreadable_package_root_is_reported() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let pack = tmp.path().join("pack");
-        fs::write(&pack, "not a directory").unwrap();
-
-        let found = discover(tmp.path());
-
-        assert!(found.packages.is_empty());
-        assert!(matches!(
-            found.problems.as_slice(),
-            [PluginError::Io { .. }]
-        ));
     }
 
     #[test]

--- a/maki-lua/src/pack.rs
+++ b/maki-lua/src/pack.rs
@@ -241,6 +241,67 @@ fn granted(
     }
 }
 
+/// Whether a declared package is already installed from the source it names.
+///
+/// Both halves matter. A recorded revision only describes the source it was
+/// recorded for, so a name pointed at a different repository is neither
+/// installed nor covered by the decision that trusted the old one.
+fn installed_from_declared_source(
+    declared: &crate::api::pack::Declared,
+    lock: &maki_pack::lockfile::Lockfile,
+    manager: &maki_pack::manager::Manager,
+) -> bool {
+    let spec = &declared.spec;
+    lock.get(&spec.name)
+        .is_some_and(|entry| entry.src == spec.src)
+        && manager.resolve(lock, &spec.name).is_some()
+}
+
+/// The declared packages that are already installed at the source and revision
+/// the lockfile records.
+///
+/// Reads only: no git, no lock, no network. This is what a session still has
+/// when it cannot install, so one held lock does not take away the packages
+/// the user already had.
+fn resolved_on_disk(
+    specs: &[crate::api::pack::Declared],
+    site: &Path,
+    lock: &maki_pack::lockfile::Lockfile,
+    failures: &mut Vec<String>,
+) -> Vec<DiscoveredPackage> {
+    let manager = maki_pack::manager::Manager::new(site);
+    let mut found = Vec::new();
+    for declared in specs {
+        let spec = &declared.spec;
+        if !installed_from_declared_source(declared, lock, &manager) {
+            continue;
+        }
+        let Some(dir) = manager.resolve(lock, &spec.name) else {
+            continue;
+        };
+        let requested = match load_requested_permissions(&dir) {
+            Ok(requested) => requested,
+            Err(problem) => {
+                // Named here, because the caller only reports why installing
+                // stopped. Dropping this would make the package vanish with
+                // the lock error as the only clue.
+                failures.push(sanitize_message(&format!("{}: {problem}", spec.name)));
+                continue;
+            }
+        };
+        found.push(DiscoveredPackage {
+            name: spec.name.clone(),
+            requested,
+            origin: Origin::Fetched {
+                src: spec.src.clone(),
+            },
+            dir,
+            eager: matches!(declared.load, crate::api::pack::LoadMode::Eager),
+        });
+    }
+    found
+}
+
 /// Installs the packages `init.lua` declared, and reports where each one
 /// landed.
 ///
@@ -440,6 +501,14 @@ pub fn install_declared(
                 // bare "another process" would be wrong after a crash.
                 tracing::error!(error = %e, "could not take the package lock");
                 report.failures.push(sanitize_message(&e.to_string()));
+                // Installing needs the lock; reading what is already there
+                // does not. Returning nothing would tell the session it has
+                // no managed packages at all, because discovery skips the
+                // managed group, so a second maki started during a clone
+                // would come up with every package the user has missing.
+                if let Some(lock) = read_lockfile(lock_path.as_deref()) {
+                    report.packages = resolved_on_disk(specs, &site, &lock, &mut report.failures);
+                }
                 return report;
             }
         },
@@ -752,6 +821,8 @@ fn commit_batch(batch: CommitBatch<'_>, report: &mut PackReport) {
 /// deleting one is refused, because every plugin is an owner.
 fn runnable_ops<'a>(
     ops: &'a [crate::api::pack::PackOp],
+    manual: &Discovery,
+    lock: &maki_pack::lockfile::Lockfile,
     report: &mut PackReport,
 ) -> Vec<&'a crate::api::pack::PackOp> {
     use crate::api::pack::PackOp;
@@ -762,6 +833,11 @@ fn runnable_ops<'a>(
         }
     };
 
+    // Every name the walk saw, not only the ones that loaded. A package whose
+    // manifest became unreadable after it loaded is still the live owner of
+    // its name, and reading the loadable set alone would let this batch tear
+    // that owner down.
+    let manual_names = manual.known_names();
     let mut seen = std::collections::BTreeSet::new();
     let mut conflicted = std::collections::BTreeSet::new();
     for op in ops {
@@ -782,13 +858,30 @@ fn runnable_ops<'a>(
             if conflicted.contains(name) {
                 return false;
             }
-            match owner_conflict(name) {
-                Some(error) => {
-                    report.failures.push(error);
-                    false
-                }
-                None => true,
+            if let Some(error) = owner_conflict(name) {
+                report.failures.push(error);
+                return false;
             }
+            // A lock entry proves a managed package exists under this name, not
+            // that the loaded owner is that one. With an orphan entry beside a
+            // hand-installed package of the same name, deleting unloads the
+            // manual package's registrations and removes the managed checkout,
+            // and nothing brings the manual one back. Refused here so every
+            // pass agrees, since not being declared is exactly what gets an
+            // operation this far.
+            if manual_names.iter().any(|manual| manual == name) && lock.get(name).is_some() {
+                let where_it_is = manual
+                    .packages
+                    .iter()
+                    .find(|package| package.name == name)
+                    .map(|package| format!(" at {}", package.dir.display()))
+                    .unwrap_or_default();
+                report.failures.push(format!(
+                    "{name}: managed package name conflicts with manual package{where_it_is}"
+                ));
+                return false;
+            }
+            true
         })
         .collect()
 }
@@ -796,7 +889,6 @@ fn runnable_ops<'a>(
 /// What the update pass reads while it resolves each requested revision.
 struct Prepare<'a> {
     declared: &'a [crate::api::pack::Declared],
-    manual: &'a [DiscoveredPackage],
     manager: &'a maki_pack::manager::Manager,
     active: &'a std::collections::BTreeSet<String>,
 }
@@ -816,7 +908,6 @@ fn prepare_updates(
 
     let Prepare {
         declared,
-        manual,
         manager,
         active,
     } = ctx;
@@ -840,14 +931,18 @@ fn prepare_updates(
                 .push(format!("{name}: not installed, so it cannot be updated"));
             continue;
         };
-        if let Some(package) = manual.iter().find(|package| package.name == *name) {
+        // A declaration that now names a different repository is a new trust
+        // decision, and the prompt for it belongs to the install path.
+        // Updating here would fetch and record the very source the user had
+        // the chance to refuse, on the strength of the lock entry the old
+        // source left behind.
+        if previous.src != declaration.spec.src {
             report.failures.push(format!(
-                "{name}: managed package name conflicts with manual package at {}",
-                package.dir.display()
+                "{name}: the declared source changed, so it cannot be updated; \
+                 reload to install it from the new source"
             ));
             continue;
         }
-
         let existed = manager.resolve(lock, name).is_some();
         let mut preview = lock.clone();
         let refresh = match options.target {
@@ -1058,14 +1153,13 @@ pub fn apply_pack_ops(
     // Decided once. Four later passes walk this batch, and each repeating the
     // same two guards is how one of them ends up disagreeing with the others
     // about whether an operation may run.
-    let runnable = runnable_ops(ops, &mut report);
+    let manual = discover(&site);
+    let runnable = runnable_ops(ops, &manual, &lock, &mut report);
 
-    let manual = discover(&site).packages;
     let prepared = prepare_updates(
         &runnable,
         &Prepare {
             declared,
-            manual: &manual,
             manager: &manager,
             active: &active,
         },
@@ -1524,11 +1618,33 @@ pub fn plan_command(
 
     match cmd {
         PackCommand::Update { names, options } => {
-            let names = if names.is_empty() {
-                known.iter().map(|n| (*n).to_owned()).collect()
+            // Updating asks what is installed as well as what is declared, for
+            // the same reason deletion does. Applying an update installs when
+            // there is no lock entry, so a package whose install was declined
+            // at startup would be cloned and recorded by a later bare
+            // `/packupdate`, and the next start would see it as installed and
+            // never ask again.
+            let names: Vec<String> = if names.is_empty() {
+                known
+                    .iter()
+                    .filter(|name| installed.iter().any(|i| i == *name))
+                    .map(|n| (*n).to_owned())
+                    .collect()
             } else {
-                resolve(names)?
+                let names = resolve(names)?;
+                for name in &names {
+                    if !installed.contains(name) {
+                        return Err(format!(
+                            "{name}: not installed, so there is nothing to update; \
+                             reload to install it"
+                        ));
+                    }
+                }
+                names
             };
+            if names.is_empty() {
+                return Err("no declared package is installed; nothing was updated".into());
+            }
             Ok(names
                 .into_iter()
                 .map(|name| PackOp::Update {
@@ -1808,7 +1924,11 @@ pub fn drain_pack_ops(
     config: &maki_config::PluginsConfig,
     interaction: Interaction,
 ) -> PackReport {
-    let ops = match host.take_pending_pack_ops() {
+    // Read and closed in one message. `maki.packadd` records here whenever
+    // the runtime cannot serve it directly, and a read followed by a separate
+    // close leaves a window where a spawned Lua task records an activation
+    // that is then sealed away unread.
+    let ops = match host.seal_pack_ops() {
         Ok(ops) => ops,
         Err(e) => {
             tracing::error!(error = %e, "could not read pending package operations");
@@ -2044,18 +2164,69 @@ fn write_atomically(path: &Path, text: &str) -> std::io::Result<()> {
 ///
 /// Problems are collected rather than returned as one error, because one
 /// unusable package must not stop the others from loading.
+/// Something the walk could not use, and the name it had for it.
+///
+/// One record and not two lists, because the name and the reason are two
+/// halves of one fact and the config layer needs the name: a `plugins.<name>`
+/// table naming a package that failed to load still names something real.
+#[derive(Debug)]
+pub struct Problem {
+    /// `None` when the failure belongs to no single package, such as a group
+    /// directory that could not be read at all.
+    pub name: Option<String>,
+    pub error: PluginError,
+}
+
+impl std::fmt::Display for Problem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.error)
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct Discovery {
     pub packages: Vec<DiscoveredPackage>,
-    pub problems: Vec<PluginError>,
+    pub problems: Vec<Problem>,
 }
 
-fn sorted_paths(dir: &Path, problems: &mut Vec<PluginError>) -> Vec<PathBuf> {
+impl Discovery {
+    /// Records a package that was found but cannot load.
+    fn refuse(&mut self, name: String, error: PluginError) {
+        self.problems.push(Problem {
+            name: Some(name),
+            error,
+        });
+    }
+
+    /// Records a failure that names no package.
+    fn note(&mut self, error: PluginError) {
+        self.problems.push(Problem { name: None, error });
+    }
+
+    /// Every package name the walk saw, loadable or not.
+    ///
+    /// This is what a `plugins.<name>` table is validated against. Validating
+    /// against the loadable set instead would turn a package maki itself
+    /// refused into a config error, and blame the user's config for it.
+    pub fn known_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .packages
+            .iter()
+            .map(|package| package.name.clone())
+            .chain(self.problems.iter().filter_map(|p| p.name.clone()))
+            .collect();
+        names.sort();
+        names.dedup();
+        names
+    }
+}
+
+fn sorted_paths(dir: &Path, out: &mut Discovery) -> Vec<PathBuf> {
     let entries = match fs::read_dir(dir) {
         Ok(entries) => entries,
         Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
         Err(source) => {
-            problems.push(PluginError::Io {
+            out.note(PluginError::Io {
                 path: dir.to_path_buf(),
                 source,
             });
@@ -2066,7 +2237,7 @@ fn sorted_paths(dir: &Path, problems: &mut Vec<PluginError>) -> Vec<PathBuf> {
     for entry in entries {
         match entry {
             Ok(entry) => paths.push(entry.path()),
-            Err(source) => problems.push(PluginError::Io {
+            Err(source) => out.note(PluginError::Io {
                 path: dir.to_path_buf(),
                 source,
             }),
@@ -2086,10 +2257,9 @@ pub fn discover_installed(no_plugins: bool) -> Discovery {
     let site = match site_dir() {
         Ok(site) => site,
         Err(source) => {
-            return Discovery {
-                packages: Vec::new(),
-                problems: vec![PluginError::PackageSiteUnavailable { source }],
-            };
+            let mut out = Discovery::default();
+            out.note(PluginError::PackageSiteUnavailable { source });
+            return out;
         }
     };
     discover(&site)
@@ -2102,12 +2272,12 @@ pub fn discover_installed(no_plugins: bool) -> Discovery {
 /// it just means no packages are installed.
 pub fn discover(site: &Path) -> Discovery {
     let mut out = Discovery::default();
-    for group in sorted_paths(&site.join("pack"), &mut out.problems) {
+    for group in sorted_paths(&site.join("pack"), &mut out) {
         if group.file_name().and_then(|n| n.to_str()) == Some(MANAGED_GROUP) {
             continue;
         }
         for (sub, eager) in [("start", true), ("opt", false)] {
-            for dir in sorted_paths(&group.join(sub), &mut out.problems) {
+            for dir in sorted_paths(&group.join(sub), &mut out) {
                 let Some(name) = dir.file_name().and_then(|n| n.to_str()) else {
                     continue;
                 };
@@ -2121,7 +2291,7 @@ pub fn discover(site: &Path) -> Discovery {
                         // A package that cannot even be resolved is reported
                         // rather than silently vanishing, since an unreadable
                         // directory looks identical to one that is not there.
-                        out.problems.push(PluginError::Io { path: dir, source });
+                        out.refuse(name, PluginError::Io { path: dir, source });
                         continue;
                     }
                 };
@@ -2130,23 +2300,33 @@ pub fn discover(site: &Path) -> Discovery {
                 }
 
                 if is_bundled(&name) {
-                    out.problems
-                        .push(PluginError::PackageNameConflict { name, path: root });
+                    out.refuse(
+                        name.clone(),
+                        PluginError::PackageNameConflict { name, path: root },
+                    );
                     continue;
                 }
-                if let Some(prev) = out.packages.iter().find(|p| p.name == name) {
-                    out.problems.push(PluginError::DuplicatePackage {
-                        name,
-                        first: prev.dir.clone(),
-                        second: root,
-                    });
+                let first = out
+                    .packages
+                    .iter()
+                    .find(|p| p.name == name)
+                    .map(|p| p.dir.clone());
+                if let Some(first) = first {
+                    out.refuse(
+                        name.clone(),
+                        PluginError::DuplicatePackage {
+                            name,
+                            first,
+                            second: root,
+                        },
+                    );
                     continue;
                 }
 
                 let requested = match load_requested_permissions(&root) {
                     Ok(requested) => requested,
                     Err(problem) => {
-                        out.problems.push(problem);
+                        out.refuse(name, problem);
                         continue;
                     }
                 };
@@ -2288,16 +2468,162 @@ mod tests {
         );
     }
 
+    fn declared_pack(name: &str, src: &str) -> crate::api::pack::Declared {
+        crate::api::pack::Declared {
+            spec: maki_pack::Spec::new(src).with_name(name),
+            load: crate::api::pack::LoadMode::Eager,
+            confirm: true,
+            data: None,
+        }
+    }
+
     fn declared_named(names: &[&str]) -> Vec<crate::api::pack::Declared> {
         names
             .iter()
-            .map(|n| crate::api::pack::Declared {
-                spec: maki_pack::Spec::new(format!("https://example.com/{n}")).with_name(*n),
-                load: crate::api::pack::LoadMode::Eager,
-                confirm: true,
-                data: None,
-            })
+            .map(|n| declared_pack(n, &format!("https://example.com/{n}")))
             .collect()
+    }
+
+    /// Sets up a site where `name` is installed from `src` at one revision.
+    fn installed_site(name: &str, src: &str) -> (tempfile::TempDir, maki_pack::lockfile::Lockfile) {
+        let site = tempfile::TempDir::new().unwrap();
+        let mut lock = maki_pack::lockfile::Lockfile::default();
+        lock.record(name, src, "abc123");
+        fs::create_dir_all(maki_pack::paths::revision_dir(site.path(), name, "abc123")).unwrap();
+        (site, lock)
+    }
+
+    /// Every pass over a batch has to agree about which operations may run.
+    /// A lock entry proves a managed package exists under a name, not that the
+    /// loaded owner is that one: with an orphan entry beside a hand-installed
+    /// package of the same name, `/packdel!` unloaded the manual package's
+    /// registrations, removed the managed checkout and revoked its approval,
+    /// and nothing brought the manual package back. Not being declared is
+    /// exactly what gets an operation this far, so no later pass can catch it.
+    #[test]
+    fn a_name_held_by_a_manual_package_runs_no_operation() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        make_package(tmp.path(), "vendor", "start", "demo");
+        let manual = discover(tmp.path());
+        assert_eq!(
+            manual.packages.len(),
+            1,
+            "the hand-installed package is there"
+        );
+
+        let mut lock = maki_pack::lockfile::Lockfile::default();
+        lock.record("demo", "https://example.com/demo", "abc123");
+
+        // A manifest that stopped parsing does not stop the package from being
+        // the live owner of its name, so the guard has to hold for it too.
+        fs::write(
+            tmp.path()
+                .join("pack/vendor/start/demo")
+                .join("plugin.toml"),
+            "not = valid = toml",
+        )
+        .unwrap();
+        let refused = discover(tmp.path());
+        assert!(refused.packages.is_empty(), "it can no longer be loaded");
+        let mut report = PackReport::default();
+        assert!(
+            runnable_ops(
+                &[crate::api::pack::PackOp::Delete {
+                    name: "demo".to_owned(),
+                    force: true,
+                }],
+                &refused,
+                &lock,
+                &mut report,
+            )
+            .is_empty(),
+            "a package that stopped loading still holds its name"
+        );
+
+        // One at a time: two operations naming one package are refused as a
+        // pair, which would hide whether this guard fired at all.
+        for op in [
+            crate::api::pack::PackOp::Delete {
+                name: "demo".to_owned(),
+                force: true,
+            },
+            crate::api::pack::PackOp::Activate {
+                name: "demo".to_owned(),
+            },
+            crate::api::pack::PackOp::Update {
+                name: "demo".to_owned(),
+                options: Default::default(),
+            },
+        ] {
+            let mut report = PackReport::default();
+            let ops = vec![op.clone()];
+            let runnable = runnable_ops(&ops, &manual, &lock, &mut report);
+
+            assert!(runnable.is_empty(), "{op:?} must not run");
+            assert_eq!(report.failures.len(), 1, "got: {:?}", report.failures);
+            assert!(
+                report.failures[0].contains("conflicts with manual package"),
+                "{op:?}: {}",
+                report.failures[0]
+            );
+        }
+    }
+
+    /// The rule that decides whether installing is a fresh trust decision.
+    /// `.maki/init.lua` is project local, so a repository maki opens can point
+    /// a name the user already trusts somewhere else.
+    #[test]
+    fn a_package_is_only_installed_when_the_recorded_source_matches() {
+        let src = "https://example.com/demo";
+        let (site, lock) = installed_site("demo", src);
+        let manager = maki_pack::manager::Manager::new(site.path());
+
+        assert!(
+            installed_from_declared_source(&declared_pack("demo", src), &lock, &manager),
+            "same name, same source, and on disk"
+        );
+        assert!(
+            !installed_from_declared_source(
+                &declared_pack("demo", "https://elsewhere.example/demo"),
+                &lock,
+                &manager
+            ),
+            "a name pointed at another repository is a new trust decision"
+        );
+    }
+
+    /// A held lock stops an install, but it does not make the packages already
+    /// on disk disappear. Discovery skips the managed group, so reporting none
+    /// left the session with every managed package missing.
+    #[test]
+    fn packages_already_on_disk_resolve_without_git_or_a_lock() {
+        let src = "https://example.com/demo";
+        let (site, lock) = installed_site("demo", src);
+
+        let mut failures = Vec::new();
+        let found = resolved_on_disk(
+            &[declared_pack("demo", src)],
+            site.path(),
+            &lock,
+            &mut failures,
+        );
+        assert_eq!(found.len(), 1, "the installed package is still usable");
+        assert_eq!(found[0].name, "demo");
+        assert_eq!(
+            found[0].dir,
+            maki_pack::paths::revision_dir(site.path(), "demo", "abc123")
+        );
+
+        let moved = resolved_on_disk(
+            &[declared_pack("demo", "https://elsewhere.example/demo")],
+            site.path(),
+            &lock,
+            &mut failures,
+        );
+        assert!(
+            moved.is_empty(),
+            "the recorded revision describes the old source only"
+        );
     }
 
     fn active_set(names: &[&str]) -> std::collections::BTreeSet<String> {
@@ -2696,14 +3022,45 @@ mod tests {
         assert!(err.contains("++ofline"), "{err}");
     }
 
-    /// No name means every declared package, which is what the command's own
-    /// help says and what `:packupdate` does.
+    /// No name means every declared package that is installed, which is what
+    /// the command's own help says and what `:packupdate` does.
     #[test]
-    fn packupdate_without_a_name_plans_every_declared_package() {
+    fn packupdate_without_a_name_plans_every_installed_declared_package() {
         let declared = declared_named(&["alpha", "beta"]);
+        let installed = vec!["alpha".to_owned(), "beta".to_owned()];
         let cmd = PackCommand::parse("/packupdate", "", false).unwrap();
-        let ops = plan_command(&cmd, &declared, &[], &active_set(&[])).unwrap();
+        let ops = plan_command(&cmd, &declared, &installed, &active_set(&[])).unwrap();
         assert_eq!(ops.len(), 2);
+    }
+
+    /// Declining the install prompt has to stick. Applying an update installs
+    /// when there is no lock entry, so planning one for a declared package
+    /// that is not installed let a bare `/packupdate` clone and record the
+    /// source the user had just refused, after which startup saw it as
+    /// installed and never asked again.
+    #[test]
+    fn packupdate_leaves_a_declared_package_that_is_not_installed() {
+        let declared = declared_named(&["alpha", "beta"]);
+        let installed = vec!["alpha".to_owned()];
+        let active = active_set(&[]);
+
+        let ops = plan_command(
+            &PackCommand::parse("/packupdate", "", false).unwrap(),
+            &declared,
+            &installed,
+            &active,
+        )
+        .unwrap();
+        assert_eq!(ops.len(), 1, "only the installed package is updated");
+
+        let err = plan_command(
+            &PackCommand::parse("/packupdate", "beta", false).unwrap(),
+            &declared,
+            &installed,
+            &active,
+        )
+        .expect_err("naming it explicitly is still not an install");
+        assert!(err.contains("beta"), "{err}");
     }
 
     #[test]
@@ -2817,6 +3174,21 @@ mod tests {
         assert!(PackCommand::parse("/packdel", "++all ++offline", false).is_err());
     }
 
+    /// A package maki itself refused is still a name the user can write in
+    /// `plugins.<name>`. Validating a config against the loadable set alone
+    /// turned one bad manifest into a startup failure that blamed the config.
+    #[test]
+    fn a_package_that_cannot_be_read_is_still_a_known_name() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = make_package(tmp.path(), "vendor", "start", "broken");
+        fs::write(dir.join("plugin.toml"), "not = valid = toml").unwrap();
+
+        let found = discover(tmp.path());
+        assert!(found.packages.is_empty(), "the package must not load");
+        assert_eq!(found.problems.len(), 1, "and the reason must be reported");
+        assert_eq!(found.known_names(), vec!["broken".to_owned()]);
+    }
+
     #[test]
     fn missing_site_dir_is_not_a_problem() {
         let found = discover(&PathBuf::from("/definitely/not/here"));
@@ -2872,7 +3244,10 @@ mod tests {
         assert!(found.packages.is_empty());
         assert!(matches!(
             found.problems.as_slice(),
-            [PluginError::PackageNameConflict { .. }]
+            [Problem {
+                error: PluginError::PackageNameConflict { .. },
+                ..
+            }]
         ));
     }
 
@@ -2887,7 +3262,10 @@ mod tests {
         assert!(found.packages.is_empty());
         assert!(matches!(
             found.problems.as_slice(),
-            [PluginError::PackageNameConflict { .. }]
+            [Problem {
+                error: PluginError::PackageNameConflict { .. },
+                ..
+            }]
         ));
     }
 
@@ -2901,7 +3279,10 @@ mod tests {
         assert_eq!(found.packages.len(), 1, "the first one still loads");
         assert!(matches!(
             found.problems.as_slice(),
-            [PluginError::DuplicatePackage { .. }]
+            [Problem {
+                error: PluginError::DuplicatePackage { .. },
+                ..
+            }]
         ));
     }
 

--- a/maki-lua/src/pack.rs
+++ b/maki-lua/src/pack.rs
@@ -111,10 +111,9 @@ struct InstallCandidate {
 }
 
 fn install_candidates(
-    specs: &[crate::api::pack::Declared],
+    specs: &[&crate::api::pack::Declared],
     lock: &maki_pack::lockfile::Lockfile,
     manager: &maki_pack::manager::Manager,
-    lock_confirm: Option<bool>,
 ) -> Vec<InstallCandidate> {
     let mut candidates = Vec::new();
     for name in lock.install_order() {
@@ -124,26 +123,27 @@ fn install_candidates(
         let Some(entry) = lock.get(name) else {
             continue;
         };
-        let current = specs.iter().find(|declared| declared.spec.name == name);
-        if current.is_some_and(|declared| declared.spec.src != entry.src) {
+        let Some(current) = specs
+            .iter()
+            .copied()
+            .find(|declared| declared.spec.name == name)
+        else {
+            continue;
+        };
+        if current.spec.src != entry.src {
             continue;
         }
         let spec = Spec::new(entry.src.clone()).with_name(name.to_owned());
-        let declared = current
-            .cloned()
-            .map(|mut declared| {
-                declared.spec = spec.clone();
-                declared
-            })
-            .unwrap_or_else(|| synthetic_declared(spec.clone()));
+        let mut declared = current.clone();
+        declared.spec = spec.clone();
         candidates.push(InstallCandidate {
             declared,
             spec,
-            confirm: lock_confirm.unwrap_or(true),
+            confirm: current.confirm,
             source_changed: false,
         });
     }
-    for declared in specs {
+    for declared in specs.iter().copied() {
         let source_changed = lock
             .get(&declared.spec.name)
             .is_some_and(|entry| entry.src != declared.spec.src);
@@ -158,6 +158,37 @@ fn install_candidates(
         }
     }
     candidates
+}
+
+fn runnable_declarations<'a>(
+    specs: &'a [crate::api::pack::Declared],
+    manual: &Discovery,
+    report: &mut InstallReport,
+) -> Vec<&'a crate::api::pack::Declared> {
+    let manual_names = manual.known_names();
+    specs
+        .iter()
+        .filter(|declared| {
+            let name = &declared.spec.name;
+            if let Some(error) = owner_conflict(name) {
+                report.failures.push(error);
+                return false;
+            }
+            if manual_names.iter().any(|manual| manual == name) {
+                let path = manual
+                    .packages
+                    .iter()
+                    .find(|package| package.name == *name)
+                    .map(|package| format!(" at {}", package.dir.display()))
+                    .unwrap_or_default();
+                report.failures.push(format!(
+                    "{name}: managed package name conflicts with manual package{path}"
+                ));
+                return false;
+            }
+            true
+        })
+        .collect()
 }
 
 /// Reads the approval store.
@@ -267,6 +298,7 @@ fn resolved_on_disk(
     specs: &[crate::api::pack::Declared],
     site: &Path,
     lock: &maki_pack::lockfile::Lockfile,
+    delivers_agent_events: bool,
     failures: &mut Vec<String>,
 ) -> Vec<DiscoveredPackage> {
     let manager = maki_pack::manager::Manager::new(site);
@@ -285,7 +317,7 @@ fn resolved_on_disk(
                 // Named here, because the caller only reports why installing
                 // stopped. Dropping this would make the package vanish with
                 // the lock error as the only clue.
-                failures.push(sanitize_message(&format!("{}: {problem}", spec.name)));
+                failures.push(format!("{}: {problem}", spec.name));
                 continue;
             }
         };
@@ -296,26 +328,45 @@ fn resolved_on_disk(
                 src: spec.src.clone(),
             },
             dir,
-            eager: matches!(declared.load, crate::api::pack::LoadMode::Eager),
+            eager: declared.loads_at_start(delivers_agent_events),
         });
     }
     found
 }
 
-/// Installs the packages `init.lua` declared, and reports where each one
-/// landed.
-///
-/// Runs on the caller's thread, never the Lua thread: installing clones, and
-/// loading blocks on a reply from the runtime, so doing either from inside a
-/// Lua call would wait on a message that cannot be processed until it returns.
-///
-/// A package that fails to install is reported and skipped. One unreachable
-/// repository must not stop maki from starting, or a network problem would
-/// make the editor unusable.
+pub fn resolve_declared_on_disk(
+    specs: &[crate::api::pack::Declared],
+    delivers_agent_events: bool,
+) -> InstallReport {
+    let mut report = InstallReport::default();
+    let site = match site_dir() {
+        Ok(site) => site,
+        Err(error) => {
+            report.failures.push(format!(
+                "no data directory, so packages cannot be resolved: {error}"
+            ));
+            return report;
+        }
+    };
+    let Some(lock) = read_lockfile(lockfile_path().as_deref()) else {
+        report
+            .failures
+            .push("pack lockfile is unreadable; no package was resolved".to_owned());
+        return report;
+    };
+    report.packages = resolved_on_disk(
+        specs,
+        &site,
+        &lock,
+        delivers_agent_events,
+        &mut report.failures,
+    );
+    report
+}
+
 /// What the approval pass reads while it decides what each package may have.
 struct Grant<'a> {
     manager: &'a maki_pack::manager::Manager,
-    manual: &'a [DiscoveredPackage],
     lock: &'a maki_pack::lockfile::Lockfile,
     interaction: Interaction,
     delivers_agent_events: bool,
@@ -329,13 +380,12 @@ struct Grant<'a> {
 /// describes. Deciding what a package may have has to be a separate step from
 /// putting it on disk, or the download would be deciding its own access.
 fn grant_installed(
-    specs: &[crate::api::pack::Declared],
+    specs: &[&crate::api::pack::Declared],
     ctx: &Grant<'_>,
     report: &mut InstallReport,
 ) {
     let Grant {
         manager,
-        manual,
         lock,
         interaction,
         delivers_agent_events,
@@ -363,31 +413,7 @@ fn grant_installed(
             revoked_sources.insert(name.clone());
         }
     }
-    for declared in specs {
-        if let Some(error) = owner_conflict(&declared.spec.name) {
-            if !report
-                .failures
-                .iter()
-                .any(|failure| failure.starts_with(&format!("{}:", declared.spec.name)))
-            {
-                report.failures.push(error);
-            }
-            continue;
-        }
-        if let Some(manual) = manual.iter().find(|p| p.name == declared.spec.name) {
-            if !report
-                .failures
-                .iter()
-                .any(|failure| failure.starts_with(&format!("{}:", declared.spec.name)))
-            {
-                report.failures.push(format!(
-                    "{}: managed package name conflicts with manual package at {}",
-                    declared.spec.name,
-                    manual.dir.display()
-                ));
-            }
-            continue;
-        }
+    for declared in specs.iter().copied() {
         let Some(dir) = manager.resolve(lock, &declared.spec.name) else {
             continue;
         };
@@ -403,10 +429,9 @@ fn grant_installed(
         let requested = match load_requested_permissions(&dir) {
             Ok(requested) => requested,
             Err(problem) => {
-                report.failures.push(sanitize_message(&format!(
-                    "{}: {problem}",
-                    declared.spec.name
-                )));
+                report
+                    .failures
+                    .push(format!("{}: {problem}", declared.spec.name));
                 continue;
             }
         };
@@ -466,15 +491,22 @@ fn grant_installed(
     }
 }
 
+/// Installs the packages the global `init.lua` declared and reports where each
+/// one landed.
+///
+/// Runs on the caller's thread, never the Lua thread: installing clones, and
+/// loading blocks on a reply from the runtime, so doing either from inside a
+/// Lua call would wait on a message that cannot be processed until it returns.
+/// One unreachable repository is reported and skipped so a network problem
+/// does not stop Maki from starting.
 pub fn install_declared(
     host: &crate::loader::PluginHost,
     specs: &[crate::api::pack::Declared],
-    lock_confirm: Option<bool>,
     interaction: Interaction,
     delivers_agent_events: bool,
 ) -> InstallReport {
     let mut report = InstallReport::default();
-    if specs.is_empty() && lock_confirm.is_none() {
+    if specs.is_empty() {
         return report;
     }
     let site = match site_dir() {
@@ -496,18 +528,23 @@ pub fn install_declared(
         Some(path) => match maki_pack::lock::Lock::acquire(&path) {
             Ok(guard) => Some(guard),
             Err(e) => {
-                // The error names the lock file and the process holding it,
-                // and says to delete it if that process is gone. Reporting a
-                // bare "another process" would be wrong after a crash.
+                // The error names the lock file. The kernel releases the lock
+                // when its process exits, including after a crash.
                 tracing::error!(error = %e, "could not take the package lock");
-                report.failures.push(sanitize_message(&e.to_string()));
+                report.failures.push(e.to_string());
                 // Installing needs the lock; reading what is already there
                 // does not. Returning nothing would tell the session it has
                 // no managed packages at all, because discovery skips the
                 // managed group, so a second maki started during a clone
                 // would come up with every package the user has missing.
                 if let Some(lock) = read_lockfile(lock_path.as_deref()) {
-                    report.packages = resolved_on_disk(specs, &site, &lock, &mut report.failures);
+                    report.packages = resolved_on_disk(
+                        specs,
+                        &site,
+                        &lock,
+                        delivers_agent_events,
+                        &mut report.failures,
+                    );
                 }
                 return report;
             }
@@ -526,10 +563,10 @@ pub fn install_declared(
     };
     let original_lock = lock.clone();
     let manager = maki_pack::manager::Manager::new(&site);
-    let manual = discover(&site).packages;
-    let collides = |name: &str| manual.iter().find(|package| package.name == name);
+    let manual = discover(&site);
+    let runnable = runnable_declarations(specs, &manual, &mut report);
     let mut source_changes = std::collections::BTreeSet::new();
-    let candidates = install_candidates(specs, &lock, &manager, lock_confirm);
+    let candidates = install_candidates(&runnable, &lock, &manager);
 
     let requiring_confirmation: Vec<String> = candidates
         .iter()
@@ -549,18 +586,6 @@ pub fn install_declared(
         ));
     let mut accepted = Vec::new();
     for candidate in candidates {
-        if let Some(error) = owner_conflict(&candidate.spec.name) {
-            report.failures.push(error);
-            continue;
-        }
-        if let Some(manual) = collides(&candidate.spec.name) {
-            report.failures.push(format!(
-                "{}: managed package name conflicts with manual package at {}",
-                candidate.spec.name,
-                manual.dir.display()
-            ));
-            continue;
-        }
         if candidate.confirm && !confirmed {
             report.failures.push(format!(
                 "{}: installation requires confirmation; set confirm = false for a non-interactive install",
@@ -637,10 +662,9 @@ pub fn install_declared(
     }
 
     grant_installed(
-        specs,
+        &runnable,
         &Grant {
             manager: &manager,
-            manual: &manual,
             lock: &lock,
             interaction,
             delivers_agent_events,
@@ -687,7 +711,6 @@ struct PreparedUpdate {
     installed: maki_pack::manager::Installed,
     was_active: bool,
     force: bool,
-    source_changed: bool,
     review: String,
 }
 
@@ -962,10 +985,10 @@ fn prepare_updates(
                     continue;
                 }
             };
-        if existed && previous.src == declaration.spec.src && previous.rev == installed.rev {
+        if existed && previous.rev == installed.rev {
             continue;
         }
-        let subjects = if previous.src == declaration.spec.src {
+        let subjects =
             match smol::block_on(manager.revision_log(name, &previous.rev, &installed.rev)) {
                 Ok(subjects) => subjects,
                 Err(error) => {
@@ -976,10 +999,7 @@ fn prepare_updates(
                         .push(format!("{name}: could not review update: {message}"));
                     continue;
                 }
-            }
-        } else {
-            Vec::new()
-        };
+            };
         let mut review = format!("{name}: {} -> {}", previous.rev, installed.rev);
         for subject in subjects {
             review.push_str("\n    ");
@@ -990,7 +1010,6 @@ fn prepare_updates(
             installed,
             was_active: active.contains(name),
             force: options.force,
-            source_changed: previous.src != declaration.spec.src,
             review,
         });
     }
@@ -1121,11 +1140,10 @@ pub fn apply_pack_ops(
         Some(path) => match maki_pack::lock::Lock::acquire(&path) {
             Ok(guard) => Some(guard),
             Err(e) => {
-                // The error names the lock file and the process holding it,
-                // and says to delete it if that process is gone. Reporting a
-                // bare "another process" would be wrong after a crash.
+                // The error names the lock file. The kernel releases the lock
+                // when its process exits, including after a crash.
                 tracing::error!(error = %e, "could not take the package lock");
-                report.failures.push(sanitize_message(&e.to_string()));
+                report.failures.push(e.to_string());
                 return report;
             }
         },
@@ -1180,7 +1198,6 @@ pub fn apply_pack_ops(
     let mut approvals = read_approvals_for_write();
     let approvals_before = approvals.clone();
     let mut approvals_changed = false;
-    let mut revoked_sources = std::collections::BTreeSet::new();
     let mut approved = Vec::new();
     for update in prepared {
         let name = &update.declared.spec.name;
@@ -1204,13 +1221,7 @@ pub fn apply_pack_ops(
             approvals,
         ) {
             Ok(changed) => {
-                let revoked = update.source_changed
-                    && !changed
-                    && revoke_mismatched_approval(approvals, name, &update.declared.spec.src);
-                if revoked {
-                    revoked_sources.insert(name.clone());
-                }
-                approvals_changed |= changed || revoked;
+                approvals_changed |= changed;
                 approved.push((update, changed));
             }
             Err(message) => report.failures.push(message),
@@ -1232,11 +1243,6 @@ pub fn apply_pack_ops(
                 true
             }
         });
-        for name in revoked_sources {
-            report.failures.push(format!(
-                "{name}: the old source permission approval could not be revoked"
-            ));
-        }
     }
 
     let mut approved: std::collections::BTreeMap<String, PreparedUpdate> = approved
@@ -1315,7 +1321,9 @@ pub fn apply_pack_ops(
                 let Some(change) = prepared_deletes.remove(name) else {
                     continue;
                 };
-                if let Err(error) = host.unload(name) {
+                if change.active
+                    && let Err(error) = host.unload(name)
+                {
                     tracing::error!(package = %name, %error, "failed to unload package");
                     report.failures.push(format!(
                         "{name}: owner cleanup failed, so it was not removed: {error}"
@@ -1982,7 +1990,7 @@ impl PackReport {
 /// outside it (an unsatisfied version range, for one) never passed through
 /// that, so the redaction is applied at the point of logging instead.
 pub(crate) fn redact_error(e: &impl std::fmt::Display) -> String {
-    sanitize_message(&maki_pack::git::redact(&e.to_string()))
+    maki_pack::git::redact(&e.to_string())
 }
 
 /// Finds where an activatable package lives, and how far to trust it.
@@ -2160,10 +2168,6 @@ fn write_atomically(path: &Path, text: &str) -> std::io::Result<()> {
     maki_storage::atomic_write(path, text.as_bytes()).map_err(std::io::Error::other)
 }
 
-/// What a discovery walk found, and what it had to refuse.
-///
-/// Problems are collected rather than returned as one error, because one
-/// unusable package must not stop the others from loading.
 /// Something the walk could not use, and the name it had for it.
 ///
 /// One record and not two lists, because the name and the reason are two
@@ -2183,6 +2187,10 @@ impl std::fmt::Display for Problem {
     }
 }
 
+/// What a discovery walk found, and what it had to refuse.
+///
+/// Problems are collected rather than returned as one error, because one
+/// unusable package must not stop the others from loading.
 #[derive(Debug, Default)]
 pub struct Discovery {
     pub packages: Vec<DiscoveredPackage>,
@@ -2570,8 +2578,6 @@ mod tests {
     }
 
     /// The rule that decides whether installing is a fresh trust decision.
-    /// `.maki/init.lua` is project local, so a repository maki opens can point
-    /// a name the user already trusts somewhere else.
     #[test]
     fn a_package_is_only_installed_when_the_recorded_source_matches() {
         let src = "https://example.com/demo";
@@ -2605,6 +2611,7 @@ mod tests {
             &[declared_pack("demo", src)],
             site.path(),
             &lock,
+            false,
             &mut failures,
         );
         assert_eq!(found.len(), 1, "the installed package is still usable");
@@ -2618,12 +2625,36 @@ mod tests {
             &[declared_pack("demo", "https://elsewhere.example/demo")],
             site.path(),
             &lock,
+            false,
             &mut failures,
         );
         assert!(
             moved.is_empty(),
             "the recorded revision describes the old source only"
         );
+    }
+
+    #[test]
+    fn on_disk_event_package_loads_when_the_mode_has_no_agent_events() {
+        let src = "https://example.com/demo";
+        let (site, lock) = installed_site("demo", src);
+        let mut declared = declared_pack("demo", src);
+        declared.load = crate::api::pack::LoadMode::Triggered(crate::api::pack::Triggers {
+            event: vec!["TurnStart".to_owned()],
+            ..Default::default()
+        });
+
+        let without_events = resolved_on_disk(
+            std::slice::from_ref(&declared),
+            site.path(),
+            &lock,
+            false,
+            &mut Vec::new(),
+        );
+        let with_events = resolved_on_disk(&[declared], site.path(), &lock, true, &mut Vec::new());
+
+        assert!(without_events[0].eager);
+        assert!(!with_events[0].eager);
     }
 
     fn active_set(names: &[&str]) -> std::collections::BTreeSet<String> {
@@ -2778,7 +2809,8 @@ mod tests {
         let mut declared = declared_named(&["demo"]);
         declared[0].spec.src = "https://example.com/new".to_owned();
 
-        let candidates = install_candidates(&declared, &lock, &manager, Some(false));
+        let runnable: Vec<_> = declared.iter().collect();
+        let candidates = install_candidates(&runnable, &lock, &manager);
 
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].spec.src, "https://example.com/new");
@@ -2801,7 +2833,8 @@ mod tests {
         let mut declared = declared_named(&["demo"]);
         declared[0].spec.src = "https://example.com/new".to_owned();
 
-        let candidates = install_candidates(&declared, &lock, &manager, Some(true));
+        let runnable: Vec<_> = declared.iter().collect();
+        let candidates = install_candidates(&runnable, &lock, &manager);
 
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].spec.src, "https://example.com/new");
@@ -2822,7 +2855,8 @@ mod tests {
         .unwrap();
         let declared = declared_named(&["demo"]);
 
-        assert!(install_candidates(&declared, &lock, &manager, Some(true)).is_empty());
+        let runnable: Vec<_> = declared.iter().collect();
+        assert!(install_candidates(&runnable, &lock, &manager).is_empty());
     }
 
     #[test]
@@ -2831,15 +2865,30 @@ mod tests {
         let manager = maki_pack::manager::Manager::new(site.path());
         let mut lock = maki_pack::lockfile::Lockfile::default();
         lock.record("demo", "https://example.com/demo", "abc123");
-        let declared = declared_named(&["demo"]);
+        let mut declared = declared_named(&["demo"]);
+        declared[0].confirm = false;
 
-        let candidates = install_candidates(&declared, &lock, &manager, Some(true));
+        let runnable: Vec<_> = declared.iter().collect();
+        let candidates = install_candidates(&runnable, &lock, &manager);
 
         assert_eq!(candidates.len(), 1);
         assert_eq!(
             candidates[0].declared.load,
             crate::api::pack::LoadMode::Eager
         );
+        assert!(!candidates[0].confirm);
+    }
+
+    #[test]
+    fn an_undeclared_lock_entry_is_not_restored() {
+        let site = tempfile::TempDir::new().unwrap();
+        let manager = maki_pack::manager::Manager::new(site.path());
+        let mut lock = maki_pack::lockfile::Lockfile::default();
+        lock.record("orphan", "https://example.com/orphan", "abc123");
+
+        let candidates = install_candidates(&[], &lock, &manager);
+
+        assert!(candidates.is_empty());
     }
 
     #[test]
@@ -3061,6 +3110,61 @@ mod tests {
         )
         .expect_err("naming it explicitly is still not an install");
         assert!(err.contains("beta"), "{err}");
+    }
+
+    #[test]
+    fn update_apply_path_rejects_a_missing_lock_entry() {
+        let site = tempfile::TempDir::new().unwrap();
+        let manager = maki_pack::manager::Manager::new(site.path());
+        let declared = declared_named(&["demo"]);
+        let operation = crate::api::pack::PackOp::Update {
+            name: "demo".to_owned(),
+            options: Default::default(),
+        };
+        let mut lock = maki_pack::lockfile::Lockfile::default();
+        let mut report = PackReport::default();
+
+        let prepared = prepare_updates(
+            &[&operation],
+            &Prepare {
+                declared: &declared,
+                manager: &manager,
+                active: &Default::default(),
+            },
+            &mut lock,
+            &mut report,
+        );
+
+        assert!(prepared.is_empty());
+        assert!(report.failures[0].contains("not installed"));
+    }
+
+    #[test]
+    fn update_apply_path_rejects_a_changed_source() {
+        let site = tempfile::TempDir::new().unwrap();
+        let manager = maki_pack::manager::Manager::new(site.path());
+        let declared = declared_named(&["demo"]);
+        let operation = crate::api::pack::PackOp::Update {
+            name: "demo".to_owned(),
+            options: Default::default(),
+        };
+        let mut lock = maki_pack::lockfile::Lockfile::default();
+        lock.record("demo", "https://elsewhere.example/demo", "abc123");
+        let mut report = PackReport::default();
+
+        let prepared = prepare_updates(
+            &[&operation],
+            &Prepare {
+                declared: &declared,
+                manager: &manager,
+                active: &Default::default(),
+            },
+            &mut lock,
+            &mut report,
+        );
+
+        assert!(prepared.is_empty());
+        assert!(report.failures[0].contains("source changed"));
     }
 
     #[test]

--- a/maki-lua/src/pack.rs
+++ b/maki-lua/src/pack.rs
@@ -103,10 +103,14 @@ pub fn read_approvals() -> maki_pack::approvals::Approvals {
     let Some(path) = approvals_path() else {
         return maki_pack::approvals::Approvals::default();
     };
-    let text = match fs::read_to_string(&path) {
+    read_approvals_file(&path).unwrap_or_default()
+}
+
+fn read_approvals_file(path: &Path) -> Option<maki_pack::approvals::Approvals> {
+    let text = match fs::read_to_string(path) {
         Ok(text) => text,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return maki_pack::approvals::Approvals::default();
+            return Some(maki_pack::approvals::Approvals::default());
         }
         Err(error) => {
             tracing::error!(
@@ -114,18 +118,18 @@ pub fn read_approvals() -> maki_pack::approvals::Approvals {
                 %error,
                 "pack approval store could not be read; granting nothing"
             );
-            return maki_pack::approvals::Approvals::default();
+            return None;
         }
     };
     match serde_json::from_str(&text) {
-        Ok(approvals) => approvals,
+        Ok(approvals) => Some(approvals),
         Err(e) => {
             tracing::error!(
                 path = %path.display(),
                 error = %e,
                 "pack approval store is unreadable; granting nothing"
             );
-            maki_pack::approvals::Approvals::default()
+            None
         }
     }
 }
@@ -374,7 +378,6 @@ pub fn apply_pack_ops(
     ops: &[crate::api::pack::PackOp],
     declared: &[crate::api::pack::Declared],
     packages: &[DiscoveredPackage],
-    active: &std::collections::BTreeSet<String>,
     config: &maki_config::PluginsConfig,
 ) -> PackReport {
     use crate::api::pack::{PackOp, UpdateTarget};
@@ -428,6 +431,18 @@ pub fn apply_pack_ops(
             return report;
         }
     };
+    // Updated as the batch proceeds. Read once and left alone, a delete
+    // followed by an activate in the same batch would skip the activate as
+    // "already loaded" for a package the delete had just unloaded.
+    let mut active = match host.active_packages() {
+        Ok(active) => active,
+        Err(error) => {
+            report
+                .failures
+                .push(format!("could not read active packages: {error}"));
+            return report;
+        }
+    };
 
     let mut changed = false;
     let manual = discover(&site).packages;
@@ -470,11 +485,23 @@ pub fn apply_pack_ops(
                     ));
                     continue;
                 }
-                report.unloaded.push(name.clone());
+                active.remove(name);
                 match manager.remove(name, &mut lock) {
                     Ok(()) => {
                         changed = true;
                         report.removed.push(name.clone());
+                        // Last, so a step that fails earlier leaves the
+                        // approval exactly as it was. Revoking first would
+                        // strip the grant from a package that is still
+                        // installed, and every guarded call it makes would
+                        // then report a permission problem instead of the
+                        // removal that actually failed.
+                        if !revoke_approval(name) {
+                            report.failures.push(format!(
+                                "{name}: removed, but its approval could not be revoked; \
+                                 reinstalling the same source would not ask again"
+                            ));
+                        }
                     }
                     Err(e) => {
                         let msg = redact_error(&e);
@@ -525,10 +552,10 @@ pub fn apply_pack_ops(
                                 }
                                 continue;
                             }
-                            report.unloaded.push(name.clone());
                             // Only reload what was running. Updating a package
                             // that was dormant, or waiting on a lazy trigger,
                             // must not be the thing that starts it.
+                            active.remove(name);
                             match load_one(
                                 host,
                                 name,
@@ -538,10 +565,15 @@ pub fn apply_pack_ops(
                                 },
                                 config,
                             ) {
-                                Ok(()) => report.loaded.push(name.clone()),
-                                Err(message) => report
+                                Ok(()) => {
+                                    active.insert(name.clone());
+                                }
+                                // The old owner is already gone, so this is a
+                                // package that is now installed and not
+                                // running. Saying so beats reporting success.
+                                Err(msg) => report
                                     .failures
-                                    .push(format!("{name}: updated but failed to load: {message}")),
+                                    .push(format!("{name}: updated but failed to load: {msg}")),
                             }
                         }
                         changed |= result.changed;
@@ -581,8 +613,8 @@ pub fn apply_pack_ops(
                 match found {
                     Some((dir, origin)) => match load_one(host, name, &dir, origin, config) {
                         Ok(()) => {
+                            active.insert(name.clone());
                             report.activated.push(name.clone());
-                            report.loaded.push(name.clone());
                         }
                         Err(message) => report
                             .failures
@@ -603,6 +635,15 @@ pub fn apply_pack_ops(
         && let Some(path) = lock_path
         && !write_lockfile(&path, &lock)
     {
+        // The packages moved on disk but nothing recorded where. The next
+        // start reads the old lockfile and loads the old revisions, so these
+        // updates did not stick and must not be counted as done.
+        for (name, _) in report.updated.drain(..) {
+            report.failures.push(format!(
+                "{name}: the new revision could not be recorded, so the old one \
+                comes back on the next start"
+            ));
+        }
         report
             .failures
             .push("packages changed but the lockfile could not be written".to_owned());
@@ -615,6 +656,161 @@ fn owner_conflict(name: &str) -> Option<String> {
         .then(|| format!("{name}: managed package name conflicts with a builtin plugin"))
 }
 
+/// Every package name the lockfile records, whether or not `init.lua` still
+/// declares it.
+///
+/// Removal is a property of what is on disk, not of what is declared. A user
+/// who deletes the `maki.pack.add` line and then wants the files gone is the
+/// ordinary case, and asking the declarations would answer "unknown package".
+pub fn installed_names() -> Option<Vec<String>> {
+    let lock = read_lockfile(lockfile_path().as_deref())?;
+    Some(lock.install_order().map(str::to_owned).collect())
+}
+
+/// What `/packupdate` or `/packdel` asked for.
+///
+/// Parsed here rather than in the UI so the flags mean exactly what the Lua
+/// options mean; `++lockfile` and `target = "lockfile"` reach the same field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PackCommand {
+    Update {
+        /// Empty means every declared package.
+        names: Vec<String>,
+        options: crate::api::pack::UpdateOptions,
+    },
+    Delete {
+        names: Vec<String>,
+        /// `++all`. Without a bang, active packages are kept.
+        all: bool,
+    },
+}
+
+impl PackCommand {
+    pub fn parse(name: &str, args: &str) -> Result<Self, String> {
+        use crate::api::pack::{UpdateOptions, UpdateTarget};
+
+        let mut names = Vec::new();
+        let mut options = UpdateOptions::default();
+        let mut all = false;
+        for word in args.split_whitespace() {
+            match word {
+                "++offline" => options.offline = true,
+                "++lockfile" => options.target = UpdateTarget::Lockfile,
+                "++all" => all = true,
+                // Refused rather than treated as a package name. A flag maki
+                // does not know is a mistake, and silently reading `++ofline`
+                // as a package would report the wrong problem.
+                flag if flag.starts_with('+') || flag.starts_with('-') => {
+                    return Err(format!("{name}: unknown option {flag:?}"));
+                }
+                other => names.push(other.to_owned()),
+            }
+        }
+
+        match name {
+            "/packupdate" => {
+                if all {
+                    return Err("/packupdate: ++all is not an option; omit the name instead".into());
+                }
+                Ok(PackCommand::Update { names, options })
+            }
+            "/packdel" => {
+                if options != UpdateOptions::default() {
+                    return Err("/packdel: ++offline and ++lockfile apply to /packupdate".into());
+                }
+                if all != names.is_empty() {
+                    return Err("/packdel: name a package, or pass ++all".into());
+                }
+                Ok(PackCommand::Delete { names, all })
+            }
+            other => Err(format!("{other}: not a package command")),
+        }
+    }
+}
+
+/// Turns a command into the operations that carry it out.
+///
+/// `declared` names what `init.lua` asked for, `installed` what the lockfile
+/// records, and `active` what is loaded. All three are passed in rather than
+/// read here, so this stays a pure decision that a test can drive.
+pub fn plan_command(
+    cmd: &PackCommand,
+    bang: bool,
+    declared: &[crate::api::pack::Declared],
+    installed: &[String],
+    active: &std::collections::BTreeSet<String>,
+) -> Result<Vec<crate::api::pack::PackOp>, String> {
+    use crate::api::pack::PackOp;
+
+    let known: Vec<&str> = declared.iter().map(|d| d.spec.name.as_str()).collect();
+    let resolve = |names: &[String]| -> Result<Vec<String>, String> {
+        for name in names {
+            if !known.contains(&name.as_str()) {
+                return Err(format!("{name}: not a package declared with maki.pack.add"));
+            }
+        }
+        Ok(names.to_vec())
+    };
+
+    match cmd {
+        PackCommand::Update { names, options } => {
+            let names = if names.is_empty() {
+                known.iter().map(|n| (*n).to_owned()).collect()
+            } else {
+                resolve(names)?
+            };
+            Ok(names
+                .into_iter()
+                .map(|name| PackOp::Update {
+                    name,
+                    options: *options,
+                })
+                .collect())
+        }
+        PackCommand::Delete { names, all } => {
+            // Deletion asks what is installed, not what is declared. Removing
+            // the `maki.pack.add` line and then removing the files is the
+            // normal way to get rid of a package, and it is the only way that
+            // works under `--no-plugins`, where nothing is declared at all.
+            let names = if *all {
+                // Without the bang this removes only what is not running,
+                // matching `:packdel ++all`. Removing a loaded package is the
+                // destructive half, so it needs the bang to say so.
+                installed
+                    .iter()
+                    .filter(|name| !known.contains(&name.as_str()))
+                    .filter(|name| bang || !active.contains(*name))
+                    .cloned()
+                    .collect()
+            } else {
+                for name in names {
+                    if !installed.contains(name) {
+                        return Err(format!("{name}: not an installed package"));
+                    }
+                    if known.contains(&name.as_str()) {
+                        return Err(format!(
+                            "{name}: package is still declared; remove it from maki.pack.add first"
+                        ));
+                    }
+                    if active.contains(name) && !bang {
+                        return Err(format!(
+                            "{name}: package is active; use /packdel! to remove it"
+                        ));
+                    }
+                }
+                names.to_vec()
+            };
+            if names.is_empty() {
+                return Err("no package matched; nothing was removed".into());
+            }
+            Ok(names
+                .into_iter()
+                .map(|name| PackOp::Delete { name })
+                .collect())
+        }
+    }
+}
+
 /// Applies whatever `init.lua` asked for, once everything it could refer to is
 /// loaded.
 ///
@@ -625,15 +821,10 @@ fn owner_conflict(name: &str) -> Option<String> {
 /// startup thread, after the packages are loaded, means the work happens off
 /// the Lua thread (so unloading cannot wait on itself) and before the terminal
 /// is taken over (so a clone cannot freeze a redraw).
-///
-/// `active` is the set of package owners currently loaded. It is updated in
-/// place, because whether a package was running decides whether an update
-/// reloads it.
 pub fn drain_pack_ops(
     host: &crate::loader::PluginHost,
     declared: &[crate::api::pack::Declared],
     packages: &[DiscoveredPackage],
-    active: &mut std::collections::BTreeSet<String>,
     config: &maki_config::PluginsConfig,
 ) -> PackReport {
     let ops = match host.take_pending_pack_ops() {
@@ -643,14 +834,7 @@ pub fn drain_pack_ops(
             return PackReport::default();
         }
     };
-    let report = apply_pack_ops(host, &ops, declared, packages, active, config);
-    for name in &report.unloaded {
-        active.remove(name);
-    }
-    for name in &report.loaded {
-        active.insert(name.clone());
-    }
-    report
+    apply_pack_ops(host, &ops, declared, packages, config)
 }
 
 /// What a batch of package operations did.
@@ -664,10 +848,6 @@ pub struct PackReport {
     pub updated: Vec<(String, String)>,
     pub removed: Vec<String>,
     pub activated: Vec<String>,
-    /// Names that are now loaded, or no longer loaded, so the caller can keep
-    /// its active set in step without asking the runtime.
-    pub loaded: Vec<String>,
-    pub unloaded: Vec<String>,
     pub failures: Vec<String>,
 }
 
@@ -700,7 +880,7 @@ impl PackReport {
 /// carry a password. The git runner redacts its own output, but an error built
 /// outside it (an unsatisfied version range, for one) never passed through
 /// that, so the redaction is applied at the point of logging instead.
-fn redact_error(e: &impl std::fmt::Display) -> String {
+pub(crate) fn redact_error(e: &impl std::fmt::Display) -> String {
     sanitize_message(&maki_pack::git::redact(&e.to_string()))
 }
 
@@ -726,6 +906,11 @@ fn resolve_for_activation(
         .map(|p| (p.dir, p.origin))
 }
 
+/// Loads one package and says whether it worked.
+///
+/// Deliberately not `load_packages`, which only logs a failure. A caller that
+/// has just unloaded the old owner has to know the new one did not arrive, or
+/// it reports an update that left the package gone.
 fn load_one(
     host: &crate::loader::PluginHost,
     name: &str,
@@ -773,6 +958,7 @@ pub(crate) fn read_lockfile(path: Option<&Path>) -> Option<maki_pack::lockfile::
     }
 }
 
+/// Writes the lockfile, and says whether it landed.
 fn write_lockfile(path: &Path, lock: &maki_pack::lockfile::Lockfile) -> bool {
     match lock.to_json() {
         Ok(text) => match write_atomically(path, &text) {
@@ -784,6 +970,38 @@ fn write_lockfile(path: &Path, lock: &maki_pack::lockfile::Lockfile) -> bool {
         },
         Err(e) => {
             tracing::error!(error = %e, "failed to serialize pack lockfile");
+            false
+        }
+    }
+}
+
+/// Drops a package's recorded approval.
+///
+/// Removal stops when this fails, so a deleted package never leaves a grant
+/// that can silently return with a later install.
+fn revoke_approval(name: &str) -> bool {
+    let Some(path) = approvals_path() else {
+        return true;
+    };
+    let Some(mut approvals) = read_approvals_file(&path) else {
+        return false;
+    };
+    approvals.revoke(name);
+    let text = if approvals.is_empty() {
+        "{}".to_owned()
+    } else {
+        match serde_json::to_string_pretty(&approvals) {
+            Ok(text) => text,
+            Err(e) => {
+                tracing::error!(error = %e, "failed to serialize pack approvals");
+                return false;
+            }
+        }
+    };
+    match write_atomically(&path, &text) {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::error!(path = %path.display(), error = %e, "failed to write pack approvals");
             false
         }
     }
@@ -960,6 +1178,23 @@ mod tests {
         assert!(read_lockfile(Some(&path)).unwrap().is_empty());
     }
 
+    #[test]
+    fn an_invalid_approval_store_is_not_safe_to_overwrite() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("approvals.json");
+        fs::write(&path, "not json").unwrap();
+
+        assert!(read_approvals_file(&path).is_none());
+    }
+
+    #[test]
+    fn a_missing_approval_store_reads_as_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("missing.json");
+
+        assert!(read_approvals_file(&path).unwrap().is_empty());
+    }
+
     fn make_package(site: &Path, group: &str, sub: &str, name: &str) -> PathBuf {
         let dir = site.join("pack").join(group).join(sub).join(name);
         fs::create_dir_all(dir.join("plugin")).unwrap();
@@ -1067,6 +1302,158 @@ mod tests {
             !granted(&moved, &approvals).is_allowed(Permission::Run),
             "an approval for one repository must not grant another"
         );
+    }
+
+    fn declared_named(names: &[&str]) -> Vec<crate::api::pack::Declared> {
+        names
+            .iter()
+            .map(|n| crate::api::pack::Declared {
+                spec: maki_pack::Spec::new(format!("https://example.com/{n}")).with_name(*n),
+                load: crate::api::pack::LoadMode::Eager,
+                confirm: true,
+            })
+            .collect()
+    }
+
+    fn active_set(names: &[&str]) -> std::collections::BTreeSet<String> {
+        names.iter().map(|n| (*n).to_owned()).collect()
+    }
+
+    #[test]
+    fn packupdate_flags_map_onto_the_same_options_lua_uses() {
+        use crate::api::pack::{UpdateOptions, UpdateTarget};
+
+        let cmd = PackCommand::parse("/packupdate", "++offline ++lockfile").unwrap();
+        assert_eq!(
+            cmd,
+            PackCommand::Update {
+                names: vec![],
+                options: UpdateOptions {
+                    target: UpdateTarget::Lockfile,
+                    offline: true,
+                },
+            }
+        );
+    }
+
+    /// A mistyped flag must not become a package name, or the error would name
+    /// the wrong problem.
+    #[test]
+    fn an_unknown_flag_is_refused_rather_than_read_as_a_name() {
+        let err = PackCommand::parse("/packupdate", "++ofline")
+            .expect_err("a misspelled flag is not a package");
+        assert!(err.contains("++ofline"), "{err}");
+    }
+
+    /// No name means every declared package, which is what the command's own
+    /// help says and what `:packupdate` does.
+    #[test]
+    fn packupdate_without_a_name_plans_every_declared_package() {
+        let declared = declared_named(&["alpha", "beta"]);
+        let cmd = PackCommand::parse("/packupdate", "").unwrap();
+        let ops = plan_command(&cmd, false, &declared, &[], &active_set(&[])).unwrap();
+        assert_eq!(ops.len(), 2);
+    }
+
+    #[test]
+    fn packupdate_refuses_a_package_that_was_never_declared() {
+        let declared = declared_named(&["alpha"]);
+        let cmd = PackCommand::parse("/packupdate", "ghost").unwrap();
+        let err = plan_command(&cmd, false, &declared, &[], &active_set(&[]))
+            .expect_err("an undeclared package cannot be updated");
+        assert!(err.contains("ghost"), "{err}");
+    }
+
+    /// `++all` without the bang removes only what is not running, and with the
+    /// bang removes everything. This is the confirmation the bang stands in
+    /// for: the destructive half has to be asked for explicitly.
+    #[test]
+    fn packdel_all_skips_loaded_packages_unless_the_bang_is_given() {
+        let declared = Vec::new();
+        let installed = vec!["alpha".to_owned(), "beta".to_owned()];
+        let active = active_set(&["alpha"]);
+        let cmd = PackCommand::parse("/packdel", "++all").unwrap();
+
+        let ops = plan_command(&cmd, false, &declared, &installed, &active).unwrap();
+        assert_eq!(
+            ops,
+            vec![crate::api::pack::PackOp::Delete {
+                name: "beta".to_owned()
+            }],
+            "without the bang, the loaded package stays"
+        );
+
+        let forced = plan_command(&cmd, true, &declared, &installed, &active).unwrap();
+        assert_eq!(forced.len(), 2, "the bang removes the loaded one too");
+    }
+
+    /// Deleting a package is how you get rid of one you no longer declare, so
+    /// it has to work from the installed set alone. Asking the declarations
+    /// would make the ordinary "remove the line, then remove the files"
+    /// sequence impossible, and would break the command under `--no-plugins`,
+    /// where nothing is declared at all.
+    #[test]
+    fn packdel_removes_an_installed_package_that_is_no_longer_declared() {
+        let installed = vec!["orphan".to_owned()];
+        let cmd = PackCommand::parse("/packdel", "orphan").unwrap();
+
+        let ops = plan_command(&cmd, false, &[], &installed, &active_set(&[]))
+            .expect("an installed package can be removed without a declaration");
+        assert_eq!(
+            ops,
+            vec![crate::api::pack::PackOp::Delete {
+                name: "orphan".to_owned()
+            }]
+        );
+    }
+
+    #[test]
+    fn packdel_refuses_a_package_that_startup_would_reinstall() {
+        let declared = declared_named(&["alpha"]);
+        let installed = vec!["alpha".to_owned()];
+        let cmd = PackCommand::parse("/packdel", "alpha").unwrap();
+
+        let error = plan_command(&cmd, true, &declared, &installed, &active_set(&[]))
+            .expect_err("a declared package would be reinstalled during the reload");
+
+        assert!(error.contains("remove it from maki.pack.add"), "{error}");
+    }
+
+    #[test]
+    fn packdel_requires_bang_for_an_active_named_package() {
+        let installed = vec!["alpha".to_owned()];
+        let active = active_set(&["alpha"]);
+        let cmd = PackCommand::parse("/packdel", "alpha").unwrap();
+
+        assert!(plan_command(&cmd, false, &[], &installed, &active).is_err());
+        assert_eq!(
+            plan_command(&cmd, true, &[], &installed, &active).unwrap(),
+            vec![crate::api::pack::PackOp::Delete {
+                name: "alpha".to_owned()
+            }]
+        );
+    }
+
+    #[test]
+    fn packdel_refuses_a_package_that_is_not_installed() {
+        let cmd = PackCommand::parse("/packdel", "ghost").unwrap();
+        let err = plan_command(&cmd, false, &[], &[], &active_set(&[]))
+            .expect_err("nothing to remove is an error, not a silent success");
+        assert!(err.contains("ghost"), "{err}");
+    }
+
+    #[test]
+    fn packdel_needs_either_a_name_or_all_but_not_both() {
+        assert!(PackCommand::parse("/packdel", "").is_err());
+        assert!(PackCommand::parse("/packdel", "++all alpha").is_err());
+        assert!(PackCommand::parse("/packdel", "alpha").is_ok());
+    }
+
+    /// The update flags mean nothing to a delete, so accepting them silently
+    /// would let a user believe an offline delete did something different.
+    #[test]
+    fn packdel_refuses_the_update_flags() {
+        assert!(PackCommand::parse("/packdel", "++all ++offline").is_err());
     }
 
     #[test]

--- a/maki-lua/src/plugin_permissions.rs
+++ b/maki-lua/src/plugin_permissions.rs
@@ -175,6 +175,20 @@ impl Requested {
         self.0.is_allowed(perm)
     }
 
+    pub fn names(&self) -> Vec<String> {
+        Permission::ALL
+            .into_iter()
+            .filter(|permission| self.is_requested(*permission))
+            .map(|permission| permission.to_string())
+            .collect()
+    }
+
+    pub fn is_granted_by(&self, permissions: &PluginPermissions) -> bool {
+        Permission::ALL
+            .into_iter()
+            .all(|permission| !self.is_requested(permission) || permissions.is_allowed(permission))
+    }
+
     /// A package the user installed by hand gets what it asks for. They placed
     /// the files, which is the same trust already given to a local `init.lua`.
     /// Only a package maki fetched has to be intersected with an approval.
@@ -270,22 +284,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn trusted_allows_everything() {
-        let p = PluginPermissions::trusted();
-        for perm in Permission::ALL {
-            assert!(p.is_allowed(perm), "{perm} should be allowed");
-        }
-    }
-
-    #[test]
-    fn denied_blocks_everything() {
-        let p = PluginPermissions::denied();
-        for perm in Permission::ALL {
-            assert!(!p.is_allowed(perm), "{perm} should be denied");
-        }
-    }
-
-    #[test]
     fn from_manifest_partial() {
         let val: toml::Value = toml::from_str(
             r#"
@@ -310,18 +308,6 @@ mod tests {
         for perm in Permission::ALL {
             assert!(p.is_allowed(perm), "{perm} should default to allowed");
         }
-    }
-
-    #[test]
-    fn set_modifies_single_permission() {
-        let mut p = PluginPermissions::trusted();
-        p.set(Permission::Net, false);
-        p.set(Permission::Run, false);
-        assert!(p.is_allowed(Permission::FsRead));
-        assert!(p.is_allowed(Permission::FsWrite));
-        assert!(!p.is_allowed(Permission::Net));
-        assert!(!p.is_allowed(Permission::Run));
-        assert!(p.is_allowed(Permission::Env));
     }
 
     #[test]
@@ -417,5 +403,18 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("permission denied"));
         assert!(msg.contains("fs_read"));
+    }
+
+    #[test]
+    fn every_requested_permission_must_be_granted() {
+        let manifest: toml::Value =
+            toml::from_str("[permissions]\nnet = true\nrun = true\n").unwrap();
+        let requested = Requested::from_manifest(&manifest);
+        let mut granted = PluginPermissions::denied();
+        granted.set(Permission::Net, true);
+
+        assert!(!requested.is_granted_by(&granted));
+        granted.set(Permission::Run, true);
+        assert!(requested.is_granted_by(&granted));
     }
 }

--- a/maki-lua/src/plugin_permissions.rs
+++ b/maki-lua/src/plugin_permissions.rs
@@ -25,6 +25,17 @@ impl Permission {
         Permission::Env,
     ];
 
+    /// Parses the name used in `plugin.toml` and in the approval store.
+    ///
+    /// Both use one spelling on purpose. If an approval were recorded under a
+    /// different name from the request, `intersect` would silently never
+    /// match, and every managed package would run with nothing granted.
+    pub fn from_key(key: &str) -> Option<Self> {
+        Permission::ALL
+            .into_iter()
+            .find(|p| p.manifest_key() == key)
+    }
+
     pub(crate) const fn manifest_key(self) -> &'static str {
         match self {
             Permission::FsRead => "fs_read",
@@ -56,6 +67,21 @@ impl PluginPermissions {
         Self {
             allowed: [false; 5],
         }
+    }
+
+    /// Builds a set from the names an approval records.
+    ///
+    /// A name this build does not know is ignored rather than treated as a
+    /// grant, so an approval file written by a newer maki cannot widen what an
+    /// older one allows.
+    pub fn from_approved<'a>(names: impl IntoIterator<Item = &'a str>) -> Self {
+        let mut out = Self::denied();
+        for name in names {
+            if let Some(perm) = Permission::from_key(name) {
+                out.set(perm, true);
+            }
+        }
+        out
     }
 
     pub fn is_allowed(&self, perm: Permission) -> bool {

--- a/maki-lua/src/plugin_permissions.rs
+++ b/maki-lua/src/plugin_permissions.rs
@@ -115,6 +115,86 @@ impl PluginPermissions {
     }
 }
 
+/// What a package's `plugin.toml` asks for.
+///
+/// Deny by default: an omitted key is *not requested*. That is the opposite of
+/// [`PluginPermissions::from_manifest`], which stays permissive for a local
+/// `init.lua` the user wrote themselves. The two parsers are separate because
+/// the inputs differ in trust, not in shape: a package manifest arrives with
+/// downloaded code and must not be able to widen its own access.
+///
+/// This is a distinct type so an effective grant can never be built by
+/// accident from a request alone.
+#[derive(Debug, Clone)]
+pub struct Requested(PluginPermissions);
+
+impl Requested {
+    pub fn none() -> Self {
+        Self(PluginPermissions::denied())
+    }
+
+    pub fn from_manifest(manifest: &toml::Value) -> Self {
+        let perms = manifest.get("permissions");
+        let mut allowed = [false; 5];
+        for perm in Permission::ALL {
+            allowed[perm as usize] = perms
+                .and_then(|p| p.get(perm.manifest_key()))
+                .and_then(toml::Value::as_bool)
+                .unwrap_or(false);
+        }
+        Self(PluginPermissions { allowed })
+    }
+
+    pub fn is_requested(&self, perm: Permission) -> bool {
+        self.0.is_allowed(perm)
+    }
+
+    /// A package the user installed by hand gets what it asks for. They placed
+    /// the files, which is the same trust already given to a local `init.lua`.
+    /// Only a package maki fetched has to be intersected with an approval.
+    pub fn granted_for_manual_install(self) -> PluginPermissions {
+        self.0
+    }
+
+    /// Effective permissions for a managed package: the request and the user's
+    /// approval must agree.
+    pub fn intersect(&self, approved: &PluginPermissions) -> PluginPermissions {
+        let mut out = PluginPermissions::denied();
+        for perm in Permission::ALL {
+            out.set(perm, self.0.is_allowed(perm) && approved.is_allowed(perm));
+        }
+        out
+    }
+}
+
+/// Reads a package's requested permissions.
+///
+/// Only an absent manifest means "requests nothing". A manifest that exists but
+/// cannot be read or parsed is an error, because silently treating it as empty
+/// would load the package and then fail every guarded call it makes, which
+/// reports the typo as a permission problem instead of a syntax one.
+pub(crate) fn load_requested_permissions(
+    plugin_dir: &Path,
+) -> Result<Requested, crate::error::PluginError> {
+    let manifest_path = plugin_dir.join(MANIFEST_FILE);
+    let content = match std::fs::read_to_string(&manifest_path) {
+        Ok(content) => content,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Requested::none()),
+        Err(source) => {
+            return Err(crate::error::PluginError::Io {
+                path: manifest_path,
+                source,
+            });
+        }
+    };
+    toml::from_str::<toml::Value>(&content)
+        .map(|value| Requested::from_manifest(&value))
+        .map_err(|e| crate::error::PluginError::PackageManifest {
+            path: manifest_path,
+            message: e.to_string(),
+        })
+}
+
 fn denied_error(perm: Permission) -> LuaError {
     let msg = format!(
         "permission denied: '{perm}' not granted for this plugin (grant it in {MANIFEST_FILE} next to the plugin file)"
@@ -227,6 +307,77 @@ mod tests {
             .unwrap();
         let result: i32 = func.call(()).unwrap();
         assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn requested_denies_omitted_keys() {
+        let val: toml::Value = toml::from_str(
+            r#"
+            [permissions]
+            net = true
+            "#,
+        )
+        .unwrap();
+        let req = Requested::from_manifest(&val);
+        assert!(req.is_requested(Permission::Net));
+        for perm in Permission::ALL {
+            if perm != Permission::Net {
+                assert!(!req.is_requested(perm), "{perm} must not be requested");
+            }
+        }
+    }
+
+    /// The legacy parser stays permissive; only the package parser is strict.
+    /// A manifest with no `[permissions]` section proves the two differ.
+    #[test]
+    fn requested_and_legacy_parsers_disagree_by_design() {
+        let val: toml::Value = toml::from_str("[package]\nname = \"p\"").unwrap();
+        let legacy = PluginPermissions::from_manifest(&val);
+        let requested = Requested::from_manifest(&val);
+        for perm in Permission::ALL {
+            assert!(legacy.is_allowed(perm), "legacy stays permissive");
+            assert!(!requested.is_requested(perm), "package requests nothing");
+        }
+    }
+
+    #[test]
+    fn intersect_needs_both_request_and_approval() {
+        let val: toml::Value = toml::from_str(
+            r#"
+            [permissions]
+            net = true
+            run = true
+            "#,
+        )
+        .unwrap();
+        let requested = Requested::from_manifest(&val);
+
+        let mut approved = PluginPermissions::denied();
+        approved.set(Permission::Net, true);
+        approved.set(Permission::FsRead, true);
+
+        let effective = requested.intersect(&approved);
+        assert!(
+            effective.is_allowed(Permission::Net),
+            "requested + approved"
+        );
+        assert!(!effective.is_allowed(Permission::Run), "not approved");
+        assert!(!effective.is_allowed(Permission::FsRead), "not requested");
+        assert!(!effective.is_allowed(Permission::Env), "neither");
+    }
+
+    #[test]
+    fn manual_install_grants_what_it_requests() {
+        let val: toml::Value = toml::from_str(
+            r#"
+            [permissions]
+            fs_read = true
+            "#,
+        )
+        .unwrap();
+        let granted = Requested::from_manifest(&val).granted_for_manual_install();
+        assert!(granted.is_allowed(Permission::FsRead));
+        assert!(!granted.is_allowed(Permission::Net));
     }
 
     #[test]

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -108,7 +108,9 @@ const RESTORE_ITEM_TIMEOUT: Duration = Duration::from_secs(60);
 ///
 /// Generous on purpose, for the same reason `RESTORE_ITEM_TIMEOUT` is: a
 /// wrongly killed load costs the user a working plugin.
-const LOAD_TIMEOUT: Duration = Duration::from_secs(30);
+/// How long one load may run before the runtime abandons it.
+pub(crate) const LOAD_TIMEOUT_SECS: u64 = 30;
+const LOAD_TIMEOUT: Duration = Duration::from_secs(LOAD_TIMEOUT_SECS);
 #[cfg(test)]
 struct LoadTimeout(Duration);
 
@@ -257,9 +259,12 @@ pub enum Request {
         change: crate::api::pack::PackChange,
         reply: flume::Sender<()>,
     },
-    /// Takes the operations Lua recorded, leaving the queue empty so the same
-    /// work is never applied twice.
-    TakePackOps {
+    /// Closes the queue and hands over whatever is still in it.
+    ///
+    /// Both halves in one message on purpose: a Lua task can record an
+    /// activation between a read and a separate close, and closing without
+    /// taking would strand it in a queue nobody reads again.
+    SealPackOps {
         reply: flume::Sender<Vec<crate::api::pack::PackOp>>,
     },
     /// Hands the runtime the packages that are installed but not loaded, so it
@@ -3443,14 +3448,15 @@ pub fn spawn(
                         Request::CollectPluginOptions { reply } => {
                             let _ = reply.send(collect_plugin_options(&rt.lua));
                         }
-                        Request::TakePackOps { reply } => {
+                        Request::SealPackOps { reply } => {
                             let ops = rt
                                 .lua
                                 .app_data_ref::<crate::api::pack::PackStore>()
                                 .map(|store| {
-                                    std::mem::take(
-                                        &mut store.lock().expect("pack declarations").pending,
-                                    )
+                                    let mut declarations =
+                                        store.lock().expect("pack declarations");
+                                    declarations.drained = true;
+                                    std::mem::take(&mut declarations.pending)
                                 })
                                 .unwrap_or_default();
                             let _ = reply.send(ops);

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -150,6 +150,7 @@ pub enum Request {
         plugin_dir: Option<PathBuf>,
         permissions: PluginPermissions,
         opts: PluginOpts,
+        mark_package_active: bool,
         reply: flume::Sender<LoadResult>,
     },
     CallTool {
@@ -201,6 +202,9 @@ pub enum Request {
     /// that is when the declared set is complete.
     CollectPackages {
         reply: flume::Sender<Vec<crate::api::pack::Declared>>,
+    },
+    CollectActivePackages {
+        reply: flume::Sender<std::collections::BTreeSet<String>>,
     },
     /// Takes the operations Lua recorded, leaving the queue empty so the same
     /// work is never applied twice.
@@ -2012,6 +2016,17 @@ impl LuaRuntime {
     }
 
     fn clear_plugin(&mut self, plugin: &str) {
+        if let Some(store) = self
+            .lua
+            .app_data_ref::<crate::api::pack::PackStore>()
+            .map(|store| store.clone())
+        {
+            store
+                .lock()
+                .expect("pack declarations")
+                .active
+                .remove(plugin);
+        }
         self.registry.clear_plugin(plugin);
         self.plugin_rules.remove(plugin);
         self.drop_plugin_keys(plugin);
@@ -2793,10 +2808,37 @@ pub fn spawn(
                             plugin_dir,
                             permissions,
                             opts,
+                            mark_package_active,
                             reply,
                         } => {
+                            if mark_package_active
+                                && rt
+                                    .lua
+                                    .app_data_ref::<crate::api::pack::PackStore>()
+                                    .is_some_and(|store| {
+                                        store
+                                            .lock()
+                                            .expect("pack declarations")
+                                            .active
+                                            .contains(name.as_ref())
+                                    })
+                            {
+                                let _ = reply.send(Ok(()));
+                                continue;
+                            }
                             drain_barrier(&rt.lua, &ex, &gate, &spawn_rx).await;
                             let res = rt.load_source(Arc::clone(&name), &chunks, plugin_dir, &permissions, opts, None).await;
+                            if mark_package_active
+                                && res.is_ok()
+                                && let Some(store) =
+                                    rt.lua.app_data_ref::<crate::api::pack::PackStore>()
+                            {
+                                store
+                                    .lock()
+                                    .expect("pack declarations")
+                                    .active
+                                    .insert(name.to_string());
+                            }
                             let _ = reply.send(res);
                         }
                         Request::CallTool {
@@ -2925,6 +2967,16 @@ pub fn spawn(
                                 .map(|store| store.lock().expect("pack declarations").specs.clone())
                                 .unwrap_or_default();
                             let _ = reply.send(declared);
+                        }
+                        Request::CollectActivePackages { reply } => {
+                            let active = rt
+                                .lua
+                                .app_data_ref::<crate::api::pack::PackStore>()
+                                .map(|store| {
+                                    store.lock().expect("pack declarations").active.clone()
+                                })
+                                .unwrap_or_default();
+                            let _ = reply.send(active);
                         }
                         Request::RestoreToolAsync { item, event_tx } => {
                             spawn_restore(&ex, &gate, &restores, &rt, item, event_tx);

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::ffi::c_int;
 use std::future::Future;
 use std::panic::catch_unwind;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::ptr;
 use std::rc::Rc;
@@ -116,15 +116,41 @@ pub(crate) struct PromptHintRegistration {
 
 pub(crate) type PromptHintCallbacks = BTreeMap<Arc<str>, Vec<PromptHintRegistration>>;
 
+/// One source file of a plugin.
+///
+/// A bundled plugin has exactly one. An external package has one per
+/// `plugin/*.lua`, and they share a single owner and a single environment, so
+/// what one registers the next can see.
+#[derive(Debug, Clone)]
+pub struct LoadChunk {
+    /// Names the chunk in Lua errors, so a failure points at the file the user
+    /// wrote rather than at the package.
+    pub name: String,
+    pub source: String,
+}
+
+impl LoadChunk {
+    pub fn new(name: impl Into<String>, source: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            source: source.into(),
+        }
+    }
+}
+
 /// Load/clear drain in-flight tools first so we never mutate a
 /// plugin environment while a tool call is still running.
 pub enum Request {
     /// Plugins are loaded, so native codegen may start using idle time. Sent
     /// last so it never interleaves with the loads themselves.
     WarmJit,
+    /// Takes the package operations Lua recorded, leaving the queue empty.
+    TakePackOps {
+        reply: flume::Sender<Vec<crate::api::pack::PackOp>>,
+    },
     LoadSource {
         name: Arc<str>,
-        source: String,
+        chunks: Vec<LoadChunk>,
         plugin_dir: Option<PathBuf>,
         permissions: PluginPermissions,
         opts: PluginOpts,
@@ -550,6 +576,45 @@ fn queue_codegen(queue: &CodegenQueue, func: &Function) {
     }
 }
 
+fn module_io_error(modname: &str, path: &Path, error: &std::io::Error) -> mlua::Error {
+    mlua::Error::runtime(format!(
+        "require '{modname}': cannot read {}: {error}",
+        path.display()
+    ))
+}
+
+fn sandbox_escape(modname: &str) -> mlua::Error {
+    mlua::Error::runtime(format!("require: '{modname}' outside sandbox"))
+}
+
+/// The directory `require` searches, or `None` when there is nothing safe to
+/// search.
+///
+/// Resolving `lua/` is not enough on its own: if `lua` is itself a symlink out
+/// of the package, its target becomes the sandbox root and everything beneath
+/// that target passes the containment check. So the resolved root must still be
+/// inside the resolved package directory. A package with no `lua/` simply has
+/// no module root, which is not an error.
+fn resolve_require_root(plugin_dir: &Path) -> Option<PathBuf> {
+    let lua_dir = plugin_dir.join("lua");
+    let Ok(resolved) = lua_dir.canonicalize() else {
+        return None;
+    };
+    let root = plugin_dir
+        .canonicalize()
+        .unwrap_or_else(|_| plugin_dir.to_path_buf());
+    if resolved.starts_with(&root) {
+        Some(resolved)
+    } else {
+        tracing::warn!(
+            plugin_dir = %plugin_dir.display(),
+            resolved = %resolved.display(),
+            "lua directory resolves outside its package; modules will not load"
+        );
+        None
+    }
+}
+
 struct ModuleLoader {
     bundled: BundledModules,
     lua_dir: Option<PathBuf>,
@@ -580,11 +645,28 @@ impl ModuleLoader {
                 acc
             });
         if !normalized.starts_with(dir) {
-            return Err(mlua::Error::runtime(format!(
-                "require: '{modname}' outside sandbox"
-            )));
+            return Err(sandbox_escape(modname));
         }
-        Ok(std::fs::read_to_string(&normalized).ok())
+        // External packages are downloaded, and git carries symlinks, so the
+        // lexical fold above is not enough: a link inside the package can still
+        // point out of it. Resolve the real path and re-check.
+        //
+        // Only an absent file is a miss. An unreadable one, a symlink loop, or
+        // a file that is not UTF-8 is reported, because reporting it as
+        // "module not found" sends the user looking for a name they can see.
+        let resolved = match std::fs::canonicalize(&normalized) {
+            Ok(resolved) => resolved,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(module_io_error(modname, &normalized, &e)),
+        };
+        if !resolved.starts_with(dir) {
+            return Err(sandbox_escape(modname));
+        }
+        match std::fs::read_to_string(&resolved) {
+            Ok(source) => Ok(Some(source)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(module_io_error(modname, &resolved, &e)),
+        }
     }
 
     fn bind(&self, chunk: Chunk<'_>, modname: &str) -> Result<Function, mlua::Error> {
@@ -597,22 +679,38 @@ impl ModuleLoader {
     /// Bundled modules load as bytecode from the shared cache. Plugin files
     /// load as source, so Luau reports syntax errors against the file the user
     /// wrote.
+    ///
+    /// Both forms Neovim accepts are tried, `<mod>.lua` before
+    /// `<mod>/init.lua`. Every bundled candidate is tried before any plugin
+    /// file, so a package still cannot shadow a bundled module.
     fn load(&self, lua: &Lua, modname: &str) -> Result<LuaValue, mlua::Error> {
-        let rel_path = modname.replace('.', "/") + ".lua";
-        let func = match self.bundled.bytecode(&rel_path)? {
-            Some(bytecode) => self.bind(
-                lua.load(bytecode.as_slice()).set_mode(ChunkMode::Binary),
-                modname,
-            )?,
-            None => {
-                let Some(source) = self.plugin_source(&rel_path, modname)? else {
-                    return Err(mlua::Error::runtime(format!(
-                        "require '{modname}': module not found"
-                    )));
-                };
-                self.bind(lua.load(source.as_str()), modname)?
+        let base = modname.replace('.', "/");
+        let candidates = [format!("{base}.lua"), format!("{base}/init.lua")];
+
+        let mut func = None;
+        for rel_path in &candidates {
+            if let Some(bytecode) = self.bundled.bytecode(rel_path)? {
+                func = Some(self.bind(
+                    lua.load(bytecode.as_slice()).set_mode(ChunkMode::Binary),
+                    modname,
+                )?);
+                break;
             }
+        }
+        if func.is_none() {
+            for rel_path in &candidates {
+                if let Some(source) = self.plugin_source(rel_path, modname)? {
+                    func = Some(self.bind(lua.load(source.as_str()), modname)?);
+                    break;
+                }
+            }
+        }
+        let Some(func) = func else {
+            return Err(mlua::Error::runtime(format!(
+                "require '{modname}': module not found"
+            )));
         };
+
         queue_codegen(&self.codegen, &func);
         func.call(())
     }
@@ -1405,6 +1503,7 @@ impl LuaRuntime {
         })?;
 
         lua.set_app_data(CommandHandlerMap::new());
+        lua.set_app_data(crate::api::pack::PackStore::default());
         lua.set_app_data(JobStore::new());
         lua.set_app_data(SpawnQueue::new());
         lua.set_app_data(command_writer);
@@ -1734,7 +1833,7 @@ impl LuaRuntime {
     async fn load_source(
         &mut self,
         name: Arc<str>,
-        source: &str,
+        chunks: &[LoadChunk],
         plugin_dir: Option<PathBuf>,
         permissions: &PluginPermissions,
         opts: PluginOpts,
@@ -1756,7 +1855,7 @@ impl LuaRuntime {
         // successful load commits them to the store.
         let pending_rules: PendingRules = Arc::default();
 
-        let require_root = plugin_dir.as_ref().map(|d| d.join("lua"));
+        let require_root = plugin_dir.as_ref().and_then(|d| resolve_require_root(d));
         let maki = create_maki_global(
             &self.lua,
             Arc::clone(&self.pending),
@@ -1773,30 +1872,41 @@ impl LuaRuntime {
                 .map_err(&map_err)?;
             maki.set("setup", setup_fn).map_err(&map_err)?;
         }
+        crate::api::pack::add_packadd(&self.lua, &maki).map_err(&map_err)?;
 
         let env = self.build_env(maki, require_root).map_err(&map_err)?;
 
         self.drop_plugin_keys(&name);
 
-        let main_fn = self
-            .lua
-            .load(source)
-            .set_name(name.as_ref())
-            .set_environment(env)
-            .into_function();
-        let exec_result = match main_fn {
-            Ok(func) => {
-                queue_codegen(&self.codegen_queue, &func);
-                func.call_async::<()>(()).await
+        // Chunks run in order against one environment, so a later file sees
+        // what an earlier one registered. The first failure stops the rest.
+        let mut exec_result = Ok(());
+        for chunk in chunks {
+            let main_fn = self
+                .lua
+                .load(chunk.source.as_str())
+                .set_name(chunk.name.as_str())
+                .set_environment(env.clone())
+                .into_function();
+            exec_result = match main_fn {
+                Ok(func) => {
+                    queue_codegen(&self.codegen_queue, &func);
+                    func.call_async::<()>(()).await
+                }
+                Err(e) => Err(e),
+            };
+            if exec_result.is_err() {
+                break;
             }
-            Err(e) => Err(e),
-        };
+        }
 
+        // Checked once, after the last chunk: an option that a later chunk
+        // reads must not be reported as unused by an earlier one.
         let exec_result = exec_result.and_then(|()| self.check_opts_consumed(&name, &opts));
         if let Err(e) = exec_result {
             let stale = self.drain_pending();
             self.discard_pending(stale);
-            self.drop_plugin_keys(&name);
+            self.clear_plugin(&name);
             return Err(map_err(e));
         }
 
@@ -1836,6 +1946,10 @@ impl LuaRuntime {
 
         if let Err(e) = self.registry.replace_plugin(&name, registry_entries) {
             self.discard_pending(pending);
+            // The chunks already published commands, keymaps, hints, and slots
+            // before we got here, so a conflict at the commit point has to
+            // unwind them too, not just drop the pending tools.
+            self.clear_plugin(&name);
             return Err(match e {
                 RegistryError::NameConflict { name: n, .. } => PluginError::NameConflict {
                     plugin: name.to_string(),
@@ -1950,7 +2064,7 @@ impl LuaRuntime {
         let perms = load_plugin_permissions(plugin_dir.as_deref());
         self.load_source(
             Arc::from(source_name),
-            source,
+            &[LoadChunk::new(source_name, source)],
             plugin_dir,
             &perms,
             PluginOpts::default(),
@@ -2648,14 +2762,14 @@ pub fn spawn(
                         Request::WarmJit => codegen_armed = true,
                         Request::LoadSource {
                             name,
-                            source,
+                            chunks,
                             plugin_dir,
                             permissions,
                             opts,
                             reply,
                         } => {
                             drain_barrier(&rt.lua, &ex, &gate, &spawn_rx).await;
-                            let res = rt.load_source(Arc::clone(&name), &source, plugin_dir, &permissions, opts, None).await;
+                            let res = rt.load_source(Arc::clone(&name), &chunks, plugin_dir, &permissions, opts, None).await;
                             let _ = reply.send(res);
                         }
                         Request::CallTool {
@@ -2692,6 +2806,18 @@ pub fn spawn(
                                 let _ = reply.send(res);
                             })
                             .detach();
+                        }
+                        Request::TakePackOps { reply } => {
+                            let ops = rt
+                                .lua
+                                .app_data_ref::<crate::api::pack::PackStore>()
+                                .map(|store| {
+                                    std::mem::take(
+                                        &mut store.lock().expect("pack declarations").pending,
+                                    )
+                                })
+                                .unwrap_or_default();
+                            let _ = reply.send(ops);
                         }
                         Request::ClearPlugin { plugin, reply } => {
                             drain_barrier(&rt.lua, &ex, &gate, &spawn_rx).await;

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -84,7 +84,7 @@ const CANCEL_ABANDON_AFTER: Duration = Duration::from_secs(5);
 const OPT_LEVEL_JIT: u8 = 2;
 const OPT_LEVEL_DEBUGGABLE: u8 = 1;
 const DEBUG_INFO_FULL: u8 = 2;
-const ASYNC_RUN_DEFAULT_DEADLINE: Duration = Duration::from_secs(60);
+pub(crate) const ASYNC_RUN_DEFAULT_DEADLINE: Duration = Duration::from_secs(60);
 /// Async tasks spawned during restore may spawn further tasks; cap the rounds.
 const RESTORE_SPAWN_ROUNDS: usize = 8;
 /// Keeps a buggy plugin's restore task from freezing the lua loop.
@@ -157,6 +157,37 @@ pub struct LoadChunk {
     pub source: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ConfigScope {
+    Global,
+    Project,
+    Named(String),
+}
+
+impl ConfigScope {
+    fn label(&self) -> &str {
+        match self {
+            Self::Global => "global/init.lua",
+            Self::Project => "project/init.lua",
+            Self::Named(name) => name,
+        }
+    }
+
+    pub(crate) fn named(name: String) -> Self {
+        match name.as_str() {
+            "global/init.lua" => Self::Global,
+            "project/init.lua" => Self::Project,
+            _ => Self::Named(name),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ConfigLoad<'a> {
+    store: &'a ConfigStore,
+    scope: &'a ConfigScope,
+}
+
 enum PluginLoad<'a> {
     Chunks(&'a [LoadChunk]),
     Function { function: Function, argument: Table },
@@ -218,7 +249,7 @@ pub enum Request {
     },
     RunInitLua {
         source: String,
-        source_name: String,
+        scope: ConfigScope,
         plugin_dir: Option<PathBuf>,
         reply: flume::Sender<Result<Option<RawConfig>, PluginError>>,
     },
@@ -240,9 +271,6 @@ pub enum Request {
     /// that is when the declared set is complete.
     CollectPackages {
         reply: flume::Sender<Vec<crate::api::pack::Declared>>,
-    },
-    CollectPackConfirm {
-        reply: flume::Sender<Option<bool>>,
     },
     CollectActivePackages {
         reply: flume::Sender<std::collections::BTreeSet<String>>,
@@ -679,7 +707,38 @@ fn sandbox_escape(modname: &str) -> mlua::Error {
 /// that target passes the containment check. So the resolved root must still be
 /// inside the resolved package directory. A package with no `lua/` simply has
 /// no module root, which is not an error.
-fn resolve_require_root(plugin_dir: &Path) -> Option<PathBuf> {
+#[derive(Clone)]
+enum RequireRoot {
+    Trusted(PathBuf),
+    Sandboxed(PathBuf),
+}
+
+impl RequireRoot {
+    fn path(&self) -> &Path {
+        match self {
+            Self::Trusted(path) | Self::Sandboxed(path) => path,
+        }
+    }
+
+    fn canonicalize(self) -> Self {
+        match self {
+            Self::Trusted(path) => {
+                let resolved = path.canonicalize().unwrap_or(path);
+                Self::Trusted(resolved)
+            }
+            Self::Sandboxed(path) => {
+                let resolved = path.canonicalize().unwrap_or(path);
+                Self::Sandboxed(resolved)
+            }
+        }
+    }
+
+    fn is_sandboxed(&self) -> bool {
+        matches!(self, Self::Sandboxed(_))
+    }
+}
+
+fn resolve_require_root(plugin_dir: &Path) -> Option<RequireRoot> {
     let lua_dir = plugin_dir.join("lua");
     let Ok(resolved) = lua_dir.canonicalize() else {
         return None;
@@ -688,7 +747,7 @@ fn resolve_require_root(plugin_dir: &Path) -> Option<PathBuf> {
         .canonicalize()
         .unwrap_or_else(|_| plugin_dir.to_path_buf());
     if resolved.starts_with(&root) {
-        Some(resolved)
+        Some(RequireRoot::Sandboxed(resolved))
     } else {
         tracing::warn!(
             plugin_dir = %plugin_dir.display(),
@@ -701,7 +760,7 @@ fn resolve_require_root(plugin_dir: &Path) -> Option<PathBuf> {
 
 struct ModuleLoader {
     bundled: BundledModules,
-    lua_dir: Option<PathBuf>,
+    require_root: Option<RequireRoot>,
     env: Table,
     codegen: CodegenQueue,
     loaded: Table,
@@ -712,9 +771,10 @@ impl ModuleLoader {
     /// Bundled modules are tried first, so a plugin cannot shadow
     /// `maki.truncate` and friends with a file of its own.
     fn plugin_source(&self, rel_path: &str, modname: &str) -> Result<Option<String>, mlua::Error> {
-        let Some(dir) = self.lua_dir.as_ref() else {
+        let Some(root) = self.require_root.as_ref() else {
             return Ok(None);
         };
+        let dir = root.path();
         let normalized = dir
             .join(rel_path)
             .components()
@@ -743,7 +803,7 @@ impl ModuleLoader {
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(e) => return Err(module_io_error(modname, &normalized, &e)),
         };
-        if !resolved.starts_with(dir) {
+        if root.is_sandboxed() && !resolved.starts_with(dir) {
             return Err(sandbox_escape(modname));
         }
         match std::fs::read_to_string(&resolved) {
@@ -1600,6 +1660,7 @@ impl LuaRuntime {
         lua.set_app_data(PromptHintCallbacks::default());
         lua.set_app_data(PluginOptionSpecs::default());
         lua.set_app_data(crate::api::pack::PackStore::default());
+        lua.set_app_data(crate::api::pack::PackRuntimeTx(tx.clone()));
         #[cfg(test)]
         lua.set_app_data(LoadTimeout(LOAD_TIMEOUT));
         lua.set_app_data(AutocmdStore::default());
@@ -1862,7 +1923,7 @@ impl LuaRuntime {
     fn build_env(
         &self,
         maki: mlua::Table,
-        require_root: Option<PathBuf>,
+        require_root: Option<RequireRoot>,
     ) -> Result<mlua::Table, mlua::Error> {
         let env = self.lua.create_table()?;
         env.set("maki", maki)?;
@@ -1883,11 +1944,11 @@ impl LuaRuntime {
     fn create_require_fn(
         &self,
         env: &mlua::Table,
-        require_root: Option<PathBuf>,
+        require_root: Option<RequireRoot>,
     ) -> Result<Function, mlua::Error> {
         let loader = ModuleLoader {
             bundled: self.bundled.clone(),
-            lua_dir: require_root.map(|r| r.canonicalize().unwrap_or(r)),
+            require_root: require_root.map(RequireRoot::canonicalize),
             env: env.clone(),
             codegen: self.codegen_queue.clone(),
             loaded: self.lua.create_table()?,
@@ -1924,7 +1985,7 @@ impl LuaRuntime {
         plugin_dir: Option<PathBuf>,
         permissions: &PluginPermissions,
         opts: PluginOpts,
-        config_store: Option<&ConfigStore>,
+        config: Option<ConfigLoad<'_>>,
     ) -> LoadResult {
         self.load_bounded(
             name,
@@ -1932,7 +1993,7 @@ impl LuaRuntime {
             plugin_dir,
             permissions,
             opts,
-            config_store,
+            config,
         )
         .await
     }
@@ -1948,7 +2009,7 @@ impl LuaRuntime {
         plugin_dir: Option<PathBuf>,
         permissions: &PluginPermissions,
         opts: PluginOpts,
-        config_store: Option<&ConfigStore>,
+        config: Option<ConfigLoad<'_>>,
     ) -> LoadResult {
         let timeout = load_timeout(&self.lua);
         let deadline = Instant::now() + timeout;
@@ -1964,7 +2025,7 @@ impl LuaRuntime {
             plugin_dir,
             permissions,
             opts,
-            config_store,
+            config,
         );
         let timeout_error = {
             let plugin = name.to_string();
@@ -2014,7 +2075,7 @@ impl LuaRuntime {
         plugin_dir: Option<PathBuf>,
         permissions: &PluginPermissions,
         opts: PluginOpts,
-        config_store: Option<&ConfigStore>,
+        config: Option<ConfigLoad<'_>>,
     ) -> LoadResult {
         let map_err = |e: mlua::Error| PluginError::Lua {
             plugin: name.to_string(),
@@ -2032,7 +2093,10 @@ impl LuaRuntime {
         // successful load commits them to the store.
         let pending_rules: PendingRules = Arc::default();
 
-        let require_root = plugin_dir.as_ref().and_then(|d| resolve_require_root(d));
+        let require_root = plugin_dir.as_ref().and_then(|dir| match config {
+            Some(_) => Some(RequireRoot::Trusted(dir.join("lua"))),
+            None => resolve_require_root(dir),
+        });
         let maki = create_maki_global(
             &self.lua,
             Arc::clone(&self.pending),
@@ -2044,32 +2108,26 @@ impl LuaRuntime {
         )
         .map_err(&map_err)?;
 
-        if let Some(cs) = config_store {
-            let setup_fn = crate::api::util::setup::create_setup_fn(&self.lua, Arc::clone(cs))
-                .map_err(&map_err)?;
+        if let Some(config) = config {
+            let setup_fn =
+                crate::api::util::setup::create_setup_fn(&self.lua, Arc::clone(config.store))
+                    .map_err(&map_err)?;
             maki.set("setup", setup_fn).map_err(&map_err)?;
 
-            // Attached under the same condition as `setup`, so declaring a
-            // package is available to `init.lua` and to nothing else. `add`
-            // fetches code and rewrites the lockfile, which is a configuration
-            // decision; a downloaded package must not be able to make it for
-            // itself, whatever permissions it holds.
-            maki.set(
-                "pack",
-                crate::api::pack::create_pack_table(&self.lua).map_err(&map_err)?,
-            )
-            .map_err(&map_err)?;
+            // Project config keeps the read API but cannot mutate the global
+            // package set. A checked-out repository must not fetch code or
+            // rewrite the user's lockfile when it opens.
+            let pack = crate::api::pack::create_pack_table(&self.lua).map_err(&map_err)?;
+            if config.scope == &ConfigScope::Project {
+                crate::api::pack::restrict_management(&self.lua, &pack).map_err(&map_err)?;
+            }
+            maki.set("pack", pack).map_err(&map_err)?;
             maki.set(
                 "version",
                 crate::api::version::create_version_table(&self.lua).map_err(&map_err)?,
             )
             .map_err(&map_err)?;
         }
-        // Available to every plugin, not only `init.lua`: activating a package
-        // that is already installed and already approved is far weaker than
-        // fetching new code, which is what the `maki.pack` table gates.
-        crate::api::pack::add_packadd(&self.lua, &maki, Some(self.tx.clone())).map_err(&map_err)?;
-
         let env = self.build_env(maki, require_root).map_err(&map_err)?;
 
         self.drop_plugin_keys(&name);
@@ -2541,18 +2599,21 @@ impl LuaRuntime {
     async fn run_init_lua(
         &mut self,
         source: &str,
-        source_name: &str,
+        scope: ConfigScope,
         plugin_dir: Option<PathBuf>,
     ) -> Result<Option<RawConfig>, PluginError> {
         let config_store: ConfigStore = Arc::new(Mutex::new(None));
         let perms = load_plugin_permissions(plugin_dir.as_deref());
         self.load_source(
-            Arc::from(source_name),
-            &[LoadChunk::new(source_name, source)],
+            Arc::from(scope.label()),
+            &[LoadChunk::new(scope.label(), source)],
             plugin_dir,
             &perms,
             PluginOpts::default(),
-            Some(&config_store),
+            Some(ConfigLoad {
+                store: &config_store,
+                scope: &scope,
+            }),
         )
         .await?;
         Ok(config_store.lock().unwrap().take())
@@ -3433,12 +3494,12 @@ pub fn spawn(
                         }
                         Request::RunInitLua {
                             source,
-                            source_name,
+                            scope,
                             plugin_dir,
                             reply,
                         } => {
                             drain_barrier(&rt.lua, &ex, &gate, &spawn_rx).await;
-                            let res = rt.run_init_lua(&source, &source_name, plugin_dir).await;
+                            let res = rt.run_init_lua(&source, scope, plugin_dir).await;
                             let _ = reply.send(res);
                         }
                         Request::CollectPromptSlots { reply } => {
@@ -3469,15 +3530,6 @@ pub fn spawn(
                                 .unwrap_or_default();
                             let _ = reply.send(declared);
                         }
-                        Request::CollectPackConfirm { reply } => {
-                            let confirm = rt
-                                .lua
-                                .app_data_ref::<crate::api::pack::PackStore>()
-                                .and_then(|store| {
-                                    store.lock().expect("pack declarations").lock_confirm
-                                });
-                            let _ = reply.send(confirm);
-                        }
                         Request::CollectActivePackages { reply } => {
                             let active = rt
                                 .lua
@@ -3501,7 +3553,9 @@ pub fn spawn(
                             let input = (|| {
                                 let crate::api::pack::LoadMode::Custom(loader) = &declared.load
                                 else {
-                                    unreachable!("only a custom load reaches this request")
+                                    return Err(mlua::Error::runtime(
+                                        "run_pack_loader: not a custom load",
+                                    ));
                                 };
                                 let function = rt.lua.registry_value::<Function>(loader.as_ref())?;
                                 let data = rt.lua.create_table()?;

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -2114,11 +2114,10 @@ impl LuaRuntime {
                     .map_err(&map_err)?;
             maki.set("setup", setup_fn).map_err(&map_err)?;
 
-            // Project config keeps the read API but cannot mutate the global
-            // package set. A checked-out repository must not fetch code or
-            // rewrite the user's lockfile when it opens.
+            // Non-global config keeps the read API but cannot mutate the
+            // shared package set.
             let pack = crate::api::pack::create_pack_table(&self.lua).map_err(&map_err)?;
-            if config.scope == &ConfigScope::Project {
+            if config.scope != &ConfigScope::Global {
                 crate::api::pack::restrict_management(&self.lua, &pack).map_err(&map_err)?;
             }
             maki.set("pack", pack).map_err(&map_err)?;

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -144,10 +144,6 @@ pub enum Request {
     /// Plugins are loaded, so native codegen may start using idle time. Sent
     /// last so it never interleaves with the loads themselves.
     WarmJit,
-    /// Takes the package operations Lua recorded, leaving the queue empty.
-    TakePackOps {
-        reply: flume::Sender<Vec<crate::api::pack::PackOp>>,
-    },
     LoadSource {
         name: Arc<str>,
         chunks: Vec<LoadChunk>,
@@ -200,6 +196,16 @@ pub enum Request {
     },
     CollectPluginOptions {
         reply: flume::Sender<PluginOptionSpecs>,
+    },
+    /// Packages `init.lua` declared. Read after the init files have run, since
+    /// that is when the declared set is complete.
+    CollectPackages {
+        reply: flume::Sender<Vec<crate::api::pack::Declared>>,
+    },
+    /// Takes the operations Lua recorded, leaving the queue empty so the same
+    /// work is never applied twice.
+    TakePackOps {
+        reply: flume::Sender<Vec<crate::api::pack::PackOp>>,
     },
     Shutdown,
     RestoreToolAsync {
@@ -1503,12 +1509,12 @@ impl LuaRuntime {
         })?;
 
         lua.set_app_data(CommandHandlerMap::new());
-        lua.set_app_data(crate::api::pack::PackStore::default());
         lua.set_app_data(JobStore::new());
         lua.set_app_data(SpawnQueue::new());
         lua.set_app_data(command_writer);
         lua.set_app_data(PromptHintCallbacks::default());
         lua.set_app_data(PluginOptionSpecs::default());
+        lua.set_app_data(crate::api::pack::PackStore::default());
         lua.set_app_data(AutocmdStore::default());
         lua.set_app_data(SlotStore::default());
         lua.set_app_data(KeymapStore::new());
@@ -1871,7 +1877,28 @@ impl LuaRuntime {
             let setup_fn = crate::api::util::setup::create_setup_fn(&self.lua, Arc::clone(cs))
                 .map_err(&map_err)?;
             maki.set("setup", setup_fn).map_err(&map_err)?;
+
+            // Attached under the same condition as `setup`, so declaring a
+            // package is available to `init.lua` and to nothing else. `add`
+            // fetches code and rewrites the lockfile, which is a configuration
+            // decision; a downloaded package must not be able to make it for
+            // itself, whatever permissions it holds.
+            maki.set(
+                "pack",
+                crate::api::pack::create_pack_table(&self.lua).map_err(&map_err)?,
+            )
+            .map_err(&map_err)?;
+            maki.set(
+                "version",
+                crate::api::version::create_version_table(&self.lua).map_err(&map_err)?,
+            )
+            .map_err(&map_err)?;
         }
+        crate::api::pack::add_packadd(&self.lua, &maki).map_err(&map_err)?;
+
+        // Available to every plugin, not only `init.lua`: activating a package
+        // that is already installed and already approved is far weaker than
+        // fetching new code, which is what the `maki.pack` table gates.
         crate::api::pack::add_packadd(&self.lua, &maki).map_err(&map_err)?;
 
         let env = self.build_env(maki, require_root).map_err(&map_err)?;
@@ -2807,18 +2834,6 @@ pub fn spawn(
                             })
                             .detach();
                         }
-                        Request::TakePackOps { reply } => {
-                            let ops = rt
-                                .lua
-                                .app_data_ref::<crate::api::pack::PackStore>()
-                                .map(|store| {
-                                    std::mem::take(
-                                        &mut store.lock().expect("pack declarations").pending,
-                                    )
-                                })
-                                .unwrap_or_default();
-                            let _ = reply.send(ops);
-                        }
                         Request::ClearPlugin { plugin, reply } => {
                             drain_barrier(&rt.lua, &ex, &gate, &spawn_rx).await;
                             rt.clear_plugin(&plugin);
@@ -2890,6 +2905,26 @@ pub fn spawn(
                         }
                         Request::CollectPluginOptions { reply } => {
                             let _ = reply.send(collect_plugin_options(&rt.lua));
+                        }
+                        Request::TakePackOps { reply } => {
+                            let ops = rt
+                                .lua
+                                .app_data_ref::<crate::api::pack::PackStore>()
+                                .map(|store| {
+                                    std::mem::take(
+                                        &mut store.lock().expect("pack declarations").pending,
+                                    )
+                                })
+                                .unwrap_or_default();
+                            let _ = reply.send(ops);
+                        }
+                        Request::CollectPackages { reply } => {
+                            let declared = rt
+                                .lua
+                                .app_data_ref::<crate::api::pack::PackStore>()
+                                .map(|store| store.lock().expect("pack declarations").specs.clone())
+                                .unwrap_or_default();
+                            let _ = reply.send(declared);
                         }
                         Request::RestoreToolAsync { item, event_tx } => {
                             spawn_restore(&ex, &gate, &restores, &rt, item, event_tx);

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -97,6 +97,32 @@ static NEXT_TASK_ID: AtomicU64 = AtomicU64::new(1);
 /// seconds on a loaded debug build, and a wrongly killed restore loses the
 /// tool's rendered output.
 const RESTORE_ITEM_TIMEOUT: Duration = Duration::from_secs(60);
+/// Wall clock one plugin or package gets to finish loading.
+///
+/// A load registers commands, tools, and handlers; it is not where work
+/// belongs, so this is far past any legitimate one. It exists because the
+/// load runs on the request loop, and since a lazy trigger can start one,
+/// that loop is also what serves the keypress that woke the package. Without
+/// a bound, a runaway top level freezes a live session rather than just
+/// failing to start.
+///
+/// Generous on purpose, for the same reason `RESTORE_ITEM_TIMEOUT` is: a
+/// wrongly killed load costs the user a working plugin.
+const LOAD_TIMEOUT: Duration = Duration::from_secs(30);
+#[cfg(test)]
+struct LoadTimeout(Duration);
+
+#[cfg(not(test))]
+fn load_timeout(_lua: &Lua) -> Duration {
+    LOAD_TIMEOUT
+}
+
+#[cfg(test)]
+fn load_timeout(lua: &Lua) -> Duration {
+    lua.app_data_ref::<LoadTimeout>()
+        .map(|timeout| timeout.0)
+        .unwrap_or(LOAD_TIMEOUT)
+}
 const TURN_END_EVENT: &str = "TurnEnd";
 /// Without a cap, a runaway plugin OOM-kills the whole process.
 /// With one, it hits a catchable Lua error instead.
@@ -129,6 +155,11 @@ pub struct LoadChunk {
     pub source: String,
 }
 
+enum PluginLoad<'a> {
+    Chunks(&'a [LoadChunk]),
+    Function { function: Function, argument: Table },
+}
+
 impl LoadChunk {
     pub fn new(name: impl Into<String>, source: impl Into<String>) -> Self {
         Self {
@@ -144,6 +175,11 @@ pub enum Request {
     /// Plugins are loaded, so native codegen may start using idle time. Sent
     /// last so it never interleaves with the loads themselves.
     WarmJit,
+    #[cfg(test)]
+    SetLoadTimeout {
+        timeout: Duration,
+        reply: flume::Sender<()>,
+    },
     LoadSource {
         name: Arc<str>,
         chunks: Vec<LoadChunk>,
@@ -203,13 +239,41 @@ pub enum Request {
     CollectPackages {
         reply: flume::Sender<Vec<crate::api::pack::Declared>>,
     },
+    CollectPackConfirm {
+        reply: flume::Sender<Option<bool>>,
+    },
     CollectActivePackages {
         reply: flume::Sender<std::collections::BTreeSet<String>>,
+    },
+    RunPackLoader {
+        declared: crate::api::pack::Declared,
+        path: PathBuf,
+        permissions: PluginPermissions,
+        opts: PluginOpts,
+        reply: flume::Sender<LoadResult>,
+    },
+    FirePackChanged {
+        event: &'static str,
+        change: crate::api::pack::PackChange,
+        reply: flume::Sender<()>,
     },
     /// Takes the operations Lua recorded, leaving the queue empty so the same
     /// work is never applied twice.
     TakePackOps {
         reply: flume::Sender<Vec<crate::api::pack::PackOp>>,
+    },
+    /// Hands the runtime the packages that are installed but not loaded, so it
+    /// can activate one when a trigger fires. Sent by the host after the
+    /// packages are on disk, because only the host knows where they landed and
+    /// what the approval narrowed their permissions to.
+    SetDormantPackages {
+        packages: Vec<crate::api::pack::Dormant>,
+        reply: flume::Sender<()>,
+    },
+    /// Activates one package after the Lua callback that called `packadd`
+    /// returns to the request loop.
+    ActivatePackage {
+        name: String,
     },
     Shutdown,
     RestoreToolAsync {
@@ -235,6 +299,11 @@ pub enum Request {
     },
     RunKeybindCallback {
         id: u64,
+        /// Carried alongside the id so activation can re-resolve after a load.
+        /// The binding a package registers gets a new id, so the id the UI
+        /// sent is meaningless once the package has loaded; the key is not.
+        key: crossterm::event::KeyCode,
+        modifiers: crossterm::event::KeyModifiers,
     },
     Describe {
         plugin: Arc<str>,
@@ -1108,12 +1177,17 @@ pub(crate) fn with_live_ctx<R>(lua: &Lua, f: impl FnOnce(&LiveCtx) -> R) -> Opti
 
 pub(crate) fn enqueue_async_task(lua: &Lua, work_fn: RegistryKey) -> Result<(), mlua::Error> {
     let handle = lua.app_data_ref::<TaskHandle>();
-    let (cancel, live_ctx, command_depth) = match &handle {
+    let (cancel, live_ctx, command_depth, parent_task_id) = match &handle {
         Some(h) => {
             let cell = lock_cell(h);
-            (cell.cancel.clone(), cell.live.clone(), cell.command_depth)
+            (
+                cell.cancel.clone(),
+                cell.live.clone(),
+                cell.command_depth,
+                Some(cell.id),
+            )
         }
-        None => (CancelToken::none(), None, 0),
+        None => (CancelToken::none(), None, 0, None),
     };
 
     let mut task = PendingAsyncTask {
@@ -1123,6 +1197,7 @@ pub(crate) fn enqueue_async_task(lua: &Lua, work_fn: RegistryKey) -> Result<(), 
         live_ctx,
         owner: None,
         command_depth,
+        parent_task_id,
     };
 
     if let Some(h) = &handle {
@@ -1278,6 +1353,7 @@ pub(crate) struct PendingAsyncTask {
     pub live_ctx: Option<LiveCtx>,
     pub owner: Option<Arc<BufsClaim>>,
     pub command_depth: u8,
+    pub parent_task_id: Option<u64>,
 }
 
 /// Shared ownership of a task's `bufs`: the scope holds one clone, each
@@ -1519,6 +1595,8 @@ impl LuaRuntime {
         lua.set_app_data(PromptHintCallbacks::default());
         lua.set_app_data(PluginOptionSpecs::default());
         lua.set_app_data(crate::api::pack::PackStore::default());
+        #[cfg(test)]
+        lua.set_app_data(LoadTimeout(LOAD_TIMEOUT));
         lua.set_app_data(AutocmdStore::default());
         lua.set_app_data(SlotStore::default());
         lua.set_app_data(KeymapStore::new());
@@ -1637,13 +1715,6 @@ impl LuaRuntime {
                     tracing::warn!(plugin = name, error = %e, "failed to drop command handler key");
                 }
             }
-            drop(cmd_map);
-            if let (Some(map), Some(writer)) = (
-                self.lua.app_data_ref::<CommandHandlerMap>(),
-                self.lua.app_data_ref::<LuaCommandWriter>(),
-            ) {
-                publish_command_snapshot(&map, &writer);
-            }
         }
         if let Some(mut hints) = self.lua.app_data_mut::<PromptHintCallbacks>()
             && let Some(regs) = hints.remove(name)
@@ -1656,6 +1727,7 @@ impl LuaRuntime {
                 }
             }
         }
+        self.publish_commands();
     }
 
     async fn run_hint_callback(&self, plugin: &str, func: Function) -> Option<String> {
@@ -1849,6 +1921,96 @@ impl LuaRuntime {
         opts: PluginOpts,
         config_store: Option<&ConfigStore>,
     ) -> LoadResult {
+        self.load_bounded(
+            name,
+            PluginLoad::Chunks(chunks),
+            plugin_dir,
+            permissions,
+            opts,
+            config_store,
+        )
+        .await
+    }
+
+    /// Bounds both CPU-bound and parked plugin top levels.
+    ///
+    /// The task deadline lets the watchdog interrupt Lua that never yields.
+    /// The timer ends a load parked in an await that never wakes.
+    async fn load_bounded(
+        &mut self,
+        name: Arc<str>,
+        load: PluginLoad<'_>,
+        plugin_dir: Option<PathBuf>,
+        permissions: &PluginPermissions,
+        opts: PluginOpts,
+        config_store: Option<&ConfigStore>,
+    ) -> LoadResult {
+        let timeout = load_timeout(&self.lua);
+        let deadline = Instant::now() + timeout;
+        let lua = self.lua.clone();
+        let scope = TaskScope::new(
+            &lua,
+            TaskCell::new(CancelToken::none(), Some(deadline), None),
+        );
+        let load_task_id = lock_cell(scope.handle()).id;
+        let inner = self.load_source_inner(
+            Arc::clone(&name),
+            load,
+            plugin_dir,
+            permissions,
+            opts,
+            config_store,
+        );
+        let timeout_error = {
+            let plugin = name.to_string();
+            async move {
+                smol::Timer::after(timeout).await;
+                Err(PluginError::LoadTimeout {
+                    plugin,
+                    milliseconds: timeout.as_millis(),
+                })
+            }
+        };
+        let mut result = futures_lite::future::or(scope.scope_future(inner), timeout_error).await;
+        if result.is_err() && Instant::now() >= deadline {
+            result = Err(PluginError::LoadTimeout {
+                plugin: name.to_string(),
+                milliseconds: timeout.as_millis(),
+            });
+        }
+        if result.is_err() {
+            self.discard_spawned_by(load_task_id);
+            self.rollback_load(&name);
+        }
+        result
+    }
+
+    fn discard_spawned_by(&self, parent_task_id: u64) {
+        let Some(queue) = self.lua.app_data_ref::<SpawnQueue>() else {
+            return;
+        };
+        let mut keep = Vec::new();
+        while let Ok(task) = queue.rx.try_recv() {
+            if task.parent_task_id == Some(parent_task_id) {
+                self.lua.remove_registry_value(task.work_fn).ok();
+            } else {
+                keep.push(task);
+            }
+        }
+        for task in keep {
+            queue.tx.send(task).ok();
+        }
+    }
+
+    async fn load_source_inner(
+        &mut self,
+        name: Arc<str>,
+        load: PluginLoad<'_>,
+        plugin_dir: Option<PathBuf>,
+        permissions: &PluginPermissions,
+        opts: PluginOpts,
+        config_store: Option<&ConfigStore>,
+    ) -> LoadResult {
         let map_err = |e: mlua::Error| PluginError::Lua {
             plugin: name.to_string(),
             source: e,
@@ -1898,46 +2060,49 @@ impl LuaRuntime {
             )
             .map_err(&map_err)?;
         }
-        crate::api::pack::add_packadd(&self.lua, &maki).map_err(&map_err)?;
-
         // Available to every plugin, not only `init.lua`: activating a package
         // that is already installed and already approved is far weaker than
         // fetching new code, which is what the `maki.pack` table gates.
-        crate::api::pack::add_packadd(&self.lua, &maki).map_err(&map_err)?;
+        crate::api::pack::add_packadd(&self.lua, &maki, Some(self.tx.clone())).map_err(&map_err)?;
 
         let env = self.build_env(maki, require_root).map_err(&map_err)?;
 
         self.drop_plugin_keys(&name);
 
-        // Chunks run in order against one environment, so a later file sees
-        // what an earlier one registered. The first failure stops the rest.
-        let mut exec_result = Ok(());
-        for chunk in chunks {
-            let main_fn = self
-                .lua
-                .load(chunk.source.as_str())
-                .set_name(chunk.name.as_str())
-                .set_environment(env.clone())
-                .into_function();
-            exec_result = match main_fn {
-                Ok(func) => {
-                    queue_codegen(&self.codegen_queue, &func);
-                    func.call_async::<()>(()).await
+        let exec_result = match load {
+            PluginLoad::Chunks(chunks) => {
+                let mut result = Ok(());
+                for chunk in chunks {
+                    let main_fn = self
+                        .lua
+                        .load(chunk.source.as_str())
+                        .set_name(chunk.name.as_str())
+                        .set_environment(env.clone())
+                        .into_function();
+                    result = match main_fn {
+                        Ok(function) => {
+                            queue_codegen(&self.codegen_queue, &function);
+                            function.call_async::<()>(()).await
+                        }
+                        Err(error) => Err(error),
+                    };
+                    if result.is_err() {
+                        break;
+                    }
                 }
-                Err(e) => Err(e),
-            };
-            if exec_result.is_err() {
-                break;
+                result
             }
-        }
+            PluginLoad::Function { function, argument } => {
+                function.set_environment(env).map_err(&map_err)?;
+                queue_codegen(&self.codegen_queue, &function);
+                function.call_async::<()>(argument).await
+            }
+        };
 
         // Checked once, after the last chunk: an option that a later chunk
         // reads must not be reported as unused by an earlier one.
         let exec_result = exec_result.and_then(|()| self.check_opts_consumed(&name, &opts));
         if let Err(e) = exec_result {
-            let stale = self.drain_pending();
-            self.discard_pending(stale);
-            self.clear_plugin(&name);
             return Err(map_err(e));
         }
 
@@ -1975,12 +2140,19 @@ impl LuaRuntime {
             })
             .collect();
 
+        // A lazy load can be parked in an async top level when `/reload`
+        // starts. The watchdog interrupt only fires at a Lua safepoint, so a
+        // future suspended in Rust is not woken by it and can finish here long
+        // after the new stack cleared the registry and filled it again.
+        // Committing then would replace the new generation's tools with this
+        // dead one's.
+        if self.shutdown.load(Ordering::Acquire) {
+            self.discard_pending(pending);
+            return Err(PluginError::HostDead);
+        }
+
         if let Err(e) = self.registry.replace_plugin(&name, registry_entries) {
             self.discard_pending(pending);
-            // The chunks already published commands, keymaps, hints, and slots
-            // before we got here, so a conflict at the commit point has to
-            // unwind them too, not just drop the pending tools.
-            self.clear_plugin(&name);
             return Err(match e {
                 RegistryError::NameConflict { name: n, .. } => PluginError::NameConflict {
                     plugin: name.to_string(),
@@ -2015,31 +2187,296 @@ impl LuaRuntime {
         Ok(())
     }
 
+    fn rollback_load(&mut self, name: &str) {
+        let pending = self.drain_pending();
+        self.discard_pending(pending);
+        self.clear_plugin(name);
+    }
+
+    async fn load_pack_function(
+        &mut self,
+        name: Arc<str>,
+        function: Function,
+        argument: Table,
+        path: PathBuf,
+        permissions: &PluginPermissions,
+        opts: PluginOpts,
+    ) -> LoadResult {
+        self.load_bounded(
+            name,
+            PluginLoad::Function { function, argument },
+            Some(path),
+            permissions,
+            opts,
+            None,
+        )
+        .await
+    }
+
+    /// The registered handler for a command, if one is registered.
+    fn command_handler(&self, plugin: &str, command: &str) -> Option<Function> {
+        self.lua.app_data_ref::<CommandHandlerMap>().and_then(|m| {
+            let entry = m.get(plugin)?.get(command)?;
+            self.lua.registry_value::<Function>(&entry.handler).ok()
+        })
+    }
+
+    /// Loads the dormant package that declared this command, if there is one.
+    ///
+    /// Returns whether a package was loaded, after the load, so the caller can
+    /// look the handler up again and dispatch once against what the package
+    /// just registered. Nothing is delivered twice: the command has not been
+    /// dispatched yet at this point.
+    async fn activate_for_command(&mut self, plugin: &str, command: &str) -> bool {
+        self.activate_matching(|d| d.name == plugin && d.handles_command(command))
+            .await
+    }
+
+    /// Loads the installed package named by `maki.packadd`.
+    async fn activate_package(&mut self, name: &str) {
+        let Some(store) = self
+            .lua
+            .app_data_ref::<crate::api::pack::PackStore>()
+            .map(|store| store.clone())
+        else {
+            return;
+        };
+        let state = {
+            let declarations = store.lock().expect("pack declarations");
+            if declarations.active.contains(name) {
+                return;
+            }
+            declarations
+                .dormant
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .find(|package| package.name == name)
+                .map(|package| package.state.clone())
+        };
+        match state {
+            Some(crate::api::pack::PackState::Inactive) => {
+                self.activate_matching(|package| package.name == name).await;
+            }
+            Some(crate::api::pack::PackState::Failed(error)) => tracing::warn!(
+                package = name,
+                %error,
+                "package activation already failed"
+            ),
+            None => tracing::warn!(
+                package = name,
+                "package is not installed or is not available for activation"
+            ),
+        }
+    }
+
+    /// Resolves a keybind callback, by id first and then by key.
+    ///
+    /// The id is the fast path for an ordinary binding. The key is what
+    /// survives an activation, because the binding a package registers when it
+    /// loads has an id the UI never sent.
+    fn keybind_callback(
+        &self,
+        id: u64,
+        key: crossterm::event::KeyCode,
+        modifiers: crossterm::event::KeyModifiers,
+    ) -> Option<Function> {
+        let store = self.lua.app_data_ref::<KeymapStore>()?;
+        let registry = match store.callback_for_id(id) {
+            Some(registry) => registry,
+            // Only a pending press falls back to the key. A real id that no
+            // longer resolves means the binding was replaced between the
+            // snapshot and this request, and running whatever holds the key
+            // now would deliver the press to a plugin the user never saw.
+            None if id == crate::api::keymap::PENDING_KEYMAP_ID => {
+                store.callback_for_key(key, modifiers)?
+            }
+            None => return None,
+        };
+        self.lua.registry_value::<Function>(registry).ok()
+    }
+
+    /// Loads the dormant package bound to this key, if there is one.
+    async fn activate_for_key(
+        &mut self,
+        key: crossterm::event::KeyCode,
+        modifiers: crossterm::event::KeyModifiers,
+    ) -> bool {
+        self.activate_matching(|d| {
+            d.triggers.keys.iter().any(|k| {
+                crate::api::keymap::parse_key_notation(k)
+                    .is_ok_and(|(c, m)| c == key && m == modifiers)
+            })
+        })
+        .await
+    }
+
+    /// Loads every dormant package listening for this event.
+    ///
+    /// Unlike a command, one event can wake several packages, so this loads
+    /// all of them before the caller dispatches. Each listener therefore sees
+    /// the event that woke it rather than the next one.
+    async fn activate_for_event(&mut self, event: &str) -> bool {
+        self.activate_matching(|d| d.triggers.event.iter().any(|e| e == event))
+            .await
+    }
+
+    /// Loads every dormant package a trigger selects.
+    ///
+    /// The runtime handles requests in sequence, so no other trigger can start
+    /// while a selected package is loading.
+    async fn activate_matching(
+        &mut self,
+        pick: impl Fn(&crate::api::pack::Dormant) -> bool,
+    ) -> bool {
+        let Some(store) = self
+            .lua
+            .app_data_ref::<crate::api::pack::PackStore>()
+            .map(|s| s.clone())
+        else {
+            return false;
+        };
+
+        let mut loaded = false;
+        let mut changed = false;
+        loop {
+            let target = {
+                let decls = store.lock().expect("pack declarations");
+                let Some(pkg) = decls
+                    .dormant
+                    .as_deref()
+                    .unwrap_or_default()
+                    .iter()
+                    .find(|d| d.is_startable() && pick(d))
+                else {
+                    break;
+                };
+                pkg.clone()
+            };
+
+            let outcome = match crate::loader::read_package(&target.name, &target.dir) {
+                Ok((root, chunks)) => {
+                    self.load_source(
+                        Arc::from(target.name.as_str()),
+                        &chunks,
+                        Some(root),
+                        &target.permissions,
+                        target.opts.clone(),
+                        None,
+                    )
+                    .await
+                }
+                Err(e) => Err(e),
+            };
+
+            loaded |= outcome.is_ok();
+            changed = true;
+            match outcome {
+                Ok(()) => {
+                    self.mark_package_active(&target.name);
+                }
+                // Recorded rather than reset to `Inactive`. A package whose
+                // top level fails would otherwise be re-run by every later
+                // trigger that would have woken it.
+                Err(e) => {
+                    let message = crate::pack::redact_error(&e);
+                    tracing::error!(package = %target.name, error = %message, "failed to activate package");
+                    let failure = crate::api::pack::PackState::Failed(message);
+                    let mut decls = store.lock().expect("pack declarations");
+                    let Some(dormant) = decls.dormant.as_mut() else {
+                        tracing::error!(
+                            package = %target.name,
+                            "package activation catalog disappeared during load"
+                        );
+                        break;
+                    };
+                    if let Some(package) = dormant
+                        .iter_mut()
+                        .find(|package| package.name == target.name)
+                    {
+                        package.state = failure;
+                    } else {
+                        let mut failed = target;
+                        failed.state = failure;
+                        dormant.push(failed);
+                    }
+                }
+            }
+        }
+        if !changed {
+            return false;
+        }
+        // The pending entries are gone either way, and a successful load has
+        // put the real registrations there instead.
+        self.publish_snapshots();
+        loaded
+    }
+
+    /// Republishes both snapshots the UI reads.
+    ///
+    /// Both, because a dormant package can contribute a command and a key, and
+    /// activating it has to take each pending entry away at the same moment
+    /// the real registrations appear.
+    fn publish_snapshots(&self) {
+        self.publish_commands();
+        crate::api::keymap::publish_keymap_snapshot(&self.lua);
+    }
+
+    /// Republishes the command snapshot the UI reads.
+    fn publish_commands(&self) {
+        publish_command_snapshot(&self.lua).ok();
+    }
+
+    fn mark_package_active(&self, name: &str) {
+        if let Some(store) = self.lua.app_data_ref::<crate::api::pack::PackStore>() {
+            let mut declarations = store.lock().expect("pack declarations");
+            declarations.active.insert(name.to_owned());
+            if let Some(dormant) = declarations.dormant.as_mut() {
+                dormant.retain(|package| package.name != name);
+            }
+        }
+    }
+
+    fn package_is_active(&self, name: &str) -> bool {
+        self.lua
+            .app_data_ref::<crate::api::pack::PackStore>()
+            .is_some_and(|store| {
+                store
+                    .lock()
+                    .expect("pack declarations")
+                    .active
+                    .contains(name)
+            })
+    }
+
     fn clear_plugin(&mut self, plugin: &str) {
+        // Same reason as the commit guard in `load_source`: after shutdown the
+        // registry belongs to the next generation, and a rollback from this
+        // one would delete tools it never registered.
+        if self.shutdown.load(Ordering::Acquire) {
+            return;
+        }
         if let Some(store) = self
             .lua
             .app_data_ref::<crate::api::pack::PackStore>()
             .map(|store| store.clone())
         {
-            store
-                .lock()
-                .expect("pack declarations")
-                .active
-                .remove(plugin);
+            let mut declarations = store.lock().expect("pack declarations");
+            declarations.active.remove(plugin);
+            if let Some(dormant) = declarations.dormant.as_mut() {
+                dormant.retain(|package| package.name != plugin);
+            }
         }
         self.registry.clear_plugin(plugin);
         self.plugin_rules.remove(plugin);
         self.drop_plugin_keys(plugin);
         if let Some(mut store) = self.lua.app_data_mut::<KeymapStore>() {
             let keys = store.clear_plugin(plugin);
-            let entries = store.snapshot_entries();
             drop(store);
             for key in keys {
                 let _ = self.lua.remove_registry_value(key);
             }
-            if let Some(writer) = self.lua.app_data_ref::<KeymapWriter>() {
-                writer.publish(entries);
-            }
+            crate::api::keymap::publish_keymap_snapshot(&self.lua);
         }
         if let Some(mut store) = self.lua.app_data_mut::<HintStore>() {
             store.clear_plugin(plugin);
@@ -2802,6 +3239,11 @@ pub fn spawn(
                     match msg {
                         Request::Shutdown => break,
                         Request::WarmJit => codegen_armed = true,
+                        #[cfg(test)]
+                        Request::SetLoadTimeout { timeout, reply } => {
+                            rt.lua.set_app_data(LoadTimeout(timeout));
+                            let _ = reply.send(());
+                        }
                         Request::LoadSource {
                             name,
                             chunks,
@@ -2811,33 +3253,15 @@ pub fn spawn(
                             mark_package_active,
                             reply,
                         } => {
-                            if mark_package_active
-                                && rt
-                                    .lua
-                                    .app_data_ref::<crate::api::pack::PackStore>()
-                                    .is_some_and(|store| {
-                                        store
-                                            .lock()
-                                            .expect("pack declarations")
-                                            .active
-                                            .contains(name.as_ref())
-                                    })
-                            {
+                            if mark_package_active && rt.package_is_active(&name) {
                                 let _ = reply.send(Ok(()));
                                 continue;
                             }
                             drain_barrier(&rt.lua, &ex, &gate, &spawn_rx).await;
                             let res = rt.load_source(Arc::clone(&name), &chunks, plugin_dir, &permissions, opts, None).await;
-                            if mark_package_active
-                                && res.is_ok()
-                                && let Some(store) =
-                                    rt.lua.app_data_ref::<crate::api::pack::PackStore>()
-                            {
-                                store
-                                    .lock()
-                                    .expect("pack declarations")
-                                    .active
-                                    .insert(name.to_string());
+                            if mark_package_active && res.is_ok() {
+                                rt.mark_package_active(&name);
+                                rt.publish_snapshots();
                             }
                             let _ = reply.send(res);
                         }
@@ -2881,17 +3305,88 @@ pub fn spawn(
                             rt.clear_plugin(&plugin);
                             let _ = reply.send(());
                         }
+                        Request::SetDormantPackages { packages, reply } => {
+                            if let Some(store) =
+                                rt.lua.app_data_ref::<crate::api::pack::PackStore>()
+                            {
+                                let mut declarations = store.lock().expect("pack declarations");
+                                let failed: HashMap<
+                                    String,
+                                    (PathBuf, crate::api::pack::PackState),
+                                > = declarations
+                                    .dormant
+                                    .as_deref()
+                                    .unwrap_or_default()
+                                    .iter()
+                                    .filter(|package| {
+                                        matches!(package.state, crate::api::pack::PackState::Failed(_))
+                                    })
+                                    .map(|package| {
+                                        (
+                                            package.name.clone(),
+                                            (package.dir.clone(), package.state.clone()),
+                                        )
+                                    })
+                                    .collect();
+                                declarations.dormant = Some(
+                                    packages
+                                        .into_iter()
+                                        .map(|mut package| {
+                                            if let Some((_, state)) = failed
+                                                .get(&package.name)
+                                                .filter(|(path, _)| path == &package.dir)
+                                            {
+                                                package.state = state.clone();
+                                            }
+                                            package
+                                        })
+                                        .collect(),
+                                );
+                            }
+                            rt.publish_snapshots();
+                            let _ = reply.send(());
+                        }
+                        Request::ActivatePackage { name } => {
+                            rt.activate_package(&name).await;
+                        }
                         Request::RunCommand {
                             plugin,
                             command,
                             args,
                             depth,
                         } => {
-                            let handler_fn =
-                                rt.lua.app_data_ref::<CommandHandlerMap>().and_then(|m| {
-                                    let entry = m.get(&plugin)?.get(&command)?;
-                                    rt.lua.registry_value::<Function>(&entry.handler).ok()
-                                });
+                            // A command that resolves to nothing may belong to
+                            // a package that has not loaded yet. This is the
+                            // first point on this thread that can do anything
+                            // about it: `PluginHost::load_package` waits for a
+                            // reply from this very loop, but `load_source` is
+                            // ours to call directly.
+                            let mut woke = false;
+                            // Deliberately no `drain_barrier` here, unlike a
+                            // load or a plugin clear. The barrier waits for
+                            // every gated task, and a running tool may be
+                            // waiting on a command or keybind that only this
+                            // loop can deliver, so waiting for it first would
+                            // deadlock the runtime. Activation does not need
+                            // the barrier anyway: it registers a brand new
+                            // owner, so no in-flight task can be holding the
+                            // state it replaces.
+                            if rt.command_handler(&plugin, &command).is_none() {
+                                woke = rt.activate_for_command(&plugin, &command).await;
+                            }
+                            let handler_fn = rt.command_handler(&plugin, &command);
+                            // A package that woke and still does not answer to
+                            // the command it declared is a broken package, not
+                            // a mistyped command. Said clearly, because the
+                            // dispatch below simply does nothing otherwise and
+                            // the user is left with a command that vanished.
+                            if woke && handler_fn.is_none() {
+                                tracing::warn!(
+                                    package = %plugin,
+                                    command = %command,
+                                    "package loaded but never registered the command that woke it"
+                                );
+                            }
                             if let Some(func) = handler_fn {
                                 let lua = rt.lua.clone();
                                 ex.spawn(async move {
@@ -2968,15 +3463,111 @@ pub fn spawn(
                                 .unwrap_or_default();
                             let _ = reply.send(declared);
                         }
+                        Request::CollectPackConfirm { reply } => {
+                            let confirm = rt
+                                .lua
+                                .app_data_ref::<crate::api::pack::PackStore>()
+                                .and_then(|store| {
+                                    store.lock().expect("pack declarations").lock_confirm
+                                });
+                            let _ = reply.send(confirm);
+                        }
                         Request::CollectActivePackages { reply } => {
                             let active = rt
                                 .lua
                                 .app_data_ref::<crate::api::pack::PackStore>()
-                                .map(|store| {
-                                    store.lock().expect("pack declarations").active.clone()
-                                })
+                                .map(|store| store.lock().expect("pack declarations").active.clone())
                                 .unwrap_or_default();
                             let _ = reply.send(active);
+                        }
+                        Request::RunPackLoader {
+                            declared,
+                            path,
+                            permissions,
+                            opts,
+                            reply,
+                        } => {
+                            let name = declared.spec.name.clone();
+                            if rt.package_is_active(&name) {
+                                let _ = reply.send(Ok(()));
+                                continue;
+                            }
+                            let input = (|| {
+                                let crate::api::pack::LoadMode::Custom(loader) = &declared.load
+                                else {
+                                    unreachable!("only a custom load reaches this request")
+                                };
+                                let function = rt.lua.registry_value::<Function>(loader.as_ref())?;
+                                let data = rt.lua.create_table()?;
+                                data.set(
+                                    "spec",
+                                    crate::api::pack::spec_to_lua(
+                                        &rt.lua,
+                                        &declared.spec,
+                                        declared.data.as_ref(),
+                                    )?,
+                                )?;
+                                data.set("path", path.display().to_string())?;
+                                Ok::<_, mlua::Error>((function, data))
+                            })()
+                            .map_err(|source| PluginError::Lua {
+                                plugin: name.clone(),
+                                source,
+                            });
+                            let result = match input {
+                                Ok((function, data)) => {
+                                    rt.load_pack_function(
+                                        Arc::from(name.as_str()),
+                                        function,
+                                        data,
+                                        path,
+                                        &permissions,
+                                        opts,
+                                    )
+                                    .await
+                                }
+                                Err(error) => Err(error),
+                            };
+                            if result.is_ok() {
+                                rt.mark_package_active(&name);
+                                rt.publish_snapshots();
+                            }
+                            let _ = reply.send(result);
+                        }
+                        Request::FirePackChanged {
+                            event,
+                            change,
+                            reply,
+                        } => {
+                            let path = change.path.display().to_string();
+                            let data = rt.lua.create_table().and_then(|data| {
+                                data.set("active", change.active)?;
+                                data.set("kind", change.kind.as_str())?;
+                                data.set(
+                                    "spec",
+                                    crate::api::pack::spec_to_lua(
+                                        &rt.lua,
+                                        &change.declared.spec,
+                                        change.declared.data.as_ref(),
+                                    )?,
+                                )?;
+                                data.set("path", path.as_str())?;
+                                Ok(data)
+                            });
+                            match data {
+                                Ok(data) => crate::api::autocmd::dispatch(
+                                    &rt.lua,
+                                    event,
+                                    Some(&path),
+                                    LuaValue::Table(data),
+                                ),
+                                Err(error) => tracing::warn!(
+                                    event,
+                                    error = %error,
+                                    "failed to build package change event"
+                                ),
+                            }
+                            let _ = reply.send(());
                         }
                         Request::RestoreToolAsync { item, event_tx } => {
                             spawn_restore(&ex, &gate, &restores, &rt, item, event_tx);
@@ -3038,6 +3629,15 @@ pub fn spawn(
                             .detach();
                         }
                         Request::FireAutocmd { event, data } => {
+                            // Only host-fired events wake a package, and this
+                            // is why: the request arrives here, where a load
+                            // can be awaited before the dispatch. A Lua
+                            // `exec_autocmds` dispatches synchronously and
+                            // has no such point, so it activates nothing.
+                            // Activation happens first, so the listener the
+                            // package registers receives this event, not the
+                            // next one, and receives it exactly once.
+                            rt.activate_for_event(&event).await;
                             let data = json_to_lua(&rt.lua, &data).unwrap_or(LuaValue::Nil);
                             crate::api::autocmd::dispatch(&rt.lua, &event, None, data);
                             if event == TURN_END_EVENT {
@@ -3082,11 +3682,21 @@ pub fn spawn(
                             })
                             .detach();
                         }
-                        Request::RunKeybindCallback { id } => {
-                            let func = rt.lua.app_data_ref::<KeymapStore>().and_then(|store| {
-                                let key = store.callback_for_id(id)?;
-                                rt.lua.registry_value::<Function>(key).ok()
-                            });
+                        Request::RunKeybindCallback {
+                            id,
+                            key,
+                            modifiers,
+                        } => {
+                            // A press that resolves to nothing may belong to a
+                            // package that has not loaded. After the load the
+                            // binding is looked up by key, never by id: the
+                            // real registration gets an id the UI never saw.
+                            if id == crate::api::keymap::PENDING_KEYMAP_ID
+                                && rt.keybind_callback(id, key, modifiers).is_none()
+                            {
+                                rt.activate_for_key(key, modifiers).await;
+                            }
+                            let func = rt.keybind_callback(id, key, modifiers);
                             if let Some(func) = func {
                                 let lua = rt.lua.clone();
                                 ex.spawn(async move {
@@ -3531,6 +4141,7 @@ mod tests {
             live_ctx: None,
             owner: None,
             command_depth: 0,
+            parent_task_id: None,
         }
     }
 
@@ -4062,6 +4673,7 @@ mod tests {
             live_ctx: None,
             owner: None,
             command_depth: 0,
+            parent_task_id: None,
         };
 
         let ex = Rc::new(smol::LocalExecutor::new());

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -2251,6 +2251,41 @@ fn project_init_cannot_change_global_packages(source: &str) {
 }
 
 #[test]
+fn a_named_config_cannot_change_global_packages() {
+    let host = PluginHost::new(fresh_registry()).unwrap();
+
+    let error = host
+        .send_run_init_lua(
+            r#"maki.pack.add({ "https://example.com/demo" })"#.to_owned(),
+            "test_init.lua".to_owned(),
+            None,
+        )
+        .expect_err("only the global config may change packages");
+
+    assert!(
+        error.to_string().contains(GLOBAL_PACK_ONLY_ERR),
+        "got: {error}"
+    );
+}
+
+#[test]
+fn global_init_can_declare_managed_packages() {
+    let host = PluginHost::new(fresh_registry()).unwrap();
+
+    let _ = host
+        .send_run_init_lua(
+            r#"maki.pack.add({ "https://example.com/demo" })"#.to_owned(),
+            "global/init.lua".to_owned(),
+            None,
+        )
+        .unwrap();
+
+    let declared = host.declared_packages().unwrap();
+    assert_eq!(declared.len(), 1);
+    assert_eq!(declared[0].spec.name, "demo");
+}
+
+#[test]
 fn project_init_can_activate_an_installed_global_package() {
     let host = PluginHost::new(fresh_registry()).unwrap();
 
@@ -2268,6 +2303,19 @@ fn project_init_can_activate_an_installed_global_package() {
             name: "demo".to_owned()
         }]
     );
+}
+
+#[test]
+fn project_init_can_inspect_global_packages() {
+    let host = PluginHost::new(fresh_registry()).unwrap();
+
+    let _ = host
+        .send_run_init_lua(
+            r#"assert(type(maki.pack.get) == "function")"#.to_owned(),
+            "project/init.lua".to_owned(),
+            None,
+        )
+        .unwrap();
 }
 
 #[test_case::test_case(
@@ -2397,7 +2445,7 @@ maki.pack.add({{
 })
 "#
         .to_owned(),
-        "test_init.lua".to_owned(),
+        "global/init.lua".to_owned(),
         None,
     )
     .unwrap();
@@ -2437,7 +2485,7 @@ maki.pack.add({ "https://example.com/broken" }, {
 })
 "#
         .to_owned(),
-        "test_init.lua".to_owned(),
+        "global/init.lua".to_owned(),
         None,
     )
     .unwrap();
@@ -2482,7 +2530,7 @@ maki.api.create_autocmd("PackChanged", {
 })
 "#
         .to_owned(),
-        "test_init.lua".to_owned(),
+        "global/init.lua".to_owned(),
         None,
     )
     .unwrap();

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -1097,6 +1097,88 @@ fn require_sandbox_escape_blocked() {
     );
 }
 
+/// Neovim resolves `lua/foo/init.lua` as well as `lua/foo.lua`, and an
+/// external package laid out the Neovim way relies on it.
+#[test]
+fn require_resolves_directory_init_form() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mod_dir = tmp.path().join("lua").join("pkg");
+    std::fs::create_dir_all(&mod_dir).unwrap();
+
+    std::fs::write(mod_dir.join("init.lua"), "return { value = 7 }\n").unwrap();
+
+    std::fs::write(
+        tmp.path().join("init.lua"),
+        r#"
+local pkg = require("pkg")
+assert(pkg.value == 7, "expected lua/pkg/init.lua to resolve")
+"#,
+    )
+    .unwrap();
+
+    let init_path = tmp.path().join("init.lua");
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_plugin_file(&init_path).unwrap();
+}
+
+/// `<mod>.lua` wins over `<mod>/init.lua`, matching Neovim's order.
+#[test]
+fn require_prefers_flat_module_over_directory_init() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let lua_dir = tmp.path().join("lua");
+    std::fs::create_dir_all(lua_dir.join("pkg")).unwrap();
+
+    std::fs::write(lua_dir.join("pkg.lua"), "return { which = \"flat\" }\n").unwrap();
+    std::fs::write(
+        lua_dir.join("pkg").join("init.lua"),
+        "return { which = \"dir\" }\n",
+    )
+    .unwrap();
+
+    std::fs::write(
+        tmp.path().join("init.lua"),
+        r#"
+local pkg = require("pkg")
+assert(pkg.which == "flat", "expected pkg.lua to win, got " .. tostring(pkg.which))
+"#,
+    )
+    .unwrap();
+
+    let init_path = tmp.path().join("init.lua");
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_plugin_file(&init_path).unwrap();
+}
+
+/// A git repository can commit a symlink, so the lexical `..` check is not
+/// enough on its own: the resolved path has to be re-checked.
+#[cfg(unix)]
+#[test]
+fn require_symlink_out_of_package_blocked() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let lua_dir = tmp.path().join("lua");
+    std::fs::create_dir_all(&lua_dir).unwrap();
+
+    let outside = tmp.path().join("outside.lua");
+    std::fs::write(&outside, "return { secret = true }\n").unwrap();
+    std::os::unix::fs::symlink(&outside, lua_dir.join("leak.lua")).unwrap();
+
+    std::fs::write(tmp.path().join("init.lua"), "require(\"leak\")\n").unwrap();
+
+    let init_path = tmp.path().join("init.lua");
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_plugin_file(&init_path)
+        .expect_err("symlink pointing out of the package must not load");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("sandbox") || msg.contains("outside"),
+        "got: {msg}"
+    );
+}
+
 #[test]
 fn require_circular_returns_sentinel_and_caches_real_value() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -2449,6 +2531,7 @@ fn edit_sub_tools_follow_edit_opts(opts: serde_json::Value, on: &[&str], off: &[
     let config = PluginsConfig {
         enabled: true,
         names: vec!["edit".to_owned()],
+        packages: Vec::new(),
         opts: HashMap::from([("edit".to_owned(), json_obj(opts))]),
     };
     host.load_builtins(&config).unwrap();
@@ -2515,6 +2598,7 @@ fn disabled_plugin_opts_are_ignored_not_rejected() {
     let config = PluginsConfig {
         enabled: true,
         names: vec!["grep".to_owned()],
+        packages: Vec::new(),
         opts: HashMap::from([(
             "bash".to_owned(),
             json_obj(serde_json::json!({ "timeout_secs": 180 })),
@@ -2729,6 +2813,532 @@ fn reload_replaces_commands() {
     let snap = host.command_reader().load();
     assert_eq!(snap.commands.len(), 1);
     assert_eq!(snap.commands[0].name.as_ref(), "/v2");
+}
+
+/// Builds a package directory with the given `plugin/*.lua` files.
+fn package_dir(files: &[(&str, &str)]) -> tempfile::TempDir {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let plugin_dir = tmp.path().join("plugin");
+    std::fs::create_dir_all(&plugin_dir).unwrap();
+    for (name, source) in files {
+        std::fs::write(plugin_dir.join(name), source).unwrap();
+    }
+    tmp
+}
+
+#[test]
+fn package_loads_every_entrypoint_under_one_owner() {
+    let pkg = package_dir(&[
+        (
+            "01_first.lua",
+            r#"maki.api.register_command({ name = "/one", handler = function() end })"#,
+        ),
+        (
+            "02_second.lua",
+            r#"maki.api.register_command({ name = "/two", handler = function() end })"#,
+        ),
+    ]);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_package(
+        "demo",
+        pkg.path(),
+        maki_lua::PluginPermissions::trusted(),
+        Default::default(),
+    )
+    .unwrap();
+
+    let snap = host.command_reader().load();
+    let mut names: Vec<&str> = snap.commands.iter().map(|c| c.name.as_ref()).collect();
+    names.sort();
+    assert_eq!(names, vec!["/one", "/two"]);
+    assert!(
+        snap.commands.iter().all(|c| c.plugin.as_ref() == "demo"),
+        "every entrypoint must register under the package owner"
+    );
+}
+
+/// One environment across the chunks, so an earlier file can set something up
+/// for a later one. This is why the chunks are not separate loads.
+#[test]
+fn package_entrypoints_share_one_environment() {
+    let pkg = package_dir(&[
+        ("01_first.lua", "shared_value = 11\n"),
+        (
+            "02_second.lua",
+            r#"
+assert(shared_value == 11, "second chunk should see the first chunk's global")
+maki.api.register_command({ name = "/ok", handler = function() end })
+"#,
+        ),
+    ]);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_package(
+        "shared",
+        pkg.path(),
+        maki_lua::PluginPermissions::trusted(),
+        Default::default(),
+    )
+    .unwrap();
+    assert_eq!(host.command_reader().load().commands.len(), 1);
+}
+
+/// A package commits or it does not. `drop_plugin_keys` alone would leave the
+/// keymap and the hint behind, so this is what proves the stronger unwind.
+#[test]
+fn package_failure_leaves_nothing_from_earlier_chunks() {
+    let pkg = package_dir(&[
+        (
+            "01_first.lua",
+            r#"
+maki.api.register_command({ name = "/ghost", handler = function() end })
+maki.keymap.set("n", "<C-g>", function() end, { desc = "ghost" })
+maki.api.register_tool({
+  name = "ghost_tool",
+  description = "should not survive",
+  schema = { type = "object", properties = {} },
+  handler = function() return "x" end,
+})
+"#,
+        ),
+        ("02_second.lua", r#"error("boom")"#),
+    ]);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_package(
+            "ghost",
+            pkg.path(),
+            maki_lua::PluginPermissions::trusted(),
+            Default::default(),
+        )
+        .expect_err("a failing chunk must fail the whole package");
+    assert!(err.to_string().contains("boom"), "got: {err}");
+
+    assert_eq!(
+        host.command_reader().load().commands.len(),
+        0,
+        "command from the first chunk survived a failed load"
+    );
+    assert_eq!(
+        host.keymap_reader().load().entries.len(),
+        0,
+        "keymap from the first chunk survived a failed load"
+    );
+    assert!(
+        !reg.has("ghost_tool"),
+        "tool from the first chunk survived a failed load"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn package_entrypoint_symlink_escape_blocked() {
+    let pkg = package_dir(&[]);
+    // Deliberately in a different directory tree, so the link really leaves
+    // the package rather than pointing at a sibling inside it.
+    let elsewhere = tempfile::TempDir::new().unwrap();
+    let outside = elsewhere.path().join("outside.lua");
+    std::fs::write(&outside, "return {}\n").unwrap();
+    std::os::unix::fs::symlink(&outside, pkg.path().join("plugin").join("leak.lua")).unwrap();
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_package(
+            "leaky",
+            pkg.path(),
+            maki_lua::PluginPermissions::trusted(),
+            Default::default(),
+        )
+        .expect_err("an entrypoint linking out of the package must not load");
+    assert!(
+        matches!(err, PluginError::PackageEscape { .. }),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn package_without_entrypoints_errors() {
+    let pkg = package_dir(&[]);
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_package(
+            "empty",
+            pkg.path(),
+            maki_lua::PluginPermissions::trusted(),
+            Default::default(),
+        )
+        .expect_err("a package with no entrypoint is a configuration error");
+    assert!(
+        matches!(err, PluginError::PackageEmpty { .. }),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn unreadable_entrypoint_directory_is_reported() {
+    let pkg = tempfile::TempDir::new().unwrap();
+    std::fs::write(pkg.path().join("plugin"), "not a directory").unwrap();
+    let host = PluginHost::new(fresh_registry()).unwrap();
+
+    let err = host
+        .load_package(
+            "unreadable",
+            pkg.path(),
+            maki_lua::PluginPermissions::trusted(),
+            Default::default(),
+        )
+        .expect_err("an unreadable entrypoint directory must not look empty");
+
+    assert!(matches!(err, PluginError::Io { .. }), "got: {err}");
+}
+
+/// Builds a site tree holding one package, the way a user cloning a repository
+/// into the package directory would.
+fn site_with_package(sub: &str, name: &str, files: &[(&str, &str)]) -> tempfile::TempDir {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let dir = tmp.path().join("pack").join("vendor").join(sub).join(name);
+    std::fs::create_dir_all(dir.join("plugin")).unwrap();
+    for (file, source) in files {
+        std::fs::write(dir.join("plugin").join(file), source).unwrap();
+    }
+    tmp
+}
+
+/// The whole layer-1 path: find a package on disk, then load it.
+#[test]
+fn discovered_start_package_is_found_and_loaded() {
+    let site = site_with_package(
+        "start",
+        "demo_pack",
+        &[(
+            "init.lua",
+            r#"maki.api.register_command({ name = "/demo", handler = function() end })"#,
+        )],
+    );
+
+    let found = maki_lua::discover(site.path());
+    assert!(found.problems.is_empty(), "{:?}", found.problems);
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    let snap = host.command_reader().load();
+    assert_eq!(snap.commands.len(), 1);
+    assert_eq!(snap.commands[0].name.as_ref(), "/demo");
+    assert_eq!(snap.commands[0].plugin.as_ref(), "demo_pack");
+}
+
+/// Builtins must still load when a package is installed. Packages once shared
+/// the builtin name list, which made `load_builtins` reject every one of them
+/// by name and fail startup outright.
+#[test]
+fn installed_package_does_not_break_builtin_loading() {
+    let site = site_with_package(
+        "start",
+        "demo_pack",
+        &[(
+            "init.lua",
+            r#"maki.api.register_command({ name = "/demo", handler = function() end })"#,
+        )],
+    );
+
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+
+    let reg = fresh_registry();
+    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_builtins(&config)
+        .expect("an installed package must not stop the builtins from loading");
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    assert!(reg.has("grep"), "builtin tools should still be registered");
+    let names: Vec<String> = host
+        .command_reader()
+        .load()
+        .commands
+        .iter()
+        .map(|c| c.name.to_string())
+        .collect();
+    assert!(names.iter().any(|n| n == "/demo"), "got: {names:?}");
+}
+
+/// Options for an installed package must reach the package, not be rejected as
+/// options for a plugin that does not exist.
+#[test]
+fn installed_package_may_take_options() {
+    let site = site_with_package(
+        "start",
+        "opt_pack",
+        &[(
+            "init.lua",
+            r#"
+local opts = maki.api.register_options({
+  depth = { type = "integer", desc = "Depth." },
+})
+if opts.depth == 3 then
+  maki.api.register_command({ name = "/depth", handler = function() end })
+end
+"#,
+        )],
+    );
+    let found = maki_lua::discover(site.path());
+
+    let mut plugins: HashMap<String, maki_config::PluginFileConfig> = HashMap::new();
+    let mut cfg = maki_config::PluginFileConfig::default();
+    cfg.opts.insert("depth".to_owned(), serde_json::json!(3));
+    plugins.insert("opt_pack".to_owned(), cfg);
+
+    let config = PluginsConfig::from_plugins_and_packages(plugins, &["opt_pack".to_owned()]);
+
+    let reg = fresh_registry();
+    let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_builtins(&config)
+        .expect("package options must not be rejected as unknown plugin options");
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    assert!(
+        host.command_reader()
+            .load()
+            .commands
+            .iter()
+            .any(|command| command.name.as_ref() == "/depth")
+    );
+}
+
+/// If `lua/` itself links out of the package, its target must not become the
+/// sandbox root; otherwise everything under that target would be requireable.
+#[cfg(unix)]
+#[test]
+fn symlinked_lua_directory_is_not_used_as_the_module_root() {
+    let pkg = package_dir(&[("init.lua", r#"require("escaped")"#)]);
+
+    let elsewhere = tempfile::TempDir::new().unwrap();
+    std::fs::write(elsewhere.path().join("escaped.lua"), "return {}\n").unwrap();
+    std::os::unix::fs::symlink(elsewhere.path(), pkg.path().join("lua")).unwrap();
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let err = host
+        .load_package(
+            "linky",
+            pkg.path(),
+            maki_lua::PluginPermissions::trusted(),
+            Default::default(),
+        )
+        .expect_err("a lua/ directory pointing out of the package must not resolve modules");
+    assert!(err.to_string().contains("module not found"), "got: {err}");
+}
+
+/// An `opt/` package waits to be activated, so startup alone must not run it.
+#[test]
+fn discovered_opt_package_is_not_loaded_at_startup() {
+    let site = site_with_package(
+        "opt",
+        "lazy_pack",
+        &[(
+            "init.lua",
+            r#"maki.api.register_command({ name = "/lazy", handler = function() end })"#,
+        )],
+    );
+
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    assert_eq!(host.command_reader().load().commands.len(), 0);
+}
+
+/// Adds one `start` and one `opt` package to a site tree.
+fn site_with_two(start: (&str, &str), opt: (&str, &str)) -> tempfile::TempDir {
+    let tmp = tempfile::TempDir::new().unwrap();
+    for (sub, name, source) in [("start", start.0, start.1), ("opt", opt.0, opt.1)] {
+        let dir = tmp.path().join("pack").join("vendor").join(sub).join(name);
+        std::fs::create_dir_all(dir.join("plugin")).unwrap();
+        std::fs::write(dir.join("plugin").join("init.lua"), source).unwrap();
+    }
+    tmp
+}
+
+fn discovered_config(found: &maki_lua::Discovery) -> (Vec<String>, PluginsConfig) {
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+    (names, config)
+}
+
+/// `maki.packadd` is the activation path for an `opt/` package. A `start`
+/// package that calls it must get the named package loaded in the same
+/// startup, not the next one, or its registrations never appear.
+#[test]
+fn packadd_from_a_start_package_activates_an_opt_package() {
+    let site = site_with_two(
+        ("waker_pack", r#"maki.packadd("lazy_pack")"#),
+        (
+            "lazy_pack",
+            r#"maki.api.register_command({ name = "/lazy", handler = function() end })"#,
+        ),
+    );
+
+    let found = maki_lua::discover(site.path());
+    let (_, config) = discovered_config(&found);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    assert!(
+        host.load_packages(&found.packages, &config).is_empty(),
+        "both packages must load without a failure"
+    );
+
+    let snap = host.command_reader().load();
+    assert_eq!(
+        snap.commands.len(),
+        1,
+        "the activated package must have registered its command"
+    );
+    assert_eq!(snap.commands[0].name.as_ref(), "/lazy");
+}
+
+/// A name that matches no installed package is reported. Doing nothing would
+/// leave the user with a package that never loads and no reason why.
+#[test]
+fn packadd_reports_a_name_that_is_not_installed() {
+    let site = site_with_two(
+        ("waker_pack", r#"maki.packadd("absent_pack")"#),
+        ("lazy_pack", ""),
+    );
+
+    let found = maki_lua::discover(site.path());
+    let (_, config) = discovered_config(&found);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let failures = host.load_packages(&found.packages, &config);
+    assert_eq!(failures.len(), 1, "got: {failures:?}");
+    assert!(failures[0].contains("absent_pack"), "got: {failures:?}");
+}
+
+/// A package the config disabled stays disabled. `packadd` must not be a way
+/// around `plugins.<name>.enabled = false`.
+#[test]
+fn packadd_cannot_activate_a_disabled_package() {
+    let site = site_with_two(
+        ("waker_pack", r#"maki.packadd("lazy_pack")"#),
+        (
+            "lazy_pack",
+            r#"maki.api.register_command({ name = "/lazy", handler = function() end })"#,
+        ),
+    );
+
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let mut plugins: HashMap<String, maki_config::PluginFileConfig> = HashMap::new();
+    plugins.insert(
+        "lazy_pack".to_owned(),
+        maki_config::PluginFileConfig {
+            enabled: Some(false),
+            ..Default::default()
+        },
+    );
+    let config = PluginsConfig::from_plugins_and_packages(plugins, &names);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let failures = host.load_packages(&found.packages, &config);
+    assert_eq!(failures.len(), 1, "got: {failures:?}");
+    assert_eq!(
+        host.command_reader().load().commands.len(),
+        0,
+        "a disabled package must not register anything"
+    );
+}
+
+/// A package that asks for nothing gets nothing. Without a `plugin.toml` the
+/// guarded APIs must refuse, so a downloaded package cannot reach the network
+/// or the environment just by being installed.
+#[test]
+fn package_without_manifest_cannot_use_guarded_apis() {
+    let site = site_with_package(
+        "start",
+        "greedy_pack",
+        &[(
+            "init.lua",
+            r#"
+local ok = pcall(function() return maki.env.config_dir() end)
+maki.api.register_command({
+  name = ok and "/allowed" or "/denied",
+  handler = function() end,
+})
+"#,
+        )],
+    );
+
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    let snap = host.command_reader().load();
+    assert_eq!(snap.commands.len(), 1);
+    assert_eq!(
+        snap.commands[0].name.as_ref(),
+        "/denied",
+        "a package requesting nothing must not reach maki.env"
+    );
+}
+
+/// The manifest is what a manual install is granted, so a package that asks
+/// for `env` gets it without any further approval.
+#[test]
+fn manual_package_is_granted_what_its_manifest_requests() {
+    let site = site_with_package(
+        "start",
+        "asking_pack",
+        &[(
+            "init.lua",
+            r#"
+local ok = pcall(function() return maki.env.config_dir() end)
+maki.api.register_command({
+  name = ok and "/allowed" or "/denied",
+  handler = function() end,
+})
+"#,
+        )],
+    );
+    let pkg_dir = site
+        .path()
+        .join("pack")
+        .join("vendor")
+        .join("start")
+        .join("asking_pack");
+    std::fs::write(pkg_dir.join("plugin.toml"), "[permissions]\nenv = true\n").unwrap();
+
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found.packages.iter().map(|p| p.name.clone()).collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    assert!(host.load_packages(&found.packages, &config).is_empty());
+
+    let snap = host.command_reader().load();
+    assert_eq!(snap.commands[0].name.as_ref(), "/allowed");
 }
 
 #[test]

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -3180,6 +3180,25 @@ fn discovered_config(found: &maki_lua::Discovery) -> (Vec<String>, PluginsConfig
     (names, config)
 }
 
+/// The whole startup order: load what starts eagerly, then apply whatever
+/// those loads recorded. `maki.packadd` only takes effect at the second step.
+fn activate_all(
+    host: &PluginHost,
+    found: &maki_lua::Discovery,
+    config: &PluginsConfig,
+) -> Vec<String> {
+    let mut failures = host.load_packages(&found.packages, config);
+    let mut active: std::collections::BTreeSet<String> = found
+        .packages
+        .iter()
+        .filter(|p| p.eager && config.packages.iter().any(|n| n == &p.name))
+        .map(|p| p.name.clone())
+        .collect();
+    let report = maki_lua::drain_pack_ops(host, &[], &found.packages, &mut active, config);
+    failures.extend(report.failures);
+    failures
+}
+
 /// `maki.packadd` is the activation path for an `opt/` package. A `start`
 /// package that calls it must get the named package loaded in the same
 /// startup, not the next one, or its registrations never appear.
@@ -3198,10 +3217,8 @@ fn packadd_from_a_start_package_activates_an_opt_package() {
 
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    assert!(
-        host.load_packages(&found.packages, &config).is_empty(),
-        "both packages must load without a failure"
-    );
+    let failures = activate_all(&host, &found, &config);
+    assert!(failures.is_empty(), "got: {failures:?}");
 
     let snap = host.command_reader().load();
     assert_eq!(
@@ -3226,7 +3243,7 @@ fn packadd_reports_a_name_that_is_not_installed() {
 
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    let failures = host.load_packages(&found.packages, &config);
+    let failures = activate_all(&host, &found, &config);
     assert_eq!(failures.len(), 1, "got: {failures:?}");
     assert!(failures[0].contains("absent_pack"), "got: {failures:?}");
 }
@@ -3257,7 +3274,7 @@ fn packadd_cannot_activate_a_disabled_package() {
 
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    let failures = host.load_packages(&found.packages, &config);
+    let failures = activate_all(&host, &found, &config);
     assert_eq!(failures.len(), 1, "got: {failures:?}");
     assert_eq!(
         host.command_reader().load().commands.len(),

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -18,6 +18,7 @@ use serde_json::{Value, json};
 
 const BUILTIN_COMMANDS: &[&str] = &["/sessions", "/rename", "/tasks"];
 const NARGS_ERR: &str = r#"'nargs' must be 0, 1, "?", "*", or "+""#;
+const GLOBAL_PACK_ONLY_ERR: &str = "only available in the global init.lua";
 const USAGE_TOOL_NAME: &str = "usage_child";
 const USAGE_VALUE: &str = "12.3k↑ 456↓ $0.123";
 const USAGE_OUTPUT: &str = "usage_done";
@@ -1179,6 +1180,45 @@ fn require_symlink_out_of_package_blocked() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn global_init_can_require_a_symlinked_module() {
+    let config = tempfile::TempDir::new().unwrap();
+    let modules = config.path().join("lua");
+    std::fs::create_dir_all(&modules).unwrap();
+    let elsewhere = tempfile::TempDir::new().unwrap();
+    let target = elsewhere.path().join("shared.lua");
+    std::fs::write(&target, "return { value = 42 }\n").unwrap();
+    std::os::unix::fs::symlink(&target, modules.join("shared.lua")).unwrap();
+
+    let host = PluginHost::new(fresh_registry()).unwrap();
+    let _ = host
+        .send_run_init_lua(
+            "assert(require('shared').value == 42)".to_owned(),
+            "global/init.lua".to_owned(),
+            Some(config.path().to_path_buf()),
+        )
+        .unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn global_init_can_use_a_symlinked_lua_directory() {
+    let config = tempfile::TempDir::new().unwrap();
+    let elsewhere = tempfile::TempDir::new().unwrap();
+    std::fs::write(elsewhere.path().join("shared.lua"), "return true\n").unwrap();
+    std::os::unix::fs::symlink(elsewhere.path(), config.path().join("lua")).unwrap();
+
+    let host = PluginHost::new(fresh_registry()).unwrap();
+    let _ = host
+        .send_run_init_lua(
+            "assert(require('shared'))".to_owned(),
+            "global/init.lua".to_owned(),
+            Some(config.path().to_path_buf()),
+        )
+        .unwrap();
+}
+
 #[test]
 fn require_circular_returns_sentinel_and_caches_real_value() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -2189,6 +2229,45 @@ fn setup_happy_path() {
         .unwrap();
     let raw = raw.expect("expected Some(RawConfig)");
     assert_eq!(raw.agent.max_output_lines, Some(3000));
+}
+
+#[test_case::test_case(
+    r#"maki.pack.add({ "https://example.com/demo" })"#;
+    "add"
+)]
+#[test_case::test_case("maki.pack.update()"; "update")]
+#[test_case::test_case(r#"maki.pack.del({ "demo" })"#; "delete")]
+fn project_init_cannot_change_global_packages(source: &str) {
+    let host = PluginHost::new(fresh_registry()).unwrap();
+
+    let error = host
+        .send_run_init_lua(source.to_owned(), "project/init.lua".to_owned(), None)
+        .expect_err("project config must not change global packages");
+
+    assert!(
+        error.to_string().contains(GLOBAL_PACK_ONLY_ERR),
+        "got: {error}"
+    );
+}
+
+#[test]
+fn project_init_can_activate_an_installed_global_package() {
+    let host = PluginHost::new(fresh_registry()).unwrap();
+
+    let _ = host
+        .send_run_init_lua(
+            r#"maki.packadd("demo")"#.to_owned(),
+            "project/init.lua".to_owned(),
+            None,
+        )
+        .unwrap();
+
+    assert_eq!(
+        host.seal_pack_ops().unwrap(),
+        [maki_lua::PackOp::Activate {
+            name: "demo".to_owned()
+        }]
+    );
 }
 
 #[test_case::test_case(

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -3116,6 +3116,38 @@ end
     );
 }
 
+#[test]
+fn loaded_package_set_excludes_a_package_that_failed_to_load() {
+    let site = tempfile::TempDir::new().unwrap();
+    for (name, source) in [("good", ""), ("broken", "this is not lua")] {
+        let plugin = site
+            .path()
+            .join("pack/vendor/start")
+            .join(name)
+            .join("plugin");
+        std::fs::create_dir_all(&plugin).unwrap();
+        std::fs::write(plugin.join("init.lua"), source).unwrap();
+    }
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found
+        .packages
+        .iter()
+        .map(|package| package.name.clone())
+        .collect();
+    let config = maki_config::PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+    let host = PluginHost::new(fresh_registry()).unwrap();
+
+    let failures = host.load_packages(&found.packages, &config);
+    let loaded = host.active_packages().unwrap();
+
+    assert!(loaded.contains("good"));
+    assert!(!loaded.contains("broken"));
+    assert_eq!(failures.len(), 1);
+
+    host.unload("good").unwrap();
+    assert!(host.active_packages().unwrap().is_empty());
+}
+
 /// If `lua/` itself links out of the package, its target must not become the
 /// sandbox root; otherwise everything under that target would be requireable.
 #[cfg(unix)]
@@ -3158,7 +3190,10 @@ fn discovered_opt_package_is_not_loaded_at_startup() {
 
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    assert!(host.load_packages(&found.packages, &config).is_empty());
+    let failures = host.load_packages(&found.packages, &config);
+    let loaded = host.active_packages().unwrap();
+    assert!(loaded.is_empty());
+    assert!(failures.is_empty());
 
     assert_eq!(host.command_reader().load().commands.len(), 0);
 }
@@ -3188,13 +3223,7 @@ fn activate_all(
     config: &PluginsConfig,
 ) -> Vec<String> {
     let mut failures = host.load_packages(&found.packages, config);
-    let mut active: std::collections::BTreeSet<String> = found
-        .packages
-        .iter()
-        .filter(|p| p.eager && config.packages.iter().any(|n| n == &p.name))
-        .map(|p| p.name.clone())
-        .collect();
-    let report = maki_lua::drain_pack_ops(host, &[], &found.packages, &mut active, config);
+    let report = maki_lua::drain_pack_ops(host, &[], &found.packages, config);
     failures.extend(report.failures);
     failures
 }

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -2298,6 +2298,139 @@ fn setup_not_called_returns_none() {
 }
 
 #[test]
+fn custom_package_loader_receives_data_and_marks_the_package_active() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.send_run_init_lua(
+        r#"
+maki.pack.add({{
+  src = "https://example.com/custom",
+  name = "custom",
+  data = { command = "/custom-loaded" },
+}}, {
+  confirm = false,
+  load = function(package)
+    maki.api.register_command({
+      name = package.spec.data.command,
+      handler = function() end,
+    })
+  end,
+})
+"#
+        .to_owned(),
+        "test_init.lua".to_owned(),
+        None,
+    )
+    .unwrap();
+    let declared = host.declared_packages().unwrap().remove(0);
+    let path = tempfile::TempDir::new().unwrap();
+
+    host.run_pack_loader(
+        declared,
+        path.path(),
+        maki_lua::PluginPermissions::trusted(),
+        Default::default(),
+    )
+    .unwrap();
+
+    assert!(host.active_packages().unwrap().contains("custom"));
+    let snapshot = host.command_reader().load();
+    let command = snapshot
+        .commands
+        .iter()
+        .find(|command| command.name.as_ref() == "/custom-loaded")
+        .expect("custom loader should register its command");
+    assert_eq!(command.plugin.as_ref(), "custom");
+
+    host.unload("custom").unwrap();
+    assert!(host.command_reader().load().commands.is_empty());
+}
+
+#[test]
+fn a_failed_custom_package_loader_does_not_mark_the_package_active() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.send_run_init_lua(
+        r#"
+maki.pack.add({ "https://example.com/broken" }, {
+  confirm = false,
+  load = function() error("custom loader failed") end,
+})
+"#
+        .to_owned(),
+        "test_init.lua".to_owned(),
+        None,
+    )
+    .unwrap();
+    let declared = host.declared_packages().unwrap().remove(0);
+    let path = tempfile::TempDir::new().unwrap();
+
+    let error = host
+        .run_pack_loader(
+            declared,
+            path.path(),
+            maki_lua::PluginPermissions::trusted(),
+            Default::default(),
+        )
+        .expect_err("the loader error must reach the host");
+
+    assert!(
+        error.to_string().contains("custom loader failed"),
+        "{error}"
+    );
+    assert!(!host.active_packages().unwrap().contains("broken"));
+}
+
+#[test]
+fn package_change_event_carries_the_neovim_fields_and_original_data() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.send_run_init_lua(
+        r#"
+maki.pack.add({{
+  src = "https://example.com/evented",
+  name = "evented",
+  data = { marker = "kept" },
+}}, { confirm = false })
+maki.api.create_autocmd("PackChanged", {
+  callback = function(event)
+    assert(event.data.active == false)
+    assert(event.data.kind == "install")
+    assert(event.data.spec.data.marker == "kept")
+    assert(event.match == event.data.path)
+    maki.api.register_command({ name = "/pack-event", handler = function() end })
+  end,
+})
+"#
+        .to_owned(),
+        "test_init.lua".to_owned(),
+        None,
+    )
+    .unwrap();
+    let declared = host.declared_packages().unwrap().remove(0);
+    let path = tempfile::TempDir::new().unwrap();
+
+    host.fire_pack_changed(
+        "PackChanged",
+        maki_lua::PackChange {
+            declared,
+            active: false,
+            kind: maki_lua::PackChangeKind::Install,
+            path: path.path().to_path_buf(),
+        },
+    )
+    .unwrap();
+
+    assert!(
+        host.command_reader()
+            .load()
+            .commands
+            .iter()
+            .any(|command| command.name.as_ref() == "/pack-event")
+    );
+}
+
+#[test]
 fn setup_all_sections_at_once() {
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
@@ -2826,6 +2959,464 @@ fn package_dir(files: &[(&str, &str)]) -> tempfile::TempDir {
     tmp
 }
 
+/// Builds a dormant package entry the runtime can activate.
+fn dormant(name: &str, dir: &std::path::Path, cmd: &str) -> maki_lua::Dormant {
+    maki_lua::Dormant {
+        name: name.to_owned(),
+        dir: dir.to_path_buf(),
+        permissions: maki_lua::PluginPermissions::trusted(),
+        opts: Default::default(),
+        triggers: maki_lua::Triggers {
+            cmd: vec![cmd.to_owned()],
+            ..Default::default()
+        },
+        state: maki_lua::PackState::Inactive,
+    }
+}
+
+fn command_names(host: &PluginHost) -> Vec<String> {
+    host.command_reader()
+        .load()
+        .commands
+        .iter()
+        .map(|command| command.name.to_string())
+        .collect()
+}
+
+#[test]
+fn unloading_an_inactive_package_removes_its_pending_trigger() {
+    let package = package_dir(&[("init.lua", "")]);
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.set_dormant_packages(vec![dormant("demo", package.path(), "/lazy")])
+        .unwrap();
+    assert!(command_names(&host).iter().any(|name| name == "/lazy"));
+
+    host.unload("demo").unwrap();
+
+    assert!(command_names(&host).iter().all(|name| name != "/lazy"));
+}
+
+/// The whole point of a command trigger: the package is on disk and not
+/// loaded, and running the command it declared loads it and then runs it.
+///
+/// This works only because the runtime activates the package itself.
+/// `PluginHost::load_package` waits for a reply from the runtime thread, so
+/// the thread handling the command cannot use it; it reads the package and
+/// calls `load_source` directly instead.
+#[test]
+fn a_command_trigger_loads_the_package_and_then_runs_the_command() {
+    let pkg = package_dir(&[(
+        "init.lua",
+        r#"
+        maki.api.register_command({
+          name = "/lazy",
+          handler = function()
+            maki.ui.flash("ran")
+          end,
+        })
+        "#,
+    )]);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.set_dormant_packages(vec![dormant("demo", pkg.path(), "/lazy")])
+        .unwrap();
+
+    // Visible before it loads, or the user could never type what wakes it.
+    let snap = host.command_reader().load();
+    assert!(
+        snap.commands.iter().any(|c| c.name.as_ref() == "/lazy"),
+        "a pending trigger must appear in the palette"
+    );
+    drop(snap);
+
+    let rx = host.ui_action_rx();
+    host.event_handle()
+        .run_command("demo".into(), "/lazy".into(), String::new(), 0);
+
+    let action = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("the command did not run after loading its package");
+    assert!(matches!(action, maki_lua::UiAction::Flash(message) if message == "ran"));
+}
+
+/// A runtime `packadd` must not wait for the startup host drain. Neovim lets
+/// one plugin request an optional package when it needs it, and Maki exposes
+/// the same operation to every plugin.
+#[test]
+fn runtime_packadd_activates_a_manual_opt_package() {
+    let site = site_with_package(
+        "opt",
+        "lazy_pack",
+        &[(
+            "init.lua",
+            r#"maki.api.register_command({ name = "/loaded", handler = function() end })"#,
+        )],
+    );
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found
+        .packages
+        .iter()
+        .map(|package| package.name.clone())
+        .collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    maki_lua::arm_packages(
+        &host,
+        &found.packages,
+        &[],
+        &[],
+        &Default::default(),
+        &config,
+    )
+    .unwrap();
+
+    host.load_source("caller", r#"maki.packadd("lazy_pack")"#)
+        .unwrap();
+
+    // This request is queued after the activation request, so its reply is a
+    // deterministic fence for the load rather than a timed wait.
+    assert!(host.active_packages().unwrap().contains("lazy_pack"));
+    assert!(command_names(&host).iter().any(|name| name == "/loaded"));
+}
+
+#[test]
+fn runtime_packadd_does_not_reactivate_a_manual_start_package() {
+    let site = site_with_package("start", "start_pack", &[("init.lua", "")]);
+    let found = maki_lua::discover(site.path());
+    let names: Vec<String> = found
+        .packages
+        .iter()
+        .map(|package| package.name.clone())
+        .collect();
+    let config = PluginsConfig::from_plugins_and_packages(Default::default(), &names);
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    maki_lua::arm_packages(
+        &host,
+        &found.packages,
+        &[],
+        &[],
+        &Default::default(),
+        &config,
+    )
+    .unwrap();
+
+    let error = host
+        .load_source("caller", r#"maki.packadd("start_pack")"#)
+        .expect_err("a start package is not an optional activation target");
+
+    assert!(error.to_string().contains("not installed"), "got: {error}");
+}
+
+#[test]
+fn runtime_packadd_reports_an_unknown_package() {
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.set_dormant_packages(Vec::new()).unwrap();
+
+    let error = host
+        .load_source("caller", r#"maki.packadd("missing")"#)
+        .expect_err("Neovim reports a missing optional package");
+
+    assert!(error.to_string().contains("not installed"), "got: {error}");
+}
+
+#[test]
+fn init_callback_uses_runtime_packadd_after_catalog_is_ready() {
+    let package = package_dir(&[(
+        "init.lua",
+        r#"maki.api.register_command({ name = "/loaded", handler = function() end })"#,
+    )]);
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.send_run_init_lua(
+        r#"
+        maki.api.create_autocmd("PackWake", {
+          callback = function()
+            maki.packadd("demo")
+          end,
+        })
+        "#
+        .to_owned(),
+        "init.lua".to_owned(),
+        None,
+    )
+    .unwrap();
+    host.set_dormant_packages(vec![maki_lua::Dormant {
+        triggers: Default::default(),
+        ..dormant("demo", package.path(), "/unused")
+    }])
+    .unwrap();
+
+    host.load_source("caller", r#"maki.api.exec_autocmds("PackWake")"#)
+        .unwrap();
+
+    assert!(host.active_packages().unwrap().contains("demo"));
+}
+
+#[test]
+fn host_packadd_removes_pending_triggers_after_activation() {
+    let package = package_dir(&[(
+        "init.lua",
+        r#"maki.api.register_command({ name = "/actual", handler = function() end })"#,
+    )]);
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.set_dormant_packages(vec![dormant("demo", package.path(), "/declared")])
+        .unwrap();
+
+    host.load_package(
+        "demo",
+        package.path(),
+        maki_lua::PluginPermissions::trusted(),
+        Default::default(),
+    )
+    .unwrap();
+
+    let names = command_names(&host);
+    assert!(names.iter().any(|name| name == "/actual"));
+    assert!(
+        names.iter().all(|name| name != "/declared"),
+        "an active package must not keep a pending trigger: {names:?}"
+    );
+}
+
+/// A host-fired event wakes the package that listens for it, and the listener
+/// the package registers receives that same event rather than the next one.
+///
+/// Activation runs before the dispatch, which is the whole reason only
+/// host-fired events can be triggers: the request arrives on the runtime loop,
+/// where a load can be awaited first. A Lua `exec_autocmds` dispatches
+/// synchronously and has no such point.
+#[test]
+fn a_host_fired_event_activates_the_package_that_listens_for_it() {
+    let pkg = package_dir(&[(
+        "init.lua",
+        r#"
+
+        local seen = 0
+        maki.api.create_autocmd("TurnEnd", {
+          callback = function()
+            seen = seen + 1
+            maki.ui.flash("saw" .. seen)
+          end,
+        })
+        "#,
+    )]);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.set_dormant_packages(vec![maki_lua::Dormant {
+        triggers: maki_lua::Triggers {
+            event: vec!["TurnEnd".to_owned()],
+            ..Default::default()
+        },
+        ..dormant("demo", pkg.path(), "/unused")
+    }])
+    .unwrap();
+
+    let rx = host.ui_action_rx();
+    host.event_handle()
+        .fire_autocmd("TurnEnd", serde_json::Value::Null);
+
+    let action = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("the package did not receive the event that woke it");
+    assert!(matches!(action, maki_lua::UiAction::Flash(message) if message == "saw1"));
+    assert!(host.active_packages().unwrap().contains("demo"));
+    assert!(
+        matches!(rx.try_recv(), Err(flume::TryRecvError::Empty)),
+        "the event reached the woken listener more than once"
+    );
+}
+
+/// A key trigger wakes the package and then runs the binding it registered.
+///
+/// The binding the package creates gets a fresh id, and the UI sent the id of
+/// the pending entry, so resolving by id after the load would find nothing.
+/// The key is what carries across.
+#[test]
+fn a_key_trigger_resolves_by_key_because_the_id_changes_across_the_load() {
+    let pkg = package_dir(&[(
+        "init.lua",
+        r#"
+        maki.keymap.set("n", "<C-g>", function()
+          maki.ui.flash("pressed")
+        end)
+        "#,
+    )]);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.set_dormant_packages(vec![maki_lua::Dormant {
+        triggers: maki_lua::Triggers {
+            keys: vec!["<C-g>".to_owned()],
+            ..Default::default()
+        },
+        ..dormant("demo", pkg.path(), "/unused")
+    }])
+    .unwrap();
+
+    // Published, or the UI would never send the press here at all.
+    let snap = host.keymap_reader().load();
+    let entry = snap
+        .entries
+        .iter()
+        .find(|e| e.key == crossterm::event::KeyCode::Char('g'))
+        .expect("a pending key must be published")
+        .clone();
+    drop(snap);
+
+    let rx = host.ui_action_rx();
+    host.event_handle()
+        .run_keybind_callback(entry.id, entry.key, entry.modifiers);
+
+    let action = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("the key did not run the binding from its package");
+    assert!(matches!(action, maki_lua::UiAction::Flash(message) if message == "pressed"));
+}
+
+#[test]
+fn a_stale_real_key_id_does_not_activate_a_dormant_package() {
+    let pkg = package_dir(&[(
+        "init.lua",
+        r#"maki.keymap.set("n", "<C-g>", function() end)"#,
+    )]);
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source("old", r#"maki.keymap.set("n", "<C-g>", function() end)"#)
+        .unwrap();
+    let snapshot = host.keymap_reader().load();
+    let old = snapshot.entries[0].clone();
+    drop(snapshot);
+
+    host.set_dormant_packages(vec![maki_lua::Dormant {
+        triggers: maki_lua::Triggers {
+            keys: vec!["<C-g>".to_owned()],
+            ..Default::default()
+        },
+        ..dormant("demo", pkg.path(), "/unused")
+    }])
+    .unwrap();
+    host.unload("old").unwrap();
+
+    host.event_handle()
+        .run_keybind_callback(old.id, old.key, old.modifiers);
+
+    assert!(!host.active_packages().unwrap().contains("demo"));
+}
+
+/// A package whose top level fails is not tried again. Without this, every
+/// later use of the command that woke it would re-run the broken code.
+#[test]
+fn a_package_that_fails_to_activate_is_not_retried() {
+    let pkg = package_dir(&[("init.lua", r#"error("broken package")"#)]);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source(
+        "fence",
+        r#"
+        maki.api.register_command({
+          name = "/fence",
+          handler = function() maki.ui.flash("fenced") end,
+        })
+        "#,
+    )
+    .unwrap();
+    host.set_dormant_packages(vec![dormant("demo", pkg.path(), "/lazy")])
+        .unwrap();
+    assert!(
+        command_names(&host).iter().any(|n| n == "/lazy"),
+        "the trigger is offered before the failure"
+    );
+
+    let rx = host.ui_action_rx();
+    let handle = host.event_handle();
+    handle.run_command("demo".into(), "/lazy".into(), String::new(), 0);
+    handle.run_command("fence".into(), "/fence".into(), String::new(), 0);
+
+    let action = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("the command fence did not run");
+    assert!(matches!(action, maki_lua::UiAction::Flash(message) if message == "fenced"));
+    assert!(!host.active_packages().unwrap().contains("demo"));
+    assert!(
+        command_names(&host).iter().all(|n| n != "/lazy"),
+        "a package that failed to load must stop being offered, not be retried"
+    );
+
+    host.set_dormant_packages(vec![dormant("demo", pkg.path(), "/lazy")])
+        .unwrap();
+    assert!(
+        command_names(&host).iter().all(|name| name != "/lazy"),
+        "refreshing the catalog must preserve the failed state"
+    );
+
+    let replacement = package_dir(&[(
+        "init.lua",
+        r#"maki.api.register_command({ name = "/fixed", handler = function() end })"#,
+    )]);
+    host.set_dormant_packages(vec![dormant("demo", replacement.path(), "/lazy")])
+        .unwrap();
+    host.load_source("caller", r#"maki.packadd("demo")"#)
+        .unwrap();
+
+    assert!(host.active_packages().unwrap().contains("demo"));
+    assert!(
+        command_names(&host).iter().any(|name| name == "/fixed"),
+        "a new immutable revision must be eligible after the old one failed"
+    );
+}
+
+/// A command nothing declared must not wake anything, or any typo would load
+/// an unrelated package.
+#[test]
+fn an_unrelated_command_does_not_activate_a_dormant_package() {
+    let pkg = package_dir(&[(
+        "init.lua",
+        r#"maki.api.register_command({ name = "/lazy", handler = function() end })"#,
+    )]);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    host.load_source(
+        "fence",
+        r#"
+        maki.api.register_command({
+          name = "/fence",
+          handler = function() maki.ui.flash("fenced") end,
+        })
+        "#,
+    )
+    .unwrap();
+    host.set_dormant_packages(vec![dormant("demo", pkg.path(), "/lazy")])
+        .unwrap();
+
+    let rx = host.ui_action_rx();
+    let handle = host.event_handle();
+    handle.run_command("demo".into(), "/other".into(), String::new(), 0);
+    handle.run_command("fence".into(), "/fence".into(), String::new(), 0);
+    let action = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("the command fence did not run");
+    assert!(matches!(action, maki_lua::UiAction::Flash(message) if message == "fenced"));
+    assert!(!host.active_packages().unwrap().contains("demo"));
+
+    let snap = host.command_reader().load();
+    assert!(
+        snap.commands
+            .iter()
+            .all(|c| c.plugin.as_ref() != "demo" || c.description.as_ref().contains("loads demo")),
+        "the package must still be dormant, so only its pending entry shows"
+    );
+}
+
 #[test]
 fn package_loads_every_entrypoint_under_one_owner() {
     let pkg = package_dir(&[
@@ -3030,12 +3621,28 @@ fn discovered_start_package_is_found_and_loaded() {
 
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    assert!(host.load_packages(&found.packages, &config).is_empty());
+    host.load_packages(&found.packages, &config);
 
     let snap = host.command_reader().load();
     assert_eq!(snap.commands.len(), 1);
     assert_eq!(snap.commands[0].name.as_ref(), "/demo");
     assert_eq!(snap.commands[0].plugin.as_ref(), "demo_pack");
+}
+
+#[test]
+fn package_load_failure_reaches_the_caller() {
+    let site = site_with_package("start", "broken_pack", &[("init.lua", "this is not lua")]);
+    let found = maki_lua::discover(site.path());
+    let config =
+        PluginsConfig::from_plugins_and_packages(Default::default(), &["broken_pack".to_owned()]);
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+
+    let failures = host.load_packages(&found.packages, &config);
+
+    assert_eq!(failures.len(), 1);
+    assert!(failures[0].contains("broken_pack"), "{:?}", failures);
+    assert!(!host.active_packages().unwrap().contains("broken_pack"));
 }
 
 /// Builtins must still load when a package is installed. Packages once shared
@@ -3060,7 +3667,7 @@ fn installed_package_does_not_break_builtin_loading() {
     let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
     host.load_builtins(&config)
         .expect("an installed package must not stop the builtins from loading");
-    assert!(host.load_packages(&found.packages, &config).is_empty());
+    host.load_packages(&found.packages, &config);
 
     assert!(reg.has("grep"), "builtin tools should still be registered");
     let names: Vec<String> = host
@@ -3105,7 +3712,7 @@ end
     let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
     host.load_builtins(&config)
         .expect("package options must not be rejected as unknown plugin options");
-    assert!(host.load_packages(&found.packages, &config).is_empty());
+    host.load_packages(&found.packages, &config);
 
     assert!(
         host.command_reader()
@@ -3117,7 +3724,7 @@ end
 }
 
 #[test]
-fn loaded_package_set_excludes_a_package_that_failed_to_load() {
+fn active_package_set_excludes_a_package_that_failed_to_load() {
     let site = tempfile::TempDir::new().unwrap();
     for (name, source) in [("good", ""), ("broken", "this is not lua")] {
         let plugin = site
@@ -3138,14 +3745,11 @@ fn loaded_package_set_excludes_a_package_that_failed_to_load() {
     let host = PluginHost::new(fresh_registry()).unwrap();
 
     let failures = host.load_packages(&found.packages, &config);
-    let loaded = host.active_packages().unwrap();
+    let active = host.active_packages().unwrap();
 
-    assert!(loaded.contains("good"));
-    assert!(!loaded.contains("broken"));
     assert_eq!(failures.len(), 1);
-
-    host.unload("good").unwrap();
-    assert!(host.active_packages().unwrap().is_empty());
+    assert!(active.contains("good"));
+    assert!(!active.contains("broken"));
 }
 
 /// If `lua/` itself links out of the package, its target must not become the
@@ -3190,10 +3794,7 @@ fn discovered_opt_package_is_not_loaded_at_startup() {
 
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    let failures = host.load_packages(&found.packages, &config);
-    let loaded = host.active_packages().unwrap();
-    assert!(loaded.is_empty());
-    assert!(failures.is_empty());
+    host.load_packages(&found.packages, &config);
 
     assert_eq!(host.command_reader().load().commands.len(), 0);
 }
@@ -3223,7 +3824,13 @@ fn activate_all(
     config: &PluginsConfig,
 ) -> Vec<String> {
     let mut failures = host.load_packages(&found.packages, config);
-    let report = maki_lua::drain_pack_ops(host, &[], &found.packages, config);
+    let report = maki_lua::drain_pack_ops(
+        host,
+        &[],
+        &found.packages,
+        config,
+        maki_lua::Interaction::None,
+    );
     failures.extend(report.failures);
     failures
 }
@@ -3338,7 +3945,7 @@ maki.api.register_command({
 
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    assert!(host.load_packages(&found.packages, &config).is_empty());
+    host.load_packages(&found.packages, &config);
 
     let snap = host.command_reader().load();
     assert_eq!(snap.commands.len(), 1);
@@ -3381,7 +3988,7 @@ maki.api.register_command({
 
     let reg = fresh_registry();
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    assert!(host.load_packages(&found.packages, &config).is_empty());
+    host.load_packages(&found.packages, &config);
 
     let snap = host.command_reader().load();
     assert_eq!(snap.commands[0].name.as_ref(), "/allowed");

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -2690,23 +2690,26 @@ fn undeclared_opts_fail_the_load() {
     assert!(err.to_string().contains(UNDECLARED_OPTS_ERR), "got: {err}");
 }
 
+/// A disabled package keeps its options in `opts` but leaves `packages`, which
+/// is exactly the shape `into_config` produces. Treating that as an unknown
+/// name stopped maki from booting over options it was already ignoring, and
+/// only for packages: a disabled builtin in the same state just warned.
 #[test]
-fn opts_for_unknown_plugin_fail_load_builtins() {
+fn opts_for_a_disabled_package_do_not_stop_the_load() {
     let reg = fresh_registry();
     let mut host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    let mut config = PluginsConfig::from_plugins(HashMap::new());
-    config.opts.insert(
-        "bsah".to_owned(),
-        json_obj(serde_json::json!({ "timeout_secs": 5 })),
-    );
-    let err = host
-        .load_builtins(&config)
-        .expect_err("load_builtins should fail");
-    assert!(
-        err.to_string()
-            .contains("plugins.bsah sets options (timeout_secs)"),
-        "got: {err}"
-    );
+    let config = PluginsConfig {
+        enabled: true,
+        names: vec!["grep".to_owned()],
+        packages: Vec::new(),
+        opts: HashMap::from([(
+            "my_pack".to_owned(),
+            json_obj(serde_json::json!({ "timeout_secs": 5 })),
+        )]),
+    };
+    host.load_builtins(&config)
+        .expect("a disabled package must not stop the builtins from loading");
+    assert!(reg.get("grep").is_some(), "enabled plugin still loads");
 }
 
 #[test]
@@ -3863,6 +3866,37 @@ fn packadd_from_a_start_package_activates_an_opt_package() {
         "the activated package must have registered its command"
     );
     assert_eq!(snap.commands[0].name.as_ref(), "/lazy");
+}
+
+/// `maki.packadd` is on the maki table for every plugin, and the runtime
+/// serves it from the activation catalog. Arming that catalog can fail, and
+/// the recording path it falls back to is only read by the startup drain, so
+/// after that drain a call must report rather than queue where nothing looks.
+#[test]
+fn packadd_reports_when_the_activation_catalog_was_never_armed() {
+    let site = site_with_two(("waker_pack", ""), ("lazy_pack", ""));
+    let found = maki_lua::discover(site.path());
+    let (_, config) = discovered_config(&found);
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    // Deliberately no `arm_packages`: this is the startup where it failed.
+    assert!(
+        host.load_packages(&found.packages, &config).is_empty(),
+        "the start package must load"
+    );
+    maki_lua::drain_pack_ops(
+        &host,
+        &[],
+        &found.packages,
+        &config,
+        maki_lua::Interaction::None,
+    );
+
+    let err = host
+        .load_source("late_plugin", r#"maki.packadd("lazy_pack")"#)
+        .expect_err("packadd must report once the startup drain is over");
+    assert!(err.to_string().contains("activation catalog"), "got: {err}");
 }
 
 /// A name that matches no installed package is reported. Doing nothing would

--- a/maki-pack/Cargo.toml
+++ b/maki-pack/Cargo.toml
@@ -14,4 +14,3 @@ tracing = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 test-case = { workspace = true }
-toml = { workspace = true }

--- a/maki-pack/Cargo.toml
+++ b/maki-pack/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+fs4 = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/maki-pack/Cargo.toml
+++ b/maki-pack/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "maki-pack"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+semver = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+smol = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+test-case = { workspace = true }
+toml = { workspace = true }

--- a/maki-pack/src/approvals.rs
+++ b/maki-pack/src/approvals.rs
@@ -1,0 +1,162 @@
+//! Which permissions the user approved, for which package, from which source.
+//!
+//! Approvals live outside every checkout. A downloaded `plugin.toml` states
+//! what a package *wants*; this file states what it may have. The manifest is
+//! never authority over itself.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// An approval is bound to the source as well as the name.
+///
+/// Without the source in the key, deleting a package and adding an unrelated
+/// repository under the same name would silently inherit the old grants. A
+/// changed `src` is a new trust decision, so it must not match.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApprovalKey {
+    pub name: String,
+    pub src: String,
+}
+
+impl ApprovalKey {
+    pub fn new(name: impl Into<String>, src: &str) -> Self {
+        Self {
+            name: name.into(),
+            src: normalize_src(src),
+        }
+    }
+}
+
+/// Canonical form of a source, for keying an approval.
+///
+/// This deliberately does almost nothing. An earlier version folded a `.git`
+/// suffix, a trailing slash, and scheme and host case, on the theory that those
+/// name the same repository. They do not always: `/x/repo` and `/x/repo.git`
+/// can both exist as separate local repositories, and lowercasing an authority
+/// also lowercases any user information in an ssh URL. Every one of those
+/// collisions hands a different repository someone else's permission grants.
+///
+/// Being too strict only costs a second prompt when a user writes the same URL
+/// two ways. Being too loose grants access that was never approved, so this
+/// errs strict and trims whitespace alone.
+fn normalize_src(src: &str) -> String {
+    src.trim().to_owned()
+}
+
+/// The approval store, as written to disk.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Approvals {
+    #[serde(default)]
+    entries: BTreeMap<String, Entry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Entry {
+    src: String,
+    #[serde(default)]
+    permissions: Vec<String>,
+}
+
+impl Approvals {
+    /// Permissions approved for this exact package and source. A package whose
+    /// source changed has no approval, which is the point.
+    pub fn get(&self, key: &ApprovalKey) -> Option<&[String]> {
+        let entry = self.entries.get(&key.name)?;
+        (entry.src == key.src).then_some(entry.permissions.as_slice())
+    }
+
+    pub fn approve(&mut self, key: &ApprovalKey, permissions: Vec<String>) {
+        self.entries.insert(
+            key.name.clone(),
+            Entry {
+                src: key.src.clone(),
+                permissions,
+            },
+        );
+    }
+
+    /// Drops a package's approval, so reinstalling it asks again.
+    pub fn revoke(&mut self, name: &str) -> bool {
+        self.entries.remove(name).is_some()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    const SRC: &str = "https://github.com/user/repo";
+
+    fn approved(store: &Approvals, name: &str, src: &str) -> Option<Vec<String>> {
+        store
+            .get(&ApprovalKey::new(name, src))
+            .map(<[String]>::to_vec)
+    }
+
+    /// The defect this key shape exists to prevent: reusing a name must not
+    /// inherit the previous repository's grants.
+    #[test]
+    fn approval_does_not_carry_over_to_a_different_source() {
+        let mut store = Approvals::default();
+        store.approve(&ApprovalKey::new("pkg", SRC), vec!["run".to_owned()]);
+        assert_eq!(
+            approved(&store, "pkg", "https://github.com/attacker/repo"),
+            None,
+            "a different repository must not inherit the approval"
+        );
+    }
+
+    /// Only surrounding whitespace is ignored. Anything else is a different
+    /// source and must be approved again.
+    #[test]
+    fn whitespace_around_the_same_source_keeps_the_approval() {
+        let mut store = Approvals::default();
+        store.approve(&ApprovalKey::new("pkg", SRC), vec!["net".to_owned()]);
+        let padded = format!("  {SRC}\n");
+        assert!(approved(&store, "pkg", &padded).is_some());
+    }
+
+    /// These all look like harmless spellings, and an earlier version folded
+    /// them together. Each can name a genuinely different repository, and
+    /// folding them lets one inherit another's grants.
+    #[test_case("https://github.com/user/repo.git" ; "git_suffix_may_be_a_separate_repo")]
+    #[test_case("https://github.com/user/repo/" ; "trailing_slash")]
+    #[test_case("HTTPS://GitHub.com/user/repo" ; "authority_case")]
+    #[test_case("https://github.com/USER/repo" ; "path_case")]
+    #[test_case("ssh://User@github.com/user/repo" ; "ssh_user_case")]
+    fn a_differently_spelled_source_is_not_approved(variant: &str) {
+        let mut store = Approvals::default();
+        store.approve(&ApprovalKey::new("pkg", SRC), vec!["net".to_owned()]);
+        assert!(
+            approved(&store, "pkg", variant).is_none(),
+            "{variant} must be a fresh trust decision"
+        );
+    }
+
+    /// Two local repositories that really can both exist side by side.
+    #[test]
+    fn a_local_path_and_its_git_suffix_are_distinct() {
+        let mut store = Approvals::default();
+        store.approve(
+            &ApprovalKey::new("pkg", "/srv/repo"),
+            vec!["run".to_owned()],
+        );
+        assert!(approved(&store, "pkg", "/srv/repo.git").is_none());
+    }
+
+    #[test]
+    fn round_trips_through_json() {
+        let mut store = Approvals::default();
+        store.approve(&ApprovalKey::new("pkg", SRC), vec!["net".to_owned()]);
+
+        let text = serde_json::to_string(&store).unwrap();
+        let back: Approvals = serde_json::from_str(&text).unwrap();
+        assert_eq!(approved(&back, "pkg", SRC), Some(vec!["net".to_owned()]));
+    }
+}

--- a/maki-pack/src/git.rs
+++ b/maki-pack/src/git.rs
@@ -93,12 +93,51 @@ pub fn list_tags_args(empty_hooks_dir: &Path) -> Vec<String> {
     args
 }
 
+pub fn log_args(empty_hooks_dir: &Path, from: &str, to: &str) -> Vec<String> {
+    let mut args = hardening_args(empty_hooks_dir);
+    args.extend([
+        "log".to_owned(),
+        "--format=%h %s".to_owned(),
+        "--no-merges".to_owned(),
+        format!("{from}..{to}"),
+    ]);
+    args
+}
+
 /// Environment every invocation runs with. Disabling the terminal prompt makes
 /// a credential request fail immediately instead of hanging a startup on a
 /// prompt nobody is watching.
 pub fn hardening_env() -> [(&'static str, &'static str); 2] {
     [("GIT_TERMINAL_PROMPT", "0"), ("GIT_ASKPASS", "")]
 }
+
+/// Variables that let a caller make git run something else, or look somewhere
+/// else, and that therefore never reach it from us.
+///
+/// maki loads `.maki/.env` from the working directory into its own environment
+/// at startup, so anything in a repository you opened would otherwise be
+/// inherited here. `GIT_SSH_COMMAND` alone turns "install this package" into
+/// "run this command". Dropping `GIT_CONFIG_COUNT` is enough to disable the
+/// numbered `GIT_CONFIG_KEY_n` and `GIT_CONFIG_VALUE_n` pairs with it, because
+/// git reads none of them without the count.
+pub const DENIED_ENV: &[&str] = &[
+    "GIT_SSH",
+    "GIT_SSH_COMMAND",
+    "GIT_EXEC_PATH",
+    "GIT_PROXY_COMMAND",
+    "GIT_EXTERNAL_DIFF",
+    "GIT_CONFIG",
+    "GIT_CONFIG_COUNT",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_CONFIG_SYSTEM",
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_NAMESPACE",
+    "GIT_ATTR_SOURCE",
+];
 
 /// What one git invocation produced.
 #[derive(Debug, Clone)]
@@ -155,6 +194,9 @@ pub async fn run(args: Vec<String>, cwd: Option<PathBuf>) -> Result<GitOutput, G
         }
         for (key, value) in hardening_env() {
             cmd.env(key, value);
+        }
+        for key in DENIED_ENV {
+            cmd.env_remove(key);
         }
         cmd.output()
     })
@@ -232,6 +274,7 @@ mod tests {
         assert!(hooks_flag_present(&checkout_args(&hooks(), "main")));
         assert!(hooks_flag_present(&rev_parse_args(&hooks(), "HEAD")));
         assert!(hooks_flag_present(&list_tags_args(&hooks())));
+        assert!(hooks_flag_present(&log_args(&hooks(), "old", "new")));
     }
 
     /// The flags have to come before the subcommand, or git treats them as
@@ -350,17 +393,48 @@ mod tests {
         let hooks = dir.path().join("nohooks");
         std::fs::create_dir_all(&hooks).unwrap();
 
-        let init = smol::block_on(run(
+        // Not skipped when git is missing. A test that returns early proves
+        // nothing and reports success, which is worse than a red build telling
+        // you the environment is wrong.
+        smol::block_on(run(
             vec!["init".to_owned(), "--quiet".to_owned()],
             Some(dir.path().to_path_buf()),
-        ));
-        if init.is_err() {
-            return; // git is not available in this environment
-        }
+        ))
+        .expect("git must be available to run the git tests");
 
         let out = smol::block_on(run(list_tags_args(&hooks), Some(dir.path().to_path_buf())))
             .expect("listing tags in a fresh repository should succeed");
         assert!(parse_tags(&out.stdout).is_empty());
+    }
+
+    /// maki reads `.maki/.env` from whatever directory you opened, so a
+    /// repository can put variables in this process. `GIT_SSH_COMMAND` would
+    /// then run during a package clone. Proven by giving git a value that
+    /// would fail loudly if it ever reached it.
+    #[test]
+    fn a_project_env_cannot_make_git_run_something_else() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // SAFETY: the test process sets this only for its own children.
+        unsafe { std::env::set_var("GIT_SSH_COMMAND", "/nonexistent/pwned") };
+        unsafe { std::env::set_var("GIT_CONFIG_COUNT", "1") };
+        unsafe { std::env::set_var("GIT_CONFIG_KEY_0", "core.sshCommand") };
+        unsafe { std::env::set_var("GIT_CONFIG_VALUE_0", "/nonexistent/pwned") };
+
+        let out = smol::block_on(run(
+            vec!["init".to_owned(), "--quiet".to_owned()],
+            Some(dir.path().to_path_buf()),
+        ));
+
+        unsafe { std::env::remove_var("GIT_SSH_COMMAND") };
+        unsafe { std::env::remove_var("GIT_CONFIG_COUNT") };
+        unsafe { std::env::remove_var("GIT_CONFIG_KEY_0") };
+        unsafe { std::env::remove_var("GIT_CONFIG_VALUE_0") };
+
+        out.expect("git must not inherit an injected command from the environment");
+        assert!(
+            DENIED_ENV.contains(&"GIT_SSH_COMMAND") && DENIED_ENV.contains(&"GIT_CONFIG_COUNT"),
+            "the deny list has to keep covering the command injection variables"
+        );
     }
 
     #[test]

--- a/maki-pack/src/git.rs
+++ b/maki-pack/src/git.rs
@@ -1,0 +1,378 @@
+//! Every git invocation maki makes.
+//!
+//! Commands are built by the functions here and run by one runner, so no call
+//! site can forget the hardening flags. Neovim shells out to `git` too, which
+//! keeps credential helpers, SSH agents, and proxy settings working without
+//! maki owning any of that.
+
+use std::path::{Path, PathBuf};
+
+/// Flags every invocation carries, whatever it is doing.
+///
+/// `core.hooksPath` points at a directory maki keeps empty, so a repository
+/// cannot run code during a clone, a fetch, or a checkout. Cloning does not
+/// import hooks from a remote, so this is defence in depth for the case that
+/// matters more: a checkout directory on this machine whose `.git/hooks`
+/// something else has written.
+pub fn hardening_args(empty_hooks_dir: &Path) -> Vec<String> {
+    vec![
+        "-c".to_owned(),
+        format!("core.hooksPath={}", empty_hooks_dir.display()),
+    ]
+}
+
+/// Clone arguments. `partial` asks the server for a blobless clone, which is
+/// much smaller; a server that refuses it makes the command fail, and the
+/// caller retries without it.
+/// `--` closes the option list, so a source beginning with `-` is treated as a
+/// repository rather than as a git option. There is no shell here, so this is
+/// argument injection, not command injection, but `--upload-pack=` alone is
+/// enough to run a program.
+pub fn clone_args(empty_hooks_dir: &Path, src: &str, dest: &Path, partial: bool) -> Vec<String> {
+    let mut args = hardening_args(empty_hooks_dir);
+    args.push("clone".to_owned());
+    if partial {
+        args.push("--filter=blob:none".to_owned());
+    }
+    args.push("--".to_owned());
+    args.push(src.to_owned());
+    args.push(dest.display().to_string());
+    args
+}
+
+/// Whether a revision can be passed to git as a positional argument.
+///
+/// `git rev-parse --not-a-flag` would be read as an option, and revisions come
+/// from a package specification, so they are checked rather than trusted.
+pub fn revision_is_safe(rev: &str) -> bool {
+    !rev.is_empty() && !rev.starts_with('-')
+}
+
+/// Whether an HTTP source embeds user information that Git would persist.
+///
+/// Tokens in clone URLs are commonly written as a username, a password, or
+/// both. Git records the URL in `.git/config`, and maki also records the source
+/// in its lockfile. Reject that form and let Git's credential helper provide
+/// credentials without putting them on disk as part of the repository URL.
+pub fn http_source_has_userinfo(src: &str) -> bool {
+    let Some((scheme, rest)) = src.trim().split_once("://") else {
+        return false;
+    };
+    if !scheme.eq_ignore_ascii_case("http") && !scheme.eq_ignore_ascii_case("https") {
+        return false;
+    }
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+    authority.contains('@')
+}
+
+pub fn fetch_args(empty_hooks_dir: &Path) -> Vec<String> {
+    let mut args = hardening_args(empty_hooks_dir);
+    args.extend([
+        "fetch".to_owned(),
+        "--tags".to_owned(),
+        "--prune".to_owned(),
+    ]);
+    args
+}
+
+pub fn checkout_args(empty_hooks_dir: &Path, rev: &str) -> Vec<String> {
+    let mut args = hardening_args(empty_hooks_dir);
+    args.extend(["checkout".to_owned(), "--detach".to_owned(), rev.to_owned()]);
+    args
+}
+
+pub fn rev_parse_args(empty_hooks_dir: &Path, rev: &str) -> Vec<String> {
+    let mut args = hardening_args(empty_hooks_dir);
+    args.extend(["rev-parse".to_owned(), rev.to_owned()]);
+    args
+}
+
+pub fn list_tags_args(empty_hooks_dir: &Path) -> Vec<String> {
+    let mut args = hardening_args(empty_hooks_dir);
+    args.extend(["tag".to_owned(), "--list".to_owned()]);
+    args
+}
+
+/// Environment every invocation runs with. Disabling the terminal prompt makes
+/// a credential request fail immediately instead of hanging a startup on a
+/// prompt nobody is watching.
+pub fn hardening_env() -> [(&'static str, &'static str); 2] {
+    [("GIT_TERMINAL_PROMPT", "0"), ("GIT_ASKPASS", "")]
+}
+
+/// What one git invocation produced.
+#[derive(Debug, Clone)]
+pub struct GitOutput {
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GitError {
+    #[error("git is not installed or not on PATH")]
+    Missing,
+    #[error("git {args} failed with status {status}: {stderr}")]
+    Failed {
+        args: String,
+        status: String,
+        stderr: String,
+    },
+}
+
+/// Hides credentials embedded in a URL, so an error message can be shown or
+/// logged without leaking a token that was only ever meant for git.
+pub fn redact(text: &str) -> String {
+    text.split_inclusive(char::is_whitespace)
+        .map(|part| {
+            let word = part.trim_end_matches(char::is_whitespace);
+            let whitespace = &part[word.len()..];
+            let redacted = match word.split_once("://") {
+                Some((scheme, rest)) => match rest.rsplit_once('@') {
+                    Some((_creds, host)) => format!("{scheme}://***@{host}"),
+                    None => word.to_owned(),
+                },
+                None => word.to_owned(),
+            };
+            redacted + whitespace
+        })
+        .collect()
+}
+
+/// Runs git off the calling thread.
+///
+/// `maki.pack.add` runs while `init.lua` is being sourced, and `init.lua`
+/// executes on the single Lua thread inside an async call. A blocking
+/// `Command::output` there would stall the whole VM, the watchdog included, so
+/// every invocation goes through `smol::unblock` and the caller awaits it. On a
+/// first start a clone can take seconds, which is exactly when this matters.
+pub async fn run(args: Vec<String>, cwd: Option<PathBuf>) -> Result<GitOutput, GitError> {
+    let display = redact(&args.join(" "));
+    let output = smol::unblock(move || {
+        let mut cmd = std::process::Command::new("git");
+        cmd.args(&args);
+        if let Some(dir) = cwd {
+            cmd.current_dir(dir);
+        }
+        for (key, value) in hardening_env() {
+            cmd.env(key, value);
+        }
+        cmd.output()
+    })
+    .await;
+
+    let output = match output {
+        Ok(output) => output,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Err(GitError::Missing),
+        Err(e) => {
+            return Err(GitError::Failed {
+                args: display,
+                status: "not started".to_owned(),
+                stderr: e.to_string(),
+            });
+        }
+    };
+
+    if output.status.success() {
+        Ok(GitOutput {
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        })
+    } else {
+        Err(GitError::Failed {
+            args: display,
+            status: output.status.to_string(),
+            stderr: redact(String::from_utf8_lossy(&output.stderr).trim()),
+        })
+    }
+}
+
+/// Tag names, one per line, as `git tag --list` prints them.
+pub fn parse_tags(stdout: &str) -> Vec<&str> {
+    stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use test_case::test_case;
+
+    fn hooks() -> PathBuf {
+        PathBuf::from("/data/site/.nohooks")
+    }
+
+    fn hooks_flag_present(args: &[String]) -> bool {
+        args.windows(2)
+            .any(|w| w[0] == "-c" && w[1].starts_with("core.hooksPath="))
+    }
+
+    #[test]
+    fn git_cannot_open_an_interactive_credential_prompt() {
+        assert_eq!(
+            hardening_env(),
+            [("GIT_TERMINAL_PROMPT", "0"), ("GIT_ASKPASS", "")]
+        );
+    }
+
+    /// The hardening is the point of routing every command through here, so
+    /// each builder is checked rather than only the shared helper.
+    #[test]
+    fn every_command_disables_hooks() {
+        assert!(hooks_flag_present(&clone_args(
+            &hooks(),
+            "src",
+            Path::new("/dest"),
+            true
+        )));
+        assert!(hooks_flag_present(&fetch_args(&hooks())));
+        assert!(hooks_flag_present(&checkout_args(&hooks(), "main")));
+        assert!(hooks_flag_present(&rev_parse_args(&hooks(), "HEAD")));
+        assert!(hooks_flag_present(&list_tags_args(&hooks())));
+    }
+
+    /// The flags have to come before the subcommand, or git treats them as
+    /// arguments to it and the hardening silently does nothing.
+    #[test]
+    fn hardening_precedes_the_subcommand() {
+        let args = clone_args(&hooks(), "src", Path::new("/dest"), false);
+        let subcommand = args.iter().position(|a| a == "clone").unwrap();
+        let config = args.iter().position(|a| a == "-c").unwrap();
+        assert!(config < subcommand);
+    }
+
+    #[test]
+    fn partial_clone_is_opt_in_so_it_can_be_retried_without_it() {
+        let partial = clone_args(&hooks(), "src", Path::new("/dest"), true);
+        let full = clone_args(&hooks(), "src", Path::new("/dest"), false);
+        assert!(partial.iter().any(|a| a == "--filter=blob:none"));
+        assert!(!full.iter().any(|a| a == "--filter=blob:none"));
+    }
+
+    #[test]
+    fn checkout_detaches_so_no_branch_tracks_the_revision() {
+        let args = checkout_args(&hooks(), "abc123");
+        assert!(args.iter().any(|a| a == "--detach"));
+        assert_eq!(args.last().unwrap(), "abc123");
+    }
+
+    /// A source is a positional argument, so it must sit after `--`. Without
+    /// it, a src of `--upload-pack=...` is an option git will act on.
+    #[test]
+    fn clone_puts_the_source_after_an_option_terminator() {
+        let args = clone_args(&hooks(), "--upload-pack=evil", Path::new("/dest"), true);
+        let terminator = args.iter().position(|a| a == "--").expect("`--` required");
+        let src = args
+            .iter()
+            .position(|a| a == "--upload-pack=evil")
+            .expect("src present");
+        assert!(
+            terminator < src,
+            "a source that looks like an option must follow `--`: {args:?}"
+        );
+    }
+
+    /// A clone URL can carry a token. Errors are shown and logged, so the
+    /// credential must not travel with them.
+    #[test]
+    fn credentials_in_a_url_are_redacted() {
+        let out = redact("clone -- https://user:tok3n@github.com/u/r /dest");
+        assert!(!out.contains("tok3n"), "token leaked: {out}");
+        assert!(!out.contains("user:"), "user leaked: {out}");
+        assert!(out.contains("github.com/u/r"), "host should survive: {out}");
+        assert!(out.contains("/dest"));
+    }
+
+    #[test_case("https://token@example.com/repo", true ; "username_token")]
+    #[test_case("https://user:token@example.com/repo", true ; "password_token")]
+    #[test_case("HTTP://user@example.com/repo", true ; "scheme_case")]
+    #[test_case("https://example.com/user@repo", false ; "at_in_path")]
+    #[test_case("ssh://git@example.com/repo", false ; "ssh_username")]
+    #[test_case("git@example.com:user/repo", false ; "scp_style")]
+    fn detects_http_user_information(src: &str, expected: bool) {
+        assert_eq!(http_source_has_userinfo(src), expected);
+    }
+
+    #[test]
+    fn redaction_leaves_ordinary_urls_alone() {
+        let plain = "clone -- https://github.com/u/r /dest";
+        assert_eq!(redact(plain), plain);
+    }
+
+    #[test]
+    fn redaction_preserves_whitespace() {
+        let source = "/a path/with spaces\nand a second line";
+        assert_eq!(redact(source), source);
+    }
+
+    #[test]
+    fn revisions_that_look_like_options_are_rejected() {
+        assert!(revision_is_safe("main"));
+        assert!(revision_is_safe("v1.2.3"));
+        assert!(revision_is_safe("abc123"));
+        assert!(!revision_is_safe("--upload-pack=evil"));
+        assert!(!revision_is_safe("-x"));
+        assert!(!revision_is_safe(""));
+    }
+
+    #[test]
+    fn tags_are_parsed_one_per_line_ignoring_blanks() {
+        assert_eq!(
+            parse_tags("v1.0.0\n\nv1.1.0\n  \n"),
+            vec!["v1.0.0", "v1.1.0"]
+        );
+        assert!(parse_tags("").is_empty());
+    }
+
+    /// A failure has to name the command, the status, and git's own message,
+    /// or a user cannot tell a network problem from a bad revision.
+    #[test]
+    fn failure_reports_command_status_and_stderr() {
+        let err = GitError::Failed {
+            args: "clone x y".to_owned(),
+            status: "exit status: 128".to_owned(),
+            stderr: "repository not found".to_owned(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("clone x y"));
+        assert!(msg.contains("128"));
+        assert!(msg.contains("repository not found"));
+    }
+
+    /// Runs against a real repository built in a temp dir, so the runner is
+    /// exercised without touching the network.
+    #[test]
+    fn runs_git_against_a_local_repository() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let hooks = dir.path().join("nohooks");
+        std::fs::create_dir_all(&hooks).unwrap();
+
+        let init = smol::block_on(run(
+            vec!["init".to_owned(), "--quiet".to_owned()],
+            Some(dir.path().to_path_buf()),
+        ));
+        if init.is_err() {
+            return; // git is not available in this environment
+        }
+
+        let out = smol::block_on(run(list_tags_args(&hooks), Some(dir.path().to_path_buf())))
+            .expect("listing tags in a fresh repository should succeed");
+        assert!(parse_tags(&out.stdout).is_empty());
+    }
+
+    #[test]
+    fn a_failing_command_reports_rather_than_panicking() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let hooks = dir.path().join("nohooks");
+        std::fs::create_dir_all(&hooks).unwrap();
+
+        let result = smol::block_on(run(
+            rev_parse_args(&hooks, "definitely-not-a-ref"),
+            Some(dir.path().to_path_buf()),
+        ));
+        assert!(result.is_err(), "an unknown revision must be an error");
+    }
+}

--- a/maki-pack/src/lib.rs
+++ b/maki-pack/src/lib.rs
@@ -1,0 +1,18 @@
+//! Durable state for packages maki installs itself.
+//!
+//! This crate owns what is installed, at which commit, from which source, and
+//! what the user approved. It deliberately knows nothing about Lua: the runtime
+//! owns which packages a session has loaded, and the two never hold a second
+//! opinion about each other's facts.
+
+pub mod approvals;
+pub mod git;
+pub mod lock;
+pub mod lockfile;
+pub mod manager;
+pub mod paths;
+mod spec;
+mod version;
+
+pub use spec::{Spec, derive_name, name_is_safe};
+pub use version::Version;

--- a/maki-pack/src/lock.rs
+++ b/maki-pack/src/lock.rs
@@ -5,28 +5,26 @@
 //! the same clone, and two writing the lockfile would lose one another's
 //! entries.
 //!
-//! A lock is a file created exclusively, holding the pid of its owner. Holding
-//! it across a whole read-modify-write is what makes concurrent updates to
+//! The kernel owns the lock and releases it when the process dies. Holding it
+//! across a whole read-modify-write is what makes concurrent updates to
 //! different packages compose: atomic rename alone gives durability, not
 //! isolation.
 
 use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+
+use fs4::{FileExt, TryLockError};
 
 /// Held for as long as the operation runs. Dropping it releases the lock.
 #[derive(Debug)]
 pub struct Lock {
-    path: PathBuf,
+    _file: File,
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum LockError {
-    #[error(
-        "{path} is locked by process {pid}; if no such process is running, \
-         delete that file"
-    )]
-    Held { path: PathBuf, pid: u32 },
+    #[error("{path} is locked by another Maki process")]
+    Held { path: PathBuf },
     #[error("cannot lock {path}: {source}")]
     Io {
         path: PathBuf,
@@ -36,7 +34,7 @@ pub enum LockError {
 }
 
 impl Lock {
-    /// Takes the lock, or reports who holds it.
+    /// Takes the lock without waiting.
     ///
     /// This never waits. A caller that cannot proceed tells the user which
     /// operation is in the way, which is more useful than a startup that hangs
@@ -48,47 +46,27 @@ impl Lock {
                 source,
             })?;
         }
-        match Self::try_create(path) {
-            Ok(lock) => Ok(lock),
-            // Held by someone. Deliberately no automatic reclaim: two
-            // processes that both judged a lock stale would each remove it and
-            // create their own, and both would believe they held it, while
-            // either one's release would delete the other's file. A lock
-            // guarding a checkout is not worth that risk, so a leftover is
-            // reported with its path and the user clears it.
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Err(LockError::Held {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)
+            .map_err(|source| LockError::Io {
                 path: path.to_path_buf(),
-                pid: read_pid(path).unwrap_or(0),
+                source,
+            })?;
+        match FileExt::try_lock(&file) {
+            Ok(()) => Ok(Self { _file: file }),
+            Err(TryLockError::WouldBlock) => Err(LockError::Held {
+                path: path.to_path_buf(),
             }),
-            Err(source) => Err(LockError::Io {
+            Err(TryLockError::Error(source)) => Err(LockError::Io {
                 path: path.to_path_buf(),
                 source,
             }),
         }
     }
-
-    fn try_create(path: &Path) -> std::io::Result<Self> {
-        let mut file: File = OpenOptions::new().write(true).create_new(true).open(path)?;
-        let lock = Self {
-            path: path.to_path_buf(),
-        };
-        let result = write!(file, "{}", std::process::id()).and_then(|()| file.sync_all());
-        drop(file);
-        result?;
-        Ok(lock)
-    }
-}
-
-impl Drop for Lock {
-    fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
-    }
-}
-
-fn read_pid(path: &Path) -> Option<u32> {
-    let mut text = String::new();
-    File::open(path).ok()?.read_to_string(&mut text).ok()?;
-    text.trim().parse().ok()
 }
 
 #[cfg(test)]
@@ -116,33 +94,16 @@ mod tests {
 
         drop(Lock::acquire(&path).unwrap());
         Lock::acquire(&path).expect("a released lock should be free");
-        assert!(!path.exists(), "dropping a lock removes its file");
+        assert!(path.exists());
     }
 
-    /// A leftover lock is never reclaimed automatically, even when its owner is
-    /// plainly gone. Two processes that both judged it stale would each create
-    /// their own and both believe they held it, and either one's release would
-    /// delete the other's. The error names the file so a user can clear it.
     #[test]
-    fn a_leftover_lock_is_reported_rather_than_stolen() {
+    fn an_existing_unlocked_file_can_be_locked() {
         let dir = tempfile::TempDir::new().unwrap();
         let path = lock_path(&dir);
 
-        fs::write(&path, "999999").unwrap();
-        let err = Lock::acquire(&path).expect_err("a leftover lock must not be stolen");
-        let msg = err.to_string();
-        assert!(msg.contains("999999"), "names the owner: {msg}");
-        assert!(msg.contains("delete that file"), "says what to do: {msg}");
-    }
-
-    /// An unreadable lock is still held, and still names its path.
-    #[test]
-    fn an_unreadable_lock_is_treated_as_held() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let path = lock_path(&dir);
-
-        fs::write(&path, "not a pid").unwrap();
-        assert!(matches!(Lock::acquire(&path), Err(LockError::Held { .. })));
+        fs::write(&path, "left by an earlier process").unwrap();
+        Lock::acquire(&path).expect("file existence does not mean the lock is held");
     }
 
     #[test]

--- a/maki-pack/src/lock.rs
+++ b/maki-pack/src/lock.rs
@@ -1,0 +1,155 @@
+//! Advisory locks between maki processes.
+//!
+//! Several maki processes share one checkout directory, one lockfile, and one
+//! approval store. Without a lock, two starting at the same moment would race
+//! the same clone, and two writing the lockfile would lose one another's
+//! entries.
+//!
+//! A lock is a file created exclusively, holding the pid of its owner. Holding
+//! it across a whole read-modify-write is what makes concurrent updates to
+//! different packages compose: atomic rename alone gives durability, not
+//! isolation.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+/// Held for as long as the operation runs. Dropping it releases the lock.
+#[derive(Debug)]
+pub struct Lock {
+    path: PathBuf,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LockError {
+    #[error(
+        "{path} is locked by process {pid}; if no such process is running, \
+         delete that file"
+    )]
+    Held { path: PathBuf, pid: u32 },
+    #[error("cannot lock {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+impl Lock {
+    /// Takes the lock, or reports who holds it.
+    ///
+    /// This never waits. A caller that cannot proceed tells the user which
+    /// operation is in the way, which is more useful than a startup that hangs
+    /// on a lock nobody is watching.
+    pub fn acquire(path: &Path) -> Result<Self, LockError> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|source| LockError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        }
+        match Self::try_create(path) {
+            Ok(lock) => Ok(lock),
+            // Held by someone. Deliberately no automatic reclaim: two
+            // processes that both judged a lock stale would each remove it and
+            // create their own, and both would believe they held it, while
+            // either one's release would delete the other's file. A lock
+            // guarding a checkout is not worth that risk, so a leftover is
+            // reported with its path and the user clears it.
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Err(LockError::Held {
+                path: path.to_path_buf(),
+                pid: read_pid(path).unwrap_or(0),
+            }),
+            Err(source) => Err(LockError::Io {
+                path: path.to_path_buf(),
+                source,
+            }),
+        }
+    }
+
+    fn try_create(path: &Path) -> std::io::Result<Self> {
+        let mut file: File = OpenOptions::new().write(true).create_new(true).open(path)?;
+        let lock = Self {
+            path: path.to_path_buf(),
+        };
+        let result = write!(file, "{}", std::process::id()).and_then(|()| file.sync_all());
+        drop(file);
+        result?;
+        Ok(lock)
+    }
+}
+
+impl Drop for Lock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn read_pid(path: &Path) -> Option<u32> {
+    let mut text = String::new();
+    File::open(path).ok()?.read_to_string(&mut text).ok()?;
+    text.trim().parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lock_path(dir: &tempfile::TempDir) -> PathBuf {
+        dir.path().join("pack.lock")
+    }
+
+    #[test]
+    fn a_second_acquire_reports_the_holder_instead_of_waiting() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = lock_path(&dir);
+
+        let _held = Lock::acquire(&path).unwrap();
+        let err = Lock::acquire(&path).expect_err("a held lock must not be taken twice");
+        assert!(matches!(err, LockError::Held { .. }), "got: {err}");
+    }
+
+    #[test]
+    fn releasing_lets_the_next_caller_take_it() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = lock_path(&dir);
+
+        drop(Lock::acquire(&path).unwrap());
+        Lock::acquire(&path).expect("a released lock should be free");
+        assert!(!path.exists(), "dropping a lock removes its file");
+    }
+
+    /// A leftover lock is never reclaimed automatically, even when its owner is
+    /// plainly gone. Two processes that both judged it stale would each create
+    /// their own and both believe they held it, and either one's release would
+    /// delete the other's. The error names the file so a user can clear it.
+    #[test]
+    fn a_leftover_lock_is_reported_rather_than_stolen() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = lock_path(&dir);
+
+        fs::write(&path, "999999").unwrap();
+        let err = Lock::acquire(&path).expect_err("a leftover lock must not be stolen");
+        let msg = err.to_string();
+        assert!(msg.contains("999999"), "names the owner: {msg}");
+        assert!(msg.contains("delete that file"), "says what to do: {msg}");
+    }
+
+    /// An unreadable lock is still held, and still names its path.
+    #[test]
+    fn an_unreadable_lock_is_treated_as_held() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = lock_path(&dir);
+
+        fs::write(&path, "not a pid").unwrap();
+        assert!(matches!(Lock::acquire(&path), Err(LockError::Held { .. })));
+    }
+
+    #[test]
+    fn missing_parent_directory_is_created() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("nested").join("deep").join("pack.lock");
+        let _lock = Lock::acquire(&path).expect("the lock directory should be created");
+        assert!(path.exists());
+    }
+}

--- a/maki-pack/src/lockfile.rs
+++ b/maki-pack/src/lockfile.rs
@@ -1,0 +1,129 @@
+//! The exact commit of every managed package.
+//!
+//! Committing this file and running an install reproduces a package set on
+//! another machine, which is the whole reason it records commits rather than
+//! the `version` that produced them.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// One recorded package. The source is stored alongside the revision so a
+/// lockfile entry describes where its commit came from, not just what it was.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockEntry {
+    pub src: String,
+    pub rev: String,
+}
+
+/// A `BTreeMap` rather than a hash map, so the file serializes in a stable
+/// order and committing it does not produce noisy diffs.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Lockfile {
+    #[serde(default)]
+    packages: BTreeMap<String, LockEntry>,
+}
+
+impl Lockfile {
+    pub fn get(&self, name: &str) -> Option<&LockEntry> {
+        self.packages.get(name)
+    }
+
+    /// Records a package at a revision. Called only after the change on disk
+    /// succeeded, so a failed fetch never moves a recorded revision.
+    pub fn record(
+        &mut self,
+        name: impl Into<String>,
+        src: impl Into<String>,
+        rev: impl Into<String>,
+    ) {
+        self.packages.insert(
+            name.into(),
+            LockEntry {
+                src: src.into(),
+                rev: rev.into(),
+            },
+        );
+    }
+
+    pub fn remove(&mut self, name: &str) {
+        self.packages.remove(name);
+    }
+
+    /// Puts an entry back exactly as it was.
+    ///
+    /// An update drops the pin so `version` is resolved again. If that resolve
+    /// then fails, the pin has to return: a later operation in the same batch
+    /// writes the lockfile, and a package that is still on disk would
+    /// otherwise be recorded nowhere.
+    pub fn restore(&mut self, name: impl Into<String>, entry: LockEntry) {
+        self.packages.insert(name.into(), entry);
+    }
+
+    /// Names in the order they should be installed from a lockfile, which is
+    /// alphabetical so a first start costs the same on every machine.
+    pub fn install_order(&self) -> impl Iterator<Item = &str> {
+        self.packages.keys().map(String::as_str)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.packages.is_empty()
+    }
+
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+
+    pub fn from_json(text: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn filled() -> Lockfile {
+        let mut lock = Lockfile::default();
+        lock.record("zebra", "https://x/zebra", "ccc");
+        lock.record("alpha", "https://x/alpha", "aaa");
+        lock.record("mid", "https://x/mid", "bbb");
+        lock
+    }
+
+    /// Alphabetical, so a committed lockfile installs identically everywhere
+    /// and a first start has a predictable cost.
+    #[test]
+    fn install_order_is_alphabetical_not_insertion_order() {
+        assert_eq!(
+            filled().install_order().collect::<Vec<_>>(),
+            ["alpha", "mid", "zebra"]
+        );
+    }
+
+    #[test]
+    fn round_trips_through_json() {
+        let lock = filled();
+        let back = Lockfile::from_json(&lock.to_json().unwrap()).unwrap();
+        assert_eq!(back, lock);
+    }
+
+    /// The file is meant to be committed, so the same content must serialize
+    /// identically however it was built.
+    #[test]
+    fn serialization_is_stable_regardless_of_insertion_order() {
+        let mut other = Lockfile::default();
+        other.record("alpha", "https://x/alpha", "aaa");
+        other.record("mid", "https://x/mid", "bbb");
+        other.record("zebra", "https://x/zebra", "ccc");
+        assert_eq!(other.to_json().unwrap(), filled().to_json().unwrap());
+    }
+
+    #[test]
+    fn missing_packages_key_reads_as_empty() {
+        assert_eq!(
+            Lockfile::from_json("{}").unwrap().install_order().count(),
+            0
+        );
+    }
+}

--- a/maki-pack/src/lockfile.rs
+++ b/maki-pack/src/lockfile.rs
@@ -50,24 +50,10 @@ impl Lockfile {
         self.packages.remove(name);
     }
 
-    /// Puts an entry back exactly as it was.
-    ///
-    /// An update drops the pin so `version` is resolved again. If that resolve
-    /// then fails, the pin has to return: a later operation in the same batch
-    /// writes the lockfile, and a package that is still on disk would
-    /// otherwise be recorded nowhere.
-    pub fn restore(&mut self, name: impl Into<String>, entry: LockEntry) {
-        self.packages.insert(name.into(), entry);
-    }
-
     /// Names in the order they should be installed from a lockfile, which is
     /// alphabetical so a first start costs the same on every machine.
     pub fn install_order(&self) -> impl Iterator<Item = &str> {
         self.packages.keys().map(String::as_str)
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.packages.is_empty()
     }
 
     pub fn to_json(&self) -> Result<String, serde_json::Error> {

--- a/maki-pack/src/manager.rs
+++ b/maki-pack/src/manager.rs
@@ -1,0 +1,1142 @@
+//! Installing, updating, and removing managed packages.
+//!
+//! The lockfile is the single source of truth for which revision of a package
+//! is active. Nothing else records it, so nothing else can disagree with it,
+//! and a package resolves straight to `core/<name>/<sha>` without the tree
+//! having to be searched.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::git::{self, GitError};
+use crate::lock::{Lock, LockError};
+use crate::lockfile::Lockfile;
+use crate::paths;
+use crate::spec::Spec;
+use crate::version::{Version, best_match};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ManagerError {
+    #[error(transparent)]
+    Git(#[from] GitError),
+    #[error(transparent)]
+    Lock(#[from] LockError),
+    #[error("no tag satisfies {constraint} in {src} (tags considered: {tags})")]
+    NoMatchingVersion {
+        constraint: String,
+        src: String,
+        tags: String,
+    },
+    #[error("package name {name:?} (from {src:?}) is not a usable directory name")]
+    UnsafeName { name: String, src: String },
+    #[error("revision {rev:?} would be read by git as an option")]
+    UnsafeRevision { rev: String },
+    #[error(
+        "package source {src:?} contains HTTP credentials; use a Git credential helper instead"
+    )]
+    UnsafeSource { src: String },
+    #[error("package {name:?} is not on disk, and fetching it was not allowed")]
+    Unavailable { name: String },
+    #[error("io error on {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// A package that is on disk and ready to load.
+#[derive(Debug, Clone)]
+pub struct Installed {
+    pub rev: String,
+    /// Absolute path of the revision directory this session should load.
+    pub dir: PathBuf,
+    /// True when this call installed or moved the package, so the caller knows
+    /// whether to fire `PackChanged`.
+    pub changed: bool,
+}
+
+/// Where a clone keeps the refs that `git fetch` actually moves.
+const REMOTE_PREFIX: &str = "refs/remotes/origin/";
+/// What the default branch resolves against. See `resolve_revision`.
+const REMOTE_HEAD: &str = "refs/remotes/origin/HEAD";
+
+/// How far an install may go to reach the remote.
+///
+/// One ordered concept rather than two independent flags, because the useful
+/// answers form a scale: never contact the remote, contact it only for what is
+/// missing, or contact it every time. Two booleans would also admit the
+/// meaningless combination "offline but fetch first".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Refresh {
+    /// Never contact the remote. Resolves against the refs already on disk,
+    /// and fails when there is no working copy to resolve against.
+    Never,
+    /// Clone when there is no working copy, and otherwise leave refs alone.
+    /// This is the steady state: an install that is already recorded and
+    /// materialized makes no git call at all.
+    IfMissing,
+    /// Fetch before resolving. An update needs this. Without it `version`
+    /// would be resolved against the refs that were current when the package
+    /// was cloned, so an update could never find a newer commit or tag.
+    Always,
+}
+
+pub struct Manager {
+    site: PathBuf,
+}
+
+impl Manager {
+    pub fn new(site: impl Into<PathBuf>) -> Self {
+        Self { site: site.into() }
+    }
+
+    /// Where a package's revision lives, without touching the network.
+    ///
+    /// Startup uses this: a package already recorded in the lockfile resolves
+    /// to a directory with no git call at all, which is what keeps a steady
+    /// state start offline.
+    pub fn resolve(&self, lock: &Lockfile, name: &str) -> Option<PathBuf> {
+        // The lockfile is a file on disk that a user edits and commits, so its
+        // contents are input, not fact. Both halves become path components, and
+        // an absolute or traversing value would point this outside the site
+        // directory entirely.
+        if !crate::spec::name_is_safe(name) {
+            return None;
+        }
+        let entry = lock.get(name)?;
+        if !revision_is_safe_component(&entry.rev) {
+            return None;
+        }
+        let dir = paths::revision_dir(&self.site, name, &entry.rev);
+        dir.is_dir().then_some(dir)
+    }
+
+    /// Makes sure a package is on disk, cloning and checking out if needed.
+    ///
+    /// When the lockfile already records a revision, that revision is used and
+    /// `version` is not consulted. That is what makes a committed lockfile
+    /// reproduce a package set rather than re-resolving to something newer.
+    pub async fn ensure_installed(
+        &self,
+        spec: &Spec,
+        lock: &mut Lockfile,
+    ) -> Result<Installed, ManagerError> {
+        self.install(spec, lock, Refresh::IfMissing).await
+    }
+
+    /// `ensure_installed` with the remote policy stated explicitly.
+    ///
+    /// `/packupdate` passes `Refresh::Always`, `++offline` passes
+    /// `Refresh::Never`, and startup keeps the `IfMissing` default.
+    pub async fn install(
+        &self,
+        spec: &Spec,
+        lock: &mut Lockfile,
+        refresh: Refresh,
+    ) -> Result<Installed, ManagerError> {
+        if git::http_source_has_userinfo(&spec.src) {
+            return Err(ManagerError::UnsafeSource {
+                src: git::redact(&spec.src),
+            });
+        }
+        self.check_name(&spec.name, &spec.src)?;
+
+        // The recorded source must match before an installed directory counts.
+        // Pointing a name at a different repository has to fetch that
+        // repository, not keep serving whatever was installed under the name.
+        let source_matches = lock
+            .get(&spec.name)
+            .is_some_and(|entry| entry.src == spec.src);
+
+        // `Always` is the caller asking whether something newer exists, so the
+        // recorded revision being on disk is not an answer to that question.
+        if refresh != Refresh::Always
+            && source_matches
+            && let Some(dir) = self.resolve(lock, &spec.name)
+        {
+            let rev = lock
+                .get(&spec.name)
+                .expect("resolved from this entry")
+                .rev
+                .clone();
+            return Ok(Installed {
+                rev,
+                dir,
+                changed: false,
+            });
+        }
+
+        let _guard = Lock::acquire(&paths::package_lock(&self.site, &spec.name))?;
+        let hooks = self.hooks_dir()?;
+        let work = self.work_dir(&spec.name);
+
+        // A cached working copy is only reusable if it is a copy of the source
+        // being asked for. Reusing one by name alone would materialize the old
+        // repository's code while recording the new source.
+        if work.join(".git").is_dir() && !self.work_matches_source(&work, &spec.src).await {
+            fs::remove_dir_all(&work).map_err(|source| ManagerError::Io {
+                path: work.clone(),
+                source,
+            })?;
+        }
+        if !work.join(".git").is_dir() {
+            if refresh == Refresh::Never {
+                return Err(ManagerError::Unavailable {
+                    name: spec.name.clone(),
+                });
+            }
+            self.clone_into(&hooks, &spec.src, &work).await?;
+        } else if refresh == Refresh::Always {
+            // A fresh clone already has current refs, so this is only for the
+            // working copy that was cloned some time ago.
+            git::run(git::fetch_args(&hooks), Some(work.clone())).await?;
+        }
+
+        // A recorded revision wins over `version`, even when nothing is on disk
+        // yet. That is the case a lockfile exists for: a fresh machine must get
+        // the commit that was committed, not whatever `version` resolves to
+        // today. Only a matching source counts, since a changed source makes
+        // the old revision meaningless.
+        let recorded = lock
+            .get(&spec.name)
+            .filter(|entry| entry.src == spec.src)
+            .map(|entry| {
+                if revision_is_safe_component(&entry.rev) {
+                    Ok(entry.rev.clone())
+                } else {
+                    Err(ManagerError::UnsafeRevision {
+                        rev: entry.rev.clone(),
+                    })
+                }
+            })
+            .transpose()?;
+
+        let rev = match recorded {
+            Some(rev) => rev,
+            None => self.resolve_revision(&hooks, &work, spec).await?,
+        };
+        let dest = paths::revision_dir(&self.site, &spec.name, &rev);
+        if !dest.is_dir() {
+            self.materialize(&hooks, &work, &rev, &dest).await?;
+        }
+
+        lock.record(&spec.name, &spec.src, &rev);
+        Ok(Installed {
+            rev,
+            dir: dest,
+            changed: true,
+        })
+    }
+
+    /// Rejects a name that would not stay inside the package root.
+    ///
+    /// Every path this type builds is `<site>/pack/core/<name>/...`, and an
+    /// absolute or traversing name escapes that entirely, so this is checked
+    /// before any directory is created or removed.
+    fn check_name(&self, name: &str, src: &str) -> Result<(), ManagerError> {
+        if crate::spec::name_is_safe(name) {
+            Ok(())
+        } else {
+            Err(ManagerError::UnsafeName {
+                name: name.to_owned(),
+                src: git::redact(src),
+            })
+        }
+    }
+
+    /// Removes every revision of a package, and its lockfile entry.
+    pub fn remove(&self, name: &str, lock: &mut Lockfile) -> Result<(), ManagerError> {
+        self.check_name(name, "")?;
+        let _guard = Lock::acquire(&paths::package_lock(&self.site, name))?;
+        let root = paths::package_root(&self.site, name);
+        if root.exists() {
+            fs::remove_dir_all(&root).map_err(|source| ManagerError::Io {
+                path: root.clone(),
+                source,
+            })?;
+        }
+        lock.remove(name);
+        Ok(())
+    }
+
+    /// Whether a cached working copy points at the source being asked for.
+    ///
+    /// A copy whose remote cannot be read is treated as not matching, so the
+    /// safe outcome is a fresh clone rather than code from an unknown origin.
+    async fn work_matches_source(&self, work: &Path, src: &str) -> bool {
+        let args = vec![
+            "remote".to_owned(),
+            "get-url".to_owned(),
+            "origin".to_owned(),
+        ];
+        match git::run(args, Some(work.to_path_buf())).await {
+            Ok(out) => out.stdout.trim() == src.trim(),
+            Err(_) => false,
+        }
+    }
+
+    /// The bare working copy git operates on. Revisions are copied out of it,
+    /// so no session ever reads a directory git is mutating.
+    fn work_dir(&self, name: &str) -> PathBuf {
+        paths::package_root(&self.site, name).join(".work")
+    }
+
+    fn hooks_dir(&self) -> Result<PathBuf, ManagerError> {
+        let dir = paths::empty_hooks_dir(&self.site);
+        fs::create_dir_all(&dir).map_err(|source| ManagerError::Io {
+            path: dir.clone(),
+            source,
+        })?;
+        Ok(dir)
+    }
+
+    async fn clone_into(&self, hooks: &Path, src: &str, work: &Path) -> Result<(), ManagerError> {
+        if let Some(parent) = work.parent() {
+            fs::create_dir_all(parent).map_err(|source| ManagerError::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        // A blobless clone is much smaller, but an older server refuses the
+        // filter outright, so fall back to a full clone rather than failing.
+        match git::run(git::clone_args(hooks, src, work, true), None).await {
+            Ok(_) => Ok(()),
+            Err(_) => {
+                let _ = fs::remove_dir_all(work);
+                git::run(git::clone_args(hooks, src, work, false), None).await?;
+                Ok(())
+            }
+        }
+    }
+
+    async fn resolve_revision(
+        &self,
+        hooks: &Path,
+        work: &Path,
+        spec: &Spec,
+    ) -> Result<String, ManagerError> {
+        let rev = match &spec.version {
+            // Deliberately not plain `HEAD`. The working copy is a clone, and
+            // `git fetch` updates remote-tracking refs without moving the
+            // local branch or `HEAD`, so `HEAD` answers with the commit that
+            // was current when the package was cloned no matter how many
+            // times it is fetched. The remote's own head is what follows the
+            // default branch.
+            Version::DefaultBranch => REMOTE_HEAD.to_owned(),
+            Version::Rev(rev) => rev.clone(),
+            Version::Range(req) => {
+                let tags = git::run(git::list_tags_args(hooks), Some(work.to_path_buf())).await?;
+                let names = git::parse_tags(&tags.stdout);
+                match best_match(req, names.iter().copied()) {
+                    Some(tag) => tag.to_owned(),
+                    None => {
+                        return Err(ManagerError::NoMatchingVersion {
+                            constraint: req.to_string(),
+                            src: git::redact(&spec.src),
+                            tags: names.join(", "),
+                        });
+                    }
+                }
+            }
+        };
+
+        // Tried in order, first one that resolves wins.
+        //
+        // A branch name has the same problem the default branch has: `git
+        // fetch` moves `refs/remotes/origin/<branch>` and leaves the local
+        // branch where it was, so `version = "main"` would pin the commit that
+        // was current at clone time for ever. A tag or a commit is not a
+        // remote-tracking ref, and falls through to the literal name.
+        let candidates: Vec<String> = match &spec.version {
+            // A clone with no `origin/HEAD` is unusual but legal, and then the
+            // local head is the only answer there is.
+            Version::DefaultBranch => vec![REMOTE_HEAD.to_owned(), "HEAD".to_owned()],
+            Version::Rev(_) => remote_branch_ref(&rev)
+                .into_iter()
+                .chain(std::iter::once(rev.clone()))
+                .collect(),
+            Version::Range(_) => vec![rev.clone()],
+        };
+
+        let mut last = None;
+        for candidate in &candidates {
+            if !git::revision_is_safe(candidate) {
+                return Err(ManagerError::UnsafeRevision {
+                    rev: candidate.clone(),
+                });
+            }
+            match git::run(
+                git::rev_parse_args(hooks, candidate),
+                Some(work.to_path_buf()),
+            )
+            .await
+            {
+                Ok(out) => return Ok(out.stdout.trim().to_owned()),
+                Err(e) => last = Some(e),
+            }
+        }
+        Err(last.expect("at least one candidate is always tried").into())
+    }
+
+    /// Builds the revision directory. It is written under a temporary name and
+    /// renamed, so a session never sees a half-populated revision.
+    async fn materialize(
+        &self,
+        hooks: &Path,
+        work: &Path,
+        rev: &str,
+        dest: &Path,
+    ) -> Result<(), ManagerError> {
+        git::run(git::checkout_args(hooks, rev), Some(work.to_path_buf())).await?;
+
+        let staging = dest.with_extension("incoming");
+        let _ = fs::remove_dir_all(&staging);
+        copy_tree(work, &staging).map_err(|source| ManagerError::Io {
+            path: staging.clone(),
+            source,
+        })?;
+        fs::rename(&staging, dest).map_err(|source| ManagerError::Io {
+            path: dest.to_path_buf(),
+            source,
+        })?;
+        Ok(())
+    }
+}
+
+fn remote_branch_ref(rev: &str) -> Option<String> {
+    if let Some(name) = rev.strip_prefix("refs/heads/") {
+        return Some(format!("{REMOTE_PREFIX}{name}"));
+    }
+    (!rev.starts_with("refs/") && rev != "HEAD").then(|| format!("{REMOTE_PREFIX}{rev}"))
+}
+
+/// A revision directory name. Revisions are recorded from `git rev-parse`, so a
+/// real one is a hex object id; anything else came from a hand-edited lockfile.
+fn revision_is_safe_component(rev: &str) -> bool {
+    !rev.is_empty() && rev.chars().all(|c| c.is_ascii_alphanumeric())
+}
+
+/// Copies a checkout without its `.git` directory, so a revision holds only the
+/// package's files and nothing that git would later mutate.
+fn copy_tree(from: &Path, to: &Path) -> std::io::Result<()> {
+    let root = from.canonicalize()?;
+    copy_tree_with_root(from, to, &root)
+}
+
+fn copy_tree_with_root(from: &Path, to: &Path, root: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        if name == ".git" {
+            continue;
+        }
+        let src = entry.path();
+        let dst = to.join(&name);
+        let meta = fs::symlink_metadata(&src)?;
+        if meta.file_type().is_symlink() {
+            let target = fs::read_link(&src)?;
+            let Some(parent) = src.parent() else {
+                continue;
+            };
+            let Ok(resolved) = parent.join(&target).canonicalize() else {
+                continue;
+            };
+            if target.is_absolute() || !resolved.starts_with(root) {
+                // Dropped, not followed: a link out of the checkout would make
+                // the package read or shadow a file the user never installed.
+                // Reported, because a package silently missing a file is far
+                // harder to diagnose than one that says what it left behind.
+                tracing::warn!(
+                    link = %src.display(),
+                    target = %target.display(),
+                    "package symlink leaves the package; it was not copied"
+                );
+                continue;
+            }
+            copy_symlink(&target, &dst, resolved.is_dir())?;
+            continue;
+        }
+        if meta.is_dir() {
+            copy_tree_with_root(&src, &dst, root)?;
+        } else {
+            fs::copy(&src, &dst)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn copy_symlink(target: &Path, dest: &Path, _is_dir: bool) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, dest)
+}
+
+#[cfg(windows)]
+fn copy_symlink(target: &Path, dest: &Path, is_dir: bool) -> std::io::Result<()> {
+    if is_dir {
+        std::os::windows::fs::symlink_dir(target, dest)
+    } else {
+        std::os::windows::fs::symlink_file(target, dest)
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn copy_symlink(_target: &Path, _dest: &Path, _is_dir: bool) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "copying symbolic links is unsupported",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    fn site() -> tempfile::TempDir {
+        tempfile::TempDir::new().unwrap()
+    }
+
+    #[test]
+    fn unnamed_source_is_rejected_rather_than_guessed() {
+        let dir = site();
+        let mgr = Manager::new(dir.path());
+        let spec = Spec::new("").with_name("");
+        let mut lock = Lockfile::default();
+
+        let err = smol::block_on(mgr.ensure_installed(&spec, &mut lock))
+            .expect_err("a package with no name cannot be installed");
+        assert!(matches!(err, ManagerError::UnsafeName { .. }), "got: {err}");
+    }
+
+    #[test]
+    fn http_credentials_are_rejected_before_clone() {
+        let dir = site();
+        let mgr = Manager::new(dir.path());
+        let spec = Spec::new("https://user:secret@example.com/repo");
+        let mut lock = Lockfile::default();
+
+        let error = smol::block_on(mgr.ensure_installed(&spec, &mut lock))
+            .expect_err("credentials must not reach Git or the lockfile");
+
+        assert!(matches!(error, ManagerError::UnsafeSource { .. }));
+        assert!(
+            !error.to_string().contains("secret"),
+            "credential leaked: {error}"
+        );
+        assert!(lock.get(&spec.name).is_none());
+    }
+
+    /// Every path is built as `<site>/pack/core/<name>/...`, and `Path::join`
+    /// replaces the base when the name is absolute, so an unchecked name puts
+    /// `remove_dir_all` anywhere on the filesystem.
+    #[test_case("/etc" ; "absolute")]
+    #[test_case("../../etc" ; "traversal")]
+    #[test_case(".." ; "parent")]
+    #[test_case("a/b" ; "separator")]
+    #[test_case(".hidden" ; "leading_dot_collides_with_work_dir")]
+    #[test_case("" ; "empty")]
+    fn unsafe_package_names_are_refused(name: &str) {
+        let dir = site();
+        let mgr = Manager::new(dir.path());
+        let mut lock = Lockfile::default();
+        let spec = Spec::new("https://x/demo").with_name(name);
+
+        assert!(
+            matches!(
+                smol::block_on(mgr.ensure_installed(&spec, &mut lock)),
+                Err(ManagerError::UnsafeName { .. })
+            ),
+            "{name:?} must not become a package directory"
+        );
+        assert!(
+            matches!(
+                mgr.remove(name, &mut lock),
+                Err(ManagerError::UnsafeName { .. })
+            ),
+            "{name:?} must not be removable either"
+        );
+    }
+
+    /// The name check has to run before anything is created or deleted, so a
+    /// refused name leaves no trace outside the site directory.
+    #[test]
+    fn a_refused_name_creates_nothing() {
+        let dir = site();
+        let outside = dir.path().join("outside");
+        fs::create_dir_all(&outside).unwrap();
+
+        let site_dir = dir.path().join("site");
+        let mgr = Manager::new(&site_dir);
+        let mut lock = Lockfile::default();
+        let spec = Spec::new("https://x/demo").with_name("../outside");
+
+        let _ = smol::block_on(mgr.ensure_installed(&spec, &mut lock));
+        let _ = mgr.remove("../outside", &mut lock);
+        assert!(outside.is_dir(), "a refused name must not touch anything");
+    }
+
+    #[test]
+    fn a_revision_that_looks_like_an_option_is_refused() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), None);
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(origin.display().to_string())
+            .with_name("demo")
+            .with_version(Version::Rev("--upload-pack=evil".to_owned()));
+
+        let err = smol::block_on(mgr.ensure_installed(&spec, &mut lock))
+            .expect_err("a revision starting with a dash must not reach git");
+        assert!(
+            matches!(err, ManagerError::UnsafeRevision { .. }),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn an_invalid_recorded_revision_is_not_re_resolved() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), None);
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let src = origin.display().to_string();
+        lock.record("demo", &src, "../invalid");
+        let spec = Spec::new(src).with_name("demo");
+
+        let err = smol::block_on(mgr.ensure_installed(&spec, &mut lock))
+            .expect_err("an invalid lock revision must not resolve a replacement");
+
+        assert!(matches!(err, ManagerError::UnsafeRevision { .. }));
+        assert_eq!(lock.get("demo").unwrap().rev, "../invalid");
+    }
+
+    /// A recorded revision that exists on disk resolves with no git call, which
+    /// is what keeps a steady state start offline.
+    #[test]
+    fn resolve_finds_a_recorded_revision_without_touching_git() {
+        let dir = site();
+        let mgr = Manager::new(dir.path());
+        let mut lock = Lockfile::default();
+        lock.record("demo", "https://x/demo", "abc123");
+
+        assert!(mgr.resolve(&lock, "demo").is_none(), "not on disk yet");
+
+        fs::create_dir_all(paths::revision_dir(dir.path(), "demo", "abc123")).unwrap();
+        assert_eq!(
+            mgr.resolve(&lock, "demo").unwrap(),
+            paths::revision_dir(dir.path(), "demo", "abc123")
+        );
+    }
+
+    #[test]
+    fn an_already_installed_package_reports_no_change() {
+        let dir = site();
+        let mgr = Manager::new(dir.path());
+        let mut lock = Lockfile::default();
+        lock.record("demo", "https://x/demo", "abc123");
+        fs::create_dir_all(paths::revision_dir(dir.path(), "demo", "abc123")).unwrap();
+
+        let spec = Spec::new("https://x/demo").with_name("demo");
+        let installed = smol::block_on(mgr.ensure_installed(&spec, &mut lock)).unwrap();
+        assert!(!installed.changed);
+        assert_eq!(installed.rev, "abc123");
+    }
+
+    #[test]
+    fn removing_deletes_every_revision_and_the_lock_entry() {
+        let dir = site();
+        let mgr = Manager::new(dir.path());
+        let mut lock = Lockfile::default();
+        lock.record("demo", "https://x/demo", "aaa");
+        fs::create_dir_all(paths::revision_dir(dir.path(), "demo", "aaa")).unwrap();
+        fs::create_dir_all(paths::revision_dir(dir.path(), "demo", "bbb")).unwrap();
+
+        mgr.remove("demo", &mut lock).unwrap();
+        assert!(!paths::package_root(dir.path(), "demo").exists());
+        assert!(lock.get("demo").is_none());
+    }
+
+    #[test]
+    fn removing_a_package_that_was_never_installed_is_not_an_error() {
+        let dir = site();
+        let mgr = Manager::new(dir.path());
+        let mut lock = Lockfile::default();
+        mgr.remove("absent", &mut lock)
+            .expect("removing nothing succeeds");
+    }
+
+    /// Builds a real repository to install from, so the whole path runs
+    /// without the network.
+    ///
+    /// Failures panic rather than skipping. git is a hard requirement of this
+    /// feature and the repository under test is itself a git checkout, so a
+    /// missing git is a broken environment, not a reason to pass silently.
+    fn origin_repo(dir: &Path, tag: Option<&str>) -> PathBuf {
+        let repo = dir.join("origin");
+        fs::create_dir_all(repo.join("plugin")).unwrap();
+        fs::write(repo.join("plugin").join("init.lua"), "-- demo\n").unwrap();
+
+        let run = |args: Vec<&str>| {
+            smol::block_on(git::run(
+                args.iter().map(|a| (*a).to_owned()).collect(),
+                Some(repo.clone()),
+            ))
+            .unwrap_or_else(|e| panic!("git {args:?} failed while building the fixture: {e}"))
+        };
+        run(vec!["init", "--quiet"]);
+        run(vec!["config", "user.email", "t@example.com"]);
+        run(vec!["config", "user.name", "test"]);
+        run(vec!["add", "."]);
+        run(vec!["commit", "--quiet", "-m", "initial"]);
+        if let Some(tag) = tag {
+            run(vec!["tag", tag]);
+        }
+        repo
+    }
+
+    #[test]
+    fn installs_a_package_from_a_local_repository() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), None);
+
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(origin.display().to_string()).with_name("demo");
+
+        let installed = smol::block_on(mgr.ensure_installed(&spec, &mut lock))
+            .expect("a local repository should install");
+
+        assert!(installed.changed);
+        assert!(
+            installed.dir.join("plugin").join("init.lua").is_file(),
+            "the package files should be in the revision directory"
+        );
+        assert!(
+            !installed.dir.join(".git").exists(),
+            "a revision must not carry a git directory"
+        );
+        assert_eq!(
+            lock.get("demo").map(|e| e.rev.as_str()),
+            Some(installed.rev.as_str()),
+            "the installed revision is recorded"
+        );
+        assert!(
+            installed.dir.ends_with(&installed.rev),
+            "the directory is named for its revision"
+        );
+    }
+
+    /// A second call must not re-clone or move the package, which is what
+    /// makes a steady state start free.
+    #[test]
+    fn installing_twice_is_idempotent() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), None);
+
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(origin.display().to_string()).with_name("demo");
+
+        let first = smol::block_on(mgr.ensure_installed(&spec, &mut lock)).unwrap();
+        let second = smol::block_on(mgr.ensure_installed(&spec, &mut lock)).unwrap();
+
+        assert!(!second.changed, "the second call changes nothing");
+        assert_eq!(first.dir, second.dir);
+        assert_eq!(first.rev, second.rev);
+    }
+
+    /// Adds a commit to an existing fixture repository, so a test can ask
+    /// whether an update sees work that landed after the first install.
+    fn commit_more(repo: &Path, text: &str) {
+        fs::write(repo.join("plugin").join("more.lua"), text).unwrap();
+        for args in [vec!["add", "."], vec!["commit", "--quiet", "-m", "second"]] {
+            smol::block_on(git::run(
+                args.iter().map(|a| (*a).to_owned()).collect(),
+                Some(repo.to_path_buf()),
+            ))
+            .unwrap_or_else(|e| panic!("git {args:?} failed while extending the fixture: {e}"));
+        }
+    }
+
+    /// The update path has to fetch. The working copy is cloned once and then
+    /// kept, so resolving `version` against its refs without fetching would
+    /// find the revision that was current at clone time for ever, and an
+    /// update would silently do nothing.
+    #[test]
+    fn refresh_always_sees_a_commit_made_after_the_install() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), None);
+
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(origin.display().to_string()).with_name("demo");
+
+        let first = smol::block_on(mgr.ensure_installed(&spec, &mut lock)).unwrap();
+        commit_more(&origin, "-- more\n");
+
+        // Dropping the entry is what makes `version` be consulted again; the
+        // fetch is what makes that consultation see anything new.
+        lock.remove("demo");
+        let second = smol::block_on(mgr.install(&spec, &mut lock, Refresh::Always))
+            .expect("an update should install the newer commit");
+
+        assert_ne!(
+            first.rev, second.rev,
+            "the update must move to the commit made after the install"
+        );
+        assert!(
+            second.dir.join("plugin").join("more.lua").is_file(),
+            "the new file should be in the updated revision directory"
+        );
+        assert_eq!(lock.get("demo").unwrap().rev, second.rev);
+    }
+
+    /// A named branch has the same trap the default branch has: `git fetch`
+    /// moves the remote-tracking ref and leaves the local branch alone, so
+    /// resolving the bare name would pin the clone-time commit for ever.
+    #[test]
+    fn an_explicit_branch_follows_the_remote_not_the_local_branch() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), None);
+        let branch = default_branch(&origin);
+
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(origin.display().to_string())
+            .with_name("demo")
+            .with_version(Version::Rev(branch));
+
+        let first = smol::block_on(mgr.ensure_installed(&spec, &mut lock)).unwrap();
+        commit_more(&origin, "-- more\n");
+
+        lock.remove("demo");
+        let second = smol::block_on(mgr.install(&spec, &mut lock, Refresh::Always))
+            .expect("an update should follow the named branch");
+
+        assert_ne!(
+            first.rev, second.rev,
+            "a branch name must follow the remote, not the local checkout"
+        );
+    }
+
+    /// A tag is not a remote-tracking ref, so it has to resolve literally
+    /// rather than being lost to the branch lookup that runs first.
+    #[test]
+    fn an_explicit_tag_still_resolves() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), Some("v1.0.0"));
+
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(origin.display().to_string())
+            .with_name("demo")
+            .with_version(Version::Rev("v1.0.0".to_owned()));
+
+        smol::block_on(mgr.ensure_installed(&spec, &mut lock)).expect("a tag should install");
+    }
+
+    /// Whatever `git init` called the first branch here.
+    fn default_branch(repo: &Path) -> String {
+        let out = smol::block_on(git::run(
+            vec![
+                "rev-parse".to_owned(),
+                "--abbrev-ref".to_owned(),
+                "HEAD".to_owned(),
+            ],
+            Some(repo.to_path_buf()),
+        ))
+        .expect("the fixture has a branch");
+        out.stdout.trim().to_owned()
+    }
+
+    /// `++offline` resolves against refs that are already on disk. The commit
+    /// exists on the remote but was never fetched, so it must not be found.
+    #[test]
+    fn refresh_never_does_not_see_an_unfetched_commit() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), None);
+
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(origin.display().to_string()).with_name("demo");
+
+        let first = smol::block_on(mgr.ensure_installed(&spec, &mut lock)).unwrap();
+        commit_more(&origin, "-- more\n");
+
+        lock.remove("demo");
+        let offline = smol::block_on(mgr.install(&spec, &mut lock, Refresh::Never))
+            .expect("an offline update should still resolve what is on disk");
+
+        assert_eq!(
+            first.rev, offline.rev,
+            "offline must stay on the revision the local refs know about"
+        );
+    }
+
+    /// Nothing on disk and no permission to fetch is a refusal, not a clone.
+    #[test]
+    fn refresh_never_refuses_a_package_that_was_never_installed() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), None);
+
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(origin.display().to_string()).with_name("demo");
+
+        let err = smol::block_on(mgr.install(&spec, &mut lock, Refresh::Never))
+            .expect_err("offline cannot install a package for the first time");
+        assert!(
+            matches!(err, ManagerError::Unavailable { .. }),
+            "got: {err}"
+        );
+    }
+
+    /// A range picks the greatest matching tag, and the lockfile then pins the
+    /// commit rather than the constraint.
+    #[test]
+    fn a_version_range_resolves_to_a_tagged_commit() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), Some("v1.2.0"));
+
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(origin.display().to_string())
+            .with_name("demo")
+            .with_version(Version::range("^1").unwrap());
+
+        let installed = smol::block_on(mgr.ensure_installed(&spec, &mut lock))
+            .expect("^1 should resolve to v1.2.0");
+        assert!(installed.dir.join("plugin").join("init.lua").is_file());
+        assert_eq!(lock.get("demo").unwrap().rev, installed.rev);
+    }
+
+    /// The point of committing a lockfile: another machine, with nothing
+    /// installed, gets the recorded commit rather than re-resolving `version`.
+    #[test]
+    fn a_committed_lockfile_reproduces_the_recorded_commit_on_a_fresh_machine() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), Some("v1.0.0"));
+        let src = origin.display().to_string();
+
+        // Machine one installs and records a commit.
+        let first_site = dir.path().join("site-one");
+        let mgr = Manager::new(&first_site);
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(src.clone()).with_name("demo");
+        let first = smol::block_on(mgr.ensure_installed(&spec, &mut lock)).unwrap();
+
+        // A later commit lands upstream, so `version` would now resolve higher.
+        fs::write(origin.join("plugin").join("extra.lua"), "-- later\n").unwrap();
+        for args in [vec!["add", "."], vec!["commit", "--quiet", "-m", "later"]] {
+            smol::block_on(git::run(
+                args.iter().map(|a| (*a).to_owned()).collect(),
+                Some(origin.clone()),
+            ))
+            .unwrap();
+        }
+
+        // Machine two starts empty but carries the committed lockfile.
+        let second_site = dir.path().join("site-two");
+        let mgr2 = Manager::new(&second_site);
+        let second = smol::block_on(mgr2.ensure_installed(&spec, &mut lock)).unwrap();
+
+        assert_eq!(
+            second.rev, first.rev,
+            "a committed lockfile must reproduce its recorded commit"
+        );
+        assert!(
+            !second.dir.join("plugin").join("extra.lua").exists(),
+            "the later commit must not be installed"
+        );
+    }
+
+    /// A changed source makes the old revision meaningless, so it must not be
+    /// reused for a different repository.
+    #[test]
+    fn a_changed_source_ignores_the_recorded_revision() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), None);
+        let mgr = Manager::new(dir.path().join("site"));
+
+        let mut lock = Lockfile::default();
+        lock.record("demo", "https://elsewhere/other", "0123456789abcdef");
+
+        let spec = Spec::new(origin.display().to_string()).with_name("demo");
+        let installed = smol::block_on(mgr.ensure_installed(&spec, &mut lock))
+            .expect("a new source should resolve afresh");
+        assert_ne!(installed.rev, "0123456789abcdef");
+        assert_eq!(lock.get("demo").unwrap().src, spec.src);
+    }
+
+    /// Repointing a name at a different repository must install that
+    /// repository. Reusing the cached checkout would serve the old code while
+    /// recording the new source.
+    #[test]
+    fn repointing_a_name_at_another_repository_installs_the_new_one() {
+        let dir = site();
+        let first = origin_repo(dir.path(), None);
+
+        let site_dir = dir.path().join("site");
+        let mgr = Manager::new(&site_dir);
+        let mut lock = Lockfile::default();
+
+        let spec = Spec::new(first.display().to_string()).with_name("demo");
+        smol::block_on(mgr.ensure_installed(&spec, &mut lock)).unwrap();
+
+        // A second, genuinely different repository under the same name.
+        let second_root = dir.path().join("second");
+        fs::create_dir_all(&second_root).unwrap();
+        let second = origin_repo(&second_root, None);
+        fs::write(second.join("plugin").join("only_here.lua"), "-- new\n").unwrap();
+        for args in [vec!["add", "."], vec!["commit", "--quiet", "-m", "second"]] {
+            smol::block_on(git::run(
+                args.iter().map(|a| (*a).to_owned()).collect(),
+                Some(second.clone()),
+            ))
+            .unwrap();
+        }
+
+        let respec = Spec::new(second.display().to_string()).with_name("demo");
+        let installed = smol::block_on(mgr.ensure_installed(&respec, &mut lock))
+            .expect("a new source should install");
+
+        assert!(
+            installed.dir.join("plugin").join("only_here.lua").is_file(),
+            "the new repository's code must be installed"
+        );
+        assert_eq!(lock.get("demo").unwrap().src, respec.src);
+    }
+
+    #[test]
+    fn a_range_matching_no_tag_is_a_clear_error() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), Some("v1.2.0"));
+
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(origin.display().to_string())
+            .with_name("demo")
+            .with_version(Version::range("^9").unwrap());
+
+        let err = smol::block_on(mgr.ensure_installed(&spec, &mut lock))
+            .expect_err("no tag satisfies ^9");
+        assert!(
+            matches!(err, ManagerError::NoMatchingVersion { .. }),
+            "got: {err}"
+        );
+    }
+
+    /// The lockfile wins over `version`, which is what makes a committed
+    /// lockfile reproduce a package set instead of resolving something newer.
+    #[test]
+    fn a_recorded_revision_is_used_instead_of_resolving_version() {
+        let dir = site();
+        let origin = origin_repo(dir.path(), Some("v1.2.0"));
+
+        let mgr = Manager::new(dir.path().join("site"));
+        let mut lock = Lockfile::default();
+        let spec = Spec::new(origin.display().to_string()).with_name("demo");
+        let first = smol::block_on(mgr.ensure_installed(&spec, &mut lock)).unwrap();
+
+        // Same package, now asking for a range that would resolve elsewhere.
+        let ranged = Spec::new(origin.display().to_string())
+            .with_name("demo")
+            .with_version(Version::range("^1").unwrap());
+        let second = smol::block_on(mgr.ensure_installed(&ranged, &mut lock)).unwrap();
+
+        assert_eq!(second.rev, first.rev, "the recorded revision must win");
+        assert!(!second.changed);
+    }
+
+    /// The lockfile is committed and hand-edited, so its values are input. Both
+    /// halves become path components and must not escape the site directory.
+    #[test_case("/tmp/evil" ; "absolute_revision")]
+    #[test_case("../../evil" ; "traversing_revision")]
+    #[test_case("has/slash" ; "revision_with_separator")]
+    fn a_crafted_lockfile_revision_does_not_resolve(rev: &str) {
+        let dir = site();
+        let mgr = Manager::new(dir.path());
+        let mut lock = Lockfile::default();
+        lock.record("demo", "https://x/demo", rev);
+
+        // Make the escaped target exist, so only the guard can reject it.
+        let escaped = paths::revision_dir(dir.path(), "demo", rev);
+        let _ = fs::create_dir_all(&escaped);
+
+        assert!(
+            mgr.resolve(&lock, "demo").is_none(),
+            "revision {rev:?} must not resolve to a directory outside the package"
+        );
+    }
+
+    #[test]
+    fn a_crafted_lockfile_package_name_does_not_resolve() {
+        let dir = site();
+        let mgr = Manager::new(dir.path());
+        let mut lock = Lockfile::default();
+        lock.record("../escape", "https://x/demo", "abc123");
+        assert!(mgr.resolve(&lock, "../escape").is_none());
+    }
+
+    /// A repository can commit a symlink to any host file. `fs::copy` follows
+    /// one, which would copy that file's contents into the installed package
+    /// where the package's own Lua can read it.
+    #[cfg(unix)]
+    #[test]
+    fn copy_tree_does_not_follow_symlinks_out_of_the_tree() {
+        let dir = site();
+        let secret = dir.path().join("secret.txt");
+        fs::write(&secret, "sensitive").unwrap();
+
+        let from = dir.path().join("from");
+        fs::create_dir_all(&from).unwrap();
+        fs::write(from.join("real.lua"), "-- ok").unwrap();
+        std::os::unix::fs::symlink(&secret, from.join("leak.txt")).unwrap();
+
+        let to = dir.path().join("to");
+        copy_tree(&from, &to).unwrap();
+
+        assert!(to.join("real.lua").is_file(), "real files still copy");
+        assert!(
+            !to.join("leak.txt").exists(),
+            "a symlink must not be followed into the installed revision"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_tree_preserves_relative_symlinks_inside_the_tree() {
+        let dir = site();
+        let from = dir.path().join("from");
+        fs::create_dir_all(&from).unwrap();
+        fs::write(from.join("real.lua"), "-- ok").unwrap();
+        std::os::unix::fs::symlink("real.lua", from.join("linked.lua")).unwrap();
+
+        let to = dir.path().join("to");
+        copy_tree(&from, &to).unwrap();
+
+        assert_eq!(
+            fs::read_link(to.join("linked.lua")).unwrap(),
+            Path::new("real.lua")
+        );
+        assert_eq!(fs::read_to_string(to.join("linked.lua")).unwrap(), "-- ok");
+    }
+
+    #[test]
+    fn copy_tree_omits_the_git_directory() {
+        let dir = site();
+        let from = dir.path().join("from");
+        fs::create_dir_all(from.join(".git")).unwrap();
+        fs::create_dir_all(from.join("plugin")).unwrap();
+        fs::write(from.join(".git").join("HEAD"), "ref").unwrap();
+        fs::write(from.join("plugin").join("init.lua"), "-- x").unwrap();
+
+        let to = dir.path().join("to");
+        copy_tree(&from, &to).unwrap();
+
+        assert!(to.join("plugin").join("init.lua").is_file());
+        assert!(!to.join(".git").exists(), "a revision must not carry .git");
+    }
+}

--- a/maki-pack/src/manager.rs
+++ b/maki-pack/src/manager.rs
@@ -229,6 +229,34 @@ impl Manager {
         })
     }
 
+    pub async fn revision_log(
+        &self,
+        name: &str,
+        from: &str,
+        to: &str,
+    ) -> Result<Vec<String>, ManagerError> {
+        self.check_name(name, "")?;
+        for rev in [from, to] {
+            if !revision_is_safe_component(rev) {
+                return Err(ManagerError::UnsafeRevision {
+                    rev: rev.to_owned(),
+                });
+            }
+        }
+        let output = git::run(
+            git::log_args(&self.hooks_dir()?, from, to),
+            Some(self.work_dir(name)),
+        )
+        .await?;
+        Ok(output
+            .stdout
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(str::to_owned)
+            .collect())
+    }
+
     /// Rejects a name that would not stay inside the package root.
     ///
     /// Every path this type builds is `<site>/pack/core/<name>/...`, and an
@@ -564,17 +592,24 @@ mod tests {
     #[test]
     fn a_refused_name_creates_nothing() {
         let dir = site();
-        let outside = dir.path().join("outside");
-        fs::create_dir_all(&outside).unwrap();
-
         let site_dir = dir.path().join("site");
+        // Where `pack/core/../outside` actually lands. Guarding a different
+        // directory would leave this test passing with the guard removed.
+        let escaped = site_dir.join("pack").join("outside");
+        fs::create_dir_all(&escaped).unwrap();
+        fs::write(escaped.join("keep"), "mine").unwrap();
+
         let mgr = Manager::new(&site_dir);
         let mut lock = Lockfile::default();
         let spec = Spec::new("https://x/demo").with_name("../outside");
 
         let _ = smol::block_on(mgr.ensure_installed(&spec, &mut lock));
         let _ = mgr.remove("../outside", &mut lock);
-        assert!(outside.is_dir(), "a refused name must not touch anything");
+
+        assert!(
+            escaped.join("keep").is_file(),
+            "a refused name must not touch what it points at"
+        );
     }
 
     #[test]
@@ -1052,7 +1087,6 @@ mod tests {
 
     /// The lockfile is committed and hand-edited, so its values are input. Both
     /// halves become path components and must not escape the site directory.
-    #[test_case("/tmp/evil" ; "absolute_revision")]
     #[test_case("../../evil" ; "traversing_revision")]
     #[test_case("has/slash" ; "revision_with_separator")]
     fn a_crafted_lockfile_revision_does_not_resolve(rev: &str) {
@@ -1061,13 +1095,35 @@ mod tests {
         let mut lock = Lockfile::default();
         lock.record("demo", "https://x/demo", rev);
 
-        // Make the escaped target exist, so only the guard can reject it.
+        // The escaped target has to exist, or the guard is not what rejects it.
+        // Every case stays inside this temporary directory: a test must never
+        // create or reuse a path shared with the machine it runs on.
         let escaped = paths::revision_dir(dir.path(), "demo", rev);
-        let _ = fs::create_dir_all(&escaped);
+        fs::create_dir_all(&escaped)
+            .expect("the escaped target must exist for this to prove anything");
 
         assert!(
             mgr.resolve(&lock, "demo").is_none(),
             "revision {rev:?} must not resolve to a directory outside the package"
+        );
+    }
+
+    /// The absolute case needs a path built at run time, so it cannot be a
+    /// `test_case` string. It must point inside this test's own directory: an
+    /// absolute literal would make the test create or reuse a path on the
+    /// machine running it.
+    #[test]
+    fn an_absolute_lockfile_revision_does_not_resolve() {
+        let dir = site();
+        let mgr = Manager::new(dir.path());
+        let mut lock = Lockfile::default();
+        let escaped = dir.path().join("evil");
+        fs::create_dir_all(&escaped).expect("the escaped target must exist");
+        lock.record("demo", "https://x/demo", escaped.display().to_string());
+
+        assert!(
+            mgr.resolve(&lock, "demo").is_none(),
+            "an absolute revision must not resolve outside the package"
         );
     }
 

--- a/maki-pack/src/paths.rs
+++ b/maki-pack/src/paths.rs
@@ -1,0 +1,84 @@
+//! Where managed packages live on disk.
+//!
+//! Every revision gets its own directory and is never rewritten, so a session
+//! that resolved one revision keeps reading it even while an update installs
+//! another. There is no symlink to swap, which also means no Windows junction
+//! or privilege question: the layout is identical on every platform.
+
+use std::path::{Path, PathBuf};
+
+/// Group name reserved for packages maki installs. Manual discovery skips it,
+/// so a managed package is never also found by walking the tree.
+pub const MANAGED_GROUP: &str = "core";
+
+/// `<site>/pack/core/<name>`, holding one directory per installed revision.
+pub fn package_root(site: &Path, name: &str) -> PathBuf {
+    site.join("pack").join(MANAGED_GROUP).join(name)
+}
+
+/// `<site>/pack/core/<name>/<sha>`, the directory a session actually loads.
+pub fn revision_dir(site: &Path, name: &str, sha: &str) -> PathBuf {
+    package_root(site, name).join(sha)
+}
+
+/// An empty directory pointed at by `core.hooksPath`, so no repository hook can
+/// run during a clone, a fetch, or a checkout.
+pub fn empty_hooks_dir(site: &Path) -> PathBuf {
+    site.join(".nohooks")
+}
+
+/// Lock covering one package's checkouts.
+pub fn package_lock(site: &Path, name: &str) -> PathBuf {
+    site.join("pack")
+        .join(MANAGED_GROUP)
+        .join(format!("{name}.lock"))
+}
+
+/// Sidecar lock for a shared file, held across its whole read-modify-write.
+pub fn sidecar_lock(file: &Path) -> PathBuf {
+    let mut name = file.file_name().unwrap_or_default().to_os_string();
+    name.push(".lock");
+    file.with_file_name(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn site() -> PathBuf {
+        PathBuf::from("/data/site")
+    }
+
+    #[test]
+    fn revisions_are_siblings_under_one_package_root() {
+        let a = revision_dir(&site(), "demo", "aaa");
+        let b = revision_dir(&site(), "demo", "bbb");
+        assert_eq!(a.parent(), b.parent());
+        assert_eq!(a.parent().unwrap(), package_root(&site(), "demo"));
+        assert_ne!(a, b, "two revisions must not share a directory");
+    }
+
+    /// Managed packages live under the reserved group, which manual discovery
+    /// skips. If this ever changed, one package could get two identities.
+    #[test]
+    fn managed_packages_live_under_the_reserved_group() {
+        let root = package_root(&site(), "demo");
+        assert!(root.starts_with(site().join("pack").join(MANAGED_GROUP)));
+    }
+
+    #[test]
+    fn sidecar_lock_sits_beside_its_file() {
+        let lock = sidecar_lock(Path::new("/cfg/pack-lock.json"));
+        assert_eq!(lock, PathBuf::from("/cfg/pack-lock.json.lock"));
+    }
+
+    #[test]
+    fn package_lock_is_not_inside_the_package_root() {
+        let name = "demo";
+        let lock = package_lock(&site(), name);
+        assert!(
+            !lock.starts_with(package_root(&site(), name)),
+            "a lock inside the directory it guards would be removed with it"
+        );
+    }
+}

--- a/maki-pack/src/spec.rs
+++ b/maki-pack/src/spec.rs
@@ -1,0 +1,146 @@
+//! What a user declares when they add a package.
+
+use crate::version::Version;
+
+/// One package, as declared by `maki.pack.add`.
+///
+/// Field names and defaults follow Neovim's `vim.pack.Spec`, so a user moving
+/// from a Neovim plugin list does not have to translate anything.
+#[derive(Debug, Clone)]
+pub struct Spec {
+    /// Any URI `git clone` accepts.
+    pub src: String,
+    /// Directory and owner name. Derived from `src` when not given.
+    pub name: String,
+    pub version: Version,
+}
+
+impl Spec {
+    pub fn new(src: impl Into<String>) -> Self {
+        let src = src.into();
+        let name = derive_name(&src);
+        Self {
+            src,
+            name,
+            version: Version::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    #[must_use]
+    pub fn with_version(mut self, version: Version) -> Self {
+        self.version = version;
+        self
+    }
+}
+
+/// Whether a name is safe to use as a directory under the package root.
+///
+/// This is a security boundary, not a tidiness rule. A name becomes a path
+/// component, and `Path::join` *replaces* the base when given an absolute path,
+/// so a package called `/etc` would make the package root `/etc` and a removal
+/// would delete it. A name containing `..` escapes upward the same way.
+pub fn name_is_safe(name: &str) -> bool {
+    !name.is_empty()
+        && name != ".."
+        && !name.starts_with('.')
+        && !name.contains('/')
+        && !name.contains('\\')
+        && !name.contains('\0')
+        // A Windows drive prefix would also escape, and names are shared
+        // across platforms, so reject it everywhere rather than only there.
+        && !name.contains(':')
+        // A name has to be writable on a command line. `/packdel -demo` reads
+        // the word as an option, and `/packdel my pack` as two names, so a
+        // name that cannot survive either is refused at the point it is
+        // chosen rather than becoming a package nobody can remove.
+        && !name.starts_with('-')
+        && !name.starts_with('+')
+        && !name
+            .chars()
+            .any(|character| character.is_whitespace() || character.is_control())
+}
+
+/// The repository name in a git URI.
+///
+/// Handles the forms git itself accepts: https URLs, scp-style `host:path`, and
+/// plain paths, with or without a `.git` suffix or a trailing slash. An
+/// unusable `src` yields an empty name, which the caller rejects rather than
+/// guessing.
+pub fn derive_name(src: &str) -> String {
+    let trimmed = src.trim().trim_end_matches('/');
+    let last = trimmed
+        .rsplit(['/', ':'])
+        .find(|part| !part.is_empty())
+        .unwrap_or("");
+    last.strip_suffix(".git").unwrap_or(last).to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    #[test_case("https://github.com/user/repo", "repo" ; "https")]
+    #[test_case("https://github.com/user/repo.git", "repo" ; "https_with_git_suffix")]
+    #[test_case("https://github.com/user/repo/", "repo" ; "trailing_slash")]
+    #[test_case("https://github.com/user/repo.git/", "repo" ; "git_suffix_and_slash")]
+    #[test_case("git@github.com:user/repo.git", "repo" ; "scp_style")]
+    #[test_case("ssh://git@host/user/repo.git", "repo" ; "ssh_url")]
+    #[test_case("/srv/git/repo.git", "repo" ; "local_path")]
+    #[test_case("repo", "repo" ; "bare_name")]
+    #[test_case("https://example.com/a.b/my-plugin.nvim", "my-plugin.nvim" ; "dots_kept_when_not_git_suffix")]
+    fn derives_name_from_src(src: &str, expected: &str) {
+        assert_eq!(derive_name(src), expected);
+    }
+
+    #[test_case("repo", true ; "plain")]
+    #[test_case("my-plugin.nvim", true ; "dots_inside")]
+    #[test_case("under_score", true ; "underscore")]
+    #[test_case("", false ; "empty")]
+    #[test_case("..", false ; "parent")]
+    #[test_case("../escape", false ; "traversal")]
+    #[test_case("/etc", false ; "absolute")]
+    #[test_case("a/b", false ; "separator")]
+    #[test_case("a\\b", false ; "backslash")]
+    #[test_case("C:evil", false ; "drive_prefix")]
+    #[test_case(".hidden", false ; "leading_dot")]
+    #[test_case("-option", false ; "command_option")]
+    #[test_case("++flag", false ; "command_flag")]
+    #[test_case("two words", false ; "command_separator")]
+    #[test_case("escape\u{1b}sequence", false ; "control_character")]
+    fn name_safety(name: &str, expected: bool) {
+        assert_eq!(name_is_safe(name), expected, "{name:?}");
+    }
+
+    /// Names derived from ordinary sources must survive the safety check, or
+    /// the guard would reject real packages.
+    #[test]
+    fn derived_names_from_real_sources_are_safe() {
+        for src in [
+            "https://github.com/user/repo.git",
+            "git@github.com:user/repo.git",
+            "ssh://git@host/user/my-plugin.nvim",
+        ] {
+            assert!(name_is_safe(&derive_name(src)), "{src}");
+        }
+    }
+
+    #[test]
+    fn unusable_src_yields_an_empty_name() {
+        assert_eq!(derive_name(""), "");
+        assert_eq!(derive_name("///"), "");
+    }
+
+    #[test]
+    fn explicit_name_overrides_the_derived_one() {
+        let spec = Spec::new("https://github.com/user/repo").with_name("other");
+        assert_eq!(spec.name, "other");
+        assert_eq!(spec.src, "https://github.com/user/repo");
+    }
+}

--- a/maki-pack/src/version.rs
+++ b/maki-pack/src/version.rs
@@ -1,0 +1,107 @@
+//! Which revision of a package to use.
+//!
+//! A plain branch, tag, or commit is handed to git untouched. A range is
+//! resolved here, because no git command understands a semver constraint.
+
+use semver::{Version as SemVer, VersionReq};
+
+/// What a package specification asks for.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum Version {
+    /// No version given: track the remote's default branch.
+    #[default]
+    DefaultBranch,
+    /// A branch, a tag, or a commit, passed to git as written.
+    Rev(String),
+    /// A semver constraint, resolved against the repository's tags.
+    Range(VersionReq),
+}
+
+impl Version {
+    /// Parses the constraint syntax `maki.version.range()` accepts.
+    pub fn range(spec: &str) -> Result<Self, semver::Error> {
+        VersionReq::parse(spec).map(Self::Range)
+    }
+}
+
+/// A tag as semver, tolerating the common `v` prefix.
+///
+/// Tags that are not versions at all are simply not candidates; a repository is
+/// free to carry `latest` or `nightly` alongside its releases.
+fn as_semver(tag: &str) -> Option<SemVer> {
+    let trimmed = tag.strip_prefix('v').unwrap_or(tag);
+    SemVer::parse(trimmed).ok()
+}
+
+/// The greatest tag the constraint admits.
+///
+/// Neovim installs "the greatest/last semver tag inside the version
+/// constraint", so this picks by version order rather than by tag order or by
+/// commit date.
+pub(crate) fn best_match<'a, I>(req: &VersionReq, tags: I) -> Option<&'a str>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    tags.into_iter()
+        .filter_map(|tag| as_semver(tag).map(|v| (v, tag)))
+        .filter(|(v, _)| req.matches(v))
+        .max_by(|(a, _), (b, _)| a.cmp(b))
+        .map(|(_, tag)| tag)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(s: &str) -> VersionReq {
+        VersionReq::parse(s).unwrap()
+    }
+
+    #[test]
+    fn picks_the_greatest_match_not_the_last_listed() {
+        let tags = ["v1.0.0", "v1.4.2", "v1.2.0"];
+        assert_eq!(best_match(&req("^1"), tags), Some("v1.4.2"));
+    }
+
+    #[test]
+    fn respects_the_constraint_upper_bound() {
+        let tags = ["v1.9.0", "v2.0.0", "v2.5.1"];
+        assert_eq!(best_match(&req("^1"), tags), Some("v1.9.0"));
+    }
+
+    #[test]
+    fn tolerates_tags_with_and_without_the_v_prefix() {
+        assert_eq!(best_match(&req(">=1"), ["1.2.3"]), Some("1.2.3"));
+        assert_eq!(best_match(&req(">=1"), ["v1.2.3"]), Some("v1.2.3"));
+    }
+
+    /// A repository may tag things that are not releases. Those are not
+    /// candidates, but they must not stop the real tags from resolving.
+    #[test]
+    fn ignores_tags_that_are_not_versions() {
+        let tags = ["nightly", "latest", "v1.1.0", "release-candidate"];
+        assert_eq!(best_match(&req("^1"), tags), Some("v1.1.0"));
+    }
+
+    #[test]
+    fn no_matching_tag_resolves_to_nothing() {
+        assert_eq!(best_match(&req("^3"), ["v1.0.0", "v2.0.0"]), None);
+        assert_eq!(best_match(&req("^1"), []), None);
+    }
+
+    /// Ordering is by version, so 10 must beat 9 even though it sorts earlier
+    /// as text.
+    #[test]
+    fn orders_numerically_not_lexically() {
+        let tags = ["v1.9.0", "v1.10.0"];
+        assert_eq!(best_match(&req("^1"), tags), Some("v1.10.0"));
+    }
+
+    /// A prerelease must not be picked for a plain caret range, matching cargo
+    /// and npm, so an alpha tag never becomes an accidental upgrade.
+    #[test]
+    fn prerelease_is_not_matched_by_a_plain_range() {
+        let tags = ["v1.0.0", "v1.1.0-alpha.1"];
+        assert_eq!(best_match(&req("^1"), tags), Some("v1.0.0"));
+    }
+}

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -28,6 +28,7 @@ use crate::app::tasks::TaskOutcome;
 use crate::chat::Chat;
 use crate::chat::{CANCELLED_TEXT, ChatEventResult, DONE_TEXT, ERROR_TEXT};
 use crate::clipboard::ClipboardState;
+use crate::components::PackRequest;
 use crate::components::btw_modal::BtwModal;
 use crate::components::command::{CommandAction, CommandPalette, ParsedCommand};
 use crate::components::file_picker::{FilePickerModal, FilePickerModalAction};
@@ -1287,14 +1288,18 @@ impl App {
         let (name, args) = trimmed
             .split_once(char::is_whitespace)
             .unwrap_or((trimmed, ""));
+        let (name, bang) = name
+            .strip_suffix('!')
+            .map_or((name, false), |name| (name, true));
         let resolved = self
             .command_palette
-            .resolve(&format!("/{}", name.trim_start_matches('/')))
+            .resolve(&format!("/{}", name.trim_start_matches('/')), bang)
             .ok_or_else(|| format!("unknown command '{name}'"))?;
         Ok(self.execute_command(
             ParsedCommand {
                 name: resolved,
                 args: args.trim().to_string(),
+                bang,
             },
             depth,
         ))
@@ -1394,6 +1399,31 @@ impl App {
             }
             "/exit" => self.quit(),
             "/reload" => self.quit_with(ExitRequest::Reload),
+            cmd_name @ ("/packupdate" | "/packdel") => {
+                // Only a person may change the installed set. `depth` is
+                // non-zero when `maki.api.run_command` sent this, so without
+                // the guard a downloaded package could call
+                // `/packupdate <itself>` and fetch new code under the approval
+                // it already holds, or `/packdel! ++all` and remove the rest.
+                if depth > 0 {
+                    self.flash(format!("{cmd_name} can only be run by you"));
+                    return vec![];
+                }
+                // Refused here, while the user is watching, rather than after
+                // the UI has closed: a typo in a flag should say so at the
+                // prompt, not tear the session down and report it afterwards.
+                match maki_lua::PackCommand::parse(cmd_name, &cmd.args) {
+                    Ok(_) => self.quit_with(ExitRequest::Pack(PackRequest {
+                        name: cmd_name.to_owned(),
+                        args: cmd.args.clone(),
+                        bang: cmd.bang,
+                    })),
+                    Err(msg) => {
+                        self.flash(msg);
+                        vec![]
+                    }
+                }
+            }
             name if name.starts_with("/project:") || name.starts_with("/user:") => {
                 self.execute_custom_command(name, &cmd.args)
             }

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -28,7 +28,6 @@ use crate::app::tasks::TaskOutcome;
 use crate::chat::Chat;
 use crate::chat::{CANCELLED_TEXT, ChatEventResult, DONE_TEXT, ERROR_TEXT};
 use crate::clipboard::ClipboardState;
-use crate::components::PackRequest;
 use crate::components::btw_modal::BtwModal;
 use crate::components::command::{CommandAction, CommandPalette, ParsedCommand};
 use crate::components::file_picker::{FilePickerModal, FilePickerModalAction};
@@ -842,7 +841,9 @@ impl App {
         for entry in &snap.entries {
             if entry.key == key.code
                 && entry.modifiers == key.modifiers
-                && self.lua_event_handle.run_keybind_callback(entry.id)
+                && self
+                    .lua_event_handle
+                    .run_keybind_callback(entry.id, entry.key, entry.modifiers)
             {
                 return true;
             }
@@ -1412,12 +1413,8 @@ impl App {
                 // Refused here, while the user is watching, rather than after
                 // the UI has closed: a typo in a flag should say so at the
                 // prompt, not tear the session down and report it afterwards.
-                match maki_lua::PackCommand::parse(cmd_name, &cmd.args) {
-                    Ok(_) => self.quit_with(ExitRequest::Pack(PackRequest {
-                        name: cmd_name.to_owned(),
-                        args: cmd.args.clone(),
-                        bang: cmd.bang,
-                    })),
+                match maki_lua::PackCommand::parse(cmd_name, &cmd.args, cmd.bang) {
+                    Ok(command) => self.quit_with(ExitRequest::Pack(command)),
                     Err(msg) => {
                         self.flash(msg);
                         vec![]

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -339,7 +339,7 @@ mod tests {
             "provider": {"allowed_models": [fallback.spec()]}
         }))
         .unwrap();
-        let policy = raw.into_config(false).unwrap().provider.model_policy;
+        let policy = raw.into_config(false, &[]).unwrap().provider.model_policy;
 
         let state = SessionState::from_session(session, &fallback, &storage, &policy);
 

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -612,6 +612,7 @@ fn cmd(name: &str) -> ParsedCommand {
     ParsedCommand {
         name: name.to_string(),
         args: String::new(),
+        bang: false,
     }
 }
 
@@ -2443,6 +2444,7 @@ fn cd_command_behavior() {
         ParsedCommand {
             name: "/cd".into(),
             args: "/tmp".into(),
+            bang: false,
         },
         0,
     );
@@ -2459,6 +2461,7 @@ fn cd_command_behavior() {
         ParsedCommand {
             name: "/cd".into(),
             args: "/nonexistent_path_12345".into(),
+            bang: false,
         },
         0,
     );
@@ -2523,6 +2526,51 @@ fn run_cmdline_splits_args_off_the_name() {
     let actions = app.run_cmdline("/btw what is rust?", 0).unwrap();
 
     assert!(matches!(&actions[..], [Action::Btw(q)] if q == "what is rust?"));
+}
+
+#[test]
+fn run_cmdline_preserves_declared_bang() {
+    let mut app = test_app();
+
+    app.run_cmdline("/packdel! demo", 0).unwrap();
+
+    assert_eq!(
+        app.exit_request,
+        ExitRequest::Pack(PackRequest {
+            name: "/packdel".into(),
+            args: "demo".into(),
+            bang: true,
+        })
+    );
+}
+
+/// Only a person may change the installed package set. A non-zero depth means
+/// `maki.api.run_command` sent this, so a downloaded package must not be able
+/// to fetch new code for itself or delete the rest.
+#[test_case("/packupdate demo" ; "update")]
+#[test_case("/packdel! ++all"  ; "delete_all")]
+fn run_cmdline_refuses_pack_commands_from_lua(cmdline: &str) {
+    let mut app = test_app();
+
+    let actions = app.run_cmdline(cmdline, 1).unwrap();
+
+    assert!(
+        actions.is_empty(),
+        "a refused command must produce no action"
+    );
+    assert_eq!(
+        app.exit_request,
+        ExitRequest::None,
+        "a Lua caller must not be able to leave the UI for a package change"
+    );
+}
+
+#[test]
+fn run_cmdline_rejects_undeclared_bang() {
+    let mut app = test_app();
+
+    assert!(app.run_cmdline("/help!", 0).is_err());
+    assert!(!app.help_modal.is_open());
 }
 
 /// Only the typed path clears the input, so a keybind or autocmd reaching for
@@ -2999,6 +3047,7 @@ fn btw_empty_flashes_error() {
         ParsedCommand {
             name: "/btw".into(),
             args: String::new(),
+            bang: false,
         },
         0,
     );
@@ -3016,6 +3065,7 @@ fn btw_with_question_returns_action() {
         ParsedCommand {
             name: "/btw".into(),
             args: "what is rust?".into(),
+            bang: false,
         },
         0,
     );
@@ -3779,6 +3829,7 @@ fn thinking_explicit_args() {
         ParsedCommand {
             name: "/thinking".into(),
             args: "8192".into(),
+            bang: false,
         },
         0,
     );
@@ -3788,6 +3839,7 @@ fn thinking_explicit_args() {
         ParsedCommand {
             name: "/thinking".into(),
             args: "high".into(),
+            bang: false,
         },
         0,
     );

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -2536,10 +2536,10 @@ fn run_cmdline_preserves_declared_bang() {
 
     assert_eq!(
         app.exit_request,
-        ExitRequest::Pack(PackRequest {
-            name: "/packdel".into(),
-            args: "demo".into(),
-            bang: true,
+        ExitRequest::Pack(maki_lua::PackCommand::Delete {
+            names: vec!["demo".into()],
+            all: false,
+            force: true,
         })
     );
 }

--- a/maki-ui/src/components/command.rs
+++ b/maki-ui/src/components/command.rs
@@ -21,99 +21,86 @@ pub struct BuiltinCommand {
     pub name: &'static str,
     pub description: &'static str,
     pub max_args: usize,
+    /// Whether a trailing `!` is part of this command rather than a typo.
+    ///
+    /// Matching is a fuzzy match on the typed word, and `!` appears in no
+    /// command name, so without this the bang form matches nothing and falls
+    /// through to the model as an ordinary message.
+    pub bang: bool,
+}
+
+impl BuiltinCommand {
+    const fn new(name: &'static str, description: &'static str, max_args: usize) -> Self {
+        Self {
+            name,
+            description,
+            max_args,
+            bang: false,
+        }
+    }
+
+    const fn with_bang(name: &'static str, description: &'static str, max_args: usize) -> Self {
+        Self {
+            name,
+            description,
+            max_args,
+            bang: true,
+        }
+    }
 }
 
 pub const BUILTIN_COMMANDS: &[BuiltinCommand] = &[
-    BuiltinCommand {
-        name: "/compact",
-        description: "Summarize and compact conversation history",
-        max_args: 0,
-    },
-    BuiltinCommand {
-        name: "/new",
-        description: "Start a new session",
-        max_args: 0,
-    },
-    BuiltinCommand {
-        name: "/help",
-        description: "Show keybindings",
-        max_args: 0,
-    },
-    BuiltinCommand {
-        name: "/usage",
-        description: "Show token usage breakdown",
-        max_args: 0,
-    },
-    BuiltinCommand {
-        name: "/queue",
-        description: "Remove items from queue",
-        max_args: 0,
-    },
-    BuiltinCommand {
-        name: "/model",
-        description: "Switch model",
-        max_args: 0,
-    },
-    BuiltinCommand {
-        name: "/theme",
-        description: "Switch color theme",
-        max_args: 0,
-    },
-    BuiltinCommand {
-        name: "/mcp",
-        description: "Configure MCP servers",
-        max_args: 0,
-    },
-    BuiltinCommand {
-        name: "/login",
-        description: "Authenticate with an LLM provider",
-        max_args: 0,
-    },
-    BuiltinCommand {
-        name: "/cd",
-        description: "Change working directory",
-        max_args: 1,
-    },
-    BuiltinCommand {
-        name: "/btw",
-        description: "Ask a quick question (no tools, no history pollution)",
-        max_args: usize::MAX,
-    },
-    BuiltinCommand {
-        name: "/yolo",
-        description: "Toggle YOLO mode (skip all permission prompts)",
-        max_args: 0,
-    },
-    BuiltinCommand {
-        name: "/thinking",
-        description: "Toggle extended thinking (off, adaptive, effort level, or budget)",
-        max_args: 1,
-    },
-    BuiltinCommand {
-        name: "/fast",
-        description: "Toggle Anthropic fast mode (Opus only)",
-        max_args: 0,
-    },
-    BuiltinCommand {
-        name: "/workflow",
-        description: "Toggle workflow mode (task callable inside code_execution)",
-        max_args: 0,
-    },
-    BuiltinCommand {
-        name: "/exit",
-        description: "Exit the application",
-        max_args: 0,
-    },
-    BuiltinCommand {
-        name: "/reload",
-        description: "Reload plugins and config",
-        max_args: 0,
-    },
+    BuiltinCommand::new("/tasks", "Browse and search tasks", 0),
+    BuiltinCommand::new("/compact", "Summarize and compact conversation history", 0),
+    BuiltinCommand::new("/new", "Start a new session", 0),
+    BuiltinCommand::new("/help", "Show keybindings", 0),
+    BuiltinCommand::new("/usage", "Show token usage breakdown", 0),
+    BuiltinCommand::new("/queue", "Remove items from queue", 0),
+    BuiltinCommand::new("/model", "Switch model", 0),
+    BuiltinCommand::new("/theme", "Switch color theme", 0),
+    BuiltinCommand::new("/mcp", "Configure MCP servers", 0),
+    BuiltinCommand::new("/login", "Authenticate with an LLM provider", 0),
+    BuiltinCommand::new("/cd", "Change working directory", 1),
+    BuiltinCommand::new(
+        "/btw",
+        "Ask a quick question (no tools, no history pollution)",
+        usize::MAX,
+    ),
+    BuiltinCommand::new("/yolo", "Toggle YOLO mode (skip all permission prompts)", 0),
+    BuiltinCommand::new(
+        "/thinking",
+        "Toggle extended thinking (off, adaptive, effort level, or budget)",
+        1,
+    ),
+    BuiltinCommand::new("/fast", "Toggle Anthropic fast mode (Opus only)", 0),
+    BuiltinCommand::new(
+        "/workflow",
+        "Toggle workflow mode (task callable inside code_execution)",
+        0,
+    ),
+    BuiltinCommand::new("/exit", "Exit the application", 0),
+    BuiltinCommand::new("/reload", "Reload plugins and config", 0),
+    // Host commands rather than Lua ones: both unload an owner, and unloading
+    // waits on a reply from the Lua thread that a Lua handler would be
+    // occupying. Being built in also keeps them usable under `--no-plugins`,
+    // which is when a package is most likely to be what needs removing.
+    BuiltinCommand::with_bang(
+        "/packupdate",
+        "Update packages (++offline, ++lockfile, or a name)",
+        usize::MAX,
+    ),
+    BuiltinCommand::with_bang(
+        "/packdel",
+        "Remove undeclared packages (++all, or a name)",
+        usize::MAX,
+    ),
 ];
 
 pub struct ParsedCommand {
     pub name: String,
     pub args: String,
+    /// The user typed the command with a trailing `!`.
+    pub bang: bool,
 }
 
 pub enum CommandAction {
@@ -137,6 +124,12 @@ struct CommandItem {
     command_type: CommandType,
 }
 
+impl CommandItem {
+    fn accepts_bang(&self) -> bool {
+        matches!(&self.command_type, CommandType::Builtin(command) if command.bang)
+    }
+}
+
 struct Match {
     command_type: CommandType,
     indices: Vec<u32>,
@@ -154,7 +147,6 @@ pub struct CommandPalette {
     lua_generation: u64,
     nucleo: Nucleo<CommandItem>,
     matcher: Matcher,
-    current_arg_count: usize,
 }
 
 impl CommandPalette {
@@ -184,7 +176,6 @@ impl CommandPalette {
             lua_generation,
             nucleo,
             matcher: Matcher::new(Config::DEFAULT),
-            current_arg_count: 0,
         }
     }
 
@@ -268,7 +259,14 @@ impl CommandPalette {
             },
             KeyCode::Tab => {
                 if let Some(item) = self.filtered.get(self.selected) {
-                    let name = self.item_name(item);
+                    let mut name = self.item_name(item);
+                    // The bang was taken off before matching, so it has to go
+                    // back on here. Without this, completing `/packdel!` would
+                    // hand back `/packdel` and quietly turn a forced command
+                    // into the confirming one.
+                    if command_input(input).is_some_and(|(_, _, bang)| bang) {
+                        name.push('!');
+                    }
                     let text = if self.item_has_args(item) {
                         format!("{name} ")
                     } else {
@@ -298,20 +296,13 @@ impl CommandPalette {
             self.lua_commands = lua_snap.commands.clone();
             self.nucleo = Self::build_nucleo(&self.custom, &self.mcp_prompts, &self.lua_commands);
         }
-        let Some(stripped) = input.strip_prefix('/') else {
+        if !input.starts_with('/') {
             self.filtered.clear();
-            self.current_arg_count = 0;
             return;
-        };
-
-        let parts: Vec<&str> = stripped.split_whitespace().collect();
-        let cmd_word = parts.first().copied().unwrap_or(stripped);
-        let trailing_space = stripped.ends_with(char::is_whitespace);
-
-        self.current_arg_count = if trailing_space {
-            parts.len()
-        } else {
-            parts.len().saturating_sub(1)
+        }
+        let Some((cmd_word, arg_count, bang)) = command_input(input) else {
+            self.filtered.clear();
+            return;
         };
 
         self.nucleo.pattern.reparse(
@@ -322,14 +313,14 @@ impl CommandPalette {
             false,
         );
 
-        self.tick();
+        self.tick(arg_count, bang);
     }
 
-    fn tick(&mut self) {
+    fn tick(&mut self, arg_count: usize, bang: bool) {
         loop {
             let status = self.nucleo.tick(TICK_TIMEOUT_MS);
             if status.changed {
-                self.refresh_matches();
+                self.refresh_matches(arg_count, bang);
             }
             if !status.running {
                 break;
@@ -337,7 +328,7 @@ impl CommandPalette {
         }
     }
 
-    fn refresh_matches(&mut self) {
+    fn refresh_matches(&mut self, arg_count: usize, bang: bool) {
         let snapshot = self.nucleo.snapshot();
         let pattern = snapshot.pattern();
         let has_pattern = !pattern.column_pattern(0).atoms.is_empty();
@@ -348,7 +339,10 @@ impl CommandPalette {
             let cmd_item = &item.data;
             let col = &item.matcher_columns[0];
 
-            if self.current_arg_count > cmd_item.max_args {
+            if arg_count > cmd_item.max_args {
+                continue;
+            }
+            if bang && !cmd_item.accepts_bang() {
                 continue;
             }
 
@@ -375,7 +369,6 @@ impl CommandPalette {
 
     pub fn close(&mut self) {
         self.filtered.clear();
-        self.current_arg_count = 0;
     }
 
     pub fn move_up(&mut self) {
@@ -438,6 +431,7 @@ impl CommandPalette {
         Some(ParsedCommand {
             name,
             args: args.to_string(),
+            bang: command_input(input).is_some_and(|(_, _, bang)| bang),
         })
     }
 
@@ -445,10 +439,10 @@ impl CommandPalette {
     /// spelling that [`crate::app::App`] dispatches on. Case-insensitive like
     /// typing, but never fuzzy: an alias names one command on purpose, and a
     /// typo should report itself instead of running the closest neighbor.
-    pub fn resolve(&self, name: &str) -> Option<String> {
+    pub fn resolve(&self, name: &str, bang: bool) -> Option<String> {
         Self::items(&self.custom, &self.mcp_prompts, &self.lua_commands)
+            .find(|item| item.name.eq_ignore_ascii_case(name) && (!bang || item.accepts_bang()))
             .map(|item| item.name)
-            .find(|n| n.eq_ignore_ascii_case(name))
     }
 
     pub fn find_custom_command(&self, display_name: &str) -> Option<&CustomCommand> {
@@ -572,6 +566,19 @@ impl CommandPalette {
     }
 }
 
+fn command_input(input: &str) -> Option<(&str, usize, bool)> {
+    let stripped = input.strip_prefix('/')?;
+    let mut parts = stripped.split_whitespace();
+    let first = parts.next();
+    let word = first.unwrap_or(stripped);
+    let (word, bang) = word
+        .strip_suffix('!')
+        .map_or((word, false), |word| (word, true));
+    let arg_count =
+        parts.count() + usize::from(first.is_some() && stripped.ends_with(char::is_whitespace));
+    Some((word, arg_count, bang))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -676,21 +683,53 @@ mod tests {
     fn sync_filters_on_first_word_only() {
         let p = synced("/cd ~/foo");
         assert!(p.is_active());
-        assert_eq!(p.filtered.len(), 1);
-        let name = p.item_name(&p.filtered[0]);
-        assert_eq!(name, "/cd");
+        // The argument takes no part in matching, so the command word alone
+        // decides the result. Asserted as "`/cd` wins" rather than "one match",
+        // because any command that fuzzy-matches `cd` and accepts arguments
+        // legitimately appears too.
+        assert_eq!(p.item_name(&p.filtered[0]), "/cd");
+        assert!(
+            !p.filtered.iter().any(|m| p.item_name(m).contains("foo")),
+            "nothing should have matched on the argument"
+        );
     }
 
-    #[test_case("/compact ", false ; "zero_arg_cmd_with_space")]
-    #[test_case("/help ", false     ; "zero_arg_help_with_space")]
-    #[test_case("/cd ", true        ; "one_arg_cmd_with_space")]
-    #[test_case("/cd ~/foo", true   ; "one_arg_cmd_mid_arg")]
-    #[test_case("/cd  ~/foo", true  ; "one_arg_cmd_double_space")]
-    #[test_case("/cd ~/foo ", false ; "one_arg_cmd_second_space")]
-    #[test_case("/btw hello world", true ; "btw_stays_active_with_many_args")]
-    fn sync_respects_nargs(input: &str, expect_active: bool) {
+    /// Whether the named command is still on offer for this input. Asked of
+    /// one command rather than of the whole list, because the list also holds
+    /// every other command that fuzzy-matches the same word.
+    #[test_case("/compact ", "/compact", false ; "zero_arg_cmd_with_space")]
+    #[test_case("/tasks ", "/tasks", false     ; "zero_arg_tasks_with_space")]
+    #[test_case("/cd ", "/cd", true            ; "one_arg_cmd_with_space")]
+    #[test_case("/cd ~/foo", "/cd", true       ; "one_arg_cmd_mid_arg")]
+    #[test_case("/cd  ~/foo", "/cd", true      ; "one_arg_cmd_double_space")]
+    #[test_case("/cd ~/foo ", "/cd", false     ; "one_arg_cmd_second_space")]
+    #[test_case("/btw hello world", "/btw", true ; "btw_stays_active_with_many_args")]
+    fn sync_respects_nargs(input: &str, command: &str, expect_offered: bool) {
         let p = synced(input);
-        assert_eq!(p.is_active(), expect_active);
+        let offered = p.filtered.iter().any(|m| p.item_name(m) == command);
+        assert_eq!(offered, expect_offered, "{command} for {input:?}");
+    }
+
+    /// A command that declares a bang is offered for the bang form, and one
+    /// that does not is not. Without the second half, `/help!` would offer
+    /// `/help` and then silently drop what was typed.
+    #[test_case("/packupdate!", "/packupdate", true  ; "declared_bang")]
+    #[test_case("/packdel!", "/packdel", true        ; "declared_bang_del")]
+    #[test_case("/help!", "/help", false             ; "undeclared_bang")]
+    fn sync_offers_only_commands_that_take_a_bang(input: &str, command: &str, expect: bool) {
+        let p = synced(input);
+        let offered = p.filtered.iter().any(|m| p.item_name(m) == command);
+        assert_eq!(offered, expect, "{command} for {input:?}");
+    }
+
+    #[test]
+    fn confirm_reports_the_bang() {
+        let mut p = CommandPalette::new(Arc::from([]), empty_snapshot(), LuaCommandReader::empty());
+        p.sync("/packupdate! ++offline");
+        let cmd = p.confirm("/packupdate! ++offline").unwrap();
+        assert_eq!(cmd.name, "/packupdate");
+        assert_eq!(cmd.args, "++offline");
+        assert!(cmd.bang, "the trailing ! has to reach the handler");
     }
 
     #[test]
@@ -710,7 +749,9 @@ mod tests {
     #[test_case("/CD ~/foo", "/cd", "~/foo"   ; "case_insensitive")]
     #[test_case("/compact", "/compact", ""    ; "other_command")]
     #[test_case("/cmp", "/compact", ""    ; "fuzzy-match-1")]
-    #[test_case("/pct", "/compact", ""    ; "fuzzy-match-2")]
+    // `cmpt` rather than `pct`: the latter also matches `/packupdate`, and
+    // which of the two a fuzzy matcher prefers is not what this asserts.
+    #[test_case("/cmpt", "/compact", ""    ; "fuzzy-match-2")]
     #[test_case("/btw hello world", "/btw", "hello world" ; "btw_multi_word")]
     fn confirm_parses_args(input: &str, expected_name: &str, expected_args: &str) {
         let mut p = CommandPalette::new(Arc::from([]), empty_snapshot(), LuaCommandReader::empty());
@@ -877,7 +918,7 @@ mod tests {
 
     #[test_case("/cmp", "/compact" ; "compact_fuzzy")]
     #[test_case("/new", "/new" ; "new_exact")]
-    #[test_case("/thm", "/theme" ; "theme_fuzzy")]
+    #[test_case("/tsk", "/tasks" ; "tasks_fuzzy")]
     fn nucleo_highlights_matching_indices(input: &str, expected_cmd: &str) {
         let p = synced(input);
         assert!(p.is_active(), "Input '{}' should activate palette", input);

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -217,19 +217,36 @@ pub enum Action {
 
 const ERROR_DISPLAY: Duration = Duration::from_secs(5);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum ExitRequest {
     #[default]
     None,
     Success,
     Error,
     Reload,
+    /// Leave the UI, change the installed packages, and come back.
+    ///
+    /// A package change unloads and reloads owners and can clone from the
+    /// network. Neither may happen on the Lua thread, which is where a Lua
+    /// command handler would run, and neither should happen while the terminal
+    /// is held, which is where a redraw would stall. Reusing the reload path
+    /// puts the work exactly where `/reload` already rebuilds a generation.
+    Pack(PackRequest),
+}
+
+/// A package command on its way out of the UI, still unparsed.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PackRequest {
+    /// `/packupdate` or `/packdel`.
+    pub name: String,
+    pub args: String,
+    pub bang: bool,
 }
 
 impl ExitRequest {
     pub fn code(&self) -> i32 {
         match self {
-            Self::None | Self::Success | Self::Reload => 0,
+            Self::None | Self::Success | Self::Reload | Self::Pack(_) => 0,
             Self::Error => 1,
         }
     }

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -224,23 +224,9 @@ pub enum ExitRequest {
     Success,
     Error,
     Reload,
-    /// Leave the UI, change the installed packages, and come back.
-    ///
-    /// A package change unloads and reloads owners and can clone from the
-    /// network. Neither may happen on the Lua thread, which is where a Lua
-    /// command handler would run, and neither should happen while the terminal
-    /// is held, which is where a redraw would stall. Reusing the reload path
-    /// puts the work exactly where `/reload` already rebuilds a generation.
-    Pack(PackRequest),
-}
-
-/// A package command on its way out of the UI, still unparsed.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct PackRequest {
-    /// `/packupdate` or `/packdel`.
-    pub name: String,
-    pub args: String,
-    pub bang: bool,
+    /// Leave the UI so the caller can change packages without holding the
+    /// terminal or blocking the Lua thread.
+    Pack(maki_lua::PackCommand),
 }
 
 impl ExitRequest {

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -1515,7 +1515,7 @@ impl<'t> EventLoop<'t> {
             phase_start = Instant::now();
             elapsed
         };
-        let exit = self.sessions[self.focused].app.exit_request;
+        let exit = self.sessions[self.focused].app.exit_request.clone();
         if let Some(ref h) = self.ctx.mcp_handle {
             mcp::kill_process_groups(&h.reader().load().pids);
         }

--- a/maki-ui/src/lib.rs
+++ b/maki-ui/src/lib.rs
@@ -42,6 +42,7 @@ use maki_storage::id::MakiId;
 pub type AppSession = maki_storage::sessions::Session<Message, TokenUsage, ToolOutput>;
 
 pub(crate) use agent::AgentCommand;
+pub use components::PackRequest;
 pub use event_loop::EventLoopParams;
 
 /// How a UI generation ended. On `Reload`, each tab carries its in-memory
@@ -54,6 +55,8 @@ pub enum RunOutcome {
     Reload {
         tabs: Vec<AppSession>,
         focused: usize,
+        /// A package change to carry out before the generation is rebuilt.
+        pack: Option<components::PackRequest>,
     },
 }
 
@@ -64,19 +67,29 @@ pub fn run(params: EventLoopParams, initial_prompt: Option<String>) -> Result<Ru
         let el = event_loop::EventLoop::new(&mut terminal, params)?;
         el.run(initial_prompt)?
     };
-    Ok(match report.exit {
+    let event_loop::ShutdownReport {
+        exit,
+        tabs,
+        focused,
+    } = report;
+    Ok(match exit {
         components::ExitRequest::Reload => RunOutcome::Reload {
-            tabs: report.tabs,
-            focused: report.focused,
+            tabs,
+            focused,
+            pack: None,
+        },
+        components::ExitRequest::Pack(request) => RunOutcome::Reload {
+            tabs,
+            focused,
+            pack: Some(request),
         },
         exit => {
-            let session_id = report
-                .tabs
-                .get(report.focused)
+            let session_id = tabs
+                .get(focused)
                 .filter(|s| app::session_has_content(s))
                 .map(|s| s.id);
             let started = Instant::now();
-            drop(report);
+            drop(tabs);
             tracing::info!(
                 elapsed_ms = started.elapsed().as_millis() as u64,
                 "session buffers dropped"

--- a/maki-ui/src/lib.rs
+++ b/maki-ui/src/lib.rs
@@ -42,7 +42,6 @@ use maki_storage::id::MakiId;
 pub type AppSession = maki_storage::sessions::Session<Message, TokenUsage, ToolOutput>;
 
 pub(crate) use agent::AgentCommand;
-pub use components::PackRequest;
 pub use event_loop::EventLoopParams;
 
 /// How a UI generation ended. On `Reload`, each tab carries its in-memory
@@ -55,8 +54,11 @@ pub enum RunOutcome {
     Reload {
         tabs: Vec<AppSession>,
         focused: usize,
-        /// A package change to carry out before the generation is rebuilt.
-        pack: Option<components::PackRequest>,
+    },
+    Pack {
+        tabs: Vec<AppSession>,
+        focused: usize,
+        command: maki_lua::PackCommand,
     },
 }
 
@@ -73,15 +75,11 @@ pub fn run(params: EventLoopParams, initial_prompt: Option<String>) -> Result<Ru
         focused,
     } = report;
     Ok(match exit {
-        components::ExitRequest::Reload => RunOutcome::Reload {
+        components::ExitRequest::Reload => RunOutcome::Reload { tabs, focused },
+        components::ExitRequest::Pack(command) => RunOutcome::Pack {
             tabs,
             focused,
-            pack: None,
-        },
-        components::ExitRequest::Pack(request) => RunOutcome::Reload {
-            tabs,
-            focused,
-            pack: Some(request),
+            command,
         },
         exit => {
             let session_id = tabs

--- a/site/docs/content/_index.md
+++ b/site/docs/content/_index.md
@@ -58,6 +58,7 @@ The docs are sorted by what you came here to do:
     <a class="card" href="/docs/commands/"><span class="card-title">Commands</span><span class="card-desc">The / palette, sessions, toggles, custom commands.</span></a>
     <a class="card" href="/docs/keybindings/"><span class="card-title">Keybindings</span><span class="card-desc">Defaults, precedence, rebinding from Lua.</span></a>
     <a class="card" href="/docs/lua-api/"><span class="card-title">Lua API</span><span class="card-desc">The plugin surface, mirrored from Neovim.</span></a>
+    <a class="card" href="/docs/packages/"><span class="card-title">Lua Packages</span><span class="card-desc">Load external Lua plugins from Neovim-style package directories.</span></a>
     <a class="card" href="/docs/cli/"><span class="card-title">CLI</span><span class="card-desc">Flags and subcommands (auth, models, acp, prompt, ...).</span></a>
     <a class="card" href="/docs/telemetry/"><span class="card-title">Telemetry</span><span class="card-desc">Opt-in OpenTelemetry metrics and events, to a collector you run.</span></a>
   </div>

--- a/site/docs/content/_index.md
+++ b/site/docs/content/_index.md
@@ -58,7 +58,7 @@ The docs are sorted by what you came here to do:
     <a class="card" href="/docs/commands/"><span class="card-title">Commands</span><span class="card-desc">The / palette, sessions, toggles, custom commands.</span></a>
     <a class="card" href="/docs/keybindings/"><span class="card-title">Keybindings</span><span class="card-desc">Defaults, precedence, rebinding from Lua.</span></a>
     <a class="card" href="/docs/lua-api/"><span class="card-title">Lua API</span><span class="card-desc">The plugin surface, mirrored from Neovim.</span></a>
-    <a class="card" href="/docs/packages/"><span class="card-title">Lua Packages</span><span class="card-desc">Load external Lua plugins from Neovim-style package directories.</span></a>
+    <a class="card" href="/docs/packages/"><span class="card-title">Lua Packages</span><span class="card-desc">Install, lock, update, and lazy-load external Lua plugins.</span></a>
     <a class="card" href="/docs/cli/"><span class="card-title">CLI</span><span class="card-desc">Flags and subcommands (auth, models, acp, prompt, ...).</span></a>
     <a class="card" href="/docs/telemetry/"><span class="card-title">Telemetry</span><span class="card-desc">Opt-in OpenTelemetry metrics and events, to a collector you run.</span></a>
   </div>

--- a/site/docs/content/commands/_index.md
+++ b/site/docs/content/commands/_index.md
@@ -13,6 +13,7 @@ Type `/` in the input box to open the command palette.
 
 | Command | Description |
 |---------|-------------|
+| `/tasks` | Browse and search tasks |
 | `/compact` | Summarize and compact conversation history |
 | `/new` | Start a new session |
 | `/help` | Show keybindings |

--- a/site/docs/content/commands/_index.md
+++ b/site/docs/content/commands/_index.md
@@ -30,6 +30,8 @@ Type `/` in the input box to open the command palette.
 | `/workflow` | Toggle workflow mode (task callable inside code_execution) |
 | `/exit` | Exit the application |
 | `/reload` | Reload plugins and config |
+| `/packupdate` | Update packages (++offline, ++lockfile, or a name) |
+| `/packdel` | Remove undeclared packages (++all, or a name) |
 | `/memory` | View, edit, and delete memory files |
 | `/rename` | Rename the current session |
 | `/sessions` | Browse and switch sessions |

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -250,7 +250,13 @@ configuration rather than something a downloaded plugin may do.
   package without loading it, leaving it for `maki.packadd`; a table of
 
 
-  `event`, `cmd`, and `keys` loads it the first time one of those fires.
+  `event`, `cmd`, and `keys` names what should wake it. Trigger tables are
+
+
+  recorded and checked but not dispatched yet, so a package that declares
+
+
+  one installs and stays dormant until `maki.packadd` activates it.
 
   - `confirm` (`boolean`) `false` clones a new source without asking, which
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -5742,3 +5742,4 @@ end
 
 return truncate
 ```
+

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -195,6 +195,9 @@ brought in. It is available to any plugin, unlike `add`, `update`, and
 much weaker act than fetching new code.
 
 Loading happens after this call returns, for the same reason as `update`.
+A runtime call reports an unknown, disabled, or previously failed package
+immediately. During `init.lua`, the host reports the result after startup
+has installed and cataloged packages.
 
 **Parameters:**
 
@@ -232,6 +235,7 @@ Declare packages to install and load, like `vim.pack.add`.
 Recording is all this does. The host installs and loads the declared set
 after `init.lua` finishes, so a slow clone never blocks the call and a
 package failure never stops maki from starting.
+The first declaration of a package name wins for the current session.
 
 Only available inside `init.lua`. Declaring a package fetches code, so it is
 configuration rather than something a downloaded plugin may do.
@@ -240,27 +244,38 @@ configuration rather than something a downloaded plugin may do.
 
 - `{specs}` (`table`) List of specs. Each is a source string, or a table with
 
-  `src` (string, required), `name` (string), and `version` (string or
+  `src` (string, required), `name` (string), `version` (string or
 
 
-  `maki.version.range()`).
-
-- `{opts?}` (`table?`) Options: `load` (boolean|table) `false` installs the
-
-  package without loading it, leaving it for `maki.packadd`; a table of
+  `maki.version.range()`), and arbitrary `data` passed to `get`, change
 
 
-  `event`, `cmd`, and `keys` names what should wake it. Trigger tables are
+  events, and a custom loader.
+
+- `{opts?}` (`table?`) Options: `confirm` (boolean, default true) asks before
+
+  installation. `load` (boolean|table|function) controls loading. `false`
 
 
-  recorded and checked but not dispatched yet, so a package that declares
+  leaves the package for `maki.packadd`. A table of `event`, `cmd`, and
 
 
-  one installs and stays dormant until `maki.packadd` activates it.
+  `keys` names what wakes it. A function runs as the package owner with
 
-  - `confirm` (`boolean`) `false` clones a new source without asking, which
 
-  states that the source is trusted and never approves its permissions.
+  `{ spec, path }` and is fully responsible for loading it. Credentials in
+
+
+  `spec.src` are redacted. The first
+
+
+  trigger loads the package and is then delivered to it. `event` accepts
+
+
+  only the host events that `create_autocmd` documents.
+
+
+  HTTP sources with credentials are rejected; use a Git credential helper.
 
 
 **Example:**
@@ -269,6 +284,33 @@ configuration rather than something a downloaded plugin may do.
 maki.pack.add({
   { src = "https://github.com/user/maki-goal", version = "main" },
 })
+```
+
+---
+
+### `maki.pack.get()` {#maki-pack-get}
+
+```lua
+maki.pack.get({names?}, {opts?})
+```
+
+Gets managed package information, optionally filtered by name.
+
+This is the read-only part of `maki.pack`, so packages may call it too.
+Information comes from the current declarations and lockfile and does not
+contact a remote.
+
+**Parameters:**
+
+- `{names?}` (`table?`) Package names. Omit for all managed packages.
+- `{opts?}` (`table?`) Reserved for future compatibility. Omit it.
+
+**Returns:** (`table`) Package records with `spec`, `path`, `rev`, and `active`.
+
+**Example:**
+
+```lua
+local packages = maki.pack.get({ "maki-goal" })
 ```
 
 ---
@@ -288,10 +330,13 @@ reloads the package and unloading waits on the runtime this call occupies.
 **Parameters:**
 
 - `{names?}` (`table?`) Package names. Omit for every declared package.
-- `{opts?}` (`table?`) `offline` to work without the network, and `target` of
+- `{opts?}` (`table?`) `offline` works without the network. `target` is
   - `"version"` (`the default`) to take what version now resolves to, or
 
-  `"lockfile"` to go back to the recorded revision.
+  `"lockfile"` to go back to the recorded revision. `force` skips the
+
+
+  update review, but not a new permission approval.
 
 
 **Example:**
@@ -306,7 +351,7 @@ maki.pack.update(nil, { target = "lockfile" })
 ### `maki.pack.del()` {#maki-pack-del}
 
 ```lua
-maki.pack.del({names})
+maki.pack.del({names}, {opts?})
 ```
 
 Remove packages, like `vim.pack.del`.
@@ -316,6 +361,7 @@ Runs after this call returns, for the same reason as `update`.
 **Parameters:**
 
 - `{names}` (`table`) Package names to remove.
+- `{opts?}` (`table?`) `force` allows removal of an active package.
 
 **Example:**
 
@@ -746,7 +792,8 @@ Built-in events fired by the host: `"TurnStart"`, `"TurnEnd"`,
 `"TurnError"`, `"ToolStart"`, `"ToolDone"`, `"SessionReset"`,
 `"SessionFocusChanged"`, `"SessionStatusChanged"`, and
 `"TaskStatusChanged"`. Plugins can also fire their own events with
-`exec_autocmds`.
+`exec_autocmds`. Package operations fire `"PackChangedPre"` and
+`"PackChanged"`.
 
 Each host event carries `data.session_id`. For `"SessionReset"` that
 is the session being left behind; the other events name the session now
@@ -5693,4 +5740,3 @@ end
 
 return truncate
 ```
-

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -84,6 +84,8 @@ The rules:
 | Module | What it is for |
 | --- | --- |
 | [`maki`](#maki) | The global entry point. |
+| [`maki.pack`](#maki-pack) | Declaring external packages, modelled after `vim.pack`. |
+| [`maki.version`](#maki-version) | Version constraints, modelled after `vim.version`. |
 | [`maki.api`](#maki-api) | Plugin registration. |
 | [`maki.agent`](#maki-agent) | Subagent primitives for plugins that need to talk to an LLM. |
 | [`maki.agent.Session`](#maki-agent-Session) | A subagent session with its own conversation history. |
@@ -175,6 +177,179 @@ set; an empty {sep} splits into single characters.
 maki.split("a,b,c", ",")                   -- { "a", "b", "c" }
 maki.split("x*y*z", "*", { plain = true }) -- { "x", "y", "z" }
 maki.split("\nhello\nworld\n", "\n", { trimempty = true }) -- { "hello", "world" }
+```
+
+---
+
+### `maki.packadd()` {#maki-packadd}
+
+```lua
+maki.packadd({name})
+```
+
+Activate an installed package that is not loaded, like `:packadd`.
+
+This is how an `opt/` package, or one declared with no automatic load, is
+brought in. It is available to any plugin, unlike `add`, `update`, and
+`del`: activating code that is already installed and already approved is a
+much weaker act than fetching new code.
+
+Loading happens after this call returns, for the same reason as `update`.
+
+**Parameters:**
+
+- `{name}` (`string`) Package to activate.
+
+**Example:**
+
+```lua
+maki.packadd("maki-goal")
+```
+
+
+## maki.pack {#maki-pack}
+
+Declaring external packages, modelled after `vim.pack`.
+
+Available only inside `init.lua`, because installing a package fetches
+code and that is a configuration decision rather than something a
+plugin may do for itself.
+
+```lua
+maki.pack.add({ "https://github.com/user/maki-goal" })
+```
+
+---
+
+### `maki.pack.add()` {#maki-pack-add}
+
+```lua
+maki.pack.add({specs}, {opts?})
+```
+
+Declare packages to install and load, like `vim.pack.add`.
+
+Recording is all this does. The host installs and loads the declared set
+after `init.lua` finishes, so a slow clone never blocks the call and a
+package failure never stops maki from starting.
+
+Only available inside `init.lua`. Declaring a package fetches code, so it is
+configuration rather than something a downloaded plugin may do.
+
+**Parameters:**
+
+- `{specs}` (`table`) List of specs. Each is a source string, or a table with
+
+  `src` (string, required), `name` (string), and `version` (string or
+
+
+  `maki.version.range()`).
+
+- `{opts?}` (`table?`) Options: `load` (boolean|table) `false` installs the
+
+  package without loading it, leaving it for `maki.packadd`; a table of
+
+
+  `event`, `cmd`, and `keys` loads it the first time one of those fires.
+
+  - `confirm` (`boolean`) `false` clones a new source without asking, which
+
+  states that the source is trusted and never approves its permissions.
+
+
+**Example:**
+
+```lua
+maki.pack.add({
+  { src = "https://github.com/user/maki-goal", version = "main" },
+})
+```
+
+---
+
+### `maki.pack.update()` {#maki-pack-update}
+
+```lua
+maki.pack.update({names?}, {opts?})
+```
+
+Update packages to what their version now resolves to, like
+`vim.pack.update`.
+
+The work happens after this call returns, because updating unloads and
+reloads the package and unloading waits on the runtime this call occupies.
+
+**Parameters:**
+
+- `{names?}` (`table?`) Package names. Omit for every declared package.
+- `{opts?}` (`table?`) `offline` to work without the network, and `target` of
+  - `"version"` (`the default`) to take what version now resolves to, or
+
+  `"lockfile"` to go back to the recorded revision.
+
+
+**Example:**
+
+```lua
+maki.pack.update({ "maki-goal" })
+maki.pack.update(nil, { target = "lockfile" })
+```
+
+---
+
+### `maki.pack.del()` {#maki-pack-del}
+
+```lua
+maki.pack.del({names})
+```
+
+Remove packages, like `vim.pack.del`.
+
+Runs after this call returns, for the same reason as `update`.
+
+**Parameters:**
+
+- `{names}` (`table`) Package names to remove.
+
+**Example:**
+
+```lua
+maki.pack.del({ "maki-goal" })
+```
+
+
+## maki.version {#maki-version}
+
+Version constraints, modelled after `vim.version`.
+
+```lua
+local v = maki.version.range("^1.2")
+```
+
+---
+
+### `maki.version.range()` {#maki-version-range}
+
+```lua
+maki.version.range({spec})
+```
+
+Build a semver constraint, like `vim.version.range`.
+
+A package given a range installs the greatest tag the constraint admits.
+
+**Parameters:**
+
+- `{spec}` (`string`) Constraint, for example `"^1.2"` or `">=1.0, <2.0"`.
+
+**Returns:** (`table`) Value to pass as a spec's `version`.
+
+**Example:**
+
+```lua
+maki.pack.add({
+  { src = "https://github.com/user/plugin", version = maki.version.range("^1") },
+})
 ```
 
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -84,7 +84,7 @@ The rules:
 | Module | What it is for |
 | --- | --- |
 | [`maki`](#maki) | The global entry point. |
-| [`maki.pack`](#maki-pack) | Declaring external packages, modelled after `vim.pack`. |
+| [`maki.pack`](#maki-pack) | Manage global external packages, modelled after `vim.pack`. |
 | [`maki.version`](#maki-version) | Version constraints, modelled after `vim.version`. |
 | [`maki.api`](#maki-api) | Plugin registration. |
 | [`maki.agent`](#maki-agent) | Subagent primitives for plugins that need to talk to an LLM. |
@@ -212,11 +212,11 @@ maki.packadd("maki-goal")
 
 ## maki.pack {#maki-pack}
 
-Declaring external packages, modelled after `vim.pack`.
+Manage global external packages, modelled after `vim.pack`.
 
-Available only inside `init.lua`, because installing a package fetches
-code and that is a configuration decision rather than something a
-plugin may do for itself.
+`get` is read-only and available to project config and plugins.
+`add`, `update`, and `del` are available only inside the global
+`init.lua`, because they change state shared by every project.
 
 ```lua
 maki.pack.add({ "https://github.com/user/maki-goal" })
@@ -237,8 +237,8 @@ after `init.lua` finishes, so a slow clone never blocks the call and a
 package failure never stops maki from starting.
 The first declaration of a package name wins for the current session.
 
-Only available inside `init.lua`. Declaring a package fetches code, so it is
-configuration rather than something a downloaded plugin may do.
+Only available inside the global `init.lua`. Declaring a package fetches
+code and changes state shared by every project.
 
 **Parameters:**
 
@@ -326,6 +326,7 @@ Update packages to what their version now resolves to, like
 
 The work happens after this call returns, because updating unloads and
 reloads the package and unloading waits on the runtime this call occupies.
+Only available inside the global `init.lua`.
 
 **Parameters:**
 
@@ -357,6 +358,7 @@ maki.pack.del({names}, {opts?})
 Remove packages, like `vim.pack.del`.
 
 Runs after this call returns, for the same reason as `update`.
+Only available inside the global `init.lua`.
 
 **Parameters:**
 

--- a/site/docs/content/packages/_index.md
+++ b/site/docs/content/packages/_index.md
@@ -8,30 +8,184 @@ group = "Reference"
 # Lua packages
 
 A Lua package lets you add tools, commands, keybindings, and event handlers
-without copying its code into `init.lua`.
+without copying its code into `init.lua`. Maki can load a package that you put
+on disk, or it can install one from a Git repository and lock it to one commit.
 
-Clone a package into a Neovim-style package directory:
+## Install from Git
+
+Declare managed packages in `init.lua`:
+
+```lua
+maki.pack.add({
+  "https://github.com/example/maki-goal",
+  {
+    src = "https://github.com/example/maki-review",
+    version = "v1.2.0",
+    data = { style = "short" },
+  },
+})
+```
+
+Maki shows all new packages in one install prompt. It writes the selected Git
+commit to `pack-lock.json` in your config directory. Commit this file if you
+want another machine to install the same revisions.
+
+The first `maki.pack.add` call restores missing lockfile entries in
+alphabetical order before it installs new declarations.
+
+Set `confirm = false` only when the package source is already trusted and Maki
+must run without a terminal:
+
+```lua
+maki.pack.add({ "https://github.com/example/maki-goal" }, {
+  confirm = false,
+})
+```
+
+This option skips the install prompt. It does not approve package permissions.
+Maki rejects an HTTP source that contains a username, password, or token because
+Git and the lockfile would store it. Use a Git credential helper or an SSH agent
+instead.
+
+## Package permissions
+
+A managed package can ask for guarded APIs in `plugin.toml`:
+
+```toml
+[permissions]
+fs_read = true
+fs_write = true
+net = true
+run = true
+env = true
+```
+
+The file is a request, not an approval. Maki asks about new permissions in a
+separate prompt. An approval applies only to the same package name and source.
+An update that asks for another permission needs another approval, even when
+you force the update.
+
+Non-interactive modes do not read a prompt from standard input. They report the
+package as unavailable until the required install and permission decisions are
+made in the terminal UI.
+
+## Load behavior
+
+Packages load at startup by default. Use `load = false` to install a package
+without loading it:
+
+```lua
+maki.pack.add({ "https://github.com/example/maki-goal" }, {
+  load = false,
+})
+```
+
+Load it later with:
+
+```lua
+maki.packadd("maki-goal")
+```
+
+Any plugin can call `maki.packadd`. Maki validates the package immediately and
+loads it after the calling Lua task returns. Calls made directly from
+`init.lua` wait in the startup queue until package installation is complete.
+
+A trigger table loads the package the first time an event, command, or key is
+used:
+
+```lua
+maki.pack.add({ "https://github.com/example/maki-goal" }, {
+  load = {
+    event = { "TurnStart" },
+    cmd = { "/goal" },
+    keys = { "<C-g>" },
+  },
+})
+```
+
+Event triggers accept the built-in turn, tool, and session events. Package
+change events and plugin-defined events do not reach a dormant package. Maki
+does not use Lua module misses as triggers because each package has its own
+module root and permission owner.
+
+In a mode that does not deliver agent events, an event-triggered package loads
+at startup. Command-only and key-only packages stay dormant.
+
+For full control, `load` can be a function. It receives the normalized
+specification and installed path. Credentials in the source are redacted. The
+function is then responsible for loading or configuring the package. See
+`maki.pack.add` in the [Lua API](/docs/lua-api/) for the exact callback value.
+
+## Inspect, update, and remove
+
+Read current package records from `init.lua` or a package:
+
+```lua
+local all = maki.pack.get()
+local goal = maki.pack.get({ "maki-goal" })[1]
+```
+
+Each record has `spec`, `path`, `rev`, and `active` fields. `path` is absent when
+the recorded revision is not on disk. The original `data` value is available as
+`record.spec.data`.
+
+Use the command palette for normal maintenance:
+
+```text
+/packupdate                 review updates for all declared packages
+/packupdate maki-goal       review one package
+/packupdate! maki-goal      update without the review prompt
+/packupdate ++offline       use Git refs that are already on disk
+/packdel maki-goal          remove an inactive, undeclared package
+/packdel! maki-goal         unload and remove an active, undeclared package
+/packdel ++all              remove all inactive, undeclared packages
+```
+
+An update shows the old and new revisions and the available commit subjects
+before it asks to apply. A failure before the change, or a declined update,
+leaves the lockfile and active owner unchanged. If the new entrypoint fails,
+the new revision stays recorded and the owner stays inactive. A dormant or
+triggered package can be activated again; an eager package waits for the next
+reload. Maki refuses to remove an active package without the force form. It
+also stops deletion if owner cleanup fails.
+
+If Maki cannot write the lockfile after a change, it restores the previous
+approval state and package revision when possible. The old lockfile remains
+authoritative.
+
+Remove a package from `maki.pack.add` before you delete it. Maki rejects a
+deletion while the package is still declared because the next reload would
+install it again.
+
+The Lua forms are available in `init.lua`:
+
+```lua
+maki.pack.update({ "maki-goal" }, { force = true })
+maki.pack.del({ "maki-goal" }, { force = true })
+```
+
+For a batch, all `PackChangedPre` events fire before its first change. The
+`PackChanged` events fire after successful changes are recorded. Event data has
+`active`, `kind`, `spec`, and `path`.
+
+## Install by hand
+
+You can also clone a package into a Neovim-style package directory:
 
 ```text
 <maki-data>/site/pack/<group>/start/<name>/
 <maki-data>/site/pack/<group>/opt/<name>/
 ```
 
-A `start` package loads at startup. An `opt` package stays installed until
-something activates it. A manual package gets the permissions that its local
+A `start` package loads at startup. An `opt` package waits for
+`maki.packadd("name")`. A manual package gets the permissions that its local
 `plugin.toml` requests because you placed the files yourself.
-
-Activate an `opt` package with `maki.packadd`, from `init.lua` or from another
-package:
-
-```lua
-maki.packadd("my-package")
-```
-
-Maki loads the named package after the calling Lua task returns. A package
-that `maki.packadd` activates can activate another one in turn. Maki reports a
-name that no installed package matches, and refuses a package that
-`plugins.<name>.enabled = false` disabled.
 
 A package directory can contain sorted `plugin/*.lua` entry files and modules
 at `lua/<module>.lua` or `lua/<module>/init.lua`.
+
+Managed packages use immutable revision directories under
+`site/pack/core/<name>/<commit>/`. Maki preserves relative symbolic links whose
+targets stay inside the package. It skips absolute links and links that leave
+the package. It does not fetch submodule working trees. Install a package by
+hand if it needs an external link or a submodule.

--- a/site/docs/content/packages/_index.md
+++ b/site/docs/content/packages/_index.md
@@ -13,7 +13,8 @@ on disk, or it can install one from a Git repository and lock it to one commit.
 
 ## Install from Git
 
-Declare managed packages in `init.lua`:
+Declare managed packages in the global `init.lua`, normally
+`~/.config/maki/init.lua`:
 
 ```lua
 maki.pack.add({
@@ -30,8 +31,13 @@ Maki shows all new packages in one install prompt. It writes the selected Git
 commit to `pack-lock.json` in your config directory. Commit this file if you
 want another machine to install the same revisions.
 
-The first `maki.pack.add` call restores missing lockfile entries in
-alphabetical order before it installs new declarations.
+Package installation is global. A project `.maki/init.lua` cannot add, update,
+or remove packages because all projects share the same lockfile and package
+directory. Project config can use `maki.pack.get` to inspect global packages
+and `maki.packadd` to activate an installed and approved package.
+
+Maki restores a missing checkout only when the global config still declares
+the package and its source matches the lockfile entry.
 
 Set `confirm = false` only when the package source is already trusted and Maki
 must run without a terminal:
@@ -157,7 +163,7 @@ Remove a package from `maki.pack.add` before you delete it. Maki rejects a
 deletion while the package is still declared because the next reload would
 install it again.
 
-The Lua forms are available in `init.lua`:
+The Lua forms are available in the global `init.lua`:
 
 ```lua
 maki.pack.update({ "maki-goal" }, { force = true })
@@ -185,7 +191,13 @@ A package directory can contain sorted `plugin/*.lua` entry files and modules
 at `lua/<module>.lua` or `lua/<module>/init.lua`.
 
 Managed packages use immutable revision directories under
-`site/pack/core/<name>/<commit>/`. Maki preserves relative symbolic links whose
-targets stay inside the package. It skips absolute links and links that leave
-the package. It does not fetch submodule working trees. Install a package by
-hand if it needs an external link or a submodule.
+`<maki-data>/site/pack/core/<name>/<commit>/`. An update creates a new revision
+directory. Maki does not remove old revision directories automatically because
+another running process can still use one. To reclaim space, stop all Maki
+processes, keep the commit recorded in `pack-lock.json`, and remove older commit
+directories for that package.
+
+Maki preserves relative symbolic links whose targets stay inside the package.
+It skips absolute links and links that leave the package. It does not fetch
+submodule working trees. Install a package by hand if it needs an external
+link or a submodule.

--- a/site/docs/content/packages/_index.md
+++ b/site/docs/content/packages/_index.md
@@ -1,0 +1,37 @@
++++
+title = "Lua Packages"
+weight = 11
+[extra]
+group = "Reference"
++++
+
+# Lua packages
+
+A Lua package lets you add tools, commands, keybindings, and event handlers
+without copying its code into `init.lua`.
+
+Clone a package into a Neovim-style package directory:
+
+```text
+<maki-data>/site/pack/<group>/start/<name>/
+<maki-data>/site/pack/<group>/opt/<name>/
+```
+
+A `start` package loads at startup. An `opt` package stays installed until
+something activates it. A manual package gets the permissions that its local
+`plugin.toml` requests because you placed the files yourself.
+
+Activate an `opt` package with `maki.packadd`, from `init.lua` or from another
+package:
+
+```lua
+maki.packadd("my-package")
+```
+
+Maki loads the named package after the calling Lua task returns. A package
+that `maki.packadd` activates can activate another one in turn. Maki reports a
+name that no installed package matches, and refuses a package that
+`plugins.<name>.enabled = false` disabled.
+
+A package directory can contain sorted `plugin/*.lua` entry files and modules
+at `lua/<module>.lua` or `lua/<module>/init.lua`.

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -79,24 +79,12 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
     // whatever `init.lua` asked to change. Draining here rather than inside
     // the Lua call is what keeps unloading from waiting on the thread that
     // requested it.
-    let mut active: std::collections::BTreeSet<String> = packages
-        .iter()
-        .chain(&installed.packages)
-        .filter(|p| p.eager && config.plugins.packages.iter().any(|n| n == &p.name))
-        .map(|p| p.name.clone())
-        .collect();
     let available: Vec<maki_lua::DiscoveredPackage> = packages
         .iter()
         .chain(&installed.packages)
         .cloned()
         .collect();
-    maki_lua::drain_pack_ops(
-        &plugin_host,
-        &declared,
-        &available,
-        &mut active,
-        &config.plugins,
-    );
+    maki_lua::drain_pack_ops(&plugin_host, &declared, &available, &config.plugins);
 
     let timeouts = maki_providers::Timeouts {
         connect: config.provider.connect_timeout,

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -33,10 +33,24 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
         .load_init_files_or_skip(no_plugins, &cwd)
         .context("load init.lua files")?;
 
-    let names: Vec<String> = packages.iter().map(|p| p.name.clone()).collect();
+    // Read after the init files, so declared packages are configurable and
+    // installable here too, not only under the terminal UI.
+    let declared = if no_plugins {
+        Vec::new()
+    } else {
+        plugin_host
+            .declared_packages()
+            .context("read declared packages")?
+    };
+
+    let known: Vec<String> = packages
+        .iter()
+        .map(|p| p.name.clone())
+        .chain(declared.iter().map(|d| d.spec.name.clone()))
+        .collect();
     let mut config = raw_config
         .unwrap_or_default()
-        .into_config(false, &names)
+        .into_config(false, &known)
         .context("invalid config")?;
     config.permissions = load_permissions(&cwd);
 
@@ -51,6 +65,38 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
     for warning in plugin_host.load_packages(&packages, &config.plugins) {
         eprintln!("warning: {warning}");
     }
+    let installed = maki_lua::install_declared(&declared, maki_lua::Interaction::None);
+    for warning in installed
+        .failures
+        .iter()
+        .cloned()
+        .chain(plugin_host.load_packages(&installed.packages, &config.plugins))
+    {
+        eprintln!("warning: {warning}");
+    }
+
+    // Same order as the terminal entry point: everything loaded first, then
+    // whatever `init.lua` asked to change. Draining here rather than inside
+    // the Lua call is what keeps unloading from waiting on the thread that
+    // requested it.
+    let mut active: std::collections::BTreeSet<String> = packages
+        .iter()
+        .chain(&installed.packages)
+        .filter(|p| p.eager && config.plugins.packages.iter().any(|n| n == &p.name))
+        .map(|p| p.name.clone())
+        .collect();
+    let available: Vec<maki_lua::DiscoveredPackage> = packages
+        .iter()
+        .chain(&installed.packages)
+        .cloned()
+        .collect();
+    maki_lua::drain_pack_ops(
+        &plugin_host,
+        &declared,
+        &available,
+        &mut active,
+        &config.plugins,
+    );
 
     let timeouts = maki_providers::Timeouts {
         connect: config.provider.connect_timeout,

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -21,13 +21,22 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
     let mut plugin_host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
         .context("initialize lua plugin host")?;
 
+    let discovery = maki_lua::discover_installed(no_plugins);
+    for problem in discovery.problems {
+        eprintln!(
+            "warning: {}",
+            super::sanitize_warning(format!("skipping package: {problem}"))
+        );
+    }
+    let packages = discovery.packages;
     let raw_config = plugin_host
         .load_init_files_or_skip(no_plugins, &cwd)
         .context("load init.lua files")?;
 
+    let names: Vec<String> = packages.iter().map(|p| p.name.clone()).collect();
     let mut config = raw_config
         .unwrap_or_default()
-        .into_config(false)
+        .into_config(false, &names)
         .context("invalid config")?;
     config.permissions = load_permissions(&cwd);
 
@@ -39,6 +48,9 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
     plugin_host
         .load_builtins(&config.plugins)
         .context("load builtin plugins")?;
+    for warning in plugin_host.load_packages(&packages, &config.plugins) {
+        eprintln!("warning: {warning}");
+    }
 
     let timeouts = maki_providers::Timeouts {
         connect: config.provider.connect_timeout,

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -22,6 +22,7 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
         .context("initialize lua plugin host")?;
 
     let discovery = maki_lua::discover_installed(no_plugins);
+    let names = discovery.known_names();
     for problem in discovery.problems {
         eprintln!(
             "warning: {}",
@@ -43,9 +44,9 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
             .context("read declared packages")?
     };
 
-    let known: Vec<String> = packages
+    let known: Vec<String> = names
         .iter()
-        .map(|p| p.name.clone())
+        .cloned()
         .chain(declared.iter().map(|d| d.spec.name.clone()))
         .collect();
     let mut config = raw_config

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -21,14 +21,9 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
     let mut plugin_host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
         .context("initialize lua plugin host")?;
 
-    let discovery = maki_lua::discover_installed(no_plugins);
-    let names = discovery.known_names();
-    for problem in discovery.problems {
-        eprintln!(
-            "warning: {}",
-            super::sanitize_warning(format!("skipping package: {problem}"))
-        );
-    }
+    let discovery = super::discover_external_packages(no_plugins);
+    let names = discovery.names;
+    super::report_warnings(discovery.warnings);
     let packages = discovery.packages;
     let raw_config = plugin_host
         .load_init_files_or_skip(no_plugins, &cwd)
@@ -63,7 +58,7 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
     plugin_host
         .load_builtins(&config.plugins)
         .context("load builtin plugins")?;
-    for warning in super::load_external_packages(
+    super::report_warnings(super::load_external_packages(
         &plugin_host,
         &packages,
         &declared,
@@ -71,9 +66,7 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
         &config.plugins,
         maki_lua::Interaction::None,
         false,
-    )? {
-        eprintln!("warning: {warning}");
-    }
+    )?);
 
     let timeouts = maki_providers::Timeouts {
         connect: config.provider.connect_timeout,

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -62,29 +62,17 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
     plugin_host
         .load_builtins(&config.plugins)
         .context("load builtin plugins")?;
-    for warning in plugin_host.load_packages(&packages, &config.plugins) {
+    for warning in super::load_external_packages(
+        &plugin_host,
+        &packages,
+        &declared,
+        &[],
+        &config.plugins,
+        maki_lua::Interaction::None,
+        false,
+    )? {
         eprintln!("warning: {warning}");
     }
-    let installed = maki_lua::install_declared(&declared, maki_lua::Interaction::None);
-    for warning in installed
-        .failures
-        .iter()
-        .cloned()
-        .chain(plugin_host.load_packages(&installed.packages, &config.plugins))
-    {
-        eprintln!("warning: {warning}");
-    }
-
-    // Same order as the terminal entry point: everything loaded first, then
-    // whatever `init.lua` asked to change. Draining here rather than inside
-    // the Lua call is what keeps unloading from waiting on the thread that
-    // requested it.
-    let available: Vec<maki_lua::DiscoveredPackage> = packages
-        .iter()
-        .chain(&installed.packages)
-        .cloned()
-        .collect();
-    maki_lua::drain_pack_ops(&plugin_host, &declared, &available, &config.plugins);
 
     let timeouts = maki_providers::Timeouts {
         connect: config.provider.connect_timeout,

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -11,6 +11,20 @@ use maki_storage::StateDir;
 use crate::cli::{AuthAction, Cli, Command, McpAction, MigrateAction};
 use crate::update;
 
+fn sanitize_warning(message: impl std::fmt::Display) -> String {
+    message
+        .to_string()
+        .chars()
+        .map(|character| {
+            if character == '\n' || character == '\t' || !character.is_control() {
+                character
+            } else {
+                ' '
+            }
+        })
+        .collect()
+}
+
 pub fn dispatch(cli: Cli) -> Result<()> {
     match cli.command {
         Some(Command::Auth { action }) => {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -6,23 +6,58 @@ mod tui;
 use color_eyre::Result;
 use color_eyre::eyre::Context;
 
+use maki_lua::{Declared, DiscoveredPackage, Interaction, PluginHost};
 use maki_storage::StateDir;
 
 use crate::cli::{AuthAction, Cli, Command, McpAction, MigrateAction};
 use crate::update;
 
+/// Strips control characters out of a message before it reaches a terminal.
+///
+/// One rule, shared with the package code that formats its own warnings: a
+/// second copy here could start disagreeing about what is safe to print.
 fn sanitize_warning(message: impl std::fmt::Display) -> String {
-    message
-        .to_string()
-        .chars()
-        .map(|character| {
-            if character == '\n' || character == '\t' || !character.is_control() {
-                character
-            } else {
-                ' '
-            }
-        })
-        .collect()
+    maki_lua::sanitize_message(&message.to_string())
+}
+
+fn load_external_packages(
+    host: &PluginHost,
+    packages: &[DiscoveredPackage],
+    declared: &[Declared],
+    reserved: &[String],
+    config: &maki_config::PluginsConfig,
+    interaction: Interaction,
+    delivers_agent_events: bool,
+) -> Result<Vec<String>> {
+    let lock_confirm = host
+        .pack_lock_confirm()
+        .context("read package confirmation")?;
+    let installed = maki_lua::install_declared(
+        host,
+        declared,
+        lock_confirm,
+        interaction,
+        delivers_agent_events,
+    );
+    let mut warnings = installed.failures;
+    let available: Vec<DiscoveredPackage> = packages
+        .iter()
+        .chain(installed.packages.iter())
+        .cloned()
+        .collect();
+
+    let active = host.active_packages().context("read active packages")?;
+    maki_lua::arm_packages(host, &available, declared, reserved, &active, config)
+        .context("catalog activatable packages")?;
+    warnings.extend(host.load_packages(packages, config));
+    warnings.extend(host.load_declared_packages(&installed.packages, declared, config));
+    warnings
+        .extend(maki_lua::drain_pack_ops(host, declared, &available, config, interaction).failures);
+
+    let active = host.active_packages().context("refresh active packages")?;
+    maki_lua::arm_packages(host, &available, declared, reserved, &active, config)
+        .context("refresh activatable packages")?;
+    Ok(warnings)
 }
 
 pub fn dispatch(cli: Cli) -> Result<()> {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -14,10 +14,39 @@ use crate::update;
 
 /// Strips control characters out of a message before it reaches a terminal.
 ///
-/// One rule, shared with the package code that formats its own warnings: a
-/// second copy here could start disagreeing about what is safe to print.
+/// Package code returns raw errors so logs keep their full detail. Terminal
+/// and UI boundaries call this function once before they display a warning.
 fn sanitize_warning(message: impl std::fmt::Display) -> String {
     maki_lua::sanitize_message(&message.to_string())
+}
+
+fn sanitize_warnings(warnings: Vec<String>) -> Vec<String> {
+    warnings.into_iter().map(sanitize_warning).collect()
+}
+
+fn report_warnings(warnings: Vec<String>) {
+    for warning in sanitize_warnings(warnings) {
+        eprintln!("warning: {warning}");
+    }
+}
+
+struct PackageDiscovery {
+    names: Vec<String>,
+    packages: Vec<DiscoveredPackage>,
+    warnings: Vec<String>,
+}
+
+fn discover_external_packages(no_plugins: bool) -> PackageDiscovery {
+    let discovery = maki_lua::discover_installed(no_plugins);
+    PackageDiscovery {
+        names: discovery.known_names(),
+        packages: discovery.packages,
+        warnings: discovery
+            .problems
+            .into_iter()
+            .map(|problem| format!("skipping package: {problem}"))
+            .collect(),
+    }
 }
 
 fn load_external_packages(
@@ -29,16 +58,7 @@ fn load_external_packages(
     interaction: Interaction,
     delivers_agent_events: bool,
 ) -> Result<Vec<String>> {
-    let lock_confirm = host
-        .pack_lock_confirm()
-        .context("read package confirmation")?;
-    let installed = maki_lua::install_declared(
-        host,
-        declared,
-        lock_confirm,
-        interaction,
-        delivers_agent_events,
-    );
+    let installed = maki_lua::install_declared(host, declared, interaction, delivers_agent_events);
     let mut warnings = installed.failures;
     let available: Vec<DiscoveredPackage> = packages
         .iter()

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -598,12 +598,7 @@ fn drain_declared(
         .chain(&installed.packages)
         .cloned()
         .collect();
-    let mut active: std::collections::BTreeSet<String> = available
-        .iter()
-        .filter(|p| p.eager && config.packages.iter().any(|n| n == &p.name))
-        .map(|p| p.name.clone())
-        .collect();
-    maki_lua::drain_pack_ops(host, declared, &available, &mut active, config).failures
+    maki_lua::drain_pack_ops(host, declared, &available, config).failures
 }
 
 pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -543,14 +543,9 @@ pub fn models(no_plugins: bool, no_jit: bool) -> Result<()> {
 
     let host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
         .context("initialize lua plugin host")?;
-    let discovery = maki_lua::discover_installed(no_plugins);
-    let names = discovery.known_names();
-    for problem in discovery.problems {
-        eprintln!(
-            "warning: {}",
-            super::sanitize_warning(format!("skipping package: {problem}"))
-        );
-    }
+    let discovery = super::discover_external_packages(no_plugins);
+    let names = discovery.names;
+    super::report_warnings(discovery.warnings);
     let config = load_effective_config(&host, no_plugins, &cwd, &names)?;
 
     smol::block_on(fetch_all_models(
@@ -599,14 +594,9 @@ pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
     let mut host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
         .context("initialize lua plugin host")?;
 
-    let discovery = maki_lua::discover_installed(no_plugins);
-    let names = discovery.known_names();
-    for problem in discovery.problems {
-        eprintln!(
-            "warning: {}",
-            super::sanitize_warning(format!("skipping package: {problem}"))
-        );
-    }
+    let discovery = super::discover_external_packages(no_plugins);
+    let names = discovery.names;
+    super::report_warnings(discovery.warnings);
     let packages = discovery.packages;
     let raw_config = host
         .load_init_files_or_skip(no_plugins, &cwd)
@@ -632,7 +622,7 @@ pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
 
     host.load_builtins(&config.plugins)
         .context("load builtin plugins")?;
-    for warning in super::load_external_packages(
+    super::report_warnings(super::load_external_packages(
         &host,
         &packages,
         &declared,
@@ -640,9 +630,7 @@ pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
         &config.plugins,
         maki_lua::Interaction::None,
         false,
-    )? {
-        eprintln!("warning: {warning}");
-    }
+    )?);
 
     let abs_path = Path::new(path)
         .canonicalize()
@@ -728,14 +716,9 @@ pub fn prompt(
     let reg = ToolRegistry::global_arc();
     let mut host =
         PluginHost::with_jit(Arc::clone(reg), !no_jit).context("initialize lua plugin host")?;
-    let discovery = maki_lua::discover_installed(no_plugins);
-    let package_names = discovery.known_names();
-    for problem in discovery.problems {
-        eprintln!(
-            "warning: {}",
-            super::sanitize_warning(format!("skipping package: {problem}"))
-        );
-    }
+    let discovery = super::discover_external_packages(no_plugins);
+    let package_names = discovery.names;
+    super::report_warnings(discovery.warnings);
     let packages = discovery.packages;
     let raw_config = host
         .load_init_files_or_skip(no_plugins, &cwd)
@@ -758,7 +741,7 @@ pub fn prompt(
         .context("invalid config")?;
     host.load_builtins(&config.plugins)
         .context("load builtin plugins")?;
-    for warning in super::load_external_packages(
+    super::report_warnings(super::load_external_packages(
         &host,
         &packages,
         &declared,
@@ -766,9 +749,7 @@ pub fn prompt(
         &config.plugins,
         maki_lua::Interaction::None,
         false,
-    )? {
-        eprintln!("warning: {warning}");
-    }
+    )?);
 
     if tools {
         let ctx = DescriptionContext {

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -544,14 +544,14 @@ pub fn models(no_plugins: bool, no_jit: bool) -> Result<()> {
     let host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
         .context("initialize lua plugin host")?;
     let discovery = maki_lua::discover_installed(no_plugins);
+    let names = discovery.known_names();
     for problem in discovery.problems {
         eprintln!(
             "warning: {}",
             super::sanitize_warning(format!("skipping package: {problem}"))
         );
     }
-    let packages = discovery.packages;
-    let config = load_effective_config(&host, no_plugins, &cwd, &packages)?;
+    let config = load_effective_config(&host, no_plugins, &cwd, &names)?;
 
     smol::block_on(fetch_all_models(
         &config.provider.model_policy,
@@ -572,7 +572,7 @@ fn load_effective_config(
     host: &PluginHost,
     no_plugins: bool,
     cwd: &Path,
-    packages: &[maki_lua::DiscoveredPackage],
+    names: &[String],
 ) -> Result<Config> {
     let raw = host
         .load_init_files_or_skip(no_plugins, cwd)
@@ -582,9 +582,9 @@ fn load_effective_config(
     } else {
         host.declared_packages().context("read declared packages")?
     };
-    let known: Vec<String> = packages
+    let known: Vec<String> = names
         .iter()
-        .map(|package| package.name.clone())
+        .cloned()
         .chain(declared.into_iter().map(|package| package.spec.name))
         .collect();
     raw.unwrap_or_default()
@@ -600,6 +600,7 @@ pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
         .context("initialize lua plugin host")?;
 
     let discovery = maki_lua::discover_installed(no_plugins);
+    let names = discovery.known_names();
     for problem in discovery.problems {
         eprintln!(
             "warning: {}",
@@ -618,9 +619,9 @@ pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
         host.declared_packages().context("read declared packages")?
     };
 
-    let known: Vec<String> = packages
+    let known: Vec<String> = names
         .iter()
-        .map(|p| p.name.clone())
+        .cloned()
         .chain(declared.iter().map(|d| d.spec.name.clone()))
         .collect();
     let mut config = raw_config
@@ -728,6 +729,7 @@ pub fn prompt(
     let mut host =
         PluginHost::with_jit(Arc::clone(reg), !no_jit).context("initialize lua plugin host")?;
     let discovery = maki_lua::discover_installed(no_plugins);
+    let package_names = discovery.known_names();
     for problem in discovery.problems {
         eprintln!(
             "warning: {}",
@@ -745,9 +747,9 @@ pub fn prompt(
     } else {
         host.declared_packages().context("read declared packages")?
     };
-    let known: Vec<String> = packages
+    let known: Vec<String> = package_names
         .iter()
-        .map(|p| p.name.clone())
+        .cloned()
         .chain(declared.iter().map(|d| d.spec.name.clone()))
         .collect();
     let config = raw_config

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -574,31 +574,22 @@ fn load_effective_config(
     cwd: &Path,
     packages: &[maki_lua::DiscoveredPackage],
 ) -> Result<Config> {
-    let names: Vec<String> = packages.iter().map(|p| p.name.clone()).collect();
-    host.load_init_files_or_skip(no_plugins, cwd)
-        .context("load init.lua files")?
-        .unwrap_or_default()
-        .into_config(false, &names)
-        .context("invalid config")
-}
-
-/// Applies whatever the init files recorded, once every package is loaded.
-///
-/// Draining here and not inside the Lua call is what keeps an unload off the
-/// thread that asked for it.
-fn drain_declared(
-    host: &PluginHost,
-    declared: &[maki_lua::Declared],
-    packages: &[maki_lua::DiscoveredPackage],
-    installed: &maki_lua::InstallReport,
-    config: &maki_config::PluginsConfig,
-) -> Vec<String> {
-    let available: Vec<maki_lua::DiscoveredPackage> = packages
+    let raw = host
+        .load_init_files_or_skip(no_plugins, cwd)
+        .context("load init.lua files")?;
+    let declared = if no_plugins {
+        Vec::new()
+    } else {
+        host.declared_packages().context("read declared packages")?
+    };
+    let known: Vec<String> = packages
         .iter()
-        .chain(&installed.packages)
-        .cloned()
+        .map(|package| package.name.clone())
+        .chain(declared.into_iter().map(|package| package.spec.name))
         .collect();
-    maki_lua::drain_pack_ops(host, declared, &available, config).failures
+    raw.unwrap_or_default()
+        .into_config(false, &known)
+        .context("invalid config")
 }
 
 pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
@@ -640,21 +631,15 @@ pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
 
     host.load_builtins(&config.plugins)
         .context("load builtin plugins")?;
-    for warning in host.load_packages(&packages, &config.plugins) {
-        eprintln!("warning: {warning}");
-    }
-    let installed = maki_lua::install_declared(&declared, maki_lua::Interaction::None);
-    for warning in installed
-        .failures
-        .iter()
-        .cloned()
-        .chain(host.load_packages(&installed.packages, &config.plugins))
-    {
-        eprintln!("warning: {warning}");
-    }
-    // Same order as the terminal entry point. Without this a `maki.packadd`
-    // in init.lua would be recorded here and never applied.
-    for warning in drain_declared(&host, &declared, &packages, &installed, &config.plugins) {
+    for warning in super::load_external_packages(
+        &host,
+        &packages,
+        &declared,
+        &[],
+        &config.plugins,
+        maki_lua::Interaction::None,
+        false,
+    )? {
         eprintln!("warning: {warning}");
     }
 
@@ -771,21 +756,15 @@ pub fn prompt(
         .context("invalid config")?;
     host.load_builtins(&config.plugins)
         .context("load builtin plugins")?;
-    for warning in host.load_packages(&packages, &config.plugins) {
-        eprintln!("warning: {warning}");
-    }
-    let installed = maki_lua::install_declared(&declared, maki_lua::Interaction::None);
-    for warning in installed
-        .failures
-        .iter()
-        .cloned()
-        .chain(host.load_packages(&installed.packages, &config.plugins))
-    {
-        eprintln!("warning: {warning}");
-    }
-    // Same order as the terminal entry point. Without this a `maki.packadd`
-    // in init.lua would be recorded here and never applied.
-    for warning in drain_declared(&host, &declared, &packages, &installed, &config.plugins) {
+    for warning in super::load_external_packages(
+        &host,
+        &packages,
+        &declared,
+        &[],
+        &config.plugins,
+        maki_lua::Interaction::None,
+        false,
+    )? {
         eprintln!("warning: {warning}");
     }
 

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -582,6 +582,30 @@ fn load_effective_config(
         .context("invalid config")
 }
 
+/// Applies whatever the init files recorded, once every package is loaded.
+///
+/// Draining here and not inside the Lua call is what keeps an unload off the
+/// thread that asked for it.
+fn drain_declared(
+    host: &PluginHost,
+    declared: &[maki_lua::Declared],
+    packages: &[maki_lua::DiscoveredPackage],
+    installed: &maki_lua::InstallReport,
+    config: &maki_config::PluginsConfig,
+) -> Vec<String> {
+    let available: Vec<maki_lua::DiscoveredPackage> = packages
+        .iter()
+        .chain(&installed.packages)
+        .cloned()
+        .collect();
+    let mut active: std::collections::BTreeSet<String> = available
+        .iter()
+        .filter(|p| p.eager && config.packages.iter().any(|n| n == &p.name))
+        .map(|p| p.name.clone())
+        .collect();
+    maki_lua::drain_pack_ops(host, declared, &available, &mut active, config).failures
+}
+
 pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
     let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
     load_env_files(&cwd);
@@ -600,17 +624,42 @@ pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
     let raw_config = host
         .load_init_files_or_skip(no_plugins, &cwd)
         .context("load init.lua files")?;
+    // Declared packages are read after the init files, so they configure and
+    // install here as they do under the terminal UI.
+    let declared = if no_plugins {
+        Vec::new()
+    } else {
+        host.declared_packages().context("read declared packages")?
+    };
 
-    let names: Vec<String> = packages.iter().map(|p| p.name.clone()).collect();
+    let known: Vec<String> = packages
+        .iter()
+        .map(|p| p.name.clone())
+        .chain(declared.iter().map(|d| d.spec.name.clone()))
+        .collect();
     let mut config = raw_config
         .unwrap_or_default()
-        .into_config(false, &names)
+        .into_config(false, &known)
         .context("invalid config")?;
     config.permissions = load_permissions(&cwd);
 
     host.load_builtins(&config.plugins)
         .context("load builtin plugins")?;
     for warning in host.load_packages(&packages, &config.plugins) {
+        eprintln!("warning: {warning}");
+    }
+    let installed = maki_lua::install_declared(&declared, maki_lua::Interaction::None);
+    for warning in installed
+        .failures
+        .iter()
+        .cloned()
+        .chain(host.load_packages(&installed.packages, &config.plugins))
+    {
+        eprintln!("warning: {warning}");
+    }
+    // Same order as the terminal entry point. Without this a `maki.packadd`
+    // in init.lua would be recorded here and never applied.
+    for warning in drain_declared(&host, &declared, &packages, &installed, &config.plugins) {
         eprintln!("warning: {warning}");
     }
 
@@ -709,14 +758,39 @@ pub fn prompt(
     let raw_config = host
         .load_init_files_or_skip(no_plugins, &cwd)
         .context("load init.lua files")?;
-    let package_names: Vec<String> = packages.iter().map(|p| p.name.clone()).collect();
+    // Declared packages are read after the init files, so they configure and
+    // install here as they do under the terminal UI.
+    let declared = if no_plugins {
+        Vec::new()
+    } else {
+        host.declared_packages().context("read declared packages")?
+    };
+    let known: Vec<String> = packages
+        .iter()
+        .map(|p| p.name.clone())
+        .chain(declared.iter().map(|d| d.spec.name.clone()))
+        .collect();
     let config = raw_config
         .unwrap_or_default()
-        .into_config(false, &package_names)
+        .into_config(false, &known)
         .context("invalid config")?;
     host.load_builtins(&config.plugins)
         .context("load builtin plugins")?;
     for warning in host.load_packages(&packages, &config.plugins) {
+        eprintln!("warning: {warning}");
+    }
+    let installed = maki_lua::install_declared(&declared, maki_lua::Interaction::None);
+    for warning in installed
+        .failures
+        .iter()
+        .cloned()
+        .chain(host.load_packages(&installed.packages, &config.plugins))
+    {
+        eprintln!("warning: {warning}");
+    }
+    // Same order as the terminal entry point. Without this a `maki.packadd`
+    // in init.lua would be recorded here and never applied.
+    for warning in drain_declared(&host, &declared, &packages, &installed, &config.plugins) {
         eprintln!("warning: {warning}");
     }
 

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -543,7 +543,15 @@ pub fn models(no_plugins: bool, no_jit: bool) -> Result<()> {
 
     let host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
         .context("initialize lua plugin host")?;
-    let config = load_effective_config(&host, no_plugins, &cwd)?;
+    let discovery = maki_lua::discover_installed(no_plugins);
+    for problem in discovery.problems {
+        eprintln!(
+            "warning: {}",
+            super::sanitize_warning(format!("skipping package: {problem}"))
+        );
+    }
+    let packages = discovery.packages;
+    let config = load_effective_config(&host, no_plugins, &cwd, &packages)?;
 
     smol::block_on(fetch_all_models(
         &config.provider.model_policy,
@@ -560,11 +568,17 @@ pub fn models(no_plugins: bool, no_jit: bool) -> Result<()> {
     Ok(())
 }
 
-fn load_effective_config(host: &PluginHost, no_plugins: bool, cwd: &Path) -> Result<Config> {
+fn load_effective_config(
+    host: &PluginHost,
+    no_plugins: bool,
+    cwd: &Path,
+    packages: &[maki_lua::DiscoveredPackage],
+) -> Result<Config> {
+    let names: Vec<String> = packages.iter().map(|p| p.name.clone()).collect();
     host.load_init_files_or_skip(no_plugins, cwd)
         .context("load init.lua files")?
         .unwrap_or_default()
-        .into_config(false)
+        .into_config(false, &names)
         .context("invalid config")
 }
 
@@ -575,18 +589,30 @@ pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
     let mut host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !no_jit)
         .context("initialize lua plugin host")?;
 
+    let discovery = maki_lua::discover_installed(no_plugins);
+    for problem in discovery.problems {
+        eprintln!(
+            "warning: {}",
+            super::sanitize_warning(format!("skipping package: {problem}"))
+        );
+    }
+    let packages = discovery.packages;
     let raw_config = host
         .load_init_files_or_skip(no_plugins, &cwd)
         .context("load init.lua files")?;
 
+    let names: Vec<String> = packages.iter().map(|p| p.name.clone()).collect();
     let mut config = raw_config
         .unwrap_or_default()
-        .into_config(false)
+        .into_config(false, &names)
         .context("invalid config")?;
     config.permissions = load_permissions(&cwd);
 
     host.load_builtins(&config.plugins)
         .context("load builtin plugins")?;
+    for warning in host.load_packages(&packages, &config.plugins) {
+        eprintln!("warning: {warning}");
+    }
 
     let abs_path = Path::new(path)
         .canonicalize()
@@ -672,15 +698,27 @@ pub fn prompt(
     let reg = ToolRegistry::global_arc();
     let mut host =
         PluginHost::with_jit(Arc::clone(reg), !no_jit).context("initialize lua plugin host")?;
+    let discovery = maki_lua::discover_installed(no_plugins);
+    for problem in discovery.problems {
+        eprintln!(
+            "warning: {}",
+            super::sanitize_warning(format!("skipping package: {problem}"))
+        );
+    }
+    let packages = discovery.packages;
     let raw_config = host
         .load_init_files_or_skip(no_plugins, &cwd)
         .context("load init.lua files")?;
+    let package_names: Vec<String> = packages.iter().map(|p| p.name.clone()).collect();
     let config = raw_config
         .unwrap_or_default()
-        .into_config(false)
+        .into_config(false, &package_names)
         .context("invalid config")?;
     host.load_builtins(&config.plugins)
         .context("load builtin plugins")?;
+    for warning in host.load_packages(&packages, &config.plugins) {
+        eprintln!("warning: {warning}");
+    }
 
     if tools {
         let ctx = DescriptionContext {

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -11,7 +11,7 @@ use color_eyre::eyre::Context;
 use maki_agent::command::{self, CustomCommand};
 use maki_agent::tools::ToolRegistry;
 use maki_config::{Config, load_env_files, load_permissions};
-use maki_lua::PluginHost;
+use maki_lua::{DiscoveredPackage, PluginHost};
 use maki_providers::model::Model;
 use maki_storage::StateDir;
 use maki_storage::id::MakiId;
@@ -81,14 +81,20 @@ fn discover_commands(disable: bool) -> Vec<CustomCommand> {
     command::discover_commands(&cwd)
 }
 
-fn load_config(plugin_host: &PluginHost, cli: &Cli, cwd: &Path) -> Result<Config> {
+fn load_config(
+    plugin_host: &PluginHost,
+    cli: &Cli,
+    cwd: &Path,
+    packages: &[DiscoveredPackage],
+) -> Result<Config> {
     let raw_config = plugin_host
         .load_init_files_or_skip(cli.no_plugins, cwd)
         .context("load init.lua files")?;
 
+    let names: Vec<String> = packages.iter().map(|p| p.name.clone()).collect();
     let mut config = raw_config
         .unwrap_or_default()
-        .into_config(cli.no_rtk)
+        .into_config(cli.no_rtk, &names)
         .context("invalid config")?;
     config.permissions = load_permissions(cwd);
 
@@ -142,10 +148,21 @@ fn build_stack(
     let mut plugin_host = PluginHost::with_jit(Arc::clone(ToolRegistry::global_arc()), !cli.no_jit)
         .context("initialize lua plugin host")?;
 
+    // Discovered before the config is built, so `plugins.<name>` can configure
+    // an installed package, and reused afterwards to load it.
+    let discovery = maki_lua::discover_installed(cli.no_plugins);
+    warnings.extend(
+        discovery
+            .problems
+            .into_iter()
+            .map(|problem| super::sanitize_warning(format!("skipping package: {problem}"))),
+    );
+    let packages = discovery.packages;
+
     let (fallback_config, fallback_model) = fallback.unzip();
     let reloading = fallback_model.is_some();
     let config = config_or_fallback(
-        load_config(&plugin_host, cli, cwd),
+        load_config(&plugin_host, cli, cwd, &packages),
         fallback_config,
         &mut warnings,
     )?;
@@ -158,6 +175,10 @@ fn build_stack(
             return Err(e);
         }
     }
+
+    // After the builtins, so a package claiming a builtin tool name is the side
+    // that fails rather than breaking the builtin.
+    warnings.extend(plugin_host.load_packages(&packages, &config.plugins));
 
     let commands = discover_commands(cli.no_commands);
 
@@ -242,12 +263,22 @@ pub fn run(mut cli: Cli) -> Result<()> {
     load_env_files(&cwd);
     warn_stale_config_toml(&cwd);
 
-    let (mut stack, _) = build_stack(&cli, &cwd, &storage, None)?;
+    let (mut stack, startup_warnings) = build_stack(&cli, &cwd, &storage, None)?;
 
     setup::init_logging(&stack.config.storage);
     setup::init_telemetry(&stack.config.telemetry);
     setup::install_panic_log_hook();
     setup::warn_ignored_provider_fields();
+
+    // Discovery runs before logging is initialized, so a package problem has
+    // no log to reach either. The TUI shows these in its first generation; a
+    // mode that never opens the UI has to report them here or a broken
+    // package fails in complete silence.
+    if cli.is_sdk_mode() || cli.print {
+        for warning in &startup_warnings {
+            eprintln!("warning: {warning}");
+        }
+    }
 
     if cli.is_sdk_mode() {
         let fast = stack.config.always_fast && stack.model.supports_fast();
@@ -299,7 +330,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
         &storage,
     )?];
     let mut focused = 0;
-    let mut warnings: Vec<String> = Vec::new();
+    let mut warnings = startup_warnings;
     let mut initial_prompt = read_initial_prompt(cli.initial_prompt.take())?;
     let mut teardown = Teardown::default();
 
@@ -473,7 +504,7 @@ mod tests {
 
     fn test_config() -> Config {
         RawConfig::default()
-            .into_config(false)
+            .into_config(false, &[])
             .expect("default config")
     }
 
@@ -530,7 +561,7 @@ mod tests {
         let mut plugin_host = PluginHost::with_jit(Arc::new(ToolRegistry::new()), true)
             .expect("live host boots under --no-plugins");
 
-        let config = load_config(&plugin_host, &cli, dir.path())
+        let config = load_config(&plugin_host, &cli, dir.path(), &[])
             .expect("no-plugins must skip the broken init.lua and still load defaults");
         assert!(
             !config.plugins.names.is_empty(),
@@ -568,7 +599,7 @@ mod tests {
         let mut plugin_host =
             PluginHost::with_jit(Arc::new(ToolRegistry::new()), true).expect("live host boots");
 
-        match load_config(&plugin_host, &cli, dir.path()) {
+        match load_config(&plugin_host, &cli, dir.path(), &[]) {
             Err(_) => {}
             Ok(_) => panic!("broken init.lua must error without --no-plugins"),
         }

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeSet;
 use std::env;
 use std::io::{self, IsTerminal, Read};
 use std::path::Path;
@@ -74,24 +73,46 @@ impl Drop for Teardown {
     }
 }
 
-/// Which package owners are loaded right now.
+/// Carries out `/packupdate` or `/packdel`, and reports what happened.
 ///
-/// `load_packages` skips a package that is not eager or that the config
-/// disabled, so the set of packages handed to it is not the set that loaded.
-/// This applies the same two filters, and is the answer an update needs to
-/// decide whether reloading a package would start something that was
-/// deliberately left dormant.
-fn active_owners(
-    manual: &[DiscoveredPackage],
-    installed: &[DiscoveredPackage],
-    config: &maki_config::PluginsConfig,
-) -> BTreeSet<String> {
-    manual
-        .iter()
-        .chain(installed)
-        .filter(|p| p.eager && config.packages.iter().any(|n| n == &p.name))
-        .map(|p| p.name.clone())
-        .collect()
+/// Runs between UI generations, which is the one place that can do this: it is
+/// off the Lua thread, so unloading an owner cannot wait on the thread that
+/// asked for it, and the terminal is not held, so a clone cannot stall a
+/// redraw.
+fn run_pack_command(stack: &Stack, request: &maki_ui::PackRequest) -> Vec<String> {
+    let cmd = match maki_lua::PackCommand::parse(&request.name, &request.args) {
+        Ok(cmd) => cmd,
+        Err(msg) => return vec![msg],
+    };
+    let declared = match stack.plugin_host.declared_packages() {
+        Ok(declared) => declared,
+        Err(e) => return vec![format!("could not read declared packages: {e}")],
+    };
+    let installed = match maki_lua::installed_names() {
+        Some(installed) => installed,
+        None => return vec!["could not read the package lockfile".to_owned()],
+    };
+    let active = match stack.plugin_host.active_packages() {
+        Ok(active) => active,
+        Err(error) => return vec![format!("could not read active packages: {error}")],
+    };
+
+    let ops = match maki_lua::plan_command(&cmd, request.bang, &declared, &installed, &active) {
+        Ok(ops) => ops,
+        Err(msg) => return vec![msg],
+    };
+    // `/packupdate` and `/packdel` name managed packages, which resolve from
+    // the lockfile, so no discovered set is needed here.
+    let report = maki_lua::apply_pack_ops(
+        &stack.plugin_host,
+        &ops,
+        &declared,
+        &[],
+        &stack.config.plugins,
+    );
+    let mut messages = vec![report.summary()];
+    messages.extend(report.failures.iter().cloned());
+    messages
 }
 
 fn discover_commands(disable: bool) -> Vec<CustomCommand> {
@@ -156,16 +177,21 @@ fn load_config(
     Ok(config)
 }
 
+/// Returns the config to use, and whether it came from the fallback.
+///
+/// The second half matters because a rejected `init.lua` may also have called
+/// `maki.pack.del`. Reporting that the old config was kept and then deleting
+/// the package anyway would be the worst of both.
 fn config_or_fallback(
     loaded: Result<Config>,
     fallback: Option<Config>,
     warnings: &mut Vec<String>,
-) -> Result<Config> {
+) -> Result<(Config, bool)> {
     match (loaded, fallback) {
-        (Ok(config), _) => Ok(config),
+        (Ok(config), _) => Ok((config, false)),
         (Err(e), Some(last_good)) => {
             warnings.push(format!("{CONFIG_FALLBACK_WARNING}: {e:#}"));
-            Ok(last_good)
+            Ok((last_good, true))
         }
         (Err(e), None) => Err(e),
     }
@@ -198,7 +224,7 @@ fn build_stack(
 
     let (fallback_config, fallback_model) = fallback.unzip();
     let reloading = fallback_model.is_some();
-    let config = config_or_fallback(
+    let (config, config_rejected) = config_or_fallback(
         load_config(&plugin_host, cli, cwd, &packages),
         fallback_config,
         &mut warnings,
@@ -221,6 +247,14 @@ fn build_stack(
     // inside the call keeps a clone off the Lua thread, and is the phase
     // Neovim's own `load` default defers to.
     match plugin_host.declared_packages() {
+        // Checked before anything is cloned or loaded, not after. A refused
+        // config must not have any part of itself carried out, and installing
+        // is already a visible act: it reaches the network, writes the
+        // lockfile, and can run the fetched code under a package name the
+        // fallback config happens to enable.
+        Ok(_) if config_rejected => {
+            warnings.push("package changes in the rejected config were not applied".to_owned());
+        }
         Ok(declared) => {
             let installed = maki_lua::install_declared(&declared, maki_lua::Interaction::Tty);
             warnings.extend(installed.failures.iter().cloned());
@@ -231,19 +265,13 @@ fn build_stack(
             // that was running. This is also the only safe place for it: the
             // work unloads owners, which waits on the Lua thread, so it cannot
             // run inside the Lua call that asked for it.
-            let mut active = active_owners(&packages, &installed.packages, &config.plugins);
             let available: Vec<maki_lua::DiscoveredPackage> = packages
                 .iter()
                 .chain(&installed.packages)
                 .cloned()
                 .collect();
-            let report = maki_lua::drain_pack_ops(
-                &plugin_host,
-                &declared,
-                &available,
-                &mut active,
-                &config.plugins,
-            );
+            let report =
+                maki_lua::drain_pack_ops(&plugin_host, &declared, &available, &config.plugins);
             warnings.extend(report.failures.iter().cloned());
         }
         Err(e) => warnings.push(format!("could not read declared packages: {e}")),
@@ -479,9 +507,17 @@ pub fn run(mut cli: Cli) -> Result<()> {
             RunOutcome::Reload {
                 tabs: reloaded,
                 focused: f,
+                pack,
             } => {
                 let started = Instant::now();
                 let last_good = (stack.config.clone(), stack.model.clone());
+                // Before the host is shut down, because the work needs it: an
+                // update unloads the old owner and loads the new one. The
+                // generation is then rebuilt below, exactly as `/reload` does,
+                // so the session comes back with the new package set.
+                let pack_messages = pack
+                    .map(|request| run_pack_command(&stack, &request))
+                    .unwrap_or_default();
                 // Shut the old host down first so nothing can repopulate
                 // the registry after the clear: its senders disconnect, the
                 // watchdog aborts in-flight callbacks, and only this thread
@@ -499,7 +535,12 @@ pub fn run(mut cli: Cli) -> Result<()> {
                     tabs.push(session);
                 }
                 stack = new_stack;
-                warnings = new_warnings;
+                // Ahead of the rebuild's own warnings, and not replaced by
+                // them. The user typed the command that produced these, so
+                // losing them to the reload would answer a direct request
+                // with silence.
+                warnings = pack_messages;
+                warnings.extend(new_warnings);
                 focused = f.min(tabs.len() - 1);
                 tracing::info!(
                     elapsed_ms = started.elapsed().as_millis() as u64,
@@ -583,10 +624,15 @@ mod tests {
         last_good.always_fast = true;
         let mut warnings = Vec::new();
 
-        let config = config_or_fallback(Err(eyre!("boom")), Some(last_good), &mut warnings)
-            .expect("fallback config");
+        let (config, rejected) =
+            config_or_fallback(Err(eyre!("boom")), Some(last_good), &mut warnings)
+                .expect("fallback config");
 
         assert!(config.always_fast);
+        assert!(
+            rejected,
+            "the caller has to know the new config was refused"
+        );
         assert_eq!(warnings.len(), 1);
         assert!(
             warnings[0].starts_with(CONFIG_FALLBACK_WARNING),

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::env;
 use std::io::{self, IsTerminal, Read};
 use std::path::Path;
@@ -73,6 +74,26 @@ impl Drop for Teardown {
     }
 }
 
+/// Which package owners are loaded right now.
+///
+/// `load_packages` skips a package that is not eager or that the config
+/// disabled, so the set of packages handed to it is not the set that loaded.
+/// This applies the same two filters, and is the answer an update needs to
+/// decide whether reloading a package would start something that was
+/// deliberately left dormant.
+fn active_owners(
+    manual: &[DiscoveredPackage],
+    installed: &[DiscoveredPackage],
+    config: &maki_config::PluginsConfig,
+) -> BTreeSet<String> {
+    manual
+        .iter()
+        .chain(installed)
+        .filter(|p| p.eager && config.packages.iter().any(|n| n == &p.name))
+        .map(|p| p.name.clone())
+        .collect()
+}
+
 fn discover_commands(disable: bool) -> Vec<CustomCommand> {
     if disable {
         return Vec::new();
@@ -91,10 +112,26 @@ fn load_config(
         .load_init_files_or_skip(cli.no_plugins, cwd)
         .context("load init.lua files")?;
 
-    let names: Vec<String> = packages.iter().map(|p| p.name.clone()).collect();
+    // Read after the init files, because that is when `maki.pack.add` has run
+    // and the declared set is complete. Both discovered and declared names
+    // have to be known before validation, or `plugins.<name>` would reject a
+    // package the user just declared.
+    let declared = if cli.no_plugins {
+        Vec::new()
+    } else {
+        plugin_host
+            .declared_packages()
+            .context("read declared packages")?
+    };
+
+    let known: Vec<String> = packages
+        .iter()
+        .map(|p| p.name.clone())
+        .chain(declared.iter().map(|d| d.spec.name.clone()))
+        .collect();
     let mut config = raw_config
         .unwrap_or_default()
-        .into_config(cli.no_rtk, &names)
+        .into_config(cli.no_rtk, &known)
         .context("invalid config")?;
     config.permissions = load_permissions(cwd);
 
@@ -179,6 +216,38 @@ fn build_stack(
     // After the builtins, so a package claiming a builtin tool name is the side
     // that fails rather than breaking the builtin.
     warnings.extend(plugin_host.load_packages(&packages, &config.plugins));
+
+    // Declared with `maki.pack.add` in init.lua. Installing here rather than
+    // inside the call keeps a clone off the Lua thread, and is the phase
+    // Neovim's own `load` default defers to.
+    match plugin_host.declared_packages() {
+        Ok(declared) => {
+            let installed = maki_lua::install_declared(&declared, maki_lua::Interaction::Tty);
+            warnings.extend(installed.failures.iter().cloned());
+            warnings.extend(plugin_host.load_packages(&installed.packages, &config.plugins));
+
+            // Applied last, once every package `init.lua` could have named is
+            // loaded, so an update knows whether it is reloading something
+            // that was running. This is also the only safe place for it: the
+            // work unloads owners, which waits on the Lua thread, so it cannot
+            // run inside the Lua call that asked for it.
+            let mut active = active_owners(&packages, &installed.packages, &config.plugins);
+            let available: Vec<maki_lua::DiscoveredPackage> = packages
+                .iter()
+                .chain(&installed.packages)
+                .cloned()
+                .collect();
+            let report = maki_lua::drain_pack_ops(
+                &plugin_host,
+                &declared,
+                &available,
+                &mut active,
+                &config.plugins,
+            );
+            warnings.extend(report.failures.iter().cloned());
+        }
+        Err(e) => warnings.push(format!("could not read declared packages: {e}")),
+    }
 
     let commands = discover_commands(cli.no_commands);
 

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -189,7 +189,7 @@ fn load_config(
     plugin_host: &PluginHost,
     cli: &Cli,
     cwd: &Path,
-    packages: &[DiscoveredPackage],
+    names: &[String],
 ) -> Result<Config> {
     let raw_config = plugin_host
         .load_init_files_or_skip(cli.no_plugins, cwd)
@@ -207,9 +207,9 @@ fn load_config(
             .context("read declared packages")?
     };
 
-    let known: Vec<String> = packages
+    let known: Vec<String> = names
         .iter()
-        .map(|p| p.name.clone())
+        .cloned()
         .chain(declared.iter().map(|d| d.spec.name.clone()))
         .collect();
 
@@ -277,6 +277,10 @@ fn build_stack(
     // Discovered before the config is built, so `plugins.<name>` can configure
     // an installed package, and reused afterwards to load it.
     let discovery = maki_lua::discover_installed(cli.no_plugins);
+    // Taken before the problems are consumed, and includes the names
+    // discovery refused, so a package it could not read does not become a
+    // config error pointing at the user's `plugins.<name>` table.
+    let names = discovery.known_names();
     warnings.extend(
         discovery
             .problems
@@ -288,7 +292,7 @@ fn build_stack(
     let (fallback_config, fallback_model) = fallback.unzip();
     let reloading = fallback_model.is_some();
     let (config, config_rejected) = config_or_fallback(
-        load_config(&plugin_host, cli, cwd, &packages),
+        load_config(&plugin_host, cli, cwd, &names),
         fallback_config,
         &mut warnings,
     )?;
@@ -328,6 +332,15 @@ fn build_stack(
             );
             warnings.extend(plugin_host.load_packages(&packages, &config.plugins));
             warnings.push("package changes in the rejected config were not applied".to_owned());
+            // Nothing drains the queue on this path, so it is closed here
+            // instead. Left open, every later `maki.packadd` that the runtime
+            // cannot serve would be recorded for a drain that already decided
+            // not to run.
+            if let Err(error) = plugin_host.seal_pack_ops() {
+                warnings.push(format!(
+                    "could not close the package activation queue: {error}"
+                ));
+            }
         }
         Ok(declared) => {
             let interaction = if cli.print || cli.is_sdk_mode() {

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -79,25 +79,27 @@ impl Drop for Teardown {
 /// off the Lua thread, so unloading an owner cannot wait on the thread that
 /// asked for it, and the terminal is not held, so a clone cannot stall a
 /// redraw.
-fn run_pack_command(stack: &Stack, request: &maki_ui::PackRequest) -> Vec<String> {
-    let cmd = match maki_lua::PackCommand::parse(&request.name, &request.args) {
-        Ok(cmd) => cmd,
-        Err(msg) => return vec![msg],
-    };
+fn run_pack_command(
+    stack: &Stack,
+    command: &maki_lua::PackCommand,
+    no_plugins: bool,
+    reserved: &[String],
+) -> Vec<String> {
     let declared = match stack.plugin_host.declared_packages() {
         Ok(declared) => declared,
         Err(e) => return vec![format!("could not read declared packages: {e}")],
     };
-    let installed = match maki_lua::installed_names() {
-        Some(installed) => installed,
-        None => return vec!["could not read the package lockfile".to_owned()],
-    };
+
     let active = match stack.plugin_host.active_packages() {
         Ok(active) => active,
         Err(error) => return vec![format!("could not read active packages: {error}")],
     };
+    let installed = match maki_lua::installed_names() {
+        Some(installed) => installed,
+        None => return vec!["the pack lockfile is unreadable".to_owned()],
+    };
 
-    let ops = match maki_lua::plan_command(&cmd, request.bang, &declared, &installed, &active) {
+    let ops = match maki_lua::plan_command(command, &declared, &installed, &active) {
         Ok(ops) => ops,
         Err(msg) => return vec![msg],
     };
@@ -109,10 +111,70 @@ fn run_pack_command(stack: &Stack, request: &maki_ui::PackRequest) -> Vec<String
         &declared,
         &[],
         &stack.config.plugins,
+        maki_lua::Interaction::Tty,
     );
     let mut messages = vec![report.summary()];
     messages.extend(report.failures.iter().cloned());
+    let discovery = maki_lua::discover_installed(no_plugins);
+    messages.extend(
+        discovery
+            .problems
+            .into_iter()
+            .map(|problem| super::sanitize_warning(format!("skipping package: {problem}"))),
+    );
+    let available: Vec<DiscoveredPackage> = discovery
+        .packages
+        .into_iter()
+        .chain(
+            declared
+                .iter()
+                .filter_map(|package| maki_lua::installed_package(&package.spec.name)),
+        )
+        .collect();
+    match stack.plugin_host.active_packages() {
+        Ok(active) => {
+            if let Err(error) = maki_lua::arm_packages(
+                &stack.plugin_host,
+                &available,
+                &declared,
+                reserved,
+                &active,
+                &stack.config.plugins,
+            ) {
+                messages.push(format!("could not refresh package state: {error}"));
+            }
+        }
+        Err(error) => messages.push(format!("could not refresh package state: {error}")),
+    }
     messages
+}
+
+fn reserved_command_names(commands: &[CustomCommand]) -> Vec<String> {
+    maki_ui::BUILTIN_COMMANDS
+        .iter()
+        .map(|command| command.name.to_string())
+        .chain(commands.iter().map(CustomCommand::display_name))
+        .collect()
+}
+
+fn catalog_packages(
+    host: &PluginHost,
+    packages: &[DiscoveredPackage],
+    declared: &[maki_lua::Declared],
+    reserved: &[String],
+    config: &maki_config::PluginsConfig,
+    warnings: &mut Vec<String>,
+) {
+    match host.active_packages() {
+        Ok(active) => {
+            if let Err(error) =
+                maki_lua::arm_packages(host, packages, declared, reserved, &active, config)
+            {
+                warnings.push(format!("could not catalog packages: {error}"));
+            }
+        }
+        Err(error) => warnings.push(format!("could not read active packages: {error}")),
+    }
 }
 
 fn discover_commands(disable: bool) -> Vec<CustomCommand> {
@@ -150,6 +212,7 @@ fn load_config(
         .map(|p| p.name.clone())
         .chain(declared.iter().map(|d| d.spec.name.clone()))
         .collect();
+
     let mut config = raw_config
         .unwrap_or_default()
         .into_config(cli.no_rtk, &known)
@@ -239,9 +302,11 @@ fn build_stack(
         }
     }
 
-    // After the builtins, so a package claiming a builtin tool name is the side
-    // that fails rather than breaking the builtin.
-    warnings.extend(plugin_host.load_packages(&packages, &config.plugins));
+    let commands = discover_commands(cli.no_commands);
+
+    // Everything the palette resolves ahead of a Lua command. A trigger on
+    // one of these would never fire, so it is removed from automatic matching.
+    let reserved = reserved_command_names(&commands);
 
     // Declared with `maki.pack.add` in init.lua. Installing here rather than
     // inside the call keeps a clone off the Lua thread, and is the phase
@@ -253,31 +318,46 @@ fn build_stack(
         // lockfile, and can run the fetched code under a package name the
         // fallback config happens to enable.
         Ok(_) if config_rejected => {
+            catalog_packages(
+                &plugin_host,
+                &packages,
+                &[],
+                &reserved,
+                &config.plugins,
+                &mut warnings,
+            );
+            warnings.extend(plugin_host.load_packages(&packages, &config.plugins));
             warnings.push("package changes in the rejected config were not applied".to_owned());
         }
         Ok(declared) => {
-            let installed = maki_lua::install_declared(&declared, maki_lua::Interaction::Tty);
-            warnings.extend(installed.failures.iter().cloned());
-            warnings.extend(plugin_host.load_packages(&installed.packages, &config.plugins));
-
-            // Applied last, once every package `init.lua` could have named is
-            // loaded, so an update knows whether it is reloading something
-            // that was running. This is also the only safe place for it: the
-            // work unloads owners, which waits on the Lua thread, so it cannot
-            // run inside the Lua call that asked for it.
-            let available: Vec<maki_lua::DiscoveredPackage> = packages
-                .iter()
-                .chain(&installed.packages)
-                .cloned()
-                .collect();
-            let report =
-                maki_lua::drain_pack_ops(&plugin_host, &declared, &available, &config.plugins);
-            warnings.extend(report.failures.iter().cloned());
+            let interaction = if cli.print || cli.is_sdk_mode() {
+                maki_lua::Interaction::None
+            } else {
+                maki_lua::Interaction::Tty
+            };
+            warnings.extend(super::load_external_packages(
+                &plugin_host,
+                &packages,
+                &declared,
+                &reserved,
+                &config.plugins,
+                interaction,
+                !cli.print && !cli.is_sdk_mode(),
+            )?);
         }
-        Err(e) => warnings.push(format!("could not read declared packages: {e}")),
+        Err(e) => {
+            catalog_packages(
+                &plugin_host,
+                &packages,
+                &[],
+                &reserved,
+                &config.plugins,
+                &mut warnings,
+            );
+            warnings.extend(plugin_host.load_packages(&packages, &config.plugins));
+            warnings.push(format!("could not read declared packages: {e}"));
+        }
     }
-
-    let commands = discover_commands(cli.no_commands);
 
     let model_result = setup::resolve_model(cli.model.as_deref(), &config.provider, storage);
     let (model, needs_login) = match (model_result, fallback_model) {
@@ -367,10 +447,6 @@ pub fn run(mut cli: Cli) -> Result<()> {
     setup::install_panic_log_hook();
     setup::warn_ignored_provider_fields();
 
-    // Discovery runs before logging is initialized, so a package problem has
-    // no log to reach either. The TUI shows these in its first generation; a
-    // mode that never opens the UI has to report them here or a broken
-    // package fails in complete silence.
     if cli.is_sdk_mode() || cli.print {
         for warning in &startup_warnings {
             eprintln!("warning: {warning}");
@@ -504,20 +580,32 @@ pub fn run(mut cli: Cli) -> Result<()> {
                 }
                 return Ok(());
             }
+            RunOutcome::Pack {
+                tabs: reloaded,
+                focused: f,
+                command,
+            } => {
+                let started = Instant::now();
+                let reserved = reserved_command_names(&stack.commands);
+                warnings = run_pack_command(&stack, &command, cli.no_plugins, &reserved);
+                tabs = reloaded;
+                if tabs.is_empty() {
+                    tabs.push(AppSession::new(&stack.model.spec(), &cwd_str));
+                }
+                stack.commands = discover_commands(cli.no_commands);
+                focused = f.min(tabs.len() - 1);
+                tracing::info!(
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    tabs = tabs.len(),
+                    "package command: resumed UI"
+                );
+            }
             RunOutcome::Reload {
                 tabs: reloaded,
                 focused: f,
-                pack,
             } => {
                 let started = Instant::now();
                 let last_good = (stack.config.clone(), stack.model.clone());
-                // Before the host is shut down, because the work needs it: an
-                // update unloads the old owner and loads the new one. The
-                // generation is then rebuilt below, exactly as `/reload` does,
-                // so the session comes back with the new package set.
-                let pack_messages = pack
-                    .map(|request| run_pack_command(&stack, &request))
-                    .unwrap_or_default();
                 // Shut the old host down first so nothing can repopulate
                 // the registry after the clear: its senders disconnect, the
                 // watchdog aborts in-flight callbacks, and only this thread
@@ -535,12 +623,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
                     tabs.push(session);
                 }
                 stack = new_stack;
-                // Ahead of the rebuild's own warnings, and not replaced by
-                // them. The user typed the command that produced these, so
-                // losing them to the reload would answer a direct request
-                // with silence.
-                warnings = pack_messages;
-                warnings.extend(new_warnings);
+                warnings = new_warnings;
                 focused = f.min(tabs.len() - 1);
                 tracing::info!(
                     elapsed_ms = started.elapsed().as_millis() as u64,

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -115,13 +115,8 @@ fn run_pack_command(
     );
     let mut messages = vec![report.summary()];
     messages.extend(report.failures.iter().cloned());
-    let discovery = maki_lua::discover_installed(no_plugins);
-    messages.extend(
-        discovery
-            .problems
-            .into_iter()
-            .map(|problem| super::sanitize_warning(format!("skipping package: {problem}"))),
-    );
+    let discovery = super::discover_external_packages(no_plugins);
+    messages.extend(discovery.warnings);
     let available: Vec<DiscoveredPackage> = discovery
         .packages
         .into_iter()
@@ -146,7 +141,7 @@ fn run_pack_command(
         }
         Err(error) => messages.push(format!("could not refresh package state: {error}")),
     }
-    messages
+    super::sanitize_warnings(messages)
 }
 
 fn reserved_command_names(commands: &[CustomCommand]) -> Vec<String> {
@@ -276,17 +271,12 @@ fn build_stack(
 
     // Discovered before the config is built, so `plugins.<name>` can configure
     // an installed package, and reused afterwards to load it.
-    let discovery = maki_lua::discover_installed(cli.no_plugins);
+    let discovery = super::discover_external_packages(cli.no_plugins);
     // Taken before the problems are consumed, and includes the names
     // discovery refused, so a package it could not read does not become a
     // config error pointing at the user's `plugins.<name>` table.
-    let names = discovery.known_names();
-    warnings.extend(
-        discovery
-            .problems
-            .into_iter()
-            .map(|problem| super::sanitize_warning(format!("skipping package: {problem}"))),
-    );
+    let names = discovery.names;
+    warnings.extend(discovery.warnings);
     let packages = discovery.packages;
 
     let (fallback_config, fallback_model) = fallback.unzip();
@@ -321,16 +311,29 @@ fn build_stack(
         // is already a visible act: it reaches the network, writes the
         // lockfile, and can run the fetched code under a package name the
         // fallback config happens to enable.
-        Ok(_) if config_rejected => {
+        Ok(declared) if config_rejected => {
+            let installed =
+                maki_lua::resolve_declared_on_disk(&declared, !cli.print && !cli.is_sdk_mode());
+            warnings.extend(installed.failures);
+            let available: Vec<DiscoveredPackage> = packages
+                .iter()
+                .chain(installed.packages.iter())
+                .cloned()
+                .collect();
             catalog_packages(
                 &plugin_host,
-                &packages,
-                &[],
+                &available,
+                &declared,
                 &reserved,
                 &config.plugins,
                 &mut warnings,
             );
             warnings.extend(plugin_host.load_packages(&packages, &config.plugins));
+            warnings.extend(plugin_host.load_declared_packages(
+                &installed.packages,
+                &declared,
+                &config.plugins,
+            ));
             warnings.push("package changes in the rejected config were not applied".to_owned());
             // Nothing drains the queue on this path, so it is closed here
             // instead. Left open, every later `maki.packadd` that the runtime
@@ -394,7 +397,7 @@ fn build_stack(
             model,
             needs_login,
         },
-        warnings,
+        super::sanitize_warnings(warnings),
     ))
 }
 

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -141,7 +141,7 @@ fn run_pack_command(
         }
         Err(error) => messages.push(format!("could not refresh package state: {error}")),
     }
-    super::sanitize_warnings(messages)
+    messages
 }
 
 fn reserved_command_names(commands: &[CustomCommand]) -> Vec<String> {
@@ -603,7 +603,12 @@ pub fn run(mut cli: Cli) -> Result<()> {
             } => {
                 let started = Instant::now();
                 let reserved = reserved_command_names(&stack.commands);
-                warnings = run_pack_command(&stack, &command, cli.no_plugins, &reserved);
+                warnings = super::sanitize_warnings(run_pack_command(
+                    &stack,
+                    &command,
+                    cli.no_plugins,
+                    &reserved,
+                ));
                 tabs = reloaded;
                 if tabs.is_empty() {
                     tabs.push(AppSession::new(&stack.model.spec(), &cwd_str));

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -1456,7 +1456,7 @@ mod tests {
             "provider": {"allowed_models": [startup.spec()]}
         }))
         .unwrap();
-        let policy = raw.into_config(false).unwrap().provider.model_policy;
+        let policy = raw.into_config(false, &[]).unwrap().provider.model_policy;
 
         assert!(
             resolve_set_model(


### PR DESCRIPTION
Part 4 of 4 for #721.

GitHub cannot stack these pull requests across forks, so this branch carries #827 through #829 and the diff is cumulative. Please merge them first. It is rebased on upstream `main` at `054fac6f`.

### The series

- 1/4 #827 load external plugin directories
- 2/4 #828 managed package state
- 3/4 #829 update and delete workflows
- 4/4 #830 lazy package activation  ← you are here

## What it does

- Adds event, command, and key triggers. A package installs, stays dormant, and loads once when a trigger fires.
- Supports a custom `load` function that runs as the package owner.
- Publishes dormant commands and keys before load, then dispatches the original action after a successful load.
- Adds read-only `maki.pack.get` package inspection.
- Adds update review, `/packupdate!`, and `force = true`. Force skips update review but never skips a new permission approval.
- Adds `PackChangedPre` and `PackChanged` for install, update, and delete.
- Keeps runtime `maki.packadd` synchronous enough to report unknown, disabled, or failed packages to its caller.
- Keeps package mutation global-only. Project config can use `maki.packadd` and `maki.pack.get`, but cannot add, update, or delete packages.
- Supports upstream `TaskStatusChanged` as a lazy event trigger after the rebase.

There is no module trigger. `require` stays within the calling package's ownership boundary, so a module miss cannot run another downloaded package as the caller.

In modes that deliver no agent events, event-triggered packages load at startup instead of remaining dormant forever. Command-only and key-only packages stay dormant.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --workspace`: 4512 passed
- `cargo test --workspace --doc`
- `just gen-docs-check`
- `cargo machete`: no unused dependencies
- `cargo audit`: only the existing `quick-xml` advisories and existing warnings

## AI use

Written with Claude Code and reviewed with Codex. The complete package lifecycle, trigger ownership, update review, approval, rollback, config fallback, and upstream task-event integration were reviewed in two counted rounds.
