### PR TITLE
fix(providers/aperture): stop sending /v1 on zai routes

### DIFF
--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -240,7 +240,7 @@ supports_vision = true
 
 Provider-level fields apply to every model from that upstream; per-model entries under `models` win field by field. Fields: `context_window`, `max_output_tokens`, `supports_thinking`, `supports_vision`, `base` (remaps an opaque vendor to a native provider; e.g. `llama-cpp`, `google`, `anthropic`), and `path_prefix`. Model ids containing dots must be quoted (`"qwen3.6"`) since TOML treats a bare dotted key as a nested table.
 
-Maki sends `/v1` (or `/v1beta` for Gemini routes), and Aperture appends that path to the upstream's base url. If an upstream base url already carries its own path, set `path_prefix = ""` for it to avoid a doubled path.
+Maki sends `/v1` (or `/v1beta` for Gemini routes, nothing for Anthropic and Z.AI), and Aperture appends that path to the upstream's base url. If an upstream base url already carries its own path, set `path_prefix = ""` for it to avoid a doubled path. Z.AI defaults to no prefix since its API path has no `/v1` segment; point the upstream base url at the full API root (e.g. `https://api.z.ai/api/paas/v4`).
 
 ### Plans
 

--- a/maki-providers/src/providers/aperture.rs
+++ b/maki-providers/src/providers/aperture.rs
@@ -160,14 +160,32 @@ fn kind_supports_thinking(kind: ProviderKind) -> bool {
 /// request path to the upstream's configured base url. The prefix therefore
 /// follows the API format the request uses: `/v1` for OpenAI chat (and for the
 /// generic gateway path), `/v1beta` for Gemini. Anthropic gets none because its
-/// provider rebuilds `/v1/messages` from the bare origin. An upstream whose
-/// base url already carries a path (e.g. z.ai's `/api/paas/v4`) would double up,
-/// so `path_prefix` in the overrides can replace it per gateway provider.
+/// provider rebuilds `/v1/messages` from the bare origin. Zai gets none because
+/// its API has no `/v1` segment at all (`/api/paas/v4/chat/completions`), so
+/// the upstream base url must carry the full path and any prefix would double
+/// up. `path_prefix` in the overrides replaces the default per gateway
+/// provider.
+/// Exhaustive on purpose: a new `ProviderKind` must state its prefix here
+/// instead of silently inheriting `/v1` (which broke Zai once already).
 fn default_path_prefix(kind: Option<ProviderKind>) -> &'static str {
     match kind {
-        Some(ProviderKind::Anthropic) => "",
+        Some(ProviderKind::Anthropic | ProviderKind::Zai) => "",
         Some(ProviderKind::Google) => GEMINI_PATH_PREFIX,
-        _ => DEFAULT_PATH_PREFIX,
+        Some(
+            ProviderKind::Ollama
+            | ProviderKind::LlamaCpp
+            | ProviderKind::Mistral
+            | ProviderKind::DeepSeek
+            | ProviderKind::OpenRouter
+            | ProviderKind::Synthetic
+            | ProviderKind::TensorX
+            | ProviderKind::OpenAi
+            | ProviderKind::Copilot
+            | ProviderKind::Opencode
+            | ProviderKind::Xai
+            | ProviderKind::Aperture,
+        )
+        | None => DEFAULT_PATH_PREFIX,
     }
 }
 
@@ -556,7 +574,7 @@ mod tests {
     }
 
     #[test_case(Some(ProviderKind::Ollama), Some("https://aperture.example.com/v1") ; "ollama_appends_v1")]
-    #[test_case(Some(ProviderKind::Zai), Some("https://aperture.example.com/v1") ; "zai_appends_v1")]
+    #[test_case(Some(ProviderKind::Zai), Some("https://aperture.example.com") ; "zai_keeps_bare_host")]
     #[test_case(Some(ProviderKind::DeepSeek), Some("https://aperture.example.com/v1") ; "deepseek_appends_v1")]
     #[test_case(None, Some("https://aperture.example.com/v1") ; "unrouted_appends_v1")]
     #[test_case(Some(ProviderKind::Google), Some("https://aperture.example.com/v1beta") ; "google_appends_v1beta")]
@@ -568,6 +586,7 @@ mod tests {
     }
 
     #[test_case(Some("") , Some("https://aperture.example.com") ; "empty_prefix_keeps_bare_host")]
+    #[test_case(Some("v1"), Some("https://aperture.example.com/v1") ; "configured_prefix_beats_zai_default")]
     #[test_case(Some("api/paas/v4"), Some("https://aperture.example.com/api/paas/v4") ; "prefix_gets_leading_slash")]
     #[test_case(Some("/v1/"), Some("https://aperture.example.com/v1") ; "prefix_trailing_slash_trimmed")]
     fn routed_auth_path_prefix_override_wins(configured: Option<&str>, expected: Option<&str>) {

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -385,7 +385,7 @@ supports_vision = true
 
 Provider-level fields apply to every model from that upstream; per-model entries under `models` win field by field. Fields: `context_window`, `max_output_tokens`, `supports_thinking`, `supports_vision`, `base` (remaps an opaque vendor to a native provider; e.g. `llama-cpp`, `google`, `anthropic`), and `path_prefix`. Model ids containing dots must be quoted (`"qwen3.6"`) since TOML treats a bare dotted key as a nested table.
 
-Maki sends `/v1` (or `/v1beta` for Gemini routes), and Aperture appends that path to the upstream's base url. If an upstream base url already carries its own path, set `path_prefix = ""` for it to avoid a doubled path.
+Maki sends `/v1` (or `/v1beta` for Gemini routes, nothing for Anthropic and Z.AI), and Aperture appends that path to the upstream's base url. If an upstream base url already carries its own path, set `path_prefix = ""` for it to avoid a doubled path. Z.AI defaults to no prefix since its API path has no `/v1` segment; point the upstream base url at the full API root (e.g. `https://api.z.ai/api/paas/v4`).
 
 ### Plans
 


### PR DESCRIPTION
Fixes #822.

`aperture/zai/*` sent `/v1/chat/completions` to the gateway, which appends the full incoming path to the upstream base url, and Z.AI has no `/v1` segment anywhere in its API (`/api/paas/v4/chat/completions`), so no upstream base url could ever make the default work and every request 404ed with a doubled path.

Zai now defaults to no prefix like Anthropic: point the upstream base url at the full API root (e.g. `https://api.z.ai/api/paas/v4`) and it works out of the box, with `path_prefix` still available to override per gateway provider.

The other routed kinds keep `/v1` since it is a real segment of their API paths; OpenRouter and Synthetic carry their odd middle segments (`/api`, `/openai`) in the gateway base url instead, same as the Aperture docs handle OpenRouter.