### PR TITLE
feat(cli): let --session-id start or resume a session in the TUI

### DIFF
--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -48,8 +48,7 @@ impl SessionStore {
         match StoredSession::load(session_id, &dir) {
             Ok(session) => Self { dir, session },
             Err(_) => {
-                let mut session = StoredSession::new(model_spec, cwd);
-                session.id = session_id;
+                let session = StoredSession::with_id(session_id, model_spec, cwd);
                 let mut store = Self { dir, session };
                 store.save();
                 store

--- a/maki-storage/src/sessions.rs
+++ b/maki-storage/src/sessions.rs
@@ -1363,10 +1363,16 @@ where
     T: Serialize + DeserializeOwned,
 {
     pub fn new(model: &str, cwd: &str) -> Self {
+        Self::with_id(MakiId::generate(), model, cwd)
+    }
+
+    /// For callers that pick the id up front, like a launcher that wants to
+    /// resume the session later without scanning the sessions dir.
+    pub fn with_id(id: MakiId, model: &str, cwd: &str) -> Self {
         let now = now_epoch();
         Self {
             version: SESSION_VERSION,
-            id: MakiId::generate(),
+            id,
             title: DEFAULT_TITLE.into(),
             cwd: cwd.into(),
             model: model.into(),

--- a/site/docs/content/cli/_index.md
+++ b/site/docs/content/cli/_index.md
@@ -24,12 +24,12 @@ If you pass a prompt (or pipe stdin) without `--print`, the TUI still opens and 
 | `--yolo` | yes | yes | yes (or `--permission-mode bypassPermissions`) |
 | `--no-plugins` / `--no-commands` / `--no-rtk` / `--no-jit` | yes | yes | yes |
 | `--allowed-tools` / `--disallowed-tools` | yes | yes | yes |
-| `-c` / `--continue`, `-s` / `--session` | yes | no (always new session) | yes |
+| `-c` / `--continue`, `-s` / `--session`, `--session-id` | yes | no (always new session) | yes |
 | `--exit-on-done` | yes | n/a (always exits) | n/a |
 | `--image` | no (use Ctrl+V paste) | yes | via wire protocol |
 | `--verbose`, `--output-format` | no | yes | stream only |
 | `--system-prompt`, `--append-system-prompt` | no | no | yes |
-| `--max-turns`, `--session-id`, `--fork-session` | no | no | yes |
+| `--max-turns`, `--fork-session` | no | no | yes |
 | `--permission-mode` | no | no | yes |
 | `--include-partial-messages` | no | no | yes |
 
@@ -53,7 +53,7 @@ If you pass a prompt (or pipe stdin) without `--print`, the TUI still opens and 
 | `--exit-on-done` | Exit when the agent finishes (TUI automation wrappers) |
 | `--allowed-tools <LIST>` | Comma-separated allow list (PascalCase or snake_case) |
 | `--disallowed-tools <LIST>` | Comma-separated deny list |
-| `--session-id <ID>` | Session id for SDK mode |
+| `--session-id <ID>` | Run under this id (UUID or maki base58): resume it if it exists, else start a new session with it. Lets a launcher pick the id up front and resume later without scanning the sessions dir (TUI / SDK) |
 | `--fork-session` | Load a session's history under a new id (SDK) |
 | `--max-turns <N>` | Cap agent turns (SDK) |
 | `--system-prompt <TEXT>` | Replace the system prompt (SDK only) |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,7 +97,7 @@ pub struct Cli {
     #[arg(long, value_delimiter = ',', visible_alias = "disallowedTools")]
     pub disallowed_tools: Vec<String>,
 
-    /// Session ID for SDK mode
+    /// Run under this session ID (UUID or maki base58): resumes it if it exists, otherwise starts a new session with it
     #[arg(long)]
     pub session_id: Option<String>,
 

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -6,15 +6,16 @@ use std::thread::{self, JoinHandle};
 use std::time::Instant;
 
 use color_eyre::Result;
-use color_eyre::eyre::Context;
+use color_eyre::eyre::{Context, bail, eyre};
 
 use maki_agent::command::{self, CustomCommand};
 use maki_agent::tools::ToolRegistry;
 use maki_config::{Config, load_env_files, load_permissions};
 use maki_lua::PluginHost;
 use maki_providers::model::Model;
-use maki_storage::StateDir;
 use maki_storage::id::MakiId;
+use maki_storage::sessions::SessionError;
+use maki_storage::{StateDir, StorageError};
 use maki_ui::{AppSession, RunOutcome};
 
 use crate::cli::{Cli, normalize_tool_name};
@@ -23,6 +24,7 @@ use crate::setup;
 const FALLBACK_MODEL_SPEC: &str = "anthropic/claude-sonnet-4-20250514";
 const CONFIG_FALLBACK_WARNING: &str = "config reload failed, using previous config";
 const MODEL_FALLBACK_WARNING: &str = "model resolution failed, keeping previous model";
+const SESSION_FLAGS_CONFLICT: &str = "pass either --session or --session-id, not both";
 
 /// One generation of the app: everything torn down and rebuilt on `/reload`.
 /// Dropping it joins the Lua thread via `PluginHost::drop`.
@@ -187,20 +189,32 @@ fn build_stack(
     ))
 }
 
-fn resolve_session(
-    continue_session: bool,
-    session_id: Option<&str>,
-    model: &str,
-    cwd: &str,
-    storage: &StateDir,
-) -> Result<AppSession> {
-    if let Some(raw) = session_id {
-        let id: MakiId = raw
-            .parse()
-            .map_err(|e| color_eyre::eyre::eyre!("invalid session id {raw:?}: {e}"))?;
-        return AppSession::load(id, storage).map_err(|e| color_eyre::eyre::eyre!("{e}"));
+fn parse_session_id(raw: &str) -> Result<MakiId> {
+    raw.parse()
+        .map_err(|e| eyre!("invalid session id {raw:?}: {e}"))
+}
+
+fn resolve_session(cli: &Cli, model: &str, cwd: &str, storage: &StateDir) -> Result<AppSession> {
+    if cli.session.is_some() && cli.session_id.is_some() {
+        bail!(SESSION_FLAGS_CONFLICT);
     }
-    if continue_session {
+    if let Some(raw) = cli.session.as_deref() {
+        let id = parse_session_id(raw)?;
+        return AppSession::load(id, storage).map_err(|e| eyre!("{e}"));
+    }
+    if let Some(raw) = cli.session_id.as_deref() {
+        let id = parse_session_id(raw)?;
+        // Only a missing session becomes a new one under that id; a broken
+        // file stays an error so it is never silently replaced.
+        return match AppSession::load(id, storage) {
+            Ok(session) => Ok(session),
+            Err(SessionError::Storage(StorageError::NotFound(_))) => {
+                Ok(AppSession::with_id(id, model, cwd))
+            }
+            Err(e) => Err(eyre!("{e}")),
+        };
+    }
+    if cli.continue_session {
         match AppSession::latest(cwd, storage) {
             Ok(Some(session)) => return Ok(session),
             Ok(None) => {
@@ -284,8 +298,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
 
     let cwd_str = cwd.to_string_lossy().into_owned();
     let mut tabs = vec![resolve_session(
-        cli.continue_session,
-        cli.session.as_deref(),
+        &cli,
         &stack.model.spec(),
         &cwd_str,
         &storage,
@@ -418,11 +431,85 @@ fn warn_stale_config_toml(cwd: &std::path::Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use color_eyre::eyre::eyre;
+    use clap::Parser;
     use maki_config::RawConfig;
+    use maki_storage::sessions::SESSIONS_DIR;
     use std::fs;
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use tempfile::{TempDir, tempdir};
+    use test_case::test_case;
+
+    const SESSION_ID: &str = "01965087-4c71-7f00-8000-000000000000";
+    const CWD: &str = "/project";
+    const MODEL_SPEC: &str = "anthropic/claude-test";
+    const TITLE: &str = "saved earlier";
+
+    fn state_dir(tmp: &TempDir) -> StateDir {
+        StateDir::from_path(tmp.path().to_path_buf())
+    }
+
+    fn resolve(tmp: &TempDir, args: &[&str]) -> Result<AppSession> {
+        let cli = Cli::parse_from([&["maki"], args].concat());
+        resolve_session(&cli, MODEL_SPEC, CWD, &state_dir(tmp))
+    }
+
+    #[test]
+    fn session_id_starts_a_new_session_under_that_id() {
+        let tmp = tempdir().unwrap();
+        let session = resolve(&tmp, &["--session-id", SESSION_ID]).unwrap();
+        assert_eq!(session.id, SESSION_ID.parse::<MakiId>().unwrap());
+        assert_eq!(session.cwd, CWD);
+        assert_eq!(session.model, MODEL_SPEC);
+        assert!(session.messages().is_empty());
+    }
+
+    #[test_case("--session-id" ; "session_id")]
+    #[test_case("--session" ; "session")]
+    fn existing_session_is_resumed(flag: &str) {
+        let tmp = tempdir().unwrap();
+        let mut saved = AppSession::with_id(SESSION_ID.parse().unwrap(), MODEL_SPEC, CWD);
+        saved.set_title(TITLE.into());
+        saved.save(&state_dir(&tmp)).unwrap();
+
+        let session = resolve(&tmp, &[flag, SESSION_ID]).unwrap();
+        assert_eq!(session.id, saved.id);
+        assert_eq!(session.title, TITLE);
+    }
+
+    /// Legacy `.json` logs parse strictly, so a broken one surfaces as a load
+    /// error rather than a fresh session under the same id.
+    #[test]
+    fn session_id_does_not_replace_a_broken_session() {
+        let tmp = tempdir().unwrap();
+        let id: MakiId = SESSION_ID.parse().unwrap();
+        let sessions = tmp.path().join(SESSIONS_DIR);
+        fs::create_dir_all(&sessions).unwrap();
+        fs::write(sessions.join(format!("{id}.json")), "not a session").unwrap();
+
+        assert!(resolve(&tmp, &["--session-id", SESSION_ID]).is_err());
+    }
+
+    #[test]
+    fn session_flag_alone_requires_the_session_to_exist() {
+        let tmp = tempdir().unwrap();
+        assert!(resolve(&tmp, &["--session", SESSION_ID]).is_err());
+    }
+
+    #[test_case("--session-id")]
+    #[test_case("--session")]
+    fn malformed_session_id_is_rejected(flag: &str) {
+        let tmp = tempdir().unwrap();
+        assert!(resolve(&tmp, &[flag, "not-an-id"]).is_err());
+    }
+
+    #[test]
+    fn session_and_session_id_together_is_an_error() {
+        let tmp = tempdir().unwrap();
+        let err =
+            resolve(&tmp, &["--session", SESSION_ID, "--session-id", SESSION_ID]).unwrap_err();
+        assert_eq!(err.to_string(), SESSION_FLAGS_CONFLICT);
+    }
 
     /// `second_saw_first` requires both joins: `defer` joining the first
     /// closure before spawning the second, and `Drop` joining the second
@@ -500,9 +587,7 @@ mod tests {
     /// `init.lua` must not be executed in that mode.
     #[test]
     fn no_plugins_skips_broken_init_lua_but_keeps_host_alive() {
-        use clap::Parser;
         use maki_agent::tools::ToolRegistry;
-        use tempfile::tempdir;
 
         let dir = tempdir().expect("tempdir");
         let maki_dir: PathBuf = dir.path().join(".maki");
@@ -538,9 +623,7 @@ mod tests {
     /// cannot silently regress into a tautology.
     #[test]
     fn broken_init_lua_errors_without_no_plugins() {
-        use clap::Parser;
         use maki_agent::tools::ToolRegistry;
-        use tempfile::tempdir;
 
         let dir = tempdir().expect("tempdir");
         let maki_dir: PathBuf = dir.path().join(".maki");


### PR DESCRIPTION
## Why

Lots of people (or corporate environments rather) wrap coding agents in a launcher: a UI/script that sets up an isolated environment for a certain task (skills, plugins, MCP servers, env) and then starts the agent inside it. Such a launcher wants to start a maki session now and resume the exact same session later, from the same script, without a human in between.

Today that is awkward. maki mints the session id itself, so the launcher only learns it after the fact, by parsing the exit hint or scanning the sessions dir for the newest file. `--session-id` looked like the answer but only SDK (`stream-json`) mode read it; the interactive TUI ignored it.

Things like Claude already support this feature BTW.

## What

`--session-id <ID>` now works in the TUI with start-or-resume semantics:

- id exists on disk: the session is resumed
- id is missing: a new session is created under that id
- id points at a session file that fails to load: still an error, never silently replaced

So a launcher can do `ID=$(uuidgen); maki --session-id "$ID"` for the first run and the exact same command for every resume.

`-s` / `--session` is unchanged and stays strict (fails when the id does not exist), so the two flags keep distinct meanings. Passing both is an error rather than one quietly winning.

The id must be a UUID or maki's base58 form, same as everywhere else; free-form names would need a name-to-id index across storage, ACP and Lua and are out of scope here.

Small cleanup on the way: `Session::with_id` is a real constructor now, and `headless.rs` uses it instead of building a session and overwriting its public `id` field.

## Testing

- Unit tests for `resolve_session` (there were none): new under id, resume via both flags, broken session stays an error, `-s` alone requires existence, malformed id rejected, both flags conflict.
- `just ci` equivalent locally: nextest (4084 passed), clippy `-D warnings`, fmt, gen-docs check.
- End to end against the built binary under a throwaway HOME: start with `--session-id`, send a message, exit, confirm the `.jsonl` lands under the base58 form of the given UUID, resume with the same command and with `-s`, and check the three error paths on stderr.

## Docs

`site/docs/content/cli/_index.md` moves `--session-id` out of the SDK-only row and describes the new behaviour.

## AI use

Implemented with Claude Code (Claude Fable 5): it mapped the session lifecycle, wrote the change and tests, and ran the end to end check in tmux. Design choices (extend the existing flag, start-or-resume, UUIDs not names) were mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
