### PR TITLE
feat(providers): send Codex reasoning effort

### DIFF
--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -614,7 +614,12 @@ impl Copilot {
                 .map(Arc::new)
         });
         if let Some(info) = reasoning_info {
-            apply_responses_reasoning(&mut body, thinking, model, &effort_dialect(&info));
+            responses::apply_responses_reasoning(
+                &mut body,
+                thinking,
+                model,
+                &effort_dialect(&info),
+            );
         }
         let resolved = super::ResolvedAuth {
             base_url: Some(auth.endpoint.clone()),
@@ -1055,17 +1060,6 @@ fn effort_dialect(info: &CopilotModelInfo) -> EffortDialect<'_> {
     }
 }
 
-fn apply_responses_reasoning(
-    body: &mut Value,
-    thinking: ThinkingConfig,
-    model: &Model,
-    dialect: &EffortDialect,
-) {
-    if let Some(effort) = thinking.effort_str(dialect, model) {
-        body["reasoning"] = json!({"effort": effort});
-    }
-}
-
 fn guess_endpoint(model_id: &str) -> Endpoint {
     if model_id.starts_with("claude-") {
         Endpoint::Messages
@@ -1338,11 +1332,11 @@ mod tests {
         let dialect = effort_dialect(&info);
 
         let mut body = json!({});
-        apply_responses_reasoning(&mut body, ThinkingConfig::Off, &model, &dialect);
+        responses::apply_responses_reasoning(&mut body, ThinkingConfig::Off, &model, &dialect);
         assert_eq!(body, json!({"reasoning": {"effort": "none"}}));
 
         let mut body = json!({});
-        apply_responses_reasoning(
+        responses::apply_responses_reasoning(
             &mut body,
             ThinkingConfig::Effort(Effort::Medium),
             &model,

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -9,6 +9,7 @@ use tracing::{debug, warn};
 
 use crate::model::Model;
 use crate::provider::{BoxFuture, Provider};
+use crate::types::EffortDialect;
 use crate::{
     AgentError, Message, ProviderEvent, ProviderUsage, RequestOptions, StreamResponse, UsageLimit,
     dialect,
@@ -275,6 +276,23 @@ fn resolve_openai_base_url() -> Option<String> {
     maki_config::providers::configured_base_url("openai", config.get("openai"))
 }
 
+// Codex models drop `minimal` and never take an explicit "none", so they get
+// their own dialects; the plain plan models keep both.
+fn plan_dialect(model_id: &str) -> &'static EffortDialect<'static> {
+    if !model_id.contains("-codex") {
+        return if model_id.starts_with("gpt-5.6-") {
+            &dialect::GPT_5_6
+        } else {
+            &dialect::CODING_PLAN
+        };
+    }
+    if model_id.starts_with("gpt-5.1-codex") && !model_id.starts_with("gpt-5.1-codex-max") {
+        &dialect::CODEX_5_1
+    } else {
+        &dialect::CODEX
+    }
+}
+
 impl Provider for OpenAi {
     fn stream_message<'a>(
         &'a self,
@@ -291,7 +309,13 @@ impl Provider for OpenAi {
             let system = super::super::with_prefix(&self.system_prefix, system, &mut buf);
 
             if is_codex_model(&model.id) {
-                let body = super::responses::build_body(model, messages, system, tools);
+                let mut body = super::responses::build_body(model, messages, system, tools);
+                super::responses::apply_responses_reasoning(
+                    &mut body,
+                    opts.thinking,
+                    model,
+                    plan_dialect(&model.id),
+                );
                 let stream_timeout = self.compat.stream_timeout();
                 return self
                     .with_oauth_retry(|| async {
@@ -388,9 +412,13 @@ impl Provider for OpenAi {
 
 #[cfg(test)]
 mod tests {
+    use maki_storage::sessions::Effort;
+    use serde_json::json;
     use test_case::test_case;
 
+    use super::super::responses;
     use super::*;
+    use crate::ThinkingConfig;
 
     #[test_case("gpt-5.6-luna")]
     #[test_case("gpt-5.6-terra")]
@@ -409,6 +437,70 @@ mod tests {
     #[test_case("gpt-5.4-nano", None)]
     fn coding_plan_context_window_resolves_plan_models(model_id: &str, expected: Option<u32>) {
         assert_eq!(coding_plan_context_window(model_id), expected);
+    }
+
+    #[test_case(ThinkingConfig::Adaptive, "gpt-5.3-codex", "medium" ; "adaptive")]
+    #[test_case(ThinkingConfig::Effort(Effort::Minimal), "gpt-5.3-codex", "low" ; "minimal_snaps_to_low_on_codex")]
+    #[test_case(ThinkingConfig::Effort(Effort::Low), "gpt-5.3-codex", "low" ; "low")]
+    #[test_case(ThinkingConfig::Effort(Effort::Medium), "gpt-5.3-codex", "medium" ; "medium")]
+    #[test_case(ThinkingConfig::Effort(Effort::High), "gpt-5.3-codex", "high" ; "high")]
+    #[test_case(ThinkingConfig::Effort(Effort::XHigh), "gpt-5.3-codex", "xhigh" ; "xhigh")]
+    #[test_case(ThinkingConfig::Effort(Effort::Max), "gpt-5.3-codex", "xhigh" ; "max_snaps_to_xhigh_on_codex")]
+    #[test_case(ThinkingConfig::Effort(Effort::XHigh), "gpt-5.1-codex", "high" ; "xhigh_snaps_to_high_on_5_1")]
+    #[test_case(ThinkingConfig::Effort(Effort::XHigh), "gpt-5.1-codex-max", "xhigh" ; "xhigh_passes_through_on_5_1_max")]
+    #[test_case(ThinkingConfig::Effort(Effort::Minimal), "gpt-5.5", "minimal" ; "minimal_passes_through_on_5_5")]
+    #[test_case(ThinkingConfig::Off, "gpt-5.5", "none" ; "off_is_explicit_on_5_5")]
+    #[test_case(ThinkingConfig::Effort(Effort::Max), "gpt-5.5", "xhigh" ; "max_snaps_to_xhigh_on_5_5")]
+    #[test_case(ThinkingConfig::Effort(Effort::Minimal), "gpt-5.6-sol", "minimal" ; "minimal_passes_through_on_5_6_sol")]
+    #[test_case(ThinkingConfig::Off, "gpt-5.6-sol", "none" ; "off_is_explicit_on_5_6_sol")]
+    #[test_case(ThinkingConfig::Effort(Effort::Max), "gpt-5.6-sol", "max" ; "max_passes_through_on_5_6_sol")]
+    #[test_case(ThinkingConfig::Effort(Effort::Max), "gpt-5.6-terra", "max" ; "max_passes_through_on_5_6_terra")]
+    #[test_case(ThinkingConfig::Effort(Effort::Max), "gpt-5.6-luna", "max" ; "max_passes_through_on_5_6_luna")]
+    fn responses_reasoning_uses_responses_effort_object(
+        thinking: ThinkingConfig,
+        model_id: &str,
+        expected: &str,
+    ) {
+        let model = Model::from_spec(&format!("openai/{model_id}")).unwrap();
+        let mut body = json!({});
+        responses::apply_responses_reasoning(&mut body, thinking, &model, plan_dialect(&model.id));
+        assert_eq!(body["reasoning"]["effort"], expected);
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn plan_models_have_a_reviewed_dialect() {
+        const EXPECTED: &[(&str, &EffortDialect)] = &[
+            ("gpt-5.6-luna", &dialect::GPT_5_6),
+            ("gpt-5.6-terra", &dialect::GPT_5_6),
+            ("gpt-5.6-sol", &dialect::GPT_5_6),
+            ("gpt-5.5", &dialect::CODING_PLAN),
+            ("gpt-5.4", &dialect::CODING_PLAN),
+            ("gpt-5.4-mini", &dialect::CODING_PLAN),
+            ("gpt-5.2", &dialect::CODING_PLAN),
+        ];
+        const UNREVIEWED: &str = "new PLAN_MODELS entry needs an effort dialect decision";
+
+        for model_id in PLAN_MODELS {
+            let (_, expected) = EXPECTED
+                .iter()
+                .find(|(id, _)| id == model_id)
+                .unwrap_or_else(|| panic!("{UNREVIEWED}: {model_id}"));
+            assert_eq!(plan_dialect(model_id), *expected, "{model_id}");
+        }
+    }
+
+    #[test]
+    fn responses_reasoning_omits_effort_when_disabled() {
+        let model = Model::from_spec("openai/gpt-5.3-codex").unwrap();
+        let mut body = json!({});
+        responses::apply_responses_reasoning(
+            &mut body,
+            ThinkingConfig::Off,
+            &model,
+            plan_dialect(&model.id),
+        );
+        assert!(body.get("reasoning").is_none());
     }
 
     #[test]

--- a/maki-providers/src/providers/openai/responses.rs
+++ b/maki-providers/src/providers/openai/responses.rs
@@ -7,15 +7,18 @@ use isahc::{HttpClient, Request};
 use serde_json::{Value, json};
 use tracing::{debug, warn};
 
+use crate::model::Model;
 use crate::providers::ResolvedAuth;
+use crate::types::EffortDialect;
 use crate::{
-    AgentError, ContentBlock, Message, ProviderEvent, Role, StopReason, StreamResponse, TokenUsage,
+    AgentError, ContentBlock, Message, ProviderEvent, Role, StopReason, StreamResponse,
+    ThinkingConfig, TokenUsage,
 };
 
 const RESPONSES_PATH: &str = "/responses";
 
 pub(crate) fn build_body(
-    model: &crate::model::Model,
+    model: &Model,
     messages: &[Message],
     system: &str,
     tools: &Value,
@@ -34,6 +37,17 @@ pub(crate) fn build_body(
         body["tools"] = wire_tools;
     }
     body
+}
+
+pub(crate) fn apply_responses_reasoning(
+    body: &mut Value,
+    thinking: ThinkingConfig,
+    model: &Model,
+    dialect: &EffortDialect,
+) {
+    if let Some(effort) = thinking.effort_str(dialect, model) {
+        body["reasoning"] = json!({ "effort": effort });
+    }
 }
 
 pub(crate) fn convert_input(messages: &[Message]) -> Value {

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -502,6 +502,32 @@ pub mod dialect {
         adaptive: Some(Medium),
         off: None,
     };
+    /// OpenAI Responses API models whose highest effort is `xhigh`.
+    pub const CODEX: EffortDialect = EffortDialect {
+        supported: &[Low, Medium, High, XHigh],
+        adaptive: Some(Medium),
+        off: None,
+    };
+    /// OpenAI GPT-5.1 Codex Responses API models.
+    pub const CODEX_5_1: EffortDialect = EffortDialect {
+        supported: &[Low, Medium, High],
+        adaptive: Some(Medium),
+        off: None,
+    };
+    /// OpenAI Coding Plan models that aren't Codex. They keep `minimal`, and
+    /// the Responses API opts out of reasoning with an explicit "none".
+    pub const CODING_PLAN: EffortDialect = EffortDialect {
+        supported: &[Minimal, Low, Medium, High, XHigh],
+        adaptive: Some(Medium),
+        off: Some(OFF),
+    };
+    /// OpenAI GPT-5.6 Coding Plan models (Luna, Terra, Sol), which also take
+    /// `max`.
+    pub const GPT_5_6: EffortDialect = EffortDialect {
+        supported: &[Minimal, Low, Medium, High, XHigh, Max],
+        adaptive: Some(Medium),
+        off: Some(OFF),
+    };
     /// opencode chat-completions, openrouter (static fallback).
     pub const PREFER_HIGH: EffortDialect = EffortDialect {
         supported: &[Low, Medium, High],
@@ -978,6 +1004,10 @@ mod tests {
     fn dialects_have_non_empty_ascending_supported() {
         let all = [
             &dialect::STANDARD,
+            &dialect::CODEX,
+            &dialect::CODEX_5_1,
+            &dialect::CODING_PLAN,
+            &dialect::GPT_5_6,
             &dialect::PREFER_HIGH,
             &dialect::HIGH_ONLY,
             &dialect::GLM,
@@ -1024,6 +1054,13 @@ mod tests {
     #[test_case(&dialect::STANDARD, ThinkingConfig::Effort(Minimal), Some("minimal") ; "standard_minimal_passthrough")]
     #[test_case(&dialect::STANDARD, ThinkingConfig::Effort(Max),     Some("high")    ; "standard_max_snaps_down")]
     #[test_case(&dialect::STANDARD, ThinkingConfig::Budget(1024),    Some("medium")  ; "standard_quarter_budget")]
+    #[test_case(&dialect::CODEX, ThinkingConfig::Adaptive,        Some("medium") ; "codex_adaptive")]
+    #[test_case(&dialect::CODEX, ThinkingConfig::Effort(Minimal), Some("low")    ; "codex_minimal_snaps_up")]
+    #[test_case(&dialect::CODEX, ThinkingConfig::Effort(Max),     Some("xhigh")  ; "codex_max_snaps_down")]
+    #[test_case(&dialect::CODING_PLAN, ThinkingConfig::Effort(Minimal), Some("minimal") ; "coding_plan_minimal_passthrough")]
+    #[test_case(&dialect::CODING_PLAN, ThinkingConfig::Effort(Max),     Some("xhigh")   ; "coding_plan_max_snaps_down")]
+    #[test_case(&dialect::CODING_PLAN, ThinkingConfig::Off,             Some("none")    ; "coding_plan_off")]
+    #[test_case(&dialect::GPT_5_6, ThinkingConfig::Off,                 Some("none")    ; "gpt_5_6_off")]
     #[test_case(&dialect::PREFER_HIGH, ThinkingConfig::Adaptive,        Some("high") ; "prefer_high_adaptive")]
     #[test_case(&dialect::HIGH_ONLY, ThinkingConfig::Adaptive,        Some("high") ; "high_only_adaptive")]
     #[test_case(&dialect::HIGH_ONLY, ThinkingConfig::Effort(Minimal), Some("high") ; "high_only_minimal")]


### PR DESCRIPTION
## Summary

- Send Codex and Coding Plan reasoning effort through the Responses API `reasoning.effort` object (`responses::apply_responses_reasoning`) shared between OpenAI and Copilot providers.
- Snap unsupported levels to each model family's accepted range without sending invalid levels (e.g. `minimal` is rejected with HTTP 400 by OpenAI on 5.1+ models).
- Key dialects based on model family and prefix:
  - `CODEX_5_1` (`low`..`high`): `gpt-5.1-codex`, `gpt-5.1-codex-mini`
  - `CODEX` (`low`..`xhigh`): `gpt-5.1-codex-max`, `gpt-5.2-codex`, `gpt-5.3-codex`, and plain plan models (`gpt-5.2`, `gpt-5.4`, `gpt-5.5`)
  - `GPT_5_6` (`low`..`max`): `gpt-5.6-luna`, `gpt-5.6-terra`, `gpt-5.6-sol`

### Supported Reasoning Effort Matrix

| Model Family / Prefix | Models | Dialect | Supported Levels | `minimal` | `xhigh` | `max` |
| --- | --- | --- | --- | --- | --- | --- |
| **GPT-5.1 Codex** | `gpt-5.1-codex`, `gpt-5.1-codex-mini` | `CODEX_5_1` | `low`, `medium`, `high` | snaps to `low` | snaps to `high` | snaps to `high` |
| **GPT-5.1 Codex Max** | `gpt-5.1-codex-max` | `CODEX` | `low`, `medium`, `high`, `xhigh` | snaps to `low` | `xhigh` | snaps to `xhigh` |
| **Other Codex** | `gpt-5.2-codex`, `gpt-5.3-codex` | `CODEX` | `low`, `medium`, `high`, `xhigh` | snaps to `low` | `xhigh` | snaps to `xhigh` |
| **Plain Plan Models** | `gpt-5.2`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.5` | `CODEX` | `low`, `medium`, `high`, `xhigh` | snaps to `low` | `xhigh` | snaps to `xhigh` |
| **GPT-5.6 Plan Models** | `gpt-5.6-luna`, `gpt-5.6-terra`, `gpt-5.6-sol` | `GPT_5_6` | `low`, `medium`, `high`, `xhigh`, `max` | snaps to `low` | `xhigh` | `max` |

## Testing

- `cargo test -p maki-providers responses_reasoning --lib`
- `cargo test -p maki-providers dialects_have_non_empty_ascending_supported --lib`
- `cargo check -p maki-providers --tests`