### PR TITLE
config: env-expanded custom headers for MCP servers and providers

### DIFF
--- a/maki-agent/src/mcp/config.rs
+++ b/maki-agent/src/mcp/config.rs
@@ -3,12 +3,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use serde::Deserialize;
-use toml_edit::DocumentMut;
-
 use super::error::McpError;
 use crate::tools::is_builtin_tool;
-use maki_config::{global_config_dir, is_valid_server_name};
+use maki_config::{expand_env, global_config_dir, is_valid_server_name};
+use serde::Deserialize;
+use toml_edit::DocumentMut;
 
 const MCP_CONFIG_FILE: &str = "mcp.toml";
 const DEFAULT_TIMEOUT_MS: u64 = 30_000;
@@ -262,6 +261,25 @@ impl McpConfig {
     }
 }
 
+/// Erroring (not dropping) surfaces the variable name in the server's status
+/// instead of an untraceable 401 later.
+fn expand_map(
+    server: &str,
+    kind: &str,
+    map: HashMap<String, String>,
+) -> Result<HashMap<String, String>, McpError> {
+    map.into_iter()
+        .map(|(key, value)| {
+            let expanded = expand_env(&value).map_err(|var| {
+                McpError::Config(format!(
+                    "server '{server}' {kind} '{key}': environment variable '{var}' is unset or empty"
+                ))
+            })?;
+            Ok((key, expanded))
+        })
+        .collect()
+}
+
 pub fn parse_server(name: String, server: RawServerConfig) -> Result<ServerConfig, McpError> {
     if !is_valid_server_name(&name) {
         return Err(McpError::Config(format!(
@@ -287,7 +305,7 @@ pub fn parse_server(name: String, server: RawServerConfig) -> Result<ServerConfi
             Transport::Stdio {
                 program,
                 args: cmd.collect(),
-                environment: cfg.environment,
+                environment: expand_map(&name, "environment", cfg.environment)?,
             }
         }
         RawTransport::Http(cfg) => {
@@ -305,7 +323,7 @@ pub fn parse_server(name: String, server: RawServerConfig) -> Result<ServerConfi
             }
             Transport::Http {
                 url: cfg.url,
-                headers: cfg.headers,
+                headers: expand_map(&name, "header", cfg.headers)?,
                 oauth: cfg.oauth,
             }
         }
@@ -464,6 +482,58 @@ mod tests {
     fn parse_server_rejects(name: &str, cfg: RawServerConfig, expected_msg: &str) {
         let err = parse_server(name.into(), cfg).unwrap_err();
         assert!(err.to_string().contains(expected_msg), "got: {err}");
+    }
+
+    #[test]
+    fn header_with_unset_var_fails_the_server_with_the_var_name() {
+        let config: McpConfig = toml::from_str(
+            r#"
+[mcp.remote]
+url = "https://mcp.example.com/mcp"
+headers = { Authorization = "Bearer ${MAKI_TEST_MCP_UNSET_84421}" }
+"#,
+        )
+        .unwrap();
+        let err = parse_server("remote".into(), config.mcp["remote"].clone()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("MAKI_TEST_MCP_UNSET_84421"), "got: {msg}");
+        assert!(msg.contains("Authorization"), "got: {msg}");
+    }
+
+    #[test]
+    fn header_with_empty_var_fails_the_server_like_unset() {
+        unsafe { std::env::set_var("MAKI_TEST_MCP_EMPTY_84421", "") };
+        let config: McpConfig = toml::from_str(
+            r#"
+[mcp.remote]
+url = "https://mcp.example.com/mcp"
+headers = { Authorization = "Bearer ${MAKI_TEST_MCP_EMPTY_84421}" }
+"#,
+        )
+        .unwrap();
+        let err = parse_server("remote".into(), config.mcp["remote"].clone()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("MAKI_TEST_MCP_EMPTY_84421"), "got: {msg}");
+    }
+
+    #[test]
+    fn stdio_environment_expands_from_the_process_env() {
+        unsafe { std::env::set_var("MAKI_TEST_MCP_ENV_84421", "tok") };
+        let config: McpConfig = toml::from_str(
+            r#"
+[mcp.local]
+command = ["server"]
+environment = { GITHUB_TOKEN = "${MAKI_TEST_MCP_ENV_84421}" }
+"#,
+        )
+        .unwrap();
+        let parsed = parse_server("local".into(), config.mcp["local"].clone()).unwrap();
+        match parsed.transport {
+            Transport::Stdio { environment, .. } => {
+                assert_eq!(environment["GITHUB_TOKEN"], "tok");
+            }
+            _ => panic!("expected Stdio"),
+        }
     }
 
     #[test_case(0               ; "zero")]

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -214,6 +214,36 @@ pub const TOP_LEVEL_FIELDS: &[ConfigField] = &[
     },
 ];
 
+/// Expand `${VAR}` references in a config value from the process environment.
+/// A variable that is unset OR set to empty fails with `Err(var)`, so callers
+/// reject the whole value instead of sending a partially expanded one (e.g.
+/// `Bearer ` with nothing after it). An unterminated `${` passes through
+/// literally; there is no escape syntax for a literal `${`.
+pub fn expand_env(value: &str) -> Result<String, String> {
+    let mut out = String::with_capacity(value.len());
+    let mut rest = value;
+    while let Some(start) = rest.find("${") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        match after.find('}') {
+            Some(end) => {
+                let var = &after[..end];
+                match std::env::var(var) {
+                    Ok(v) if !v.is_empty() => out.push_str(&v),
+                    _ => return Err(var.to_string()),
+                }
+                rest = &after[end + 1..];
+            }
+            None => {
+                out.push_str(&rest[start..]);
+                rest = "";
+            }
+        }
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
 #[derive(Debug, Error)]
 pub enum ConfigError {
     #[error("invalid config: {section}.{field} = {value} is below minimum ({min})")]
@@ -3612,6 +3642,66 @@ mod tests {
         assert_eq!(
             perms.rules[0].tool,
             ToolKey::parse("github.delete").unwrap()
+        );
+    }
+
+    // Uniquely named vars per test: env is process-global and tests run in parallel.
+
+    #[test]
+    fn expand_env_literal_text_passes_through() {
+        assert_eq!(expand_env("plain value").as_deref(), Ok("plain value"));
+    }
+
+    #[test]
+    fn expand_env_expands_whole_value_var() {
+        unsafe { std::env::set_var("MAKI_TEST_HDR_WHOLE_71535", "secret") };
+        assert_eq!(
+            expand_env("${MAKI_TEST_HDR_WHOLE_71535}").as_deref(),
+            Ok("secret")
+        );
+    }
+
+    #[test]
+    fn expand_env_expands_mid_string_var() {
+        unsafe { std::env::set_var("MAKI_TEST_HDR_MID_71535", "tok") };
+        assert_eq!(
+            expand_env("Bearer ${MAKI_TEST_HDR_MID_71535}!").as_deref(),
+            Ok("Bearer tok!")
+        );
+    }
+
+    #[test]
+    fn expand_env_expands_multiple_vars() {
+        unsafe { std::env::set_var("MAKI_TEST_HDR_A_71535", "a") };
+        unsafe { std::env::set_var("MAKI_TEST_HDR_B_71535", "b") };
+        assert_eq!(
+            expand_env("${MAKI_TEST_HDR_A_71535}-${MAKI_TEST_HDR_B_71535}").as_deref(),
+            Ok("a-b")
+        );
+    }
+
+    #[test]
+    fn expand_env_unset_var_names_the_variable() {
+        assert_eq!(
+            expand_env("Bearer ${MAKI_TEST_HDR_UNSET_71535}"),
+            Err("MAKI_TEST_HDR_UNSET_71535".to_string())
+        );
+    }
+
+    #[test]
+    fn expand_env_unterminated_brace_passes_through() {
+        assert_eq!(
+            expand_env("x ${NOT_CLOSED").as_deref(),
+            Ok("x ${NOT_CLOSED")
+        );
+    }
+
+    #[test]
+    fn expand_env_empty_var_is_treated_as_unset() {
+        unsafe { std::env::set_var("MAKI_TEST_HDR_EMPTY_71535", "") };
+        assert_eq!(
+            expand_env("Bearer ${MAKI_TEST_HDR_EMPTY_71535}"),
+            Err("MAKI_TEST_HDR_EMPTY_71535".to_string())
         );
     }
 }

--- a/maki-config/src/providers.rs
+++ b/maki-config/src/providers.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::PathBuf;
 use std::process;
@@ -181,6 +181,25 @@ pub struct ProviderDef {
     pub default_model: Option<String>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub discover_models: bool,
+    /// Extra HTTP headers sent with every request to this provider. Values
+    /// expand `${VAR}` from the environment, so gateway credentials (e.g.
+    /// Cloudflare Access service tokens in front of a private endpoint) never
+    /// land in the config file:
+    ///
+    /// ```toml
+    /// [anthropic]
+    /// base_url = "https://gw.internal/anthropic"
+    /// [anthropic.headers]
+    /// CF-Access-Client-Id = "${CF_ACCESS_CLIENT_ID}"
+    /// CF-Access-Client-Secret = "${CF_ACCESS_CLIENT_SECRET}"
+    /// ```
+    ///
+    /// A same-name header (case-insensitive) replaces the built-in auth
+    /// header instead of appending, and keeps winning across key rotations.
+    /// An unset or empty variable fails the whole provider so callers see the
+    /// missing name instead of a silent 401.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub headers: BTreeMap<String, String>,
     /// Opencode-only: when `Some(false)`, free catalog models are hidden
     /// entirely. Defaults to `false` when `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -402,6 +421,22 @@ pub fn resolve_login_url(slug: &str, plan: Option<&str>) -> Option<String> {
 mod tests {
     use super::*;
     use test_case::test_case;
+
+    #[test]
+    fn provider_def_parses_custom_headers() {
+        let def: ProviderDef = toml::from_str(
+            "base_url = \"https://gw.example.com/v1\"\n[headers]\n\"CF-Access-Client-Id\" = \"${CF_ID}\"\n\"CF-Access-Client-Secret\" = \"${CF_SECRET}\"\n",
+        )
+        .unwrap();
+        assert_eq!(def.headers.len(), 2);
+        assert_eq!(def.headers["CF-Access-Client-Id"], "${CF_ID}");
+    }
+
+    #[test]
+    fn provider_def_without_headers_is_empty() {
+        let def: ProviderDef = toml::from_str("base_url = \"https://x\"\n").unwrap();
+        assert!(def.headers.is_empty());
+    }
 
     #[test]
     fn provider_def_roundtrip() {

--- a/maki-docgen/src/gen_providers.rs
+++ b/maki-docgen/src/gen_providers.rs
@@ -197,6 +197,7 @@ supports_vision = false
 | `plan` | string | Built-in plan key (see Plans below). Sets base URL and default model |
 | `api_key_env` | string | Env var that holds the key. Defaults to `<SLUG>_API_KEY` |
 | `api_key` | string | Inline key (prefer the env var or `maki auth login`) |
+| `headers` | table | Extra HTTP headers sent on every request to this provider. Values expand `${{VAR}}` from the environment; an unset or empty variable fails the provider instead of sending a half-filled header. A same-name header (case-insensitive) replaces the built-in auth header and survives key rotation |
 | `default_model` | string | Used after login when no model is saved yet |
 | `discover_models` | bool | When true, also probe the provider's model list endpoint (default false) |
 | `enable_free_models` | bool | Opencode only. Show free catalog models (default false) |

--- a/maki-providers/src/providers/anthropic/mod.rs
+++ b/maki-providers/src/providers/anthropic/mod.rs
@@ -35,6 +35,7 @@ const LABEL_SESSION: &str = "Current session";
 const LABEL_WEEK_ALL: &str = "Current week (all models)";
 
 const ENV_VAR: &str = "ANTHROPIC_API_KEY";
+const API_KEY_HEADER: &str = "x-api-key";
 
 inventory::submit!(maki_config::providers::BuiltInProvider {
     slug: "anthropic",
@@ -240,11 +241,14 @@ fn resolve_anthropic_base_url() -> Option<String> {
     maki_config::providers::resolve_base_url("anthropic", config.get("anthropic"))
 }
 
-fn resolve_auth_from_key(key: &str, base_url: Option<String>) -> super::ResolvedAuth {
-    super::ResolvedAuth {
-        base_url,
-        headers: vec![("x-api-key".into(), key.to_string())],
-    }
+fn resolve_auth_from_key(
+    key: &str,
+    base_url: Option<String>,
+) -> Result<super::ResolvedAuth, AgentError> {
+    Ok(
+        super::ResolvedAuth::new("anthropic", vec![(API_KEY_HEADER.into(), key.to_string())])?
+            .with_base_url(base_url),
+    )
 }
 
 pub struct Anthropic {
@@ -262,7 +266,7 @@ impl Anthropic {
     pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
         let pool = KeyPool::resolve("anthropic", ENV_VAR)?;
         let resolved_base_url = resolve_anthropic_base_url();
-        let resolved = resolve_auth_from_key(pool.current(), resolved_base_url.clone());
+        let resolved = resolve_auth_from_key(pool.current(), resolved_base_url.clone())?;
         debug!(keys = pool.len(), "using API key authentication");
         Ok(Self {
             client: super::http_client(timeouts),
@@ -440,7 +444,7 @@ impl Provider for Anthropic {
         Box::pin(async {
             let pool = KeyPool::resolve("anthropic", ENV_VAR)?;
             *self.auth.lock().unwrap() =
-                resolve_auth_from_key(pool.current(), self.resolved_base_url.clone());
+                resolve_auth_from_key(pool.current(), self.resolved_base_url.clone())?;
             debug!("reloaded Anthropic auth from env");
             Ok(())
         })
@@ -448,12 +452,10 @@ impl Provider for Anthropic {
 
     fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
         Box::pin(async {
-            let base_url = self.resolved_base_url.clone();
-            Ok(self.key_pool.as_ref().is_some_and(|p| {
-                p.rotate_auth(&self.auth, |key| {
-                    resolve_auth_from_key(key, base_url.clone())
-                })
-            }))
+            Ok(self
+                .key_pool
+                .as_ref()
+                .is_some_and(|p| p.rotate_key_header(&self.auth, API_KEY_HEADER, str::to_string)))
         })
     }
 
@@ -624,17 +626,19 @@ mod tests {
     #[test_case("x-api-key", None, false ; "api_key_not_eligible")]
     #[test_case("Authorization", Some("https://proxy.example.com/v1/messages"), false ; "foreign_base_url_not_eligible")]
     fn usage_eligibility(header: &str, base_url: Option<&str>, expected: bool) {
-        let auth = crate::providers::ResolvedAuth {
-            base_url: base_url.map(String::from),
-            headers: vec![(header.into(), "token".into())],
-        };
+        let auth = crate::providers::ResolvedAuth::for_test(
+            base_url.map(String::from),
+            vec![(header.into(), "token".into())],
+        );
         assert_eq!(usage_eligible(&auth, None), expected);
     }
 
     #[test]
     fn with_auth_keeps_third_party_endpoint_ineligible() {
-        let mut auth = crate::providers::ResolvedAuth::bearer("token");
-        auth.base_url = Some(THIRD_PARTY_BASE_URL.into());
+        let auth = crate::providers::ResolvedAuth::for_test(
+            Some(THIRD_PARTY_BASE_URL.into()),
+            vec![("authorization".into(), "Bearer token".into())],
+        );
         let provider = Anthropic::with_auth(
             Arc::new(Mutex::new(auth)),
             crate::providers::Timeouts::default(),
@@ -648,10 +652,10 @@ mod tests {
 
     #[test]
     fn usage_eligible_when_url_matches_configured_override() {
-        let auth = crate::providers::ResolvedAuth {
-            base_url: Some(THIRD_PARTY_BASE_URL.into()),
-            headers: vec![("Authorization".into(), "token".into())],
-        };
+        let auth = crate::providers::ResolvedAuth::for_test(
+            Some(THIRD_PARTY_BASE_URL.into()),
+            vec![("Authorization".into(), "token".into())],
+        );
         assert!(usage_eligible(&auth, Some(THIRD_PARTY_BASE_URL)));
         assert!(!usage_eligible(
             &auth,

--- a/maki-providers/src/providers/aperture.rs
+++ b/maki-providers/src/providers/aperture.rs
@@ -274,10 +274,9 @@ pub struct Aperture {
 impl Aperture {
     pub fn new(timeouts: Timeouts) -> Result<Self, AgentError> {
         let base_url = resolve_base_url()?;
-        let auth = Arc::new(Mutex::new(ResolvedAuth {
-            base_url: Some(base_url),
-            headers: Vec::new(),
-        }));
+        let auth = Arc::new(Mutex::new(
+            ResolvedAuth::new(CONFIG.slug, Vec::new())?.with_base_url(Some(base_url)),
+        ));
         Ok(Self::with_auth_and_overrides(
             auth,
             timeouts,
@@ -567,10 +566,10 @@ mod tests {
     }
 
     fn test_auth() -> Arc<Mutex<ResolvedAuth>> {
-        Arc::new(Mutex::new(ResolvedAuth {
-            base_url: Some("https://aperture.example.com".into()),
-            headers: Vec::new(),
-        }))
+        Arc::new(Mutex::new(ResolvedAuth::for_test(
+            Some("https://aperture.example.com".into()),
+            Vec::new(),
+        )))
     }
 
     #[test_case(Some(ProviderKind::Ollama), Some("https://aperture.example.com/v1") ; "ollama_appends_v1")]
@@ -600,10 +599,10 @@ mod tests {
 
     #[test]
     fn routed_auth_handles_host_with_trailing_slash() {
-        let auth = Arc::new(Mutex::new(ResolvedAuth {
-            base_url: Some("https://aperture.example.com/".into()),
-            headers: Vec::new(),
-        }));
+        let auth = Arc::new(Mutex::new(ResolvedAuth::for_test(
+            Some("https://aperture.example.com/".into()),
+            Vec::new(),
+        )));
         let routed = routed_auth(&auth, DEFAULT_PATH_PREFIX);
         assert_eq!(
             routed.lock().unwrap().base_url.as_deref(),
@@ -804,10 +803,10 @@ mod tests {
 
     #[test]
     fn adjust_model_inherits_routed_provider_thinking_support() {
-        let auth = Arc::new(Mutex::new(ResolvedAuth {
-            base_url: Some("https://example.com".into()),
-            headers: Vec::new(),
-        }));
+        let auth = Arc::new(Mutex::new(ResolvedAuth::for_test(
+            Some("https://example.com".into()),
+            Vec::new(),
+        )));
         let aperture =
             Aperture::with_auth_and_overrides(auth, Timeouts::default(), Overrides::new());
         let mut model = Model::from_spec("aperture/zai/glm-5.2").unwrap();

--- a/maki-providers/src/providers/catalog.rs
+++ b/maki-providers/src/providers/catalog.rs
@@ -124,28 +124,27 @@ impl ProviderData {
         }
     }
 
-    pub fn build_auth(&self, state_dir: &StateDir) -> Authentication {
+    fn auth_for(&self, api_key: &str) -> Result<ResolvedAuth, AgentError> {
+        Ok(ResolvedAuth::new(&self.slug, self.auth_headers(api_key))?
+            .with_base_url(self.base_url.clone()))
+    }
+
+    pub fn build_auth(&self, state_dir: &StateDir) -> Result<Authentication, AgentError> {
         let api_key = match self.resolve_api_key(state_dir) {
             Some(key) => key,
             None if OPENCODE_FAMILY_SLUGS.contains(&self.slug.as_str()) => {
-                return Authentication::OpenCodeFreeKey(ResolvedAuth {
-                    base_url: self.base_url.clone(),
-                    headers: self.auth_headers("public"),
-                });
+                return Ok(Authentication::OpenCodeFreeKey(self.auth_for("public")?));
             }
-            None => return Authentication::NoAuth,
+            None => return Ok(Authentication::NoAuth),
         };
-        Authentication::KeyBased(ResolvedAuth {
-            base_url: self.base_url.clone(),
-            headers: self.auth_headers(&api_key),
-        })
+        Ok(Authentication::KeyBased(self.auth_for(&api_key)?))
     }
 
-    pub fn resolve_auth(&self, state_dir: &StateDir) -> Option<ResolvedAuth> {
-        match self.build_auth(state_dir) {
+    pub fn resolve_auth(&self, state_dir: &StateDir) -> Result<Option<ResolvedAuth>, AgentError> {
+        Ok(match self.build_auth(state_dir)? {
             Authentication::KeyBased(auth) | Authentication::OpenCodeFreeKey(auth) => Some(auth),
             Authentication::NoAuth => None,
-        }
+        })
     }
 
     /// Resolve auth with optional dynamic override (e.g. from Lua).
@@ -153,11 +152,11 @@ impl ProviderData {
         &self,
         override_auth: Option<&Arc<Mutex<ResolvedAuth>>>,
         state_dir: &StateDir,
-    ) -> Option<ResolvedAuth> {
+    ) -> Result<Option<ResolvedAuth>, AgentError> {
         if OPENCODE_FAMILY_SLUGS.contains(&self.slug.as_str())
             && let Some(auth) = override_auth
         {
-            return Some(auth.lock().unwrap().clone());
+            return Ok(Some(auth.lock().unwrap().clone()));
         }
         self.resolve_auth(state_dir)
     }
@@ -167,7 +166,11 @@ impl ProviderData {
         state_dir: &StateDir,
         enable_free_models: bool,
     ) -> Vec<ModelInfo> {
-        let auth = self.build_auth(state_dir);
+        // A broken `[<slug>.headers]` hides the models instead of killing the
+        // whole listing; creating the provider reports the real error.
+        let Ok(auth) = self.build_auth(state_dir) else {
+            return Vec::new();
+        };
         let mut models: Vec<ModelInfo> = self
             .models
             .iter()
@@ -469,7 +472,7 @@ pub fn available_if_warm(slug: &str) -> bool {
     let Ok(state_dir) = StateDir::resolve() else {
         return false;
     };
-    data.resolve_auth(&state_dir).is_some()
+    matches!(data.resolve_auth(&state_dir), Ok(Some(_)))
 }
 
 fn catalog_cache_path() -> Option<PathBuf> {
@@ -646,7 +649,7 @@ impl CatalogProvider {
         timeouts: Timeouts,
         allow_free_fallback: bool,
     ) -> Result<Self, AgentError> {
-        let auth = match data.build_auth(state_dir) {
+        let auth = match data.build_auth(state_dir)? {
             Authentication::KeyBased(auth) => CatalogAuth::Keyed(auth),
             Authentication::OpenCodeFreeKey(auth) if allow_free_fallback => {
                 CatalogAuth::FreeOnly(auth)
@@ -1258,7 +1261,7 @@ mod tests {
         );
         // No env vars and no OPENCODE_API_KEY fallback — no auth
         assert!(matches!(
-            provider_data.build_auth(&state_dir),
+            provider_data.build_auth(&state_dir).unwrap(),
             Authentication::NoAuth
         ));
     }
@@ -1282,7 +1285,7 @@ mod tests {
             EndpointType::ChatCompletions,
             HashMap::new(),
         );
-        let auth = provider_data.build_auth(&state_dir);
+        let auth = provider_data.build_auth(&state_dir).unwrap();
         match auth {
             Authentication::OpenCodeFreeKey(resolved) => {
                 assert_eq!(resolved.headers[0].0, "authorization");
@@ -1312,7 +1315,7 @@ mod tests {
             EndpointType::ChatCompletions,
             HashMap::new(),
         );
-        let auth = provider_data.build_auth(&state_dir);
+        let auth = provider_data.build_auth(&state_dir).unwrap();
         match auth {
             Authentication::KeyBased(resolved) => {
                 assert_eq!(resolved.headers[0].0, "authorization");
@@ -1343,7 +1346,7 @@ mod tests {
             EndpointType::Messages,
             HashMap::new(),
         );
-        let auth = provider_data.build_auth(&state_dir);
+        let auth = provider_data.build_auth(&state_dir).unwrap();
         match auth {
             Authentication::KeyBased(resolved) => {
                 assert_eq!(resolved.headers[0].0, "x-api-key");
@@ -1466,7 +1469,7 @@ mod tests {
         assert_eq!(opencode.models.len(), 2, "all models included");
         // Public fallback auth registered
         assert!(matches!(
-            opencode.build_auth(&state_dir),
+            opencode.build_auth(&state_dir).unwrap(),
             Authentication::OpenCodeFreeKey(_)
         ));
     }
@@ -1579,7 +1582,7 @@ mod tests {
         assert!(opencode.models.contains_key("free-model"));
         assert!(opencode.models.contains_key("paid-model"));
         assert!(matches!(
-            opencode.build_auth(&state_dir),
+            opencode.build_auth(&state_dir).unwrap(),
             Authentication::KeyBased(_)
         ));
         unsafe { std::env::remove_var("MAKI_TEST_OPENCODE_ALL_81274") };
@@ -1642,7 +1645,7 @@ mod tests {
         assert!(opencode.models.contains_key("paid-model"));
         // Provider ID is "opencode" so slug becomes "opencode" -> OpenCodeFreeKey fallback
         assert!(matches!(
-            opencode.build_auth(&state_dir),
+            opencode.build_auth(&state_dir).unwrap(),
             Authentication::OpenCodeFreeKey(_)
         ));
         // all_models with OpenCodeFreeKey only shows free models; with enable_free_models=false, no models shown
@@ -1662,7 +1665,7 @@ mod tests {
         assert!(opencode.models.contains_key("paid-model"));
         // Provider ID is "opencode" so slug becomes "opencode" -> OpenCodeFreeKey fallback
         assert!(matches!(
-            opencode.build_auth(&state_dir),
+            opencode.build_auth(&state_dir).unwrap(),
             Authentication::OpenCodeFreeKey(_)
         ));
         // all_models filters both free (enable_free_models=false) and paid (OpenCodeFreeKey only shows free)

--- a/maki-providers/src/providers/copilot/mod.rs
+++ b/maki-providers/src/providers/copilot/mod.rs
@@ -24,10 +24,11 @@ use crate::{
 
 pub mod auth;
 
+const SLUG: &str = "copilot";
 const DEFAULT_API_ENDPOINT: &str = "https://api.githubcopilot.com";
 
 inventory::submit!(maki_config::providers::BuiltInProvider {
-    slug: "copilot",
+    slug: SLUG,
     display_name: "Copilot",
     protocol: maki_config::providers::Protocol::Openai,
     default_base_url: DEFAULT_API_ENDPOINT,
@@ -621,10 +622,9 @@ impl Copilot {
                 &effort_dialect(&info),
             );
         }
-        let resolved = super::ResolvedAuth {
-            base_url: Some(auth.endpoint.clone()),
-            headers: copilot_headers(&auth, Some("conversation-agent")),
-        };
+        let resolved =
+            super::ResolvedAuth::new(SLUG, copilot_headers(&auth, Some("conversation-agent")))?
+                .with_base_url(Some(auth.endpoint.clone()));
         responses::do_stream(
             &self.client,
             model,

--- a/maki-providers/src/providers/custom.rs
+++ b/maki-providers/src/providers/custom.rs
@@ -59,10 +59,10 @@ fn resolve_custom_auth(slug: &str) -> Result<ResolvedAuth, AgentError> {
     let env_var = def.api_key_env.as_deref().unwrap_or(&resolved_env);
     let pool = super::KeyPool::resolve(slug, env_var)?;
 
-    let base_url = resolve_base_url(slug, Some(def));
-    let mut auth = ResolvedAuth::bearer(pool.current());
-    auth.base_url = base_url;
-    Ok(auth)
+    Ok(
+        ResolvedAuth::bearer(slug, pool.current())?
+            .with_base_url(resolve_base_url(slug, Some(def))),
+    )
 }
 
 pub fn create(slug: &str, timeouts: Timeouts) -> Result<Box<dyn Provider>, AgentError> {

--- a/maki-providers/src/providers/deepseek.rs
+++ b/maki-providers/src/providers/deepseek.rs
@@ -145,7 +145,10 @@ impl DeepSeek {
         let pool = KeyPool::resolve("deepseek", CONFIG.api_key_env)?;
         Ok(Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
-            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(pool.current()))),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(
+                "deepseek",
+                pool.current(),
+            )?)),
             key_pool: Some(pool),
             system_prefix: None,
         })
@@ -222,7 +225,7 @@ impl Provider for DeepSeek {
             Ok(self
                 .key_pool
                 .as_ref()
-                .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
+                .is_some_and(|p| p.rotate_bearer(&self.auth)))
         })
     }
 }

--- a/maki-providers/src/providers/dynamic.rs
+++ b/maki-providers/src/providers/dynamic.rs
@@ -125,12 +125,10 @@ struct ScriptResolvedAuth {
     headers: HashMap<String, String>,
 }
 
-impl From<ScriptResolvedAuth> for ResolvedAuth {
-    fn from(s: ScriptResolvedAuth) -> Self {
-        Self {
-            base_url: s.base_url,
-            headers: s.headers.into_iter().collect(),
-        }
+impl ScriptResolvedAuth {
+    fn into_resolved(self, slug: &str) -> Result<ResolvedAuth, AgentError> {
+        Ok(ResolvedAuth::new(slug, self.headers.into_iter().collect())?
+            .with_base_url(self.base_url))
     }
 }
 
@@ -232,7 +230,7 @@ fn resolve_auth(meta: &DynamicProviderMeta) -> Result<ResolvedAuth, AgentError> 
         serde_json::from_str(&stdout).map_err(|e| AgentError::Config {
             message: format!("{} resolve: invalid JSON: {e}", meta.script_path.display()),
         })?;
-    Ok(parsed.into())
+    parsed.into_resolved(&meta.slug)
 }
 
 /// `info` and `models` describe the script, not the world, so their output only
@@ -596,6 +594,7 @@ pub fn create(slug: &str, timeouts: super::Timeouts) -> Result<Box<dyn Provider>
     };
 
     Ok(Box::new(DynamicProvider {
+        slug: &meta.slug,
         script_path: &meta.script_path,
         inner,
         auth,
@@ -654,6 +653,7 @@ pub fn find_model_for_tier(slug: &str, tier: ModelTier) -> Option<Model> {
 }
 
 struct DynamicProvider {
+    slug: &'static str,
     script_path: &'static Path,
     inner: Box<dyn Provider>,
     auth: Arc<Mutex<ResolvedAuth>>,
@@ -677,6 +677,7 @@ struct RefreshGate {
 impl RefreshGate {
     async fn refresh(
         &self,
+        slug: &str,
         script_path: &Path,
         auth: &Arc<Mutex<ResolvedAuth>>,
     ) -> Result<(), AgentError> {
@@ -686,26 +687,28 @@ impl RefreshGate {
             debug!("peer refreshed while we waited, skipping script run");
             return Ok(());
         }
-        run_auth_script(script_path, auth, "refresh").await?;
+        run_auth_script(slug, script_path, auth, "refresh").await?;
         self.generation.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
 }
 
 async fn run_auth_script(
+    slug: &str,
     script_path: &Path,
     auth: &Arc<Mutex<ResolvedAuth>>,
     subcommand: &'static str,
 ) -> Result<(), AgentError> {
     let script_path = script_path.to_path_buf();
     let auth = auth.clone();
+    let slug = slug.to_string();
     smol::unblock(move || {
         let stdout = run_script(&script_path, subcommand, SCRIPT_TIMEOUT)?;
         let parsed: ScriptResolvedAuth =
             serde_json::from_str(&stdout).map_err(|e| AgentError::Config {
                 message: format!("{} {subcommand}: invalid JSON: {e}", script_path.display()),
             })?;
-        let mut fresh: ResolvedAuth = parsed.into();
+        let mut fresh = parsed.into_resolved(&slug)?;
         let mut guard = auth.lock().unwrap();
         // A script that omits base_url keeps the resolved one; falling back to
         // the provider's default origin would silently repoint the token.
@@ -761,7 +764,7 @@ impl Provider for DynamicProvider {
                     debug!(error = %e, "auth error, refreshing script-backed credentials");
                     match self
                         .refresh_gate
-                        .refresh(self.script_path, &self.auth)
+                        .refresh(self.slug, self.script_path, &self.auth)
                         .await
                     {
                         Ok(()) => {
@@ -805,13 +808,21 @@ impl Provider for DynamicProvider {
     }
 
     fn refresh_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
-        Box::pin(self.refresh_gate.refresh(self.script_path, &self.auth))
+        Box::pin(
+            self.refresh_gate
+                .refresh(self.slug, self.script_path, &self.auth),
+        )
     }
 
     fn reload_auth(&self) -> BoxFuture<'_, Result<(), AgentError>> {
         // Deliberately ungated: this runs under block_on on the ui thread, and
         // parking it behind someone else's slow refresh script freezes the ui.
-        Box::pin(run_auth_script(self.script_path, &self.auth, "reload"))
+        Box::pin(run_auth_script(
+            self.slug,
+            self.script_path,
+            &self.auth,
+            "reload",
+        ))
     }
 
     fn fetch_usage(&self) -> BoxFuture<'_, Result<Option<ProviderUsage>, AgentError>> {
@@ -831,6 +842,8 @@ mod tests {
     #[cfg(unix)]
     use tempfile::TempDir;
     use test_case::test_case;
+
+    const TEST_SLUG: &str = "script-provider";
 
     #[cfg(unix)]
     const STALE_TOKEN: &str = "Bearer stale";
@@ -854,16 +867,18 @@ mod tests {
     fn script_resolved_auth_deserialization() {
         let with_base =
             r#"{"base_url": "https://example.com", "headers": {"authorization": "Bearer tok"}}"#;
-        let resolved: ResolvedAuth = serde_json::from_str::<ScriptResolvedAuth>(with_base)
+        let resolved = serde_json::from_str::<ScriptResolvedAuth>(with_base)
             .unwrap()
-            .into();
+            .into_resolved(TEST_SLUG)
+            .unwrap();
         assert_eq!(resolved.base_url.as_deref(), Some("https://example.com"));
         assert_eq!(resolved.headers[0].1, "Bearer tok");
 
         let without_base = r#"{"headers": {"authorization": "Bearer x"}}"#;
-        let resolved: ResolvedAuth = serde_json::from_str::<ScriptResolvedAuth>(without_base)
+        let resolved = serde_json::from_str::<ScriptResolvedAuth>(without_base)
             .unwrap()
-            .into();
+            .into_resolved(TEST_SLUG)
+            .unwrap();
         assert!(resolved.base_url.is_none());
     }
 
@@ -1031,16 +1046,16 @@ esac
         let tmp = TempDir::new().unwrap();
         let counter = tmp.path().join("count");
         let script = write_counting_refresh_script(tmp.path(), &counter, rotating);
-        let auth = Arc::new(Mutex::new(ResolvedAuth {
-            base_url: None,
-            headers: vec![("authorization".into(), STALE_TOKEN.into())],
-        }));
+        let auth = Arc::new(Mutex::new(ResolvedAuth::for_test(
+            None,
+            vec![("authorization".into(), STALE_TOKEN.into())],
+        )));
         let gate = RefreshGate::default();
 
         smol::block_on(async {
             let (first, second) = futures_lite::future::zip(
-                gate.refresh(&script, &auth),
-                gate.refresh(&script, &auth),
+                gate.refresh(TEST_SLUG, &script, &auth),
+                gate.refresh(TEST_SLUG, &script, &auth),
             )
             .await;
             first.unwrap();
@@ -1055,7 +1070,7 @@ esac
 
             // The late caller snapshots the bumped generation before locking, so
             // a refresh that doesn't overlap anyone still runs the script.
-            gate.refresh(&script, &auth).await.unwrap();
+            gate.refresh(TEST_SLUG, &script, &auth).await.unwrap();
         });
 
         assert_eq!(

--- a/maki-providers/src/providers/google.rs
+++ b/maki-providers/src/providers/google.rs
@@ -20,6 +20,7 @@ use super::{KeyPool, ResolvedAuth, http_client, next_sse_line};
 
 const BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
 const ENV_VAR: &str = "GEMINI_API_KEY";
+const API_KEY_HEADER: &str = "x-goog-api-key";
 const FLASH_MAX_THINKING: u32 = 24_576;
 const PRO_MAX_THINKING: u32 = 32_768;
 
@@ -104,11 +105,11 @@ fn resolve_google_base_url() -> Option<String> {
     maki_config::providers::resolve_base_url("google", config.get("google"))
 }
 
-fn resolve_auth_from_key(key: &str, base_url: Option<String>) -> ResolvedAuth {
-    ResolvedAuth {
-        base_url,
-        headers: vec![("x-goog-api-key".into(), key.to_string())],
-    }
+fn resolve_auth_from_key(key: &str, base_url: Option<String>) -> Result<ResolvedAuth, AgentError> {
+    Ok(
+        ResolvedAuth::new("google", vec![(API_KEY_HEADER.into(), key.to_string())])?
+            .with_base_url(base_url),
+    )
 }
 
 pub struct Google {
@@ -124,7 +125,7 @@ impl Google {
     pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
         let pool = KeyPool::resolve("google", ENV_VAR)?;
         let resolved_base_url = resolve_google_base_url();
-        let resolved = resolve_auth_from_key(pool.current(), resolved_base_url.clone());
+        let resolved = resolve_auth_from_key(pool.current(), resolved_base_url.clone())?;
         Ok(Self {
             client: http_client(timeouts),
             auth: Arc::new(Mutex::new(resolved)),
@@ -162,7 +163,7 @@ impl Google {
         let auth = self.auth.lock().unwrap();
         auth.headers
             .iter()
-            .find(|(k, _)| k == "x-goog-api-key")
+            .find(|(k, _)| k == API_KEY_HEADER)
             .map(|(_, v)| v.clone())
             .unwrap_or_default()
     }
@@ -295,19 +296,17 @@ impl Provider for Google {
         Box::pin(async {
             let pool = KeyPool::resolve("google", ENV_VAR)?;
             *self.auth.lock().unwrap() =
-                resolve_auth_from_key(pool.current(), self.resolved_base_url.clone());
+                resolve_auth_from_key(pool.current(), self.resolved_base_url.clone())?;
             Ok(())
         })
     }
 
     fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
         Box::pin(async {
-            let base_url = self.resolved_base_url.clone();
-            Ok(self.key_pool.as_ref().is_some_and(|p| {
-                p.rotate_auth(&self.auth, |key| {
-                    resolve_auth_from_key(key, base_url.clone())
-                })
-            }))
+            Ok(self
+                .key_pool
+                .as_ref()
+                .is_some_and(|p| p.rotate_key_header(&self.auth, API_KEY_HEADER, str::to_string)))
         })
     }
 }
@@ -677,10 +676,10 @@ mod tests {
     const GEMINI_API_KEY: &str = "test-key";
 
     fn test_auth() -> Arc<Mutex<ResolvedAuth>> {
-        Arc::new(Mutex::new(ResolvedAuth {
-            base_url: None,
-            headers: vec![("x-goog-api-key".into(), GEMINI_API_KEY.into())],
-        }))
+        Arc::new(Mutex::new(ResolvedAuth::for_test(
+            None,
+            vec![("x-goog-api-key".into(), GEMINI_API_KEY.into())],
+        )))
     }
 
     fn test_timeouts() -> super::super::Timeouts {

--- a/maki-providers/src/providers/local.rs
+++ b/maki-providers/src/providers/local.rs
@@ -111,12 +111,10 @@ impl LocalEndpoint {
             None => Vec::new(),
         };
         let compat_config = &cfg.compat;
+        let auth = ResolvedAuth::new(cfg.slug, headers)?.with_base_url(Some(base_url));
         Ok(Self {
             compat: OpenAiCompatProvider::new(compat_config, timeouts),
-            auth: Arc::new(Mutex::new(ResolvedAuth {
-                base_url: Some(base_url),
-                headers,
-            })),
+            auth: Arc::new(Mutex::new(auth)),
             key_pool,
             system_prefix: None,
             thinking_budget_field: cfg.thinking_budget_field,
@@ -184,11 +182,10 @@ impl Provider for LocalEndpoint {
 
     fn rotate_key(&self) -> BoxFuture<'_, Result<bool, AgentError>> {
         Box::pin(async {
-            Ok(self.key_pool.as_ref().is_some_and(|p| {
-                p.rotate_headers(&self.auth, |key| {
-                    vec![("authorization".into(), format!("Bearer {key}"))]
-                })
-            }))
+            Ok(self
+                .key_pool
+                .as_ref()
+                .is_some_and(|p| p.rotate_bearer(&self.auth)))
         })
     }
 }

--- a/maki-providers/src/providers/mistral.rs
+++ b/maki-providers/src/providers/mistral.rs
@@ -179,7 +179,7 @@ impl Mistral {
         let pool = KeyPool::resolve("mistral", CONFIG.api_key_env)?;
         Ok(Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
-            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(pool.current()))),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer("mistral", pool.current())?)),
             key_pool: Some(pool),
             system_prefix: None,
         })
@@ -283,7 +283,7 @@ impl Provider for Mistral {
             Ok(self
                 .key_pool
                 .as_ref()
-                .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
+                .is_some_and(|p| p.rotate_bearer(&self.auth)))
         })
     }
 

--- a/maki-providers/src/providers/mod.rs
+++ b/maki-providers/src/providers/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -35,6 +36,11 @@ pub(crate) mod zai;
 
 const LOW_SPEED_BYTES_PER_SEC: u32 = 1;
 const UNMAPPED_SSE_ERROR_STATUS: u16 = 400;
+const AUTHORIZATION_HEADER: &str = "authorization";
+
+fn bearer_value(api_key: &str) -> String {
+    format!("Bearer {api_key}")
+}
 
 pub(crate) fn user_agent() -> &'static str {
     concat!(
@@ -66,13 +72,87 @@ impl Default for Timeouts {
 pub struct ResolvedAuth {
     pub base_url: Option<String>,
     pub headers: Vec<(String, String)>,
+    /// Header names that came from `[<slug>.headers]`. They win over anything
+    /// the provider sets afterwards, so a key rotation cannot drop a gateway
+    /// credential that replaced the built-in auth header.
+    config_headers: Vec<String>,
 }
 
 impl ResolvedAuth {
-    pub fn bearer(api_key: &str) -> Self {
-        Self {
+    /// The only way to build auth, so every provider picks up
+    /// `[<slug>.headers]` from `providers.toml`. Skipping it would silently
+    /// ignore the user's config, which is why there is no slug-less
+    /// constructor outside of tests.
+    pub fn new(slug: &str, headers: Vec<(String, String)>) -> Result<Self, AgentError> {
+        let mut auth = Self {
             base_url: None,
-            headers: vec![("authorization".into(), format!("Bearer {api_key}"))],
+            headers,
+            config_headers: Vec::new(),
+        };
+        if let Some(def) = maki_config::providers::ProvidersConfig::load().get(slug) {
+            auth.apply_config_headers(slug, &def.headers)?;
+        }
+        Ok(auth)
+    }
+
+    /// Fold `[<slug>.headers]` in, expanding `${VAR}` from the environment. An
+    /// unset or empty variable fails the whole provider (see
+    /// `maki_config::expand_env`), matching the MCP path.
+    fn apply_config_headers(
+        &mut self,
+        slug: &str,
+        headers: &BTreeMap<String, String>,
+    ) -> Result<(), AgentError> {
+        for (name, value) in headers {
+            let expanded = maki_config::expand_env(value).map_err(|var| {
+                AgentError::Config {
+                    message: format!(
+                        "provider '{slug}' header '{name}': environment variable '{var}' is unset or empty"
+                    ),
+                }
+            })?;
+            self.set_header(name, expanded);
+            self.config_headers.push(name.clone());
+        }
+        Ok(())
+    }
+
+    pub fn bearer(slug: &str, api_key: &str) -> Result<Self, AgentError> {
+        Self::new(
+            slug,
+            vec![(AUTHORIZATION_HEADER.into(), bearer_value(api_key))],
+        )
+    }
+
+    pub fn with_base_url(mut self, base_url: Option<String>) -> Self {
+        self.base_url = base_url;
+        self
+    }
+
+    /// Set the header carrying the API key, unless `[<slug>.headers]` already
+    /// owns that name: the config value is the one the gateway expects.
+    fn set_key_header(&mut self, name: &str, value: String) {
+        if self
+            .config_headers
+            .iter()
+            .any(|configured| configured.eq_ignore_ascii_case(name))
+        {
+            return;
+        }
+        self.set_header(name, value);
+    }
+
+    /// Replace a same-name header (case-insensitive) instead of appending a
+    /// second one: `Builder::header` appends, so a configured `Authorization`
+    /// next to the built-in bearer would send two credentials.
+    fn set_header(&mut self, name: &str, value: String) {
+        match self
+            .headers
+            .iter_mut()
+            .find(|(k, _)| k.eq_ignore_ascii_case(name))
+        {
+            Some(slot) => slot.1 = value,
+            None => self.headers.push((name.to_string(), value)),
         }
     }
 
@@ -81,6 +161,15 @@ impl ResolvedAuth {
         self.headers.iter().fold(builder, |b, (key, value)| {
             b.header(key.as_str(), value.as_str())
         })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(base_url: Option<String>, headers: Vec<(String, String)>) -> Self {
+        Self {
+            base_url,
+            headers,
+            config_headers: Vec::new(),
+        }
     }
 }
 
@@ -270,28 +359,25 @@ impl KeyPool {
         true
     }
 
-    pub fn rotate_auth(
+    /// Rotate to the next key and refresh only the header carrying it, so the
+    /// resolved `base_url` and any `[<slug>.headers]` survive the rotation.
+    pub fn rotate_key_header(
         &self,
         auth: &Mutex<ResolvedAuth>,
-        build: impl FnOnce(&str) -> ResolvedAuth,
+        name: &str,
+        build: impl FnOnce(&str) -> String,
     ) -> bool {
         if !self.rotate() {
             return false;
         }
-        *auth.lock().unwrap() = build(self.current());
+        auth.lock()
+            .unwrap()
+            .set_key_header(name, build(self.current()));
         true
     }
 
-    pub fn rotate_headers(
-        &self,
-        auth: &Mutex<ResolvedAuth>,
-        build: impl FnOnce(&str) -> Vec<(String, String)>,
-    ) -> bool {
-        if !self.rotate() {
-            return false;
-        }
-        auth.lock().unwrap().headers = build(self.current());
-        true
+    pub fn rotate_bearer(&self, auth: &Mutex<ResolvedAuth>) -> bool {
+        self.rotate_key_header(auth, AUTHORIZATION_HEADER, bearer_value)
     }
 
     pub fn len(&self) -> usize {
@@ -432,5 +518,115 @@ mod tests {
         assert!(result.is_err());
         let msg = format!("{result:?}");
         assert!(msg.contains(&env_var) || msg.contains(&slug));
+    }
+
+    const TEST_SLUG: &str = "gateway";
+    const GATEWAY_HEADER: &str = "CF-Access-Client-Id";
+    const GATEWAY_ID: &str = "client-id";
+    const GATEWAY_URL: &str = "https://gw.internal/v1";
+    const GATEWAY_CRED: &str = "Basic gateway-cred";
+
+    fn config_headers(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn header_value(auth: &ResolvedAuth, name: &str) -> Option<String> {
+        auth.headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.clone())
+    }
+
+    fn test_bearer(key: &str) -> ResolvedAuth {
+        ResolvedAuth::for_test(None, vec![(AUTHORIZATION_HEADER.into(), bearer_value(key))])
+    }
+
+    #[test]
+    fn config_headers_append_unknown_and_replace_same_name() {
+        let mut auth = test_bearer("sk-1");
+        auth.apply_config_headers(
+            TEST_SLUG,
+            &config_headers(&[
+                (GATEWAY_HEADER, GATEWAY_ID),
+                // Case differs from the built-in header on purpose: appending
+                // instead of replacing would send two credentials.
+                ("Authorization", "Basic other"),
+            ]),
+        )
+        .unwrap();
+        assert_eq!(auth.headers.len(), 2);
+        assert_eq!(
+            header_value(&auth, AUTHORIZATION_HEADER).as_deref(),
+            Some("Basic other")
+        );
+        assert_eq!(
+            header_value(&auth, GATEWAY_HEADER).as_deref(),
+            Some(GATEWAY_ID)
+        );
+    }
+
+    #[test]
+    fn config_headers_unset_var_names_slug_header_and_var() {
+        let var = format!("MAKI_TEST_GATEWAY_UNSET_{}", fastrand::u32(..));
+        let mut auth = test_bearer("sk-1");
+        let err = auth
+            .apply_config_headers(
+                TEST_SLUG,
+                &config_headers(&[(GATEWAY_HEADER, &format!("${{{var}}}"))]),
+            )
+            .unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains(TEST_SLUG), "got: {msg}");
+        assert!(msg.contains(GATEWAY_HEADER), "got: {msg}");
+        assert!(msg.contains(&var), "got: {msg}");
+    }
+
+    #[test]
+    fn rotate_bearer_keeps_base_url_and_config_headers() {
+        let pool = KeyPool::from_keys(vec!["sk-1".into(), "sk-2".into()]);
+        let mut auth = test_bearer(pool.current());
+        auth.base_url = Some(GATEWAY_URL.into());
+        auth.apply_config_headers(TEST_SLUG, &config_headers(&[(GATEWAY_HEADER, GATEWAY_ID)]))
+            .unwrap();
+
+        let auth = Mutex::new(auth);
+        assert!(pool.rotate_bearer(&auth));
+
+        let auth = auth.lock().unwrap();
+        assert_eq!(auth.base_url.as_deref(), Some(GATEWAY_URL));
+        assert_eq!(
+            header_value(&auth, AUTHORIZATION_HEADER).as_deref(),
+            Some("Bearer sk-2")
+        );
+        assert_eq!(
+            header_value(&auth, GATEWAY_HEADER).as_deref(),
+            Some(GATEWAY_ID)
+        );
+    }
+
+    #[test]
+    fn rotate_bearer_keeps_a_configured_auth_header() {
+        let pool = KeyPool::from_keys(vec!["sk-1".into(), "sk-2".into()]);
+        let mut auth = test_bearer(pool.current());
+        auth.apply_config_headers(
+            TEST_SLUG,
+            &config_headers(&[("Authorization", GATEWAY_CRED)]),
+        )
+        .unwrap();
+
+        let auth = Mutex::new(auth);
+        assert!(pool.rotate_bearer(&auth));
+
+        // The gateway credential replaced the built-in bearer, so rotating the
+        // key must not put `Bearer sk-2` back and lock the user out.
+        let auth = auth.lock().unwrap();
+        assert_eq!(auth.headers.len(), 1);
+        assert_eq!(
+            header_value(&auth, AUTHORIZATION_HEADER).as_deref(),
+            Some(GATEWAY_CRED)
+        );
     }
 }

--- a/maki-providers/src/providers/openai/auth.rs
+++ b/maki-providers/src/providers/openai/auth.rs
@@ -249,22 +249,16 @@ pub(crate) fn refresh_tokens(tokens: &OAuthTokens) -> Result<OAuthTokens, AgentE
 
 pub(crate) const CODING_PLAN_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 
-pub(crate) fn build_oauth_resolved(tokens: &OAuthTokens) -> ResolvedAuth {
-    ResolvedAuth {
-        base_url: None,
-        headers: vec![("authorization".into(), format!("Bearer {}", tokens.access))],
-    }
+pub(crate) fn build_oauth_resolved(tokens: &OAuthTokens) -> Result<ResolvedAuth, AgentError> {
+    ResolvedAuth::bearer(PROVIDER, &tokens.access)
 }
 
-pub(crate) fn build_coding_plan_resolved(tokens: &OAuthTokens) -> ResolvedAuth {
+pub(crate) fn build_coding_plan_resolved(tokens: &OAuthTokens) -> Result<ResolvedAuth, AgentError> {
     let mut headers = vec![("authorization".into(), format!("Bearer {}", tokens.access))];
     if let Some(account_id) = &tokens.account_id {
         headers.push(("chatgpt-account-id".into(), account_id.clone()));
     }
-    ResolvedAuth {
-        base_url: Some(CODING_PLAN_BASE_URL.into()),
-        headers,
-    }
+    Ok(ResolvedAuth::new(PROVIDER, headers)?.with_base_url(Some(CODING_PLAN_BASE_URL.into())))
 }
 
 pub(crate) fn is_oauth(dir: &StateDir) -> bool {
@@ -275,13 +269,13 @@ pub fn resolve(dir: &StateDir) -> Result<ResolvedAuth, AgentError> {
     if let Some(tokens) = load_tokens(dir, PROVIDER) {
         if !tokens.is_expired() {
             debug!("using OpenAI OAuth authentication");
-            return Ok(build_oauth_resolved(&tokens));
+            return build_oauth_resolved(&tokens);
         }
         match refresh_tokens(&tokens) {
             Ok(fresh) => {
                 save_tokens(dir, PROVIDER, &fresh)?;
                 debug!("using OpenAI OAuth authentication (refreshed)");
-                return Ok(build_oauth_resolved(&fresh));
+                return build_oauth_resolved(&fresh);
             }
             Err(e) => {
                 warn!(error = %e, "OpenAI OAuth refresh failed, clearing stale tokens");
@@ -292,18 +286,12 @@ pub fn resolve(dir: &StateDir) -> Result<ResolvedAuth, AgentError> {
 
     if let Ok(key) = env::var("OPENAI_API_KEY") {
         debug!("using OpenAI API key authentication");
-        return Ok(ResolvedAuth {
-            base_url: None,
-            headers: vec![("authorization".into(), format!("Bearer {key}"))],
-        });
+        return ResolvedAuth::bearer(PROVIDER, &key);
     }
 
     if let Some(creds) = maki_storage::auth::load_provider_credentials(dir, PROVIDER) {
         debug!("using OpenAI saved API key");
-        return Ok(ResolvedAuth {
-            base_url: None,
-            headers: vec![("authorization".into(), format!("Bearer {}", creds.api_key))],
-        });
+        return ResolvedAuth::bearer(PROVIDER, &creds.api_key);
     }
 
     Err(AgentError::Config {

--- a/maki-providers/src/providers/openai/platform.rs
+++ b/maki-providers/src/providers/openai/platform.rs
@@ -160,7 +160,7 @@ impl OpenAi {
             match auth::refresh_tokens(&tokens) {
                 Ok(fresh) => {
                     maki_storage::auth::save_tokens(&storage, auth::PROVIDER, &fresh)?;
-                    Ok(auth::build_oauth_resolved(&fresh))
+                    auth::build_oauth_resolved(&fresh)
                 }
                 Err(e) => {
                     warn!(error = %e, "OpenAI OAuth refresh failed, clearing stale tokens");
@@ -195,7 +195,7 @@ impl OpenAi {
         if let Some(storage) = self.storage.as_ref()
             && let Some(tokens) = maki_storage::auth::load_tokens(storage, auth::PROVIDER)
         {
-            return Ok(auth::build_coding_plan_resolved(&tokens));
+            return auth::build_coding_plan_resolved(&tokens);
         }
         // Fall back to standard API key via the Responses API. Env /
         // providers.toml base_url overrides the platform API only, never the

--- a/maki-providers/src/providers/opencode.rs
+++ b/maki-providers/src/providers/opencode.rs
@@ -156,7 +156,7 @@ impl Opencode {
             let (meta, provider_data) = guard.lookup(&sub_provider, &actual_id)?;
             let state_dir = &guard.state_dir;
             let auth = provider_data
-                .resolve_auth_with_override(auth_override.as_ref(), state_dir)
+                .resolve_auth_with_override(auth_override.as_ref(), state_dir)?
                 .ok_or_else(|| {
                     config_error(format!(
                         "authentication required for provider '{sub_provider}', run `maki auth login {sub_provider}`"

--- a/maki-providers/src/providers/openrouter.rs
+++ b/maki-providers/src/providers/openrouter.rs
@@ -62,7 +62,10 @@ impl OpenRouter {
         let pool = KeyPool::resolve(CONFIG.slug, CONFIG.api_key_env)?;
         Ok(Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
-            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(pool.current()))),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(
+                CONFIG.slug,
+                pool.current(),
+            )?)),
             key_pool: Some(pool),
             system_prefix: None,
         })
@@ -230,7 +233,7 @@ impl Provider for OpenRouter {
             Ok(self
                 .key_pool
                 .as_ref()
-                .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
+                .is_some_and(|p| p.rotate_bearer(&self.auth)))
         })
     }
 }

--- a/maki-providers/src/providers/synthetic.rs
+++ b/maki-providers/src/providers/synthetic.rs
@@ -97,7 +97,10 @@ impl Synthetic {
         let pool = KeyPool::resolve("synthetic", CONFIG.api_key_env)?;
         Ok(Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
-            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(pool.current()))),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(
+                "synthetic",
+                pool.current(),
+            )?)),
             key_pool: Some(pool),
             system_prefix: None,
         })
@@ -154,7 +157,7 @@ impl Provider for Synthetic {
             Ok(self
                 .key_pool
                 .as_ref()
-                .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
+                .is_some_and(|p| p.rotate_bearer(&self.auth)))
         })
     }
 }

--- a/maki-providers/src/providers/tensorx.rs
+++ b/maki-providers/src/providers/tensorx.rs
@@ -54,7 +54,7 @@ impl TensorX {
         let pool = KeyPool::resolve("tensorx", CONFIG.api_key_env)?;
         Ok(Self {
             compat: OpenAiCompatProvider::new(&CONFIG, timeouts),
-            auth: Arc::new(Mutex::new(ResolvedAuth::bearer(pool.current()))),
+            auth: Arc::new(Mutex::new(ResolvedAuth::bearer("tensorx", pool.current())?)),
             key_pool: Some(pool),
             system_prefix: None,
         })
@@ -223,7 +223,7 @@ impl Provider for TensorX {
             Ok(self
                 .key_pool
                 .as_ref()
-                .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
+                .is_some_and(|p| p.rotate_bearer(&self.auth)))
         })
     }
 }

--- a/maki-providers/src/providers/xai/auth.rs
+++ b/maki-providers/src/providers/xai/auth.rs
@@ -204,11 +204,9 @@ fn client_mode() -> &'static str {
     }
 }
 
-pub(crate) fn build_oauth_resolved(tokens: &OAuthTokens) -> ResolvedAuth {
-    ResolvedAuth {
-        base_url: Some(CLI_BASE_URL.into()),
-        headers: oauth_headers(&tokens.access),
-    }
+pub(crate) fn build_oauth_resolved(tokens: &OAuthTokens) -> Result<ResolvedAuth, AgentError> {
+    Ok(ResolvedAuth::new(PROVIDER, oauth_headers(&tokens.access))?
+        .with_base_url(Some(CLI_BASE_URL.into())))
 }
 
 pub(crate) fn is_oauth(dir: &StateDir) -> bool {
@@ -219,13 +217,13 @@ pub fn resolve(dir: &StateDir) -> Result<ResolvedAuth, AgentError> {
     if let Some(tokens) = load_tokens(dir, PROVIDER) {
         if !tokens.is_expired() {
             debug!("using xAI OAuth authentication");
-            return Ok(build_oauth_resolved(&tokens));
+            return build_oauth_resolved(&tokens);
         }
         match refresh_tokens(&tokens) {
             Ok(fresh) => {
                 save_tokens(dir, PROVIDER, &fresh)?;
                 debug!("using xAI OAuth authentication (refreshed)");
-                return Ok(build_oauth_resolved(&fresh));
+                return build_oauth_resolved(&fresh);
             }
             Err(e) => {
                 warn!(error = %e, "xAI OAuth refresh failed, clearing stale tokens");
@@ -237,7 +235,7 @@ pub fn resolve(dir: &StateDir) -> Result<ResolvedAuth, AgentError> {
 
     if let Ok(pool) = KeyPool::resolve(PROVIDER, API_KEY_ENV) {
         debug!("using xAI API key authentication");
-        return Ok(ResolvedAuth::bearer(pool.current()));
+        return ResolvedAuth::bearer(PROVIDER, pool.current());
     }
 
     Err(AgentError::Config {

--- a/maki-providers/src/providers/xai/platform.rs
+++ b/maki-providers/src/providers/xai/platform.rs
@@ -87,7 +87,7 @@ impl Xai {
             match auth::refresh_tokens(&tokens) {
                 Ok(fresh) => {
                     maki_storage::auth::save_tokens(&storage, auth::PROVIDER, &fresh)?;
-                    Ok(auth::build_oauth_resolved(&fresh))
+                    auth::build_oauth_resolved(&fresh)
                 }
                 Err(e) => {
                     warn!(error = %e, "xAI OAuth refresh failed, clearing stale tokens");
@@ -344,10 +344,10 @@ mod tests {
 
     #[test]
     fn bearer_token_extracts_access() {
-        let auth = ResolvedAuth {
-            base_url: None,
-            headers: vec![("authorization".into(), "Bearer tok-123".into())],
-        };
+        let auth = ResolvedAuth::for_test(
+            None,
+            vec![("authorization".into(), "Bearer tok-123".into())],
+        );
         assert_eq!(bearer_token(&auth).as_deref(), Some("tok-123"));
     }
 }

--- a/maki-providers/src/providers/zai/mod.rs
+++ b/maki-providers/src/providers/zai/mod.rs
@@ -253,7 +253,7 @@ pub struct Zai {
 impl Zai {
     pub fn new(timeouts: super::Timeouts) -> Result<Self, AgentError> {
         let pool = KeyPool::resolve("zai", CONFIG_STANDARD.api_key_env)?;
-        let mut auth = ResolvedAuth::bearer(pool.current());
+        let mut auth = ResolvedAuth::bearer("zai", pool.current())?;
         let provider_config = maki_config::providers::ProvidersConfig::load();
         if let Some(url) =
             maki_config::providers::resolve_base_url("zai", provider_config.get("zai"))
@@ -344,7 +344,7 @@ impl Provider for Zai {
             Ok(self
                 .key_pool
                 .as_ref()
-                .is_some_and(|p| p.rotate_auth(&self.auth, ResolvedAuth::bearer)))
+                .is_some_and(|p| p.rotate_bearer(&self.auth)))
         })
     }
 

--- a/site/docs/content/mcp/_index.md
+++ b/site/docs/content/mcp/_index.md
@@ -34,8 +34,12 @@ enabled = false
 ```toml
 [mcp.analytics]
 url = "https://mcp.example.com/mcp"
-headers = { Authorization = "Bearer tok123" }
+headers = { Authorization = "Bearer ${ANALYTICS_TOKEN}" }
 ```
+
+`headers` and `environment` values expand `${VAR}` from the environment. A
+referenced variable that is unset or empty fails that server with the variable
+named in its status, instead of sending a dangling `Bearer ` and getting a 401.
 
 Some HTTP servers need OAuth but have no dynamic client registration. For those, give Maki a static client:
 
@@ -51,8 +55,8 @@ oauth = { client_id = "acme-client", client_secret = "s3cret", callback_port = 3
 |-------|------|---------|-------|
 | `command` | array | | Stdio: program + args |
 | `url` | string | | HTTP: server URL |
-| `environment` | map | | Stdio only |
-| `headers` | map | | HTTP only |
+| `environment` | map | | Stdio only. Values expand `${VAR}` from the environment |
+| `headers` | map | | HTTP only. Values expand `${VAR}` from the environment |
 | `oauth` | table | | HTTP only: static client (`client_id`, optional `client_secret`, optional `callback_port`, optional `callback_path`, optional `callback_hostname`) |
 | `timeout` | u64 | 30000 | Milliseconds (1-300000) |
 | `enabled` | bool | true | |

--- a/site/docs/content/providers/_index.md
+++ b/site/docs/content/providers/_index.md
@@ -362,6 +362,7 @@ supports_vision = false
 | `plan` | string | Built-in plan key (see Plans below). Sets base URL and default model |
 | `api_key_env` | string | Env var that holds the key. Defaults to `<SLUG>_API_KEY` |
 | `api_key` | string | Inline key (prefer the env var or `maki auth login`) |
+| `headers` | table | Extra HTTP headers sent on every request to this provider. Values expand `${VAR}` from the environment; an unset or empty variable fails the provider instead of sending a half-filled header. A same-name header (case-insensitive) replaces the built-in auth header and survives key rotation |
 | `default_model` | string | Used after login when no model is saved yet |
 | `discover_models` | bool | When true, also probe the provider's model list endpoint (default false) |
 | `enable_free_models` | bool | Opencode only. Show free catalog models (default false) |


### PR DESCRIPTION
MCP server HTTP headers get ${VAR} expansion from the process environment, and providers.toml gains a [slug.headers] table with the same expansion, applied on every request across the openai-compat, anthropic, and google paths.

Motivation: anything behind an authenticating gateway needs per-request credentials that should not live in a config file. The concrete case is Cloudflare Access service tokens in front of private cliproxy / llama.cpp endpoints:

    [cliproxy.headers]
    CF-Access-Client-Id = "${CF_ACCESS_CLIENT_ID}"
    CF-Access-Client-Secret = "${CF_ACCESS_CLIENT_SECRET}"

An unset variable fails provider construction loudly, naming the variable; a set-but-empty one drops the header rather than sending a dangling value. The expansion helper moved to maki-config so both consumers share one implementation.