### PR TITLE
feat(edit): turn `edit_lines` on by default

### DIFF
--- a/maki-docgen/src/gen_config.rs
+++ b/maki-docgen/src/gen_config.rs
@@ -255,7 +255,7 @@ All fields are optional. Typos in field names cause an error right away.
          type, or an unknown plugin name gives you a clear error right \
          away.\n\n\
          The edit plugin's extra tools are options too: \
-         `plugins.edit = {{ multiedit = false, edit_lines = true }}`. \
+         `plugins.edit = {{ multiedit = false, insert_lines = true }}`. \
          The old `tools` table is gone. If your config still uses it, \
          Maki stops at startup and shows you the new form.\n\n\
          This table is for bundled plugins only. Your own plugins go in \

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -2435,12 +2435,12 @@ fn builtin_opts_flow_from_setup_plugins() {
 
 #[test_case::test_case(
     serde_json::json!({}),
-    &["edit", "multiedit"], &["edit_lines", "insert_lines"]
-    ; "multiedit_on_others_opt_in"
+    &["edit", "multiedit", "edit_lines"], &["insert_lines"]
+    ; "defaults_on_insert_lines_opt_in"
 )]
 #[test_case::test_case(
-    serde_json::json!({ "multiedit": false, "edit_lines": true }),
-    &["edit", "edit_lines"], &["multiedit", "insert_lines"]
+    serde_json::json!({ "multiedit": false, "edit_lines": false, "insert_lines": true }),
+    &["edit", "insert_lines"], &["multiedit", "edit_lines"]
     ; "toggles_flip_sub_tools"
 )]
 fn edit_sub_tools_follow_edit_opts(opts: serde_json::Value, on: &[&str], off: &[&str]) {

--- a/plugins/edit/init.lua
+++ b/plugins/edit/init.lua
@@ -235,7 +235,7 @@ end
 
 local opts = maki.api.register_options({
   multiedit = { default = true, desc = "Provide the `multiedit` tool." },
-  edit_lines = { default = false, desc = "Provide the opt-in `edit_lines` tool." },
+  edit_lines = { default = true, desc = "Provide the `edit_lines` tool." },
   insert_lines = { default = false, desc = "Provide the opt-in `insert_lines` tool." },
 })
 

--- a/site/docs/content/cli/_index.md
+++ b/site/docs/content/cli/_index.md
@@ -63,7 +63,7 @@ If you pass a prompt (or pipe stdin) without `--print`, the TUI still opens and 
 
 ### Tool name lists
 
-`--allowed-tools` / `--disallowed-tools` accept Claude Code PascalCase (`Read,Edit,Bash`) or snake_case (`read,edit,bash`). Maki lowercases PascalCase to snake_case and checks the result against the built-in tool names, so `CodeExecution` works but `MultiEdit` errors: it normalizes to `multi_edit`, and the tool is called `multiedit`. Write `multiedit` or `edit_lines` as-is. Unknown names error out with the list of valid names. The opt-in edit tools (`edit_lines`, `insert_lines`, `multiedit`) are always valid names here, even while disabled; listing one does nothing until you enable the tool in config.
+`--allowed-tools` / `--disallowed-tools` accept Claude Code PascalCase (`Read,Edit,Bash`) or snake_case (`read,edit,bash`). Maki lowercases PascalCase to snake_case and checks the result against the built-in tool names, so `CodeExecution` works but `MultiEdit` errors: it normalizes to `multi_edit`, and the tool is called `multiedit`. Write `multiedit` or `edit_lines` as-is. Unknown names error out with the list of valid names. The edit plugin's sub-tools (`multiedit`, `edit_lines`, `insert_lines`) are valid names here even when disabled. Listing a disabled tool has no effect until you enable it in config.
 
 ### Permission modes (SDK)
 

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -179,7 +179,7 @@ The `plugins` table turns plugins on or off and passes options to them. All bund
 
 Each plugin checks its own options at startup. A typo, a wrong type, or an unknown plugin name gives you a clear error right away.
 
-The edit plugin's extra tools are options too: `plugins.edit = { multiedit = false, edit_lines = true }`. The old `tools` table is gone. If your config still uses it, Maki stops at startup and shows you the new form.
+The edit plugin's extra tools are options too: `plugins.edit = { multiedit = false, insert_lines = true }`. The old `tools` table is gone. If your config still uses it, Maki stops at startup and shows you the new form.
 
 This table is for bundled plugins only. Your own plugins go in `~/.config/maki/lua/`, see [Plugins](/docs/plugins/).
 
@@ -213,7 +213,7 @@ maki.setup({
 
 | Field | Type | Default | Min | Description |
 |-------|------|---------|-----|-------------|
-| `edit_lines` | boolean | `false` | - | Provide the opt-in `edit_lines` tool. |
+| `edit_lines` | boolean | `true` | - | Provide the `edit_lines` tool. |
 | `insert_lines` | boolean | `false` | - | Provide the opt-in `insert_lines` tool. |
 | `multiedit` | boolean | `true` | - | Provide the `multiedit` tool. |
 

--- a/site/docs/content/permissions/_index.md
+++ b/site/docs/content/permissions/_index.md
@@ -48,7 +48,7 @@ File-write tools are pre-allowed inside the project working directory (cwd at se
 | `write` | `<cwd>/**` | Outside cwd requires permission |
 | `edit` | `<cwd>/**` | Outside cwd requires permission |
 | `multiedit` | `<cwd>/**` | Outside cwd requires permission |
-| `edit_lines` | `<cwd>/**` | Same, when the opt-in tool is enabled |
+| `edit_lines` | `<cwd>/**` | Outside cwd requires permission |
 | `insert_lines` | `<cwd>/**` | Same, when the opt-in tool is enabled |
 | `task` | `*` | Subagent spawning always allowed |
 

--- a/site/docs/content/tools/_index.md
+++ b/site/docs/content/tools/_index.md
@@ -7,7 +7,7 @@ group = "Reference"
 
 # Tools
 
-Maki ships with 21 built-in tools in this reference (19 on by default, 2 opt-in via plugin options). Tools marked **opt-in** are off until you enable them under `plugins` in [Configuration](/docs/configuration/).
+Maki ships with 21 built-in tools in this reference (20 on by default, 1 opt-in via plugin options). Tools marked **opt-in** are off until you enable them under `plugins` in [Configuration](/docs/configuration/).
 
 ## File Operations
 
@@ -71,7 +71,7 @@ Prefer this over edit when making multiple changes to the same file.
 | `edits` | array | yes | Array of edit operations to apply sequentially |
 | `path` | string | yes | Absolute path to the file |
 
-### `edit_lines` <span class="badge badge-optin">opt-in</span> {#edit_lines}
+### `edit_lines` {#edit_lines}
 
 Edit lines by number. Replaces lines from `start` to `end` (inclusive) with `new_string`. Use empty `new_string` to delete a range. Do not use with the batch tool.
 


### PR DESCRIPTION
`edit_lines` was opt-in, so nobody used it, even though editing by line number is the cheapest way to replace a known range and beats quoting the old text back.

Only `insert_lines` stays opt-in now, and `plugins.edit = { edit_lines = false }` turns it off again.

The docs for tools, configuration, permissions and the CLI tool lists all followed, since the opt-in badge is derived from the plugin option default.