### PR TITLE
feat(providers/openai): support fast mode

### DIFF
--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -123,7 +123,7 @@ pub const TOP_LEVEL_FIELDS: &[ConfigField] = &[
         ty: "bool",
         default: ConfigValue::Bool(false),
         min: None,
-        description: "Start every session with Anthropic fast mode (Opus only; ignored otherwise)",
+        description: "Start every session with fast mode (Anthropic Opus and OpenAI GPT-5.4+ only; ignored otherwise)",
     },
     ConfigField {
         name: "always_workflow",

--- a/maki-docgen/src/gen_commands.rs
+++ b/maki-docgen/src/gen_commands.rs
@@ -88,7 +88,7 @@ pub fn generate() -> String {
     .unwrap();
     writeln!(
         out,
-        "- **`/fast`**: Anthropic fast mode (Opus only; ignored on other models). Config: `always_fast = true`."
+        "- **`/fast`**: fast mode (Anthropic Opus and OpenAI GPT-5.4+ only; ignored on other models). Config: `always_fast = true`."
     )
     .unwrap();
     writeln!(

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -45,9 +45,10 @@ pub struct ModelPricing {
     pub output: f64,
     pub cache_write: f64,
     pub cache_read: f64,
-    /// Anthropic fast mode charges a premium that differs per model. `None`
-    /// means the model has no fast tier, so asking for fast mode quietly falls
-    /// back to standard rates instead of overcharging.
+    /// Fast-tier rates, which carry a premium that differs per model (2x on
+    /// most, 2.5x on `gpt-5.5`). `None` means the model has no fast tier, so
+    /// asking for fast mode quietly falls back to standard rates instead of
+    /// overcharging.
     #[serde(default)]
     pub fast: Option<FastPricing>,
 }
@@ -82,9 +83,9 @@ impl ModelInfo {
     }
 }
 
-/// Cache rates are missing on purpose: Anthropic derives them from `input` with
-/// the same multipliers it uses for standard pricing, so storing them would just
-/// invite the two copies to drift apart.
+/// Cache rates are missing on purpose: both Anthropic and OpenAI scale the
+/// cache columns with the input rate, so [`TokenUsage::cost`] derives them from
+/// the standard entry rather than storing a second copy that could drift.
 #[derive(Debug, Clone, Deserialize)]
 pub struct FastPricing {
     pub input: f64,
@@ -103,10 +104,6 @@ impl ModelPricing {
     pub fn is_zero(&self) -> bool {
         self.input == 0.0 && self.output == 0.0 && self.cache_write == 0.0 && self.cache_read == 0.0
     }
-
-    /// Cache multipliers Anthropic applies on top of the base input rate.
-    const CACHE_WRITE_MULTIPLIER: f64 = 1.25;
-    const CACHE_READ_MULTIPLIER: f64 = 0.10;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -206,7 +203,11 @@ impl ModelFamily {
     }
 }
 
-const FAST_PROVIDER: &str = "anthropic";
+/// Providers whose direct API exposes a paid fast/priority tier. Anthropic
+/// calls it fast mode (`speed: "fast"`), OpenAI calls it Fast mode and takes
+/// it as `service_tier`. Resellers (Copilot, OpenRouter, Bedrock) are absent
+/// on purpose: they surface the same model ids without the tier.
+const FAST_PROVIDERS: &[&str] = &["anthropic", "openai"];
 
 /// `Required` marks APIs that reject requests with thinking disabled;
 /// [`crate::RequestOptions::clamped`] raises `Off` to minimal effort for them.
@@ -377,12 +378,13 @@ impl Model {
 
     /// A model supports fast mode exactly when it carries fast-tier pricing, so
     /// capability and billing can never disagree. The provider gate keeps fast
-    /// mode to Anthropic-based providers, resolved through the base manifest so
-    /// oauth scripts keep it; Bedrock separately ignores `opts.fast` at request
-    /// time.
+    /// mode to providers whose direct API sells it ([`FAST_PROVIDERS`]),
+    /// resolved through the base manifest so oauth scripts keep it; Bedrock
+    /// separately ignores `opts.fast` at request time.
     pub fn supports_fast(&self) -> bool {
         self.pricing.fast.is_some()
-            && ManifestRegistry::for_slug(&self.provider).is_some_and(|m| m.slug == FAST_PROVIDER)
+            && ManifestRegistry::for_slug(&self.provider)
+                .is_some_and(|m| FAST_PROVIDERS.contains(&m.slug))
     }
 
     pub fn spec(&self) -> String {
@@ -606,12 +608,24 @@ impl TokenUsage {
     /// schedule.
     pub(crate) fn cost(&self, pricing: &ModelPricing, fast: bool) -> f64 {
         let (input, output, cache_write, cache_read) = match &pricing.fast {
-            Some(f) if fast => (
-                f.input,
-                f.output,
-                f.input * ModelPricing::CACHE_WRITE_MULTIPLIER,
-                f.input * ModelPricing::CACHE_READ_MULTIPLIER,
-            ),
+            Some(f) if fast => {
+                // Both vendors scale the cache columns with the input rate, so
+                // deriving them keeps one source of truth. Scale by the ratio
+                // rather than reapplying the standard multipliers: OpenAI bills
+                // nothing for cache writes before the GPT-5.6 family, and a
+                // flat 1.25x would invent a charge that does not exist there.
+                let ratio = if pricing.input > 0.0 {
+                    f.input / pricing.input
+                } else {
+                    1.0
+                };
+                (
+                    f.input,
+                    f.output,
+                    pricing.cache_write * ratio,
+                    pricing.cache_read * ratio,
+                )
+            }
             _ => (
                 pricing.input,
                 pricing.output,
@@ -1039,7 +1053,7 @@ mod tests {
     }
 
     #[test]
-    fn supports_fast_false_for_non_anthropic_even_with_fast_pricing() {
+    fn supports_fast_false_for_provider_without_a_fast_tier() {
         let mut model = Model::from_base(
             ManifestRegistry::get("google").unwrap(),
             "google",

--- a/maki-providers/src/providers/openai/mod.rs
+++ b/maki-providers/src/providers/openai/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod responses;
 
 pub use platform::OpenAi;
 
-use crate::model::{ModelEntry, ModelFamily, ModelPricing, ModelTier};
+use crate::model::{FastPricing, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 
 const GPT_5_6_CONTEXT_WINDOW: u32 = 372_000;
 const GPT_5_6_MAX_OUTPUT_TOKENS: u32 = 128_000;
@@ -30,11 +30,14 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
             vision: true,
             default: true,
             pricing: ModelPricing {
-                input: 1.00,
-                output: 6.00,
-                cache_write: 1.25,
-                cache_read: 0.10,
-                fast: None,
+                input: 0.20,
+                output: 1.20,
+                cache_write: 0.25,
+                cache_read: 0.02,
+                fast: Some(FastPricing {
+                    input: 0.40,
+                    output: 2.40,
+                }),
             },
             max_output_tokens: Some(GPT_5_6_MAX_OUTPUT_TOKENS),
             context_window: GPT_5_6_CONTEXT_WINDOW,
@@ -46,11 +49,14 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
             vision: true,
             default: true,
             pricing: ModelPricing {
-                input: 2.50,
-                output: 15.00,
-                cache_write: 3.125,
-                cache_read: 0.25,
-                fast: None,
+                input: 2.00,
+                output: 12.00,
+                cache_write: 2.50,
+                cache_read: 0.20,
+                fast: Some(FastPricing {
+                    input: 4.00,
+                    output: 24.00,
+                }),
             },
             max_output_tokens: Some(GPT_5_6_MAX_OUTPUT_TOKENS),
             context_window: GPT_5_6_CONTEXT_WINDOW,
@@ -62,11 +68,14 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
             vision: true,
             default: true,
             pricing: ModelPricing {
-                input: 5.00,
-                output: 30.00,
-                cache_write: 6.25,
-                cache_read: 0.50,
-                fast: None,
+                input: 4.00,
+                output: 20.00,
+                cache_write: 5.00,
+                cache_read: 0.40,
+                fast: Some(FastPricing {
+                    input: 8.00,
+                    output: 40.00,
+                }),
             },
             max_output_tokens: Some(GPT_5_6_MAX_OUTPUT_TOKENS),
             context_window: GPT_5_6_CONTEXT_WINDOW,
@@ -98,7 +107,10 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 output: 4.50,
                 cache_write: 0.00,
                 cache_read: 0.075,
-                fast: None,
+                fast: Some(FastPricing {
+                    input: 1.50,
+                    output: 9.00,
+                }),
             },
             max_output_tokens: Some(128_000),
             context_window: 400_000,
@@ -168,6 +180,22 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
             context_window: 200_000,
         },
         ModelEntry {
+            prefixes: &["gpt-5.5-pro"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Gpt,
+            vision: true,
+            default: false,
+            pricing: ModelPricing {
+                input: 30.00,
+                output: 180.00,
+                cache_write: 0.00,
+                cache_read: 0.00,
+                fast: None,
+            },
+            max_output_tokens: Some(128_000),
+            context_window: 1_050_000,
+        },
+        ModelEntry {
             prefixes: &["gpt-5.5"],
             tier: ModelTier::Strong,
             family: ModelFamily::Gpt,
@@ -178,7 +206,10 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 output: 30.00,
                 cache_write: 0.00,
                 cache_read: 0.50,
-                fast: None,
+                fast: Some(FastPricing {
+                    input: 12.50,
+                    output: 75.00,
+                }),
             },
             max_output_tokens: Some(128_000),
             context_window: 1_050_000,
@@ -194,7 +225,10 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
                 output: 15.00,
                 cache_write: 0.00,
                 cache_read: 0.25,
-                fast: None,
+                fast: Some(FastPricing {
+                    input: 5.00,
+                    output: 30.00,
+                }),
             },
             max_output_tokens: Some(128_000),
             context_window: 1_050_000,
@@ -304,9 +338,9 @@ mod tests {
 
     use super::*;
 
-    #[test_case("gpt-5.6-luna", ModelTier::Weak, 1.0, 0.1, 1.25, 6.0)]
-    #[test_case("gpt-5.6-terra", ModelTier::Medium, 2.5, 0.25, 3.125, 15.0)]
-    #[test_case("gpt-5.6-sol", ModelTier::Strong, 5.0, 0.5, 6.25, 30.0)]
+    #[test_case("gpt-5.6-luna", ModelTier::Weak, 0.2, 0.02, 0.25, 1.2)]
+    #[test_case("gpt-5.6-terra", ModelTier::Medium, 2.0, 0.2, 2.5, 12.0)]
+    #[test_case("gpt-5.6-sol", ModelTier::Strong, 4.0, 0.4, 5.0, 20.0)]
     fn gpt_5_6_models_have_expected_tier_and_short_context_pricing(
         model_id: &str,
         tier: ModelTier,
@@ -326,5 +360,79 @@ mod tests {
         assert_eq!(model.pricing.cache_read, cache_read);
         assert_eq!(model.pricing.cache_write, cache_write);
         assert_eq!(model.pricing.output, output);
+    }
+
+    fn entry(model_id: &str) -> &'static ModelEntry {
+        models()
+            .iter()
+            .find(|model| model.prefixes.contains(&model_id))
+            .expect("model should be registered")
+    }
+
+    #[test_case("gpt-5.6-sol", 8.00, 40.00)]
+    #[test_case("gpt-5.6-terra", 4.00, 24.00)]
+    #[test_case("gpt-5.6-luna", 0.40, 2.40)]
+    #[test_case("gpt-5.5", 12.50, 75.00)]
+    #[test_case("gpt-5.4", 5.00, 30.00)]
+    #[test_case("gpt-5.4-mini", 1.50, 9.00)]
+    fn fast_tier_matches_published_rates(model_id: &str, input: f64, output: f64) {
+        let fast = entry(model_id)
+            .pricing
+            .fast
+            .as_ref()
+            .expect("model should carry fast-tier pricing");
+
+        assert_eq!(fast.input, input);
+        assert_eq!(fast.output, output);
+    }
+
+    /// `gpt-5.5-pro` and `gpt-5.4-nano` have no published fast rate. OpenAI
+    /// does sell one for `gpt-4.1`, `o3` and `gpt-5.3-codex`, but we only wire
+    /// fast mode for the GPT-5.4+ line, so the flag must not reach any of them.
+    #[test_case("gpt-5.5-pro")]
+    #[test_case("gpt-5.4-nano")]
+    #[test_case("gpt-4.1")]
+    #[test_case("o3")]
+    #[test_case("gpt-5.3-codex")]
+    fn models_without_a_wired_fast_tier_have_none(model_id: &str) {
+        assert!(entry(model_id).pricing.fast.is_none());
+    }
+
+    /// `gpt-5.5-pro` shares the `gpt-5.5` prefix but sells no fast tier, so
+    /// resolution has to land on its own entry rather than `gpt-5.5`'s.
+    #[test]
+    fn gpt_5_5_pro_resolves_to_its_own_entry() {
+        let entry = crate::model::lookup_entry(models(), "gpt-5.5-pro").unwrap();
+        assert!(entry.prefixes.contains(&"gpt-5.5-pro"));
+        assert!(entry.pricing.fast.is_none());
+    }
+
+    /// Cache columns are derived, not stored, so the derivation has to land on
+    /// OpenAI's published fast rates for every model that has them.
+    #[test_case("gpt-5.6-sol", 10.00, 0.80)]
+    #[test_case("gpt-5.6-terra", 5.00, 0.40)]
+    #[test_case("gpt-5.6-luna", 0.50, 0.04)]
+    #[test_case("gpt-5.5", 0.00, 1.25)]
+    #[test_case("gpt-5.4", 0.00, 0.50)]
+    #[test_case("gpt-5.4-mini", 0.00, 0.15)]
+    fn derived_fast_cache_rates_match_published_rates(
+        model_id: &str,
+        cache_write: f64,
+        cache_read: f64,
+    ) {
+        use crate::model::TokenUsage;
+
+        let pricing = &entry(model_id).pricing;
+        let one_million_writes = TokenUsage {
+            cache_creation: 1_000_000,
+            ..Default::default()
+        };
+        let one_million_reads = TokenUsage {
+            cache_read: 1_000_000,
+            ..Default::default()
+        };
+
+        assert!((one_million_writes.cost(pricing, true) - cache_write).abs() < 1e-9);
+        assert!((one_million_reads.cost(pricing, true) - cache_read).abs() < 1e-9);
     }
 }

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -4,7 +4,7 @@ use flume::Sender;
 use maki_storage::StateDir;
 use maki_storage::id::SessionRef;
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{Value, json};
 use tracing::{debug, warn};
 
 use crate::model::Model;
@@ -275,6 +275,19 @@ fn resolve_openai_base_url() -> Option<String> {
     maki_config::providers::configured_base_url("openai", config.get("openai"))
 }
 
+/// Opts into Fast mode, the tier OpenAI used to call Priority Processing. We
+/// re-check `supports_fast()` rather than trusting `opts.fast` alone, so a
+/// stale UI flag can never bill an ineligible model at the premium rate.
+///
+/// `"fast"` and `"priority"` mean the same thing on the wire, and the response
+/// echoes back the tier actually served, which may not be the one we asked
+/// for.
+fn apply_fast_mode(body: &mut Value, model: &Model, opts: RequestOptions) {
+    if opts.fast && model.supports_fast() {
+        body["service_tier"] = json!("fast");
+    }
+}
+
 impl Provider for OpenAi {
     fn stream_message<'a>(
         &'a self,
@@ -291,7 +304,15 @@ impl Provider for OpenAi {
             let system = super::super::with_prefix(&self.system_prefix, system, &mut buf);
 
             if is_codex_model(&model.id) {
-                let body = super::responses::build_body(model, messages, system, tools);
+                let mut body = super::responses::build_body(model, messages, system, tools);
+                // Every fast-capable model is also a plan model, so this branch
+                // is where fast mode actually lands. `codex_auth` sends OAuth
+                // traffic to the ChatGPT Coding Plan backend, which bills by
+                // subscription and does not sell the tier, so gate on the
+                // same predicate it uses and the two cannot disagree.
+                if !self.is_oauth() {
+                    apply_fast_mode(&mut body, model, opts);
+                }
                 let stream_timeout = self.compat.stream_timeout();
                 return self
                     .with_oauth_retry(|| async {
@@ -312,6 +333,7 @@ impl Provider for OpenAi {
             let mut body = self.compat.build_body(model, messages, system, tools);
             opts.thinking
                 .apply_reasoning_effort(&mut body, &dialect::STANDARD, model);
+            apply_fast_mode(&mut body, model, opts);
             self.with_oauth_retry(|| async {
                 let auth = self.current_auth();
                 self.compat
@@ -397,6 +419,63 @@ mod tests {
     #[test_case("gpt-5.6-sol")]
     fn gpt_5_6_models_use_coding_plan(model_id: &str) {
         assert!(is_codex_model(model_id));
+    }
+
+    /// Fast mode rides the Responses branch, so every model carrying fast-tier
+    /// pricing must route through it -- otherwise `apply_fast_mode` is dead code.
+    #[test_case("gpt-5.6-sol")]
+    #[test_case("gpt-5.6-terra")]
+    #[test_case("gpt-5.6-luna")]
+    #[test_case("gpt-5.5")]
+    #[test_case("gpt-5.4")]
+    #[test_case("gpt-5.4-mini")]
+    fn every_fast_capable_model_routes_through_the_responses_branch(model_id: &str) {
+        let model = Model::from_spec(&format!("openai/{model_id}")).unwrap();
+        assert!(model.supports_fast(), "{model_id} should have fast pricing");
+        assert!(
+            is_codex_model(model_id),
+            "{model_id} should route to Responses"
+        );
+    }
+
+    #[test]
+    fn sets_service_tier_on_capable_model() {
+        let model = Model::from_spec("openai/gpt-5.6-sol").unwrap();
+        let mut body = serde_json::json!({});
+        apply_fast_mode(&mut body, &model, fast_opts());
+        assert_eq!(body["service_tier"], serde_json::json!("fast"));
+    }
+
+    #[test]
+    fn ignores_stale_flag_on_ineligible_model() {
+        // gpt-5.4-nano has no published fast rate, so opts.fast must not
+        // upgrade the request and bill a premium that was never quoted.
+        let model = Model::from_spec("openai/gpt-5.4-nano").unwrap();
+        let mut body = serde_json::json!({});
+        apply_fast_mode(&mut body, &model, fast_opts());
+        assert!(body.get("service_tier").is_none());
+    }
+
+    #[test]
+    fn absent_when_not_requested() {
+        let model = Model::from_spec("openai/gpt-5.6-sol").unwrap();
+        let mut body = serde_json::json!({});
+        apply_fast_mode(&mut body, &model, RequestOptions::default());
+        assert!(body.get("service_tier").is_none());
+    }
+
+    /// Resellers surface the same model ids without selling the tier.
+    #[test]
+    fn not_applied_for_a_reseller_serving_the_same_model() {
+        let model = Model::from_spec("openrouter/gpt-5.6-sol").unwrap();
+        assert!(!model.supports_fast());
+    }
+
+    fn fast_opts() -> RequestOptions {
+        RequestOptions {
+            fast: true,
+            ..Default::default()
+        }
     }
 
     #[test_case("gpt-5.6-luna", Some(372_000))]

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -88,7 +88,8 @@ const FLASH_REWIND: &str = "Press esc again to rewind...";
 const AUTH_EXPIRED_MSG: &str =
     "Token expired. Run `maki auth login` in another terminal, then press Enter to retry.";
 const FLASH_NO_PLAN: &str = "No plan file";
-const FAST_UNSUPPORTED_MSG: &str = "Fast mode requires an Anthropic Opus 4.6+ model (API only)";
+const FAST_UNSUPPORTED_MSG: &str =
+    "Fast mode requires an Anthropic Opus 4.6+ or OpenAI GPT-5.4+ model (API only)";
 const THINKING_UNSUPPORTED_MSG: &str = "Thinking requires a model that supports it";
 const FAST_ON_MSG: &str = "Fast mode: on";
 const FAST_OFF_MSG: &str = "Fast mode: off";

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -3929,6 +3929,21 @@ fn fast_toggle_on_off_on_opus() {
 }
 
 #[test]
+fn fast_toggle_on_off_on_openai_fast_model() {
+    let mut app = test_app();
+    app.state.model = maki_providers::Model::from_spec("openai/gpt-5.5").unwrap();
+    assert!(!app.state.fast);
+
+    app.execute_command(cmd("/fast"), 0);
+    assert!(app.state.fast);
+    assert_eq!(app.status_bar.flash_text(), Some(FAST_ON_MSG));
+
+    app.execute_command(cmd("/fast"), 0);
+    assert!(!app.state.fast);
+    assert_eq!(app.status_bar.flash_text(), Some(FAST_OFF_MSG));
+}
+
+#[test]
 fn workflow_toggle_flows_into_agent_input() {
     let mut app = test_app();
     let msg = QueuedMessage {
@@ -3972,8 +3987,10 @@ fn subagent_history_finishes_workflow_chat() {
     assert_eq!(app.chats[1].last_message_text(), DONE_TEXT);
 }
 
+/// `gpt-5.5-pro` is an OpenAI model that sells no fast tier, unlike `gpt-5.5`.
 #[test_case(SONNET_SPEC ; "non_opus_anthropic")]
-#[test_case("openai/gpt-5.5" ; "non_anthropic")]
+#[test_case("openai/gpt-5.5-pro" ; "openai_without_fast_tier")]
+#[test_case("google/gemini-2.5-pro" ; "provider_without_fast")]
 fn fast_flashes_error_on_ineligible_model(spec: &str) {
     let mut app = test_app();
     app.state.model = maki_providers::Model::from_spec(spec).unwrap();

--- a/maki-ui/src/components/command.rs
+++ b/maki-ui/src/components/command.rs
@@ -96,7 +96,7 @@ pub const BUILTIN_COMMANDS: &[BuiltinCommand] = &[
     },
     BuiltinCommand {
         name: "/fast",
-        description: "Toggle Anthropic fast mode (Opus only)",
+        description: "Toggle fast mode (Anthropic Opus / OpenAI GPT-5.4+)",
         max_args: 0,
     },
     BuiltinCommand {

--- a/site/docs/content/commands/_index.md
+++ b/site/docs/content/commands/_index.md
@@ -27,7 +27,7 @@ Type `/` in the input box to open the command palette.
 | `/btw` | Ask a quick question (no tools, no history pollution) |
 | `/yolo` | Toggle YOLO mode (skip all permission prompts) |
 | `/thinking` | Toggle extended thinking (off, adaptive, effort level, or budget) |
-| `/fast` | Toggle Anthropic fast mode (Opus only) |
+| `/fast` | Toggle fast mode (Anthropic Opus / OpenAI GPT-5.4+) |
 | `/workflow` | Toggle workflow mode (task callable inside code_execution) |
 | `/exit` | Exit the application |
 | `/reload` | Reload plugins and config |
@@ -43,7 +43,7 @@ Sessions run concurrently. `/new` starts a fresh session while the old one keeps
 
 - **`/yolo`**: skip permission prompts for this session (deny rules still apply). Config: `always_yolo = true`.
 - **`/thinking`**: extended thinking. Optional arg: `off`, `adaptive`, an effort level (`minimal` … `max`), or a token budget number. Config: `always_thinking`.
-- **`/fast`**: Anthropic fast mode (Opus only; ignored on other models). Config: `always_fast = true`.
+- **`/fast`**: fast mode (Anthropic Opus and OpenAI GPT-5.4+ only; ignored on other models). Config: `always_fast = true`.
 - **`/workflow`**: let `code_execution` call the `task` tool (and other workflow-only tools) from inside the Python sandbox. Config: `always_workflow = true`.
 - **Plan / build**: not a slash command. Press `Tab` in the input to toggle plan mode (plan-file writes only).
 - **`/reload`**: rebuild plugins and config without leaving the app.

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -61,7 +61,7 @@ All fields are optional. Typos in field names cause an error right away.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `always_yolo` | bool | `false` | Start every session with YOLO mode (skip permission prompts, deny rules still apply) |
-| `always_fast` | bool | `false` | Start every session with Anthropic fast mode (Opus only; ignored otherwise) |
+| `always_fast` | bool | `false` | Start every session with fast mode (Anthropic Opus and OpenAI GPT-5.4+ only; ignored otherwise) |
 | `always_workflow` | bool | `false` | Start every session with workflow mode (task callable inside code_execution) |
 | `always_thinking` | bool \| string | `false` | Start every session with extended thinking (true/"adaptive", "off", an effort level ("minimal" to "max"), or a token budget) |
 

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -85,16 +85,17 @@ You can override the model with `ANTHROPIC_MODEL` and the endpoint with `ANTHROP
 
 | Tier | Models | Pricing (in/out per 1M tokens) | Context |
 |------|--------|-------------------------------|---------|
-| Weak | **gpt-5.6-luna** (default) | $1.00 / $6.00 | 372K ctx / 128K out |
+| Weak | **gpt-5.6-luna** (default) | $0.20 / $1.20 | 372K ctx / 128K out |
 | Weak | gpt-5.4-nano | $0.20 / $1.25 | 400K ctx / 128K out |
 | Weak | gpt-5.4-mini | $0.75 / $4.50 | 400K ctx / 128K out |
 | Weak | gpt-4.1-nano | $0.10 / $0.40 | 1047K ctx / 32K out |
-| Medium | **gpt-5.6-terra** (default) | $2.50 / $15.00 | 372K ctx / 128K out |
+| Medium | **gpt-5.6-terra** (default) | $2.00 / $12.00 | 372K ctx / 128K out |
 | Medium | gpt-4.1-mini | $0.40 / $1.60 | 1047K ctx / 32K out |
 | Medium | gpt-4.1 | $2.00 / $8.00 | 1047K ctx / 32K out |
 | Medium | o4-mini | $1.10 / $4.40 | 200K ctx / 100K out |
 | Medium | gpt-5.1-codex-mini | $0.25 / $2.00 | 400K ctx / 128K out |
-| Strong | **gpt-5.6-sol** (default) | $5.00 / $30.00 | 372K ctx / 128K out |
+| Strong | **gpt-5.6-sol** (default) | $4.00 / $20.00 | 372K ctx / 128K out |
+| Strong | gpt-5.5-pro | $30.00 / $180.00 | 1050K ctx / 128K out |
 | Strong | gpt-5.5 | $5.00 / $30.00 | 1050K ctx / 128K out |
 | Strong | gpt-5.4 | $2.50 / $15.00 | 1050K ctx / 128K out |
 | Strong | o3 | $2.00 / $8.00 | 200K ctx / 100K out |


### PR DESCRIPTION
OpenAI renamed Priority Processing to Fast mode and sells it per request
through `service_tier`, so wire it to the `fast` flag we already had for
Anthropic. Every fast capable model routes through the Responses branch,
and that branch also serves Coding Plan traffic, which is billed in
subscription credits rather than per token, so we gate on the same
predicate `codex_auth` uses to pick the backend and leave the tier off
there.

Only the GPT-5.4+ line gets a fast tier here. OpenAI also sells one for
gpt-4.1, o3 and gpt-5.3-codex, but we do not wire it for those.

Three pricing fixes came along for the ride, all checked against the
published pricing page. gpt-5.6-terra and gpt-5.6-luna were reading from
the batch table rather than the standard one, one row off, which
overcharged luna by 5x. gpt-5.6-sol is $4/$20 (fast $8/$40) under the
promotional pricing OpenAI has committed to through at least November
2026, not the $5/$30 we had. And fast cache rates were recomputed from
Anthropic's multipliers, inventing a cache write charge on the pre-5.6
OpenAI models that bill nothing for it, so scale the standard columns by
the input ratio instead; that also lands on the published 1.25x write
rate for the 5.6 family. Anthropic costs come out identical.
