### PR TITLE
Reflow performance

### DIFF
--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -46,6 +46,7 @@ use ratatui::text::{Line, Span};
 use tracing::warn;
 
 const THINKING_HIDDEN_HEADER: &str = "thinking> ...";
+const REFLOW_MARGIN_VIEWPORTS: u32 = 1;
 
 #[derive(Clone, Copy)]
 pub struct PromptProgress {
@@ -750,7 +751,7 @@ impl MessagesPanel {
         }
 
         if width_changed {
-            self.cache.invalidate_from_msg_count();
+            self.cache.mark_all_width_stale();
             let thinking = thinking_style();
             let assistant = assistant_style();
             self.streaming_thinking.set_style(
@@ -801,20 +802,13 @@ impl MessagesPanel {
             streaming_heights.push(wrapped_line_count(lines, width));
         }
 
-        let cached_height = self.cache.total_height(width);
         let streaming_sum: u32 = streaming_heights.iter().map(|&h| h as u32).sum();
-        let total_lines: u16 = (cached_height + streaming_sum).min(u16::MAX as u32) as u16;
-        self.last_total_lines = total_lines;
-        let max_scroll = total_lines.saturating_sub(self.viewport_height);
-        self.scroll_top = self.scroll_top.min(max_scroll);
-        if !has_selection {
-            if self.scroll_top >= max_scroll {
-                self.auto_scroll = true;
-            }
-            if self.auto_scroll {
-                self.scroll_top = max_scroll;
-            }
-        }
+        // The reflow window is picked from `scroll_top` and the bottom pin,
+        // and the reflow changes the heights both are derived from: resolve
+        // before to aim the window, and after to place the result.
+        self.resolve_scroll(width, streaming_sum, has_selection);
+        self.reflow_viewport(width);
+        let total_lines = self.resolve_scroll(width, streaming_sum, has_selection);
 
         let viewport = Rect::new(area.x, area.y, width, area.height);
         let mut cursor = RenderCursor::new(self.scroll_top, viewport);
@@ -1306,62 +1300,141 @@ impl MessagesPanel {
                         .push(Segment::with_lines(lines, search_text, Some(i)));
                     continue;
                 }
-                let style = match &msg.role {
-                    DisplayRole::User => user_style(),
-                    DisplayRole::Assistant => assistant_style(),
-                    DisplayRole::Thinking => thinking_style(),
-                    DisplayRole::Error => error_style(),
-                    DisplayRole::Done => done_style(),
-                    DisplayRole::Tool(_) => unreachable!(),
-                };
-                let prefix = if msg.plan_path.is_some() {
-                    ""
-                } else {
-                    style.prefix
-                };
-                let mut lines = if style.use_markdown {
-                    text_to_lines(
-                        &msg.text,
-                        prefix,
-                        style.text_style,
-                        style.prefix_style,
-                        self.viewport_width,
-                        style.max_line_bytes,
-                    )
-                } else {
-                    plain_lines(&msg.text, prefix, style.text_style, style.prefix_style)
-                };
-                if let Some(pp) = &msg.plan_path {
-                    if !msg.text.is_empty() {
-                        let rule = hr_line(self.viewport_width, theme::current().plan_rule);
-                        lines.insert(0, rule.clone());
-                        lines.push(rule);
-                    } else {
-                        lines.clear();
-                    }
-                    if !msg.text.is_empty() {
-                        lines.push(Line::from(""));
-                    }
-                    lines.push(Line::from(Span::styled(
-                        pp.to_owned(),
-                        theme::current().plan_path,
-                    )));
-                    lines.push(Line::from(Span::styled(
-                        format!(
-                            "{} to open in editor ($VISUAL / $EDITOR)",
-                            key::OPEN_EDITOR.label
-                        ),
-                        theme::current().tool_dim,
-                    )));
-                }
-
-                let search_text = format!("{prefix}{}", msg.text);
+                let (lines, search_text) = build_message_lines(msg, self.viewport_width);
                 self.cache.push_spacer_if_needed();
                 self.cache
                     .push(Segment::with_lines(lines, search_text, Some(i)));
             }
         }
         self.cache.mark_built(self.messages.len());
+    }
+
+    /// Clamps `scroll_top` against the document height and applies the bottom
+    /// pin, returning the total the scrollbar draws from.
+    fn resolve_scroll(&mut self, width: u16, streaming_sum: u32, has_selection: bool) -> u16 {
+        let total_lines: u16 =
+            (self.cache.total_height(width) + streaming_sum).min(u16::MAX as u32) as u16;
+        self.last_total_lines = total_lines;
+        let max_scroll = total_lines.saturating_sub(self.viewport_height);
+        self.scroll_top = self.scroll_top.min(max_scroll);
+        if !has_selection {
+            if self.scroll_top >= max_scroll {
+                self.auto_scroll = true;
+            }
+            if self.auto_scroll {
+                self.scroll_top = max_scroll;
+            }
+        }
+        total_lines
+    }
+
+    /// Re-lays out the stale segments the viewport plus its margin reaches,
+    /// keeping the topmost visible one pinned: `scroll_top` is a line offset,
+    /// so re-laying out anything above the viewport would slide the content
+    /// the reader is looking at.
+    ///
+    /// The window is walked outward from an anchor segment, counting heights
+    /// only after each segment is reflowed. Document offsets move as the
+    /// reflow runs, so a window expressed in them would need repeated passes
+    /// to settle; this one is right the first time.
+    fn reflow_viewport(&mut self, width: u16) {
+        let anchor = (!self.auto_scroll)
+            .then(|| self.cache.anchor_at(self.scroll_top as u32, width))
+            .flatten();
+        let viewport = self.viewport_height as u32;
+        let margin = viewport.saturating_mul(REFLOW_MARGIN_VIEWPORTS);
+        let below = viewport.saturating_add(margin);
+        // Pinned to the bottom (or scrolled into the streaming tail): the
+        // viewport is the last `below` lines, so the window is all above.
+        let (start, above) = match anchor {
+            Some((i, _)) => (i, margin),
+            None => (self.cache.len().saturating_sub(1), below),
+        };
+        let len_before = self.cache.len();
+
+        let mut acc = 0;
+        let mut i = start;
+        while i < self.cache.len() && acc < below {
+            acc += self.reflowed_height(i, width);
+            i += 1;
+        }
+        let mut acc = 0;
+        let mut i = start;
+        while i > 0 && acc < above {
+            i -= 1;
+            acc += self.reflowed_height(i, width);
+        }
+
+        // A rebuild can insert a missing instruction segment, which shifts the
+        // anchor index. Rare enough to just skip the pin for one frame.
+        if let Some(anchor) = anchor
+            && self.cache.len() == len_before
+        {
+            self.scroll_top = self.cache.anchor_offset(anchor, width).min(u16::MAX as u32) as u16;
+        }
+    }
+
+    /// Reflows `seg_idx` if it is stale, then reports the height it draws at.
+    fn reflowed_height(&mut self, seg_idx: usize, width: u16) -> u32 {
+        // A tool segment and its instruction segment both map back to the
+        // same parent, and one `rebuild_tool_segment` clears both flags.
+        // Re-check so the parent is not rebuilt twice.
+        if self.cache.get(seg_idx).is_some_and(|s| s.stale) {
+            self.reflow_segment(seg_idx, width);
+        }
+        self.cache
+            .get(seg_idx)
+            .map_or(0, |s| s.height(width) as u32)
+    }
+
+    fn reflow_segment(&mut self, seg_idx: usize, width: u16) {
+        // Clear up front so a reflow that bails early (message gone, empty
+        // instructions) costs one frame of old-width lines instead of
+        // retrying forever.
+        let Some(seg) = self.cache.get_mut(seg_idx) else {
+            return;
+        };
+        seg.stale = false;
+        let (tool_id, msg_idx) = (seg.tool_id.clone(), seg.msg_index);
+
+        if let Some(tid) = tool_id {
+            let parent = segment::instruction_parent(&tid)
+                .map(str::to_string)
+                .unwrap_or(tid);
+            self.rebuild_tool_segment(&parent);
+            return;
+        }
+
+        let Some(msg_idx) = msg_idx else {
+            return;
+        };
+
+        let collapsed = self
+            .messages
+            .get(msg_idx)
+            .is_some_and(|m| matches!(m.role, DisplayRole::Thinking) && m.thinking_collapsed);
+        if collapsed {
+            // Geometry is width-independent, but `width_changed` also fires on
+            // theme changes; rebuild so spans pick up the new palette.
+            self.rebuild_thinking_segment(msg_idx, width);
+        } else {
+            self.reflow_text_segment(seg_idx, width);
+        }
+    }
+
+    fn reflow_text_segment(&mut self, seg_idx: usize, width: u16) {
+        let Some(msg_idx) = self.cache.get(seg_idx).and_then(|s| s.msg_index) else {
+            return;
+        };
+        let Some(msg) = self.messages.get(msg_idx) else {
+            return;
+        };
+        let (lines, search_text) = build_message_lines(msg, width);
+        let Some(seg) = self.cache.get_mut(seg_idx) else {
+            return;
+        };
+        seg.set_lines(lines);
+        seg.search_text = search_text;
     }
 }
 
@@ -1385,4 +1458,61 @@ fn logical_line_count(text: &str) -> usize {
     } else {
         text.bytes().filter(|&b| b == b'\n').count() + 1
     }
+}
+
+/// Builds ratatui lines for a non-Tool, non-collapsed-Thinking message at the
+/// given width, returning the lines and search text. Shared by
+/// `rebuild_line_cache` (new messages) and `reflow_text_segment` (stale-on-resize
+/// messages) so both paths produce identical segments.
+fn build_message_lines(msg: &DisplayMessage, width: u16) -> (Vec<Line<'static>>, String) {
+    let style = match &msg.role {
+        DisplayRole::User => user_style(),
+        DisplayRole::Assistant => assistant_style(),
+        DisplayRole::Thinking => thinking_style(),
+        DisplayRole::Error => error_style(),
+        DisplayRole::Done => done_style(),
+        DisplayRole::Tool(_) => unreachable!(),
+    };
+    let prefix = if msg.plan_path.is_some() {
+        ""
+    } else {
+        style.prefix
+    };
+    let mut lines = if style.use_markdown {
+        text_to_lines(
+            &msg.text,
+            prefix,
+            style.text_style,
+            style.prefix_style,
+            width,
+            style.max_line_bytes,
+        )
+    } else {
+        plain_lines(&msg.text, prefix, style.text_style, style.prefix_style)
+    };
+    if let Some(pp) = &msg.plan_path {
+        if !msg.text.is_empty() {
+            let rule = hr_line(width, theme::current().plan_rule);
+            lines.insert(0, rule.clone());
+            lines.push(rule);
+        } else {
+            lines.clear();
+        }
+        if !msg.text.is_empty() {
+            lines.push(Line::from(""));
+        }
+        lines.push(Line::from(Span::styled(
+            pp.to_owned(),
+            theme::current().plan_path,
+        )));
+        lines.push(Line::from(Span::styled(
+            format!(
+                "{} to open in editor ($VISUAL / $EDITOR)",
+                key::OPEN_EDITOR.label
+            ),
+            theme::current().tool_dim,
+        )));
+    }
+    let search_text = format!("{prefix}{}", msg.text);
+    (lines, search_text)
 }

--- a/maki-ui/src/components/messages/segment.rs
+++ b/maki-ui/src/components/messages/segment.rs
@@ -1,4 +1,5 @@
 use crate::render_worker::RenderWorker;
+use crate::theme;
 
 use super::super::code_view::SectionFlags;
 use super::super::tool_display::{HighlightRequest, ToolLines};
@@ -29,12 +30,17 @@ struct CachedHeight {
 #[derive(Default, PartialEq, Eq)]
 struct HighlightKey {
     has_output: bool,
+    theme_gen: u64,
 }
 
 impl HighlightKey {
+    /// The generation is read here rather than passed in: a theme only swaps
+    /// from `update`, never mid-`view`, and a missed call site would silently
+    /// splice old-palette lines back in.
     fn from_request(hl: Option<&HighlightRequest>) -> Self {
         Self {
             has_output: hl.is_some_and(|h| h.output.is_some()),
+            theme_gen: theme::generation(),
         }
     }
 }
@@ -57,6 +63,11 @@ pub(super) struct Segment {
     pub spinner_lines: Vec<(usize, usize)>,
     snapshot_base: Option<usize>,
     pub content_indent: &'static str,
+    /// Lines were laid out at a width or theme that is no longer current.
+    /// Cleared by `set_lines` (whole vector replaced) and up front by
+    /// `reflow_segment`; partial splices (`apply_highlight_result`) leave it
+    /// set so the segment still reflows later.
+    pub(super) stale: bool,
 }
 
 impl Segment {
@@ -93,12 +104,22 @@ impl Segment {
 
     pub fn set_lines(&mut self, lines: Vec<Line<'static>>) {
         self.lines = lines;
+        self.stale = false;
         self.invalidate_height();
     }
 
+    /// Height in the document layout. While `stale` is set this is the height
+    /// measured at an older width, which is what keeps a resize off the
+    /// O(transcript) path: re-measuring means re-wrapping every line.
+    ///
+    /// Render, `segment_at_row` and the scrollbar all read this same number so
+    /// the layout stays self consistent, and `reflow_viewport` keeps every
+    /// segment the viewport can reach fresh. A caller that re-wraps the lines
+    /// itself has to use `drawn_height`, or it disagrees with the layout by
+    /// however much the width moved.
     pub fn height(&self, width: u16) -> u16 {
         if let Some(c) = self.cached_height.get()
-            && c.at_width == width
+            && (c.at_width == width || self.stale)
         {
             return c.height;
         }
@@ -108,6 +129,12 @@ impl Segment {
             height: h,
         }));
         h
+    }
+
+    /// Rows the lines really take at `width`, ignoring the cache. Same as
+    /// `height` for any segment that is not stale.
+    pub fn drawn_height(&self, width: u16) -> u16 {
+        wrapped_line_count(&self.lines, width)
     }
 
     /// Maps a display row (after wrapping) back to the source line index.
@@ -297,6 +324,26 @@ impl SegmentCache {
         None
     }
 
+    /// The segment holding `doc_row` and the row's offset inside it. Survives
+    /// a reflow, which a bare document-line offset does not.
+    pub fn anchor_at(&self, doc_row: u32, width: u16) -> Option<(usize, u16)> {
+        let (i, _, start) = self.segment_at_row(doc_row, width)?;
+        Some((i, (doc_row - start).min(u16::MAX as u32) as u16))
+    }
+
+    /// Where `anchor` sits now, clamped in case the reflow shrank the segment
+    /// it points into.
+    pub fn anchor_offset(&self, (idx, rel): (usize, u16), width: u16) -> u32 {
+        let before: u32 = self
+            .segments
+            .iter()
+            .take(idx)
+            .map(|s| s.height(width) as u32)
+            .sum();
+        let h = self.segments.get(idx).map_or(0, |s| s.height(width));
+        before + rel.min(h.saturating_sub(1)) as u32
+    }
+
     pub fn segments(&self) -> &[Segment] {
         &self.segments
     }
@@ -336,9 +383,10 @@ impl SegmentCache {
             .collect()
     }
 
-    pub fn invalidate_from_msg_count(&mut self) {
-        self.msg_count = 0;
-        self.segments.clear();
+    pub fn mark_all_width_stale(&mut self) {
+        for seg in &mut self.segments {
+            seg.stale = true;
+        }
     }
 }
 
@@ -355,6 +403,8 @@ pub(super) fn wrapped_line_count(lines: &[Line<'_>], width: u16) -> u16 {
 mod tests {
     use super::*;
     use test_case::test_case;
+
+    const OTHER_THEME: &str = "dracula";
 
     fn seg_with_base(line_count: usize, base: Option<usize>) -> Segment {
         Segment {
@@ -386,6 +436,56 @@ mod tests {
         assert_eq!(seg.buf_row(2), 0, "pre-snapshot lines map outside the buf");
         assert_eq!(seg.buf_row(3), 1);
         assert_eq!(seg.buf_row(5), 3);
+    }
+
+    #[test]
+    fn reuse_highlight_keys_on_theme_not_width() {
+        use crate::components::code_view::RenderLimits;
+        use maki_agent::ToolOutput;
+        use std::sync::Arc;
+
+        let output = Arc::new(ToolOutput::ReadCode {
+            path: "f.rs".into(),
+            start_line: 1,
+            lines: vec!["fn main() {}".into()],
+            total_lines: 1,
+            instructions: None,
+        });
+        let key = || {
+            HighlightKey::from_request(Some(&HighlightRequest {
+                range: (1, 3),
+                input: None,
+                output: Some(Arc::clone(&output)),
+                limits: RenderLimits {
+                    script: 0,
+                    output: 0,
+                },
+            }))
+        };
+        let seg = Segment {
+            highlight_key: key(),
+            highlight_range: Some((1, 3)),
+            lines: vec![
+                Line::raw("h"),
+                Line::raw("a"),
+                Line::raw("b"),
+                Line::raw("t"),
+            ],
+            ..Segment::default()
+        };
+
+        // Highlighted lines are source lines, not wrapped rows (the worker
+        // job carries no width), so the key deliberately omits width.
+        assert!(
+            seg.reuse_highlight(&key(), (1, 3)).is_some(),
+            "reuse must fire across a width change; highlight lines are width-independent"
+        );
+
+        theme::set(theme::load_by_name(OTHER_THEME).unwrap());
+        assert!(
+            seg.reuse_highlight(&key(), (1, 3)).is_none(),
+            "theme mismatch must force a fresh highlight, not splice old-palette lines"
+        );
     }
 
     #[test_case(4, 6 ; "splice_grows")]

--- a/maki-ui/src/components/messages/selection.rs
+++ b/maki-ui/src/components/messages/selection.rs
@@ -38,14 +38,23 @@ pub(super) fn extract_selection_text(
             continue;
         }
 
-        let tmp_area = Rect::new(0, 0, width, h);
+        // `h` is the document layout height, which can predate a resize (see
+        // `Segment::height`), while the wrap below happens at the real width.
+        // The rows we copy come from that wrap, so measure and clamp against
+        // it, and take the whole segment whenever the selection covers it.
+        let drawn = seg.drawn_height(width);
+        let tmp_area = Rect::new(0, 0, width, drawn);
         let mut tmp = Buffer::empty(tmp_area);
         Paragraph::new(seg.lines().to_vec())
             .wrap(Wrap { trim: false })
             .render(tmp_area, &mut tmp);
 
-        let rel_start = doc_start.row.saturating_sub(seg_start) as u16;
-        let rel_end = ((doc_end.row + 1).saturating_sub(seg_start) as u16).min(h);
+        let rel_start = (doc_start.row.saturating_sub(seg_start) as u16).min(drawn);
+        let rel_end = if doc_end.row + 1 >= seg_end {
+            drawn
+        } else {
+            ((doc_end.row + 1 - seg_start) as u16).min(drawn)
+        };
 
         let start_col = if seg_start > doc_start.row {
             0

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -1900,3 +1900,340 @@ fn stream_reset_clears_thinking_expand_state() {
         "new stream must stay hidden; got: {text}"
     );
 }
+
+#[test]
+fn stale_height_keeps_the_old_width_but_drawn_height_does_not() {
+    let long_line = Line::from("x".repeat(80));
+    let mut seg = Segment::with_lines(vec![long_line.clone()], "test".into(), None);
+
+    let h_wide = seg.height(80);
+    assert_eq!(h_wide, 1, "80 chars at width 80 fits on one line");
+
+    // Keeping the old height is what keeps a resize cheap: the document
+    // layout stays put until the segment is really reflowed.
+    seg.stale = true;
+    assert_eq!(
+        seg.height(40),
+        h_wide,
+        "stale segment should return old cached height, not recompute"
+    );
+    // Callers that re-wrap the lines themselves need the real number.
+    assert_eq!(
+        seg.drawn_height(40),
+        2,
+        "drawn_height must report what the lines really take at the new width"
+    );
+
+    seg.set_lines(vec![long_line]);
+    assert_eq!(seg.height(40), 2, "80 chars at width 40 wraps to two lines");
+}
+
+#[test]
+fn copy_after_resize_keeps_offscreen_text() {
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
+    let body = "x".repeat(60);
+    for i in 0..30 {
+        panel.push(DisplayMessage::new(
+            DisplayRole::Assistant,
+            format!("m{i:02}{body}"),
+        ));
+    }
+    render(&mut panel, 80, 10);
+    render(&mut panel, 40, 10);
+
+    let total: u32 = panel.segment_heights().iter().map(|&h| h as u32).sum();
+    let area = Rect::new(0, 0, 40, 10);
+    let sel = make_sel(area, (0, 0), (total - 1, 39));
+    let text = panel.extract_selection_text(&sel, area);
+
+    // The top of the transcript is far off-screen and never gets reflowed.
+    // Selection sizes its buffer from `height` and then re-wraps, so a height
+    // measured at the old width would clip every line it copies.
+    assert!(
+        text.contains(&format!("m00{body}")),
+        "off-screen message was truncated in the copy: {text:?}"
+    );
+}
+
+#[test]
+fn resize_reflows_only_viewport_segments() {
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
+    // 30 messages, each ~60 chars beyond the label — enough to exceed
+    // viewport (10) + reflow margin (1 * 10 = 10 lines) so top segments
+    // stay out of the reflow range when auto-scrolled to the bottom.
+    for i in 0..30 {
+        panel.push(DisplayMessage::new(
+            DisplayRole::Assistant,
+            format!("message {i:02} {}", "x".repeat(60)),
+        ));
+    }
+    render(&mut panel, 80, 10);
+    let seg_count_before = panel.cache.len();
+    assert!(seg_count_before > 0);
+
+    render(&mut panel, 40, 10);
+
+    // Cache preserved — no nuke
+    assert_eq!(
+        panel.cache.len(),
+        seg_count_before,
+        "resize must not clear the segment cache"
+    );
+
+    let segs = panel.cache.segments();
+
+    // Bottom segments (near the auto-scrolled viewport) are reflowed
+    let bottom_fresh = segs
+        .iter()
+        .filter(|s| s.msg_index.is_some())
+        .rev()
+        .take(5)
+        .all(|s| !s.stale);
+    assert!(
+        bottom_fresh,
+        "viewport segments should be reflowed to new width"
+    );
+
+    // Top segments (far above the viewport) remain width-stale
+    let top_stale = segs
+        .iter()
+        .filter(|s| s.msg_index.is_some())
+        .take(5)
+        .all(|s| s.stale);
+    assert!(
+        top_stale,
+        "off-viewport segments should stay width-stale after resize"
+    );
+}
+
+fn msg_seg_text(panel: &MessagesPanel, msg_idx: usize) -> String {
+    panel
+        .cache
+        .segments()
+        .iter()
+        .find(|s| s.msg_index == Some(msg_idx) && s.tool_id.is_none())
+        .unwrap()
+        .lines()
+        .iter()
+        .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+        .collect()
+}
+
+#[test]
+fn reflow_rebuilds_collapsed_thinking_instead_of_only_stamping() {
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
+    panel.show_thinking = false;
+    let mut m = DisplayMessage::new(DisplayRole::Thinking, "one\ntwo".to_string());
+    m.thinking_collapsed = true;
+    panel.push(m);
+    render(&mut panel, 80, 10);
+    assert!(
+        msg_seg_text(&panel, 0).contains("(2 lines)"),
+        "indicator should report the initial line count"
+    );
+
+    // Change what the indicator renders, then mark it stale the way a theme
+    // change does. Clearing the flag without rebuilding keeps the old spans.
+    panel.messages[0].text = "one\ntwo\nthree\nfour".to_string();
+    panel.cache.mark_all_width_stale();
+    render(&mut panel, 80, 10);
+
+    assert!(
+        msg_seg_text(&panel, 0).contains("(4 lines)"),
+        "stale collapsed-thinking segment must be rebuilt, not just stamped; got: {}",
+        msg_seg_text(&panel, 0)
+    );
+}
+
+#[test]
+fn reflow_runs_without_a_width_or_scroll_change() {
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
+    for i in 0..5 {
+        panel.push(DisplayMessage::new(
+            DisplayRole::Assistant,
+            format!("message {i}"),
+        ));
+    }
+    render(&mut panel, 80, 10);
+
+    // Segments go stale between frames without either trigger firing.
+    panel.cache.mark_all_width_stale();
+    render(&mut panel, 80, 10);
+
+    assert!(
+        panel.cache.segments().iter().all(|s| !s.stale),
+        "visible segments must be reflowed even when width and scroll_top are unchanged"
+    );
+}
+
+#[test]
+fn resize_reflows_tool_segment_and_keeps_instruction_segment() {
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
+    panel.tool_start(start("t1", "read"));
+    panel.tool_done(ToolDoneEvent {
+        id: "t1".into(),
+        tool: "read".into(),
+        output: read_code_with_instructions(instruction_blocks()),
+        is_error: false,
+        annotation: None,
+        written_path: None,
+    });
+    render(&mut panel, 80, 10);
+
+    // Tool + spacer + instruction segments are built up front.
+    let seg_count = panel.cache.len();
+    assert!(seg_count >= 3);
+
+    render(&mut panel, 40, 10);
+
+    // The instruction segment already exists, so reflowing the tool segment
+    // updates it in place rather than re-inserting (exercises the to_reflow
+    // index path through `rebuild_tool_segment` and the upsert).
+    assert_eq!(
+        panel.cache.len(),
+        seg_count,
+        "reflow must reuse the existing instruction segment, not re-insert"
+    );
+    // The viewport auto-scrolls to the bottom, where the tool and instruction
+    // segments sit, so neither stays stale after the resize.
+    assert!(
+        panel.cache.segments().iter().all(|s| !s.stale),
+        "tool and instruction segments in the viewport must be reflowed, not left stale"
+    );
+}
+
+#[test]
+fn big_widen_keeps_no_stale_segment_in_the_viewport() {
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
+    for i in 0..40 {
+        panel.push(DisplayMessage::new(
+            DisplayRole::Assistant,
+            format!("message {i:02} {}", "x".repeat(150)),
+        ));
+    }
+    render(&mut panel, 80, 30);
+    render(&mut panel, 240, 30);
+
+    // 3x widen: content shrinks and the bottom pin pulls up, so a single
+    // pre-reflow pass would leave stale segments in the viewport.
+    let vh = 30u32;
+    let top = panel.scroll_top() as u32;
+    let mut offset: u32 = 0;
+    for seg in panel.cache.segments() {
+        let h = seg.height(240) as u32;
+        let in_view = offset < top.saturating_add(vh) && offset + h > top;
+        assert!(
+            !(in_view && seg.stale),
+            "a stale segment overlaps the viewport after a big widen"
+        );
+        offset += h;
+    }
+    assert!(
+        panel.cache.segments().iter().any(|s| s.stale),
+        "off-viewport segments must stay stale so the test exercises convergence"
+    );
+}
+
+#[test]
+fn anchored_resize_keeps_the_topmost_visible_segment() {
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
+    for i in 0..40 {
+        panel.push(DisplayMessage::new(
+            DisplayRole::Assistant,
+            format!("message {i:02} {}", "x".repeat(60)),
+        ));
+    }
+    render(&mut panel, 80, 10);
+    panel.set_scroll_top(panel.max_scroll() / 2); // mid-transcript, unpins
+    render(&mut panel, 80, 10);
+    assert!(
+        !panel.auto_scroll(),
+        "the test must start anchored, not pinned"
+    );
+    let before = panel
+        .cache
+        .anchor_at(panel.scroll_top() as u32, 79)
+        .expect("scroll_top lands inside a segment");
+
+    render(&mut panel, 40, 10);
+
+    let after = panel
+        .cache
+        .anchor_at(panel.scroll_top() as u32, 39)
+        .expect("scroll_top still lands inside a segment after the resize");
+    assert_eq!(
+        after.0, before.0,
+        "narrowing must not slide the anchored topmost segment off the viewport"
+    );
+    assert!(
+        !panel.auto_scroll(),
+        "an anchored mid-transcript resize must not flip to the bottom pin"
+    );
+}
+const THEME_CODE: &str = "fn main() { let x = 1; }";
+const THEME_CODE_KEYWORDS: [&str; 3] = ["fn", "main", "let"];
+
+fn code_span_styles(panel: &MessagesPanel, tool_id: &str) -> Vec<(String, Style)> {
+    panel
+        .cache
+        .segments()
+        .iter()
+        .find(|s| s.tool_id.as_deref() == Some(tool_id))
+        .unwrap()
+        .lines()
+        .iter()
+        .flat_map(|l| l.spans.iter())
+        .filter(|s| THEME_CODE_KEYWORDS.contains(&s.content.trim()))
+        .map(|s| (s.content.to_string(), s.style))
+        .collect()
+}
+
+fn drain_highlight_worker(panel: &mut MessagesPanel) {
+    let deadline = Instant::now() + HIGHLIGHT_DEADLINE;
+    while panel.tick() == Dirty::NO {
+        assert!(
+            Instant::now() < deadline,
+            "the highlight worker never delivered a result"
+        );
+        std::thread::yield_now();
+    }
+    render(panel, 80, 20);
+}
+
+/// The unit test above only proves two generations make two keys. This is the
+/// wiring: drop `theme_gen` at a call site and the old palette gets spliced
+/// straight back in with no test to catch it.
+#[test]
+fn theme_switch_repaints_highlighted_code() {
+    theme::set(theme::load_by_name("dracula").unwrap());
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
+    panel.tool_start(start("t1", "read"));
+    panel.tool_done(ToolDoneEvent {
+        id: "t1".into(),
+        tool: "read".into(),
+        output: ToolOutput::ReadCode {
+            path: "file.rs".into(),
+            start_line: 1,
+            lines: vec![THEME_CODE.into()],
+            total_lines: 1,
+            instructions: None,
+        },
+        is_error: false,
+        annotation: None,
+        written_path: None,
+    });
+    render(&mut panel, 80, 20);
+    drain_highlight_worker(&mut panel);
+    let dracula = code_span_styles(&panel, "t1");
+    assert!(!dracula.is_empty(), "no highlighted keywords to compare");
+
+    theme::set(theme::load_by_name("tokyonight").unwrap());
+    render(&mut panel, 80, 20);
+    drain_highlight_worker(&mut panel);
+
+    assert_ne!(
+        dracula,
+        code_span_styles(&panel, "t1"),
+        "a theme switch must re-highlight, not splice old-palette lines back"
+    );
+}


### PR DESCRIPTION
I noticed that reflowing after resizing can be laggy when you've got a long transcript (I'm guessing this could be made worse by pathological markdown content). This manifested for me as the maki going blank for a second or two when I resized the window. In a tiling window manager flitting back and forth between fullscreened and windowed is a common occurrence and having it lag like that is disruptive.

I've tried to keep the changes minimal as possible while still making reflowing more responsive. Effectively with this changeset it only reflows when the segment goes stale (e.g., the window resizes or a theme is applied), and it that segment is in the viewport (plus a margin). Offscreen segments are reflowed lazily as they scroll into view and by an incremental sweep that batches the reflowing work.

I'm personally ambivalent about the sweep--it's only motivation is have the scroll bar converge back to being accurate rather than an estimate. I wouldn't care if the scroll indicator went away entirely. But other's might care more about its accuracy. If you're fine with scroll being just being an estimate it'd save maybe 100 lines here.

Let me know if there are any changes you'd like or design issues you have concerns about. 