### PR TITLE
fix(providers): update DeepSeek prices and bill peak hours

### DIFF
--- a/maki-acp/src/server.rs
+++ b/maki-acp/src/server.rs
@@ -27,8 +27,9 @@ use maki_agent::{AgentInput, AgentMode, Envelope, ImageMediaType, ImageSource};
 use maki_config::{MAX_SERVER_NAME_LEN, ModelPolicy};
 use maki_providers::model::Model;
 use maki_providers::provider::{available_model_specs, fetch_all_models};
-use maki_providers::{Message, TokenUsage, add_cost};
+use maki_providers::{Message, TokenUsage, add_cost, settle_session};
 use maki_storage::id::{MakiId, SessionRef};
+use maki_storage::sessions::StoredTokenUsage;
 use serde::Serialize;
 use serde_json::Value;
 use smol::io::AsyncBufReadExt;
@@ -37,6 +38,8 @@ use tracing::{debug, warn};
 use crate::{AcpParams, elicitation, methods, permissions, translate};
 
 const FIRST_OUTGOING_REQUEST_ID: i64 = 1000;
+/// ACP has no fast-mode toggle, so a restored total is priced at standard rates.
+const RESTORED_FAST: bool = false;
 
 /// Ids come from here and are never reused, so a late answer for a closed
 /// session cannot match a request of the session that replaced it.
@@ -273,13 +276,13 @@ async fn load_session(
         .0
         .parse()
         .map_err(|_| AcpError::resource_not_found(Some(req.session_id.0.to_string())))?;
-    let (history, recorded_cwd, restored_usage, restored_model) = load_history(session_ref.id())?;
+    let mut restored = load_history(session_ref.id())?;
     close_session(srv).await;
     let mcp = start_mcp(&req.cwd, &req.mcp_servers).await;
     let sid = SessionId::from(session_ref.to_string());
     let home = maki_storage::paths::home();
-    let replay_cwd = recorded_cwd.as_deref().unwrap_or(&req.cwd);
-    for update in translate::replay_history(&history, replay_cwd, home.as_deref()) {
+    let replay_cwd = restored.cwd.as_deref().unwrap_or(&req.cwd);
+    for update in translate::replay_history(&restored.history, replay_cwd, home.as_deref()) {
         session_update(&srv.out_tx, &sid, update);
     }
     let cwd = req.cwd.clone();
@@ -288,18 +291,21 @@ async fn load_session(
         params,
         req.cwd,
         Some(session_ref),
-        history,
+        restored.history,
         mcp.clone(),
     );
     let spec = params.model.spec();
     let resp = methods::load_session_response()
         .config_options(vec![methods::model_config_option(&spec, &srv.model_specs)]);
-    // The restored total predates any per-turn cost, so price it once with
-    // the model the session recorded (the current default may cost 10x more
-    // or less); later turns add their own exact cost.
-    let restored_cost = Model::from_spec(&restored_model)
-        .map(|m| m.cost_of(&restored_usage, false))
-        .unwrap_or_else(|_| params.model.cost_of(&restored_usage, false));
+    // Priced against the model the session recorded, not the one selected now
+    // (which may cost 10x more or less). Later turns add their own exact cost.
+    let recorded_model = Model::from_spec(&restored.model).unwrap_or_else(|_| params.model.clone());
+    let restored_cost = settle_session(
+        &restored.usage,
+        &mut restored.by_model,
+        &recorded_model,
+        RESTORED_FAST,
+    );
     install_session(srv, handle, mcp, spec, pending, cwd, restored_cost);
     Ok(AgentResponse::LoadSessionResponse(resp))
 }
@@ -515,9 +521,17 @@ fn install_session(
     });
 }
 
-fn load_history(
-    session_id: MakiId,
-) -> Result<(Vec<Message>, Option<PathBuf>, TokenUsage, String), AcpError> {
+#[derive(Debug)]
+struct Restored {
+    history: Vec<Message>,
+    /// Only set when the session recorded an absolute cwd.
+    cwd: Option<PathBuf>,
+    usage: TokenUsage,
+    by_model: HashMap<String, StoredTokenUsage>,
+    model: String,
+}
+
+fn load_history(session_id: MakiId) -> Result<Restored, AcpError> {
     let storage = maki_storage::StateDir::resolve()
         .map_err(|e| AcpError::internal_error().data(json_str(&e)))?;
     load_history_from(&storage, session_id)
@@ -529,7 +543,7 @@ fn load_history(
 fn load_history_from(
     storage: &maki_storage::StateDir,
     session_id: MakiId,
-) -> Result<(Vec<Message>, Option<PathBuf>, TokenUsage, String), AcpError> {
+) -> Result<Restored, AcpError> {
     let session: maki_storage::sessions::Session<
         Message,
         maki_providers::TokenUsage,
@@ -542,9 +556,13 @@ fn load_history_from(
     } else {
         None
     };
-    let usage = session.token_usage;
-    let model = session.model.clone();
-    Ok((session.take_messages(), recorded, usage, model))
+    Ok(Restored {
+        cwd: recorded,
+        usage: session.token_usage,
+        by_model: session.usage_by_model().clone(),
+        model: session.model.clone(),
+        history: session.take_messages(),
+    })
 }
 
 fn handle_prompt(srv: &mut Server, raw: &Value, id: &RequestId) -> Result<(), AcpError> {
@@ -837,6 +855,12 @@ mod tests {
     const UNKNOWN_ID: i64 = 1002;
     const DISCOVERED_SPEC: &str = "openrouter/discovered-model";
     const OFFLINE_SPEC: &str = "openai/gpt-5";
+    const SELECTED_SPEC: &str = "openai/gpt-5.6-sol";
+    /// Neither resolves in the price tables, so nothing can re-price a restored
+    /// session back onto the recorded number by luck.
+    const RETIRED_SPEC: &str = "retired-vendor/retired-model-9000";
+    const RETIRED_MODEL_ID: &str = "retired-model-9000";
+    const RECORDED_COST: f64 = 1.25;
 
     fn allow_once(id: i64) -> Value {
         serde_json::json!({
@@ -986,14 +1010,61 @@ mod tests {
         session.save(&dir).unwrap();
 
         let id: MakiId = session.id;
-        let (history, recorded, usage, model) = load_history_from(&dir, id).unwrap();
-        assert_eq!(model, "anthropic/test-model");
+        let restored = load_history_from(&dir, id).unwrap();
+        assert_eq!(restored.model, "anthropic/test-model");
         assert_eq!(
-            serde_json::to_value(&history).unwrap(),
+            serde_json::to_value(&restored.history).unwrap(),
             serde_json::to_value(&messages).unwrap()
         );
-        assert_eq!(recorded, Some(PathBuf::from("/project")));
-        assert_eq!(usage, session.token_usage);
+        assert_eq!(restored.cwd, Some(PathBuf::from("/project")));
+        assert_eq!(restored.usage, session.token_usage);
+    }
+
+    /// Resuming must bill what the session actually paid. If `by_model` came
+    /// back empty or lost its recorded costs, ACP would re-price the restored
+    /// total against today's table and disagree with the TUI.
+    #[test]
+    fn load_history_prices_a_resumed_session_at_what_it_paid() {
+        let tmp = TempDir::new().unwrap();
+        let dir = StateDir::from_path(tmp.path().to_path_buf());
+        let mut session: Session<Message, TokenUsage, maki_agent::ToolOutput> =
+            Session::new(RETIRED_SPEC, "/project");
+        session.token_usage = TokenUsage {
+            input: 1_000_000,
+            output: 200_000,
+            ..Default::default()
+        };
+        session.add_model_usage(
+            RETIRED_MODEL_ID,
+            StoredTokenUsage {
+                input: 1_000_000,
+                output: 200_000,
+                cost: Some(RECORDED_COST),
+                ..Default::default()
+            },
+        );
+        session.save(&dir).unwrap();
+
+        let mut restored = load_history_from(&dir, session.id).unwrap();
+        assert_eq!(
+            restored.by_model[RETIRED_MODEL_ID].cost,
+            Some(RECORDED_COST),
+            "the per-model breakdown survives the file"
+        );
+
+        // Mirrors `load_session`: the recorded spec no longer parses, so the
+        // selected model stands in, and that must not change the bill.
+        let recorded_model = Model::from_spec(&restored.model)
+            .unwrap_or_else(|_| Model::from_spec(SELECTED_SPEC).expect("a shipped model"));
+        assert_eq!(
+            settle_session(
+                &restored.usage,
+                &mut restored.by_model,
+                &recorded_model,
+                RESTORED_FAST
+            ),
+            Some(RECORDED_COST)
+        );
     }
 
     #[test]
@@ -1003,8 +1074,7 @@ mod tests {
         let mut session: Session<Message, TokenUsage, maki_agent::ToolOutput> =
             Session::new("anthropic/test-model", "relative/project");
         session.save(&dir).unwrap();
-        let (_, recorded, _, _) = load_history_from(&dir, session.id).unwrap();
-        assert_eq!(recorded, None);
+        assert_eq!(load_history_from(&dir, session.id).unwrap().cwd, None);
     }
 
     #[test]

--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -97,7 +97,7 @@ fn finish_compact(
         message: response.message.clone(),
         usage: response.usage,
         model: model.id.clone(),
-        cost: model.cost_of(&response.usage, false),
+        cost: model.billed_cost(&response.usage, false),
         context_size: Some(response.usage.output),
         context_window: model.context_window,
     })));

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -409,7 +409,7 @@ impl<'h> Agent<'h> {
                 model: self.model.id.clone(),
                 cost: self
                     .model
-                    .cost_of(&response.usage, self.opts.clamped(&self.model).fast),
+                    .billed_cost(&response.usage, self.opts.clamped(&self.model).fast),
                 context_size: Some(response.usage.context_tokens()),
                 context_window: self.model.context_window,
             })))

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -524,6 +524,16 @@ fn write_section(out: &mut String, section: &ProviderSection) {
         let _ = writeln!(out, "- **Features**: {features}");
     }
 
+    // Rendered from the schedule, so the docs cannot drift from what we bill.
+    if let Some(schedule) = ManifestRegistry::get(&section.kind.to_string())
+        .and_then(|manifest| manifest.pricing_schedule)
+    {
+        let _ = writeln!(
+            out,
+            "- **Peak pricing**: the prices below are off-peak; each turn is billed as it happens, at {schedule}"
+        );
+    }
+
     let _ = writeln!(out);
 
     if section.entries.is_empty() {

--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -2,16 +2,19 @@ pub(crate) mod error;
 pub mod manifest;
 pub mod model;
 pub mod model_registry;
+pub mod pricing;
 pub mod provider;
 pub(crate) mod providers;
 pub mod retry;
 pub(crate) mod types;
 
 pub use error::AgentError;
+pub use maki_storage::sessions::add_cost;
 pub use model::{
     FastPricing, Model, ModelEntry, ModelError, ModelFamily, ModelInfo, ModelPricing, ModelTier,
-    ThinkingSupport, TokenUsage, add_cost, format_tokens,
+    ThinkingSupport, TokenUsage, format_tokens,
 };
+pub use pricing::{model_cost, settle_session};
 pub use providers::Timeouts;
 pub use providers::catalog::ProviderData;
 pub use providers::catalog::{

--- a/maki-providers/src/manifest.rs
+++ b/maki-providers/src/manifest.rs
@@ -1,4 +1,5 @@
 use crate::model::{ModelEntry, ModelFamily, ModelTier};
+use crate::pricing::PricingSchedule;
 use crate::providers::{
     anthropic, aperture, copilot, custom, deepseek, dynamic, google, llama_cpp, mistral, ollama,
     openai, openrouter, synthetic, tensorx, xai, zai,
@@ -14,6 +15,9 @@ pub struct ProviderManifest {
     pub fallback_max_output: Option<u32>,
     pub fallback_context_window: u32,
     pub models: &'static [ModelEntry],
+    /// Set by the providers whose rates move with the wall clock, so the hours
+    /// sit next to the prices they scale. Everyone else bills flat.
+    pub pricing_schedule: Option<&'static PricingSchedule>,
 }
 
 const ANTHROPIC: ProviderManifest = ProviderManifest {
@@ -25,6 +29,7 @@ const ANTHROPIC: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(128_000),
     fallback_context_window: 200_000,
     models: anthropic::models(),
+    pricing_schedule: None,
 };
 
 const OPENAI: ProviderManifest = ProviderManifest {
@@ -36,6 +41,7 @@ const OPENAI: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(100_000),
     fallback_context_window: 200_000,
     models: openai::models(),
+    pricing_schedule: None,
 };
 
 const GOOGLE: ProviderManifest = ProviderManifest {
@@ -47,6 +53,7 @@ const GOOGLE: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(65_536),
     fallback_context_window: 1_000_000,
     models: google::models(),
+    pricing_schedule: None,
 };
 
 const COPILOT: ProviderManifest = ProviderManifest {
@@ -58,6 +65,7 @@ const COPILOT: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(100_000),
     fallback_context_window: 200_000,
     models: copilot::models(),
+    pricing_schedule: None,
 };
 
 const OLLAMA: ProviderManifest = ProviderManifest {
@@ -69,6 +77,7 @@ const OLLAMA: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(16_384),
     fallback_context_window: 128_000,
     models: ollama::models(),
+    pricing_schedule: None,
 };
 
 const LLAMA_CPP: ProviderManifest = ProviderManifest {
@@ -80,6 +89,7 @@ const LLAMA_CPP: ProviderManifest = ProviderManifest {
     fallback_max_output: None,
     fallback_context_window: 128_000,
     models: llama_cpp::models(),
+    pricing_schedule: None,
 };
 
 const MISTRAL: ProviderManifest = ProviderManifest {
@@ -91,6 +101,7 @@ const MISTRAL: ProviderManifest = ProviderManifest {
     fallback_max_output: None,
     fallback_context_window: 128_000,
     models: mistral::models(),
+    pricing_schedule: None,
 };
 
 const ZAI: ProviderManifest = ProviderManifest {
@@ -102,6 +113,7 @@ const ZAI: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(16_000),
     fallback_context_window: 128_000,
     models: zai::models(),
+    pricing_schedule: None,
 };
 
 const DEEPSEEK: ProviderManifest = ProviderManifest {
@@ -113,6 +125,7 @@ const DEEPSEEK: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(384_000),
     fallback_context_window: 1_000_000,
     models: deepseek::models(),
+    pricing_schedule: Some(&deepseek::PEAK_HOURS),
 };
 
 const OPENROUTER: ProviderManifest = ProviderManifest {
@@ -124,6 +137,7 @@ const OPENROUTER: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(128_000),
     fallback_context_window: 200_000,
     models: openrouter::models(),
+    pricing_schedule: None,
 };
 
 const SYNTHETIC: ProviderManifest = ProviderManifest {
@@ -135,6 +149,7 @@ const SYNTHETIC: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(32_000),
     fallback_context_window: 128_000,
     models: synthetic::models(),
+    pricing_schedule: None,
 };
 
 const TENSORX: ProviderManifest = ProviderManifest {
@@ -146,6 +161,7 @@ const TENSORX: ProviderManifest = ProviderManifest {
     fallback_max_output: None,
     fallback_context_window: 200_000,
     models: tensorx::models(),
+    pricing_schedule: None,
 };
 
 const OPENCODE: ProviderManifest = ProviderManifest {
@@ -157,6 +173,7 @@ const OPENCODE: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(128_000),
     fallback_context_window: 256_000,
     models: &[],
+    pricing_schedule: None,
 };
 
 const XAI: ProviderManifest = ProviderManifest {
@@ -168,6 +185,7 @@ const XAI: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(131_072),
     fallback_context_window: 500_000,
     models: xai::models(),
+    pricing_schedule: None,
 };
 
 const OPENCODE_GO: ProviderManifest = ProviderManifest {
@@ -179,6 +197,7 @@ const OPENCODE_GO: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(64_000),
     fallback_context_window: 128_000,
     models: &[],
+    pricing_schedule: None,
 };
 
 const APERTURE: ProviderManifest = ProviderManifest {
@@ -190,6 +209,7 @@ const APERTURE: ProviderManifest = ProviderManifest {
     fallback_max_output: Some(16_384),
     fallback_context_window: 128_000,
     models: aperture::models(),
+    pricing_schedule: None,
 };
 
 const BUILTINS: &[ProviderManifest] = &[

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -9,6 +9,7 @@ use std::ops::AddAssign;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use jiff::Timestamp;
 use maki_config::ModelPolicy;
 use maki_storage::sessions::{MIN_THINKING_BUDGET, StoredTokenUsage};
 use serde::{Deserialize, Serialize};
@@ -382,9 +383,24 @@ impl Model {
         format!("{}/{}", self.provider, self.id)
     }
 
+    /// What the provider charges right now, so it is only ever correct for a
+    /// turn that just finished: under a
+    /// [`PricingSchedule`](crate::pricing::PricingSchedule) the answer moves
+    /// with the clock. Anything historical wants [`Self::list_cost`].
+    ///
     /// `None` on an unpriced model (oauth, local), so callers can hide the cost
     /// instead of showing a misleading "$0.000".
-    pub fn cost_of(&self, usage: &TokenUsage, fast: bool) -> Option<f64> {
+    pub fn billed_cost(&self, usage: &TokenUsage, fast: bool) -> Option<f64> {
+        let cost = self.list_cost(usage, fast)?;
+        let schedule = ManifestRegistry::for_slug(&self.provider).and_then(|m| m.pricing_schedule);
+        Some(schedule.map_or(cost, |s| cost * s.multiplier_at(Timestamp::now())))
+    }
+
+    /// The quoted rates, with no wall-clock surcharge. Deterministic, which is
+    /// what makes it right for re-pricing a session whose turns never recorded
+    /// what they paid: the rate back then is unknown, and the table price is
+    /// the honest guess.
+    pub fn list_cost(&self, usage: &TokenUsage, fast: bool) -> Option<f64> {
         (!self.pricing.is_zero()).then(|| usage.cost(&self.pricing, fast))
     }
 
@@ -532,18 +548,20 @@ impl From<StoredTokenUsage> for TokenUsage {
     }
 }
 
-impl From<TokenUsage> for StoredTokenUsage {
-    fn from(u: TokenUsage) -> Self {
-        Self {
-            input: u.input,
-            output: u.output,
-            cache_creation: u.cache_creation,
-            cache_read: u.cache_read,
+impl TokenUsage {
+    /// Ready to store, with what the turn was billed. No `From<TokenUsage>` on
+    /// purpose: a caller that forgets the cost quietly loses money from the
+    /// session total, so saying it out loud is mandatory.
+    pub fn billed(&self, cost: Option<f64>) -> StoredTokenUsage {
+        StoredTokenUsage {
+            input: self.input,
+            output: self.output,
+            cache_creation: self.cache_creation,
+            cache_read: self.cache_read,
+            cost,
         }
     }
-}
 
-impl TokenUsage {
     pub fn total_input(&self) -> u32 {
         self.input
             .saturating_add(self.cache_read)
@@ -575,7 +593,9 @@ impl TokenUsage {
         }
     }
 
-    pub fn cost(&self, pricing: &ModelPricing, fast: bool) -> f64 {
+    /// Crate-private on purpose: pricing outside [`Model`] skips the provider's
+    /// schedule.
+    pub(crate) fn cost(&self, pricing: &ModelPricing, fast: bool) -> f64 {
         let (input, output, cache_write, cache_read) = match &pricing.fast {
             Some(f) if fast => (
                 f.input,
@@ -594,13 +614,6 @@ impl TokenUsage {
             + self.output as f64 * output / PER_MILLION
             + self.cache_creation as f64 * cache_write / PER_MILLION
             + self.cache_read as f64 * cache_read / PER_MILLION
-    }
-}
-
-/// A total stays `None` (unpriced) until the first priced turn shows up.
-pub fn add_cost(total: &mut Option<f64>, turn: Option<f64>) {
-    if let Some(turn) = turn {
-        *total = Some(total.unwrap_or_default() + turn);
     }
 }
 
@@ -646,6 +659,27 @@ mod tests {
         ModelTier::Strong,
         ModelTier::Compaction,
     ];
+
+    const EPSILON: f64 = 1e-10;
+    /// The only builtin whose rates move with the wall clock.
+    const SCHEDULED_PROVIDERS: [&str; 1] = ["deepseek"];
+    const DEEPSEEK_SPEC: &str = "deepseek/deepseek-v4-pro";
+    const UNPRICED_DEEPSEEK_SPEC: &str = "deepseek/my-custom-model";
+    const MILLION: u32 = 1_000_000;
+    const INPUT_ONLY: TokenUsage = TokenUsage {
+        input: MILLION,
+        output: 0,
+        cache_creation: 0,
+        cache_read: 0,
+    };
+    /// Four counters that cannot be confused with each other.
+    const COUNTERS: TokenUsage = TokenUsage {
+        input: 11,
+        output: 22,
+        cache_creation: 33,
+        cache_read: 44,
+    };
+    const RECORDED_COST: f64 = 0.25;
 
     #[test_case(999, "999"         ; "under_thousand")]
     #[test_case(1_000, "1.0k"      ; "thousand")]
@@ -1047,5 +1081,73 @@ mod tests {
         );
         assert_eq!(wrapped.spec(), format!("my-ollama-wrap/{model_id}"));
         assert_eq!(wrapped.context_window, expected_window);
+    }
+
+    /// A schedule hung on the wrong manifest silently doubles every turn of a
+    /// provider that bills flat.
+    #[test]
+    fn only_deepseek_bills_by_the_clock() {
+        let scheduled: Vec<&str> = ManifestRegistry::builtins()
+            .iter()
+            .filter(|m| m.pricing_schedule.is_some())
+            .map(|m| m.slug)
+            .collect();
+        assert_eq!(scheduled, SCHEDULED_PROVIDERS);
+    }
+
+    /// Nothing else pins the wiring: a real DeepSeek model has to pick the
+    /// schedule up out of its manifest, and `list_cost` has to stay out of it.
+    /// `billed_cost` reads the real clock, so the expectation is sampled either
+    /// side of the call in case the hour ticks over mid-test.
+    #[test]
+    fn deepseek_bills_its_peak_surcharge_on_top_of_the_table() {
+        let model = Model::from_spec(DEEPSEEK_SPEC).unwrap();
+        let schedule = ManifestRegistry::for_slug(&model.provider)
+            .and_then(|m| m.pricing_schedule)
+            .expect("deepseek bills by the clock");
+
+        let list = model.list_cost(&INPUT_ONLY, false).unwrap();
+        let table_price = f64::from(INPUT_ONLY.input) * model.pricing.input / PER_MILLION;
+        assert!(
+            (list - table_price).abs() < EPSILON,
+            "list_cost {list} must be the table price {table_price}, surcharge free"
+        );
+
+        let before = schedule.multiplier_at(Timestamp::now());
+        let billed = model.billed_cost(&INPUT_ONLY, false).unwrap();
+        let after = schedule.multiplier_at(Timestamp::now());
+        assert!(
+            [before, after]
+                .iter()
+                .any(|multiplier| (billed - list * multiplier).abs() < EPSILON),
+            "billed {billed} is not {list} scaled by the schedule ({before} or {after})"
+        );
+    }
+
+    /// A schedule must not turn "no price" into "$0.000". Callers hide `None`,
+    /// and any multiple of nothing is still nothing.
+    #[test]
+    fn unpriced_models_stay_unpriced_under_a_schedule() {
+        let model = Model::from_spec(UNPRICED_DEEPSEEK_SPEC).unwrap();
+        assert!(model.pricing.is_zero());
+        assert_eq!(model.list_cost(&INPUT_ONLY, false), None);
+        assert_eq!(model.billed_cost(&INPUT_ONLY, false), None);
+    }
+
+    /// Every later total is rebuilt from what was stored, so storing a turn must
+    /// not shuffle the counters, invent one, or drop the cost.
+    #[test]
+    fn billed_stores_every_counter_and_the_cost() {
+        assert_eq!(
+            COUNTERS.billed(Some(RECORDED_COST)),
+            StoredTokenUsage {
+                input: COUNTERS.input,
+                output: COUNTERS.output,
+                cache_creation: COUNTERS.cache_creation,
+                cache_read: COUNTERS.cache_read,
+                cost: Some(RECORDED_COST),
+            }
+        );
+        assert_eq!(COUNTERS.billed(None).cost, None);
     }
 }

--- a/maki-providers/src/pricing.rs
+++ b/maki-providers/src/pricing.rs
@@ -1,0 +1,395 @@
+//! What a turn, and a whole session, cost.
+//!
+//! Rates live on the model. Turning them into a bill happens here: the
+//! wall-clock schedules that scale them, and how a stored session's total comes
+//! back. The rule everything else leans on is that a turn is priced once, when
+//! it runs, and that number is what gets stored, summed and shown. History is
+//! never re-priced, because rates move.
+
+use std::collections::HashMap;
+use std::fmt;
+
+use jiff::Timestamp;
+use maki_storage::sessions::StoredTokenUsage;
+
+use crate::model::{Model, TokenUsage};
+
+const HOURS_PER_DAY: u8 = 24;
+const SECONDS_PER_HOUR: i64 = 3_600;
+const SECONDS_PER_DAY: i64 = HOURS_PER_DAY as i64 * SECONDS_PER_HOUR;
+/// Multiplier of a provider that bills the same rate around the clock.
+pub(crate) const FLAT_RATE: f64 = 1.0;
+
+/// Rates that move with the wall clock. DeepSeek doubles everything during its
+/// peak UTC hours, so model tables quote the off-peak rates and the provider's
+/// schedule scales the bill inside its windows. The next price change is then a
+/// constant edit instead of new code.
+///
+/// One multiplier is enough while providers move all four rates together.
+#[derive(Debug)]
+pub struct PricingSchedule {
+    windows: &'static [PricingWindow],
+    multiplier: f64,
+}
+
+/// Half-open `[start, end)` in whole UTC hours. `start > end` wraps past
+/// midnight, so a window never needs splitting in two.
+#[derive(Debug)]
+pub struct PricingWindow {
+    start: u8,
+    end: u8,
+}
+
+impl PricingWindow {
+    /// `hours(22, 2)` wraps past midnight. Every window is a `const`, so a typo
+    /// here is a build error rather than a mispriced turn.
+    pub const fn hours(start: u8, end: u8) -> Self {
+        assert!(start < HOURS_PER_DAY, "window starts after the day ends");
+        assert!(end <= HOURS_PER_DAY, "window ends after the day ends");
+        assert!(start != end, "window covers no time at all");
+        Self { start, end }
+    }
+
+    fn contains(&self, hour: u8) -> bool {
+        if self.start < self.end {
+            hour >= self.start && hour < self.end
+        } else {
+            hour >= self.start || hour < self.end
+        }
+    }
+}
+
+/// `01:00-04:00`, the shape provider docs quote peak hours in.
+impl fmt::Display for PricingWindow {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:02}:00-{:02}:00", self.start, self.end)
+    }
+}
+
+impl PricingSchedule {
+    pub const fn new(windows: &'static [PricingWindow], multiplier: f64) -> Self {
+        assert!(
+            !windows.is_empty(),
+            "a schedule with no windows never applies; drop it instead"
+        );
+        assert!(
+            multiplier > FLAT_RATE,
+            "model tables quote the off-peak rates, so a schedule only ever adds a surcharge"
+        );
+        Self {
+            windows,
+            multiplier,
+        }
+    }
+
+    pub(crate) fn multiplier_at(&self, at: Timestamp) -> f64 {
+        let hour = (at.as_second().rem_euclid(SECONDS_PER_DAY) / SECONDS_PER_HOUR) as u8;
+        if self.windows.iter().any(|w| w.contains(hour)) {
+            self.multiplier
+        } else {
+            FLAT_RATE
+        }
+    }
+}
+
+/// `2x during 01:00-04:00, 06:00-10:00 UTC`. Docs and hints render this rather
+/// than restate the hours in prose that drifts.
+impl fmt::Display for PricingSchedule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}x during ", self.multiplier)?;
+        for (i, window) in self.windows.iter().enumerate() {
+            if i > 0 {
+                f.write_str(", ")?;
+            }
+            write!(f, "{window}")?;
+        }
+        f.write_str(" UTC")
+    }
+}
+
+/// The bill a stored session ran up. Status bar, `/usage`, ACP and headless all
+/// come here, so they cannot disagree about the same session.
+///
+/// Turns record what they paid, so summing those is the truth. What was written
+/// before that kept counters only, and its estimate against today's table is
+/// settled into the entry here, once: after a later turn merges its own cost in,
+/// the counters no longer say which of them was already paid for, so estimating
+/// again would drop everything the entry had before. Counters with no breakdown
+/// get one seeded, so there is always somewhere to settle into.
+///
+/// `None` when nothing here is priced (oauth, local models), so callers show no
+/// cost instead of a made up "$0.000".
+pub fn settle_session(
+    total: &TokenUsage,
+    by_model: &mut HashMap<String, StoredTokenUsage>,
+    current: &Model,
+    fast: bool,
+) -> Option<f64> {
+    if by_model.is_empty() && *total != TokenUsage::default() {
+        by_model.insert(current.id.clone(), total.billed(None));
+    }
+    for (id, usage) in by_model.iter_mut() {
+        usage.cost = model_cost(id, usage, current, fast);
+    }
+    by_model
+        .values()
+        .filter_map(|usage| usage.cost)
+        .reduce(|total, cost| total + cost)
+}
+
+/// One model's slice of [`settle_session`], as `/usage` breaks it down per row.
+/// Usage is keyed by bare model id, so resolving it needs the session's
+/// provider put back in front.
+pub fn model_cost(id: &str, usage: &StoredTokenUsage, current: &Model, fast: bool) -> Option<f64> {
+    if let Some(cost) = usage.cost {
+        return Some(cost);
+    }
+    if id == current.id {
+        return current.list_cost(&(*usage).into(), fast);
+    }
+    Model::from_spec(id)
+        .or_else(|_| Model::from_spec(&format!("{}/{}", current.provider, id)))
+        .ok()?
+        .list_cost(&(*usage).into(), fast)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::ManifestRegistry;
+    use crate::model::{FastPricing, ModelFamily, ModelPricing, ModelTier};
+    use std::sync::Arc;
+    use test_case::test_case;
+
+    const SECONDS_PER_MINUTE: i64 = 60;
+    const PEAK: f64 = 2.0;
+    const DAYS_SINCE_EPOCH: i64 = 20_000;
+    const PEAK_WINDOWS: &[PricingWindow] =
+        &[PricingWindow::hours(1, 4), PricingWindow::hours(6, 10)];
+    const WRAPPING_WINDOW: &[PricingWindow] = &[PricingWindow::hours(22, 2)];
+    const UNTIL_MIDNIGHT_WINDOW: &[PricingWindow] = &[PricingWindow::hours(22, HOURS_PER_DAY)];
+    const WHOLE_DAY_WINDOW: &[PricingWindow] = &[PricingWindow::hours(0, HOURS_PER_DAY)];
+    const LAST_MINUTE: i64 = 59;
+    const LAST_SECOND: i64 = 59;
+
+    const CURRENT: &str = "current";
+    const INPUT_RATE: f64 = 3.0;
+    const UNPRICED: f64 = 0.0;
+    const ONE_MILLION: u32 = 1_000_000;
+    /// [`ONE_MILLION`] input tokens at [`INPUT_RATE`].
+    const LIST_PRICE: f64 = 3.0;
+    const RECORDED: f64 = 0.5;
+    const UNRESOLVABLE: &str = "a-model-no-table-has-ever-heard-of";
+    const ALSO_UNRESOLVABLE: &str = "another-model-no-table-has-ever-heard-of";
+    const FAST_INPUT_RATE: f64 = 12.0;
+    /// [`ONE_MILLION`] input tokens at [`FAST_INPUT_RATE`].
+    const FAST_LIST_PRICE: f64 = 12.0;
+    /// A real spec, so the bare-id fallback runs against the real tables.
+    const SCHEDULED_SPEC: &str = "deepseek/deepseek-v4-pro";
+
+    fn utc(day: i64, hour: i64, minute: i64, second: i64) -> Timestamp {
+        Timestamp::from_second(
+            day * SECONDS_PER_DAY + hour * SECONDS_PER_HOUR + minute * SECONDS_PER_MINUTE + second,
+        )
+        .expect("timestamp in range")
+    }
+
+    fn model(id: &str, input_rate: f64) -> Model {
+        Model {
+            id: id.into(),
+            provider: Arc::from("anthropic"),
+            tier: ModelTier::Medium,
+            family: ModelFamily::Claude,
+            supports_tool_examples_override: None,
+            thinking_override: None,
+            supports_vision_override: None,
+            pricing: ModelPricing {
+                input: input_rate,
+                ..ModelPricing::ZERO
+            },
+            max_output_tokens: None,
+            context_window: 0,
+            thinking_fields: None,
+        }
+    }
+
+    fn stored(cost: Option<f64>) -> StoredTokenUsage {
+        StoredTokenUsage {
+            input: ONE_MILLION,
+            cost,
+            ..Default::default()
+        }
+    }
+
+    fn breakdown(entries: &[(&str, Option<f64>)]) -> HashMap<String, StoredTokenUsage> {
+        entries
+            .iter()
+            .map(|(id, cost)| ((*id).to_owned(), stored(*cost)))
+            .collect()
+    }
+
+    /// Windows are half-open down to the second, since an off-by-one bills a
+    /// whole hour at the wrong rate. Every case also runs on a day before the
+    /// epoch, where the timestamp is negative and must not wrap into another
+    /// window.
+    #[test_case(PEAK_WINDOWS, 0, LAST_MINUTE, LAST_SECOND, FLAT_RATE ; "last_second_before_the_start")]
+    #[test_case(PEAK_WINDOWS, 1, 0, 0, PEAK                          ; "first_second_of_a_window")]
+    #[test_case(PEAK_WINDOWS, 3, LAST_MINUTE, LAST_SECOND, PEAK      ; "last_second_inside")]
+    #[test_case(PEAK_WINDOWS, 4, 0, 0, FLAT_RATE                     ; "first_second_after_the_end")]
+    #[test_case(PEAK_WINDOWS, 7, 15, 0, PEAK                         ; "second_window")]
+    #[test_case(PEAK_WINDOWS, 23, 0, 0, FLAT_RATE                    ; "after_the_last_window")]
+    #[test_case(WRAPPING_WINDOW, 23, 0, 0, PEAK                      ; "wrapping_before_midnight")]
+    #[test_case(WRAPPING_WINDOW, 0, 0, 0, PEAK                       ; "wrapping_across_midnight")]
+    #[test_case(WRAPPING_WINDOW, 21, LAST_MINUTE, LAST_SECOND, FLAT_RATE ; "wrapping_start_is_half_open")]
+    #[test_case(WRAPPING_WINDOW, 2, 0, 0, FLAT_RATE                  ; "wrapping_end_is_half_open")]
+    #[test_case(UNTIL_MIDNIGHT_WINDOW, 23, LAST_MINUTE, LAST_SECOND, PEAK ; "ends_at_midnight")]
+    #[test_case(UNTIL_MIDNIGHT_WINDOW, 0, 0, 0, FLAT_RATE            ; "ending_at_midnight_does_not_wrap")]
+    #[test_case(WHOLE_DAY_WINDOW, 0, 0, 0, PEAK                      ; "whole_day_starts_at_midnight")]
+    #[test_case(WHOLE_DAY_WINDOW, 23, LAST_MINUTE, LAST_SECOND, PEAK ; "whole_day_never_leaves_peak")]
+    fn windows_price_by_the_utc_clock(
+        windows: &'static [PricingWindow],
+        hour: i64,
+        minute: i64,
+        second: i64,
+        expected: f64,
+    ) {
+        let schedule = PricingSchedule::new(windows, PEAK);
+        for day in [DAYS_SINCE_EPOCH, -DAYS_SINCE_EPOCH] {
+            assert_eq!(
+                schedule.multiplier_at(utc(day, hour, minute, second)),
+                expected,
+                "day {day}"
+            );
+        }
+    }
+
+    #[test]
+    fn schedules_render_the_hours_they_bill() {
+        assert_eq!(
+            PricingSchedule::new(PEAK_WINDOWS, PEAK).to_string(),
+            "2x during 01:00-04:00, 06:00-10:00 UTC"
+        );
+        assert_eq!(
+            PricingSchedule::new(WRAPPING_WINDOW, PEAK).to_string(),
+            "2x during 22:00-02:00 UTC"
+        );
+    }
+
+    /// Each entry bills [`ONE_MILLION`] input tokens, so a row worth
+    /// [`LIST_PRICE`] came from the price table and [`RECORDED`] came from the
+    /// turn itself. A breakdown nothing can price is not a free session:
+    /// `Some(0.0)` would put a confident "$0.000" on screen.
+    #[test_case(&[(UNRESOLVABLE, Some(RECORDED)), (ALSO_UNRESOLVABLE, Some(RECORDED))], INPUT_RATE, Some(2.0 * RECORDED) ; "recorded_costs_win_over_the_price_table")]
+    #[test_case(&[(CURRENT, None), (UNRESOLVABLE, None)], INPUT_RATE, Some(LIST_PRICE)                                   ; "legacy_counters_use_each_models_own_rates")]
+    #[test_case(&[(UNRESOLVABLE, Some(RECORDED)), (CURRENT, None), (ALSO_UNRESOLVABLE, None)], INPUT_RATE, Some(RECORDED + LIST_PRICE) ; "mixed_eras_sum_recorded_and_listed")]
+    #[test_case(&[(UNRESOLVABLE, None)], INPUT_RATE, None                                                               ; "a_breakdown_that_prices_to_nothing")]
+    #[test_case(&[(CURRENT, None)], UNPRICED, None                                                                      ; "unpriced_model_with_a_breakdown")]
+    #[test_case(&[], INPUT_RATE, Some(LIST_PRICE)                                                                       ; "no_breakdown_prices_the_total")]
+    #[test_case(&[], UNPRICED, None                                                                                     ; "no_breakdown_on_an_unpriced_model")]
+    fn session_cost_bills_every_breakdown(
+        entries: &[(&str, Option<f64>)],
+        input_rate: f64,
+        expected: Option<f64>,
+    ) {
+        let current = model(CURRENT, input_rate);
+        let mut by_model = breakdown(entries);
+        let counted = entries.len().max(1) as u32 * ONE_MILLION;
+
+        // With a breakdown the stored running total says nothing about the
+        // bill, so the two drifting apart (compaction, a resume) must not
+        // change the answer.
+        let totals = if entries.is_empty() {
+            vec![counted]
+        } else {
+            vec![counted, 0, 999 * ONE_MILLION]
+        };
+        for input in totals {
+            let total = TokenUsage {
+                input,
+                ..Default::default()
+            };
+            assert_eq!(
+                settle_session(&total, &mut by_model, &current, false),
+                expected,
+                "total of {input} input tokens"
+            );
+        }
+    }
+
+    /// An entry written before turns recorded their cost used to keep only the
+    /// cost of the next turn that touched it, so every later load reported the
+    /// session as costing whatever it last did.
+    #[test_case(&[]                ; "counters_with_no_breakdown")]
+    #[test_case(&[(CURRENT, None)] ; "a_breakdown_written_before_costs")]
+    fn a_settled_estimate_survives_the_next_turn(entries: &[(&str, Option<f64>)]) {
+        let current = model(CURRENT, INPUT_RATE);
+        let mut by_model = breakdown(entries);
+        let total = TokenUsage {
+            input: ONE_MILLION,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            settle_session(&total, &mut by_model, &current, false),
+            Some(LIST_PRICE)
+        );
+
+        *by_model.entry(CURRENT.to_owned()).or_default() += stored(Some(RECORDED));
+
+        assert_eq!(
+            settle_session(&total, &mut by_model, &current, false),
+            Some(LIST_PRICE + RECORDED)
+        );
+    }
+
+    /// The sibling is priced differently on purpose, so passing here cannot be
+    /// `current`'s rates leaking through.
+    #[test]
+    fn bare_ids_resolve_against_the_current_provider() {
+        let current = Model::from_spec(SCHEDULED_SPEC).unwrap();
+        let sibling_id = ManifestRegistry::for_slug(&current.provider)
+            .expect("a builtin provider")
+            .models
+            .iter()
+            .find_map(|e| (e.pricing.input != current.pricing.input).then_some(e.prefixes[0]))
+            .expect("a sibling model the table prices differently");
+        let sibling = Model::from_spec(&format!("{}/{sibling_id}", current.provider)).unwrap();
+        let usage = stored(None);
+
+        let cost = model_cost(sibling_id, &usage, &current, false);
+        assert_eq!(cost, sibling.list_cost(&usage.into(), false));
+        assert_ne!(cost, current.list_cost(&usage.into(), false));
+    }
+
+    /// What was paid is what was paid, even for an id the table prices
+    /// differently, and even for a model that prices to nothing today.
+    #[test_case(INPUT_RATE ; "priced_model")]
+    #[test_case(UNPRICED   ; "unpriced_model")]
+    fn a_recorded_cost_short_circuits_the_price_table(input_rate: f64) {
+        let current = model(CURRENT, input_rate);
+        assert_eq!(
+            model_cost(CURRENT, &stored(Some(RECORDED)), &current, false),
+            Some(RECORDED)
+        );
+    }
+
+    #[test_case(true, &[]                => Some(FAST_LIST_PRICE) ; "fast_seeded_from_the_counters")]
+    #[test_case(true, &[(CURRENT, None)] => Some(FAST_LIST_PRICE) ; "fast_from_a_breakdown")]
+    #[test_case(false, &[(CURRENT, None)] => Some(LIST_PRICE)     ; "standard_from_a_breakdown")]
+    fn fast_rates_reach_the_session_total(
+        fast: bool,
+        entries: &[(&str, Option<f64>)],
+    ) -> Option<f64> {
+        let mut current = model(CURRENT, INPUT_RATE);
+        current.pricing.fast = Some(FastPricing {
+            input: FAST_INPUT_RATE,
+            output: 0.0,
+        });
+        let total = TokenUsage {
+            input: ONE_MILLION,
+            ..Default::default()
+        };
+
+        settle_session(&total, &mut breakdown(entries), &current, fast)
+    }
+}

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -1269,7 +1269,7 @@ mod tests {
         };
         let cost = Model::from_spec(spec)
             .unwrap()
-            .cost_of(&usage, false)
+            .list_cost(&usage, false)
             .unwrap();
         assert!((cost - expected).abs() < 1e-9);
     }

--- a/maki-providers/src/providers/deepseek.rs
+++ b/maki-providers/src/providers/deepseek.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 use tracing::warn;
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
+use crate::pricing::{PricingSchedule, PricingWindow};
 use crate::provider::{BoxFuture, Provider};
 use crate::types::{ProviderUsage, UsageLimit};
 use crate::{
@@ -41,6 +42,13 @@ inventory::submit!(maki_config::providers::BuiltInProvider {
     needs_url: false,
 });
 
+/// Peak hours double every rate, and the tables below quote the off-peak ones.
+/// <https://api-docs.deepseek.com/quick_start/pricing/>
+pub(crate) const PEAK_HOURS: PricingSchedule = PricingSchedule::new(PEAK_WINDOWS, PEAK_MULTIPLIER);
+
+const PEAK_WINDOWS: &[PricingWindow] = &[PricingWindow::hours(1, 4), PricingWindow::hours(6, 10)];
+const PEAK_MULTIPLIER: f64 = 2.0;
+
 pub(crate) const fn models() -> &'static [ModelEntry] {
     &[
         ModelEntry {
@@ -50,10 +58,10 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
             vision: false,
             default: true,
             pricing: ModelPricing {
-                input: 0.14,
-                output: 0.28,
+                input: 0.22,
+                output: 0.66,
                 cache_write: 0.00,
-                cache_read: 0.0028,
+                cache_read: 0.007,
                 fast: None,
             },
             max_output_tokens: Some(384_000),
@@ -66,10 +74,10 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
             vision: false,
             default: true,
             pricing: ModelPricing {
-                input: 0.435,
-                output: 0.87,
+                input: 0.66,
+                output: 1.98,
                 cache_write: 0.00,
-                cache_read: 0.003625,
+                cache_read: 0.022,
                 fast: None,
             },
             max_output_tokens: Some(384_000),
@@ -247,10 +255,27 @@ fn pad_reasoning_content(model_id: &str, body: &mut Value) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::manifest::ManifestRegistry;
     use serde_json::json;
 
     const V4: &str = "deepseek-v4-pro";
     const R1: &str = "deepseek-reasoner";
+    /// The hours and the surcharge as the pricing page states them.
+    const PUBLISHED_PEAK_HOURS: &str = "2x during 01:00-04:00, 06:00-10:00 UTC";
+
+    /// `PEAK_HOURS` only reaches a bill through the manifest, and a schedule
+    /// that never got hooked up looks exactly like off-peak all day. The
+    /// published hours are pinned here too, since either drifting bills every
+    /// DeepSeek turn at the wrong rate.
+    #[test]
+    fn the_manifest_bills_the_published_peak_hours() {
+        let schedule = ManifestRegistry::get(CONFIG.slug)
+            .expect("deepseek is a builtin")
+            .pricing_schedule
+            .expect("deepseek bills by the clock");
+        assert_eq!(schedule.to_string(), PEAK_HOURS.to_string());
+        assert_eq!(PEAK_HOURS.to_string(), PUBLISHED_PEAK_HOURS);
+    }
 
     #[test]
     fn v4_pads_only_assistant_turns_without_reasoning() {

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -83,7 +83,7 @@ pub enum SessionError {
 /// Per-model token breakdown entry. Mirrors the four usage counters tracked by
 /// the active provider; kept storage-local to avoid a circular dependency on
 /// `maki-providers`.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct StoredTokenUsage {
     #[serde(default)]
     pub input: u32,
@@ -93,6 +93,12 @@ pub struct StoredTokenUsage {
     pub cache_creation: u32,
     #[serde(default)]
     pub cache_read: u32,
+    /// What the turns billed, in USD. Prices move (some providers by the hour),
+    /// so re-pricing these counters later would be fiction. `None` on unpriced
+    /// models, and on entries written before we recorded it until the next load
+    /// settles an estimate into them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost: Option<f64>,
 }
 
 impl StoredTokenUsage {
@@ -113,6 +119,16 @@ impl std::ops::AddAssign for StoredTokenUsage {
         self.output = self.output.saturating_add(rhs.output);
         self.cache_creation = self.cache_creation.saturating_add(rhs.cache_creation);
         self.cache_read = self.cache_read.saturating_add(rhs.cache_read);
+        add_cost(&mut self.cost, rhs.cost);
+    }
+}
+
+/// The one way costs are summed, re-exported by `maki-providers` so every
+/// running total agrees: `None` until the first priced turn shows up, and from
+/// there it only grows.
+pub fn add_cost(total: &mut Option<f64>, addend: Option<f64>) {
+    if let Some(addend) = addend {
+        *total = Some(total.unwrap_or_default() + addend);
     }
 }
 
@@ -1535,6 +1551,13 @@ where
         &self.usage_by_model
     }
 
+    /// For settling costs on load; every other write goes through
+    /// [`Self::add_model_usage`].
+    pub fn usage_by_model_mut(&mut self) -> &mut HashMap<String, StoredTokenUsage> {
+        self.touch();
+        &mut self.usage_by_model
+    }
+
     pub fn set_title(&mut self, title: String) {
         if self.title == title {
             return;
@@ -1717,6 +1740,8 @@ mod tests {
     type TestSession = Session<Value, Value, Value>;
 
     const LEGACY_HEX_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
+    const SONNET_COST: f64 = 0.42;
+    const HAIKU_COST: f64 = 0.08;
     const TAMPERED_TITLE: &str = "tampered cached title";
     const PENDING_DRAFT: &str = "half typed thought";
     /// Two of these already break the byte budget.
@@ -1843,6 +1868,7 @@ mod tests {
                 output: 20,
                 cache_creation: 5,
                 cache_read: 40,
+                cost: Some(SONNET_COST),
             },
         );
         session.add_model_usage(
@@ -1850,6 +1876,7 @@ mod tests {
             super::StoredTokenUsage {
                 input: 30,
                 output: 10,
+                cost: Some(HAIKU_COST),
                 ..Default::default()
             },
         );
@@ -1861,7 +1888,96 @@ mod tests {
         assert_eq!(sonnet.output, 20);
         assert_eq!(sonnet.cache_read, 40);
         assert_eq!(sonnet.total_input(), 145);
+        assert_eq!(sonnet.cost, Some(SONNET_COST));
         assert_eq!(loaded.usage_by_model()["claude-haiku-4"].total(), 40);
+        assert_eq!(
+            loaded.usage_by_model()["claude-haiku-4"].cost,
+            Some(HAIKU_COST)
+        );
+    }
+
+    /// A turn that reports no price must not erase what was already billed.
+    #[test_case(None, None, None ; "unpriced_stays_unpriced")]
+    #[test_case(None, Some(SONNET_COST), Some(SONNET_COST) ; "first_price_starts_the_total")]
+    #[test_case(Some(SONNET_COST), Some(HAIKU_COST), Some(SONNET_COST + HAIKU_COST) ; "priced_turns_accumulate")]
+    #[test_case(Some(SONNET_COST), None, Some(SONNET_COST) ; "unpriced_turn_keeps_the_total")]
+    fn add_cost_only_grows_a_total(
+        mut total: Option<f64>,
+        addend: Option<f64>,
+        expected: Option<f64>,
+    ) {
+        super::add_cost(&mut total, addend);
+        assert_eq!(total, expected);
+    }
+
+    fn usage(input: u32, cost: Option<f64>) -> super::StoredTokenUsage {
+        super::StoredTokenUsage {
+            input,
+            cost,
+            ..Default::default()
+        }
+    }
+
+    fn saved_usage_by_model(dir: &Path, id: MakiId) -> Value {
+        let text = fs::read_to_string(jsonl_path(dir, id)).unwrap();
+        let meta = text
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).unwrap())
+            .find(|record| record["t"] == "meta")
+            .expect("saved session has a meta record");
+        meta["usage_by_model"].clone()
+    }
+
+    /// Session files predate `cost`, so an entry without the key loads unpriced
+    /// with its counters intact, and saving it back must not mint one: older
+    /// builds still read these files.
+    #[test]
+    fn legacy_usage_entry_loads_unpriced_and_stays_that_way_on_disk() {
+        let id: MakiId = LEGACY_HEX_ID.parse().unwrap();
+        let json = format!(
+            r#"{{"t":"header","v":2,"id":"{LEGACY_HEX_ID}","model":"m","cwd":"/","created_at":0}}
+{{"t":"meta","title":"t","token_usage":null,"updated_at":0,"usage_by_model":{{"m":{{"input":7,"output":3}}}}}}"#
+        );
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(format!("{LEGACY_HEX_ID}.jsonl")), json).unwrap();
+
+        let mut loaded = TestSession::load_from(id, tmp.path()).unwrap();
+        let entry = loaded.usage_by_model()["m"];
+        assert_eq!(entry.cost, None, "no key means unpriced, not free");
+        assert_eq!((entry.input, entry.output), (7, 3));
+
+        let dir = tmp.path().join("rewritten");
+        fs::create_dir(&dir).unwrap();
+        loaded.save_to(&dir).unwrap();
+        assert!(
+            saved_usage_by_model(&dir, id)["m"].get("cost").is_none(),
+            "an unpriced entry writes no cost key"
+        );
+    }
+
+    /// What a turn billed is written verbatim, read back verbatim, and keeps
+    /// adding up after a reload. A later unpriced turn must not throw away what
+    /// the earlier ones paid.
+    #[test]
+    fn recorded_costs_survive_a_reload_and_keep_adding_up() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let mut session: TestSession = Session::new("anthropic/claude-sonnet-4", "/project");
+        session.add_model_usage("claude-sonnet-4", usage(100, Some(SONNET_COST)));
+        session.add_model_usage("claude-haiku-4", usage(30, None));
+        session.save_to(dir).unwrap();
+
+        let on_disk = saved_usage_by_model(dir, session.id);
+        assert_eq!(on_disk["claude-sonnet-4"]["cost"], Value::from(SONNET_COST));
+
+        let mut loaded = TestSession::load_from(session.id, dir).unwrap();
+        loaded.add_model_usage("claude-sonnet-4", usage(50, None));
+        loaded.add_model_usage("claude-haiku-4", usage(10, Some(HAIKU_COST)));
+
+        let sonnet = loaded.usage_by_model()["claude-sonnet-4"];
+        assert_eq!((sonnet.input, sonnet.cost), (150, Some(SONNET_COST)));
+        let haiku = loaded.usage_by_model()["claude-haiku-4"];
+        assert_eq!((haiku.input, haiku.cost), (40, Some(HAIKU_COST)));
     }
 
     #[test]

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -1242,10 +1242,11 @@ impl App {
 
         if let AgentEvent::TurnComplete(ref tc) = envelope.event {
             self.state.token_usage += tc.usage;
+            add_cost(&mut self.state.cost, tc.cost);
             add_cost(&mut self.chats[chat_idx].cost, tc.cost);
             self.state
                 .session_mut()
-                .add_model_usage(&tc.model, tc.usage.into());
+                .add_model_usage(&tc.model, tc.usage.billed(tc.cost));
             let ctx_size = tc.context_size.unwrap_or_else(|| tc.usage.context_tokens());
             self.chats[chat_idx].context_size = ctx_size;
             if chat_idx == 0 {

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -194,12 +194,7 @@ impl App {
             &self.ui_config.tool_output_lines,
         );
         self.main_chat().load_messages(display_msgs);
-        // The restored total predates any per-turn cost, so price it once with the
-        // selected model. Later turns add their own exact cost.
-        let cost = self
-            .state
-            .model
-            .cost_of(&self.state.token_usage, self.state.fast);
+        let cost = self.state.cost;
         let context_size = self.state.context_size;
         let main = self.main_chat();
         main.cost = cost;
@@ -289,6 +284,7 @@ impl App {
         self.checkpoint_now();
         self.reset_ui_chrome();
         self.state.token_usage = TokenUsage::default();
+        self.state.cost = None;
         self.state.context_size = 0;
         self.state.plan = PlanState::None;
         if self.state.mode == Mode::Plan {

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use maki_config::{Effect, ModelPolicy};
 use maki_providers::provider::adjust_model;
-use maki_providers::{Model, ThinkingConfig, Timeouts, TokenUsage};
+use maki_providers::{Model, ThinkingConfig, Timeouts, TokenUsage, settle_session};
 use maki_storage::StateDir;
 use maki_storage::sessions::{StoredEffect, StoredMode, StoredRule};
 
@@ -16,6 +16,10 @@ pub(crate) struct SessionState {
     pub session: Arc<AppSession>,
     pub model: Model,
     pub token_usage: TokenUsage,
+    /// What the session has billed so far: the restored total plus every turn
+    /// since. Kept running, because re-deriving it from the counters would
+    /// re-price history at today's rates. `None` while nothing was priced.
+    pub cost: Option<f64>,
     pub context_size: u32,
     pub mode: Mode,
     pub plan: PlanState,
@@ -77,7 +81,9 @@ impl SessionState {
             plan.allocate_path(storage);
         }
 
+        let fast = session.meta.fast && model.supports_fast();
         let token_usage = session.token_usage;
+        let cost = settle_session(&token_usage, session.usage_by_model_mut(), &model, fast);
         let context_size = session.meta.context_size;
 
         Self {
@@ -89,11 +95,12 @@ impl SessionState {
                 .map(Into::into)
                 .filter(|_| model.supports_thinking())
                 .unwrap_or_default(),
-            fast: session.meta.fast && model.supports_fast(),
+            fast,
             workflow: session.meta.workflow,
             session: Arc::new(session),
             model,
             token_usage,
+            cost,
             context_size,
             mode,
             plan,
@@ -200,14 +207,83 @@ pub(crate) fn stored_to_rules(stored: &[StoredRule]) -> Vec<maki_config::Permiss
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::components::test_model;
+    use crate::components::{test_model, test_pricing};
+    use maki_providers::{FastPricing, ModelPricing};
     use maki_storage::sessions::StoredThinking;
+    use test_case::test_case;
+
+    const RECORDED_COST: f64 = 0.42;
+    /// A round million, so a per-million rate reads straight off the bill.
+    const MILLION_INPUT: TokenUsage = TokenUsage {
+        input: 1_000_000,
+        output: 0,
+        cache_creation: 0,
+        cache_read: 0,
+    };
+    /// [`MILLION_INPUT`] at `test_pricing`'s standard input rate.
+    const LIST_PRICE: f64 = 3.0;
+    /// Twice the standard rate, so a resume that ignores `fast` bills half.
+    const FAST_INPUT_RATE: f64 = 6.0;
+    const UNRESOLVABLE_MODEL: &str = "a-model-no-table-has-ever-heard-of";
+    const FAST_FLAG_LOST: &str = "the model has fast pricing, so the flag must survive as stored";
+
+    fn resumed(session: AppSession, model: &Model) -> SessionState {
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = StateDir::from_path(tmp.path().to_path_buf());
+        SessionState::from_session(session, model, &storage, &ModelPolicy::default())
+    }
+
+    /// An old session: counters, no per-model breakdown.
+    fn session_with_counters() -> AppSession {
+        let mut session = AppSession::new("test-model", "/tmp");
+        session.token_usage = MILLION_INPUT;
+        session
+    }
 
     fn make_plan_session(mode: Option<StoredMode>, plan_path: Option<String>) -> AppSession {
         let mut session = AppSession::new("test-model", "/tmp");
         session.meta.mode = mode;
         session.meta.plan_path = plan_path;
         session
+    }
+
+    /// A resumed session opens on the bill it ran up, not on its counters
+    /// re-priced with whatever model is selected now. The model that recorded
+    /// this one prices to nothing, so only the recorded cost can answer.
+    #[test]
+    fn resumed_session_opens_on_the_cost_its_turns_recorded() {
+        let mut session = session_with_counters();
+        session.add_model_usage(
+            UNRESOLVABLE_MODEL,
+            session.token_usage.billed(Some(RECORDED_COST)),
+        );
+        let state = resumed(session, &test_model());
+        assert_eq!(state.cost, Some(RECORDED_COST));
+    }
+
+    /// Older sessions kept counters only, and those are priced with the
+    /// session's own clamped `fast` flag. A hardcoded `false` would open a
+    /// resumed fast session on half its bill.
+    #[test_case(false => Some(LIST_PRICE)     ; "standard_rates")]
+    #[test_case(true  => Some(FAST_INPUT_RATE) ; "fast_rates")]
+    fn resume_without_a_breakdown_prices_the_counters(fast: bool) -> Option<f64> {
+        let mut session = session_with_counters();
+        session.meta.fast = fast;
+        let model = Model {
+            pricing: ModelPricing {
+                fast: Some(FastPricing {
+                    input: FAST_INPUT_RATE,
+                    output: test_pricing().output,
+                }),
+                ..test_pricing()
+            },
+            ..test_model()
+        };
+
+        let state = resumed(session, &model);
+
+        assert_eq!(state.fast, fast, "{FAST_FLAG_LOST}");
+        state.cost
     }
 
     #[test]

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -891,6 +891,11 @@ const MAIN_TOKENS: TokenUsage = TokenUsage {
     cache_read: 0,
 };
 const MAIN_COST: Option<f64> = Some(0.002);
+const MAIN_MODEL: &str = "main-model";
+
+fn main_turn() -> Msg {
+    agent_msg(turn_complete(MAIN_TOKENS, MAIN_MODEL, MAIN_COST))
+}
 
 fn sub_turn_complete() -> Msg {
     subagent_msg(
@@ -904,6 +909,106 @@ fn sub_turn_complete() -> Msg {
 /// usage, not how it is spelled (maki-providers covers the spelling).
 fn sub_usage_text() -> String {
     SUB_TOKENS.format_sum_cost(SUB_COST)
+}
+
+/// Each turn bills at the rates of the model that ran it, subagent tiers
+/// included, so the session total is the sum of what the turns recorded.
+#[test]
+fn session_cost_sums_what_each_model_recorded() {
+    let mut app = streaming_app();
+    app.update(main_turn());
+    app.update(agent_msg(tool_start(TASK_ID, "task")));
+    app.update(sub_turn_complete());
+
+    let expected = MAIN_COST.unwrap() + SUB_COST.unwrap();
+    assert_eq!(app.state.cost, Some(expected));
+    let stored: f64 = app
+        .state
+        .session
+        .usage_by_model()
+        .values()
+        .filter_map(|u| u.cost)
+        .sum();
+    assert_eq!(stored, expected);
+}
+
+const RESTORED_COST: f64 = 0.42;
+/// Counters big enough that re-pricing them could never land on
+/// [`RESTORED_COST`], so a total derived from them stands out.
+const RESTORED_TOKENS: TokenUsage = TokenUsage {
+    input: 1_000_000,
+    output: 0,
+    cache_creation: 0,
+    cache_read: 0,
+};
+const RESTORED_MODEL: &str = "model-that-ran-before";
+const SIGMA_MISSING: &str = "the status bar must draw the session total";
+const COST_WAS_NOT_BILLED: &str = "the turn must bill something for the reset to prove anything";
+
+/// A new session opens on a clean bill. The total is never re-derived from the
+/// counters, so anything left behind here follows the user forever.
+#[test]
+fn reset_session_clears_the_bill_and_the_model_breakdown() {
+    let mut app = streaming_app();
+    app.update(main_turn());
+    assert_eq!(app.state.cost, MAIN_COST, "{COST_WAS_NOT_BILLED}");
+
+    app.reset_session();
+
+    assert_eq!(app.state.cost, None);
+    assert!(app.state.session.usage_by_model().is_empty());
+}
+
+/// `None` is what hides the cost, so an unpriced turn must leave the total
+/// alone. `Some(0.0)` would advertise a free session.
+#[test_case(None, None ; "unpriced_turns_only")]
+#[test_case(MAIN_COST, MAIN_COST ; "priced_turn_after_an_unpriced_one")]
+fn session_cost_counts_only_priced_turns(second: Option<f64>, expected: Option<f64>) {
+    let mut app = streaming_app();
+    // How an unpriced session opens; `session_state` covers the seeding.
+    app.state.cost = None;
+    app.update(agent_msg(turn_complete(MAIN_TOKENS, MAIN_MODEL, None)));
+
+    app.update(agent_msg(turn_complete(MAIN_TOKENS, MAIN_MODEL, second)));
+
+    assert_eq!(app.state.cost, expected);
+}
+
+/// The restored bill is a running total later turns add to, so a resumed
+/// session shows what it paid back then plus what it pays now, never its
+/// counters re-priced at today's rates.
+#[test]
+fn resumed_session_keeps_adding_to_the_restored_bill() {
+    let mut app = test_app();
+    let mut stored = AppSession::new("test-model", "/tmp");
+    stored.token_usage = RESTORED_TOKENS;
+    stored.add_model_usage(RESTORED_MODEL, RESTORED_TOKENS.billed(Some(RESTORED_COST)));
+
+    app.apply_loaded_session(stored, &test_model());
+    assert_eq!(app.state.cost, Some(RESTORED_COST));
+    assert_eq!(app.chats[0].cost, Some(RESTORED_COST));
+
+    app.status = Status::Streaming;
+    app.run_id = 1;
+    app.update(main_turn());
+
+    assert_eq!(app.state.cost, Some(RESTORED_COST + MAIN_COST.unwrap()));
+}
+
+/// The sigma the status bar draws once subagents split the bill is the session
+/// total itself, so it cannot drift from what `/usage` sums.
+#[test]
+fn status_bar_sigma_draws_the_session_cost() {
+    let mut app = app_with_subagent();
+    app.update(main_turn());
+    app.update(sub_turn_complete());
+
+    let total = app.state.cost.expect("both turns were priced");
+    let sigma = format!("\u{03a3}${total:.3}");
+    assert!(
+        rendered(&mut app).contains(&sigma),
+        "{SIGMA_MISSING}: {sigma}"
+    );
 }
 
 #[test]
@@ -936,11 +1041,7 @@ fn subagent_turn_complete_updates_matching_parent_header_with_last_turn() {
 #[test_case(true  ; "subagent_stamp_is_not_overwritten")]
 fn parent_turn_flush_stamps_the_last_unstamped_tool(subagent_ran: bool) {
     let mut app = streaming_app();
-    app.update(agent_msg(turn_complete(
-        MAIN_TOKENS,
-        "main-model",
-        MAIN_COST,
-    )));
+    app.update(main_turn());
     app.update(agent_msg(tool_start(TASK_ID, "task")));
     if subagent_ran {
         app.update(sub_turn_complete());

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -268,6 +268,7 @@ impl App {
         if self.usage_modal.is_open() {
             let ctx = UsageModalContext {
                 total: &self.state.token_usage,
+                total_cost: self.state.cost,
                 by_model: self.state.session.usage_by_model(),
                 model: &self.state.model,
                 fast: self.state.fast,
@@ -298,10 +299,9 @@ impl App {
                 .as_deref()
                 .unwrap_or(&self.state.session.model),
             stats: UsageStats {
-                global_usage: &self.state.token_usage,
+                global_cost: self.state.cost,
                 context_size: chat.context_size,
                 cost: chat.cost,
-                pricing: &self.state.model.pricing,
                 context_window: self.state.model.context_window,
                 show_global: self.chats.len() > 1,
             },

--- a/maki-ui/src/components/status_bar.rs
+++ b/maki-ui/src/components/status_bar.rs
@@ -8,7 +8,7 @@ use super::{RetryInfo, Status};
 use crate::animation::spinner_frame;
 use crate::theme;
 
-use maki_providers::{ModelPricing, TokenUsage, format_tokens};
+use maki_providers::format_tokens;
 use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::Style;
@@ -23,11 +23,12 @@ const CWD_MODEL_SEPARATOR: &str = "  ";
 const FAST_LABEL: &str = " [fast]";
 const WORKFLOW_LABEL: &str = " [workflow]";
 
-pub struct UsageStats<'a> {
-    pub global_usage: &'a TokenUsage,
+pub struct UsageStats {
+    /// The whole session's bill, drawn next to the focused chat's own once
+    /// subagents make the two differ.
+    pub global_cost: Option<f64>,
     pub context_size: u32,
     pub cost: Option<f64>,
-    pub pricing: &'a ModelPricing,
     pub context_window: u32,
     pub show_global: bool,
 }
@@ -37,7 +38,7 @@ pub struct StatusBarContext<'a> {
     pub mode_label: Cow<'static, str>,
     pub mode_style: Style,
     pub model_id: &'a str,
-    pub stats: UsageStats<'a>,
+    pub stats: UsageStats,
     pub auto_scroll: bool,
     pub chat_name: Option<&'a str>,
     pub retry_info: Option<&'a RetryInfo>,
@@ -209,11 +210,8 @@ impl StatusBar {
                     Style::new().fg(theme::current().foreground),
                 ));
 
-                if ctx.stats.show_global && !ctx.stats.pricing.is_zero() {
-                    let global_text = format!(
-                        " \u{03a3}${:.3} ",
-                        ctx.stats.global_usage.cost(ctx.stats.pricing, ctx.fast),
-                    );
+                if let Some(global) = ctx.stats.global_cost.filter(|_| ctx.stats.show_global) {
+                    let global_text = format!(" \u{03a3}${global:.3} ");
                     rest_spans.push(Span::styled(
                         global_text,
                         Style::new().fg(theme::current().foreground),
@@ -354,6 +352,64 @@ mod tests {
     const FLASH_TTL: Duration = Duration::from_secs(3600);
     const FLASH_MSG: &str = "Copied";
     const STALE_BRANCH: &str = "/nowhere:gone";
+    const BAR_WIDTH: u16 = 120;
+    const MODEL_ID: &str = "test-model";
+    const CONTEXT_SIZE: u32 = 12_000;
+    const CHAT_COST: f64 = 0.25;
+    const CHAT_COST_TEXT: &str = "$0.250";
+    const SESSION_COST: f64 = 1.5;
+    const SESSION_COST_TEXT: &str = "\u{03a3}$1.500";
+    const SIGMA: char = '\u{03a3}';
+
+    fn render(global_cost: Option<f64>, show_global: bool) -> String {
+        let bar = StatusBar::new(FLASH_TTL);
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(BAR_WIDTH, 1)).unwrap();
+        let ctx = StatusBarContext {
+            status: &Status::Idle,
+            mode_label: "build".into(),
+            mode_style: Style::new(),
+            model_id: MODEL_ID,
+            stats: UsageStats {
+                global_cost,
+                context_size: CONTEXT_SIZE,
+                cost: Some(CHAT_COST),
+                context_window: crate::components::TEST_CONTEXT_WINDOW,
+                show_global,
+            },
+            auto_scroll: true,
+            chat_name: None,
+            retry_info: None,
+            thinking_label: None,
+            fast: false,
+            workflow: false,
+            restoring: false,
+        };
+        terminal.draw(|f| bar.view(f, f.area(), &ctx)).unwrap();
+        crate::components::buffer_text(terminal.backend().buffer())
+    }
+
+    /// The sigma is the whole session's bill, and only the session can hand it
+    /// over. Pricing the focused chat's counters instead (what the bar used to
+    /// do) tells the user a paid session was free, or bills another chat's
+    /// tokens at this model's rates. A lone chat has nothing extra to show.
+    #[test_case(Some(SESSION_COST), true  => true  ; "subagents_add_the_session_total")]
+    #[test_case(Some(SESSION_COST), false => false ; "single_chat_shows_its_own_cost_only")]
+    #[test_case(None,               true  => false ; "unpriced_session_claims_nothing")]
+    fn session_total_appears_only_when_there_is_one_to_show(
+        global_cost: Option<f64>,
+        show_global: bool,
+    ) -> bool {
+        let text = render(global_cost, show_global);
+        assert_eq!(text.matches(CHAT_COST_TEXT).count(), 1, "{text}");
+        let shown = text.matches(SESSION_COST_TEXT).count() == 1;
+        assert_eq!(
+            text.contains(SIGMA),
+            shown,
+            "a sigma carrying another number is a misrender: {text}"
+        );
+        shown
+    }
 
     #[test_case("/home/user/projects/app", "/home/user", "~/projects/app" ; "inside_home")]
     #[test_case("/tmp/other", "/home/user", "/tmp/other"                  ; "outside_home")]

--- a/maki-ui/src/components/usage_modal.rs
+++ b/maki-ui/src/components/usage_modal.rs
@@ -7,7 +7,7 @@ use crossterm::event::{KeyCode, KeyEvent};
 use jiff::Timestamp;
 use jiff::tz::TimeZone;
 use maki_config::ClockFormat;
-use maki_providers::{Model, ModelPricing, ProviderUsage, TokenUsage, format_tokens};
+use maki_providers::{Model, ProviderUsage, TokenUsage, format_tokens, model_cost};
 use maki_storage::sessions::StoredTokenUsage;
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -43,6 +43,9 @@ pub enum UsageFetchState {
 
 pub struct UsageModalContext<'a> {
     pub total: &'a TokenUsage,
+    /// What the session billed, from [`maki_providers::session_cost`]. `None`
+    /// means nothing here is priced, so the modal shows tokens only.
+    pub total_cost: Option<f64>,
     pub by_model: &'a HashMap<String, StoredTokenUsage>,
     pub model: &'a Model,
     pub fast: bool,
@@ -144,17 +147,6 @@ impl UsageModal {
     }
 }
 
-fn pricing_for(id: &str, current: &Model) -> Option<ModelPricing> {
-    if id == current.id {
-        return Some(current.pricing.clone());
-    }
-    Model::from_spec(id).ok().map(|m| m.pricing).or_else(|| {
-        Model::from_spec(&format!("{}/{}", current.provider, id))
-            .ok()
-            .map(|m| m.pricing)
-    })
-}
-
 fn build_lines(
     ctx: &UsageModalContext,
     quota: Option<&UsageFetchState>,
@@ -168,12 +160,7 @@ fn build_lines(
         theme.keybind_section,
     )));
 
-    let total_cost = if ctx.model.pricing.is_zero() {
-        None
-    } else {
-        Some(ctx.total.cost(&ctx.model.pricing, ctx.fast))
-    };
-    lines.push(Line::from(totals_row(ctx.total, total_cost, theme)));
+    lines.push(Line::from(totals_row(ctx.total, ctx.total_cost, theme)));
 
     if let Some(state) = quota {
         lines.push(Line::default());
@@ -206,10 +193,7 @@ fn build_lines(
     lines.push(Line::from(header_row(model_w, theme)));
 
     for (id, usage) in entries {
-        let pricing = pricing_for(id, ctx.model);
-        let cost = pricing
-            .as_ref()
-            .map(|p| TokenUsage::from(*usage).cost(p, ctx.fast));
+        let cost = model_cost(id, usage, ctx.model, ctx.fast);
         lines.push(Line::from(model_row(
             id,
             usage,
@@ -406,6 +390,23 @@ mod tests {
     use std::sync::Arc;
     use test_case::test_case;
 
+    const RECORDED_COST: f64 = 0.123;
+    const RECORDED_TEXT: &str = "0.123";
+    /// 1M input tokens at the test model's $3/1M: what the modal would print if
+    /// it re-priced the counters.
+    const REPRICED_TEXT: &str = "3.000";
+    const ONE_MILLION: u32 = 1_000_000;
+    const ONE_MILLION_TEXT: &str = "1.0m";
+    const UNKNOWN_MODEL: &str = "a-model-no-table-has-ever-heard-of";
+    const NO_COST_TEXT: &str = "—";
+
+    fn line_texts(lines: &[Line<'static>]) -> Vec<String> {
+        lines
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect()
+    }
+
     fn key(code: KeyCode, mods: KeyModifiers) -> KeyEvent {
         KeyEvent::new(code, mods)
     }
@@ -510,6 +511,89 @@ mod tests {
         assert!(err[0].spans.iter().any(|s| s.content.contains("nope")));
     }
 
+    fn stored(cost: Option<f64>) -> StoredTokenUsage {
+        StoredTokenUsage {
+            input: ONE_MILLION,
+            cost,
+            ..Default::default()
+        }
+    }
+
+    fn modal_rows(
+        total: &TokenUsage,
+        total_cost: Option<f64>,
+        by_model: &HashMap<String, StoredTokenUsage>,
+        model: &Model,
+    ) -> Vec<String> {
+        let ctx = UsageModalContext {
+            total,
+            total_cost,
+            by_model,
+            model,
+            fast: false,
+            clock_format: ClockFormat::Hour24,
+        };
+        line_texts(&build_lines(&ctx, None, &crate::theme::current()))
+    }
+
+    /// A recorded cost is what the turn was billed, and re-pricing its tokens
+    /// restates the bill every time a provider moves its rates (DeepSeek moves
+    /// them twice a day). A model the tables cannot resolve shows nothing,
+    /// since charging it the selected model's rates invents a bill.
+    #[test]
+    fn model_rows_show_what_was_recorded_and_never_todays_price() {
+        let model = test_model();
+        let total = TokenUsage {
+            input: 2 * ONE_MILLION,
+            ..Default::default()
+        };
+        let by_model = HashMap::from([
+            (model.id.clone(), stored(Some(RECORDED_COST))),
+            (UNKNOWN_MODEL.to_string(), stored(None)),
+        ]);
+
+        let rows = modal_rows(&total, Some(RECORDED_COST), &by_model, &model);
+        let row = |id: &str| {
+            rows.iter()
+                .find(|t| t.contains(id))
+                .unwrap_or_else(|| panic!("no row for {id}: {rows:?}"))
+                .clone()
+        };
+
+        let recorded_row = row(&model.id);
+        assert!(recorded_row.contains(RECORDED_TEXT), "{recorded_row}");
+        assert!(!recorded_row.contains(REPRICED_TEXT), "{recorded_row}");
+
+        let unknown_row = row(UNKNOWN_MODEL);
+        assert!(unknown_row.contains(NO_COST_TEXT), "{unknown_row}");
+        assert!(!unknown_row.contains(REPRICED_TEXT), "{unknown_row}");
+    }
+
+    /// The session's bill arrives already computed, from the turns that paid it.
+    /// These counters would price to [`REPRICED_TEXT`] against the selected
+    /// model, so a modal doing its own arithmetic prints a different number,
+    /// and "$0.000" for a session nothing priced.
+    #[test_case(Some(RECORDED_COST) => Some(RECORDED_TEXT.to_string()) ; "prints_the_bill_it_was_handed")]
+    #[test_case(None                => None                            ; "unpriced_session_shows_tokens_only")]
+    fn totals_row_never_re_prices_the_counters(total_cost: Option<f64>) -> Option<String> {
+        let model = test_model();
+        assert!(!model.pricing.is_zero(), "the fallback must be tempting");
+        let total = TokenUsage {
+            input: ONE_MILLION,
+            ..Default::default()
+        };
+
+        let rows = modal_rows(&total, total_cost, &HashMap::new(), &model);
+        // With no breakdown, the totals row is the only one carrying counters.
+        let totals = rows
+            .iter()
+            .find(|t| t.contains(ONE_MILLION_TEXT))
+            .unwrap_or_else(|| panic!("no totals row: {rows:?}"));
+        totals
+            .split_once('$')
+            .map(|(_, cost)| cost.trim().to_string())
+    }
+
     fn slot(state: UsageFetchState) -> ArcSwapOption<UsageFetchState> {
         ArcSwapOption::from_pointee(state)
     }
@@ -520,6 +604,7 @@ mod tests {
         let model = test_model();
         let ctx = UsageModalContext {
             total: &TokenUsage::default(),
+            total_cost: None,
             by_model: &HashMap::new(),
             model: &model,
             fast: false,

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -208,11 +208,12 @@ Defaults: glm-5-code (strong), glm-4.7-flash (weak), glm-4.7 (medium)
 - **Env var**: `DEEPSEEK_API_KEY`
 - **API**: `https://api.deepseek.com`
 - **Features**: Thinking mode toggle (on/off), open-weight models
+- **Peak pricing**: the prices below are off-peak; each turn is billed as it happens, at 2x during 01:00-04:00, 06:00-10:00 UTC
 
 | Tier | Models | Pricing (in/out per 1M tokens) | Context |
 |------|--------|-------------------------------|---------|
-| Medium | **deepseek-v4-flash** (default) | $0.14 / $0.28 | 1000K ctx / 384K out |
-| Strong | **deepseek-v4-pro** (default) | $0.43 / $0.87 | 1000K ctx / 384K out |
+| Medium | **deepseek-v4-flash** (default) | $0.22 / $0.66 | 1000K ctx / 384K out |
+| Strong | **deepseek-v4-pro** (default) | $0.66 / $1.98 | 1000K ctx / 384K out |
 
 Defaults: deepseek-v4-flash (medium), deepseek-v4-pro (strong)
 

--- a/site/docs/content/token-economy/_index.md
+++ b/site/docs/content/token-economy/_index.md
@@ -68,3 +68,5 @@ in context forever               1 turn, 1 line in context
 ## Watching it work
 
 `/usage` shows the token breakdown of the current session, and `--output-format json` in [Headless Mode](/docs/headless/) reports `total_cost_usd` per run. Cheap is a feature you can measure.
+
+Each turn is priced when it happens and that number is stored with the session. Prices move (DeepSeek, for one, doubles every rate during peak UTC hours), so a total re-priced later would be a guess. What you see is what you were billed.

--- a/src/print.rs
+++ b/src/print.rs
@@ -21,8 +21,8 @@ use maki_agent::tools::QUESTION_TOOL_NAME;
 use maki_agent::{AgentConfig, AgentEvent, DoneReason, Envelope, ImageSource, PermissionsConfig};
 use maki_config::ModelPolicy;
 use maki_lua::EventHandle;
-use maki_providers::TokenUsage;
 use maki_providers::model::Model;
+use maki_providers::{TokenUsage, add_cost};
 use maki_storage::id::SessionRef;
 use serde::Serialize;
 use serde_json::Value;
@@ -218,6 +218,9 @@ pub fn run(
     let mut is_error = false;
     let mut num_turns: u32 = 0;
     let mut usage = TokenUsage::default();
+    // Summed as the turns land: rates move mid-run, and only a turn knows the
+    // rate it paid.
+    let mut cost = None;
     let mut stop_reason: Option<DoneReason> = None;
 
     while let Ok(envelope) = smol::block_on(event_rx.recv_async()) {
@@ -268,6 +271,7 @@ pub fn run(
                 }
             }
             AgentEvent::TurnComplete(tc) => {
+                add_cost(&mut cost, tc.cost);
                 if let Some(out) = &mut verbose_out {
                     let content_value = serde_json::to_value(&tc.message.content)?;
                     out.emit(&AssistantEvent {
@@ -322,7 +326,8 @@ pub fn run(
     });
 
     let duration_ms = start.elapsed().as_millis();
-    let total_cost_usd = usage.cost(&model.pricing, fast);
+    // Zero on an unpriced model, which is what its turns reported too.
+    let total_cost_usd = cost.unwrap_or_default();
 
     match format {
         OutputFormat::Text => {

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -28,7 +28,7 @@ use maki_agent::{
 };
 use maki_config::ModelPolicy;
 use maki_providers::model::Model;
-use maki_providers::{ImageSource, Message, StopReason, Timeouts, TokenUsage};
+use maki_providers::{ImageSource, Message, StopReason, Timeouts, TokenUsage, add_cost};
 use maki_storage::StateDir;
 use maki_storage::id::SessionRef;
 use maki_storage::sessions::Session;
@@ -554,10 +554,10 @@ pub fn run(params: SdkParams) -> Result<()> {
         shared: Arc::clone(&shared),
         answer_tx: handle.answer_tx.clone(),
         include_partial_messages: cli.include_partial_messages,
-        fast,
         synth: StreamSynth::new(),
         tool_inputs: HashMap::new(),
         result_text: String::new(),
+        cost: None,
         request_counter: 0,
     }
     .spawn(handle.event_rx.clone());
@@ -853,10 +853,12 @@ struct EventPump {
     shared: Arc<Mutex<Shared>>,
     answer_tx: Sender<String>,
     include_partial_messages: bool,
-    fast: bool,
     synth: StreamSynth,
     tool_inputs: HashMap<String, (String, Value)>,
     result_text: String,
+    /// Summed as the turns land: rates move mid-prompt, and only a turn knows
+    /// the rate it paid.
+    cost: Option<f64>,
     request_counter: u64,
 }
 
@@ -887,6 +889,7 @@ impl EventPump {
         self.synth.reset();
         self.tool_inputs.clear();
         self.result_text.clear();
+        self.cost = None;
         self.shared.lock().unwrap().pending.clear();
     }
 
@@ -897,13 +900,9 @@ impl EventPump {
         num_turns: u32,
         usage: TokenUsage,
     ) -> Result<()> {
-        let (duration_ms, total_cost_usd) = {
-            let shared = self.shared.lock().unwrap();
-            (
-                shared.turn_start.elapsed().as_millis(),
-                usage.cost(&shared.model.pricing, self.fast),
-            )
-        };
+        let duration_ms = self.shared.lock().unwrap().turn_start.elapsed().as_millis();
+        // Zero on an unpriced model, which is what its turns reported too.
+        let total_cost_usd = self.cost.unwrap_or_default();
         self.writer.emit(WireInner::Result(ResultPayload {
             subtype: if is_error {
                 "error_during_execution"
@@ -989,6 +988,7 @@ impl EventPump {
                 )?;
             }
             AgentEvent::TurnComplete(tc) => {
+                add_cost(&mut self.cost, tc.cost);
                 if self.include_partial_messages {
                     let events = self.synth.finish_message(&tc.usage);
                     self.emit_stream(events)?;


### PR DESCRIPTION
DeepSeek raised its rates and now doubles all of them between 01:00-04:00 and 06:00-10:00 UTC, so the model tables quote the off-peak prices and a `PricingSchedule` on the provider manifest scales the bill inside those windows.

Pricing splits in two so the clock cannot leak where it does not belong: `Model::billed_cost` reads it and is only for a turn that just ran, `Model::list_cost` never does, and `TokenUsage::cost` went crate private so nothing can price around a schedule.

Every turn stores what it paid in `StoredTokenUsage.cost` and `pricing::session_cost` is the one answer for a stored session, so the status bar, `/usage` and ACP cannot disagree; sessions written before this have counters only and fall back to each model's listed rates rather than to whatever model happens to be selected.

Windows and multipliers are asserted in const context, so `hours(25, 4)` or a schedule that undercuts the table fails the build, and the provider docs render the hours from the schedule instead of restating them in prose that drifts.

Closes #837.