### PR TITLE
feat(lua): add `maki.model` so a keybind can switch model and thinking

### DIFF
--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod interpreter;
 pub(crate) mod json;
 pub(crate) mod keymap;
 pub(crate) mod log;
+pub(crate) mod model;
 pub(crate) mod net;
 pub(crate) mod options;
 pub(crate) mod session;
@@ -68,6 +69,10 @@ pub(crate) fn create_maki_global(
     maki.set(
         "session",
         session::create_session_table(lua, ui_action_tx.clone())?,
+    )?;
+    maki.set(
+        "model",
+        model::create_model_table(lua, ui_action_tx.clone())?,
     )?;
     maki.set(
         "ui",

--- a/maki-lua/src/api/model.rs
+++ b/maki-lua/src/api/model.rs
@@ -1,0 +1,198 @@
+//! `maki.model`. The event loop owns the model slot and the per-session
+//! request options, so every call has to round-trip to it.
+
+use maki_lua_macro::{lua_fn, lua_table};
+use mlua::{Error as LuaError, Lua, Result as LuaResult, Value};
+
+use crate::api::util::command::{ModelRequest, UiAction, ui_json_roundtrip};
+use crate::api::util::pair::Pair;
+
+const SET_ARG_ERR: &str = "expected a model spec string or an options table";
+
+async fn roundtrip(
+    lua: Lua,
+    tx: Option<flume::Sender<UiAction>>,
+    req: ModelRequest,
+) -> LuaResult<Pair<Value>> {
+    ui_json_roundtrip(&lua, tx.as_ref(), |reply_tx| UiAction::Model {
+        req,
+        reply_tx,
+    })
+    .await
+}
+
+/// Reads the focused session's model, thinking level, and fast mode.
+/// `thinking` comes back in the spelling `set` accepts, so a table from here
+/// can go straight back in.
+///
+/// @return (table|nil, string|nil) `{spec, id, provider, thinking, fast,
+///   supports_thinking, supports_fast}`, or nil and an error.
+/// @example
+/// local m = maki.model.get()
+/// if m.spec ~= "anthropic/claude-opus-4-6" then ... end
+#[lua_fn]
+async fn get(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaResult<Pair<Value>> {
+    roundtrip(lua, tx, ModelRequest::Get).await
+}
+
+/// Lists the model specs you can switch to: what the providers you are logged
+/// into offer, minus what your model policy blocks. The list fills in the
+/// background at startup, so right after launch it can still be empty.
+///
+/// @return (table|nil, string|nil) Array of `"provider/id"` specs, or nil and an error.
+/// @example
+/// local specs = maki.model.available()
+#[lua_fn]
+async fn available(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaResult<Pair<Value>> {
+    roundtrip(lua, tx, ModelRequest::Available).await
+}
+
+/// Switches the focused session's model, thinking level, or fast mode. Fields
+/// you leave out stay as they are, so this doubles as a thinking-only switch.
+/// Answers with the new state, in the same shape `get` returns.
+///
+/// @param opts string|table A model spec, or a table with any of:
+///   `spec` (string) `"provider/id"`, as listed by `available()`;
+///   `thinking` (string|number) `"off"`, `"adaptive"`, an effort level
+///   (`"minimal"` to `"max"`), a token budget, or `""` to toggle it on and off;
+///   `fast` (boolean) Anthropic fast mode.
+/// @return (table|nil, string|nil) The new state, or nil and an error.
+/// @example
+/// maki.model.set("anthropic/claude-opus-4-6")
+/// maki.model.set({ spec = "zai/glm-5", thinking = "high" })
+/// maki.keymap.set("n", "<M-t>", function() maki.model.set({ thinking = "" }) end)
+#[lua_fn]
+async fn set(
+    lua: Lua,
+    #[ctx] tx: Option<flume::Sender<UiAction>>,
+    opts: Value,
+) -> LuaResult<Pair<Value>> {
+    let req = match opts {
+        Value::String(spec) => ModelRequest::Set {
+            spec: Some(spec.to_str()?.to_owned()),
+            thinking: None,
+            fast: None,
+        },
+        Value::Table(opts) => ModelRequest::Set {
+            spec: opts.get("spec")?,
+            thinking: opts.get("thinking")?,
+            fast: opts.get("fast")?,
+        },
+        other => {
+            return Err(LuaError::runtime(format!(
+                "{SET_ARG_ERR}, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    roundtrip(lua, tx, req).await
+}
+
+lua_table! {
+    /// The model behind the focused session. Good for a keybind that flips
+    /// between your two go-to models, or lifts thinking for one hard question.
+    /// Without an interactive UI every function returns
+    /// `nil, "no interactive UI attached"`.
+    "maki.model" => pub(crate) fn create_model_table(tx: Option<flume::Sender<UiAction>>),
+    DOCS [get(tx), available(tx), set(tx)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::util::command::{NO_UI_ERR, UI_DROPPED_ERR, UiReply};
+    use crate::api::util::convert::lua_to_json;
+    use serde_json::{Value as Json, json};
+    use test_case::test_case;
+
+    const SPEC: &str = "anthropic/claude-opus-4-6";
+    const THINKING: &str = "high";
+    const UI_FAILURE: &str = "Model is not allowed by policy: anthropic/claude-opus-4-6";
+
+    fn lua_with_model(tx: Option<flume::Sender<UiAction>>) -> Lua {
+        let lua = Lua::new();
+        let t = create_model_table(&lua, tx).unwrap();
+        lua.globals().set("model", t).unwrap();
+        lua
+    }
+
+    /// The receiver is dropped up front, so the request cannot even leave.
+    fn closed_ui() -> Lua {
+        let (tx, rx) = flume::unbounded::<UiAction>();
+        drop(rx);
+        lua_with_model(Some(tx))
+    }
+
+    /// Answering `None` drops the reply channel, like a UI that took the
+    /// request and then vanished.
+    fn stub_ui(answer: fn(ModelRequest) -> Option<UiReply>) -> Lua {
+        let (tx, rx) = flume::unbounded::<UiAction>();
+        std::thread::spawn(move || {
+            while let Ok(UiAction::Model { req, reply_tx }) = rx.recv() {
+                if let Some(reply) = answer(req) {
+                    let _ = reply_tx.send(reply);
+                }
+            }
+        });
+        lua_with_model(Some(tx))
+    }
+
+    /// Echoes the request back, so a test can assert on what the UI would have
+    /// acted on. Fields left out stay `nil` on the way back.
+    fn echo(req: ModelRequest) -> Option<UiReply> {
+        Some(Ok(match req {
+            ModelRequest::Get => json!({ "spec": SPEC, "thinking": THINKING, "fast": true }),
+            ModelRequest::Available => json!([SPEC]),
+            ModelRequest::Set {
+                spec,
+                thinking,
+                fast,
+            } => json!({ "spec": spec, "thinking": thinking, "fast": fast }),
+        }))
+    }
+
+    /// The value comes back as JSON so assertions outlive the Lua state.
+    fn eval(lua: &Lua, script: &str) -> (Json, Option<String>) {
+        let (val, err): (Value, Option<String>) =
+            smol::block_on(lua.load(script).eval_async()).unwrap();
+        (lua_to_json(lua, &val).unwrap(), err)
+    }
+
+    /// `set` forwards only the fields it was given, so whatever you leave out
+    /// the UI leaves alone. `false` and `""` are values though, not omissions:
+    /// `""` is the thinking toggle. The last case is the documented loop, `get`
+    /// straight back into `set`, read-only extras and all.
+    #[test_case("return model.get()", json!({ "spec": SPEC, "thinking": THINKING, "fast": true }) ; "get")]
+    #[test_case("return model.available()", json!([SPEC]) ; "available")]
+    #[test_case("return model.set('anthropic/claude-opus-4-6')", json!({ "spec": SPEC }) ; "set_bare_spec_string")]
+    #[test_case("return model.set({ thinking = 8192, fast = true })", json!({ "thinking": "8192", "fast": true }) ; "set_table_without_spec")]
+    #[test_case("return model.set({ thinking = '', fast = false })", json!({ "thinking": "", "fast": false }) ; "set_empty_thinking_and_false_fast")]
+    #[test_case("local m = model.get() return model.set(m)", json!({ "spec": SPEC, "thinking": THINKING, "fast": true }) ; "set_fed_by_get")]
+    fn requests_cross_the_channel_and_answer_with_the_new_state(script: &str, expected: Json) {
+        assert_eq!(eval(&stub_ui(echo), script), (expected, None));
+    }
+
+    /// Every way of not getting an answer lands in the error slot, instead of
+    /// throwing or parking forever.
+    #[test_case(lua_with_model(None), NO_UI_ERR ; "no_ui_attached")]
+    #[test_case(closed_ui(), NO_UI_ERR ; "event_loop_closed")]
+    #[test_case(stub_ui(|_| None), UI_DROPPED_ERR ; "reply_channel_dropped")]
+    #[test_case(stub_ui(|_| Some(Err(UI_FAILURE.to_owned()))), UI_FAILURE ; "ui_refused")]
+    fn unanswered_request_returns_an_error_pair(lua: Lua, expected: &str) {
+        assert_eq!(
+            eval(&lua, "return model.get()"),
+            (Json::Null, Some(expected.to_owned()))
+        );
+    }
+
+    /// A non-spec argument is a programmer error, so it throws instead of
+    /// answering with a pair.
+    #[test_case("return model.set(42)" ; "number")]
+    #[test_case("return model.set()" ; "no_argument")]
+    #[test_case("return model.set(nil)" ; "explicit_nil")]
+    fn set_throws_on_a_non_spec_argument(script: &str) {
+        let lua = lua_with_model(None);
+        let err = smol::block_on(lua.load(script).eval_async::<Value>()).unwrap_err();
+        assert!(err.to_string().contains(SET_ARG_ERR));
+    }
+}

--- a/maki-lua/src/api/session.rs
+++ b/maki-lua/src/api/session.rs
@@ -7,9 +7,8 @@ use maki_lua_macro::{lua_fn, lua_table};
 use maki_storage::id::MakiId;
 use mlua::{Lua, Result as LuaResult, Table, Value};
 
-use crate::api::util::command::{SessionRequest, UiAction, ui_roundtrip};
-use crate::api::util::convert::json_to_lua;
-use crate::api::util::pair::{Pair, err_pair, try_pair};
+use crate::api::util::command::{SessionRequest, UiAction, ui_json_roundtrip};
+use crate::api::util::pair::{Pair, err_pair};
 
 const BLANK_NOTIFY_ERR: &str = "text must not be blank";
 const SESSION_REQUIRED_ERR: &str = "session is required";
@@ -19,10 +18,11 @@ async fn roundtrip(
     tx: Option<flume::Sender<UiAction>>,
     req: SessionRequest,
 ) -> LuaResult<Pair<Value>> {
-    let reply =
-        try_pair!(ui_roundtrip(tx.as_ref(), |reply_tx| UiAction::Session { req, reply_tx }).await);
-    let value = try_pair!(reply);
-    Ok((Some(json_to_lua(&lua, &value)?), None))
+    ui_json_roundtrip(&lua, tx.as_ref(), |reply_tx| UiAction::Session {
+        req,
+        reply_tx,
+    })
+    .await
 }
 
 /// Lists sessions stored for the current project. Answered from a

--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -5,11 +5,14 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use arc_swap::ArcSwap;
 use maki_agent::SharedBuf;
-use mlua::RegistryKey;
+use mlua::{Lua, RegistryKey, Result as LuaResult, Value};
 use strum::{EnumString, VariantNames};
 
+use crate::api::util::convert::json_to_lua;
+use crate::api::util::pair::{Pair, try_pair};
+
 pub(crate) const NO_UI_ERR: &str = "no interactive UI attached";
-const UI_DROPPED_ERR: &str = "ui event loop dropped the request";
+pub(crate) const UI_DROPPED_ERR: &str = "ui event loop dropped the request";
 
 #[derive(Clone)]
 pub struct LuaCommandInfo {
@@ -412,7 +415,17 @@ pub enum SessionRequest {
     SetTitle { id: String, title: String },
 }
 
-pub type SessionReply = Result<serde_json::Value, String>;
+pub enum ModelRequest {
+    Get,
+    Available,
+    Set {
+        spec: Option<String>,
+        thinking: Option<String>,
+        fast: Option<bool>,
+    },
+}
+
+pub type UiReply = Result<serde_json::Value, String>;
 
 /// Viewport of the focused chat transcript, zero-based like the rest of the
 /// UI; `maki.fn.winsaveview` is what puts it in Vim's 1-based shape.
@@ -457,7 +470,11 @@ pub enum UiAction {
     },
     Session {
         req: SessionRequest,
-        reply_tx: flume::Sender<SessionReply>,
+        reply_tx: flume::Sender<UiReply>,
+    },
+    Model {
+        req: ModelRequest,
+        reply_tx: flume::Sender<UiReply>,
     },
     WinSaveView {
         reply_tx: flume::Sender<WinView>,
@@ -495,6 +512,19 @@ pub(crate) async fn ui_roundtrip<T>(
     let (reply_tx, reply_rx) = flume::bounded(1);
     ui_send(tx, action(reply_tx))?;
     reply_rx.recv_async().await.map_err(|_| UI_DROPPED_ERR)
+}
+
+/// `ui_roundtrip` for JSON replies, shaped into the `(value, err)` pair Lua
+/// expects. Never reaching the UI and the UI refusing both land in the error
+/// slot.
+pub(crate) async fn ui_json_roundtrip(
+    lua: &Lua,
+    tx: Option<&flume::Sender<UiAction>>,
+    action: impl FnOnce(flume::Sender<UiReply>) -> UiAction,
+) -> LuaResult<Pair<Value>> {
+    let reply = try_pair!(ui_roundtrip(tx, action).await);
+    let value = try_pair!(reply);
+    Ok((Some(json_to_lua(lua, &value)?), None))
 }
 
 #[cfg(test)]

--- a/maki-lua/src/docs.rs
+++ b/maki-lua/src/docs.rs
@@ -72,6 +72,7 @@ pub fn api_docs() -> Vec<&'static ModuleDoc> {
         &api::json::VALIDATOR_DOCS,
         &api::keymap::DOCS,
         &api::log::DOCS,
+        &api::model::DOCS,
         &api::net::DOCS,
         &api::session::DOCS,
         &api::text::DOCS,

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -11,8 +11,8 @@ pub use api::keymap::{KeymapEntry, KeymapReader, KeymapSnapshot};
 pub use api::options::{OptionSpec, OptionType, PluginOptionSpecs};
 pub use api::util::command::{
     Anchor, Axis, Border, BuiltinAction, Dimension, Edge, FloatConfig, FloatConfigPatch,
-    HintReader, HintSnapshot, LuaCommandInfo, LuaCommandReader, SessionReply, SessionRequest,
-    Split, TitlePos, UiAction, WinCommand, WinEvent, WinView,
+    HintReader, HintSnapshot, LuaCommandInfo, LuaCommandReader, ModelRequest, SessionRequest,
+    Split, TitlePos, UiAction, UiReply, WinCommand, WinEvent, WinView,
 };
 pub use docs::{DocKind, FnDoc, ModuleDoc, ParamDoc, api_docs};
 pub use error::PluginError;

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -25,5 +25,6 @@ pub use providers::xai::auth as xai_auth;
 pub use types::{
     ContentBlock, EMPTY_RESPONSE_MARKER, Effort, EffortDialect, IMAGE_OMITTED_NOTE, ImageMediaType,
     ImageSource, Message, MessageKind, ProviderEvent, ProviderUsage, RequestOptions, Role,
-    StopReason, StreamResponse, ThinkingConfig, UsageLimit, adapt_images_for_model, dialect,
+    StopReason, StreamResponse, THINKING_USAGE, ThinkingConfig, UsageLimit, adapt_images_for_model,
+    dialect,
 };

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -391,7 +391,7 @@ impl StopReason {
     }
 }
 
-const THINKING_USAGE: &str =
+pub const THINKING_USAGE: &str =
     "Usage: /thinking [off|adaptive|minimal|low|medium|high|xhigh|max|<budget>]";
 
 /// Effort levels are percentages, so they need a ceiling even when the model

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -89,6 +89,7 @@ const AUTH_EXPIRED_MSG: &str =
     "Token expired. Run `maki auth login` in another terminal, then press Enter to retry.";
 const FLASH_NO_PLAN: &str = "No plan file";
 const FAST_UNSUPPORTED_MSG: &str = "Fast mode requires an Anthropic Opus 4.6+ model (API only)";
+const THINKING_UNSUPPORTED_MSG: &str = "Thinking requires a model that supports it";
 const FAST_ON_MSG: &str = "Fast mode: on";
 const FAST_OFF_MSG: &str = "Fast mode: off";
 const WORKFLOW_ON_MSG: &str = "Workflow mode: on";
@@ -383,6 +384,39 @@ impl App {
     pub(crate) fn update_model(&mut self, model: &Model) {
         self.state.update_model(model);
         persist_model(&self.storage, &self.state.session.model);
+    }
+
+    /// Takes the spelling both `/thinking` and `maki.model.set` accept; a
+    /// blank {input} toggles.
+    pub(crate) fn set_thinking(&mut self, input: &str) -> Result<ThinkingConfig, String> {
+        if !self.state.model.supports_thinking() {
+            return Err(THINKING_UNSUPPORTED_MSG.into());
+        }
+        self.state.thinking =
+            ThinkingConfig::parse(input.trim(), self.state.thinking).map_err(str::to_owned)?;
+        Ok(self.state.thinking)
+    }
+
+    pub(crate) fn set_fast(&mut self, fast: bool) -> Result<(), String> {
+        if fast && !self.state.model.supports_fast() {
+            return Err(FAST_UNSUPPORTED_MSG.into());
+        }
+        self.state.fast = fast;
+        Ok(())
+    }
+
+    /// What `maki.model.get` hands to Lua.
+    pub(crate) fn model_state(&self) -> serde_json::Value {
+        let model = &self.state.model;
+        serde_json::json!({
+            "spec": model.spec(),
+            "id": model.id,
+            "provider": model.provider.to_string(),
+            "thinking": self.state.thinking.to_string(),
+            "fast": self.state.fast,
+            "supports_thinking": model.supports_thinking(),
+            "supports_fast": model.supports_fast(),
+        })
     }
 
     pub(crate) fn record_recent_model(&mut self, spec: &str) {
@@ -1421,33 +1455,18 @@ impl App {
                 vec![]
             }
             "/thinking" => {
-                if !self.state.model.supports_thinking() {
-                    self.flash("Thinking requires a model that supports it".into());
-                    return vec![];
-                }
-                match ThinkingConfig::parse(cmd.args.trim(), self.state.thinking) {
-                    Ok(thinking) => {
-                        self.state.thinking = thinking;
-                        self.flash(format!("Thinking: {thinking}"));
-                    }
-                    Err(msg) => self.flash(msg.into()),
+                match self.set_thinking(&cmd.args) {
+                    Ok(thinking) => self.flash(format!("Thinking: {thinking}")),
+                    Err(msg) => self.flash(msg),
                 }
                 vec![]
             }
             "/fast" => {
-                if !self.state.model.supports_fast() {
-                    self.flash(FAST_UNSUPPORTED_MSG.into());
-                    return vec![];
+                let fast = !self.state.fast;
+                match self.set_fast(fast) {
+                    Ok(()) => self.flash(if fast { FAST_ON_MSG } else { FAST_OFF_MSG }.into()),
+                    Err(msg) => self.flash(msg),
                 }
-                self.state.fast = !self.state.fast;
-                self.flash(
-                    if self.state.fast {
-                        FAST_ON_MSG
-                    } else {
-                        FAST_OFF_MSG
-                    }
-                    .into(),
-                );
                 vec![]
             }
             "/workflow" => {

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -19,7 +19,7 @@ use maki_agent::{
 use maki_config::{PermissionsConfig, UiConfig};
 use maki_lua::test_support::{HintWriterHandle, hint_writer_pair};
 use maki_lua::{BuiltinAction, HintReader, KeymapReader, LuaCommandInfo, LuaCommandReader};
-use maki_providers::{ContentBlock, Effort, Message, Role, TokenUsage};
+use maki_providers::{ContentBlock, Effort, Message, Role, THINKING_USAGE, TokenUsage};
 use maki_storage::sessions::{StoredMode, StoredThinking};
 use ratatui::layout::Rect;
 use std::env;
@@ -39,6 +39,9 @@ const HINT_STYLE: &str = "fg";
 const RETRY_MESSAGE: &str = "overloaded";
 const RETRY_DELAY: Duration = Duration::from_secs(5);
 const MISSING_DIR: &str = "gone";
+const SONNET_SPEC: &str = "anthropic/claude-sonnet-4-5";
+const OPUS_SPEC: &str = "anthropic/claude-opus-4-8";
+const PLAIN_MODEL_SPEC: &str = "ollama/qwen3";
 const WALK_TIMEOUT: Duration = Duration::from_secs(5);
 /// Stands in for a size the provider measured, baseline included.
 const MEASURED_CONTEXT: u32 = 100_000;
@@ -3786,7 +3789,7 @@ fn thinking_unsupported_model_flashes_error() {
 
     app.execute_command(cmd("/thinking"), 0);
     assert_eq!(app.state.thinking, ThinkingConfig::Off);
-    assert!(app.status_bar.flash_text().is_some());
+    assert_eq!(app.status_bar.flash_text(), Some(THINKING_UNSUPPORTED_MSG));
 }
 
 #[test]
@@ -3806,7 +3809,7 @@ fn thinking_restored_from_session_meta() {
 }
 
 fn set_opus_model(app: &mut App) {
-    app.state.model = maki_providers::Model::from_spec("anthropic/claude-opus-4-8").unwrap();
+    app.state.model = maki_providers::Model::from_spec(OPUS_SPEC).unwrap();
 }
 
 #[test]
@@ -3868,7 +3871,7 @@ fn subagent_history_finishes_workflow_chat() {
     assert_eq!(app.chats[1].last_message_text(), DONE_TEXT);
 }
 
-#[test_case("anthropic/claude-sonnet-4-5" ; "non_opus_anthropic")]
+#[test_case(SONNET_SPEC ; "non_opus_anthropic")]
 #[test_case("openai/gpt-5.5" ; "non_anthropic")]
 fn fast_flashes_error_on_ineligible_model(spec: &str) {
     let mut app = test_app();
@@ -3901,7 +3904,7 @@ fn fast_normalized_off_when_restored_onto_ineligible_model() {
     let storage = StateDir::from_path(tmp.path().to_path_buf());
     // Saved as fast=true, but sonnet cannot do fast mode, so restoring must drop
     // it to false or the UI would show a phantom [fast] badge.
-    let mut session = AppSession::new("anthropic/claude-sonnet-4-5", "/tmp/test");
+    let mut session = AppSession::new(SONNET_SPEC, "/tmp/test");
     session.meta.fast = true;
 
     let state = SessionState::from_session(
@@ -3914,12 +3917,98 @@ fn fast_normalized_off_when_restored_onto_ineligible_model() {
 }
 
 #[test]
+fn model_state_reports_the_model_and_what_it_supports() {
+    let mut app = test_app();
+    app.state.model = maki_providers::Model::from_spec(PLAIN_MODEL_SPEC).unwrap();
+    assert_eq!(
+        app.model_state(),
+        serde_json::json!({
+            "spec": PLAIN_MODEL_SPEC,
+            "id": "qwen3",
+            "provider": "ollama",
+            "thinking": "off",
+            "fast": false,
+            "supports_thinking": false,
+            "supports_fast": false,
+        })
+    );
+
+    set_opus_model(&mut app);
+    app.set_thinking("high").unwrap();
+    app.set_fast(true).unwrap();
+    assert_eq!(
+        app.model_state(),
+        serde_json::json!({
+            "spec": OPUS_SPEC,
+            "id": "claude-opus-4-8",
+            "provider": "anthropic",
+            "thinking": "high",
+            "fast": true,
+            "supports_thinking": true,
+            "supports_fast": true,
+        })
+    );
+}
+
+/// What `model_state` reports has to parse back into the same state, or a
+/// `maki.model.get` -> `maki.model.set` hop would silently change it.
+#[test_case(ThinkingConfig::Off, "off" ; "off")]
+#[test_case(ThinkingConfig::Adaptive, "adaptive" ; "adaptive")]
+#[test_case(ThinkingConfig::Effort(Effort::High), "high" ; "effort")]
+#[test_case(ThinkingConfig::Budget(8192), "8192" ; "budget")]
+fn model_state_thinking_round_trips_into_set_thinking(thinking: ThinkingConfig, expected: &str) {
+    let mut app = test_app();
+    app.state.thinking = thinking;
+
+    let reported = app.model_state()["thinking"].as_str().unwrap().to_owned();
+    assert_eq!(reported, expected);
+    assert_eq!(app.set_thinking(&reported).unwrap(), thinking);
+    assert_eq!(app.set_thinking(&reported).unwrap(), thinking);
+}
+
+#[test]
+fn set_thinking_toggles_on_blank_input() {
+    let mut app = test_app();
+    assert_eq!(app.set_thinking("").unwrap(), ThinkingConfig::Adaptive);
+    assert_eq!(app.set_thinking("").unwrap(), ThinkingConfig::Off);
+}
+
+#[test_case(true, "garbage", THINKING_USAGE ; "unknown_word")]
+#[test_case(true, "0", THINKING_USAGE ; "zero_budget")]
+#[test_case(false, "low", THINKING_UNSUPPORTED_MSG ; "model_without_thinking")]
+fn set_thinking_keeps_state_on_rejected_input(supported: bool, input: &str, expected: &str) {
+    let mut app = test_app();
+    app.set_thinking("high").unwrap();
+    if !supported {
+        app.state.model.thinking_override = Some(maki_providers::ThinkingSupport::No);
+    }
+
+    assert_eq!(app.set_thinking(input).unwrap_err(), expected);
+    assert_eq!(app.state.thinking, ThinkingConfig::Effort(Effort::High));
+}
+
+/// Fast must never get stuck on: after switching to a model without fast mode,
+/// you still have to be able to turn it off.
+#[test]
+fn fast_turns_off_on_a_model_that_lost_fast_support() {
+    let mut app = test_app();
+    set_opus_model(&mut app);
+    app.execute_command(cmd("/fast"), 0);
+    assert!(app.state.fast);
+
+    app.state.model = maki_providers::Model::from_spec(SONNET_SPEC).unwrap();
+    app.execute_command(cmd("/fast"), 0);
+    assert!(!app.state.fast);
+    assert_eq!(app.status_bar.flash_text(), Some(FAST_OFF_MSG));
+}
+
+#[test]
 fn update_model_to_ineligible_resets_fast() {
     let mut app = test_app();
     set_opus_model(&mut app);
     app.state.fast = true;
 
-    let sonnet = maki_providers::Model::from_spec("anthropic/claude-sonnet-4-5").unwrap();
+    let sonnet = maki_providers::Model::from_spec(SONNET_SPEC).unwrap();
     app.state.update_model(&sonnet);
     assert!(!app.state.fast);
 }

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -24,7 +24,8 @@ use maki_agent::{
 };
 use maki_config::{ModelPolicy, UiConfig};
 use maki_lua::{
-    EventHandle, HintReader, KeymapReader, LuaCommandReader, SessionReply, SessionRequest, UiAction,
+    EventHandle, HintReader, KeymapReader, LuaCommandReader, ModelRequest, SessionRequest,
+    UiAction, UiReply,
 };
 use maki_providers::Timeouts;
 use maki_providers::provider::{Provider, fetch_all_models, from_model};
@@ -54,6 +55,9 @@ use crate::terminal;
 const DRAIN_BUDGET: usize = 256;
 const AGENT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
 const DELETE_FOCUSED_ERR: &str = "cannot delete the focused session";
+const MODEL_POLICY_ERR: &str = "Model is not allowed by policy";
+const INVALID_MODEL_ERR: &str = "Invalid model";
+const PROVIDER_INIT_ERR: &str = "Failed to create provider";
 const NOT_LIVE_ERR: &str = "session not live";
 
 /// Tabs carry their in-memory sessions so `/reload` reopens them without a
@@ -813,6 +817,9 @@ impl<'t> EventLoop<'t> {
             UiAction::Session { req, reply_tx } => {
                 self.handle_session_request(req, reply_tx);
             }
+            UiAction::Model { req, reply_tx } => {
+                let _ = reply_tx.send(self.handle_model_request(req));
+            }
             UiAction::WinSaveView { reply_tx } => {
                 let _ = reply_tx.send(self.focused_app().win_view());
             }
@@ -942,11 +949,7 @@ impl<'t> EventLoop<'t> {
     /// `List` replies from a background task (the scan can be slow); every
     /// other request is answered synchronously by the event loop, which owns
     /// the live runtimes.
-    fn handle_session_request(
-        &mut self,
-        req: SessionRequest,
-        reply_tx: flume::Sender<SessionReply>,
-    ) {
+    fn handle_session_request(&mut self, req: SessionRequest, reply_tx: flume::Sender<UiReply>) {
         match req {
             SessionRequest::List => {
                 let storage = self.ctx.storage.clone();
@@ -1059,7 +1062,38 @@ impl<'t> EventLoop<'t> {
         }
     }
 
-    fn submit_text(&mut self, idx: usize, text: String) -> SessionReply {
+    /// Lua acts on the focused session, the same target the model picker and
+    /// `/thinking` write to.
+    fn handle_model_request(&mut self, req: ModelRequest) -> UiReply {
+        match req {
+            ModelRequest::Get => Ok(self.focused_app().model_state()),
+            ModelRequest::Available => {
+                let available = self.ctx.available_models.load();
+                Ok(json!(
+                    available.as_deref().map(Vec::as_slice).unwrap_or(&[])
+                ))
+            }
+            ModelRequest::Set {
+                spec,
+                thinking,
+                fast,
+            } => {
+                if let Some(spec) = spec {
+                    self.change_model(&spec)?;
+                }
+                let app = self.focused_app();
+                if let Some(thinking) = thinking {
+                    app.set_thinking(&thinking)?;
+                }
+                if let Some(fast) = fast {
+                    app.set_fast(fast)?;
+                }
+                Ok(app.model_state())
+            }
+        }
+    }
+
+    fn submit_text(&mut self, idx: usize, text: String) -> UiReply {
         let msg = QueuedMessage {
             text,
             images: Vec::new(),
@@ -1284,7 +1318,11 @@ impl<'t> EventLoop<'t> {
                 }
                 self.respawn_agent(idx, loaded.messages);
             }
-            Action::ChangeModel(spec) => self.change_model(spec),
+            Action::ChangeModel(spec) => {
+                if let Err(e) = self.change_model(&spec) {
+                    self.focused_app().flash(e);
+                }
+            }
             Action::RefreshProvider { slug } => self.refresh_provider(slug),
             Action::AssignTier(spec, tier) => {
                 maki_providers::model_registry::set_and_persist(spec, tier, &self.ctx.storage);
@@ -1355,30 +1393,23 @@ impl<'t> EventLoop<'t> {
         }
     }
 
-    fn change_model(&mut self, spec: String) {
-        if !self.ctx.model_policy.allows(&spec) {
-            self.focused_app()
-                .flash(format!("Model is not allowed by policy: {spec}"));
-            return;
+    fn change_model(&mut self, spec: &str) -> Result<(), String> {
+        if !self.ctx.model_policy.allows(spec) {
+            return Err(format!("{MODEL_POLICY_ERR}: {spec}"));
         }
-        match Model::from_spec(&spec) {
-            Ok(mut new_model) => match from_model(&mut new_model, self.ctx.timeouts) {
-                Ok(new_provider) => {
-                    let app = self.focused_app();
-                    app.update_model(&new_model);
-                    app.record_recent_model(&spec);
-                    app.usage_slot.store(None);
-                    self.ctx.model_slot.store(Arc::new(ModelSlot {
-                        model: new_model,
-                        provider: Arc::from(new_provider),
-                    }));
-                }
-                Err(e) => self
-                    .focused_app()
-                    .flash(format!("Failed to create provider: {e}")),
-            },
-            Err(e) => self.focused_app().flash(format!("Invalid model: {e}")),
-        }
+        let mut new_model =
+            Model::from_spec(spec).map_err(|e| format!("{INVALID_MODEL_ERR}: {e}"))?;
+        let new_provider = from_model(&mut new_model, self.ctx.timeouts)
+            .map_err(|e| format!("{PROVIDER_INIT_ERR}: {e}"))?;
+        let app = self.focused_app();
+        app.update_model(&new_model);
+        app.record_recent_model(spec);
+        app.usage_slot.store(None);
+        self.ctx.model_slot.store(Arc::new(ModelSlot {
+            model: new_model,
+            provider: Arc::from(new_provider),
+        }));
+        Ok(())
     }
 
     fn refresh_models(&self) {
@@ -1424,8 +1455,10 @@ impl<'t> EventLoop<'t> {
                     provider: Arc::from(provider),
                 }));
             }
-        } else if let Some(builtin) = maki_config::providers::builtin_provider(&slug) {
-            self.change_model(builtin.default_model.to_string());
+        } else if let Some(builtin) = maki_config::providers::builtin_provider(&slug)
+            && let Err(e) = self.change_model(builtin.default_model)
+        {
+            self.focused_app().flash(e);
         }
     }
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -99,6 +99,7 @@ The rules:
 | [`maki.json.SchemaValidator`](#maki-json-SchemaValidator) | A compiled JSON Schema validator. |
 | [`maki.keymap`](#maki-keymap) | Key mappings, modeled after `vim.keymap`. |
 | [`maki.log`](#maki-log) | Structured logging for plugins. |
+| [`maki.model`](#maki-model) | The model behind the focused session. |
 | [`maki.net`](#maki-net) | HTTP client for fetching web content. |
 | [`maki.session`](#maki-session) | Host session primitives. |
 | [`maki.text`](#maki-text) | Text transformation utilities. |
@@ -2614,6 +2615,88 @@ Emit an ERROR-level log message. Use for failures that need attention.
 
 ```lua
 maki.log.error("failed to connect to API")
+```
+
+
+## maki.model {#maki-model}
+
+The model behind the focused session. Good for a keybind that flips
+between your two go-to models, or lifts thinking for one hard question.
+Without an interactive UI every function returns
+`nil, "no interactive UI attached"`.
+
+---
+
+### `maki.model.get()` {#maki-model-get}
+
+```lua
+maki.model.get()
+```
+
+Reads the focused session's model, thinking level, and fast mode.
+`thinking` comes back in the spelling `set` accepts, so a table from here
+can go straight back in.
+
+**Returns:** (`table|nil`, `string|nil`) `{spec, id, provider, thinking, fast,
+  supports_thinking, supports_fast}`, or nil and an error.
+
+**Example:**
+
+```lua
+local m = maki.model.get()
+if m.spec ~= "anthropic/claude-opus-4-6" then ... end
+```
+
+---
+
+### `maki.model.available()` {#maki-model-available}
+
+```lua
+maki.model.available()
+```
+
+Lists the model specs you can switch to: what the providers you are logged
+into offer, minus what your model policy blocks. The list fills in the
+background at startup, so right after launch it can still be empty.
+
+**Returns:** (`table|nil`, `string|nil`) Array of `"provider/id"` specs, or nil and an error.
+
+**Example:**
+
+```lua
+local specs = maki.model.available()
+```
+
+---
+
+### `maki.model.set()` {#maki-model-set}
+
+```lua
+maki.model.set({opts})
+```
+
+Switches the focused session's model, thinking level, or fast mode. Fields
+you leave out stay as they are, so this doubles as a thinking-only switch.
+Answers with the new state, in the same shape `get` returns.
+
+**Parameters:**
+
+- `{opts}` (`string|table`) A model spec, or a table with any of:
+  - `spec` (`string`) `"provider/id"`, as listed by `available()`;
+  - `thinking` (`string|number`) `"off"`, `"adaptive"`, an effort level
+
+  (`"minimal"` to `"max"`), a token budget, or `""` to toggle it on and off;
+
+  - `fast` (`boolean`) Anthropic fast mode.
+
+**Returns:** (`table|nil`, `string|nil`) The new state, or nil and an error.
+
+**Example:**
+
+```lua
+maki.model.set("anthropic/claude-opus-4-6")
+maki.model.set({ spec = "zai/glm-5", thinking = "high" })
+maki.keymap.set("n", "<M-t>", function() maki.model.set({ thinking = "" }) end)
 ```
 
 


### PR DESCRIPTION
There was no way to reach the model from Lua, so people asking for an amp style "flip between my two models" keybind had nothing to bind (#842).

`maki.model.get`, `maki.model.available`, and `maki.model.set` now round-trip to the event loop and act on the focused session, the same target the model picker and `/thinking` write to. `set` takes a bare spec or a table of `spec`, `thinking`, and `fast`, leaves out fields alone, and speaks the same thinking spelling `get` reports, so a state table goes straight back in.

Getting there moved the thinking and fast rules into `App::set_thinking` and `App::set_fast`, which `/thinking` and `/fast` now share with Lua, and turned `change_model` into a `Result` so callers pick between flashing and replying.