### PR TITLE
lua,ui: turn-boundary observability for supervision plugins

### DIFF
--- a/maki-acp/src/translate.rs
+++ b/maki-acp/src/translate.rs
@@ -279,6 +279,9 @@ pub fn map_done_reason(reason: DoneReason) -> StopReason {
         DoneReason::MaxTokens => StopReason::MaxTokens,
         DoneReason::MaxTurns => StopReason::MaxTurnRequests,
         DoneReason::Cancelled => StopReason::Cancelled,
+        // Manual `/compact` isn't a turn boundary; ACP has no dedicated
+        // stop reason for housekeeping, so surface it as EndTurn.
+        DoneReason::Compact => StopReason::EndTurn,
     }
 }
 

--- a/maki-agent/src/agent/compaction.rs
+++ b/maki-agent/src/agent/compaction.rs
@@ -135,10 +135,27 @@ pub async fn compact(
         history.push(Message::synthetic(post.to_string()));
     }
 
+    // There is no running context gauge on the manual `/compact` path, so the
+    // summariser stands in for it: what it read is the size before, what it
+    // wrote is the size after.
+    let context_size_before = usage.total_input();
+    let context_size_after = usage.output;
+    event_tx.send(AgentEvent::CompactionDone {
+        context_size_before,
+        context_size_after,
+        context_window: model.context_window,
+    })?;
+
+    // `Compact` and not `EndTurn`, so a goal loop reading this sees
+    // housekeeping and does not treat it as a turn boundary.
     event_tx.send(AgentEvent::Done {
         usage,
+        cost: model.billed_cost(&usage, false),
+        list_cost: model.list_cost(&usage, false),
+        context_size: context_size_after,
+        context_window: model.context_window,
         num_turns: 1,
-        reason: DoneReason::EndTurn,
+        reason: DoneReason::Compact,
     })?;
 
     Ok(())

--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -23,7 +23,7 @@ use crate::tools::{
 };
 use crate::{
     AgentConfig, AgentError, AgentEvent, AgentInput, AgentMode, DoneReason, EventSender,
-    ExtractedCommand, InterruptSource, SessionMailbox, TurnCompleteEvent,
+    ExtractedCommand, InterruptSource, RunLedger, SessionMailbox, TurnCompleteEvent,
 };
 use maki_config::{ModelPolicy, ToolOutputLines};
 use maki_storage::id::SessionRef;
@@ -77,6 +77,8 @@ pub struct AgentParams {
     pub file_tracker: Arc<FileReadTracker>,
     pub prompt_slots: Arc<crate::prompt::ResolvedSlots>,
     pub subagent_cancels: Arc<CancelMap<String>>,
+    /// Subagents inherit this, so a turn's totals cover everything it spawned.
+    pub ledger: Arc<RunLedger>,
     pub registry: Arc<crate::tools::ToolRegistry>,
     pub audience: ToolAudience,
     pub model_policy: Arc<ModelPolicy>,
@@ -100,7 +102,7 @@ pub struct Agent<'h> {
     user_response_rx: Option<Arc<async_lock::Mutex<flume::Receiver<String>>>>,
     interrupt_source: Option<Arc<dyn InterruptSource>>,
     cancel: CancelToken,
-    total_usage: TokenUsage,
+    ledger: Arc<RunLedger>,
     context_size: u32,
     num_turns: u32,
     recent_calls: RecentCalls,
@@ -143,7 +145,7 @@ impl<'h> Agent<'h> {
             user_response_rx: None,
             interrupt_source: None,
             cancel: CancelToken::none(),
-            total_usage: TokenUsage::default(),
+            ledger: params.ledger,
             context_size: 0,
             num_turns: 0,
             recent_calls: RecentCalls::new(),
@@ -359,10 +361,8 @@ impl<'h> Agent<'h> {
             "API response received"
         );
 
+        self.context_size = response.usage.total_input();
         self.emit_turn_complete(&response)?;
-        let usage = response.usage;
-        self.total_usage += usage;
-        self.context_size = usage.total_input();
 
         if has_tools {
             let history_len_before = self.history.len();
@@ -426,29 +426,36 @@ impl<'h> Agent<'h> {
     }
 
     fn emit_turn_complete(&self, response: &StreamResponse) -> Result<(), AgentError> {
+        let fast = self.opts.clamped(&self.model).fast;
+        let cost = self.model.billed_cost(&response.usage, fast);
+        let list_cost = self.model.list_cost(&response.usage, fast);
+        self.ledger.add(response.usage, cost, list_cost);
         self.event_tx
             .send(AgentEvent::TurnComplete(Box::new(TurnCompleteEvent {
                 message: response.message.clone(),
                 usage: response.usage,
                 model: self.model.id.clone(),
-                cost: self
-                    .model
-                    .billed_cost(&response.usage, self.opts.clamped(&self.model).fast),
-                context_size: Some(response.usage.context_tokens()),
+                cost,
+                context_size: Some(self.context_size),
                 context_window: self.model.context_window,
             })))
     }
 
     fn emit_done(&self, reason: DoneReason) -> Result<(), AgentError> {
+        let totals = self.ledger.totals();
         info!(
             self.num_turns,
-            total_input = self.total_usage.input,
-            total_output = self.total_usage.output,
+            total_input = totals.usage.input,
+            total_output = totals.usage.output,
             %reason,
             "agent run completed"
         );
         self.event_tx.send(AgentEvent::Done {
-            usage: self.total_usage,
+            usage: totals.usage,
+            cost: totals.cost,
+            list_cost: totals.list_cost,
+            context_size: self.context_size,
+            context_window: self.model.context_window,
             num_turns: self.num_turns,
             reason,
         })
@@ -507,6 +514,7 @@ impl<'h> Agent<'h> {
             prompt_slots: Arc::clone(&self.prompt_slots),
             opts: self.opts,
             subagent_cancels: Arc::clone(&self.subagent_cancels),
+            ledger: Arc::clone(&self.ledger),
             registry: Arc::clone(&self.registry),
             workflow: self.workflow,
             audience: self.audience,
@@ -530,19 +538,23 @@ impl<'h> Agent<'h> {
             return Ok(false);
         }
         info!(context_size = self.context_size, "auto-compacting");
-        self.event_tx.send(AgentEvent::AutoCompacting)?;
+        self.event_tx.send(AgentEvent::AutoCompacting {
+            context_size: self.context_size,
+            context_window: self.model.context_window,
+        })?;
         self.do_compact().await?;
         Ok(true)
     }
 
     async fn do_compact(&mut self) -> Result<(), AgentError> {
+        let context_size_before = self.context_size;
         let (compact_provider, compact_model) = resolve_compaction_model(
             &self.provider,
             &self.model,
             self.timeouts,
             &self.model_policy,
         );
-        self.total_usage += compaction::compact_history(
+        let compaction_usage = compaction::compact_history(
             &*compact_provider,
             &compact_model,
             self.history,
@@ -551,8 +563,23 @@ impl<'h> Agent<'h> {
             &self.config,
         )
         .await?;
+        // The summariser can be a different model, so price this with
+        // `compact_model` and not `self.model`.
+        let fast = self.opts.clamped(&compact_model).fast;
+        let compact_cost = compact_model.billed_cost(&compaction_usage, fast);
+        let compact_list_cost = compact_model.list_cost(&compaction_usage, fast);
+        self.ledger
+            .add(compaction_usage, compact_cost, compact_list_cost);
+        // The summary the model just wrote is all the next call will see, so
+        // its output count is the new gauge.
+        let context_size_after = compaction_usage.output;
+        self.context_size = context_size_after;
         self.rollback_len = self.history.len();
-        self.event_tx.send(AgentEvent::CompactionDone)?;
+        self.event_tx.send(AgentEvent::CompactionDone {
+            context_size_before,
+            context_size_after,
+            context_window: self.model.context_window,
+        })?;
         self.history
             .push(Message::synthetic(compaction::continue_message(
                 &self.config,
@@ -638,6 +665,8 @@ mod tests {
     use crate::permissions::PermissionManager;
 
     const QUEUED_MESSAGES: [&str; 3] = ["first", "second", "third"];
+    const ONE_GAUGE_MSG: &str =
+        "TurnComplete, Done, and the compaction trigger must read one context gauge";
 
     struct MockInterruptSource {
         commands: Mutex<VecDeque<ExtractedCommand>>,
@@ -805,6 +834,7 @@ mod tests {
                 file_tracker: FileReadTracker::fresh(),
                 prompt_slots: Arc::new(crate::prompt::ResolvedSlots::default()),
                 subagent_cancels: Arc::new(crate::cancel::CancelMap::new()),
+                ledger: Arc::new(RunLedger::default()),
                 registry: Arc::new(crate::tools::ToolRegistry::new()),
                 audience: ToolAudience::MAIN,
                 model_policy: Arc::new(ModelPolicy::default()),
@@ -1152,6 +1182,38 @@ mod tests {
         });
     }
 
+    /// `TurnComplete`, `Done` and the auto-compaction trigger all report the
+    /// same context number, so nobody downstream thinks it has spare room.
+    #[test]
+    fn context_size_is_one_gauge_across_turn_complete_and_done() {
+        smol::block_on(async {
+            let mut response = text_response(StopReason::EndTurn);
+            response.usage = TokenUsage {
+                input: 1_000,
+                output: 400,
+                cache_read: 250,
+                cache_creation: 50,
+                ..Default::default()
+            };
+            let expected = response.usage.total_input();
+            let mut history = History::new(vec![Message::user("go".into())]);
+            let (mut agent, event_rx) = make_agent(MockProvider::new(vec![response]), &mut history);
+            agent.run(default_input()).await.unwrap();
+            drop(agent);
+
+            let events = drain_events(&event_rx);
+            let reported: Vec<u32> = events
+                .iter()
+                .filter_map(|e| match &e.event {
+                    AgentEvent::TurnComplete(tc) => tc.context_size,
+                    AgentEvent::Done { context_size, .. } => Some(*context_size),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(reported, vec![expected, expected], "{ONE_GAUGE_MSG}");
+        });
+    }
+
     #[test_case(true,  170_000, true  ; "enabled_and_over_threshold")]
     #[test_case(true,  150_000, false ; "enabled_but_below_threshold")]
     #[test_case(false, 170_000, false ; "disabled_even_over_threshold")]
@@ -1174,7 +1236,7 @@ mod tests {
             assert_eq!(
                 has_event(&drain_events(&event_rx), |e| matches!(
                     e,
-                    AgentEvent::AutoCompacting
+                    AgentEvent::AutoCompacting { .. }
                 )),
                 expected,
             );

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -23,8 +23,8 @@ use crate::template;
 use crate::tools::{FileReadTracker, LocalTools, RequestTools, ToolAudience, ToolRegistry};
 use crate::{
     Agent, AgentConfig, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, Envelope,
-    EventSender, ImageSource, McpHandle, McpSession, PermissionsConfig, SessionMailbox, ToolOutput,
-    ToolOutputLines,
+    EventSender, ImageSource, McpHandle, McpSession, PermissionsConfig, RunLedger, SessionMailbox,
+    ToolOutput, ToolOutputLines,
 };
 
 type StoredSession = Session<Message, TokenUsage, ToolOutput>;
@@ -208,6 +208,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
                     file_tracker: FileReadTracker::fresh(),
                     prompt_slots: Arc::new(params.prompt_slots),
                     subagent_cancels: Arc::new(CancelMap::new()),
+                    ledger: Arc::new(RunLedger::default()),
                     registry: Arc::clone(ToolRegistry::global_arc()),
                     audience: ToolAudience::MAIN,
                     model_policy: Arc::clone(&params.model_policy),
@@ -440,6 +441,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                         file_tracker: Arc::clone(&file_tracker),
                         prompt_slots: Arc::clone(&params.prompt_slots),
                         subagent_cancels: Arc::new(CancelMap::new()),
+                        ledger: Arc::new(RunLedger::default()),
                         registry: Arc::clone(ToolRegistry::global_arc()),
                         audience: ToolAudience::MAIN,
                         model_policy: Arc::clone(&params.model_policy),

--- a/maki-agent/src/lib.rs
+++ b/maki-agent/src/lib.rs
@@ -38,9 +38,9 @@ use maki_providers::Message;
 pub use maki_providers::{EMPTY_RESPONSE_MARKER, ImageMediaType, ImageSource, ThinkingConfig};
 pub use types::{
     AgentEvent, BufferSnapshot, DoneReason, Envelope, EventSender, GrepFileEntry, GrepLine,
-    GrepMatchGroup, InstructionBlock, NO_FILES_FOUND, SessionEndReason, SharedBuf, SnapshotLine,
-    SnapshotSpan, SpanStyle, SubagentInfo, TextOutput, ToolDoneEvent, ToolInput, ToolOutput,
-    ToolStartEvent, TurnCompleteEvent,
+    GrepMatchGroup, InstructionBlock, NO_FILES_FOUND, RunLedger, RunTotals, SessionEndReason,
+    SharedBuf, SnapshotLine, SnapshotSpan, SpanStyle, SubagentInfo, TextOutput, ToolDoneEvent,
+    ToolInput, ToolOutput, ToolStartEvent, TurnCompleteEvent,
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -33,7 +33,7 @@ use crate::agent::LoadedInstructions;
 use crate::cancel::{CancelMap, CancelToken};
 use crate::mcp::McpSession;
 use crate::permissions::PermissionManager;
-use crate::{AgentConfig, AgentMode, EventSender, SharedBuf};
+use crate::{AgentConfig, AgentMode, EventSender, RunLedger, SharedBuf};
 use maki_config::{ModelPolicy, ToolOutputLines};
 use maki_providers::Model;
 use maki_providers::RequestOptions;
@@ -340,6 +340,9 @@ pub struct ToolContext {
     pub prompt_slots: Arc<crate::prompt::ResolvedSlots>,
     pub opts: RequestOptions,
     pub subagent_cancels: Arc<CancelMap<String>>,
+    /// Shared with the run that spawned this tool, so a subagent's spend lands
+    /// in the parent turn's totals.
+    pub ledger: Arc<RunLedger>,
     pub registry: Arc<ToolRegistry>,
     pub workflow: bool,
     pub audience: ToolAudience,
@@ -564,6 +567,7 @@ pub fn interpreter_ctx(
         prompt_slots: Arc::new(crate::prompt::ResolvedSlots::default()),
         opts: RequestOptions::default(),
         subagent_cancels: Arc::new(CancelMap::new()),
+        ledger: Arc::default(),
         registry,
         workflow: false,
         audience: ToolAudience::MAIN,

--- a/maki-agent/src/types.rs
+++ b/maki-agent/src/types.rs
@@ -2,11 +2,11 @@ use std::any::Any;
 use std::fmt::Write;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use flume::Sender;
 use maki_config::ToolKey;
-use maki_providers::{AgentError, ContentBlock, Message, Role, StopReason, TokenUsage};
+use maki_providers::{AgentError, ContentBlock, Message, Role, StopReason, TokenUsage, add_cost};
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 use strum::Display;
@@ -535,6 +535,9 @@ pub enum DoneReason {
     MaxTokens,
     MaxTurns,
     Cancelled,
+    /// A manual `/compact` ended the run, but no user turn ended with it, so
+    /// a goal loop should not treat this as a turn boundary.
+    Compact,
 }
 
 impl From<Option<StopReason>> for DoneReason {
@@ -603,11 +606,24 @@ pub enum AgentEvent {
     QueueDrained,
     Done {
         usage: TokenUsage,
+        /// Billed cost for the whole run, `None` while nothing was priced.
+        cost: Option<f64>,
+        /// List-price reference cost, for subsidised models.
+        list_cost: Option<f64>,
+        context_size: u32,
+        context_window: u32,
         num_turns: u32,
         reason: DoneReason,
     },
-    AutoCompacting,
-    CompactionDone,
+    AutoCompacting {
+        context_size: u32,
+        context_window: u32,
+    },
+    CompactionDone {
+        context_size_before: u32,
+        context_size_after: u32,
+        context_window: u32,
+    },
     Retry {
         attempt: u32,
         message: String,
@@ -870,11 +886,64 @@ pub struct TurnCompleteEvent {
     pub model: String,
     #[serde(skip)]
     pub cost: Option<f64>,
+    /// Tokens the next request would carry. This is the one context number
+    /// the host reports, so `Done` and the compaction trigger agree with it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context_size: Option<u32>,
     /// The model's context window, so consumers can gauge `context_size`
     /// against the ceiling without resolving the model.
     pub context_window: u32,
+}
+
+/// What one run spent, itself and everything it spawned.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RunTotals {
+    pub usage: TokenUsage,
+    pub cost: Option<f64>,
+    pub list_cost: Option<f64>,
+}
+
+/// Spend accumulator for one run, chained to the run that spawned it.
+///
+/// A round is added where it was paid for and walks up the chain, so every
+/// ledger holds its own subtree: a subagent reports its own spend, and the
+/// turn that spawned it still gets billed for the whole fan-out. Several
+/// subagents run at once, hence the lock.
+#[derive(Debug, Default)]
+pub struct RunLedger {
+    totals: Mutex<RunTotals>,
+    parent: Option<Arc<RunLedger>>,
+}
+
+impl RunLedger {
+    pub fn child(parent: &Arc<Self>) -> Arc<Self> {
+        Arc::new(Self {
+            totals: Mutex::default(),
+            parent: Some(Arc::clone(parent)),
+        })
+    }
+
+    pub fn add(&self, usage: TokenUsage, cost: Option<f64>, list_cost: Option<f64>) {
+        {
+            let mut totals = self.locked();
+            totals.usage += usage;
+            add_cost(&mut totals.cost, cost);
+            add_cost(&mut totals.list_cost, list_cost);
+        }
+        if let Some(parent) = &self.parent {
+            parent.add(usage, cost, list_cost);
+        }
+    }
+
+    pub fn totals(&self) -> RunTotals {
+        *self.locked()
+    }
+
+    /// A poisoned lock only means another run panicked mid-update. The totals
+    /// are still sound, and dropping a session's accounting over it is worse.
+    fn locked(&self) -> MutexGuard<'_, RunTotals> {
+        self.totals.lock().unwrap_or_else(|e| e.into_inner())
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1485,5 +1554,60 @@ mod tests {
         let display = output.as_display_text();
         assert!(display.contains("fn main()"), "{EXCLUDES_MSG}");
         assert!(!display.contains("Instructions from:"), "{EXCLUDES_MSG}");
+    }
+
+    const FIRST_COST: f64 = 0.5;
+    const SECOND_COST: f64 = 0.25;
+    const FIRST_INPUT: u32 = 10;
+    const SECOND_INPUT: u32 = 5;
+    const OWN_SUBTREE_MSG: &str = "a child ledger reports only what it spent itself";
+    const ROLLUP_MSG: &str = "a child's spend has to land in the parent's totals";
+
+    fn usage(input: u32) -> TokenUsage {
+        TokenUsage {
+            input,
+            ..Default::default()
+        }
+    }
+
+    #[test_case(Some(FIRST_COST), Some(SECOND_COST), Some(FIRST_COST + SECOND_COST) ; "priced_rounds_add_up")]
+    #[test_case(None, None, None ; "unpriced_rounds_stay_unpriced")]
+    fn ledger_folds_usage_and_cost_across_adds(
+        first: Option<f64>,
+        second: Option<f64>,
+        expected: Option<f64>,
+    ) {
+        let ledger = RunLedger::default();
+        ledger.add(usage(FIRST_INPUT), first, first);
+        ledger.add(usage(SECOND_INPUT), second, second);
+
+        let totals = ledger.totals();
+        assert_eq!(totals.usage.input, FIRST_INPUT + SECOND_INPUT);
+        assert_eq!(totals.cost, expected);
+        assert_eq!(totals.list_cost, expected);
+    }
+
+    #[test]
+    fn ledger_child_spend_rolls_up_into_parent() {
+        let parent = Arc::new(RunLedger::default());
+        parent.add(usage(FIRST_INPUT), Some(FIRST_COST), Some(FIRST_COST));
+        let child = RunLedger::child(&parent);
+        child.add(usage(SECOND_INPUT), Some(SECOND_COST), Some(SECOND_COST));
+
+        let own = child.totals();
+        assert_eq!(own.usage.input, SECOND_INPUT, "{OWN_SUBTREE_MSG}");
+        assert_eq!(own.cost, Some(SECOND_COST), "{OWN_SUBTREE_MSG}");
+
+        let rolled_up = parent.totals();
+        assert_eq!(
+            rolled_up.usage.input,
+            FIRST_INPUT + SECOND_INPUT,
+            "{ROLLUP_MSG}"
+        );
+        assert_eq!(
+            rolled_up.cost,
+            Some(FIRST_COST + SECOND_COST),
+            "{ROLLUP_MSG}"
+        );
     }
 }

--- a/maki-lua/src/agent_autocmd.rs
+++ b/maki-lua/src/agent_autocmd.rs
@@ -1,0 +1,220 @@
+//! One place that turns agent events into autocmds, shared by the UI app loop,
+//! `maki -p` and sdk mode, so a plugin sees the same events whichever way maki
+//! was started. `maki-acp` drives the agent from its own loop and does not call
+//! this yet, so plugins loaded under ACP get no turn events.
+
+use std::fmt::Display;
+
+use maki_agent::{AgentEvent, DoneReason, Envelope};
+use serde_json::{Value, json};
+
+use crate::EventHandle;
+
+pub fn dispatch(
+    handle: &EventHandle,
+    session_id: &dyn Display,
+    envelope: &Envelope,
+    subagent_bounded: bool,
+) {
+    if let Some((event, data)) = autocmd_for(&envelope.event, session_id, subagent_bounded) {
+        handle.fire_autocmd(event, data);
+    }
+}
+
+/// Subagent envelopes carry the parent's `session_id`, so firing on them too
+/// would double count every budget and every tool the parent already reported,
+/// and a subagent compacting would look like the main context shrank.
+///
+/// `session_id` stays a `Display` because this runs on every envelope, streaming
+/// deltas included, and almost all of them map to nothing. Only the arms that
+/// build a payload pay for formatting the id.
+pub fn autocmd_for(
+    event: &AgentEvent,
+    session_id: &dyn Display,
+    subagent_bounded: bool,
+) -> Option<(&'static str, Value)> {
+    if subagent_bounded {
+        return None;
+    }
+    let sid = || Value::String(session_id.to_string());
+    match event {
+        AgentEvent::ToolStart(e) => Some((
+            "ToolStart",
+            json!({ "session_id": sid(), "tool_id": e.id, "tool": e.tool }),
+        )),
+        AgentEvent::ToolDone(e) => Some((
+            "ToolDone",
+            json!({ "session_id": sid(), "tool_id": e.id, "tool": e.tool }),
+        )),
+        AgentEvent::AutoCompacting {
+            context_size,
+            context_window,
+        } => Some((
+            "AutoCompacting",
+            json!({
+                "session_id": sid(),
+                "context_size": context_size,
+                "context_window": context_window,
+            }),
+        )),
+        AgentEvent::CompactionDone {
+            context_size_before,
+            context_size_after,
+            context_window,
+        } => Some((
+            "CompactionDone",
+            json!({
+                "session_id": sid(),
+                "context_size_before": context_size_before,
+                "context_size_after": context_size_after,
+                "context_window": context_window,
+            }),
+        )),
+        AgentEvent::Done {
+            reason,
+            usage,
+            cost,
+            list_cost,
+            context_size,
+            context_window,
+            num_turns,
+        } => Some((
+            "TurnEnd",
+            json!({
+                "session_id": sid(),
+                "reason": turn_end_reason(*reason)?,
+                "usage": usage,
+                "cost": cost,
+                "list_cost": list_cost,
+                "context_size": context_size,
+                "context_window": context_window,
+                "num_turns": num_turns,
+            }),
+        )),
+        AgentEvent::Error { message } => Some((
+            "TurnError",
+            json!({ "session_id": sid(), "message": message }),
+        )),
+        _ => None,
+    }
+}
+
+/// Nothing for a manual `/compact`: it closes a run without ending a turn, and
+/// a goal loop hearing TurnEnd there would inject "continue" mid cleanup.
+fn turn_end_reason(reason: DoneReason) -> Option<&'static str> {
+    match reason {
+        DoneReason::EndTurn => Some("finished"),
+        DoneReason::MaxTokens => Some("max_tokens"),
+        DoneReason::MaxTurns => Some("max_turns"),
+        DoneReason::Cancelled => Some("cancelled"),
+        DoneReason::Compact => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use maki_agent::{ToolDoneEvent, ToolOutput, ToolStartEvent};
+    use maki_providers::TokenUsage;
+    use test_case::test_case;
+
+    use super::*;
+
+    const SESSION: &str = "session-x";
+
+    fn done(reason: DoneReason) -> AgentEvent {
+        AgentEvent::Done {
+            usage: TokenUsage {
+                input: 1_000,
+                output: 500,
+                ..Default::default()
+            },
+            cost: Some(0.05),
+            list_cost: Some(0.25),
+            context_size: 12_000,
+            context_window: 200_000,
+            num_turns: 4,
+            reason,
+        }
+    }
+
+    fn every_event() -> Vec<AgentEvent> {
+        vec![
+            AgentEvent::ToolStart(Box::new(ToolStartEvent {
+                id: "t1".into(),
+                tool: "bash".into(),
+                summary: String::new(),
+                render_header: None,
+                annotation: None,
+                input: None,
+                raw_input: None,
+                output: None,
+            })),
+            AgentEvent::ToolDone(Box::new(ToolDoneEvent {
+                id: "t1".into(),
+                tool: "bash".into(),
+                output: ToolOutput::Plain("ok".into()),
+                is_error: false,
+                annotation: None,
+                written_path: None,
+            })),
+            AgentEvent::AutoCompacting {
+                context_size: 1,
+                context_window: 2,
+            },
+            AgentEvent::CompactionDone {
+                context_size_before: 100_000,
+                context_size_after: 30_000,
+                context_window: 200_000,
+            },
+            done(DoneReason::EndTurn),
+            AgentEvent::Error {
+                message: "boom".into(),
+            },
+        ]
+    }
+
+    #[test_case(DoneReason::EndTurn, Some("finished") ; "finished")]
+    #[test_case(DoneReason::MaxTokens, Some("max_tokens") ; "max_tokens")]
+    #[test_case(DoneReason::MaxTurns, Some("max_turns") ; "max_turns")]
+    #[test_case(DoneReason::Cancelled, Some("cancelled") ; "cancelled")]
+    #[test_case(DoneReason::Compact, None ; "manual_compact_is_not_a_turn")]
+    fn done_maps_to_a_turn_end_reason(reason: DoneReason, expected: Option<&str>) {
+        let fired = autocmd_for(&done(reason), &SESSION, false);
+        let got = fired
+            .as_ref()
+            .map(|(event, data)| (*event, data["reason"].as_str().unwrap_or_default()));
+        assert_eq!(got, expected.map(|reason| ("TurnEnd", reason)));
+    }
+
+    /// A budget watchdog reads the whole bill off this one payload, so the keys
+    /// it charges against have to survive refactors.
+    #[test]
+    fn turn_end_carries_the_turn_totals() {
+        let (_, data) = autocmd_for(&done(DoneReason::EndTurn), &SESSION, false).unwrap();
+        assert_eq!(data["usage"]["input_tokens"], 1_000);
+        assert_eq!(data["cost"], 0.05);
+        assert_eq!(data["list_cost"], 0.25);
+        assert_eq!(data["context_size"], 12_000);
+        assert_eq!(data["context_window"], 200_000);
+        assert_eq!(data["num_turns"], 4);
+    }
+
+    #[test]
+    fn every_fired_event_names_its_session() {
+        for event in every_event() {
+            let (name, data) = autocmd_for(&event, &SESSION, false)
+                .unwrap_or_else(|| panic!("{event:?} fires nothing"));
+            assert_eq!(data["session_id"], SESSION, "{name}");
+        }
+    }
+
+    #[test]
+    fn subagent_envelopes_fire_nothing() {
+        for event in every_event() {
+            assert!(
+                autocmd_for(&event, &SESSION, true).is_none(),
+                "{event:?} leaked from a subagent"
+            );
+        }
+    }
+}

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -19,7 +19,8 @@ use maki_agent::tools::{
 };
 use maki_agent::{
     Agent, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, DoneReason,
-    EMPTY_RESPONSE_MARKER, Envelope, EventSender, History, McpSession, SubagentInfo, ToolDoneEvent,
+    EMPTY_RESPONSE_MARKER, Envelope, EventSender, History, McpSession, RunLedger, SubagentInfo,
+    ToolDoneEvent,
 };
 use maki_lua_macro::{lua_class, lua_fn, lua_table};
 use maki_providers::model::ModelTier;
@@ -598,6 +599,7 @@ async fn session(
             file_tracker: FileReadTracker::fresh(),
             prompt_slots: Arc::clone(&agent_ctx.prompt_slots),
             subagent_cancels: Arc::new(CancelMap::new()),
+            ledger: RunLedger::child(&agent_ctx.ledger),
             registry: Arc::clone(maki_agent::tools::ToolRegistry::global_arc()),
             audience,
             model_policy: Arc::clone(&agent_ctx.model_policy),
@@ -1052,6 +1054,10 @@ mod tests {
             },
             AgentEvent::Done {
                 usage: DONE_USAGE,
+                cost: None,
+                list_cost: None,
+                context_size: 0,
+                context_window: 0,
                 num_turns: 2,
                 reason: DoneReason::EndTurn,
             },

--- a/maki-lua/src/api/autocmd.rs
+++ b/maki-lua/src/api/autocmd.rs
@@ -147,27 +147,50 @@ fn parse_string_or_seq(value: Value, what: &str) -> LuaResult<Vec<String>> {
 /// `del_autocmd` later to remove the listener.
 ///
 /// Built-in events fired by the host: `"TurnStart"`, `"TurnEnd"`,
-/// `"TurnError"`, `"ToolStart"`, `"ToolDone"`, `"SessionReset"`,
-/// `"SessionEnd"`, `"SessionFocusChanged"`, `"SessionStatusChanged"`,
-/// `"TaskStatusChanged"`, and `"ModelChanged"`. Plugins can also fire their
-/// own events with `exec_autocmds`.
+/// `"TurnError"`, `"ToolStart"`, `"ToolDone"`, `"AutoCompacting"`,
+/// `"CompactionDone"`, `"PlanReady"`, `"SessionReset"`, `"SessionEnd"`,
+/// `"SessionFocusChanged"`, `"SessionStatusChanged"`, `"TaskStatusChanged"`,
+/// and `"ModelChanged"`. Plugins can also fire their own events with
+/// `exec_autocmds`.
 ///
-/// Each host event carries `data.session_id`. For `"SessionReset"` and
-/// `"SessionEnd"` that is the session being left behind; the other events
-/// name the session now running or focused. Tool events also carry
-/// `data.tool_id` and `data.tool`. `"SessionFocusChanged"` also carries
-/// `data.previous_session_id` except on initial startup.
-/// `"SessionStatusChanged"` fires whenever a session moves between
-/// `"working"`, `"needs_input"`, and `"idle"`; it carries `data.status`,
-/// `data.title`, and `data.focused` (boolean).
-/// `"TaskStatusChanged"` fires when a subagent starts, or when one moves
-/// between `"working"`, `"done"`, and `"error"`; it carries `data.id` and
-/// `data.name` alongside `data.status`. A task that comes back from disk
-/// already finished stays quiet, so reloading a session does not replay
-/// old tasks. `"ModelChanged"` fires when a session switches model, whoever
-/// asked for it; it carries `data.model` in the shape `maki.model.get`
-/// returns, plus `data.previous_spec`. Picking the model already in use stays
-/// quiet, and so does startup.
+/// Every host event carries `data.session_id`. For `"SessionReset"` and
+/// `"SessionEnd"` that is the session being left behind, the other events
+/// name the session now running or focused. What each event adds:
+///
+/// - `"ToolStart"`, `"ToolDone"`: `data.tool_id` and `data.tool`.
+/// - `"TurnEnd"`: `data.reason` (`"finished"`, `"max_tokens"`,
+///   `"max_turns"`, or `"cancelled"`), `data.usage` (four token fields,
+///   cache included), `data.cost`, `data.list_cost`, `data.context_size`,
+///   `data.context_window`, and `data.num_turns` (model round-trips the
+///   turn took). `list_cost` is the un-subsidised list price and `cost` is
+///   the real bill, so a budget plugin charges against whichever one it
+///   wants.
+/// - `"AutoCompacting"`: `data.context_size` and `data.context_window` at
+///   trigger time.
+/// - `"CompactionDone"`: `data.context_size_before`,
+///   `data.context_size_after`, and `data.context_window`.
+/// - `"PlanReady"`: `data.path`, the absolute path of the plan file the
+///   agent just wrote. Fires once per draft.
+/// - `"SessionFocusChanged"`: `data.previous_session_id`, absent on the
+///   first focus at startup.
+/// - `"SessionStatusChanged"`: `data.status` (`"working"`, `"needs_input"`,
+///   or `"idle"`), `data.title`, and `data.focused` (boolean).
+/// - `"TaskStatusChanged"`: `data.id`, `data.name`, and `data.status`
+///   (`"working"`, `"done"`, or `"error"`), when a subagent starts or
+///   changes status. A task that comes back from disk already finished
+///   stays quiet, so reloading a session does not replay old tasks.
+/// - `"ModelChanged"`: `data.model` in the shape `maki.model.get` returns,
+///   plus `data.previous_spec`. Picking the model already in use stays
+///   quiet, and so does startup.
+///
+/// `"TurnEnd"` fires once per turn and only for the main session, so
+/// subagent turns never show up. A manual `/compact` ends its run without
+/// ending a turn, so it stays quiet too.
+///
+/// Drivers are not all caught up. `"TurnStart"` and `"PlanReady"` come from
+/// `maki-ui` only. `maki-acp` runs the agent on its own loop and does not
+/// call the dispatcher yet, so plugins loaded under ACP receive no turn
+/// events. Everything else fires under `maki -p` and sdk mode as well.
 ///
 /// `"SessionEnd"` is the teardown signal: it fires first so handlers can
 /// still inspect or stop the session's jobs, then session-owned jobs are

--- a/maki-lua/src/api/session.rs
+++ b/maki-lua/src/api/session.rs
@@ -8,7 +8,16 @@ use maki_storage::id::MakiId;
 use mlua::{Lua, Result as LuaResult, Table, Value};
 
 use crate::api::util::command::{SessionRequest, UiAction, ui_json_roundtrip};
+use crate::api::util::convert::json_to_lua;
 use crate::api::util::pair::{Pair, err_pair};
+
+/// Answers `maki.session.read` for a driver that has no UI to ask. Takes the
+/// optional session id from Lua and returns a serialized
+/// [`crate::SessionSnapshot`].
+pub type SessionSnapshotFn =
+    Box<dyn Fn(Option<&str>) -> Result<serde_json::Value, String> + Send + Sync + 'static>;
+
+pub struct SessionSnapshotSlot(pub SessionSnapshotFn);
 
 const BLANK_NOTIFY_ERR: &str = "text must not be blank";
 const SESSION_REQUIRED_ERR: &str = "session is required";
@@ -46,6 +55,62 @@ async fn list(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaResult
 #[lua_fn]
 async fn live(lua: Lua, #[ctx] tx: Option<flume::Sender<UiAction>>) -> LuaResult<Pair<Value>> {
     roundtrip(lua, tx, SessionRequest::Live).await
+}
+
+/// One-call snapshot of a session: queue, usage, context, cost, mode, and
+/// status. Reads the focused session, or the one you name in `session` when
+/// you act on a background tab.
+///
+/// The returned table:
+/// ```
+/// {
+///   id, cwd, model, mode = "build" | "plan",
+///   status = "idle" | "working" | "needs_input",
+///   focused, updated_at,
+///   usage = { input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens },
+///   context_size, context_window,
+///   cost,
+///   queue = { count }, -- nil under headless drivers
+///   title,             -- nil under headless drivers
+/// }
+/// ```
+///
+/// `usage` and `cost` include subagent spend. `context_size` is the main
+/// session's own, since a subagent runs its own window. There is no
+/// `list_cost` here because `cost` is re-settled from stored usage when a
+/// session resumes and list price is not stored, so per-turn list price
+/// lives on the `TurnEnd` autocmd instead.
+///
+/// @param opts table? `session` (string?) Session id; defaults to focused.
+/// @return (table|nil, string|nil) Snapshot table, or nil and an error.
+/// @example
+/// local s = maki.session.read()
+/// if s.context_size > s.context_window * 0.8 then
+///   maki.ui.notify("context is nearly full")
+/// end
+#[lua_fn]
+async fn read(
+    lua: Lua,
+    #[ctx] tx: Option<flume::Sender<UiAction>>,
+    opts: Option<Table>,
+) -> LuaResult<Pair<Value>> {
+    let id = match opts {
+        Some(t) => t.get::<Option<String>>("session")?,
+        None => None,
+    };
+    // Headless drivers install a provider, the UI leaves the slot empty and
+    // answers from its event loop, which owns the live session runtimes.
+    if let Some(slot) = lua.app_data_ref::<SessionSnapshotSlot>() {
+        return match (slot.0)(id.as_deref()) {
+            Ok(value) => Ok((Some(json_to_lua(&lua, &value)?), None)),
+            Err(msg) => Ok(err_pair(msg)),
+        };
+    }
+    ui_json_roundtrip(&lua, tx.as_ref(), |reply_tx| UiAction::Session {
+        req: SessionRequest::Read { id },
+        reply_tx,
+    })
+    .await
 }
 
 /// Returns the id of the currently focused session.
@@ -193,7 +258,7 @@ lua_table! {
     /// attached"` without a UI. `notify` instead targets a live agent mailbox
     /// directly, so it also works under ACP and SDK frontends.
     "maki.session" => pub(crate) fn create_session_table(tx: Option<flume::Sender<UiAction>>),
-    DOCS [list(tx), live(tx), current(tx), focus(tx), delete(tx), new(tx), prompt(tx), notify(), set_title(tx)]
+    DOCS [list(tx), live(tx), current(tx), read(tx), focus(tx), delete(tx), new(tx), prompt(tx), notify(), set_title(tx)]
 }
 
 #[cfg(test)]

--- a/maki-lua/src/api/ui/mod.rs
+++ b/maki-lua/src/api/ui/mod.rs
@@ -280,7 +280,7 @@ fn set_window_title(
 ///
 /// Valid names: `"file_picker"`, `"search"`, `"help"`,
 /// `"plan_toggle"`, `"plan_editor"`, `"edit_input"`, `"pop_queue"`,
-/// `"prev_chat"`, `"next_chat"`.
+/// `"prev_chat"`, `"next_chat"`, `"model_picker"`.
 ///
 /// For slash commands rather than keybound actions, see
 /// `maki.api.run_command`.

--- a/maki-lua/src/api/util/command.rs
+++ b/maki-lua/src/api/util/command.rs
@@ -409,11 +409,31 @@ pub enum SessionRequest {
     List,
     Live,
     Current,
-    New { prompt: Option<String>, focus: bool },
-    Prompt { id: Option<String>, text: String },
-    Focus { id: String },
-    Delete { id: String },
-    SetTitle { id: String, title: String },
+    /// UI-mode fallback for `maki.session.read` when no snapshot slot is
+    /// installed — the UI resolves the id and returns a `session_snapshot_json`
+    /// payload. Headless drivers install a `SessionSnapshotSlot` instead
+    /// so `read` doesn't need a UI.
+    Read {
+        id: Option<String>,
+    },
+    New {
+        prompt: Option<String>,
+        focus: bool,
+    },
+    Prompt {
+        id: Option<String>,
+        text: String,
+    },
+    Focus {
+        id: String,
+    },
+    Delete {
+        id: String,
+    },
+    SetTitle {
+        id: String,
+        title: String,
+    },
 }
 
 pub enum TaskRequest {

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod agent_autocmd;
 mod api;
 pub mod docs;
 pub mod docs_render;
@@ -7,11 +8,13 @@ mod loader;
 mod pack;
 pub(crate) mod plugin_permissions;
 mod runtime;
+pub mod session_snapshot;
 
 pub use api::keymap::{KeymapEntry, KeymapReader, KeymapSnapshot};
 pub use api::net::set_allowed_private_hosts;
 pub use api::options::{OptionSpec, OptionType, PluginOptionSpecs};
 pub use api::pack::{Declared, PackOp};
+pub use api::session::SessionSnapshotFn;
 pub use api::util::command::{
     Anchor, Axis, Border, BuiltinAction, Dimension, Edge, FloatConfig, FloatConfigPatch,
     HintReader, HintSnapshot, LuaCommandInfo, LuaCommandReader, ModelRequest, SessionRequest,
@@ -27,6 +30,7 @@ pub use pack::{
 };
 pub use plugin_permissions::{Permission, PluginPermissions, Requested};
 pub use runtime::{KILL_GRACE, MAX_INFLIGHT_TOOLS, RestoreItem, WARM_TOOL_CAP};
+pub use session_snapshot::{SessionQueueSnapshot, SessionSnapshot};
 
 pub mod test_support {
     use crate::KeymapReader;

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -1035,6 +1035,16 @@ impl EventHandle {
         });
     }
 
+    /// Headless drivers install their own provider so `maki.session.read` has
+    /// something to answer with instead of "no interactive UI attached". The UI
+    /// leaves the slot empty and answers through its event loop, which owns the
+    /// live session runtimes.
+    pub fn install_session_snapshot(&self, provider: crate::api::session::SessionSnapshotFn) {
+        let _ = self
+            .tx
+            .try_send(Request::InstallSessionSnapshot { provider });
+    }
+
     /// Queue the kill of session-owned jobs and the `SessionEnd` dispatch,
     /// then return. Call from every session-end path so a Lua monitor can
     /// stay a plugin. Process exit wants [`Self::end_sessions_blocking`].

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -214,6 +214,11 @@ pub enum Request {
     /// Plugins are loaded, so native codegen may start using idle time. Sent
     /// last so it never interleaves with the loads themselves.
     WarmJit,
+    /// Install a `SessionSnapshotSlot` on the Lua thread. Headless drivers send
+    /// one so `maki.session.read` works without a UI to ask.
+    InstallSessionSnapshot {
+        provider: crate::api::session::SessionSnapshotFn,
+    },
     /// Takes the package operations Lua recorded, leaving the queue empty.
     TakePackOps {
         reply: flume::Sender<Vec<crate::api::pack::PackOp>>,
@@ -3114,6 +3119,10 @@ pub fn spawn(
                     match msg {
                         Request::Shutdown => break,
                         Request::WarmJit => codegen_armed = true,
+                        Request::InstallSessionSnapshot { provider } => {
+                            rt.lua
+                                .set_app_data(crate::api::session::SessionSnapshotSlot(provider));
+                        }
                         Request::LoadSource {
                             name,
                             chunks,

--- a/maki-lua/src/session_snapshot.rs
+++ b/maki-lua/src/session_snapshot.rs
@@ -1,0 +1,250 @@
+//! The one shape `maki.session.read()` returns. The UI and the headless
+//! drivers all serialize this struct, so a plugin sees the same keys wherever
+//! it runs and a new field is one edit instead of three `json!` blobs.
+
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use maki_agent::{AgentEvent, Envelope};
+use maki_providers::{TokenUsage, add_cost};
+use serde::Serialize;
+
+use crate::EventHandle;
+
+pub const MODE_BUILD: &str = "build";
+pub const MODE_PLAN: &str = "plan";
+pub const STATUS_IDLE: &str = "idle";
+pub const STATUS_WORKING: &str = "working";
+pub const STATUS_NEEDS_INPUT: &str = "needs_input";
+
+#[derive(Serialize)]
+pub struct SessionSnapshot {
+    pub id: String,
+    /// Working directory the session runs against.
+    pub cwd: String,
+    /// Left out when the host has no title to give. Never filled with the
+    /// session id, so a plugin can tell "no title" from a real one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Model spec as shown in the status bar (`provider/id`).
+    pub model: String,
+    /// [`MODE_BUILD`] or [`MODE_PLAN`].
+    pub mode: &'static str,
+    /// [`STATUS_IDLE`], [`STATUS_WORKING`], or [`STATUS_NEEDS_INPUT`].
+    pub status: &'static str,
+    /// Whether this is the session the user is looking at. Always true
+    /// for the single-session headless drivers.
+    pub focused: bool,
+    /// Unix seconds.
+    pub updated_at: u64,
+    /// Omitted by hosts that hold no queue of their own. An sdk client can
+    /// pipeline messages that wait outside the driver's sight, so leaving
+    /// this out beats reporting a zero the plugin would trust.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub queue: Option<SessionQueueSnapshot>,
+    /// Subagent turns included, their tokens are real spend on this session
+    /// too.
+    pub usage: TokenUsage,
+    /// Main session only. A subagent fills its own window, not ours.
+    pub context_size: u32,
+    pub context_window: u32,
+    /// What the session bills, `None` on an unpriced model. No list price
+    /// twin here, because `cost` is re-settled from stored usage when a
+    /// session resumes and list price is not stored. Per turn list price
+    /// lives on the `TurnEnd` autocmd instead.
+    pub cost: Option<f64>,
+}
+
+#[derive(Serialize)]
+pub struct SessionQueueSnapshot {
+    /// Pending user text only. A queued `/compact` is housekeeping, not human
+    /// input a supervisor should yield to.
+    pub count: usize,
+}
+
+/// What a headless driver knows about its session before it runs.
+pub struct HeadlessMeta {
+    pub id: String,
+    pub cwd: String,
+    /// Model spec (`provider/id`).
+    pub model: String,
+}
+
+#[derive(Default)]
+struct Totals {
+    usage: TokenUsage,
+    cost: Option<f64>,
+    context_size: u32,
+    context_window: u32,
+    working: bool,
+}
+
+/// A poisoned lock only means some other run panicked mid-update. The
+/// numbers are still whole, so read them instead of losing the session's
+/// whole accounting over it.
+fn lock(totals: &Mutex<Totals>) -> MutexGuard<'_, Totals> {
+    totals.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Backs `maki.session.read` for the single session headless drivers
+/// (`maki -p`, sdk mode). The driver writes while the Lua thread reads, hence
+/// the lock, though the two rarely meet.
+#[derive(Clone, Default)]
+pub struct HeadlessSnapshot(Arc<Mutex<Totals>>);
+
+impl HeadlessSnapshot {
+    /// Fold one envelope in. The drivers already loop over the stream, so
+    /// they hand every envelope here and keep no bookkeeping of their own.
+    pub fn observe(&self, envelope: &Envelope) {
+        let event = &envelope.event;
+        let mut totals = lock(&self.0);
+        // Envelopes only flow while a run is alive, so anything that is not
+        // an ending means the agent is busy. Sdk mode runs many turns and no
+        // driver has to remember to clear a flag between them.
+        totals.working = !matches!(event, AgentEvent::Done { .. } | AgentEvent::Error { .. });
+        match event {
+            AgentEvent::Done {
+                usage,
+                cost,
+                context_size,
+                context_window,
+                ..
+            } => {
+                // Each turn's `Done` carries that turn's whole bill, subagents
+                // and compaction included, so summing them lands on the exact
+                // session total. Summing `TurnComplete` would miss compaction.
+                totals.usage += *usage;
+                add_cost(&mut totals.cost, *cost);
+                totals.context_size = *context_size;
+                totals.context_window = *context_window;
+            }
+            AgentEvent::TurnComplete(turn) if envelope.subagent.is_none() => {
+                totals.context_size = turn.context_size.unwrap_or(totals.context_size);
+                totals.context_window = turn.context_window;
+            }
+            _ => {}
+        }
+    }
+
+    /// Install as the provider `maki.session.read` answers from. `mode`
+    /// is a callback because sdk mode can flip between build and plan
+    /// mid-run.
+    ///
+    /// There is no stored session and no rename path under either driver,
+    /// so `title` stays nil rather than echoing the id back as a fake one.
+    pub fn install(
+        &self,
+        handle: &EventHandle,
+        meta: HeadlessMeta,
+        mode: impl Fn() -> &'static str + Send + Sync + 'static,
+    ) {
+        let totals = Arc::clone(&self.0);
+        handle.install_session_snapshot(Box::new(move |id| {
+            // One session here, so any other id names a tab that is not ours.
+            if let Some(want) = id
+                && want != meta.id
+            {
+                return Err(format!("session {want} not live"));
+            }
+            let mode = mode();
+            let totals = lock(&totals);
+            serde_json::to_value(SessionSnapshot {
+                id: meta.id.clone(),
+                cwd: meta.cwd.clone(),
+                title: None,
+                model: meta.model.clone(),
+                mode,
+                status: if totals.working {
+                    STATUS_WORKING
+                } else {
+                    STATUS_IDLE
+                },
+                focused: true,
+                updated_at: maki_storage::now_epoch(),
+                queue: None,
+                usage: totals.usage,
+                context_size: totals.context_size,
+                context_window: totals.context_window,
+                cost: totals.cost,
+            })
+            .map_err(|e| e.to_string())
+        }));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use maki_agent::{DoneReason, TurnCompleteEvent};
+    use maki_providers::Message;
+
+    use super::*;
+
+    const FIRST_TURN_INPUT: u32 = 1_000;
+    const SECOND_TURN_INPUT: u32 = 400;
+    const TURN_COST: f64 = 0.25;
+    const WINDOW: u32 = 200_000;
+    const GROWS_MSG: &str = "session totals add up across turns, they never restart at one turn";
+    const WORKING_MSG: &str = "a second turn has to read as working again";
+
+    fn envelope(event: AgentEvent) -> Envelope {
+        Envelope {
+            event,
+            subagent: None,
+            run_id: 0,
+        }
+    }
+
+    /// Carries no usage or cost of its own, so a fold that summed these instead
+    /// of `Done` would leave the totals empty and fail below.
+    fn turn_complete(context_size: u32) -> Envelope {
+        envelope(AgentEvent::TurnComplete(Box::new(TurnCompleteEvent {
+            message: Message::user("go".into()),
+            usage: TokenUsage::default(),
+            model: String::new(),
+            cost: None,
+            context_size: Some(context_size),
+            context_window: WINDOW,
+        })))
+    }
+
+    fn done(input: u32) -> Envelope {
+        envelope(AgentEvent::Done {
+            usage: TokenUsage {
+                input,
+                ..Default::default()
+            },
+            cost: Some(TURN_COST),
+            list_cost: None,
+            context_size: input,
+            context_window: WINDOW,
+            num_turns: 1,
+            reason: DoneReason::EndTurn,
+        })
+    }
+
+    /// Sdk mode serves many turns on one session, so `Done` is a turn boundary
+    /// and not the end. Totals have to keep climbing and the status has to come
+    /// back to life on turn two, with no driver clearing anything by hand.
+    #[test]
+    fn totals_grow_and_status_revives_across_turns() {
+        let snapshot = HeadlessSnapshot::default();
+
+        snapshot.observe(&turn_complete(FIRST_TURN_INPUT));
+        assert!(lock(&snapshot.0).working);
+        snapshot.observe(&done(FIRST_TURN_INPUT));
+        assert!(!lock(&snapshot.0).working);
+
+        snapshot.observe(&turn_complete(SECOND_TURN_INPUT));
+        assert!(lock(&snapshot.0).working, "{WORKING_MSG}");
+        snapshot.observe(&done(SECOND_TURN_INPUT));
+
+        let totals = lock(&snapshot.0);
+        assert!(!totals.working);
+        assert_eq!(
+            totals.usage.input,
+            FIRST_TURN_INPUT + SECOND_TURN_INPUT,
+            "{GROWS_MSG}"
+        );
+        assert_eq!(totals.cost, Some(TURN_COST * 2.0), "{GROWS_MSG}");
+        assert_eq!(totals.context_size, SECOND_TURN_INPUT);
+    }
+}

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -11,7 +11,7 @@ use maki_agent::tools::{FileReadTracker, RequestTools, ToolAudience, ToolRegistr
 use maki_agent::{
     Agent, AgentConfig, AgentEvent, AgentInput, AgentParams, AgentRunParams, CancelMap,
     CancelToken, CancelTrigger, DoneReason, Envelope, EventSender, History, Instructions,
-    McpCommand, PromptRole, SessionMailbox, SharedMessages, ToolOutputLines,
+    McpCommand, PromptRole, RunLedger, SessionMailbox, SharedMessages, ToolOutputLines,
 };
 use maki_config::ModelPolicy;
 use maki_lua::EventHandle;
@@ -261,6 +261,7 @@ impl AgentLoop {
                 file_tracker: Arc::clone(&self.file_tracker),
                 prompt_slots: Arc::new(prompt_slots),
                 subagent_cancels: Arc::clone(&self.subagent_cancels),
+                ledger: Arc::new(RunLedger::default()),
                 registry: Arc::clone(maki_agent::tools::ToolRegistry::global_arc()),
                 audience: ToolAudience::MAIN,
                 model_policy: Arc::clone(&self.model_policy),

--- a/maki-ui/src/app/mod.rs
+++ b/maki-ui/src/app/mod.rs
@@ -1115,23 +1115,12 @@ impl App {
             return vec![];
         }
 
-        match &envelope.event {
-            AgentEvent::ToolStart(event) => self.fire_session_autocmd(
-                "ToolStart",
-                serde_json::json!({
-                    "tool_id": event.id,
-                    "tool": event.tool,
-                }),
-            ),
-            AgentEvent::ToolDone(event) => self.fire_session_autocmd(
-                "ToolDone",
-                serde_json::json!({
-                    "tool_id": event.id,
-                    "tool": event.tool,
-                }),
-            ),
-            _ => {}
-        }
+        maki_lua::agent_autocmd::dispatch(
+            &self.lua_event_handle,
+            &self.state.session.id,
+            &envelope,
+            envelope.subagent.is_some(),
+        );
 
         let subagent_id = envelope
             .subagent
@@ -1243,7 +1232,6 @@ impl App {
                     self.chat_index.clear();
                     self.subagent_answers.clear();
                     self.status = Status::Idle;
-                    self.fire_session_autocmd("TurnEnd", serde_json::json!({}));
                     if self.exit_on_done {
                         self.exit_request = ExitRequest::Success;
                     }
@@ -1256,10 +1244,6 @@ impl App {
                     self.recoverable_queue = self.queue.text_messages();
                     self.queue.clear();
                     self.chat_index.clear();
-                    self.fire_session_autocmd(
-                        "TurnError",
-                        serde_json::json!({ "message": message }),
-                    );
                     if self.exit_on_done {
                         self.exit_request = ExitRequest::Error;
                     }

--- a/maki-ui/src/app/mode.rs
+++ b/maki-ui/src/app/mode.rs
@@ -84,6 +84,11 @@ impl App {
                 }
                 self.state.plan.mark_ready();
                 self.plan_form.on_plan_ready();
+                // The path is the whole point here, so with no path we stay
+                // quiet instead of handing a plugin an empty one to open.
+                if let Some(path) = self.state.plan.path().map(|p| p.display().to_string()) {
+                    self.fire_session_autocmd("PlanReady", serde_json::json!({ "path": path }));
+                }
             }
             PlanTrigger::InteractivePrompt => {
                 if self.state.plan.is_ready() {

--- a/maki-ui/src/app/tests.rs
+++ b/maki-ui/src/app/tests.rs
@@ -48,6 +48,8 @@ const SONNET_SPEC: &str = "anthropic/claude-sonnet-4-5";
 const OPUS_SPEC: &str = "anthropic/claude-opus-4-8";
 const PLAIN_MODEL_SPEC: &str = "ollama/qwen3";
 const MODEL_CHANGED_EVENT: &str = "ModelChanged";
+const PLAN_READY_EVENT: &str = "PlanReady";
+const PLAN_DRAFT_PATH: &str = "/tmp/plan.md";
 const WALK_TIMEOUT: Duration = Duration::from_secs(5);
 /// Stands in for a size the provider measured, baseline included.
 const MEASURED_CONTEXT: u32 = 100_000;
@@ -207,6 +209,10 @@ fn agent_msg_with_run_id(event: AgentEvent, run_id: u64) -> Msg {
 fn done() -> AgentEvent {
     AgentEvent::Done {
         usage: TokenUsage::default(),
+        cost: None,
+        list_cost: None,
+        context_size: 0,
+        context_window: 0,
         num_turns: 1,
         reason: DoneReason::EndTurn,
     }
@@ -394,6 +400,10 @@ fn reset_session_clears_exit_request_source() {
     app.run_id = 1;
     app.update(agent_msg(AgentEvent::Done {
         usage: TokenUsage::default(),
+        cost: None,
+        list_cost: None,
+        context_size: 0,
+        context_window: 0,
         num_turns: 1,
         reason: DoneReason::EndTurn,
     }));
@@ -865,6 +875,41 @@ fn reset_session_clears_drafting_plan_in_build_mode() {
     app.reset_session();
     assert_eq!(app.state.mode, Mode::Build);
     assert_eq!(app.state.plan, PlanState::None);
+}
+
+/// A retried write hits the same transition again, and the plugin still gets
+/// one event with the draft path it needs to open.
+#[test]
+fn plan_ready_fires_once_per_draft() {
+    let mut app = test_app();
+    let (handle, probe) = maki_lua::test_support::probed_event_handle();
+    app.lua_event_handle = handle;
+
+    app.state.mode = Mode::Plan;
+    app.state.plan = PlanState::Drafting(PathBuf::from(PLAN_DRAFT_PATH));
+    app.transition_plan(PlanTrigger::WriteDone);
+    app.transition_plan(PlanTrigger::WriteDone);
+
+    let (event, data) = probe.try_recv_autocmd().expect("PlanReady fired");
+    assert_eq!(event, PLAN_READY_EVENT);
+    assert_eq!(data["path"], serde_json::json!(PLAN_DRAFT_PATH));
+    assert!(
+        probe.try_recv_autocmd().is_none(),
+        "second WriteDone must not re-emit"
+    );
+}
+
+#[test]
+fn plan_ready_does_not_fire_outside_plan_mode() {
+    let mut app = test_app();
+    let (handle, probe) = maki_lua::test_support::probed_event_handle();
+    app.lua_event_handle = handle;
+
+    app.state.mode = Mode::Build;
+    app.state.plan = PlanState::Drafting(PathBuf::from(PLAN_DRAFT_PATH));
+    app.transition_plan(PlanTrigger::WriteDone);
+
+    assert!(probe.try_recv_autocmd().is_none());
 }
 
 #[test]

--- a/maki-ui/src/chat.rs
+++ b/maki-ui/src/chat.rs
@@ -138,14 +138,14 @@ impl Chat {
                     self.messages_panel.set_turn_usage_on_last_tool(usage);
                 }
             }
-            AgentEvent::AutoCompacting => {
+            AgentEvent::AutoCompacting { .. } => {
                 self.messages_panel.flush();
                 self.messages_panel.push(DisplayMessage::new(
                     DisplayRole::Assistant,
                     "Auto-compacting conversation...".into(),
                 ));
             }
-            AgentEvent::CompactionDone => {
+            AgentEvent::CompactionDone { .. } => {
                 self.messages_panel.flush();
             }
             AgentEvent::QueueItemConsumed { text, image_count } => {
@@ -1111,7 +1111,13 @@ mod tests {
     fn compaction_done_flushes_streaming_buffers() {
         let mut chat = chat();
 
-        chat.handle_event(AgentEvent::AutoCompacting, None);
+        chat.handle_event(
+            AgentEvent::AutoCompacting {
+                context_size: 0,
+                context_window: 0,
+            },
+            None,
+        );
         assert_eq!(chat.message_count(), 1);
 
         chat.handle_event(
@@ -1129,7 +1135,14 @@ mod tests {
         assert!(!chat.streaming_text_is_empty());
         assert!(!chat.streaming_thinking_is_empty());
 
-        chat.handle_event(AgentEvent::CompactionDone, None);
+        chat.handle_event(
+            AgentEvent::CompactionDone {
+                context_size_before: 0,
+                context_size_after: 0,
+                context_window: 0,
+            },
+            None,
+        );
         assert!(chat.streaming_text_is_empty());
         assert!(chat.streaming_thinking_is_empty());
         assert_eq!(chat.message_count(), 3);

--- a/maki-ui/src/event_loop.rs
+++ b/maki-ui/src/event_loop.rs
@@ -23,6 +23,10 @@ use maki_agent::{
     AgentConfig, AgentEvent, CancelToken, Envelope, McpCommand, McpConfigErrors, McpHandle, mcp,
 };
 use maki_config::{ModelPolicy, UiConfig};
+use maki_lua::session_snapshot::{
+    MODE_BUILD, MODE_PLAN, STATUS_IDLE, STATUS_NEEDS_INPUT, STATUS_WORKING, SessionQueueSnapshot,
+    SessionSnapshot,
+};
 use maki_lua::{
     EventHandle, HintReader, KeymapReader, LuaCommandReader, ModelRequest, SessionEndReason,
     SessionRequest, TaskRequest, UiAction, UiAttachment, UiReply,
@@ -202,9 +206,9 @@ impl SessionStatus {
 
     fn as_str(self) -> &'static str {
         match self {
-            Self::Working => "working",
-            Self::NeedsInput => "needs_input",
-            Self::Idle => "idle",
+            Self::Working => STATUS_WORKING,
+            Self::NeedsInput => STATUS_NEEDS_INPUT,
+            Self::Idle => STATUS_IDLE,
         }
     }
 }
@@ -1104,6 +1108,13 @@ impl<'t> EventLoop<'t> {
             SessionRequest::Current => {
                 let _ = reply_tx.send(Ok(json!(self.sessions[self.focused].id())));
             }
+            SessionRequest::Read { id } => {
+                let reply = match self.resolve_session_index(id.as_deref()) {
+                    Ok(idx) => Ok(self.session_snapshot_json(idx)),
+                    Err(e) => Err(e),
+                };
+                let _ = reply_tx.send(reply);
+            }
             SessionRequest::New { prompt, focus } => {
                 let session = self.focused_app().blank_session();
                 let idx = self.push_runtime(self.ctx.spawn_runtime(session));
@@ -1210,6 +1221,45 @@ impl<'t> EventLoop<'t> {
 
     fn position(&self, id: MakiId) -> Option<usize> {
         self.sessions.iter().position(|rt| rt.id() == id)
+    }
+
+    /// No id means the focused session. A plugin holding the id of a tab that
+    /// has since closed gets `session not live` back, so it knows to stop.
+    fn resolve_session_index(&self, id: Option<&str>) -> Result<usize, String> {
+        let Some(id) = id else {
+            return Ok(self.focused);
+        };
+        let parsed = parse_session_id(id)?;
+        self.position(parsed).ok_or_else(|| NOT_LIVE_ERR.into())
+    }
+
+    /// The totals live on the session, so a plugin that reloads mid run keeps
+    /// the accounting it would lose by summing `TurnEnd` payloads itself.
+    fn session_snapshot_json(&self, idx: usize) -> serde_json::Value {
+        let rt = &self.sessions[idx];
+        let app = &rt.app;
+        let snapshot = SessionSnapshot {
+            id: rt.id().to_string(),
+            cwd: app.state.session.cwd.clone(),
+            title: Some(app.state.session.title.clone()),
+            model: app.state.model.spec(),
+            mode: if app.state.mode == crate::app::mode::Mode::Plan {
+                MODE_PLAN
+            } else {
+                MODE_BUILD
+            },
+            status: SessionStatus::of(app).as_str(),
+            focused: idx == self.focused,
+            updated_at: app.state.session.updated_at,
+            queue: Some(SessionQueueSnapshot {
+                count: app.queue.text_messages().len(),
+            }),
+            usage: app.state.token_usage,
+            context_size: app.state.context_size,
+            context_window: app.state.model.context_window,
+            cost: app.state.cost,
+        };
+        json!(snapshot)
     }
 
     /// The single place that removes a runtime: keeps `focused` pointing at
@@ -1663,6 +1713,10 @@ mod tests {
     fn done_event() -> AgentEvent {
         AgentEvent::Done {
             usage: TokenUsage::default(),
+            cost: None,
+            list_cost: None,
+            context_size: 0,
+            context_window: 0,
             num_turns: 1,
             reason: DoneReason::EndTurn,
         }

--- a/plugins/code_execution/init.lua
+++ b/plugins/code_execution/init.lua
@@ -305,9 +305,15 @@ local function handler(input, ctx)
   for _, t in ipairs(interpreter_tools(callable, ctx:audience(), ctx:workflow())) do
     local bind, name = t.alias or t.name, t.name
     if bind:match(PY_IDENTIFIER) then
-      local call_opts = t.workflow_only and {} or { timeout = timeout }
       tools[bind] = function(tool_input)
-        return maki.agent.call_tool(ctx, name, tool_input, call_opts)
+        if t.workflow_only then
+          return maki.agent.call_tool(ctx, name, tool_input, {})
+        end
+        -- The script clock stops while a tool call is awaited, so an explicit
+        -- longer timeout on the call has to win over the script budget.
+        local explicit = type(tool_input) == "table" and tonumber(tool_input.timeout) or nil
+        local deadline = math.max(timeout, explicit or 0)
+        return maki.agent.call_tool(ctx, name, tool_input, { timeout = deadline })
       end
     end
   end

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -658,27 +658,50 @@ Listen for one or more events. Returns an id you can pass to
 `del_autocmd` later to remove the listener.
 
 Built-in events fired by the host: `"TurnStart"`, `"TurnEnd"`,
-`"TurnError"`, `"ToolStart"`, `"ToolDone"`, `"SessionReset"`,
-`"SessionEnd"`, `"SessionFocusChanged"`, `"SessionStatusChanged"`,
-`"TaskStatusChanged"`, and `"ModelChanged"`. Plugins can also fire their
-own events with `exec_autocmds`.
+`"TurnError"`, `"ToolStart"`, `"ToolDone"`, `"AutoCompacting"`,
+`"CompactionDone"`, `"PlanReady"`, `"SessionReset"`, `"SessionEnd"`,
+`"SessionFocusChanged"`, `"SessionStatusChanged"`, `"TaskStatusChanged"`,
+and `"ModelChanged"`. Plugins can also fire their own events with
+`exec_autocmds`.
 
-Each host event carries `data.session_id`. For `"SessionReset"` and
-`"SessionEnd"` that is the session being left behind; the other events
-name the session now running or focused. Tool events also carry
-`data.tool_id` and `data.tool`. `"SessionFocusChanged"` also carries
-`data.previous_session_id` except on initial startup.
-`"SessionStatusChanged"` fires whenever a session moves between
-`"working"`, `"needs_input"`, and `"idle"`; it carries `data.status`,
-`data.title`, and `data.focused` (boolean).
-`"TaskStatusChanged"` fires when a subagent starts, or when one moves
-between `"working"`, `"done"`, and `"error"`; it carries `data.id` and
-`data.name` alongside `data.status`. A task that comes back from disk
-already finished stays quiet, so reloading a session does not replay
-old tasks. `"ModelChanged"` fires when a session switches model, whoever
-asked for it; it carries `data.model` in the shape `maki.model.get`
-returns, plus `data.previous_spec`. Picking the model already in use stays
-quiet, and so does startup.
+Every host event carries `data.session_id`. For `"SessionReset"` and
+`"SessionEnd"` that is the session being left behind, the other events
+name the session now running or focused. What each event adds:
+
+- `"ToolStart"`, `"ToolDone"`: `data.tool_id` and `data.tool`.
+- `"TurnEnd"`: `data.reason` (`"finished"`, `"max_tokens"`,
+  `"max_turns"`, or `"cancelled"`), `data.usage` (four token fields,
+  cache included), `data.cost`, `data.list_cost`, `data.context_size`,
+  `data.context_window`, and `data.num_turns` (model round-trips the
+  turn took). `list_cost` is the un-subsidised list price and `cost` is
+  the real bill, so a budget plugin charges against whichever one it
+  wants.
+- `"AutoCompacting"`: `data.context_size` and `data.context_window` at
+  trigger time.
+- `"CompactionDone"`: `data.context_size_before`,
+  `data.context_size_after`, and `data.context_window`.
+- `"PlanReady"`: `data.path`, the absolute path of the plan file the
+  agent just wrote. Fires once per draft.
+- `"SessionFocusChanged"`: `data.previous_session_id`, absent on the
+  first focus at startup.
+- `"SessionStatusChanged"`: `data.status` (`"working"`, `"needs_input"`,
+  or `"idle"`), `data.title`, and `data.focused` (boolean).
+- `"TaskStatusChanged"`: `data.id`, `data.name`, and `data.status`
+  (`"working"`, `"done"`, or `"error"`), when a subagent starts or
+  changes status. A task that comes back from disk already finished
+  stays quiet, so reloading a session does not replay old tasks.
+- `"ModelChanged"`: `data.model` in the shape `maki.model.get` returns,
+  plus `data.previous_spec`. Picking the model already in use stays
+  quiet, and so does startup.
+
+`"TurnEnd"` fires once per turn and only for the main session, so
+subagent turns never show up. A manual `/compact` ends its run without
+ending a turn, so it stays quiet too.
+
+Drivers are not all caught up. `"TurnStart"` and `"PlanReady"` come from
+`maki-ui` only. `maki-acp` runs the agent on its own loop and does not
+call the dispatcher yet, so plugins loaded under ACP receive no turn
+events. Everything else fires under `maki -p` and sdk mode as well.
 
 `"SessionEnd"` is the teardown signal: it fires first so handlers can
 still inspect or stop the session's jobs, then session-owned jobs are
@@ -3232,6 +3255,53 @@ local id = maki.session.current()
 
 ---
 
+### `maki.session.read()` {#maki-session-read}
+
+```lua
+maki.session.read({opts?})
+```
+
+One-call snapshot of a session: queue, usage, context, cost, mode, and
+status. Reads the focused session, or the one you name in `session` when
+you act on a background tab.
+
+The returned table:
+```
+{
+  id, cwd, model, mode = "build" | "plan",
+  status = "idle" | "working" | "needs_input",
+  focused, updated_at,
+  usage = { input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens },
+  context_size, context_window,
+  cost,
+  queue = { count }, -- nil under headless drivers
+  title,             -- nil under headless drivers
+}
+```
+
+`usage` and `cost` include subagent spend. `context_size` is the main
+session's own, since a subagent runs its own window. There is no
+`list_cost` here because `cost` is re-settled from stored usage when a
+session resumes and list price is not stored, so per-turn list price
+lives on the `TurnEnd` autocmd instead.
+
+**Parameters:**
+
+- `{opts?}` (`table?`) `session` (string?) Session id; defaults to focused.
+
+**Returns:** (`table|nil`, `string|nil`) Snapshot table, or nil and an error.
+
+**Example:**
+
+```lua
+local s = maki.session.read()
+if s.context_size > s.context_window * 0.8 then
+  maki.ui.notify("context is nearly full")
+end
+```
+
+---
+
 ### `maki.session.focus()` {#maki-session-focus}
 
 ```lua
@@ -4866,7 +4936,7 @@ and call this from it.
 
 Valid names: `"file_picker"`, `"search"`, `"help"`,
 `"plan_toggle"`, `"plan_editor"`, `"edit_input"`, `"pop_queue"`,
-`"prev_chat"`, `"next_chat"`.
+`"prev_chat"`, `"next_chat"`, `"model_picker"`.
 
 For slash commands rather than keybound actions, see
 `maki.api.run_command`.

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -284,6 +284,7 @@ pub fn run(mut cli: Cli) -> Result<()> {
             workflow: stack.config.always_workflow,
             model_policy: Arc::new(stack.config.provider.model_policy.clone()),
             plugin_rules: stack.plugin_host.plugin_rules(),
+            lua_handle: stack.plugin_host.event_handle(),
         })
         .context("run sdk mode")?;
         return Ok(());

--- a/src/print.rs
+++ b/src/print.rs
@@ -20,6 +20,7 @@ use maki_agent::permissions::PluginRuleStore;
 use maki_agent::tools::QUESTION_TOOL_NAME;
 use maki_agent::{AgentConfig, AgentEvent, DoneReason, Envelope, ImageSource, PermissionsConfig};
 use maki_config::ModelPolicy;
+use maki_lua::session_snapshot::{HeadlessMeta, HeadlessSnapshot, MODE_BUILD};
 use maki_lua::{EventHandle, SessionEndReason};
 use maki_providers::model::Model;
 use maki_providers::{TokenUsage, add_cost};
@@ -224,7 +225,29 @@ pub fn run(
     let mut cost = None;
     let mut stop_reason: Option<DoneReason> = None;
 
+    let snapshot = HeadlessSnapshot::default();
+    snapshot.install(
+        &lua_handle,
+        HeadlessMeta {
+            id: session_id.to_string(),
+            cwd: cwd.clone(),
+            model: model.spec(),
+        },
+        // `maki -p` always runs the agent in build mode
+        // (`headless::spawn` hardcodes `AgentMode::Build`).
+        || MODE_BUILD,
+    );
+
     while let Ok(envelope) = smol::block_on(event_rx.recv_async()) {
+        // Folded in first, so a plugin handling `TurnEnd` finds the finished
+        // totals when it calls `maki.session.read()`.
+        snapshot.observe(&envelope);
+        maki_lua::agent_autocmd::dispatch(
+            &lua_handle,
+            &session_id,
+            &envelope,
+            envelope.subagent.is_some(),
+        );
         let Envelope {
             ref event,
             ref subagent,
@@ -245,8 +268,8 @@ pub fn run(
             | AgentEvent::ToolDone(_)
             | AgentEvent::QueueItemConsumed { .. }
             | AgentEvent::QueueDrained
-            | AgentEvent::AutoCompacting
-            | AgentEvent::CompactionDone
+            | AgentEvent::AutoCompacting { .. }
+            | AgentEvent::CompactionDone { .. }
             | AgentEvent::AuthRequired
             | AgentEvent::PermissionRequest { .. }
             | AgentEvent::SubagentHistory { .. }
@@ -306,9 +329,14 @@ pub fn run(
                 usage: u,
                 num_turns: turns,
                 reason,
+                cost: dcost,
+                ..
             } => {
                 num_turns = *turns;
                 usage = *u;
+                // The agent's own ledger also counts compaction spend, which
+                // summing the turns misses.
+                cost = (*dcost).or(cost);
                 stop_reason = Some(*reason);
                 break;
             }

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -27,6 +27,7 @@ use maki_agent::{
     ToolOutput,
 };
 use maki_config::ModelPolicy;
+use maki_lua::session_snapshot::{HeadlessMeta, HeadlessSnapshot, MODE_BUILD, MODE_PLAN};
 use maki_providers::model::Model;
 use maki_providers::{ImageSource, Message, StopReason, Timeouts, TokenUsage, add_cost};
 use maki_storage::StateDir;
@@ -451,6 +452,9 @@ pub struct SdkParams {
     pub workflow: bool,
     pub model_policy: Arc<ModelPolicy>,
     pub plugin_rules: Arc<PluginRuleStore>,
+    /// Plugins loaded here still want turn events, and this is what fires
+    /// them the way `maki-ui` does.
+    pub lua_handle: maki_lua::EventHandle,
 }
 
 struct Shared {
@@ -472,6 +476,7 @@ pub fn run(params: SdkParams) -> Result<()> {
         workflow,
         model_policy,
         plugin_rules,
+        lua_handle,
     } = params;
     cli.warn_ignored_flags();
     if let Some(max) = cli.max_turns {
@@ -557,6 +562,22 @@ pub fn run(params: SdkParams) -> Result<()> {
         pending: HashSet::new(),
     }));
 
+    let snapshot = HeadlessSnapshot::default();
+    let shared_for_mode = Arc::clone(&shared);
+    snapshot.install(
+        &lua_handle,
+        HeadlessMeta {
+            id: handle.session_id.to_string(),
+            cwd: working_dir.clone(),
+            model: startup_model.spec(),
+        },
+        // `set_permission_mode` can flip this mid-run, so read it per call.
+        move || match shared_for_mode.lock().unwrap().permission_mode {
+            PermissionMode::Plan => MODE_PLAN,
+            _ => MODE_BUILD,
+        },
+    );
+
     let pump = EventPump {
         writer: writer.clone(),
         shared: Arc::clone(&shared),
@@ -567,6 +588,9 @@ pub fn run(params: SdkParams) -> Result<()> {
         result_text: String::new(),
         cost: None,
         request_counter: 0,
+        lua_handle: lua_handle.clone(),
+        session_id: handle.session_id.to_string(),
+        snapshot,
     }
     .spawn(handle.event_rx.clone());
 
@@ -868,12 +892,24 @@ struct EventPump {
     /// the rate it paid.
     cost: Option<f64>,
     request_counter: u64,
+    lua_handle: maki_lua::EventHandle,
+    session_id: String,
+    snapshot: HeadlessSnapshot,
 }
 
 impl EventPump {
     fn spawn(mut self, event_rx: Receiver<Envelope>) -> smol::Task<()> {
         smol::spawn(async move {
             while let Ok(envelope) = event_rx.recv_async().await {
+                // Folded in first, so a plugin handling `TurnEnd` finds the
+                // finished totals when it calls `maki.session.read()`.
+                self.snapshot.observe(&envelope);
+                maki_lua::agent_autocmd::dispatch(
+                    &self.lua_handle,
+                    &self.session_id,
+                    &envelope,
+                    envelope.subagent.is_some(),
+                );
                 if let Err(e) = self.handle(envelope) {
                     warn!(error = %e, "sdk event pump stopped");
                     break;
@@ -972,8 +1008,8 @@ impl EventPump {
             | AgentEvent::ToolDone(_)
             | AgentEvent::QueueItemConsumed { .. }
             | AgentEvent::QueueDrained
-            | AgentEvent::AutoCompacting
-            | AgentEvent::CompactionDone
+            | AgentEvent::AutoCompacting { .. }
+            | AgentEvent::CompactionDone { .. }
             | AgentEvent::AuthRequired
             | AgentEvent::SubagentHistory { .. }
             | AgentEvent::ToolSnapshot { .. }
@@ -1059,6 +1095,7 @@ impl EventPump {
                 usage,
                 num_turns,
                 reason,
+                ..
             } => {
                 // An interrupted run leaves a partial answer, so it is not a success.
                 let is_error = *reason == DoneReason::Cancelled;


### PR DESCRIPTION
Builds on #875 (top commit is this change).

Plugins that own an objective (goal loops, budget watchdogs, context managers) need the turn boundary: TurnEnd now carries reason (finished|cancelled|limit) so an auto-continue plugin can appeal a finished turn, always yield to a cancellation, and back off on limits. TurnComplete, AutoCompacting, and CompactionDone become autocmds exposing per-turn usage, cost, and context pressure. maki.session.queue() reads the pending message count without consuming it, so an injector yields when the human already typed.

Also: maki.ui.action docs list every builtin action, and code_execution child calls no longer have their dispatch deadline silently capped at the script budget when the call carries its own longer timeout input.