### PR TITLE
feat(lua): move the tasks picker to Lua and put running subagents first

### DIFF
--- a/maki-docgen/src/gen_keybindings.rs
+++ b/maki-docgen/src/gen_keybindings.rs
@@ -15,7 +15,8 @@ const LUA_CONTEXT_BINDS: &[(&str, &str, &str)] = &[
 ];
 
 // Built-in plugins own these globally, so they never reach `KEYBINDS`.
-const PLUGIN_BINDS: &[(&str, &str)] = &[("`Ctrl+P`", "Browse sessions")];
+const PLUGIN_BINDS: &[(&str, &str)] =
+    &[("`Ctrl+P`", "Browse sessions"), ("`Ctrl+X`", "Open tasks")];
 
 const MAIN_CONTEXTS: &[KeybindContext] = &[
     KeybindContext::General,

--- a/maki-docgen/src/lua_util.rs
+++ b/maki-docgen/src/lua_util.rs
@@ -66,12 +66,16 @@ pub fn load_builtin_plugin_commands() -> Vec<LuaPluginCommand> {
     };
     let mut commands: Vec<LuaPluginCommand> = entries
         .filter_map(|e| e.ok())
-        .flat_map(|e| {
-            let path = e.path().join("init.lua");
-            let source = std::fs::read_to_string(&path).ok()?;
-            Some(parse_lua_commands(&source))
+        .flat_map(|plugin| {
+            std::fs::read_dir(plugin.path())
+                .into_iter()
+                .flatten()
+                .filter_map(|e| e.ok())
+                .filter(|e| e.path().extension().is_some_and(|ext| ext == "lua"))
+                .filter_map(|e| std::fs::read_to_string(e.path()).ok())
+                .flat_map(|source| parse_lua_commands(&source))
+                .collect::<Vec<_>>()
         })
-        .flatten()
         .collect();
     commands.sort_by(|a, b| a.name.cmp(&b.name));
     commands

--- a/maki-lua/src/api/autocmd.rs
+++ b/maki-lua/src/api/autocmd.rs
@@ -129,8 +129,9 @@ fn parse_string_or_seq(value: Value, what: &str) -> LuaResult<Vec<String>> {
 ///
 /// Built-in events fired by the host: `"TurnStart"`, `"TurnEnd"`,
 /// `"TurnError"`, `"ToolStart"`, `"ToolDone"`, `"SessionReset"`,
-/// `"SessionFocusChanged"`, and `"SessionStatusChanged"`. Plugins can also
-/// fire their own events with `exec_autocmds`.
+/// `"SessionFocusChanged"`, `"SessionStatusChanged"`, and
+/// `"TaskStatusChanged"`. Plugins can also fire their own events with
+/// `exec_autocmds`.
 ///
 /// Each host event carries `data.session_id`. For `"SessionReset"` that
 /// is the session being left behind; the other events name the session now
@@ -139,6 +140,11 @@ fn parse_string_or_seq(value: Value, what: &str) -> LuaResult<Vec<String>> {
 /// initial startup. `"SessionStatusChanged"` fires whenever a session moves
 /// between `"working"`, `"needs_input"`, and `"idle"`; it carries
 /// `data.status`, `data.title`, and `data.focused` (boolean).
+/// `"TaskStatusChanged"` fires when a subagent starts, or when one moves
+/// between `"working"`, `"done"`, and `"error"`; it carries `data.id` and
+/// `data.name` alongside `data.status`. A task that comes back from disk
+/// already finished stays quiet, so reloading a session does not replay
+/// old tasks.
 ///
 /// @param event string|string[] Event name or list of names.
 /// @param opts table Options:

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod options;
 pub(crate) mod session;
 pub(crate) mod slot;
 pub(crate) mod split;
+pub(crate) mod task;
 pub(crate) mod text;
 pub(crate) mod tool;
 pub(crate) mod treesitter;
@@ -74,6 +75,7 @@ pub(crate) fn create_maki_global(
         "model",
         model::create_model_table(lua, ui_action_tx.clone())?,
     )?;
+    maki.set("task", task::create_task_table(lua, ui_action_tx.clone())?)?;
     maki.set(
         "ui",
         ui::create_ui_table(lua, ui_action_tx.clone(), Arc::clone(&plugin))?,

--- a/maki-lua/src/api/task.rs
+++ b/maki-lua/src/api/task.rs
@@ -1,0 +1,195 @@
+//! `maki.task`. The host keeps the subagent transcripts, so a plugin only needs
+//! to list the tasks and show one.
+
+use maki_lua_macro::{lua_fn, lua_table};
+use mlua::{Lua, Result as LuaResult, Value};
+
+use crate::api::util::command::{TaskRequest, UiAction, ui_json_roundtrip};
+use crate::api::util::pair::Pair;
+
+async fn roundtrip(
+    lua: Lua,
+    tx: Option<flume::Sender<UiAction>>,
+    req: TaskRequest,
+) -> LuaResult<Pair<Value>> {
+    ui_json_roundtrip(&lua, tx.as_ref(), |reply_tx| UiAction::Task {
+        req,
+        reply_tx,
+    })
+    .await
+}
+
+/// Lists the focused session's chats in chat order. Entry 1 is always the main
+/// chat, with id `"main"` and no `status`: its work is the session's own, and
+/// `maki.session.live()` already reports that. The rest are subagents, keyed by
+/// the tool call that spawned them.
+///
+/// @return (table|nil, string|nil) Array of `{id, name, focused, status?}` where
+///   `status` is `"working"`, `"done"`, or `"error"`, or nil and an error.
+/// @example
+/// for _, t in ipairs(maki.task.list() or {}) do
+///   print(t.name, t.status or "main")
+/// end
+#[lua_fn]
+async fn list(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaResult<Pair<Value>> {
+    roundtrip(lua, tx, TaskRequest::List).await
+}
+
+/// Shows a task's transcript, the way the chat cycling keys do. An id from
+/// another session returns an error instead of landing on the wrong task.
+///
+/// @param id string Task id, as returned by `list()`. `"main"` is the main chat.
+/// @return (boolean|nil, string|nil) true on success, or nil and an error.
+/// @example
+/// local _, err = maki.task.focus("main")
+#[lua_fn]
+async fn focus(
+    lua: Lua,
+    #[ctx] tx: Option<flume::Sender<UiAction>>,
+    id: String,
+) -> LuaResult<Pair<Value>> {
+    roundtrip(lua, tx, TaskRequest::Focus { id }).await
+}
+
+lua_table! {
+    /// The subagents of the focused session and their transcripts. Tasks are
+    /// spawned by the `task` tool and addressed by an id that survives a reload.
+    /// Without an interactive UI every function returns
+    /// `nil, "no interactive UI attached"`.
+    "maki.task" => pub(crate) fn create_task_table(tx: Option<flume::Sender<UiAction>>),
+    DOCS [list(tx), focus(tx)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::util::command::{NO_UI_ERR, UiReply};
+    use mlua::Table;
+    use serde_json::json;
+    use std::thread::JoinHandle;
+    use test_case::test_case;
+
+    const TASK_ID: &str = "toolu_01";
+    const DONE_ID: &str = "toolu_02";
+    const ERROR_ID: &str = "toolu_03";
+    const MAIN_ID: &str = "main";
+    const MAIN_NAME: &str = "chat";
+    const SUBAGENT_NAME: &str = "explore repo";
+    const WORKING_STATUS: &str = "working";
+    const DONE_STATUS: &str = "done";
+    const ERROR_STATUS: &str = "error";
+    const NIL_STATUS: &str = "nil";
+    const UNKNOWN_TASK_ERR: &str = "unknown task: toolu_01";
+    const NO_REQUEST_ERR: &str = "expected a task request";
+    const LIST_CALL: &str = "return task.list()";
+    const FOCUS_CALL: &str = "return task.focus('toolu_01')";
+    const LIST_SCRIPT: &str = "
+        local tasks = task.list()
+        local ids, statuses = {}, {}
+        for i, t in ipairs(tasks) do
+            ids[i] = t.id
+            statuses[i] = tostring(t.status)
+        end
+        return table.concat(ids, ','), table.concat(statuses, ','), tasks[1].name
+    ";
+
+    fn lua_with_task(tx: Option<flume::Sender<UiAction>>) -> Lua {
+        let lua = Lua::new();
+        let t = create_task_table(&lua, tx).unwrap();
+        lua.globals().set("task", t).unwrap();
+        lua
+    }
+
+    /// Answers the first request with {reply} and hands it back to assert on.
+    /// Join only after dropping the `Lua` that holds the sender, or a missing
+    /// request parks the thread forever.
+    fn spawn_host(rx: flume::Receiver<UiAction>, reply: UiReply) -> JoinHandle<TaskRequest> {
+        std::thread::spawn(move || {
+            let Ok(UiAction::Task { req, reply_tx }) = rx.recv() else {
+                panic!("{NO_REQUEST_ERR}");
+            };
+            reply_tx.send(reply).unwrap();
+            req
+        })
+    }
+
+    #[test_case(LIST_CALL ; "list")]
+    #[test_case(FOCUS_CALL ; "focus")]
+    fn without_ui_returns_error_pair(code: &str) {
+        let lua = lua_with_task(None);
+        let (val, err): (Value, Option<String>) =
+            smol::block_on(lua.load(code).eval_async()).unwrap();
+        assert!(val.is_nil());
+        assert_eq!(err.as_deref(), Some(NO_UI_ERR));
+    }
+
+    /// A stale id should be visible but not fatal: the host's `Err` comes back
+    /// as the `(nil, err)` pair, word for word, without raising into the plugin.
+    #[test_case(LIST_CALL ; "list")]
+    #[test_case(FOCUS_CALL ; "focus")]
+    fn host_error_reply_surfaces_as_error_pair(code: &str) {
+        let (tx, rx) = flume::unbounded::<UiAction>();
+        let lua = lua_with_task(Some(tx));
+        let host = spawn_host(rx, Err(UNKNOWN_TASK_ERR.to_owned()));
+
+        let (val, err): (Value, Option<String>) =
+            smol::block_on(lua.load(code).eval_async()).expect("error reply must not throw");
+        assert!(val.is_nil());
+        assert_eq!(err.as_deref(), Some(UNKNOWN_TASK_ERR));
+
+        drop(lua);
+        host.join().unwrap();
+    }
+
+    /// `plugins/task/picker_rows.lua` spots the main chat with `if not task.status`,
+    /// so a missing key has to stay missing on the Lua side.
+    #[test]
+    fn list_passes_host_array_through_unchanged() {
+        let (tx, rx) = flume::unbounded::<UiAction>();
+        let lua = lua_with_task(Some(tx));
+        let host = spawn_host(
+            rx,
+            Ok(json!([
+                { "id": MAIN_ID, "name": MAIN_NAME, "focused": true },
+                { "id": TASK_ID, "name": SUBAGENT_NAME, "status": WORKING_STATUS, "focused": false },
+                { "id": DONE_ID, "name": SUBAGENT_NAME, "status": DONE_STATUS, "focused": false },
+                { "id": ERROR_ID, "name": SUBAGENT_NAME, "status": ERROR_STATUS, "focused": false },
+            ])),
+        );
+
+        let (ids, statuses, main_name): (String, String, String) =
+            smol::block_on(lua.load(LIST_SCRIPT).eval_async()).unwrap();
+        assert_eq!(ids, format!("{MAIN_ID},{TASK_ID},{DONE_ID},{ERROR_ID}"));
+        assert_eq!(
+            statuses,
+            format!("{NIL_STATUS},{WORKING_STATUS},{DONE_STATUS},{ERROR_STATUS}")
+        );
+        assert_eq!(main_name, MAIN_NAME);
+
+        drop(lua);
+        assert!(matches!(host.join().unwrap(), TaskRequest::List));
+    }
+
+    #[test]
+    fn focus_roundtrips_through_ui_channel() {
+        let (tx, rx) = flume::unbounded::<UiAction>();
+        let lua = lua_with_task(Some(tx));
+        std::thread::spawn(move || {
+            let Ok(UiAction::Task {
+                req: TaskRequest::Focus { id },
+                reply_tx,
+            }) = rx.recv()
+            else {
+                panic!("expected focus request");
+            };
+            reply_tx.send(Ok(json!({ "focused": id }))).unwrap();
+        });
+        let (val, err): (Table, Option<String>) = smol::block_on(
+            lua.load(format!("return task.focus('{TASK_ID}')"))
+                .eval_async(),
+        )
+        .unwrap();
+        assert_eq!(err, None);
+        assert_eq!(val.get::<String>("focused").unwrap(), TASK_ID);
+    }
+}

--- a/maki-lua/src/api/ui/mod.rs
+++ b/maki-lua/src/api/ui/mod.rs
@@ -254,7 +254,7 @@ fn flash(_lua: &Lua, #[ctx] tx: flume::Sender<UiAction>, msg: String) -> LuaResu
 /// your terminal grabs it first: bind a new key with `maki.keymap.set`
 /// and call this from it.
 ///
-/// Valid names: `"file_picker"`, `"search"`, `"tasks"`, `"help"`,
+/// Valid names: `"file_picker"`, `"search"`, `"help"`,
 /// `"plan_toggle"`, `"plan_editor"`, `"edit_input"`, `"pop_queue"`,
 /// `"prev_chat"`, `"next_chat"`.
 ///

--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -415,6 +415,11 @@ pub enum SessionRequest {
     SetTitle { id: String, title: String },
 }
 
+pub enum TaskRequest {
+    List,
+    Focus { id: String },
+}
+
 pub enum ModelRequest {
     Get,
     Available,
@@ -444,7 +449,6 @@ pub struct WinView {
 pub enum BuiltinAction {
     FilePicker,
     Search,
-    Tasks,
     Help,
     PlanToggle,
     PlanEditor,
@@ -474,6 +478,10 @@ pub enum UiAction {
     },
     Model {
         req: ModelRequest,
+        reply_tx: flume::Sender<UiReply>,
+    },
+    Task {
+        req: TaskRequest,
         reply_tx: flume::Sender<UiReply>,
     },
     WinSaveView {

--- a/maki-lua/src/docs.rs
+++ b/maki-lua/src/docs.rs
@@ -75,6 +75,7 @@ pub fn api_docs() -> Vec<&'static ModuleDoc> {
         &api::model::DOCS,
         &api::net::DOCS,
         &api::session::DOCS,
+        &api::task::DOCS,
         &api::text::DOCS,
         &api::treesitter::DOCS,
         &api::treesitter::language::DOCS,

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -12,7 +12,7 @@ pub use api::options::{OptionSpec, OptionType, PluginOptionSpecs};
 pub use api::util::command::{
     Anchor, Axis, Border, BuiltinAction, Dimension, Edge, FloatConfig, FloatConfigPatch,
     HintReader, HintSnapshot, LuaCommandInfo, LuaCommandReader, ModelRequest, SessionRequest,
-    Split, TitlePos, UiAction, UiReply, WinCommand, WinEvent, WinView,
+    Split, TaskRequest, TitlePos, UiAction, UiReply, WinCommand, WinEvent, WinView,
 };
 pub use docs::{DocKind, FnDoc, ModuleDoc, ParamDoc, api_docs};
 pub use error::PluginError;

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -16,6 +16,7 @@ use maki_storage::id::SessionRef;
 use rustix::process::{Pid, test_kill_process_group};
 use serde_json::{Value, json};
 
+const BUILTIN_COMMANDS: &[&str] = &["/sessions", "/rename", "/tasks"];
 const NARGS_ERR: &str = r#"'nargs' must be 0, 1, "?", "*", or "+""#;
 const USAGE_TOOL_NAME: &str = "usage_child";
 const USAGE_VALUE: &str = "12.3k↑ 456↓ $0.123";
@@ -2745,16 +2746,16 @@ fn unload_clears_commands() {
     assert_eq!(host.command_reader().load().commands.len(), 0);
 }
 
+/// `/tasks` and `/sessions` used to be Rust commands. The plugins that took
+/// them over have to keep the names, or the palette quietly loses a row.
 #[test]
-fn sessions_plugin_registers_commands() {
+fn builtin_plugins_register_their_commands() {
     let (_reg, host) = builtins_host();
     let snap = host.command_reader().load();
     let names: Vec<&str> = snap.commands.iter().map(|c| c.name.as_ref()).collect();
-    assert!(
-        names.contains(&"/sessions"),
-        "missing /sessions in {names:?}"
-    );
-    assert!(names.contains(&"/rename"), "missing /rename in {names:?}");
+    for command in BUILTIN_COMMANDS {
+        assert!(names.contains(command), "missing {command} in {names:?}");
+    }
 }
 
 #[test]

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -12,6 +12,7 @@ mod queue;
 mod session;
 pub(crate) mod session_state;
 pub(crate) mod shell;
+pub(crate) mod tasks;
 #[cfg(test)]
 pub(crate) mod tests;
 pub(crate) mod view;
@@ -23,6 +24,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use crate::AppSession;
+use crate::app::tasks::TaskOutcome;
 use crate::chat::Chat;
 use crate::chat::{CANCELLED_TEXT, ChatEventResult, DONE_TEXT, ERROR_TEXT};
 use crate::clipboard::ClipboardState;
@@ -32,7 +34,6 @@ use crate::components::file_picker::{FilePickerModal, FilePickerModalAction};
 use crate::components::help_modal::HelpModal;
 use crate::components::input::{InputAction, InputBox, Submission};
 use crate::components::keybindings::key;
-use crate::components::list_picker::{ListPicker, PickerAction, PickerItem};
 use crate::components::login_picker::{LoginPicker, LoginPickerAction};
 use crate::components::lua_float::FloatManager;
 use crate::components::mcp_picker::{McpPicker, McpPickerAction};
@@ -97,7 +98,6 @@ const WORKFLOW_OFF_MSG: &str = "Workflow mode: off";
 const IMPLEMENT_MSG_PREFIX: &str = "Implement the plan";
 const IMPLEMENT_PARALLEL_HINT: &str = "Use batch+task to parallelize, assign each subagent a separate module and restrict its tests to that module to avoid interference.";
 
-const TASK_DONE_DETAIL: &str = "✓ ";
 const MISSING_TOOL_COMPLETION: &str = "Tool did not report completion before the turn ended";
 const NOTIFICATION_PREVIEW_CHARS: usize = 200;
 
@@ -106,25 +106,6 @@ const NOTIFICATION_PREVIEW_CHARS: usize = 200;
 /// error instead of ping-ponging with the Lua thread forever.
 pub(crate) const MAX_COMMAND_DEPTH: u8 = 8;
 pub(crate) const COMMAND_DEPTH_MSG: &str = "slash command nested too deeply (alias cycle?)";
-
-#[derive(Clone)]
-pub(super) struct TaskEntry {
-    name: String,
-    finished: Option<bool>,
-    chat_index: usize,
-}
-
-impl PickerItem for TaskEntry {
-    fn label(&self) -> &str {
-        &self.name
-    }
-    fn detail(&self) -> Option<&str> {
-        matches!(self.finished, Some(true)).then_some(TASK_DONE_DETAIL)
-    }
-    fn is_spinning(&self) -> bool {
-        matches!(self.finished, Some(false))
-    }
-}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Notification {
@@ -216,8 +197,6 @@ pub struct App {
     pub(super) chat_index: HashMap<String, usize>,
     pub(crate) input_box: InputBox,
     pub(super) command_palette: CommandPalette,
-    pub(super) task_picker: ListPicker<TaskEntry>,
-    pub(super) task_picker_original: Option<usize>,
     pub(super) theme_picker: ThemePicker,
     pub(super) model_picker: ModelPicker,
     pub(super) login_picker: LoginPicker,
@@ -310,8 +289,6 @@ impl App {
                 mcp_reader.clone(),
                 lua_command_reader,
             ),
-            task_picker: ListPicker::new(),
-            task_picker_original: None,
             theme_picker: ThemePicker::new(),
             model_picker: ModelPicker::new(available_models),
             login_picker: LoginPicker::new(),
@@ -552,45 +529,11 @@ impl App {
             };
         }
         try_picker!(self.rewind_picker);
-        try_picker!(self.task_picker);
         try_picker!(self.model_picker);
         try_picker!(self.file_picker);
         let zone = self.zone_at(row, column)?.zone;
         self.scroll_zone(zone, delta);
         Some(zone)
-    }
-
-    fn task_entries(&self) -> Vec<TaskEntry> {
-        self.chats
-            .iter()
-            .enumerate()
-            .map(|(chat_index, chat)| TaskEntry {
-                name: chat.name.clone(),
-                finished: (chat_index > 0).then_some(chat.is_finished()),
-                chat_index,
-            })
-            .collect()
-    }
-
-    fn open_tasks(&mut self) {
-        self.task_picker_original = Some(self.active_chat);
-        self.task_picker.open(self.task_entries(), " Tasks ");
-        self.task_picker.select(self.active_chat);
-    }
-
-    fn sync_task_picker(&mut self) {
-        if !self.task_picker.is_open() {
-            return;
-        }
-        let selected = self
-            .task_picker
-            .selected_item()
-            .map(|entry| entry.chat_index);
-        self.task_picker.replace_items(self.task_entries());
-        if let Some(chat_index) = selected {
-            self.task_picker
-                .select_item_by(|entry| entry.chat_index == chat_index);
-        }
     }
 
     fn handle_ctrl(&mut self, key: KeyEvent) -> Option<Vec<Action>> {
@@ -611,9 +554,6 @@ impl App {
         }
         if key::HELP.matches(key) {
             return Some(self.run_builtin(BuiltinAction::Help));
-        }
-        if key::TASKS.matches(key) {
-            return Some(self.run_builtin(BuiltinAction::Tasks));
         }
         if key::SCROLL_HALF_UP.matches(key) {
             let half = self.chats[self.active_chat].half_page();
@@ -742,25 +682,6 @@ impl App {
             return Some(vec![]);
         }
 
-        if self.task_picker.is_open() {
-            if key::TASKS.matches(key) {
-                self.task_picker.close();
-                return Some(vec![]);
-            }
-            return Some(match self.task_picker.handle_key(key) {
-                PickerAction::Consumed | PickerAction::Toggle(..) => vec![],
-                PickerAction::Select(entry) => {
-                    self.task_picker_original = None;
-                    self.active_chat = entry.chat_index;
-                    vec![]
-                }
-                PickerAction::Close => {
-                    self.active_chat = self.task_picker_original.take().unwrap_or(0);
-                    vec![]
-                }
-            });
-        }
-
         if self.rewind_picker.is_open() {
             return Some(match self.rewind_picker.handle_key(key) {
                 RewindPickerAction::Consumed => vec![],
@@ -841,13 +762,6 @@ impl App {
                 let top = self.chats[self.active_chat].scroll_top();
                 let auto = self.chats[self.active_chat].auto_scroll();
                 self.search_modal.open(top, auto);
-            }
-            BuiltinAction::Tasks => {
-                if self.task_picker.is_open() {
-                    self.task_picker.close();
-                } else {
-                    self.open_tasks();
-                }
             }
             BuiltinAction::Help => self.help_modal.toggle(),
             BuiltinAction::PlanToggle => {
@@ -1080,7 +994,7 @@ impl App {
         self.retry_info = None;
         self.close_all_overlays();
         self.pending_input = PendingInput::None;
-        self.finish_subagents(DisplayRole::Error, CANCELLED_TEXT);
+        self.finish_subagents(TaskOutcome::Error, CANCELLED_TEXT);
         self.subagent_answers.clear();
         self.shell.cancel_all();
         for chat in &mut self.chats {
@@ -1110,7 +1024,7 @@ impl App {
 
         self.chats[self.active_chat].flush();
         self.chats[self.active_chat].cancel_in_progress();
-        self.chats[self.active_chat].mark_finished(DisplayRole::Error, CANCELLED_TEXT);
+        self.chats[self.active_chat].mark_finished(TaskOutcome::Error, CANCELLED_TEXT);
         self.subagent_answers.remove(&tool_use_id);
 
         vec![Action::CancelSubagent { tool_use_id }]
@@ -1162,11 +1076,12 @@ impl App {
         } = envelope.event
         {
             // Workflow sessions use synthetic ids that no ToolDone will match,
-            // so we finish them here on SubagentHistory.
+            // so we finish them here on SubagentHistory. This event only knows
+            // that the transcript closed, so say Unknown and leave the verdict
+            // to the ToolDone that follows elsewhere.
             if let Some(&sub_idx) = self.chat_index.get(tool_use_id.as_str()) {
-                self.chats[sub_idx].mark_finished(DisplayRole::Done, DONE_TEXT);
+                self.chats[sub_idx].mark_finished(TaskOutcome::Unknown, DONE_TEXT);
             }
-            self.sync_task_picker();
             self.state
                 .session_mut()
                 .set_subagent_messages(tool_use_id, messages);
@@ -1211,14 +1126,13 @@ impl App {
                 .session_mut()
                 .insert_tool_output(e.id.clone(), e.output.clone());
             if let Some(&sub_idx) = self.chat_index.get(&e.id) {
-                let (role, text) = if e.is_error {
-                    (DisplayRole::Error, ERROR_TEXT)
+                let (outcome, text) = if e.is_error {
+                    (TaskOutcome::Error, ERROR_TEXT)
                 } else {
-                    (DisplayRole::Done, DONE_TEXT)
+                    (TaskOutcome::Done, DONE_TEXT)
                 };
-                self.chats[sub_idx].mark_finished(role, text);
+                self.chats[sub_idx].mark_finished(outcome, text);
             }
-            self.sync_task_picker();
         }
 
         if let AgentEvent::Retry {
@@ -1346,7 +1260,8 @@ impl App {
         if let Some(ref model) = subagent.model {
             self.chats[0].update_tool_model(id, model);
         }
-        let mut chat = Chat::new(
+        let mut chat = Chat::subagent(
+            id,
             subagent.name.clone(),
             self.ui_config.clone(),
             self.lua_event_handle.clone(),
@@ -1357,7 +1272,6 @@ impl App {
             chat.push_user_message(prompt);
         }
         self.chats.push(chat);
-        self.sync_task_picker();
         self.sync_subagents();
         idx
     }
@@ -1390,10 +1304,6 @@ impl App {
     /// handler so an alias cycle keeps counting. 0 when the user typed it.
     fn execute_command(&mut self, cmd: ParsedCommand, depth: u8) -> Vec<Action> {
         match cmd.name.as_str() {
-            "/tasks" => {
-                self.open_tasks();
-                vec![]
-            }
             "/compact" => {
                 if self.status == Status::Streaming {
                     self.queue_compact();
@@ -1614,7 +1524,7 @@ impl App {
         vec![]
     }
 
-    fn overlays(&self) -> [&dyn Overlay; 13] {
+    fn overlays(&self) -> [&dyn Overlay; 12] {
         [
             &self.help_modal,
             &self.usage_modal,
@@ -1622,7 +1532,6 @@ impl App {
             &self.float_mgr,
             &self.search_modal,
             &self.file_picker,
-            &self.task_picker,
             &self.rewind_picker,
             &self.theme_picker,
             &self.model_picker,
@@ -1632,7 +1541,7 @@ impl App {
         ]
     }
 
-    fn overlays_mut(&mut self) -> [&mut dyn Overlay; 13] {
+    fn overlays_mut(&mut self) -> [&mut dyn Overlay; 12] {
         [
             &mut self.help_modal,
             &mut self.usage_modal,
@@ -1640,7 +1549,6 @@ impl App {
             &mut self.float_mgr,
             &mut self.search_modal,
             &mut self.file_picker,
-            &mut self.task_picker,
             &mut self.rewind_picker,
             &mut self.theme_picker,
             &mut self.model_picker,
@@ -1739,31 +1647,30 @@ impl App {
         ])
     }
 
-    fn finish_subagents(&mut self, role: DisplayRole, text: &str) {
-        self.retain_resolved_subagents(role, text);
+    fn finish_subagents(&mut self, outcome: TaskOutcome, text: &str) {
+        self.retain_resolved_subagents(outcome, text);
         self.chat_index.clear();
     }
 
     /// Terminalizes every tool left in progress when a turn ends, sparing
     /// shell commands that outlive the agent.
     fn terminalize_turn(&mut self, message: &str) {
-        self.retain_resolved_subagents(DisplayRole::Error, ERROR_TEXT);
+        self.retain_resolved_subagents(TaskOutcome::Error, ERROR_TEXT);
         self.chats[0].fail_in_progress_except(message.into(), self.shell.active_ids());
         for chat in self.chats.iter_mut().skip(1) {
             chat.fail_in_progress_with_message(message.into());
         }
-        self.sync_task_picker();
     }
 
     /// Marks unfinished subagent chats as ended and drops them from
     /// `chat_index`, so the session records only the children that really
     /// completed.
-    fn retain_resolved_subagents(&mut self, role: DisplayRole, text: &str) {
+    fn retain_resolved_subagents(&mut self, outcome: TaskOutcome, text: &str) {
         self.chat_index.retain(|_, &mut sub_idx| {
             if self.chats[sub_idx].is_finished() {
                 true
             } else {
-                self.chats[sub_idx].mark_finished(role.clone(), text);
+                self.chats[sub_idx].mark_finished(outcome, text);
                 false
             }
         });
@@ -1802,7 +1709,6 @@ impl App {
             };
         }
         try_picker!(self.file_picker);
-        try_picker!(self.task_picker);
         try_picker!(self.rewind_picker);
         try_picker!(self.theme_picker);
         try_picker!(self.model_picker);

--- a/maki-ui/src/app/session.rs
+++ b/maki-ui/src/app/session.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::time::{Duration, Instant};
 
+use crate::app::tasks::TaskOutcome;
 use crate::chat::{Chat, DONE_TEXT, history_to_display};
-use crate::components::DisplayRole;
 use crate::components::rewind_picker::RewindEntry;
 use crate::components::{Action, LoadedSession};
 use maki_agent::agent::estimate_message_tokens;
@@ -178,7 +178,6 @@ impl App {
         self.close_all_overlays();
         self.pending_input = PendingInput::None;
         self.status_bar.clear_flash();
-        self.task_picker_original = None;
         self.last_esc = None;
         self.restoring = Arc::new(AtomicBool::new(false));
         self.plan_form.reset();
@@ -210,25 +209,34 @@ impl App {
         // mirrors back, so emptying the session here would only make the next
         // checkpoint write the same list again.
         for sa in self.state.session.subagents().to_vec() {
-            let idx = self.chats.len();
-            self.chat_index.insert(sa.tool_use_id.clone(), idx);
-            let mut chat = Chat::new(
+            // A subagent reaches disk when it spawns but its transcript only
+            // when it ends, so one without an entry here never got to finish:
+            // leftovers from a kill mid-turn. It has nothing to show, and
+            // restoring it would park a task no agent backs at the top of the
+            // picker, running forever. `sync_subagents` below drops it for good.
+            let Some(messages) = self.state.session.subagent_messages().get(&sa.tool_use_id) else {
+                continue;
+            };
+            let (display, items) = history_to_display(
+                messages,
+                self.state.session.tool_outputs(),
+                &self.ui_config.tool_output_lines,
+            );
+            self.chat_index
+                .insert(sa.tool_use_id.clone(), self.chats.len());
+            let mut chat = Chat::subagent(
+                &sa.tool_use_id,
                 sa.name,
                 self.ui_config.clone(),
                 self.lua_event_handle.clone(),
             );
             chat.set_restore_channel(self.restore_event_tx.clone());
             chat.model_id = sa.model;
-            if let Some(messages) = self.state.session.subagent_messages().get(&sa.tool_use_id) {
-                let (display, items) = history_to_display(
-                    messages,
-                    self.state.session.tool_outputs(),
-                    &self.ui_config.tool_output_lines,
-                );
-                chat.load_messages(display);
-                chat.mark_finished(DisplayRole::Done, DONE_TEXT);
-                self.fire_restore_items(items);
-            }
+            chat.load_messages(display);
+            // The session file keeps the transcript but never how it ended,
+            // so a reload admits that instead of guessing.
+            chat.mark_finished(TaskOutcome::Unknown, DONE_TEXT);
+            self.fire_restore_items(items);
             self.chats.push(chat);
         }
 

--- a/maki-ui/src/app/tasks.rs
+++ b/maki-ui/src/app/tasks.rs
@@ -1,0 +1,394 @@
+//! A task is a subagent chat, addressed by its `tool_use_id`. The main chat
+//! goes by [`MAIN_TASK_ID`] and carries no status, since its work is the
+//! session's own and `maki.session.live()` already reports that.
+//!
+//! Both `maki.task.list()` and the `TaskStatusChanged` autocmd serialize the
+//! types below, so the two can never spell a status differently.
+
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use crate::app::App;
+use crate::components::DisplayRole;
+
+pub(crate) const MAIN_TASK_ID: &str = "main";
+const UNKNOWN_TASK_ERR: &str = "unknown task: ";
+
+/// How a chat ended, from the vaguest to the most specific. `SubagentHistory`
+/// only sees the transcript close, and the `ToolDone` carrying `is_error`
+/// lands after it, so [`Self::Unknown`] holds the place until then.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum TaskOutcome {
+    /// Ended, and nobody said how. Reads as done unless a verdict follows.
+    Unknown,
+    Done,
+    Error,
+}
+
+impl TaskOutcome {
+    /// Only the placeholder gives way, so a late event cannot walk a finished
+    /// task back to another ending.
+    pub(crate) fn refines(self, previous: Self) -> bool {
+        previous == Self::Unknown && self != Self::Unknown
+    }
+
+    /// The bubble that ends the transcript. Derived from the outcome rather
+    /// than passed beside it, so a green marker cannot sit on a failed task.
+    pub(crate) fn role(self) -> DisplayRole {
+        match self {
+            Self::Error => DisplayRole::Error,
+            Self::Unknown | Self::Done => DisplayRole::Done,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum TaskStatus {
+    Working,
+    Done,
+    Error,
+}
+
+impl From<Option<TaskOutcome>> for TaskStatus {
+    fn from(outcome: Option<TaskOutcome>) -> Self {
+        match outcome {
+            None => Self::Working,
+            Some(TaskOutcome::Error) => Self::Error,
+            Some(TaskOutcome::Unknown | TaskOutcome::Done) => Self::Done,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct TaskState<'a> {
+    pub(crate) id: &'a Arc<str>,
+    pub(crate) name: &'a str,
+    pub(crate) status: TaskStatus,
+}
+
+/// The wire shape of `maki.task.list()`. The main chat leaves `status` unset.
+#[derive(Serialize)]
+pub(crate) struct TaskInfo {
+    id: Arc<str>,
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<TaskStatus>,
+    focused: bool,
+}
+
+impl App {
+    /// Subagent chats only, in chat order.
+    pub(crate) fn task_states(&self) -> impl Iterator<Item = TaskState<'_>> {
+        self.chats.iter().filter_map(|chat| {
+            Some(TaskState {
+                id: chat.task_id()?,
+                name: &chat.name,
+                status: chat.task_status(),
+            })
+        })
+    }
+
+    /// The same walk widened to every chat, so the main chat at index 0 lands
+    /// first on its own and no extra code path has to place it.
+    pub(crate) fn tasks(&self) -> Vec<TaskInfo> {
+        self.chats
+            .iter()
+            .enumerate()
+            .map(|(idx, chat)| {
+                let task_id = chat.task_id();
+                TaskInfo {
+                    id: task_id.map_or_else(|| Arc::from(MAIN_TASK_ID), Arc::clone),
+                    name: chat.name.clone(),
+                    status: task_id.map(|_| chat.task_status()),
+                    focused: idx == self.active_chat,
+                }
+            })
+            .collect()
+    }
+
+    /// The only writer of `active_chat` outside the chat cycling keys. Tasks
+    /// are looked up by id, never by position and never through `chat_index`,
+    /// a routing cache wiped at the end of every turn.
+    pub(crate) fn focus_task(&mut self, id: &str) -> Result<(), String> {
+        self.active_chat = if id == MAIN_TASK_ID {
+            0
+        } else {
+            self.chats
+                .iter()
+                .position(|chat| chat.task_id().is_some_and(|task_id| &**task_id == id))
+                .ok_or_else(|| format!("{UNKNOWN_TASK_ERR}{id}"))?
+        };
+        Ok(())
+    }
+}
+
+/// Fires when a known task changes status, or when a new one shows up working.
+/// A task first seen already finished is recorded quietly, so a restored
+/// session does not replay yesterday's tasks.
+///
+/// `previous` is keyed by id, because a session reset reuses positions.
+pub(crate) fn diff_task_states<'a>(
+    previous: &mut Vec<(Arc<str>, TaskStatus)>,
+    current: impl Iterator<Item = TaskState<'a>>,
+    mut emit: impl FnMut(TaskState<'a>),
+) {
+    let mut next = Vec::with_capacity(previous.len());
+    for task in current {
+        let announce = match previous.iter().find(|(id, _)| id == task.id) {
+            Some((_, status)) => *status != task.status,
+            None => task.status == TaskStatus::Working,
+        };
+        if announce {
+            emit(task);
+        }
+        next.push((Arc::clone(task.id), task.status));
+    }
+    *previous = next;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::tests::{
+        RESEARCH_NAME, app_with_subagent_id, cancel_app, close_subagent_transcript, end_turn,
+        error_app, finish_subagent, start_subagent,
+    };
+    use crate::chat::{DONE_TEXT, ERROR_TEXT};
+    use test_case::test_case;
+
+    const TASK_ID: &str = "toolu_01";
+    const OTHER_ID: &str = "toolu_02";
+    const MISSING_ID: &str = "toolu_nope";
+    const BUILD_NAME: &str = "build";
+    const UNCHANGED_CHAT: usize = 2;
+
+    fn app_with_two_subagents() -> App {
+        let mut app = app_with_subagent_id(TASK_ID);
+        start_subagent(&mut app, OTHER_ID, BUILD_NAME);
+        app
+    }
+
+    /// Restores the two subagents in the reverse of the order their ids
+    /// suggest, so a lookup guessing a position from an id lands on the wrong
+    /// transcript instead of being right by accident.
+    fn restored_app_with_two_subagents() -> App {
+        let mut app = app_with_subagent_id(OTHER_ID);
+        start_subagent(&mut app, TASK_ID, BUILD_NAME);
+        // Only a subagent that handed over its transcript survives a reload,
+        // so both have to close before the session is written.
+        close_subagent_transcript(&mut app, OTHER_ID);
+        close_subagent_transcript(&mut app, TASK_ID);
+        app.reset_ui_chrome();
+        app.restore_display();
+        app
+    }
+
+    fn state(id: &Arc<str>, status: TaskStatus) -> TaskState<'_> {
+        TaskState {
+            id,
+            name: "task",
+            status,
+        }
+    }
+
+    fn collect(
+        previous: &mut Vec<(Arc<str>, TaskStatus)>,
+        current: &[(Arc<str>, TaskStatus)],
+    ) -> Vec<(String, TaskStatus)> {
+        let mut fired = Vec::new();
+        diff_task_states(
+            previous,
+            current.iter().map(|(id, status)| state(id, *status)),
+            |task| fired.push((task.id.to_string(), task.status)),
+        );
+        fired
+    }
+
+    /// Identity lives on the chat, not in `chat_index`: that one is wiped at
+    /// the end of every turn, while the picker keeps addressing tasks long
+    /// after.
+    #[test_case(MAIN_TASK_ID, Some(0) ; "main")]
+    #[test_case(TASK_ID, Some(1)      ; "subagent")]
+    #[test_case(MISSING_ID, None      ; "unknown_id")]
+    fn focus_addresses_a_task_by_id_alone(id: &str, expected: Option<usize>) {
+        let mut app = app_with_two_subagents();
+        app.focus_task(OTHER_ID).unwrap();
+        assert_eq!(app.active_chat, UNCHANGED_CHAT);
+        app.chat_index.clear();
+
+        let err = app.focus_task(id).err();
+
+        assert_eq!(
+            err,
+            expected
+                .is_none()
+                .then(|| format!("{UNKNOWN_TASK_ERR}{id}"))
+        );
+        assert_eq!(app.active_chat, expected.unwrap_or(UNCHANGED_CHAT));
+    }
+
+    /// A reload rebuilds the chats from scratch, so the id is all the picker
+    /// has left to aim with.
+    #[test_case(OTHER_ID, RESEARCH_NAME, 1 ; "first_restored")]
+    #[test_case(TASK_ID, BUILD_NAME, 2     ; "second_restored")]
+    fn focus_addresses_a_restored_task_by_id(id: &str, name: &str, expected: usize) {
+        let mut app = restored_app_with_two_subagents();
+        app.focus_task(id).unwrap();
+
+        assert_eq!(app.active_chat, expected);
+        let chat = &app.chats[app.active_chat];
+        assert_eq!(chat.task_id().map(|task_id| &**task_id), Some(id));
+        assert_eq!(chat.name, name);
+    }
+
+    /// A subagent reaches disk when it spawns but its transcript only when it
+    /// ends, so quitting mid-turn strands one with no messages. Restoring it
+    /// would pin a task no agent backs at the top of the picker, running
+    /// forever. The reload drops it instead.
+    #[test]
+    fn a_subagent_stranded_without_a_transcript_is_not_restored() {
+        let mut app = app_with_subagent_id(TASK_ID);
+        start_subagent(&mut app, OTHER_ID, BUILD_NAME);
+        close_subagent_transcript(&mut app, OTHER_ID);
+
+        app.reset_ui_chrome();
+        app.restore_display();
+
+        let restored: Vec<_> = app
+            .task_states()
+            .map(|task| (task.id.to_string(), task.status))
+            .collect();
+        assert_eq!(restored, vec![(OTHER_ID.to_owned(), TaskStatus::Done)]);
+        let recorded: Vec<_> = app
+            .state
+            .session
+            .subagents()
+            .iter()
+            .map(|sa| sa.tool_use_id.clone())
+            .collect();
+        assert_eq!(recorded, vec![OTHER_ID.to_owned()], "and stays dropped");
+    }
+
+    /// The `task` tool closes the subagent session before it reports a failure,
+    /// so the `SubagentHistory` that only knows "it ended" always arrives before
+    /// the `ToolDone` holding the verdict. Let the first one decide and every
+    /// failure reads as done.
+    #[test_case(
+        |app: &mut App| close_subagent_transcript(app, TASK_ID),
+        TaskStatus::Done, DONE_TEXT
+        ; "a_close_nothing_follows_reads_as_done"
+    )]
+    #[test_case(
+        |app| {
+            close_subagent_transcript(app, TASK_ID);
+            finish_subagent(app, TASK_ID, true);
+        },
+        TaskStatus::Error, ERROR_TEXT
+        ; "a_late_verdict_corrects_the_close"
+    )]
+    #[test_case(
+        |app| {
+            finish_subagent(app, TASK_ID, true);
+            close_subagent_transcript(app, TASK_ID);
+        },
+        TaskStatus::Error, ERROR_TEXT
+        ; "a_close_never_clears_a_verdict"
+    )]
+    fn the_most_specific_ending_decides(end: fn(&mut App), status: TaskStatus, text: &str) {
+        let mut app = app_with_subagent_id(TASK_ID);
+        end(&mut app);
+        assert_eq!(app.chats[1].task_status(), status);
+        assert_eq!(app.chats[1].last_message_text(), text);
+    }
+
+    /// No way of ending a turn may leave a task `working`: nothing runs after
+    /// to correct it, and the picker would spin on it forever. The finished
+    /// task comes along to show the sweep leaves it alone.
+    #[test_case(end_turn as fn(&mut App) ; "turn_end")]
+    #[test_case(error_app                ; "parent_error")]
+    #[test_case(cancel_app               ; "user_cancel")]
+    fn a_turn_ending_terminalizes_every_unfinished_task(terminate: fn(&mut App)) {
+        let mut app = app_with_two_subagents();
+        finish_subagent(&mut app, TASK_ID, false);
+        assert_eq!(app.chats[2].task_status(), TaskStatus::Working);
+
+        terminate(&mut app);
+
+        assert_eq!(
+            app.task_states().map(|t| t.status).collect::<Vec<_>>(),
+            vec![TaskStatus::Done, TaskStatus::Error]
+        );
+    }
+
+    /// The picker remembers the focused id before it previews anything and
+    /// goes back there on cancel. With two entries claiming focus, or none,
+    /// the user is stranded on a task they were only peeking at.
+    #[test_case(MAIN_TASK_ID, 0 ; "main")]
+    #[test_case(TASK_ID, 1      ; "first_task")]
+    #[test_case(OTHER_ID, 2     ; "second_task")]
+    fn exactly_one_task_reports_focused(id: &str, expected: usize) {
+        let mut app = app_with_two_subagents();
+        app.focus_task(OTHER_ID).unwrap();
+        app.focus_task(id).unwrap();
+
+        let tasks = app.tasks();
+        let focused: Vec<_> = tasks
+            .iter()
+            .enumerate()
+            .filter(|(_, task)| task.focused)
+            .map(|(idx, task)| (idx, &*task.id))
+            .collect();
+        assert_eq!(focused, vec![(expected, id)]);
+    }
+
+    /// A task announces itself the moment it shows up working and on every
+    /// change after, never twice for the same state. A session reset forgets
+    /// it, so running the same task again reads as new.
+    #[test]
+    fn diff_announces_first_sight_and_every_change() {
+        let id: Arc<str> = Arc::from(TASK_ID);
+        let working = [(Arc::clone(&id), TaskStatus::Working)];
+        let mut previous = Vec::new();
+
+        assert_eq!(
+            collect(&mut previous, &working),
+            vec![(TASK_ID.to_owned(), TaskStatus::Working)]
+        );
+        assert!(collect(&mut previous, &working).is_empty());
+        assert_eq!(
+            collect(&mut previous, &[(Arc::clone(&id), TaskStatus::Done)]),
+            vec![(TASK_ID.to_owned(), TaskStatus::Done)]
+        );
+
+        assert!(collect(&mut previous, &[]).is_empty());
+        assert!(previous.is_empty());
+        assert_eq!(
+            collect(&mut previous, &working),
+            vec![(TASK_ID.to_owned(), TaskStatus::Working)]
+        );
+    }
+
+    /// A task first seen already finished stays quiet, so a reload does not
+    /// replay old news. It is still recorded, or its next change would look
+    /// like another first sight and stay quiet too.
+    #[test]
+    fn a_task_first_seen_finished_is_recorded_silently() {
+        let one: Arc<str> = Arc::from(TASK_ID);
+        let two: Arc<str> = Arc::from(OTHER_ID);
+        let mut previous = Vec::new();
+
+        assert!(collect(&mut previous, &[(Arc::clone(&one), TaskStatus::Done)]).is_empty());
+        assert_eq!(
+            collect(&mut previous, &[(one, TaskStatus::Error)]),
+            vec![(TASK_ID.to_owned(), TaskStatus::Error)]
+        );
+
+        assert_eq!(
+            collect(&mut previous, &[(Arc::clone(&two), TaskStatus::Working)]),
+            vec![(OTHER_ID.to_owned(), TaskStatus::Working)]
+        );
+        assert_eq!(previous, vec![(two, TaskStatus::Working)]);
+    }
+}

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -30,6 +30,7 @@ use test_case::test_case;
 
 const WRITER_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
 const TASK_ID: &str = "task1";
+pub(crate) const RESEARCH_NAME: &str = "research";
 const SUB_TOOL_ID: &str = "sub_t1";
 const TOOL_OUTPUT_LINE: &str = "hello from the subagent";
 const LATE_MODEL_SPEC: &str = "zai/glm-5";
@@ -173,6 +174,10 @@ fn done() -> AgentEvent {
 
 fn done_event() -> Msg {
     agent_msg(done())
+}
+
+pub(crate) fn end_turn(app: &mut App) {
+    app.update(done_event());
 }
 
 fn subagent_info(parent_id: &str, name: &str) -> SubagentInfo {
@@ -592,12 +597,12 @@ fn type_and_submit(app: &mut App, text: &str) -> Vec<Action> {
     app.update(Msg::Key(key(KeyCode::Enter)))
 }
 
-fn cancel_app(app: &mut App) {
+pub(crate) fn cancel_app(app: &mut App) {
     app.last_esc = Some(Instant::now());
     app.update(Msg::Key(key(KeyCode::Esc)));
 }
 
-fn error_app(app: &mut App) {
+pub(crate) fn error_app(app: &mut App) {
     app.update(agent_msg(AgentEvent::Error {
         message: "boom".into(),
     }));
@@ -1126,7 +1131,6 @@ fn turn_complete_accumulates_usage_by_model() {
 #[test]
 fn cancel_resets_all_chats_and_indices() {
     let mut app = app_with_subagent();
-    open_tasks_picker(&mut app);
     app.update(subagent_msg(
         AgentEvent::ToolStart(Box::new(ToolStartEvent {
             id: "sub_t1".into(),
@@ -1153,7 +1157,6 @@ fn cancel_resets_all_chats_and_indices() {
 
     let actions = app.handle_cancel();
     assert!(matches!(actions.as_slice(), [Action::CancelAgent { .. }]));
-    assert!(!app.task_picker.is_open());
     assert_eq!(app.chats[0].in_progress_count(), 0);
     assert_eq!(app.chats[1].in_progress_count(), 0);
     assert!(app.chats[1].is_finished());
@@ -1161,7 +1164,16 @@ fn cancel_resets_all_chats_and_indices() {
     assert_eq!(app.cadence(), Cadence::IDLE);
 }
 
-fn finish_subagent(app: &mut App, id: &str, is_error: bool) {
+/// What a subagent's own session sends when it closes, which the `task` tool
+/// does before it reports success or failure.
+pub(crate) fn close_subagent_transcript(app: &mut App, id: &str) {
+    app.update(agent_msg(AgentEvent::SubagentHistory {
+        tool_use_id: id.into(),
+        messages: vec![],
+    }));
+}
+
+pub(crate) fn finish_subagent(app: &mut App, id: &str, is_error: bool) {
     app.update(agent_msg(AgentEvent::ToolDone(Box::new(ToolDoneEvent {
         id: id.into(),
         tool: "task".into(),
@@ -1218,22 +1230,6 @@ fn batch_subagent_done_marker(is_error: bool, expected_text: &str, expected_role
     assert_eq!(app.chats[1].last_message_role(), Some(expected_role));
 }
 
-fn open_tasks_picker(app: &mut App) {
-    for c in "/tasks".chars() {
-        app.update(Msg::Key(key(KeyCode::Char(c))));
-    }
-    app.update(Msg::Key(key(KeyCode::Enter)));
-}
-
-#[test]
-fn ctrl_x_toggles_tasks_picker() {
-    let mut app = test_app();
-    app.update(Msg::Key(kb::TASKS.to_key_event()));
-    assert!(app.task_picker.is_open());
-    app.update(Msg::Key(kb::TASKS.to_key_event()));
-    assert!(!app.task_picker.is_open());
-}
-
 fn streaming_app() -> App {
     let mut app = test_app();
     app.status = Status::Streaming;
@@ -1241,13 +1237,17 @@ fn streaming_app() -> App {
     app
 }
 
-fn app_with_subagent_id(id: &str) -> App {
-    let mut app = streaming_app();
+pub(crate) fn start_subagent(app: &mut App, id: &str, name: &str) {
     app.update(subagent_msg(
         AgentEvent::TextDelta { text: "x".into() },
         id,
-        Some("research"),
+        Some(name),
     ));
+}
+
+pub(crate) fn app_with_subagent_id(id: &str) -> App {
+    let mut app = streaming_app();
+    start_subagent(&mut app, id, RESEARCH_NAME);
     app
 }
 
@@ -1255,127 +1255,45 @@ fn app_with_subagent() -> App {
     app_with_subagent_id(TASK_ID)
 }
 
+/// The shape the picker filters on: the main chat first without a status, then
+/// every status a subagent can report, spelled the way Lua reads it.
 #[test]
-fn open_task_picker_refreshes_after_tool_done() {
-    let mut app = app_with_subagent();
-    open_tasks_picker(&mut app);
-    assert!(
-        app.task_picker
-            .selected_item()
-            .is_some_and(|entry| entry.chat_index == 0)
+fn tasks_report_main_chat_then_subagent_outcomes() {
+    let mut app = app_with_subagent_id("task1");
+    for (id, name) in [("task2", "build"), ("task3", "deploy")] {
+        app.update(subagent_msg(
+            AgentEvent::TextDelta { text: "y".into() },
+            id,
+            Some(name),
+        ));
+    }
+    finish_subagent(&mut app, "task1", false);
+    finish_subagent(&mut app, "task2", true);
+
+    let tasks = serde_json::to_value(app.tasks()).unwrap();
+    assert_eq!(
+        tasks,
+        serde_json::json!([
+            { "id": "main", "name": "Main", "focused": true },
+            { "id": "task1", "name": "research", "status": "done", "focused": false },
+            { "id": "task2", "name": "build", "status": "error", "focused": false },
+            { "id": "task3", "name": "deploy", "status": "working", "focused": false },
+        ])
     );
-
-    finish_subagent_task(&mut app, false);
-
-    assert!(app.task_picker.is_open());
-    assert_eq!(app.task_picker.item(1).unwrap().finished, Some(true));
 }
 
+/// Escaping out of a subagent takes the single-chat cancel path instead of the
+/// sweep over the whole turn, and that path has to land the task in `error`
+/// too, or it spins forever.
 #[test]
-fn open_task_picker_inserts_new_child_without_changing_selection() {
+fn cancelling_from_inside_a_subagent_reports_error() {
     let mut app = app_with_subagent();
-    open_tasks_picker(&mut app);
-    app.update(Msg::Key(key(KeyCode::Down)));
-
-    app.update(subagent_msg(
-        AgentEvent::TextDelta { text: "new".into() },
-        "task2",
-        Some("build"),
-    ));
-
-    assert_eq!(app.task_picker.item(2).unwrap().name, "build");
-    assert_eq!(app.task_picker.selected_item().unwrap().chat_index, 1);
-}
-
-#[test]
-fn filtered_task_picker_enter_selects_entry_chat() {
-    let mut app = app_with_subagent_id("task1");
-    app.update(subagent_msg(
-        AgentEvent::TextDelta { text: "y".into() },
-        "task2",
-        Some("build"),
-    ));
-    open_tasks_picker(&mut app);
-    app.update(Msg::Key(key(KeyCode::Char('b'))));
-
-    assert_eq!(app.task_picker.selected_item().unwrap().chat_index, 2);
-    app.update(Msg::Key(key(KeyCode::Enter)));
-
-    assert!(!app.task_picker.is_open());
-    assert_eq!(app.active_chat, 2);
-}
-
-#[test]
-fn filtered_task_picker_refresh_preserves_selected_chat_identity() {
-    let mut app = app_with_subagent_id("task1");
-    app.update(subagent_msg(
-        AgentEvent::TextDelta { text: "y".into() },
-        "task2",
-        Some("build"),
-    ));
-    open_tasks_picker(&mut app);
-    app.update(Msg::Key(key(KeyCode::Char('b'))));
-    assert_eq!(app.task_picker.selected_item().unwrap().chat_index, 2);
-
-    app.update(subagent_msg(
-        AgentEvent::TextDelta { text: "z".into() },
-        "task3",
-        Some("benchmark"),
-    ));
-
-    assert!(app.task_picker.is_open());
-    assert_eq!(app.task_picker.selected_item().unwrap().chat_index, 2);
-}
-
-#[test]
-fn open_task_picker_refreshes_after_subagent_history() {
-    let mut app = app_with_subagent_id("session-abc");
-    open_tasks_picker(&mut app);
-
-    app.update(agent_msg(AgentEvent::SubagentHistory {
-        tool_use_id: "session-abc".into(),
-        messages: vec![],
-    }));
-
-    assert!(app.task_picker.is_open());
-    assert_eq!(app.task_picker.item(1).unwrap().finished, Some(true));
-}
-
-#[test]
-fn closed_task_picker_stays_closed_after_lifecycle_events() {
-    let mut app = app_with_subagent();
-    finish_subagent_task(&mut app, false);
-    app.update(subagent_msg(
-        AgentEvent::TextDelta { text: "new".into() },
-        "task2",
-        Some("build"),
-    ));
-    assert!(!app.task_picker.is_open());
-}
-
-#[test]
-fn picker_escape_restores_chat() {
-    let mut app = app_with_subagent();
-    assert_eq!(app.active_chat, 0);
-
-    open_tasks_picker(&mut app);
-    app.update(Msg::Key(key(KeyCode::Down)));
-    app.update(Msg::Key(key(KeyCode::Esc)));
-
-    assert!(!app.task_picker.is_open());
-    assert_eq!(app.active_chat, 0);
-}
-
-#[test]
-fn picker_enter_stays_at_navigated() {
-    let mut app = app_with_subagent();
-
-    open_tasks_picker(&mut app);
-    app.update(Msg::Key(key(KeyCode::Down)));
-    app.update(Msg::Key(key(KeyCode::Enter)));
-
-    assert!(!app.task_picker.is_open());
-    assert_eq!(app.active_chat, 1);
+    app.focus_task(TASK_ID).unwrap();
+    cancel_app(&mut app);
+    assert_eq!(
+        serde_json::to_value(app.tasks()).unwrap()[1]["status"],
+        serde_json::json!("error")
+    );
 }
 
 const OVERLAY_BLOCKED_KEYS: &[KeyEvent] = &[
@@ -1399,10 +1317,9 @@ fn focus_queue(app: &mut App) {
     app.queue.set_focus_at(0);
 }
 
-#[test_case(open_tasks_picker as fn(&mut App) ; "task_picker")]
-#[test_case(open_help                         ; "help_modal")]
-#[test_case(open_search                       ; "search_modal")]
-#[test_case(focus_queue                       ; "queue_focus")]
+#[test_case(open_help as fn(&mut App) ; "help_modal")]
+#[test_case(open_search               ; "search_modal")]
+#[test_case(focus_queue               ; "queue_focus")]
 fn overlay_blocks_ctrl_shortcuts(setup: fn(&mut App)) {
     let mut app = app_with_subagent();
     setup(&mut app);
@@ -2299,12 +2216,6 @@ fn help_modal_consumes_keys_and_esc_closes() {
     ; "queue_focus"
 )]
 #[test_case(
-    |app: &mut App| { open_tasks_picker(app); },
-    &[KeybindContext::TaskPicker],
-    &[KeybindContext::Editing]
-    ; "task_picker"
-)]
-#[test_case(
     |app: &mut App| {
         app.state.session_mut().push_message(Message::user("test".into()));
         app.open_rewind_picker();
@@ -3030,7 +2941,10 @@ fn mcp_toggle_dispatches_action() {
     ; "consumed_by_plan_form"
 )]
 #[test_case(
-    |app: &mut App| { open_tasks_picker(app); },
+    |app: &mut App| {
+        app.state.session_mut().push_message(Message::user("test".into()));
+        app.open_rewind_picker();
+    },
     ""
     ; "routed_to_open_picker"
 )]
@@ -3267,14 +3181,11 @@ fn parent_error_refreshes_picker_and_persists_only_completed_children() {
         "model-c",
     ));
     finish_subagent(&mut app, "task3", false);
-    open_tasks_picker(&mut app);
 
     app.update(agent_msg(AgentEvent::Error {
         message: "boom".into(),
     }));
 
-    assert!(app.task_picker.is_open());
-    assert_eq!(app.task_picker.item(2).unwrap().finished, Some(true));
     app.checkpoint();
     let saved: Vec<_> = app
         .state

--- a/maki-ui/src/app/view.rs
+++ b/maki-ui/src/app/view.rs
@@ -33,7 +33,7 @@ impl App {
     pub fn view(&mut self, frame: &mut Frame) {
         let form_visible = self.permission_prompt.is_open() || self.plan_form_active();
         let layout = self.compute_layout(frame.area(), form_visible);
-        let render_chat = self.resolve_render_chat();
+        let render_chat = self.active_chat;
 
         self.render_background(frame);
         self.render_messages(frame, &layout, render_chat);
@@ -129,16 +129,6 @@ impl App {
         }
     }
 
-    fn resolve_render_chat(&self) -> usize {
-        if self.task_picker.is_open() {
-            self.task_picker
-                .selected_index()
-                .unwrap_or(self.active_chat)
-        } else {
-            self.active_chat
-        }
-    }
-
     fn render_background(&self, frame: &mut Frame) {
         let bg =
             Block::default().style(ratatui::style::Style::new().bg(theme::current().background));
@@ -228,10 +218,6 @@ impl App {
 
         if self.search_modal.is_open() {
             overlay_rect = self.search_modal.view(frame, layout.msg_area);
-        }
-
-        if self.task_picker.is_open() {
-            overlay_rect = self.task_picker.view(frame, full);
         }
 
         if self.file_picker.is_open() {
@@ -431,8 +417,6 @@ impl App {
             contexts.push(KeybindContext::QueueFocus);
         } else if self.rewind_picker.is_open() {
             contexts.push(KeybindContext::RewindPicker);
-        } else if self.task_picker.is_open() {
-            contexts.push(KeybindContext::TaskPicker);
         } else if self.theme_picker.is_open() {
             contexts.push(KeybindContext::ThemePicker);
         } else if self.model_picker.is_open() {

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 
+use crate::app::tasks::{TaskOutcome, TaskStatus};
 use crate::components::messages::{MessagesPanel, PromptProgress};
 use crate::components::tool_display::append_annotation;
 use crate::components::{DisplayMessage, DisplayRole, ToolRole, ToolStatus};
@@ -52,7 +53,12 @@ pub struct Chat {
     pub model_id: Option<String>,
     pending_turn_usage: Option<String>,
     messages_panel: MessagesPanel,
-    finished: bool,
+    /// The ending and the index of the bubble announcing it, so a later, better
+    /// informed outcome can fix that bubble instead of appending a second one.
+    finish: Option<(TaskOutcome, usize)>,
+    /// `None` for the main chat, the subagent's `tool_use_id` otherwise. That
+    /// is the handle `maki.task` addresses a task by, see `app::tasks`.
+    task_id: Option<Arc<str>>,
 }
 
 impl Chat {
@@ -64,8 +70,29 @@ impl Chat {
             model_id: None,
             pending_turn_usage: None,
             messages_panel: MessagesPanel::new(ui_config, lua_event_handle),
-            finished: false,
+            finish: None,
+            task_id: None,
         }
+    }
+
+    pub(crate) fn subagent(
+        task_id: &str,
+        name: String,
+        ui_config: UiConfig,
+        lua_event_handle: maki_lua::EventHandle,
+    ) -> Self {
+        Self {
+            task_id: Some(Arc::from(task_id)),
+            ..Self::new(name, ui_config, lua_event_handle)
+        }
+    }
+
+    pub(crate) fn task_id(&self) -> Option<&Arc<str>> {
+        self.task_id.as_ref()
+    }
+
+    pub(crate) fn task_status(&self) -> TaskStatus {
+        self.finish.map(|(outcome, _)| outcome).into()
     }
 
     pub fn set_pending_turn_usage(&mut self, usage: String) {
@@ -305,18 +332,27 @@ impl Chat {
         self.messages_panel.push(msg);
     }
 
-    pub fn mark_finished(&mut self, role: DisplayRole, text: &str) {
-        if self.finished {
+    /// Ends the transcript with the bubble [`TaskOutcome::role`] picks. A chat
+    /// only ever grows one ending, but a caller who knows more than the one who
+    /// got here first rewrites it in place. See [`TaskOutcome::refines`].
+    pub(crate) fn mark_finished(&mut self, outcome: TaskOutcome, text: &str) {
+        if let Some((previous, bubble)) = self.finish {
+            if outcome.refines(previous) {
+                self.finish = Some((outcome, bubble));
+                self.messages_panel
+                    .replace(bubble, DisplayMessage::new(outcome.role(), text.into()));
+            }
             return;
         }
-        self.finished = true;
         self.messages_panel.flush();
-        self.messages_panel
-            .push(DisplayMessage::new(role, text.into()));
+        let bubble = self
+            .messages_panel
+            .push(DisplayMessage::new(outcome.role(), text.into()));
+        self.finish = Some((outcome, bubble));
     }
 
     pub fn is_finished(&self) -> bool {
-        self.finished
+        self.finish.is_some()
     }
 
     pub fn update_tool_summary(&mut self, tool_id: &str, summary: &str) {
@@ -363,6 +399,11 @@ impl Chat {
     #[cfg(test)]
     pub fn message_count(&self) -> usize {
         self.messages_panel.message_count()
+    }
+
+    #[cfg(test)]
+    pub fn message_at(&self, index: usize) -> Option<&DisplayMessage> {
+        self.messages_panel.message_at(index)
     }
 
     #[cfg(test)]
@@ -663,13 +704,44 @@ mod tests {
         HashMap::new()
     }
 
-    #[test]
-    fn tool_lifecycle() {
-        let mut chat = Chat::new(
-            "Main".into(),
+    const MAIN_NAME: &str = "Main";
+    const SUBAGENT_NAME: &str = "research";
+    const TASK_ID: &str = "toolu_01";
+    const USER_TEXT: &str = "one more thing";
+    const REPLY_TEXT: &str = "on it";
+
+    fn chat() -> Chat {
+        Chat::new(
+            MAIN_NAME.into(),
             UiConfig::default(),
             maki_lua::EventHandle::disconnected_for_test(),
-        );
+        )
+    }
+
+    fn subagent_chat() -> Chat {
+        Chat::subagent(
+            TASK_ID,
+            SUBAGENT_NAME.into(),
+            UiConfig::default(),
+            maki_lua::EventHandle::disconnected_for_test(),
+        )
+    }
+
+    fn end(chat: &mut Chat, outcome: TaskOutcome) {
+        let text = match outcome {
+            TaskOutcome::Error => ERROR_TEXT,
+            TaskOutcome::Unknown | TaskOutcome::Done => DONE_TEXT,
+        };
+        chat.mark_finished(outcome, text);
+    }
+
+    fn text_delta(chat: &mut Chat, text: &str) {
+        chat.handle_event(AgentEvent::TextDelta { text: text.into() }, None);
+    }
+
+    #[test]
+    fn tool_lifecycle() {
+        let mut chat = chat();
         chat.handle_event(tool_start("t1", "bash"), None);
         assert_eq!(chat.in_progress_count(), 1);
 
@@ -682,11 +754,7 @@ mod tests {
 
     #[test]
     fn plan_write_renders_file_content() {
-        let mut chat = Chat::new(
-            "Main".into(),
-            UiConfig::default(),
-            maki_lua::EventHandle::disconnected_for_test(),
-        );
+        let mut chat = chat();
         let dir = tempfile::tempdir().unwrap();
         let plan_path = dir.path().join("plan.md");
         std::fs::write(&plan_path, "# My Plan\n\n- Step 1").unwrap();
@@ -706,11 +774,7 @@ mod tests {
 
     #[test]
     fn plan_write_ignores_different_path() {
-        let mut chat = Chat::new(
-            "Main".into(),
-            UiConfig::default(),
-            maki_lua::EventHandle::disconnected_for_test(),
-        );
+        let mut chat = chat();
         let plan_path = Path::new("/plans/123.md");
         chat.handle_event(tool_start("w1", "write"), Some(plan_path));
         let (output, wp) = write_output("src/main.rs");
@@ -723,11 +787,7 @@ mod tests {
 
     #[test]
     fn plan_edit_shows_path_only() {
-        let mut chat = Chat::new(
-            "Main".into(),
-            UiConfig::default(),
-            maki_lua::EventHandle::disconnected_for_test(),
-        );
+        let mut chat = chat();
         let dir = tempfile::tempdir().unwrap();
         let plan_path = dir.path().join("plan.md");
         std::fs::write(&plan_path, "# My Plan\n\n- Step 1").unwrap();
@@ -1045,11 +1105,7 @@ mod tests {
 
     #[test]
     fn compaction_done_flushes_streaming_buffers() {
-        let mut chat = Chat::new(
-            "Main".into(),
-            UiConfig::default(),
-            maki_lua::EventHandle::disconnected_for_test(),
-        );
+        let mut chat = chat();
 
         chat.handle_event(AgentEvent::AutoCompacting, None);
         assert_eq!(chat.message_count(), 1);
@@ -1078,5 +1134,122 @@ mod tests {
         chat.flush();
         assert_eq!(chat.message_count(), 4);
         assert_eq!(chat.last_message_text(), "new");
+    }
+
+    /// The transcript keeps growing after the ending, since the subagent chat
+    /// stays on screen while the parent turn talks on. A fix aimed at the last
+    /// message would eat whatever landed in between.
+    #[test]
+    fn a_correction_rewrites_the_recorded_bubble_not_the_last_one() {
+        let mut chat = chat();
+        end(&mut chat, TaskOutcome::Unknown);
+        let ending = chat.message_count() - 1;
+
+        chat.show_user_message(USER_TEXT);
+        text_delta(&mut chat, REPLY_TEXT);
+        chat.flush();
+        let before = chat.message_count();
+
+        end(&mut chat, TaskOutcome::Error);
+
+        assert_eq!(chat.message_count(), before);
+        let bubble = chat
+            .message_at(ending)
+            .expect("recorded ending still there");
+        assert_eq!(bubble.text, ERROR_TEXT);
+        assert_eq!(bubble.role, DisplayRole::Error);
+        assert_eq!(
+            chat.message_at(ending + 1).map(|m| &m.role),
+            Some(&DisplayRole::User)
+        );
+        assert_eq!(
+            chat.message_at(ending + 1).map(|m| m.text.as_str()),
+            Some(USER_TEXT)
+        );
+        assert_eq!(chat.last_message_text(), REPLY_TEXT);
+        assert_eq!(chat.last_message_role(), Some(&DisplayRole::Assistant));
+    }
+
+    /// The stream is flushed before the ending is pushed, so a reply still in
+    /// the buffer keeps its place ahead of it and the recorded index points at
+    /// the ending, not at the flushed text.
+    #[test]
+    fn a_pending_stream_lands_before_the_ending_bubble() {
+        let mut chat = chat();
+        text_delta(&mut chat, REPLY_TEXT);
+        assert!(!chat.streaming_text_is_empty());
+
+        end(&mut chat, TaskOutcome::Unknown);
+
+        assert!(chat.streaming_text_is_empty());
+        assert_eq!(chat.message_count(), 2);
+        assert_eq!(
+            chat.message_at(0).map(|m| m.text.as_str()),
+            Some(REPLY_TEXT)
+        );
+        assert_eq!(chat.last_message_text(), DONE_TEXT);
+
+        end(&mut chat, TaskOutcome::Error);
+
+        assert_eq!(chat.message_count(), 2);
+        assert_eq!(
+            chat.message_at(0).map(|m| m.text.as_str()),
+            Some(REPLY_TEXT)
+        );
+        assert_eq!(
+            chat.message_at(0).map(|m| &m.role),
+            Some(&DisplayRole::Assistant)
+        );
+        assert_eq!(chat.last_message_text(), ERROR_TEXT);
+        assert_eq!(chat.last_message_role(), Some(&DisplayRole::Error));
+    }
+
+    /// Every order two endings can arrive in. Only the placeholder gives way,
+    /// a verdict is never walked back, and no order grows a second bubble.
+    #[test_case(TaskOutcome::Unknown, TaskOutcome::Done, DONE_TEXT, DisplayRole::Done, TaskStatus::Done   ; "placeholder_settles_as_done")]
+    #[test_case(TaskOutcome::Unknown, TaskOutcome::Error, ERROR_TEXT, DisplayRole::Error, TaskStatus::Error ; "placeholder_corrected_to_error")]
+    #[test_case(TaskOutcome::Done, TaskOutcome::Error, DONE_TEXT, DisplayRole::Done, TaskStatus::Done     ; "verdict_survives_late_error")]
+    #[test_case(TaskOutcome::Error, TaskOutcome::Done, ERROR_TEXT, DisplayRole::Error, TaskStatus::Error  ; "verdict_survives_late_done")]
+    #[test_case(TaskOutcome::Done, TaskOutcome::Done, DONE_TEXT, DisplayRole::Done, TaskStatus::Done      ; "repeated_verdict")]
+    #[test_case(TaskOutcome::Unknown, TaskOutcome::Unknown, DONE_TEXT, DisplayRole::Done, TaskStatus::Done ; "repeated_placeholder")]
+    fn a_second_ending_never_adds_a_bubble(
+        first: TaskOutcome,
+        second: TaskOutcome,
+        text: &str,
+        role: DisplayRole,
+        status: TaskStatus,
+    ) {
+        let mut chat = chat();
+        chat.show_user_message(USER_TEXT);
+        end(&mut chat, first);
+        let count = chat.message_count();
+
+        end(&mut chat, second);
+
+        assert_eq!(chat.message_count(), count);
+        assert_eq!(chat.last_message_text(), text);
+        assert_eq!(chat.last_message_role(), Some(&role));
+        assert_eq!(chat.task_status(), status);
+    }
+
+    /// The shape `maki.task.list()` serializes: the main chat is not a task,
+    /// and a subagent is one from the moment it starts, working until an
+    /// ending lands on it.
+    #[test]
+    fn only_a_subagent_reports_a_task_and_its_status() {
+        let main = chat();
+        assert!(main.task_id().is_none());
+        assert!(!main.is_finished());
+
+        let mut sub = subagent_chat();
+        assert_eq!(sub.task_id().map(|id| &**id), Some(TASK_ID));
+        assert_eq!(sub.task_status(), TaskStatus::Working);
+        assert!(!sub.is_finished());
+
+        end(&mut sub, TaskOutcome::Error);
+
+        assert!(sub.is_finished());
+        assert_eq!(sub.task_status(), TaskStatus::Error);
+        assert_eq!(sub.task_id().map(|id| &**id), Some(TASK_ID));
     }
 }

--- a/maki-ui/src/components/command.rs
+++ b/maki-ui/src/components/command.rs
@@ -25,11 +25,6 @@ pub struct BuiltinCommand {
 
 pub const BUILTIN_COMMANDS: &[BuiltinCommand] = &[
     BuiltinCommand {
-        name: "/tasks",
-        description: "Browse and search tasks",
-        max_args: 0,
-    },
-    BuiltinCommand {
         name: "/compact",
         description: "Summarize and compact conversation history",
         max_args: 0,
@@ -687,7 +682,7 @@ mod tests {
     }
 
     #[test_case("/compact ", false ; "zero_arg_cmd_with_space")]
-    #[test_case("/tasks ", false   ; "zero_arg_tasks_with_space")]
+    #[test_case("/help ", false     ; "zero_arg_help_with_space")]
     #[test_case("/cd ", true        ; "one_arg_cmd_with_space")]
     #[test_case("/cd ~/foo", true   ; "one_arg_cmd_mid_arg")]
     #[test_case("/cd  ~/foo", true  ; "one_arg_cmd_double_space")]
@@ -882,7 +877,7 @@ mod tests {
 
     #[test_case("/cmp", "/compact" ; "compact_fuzzy")]
     #[test_case("/new", "/new" ; "new_exact")]
-    #[test_case("/tsk", "/tasks" ; "tasks_fuzzy")]
+    #[test_case("/thm", "/theme" ; "theme_fuzzy")]
     fn nucleo_highlights_matching_indices(input: &str, expected_cmd: &str) {
         let p = synced(input);
         assert!(p.is_active(), "Input '{}' should activate palette", input);

--- a/maki-ui/src/components/keybindings.rs
+++ b/maki-ui/src/components/keybindings.rs
@@ -142,7 +142,6 @@ pub mod key {
     pub const FILE_PICKER: Bind = ctrl_bind!('s');
     pub const OPEN_EDITOR: Bind = ctrl_bind!('o');
     pub const PLAN_TOGGLE: Bind = ctrl_bind!('t');
-    pub const TASKS: Bind = ctrl_bind!('x');
     pub const MODEL_PICKER: Bind = ctrl_bind!('m');
     pub const REFRESH: Bind = ctrl_bind!('r');
     pub const SUSPEND: Bind = ctrl_bind!('z');
@@ -164,7 +163,6 @@ pub enum KeybindContext {
     Streaming,
     Picker,
     FormInput,
-    TaskPicker,
     RewindPicker,
     ThemePicker,
     ModelPicker,
@@ -182,7 +180,6 @@ impl KeybindContext {
             Self::Streaming => "While Streaming",
             Self::Picker => "Pickers",
             Self::FormInput => "Form",
-            Self::TaskPicker => "Task Picker",
             Self::RewindPicker => "Rewind Picker",
             Self::ThemePicker => "Theme Picker",
             Self::ModelPicker => "Model Picker",
@@ -195,8 +192,7 @@ impl KeybindContext {
 
     pub const fn parent(self) -> Option<KeybindContext> {
         match self {
-            Self::TaskPicker
-            | Self::RewindPicker
+            Self::RewindPicker
             | Self::ThemePicker
             | Self::ModelPicker
             | Self::QueueFocus
@@ -336,12 +332,6 @@ pub const KEYBINDS: &[Keybind] = &[
     Keybind {
         label: KeyLabel::Single(key::PLAN_TOGGLE.label),
         description: "Toggle plan panel",
-        context: KeybindContext::General,
-        platform: Platform::All,
-    },
-    Keybind {
-        label: KeyLabel::Single(key::TASKS.label),
-        description: "Open tasks",
         context: KeybindContext::General,
         platform: Platform::All,
     },

--- a/maki-ui/src/components/messages/mod.rs
+++ b/maki-ui/src/components/messages/mod.rs
@@ -142,8 +142,23 @@ impl MessagesPanel {
         self.restore_event_tx = event_tx;
     }
 
-    pub fn push(&mut self, msg: DisplayMessage) {
+    /// Hands back the index of the message, which [`Self::replace`] needs to
+    /// correct it later.
+    pub fn push(&mut self, msg: DisplayMessage) -> usize {
         self.messages.push(msg);
+        self.messages.len() - 1
+    }
+
+    /// Drops the whole segment cache, so keep it for one-off corrections and
+    /// never for streaming. Marking the message stale is not enough: only the
+    /// segments the viewport reaches get reflowed, so a fix above it would
+    /// keep painting the old bubble.
+    pub fn replace(&mut self, index: usize, msg: DisplayMessage) {
+        let Some(slot) = self.messages.get_mut(index) else {
+            return;
+        };
+        *slot = msg;
+        self.cache.clear();
     }
 
     pub fn load_messages(&mut self, mut msgs: Vec<DisplayMessage>) {
@@ -475,6 +490,11 @@ impl MessagesPanel {
     #[cfg(test)]
     pub fn message_count(&self) -> usize {
         self.messages.len()
+    }
+
+    #[cfg(test)]
+    pub fn message_at(&self, index: usize) -> Option<&DisplayMessage> {
+        self.messages.get(index)
     }
 
     pub fn last_message_text(&self) -> &str {

--- a/maki-ui/src/components/messages/tests.rs
+++ b/maki-ui/src/components/messages/tests.rs
@@ -1,5 +1,6 @@
 use super::segment;
 use super::*;
+use crate::chat::{DONE_TEXT, ERROR_TEXT};
 use crate::components::scrollbar::SCROLLBAR_THUMB;
 use crate::repaint::expect::{OWED, QUIET};
 use crate::selection::{Selection, SelectionZone};
@@ -2217,6 +2218,7 @@ fn anchored_resize_keeps_the_topmost_visible_segment() {
         "an anchored mid-transcript resize must not flip to the bottom pin"
     );
 }
+
 const THEME_CODE: &str = "fn main() { let x = 1; }";
 const THEME_CODE_KEYWORDS: [&str; 3] = ["fn", "main", "let"];
 
@@ -2283,4 +2285,73 @@ fn theme_switch_repaints_highlighted_code() {
         code_span_styles(&panel, "t1"),
         "a theme switch must re-highlight, not splice old-palette lines back"
     );
+}
+
+const FIRST_TEXT: &str = "run the migration";
+const FOLLOW_UP_TEXT: &str = "and then deploy";
+const STALE_BUBBLE_MSG: &str = "the superseded bubble must disappear from the viewport";
+const UNTOUCHED_MSG: &str = "a rejected replace must leave the transcript untouched";
+
+fn style_of(terminal: &ratatui::Terminal<TestBackend>, text: &str) -> Style {
+    let buf = terminal.backend().buffer();
+    for y in 0..buf.area.height {
+        let row: String = (0..buf.area.width)
+            .filter_map(|x| buf.cell((x, y)).map(|c| c.symbol()))
+            .collect();
+        if let Some(col) = row.find(text) {
+            return buf.cell((col as u16, y)).unwrap().style();
+        }
+    }
+    panic!("{text} was never rendered");
+}
+
+/// `Chat::mark_finished` corrects a bubble long after it was drawn, with the
+/// transcript still growing in between. Unless `replace` throws the baked
+/// segments away, the viewport keeps painting a green "Done!" the message
+/// vector no longer holds.
+#[test]
+fn replace_repaints_the_corrected_bubble_in_place() {
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
+    panel.push(DisplayMessage::new(DisplayRole::User, FIRST_TEXT.into()));
+    let bubble = panel.push(DisplayMessage::new(DisplayRole::Done, DONE_TEXT.into()));
+    panel.push(DisplayMessage::new(
+        DisplayRole::User,
+        FOLLOW_UP_TEXT.into(),
+    ));
+    let done_style = style_of(&render(&mut panel, 80, 24), DONE_TEXT);
+
+    panel.replace(
+        bubble,
+        DisplayMessage::new(DisplayRole::Error, ERROR_TEXT.into()),
+    );
+
+    let rendered = render(&mut panel, 80, 24);
+    let text = buffer_text(&rendered);
+    let texts: Vec<&str> = panel.messages.iter().map(|m| m.text.as_str()).collect();
+    assert_eq!(texts, [FIRST_TEXT, ERROR_TEXT, FOLLOW_UP_TEXT]);
+    assert!(text.contains(ERROR_TEXT), "got: {text}");
+    assert!(text.contains(FOLLOW_UP_TEXT), "got: {text}");
+    assert!(!text.contains(DONE_TEXT), "{STALE_BUBBLE_MSG}: {text}");
+    assert_ne!(
+        style_of(&rendered, ERROR_TEXT),
+        done_style,
+        "the corrected bubble kept the success styling"
+    );
+}
+
+#[test]
+fn replace_past_the_end_is_a_noop() {
+    let mut panel = MessagesPanel::new(UiConfig::default(), EventHandle::disconnected_for_test());
+    panel.push(DisplayMessage::new(DisplayRole::Done, DONE_TEXT.into()));
+    rebuild(&mut panel);
+
+    panel.replace(
+        panel.message_count(),
+        DisplayMessage::new(DisplayRole::Error, ERROR_TEXT.into()),
+    );
+
+    assert_eq!(panel.message_count(), 1, "{UNTOUCHED_MSG}");
+    let text = buffer_text(&render(&mut panel, 80, 10));
+    assert!(text.contains(DONE_TEXT), "{UNTOUCHED_MSG}: {text}");
+    assert!(!text.contains(ERROR_TEXT), "{UNTOUCHED_MSG}: {text}");
 }

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -25,7 +25,7 @@ use maki_agent::{
 use maki_config::{ModelPolicy, UiConfig};
 use maki_lua::{
     EventHandle, HintReader, KeymapReader, LuaCommandReader, ModelRequest, SessionRequest,
-    UiAction, UiReply,
+    TaskRequest, UiAction, UiReply,
 };
 use maki_providers::Timeouts;
 use maki_providers::provider::{Provider, fetch_all_models, from_model};
@@ -40,6 +40,7 @@ use tracing::{info, warn};
 use crate::AppSession;
 use crate::agent::{AgentCommand, AgentHandles, ModelSlot, shared_queue::QueueItem};
 use crate::app::shell::{ShellEvent, spawn_shell};
+use crate::app::tasks::{TaskStatus, diff_task_states};
 use crate::app::{App, Msg, Notification, QueuedMessage, SubmitOutcome, turn_response};
 use crate::color_compat;
 use crate::components::input::Submission;
@@ -265,6 +266,9 @@ struct SessionRuntime {
     shell_tx: flume::Sender<ShellEvent>,
     shell_rx: flume::Receiver<ShellEvent>,
     last_status: SessionStatus,
+    /// Keyed by task id, never by position: a session reset reuses positions,
+    /// so a new task would inherit the old one's status.
+    last_tasks: Vec<(Arc<str>, TaskStatus)>,
     notifications: RunNotificationState,
 }
 
@@ -362,6 +366,7 @@ impl SpawnCtx {
             shell_tx,
             shell_rx,
             last_status: SessionStatus::Idle,
+            last_tasks: Vec::new(),
             notifications: RunNotificationState::default(),
         }
     }
@@ -775,6 +780,7 @@ impl<'t> EventLoop<'t> {
         self.emit_focus_change();
         dirty |= self.start_mailbox_runs();
         self.emit_status_changes();
+        self.emit_task_changes();
         self.emit_notifications();
         // An `exit_on_done` exit waits on `QueueDrained`; a dead agent loop
         // can never send it, so fail instead of hanging forever.
@@ -819,6 +825,9 @@ impl<'t> EventLoop<'t> {
             }
             UiAction::Model { req, reply_tx } => {
                 let _ = reply_tx.send(self.handle_model_request(req));
+            }
+            UiAction::Task { req, reply_tx } => {
+                let _ = reply_tx.send(self.handle_task_request(req));
             }
             UiAction::WinSaveView { reply_tx } => {
                 let _ = reply_tx.send(self.focused_app().win_view());
@@ -884,6 +893,26 @@ impl<'t> EventLoop<'t> {
                     "focused": i == self.focused,
                 }),
             );
+        }
+    }
+
+    /// One diff per frame covers every path that finishes, cancels or errors a
+    /// chat, so none of them has to remember to fire an event.
+    fn emit_task_changes(&mut self) {
+        let handle = &self.ctx.lua_event_handle;
+        for rt in &mut self.sessions {
+            let session_id = rt.app.state.session.id;
+            diff_task_states(&mut rt.last_tasks, rt.app.task_states(), |task| {
+                handle.fire_autocmd(
+                    "TaskStatusChanged",
+                    json!({
+                        "session_id": session_id,
+                        "id": task.id,
+                        "name": task.name,
+                        "status": task.status,
+                    }),
+                );
+            });
         }
     }
 
@@ -1094,6 +1123,13 @@ impl<'t> EventLoop<'t> {
                 }
                 Ok(app.model_state())
             }
+        }
+    }
+
+    fn handle_task_request(&mut self, req: TaskRequest) -> UiReply {
+        match req {
+            TaskRequest::List => Ok(json!(self.focused_app().tasks())),
+            TaskRequest::Focus { id } => self.focused_app().focus_task(&id).map(|()| json!(true)),
         }
     }
 

--- a/maki-ui/src/splash.rs
+++ b/maki-ui/src/splash.rs
@@ -23,7 +23,7 @@ const TIPS: &[(&str, &str)] = &[
         key::FILE_PICKER.label,
         "to grab file paths with fuzzy search",
     ),
-    (key::TASKS.label, "to see what your subagents are up to"),
+    ("/tasks", "to see what your subagents are up to"),
     (key::SEARCH.label, "to find things in the conversation"),
     ("/btw", "to ask something without interrupting the session"),
     ("/memory", "to view, edit, and delete persistent notes"),

--- a/plugins/lib/maki/list_picker.lua
+++ b/plugins/lib/maki/list_picker.lua
@@ -180,6 +180,20 @@ local function render_lines(items, selected, width, query)
   return lines, item_lines
 end
 
+-- Draws the filter query and its blank spacer into {lines}, pins that height on
+-- {win} and returns it, which is also the first scrollable line. Drawing and
+-- pinning belong together: a query that wraps, or one pasted with a newline,
+-- makes the header taller than a picker would guess, and a reserved_top guessed
+-- elsewhere then mis-scrolls the list.
+function ListPicker.render_header(win, lines, input, prefix, inner)
+  for _, ln in ipairs(input:render(prefix, utf8.len(prefix) or #prefix, inner).lines) do
+    lines[#lines + 1] = ln
+  end
+  lines[#lines + 1] = {}
+  win:set_config({ reserved_top = #lines })
+  return #lines
+end
+
 -- Open a fuzzy-filter picker in a floating window and block until the user
 -- decides. {items} is a list of strings or { label, detail? } tables. {opts}:
 -- title, footer, cursor (initial index), submit_keys (extra submit keys

--- a/plugins/lib/tests/spec.lua
+++ b/plugins/lib/tests/spec.lua
@@ -1436,4 +1436,46 @@ case("render_lines_nil_sections_mix_with_grouped", function()
   eq(item_lines[2], 3, "nil-section item follows without a new header")
 end)
 
+local function mock_win()
+  local w = {}
+  function w:set_config(cfg)
+    self.reserved_top = cfg.reserved_top
+  end
+  return w
+end
+
+-- A query that wraps, or one pasted with a newline, grows the header past the
+-- single line a picker would guess. Whatever it draws is what the window pins,
+-- or the query scrolls out from under itself.
+case("render_header_pins_the_height_it_actually_drew", function()
+  local TextInput = require("maki.text_input")
+  local win = mock_win()
+  local input = TextInput.new()
+  local lines = {}
+
+  eq(ListPicker.render_header(win, lines, input, "> ", 40), 2, "empty query is one line plus a spacer")
+  eq(win.reserved_top, 2)
+  eq(#lines, 2)
+
+  input:insert_text(string.rep("x", 60))
+  lines = {}
+  eq(ListPicker.render_header(win, lines, input, "> ", 40), 3, "a wrapped query is two lines plus a spacer")
+  eq(win.reserved_top, 3)
+  eq(#lines, 3)
+
+  input:clear()
+  input:insert_text("a\nb")
+  lines = {}
+  eq(ListPicker.render_header(win, lines, input, "> ", 40), 3, "a pasted newline is two lines plus a spacer")
+  eq(win.reserved_top, 3)
+
+  -- Shrinking back matters too: a header pinned taller than it draws leaves a
+  -- gap and mis-scrolls the list under it.
+  input:clear()
+  lines = {}
+  eq(ListPicker.render_header(win, lines, input, "> ", 40), 2, "clearing the query shrinks the header back")
+  eq(win.reserved_top, 2)
+  eq(#lines, 2)
+end)
+
 th.report()

--- a/plugins/sessions/init.lua
+++ b/plugins/sessions/init.lua
@@ -157,15 +157,7 @@ local function render()
   local inner = board.width - 4
   local input = board.rename and board.rename.input or board.input
   local prefix = board.rename and RENAME_PREFIX or FILTER_PREFIX
-  for _, ln in ipairs(input:render(prefix, dispw(prefix), inner).lines) do
-    lines[#lines + 1] = ln
-  end
-  lines[#lines + 1] = {}
-  -- The query and its blank spacer stay pinned while the list scrolls.
-  if #lines ~= board.reserved then
-    board.reserved = #lines
-    board.win:set_config({ reserved_top = board.reserved })
-  end
+  board.reserved = ListPicker.render_header(board.win, lines, input, prefix, inner)
   local cursor_line = board.reserved
   local words = filter_words()
   for i, s in ipairs(board.items) do
@@ -461,7 +453,6 @@ local function open()
     width = "70%",
     height = "70%",
     border = "rounded",
-    reserved_top = 2,
     focus = true,
     footer = FILTER_KEYS,
   })
@@ -470,7 +461,7 @@ local function open()
     buf = buf,
     width = win.width,
     height = win.height,
-    reserved = 2,
+    reserved = 0,
     input = TextInput.new(),
     all = {},
     items = {},

--- a/plugins/task/init.lua
+++ b/plugins/task/init.lua
@@ -4,9 +4,14 @@
 -- This plugin owns structured output and subagent concurrency; Rust exposes
 -- primitives only (`maki.agent.session`, `maki.json.schema_validator`,
 -- `maki.async.semaphore`).
+--
+-- It also owns the /tasks picker over the subagents spawned here: picker.lua
+-- registers the command and the keymap when this file is loaded, so the two
+-- cannot be enabled apart and left pointing at each other's absence.
 
 local ToolView = require("maki.tool_view")
 local output_limits = require("maki.output_limits")
+require("picker")
 
 local STRUCTURED_OUTPUT_NAME = "structured_output"
 local STRUCTURED_OUTPUT_DESCRIPTION = "Report your final result. Call it exactly once when your task is complete."

--- a/plugins/task/picker.lua
+++ b/plugins/task/picker.lua
@@ -1,0 +1,302 @@
+-- The /tasks picker: the subagents of the focused session, running ones first.
+-- The tool in init.lua spawns them, this file only shows them.
+--
+-- The host keeps the transcripts, so there is no task state here. Every
+-- refresh rebuilds the rows from maki.task.list(), and previewing is just
+-- maki.task.focus() with a restore on cancel.
+
+local TextInput = require("maki.text_input")
+local ListPicker = require("maki.list_picker")
+local Rows = require("picker_rows")
+
+local TITLE = " Tasks "
+local FILTER_PREFIX = "❯ "
+local TICK_MS = 100
+-- A placeholder frame. The host swaps "spinner:*" spans for the live one, so
+-- running rows spin without this plugin redrawing.
+local RUNNING_ICON = "· "
+local MAIN_ICON = "● "
+-- The footer counts never animate, so they get a real bullet.
+local RUNNING_COUNT_ICON = "● "
+local DONE_ICON = "✓ "
+local ERROR_ICON = "✗ "
+local NO_MATCHES_HINT = "  No matches"
+local FOOTER_KEYS = { { "Enter", "open" }, { "Esc", "cancel" } }
+-- The main chat has no status, so it falls through to MAIN.
+local ICONS = {
+  working = { RUNNING_ICON, "accent", true },
+  done = { DONE_ICON, "success" },
+  error = { ERROR_ICON, "error" },
+}
+local MAIN = { MAIN_ICON, "accent" }
+
+local board = nil
+
+local function dispw(s)
+  return utf8.len(s) or #s
+end
+
+local function icon_of(task)
+  local icon = ICONS[task.status] or MAIN
+  return icon[1], icon[2], icon[3]
+end
+
+-- The counts describe the rows on screen, so a filter that hides half the list
+-- has to retally them.
+local function update_footer(counts)
+  local footer = {}
+  if counts.running > 0 then
+    footer[#footer + 1] = { RUNNING_COUNT_ICON .. counts.running, "running" }
+  end
+  if counts.finished > 0 then
+    footer[#footer + 1] = { DONE_ICON .. counts.finished, "finished" }
+  end
+  for _, key in ipairs(FOOTER_KEYS) do
+    footer[#footer + 1] = key
+  end
+  board.win:set_config({ footer = footer })
+end
+
+-- The cursor follows its task while the task is still listed, and otherwise
+-- falls to whatever row took over the old position.
+local function rebuild()
+  local previous = Rows.index_of(board.rows, board.sel_id) or 1
+  local built = Rows.build(board.tasks, board.input:value())
+  board.rows = built.rows
+  local idx = Rows.index_of(board.rows, board.sel_id) or math.min(previous, math.max(#board.rows, 1))
+  board.sel_id = board.rows[idx] and board.rows[idx].task.id or nil
+  update_footer(built.sections)
+end
+
+local function render()
+  local lines = {}
+  local inner = board.width - 4
+  board.reserved = ListPicker.render_header(board.win, lines, board.input, FILTER_PREFIX, inner)
+  local cursor_line = board.reserved
+  local words = ListPicker.split_words(board.input:value())
+  for _, row in ipairs(board.rows) do
+    if row.section then
+      lines[#lines + 1] = { { "  " .. row.section, "keybind_section" } }
+    end
+    local task = row.task
+    local selected = task.id == board.sel_id
+    local base = selected and "selected" or "item"
+    local icon, icon_style, spinning = icon_of(task)
+    if selected then
+      icon_style = "selected"
+    end
+    -- Prefixed after the selection style so a running row keeps spinning on
+    -- the selection background.
+    if spinning then
+      icon_style = "spinner:" .. icon_style
+    end
+    local line = { { "  ", base }, { icon, icon_style } }
+    local match_style = selected and "match_selected" or "match"
+    for _, span in ipairs(ListPicker.highlight_spans(task.name, words, base, match_style)) do
+      line[#line + 1] = span
+    end
+    -- Rows with nothing on the right would otherwise end short of the border
+    -- and read as padding on one side only, so the bar runs the full width.
+    local trail = board.width - 2 - dispw(icon) - dispw(task.name)
+    if trail > 0 then
+      line[#line + 1] = { string.rep(" ", trail), base }
+    end
+    lines[#lines + 1] = line
+    if selected then
+      cursor_line = #lines
+    end
+  end
+  if #board.rows == 0 then
+    lines[#lines + 1] = { { NO_MATCHES_HINT, "dim" } }
+  end
+  board.buf:set_lines(lines)
+  board.win:set_cursor(cursor_line)
+end
+
+-- The one host round-trip. `list()` suspends this coroutine and the picker can
+-- close while it waits, so bail out unless this board is still the current one.
+local function refresh()
+  local this_board = board
+  local tasks, err = maki.task.list()
+  if board ~= this_board then
+    return
+  end
+  if err then
+    maki.ui.flash(err)
+    return
+  end
+  board.tasks = tasks
+  rebuild()
+  render()
+end
+
+-- The only exit. Unless the user committed, it puts back whatever was on screen
+-- before the picker opened, so a cancelled preview never sticks.
+local function finish(commit)
+  local closing = board
+  if not closing then
+    return
+  end
+  board = nil
+  if not commit and closing.origin_id then
+    maki.task.focus(closing.origin_id)
+  end
+  closing.win:close()
+end
+
+-- Previewing is a real focus, so the transcript behind the float is the one the
+-- host already draws. Render first for an instant cursor and let the host catch
+-- up next frame.
+local function move_sel(delta, wrap)
+  local n = #board.rows
+  if n == 0 then
+    return
+  end
+  local cur = Rows.index_of(board.rows, board.sel_id) or 1
+  local idx
+  if wrap then
+    idx = (cur - 1 + delta) % n + 1
+  else
+    idx = math.min(math.max(cur + delta, 1), n)
+  end
+  board.sel_id = board.rows[idx].task.id
+  render()
+  local _, err = maki.task.focus(board.sel_id)
+  if err then
+    maki.ui.flash(err)
+  end
+end
+
+local function page_size()
+  return math.max(board.height - board.reserved - 1, 1)
+end
+
+local function open_selected()
+  if not board.sel_id then
+    return
+  end
+  local _, err = maki.task.focus(board.sel_id)
+  if err then
+    maki.ui.flash(err)
+    return
+  end
+  finish(true)
+end
+
+local function handle_key(key)
+  if key == "ctrl+c" or key == "ctrl+x" then
+    finish(false)
+  elseif key == "esc" then
+    if board.input:is_empty() then
+      finish(false)
+    else
+      board.input:clear()
+      rebuild()
+      render()
+    end
+  elseif key == "up" then
+    move_sel(-1, true)
+  elseif key == "down" then
+    move_sel(1, true)
+  elseif key == "pageup" then
+    move_sel(-page_size())
+  elseif key == "pagedown" then
+    move_sel(page_size())
+  elseif key == "enter" then
+    open_selected()
+  elseif board.input:handle_key(key) ~= "ignored" then
+    rebuild()
+    render()
+  end
+end
+
+local function open()
+  if board then
+    return
+  end
+  local buf = maki.ui.buf()
+  local win = maki.ui.open_win(buf, {
+    title = TITLE,
+    width = "70%",
+    height = "70%",
+    border = "rounded",
+    focus = true,
+    footer = FOOTER_KEYS,
+  })
+  board = {
+    win = win,
+    buf = buf,
+    width = win.width,
+    height = win.height,
+    input = TextInput.new(),
+    -- Owned by render(), the only place that knows how tall the query block
+    -- ended up once it wrapped.
+    reserved = 0,
+    tasks = {},
+    rows = {},
+  }
+  refresh()
+  if not board then
+    return
+  end
+  for _, task in ipairs(board.tasks) do
+    if task.focused then
+      board.origin_id, board.sel_id = task.id, task.id
+    end
+  end
+  render()
+
+  while board do
+    local ev = board.win:recv(TICK_MS)
+    if not ev or ev.type == "close" then
+      -- The window is already gone, so there is nothing to restore into.
+      finish(true)
+    elseif ev.type == "timeout" then
+      if board.expired then
+        -- The session changed under us and its ids mean nothing here now.
+        finish(true)
+      elseif board.dirty then
+        board.dirty = false
+        refresh()
+      end
+    elseif ev.type == "key" then
+      handle_key(ev.key)
+    elseif ev.type == "paste" then
+      board.input:insert_text(ev.text)
+      rebuild()
+      render()
+    elseif ev.type == "resize" then
+      board.width = ev.width
+      board.height = ev.height
+      render()
+    end
+  end
+end
+
+-- Autocmds run synchronously while a refresh needs an async round-trip, so both
+-- handlers only raise a flag and let the recv tick do the work.
+maki.api.create_autocmd({ "TaskStatusChanged", "SessionStatusChanged" }, {
+  callback = function()
+    if board then
+      board.dirty = true
+    end
+  end,
+})
+
+-- The picker only ever shows the focused session, so a session switch closes it
+-- instead of leaving ids from elsewhere on screen.
+maki.api.create_autocmd("SessionFocusChanged", {
+  callback = function()
+    if board then
+      board.expired = true
+    end
+  end,
+})
+
+maki.api.register_command({
+  name = "/tasks",
+  description = "Browse and search tasks",
+  handler = open,
+})
+
+maki.keymap.set("n", "<C-x>", open, { desc = "Open tasks" })

--- a/plugins/task/picker_rows.lua
+++ b/plugins/task/picker_rows.lua
@@ -1,0 +1,58 @@
+-- Row building for the /tasks picker in picker.lua: filtering, ordering and
+-- sections, with no
+-- host calls and no globals. Every refresh throws the old rows away and builds
+-- them again, so nothing here can drift from the host list.
+
+local ListPicker = require("maki.list_picker")
+
+local RUNNING_SECTION = "Running"
+local FINISHED_SECTION = "Finished"
+
+local M = {}
+
+-- The main chat comes first and has no status. The subagents follow, running
+-- ones above finished ones so a long job never gets buried under the ones that
+-- already returned. Within a section, chat order.
+--
+-- Returns { rows, sections }. A row carries a section header only when it opens
+-- one, and `sections` counts what survived the filter.
+function M.build(tasks, query)
+  local words = ListPicker.split_words(query)
+  local main, running, finished = nil, {}, {}
+  for _, task in ipairs(tasks) do
+    if ListPicker.matches(task.name, words) then
+      if not task.status then
+        main = task
+      elseif task.status == "working" then
+        running[#running + 1] = task
+      else
+        finished[#finished + 1] = task
+      end
+    end
+  end
+
+  local rows = {}
+  if main then
+    rows[#rows + 1] = { task = main }
+  end
+  for _, group in ipairs({ { RUNNING_SECTION, running }, { FINISHED_SECTION, finished } }) do
+    for i, task in ipairs(group[2]) do
+      rows[#rows + 1] = { task = task, section = i == 1 and group[1] or nil }
+    end
+  end
+  return { rows = rows, sections = { running = #running, finished = #finished } }
+end
+
+-- Position of {id} among {rows}, or nil. The selection is kept as an id and
+-- resolved here at render time, so a task moving between sections never drags
+-- the cursor with it.
+function M.index_of(rows, id)
+  for i, row in ipairs(rows) do
+    if row.task.id == id then
+      return i
+    end
+  end
+  return nil
+end
+
+return M

--- a/plugins/task/tests/spec.lua
+++ b/plugins/task/tests/spec.lua
@@ -1,17 +1,16 @@
-local failures = {}
+local Rows = require("picker_rows")
+local th = require("maki.test_helpers")
 
-local function case(name, fn)
-  local ok, err = pcall(fn)
-  if not ok then
-    table.insert(failures, name .. ": " .. tostring(err))
-  end
-end
+local case = th.case
+local eq = th.eq
 
-local function eq(actual, expected, msg)
-  if actual ~= expected then
-    error((msg or "") .. "\nexpected: " .. tostring(expected) .. "\n  actual: " .. tostring(actual))
-  end
-end
+local MAIN = { id = "main", name = "Main", focused = true }
+local RESEARCH = { id = "toolu_01", name = "research", status = "working", focused = false }
+local BUILD = { id = "toolu_02", name = "build", status = "done", focused = false }
+local BENCH = { id = "toolu_03", name = "benchmark", status = "error", focused = false }
+local DEPLOY = { id = "toolu_04", name = "deploy", status = "working", focused = false }
+local AUDIT = { id = "toolu_05", name = "audit", status = "working", focused = false }
+local RESEARCH_DONE = { id = RESEARCH.id, name = RESEARCH.name, status = "done", focused = false }
 
 case("maki_agent_has_expected_functions", function()
   assert(type(maki.agent) == "table", "maki.agent must be a table")
@@ -39,6 +38,90 @@ case("schema_validator_rejects_bad_schema", function()
   assert(err ~= nil, "bad schema must return an error")
 end)
 
-if #failures > 0 then
-  error(#failures .. " case(s) failed:\n\n" .. table.concat(failures, "\n\n"))
+local function ids(rows)
+  local out = {}
+  for _, row in ipairs(rows) do
+    out[#out + 1] = row.task.id
+  end
+  return table.concat(out, ",")
 end
+
+-- "3:Finished" reads as: row 3 opens the Finished section. Rows left out of the
+-- string draw no header, so it also pins down where sections do not appear.
+local function sections(rows)
+  local out = {}
+  for i, row in ipairs(rows) do
+    if row.section then
+      out[#out + 1] = i .. ":" .. row.section
+    end
+  end
+  return table.concat(out, ",")
+end
+
+case("main_is_pinned_first_and_running_beats_finished", function()
+  local built = Rows.build({ MAIN, RESEARCH, BUILD, BENCH, DEPLOY }, "")
+  eq(ids(built.rows), "main,toolu_01,toolu_04,toolu_02,toolu_03")
+  eq(sections(built.rows), "2:Running,4:Finished", "main has no header and each section opens once")
+  eq(built.sections.running, 2)
+  eq(built.sections.finished, 2)
+end)
+
+-- The worst case for a cursor kept as a position: the first running task
+-- finishes, crosses into the section below, and everything in between shifts up
+-- a row. The selection is an id, so it has to follow the task.
+case("a_task_that_finishes_moves_sections_and_stays_addressable", function()
+  local before = Rows.build({ MAIN, RESEARCH, DEPLOY, AUDIT, BUILD }, "")
+  eq(ids(before.rows), table.concat({ MAIN.id, RESEARCH.id, DEPLOY.id, AUDIT.id, BUILD.id }, ","))
+  eq(sections(before.rows), "2:Running,5:Finished")
+  eq(Rows.index_of(before.rows, RESEARCH.id), 2)
+
+  local after = Rows.build({ MAIN, RESEARCH_DONE, DEPLOY, AUDIT, BUILD }, "")
+  eq(sections(after.rows), "2:Running,4:Finished")
+  eq(Rows.index_of(after.rows, DEPLOY.id), 2)
+  eq(Rows.index_of(after.rows, AUDIT.id), 3)
+  eq(Rows.index_of(after.rows, RESEARCH.id), 4)
+  eq(Rows.index_of(after.rows, BUILD.id), 5)
+end)
+
+-- `rebuild` resolves the cursor through `index_of(rows, board.sel_id)`, and
+-- `sel_id` is nil when nothing is selected, so a nil id has to match no row
+-- rather than the first one.
+case("index_of_matches_no_row_for_a_nil_or_departed_id", function()
+  local built = Rows.build({ MAIN, RESEARCH }, "")
+  eq(Rows.index_of(built.rows, nil), nil)
+  eq(Rows.index_of(built.rows, BUILD.id), nil)
+end)
+
+case("the_filter_matches_any_name_including_the_main_chat", function()
+  local all = { MAIN, RESEARCH, BUILD, BENCH }
+  eq(ids(Rows.build(all, "arch").rows), RESEARCH.id, "matches inside a name")
+  eq(ids(Rows.build(all, RESEARCH.name).rows), RESEARCH.id, "the main chat is filtered out like any other row")
+  eq(ids(Rows.build(all, "nope").rows), "")
+end)
+
+-- The counts feed the footer, which describes the rows on screen, so a filter
+-- that empties a section has to zero its tally and drop its header.
+case("a_filter_that_empties_a_section_zeroes_its_count_and_header", function()
+  local all = { MAIN, RESEARCH, BUILD, BENCH, DEPLOY }
+
+  local finished_only = Rows.build(all, "b")
+  eq(ids(finished_only.rows), BUILD.id .. "," .. BENCH.id)
+  eq(sections(finished_only.rows), "1:Finished", "no running row means no Running header")
+  eq(finished_only.sections.running, 0)
+  eq(finished_only.sections.finished, 2)
+
+  local running_only = Rows.build(all, DEPLOY.name)
+  eq(ids(running_only.rows), DEPLOY.id)
+  eq(sections(running_only.rows), "1:Running", "no finished row means no Finished header")
+  eq(running_only.sections.running, 1)
+  eq(running_only.sections.finished, 0)
+
+  -- With zero rows the picker draws its "No matches" hint, and the footer next
+  -- to it has to agree that nothing is left.
+  local nothing = Rows.build({}, "")
+  eq(#nothing.rows, 0)
+  eq(nothing.sections.running, 0)
+  eq(nothing.sections.finished, 0)
+end)
+
+th.report()

--- a/site/docs/content/commands/_index.md
+++ b/site/docs/content/commands/_index.md
@@ -13,7 +13,6 @@ Type `/` in the input box to open the command palette.
 
 | Command | Description |
 |---------|-------------|
-| `/tasks` | Browse and search tasks |
 | `/compact` | Summarize and compact conversation history |
 | `/new` | Start a new session |
 | `/help` | Show keybindings |
@@ -34,6 +33,7 @@ Type `/` in the input box to open the command palette.
 | `/memory` | View, edit, and delete memory files |
 | `/rename` | Rename the current session |
 | `/sessions` | Browse and switch sessions |
+| `/tasks` | Browse and search tasks |
 
 ## Sessions
 

--- a/site/docs/content/keybindings/_index.md
+++ b/site/docs/content/keybindings/_index.md
@@ -19,7 +19,6 @@ On macOS, some bindings use Option or Fn keys instead (run `/help` for exact key
 | `Ctrl+S` | File picker |
 | `Ctrl+O` | Open plan in editor |
 | `Ctrl+T` | Toggle plan panel |
-| `Ctrl+X` | Open tasks |
 | `Ctrl+M` | Model picker |
 
 ## Editing
@@ -95,12 +94,13 @@ Built-in plugins register these themselves, and your own plugins can add more wi
 | Key | Action |
 |-----|--------|
 | `Ctrl+P` | Browse sessions |
+| `Ctrl+X` | Open tasks |
 
 ## Context Inheritance
 
 Child contexts inherit their parent's bindings and add their own.
 
-- **Pickers** is the base for: Task Picker, Rewind Picker, Theme Picker, Model Picker, Queue, Commands, Search, File Picker
+- **Pickers** is the base for: Rewind Picker, Theme Picker, Model Picker, Queue, Commands, Search, File Picker
 
 ## Overriding Keybindings
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -104,6 +104,7 @@ The rules:
 | [`maki.model`](#maki-model) | The model behind the focused session. |
 | [`maki.net`](#maki-net) | HTTP client for fetching web content. |
 | [`maki.session`](#maki-session) | Host session primitives. |
+| [`maki.task`](#maki-task) | The subagents of the focused session and their transcripts. |
 | [`maki.text`](#maki-text) | Text transformation utilities. |
 | [`maki.treesitter`](#maki-treesitter) | Tree-sitter parsing and query API. |
 | [`maki.treesitter.language`](#maki-treesitter-language) | Language registry for tree-sitter grammars. |
@@ -562,8 +563,9 @@ Listen for one or more events. Returns an id you can pass to
 
 Built-in events fired by the host: `"TurnStart"`, `"TurnEnd"`,
 `"TurnError"`, `"ToolStart"`, `"ToolDone"`, `"SessionReset"`,
-`"SessionFocusChanged"`, and `"SessionStatusChanged"`. Plugins can also
-fire their own events with `exec_autocmds`.
+`"SessionFocusChanged"`, `"SessionStatusChanged"`, and
+`"TaskStatusChanged"`. Plugins can also fire their own events with
+`exec_autocmds`.
 
 Each host event carries `data.session_id`. For `"SessionReset"` that
 is the session being left behind; the other events name the session now
@@ -572,6 +574,11 @@ running or focused. Tool events also carry `data.tool_id` and `data.tool`.
 initial startup. `"SessionStatusChanged"` fires whenever a session moves
 between `"working"`, `"needs_input"`, and `"idle"`; it carries
 `data.status`, `data.title`, and `data.focused` (boolean).
+`"TaskStatusChanged"` fires when a subagent starts, or when one moves
+between `"working"`, `"done"`, and `"error"`; it carries `data.id` and
+`data.name` alongside `data.status`. A task that comes back from disk
+already finished stays quiet, so reloading a session does not replay
+old tasks.
 
 **Parameters:**
 
@@ -2974,6 +2981,61 @@ local _, err = maki.session.set_title({ id = id, title = "refactor" })
 ```
 
 
+## maki.task {#maki-task}
+
+The subagents of the focused session and their transcripts. Tasks are
+spawned by the `task` tool and addressed by an id that survives a reload.
+Without an interactive UI every function returns
+`nil, "no interactive UI attached"`.
+
+---
+
+### `maki.task.list()` {#maki-task-list}
+
+```lua
+maki.task.list()
+```
+
+Lists the focused session's chats in chat order. Entry 1 is always the main
+chat, with id `"main"` and no `status`: its work is the session's own, and
+`maki.session.live()` already reports that. The rest are subagents, keyed by
+the tool call that spawned them.
+
+**Returns:** (`table|nil`, `string|nil`) Array of `{id, name, focused, status?}` where
+  `status` is `"working"`, `"done"`, or `"error"`, or nil and an error.
+
+**Example:**
+
+```lua
+for _, t in ipairs(maki.task.list() or {}) do
+  print(t.name, t.status or "main")
+end
+```
+
+---
+
+### `maki.task.focus()` {#maki-task-focus}
+
+```lua
+maki.task.focus({id})
+```
+
+Shows a task's transcript, the way the chat cycling keys do. An id from
+another session returns an error instead of landing on the wrong task.
+
+**Parameters:**
+
+- `{id}` (`string`) Task id, as returned by `list()`. `"main"` is the main chat.
+
+**Returns:** (`boolean|nil`, `string|nil`) true on success, or nil and an error.
+
+**Example:**
+
+```lua
+local _, err = maki.task.focus("main")
+```
+
+
 ## maki.text {#maki-text}
 
 Text transformation utilities.
@@ -4404,7 +4466,7 @@ would. Handy when a default key never reaches maki because tmux or
 your terminal grabs it first: bind a new key with `maki.keymap.set`
 and call this from it.
 
-Valid names: `"file_picker"`, `"search"`, `"tasks"`, `"help"`,
+Valid names: `"file_picker"`, `"search"`, `"help"`,
 `"plan_toggle"`, `"plan_editor"`, `"edit_input"`, `"pop_queue"`,
 `"prev_chat"`, `"next_chat"`.
 
@@ -5144,6 +5206,13 @@ function M.replace(content, old_string, new_string, replace_all)
 ### `require("maki.list_picker")`
 
 ```lua
+-- Draws the filter query and its blank spacer into {lines}, pins that height on
+-- {win} and returns it, which is also the first scrollable line. Drawing and
+-- pinning belong together: a query that wraps, or one pasted with a newline,
+-- makes the header taller than a picker would guess, and a reserved_top guessed
+-- elsewhere then mis-scrolls the list.
+function ListPicker.render_header(win, lines, input, prefix, inner)
+
 -- Open a fuzzy-filter picker in a floating window and block until the user
 -- decides. {items} is a list of strings or { label, detail? } tables. {opts}:
 -- title, footer, cursor (initial index), submit_keys (extra submit keys


### PR DESCRIPTION
`/tasks` listed chats in session order, so a long running subagent got buried under the ones that already finished, and the picker now lives in `plugins/task/picker.lua`, next to the tool that spawns the subagents it shows, so one switch turns both off.

The host keeps the transcripts, since piping every streaming delta into Lua would only buy a second source of truth that disagrees with the visible tabs after a restore.

`maki-ui/src/app/tasks.rs` is the one read-model behind both `maki.task.list` and the new `TaskStatusChanged` event, and a task is addressed by its `tool_use_id`, which now lives on the chat instead of in `chat_index`, a routing cache cleared at the end of every turn.

Watch out for `maki-docgen`, it used to read commands from each plugin's `init.lua` alone and now walks every Lua file in the directory, otherwise `/tasks` quietly falls out of the docs.

`maki.ui.action("tasks")` is gone, use `maki.api.run_command("/tasks")` instead.

Closes https://github.com/tontinton/maki/issues/835.