### PR TITLE
fix(deps): patch crossterm for bracketed paste on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,14 +831,12 @@ checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 [[package]]
 name = "crossterm"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+source = "git+https://github.com/crossterm-rs/crossterm?rev=3ca54292d2b1f1c58e200a06122ddaf5dd6b5c77#3ca54292d2b1f1c58e200a06122ddaf5dd6b5c77"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "bitflags 2.13.1",
  "crossterm_winapi",
  "derive_more",
- "document-features",
  "mio",
  "parking_lot",
  "rustix",
@@ -1050,15 +1054,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
 ]
 
 [[package]]
@@ -2264,7 +2259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d46662859bc5f60a145b75f4632fbadc84e829e45df6c5de74cfc8e05acb96b5"
 dependencies = [
  "ahash",
- "base64",
+ "base64 0.22.1",
  "bytecount",
  "email_address",
  "fancy-regex 0.16.2",
@@ -2403,12 +2398,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2507,7 +2496,7 @@ dependencies = [
  "async-io",
  "async-lock",
  "async-process",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "event-listener",
  "flume 0.11.1",
@@ -2614,7 +2603,7 @@ version = "0.4.11"
 dependencies = [
  "arc-swap",
  "async-lock",
- "base64",
+ "base64 0.22.1",
  "criterion",
  "crossterm",
  "event-listener",
@@ -2707,7 +2696,7 @@ dependencies = [
 name = "maki-providers"
 version = "0.4.11"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "fastrand",
  "flume 0.11.1",
  "futures",
@@ -2759,7 +2748,7 @@ dependencies = [
  "arc-swap",
  "async-lock",
  "async-process",
- "base64",
+ "base64 0.22.1",
  "color-eyre",
  "criterion",
  "crossterm",
@@ -3694,7 +3683,7 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "indexmap 2.14.0",
  "quick-xml 0.41.0",
  "serde",
@@ -4519,7 +4508,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
@@ -4951,7 +4940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "fancy-regex 0.11.0",
  "filedescriptor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,3 +203,10 @@ debug = false
 # grammars. Those static archives held the bulk of the bytes.
 [profile.dev.build-override]
 debug = false
+
+# crossterm 0.29.0 has no VT input on Windows, so bracketed paste never decodes and a
+# multiline paste submits at the first newline (#336). Pinned to the head of
+# crossterm-rs/crossterm#1030, which lives in refs/pull/1030/head on the upstream repo.
+# Remove once the PR ships in a crossterm release.
+[patch.crates-io]
+crossterm = { git = "https://github.com/crossterm-rs/crossterm", rev = "3ca54292d2b1f1c58e200a06122ddaf5dd6b5c77" }

--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,8 @@
       gitDepHashes = {
         "git+https://github.com/pydantic/monty.git?tag=v0.0.21#70fe3f5781381eb33579e45046f8cb3845953373" =
           "sha256-P4PgqfYykkZrWGg5G3WQo070lORLEhmXQUQPx3+Yslo=";
+        "git+https://github.com/crossterm-rs/crossterm?rev=3ca54292d2b1f1c58e200a06122ddaf5dd6b5c77#3ca54292d2b1f1c58e200a06122ddaf5dd6b5c77" =
+          "sha256-A5lgiEEi7mktf7m2GljdAxst7Fdl7Uqko29Xq6o90Ow=";
       };
 
       missingGitDepHashes = builtins.filter (s: !(builtins.hasAttr s gitDepHashes)) gitDepSources;


### PR DESCRIPTION
crossterm 0.29.0 reads console `INPUT_RECORD`s on Windows instead of VT input, so the `ESC[200~` markers a terminal sends around a paste never decode, `Event::Paste` never fires, and a multiline paste submits at its first newline (#336).

The fix lives in crossterm-rs/crossterm#1030, which is not released yet, so we pin the patch to that PR head.

The rev is taken from `refs/pull/1030/head` on the upstream repo, which lives there forever, so the pin survives the contributor deleting their fork.

The PR also rewrites the unix input path, so Linux wants a hand test before this ships, and `cargo update` will not move a rev pin when the PR gets rebased.