### PR TITLE
feat(code_execution): make MCP and client tools callable from python

### DIFF
--- a/maki-agent/src/agent/run.rs
+++ b/maki-agent/src/agent/run.rs
@@ -474,7 +474,6 @@ impl<'h> Agent<'h> {
         tool_dispatch::process_tool_calls(
             response,
             &mut self.recent_calls,
-            self.mcp.as_ref(),
             self.history,
             &self.event_tx,
             &ctx,
@@ -972,7 +971,7 @@ mod tests {
             let captured = Arc::clone(&provider.captured_tools);
             let mut history = History::new(Vec::new());
             let (agent, _event_rx) = make_agent(provider, &mut history);
-            let mut agent = agent.with_mcp(Some(crate::mcp::stub_session(&[(
+            let mut agent = agent.with_mcp(Some(crate::mcp::test_support::stub_session(&[(
                 "srv.fetch_issue",
                 "Fetch a GitHub issue",
             )])));

--- a/maki-agent/src/agent/tool_dispatch.rs
+++ b/maki-agent/src/agent/tool_dispatch.rs
@@ -10,16 +10,10 @@ use tracing::{debug, error, warn};
 
 use crate::mcp::{McpSession, TOOL_SEARCH_TOOL_NAME, UNKNOWN_MCP};
 use crate::task_set::TaskSet;
-use crate::tools::registry::{ToolInvocation, ToolRegistry};
-use crate::tools::{LocalToolFn, ToolContext, truncate_bytes};
+use crate::tools::registry::{RegisteredTool, ToolInvocation};
+use crate::tools::{CallOrigin, LocalToolFn, ToolContext, truncate_bytes};
 use crate::{AgentError, AgentEvent, ToolDoneEvent, ToolOutput, ToolStartEvent};
 use maki_config::ToolKey;
-
-#[derive(Clone, Copy)]
-pub enum Emit {
-    Notify,
-    Silent,
-}
 
 const DOOM_LOOP_THRESHOLD: usize = 3;
 const DOOM_LOOP_MESSAGE: &str = "You have called this tool with identical input 3 times in a row. You are stuck in a loop. Break out and try a different approach.";
@@ -27,11 +21,9 @@ const MCP_BLOCKED_IN_PLAN: &str = "MCP tools are not available in plan mode";
 const UNKNOWN_TOOL_PREFIX: &str = "unknown tool";
 const MCP_PERM_SCOPE_MAX_BYTES: usize = 200;
 
-const SOURCE_NATIVE: &str = "native";
 const SOURCE_LOCAL: &str = "local";
+const SOURCE_MCP: &str = "mcp";
 const SOURCE_UNKNOWN: &str = "unknown";
-/// A name that still carries one means the MCP server behind it is gone.
-const MCP_NAME_SEPARATOR: &str = "__";
 const BASH_TOOL: &str = "bash";
 const BASH_COMMAND_FIELD: &str = "command";
 const GIT_COMMIT: &str = "git commit";
@@ -83,58 +75,116 @@ impl RecentCalls {
 /// Every tool call in maki lands here (native, Lua, MCP, subagents, batch
 /// children), which makes it the one place telemetry has to wrap.
 pub async fn run(
-    registry: &ToolRegistry,
-    mcp: Option<&McpSession>,
     id: String,
     name: &str,
     input: &Value,
     ctx: &ToolContext,
-    emit: Emit,
+    origin: CallOrigin,
 ) -> ToolDoneEvent {
+    let resolved = resolve(ctx, name);
     if !maki_otel::enabled() {
-        return run_inner(registry, mcp, id, name, input, ctx, emit).await;
+        return run_inner(resolved, id, input, ctx, origin).await;
     }
-    let canonical = super::streaming::canonical_tool_name(name);
-    let source = tool_source(registry, ctx, canonical);
+    let name = resolved.name;
+    let source = resolved.route.source();
     let started = Instant::now();
-    let done = run_inner(registry, mcp, id, name, input, ctx, emit).await;
-    report(&done, canonical, &source, input, started.elapsed());
+    let done = run_inner(resolved, id, input, ctx, origin).await;
+    report(&done, name, &source, input, started.elapsed());
     done
+}
+
+/// Where a name goes for one context. Dispatch and telemetry read this one
+/// answer, so a name can never be reported as one thing and run as another.
+enum Route<'a> {
+    Local(&'a LocalToolFn),
+    Native(RegisteredTool),
+    ToolSearch(&'a McpSession),
+    Mcp(&'a McpSession, Arc<str>),
+    Unknown,
+}
+
+impl Route<'_> {
+    /// Registry tools report the plugin behind them, because "native" alone
+    /// tells whoever reads the metric nothing.
+    fn source(&self) -> Cow<'static, str> {
+        match self {
+            Self::Native(entry) => entry.source.as_log_field(),
+            Self::Local(_) => Cow::Borrowed(SOURCE_LOCAL),
+            Self::Mcp(..) => Cow::Borrowed(SOURCE_MCP),
+            Self::ToolSearch(_) => Cow::Borrowed(TOOL_SEARCH_TOOL_NAME),
+            Self::Unknown => Cow::Borrowed(SOURCE_UNKNOWN),
+        }
+    }
+}
+
+/// A canonical name paired with where it goes. Only [`resolve`] builds one, so
+/// no caller can act on a name it forgot to canonicalize.
+struct Resolved<'a> {
+    name: &'a str,
+    route: Route<'a>,
+}
+
+/// Precedence, highest first: client (ACP) tools, the registry, then MCP.
+/// The context is the only input, because resolving against one session and
+/// executing against another is how a tool escapes its audience.
+fn resolve<'a>(ctx: &'a ToolContext, name: &'a str) -> Resolved<'a> {
+    // Names coming back from model JSON (batch children, `call_tool`, the
+    // interpreter bridge) never passed through streaming.rs, so clean up here.
+    let name = super::streaming::canonical_tool_name(name);
+    let route = if let Some(local) = ctx.local_tools.get(name) {
+        Route::Local(local)
+    } else if let Some(entry) = ctx.registry.get(name) {
+        Route::Native(entry)
+    } else if let Some(mcp) = ctx.mcp.as_ref() {
+        match mcp.resolve(name) {
+            Some(qualified) => Route::Mcp(mcp, qualified),
+            None if name == TOOL_SEARCH_TOOL_NAME => Route::ToolSearch(mcp),
+            None => Route::Unknown,
+        }
+    } else {
+        Route::Unknown
+    };
+    Resolved { name, route }
 }
 
 /// Parse errors and unknown tools skip the start event so the UI never
 /// shows a phantom spinner.
 async fn run_inner(
-    registry: &ToolRegistry,
-    mcp: Option<&McpSession>,
+    resolved: Resolved<'_>,
     id: String,
-    name: &str,
     input: &Value,
     ctx: &ToolContext,
-    emit: Emit,
+    origin: CallOrigin,
 ) -> ToolDoneEvent {
-    // Covers names re-entering from model JSON (batch children, `call_tool`,
-    // the interpreter bridge); streamed names are canonicalized in streaming.rs.
-    let name = super::streaming::canonical_tool_name(name);
-    if let Some(local) = ctx.local_tools.get(name) {
-        return run_local_tool(local, id, name, input, ctx, emit).await;
-    }
-    let entry = registry.get(name);
-    // LLM providers send tool names in wire format (server__tool) but our
-    // internal index uses server.tool. Only convert if the name isn't a
-    // native tool — avoids mangling native names that happen to contain __.
-    let mcp_name;
-    let mcp_lookup = if entry.is_none() && name.contains("__") && mcp.is_some() {
-        mcp_name = crate::mcp::internal_tool_name(name);
-        mcp_name.as_str()
-    } else {
-        name
+    let name = resolved.name;
+    let entry = match resolved.route {
+        Route::Local(local) => return run_local_tool(local, id, name, input, ctx, origin).await,
+        Route::ToolSearch(mcp) => return run_tool_search(mcp, id, input, ctx, origin),
+        Route::Mcp(mcp, qualified) => {
+            emit_raw_start(
+                ctx,
+                origin,
+                &id,
+                &qualified,
+                format!("mcp: {qualified}"),
+                input,
+            );
+            return execute_mcp_tool(ctx, mcp, &id, qualified, input, origin).await;
+        }
+        Route::Unknown => {
+            warn!(tool = %name, "unknown tool");
+            return ToolDoneEvent {
+                id,
+                tool: Arc::from(UNKNOWN_MCP),
+                output: ToolOutput::Plain(format!("{UNKNOWN_TOOL_PREFIX}: {name}").into()),
+                is_error: true,
+                annotation: None,
+                written_path: None,
+            };
+        }
+        Route::Native(entry) => entry,
     };
-    let tool_id: Arc<str> = entry
-        .as_ref()
-        .map(|e| Arc::from(e.tool.name()))
-        .or_else(|| mcp.map(|m| m.interned_name(mcp_lookup)))
-        .unwrap_or_else(|| Arc::from(UNKNOWN_MCP));
+    let tool_id: Arc<str> = Arc::from(entry.tool.name());
     let started = Instant::now();
 
     let done_error = |msg: String| ToolDoneEvent {
@@ -146,106 +196,88 @@ async fn run_inner(
         written_path: None,
     };
 
-    if let Some(entry) = entry {
-        let invocation = match entry.tool.parse(input) {
-            Ok(inv) => inv,
-            Err(e) => {
+    let invocation = match entry.tool.parse(input) {
+        Ok(inv) => inv,
+        Err(e) => {
+            warn!(
+                tool = %name,
+                source = %entry.source.as_log_field(),
+                input_preview = %crate::tools::schema::preview(&input.to_string()),
+                error = %e,
+                "tool input parse failed"
+            );
+            return done_error(e.to_string());
+        }
+    };
+
+    if let Some(target) = invocation.mutable_path() {
+        let is_plan_target = ctx.mode.plan_path().is_some_and(|pp| target == pp);
+        if !is_plan_target {
+            if ctx.mode.plan_path().is_some() {
                 warn!(
                     tool = %name,
-                    source = %entry.source.as_log_field(),
-                    input_preview = %crate::tools::schema::preview(&input.to_string()),
-                    error = %e,
-                    "tool input parse failed"
+                    target = %target.display(),
+                    "blocked write in plan mode"
                 );
-                return done_error(e.to_string());
+                return done_error(crate::tools::PLAN_WRITE_RESTRICTED.into());
             }
-        };
-
-        if let Some(target) = invocation.mutable_path() {
-            let is_plan_target = ctx.mode.plan_path().is_some_and(|pp| target == pp);
-            if !is_plan_target {
-                if ctx.mode.plan_path().is_some() {
-                    warn!(
-                        tool = %name,
-                        target = %target.display(),
-                        "blocked write in plan mode"
-                    );
-                    return done_error(crate::tools::PLAN_WRITE_RESTRICTED.into());
-                }
-                if let Some(reason) = ctx.permissions.boundary_block_reason(target) {
-                    return done_error(reason);
-                }
+            if let Some(reason) = ctx.permissions.boundary_block_reason(target) {
+                return done_error(reason);
             }
         }
+    }
 
-        let header_result = invocation.start_header().await;
-        let start = ToolStartEvent {
-            id: id.clone(),
-            tool: Arc::clone(&tool_id),
-            summary: header_result.text(),
-            render_header: header_result.snapshot(),
-            annotation: invocation.start_annotation(),
-            input: None,
-            raw_input: Some(input.clone()),
-            output: invocation.start_output(ctx),
-        };
-        if matches!(emit, Emit::Notify) {
-            let _ = ctx.event_tx.send(AgentEvent::ToolStart(Box::new(start)));
-        }
+    let header_result = invocation.start_header().await;
+    let start = ToolStartEvent {
+        id: id.clone(),
+        tool: Arc::clone(&tool_id),
+        summary: header_result.text(),
+        render_header: header_result.snapshot(),
+        annotation: invocation.start_annotation(),
+        input: None,
+        raw_input: Some(input.clone()),
+        output: invocation.start_output(ctx),
+    };
+    if origin.is_model() {
+        let _ = ctx.event_tx.send(AgentEvent::ToolStart(Box::new(start)));
+    }
 
-        invocation.start(ctx).await;
+    invocation.start(ctx).await;
 
-        if let Err(e) = enforce_permission(invocation.as_ref(), name, ctx, &id).await {
-            return done_error(e);
-        }
+    if let Err(e) = enforce_permission(invocation.as_ref(), name, ctx, &id).await {
+        return done_error(e);
+    }
 
-        let result = invocation.execute(ctx).await;
+    let result = invocation.execute(ctx).await;
 
-        let elapsed = started.elapsed();
-        match result.output {
-            Ok(output) => {
-                debug!(
-                    tool = %name,
-                    source = %entry.source.as_log_field(),
-                    elapsed_ms = elapsed.as_millis() as u64,
-                    "tool ok"
-                );
-                ToolDoneEvent {
-                    id,
-                    tool: tool_id,
-                    output,
-                    is_error: false,
-                    annotation: result.annotation,
-                    written_path: result.written_path,
-                }
-            }
-            Err(message) => {
-                warn!(
-                    tool = %name,
-                    source = %entry.source.as_log_field(),
-                    elapsed_ms = elapsed.as_millis() as u64,
-                    error = %message,
-                    "tool failed"
-                );
-                done_error(message)
+    let elapsed = started.elapsed();
+    match result.output {
+        Ok(output) => {
+            debug!(
+                tool = %name,
+                source = %entry.source.as_log_field(),
+                elapsed_ms = elapsed.as_millis() as u64,
+                "tool ok"
+            );
+            ToolDoneEvent {
+                id,
+                tool: tool_id,
+                output,
+                is_error: false,
+                annotation: result.annotation,
+                written_path: result.written_path,
             }
         }
-    } else if let Some(mcp) = mcp.filter(|_| name == TOOL_SEARCH_TOOL_NAME) {
-        run_tool_search(mcp, id, input, ctx, emit)
-    } else if mcp.is_some_and(|m| m.has_tool(mcp_lookup)) {
-        emit_raw_start(
-            ctx,
-            emit,
-            &id,
-            &tool_id,
-            format!("mcp: {mcp_lookup}"),
-            input,
-        );
-        execute_mcp_tool(ctx, &id, tool_id, mcp_lookup, input).await
-    } else {
-        let msg = format!("{UNKNOWN_TOOL_PREFIX}: {mcp_lookup}");
-        warn!(tool = %mcp_lookup, "unknown tool");
-        done_error(msg)
+        Err(message) => {
+            warn!(
+                tool = %name,
+                source = %entry.source.as_log_field(),
+                elapsed_ms = elapsed.as_millis() as u64,
+                error = %message,
+                "tool failed"
+            );
+            done_error(message)
+        }
     }
 }
 
@@ -253,13 +285,13 @@ async fn run_inner(
 /// so there is no parsed input to show; the UI gets the raw JSON instead.
 fn emit_raw_start(
     ctx: &ToolContext,
-    emit: Emit,
+    origin: CallOrigin,
     id: &str,
     tool: &Arc<str>,
     summary: String,
     input: &Value,
 ) {
-    if !matches!(emit, Emit::Notify) {
+    if !origin.is_model() {
         return;
     }
     let start = ToolStartEvent {
@@ -282,12 +314,12 @@ fn run_tool_search(
     id: String,
     input: &Value,
     ctx: &ToolContext,
-    emit: Emit,
+    origin: CallOrigin,
 ) -> ToolDoneEvent {
     let tool_id: Arc<str> = Arc::from(TOOL_SEARCH_TOOL_NAME);
     let query = input["query"].as_str().unwrap_or_default();
-    emit_raw_start(ctx, emit, &id, &tool_id, query.to_owned(), input);
-    let (output, is_error) = match mcp.search_tools(query) {
+    emit_raw_start(ctx, origin, &id, &tool_id, query.to_owned(), input);
+    let (output, is_error) = match mcp.search_tools(query, origin) {
         Ok(out) => (out, false),
         Err(e) => (e, true),
     };
@@ -307,10 +339,10 @@ async fn run_local_tool(
     name: &str,
     input: &Value,
     ctx: &ToolContext,
-    emit: Emit,
+    origin: CallOrigin,
 ) -> ToolDoneEvent {
     let tool_id: Arc<str> = Arc::from(name);
-    emit_raw_start(ctx, emit, &id, &tool_id, name.to_owned(), input);
+    emit_raw_start(ctx, origin, &id, &tool_id, name.to_owned(), input);
     let tool_ctx = ToolContext {
         tool_use_id: Some(id.clone()),
         ..ctx.clone()
@@ -367,14 +399,15 @@ async fn enforce_permission(
 
 async fn execute_mcp_tool(
     ctx: &ToolContext,
+    mcp: &McpSession,
     id: &str,
-    tool_id: Arc<str>,
-    tool_name: &str,
+    tool: Arc<str>,
     input: &Value,
+    origin: CallOrigin,
 ) -> ToolDoneEvent {
     let done = |output: String, is_error: bool| ToolDoneEvent {
         id: id.to_owned(),
-        tool: Arc::clone(&tool_id),
+        tool: Arc::clone(&tool),
         output: ToolOutput::Plain(output.into()),
         is_error,
         annotation: None,
@@ -385,10 +418,10 @@ async fn execute_mcp_tool(
         return done(MCP_BLOCKED_IN_PLAN.into(), true);
     }
 
-    let perm_tool = match ToolKey::parse(tool_name) {
+    let perm_tool = match ToolKey::parse(&tool) {
         Ok(k) => k,
         Err(e) => {
-            return done(format!("invalid MCP tool key '{tool_name}': {e}"), true);
+            return done(format!("invalid MCP tool key '{tool}': {e}"), true);
         }
     };
     let perm_scope = truncate_bytes(&input.to_string(), MCP_PERM_SCOPE_MAX_BYTES);
@@ -410,14 +443,10 @@ async fn execute_mcp_tool(
         return done(e.to_string(), true);
     }
 
-    let Some(mcp) = &ctx.mcp else {
-        return done(format!("MCP manager not available for {tool_name}"), true);
-    };
-
-    // A permitted call to a deferred tool counts as loading it, so its full
-    // definition joins the next request; a denied call must not load anything.
-    mcp.mark_loaded(tool_name);
-    match mcp.call_tool(tool_name, input).await {
+    // A permitted call counts as loading the tool, so its definition joins the
+    // next request; a denied one must not load anything.
+    mcp.mark_loaded(&tool, origin);
+    match mcp.call_tool(&tool, input).await {
         Ok(text) => done(text, false),
         Err(e) => done(e.to_string(), true),
     }
@@ -427,7 +456,6 @@ async fn execute_mcp_tool(
 pub(super) async fn process_tool_calls(
     response: maki_providers::StreamResponse,
     recent_calls: &mut RecentCalls,
-    mcp: Option<&McpSession>,
     history: &mut super::history::History,
     event_tx: &crate::EventSender,
     ctx: &ToolContext,
@@ -472,18 +500,8 @@ pub(super) async fn process_tool_calls(
             tool_use_id: Some(id.clone()),
             ..ctx.clone()
         };
-        let mcp_owned = mcp.cloned();
         set.spawn(async move {
-            let done = run(
-                &tool_ctx.registry,
-                mcp_owned.as_ref(),
-                id,
-                &name,
-                &input,
-                &tool_ctx,
-                Emit::Notify,
-            )
-            .await;
+            let done = run(id, &name, &input, &tool_ctx, CallOrigin::Model).await;
             event_tx_clone.try_send(AgentEvent::ToolDone(Box::new(done.clone())));
             done
         });
@@ -511,17 +529,6 @@ pub(super) async fn process_tool_calls(
     })?;
     history.push(tool_msg);
     Ok(())
-}
-
-fn tool_source(registry: &ToolRegistry, ctx: &ToolContext, name: &str) -> Cow<'static, str> {
-    if ctx.local_tools.contains_key(name) {
-        return Cow::Borrowed(SOURCE_LOCAL);
-    }
-    match registry.get(name) {
-        Some(entry) => entry.source.as_log_field(),
-        None if name.contains(MCP_NAME_SEPARATOR) => Cow::Borrowed(SOURCE_UNKNOWN),
-        None => Cow::Borrowed(SOURCE_NATIVE),
-    }
 }
 
 /// Low-cardinality buckets, because a raw error message would give the
@@ -596,37 +603,43 @@ fn report(done: &ToolDoneEvent, name: &str, source: &str, input: &Value, took: D
     }
 }
 
-/// Test-only entry that skips native lookup, letting plan-mode and MCP tests
-/// exercise the dispatch path without registering a fake native tool.
-#[cfg(test)]
-async fn dispatch_mcp(
-    ctx: &ToolContext,
-    id: &str,
-    tool_name: &str,
-    input: &Value,
-) -> ToolDoneEvent {
-    let tool_id = ctx
-        .mcp
-        .as_ref()
-        .map(|m| m.interned_name(tool_name))
-        .unwrap_or_else(|| Arc::from(UNKNOWN_MCP));
-    execute_mcp_tool(ctx, id, tool_id, tool_name, input).await
-}
-
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use maki_config::{Effect, PermissionRule, PermissionsConfig, ToolKey};
-    use tempfile::TempDir;
     use test_case::test_case;
 
     use super::*;
     use crate::AgentMode;
+    use crate::mcp::test_support::stub_session;
+    use crate::mcp::tool_names;
     use crate::permissions::{PERMISSION_DENIED_PREFIX, PermissionManager};
-    use crate::tools::registry::ToolSource;
-    use crate::tools::test_support::{GUARDED_TOOL_NAME, GuardedMock};
+    use crate::tools::interpreter_bridge::context_tools;
+    use crate::tools::registry::{ToolRegistry, ToolSource};
+    use crate::tools::test_support::{
+        GUARDED_TOOL_NAME, GuardedMock, mock_tool, stub_ctx, stub_ctx_with_permissions,
+    };
+    use crate::tools::{
+        BoxFuture, DescriptionContext, ExecFuture, HeaderFuture, HeaderResult, ParseError,
+        PermissionScopes, Tool, ToolAudience, ToolExecResult,
+    };
+
+    const TEST_ID: &str = "t1";
+    const PROBE_WIRE: &str = "srv__probe";
+    const PROBE_QUALIFIED: &str = "srv.probe";
+    const OTHER_WIRE: &str = "srv__other";
+    const OTHER_QUALIFIED: &str = "srv.other";
+    const SHADOWED_NAME: &str = "batch";
+    const CLIENT_NAME: &str = "client_probe";
+    const TEST_PLUGIN: &str = "test";
+    const TEST_PLUGIN_SOURCE: &str = "lua:test";
+    const START_PROBE_NAME: &str = "start_probe";
+    /// Allowed by the shared stub permissions; nothing is ever written here.
+    const TEST_ROOT: &str = "/tmp";
+    const PLAN_PATH: &str = "/tmp/plan.md";
 
     fn recent_calls(entries: &[(&str, Value)]) -> RecentCalls {
         let mut rc = RecentCalls::new();
@@ -667,34 +680,84 @@ mod tests {
         ctx
     }
 
+    async fn dispatch(ctx: &ToolContext, name: &str, input: &Value) -> ToolDoneEvent {
+        run(TEST_ID.into(), name, input, ctx, CallOrigin::Model).await
+    }
+
+    async fn dispatch_nested(ctx: &ToolContext, name: &str, input: &Value) -> ToolDoneEvent {
+        run(TEST_ID.into(), name, input, ctx, CallOrigin::Nested).await
+    }
+
+    fn with_mcp(mut ctx: ToolContext, mcp: &McpSession) -> ToolContext {
+        ctx.mcp = Some(mcp.clone());
+        ctx
+    }
+
+    /// Publishes the tools with empty descriptions: search matches on the name.
+    fn stub_mcp(qualified: &[&str]) -> McpSession {
+        let tools: Vec<_> = qualified.iter().map(|name| (*name, "")).collect();
+        stub_session(&tools)
+    }
+
+    fn mcp_ctx(mcp: &McpSession) -> ToolContext {
+        with_mcp(stub_ctx(&AgentMode::Build), mcp)
+    }
+
+    fn registered(tool: Arc<dyn Tool>) -> Arc<ToolRegistry> {
+        let registry = ToolRegistry::new();
+        register(&registry, tool);
+        Arc::new(registry)
+    }
+
+    fn register(registry: &ToolRegistry, tool: Arc<dyn Tool>) {
+        registry
+            .register(
+                tool,
+                ToolSource::Lua {
+                    plugin: TEST_PLUGIN.into(),
+                },
+            )
+            .unwrap();
+    }
+
+    fn registry_with(names: &[&str]) -> Arc<ToolRegistry> {
+        let registry = ToolRegistry::new();
+        for name in names {
+            register(&registry, mock_tool(name, ToolAudience::all()));
+        }
+        Arc::new(registry)
+    }
+
+    fn denying_ctx(tool: ToolKey) -> ToolContext {
+        let config = PermissionsConfig {
+            rules: vec![PermissionRule {
+                tool,
+                scope: None,
+                effect: Effect::Deny,
+            }],
+            ..Default::default()
+        };
+        let permissions = Arc::new(PermissionManager::new(
+            config,
+            PathBuf::from(TEST_ROOT),
+            Arc::default(),
+        ));
+        stub_ctx_with_permissions(&AgentMode::Build, permissions)
+    }
+
     #[test]
     fn local_tool_shadows_registry_and_maps_errors() {
         smol::block_on(async {
-            let ctx = local_ctx("batch", |input| Ok(format!("local:{}", input["path"])));
-            let done = run(
-                ToolRegistry::global(),
-                None,
-                "t1".into(),
-                "batch",
-                &serde_json::json!({"path": "/a"}),
-                &ctx,
-                Emit::Silent,
-            )
-            .await;
+            let mut ctx = local_ctx(SHADOWED_NAME, |input| {
+                Ok(format!("local:{}", input["path"]))
+            });
+            ctx.registry = registry_with(&[SHADOWED_NAME]);
+            let done = dispatch(&ctx, SHADOWED_NAME, &serde_json::json!({"path": "/a"})).await;
             assert!(!done.is_error);
             assert_eq!(done.output.as_text(), r#"local:"/a""#);
 
             let ctx = local_ctx("boom", |_| Err("nope".into()));
-            let done = run(
-                ToolRegistry::global(),
-                None,
-                "t2".into(),
-                "boom",
-                &serde_json::json!({}),
-                &ctx,
-                Emit::Silent,
-            )
-            .await;
+            let done = dispatch(&ctx, "boom", &serde_json::json!({})).await;
             assert!(done.is_error);
             assert_eq!(done.output.as_text(), "nope");
         });
@@ -704,16 +767,7 @@ mod tests {
     fn functions_prefixed_name_dispatches_to_canonical_tool() {
         smol::block_on(async {
             let ctx = local_ctx("ok", |_| Ok("ran".into()));
-            let done = run(
-                ToolRegistry::global(),
-                None,
-                "t1".into(),
-                "functions.ok",
-                &serde_json::json!({}),
-                &ctx,
-                Emit::Silent,
-            )
-            .await;
+            let done = dispatch(&ctx, "functions.ok", &serde_json::json!({})).await;
             assert!(!done.is_error);
             assert_eq!(done.output.as_text(), "ran");
         });
@@ -737,16 +791,7 @@ mod tests {
             ctx.local_tools = Arc::new(map);
 
             let input = serde_json::json!({"path": "/a"});
-            let done = run(
-                ToolRegistry::global(),
-                None,
-                "t1".into(),
-                "local_echo",
-                &input,
-                &ctx,
-                Emit::Notify,
-            )
-            .await;
+            let done = dispatch(&ctx, "local_echo", &input).await;
             assert!(!done.is_error);
 
             let envelope = rx
@@ -764,26 +809,21 @@ mod tests {
     #[test]
     fn tool_search_routes_and_loads_matches() {
         smol::block_on(async {
-            let mcp = crate::mcp::stub_session(&[("srv.fetch_issue", "Fetch a GitHub issue")]);
-            let ctx = crate::tools::test_support::stub_ctx(&AgentMode::Build);
-            let done = run(
-                ToolRegistry::global(),
-                Some(&mcp),
-                "t1".into(),
+            let mcp = stub_mcp(&[PROBE_QUALIFIED]);
+            let done = dispatch(
+                &mcp_ctx(&mcp),
                 TOOL_SEARCH_TOOL_NAME,
-                &serde_json::json!({"query": "issue"}),
-                &ctx,
-                Emit::Silent,
+                &serde_json::json!({"query": "probe"}),
             )
             .await;
             assert!(!done.is_error, "got: {}", done.output.as_text());
             assert_eq!(done.tool.as_ref(), TOOL_SEARCH_TOOL_NAME);
-            assert!(done.output.as_text().contains("srv__fetch_issue"));
+            assert!(done.output.as_text().contains(PROBE_WIRE));
 
             let mut tools = serde_json::json!([]);
             mcp.extend_tools(&mut tools);
             assert!(
-                crate::mcp::tool_names(&tools).contains(&"srv__fetch_issue"),
+                tool_names(&tools).contains(&PROBE_WIRE),
                 "searched tool must join the next request"
             );
         });
@@ -793,16 +833,10 @@ mod tests {
     #[test_case(serde_json::json!({}) ; "missing_query")]
     fn tool_search_bad_query_is_error_event(input: Value) {
         smol::block_on(async {
-            let mcp = crate::mcp::stub_session(&[("srv.tool", "")]);
-            let ctx = crate::tools::test_support::stub_ctx(&AgentMode::Build);
-            let done = run(
-                ToolRegistry::global(),
-                Some(&mcp),
-                "t1".into(),
+            let done = dispatch(
+                &mcp_ctx(&stub_mcp(&[PROBE_QUALIFIED])),
                 TOOL_SEARCH_TOOL_NAME,
                 &input,
-                &ctx,
-                Emit::Silent,
             )
             .await;
             assert!(done.is_error);
@@ -813,27 +847,37 @@ mod tests {
     #[test]
     fn calling_deferred_mcp_tool_marks_it_loaded() {
         smol::block_on(async {
-            let mcp = crate::mcp::stub_session(&[("srv.fetch_issue", "")]);
-            let mut ctx = crate::tools::test_support::stub_ctx(&AgentMode::Build);
-            ctx.mcp = Some(mcp.clone());
-            let done = run(
-                ToolRegistry::global(),
-                Some(&mcp),
-                "t1".into(),
-                "srv__fetch_issue",
-                &serde_json::json!({}),
-                &ctx,
-                Emit::Silent,
-            )
-            .await;
-            assert_eq!(done.tool.as_ref(), "srv.fetch_issue", "must route to MCP");
+            let mcp = stub_mcp(&[PROBE_QUALIFIED]);
+            let done = dispatch(&mcp_ctx(&mcp), PROBE_WIRE, &serde_json::json!({})).await;
+            assert_eq!(done.tool.as_ref(), PROBE_QUALIFIED, "must route to MCP");
 
             let mut tools = serde_json::json!([]);
             mcp.extend_tools(&mut tools);
             assert_eq!(
-                crate::mcp::tool_names(&tools),
-                vec!["srv__fetch_issue"],
+                tool_names(&tools),
+                vec![PROBE_WIRE],
                 "called tool must join the next request"
+            );
+        });
+    }
+
+    /// `McpSession::new` rebuilds the loaded set from the `ToolUse` blocks in
+    /// history, which hold no nested call, so loading one here would make the
+    /// live tool array differ from the resumed one.
+    #[test_case(PROBE_WIRE, serde_json::json!({}), PROBE_QUALIFIED ; "tool_call")]
+    #[test_case(TOOL_SEARCH_TOOL_NAME, serde_json::json!({"query": "probe"}), TOOL_SEARCH_TOOL_NAME ; "tool_search")]
+    fn nested_call_reaches_mcp_without_loading_anything(name: &str, input: Value, routed: &str) {
+        smol::block_on(async {
+            let mcp = stub_mcp(&[PROBE_QUALIFIED]);
+            let done = dispatch_nested(&mcp_ctx(&mcp), name, &input).await;
+            assert_eq!(done.tool.as_ref(), routed, "must route to MCP");
+
+            let mut tools = serde_json::json!([]);
+            mcp.extend_tools(&mut tools);
+            assert_eq!(
+                tool_names(&tools),
+                vec![TOOL_SEARCH_TOOL_NAME],
+                "a nested call must not change the next request"
             );
         });
     }
@@ -841,36 +885,9 @@ mod tests {
     #[test]
     fn denied_mcp_call_does_not_load_definition() {
         smol::block_on(async {
-            let mcp = crate::mcp::stub_session(&[("srv.fetch_issue", "")]);
-            let deny_cfg = PermissionsConfig {
-                rules: vec![PermissionRule {
-                    tool: ToolKey::parse("srv.fetch_issue").unwrap(),
-                    scope: None,
-                    effect: Effect::Deny,
-                }],
-                ..Default::default()
-            };
-            let dir = TempDir::new().unwrap();
-            let permissions = Arc::new(PermissionManager::new(
-                deny_cfg,
-                dir.path().to_path_buf(),
-                Arc::default(),
-            ));
-            let mut ctx = crate::tools::test_support::stub_ctx_with_permissions(
-                &AgentMode::Build,
-                permissions,
-            );
-            ctx.mcp = Some(mcp.clone());
-            let done = run(
-                ToolRegistry::global(),
-                Some(&mcp),
-                "t1".into(),
-                "srv__fetch_issue",
-                &serde_json::json!({}),
-                &ctx,
-                Emit::Silent,
-            )
-            .await;
+            let mcp = stub_mcp(&[PROBE_QUALIFIED]);
+            let ctx = with_mcp(denying_ctx(ToolKey::parse(PROBE_QUALIFIED).unwrap()), &mcp);
+            let done = dispatch(&ctx, PROBE_WIRE, &serde_json::json!({})).await;
             assert!(done.is_error);
             assert!(
                 done.output.as_text().starts_with(PERMISSION_DENIED_PREFIX),
@@ -881,7 +898,7 @@ mod tests {
             let mut tools = serde_json::json!([]);
             mcp.extend_tools(&mut tools);
             assert_eq!(
-                crate::mcp::tool_names(&tools),
+                tool_names(&tools),
                 vec![TOOL_SEARCH_TOOL_NAME],
                 "denied call must not load the definition"
             );
@@ -891,16 +908,15 @@ mod tests {
     #[test]
     fn local_tool_named_tool_search_shadows_mcp_search() {
         smol::block_on(async {
-            let mcp = crate::mcp::stub_session(&[("srv.tool", "")]);
-            let ctx = local_ctx(TOOL_SEARCH_TOOL_NAME, |_| Ok("local wins".into()));
-            let done = run(
-                ToolRegistry::global(),
-                Some(&mcp),
-                "t1".into(),
-                TOOL_SEARCH_TOOL_NAME,
-                &serde_json::json!({"query": "tool"}),
+            let mcp = stub_mcp(&[PROBE_QUALIFIED]);
+            let ctx = with_mcp(
+                local_ctx(TOOL_SEARCH_TOOL_NAME, |_| Ok("local wins".into())),
+                &mcp,
+            );
+            let done = dispatch(
                 &ctx,
-                Emit::Silent,
+                TOOL_SEARCH_TOOL_NAME,
+                &serde_json::json!({"query": "probe"}),
             )
             .await;
             assert_eq!(done.output.as_text(), "local wins");
@@ -908,101 +924,88 @@ mod tests {
     }
 
     #[test]
-    fn unknown_tool_returns_error_event() {
+    fn telemetry_source_names_the_plugin_for_registry_tools() {
+        let mut ctx = mcp_ctx(&stub_mcp(&[PROBE_QUALIFIED, OTHER_QUALIFIED]));
+        ctx.registry = registry_with(&[PROBE_WIRE]);
+        assert_eq!(resolve(&ctx, PROBE_WIRE).route.source(), TEST_PLUGIN_SOURCE);
+        assert_eq!(resolve(&ctx, OTHER_WIRE).route.source(), SOURCE_MCP);
+    }
+
+    #[test]
+    fn resolve_prefers_local_over_registry_and_registry_over_mcp() {
+        let mcp = stub_mcp(&[PROBE_QUALIFIED]);
+        let mut ctx = with_mcp(local_ctx(PROBE_WIRE, |_| Ok(String::new())), &mcp);
+        ctx.registry = registry_with(&[PROBE_WIRE]);
+
+        assert!(matches!(resolve(&ctx, PROBE_WIRE).route, Route::Local(_)));
+
+        ctx.local_tools = Arc::default();
+        assert!(matches!(resolve(&ctx, PROBE_WIRE).route, Route::Native(_)));
+
+        ctx.registry = Arc::new(ToolRegistry::new());
+        assert!(matches!(resolve(&ctx, PROBE_WIRE).route, Route::Mcp(..)));
+    }
+
+    /// A registry entry is an audience decision about that name, so any name the
+    /// registry holds stays unbound, be it one MCP publishes or one a client
+    /// tool shadows. Deferred MCP tools do bind: hidden from the tool array is
+    /// not the same as uncallable.
+    #[test]
+    fn context_tools_bind_only_names_the_registry_does_not_hold() {
+        let ctx = stub_ctx(&AgentMode::Build);
+        assert!(
+            context_tools(&ctx).is_empty(),
+            "without MCP and client tools there is nothing to bind"
+        );
+
+        let mcp = stub_mcp(&[PROBE_QUALIFIED, OTHER_QUALIFIED]);
+        let mut ctx = with_mcp(local_ctx(CLIENT_NAME, |_| Ok(String::new())), &mcp);
+        assert_eq!(
+            context_tools(&ctx),
+            [CLIENT_NAME, OTHER_WIRE, PROBE_WIRE, TOOL_SEARCH_TOOL_NAME]
+        );
+
+        ctx.registry = registry_with(&[PROBE_WIRE, CLIENT_NAME]);
+        assert_eq!(context_tools(&ctx), [OTHER_WIRE, TOOL_SEARCH_TOOL_NAME]);
+    }
+
+    /// The model only fixes names it recognizes, so it hears back what it sent.
+    #[test_case(None, "nonexistent.tool" ; "without_mcp")]
+    #[test_case(Some(PROBE_QUALIFIED), OTHER_WIRE ; "unpublished_wire_name")]
+    fn unknown_tool_errors_and_echoes_the_name_verbatim(published: Option<&str>, name: &str) {
         smol::block_on(async {
-            let ctx = crate::tools::test_support::stub_ctx(&AgentMode::Build);
-            let done = run(
-                &ctx.registry,
-                None,
-                "t1".into(),
-                "nonexistent.tool",
-                &serde_json::json!({}),
-                &ctx,
-                Emit::Silent,
-            )
-            .await;
+            let mcp = published.map(|tool| stub_mcp(&[tool]));
+            let ctx = match &mcp {
+                Some(mcp) => mcp_ctx(mcp),
+                None => stub_ctx(&AgentMode::Build),
+            };
+            let done = dispatch(&ctx, name, &serde_json::json!({})).await;
             assert!(done.is_error);
             assert_eq!(done.tool.as_ref(), UNKNOWN_MCP);
             let text = done.output.as_text();
-            assert!(text.starts_with(UNKNOWN_TOOL_PREFIX));
-            assert!(text.contains("nonexistent.tool"));
+            assert!(text.starts_with(UNKNOWN_TOOL_PREFIX), "got: {text}");
+            assert!(text.contains(name), "got: {text}");
         });
     }
 
     #[test]
     fn mcp_tool_blocked_in_plan_mode() {
         smol::block_on(async {
-            let result = dispatch_mcp(
-                &crate::tools::test_support::stub_ctx(&AgentMode::Plan(PathBuf::from(
-                    "/tmp/plan.md",
-                ))),
-                "t1",
-                "myserver.mytool",
-                &serde_json::json!({}),
-            )
-            .await;
-            assert!(result.is_error);
-            assert_eq!(result.output.as_text(), MCP_BLOCKED_IN_PLAN);
-        });
-    }
-
-    #[test]
-    fn mcp_tool_errors_without_mcp_manager() {
-        smol::block_on(async {
-            let result = dispatch_mcp(
-                &crate::tools::test_support::stub_ctx(&AgentMode::Build),
-                "t1",
-                "myserver.mytool",
-                &serde_json::json!({}),
-            )
-            .await;
-            assert!(result.is_error);
-            assert!(result.output.as_text().contains("not available"));
+            let plan = AgentMode::Plan(PathBuf::from(PLAN_PATH));
+            let ctx = with_mcp(stub_ctx(&plan), &stub_mcp(&[PROBE_QUALIFIED]));
+            let done = dispatch(&ctx, PROBE_WIRE, &serde_json::json!({})).await;
+            assert!(done.is_error);
+            assert_eq!(done.output.as_text(), MCP_BLOCKED_IN_PLAN);
         });
     }
 
     #[test]
     fn permission_denial_short_circuits_execute() {
         smol::block_on(async {
-            let deny_cfg = PermissionsConfig {
-                rules: vec![PermissionRule {
-                    tool: ToolKey::native(GUARDED_TOOL_NAME),
-                    scope: None,
-                    effect: Effect::Deny,
-                }],
-                ..Default::default()
-            };
-            let dir = TempDir::new().unwrap();
-            let permissions = Arc::new(PermissionManager::new(
-                deny_cfg,
-                dir.path().to_path_buf(),
-                Arc::default(),
-            ));
-            let ctx = crate::tools::test_support::stub_ctx_with_permissions(
-                &AgentMode::Build,
-                permissions,
-            );
+            let mut ctx = denying_ctx(ToolKey::native(GUARDED_TOOL_NAME));
+            ctx.registry = registered(Arc::new(GuardedMock));
 
-            let registry = ToolRegistry::new();
-            registry
-                .register(
-                    Arc::new(GuardedMock),
-                    ToolSource::Lua {
-                        plugin: "test".into(),
-                    },
-                )
-                .unwrap();
-
-            let done = run(
-                &registry,
-                None,
-                "t1".into(),
-                GUARDED_TOOL_NAME,
-                &serde_json::json!({}),
-                &ctx,
-                Emit::Silent,
-            )
-            .await;
+            let done = dispatch(&ctx, GUARDED_TOOL_NAME, &serde_json::json!({})).await;
 
             assert!(done.is_error, "permission denial must produce error event");
             assert!(
@@ -1012,15 +1015,6 @@ mod tests {
             );
         });
     }
-
-    const START_PROBE_NAME: &str = "start_probe";
-
-    use std::sync::atomic::{AtomicBool, Ordering};
-
-    use crate::tools::{
-        BoxFuture, DescriptionContext, ExecFuture, HeaderFuture, HeaderResult, ParseError,
-        PermissionScopes, Tool, ToolExecResult,
-    };
 
     #[derive(Default)]
     struct StartProbe {
@@ -1076,47 +1070,12 @@ mod tests {
     #[test]
     fn start_runs_before_permission_denial_blocks_execute() {
         smol::block_on(async {
-            let deny_cfg = PermissionsConfig {
-                rules: vec![PermissionRule {
-                    tool: ToolKey::native(START_PROBE_NAME),
-                    scope: None,
-                    effect: Effect::Deny,
-                }],
-                ..Default::default()
-            };
-            let dir = TempDir::new().unwrap();
-            let permissions = Arc::new(PermissionManager::new(
-                deny_cfg,
-                dir.path().to_path_buf(),
-                Arc::default(),
-            ));
-            let ctx = crate::tools::test_support::stub_ctx_with_permissions(
-                &AgentMode::Build,
-                permissions,
-            );
-
+            let mut ctx = denying_ctx(ToolKey::native(START_PROBE_NAME));
             let probe = StartProbe::default();
             let (started, executed) = (Arc::clone(&probe.started), Arc::clone(&probe.executed));
-            let registry = ToolRegistry::new();
-            registry
-                .register(
-                    Arc::new(probe),
-                    ToolSource::Lua {
-                        plugin: "test".into(),
-                    },
-                )
-                .unwrap();
+            ctx.registry = registered(Arc::new(probe));
 
-            let done = run(
-                &registry,
-                None,
-                "t1".into(),
-                START_PROBE_NAME,
-                &serde_json::json!({}),
-                &ctx,
-                Emit::Silent,
-            )
-            .await;
+            let done = dispatch(&ctx, START_PROBE_NAME, &serde_json::json!({})).await;
 
             assert!(done.is_error, "denial must error");
             assert!(

--- a/maki-agent/src/headless.rs
+++ b/maki-agent/src/headless.rs
@@ -107,6 +107,7 @@ fn setup(
     config: &AgentConfig,
     excluded_tools: &[&'static str],
     workflow: bool,
+    mcp: bool,
 ) -> AgentSetup {
     let vars = template::env_vars();
     let instructions = agent::load_instructions(&vars.apply("{cwd}"));
@@ -117,6 +118,7 @@ fn setup(
         excluded_tools,
         workflow,
         ToolRegistry::global(),
+        mcp,
     );
 
     AgentSetup {
@@ -135,12 +137,14 @@ fn tool_definitions(
     excluded_tools: &[&'static str],
     workflow: bool,
     registry: &ToolRegistry,
+    mcp: bool,
 ) -> Value {
     let filter = ToolFilter::from_config(config, model, excluded_tools);
     let ctx = DescriptionContext {
         filter: &filter,
         audience: ToolAudience::MAIN,
         workflow,
+        mcp,
     };
     registry.definitions(vars, &ctx, model.supports_tool_examples())
 }
@@ -167,6 +171,7 @@ pub fn spawn(params: HeadlessParams) -> HeadlessHandle {
         &params.config,
         &params.excluded_tools,
         params.workflow,
+        params.mcp_handle.is_some(),
     );
 
     let system = agent::build_system_prompt(
@@ -318,6 +323,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
         &params.config,
         &params.excluded_tools,
         params.workflow,
+        params.mcp_handle.is_some(),
     );
 
     let mcp = params
@@ -411,6 +417,7 @@ pub fn spawn_interactive(params: InteractiveParams) -> InteractiveHandle {
                                 &params.excluded_tools,
                                 params.workflow,
                                 ToolRegistry::global(),
+                                mcp.is_some(),
                             );
                             model = new_model;
                         }
@@ -616,7 +623,8 @@ mod tests {
     #[test]
     fn advertised_names_show_tool_search_not_deferred_tools() {
         let base = serde_json::json!([{"name": "read"}]);
-        let mcp = crate::mcp::stub_session(&[("srv.fetch_issue", "Fetch a GitHub issue")]);
+        let mcp =
+            crate::mcp::test_support::stub_session(&[("srv.fetch_issue", "Fetch a GitHub issue")]);
         let names = advertised_tool_names(&base, Some(&mcp));
         assert_eq!(
             names,

--- a/maki-agent/src/mcp/mod.rs
+++ b/maki-agent/src/mcp/mod.rs
@@ -43,6 +43,7 @@ use self::error::McpError;
 use self::http::HttpTransport;
 use self::stdio::StdioTransport;
 use self::transport::McpTransport;
+use crate::tools::CallOrigin;
 use crate::tools::schema::sanitize_tool_input_schema;
 
 const SEPARATOR: &str = ".";
@@ -61,6 +62,10 @@ const DESCRIPTION_HIT_SCORE: usize = 1;
 const MAX_OVERFLOW_NAMES: usize = 20;
 const SEARCH_NO_MATCH: &str = "No deferred MCP tools matched";
 const SEARCH_OVERFLOW_PREFIX: &str = "Also matched but not loaded: ";
+/// A nested search loads nothing, so it must not promise a next request that
+/// carries the matches.
+const SEARCH_HEADER_MODEL: (&str, &str) = ("Loaded", ", callable from your next message:");
+const SEARCH_HEADER_NESTED: (&str, &str) = ("Matched", ", callable here by name:");
 pub(crate) const SEARCH_EMPTY_QUERY: &str = "query must not be empty";
 
 /// Convert internal qualified name (`server.tool`) to wire format (`server__tool`)
@@ -387,10 +392,12 @@ impl McpSession {
         }
     }
 
-    /// Rank deferred tools against `query` keywords (exact name first,
-    /// then name hits over description hits) and mark the top
-    /// `MAX_SEARCH_LOADS` loaded; their definitions join the next request.
-    pub fn search_tools(&self, query: &str) -> Result<String, String> {
+    /// Rank deferred tools against `query` keywords (exact name first, then
+    /// name hits over description hits). A model-originated search marks the
+    /// top `MAX_SEARCH_LOADS` loaded so their definitions join the next
+    /// request; a nested one only reports the names, which the sandbox can
+    /// already call.
+    pub fn search_tools(&self, query: &str, origin: CallOrigin) -> Result<String, String> {
         let q = query.trim().to_lowercase();
         let tokens: Vec<&str> = q
             .split(|c: char| !c.is_alphanumeric())
@@ -433,35 +440,41 @@ impl McpSession {
                 .cmp(&(a.0, a.1))
                 .then_with(|| a.2.wire_name().cmp(b.2.wire_name()))
         });
-        let mut loaded = self.lock_loaded();
-        let mut hits: Vec<&str> = Vec::new();
-        let mut overflow: Vec<&str> = Vec::new();
-        for (_, _, d) in &matches {
-            if hits.len() < MAX_SEARCH_LOADS {
+        let (hits, overflow) = matches.split_at(matches.len().min(MAX_SEARCH_LOADS));
+        if origin.is_model() {
+            let mut loaded = self.lock_loaded();
+            for (_, _, d) in hits {
                 loaded.insert(Arc::clone(&d.qualified_name));
-                hits.push(d.wire_name());
-            } else {
-                overflow.push(d.wire_name());
             }
         }
-        drop(loaded);
-        info!(query = %q, loaded = hits.len(), overflow = overflow.len(), "MCP tool search");
+        info!(
+            query = %q,
+            hits = hits.len(),
+            overflow = overflow.len(),
+            origin = ?origin,
+            "MCP tool search"
+        );
         if hits.is_empty() {
             return Ok(format!(
                 "{SEARCH_NO_MATCH} '{query}'. Try other keywords or an exact name from the catalog."
             ));
         }
         let plural = if hits.len() == 1 { "tool" } else { "tools" };
-        let mut out = format!(
-            "Loaded {} {plural}, callable from your next message:",
-            hits.len()
-        );
-        for hit in &hits {
-            out.push_str(&format!("\n- `{hit}`"));
+        let (verb, tail) = if origin.is_model() {
+            SEARCH_HEADER_MODEL
+        } else {
+            SEARCH_HEADER_NESTED
+        };
+        let mut out = format!("{verb} {} {plural}{tail}", hits.len());
+        for (_, _, d) in hits {
+            out.push_str(&format!("\n- `{}`", d.wire_name()));
         }
         if !overflow.is_empty() {
             let shown = overflow.len().min(MAX_OVERFLOW_NAMES);
-            let names: Vec<String> = overflow[..shown].iter().map(|n| format!("`{n}`")).collect();
+            let names: Vec<String> = overflow[..shown]
+                .iter()
+                .map(|(_, _, d)| format!("`{}`", d.wire_name()))
+                .collect();
             out.push_str(&format!("\n{SEARCH_OVERFLOW_PREFIX}{}", names.join(", ")));
             if overflow.len() > shown {
                 out.push_str(&format!(" and {} more", overflow.len() - shown));
@@ -471,10 +484,30 @@ impl McpSession {
         Ok(out)
     }
 
+    /// Every published tool's wire name, deferred ones included. Callers that
+    /// enumerate callable names (the interpreter sandbox) have to see past the
+    /// `tool_search` catalog that `extend_tools` hides deferred tools behind.
+    pub fn wire_names(&self) -> Vec<String> {
+        self.handle
+            .index
+            .load()
+            .descriptors
+            .iter()
+            .map(|d| d.wire_name().to_owned())
+            .collect()
+    }
+
     /// Invoked on every MCP dispatch: a deferred tool the model calls by
     /// catalog name gets its full definition on the next request.
-    pub fn mark_loaded(&self, qualified_name: &str) {
-        self.lock_loaded().insert(Arc::from(qualified_name));
+    ///
+    /// Nested calls are ignored, because [`McpSession::new`] rebuilds this set
+    /// from the `ToolUse` blocks in history and those hold no nested call. A
+    /// script fanning out over deferred tools would otherwise leave a resumed
+    /// session with a different tool array than the live one.
+    pub fn mark_loaded(&self, qualified_name: &str, origin: CallOrigin) {
+        if origin.is_model() {
+            self.lock_loaded().insert(Arc::from(qualified_name));
+        }
     }
 
     fn lock_loaded(&self) -> std::sync::MutexGuard<'_, HashSet<Arc<str>>> {
@@ -500,17 +533,19 @@ impl McpHandle {
         McpSnapshotReader(Arc::clone(&self.snapshot))
     }
 
-    pub fn has_tool(&self, name: &str) -> bool {
-        self.index.load().tools.contains_key(name)
-    }
-
-    pub fn interned_name(&self, name: &str) -> Arc<str> {
-        self.index
-            .load()
-            .tools
-            .get_key_value(name)
-            .map(|(k, _)| Arc::clone(k))
-            .unwrap_or_else(|| Arc::from(UNKNOWN_MCP))
+    /// Where wire names (`server__tool`, what providers send) and internal names
+    /// (`server.tool`, what the index holds) meet. Returns the interned qualified
+    /// name every other MCP entry point takes, or `None` when no server publishes
+    /// it. Deferred tools resolve too: hidden from the tool array is not the same
+    /// as uncallable.
+    pub fn resolve(&self, name: &str) -> Option<Arc<str>> {
+        let index = self.index.load();
+        let interned = |n: &str| index.tools.get_key_value(n).map(|(k, _)| Arc::clone(k));
+        interned(name).or_else(|| {
+            name.contains(WIRE_SEPARATOR)
+                .then(|| interned(&internal_tool_name(name)))
+                .flatten()
+        })
     }
 
     pub async fn call_tool(&self, qualified_name: &str, args: &Value) -> Result<String, McpError> {
@@ -1043,48 +1078,99 @@ fn publish(inner: &McpManagerInner, index: &ArcSwap<ToolIndex>, snapshot: &ArcSw
     }));
 }
 
-/// Session for dispatch-level tests outside this module, built through the
-/// real `publish` path so it can't drift from production index construction.
-#[cfg(test)]
-pub(crate) fn stub_session(tools: &[(&str, &str)]) -> McpSession {
-    let entry = ServerEntry {
-        name: "stub".into(),
-        config: None,
-        transport_kind: "stub",
-        origin: PathBuf::new(),
-        status: McpServerStatus::Running,
-        transport: Some(Arc::new(StubTransport(Arc::from("stub")))),
-        tools: tools
-            .iter()
-            .map(|(qualified, description)| McpToolDef {
-                qualified_name: Arc::from(*qualified),
-                raw_name: qualified
-                    .split_once(SEPARATOR)
-                    .map_or(*qualified, |(_, r)| r)
-                    .into(),
-                description: (*description).into(),
-                input_schema: json!({}),
+/// Sessions for dispatch-level tests. Always compiled, so tests outside this
+/// crate can build a `ToolContext` that carries MCP.
+pub mod test_support {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use arc_swap::ArcSwap;
+    use serde_json::{Value, json};
+
+    use super::config::McpServerStatus;
+    use super::error::McpError;
+    use super::transport::{self, McpTransport};
+    use super::{
+        McpHandle, McpManagerInner, McpSession, McpSnapshot, McpToolDef, SEPARATOR, ServerEntry,
+        ToolIndex, publish,
+    };
+
+    /// Goes through the real `publish` path, so it cannot drift from how the
+    /// index is built in production. Tools are named `server.tool`.
+    pub fn stub_session(tools: &[(&str, &str)]) -> McpSession {
+        let entry = ServerEntry {
+            name: "stub".into(),
+            config: None,
+            transport_kind: "stub",
+            origin: PathBuf::new(),
+            status: McpServerStatus::Running,
+            transport: Some(Arc::new(StubTransport(Arc::from("stub")))),
+            tools: tools
+                .iter()
+                .map(|(qualified, description)| McpToolDef {
+                    qualified_name: Arc::from(*qualified),
+                    raw_name: qualified
+                        .split_once(SEPARATOR)
+                        .map_or(*qualified, |(_, r)| r)
+                        .into(),
+                    description: (*description).into(),
+                    input_schema: json!({}),
+                })
+                .collect(),
+            prompts: Vec::new(),
+        };
+        let inner = McpManagerInner {
+            entries: vec![entry],
+            generation: 0,
+        };
+        let index = Arc::new(ArcSwap::from_pointee(ToolIndex::default()));
+        let snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot::default()));
+        publish(&inner, &index, &snapshot);
+        McpSession::new(
+            McpHandle {
+                cmd_tx: flume::unbounded().0,
+                index,
+                snapshot,
+                defer_tools: 0,
+                ready_rx: flume::bounded(0).1,
+            },
+            &[],
+        )
+    }
+
+    /// Fails every call with `UnknownTool`, which is how a test proves the call
+    /// reached MCP at all.
+    struct StubTransport(Arc<str>);
+
+    impl McpTransport for StubTransport {
+        fn send_request<'a>(
+            &'a self,
+            method: &'a str,
+            _params: Option<Value>,
+        ) -> transport::BoxFuture<'a, Result<Value, McpError>> {
+            Box::pin(async move {
+                Err(McpError::UnknownTool {
+                    name: method.into(),
+                })
             })
-            .collect(),
-        prompts: Vec::new(),
-    };
-    let inner = McpManagerInner {
-        entries: vec![entry],
-        generation: 0,
-    };
-    let index = Arc::new(ArcSwap::from_pointee(ToolIndex::default()));
-    let snapshot = Arc::new(ArcSwap::from_pointee(McpSnapshot::default()));
-    publish(&inner, &index, &snapshot);
-    McpSession::new(
-        McpHandle {
-            cmd_tx: flume::unbounded().0,
-            index,
-            snapshot,
-            defer_tools: 0,
-            ready_rx: flume::bounded(0).1,
-        },
-        &[],
-    )
+        }
+        fn send_notification<'a>(
+            &'a self,
+            _method: &'a str,
+            _params: Option<Value>,
+        ) -> transport::BoxFuture<'a, Result<(), McpError>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn shutdown<'a>(&'a self) -> transport::BoxFuture<'a, ()> {
+            Box::pin(async {})
+        }
+        fn server_name(&self) -> &Arc<str> {
+            &self.0
+        }
+        fn transport_kind(&self) -> &'static str {
+            "stub"
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1095,40 +1181,6 @@ pub(crate) fn tool_names(tools: &Value) -> Vec<&str> {
         .iter()
         .filter_map(|t| t["name"].as_str())
         .collect()
-}
-
-#[cfg(test)]
-struct StubTransport(Arc<str>);
-
-#[cfg(test)]
-impl McpTransport for StubTransport {
-    fn send_request<'a>(
-        &'a self,
-        method: &'a str,
-        _params: Option<Value>,
-    ) -> transport::BoxFuture<'a, Result<Value, McpError>> {
-        Box::pin(async move {
-            Err(McpError::UnknownTool {
-                name: method.into(),
-            })
-        })
-    }
-    fn send_notification<'a>(
-        &'a self,
-        _method: &'a str,
-        _params: Option<Value>,
-    ) -> transport::BoxFuture<'a, Result<(), McpError>> {
-        Box::pin(async { Ok(()) })
-    }
-    fn shutdown<'a>(&'a self) -> transport::BoxFuture<'a, ()> {
-        Box::pin(async {})
-    }
-    fn server_name(&self) -> &Arc<str> {
-        &self.0
-    }
-    fn transport_kind(&self) -> &'static str {
-        "stub"
-    }
 }
 
 fn build_haystack(definition: &Value) -> String {
@@ -1455,7 +1507,29 @@ mod tests {
         assert_eq!(tool_names(&tools), vec![TOOL_SEARCH_TOOL_NAME]);
         let catalog = tools[0]["description"].as_str().unwrap();
         assert!(catalog.contains("srv: tool"), "catalog groups by server");
-        assert!(handle.has_tool(TOOL_NAME), "deferred tools stay callable");
+        assert!(
+            handle.resolve(TOOL_NAME).is_some(),
+            "deferred tools stay callable"
+        );
+    }
+
+    #[test]
+    fn wire_names_lists_deferred_tools() {
+        let (_inner, handle) = setup(vec![fake_entry("srv", FakeTransport::new())]);
+        let mut tools = json!([]);
+        handle.extend_tools(&mut tools);
+        assert_eq!(tool_names(&tools), vec![TOOL_SEARCH_TOOL_NAME]);
+        assert_eq!(handle.wire_names(), vec![WIRE_TOOL_NAME]);
+    }
+
+    #[test_case(TOOL_NAME, Some(TOOL_NAME) ; "internal_name")]
+    #[test_case(WIRE_TOOL_NAME, Some(TOOL_NAME) ; "wire_name")]
+    #[test_case("srv.missing", None ; "unpublished_tool")]
+    #[test_case("read", None ; "native_name")]
+    #[test_case("gone__tool", None ; "unpublished_server")]
+    fn resolve_maps_published_names_only(name: &str, expected: Option<&str>) {
+        let (_inner, handle) = setup(vec![fake_entry("srv", FakeTransport::new())]);
+        assert_eq!(handle.resolve(name).as_deref(), expected);
     }
 
     #[test]
@@ -1475,7 +1549,7 @@ mod tests {
     #[test]
     fn search_loads_tools_into_next_extend() {
         let (_inner, handle) = setup(vec![fake_entry("srv", FakeTransport::new())]);
-        let result = handle.search_tools("TOOL").unwrap();
+        let result = handle.search_tools("TOOL", CallOrigin::Model).unwrap();
         assert!(result.contains(WIRE_TOOL_NAME), "got: {result}");
 
         let mut tools = json!([]);
@@ -1486,7 +1560,9 @@ mod tests {
     #[test]
     fn search_reports_no_match_without_loading() {
         let (_inner, handle) = setup(vec![fake_entry("srv", FakeTransport::new())]);
-        let result = handle.search_tools("nonexistent-capability").unwrap();
+        let result = handle
+            .search_tools("nonexistent-capability", CallOrigin::Model)
+            .unwrap();
         assert!(result.contains(SEARCH_NO_MATCH), "got: {result}");
         let mut tools = json!([]);
         handle.extend_tools(&mut tools);
@@ -1507,7 +1583,7 @@ mod tests {
             .collect();
         let (_inner, handle) = setup(vec![entry]);
 
-        let result = handle.search_tools("tool").unwrap();
+        let result = handle.search_tools("tool", CallOrigin::Model).unwrap();
         let expected = format!(
             "{SEARCH_OVERFLOW_PREFIX}`srv__tool-{}`, `srv__tool-{}`",
             MAX_SEARCH_LOADS,
@@ -1547,7 +1623,7 @@ mod tests {
         let (_inner, handle) = setup(vec![entry_with_tools("srv", tools)]);
         // Alphabetical tie-break alone would leave the last tool in overflow.
         let last = format!("{prefix}{MAX_SEARCH_LOADS}");
-        let result = handle.search_tools(&last).unwrap();
+        let result = handle.search_tools(&last, CallOrigin::Model).unwrap();
         let overflow = result
             .lines()
             .find(|l| l.starts_with(SEARCH_OVERFLOW_PREFIX))
@@ -1566,7 +1642,7 @@ mod tests {
             tool_def("srv", "create_issue", "Open a ticket", json!({})),
         ];
         let (_inner, handle) = setup(vec![entry_with_tools("srv", tools)]);
-        let result = handle.search_tools("issue").unwrap();
+        let result = handle.search_tools("issue", CallOrigin::Model).unwrap();
         let pos = |name: &str| {
             result
                 .find(name)
@@ -1587,7 +1663,9 @@ mod tests {
             json!({}),
         )];
         let (_inner, handle) = setup(vec![entry_with_tools("srv", tools)]);
-        let result = handle.search_tools("pull request").unwrap();
+        let result = handle
+            .search_tools("pull request", CallOrigin::Model)
+            .unwrap();
         assert!(result.contains("srv__create_pr"), "got: {result}");
     }
 
@@ -1596,7 +1674,7 @@ mod tests {
         let schema = json!({"type": "object", "properties": {"labels": {"type": "array"}}});
         let tools = vec![tool_def("srv", "update", "Update a thing", schema)];
         let (_inner, handle) = setup(vec![entry_with_tools("srv", tools)]);
-        let result = handle.search_tools("labels").unwrap();
+        let result = handle.search_tools("labels", CallOrigin::Model).unwrap();
         assert!(result.contains("srv__update"), "got: {result}");
     }
 
@@ -1641,8 +1719,8 @@ mod tests {
             tool_def("srv", "gamma", "", json!({})),
         ];
         let (_inner, handle) = setup_with_defer(vec![entry_with_tools("srv", defs)], 2);
-        handle.mark_loaded("srv.alpha");
-        handle.mark_loaded("srv.beta");
+        handle.mark_loaded("srv.alpha", CallOrigin::Model);
+        handle.mark_loaded("srv.beta", CallOrigin::Model);
         let mut tools = json!([]);
         handle.extend_tools(&mut tools);
         let names = tool_names(&tools);
@@ -1664,7 +1742,7 @@ mod tests {
     #[test]
     fn mark_loaded_declares_tool_and_drops_empty_catalog() {
         let (_inner, handle) = setup(vec![fake_entry("srv", FakeTransport::new())]);
-        handle.mark_loaded(TOOL_NAME);
+        handle.mark_loaded(TOOL_NAME, CallOrigin::Model);
         let mut tools = json!([]);
         handle.extend_tools(&mut tools);
         assert_eq!(
@@ -1672,6 +1750,24 @@ mod tests {
             vec![WIRE_TOOL_NAME],
             "loaded tool must be declared; an empty catalog must not be advertised"
         );
+    }
+
+    /// History holds no nested call to replay, so neither entry point may let
+    /// one change what the next request carries.
+    #[test]
+    fn nested_calls_leave_the_loaded_set_alone() {
+        let (_inner, handle) = setup(vec![fake_entry("srv", FakeTransport::new())]);
+        handle.mark_loaded(TOOL_NAME, CallOrigin::Nested);
+        let result = handle.search_tools("tool", CallOrigin::Nested).unwrap();
+        assert!(result.contains(WIRE_TOOL_NAME), "got: {result}");
+        assert!(
+            !result.contains(SEARCH_HEADER_MODEL.0),
+            "a nested search must not claim it loaded anything: {result}"
+        );
+
+        let mut tools = json!([]);
+        handle.extend_tools(&mut tools);
+        assert_eq!(tool_names(&tools), vec![TOOL_SEARCH_TOOL_NAME]);
     }
 
     #[test]
@@ -1716,7 +1812,7 @@ mod tests {
     #[test]
     fn search_ignores_always_load_tools() {
         let (_inner, handle) = setup(vec![always_load_entry("eager", FakeTransport::new())]);
-        let result = handle.search_tools("tool").unwrap();
+        let result = handle.search_tools("tool", CallOrigin::Model).unwrap();
         assert!(
             result.contains(SEARCH_NO_MATCH),
             "always_load tools are already declared: {result}"
@@ -1727,7 +1823,7 @@ mod tests {
     fn search_loads_stay_scoped_to_their_session() {
         let (_inner, session_a) = setup(vec![fake_entry("srv", FakeTransport::new())]);
         let session_b = session_a.fresh();
-        session_a.search_tools("tool").unwrap();
+        session_a.search_tools("tool", CallOrigin::Model).unwrap();
 
         let mut tools_a = json!([]);
         session_a.extend_tools(&mut tools_a);
@@ -1812,7 +1908,7 @@ mod tests {
             let t = FakeTransport::new();
             let (mut inner, handle) = setup(vec![fake_entry("srv", Arc::clone(&t) as _)]);
 
-            assert!(handle.has_tool(TOOL_NAME));
+            assert!(handle.resolve(TOOL_NAME).is_some());
             let mut tools = json!([]);
             handle.extend_tools(&mut tools);
             assert_eq!(tools[0]["name"], TOOL_SEARCH_TOOL_NAME);
@@ -1825,7 +1921,7 @@ mod tests {
             assert!(entry.tools.is_empty());
             assert!(entry.transport.is_none());
             assert_eq!(entry.status, McpServerStatus::Disabled);
-            assert!(!handle.has_tool(TOOL_NAME));
+            assert!(handle.resolve(TOOL_NAME).is_none());
             let mut tools = json!([]);
             handle.extend_tools(&mut tools);
             assert!(tools.as_array().unwrap().is_empty());

--- a/maki-agent/src/tools/interpreter_bridge.rs
+++ b/maki-agent/src/tools/interpreter_bridge.rs
@@ -1,24 +1,45 @@
 use serde_json::Value;
 
-use crate::agent::tool_dispatch::{self, Emit};
+use crate::agent::tool_dispatch;
+use crate::mcp::TOOL_SEARCH_TOOL_NAME;
 
-use super::ToolContext;
+use super::{CallOrigin, ToolContext};
 
 pub const IMAGE_NOT_VISIBLE_NOTE: &str =
     "image pixels are not visible from here; call the view_image tool directly";
 
+/// Names this context can dispatch that the registry knows nothing about: ACP
+/// client tools, MCP tools (deferred ones included) and `tool_search`. The
+/// sandbox binds these; registry tools it takes from the registry, already
+/// filtered by audience.
+///
+/// A registry entry is an audience decision about that name, so any name the
+/// registry holds is dropped here, even one a client tool shadows in dispatch.
+/// Otherwise precedence would launder the decision, handing a script an ACP
+/// `question` that the registry's `question` audience keeps out.
+///
+/// Recompute per call: MCP republishes its index whenever a server comes or
+/// goes.
+pub fn context_tools(ctx: &ToolContext) -> Vec<String> {
+    let mut names: Vec<String> = ctx
+        .local_tools
+        .keys()
+        .cloned()
+        .chain(ctx.mcp.iter().flat_map(|mcp| {
+            mcp.wire_names()
+                .into_iter()
+                .chain([TOOL_SEARCH_TOOL_NAME.to_owned()])
+        }))
+        .filter(|name| ctx.registry.get(name).is_none())
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
 pub async fn dispatch(ctx: &ToolContext, name: &str, input: &Value) -> Result<String, String> {
     ctx.deadline.check()?;
-    let done = tool_dispatch::run(
-        &ctx.registry,
-        ctx.mcp.as_ref(),
-        String::new(),
-        name,
-        input,
-        ctx,
-        Emit::Silent,
-    )
-    .await;
+    let done = tool_dispatch::run(String::new(), name, input, ctx, CallOrigin::Nested).await;
     flatten(&done)
 }
 

--- a/maki-agent/src/tools/mod.rs
+++ b/maki-agent/src/tools/mod.rs
@@ -40,10 +40,31 @@ use maki_providers::RequestOptions;
 use maki_providers::provider::Provider;
 use maki_storage::id::SessionRef;
 
+/// Who made a tool call. History keeps only the model's own calls, as `ToolUse`
+/// blocks, so those are also the only calls the UI shows and the only ones
+/// allowed to change what the next request carries. State a resumed session
+/// cannot rebuild must never differ from the live one.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CallOrigin {
+    /// Emitted by the model and recorded in history under its own id.
+    Model,
+    /// Made on the model's behalf and invisible to history: batch children,
+    /// `code_execution` scripts, Lua `call_tool`.
+    Nested,
+}
+
+impl CallOrigin {
+    pub fn is_model(self) -> bool {
+        matches!(self, Self::Model)
+    }
+}
+
 pub struct DescriptionContext<'a> {
     pub filter: &'a ToolFilter,
     pub audience: ToolAudience,
     pub workflow: bool,
+    /// Whether the session being described can reach MCP tools.
+    pub mcp: bool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -486,6 +507,57 @@ pub mod test_support {
     use super::*;
 
     pub const GUARDED_TOOL_NAME: &str = "guarded_mock";
+
+    /// Registry and routing tests care about the name and audience only, never
+    /// about what the tool returns.
+    #[cfg(test)]
+    pub(crate) fn mock_tool(name: &str, audience: ToolAudience) -> Arc<dyn registry::Tool> {
+        Arc::new(MockTool {
+            name: name.to_owned(),
+            audience,
+        })
+    }
+
+    #[cfg(test)]
+    struct MockTool {
+        name: String,
+        audience: ToolAudience,
+    }
+
+    #[cfg(test)]
+    struct MockInvocation;
+
+    #[cfg(test)]
+    impl registry::ToolInvocation for MockInvocation {
+        fn start_header(&self) -> registry::HeaderFuture {
+            registry::HeaderFuture::Ready(registry::HeaderResult::plain("mock".into()))
+        }
+        fn execute<'a>(self: Box<Self>, _ctx: &'a ToolContext) -> registry::ExecFuture<'a> {
+            Box::pin(async { Ok(ToolOutput::Plain(String::new().into())).into() })
+        }
+    }
+
+    #[cfg(test)]
+    impl registry::Tool for MockTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn description(&self, _ctx: &DescriptionContext) -> Cow<'_, str> {
+            "mock tool".into()
+        }
+        fn schema(&self) -> Value {
+            serde_json::json!({"type": "object", "properties": {}, "additionalProperties": false})
+        }
+        fn audience(&self) -> ToolAudience {
+            self.audience
+        }
+        fn parse(
+            &self,
+            _input: &Value,
+        ) -> Result<Box<dyn registry::ToolInvocation>, registry::ParseError> {
+            Ok(Box::new(MockInvocation))
+        }
+    }
 
     pub struct GuardedMock;
 

--- a/maki-agent/src/tools/registry.rs
+++ b/maki-agent/src/tools/registry.rs
@@ -514,49 +514,10 @@ mod tests {
     use crate::template::Vars;
     use test_case::test_case;
 
-    struct MockTool {
-        name: String,
-        audience: ToolAudience,
-    }
-
-    struct MockInvocation;
-
-    impl ToolInvocation for MockInvocation {
-        fn start_header(&self) -> HeaderFuture {
-            HeaderFuture::Ready(HeaderResult::plain("mock".into()))
-        }
-        fn execute<'a>(self: Box<Self>, _ctx: &'a super::ToolContext) -> ExecFuture<'a> {
-            Box::pin(async { Ok(ToolOutput::Plain(String::new().into())).into() })
-        }
-    }
-
-    impl Tool for MockTool {
-        fn name(&self) -> &str {
-            &self.name
-        }
-        fn description(&self, _ctx: &DescriptionContext) -> Cow<'_, str> {
-            "mock tool".into()
-        }
-        fn schema(&self) -> Value {
-            json!({"type": "object", "properties": {}, "additionalProperties": false})
-        }
-        fn audience(&self) -> ToolAudience {
-            self.audience
-        }
-        fn parse(&self, _input: &Value) -> Result<Box<dyn ToolInvocation>, ParseError> {
-            Ok(Box::new(MockInvocation))
-        }
-    }
+    use crate::tools::test_support::mock_tool as mock_scoped;
 
     fn mock(name: &str) -> Arc<dyn Tool> {
         mock_scoped(name, ToolAudience::all())
-    }
-
-    fn mock_scoped(name: &str, audience: ToolAudience) -> Arc<dyn Tool> {
-        Arc::new(MockTool {
-            name: name.to_owned(),
-            audience,
-        })
     }
 
     fn lua_source(plugin: &str) -> ToolSource {
@@ -591,6 +552,7 @@ mod tests {
             filter: &filter,
             audience: ToolAudience::MAIN,
             workflow: false,
+            mcp: false,
         };
         let vars = Vars::new();
         let defs = reg.definitions(&vars, &ctx, false);
@@ -755,6 +717,7 @@ mod tests {
                 filter: &filter,
                 audience,
                 workflow: false,
+                mcp: false,
             };
             reg.definitions(&vars, &ctx, false)
                 .as_array()

--- a/maki-docgen/src/gen_tools.rs
+++ b/maki-docgen/src/gen_tools.rs
@@ -263,6 +263,7 @@ pub fn generate() -> String {
             filter: &ToolFilter::All,
             audience: ToolAudience::MAIN,
             workflow: false,
+            mcp: false,
         },
         false,
     );

--- a/maki-lua/src/api/agent.rs
+++ b/maki-lua/src/api/agent.rs
@@ -8,14 +8,14 @@ use std::time::{Duration, Instant};
 
 use async_lock::Mutex as AsyncMutex;
 use futures::future::{Either, select};
-use maki_agent::agent::tool_dispatch::{self, Emit};
+use maki_agent::agent::tool_dispatch;
 use maki_agent::cancel::{CancelMap, CancelSlot};
 use maki_agent::tools::interpreter_bridge;
 use maki_agent::tools::registry::ToolRegistry;
 use maki_agent::tools::schema::sanitize_tool_input_schema;
 use maki_agent::tools::{
-    Deadline, DescriptionContext, FileReadTracker, LocalToolFn, LocalTools, ToolAudience,
-    ToolContext, ToolFilter, ToolLive,
+    CallOrigin, Deadline, DescriptionContext, FileReadTracker, LocalToolFn, LocalTools,
+    ToolAudience, ToolContext, ToolFilter, ToolLive,
 };
 use maki_agent::{
     Agent, AgentEvent, AgentInput, AgentMode, AgentParams, AgentRunParams, DoneReason,
@@ -214,6 +214,9 @@ async fn system_prompt(
 ///   `except` (string[]?) - exclude these tool names.
 ///   `workflow` (boolean?) - use workflow-mode descriptions. Default: `false`.
 ///   `spec` (string?) - evaluate capability exclusions against this model spec.
+///   `mcp` (boolean?) - describe tools as if MCP is reachable. Default: `true`.
+///     Pass the same value you pass to `maki.agent.session()`, or the
+///     descriptions promise MCP tools the session cannot call.
 /// @return (table?, string?) Array of tool definition tables, or `(nil, err)` on failure.
 /// @example
 /// local defs, err = maki.agent.tools(ctx, {
@@ -235,6 +238,7 @@ async fn tools(lua: Lua, ctx: mlua::UserDataRef<LuaCtx>, opts: Table) -> LuaResu
     let except: Option<Vec<String>> = opts.get("except")?;
     let workflow: bool = opts.get::<Option<bool>>("workflow")?.unwrap_or(false);
     let spec_str: Option<String> = opts.get("spec")?;
+    let mcp_enabled: bool = opts.get::<Option<bool>>("mcp")?.unwrap_or(true);
 
     let parsed = spec_str
         .as_deref()
@@ -261,12 +265,38 @@ async fn tools(lua: Lua, ctx: mlua::UserDataRef<LuaCtx>, opts: Table) -> LuaResu
         filter: &filter,
         audience,
         workflow,
+        mcp: mcp_enabled && agent.mcp.is_some(),
     };
     // Base definitions only: the session injects MCP definitions per
     // request, so baking them into a tools array would freeze the catalog.
     let defs = ToolRegistry::global().definitions(&vars, &ctx_desc, model.supports_tool_examples());
 
     Ok((Some(json_to_lua(&lua, &defs)?), None))
+}
+
+/// List the tool names this context can call that the registry knows nothing
+/// about: MCP tools (deferred ones included), ACP client tools, and
+/// `tool_search`. Use it to bind callable names in a sandbox. Registry tools
+/// come from `maki.api.get_tools()` instead, already filtered by audience.
+///
+/// Any name the registry holds is left out, even one a client tool shadows: the
+/// registry entry carries an audience, and routing precedence must not hand a
+/// sandbox what that audience keeps out.
+///
+/// @param ctx LuaCtx Agent context.
+/// @return (table?, string?) Array of tool names, empty when the session has
+///   neither MCP nor client tools, or `(nil, err)` on failure.
+/// @example
+/// local extra, err = maki.agent.context_tools(ctx)
+/// if err then error(err) end
+/// for _, name in ipairs(extra) do
+///   print(name)
+/// end
+#[lua_fn]
+async fn context_tools(lua: Lua, ctx: mlua::UserDataRef<LuaCtx>) -> LuaResult<Pair<Table>> {
+    let agent = try_pair!(dispatch_ctx(&ctx, "context_tools"));
+    let names = interpreter_bridge::context_tools(&agent.to_tool_context());
+    Ok((Some(lua.create_sequence_from(names)?), None))
 }
 
 /// Run a tool by name and wait for the result. This is how you call built-in
@@ -592,7 +622,7 @@ lua_table! {
     /// sess:close()
     /// ```
     "maki.agent" => pub(crate) fn create_agent_table(), DOCS [
-        resolve_model, system_prompt, tools, call_tool, session,
+        resolve_model, system_prompt, tools, context_tools, call_tool, session,
     ]
 }
 
@@ -635,15 +665,7 @@ async fn dispatch_racing_live(
     rx: Option<flume::Receiver<ToolLive>>,
     cbs: &LiveCallbacks<'_>,
 ) -> ToolDoneEvent {
-    let run = tool_dispatch::run(
-        &tctx.registry,
-        tctx.mcp.as_ref(),
-        String::new(),
-        name,
-        input,
-        tctx,
-        Emit::Silent,
-    );
+    let run = tool_dispatch::run(String::new(), name, input, tctx, CallOrigin::Nested);
     let Some(rx) = rx else {
         return run.await;
     };

--- a/maki-lua/src/api/tool.rs
+++ b/maki-lua/src/api/tool.rs
@@ -86,6 +86,7 @@ fn dctx_json(ctx: &DescriptionContext) -> Value {
     let mut obj = json!({
         "audience": ctx.audience.name().unwrap_or("main"),
         "workflow": ctx.workflow,
+        "mcp": ctx.mcp,
     });
     match ctx.filter {
         ToolFilter::All => {}
@@ -1710,6 +1711,7 @@ mod tests {
             filter: &ToolFilter::All,
             audience: ToolAudience::MAIN,
             workflow: false,
+            mcp: false,
         };
         assert_eq!(tool.description(&ctx), "test");
     }

--- a/maki-lua/src/api/util/ctx.rs
+++ b/maki-lua/src/api/util/ctx.rs
@@ -5,9 +5,7 @@ use std::time::{Duration, Instant};
 
 use maki_agent::agent::LoadedInstructions;
 use maki_agent::cancel::CancelToken;
-use maki_agent::tools::{
-    Deadline, FileReadTracker, LocalTools, ToolAudience, ToolContext, ToolLive,
-};
+use maki_agent::tools::{Deadline, FileReadTracker, ToolAudience, ToolContext, ToolLive};
 use maki_config::{AgentConfig, ToolOutputLines};
 use maki_storage::id::SessionRef;
 use mlua::{LuaSerdeExt, MultiValue, UserData, UserDataMethods, Value as LuaValue};
@@ -42,6 +40,11 @@ fn send_live_buf(lua: &mlua::Lua, buf: &mlua::AnyUserData) -> mlua::Result<()> {
 
 /// Captured snapshot of the parent `ToolContext`. Per-call state (deadline,
 /// instructions, output lines) is reset so child calls start clean.
+///
+/// Routing state is kept verbatim, `local_tools` included: a name a Lua tool
+/// dispatches must land where the same name lands when the model calls it, or
+/// shadowing quietly inverts for nested calls. A child session does not inherit
+/// them anyway, `session()` always sets its own.
 #[derive(Clone)]
 pub(crate) struct AgentContext(ToolContext);
 
@@ -51,7 +54,6 @@ impl From<&ToolContext> for AgentContext {
         c.loaded_instructions = LoadedInstructions::new();
         c.deadline = Deadline::None;
         c.tool_output_lines = ToolOutputLines::default();
-        c.local_tools = LocalTools::default();
         Self(c)
     }
 }
@@ -450,7 +452,10 @@ mod tests {
         );
         assert!(matches!(agent.deadline, Deadline::None));
         assert_eq!(agent.tool_output_lines, ToolOutputLines::default());
-        assert!(agent.local_tools.is_empty());
+        assert!(
+            agent.local_tools.contains_key(LOCAL_TOOL_NAME),
+            "a nested call must route names exactly like the model's own call"
+        );
         assert!(
             !agent
                 .loaded_instructions

--- a/maki-lua/tests/code_execution_policy.rs
+++ b/maki-lua/tests/code_execution_policy.rs
@@ -2,11 +2,16 @@
 //! gates both `describe` text and the handler's fn-map, so what the model
 //! sees is exactly what the interpreter can call.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use maki_agent::AgentMode;
+use maki_agent::mcp::McpSession;
+use maki_agent::mcp::test_support::stub_session;
 use maki_agent::tools::test_support::stub_ctx;
-use maki_agent::tools::{DescriptionContext, ToolAudience, ToolContext, ToolFilter, ToolRegistry};
+use maki_agent::tools::{
+    DescriptionContext, ToolAudience, ToolContext, ToolFilter, ToolRegistry, local_tool,
+};
 use maki_lua::PluginHost;
 
 const CODE_EXECUTION_SRC: &str = include_str!("../../plugins/code_execution/init.lua");
@@ -20,6 +25,22 @@ const WORKFLOW_NOTE_SUBSTR: &str = "Workflow mode: orchestrate subagents";
 const INTERP_ECHO_SIG: &str = "- interp_echo(msg: str, count: int = None, flag: bool = None, items: list = None, raw: any = None) -> str";
 const WF_TASK_SIG: &str = "- wf_task(prompt: str, model_tier: str = None) -> str";
 const SUB_TOOL_SIG: &str = "- sub_tool() -> str";
+const MCP_NOTE_SUBSTR: &str = "callable here too";
+const MCP_TOOL_QUALIFIED: &str = "srv.fetch_issue";
+const MCP_TOOL_WIRE: &str = "srv__fetch_issue";
+const GATED_QUALIFIED: &str = "srv.gated";
+const GATED_WIRE: &str = "srv__gated";
+/// The stub transport fails every request with this, so seeing it proves the
+/// call reached MCP instead of dying at name lookup.
+const MCP_REACHED_ERR: &str = "unknown MCP tool";
+const NAME_ERROR: &str = "NameError";
+const CODE_EXECUTION: &str = "code_execution";
+const TOOLS_MCP_PROBE: &str = "tools_mcp_probe";
+/// Stands in for an ACP client tool: dispatched from the context, not the
+/// registry.
+const CLIENT_TOOL: &str = "client_probe";
+const CLIENT_TOOL_OUT: &str = "client ran";
+const MAIN_ONLY_NAME: &str = "main_only_probe";
 
 fn fixture_plugin() -> String {
     format!(
@@ -63,6 +84,39 @@ maki.api.register_tool({{
     handler = function() return {{ llm_output = "{FAIL_MSG}", is_error = true }} end,
 }})
 maki.api.register_tool({{
+    name = "{GATED_WIRE}",
+    description = "registry tool wearing an MCP wire name",
+    audiences = {{ "main", "interpreter" }},
+    schema = {{ type = "object", properties = {{}}, additionalProperties = false }},
+    handler = function() return "" end,
+}})
+maki.api.register_tool({{
+    name = "{TOOLS_MCP_PROBE}",
+    description = "returns the code_execution description agent.tools built",
+    audiences = {{ "main" }},
+    schema = {{
+        type = "object",
+        required = {{ "mcp" }},
+        properties = {{ mcp = {{ type = "boolean" }} }},
+        additionalProperties = false,
+    }},
+    handler = function(input, ctx)
+        local defs, err = maki.agent.tools(ctx, {{ audience = "main", mcp = input.mcp }})
+        if err then return {{ llm_output = err, is_error = true }} end
+        for _, d in ipairs(defs) do
+            if d.name == "{CODE_EXECUTION}" then return d.description end
+        end
+        return {{ llm_output = "{CODE_EXECUTION} missing", is_error = true }}
+    end,
+}})
+maki.api.register_tool({{
+    name = "{MAIN_ONLY_NAME}",
+    description = "registry tool a client tool may shadow",
+    audiences = {{ "main" }},
+    schema = {{ type = "object", properties = {{}}, additionalProperties = false }},
+    handler = function() return "" end,
+}})
+maki.api.register_tool({{
     name = "sub_tool",
     description = "subagent fixture",
     audiences = {{ "general_sub", "interpreter" }},
@@ -86,8 +140,8 @@ fn setup() -> (Arc<ToolRegistry>, PluginHost) {
     setup_with(Arc::new(ToolRegistry::new()))
 }
 
-/// Uses the global native registry because `interpreter_bridge::dispatch` does.
-/// Safe: nextest runs each test in its own process.
+/// The plugin lists callable tools through `maki.api.get_tools()`, which reads
+/// the global registry. Safe: nextest runs each test in its own process.
 fn setup_native() -> (Arc<ToolRegistry>, PluginHost) {
     setup_with(Arc::clone(ToolRegistry::global_arc()))
 }
@@ -98,31 +152,41 @@ fn describe(
     audience: ToolAudience,
     workflow: bool,
 ) -> String {
-    reg.get("code_execution")
+    reg.get(CODE_EXECUTION)
         .expect("code_execution registered")
         .tool
         .description(&DescriptionContext {
             filter,
             audience,
             workflow,
+            mcp: false,
         })
         .into_owned()
 }
 
-fn exec_code(reg: &ToolRegistry, ctx: &ToolContext, code: &str) -> Result<String, String> {
-    let entry = reg
-        .get("code_execution")
-        .expect("code_execution registered");
-    let inv = entry
-        .tool
-        .parse(&serde_json::json!({ "code": code, "timeout": 10 }))
-        .expect("parse failed");
+fn run_tool(
+    reg: &ToolRegistry,
+    ctx: &ToolContext,
+    name: &str,
+    input: serde_json::Value,
+) -> Result<String, String> {
+    let entry = reg.get(name).unwrap_or_else(|| panic!("{name} registered"));
+    let inv = entry.tool.parse(&input).expect("parse failed");
     smol::block_on(async { inv.execute(ctx).await })
         .output
         .map(|out| match out {
             maki_agent::ToolOutput::Plain(s) => s.text,
             other => panic!("unexpected output: {other:?}"),
         })
+}
+
+fn exec_code(reg: &ToolRegistry, ctx: &ToolContext, code: &str) -> Result<String, String> {
+    run_tool(
+        reg,
+        ctx,
+        CODE_EXECUTION,
+        serde_json::json!({ "code": code, "timeout": 10 }),
+    )
 }
 
 fn run_code_in(code: &str, workflow: bool) -> Result<String, String> {
@@ -243,6 +307,98 @@ fn workflow_tool_callable_when_workflow_true() {
     let out = run_code_in("result = await wf_task(prompt='x')\nprint(result)", true)
         .expect("workflow tool must be callable when workflow=true");
     assert!(out.contains(&format!("{TASK_PREFIX}x")), "got: {out}");
+}
+
+// --- context tools (MCP, client tools) ---
+
+fn run_code_with_mcp(
+    code: &str,
+    mcp: McpSession,
+    audience: ToolAudience,
+) -> Result<String, String> {
+    let (reg, _host) = setup_native();
+    let mut ctx = stub_ctx(&AgentMode::Build);
+    ctx.registry = Arc::clone(&reg);
+    ctx.audience = audience;
+    ctx.mcp = Some(mcp);
+    exec_code(&reg, &ctx, code)
+}
+
+/// A caller that drops MCP for a subagent must not hand it a description
+/// promising MCP tools that subagent cannot call.
+#[test_case::test_case(true ; "session_keeps_mcp")]
+#[test_case::test_case(false ; "session_drops_mcp")]
+fn agent_tools_describes_mcp_only_when_the_session_keeps_it(enabled: bool) {
+    let (reg, _host) = setup_native();
+    let mut ctx = stub_ctx(&AgentMode::Build);
+    ctx.registry = Arc::clone(&reg);
+    ctx.mcp = Some(stub_session(&[(MCP_TOOL_QUALIFIED, "")]));
+    let desc = run_tool(
+        &reg,
+        &ctx,
+        TOOLS_MCP_PROBE,
+        serde_json::json!({ "mcp": enabled }),
+    )
+    .expect("probe must describe code_execution");
+    assert_eq!(
+        desc.matches(MCP_NOTE_SUBSTR).count(),
+        usize::from(enabled),
+        "got: {desc}"
+    );
+}
+
+/// The stub leaves the tool deferred, so binding it means reading the MCP index
+/// rather than the request's tool array.
+#[test]
+fn deferred_mcp_tool_is_callable_from_the_sandbox() {
+    let err = run_code_with_mcp(
+        &format!("await {MCP_TOOL_WIRE}()"),
+        stub_session(&[(MCP_TOOL_QUALIFIED, "")]),
+        ToolAudience::MAIN,
+    )
+    .expect_err("the stub transport fails every call");
+    assert!(err.contains(MCP_REACHED_ERR), "got: {err}");
+    assert!(!err.contains(NAME_ERROR), "got: {err}");
+}
+
+fn run_code_with_client_tool(code: &str, name: &str) -> Result<String, String> {
+    let (reg, _host) = setup_native();
+    let mut ctx = stub_ctx(&AgentMode::Build);
+    ctx.registry = Arc::clone(&reg);
+    ctx.local_tools = Arc::new(HashMap::from([(
+        name.to_owned(),
+        local_tool(|_, _| Box::pin(async { Ok(CLIENT_TOOL_OUT.to_owned()) })),
+    )]));
+    exec_code(&reg, &ctx, code)
+}
+
+/// A nested call resolves names exactly like the model's own, so a client tool
+/// the registry never heard of is callable. One that shadows a registry entry is
+/// not: that entry is `main`-only, and precedence must not launder its audience
+/// into the interpreter.
+#[test]
+fn client_tool_binds_unless_the_registry_holds_the_name() {
+    let out = run_code_with_client_tool(&format!("print(await {CLIENT_TOOL}())"), CLIENT_TOOL)
+        .expect("a client tool must be callable");
+    assert!(out.contains(CLIENT_TOOL_OUT), "got: {out}");
+
+    let err = run_code_with_client_tool(&format!("await {MAIN_ONLY_NAME}()"), MAIN_ONLY_NAME)
+        .expect_err("a shadowed registry name must not be bound at all");
+    assert!(err.contains(NAME_ERROR), "got: {err}");
+}
+
+/// A registry tool wears the same wire name as an MCP tool, and its audience
+/// keeps it out of this sandbox. Binding the name would hand the script the tool
+/// anyway, through MCP's back door.
+#[test]
+fn mcp_name_never_reaches_an_audience_gated_registry_tool() {
+    let err = run_code_with_mcp(
+        &format!("await {GATED_WIRE}()"),
+        stub_session(&[(GATED_QUALIFIED, "")]),
+        ToolAudience::GENERAL_SUB,
+    )
+    .expect_err("a gated name must not be bound at all");
+    assert!(err.contains(NAME_ERROR), "got: {err}");
 }
 
 // --- script rendering ---

--- a/maki-ui/src/agent/agent_loop.rs
+++ b/maki-ui/src/agent/agent_loop.rs
@@ -301,6 +301,7 @@ impl AgentLoop {
             filter: &filter,
             audience: ToolAudience::MAIN,
             workflow,
+            mcp: self.mcp.is_some(),
         };
         ToolRegistry::global().definitions(&self.vars, &ctx, examples)
     }

--- a/plugins/code_execution/init.lua
+++ b/plugins/code_execution/init.lua
@@ -51,6 +51,14 @@ async def gather(*calls):
 local TOOLS_HEADER = "\n\nAvailable tools (called as Python functions with keyword arguments):\n"
 local WORKFLOW_TOOLS_NOTE =
   "\nWorkflow mode: orchestrate subagents from this script. Await every `task(...)` call and use `gather(task(...), task(...))` for parallel fan-out. Pass `output_schema` to task for machine-readable results (a JSON string, parse with `json.loads`).\n"
+-- MCP names and schemas already sit in the tool array (or the tool_search
+-- catalog), so point at those instead of repeating them here.
+local MCP_NOTE =
+  "\nMCP tools whose names are valid Python identifiers are callable here too, with the arguments their tool definitions declare.\n"
+local CONTEXT_TOOLS_WARN = "context_tools failed, MCP and client tools are not bound: "
+-- Servers ship hyphenated names like `srv__get-docs`, which Python reads as
+-- subtraction, so binding those would only add dead weight.
+local PY_IDENTIFIER = "^[%a_][%w_]*$"
 local PY_TYPES = { string = "str", integer = "int", boolean = "bool", array = "list" }
 
 local opts = maki.api.register_options(output_limits.extend({
@@ -159,7 +167,8 @@ for line in content.splitlines():
 
 -- Shared predicate for describe and handler so advertised == callable.
 -- The interpreter is a calling convention, not a capability grant: a read-only
--- subagent must not reach edit/write through Python.
+-- subagent must not reach edit/write through Python. Only registry tools carry
+-- an audience, so only they come through here.
 local function interpreter_tools(tools, audience, workflow)
   local out = {}
   for _, t in ipairs(tools) do
@@ -233,6 +242,9 @@ local function describe(dctx)
   if has_workflow_only then
     parts[#parts + 1] = WORKFLOW_TOOLS_NOTE
   end
+  if dctx.mcp then
+    parts[#parts + 1] = MCP_NOTE
+  end
   return table.concat(parts)
 end
 
@@ -289,6 +301,22 @@ local function handler(input, ctx)
     local call_opts = t.workflow_only and {} or { timeout = timeout }
     tools[name] = function(tool_input)
       return maki.agent.call_tool(ctx, name, tool_input, call_opts)
+    end
+  end
+
+  -- MCP tools, ACP client tools and tool_search: dispatchable, but absent from
+  -- the registry, so they hold no audience to check. `context_tools` already
+  -- dropped every name the registry does hold, so nothing collides above.
+  local extra, ctx_err = maki.agent.context_tools(ctx)
+  if ctx_err then
+    maki.log.warn(CONTEXT_TOOLS_WARN .. ctx_err)
+  else
+    for _, name in ipairs(extra) do
+      if name:match(PY_IDENTIFIER) then
+        tools[name] = function(tool_input)
+          return maki.agent.call_tool(ctx, name, tool_input, { timeout = timeout })
+        end
+      end
     end
   end
 

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -847,6 +847,9 @@ available.
   - `except` (`string[]?`) exclude these tool names.
   - `workflow` (`boolean?`) use workflow-mode descriptions. Default: `false`.
   - `spec` (`string?`) evaluate capability exclusions against this model spec.
+  - `mcp` (`boolean?`) describe tools as if MCP is reachable. Default: `true`.
+    Pass the same value you pass to `maki.agent.session()`, or the
+    descriptions promise MCP tools the session cannot call.
 
 **Returns:** (`table?`, `string?`) Array of tool definition tables, or `(nil, err)` on failure.
 
@@ -859,6 +862,40 @@ local defs, err = maki.agent.tools(ctx, {
 })
 if err then error(err) end
 print(#defs .. " tools available")
+```
+
+---
+
+### `maki.agent.context_tools()` {#maki-agent-context_tools}
+
+```lua
+maki.agent.context_tools({ctx})
+```
+
+List the tool names this context can call that the registry knows nothing
+about: MCP tools (deferred ones included), ACP client tools, and
+`tool_search`. Use it to bind callable names in a sandbox. Registry tools
+come from `maki.api.get_tools()` instead, already filtered by audience.
+
+Any name the registry holds is left out, even one a client tool shadows: the
+registry entry carries an audience, and routing precedence must not hand a
+sandbox what that audience keeps out.
+
+**Parameters:**
+
+- `{ctx}` (`LuaCtx`) Agent context.
+
+**Returns:** (`table?`, `string?`) Array of `{ name = string, kind = "mcp"|"local"|"tool_search" }`,
+  empty when the session has neither MCP nor client tools, or `(nil, err)` on failure.
+
+**Example:**
+
+```lua
+local extra, err = maki.agent.context_tools(ctx)
+if err then error(err) end
+for _, t in ipairs(extra) do
+  print(t.kind .. ": " .. t.name)
+end
 ```
 
 ---

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -687,6 +687,7 @@ pub fn prompt(
             filter: &ToolFilter::All,
             audience: ToolAudience::MAIN,
             workflow: false,
+            mcp: false,
         };
         let defs = reg.definitions(&vars, &ctx, true);
         if names {


### PR DESCRIPTION
Calling `srv__tool(...)` inside a `code_execution` script raised `NameError`, because the plugin bound its Python names from the registry only, while MCP tools, ACP client tools and `tool_search` are granted by the `ToolContext` itself.

Name resolution now lives in one place, `tool_dispatch::route`, and `interpreter_bridge::context_tools` is derived from it, so the sandbox binds a name only when dispatch would route it outside the registry.

That filter is the escalation guard: a Lua tool named `srv__x` shadows an MCP `srv.x` in dispatch, so the MCP name stays unbound instead of handing a subagent a tool its audience was denied.

Worth knowing: deferred tools are bound too and every call marks them loaded, so a script that fans out over twenty of them grows the next request's tool array by twenty definitions.