### PR TITLE
feat(ui): flag discovered free models and sort them first in the picker

### DIFF
--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -243,6 +243,9 @@ pub struct Model {
     pub thinking_override: Option<ThinkingSupport>,
     pub supports_vision_override: Option<bool>,
     pub pricing: ModelPricing,
+    /// Discovery reported an explicit all-zero price. Distinct from a zero
+    /// `pricing`, which also covers "no price is known".
+    pub discovered_free: bool,
     /// `None` when unknown, see [`ProviderKind::fallback_max_output`].
     pub max_output_tokens: Option<u32>,
     pub context_window: u32,
@@ -261,9 +264,10 @@ impl Model {
         let discovered = discovered.as_ref();
         let tier = model_registry::tier_for(&spec, manifest.slug, static_entry.map(|e| e.tier));
         let family = static_entry.map_or(manifest.family, |entry| entry.family);
-        let pricing = discovered
-            .and_then(|info| info.pricing.clone())
-            .or_else(|| static_entry.map(|entry| entry.pricing.clone()))
+        let discovered_pricing = discovered.and_then(|info| info.pricing.as_ref());
+        let pricing = discovered_pricing
+            .or_else(|| static_entry.map(|entry| &entry.pricing))
+            .cloned()
             .unwrap_or_default();
         let max_output_tokens = discovered
             .and_then(|info| info.max_output_tokens)
@@ -283,6 +287,7 @@ impl Model {
             thinking_override: None,
             supports_vision_override: None,
             pricing,
+            discovered_free: discovered_pricing.is_some_and(ModelPricing::is_zero),
             max_output_tokens,
             context_window,
             thinking_fields: None,
@@ -314,6 +319,7 @@ impl Model {
                 cache_read: meta.cache_read,
                 fast: None,
             },
+            discovered_free: false,
             max_output_tokens: Some(meta.output),
             context_window: meta.context,
             thinking_fields: None,
@@ -515,12 +521,15 @@ impl Model {
 
     /// Free public models surfaced through the OpenCode provider (Zen/Go),
     /// using the catalog's definition of free (zero input and output price),
-    /// the same one that gates `enable_free_models`.
+    /// the same one that gates `enable_free_models`, plus models a provider's
+    /// `/models` call reported at an explicit zero price.
     ///
     /// Queries the live catalog rather than `self.pricing`, which may not yet
-    /// reflect catalog prices when discovery hasn't seeded the registry.
+    /// reflect catalog prices when discovery hasn't seeded the registry, and
+    /// which reads zero for "price unknown" too.
     pub fn is_free(&self) -> bool {
-        crate::providers::catalog::free_model_if_available(&self.provider, &self.id)
+        self.discovered_free
+            || crate::providers::catalog::free_model_if_available(&self.provider, &self.id)
     }
 }
 
@@ -680,6 +689,14 @@ mod tests {
         cache_read: 44,
     };
     const RECORDED_COST: f64 = 0.25;
+    const FREE_MEANS_A_KNOWN_ZERO: &str = "only a price discovery reported as zero means free";
+    const PAID_PRICING: ModelPricing = ModelPricing {
+        input: 3.0,
+        output: 15.0,
+        cache_write: 0.0,
+        cache_read: 0.0,
+        fast: None,
+    };
 
     #[test_case(999, "999"         ; "under_thousand")]
     #[test_case(1_000, "1.0k"      ; "thousand")]
@@ -1081,6 +1098,25 @@ mod tests {
         );
         assert_eq!(wrapped.spec(), format!("my-ollama-wrap/{model_id}"));
         assert_eq!(wrapped.context_window, expected_window);
+    }
+
+    /// "We could not read a price" must never reach the picker as "free", so
+    /// only an explicit zero from discovery sets the flag.
+    #[test_case(Some(ModelPricing::ZERO), true  ; "explicit_zero_is_free")]
+    #[test_case(Some(PAID_PRICING),       false ; "priced_is_not_free")]
+    #[test_case(None,                     false ; "unknown_price_is_not_free")]
+    fn discovered_pricing_decides_free(pricing: Option<ModelPricing>, expected: bool) {
+        let model_id = "test-discovered-free-model";
+        model_registry::set_known_models(
+            "ollama",
+            vec![ModelInfo {
+                pricing,
+                ..ModelInfo::id_only(model_id.to_string())
+            }],
+        );
+
+        let model = Model::from_base(ManifestRegistry::get("ollama").unwrap(), "ollama", model_id);
+        assert_eq!(model.is_free(), expected, "{FREE_MEANS_A_KNOWN_ZERO}");
     }
 
     /// A schedule hung on the wrong manifest silently doubles every turn of a

--- a/maki-providers/src/pricing.rs
+++ b/maki-providers/src/pricing.rs
@@ -207,6 +207,7 @@ mod tests {
                 input: input_rate,
                 ..ModelPricing::ZERO
             },
+            discovered_free: false,
             max_output_tokens: None,
             context_window: 0,
             thinking_fields: None,

--- a/maki-providers/src/providers/catalog.rs
+++ b/maki-providers/src/providers/catalog.rs
@@ -1025,6 +1025,7 @@ mod tests {
             thinking_override: None,
             supports_vision_override: None,
             pricing: ModelPricing::default(),
+            discovered_free: false,
             max_output_tokens: None,
             context_window: 0,
             thinking_fields: None,

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -152,6 +152,7 @@ fn model_from_def(def: &ProviderDef, kind: ProviderKind, slug: &str, model_id: &
         thinking_override,
         supports_vision_override,
         pricing,
+        discovered_free: false,
         max_output_tokens,
         context_window,
         thinking_fields: None,

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -99,6 +99,7 @@ impl ScriptModel {
             ),
             supports_vision_override: self.supports_vision,
             pricing: self.pricing.clone().unwrap_or_default(),
+            discovered_free: false,
             max_output_tokens: Some(self.max_output_tokens),
             context_window: self.context_window,
             thinking_fields: self.thinking_fields.clone().map(Box::new),

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -701,6 +701,7 @@ mod tests {
             supports_tool_examples_override: None,
             thinking_override: None,
             pricing: ModelPricing::default(),
+            discovered_free: false,
             max_output_tokens: Some(8192),
             context_window: 1_048_576,
             thinking_fields: None,

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -117,28 +117,26 @@ fn parse_model(m: &Value) -> Option<ModelInfo> {
     let supports_vision = input_modalities.iter().any(|m| m.as_str() == Some("image"));
 
     // Parse with OpenRouter-specific pricing field names. OpenRouter reports
-    // per-token prices; scale to $/M as `ModelPricing` expects.
+    // per-token prices; scale to $/M as `ModelPricing` expects. A missing or
+    // unparsable price stays `None` so it never reads as free.
     let id = m["id"].as_str()?;
     let context_window = m["context_length"]
         .as_u64()
         .and_then(|v| u32::try_from(v).ok());
     let per_token =
         |p: &Value| -> Option<f64> { Some(p.as_str()?.parse::<f64>().ok()? * PER_MILLION) };
-    let pricing = m["pricing"]
-        .as_object()
-        .and_then(|p| {
-            Some(ModelPricing {
-                input: per_token(p.get("prompt")?)?,
-                output: per_token(p.get("completion")?)?,
-                cache_write: p
-                    .get("input_cache_write")
-                    .and_then(per_token)
-                    .unwrap_or(0.0),
-                cache_read: p.get("input_cache_read").and_then(per_token).unwrap_or(0.0),
-                fast: None,
-            })
+    let pricing = m["pricing"].as_object().and_then(|p| {
+        Some(ModelPricing {
+            input: per_token(p.get("prompt")?)?,
+            output: per_token(p.get("completion")?)?,
+            cache_write: p
+                .get("input_cache_write")
+                .and_then(per_token)
+                .unwrap_or(0.0),
+            cache_read: p.get("input_cache_read").and_then(per_token).unwrap_or(0.0),
+            fast: None,
         })
-        .unwrap_or_default();
+    });
 
     let reasoning = m
         .get("reasoning")
@@ -170,7 +168,7 @@ fn parse_model(m: &Value) -> Option<ModelInfo> {
         id: id.to_string(),
         context_window,
         max_output_tokens: None,
-        pricing: Some(pricing),
+        pricing,
         supports_thinking: Some(supports_thinking),
         supports_vision: Some(supports_vision),
         tier: None,
@@ -244,6 +242,8 @@ mod tests {
     use super::*;
     use crate::ThinkingConfig;
 
+    const UNKNOWN_PRICE_STAYS_UNKNOWN: &str = "a price we cannot read must not become a zero price";
+
     fn kimi_k3_json() -> Value {
         json!({
             "id": "moonshotai/kimi-k3",
@@ -288,6 +288,19 @@ mod tests {
         assert_eq!(pricing.cache_write, 3.75);
     }
 
+    /// A price we cannot read used to collapse to an all-zero `ModelPricing`,
+    /// which downstream reads as "free". Unknown has to stay unknown.
+    #[test_case(json!(null)                                       ; "no_pricing_object")]
+    #[test_case(json!({"prompt": "0.000003"})                     ; "no_completion")]
+    #[test_case(json!({"prompt": "n/a", "completion": "0.000015"}) ; "unparsable_prompt")]
+    fn parse_model_keeps_unusable_pricing_unknown(pricing: Value) {
+        let mut m = kimi_k3_json();
+        m["pricing"] = pricing;
+
+        let info = parse_model(&m).expect("model should parse");
+        assert!(info.pricing.is_none(), "{UNKNOWN_PRICE_STAYS_UNKNOWN}");
+    }
+
     #[test]
     fn parse_model_reasoning_efforts_skips_unknown_and_sorts() {
         let mut m = kimi_k3_json();
@@ -317,6 +330,7 @@ mod tests {
             thinking_override: None,
             supports_vision_override: None,
             pricing: ModelPricing::default(),
+            discovered_free: false,
             max_output_tokens: Some(8192),
             context_window: 200_000,
             thinking_fields: None,

--- a/maki-providers/src/providers/xai/platform.rs
+++ b/maki-providers/src/providers/xai/platform.rs
@@ -310,6 +310,7 @@ mod tests {
             }),
             supports_vision_override: Some(true),
             pricing: ModelPricing::ZERO,
+            discovered_free: false,
             max_output_tokens: Some(131_072),
             context_window: 500_000,
             thinking_fields: None,

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -1165,6 +1165,7 @@ mod tests {
             thinking_override: None,
             supports_vision_override: Some(provider.family().supports_vision()),
             pricing: crate::model::ModelPricing::default(),
+            discovered_free: false,
             max_output_tokens: Some(8192),
             context_window: 200_000,
             thinking_fields: None,

--- a/maki-ui/src/components/mod.rs
+++ b/maki-ui/src/components/mod.rs
@@ -399,6 +399,7 @@ pub(crate) fn test_model() -> maki_providers::Model {
         thinking_override: None,
         supports_vision_override: Some(true),
         pricing: test_pricing(),
+        discovered_free: false,
         max_output_tokens: Some(8192),
         context_window: TEST_CONTEXT_WINDOW,
         thinking_fields: None,

--- a/maki-ui/src/components/model_picker.rs
+++ b/maki-ui/src/components/model_picker.rs
@@ -18,6 +18,7 @@ use crate::theme;
 
 const TITLE: &str = " Models ";
 const RECENT_SECTION: &str = "Recent";
+const FREE_LABEL: &str = "Free";
 const FREE_PREFIX: &str = "Free · ";
 
 fn footer_line() -> Line<'static> {
@@ -71,6 +72,7 @@ struct ModelEntry {
     suffix: Option<String>,
     tier: String,
     override_tiers: Vec<ModelTier>,
+    free: bool,
 }
 
 impl PickerItem for ModelEntry {
@@ -174,6 +176,7 @@ impl ModelPicker {
         full.sort_by(|a, b| {
             a.provider_display
                 .cmp(&b.provider_display)
+                .then_with(|| b.free.cmp(&a.free))
                 .then_with(|| a.id.cmp(&b.id))
         });
         entries.extend(full);
@@ -298,10 +301,10 @@ fn parse_model_entry(spec: &str) -> Option<ModelEntry> {
             .collect::<Vec<_>>()
             .join("/")
     };
-    let tier = if free {
-        format!("{FREE_PREFIX}{tier}")
-    } else {
-        tier
+    let tier = match (free, tier.is_empty()) {
+        (true, true) => FREE_LABEL.to_string(),
+        (true, false) => format!("{FREE_PREFIX}{tier}"),
+        (false, _) => tier,
     };
     let id = model_id.to_string();
     Some(ModelEntry {
@@ -311,12 +314,15 @@ fn parse_model_entry(spec: &str) -> Option<ModelEntry> {
         suffix: None,
         tier,
         override_tiers,
+        free,
     })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use maki_providers::ModelInfo;
+    use maki_providers::ModelPricing;
     use crate::components::key;
     use crate::components::keybindings::key as kb;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -626,5 +632,67 @@ mod tests {
         let entry = p.picker.selected_item().expect("selection after refresh");
         assert_eq!(entry.spec, "zai/glm-5");
         assert_eq!(entry.section(), Some("Z.AI"));
+    }
+
+    fn discovered(id: &str, pricing: ModelPricing) -> ModelInfo {
+        ModelInfo {
+            pricing: Some(pricing),
+            ..ModelInfo::id_only(id.into())
+        }
+    }
+
+    const OX_SPEC: &str = "openrouter/stealth/ox-alpha";
+    const PAID_ID: &str = "vendor/paid-model";
+    const PAID_PRICING: ModelPricing = ModelPricing {
+        input: 3.0,
+        output: 15.0,
+        cache_write: 0.0,
+        cache_read: 0.0,
+        fast: None,
+    };
+
+    fn register_openrouter_models() {
+        model_registry::set_known_models(
+            "openrouter",
+            vec![
+                discovered("stealth/ox-alpha", ModelPricing::ZERO),
+                discovered(PAID_ID, PAID_PRICING),
+            ],
+        );
+    }
+
+    #[test]
+    fn zero_priced_discovery_marks_entry_free() {
+        register_openrouter_models();
+        let entry = parse_model_entry(OX_SPEC).unwrap();
+        assert!(
+            entry.tier.starts_with(FREE_PREFIX),
+            "zero-priced discovery must mark the entry free"
+        );
+    }
+
+    #[test]
+    fn paid_discovery_not_marked_free() {
+        register_openrouter_models();
+        let entry = parse_model_entry(&format!("openrouter/{PAID_ID}")).unwrap();
+        assert!(
+            !entry.tier.starts_with(FREE_PREFIX),
+            "paid discovery must not mark the entry free"
+        );
+    }
+
+    #[test]
+    fn free_models_sort_before_paid_within_a_provider() {
+        register_openrouter_models();
+        let models = Arc::new(ArcSwapOption::empty());
+        models.store(Some(Arc::new(vec![
+            format!("openrouter/{PAID_ID}"),
+            OX_SPEC.into(),
+        ])));
+        let mut p = ModelPicker::new(models);
+        p.open("");
+        let entries = p.load_entries();
+        let ids: Vec<&str> = entries.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(ids, ["stealth/ox-alpha", PAID_ID]);
     }
 }

--- a/maki-ui/src/components/model_picker.rs
+++ b/maki-ui/src/components/model_picker.rs
@@ -321,11 +321,11 @@ fn parse_model_entry(spec: &str) -> Option<ModelEntry> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use maki_providers::ModelInfo;
-    use maki_providers::ModelPricing;
     use crate::components::key;
     use crate::components::keybindings::key as kb;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use maki_providers::ModelInfo;
+    use maki_providers::ModelPricing;
     use test_case::test_case;
 
     const SAME_SIZED_LIST: &str = "a republished list of the same length is still a new list";


### PR DESCRIPTION
The model picker's `Free · ` tier prefix only consulted the OpenCode catalog, so zero-priced models discovered from a provider's `/models` endpoint (e.g. OpenRouter's `stealth/ox-alpha`, currently free) showed no hint.

- discovery pricing that reports $0 now feeds the same `Free · ` prefix
- the list sorts free models ahead of paid ones within each provider section