### PR TITLE
fix(code_execution): keep results a failed `gather` call didn't touch

### DIFF
--- a/maki-interpreter/src/runner.rs
+++ b/maki-interpreter/src/runner.rs
@@ -62,20 +62,11 @@ impl PrintWriterCallback for StreamingWriter<'_> {
     }
 }
 
+/// `preamble` holds imports and helpers; it is compiled ahead of `code` as one
+/// script, and tracebacks come back rebased so line 1 is `code` line 1.
 pub fn run(
     code: &str,
-    tools: &HashMap<String, ToolFn>,
-    resolver: Option<&AsyncResolver>,
-    limits: ResourceLimits,
-) -> Result<InterpreterResult, InterpreterError> {
-    let mut stdout = String::new();
-    let mut print_writer = PrintWriter::collect_string(&mut stdout);
-    let output = run_inner(code, tools, resolver, limits, &mut print_writer)?;
-    Ok(InterpreterResult { output, stdout })
-}
-
-pub fn run_streaming(
-    code: &str,
+    preamble: &str,
     tools: &HashMap<String, ToolFn>,
     resolver: Option<&AsyncResolver>,
     limits: ResourceLimits,
@@ -86,27 +77,45 @@ pub fn run_streaming(
         flushed_pos: 0,
         on_line: on_output,
     };
-    let mut print_writer = PrintWriter::Callback(&mut writer);
-    let output = run_inner(code, tools, resolver, limits, &mut print_writer)?;
-    let stdout = writer.buffer;
-    Ok(InterpreterResult { output, stdout })
+    let preamble = preamble.trim_end_matches('\n');
+    let script = if preamble.is_empty() {
+        code.to_owned()
+    } else {
+        format!("{preamble}\n{code}")
+    };
+    let output = execute(
+        script,
+        tools,
+        resolver,
+        limits,
+        &mut PrintWriter::Callback(&mut writer),
+    )
+    .map_err(|e| {
+        let offset = preamble.lines().count();
+        match e {
+            InterpreterError::Parse(msg) => InterpreterError::Parse(rebase_traceback(&msg, offset)),
+            InterpreterError::Runtime(msg) => {
+                InterpreterError::Runtime(rebase_traceback(&msg, offset))
+            }
+            other => other,
+        }
+    })?;
+    Ok(InterpreterResult {
+        output,
+        stdout: writer.buffer,
+    })
 }
 
-fn run_inner(
-    code: &str,
+fn execute(
+    script: String,
     tools: &HashMap<String, ToolFn>,
     resolver: Option<&AsyncResolver>,
     limits: ResourceLimits,
     print_writer: &mut PrintWriter<'_>,
 ) -> Result<Option<Value>, InterpreterError> {
     let _sandbox = limits.max_memory.is_some().then(SandboxScope::enter);
-    let runner = MontyRun::new(
-        code.to_owned(),
-        SCRIPT_NAME,
-        vec![],
-        CompileOptions::default(),
-    )
-    .map_err(|e| InterpreterError::Parse(e.to_string()))?;
+    let runner = MontyRun::new(script, SCRIPT_NAME, vec![], CompileOptions::default())
+        .map_err(|e| InterpreterError::Parse(e.to_string()))?;
 
     let tracker = ResourceTracker::new(limits);
 
@@ -228,6 +237,39 @@ fn run_inner(
     }
 }
 
+/// Monty counts lines in the whole script, so user frames come back
+/// `preamble_lines` too high. Preamble frames are dropped along with their
+/// source excerpt: the caller never wrote those lines, so pointing at them only
+/// sends it hunting through code it cannot see.
+fn rebase_traceback(msg: &str, preamble_lines: usize) -> String {
+    let prefix = format!("  File \"{SCRIPT_NAME}\", line ");
+    let mut kept: Vec<Cow<'_, str>> = Vec::new();
+    let mut in_preamble_frame = false;
+    for line in msg.lines() {
+        match line.strip_prefix(&prefix).and_then(split_line_number) {
+            Some((number, rest)) => {
+                in_preamble_frame = number <= preamble_lines;
+                if !in_preamble_frame {
+                    kept.push(format!("{prefix}{}{rest}", number - preamble_lines).into());
+                }
+            }
+            None if in_preamble_frame && line.starts_with(' ') => {}
+            None => {
+                in_preamble_frame = false;
+                kept.push(line.into());
+            }
+        }
+    }
+    kept.join("\n")
+}
+
+fn split_line_number(rest: &str) -> Option<(usize, &str)> {
+    let end = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(rest.len());
+    rest[..end].parse().ok().map(|n| (n, &rest[end..]))
+}
+
 pub fn limits(timeout: Duration, max_memory: usize) -> ResourceLimits {
     ResourceLimits::default()
         .max_duration(timeout)
@@ -241,13 +283,40 @@ mod tests {
     use serde_json::json;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use test_case::test_case;
 
+    const NO_PREAMBLE: &str = "";
+    const RAISING_PREAMBLE: &str = "def helper():\n    raise ValueError('inside preamble')\n";
     const DEFAULT_MAX_MEMORY: usize = 50 * 1024 * 1024;
     const SMALL_MAX_MEMORY: usize = 2 * 1024 * 1024;
     const OVER_LIMIT_ALLOC: &str = "x = [0] * 10_000_000";
     const MEMORY_ERR_FRAGMENT: &str = "memory";
     const NESTED_TIMEOUT: Duration = Duration::from_secs(5);
     const NESTED_DEADLOCK: &str = "nested run deadlocked";
+    const USER_ERROR_LINE: usize = 2;
+
+    fn run_code(
+        code: &str,
+        tools: &HashMap<String, ToolFn>,
+        resolver: Option<&AsyncResolver>,
+        limits: ResourceLimits,
+    ) -> Result<InterpreterResult, InterpreterError> {
+        run(code, NO_PREAMBLE, tools, resolver, limits, &mut |_| {})
+    }
+
+    fn run_with_preamble(
+        code: &str,
+        preamble: &str,
+    ) -> Result<InterpreterResult, InterpreterError> {
+        run(
+            code,
+            preamble,
+            &empty_tools(),
+            None,
+            default_limits(),
+            &mut |_| {},
+        )
+    }
 
     fn default_limits() -> ResourceLimits {
         limits(Duration::from_secs(30), DEFAULT_MAX_MEMORY)
@@ -266,6 +335,15 @@ mod tests {
         HashMap::new()
     }
 
+    fn reported_lines(msg: &str) -> Vec<usize> {
+        let prefix = format!("File \"{SCRIPT_NAME}\", line ");
+        msg.lines()
+            .filter_map(|l| l.trim_start().strip_prefix(&prefix))
+            .filter_map(split_line_number)
+            .map(|(n, _)| n)
+            .collect()
+    }
+
     fn stub_tools(names: &[&str]) -> HashMap<String, ToolFn> {
         names
             .iter()
@@ -278,7 +356,7 @@ mod tests {
 
     #[test]
     fn memory_limit_raises_memory_error() {
-        let err = run(
+        let err = run_code(
             OVER_LIMIT_ALLOC,
             &empty_tools(),
             None,
@@ -294,7 +372,7 @@ mod tests {
     fn concurrent_memory_limited_runs_both_enforce() {
         let spawn = || {
             std::thread::spawn(|| {
-                run(
+                run_code(
                     OVER_LIMIT_ALLOC,
                     &empty_tools(),
                     None,
@@ -317,12 +395,12 @@ mod tests {
         std::thread::spawn(move || {
             let subagent: ToolFn = Box::new(|_, _, _| {
                 let inner = std::thread::spawn(|| {
-                    run("2 + 3", &empty_tools(), None, default_limits()).unwrap()
+                    run_code("2 + 3", &empty_tools(), None, default_limits()).unwrap()
                 });
                 Ok(inner.join().unwrap().output.unwrap())
             });
             let tools = HashMap::from([("task".to_owned(), subagent)]);
-            let _ = tx.send(run("task()", &tools, None, default_limits()));
+            let _ = tx.send(run_code("task()", &tools, None, default_limits()));
         });
         let result = rx.recv_timeout(NESTED_TIMEOUT).expect(NESTED_DEADLOCK);
         assert_eq!(result.unwrap().output, Some(json!(5)));
@@ -330,7 +408,7 @@ mod tests {
 
     #[test]
     fn memory_limit_not_tripped_by_small_workload() {
-        let result = run(
+        let result = run_code(
             "sum([i for i in range(1000)])",
             &empty_tools(),
             None,
@@ -342,14 +420,14 @@ mod tests {
 
     #[test]
     fn simple_expression() {
-        let result = run("2 + 3", &empty_tools(), None, default_limits()).unwrap();
+        let result = run_code("2 + 3", &empty_tools(), None, default_limits()).unwrap();
         assert_eq!(result.output, Some(json!(5)));
         assert!(result.stdout.is_empty());
     }
 
     #[test]
     fn print_output() {
-        let result = run(
+        let result = run_code(
             "print('hello world')",
             &empty_tools(),
             None,
@@ -366,7 +444,7 @@ mod tests {
             "echo".into(),
             Box::new(|_, args, _| Ok(args.first().cloned().unwrap_or(json!(null)))),
         );
-        let result = run("echo(42)", &tools, None, default_limits()).unwrap();
+        let result = run_code("echo(42)", &tools, None, default_limits()).unwrap();
         assert_eq!(result.output, Some(json!(42)));
     }
 
@@ -384,19 +462,19 @@ mod tests {
                 Ok(json!(format!("hello {name}")))
             }),
         );
-        let result = run("greet(name='world')", &tools, None, default_limits()).unwrap();
+        let result = run_code("greet(name='world')", &tools, None, default_limits()).unwrap();
         assert_eq!(result.output, Some(json!("hello world")));
     }
 
     #[test]
     fn parse_error() {
-        let err = run("def", &empty_tools(), None, default_limits()).unwrap_err();
+        let err = run_code("def", &empty_tools(), None, default_limits()).unwrap_err();
         assert!(matches!(err, InterpreterError::Parse(_)));
     }
 
     #[test]
     fn unknown_tool_raises_name_error() {
-        let err = run("nonexistent()", &empty_tools(), None, default_limits()).unwrap_err();
+        let err = run_code("nonexistent()", &empty_tools(), None, default_limits()).unwrap_err();
         assert!(
             matches!(err, InterpreterError::Runtime(_)),
             "expected Runtime NameError, got {err:?}"
@@ -410,15 +488,16 @@ mod tests {
             "fail".into(),
             Box::new(|_, _, _| Err("intentional failure".into())),
         );
-        let err = run("fail()", &tools, None, default_limits()).unwrap_err();
+        let err = run_code("fail()", &tools, None, default_limits()).unwrap_err();
         assert!(matches!(err, InterpreterError::ToolCall { .. }));
     }
 
     #[test]
     fn streaming_collects_stdout() {
         let mut called = false;
-        let result = run_streaming(
+        let result = run(
             "print('hello')\nprint('world')",
+            NO_PREAMBLE,
             &empty_tools(),
             None,
             default_limits(),
@@ -457,7 +536,7 @@ await main()
                 .collect())
         });
 
-        let result = run(code, &tools, Some(&resolver), default_limits()).unwrap();
+        let result = run_code(code, &tools, Some(&resolver), default_limits()).unwrap();
         assert_eq!(result.output, Some(json!("a_val|b_val")));
     }
 
@@ -483,7 +562,7 @@ await main()
                 .collect())
         });
 
-        let result = run(code, &tools, Some(&resolver), default_limits()).unwrap();
+        let result = run_code(code, &tools, Some(&resolver), default_limits()).unwrap();
         assert!(result.output.is_some());
         assert!(
             call_count.load(Ordering::SeqCst) >= 2,
@@ -493,10 +572,11 @@ await main()
 
     #[test]
     fn resolver_wait_does_not_count_against_timeout() {
-        const TIMEOUT: Duration = Duration::from_millis(500);
-        const WAIT: Duration = Duration::from_millis(700);
+        const TIMEOUT: Duration = Duration::from_millis(1000);
+        const WAIT: Duration = Duration::from_millis(1100);
         // Monty's tracker must stop the clock while we sit in the resolver.
-        // Two awaits so a clock paused only for the first wait still fails.
+        // Two awaits so a clock paused only for the first wait still fails,
+        // and generous durations so a busy machine cannot tip the balance.
         let code = r#"
 async def main():
     a = await slow()
@@ -514,8 +594,63 @@ await main()
         });
 
         let lims = limits(TIMEOUT, DEFAULT_MAX_MEMORY);
-        let result = run(code, &tools, Some(&resolver), lims).unwrap();
+        let result = run_code(code, &tools, Some(&resolver), lims).unwrap();
         assert_eq!(result.output, Some(json!("donedone")));
+    }
+
+    #[test_case("x = 1\nprint(boom_undefined)\n", "import re\nimport asyncio\n" ; "runtime_frame")]
+    #[test_case("x = 1\nprint(boom_undefined)\n", "import re" ; "preamble_without_trailing_newline")]
+    #[test_case("x = 1\ndef\n", "import re\n" ; "parse_error")]
+    fn traceback_lines_count_from_the_users_first_line(code: &str, preamble: &str) {
+        let err = run_with_preamble(code, preamble).unwrap_err().to_string();
+        assert_eq!(reported_lines(&err), [USER_ERROR_LINE], "got: {err}");
+    }
+
+    /// The error must survive even though the frame that raised it is gone.
+    #[test]
+    fn preamble_frames_are_dropped_from_traceback() {
+        let err = run_with_preamble("helper()\n", RAISING_PREAMBLE)
+            .unwrap_err()
+            .to_string();
+        assert_eq!(reported_lines(&err), [1], "preamble frame leaked: {err}");
+        assert!(!err.contains("raise ValueError"), "excerpt leaked: {err}");
+        assert!(err.contains("inside preamble"), "error lost: {err}");
+    }
+
+    /// The `gather` helper in the code_execution preamble awaits calls one at a
+    /// time so it can catch each failure alone. That stays concurrent only
+    /// because every call is already pending when the first await parks, and
+    /// here is where we would notice if that stopped being true.
+    #[test]
+    fn calls_made_before_the_first_await_resolve_in_one_batch() {
+        let code = r#"
+async def main():
+    out = []
+    for call in [tool_a(), tool_fail(), tool_b()]:
+        try:
+            out.append(await call)
+        except Exception as e:
+            out.append(str(e))
+    return out
+await main()
+"#;
+        let tools = stub_tools(&["tool_a", "tool_b", "tool_fail"]);
+        let batches = Arc::new(AtomicUsize::new(0));
+        let counted = batches.clone();
+        let resolver: AsyncResolver = Box::new(move |pending: Vec<PendingCall>| {
+            counted.fetch_add(1, Ordering::SeqCst);
+            Ok(pending
+                .into_iter()
+                .map(|pc| match pc.name.as_str() {
+                    "tool_fail" => (pc.call_id, Err("boom".to_owned())),
+                    name => (pc.call_id, Ok(json!(name))),
+                })
+                .collect())
+        });
+
+        let result = run_code(code, &tools, Some(&resolver), default_limits()).unwrap();
+        assert_eq!(result.output, Some(json!(["tool_a", "boom", "tool_b"])));
+        assert_eq!(batches.load(Ordering::SeqCst), 1, "calls must be batched");
     }
 
     #[test]
@@ -539,7 +674,7 @@ await main()
                 .collect())
         });
 
-        let err = run(code, &tools, Some(&resolver), default_limits()).unwrap_err();
+        let err = run_code(code, &tools, Some(&resolver), default_limits()).unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("boom"),

--- a/maki-lua/src/api/interpreter.rs
+++ b/maki-lua/src/api/interpreter.rs
@@ -49,7 +49,7 @@ fn forward_calls(
 
 async fn call_lua_tool(lua: Lua, f: Option<Function>, pc: &PendingCall) -> Result<Value, String> {
     let Some(f) = f else {
-        return Err(format!("unknown tool: {}", pc.name));
+        return Err("unknown tool".to_owned());
     };
     let input = build_tool_input(&pc.args, &pc.kwargs)?;
     let arg = json_to_lua(&lua, &input).map_err(|e| e.to_string())?;
@@ -57,9 +57,7 @@ async fn call_lua_tool(lua: Lua, f: Option<Function>, pc: &PendingCall) -> Resul
         .call_async::<mlua::MultiValue>(arg)
         .await
         .map_err(|e| e.to_string())?;
-    lua_tool_result(values)
-        .map(Value::String)
-        .map_err(|e| format!("{}: {e}", pc.name))
+    lua_tool_result(values).map(Value::String)
 }
 
 /// Run Python code in a sandboxed interpreter with memory and time limits.
@@ -78,6 +76,8 @@ async fn call_lua_tool(lua: Lua, f: Option<Function>, pc: &PendingCall) -> Resul
 ///   `on_output` (function) - called with each stdout line (string) as it is
 ///     produced. Must not yield.
 /// Optional fields:
+///   `preamble` (string?) - Python source (imports, helpers) compiled ahead of
+///     {code}. Tracebacks are rebased so line 1 is {code} line 1.
 ///   `tools` (table?) - map of `name -> function` for tools the sandbox may call.
 ///     Each function receives the tool input table and must return `(string)` or
 ///     `(nil, err)`. Tool calls are batched and dispatched concurrently.
@@ -95,6 +95,7 @@ async fn interpreter_run(lua: Lua, code: String, opts: Table) -> LuaResult<Pair<
     let timeout_secs: u64 = required(&opts, "timeout")?;
     let max_memory_mb: usize = required(&opts, "max_memory_mb")?;
     let on_output: Function = required(&opts, "on_output")?;
+    let preamble: String = opts.get::<Option<String>>("preamble")?.unwrap_or_default();
     let tools_tbl: Option<Table> = opts.get("tools")?;
 
     let mut fns: HashMap<String, Function> = HashMap::new();
@@ -144,12 +145,19 @@ async fn interpreter_run(lua: Lua, code: String, opts: Table) -> LuaResult<Pair<
         };
 
         let mut flushed = 0usize;
-        let result = runner::run_streaming(&code, &tools, Some(&resolver), limits, &mut |chunk| {
-            flushed += chunk.len();
-            for line in chunk.lines() {
-                let _ = tx.send(BridgeMsg::Line(line.to_owned()));
-            }
-        })
+        let result = runner::run(
+            &code,
+            &preamble,
+            &tools,
+            Some(&resolver),
+            limits,
+            &mut |chunk| {
+                flushed += chunk.len();
+                for line in chunk.lines() {
+                    let _ = tx.send(BridgeMsg::Line(line.to_owned()));
+                }
+            },
+        )
         .map_err(|e| e.to_string());
         if let Ok(ir) = &result {
             for line in ir.stdout[flushed..].lines() {
@@ -167,7 +175,12 @@ async fn interpreter_run(lua: Lua, code: String, opts: Table) -> LuaResult<Pair<
                     let futs = batch.into_iter().map(|pc| {
                         let f = fns.get(&pc.name).cloned();
                         let lua = lua.clone();
-                        async move { (pc.call_id, call_lua_tool(lua, f, &pc).await) }
+                        // Name the tool on every failure: neither a traceback nor a
+                        // list of gathered results says which call broke.
+                        async move {
+                            let result = call_lua_tool(lua, f, &pc).await;
+                            (pc.call_id, result.map_err(|e| format!("{}: {e}", pc.name)))
+                        }
                     });
                     let _ = reply.send(join_all(futs).await);
                 }

--- a/maki-lua/tests/code_execution_policy.rs
+++ b/maki-lua/tests/code_execution_policy.rs
@@ -12,6 +12,9 @@ use maki_lua::PluginHost;
 const CODE_EXECUTION_SRC: &str = include_str!("../../plugins/code_execution/init.lua");
 
 const ECHO_PREFIX: &str = "echo:";
+const FAIL_MSG: &str = "fixture blew up";
+const ERROR_PREFIX: &str = "[ERROR] ";
+const GATHER_HINT_SUBSTR: &str = "`gather(...)` keeps the other results";
 const TASK_PREFIX: &str = "task:";
 const WORKFLOW_NOTE_SUBSTR: &str = "Workflow mode: orchestrate subagents";
 const INTERP_ECHO_SIG: &str = "- interp_echo(msg: str, count: int = None, flag: bool = None, items: list = None, raw: any = None) -> str";
@@ -53,6 +56,13 @@ maki.api.register_tool({{
     handler = function(input) return "{ECHO_PREFIX}" .. input.msg end,
 }})
 maki.api.register_tool({{
+    name = "interp_fail",
+    description = "failing interpreter fixture",
+    audiences = {{ "main", "interpreter" }},
+    schema = {{ type = "object", properties = {{}}, additionalProperties = false }},
+    handler = function() return {{ llm_output = "{FAIL_MSG}", is_error = true }} end,
+}})
+maki.api.register_tool({{
     name = "sub_tool",
     description = "subagent fixture",
     audiences = {{ "general_sub", "interpreter" }},
@@ -63,8 +73,7 @@ maki.api.register_tool({{
     )
 }
 
-fn setup() -> (Arc<ToolRegistry>, PluginHost) {
-    let reg = Arc::new(ToolRegistry::new());
+fn setup_with(reg: Arc<ToolRegistry>) -> (Arc<ToolRegistry>, PluginHost) {
     let host = PluginHost::new(Arc::clone(&reg)).unwrap();
     host.load_source("code_execution", CODE_EXECUTION_SRC)
         .expect("real plugin should load");
@@ -73,16 +82,14 @@ fn setup() -> (Arc<ToolRegistry>, PluginHost) {
     (reg, host)
 }
 
+fn setup() -> (Arc<ToolRegistry>, PluginHost) {
+    setup_with(Arc::new(ToolRegistry::new()))
+}
+
 /// Uses the global native registry because `interpreter_bridge::dispatch` does.
 /// Safe: nextest runs each test in its own process.
 fn setup_native() -> (Arc<ToolRegistry>, PluginHost) {
-    let reg = Arc::clone(ToolRegistry::global_arc());
-    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
-    host.load_source("code_execution", CODE_EXECUTION_SRC)
-        .expect("real plugin should load");
-    host.load_source("policy_fixtures", &fixture_plugin())
-        .expect("fixture plugin should load");
-    (reg, host)
+    setup_with(Arc::clone(ToolRegistry::global_arc()))
 }
 
 fn describe(
@@ -118,10 +125,16 @@ fn exec_code(reg: &ToolRegistry, ctx: &ToolContext, code: &str) -> Result<String
         })
 }
 
-fn stub_ctx_for(reg: &Arc<ToolRegistry>, mode: &AgentMode) -> ToolContext {
-    let mut ctx = stub_ctx(mode);
-    ctx.registry = Arc::clone(reg);
-    ctx
+fn run_code_in(code: &str, workflow: bool) -> Result<String, String> {
+    let (reg, _host) = setup_native();
+    let mut ctx = stub_ctx(&AgentMode::Build);
+    ctx.registry = Arc::clone(&reg);
+    ctx.workflow = workflow;
+    exec_code(&reg, &ctx, code)
+}
+
+fn run_code(code: &str) -> Result<String, String> {
+    run_code_in(code, false)
 }
 
 #[test]
@@ -165,40 +178,70 @@ fn except_filter_removes_tool_from_description() {
 
 #[test]
 fn interpreter_calls_advertised_tool_end_to_end() {
-    let (reg, _host) = setup_native();
-    let ctx = stub_ctx_for(&reg, &AgentMode::Build);
-    let out = exec_code(
-        &reg,
-        &ctx,
-        "result = await interp_echo(msg='hi')\nprint(result)",
-    )
-    .expect("advertised tool must be callable");
+    let out = run_code("result = await interp_echo(msg='hi')\nprint(result)")
+        .expect("advertised tool must be callable");
     assert!(out.contains(&format!("{ECHO_PREFIX}hi")), "got: {out}");
+}
+
+/// The list form covers a model that forgets the `*`. It must run rather than
+/// cost a TypeError round-trip.
+#[test_case::test_case("gather(interp_echo(msg='hi'), interp_fail())" ; "varargs")]
+#[test_case::test_case("gather([interp_echo(msg='hi'), interp_fail()])" ; "single_list")]
+fn gather_keeps_sibling_results_when_one_call_fails(call: &str) {
+    let out = run_code(&format!("ok, bad = await {call}\nprint(ok)\nprint(bad)"))
+        .expect("a failed call must not fail the script");
+    assert!(out.contains(&format!("{ECHO_PREFIX}hi")), "got: {out}");
+    assert!(
+        out.contains(&format!("{ERROR_PREFIX}interp_fail: {FAIL_MSG}")),
+        "failed call must name the tool and its error: {out}"
+    );
+}
+
+/// Only a failed tool call belongs in the results. The script's own mistake
+/// must stop the run instead of hiding as an `[ERROR]` entry.
+#[test]
+fn gather_lets_script_errors_through() {
+    let err = run_code("await gather(interp_echo(msg='hi'), 'not a call')")
+        .expect_err("awaiting a non-call must raise");
+    assert!(!err.contains(ERROR_PREFIX), "got: {err}");
+}
+
+/// `asyncio.gather` still cancels its siblings, so its error is the one place
+/// worth pointing at the wrapper. A bare await is fail-fast on purpose and
+/// must not nag.
+#[test_case::test_case("await interp_fail()", false ; "plain_await_stays_fail_fast")]
+#[test_case::test_case("await asyncio.gather(interp_echo(msg='hi'), interp_fail())", true ; "asyncio_gather_points_at_the_wrapper")]
+fn failed_call_error_names_the_tool_and_hints_only_for_asyncio_gather(code: &str, hint: bool) {
+    let err = run_code(code).expect_err("a failed call must raise");
+    assert!(
+        err.contains("interp_fail") && err.contains(FAIL_MSG),
+        "got: {err}"
+    );
+    assert_eq!(err.contains(GATHER_HINT_SUBSTR), hint, "got: {err}");
+}
+
+/// The model counts lines in the code it wrote, so the preamble it never sees
+/// must not shift them. Guards the plugin passing the preamble as its own
+/// option instead of pasting it onto the code.
+#[test]
+fn traceback_lines_are_numbered_from_the_users_first_line() {
+    let err = run_code("x = 1\nprint(boom_undefined)").expect_err("undefined name must error");
+    assert!(err.contains("line 2, in <module>"), "got: {err}");
 }
 
 #[test]
 fn workflow_tool_not_callable_when_workflow_false() {
-    let (reg, _host) = setup_native();
-    let ctx = stub_ctx_for(&reg, &AgentMode::Build);
-    let err = exec_code(&reg, &ctx, "await wf_task(prompt='x')")
+    let err = run_code("await wf_task(prompt='x')")
         .expect_err("workflow tool must not be in the fn-map when workflow=false");
     assert!(err.contains("wf_task"), "got: {err}");
 }
 
 /// Regression guard: the old `ctx:agent_context()` take() used to reset
-/// audience/workflow reads. That accessor is gone now, this makes sure
-/// workflow tools stay callable when `ctx.workflow = true`.
+/// audience/workflow reads, leaving workflow tools uncallable.
 #[test]
 fn workflow_tool_callable_when_workflow_true() {
-    let (reg, _host) = setup_native();
-    let mut ctx = stub_ctx_for(&reg, &AgentMode::Build);
-    ctx.workflow = true;
-    let out = exec_code(
-        &reg,
-        &ctx,
-        "result = await wf_task(prompt='x')\nprint(result)",
-    )
-    .expect("workflow tool must be callable when workflow=true");
+    let out = run_code_in("result = await wf_task(prompt='x')\nprint(result)", true)
+        .expect("workflow tool must be callable when workflow=true");
     assert!(out.contains(&format!("{TASK_PREFIX}x")), "got: {out}");
 }
 

--- a/plugins/code_execution/init.lua
+++ b/plugins/code_execution/init.lua
@@ -1,7 +1,7 @@
 -- Policy for the Python interpreter: which tools it may call, what the model
--- sees (via the `describe(dctx)` callback), and the import preamble. The
--- sandbox and dispatch live in Rust, which exposes primitives only
--- (`maki.api.get_tools`, `maki.agent.call_tool`); orchestration policy is here.
+-- sees (via the `describe(dctx)` callback), and the preamble. The sandbox and
+-- dispatch live in Rust, which exposes primitives only (`maki.api.get_tools`,
+-- `maki.agent.call_tool`); orchestration policy is here.
 
 local truncate = require("maki.truncate")
 local ToolView = require("maki.tool_view")
@@ -15,10 +15,42 @@ local NO_OUTPUT = "(no output)"
 local SEPARATOR = "──────"
 local CANCELLED_ERR = "cancelled"
 local TIME_LIMIT_SUBSTR = "time limit exceeded"
-local PREAMBLE = "import re\nimport asyncio\nimport sys\nimport os\nimport json\n"
+-- Same marker the batch tool uses for a failed child, so a failure reads the
+-- same wherever the model meets it.
+local ERROR_PREFIX = "[ERROR] "
+local ASYNCIO_GATHER = "asyncio.gather"
+local GATHER_HINT = "\n\nHint: `gather(...)` keeps the other results, returning `"
+  .. ERROR_PREFIX
+  .. "...` for the failed call."
+-- `asyncio.gather` cancels its siblings the moment one call raises, throwing away
+-- results the model already paid for, so `gather` awaits each call in its own
+-- `try` instead. Awaiting one at a time is still concurrent: every call was made
+-- before the first await, so they all sit pending and the host dispatches them in
+-- one batch. Tasks look like the obvious fix, but monty 0.0.21 fails the whole
+-- gather on an external call error rather than raising inside the awaiting task,
+-- and a coroutine wrapper is lazy, so a call handed over that way would run alone.
+-- Only `RuntimeError` is caught, the shape a failed tool call arrives in; a
+-- TypeError from the script itself must still stop the run.
+local PREAMBLE = ([[
+import re
+import asyncio
+import sys
+import os
+import json
+async def gather(*calls):
+    if len(calls) == 1 and isinstance(calls[0], list):
+        calls = calls[0]
+    results = []
+    for c in calls:
+        try:
+            results.append(await c)
+        except RuntimeError as e:
+            results.append('%s' + str(e))
+    return results
+]]):format(ERROR_PREFIX)
 local TOOLS_HEADER = "\n\nAvailable tools (called as Python functions with keyword arguments):\n"
 local WORKFLOW_TOOLS_NOTE =
-  "\nWorkflow mode: orchestrate subagents from this script. Await every `task(...)` call and use `asyncio.gather` for parallel fan-out. Pass `output_schema` to task for machine-readable results (a JSON string, parse with `json.loads`).\n"
+  "\nWorkflow mode: orchestrate subagents from this script. Await every `task(...)` call and use `gather(task(...), task(...))` for parallel fan-out. Pass `output_schema` to task for machine-readable results (a JSON string, parse with `json.loads`).\n"
 local PY_TYPES = { string = "str", integer = "int", boolean = "bool", array = "list" }
 
 local opts = maki.api.register_options(output_limits.extend({
@@ -80,10 +112,10 @@ end
 
 local description = [[Execute Python code in a sandboxed interpreter with tools as callable functions.
 
-Use for chained/dependent tool calls and filtering/processing results, e.g. filtering web tool output. **DRAMATICALLY** faster than sequential tool calls!
+Use for chained/dependent tool calls and filtering/processing results, e.g. filtering web tool output. **DRAMATICALLY** cheaper than sequential tool calls!
 
 - All tools are async and return strings: `result = await read(path='file.txt', offset=1, limit=0)`. Parse output yourself.
-- Use `asyncio.gather()` for concurrency within one execution.
+- Concurrency: `a, b = await gather(read(path='a.py', offset=1, limit=0), grep(pattern='x'))`. Pass calls directly, never wrapped in `async def`.
 - Available libs: re, asyncio, sys, os, json. No other imports, no classes, no filesystem/network access.
 - Fresh sandbox each run: no state persists between executions.
 - 30s script timeout (`timeout` param); time awaiting tool calls doesn't count.
@@ -98,7 +130,7 @@ local schema = {
   properties = {
     code = {
       type = "string",
-      description = "Python code to execute. Tools are async functions that return strings (not objects). You MUST await every call: `result = await read(path='/file', offset=1, limit=0)`. Use `await asyncio.gather(...)` for concurrency.",
+      description = "Python code to execute. Tools are async functions that return strings (not objects). You MUST await every call: `result = await read(path='/file', offset=1, limit=0)`. Use `await gather(...)` for concurrency.",
     },
     timeout = {
       type = "integer",
@@ -110,7 +142,7 @@ local schema = {
 local examples = {
   {
     code = [[files = (await glob(pattern='**/*.rs')).strip().split('\n')
-results = await asyncio.gather(*[read(path=f, offset=1, limit=0) for f in files if f.strip()])
+results = await gather(*[read(path=f, offset=1, limit=0) for f in files if f.strip()])
 for f, c in zip(files, results):
     if 'fn main' in c: print(f)]],
   },
@@ -260,9 +292,10 @@ local function handler(input, ctx)
     end
   end
 
-  local result, err = maki.interpreter.run(PREAMBLE .. input.code, {
+  local result, err = maki.interpreter.run(input.code, {
     timeout = timeout,
     max_memory_mb = opts.max_memory_mb,
+    preamble = PREAMBLE,
     on_output = show,
     tools = tools,
   })
@@ -279,7 +312,10 @@ local function handler(input, ctx)
     end
     view:append_text(err)
     view:finish()
-    return { llm_output = err, is_error = true, body = buf }
+    -- The run is already paid for, so point a script that reached for
+    -- `asyncio.gather` at the wrapper that would have kept its other results.
+    local hint = input.code:find(ASYNCIO_GATHER, 1, true) and GATHER_HINT or ""
+    return { llm_output = err .. hint, is_error = true, body = buf }
   end
 
   local output = result.stdout or ""

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -2322,6 +2322,8 @@ Requires the `run` [plugin permission](#plugin-permissions).
 
   Optional fields:
 
+  - `preamble` (`string?`) Python source (imports, helpers) compiled ahead of
+    {code}. Tracebacks are rebased so line 1 is {code} line 1.
   - `tools` (`table?`) map of `name -> function` for tools the sandbox may call.
     Each function receives the tool input table and must return `(string)` or
     `(nil, err)`. Tool calls are batched and dispatched concurrently.

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -146,7 +146,7 @@ Execute Python code in a sandboxed interpreter with tools as callable functions.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `code` | string | yes |  | Python code to execute. Tools are async functions that return strings (not objects). You MUST await every call: `result = await read(path='/file', offset=1, limit=0)`. Use `await asyncio.gather(...)` for concurrency. |
+| `code` | string | yes |  | Python code to execute. Tools are async functions that return strings (not objects). You MUST await every call: `result = await read(path='/file', offset=1, limit=0)`. Use `await gather(...)` for concurrency. |
 | `timeout` | integer | no | 30 | Script execution timeout in seconds |
 
 ### `question` {#question}


### PR DESCRIPTION
`asyncio.gather` cancels its siblings the moment one call raises, so a single bad `index` call threw away two good greps and the model paid to run all three again.

The sandbox preamble now defines `gather(*calls)`, which awaits each call in its own `try` and hands back `[ERROR] <tool>: msg` for the ones that broke, while the rest keep their output. Awaiting one at a time costs nothing: every call is already pending when the first await parks, so the host still dispatches them in one concurrent batch. Wrapping each item in a coroutine so `asyncio.gather` could spawn tasks does not work, because monty 0.0.21 fails the whole gather on an external call error instead of raising it inside the task that awaited it.

Plain `await` still raises, dependent scripts stay fail fast, and a script that used `asyncio.gather` and died gets one line telling it about the wrapper.

`maki.interpreter.run` takes the preamble as its own option now and rebases tracebacks onto it, so `line 2` means the second line the model wrote instead of the second line of our imports.

Closes #836.