### PR TITLE
feat(providers): add Regolo.ai support

### DIFF
--- a/maki-providers/src/lib.rs
+++ b/maki-providers/src/lib.rs
@@ -27,7 +27,7 @@ pub use providers::openai::auth as openai_auth;
 pub use providers::xai::auth as xai_auth;
 pub use types::{
     ContentBlock, EMPTY_RESPONSE_MARKER, Effort, EffortDialect, IMAGE_OMITTED_NOTE, ImageMediaType,
-    ImageSource, Message, MessageKind, ProviderEvent, ProviderUsage, RequestOptions, Role,
-    StopReason, StreamResponse, THINKING_USAGE, ThinkingConfig, UsageLimit, adapt_images_for_model,
-    dialect,
+    ImageSource, Message, MessageKind, ModelUsageRow, ProviderEvent, ProviderUsage, RequestOptions,
+    Role, StopReason, StreamResponse, THINKING_USAGE, ThinkingConfig, UsageLimit,
+    adapt_images_for_model, dialect,
 };

--- a/maki-providers/src/manifest.rs
+++ b/maki-providers/src/manifest.rs
@@ -2,7 +2,7 @@ use crate::model::{ModelEntry, ModelFamily, ModelTier};
 use crate::pricing::PricingSchedule;
 use crate::providers::{
     anthropic, aperture, copilot, custom, deepseek, dynamic, google, llama_cpp, mistral, ollama,
-    openai, openrouter, synthetic, tensorx, xai, zai,
+    openai, openrouter, regolo, synthetic, tensorx, xai, zai,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -140,6 +140,18 @@ const OPENROUTER: ProviderManifest = ProviderManifest {
     pricing_schedule: None,
 };
 
+const REGOLO: ProviderManifest = ProviderManifest {
+    slug: "regolo",
+    display_name: "Regolo",
+    family: ModelFamily::Generic,
+    supports_thinking: true,
+    accepts_arbitrary_models: false,
+    fallback_max_output: Some(120_000),
+    fallback_context_window: 120_000,
+    models: regolo::models(),
+    pricing_schedule: None,
+};
+
 const SYNTHETIC: ProviderManifest = ProviderManifest {
     slug: "synthetic",
     display_name: "Synthetic",
@@ -223,6 +235,7 @@ const BUILTINS: &[ProviderManifest] = &[
     ZAI,
     DEEPSEEK,
     OPENROUTER,
+    REGOLO,
     SYNTHETIC,
     TENSORX,
     OPENCODE,

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -54,7 +54,7 @@ pub struct ModelPricing {
 
 /// Metadata discovered at runtime from a provider's `/models` endpoint.
 /// All fields optional -- most providers only return an ID.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ModelInfo {
     pub id: String,
     pub context_window: Option<u32>,

--- a/maki-providers/src/model.rs
+++ b/maki-providers/src/model.rs
@@ -648,11 +648,12 @@ impl TokenUsage {
     }
 }
 
-pub fn format_tokens(tokens: u32) -> String {
+pub fn format_tokens(tokens: impl Into<u64>) -> String {
+    let tokens = tokens.into();
     match tokens {
         0..1_000 => tokens.to_string(),
-        1_000..1_000_000 => format!("{:.1}k", f64::from(tokens) / 1_000.0),
-        _ => format!("{:.1}m", f64::from(tokens) / 1_000_000.0),
+        1_000..1_000_000 => format!("{:.1}k", tokens as f64 / 1_000.0),
+        _ => format!("{:.1}m", tokens as f64 / 1_000_000.0),
     }
 }
 

--- a/maki-providers/src/provider.rs
+++ b/maki-providers/src/provider.rs
@@ -28,6 +28,7 @@ use crate::providers::mistral::Mistral;
 use crate::providers::openai::OpenAi;
 use crate::providers::opencode::Opencode;
 use crate::providers::openrouter::OpenRouter;
+use crate::providers::regolo::Regolo;
 use crate::providers::synthetic::Synthetic;
 use crate::providers::tensorx::TensorX;
 use crate::providers::xai::Xai;
@@ -51,6 +52,7 @@ pub enum ProviderKind {
     #[strum(serialize = "openrouter")]
     OpenRouter,
     Synthetic,
+    Regolo,
     #[strum(serialize = "tensorx")]
     TensorX,
     #[strum(serialize = "opencode")]
@@ -74,6 +76,7 @@ impl ProviderKind {
             Self::DeepSeek => "DeepSeek",
             Self::OpenRouter => "OpenRouter",
             Self::Synthetic => "Synthetic",
+            Self::Regolo => "Regolo",
             Self::TensorX => "TensorX",
             Self::Opencode => "Opencode Zen",
             Self::Xai => "xAI",
@@ -94,6 +97,7 @@ impl ProviderKind {
             Self::DeepSeek => "DEEPSEEK_API_KEY",
             Self::OpenRouter => "OPENROUTER_API_KEY",
             Self::Synthetic => "SYNTHETIC_API_KEY",
+            Self::Regolo => "REGOLO_API_KEY",
             Self::TensorX => "TENSORX_API_KEY",
             Self::Opencode => "OPENCODE_API_KEY",
             Self::Xai => "XAI_API_KEY",
@@ -116,6 +120,7 @@ impl ProviderKind {
             Self::DeepSeek => "https://api.deepseek.com",
             Self::OpenRouter => "https://openrouter.ai/api/v1",
             Self::Synthetic => "https://api.synthetic.new/openai/v1",
+            Self::Regolo => "https://api.regolo.ai/v1",
             Self::TensorX => "https://api.tensorx.ai/v1",
             Self::Opencode => "https://opencode.ai/zen/v1",
             Self::Xai => "https://api.x.ai/v1",
@@ -140,6 +145,9 @@ impl ProviderKind {
                 Some("Reasoning effort support (low/medium/high), open-weight models")
             }
             Self::TensorX => Some("Open-weight models, zero data retention, prompt caching"),
+            Self::Regolo => Some(
+                "EU-hosted open-weight models with tool calling. The catalogue and prices are listed live from the API",
+            ),
             Self::DeepSeek => Some("Thinking mode toggle (on/off), open-weight models"),
             Self::OpenRouter => {
                 Some("300+ models from all providers, prompt caching, provider routing")
@@ -170,6 +178,7 @@ impl ProviderKind {
             Self::DeepSeek => ModelFamily::Generic,
             Self::OpenRouter => ModelFamily::Generic,
             Self::Synthetic => ModelFamily::Synthetic,
+            Self::Regolo => ModelFamily::Generic,
             Self::TensorX => ModelFamily::Generic,
             Self::Opencode => ModelFamily::Generic,
             Self::Xai => ModelFamily::Generic,
@@ -195,6 +204,7 @@ impl ProviderKind {
             Self::DeepSeek => Some(384_000),
             Self::OpenRouter => Some(128_000),
             Self::Synthetic => Some(32_000),
+            Self::Regolo => Some(120_000),
             Self::TensorX => None,
             Self::Opencode => Some(128_000),
             Self::Xai => Some(131_072),
@@ -215,6 +225,7 @@ impl ProviderKind {
             Self::DeepSeek => 1_000_000,
             Self::OpenRouter => 200_000,
             Self::Synthetic => 128_000,
+            Self::Regolo => 120_000,
             Self::TensorX => 200_000,
             Self::Opencode => 256_000,
             Self::Xai => 500_000,
@@ -241,6 +252,7 @@ impl ProviderKind {
             Self::DeepSeek => Ok(Box::new(DeepSeek::new(timeouts)?)),
             Self::OpenRouter => Ok(Box::new(OpenRouter::new(timeouts)?)),
             Self::Synthetic => Ok(Box::new(Synthetic::new(timeouts)?)),
+            Self::Regolo => Ok(Box::new(Regolo::new(timeouts)?)),
             Self::TensorX => Ok(Box::new(TensorX::new(timeouts)?)),
             Self::Opencode => Ok(Box::new(Opencode::new(timeouts)?)),
             Self::Xai => Ok(Box::new(Xai::new(timeouts)?)),

--- a/maki-providers/src/providers/anthropic/mod.rs
+++ b/maki-providers/src/providers/anthropic/mod.rs
@@ -203,7 +203,11 @@ impl From<OauthUsage> for ProviderUsage {
             }));
         }
         limits.extend(credits_limit(&u));
-        ProviderUsage { plan: None, limits }
+        ProviderUsage {
+            plan: None,
+            limits,
+            by_model_today: vec![],
+        }
     }
 }
 

--- a/maki-providers/src/providers/aperture.rs
+++ b/maki-providers/src/providers/aperture.rs
@@ -20,6 +20,7 @@ use super::local::{LLAMACPP, LocalEndpoint, OLLAMA};
 use super::mistral::Mistral;
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 use super::openrouter::OpenRouter;
+use super::regolo::Regolo;
 use super::synthetic::Synthetic;
 use super::tensorx::TensorX;
 use super::zai::Zai;
@@ -127,6 +128,7 @@ fn compat_kind(kind: ProviderKind) -> Option<ProviderKind> {
         | ProviderKind::DeepSeek
         | ProviderKind::OpenRouter
         | ProviderKind::Synthetic
+        | ProviderKind::Regolo
         | ProviderKind::TensorX => Some(kind),
         _ => None,
     }
@@ -178,6 +180,7 @@ fn default_path_prefix(kind: Option<ProviderKind>) -> &'static str {
             | ProviderKind::DeepSeek
             | ProviderKind::OpenRouter
             | ProviderKind::Synthetic
+            | ProviderKind::Regolo
             | ProviderKind::TensorX
             | ProviderKind::OpenAi
             | ProviderKind::Copilot
@@ -243,11 +246,21 @@ fn build_routed_provider(
         ProviderKind::TensorX => {
             Box::new(TensorX::with_auth(auth, timeouts).with_system_prefix(system_prefix))
         }
+        ProviderKind::Regolo => {
+            Box::new(Regolo::with_auth(auth, timeouts).with_system_prefix(system_prefix))
+        }
         ProviderKind::Anthropic => {
             Box::new(Anthropic::with_auth(auth, timeouts).with_system_prefix(system_prefix))
         }
         ProviderKind::Google => Box::new(Google::with_auth(auth, timeouts)),
-        _ => unreachable!("routed_kind only returns the variants matched above"),
+        // Excluded by `compat_kind`: routing to native OpenAI would bypass the
+        // gateway for codex models, and the rest have no clean proxy story. A
+        // new kind must pick a side here.
+        ProviderKind::OpenAi
+        | ProviderKind::Copilot
+        | ProviderKind::Opencode
+        | ProviderKind::Xai
+        | ProviderKind::Aperture => unreachable!("excluded by compat_kind"),
     }
 }
 

--- a/maki-providers/src/providers/deepseek.rs
+++ b/maki-providers/src/providers/deepseek.rs
@@ -129,7 +129,11 @@ impl From<BalanceResponse> for ProviderUsage {
                 }
             })
             .collect();
-        ProviderUsage { plan: None, limits }
+        ProviderUsage {
+            plan: None,
+            limits,
+            by_model_today: vec![],
+        }
     }
 }
 

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -32,6 +32,7 @@ use super::mistral::Mistral;
 use super::openai::OpenAi;
 use super::opencode::Opencode;
 use super::openrouter::OpenRouter;
+use super::regolo::Regolo;
 use super::synthetic::Synthetic;
 use super::tensorx::TensorX;
 use super::xai::Xai;
@@ -566,6 +567,10 @@ pub fn create(slug: &str, timeouts: super::Timeouts) -> Result<Box<dyn Provider>
         ),
         ProviderKind::Synthetic => Box::new(
             Synthetic::with_auth(auth.clone(), timeouts)
+                .with_system_prefix(meta.system_prefix.clone()),
+        ),
+        ProviderKind::Regolo => Box::new(
+            Regolo::with_auth(auth.clone(), timeouts)
                 .with_system_prefix(meta.system_prefix.clone()),
         ),
         ProviderKind::DeepSeek => Box::new(

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -29,6 +29,7 @@ pub(crate) mod openai;
 pub(crate) mod openai_compat;
 pub mod opencode;
 pub(crate) mod openrouter;
+pub(crate) mod regolo;
 pub(crate) mod synthetic;
 pub(crate) mod tensorx;
 pub(crate) mod xai;

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -257,6 +257,7 @@ impl From<CodexUsage> for ProviderUsage {
         Self {
             plan: usage.plan_type,
             limits,
+            by_model_today: vec![],
         }
     }
 }

--- a/maki-providers/src/providers/openai_compat.rs
+++ b/maki-providers/src/providers/openai_compat.rs
@@ -140,7 +140,7 @@ impl OpenAiCompatProvider {
     /// Effective base URL: an auth-supplied value (dynamic/custom providers)
     /// wins, then the construction-time env / `providers.toml` override, then
     /// the static compat default.
-    fn base_url(&self, auth: &ResolvedAuth) -> String {
+    pub(crate) fn base_url(&self, auth: &ResolvedAuth) -> String {
         if let Some(explicit) = auth.base_url.as_deref() {
             return explicit.to_string();
         }

--- a/maki-providers/src/providers/regolo.rs
+++ b/maki-providers/src/providers/regolo.rs
@@ -1,3 +1,4 @@
+use std::cmp::Reverse;
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
@@ -8,7 +9,7 @@ use serde_json::Value;
 
 use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
 use crate::provider::{BoxFuture, Provider};
-use crate::types::{ProviderUsage, UsageLimit};
+use crate::types::{ModelUsageRow, ProviderUsage, UsageLimit};
 use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
 
 use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
@@ -98,6 +99,51 @@ pub(crate) const fn models() -> &'static [ModelEntry] {
 }
 
 #[derive(Deserialize)]
+struct SpendLogsResponse {
+    data: Vec<SpendLogEntry>,
+}
+
+#[derive(Deserialize)]
+struct SpendLogEntry {
+    model_group: String,
+    prompt_tokens: u64,
+    completion_tokens: u64,
+    total_tokens: u64,
+    /// USD; rendered as micro-dollars at the boundary to keep `ProviderUsage`
+    /// in `Eq` land.
+    spend: f64,
+}
+
+impl SpendLogsResponse {
+    fn into_rows(self) -> Vec<ModelUsageRow> {
+        let mut by_model: BTreeMap<String, SpendLogEntry> = BTreeMap::new();
+        for entry in self.data {
+            by_model
+                .entry(entry.model_group.clone())
+                .and_modify(|acc| {
+                    acc.prompt_tokens += entry.prompt_tokens;
+                    acc.completion_tokens += entry.completion_tokens;
+                    acc.total_tokens += entry.total_tokens;
+                    acc.spend += entry.spend;
+                })
+                .or_insert(entry);
+        }
+        let mut rows: Vec<ModelUsageRow> = by_model
+            .into_values()
+            .map(|e| ModelUsageRow {
+                model: e.model_group,
+                input_tokens: e.prompt_tokens,
+                output_tokens: e.completion_tokens,
+                total_tokens: e.total_tokens,
+                spend_microdollars: (e.spend * PER_MILLION).round() as u64,
+            })
+            .collect();
+        rows.sort_by_key(|row| Reverse(row.spend_microdollars));
+        rows
+    }
+}
+
+#[derive(Deserialize)]
 struct KeyInfoResponse {
     info: KeyInfo,
 }
@@ -142,6 +188,12 @@ struct ActivityResponse {
 /// `/global/activity` is key-scoped despite its name and answers per UTC day.
 fn activity_url(root: &str, day: jiff::civil::Date) -> String {
     format!("{root}{ACTIVITY_PATH}?start_date={day}&end_date={day}")
+}
+
+/// `/spend/logs/v2` accepts YYYY-MM-DD, end-inclusive. One hour = one row per
+/// model, so callers must sum across rows to get per-model daily totals.
+fn spend_logs_url(root: &str, day: jiff::civil::Date) -> String {
+    format!("{root}{SPEND_LOGS_PATH}?start_date={day}&end_date={day}")
 }
 
 fn next_utc_midnight(now: jiff::Timestamp) -> Option<u64> {
@@ -236,6 +288,7 @@ pub struct Regolo {
 
 const KEY_INFO_PATH: &str = "/key/info";
 const ACTIVITY_PATH: &str = "/global/activity";
+const SPEND_LOGS_PATH: &str = "/spend/logs/v2";
 const MODEL_GROUP_INFO_PATH: &str = "/model_group/info";
 
 /// Regolo's management endpoints live at the host root, outside `/v1`, so
@@ -355,7 +408,19 @@ impl Provider for Regolo {
             {
                 limits.push(activity.into());
             }
-            Ok(Some(ProviderUsage { plan: None, limits }))
+            let by_model_today = self
+                .compat
+                .get_text(&auth, &spend_logs_url(&root, today))
+                .await
+                .ok()
+                .and_then(|body| serde_json::from_str::<SpendLogsResponse>(&body).ok())
+                .map(SpendLogsResponse::into_rows)
+                .unwrap_or_default();
+            Ok(Some(ProviderUsage {
+                plan: None,
+                limits,
+                by_model_today,
+            }))
         })
     }
 
@@ -497,5 +562,51 @@ mod tests {
         let infos = join_fixture(&["Qwen3-Embedding-8B", "glm5.2", "brand-new-model"]);
         let ids: Vec<&str> = infos.iter().map(|i| i.id.as_str()).collect();
         assert_eq!(ids, ["glm5.2"]);
+    }
+
+    const SPEND_LOGS_FIXTURE: &str = r#"{
+      "data": [
+        {
+          "request_id": "h1", "api_key": "k",
+          "model_group": "qwen3-coder-next", "key_alias": "a",
+          "startTime": "2026-08-25T09:00:00+00:00", "endTime": "2026-08-25T10:00:00+00:00",
+          "completionStartTime": null,
+          "api_requests": 4, "total_tokens": 20000,
+          "prompt_tokens": 15000, "completion_tokens": 5000,
+          "spend": 0.010000, "request_duration_ms": 3600000
+        },
+        {
+          "request_id": "h2", "api_key": "k",
+          "model_group": "qwen3-coder-next", "key_alias": "a",
+          "startTime": "2026-08-25T10:00:00+00:00", "endTime": "2026-08-25T11:00:00+00:00",
+          "completionStartTime": null,
+          "api_requests": 3, "total_tokens": 8000,
+          "prompt_tokens": 5000, "completion_tokens": 3000,
+          "spend": 0.004200, "request_duration_ms": 3600000
+        },
+        {
+          "request_id": "h3", "api_key": "k",
+          "model_group": "glm5.2", "key_alias": "a",
+          "startTime": "2026-08-25T09:00:00+00:00", "endTime": "2026-08-25T10:00:00+00:00",
+          "completionStartTime": null,
+          "api_requests": 2, "total_tokens": 360,
+          "prompt_tokens": 200, "completion_tokens": 160,
+          "spend": 0.000900, "request_duration_ms": 3600000
+        }
+      ]
+    }"#;
+
+    #[test]
+    fn spend_logs_aggregate_by_model_and_rank_by_spend() {
+        let resp: SpendLogsResponse = serde_json::from_str(SPEND_LOGS_FIXTURE).unwrap();
+        let rows = resp.into_rows();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].model, "qwen3-coder-next");
+        assert_eq!(rows[0].input_tokens, 20_000);
+        assert_eq!(rows[0].output_tokens, 8_000);
+        assert_eq!(rows[0].total_tokens, 28_000);
+        assert_eq!(rows[0].spend_microdollars, 14_200);
+        assert_eq!(rows[1].model, "glm5.2");
+        assert_eq!(rows[1].spend_microdollars, 900);
     }
 }

--- a/maki-providers/src/providers/regolo.rs
+++ b/maki-providers/src/providers/regolo.rs
@@ -1,0 +1,501 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use flume::Sender;
+use maki_storage::id::SessionRef;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::model::{Model, ModelEntry, ModelFamily, ModelPricing, ModelTier};
+use crate::provider::{BoxFuture, Provider};
+use crate::types::{ProviderUsage, UsageLimit};
+use crate::{AgentError, Message, ProviderEvent, RequestOptions, StreamResponse, dialect};
+
+use super::openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
+use super::{KeyPool, ResolvedAuth};
+
+static CONFIG: OpenAiCompatConfig = OpenAiCompatConfig {
+    slug: "regolo",
+    api_key_env: "REGOLO_API_KEY",
+    base_url: "https://api.regolo.ai/v1",
+    max_tokens_field: "max_completion_tokens",
+    include_stream_usage: true,
+    provider_name: "Regolo",
+};
+
+inventory::submit!(maki_config::providers::BuiltInProvider {
+    slug: "regolo",
+    display_name: "Regolo",
+    protocol: maki_config::providers::Protocol::Openai,
+    default_base_url: "https://api.regolo.ai/v1",
+    default_api_key_env: "REGOLO_API_KEY",
+    default_model: "regolo/qwen3-coder-next",
+    plans: None,
+    login_url: Some("https://dashboard.regolo.ai"),
+    needs_url: false,
+});
+
+/// Curated tier defaults only: pricing, context windows and capabilities for
+/// the full catalogue come live from `/v1/models` joined with
+/// `/model_group/info` in [`Regolo::list_models`]. Context windows mirror the
+/// group's `max_input_tokens`, the same field [`join_model_info`] prefers, not
+/// its `max_tokens` (input plus output) which would let a session grow past
+/// what the upstream accepts.
+pub(crate) const fn models() -> &'static [ModelEntry] {
+    &[
+        ModelEntry {
+            prefixes: &["qwen3.5-122b"],
+            tier: ModelTier::Strong,
+            family: ModelFamily::Generic,
+            vision: true,
+            default: true,
+            pricing: ModelPricing {
+                input: 1.00,
+                output: 4.20,
+                cache_write: 0.00,
+                cache_read: 0.00,
+                fast: None,
+            },
+            max_output_tokens: Some(120_000),
+            context_window: 120_000,
+        },
+        ModelEntry {
+            prefixes: &["qwen3-coder-next"],
+            tier: ModelTier::Medium,
+            family: ModelFamily::Generic,
+            vision: false,
+            default: true,
+            pricing: ModelPricing {
+                input: 0.50,
+                output: 2.00,
+                cache_write: 0.00,
+                cache_read: 0.00,
+                fast: None,
+            },
+            max_output_tokens: Some(120_000),
+            context_window: 120_000,
+        },
+        ModelEntry {
+            prefixes: &["qwen3.5-9b"],
+            tier: ModelTier::Weak,
+            family: ModelFamily::Generic,
+            vision: false,
+            default: true,
+            pricing: ModelPricing {
+                input: 0.07,
+                output: 0.35,
+                cache_write: 0.00,
+                cache_read: 0.00,
+                fast: None,
+            },
+            // The group advertises 120k output against an 80k input window;
+            // capped so a tier default never promises more output than the
+            // window it has to fit in.
+            max_output_tokens: Some(80_000),
+            context_window: 80_000,
+        },
+    ]
+}
+
+#[derive(Deserialize)]
+struct KeyInfoResponse {
+    info: KeyInfo,
+}
+
+#[derive(Deserialize)]
+struct KeyInfo {
+    spend: f64,
+    max_budget: Option<f64>,
+    budget_reset_at: Option<String>,
+}
+
+impl From<KeyInfo> for UsageLimit {
+    fn from(info: KeyInfo) -> Self {
+        let mut detail = format!("${:.2} spent", info.spend);
+        if let Some(budget) = info.max_budget {
+            detail.push_str(&format!(" of ${budget:.2} budget"));
+        }
+        let percentage = info
+            .max_budget
+            .filter(|budget| *budget > 0.0)
+            .map(|budget| ((info.spend / budget * 100.0) as u32).min(100));
+        let reset_at = info
+            .budget_reset_at
+            .as_deref()
+            .and_then(|at| at.parse::<jiff::Timestamp>().ok())
+            .map(|at| at.as_millisecond().max(0) as u64);
+        Self {
+            label: "Spend".into(),
+            percentage,
+            reset_at,
+            detail: Some(detail),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct ActivityResponse {
+    sum_api_requests: u64,
+    sum_total_tokens: u64,
+}
+
+/// `/global/activity` is key-scoped despite its name and answers per UTC day.
+fn activity_url(root: &str, day: jiff::civil::Date) -> String {
+    format!("{root}{ACTIVITY_PATH}?start_date={day}&end_date={day}")
+}
+
+fn next_utc_midnight(now: jiff::Timestamp) -> Option<u64> {
+    let day = now.as_second().div_euclid(SECONDS_PER_DAY) + 1;
+    jiff::Timestamp::from_second(day * SECONDS_PER_DAY)
+        .ok()
+        .map(|at| at.as_millisecond() as u64)
+}
+
+impl From<ActivityResponse> for UsageLimit {
+    fn from(activity: ActivityResponse) -> Self {
+        Self {
+            label: "Today".into(),
+            // Regolo tracks a per-account daily token cap (free trial: 1M) but
+            // no endpoint reports it, so there is no honest percentage to show.
+            percentage: None,
+            reset_at: next_utc_midnight(jiff::Timestamp::now()),
+            detail: Some(format!(
+                "{} requests · {} tokens",
+                activity.sum_api_requests, activity.sum_total_tokens
+            )),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct ModelGroupInfoResponse {
+    data: Vec<ModelGroup>,
+}
+
+#[derive(Deserialize)]
+struct ModelGroup {
+    model_group: String,
+    mode: String,
+    input_cost_per_token: Option<f64>,
+    output_cost_per_token: Option<f64>,
+    max_input_tokens: Option<f64>,
+    max_output_tokens: Option<f64>,
+    max_tokens: Option<f64>,
+    supports_reasoning: bool,
+    supports_vision: bool,
+}
+
+/// Joins the callable IDs from `/v1/models` with the metadata from
+/// `/model_group/info`. Groups in a non-chat `mode` (embedding, rerank, ocr,
+/// image, audio) and IDs without a chat group are not agent models. Order
+/// follows `ids`, which the compat lister already sorts.
+fn join_model_info(ids: Vec<String>, groups: Vec<ModelGroup>) -> Vec<crate::model::ModelInfo> {
+    let by_group: BTreeMap<&str, &ModelGroup> = groups
+        .iter()
+        .filter(|group| group.mode == CHAT_MODE)
+        .map(|group| (group.model_group.as_str(), group))
+        .collect();
+    ids.into_iter()
+        .filter_map(|id| {
+            let group = by_group.get(id.as_str())?;
+            let pricing = match (group.input_cost_per_token, group.output_cost_per_token) {
+                (Some(input), Some(output)) => Some(ModelPricing {
+                    input: input * PER_MILLION,
+                    output: output * PER_MILLION,
+                    cache_write: 0.00,
+                    cache_read: 0.00,
+                    fast: None,
+                }),
+                _ => None,
+            };
+            Some(crate::model::ModelInfo {
+                context_window: group
+                    .max_input_tokens
+                    .or(group.max_tokens)
+                    .and_then(|tokens| u32::try_from(tokens as u64).ok()),
+                max_output_tokens: group
+                    .max_output_tokens
+                    .and_then(|tokens| u32::try_from(tokens as u64).ok()),
+                pricing,
+                supports_thinking: Some(group.supports_reasoning),
+                supports_vision: Some(group.supports_vision),
+                id,
+                tier: None,
+                provider_info: None,
+            })
+        })
+        .collect()
+}
+
+pub struct Regolo {
+    compat: OpenAiCompatProvider,
+    auth: Arc<Mutex<ResolvedAuth>>,
+    key_pool: Option<KeyPool>,
+    system_prefix: Option<String>,
+}
+
+const KEY_INFO_PATH: &str = "/key/info";
+const ACTIVITY_PATH: &str = "/global/activity";
+const MODEL_GROUP_INFO_PATH: &str = "/model_group/info";
+
+/// Regolo's management endpoints live at the host root, outside `/v1`, so
+/// they must not be absolute urls: a custom base url or a gateway (Aperture)
+/// keeps serving them, an absolute one would bypass it and 401 on its key.
+fn root_url(base: &str) -> String {
+    let trimmed = base.trim_end_matches('/');
+    trimmed.strip_suffix("/v1").unwrap_or(trimmed).to_string()
+}
+const CHAT_MODE: &str = "chat";
+const PER_MILLION: f64 = 1_000_000.0;
+const SECONDS_PER_DAY: i64 = 86_400;
+
+impl Regolo {
+    pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
+        let pool = KeyPool::resolve("regolo", CONFIG.api_key_env)?;
+        Ok(Self {
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(
+                CONFIG.slug,
+                pool.current(),
+            )?)),
+            key_pool: Some(pool),
+            system_prefix: None,
+        })
+    }
+
+    pub(crate) fn with_auth(auth: Arc<Mutex<ResolvedAuth>>, timeouts: super::Timeouts) -> Self {
+        Self {
+            compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
+            auth,
+            key_pool: None,
+            system_prefix: None,
+        }
+    }
+
+    pub(crate) fn with_system_prefix(mut self, prefix: Option<String>) -> Self {
+        self.system_prefix = prefix;
+        self
+    }
+}
+
+impl Provider for Regolo {
+    fn stream_message<'a>(
+        &'a self,
+        model: &'a Model,
+        messages: &'a [Message],
+        system: &'a str,
+        tools: &'a Value,
+        event_tx: &'a Sender<ProviderEvent>,
+        opts: RequestOptions,
+        _session_id: Option<&'a SessionRef>,
+    ) -> BoxFuture<'a, Result<StreamResponse, AgentError>> {
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            let mut buf = String::new();
+            let system = super::with_prefix(&self.system_prefix, system, &mut buf);
+            let mut body = self.compat.build_body(model, messages, system, tools);
+            opts.thinking
+                .apply_reasoning_effort(&mut body, &dialect::STANDARD, model);
+            self.compat
+                .do_stream(model, &[], &body, event_tx, &auth)
+                .await
+        })
+    }
+
+    fn list_models(&self) -> BoxFuture<'_, Result<Vec<crate::model::ModelInfo>, AgentError>> {
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            let ids = self
+                .compat
+                .do_list_models(&auth)
+                .await?
+                .into_iter()
+                .map(|info| info.id)
+                .collect::<Vec<_>>();
+            let root = root_url(&self.compat.base_url(&auth));
+            let groups = self
+                .compat
+                .get_text(&auth, &format!("{root}{MODEL_GROUP_INFO_PATH}"))
+                .await
+                .ok()
+                .and_then(|body| serde_json::from_str::<ModelGroupInfoResponse>(&body).ok());
+            match groups {
+                Some(groups) => Ok(join_model_info(ids, groups.data)),
+                // The endpoint hiccups (it has 500ed): keep the live ids
+                // without metadata instead of dropping to the static few.
+                None => Ok(ids
+                    .into_iter()
+                    .map(|id| crate::model::ModelInfo {
+                        id,
+                        ..Default::default()
+                    })
+                    .collect()),
+            }
+        })
+    }
+
+    fn fetch_usage(&self) -> BoxFuture<'_, Result<Option<ProviderUsage>, AgentError>> {
+        Box::pin(async move {
+            let auth = self.auth.lock().unwrap().clone();
+            let root = root_url(&self.compat.base_url(&auth));
+            let key_body = self
+                .compat
+                .get_text(&auth, &format!("{root}{KEY_INFO_PATH}"))
+                .await?;
+            let key_info: KeyInfoResponse = serde_json::from_str(&key_body)?;
+            let mut limits = vec![UsageLimit::from(key_info.info)];
+            let today = jiff::Timestamp::now()
+                .to_zoned(jiff::tz::TimeZone::UTC)
+                .date();
+            if let Ok(body) = self
+                .compat
+                .get_text(&auth, &activity_url(&root, today))
+                .await
+                && let Ok(activity) = serde_json::from_str::<ActivityResponse>(&body)
+            {
+                limits.push(activity.into());
+            }
+            Ok(Some(ProviderUsage { plan: None, limits }))
+        })
+    }
+
+    fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
+        Box::pin(async {
+            Ok(self
+                .key_pool
+                .as_ref()
+                .is_some_and(|p| p.rotate_bearer(&self.auth)))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::ManifestRegistry;
+
+    const BUDGETED_KEY_INFO: &str = r#"{"key":"abc","info":{"key_alias":"me@example.com","spend":2.5,"max_budget":10.0,"budget_reset_at":"2026-09-01T00:00:00Z"}}"#;
+    const UNBUDGETED_KEY_INFO: &str =
+        r#"{"key":"abc","info":{"spend":0.42,"max_budget":null,"budget_reset_at":null}}"#;
+
+    #[test]
+    fn budgeted_key_reports_percentage_and_reset() {
+        let resp: KeyInfoResponse = serde_json::from_str(BUDGETED_KEY_INFO).unwrap();
+        let limit = UsageLimit::from(resp.info);
+        assert_eq!(limit.percentage, Some(25));
+        assert_eq!(
+            limit.detail.as_deref(),
+            Some("$2.50 spent of $10.00 budget")
+        );
+        assert_eq!(limit.reset_at, Some(1_788_220_800_000));
+    }
+
+    #[test]
+    fn unbudgeted_key_reports_spend_without_percentage() {
+        let resp: KeyInfoResponse = serde_json::from_str(UNBUDGETED_KEY_INFO).unwrap();
+        let limit = UsageLimit::from(resp.info);
+        assert_eq!(limit.percentage, None);
+        assert_eq!(limit.reset_at, None);
+        assert_eq!(limit.detail.as_deref(), Some("$0.42 spent"));
+    }
+
+    const ACTIVITY_TODAY: &str = r#"{"sum_api_requests":14,"sum_total_tokens":29027}"#;
+
+    #[test]
+    fn activity_maps_to_daily_counts_without_percentage() {
+        let activity: ActivityResponse = serde_json::from_str(ACTIVITY_TODAY).unwrap();
+        let limit = UsageLimit::from(activity);
+        assert_eq!(limit.label, "Today");
+        assert_eq!(limit.percentage, None);
+        assert!(limit.reset_at.is_some());
+        assert_eq!(limit.detail.as_deref(), Some("14 requests · 29027 tokens"));
+    }
+
+    #[test]
+    fn next_utc_midnight_is_following_day_start() {
+        let now = "2026-08-25T13:45:10Z".parse::<jiff::Timestamp>().unwrap();
+        assert_eq!(next_utc_midnight(now), Some(1_787_702_400_000));
+    }
+
+    #[test]
+    fn root_url_strips_the_version_segment() {
+        assert_eq!(
+            root_url("https://api.regolo.ai/v1"),
+            "https://api.regolo.ai"
+        );
+        assert_eq!(
+            root_url("https://api.regolo.ai/v1/"),
+            "https://api.regolo.ai"
+        );
+        assert_eq!(root_url("https://api.regolo.ai"), "https://api.regolo.ai");
+    }
+
+    #[test]
+    fn manifest_lists_the_catalogued_default_model() {
+        let manifest = ManifestRegistry::get(CONFIG.slug).expect("regolo is a builtin");
+        assert!(
+            manifest
+                .models
+                .iter()
+                .any(|m| m.prefixes == ["qwen3-coder-next"])
+        );
+    }
+
+    const MODEL_GROUPS_FIXTURE: &str = r#"{"data":[
+        {
+            "model_group": "glm5.2", "mode": "chat",
+            "input_cost_per_token": 2e-06, "output_cost_per_token": 5.2e-06,
+            "max_input_tokens": 96000.0, "max_output_tokens": 96000.0, "max_tokens": null,
+            "supports_reasoning": true, "supports_vision": false
+        },
+        {
+            "model_group": "qwen3-coder-next", "mode": "chat",
+            "input_cost_per_token": 5e-07, "output_cost_per_token": 2e-06,
+            "max_input_tokens": null, "max_output_tokens": 120000.0, "max_tokens": 240000.0,
+            "supports_reasoning": false, "supports_vision": true
+        },
+        {
+            "model_group": "Qwen3-Embedding-8B", "mode": "embedding",
+            "input_cost_per_token": 0.0, "output_cost_per_token": 0.0,
+            "max_input_tokens": null, "max_output_tokens": null, "max_tokens": null,
+            "supports_reasoning": false, "supports_vision": false
+        }
+    ]}"#;
+
+    fn join_fixture(ids: &[&str]) -> Vec<crate::model::ModelInfo> {
+        let groups: ModelGroupInfoResponse = serde_json::from_str(MODEL_GROUPS_FIXTURE).unwrap();
+        join_model_info(
+            ids.iter().map(|id| (*id).to_string()).collect(),
+            groups.data,
+        )
+    }
+
+    #[test]
+    fn group_metadata_maps_to_pricing_context_and_capabilities() {
+        let mut infos = join_fixture(&["glm5.2"]);
+        assert_eq!(infos.len(), 1);
+        let info = infos.pop().unwrap();
+        assert_eq!(info.id, "glm5.2");
+        assert_eq!(info.context_window, Some(96_000));
+        assert_eq!(info.max_output_tokens, Some(96_000));
+        let pricing = info.pricing.unwrap();
+        assert_eq!(pricing.input, 2.0);
+        assert_eq!(pricing.output, 5.2);
+        assert_eq!(info.supports_thinking, Some(true));
+        assert_eq!(info.supports_vision, Some(false));
+    }
+
+    #[test]
+    fn missing_input_window_falls_back_to_max_tokens() {
+        let info = join_fixture(&["qwen3-coder-next"]).pop().unwrap();
+        assert_eq!(info.context_window, Some(240_000));
+        assert_eq!(info.supports_thinking, Some(false));
+    }
+
+    #[test]
+    fn non_chat_groups_and_ids_without_group_are_dropped() {
+        let infos = join_fixture(&["Qwen3-Embedding-8B", "glm5.2", "brand-new-model"]);
+        let ids: Vec<&str> = infos.iter().map(|i| i.id.as_str()).collect();
+        assert_eq!(ids, ["glm5.2"]);
+    }
+}

--- a/maki-providers/src/providers/zai/mod.rs
+++ b/maki-providers/src/providers/zai/mod.rs
@@ -75,6 +75,7 @@ impl From<QuotaResponse> for ProviderUsage {
                     detail: None,
                 })
                 .collect(),
+            by_model_today: vec![],
         }
     }
 }

--- a/maki-providers/src/types.rs
+++ b/maki-providers/src/types.rs
@@ -812,6 +812,26 @@ pub struct ProviderUsage {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plan: Option<String>,
     pub limits: Vec<UsageLimit>,
+    /// Per-model breakdown of the current UTC day, when the provider exposes
+    /// one. The window is part of the contract: the modal labels these rows as
+    /// today's, so a provider reporting a month or a lifetime needs its own
+    /// field rather than this one. Sorted by the provider (typically spend
+    /// desc).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub by_model_today: Vec<ModelUsageRow>,
+}
+
+/// One row of a provider-reported per-model usage table. Money is kept as
+/// integer micro-dollars to keep `ProviderUsage` in `Eq` territory for tests;
+/// callers format at the UI layer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelUsageRow {
+    pub model: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub total_tokens: u64,
+    /// Spend in micro-dollars (1_000_000 = $1.00).
+    pub spend_microdollars: u64,
 }
 
 /// A single quota window (e.g. a 5-hour or weekly token quota).

--- a/maki-ui/src/components/usage_modal.rs
+++ b/maki-ui/src/components/usage_modal.rs
@@ -7,7 +7,7 @@ use crossterm::event::{KeyCode, KeyEvent};
 use jiff::Timestamp;
 use jiff::tz::TimeZone;
 use maki_config::ClockFormat;
-use maki_providers::{Model, ProviderUsage, TokenUsage, format_tokens, model_cost};
+use maki_providers::{Model, ModelUsageRow, ProviderUsage, TokenUsage, format_tokens, model_cost};
 use maki_storage::sessions::StoredTokenUsage;
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -169,6 +169,20 @@ fn build_lines(
             theme.keybind_section,
         )));
         lines.extend(quota_lines(state, theme, ctx.clock_format));
+        if let Some(ready) = provider_usage(state)
+            && !ready.by_model_today.is_empty()
+        {
+            let model_w = model_col_width(ready.by_model_today.iter().map(|row| &row.model));
+            lines.push(Line::default());
+            lines.push(Line::from(Span::styled(
+                format!("{PREFIX}By model (provider, today)"),
+                theme.keybind_section,
+            )));
+            lines.push(Line::from(provider_by_model_header(model_w, theme)));
+            for row in &ready.by_model_today {
+                lines.push(Line::from(provider_by_model_row(row, model_w, fg)));
+            }
+        }
     }
 
     if ctx.by_model.is_empty() {
@@ -178,12 +192,7 @@ fn build_lines(
     let mut entries: Vec<(&String, &StoredTokenUsage)> = ctx.by_model.iter().collect();
     entries.sort_by_key(|(_, u)| Reverse(u.total()));
 
-    let model_w = entries
-        .iter()
-        .map(|(id, _)| id.chars().count())
-        .max()
-        .unwrap_or(0)
-        .max(MODEL_COL_MIN);
+    let model_w = model_col_width(entries.iter().map(|(id, _)| id));
 
     lines.push(Line::default());
     lines.push(Line::from(Span::styled(
@@ -232,6 +241,15 @@ fn totals_row(
     spans
 }
 
+fn model_col_width(names: impl IntoIterator<Item = impl AsRef<str>>) -> usize {
+    names
+        .into_iter()
+        .map(|name| name.as_ref().chars().count())
+        .max()
+        .unwrap_or(0)
+        .max(MODEL_COL_MIN)
+}
+
 fn header_row(model_w: usize, theme: &crate::theme::Theme) -> Vec<Span<'static>> {
     let h = |label: &str| Span::styled(format!("{label:>NUM_COL$}"), theme.status_dim);
     let gap = || Span::raw(" ".repeat(COL_GAP));
@@ -251,6 +269,52 @@ fn header_row(model_w: usize, theme: &crate::theme::Theme) -> Vec<Span<'static>>
         h("total"),
         gap(),
         Span::styled(format!("{:>6}", "cost"), theme.status_dim),
+    ]
+}
+
+fn provider_usage(state: &UsageFetchState) -> Option<&ProviderUsage> {
+    if let UsageFetchState::Ready(usage) = state {
+        Some(usage)
+    } else {
+        None
+    }
+}
+
+fn provider_by_model_header(model_w: usize, theme: &crate::theme::Theme) -> Vec<Span<'static>> {
+    let h = |label: &str| Span::styled(format!("{label:>NUM_COL$}"), theme.status_dim);
+    let gap = || Span::raw(" ".repeat(COL_GAP));
+    vec![
+        Span::raw(PREFIX),
+        Span::styled(
+            format!("{:width$}", "model", width = model_w),
+            theme.status_dim,
+        ),
+        gap(),
+        h("in"),
+        gap(),
+        h("out"),
+        gap(),
+        h("total"),
+        gap(),
+        Span::styled(format!("{:>7}", "spend"), theme.status_dim),
+    ]
+}
+
+fn provider_by_model_row(row: &ModelUsageRow, model_w: usize, fg: Style) -> Vec<Span<'static>> {
+    let num = |v: u64| Span::styled(format!("{:>NUM_COL$}", format_tokens(v)), fg);
+    let gap = || Span::raw(" ".repeat(COL_GAP));
+    let dollars = row.spend_microdollars as f64 / 1_000_000.0;
+    vec![
+        Span::raw(PREFIX),
+        Span::styled(format!("{:<width$}", row.model, width = model_w), fg),
+        gap(),
+        num(row.input_tokens),
+        gap(),
+        num(row.output_tokens),
+        gap(),
+        num(row.total_tokens),
+        gap(),
+        Span::styled(format!("{dollars:>7.4}"), fg),
     ]
 }
 
@@ -458,6 +522,7 @@ mod tests {
                     detail: Some("$2.33 spent".into()),
                 },
             ],
+            by_model_today: vec![],
         };
         let lines = quota_lines(&UsageFetchState::Ready(usage), &theme, ClockFormat::Hour24);
         assert_eq!(lines.len(), 3);

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -239,6 +239,20 @@ OpenRouter aggregates models from many providers behind a single API key. Browse
 
 Defaults: hf:moonshotai/Kimi-K2.5 (strong), hf:deepseek-ai/DeepSeek-V3.2 (medium), hf:zai-org/GLM-4.7-Flash (weak)
 
+### Regolo
+
+- **Env var**: `REGOLO_API_KEY`
+- **API**: `https://api.regolo.ai/v1`
+- **Features**: EU-hosted open-weight models with tool calling. The catalogue and prices are listed live from the API
+
+| Tier | Models | Pricing (in/out per 1M tokens) | Context |
+|------|--------|-------------------------------|---------|
+| Weak | **qwen3.5-9b** (default) | $0.07 / $0.35 | 80K ctx / 80K out |
+| Medium | **qwen3-coder-next** (default) | $0.50 / $2.00 | 120K ctx / 120K out |
+| Strong | **qwen3.5-122b** (default) | $1.00 / $4.20 | 120K ctx / 120K out |
+
+Defaults: qwen3.5-122b (strong), qwen3-coder-next (medium), qwen3.5-9b (weak)
+
 ### TensorX
 
 - **Env var**: `TENSORX_API_KEY`
@@ -446,7 +460,7 @@ To add a custom provider or proxy, drop an executable script into the config `pr
 
 `resolve` is called each time a new agent spawns, so scripts should read tokens from disk instead of caching them in memory. That way auth changes from other processes get picked up.
 
-The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `copilot`, `ollama`, `llama-cpp`, `mistral`, `zai`, `deepseek`, `openrouter`, `synthetic`, `tensorx`, `opencode`, `xai`, `aperture`.
+The `base` field specifies which built-in provider to inherit the model catalog from. Valid values: `anthropic`, `openai`, `google`, `copilot`, `ollama`, `llama-cpp`, `mistral`, `zai`, `deepseek`, `openrouter`, `synthetic`, `regolo`, `tensorx`, `opencode`, `xai`, `aperture`.
 
 If your provider serves models not in the base catalog, add a `models` subcommand returning:
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -19,6 +19,7 @@ const PROVIDER_PRIORITY: &[&str] = &[
     "zai",
     "synthetic",
     "deepseek",
+    "regolo",
 ];
 
 pub fn resolve_model(


### PR DESCRIPTION
## What

Adds [Regolo.ai](https://regolo.ai) as a builtin provider: an EU-hosted LiteLLM-style proxy speaking the OpenAI protocol at `https://api.regolo.ai/v1`.

- `maki-providers/src/providers/regolo.rs`: wraps the generic `OpenAiCompatProvider` (streaming, tool calling, reasoning via `reasoning_content`); the model list is live, joining `/v1/models` IDs with `/model_group/info` for pricing, context windows and capabilities, filtered to chat modes. The static manifest keeps only the curated tier defaults as offline fallback
- Registered everywhere the other OpenAI-compat providers are: `ProviderKind`, manifest, setup priority, aperture gateway compat lists, dynamic-provider dispatch
- Usage modal support via `fetch_usage`

## Usage data

| Endpoint | Used for |
|---|---|
| `GET /key/info` | lifetime spend / budget ("Spend" row) |
| `GET /global/activity?start_date=X&end_date=X` | per-day request/token counts for the key ("Today" row, resets UTC midnight) |
| `GET /spend/logs/v2` | per-model daily breakdown in the usage modal |

Notes from poking at their proxy:

- despite the name, `/global/activity` is key-scoped; end date is inclusive
- `/spend/logs/v2` was 500ing this morning (naive vs tz-aware datetime mismatch server-side); it works now
- Regolo enforces a soft per-account daily token cap (1M on free trial). No endpoint reports it, so the Today row shows counts only rather than a made-up percentage. Worth asking them to expose it.

## Testing

- unit tests for key/info parsing, activity mapping, spend-log aggregation, midnight reset math
- live-tested streaming, tool calls (qwen3-coder-next, gpt-oss-120b, glm5.2, qwen3.8-27b), auth-file login flow, and the usage endpoints

Docs: provider table regenerated (`just gen-docs`).
