### PR TITLE
feat(ui): window title support with lua binding

### DIFF
--- a/maki-lua/src/api/ui/mod.rs
+++ b/maki-lua/src/api/ui/mod.rs
@@ -249,6 +249,30 @@ fn flash(_lua: &Lua, #[ctx] tx: flume::Sender<UiAction>, msg: String) -> LuaResu
     Ok(())
 }
 
+/// Sets the terminal emulator's window title. Pass an empty string to
+/// clear it.
+///
+/// The title passes through tmux, GNU screen, and zellij untouched, and
+/// control characters are stripped, so model text cannot inject escape
+/// sequences into the terminal. On exit maki hands the title back to the
+/// shell, on terminals that support the title stack.
+///
+/// @param title string New window title, e.g. `"● 3/5 tests"`.
+/// @return
+/// @example
+/// maki.ui.set_window_title("maki: " .. session_name)
+/// -- Give the title back to the shell:
+/// maki.ui.set_window_title("")
+#[lua_fn]
+fn set_window_title(
+    _lua: &Lua,
+    #[ctx] tx: flume::Sender<UiAction>,
+    title: String,
+) -> LuaResult<()> {
+    let _ = tx.try_send(UiAction::SetWindowTitle(title));
+    Ok(())
+}
+
 /// Runs a built-in UI action by name, exactly as its default keybinding
 /// would. Handy when a default key never reaches maki because tmux or
 /// your terminal grabs it first: bind a new key with `maki.keymap.set`
@@ -456,6 +480,7 @@ lua_table! {
         buf, theme_color, highlight, markdown, humantime, terminal_size,
         display_width, truncate_text,
         manual flash, manual action, manual open_editor, manual open_win, manual set_status_hint,
+        manual set_window_title,
     ]
 }
 
@@ -469,6 +494,7 @@ pub(crate) fn create_ui_table(
 
     if let Some(tx) = ui_action_tx {
         flash__register(&t, lua, tx.clone())?;
+        set_window_title__register(&t, lua, tx.clone())?;
         action__register(&t, lua, tx.clone())?;
         open_editor__register(&t, lua, tx.clone())?;
         open_win__register(&t, lua, tx)?;

--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -464,6 +464,7 @@ pub enum UiAction {
         cmd_rx: flume::Receiver<WinCommand>,
     },
     Flash(String),
+    SetWindowTitle(String),
     OpenEditor {
         path: PathBuf,
         reply_tx: flume::Sender<i32>,

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -797,6 +797,11 @@ impl<'t> EventLoop<'t> {
             UiAction::Flash(msg) => {
                 self.focused_app().flash(msg);
             }
+            UiAction::SetWindowTitle(title) => {
+                if let Err(error) = terminal::set_window_title(&title) {
+                    warn!(%error, "failed to set window title");
+                }
+            }
             UiAction::OpenEditor { path, reply_tx } => {
                 let code = self.open_editor(self.focused, &path);
                 let _ = reply_tx.send(code);

--- a/maki-ui/src/terminal.rs
+++ b/maki-ui/src/terminal.rs
@@ -19,6 +19,11 @@ use maki_config::NotificationMethod;
 
 const FALLBACK_NOTIFICATION_MESSAGE: &str = "Maki needs attention";
 const BELL_SEQUENCE: &str = "\u{7}";
+/// XTPUSHTITLE saves whatever title the shell left on the window, so the
+/// matching XTPOPTITLE on exit or suspend hands it back and no plugin
+/// title outlives the session. Terminals without a title stack ignore both.
+const PUSH_WINDOW_TITLE_SEQUENCE: &str = "\u{1b}[22;2t";
+const POP_WINDOW_TITLE_SEQUENCE: &str = "\u{1b}[23;2t";
 /// Raw mode is already on when the tmux query runs, so a wedged tmux server
 /// must not be able to hang startup with Ctrl-C disabled.
 const TMUX_QUERY_TIMEOUT: Duration = Duration::from_millis(500);
@@ -76,11 +81,7 @@ impl TerminalNotifier {
     }
 
     pub(crate) fn notify(&self, message: &str) -> std::io::Result<()> {
-        let sequence = notification_sequence(self.notifier, self.mux, message);
-        let mut stdout = stdout().lock();
-        stdout
-            .write_all(sequence.as_bytes())
-            .and_then(|()| stdout.flush())
+        write_sequence(&notification_sequence(self.notifier, self.mux, message))
     }
 }
 
@@ -190,19 +191,42 @@ fn query_tmux_client() -> Option<TmuxClient> {
     })
 }
 
-/// A model response must not inject escape sequences into the terminal;
-/// `is_control` also covers DEL and the C1 range.
 fn sanitize_notification_message(message: &str) -> String {
-    let sanitized = message
-        .split(|c: char| c.is_whitespace() || c.is_control())
-        .filter(|part| !part.is_empty())
-        .collect::<Vec<_>>()
-        .join(" ");
+    let sanitized = visible_text(message);
     if sanitized.is_empty() {
         FALLBACK_NOTIFICATION_MESSAGE.into()
     } else {
         sanitized
     }
+}
+
+/// Control bytes would terminate the OSC payload early or inject new
+/// sequences; whitespace runs collapse so spinner frames stay tidy.
+fn visible_text(text: &str) -> String {
+    text.split(|c: char| c.is_whitespace() || c.is_control())
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// OSC 2 sets the window title only; OSC 0 would stomp the icon name too.
+fn window_title_sequence(mux: TerminalMux, title: &str) -> String {
+    mux.wrap_for_mux(format!("\u{1b}]2;{}\u{7}", visible_text(title)))
+}
+
+pub(crate) fn set_window_title(title: &str) -> std::io::Result<()> {
+    write_sequence(&window_title_sequence(TerminalMux::detect(), title))
+}
+
+fn write_mux_sequence(sequence: &str) {
+    let _ = write_sequence(&TerminalMux::detect().wrap_for_mux(sequence.into()));
+}
+
+fn write_sequence(sequence: &str) -> std::io::Result<()> {
+    let mut stdout = stdout().lock();
+    stdout
+        .write_all(sequence.as_bytes())
+        .and_then(|()| stdout.flush())
 }
 
 fn notification_sequence(notifier: ResolvedNotifier, mux: TerminalMux, message: &str) -> String {
@@ -250,6 +274,7 @@ impl TerminalMux {
 impl TerminalGuard {
     pub(crate) fn init() -> Result<(Self, ratatui::DefaultTerminal)> {
         let terminal = ratatui::init();
+        write_mux_sequence(PUSH_WINDOW_TITLE_SEQUENCE);
         stdout().execute(EnableBracketedPaste)?;
         stdout().execute(EnableMouseCapture)?;
         enable_focus_change();
@@ -287,6 +312,7 @@ fn teardown() {
 }
 
 fn pop_terminal_modes() {
+    write_mux_sequence(POP_WINDOW_TITLE_SEQUENCE);
     stdout().execute(crossterm::cursor::Show).ok();
     stdout().execute(PopKeyboardEnhancementFlags).ok();
     disable_focus_change();
@@ -295,6 +321,7 @@ fn pop_terminal_modes() {
 }
 
 fn resume(terminal: &mut ratatui::DefaultTerminal) {
+    write_mux_sequence(PUSH_WINDOW_TITLE_SEQUENCE);
     stdout().execute(EnterAlternateScreen).ok();
     stdout().execute(EnableBracketedPaste).ok();
     stdout().execute(EnableMouseCapture).ok();
@@ -570,6 +597,38 @@ mod tests {
     #[test_case("\0\t\u{7f}\u{85}\n\u{2003}", FALLBACK_NOTIFICATION_MESSAGE ; "all_control_input_falls_back")]
     fn sanitize_notification_message_cases(message: &str, expected: &str) {
         assert_eq!(sanitize_notification_message(message), expected);
+    }
+
+    #[test]
+    fn window_title_sequence_encodes_sanitized_title() {
+        const TITLE: &str = "◐ building";
+        const OSC2_SEQUENCE: &str = "\u{1b}]2;◐ building\u{7}";
+
+        assert_eq!(
+            window_title_sequence(TerminalMux::None, TITLE),
+            OSC2_SEQUENCE
+        );
+        // Control bytes are gone, so what remains cannot terminate the
+        // payload or start a new sequence.
+        assert_eq!(
+            window_title_sequence(TerminalMux::None, "\u{1b}\u{7}pwned\u{85}\ntitle"),
+            "\u{1b}]2;pwned title\u{7}"
+        );
+        assert_eq!(
+            window_title_sequence(TerminalMux::None, ""),
+            "\u{1b}]2;\u{7}"
+        );
+    }
+
+    #[test]
+    fn window_title_roundtrips_mux_passthrough() {
+        const TITLE: &str = "maki";
+        const OSC2_SEQUENCE: &str = "\u{1b}]2;maki\u{7}";
+
+        let tmux = window_title_sequence(TerminalMux::Tmux, TITLE);
+        let screen = window_title_sequence(TerminalMux::Screen, TITLE);
+        assert_eq!(parse_dcs_passthrough(&tmux, "\u{1b}Ptmux;"), OSC2_SEQUENCE);
+        assert_eq!(parse_dcs_passthrough(&screen, "\u{1b}P"), OSC2_SEQUENCE);
     }
 
     #[test]

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -4526,6 +4526,34 @@ maki.ui.set_status_hint({ {"q", "quit"}, {"j", "down"} })
 maki.ui.set_status_hint(nil)
 ```
 
+---
+
+### `maki.ui.set_window_title()` {#maki-ui-set_window_title}
+
+```lua
+maki.ui.set_window_title({title})
+```
+
+Sets the terminal emulator's window title. Pass an empty string to
+clear it.
+
+The title passes through tmux, GNU screen, and zellij untouched, and
+control characters are stripped, so model text cannot inject escape
+sequences into the terminal. On exit maki hands the title back to the
+shell, on terminals that support the title stack.
+
+**Parameters:**
+
+- `{title}` (`string`) New window title, e.g. `"● 3/5 tests"`.
+
+**Example:**
+
+```lua
+maki.ui.set_window_title("maki: " .. session_name)
+-- Give the title back to the shell:
+maki.ui.set_window_title("")
+```
+
 
 ## maki.ui.Win {#maki-ui-Win}
 


### PR DESCRIPTION
maki never touched the terminal title, so the window kept whatever the shell set before launch.

- `set_window_title()` in `terminal.rs` emits OSC 2 through the existing mux passthrough, so it works inside tmux, GNU screen, and zellij
- titles are stripped of control characters (shared `visible_text()` with the notification sanitizer), so model text or animated frames cannot inject escape sequences
- exposed to plugins as `maki.ui.set_window_title(title)`; empty string clears the title

Plugin-driven only for now: no automatic native title from session names, since with multiple live tabs single-title ownership gets ambiguous. A native default that yields to plugins can layer on later.