### PR TITLE
fix(edit): reindent a replacement when the match was fuzzy

### DIFF
--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -4017,11 +4017,10 @@ mod read_tool_required_params {
     }
 
     #[test]
-    fn limit_zero_parses_and_reads_to_cap() {
+    fn limit_zero_reads_to_end_with_right_aligned_line_numbers() {
         let (reg, _host) = builtins_host();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("big.txt");
-        // Write 100 lines
         let content = (1..=100i32)
             .map(|i| format!("line {i}"))
             .collect::<Vec<_>>()
@@ -4038,14 +4037,13 @@ mod read_tool_required_params {
             }),
         );
         let out = out.expect("read should succeed");
-        // limit=0 means read to end (capped at 2000). 100 lines < 2000, so all should be read.
         assert!(
-            out.contains("1: line 1"),
-            "should start at line 1, got: {out}"
+            out.starts_with("  1: line 1\n"),
+            "line 1 must be padded to the width of line 100, got: {out}"
         );
         assert!(
-            out.contains("100: line 100"),
-            "should include last line, got: {out}"
+            out.ends_with("\n100: line 100"),
+            "limit=0 should read to the end, got: {out}"
         );
     }
 

--- a/plugins/code_execution/init.lua
+++ b/plugins/code_execution/init.lua
@@ -34,11 +34,6 @@ local function new_view(ctx, buf)
   return ToolView.new(buf, { max_lines = ctx:tool_output_lines().code_execution or 30 })
 end
 
-local function line_nr_fmt(count)
-  local w = math.max(1, math.floor(math.log(count, 10)) + 1)
-  return "%" .. w .. "d "
-end
-
 -- One body builder for every path (start preview, handler, restore), so the
 -- script renders the same no matter which lifecycle callbacks ran. The
 -- header is always rebuilt from scratch; nothing mutates existing lines.
@@ -51,7 +46,7 @@ local function build_body(ctx, code)
   local function header()
     local total = #lines
     local shown = view.expanded and total or math.min(total, MAX_SCRIPT_LINES)
-    local fmt = line_nr_fmt(shown)
+    local fmt = ToolView.line_nr_fmt(shown) .. " "
     local out = {}
     for i = 1, shown do
       local spans = { { string.format(fmt, i), "line_nr" } }

--- a/plugins/edit/tests/spec.lua
+++ b/plugins/edit/tests/spec.lua
@@ -1,25 +1,9 @@
 local fr = require("maki.fuzzy_replace")
+local th = require("maki.test_helpers")
 
-local failures = {}
-
-local function case(name, fn)
-  local ok, err = pcall(fn)
-  if not ok then
-    table.insert(failures, name .. ": " .. tostring(err))
-  end
-end
-
-local function eq(actual, expected, msg)
-  if actual ~= expected then
-    error((msg or "") .. "\nexpected: " .. tostring(expected) .. "\n  actual: " .. tostring(actual))
-  end
-end
-
-local function has(s, substr, msg)
-  if not s:find(substr, 1, true) then
-    error((msg or "") .. "\nexpected to contain: " .. tostring(substr) .. "\n  actual: " .. tostring(s))
-  end
-end
+local case = th.case
+local eq = th.eq
+local has = th.has
 
 local R = "REPLACED"
 local NO_MATCH = fr.NO_MATCH
@@ -41,6 +25,76 @@ end)
 case("different_indentation", function()
   local result = fr.replace("    fn f() {\n        bar();\n    }", "fn f() {\n    bar();\n}", R, false)
   has(result, R)
+end)
+
+case("fuzzy_match_reindents_new_string", function()
+  local content = "class Foo\n  def bar\n    baz(\n      a,\n    )\n  end\nend\n"
+  local old = "def bar\n  baz(\n    a,\n  )\nend"
+  local new = "def bar\n  baz(\n    a,\n    b,\n  )\nend"
+  local result = fr.replace(content, old, new, false)
+  eq(result, "class Foo\n  def bar\n    baz(\n      a,\n      b,\n    )\n  end\nend\n")
+end)
+
+case("reindent_ignores_new_string_own_indentation", function()
+  local content = "class A\n  def f\n    x\n  end\nend\n"
+  local old = "def f\n  x\nend"
+  local new = "  def f\n    y\n  end"
+  local result = fr.replace(content, old, new, false)
+  eq(result, "class A\n  def f\n    y\n  end\nend\n")
+end)
+
+case("reindent_converts_spaces_to_tabs", function()
+  local content = "\tfn f() {\n\t\tif x {\n\t\t\tg();\n\t\t}\n\t}"
+  local old = "fn f() {\n    if x {\n        g();\n    }\n}"
+  local new = "fn f() {\n    if x {\n        h();\n    }\n}"
+  local result = fr.replace(content, old, new, false)
+  eq(result, "\tfn f() {\n\t\tif x {\n\t\t\th();\n\t\t}\n\t}")
+end)
+
+case("reindent_leaves_a_correct_new_string_alone", function()
+  local content = "def f():\n    a = 1 \n    return a\n"
+  local old = "    a = 1\n    return a"
+  local new = "    a = 1\n    return a\n\n\ndef g():\n    return 2"
+  local result = fr.replace(content, old, new, false)
+  eq(result, "def f():\n    a = 1\n    return a\n\n\ndef g():\n    return 2\n")
+end)
+
+case("reindent_leaves_a_line_that_exits_the_block_alone", function()
+  local content = "def f():\n    a = 1\n    return a\n"
+  local new = "  a = 1\n  return a\n\n\ndef g():\n  return 2"
+  local result = fr.replace(content, "  a = 1\n  return a", new, false)
+  eq(result, "def f():\n    a = 1\n    return a\n\n\ndef g():\n    return 2\n")
+end)
+
+case("reindent_keeps_the_block_when_a_column_zero_line_is_dropped", function()
+  local content = "def f():\n    a = 1\n# TODO\n    b = 2\n"
+  local old = "  a = 1\n# TODO\n  b = 2"
+  local result = fr.replace(content, old, "  a = 1\n  b = 2", false)
+  eq(result, "def f():\n    a = 1\n    b = 2\n")
+end)
+
+case("reindent_takes_its_widths_from_the_block_not_the_file", function()
+  local content = 'M = """\n\tgcc x.c\n"""\n\ndef g():\n    if x:\n        foo()\n'
+  local old = "  if x:\n    foo()"
+  local result = fr.replace(content, old, "  if x:\n    foo()\n    baz()", false)
+  eq(result, 'M = """\n\tgcc x.c\n"""\n\ndef g():\n    if x:\n        foo()\n        baz()\n')
+end)
+
+case("reindent_leaves_a_midline_match_alone", function()
+  local result = fr.replace("    let x = compute(a,  b);", "compute(a, b)", "compute(c, d)", false)
+  eq(result, "    let x = compute(c, d);")
+end)
+
+case("reindent_applies_to_every_replaced_occurrence", function()
+  local content = "  a();\n  b();\nx\n  a();\n  b();\n"
+  local result = fr.replace(content, "a();\nb();", "a();\nc();\nb();", true)
+  eq(result, "  a();\n  c();\n  b();\nx\n  a();\n  c();\n  b();\n")
+end)
+
+case("exact_match_keeps_new_string_indentation", function()
+  local content = "  a\n  b\n"
+  local result = fr.replace(content, "  a\n  b", "  a\n      b", false)
+  eq(result, "  a\n      b\n")
 end)
 
 case("whitespace_collapsed", function()
@@ -152,16 +206,21 @@ case("empty_content_no_match", function()
   eq(err, NO_MATCH)
 end)
 
-case("empty_old_string", function()
-  local result, err = fr.replace("abc", "", "x", false)
-  eq(result, nil)
-  eq(err, EMPTY_OLD_STRING)
-end)
-
-case("empty_old_string_replace_all_does_not_hang", function()
-  local result, err = fr.replace("abc", "", "x", true)
-  eq(result, nil)
-  eq(err, EMPTY_OLD_STRING)
+-- An old_string that trims down to nothing used to match at every offset, so
+-- replace_all spliced forever. A regression hangs here instead of failing.
+case("degenerate_old_string_is_rejected", function()
+  local vectors = {
+    { "abc", "", false, EMPTY_OLD_STRING },
+    { "abc", "", true, EMPTY_OLD_STRING },
+    { "a\n\nb", "   ", true, NO_MATCH },
+  }
+  for _, v in ipairs(vectors) do
+    local content, old, replace_all, expected_err = table.unpack(v)
+    local msg = ("old_string=%q replace_all=%s"):format(old, tostring(replace_all))
+    local result, err = fr.replace(content, old, "x", replace_all)
+    eq(result, nil, msg)
+    eq(err, expected_err, msg)
+  end
 end)
 
 case("replace_all_no_occurrences", function()
@@ -186,13 +245,6 @@ case("lua_pattern_special_chars", function()
   local result = fr.replace(content, "assert(x % 2 == 0);", R, false)
   has(result, R)
   has(result, "foo(a+b).bar;")
-end)
-
-case("tabs_vs_spaces_indentation", function()
-  local content = "\tfn f() {\n\t\tbar();\n\t}"
-  local search = "    fn f() {\n        bar();\n    }"
-  local result = fr.replace(content, search, R, false)
-  has(result, R)
 end)
 
 case("double_backslash_literal", function()
@@ -281,6 +333,4 @@ case("insert_after_mode", function()
   has(e2, "out of range")
 end)
 
-if #failures > 0 then
-  error(#failures .. " case(s) failed:\n\n" .. table.concat(failures, "\n\n"))
-end
+th.report()

--- a/plugins/grep/init.lua
+++ b/plugins/grep/init.lua
@@ -115,7 +115,7 @@ local function build_grep_view(entries, ctx)
       end
     end
   end
-  local nr_fmt = "%" .. math.max(1, math.floor(math.log(max_nr + 1, 10)) + 1) .. "d "
+  local nr_fmt = ToolView.line_nr_fmt(max_nr) .. " "
 
   local hl_tasks = {}
 

--- a/plugins/lib/maki/fuzzy_replace.lua
+++ b/plugins/lib/maki/fuzzy_replace.lua
@@ -8,6 +8,7 @@ local SINGLE_CANDIDATE_THRESHOLD = 0.0
 local MULTI_CANDIDATE_THRESHOLD = 0.3
 local CONTEXT_AWARE_LINE_MIN = 3
 local CONTEXT_AWARE_MATCH_RATIO = 0.5
+local INDENT_PATTERN = "^[ \t]*"
 
 local function split_lines(s)
   local lines = {}
@@ -42,6 +43,86 @@ end
 
 local function trim(s)
   return s:match("^%s*(.-)%s*$")
+end
+
+local function indent_of(line)
+  return line:match(INDENT_PATTERN)
+end
+
+-- Only `old_string` was ever checked against the file, so the drift between the
+-- two is the sole evidence of what the matcher forgave. Positions correspond
+-- when the line counts agree, which every matcher but `block_anchor` guarantees;
+-- otherwise only lines whose content agrees are the same line.
+local function indent_drift(matched, find)
+  local file_lines, model_lines = split_lines(matched), split_lines(find)
+  local paired_by_position = #file_lines == #model_lines
+  local drift, forgave = {}, false
+  for i = 1, math.min(#file_lines, #model_lines) do
+    local file_line, model_line = file_lines[i], model_lines[i]
+    local same_line = paired_by_position or trim(file_line) == trim(model_line)
+    if same_line and trim(file_line) ~= "" and trim(model_line) ~= "" then
+      local model_indent, file_indent = indent_of(model_line), indent_of(file_line)
+      if drift[model_indent] == nil then
+        drift[model_indent] = file_indent
+        forgave = forgave or model_indent ~= file_indent
+      end
+    end
+  end
+  return forgave and drift or nil
+end
+
+-- A column the model never used is extrapolated from the deepest one it did, so
+-- a level the replacement adds keeps the shape the model gave it. A column
+-- shallower than any in the block belongs to a line that leaves the block, a new
+-- top level definition say, so it stays where the model put it.
+local function rebase(drift, indent)
+  local exact_column = drift[indent]
+  if exact_column then
+    return exact_column
+  end
+  local deepest
+  for model_indent in pairs(drift) do
+    if #model_indent < #indent and indent:sub(1, #model_indent) == model_indent then
+      if not deepest or #model_indent > #deepest then
+        deepest = model_indent
+      end
+    end
+  end
+  return deepest and drift[deepest] .. indent:sub(#deepest + 1) or indent
+end
+
+-- The model can write `old_string` sloppily and `new_string` in the file's own
+-- frame, and then there is nothing left to correct.
+local function written_in_file_frame(drift, replacement)
+  local file_columns = {}
+  for _, file_indent in pairs(drift) do
+    file_columns[file_indent] = true
+  end
+  for _, line in ipairs(split_lines(replacement)) do
+    if trim(line) ~= "" and not file_columns[indent_of(line)] then
+      return false
+    end
+  end
+  return true
+end
+
+-- Corrects exactly what the match forgave in `old_string`, and nothing else.
+local function reindent(matched, find, replacement)
+  local drift = indent_drift(matched, find)
+  if not drift or written_in_file_frame(drift, replacement) then
+    return replacement
+  end
+
+  local out = {}
+  for i, line in ipairs(split_lines(replacement)) do
+    local indent = indent_of(line)
+    if trim(line) == "" then
+      out[i] = line
+    else
+      out[i] = rebase(drift, indent) .. line:sub(#indent + 1)
+    end
+  end
+  return table.concat(out, "\n")
 end
 
 local function escape_pattern(s)
@@ -468,20 +549,44 @@ end
 local REPLACERS = { exact, line_trimmed, block_anchor, whitespace_normalized, indentation_flexible }
 local LATE_REPLACERS = { trimmed_boundary, context_aware }
 
-local function replace_all_occurrences(content, matched, replacement)
-  local result = {}
+-- An empty candidate matches at every offset and would splice forever, so it
+-- is made to match nowhere instead.
+local function occurrences(content, matched)
+  local at = {}
+  if matched == "" then
+    return at
+  end
   local pos = 1
   while true do
-    local s, e = content:find(matched, pos, true)
+    local s = content:find(matched, pos, true)
     if not s then
-      break
+      return at
     end
-    result[#result + 1] = content:sub(pos, s - 1)
-    result[#result + 1] = replacement
-    pos = e + 1
+    at[#at + 1] = s
+    pos = s + #matched
   end
-  result[#result + 1] = content:sub(pos)
-  return table.concat(result)
+end
+
+local function splice(content, at, len, replacement)
+  local out, pos = {}, 1
+  for _, s in ipairs(at) do
+    out[#out + 1] = content:sub(pos, s - 1)
+    out[#out + 1] = replacement
+    pos = s + len
+  end
+  out[#out + 1] = content:sub(pos)
+  return table.concat(out)
+end
+
+-- Indentation only means something for a block that starts its own line; a match
+-- landing mid line keeps whatever the model wrote.
+local function all_start_a_line(content, at)
+  for _, s in ipairs(at) do
+    if s > 1 and content:sub(s - 1, s - 1) ~= "\n" then
+      return false
+    end
+  end
+  return true
 end
 
 -- Replace {old_string} with {new_string} in {content}, tolerating small
@@ -494,16 +599,17 @@ function M.replace(content, old_string, new_string, replace_all)
 
   local any_found = false
 
-  local function try_match(candidates, replacement)
+  local function try_match(candidates, find, replacement)
     for _, matched in ipairs(candidates) do
-      local first = content:find(matched, 1, true)
-      if first then
+      local at = occurrences(content, matched)
+      if #at > 0 then
         any_found = true
-        if replace_all then
-          return replace_all_occurrences(content, matched, replacement)
-        end
-        if not content:find(matched, first + #matched, true) then
-          return content:sub(1, first - 1) .. replacement .. content:sub(first + #matched)
+        if replace_all or #at == 1 then
+          local text = replacement
+          if all_start_a_line(content, at) then
+            text = reindent(matched, find, replacement)
+          end
+          return splice(content, at, #matched, text)
         end
       end
     end
@@ -511,7 +617,7 @@ function M.replace(content, old_string, new_string, replace_all)
   end
 
   for _, r in ipairs(REPLACERS) do
-    local res = try_match(r(content, old_string), new_string)
+    local res = try_match(r(content, old_string), old_string, new_string)
     if res then
       return res, nil
     end
@@ -519,14 +625,14 @@ function M.replace(content, old_string, new_string, replace_all)
 
   local unescaped = unescape(old_string)
   if unescaped ~= old_string then
-    local res = try_match(escape_normalized(content, unescaped), unescape(new_string))
+    local res = try_match(escape_normalized(content, unescaped), unescaped, unescape(new_string))
     if res then
       return res, nil
     end
   end
 
   for _, r in ipairs(LATE_REPLACERS) do
-    local res = try_match(r(content, old_string), new_string)
+    local res = try_match(r(content, old_string), old_string, new_string)
     if res then
       return res, nil
     end

--- a/plugins/lib/maki/test_helpers.lua
+++ b/plugins/lib/maki/test_helpers.lua
@@ -21,6 +21,12 @@ function M.eq(actual, expected, msg)
   end
 end
 
+function M.has(s, substr, msg)
+  if not s:find(substr, 1, true) then
+    error((msg or "") .. "\nexpected to contain: " .. tostring(substr) .. "\n  actual: " .. tostring(s))
+  end
+end
+
 local _tmpdir_counter = 0
 
 function M.mktmpdir(prefix)

--- a/plugins/lib/maki/tool_view.lua
+++ b/plugins/lib/maki/tool_view.lua
@@ -15,9 +15,10 @@ local function format_line_nr(fmt, idx)
   return { string.format(fmt, idx), "line_nr" }
 end
 
-local function line_nr_fmt(count)
-  local w = math.max(1, math.floor(math.log(count, 10)) + 1)
-  return "%" .. w .. "d "
+-- Right aligned, so the content column stays put when a number gains a digit.
+-- Formats the number alone, callers add their own separator.
+function ToolView.line_nr_fmt(max_line_nr)
+  return "%" .. #tostring(max_line_nr) .. "d"
 end
 
 -- Truncate a UTF-8 string at a byte boundary that is also a codepoint
@@ -190,7 +191,7 @@ function ToolView:set_highlight(content, ext)
   end
   local lines = maki.split(content, "\n")
 
-  local fmt = line_nr_fmt(#lines)
+  local fmt = ToolView.line_nr_fmt(#lines) .. " "
   for idx, line in ipairs(lines) do
     self:append({ format_line_nr(fmt, idx), { line } })
   end

--- a/plugins/lib/tests/spec.lua
+++ b/plugins/lib/tests/spec.lua
@@ -1,20 +1,9 @@
 local truncate = require("maki.truncate")
 local ToolView = require("maki.tool_view")
+local th = require("maki.test_helpers")
 
-local failures = {}
-
-local function case(name, fn)
-  local ok, err = pcall(fn)
-  if not ok then
-    table.insert(failures, name .. ": " .. tostring(err))
-  end
-end
-
-local function eq(actual, expected, msg)
-  if actual ~= expected then
-    error((msg or "") .. "\nexpected: " .. tostring(expected) .. "\n  actual: " .. tostring(actual))
-  end
-end
+local case = th.case
+local eq = th.eq
 
 -- Mock buf that records set_lines calls
 local function mock_buf()
@@ -62,6 +51,21 @@ case("truncate_trailing_newlines_counted", function()
 end)
 
 -- ToolView tests
+
+case("tool_view_line_nr_fmt_right_aligns_to_max_width", function()
+  local vectors = {
+    { 0, "1" },
+    { 9, "1" },
+    { 10, " 1" },
+    { 99, " 1" },
+    { 100, "  1" },
+    { 1000, "   1" },
+  }
+  for _, v in ipairs(vectors) do
+    eq(string.format(ToolView.line_nr_fmt(v[1]), 1), v[2], "max_line_nr=" .. v[1])
+  end
+  eq(string.format(ToolView.line_nr_fmt(100), 100), "100")
+end)
 
 case("tool_view_tail_keeps_last_n", function()
   local buf = mock_buf()
@@ -1432,6 +1436,4 @@ case("render_lines_nil_sections_mix_with_grouped", function()
   eq(item_lines[2], 3, "nil-section item follows without a new header")
 end)
 
-if #failures > 0 then
-  error(#failures .. " case(s) failed:\n\n" .. table.concat(failures, "\n\n"))
-end
+th.report()

--- a/plugins/read/init.lua
+++ b/plugins/read/init.lua
@@ -1,6 +1,10 @@
 local ToolView = require("maki.tool_view")
 local shorten_path = require("maki.shorten_path")
 local output_limits = require("maki.output_limits")
+local helpers = require("read_helpers")
+
+local truncate_bytes = helpers.truncate_bytes
+local split_lines = helpers.split_lines
 
 local DESCRIPTION = [[Read a file. Returns contents with line numbers (1-indexed).
 
@@ -22,25 +26,6 @@ local opts = maki.api.register_options({
   max_line_bytes = { default = 500, min = 80, desc = "Truncate lines longer than this many bytes." },
   max_output_lines = output_limits.specs.max_output_lines,
 })
-
-local function line_nr_fmt(count)
-  local w = math.max(1, math.floor(math.log(count + 1, 10)) + 1)
-  return "%" .. w .. "d "
-end
-
-local function truncate_bytes(line, max_bytes)
-  if #line <= max_bytes then
-    return line
-  end
-  local i = max_bytes
-  while i > 0 and line:byte(i) >= 0x80 and line:byte(i) < 0xC0 do
-    i = i - 1
-  end
-  if i > 0 and line:byte(i) >= 0xC0 then
-    i = i - 1
-  end
-  return line:sub(1, i) .. "..."
-end
 
 local function read_view_opts(ctx)
   local tol = ctx:tool_output_lines()
@@ -66,7 +51,7 @@ end
 local function build_file_view(lines, start_line, total_lines, path, ctx, prefix)
   local buf = maki.ui.buf()
   local view = ToolView.new(buf, read_view_opts(ctx))
-  local nr_fmt = line_nr_fmt(total_lines)
+  local nr_fmt = ToolView.line_nr_fmt(start_line + #lines - 1) .. " "
 
   for i, line in ipairs(lines) do
     view:append({ { string.format(nr_fmt, start_line + i - 1), "line_nr" }, { line } })
@@ -105,17 +90,10 @@ local function read_file(path, offset, limit, ctx)
     return { llm_output = "read error: " .. tostring(err), is_error = true }
   end
 
-  local all_lines = {}
-  local pos = 1
-  while pos <= #content do
-    local nl = content:find("\n", pos, true)
-    local raw = nl and content:sub(pos, nl - 1) or content:sub(pos)
-    all_lines[#all_lines + 1] = raw:find("\r$") and raw:sub(1, -2) or raw
-    pos = nl and nl + 1 or #content + 1
-  end
+  local all_lines = split_lines(content)
   local total_lines = #all_lines
 
-  local start = math.max(offset, 1)
+  local start = math.max(math.floor(offset), 1)
   local default_max = opts.max_output_lines or ctx:config("max_output_lines", DEFAULT_MAX_OUTPUT_LINES)
   local max_lines = limit == 0 and default_max or math.min(limit, default_max)
   local max_line_bytes = opts.max_line_bytes
@@ -128,8 +106,9 @@ local function read_file(path, offset, limit, ctx)
   ctx:record_read(path)
 
   local parts = {}
+  local nr_fmt = ToolView.line_nr_fmt(start + #lines - 1) .. ": %s"
   for i, line in ipairs(lines) do
-    parts[#parts + 1] = (start + i - 1) .. ": " .. line
+    parts[#parts + 1] = string.format(nr_fmt, start + i - 1, line)
   end
   local llm_output = table.concat(parts, "\n")
 

--- a/plugins/read/read_helpers.lua
+++ b/plugins/read/read_helpers.lua
@@ -1,0 +1,29 @@
+local M = {}
+
+function M.truncate_bytes(line, max_bytes)
+  if #line <= max_bytes then
+    return line
+  end
+  local i = max_bytes
+  while i > 0 and line:byte(i) >= 0x80 and line:byte(i) < 0xC0 do
+    i = i - 1
+  end
+  if i > 0 and line:byte(i) >= 0xC0 then
+    i = i - 1
+  end
+  return line:sub(1, i) .. "..."
+end
+
+function M.split_lines(content)
+  local lines = {}
+  local pos = 1
+  while pos <= #content do
+    local nl = content:find("\n", pos, true)
+    local raw = nl and content:sub(pos, nl - 1) or content:sub(pos)
+    lines[#lines + 1] = raw:find("\r$") and raw:sub(1, -2) or raw
+    pos = nl and nl + 1 or #content + 1
+  end
+  return lines
+end
+
+return M

--- a/plugins/read/tests/spec.lua
+++ b/plugins/read/tests/spec.lua
@@ -1,73 +1,12 @@
-local function line_nr_fmt(count)
-  local w = math.max(1, math.floor(math.log(count + 1, 10)) + 1)
-  return "%" .. w .. "d "
-end
+local helpers = require("read_helpers")
 
-local function truncate_bytes(line, max_bytes)
-  if #line <= max_bytes then
-    return line
-  end
-  local i = max_bytes
-  while i > 0 and line:byte(i) >= 0x80 and line:byte(i) < 0xC0 do
-    i = i - 1
-  end
-  if i > 0 and line:byte(i) >= 0xC0 then
-    i = i - 1
-  end
-  return line:sub(1, i) .. "..."
-end
-
-local function split_lines(content)
-  local lines = {}
-  local pos = 1
-  while pos <= #content do
-    local nl = content:find("\n", pos, true)
-    if nl then
-      local line = content:sub(pos, nl - 1)
-      lines[#lines + 1] = line:find("\r$") and line:sub(1, -2) or line
-      pos = nl + 1
-    else
-      local line = content:sub(pos)
-      lines[#lines + 1] = line:find("\r$") and line:sub(1, -2) or line
-      pos = #content + 1
-    end
-  end
-  return lines
-end
+local truncate_bytes = helpers.truncate_bytes
+local split_lines = helpers.split_lines
 
 local th = require("maki.test_helpers")
 
 local case = th.case
 local eq = th.eq
-local mktmpdir = function()
-  return th.mktmpdir("read_spec")
-end
-local rmtree = th.rmtree
-
--- line_nr_fmt: table-driven across all boundaries + alignment
-
-case("line_nr_fmt_boundaries_and_alignment", function()
-  local vectors = {
-    { 0, "%1d " },
-    { 1, "%1d " },
-    { 8, "%1d " },
-    { 9, "%2d " },
-    { 10, "%2d " },
-    { 98, "%2d " },
-    { 99, "%3d " },
-    { 100, "%3d " },
-    { 999, "%4d " },
-    { 1000, "%4d " },
-  }
-  for _, v in ipairs(vectors) do
-    eq(line_nr_fmt(v[1]), v[2], "count=" .. v[1])
-  end
-  local fmt = line_nr_fmt(100)
-  eq(string.format(fmt, 1), "  1 ")
-  eq(string.format(fmt, 100), "100 ")
-end)
-
--- truncate_bytes: ASCII + all UTF-8 widths
 
 case("truncate_ascii", function()
   eq(truncate_bytes("", 10), "")
@@ -99,8 +38,6 @@ case("truncate_utf8_boundary_safety", function()
   eq(truncate_bytes(s, 4), "\xC3\xA9...")
   eq(truncate_bytes(s, 2), "...")
 end)
-
--- split_lines: table-driven
 
 case("split_lines", function()
   local vectors = {

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -5256,6 +5256,7 @@ return shorten_path
 -- and surfaced by `report()` at the end.
 function M.case(name, fn)
 function M.eq(actual, expected, msg)
+function M.has(s, substr, msg)
 function M.mktmpdir(prefix)
 function M.rmtree(dir)
 function M.report()
@@ -5332,6 +5333,10 @@ function TextInput:render(prefix, prefix_width, width)
 -- stays a pure flag flip + re-render, deterministic across replays.
 -- Async highlighting goes through `maki.async.run`; during restore the
 -- runtime runs those tasks inline before snapshotting.
+
+-- Right aligned, so the content column stays put when a number gains a digit.
+-- Formats the number alone, callers add their own separator.
+function ToolView.line_nr_fmt(max_line_nr)
 
 -- opts: max_lines (default 80) shown while collapsed, keep "head"|"tail"
 -- (default "tail"), max_expand_lines (default 2000) kept for expansion,


### PR DESCRIPTION
The tolerant matchers in `fuzzy_replace` forgive indentation drift in `old_string`, then spliced `new_string` in untouched, so a model that miscounted the indentation of the block it was editing wrote that same wrong indentation into the file.

A fuzzy match now anchors the replacement on the common indent of the block it really matched, keeps the shape the model wrote relative to its own first column, and retypes the levels when the file uses tabs and the model wrote spaces.

An exact match is left alone, so deliberate reindentation still works, and a match that starts mid line is left alone too, since leading whitespace there is not indentation.

Finding and splicing occurrences is one path now, which also stops `replace_all` from looping forever on a whitespace only `old_string`, and the `read` tool right aligns its line numbers with the same width helper the UI gutter uses, so the content column stops moving when a number gains a digit.

Closes #838.