### PR TITLE
lua: maki.toast lib, list picker action keys, maki.async.sleep

### DIFF
--- a/maki-lua/src/api/async.rs
+++ b/maki-lua/src/api/async.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_lock::{Semaphore, SemaphoreGuardArc};
 use futures::future::join_all;
@@ -195,6 +196,26 @@ async fn gather(lua: Lua, fns: Table) -> LuaResult<Table> {
     Ok(out)
 }
 
+/// Suspend the calling task for {ms} milliseconds. The plugin thread is
+/// never blocked, so other tasks and the UI keep running, and a cancel
+/// still lands while you sleep.
+///
+/// For a timer that has to outlive the tool call that started it, such
+/// as a toast dismissing itself, use `maki.defer_fn`.
+///
+/// @param ms integer Milliseconds to sleep.
+/// @return
+/// @example
+/// maki.async.run(function()
+///   maki.async.sleep(4000)
+///   win:close()
+/// end)
+#[lua_fn]
+async fn sleep(_lua: Lua, ms: u64) -> LuaResult<()> {
+    smol::Timer::after(Duration::from_millis(ms)).await;
+    Ok(())
+}
+
 /// Create a counting semaphore that allows at most {n} concurrent permits.
 /// Use this to limit how many tasks hit a resource at the same time.
 ///
@@ -302,7 +323,7 @@ lua_table! {
     /// })
     /// ```
     extend "maki.async" => pub(crate) fn add_async_fns(), DOCS [
-        run, manual r#await, manual wrap, manual join, gather, semaphore, on_cancel,
+        run, sleep, manual r#await, manual wrap, manual join, gather, semaphore, on_cancel,
     ]
 }
 

--- a/maki-lua/src/api/mod.rs
+++ b/maki-lua/src/api/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod split;
 pub(crate) mod task;
 pub(crate) mod text;
 pub(crate) mod tool;
+pub(crate) mod top;
 pub(crate) mod treesitter;
 pub(crate) mod ui;
 pub(crate) mod util;
@@ -28,7 +29,7 @@ pub(crate) mod yaml;
 
 use std::sync::Arc;
 
-use mlua::{Lua, Result as LuaResult, Table};
+use mlua::{Lua, Result as LuaResult, Table, Value};
 
 use crate::api::options::PluginOpts;
 use crate::api::tool::{PendingRules, PendingTools};
@@ -89,10 +90,11 @@ pub(crate) fn create_maki_global(
             Arc::clone(&plugin),
             permissions,
             permissions.is_allowed(Permission::FsWrite),
-            ui_action_tx,
+            ui_action_tx.clone(),
         )?,
     )?;
     split::split__register(&maki, lua)?;
+    top::add_top_methods(&maki, lua, Arc::clone(&plugin))?;
     maki.set("async", r#async::create_async_table(lua)?)?;
     maki.set(
         "interpreter",
@@ -105,6 +107,24 @@ pub(crate) fn create_maki_global(
     )?;
     pack::add_packadd(lua, &maki)?;
     maki.set("pack", pack::create_pack_read_table(lua)?)?;
+
+    // `notify` sits on the metatable's `__index` rather than on the table
+    // itself, because Lua only fires `__newindex` for keys missing from the
+    // raw table. That is what gives `maki.notify = fn` somewhere to be caught
+    // and routed into the one shared slot, instead of quietly shadowing notify
+    // for the assigning plugin alone.
+    let index = lua.create_table()?;
+    top::notify__register(&index, lua, ui_action_tx, Arc::clone(&plugin))?;
+    let notify_router = lua.create_function(
+        move |lua, (t, k, v): (Table, String, Value)| match k.as_str() {
+            "notify" => top::install_notify_handler(lua, Arc::clone(&plugin), v),
+            _ => t.raw_set(k, v),
+        },
+    )?;
+    let meta = lua.create_table()?;
+    meta.set("__index", index)?;
+    meta.set("__newindex", notify_router)?;
+    maki.set_metatable(Some(meta))?;
 
     Ok(maki)
 }

--- a/maki-lua/src/api/top.rs
+++ b/maki-lua/src/api/top.rs
@@ -1,0 +1,383 @@
+//! Top-level entries directly on the `maki` global: `defer_fn` (a
+//! UI-scoped timer for "run this after N ms, not tied to my task") and
+//! `notify` (a one-line notice whose default any plugin can swap via
+//! `maki.set_notify_handler`).
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use maki_lua_macro::{lua_class, lua_fn, lua_table};
+use mlua::{Function, Lua, RegistryKey, Result as LuaResult, Table, Value};
+
+use crate::api::util::command::{UiAction, ui_send};
+use crate::runtime::{DeferQueue, DeferredCallback};
+
+/// The one `maki.notify` override for the whole process. `create_maki_global`
+/// runs per plugin load, so an override stored on the `maki` table itself would
+/// only ever reach the plugin that installed it. The owner's name rides along
+/// so [`clear_notify_handler`] can hand the slot back when that plugin is
+/// unloaded, instead of leaving everyone calling into a dead env.
+#[derive(Default)]
+pub(crate) struct NotifyHandler(pub(crate) Mutex<Option<(Arc<str>, RegistryKey)>>);
+
+/// Run {callback} after {ms} milliseconds, on the Lua thread and outside
+/// any task scope. The timer does not hang off the caller's cancel token
+/// or the 60 second `async.run` deadline, so the callback still fires
+/// once the tool call that scheduled it is over. That is what a toast
+/// needs to dismiss itself, and the difference from `maki.async.sleep`.
+///
+/// You get back a handle. Its `:stop()` cancels a callback that has not
+/// fired yet, which is how you debounce: schedule, then stop and
+/// reschedule on every new event. An error raised by the callback is
+/// logged and dropped, since nobody is waiting for a result.
+///
+/// @param callback function Called with no arguments.
+/// @param ms integer Delay in milliseconds. Zero fires on the next tick.
+/// @return (maki.Timer) Handle with `:stop()` to cancel before it fires.
+/// @example
+/// -- A toast that dismisses itself 4 seconds later:
+/// local buf = maki.ui.buf({ scratch = true })
+/// buf:line("copied!")
+/// local win = maki.ui.open_win(buf, { split = "right", width = 20, height = 3 })
+/// maki.defer_fn(function() win:close() end, 4000)
+///
+/// -- Repaint only after the user has stopped typing for half a second:
+/// local pending
+/// local function repaint_soon()
+///   if pending then
+///     pending:stop()
+///   end
+///   pending = maki.defer_fn(repaint, 500)
+/// end
+#[lua_fn]
+fn defer_fn(lua: &Lua, #[ctx] plugin: Arc<str>, callback: Function, ms: u64) -> LuaResult<Timer> {
+    let queue = lua
+        .app_data_ref::<DeferQueue>()
+        .ok_or_else(|| mlua::Error::runtime("defer queue not initialized"))?;
+    let func = lua.create_registry_value(callback)?;
+    let cancel = Arc::new(AtomicBool::new(false));
+    if let Err(rejected) = queue.push(DeferredCallback {
+        func,
+        delay: Duration::from_millis(ms),
+        plugin,
+        cancel: Arc::clone(&cancel),
+    }) {
+        // Reclaim the registry slot, the runtime never got the callback.
+        let _ = lua.remove_registry_value(rejected.func);
+        return Err(mlua::Error::runtime("defer queue closed"));
+    }
+    Ok(Timer { cancel })
+}
+
+/// Handle returned by `maki.defer_fn`. The runtime reads the flag once the
+/// timer goes off, so flipping it before then skips the callback entirely.
+pub(crate) struct Timer {
+    cancel: Arc<AtomicBool>,
+}
+
+/// Cancel the pending callback. Safe to call more than once, and does
+/// nothing once the callback has already run.
+///
+/// @return
+/// @example
+/// local h = maki.defer_fn(function() rebuild() end, 300)
+/// h:stop()
+#[lua_fn]
+fn stop(_lua: &Lua, this: &Timer) -> LuaResult<()> {
+    this.cancel.store(true, Ordering::Release);
+    Ok(())
+}
+
+lua_class! {
+    /// Handle returned by `maki.defer_fn`. Its `:stop()` cancels the
+    /// callback before it fires, which is what debouncing is built on.
+    "maki.Timer" => Timer, TIMER_DOCS [stop]
+}
+
+/// Show a one line notice. By default it goes to `maki.ui.flash`, with
+/// `{opts.title}` in front of the message when you pass one. A run with
+/// no UI, such as `maki -p` or the sdk, logs the notice instead of
+/// dropping it.
+///
+/// There is one handler for the whole process. Once a plugin calls
+/// `maki.set_notify_handler`, notices from every plugin go through it.
+/// That is how a UI plugin turns flashes into stacked toasts without
+/// any of the callers knowing about it.
+///
+/// {level} reaches the handler untouched, and the default ignores it.
+///
+/// @param msg string Notice text.
+/// @param level string? Optional. Severity name such as "info", "warn" or "error".
+/// @param opts table? Optional. `title` (string) labels the notice. Free form otherwise.
+/// @return
+/// @example
+/// maki.notify("saved!")
+/// maki.notify("build failed", "error", { title = "make" })
+#[lua_fn]
+fn notify(
+    lua: &Lua,
+    #[ctx] tx: Option<flume::Sender<UiAction>>,
+    #[ctx] plugin: Arc<str>,
+    msg: String,
+    level: Option<String>,
+    opts: Option<Table>,
+) -> LuaResult<()> {
+    let title = match &opts {
+        Some(t) => t.get::<Option<String>>("title")?,
+        None => None,
+    };
+    let handler_fn = lua.app_data_ref::<NotifyHandler>().and_then(|slot| {
+        let guard = locked(&slot);
+        let (_, key) = guard.as_ref()?;
+        lua.registry_value::<Function>(key).ok()
+    });
+    if let Some(func) = handler_fn {
+        // A broken override must not swallow the message, so fall through.
+        match func.call::<()>((msg.clone(), level.clone(), opts)) {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                tracing::warn!(error = %e, "maki.notify handler failed; falling through to flash");
+            }
+        }
+    }
+    let text = match title {
+        Some(title) => format!("{title}: {msg}"),
+        None => msg,
+    };
+    if ui_send(tx.as_ref(), UiAction::Flash(text.clone())).is_err() {
+        tracing::info!(plugin = %plugin, level = level.as_deref(), "{text}");
+    }
+    Ok(())
+}
+
+/// Install the handler that every `maki.notify` call in the process goes
+/// through, in place of the default flash. Pass `nil` to put the default
+/// back.
+///
+/// The handler runs on the Lua thread, so keep it short and hand real
+/// work to `maki.async.run`. If it raises an error, the error is logged
+/// and the notice falls back to `maki.ui.flash`, so the user still sees
+/// it. Unloading the plugin that installed the handler also restores the
+/// default.
+///
+/// @param handler function|nil Handler `function(msg, level?, opts?)`, or nil.
+/// @return
+/// @example
+/// local Toast = require("maki.toast")
+/// maki.set_notify_handler(function(msg, level, opts)
+///   Toast.show(msg, { title = opts and opts.title, level = level })
+/// end)
+#[lua_fn]
+fn set_notify_handler(lua: &Lua, #[ctx] plugin: Arc<str>, handler: Value) -> LuaResult<()> {
+    install_notify_handler(lua, plugin, handler)
+}
+
+/// Install a `maki.notify` override into the shared slot. Reached both by
+/// `set_notify_handler` and by the `maki.notify = fn` sugar that the `maki`
+/// global's `__newindex` routes here.
+pub(crate) fn install_notify_handler(lua: &Lua, plugin: Arc<str>, handler: Value) -> LuaResult<()> {
+    // Validate the argument before touching the slot: a wrong-typed
+    // handler must not silently clear a previously installed one.
+    let new_key = match handler {
+        Value::Nil => None,
+        Value::Function(f) => Some((plugin, lua.create_registry_value(f)?)),
+        _ => {
+            return Err(mlua::Error::runtime(
+                "set_notify_handler expects a function or nil",
+            ));
+        }
+    };
+    let slot = lua
+        .app_data_ref::<NotifyHandler>()
+        .ok_or_else(|| mlua::Error::runtime("notify handler slot not initialized"))?;
+    let old = std::mem::replace(&mut *locked(&slot), new_key);
+    if let Some((_, key)) = old {
+        let _ = lua.remove_registry_value(key);
+    }
+    Ok(())
+}
+
+fn locked(slot: &NotifyHandler) -> std::sync::MutexGuard<'_, Option<(Arc<str>, RegistryKey)>> {
+    slot.0.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Hand the slot back when {plugin} is unloaded. Its handler closes over an
+/// env that is going away, and nobody else knows to clean up after it.
+pub(crate) fn clear_notify_handler(lua: &Lua, plugin: &str) {
+    let Some(slot) = lua.app_data_ref::<NotifyHandler>() else {
+        return;
+    };
+    if let Some((_, key)) = locked(&slot).take_if(|(owner, _)| &**owner == plugin) {
+        let _ = lua.remove_registry_value(key);
+    }
+}
+
+lua_table! {
+    extend "maki" => pub(crate) fn add_top_methods(
+        plugin: Arc<str>,
+    ), DOCS [
+        defer_fn(plugin), manual notify, set_notify_handler(plugin),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    use super::*;
+
+    const BY_FUNCTION: &str = "maki.set_notify_handler(function(msg) seen = msg end)";
+    const BY_ASSIGNMENT: &str = "maki.notify = function(msg) seen = msg end";
+
+    /// Builds one plugin's `maki` table under the global {plugin}, wired the
+    /// way `create_maki_global` wires it: `notify` on the metatable's
+    /// `__index` so `maki.notify = fn` hits `__newindex` and lands in the
+    /// shared slot instead of shadowing it.
+    fn install(lua: &Lua, tx: Option<flume::Sender<UiAction>>, plugin: &str) {
+        if lua.app_data_ref::<NotifyHandler>().is_none() {
+            lua.set_app_data(NotifyHandler::default());
+        }
+        let maki = lua.create_table().unwrap();
+        let owner: Arc<str> = Arc::from(plugin);
+        add_top_methods(&maki, lua, Arc::clone(&owner)).unwrap();
+        let index = lua.create_table().unwrap();
+        notify__register(&index, lua, tx, Arc::clone(&owner)).unwrap();
+        let router = lua
+            .create_function(
+                move |lua, (t, k, v): (Table, String, Value)| match k.as_str() {
+                    "notify" => install_notify_handler(lua, Arc::clone(&owner), v),
+                    _ => t.raw_set(k, v),
+                },
+            )
+            .unwrap();
+        let meta = lua.create_table().unwrap();
+        meta.set("__index", index).unwrap();
+        meta.set("__newindex", router).unwrap();
+        maki.set_metatable(Some(meta)).unwrap();
+        lua.globals().set(plugin, maki).unwrap();
+    }
+
+    fn flashed(rx: &flume::Receiver<UiAction>) -> String {
+        match rx.try_recv().expect("a flash") {
+            UiAction::Flash(msg) => msg,
+            _ => panic!("expected Flash"),
+        }
+    }
+
+    #[test_case("" ; "no handler installed")]
+    #[test_case("maki.set_notify_handler(function() end) maki.set_notify_handler(nil)" ; "handler removed again")]
+    fn notify_falls_back_to_flash(prelude: &str) {
+        let lua = Lua::new();
+        let (tx, rx) = flume::unbounded();
+        install(&lua, Some(tx), "maki");
+        lua.load(format!(r#"{prelude} maki.notify("hi")"#))
+            .exec()
+            .unwrap();
+        assert_eq!(flashed(&rx), "hi");
+    }
+
+    #[test]
+    fn notify_title_labels_the_flash() {
+        let lua = Lua::new();
+        let (tx, rx) = flume::unbounded();
+        install(&lua, Some(tx), "maki");
+        lua.load(r#"maki.notify("hi", nil, { title = "make" })"#)
+            .exec()
+            .unwrap();
+        assert_eq!(flashed(&rx), "make: hi");
+    }
+
+    /// Headless runs (`maki -p`, sdk) have no UI to flash to, and a plugin
+    /// should not have to care.
+    #[test]
+    fn notify_without_a_ui_is_not_an_error() {
+        let lua = Lua::new();
+        install(&lua, None, "maki");
+        lua.load(r#"maki.notify("hi", "warn")"#).exec().unwrap();
+    }
+
+    /// Both spellings of "override notify" have to reach notify calls made
+    /// through *any* plugin's `maki`, not just the installer's. That is the
+    /// whole point of a shared slot.
+    #[test_case(BY_FUNCTION ; "set_notify_handler")]
+    #[test_case(BY_ASSIGNMENT ; "assignment")]
+    fn override_reroutes_every_plugins_notify(install_handler: &str) {
+        let lua = Lua::new();
+        let (tx, _rx) = flume::unbounded();
+        install(&lua, Some(tx.clone()), "maki");
+        install(&lua, Some(tx), "maki_b");
+
+        let seen: String = lua
+            .load(format!(
+                r#"
+                seen = ""
+                {install_handler}
+                maki_b.notify("from the other plugin")
+                return seen
+            "#
+            ))
+            .eval()
+            .unwrap();
+        assert_eq!(seen, "from the other plugin");
+    }
+
+    /// The handler closes over an env that dies with its plugin, so unloading
+    /// has to hand the slot back rather than leave everyone calling into it.
+    #[test]
+    fn unloading_the_installer_restores_the_default() {
+        let lua = Lua::new();
+        let (tx, rx) = flume::unbounded();
+        install(&lua, Some(tx.clone()), "maki");
+        install(&lua, Some(tx), "maki_b");
+        lua.load(r#"seen = "" maki_b.set_notify_handler(function(msg) seen = msg end)"#)
+            .exec()
+            .unwrap();
+
+        clear_notify_handler(&lua, "maki");
+        lua.load(r#"maki.notify("still routed")"#).exec().unwrap();
+        assert_eq!(lua.globals().get::<String>("seen").unwrap(), "still routed");
+        assert!(rx.try_recv().is_err(), "the handler took it, not the flash");
+
+        clear_notify_handler(&lua, "maki_b");
+        lua.load(r#"maki.notify("back to flash")"#).exec().unwrap();
+        assert_eq!(flashed(&rx), "back to flash");
+    }
+
+    #[test]
+    fn notify_assignment_rejects_non_function() {
+        let lua = Lua::new();
+        let (tx, _rx) = flume::unbounded();
+        install(&lua, Some(tx), "maki");
+        let err = lua
+            .load(r#"maki.notify = 42"#)
+            .exec()
+            .expect_err("assigning a non-function to maki.notify must fail");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("function or nil"),
+            "expected type error, got: {msg}"
+        );
+    }
+
+    /// The sleep-and-dispatch half lives in the runtime, so this only pins
+    /// the contract between the handle and the flag the runtime reads.
+    #[test]
+    fn defer_handle_stop_marks_cancel_flag() {
+        let lua = Lua::new();
+        lua.set_app_data(DeferQueue::new());
+        install(&lua, None, "maki");
+        lua.load(r#"H = maki.defer_fn(function() end, 5000)"#)
+            .exec()
+            .unwrap();
+        let cancel = {
+            let queue = lua.app_data_ref::<DeferQueue>().unwrap();
+            let cb = queue.rx.try_recv().expect("callback queued");
+            Arc::clone(&cb.cancel)
+        };
+        assert!(!cancel.load(Ordering::Acquire));
+        lua.load(r#"H:stop()"#).exec().unwrap();
+        assert!(cancel.load(Ordering::Acquire));
+    }
+}

--- a/maki-lua/src/api/ui/mod.rs
+++ b/maki-lua/src/api/ui/mod.rs
@@ -75,18 +75,36 @@ pub(crate) fn parse_footer(tbl: &Table) -> LuaResult<Vec<(String, String)>> {
         .collect()
 }
 
-/// Creates a new buffer for building UI content. The first buffer you
-/// create in a task becomes the "live" buffer, streamed to the UI while
-/// your tool runs. Create more buffers for secondary content like
-/// floating windows.
+/// Creates a new buffer for building UI content. The first buffer
+/// created in a task becomes the "live" buffer, streamed to the UI while
+/// the tool runs, which is what the tool's own output pane wants. A
+/// float that opens during a tool call would take that spot away, so
+/// create its buffer with `{ scratch = true }`. It matches nvim's
+/// `nvim_create_buf(false, true)`.
 ///
+/// @param opts table? Optional. `scratch` (boolean) keeps the buffer out of the live slot, default false.
 /// @return (Buf) Buffer handle.
 /// @example
-/// local buf = maki.ui.buf()
-/// buf:line("hello world")
+/// -- The tool's output pane:
+/// local out = maki.ui.buf()
+/// out:line("hello world")
+///
+/// -- A float raised during a tool call needs its own buffer:
+/// local toast = maki.ui.buf({ scratch = true })
+/// toast:line("copied!")
 #[lua_fn]
-fn buf(lua: &Lua) -> LuaResult<buf::BufHandle> {
-    Ok(with_task_bufs(lua, |store| store.create_live()))
+fn buf(lua: &Lua, opts: Option<Table>) -> LuaResult<buf::BufHandle> {
+    let scratch = match opts {
+        Some(t) => t.get::<Option<bool>>("scratch")?.unwrap_or(false),
+        None => false,
+    };
+    Ok(with_task_bufs(lua, |store| {
+        if scratch {
+            store.create()
+        } else {
+            store.create_live()
+        }
+    }))
 }
 
 /// Looks up a semantic color from the current theme. Use this to keep
@@ -356,6 +374,7 @@ async fn open_editor(
 ///   - focus (boolean): whether the window takes keyboard focus on open. Default true.
 ///   - visible (boolean): whether the window is initially visible. Default true.
 ///   - needs_input (boolean): whether the window means the session needs user input. Default false.
+///   - stack (boolean): offset the window past the other stacked windows sharing its anchor, in open order, with a one row gap. Closing one moves the rest up. Floating windows only. Default false.
 /// @return (Win) Window handle.
 /// @example
 /// local buf = maki.ui.buf()
@@ -398,6 +417,7 @@ fn open_win(
     let order: u16 = opts.get("order").unwrap_or(50);
     let visible: bool = opts.get("visible").unwrap_or(true);
     let needs_input: bool = opts.get("needs_input").unwrap_or(false);
+    let stack: bool = opts.get("stack").unwrap_or(false);
 
     let config = FloatConfig {
         width,
@@ -417,6 +437,7 @@ fn open_win(
         order,
         visible,
         needs_input,
+        stack,
     };
 
     let (term_cols, term_rows) = crossterm::terminal::size().unwrap_or((80, 24));

--- a/maki-lua/src/api/ui/win.rs
+++ b/maki-lua/src/api/ui/win.rs
@@ -226,6 +226,10 @@ fn set_config(_lua: &Lua, this: &WinHandle, opts: Table) -> LuaResult<()> {
     }
     patch.width = try_parse_dimension(&opts, "width");
     patch.height = try_parse_dimension(&opts, "height");
+    // A missing key leaves the window where it is. Lua has no way to say
+    // "clear this back to the centre", since a table cannot hold a nil.
+    patch.row = opts.get::<Option<i16>>("row")?.map(Some);
+    patch.col = opts.get::<Option<i16>>("col")?.map(Some);
     this.send(WinCommand::SetConfig(patch));
     Ok(())
 }

--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -312,6 +312,9 @@ pub struct FloatConfig {
     pub order: u16,
     pub visible: bool,
     pub needs_input: bool,
+    /// Opt in to corner stacking: the UI offsets this window past the other
+    /// stacked windows sharing its anchor. Open time only, so no patch field.
+    pub stack: bool,
 }
 
 impl Default for FloatConfig {
@@ -334,6 +337,7 @@ impl Default for FloatConfig {
             order: 50,
             visible: true,
             needs_input: false,
+            stack: false,
         }
     }
 }

--- a/maki-lua/src/docs.rs
+++ b/maki-lua/src/docs.rs
@@ -76,6 +76,8 @@ pub fn api_docs() -> Vec<&'static ModuleDoc> {
         &api::model::DOCS,
         &api::net::DOCS,
         &api::session::DOCS,
+        &api::top::DOCS,
+        &api::top::TIMER_DOCS,
         &api::task::DOCS,
         &api::text::DOCS,
         &api::treesitter::DOCS,
@@ -115,10 +117,19 @@ mod tests {
     }
 
     fn table_keys(table: &Table) -> BTreeSet<String> {
-        table
+        let mut keys: BTreeSet<String> = table
             .pairs::<String, Value>()
             .map(|pair| pair.unwrap().0)
-            .collect()
+            .collect();
+        // `maki.notify` is stashed in the `__index` table (see
+        // `create_maki_global`), so the drift check has to see through the
+        // metatable to consider it registered.
+        if let Some(mt) = table.metatable()
+            && let Ok(idx) = mt.get::<Table>("__index")
+        {
+            keys.extend(idx.pairs::<String, Value>().map(|p| p.unwrap().0));
+        }
+        keys
     }
 
     /// Docs and registration live side by side; this test keeps them equal so

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -1597,6 +1597,69 @@ impl SpawnQueue {
     }
 }
 
+/// Fire-and-forget callback queued from Lua. Runs on the Lua thread's
+/// executor after `delay`, outside any TaskScope: no cancel token, no
+/// script deadline. Meant for UI intent that must outlive the caller
+/// (a toast dismissing itself, a debounced repaint).
+///
+/// `cancel` is what the `Timer` handed back to Lua flips, and what
+/// [`DeferQueue::cancel_plugin`] flips on unload.
+pub(crate) struct DeferredCallback {
+    pub func: RegistryKey,
+    pub delay: Duration,
+    pub plugin: Arc<str>,
+    pub cancel: Arc<AtomicBool>,
+}
+
+pub(crate) struct DeferQueue {
+    tx: flume::Sender<DeferredCallback>,
+    pub(crate) rx: flume::Receiver<DeferredCallback>,
+    /// Timers that have not fired yet, by owner. A sleeping timer holds no
+    /// [`GateGuard`], so [`drain_barrier`] walks straight past it and a reload
+    /// would leave the callback to wake up against a torn down env. Cancelling
+    /// the doomed plugin's timers in [`LuaRuntime::clear_plugin`] closes that
+    /// window: whatever is left is either cancelled or already gated.
+    timers: Mutex<Vec<(Arc<str>, Arc<AtomicBool>)>>,
+}
+
+impl DeferQueue {
+    pub(crate) fn new() -> Self {
+        let (tx, rx) = flume::unbounded();
+        Self {
+            tx,
+            rx,
+            timers: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn locked(&self) -> std::sync::MutexGuard<'_, Vec<(Arc<str>, Arc<AtomicBool>)>> {
+        self.timers.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Hands the callback to the dispatcher and remembers it as pending, so
+    /// the two can never drift apart.
+    pub(crate) fn push(&self, cb: DeferredCallback) -> Result<(), DeferredCallback> {
+        let pending = (Arc::clone(&cb.plugin), Arc::clone(&cb.cancel));
+        self.tx.try_send(cb).map_err(|e| e.into_inner())?;
+        self.locked().push(pending);
+        Ok(())
+    }
+
+    fn forget(&self, cancel: &Arc<AtomicBool>) {
+        self.locked().retain(|(_, c)| !Arc::ptr_eq(c, cancel));
+    }
+
+    fn cancel_plugin(&self, plugin: &str) {
+        self.locked().retain(|(owner, cancel)| {
+            let doomed = &**owner == plugin;
+            if doomed {
+                cancel.store(true, Ordering::Release);
+            }
+            !doomed
+        });
+    }
+}
+
 /// Ends `fut` once nobody waits for its reply any more: at `deadline`, or
 /// [`CANCEL_ABANDON_AFTER`] past a cancel. The watchdog cannot do this on
 /// its own, because a task parked in an await runs no Lua to interrupt and
@@ -1645,6 +1708,52 @@ async fn run_work_fn(
     let func: Function = lua.registry_value(work_fn)?;
     let fut = lua.create_thread(func)?.into_async::<LuaValue>(())?;
     until_abandoned(fut, handle).await
+}
+
+/// Fire a `maki.defer_fn` callback: sleep, then run the Function once.
+///
+/// The detached scope matters twice over. It keeps the callback from
+/// inheriting whatever `TaskHandle` the previous task left in app_data, which
+/// a cancelled parent would otherwise use to shoot it at its first safepoint,
+/// and it pumps job events so a `maki.system` started in the callback still
+/// gets its `on_stdout` and `on_exit`.
+///
+/// The gate guard comes after the sleep: pending timers should pile up
+/// cheaply, but the bodies compete for the `MAX_INFLIGHT_TOOLS` budget so
+/// `for i=1,10000 do maki.defer_fn(f, 0) end` can't run 10k coroutines at
+/// once. Errors are logged and dropped, nobody is awaiting a result.
+fn spawn_deferred_callback(
+    lua: &Lua,
+    ex: &Rc<smol::LocalExecutor<'_>>,
+    gate: &Rc<InflightGate>,
+    cb: DeferredCallback,
+) {
+    let lua = lua.clone();
+    let gate = Rc::clone(gate);
+    ex.spawn(async move {
+        smol::Timer::after(cb.delay).await;
+        let _guard = gate.acquire().await;
+        // Only now stop advertising the timer as pending: up to here a
+        // `clear_plugin` can still flip the flag we read below, and from here
+        // on the drain barrier waits for the guard instead.
+        if let Some(queue) = lua.app_data_ref::<DeferQueue>() {
+            queue.forget(&cb.cancel);
+        }
+        if cb.cancel.load(Ordering::Acquire) {
+            let _ = lua.remove_registry_value(cb.func);
+            return;
+        }
+        let run = async {
+            let func: Function = lua.registry_value(&cb.func)?;
+            let thread = lua.create_thread(func)?;
+            thread.into_async::<()>(())?.await
+        };
+        if let Err(e) = run_detached(&lua, run).await {
+            tracing::warn!(plugin = %cb.plugin, error = %strip_traceback(&e), "defer_fn callback failed");
+        }
+        let _ = lua.remove_registry_value(cb.func);
+    })
+    .detach();
 }
 
 fn spawn_async_task(
@@ -1805,6 +1914,8 @@ impl LuaRuntime {
         lua.set_app_data(CommandHandlerMap::new());
         lua.set_app_data(JobStore::new());
         lua.set_app_data(SpawnQueue::new());
+        lua.set_app_data(DeferQueue::new());
+        lua.set_app_data(crate::api::top::NotifyHandler::default());
         lua.set_app_data(command_writer);
         lua.set_app_data(PromptHintCallbacks::default());
         lua.set_app_data(PluginOptionSpecs::default());
@@ -2313,6 +2424,10 @@ impl LuaRuntime {
     fn clear_plugin(&mut self, plugin: &str) {
         self.registry.clear_plugin(plugin);
         self.plugin_rules.remove(plugin);
+        if let Some(queue) = self.lua.app_data_ref::<DeferQueue>() {
+            queue.cancel_plugin(plugin);
+        }
+        crate::api::top::clear_notify_handler(&self.lua, plugin);
         let revision_guard = self.drop_plugin_keys(plugin);
         with_packs(&self.lua, |packs| packs.active.remove(plugin));
         if let Some(mut store) = self.lua.app_data_mut::<KeymapStore>() {
@@ -3067,6 +3182,12 @@ pub fn spawn(
                 .expect("spawn queue installed at init")
                 .rx
                 .clone();
+            let defer_rx = rt
+                .lua
+                .app_data_ref::<DeferQueue>()
+                .expect("defer queue installed at init")
+                .rx
+                .clone();
 
             let mut codegen_armed = false;
 
@@ -3074,6 +3195,9 @@ pub fn spawn(
                 loop {
                     while let Ok(task) = spawn_rx.try_recv() {
                         spawn_async_task(&rt.lua, &ex, &gate, task);
+                    }
+                    while let Ok(cb) = defer_rx.try_recv() {
+                        spawn_deferred_callback(&rt.lua, &ex, &gate, cb);
                     }
                     // Nothing to serve, so spend the lull on native codegen.
                     // One chunk per pass with a yield in between, so no request
@@ -3090,7 +3214,9 @@ pub fn spawn(
                     // Biased: user-initiated requests (commands, keybinds) jump
                     // ahead of bulk work like session restores so the UI stays
                     // snappy, and queued `maki.async.run` tasks jump ahead of
-                    // plain requests.
+                    // plain requests. `defer_rx` is selected on so a queued
+                    // `maki.defer_fn` wakes the loop instead of stalling
+                    // behind the next unrelated request.
                     let next = smol::future::or(
                         async { prio_rx.recv_async().await.map(Some) },
                         smol::future::or(
@@ -3099,7 +3225,14 @@ pub fn spawn(
                                 spawn_async_task(&rt.lua, &ex, &gate, task);
                                 Ok(None)
                             },
-                            async { rx.recv_async().await.map(Some) },
+                            smol::future::or(
+                                async {
+                                    let cb = defer_rx.recv_async().await?;
+                                    spawn_deferred_callback(&rt.lua, &ex, &gate, cb);
+                                    Ok(None)
+                                },
+                                async { rx.recv_async().await.map(Some) },
+                            ),
                         ),
                     )
                     .await;
@@ -3636,6 +3769,36 @@ mod tests {
         assert_eq!(
             with_live_ctx(&lua, |ctx| ctx.tool_use_id.clone()).unwrap(),
             "tool_abc"
+        );
+    }
+
+    #[test]
+    fn defer_queue_cancels_only_the_doomed_plugins_timers() {
+        let lua = Lua::new();
+        let queue = DeferQueue::new();
+        let timer = |plugin: &str| {
+            let cancel = Arc::new(AtomicBool::new(false));
+            let queued = queue.push(DeferredCallback {
+                func: lua.create_registry_value(true).unwrap(),
+                delay: Duration::ZERO,
+                plugin: Arc::from(plugin),
+                cancel: Arc::clone(&cancel),
+            });
+            assert!(queued.is_ok(), "the queue is unbounded");
+            cancel
+        };
+        let doomed = timer("memory");
+        let bystander = timer("other");
+
+        queue.cancel_plugin("memory");
+        assert!(doomed.load(Ordering::Acquire));
+        assert!(!bystander.load(Ordering::Acquire));
+
+        queue.forget(&bystander);
+        queue.cancel_plugin("other");
+        assert!(
+            !bystander.load(Ordering::Acquire),
+            "a timer past the gate is running, not pending"
         );
     }
 

--- a/maki-ui/src/components/lua_float.rs
+++ b/maki-ui/src/components/lua_float.rs
@@ -19,6 +19,9 @@ use crate::components::{
 use crate::repaint::{Cadence, Dirty};
 use crate::theme;
 
+/// Blank rows kept between two windows of the same stack.
+const STACK_GAP: u16 = 1;
+
 /// A top band, a bottom band, and the scrollable middle. When the window is too
 /// short for both bands the bottom wins, so footers like keybind hints survive
 /// even when the header gets squeezed out.
@@ -301,6 +304,32 @@ impl FloatManager {
         true
     }
 
+    /// A stacked window sits below (or above, for the south anchors) every
+    /// stacked window opened before it in the same corner, so its offset can
+    /// only be known here, where the whole list is in scope. Recomputing it
+    /// each frame is what makes survivors close the hole left by a window
+    /// that went away, with nothing to keep in sync.
+    fn stack_offset(&self, idx: usize, area: Rect) -> u16 {
+        let win = &self.windows[idx];
+        if !Self::stacks(win) {
+            return 0;
+        }
+        self.windows
+            .iter()
+            .filter(|w| Self::stacks(w) && w.config.anchor == win.config.anchor && w.id < win.id)
+            .fold(0, |acc, w| {
+                acc.saturating_add(w.config.height.resolve(area.height).min(area.height))
+                    .saturating_add(STACK_GAP)
+            })
+    }
+
+    /// Deliberately blind to `visible`: `view` paints every float whatever
+    /// that flag says, and a window that is drawn but left out of the stack
+    /// would land right on top of whoever took its slot.
+    fn stacks(win: &FloatWindow) -> bool {
+        win.config.stack && win.config.split == Split::None
+    }
+
     pub fn view(&mut self, frame: &mut Frame, area: Rect) -> Rect {
         let mut union = Rect::default();
 
@@ -308,7 +337,11 @@ impl FloatManager {
             if self.windows[idx].config.split != Split::None {
                 continue;
             }
-            let popup = resolve_rect(&self.windows[idx].config, area);
+            let popup = resolve_rect(
+                &self.windows[idx].config,
+                area,
+                self.stack_offset(idx, area),
+            );
             if popup.width == 0 || popup.height == 0 {
                 continue;
             }
@@ -542,7 +575,10 @@ fn hint_footer<K: AsRef<str>, V: AsRef<str>>(pairs: &[(K, V)]) -> Line<'static> 
     Line::from(spans)
 }
 
-fn resolve_rect(config: &FloatConfig, area: Rect) -> Rect {
+/// `stack_offset` slides the window along the anchor's vertical direction
+/// after `config.row` has been applied, so `row` stays the point the stack
+/// grows from.
+fn resolve_rect(config: &FloatConfig, area: Rect, stack_offset: u16) -> Rect {
     let w = config.width.resolve(area.width).min(area.width);
     let h = config.height.resolve(area.height).min(area.height);
 
@@ -575,6 +611,12 @@ fn resolve_rect(config: &FloatConfig, area: Rect) -> Rect {
             (x, y)
         }
     };
+
+    let y = match config.anchor {
+        Anchor::NW | Anchor::NE => y.saturating_add(stack_offset),
+        Anchor::SW | Anchor::SE => y.saturating_sub(stack_offset),
+    }
+    .clamp(area.y, area.y + area.height);
 
     let clamped_w = w.min(area.x + area.width - x);
     let clamped_h = h.min(area.y + area.height - y);
@@ -674,6 +716,7 @@ mod tests {
     const EXPECT_PASTE_TRUE: &str = "handle_paste should return true when focused";
     const EXPECT_PASTE_FALSE: &str = "handle_paste should return false with no focus";
     const PASTE_TEXT: &str = "hello";
+    const NO_STACK_OFFSET: u16 = 0;
 
     fn make_line(text: &str) -> SnapshotLine {
         SnapshotLine {
@@ -757,7 +800,7 @@ mod tests {
             height: Dimension::Percent(40),
             ..FloatConfig::default()
         };
-        let r = resolve_rect(&config, area);
+        let r = resolve_rect(&config, area, NO_STACK_OFFSET);
         assert_eq!(r.width, 100);
         assert_eq!(r.height, 40);
         assert_eq!(r.x, 50);
@@ -775,7 +818,7 @@ mod tests {
             anchor: Anchor::NW,
             ..FloatConfig::default()
         };
-        let r = resolve_rect(&config, area);
+        let r = resolve_rect(&config, area, NO_STACK_OFFSET);
         assert_eq!(r.x, 10);
         assert_eq!(r.y, 5);
         assert_eq!(r.width, 20);
@@ -793,7 +836,7 @@ mod tests {
             anchor: Anchor::SE,
             ..FloatConfig::default()
         };
-        let r = resolve_rect(&config, area);
+        let r = resolve_rect(&config, area, NO_STACK_OFFSET);
         assert_eq!(r.x, 80);
         assert_eq!(r.y, 40);
     }
@@ -806,7 +849,7 @@ mod tests {
             height: Dimension::Abs(50),
             ..FloatConfig::default()
         };
-        let r = resolve_rect(&config, area);
+        let r = resolve_rect(&config, area, NO_STACK_OFFSET);
         assert_eq!(r.width, 30);
         assert_eq!(r.height, 20);
     }
@@ -822,7 +865,7 @@ mod tests {
             anchor: Anchor::NE,
             ..FloatConfig::default()
         };
-        let r = resolve_rect(&config, area);
+        let r = resolve_rect(&config, area, NO_STACK_OFFSET);
         assert_eq!(r.x, 80);
         assert_eq!(r.y, 5);
     }
@@ -838,7 +881,7 @@ mod tests {
             anchor: Anchor::SW,
             ..FloatConfig::default()
         };
-        let r = resolve_rect(&config, area);
+        let r = resolve_rect(&config, area, NO_STACK_OFFSET);
         assert_eq!(r.x, 5);
         assert_eq!(r.y, 40);
     }
@@ -854,7 +897,7 @@ mod tests {
             anchor: Anchor::SE,
             ..FloatConfig::default()
         };
-        let r = resolve_rect(&config, area);
+        let r = resolve_rect(&config, area, NO_STACK_OFFSET);
         assert_eq!(r.x, 70);
         assert_eq!(r.y, 35);
     }
@@ -867,7 +910,7 @@ mod tests {
             height: Dimension::Abs(10),
             ..FloatConfig::default()
         };
-        let r = resolve_rect(&config, area);
+        let r = resolve_rect(&config, area, NO_STACK_OFFSET);
         assert_eq!(r.x, 40);
         assert_eq!(r.y, 20);
         assert!(r.x >= area.x && r.x + r.width <= area.x + area.width);
@@ -882,7 +925,7 @@ mod tests {
             height: Dimension::Abs(10),
             ..FloatConfig::default()
         };
-        let r = resolve_rect(&config, area);
+        let r = resolve_rect(&config, area, NO_STACK_OFFSET);
         assert_eq!(r.width, 0);
         assert_eq!(r.height, 0);
     }
@@ -898,9 +941,92 @@ mod tests {
             anchor: Anchor::NW,
             ..FloatConfig::default()
         };
-        let r = resolve_rect(&config, area);
+        let r = resolve_rect(&config, area, NO_STACK_OFFSET);
         assert_eq!(r.x, 10);
         assert_eq!(r.y, 0, "only col is set, so row falls back to 0");
+    }
+
+    const STACK_AREA: Rect = Rect::new(0, 0, 100, 50);
+    const STACK_ROW: i16 = 1;
+    const STACK_HEIGHT: u16 = 4;
+    const EXPECT_STACK_STEPS: &str =
+        "a stacked float must clear every earlier float in its corner, plus the gap";
+    const EXPECT_STACK_CLOSES_GAP: &str = "survivors must take over the closed float's slot";
+    const EXPECT_PLAIN_UNSTACKED: &str =
+        "a float without stack must neither move nor take up stack room";
+
+    fn stack_config(anchor: Anchor, stack: bool) -> FloatConfig {
+        FloatConfig {
+            width: Dimension::Abs(20),
+            height: Dimension::Abs(STACK_HEIGHT),
+            row: Some(STACK_ROW),
+            col: Some(0),
+            anchor,
+            stack,
+            ..FloatConfig::default()
+        }
+    }
+
+    fn open_float(mgr: &mut FloatManager, config: FloatConfig) -> u32 {
+        let (event_tx, cmd_rx, _event_rx, _cmd_tx) = make_channels();
+        mgr.open(make_buf(&["x"]), config, false, event_tx, cmd_rx);
+        mgr.next_id - 1
+    }
+
+    /// Rows the windows would be painted at this frame, keyed by id so the
+    /// zindex sort of `windows` cannot make the expectations drift.
+    fn rows_by_id(mgr: &FloatManager) -> Vec<(u32, u16)> {
+        let mut rows: Vec<(u32, u16)> = (0..mgr.windows.len())
+            .map(|idx| {
+                let win = &mgr.windows[idx];
+                let offset = mgr.stack_offset(idx, STACK_AREA);
+                (win.id, resolve_rect(&win.config, STACK_AREA, offset).y)
+            })
+            .collect();
+        rows.sort_by_key(|(id, _)| *id);
+        rows
+    }
+
+    #[test_case(Anchor::NE, [1, 6, 11] ; "ne_grows_downwards")]
+    #[test_case(Anchor::SE, [47, 42, 37] ; "se_grows_upwards")]
+    fn stacked_floats_offset_past_earlier_windows(anchor: Anchor, expected: [u16; 3]) {
+        let mut mgr = FloatManager::new();
+        for _ in 0..expected.len() {
+            open_float(&mut mgr, stack_config(anchor, true));
+        }
+
+        let rows: Vec<u16> = rows_by_id(&mgr).into_iter().map(|(_, y)| y).collect();
+        assert_eq!(rows, expected, "{EXPECT_STACK_STEPS}");
+    }
+
+    #[test]
+    fn closing_first_stacked_float_moves_survivors_up() {
+        let mut mgr = FloatManager::new();
+        let first = open_float(&mut mgr, stack_config(Anchor::NE, true));
+        let second = open_float(&mut mgr, stack_config(Anchor::NE, true));
+        let third = open_float(&mut mgr, stack_config(Anchor::NE, true));
+
+        mgr.remove_windows(|w| w.id == first);
+
+        assert_eq!(
+            rows_by_id(&mgr),
+            vec![(second, 1), (third, 6)],
+            "{EXPECT_STACK_CLOSES_GAP}",
+        );
+    }
+
+    #[test]
+    fn plain_float_neither_shifts_nor_joins_the_stack() {
+        let mut mgr = FloatManager::new();
+        let first = open_float(&mut mgr, stack_config(Anchor::NE, true));
+        let plain = open_float(&mut mgr, stack_config(Anchor::NE, false));
+        let second = open_float(&mut mgr, stack_config(Anchor::NE, true));
+
+        assert_eq!(
+            rows_by_id(&mgr),
+            vec![(first, 1), (plain, 1), (second, 6)],
+            "{EXPECT_PLAIN_UNSTACKED}",
+        );
     }
 
     #[test_case(0, 5, 0, 10 => 0 ; "empty_content")]

--- a/plugins/lib/maki/list_picker.lua
+++ b/plugins/lib/maki/list_picker.lua
@@ -197,7 +197,10 @@ end
 -- Open a fuzzy-filter picker in a floating window and block until the user
 -- decides. {items} is a list of strings or { label, detail? } tables. {opts}:
 -- title, footer, cursor (initial index), submit_keys (extra submit keys
--- besides enter). Returns { type = "choice"|"delete", index } or
+-- besides enter), action_keys (keys that close the picker and report
+-- themselves, like { "R" } for a refresh binding. Use uppercase keys, since
+-- lowercase ones keep feeding the filter). Returns
+-- { type = "choice"|"delete", index }, { type = "key", key, index? } or
 -- { type = "close" }.
 function ListPicker.open(items, opts)
   opts = opts or {}
@@ -205,6 +208,12 @@ function ListPicker.open(items, opts)
   if opts.submit_keys then
     for _, k in ipairs(opts.submit_keys) do
       submit_keys[k] = true
+    end
+  end
+  local action_keys = {}
+  if opts.action_keys then
+    for _, k in ipairs(opts.action_keys) do
+      action_keys[k] = true
     end
   end
   local width
@@ -303,6 +312,13 @@ function ListPicker.open(items, opts)
           win:close()
           return { type = "choice", index = original_indices[cursor] }
         end
+      elseif action_keys[ev.key] then
+        win:close()
+        return {
+          type = "key",
+          key = ev.key,
+          index = #filtered > 0 and original_indices[cursor] or nil,
+        }
       else
         local result = input:handle_key(ev.key)
         if result == TextInput.Result.CHANGED then

--- a/plugins/lib/maki/toast.lua
+++ b/plugins/lib/maki/toast.lua
@@ -1,0 +1,56 @@
+-- Corner toast notifications built on floating windows. `maki.ui.flash` gives
+-- you one line in the status area. A toast stays up long enough to read, can
+-- carry a title, and stacks under the toasts already on screen.
+
+local Toast = {}
+
+local MAX_LINES = 5
+local MAX_WIDTH = 48
+local MIN_WIDTH = 20
+local DEFAULT_TIMEOUT_SECS = 4
+-- Above the default 50 every other float gets, so a picker opened after the
+-- toast doesn't bury it and callers don't have to time their notices.
+local ZINDEX = 200
+
+-- Show {text} as a toast, up to 5 lines of it. {opts}: title (string),
+-- timeout_secs (integer, default 4). Returns right away and the toast
+-- dismisses itself when the time is up.
+function Toast.show(text, opts)
+  opts = opts or {}
+  local lines = {}
+  local width = MIN_WIDTH
+  for line in tostring(text):gmatch("[^\n]+") do
+    if #lines == MAX_LINES then
+      break
+    end
+    lines[#lines + 1] = { { line, "item" } }
+    width = math.max(width, maki.ui.display_width(line) + 2)
+  end
+  if #lines == 0 then
+    return
+  end
+  width = math.min(width, MAX_WIDTH)
+
+  -- A live buffer would steal the output pane of whatever tool raised us.
+  local buf = maki.ui.buf({ scratch = true })
+  buf:set_lines(lines)
+  local win = maki.ui.open_win(buf, {
+    title = opts.title,
+    anchor = "NE",
+    stack = true,
+    col = 0,
+    width = width,
+    height = #lines + 2,
+    zindex = ZINDEX,
+    focus = false,
+  })
+
+  -- defer_fn and not async.sleep: the toast outlives the tool call that
+  -- raised it, so the timer must not hang off that call's cancel token.
+  local timeout_secs = math.max(0, tonumber(opts.timeout_secs) or DEFAULT_TIMEOUT_SECS)
+  maki.defer_fn(function()
+    win:close()
+  end, math.floor(timeout_secs * 1000))
+end
+
+return Toast

--- a/plugins/memory/init.lua
+++ b/plugins/memory/init.lua
@@ -1,8 +1,17 @@
 local ToolView = require("maki.tool_view")
 local helpers = require("memory_helpers")
 local ListPicker = require("maki.list_picker")
+local Toast = require("maki.toast")
 
 local WRITE_TOOLS = { "write", "edit", "multiedit", "edit_lines", "insert_lines" }
+
+-- A toast and not a flash, because this feedback has to stay readable while
+-- the picker is still covering the screen. Kept local on purpose: claiming the
+-- global `maki.notify` slot here would put a "memory" toast in front of every
+-- other plugin's notices too.
+local function notify(msg)
+  Toast.show(msg, { title = "memory" })
+end
 
 local function memories_path_suffix()
   local cwd = maki.uv.cwd()
@@ -301,10 +310,12 @@ maki.api.register_command({
         title = " Memory Files ",
         cursor = last_cursor,
         submit_keys = { "ctrl+o" },
+        action_keys = { "R" },
         footer = {
           { "Enter", "open" },
           { "Ctrl+O", "edit" },
           { "Ctrl+D", "delete" },
+          { "R", "refresh" },
         },
       })
 
@@ -326,14 +337,21 @@ maki.api.register_command({
         local item = items[event.index]
         local ok, err = maki.fs.rm(maki.fs.joinpath(dir, item.label))
         if ok then
-          maki.ui.flash("Deleted " .. item.label)
+          notify("Deleted " .. item.label)
           items = popup_build_items(dir)
           if #items == 0 then
             break
           end
         else
-          maki.ui.flash("Delete failed: " .. tostring(err))
+          notify("Delete failed: " .. tostring(err))
         end
+      elseif event.type == "key" and event.key == "R" then
+        items = popup_build_items(dir)
+        if #items == 0 then
+          notify("No memories yet")
+          break
+        end
+        notify(#items .. " memories loaded")
       else
         break
       end

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -121,6 +121,7 @@ The rules:
 | [`maki.model`](#maki-model) | The model behind the focused session. |
 | [`maki.net`](#maki-net) | HTTP client for fetching web content. |
 | [`maki.session`](#maki-session) | Host session primitives. |
+| [`maki.Timer`](#maki-Timer) | Handle returned by `maki.defer_fn`. |
 | [`maki.task`](#maki-task) | The subagents of the focused session and their transcripts. |
 | [`maki.text`](#maki-text) | Text transformation utilities. |
 | [`maki.treesitter`](#maki-treesitter) | Tree-sitter parsing and query API. |
@@ -207,6 +208,115 @@ Load an installed package that is not active.
 **Parameters:**
 
 - `{name}` (`string`) Package name.
+
+---
+
+### `maki.defer_fn()` {#maki-defer_fn}
+
+```lua
+maki.defer_fn({callback}, {ms})
+```
+
+Run {callback} after {ms} milliseconds, on the Lua thread and outside
+any task scope. The timer does not hang off the caller's cancel token
+or the 60 second `async.run` deadline, so the callback still fires
+once the tool call that scheduled it is over. That is what a toast
+needs to dismiss itself, and the difference from `maki.async.sleep`.
+
+You get back a handle. Its `:stop()` cancels a callback that has not
+fired yet, which is how you debounce: schedule, then stop and
+reschedule on every new event. An error raised by the callback is
+logged and dropped, since nobody is waiting for a result.
+
+**Parameters:**
+
+- `{callback}` (`function`) Called with no arguments.
+- `{ms}` (`integer`) Delay in milliseconds. Zero fires on the next tick.
+
+**Returns:** ([`maki.Timer`](#maki-Timer)) Handle with `:stop()` to cancel before it fires.
+
+**Example:**
+
+```lua
+-- A toast that dismisses itself 4 seconds later:
+local buf = maki.ui.buf({ scratch = true })
+buf:line("copied!")
+local win = maki.ui.open_win(buf, { split = "right", width = 20, height = 3 })
+maki.defer_fn(function() win:close() end, 4000)
+
+-- Repaint only after the user has stopped typing for half a second:
+local pending
+local function repaint_soon()
+  if pending then
+    pending:stop()
+  end
+  pending = maki.defer_fn(repaint, 500)
+end
+```
+
+---
+
+### `maki.notify()` {#maki-notify}
+
+```lua
+maki.notify({msg}, {level?}, {opts?})
+```
+
+Show a one line notice. By default it goes to `maki.ui.flash`, with
+`{opts.title}` in front of the message when you pass one. A run with
+no UI, such as `maki -p` or the sdk, logs the notice instead of
+dropping it.
+
+There is one handler for the whole process. Once a plugin calls
+`maki.set_notify_handler`, notices from every plugin go through it.
+That is how a UI plugin turns flashes into stacked toasts without
+any of the callers knowing about it.
+
+{level} reaches the handler untouched, and the default ignores it.
+
+**Parameters:**
+
+- `{msg}` (`string`) Notice text.
+- `{level?}` (`string?`) Optional. Severity name such as "info", "warn" or "error".
+- `{opts?}` (`table?`) Optional. `title` (string) labels the notice. Free form otherwise.
+
+**Example:**
+
+```lua
+maki.notify("saved!")
+maki.notify("build failed", "error", { title = "make" })
+```
+
+---
+
+### `maki.set_notify_handler()` {#maki-set_notify_handler}
+
+```lua
+maki.set_notify_handler({handler})
+```
+
+Install the handler that every `maki.notify` call in the process goes
+through, in place of the default flash. Pass `nil` to put the default
+back.
+
+The handler runs on the Lua thread, so keep it short and hand real
+work to `maki.async.run`. If it raises an error, the error is logged
+and the notice falls back to `maki.ui.flash`, so the user still sees
+it. Unloading the plugin that installed the handler also restores the
+default.
+
+**Parameters:**
+
+- `{handler}` (`function|nil`) Handler `function(msg, level?, opts?)`, or nil.
+
+**Example:**
+
+```lua
+local Toast = require("maki.toast")
+maki.set_notify_handler(function(msg, level, opts)
+  Toast.show(msg, { title = opts and opts.title, level = level })
+end)
+```
 
 
 ## maki.pack {#maki-pack}
@@ -1235,6 +1345,34 @@ callback.
 maki.async.run(function()
   local data = expensive_fetch()
   process(data)
+end)
+```
+
+---
+
+### `maki.async.sleep()` {#maki-async-sleep}
+
+```lua
+maki.async.sleep({ms})
+```
+
+Suspend the calling task for {ms} milliseconds. The plugin thread is
+never blocked, so other tasks and the UI keep running, and a cancel
+still lands while you sleep.
+
+For a timer that has to outlive the tool call that started it, such
+as a toast dismissing itself, use `maki.defer_fn`.
+
+**Parameters:**
+
+- `{ms}` (`integer`) Milliseconds to sleep.
+
+**Example:**
+
+```lua
+maki.async.run(function()
+  maki.async.sleep(4000)
+  win:close()
 end)
 ```
 
@@ -3379,6 +3517,30 @@ local _, err = maki.session.set_title({ id = id, title = "refactor" })
 ```
 
 
+## maki.Timer {#maki-Timer}
+
+Handle returned by `maki.defer_fn`. Its `:stop()` cancels the
+callback before it fires, which is what debouncing is built on.
+
+---
+
+### `Timer:stop()` {#Timer-stop}
+
+```lua
+Timer:stop()
+```
+
+Cancel the pending callback. Safe to call more than once, and does
+nothing once the callback has already run.
+
+**Example:**
+
+```lua
+local h = maki.defer_fn(function() rebuild() end, 300)
+h:stop()
+```
+
+
 ## maki.task {#maki-task}
 
 The subagents of the focused session and their transcripts. Tasks are
@@ -4634,21 +4796,32 @@ local win = maki.ui.open_win(buf, { title = "Greeting", width = "50%", height = 
 ### `maki.ui.buf()` {#maki-ui-buf}
 
 ```lua
-maki.ui.buf()
+maki.ui.buf({opts?})
 ```
 
-Creates a new buffer for building UI content. The first buffer you
-create in a task becomes the "live" buffer, streamed to the UI while
-your tool runs. Create more buffers for secondary content like
-floating windows.
+Creates a new buffer for building UI content. The first buffer
+created in a task becomes the "live" buffer, streamed to the UI while
+the tool runs, which is what the tool's own output pane wants. A
+float that opens during a tool call would take that spot away, so
+create its buffer with `{ scratch = true }`. It matches nvim's
+`nvim_create_buf(false, true)`.
+
+**Parameters:**
+
+- `{opts?}` (`table?`) Optional. `scratch` (boolean) keeps the buffer out of the live slot, default false.
 
 **Returns:** ([`Buf`](#maki-ui-Buf)) Buffer handle.
 
 **Example:**
 
 ```lua
-local buf = maki.ui.buf()
-buf:line("hello world")
+-- The tool's output pane:
+local out = maki.ui.buf()
+out:line("hello world")
+
+-- A float raised during a tool call needs its own buffer:
+local toast = maki.ui.buf({ scratch = true })
+toast:line("copied!")
 ```
 
 ---
@@ -4947,6 +5120,7 @@ and close the window when you are done.
   - `focus` (`boolean`) whether the window takes keyboard focus on open. Default true.
   - `visible` (`boolean`) whether the window is initially visible. Default true.
   - `needs_input` (`boolean`) whether the window means the session needs user input. Default false.
+  - `stack` (`boolean`) offset the window past the other stacked windows sharing its anchor, in open order, with a one row gap. Closing one moves the rest up. Floating windows only. Default false.
 
 **Returns:** ([`Win`](#maki-ui-Win)) Window handle.
 
@@ -5646,7 +5820,10 @@ function ListPicker.render_header(win, lines, input, prefix, inner)
 -- Open a fuzzy-filter picker in a floating window and block until the user
 -- decides. {items} is a list of strings or { label, detail? } tables. {opts}:
 -- title, footer, cursor (initial index), submit_keys (extra submit keys
--- besides enter). Returns { type = "choice"|"delete", index } or
+-- besides enter), action_keys (keys that close the picker and report
+-- themselves, like { "R" } for a refresh binding. Use uppercase keys, since
+-- lowercase ones keep feeding the filter). Returns
+-- { type = "choice"|"delete", index }, { type = "key", key, index? } or
 -- { type = "close" }.
 function ListPicker.open(items, opts)
 ListPicker.split_words = split_words
@@ -5821,6 +5998,19 @@ function TextInput:handle_key(key)
 -- Wrap lines to {width} with {prefix} before the first row. Returns
 -- { lines = styled lines, cursor_row = 1-based row holding the cursor }.
 function TextInput:render(prefix, prefix_width, width)
+```
+
+### `require("maki.toast")`
+
+```lua
+-- Corner toast notifications built on floating windows. `maki.ui.flash` gives
+-- you one line in the status area. A toast stays up long enough to read, can
+-- carry a title, and stacks under the toasts already on screen.
+
+-- Show {text} as a toast, up to 5 lines of it. {opts}: title (string),
+-- timeout_secs (integer, default 4). Returns right away and the toast
+-- dismisses itself when the time is up.
+function Toast.show(text, opts)
 ```
 
 ### `require("maki.tool_view")`


### PR DESCRIPTION
Reworked per review: reusable UI as shared Lua over the existing float primitives, not exported native components.

- `maki/toast.lua`: corner notifications — NE-anchored floats with a title and a few lines, stacking downwards and restacking as each dismisses itself
- `maki/list_picker.lua` grows `action_keys`: keys that close the picker and report themselves (with the cursor's item index), for act-and-reopen bindings like R-to-refresh; uppercase by convention since lowercase feeds the filter
- `maki.async.sleep(ms)`: the one new primitive both need — suspend the calling task without blocking the plugin thread

The earlier native picker/toast components and their `maki.ui` exports are gone.