### PR TITLE
feat(lua): support plugin Maki version floors 🤖🤖🤖

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2813,6 +2813,7 @@ dependencies = [
  "pin-project-lite",
  "regex",
  "rustix",
+ "semver",
  "serde_json",
  "serde_yaml",
  "smol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ fs4 = "1"
 pin-project-lite = "0.2"
 rustix = { version = "1", default-features = false, features = ["process"] }
 humantime = "2"
+semver = "1"
 toml = "0.8"
 toml_edit = "0.22"
 smol = "2"

--- a/maki-lua/Cargo.toml
+++ b/maki-lua/Cargo.toml
@@ -24,6 +24,7 @@ maki-providers = { workspace = true }
 mlua = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+semver = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 smol = { workspace = true }

--- a/maki-lua/src/docs_render.rs
+++ b/maki-lua/src/docs_render.rs
@@ -36,6 +36,8 @@ Grants come from a `plugin.toml` next to the Lua file (for
 `~/.config/maki/init.lua` that is `~/.config/maki/plugin.toml`):
 
 ```toml
+min_maki_version = "0.4.12"
+
 [permissions]
 {KEYS}```
 
@@ -46,6 +48,10 @@ The rules:
 - `plugin.toml` exists: permissions default to granted; set a key to
   `false` to revoke it. An empty file grants everything.
 - Invalid TOML: everything denied, with a warning in the log.
+- `min_maki_version` is optional and takes a plain semantic version as a lower
+  bound, so ranges do not work. When the field is invalid or the running
+  version is older, Maki skips the Lua in that directory and warns at startup
+  instead of failing. `--no-plugins` still skips every user plugin at once.
 "#;
     let keys = Permission::ALL.map(Permission::manifest_key);
     let anchor = if anchored {
@@ -304,7 +310,8 @@ pub fn guide_page() -> String {
         "## Permissions and plugin.toml\n\n\
          Sensitive APIs are gated per plugin file, and a plugin without a\n\
          `plugin.toml` next to it gets nothing. The gates and the file format are\n\
-         in [the reference]({REFERENCE_URL}#{PERMISSIONS_ANCHOR})."
+         in [the reference]({REFERENCE_URL}#{PERMISSIONS_ANCHOR}). Set\n\
+         `min_maki_version` there when a plugin needs a newer Maki Lua API."
     );
     format!(
         "{}\n## Full API reference\n\n\

--- a/maki-lua/src/error.rs
+++ b/maki-lua/src/error.rs
@@ -17,6 +17,31 @@ pub enum PluginError {
         #[source]
         source: io::Error,
     },
+    #[error(
+        "plugin {plugin} has a non-string min_maki_version; use a plain major.minor.patch string"
+    )]
+    InvalidMinimumVersionType { plugin: String },
+    #[error(
+        "plugin {plugin} has invalid min_maki_version {version:?}: {source}; use a semantic version such as \"1.2.3\""
+    )]
+    InvalidMinimumVersion {
+        plugin: String,
+        version: String,
+        #[source]
+        source: semver::Error,
+    },
+    #[error("Maki was built with invalid package version {version:?}: {source}")]
+    InvalidRuntimeVersion {
+        version: String,
+        #[source]
+        source: semver::Error,
+    },
+    #[error("plugin {plugin} requires Maki {required} or newer, but this is Maki {running}")]
+    MakiVersionTooOld {
+        plugin: String,
+        required: semver::Version,
+        running: semver::Version,
+    },
     #[error("no bundled plugin named \"{plugin}\" (enabled via plugins.{plugin})")]
     UnknownPlugin { plugin: String },
     #[error("plugin host is not running")]

--- a/maki-lua/src/lib.rs
+++ b/maki-lua/src/lib.rs
@@ -18,7 +18,7 @@ pub use api::util::command::{
 };
 pub use docs::{DocKind, FnDoc, ModuleDoc, ParamDoc, api_docs};
 pub use error::PluginError;
-pub use loader::{EventHandle, PluginHost};
+pub use loader::{EventHandle, PluginHost, SKIPPED_PLUGIN_WARNING};
 pub use pack::{
     DiscoveredPackage, Discovery, InstallReport, Interaction, MANAGED_GROUP, Origin, discover,
     discover_installed, install_declared, lockfile_path, sanitize_message, site_dir,

--- a/maki-lua/src/loader.rs
+++ b/maki-lua/src/loader.rs
@@ -15,13 +15,17 @@ use crate::api::options::{PluginOptionSpecs, PluginOpts};
 use crate::api::util::command::{HintReader, LuaCommandReader, UiAction};
 use crate::error::PluginError;
 use crate::pack::DiscoveredPackage;
-use crate::plugin_permissions::{PluginPermissions, load_plugin_permissions};
+use crate::plugin_permissions::{
+    PluginPermissions, check_plugin_compatibility, load_plugin_permissions,
+};
 use crate::runtime::{
     self, ClickFallback, ConfigScope, LoadChunk, LuaThread, Request, RestoreItem,
 };
 use maki_agent::prompt::ResolvedSlots;
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+const USER_PLUGIN: &str = "user";
+pub const SKIPPED_PLUGIN_WARNING: &str = "skipping plugin lua";
 
 struct BundledPlugin {
     name: &'static str,
@@ -253,7 +257,13 @@ impl PluginHost {
         Ok(host)
     }
 
-    pub fn load_init_files(&self, cwd: &Path) -> Result<Option<RawConfig>, PluginError> {
+    /// `warnings` collects non-fatal startup problems (an incompatible
+    /// `plugin.toml` skips that directory's Lua) for the caller to surface.
+    pub fn load_init_files(
+        &self,
+        cwd: &Path,
+        warnings: &mut Vec<String>,
+    ) -> Result<Option<RawConfig>, PluginError> {
         let mut merged: Option<RawConfig> = None;
 
         for global_dir in maki_config::global_config_dirs() {
@@ -261,6 +271,7 @@ impl PluginHost {
                 &global_dir.join("init.lua"),
                 ConfigScope::Global,
                 &mut merged,
+                warnings,
             )?;
             if merged.is_some() {
                 break;
@@ -270,6 +281,7 @@ impl PluginHost {
             &cwd.join(".maki/init.lua"),
             ConfigScope::Project,
             &mut merged,
+            warnings,
         )?;
 
         Ok(merged)
@@ -282,11 +294,12 @@ impl PluginHost {
         &self,
         no_plugins: bool,
         cwd: &Path,
+        warnings: &mut Vec<String>,
     ) -> Result<Option<RawConfig>, PluginError> {
         if no_plugins {
             return Ok(None);
         }
-        self.load_init_files(cwd)
+        self.load_init_files(cwd, warnings)
     }
 
     fn run_init_file(
@@ -294,6 +307,7 @@ impl PluginHost {
         path: &Path,
         scope: ConfigScope,
         merged: &mut Option<RawConfig>,
+        warnings: &mut Vec<String>,
     ) -> Result<(), PluginError> {
         if !path.is_file() {
             return Ok(());
@@ -303,6 +317,10 @@ impl PluginHost {
             source: e,
         })?;
         let plugin_dir = path.parent().map(Path::to_path_buf);
+        if let Err(e) = check_plugin_compatibility(scope.label(), plugin_dir.as_deref()) {
+            warnings.push(format!("{SKIPPED_PLUGIN_WARNING}: {e}"));
+            return Ok(());
+        }
         if let Some(raw) = self.send_config_lua(source, scope, plugin_dir)? {
             match merged {
                 Some(existing) => existing.merge(raw),
@@ -502,13 +520,14 @@ impl PluginHost {
             source: e,
         })?;
         let plugin_dir = path.parent().map(Path::to_path_buf);
+        check_plugin_compatibility(USER_PLUGIN, plugin_dir.as_deref())?;
         let permissions = load_plugin_permissions(plugin_dir.as_deref());
         // Test-only path today. Once user plugin dirs exist: derive a real
         // plugin name, since the hardcoded "user" would collide across files,
         // pass the `plugins.<name>` opts through, and teach the
         // unknown-plugin guards about user plugin names.
         self.send_load(
-            Arc::from("user"),
+            Arc::from(USER_PLUGIN),
             vec![LoadChunk::new(path.display().to_string(), source)],
             plugin_dir,
             permissions,
@@ -1219,15 +1238,16 @@ mod tests {
 
         let host = PluginHost::new(Arc::new(ToolRegistry::new())).unwrap();
 
+        let mut warnings = Vec::new();
         let skipped = host
-            .load_init_files_or_skip(true, dir.path())
+            .load_init_files_or_skip(true, dir.path(), &mut warnings)
             .expect("no-plugins skips broken init.lua");
         assert!(
             skipped.is_none(),
             "--no-plugins must skip user init.lua entirely"
         );
 
-        let ran = host.load_init_files_or_skip(false, dir.path());
+        let ran = host.load_init_files_or_skip(false, dir.path(), &mut warnings);
         assert!(
             ran.is_err(),
             "without --no-plugins the broken init.lua must surface as an error"

--- a/maki-lua/src/plugin_permissions.rs
+++ b/maki-lua/src/plugin_permissions.rs
@@ -3,9 +3,14 @@ use std::io;
 use std::path::Path;
 
 use mlua::{Error as LuaError, Function, IntoLuaMulti, Lua, Result as LuaResult};
+use semver::Version;
 use tracing::warn;
 
+use crate::error::PluginError;
+
 const MANIFEST_FILE: &str = "plugin.toml";
+const MIN_MAKI_VERSION: &str = "min_maki_version";
+const RUNTIME_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Permission {
@@ -238,20 +243,41 @@ fn denied_error(perm: Permission) -> LuaError {
 }
 
 pub(crate) fn load_plugin_permissions(plugin_dir: Option<&Path>) -> PluginPermissions {
-    let Some(dir) = plugin_dir else {
-        return PluginPermissions::denied();
+    load_plugin_manifest(plugin_dir)
+        .as_ref()
+        .map_or_else(PluginPermissions::denied, PluginPermissions::from_manifest)
+}
+
+/// Host-side gate, run before any Lua from `plugin_dir` reaches the runtime.
+/// An `Err` means the directory is refused; the startup path turns it into a
+/// warning and skips the plugin, so one bad `min_maki_version` cannot keep
+/// Maki from booting.
+pub(crate) fn check_plugin_compatibility(
+    plugin: &str,
+    plugin_dir: Option<&Path>,
+) -> Result<(), PluginError> {
+    let Some(manifest) = load_plugin_manifest(plugin_dir) else {
+        return Ok(());
     };
+    let Some(required) = manifest.get(MIN_MAKI_VERSION) else {
+        return Ok(());
+    };
+    check_minimum_version(plugin, required, RUNTIME_VERSION)
+}
+
+fn load_plugin_manifest(plugin_dir: Option<&Path>) -> Option<toml::Value> {
+    let dir = plugin_dir?;
     let manifest_path = dir.join(MANIFEST_FILE);
     match std::fs::read_to_string(&manifest_path) {
         Ok(content) => match toml::from_str::<toml::Value>(&content) {
-            Ok(val) => PluginPermissions::from_manifest(&val),
+            Ok(manifest) => Some(manifest),
             Err(e) => {
                 warn!(
                     path = %manifest_path.display(),
                     error = %e,
                     "invalid {MANIFEST_FILE}, denying all permissions"
                 );
-                PluginPermissions::denied()
+                None
             }
         },
         Err(e) => {
@@ -268,14 +294,59 @@ pub(crate) fn load_plugin_permissions(plugin_dir: Option<&Path>) -> PluginPermis
                     "cannot read {MANIFEST_FILE}, denying all permissions"
                 );
             }
-            PluginPermissions::denied()
+            None
         }
     }
 }
 
+fn check_minimum_version(
+    plugin: &str,
+    required: &toml::Value,
+    running: &str,
+) -> Result<(), PluginError> {
+    let required = required
+        .as_str()
+        .ok_or_else(|| PluginError::InvalidMinimumVersionType {
+            plugin: plugin.to_owned(),
+        })?;
+    let required =
+        Version::parse(required).map_err(|source| PluginError::InvalidMinimumVersion {
+            plugin: plugin.to_owned(),
+            version: required.to_owned(),
+            source,
+        })?;
+    let running = Version::parse(running).map_err(|source| PluginError::InvalidRuntimeVersion {
+        version: running.to_owned(),
+        source,
+    })?;
+    if required > running {
+        return Err(PluginError::MakiVersionTooOld {
+            plugin: plugin.to_owned(),
+            required,
+            running,
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use test_case::test_case;
+
     use super::*;
+
+    const PLUGIN: &str = "test-plugin";
+
+    fn assert_denied(permissions: &PluginPermissions) {
+        for permission in Permission::ALL {
+            assert!(
+                !permissions.is_allowed(permission),
+                "{permission} should be denied"
+            );
+        }
+    }
 
     #[test]
     fn trusted_allows_everything() {
@@ -288,9 +359,7 @@ mod tests {
     #[test]
     fn denied_blocks_everything() {
         let p = PluginPermissions::denied();
-        for perm in Permission::ALL {
-            assert!(!p.is_allowed(perm), "{perm} should be denied");
-        }
+        assert_denied(&p);
     }
 
     #[test]
@@ -442,5 +511,102 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("permission denied"));
         assert!(msg.contains("fs_read"));
+    }
+
+    #[test_case("1.2.2", "1.2.3", true; "lower")]
+    #[test_case("1.2.3", "1.2.3", true; "equal")]
+    #[test_case("1.2.3-alpha.1", "1.2.3-alpha.2", true; "older_prerelease")]
+    #[test_case("1.2.3-alpha.2", "1.2.3-alpha.1", false; "newer_prerelease")]
+    #[test_case("1.2.4", "1.2.3", false; "higher")]
+    fn minimum_version_uses_semver_precedence(required: &str, running: &str, compatible: bool) {
+        let required = toml::Value::String(required.to_owned());
+        let result = check_minimum_version(PLUGIN, &required, running);
+        assert_eq!(result.is_ok(), compatible);
+        if !compatible {
+            assert!(matches!(result, Err(PluginError::MakiVersionTooOld { .. })));
+        }
+    }
+
+    #[test]
+    fn minimum_version_requires_a_plain_semver_string() {
+        let wrong_type = check_minimum_version(PLUGIN, &toml::Value::Integer(1), RUNTIME_VERSION);
+        assert!(matches!(
+            wrong_type,
+            Err(PluginError::InvalidMinimumVersionType { .. })
+        ));
+
+        for version in ["not-a-version", "v1.2.3"] {
+            let value = toml::Value::String(version.to_owned());
+            assert!(matches!(
+                check_minimum_version(PLUGIN, &value, RUNTIME_VERSION),
+                Err(PluginError::InvalidMinimumVersion { .. })
+            ));
+        }
+
+        let value = toml::Value::String("1.2.3".to_owned());
+        assert!(matches!(
+            check_minimum_version(PLUGIN, &value, "invalid"),
+            Err(PluginError::InvalidRuntimeVersion { .. })
+        ));
+    }
+
+    #[test]
+    fn manifest_rejects_an_invalid_declared_minimum() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join(MANIFEST_FILE),
+            format!("{MIN_MAKI_VERSION} = 1\n"),
+        )
+        .unwrap();
+        assert!(matches!(
+            check_plugin_compatibility(PLUGIN, Some(dir.path())),
+            Err(PluginError::InvalidMinimumVersionType { .. })
+        ));
+
+        fs::write(
+            dir.path().join(MANIFEST_FILE),
+            format!("{MIN_MAKI_VERSION} = \"v1.2.3\"\n"),
+        )
+        .unwrap();
+        assert!(matches!(
+            check_plugin_compatibility(PLUGIN, Some(dir.path())),
+            Err(PluginError::InvalidMinimumVersion { .. })
+        ));
+    }
+
+    #[test]
+    fn missing_valid_and_malformed_manifests_keep_existing_defaults() {
+        assert_denied(&load_plugin_permissions(None));
+
+        let dir = tempfile::tempdir().unwrap();
+        assert_denied(&load_plugin_permissions(Some(dir.path())));
+
+        fs::write(dir.path().join(MANIFEST_FILE), "").unwrap();
+        let permissions = load_plugin_permissions(Some(dir.path()));
+        for permission in Permission::ALL {
+            assert!(permissions.is_allowed(permission));
+        }
+
+        fs::write(dir.path().join(MANIFEST_FILE), "not = [valid").unwrap();
+        assert_denied(&load_plugin_permissions(Some(dir.path())));
+        assert!(
+            check_plugin_compatibility(PLUGIN, Some(dir.path())).is_ok(),
+            "an unparseable manifest has no floor to enforce"
+        );
+    }
+
+    #[test]
+    fn one_manifest_provides_compatibility_and_permissions() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join(MANIFEST_FILE),
+            format!("{MIN_MAKI_VERSION} = {RUNTIME_VERSION:?}\n\n[permissions]\nnet = false\n"),
+        )
+        .unwrap();
+
+        check_plugin_compatibility(PLUGIN, Some(dir.path())).unwrap();
+        let permissions = load_plugin_permissions(Some(dir.path()));
+        assert!(permissions.is_allowed(Permission::FsRead));
+        assert!(!permissions.is_allowed(Permission::Net));
     }
 }

--- a/maki-lua/src/runtime.rs
+++ b/maki-lua/src/runtime.rs
@@ -146,7 +146,7 @@ pub(crate) enum ConfigScope {
 }
 
 impl ConfigScope {
-    fn label(&self) -> &str {
+    pub(crate) fn label(&self) -> &str {
         match self {
             Self::Global => "global/init.lua",
             Self::Project => "project/init.lua",

--- a/maki-lua/tests/plugin_host.rs
+++ b/maki-lua/tests/plugin_host.rs
@@ -10,7 +10,7 @@ use maki_agent::tools::{
     ToolExecResult, ToolInvocation, ToolLive, ToolRegistry, ToolSource, timeout_annotation,
 };
 use maki_config::{AlwaysThinking, Effect, PluginsConfig, ToolKey, ToolOutputLines};
-use maki_lua::{PluginError, PluginHost, WARM_TOOL_CAP};
+use maki_lua::{PluginError, PluginHost, SKIPPED_PLUGIN_WARNING, WARM_TOOL_CAP};
 use maki_storage::id::SessionRef;
 #[cfg(unix)]
 use rustix::process::{Pid, test_kill_process_group};
@@ -1050,6 +1050,36 @@ greet.setup()
 
     assert!(reg.has("greet"));
     assert_eq!(reg.names().len(), 1);
+}
+
+/// An incompatible `plugin.toml` must cost that directory its Lua, not the
+/// whole startup: `load_init_files` keeps going and reports a warning.
+#[test]
+fn incompatible_plugin_warns_instead_of_aborting_startup() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let maki_dir = tmp.path().join(".maki");
+    std::fs::create_dir_all(&maki_dir).unwrap();
+    let running = semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
+    let required = format!("{}.0.0", running.major + 1);
+    std::fs::write(
+        maki_dir.join("plugin.toml"),
+        format!("min_maki_version = {required:?}\n"),
+    )
+    .unwrap();
+    std::fs::write(maki_dir.join("init.lua"), ECHO_PLUGIN).unwrap();
+
+    let reg = fresh_registry();
+    let host = PluginHost::new(Arc::clone(&reg)).unwrap();
+    let mut warnings = Vec::new();
+    host.load_init_files_or_skip(false, tmp.path(), &mut warnings)
+        .expect("an incompatible plugin must not abort startup");
+
+    assert!(!reg.has("echo_"));
+    let warning = warnings
+        .iter()
+        .find(|w| w.contains(SKIPPED_PLUGIN_WARNING))
+        .unwrap_or_else(|| panic!("no skip warning in {warnings:?}"));
+    assert!(warning.contains(&required), "{warning}");
 }
 
 #[test]

--- a/site/docs/content/lua-api/_index.md
+++ b/site/docs/content/lua-api/_index.md
@@ -63,6 +63,8 @@ Grants come from a `plugin.toml` next to the Lua file (for
 `~/.config/maki/init.lua` that is `~/.config/maki/plugin.toml`):
 
 ```toml
+min_maki_version = "0.4.12"
+
 [permissions]
 fs_read = true
 fs_write = true
@@ -78,6 +80,10 @@ The rules:
 - `plugin.toml` exists: permissions default to granted; set a key to
   `false` to revoke it. An empty file grants everything.
 - Invalid TOML: everything denied, with a warning in the log.
+- `min_maki_version` is optional and takes a plain semantic version as a lower
+  bound, so ranges do not work. When the field is invalid or the running
+  version is older, Maki skips the Lua in that directory and warns at startup
+  instead of failing. `--no-plugins` still skips every user plugin at once.
 
 ## Overview
 

--- a/site/docs/content/plugins/_index.md
+++ b/site/docs/content/plugins/_index.md
@@ -74,7 +74,8 @@ settings in a local table, or export a `setup(opts)` function `init.lua` calls.
 
 Sensitive APIs are gated per plugin file, and a plugin without a
 `plugin.toml` next to it gets nothing. The gates and the file format are
-in [the reference](/docs/lua-api/#plugin-permissions).
+in [the reference](/docs/lua-api/#plugin-permissions). Set
+`min_maki_version` there when a plugin needs a newer Maki Lua API.
 
 ## Development loop
 

--- a/src/cmd/acp.rs
+++ b/src/cmd/acp.rs
@@ -26,9 +26,9 @@ pub fn run(model_arg: Option<String>, yolo: bool, no_plugins: bool, no_jit: bool
         no_plugins,
         super::BuiltinFailure::Fatal,
         maki_lua::Interaction::None,
-        |host, names, _| {
+        |host, names, warnings| {
             let mut config = host
-                .load_init_files_or_skip(no_plugins, &cwd)
+                .load_init_files_or_skip(no_plugins, &cwd, warnings)
                 .context("load init.lua files")?
                 .unwrap_or_default()
                 .into_config(&names(host)?)

--- a/src/cmd/subcmd.rs
+++ b/src/cmd/subcmd.rs
@@ -548,7 +548,7 @@ pub fn models(no_plugins: bool, no_jit: bool) -> Result<()> {
         no_plugins,
         super::BuiltinFailure::Fatal,
         maki_lua::Interaction::None,
-        |host, names, _| load_effective_config(host, no_plugins, &cwd, names),
+        |host, names, warnings| load_effective_config(host, no_plugins, &cwd, names, warnings),
     )?;
     super::report_warnings(warnings);
 
@@ -572,9 +572,10 @@ fn load_effective_config(
     no_plugins: bool,
     cwd: &Path,
     names: &super::KnownNames<'_>,
+    warnings: &mut Vec<String>,
 ) -> Result<Config> {
     let raw_config = host
-        .load_init_files_or_skip(no_plugins, cwd)
+        .load_init_files_or_skip(no_plugins, cwd, warnings)
         .context("load init.lua files")?;
     raw_config
         .unwrap_or_default()
@@ -594,8 +595,8 @@ pub fn index(path: &str, no_plugins: bool, no_jit: bool) -> Result<()> {
         no_plugins,
         super::BuiltinFailure::Fatal,
         maki_lua::Interaction::None,
-        |host, names, _| {
-            let mut config = load_effective_config(host, no_plugins, &cwd, names)?;
+        |host, names, warnings| {
+            let mut config = load_effective_config(host, no_plugins, &cwd, names, warnings)?;
             config.permissions = load_permissions(&cwd);
             Ok(config)
         },
@@ -691,7 +692,7 @@ pub fn prompt(
         no_plugins,
         super::BuiltinFailure::Fatal,
         maki_lua::Interaction::None,
-        |host, names, _| load_effective_config(host, no_plugins, &cwd, names),
+        |host, names, warnings| load_effective_config(host, no_plugins, &cwd, names, warnings),
     )?;
     super::report_warnings(warnings);
 

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -86,9 +86,10 @@ fn load_config(
     cli: &Cli,
     cwd: &Path,
     names: &super::KnownNames<'_>,
+    warnings: &mut Vec<String>,
 ) -> Result<Config> {
     let raw_config = plugin_host
-        .load_init_files_or_skip(cli.no_plugins, cwd)
+        .load_init_files_or_skip(cli.no_plugins, cwd, warnings)
         .context("load init.lua files")?;
 
     let mut config = raw_config
@@ -157,11 +158,8 @@ fn build_stack(
         },
         interaction,
         |host, names, warnings| {
-            config_or_fallback(
-                load_config(host, cli, cwd, names),
-                fallback_config,
-                warnings,
-            )
+            let loaded = load_config(host, cli, cwd, names, warnings);
+            config_or_fallback(loaded, fallback_config, warnings)
         },
     )?;
 
@@ -558,7 +556,7 @@ mod tests {
         let mut plugin_host = PluginHost::with_jit(Arc::new(ToolRegistry::new()), true)
             .expect("live host boots under --no-plugins");
 
-        let config = load_config(&plugin_host, &cli, dir.path(), &no_names)
+        let config = load_config(&plugin_host, &cli, dir.path(), &no_names, &mut Vec::new())
             .expect("no-plugins must skip the broken init.lua and still load defaults");
         assert!(
             !config.plugins.names.is_empty(),
@@ -596,7 +594,7 @@ mod tests {
         let mut plugin_host =
             PluginHost::with_jit(Arc::new(ToolRegistry::new()), true).expect("live host boots");
 
-        match load_config(&plugin_host, &cli, dir.path(), &no_names) {
+        match load_config(&plugin_host, &cli, dir.path(), &no_names, &mut Vec::new()) {
             Err(_) => {}
             Ok(_) => panic!("broken init.lua must error without --no-plugins"),
         }


### PR DESCRIPTION
## Summary

- Add an optional top-level `min_maki_version = "0.4.12"` field to `plugin.toml`.
- Treat the exact semantic version as a lower bound, with no range syntax or override.
- Reuse one parsed manifest for compatibility and permissions.
- Refuse invalid or too-new requirements before plugin Lua can run.
- Document the field in the generated plugin and Lua API pages.

This is the minimum-version follow-up discussed in #721.

## Verification

- `just ci` (4,333 tests)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --doc`
- `cargo hack check --workspace --each-feature`
- `cargo machete`

The existing MSRV gate cannot build the current Monty and Ruff dependencies on Rust 1.88. `cargo audit` also still reports the existing `quick-xml` advisories. This change adds neither problem.

## AI use

I used Codex to trace the manifest and Lua load paths, implement the field, write tests and generated documentation, and perform repeated adversarial reviews. I directed the design decisions and verified the final diff and checks.
