### PR TITLE
feat(config): move `--no-rtk` into `agent.rtk`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An AI coding agent optimized for minimal use of context tokens, while providing 
 * `code_execution` tool - uses [monty](https://github.com/pydantic/monty) to run an interpreter that has all other tools available as async functions. Maki uses it to filter / summarize / transform / pipe data to other tools as input, without it ever reaching and polluting the context window. Sandbox limited by time & memory.
 * `task` tool - when delegating work to subagents, the AI chooses whether to run weak / medium / strong model of used provider. Think haiku / sonnet / opus.
 * System prompt, tool descriptions, and tool examples are all concise, I've made sure not to bloat your context.
-* Uses [rtk](https://github.com/rtk-ai/rtk) if you have it installed, disable with `--no-rtk`. Saves ~50% of bash output tokens. Remember bash is just 12% of total token usage, so 6% is nice, but saving on reads (65% of total) by using `index` gave me more benefit. I think I'll do bash output filtering like this myself in a future release.
+* Uses [rtk](https://github.com/rtk-ai/rtk) if you have it installed, disable with `maki.setup({ agent = { rtk = false } })` in your `init.lua`. Saves ~50% of bash output tokens. Remember bash is just 12% of total token usage, so 6% is nice, but saving on reads (65% of total) by using `index` gave me more benefit. I think I'll do bash output filtering like this myself in a future release.
 
 ### User experience
 

--- a/maki-config/src/lib.rs
+++ b/maki-config/src/lib.rs
@@ -271,7 +271,7 @@ impl RawConfig {
         self.tools.extend(overlay.tools);
     }
 
-    pub fn into_config(self, no_rtk: bool) -> Result<Config, ConfigError> {
+    pub fn into_config(self) -> Result<Config, ConfigError> {
         self.validate_plugin_tables()?;
         let disabled_tools: Vec<String> = self
             .plugins
@@ -288,7 +288,7 @@ impl RawConfig {
                 .map(AlwaysThinking::resolve)
                 .transpose()?,
             ui: UiConfig::from_file(self.ui),
-            agent: AgentConfig::from_file(self.agent, no_rtk, disabled_tools),
+            agent: AgentConfig::from_file(self.agent, disabled_tools),
             provider: ProviderConfig::from_file(self.provider)?,
             storage: StorageConfig::from_file(self.storage),
             telemetry: self.telemetry,
@@ -494,6 +494,7 @@ pub struct AgentFileConfig {
     pub compaction_instructions: Option<String>,
     pub post_compaction_instructions: Option<String>,
     pub stale_read_check: Option<bool>,
+    pub rtk: Option<bool>,
 }
 
 impl AgentFileConfig {
@@ -507,7 +508,8 @@ impl AgentFileConfig {
             compaction_buffer,
             compaction_instructions,
             post_compaction_instructions,
-            stale_read_check
+            stale_read_check,
+            rtk
         );
     }
 }
@@ -1068,8 +1070,11 @@ pub struct AgentConfig {
     )]
     pub stale_read_check: bool,
 
-    #[config(skip, default = false)]
-    pub no_rtk: bool,
+    #[config(
+        default = true,
+        desc = "Rewrite bash commands with [rtk](https://github.com/rtk-ai/rtk) when it is installed"
+    )]
+    pub rtk: bool,
 
     #[config(skip, default = "None")]
     pub max_turns: Option<u32>,
@@ -1082,9 +1087,8 @@ pub struct AgentConfig {
 }
 
 impl AgentConfig {
-    fn from_file(file: AgentFileConfig, no_rtk: bool, disabled_tools: Vec<String>) -> Self {
+    fn from_file(file: AgentFileConfig, disabled_tools: Vec<String>) -> Self {
         Self {
-            no_rtk,
             max_output_bytes: file.max_output_bytes.unwrap_or(DEFAULT_MAX_OUTPUT_BYTES),
             max_output_lines: file.max_output_lines.unwrap_or(DEFAULT_MAX_OUTPUT_LINES),
             max_continuation_turns: file
@@ -1094,6 +1098,7 @@ impl AgentConfig {
             compaction_instructions: file.compaction_instructions,
             post_compaction_instructions: file.post_compaction_instructions,
             stale_read_check: file.stale_read_check.unwrap_or(true),
+            rtk: file.rtk.unwrap_or(true),
             max_turns: None,
             allowed_tools: Vec::new(),
             disabled_tools,
@@ -2243,7 +2248,7 @@ mod tests {
 
     #[test]
     fn empty_config_returns_defaults() {
-        let config = RawConfig::default().into_config(false).unwrap();
+        let config = RawConfig::default().into_config().unwrap();
         assert!(config.ui.splash_animation);
         assert_eq!(config.ui.notifications, NotificationMethod::Auto);
         assert_eq!(config.agent.max_output_bytes, DEFAULT_MAX_OUTPUT_BYTES);
@@ -2264,7 +2269,7 @@ mod tests {
     fn notifications_deserialize(value: &str, expected: NotificationMethod) {
         let raw: RawConfig =
             toml::from_str(&format!("[ui]\nnotifications = \"{value}\"\n")).unwrap();
-        assert_eq!(raw.into_config(false).unwrap().ui.notifications, expected);
+        assert_eq!(raw.into_config().unwrap().ui.notifications, expected);
     }
 
     #[test]
@@ -2282,7 +2287,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let config = raw.into_config(false).unwrap();
+        let config = raw.into_config().unwrap();
         assert_eq!(config.agent.max_output_lines, 5000);
         assert_eq!(config.agent.max_output_bytes, DEFAULT_MAX_OUTPUT_BYTES);
     }
@@ -2349,7 +2354,7 @@ mod tests {
             ..Default::default()
         });
 
-        let provider = global.into_config(false).unwrap().provider;
+        let provider = global.into_config().unwrap().provider;
         assert!(provider.allowed_models.is_empty());
         assert_eq!(provider.excluded_models, ["*/*-preview"]);
         assert!(provider.model_policy.allows("openai/gpt-5"));
@@ -2366,7 +2371,7 @@ mod tests {
             },
             ..Default::default()
         }
-        .into_config(false)
+        .into_config()
         .unwrap();
         let policy = &config.provider.model_policy;
 
@@ -2382,7 +2387,7 @@ mod tests {
             },
             ..Default::default()
         }
-        .into_config(false)
+        .into_config()
         .unwrap();
         assert!(exclude_only.provider.model_policy.allows("openai/gpt-5"));
         assert!(
@@ -2402,7 +2407,7 @@ mod tests {
             },
             ..Default::default()
         }
-        .into_config(false);
+        .into_config();
 
         assert!(matches!(
             result,
@@ -2437,14 +2442,14 @@ mod tests {
 
     #[test]
     fn always_workflow_resolves_default_and_set() {
-        let defaults = RawConfig::default().into_config(false).unwrap();
+        let defaults = RawConfig::default().into_config().unwrap();
         assert!(!defaults.always_workflow, "absent resolves to false");
 
         let raw = RawConfig {
             always_workflow: Some(true),
             ..Default::default()
         };
-        assert!(raw.into_config(false).unwrap().always_workflow);
+        assert!(raw.into_config().unwrap().always_workflow);
     }
 
     #[test_case(AlwaysThinking::Toggle(true), StoredThinking::Adaptive ; "toggle_true")]
@@ -2458,14 +2463,14 @@ mod tests {
 
     #[test]
     fn into_config_resolves_always_thinking() {
-        let defaults = RawConfig::default().into_config(false).unwrap();
+        let defaults = RawConfig::default().into_config().unwrap();
         assert!(defaults.always_thinking.is_none());
 
         let raw = RawConfig {
             always_thinking: Some(AlwaysThinking::Mode("8192".into())),
             ..Default::default()
         };
-        let config = raw.into_config(false).unwrap();
+        let config = raw.into_config().unwrap();
         assert_eq!(
             config.always_thinking,
             Some(StoredThinking::Budget { tokens: 8192 })
@@ -2475,7 +2480,7 @@ mod tests {
             always_thinking: Some(AlwaysThinking::Mode("fast".into())),
             ..Default::default()
         };
-        let err = raw.into_config(false).err().expect("expected config error");
+        let err = raw.into_config().err().expect("expected config error");
         assert!(matches!(err, ConfigError::Thinking(_)));
     }
 
@@ -2506,7 +2511,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let config = raw.into_config(false).unwrap();
+        let config = raw.into_config().unwrap();
         assert_eq!(config.ui.tool_output_lines.bash, 20);
         assert_eq!(config.ui.tool_output_lines.read, 20);
         assert_eq!(
@@ -2931,14 +2936,14 @@ mod tests {
     #[test]
     fn show_thinking_missing_defaults_true() {
         let raw: RawConfig = toml::from_str("").unwrap();
-        let config = raw.into_config(false).unwrap();
+        let config = raw.into_config().unwrap();
         assert!(config.ui.show_thinking);
     }
 
     #[test]
     fn max_input_lines_defaults_and_deserializes() {
         let raw: RawConfig = toml::from_str("").unwrap();
-        let config = raw.into_config(false).unwrap();
+        let config = raw.into_config().unwrap();
         assert_eq!(config.ui.max_input_lines, DEFAULT_MAX_INPUT_LINES);
 
         let raw: RawConfig = toml::from_str("[ui]\nmax_input_lines = 5\n").unwrap();
@@ -2984,7 +2989,7 @@ mod tests {
             "[plugins.bash]\ntimeout_secs = 180\n[plugins.websearch]\nenabled = false\n",
         )
         .unwrap();
-        let config = raw.into_config(false).unwrap();
+        let config = raw.into_config().unwrap();
         assert!(config.plugins.names.contains(&"bash".to_string()));
         assert!(!config.plugins.names.contains(&"websearch".to_string()));
         assert!(
@@ -3095,7 +3100,7 @@ mod tests {
     fn removed_sub_tool_tables_error() {
         for &tool in EDIT_SUB_TOOLS {
             let raw: RawConfig = toml::from_str(&format!("[plugins.{tool}]\n")).unwrap();
-            let Err(err) = raw.into_config(false) else {
+            let Err(err) = raw.into_config() else {
                 panic!("plugins.{tool} should be rejected");
             };
             let msg = err.to_string();
@@ -3111,7 +3116,7 @@ mod tests {
     #[test_case("search_result_limit = 50" ; "opts_only")]
     fn unknown_plugin_name_errors(body: &str) {
         let raw: RawConfig = toml::from_str(&format!("[plugins.gerp]\n{body}\n")).unwrap();
-        let Err(err) = raw.into_config(false) else {
+        let Err(err) = raw.into_config() else {
             panic!("plugins.gerp should be rejected");
         };
         let msg = err.to_string();
@@ -3125,7 +3130,7 @@ mod tests {
     fn disabled_plugin_keeps_opts_but_not_load_entry() {
         let raw: RawConfig =
             toml::from_str("[plugins.bash]\nenabled = false\ntimeout_secs = 180\n").unwrap();
-        let config = raw.into_config(false).unwrap();
+        let config = raw.into_config().unwrap();
         assert!(!config.plugins.names.contains(&"bash".to_string()));
         assert_eq!(
             config.plugins.opts["bash"]["timeout_secs"],
@@ -3137,7 +3142,7 @@ mod tests {
     #[test]
     fn renamed_tools_table_errors() {
         let raw: RawConfig = toml::from_str("[tools.bash]\nenabled = true\n").unwrap();
-        let Err(err) = raw.into_config(false) else {
+        let Err(err) = raw.into_config() else {
             panic!("old tools table should be rejected");
         };
         assert!(
@@ -3150,7 +3155,7 @@ mod tests {
     fn edit_sub_tool_toggles_flow_as_edit_opts() {
         let raw: RawConfig =
             toml::from_str("[plugins.edit]\nmultiedit = false\nedit_lines = true\n").unwrap();
-        let config = raw.into_config(false).unwrap();
+        let config = raw.into_config().unwrap();
         assert_eq!(
             config.plugins.opts["edit"]["multiedit"],
             serde_json::json!(false)

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -2905,7 +2905,7 @@ fn cancelled_bash_keeps_streamed_output_as_partial() {
         ctx.cancel = token;
         // The rtk probe costs up to two 2s job waits before the command even
         // starts: pointless here, and a flake risk under load.
-        ctx.config.no_rtk = true;
+        ctx.config.rtk = false;
         let input = json!({ "command": BASH_PARTIAL_CMD });
         result_tx
             .send(exec_with_ctx(&reg, "bash", input, &ctx))

--- a/maki-ui/src/app/session_state.rs
+++ b/maki-ui/src/app/session_state.rs
@@ -339,7 +339,7 @@ mod tests {
             "provider": {"allowed_models": [fallback.spec()]}
         }))
         .unwrap();
-        let policy = raw.into_config(false).unwrap().provider.model_policy;
+        let policy = raw.into_config().unwrap().provider.model_policy;
 
         let state = SessionState::from_session(session, &fallback, &storage, &policy);
 

--- a/plugins/bash/init.lua
+++ b/plugins/bash/init.lua
@@ -104,7 +104,7 @@ end
 
 local function rtk_rewrite(command, ctx)
   local config = ctx:config()
-  if config and config.no_rtk then
+  if config and not config.rtk then
     return nil
   end
 

--- a/site/docs/content/cli/_index.md
+++ b/site/docs/content/cli/_index.md
@@ -46,7 +46,6 @@ If you pass a prompt (or pipe stdin) without `--print`, the TUI still opens and 
 | `--output-format <text\|json\|stream-json>` | Output shape for `--print` (default `text`) |
 | `--input-format <text\|stream-json>` | With `--print`, `stream-json` enters SDK mode |
 | `--no-commands` | Skip custom commands from `.maki/commands`, `.claude/commands`, etc. |
-| `--no-rtk` | Disable [rtk](https://github.com/rtk-ai/rtk) command rewriting |
 | `--no-plugins` | Skip user `init.lua` (global and project); keep the Lua host and builtin plugins so tools and the default keymap still load |
 | `--no-jit` | Run plugin Lua on the interpreter with full debug info |
 | `--yolo` | Skip permission prompts on gated tools (alias: `--dangerously-skip-permissions`). Deny rules still apply |

--- a/site/docs/content/configuration/_index.md
+++ b/site/docs/content/configuration/_index.md
@@ -116,6 +116,7 @@ How many lines of output to show per tool in the UI. All values are `usize` with
 | `compaction_instructions` | String | `none` | - | Extra instructions appended to the compaction summary prompt |
 | `post_compaction_instructions` | String | `none` | - | Extra instructions the agent receives after any compaction (e.g. re-read plan.md) |
 | `stale_read_check` | bool | `true` | - | Require re-reading a file that changed on disk before editing it |
+| `rtk` | bool | `true` | - | Rewrite bash commands with [rtk](https://github.com/rtk-ai/rtk) when it is installed |
 
 ### `provider`
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -65,10 +65,6 @@ pub struct Cli {
     #[arg(long)]
     pub no_commands: bool,
 
-    /// Disable rtk command rewriting
-    #[arg(long)]
-    pub no_rtk: bool,
-
     /// Skip user `init.lua` files (global and project) but keep the Lua
     /// host and every builtin plugin running, so tools and the default
     /// keymap still load. Use this to recover from a broken `init.lua`

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -27,7 +27,7 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
 
     let mut config = raw_config
         .unwrap_or_default()
-        .into_config(false)
+        .into_config()
         .context("invalid config")?;
     config.permissions = load_permissions(&cwd);
 

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -564,7 +564,7 @@ fn load_effective_config(host: &PluginHost, no_plugins: bool, cwd: &Path) -> Res
     host.load_init_files_or_skip(no_plugins, cwd)
         .context("load init.lua files")?
         .unwrap_or_default()
-        .into_config(false)
+        .into_config()
         .context("invalid config")
 }
 
@@ -581,7 +581,7 @@ pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
 
     let mut config = raw_config
         .unwrap_or_default()
-        .into_config(false)
+        .into_config()
         .context("invalid config")?;
     config.permissions = load_permissions(&cwd);
 
@@ -677,7 +677,7 @@ pub fn prompt(
         .context("load init.lua files")?;
     let config = raw_config
         .unwrap_or_default()
-        .into_config(false)
+        .into_config()
         .context("invalid config")?;
     host.load_builtins(&config.plugins)
         .context("load builtin plugins")?;

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -88,7 +88,7 @@ fn load_config(plugin_host: &PluginHost, cli: &Cli, cwd: &Path) -> Result<Config
 
     let mut config = raw_config
         .unwrap_or_default()
-        .into_config(cli.no_rtk)
+        .into_config()
         .context("invalid config")?;
     config.permissions = load_permissions(cwd);
 
@@ -472,9 +472,7 @@ mod tests {
     }
 
     fn test_config() -> Config {
-        RawConfig::default()
-            .into_config(false)
-            .expect("default config")
+        RawConfig::default().into_config().expect("default config")
     }
 
     #[test]

--- a/src/sdk_mode.rs
+++ b/src/sdk_mode.rs
@@ -1456,7 +1456,7 @@ mod tests {
             "provider": {"allowed_models": [startup.spec()]}
         }))
         .unwrap();
-        let policy = raw.into_config(false).unwrap().provider.model_policy;
+        let policy = raw.into_config().unwrap().provider.model_policy;
 
         assert!(
             resolve_set_model(


### PR DESCRIPTION
The rtk rewrite switch lived only as a CLI flag, so you had to repeat it on every run instead of setting it once.

It is now `agent.rtk` in `init.lua`, defaults to `true`, and the bash plugin reads it through `ctx:config()` like any other agent setting.

The `--no-rtk` flag is gone, so scripts passing it will fail on startup and need `maki.setup({ agent = { rtk = false } })` instead.
