### PR TITLE
feat(ui): keep the /yolo toggle across session resume

### DIFF
--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -342,14 +342,13 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
     let mailbox = SessionMailbox::register(session_id);
 
     let working_dir = params.initial_wd.to_string_lossy().into_owned();
+    let mut permissions_config = params.permissions_config;
+    permissions_config.yolo |= params.yolo;
     let permissions = Arc::new(PermissionManager::new(
-        params.permissions_config,
+        permissions_config,
         params.initial_wd,
         Arc::clone(&params.plugin_rules),
     ));
-    if params.yolo {
-        permissions.toggle_yolo();
-    }
 
     let answer_rx = Arc::new(Mutex::new(answer_rx));
     let file_tracker = FileReadTracker::fresh();

--- a/maki-agent/src/permissions.rs
+++ b/maki-agent/src/permissions.rs
@@ -191,6 +191,12 @@ pub struct PermissionManager {
     config_rules: Vec<PermissionRule>,
     builtin_rules: Vec<PermissionRule>,
     yolo: AtomicBool,
+    /// Whether the user set yolo for this session themselves, which is what
+    /// makes it worth persisting.
+    yolo_explicit: AtomicBool,
+    /// What `--yolo` / `always_yolo` seeded `yolo` with, so a session with no
+    /// stored intent falls back to the flag instead of to off.
+    seed_yolo: bool,
     default: DefaultEffect,
     tool_defaults: HashMap<ToolKey, DefaultEffect>,
     cwd: PathBuf,
@@ -234,6 +240,8 @@ impl PermissionManager {
             session_rules: Mutex::new(Vec::new()),
             config_rules,
             yolo: AtomicBool::new(config.yolo),
+            yolo_explicit: AtomicBool::new(false),
+            seed_yolo: config.yolo,
             default: config.default,
             tool_defaults: config.tool_defaults,
             cwd,
@@ -250,6 +258,8 @@ impl PermissionManager {
             config_rules: self.config_rules.clone(),
             builtin_rules: self.builtin_rules.clone(),
             yolo: AtomicBool::new(self.is_yolo()),
+            yolo_explicit: AtomicBool::new(self.yolo_explicit.load(Ordering::Relaxed)),
+            seed_yolo: self.seed_yolo,
             default: self.default,
             tool_defaults: self.tool_defaults.clone(),
             cwd: self.cwd.clone(),
@@ -399,13 +409,34 @@ impl PermissionManager {
         }
     }
 
+    /// The explicit toggle, so it also claims the session's intent: `/yolo` off
+    /// under `--yolo` genuinely turns the session off and is remembered.
     pub fn toggle_yolo(&self) -> bool {
-        let prev = self.yolo.fetch_xor(true, Ordering::Relaxed);
-        !prev
+        let enabled = !self.yolo.fetch_xor(true, Ordering::Relaxed);
+        self.yolo_explicit.store(true, Ordering::Relaxed);
+        enabled
+    }
+
+    /// Replaces whatever this session was running with: `Some` is the user's
+    /// stored intent, `None` means they never expressed one and the seed
+    /// applies again.
+    pub fn set_session_yolo(&self, stored: Option<bool>) {
+        self.yolo
+            .store(stored.unwrap_or(self.seed_yolo), Ordering::Relaxed);
+        self.yolo_explicit
+            .store(stored.is_some(), Ordering::Relaxed);
     }
 
     pub fn is_yolo(&self) -> bool {
         self.yolo.load(Ordering::Relaxed)
+    }
+
+    /// What the session may persist. A one-shot `--yolo` is a property of the
+    /// invocation, so on its own it stores nothing.
+    pub fn persisted_yolo(&self) -> Option<bool> {
+        self.yolo_explicit
+            .load(Ordering::Relaxed)
+            .then(|| self.is_yolo())
     }
 
     /// Outside-cwd paths are not blocked here. They flow through the normal
@@ -1273,6 +1304,55 @@ mod tests {
             mgr.check(&ToolKey::native("bash"), "rm -rf /", None),
             PermissionCheck::Denied
         ));
+    }
+
+    fn seeded_mgr(yolo: bool) -> PermissionManager {
+        mgr_with(
+            PermissionsConfig {
+                yolo,
+                ..Default::default()
+            },
+            PathBuf::from("/tmp"),
+        )
+    }
+
+    /// A fork runs the same session, so it has to answer both questions the
+    /// same way or a respawned agent drifts from the tab that owns it.
+    fn yolo_state(mgr: &PermissionManager) -> (bool, Option<bool>) {
+        let forked = mgr.fork();
+        assert_eq!(
+            (forked.is_yolo(), forked.persisted_yolo()),
+            (mgr.is_yolo(), mgr.persisted_yolo()),
+        );
+        (mgr.is_yolo(), mgr.persisted_yolo())
+    }
+
+    /// A stored intent replaces the seed outright, and no stored intent falls
+    /// back to it: `--yolo` must neither be erased by an untouched session nor
+    /// survive one the user explicitly turned off.
+    #[test_case(false, None        => (false, None)        ; "no_flag_and_no_intent_stays_off")]
+    #[test_case(true,  None        => (true,  None)        ; "the_flag_applies_but_is_never_stored")]
+    #[test_case(false, Some(true)  => (true,  Some(true))  ; "stored_on_comes_back_without_the_flag")]
+    #[test_case(true,  Some(true)  => (true,  Some(true))  ; "the_flag_does_not_wipe_stored_on")]
+    #[test_case(true,  Some(false) => (false, Some(false)) ; "stored_off_overrides_the_flag")]
+    #[test_case(false, Some(false) => (false, Some(false)) ; "stored_off_stays_off")]
+    fn a_stored_yolo_intent_replaces_the_seed(
+        seed: bool,
+        stored: Option<bool>,
+    ) -> (bool, Option<bool>) {
+        let mgr = seeded_mgr(seed);
+        mgr.set_session_yolo(stored);
+        yolo_state(&mgr)
+    }
+
+    /// `/yolo` always drives the effective state, so under `--yolo` it can turn
+    /// the session off, and either way the session now owns the answer.
+    #[test_case(false => (true,  Some(true))  ; "toggling_on_claims_the_session")]
+    #[test_case(true  => (false, Some(false)) ; "toggling_off_under_the_flag_claims_the_session")]
+    fn toggling_yolo_records_the_intent(seed: bool) -> (bool, Option<bool>) {
+        let mgr = seeded_mgr(seed);
+        assert_eq!(mgr.toggle_yolo(), !seed);
+        yolo_state(&mgr)
     }
 
     #[test]

--- a/maki-docgen/src/gen_commands.rs
+++ b/maki-docgen/src/gen_commands.rs
@@ -78,7 +78,7 @@ pub fn generate() -> String {
     writeln!(out).unwrap();
     writeln!(
         out,
-        "- **`/yolo`**: skip permission prompts for this session (deny rules still apply). Config: `always_yolo = true`."
+        "- **`/yolo`**: skip permission prompts for this session (deny rules still apply). The toggle survives a resume, and `--yolo` only sets the starting value. Config: `always_yolo = true`."
     )
     .unwrap();
     writeln!(

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -154,6 +154,10 @@ pub struct SessionMeta {
     pub fast: bool,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub workflow: bool,
+    /// `None` when the user never set yolo for this session, which is what
+    /// makes `--yolo` a property of the invocation rather than of the log.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub yolo: Option<bool>,
 }
 
 /// Messages plus the token of the run they belong to. Comparing tokens tells
@@ -3046,6 +3050,7 @@ mod tests {
         assert!(meta.thinking.is_none());
         assert!(!meta.fast);
         assert!(!meta.workflow);
+        assert!(meta.yolo.is_none());
     }
 
     #[test]
@@ -3056,6 +3061,7 @@ mod tests {
         session.meta.thinking = Some(StoredThinking::Budget { tokens: 8192 });
         session.meta.fast = true;
         session.meta.workflow = true;
+        session.meta.yolo = Some(true);
         session.save_to(dir).unwrap();
 
         let loaded = TestSession::load_from(session.id, dir).unwrap();
@@ -3065,6 +3071,7 @@ mod tests {
         );
         assert!(loaded.meta.fast);
         assert!(loaded.meta.workflow);
+        assert_eq!(loaded.meta.yolo, Some(true));
     }
 
     #[test]

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -131,6 +131,7 @@ impl App {
             thinking: Some(state.thinking.into()),
             fast: state.fast,
             workflow: state.workflow,
+            yolo: self.permissions.persisted_yolo(),
         }
     }
 
@@ -255,12 +256,22 @@ impl App {
         }
     }
 
+    /// Shared by every restore path: `focus_session` picks between resuming in
+    /// place and spawning a fresh runtime by tab state alone, so the same key
+    /// press has to land on the same permissions. The stored value replaces
+    /// whatever the previous session was running with, and a session that
+    /// stored nothing falls back to `--yolo` / `always_yolo`.
+    fn apply_stored_yolo(&self, meta: &SessionMeta) {
+        self.permissions.set_session_yolo(meta.yolo);
+    }
+
     /// Resume at process start: the agent was already spawned with this
     /// history, so no respawn follows and the restored queue must be
     /// flushed here.
     pub(crate) fn restore_resumed_session(&mut self) {
         self.permissions
             .load_session_rules(stored_to_rules(&self.state.session.meta.session_rules));
+        self.apply_stored_yolo(&self.state.session.meta);
         self.restore_display();
         self.flush_restored_queue();
         for w in self.state.warnings.drain(..) {
@@ -287,6 +298,7 @@ impl App {
         self.state.cost = None;
         self.state.context_size = 0;
         self.state.plan = PlanState::None;
+        self.permissions.set_session_yolo(None);
         if self.state.mode == Mode::Plan {
             self.enter_plan();
         }
@@ -346,6 +358,7 @@ impl App {
         self.checkpoint_now();
         self.permissions
             .load_session_rules(stored_to_rules(&session.meta.session_rules));
+        self.apply_stored_yolo(&session.meta);
         self.state =
             SessionState::from_session(session, fallback_model, &self.storage, &self.model_policy);
         for w in self.state.warnings.drain(..) {

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -39,6 +39,7 @@ const HINT_STYLE: &str = "fg";
 const RETRY_MESSAGE: &str = "overloaded";
 const RETRY_DELAY: Duration = Duration::from_secs(5);
 const MISSING_DIR: &str = "gone";
+const RESUMED_PROMPT: &str = "carry me over";
 const SONNET_SPEC: &str = "anthropic/claude-sonnet-4-5";
 const OPUS_SPEC: &str = "anthropic/claude-opus-4-8";
 const PLAIN_MODEL_SPEC: &str = "ollama/qwen3";
@@ -2487,6 +2488,92 @@ fn yolo_toggle() {
     assert!(!app.permissions.is_yolo());
     let flash = app.status_bar.flash_text().unwrap();
     assert!(flash.contains("disabled"), "flash={flash:?}");
+}
+
+/// The toggle is session state like mode and thinking, so a checkpoint has to
+/// mirror it or a resume silently downgrades the session's permissions.
+#[test]
+fn checkpoint_mirrors_the_yolo_toggle_into_meta() {
+    let mut app = test_app();
+    app.checkpoint();
+    assert_eq!(app.state.session.meta.yolo, None);
+
+    app.execute_command(cmd("/yolo"), 0);
+    app.checkpoint();
+    assert_eq!(app.state.session.meta.yolo, Some(true));
+
+    app.execute_command(cmd("/yolo"), 0);
+    app.checkpoint();
+    assert_eq!(app.state.session.meta.yolo, Some(false));
+}
+
+fn app_and_session_with_yolo(seed: bool, stored: Option<bool>) -> (App, AppSession) {
+    let mut app = test_app();
+    if seed {
+        app.permissions = Arc::new(PermissionManager::new(
+            PermissionsConfig {
+                yolo: true,
+                ..Default::default()
+            },
+            PathBuf::from("/tmp"),
+            Arc::default(),
+        ));
+    }
+    let mut session = AppSession::new("test-model", "/tmp/test");
+    session.meta.yolo = stored;
+    session.push_message(Message::user(RESUMED_PROMPT.into()));
+    (app, session)
+}
+
+/// The restored permissions, then what the next checkpoint writes back. Both
+/// matter: `--yolo` and `always_yolo` are properties of the invocation, so a
+/// resume under the flag must neither mark an untouched session nor erase the
+/// intent a marked one already carries.
+#[test_case(false, None        => (false, None)        ; "no_flag_and_nothing_stored_stays_off")]
+#[test_case(true,  None        => (true,  None)        ; "the_flag_applies_without_marking_the_session")]
+#[test_case(false, Some(true)  => (true,  Some(true))  ; "stored_on_comes_back_without_the_flag")]
+#[test_case(true,  Some(true)  => (true,  Some(true))  ; "the_flag_does_not_wipe_stored_on")]
+#[test_case(true,  Some(false) => (false, Some(false)) ; "stored_off_overrides_the_flag")]
+fn resume_applies_stored_yolo(seed: bool, stored: Option<bool>) -> (bool, Option<bool>) {
+    let (mut app, session) = app_and_session_with_yolo(seed, stored);
+    app.state.session = Arc::new(session);
+
+    app.restore_resumed_session();
+    app.checkpoint();
+    (app.permissions.is_yolo(), app.state.session.meta.yolo)
+}
+
+/// `focus_session` sends the same key press down this path instead of a fresh
+/// runtime whenever the focused tab is blank and idle, so it has to reach the
+/// same permissions as `resume_applies_stored_yolo`.
+#[test_case(false, None        => (false, None)        ; "no_flag_and_nothing_stored_stays_off")]
+#[test_case(true,  None        => (true,  None)        ; "the_flag_applies_without_marking_the_session")]
+#[test_case(false, Some(true)  => (true,  Some(true))  ; "stored_on_comes_back_without_the_flag")]
+#[test_case(true,  Some(true)  => (true,  Some(true))  ; "the_flag_does_not_wipe_stored_on")]
+#[test_case(true,  Some(false) => (false, Some(false)) ; "stored_off_overrides_the_flag")]
+fn loading_a_session_applies_stored_yolo(seed: bool, stored: Option<bool>) -> (bool, Option<bool>) {
+    let (mut app, session) = app_and_session_with_yolo(seed, stored);
+    let model = app.state.model.clone();
+
+    app.apply_loaded_session(session, &model);
+    app.checkpoint();
+    (app.permissions.is_yolo(), app.state.session.meta.yolo)
+}
+
+/// A tab keeps one permission manager for its whole life, so without an
+/// explicit reset `/new` would inherit the resumed session's answer and then
+/// checkpoint it into a session the user never said anything about.
+#[test_case(false => (false, None) ; "a_fresh_session_drops_a_stored_bypass")]
+#[test_case(true  => (true,  None) ; "a_fresh_session_returns_to_the_flag")]
+fn resetting_the_session_falls_back_to_the_yolo_seed(seed: bool) -> (bool, Option<bool>) {
+    let (mut app, session) = app_and_session_with_yolo(seed, Some(!seed));
+    app.state.session = Arc::new(session);
+    app.restore_resumed_session();
+    assert_eq!(app.permissions.is_yolo(), !seed);
+
+    app.reset_session();
+    app.checkpoint();
+    (app.permissions.is_yolo(), app.state.session.meta.yolo)
 }
 
 #[test]

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -311,6 +311,7 @@ impl App {
             thinking_label: self.state.thinking.status_label(),
             fast: self.state.fast,
             workflow: self.state.workflow,
+            yolo: self.permissions.is_yolo(),
             restoring: self.restoring.load(Ordering::Relaxed),
         };
         self.status_bar.view(frame, status_area, &ctx);

--- a/maki-ui/src/components/status_bar.rs
+++ b/maki-ui/src/components/status_bar.rs
@@ -22,6 +22,7 @@ const TRUNCATE_PREFIX: &str = "..";
 const CWD_MODEL_SEPARATOR: &str = "  ";
 const FAST_LABEL: &str = " [fast]";
 const WORKFLOW_LABEL: &str = " [workflow]";
+const YOLO_LABEL: &str = " [yolo]";
 
 pub struct UsageStats {
     /// The whole session's bill, drawn next to the focused chat's own once
@@ -45,6 +46,7 @@ pub struct StatusBarContext<'a> {
     pub thinking_label: Option<Cow<'static, str>>,
     pub fast: bool,
     pub workflow: bool,
+    pub yolo: bool,
     pub restoring: bool,
 }
 
@@ -193,6 +195,9 @@ impl StatusBar {
                 }
                 if ctx.workflow {
                     rest_spans.push(Span::styled(WORKFLOW_LABEL, theme::current().status_dim));
+                }
+                if ctx.yolo {
+                    rest_spans.push(Span::styled(YOLO_LABEL, theme::current().error));
                 }
 
                 let context_text = format!(
@@ -361,7 +366,7 @@ mod tests {
     const SESSION_COST_TEXT: &str = "\u{03a3}$1.500";
     const SIGMA: char = '\u{03a3}';
 
-    fn render(global_cost: Option<f64>, show_global: bool) -> String {
+    fn render(global_cost: Option<f64>, show_global: bool, yolo: bool) -> String {
         let bar = StatusBar::new(FLASH_TTL);
         let mut terminal =
             ratatui::Terminal::new(ratatui::backend::TestBackend::new(BAR_WIDTH, 1)).unwrap();
@@ -383,6 +388,7 @@ mod tests {
             thinking_label: None,
             fast: false,
             workflow: false,
+            yolo,
             restoring: false,
         };
         terminal.draw(|f| bar.view(f, f.area(), &ctx)).unwrap();
@@ -400,7 +406,7 @@ mod tests {
         global_cost: Option<f64>,
         show_global: bool,
     ) -> bool {
-        let text = render(global_cost, show_global);
+        let text = render(global_cost, show_global, false);
         assert_eq!(text.matches(CHAT_COST_TEXT).count(), 1, "{text}");
         let shown = text.matches(SESSION_COST_TEXT).count() == 1;
         assert_eq!(
@@ -409,6 +415,14 @@ mod tests {
             "a sigma carrying another number is a misrender: {text}"
         );
         shown
+    }
+
+    /// Yolo now outlives the process that turned it on, so the one-shot flash
+    /// is no longer enough to tell the user their prompts are being skipped.
+    #[test_case(true  => true  ; "a_bypassed_session_says_so")]
+    #[test_case(false => false ; "a_prompting_session_stays_quiet")]
+    fn the_bar_advertises_yolo(yolo: bool) -> bool {
+        render(None, false, yolo).contains(YOLO_LABEL.trim())
     }
 
     #[test_case("/home/user/projects/app", "/home/user", "~/projects/app" ; "inside_home")]

--- a/site/docs/content/commands/_index.md
+++ b/site/docs/content/commands/_index.md
@@ -41,7 +41,7 @@ Sessions run concurrently. `/new` starts a fresh session while the old one keeps
 
 ## Modes and toggles
 
-- **`/yolo`**: skip permission prompts for this session (deny rules still apply). Config: `always_yolo = true`.
+- **`/yolo`**: skip permission prompts for this session (deny rules still apply). The toggle survives a resume, and `--yolo` only sets the starting value. Config: `always_yolo = true`.
 - **`/thinking`**: extended thinking. Optional arg: `off`, `adaptive`, an effort level (`minimal` … `max`), or a token budget number. Config: `always_thinking`.
 - **`/fast`**: Anthropic fast mode (Opus only; ignored on other models). Config: `always_fast = true`.
 - **`/workflow`**: let `code_execution` call the `task` tool (and other workflow-only tools) from inside the Python sandbox. Config: `always_workflow = true`.

--- a/site/docs/content/permissions/_index.md
+++ b/site/docs/content/permissions/_index.md
@@ -171,7 +171,7 @@ For MCP tools, both allow and deny decisions generalize to `*` (the entire tool)
 
 ## YOLO Mode
 
-To skip prompts on gated tools, toggle YOLO with `/yolo`, or run with `--yolo`. Explicit deny rules still apply. Tools that never declare permission scopes are unaffected (they never prompted).
+To skip prompts on gated tools, toggle YOLO with `/yolo`, or run with `--yolo`. Explicit deny rules still apply. The status bar shows `[yolo]` while it is on, and `/yolo` is stored with the session, so a resume comes back the same way. `--yolo` only sets the starting value for sessions you never toggled. Tools that never declare permission scopes are unaffected (they never prompted).
 
 To start in YOLO mode every time:
 


### PR DESCRIPTION
## Problem

Every other session setting (mode, thinking, fast, workflow, session rules) is mirrored into `SessionMeta` and restored on resume, but yolo lived only in an `AtomicBool` on the permission manager. Quitting and coming back reset the session to prompting again.

## Solution

- Mirror the toggle into a new `yolo` field on `SessionMeta` (`#[serde(default)]`, so old logs load untouched).
- Process-start resume (`-c` / `-s`) applies it upgrade-only: a session toggled into yolo comes back that way, but a stored `false` never undoes an explicit `--yolo` on this invocation.
- Loading a session mid-run (picker) restores it exactly, like every other field the load replaces.
- `/reload` needs nothing special since it re-spawns runtimes through the same restore path.

## Testing

- checkpoint mirroring test (toggle → meta → toggle back)
- resume test with three combinations of stored/live state
- exact restore on mid-run session load
- storage roundtrip + backward-compat defaults

All 4072 workspace tests pass; lint, fmt and gen-docs-check clean.