### PR TITLE
feat(providers): add Command Code token-plan and credits providers

### DIFF
--- a/maki-config/src/providers.rs
+++ b/maki-config/src/providers.rs
@@ -93,6 +93,7 @@ pub enum Protocol {
     OpenaiResponses,
     Anthropic,
     Google,
+    CommandCode,
 }
 
 impl FromStr for Protocol {
@@ -104,6 +105,7 @@ impl FromStr for Protocol {
             "openai-responses" => Ok(Self::OpenaiResponses),
             "anthropic" => Ok(Self::Anthropic),
             "google" => Ok(Self::Google),
+            "commandcode" | "command-code" => Ok(Self::CommandCode),
             _ => Err(format!("unknown protocol: {s}")),
         }
     }

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -410,7 +410,7 @@ fn build_sections() -> Vec<ProviderSection> {
                     kind,
                     name: kind.display_name(),
                     auth_line: format!(
-                        "{} (or an existing Command Code CLI login in `~/.commandcode/auth.json`)",
+                        "browser login via `maki auth login command-code`, {}, or an existing Command Code CLI login in `~/.commandcode/auth.json`",
                         format_auth(kind)
                     ),
                     urls: vec![kind.base_url()],

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -405,6 +405,19 @@ fn build_sections() -> Vec<ProviderSection> {
                     entries: ManifestRegistry::get(&kind.to_string()).unwrap().models,
                 });
             }
+            ProviderKind::CommandCode => {
+                sections.push(ProviderSection {
+                    kind,
+                    name: kind.display_name(),
+                    auth_line: format!(
+                        "{} (or an existing Command Code CLI login in `~/.commandcode/auth.json`)",
+                        format_auth(kind)
+                    ),
+                    urls: vec![kind.base_url()],
+                    features: kind.features(),
+                    entries: ManifestRegistry::get(&kind.to_string()).unwrap().models,
+                });
+            }
             ProviderKind::Copilot => {
                 sections.push(ProviderSection {
                     kind,

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -21,6 +21,7 @@ pub use providers::catalog::{
     catalog_provider, catalog_provider_if_available, catalog_providers,
     catalog_providers_if_available, model_meta_if_available, warm_catalog,
 };
+pub use providers::commandcode::auth as commandcode_auth;
 pub use providers::copilot::auth as copilot_auth;
 pub use providers::dynamic;
 pub use providers::openai::auth as openai_auth;

--- a/maki-providers/src/manifest.rs
+++ b/maki-providers/src/manifest.rs
@@ -1,8 +1,8 @@
 use crate::model::{ModelEntry, ModelFamily, ModelTier};
 use crate::pricing::PricingSchedule;
 use crate::providers::{
-    anthropic, aperture, copilot, custom, deepseek, dynamic, google, llama_cpp, mistral, ollama,
-    openai, openrouter, synthetic, tensorx, xai, zai,
+    anthropic, aperture, commandcode, copilot, custom, deepseek, dynamic, google, llama_cpp,
+    mistral, ollama, openai, openrouter, synthetic, tensorx, xai, zai,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -212,6 +212,18 @@ const APERTURE: ProviderManifest = ProviderManifest {
     pricing_schedule: None,
 };
 
+const COMMAND_CODE: ProviderManifest = ProviderManifest {
+    slug: "command-code",
+    display_name: "Command Code",
+    family: ModelFamily::Generic,
+    supports_thinking: true,
+    accepts_arbitrary_models: true,
+    fallback_max_output: Some(64_000),
+    fallback_context_window: 200_000,
+    pricing_schedule: None,
+    models: commandcode::models(),
+};
+
 const BUILTINS: &[ProviderManifest] = &[
     ANTHROPIC,
     OPENAI,
@@ -229,6 +241,7 @@ const BUILTINS: &[ProviderManifest] = &[
     OPENCODE_GO,
     XAI,
     APERTURE,
+    COMMAND_CODE,
 ];
 
 pub struct ManifestRegistry;

--- a/maki-providers/src/manifest.rs
+++ b/maki-providers/src/manifest.rs
@@ -224,6 +224,18 @@ const COMMAND_CODE: ProviderManifest = ProviderManifest {
     models: commandcode::models(),
 };
 
+const COMMAND_CODE_CREDITS: ProviderManifest = ProviderManifest {
+    slug: "command-code-credits",
+    display_name: "Command Code Credits",
+    family: ModelFamily::Generic,
+    supports_thinking: true,
+    accepts_arbitrary_models: true,
+    fallback_max_output: Some(64_000),
+    fallback_context_window: 200_000,
+    pricing_schedule: None,
+    models: commandcode::models(),
+};
+
 const BUILTINS: &[ProviderManifest] = &[
     ANTHROPIC,
     OPENAI,
@@ -242,6 +254,7 @@ const BUILTINS: &[ProviderManifest] = &[
     XAI,
     APERTURE,
     COMMAND_CODE,
+    COMMAND_CODE_CREDITS,
 ];
 
 pub struct ManifestRegistry;

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -646,6 +646,7 @@ impl AddAssign for TokenUsage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
     use test_case::test_case;
 
     fn policy(allowed: &[&str], excluded: &[&str]) -> ModelPolicy {
@@ -1072,9 +1073,19 @@ mod tests {
         assert!(!vision("synthetic/syn:test-blind"));
     }
 
+    /// `set_known_models` replaces a provider's whole discovered list, so two
+    /// tests seeding the same slug clobber each other when they run in
+    /// parallel. Everyone seeding `ollama` takes this in turn.
+    static OLLAMA_DISCOVERY: Mutex<()> = Mutex::new(());
+
+    fn seeding_ollama() -> std::sync::MutexGuard<'static, ()> {
+        OLLAMA_DISCOVERY.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     #[test]
     fn discovered_context_window_flows_into_from_base_for_unknown_model() {
         use crate::model::ModelInfo;
+        let _seeding = seeding_ollama();
 
         let model_id = "test-discovered-context-window-model";
         let expected_window: u32 = 131_072;
@@ -1106,6 +1117,7 @@ mod tests {
     #[test_case(Some(PAID_PRICING),       false ; "priced_is_not_free")]
     #[test_case(None,                     false ; "unknown_price_is_not_free")]
     fn discovered_pricing_decides_free(pricing: Option<ModelPricing>, expected: bool) {
+        let _seeding = seeding_ollama();
         let model_id = "test-discovered-free-model";
         model_registry::set_known_models(
             "ollama",

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -629,9 +629,9 @@ mod tests {
     #[test]
     fn provider_for_slug_unknown_returns_error() {
         let tmp = tempfile::tempdir().unwrap();
-        crate::providers::catalog::warm_empty_catalog_for_tests(maki_storage::StateDir::from_path(
-            tmp.path().to_path_buf(),
-        ));
+        let _catalog = crate::providers::catalog::warm_empty_catalog_for_tests(
+            maki_storage::StateDir::from_path(tmp.path().to_path_buf()),
+        );
         let result = provider_for_slug("nonexistent-provider-xyz", Timeouts::default());
         match result {
             Err(e) => {

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -19,7 +19,7 @@ use crate::providers::aperture::Aperture;
 use crate::providers::catalog::{
     OPENCODE_FAMILY_SLUGS, available_if_warm, catalog_providers, catalog_providers_if_available,
 };
-use crate::providers::commandcode::CommandCode;
+use crate::providers::commandcode::{CommandCode, CommandCodeCredits};
 use crate::providers::copilot::Copilot;
 use crate::providers::deepseek::DeepSeek;
 use crate::providers::dynamic;
@@ -61,6 +61,8 @@ pub enum ProviderKind {
     Aperture,
     #[strum(serialize = "command-code")]
     CommandCode,
+    #[strum(serialize = "command-code-credits")]
+    CommandCodeCredits,
 }
 
 impl ProviderKind {
@@ -82,6 +84,7 @@ impl ProviderKind {
             Self::Xai => "xAI",
             Self::Aperture => "Aperture",
             Self::CommandCode => "Command Code",
+            Self::CommandCodeCredits => "Command Code Credits",
         }
     }
 
@@ -103,6 +106,7 @@ impl ProviderKind {
             Self::Xai => "XAI_API_KEY",
             Self::Aperture => "",
             Self::CommandCode => "COMMAND_CODE_API_KEY",
+            Self::CommandCodeCredits => "COMMAND_CODE_API_KEY",
         }
     }
 
@@ -126,6 +130,7 @@ impl ProviderKind {
             Self::Xai => "https://api.x.ai/v1",
             Self::Aperture => "Aperture gateway (set APERTURE_HOST)",
             Self::CommandCode => "https://api.commandcode.ai",
+            Self::CommandCodeCredits => "https://api.commandcode.ai/provider/v1",
         }
     }
 
@@ -160,8 +165,11 @@ impl ProviderKind {
                 "Tailscale Aperture LLM gateway; set APERTURE_HOST or configure in providers.toml",
             ),
             Self::CommandCode => Some(
-                "Token-plan (GOAT/Pro/Max/Team) access to the whole Command Code catalog, per-model reasoning effort",
+                "Token-plan (GOAT/Pro/Max/Team) access via browser login, per-model reasoning effort",
             ),
+            Self::CommandCodeCredits => {
+                Some("Metered pay-as-you-go credits on the same account, via API key")
+            }
             _ => None,
         }
     }
@@ -184,6 +192,7 @@ impl ProviderKind {
             Self::Xai => ModelFamily::Generic,
             Self::Aperture => ModelFamily::Generic,
             Self::CommandCode => ModelFamily::Generic,
+            Self::CommandCodeCredits => ModelFamily::Generic,
         }
     }
 
@@ -210,6 +219,7 @@ impl ProviderKind {
             Self::Xai => Some(131_072),
             Self::Aperture => Some(16_384),
             Self::CommandCode => Some(64_000),
+            Self::CommandCodeCredits => Some(64_000),
         }
     }
 
@@ -231,6 +241,7 @@ impl ProviderKind {
             Self::Xai => 500_000,
             Self::Aperture => 128_000,
             Self::CommandCode => 200_000,
+            Self::CommandCodeCredits => 200_000,
         }
     }
 
@@ -258,6 +269,7 @@ impl ProviderKind {
             Self::Xai => Ok(Box::new(Xai::new(timeouts)?)),
             Self::Aperture => Ok(Box::new(Aperture::new(timeouts)?)),
             Self::CommandCode => Ok(Box::new(CommandCode::new(timeouts)?)),
+            Self::CommandCodeCredits => Ok(Box::new(CommandCodeCredits::new(timeouts)?)),
         }
     }
 }

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -19,6 +19,7 @@ use crate::providers::aperture::Aperture;
 use crate::providers::catalog::{
     OPENCODE_FAMILY_SLUGS, available_if_warm, catalog_providers, catalog_providers_if_available,
 };
+use crate::providers::commandcode::CommandCode;
 use crate::providers::copilot::Copilot;
 use crate::providers::deepseek::DeepSeek;
 use crate::providers::dynamic;
@@ -58,6 +59,8 @@ pub enum ProviderKind {
     #[strum(serialize = "xai")]
     Xai,
     Aperture,
+    #[strum(serialize = "command-code")]
+    CommandCode,
 }
 
 impl ProviderKind {
@@ -78,6 +81,7 @@ impl ProviderKind {
             Self::Opencode => "Opencode Zen",
             Self::Xai => "xAI",
             Self::Aperture => "Aperture",
+            Self::CommandCode => "Command Code",
         }
     }
 
@@ -98,6 +102,7 @@ impl ProviderKind {
             Self::Opencode => "OPENCODE_API_KEY",
             Self::Xai => "XAI_API_KEY",
             Self::Aperture => "",
+            Self::CommandCode => "COMMAND_CODE_API_KEY",
         }
     }
 
@@ -120,6 +125,7 @@ impl ProviderKind {
             Self::Opencode => "https://opencode.ai/zen/v1",
             Self::Xai => "https://api.x.ai/v1",
             Self::Aperture => "Aperture gateway (set APERTURE_HOST)",
+            Self::CommandCode => "https://api.commandcode.ai",
         }
     }
 
@@ -153,6 +159,9 @@ impl ProviderKind {
             Self::Aperture => Some(
                 "Tailscale Aperture LLM gateway; set APERTURE_HOST or configure in providers.toml",
             ),
+            Self::CommandCode => Some(
+                "Token-plan (GOAT/Pro/Max/Team) access to the whole Command Code catalog, per-model reasoning effort",
+            ),
             _ => None,
         }
     }
@@ -174,6 +183,7 @@ impl ProviderKind {
             Self::Opencode => ModelFamily::Generic,
             Self::Xai => ModelFamily::Generic,
             Self::Aperture => ModelFamily::Generic,
+            Self::CommandCode => ModelFamily::Generic,
         }
     }
 
@@ -199,6 +209,7 @@ impl ProviderKind {
             Self::Opencode => Some(128_000),
             Self::Xai => Some(131_072),
             Self::Aperture => Some(16_384),
+            Self::CommandCode => Some(64_000),
         }
     }
 
@@ -219,6 +230,7 @@ impl ProviderKind {
             Self::Opencode => 256_000,
             Self::Xai => 500_000,
             Self::Aperture => 128_000,
+            Self::CommandCode => 200_000,
         }
     }
 
@@ -245,6 +257,7 @@ impl ProviderKind {
             Self::Opencode => Ok(Box::new(Opencode::new(timeouts)?)),
             Self::Xai => Ok(Box::new(Xai::new(timeouts)?)),
             Self::Aperture => Ok(Box::new(Aperture::new(timeouts)?)),
+            Self::CommandCode => Ok(Box::new(CommandCode::new(timeouts)?)),
         }
     }
 }

--- a/maki-providers/src/providers/aperture.rs
+++ b/maki-providers/src/providers/aperture.rs
@@ -169,7 +169,10 @@ fn kind_supports_thinking(kind: ProviderKind) -> bool {
 /// instead of silently inheriting `/v1` (which broke Zai once already).
 fn default_path_prefix(kind: Option<ProviderKind>) -> &'static str {
     match kind {
-        Some(ProviderKind::Anthropic | ProviderKind::Zai) => "",
+        // Command Code like Zai: the plan endpoint is `/alpha/generate`, and the
+        // credits base url already carries `/provider/v1`, so a prefix would
+        // double up either way.
+        Some(ProviderKind::Anthropic | ProviderKind::Zai | ProviderKind::CommandCode) => "",
         Some(ProviderKind::Google) => GEMINI_PATH_PREFIX,
         Some(
             ProviderKind::Ollama

--- a/maki-providers/src/providers/aperture.rs
+++ b/maki-providers/src/providers/aperture.rs
@@ -172,7 +172,12 @@ fn default_path_prefix(kind: Option<ProviderKind>) -> &'static str {
         // Command Code like Zai: the plan endpoint is `/alpha/generate`, and the
         // credits base url already carries `/provider/v1`, so a prefix would
         // double up either way.
-        Some(ProviderKind::Anthropic | ProviderKind::Zai | ProviderKind::CommandCode) => "",
+        Some(
+            ProviderKind::Anthropic
+            | ProviderKind::Zai
+            | ProviderKind::CommandCode
+            | ProviderKind::CommandCodeCredits,
+        ) => "",
         Some(ProviderKind::Google) => GEMINI_PATH_PREFIX,
         Some(
             ProviderKind::Ollama

--- a/maki-providers/src/providers/catalog.rs
+++ b/maki-providers/src/providers/catalog.rs
@@ -788,19 +788,41 @@ impl Provider for CatalogProvider {
     }
 }
 
+/// The catalog is a process-global, so the tests that seed it are not
+/// independent of each other. Every seeding helper takes this lock and hands
+/// the guard back, and holding it for the length of the test is what keeps one
+/// test's seed from landing under another test's assertions.
 #[cfg(test)]
-pub(crate) fn seed_catalog_for_tests(index: schema::CatalogIndex, state_dir: StateDir) {
-    let _ = SHARED_CATALOG.set(Mutex::new(CatalogData::from_index(
-        index,
-        false,
-        &state_dir,
-        std::collections::HashSet::new(),
-    )));
+static CATALOG_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// Replaces the catalog rather than initialising it once: with `OnceLock::set`
+/// the first test to run silently decided the contents for every test after
+/// it, so a suite passed or failed on thread scheduling.
+#[cfg(test)]
+#[must_use = "hold the guard for the whole test, or another test may reseed underneath it"]
+pub(crate) fn seed_catalog_for_tests(
+    index: schema::CatalogIndex,
+    state_dir: StateDir,
+) -> std::sync::MutexGuard<'static, ()> {
+    // A test that panicked while holding the lock poisoned it but left the
+    // catalog usable, so recover rather than cascading one failure into all.
+    let guard = CATALOG_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let data = CatalogData::from_index(index, false, &state_dir, std::collections::HashSet::new());
+    match SHARED_CATALOG.get() {
+        Some(existing) => *existing.lock().unwrap_or_else(|e| e.into_inner()) = data,
+        None => {
+            let _ = SHARED_CATALOG.set(Mutex::new(data));
+        }
+    }
+    guard
 }
 
 #[cfg(test)]
-pub(crate) fn warm_empty_catalog_for_tests(state_dir: StateDir) {
-    seed_catalog_for_tests(HashMap::new(), state_dir);
+#[must_use = "hold the guard for the whole test, or another test may reseed underneath it"]
+pub(crate) fn warm_empty_catalog_for_tests(
+    state_dir: StateDir,
+) -> std::sync::MutexGuard<'static, ()> {
+    seed_catalog_for_tests(HashMap::new(), state_dir)
 }
 
 /// Defers catalog resolution to first use so that provider construction
@@ -1513,7 +1535,7 @@ mod tests {
                 models,
             },
         )]);
-        super::seed_catalog_for_tests(index, state_dir);
+        let _catalog = super::seed_catalog_for_tests(index, state_dir);
 
         let model = super::Model::from_spec(&format!("opencode/{model_id}")).unwrap();
         assert_eq!(model.is_free(), expected);

--- a/maki-providers/src/providers/commandcode.rs
+++ b/maki-providers/src/providers/commandcode.rs
@@ -1,0 +1,1187 @@
+//! Command Code token-plan provider (GOAT / Pro / Max / Team).
+//!
+//! Token plans do not speak the OpenAI-compatible `/provider/v1/chat/completions`
+//! endpoint the pay-as-you-go Provider plan uses. They speak a custom SSE
+//! protocol at `POST {base}/alpha/generate`: a request envelope of
+//! `config`/`memory`/`taste`/`skills`/`params`/`threadId`, and a Vercel-AI-SDK
+//! shaped event stream (`text-delta`, `reasoning-delta`, `tool-call`, `finish`).
+//! Wire format reverse-engineered from `pi-commandcode-provider` against
+//! command-code CLI 1.15.1; the model catalog at `/provider/v1/models` is the
+//! only OpenAI-shaped part.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use flume::Sender;
+use futures_lite::io::{AsyncBufReadExt, BufReader};
+use isahc::{AsyncReadResponseExt, HttpClient, Request};
+use maki_storage::id::{MakiId, SessionRef};
+use maki_storage::sessions::Effort;
+use maki_storage::sessions::Effort::{High, Low, Max, Medium, XHigh};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tracing::{debug, warn};
+
+use crate::model::{Model, ModelEntry, ModelInfo, ThinkingSupport};
+use crate::provider::{BoxFuture, Provider};
+use crate::types::EffortDialect;
+use crate::{
+    AgentError, ContentBlock, Message, ProviderEvent, RequestOptions, Role, StopReason,
+    StreamResponse, ThinkingConfig, TokenUsage,
+};
+
+use super::{KeyPool, ResolvedAuth, http_client, next_sse_line, user_agent};
+
+const SLUG: &str = "command-code";
+const BASE_URL: &str = "https://api.commandcode.ai";
+const ENV_VAR: &str = "COMMAND_CODE_API_KEY";
+/// Sent as `x-command-code-version`; the endpoint gates behaviour on it.
+const CLI_VERSION: &str = "1.15.1";
+/// The generate endpoint's own ceiling, independent of the model window.
+const MAX_GENERATE_TOKENS: u32 = 64_000;
+const DEFAULT_TEMPERATURE: f64 = 0.3;
+
+inventory::submit!(maki_config::providers::BuiltInProvider {
+    slug: SLUG,
+    display_name: "Command Code",
+    protocol: maki_config::providers::Protocol::CommandCode,
+    default_base_url: BASE_URL,
+    default_api_key_env: ENV_VAR,
+    default_model: "command-code/claude-opus-5",
+    plans: None,
+    login_url: Some("https://commandcode.ai"),
+    needs_url: false,
+});
+
+/// Empty on purpose: the catalog is fetched from `/provider/v1/models`, and a
+/// token plan bills against the subscription, so static per-token pricing here
+/// would only be a second source of truth to keep in sync.
+pub(crate) const fn models() -> &'static [ModelEntry] {
+    &[]
+}
+
+const FULL: &[Effort] = &[Low, Medium, High, XHigh, Max];
+const TO_XHIGH: &[Effort] = &[Low, Medium, High, XHigh];
+const TO_HIGH: &[Effort] = &[Low, Medium, High];
+const HIGH_MAX: &[Effort] = &[High, Max];
+const HIGH_XHIGH: &[Effort] = &[High, XHigh];
+const NONE: &[Effort] = &[];
+
+/// `(model id, accepted reasoning efforts, accepts image input)`.
+///
+/// `/provider/v1/models` returns only id/name/context_length, so reasoning and
+/// vision have to come from somewhere: this is a snapshot of the
+/// command-code@1.15.1 bundled catalog. An id missing here is treated as
+/// text-only with provider-chosen reasoning depth, which is what the CLI does
+/// too, so a newly released model degrades instead of erroring.
+///
+/// ponytail: hand-maintained snapshot. Refresh from
+/// <https://commandcode.ai/docs/resources/pricing-limits> when models land; if
+/// the catalog endpoint ever exposes these fields, delete the table.
+const CATALOG: &[(&str, &[Effort], bool)] = &[
+    ("MiniMaxAI/MiniMax-M3", NONE, true),
+    ("Qwen/Qwen3.6-Plus", NONE, true),
+    ("Qwen/Qwen3.7-Flash", NONE, true),
+    ("Qwen/Qwen3.7-Plus", NONE, true),
+    ("Qwen/Qwen3.8-Max", &[Low, Medium, XHigh], true),
+    ("claude-fable-5", FULL, true),
+    ("claude-haiku-4-5-20251001", NONE, true),
+    ("claude-opus-4-7", FULL, true),
+    ("claude-opus-4-8", FULL, true),
+    ("claude-opus-5", FULL, true),
+    ("claude-sonnet-4-6", FULL, true),
+    ("claude-sonnet-5", FULL, true),
+    ("deepseek/deepseek-v4-flash", HIGH_MAX, false),
+    ("deepseek/deepseek-v4-pro", HIGH_MAX, false),
+    ("google/gemini-3.1-flash-lite", TO_HIGH, true),
+    ("google/gemini-3.5-flash", TO_HIGH, true),
+    ("google/gemini-3.5-flash-lite", TO_HIGH, true),
+    ("google/gemini-3.6-flash", TO_HIGH, true),
+    ("gpt-5.3-codex", TO_XHIGH, true),
+    ("gpt-5.4", TO_XHIGH, true),
+    ("gpt-5.4-mini", TO_HIGH, true),
+    ("gpt-5.5", TO_XHIGH, true),
+    ("gpt-5.6-luna", FULL, true),
+    ("gpt-5.6-sol", FULL, true),
+    ("gpt-5.6-terra", FULL, true),
+    ("meta/muse-spark-1.1", NONE, true),
+    ("meta/muse-spark-1.2", NONE, true),
+    ("meta/muse-spark-1.2-contributor", NONE, true),
+    ("moonshotai/Kimi-K2.5", NONE, true),
+    ("moonshotai/Kimi-K2.6", NONE, true),
+    ("moonshotai/Kimi-K2.7-Code", NONE, true),
+    ("moonshotai/Kimi-K2.7-Code-Highspeed", NONE, true),
+    ("moonshotai/Kimi-K3", NONE, true),
+    ("sakana/fugu-ultra", HIGH_XHIGH, true),
+    ("stepfun/Step-3.7-Flash", NONE, true),
+    ("thinkingmachines/inkling", NONE, true),
+    ("thinkingmachines/inkling-small", NONE, true),
+    ("xai/grok-4.5", TO_HIGH, true),
+    ("xiaomi/mimo-v2.5", NONE, true),
+    ("zai-org/GLM-5.2", HIGH_MAX, false),
+];
+
+fn catalog_entry(model_id: &str) -> Option<&'static (&'static str, &'static [Effort], bool)> {
+    CATALOG.iter().find(|(id, _, _)| *id == model_id)
+}
+
+/// `None` means send no `reasoning_effort` and let Command Code pick, which is
+/// also what an unknown model gets.
+fn reasoning_effort(model: &Model, thinking: ThinkingConfig) -> Option<&'static str> {
+    let (_, efforts, _) = catalog_entry(&model.id)?;
+    if efforts.is_empty() {
+        return None;
+    }
+    thinking.effort_str(
+        &EffortDialect {
+            supported: efforts,
+            // Command Code has no adaptive level and no explicit opt-out
+            // string: both mean "omit the field".
+            adaptive: None,
+            off: None,
+        },
+        model,
+    )
+}
+
+/// Credential files written by the Command Code CLI and by pi/omp hosts. maki's
+/// own `KeyPool` (env, `maki auth login`, providers.toml) is tried first; this
+/// is the fallback that makes an existing CLI login just work.
+fn key_from_cli_files() -> Option<String> {
+    let home = std::env::var_os("HOME").map(std::path::PathBuf::from)?;
+    let paths = [
+        home.join(".commandcode/auth.json"),
+        home.join(".omp/agent/auth.json"),
+        home.join(".pi/agent/auth.json"),
+    ];
+    for path in paths {
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(root) = serde_json::from_str::<Value>(&text) else {
+            continue;
+        };
+        let direct = ["apiKey", "commandcode"]
+            .iter()
+            .find_map(|k| root.get(*k)?.as_str());
+        if let Some(key) = direct {
+            return Some(key.to_string());
+        }
+        // `{"command-code": {"type":"api","key":"..."}}` from the CLI, or the
+        // same shape with `type: "oauth"` and an `access` token.
+        let nested = ["commandcode", "command-code"].iter().find_map(|k| {
+            let record = root.get(*k)?;
+            record.get("key").or_else(|| record.get("access"))?.as_str()
+        });
+        if let Some(key) = nested {
+            return Some(key.to_string());
+        }
+    }
+    None
+}
+
+fn resolve_key_pool() -> Result<KeyPool, AgentError> {
+    match KeyPool::resolve(SLUG, ENV_VAR) {
+        Ok(pool) => Ok(pool),
+        Err(e) => key_from_cli_files().map_or(Err(e), |key| Ok(KeyPool::from_keys(vec![key]))),
+    }
+}
+
+fn resolve_auth_from_key(key: &str, base_url: Option<String>) -> ResolvedAuth {
+    let mut auth = ResolvedAuth::bearer(key);
+    auth.base_url = base_url;
+    auth
+}
+
+pub struct CommandCode {
+    client: HttpClient,
+    auth: Arc<Mutex<ResolvedAuth>>,
+    key_pool: Option<KeyPool>,
+    stream_timeout: Duration,
+}
+
+impl CommandCode {
+    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
+        let pool = resolve_key_pool()?;
+        let config = maki_config::providers::ProvidersConfig::load();
+        let base_url = maki_config::providers::resolve_base_url(SLUG, config.get(SLUG));
+        Ok(Self {
+            client: http_client(timeouts),
+            auth: Arc::new(Mutex::new(resolve_auth_from_key(pool.current(), base_url))),
+            key_pool: Some(pool),
+            stream_timeout: timeouts.stream,
+        })
+    }
+
+    pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
+        Self {
+            client: http_client(timeouts),
+            auth,
+            key_pool: None,
+            stream_timeout: timeouts.stream,
+        }
+    }
+
+    /// Live, so a base URL a caller sets on the shared auth after construction
+    /// is honoured instead of a snapshot taken in the constructor.
+    fn base_url(&self) -> Option<String> {
+        self.auth.lock().unwrap().base_url.clone()
+    }
+
+    fn base(&self) -> String {
+        self.auth
+            .lock()
+            .unwrap()
+            .base_url
+            .as_deref()
+            .unwrap_or(BASE_URL)
+            .trim_end_matches('/')
+            .to_string()
+    }
+
+    fn build_request(&self, method: &str, url: &str) -> isahc::http::request::Builder {
+        let auth = self.auth.lock().unwrap();
+        auth.configure_request(
+            Request::builder()
+                .method(method)
+                .uri(url)
+                .header("user-agent", user_agent())
+                .header("x-command-code-version", CLI_VERSION)
+                .header("x-cli-environment", "production"),
+        )
+    }
+
+    fn build_body(
+        &self,
+        model: &Model,
+        messages: &[Message],
+        system: &str,
+        tools: &Value,
+        opts: RequestOptions,
+        working_dir: &str,
+    ) -> Value {
+        let mut params = json!({
+            "model": model.id,
+            "messages": convert_messages(messages),
+            "tools": convert_tools(tools),
+            "system": system,
+            "max_tokens": model
+                .max_output_tokens
+                .unwrap_or(MAX_GENERATE_TOKENS)
+                .min(MAX_GENERATE_TOKENS),
+            "temperature": DEFAULT_TEMPERATURE,
+            "stream": true,
+        });
+        if let Some(effort) = reasoning_effort(model, opts.thinking) {
+            params["reasoning_effort"] = json!(effort);
+        }
+
+        json!({
+            // The endpoint expects the CLI's project envelope. maki builds its
+            // own system prompt, so only the working directory and date carry
+            // real information; the git fields stay empty rather than
+            // duplicating what the prompt already says.
+            "config": {
+                "workingDir": working_dir,
+                "date": jiff::Zoned::now().date().to_string(),
+                "environment": format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH),
+                "structure": [],
+                "isGitRepo": false,
+                "currentBranch": "",
+                "mainBranch": "",
+                "gitStatus": "",
+                "recentCommits": [],
+            },
+            "memory": Value::Null,
+            "taste": Value::Null,
+            "skills": Value::Null,
+            "params": params,
+            "threadId": thread_id(),
+        })
+    }
+
+    async fn do_stream(
+        &self,
+        model: &Model,
+        messages: &[Message],
+        system: &str,
+        tools: &Value,
+        event_tx: &Sender<ProviderEvent>,
+        opts: RequestOptions,
+    ) -> Result<StreamResponse, AgentError> {
+        // One getcwd per request: the envelope and the project-slug header
+        // must agree, and they cannot if each reads the cwd separately.
+        let working_dir = std::env::current_dir()
+            .map(|p| p.display().to_string())
+            .unwrap_or_default();
+        let body = serde_json::to_vec(&self.build_body(
+            model,
+            messages,
+            system,
+            tools,
+            opts,
+            &working_dir,
+        ))?;
+        let url = format!("{}/alpha/generate", self.base());
+        let request = self
+            .build_request("POST", &url)
+            .header("content-type", "application/json")
+            // maki has no taste/co features, so never opt this session into
+            // training them.
+            .header("x-project-slug", project_slug(&working_dir))
+            .header("x-taste-learning", "false")
+            .header("x-co-flag", "false")
+            .body(body)?;
+
+        let response = self.client.send_async(request).await?;
+        if response.status().as_u16() == 200 {
+            parse_sse(response, event_tx, self.stream_timeout).await
+        } else {
+            Err(AgentError::from_response(response).await)
+        }
+    }
+}
+
+/// Command Code groups requests server-side by project. The reference client
+/// derives the slug from the working directory path, so the same directory has
+/// to produce the same slug here.
+fn project_slug(path: &str) -> String {
+    // Exactly one leading letter plus a colon, so a Windows drive is stripped
+    // but a path segment like `mydir:file` keeps its head.
+    let path = path
+        .strip_prefix(|c: char| c.is_ascii_alphabetic())
+        .and_then(|rest| rest.strip_prefix(':'))
+        .unwrap_or(path);
+    // `slugify` folds on Unicode alphanumerics where the reference client folds
+    // on ASCII, so a non-ASCII path groups under a different key server-side
+    // than the CLI would pick. A grouping label, not a request failure.
+    let slug = maki_config::providers::slugify(path);
+    if slug.is_empty() {
+        "project".into()
+    } else {
+        slug
+    }
+}
+
+/// A fresh RFC 4122 string per request, matching the reference client. The
+/// endpoint treats it as an opaque conversation key.
+///
+/// ponytail: per-request id means no server-side thread reuse. Thread it from
+/// `SessionRef` if Command Code turns out to cache across a thread.
+fn thread_id() -> String {
+    MakiId::generate().hyphenated()
+}
+
+/// maki hands tools over in the Anthropic shape, which is what the endpoint
+/// wants apart from the `type` discriminator.
+fn convert_tools(tools: &Value) -> Vec<Value> {
+    let Some(arr) = tools.as_array() else {
+        return Vec::new();
+    };
+    arr.iter()
+        .filter_map(|t| {
+            Some(json!({
+                "type": "function",
+                "name": t.get("name")?.as_str()?,
+                "description": t.get("description").and_then(Value::as_str).unwrap_or(""),
+                "input_schema": t
+                    .get("input_schema")
+                    .cloned()
+                    .unwrap_or_else(|| json!({"type": "object", "properties": {}})),
+            }))
+        })
+        .collect()
+}
+
+fn image_part(source: &crate::types::ImageSource) -> Value {
+    json!({
+        "type": "image",
+        "image": source.to_data_url(),
+        "mimeType": source.media_type.mime(),
+    })
+}
+
+/// Command Code rejects a tool call without its result and a result without its
+/// call, so unpaired halves (an aborted turn, a trimmed history) are dropped
+/// together rather than sent and 400'd.
+fn convert_messages(messages: &[Message]) -> Vec<Value> {
+    let calls: std::collections::HashMap<&str, &str> = messages
+        .iter()
+        .flat_map(|m| &m.content)
+        .filter_map(|b| match b {
+            ContentBlock::ToolUse { id, name, .. } => Some((id.as_str(), name.as_str())),
+            _ => None,
+        })
+        .collect();
+    let paired: std::collections::HashSet<&str> = messages
+        .iter()
+        .flat_map(|m| &m.content)
+        .filter_map(|b| match b {
+            ContentBlock::ToolResult { tool_use_id, .. }
+                if calls.contains_key(tool_use_id.as_str()) =>
+            {
+                Some(tool_use_id.as_str())
+            }
+            _ => None,
+        })
+        .collect();
+
+    let mut out = Vec::new();
+    for msg in messages {
+        match msg.role {
+            Role::Assistant => {
+                // Reasoning is never replayed: the endpoint does not accept it
+                // back on a later turn.
+                let parts: Vec<Value> = msg
+                    .content
+                    .iter()
+                    .filter_map(|b| match b {
+                        ContentBlock::Text { text } => Some(json!({"type": "text", "text": text})),
+                        ContentBlock::ToolUse {
+                            id, name, input, ..
+                        } if paired.contains(id.as_str()) => Some(json!({
+                            "type": "tool-call",
+                            "toolCallId": id,
+                            "toolName": name,
+                            "input": input,
+                        })),
+                        _ => None,
+                    })
+                    .collect();
+                if !parts.is_empty() {
+                    out.push(json!({"role": "assistant", "content": parts}));
+                }
+            }
+            Role::User => {
+                let mut results = Vec::new();
+                let mut images = Vec::new();
+                let mut plain = Vec::new();
+                for block in &msg.content {
+                    match block {
+                        ContentBlock::ToolResult {
+                            tool_use_id,
+                            content,
+                            is_error,
+                        } if paired.contains(tool_use_id.as_str()) => {
+                            results.push(json!({
+                                "type": "tool-result",
+                                "toolCallId": tool_use_id,
+                                "toolName": calls.get(tool_use_id.as_str()).copied().unwrap_or(""),
+                                "output": {
+                                    "type": if *is_error { "error-text" } else { "text" },
+                                    "value": content,
+                                },
+                            }));
+                        }
+                        ContentBlock::Text { text } => {
+                            plain.push(json!({"type": "text", "text": text}));
+                        }
+                        ContentBlock::Image { source } => images.push(image_part(source)),
+                        _ => {}
+                    }
+                }
+                if !results.is_empty() {
+                    out.push(json!({"role": "tool", "content": results}));
+                }
+                // Images never ride along in a tool-result turn; they get their
+                // own user turn, as the reference client does.
+                plain.extend(images);
+                if !plain.is_empty() {
+                    out.push(json!({"role": "user", "content": plain}));
+                }
+            }
+        }
+    }
+    out
+}
+
+// --- stream events ---
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct InputTokenDetails {
+    no_cache_tokens: Option<u32>,
+    cache_read_tokens: Option<u32>,
+    cache_write_tokens: Option<u32>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CcUsage {
+    input_tokens: Option<u32>,
+    output_tokens: Option<u32>,
+    input_token_details: Option<InputTokenDetails>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CcEvent {
+    r#type: String,
+    text: Option<String>,
+    tool_call_id: Option<String>,
+    tool_name: Option<String>,
+    input: Option<Value>,
+    finish_reason: Option<String>,
+    total_usage: Option<CcUsage>,
+    error: Option<Value>,
+    message: Option<Value>,
+}
+
+fn error_text(value: Option<&Value>) -> Option<String> {
+    match value? {
+        Value::String(s) => Some(s.clone()),
+        Value::Object(map) => map
+            .get("message")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        _ => None,
+    }
+}
+
+fn stop_reason_of(reason: &str) -> StopReason {
+    match reason {
+        "tool-calls" | "tool_calls" => StopReason::ToolUse,
+        "length" | "max_tokens" | "max-tokens" | "max_output_tokens" => StopReason::MaxTokens,
+        _ => StopReason::EndTurn,
+    }
+}
+
+fn apply_usage(usage: &mut TokenUsage, reported: &CcUsage) {
+    let details = reported.input_token_details.as_ref();
+    let cache_read = details.and_then(|d| d.cache_read_tokens).unwrap_or(0);
+    let cache_write = details.and_then(|d| d.cache_write_tokens).unwrap_or(0);
+    usage.input = details.and_then(|d| d.no_cache_tokens).unwrap_or_else(|| {
+        // `inputTokens` is the all-in total, so the uncached part is what is
+        // left after the cache halves; saturating so a provider inconsistency
+        // cannot underflow into a huge number.
+        reported
+            .input_tokens
+            .unwrap_or(0)
+            .saturating_sub(cache_read)
+            .saturating_sub(cache_write)
+    });
+    usage.output = reported.output_tokens.unwrap_or(0);
+    usage.cache_read = cache_read;
+    usage.cache_creation = cache_write;
+}
+
+/// Events arrive one JSON object per line, with or without an SSE `data:`
+/// prefix. `None` for anything that is not an event (comments, `event:` lines,
+/// keepalives, `[DONE]`).
+fn parse_event_line(line: &str) -> Option<CcEvent> {
+    let trimmed = line.trim();
+    let payload = trimmed.strip_prefix("data:").unwrap_or(trimmed).trim();
+    if payload.is_empty()
+        || payload == "[DONE]"
+        || trimmed.starts_with(':')
+        || trimmed.starts_with("event:")
+    {
+        return None;
+    }
+    match serde_json::from_str(payload) {
+        Ok(event) => Some(event),
+        Err(e) => {
+            // A drifted `finish` or `error` shape lands here; swallowing it
+            // silently would surface later as a truncated turn instead.
+            warn!(error = %e, "unparseable Command Code stream event");
+            None
+        }
+    }
+}
+
+fn push_or_extend_text(blocks: &mut Vec<ContentBlock>, delta: &str) {
+    if let Some(ContentBlock::Text { text }) = blocks.last_mut() {
+        text.push_str(delta);
+    } else {
+        blocks.push(ContentBlock::Text { text: delta.into() });
+    }
+}
+
+fn push_or_extend_thinking(blocks: &mut Vec<ContentBlock>, delta: &str) {
+    if let Some(ContentBlock::Thinking { thinking, .. }) = blocks.last_mut() {
+        thinking.push_str(delta);
+    } else {
+        blocks.push(ContentBlock::Thinking {
+            thinking: delta.into(),
+            signature: None,
+        });
+    }
+}
+
+async fn parse_sse(
+    response: isahc::Response<isahc::AsyncBody>,
+    event_tx: &Sender<ProviderEvent>,
+    stream_timeout: Duration,
+) -> Result<StreamResponse, AgentError> {
+    let mut lines = BufReader::new(response.into_body()).lines();
+    let mut content: Vec<ContentBlock> = Vec::new();
+    let mut usage = TokenUsage::default();
+    let mut stop_reason: Option<StopReason> = None;
+    let mut saw_finish = false;
+    let mut deadline = Instant::now() + stream_timeout;
+
+    while let Some(line) = next_sse_line(&mut lines, &mut deadline, stream_timeout).await? {
+        let Some(event) = parse_event_line(&line) else {
+            continue;
+        };
+        match event.r#type.as_str() {
+            "text-delta" => {
+                let Some(text) = event.text.filter(|t| !t.is_empty()) else {
+                    continue;
+                };
+                event_tx
+                    .send_async(ProviderEvent::TextDelta { text: text.clone() })
+                    .await?;
+                push_or_extend_text(&mut content, &text);
+            }
+            "reasoning-delta" => {
+                let Some(text) = event.text.filter(|t| !t.is_empty()) else {
+                    continue;
+                };
+                event_tx
+                    .send_async(ProviderEvent::ThinkingDelta { text: text.clone() })
+                    .await?;
+                push_or_extend_thinking(&mut content, &text);
+            }
+            "tool-call" => {
+                // An empty id or name would have the agent "execute" a tool
+                // called "" and answer a call nothing is waiting on.
+                let (Some(id), Some(name)) = (event.tool_call_id, event.tool_name) else {
+                    warn!("Command Code tool-call event without an id or name, skipping");
+                    continue;
+                };
+                event_tx
+                    .send_async(ProviderEvent::ToolUseStart {
+                        id: id.clone(),
+                        name: name.clone(),
+                    })
+                    .await?;
+                content.push(ContentBlock::ToolUse {
+                    id,
+                    name,
+                    input: event.input.unwrap_or_else(|| json!({})),
+                    thought_signature: None,
+                });
+                stop_reason = Some(StopReason::ToolUse);
+            }
+            "finish" => {
+                if let Some(reported) = &event.total_usage {
+                    apply_usage(&mut usage, reported);
+                }
+                if let Some(reason) = &event.finish_reason {
+                    stop_reason = Some(stop_reason_of(reason));
+                }
+                saw_finish = true;
+                break;
+            }
+            "error" => {
+                let message = error_text(event.error.as_ref())
+                    .or_else(|| error_text(event.message.as_ref()))
+                    .unwrap_or_else(|| "Command Code stream error".into());
+                // The endpoint reports mid-stream failures inside a 200, so
+                // status is unavailable; 500 keeps them retryable.
+                return Err(AgentError::Api {
+                    status: 500,
+                    message,
+                });
+            }
+            // reasoning-start/reasoning-end/tool-result carry no content maki
+            // needs; the block boundaries are implied by the deltas. Anything
+            // else is logged, not dropped silently: the protocol is
+            // reverse-engineered and may grow events that matter.
+            other => debug!(event = other, "unhandled Command Code stream event"),
+        }
+    }
+
+    // Every complete turn ends in a `finish` event. Reaching EOF without one
+    // means the connection dropped mid-answer, and a `None` stop reason would
+    // be committed to history as a finished turn (`DoneReason::EndTurn`).
+    // Retryable, so the turn is regenerated rather than silently truncated.
+    if !saw_finish {
+        return Err(AgentError::Api {
+            status: 500,
+            message: "Command Code stream ended without a finish event".into(),
+        });
+    }
+
+    Ok(StreamResponse {
+        message: Message {
+            role: Role::Assistant,
+            content,
+            ..Default::default()
+        },
+        usage,
+        stop_reason,
+    })
+}
+
+// --- model catalog ---
+
+#[derive(Deserialize)]
+struct CatalogModel {
+    id: String,
+    context_length: Option<u32>,
+}
+
+#[derive(Deserialize)]
+struct CatalogResponse {
+    data: Vec<CatalogModel>,
+}
+
+impl Provider for CommandCode {
+    fn stream_message<'a>(
+        &'a self,
+        model: &'a Model,
+        messages: &'a [Message],
+        system: &'a str,
+        tools: &'a Value,
+        event_tx: &'a Sender<ProviderEvent>,
+        opts: RequestOptions,
+        _session_id: Option<&'a SessionRef>,
+    ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
+        Box::pin(self.do_stream(model, messages, system, tools, event_tx, opts))
+    }
+
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<ModelInfo>, AgentError>> {
+        let url = format!("{}/provider/v1/models", self.base());
+        let request = self.build_request("GET", &url).body(());
+        let client = self.client.clone();
+        Box::pin(async move {
+            let mut response = client.send_async(request?).await?;
+            if response.status().as_u16() != 200 {
+                return Err(AgentError::from_response(response).await);
+            }
+            let body = response.text().await?;
+            let catalog: CatalogResponse = serde_json::from_str(&body)?;
+            let mut infos: Vec<ModelInfo> = catalog
+                .data
+                .into_iter()
+                .map(|m| {
+                    let entry = catalog_entry(&m.id);
+                    ModelInfo {
+                        context_window: m.context_length,
+                        // The catalog exposes no output ceiling, so the context
+                        // window stands in for it, as the reference client
+                        // does. A model whose real cap is under 64k would be
+                        // asked for more than it allows.
+                        max_output_tokens: Some(
+                            m.context_length
+                                .unwrap_or(MAX_GENERATE_TOKENS)
+                                .min(MAX_GENERATE_TOKENS),
+                        ),
+                        supports_thinking: entry.map(|(_, efforts, _)| !efforts.is_empty()),
+                        supports_vision: entry.map(|(_, _, vision)| *vision),
+                        ..ModelInfo::id_only(m.id)
+                    }
+                })
+                .collect();
+            infos.sort_by(|a, b| a.id.cmp(&b.id));
+            Ok(infos)
+        })
+    }
+
+    /// Discovery has not necessarily run when the first request goes out, and
+    /// until it does the Generic manifest answers "no vision, thinking on
+    /// everything" — which silently strips images from the first turn on a
+    /// vision model. Seed both from the catalog snapshot; unknown ids fall
+    /// through to discovery unchanged.
+    fn adjust_model(&self, model: &mut Model) {
+        let Some((_, efforts, vision)) = catalog_entry(&model.id) else {
+            return;
+        };
+        model.supports_vision_override = Some(*vision);
+        model.thinking_override = Some(if efforts.is_empty() {
+            ThinkingSupport::No
+        } else {
+            ThinkingSupport::Yes
+        });
+    }
+
+    fn reload_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
+        Box::pin(async {
+            let pool = resolve_key_pool()?;
+            let base_url = self.base_url();
+            *self.auth.lock().unwrap() = resolve_auth_from_key(pool.current(), base_url);
+            Ok(())
+        })
+    }
+
+    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
+        Box::pin(async {
+            let base_url = self.base_url();
+            Ok(self.key_pool.as_ref().is_some_and(|p| {
+                p.rotate_auth(&self.auth, |key| {
+                    resolve_auth_from_key(key, base_url.clone())
+                })
+            }))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ModelFamily, ModelPricing, ModelTier};
+
+    fn model(id: &str) -> Model {
+        Model {
+            id: id.into(),
+            provider: Arc::from(SLUG),
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            supports_tool_examples_override: None,
+            thinking_override: None,
+            supports_vision_override: None,
+            pricing: ModelPricing::default(),
+            max_output_tokens: Some(200_000),
+            context_window: 400_000,
+            discovered_free: false,
+            thinking_fields: None,
+        }
+    }
+
+    fn provider() -> CommandCode {
+        CommandCode {
+            client: http_client(super::super::Timeouts::default()),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer("k"))),
+            key_pool: None,
+            stream_timeout: Duration::from_secs(300),
+        }
+    }
+
+    #[test]
+    fn max_tokens_capped_at_generate_ceiling() {
+        let body = provider().build_body(
+            &model("claude-opus-5"),
+            &[Message::user("hi".into())],
+            "sys",
+            &json!([]),
+            RequestOptions::default(),
+            "/tmp/proj",
+        );
+        assert_eq!(body["params"]["max_tokens"], MAX_GENERATE_TOKENS);
+        assert_eq!(body["params"]["system"], "sys");
+        assert_eq!(body["params"]["messages"][0]["role"], "user");
+        assert_eq!(body["config"]["workingDir"], "/tmp/proj");
+    }
+
+    #[test]
+    fn effort_snaps_to_what_the_model_accepts() {
+        // deepseek accepts only high/max, so Low must not go out as "low".
+        assert_eq!(
+            reasoning_effort(
+                &model("deepseek/deepseek-v4-pro"),
+                ThinkingConfig::Effort(Low)
+            ),
+            Some("high"),
+        );
+        assert_eq!(
+            reasoning_effort(&model("claude-opus-5"), ThinkingConfig::Effort(XHigh)),
+            Some("xhigh"),
+        );
+        // Non-reasoning and unknown models send nothing at all.
+        assert_eq!(
+            reasoning_effort(&model("moonshotai/Kimi-K3"), ThinkingConfig::Effort(High)),
+            None,
+        );
+        assert_eq!(
+            reasoning_effort(&model("brand/new-model"), ThinkingConfig::Effort(High)),
+            None,
+        );
+        assert_eq!(
+            reasoning_effort(&model("claude-opus-5"), ThinkingConfig::Off),
+            None,
+        );
+    }
+
+    #[test]
+    fn unpaired_tool_calls_and_results_are_dropped() {
+        let messages = vec![
+            Message::user("run it".into()),
+            Message {
+                role: Role::Assistant,
+                content: vec![
+                    ContentBlock::Text {
+                        text: "sure".into(),
+                    },
+                    ContentBlock::ToolUse {
+                        id: "a".into(),
+                        name: "bash".into(),
+                        input: json!({"cmd": "ls"}),
+                        thought_signature: None,
+                    },
+                    // Never answered: must not reach the wire.
+                    ContentBlock::ToolUse {
+                        id: "b".into(),
+                        name: "bash".into(),
+                        input: json!({}),
+                        thought_signature: None,
+                    },
+                ],
+                ..Default::default()
+            },
+            Message {
+                role: Role::User,
+                content: vec![
+                    ContentBlock::ToolResult {
+                        tool_use_id: "a".into(),
+                        content: "ok".into(),
+                        is_error: false,
+                    },
+                    // Answers a call that was never made.
+                    ContentBlock::ToolResult {
+                        tool_use_id: "zzz".into(),
+                        content: "stale".into(),
+                        is_error: false,
+                    },
+                ],
+                ..Default::default()
+            },
+        ];
+
+        let wire = convert_messages(&messages);
+        let assistant = &wire[1];
+        assert_eq!(assistant["content"].as_array().unwrap().len(), 2);
+        assert_eq!(assistant["content"][1]["toolCallId"], "a");
+
+        let tool = &wire[2];
+        assert_eq!(tool["role"], "tool");
+        let results = tool["content"].as_array().unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["toolCallId"], "a");
+        assert_eq!(results[0]["toolName"], "bash");
+        assert_eq!(results[0]["output"]["type"], "text");
+    }
+
+    #[test]
+    fn thinking_is_not_replayed() {
+        let messages = vec![Message {
+            role: Role::Assistant,
+            content: vec![
+                ContentBlock::Thinking {
+                    thinking: "hmm".into(),
+                    signature: None,
+                },
+                ContentBlock::Text {
+                    text: "answer".into(),
+                },
+            ],
+            ..Default::default()
+        }];
+        let wire = convert_messages(&messages);
+        let parts = wire[0]["content"].as_array().unwrap();
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0]["type"], "text");
+    }
+
+    #[test]
+    fn error_results_use_error_text_output() {
+        let messages = vec![
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::ToolUse {
+                    id: "a".into(),
+                    name: "bash".into(),
+                    input: json!({}),
+                    thought_signature: None,
+                }],
+                ..Default::default()
+            },
+            Message {
+                role: Role::User,
+                content: vec![ContentBlock::ToolResult {
+                    tool_use_id: "a".into(),
+                    content: "boom".into(),
+                    is_error: true,
+                }],
+                ..Default::default()
+            },
+        ];
+        let wire = convert_messages(&messages);
+        assert_eq!(wire[1]["content"][0]["output"]["type"], "error-text");
+    }
+
+    #[test]
+    fn tools_gain_the_function_discriminator() {
+        let tools = json!([{
+            "name": "bash",
+            "description": "run",
+            "input_schema": {"type": "object", "properties": {}},
+        }]);
+        let converted = convert_tools(&tools);
+        assert_eq!(converted.len(), 1);
+        assert_eq!(converted[0]["type"], "function");
+        assert_eq!(converted[0]["name"], "bash");
+        assert!(converted[0]["input_schema"]["properties"].is_object());
+    }
+
+    #[test]
+    fn project_slug_matches_the_reference_derivation() {
+        assert_eq!(
+            project_slug("/Users/karl/Projects/maki"),
+            "users-karl-projects-maki"
+        );
+        assert_eq!(project_slug("C:\\code\\My App"), "code-my-app");
+        assert_eq!(project_slug("/"), "project");
+        // Only a real drive letter is stripped; a colon deeper in a segment
+        // must not eat the segment before it.
+        assert_eq!(project_slug("/srv/mydir:file"), "srv-mydir-file");
+    }
+
+    #[test]
+    fn thread_id_is_a_hyphenated_uuid() {
+        let id = thread_id();
+        assert_eq!(id.len(), 36);
+        assert_eq!(
+            id.match_indices('-').map(|(i, _)| i).collect::<Vec<_>>(),
+            vec![8, 13, 18, 23]
+        );
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit() || c == '-'));
+        assert_ne!(thread_id(), thread_id());
+    }
+
+    #[test]
+    fn truncated_stream_is_an_error_not_a_finished_turn() {
+        let sse = "data: {\"type\":\"text-delta\",\"text\":\"half an ans\"}\n";
+        let response = isahc::Response::builder()
+            .status(200)
+            .body(isahc::AsyncBody::from(sse))
+            .unwrap();
+        let (tx, _rx) = flume::unbounded();
+        let err = smol::block_on(parse_sse(response, &tx, Duration::from_secs(5))).unwrap_err();
+        assert!(err.is_retryable());
+        assert!(err.to_string().contains("without a finish event"));
+    }
+
+    #[test]
+    fn tool_call_without_an_id_is_skipped() {
+        let sse = concat!(
+            "data: {\"type\":\"tool-call\",\"toolName\":\"bash\",\"input\":{}}\n",
+            "data: {\"type\":\"finish\",\"finishReason\":\"stop\"}\n",
+        );
+        let response = isahc::Response::builder()
+            .status(200)
+            .body(isahc::AsyncBody::from(sse))
+            .unwrap();
+        let (tx, rx) = flume::unbounded();
+        let result = smol::block_on(parse_sse(response, &tx, Duration::from_secs(5))).unwrap();
+        drop(tx);
+        assert!(result.message.content.is_empty());
+        assert_eq!(rx.len(), 0);
+    }
+
+    #[test]
+    fn catalog_capabilities_apply_before_discovery_warms() {
+        let cc = provider();
+        let mut vision_model = model("claude-opus-5");
+        cc.adjust_model(&mut vision_model);
+        assert!(vision_model.supports_vision());
+        assert!(vision_model.supports_thinking());
+
+        let mut plain = model("moonshotai/Kimi-K3");
+        cc.adjust_model(&mut plain);
+        assert!(plain.supports_vision());
+        assert!(!plain.supports_thinking());
+
+        // Unknown ids stay untouched so discovery can still fill them in.
+        let mut unknown = model("brand/new-model");
+        cc.adjust_model(&mut unknown);
+        assert!(unknown.supports_vision_override.is_none());
+        assert!(unknown.thinking_override.is_none());
+    }
+
+    #[test]
+    fn parses_event_lines_with_and_without_sse_prefix() {
+        assert_eq!(
+            parse_event_line(r#"data: {"type":"text-delta","text":"hi"}"#)
+                .unwrap()
+                .text
+                .unwrap(),
+            "hi"
+        );
+        assert_eq!(
+            parse_event_line(r#"{"type":"text-delta","text":"hi"}"#)
+                .unwrap()
+                .r#type,
+            "text-delta"
+        );
+        assert!(parse_event_line("data: [DONE]").is_none());
+        assert!(parse_event_line(": keepalive").is_none());
+        assert!(parse_event_line("").is_none());
+    }
+
+    #[test]
+    fn usage_falls_back_to_subtracting_cache_from_the_total() {
+        let reported: CcUsage = serde_json::from_str(
+            r#"{"inputTokens":1000,"outputTokens":50,
+                "inputTokenDetails":{"cacheReadTokens":600,"cacheWriteTokens":100}}"#,
+        )
+        .unwrap();
+        let mut usage = TokenUsage::default();
+        apply_usage(&mut usage, &reported);
+        assert_eq!(usage.input, 300);
+        assert_eq!(usage.output, 50);
+        assert_eq!(usage.cache_read, 600);
+        assert_eq!(usage.cache_creation, 100);
+
+        // An explicit uncached count wins over the subtraction.
+        let reported: CcUsage = serde_json::from_str(
+            r#"{"inputTokens":1000,"outputTokens":1,
+                "inputTokenDetails":{"noCacheTokens":250,"cacheReadTokens":600}}"#,
+        )
+        .unwrap();
+        let mut usage = TokenUsage::default();
+        apply_usage(&mut usage, &reported);
+        assert_eq!(usage.input, 250);
+    }
+
+    #[test]
+    fn stream_parses_text_tool_call_and_usage() {
+        let sse = concat!(
+            "data: {\"type\":\"text-delta\",\"text\":\"he\"}\n",
+            "data: {\"type\":\"text-delta\",\"text\":\"llo\"}\n",
+            "data: {\"type\":\"reasoning-delta\",\"text\":\"think\"}\n",
+            "data: {\"type\":\"tool-call\",\"toolCallId\":\"c1\",\"toolName\":\"bash\",",
+            "\"input\":{\"cmd\":\"ls\"}}\n",
+            "data: {\"type\":\"finish\",\"finishReason\":\"tool-calls\",",
+            "\"totalUsage\":{\"inputTokens\":10,\"outputTokens\":3}}\n",
+        );
+        let response = isahc::Response::builder()
+            .status(200)
+            .body(isahc::AsyncBody::from(sse))
+            .unwrap();
+        let (tx, rx) = flume::unbounded();
+        let result = smol::block_on(parse_sse(response, &tx, Duration::from_secs(5))).unwrap();
+        drop(tx);
+
+        assert_eq!(result.stop_reason, Some(StopReason::ToolUse));
+        assert_eq!(result.usage.input, 10);
+        assert_eq!(result.usage.output, 3);
+        assert!(matches!(
+            &result.message.content[0],
+            ContentBlock::Text { text } if text == "hello"
+        ));
+        assert!(matches!(
+            &result.message.content[1],
+            ContentBlock::Thinking { thinking, .. } if thinking == "think"
+        ));
+        assert!(matches!(
+            &result.message.content[2],
+            ContentBlock::ToolUse { id, name, .. } if id == "c1" && name == "bash"
+        ));
+        assert_eq!(rx.len(), 4);
+    }
+
+    #[test]
+    fn mid_stream_error_event_becomes_a_retryable_api_error() {
+        let sse = "data: {\"type\":\"error\",\"error\":{\"message\":\"upstream exploded\"}}\n";
+        let response = isahc::Response::builder()
+            .status(200)
+            .body(isahc::AsyncBody::from(sse))
+            .unwrap();
+        let (tx, _rx) = flume::unbounded();
+        let err = smol::block_on(parse_sse(response, &tx, Duration::from_secs(5))).unwrap_err();
+        assert!(err.is_retryable());
+        assert!(err.to_string().contains("upstream exploded"));
+    }
+}

--- a/maki-providers/src/providers/commandcode/auth.rs
+++ b/maki-providers/src/providers/commandcode/auth.rs
@@ -11,14 +11,9 @@
 //! `{apiKey, state, …}` back. A browser that cannot reach loopback (the studio
 //! then offers "copy your API key" instead) falls through to a paste prompt.
 
-use std::io::{self, Write};
-use std::net::TcpListener;
-use std::sync::mpsc;
-use std::thread;
-use std::time::{Duration, Instant};
+use std::io;
+use std::time::Duration;
 
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use maki_storage::StateDir;
 use maki_storage::auth::{ProviderCredentials, save_provider_credentials};
 use serde::Deserialize;
@@ -26,23 +21,29 @@ use tracing::warn;
 
 use crate::AgentError;
 
+use super::super::{CallbackRequest, LoopbackCallback, Reply, random_token, urlenc};
 use super::PLAN_SLUG;
 
 const STUDIO_BASE_URL: &str = "https://commandcode.ai";
-const CALLBACK_HOST: &str = "127.0.0.1";
 /// The port the studio's allow-list expects, with the same small search range
 /// the reference client uses before falling back to an ephemeral port.
 const CALLBACK_PORT: u16 = 5959;
 const CALLBACK_PORT_RANGE: u16 = 10;
 const CALLBACK_PATH: &str = "/callback";
 const CALLBACK_TIMEOUT: Duration = Duration::from_secs(180);
-const ACCEPT_POLL: Duration = Duration::from_millis(100);
-/// The studio posts a handful of short fields; anything larger is not ours.
-const MAX_BODY: usize = 10_000;
+/// The studio's keys are long opaque tokens; nothing near this short is one.
+const MIN_API_KEY_LEN: usize = 32;
+
+const OK: &str = r#"{"success":true}"#;
+const NOT_OK: &str = r#"{"success":false}"#;
+const JSON: &str = "application/json";
 
 pub fn login(dir: &StateDir) -> Result<(), AgentError> {
-    let key = match bind_callback() {
-        Ok(listener) => browser_login(listener)?,
+    let ports = (0..CALLBACK_PORT_RANGE).map(|offset| CALLBACK_PORT + offset);
+    // The studio is an HTTPS page posting to this loopback server with `fetch`,
+    // so the CORS and Private Network Access headers are not optional here.
+    let key = match LoopbackCallback::bind("Command Code", ports, Some(STUDIO_BASE_URL)) {
+        Ok(callback) => browser_login(&callback)?,
         Err(e) => {
             warn!(error = %e, "could not start the Command Code callback server");
             prompt_api_key("Could not start browser auth. Paste your Command Code API key:")?
@@ -65,14 +66,13 @@ pub fn login(dir: &StateDir) -> Result<(), AgentError> {
     Ok(())
 }
 
-fn browser_login(listener: TcpListener) -> Result<String, AgentError> {
+fn browser_login(callback: &LoopbackCallback) -> Result<String, AgentError> {
     let state = random_token()?;
-    let port = listener.local_addr()?.port();
-    let callback_url = format!("http://localhost:{port}{CALLBACK_PATH}");
+    let callback_url = format!("http://localhost:{}{CALLBACK_PATH}", callback.port()?);
     let auth_url = format!(
         "{STUDIO_BASE_URL}/studio/auth/cli?callback={}&state={}",
-        super::super::urlenc(&callback_url),
-        super::super::urlenc(&state),
+        urlenc(&callback_url),
+        urlenc(&state),
     );
 
     println!("Open this URL in your browser:\n\n  {auth_url}\n");
@@ -82,25 +82,22 @@ fn browser_login(listener: TcpListener) -> Result<String, AgentError> {
     println!("Waiting for Command Code to send the key back to {callback_url}...");
     println!("If it cannot reach this process, paste your API key below instead.");
 
-    wait_for_callback(listener, &state)
-}
-
-fn bind_callback() -> Result<TcpListener, AgentError> {
-    (0..CALLBACK_PORT_RANGE)
-        .map(|offset| CALLBACK_PORT + offset)
-        .chain(std::iter::once(0))
-        .find_map(|port| TcpListener::bind((CALLBACK_HOST, port)).ok())
-        .ok_or_else(|| AgentError::Config {
-            message: "could not bind a loopback port for the Command Code callback".into(),
-        })
-        .and_then(|listener| {
-            listener
-                .set_nonblocking(true)
-                .map_err(|e| AgentError::Config {
-                    message: format!("Command Code callback server: {e}"),
-                })?;
-            Ok(listener)
-        })
+    callback.wait(
+        CALLBACK_TIMEOUT,
+        "Command Code browser login timed out",
+        |request, reply| handle_request(request, reply, &state),
+        |pasted| {
+            // Anything typed at this prompt that is not key-shaped is a stray
+            // keypress, not a paste: saving it would report success and only
+            // fail on the next request.
+            let key = sanitize_api_key(pasted);
+            if looks_like_api_key(&key) {
+                return Ok(Some(key));
+            }
+            println!("That does not look like a Command Code API key, still waiting...");
+            Ok(None)
+        },
+    )
 }
 
 /// The studio mixes casings on the wire — `apiKey` but `error_description` —
@@ -123,78 +120,35 @@ impl Callback {
     }
 }
 
-fn wait_for_callback(listener: TcpListener, expected_state: &str) -> Result<String, AgentError> {
-    let deadline = Instant::now() + CALLBACK_TIMEOUT;
-    let paste_rx = spawn_paste_reader();
-    loop {
-        if Instant::now() >= deadline {
-            return Err(AgentError::Config {
-                message: "Command Code browser login timed out".into(),
-            });
-        }
-        if let Ok(pasted) = paste_rx.try_recv() {
-            let key = sanitize_api_key(&pasted);
-            if !key.is_empty() {
-                return Ok(key);
-            }
-        }
-
-        match listener.accept() {
-            Ok((mut stream, _)) => {
-                stream.set_nonblocking(false).ok();
-                stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
-                match handle_request(&mut stream, expected_state) {
-                    Ok(Some(key)) => return Ok(key),
-                    Ok(None) => continue,
-                    Err(e) => return Err(e),
-                }
-            }
-            Err(e) if e.kind() == io::ErrorKind::WouldBlock => thread::sleep(ACCEPT_POLL),
-            Err(e) => {
-                return Err(AgentError::Config {
-                    message: format!("Command Code callback server: {e}"),
-                });
-            }
-        }
-    }
-}
-
 /// `Ok(None)` means the exchange is not finished: a preflight, a stray probe,
 /// or a body that did not carry a usable key.
 fn handle_request(
-    stream: &mut std::net::TcpStream,
+    request: &CallbackRequest,
+    reply: &mut Reply,
     expected_state: &str,
 ) -> Result<Option<String>, AgentError> {
-    let Some((head, body)) = read_request(stream) else {
-        return Ok(None);
-    };
-    let mut parts = head.split_whitespace();
-    let (Some(method), Some(target)) = (parts.next(), parts.next()) else {
-        return Ok(None);
-    };
-
     // The studio is an HTTPS page posting to a loopback HTTP server, so Chrome
     // sends a Private Network Access preflight that has to be answered.
-    if method == "OPTIONS" {
-        let _ = write_http(stream, 204, "", "");
+    if request.method == "OPTIONS" {
+        reply.send(204, "", "");
         return Ok(None);
     }
-    if !target.starts_with(CALLBACK_PATH) {
-        let _ = write_http(stream, 404, "application/json", r#"{"success":false}"#);
+    if !request.target.starts_with(CALLBACK_PATH) {
+        reply.send(404, JSON, NOT_OK);
         return Ok(None);
     }
-    if method != "POST" {
-        let _ = write_http(stream, 405, "application/json", r#"{"success":false}"#);
+    if request.method != "POST" {
+        reply.send(405, JSON, NOT_OK);
         return Ok(None);
     }
 
-    let Some(callback) = Callback::parse(&body) else {
-        let _ = write_http(stream, 400, "application/json", r#"{"success":false}"#);
+    let Some(callback) = Callback::parse(&request.body) else {
+        reply.send(400, JSON, NOT_OK);
         return Ok(None);
     };
 
     if let Some(error) = callback.error {
-        let _ = write_http(stream, 200, "application/json", r#"{"success":true}"#);
+        reply.send(200, JSON, OK);
         let detail = callback.error_description.unwrap_or(error);
         return Err(AgentError::Config {
             message: format!("Command Code authorization failed: {detail}"),
@@ -204,7 +158,7 @@ fn handle_request(
     // Reject a key that arrives without the state we minted: a page we did not
     // open must not be able to plant a credential on this machine.
     if callback.state.as_deref() != Some(expected_state) {
-        let _ = write_http(stream, 400, "application/json", r#"{"success":false}"#);
+        reply.send(400, JSON, NOT_OK);
         return Err(AgentError::Config {
             message: "Command Code state token mismatch, the login was not the one maki started"
                 .into(),
@@ -216,109 +170,11 @@ fn handle_request(
         .map(|k| sanitize_api_key(&k))
         .unwrap_or_default();
     if key.is_empty() {
-        let _ = write_http(stream, 400, "application/json", r#"{"success":false}"#);
+        reply.send(400, JSON, NOT_OK);
         return Ok(None);
     }
-    let _ = write_http(stream, 200, "application/json", r#"{"success":true}"#);
+    reply.send(200, JSON, OK);
     Ok(Some(key))
-}
-
-/// Returns the request line and the body, reading exactly the advertised
-/// `content-length` so a POST is not truncated by a short first read.
-fn read_request(stream: &mut std::net::TcpStream) -> Option<(String, String)> {
-    use std::io::Read;
-    let mut buf = Vec::new();
-    let mut chunk = [0u8; 2048];
-    let header_end = loop {
-        if let Some(at) = find_header_end(&buf) {
-            break at;
-        }
-        if buf.len() > MAX_BODY {
-            return None;
-        }
-        match stream.read(&mut chunk) {
-            Ok(0) | Err(_) => return None,
-            Ok(n) => buf.extend_from_slice(&chunk[..n]),
-        }
-    };
-
-    let head = String::from_utf8_lossy(&buf[..header_end]).to_string();
-    let want = content_length(&head).unwrap_or(0).min(MAX_BODY);
-    let body_start = header_end + 4;
-    while buf.len() < body_start + want {
-        match stream.read(&mut chunk) {
-            Ok(0) | Err(_) => break,
-            Ok(n) => buf.extend_from_slice(&chunk[..n]),
-        }
-    }
-    let body = String::from_utf8_lossy(&buf[body_start..]).to_string();
-    let request_line = head.lines().next().unwrap_or("").to_string();
-    Some((request_line, body))
-}
-
-fn find_header_end(buf: &[u8]) -> Option<usize> {
-    buf.windows(4).position(|w| w == b"\r\n\r\n")
-}
-
-fn content_length(head: &str) -> Option<usize> {
-    head.lines()
-        .find_map(|line| {
-            line.split_once(':')
-                .filter(|(k, _)| k.eq_ignore_ascii_case("content-length"))
-        })
-        .and_then(|(_, v)| v.trim().parse().ok())
-}
-
-fn write_http(
-    stream: &mut impl Write,
-    status: u16,
-    content_type: &str,
-    body: &str,
-) -> io::Result<()> {
-    let reason = match status {
-        200 => "OK",
-        204 => "No Content",
-        404 => "Not Found",
-        405 => "Method Not Allowed",
-        _ => "Bad Request",
-    };
-    write!(stream, "HTTP/1.1 {status} {reason}\r\n")?;
-    // The studio page is a different origin than the loopback callback, and
-    // Chrome additionally gates HTTPS-to-loopback behind Private Network Access.
-    write!(
-        stream,
-        "access-control-allow-origin: {STUDIO_BASE_URL}\r\n\
-         access-control-allow-methods: POST, OPTIONS\r\n\
-         access-control-allow-headers: content-type\r\n\
-         access-control-allow-private-network: true\r\n"
-    )?;
-    if !content_type.is_empty() {
-        write!(stream, "content-type: {content_type}\r\n")?;
-    }
-    write!(
-        stream,
-        "content-length: {}\r\nconnection: close\r\n\r\n{body}",
-        body.len()
-    )
-}
-
-fn spawn_paste_reader() -> mpsc::Receiver<String> {
-    let (tx, rx) = mpsc::channel();
-    thread::spawn(move || {
-        loop {
-            let mut line = String::new();
-            match io::stdin().read_line(&mut line) {
-                Ok(0) | Err(_) => return,
-                Ok(_) => {
-                    let pasted = line.trim().to_string();
-                    if !pasted.is_empty() && tx.send(pasted).is_err() {
-                        return;
-                    }
-                }
-            }
-        }
-    });
-    rx
 }
 
 fn prompt_api_key(message: &str) -> Result<String, AgentError> {
@@ -330,7 +186,7 @@ fn prompt_api_key(message: &str) -> Result<String, AgentError> {
             message: format!("read API key: {e}"),
         })?;
     let key = sanitize_api_key(&line);
-    if key.is_empty() {
+    if !looks_like_api_key(&key) {
         return Err(AgentError::Config {
             message: "no Command Code API key provided".into(),
         });
@@ -353,12 +209,14 @@ fn sanitize_api_key(input: &str) -> String {
         .to_string()
 }
 
-fn random_token() -> Result<String, AgentError> {
-    let mut buf = [0u8; 32];
-    getrandom::fill(&mut buf).map_err(|e| AgentError::Config {
-        message: format!("CSPRNG unavailable: {e}"),
-    })?;
-    Ok(URL_SAFE_NO_PAD.encode(buf))
+/// Shape only, and deliberately loose: this rejects a typo, not a forgery. The
+/// key that arrives over the state-checked callback is not put through it, so
+/// a change to the studio's key format cannot break the browser flow.
+fn looks_like_api_key(key: &str) -> bool {
+    key.len() >= MIN_API_KEY_LEN
+        && key
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
 }
 
 #[cfg(test)]
@@ -377,16 +235,20 @@ mod tests {
     }
 
     #[test]
-    fn content_length_is_case_insensitive() {
-        assert_eq!(
-            content_length("POST /callback HTTP/1.1\r\nContent-Length: 42"),
-            Some(42)
-        );
-        assert_eq!(
-            content_length("POST /callback HTTP/1.1\r\ncontent-length:  7 "),
-            Some(7)
-        );
-        assert_eq!(content_length("POST /callback HTTP/1.1"), None);
+    fn only_key_shaped_input_is_accepted_from_a_paste() {
+        // A real studio key: long, opaque, url-safe.
+        assert!(looks_like_api_key(
+            "user_2abcDEF456ghiJKL789mnoPQR012stuVWX345yz"
+        ));
+        // A stray keypress or a fat-fingered line, which is what the waiting
+        // prompt actually collects when the browser flow is still running.
+        assert!(!looks_like_api_key(""));
+        assert!(!looks_like_api_key("y"));
+        assert!(!looks_like_api_key("yes please"));
+        // Long enough, but a URL is not a key.
+        assert!(!looks_like_api_key(
+            "https://commandcode.ai/studio/keys/mine"
+        ));
     }
 
     #[test]
@@ -406,16 +268,5 @@ mod tests {
         assert_eq!(denied.error_description.as_deref(), Some("user said no"));
 
         assert!(Callback::parse("not json").is_none());
-    }
-
-    #[test]
-    fn random_tokens_differ_and_are_url_safe() {
-        let a = random_token().unwrap();
-        let b = random_token().unwrap();
-        assert_ne!(a, b);
-        assert!(
-            a.chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-        );
     }
 }

--- a/maki-providers/src/providers/commandcode/auth.rs
+++ b/maki-providers/src/providers/commandcode/auth.rs
@@ -1,0 +1,421 @@
+//! Browser login for Command Code.
+//!
+//! Despite being presented as OAuth by the Command Code CLI, this is not a
+//! token exchange: the studio mints a long-lived API key and hands it back, so
+//! there is no authorization code, no refresh, and nothing to expire. maki
+//! therefore stores the result as an ordinary provider credential rather than
+//! wrapping it in an OAuth envelope with a fabricated expiry.
+//!
+//! The handshake: bind a one-shot loopback server, open
+//! `/studio/auth/cli?callback=…&state=…`, and wait for the studio to POST
+//! `{apiKey, state, …}` back. A browser that cannot reach loopback (the studio
+//! then offers "copy your API key" instead) falls through to a paste prompt.
+
+use std::io::{self, Write};
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use maki_storage::StateDir;
+use maki_storage::auth::{ProviderCredentials, save_provider_credentials};
+use serde::Deserialize;
+use tracing::warn;
+
+use crate::AgentError;
+
+use super::PLAN_SLUG;
+
+const STUDIO_BASE_URL: &str = "https://commandcode.ai";
+const CALLBACK_HOST: &str = "127.0.0.1";
+/// The port the studio's allow-list expects, with the same small search range
+/// the reference client uses before falling back to an ephemeral port.
+const CALLBACK_PORT: u16 = 5959;
+const CALLBACK_PORT_RANGE: u16 = 10;
+const CALLBACK_PATH: &str = "/callback";
+const CALLBACK_TIMEOUT: Duration = Duration::from_secs(180);
+const ACCEPT_POLL: Duration = Duration::from_millis(100);
+/// The studio posts a handful of short fields; anything larger is not ours.
+const MAX_BODY: usize = 10_000;
+
+pub fn login(dir: &StateDir) -> Result<(), AgentError> {
+    let key = match bind_callback() {
+        Ok(listener) => browser_login(listener)?,
+        Err(e) => {
+            warn!(error = %e, "could not start the Command Code callback server");
+            prompt_api_key("Could not start browser auth. Paste your Command Code API key:")?
+        }
+    };
+
+    save_provider_credentials(
+        dir,
+        PLAN_SLUG,
+        &ProviderCredentials {
+            api_key: key,
+            host: None,
+        },
+    )
+    .map_err(|e| AgentError::Config {
+        message: format!("save Command Code credentials: {e}"),
+    })?;
+
+    println!("\n  \x1b[32m✓\x1b[0m Command Code authenticated");
+    Ok(())
+}
+
+fn browser_login(listener: TcpListener) -> Result<String, AgentError> {
+    let state = random_token()?;
+    let port = listener.local_addr()?.port();
+    let callback_url = format!("http://localhost:{port}{CALLBACK_PATH}");
+    let auth_url = format!(
+        "{STUDIO_BASE_URL}/studio/auth/cli?callback={}&state={}",
+        super::super::urlenc(&callback_url),
+        super::super::urlenc(&state),
+    );
+
+    println!("Open this URL in your browser:\n\n  {auth_url}\n");
+    if let Err(e) = open::that(&auth_url) {
+        warn!(error = %e, "failed to open browser");
+    }
+    println!("Waiting for Command Code to send the key back to {callback_url}...");
+    println!("If it cannot reach this process, paste your API key below instead.");
+
+    wait_for_callback(listener, &state)
+}
+
+fn bind_callback() -> Result<TcpListener, AgentError> {
+    (0..CALLBACK_PORT_RANGE)
+        .map(|offset| CALLBACK_PORT + offset)
+        .chain(std::iter::once(0))
+        .find_map(|port| TcpListener::bind((CALLBACK_HOST, port)).ok())
+        .ok_or_else(|| AgentError::Config {
+            message: "could not bind a loopback port for the Command Code callback".into(),
+        })
+        .and_then(|listener| {
+            listener
+                .set_nonblocking(true)
+                .map_err(|e| AgentError::Config {
+                    message: format!("Command Code callback server: {e}"),
+                })?;
+            Ok(listener)
+        })
+}
+
+/// The studio mixes casings on the wire — `apiKey` but `error_description` —
+/// so each field is renamed explicitly rather than with a blanket rule.
+#[derive(Deserialize)]
+struct Callback {
+    #[serde(default, rename = "apiKey")]
+    api_key: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    error_description: Option<String>,
+}
+
+impl Callback {
+    fn parse(body: &str) -> Option<Self> {
+        serde_json::from_str(body).ok()
+    }
+}
+
+fn wait_for_callback(listener: TcpListener, expected_state: &str) -> Result<String, AgentError> {
+    let deadline = Instant::now() + CALLBACK_TIMEOUT;
+    let paste_rx = spawn_paste_reader();
+    loop {
+        if Instant::now() >= deadline {
+            return Err(AgentError::Config {
+                message: "Command Code browser login timed out".into(),
+            });
+        }
+        if let Ok(pasted) = paste_rx.try_recv() {
+            let key = sanitize_api_key(&pasted);
+            if !key.is_empty() {
+                return Ok(key);
+            }
+        }
+
+        match listener.accept() {
+            Ok((mut stream, _)) => {
+                stream.set_nonblocking(false).ok();
+                stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+                match handle_request(&mut stream, expected_state) {
+                    Ok(Some(key)) => return Ok(key),
+                    Ok(None) => continue,
+                    Err(e) => return Err(e),
+                }
+            }
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => thread::sleep(ACCEPT_POLL),
+            Err(e) => {
+                return Err(AgentError::Config {
+                    message: format!("Command Code callback server: {e}"),
+                });
+            }
+        }
+    }
+}
+
+/// `Ok(None)` means the exchange is not finished: a preflight, a stray probe,
+/// or a body that did not carry a usable key.
+fn handle_request(
+    stream: &mut std::net::TcpStream,
+    expected_state: &str,
+) -> Result<Option<String>, AgentError> {
+    let Some((head, body)) = read_request(stream) else {
+        return Ok(None);
+    };
+    let mut parts = head.split_whitespace();
+    let (Some(method), Some(target)) = (parts.next(), parts.next()) else {
+        return Ok(None);
+    };
+
+    // The studio is an HTTPS page posting to a loopback HTTP server, so Chrome
+    // sends a Private Network Access preflight that has to be answered.
+    if method == "OPTIONS" {
+        let _ = write_http(stream, 204, "", "");
+        return Ok(None);
+    }
+    if !target.starts_with(CALLBACK_PATH) {
+        let _ = write_http(stream, 404, "application/json", r#"{"success":false}"#);
+        return Ok(None);
+    }
+    if method != "POST" {
+        let _ = write_http(stream, 405, "application/json", r#"{"success":false}"#);
+        return Ok(None);
+    }
+
+    let Some(callback) = Callback::parse(&body) else {
+        let _ = write_http(stream, 400, "application/json", r#"{"success":false}"#);
+        return Ok(None);
+    };
+
+    if let Some(error) = callback.error {
+        let _ = write_http(stream, 200, "application/json", r#"{"success":true}"#);
+        let detail = callback.error_description.unwrap_or(error);
+        return Err(AgentError::Config {
+            message: format!("Command Code authorization failed: {detail}"),
+        });
+    }
+
+    // Reject a key that arrives without the state we minted: a page we did not
+    // open must not be able to plant a credential on this machine.
+    if callback.state.as_deref() != Some(expected_state) {
+        let _ = write_http(stream, 400, "application/json", r#"{"success":false}"#);
+        return Err(AgentError::Config {
+            message: "Command Code state token mismatch, the login was not the one maki started"
+                .into(),
+        });
+    }
+
+    let key = callback
+        .api_key
+        .map(|k| sanitize_api_key(&k))
+        .unwrap_or_default();
+    if key.is_empty() {
+        let _ = write_http(stream, 400, "application/json", r#"{"success":false}"#);
+        return Ok(None);
+    }
+    let _ = write_http(stream, 200, "application/json", r#"{"success":true}"#);
+    Ok(Some(key))
+}
+
+/// Returns the request line and the body, reading exactly the advertised
+/// `content-length` so a POST is not truncated by a short first read.
+fn read_request(stream: &mut std::net::TcpStream) -> Option<(String, String)> {
+    use std::io::Read;
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 2048];
+    let header_end = loop {
+        if let Some(at) = find_header_end(&buf) {
+            break at;
+        }
+        if buf.len() > MAX_BODY {
+            return None;
+        }
+        match stream.read(&mut chunk) {
+            Ok(0) | Err(_) => return None,
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+        }
+    };
+
+    let head = String::from_utf8_lossy(&buf[..header_end]).to_string();
+    let want = content_length(&head).unwrap_or(0).min(MAX_BODY);
+    let body_start = header_end + 4;
+    while buf.len() < body_start + want {
+        match stream.read(&mut chunk) {
+            Ok(0) | Err(_) => break,
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+        }
+    }
+    let body = String::from_utf8_lossy(&buf[body_start..]).to_string();
+    let request_line = head.lines().next().unwrap_or("").to_string();
+    Some((request_line, body))
+}
+
+fn find_header_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+fn content_length(head: &str) -> Option<usize> {
+    head.lines()
+        .find_map(|line| {
+            line.split_once(':')
+                .filter(|(k, _)| k.eq_ignore_ascii_case("content-length"))
+        })
+        .and_then(|(_, v)| v.trim().parse().ok())
+}
+
+fn write_http(
+    stream: &mut impl Write,
+    status: u16,
+    content_type: &str,
+    body: &str,
+) -> io::Result<()> {
+    let reason = match status {
+        200 => "OK",
+        204 => "No Content",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        _ => "Bad Request",
+    };
+    write!(stream, "HTTP/1.1 {status} {reason}\r\n")?;
+    // The studio page is a different origin than the loopback callback, and
+    // Chrome additionally gates HTTPS-to-loopback behind Private Network Access.
+    write!(
+        stream,
+        "access-control-allow-origin: {STUDIO_BASE_URL}\r\n\
+         access-control-allow-methods: POST, OPTIONS\r\n\
+         access-control-allow-headers: content-type\r\n\
+         access-control-allow-private-network: true\r\n"
+    )?;
+    if !content_type.is_empty() {
+        write!(stream, "content-type: {content_type}\r\n")?;
+    }
+    write!(
+        stream,
+        "content-length: {}\r\nconnection: close\r\n\r\n{body}",
+        body.len()
+    )
+}
+
+fn spawn_paste_reader() -> mpsc::Receiver<String> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        loop {
+            let mut line = String::new();
+            match io::stdin().read_line(&mut line) {
+                Ok(0) | Err(_) => return,
+                Ok(_) => {
+                    let pasted = line.trim().to_string();
+                    if !pasted.is_empty() && tx.send(pasted).is_err() {
+                        return;
+                    }
+                }
+            }
+        }
+    });
+    rx
+}
+
+fn prompt_api_key(message: &str) -> Result<String, AgentError> {
+    println!("{message}");
+    let mut line = String::new();
+    io::stdin()
+        .read_line(&mut line)
+        .map_err(|e| AgentError::Config {
+            message: format!("read API key: {e}"),
+        })?;
+    let key = sanitize_api_key(&line);
+    if key.is_empty() {
+        return Err(AgentError::Config {
+            message: "no Command Code API key provided".into(),
+        });
+    }
+    Ok(key)
+}
+
+/// Terminals wrap a paste in bracketed-paste markers and users bring along
+/// stray control characters; a key that carries either fails auth confusingly.
+fn sanitize_api_key(input: &str) -> String {
+    input
+        .replace("\u{1b}[200~", "")
+        .replace("\u{1b}[201~", "")
+        .replace("[200~", "")
+        .replace("[201~", "")
+        .chars()
+        .filter(|c| !c.is_control() && *c != '\u{7f}')
+        .collect::<String>()
+        .trim()
+        .to_string()
+}
+
+fn random_token() -> Result<String, AgentError> {
+    let mut buf = [0u8; 32];
+    getrandom::fill(&mut buf).map_err(|e| AgentError::Config {
+        message: format!("CSPRNG unavailable: {e}"),
+    })?;
+    Ok(URL_SAFE_NO_PAD.encode(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_strips_bracketed_paste_and_control_bytes() {
+        assert_eq!(
+            sanitize_api_key("\u{1b}[200~cc-abc123\u{1b}[201~\n"),
+            "cc-abc123"
+        );
+        assert_eq!(sanitize_api_key("[200~cc-abc123[201~"), "cc-abc123");
+        assert_eq!(sanitize_api_key("  cc-key  "), "cc-key");
+        assert_eq!(sanitize_api_key("\n\t "), "");
+    }
+
+    #[test]
+    fn content_length_is_case_insensitive() {
+        assert_eq!(
+            content_length("POST /callback HTTP/1.1\r\nContent-Length: 42"),
+            Some(42)
+        );
+        assert_eq!(
+            content_length("POST /callback HTTP/1.1\r\ncontent-length:  7 "),
+            Some(7)
+        );
+        assert_eq!(content_length("POST /callback HTTP/1.1"), None);
+    }
+
+    #[test]
+    fn callback_parses_the_studio_camel_case_payload() {
+        let c = Callback::parse(
+            r#"{"apiKey":"cc-1","state":"s1","userId":"u","userName":"n","keyName":"k"}"#,
+        )
+        .unwrap();
+        assert_eq!(c.api_key.as_deref(), Some("cc-1"));
+        assert_eq!(c.state.as_deref(), Some("s1"));
+        assert!(c.error.is_none());
+
+        let denied =
+            Callback::parse(r#"{"error":"access_denied","error_description":"user said no"}"#)
+                .unwrap();
+        assert_eq!(denied.error.as_deref(), Some("access_denied"));
+        assert_eq!(denied.error_description.as_deref(), Some("user said no"));
+
+        assert!(Callback::parse("not json").is_none());
+    }
+
+    #[test]
+    fn random_tokens_differ_and_are_url_safe() {
+        let a = random_token().unwrap();
+        let b = random_token().unwrap();
+        assert_ne!(a, b);
+        assert!(
+            a.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        );
+    }
+}

--- a/maki-providers/src/providers/commandcode/credits.rs
+++ b/maki-providers/src/providers/commandcode/credits.rs
@@ -94,10 +94,11 @@ impl Provider for CommandCodeCredits {
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<ModelInfo>, AgentError>> {
         Box::pin(async move {
             let auth = self.auth.lock().unwrap().clone();
-            let base = auth.base_url.as_deref().unwrap_or(CREDITS_BASE_URL);
-            let url = format!("{}/models", base.trim_end_matches('/'));
-            let body = self.compat.get_text(&auth, &url).await?;
-            super::parse_models(&body)
+            // Through the compat layer so a `providers.toml` base URL resolves
+            // the same way it does for streaming.
+            self.compat
+                .fetch_and_parse_models(&auth, super::parse_model)
+                .await
         })
     }
 

--- a/maki-providers/src/providers/commandcode/credits.rs
+++ b/maki-providers/src/providers/commandcode/credits.rs
@@ -1,0 +1,125 @@
+//! Command Code metered credits, the pay-as-you-go Provider plan.
+//!
+//! Unlike the token plans in [`super::plan`], this is an ordinary
+//! OpenAI-compatible endpoint, so the shared compat layer does the work and
+//! this file only supplies the account's key, the per-model reasoning dialect
+//! and the catalog that `/provider/v1/models` cannot fully describe.
+
+use std::sync::{Arc, Mutex};
+
+use flume::Sender;
+use maki_storage::id::SessionRef;
+use serde_json::Value;
+
+use crate::model::{Model, ModelInfo};
+use crate::provider::{BoxFuture, Provider};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse};
+
+use super::super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+use super::super::{KeyPool, ResolvedAuth, Timeouts};
+use super::{CREDITS_BASE_URL, CREDITS_SLUG, ENV_VAR, resolve_auth_from_key, resolve_key_pool};
+
+static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
+    slug: CREDITS_SLUG,
+    api_key_env: ENV_VAR,
+    base_url: CREDITS_BASE_URL,
+    max_tokens_field: "max_tokens",
+    include_stream_usage: true,
+    provider_name: "Command Code Credits",
+};
+
+inventory::submit!(maki_config::providers::BuiltInProvider {
+    slug: CREDITS_SLUG,
+    display_name: "Command Code Credits",
+    protocol: maki_config::providers::Protocol::Openai,
+    default_base_url: CREDITS_BASE_URL,
+    default_api_key_env: ENV_VAR,
+    default_model: "command-code-credits/claude-opus-5",
+    plans: None,
+    login_url: Some("https://commandcode.ai/studio/keys"),
+    needs_url: false,
+});
+
+pub struct CommandCodeCredits {
+    compat: OpenAiCompatProvider,
+    auth: Arc<Mutex<ResolvedAuth>>,
+    key_pool: Option<KeyPool>,
+}
+
+impl CommandCodeCredits {
+    pub fn new(timeouts: Timeouts) -> Result<Self, AgentError> {
+        let pool = resolve_key_pool(CREDITS_SLUG)?;
+        Ok(Self {
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(pool.current()))),
+            key_pool: Some(pool),
+        })
+    }
+
+    pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: Timeouts) -> Self {
+        Self {
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
+            auth,
+            key_pool: None,
+        }
+    }
+}
+
+impl Provider for CommandCodeCredits {
+    fn stream_message<'a>(
+        &'a self,
+        model: &'a Model,
+        messages: &'a [Message],
+        system: &'a str,
+        tools: &'a Value,
+        event_tx: &'a Sender<ProviderEvent>,
+        opts: RequestOptions,
+        _session_id: Option<&'a SessionRef>,
+    ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            let mut body = self.compat.build_body(model, messages, system, tools);
+            // Only models the catalog snapshot knows accept an effort, and each
+            // accepts its own subset; everything else lets the endpoint choose.
+            if let Some(dialect) = super::effort_dialect(&model.id) {
+                opts.thinking
+                    .apply_reasoning_effort(&mut body, &dialect, model);
+            }
+            self.compat
+                .do_stream(model, &[], &body, event_tx, &auth)
+                .await
+        })
+    }
+
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<ModelInfo>, AgentError>> {
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            let base = auth.base_url.as_deref().unwrap_or(CREDITS_BASE_URL);
+            let url = format!("{}/models", base.trim_end_matches('/'));
+            let body = self.compat.get_text(&auth, &url).await?;
+            super::parse_models(&body)
+        })
+    }
+
+    fn adjust_model(&self, model: &mut Model) {
+        super::adjust_model(model);
+    }
+
+    fn reload_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
+        Box::pin(async {
+            let pool = resolve_key_pool(CREDITS_SLUG)?;
+            let base_url = self.auth.lock().unwrap().base_url.clone();
+            *self.auth.lock().unwrap() = resolve_auth_from_key(pool.current(), base_url);
+            Ok(())
+        })
+    }
+
+    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
+        Box::pin(async {
+            Ok(self
+                .key_pool
+                .as_ref()
+                .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
+        })
+    }
+}

--- a/maki-providers/src/providers/commandcode/mod.rs
+++ b/maki-providers/src/providers/commandcode/mod.rs
@@ -1,0 +1,367 @@
+//! Command Code, as two providers over one account.
+//!
+//! [`credits`] is the metered pay-as-you-go Provider plan: an ordinary
+//! OpenAI-compatible endpoint under `/provider/v1`, authenticated with a
+//! pasted API key, so the shared compat layer does all the work.
+//!
+//! [`plan`] is the token plans (GOAT / Pro / Max / Team). Those do not speak
+//! chat-completions at all: they use a custom SSE protocol at
+//! `POST /alpha/generate` and are authenticated through the browser handshake
+//! in [`auth`], since a plan key is minted in the studio rather than pasted.
+//!
+//! Both bill the same account and accept the same key, and both read their
+//! per-model reasoning and vision support from [`CATALOG`], because the shared
+//! `/provider/v1/models` catalog exposes neither.
+
+use maki_storage::sessions::Effort;
+use maki_storage::sessions::Effort::{High, Low, Max, Medium, XHigh};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::model::{Model, ModelEntry, ModelInfo, ThinkingSupport};
+use crate::types::EffortDialect;
+use crate::{AgentError, ThinkingConfig};
+
+use super::{KeyPool, ResolvedAuth};
+
+pub mod auth;
+mod credits;
+mod plan;
+
+pub(crate) use credits::CommandCodeCredits;
+pub(crate) use plan::CommandCode;
+
+pub(crate) const PLAN_SLUG: &str = "command-code";
+pub(crate) const CREDITS_SLUG: &str = "command-code-credits";
+pub(crate) const BASE_URL: &str = "https://api.commandcode.ai";
+/// The metered endpoint is the OpenAI-compatible surface under the same host.
+pub(crate) const CREDITS_BASE_URL: &str = "https://api.commandcode.ai/provider/v1";
+pub(crate) const ENV_VAR: &str = "COMMAND_CODE_API_KEY";
+/// The generate endpoint's own ceiling, independent of the model window.
+pub(crate) const MAX_GENERATE_TOKENS: u32 = 64_000;
+
+/// Empty on purpose for both slugs: the catalog is fetched from
+/// `/provider/v1/models`, and a token plan bills against the subscription, so
+/// a static per-token table here would only be a second source of truth.
+pub(crate) const fn models() -> &'static [ModelEntry] {
+    &[]
+}
+
+const FULL: &[Effort] = &[Low, Medium, High, XHigh, Max];
+const TO_XHIGH: &[Effort] = &[Low, Medium, High, XHigh];
+const TO_HIGH: &[Effort] = &[Low, Medium, High];
+const HIGH_MAX: &[Effort] = &[High, Max];
+const HIGH_XHIGH: &[Effort] = &[High, XHigh];
+const NONE: &[Effort] = &[];
+
+/// `(model id, accepted reasoning efforts, accepts image input)`.
+///
+/// `/provider/v1/models` returns only id/name/context_length, so reasoning and
+/// vision have to come from somewhere: this is a snapshot of the
+/// command-code@1.15.1 bundled catalog. An id missing here is treated as
+/// text-only with provider-chosen reasoning depth, which is what the CLI does
+/// too, so a newly released model degrades instead of erroring.
+///
+/// ponytail: hand-maintained snapshot. Refresh from
+/// <https://commandcode.ai/docs/resources/pricing-limits> when models land; if
+/// the catalog endpoint ever exposes these fields, delete the table.
+const CATALOG: &[(&str, &[Effort], bool)] = &[
+    ("MiniMaxAI/MiniMax-M3", NONE, true),
+    ("Qwen/Qwen3.6-Plus", NONE, true),
+    ("Qwen/Qwen3.7-Flash", NONE, true),
+    ("Qwen/Qwen3.7-Plus", NONE, true),
+    ("Qwen/Qwen3.8-Max", &[Low, Medium, XHigh], true),
+    ("claude-fable-5", FULL, true),
+    ("claude-haiku-4-5-20251001", NONE, true),
+    ("claude-opus-4-7", FULL, true),
+    ("claude-opus-4-8", FULL, true),
+    ("claude-opus-5", FULL, true),
+    ("claude-sonnet-4-6", FULL, true),
+    ("claude-sonnet-5", FULL, true),
+    ("deepseek/deepseek-v4-flash", HIGH_MAX, false),
+    ("deepseek/deepseek-v4-pro", HIGH_MAX, false),
+    ("google/gemini-3.1-flash-lite", TO_HIGH, true),
+    ("google/gemini-3.5-flash", TO_HIGH, true),
+    ("google/gemini-3.5-flash-lite", TO_HIGH, true),
+    ("google/gemini-3.6-flash", TO_HIGH, true),
+    ("gpt-5.3-codex", TO_XHIGH, true),
+    ("gpt-5.4", TO_XHIGH, true),
+    ("gpt-5.4-mini", TO_HIGH, true),
+    ("gpt-5.5", TO_XHIGH, true),
+    ("gpt-5.6-luna", FULL, true),
+    ("gpt-5.6-sol", FULL, true),
+    ("gpt-5.6-terra", FULL, true),
+    ("meta/muse-spark-1.1", NONE, true),
+    ("meta/muse-spark-1.2", NONE, true),
+    ("meta/muse-spark-1.2-contributor", NONE, true),
+    ("moonshotai/Kimi-K2.5", NONE, true),
+    ("moonshotai/Kimi-K2.6", NONE, true),
+    ("moonshotai/Kimi-K2.7-Code", NONE, true),
+    ("moonshotai/Kimi-K2.7-Code-Highspeed", NONE, true),
+    ("moonshotai/Kimi-K3", NONE, true),
+    ("sakana/fugu-ultra", HIGH_XHIGH, true),
+    ("stepfun/Step-3.7-Flash", NONE, true),
+    ("thinkingmachines/inkling", NONE, true),
+    ("thinkingmachines/inkling-small", NONE, true),
+    ("xai/grok-4.5", TO_HIGH, true),
+    ("xiaomi/mimo-v2.5", NONE, true),
+    ("zai-org/GLM-5.2", HIGH_MAX, false),
+];
+
+pub(super) fn catalog_entry(
+    model_id: &str,
+) -> Option<&'static (&'static str, &'static [Effort], bool)> {
+    CATALOG.iter().find(|(id, _, _)| *id == model_id)
+}
+
+/// `None` means send no `reasoning_effort` and let Command Code pick, which is
+/// also what an unknown model gets.
+pub(super) fn reasoning_effort(model: &Model, thinking: ThinkingConfig) -> Option<&'static str> {
+    let (_, efforts, _) = catalog_entry(&model.id)?;
+    if efforts.is_empty() {
+        return None;
+    }
+    thinking.effort_str(
+        &EffortDialect {
+            supported: efforts,
+            // Command Code has no adaptive level and no explicit opt-out
+            // string: both mean "omit the field".
+            adaptive: None,
+            off: None,
+        },
+        model,
+    )
+}
+
+/// Seeds the capabilities discovery has not fetched yet. Until it runs, the
+/// Generic manifest answers "no vision, thinking on everything", which
+/// silently strips images from the first turn on a vision model. Unknown ids
+/// fall through untouched so discovery can still fill them in.
+pub(super) fn adjust_model(model: &mut Model) {
+    let Some((_, efforts, vision)) = catalog_entry(&model.id) else {
+        return;
+    };
+    model.supports_vision_override = Some(*vision);
+    model.thinking_override = Some(if efforts.is_empty() {
+        ThinkingSupport::No
+    } else {
+        ThinkingSupport::Yes
+    });
+}
+
+/// The reasoning efforts the endpoint accepts for this model, as a dialect the
+/// shared effort plumbing can snap against. `None` means send nothing and let
+/// Command Code choose, which is also what an unknown model gets.
+pub(super) fn effort_dialect(model_id: &str) -> Option<EffortDialect<'static>> {
+    let (_, efforts, _) = catalog_entry(model_id)?;
+    if efforts.is_empty() {
+        return None;
+    }
+    Some(EffortDialect {
+        supported: efforts,
+        // Command Code has no adaptive level and no explicit opt-out string:
+        // both mean "omit the field".
+        adaptive: None,
+        off: None,
+    })
+}
+
+/// Credential files written by the Command Code CLI and by pi/omp hosts. maki's
+/// own `KeyPool` (env, `maki auth login`, providers.toml) is tried first; this
+/// is the fallback that makes an existing CLI login just work.
+fn key_from_cli_files() -> Option<String> {
+    let home = std::env::var_os("HOME").map(std::path::PathBuf::from)?;
+    let paths = [
+        home.join(".commandcode/auth.json"),
+        home.join(".omp/agent/auth.json"),
+        home.join(".pi/agent/auth.json"),
+    ];
+    for path in paths {
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(root) = serde_json::from_str::<Value>(&text) else {
+            continue;
+        };
+        let direct = ["apiKey", "commandcode"]
+            .iter()
+            .find_map(|k| root.get(*k)?.as_str());
+        if let Some(key) = direct {
+            return Some(key.to_string());
+        }
+        // `{"command-code": {"type":"api","key":"..."}}` from the CLI, or the
+        // same shape with `type: "oauth"` and an `access` token.
+        let nested = ["commandcode", "command-code"].iter().find_map(|k| {
+            let record = root.get(*k)?;
+            record.get("key").or_else(|| record.get("access"))?.as_str()
+        });
+        if let Some(key) = nested {
+            return Some(key.to_string());
+        }
+    }
+    None
+}
+
+/// One Command Code account issues one API key, and both endpoints accept it,
+/// so a login under either slug authenticates the other. Without this a plan
+/// subscriber who also wants metered credits would log in twice for one key.
+fn sibling_key(slug: &str) -> Option<String> {
+    let sibling = if slug == PLAN_SLUG {
+        CREDITS_SLUG
+    } else {
+        PLAN_SLUG
+    };
+    let dir = maki_storage::StateDir::resolve().ok()?;
+    maki_storage::auth::load_provider_credentials(&dir, sibling).map(|c| c.api_key)
+}
+
+pub(super) fn resolve_key_pool(slug: &str) -> Result<KeyPool, AgentError> {
+    match KeyPool::resolve(slug, ENV_VAR) {
+        Ok(pool) => Ok(pool),
+        Err(e) => sibling_key(slug)
+            .or_else(key_from_cli_files)
+            .map_or(Err(e), |key| Ok(KeyPool::from_keys(vec![key]))),
+    }
+}
+
+pub(super) fn resolve_auth_from_key(key: &str, base_url: Option<String>) -> ResolvedAuth {
+    let mut auth = ResolvedAuth::bearer(key);
+    auth.base_url = base_url;
+    auth
+}
+
+#[derive(Deserialize)]
+struct CatalogModel {
+    id: String,
+    context_length: Option<u32>,
+}
+
+#[derive(Deserialize)]
+struct CatalogResponse {
+    data: Vec<CatalogModel>,
+}
+
+/// Parses `GET /provider/v1/models`, shared because both providers read the
+/// same catalog and both need the [`CATALOG`] capabilities folded in.
+pub(super) fn parse_models(body: &str) -> Result<Vec<ModelInfo>, AgentError> {
+    let catalog: CatalogResponse = serde_json::from_str(body)?;
+    let mut infos: Vec<ModelInfo> = catalog
+        .data
+        .into_iter()
+        .map(|m| {
+            let entry = catalog_entry(&m.id);
+            ModelInfo {
+                context_window: m.context_length,
+                // The catalog exposes no output ceiling, so the context window
+                // stands in for it, as the reference client does. A model whose
+                // real cap is under 64k would be asked for more than it allows.
+                max_output_tokens: Some(
+                    m.context_length
+                        .unwrap_or(MAX_GENERATE_TOKENS)
+                        .min(MAX_GENERATE_TOKENS),
+                ),
+                supports_thinking: entry.map(|(_, efforts, _)| !efforts.is_empty()),
+                supports_vision: entry.map(|(_, _, vision)| *vision),
+                ..ModelInfo::id_only(m.id)
+            }
+        })
+        .collect();
+    infos.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(infos)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ModelFamily, ModelPricing, ModelTier};
+    use maki_storage::sessions::Effort::{High, Low, XHigh};
+    use std::sync::Arc;
+
+    pub(super) fn model(id: &str) -> Model {
+        Model {
+            id: id.into(),
+            provider: Arc::from(PLAN_SLUG),
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            supports_tool_examples_override: None,
+            thinking_override: None,
+            supports_vision_override: None,
+            pricing: ModelPricing::default(),
+            max_output_tokens: Some(200_000),
+            context_window: 400_000,
+            discovered_free: false,
+            thinking_fields: None,
+        }
+    }
+
+    #[test]
+    fn effort_snaps_to_what_the_model_accepts() {
+        // deepseek accepts only high/max, so Low must not go out as "low".
+        assert_eq!(
+            reasoning_effort(
+                &model("deepseek/deepseek-v4-pro"),
+                ThinkingConfig::Effort(Low)
+            ),
+            Some("high"),
+        );
+        assert_eq!(
+            reasoning_effort(&model("claude-opus-5"), ThinkingConfig::Effort(XHigh)),
+            Some("xhigh"),
+        );
+        // Non-reasoning and unknown models send nothing at all.
+        assert_eq!(
+            reasoning_effort(&model("moonshotai/Kimi-K3"), ThinkingConfig::Effort(High)),
+            None,
+        );
+        assert_eq!(
+            reasoning_effort(&model("brand/new-model"), ThinkingConfig::Effort(High)),
+            None,
+        );
+        assert_eq!(
+            reasoning_effort(&model("claude-opus-5"), ThinkingConfig::Off),
+            None,
+        );
+    }
+
+    #[test]
+    fn catalog_capabilities_apply_before_discovery_warms() {
+        let mut vision_model = model("claude-opus-5");
+        adjust_model(&mut vision_model);
+        assert!(vision_model.supports_vision());
+        assert!(vision_model.supports_thinking());
+
+        let mut plain = model("moonshotai/Kimi-K3");
+        adjust_model(&mut plain);
+        assert!(plain.supports_vision());
+        assert!(!plain.supports_thinking());
+
+        // Unknown ids stay untouched so discovery can still fill them in.
+        let mut unknown = model("brand/new-model");
+        adjust_model(&mut unknown);
+        assert!(unknown.supports_vision_override.is_none());
+        assert!(unknown.thinking_override.is_none());
+    }
+
+    #[test]
+    fn parse_models_folds_in_catalog_capabilities() {
+        let body = r#"{"data":[
+            {"id":"claude-opus-5","name":"Opus","context_length":400000},
+            {"id":"moonshotai/Kimi-K3","name":"K3","context_length":200000},
+            {"id":"brand/new-model","name":"New","context_length":8000}
+        ]}"#;
+        let models = parse_models(body).unwrap();
+        assert_eq!(models.len(), 3);
+        // Sorted by id, and the output ceiling never exceeds the endpoint cap.
+        assert_eq!(models[0].id, "brand/new-model");
+        assert_eq!(models[0].max_output_tokens, Some(8_000));
+        assert_eq!(models[0].supports_vision, None);
+
+        let opus = models.iter().find(|m| m.id == "claude-opus-5").unwrap();
+        assert_eq!(opus.max_output_tokens, Some(MAX_GENERATE_TOKENS));
+        assert_eq!(opus.supports_vision, Some(true));
+        assert_eq!(opus.supports_thinking, Some(true));
+
+        let kimi = models.iter().find(|m| m.id.contains("Kimi")).unwrap();
+        assert_eq!(kimi.supports_thinking, Some(false));
+    }
+}

--- a/maki-providers/src/providers/commandcode/mod.rs
+++ b/maki-providers/src/providers/commandcode/mod.rs
@@ -15,7 +15,6 @@
 
 use maki_storage::sessions::Effort;
 use maki_storage::sessions::Effort::{High, Low, Max, Medium, XHigh};
-use serde::Deserialize;
 use serde_json::Value;
 
 use crate::model::{Model, ModelEntry, ModelInfo, ThinkingSupport};
@@ -230,42 +229,33 @@ pub(super) fn resolve_auth_from_key(key: &str, base_url: Option<String>) -> Reso
     auth
 }
 
-#[derive(Deserialize)]
-struct CatalogModel {
-    id: String,
-    context_length: Option<u32>,
+/// One row of `GET /provider/v1/models`, shared because both providers read
+/// the same catalog and both need the [`CATALOG`] capabilities folded in.
+pub(super) fn parse_model(m: &Value) -> Option<ModelInfo> {
+    let id = m["id"].as_str()?;
+    let entry = catalog_entry(id);
+    Some(ModelInfo {
+        context_window: m["context_length"]
+            .as_u64()
+            .and_then(|v| u32::try_from(v).ok()),
+        // The catalog exposes no output ceiling, and the context window is not
+        // one: an 8k model would end up spending its whole window on output.
+        // Left unset so `ProviderManifest::fallback_max_output` decides.
+        max_output_tokens: None,
+        supports_thinking: entry.map(|(_, efforts, _)| !efforts.is_empty()),
+        supports_vision: entry.map(|(_, _, vision)| *vision),
+        ..ModelInfo::id_only(id.to_string())
+    })
 }
 
-#[derive(Deserialize)]
-struct CatalogResponse {
-    data: Vec<CatalogModel>,
-}
-
-/// Parses `GET /provider/v1/models`, shared because both providers read the
-/// same catalog and both need the [`CATALOG`] capabilities folded in.
+/// The whole catalog response, for [`plan`], which does not go through the
+/// compat layer's `fetch_and_parse_models`.
 pub(super) fn parse_models(body: &str) -> Result<Vec<ModelInfo>, AgentError> {
-    let catalog: CatalogResponse = serde_json::from_str(body)?;
-    let mut infos: Vec<ModelInfo> = catalog
-        .data
-        .into_iter()
-        .map(|m| {
-            let entry = catalog_entry(&m.id);
-            ModelInfo {
-                context_window: m.context_length,
-                // The catalog exposes no output ceiling, so the context window
-                // stands in for it, as the reference client does. A model whose
-                // real cap is under 64k would be asked for more than it allows.
-                max_output_tokens: Some(
-                    m.context_length
-                        .unwrap_or(MAX_GENERATE_TOKENS)
-                        .min(MAX_GENERATE_TOKENS),
-                ),
-                supports_thinking: entry.map(|(_, efforts, _)| !efforts.is_empty()),
-                supports_vision: entry.map(|(_, _, vision)| *vision),
-                ..ModelInfo::id_only(m.id)
-            }
-        })
-        .collect();
+    let body: Value = serde_json::from_str(body)?;
+    let mut infos: Vec<ModelInfo> = body["data"]
+        .as_array()
+        .map(|arr| arr.iter().filter_map(parse_model).collect())
+        .unwrap_or_default();
     infos.sort_by(|a, b| a.id.cmp(&b.id));
     Ok(infos)
 }
@@ -351,13 +341,14 @@ mod tests {
         ]}"#;
         let models = parse_models(body).unwrap();
         assert_eq!(models.len(), 3);
-        // Sorted by id, and the output ceiling never exceeds the endpoint cap.
+        // Sorted by id, and the context window never leaks into the output cap.
         assert_eq!(models[0].id, "brand/new-model");
-        assert_eq!(models[0].max_output_tokens, Some(8_000));
+        assert_eq!(models[0].context_window, Some(8_000));
+        assert_eq!(models[0].max_output_tokens, None);
         assert_eq!(models[0].supports_vision, None);
 
         let opus = models.iter().find(|m| m.id == "claude-opus-5").unwrap();
-        assert_eq!(opus.max_output_tokens, Some(MAX_GENERATE_TOKENS));
+        assert_eq!(opus.max_output_tokens, None);
         assert_eq!(opus.supports_vision, Some(true));
         assert_eq!(opus.supports_thinking, Some(true));
 

--- a/maki-providers/src/providers/commandcode/plan.rs
+++ b/maki-providers/src/providers/commandcode/plan.rs
@@ -106,6 +106,9 @@ impl CommandCode {
         )
     }
 
+    // Mirrors the trait's request shape; splitting it would only move the
+    // same arguments one call deeper.
+    #[allow(clippy::too_many_arguments)]
     fn build_body(
         &self,
         model: &Model,
@@ -114,6 +117,7 @@ impl CommandCode {
         tools: &Value,
         opts: RequestOptions,
         working_dir: &str,
+        session_id: Option<&SessionRef>,
     ) -> Value {
         let mut params = json!({
             "model": model.id,
@@ -151,10 +155,11 @@ impl CommandCode {
             "taste": Value::Null,
             "skills": Value::Null,
             "params": params,
-            "threadId": thread_id(),
+            "threadId": thread_id(session_id),
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn do_stream(
         &self,
         model: &Model,
@@ -163,6 +168,7 @@ impl CommandCode {
         tools: &Value,
         event_tx: &Sender<ProviderEvent>,
         opts: RequestOptions,
+        session_id: Option<&SessionRef>,
     ) -> Result<StreamResponse, AgentError> {
         // One getcwd per request: the envelope and the project-slug header
         // must agree, and they cannot if each reads the cwd separately.
@@ -176,6 +182,7 @@ impl CommandCode {
             tools,
             opts,
             &working_dir,
+            session_id,
         ))?;
         let url = format!("{}/alpha/generate", self.base());
         let request = self
@@ -232,13 +239,13 @@ fn project_slug(path: &str) -> String {
     }
 }
 
-/// A fresh RFC 4122 string per request, matching the reference client. The
-/// endpoint treats it as an opaque conversation key.
+/// The conversation key the endpoint caches against, so it has to be stable
+/// across a session's turns: usage comes back with `cacheReadTokens`, and a
+/// fresh id every request would make each turn look like a new thread.
 ///
-/// ponytail: per-request id means no server-side thread reuse. Thread it from
-/// `SessionRef` if Command Code turns out to cache across a thread.
-fn thread_id() -> String {
-    MakiId::generate().hyphenated()
+/// Only a provider call outside any session falls back to a fresh id.
+fn thread_id(session_id: Option<&SessionRef>) -> String {
+    session_id.map_or_else(|| MakiId::generate().hyphenated(), |s| s.id().hyphenated())
 }
 
 /// maki hands tools over in the Anthropic shape, which is what the endpoint
@@ -598,9 +605,9 @@ impl Provider for CommandCode {
         tools: &'a Value,
         event_tx: &'a Sender<ProviderEvent>,
         opts: RequestOptions,
-        _session_id: Option<&'a SessionRef>,
+        session_id: Option<&'a SessionRef>,
     ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
-        Box::pin(self.do_stream(model, messages, system, tools, event_tx, opts))
+        Box::pin(self.do_stream(model, messages, system, tools, event_tx, opts, session_id))
     }
 
     fn list_models(&self) -> BoxFuture<'_, Result<Vec<ModelInfo>, AgentError>> {
@@ -664,6 +671,7 @@ mod tests {
             &json!([]),
             RequestOptions::default(),
             "/tmp/proj",
+            None,
         );
         assert_eq!(body["params"]["max_tokens"], MAX_GENERATE_TOKENS);
         assert_eq!(body["params"]["system"], "sys");
@@ -806,15 +814,20 @@ mod tests {
     }
 
     #[test]
-    fn thread_id_is_a_hyphenated_uuid() {
-        let id = thread_id();
+    fn thread_id_follows_the_session_so_the_endpoint_can_cache() {
+        let session = SessionRef::from_id(MakiId::generate());
+        assert_eq!(thread_id(Some(&session)), thread_id(Some(&session)));
+        assert_eq!(thread_id(Some(&session)), session.id().hyphenated());
+
+        // No session: a fresh hyphenated uuid, still what the endpoint wants.
+        let id = thread_id(None);
         assert_eq!(id.len(), 36);
         assert_eq!(
             id.match_indices('-').map(|(i, _)| i).collect::<Vec<_>>(),
             vec![8, 13, 18, 23]
         );
         assert!(id.chars().all(|c| c.is_ascii_hexdigit() || c == '-'));
-        assert_ne!(thread_id(), thread_id());
+        assert_ne!(thread_id(None), thread_id(None));
     }
 
     #[test]

--- a/maki-providers/src/providers/commandcode/plan.rs
+++ b/maki-providers/src/providers/commandcode/plan.rs
@@ -192,9 +192,23 @@ impl CommandCode {
         if response.status().as_u16() == 200 {
             parse_sse(response, event_tx, self.stream_timeout).await
         } else {
-            Err(AgentError::from_response(response).await)
+            Err(api_error(response).await)
         }
     }
+}
+
+/// Command Code reports HTTP failures as
+/// `{"success":false,"error":{"code","status","message"}}`. Lifting the message
+/// out keeps a plan or quota refusal readable — "MODEL_NOT_IN_PLAN: ..." rather
+/// than a wall of JSON the user has to parse by eye.
+async fn api_error(mut response: isahc::Response<isahc::AsyncBody>) -> AgentError {
+    let status = response.status().as_u16();
+    let body = response.text().await.unwrap_or_default();
+    let message = serde_json::from_str::<Value>(&body)
+        .ok()
+        .and_then(|v| Some(v.pointer("/error/message")?.as_str()?.to_string()))
+        .unwrap_or(body);
+    AgentError::Api { status, message }
 }
 
 /// Command Code groups requests server-side by project. The reference client
@@ -540,10 +554,15 @@ async fn parse_sse(
                     message,
                 });
             }
-            // reasoning-start/reasoning-end/tool-result carry no content maki
-            // needs; the block boundaries are implied by the deltas. Anything
-            // else is logged, not dropped silently: the protocol is
-            // reverse-engineered and may grow events that matter.
+            // Everything the live stream also emits, none of it load-bearing
+            // here: block boundaries are implied by the deltas, the assembled
+            // `tool-call` supersedes the `tool-input-*` fragments that precede
+            // it, and `finish-step` reports per-step usage that `finish`
+            // totals. Listing them keeps the log below meaningful — an event
+            // that reaches it is genuinely one this parser has never seen.
+            "start" | "start-step" | "finish-step" | "text-start" | "text-end"
+            | "reasoning-start" | "reasoning-end" | "tool-input-start" | "tool-input-delta"
+            | "tool-input-end" | "tool-result" | "provider-metadata" => {}
             other => debug!(event = other, "unhandled Command Code stream event"),
         }
     }
@@ -591,7 +610,7 @@ impl Provider for CommandCode {
         Box::pin(async move {
             let mut response = client.send_async(request?).await?;
             if response.status().as_u16() != 200 {
-                return Err(AgentError::from_response(response).await);
+                return Err(api_error(response).await);
             }
             super::parse_models(&response.text().await?)
         })
@@ -796,6 +815,86 @@ mod tests {
         );
         assert!(id.chars().all(|c| c.is_ascii_hexdigit() || c == '-'));
         assert_ne!(thread_id(), thread_id());
+    }
+
+    #[test]
+    fn live_event_vocabulary_is_all_accounted_for() {
+        // Every event type observed from api.commandcode.ai on text, tool-call
+        // and reasoning turns. A new one here means the protocol moved.
+        let sse = concat!(
+            "{\"type\":\"start\"}\n",
+            "{\"type\":\"start-step\",\"warnings\":[]}\n",
+            "{\"type\":\"reasoning-start\",\"id\":\"reasoning-0\"}\n",
+            "{\"type\":\"reasoning-delta\",\"id\":\"reasoning-0\",\"text\":\"hmm\"}\n",
+            "{\"type\":\"reasoning-end\",\"id\":\"reasoning-0\"}\n",
+            "{\"type\":\"text-start\",\"id\":\"txt-0\"}\n",
+            "{\"type\":\"text-delta\",\"id\":\"txt-0\",\"text\":\"OK\"}\n",
+            "{\"type\":\"text-end\",\"id\":\"txt-0\"}\n",
+            "{\"type\":\"tool-input-start\",\"id\":\"c1\",\"toolName\":\"bash\"}\n",
+            "{\"type\":\"tool-input-delta\",\"id\":\"c1\",\"delta\":\"{\\\"command\\\":\"}\n",
+            "{\"type\":\"tool-input-end\",\"id\":\"c1\"}\n",
+            "{\"type\":\"tool-call\",\"toolCallId\":\"c1\",\"toolName\":\"bash\",",
+            "\"input\":{\"command\":\"ls /tmp\"}}\n",
+            "{\"type\":\"finish-step\",\"finishReason\":\"tool-calls\"}\n",
+            "{\"type\":\"finish\",\"finishReason\":\"tool-calls\",\"totalUsage\":",
+            "{\"inputTokens\":117,\"inputTokenDetails\":{\"noCacheTokens\":117,\"cacheReadTokens\":0},",
+            "\"outputTokens\":36,\"totalTokens\":153}}\n",
+        );
+        let response = isahc::Response::builder()
+            .status(200)
+            .body(isahc::AsyncBody::from(sse))
+            .unwrap();
+        let (tx, rx) = flume::unbounded();
+        let result = smol::block_on(parse_sse(response, &tx, Duration::from_secs(5))).unwrap();
+        drop(tx);
+
+        assert_eq!(result.stop_reason, Some(StopReason::ToolUse));
+        // The streaming tool-input fragments must not become a second call.
+        assert_eq!(result.message.content.len(), 3);
+        assert!(matches!(
+            &result.message.content[0],
+            ContentBlock::Thinking { thinking, .. } if thinking == "hmm"
+        ));
+        assert!(matches!(
+            &result.message.content[1],
+            ContentBlock::Text { text } if text == "OK"
+        ));
+        assert!(matches!(
+            &result.message.content[2],
+            ContentBlock::ToolUse { id, name, input, .. }
+                if id == "c1" && name == "bash" && input["command"] == "ls /tmp"
+        ));
+        // Real payloads carry noCacheTokens, so the subtraction never runs.
+        assert_eq!(result.usage.input, 117);
+        assert_eq!(result.usage.output, 36);
+        assert_eq!(rx.len(), 3);
+    }
+
+    #[test]
+    fn http_errors_surface_the_message_not_the_envelope() {
+        // Verbatim 403 body from api.commandcode.ai for an out-of-plan model.
+        let body = r#"{"success":false,"error":{"code":"FORBIDDEN","status":403,"message":"MODEL_NOT_IN_PLAN: Gemini 3.5 Flash Lite available in Pro and above plans"}}"#;
+        let response = isahc::Response::builder()
+            .status(403)
+            .body(isahc::AsyncBody::from(body))
+            .unwrap();
+        let err = smol::block_on(api_error(response));
+        assert!(matches!(err, AgentError::Api { status: 403, .. }));
+        assert_eq!(
+            err.to_string(),
+            "API error (403): MODEL_NOT_IN_PLAN: Gemini 3.5 Flash Lite available in Pro and above plans"
+        );
+
+        // A body that is not the documented envelope still reaches the user.
+        let response = isahc::Response::builder()
+            .status(502)
+            .body(isahc::AsyncBody::from("upstream down"))
+            .unwrap();
+        assert!(
+            smol::block_on(api_error(response))
+                .to_string()
+                .contains("upstream down")
+        );
     }
 
     #[test]

--- a/maki-providers/src/providers/commandcode/plan.rs
+++ b/maki-providers/src/providers/commandcode/plan.rs
@@ -1,13 +1,12 @@
-//! Command Code token-plan provider (GOAT / Pro / Max / Team).
+//! The Command Code token plans (GOAT / Pro / Max / Team).
 //!
-//! Token plans do not speak the OpenAI-compatible `/provider/v1/chat/completions`
-//! endpoint the pay-as-you-go Provider plan uses. They speak a custom SSE
-//! protocol at `POST {base}/alpha/generate`: a request envelope of
-//! `config`/`memory`/`taste`/`skills`/`params`/`threadId`, and a Vercel-AI-SDK
-//! shaped event stream (`text-delta`, `reasoning-delta`, `tool-call`, `finish`).
-//! Wire format reverse-engineered from `pi-commandcode-provider` against
-//! command-code CLI 1.15.1; the model catalog at `/provider/v1/models` is the
-//! only OpenAI-shaped part.
+//! Plans do not speak the OpenAI-compatible `/provider/v1/chat/completions`
+//! endpoint that [`super::credits`] uses. They speak a custom SSE protocol at
+//! `POST {base}/alpha/generate`: a request envelope of
+//! `config`/`memory`/`taste`/`skills`/`params`/`threadId`, and a
+//! Vercel-AI-SDK shaped event stream (`text-delta`, `reasoning-delta`,
+//! `tool-call`, `finish`). Reverse-engineered from `pi-commandcode-provider`
+//! against command-code CLI 1.15.1, not from token-plan API docs.
 
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -16,33 +15,29 @@ use flume::Sender;
 use futures_lite::io::{AsyncBufReadExt, BufReader};
 use isahc::{AsyncReadResponseExt, HttpClient, Request};
 use maki_storage::id::{MakiId, SessionRef};
-use maki_storage::sessions::Effort;
-use maki_storage::sessions::Effort::{High, Low, Max, Medium, XHigh};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use tracing::{debug, warn};
 
-use crate::model::{Model, ModelEntry, ModelInfo, ThinkingSupport};
+use crate::model::{Model, ModelInfo};
 use crate::provider::{BoxFuture, Provider};
-use crate::types::EffortDialect;
 use crate::{
     AgentError, ContentBlock, Message, ProviderEvent, RequestOptions, Role, StopReason,
-    StreamResponse, ThinkingConfig, TokenUsage,
+    StreamResponse, TokenUsage,
 };
 
-use super::{KeyPool, ResolvedAuth, http_client, next_sse_line, user_agent};
+use super::super::{KeyPool, ResolvedAuth, Timeouts, http_client, next_sse_line, user_agent};
+use super::{
+    BASE_URL, ENV_VAR, MAX_GENERATE_TOKENS, PLAN_SLUG, reasoning_effort, resolve_auth_from_key,
+    resolve_key_pool,
+};
 
-const SLUG: &str = "command-code";
-const BASE_URL: &str = "https://api.commandcode.ai";
-const ENV_VAR: &str = "COMMAND_CODE_API_KEY";
 /// Sent as `x-command-code-version`; the endpoint gates behaviour on it.
 const CLI_VERSION: &str = "1.15.1";
-/// The generate endpoint's own ceiling, independent of the model window.
-const MAX_GENERATE_TOKENS: u32 = 64_000;
 const DEFAULT_TEMPERATURE: f64 = 0.3;
 
 inventory::submit!(maki_config::providers::BuiltInProvider {
-    slug: SLUG,
+    slug: PLAN_SLUG,
     display_name: "Command Code",
     protocol: maki_config::providers::Protocol::CommandCode,
     default_base_url: BASE_URL,
@@ -53,146 +48,6 @@ inventory::submit!(maki_config::providers::BuiltInProvider {
     needs_url: false,
 });
 
-/// Empty on purpose: the catalog is fetched from `/provider/v1/models`, and a
-/// token plan bills against the subscription, so static per-token pricing here
-/// would only be a second source of truth to keep in sync.
-pub(crate) const fn models() -> &'static [ModelEntry] {
-    &[]
-}
-
-const FULL: &[Effort] = &[Low, Medium, High, XHigh, Max];
-const TO_XHIGH: &[Effort] = &[Low, Medium, High, XHigh];
-const TO_HIGH: &[Effort] = &[Low, Medium, High];
-const HIGH_MAX: &[Effort] = &[High, Max];
-const HIGH_XHIGH: &[Effort] = &[High, XHigh];
-const NONE: &[Effort] = &[];
-
-/// `(model id, accepted reasoning efforts, accepts image input)`.
-///
-/// `/provider/v1/models` returns only id/name/context_length, so reasoning and
-/// vision have to come from somewhere: this is a snapshot of the
-/// command-code@1.15.1 bundled catalog. An id missing here is treated as
-/// text-only with provider-chosen reasoning depth, which is what the CLI does
-/// too, so a newly released model degrades instead of erroring.
-///
-/// ponytail: hand-maintained snapshot. Refresh from
-/// <https://commandcode.ai/docs/resources/pricing-limits> when models land; if
-/// the catalog endpoint ever exposes these fields, delete the table.
-const CATALOG: &[(&str, &[Effort], bool)] = &[
-    ("MiniMaxAI/MiniMax-M3", NONE, true),
-    ("Qwen/Qwen3.6-Plus", NONE, true),
-    ("Qwen/Qwen3.7-Flash", NONE, true),
-    ("Qwen/Qwen3.7-Plus", NONE, true),
-    ("Qwen/Qwen3.8-Max", &[Low, Medium, XHigh], true),
-    ("claude-fable-5", FULL, true),
-    ("claude-haiku-4-5-20251001", NONE, true),
-    ("claude-opus-4-7", FULL, true),
-    ("claude-opus-4-8", FULL, true),
-    ("claude-opus-5", FULL, true),
-    ("claude-sonnet-4-6", FULL, true),
-    ("claude-sonnet-5", FULL, true),
-    ("deepseek/deepseek-v4-flash", HIGH_MAX, false),
-    ("deepseek/deepseek-v4-pro", HIGH_MAX, false),
-    ("google/gemini-3.1-flash-lite", TO_HIGH, true),
-    ("google/gemini-3.5-flash", TO_HIGH, true),
-    ("google/gemini-3.5-flash-lite", TO_HIGH, true),
-    ("google/gemini-3.6-flash", TO_HIGH, true),
-    ("gpt-5.3-codex", TO_XHIGH, true),
-    ("gpt-5.4", TO_XHIGH, true),
-    ("gpt-5.4-mini", TO_HIGH, true),
-    ("gpt-5.5", TO_XHIGH, true),
-    ("gpt-5.6-luna", FULL, true),
-    ("gpt-5.6-sol", FULL, true),
-    ("gpt-5.6-terra", FULL, true),
-    ("meta/muse-spark-1.1", NONE, true),
-    ("meta/muse-spark-1.2", NONE, true),
-    ("meta/muse-spark-1.2-contributor", NONE, true),
-    ("moonshotai/Kimi-K2.5", NONE, true),
-    ("moonshotai/Kimi-K2.6", NONE, true),
-    ("moonshotai/Kimi-K2.7-Code", NONE, true),
-    ("moonshotai/Kimi-K2.7-Code-Highspeed", NONE, true),
-    ("moonshotai/Kimi-K3", NONE, true),
-    ("sakana/fugu-ultra", HIGH_XHIGH, true),
-    ("stepfun/Step-3.7-Flash", NONE, true),
-    ("thinkingmachines/inkling", NONE, true),
-    ("thinkingmachines/inkling-small", NONE, true),
-    ("xai/grok-4.5", TO_HIGH, true),
-    ("xiaomi/mimo-v2.5", NONE, true),
-    ("zai-org/GLM-5.2", HIGH_MAX, false),
-];
-
-fn catalog_entry(model_id: &str) -> Option<&'static (&'static str, &'static [Effort], bool)> {
-    CATALOG.iter().find(|(id, _, _)| *id == model_id)
-}
-
-/// `None` means send no `reasoning_effort` and let Command Code pick, which is
-/// also what an unknown model gets.
-fn reasoning_effort(model: &Model, thinking: ThinkingConfig) -> Option<&'static str> {
-    let (_, efforts, _) = catalog_entry(&model.id)?;
-    if efforts.is_empty() {
-        return None;
-    }
-    thinking.effort_str(
-        &EffortDialect {
-            supported: efforts,
-            // Command Code has no adaptive level and no explicit opt-out
-            // string: both mean "omit the field".
-            adaptive: None,
-            off: None,
-        },
-        model,
-    )
-}
-
-/// Credential files written by the Command Code CLI and by pi/omp hosts. maki's
-/// own `KeyPool` (env, `maki auth login`, providers.toml) is tried first; this
-/// is the fallback that makes an existing CLI login just work.
-fn key_from_cli_files() -> Option<String> {
-    let home = std::env::var_os("HOME").map(std::path::PathBuf::from)?;
-    let paths = [
-        home.join(".commandcode/auth.json"),
-        home.join(".omp/agent/auth.json"),
-        home.join(".pi/agent/auth.json"),
-    ];
-    for path in paths {
-        let Ok(text) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        let Ok(root) = serde_json::from_str::<Value>(&text) else {
-            continue;
-        };
-        let direct = ["apiKey", "commandcode"]
-            .iter()
-            .find_map(|k| root.get(*k)?.as_str());
-        if let Some(key) = direct {
-            return Some(key.to_string());
-        }
-        // `{"command-code": {"type":"api","key":"..."}}` from the CLI, or the
-        // same shape with `type: "oauth"` and an `access` token.
-        let nested = ["commandcode", "command-code"].iter().find_map(|k| {
-            let record = root.get(*k)?;
-            record.get("key").or_else(|| record.get("access"))?.as_str()
-        });
-        if let Some(key) = nested {
-            return Some(key.to_string());
-        }
-    }
-    None
-}
-
-fn resolve_key_pool() -> Result<KeyPool, AgentError> {
-    match KeyPool::resolve(SLUG, ENV_VAR) {
-        Ok(pool) => Ok(pool),
-        Err(e) => key_from_cli_files().map_or(Err(e), |key| Ok(KeyPool::from_keys(vec![key]))),
-    }
-}
-
-fn resolve_auth_from_key(key: &str, base_url: Option<String>) -> ResolvedAuth {
-    let mut auth = ResolvedAuth::bearer(key);
-    auth.base_url = base_url;
-    auth
-}
-
 pub struct CommandCode {
     client: HttpClient,
     auth: Arc<Mutex<ResolvedAuth>>,
@@ -201,10 +56,10 @@ pub struct CommandCode {
 }
 
 impl CommandCode {
-    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
-        let pool = resolve_key_pool()?;
+    pub fn new(timeouts: Timeouts) -> Result<Self, AgentError> {
+        let pool = resolve_key_pool(PLAN_SLUG)?;
         let config = maki_config::providers::ProvidersConfig::load();
-        let base_url = maki_config::providers::resolve_base_url(SLUG, config.get(SLUG));
+        let base_url = maki_config::providers::resolve_base_url(PLAN_SLUG, config.get(PLAN_SLUG));
         Ok(Self {
             client: http_client(timeouts),
             auth: Arc::new(Mutex::new(resolve_auth_from_key(pool.current(), base_url))),
@@ -213,7 +68,7 @@ impl CommandCode {
         })
     }
 
-    pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
+    pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: Timeouts) -> Self {
         Self {
             client: http_client(timeouts),
             auth,
@@ -715,19 +570,6 @@ async fn parse_sse(
     })
 }
 
-// --- model catalog ---
-
-#[derive(Deserialize)]
-struct CatalogModel {
-    id: String,
-    context_length: Option<u32>,
-}
-
-#[derive(Deserialize)]
-struct CatalogResponse {
-    data: Vec<CatalogModel>,
-}
-
 impl Provider for CommandCode {
     fn stream_message<'a>(
         &'a self,
@@ -751,55 +593,17 @@ impl Provider for CommandCode {
             if response.status().as_u16() != 200 {
                 return Err(AgentError::from_response(response).await);
             }
-            let body = response.text().await?;
-            let catalog: CatalogResponse = serde_json::from_str(&body)?;
-            let mut infos: Vec<ModelInfo> = catalog
-                .data
-                .into_iter()
-                .map(|m| {
-                    let entry = catalog_entry(&m.id);
-                    ModelInfo {
-                        context_window: m.context_length,
-                        // The catalog exposes no output ceiling, so the context
-                        // window stands in for it, as the reference client
-                        // does. A model whose real cap is under 64k would be
-                        // asked for more than it allows.
-                        max_output_tokens: Some(
-                            m.context_length
-                                .unwrap_or(MAX_GENERATE_TOKENS)
-                                .min(MAX_GENERATE_TOKENS),
-                        ),
-                        supports_thinking: entry.map(|(_, efforts, _)| !efforts.is_empty()),
-                        supports_vision: entry.map(|(_, _, vision)| *vision),
-                        ..ModelInfo::id_only(m.id)
-                    }
-                })
-                .collect();
-            infos.sort_by(|a, b| a.id.cmp(&b.id));
-            Ok(infos)
+            super::parse_models(&response.text().await?)
         })
     }
 
-    /// Discovery has not necessarily run when the first request goes out, and
-    /// until it does the Generic manifest answers "no vision, thinking on
-    /// everything" — which silently strips images from the first turn on a
-    /// vision model. Seed both from the catalog snapshot; unknown ids fall
-    /// through to discovery unchanged.
     fn adjust_model(&self, model: &mut Model) {
-        let Some((_, efforts, vision)) = catalog_entry(&model.id) else {
-            return;
-        };
-        model.supports_vision_override = Some(*vision);
-        model.thinking_override = Some(if efforts.is_empty() {
-            ThinkingSupport::No
-        } else {
-            ThinkingSupport::Yes
-        });
+        super::adjust_model(model);
     }
 
     fn reload_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
         Box::pin(async {
-            let pool = resolve_key_pool()?;
+            let pool = resolve_key_pool(PLAN_SLUG)?;
             let base_url = self.base_url();
             *self.auth.lock().unwrap() = resolve_auth_from_key(pool.current(), base_url);
             Ok(())
@@ -820,29 +624,12 @@ impl Provider for CommandCode {
 
 #[cfg(test)]
 mod tests {
+    use super::super::tests::model;
     use super::*;
-    use crate::model::{ModelFamily, ModelPricing, ModelTier};
-
-    fn model(id: &str) -> Model {
-        Model {
-            id: id.into(),
-            provider: Arc::from(SLUG),
-            tier: ModelTier::Medium,
-            family: ModelFamily::Generic,
-            supports_tool_examples_override: None,
-            thinking_override: None,
-            supports_vision_override: None,
-            pricing: ModelPricing::default(),
-            max_output_tokens: Some(200_000),
-            context_window: 400_000,
-            discovered_free: false,
-            thinking_fields: None,
-        }
-    }
 
     fn provider() -> CommandCode {
         CommandCode {
-            client: http_client(super::super::Timeouts::default()),
+            client: http_client(Timeouts::default()),
             auth: Arc::new(Mutex::new(ResolvedAuth::bearer("k"))),
             key_pool: None,
             stream_timeout: Duration::from_secs(300),
@@ -863,35 +650,6 @@ mod tests {
         assert_eq!(body["params"]["system"], "sys");
         assert_eq!(body["params"]["messages"][0]["role"], "user");
         assert_eq!(body["config"]["workingDir"], "/tmp/proj");
-    }
-
-    #[test]
-    fn effort_snaps_to_what_the_model_accepts() {
-        // deepseek accepts only high/max, so Low must not go out as "low".
-        assert_eq!(
-            reasoning_effort(
-                &model("deepseek/deepseek-v4-pro"),
-                ThinkingConfig::Effort(Low)
-            ),
-            Some("high"),
-        );
-        assert_eq!(
-            reasoning_effort(&model("claude-opus-5"), ThinkingConfig::Effort(XHigh)),
-            Some("xhigh"),
-        );
-        // Non-reasoning and unknown models send nothing at all.
-        assert_eq!(
-            reasoning_effort(&model("moonshotai/Kimi-K3"), ThinkingConfig::Effort(High)),
-            None,
-        );
-        assert_eq!(
-            reasoning_effort(&model("brand/new-model"), ThinkingConfig::Effort(High)),
-            None,
-        );
-        assert_eq!(
-            reasoning_effort(&model("claude-opus-5"), ThinkingConfig::Off),
-            None,
-        );
     }
 
     #[test]
@@ -1068,26 +826,6 @@ mod tests {
         drop(tx);
         assert!(result.message.content.is_empty());
         assert_eq!(rx.len(), 0);
-    }
-
-    #[test]
-    fn catalog_capabilities_apply_before_discovery_warms() {
-        let cc = provider();
-        let mut vision_model = model("claude-opus-5");
-        cc.adjust_model(&mut vision_model);
-        assert!(vision_model.supports_vision());
-        assert!(vision_model.supports_thinking());
-
-        let mut plain = model("moonshotai/Kimi-K3");
-        cc.adjust_model(&mut plain);
-        assert!(plain.supports_vision());
-        assert!(!plain.supports_thinking());
-
-        // Unknown ids stay untouched so discovery can still fill them in.
-        let mut unknown = model("brand/new-model");
-        cc.adjust_model(&mut unknown);
-        assert!(unknown.supports_vision_override.is_none());
-        assert!(unknown.thinking_override.is_none());
     }
 
     #[test]

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -34,6 +34,7 @@ fn protocol_kind(protocol: Protocol) -> ProviderKind {
         Protocol::Openai | Protocol::OpenaiResponses => ProviderKind::OpenAi,
         Protocol::Anthropic => ProviderKind::Anthropic,
         Protocol::Google => ProviderKind::Google,
+        Protocol::CommandCode => ProviderKind::CommandCode,
     }
 }
 

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -24,7 +24,7 @@ use crate::{AgentError, Message, ProviderEvent, ProviderUsage, RequestOptions, S
 use super::ResolvedAuth;
 use super::anthropic::Anthropic;
 use super::aperture::Aperture;
-use super::commandcode::CommandCode;
+use super::commandcode::{CommandCode, CommandCodeCredits};
 use super::copilot::Copilot;
 use super::deepseek::DeepSeek;
 use super::google::Google;
@@ -595,6 +595,9 @@ pub fn create(slug: &str, timeouts: super::Timeouts) -> Result<Box<dyn Provider>
                 .with_system_prefix(meta.system_prefix.clone()),
         ),
         ProviderKind::CommandCode => Box::new(CommandCode::with_auth(auth.clone(), timeouts)),
+        ProviderKind::CommandCodeCredits => {
+            Box::new(CommandCodeCredits::with_auth(auth.clone(), timeouts))
+        }
     };
 
     Ok(Box::new(DynamicProvider {

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -24,6 +24,7 @@ use crate::{AgentError, Message, ProviderEvent, ProviderUsage, RequestOptions, S
 use super::ResolvedAuth;
 use super::anthropic::Anthropic;
 use super::aperture::Aperture;
+use super::commandcode::CommandCode;
 use super::copilot::Copilot;
 use super::deepseek::DeepSeek;
 use super::google::Google;
@@ -593,6 +594,7 @@ pub fn create(slug: &str, timeouts: super::Timeouts) -> Result<Box<dyn Provider>
             Aperture::with_auth(auth.clone(), timeouts)
                 .with_system_prefix(meta.system_prefix.clone()),
         ),
+        ProviderKind::CommandCode => Box::new(CommandCode::with_auth(auth.clone(), timeouts)),
     };
 
     Ok(Box::new(DynamicProvider {

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -14,6 +14,7 @@ use crate::AgentError;
 pub(crate) mod anthropic;
 pub(crate) mod aperture;
 pub(crate) mod catalog;
+pub(crate) mod commandcode;
 pub(crate) mod copilot;
 pub mod custom;
 pub(crate) mod deepseek;

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -1,7 +1,12 @@
+use std::io::{self, Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, mpsc};
+use std::thread;
 use std::time::{Duration, Instant};
 
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use futures_lite::StreamExt;
 use futures_lite::io::AsyncBufRead;
 use isahc::config::Configurable;
@@ -95,6 +100,249 @@ pub(crate) fn with_prefix<'a>(
         }
         None => system,
     }
+}
+
+/// Loopback is the only address a browser callback may bind: a login
+/// credential must never be reachable off this machine.
+const CALLBACK_HOST: &str = "127.0.0.1";
+const ACCEPT_POLL: Duration = Duration::from_millis(100);
+const CALLBACK_READ_TIMEOUT: Duration = Duration::from_secs(2);
+/// A login callback carries a handful of short fields; anything larger is not
+/// ours, and reading it would only let a local process grow our memory.
+const MAX_CALLBACK_BYTES: usize = 10_000;
+
+/// A one-shot loopback HTTP server for a browser login, shared by the
+/// providers whose sign-in hands a credential back to a local port.
+///
+/// [`Self::wait`] polls for one request at a time and lets the caller decide
+/// when the exchange is done, so a provider only writes the part that is
+/// actually its own: whether the credential arrives as a POST body or as query
+/// parameters, and what makes one valid.
+///
+/// stdin is polled alongside the socket throughout, because a browser cannot
+/// always reach loopback and the user then has to paste instead.
+pub(crate) struct LoopbackCallback {
+    listener: TcpListener,
+    what: &'static str,
+    cors_origin: Option<&'static str>,
+}
+
+impl LoopbackCallback {
+    /// Binds the first free port of `ports`, then any ephemeral one. Pass the
+    /// ports an authorization server pre-registers, in preference order.
+    ///
+    /// `cors_origin` is the HTTPS page that will call back, and is only needed
+    /// when it calls with `fetch` rather than by navigating here.
+    pub(crate) fn bind(
+        what: &'static str,
+        ports: impl IntoIterator<Item = u16>,
+        cors_origin: Option<&'static str>,
+    ) -> Result<Self, AgentError> {
+        let listener = ports
+            .into_iter()
+            .chain(std::iter::once(0))
+            .find_map(|port| TcpListener::bind((CALLBACK_HOST, port)).ok())
+            .ok_or_else(|| AgentError::Config {
+                message: format!("could not bind a loopback port for the {what} callback"),
+            })?;
+        listener
+            .set_nonblocking(true)
+            .map_err(|e| AgentError::Config {
+                message: format!("{what} callback server: {e}"),
+            })?;
+        Ok(Self {
+            listener,
+            what,
+            cors_origin,
+        })
+    }
+
+    pub(crate) fn port(&self) -> Result<u16, AgentError> {
+        Ok(self.listener.local_addr()?.port())
+    }
+
+    /// Polls until `timeout`, handing every request to `on_request` and every
+    /// pasted stdin line to `on_paste`. Either returns `Ok(None)` to keep
+    /// waiting, `Ok(Some(_))` to finish, or `Err` to abort the login.
+    pub(crate) fn wait<T>(
+        &self,
+        timeout: Duration,
+        timeout_message: &str,
+        mut on_request: impl FnMut(&CallbackRequest, &mut Reply) -> Result<Option<T>, AgentError>,
+        mut on_paste: impl FnMut(&str) -> Result<Option<T>, AgentError>,
+    ) -> Result<T, AgentError> {
+        let deadline = Instant::now() + timeout;
+        let paste_rx = spawn_paste_reader();
+        loop {
+            if Instant::now() >= deadline {
+                return Err(AgentError::Config {
+                    message: timeout_message.into(),
+                });
+            }
+            if let Ok(pasted) = paste_rx.try_recv()
+                && let Some(done) = on_paste(&pasted)?
+            {
+                return Ok(done);
+            }
+
+            match self.listener.accept() {
+                Ok((mut stream, _)) => {
+                    stream.set_nonblocking(false).ok();
+                    stream.set_read_timeout(Some(CALLBACK_READ_TIMEOUT)).ok();
+                    let Some(request) = CallbackRequest::read(&mut stream) else {
+                        continue;
+                    };
+                    let mut reply = Reply {
+                        stream: &mut stream,
+                        cors_origin: self.cors_origin,
+                    };
+                    if let Some(done) = on_request(&request, &mut reply)? {
+                        return Ok(done);
+                    }
+                }
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => thread::sleep(ACCEPT_POLL),
+                Err(e) => {
+                    return Err(AgentError::Config {
+                        message: format!("{} callback server: {e}", self.what),
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// One request line and body from the callback socket.
+pub(crate) struct CallbackRequest {
+    pub(crate) method: String,
+    pub(crate) target: String,
+    pub(crate) body: String,
+}
+
+impl CallbackRequest {
+    /// Reads exactly the advertised `content-length`, so a POST body is not
+    /// truncated by a short first read. `None` for anything unparseable.
+    fn read(stream: &mut TcpStream) -> Option<Self> {
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 2048];
+        let header_end = loop {
+            if let Some(at) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break at;
+            }
+            if buf.len() > MAX_CALLBACK_BYTES {
+                return None;
+            }
+            match stream.read(&mut chunk) {
+                Ok(0) | Err(_) => return None,
+                Ok(n) => buf.extend_from_slice(&chunk[..n]),
+            }
+        };
+
+        let head = String::from_utf8_lossy(&buf[..header_end]).to_string();
+        let want = content_length(&head).unwrap_or(0).min(MAX_CALLBACK_BYTES);
+        let body_start = header_end + 4;
+        while buf.len() < body_start + want {
+            match stream.read(&mut chunk) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => buf.extend_from_slice(&chunk[..n]),
+            }
+        }
+
+        let mut parts = head.lines().next()?.split_whitespace();
+        Some(Self {
+            method: parts.next()?.to_string(),
+            target: parts.next()?.to_string(),
+            body: String::from_utf8_lossy(&buf[body_start..]).to_string(),
+        })
+    }
+
+    /// The target's query string, empty when it has none.
+    pub(crate) fn query(&self) -> &str {
+        self.target.split_once('?').map_or("", |(_, q)| q)
+    }
+}
+
+/// The response side of one callback request.
+pub(crate) struct Reply<'a> {
+    stream: &'a mut TcpStream,
+    cors_origin: Option<&'static str>,
+}
+
+impl Reply<'_> {
+    /// Best-effort: a browser that has already navigated away cannot be told
+    /// anything, and that must not fail a login whose credential did arrive.
+    pub(crate) fn send(&mut self, status: u16, content_type: &str, body: &str) {
+        let _ = self.write(status, content_type, body);
+    }
+
+    fn write(&mut self, status: u16, content_type: &str, body: &str) -> io::Result<()> {
+        let reason = match status {
+            200 => "OK",
+            204 => "No Content",
+            403 => "Forbidden",
+            404 => "Not Found",
+            405 => "Method Not Allowed",
+            _ => "Bad Request",
+        };
+        write!(self.stream, "HTTP/1.1 {status} {reason}\r\n")?;
+        if let Some(origin) = self.cors_origin {
+            // An HTTPS page calling loopback is cross-origin, and Chrome gates
+            // it behind a Private Network Access preflight on top of CORS.
+            write!(
+                self.stream,
+                "access-control-allow-origin: {origin}\r\n\
+                 access-control-allow-methods: POST, OPTIONS\r\n\
+                 access-control-allow-headers: content-type\r\n\
+                 access-control-allow-private-network: true\r\n"
+            )?;
+        }
+        if !content_type.is_empty() {
+            write!(self.stream, "content-type: {content_type}\r\n")?;
+        }
+        write!(
+            self.stream,
+            "content-length: {}\r\nconnection: close\r\n\r\n{body}",
+            body.len()
+        )
+    }
+}
+
+fn content_length(head: &str) -> Option<usize> {
+    head.lines()
+        .find_map(|line| {
+            line.split_once(':')
+                .filter(|(k, _)| k.eq_ignore_ascii_case("content-length"))
+        })
+        .and_then(|(_, v)| v.trim().parse().ok())
+}
+
+/// Reads pasted lines off stdin for as long as anyone is listening, so a
+/// browser that cannot reach loopback is not a dead end.
+fn spawn_paste_reader() -> mpsc::Receiver<String> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        loop {
+            let mut line = String::new();
+            match io::stdin().read_line(&mut line) {
+                Ok(0) | Err(_) => return,
+                Ok(_) => {
+                    let pasted = line.trim().to_string();
+                    if !pasted.is_empty() && tx.send(pasted).is_err() {
+                        return;
+                    }
+                }
+            }
+        }
+    });
+    rx
+}
+
+/// 256 CSPRNG bits, url-safe: the state and PKCE tokens a login mints.
+pub(crate) fn random_token() -> Result<String, AgentError> {
+    let mut buf = [0u8; 32];
+    getrandom::fill(&mut buf).map_err(|e| AgentError::Config {
+        message: format!("CSPRNG unavailable: {e}"),
+    })?;
+    Ok(URL_SAFE_NO_PAD.encode(buf))
 }
 
 pub(crate) fn urlenc(s: &str) -> String {
@@ -292,6 +540,115 @@ mod tests {
     #[test_case("abc", "abc"   ; "passthrough")]
     fn urlenc_encodes(input: &str, expected: &str) {
         assert_eq!(urlenc(input), expected);
+    }
+
+    #[test_case("POST /callback HTTP/1.1\r\nContent-Length: 42", Some(42) ; "capitalized")]
+    #[test_case("POST /callback HTTP/1.1\r\ncontent-length:  7 ", Some(7)  ; "lowercase_padded")]
+    #[test_case("POST /callback HTTP/1.1",                        None     ; "absent")]
+    fn content_length_is_case_insensitive(head: &str, expected: Option<usize>) {
+        assert_eq!(content_length(head), expected);
+    }
+
+    #[test]
+    fn callback_reads_a_whole_post_body_and_answers_with_cors() {
+        let callback = LoopbackCallback::bind("test", [], Some("https://example.test")).unwrap();
+        let port = callback.port().unwrap();
+
+        // A body split across writes: the reader must follow content-length
+        // rather than stopping at whatever the first read happened to return.
+        let body = r#"{"apiKey":"secret","state":"s1"}"#;
+        let sender = std::thread::spawn(move || {
+            let mut stream = TcpStream::connect((CALLBACK_HOST, port)).unwrap();
+            let (head, tail) = body.split_at(10);
+            write!(
+                stream,
+                "POST /callback?x=1 HTTP/1.1\r\ncontent-length: {}\r\n\r\n{head}",
+                body.len()
+            )
+            .unwrap();
+            stream.flush().unwrap();
+            std::thread::sleep(Duration::from_millis(50));
+            stream.write_all(tail.as_bytes()).unwrap();
+            let mut response = String::new();
+            stream.read_to_string(&mut response).unwrap();
+            response
+        });
+
+        let got = callback
+            .wait(
+                Duration::from_secs(10),
+                "timed out",
+                |request, reply| {
+                    reply.send(200, "application/json", r#"{"ok":true}"#);
+                    Ok(Some((
+                        request.method.clone(),
+                        request.target.clone(),
+                        request.query().to_string(),
+                        request.body.clone(),
+                    )))
+                },
+                |_| Ok(None),
+            )
+            .unwrap();
+
+        assert_eq!(got.0, "POST");
+        assert_eq!(got.1, "/callback?x=1");
+        assert_eq!(got.2, "x=1");
+        assert_eq!(got.3, body);
+
+        let response = sender.join().unwrap();
+        assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(response.contains("access-control-allow-origin: https://example.test\r\n"));
+        assert!(response.contains("access-control-allow-private-network: true\r\n"));
+        assert!(response.ends_with("\r\n\r\n{\"ok\":true}"));
+    }
+
+    #[test]
+    fn callback_without_a_cors_origin_sends_no_cors_headers() {
+        let callback = LoopbackCallback::bind("test", [], None).unwrap();
+        let port = callback.port().unwrap();
+
+        let sender = std::thread::spawn(move || {
+            let mut stream = TcpStream::connect((CALLBACK_HOST, port)).unwrap();
+            write!(stream, "GET /callback?code=abc HTTP/1.1\r\n\r\n").unwrap();
+            let mut response = String::new();
+            stream.read_to_string(&mut response).unwrap();
+            response
+        });
+
+        // The first request keeps waiting, so a stray probe cannot end a login.
+        let mut seen = 0;
+        let code = callback
+            .wait(
+                Duration::from_secs(10),
+                "timed out",
+                |request, reply| {
+                    seen += 1;
+                    reply.send(404, "text/plain", "no");
+                    Ok(request
+                        .query()
+                        .strip_prefix("code=")
+                        .map(std::string::ToString::to_string))
+                },
+                |_| Ok(None),
+            )
+            .unwrap();
+
+        assert_eq!(code, "abc");
+        assert_eq!(seen, 1);
+        let response = sender.join().unwrap();
+        assert!(!response.contains("access-control-allow-origin"));
+    }
+
+    #[test]
+    fn random_tokens_differ_and_are_url_safe() {
+        let a = random_token().unwrap();
+        let b = random_token().unwrap();
+        assert_ne!(a, b);
+        assert!(
+            a.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        );
     }
 
     struct NeverReader;

--- a/maki-providers/src/providers/xai/auth.rs
+++ b/maki-providers/src/providers/xai/auth.rs
@@ -1,8 +1,6 @@
 use std::io::{self, Write};
-use std::net::TcpListener;
 use std::path::PathBuf;
 use std::str;
-use std::sync::mpsc;
 use std::time::{Duration, Instant};
 use std::{env, fs, thread};
 
@@ -17,7 +15,9 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, error, warn};
 
 use crate::AgentError;
-use crate::providers::{KeyPool, ResolvedAuth, urlenc};
+use crate::providers::{
+    CallbackRequest, KeyPool, LoopbackCallback, Reply, ResolvedAuth, random_token, urlenc,
+};
 
 use super::catalog;
 
@@ -25,7 +25,6 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const TOKEN_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(30);
 const POLL_TIMEOUT: Duration = Duration::from_secs(300);
 const CALLBACK_TIMEOUT: Duration = Duration::from_secs(180);
-const ACCEPT_POLL: Duration = Duration::from_millis(100);
 const DEFAULT_EXPIRES_SECS: u64 = 3600;
 const GROK_CLI_DEFAULT_TTL_MS: u64 = 6 * 60 * 60 * 1000;
 const MS_THRESHOLD: f64 = 10_000_000_000.0;
@@ -522,9 +521,9 @@ fn browser_login() -> Result<OAuthTokens, AgentError> {
     let (verifier, challenge) = pkce_pair()?;
     let state = random_token()?;
     let nonce = random_token()?;
-    let listener = bind_callback()?;
-    let port = listener.local_addr()?.port();
-    let redirect_uri = format!("http://{REDIRECT_HOST}:{port}{REDIRECT_PATH}");
+    // No CORS: the browser navigates here, it does not `fetch` here.
+    let listener = LoopbackCallback::bind("xAI OAuth", [REDIRECT_PORT], None)?;
+    let redirect_uri = format!("http://{REDIRECT_HOST}:{}{REDIRECT_PATH}", listener.port()?);
 
     let authorize_url = format!(
         "{AUTHORIZE_URL}?response_type=code&client_id={}&redirect_uri={}&scope={}&code_challenge={}&code_challenge_method=S256&state={}&nonce={}",
@@ -543,7 +542,7 @@ fn browser_login() -> Result<OAuthTokens, AgentError> {
     println!("Waiting for xAI OAuth callback on {redirect_uri}...");
     println!("If the redirect cannot reach this process, paste the complete redirect URL below.");
 
-    let callback = wait_for_callback(listener, &state)?;
+    let callback = wait_for_callback(&listener, &state)?;
     if let Some(error) = callback.error {
         return Err(AgentError::Config {
             message: format!("xAI authorization failed: {error}"),
@@ -576,122 +575,48 @@ struct CallbackResult {
     error: Option<String>,
 }
 
-fn bind_callback() -> Result<TcpListener, AgentError> {
-    TcpListener::bind((REDIRECT_HOST, REDIRECT_PORT))
-        .or_else(|_| TcpListener::bind((REDIRECT_HOST, 0)))
-        .and_then(|listener| {
-            listener.set_nonblocking(true)?;
-            Ok(listener)
-        })
-        .map_err(|e| AgentError::Config {
-            message: format!("xAI OAuth callback server: {e}"),
-        })
-}
-
 fn wait_for_callback(
-    listener: TcpListener,
+    listener: &LoopbackCallback,
     expected_state: &str,
 ) -> Result<CallbackResult, AgentError> {
-    let deadline = Instant::now() + CALLBACK_TIMEOUT;
-    let paste_rx = spawn_paste_reader();
-    loop {
-        if Instant::now() >= deadline {
-            return Err(AgentError::Config {
-                message: CALLBACK_TIMEOUT_MSG.into(),
-            });
-        }
-        if let Ok(pasted) = paste_rx.try_recv() {
-            return parse_callback_input(&pasted, expected_state);
-        }
-
-        match listener.accept() {
-            Ok((mut stream, _)) => {
-                let mut buf = [0u8; 4096];
-                stream.set_nonblocking(false).ok();
-                stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
-                let n = std::io::Read::read(&mut stream, &mut buf).unwrap_or(0);
-                let request = String::from_utf8_lossy(&buf[..n]);
-                let Some(target) = request.split_whitespace().nth(1) else {
-                    continue;
-                };
-                if !target.starts_with(REDIRECT_PATH) {
-                    let _ = write_http(&mut stream, 404, "text/plain; charset=utf-8", "Not found");
-                    continue;
-                }
-                match parse_callback_target(target, expected_state) {
-                    Ok(result) => {
-                        let html = if result.error.is_some() {
-                            "<html><body><h1>xAI authorization failed.</h1>You can close this tab.</body></html>"
-                        } else {
-                            "<html><body><h1>xAI authorization received.</h1>You can close this tab.</body></html>"
-                        };
-                        let _ = write_http(&mut stream, 200, "text/html; charset=utf-8", html);
-                        return Ok(result);
-                    }
-                    Err(_) => {
-                        let _ = write_http(
-                            &mut stream,
-                            400,
-                            "text/html; charset=utf-8",
-                            "<html><body><h1>xAI authorization state mismatch.</h1>Please return to maki and try again.</body></html>",
-                        );
-                    }
-                }
-            }
-            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
-                thread::sleep(ACCEPT_POLL);
-            }
-            Err(e) => {
-                return Err(AgentError::Config {
-                    message: format!("xAI OAuth callback: {e}"),
-                });
-            }
-        }
-    }
-}
-
-fn spawn_paste_reader() -> mpsc::Receiver<String> {
-    let (tx, rx) = mpsc::channel();
-    thread::spawn(move || {
-        loop {
-            let mut line = String::new();
-            match io::stdin().read_line(&mut line) {
-                Ok(0) | Err(_) => return,
-                Ok(_) => {
-                    let pasted = line.trim().to_string();
-                    if !pasted.is_empty() && tx.send(pasted).is_err() {
-                        return;
-                    }
-                }
-            }
-        }
-    });
-    rx
-}
-
-fn write_http(
-    stream: &mut impl Write,
-    status: u16,
-    content_type: &str,
-    body: &str,
-) -> io::Result<()> {
-    write!(
-        stream,
-        "HTTP/1.1 {status} {}\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
-        if status == 200 {
-            "OK"
-        } else if status == 404 {
-            "Not Found"
-        } else {
-            "Bad Request"
-        },
-        body.len(),
+    listener.wait(
+        CALLBACK_TIMEOUT,
+        CALLBACK_TIMEOUT_MSG,
+        |request, reply| handle_request(request, reply, expected_state),
+        |pasted| parse_callback_input(pasted, expected_state).map(Some),
     )
 }
 
-fn parse_callback_target(target: &str, expected_state: &str) -> Result<CallbackResult, AgentError> {
-    let query = target.split_once('?').map(|(_, q)| q).unwrap_or("");
-    parse_callback_query(query, expected_state)
+/// `Ok(None)` means the redirect has not arrived yet: a stray probe, or a
+/// callback whose state did not match the one we minted.
+fn handle_request(
+    request: &CallbackRequest,
+    reply: &mut Reply,
+    expected_state: &str,
+) -> Result<Option<CallbackResult>, AgentError> {
+    if !request.target.starts_with(REDIRECT_PATH) {
+        reply.send(404, "text/plain; charset=utf-8", "Not found");
+        return Ok(None);
+    }
+    match parse_callback_query(request.query(), expected_state) {
+        Ok(result) => {
+            let html = if result.error.is_some() {
+                "<html><body><h1>xAI authorization failed.</h1>You can close this tab.</body></html>"
+            } else {
+                "<html><body><h1>xAI authorization received.</h1>You can close this tab.</body></html>"
+            };
+            reply.send(200, "text/html; charset=utf-8", html);
+            Ok(Some(result))
+        }
+        Err(_) => {
+            reply.send(
+                400,
+                "text/html; charset=utf-8",
+                "<html><body><h1>xAI authorization state mismatch.</h1>Please return to maki and try again.</body></html>",
+            );
+            Ok(None)
+        }
+    }
 }
 
 fn parse_callback_input(input: &str, expected_state: &str) -> Result<CallbackResult, AgentError> {
@@ -769,14 +694,6 @@ fn pkce_pair() -> Result<(String, String), AgentError> {
     let digest = Sha256::digest(verifier.as_bytes());
     let challenge = URL_SAFE_NO_PAD.encode(digest);
     Ok((verifier, challenge))
-}
-
-fn random_token() -> Result<String, AgentError> {
-    let mut buf = [0u8; 32];
-    getrandom::fill(&mut buf).map_err(|e| AgentError::Config {
-        message: format!("CSPRNG unavailable: {e}"),
-    })?;
-    Ok(URL_SAFE_NO_PAD.encode(buf))
 }
 
 pub(crate) fn grok_cli_credentials() -> Option<OAuthTokens> {

--- a/maki-storage/src/id.rs
+++ b/maki-storage/src/id.rs
@@ -45,6 +45,14 @@ impl MakiId {
     pub fn as_bytes(&self) -> &[u8; UUID_BYTES] {
         &self.0
     }
+
+    /// The standard hyphenated RFC 4122 form, for wire protocols that expect a
+    /// UUID rather than maki's base58 `Display`. Lives here so callers never
+    /// need `Uuid` directly (see `disallowed-methods` in clippy.toml) or a
+    /// hand-rolled hex formatter that can drift from the real thing.
+    pub fn hyphenated(&self) -> String {
+        Uuid::from_bytes(self.0).hyphenated().to_string()
+    }
 }
 
 impl fmt::Display for MakiId {

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -294,9 +294,17 @@ Aperture discovers models from your gateway. Set `APERTURE_HOST` to your Tailsca
 
 ### Command Code
 
-- **Env var**: `COMMAND_CODE_API_KEY` (or an existing Command Code CLI login in `~/.commandcode/auth.json`)
+- **Env var**: browser login via `maki auth login command-code`, `COMMAND_CODE_API_KEY`, or an existing Command Code CLI login in `~/.commandcode/auth.json`
 - **API**: `https://api.commandcode.ai`
-- **Features**: Token-plan (GOAT/Pro/Max/Team) access to the whole Command Code catalog, per-model reasoning effort
+- **Features**: Token-plan (GOAT/Pro/Max/Team) access via browser login, per-model reasoning effort
+
+No hardcoded model catalog. Use any model ID supported by this provider.
+
+### Command Code Credits
+
+- **Env var**: `COMMAND_CODE_API_KEY`
+- **API**: `https://api.commandcode.ai/provider/v1`
+- **Features**: Metered pay-as-you-go credits on the same account, via API key
 
 No hardcoded model catalog. Use any model ID supported by this provider.
 
@@ -453,7 +461,7 @@ To add a custom provider or proxy, drop an executable script into the config `pr
 
 `resolve` is called each time a new agent spawns, so scripts should read tokens from disk instead of caching them in memory. That way auth changes from other processes get picked up.
 
-The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `copilot`, `ollama`, `llama-cpp`, `mistral`, `zai`, `deepseek`, `openrouter`, `synthetic`, `tensorx`, `opencode`, `xai`, `aperture`, `command-code`.
+The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `copilot`, `ollama`, `llama-cpp`, `mistral`, `zai`, `deepseek`, `openrouter`, `synthetic`, `tensorx`, `opencode`, `xai`, `aperture`, `command-code`, `command-code-credits`.
 
 If your provider serves models not in the base catalog, add a `models` subcommand returning:
 

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -292,6 +292,14 @@ If `~/.grok/auth.json` already exists, login offers to reuse it without writing 
 
 Aperture discovers models from your gateway. Set `APERTURE_HOST` to your Tailscale Aperture endpoint (e.g. `https://your-host.tailnet.ts.net`). No API key needed, Tailscale handles auth.
 
+### Command Code
+
+- **Env var**: `COMMAND_CODE_API_KEY` (or an existing Command Code CLI login in `~/.commandcode/auth.json`)
+- **API**: `https://api.commandcode.ai`
+- **Features**: Token-plan (GOAT/Pro/Max/Team) access to the whole Command Code catalog, per-model reasoning effort
+
+No hardcoded model catalog. Use any model ID supported by this provider.
+
 ### Opencode Go
 
 - **Env var**: `OPENCODE_API_KEY`
@@ -445,7 +453,7 @@ To add a custom provider or proxy, drop an executable script into the config `pr
 
 `resolve` is called each time a new agent spawns, so scripts should read tokens from disk instead of caching them in memory. That way auth changes from other processes get picked up.
 
-The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `copilot`, `ollama`, `llama-cpp`, `mistral`, `zai`, `deepseek`, `openrouter`, `synthetic`, `tensorx`, `opencode`, `xai`, `aperture`.
+The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `copilot`, `ollama`, `llama-cpp`, `mistral`, `zai`, `deepseek`, `openrouter`, `synthetic`, `tensorx`, `opencode`, `xai`, `aperture`, `command-code`.
 
 If your provider serves models not in the base catalog, add a `models` subcommand returning:
 

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -16,7 +16,7 @@ use maki_config::{Config, load_env_files, load_permissions};
 use maki_lua::PluginHost;
 use maki_providers::provider::fetch_all_models;
 use maki_providers::{ProviderData, catalog_providers};
-use maki_providers::{copilot_auth, dynamic, openai_auth, xai_auth};
+use maki_providers::{commandcode_auth, copilot_auth, dynamic, openai_auth, xai_auth};
 use maki_storage::StateDir;
 use maki_storage::auth::ProviderCredentials;
 use maki_storage::auth::{
@@ -29,6 +29,7 @@ pub fn auth_login(provider: Option<&str>, storage: &StateDir) -> Result<()> {
         Some("openai") => openai_auth::login(storage)?,
         Some("xai") => xai_auth::login(storage)?,
         Some("copilot") => copilot_auth::login(storage)?,
+        Some("command-code") => commandcode_auth::login(storage)?,
         Some(slug) => {
             let slug = slugify(slug);
             if builtin_provider(&slug).is_none()


### PR DESCRIPTION
## Introduction

Command Code is not reachable from Maki today. A single Command Code account can be billed two ways, and the two do not share a wire protocol. Metered credits, the pay-as-you-go Provider plan, are served by an ordinary OpenAI-compatible endpoint under `/provider/v1`. Token plans (GOAT, Pro, Max and Team) are served by a private endpoint at `/alpha/generate` that speaks neither chat-completions nor the Anthropic messages format.

Neither is expressible in configuration. The Lua plugin API exposes tools, commands, keymaps and UI, but no provider registration or streaming surface, and `providers.toml` can only declare providers against the protocols already compiled in.

The token-plan protocol has no published specification. This change takes its inspiration from [`pi-commandcode-provider`](https://github.com/patlux/pi-commandcode-provider), an extension that implements the same endpoint for pi, and which served as the reference for the request envelope, the stream event vocabulary, the credential file locations and the browser login handshake. The behaviour it documents was then checked against a live Command Code account before this was opened, and the parser corrected where the two disagreed.

## Change

* Add `command-code`, a token-plan provider speaking the custom SSE protocol at `/alpha/generate`.
* Add `command-code-credits`, a metered pay-as-you-go provider on the OpenAI-compatible `/provider/v1` endpoint.
* Add a browser login for the token-plan provider, reached through `maki auth login command-code`.
* Resolve credentials from `COMMAND_CODE_API_KEY`, either slug's saved credential, or an existing Command Code CLI login.
* Discover the model catalog from `/provider/v1/models` for both providers.
* Send a per-model reasoning effort, snapped to the levels each model accepts.
* Report a Command Code API failure by its message rather than its JSON envelope.
* Document both providers in the generated provider reference.

One commit in this branch is unrelated to Command Code. `seed_catalog_for_tests` initialised a `OnceLock`, so the first seeding test to run silently owned the catalog for every test after it in the same process. That test bug is fixed first in the branch, so it is not attributed to the feature.

## Configuration

Neither provider requires a `providers.toml` entry. Token plans authenticate through the browser:

```text
maki auth login command-code
```

Metered credits take an API key from the Command Code studio, either through `maki auth login command-code-credits` or from the environment:

```text
export COMMAND_CODE_API_KEY=...
```

One account issues one key and both endpoints accept it, so a login under either slug also authenticates the other. A credential written by the Command Code CLI at `~/.commandcode/auth.json` is read as a fallback, as are the `~/.pi/agent/auth.json` and `~/.omp/agent/auth.json` locations that pi and omp hosts use.

## How

### Two slugs rather than one provider with two plans

`BuiltInProvider` already supports plans, but a plan only swaps a base URL and a default model. It cannot express a difference in wire protocol, nor in how a credential is obtained, so the two billing modes cannot share a slug. They are registered as separate `ProviderKind` variants and separate manifests, and share a module.

### The token-plan protocol

`/alpha/generate` takes the Command Code CLI's request envelope, of `config`, `memory`, `taste`, `skills`, `params` and `threadId`, with the model, messages, tools and sampling parameters nested under `params`. It answers with a Vercel AI SDK shaped event stream, delivered as one JSON object per line, with or without an SSE `data:` prefix.

The parser acts on `text-delta`, `reasoning-delta`, `tool-call`, `finish` and `error`. The remaining event types the stream emits are named and ignored explicitly, rather than falling through a catch-all: block boundaries are implied by the deltas, the assembled `tool-call` supersedes the `tool-input-*` fragments that stream ahead of it, and `finish-step` reports per-step usage that `finish` totals. Naming them keeps the log for an unrecognised event meaningful, which matters for a protocol with no specification behind it.

A stream that reaches end of input without a `finish` event is reported as a retryable error. Every complete turn ends in one, so the alternative is a truncated answer committed to history as though the model had finished speaking.

Tool calls and their results are dropped in pairs when either half is missing, because the endpoint rejects an unpaired call or result. Reasoning is not replayed on later turns, matching the reference client.

### Browser login

The Command Code CLI presents its login as OAuth, but it is not a token exchange. The studio mints a long-lived API key and posts it to a loopback callback, so there is no authorization code, no refresh and nothing to expire. The result is therefore stored as an ordinary provider credential rather than as an OAuth envelope with a fabricated expiry, which means the existing key pool reads it and `maki auth logout` clears it with no further work.

The callback binds the port the studio expects, searches a small range, and falls back to an ephemeral port. Because the studio is an HTTPS page posting to a plaintext loopback server, the callback answers the CORS and Private Network Access preflight that Chrome sends first. A state token is validated before a key is accepted, so a page the user did not open cannot plant a credential. When the browser cannot reach the callback at all, the flow falls back to a paste prompt.

### Model capabilities

`/provider/v1/models` returns only an id, a name and a context length. Reasoning support, the reasoning levels a model accepts, and image support are not exposed by any endpoint, so they come from a snapshot of the Command Code CLI's bundled catalog. A model absent from that table is treated as text-only with a provider-chosen reasoning depth, which is what the CLI itself does, so a newly released model degrades rather than erroring.

Because discovery has not necessarily run when the first request goes out, `adjust_model` seeds vision and reasoning support from that table. Without it the first turn on a vision-capable model would silently drop its images.

### Cost

Neither provider ships a pricing table. A token plan bills against the subscription, and the credits endpoint prices per model server-side, so a static table would be a second source of truth. It would also be a wrong one: a `deepseek-v4-pro` call was billed at rates near $0.66 per million input tokens and $1.98 per million output, against the $0.435 and $0.87 the reference extension's table records.

The gateway does report an authoritative per-request cost in its trailing metadata. Surfacing it requires a notion of provider-reported cost that Maki does not currently have, reaching `StreamResponse` and every `cost_of` call site, so it is left to a separate change.

## Why

Keeping the two billing modes apart is what the protocols require, but it is also clearer to operate: the slug states which balance a session is spending, and the model picker does not mix a subscription with metered credits.

Storing the browser login's result as a plain credential rather than an OAuth envelope avoids inventing an expiry and a refresh path for a key that has neither. Failing loudly on a stream that ends without its terminator is the same principle applied to the parser: for a protocol that can change without notice, an error a user can report is worth more than a plausible-looking truncated answer.

## Validation

```text
cargo fmt --all --check
cargo clippy --workspace --all-targets
cargo test -p maki-providers
cargo test -p maki-providers -- --test-threads=1
cargo machete
cargo run -p maki-docgen -- --check
```

All pass, with no clippy warnings. Each of the four commits builds and passes the provider tests on its own.

Beyond the test suite, the token-plan endpoint was exercised against a live account on a text turn, a tool-call turn and a reasoning turn. That run corrected two things the reference extension had not made apparent: the breadth of the event vocabulary, and the shape of an HTTP error body. It also confirmed the token accounting, which carries an explicit uncached count in practice. The regression tests use the payloads the endpoint actually returned.

The remaining workspace test failures on this branch are present on `main` and are untouched here.

## AI use

The code change was implemented by an AI agent. I fully reviewed and tested the change myself.
